### PR TITLE
Persist prompt markdown content across OpenAI wireframe flow and persist in backend

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/openai/core/model/OpenAiDispatch.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/openai/core/model/OpenAiDispatch.java
@@ -9,6 +9,7 @@ public record OpenAiDispatch(
         String prompt,
         String schemaJson,
         String requestBodyJson,
+        String promptMarkdownContent,
         Instant dispatchedAt
 ) {
     /** Valida os campos obrigatórios e define o horário do despacho quando ausente. */
@@ -16,6 +17,7 @@ public record OpenAiDispatch(
         Objects.requireNonNull(prompt, "prompt must not be null");
         Objects.requireNonNull(schemaJson, "schemaJson must not be null");
         Objects.requireNonNull(requestBodyJson, "requestBodyJson must not be null");
+        Objects.requireNonNull(promptMarkdownContent, "promptMarkdownContent must not be null");
         dispatchedAt = dispatchedAt == null ? Instant.now() : dispatchedAt;
     }
 }

--- a/ai-worker/src/main/java/com/marketinghub/worker/openai/core/model/OpenAiRequest.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/openai/core/model/OpenAiRequest.java
@@ -3,18 +3,22 @@ package com.marketinghub.worker.openai.core.model;
 import java.util.Map;
 import java.util.Objects;
 
+/** Responsabilidade: transportar o request OpenAI montado com dados de auditoria da etapa. */
 public record OpenAiRequest(
         String model,
         String prompt,
         String requestBodyJson,
         String schemaName,
         String schemaJson,
+        String promptMarkdownContent,
         Map<String, Object> metadata
 ) {
+    /** Valida os campos obrigatórios e normaliza metadados opcionais. */
     public OpenAiRequest {
         Objects.requireNonNull(model, "model must not be null");
         Objects.requireNonNull(prompt, "prompt must not be null");
         Objects.requireNonNull(requestBodyJson, "requestBodyJson must not be null");
+        Objects.requireNonNull(promptMarkdownContent, "promptMarkdownContent must not be null");
         metadata = metadata == null ? Map.of() : Map.copyOf(metadata);
     }
 }

--- a/ai-worker/src/main/java/com/marketinghub/worker/openai/core/openai/ResponsesApiOpenAiClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/openai/core/openai/ResponsesApiOpenAiClient.java
@@ -96,6 +96,7 @@ public class ResponsesApiOpenAiClient implements OpenAiClientPort {
                     request.prompt(),
                     request.schemaJson(),
                     request.requestBodyJson(),
+                    request.promptMarkdownContent(),
                     Instant.now()
             );
         } catch (WebClientResponseException error) {

--- a/ai-worker/src/main/java/com/marketinghub/worker/openai/core/wireframe/WireframeBackendClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/openai/core/wireframe/WireframeBackendClient.java
@@ -66,6 +66,7 @@ public class WireframeBackendClient implements StageBackendPort<WireframeInput, 
     public void markDispatched(StageExecution<WireframeInput> execution, OpenAiDispatch dispatch) {
         Map<String, Object> body = new LinkedHashMap<>();
         body.put("prompt", dispatch.prompt());
+        body.put("promptMarkdownContent", dispatch.promptMarkdownContent());
         body.put("schemaJson", dispatch.schemaJson());
         body.put("requestBodyJson", dispatch.requestBodyJson());
         body.put("jobidopenai", dispatch.openAiJobId());

--- a/ai-worker/src/main/java/com/marketinghub/worker/openai/core/wireframe/WireframePromptBuilder.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/openai/core/wireframe/WireframePromptBuilder.java
@@ -15,12 +15,14 @@ import java.util.Map;
 
 import org.springframework.core.io.ClassPathResource;
 
+/** Responsabilidade: montar o prompt, schema e request OpenAI da etapa wireframe. */
 public class WireframePromptBuilder implements StagePromptBuilder<WireframeInput> {
 
     private final ObjectMapper objectMapper;
     private final OpenAiClientProperties openAiProperties;
     private final WireframeWorkerProperties wireframeProperties;
 
+    /** Inicializa o builder com serializador, propriedades OpenAI e propriedades da etapa wireframe. */
     public WireframePromptBuilder(
             ObjectMapper objectMapper,
             OpenAiClientProperties openAiProperties,
@@ -31,11 +33,13 @@ public class WireframePromptBuilder implements StagePromptBuilder<WireframeInput
         this.wireframeProperties = wireframeProperties;
     }
 
+    /** Monta o request completo da OpenAI mantendo o conteúdo bruto do markdown usado no prompt. */
     @Override
     public OpenAiRequest build(StageExecution<WireframeInput> execution) {
         Map<String, Object> data = execution.input().promptData();
 
-        String prompt = resolvePrompt(loadResource(wireframeProperties.promptResource()), data);
+        String promptMarkdownContent = loadResource(wireframeProperties.promptResource());
+        String prompt = resolvePrompt(promptMarkdownContent, data);
         String schemaJson = loadResource(wireframeProperties.schemaResource());
         String requestBodyJson = buildResponsesApiRequest(prompt, schemaJson);
 
@@ -45,6 +49,7 @@ public class WireframePromptBuilder implements StagePromptBuilder<WireframeInput
                 requestBodyJson,
                 wireframeProperties.schemaName(),
                 schemaJson,
+                promptMarkdownContent,
                 Map.of(
                         "stageCode", execution.stageCode(),
                         "idJob", execution.idJob(),
@@ -53,6 +58,7 @@ public class WireframePromptBuilder implements StagePromptBuilder<WireframeInput
         );
     }
 
+    /** Serializa o corpo compatível com Responses API usando schema JSON estrito. */
     private String buildResponsesApiRequest(String prompt, String schemaJson) {
         try {
             Object schema = objectMapper.readValue(schemaJson, Object.class);
@@ -77,6 +83,7 @@ public class WireframePromptBuilder implements StagePromptBuilder<WireframeInput
         }
     }
 
+    /** Aplica os dados do job nos placeholders do conteúdo markdown do prompt. */
     private String resolvePrompt(String template, Map<String, Object> data) {
         String result = template;
 
@@ -91,6 +98,7 @@ public class WireframePromptBuilder implements StagePromptBuilder<WireframeInput
         return result;
     }
 
+    /** Converte valores de placeholder para texto ou JSON formatado antes da substituição. */
     private String toJsonOrText(Object value) {
         if (value == null) {
             return "";
@@ -107,6 +115,7 @@ public class WireframePromptBuilder implements StagePromptBuilder<WireframeInput
         }
     }
 
+    /** Lê recursos do classpath usados como prompt markdown ou schema da etapa. */
     private String loadResource(String path) {
         try {
             return new ClassPathResource(path).getContentAsString(StandardCharsets.UTF_8);

--- a/ai-worker/src/test/java/com/marketinghub/worker/openai/core/openai/ResponsesApiOpenAiClientTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/openai/core/openai/ResponsesApiOpenAiClientTest.java
@@ -75,6 +75,7 @@ class ResponsesApiOpenAiClientTest {
                 requestBodyJson,
                 "schema-wireframe",
                 "{\"type\":\"object\"}",
+                "# Prompt markdown bruto",
                 Map.of("idJob", "job-123"));
 
         Throwable thrown = catchThrowable(() -> client.dispatch(request));

--- a/ai-worker/src/test/java/com/marketinghub/worker/openai/core/wireframe/WireframeBackendClientTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/openai/core/wireframe/WireframeBackendClientTest.java
@@ -66,6 +66,7 @@ class WireframeBackendClientTest {
                 "Prompt renderizado",
                 "{\"type\":\"object\"}",
                 "{\"model\":\"gpt-test\",\"input\":\"Prompt renderizado\"}",
+                "# Prompt markdown bruto",
                 Instant.parse("2026-05-29T10:01:00Z"));
 
         client.markDispatched(execution, dispatch);
@@ -77,6 +78,7 @@ class WireframeBackendClientTest {
         Map<String, Object> payload = objectMapper.readValue(request.getBody().readUtf8(), new TypeReference<>() {});
         assertThat(payload)
                 .containsEntry("prompt", "Prompt renderizado")
+                .containsEntry("promptMarkdownContent", "# Prompt markdown bruto")
                 .containsEntry("schemaJson", "{\"type\":\"object\"}")
                 .containsEntry("requestBodyJson", "{\"model\":\"gpt-test\",\"input\":\"Prompt renderizado\"}")
                 .containsEntry("jobidopenai", "openai-job-1");

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/service/BackendWireframeService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/service/BackendWireframeService.java
@@ -111,6 +111,7 @@ public class BackendWireframeService {
     public void markWaitingOpenAiDispatch(
             String idJob,
             String prompt,
+            String promptMarkdownContent,
             String schemaJson,
             String requestBodyJson,
             String openAiJobId) {
@@ -121,6 +122,7 @@ public class BackendWireframeService {
                 ));
 
         execution.setPrompt(prompt);
+        execution.setPromptMarkdownContent(resolvePromptMarkdownContent(prompt, promptMarkdownContent));
         execution.setSchemaJson(schemaJson);
         execution.setOpenAiRequestBody(requestBodyJson);
         execution.setOpenAiJobId(openAiJobId);
@@ -128,6 +130,14 @@ public class BackendWireframeService {
         execution.setStatus(STATUS_WAITING_OPENAI_DISPATCH);
 
         executionRepository.save(execution);
+    }
+
+    /** Resolve o markdown bruto do prompt mantendo compatibilidade com clientes antigos que enviavam esse conteúdo em prompt. */
+    private String resolvePromptMarkdownContent(String prompt, String promptMarkdownContent) {
+        if (promptMarkdownContent != null && !promptMarkdownContent.isBlank()) {
+            return promptMarkdownContent;
+        }
+        return prompt;
     }
 
     /** Conclui ou falha a execução da etapa wireframe com a resposta devolvida pelo Worker AI. */

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/service/recebeprompt/RecebePromptRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/service/recebeprompt/RecebePromptRequest.java
@@ -6,6 +6,7 @@ import jakarta.validation.constraints.NotBlank;
 /** Representa o payload interno com prompt, schema e request cru enviados ao provedor de IA. */
 public record RecebePromptRequest(
         @NotBlank String prompt,
+        String promptMarkdownContent,
         @NotBlank String schemaJson,
         @NotBlank @JsonAlias("openAiRequestBody") String requestBodyJson,
         @NotBlank String jobidopenai) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/web/BackendWireframeController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/web/BackendWireframeController.java
@@ -62,15 +62,17 @@ public class BackendWireframeController {
   public ResponseEntity<Void> recebePrompt(
       @PathVariable String idJob, @Valid @RequestBody RecebePromptRequest payload) {
     LOGGER.info(
-        "[GeraLanding][Wireframe] Recebido request enviado para IA idJob={} jobidopenai={} promptLength={} schemaLength={} requestBodyLength={}",
+        "[GeraLanding][Wireframe] Recebido request enviado para IA idJob={} jobidopenai={} promptLength={} promptMarkdownLength={} schemaLength={} requestBodyLength={}",
         idJob,
         payload.jobidopenai(),
         payload.prompt().length(),
+        payload.promptMarkdownContent() != null ? payload.promptMarkdownContent().length() : 0,
         payload.schemaJson().length(),
         payload.requestBodyJson().length());
     executionService.markWaitingOpenAiDispatch(
         idJob,
         payload.prompt(),
+        payload.promptMarkdownContent(),
         payload.schemaJson(),
         payload.requestBodyJson(),
         payload.jobidopenai());

--- a/backend/ads-service/src/test/java/com/marketinghub/geralanding/wireframe/service/BackendWireframeServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/geralanding/wireframe/service/BackendWireframeServiceTest.java
@@ -161,11 +161,13 @@ class BackendWireframeServiceTest {
         service.markWaitingOpenAiDispatch(
                 "job-ia-1",
                 "Prompt para IA",
+                "# Prompt markdown bruto",
                 "{\"type\":\"object\"}",
                 "{\"model\":\"gpt-test\"}",
                 "openai-job-1");
 
         assertEquals("Prompt para IA", execution.getPrompt());
+        assertEquals("# Prompt markdown bruto", execution.getPromptMarkdownContent());
         assertEquals("{\"type\":\"object\"}", execution.getSchemaJson());
         assertEquals("{\"model\":\"gpt-test\"}", execution.getOpenAiRequestBody());
         assertEquals("openai-job-1", execution.getOpenAiJobId());

--- a/backend/ads-service/src/test/java/com/marketinghub/geralanding/wireframe/web/BackendWireframeControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/geralanding/wireframe/web/BackendWireframeControllerTest.java
@@ -71,6 +71,7 @@ class BackendWireframeControllerTest {
         BackendWireframeController controller = new BackendWireframeController(executionService);
         RecebePromptRequest payload = new RecebePromptRequest(
                 "Prompt para IA",
+                "# Prompt markdown bruto",
                 "{\"type\":\"object\"}",
                 "{\"model\":\"gpt-test\"}",
                 "openai-job-1");
@@ -80,11 +81,13 @@ class BackendWireframeControllerTest {
         assertEquals(202, response.getStatusCode().value());
         assertEquals("Prompt para IA", payload.prompt());
         assertEquals("openai-job-1", payload.jobidopenai());
+        assertEquals("# Prompt markdown bruto", payload.promptMarkdownContent());
         assertEquals("{\"type\":\"object\"}", payload.schemaJson());
         assertEquals("{\"model\":\"gpt-test\"}", payload.requestBodyJson());
         verify(executionService).markWaitingOpenAiDispatch(
                 "job-ia-1",
                 "Prompt para IA",
+                "# Prompt markdown bruto",
                 "{\"type\":\"object\"}",
                 "{\"model\":\"gpt-test\"}",
                 "openai-job-1");

--- a/docs/canonical/geralanding-backend-swagger.v1.yaml
+++ b/docs/canonical/geralanding-backend-swagger.v1.yaml
@@ -278,6 +278,10 @@ components:
           type: string
           minLength: 1
           description: Prompt final enviado ao provedor de IA.
+        promptMarkdownContent:
+          type: string
+          nullable: true
+          description: Conteúdo bruto do arquivo markdown usado como base para montar o prompt.
         schemaJson:
           type: string
           minLength: 1

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -2595,3 +2595,13 @@
   - atualizado o comentário do método para refletir a nova cadência de 1 minuto.
 - impacto esperado: o Worker AI passa a buscar jobs pendentes de wireframe do OpenAI core a cada minuto, reduzindo espera operacional sem alterar contratos de backend ou payloads OpenAI.
 - 2026-05-30 (UTC): ajuste operacional no `ai-worker` OpenAI core para usar `gpt-5.2` como modelo padrão. Foram atualizados `openai.model`, o fallback `OPENAI_MODEL` nos docker-compose do worker e a documentação do README, mantendo a possibilidade de sobrescrita por variável de ambiente para preservar controle operacional por ambiente.
+
+## 2026-05-30 — Persistência do markdown bruto no OpenAI core wireframe
+- tarefa: ajustar o fluxo `openai.core` da etapa `landing-page-wireframe` para tratar o conteúdo lido do arquivo `.md` como `promptMarkdownContent` e persisti-lo no backend para rastreabilidade da tela de detalhe.
+- causa-raiz: o worker carregava o markdown do prompt, renderizava o texto final e enviava apenas o campo `prompt` no callback `recebe-prompt`; o contrato específico de wireframe no backend não recebia nem persistia `promptMarkdownContent`, deixando a seção “Conteúdo do arquivo .md usado no prompt” vazia.
+- correção aplicada:
+  - o `WireframePromptBuilder` passou a manter o markdown bruto em `promptMarkdownContent` antes de renderizar o `prompt` final.
+  - `OpenAiRequest` e `OpenAiDispatch` passaram a transportar `promptMarkdownContent` junto com o prompt renderizado, schema e request cru.
+  - o `WireframeBackendClient` passou a enviar `promptMarkdownContent` ao backend no callback `recebe-prompt`.
+  - o DTO, controller e serviço backend de wireframe passaram a receber e persistir `promptMarkdownContent`, com fallback para clientes antigos que ainda enviem o conteúdo apenas em `prompt`.
+- impacto esperado: novas execuções do wireframe OpenAI core passam a exibir o conteúdo do arquivo `.md` na tela de detalhe, sem perder o prompt renderizado usado na chamada à OpenAI.


### PR DESCRIPTION
### Motivation
- Preserve and persist the raw markdown file used to build wireframe prompts so the backend can display the original `.md` content for traceability and debugging. 

### Description
- Added `promptMarkdownContent` to the OpenAI transport models `OpenAiRequest` and `OpenAiDispatch` and validated it on construction. 
- `WireframePromptBuilder` now keeps the raw markdown (`promptMarkdownContent`) and renders the final `prompt` from it, and `ResponsesApiOpenAiClient` and `WireframeBackendClient` now propagate and send `promptMarkdownContent` to the backend. 
- Backend controller, DTO (`RecebePromptRequest`), service (`BackendWireframeService`) and persistence were updated to accept and store `promptMarkdownContent` with a compatibility fallback to the existing `prompt` value when the new field is absent. 
- Updated unit tests, OpenAPI spec (`docs/canonical/geralanding-backend-swagger.v1.yaml`) and the project change log (`docs/registros/experimentos.md`) to reflect the new field and behavior. 

### Testing
- Ran unit tests covering the modified areas including `ResponsesApiOpenAiClientTest`, `WireframeBackendClientTest`, `BackendWireframeServiceTest` and `BackendWireframeControllerTest`, and they all passed. 
- Verified compilation of the `ai-worker` and `backend/ads-service` modules after the changes with the project test suite, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1a702fd8548321975dca57d18a4c0d)