### PR TITLE
Fix: force `service_tier=flex` in OpenAI Responses payload and persist final request in dispatch/logs

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/openai/core/openai/ResponsesApiOpenAiClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/openai/core/openai/ResponsesApiOpenAiClient.java
@@ -1,6 +1,7 @@
 package com.marketinghub.worker.openai.core.openai;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marketinghub.worker.openai.core.exception.OpenAiHttpException;
 import com.marketinghub.worker.openai.core.exception.StageWorkerException;
@@ -50,14 +51,20 @@ public class ResponsesApiOpenAiClient implements OpenAiClientPort {
                 .build();
     }
 
-    /** Envia o request cru para a OpenAI e devolve os dados de despacho para auditoria no backend. */
+    /** Envia o request final em modo flex para a OpenAI e devolve os dados de despacho para auditoria no backend. */
     @Override
     public OpenAiDispatch dispatch(OpenAiRequest request) {
-        String requestBodyJson = request.requestBodyJson();
+        String originalRequestBodyJson = request.requestBodyJson();
         String marketingHubJobId = marketingHubJobId(request);
+        String requestBodyJson = originalRequestBodyJson;
         try {
-            Map<String, Object> requestBody = objectMapper.readValue(requestBodyJson, Map.class);
-            log.info("Enviando request cru para OpenAI Responses API [jobId={}, schemaName={}, requestBodyJson={}]", marketingHubJobId, request.schemaName(), requestBodyJson);
+            Map<String, Object> requestBody = buildFlexRequestBody(originalRequestBodyJson);
+            requestBodyJson = objectMapper.writeValueAsString(requestBody);
+            log.info(
+                    "Enviando request final em modo flex para OpenAI Responses API [jobId={}, schemaName={}, requestBodyJson={}]",
+                    marketingHubJobId,
+                    request.schemaName(),
+                    requestBodyJson);
 
             Map<String, Object> raw = webClient.post()
                     .uri("/responses")
@@ -95,7 +102,7 @@ public class ResponsesApiOpenAiClient implements OpenAiClientPort {
                     openAiJobId,
                     request.prompt(),
                     request.schemaJson(),
-                    request.requestBodyJson(),
+                    requestBodyJson,
                     request.promptMarkdownContent(),
                     Instant.now()
             );
@@ -110,8 +117,21 @@ public class ResponsesApiOpenAiClient implements OpenAiClientPort {
                     error);
             throw new OpenAiHttpException(error.getStatusCode().value(), error.getResponseBodyAsString(), error);
         } catch (JsonProcessingException error) {
+            log.error(
+                    "Falha ao preparar request JSON da OpenAI Responses API [jobId={}, schemaName={}, originalRequestBodyJson={}]",
+                    marketingHubJobId,
+                    request.schemaName(),
+                    originalRequestBodyJson,
+                    error);
             throw new StageWorkerException("Invalid OpenAI request JSON", error);
         }
+    }
+
+    /** Monta o payload final da Responses API fixando o processamento OpenAI em service_tier flex. */
+    private Map<String, Object> buildFlexRequestBody(String requestBodyJson) throws JsonProcessingException {
+        Map<String, Object> requestBody = objectMapper.readValue(requestBodyJson, new TypeReference<>() {});
+        requestBody.put("service_tier", "flex");
+        return requestBody;
     }
 
     /** Recupera o idJob do Marketing Hub a partir dos metadados do request para correlacionar logs operacionais. */

--- a/ai-worker/src/test/java/com/marketinghub/worker/openai/core/openai/ResponsesApiOpenAiClientTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/openai/core/openai/ResponsesApiOpenAiClientTest.java
@@ -7,6 +7,7 @@ import ch.qos.logback.classic.Level;
 import ch.qos.logback.classic.Logger;
 import ch.qos.logback.classic.spi.ILoggingEvent;
 import ch.qos.logback.core.read.ListAppender;
+import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marketinghub.worker.openai.core.exception.OpenAiHttpException;
 import com.marketinghub.worker.openai.core.model.OpenAiRequest;
@@ -51,9 +52,9 @@ class ResponsesApiOpenAiClientTest {
         server.shutdown();
     }
 
-    /** Deve registrar o request cru enviado à OpenAI quando a Responses API rejeitar a chamada com erro HTTP. */
+    /** Deve registrar o request final em modo flex quando a Responses API rejeitar a chamada com erro HTTP. */
     @Test
-    void dispatchShouldLogRawOpenAiRequestWhenHttpErrorHappens() {
+    void dispatchShouldLogFlexOpenAiRequestWhenHttpErrorHappens() throws Exception {
         server.enqueue(new MockResponse()
                 .setResponseCode(400)
                 .setHeader("Content-Type", "application/json")
@@ -80,6 +81,13 @@ class ResponsesApiOpenAiClientTest {
 
         Throwable thrown = catchThrowable(() -> client.dispatch(request));
 
+        Map<String, Object> sentPayload = new ObjectMapper().readValue(
+                server.takeRequest().getBody().readUtf8(),
+                new TypeReference<>() {});
+        assertThat(sentPayload)
+                .containsEntry("model", "gpt-test")
+                .containsEntry("input", "Prompt")
+                .containsEntry("service_tier", "flex");
         assertThat(thrown).isInstanceOf(OpenAiHttpException.class);
         assertThat(thrown.getMessage())
                 .contains("OpenAI Responses API returned HTTP 400")
@@ -90,7 +98,61 @@ class ResponsesApiOpenAiClientTest {
                 .anySatisfy(message -> assertThat(message)
                         .contains("Falha HTTP na OpenAI Responses API")
                         .contains("jobId=job-123")
-                        .contains("requestBodyJson=" + requestBodyJson)
+                        .contains("\"service_tier\":\"flex\"")
                         .contains("Invalid schema"));
+    }
+
+    /** Deve fixar service_tier flex no payload enviado e no despacho auditável do core OpenAI. */
+    @Test
+    void dispatchShouldForceFlexServiceTierInOpenAiPayloadAndDispatch() throws Exception {
+        server.enqueue(new MockResponse()
+                .setResponseCode(200)
+                .setHeader("Content-Type", "application/json")
+                .setBody("""
+                        {
+                          "id": "resp-test",
+                          "output": [
+                            {
+                              "type": "message",
+                              "content": [
+                                {"type": "output_text", "text": "{\\"ok\\":true}"}
+                              ]
+                            }
+                          ],
+                          "usage": {"input_tokens": 10, "output_tokens": 5}
+                        }
+                        """));
+        ResponsesApiOpenAiClient client = new ResponsesApiOpenAiClient(
+                WebClient.builder(),
+                new ObjectMapper(),
+                new OpenAiClientProperties(
+                        "test-key",
+                        server.url("/").toString(),
+                        "gpt-test",
+                        Duration.ofSeconds(5),
+                        BigDecimal.ZERO,
+                        BigDecimal.ZERO));
+        OpenAiRequest request = new OpenAiRequest(
+                "gpt-test",
+                "Prompt",
+                "{\"model\":\"gpt-test\",\"input\":\"Prompt\",\"service_tier\":\"default\"}",
+                "schema-wireframe",
+                "{\"type\":\"object\"}",
+                "# Prompt markdown bruto",
+                Map.of("idJob", "job-123"));
+
+        var dispatch = client.dispatch(request);
+
+        Map<String, Object> sentPayload = new ObjectMapper().readValue(
+                server.takeRequest().getBody().readUtf8(),
+                new TypeReference<>() {});
+        assertThat(sentPayload)
+                .containsEntry("model", "gpt-test")
+                .containsEntry("input", "Prompt")
+                .containsEntry("service_tier", "flex");
+        Map<String, Object> dispatchPayload = new ObjectMapper().readValue(
+                dispatch.requestBodyJson(),
+                new TypeReference<>() {});
+        assertThat(dispatchPayload).containsEntry("service_tier", "flex");
     }
 }

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -2626,3 +2626,13 @@
   - mantida compatibilidade com placeholders diretos existentes, como `{{NICHE_NAME}}` e `${NICHE_NAME}`.
   - criado teste unitário no pacote comum cobrindo exatamente o formato informado pelo usuário.
 - impacto esperado: os prompts publicados para a OpenAI deixam de conter placeholders não resolvidos nesses campos críticos, preservando o eixo Dor → Resultado → Mecanismo → Prova → Oferta no fluxo de geração de landing page.
+
+## 2026-05-30 — Fixação de Flex processing no OpenAI core
+- tarefa: fixar o envio das chamadas do `ai-worker` no módulo `openai.core` em modo Flex para a OpenAI Responses API.
+- causa-raiz: o `ResponsesApiOpenAiClient` enviava o `requestBodyJson` montado pela etapa sem acrescentar `service_tier=flex`, permitindo que a OpenAI processasse a requisição no tier padrão/automático, apesar da regra canônica do GeraLanding exigir Flex.
+- correção aplicada:
+  - o `ResponsesApiOpenAiClient` agora transforma o payload final antes do envio para `/responses`, sobrescrevendo qualquer valor anterior de `service_tier` para `flex`.
+  - o despacho auditável retornado ao backend também passa a carregar o `requestBodyJson` final com `service_tier=flex`.
+  - os logs de envio e falha HTTP passam a refletir o request final em modo Flex.
+  - adicionados testes unitários garantindo que o payload enviado à OpenAI e o despacho persistível ficam fixados em `service_tier=flex`, inclusive quando o request original vier com outro tier.
+- impacto esperado: todas as etapas atuais e futuras que usam o cliente comum `openai.core` passam a obedecer ao contrato de Flex processing sem depender de cada builder de etapa lembrar de acrescentar o campo manualmente.


### PR DESCRIPTION
### Motivation
- Ensure all calls to the OpenAI Responses API from the core client are processed under the canonical Flex tier by forcing `service_tier` to `flex` regardless of the original request payload. 
- Make the request persisted/auditable by the backend and the logs reflect the actual payload sent to OpenAI (including the `service_tier` override). 

### Description
- Added `buildFlexRequestBody` that reads the original `requestBodyJson`, forces `service_tier` to `flex`, and returns the modified payload used for the HTTP call. 
- Updated `dispatch` to use the built payload for the POST to `/responses`, to serialize the final payload into the returned `OpenAiDispatch.requestBodyJson`, and to log the final request body; improved error logging for JSON preparation errors. 
- Added `TypeReference` usages and corresponding imports for robust JSON mapping and updated the local unit tests to assert that the outgoing payload and the dispatch-stored payload contain `service_tier=flex`. 
- Documented the change in `docs/registros/experimentos.md` describing the behavior and impact. 

### Testing
- Ran the updated unit tests in `ResponsesApiOpenAiClientTest`, including `dispatchShouldLogFlexOpenAiRequestWhenHttpErrorHappens` and `dispatchShouldForceFlexServiceTierInOpenAiPayloadAndDispatch`, and they passed. 
- Executed the module unit test suite (`mvn test` for the module) and observed no test failures related to these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1a80cfc6308321901bce2634589d78)