### PR TITLE
Enviar `prompt`, `schemaJson` e `requestBodyJson` no callback `recebe-prompt` (wireframe)

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/openai/core/model/OpenAiDispatch.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/openai/core/model/OpenAiDispatch.java
@@ -3,14 +3,18 @@ package com.marketinghub.worker.openai.core.model;
 import java.time.Instant;
 import java.util.Objects;
 
+/** Responsabilidade: transportar os dados auditáveis do despacho feito para a OpenAI. */
 public record OpenAiDispatch(
         String openAiJobId,
         String prompt,
+        String schemaJson,
         String requestBodyJson,
         Instant dispatchedAt
 ) {
+    /** Valida os campos obrigatórios e define o horário do despacho quando ausente. */
     public OpenAiDispatch {
         Objects.requireNonNull(prompt, "prompt must not be null");
+        Objects.requireNonNull(schemaJson, "schemaJson must not be null");
         Objects.requireNonNull(requestBodyJson, "requestBodyJson must not be null");
         dispatchedAt = dispatchedAt == null ? Instant.now() : dispatchedAt;
     }

--- a/ai-worker/src/main/java/com/marketinghub/worker/openai/core/openai/ResponsesApiOpenAiClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/openai/core/openai/ResponsesApiOpenAiClient.java
@@ -16,6 +16,7 @@ import java.util.concurrent.ConcurrentHashMap;
 
 import org.springframework.web.reactive.function.client.WebClient;
 
+/** Responsabilidade: executar chamadas síncronas para a OpenAI Responses API no core OpenAI. */
 public class ResponsesApiOpenAiClient implements OpenAiClientPort {
 
     private final WebClient webClient;
@@ -24,6 +25,7 @@ public class ResponsesApiOpenAiClient implements OpenAiClientPort {
     private final OpenAiCostEstimator costEstimator;
     private final Map<String, OpenAiResult<String>> resultCache = new ConcurrentHashMap<>();
 
+    /** Inicializa o cliente com WebClient, ObjectMapper, propriedades e estimador de custo. */
     public ResponsesApiOpenAiClient(
             WebClient.Builder builder,
             ObjectMapper objectMapper,
@@ -42,6 +44,7 @@ public class ResponsesApiOpenAiClient implements OpenAiClientPort {
                 .build();
     }
 
+    /** Envia o request cru para a OpenAI e devolve os dados de despacho para auditoria no backend. */
     @Override
     public OpenAiDispatch dispatch(OpenAiRequest request) {
         try {
@@ -81,6 +84,7 @@ public class ResponsesApiOpenAiClient implements OpenAiClientPort {
             return new OpenAiDispatch(
                     openAiJobId,
                     request.prompt(),
+                    request.schemaJson(),
                     request.requestBodyJson(),
                     Instant.now()
             );
@@ -89,6 +93,7 @@ public class ResponsesApiOpenAiClient implements OpenAiClientPort {
         }
     }
 
+    /** Recupera a resposta bruta da OpenAI armazenada localmente após o despacho síncrono. */
     @Override
     public OpenAiResult<String> awaitResult(OpenAiDispatch dispatch) {
         if (dispatch.openAiJobId() == null) {
@@ -104,6 +109,7 @@ public class ResponsesApiOpenAiClient implements OpenAiClientPort {
         return result;
     }
 
+    /** Extrai o texto principal da resposta retornada pela OpenAI. */
     private String extractModelResponse(Map<String, Object> raw) {
         Object outputText = raw.get("output_text");
         if (outputText != null && !outputText.toString().isBlank()) {
@@ -138,6 +144,7 @@ public class ResponsesApiOpenAiClient implements OpenAiClientPort {
         throw new StageWorkerException("Could not extract model response text from OpenAI response");
     }
 
+    /** Extrai um número inteiro de uma chave filha dentro de uma chave pai na resposta da OpenAI. */
     private Integer extractInteger(Map<String, Object> raw, String parentKey, String childKey) {
         Object parent = raw.get(parentKey);
         if (!(parent instanceof Map<?, ?> map)) {
@@ -156,6 +163,7 @@ public class ResponsesApiOpenAiClient implements OpenAiClientPort {
         return null;
     }
 
+    /** Converte valores recebidos da OpenAI para texto quando presentes. */
     private String stringValue(Object value) {
         return value != null ? value.toString() : null;
     }

--- a/ai-worker/src/main/java/com/marketinghub/worker/openai/core/wireframe/WireframeBackendClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/openai/core/wireframe/WireframeBackendClient.java
@@ -14,6 +14,7 @@ import java.util.Map;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.web.reactive.function.client.WebClient;
 
+/** Responsabilidade: integrar a etapa wireframe do core OpenAI aos endpoints internos do backend. */
 public class WireframeBackendClient implements StageBackendPort<WireframeInput, WireframeOutput> {
 
     private static final String STATUS_STARTED = "INICIADO";
@@ -22,6 +23,7 @@ public class WireframeBackendClient implements StageBackendPort<WireframeInput, 
     private final WireframeWorkerProperties properties;
     private final ObjectMapper objectMapper;
 
+    /** Inicializa o cliente com WebClient, propriedades de wireframe e ObjectMapper para normalizar artefatos. */
     public WireframeBackendClient(
             WebClient.Builder builder,
             WireframeWorkerProperties properties,
@@ -32,6 +34,7 @@ public class WireframeBackendClient implements StageBackendPort<WireframeInput, 
         this.objectMapper = objectMapper;
     }
 
+    /** Busca no backend os jobs de wireframe iniciados e aptos para processamento pela OpenAI. */
     @Override
     public List<StageExecution<WireframeInput>> listPending(int limit) {
         int effectiveLimit = Math.max(1, limit);
@@ -58,10 +61,13 @@ public class WireframeBackendClient implements StageBackendPort<WireframeInput, 
                 .toList();
     }
 
+    /** Envia ao backend o prompt renderizado, o schema e o request cru despachados para a OpenAI. */
     @Override
     public void markDispatched(StageExecution<WireframeInput> execution, OpenAiDispatch dispatch) {
         Map<String, Object> body = new LinkedHashMap<>();
         body.put("prompt", dispatch.prompt());
+        body.put("schemaJson", dispatch.schemaJson());
+        body.put("requestBodyJson", dispatch.requestBodyJson());
         body.put("jobidopenai", dispatch.openAiJobId());
 
         webClient.post()
@@ -72,6 +78,7 @@ public class WireframeBackendClient implements StageBackendPort<WireframeInput, 
                 .block(properties.timeout());
     }
 
+    /** Envia ao backend a resposta validada da OpenAI para concluir a etapa wireframe. */
     @Override
     public void markCompleted(StageExecution<WireframeInput> execution, OpenAiResult<WireframeOutput> result) {
         Map<String, Object> body = new LinkedHashMap<>();
@@ -93,6 +100,7 @@ public class WireframeBackendClient implements StageBackendPort<WireframeInput, 
                 .block(properties.timeout());
     }
 
+    /** Envia ao backend os dados de falha quando a etapa wireframe não é concluída. */
     @Override
     public void markFailed(StageExecution<WireframeInput> execution, Throwable error) {
         Map<String, Object> body = new LinkedHashMap<>();
@@ -114,6 +122,7 @@ public class WireframeBackendClient implements StageBackendPort<WireframeInput, 
                 .block(properties.timeout());
     }
 
+    /** Converte o payload pendente do backend para o modelo interno de execução da etapa. */
     private StageExecution<WireframeInput> toStageExecution(Map<String, Object> item) {
         Long experimentId = asLong(item.get("experimentId"));
         String stageCode = asString(item.get("stageCode"));
@@ -136,6 +145,7 @@ public class WireframeBackendClient implements StageBackendPort<WireframeInput, 
         );
     }
 
+    /** Monta os dados do prompt com os artefatos e informações de framework disponíveis no backend. */
     private Map<String, Object> buildPromptDataFromPending(Map<String, Object> pending) {
         Map<String, Object> experiment = asMap(pending.get("experiment"));
         Map<String, Object> hypothesis = asMap(pending.get("hypothesis"));
@@ -154,6 +164,7 @@ public class WireframeBackendClient implements StageBackendPort<WireframeInput, 
         return payload;
     }
 
+    /** Normaliza artefatos que podem chegar como JSON textual, objeto estruturado ou valor simples. */
     private Object normalizeJsonArtifact(Object value) {
         if (value instanceof String text) {
             return parseJsonField(text);
@@ -161,6 +172,7 @@ public class WireframeBackendClient implements StageBackendPort<WireframeInput, 
         return value != null ? value : Map.of();
     }
 
+    /** Interpreta um campo textual JSON quando possível, preservando o texto original em caso de formato inválido. */
     private Object parseJsonField(String raw) {
         if (raw == null || raw.isBlank()) {
             return Map.of();
@@ -173,6 +185,7 @@ public class WireframeBackendClient implements StageBackendPort<WireframeInput, 
         }
     }
 
+    /** Extrai um mapa tipado quando o valor recebido é um objeto JSON. */
     private Map<String, Object> asMap(Object value) {
         if (value instanceof Map<?, ?> rawMap) {
             Map<String, Object> converted = new LinkedHashMap<>();
@@ -187,6 +200,7 @@ public class WireframeBackendClient implements StageBackendPort<WireframeInput, 
         return Map.of();
     }
 
+    /** Converte um valor genérico para Long quando possível. */
     private Long asLong(Object value) {
         if (value instanceof Number number) {
             return number.longValue();
@@ -199,10 +213,12 @@ public class WireframeBackendClient implements StageBackendPort<WireframeInput, 
         return null;
     }
 
+    /** Converte um valor genérico para texto preservando nulo quando ausente. */
     private String asString(Object value) {
         return value != null ? value.toString() : null;
     }
 
+    /** Converte um valor genérico para Instant quando possível. */
     private Instant asInstant(Object value) {
         if (value instanceof Instant instant) {
             return instant;
@@ -215,6 +231,7 @@ public class WireframeBackendClient implements StageBackendPort<WireframeInput, 
         return null;
     }
 
+    /** Retorna o primeiro valor textual não vazio entre as opções informadas. */
     private String firstText(Object... values) {
         for (Object value : values) {
             if (value != null && !value.toString().isBlank()) {
@@ -224,6 +241,7 @@ public class WireframeBackendClient implements StageBackendPort<WireframeInput, 
         return "";
     }
 
+    /** Monta a URL base dos endpoints internos de execução da etapa wireframe. */
     private String stageExecutionBaseUrl() {
         return joinPath(
                 properties.backendBaseUrl(),
@@ -232,6 +250,7 @@ public class WireframeBackendClient implements StageBackendPort<WireframeInput, 
         );
     }
 
+    /** Resume a stack trace em texto para envio controlado ao backend. */
     private String stackTraceSummary(Throwable error) {
         StringBuilder builder = new StringBuilder(error.toString());
         for (StackTraceElement element : error.getStackTrace()) {
@@ -243,6 +262,7 @@ public class WireframeBackendClient implements StageBackendPort<WireframeInput, 
         return builder.toString();
     }
 
+    /** Junta partes de URL evitando barras duplicadas entre segmentos. */
     private String joinPath(String... parts) {
         StringBuilder builder = new StringBuilder();
         for (String part : parts) {
@@ -259,10 +279,12 @@ public class WireframeBackendClient implements StageBackendPort<WireframeInput, 
         return builder.toString();
     }
 
+    /** Remove a barra final de um segmento de URL quando presente. */
     private String stripTrailingSlash(String value) {
         return value.endsWith("/") ? value.substring(0, value.length() - 1) : value;
     }
 
+    /** Remove barras iniciais e finais de um segmento intermediário de URL. */
     private String stripSlashes(String value) {
         String result = value;
         while (result.startsWith("/")) {

--- a/ai-worker/src/test/java/com/marketinghub/worker/openai/core/wireframe/WireframeBackendClientTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/openai/core/wireframe/WireframeBackendClientTest.java
@@ -1,0 +1,81 @@
+package com.marketinghub.worker.openai.core.wireframe;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marketinghub.worker.openai.core.model.OpenAiDispatch;
+import com.marketinghub.worker.openai.core.model.StageExecution;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Map;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.reactive.function.client.WebClient;
+
+/** Responsabilidade: validar o contrato HTTP do client wireframe do core OpenAI. */
+class WireframeBackendClientTest {
+
+    private MockWebServer server;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    /** Inicializa o backend simulado usado para capturar os payloads enviados pelo client. */
+    @BeforeEach
+    void setUp() throws Exception {
+        server = new MockWebServer();
+        server.start();
+    }
+
+    /** Encerra o backend simulado após cada teste do client. */
+    @AfterEach
+    void tearDown() throws Exception {
+        server.shutdown();
+    }
+
+    /** Deve enviar prompt, schema e request cru no callback recebe-prompt. */
+    @Test
+    void markDispatchedShouldSendPromptSchemaAndRawRequestToRecebePrompt() throws Exception {
+        server.enqueue(new MockResponse().setResponseCode(202));
+        WireframeBackendClient client = new WireframeBackendClient(
+                WebClient.builder(),
+                new WireframeWorkerProperties(
+                        true,
+                        5,
+                        server.url("/").toString(),
+                        "/api",
+                        "prompts/geralanding/landing-page-wireframe.md",
+                        "prompts/geralanding/landing-page-wireframe-schema.json",
+                        "experiment_pipeline_landing_page_wireframe",
+                        Duration.ofSeconds(5)),
+                objectMapper);
+        StageExecution<WireframeInput> execution = new StageExecution<>(
+                "job-ia-1",
+                12L,
+                "landing-page-wireframe",
+                "INICIADO",
+                Instant.parse("2026-05-29T10:00:00Z"),
+                new WireframeInput(12L, "landing-page-wireframe", "job-ia-1", Map.of()));
+        OpenAiDispatch dispatch = new OpenAiDispatch(
+                "openai-job-1",
+                "Prompt renderizado",
+                "{\"type\":\"object\"}",
+                "{\"model\":\"gpt-test\",\"input\":\"Prompt renderizado\"}",
+                Instant.parse("2026-05-29T10:01:00Z"));
+
+        client.markDispatched(execution, dispatch);
+
+        var request = server.takeRequest();
+        assertThat(request.getMethod()).isEqualTo("POST");
+        assertThat(request.getPath())
+                .isEqualTo("/api/internal/geralanding/wireframe/stage-executions/job-ia-1/recebe-prompt");
+        Map<String, Object> payload = objectMapper.readValue(request.getBody().readUtf8(), new TypeReference<>() {});
+        assertThat(payload)
+                .containsEntry("prompt", "Prompt renderizado")
+                .containsEntry("schemaJson", "{\"type\":\"object\"}")
+                .containsEntry("requestBodyJson", "{\"model\":\"gpt-test\",\"input\":\"Prompt renderizado\"}")
+                .containsEntry("jobidopenai", "openai-job-1");
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/service/BackendWireframeService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/service/BackendWireframeService.java
@@ -106,9 +106,14 @@ public class BackendWireframeService {
                 .toList();
     }
 
-    /** Marca a execução como aguardando retorno da OpenAI após receber o prompt despachado. */
+    /** Marca a execução como aguardando retorno da OpenAI após receber prompt, schema e request cru despachados. */
     @Transactional
-    public void markWaitingOpenAiDispatch(String idJob, String prompt, String openAiJobId) {
+    public void markWaitingOpenAiDispatch(
+            String idJob,
+            String prompt,
+            String schemaJson,
+            String requestBodyJson,
+            String openAiJobId) {
         GeraLandingStageExecution execution = executionRepository
                 .findTopByIdJobOrderByExecutionRequestedAtDesc(toDatabaseIdJob(idJob))
                 .orElseThrow(() -> new EntityNotFoundException(
@@ -116,7 +121,8 @@ public class BackendWireframeService {
                 ));
 
         execution.setPrompt(prompt);
-        execution.setOpenAiRequestBody(prompt);
+        execution.setSchemaJson(schemaJson);
+        execution.setOpenAiRequestBody(requestBodyJson);
         execution.setOpenAiJobId(openAiJobId);
         execution.setProcessingStartedAt(Instant.now());
         execution.setStatus(STATUS_WAITING_OPENAI_DISPATCH);

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/service/recebeprompt/RecebePromptRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/service/recebeprompt/RecebePromptRequest.java
@@ -1,6 +1,11 @@
 package com.marketinghub.geralanding.wireframe.service.recebeprompt;
 
+import com.fasterxml.jackson.annotation.JsonAlias;
 import jakarta.validation.constraints.NotBlank;
 
-/** Representa o payload interno de recebimento do prompt enviado ao provedor de IA. */
-public record RecebePromptRequest(@NotBlank String prompt, @NotBlank String jobidopenai) {}
+/** Representa o payload interno com prompt, schema e request cru enviados ao provedor de IA. */
+public record RecebePromptRequest(
+        @NotBlank String prompt,
+        @NotBlank String schemaJson,
+        @NotBlank @JsonAlias("openAiRequestBody") String requestBodyJson,
+        @NotBlank String jobidopenai) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/web/BackendWireframeController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/web/BackendWireframeController.java
@@ -57,16 +57,23 @@ public class BackendWireframeController {
     return executionService.listPending(STAGE_CODE);
   }
 
-  /** Recebe o prompt enviado para IA, registra o prompt e marca a execução como aguardando retorno da OpenAI. */
+  /** Recebe prompt, schema e request cru enviados para IA e marca a execução aguardando retorno da OpenAI. */
   @PostMapping("/internal/geralanding/wireframe/stage-executions/{idJob}/recebe-prompt")
   public ResponseEntity<Void> recebePrompt(
       @PathVariable String idJob, @Valid @RequestBody RecebePromptRequest payload) {
     LOGGER.info(
-        "[GeraLanding][Wireframe] Recebido prompt enviado para IA idJob={} jobidopenai={} prompt={}",
+        "[GeraLanding][Wireframe] Recebido request enviado para IA idJob={} jobidopenai={} promptLength={} schemaLength={} requestBodyLength={}",
         idJob,
         payload.jobidopenai(),
-        payload.prompt());
-    executionService.markWaitingOpenAiDispatch(idJob, payload.prompt(), payload.jobidopenai());
+        payload.prompt().length(),
+        payload.schemaJson().length(),
+        payload.requestBodyJson().length());
+    executionService.markWaitingOpenAiDispatch(
+        idJob,
+        payload.prompt(),
+        payload.schemaJson(),
+        payload.requestBodyJson(),
+        payload.jobidopenai());
     return ResponseEntity.accepted().build();
   }
 

--- a/backend/ads-service/src/test/java/com/marketinghub/geralanding/wireframe/service/BackendWireframeServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/geralanding/wireframe/service/BackendWireframeServiceTest.java
@@ -158,9 +158,16 @@ class BackendWireframeServiceTest {
         when(executionRepository.findTopByIdJobOrderByExecutionRequestedAtDesc(any(byte[].class)))
                 .thenReturn(Optional.of(execution));
 
-        service.markWaitingOpenAiDispatch("job-ia-1", "Prompt para IA", "openai-job-1");
+        service.markWaitingOpenAiDispatch(
+                "job-ia-1",
+                "Prompt para IA",
+                "{\"type\":\"object\"}",
+                "{\"model\":\"gpt-test\"}",
+                "openai-job-1");
 
-        assertEquals("Prompt para IA", execution.getOpenAiRequestBody());
+        assertEquals("Prompt para IA", execution.getPrompt());
+        assertEquals("{\"type\":\"object\"}", execution.getSchemaJson());
+        assertEquals("{\"model\":\"gpt-test\"}", execution.getOpenAiRequestBody());
         assertEquals("openai-job-1", execution.getOpenAiJobId());
         assertNotNull(execution.getProcessingStartedAt());
         assertEquals("AGUARDANDO_RETORNO_OPENAI", execution.getStatus());

--- a/backend/ads-service/src/test/java/com/marketinghub/geralanding/wireframe/web/BackendWireframeControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/geralanding/wireframe/web/BackendWireframeControllerTest.java
@@ -69,15 +69,26 @@ class BackendWireframeControllerTest {
     void recebePromptShouldMarkExecutionWaitingOpenAiDispatch(CapturedOutput output) {
         BackendWireframeService executionService = mock(BackendWireframeService.class);
         BackendWireframeController controller = new BackendWireframeController(executionService);
-        RecebePromptRequest payload = new RecebePromptRequest("Prompt para IA", "openai-job-1");
+        RecebePromptRequest payload = new RecebePromptRequest(
+                "Prompt para IA",
+                "{\"type\":\"object\"}",
+                "{\"model\":\"gpt-test\"}",
+                "openai-job-1");
 
         var response = controller.recebePrompt("job-ia-1", payload);
 
         assertEquals(202, response.getStatusCode().value());
         assertEquals("Prompt para IA", payload.prompt());
         assertEquals("openai-job-1", payload.jobidopenai());
-        verify(executionService).markWaitingOpenAiDispatch("job-ia-1", "Prompt para IA", "openai-job-1");
-        assertTrue(output.getOut().contains("prompt=Prompt para IA"));
+        assertEquals("{\"type\":\"object\"}", payload.schemaJson());
+        assertEquals("{\"model\":\"gpt-test\"}", payload.requestBodyJson());
+        verify(executionService).markWaitingOpenAiDispatch(
+                "job-ia-1",
+                "Prompt para IA",
+                "{\"type\":\"object\"}",
+                "{\"model\":\"gpt-test\"}",
+                "openai-job-1");
+        assertTrue(output.getOut().contains("requestBodyLength="));
     }
 
     /** Deve receber a resposta da IA e delegar a conclusão da execução wireframe. */

--- a/docs/canonical/arquitetura-etapas.md
+++ b/docs/canonical/arquitetura-etapas.md
@@ -150,13 +150,15 @@ Content-Type: application/json
 
 {
   "prompt": "...",
+  "schemaJson": "...",
+  "requestBodyJson": "...",
   "jobidopenai": "..."
 }
 ```
 
 O endpoint fica no `BackendWireframeController`, usa o método `recebePrompt` e recebe o payload com os
-campos obrigatórios `prompt` e `jobidopenai`, mantendo rastreabilidade contratual do prompt e do job
-aberto na OpenAI.
+campos obrigatórios `prompt`, `schemaJson`, `requestBodyJson` e `jobidopenai`, mantendo rastreabilidade
+contratual do prompt renderizado, do schema, do request cru enviado à OpenAI e do job aberto na OpenAI.
 
 Após receber a resposta da IA, o Worker AI deve chamar o callback interno inicial:
 

--- a/docs/canonical/geralanding-backend-swagger.v1.yaml
+++ b/docs/canonical/geralanding-backend-swagger.v1.yaml
@@ -272,18 +272,28 @@ components:
     RecebePromptRequest:
       type: object
       additionalProperties: false
-      description: Payload do prompt enviado para IA pelo Worker AI.
+      description: Payload com prompt, schema e request cru enviados para IA pelo Worker AI.
       properties:
         prompt:
           type: string
           minLength: 1
           description: Prompt final enviado ao provedor de IA.
+        schemaJson:
+          type: string
+          minLength: 1
+          description: Schema JSON usado para restringir a resposta da OpenAI.
+        requestBodyJson:
+          type: string
+          minLength: 1
+          description: Request cru completo enviado para a OpenAI Responses API.
         jobidopenai:
           type: string
           minLength: 1
           description: Identificador do job aberto na OpenAI para rastreabilidade.
       required:
         - prompt
+        - schemaJson
+        - requestBodyJson
         - jobidopenai
     RecebeRespostaRequest:
       type: object

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -2513,3 +2513,16 @@
   - ai-worker/src/main/java/com/marketinghub/worker/openai/core/wireframe/WireframeWorkerProperties.java
   - ai-worker/src/main/java/com/marketinghub/worker/geralanding/wireframe/request/MontaRequest.java
   - ai-worker/src/main/resources/application.properties
+
+## 2026-05-29 — Recebe-prompt persiste prompt, schema e request cru
+
+- Solicitação: enviar para o endpoint interno `recebe-prompt` da etapa wireframe as três variáveis geradas no Worker AI core: `prompt`, `schemaJson` e `requestBodyJson`.
+- Causa-raiz: o Worker AI core já montava as três informações antes do despacho para a OpenAI, mas o callback `recebe-prompt` enviava ao backend apenas `prompt` e `jobidopenai`; no backend, `openai_request_body` era preenchido indevidamente com o mesmo conteúdo do prompt e `schema_json` não era atualizado nesse fluxo.
+- Correção aplicada:
+  - o despacho do core OpenAI passou a carregar `schemaJson` junto com `prompt` e `requestBodyJson`;
+  - `WireframeBackendClient.markDispatched(...)` passou a enviar `prompt`, `schemaJson`, `requestBodyJson` e `jobidopenai` para `/recebe-prompt`;
+  - `RecebePromptRequest` da etapa wireframe passou a receber os três campos obrigatórios;
+  - `BackendWireframeService.markWaitingOpenAiDispatch(...)` passou a persistir `prompt`, `schema_json` e `openai_request_body` separadamente na tabela `gera_landing_stage_execution`.
+- Testes previstos/atualizados:
+  - backend: validação do controller e da persistência das três informações;
+  - ai-worker: validação do payload HTTP enviado pelo core para o endpoint `recebe-prompt`.


### PR DESCRIPTION
### Motivation
- Garantir rastreabilidade e auditoria do despacho para a OpenAI persistindo o `schema` e o `request` cru além do `prompt` e do `jobidopenai` no callback interno da etapa wireframe.
- Corrigir preenchimento indevido de `openai_request_body` no backend e alinhar o contrato HTTP entre o Worker AI core e o backend wireframe.

### Description
- Adiciona o campo `schemaJson` ao record `OpenAiDispatch` com validação e ajusta `ResponsesApiOpenAiClient.dispatch` para preencher o novo campo a partir de `OpenAiRequest`.
- Atualiza `WireframeBackendClient.markDispatched` para enviar `prompt`, `schemaJson`, `requestBodyJson` e `jobidopenai` ao endpoint `/recebe-prompt` e adiciona o teste `WireframeBackendClientTest` para validar o payload HTTP.
- Altera o backend: `RecebePromptRequest` agora contém `schemaJson` e `requestBodyJson` (com `@JsonAlias`), `BackendWireframeController.recebePrompt` registra comprimentos e delega os três campos, e `BackendWireframeService.markWaitingOpenAiDispatch` aceita e persiste `prompt`, `schema_json` e `openai_request_body` separadamente.
- Atualiza documentação e Swagger (`docs/canonical/*` e `docs/registros/experimentos.md`) para refletir o novo contrato com os campos obrigatórios `schemaJson` e `requestBodyJson`.

### Testing
- Executado o novo unit test `WireframeBackendClientTest`, que valida o POST para `/recebe-prompt` e passou com sucesso.
- Executados os testes de unidade atualizados `BackendWireframeServiceTest` e `BackendWireframeControllerTest`, que passaram e verificam persistência e delegação com os novos campos.
- Executada a suíte de testes unitários dos módulos modificados (ai-worker e backend/ads-service) com sucesso.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1a1da65ca48321a3303735c3ac4667)