### PR TITLE
Fix Worker AI tests: expect landing copy template v4 and stabilize MockWebServer

### DIFF
--- a/ai-worker/src/test/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineOpenAiClientTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineOpenAiClientTest.java
@@ -25,6 +25,7 @@ import org.springframework.web.reactive.function.client.ExchangeStrategies;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
 
+/** Verifica a montagem de payloads OpenAI do pipeline de experimentos. */
 class ExperimentPipelineOpenAiClientTest {
     private static final ObjectMapper MAPPER = new ObjectMapper();
 
@@ -1000,6 +1001,7 @@ class ExperimentPipelineOpenAiClientTest {
         assertThat(payload.get("model")).isEqualTo("gpt-5.1-codex");
     }
 
+    /** Confirma que o rastreio do template de copy reflete a versão atual do prompt carregado. */
     @Test
     void storesTemplateTraceInTrackedRequestBodyForLandingCopy() throws Exception {
         AtomicReference<Map<String, Object>> payloadRef = new AtomicReference<>();
@@ -1031,7 +1033,7 @@ class ExperimentPipelineOpenAiClientTest {
         Map<String, Object> templateTrace = (Map<String, Object>) trackedRequest.get("templateTrace");
         assertThat(templateTrace)
                 .containsEntry("template_id", "landing-page-copy")
-                .containsEntry("template_version", "v3")
+                .containsEntry("template_version", "v4")
                 .containsEntry("artifact_target", "landingPageCopy")
                 .containsEntry("model", "gpt-5.2");
     }

--- a/ai-worker/src/test/java/com/marketinghub/worker/niche/NicheHypothesisServiceTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/niche/NicheHypothesisServiceTest.java
@@ -20,8 +20,14 @@ import com.marketinghub.prompt.repository.PromptDomainRepository;
 import com.marketinghub.prompt.repository.PromptEntityRepository;
 import com.marketinghub.prompt.repository.PromptRepository;
 import com.marketinghub.worker.config.TestServiceMocksConfig;
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicReference;
+import okhttp3.mockwebserver.Dispatcher;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
+import okhttp3.mockwebserver.RecordedRequest;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -36,12 +42,9 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.DynamicPropertyRegistry;
 import org.springframework.test.context.DynamicPropertySource;
 
-import java.io.IOException;
-import java.util.List;
-import java.util.Map;
-
 import static org.assertj.core.api.Assertions.assertThat;
 
+/** Verifica a geração e persistência de hipóteses de nicho via cliente OpenAI em lote. */
 @SpringBootTest(properties = {
         "spring.datasource.url=jdbc:h2:mem:aiworker;MODE=MySQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE",
         "spring.datasource.driver-class-name=org.h2.Driver",
@@ -63,6 +66,7 @@ class NicheHypothesisServiceTest {
     static MockWebServer mockWebServer;
 
     private final ObjectMapper objectMapper = new ObjectMapper();
+    private final AtomicReference<String> batchOutputBody = new AtomicReference<>("");
 
     @MockBean
     AiWorkerGenerationService aiWorkerGenerationService;
@@ -107,6 +111,7 @@ class NicheHypothesisServiceTest {
         mockWebServer.shutdown();
     }
 
+    /** Reinicia dados e respostas HTTP para isolar cada cenário de geração de hipóteses. */
     @BeforeEach
     void resetDb() {
         hypothesisRepository.deleteAll();
@@ -119,6 +124,8 @@ class NicheHypothesisServiceTest {
         promptRepository.deleteAll();
         seedPromptDomains();
         createActivePrompt();
+        batchOutputBody.set("");
+        mockWebServer.setDispatcher(openAiBatchDispatcher());
     }
 
     private void createActivePrompt() {
@@ -149,6 +156,7 @@ class NicheHypothesisServiceTest {
         promptDomainRepository.save(hypotheses);
     }
 
+    /** Garante que hipóteses válidas são criadas, rastreadas e removidas da fila do nicho. */
     @Test
     @org.springframework.transaction.annotation.Transactional
     void generateHypothesesForNiches() {
@@ -193,6 +201,7 @@ class NicheHypothesisServiceTest {
         assertThat(nicheRepository.findById(niche.getId()).orElseThrow().getHypothesesToGenerate()).isZero();
     }
 
+    /** Garante que respostas sem título são descartadas sem bloquear as demais hipóteses válidas. */
     @Test
     void skipHypothesesWithoutTitle() {
         MarketNiche niche = MarketNiche.builder()
@@ -291,10 +300,8 @@ class NicheHypothesisServiceTest {
         assertThat(nicheRepository.findById(niche.getId()).orElseThrow().getHypothesesToGenerate()).isZero();
     }
 
+    /** Prepara o corpo JSONL que o dispatcher do OpenAI Batch devolverá para o nicho do cenário. */
     private void enqueueBatchResponse(Long nicheId, String content) {
-        mockWebServer.enqueue(jsonResponse("{\"id\":\"file-1\"}"));
-        mockWebServer.enqueue(jsonResponse("{\"id\":\"batch-1\",\"status\":\"validating\"}"));
-        mockWebServer.enqueue(jsonResponse("{\"id\":\"batch-1\",\"status\":\"completed\",\"output_file_id\":\"file-output-1\"}"));
         try {
             Map<String, Object> outputContent = Map.of(
                     "type", "output_text",
@@ -316,15 +323,38 @@ class NicheHypothesisServiceTest {
                             "status_code", 200,
                             "request_id", "req_123",
                             "body", responseBody));
-            String line = objectMapper.writeValueAsString(lineObject);
-            mockWebServer.enqueue(new MockResponse()
-                    .addHeader("Content-Type", "application/json")
-                    .setBody(line));
+            batchOutputBody.set(objectMapper.writeValueAsString(lineObject));
         } catch (Exception e) {
             throw new RuntimeException(e);
         }
     }
 
+    /** Cria um dispatcher determinístico para evitar esgotamento de filas do MockWebServer entre testes. */
+    private Dispatcher openAiBatchDispatcher() {
+        return new Dispatcher() {
+            @Override
+            public MockResponse dispatch(RecordedRequest request) {
+                String path = request.getPath();
+                if ("/files".equals(path)) {
+                    return jsonResponse("{\"id\":\"file-1\"}");
+                }
+                if ("/batches".equals(path)) {
+                    return jsonResponse("{\"id\":\"batch-1\",\"status\":\"validating\"}");
+                }
+                if ("/batches/batch-1".equals(path)) {
+                    return jsonResponse("{\"id\":\"batch-1\",\"status\":\"completed\",\"output_file_id\":\"file-output-1\"}");
+                }
+                if ("/files/file-output-1/content".equals(path)) {
+                    return new MockResponse()
+                            .addHeader("Content-Type", "application/json")
+                            .setBody(batchOutputBody.get());
+                }
+                return new MockResponse().setResponseCode(404).setBody("{}");
+            }
+        };
+    }
+
+    /** Monta uma resposta JSON simples para o MockWebServer. */
     private MockResponse jsonResponse(String body) {
         return new MockResponse()
                 .addHeader("Content-Type", "application/json")

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -2759,3 +2759,14 @@
   - adicionados testes de contrato garantindo que o schema expõe apenas `bodySections` e que o prompt bloqueia blocos extras;
   - atualizado o JSON de exemplo da etapa copy para remover blocos fora do wireframe e manter somente `bodySections`.
 - impacto esperado: a etapa copy passa a preencher apenas os textos solicitados pelo wireframe, reduzindo divergência entre etapas e evitando contaminação do artefato final com conteúdo inventado.
+
+## 2026-05-31 — Correção de testes do Worker AI para copy e hipóteses
+- tarefa: corrigir falhas de testes no Worker AI relacionadas ao rastreio do template de `landing-page-copy` e à geração de hipóteses sem título.
+- causa-raiz:
+  - o teste de rastreio da copy ainda esperava `template_version: v3`, mas o prompt canônico da etapa está em `v4`;
+  - `NicheHypothesisServiceTest` usava fila sequencial do `MockWebServer`, o que podia esgotar respostas e gerar timeout em leituras bloqueantes quando a ordem/estado dos testes ficava desalinhada.
+- correção aplicada:
+  - atualizado o teste da etapa copy para validar `template_version: v4`;
+  - substituída a fila de respostas do `MockWebServer` por um dispatcher determinístico no teste de hipóteses;
+  - mantida a transação necessária no cenário que valida associações JPA, com o isolamento HTTP garantido pelo dispatcher determinístico.
+- impacto esperado: a suíte do Worker AI passa a validar a versão atual do prompt e reduz intermitência nos testes de geração de hipóteses, mantendo o fluxo Dor → Resultado → Mecanismo → Prova → Oferta confiável para produtos vendáveis.


### PR DESCRIPTION
### Motivation
- Fix flaky Worker AI tests caused by an outdated expectation for the landing copy template version and by brittle queued MockWebServer responses that could exhaust the test HTTP queue and cause blocking-read timeouts. 
- Ensure unit tests reflect the canonical prompt version and run deterministically across environments.

### Description
- Updated `ExperimentPipelineOpenAiClientTest` to expect the current `landing-page-copy` `template_version` `v4` and added a short class/method responsibility comment. 
- Reworked `NicheHypothesisServiceTest` to use a deterministic `MockWebServer` `Dispatcher`, introduced an `AtomicReference<String> batchOutputBody` and replaced queued enqueues with a dispatcher that serves `/files`, `/batches`, `/batches/{id}` and `/files/{id}/content`. 
- Adjusted the test helper `enqueueBatchResponse` to populate the shared `batchOutputBody` and added `openAiBatchDispatcher()` and `jsonResponse()` helpers to centralize mock behavior. 
- Added/updated test-level comments and kept the necessary transactional annotation on the JPA validation scenario to preserve correct association loading. 
- Documented the change in `docs/registros/experimentos.md` explaining cause, fix and expected impact.

### Testing
- Ran `mvn -DskipTests install` in `backend/ads-service`, which completed successfully and installed the local `ads-service` artifact used by `ai-worker`. (Succeeded) 
- Ran `mvn -Dtest=ExperimentPipelineOpenAiClientTest,NicheHypothesisServiceTest test` in `ai-worker`, and both tests completed with a successful build (`BUILD SUCCESS`). (Succeeded)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c7d4369e88321bb263052d2049ee8)