### PR TITLE
Schedule Hotmart cycle 1 to 2026-05-29 19:30 (America/Sao_Paulo) and update registry docs

### DIFF
--- a/docs/registros/mois1.md
+++ b/docs/registros/mois1.md
@@ -5,6 +5,15 @@
 > Em caso de dúvida entre arquivos de registro, este é o ponto único de verdade.
 
 
+
+## 2026-05-29 - Agendamento pontual do ciclo 1 Hotmart
+
+- ajustado o agendamento do ciclo 1 do `mois-hotmart-collector` para executar em 29/05 às 19:30 no timezone `America/Sao_Paulo`, conforme solicitação operacional.
+- mantido cron literal diretamente na anotação `@Scheduled`, conforme regra operacional para agendamentos Spring Boot.
+
+Arquivos alterados:
+- `mois-hotmart-collector/src/main/java/com/marketinghub/moishotmart/service/HotmartCollectorScheduler.java`
+
 ## 2026-05-18 19:27:36 UTC-3
 - criada a camada backend de snapshots brutos da Biblioteca de Páginas de Vendas do MOIS.
 - adicionado endpoint `POST /api/mois/sales-library/snapshots:capture` para capturar HTML bruto e screenshot PNG básico das URLs ingeridas.

--- a/mois-hotmart-collector/src/main/java/com/marketinghub/moishotmart/service/HotmartCollectorScheduler.java
+++ b/mois-hotmart-collector/src/main/java/com/marketinghub/moishotmart/service/HotmartCollectorScheduler.java
@@ -34,17 +34,17 @@ public class HotmartCollectorScheduler {
     }
 
     /**
-     * Executa o ciclo 1 de listagem de produtos às 00:05 no dia 27 de maio.
+     * Executa o ciclo 1 de listagem de produtos às 19:30 no dia 29 de maio, no horário de São Paulo.
      */
-    @Scheduled(cron = "0 5 0 27 5 *")
-    public void collectFirstCycleAtZeroZeroFiveOnMayTwentySeventh() {
+    @Scheduled(cron = "0 30 19 29 5 *", zone = "America/Sao_Paulo")
+    public void collectFirstCycleAtNineteenThirtyOnMayTwentyNinth() {
         if (!enabled) {
             log.info("Hotmart scheduler desabilitado por configuração.");
             return;
         }
         HotmartCollectionRequest request = new HotmartCollectionRequest(source, maxProducts);
         HotmartCollectionResponse response = collectorService.collectFirstCycle(request);
-        log.info("Hotmart scheduler executado hora=00:05 dia=27/05 ciclo={} status={} produtos={} mensagem={}",
+        log.info("Hotmart scheduler executado hora=19:30 dia=29/05 timezone=America/Sao_Paulo ciclo={} status={} produtos={} mensagem={}",
                 "CICLO_1_LISTAGEM",
                 response.status(),
                 response.products().size(),


### PR DESCRIPTION
### Motivation
- Adjust the one-off operational schedule for the Hotmart collector cycle 1 to run at the requested local time in São Paulo and record the change in the canonical operational registry.

### Description
- Updated `HotmartCollectorScheduler` to change the cycle 1 cron from `0 5 0 27 5 *` to `0 30 19 29 5 *` and set the timezone to `America/Sao_Paulo` in the `@Scheduled` annotation.
- Renamed the cycle 1 method and updated its JavaDoc and runtime log message to reflect execution at `19:30` on `29/05` with the `America/Sao_Paulo` timezone.
- Added a registry entry in `docs/registros/mois1.md` documenting the punctual scheduling change and referenced the modified source file `mois-hotmart-collector/src/main/java/com/marketinghub/moishotmart/service/HotmartCollectorScheduler.java`.
- Kept the cron literal directly in the `@Scheduled` annotation as required by the operational scheduling rule.

### Testing
- Ran the project's automated unit tests via `./gradlew test`; the test suite completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a19e838c4548321b60e73c99d1a64c3)