### PR TITLE
Remover regra arquitetural de cron externalizado (ArquiteturaCoreTest)

### DIFF
--- a/ai-worker/src/test/java/com/marketinghub/worker/openai/core/ArquiteturaCoreTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/openai/core/ArquiteturaCoreTest.java
@@ -8,7 +8,6 @@ import com.marketinghub.worker.openai.core.port.StageResponseValidator;
 import com.tngtech.archunit.base.DescribedPredicate;
 import com.tngtech.archunit.core.domain.Dependency;
 import com.tngtech.archunit.core.domain.JavaClass;
-import com.tngtech.archunit.core.domain.JavaMethod;
 import com.tngtech.archunit.core.importer.ImportOption;
 import com.tngtech.archunit.junit.AnalyzeClasses;
 import com.tngtech.archunit.junit.ArchTest;
@@ -23,7 +22,6 @@ import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 import org.springframework.stereotype.Service;
 import org.springframework.validation.annotation.Validated;
@@ -255,14 +253,6 @@ class ArquiteturaCoreTest {
                     .because("[ARQUITETURA] usar injeção por construtor ou criação explícita por @Bean");
 
     @ArchTest
-    static final ArchRule scheduled_deve_usar_cron_externalizado =
-            methods()
-                    .that()
-                    .areAnnotatedWith(Scheduled.class)
-                    .should(useExternalizedCronExpression())
-                    .because("[ARQUITETURA] frequência operacional deve ser configurável por ambiente");
-
-    @ArchTest
     static final ArchRule metodos_publicos_em_worker_configuration_devem_ser_bean =
             methods()
                     .that()
@@ -310,28 +300,6 @@ class ArquiteturaCoreTest {
 
                         events.add(SimpleConditionEvent.violated(source, message));
                     }
-                }
-            }
-        };
-    }
-
-    private static ArchCondition<JavaMethod> useExternalizedCronExpression() {
-        return new ArchCondition<>("[ARQUITETURA] usar cron externalizado por placeholder de propriedade") {
-            @Override
-            public void check(JavaMethod method, ConditionEvents events) {
-                Scheduled scheduled = method.getAnnotationOfType(Scheduled.class);
-                String cron = scheduled.cron();
-
-                boolean valid = cron != null
-                        && cron.contains("${")
-                        && cron.contains("}");
-
-                if (!valid) {
-                    String message = "[ARQUITETURA] " + method.getFullName()
-                            + " usa @Scheduled com cron fixo. Use formato externalizado, por exemplo: "
-                            + "@Scheduled(cron = \"${wireframe.worker.cron:0 */5 * * * *}\")";
-
-                    events.add(SimpleConditionEvent.violated(method, message));
                 }
             }
         };

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -2578,3 +2578,11 @@
   - substituída a chamada incompatível por `.and(ARE_NOT_WORKER_CONFIGURATION)`, preservando a intenção da regra.
   - padronizadas mensagens de falha do `ArquiteturaCoreTest` com o prefixo obrigatório `[ARQUITETURA] `.
 - validação: `mvn test-compile -DskipTests` foi executado em `ai-worker`, mas não pôde chegar à compilação porque a dependência privada `com.marketinghub:ads-service:0.0.1-SNAPSHOT` retornou `401 Unauthorized` no GitHub Packages neste ambiente.
+
+## 2026-05-30 — Remoção da exigência de cron externalizado no ArquiteturaCoreTest
+- tarefa: retirar dos testes de arquitetura do Worker AI a exigência de que métodos `@Scheduled` usem cron externalizado por placeholder de propriedade.
+- causa-raiz: a regra arquitetural `scheduled_deve_usar_cron_externalizado` conflita com o cânone atual de agendamento por etapa, que define cron explícito diretamente na anotação `@Scheduled`, sem variável intermediária.
+- correção aplicada:
+  - removida a regra ArchUnit `scheduled_deve_usar_cron_externalizado` de `ArquiteturaCoreTest`.
+  - removida a condição auxiliar `useExternalizedCronExpression()` e imports que só existiam para validar placeholder de cron.
+- impacto esperado: schedulers como `WireframeExecutionScheduler.run()` deixam de falhar no teste de arquitetura por usar cron fixo direto na anotação.


### PR DESCRIPTION
### Motivation
- Corrigir falha do teste arquitetural que exigia cron externalizado para métodos anotados com `@Scheduled`, a qual conflita com o cânone existente que usa cron literal em schedulers por etapa. 
- Evitar que schedulers como `WireframeExecutionScheduler.run()` falhem no `ArquiteturaCoreTest` por usarem cron fixo direto na anotação.

### Description
- Remove a regra ArchUnit `scheduled_deve_usar_cron_externalizado` do arquivo `ai-worker/src/test/java/com/marketinghub/worker/openai/core/ArquiteturaCoreTest.java`.
- Remove a condição auxiliar `useExternalizedCronExpression()` e os imports relacionados (`Scheduled` e `JavaMethod`) que existiam apenas para essa validação em `ArquiteturaCoreTest`.
- Adiciona registro da mudança em `docs/registros/experimentos.md` descrevendo causa-raiz, correção aplicada e impacto esperado.

### Testing
- `git diff --check` foi executado e não retornou problemas.
- Alterações foram commitadas localmente (`Remove cron placeholder architecture rule`).
- Tentativa de executar `../backend/mvnw -Dtest=ArquiteturaCoreTest test -q` foi realizada, mas a execução do teste foi bloqueada por uma dependência privada `com.marketinghub:ads-service:0.0.1-SNAPSHOT` que retornou `401 Unauthorized` no GitHub Packages, portanto os testes Arquitetura/ArchUnit não puderam ser concluídos neste ambiente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1a62772a3483218ac536cf1a75f981)