### PR TITLE
Wireframe: enforce classes-only-in-estilos, simplify schema and update prompts/tests

### DIFF
--- a/ai-worker/src/main/resources/prompts/geralanding/landing-page-wireframe-schema.json
+++ b/ai-worker/src/main/resources/prompts/geralanding/landing-page-wireframe-schema.json
@@ -105,18 +105,6 @@
         "id": {
           "type": "string"
         },
-        "estrutura": {
-          "$ref": "#/$defs/referenciasCategoriaPagina"
-        },
-        "posicao": {
-          "$ref": "#/$defs/referenciasCategoriaPagina"
-        },
-        "layout": {
-          "$ref": "#/$defs/referenciasCategoriaPagina"
-        },
-        "mistas": {
-          "$ref": "#/$defs/referenciasCategoriaPagina"
-        },
         "elementosSeccao": {
           "type": "array",
           "minItems": 1,
@@ -170,10 +158,6 @@
         "fonteContexto",
         "id",
         "estilos",
-        "estrutura",
-        "posicao",
-        "layout",
-        "mistas",
         "elementosSeccao"
       ]
     },

--- a/ai-worker/src/main/resources/prompts/geralanding/landing-page-wireframe.md
+++ b/ai-worker/src/main/resources/prompts/geralanding/landing-page-wireframe.md
@@ -51,9 +51,9 @@ Regras fixas da etapa (Gera Landing, contrato v3):
 - `definicoes` deve conter exatamente: `estrutura`, `posicao`, `layout`, `mistas`.
 - Cada categoria de `definicoes` deve conter `desktop[]` e `mobile[]`.
 - Cada item de definição deve conter somente: `nome`, `atributoCss`, `valor`.
-- Em `pagina`/`secoes`, usar somente referências por `nome` já definido em `definicoes`.
-- Em `pagina`/`secoes`, usar referências simples por nome de classe (sem separar por `desktop` e `mobile`).
-- Em `estilos[]` (seção e elementos internos), use exclusivamente nomes existentes em `definicoes.*.desktop[].nome` ou `definicoes.*.mobile[].nome`; qualquer nome fora disso viola contrato.
+- Em `pagina`/`secoes` e elementos internos, toda classe aplicada deve aparecer SOMENTE no campo `estilos[]`.
+- É proibido criar campos de classe por categoria (`estrutura`, `posicao`, `layout`, `mistas`) dentro de `pagina`, `pagina.corpo`, `pagina.corpo.secoes[]`, `elementosSeccao[]` ou `elementosInternos[]`; essas categorias existem apenas em `definicoes`.
+- Em `estilos[]` (`pagina.corpo`, seção e elementos internos), use exclusivamente nomes existentes em `definicoes.*.desktop[].nome` ou `definicoes.*.mobile[].nome`; qualquer nome fora disso viola contrato.
 - É proibido repetir `atributoCss`/`valor` fora de `definicoes`.
 - Não invente campos fora do schema.
 - Não invente nicho, persona, hipótese, mecanismo, prova, oferta ou entregáveis fora dos dados recebidos.
@@ -85,7 +85,7 @@ Regra de conformidade dos grupos:
 
 
 Trecho obrigatório do contrato de seção/elementos (manter):
-- Cada seção deve conter: `nome`, `objetivo`, `oQueQuerProvocarNoUsuario`, `papelComercial`, `fasePersuasao`, `objeçãoQueRemove`, `prioridadeConversao`, `acaoEsperada`, `fonteContexto[]`, `id`, `estilos[]`, `elementosSeccao[]`.
+- Cada seção deve conter: `nome`, `objetivo`, `oQueQuerProvocarNoUsuario`, `papelComercial`, `fasePersuasao`, `objeçãoQueRemove`, `prioridadeConversao`, `acaoEsperada`, `fonteContexto[]`, `id`, `estilos[]`, `elementosSeccao[]`; não deve conter `estrutura`, `posicao`, `layout` ou `mistas`.
 - Cada item de `elementosSeccao[]` deve conter: `id`, `tag`, `texto`, `estilos[]`, `elementosInternos[]`.
 - Quando `tag = "img"`, o elemento deve conter também `briefingVisual` com:
   - `ondeEntraNoVisual`;

--- a/ai-worker/src/test/java/com/marketinghub/worker/geralanding/GeraLandingServiceTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/geralanding/GeraLandingServiceTest.java
@@ -46,7 +46,7 @@ class GeraLandingServiceTest {
         assertThat(prompt).contains("Nicho: E-commerce");
         assertThat(prompt).contains("Baixa conversão");
         assertThat(prompt).contains("Mais vendas");
-        assertThat(prompt).contains("Em `estilos[]` (seção e elementos internos), use exclusivamente nomes existentes em `definicoes.*.desktop[].nome` ou `definicoes.*.mobile[].nome`");
+        assertThat(prompt).contains("toda classe aplicada deve aparecer SOMENTE no campo `estilos[]`");
         assertThat(prompt).doesNotContain("{{NICHE_NAME}}");
         assertThat(prompt).doesNotContain("{{PAIN_JSON}}");
         assertThat(prompt).doesNotContain("{{RESULT_JSON}}");

--- a/ai-worker/src/test/java/com/marketinghub/worker/openai/core/wireframe/WireframeBackendClientTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/openai/core/wireframe/WireframeBackendClientTest.java
@@ -166,4 +166,25 @@ class WireframeBackendClientTest {
                 .isEqualTo("[\"bgBody\",\"fontBase\",\"textPrimary\",\"marginReset\"]");
     }
 
+    /** Deve impedir duplicidade de classes categorizadas nas seções do wireframe. */
+    @Test
+    void wireframeSchemaShouldKeepAppliedSectionClassesOnlyInEstilos() throws Exception {
+        String schemaJson = new ClassPathResource("prompts/geralanding/landing-page-wireframe-schema.json")
+                .getContentAsString(StandardCharsets.UTF_8);
+        JsonNode schema = objectMapper.readTree(schemaJson);
+        JsonNode secao = schema.path("$defs").path("secao");
+        JsonNode secaoProperties = secao.path("properties");
+
+        assertThat(secaoProperties.has("estilos")).isTrue();
+        assertThat(secaoProperties.has("estrutura")).isFalse();
+        assertThat(secaoProperties.has("posicao")).isFalse();
+        assertThat(secaoProperties.has("layout")).isFalse();
+        assertThat(secaoProperties.has("mistas")).isFalse();
+        assertThat(secao.path("required").toString())
+                .doesNotContain("estrutura")
+                .doesNotContain("posicao")
+                .doesNotContain("layout")
+                .doesNotContain("mistas");
+    }
+
 }

--- a/docs/canonical/system-governance-canon.v2.md
+++ b/docs/canonical/system-governance-canon.v2.md
@@ -37,6 +37,7 @@
 
 12. **Sem metainstrução no artefato final.** Qualquer texto técnico/operacional vazado em conteúdo final ao usuário (copy, CTA, FAQ, HTML publicado) deve bloquear publicação com erro explícito de contrato e apontamento do campo literal rejeitado.
 13. **Wireframe só aceita estilos existentes em definições canônicas.** O artefato de wireframe não pode introduzir `style`, `surfaceStyle`, `contrastMode`, `layoutPreset` ou variação visual fora do conjunto previsto nas definições canônicas vigentes. Qualquer estilo inexistente nas definições deve ser rejeitado em validação de contrato com indicação literal do valor inválido e da definição esperada.
+14. **Classes aplicadas do wireframe ficam somente em `estilos`.** No artefato `landingPageWireframe`, as categorias `estrutura`, `posicao`, `layout` e `mistas` existem apenas dentro de `definicoes` para declarar classes canônicas. Dentro de `pagina.head`, `pagina.corpo`, `pagina.corpo.secoes[]`, `elementosSeccao[]` e `elementosInternos[]`, nomes de classes aplicadas devem aparecer exclusivamente em `estilos[]`, sem duplicação em campos categorizados.
 
 ## 3.1 Regra global de exclusividade de artefatos (todo o sistema)
 

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -2645,3 +2645,12 @@
   - os logs de envio e falha HTTP passam a refletir o request final em modo Flex.
   - adicionados testes unitários garantindo que o payload enviado à OpenAI e o despacho persistível ficam fixados em `service_tier=flex`, inclusive quando o request original vier com outro tier.
 - impacto esperado: todas as etapas atuais e futuras que usam o cliente comum `openai.core` passam a obedecer ao contrato de Flex processing sem depender de cada builder de etapa lembrar de acrescentar o campo manualmente.
+
+## 2026-05-30 — Exclusividade de classes em `estilos` no wireframe
+- tarefa: ajustar a etapa `landing-page-wireframe` do OpenAI core para impedir que a resposta JSON repita classes em `estrutura`, `posicao`, `layout` e `mistas` dentro de seções da página.
+- causa-raiz: o schema ainda permitia campos categorizados de classes em `pagina.corpo.secoes[]`, enquanto o prompt também exigia esses campos; isso induzia a OpenAI a duplicar as mesmas classes nos grupos categorizados e novamente em `estilos[]`.
+- alteração aplicada:
+  - removidos `estrutura`, `posicao`, `layout` e `mistas` do contrato de cada seção no schema `landing-page-wireframe-schema.json`;
+  - atualizado o prompt `landing-page-wireframe.md` para declarar que classes aplicadas em `head`, `corpo`, seções e elementos internos devem ficar somente em `estilos[]`;
+  - registrada a regra canônica no governance canon para evitar reintrodução da duplicidade.
+- impacto esperado: novas respostas JSON da etapa wireframe exibem as definições canônicas somente em `definicoes` e aplicam nomes de classes somente via `estilos[]`, deixando a tela operacional mais simples e sem repetição.


### PR DESCRIPTION
### Motivation
- Prevent duplication of CSS class declarations (classes were being emitted both in categorized fields `estrutura`/`posicao`/`layout`/`mistas` and again in `estilos[]`), ensuring applied classes for head/body/sections/elements live only in `estilos[]` while `definicoes` keeps the canonical token definitions.
- Avoid OpenAI structured-output ambiguity and reduce drift between wireframe → design preset → HTML assembly by simplifying the contract and clarifying the prompt.

### Description
- Removed `estrutura`, `posicao`, `layout` and `mistas` from the per-section properties and required list in `ai-worker/src/main/resources/prompts/geralanding/landing-page-wireframe-schema.json` so sections reference classes only via `estilos[]` and `definicoes` remains the source of token definitions.
- Updated the wireframe prompt `ai-worker/src/main/resources/prompts/geralanding/landing-page-wireframe.md` to instruct the model that classes applied in `head`, `pagina.corpo`, sections and internal elements must appear exclusively in `estilos[]` and that the categorized groups live only in `definicoes`.
- Added a test ensuring the schema no longer exposes `estrutura`/`posicao`/`layout`/`mistas` in `secao` and that `estilos` remains present in `ai-worker/src/test/java/com/marketinghub/worker/openai/core/wireframe/WireframeBackendClientTest.java`.
- Adjusted `GeraLandingServiceTest` expectation to reflect the new prompt wording about classes and updated governance and experiment registro docs (`docs/canonical/system-governance-canon.v2.md`, `docs/registros/experimentos.md`) to record the rule and change.

### Testing
- Ran the modified unit tests in the ai-worker module targeting the changed behavior: `WireframeBackendClientTest` and `GeraLandingServiceTest`; the test run was executed via Maven in the ai-worker module and completed without failing assertions for the updated checks.
- Earlier attempt to run a multi-module Maven invocation needed adjustment and was re-run scoped to the `ai-worker` module to validate changes to prompt/schema and tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1b706c304c83218e67b5dbb5f620f8)