### PR TITLE
Enforce 'princípio de pouco esforço' in wireframe and copy prompts; update docs and tests

### DIFF
--- a/ai-worker/src/main/resources/prompts/geralanding/landing-page-copy.md
+++ b/ai-worker/src/main/resources/prompts/geralanding/landing-page-copy.md
@@ -42,6 +42,7 @@ Regra central de contrato:
 - O wireframe é a única fonte de verdade estrutural.
 - A etapa copy não decide estrutura, não adiciona seções, não adiciona blocos e não cria metadados.
 - A etapa copy apenas escreve o valor `texto` para ids textuais existentes no wireframe.
+- Princípio de pouco esforço obrigatório: o usuário não quer fazer esforço para entender a comunicação da página; portanto, cada texto deve ser claro em leitura rápida, reduzir carga cognitiva, evitar explicação longa sem necessidade e conduzir naturalmente para o próximo CTA ou próximo passo definido pelo wireframe.
 
 Elementos de contexto (usar apenas para escolher palavras, sem mudar a estrutura do wireframe):
 - `nicho`: define com quem a landing está falando.

--- a/ai-worker/src/main/resources/prompts/geralanding/landing-page-wireframe.md
+++ b/ai-worker/src/main/resources/prompts/geralanding/landing-page-wireframe.md
@@ -120,6 +120,7 @@ Trecho obrigatório do contrato de seção/elementos (manter):
 
 Regras comerciais e estruturais obrigatórias (mantidas):
 - Mobile-first obrigatório: priorize leitura vertical e CTA claro nas primeiras seções.
+- Princípio de pouco esforço obrigatório: o usuário não quer fazer esforço para entender a comunicação da página; portanto, cada seção deve reduzir carga cognitiva, deixar a mensagem principal evidente em leitura rápida, usar poucos caminhos de decisão, evitar excesso de informações simultâneas e conduzir naturalmente para o próximo CTA.
 - Objetivo comercial obrigatório: estruturar a página para venda com foco na coleta de informação para envio de amostra/prova do produto (ex.: formulário/CTA de captura).
 - Fase wireframe NÃO preenche copy: em TODOS os elementos, `texto.conteudo` deve ser string vazia (`""`) nesta etapa.
 - Para tags de lista (`ul`), sempre declarar os `li` internos explicitamente.

--- a/ai-worker/src/test/java/com/marketinghub/worker/geralanding/copy/request/MontaRequestContractTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/geralanding/copy/request/MontaRequestContractTest.java
@@ -37,7 +37,9 @@ class MontaRequestContractTest {
                 .contains("A raiz do JSON deve conter somente `bodySections`")
                 .contains("É proibido devolver `faq`, `ctaBlocks`, `formMicrocopy`, `imageAccessibilityPlan`, `consistencyChecks`, `complianceNotes`, `pageGoal`, `primaryCTA`, `messageMatchSource`, `messageMatchNotes`")
                 .contains("O wireframe é a única fonte de verdade estrutural")
-                .contains("A etapa copy apenas escreve o valor `texto` para ids textuais existentes no wireframe");
+                .contains("A etapa copy apenas escreve o valor `texto` para ids textuais existentes no wireframe")
+                .contains("Princípio de pouco esforço obrigatório")
+                .contains("o usuário não quer fazer esforço para entender a comunicação da página");
     }
 
     /** Lê um recurso JSON do classpath e converte para mapa genérico. */

--- a/docs/canonical/arquitetura-etapas.md
+++ b/docs/canonical/arquitetura-etapas.md
@@ -128,6 +128,8 @@ Contrato de saída do wireframe: a raiz deve conter `definicoes` e `pagina`; den
 
 Nos elementos de texto do wireframe, `texto.conteudo` permanece vazio nessa etapa, mas `tamMinimo` e `tamMaximo` devem ser tratados como contrato de espaço textual para a etapa posterior de copy. Esses limites não podem ser arbitrários: precisam seguir a função do texto no espaço da tela, a hierarquia visual e o esforço cognitivo do usuário no mobile. Títulos, chamadas, CTAs, bullets, badges e labels devem reservar faixas menores e escaneáveis; parágrafos, explicações de mecanismo, prova, FAQ e objeções podem reservar faixas maiores quando a função do bloco exigir contexto, sempre evitando parede de texto e preservando avanço para o CTA. O limite mínimo deve representar o menor texto ainda útil para cumprir a função comercial do elemento, e o limite máximo deve representar o maior texto que cabe sem quebrar clareza, hierarquia ou conversão.
 
+A composição do wireframe deve aplicar o princípio de pouco esforço: o usuário não quer ter trabalho para entender a comunicação da página. Por isso, cada seção precisa deixar a ideia principal evidente em leitura rápida, reduzir informações simultâneas, evitar escolhas concorrentes sem necessidade e conduzir de forma natural para a próxima ação/CTA.
+
 A etapa `landing-page-wireframe` expõe a fila interna pelo endpoint:
 
 ```http

--- a/docs/canonical/procedimento-experimento-canon.v1.md
+++ b/docs/canonical/procedimento-experimento-canon.v1.md
@@ -258,3 +258,9 @@ Critérios mínimos de bloqueio:
 
 Mensagem padrão recomendada: `IllegalStateException: Copy inválida: vazamento de metainstrução/texto técnico detectado em <campo>=<valor>`.
 
+### 15.6 Regra mandatória — pouco esforço na copy da landing
+
+A etapa `landing-page-copy` deve aplicar o princípio de pouco esforço em todos os campos textuais finais: o usuário não quer trabalhar para entender a comunicação da página. A copy deve ser clara em leitura rápida, respeitar os limites `tamMinimo`/`tamMaximo` definidos pelo wireframe, evitar explicações longas sem necessidade, não multiplicar escolhas de ação e conduzir naturalmente para o CTA ou próximo passo previsto na estrutura do wireframe.
+
+Essa regra não autoriza criar novos blocos, seções, FAQs, CTAs ou metadados: o wireframe permanece a única fonte de verdade estrutural, e o princípio de pouco esforço deve ser aplicado somente dentro dos textos que o wireframe já solicitou.
+

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -2759,3 +2759,20 @@
   - adicionados testes de contrato garantindo que o schema expõe apenas `bodySections` e que o prompt bloqueia blocos extras;
   - atualizado o JSON de exemplo da etapa copy para remover blocos fora do wireframe e manter somente `bodySections`.
 - impacto esperado: a etapa copy passa a preencher apenas os textos solicitados pelo wireframe, reduzindo divergência entre etapas e evitando contaminação do artefato final com conteúdo inventado.
+
+## 2026-05-31 — Princípio de pouco esforço no wireframe GeraLanding
+- tarefa: reforçar o prompt da etapa `landing-page-wireframe` com o princípio de pouco esforço na comunicação da landing page.
+- causa-raiz/objetivo: garantir que o wireframe seja planejado considerando que o usuário não quer esforço para entender a página, preservando clareza rápida, baixa carga cognitiva e avanço natural para o CTA.
+- correção aplicada:
+  - adicionada regra obrigatória no prompt do wireframe para reduzir esforço de entendimento, evitar excesso de informações simultâneas e limitar caminhos de decisão;
+  - sincronizado o cânone de arquitetura por etapa para registrar o princípio de pouco esforço como regra de composição do wireframe.
+- impacto esperado: as landings geradas devem comunicar a promessa e o próximo passo com mais simplicidade, aumentando a chance de conversão sem sacrificar aderência ao contrato técnico da etapa.
+
+## 2026-05-31 — Princípio de pouco esforço na copy GeraLanding
+- tarefa: reforçar o prompt da etapa `landing-page-copy` com o princípio de pouco esforço na comunicação textual da landing page.
+- causa-raiz/objetivo: complementar a regra já adicionada ao wireframe para garantir que a copy final também preserve clareza rápida, baixa carga cognitiva e avanço natural para o CTA.
+- correção aplicada:
+  - adicionada regra obrigatória no prompt da copy para orientar textos curtos, claros e vendáveis dentro dos elementos já definidos pelo wireframe;
+  - atualizado teste de contrato da etapa copy para validar a presença explícita da regra no prompt;
+  - sincronizado o procedimento canônico de experimento com a regra mandatória de pouco esforço na copy.
+- impacto esperado: a etapa copy deve preencher apenas os textos solicitados pelo wireframe, porém com linguagem mais simples e direta para reduzir esforço de entendimento e favorecer conversão.


### PR DESCRIPTION
### Motivation
- Align wireframe and copy stages to a usability principle so landing content is immediately scannable and drives users naturally to the CTA. 
- Make the rule explicit in prompts and canon so both the planner (wireframe) and writer (copy) apply the same constraint on text length and cognitive load. 
- Ensure the copy stage remains restricted to the wireframe structure while also favoring short, clear texts that reduce user effort.

### Description
- Added the `Princípio de pouco esforço obrigatório` guidance to `prompts/geralanding/landing-page-copy.md` and `prompts/geralanding/landing-page-wireframe.md` to require concise, low-effort text. 
- Updated canonical documentation in `docs/canonical/arquitetura-etapas.md`, `docs/canonical/procedimento-experimento-canon.v1.md`, and `docs/registros/experimentos.md` to record the new rule and its scope. 
- Strengthened the copy contract test by modifying `ai-worker/src/test/java/com/marketinghub/worker/geralanding/copy/request/MontaRequestContractTest.java` to assert the prompt contains the new principle language. 
- Preserved existing structural constraints that limit the copy output to `bodySections` defined by the wireframe and did not change JSON schema shape.

### Testing
- Ran the updated unit test `MontaRequestContractTest` with `mvn -Dtest=MontaRequestContractTest test` and it passed. 
- No additional automated test failures were observed for the modified files in this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c7fafc804832188b88192353693fa)