### PR TITLE
Docs: add generic GeraLanding backend block example

### DIFF
--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -2685,3 +2685,12 @@
   - ajustado o cliente de copy para usar apenas o payload e DTO próprios do pacote `geralanding.copy`;
   - revisados os comentários de responsabilidade da classe e dos métodos alterados.
 - impacto esperado: o slice copy volta a cumprir a regra ArchUnit de independência entre `copy`, `imageplanning`, `presetdesign` e `deliverables`, reduzindo acoplamento e preservando a evolução isolada de cada etapa.
+
+## 2026-05-31 — Exemplo genérico de bloco backend GeraLanding
+- tarefa: criar em `/exemplos/bloco backend` uma referência genérica baseada no módulo backend `geralanding.wireframe`.
+- causa-raiz: a estrutura de wireframe já consolida o fluxo backend de etapa do GeraLanding, mas faltava um exemplo reaproveitável para orientar novas etapas sem copiar diretamente código de produção.
+- alteração aplicada:
+  - documentado o fluxo de controller, service, DTOs, estados e contratos HTTP esperados;
+  - adicionados templates genéricos de controller e service com comentários de responsabilidade e logs operacionais;
+  - incluídos exemplos de chamadas para start, pending, recebe-prompt e recebe-resposta.
+- impacto esperado: novas etapas backend do GeraLanding podem ser criadas com menos divergência de contrato, preservando rastreabilidade operacional e o eixo Dor → Resultado → Mecanismo → Prova → Oferta.

--- a/exemplos/bloco backend/BackendBlocoController.java.exemplo
+++ b/exemplos/bloco backend/BackendBlocoController.java.exemplo
@@ -1,0 +1,110 @@
+package com.marketinghub.geralanding.bloco.web;
+
+import com.marketinghub.geralanding.bloco.service.BackendBlocoService;
+import com.marketinghub.geralanding.bloco.service.GeraLandingBlocoStartResponse;
+import com.marketinghub.geralanding.bloco.service.detailStageExecution.RecordBackendBlocoDetalheDto;
+import com.marketinghub.geralanding.bloco.service.listStageExecutions.GeraLandingBlocoExecutionSummaryResponse;
+import com.marketinghub.geralanding.bloco.service.pending.RecordBlocoPending;
+import com.marketinghub.geralanding.bloco.service.recebePrompt.RecebePromptRequest;
+import com.marketinghub.geralanding.bloco.service.recebeResposta.RecebeRespostaRequest;
+import jakarta.validation.Valid;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/** Responsável por expor os endpoints de backend da etapa genérica bloco no GeraLanding. */
+@RestController
+@RequestMapping("/api")
+public class BackendBlocoController {
+    private static final Logger LOGGER = LoggerFactory.getLogger(BackendBlocoController.class);
+    private static final String STAGE_CODE = "landing-page-bloco";
+
+    private final BackendBlocoService executionService;
+
+    /** Inicializa o controller com o serviço backend da etapa bloco. */
+    public BackendBlocoController(BackendBlocoService executionService) {
+        this.executionService = executionService;
+    }
+
+    /** Registra uma execução inicial da etapa bloco. */
+    @PostMapping("/experiments/{experimentId}/geralanding/bloco/start")
+    public ResponseEntity<GeraLandingBlocoStartResponse> start(@PathVariable Long experimentId) {
+        return ResponseEntity.accepted().body(executionService.start(experimentId));
+    }
+
+    /** Lista as execuções da etapa para o experimento. */
+    @GetMapping("/experiments/{experimentId}/geralanding/bloco/stage-executions")
+    public ResponseEntity<List<GeraLandingBlocoExecutionSummaryResponse>> listStageExecutions(
+            @PathVariable Long experimentId,
+            @RequestParam(defaultValue = "true") boolean includeCompleted) {
+        return ResponseEntity.ok(
+                executionService.listExperimentStageExecutions(experimentId, STAGE_CODE, includeCompleted));
+    }
+
+    /** Lista os jobs pendentes iniciados da etapa bloco para processamento pelo Worker AI. */
+    @GetMapping("/internal/geralanding/bloco/stage-executions/pending")
+    public List<RecordBlocoPending> pending() {
+        return executionService.listPending(STAGE_CODE);
+    }
+
+    /** Recebe prompt, schema e request enviados para IA e marca a execução aguardando retorno da OpenAI. */
+    @PostMapping("/internal/geralanding/bloco/stage-executions/{idJob}/recebe-prompt")
+    public ResponseEntity<Void> recebePrompt(
+            @PathVariable String idJob, @Valid @RequestBody RecebePromptRequest payload) {
+        LOGGER.info(
+                "[GeraLanding][Bloco] Recebido request enviado para IA idJob={} jobidopenai={} promptLength={} schemaLength={} requestBodyLength={}",
+                idJob,
+                payload.jobidopenai(),
+                payload.prompt().length(),
+                payload.schemaJson().length(),
+                payload.requestBodyJson().length());
+        executionService.markWaitingOpenAiDispatch(
+                idJob,
+                payload.prompt(),
+                payload.promptMarkdownContent(),
+                payload.schemaJson(),
+                payload.requestBodyJson(),
+                payload.jobidopenai());
+        return ResponseEntity.accepted().build();
+    }
+
+    /** Recebe a resposta da IA para a etapa bloco e conclui ou falha a execução do job. */
+    @PostMapping("/internal/geralanding/bloco/stage-executions/{idJob}/recebe-resposta")
+    public ResponseEntity<Void> recebeResposta(
+            @PathVariable String idJob, @Valid @RequestBody RecebeRespostaRequest payload) {
+        LOGGER.info(
+                "[GeraLanding][Bloco] Recebida resposta da IA idJob={} experimentId={} stageCode={} openAiJobId={} hasError={}",
+                idJob,
+                payload.experimentId(),
+                payload.stageCode(),
+                payload.openAiJobId(),
+                payload.errorMessage() != null && !payload.errorMessage().isBlank());
+        executionService.markCompletedFromResponse(
+                idJob,
+                payload.experimentId(),
+                payload.stageCode(),
+                payload.modelResponse(),
+                payload.inputTokens(),
+                payload.outputTokens(),
+                payload.costUsd(),
+                payload.openAiJobId(),
+                payload.errorMessage(),
+                payload.errorDetail());
+        return ResponseEntity.accepted().build();
+    }
+
+    /** Retorna os detalhes de uma execução específica da etapa. */
+    @GetMapping("/experiments/{experimentId}/geralanding/bloco/stage-executions/{idJob}")
+    public ResponseEntity<RecordBackendBlocoDetalheDto> detailStageExecution(
+            @PathVariable Long experimentId, @PathVariable String idJob) {
+        return ResponseEntity.ok(executionService.getStageExecutionDetail(experimentId, idJob));
+    }
+}

--- a/exemplos/bloco backend/BackendBlocoService.java.exemplo
+++ b/exemplos/bloco backend/BackendBlocoService.java.exemplo
@@ -1,0 +1,181 @@
+package com.marketinghub.geralanding.bloco.service;
+
+import com.marketinghub.experiment.Experiment;
+import com.marketinghub.experiment.repository.ExperimentRepository;
+import com.marketinghub.geralanding.GeraLandingStageExecution;
+import com.marketinghub.geralanding.GeraLandingStageExecutionRepository;
+import com.marketinghub.geralanding.bloco.service.detailStageExecution.RecordBackendBlocoDetalheDto;
+import com.marketinghub.geralanding.bloco.service.listStageExecutions.GeraLandingBlocoExecutionSummaryResponse;
+import com.marketinghub.geralanding.bloco.service.pending.RecordBlocoPending;
+import jakarta.persistence.EntityNotFoundException;
+import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.List;
+import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+/** Responsável por adaptar execuções do GeraLanding para o contrato backend da etapa genérica bloco. */
+@Service
+public class BackendBlocoService {
+    private static final Logger LOGGER = LoggerFactory.getLogger(BackendBlocoService.class);
+    private static final String STAGE_CODE = "landing-page-bloco";
+    private static final String STATUS_STARTED = "INICIADO";
+    private static final String STATUS_WAITING_OPENAI_DISPATCH = "AGUARDANDO_RETORNO_OPENAI";
+    private static final String STATUS_COMPLETED = "CONCLUIDO";
+    private static final String STATUS_FAILED = "FALHA";
+
+    private final ExperimentRepository experimentRepository;
+    private final GeraLandingStageExecutionRepository executionRepository;
+
+    /** Inicializa o serviço com os repositórios necessários para consultar e persistir execuções. */
+    public BackendBlocoService(
+            ExperimentRepository experimentRepository,
+            GeraLandingStageExecutionRepository executionRepository) {
+        this.experimentRepository = experimentRepository;
+        this.executionRepository = executionRepository;
+    }
+
+    /** Inicia a execução manual da etapa bloco usando o código canônico da etapa. */
+    @Transactional
+    public GeraLandingBlocoStartResponse start(Long experimentId) {
+        Instant now = Instant.now();
+        Experiment experiment = experimentRepository.findById(experimentId)
+                .orElseThrow(() -> new EntityNotFoundException("Experiment not found: " + experimentId));
+        GeraLandingStageExecution execution = GeraLandingStageExecution.builder()
+                .experimentId(experiment.getId())
+                .experiment(experiment)
+                .stageCode(STAGE_CODE)
+                .executionRequestedAt(now)
+                .createdAt(now)
+                .promptTemplateId("manual/start")
+                .promptContent("Início manual via interface do experimento.")
+                .status(STATUS_STARTED)
+                .idJob(toDatabaseIdJob(UUID.randomUUID().toString()))
+                .build();
+        GeraLandingStageExecution saved = executionRepository.save(execution);
+        return new GeraLandingBlocoStartResponse(fromDatabaseIdJob(saved.getIdJob()), saved.getStatus());
+    }
+
+    /** Lista execuções da etapa convertendo para o DTO local da etapa. */
+    @Transactional(readOnly = true)
+    public List<GeraLandingBlocoExecutionSummaryResponse> listExperimentStageExecutions(
+            Long experimentId, String stageCode, boolean includeCompleted) {
+        return List.of();
+    }
+
+    /** Lista os jobs iniciados da etapa bloco para processamento pelo Worker AI. */
+    @Transactional(readOnly = true)
+    public List<RecordBlocoPending> listPending(String stageCode) {
+        return List.of();
+    }
+
+    /** Marca a execução como aguardando retorno da OpenAI após receber prompt, schema e request cru despachados. */
+    @Transactional
+    public void markWaitingOpenAiDispatch(
+            String idJob,
+            String prompt,
+            String promptMarkdownContent,
+            String schemaJson,
+            String requestBodyJson,
+            String openAiJobId) {
+        GeraLandingStageExecution execution = executionRepository
+                .findTopByIdJobOrderByExecutionRequestedAtDesc(toDatabaseIdJob(idJob))
+                .orElseThrow(() -> new EntityNotFoundException("GeraLanding execution not found for idJob: " + idJob));
+        execution.setPrompt(prompt);
+        execution.setPromptMarkdownContent(StringUtils.hasText(promptMarkdownContent) ? promptMarkdownContent : prompt);
+        execution.setSchemaJson(schemaJson);
+        execution.setOpenAiRequestBody(requestBodyJson);
+        execution.setOpenAiJobId(openAiJobId);
+        execution.setProcessingStartedAt(Instant.now());
+        execution.setStatus(STATUS_WAITING_OPENAI_DISPATCH);
+        executionRepository.save(execution);
+    }
+
+    /** Conclui ou falha a execução da etapa bloco com a resposta devolvida pelo Worker AI. */
+    @Transactional
+    public void markCompletedFromResponse(
+            String idJob,
+            Long experimentId,
+            String stageCode,
+            String modelResponse,
+            Integer inputTokens,
+            Integer outputTokens,
+            BigDecimal costUsd,
+            String openAiJobId,
+            String errorMessage,
+            String errorDetail) {
+        GeraLandingStageExecution execution = executionRepository
+                .findTopByIdJobOrderByExecutionRequestedAtDesc(toDatabaseIdJob(idJob))
+                .or(() -> executionRepository.findTopByExperimentIdAndStageCodeOrderByExecutionRequestedAtDesc(
+                        experimentId, stageCode))
+                .orElseThrow(() -> new EntityNotFoundException("GeraLanding execution not found for idJob: " + idJob));
+        try {
+            execution.setModelResponse(modelResponse);
+            if (StringUtils.hasText(openAiJobId)) {
+                execution.setOpenAiJobId(openAiJobId);
+            }
+            execution.setInputTokens(inputTokens);
+            execution.setOutputTokens(outputTokens);
+            execution.setCostUsd(costUsd);
+            String normalizedErrorDetail = StringUtils.hasText(errorDetail) ? errorDetail.trim() : null;
+            String normalizedErrorMessage = normalizeErrorMessage(errorMessage, normalizedErrorDetail);
+            execution.setErrorMessage(normalizedErrorMessage);
+            execution.setErrorDetail(normalizedErrorDetail);
+            execution.setCompletedAt(Instant.now());
+            execution.setStatus(normalizedErrorMessage != null ? STATUS_FAILED : STATUS_COMPLETED);
+            executionRepository.save(execution);
+            if (normalizedErrorMessage == null) {
+                persistArtifactOnExperiment(execution, modelResponse);
+            }
+        } catch (RuntimeException ex) {
+            LOGGER.error(
+                    "Erro ao concluir resposta bloco idJob={} experimentId={} stageCode={} openAiJobId={}",
+                    idJob,
+                    experimentId,
+                    stageCode,
+                    openAiJobId,
+                    ex);
+            throw ex;
+        }
+    }
+
+    /** Retorna os detalhes de auditoria de uma execução da etapa bloco. */
+    @Transactional(readOnly = true)
+    public RecordBackendBlocoDetalheDto getStageExecutionDetail(Long experimentId, String idJob) {
+        throw new EntityNotFoundException("Exemplo genérico: implementar consulta de detalhe conforme a etapa real.");
+    }
+
+    /** Normaliza a mensagem de erro e garante falha quando o callback traz apenas detalhe técnico. */
+    private String normalizeErrorMessage(String errorMessage, String normalizedErrorDetail) {
+        if (StringUtils.hasText(errorMessage)) {
+            return errorMessage.trim();
+        }
+        return StringUtils.hasText(normalizedErrorDetail) ? "Falha ao processar etapa bloco" : null;
+    }
+
+    /** Persiste no experimento o artefato final produzido pela etapa real. */
+    private void persistArtifactOnExperiment(GeraLandingStageExecution execution, String modelResponse) {
+        Experiment experiment = execution.getExperiment();
+        if (experiment == null) {
+            experiment = experimentRepository.findById(execution.getExperimentId())
+                    .orElseThrow(() -> new EntityNotFoundException("Experiment not found: " + execution.getExperimentId()));
+        }
+        // Exemplo: experiment.setLandingPageBloco(modelResponse);
+        experimentRepository.save(experiment);
+    }
+
+    /** Converte id de job textual para o formato gravado no banco. */
+    private byte[] toDatabaseIdJob(String idJob) {
+        return idJob.getBytes(StandardCharsets.UTF_8);
+    }
+
+    /** Converte id de job do banco para texto exposto na API. */
+    private String fromDatabaseIdJob(byte[] idJob) {
+        return idJob == null ? null : new String(idJob, StandardCharsets.UTF_8);
+    }
+}

--- a/exemplos/bloco backend/README.md
+++ b/exemplos/bloco backend/README.md
@@ -1,0 +1,81 @@
+# Bloco backend — exemplo genérico baseado em `geralanding.wireframe`
+
+Este exemplo documenta um bloco backend genérico inspirado no módulo real `com.marketinghub.geralanding.wireframe`.
+Ele deve ser usado como referência operacional para criar uma etapa backend do GeraLanding que:
+
+- abre uma execução manual para um experimento;
+- expõe uma fila interna de jobs iniciados para o Worker AI;
+- recebe do Worker AI o prompt/schema/request enviados à IA;
+- recebe a resposta final ou erro da IA;
+- lista e detalha execuções para a tela administrativa;
+- persiste o artefato final no campo correto do experimento.
+
+> O exemplo é intencionalmente genérico e não deve ser compilado diretamente. Ao criar uma etapa real, substitua `bloco`, `Bloco`, `landing-page-bloco` e o campo de artefato pelo nome canônico da etapa.
+
+## Estrutura sugerida
+
+```text
+backend/ads-service/src/main/java/com/marketinghub/geralanding/bloco/
+├── web/
+│   └── BackendBlocoController.java
+└── service/
+    ├── BackendBlocoService.java
+    ├── GeraLandingBlocoStartResponse.java
+    ├── detailStageExecution/
+    │   └── RecordBackendBlocoDetalheDto.java
+    ├── listStageExecutions/
+    │   └── GeraLandingBlocoExecutionSummaryResponse.java
+    ├── pending/
+    │   ├── RecordBlocoExperiment.java
+    │   ├── RecordBlocoHypothesis.java
+    │   └── RecordBlocoPending.java
+    ├── recebePrompt/
+    │   └── RecebePromptRequest.java
+    └── recebeResposta/
+        └── RecebeRespostaRequest.java
+```
+
+## Contrato HTTP do bloco
+
+Use sempre o código canônico da etapa na constante `STAGE_CODE`.
+
+| Operação | Método e rota | Uso |
+| --- | --- | --- |
+| Iniciar etapa | `POST /api/experiments/{experimentId}/geralanding/bloco/start` | Cria execução com status `INICIADO`. |
+| Listar execuções | `GET /api/experiments/{experimentId}/geralanding/bloco/stage-executions?includeCompleted=true` | Lista até 20 execuções mais recentes da etapa. |
+| Listar fila interna | `GET /api/internal/geralanding/bloco/stage-executions/pending` | Worker AI busca jobs `INICIADO`. |
+| Registrar prompt enviado | `POST /api/internal/geralanding/bloco/stage-executions/{idJob}/recebe-prompt` | Marca execução como `AGUARDANDO_RETORNO_OPENAI`. |
+| Registrar resposta | `POST /api/internal/geralanding/bloco/stage-executions/{idJob}/recebe-resposta` | Conclui ou falha a execução e persiste o artefato. |
+| Detalhar execução | `GET /api/experiments/{experimentId}/geralanding/bloco/stage-executions/{idJob}` | Retorna prompt, request, resposta, HTML provisório, métricas e erro. |
+
+## Estados mínimos
+
+- `INICIADO`: execução aberta pelo backend e pronta para ser consumida pelo Worker AI.
+- `AGUARDANDO_RETORNO_OPENAI`: Worker AI já montou o prompt/request e despachou para a OpenAI.
+- `CONCLUIDO`: Worker AI retornou resposta sem erro; o backend salvou o artefato no experimento.
+- `FALHA`: Worker AI retornou `errorMessage` ou `errorDetail`; o backend registrou erro sem sobrescrever o artefato final.
+
+## Fluxo raiz
+
+1. A tela administrativa chama `start` para criar uma execução rastreável.
+2. O Worker AI consulta `pending` e recebe o experimento, hipótese e artefatos anteriores necessários.
+3. O Worker AI envia `recebe-prompt` com prompt, schema, request final e identificador do job OpenAI.
+4. O Worker AI envia `recebe-resposta` com a resposta do modelo, métricas e erro quando houver.
+5. O backend atualiza a execução e, apenas em caso de sucesso, persiste o artefato final no experimento.
+6. A tela usa `listStageExecutions` e `detailStageExecution` para auditoria operacional.
+
+## Regras de implementação
+
+- Mantenha controller, service e records dentro do pacote da etapa para respeitar o isolamento por módulo.
+- Use comentários de responsabilidade em toda classe Java e comentários breves em todos os métodos criados ou alterados.
+- Não grave artefato final quando o callback contiver erro.
+- Registre logs com contexto operacional em callbacks internos: `idJob`, `experimentId`, `stageCode`, `openAiJobId` e presença de erro.
+- Preserve JSON estruturado nos objetos de fila sempre que possível; evite transformar artefatos em texto quando o consumidor precisa de objeto.
+- Ao criar etapa real, adicione testes unitários para controller e service cobrindo início, fila, callbacks, persistência de sucesso e falha.
+
+## Arquivos incluídos neste exemplo
+
+- `BackendBlocoController.java.exemplo`: template do controller HTTP da etapa.
+- `BackendBlocoService.java.exemplo`: template do serviço transacional da etapa.
+- `Records.java.exemplo`: conjunto compacto dos records/DTOs usados pelo controller e pelo service.
+- `contratos-http.md`: exemplos de chamadas e payloads mínimos para auditoria do fluxo.

--- a/exemplos/bloco backend/Records.java.exemplo
+++ b/exemplos/bloco backend/Records.java.exemplo
@@ -1,0 +1,95 @@
+package com.marketinghub.geralanding.bloco.service;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.Map;
+import java.util.UUID;
+
+/** Representa a resposta de início da etapa genérica bloco do GeraLanding. */
+public record GeraLandingBlocoStartResponse(String idJob, String status) {}
+
+/** Responsável por representar o resumo de uma execução da etapa genérica bloco. */
+public record GeraLandingBlocoExecutionSummaryResponse(
+        String idJob,
+        String status,
+        Instant executionRequestedAt,
+        BigDecimal costUsd) {}
+
+/** Responsável por representar os detalhes de uma execução da etapa genérica bloco. */
+public record RecordBackendBlocoDetalheDto(
+        String idJob,
+        Long experimentId,
+        String stageCode,
+        Instant executionRequestedAt,
+        Instant createdAt,
+        Instant processingStartedAt,
+        Instant completedAt,
+        String promptTemplateId,
+        String promptContent,
+        String prompt,
+        String openAiRequestBody,
+        String openAiModel,
+        String schemaJson,
+        String promptMarkdownContent,
+        String status,
+        String openAiJobId,
+        String modelResponse,
+        String provisionalHtml,
+        String errorMessage,
+        String errorDetail,
+        Integer inputTokens,
+        Integer outputTokens,
+        BigDecimal costUsd) {}
+
+/** Representa os dados do experimento expostos na fila interna da etapa genérica bloco. */
+public record RecordBlocoExperiment(
+        Long id,
+        String name,
+        String hypothesis,
+        String status,
+        String stage,
+        String creativeTextPrompt,
+        String creativeImagePrompt,
+        Object campaignAngle,
+        Object adCopy,
+        Object adImageBriefing,
+        Object landingPageCopy,
+        Object landingPageWireframe,
+        Object landingPageImagePlanning,
+        Object landingPageDesignPreset,
+        Object landingPageDeliverables,
+        String htmlGeraLanding) {}
+
+/** Representa a hipótese e o framework usados na fila interna da etapa genérica bloco. */
+public record RecordBlocoHypothesis(
+        UUID id,
+        String title,
+        Map<String, Object> framework) {}
+
+/** Representa o item mínimo de pendência da etapa genérica bloco consumido pelo Worker AI. */
+public record RecordBlocoPending(
+        Long experimentId,
+        String jobid,
+        String stageCode,
+        RecordBlocoExperiment experiment,
+        RecordBlocoHypothesis hypothesis) {}
+
+/** Representa o payload interno com prompt, schema e request enviados ao provedor de IA. */
+public record RecebePromptRequest(
+        String prompt,
+        String promptMarkdownContent,
+        String schemaJson,
+        String requestBodyJson,
+        String jobidopenai) {}
+
+/** Representa o payload enviado pelo Worker AI para concluir ou falhar a resposta da etapa genérica bloco. */
+public record RecebeRespostaRequest(
+        Long experimentId,
+        String stageCode,
+        String modelResponse,
+        Integer inputTokens,
+        Integer outputTokens,
+        BigDecimal costUsd,
+        String openAiJobId,
+        String errorMessage,
+        String errorDetail) {}

--- a/exemplos/bloco backend/contratos-http.md
+++ b/exemplos/bloco backend/contratos-http.md
@@ -1,0 +1,120 @@
+# Contratos HTTP — bloco backend genérico
+
+## 1. Iniciar execução
+
+```bash
+curl -X POST "$BACKEND/api/experiments/44/geralanding/bloco/start"
+```
+
+Resposta esperada:
+
+```json
+{
+  "idJob": "job-gerado-pelo-backend",
+  "status": "INICIADO"
+}
+```
+
+## 2. Listar pendências internas
+
+```bash
+curl "$BACKEND/api/internal/geralanding/bloco/stage-executions/pending"
+```
+
+Resposta esperada:
+
+```json
+[
+  {
+    "experimentId": 44,
+    "jobid": "job-gerado-pelo-backend",
+    "stageCode": "landing-page-bloco",
+    "experiment": {
+      "id": 44,
+      "name": "Experimento genérico",
+      "hypothesis": "Pessoa com uma dor clara quer um resultado concreto por um mecanismo simples.",
+      "status": "ACTIVE",
+      "stage": "GERALANDING"
+    },
+    "hypothesis": {
+      "id": "00000000-0000-0000-0000-000000000044",
+      "title": "Hipótese genérica",
+      "framework": {
+        "dor": "Esforço excessivo para executar uma tarefa relevante.",
+        "resultado": "Executar a tarefa com menos tempo, menos erro e mais clareza.",
+        "mecanismo": "Roteiro prático assistido por IA.",
+        "prova": "Antes e depois com redução objetiva de esforço.",
+        "oferta": "Produto digital aplicável imediatamente."
+      }
+    }
+  }
+]
+```
+
+## 3. Registrar prompt/request enviado para IA
+
+```bash
+curl -X POST "$BACKEND/api/internal/geralanding/bloco/stage-executions/job-gerado-pelo-backend/recebe-prompt" \
+  -H 'Content-Type: application/json' \
+  --data @payload-recebe-prompt.json
+```
+
+Payload mínimo:
+
+```json
+{
+  "prompt": "Crie o artefato da etapa usando Dor, Resultado, Mecanismo, Prova e Oferta.",
+  "promptMarkdownContent": "# Prompt\nCrie o artefato da etapa com foco em transformação real.",
+  "schemaJson": "{\"type\":\"object\"}",
+  "requestBodyJson": "{\"model\":\"gpt-5.3\",\"service_tier\":\"flex\"}",
+  "jobidopenai": "openai-job-123"
+}
+```
+
+## 4. Registrar resposta de sucesso
+
+```bash
+curl -X POST "$BACKEND/api/internal/geralanding/bloco/stage-executions/job-gerado-pelo-backend/recebe-resposta" \
+  -H 'Content-Type: application/json' \
+  --data @payload-recebe-resposta-sucesso.json
+```
+
+Payload mínimo:
+
+```json
+{
+  "experimentId": 44,
+  "stageCode": "landing-page-bloco",
+  "modelResponse": "{\"artefato\":{\"titulo\":\"Exemplo de saída final\"}}",
+  "inputTokens": 1200,
+  "outputTokens": 800,
+  "costUsd": 0.0456,
+  "openAiJobId": "openai-job-123",
+  "errorMessage": null,
+  "errorDetail": null
+}
+```
+
+## 5. Registrar resposta de falha
+
+```bash
+curl -X POST "$BACKEND/api/internal/geralanding/bloco/stage-executions/job-gerado-pelo-backend/recebe-resposta" \
+  -H 'Content-Type: application/json' \
+  --data @payload-recebe-resposta-falha.json
+```
+
+Payload mínimo:
+
+```json
+{
+  "experimentId": 44,
+  "stageCode": "landing-page-bloco",
+  "modelResponse": null,
+  "inputTokens": null,
+  "outputTokens": null,
+  "costUsd": null,
+  "openAiJobId": "openai-job-123",
+  "errorMessage": "Falha ao gerar artefato da etapa",
+  "errorDetail": "Detalhe técnico do provedor ou validador"
+}
+```


### PR DESCRIPTION
### Motivation
- Provide a reusable, low-friction example for implementing new GeraLanding backend stages following the `geralanding.wireframe` contract and operational flow. 
- Ensure teams have a documented template for controller/service/DTOs, HTTP contracts and implementation rules to reduce contract divergence across new stages.

### Description
- Added `exemplos/bloco backend/` containing `README.md`, `BackendBlocoController.java.exemplo`, `BackendBlocoService.java.exemplo`, `Records.java.exemplo` and `contratos-http.md` as a generic template for a backend stage that exposes `start`, `pending`, `recebe-prompt`, `recebe-resposta` and `detail` endpoints. 
- The service template implements the canonical execution states (`INICIADO`, `AGUARDANDO_RETORNO_OPENAI`, `CONCLUIDO`, `FALHA`), wiring to `GeraLandingStageExecution` and `Experiment` persistence patterns used by `geralanding.wireframe`. 
- Documented HTTP payload examples and minimal contracts in `contratos-http.md` and recorded the change in `docs/registros/experimentos.md` under a new entry describing the example and intent. 

### Testing
- Ran pre-commit checks with `git diff --cached --check` which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c49fe22048321b321c308c6e74b84)