### PR TITLE
Log OpenAI request bodies on Responses API errors and remove `uniqueItems` from wireframe schema

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/wireframe/request/GeraLandingWireframeOpenAiExecutionService.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/wireframe/request/GeraLandingWireframeOpenAiExecutionService.java
@@ -115,12 +115,14 @@ public class GeraLandingWireframeOpenAiExecutionService {
 
     /** Prepara e executa a chamada flex da OpenAI para a etapa wireframe. */
     private OpenAiResponse createFlexResponse(RecordJobDto job) throws Exception {
+        String finalRequestBodyJson = null;
         try {
             log.info("Iniciando preparação do request para flex wireframe [jobId={}, stage={}, requestBodyJsonPreview={}]", job.id(), job.section(), preview(job.requestBodyJson()));
             Map<String, Object> requestBody = prepareRequestBodyForFlex(job);
             log.info("RequestBody parseado para flex wireframe [jobId={}, stage={}, keys={}, requestBodyMapPreview={}]", job.id(), job.section(), requestBody.keySet(), preview(objectMapper.writeValueAsString(requestBody)));
             requestBody.put("service_tier", "flex");
-            log.info("RequestBody final para /responses wireframe [jobId={}, stage={}, requestBodyWithFlexPreview={}]", job.id(), job.section(), preview(objectMapper.writeValueAsString(requestBody)));
+            finalRequestBodyJson = objectMapper.writeValueAsString(requestBody);
+            log.info("RequestBody final cru para /responses wireframe [jobId={}, stage={}, requestBodyJson={}]", job.id(), job.section(), finalRequestBodyJson);
 
             OpenAiResponse response = webClient.post().uri("/responses")
                     .contentType(MediaType.APPLICATION_JSON)
@@ -138,7 +140,7 @@ public class GeraLandingWireframeOpenAiExecutionService {
             return response;
         } catch (WebClientResponseException ex) {
             HttpStatusCode statusCode = ex.getStatusCode();
-            log.error("Falha HTTP OpenAI flex no gera-landing wireframe [jobId={}, stage={}, status={}, responseBody={}]", job.id(), job.section(), statusCode.value(), ex.getResponseBodyAsString(), ex);
+            log.error("Falha HTTP OpenAI flex no gera-landing wireframe [jobId={}, stage={}, status={}, responseBody={}, requestBodyJson={}]", job.id(), job.section(), statusCode.value(), ex.getResponseBodyAsString(), finalRequestBodyJson, ex);
             throw new IllegalStateException("Falha HTTP ao gerar conteúdo de gera-landing wireframe em modo flex", ex);
         } catch (Exception ex) {
             log.error("Falha inesperada no gera-landing wireframe em modo flex [jobId={}, stage={}, model={}, requestBodyPreview={}]", job.id(), job.section(), job.model(), preview(job.requestBodyJson()), ex);

--- a/ai-worker/src/main/java/com/marketinghub/worker/openai/core/openai/ResponsesApiOpenAiClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/openai/core/openai/ResponsesApiOpenAiClient.java
@@ -14,10 +14,15 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientResponseException;
 
 /** Responsabilidade: executar chamadas síncronas para a OpenAI Responses API no core OpenAI. */
 public class ResponsesApiOpenAiClient implements OpenAiClientPort {
+
+    private static final Logger log = LoggerFactory.getLogger(ResponsesApiOpenAiClient.class);
 
     private final WebClient webClient;
     private final ObjectMapper objectMapper;
@@ -47,8 +52,11 @@ public class ResponsesApiOpenAiClient implements OpenAiClientPort {
     /** Envia o request cru para a OpenAI e devolve os dados de despacho para auditoria no backend. */
     @Override
     public OpenAiDispatch dispatch(OpenAiRequest request) {
+        String requestBodyJson = request.requestBodyJson();
+        String marketingHubJobId = marketingHubJobId(request);
         try {
-            Map<String, Object> requestBody = objectMapper.readValue(request.requestBodyJson(), Map.class);
+            Map<String, Object> requestBody = objectMapper.readValue(requestBodyJson, Map.class);
+            log.info("Enviando request cru para OpenAI Responses API [jobId={}, schemaName={}, requestBodyJson={}]", marketingHubJobId, request.schemaName(), requestBodyJson);
 
             Map<String, Object> raw = webClient.post()
                     .uri("/responses")
@@ -62,6 +70,7 @@ public class ResponsesApiOpenAiClient implements OpenAiClientPort {
             }
 
             String rawJson = objectMapper.writeValueAsString(raw);
+            log.info("Resposta crua recebida da OpenAI Responses API [jobId={}, openAiJobId={}, rawResponseJson={}]", marketingHubJobId, stringValue(raw.get("id")), rawJson);
             String openAiJobId = stringValue(raw.get("id"));
             String modelResponse = extractModelResponse(raw);
             Integer inputTokens = extractInteger(raw, "usage", "input_tokens");
@@ -88,9 +97,25 @@ public class ResponsesApiOpenAiClient implements OpenAiClientPort {
                     request.requestBodyJson(),
                     Instant.now()
             );
+        } catch (WebClientResponseException error) {
+            log.error(
+                    "Falha HTTP na OpenAI Responses API [jobId={}, schemaName={}, status={}, responseBody={}, requestBodyJson={}]",
+                    marketingHubJobId,
+                    request.schemaName(),
+                    error.getStatusCode().value(),
+                    error.getResponseBodyAsString(),
+                    requestBodyJson,
+                    error);
+            throw new StageWorkerException("OpenAI Responses API returned HTTP " + error.getStatusCode().value(), error);
         } catch (JsonProcessingException error) {
             throw new StageWorkerException("Invalid OpenAI request JSON", error);
         }
+    }
+
+    /** Recupera o idJob do Marketing Hub a partir dos metadados do request para correlacionar logs operacionais. */
+    private String marketingHubJobId(OpenAiRequest request) {
+        Object value = request.metadata().get("idJob");
+        return value != null ? value.toString() : "<unknown>";
     }
 
     /** Recupera a resposta bruta da OpenAI armazenada localmente após o despacho síncrono. */

--- a/ai-worker/src/main/resources/prompts/geralanding/landing-page-wireframe-schema.json
+++ b/ai-worker/src/main/resources/prompts/geralanding/landing-page-wireframe-schema.json
@@ -74,8 +74,7 @@
                   "textPrimary",
                   "marginReset"
                 ]
-              },
-              "uniqueItems": true
+              }
             }
           },
           "required": [

--- a/ai-worker/src/test/java/com/marketinghub/worker/openai/core/openai/ResponsesApiOpenAiClientTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/openai/core/openai/ResponsesApiOpenAiClientTest.java
@@ -1,0 +1,91 @@
+package com.marketinghub.worker.openai.core.openai;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.catchThrowable;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.Logger;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import ch.qos.logback.core.read.ListAppender;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marketinghub.worker.openai.core.exception.StageWorkerException;
+import com.marketinghub.worker.openai.core.model.OpenAiRequest;
+import java.math.BigDecimal;
+import java.time.Duration;
+import java.util.Map;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.slf4j.LoggerFactory;
+import org.springframework.web.reactive.function.client.WebClient;
+
+/** Responsabilidade: validar observabilidade e contrato do client OpenAI Responses API do core. */
+class ResponsesApiOpenAiClientTest {
+
+    private MockWebServer server;
+    private ListAppender<ILoggingEvent> appender;
+    private Logger logger;
+    private Level originalLevel;
+
+    /** Inicializa servidor HTTP e captura de logs para cada cenário de teste do client OpenAI. */
+    @BeforeEach
+    void setUp() throws Exception {
+        server = new MockWebServer();
+        server.start();
+        logger = (Logger) LoggerFactory.getLogger(ResponsesApiOpenAiClient.class);
+        originalLevel = logger.getLevel();
+        logger.setLevel(Level.INFO);
+        appender = new ListAppender<>();
+        appender.start();
+        logger.addAppender(appender);
+    }
+
+    /** Encerra recursos externos e remove o appender de log após cada teste. */
+    @AfterEach
+    void tearDown() throws Exception {
+        logger.detachAppender(appender);
+        logger.setLevel(originalLevel);
+        appender.stop();
+        server.shutdown();
+    }
+
+    /** Deve registrar o request cru enviado à OpenAI quando a Responses API rejeitar a chamada com erro HTTP. */
+    @Test
+    void dispatchShouldLogRawOpenAiRequestWhenHttpErrorHappens() {
+        server.enqueue(new MockResponse()
+                .setResponseCode(400)
+                .setHeader("Content-Type", "application/json")
+                .setBody("{\"error\":{\"message\":\"Invalid schema\"}}"));
+        ResponsesApiOpenAiClient client = new ResponsesApiOpenAiClient(
+                WebClient.builder(),
+                new ObjectMapper(),
+                new OpenAiClientProperties(
+                        "test-key",
+                        server.url("/").toString(),
+                        "gpt-test",
+                        Duration.ofSeconds(5),
+                        BigDecimal.ZERO,
+                        BigDecimal.ZERO));
+        String requestBodyJson = "{\"model\":\"gpt-test\",\"input\":\"Prompt\"}";
+        OpenAiRequest request = new OpenAiRequest(
+                "gpt-test",
+                "Prompt",
+                requestBodyJson,
+                "schema-wireframe",
+                "{\"type\":\"object\"}",
+                Map.of("idJob", "job-123"));
+
+        Throwable thrown = catchThrowable(() -> client.dispatch(request));
+
+        assertThat(thrown).isInstanceOf(StageWorkerException.class);
+        assertThat(appender.list)
+                .extracting(ILoggingEvent::getFormattedMessage)
+                .anySatisfy(message -> assertThat(message)
+                        .contains("Falha HTTP na OpenAI Responses API")
+                        .contains("jobId=job-123")
+                        .contains("requestBodyJson=" + requestBodyJson)
+                        .contains("Invalid schema"));
+    }
+}

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -2526,3 +2526,28 @@
 - Testes previstos/atualizados:
   - backend: validação do controller e da persistência das três informações;
   - ai-worker: validação do payload HTTP enviado pelo core para o endpoint `recebe-prompt`.
+
+## 2026-05-30 — Investigação da falha do job wireframe 123f3449
+
+- Solicitação: pesquisar o que aconteceu com o job `123f3449-4a7e-4962-80a7-b796cf7fc9b3` do GeraLanding wireframe no experimento 34.
+- Causa-raiz provável: a execução chegou à chamada da OpenAI Responses API e falhou com `400 Bad Request`; a tabela `gera_landing_stage_execution` não recebeu `prompt`, `schema_json`, `openai_request_body`, `openai_model` nem `openai_job_id` para esse job, indicando falha antes do callback de rastreabilidade `recebe-prompt`.
+- Evidências coletadas:
+  - banco via MCP: o job está em `FALHA`, etapa `landing-page-wireframe`, criado em `2026-05-30T01:59:43.633Z` e concluído em `2026-05-30T02:00:22.549Z`, com `error_message = 400 Bad Request from POST https://api.openai.com/v1/responses`;
+  - logs via MCP: não havia mais linhas filtráveis pelo job/erro na janela consultada, apesar da aplicação possuir log do corpo HTTP da OpenAI no catch de `WebClientResponseException`;
+  - código local: o montador da etapa wireframe usa Structured Outputs com `strict=true`, e o schema atual contém `uniqueItems`, palavra-chave não listada entre as propriedades de array suportadas na documentação oficial de Structured Outputs da OpenAI.
+- Próximo passo recomendado: corrigir a etapa wireframe para remover/substituir `uniqueItems` do schema estrito, persistir o corpo da resposta HTTP da OpenAI em `error_detail` quando houver `WebClientResponseException`, e reexecutar o job para validar a causa-raiz com resposta completa.
+- Comandos usados na investigação:
+  - consultas MCP `db_query` em `gera_landing_stage_execution`;
+  - consultas MCP `java_module_logs` nos módulos `backend` e `ai-worker`;
+  - inspeção local com `rg`, `nl` e scripts Python pontuais sobre schema/código.
+
+## 2026-05-30 — Correção do schema e log do request OpenAI no wireframe
+
+- Solicitação: retirar `uniqueItems` do schema da etapa `landing-page-wireframe` e garantir que, em falhas como o `400 Bad Request` da OpenAI, o Worker AI registre no log o request enviado à OpenAI.
+- Causa-raiz tratada: o schema estrito do wireframe exigia unicidade em `pagina.body.classes`, mas essa validação não era necessária no contrato funcional e aumentava o risco de rejeição do schema pela OpenAI Responses API.
+- Correção aplicada:
+  - removido `uniqueItems` de `pagina.body.classes` no schema do wireframe;
+  - o client core `ResponsesApiOpenAiClient` passou a registrar o request cru antes da chamada à OpenAI e a resposta crua no sucesso;
+  - em erro HTTP da Responses API, o log agora inclui `jobId`, schema, status, corpo de resposta da OpenAI e `requestBodyJson` enviado;
+  - o executor legado/flex da etapa wireframe também passou a registrar o request final cru no envio e no log de falha HTTP.
+- Teste adicionado: validação unitária de que uma rejeição HTTP da OpenAI registra o request cru com o `jobId` do Marketing Hub.


### PR DESCRIPTION
### Motivation

- Debug failing wireframe jobs where the OpenAI Responses API returned `400` but the request body and openai response details were not persisted or visible in logs. 
- Fix a strict schema keyword (`uniqueItems`) in the landing-page wireframe Structured Output that likely caused the Responses API rejection.

### Description

- Add structured logging to `ResponsesApiOpenAiClient` so the raw `requestBodyJson` is logged before the `/responses` call and the raw response is logged on success. 
- Catch `WebClientResponseException` in `ResponsesApiOpenAiClient` and log `jobId`, `schemaName`, HTTP status, OpenAI response body and the `requestBodyJson`, then rethrow as `StageWorkerException`, and add a helper `marketingHubJobId()` to extract `idJob` from metadata for correlation. 
- Update the legacy flex executor `GeraLandingWireframeOpenAiExecutionService` to serialize and log the final raw request body (`finalRequestBodyJson`) and include it in HTTP error logs. 
- Remove the `uniqueItems` keyword from `pagina.body.classes` in `landing-page-wireframe-schema.json`. 
- Add unit test `ResponsesApiOpenAiClientTest` that verifies a HTTP 4xx from the Responses API results in a log entry containing the raw request body and `jobId`, and update experiment documentation in `docs/registros/experimentos.md` with investigation and remediation notes.

### Testing

- Added `ResponsesApiOpenAiClientTest` which simulates a `400` response from a mock OpenAI server and asserts that the failure log contains `jobId` and `requestBodyJson`, and the test passed. 
- Ran the unit test suite with `./gradlew test` for the OpenAI core module and the affected tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1a48554558832181acda12c87694cb)