### PR TITLE
Disable GeraLanding schedulers in AI worker

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/copy/monitor/CopyExecutionScheduler.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/copy/monitor/CopyExecutionScheduler.java
@@ -1,14 +1,11 @@
 package com.marketinghub.worker.geralanding.copy.monitor;
 
-
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
-/** Agenda o processamento de jobs pendentes da etapa copy. */
+/** Mantém desligado o agendamento automático de jobs pendentes da etapa copy. */
 @Component
 public class CopyExecutionScheduler {
     private static final Logger log = LoggerFactory.getLogger(CopyExecutionScheduler.class);
@@ -17,6 +14,7 @@ public class CopyExecutionScheduler {
     private final CopyPendingJobsService pendingJobsService;
     private final int pendingLimit;
 
+    /** Configura as dependências da etapa copy mantendo limite mínimo de um job. */
     public CopyExecutionScheduler(CopyExecutionProcessor processor,
                                   CopyPendingJobsService pendingJobsService,
                                   @Value("${geralanding.execution.pending-limit:20}") int pendingLimit) {
@@ -25,8 +23,7 @@ public class CopyExecutionScheduler {
         this.pendingLimit = Math.max(1, pendingLimit);
     }
 
-    /** Executa o ciclo da etapa copy consultando apenas o endpoint específico da etapa. */
-    @Scheduled(cron = "10 */1 * * * *")
+    /** Executa manualmente o ciclo da etapa copy consultando apenas o endpoint específico da etapa. */
     public void run() {
         long startedAt = System.currentTimeMillis();
         try {

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/deliverables/monitor/DeliverablesExecutionScheduler.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/deliverables/monitor/DeliverablesExecutionScheduler.java
@@ -1,14 +1,11 @@
 package com.marketinghub.worker.geralanding.deliverables.monitor;
 
-
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
-/** Agenda o processamento de jobs pendentes da etapa deliverables. */
+/** Mantém desligado o agendamento automático de jobs pendentes da etapa deliverables. */
 @Component
 public class DeliverablesExecutionScheduler {
     private static final Logger log = LoggerFactory.getLogger(DeliverablesExecutionScheduler.class);
@@ -17,6 +14,7 @@ public class DeliverablesExecutionScheduler {
     private final DeliverablesPendingJobsService pendingJobsService;
     private final int pendingLimit;
 
+    /** Configura as dependências da etapa deliverables mantendo limite mínimo de um job. */
     public DeliverablesExecutionScheduler(DeliverablesExecutionProcessor processor,
                                           DeliverablesPendingJobsService pendingJobsService,
                                           @Value("${geralanding.execution.pending-limit:20}") int pendingLimit) {
@@ -25,8 +23,7 @@ public class DeliverablesExecutionScheduler {
         this.pendingLimit = Math.max(1, pendingLimit);
     }
 
-    /** Executa o ciclo da etapa deliverables consultando apenas o endpoint específico da etapa. */
-    @Scheduled(cron = "40 */1 * * * *")
+    /** Executa manualmente o ciclo da etapa deliverables consultando apenas o endpoint específico da etapa. */
     public void run() {
         long startedAt = System.currentTimeMillis();
         try {

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/imageplanning/monitor/ImagePlanningExecutionScheduler.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/imageplanning/monitor/ImagePlanningExecutionScheduler.java
@@ -1,14 +1,11 @@
 package com.marketinghub.worker.geralanding.imageplanning.monitor;
 
-
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
-/** Agenda o processamento de jobs pendentes da etapa image-planning. */
+/** Mantém desligado o agendamento automático de jobs pendentes da etapa image-planning. */
 @Component
 public class ImagePlanningExecutionScheduler {
     private static final Logger log = LoggerFactory.getLogger(ImagePlanningExecutionScheduler.class);
@@ -17,6 +14,7 @@ public class ImagePlanningExecutionScheduler {
     private final ImagePlanningPendingJobsService pendingJobsService;
     private final int pendingLimit;
 
+    /** Configura as dependências da etapa image-planning mantendo limite mínimo de um job. */
     public ImagePlanningExecutionScheduler(ImagePlanningExecutionProcessor processor,
                                            ImagePlanningPendingJobsService pendingJobsService,
                                            @Value("${geralanding.execution.pending-limit:20}") int pendingLimit) {
@@ -25,8 +23,7 @@ public class ImagePlanningExecutionScheduler {
         this.pendingLimit = Math.max(1, pendingLimit);
     }
 
-    /** Executa o ciclo da etapa image-planning consultando apenas o endpoint específico da etapa. */
-    @Scheduled(cron = "20 */1 * * * *")
+    /** Executa manualmente o ciclo da etapa image-planning consultando apenas o endpoint específico da etapa. */
     public void run() {
         long startedAt = System.currentTimeMillis();
         try {

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/presetdesign/monitor/PresetDesignExecutionScheduler.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/presetdesign/monitor/PresetDesignExecutionScheduler.java
@@ -1,14 +1,11 @@
 package com.marketinghub.worker.geralanding.presetdesign.monitor;
 
-
-
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
-/** Agenda o processamento de jobs pendentes da etapa design-preset. */
+/** Mantém desligado o agendamento automático de jobs pendentes da etapa design-preset. */
 @Component
 public class PresetDesignExecutionScheduler {
     private static final Logger log = LoggerFactory.getLogger(PresetDesignExecutionScheduler.class);
@@ -17,6 +14,7 @@ public class PresetDesignExecutionScheduler {
     private final PresetDesignPendingJobsService pendingJobsService;
     private final int pendingLimit;
 
+    /** Configura as dependências da etapa design-preset mantendo limite mínimo de um job. */
     public PresetDesignExecutionScheduler(PresetDesignExecutionProcessor processor,
                                           PresetDesignPendingJobsService pendingJobsService,
                                           @Value("${geralanding.execution.pending-limit:20}") int pendingLimit) {
@@ -25,8 +23,7 @@ public class PresetDesignExecutionScheduler {
         this.pendingLimit = Math.max(1, pendingLimit);
     }
 
-    /** Executa o ciclo da etapa design-preset consultando apenas o endpoint específico da etapa. */
-    @Scheduled(cron = "30 */1 * * * *")
+    /** Executa manualmente o ciclo da etapa design-preset consultando apenas o endpoint específico da etapa. */
     public void run() {
         long startedAt = System.currentTimeMillis();
         try {

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -2526,3 +2526,12 @@
 - Testes previstos/atualizados:
   - backend: validação do controller e da persistência das três informações;
   - ai-worker: validação do payload HTTP enviado pelo core para o endpoint `recebe-prompt`.
+
+## 2026-05-29 23:20:28 UTC-3
+- solicitação para desligar todos os schedulers do Worker AI no pacote `geralanding.*`.
+- raciocínio aplicado: remover a anotação `@Scheduled` apenas das classes de monitoramento das etapas GeraLanding, preservando os métodos `run()` para eventual execução manual e sem afetar schedulers de outros domínios do Worker AI.
+- foi feito: os agendamentos automáticos das etapas copy, image-planning, design-preset e deliverables foram desativados por remoção das anotações Spring Scheduling e dos imports correspondentes.
+- documentos lidos para pesquisar e resolver o problema:
+  - AGENTS.md
+  - ai-worker/AGENTS.md
+  - docs/registros/experimentos.md


### PR DESCRIPTION
### Motivation
- Pausar a execução automática das rotinas do pacote `geralanding.*` do Worker AI para permitir execução manual/controle operacional e evitar dispatchs automáticos durante manutenção ou investigação.

### Description
- Removed the Spring `@Scheduled` annotation and the `org.springframework.scheduling.annotation.Scheduled` import from the four GeraLanding scheduler classes: `ai-worker/src/main/java/com/marketinghub/worker/geralanding/copy/monitor/CopyExecutionScheduler.java`, `.../imageplanning/.../ImagePlanningExecutionScheduler.java`, `.../presetdesign/.../PresetDesignExecutionScheduler.java` and `.../deliverables/.../DeliverablesExecutionScheduler.java`.
- Updated JavaDoc/class comments to explicitly state that automatic scheduling is disabled and added brief constructor responsibility comments while keeping the `run()` method public for manual invocation.
- Added an operational record entry in `docs/registros/experimentos.md` documenting the change and rationale.

### Testing
- Verified removal with `rg -n "@Scheduled|scheduling.annotation.Scheduled" ai-worker/src/main/java/com/marketinghub/worker/geralanding -g '*.java'` which returned no scheduled annotations in the modified package.
- Ran `git diff --check` to ensure no whitespace/conflict issues were introduced and the repository diff was clean.
- Attempted `mvn test` in `ai-worker`, but the build/tests were blocked by dependency resolution failing for `com.marketinghub:ads-service:0.0.1-SNAPSHOT` due to `401 Unauthorized` from GitHub Packages, so unit tests could not complete in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1a4933b2dc83219a74c902ef4abf51)