### PR TITLE
Centralizar resolução de placeholders de prompt com PromptTemplateResolver e integrar ao WireframePromptBuilder

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/openai/core/prompt/PromptTemplateResolver.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/openai/core/prompt/PromptTemplateResolver.java
@@ -1,0 +1,105 @@
+package com.marketinghub.worker.openai.core.prompt;
+
+import java.util.Map;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+
+/** Responsabilidade: resolver placeholders reutilizáveis em templates de prompt do core OpenAI. */
+public class PromptTemplateResolver {
+
+    private static final Pattern PREFIXED_PLACEHOLDER_PATTERN = Pattern.compile(
+            "\\{\\{(prompt|dados)-([A-Za-z0-9_-]+)}}|\\{(prompt|dados)-([A-Za-z0-9_-]+)}"
+    );
+    private static final Pattern MUSTACHE_PLACEHOLDER_PATTERN = Pattern.compile("\\{\\{([A-Za-z0-9_\\-.]+)}}");
+
+    private final Function<String, String> promptLoader;
+    private final Function<Object, String> valueRenderer;
+
+    /** Inicializa o resolvedor com funções externas para carregar prompts e renderizar valores. */
+    public PromptTemplateResolver(Function<String, String> promptLoader, Function<Object, String> valueRenderer) {
+        this.promptLoader = Objects.requireNonNull(promptLoader, "promptLoader must not be null");
+        this.valueRenderer = Objects.requireNonNull(valueRenderer, "valueRenderer must not be null");
+    }
+
+    /** Resolve o template informado usando dados do job e o caminho do recurso atual como base. */
+    public String resolve(String template, Map<String, Object> data, String currentResourcePath) {
+        Map<String, Object> safeData = data == null ? Map.of() : data;
+        String result = resolvePrefixedPlaceholders(template, safeData, currentResourcePath);
+
+        for (Map.Entry<String, Object> entry : safeData.entrySet()) {
+            String key = entry.getKey();
+            String value = valueRenderer.apply(entry.getValue());
+
+            result = result.replace("{{" + key + "}}", value);
+            result = result.replace("${" + key + "}", value);
+        }
+
+        return resolveMustachePlaceholders(result, safeData);
+    }
+
+    /** Resolve placeholders prefixados `{dados-*}`, `{{dados-*}}`, `{prompt-*}` e `{{prompt-*}}`. */
+    private String resolvePrefixedPlaceholders(String template, Map<String, Object> data, String currentResourcePath) {
+        String result = template == null ? "" : template;
+        boolean found;
+        do {
+            Matcher matcher = PREFIXED_PLACEHOLDER_PATTERN.matcher(result);
+            StringBuffer buffer = new StringBuffer();
+            found = false;
+            while (matcher.find()) {
+                found = true;
+                String type = firstNonNull(matcher.group(1), matcher.group(3));
+                String name = firstNonNull(matcher.group(2), matcher.group(4));
+                String replacement = resolvePrefixedValue(type, name, data, currentResourcePath);
+                matcher.appendReplacement(buffer, Matcher.quoteReplacement(replacement));
+            }
+            matcher.appendTail(buffer);
+            result = buffer.toString();
+        } while (found);
+        return result;
+    }
+
+    /** Resolve o valor prefixado como dado do job ou como inclusão de outro arquivo markdown. */
+    private String resolvePrefixedValue(String type, String name, Map<String, Object> data, String currentResourcePath) {
+        if ("prompt".equals(type)) {
+            String includedResourcePath = siblingResourcePath(currentResourcePath, name + ".md");
+            return resolve(promptLoader.apply(includedResourcePath), data, includedResourcePath);
+        }
+        return valueRenderer.apply(data.get(name));
+    }
+
+    /** Resolve placeholders mustache diretos que ainda restarem no template. */
+    private String resolveMustachePlaceholders(String template, Map<String, Object> data) {
+        Matcher matcher = MUSTACHE_PLACEHOLDER_PATTERN.matcher(template);
+        StringBuffer buffer = new StringBuffer();
+        while (matcher.find()) {
+            String key = matcher.group(1);
+            Object value = data.get(key);
+            if (value == null) {
+                matcher.appendReplacement(buffer, Matcher.quoteReplacement(matcher.group(0)));
+            } else {
+                matcher.appendReplacement(buffer, Matcher.quoteReplacement(valueRenderer.apply(value)));
+            }
+        }
+        matcher.appendTail(buffer);
+        return buffer.toString();
+    }
+
+    /** Retorna o primeiro texto não nulo entre grupos alternativos de regex. */
+    private String firstNonNull(String first, String second) {
+        return first != null ? first : second;
+    }
+
+    /** Monta o caminho de um recurso incluído no mesmo diretório do prompt atual. */
+    private String siblingResourcePath(String currentResourcePath, String includedFileName) {
+        if (currentResourcePath == null) {
+            return includedFileName;
+        }
+        int lastSlash = currentResourcePath.lastIndexOf('/');
+        if (lastSlash < 0) {
+            return includedFileName;
+        }
+        return currentResourcePath.substring(0, lastSlash + 1) + includedFileName;
+    }
+}

--- a/ai-worker/src/main/java/com/marketinghub/worker/openai/core/wireframe/WireframePromptBuilder.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/openai/core/wireframe/WireframePromptBuilder.java
@@ -7,12 +7,12 @@ import com.marketinghub.worker.openai.core.model.OpenAiRequest;
 import com.marketinghub.worker.openai.core.model.StageExecution;
 import com.marketinghub.worker.openai.core.openai.OpenAiClientProperties;
 import com.marketinghub.worker.openai.core.port.StagePromptBuilder;
+import com.marketinghub.worker.openai.core.prompt.PromptTemplateResolver;
 
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.LinkedHashMap;
 import java.util.Map;
-
 import org.springframework.core.io.ClassPathResource;
 
 /** Responsabilidade: montar o prompt, schema e request OpenAI da etapa wireframe. */
@@ -21,6 +21,7 @@ public class WireframePromptBuilder implements StagePromptBuilder<WireframeInput
     private final ObjectMapper objectMapper;
     private final OpenAiClientProperties openAiProperties;
     private final WireframeWorkerProperties wireframeProperties;
+    private final PromptTemplateResolver promptTemplateResolver;
 
     /** Inicializa o builder com serializador, propriedades OpenAI e propriedades da etapa wireframe. */
     public WireframePromptBuilder(
@@ -31,6 +32,7 @@ public class WireframePromptBuilder implements StagePromptBuilder<WireframeInput
         this.objectMapper = objectMapper;
         this.openAiProperties = openAiProperties;
         this.wireframeProperties = wireframeProperties;
+        this.promptTemplateResolver = new PromptTemplateResolver(this::loadResource, this::toJsonOrText);
     }
 
     /** Monta o request completo da OpenAI mantendo o conteúdo bruto do markdown usado no prompt. */
@@ -38,8 +40,9 @@ public class WireframePromptBuilder implements StagePromptBuilder<WireframeInput
     public OpenAiRequest build(StageExecution<WireframeInput> execution) {
         Map<String, Object> data = execution.input().promptData();
 
-        String promptMarkdownContent = loadResource(wireframeProperties.promptResource());
-        String prompt = resolvePrompt(promptMarkdownContent, data);
+        String promptResource = wireframeProperties.promptResource();
+        String promptMarkdownContent = loadResource(promptResource);
+        String prompt = promptTemplateResolver.resolve(promptMarkdownContent, data, promptResource);
         String schemaJson = loadResource(wireframeProperties.schemaResource());
         String requestBodyJson = buildResponsesApiRequest(prompt, schemaJson);
 
@@ -81,21 +84,6 @@ public class WireframePromptBuilder implements StagePromptBuilder<WireframeInput
         } catch (JsonProcessingException error) {
             throw new StageWorkerException("Could not build OpenAI Responses API request", error);
         }
-    }
-
-    /** Aplica os dados do job nos placeholders do conteúdo markdown do prompt. */
-    private String resolvePrompt(String template, Map<String, Object> data) {
-        String result = template;
-
-        for (Map.Entry<String, Object> entry : data.entrySet()) {
-            String key = entry.getKey();
-            String value = toJsonOrText(entry.getValue());
-
-            result = result.replace("{{" + key + "}}", value);
-            result = result.replace("${" + key + "}", value);
-        }
-
-        return result;
     }
 
     /** Converte valores de placeholder para texto ou JSON formatado antes da substituição. */

--- a/ai-worker/src/test/java/com/marketinghub/worker/openai/core/ArquiteturaCoreTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/openai/core/ArquiteturaCoreTest.java
@@ -58,7 +58,8 @@ class ArquiteturaCoreTest {
             "exception",
             "model",
             "openai",
-            "port"
+            "port",
+            "prompt"
     );
 
     private static final DescribedPredicate<JavaClass> ARE_IN_CORE_ROOT_PACKAGE =
@@ -76,6 +77,7 @@ class ArquiteturaCoreTest {
                     String packageName = input.getPackageName();
                     return packageName.startsWith(BASE_PACKAGE + ".model")
                             || packageName.startsWith(BASE_PACKAGE + ".port")
+                            || packageName.startsWith(BASE_PACKAGE + ".prompt")
                             || packageName.startsWith(BASE_PACKAGE + ".exception");
                 }
             };

--- a/ai-worker/src/test/java/com/marketinghub/worker/openai/core/prompt/PromptTemplateResolverTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/openai/core/prompt/PromptTemplateResolverTest.java
@@ -1,0 +1,78 @@
+package com.marketinghub.worker.openai.core.prompt;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/** Responsabilidade: validar a resolução comum de placeholders dos prompts do core OpenAI. */
+class PromptTemplateResolverTest {
+
+    /** Deve substituir placeholders prefixados usados pelos prompts editáveis das etapas OpenAI. */
+    @Test
+    void resolveShouldReplacePrefixedDataAndPromptPlaceholders() {
+        PromptTemplateResolver resolver = new PromptTemplateResolver(
+                this::loadPrompt,
+                this::renderValue);
+        String template = loadPrompt("prompts/geralanding/openai-core-placeholder-test.md");
+        Map<String, Object> data = Map.of(
+                "campaignAngle", Map.of("primaryPromise", "Agenda cheia"),
+                "adCopy", Map.of("headline", "Sem desconto"),
+                "adImageBriefing", Map.of("concept", "Calendário lotado"),
+                "NICHE_NAME", "Clínicas");
+
+        String prompt = resolver.resolve(template, data, "prompts/geralanding/openai-core-placeholder-test.md");
+
+        assertThat(prompt)
+                .contains("REGRAS GLOBAIS")
+                .contains("campaignAngle={primaryPromise=Agenda cheia}")
+                .contains("adCopy={headline=Sem desconto}")
+                .contains("adImageBriefing={concept=Calendário lotado}")
+                .contains("Nicho:\nClínicas")
+                .doesNotContain("{{prompt-regras-globais}}")
+                .doesNotContain("{{dados-campaignAngle}}")
+                .doesNotContain("{{dados-adCopy}}")
+                .doesNotContain("{{dados-adImageBriefing}}")
+                .doesNotContain("{{NICHE_NAME}}");
+    }
+
+    /** Carrega prompts controlados pelo teste simulando arquivos irmãos da etapa. */
+    private String loadPrompt(String path) {
+        return switch (path) {
+            case "prompts/geralanding/openai-core-placeholder-test.md" -> """
+                    {{prompt-regras-globais}}
+
+                    Ângulo da Campanha que vai ser publicada:
+                    {{dados-campaignAngle}}
+
+                    Copy do Anuncio:
+                    {{dados-adCopy}}
+
+                    Briefing das Imagens dos Anuncios:
+                    {{dados-adImageBriefing}}
+
+                    Nicho:
+                    {{NICHE_NAME}}
+                    """;
+            case "prompts/geralanding/regras-globais.md" -> "REGRAS GLOBAIS";
+            default -> throw new IllegalArgumentException("Prompt não encontrado: " + path);
+        };
+    }
+
+    /** Renderiza valores de teste com prefixo da chave principal para facilitar asserção. */
+    private String renderValue(Object value) {
+        if (value == null) {
+            return "";
+        }
+        if (value instanceof Map<?, ?> map && map.containsKey("primaryPromise")) {
+            return "campaignAngle=" + value;
+        }
+        if (value instanceof Map<?, ?> map && map.containsKey("headline")) {
+            return "adCopy=" + value;
+        }
+        if (value instanceof Map<?, ?> map && map.containsKey("concept")) {
+            return "adImageBriefing=" + value;
+        }
+        return value.toString();
+    }
+}

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -2605,3 +2605,15 @@
   - o `WireframeBackendClient` passou a enviar `promptMarkdownContent` ao backend no callback `recebe-prompt`.
   - o DTO, controller e serviço backend de wireframe passaram a receber e persistir `promptMarkdownContent`, com fallback para clientes antigos que ainda enviem o conteúdo apenas em `prompt`.
 - impacto esperado: novas execuções do wireframe OpenAI core passam a exibir o conteúdo do arquivo `.md` na tela de detalhe, sem perder o prompt renderizado usado na chamada à OpenAI.
+
+## 2026-05-30 — Correção de placeholders `dados-*` no OpenAI core wireframe
+- tarefa: corrigir a substituição de placeholders em prompts editáveis executados pelo `ai-worker` no módulo `openai.core`, especialmente no formato `{{dados-campaignAngle}}`, `{{dados-adCopy}}`, `{{dados-adImageBriefing}}` e `{{prompt-regras-globais}}`.
+- causa-raiz: o `WireframePromptBuilder` substituía apenas chaves diretas (`{{campaignAngle}}` e `${campaignAngle}`), enquanto os prompts do GeraLanding usam também placeholders prefixados por tipo (`dados-` para payload do job e `prompt-` para inclusão de markdown base).
+- correção aplicada:
+  - centralizada a resolução em `PromptTemplateResolver`, dentro de `openai.core.prompt`, para reutilização por todas as etapas atuais e futuras do core OpenAI.
+  - o `WireframePromptBuilder` passou apenas a delegar a renderização de templates ao resolvedor comum, mantendo no adapter da etapa somente carregamento de recurso, serialização JSON e montagem do request específico.
+  - adicionada resolução de placeholders prefixados com uma ou duas chaves: `{dados-*}`, `{{dados-*}}`, `{prompt-*}` e `{{prompt-*}}`.
+  - inclusões `prompt-*` passam a carregar arquivos `.md` irmãos do prompt atual, permitindo reaproveitar `regras-globais.md` no OpenAI core.
+  - mantida compatibilidade com placeholders diretos existentes, como `{{NICHE_NAME}}` e `${NICHE_NAME}`.
+  - criado teste unitário no pacote comum cobrindo exatamente o formato informado pelo usuário.
+- impacto esperado: os prompts publicados para a OpenAI deixam de conter placeholders não resolvidos nesses campos críticos, preservando o eixo Dor → Resultado → Mecanismo → Prova → Oferta no fluxo de geração de landing page.


### PR DESCRIPTION
### Motivation

- Corrigir placeholders não resolvidos nos prompts editáveis do core OpenAI, especialmente os formatos `{{dados-*}}` e `{{prompt-*}}` usados pelo fluxo GeraLanding. 
- Centralizar a lógica de resolução de templates para permitir reaproveitamento entre etapas e suportar inclusões de arquivos markdown irmãos. 
- Manter a persistência do markdown bruto (`promptMarkdownContent`) ao montar a requisição para rastreabilidade do wireframe. 

### Description

- Adiciona `PromptTemplateResolver` em `openai.core.prompt` que resolve placeholders prefixados (`{dados-*}`, `{{dados-*}}`, `{prompt-*}`, `{{prompt-*}}`), placeholders mustache simples e inclusões recursivas de arquivos `.md` irmãos via `prompt-*`.
- Integra `PromptTemplateResolver` no `WireframePromptBuilder`, removendo o método inline `resolvePrompt` e delegando a renderização de templates ao resolvedor, enquanto continua retornando `promptMarkdownContent` bruto.
- Atualiza a regra de arquitetura em `ArquiteturaCoreTest` para considerar o novo pacote `openai.core.prompt` como pacote de suporte interno do core.
- Adiciona `PromptTemplateResolverTest` cobrindo resolução de `dados-*` e `prompt-*` com um loader e renderer de teste, e atualiza documentação em `docs/registros/experimentos.md` descrevendo a correção e impacto.

### Testing

- Executado o novo teste unitário `PromptTemplateResolverTest`, que passou com sucesso.
- Executada a suíte de testes do módulo `ai-worker` incluindo os testes de arquitetura (`ArquiteturaCoreTest`), que passou após a inclusão do pacote `prompt` nas exceções de dependência do core.
- Build e testes unitários no módulo OpenAI core foram executados sem falhas.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1a75256efc8321b474cf5f1a93019c)