### PR TITLE
Simplifica schema do wireframe: remover `pagina.body` e usar `pagina.corpo.estilos`

### DIFF
--- a/ai-worker/src/main/resources/prompts/geralanding/landing-page-wireframe-schema.json
+++ b/ai-worker/src/main/resources/prompts/geralanding/landing-page-wireframe-schema.json
@@ -46,23 +46,7 @@
           "type": "object",
           "additionalProperties": false,
           "properties": {
-            "secoes": {
-              "type": "array",
-              "minItems": 4,
-              "items": {
-                "$ref": "#/$defs/secao"
-              }
-            }
-          },
-          "required": [
-            "secoes"
-          ]
-        },
-        "body": {
-          "type": "object",
-          "additionalProperties": false,
-          "properties": {
-            "classes": {
+            "estilos": {
               "type": "array",
               "minItems": 4,
               "maxItems": 4,
@@ -75,17 +59,24 @@
                   "marginReset"
                 ]
               }
+            },
+            "secoes": {
+              "type": "array",
+              "minItems": 4,
+              "items": {
+                "$ref": "#/$defs/secao"
+              }
             }
           },
           "required": [
-            "classes"
+            "estilos",
+            "secoes"
           ]
         }
       },
       "required": [
         "head",
-        "corpo",
-        "body"
+        "corpo"
       ]
     }
   },

--- a/ai-worker/src/main/resources/prompts/geralanding/landing-page-wireframe.md
+++ b/ai-worker/src/main/resources/prompts/geralanding/landing-page-wireframe.md
@@ -60,7 +60,7 @@ Regras fixas da etapa (Gera Landing, contrato v3):
 - Evite JSON dentro de strings; mantenha cada informação no campo próprio.
 
 
-- `pagina.body` obrigatório: declarar classes base aplicadas ao `<body>` usando apenas `bgBody`, `fontBase`, `textPrimary`, `marginReset`.
+- `pagina.corpo.estilos` obrigatório: declarar classes base aplicadas ao elemento HTML `<body>` usando apenas `bgBody`, `fontBase`, `textPrimary`, `marginReset`; não criar o campo `pagina.body`.
 - Em TODO elemento interativo (`a`, `button`), declarar `intencaoAcao` e, quando for navegação interna, `targetSectionId` apontando para `id` real de seção (ex.: `#sec-prova`); quando for link externo, declarar `hrefEsperado`.
 - Em toda `img`, declarar contrato de asset em `asset`: `src`, `alt`, `width`, `height` (wireframe deve especificar esses campos mesmo com `src` provisório).
 - Em todo campo de formulário (`input`), declarar `contratoCampo`: `type`, `name`, `autocomplete`, `required`, `placeholder`.

--- a/ai-worker/src/test/java/com/marketinghub/worker/openai/core/wireframe/WireframeBackendClientTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/openai/core/wireframe/WireframeBackendClientTest.java
@@ -3,6 +3,7 @@ package com.marketinghub.worker.openai.core.wireframe;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marketinghub.worker.openai.core.exception.OpenAiHttpException;
 import com.marketinghub.worker.openai.core.model.OpenAiDispatch;
@@ -145,6 +146,24 @@ class WireframeBackendClientTest {
                 .doesNotContain("\"if\"")
                 .doesNotContain("\"then\"")
                 .doesNotContain("\"not\"");
+    }
+
+    /** Deve manter apenas pagina.corpo no contrato de estrutura visual, sem pagina.body duplicado. */
+    @Test
+    void wireframeSchemaShouldUseOnlyCorpoAndRejectDuplicatedBodyField() throws Exception {
+        String schemaJson = new ClassPathResource("prompts/geralanding/landing-page-wireframe-schema.json")
+                .getContentAsString(StandardCharsets.UTF_8);
+        JsonNode schema = objectMapper.readTree(schemaJson);
+        JsonNode pagina = schema.path("properties").path("pagina");
+        JsonNode paginaProperties = pagina.path("properties");
+        JsonNode corpo = paginaProperties.path("corpo");
+
+        assertThat(paginaProperties.has("body")).isFalse();
+        assertThat(pagina.path("required").toString()).isEqualTo("[\"head\",\"corpo\"]");
+        assertThat(corpo.path("required").toString()).isEqualTo("[\"estilos\",\"secoes\"]");
+        assertThat(corpo.path("properties").has("estilos")).isTrue();
+        assertThat(corpo.path("properties").path("estilos").path("items").path("enum").toString())
+                .isEqualTo("[\"bgBody\",\"fontBase\",\"textPrimary\",\"marginReset\"]");
     }
 
 }

--- a/docs/canonical/arquitetura-etapas.md
+++ b/docs/canonical/arquitetura-etapas.md
@@ -117,6 +117,8 @@ enviar um request determinístico e rastreável para a OpenAI.
 
 ## GeraLanding — wireframe
 
+Contrato de saída do wireframe: a raiz deve conter `definicoes` e `pagina`; dentro de `pagina`, são permitidos apenas `head` e `corpo` para a estrutura da página. As classes globais aplicadas ao elemento HTML `<body>` devem ser declaradas em `pagina.corpo.estilos`; o campo `pagina.body` é proibido para evitar duplicidade semântica entre `body` e `corpo` na resposta do modelo.
+
 A etapa `landing-page-wireframe` expõe a fila interna pelo endpoint:
 
 ```http

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -2626,3 +2626,13 @@
   - mantida compatibilidade com placeholders diretos existentes, como `{{NICHE_NAME}}` e `${NICHE_NAME}`.
   - criado teste unitário no pacote comum cobrindo exatamente o formato informado pelo usuário.
 - impacto esperado: os prompts publicados para a OpenAI deixam de conter placeholders não resolvidos nesses campos críticos, preservando o eixo Dor → Resultado → Mecanismo → Prova → Oferta no fluxo de geração de landing page.
+
+## 2026-05-30 — Simplificação do schema wireframe para usar apenas corpo
+- tarefa: ajustar o contrato da etapa `landing-page-wireframe` para eliminar a duplicidade entre `pagina.body` e `pagina.corpo` na resposta do modelo.
+- causa-raiz: o schema permitia dois campos conceitualmente sobrepostos (`body` e `corpo`) dentro de `pagina`, o que tornava a resposta exibida na tela confusa e aumentava o risco de divergência no contrato estruturado.
+- correção aplicada:
+  - removido `pagina.body` do schema de wireframe;
+  - movidas as classes globais do elemento HTML `<body>` para `pagina.corpo.estilos`, mantendo apenas `head` e `corpo` dentro de `pagina`;
+  - atualizado o prompt da etapa para proibir `pagina.body` e orientar o modelo a responder somente com `pagina.corpo.estilos`;
+  - adicionada validação unitária garantindo que o schema não reintroduza `pagina.body` e mantenha `corpo.estilos` como campo obrigatório.
+- impacto esperado: novas respostas do wireframe deixam de exibir `body` e `corpo` simultaneamente, preservando um contrato mais simples, objetivo e aderente à tela operacional.


### PR DESCRIPTION
### Motivation
- Eliminar duplicidade semântica entre `pagina.body` e `pagina.corpo` no artefato do wireframe para reduzir ambiguidade e evitar divergências entre o modelo gerado e o HTML operacional.
- Garantir que as classes globais aplicadas ao elemento `<body>` estejam num único local previsível (`pagina.corpo.estilos`) compatível com o assembler/preview do backend.

### Description
- Remove `pagina.body` do schema `ai-worker/src/main/resources/prompts/geralanding/landing-page-wireframe-schema.json` e passa a exigir `pagina.corpo.estilos` com whitelist `bgBody|fontBase|textPrimary|marginReset` e `pagina.corpo.secoes` obrigatórios.
- Atualiza o prompt `ai-worker/src/main/resources/prompts/geralanding/landing-page-wireframe.md` para instruir o modelo a usar `pagina.corpo.estilos` e proibir a criação de `pagina.body`.
- Adiciona um teste em `ai-worker/src/test/java/com/marketinghub/worker/openai/core/wireframe/WireframeBackendClientTest.java` que verifica a ausência de `pagina.body` e a presença/forma de `corpo.estilos` no schema.
- Documenta a regra no cânone `docs/canonical/arquitetura-etapas.md` e registra a mudança em `docs/registros/experimentos.md` para rastreabilidade operacional.

### Testing
- Executed `python -m json.tool ai-worker/src/main/resources/prompts/geralanding/landing-page-wireframe-schema.json >/tmp/wireframe-schema.pretty.json` and it succeeded (JSON well-formed).
- Ran a small Python assertion script that validates the modified schema shape (checks absence of `pagina.body`, `pagina.required == ["head","corpo"]`, `corpo.required == ["estilos","secoes"]` and the `estilos` enum) and it printed `schema ok`.
- Ran `git diff --check` to ensure no trailing whitespace/errors in diffs and it passed.
- Attempted to run the unit test via Maven (`mvn -pl . -Dtest=WireframeBackendClientTest test`) but the build did not complete in this environment due to resolution of a private snapshot dependency (`com.marketinghub:ads-service:0.0.1-SNAPSHOT`) against GitHub Packages returning `401 Unauthorized`; this is an infrastructure/auth issue and not related to the schema change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1a826a2a948321817675e84e0550fa)