### PR TITLE
Align landing-page-image-planning schema and prompt to use `images[]`

### DIFF
--- a/ai-worker/src/main/resources/prompts/geralanding/landing-page-image-planning-schema.json
+++ b/ai-worker/src/main/resources/prompts/geralanding/landing-page-image-planning-schema.json
@@ -6,7 +6,7 @@
       "type": "object",
       "additionalProperties": false,
       "properties": {
-        "imagePlan": {
+        "images": {
           "type": "array",
           "minItems": 1,
           "items": {
@@ -22,7 +22,7 @@
           }
         }
       },
-      "required": ["imagePlan"]
+      "required": ["images"]
     }
   },
   "required": ["landingPageImagePlanning"]

--- a/ai-worker/src/main/resources/prompts/geralanding/landing-page-image-planning.md
+++ b/ai-worker/src/main/resources/prompts/geralanding/landing-page-image-planning.md
@@ -7,8 +7,8 @@ Objetivo: ler o wireframe salvo no experimento e gerar um planejamento de prompt
 ## Regras
 - Use como base os elementos de imagem definidos no wireframe (`tag: img`).
 - Não altere estrutura do wireframe nem da copy; apenas planeje imagens.
-- A resposta DEVE ser um objeto com o atributo raiz `imagePlan` (array) e cada item deve possuir `sectionId`, `elementId`, `imagePrompt` e `imageGoal`.
-- É proibido retornar array na raiz ou concatenar múltiplos JSONs; retorne exatamente um único objeto JSON com `imagePlan`.
+- A resposta DEVE ser um objeto com o atributo `images` (array) dentro de `landingPageImagePlanning` e cada item deve possuir `sectionId`, `elementId`, `imagePrompt` e `imageGoal`.
+- É proibido retornar array na raiz ou concatenar múltiplos JSONs; retorne exatamente um único objeto JSON com `landingPageImagePlanning.images`.
 - O prompt deve ser claro para execução posterior no Worker AI, com contexto comercial e visual.
 
 ## Contexto disponível

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -2786,3 +2786,11 @@
   - substituída a fila de respostas do `MockWebServer` por um dispatcher determinístico no teste de hipóteses;
   - mantida a transação necessária no cenário que valida associações JPA, com o isolamento HTTP garantido pelo dispatcher determinístico.
 - impacto esperado: a suíte do Worker AI passa a validar a versão atual do prompt e reduz intermitência nos testes de geração de hipóteses, mantendo o fluxo Dor → Resultado → Mecanismo → Prova → Oferta confiável para produtos vendáveis.
+
+## 2026-05-31 — Schema do Image Planning alinhado ao contador de imagens
+- tarefa: alterar o schema da etapa `landing-page-image-planning` para manter a contagem correta no bloco **Gera imagens**.
+- causa-raiz: o AI Worker passou a gerar `landingPageImagePlanning.imagePlan[]`, enquanto o backend que calcula `/framework-images/summary` conta os itens em `landingPageImagePlanning.images[]`; com isso, planejamentos concluídos eram salvos, mas apareciam com `totalItems = 0`.
+- correção aplicada:
+  - o schema JSON da etapa agora exige `landingPageImagePlanning.images[]`;
+  - o prompt da etapa foi sincronizado para instruir a saída no mesmo caminho consumido pelo backend.
+- impacto esperado: novas execuções do Image Planning serão persistidas no formato já lido pelo Gera imagens, permitindo que o total planejado apareça corretamente antes e durante a geração real das imagens.


### PR DESCRIPTION
### Motivation
- Fix discrepancy between the image planning produced by the AI Worker and the backend counter that expects items under `landingPageImagePlanning.images[]`. 
- Without this alignment, planned image sets were persisted but counted as zero in the `/framework-images/summary` flow. 
- Ensure the prompt contract and schema are consistent so downstream systems correctly recognize planned images. 

### Description
- Renamed the image array property in the JSON schema from `imagePlan` to `images` and updated the required entry to `landingPageImagePlanning.images`. 
- Updated the prompt `landing-page-image-planning.md` to instruct the model to emit `landingPageImagePlanning.images` with items containing `sectionId`, `elementId`, `imagePrompt`, and `imageGoal`. 
- Recorded the change and rationale in `docs/registros/experimentos.md` to document the schema alignment and expected impact. 

### Testing
- Ran the project test suite for the AI worker with `./gradlew :ai-worker:test` and `./gradlew check`, and the tasks completed successfully. 
- Validated the updated JSON schema against the sample output shape to confirm `landingPageImagePlanning.images[]` is accepted by the schema.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c89f42b048321b0fdcd17c10d35af)