### PR TITLE
docs: add generic OpenAI Core block example

### DIFF
--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -2675,3 +2675,21 @@
   - criados DTOs/records segmentados em `detailStageExecution`, `listStageExecutions`, `pending`, `recebePrompt` e `recebeResposta` para alinhar a árvore de pacotes de copy ao padrão de wireframe;
   - adicionados testes unitários de serviço e controller cobrindo início, pending, callbacks internos e persistência do artefato final.
 - impacto esperado: a etapa `landing-page-copy` fica pronta para o mesmo fluxo operacional do wireframe, reduzindo divergência de contratos com o Worker AI e preservando rastreabilidade de prompt, request, métricas, falhas e artefato final.
+
+## 2026-05-31 11:45:53 UTC-3
+- solicitação para analisar o módulo `openai.core.wireframe` do Worker AI e criar um exemplo genérico reutilizável em `/exemplos`.
+- raciocínio aplicado: documentar o padrão do `StageWorker` como bloco genérico, separando responsabilidades de backend port, prompt builder, validador, handler, scheduler, propriedades e configuração Spring sem acoplar o exemplo às regras específicas de wireframe.
+- foi feito: criação da pasta `exemplos/bloco openai core` com README explicativo, exemplo de configuração, prompt genérico, schema JSON e payload pendente de backend para servir como referência de implementação de novas etapas OpenAI Core.
+- documentos lidos para pesquisar e resolver o problema:
+  - AGENTS.md
+  - ai-worker/AGENTS.md
+  - docs/registros/experimentos.md
+  - ai-worker/src/main/java/com/marketinghub/worker/openai/core/StageWorker.java
+  - ai-worker/src/main/java/com/marketinghub/worker/openai/core/wireframe/WireframeWorkerConfiguration.java
+  - ai-worker/src/main/java/com/marketinghub/worker/openai/core/wireframe/WireframeExecutionScheduler.java
+  - ai-worker/src/main/java/com/marketinghub/worker/openai/core/wireframe/WireframeBackendClient.java
+  - ai-worker/src/main/java/com/marketinghub/worker/openai/core/wireframe/WireframePromptBuilder.java
+  - ai-worker/src/main/java/com/marketinghub/worker/openai/core/wireframe/WireframeResponseValidator.java
+  - ai-worker/src/main/java/com/marketinghub/worker/openai/core/wireframe/WireframeResponseHandler.java
+  - ai-worker/src/main/java/com/marketinghub/worker/openai/core/wireframe/WireframeInput.java
+  - ai-worker/src/main/java/com/marketinghub/worker/openai/core/wireframe/WireframeOutput.java

--- a/exemplos/bloco openai core/README.md
+++ b/exemplos/bloco openai core/README.md
@@ -1,0 +1,180 @@
+# Exemplo genérico — bloco OpenAI Core
+
+Este exemplo mostra como criar um novo bloco/etapa usando o padrão do módulo `openai.core.wireframe` do Worker AI, sem copiar regras específicas de wireframe ou de landing page.
+
+## Objetivo
+
+Usar o `StageWorker<I, O>` como orquestrador genérico para uma etapa que:
+
+1. busca jobs pendentes no backend;
+2. monta prompt, schema e request para a OpenAI;
+3. despacha a requisição;
+4. registra o prompt/request enviado;
+5. aguarda e valida a resposta;
+6. envia sucesso ou falha de volta ao backend.
+
+## Mapa do padrão observado no módulo real
+
+| Papel | Implementação real no wireframe | Exemplo genérico equivalente |
+| --- | --- | --- |
+| Orquestrador | `StageWorker<WireframeInput, WireframeOutput>` | `StageWorker<BlocoInput, BlocoOutput>` |
+| Dados de entrada | `WireframeInput` | `BlocoInput` |
+| Dados de saída | `WireframeOutput` | `BlocoOutput` |
+| Cliente backend | `WireframeBackendClient` | `BlocoBackendClient` |
+| Builder de prompt | `WireframePromptBuilder` | `BlocoPromptBuilder` |
+| Validador | `WireframeResponseValidator` | `BlocoResponseValidator` |
+| Handler/log | `WireframeResponseHandler` | `BlocoResponseHandler` |
+| Scheduler | `WireframeExecutionScheduler` | `BlocoExecutionScheduler` |
+| Propriedades | `WireframeWorkerProperties` | `BlocoWorkerProperties` |
+| Configuração Spring | `WireframeWorkerConfiguration` | `BlocoWorkerConfiguration` |
+
+## Fluxo operacional
+
+```text
+Scheduler
+  -> StageWorker.processPending(limit)
+    -> BackendPort.listPending(limit)
+    -> PromptBuilder.build(execution)
+    -> OpenAiClientPort.dispatch(request)
+    -> BackendPort.markDispatched(execution, dispatch)
+    -> OpenAiClientPort.awaitResult(dispatch)
+    -> ResponseValidator.validateAndParse(modelResponse)
+    -> ResponseHandler.handleSuccess(...)
+    -> BackendPort.markCompleted(...)
+
+Se qualquer passo falhar:
+    -> ResponseHandler.handleFailure(...)
+    -> BackendPort.markFailed(...)
+```
+
+## Estrutura sugerida de pacote
+
+```text
+com.marketinghub.worker.openai.core.bloco
+├── BlocoBackendClient.java
+├── BlocoExecutionScheduler.java
+├── BlocoInput.java
+├── BlocoOutput.java
+├── BlocoPromptBuilder.java
+├── BlocoResponseHandler.java
+├── BlocoResponseValidator.java
+├── BlocoWorkerConfiguration.java
+└── BlocoWorkerProperties.java
+```
+
+## Contratos mínimos
+
+### `BlocoInput`
+
+```java
+/** Responsabilidade: transportar os dados de entrada necessários para montar o prompt do bloco genérico. */
+public record BlocoInput(
+        Long aggregateId,
+        String stageCode,
+        String idJob,
+        Map<String, Object> promptData
+) {
+    /** Normaliza os dados de prompt para evitar mapa nulo durante a renderização. */
+    public BlocoInput {
+        promptData = promptData == null ? Map.of() : Map.copyOf(promptData);
+    }
+}
+```
+
+### `BlocoOutput`
+
+```java
+/** Responsabilidade: transportar o payload validado retornado pela OpenAI para o bloco genérico. */
+public record BlocoOutput(
+        Map<String, Object> payload
+) {
+    /** Normaliza o payload validado para evitar mapa nulo no envio ao backend. */
+    public BlocoOutput {
+        payload = payload == null ? Map.of() : Map.copyOf(payload);
+    }
+}
+```
+
+### `BlocoWorkerProperties`
+
+```java
+/** Responsabilidade: concentrar as propriedades operacionais do worker OpenAI do bloco genérico. */
+@Validated
+@ConfigurationProperties(prefix = "bloco.worker")
+public record BlocoWorkerProperties(
+        boolean enabled,
+        @Min(1) int pendingLimit,
+        @NotBlank String backendBaseUrl,
+        String apiPrefix,
+        @NotBlank String promptResource,
+        @NotBlank String schemaResource,
+        @NotBlank String schemaName,
+        @NotNull Duration timeout
+) {
+    /** Normaliza valores opcionais usados pelo worker do bloco quando a configuração externa omite o campo. */
+    public BlocoWorkerProperties {
+        if (apiPrefix == null || apiPrefix.isBlank()) {
+            apiPrefix = "/api";
+        }
+        if (timeout == null) {
+            timeout = Duration.ofMinutes(30);
+        }
+    }
+}
+```
+
+## Endpoints esperados no backend
+
+O cliente do backend deve manter o mesmo contrato conceitual do wireframe, mudando apenas o caminho do domínio/etapa:
+
+| Operação | Método | Exemplo de rota |
+| --- | --- | --- |
+| Buscar pendentes | `GET` | `/api/internal/<dominio>/<bloco>/stage-executions/pending` |
+| Registrar prompt/request | `POST` | `/api/internal/<dominio>/<bloco>/stage-executions/{idJob}/recebe-prompt` |
+| Registrar resposta ou erro | `POST` | `/api/internal/<dominio>/<bloco>/stage-executions/{idJob}/recebe-resposta` |
+
+### Payload de prompt enviado ao backend
+
+```json
+{
+  "prompt": "prompt final renderizado",
+  "promptMarkdownContent": "template markdown original",
+  "schemaJson": "schema JSON do contrato de saída",
+  "requestBodyJson": "corpo cru enviado à OpenAI",
+  "jobidopenai": "resp_abc123"
+}
+```
+
+### Payload de resposta enviado ao backend
+
+```json
+{
+  "experimentId": 123,
+  "stageCode": "BLOCO_GENERICO",
+  "modelResponse": "{\"resultado\":{\"titulo\":\"Exemplo\"}}",
+  "inputTokens": 1000,
+  "outputTokens": 500,
+  "costUsd": 0.01,
+  "openAiJobId": "resp_abc123",
+  "errorMessage": null,
+  "errorDetail": null
+}
+```
+
+> Observação: o campo `modelResponse` aparece como texto porque o contrato real da etapa envia a resposta bruta do modelo. Para novos contratos, prefira campos estruturados quando o backend já suportar esse formato e evite JSON serializado dentro de JSON.
+
+## Regras importantes para adaptar o bloco
+
+- Mantenha o acesso ao banco exclusivamente no backend; o Worker AI deve chamar apenas endpoints internos.
+- Registre logs com `idJob`, identificador agregado e contexto operacional em sucesso e falha.
+- Registre request cru enviado à OpenAI, resposta crua recebida e payload enviado ao backend.
+- Use schema JSON estrito para reduzir variação de resposta.
+- Não publique metadados técnicos no artefato final do cliente.
+- Para cada nova etapa, mantenha prompt, schema, DTOs, cliente, validador e scheduler dentro do pacote da própria etapa.
+
+## Arquivos auxiliares deste exemplo
+
+- `exemplo-configuracao.properties`: propriedades mínimas para habilitar o bloco.
+- `prompt-bloco-generico.md`: template simples com placeholders.
+- `schema-bloco-generico.json`: schema JSON estrito de saída.
+- `exemplo-payload-pendente.json`: exemplo de resposta do backend para `listPending`.

--- a/exemplos/bloco openai core/exemplo-configuracao.properties
+++ b/exemplos/bloco openai core/exemplo-configuracao.properties
@@ -1,0 +1,15 @@
+# Exemplo de configuração para um bloco genérico baseado em openai.core.wireframe.
+bloco.worker.enabled=true
+bloco.worker.pending-limit=5
+bloco.worker.backend-base-url=http://191.252.181.168
+bloco.worker.api-prefix=/api
+bloco.worker.prompt-resource=prompts/bloco/bloco-generico.md
+bloco.worker.schema-resource=prompts/bloco/bloco-generico-schema.json
+bloco.worker.schema-name=marketing_hub_bloco_generico
+bloco.worker.timeout=PT30M
+
+# Propriedades compartilhadas do cliente OpenAI já usadas pelo core.
+openai.model=${OPENAI_MODEL:gpt-5.2}
+openai.api-key=${OPENAI_API_KEY:}
+openai.base-url=${OPENAI_BASE_URL:https://api.openai.com/v1}
+openai.timeout=${OPENAI_TIMEOUT:PT30M}

--- a/exemplos/bloco openai core/exemplo-payload-pendente.json
+++ b/exemplos/bloco openai core/exemplo-payload-pendente.json
@@ -1,0 +1,34 @@
+[
+  {
+    "experimentId": 123,
+    "stageCode": "BLOCO_GENERICO",
+    "jobid": "job-bloco-123",
+    "executionRequestedAt": "2026-05-31T12:00:00Z",
+    "experiment": {
+      "nicheName": "Profissionais autônomos com pouco tempo",
+      "campaignAngle": {
+        "headline": "Recupere horas da semana sem contratar equipe"
+      }
+    },
+    "hypothesis": {
+      "framework": {
+        "pain": {
+          "descricao": "Rotina manual consome tempo e atrasa vendas"
+        },
+        "result": {
+          "descricao": "Processo simples para reduzir tarefas repetitivas"
+        },
+        "mechanism": {
+          "descricao": "Checklist guiado com automações leves apoiadas por IA"
+        }
+      }
+    },
+    "jobContext": {
+      "objetivo": "Gerar uma proposta de bloco reutilizável para produto digital",
+      "restricoes": [
+        "manter linguagem simples",
+        "não prometer resultado garantido"
+      ]
+    }
+  }
+]

--- a/exemplos/bloco openai core/prompt-bloco-generico.md
+++ b/exemplos/bloco openai core/prompt-bloco-generico.md
@@ -1,0 +1,24 @@
+# Bloco genérico do Marketing Hub
+
+Você é um bloco de geração do Marketing Hub.
+
+Contexto comercial:
+- Nicho: {{NICHE_NAME}}
+- Dor principal: {{PAIN_JSON}}
+- Resultado desejado: {{RESULT_JSON}}
+- Mecanismo proposto: {{MECHANISM_JSON}}
+
+Dados adicionais do job:
+{{JOB_CONTEXT_JSON}}
+
+## Tarefa
+
+Crie uma saída objetiva que ajude a transformar a dor em resultado por meio de um mecanismo plausível e vendável.
+
+## Regras
+
+- Responda somente JSON válido aderente ao schema informado.
+- Não invente dados fora do contexto recebido.
+- Priorize clareza comercial, utilidade prática e conexão com Dor → Resultado → Mecanismo → Prova → Oferta.
+- Evite JSON serializado dentro de campos textuais.
+- Não inclua comentários técnicos, flags internas, mensagens de debug ou metadados operacionais no artefato final.

--- a/exemplos/bloco openai core/schema-bloco-generico.json
+++ b/exemplos/bloco openai core/schema-bloco-generico.json
@@ -1,0 +1,51 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "title": "Marketing Hub - Bloco Generico",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "resultado": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "titulo": {
+          "type": "string",
+          "minLength": 1
+        },
+        "descricao": {
+          "type": "string",
+          "minLength": 1
+        },
+        "proximaAcao": {
+          "type": "string",
+          "minLength": 1
+        }
+      },
+      "required": [
+        "titulo",
+        "descricao",
+        "proximaAcao"
+      ]
+    },
+    "evidenciasUsadas": {
+      "type": "array",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    },
+    "riscosDeAderencia": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "minLength": 1
+      }
+    }
+  },
+  "required": [
+    "resultado",
+    "evidenciasUsadas",
+    "riscosDeAderencia"
+  ]
+}


### PR DESCRIPTION
### Motivation
- Provide a reusable, generic example of how to implement a new Worker AI OpenAI Core stage following the `openai.core.wireframe` pattern and the existing `StageWorker` orchestration. 
- Make explicit the expected backend endpoints, payload contracts and adaptation rules so new stages stay consistent with project conventions (prompt, schema, request/response auditing, and backend callbacks).

### Description
- Add a new example package at `exemplos/bloco openai core` containing a `README.md` that documents the `StageWorker` flow, role mapping, package structure and adaptation rules. 
- Include sample assets in the example folder: `exemplo-configuracao.properties`, `prompt-bloco-generico.md`, `schema-bloco-generico.json` and `exemplo-payload-pendente.json` to serve as a minimal working reference for configuration, prompt template, strict output schema and backend pending payload. 
- Update the operational register `docs/registros/experimentos.md` with an entry describing the analysis and creation of the example for traceability and alignment with repository rules. 
- Ensure the example follows repository rules: backend-only DB access, request/response auditing, strict JSON schema, and prohibition of internal metadata in final artifacts.

### Testing
- Ran `python -m json.tool "exemplos/bloco openai core/schema-bloco-generico.json" >/tmp/schema-bloco-generico.pretty.json` to validate and pretty-print the JSON schema, and it completed successfully. 
- Ran `python -m json.tool "exemplos/bloco openai core/exemplo-payload-pendente.json" >/tmp/exemplo-payload-pendente.pretty.json` to validate the example pending payload, and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c4929883c83218299b9358d42b1b6)