### PR TITLE
Corrige placeholders mustache do GeraLanding

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/GeraLandingService.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/GeraLandingService.java
@@ -25,6 +25,9 @@ import org.springframework.util.StringUtils;
 
 import org.springframework.core.io.ClassPathResource;
 
+/**
+ * Responsabilidade: montar prompts do GeraLanding com dados do experimento e registrar rastreabilidade operacional.
+ */
 @Service
 public class GeraLandingService {
 
@@ -122,12 +125,27 @@ public class GeraLandingService {
         return context.dados();
     }
 
+    /** Resolve placeholders simples, registra os tokens tratados e preserva rastreabilidade da montagem. */
     private String resolverPlaceholders(String template, Map<String, Object> dadosPayload) throws IOException {
-        String resolved = template;
         Set<String> stack = new LinkedHashSet<>();
         Set<String> placeholdersDados = new HashSet<>();
         Set<String> placeholdersPrompt = new HashSet<>();
         Set<String> placeholdersMustache = new HashSet<>();
+        String resolved = resolverPlaceholders(
+                template, dadosPayload, stack, placeholdersMustache, placeholdersPrompt, placeholdersDados);
+        log.info("Placeholders tratados na resolução de prompt. promptRefs={}, dadosRefs={}, mustacheRefs={}",
+                placeholdersPrompt, placeholdersDados, placeholdersMustache);
+        return resolved;
+    }
+
+    /** Resolve placeholders reprocessando referências encadeadas e bloqueando ciclos na pilha de prompts. */
+    private String resolverPlaceholders(String template,
+                                        Map<String, Object> dadosPayload,
+                                        Set<String> stack,
+                                        Set<String> placeholdersMustache,
+                                        Set<String> placeholdersPrompt,
+                                        Set<String> placeholdersDados) throws IOException {
+        String resolved = template;
         Deque<String> pending = new ArrayDeque<>();
         pending.push(template);
         while (!pending.isEmpty()) {
@@ -139,48 +157,81 @@ public class GeraLandingService {
                 found = true;
                 String tipo = matcher.group(1);
                 String nome = matcher.group(2);
-                String token = tipo + ":" + nome;
-                String replacement;
-                if ("prompt".equals(tipo)) {
-                    placeholdersPrompt.add(nome);
-                    if (!stack.add(token)) {
-                        throw new IllegalStateException("Referência circular de prompts detectada: " + token);
-                    }
-                    replacement = resolverPlaceholders(carregarPromptBase(nome + ".md"), dadosPayload);
-                    stack.remove(token);
-                } else {
-                    placeholdersDados.add(nome);
-                    Object dado = dadosPayload.get(nome);
-                    replacement = renderPlaceholderValue(dado);
-                }
+                String replacement = resolveTypedPlaceholder(tipo, nome, dadosPayload, stack, placeholdersMustache, placeholdersPrompt, placeholdersDados);
                 matcher.appendReplacement(buffer, Matcher.quoteReplacement(replacement));
             }
             matcher.appendTail(buffer);
             resolved = buffer.toString();
-            resolved = resolverMustachePlaceholders(resolved, dadosPayload, placeholdersMustache);
+            resolved = resolverMustachePlaceholders(
+                    resolved, dadosPayload, stack, placeholdersMustache, placeholdersPrompt, placeholdersDados);
             if (found) {
                 pending.push(resolved);
             }
         }
-        log.info("Placeholders tratados na resolução de prompt. promptRefs={}, dadosRefs={}, mustacheRefs={}",
-                placeholdersPrompt, placeholdersDados, placeholdersMustache);
         return resolved;
     }
 
+    /** Resolve placeholders no formato mustache, incluindo aliases {{prompt-*}} e {{dados-*}}. */
     private String resolverMustachePlaceholders(String template,
                                                 Map<String, Object> dadosPayload,
-                                                Set<String> placeholdersMustache) throws IOException {
+                                                Set<String> stack,
+                                                Set<String> placeholdersMustache,
+                                                Set<String> placeholdersPrompt,
+                                                Set<String> placeholdersDados) throws IOException {
         Matcher matcher = MUSTACHE_PLACEHOLDER_PATTERN.matcher(template);
         StringBuffer buffer = new StringBuffer();
         while (matcher.find()) {
             String nome = matcher.group(1);
             placeholdersMustache.add(nome);
-            Object dado = dadosPayload.get(nome);
-            String replacement = renderPlaceholderValue(dado);
+            String replacement = resolveMustachePlaceholder(nome, dadosPayload, stack, placeholdersMustache, placeholdersPrompt, placeholdersDados);
             matcher.appendReplacement(buffer, Matcher.quoteReplacement(replacement));
         }
         matcher.appendTail(buffer);
         return buffer.toString();
+    }
+
+    /** Resolve um placeholder mustache como dado direto ou como alias prefixado por prompt-/dados-. */
+    private String resolveMustachePlaceholder(String nome,
+                                              Map<String, Object> dadosPayload,
+                                              Set<String> stack,
+                                              Set<String> placeholdersMustache,
+                                              Set<String> placeholdersPrompt,
+                                              Set<String> placeholdersDados) throws IOException {
+        if (nome != null && nome.startsWith("prompt-")) {
+            return resolveTypedPlaceholder("prompt", nome.substring("prompt-".length()), dadosPayload, stack,
+                    placeholdersMustache, placeholdersPrompt, placeholdersDados);
+        }
+        if (nome != null && nome.startsWith("dados-")) {
+            return resolveTypedPlaceholder("dados", nome.substring("dados-".length()), dadosPayload, stack,
+                    placeholdersMustache, placeholdersPrompt, placeholdersDados);
+        }
+        return renderPlaceholderValue(dadosPayload.get(nome));
+    }
+
+    /** Resolve o valor de um placeholder tipado, carregando prompts recursivos ou dados do payload. */
+    private String resolveTypedPlaceholder(String tipo,
+                                           String nome,
+                                           Map<String, Object> dadosPayload,
+                                           Set<String> stack,
+                                           Set<String> placeholdersMustache,
+                                           Set<String> placeholdersPrompt,
+                                           Set<String> placeholdersDados) throws IOException {
+        if ("prompt".equals(tipo)) {
+            placeholdersPrompt.add(nome);
+            String token = tipo + ":" + nome;
+            if (!stack.add(token)) {
+                throw new IllegalStateException("Referência circular de prompts detectada: " + token);
+            }
+            try {
+                return resolverPlaceholders(
+                        carregarPromptBase(nome + ".md"), dadosPayload, stack, placeholdersMustache,
+                        placeholdersPrompt, placeholdersDados);
+            } finally {
+                stack.remove(token);
+            }
+        }
+        placeholdersDados.add(nome);
+        return renderPlaceholderValue(dadosPayload.get(nome));
     }
 
     private String renderPlaceholderValue(Object dado) throws JsonProcessingException {

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/MontaRequestSupport.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/MontaRequestSupport.java
@@ -55,9 +55,18 @@ public final class MontaRequestSupport {
         }
     }
 
-    private static String resolverPlaceholders(String template, Map<String, Object> dadosPayload, ObjectMapper objectMapper) throws IOException {
+    /** Resolve placeholders simples e reprocessa o texto até não haver referências encadeadas. */
+    private static String resolverPlaceholders(String template, Map<String, Object> dadosPayload, ObjectMapper objectMapper)
+            throws IOException {
+        return resolverPlaceholders(template, dadosPayload, objectMapper, new LinkedHashSet<>());
+    }
+
+    /** Resolve placeholders preservando a pilha de prompts para bloquear referências circulares. */
+    private static String resolverPlaceholders(String template,
+                                               Map<String, Object> dadosPayload,
+                                               ObjectMapper objectMapper,
+                                               Set<String> stack) throws IOException {
         String resolved = template;
-        Set<String> stack = new LinkedHashSet<>();
         Deque<String> pending = new ArrayDeque<>();
         pending.push(template);
         while (!pending.isEmpty()) {
@@ -69,21 +78,11 @@ public final class MontaRequestSupport {
                 found = true;
                 String tipo = matcher.group(1);
                 String nome = matcher.group(2);
-                String replacement;
-                if ("prompt".equals(tipo)) {
-                    String token = tipo + ":" + nome;
-                    if (!stack.add(token)) {
-                        throw new IllegalStateException("Referência circular de prompts detectada: " + token);
-                    }
-                    replacement = resolverPlaceholders(carregarPromptBase(nome + ".md"), dadosPayload, objectMapper);
-                    stack.remove(token);
-                } else {
-                    replacement = renderPlaceholderValue(dadosPayload.get(nome), objectMapper);
-                }
+                String replacement = resolveTypedPlaceholder(tipo, nome, dadosPayload, objectMapper, stack);
                 matcher.appendReplacement(buffer, Matcher.quoteReplacement(replacement));
             }
             matcher.appendTail(buffer);
-            resolved = resolverMustachePlaceholders(buffer.toString(), dadosPayload, objectMapper);
+            resolved = resolverMustachePlaceholders(buffer.toString(), dadosPayload, objectMapper, stack);
             if (found) {
                 pending.push(resolved);
             }
@@ -91,17 +90,55 @@ public final class MontaRequestSupport {
         return resolved;
     }
 
-    private static String resolverMustachePlaceholders(String template, Map<String, Object> dadosPayload, ObjectMapper objectMapper)
+    /** Resolve placeholders no formato mustache, incluindo aliases {{prompt-*}} e {{dados-*}}. */
+    private static String resolverMustachePlaceholders(String template,
+                                                       Map<String, Object> dadosPayload,
+                                                       ObjectMapper objectMapper,
+                                                       Set<String> stack)
             throws IOException {
         Matcher matcher = MUSTACHE_PLACEHOLDER_PATTERN.matcher(template);
         StringBuffer buffer = new StringBuffer();
         while (matcher.find()) {
             String nome = matcher.group(1);
-            String replacement = renderPlaceholderValue(dadosPayload.get(nome), objectMapper);
+            String replacement = resolveMustachePlaceholder(nome, dadosPayload, objectMapper, stack);
             matcher.appendReplacement(buffer, Matcher.quoteReplacement(replacement));
         }
         matcher.appendTail(buffer);
         return buffer.toString();
+    }
+
+    /** Resolve um placeholder mustache como dado direto ou como alias prefixado por prompt-/dados-. */
+    private static String resolveMustachePlaceholder(String nome,
+                                                     Map<String, Object> dadosPayload,
+                                                     ObjectMapper objectMapper,
+                                                     Set<String> stack) throws IOException {
+        if (nome != null && nome.startsWith("prompt-")) {
+            return resolveTypedPlaceholder("prompt", nome.substring("prompt-".length()), dadosPayload, objectMapper, stack);
+        }
+        if (nome != null && nome.startsWith("dados-")) {
+            return resolveTypedPlaceholder("dados", nome.substring("dados-".length()), dadosPayload, objectMapper, stack);
+        }
+        return renderPlaceholderValue(dadosPayload.get(nome), objectMapper);
+    }
+
+    /** Resolve o valor de um placeholder tipado, carregando prompts recursivos ou dados do payload. */
+    private static String resolveTypedPlaceholder(String tipo,
+                                                  String nome,
+                                                  Map<String, Object> dadosPayload,
+                                                  ObjectMapper objectMapper,
+                                                  Set<String> stack) throws IOException {
+        if ("prompt".equals(tipo)) {
+            String token = tipo + ":" + nome;
+            if (!stack.add(token)) {
+                throw new IllegalStateException("Referência circular de prompts detectada: " + token);
+            }
+            try {
+                return resolverPlaceholders(carregarPromptBase(nome + ".md"), dadosPayload, objectMapper, stack);
+            } finally {
+                stack.remove(token);
+            }
+        }
+        return renderPlaceholderValue(dadosPayload.get(nome), objectMapper);
     }
 
     private static String renderPlaceholderValue(Object dado, ObjectMapper objectMapper) throws JsonProcessingException {

--- a/ai-worker/src/main/java/com/marketinghub/worker/geralanding/comum/MontaRequestSupport.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/geralanding/comum/MontaRequestSupport.java
@@ -55,9 +55,18 @@ public final class MontaRequestSupport {
         }
     }
 
-    private static String resolverPlaceholders(String template, Map<String, Object> dadosPayload, ObjectMapper objectMapper) throws IOException {
+    /** Resolve placeholders simples e reprocessa o texto até não haver referências encadeadas. */
+    private static String resolverPlaceholders(String template, Map<String, Object> dadosPayload, ObjectMapper objectMapper)
+            throws IOException {
+        return resolverPlaceholders(template, dadosPayload, objectMapper, new LinkedHashSet<>());
+    }
+
+    /** Resolve placeholders preservando a pilha de prompts para bloquear referências circulares. */
+    private static String resolverPlaceholders(String template,
+                                               Map<String, Object> dadosPayload,
+                                               ObjectMapper objectMapper,
+                                               Set<String> stack) throws IOException {
         String resolved = template;
-        Set<String> stack = new LinkedHashSet<>();
         Deque<String> pending = new ArrayDeque<>();
         pending.push(template);
         while (!pending.isEmpty()) {
@@ -69,21 +78,11 @@ public final class MontaRequestSupport {
                 found = true;
                 String tipo = matcher.group(1);
                 String nome = matcher.group(2);
-                String replacement;
-                if ("prompt".equals(tipo)) {
-                    String token = tipo + ":" + nome;
-                    if (!stack.add(token)) {
-                        throw new IllegalStateException("Referência circular de prompts detectada: " + token);
-                    }
-                    replacement = resolverPlaceholders(carregarPromptBase(nome + ".md"), dadosPayload, objectMapper);
-                    stack.remove(token);
-                } else {
-                    replacement = renderPlaceholderValue(dadosPayload.get(nome), objectMapper);
-                }
+                String replacement = resolveTypedPlaceholder(tipo, nome, dadosPayload, objectMapper, stack);
                 matcher.appendReplacement(buffer, Matcher.quoteReplacement(replacement));
             }
             matcher.appendTail(buffer);
-            resolved = resolverMustachePlaceholders(buffer.toString(), dadosPayload, objectMapper);
+            resolved = resolverMustachePlaceholders(buffer.toString(), dadosPayload, objectMapper, stack);
             if (found) {
                 pending.push(resolved);
             }
@@ -91,17 +90,55 @@ public final class MontaRequestSupport {
         return resolved;
     }
 
-    private static String resolverMustachePlaceholders(String template, Map<String, Object> dadosPayload, ObjectMapper objectMapper)
+    /** Resolve placeholders no formato mustache, incluindo aliases {{prompt-*}} e {{dados-*}}. */
+    private static String resolverMustachePlaceholders(String template,
+                                                       Map<String, Object> dadosPayload,
+                                                       ObjectMapper objectMapper,
+                                                       Set<String> stack)
             throws IOException {
         Matcher matcher = MUSTACHE_PLACEHOLDER_PATTERN.matcher(template);
         StringBuffer buffer = new StringBuffer();
         while (matcher.find()) {
             String nome = matcher.group(1);
-            String replacement = renderPlaceholderValue(dadosPayload.get(nome), objectMapper);
+            String replacement = resolveMustachePlaceholder(nome, dadosPayload, objectMapper, stack);
             matcher.appendReplacement(buffer, Matcher.quoteReplacement(replacement));
         }
         matcher.appendTail(buffer);
         return buffer.toString();
+    }
+
+    /** Resolve um placeholder mustache como dado direto ou como alias prefixado por prompt-/dados-. */
+    private static String resolveMustachePlaceholder(String nome,
+                                                     Map<String, Object> dadosPayload,
+                                                     ObjectMapper objectMapper,
+                                                     Set<String> stack) throws IOException {
+        if (nome != null && nome.startsWith("prompt-")) {
+            return resolveTypedPlaceholder("prompt", nome.substring("prompt-".length()), dadosPayload, objectMapper, stack);
+        }
+        if (nome != null && nome.startsWith("dados-")) {
+            return resolveTypedPlaceholder("dados", nome.substring("dados-".length()), dadosPayload, objectMapper, stack);
+        }
+        return renderPlaceholderValue(dadosPayload.get(nome), objectMapper);
+    }
+
+    /** Resolve o valor de um placeholder tipado, carregando prompts recursivos ou dados do payload. */
+    private static String resolveTypedPlaceholder(String tipo,
+                                                  String nome,
+                                                  Map<String, Object> dadosPayload,
+                                                  ObjectMapper objectMapper,
+                                                  Set<String> stack) throws IOException {
+        if ("prompt".equals(tipo)) {
+            String token = tipo + ":" + nome;
+            if (!stack.add(token)) {
+                throw new IllegalStateException("Referência circular de prompts detectada: " + token);
+            }
+            try {
+                return resolverPlaceholders(carregarPromptBase(nome + ".md"), dadosPayload, objectMapper, stack);
+            } finally {
+                stack.remove(token);
+            }
+        }
+        return renderPlaceholderValue(dadosPayload.get(nome), objectMapper);
     }
 
     private static String renderPlaceholderValue(Object dado, ObjectMapper objectMapper) throws JsonProcessingException {

--- a/ai-worker/src/main/resources/prompts/geralanding/test-placeholder-mustache.md
+++ b/ai-worker/src/main/resources/prompts/geralanding/test-placeholder-mustache.md
@@ -1,0 +1,10 @@
+{{prompt-regras-globais}}
+
+Ângulo da Campanha que vai ser publicada:
+{{dados-campaignAngle}}
+
+Copy do Anuncio:
+{{dados-adCopy}}
+
+Briefing das Imagens dos Anuncios:
+{{dados-adImageBriefing}}

--- a/ai-worker/src/test/java/com/marketinghub/worker/geralanding/GeraLandingServiceTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/geralanding/GeraLandingServiceTest.java
@@ -117,6 +117,31 @@ class GeraLandingServiceTest {
                 .contains("- experimentMetadata:");
     }
 
+
+    @Test
+    void deveResolverAliasesMustacheDePromptEDadosComHifen() throws Exception {
+        GeraLandingPromptContext context = new GeraLandingPromptContext(
+                10L,
+                "id-job-original",
+                "test-placeholder-mustache",
+                Map.of(
+                        "campaignAngle", Map.of("headline", "Ângulo de economia de esforço"),
+                        "adCopy", Map.of("headline", "Resultado claro", "ctaText", "Começar agora"),
+                        "adImageBriefing", Map.of("scene", "Pessoa vendo o resultado no celular")));
+
+        String prompt = service.montarPromptEtapa(context, "test-placeholder-mustache");
+
+        assertThat(prompt)
+                .contains("REGRAS GLOBAIS")
+                .contains("Ângulo de economia de esforço")
+                .contains("Resultado claro")
+                .contains("Pessoa vendo o resultado no celular")
+                .doesNotContain("{{prompt-regras-globais}}")
+                .doesNotContain("{{dados-campaignAngle}}")
+                .doesNotContain("{{dados-adCopy}}")
+                .doesNotContain("{{dados-adImageBriefing}}");
+    }
+
     @Test
     void deveRegistrarPromptMontadoComChaveDeRastreio() throws Exception {
         GeraLandingPromptContext context = novoContexto();

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -2595,3 +2595,13 @@
   - atualizado o comentário do método para refletir a nova cadência de 1 minuto.
 - impacto esperado: o Worker AI passa a buscar jobs pendentes de wireframe do OpenAI core a cada minuto, reduzindo espera operacional sem alterar contratos de backend ou payloads OpenAI.
 - 2026-05-30 (UTC): ajuste operacional no `ai-worker` OpenAI core para usar `gpt-5.2` como modelo padrão. Foram atualizados `openai.model`, o fallback `OPENAI_MODEL` nos docker-compose do worker e a documentação do README, mantendo a possibilidade de sobrescrita por variável de ambiente para preservar controle operacional por ambiente.
+
+## 2026-05-30 — Correção de placeholders mustache em prompts GeraLanding
+- tarefa: corrigir a substituição de campos em prompts do GeraLanding quando o usuário usa tokens no formato `{{prompt-*}}` e `{{dados-*}}`, como `{{prompt-regras-globais}}`, `{{dados-campaignAngle}}`, `{{dados-adCopy}}` e `{{dados-adImageBriefing}}`.
+- causa-raiz: a resolução antiga aceitava `{prompt-*}` e `{dados-*}` com uma chave normalizada, mas no formato mustache tratava todo conteúdo como chave direta do payload; por isso `{{prompt-regras-globais}}` e `{{dados-campaignAngle}}` eram buscados literalmente no mapa de dados e ficavam vazios.
+- correção aplicada:
+  - o resolver mustache passou a reconhecer os prefixos `prompt-` e `dados-`;
+  - `{{prompt-*}}` agora carrega prompts base recursivamente com proteção contra referência circular;
+  - `{{dados-*}}` agora remove o prefixo antes de buscar o campo real do payload;
+  - adicionado prompt de teste reproduzindo exatamente o padrão reportado e teste unitário garantindo a substituição dos três artefatos de campanha.
+- impacto esperado: prompts configurados com chaves mustache passam a montar corretamente as regras globais e os artefatos `campaignAngle`, `adCopy` e `adImageBriefing` antes do envio para o modelo.


### PR DESCRIPTION
### Motivation
- Corrigir substituição incorreta de tokens no formato mustache como `{{prompt-regras-globais}}`, `{{dados-campaignAngle}}`, `{{dados-adCopy}}` e `{{dados-adImageBriefing}}` que eram buscados literalmente e não reidratados a partir de prompts/dados.
- Preservar resolução recursiva de prompts e proteger contra referências circulares ao expandir `{{prompt-*}}` aninhados.
- Manter compatibilidade com os resolvers existentes que aceitavam `{prompt-*}` / `{dados-*}` e estender o suporte ao formato mustache com hífen.

### Description
- Implementa reconhecimento de aliases mustache `{{prompt-*}}` e `{{dados-*}}` e remove o prefixo antes da resolução, tornando-os equivalentes às sintaxes existentes de placeholder.
- Centraliza e expande a lógica de resolução em `MontaRequestSupport` e `GeraLandingService`, adicionando helpers `resolveMustachePlaceholder`, `resolveTypedPlaceholder` e variantes que preservam uma pilha (`stack`) para bloquear ciclos em prompts recursivos.
- Atualiza os montadores do GeraLanding (`ai-worker/src/main/java/.../MontaRequestSupport.java`, `GeraLandingService.java` e cópia em `comum/`) para reprocessar o texto enquanto houver placeholders encadeados e para preencher tanto `{prompt-*}`/`{dados-*}` quanto `{{prompt-*}}`/`{{dados-*}}`.
- Adiciona um fixture de prompt `ai-worker/src/main/resources/prompts/geralanding/test-placeholder-mustache.md` e um teste unitário `GeraLandingServiceTest.deveResolverAliasesMustacheDePromptEDadosComHifen()` que valida a substituição dos três artefatos (`campaignAngle`, `adCopy`, `adImageBriefing`) e das regras globais.
- Registra a correção no documento operacional `docs/registros/experimentos.md`.

### Testing
- Executado `mvn -f ai-worker/pom.xml -Dtest=GeraLandingServiceTest test`, que não concluiu neste ambiente por falha de dependência externa: GitHub Packages retornou `401 Unauthorized` para `com.marketinghub:ads-service:0.0.1-SNAPSHOT` (falha de resolução de artifact). (failed)
- Tentado `mvn -f ai-worker/pom.xml -Dtest=GeraLandingServiceTest -o test` em modo offline, que não pôde completar porque dependências necessárias não estavam em cache local. (failed)
- Verificado `git diff --cached --check` e estático do diff; esse check passou e o patch foi comitado com a mensagem `Corrige placeholders mustache do GeraLanding`. (succeeded)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1a735d8f7c8321ab376ebc88642988)