### PR TITLE
Add geralanding.imagegeneration backend package and endpoints for landing-page-image-generation

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/imagegeneration/service/BackendImageGenerationService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/imagegeneration/service/BackendImageGenerationService.java
@@ -1,0 +1,343 @@
+package com.marketinghub.geralanding.imagegeneration.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marketinghub.experiment.Experiment;
+import com.marketinghub.experiment.repository.ExperimentRepository;
+import com.marketinghub.geralanding.GeraLandingStageExecution;
+import com.marketinghub.geralanding.GeraLandingStageExecutionRepository;
+import com.marketinghub.geralanding.imagegeneration.service.detailStageExecution.RecordBackendImageGenerationDetalheDto;
+import com.marketinghub.geralanding.imagegeneration.service.listStageExecutions.GeraLandingImageGenerationExecutionSummaryResponse;
+import com.marketinghub.geralanding.imagegeneration.service.pending.RecordImageGenerationExperiment;
+import com.marketinghub.geralanding.imagegeneration.service.pending.RecordImageGenerationHypothesis;
+import com.marketinghub.geralanding.imagegeneration.service.pending.RecordImageGenerationPending;
+import jakarta.persistence.EntityNotFoundException;
+import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+/** Responsável por adaptar consultas de execução para o contrato da etapa image generation. */
+@Service
+public class BackendImageGenerationService {
+
+    private static final Logger log = LoggerFactory.getLogger(BackendImageGenerationService.class);
+    private static final TypeReference<LinkedHashMap<String, Object>> FRAMEWORK_TYPE = new TypeReference<>() {};
+    private static final String STAGE_CODE = "landing-page-image-generation";
+    private static final String STATUS_STARTED = "INICIADO";
+    private static final String STATUS_WAITING_OPENAI_DISPATCH = "AGUARDANDO_RETORNO_OPENAI";
+    private static final String STATUS_COMPLETED = "CONCLUIDO";
+    private static final String STATUS_FAILED = "FALHA";
+    private final ExperimentRepository experimentRepository;
+    private final GeraLandingStageExecutionRepository executionRepository;
+    private final ObjectMapper objectMapper;
+
+    /** Inicializa o serviço com os repositórios necessários para consultar execuções de image generation. */
+    public BackendImageGenerationService(
+            ExperimentRepository experimentRepository,
+            GeraLandingStageExecutionRepository executionRepository,
+            ObjectMapper objectMapper) {
+        this.experimentRepository = experimentRepository;
+        this.executionRepository = executionRepository;
+        this.objectMapper = objectMapper;
+    }
+
+    /** Inicia a execução manual da etapa image generation usando o código canônico da etapa. */
+    @Transactional
+    public GeraLandingImageGenerationStartResponse start(Long experimentId) {
+        return registerInitialExecution(experimentId, STAGE_CODE);
+    }
+
+    /** Registra a execução inicial da etapa convertendo para o DTO local de início. */
+    private GeraLandingImageGenerationStartResponse registerInitialExecution(Long experimentId, String stageCode) {
+        Instant now = Instant.now();
+        var experiment = experimentRepository.findById(experimentId)
+                .orElseThrow(() -> new EntityNotFoundException("Experiment not found: " + experimentId));
+
+        GeraLandingStageExecution execution = GeraLandingStageExecution.builder()
+                .experimentId(experiment.getId())
+                .experiment(experiment)
+                .stageCode(stageCode)
+                .executionRequestedAt(now)
+                .createdAt(now)
+                .promptTemplateId("manual/start")
+                .promptContent("Início manual via interface do experimento.")
+                .status(STATUS_STARTED)
+                .idJob(toDatabaseIdJob(UUID.randomUUID().toString()))
+                .build();
+        GeraLandingStageExecution saved = executionRepository.save(execution);
+        return new GeraLandingImageGenerationStartResponse(fromDatabaseIdJob(saved.getIdJob()), saved.getStatus());
+    }
+
+    /** Lista execuções da etapa convertendo para o DTO local da etapa. */
+    @Transactional(readOnly = true)
+    public List<GeraLandingImageGenerationExecutionSummaryResponse> listExperimentStageExecutions(Long experimentId, String stageCode, boolean includeCompleted) {
+        List<GeraLandingStageExecution> executions = includeCompleted
+                ? executionRepository.findTop20ByExperimentIdAndStageCodeOrderByExecutionRequestedAtDesc(experimentId, stageCode)
+                : executionRepository.findTop20ByExperimentIdAndStageCodeAndStatusNotOrderByExecutionRequestedAtDesc(
+                        experimentId,
+                        stageCode,
+                        STATUS_COMPLETED);
+        return executions.stream()
+                .map(this::toSummaryResponse)
+                .toList();
+    }
+
+    /** Lista os jobs iniciados da etapa image generation para processamento independente de experimento. */
+    @Transactional(readOnly = true)
+    public List<RecordImageGenerationPending> listPending(String stageCode) {
+        return executionRepository.findTop20ByStageCodeAndStatusOrderByExecutionRequestedAtAsc(stageCode, STATUS_STARTED)
+                .stream()
+                .map(execution -> new RecordImageGenerationPending(
+                        execution.getExperimentId(),
+                        fromDatabaseIdJob(execution.getIdJob()),
+                        execution.getStageCode(),
+                        toPendingExperiment(execution.getExperiment()),
+                        toPendingHypothesis(execution.getExperiment())))
+                .toList();
+    }
+
+    /** Marca a execução como aguardando retorno da OpenAI após receber prompt, schema e request cru despachados. */
+    @Transactional
+    public void markWaitingOpenAiDispatch(
+            String idJob,
+            String prompt,
+            String promptMarkdownContent,
+            String schemaJson,
+            String requestBodyJson,
+            String openAiJobId) {
+        GeraLandingStageExecution execution = executionRepository
+                .findTopByIdJobOrderByExecutionRequestedAtDesc(toDatabaseIdJob(idJob))
+                .orElseThrow(() -> new EntityNotFoundException(
+                        "GeraLanding execution not found for idJob: " + idJob
+                ));
+
+        execution.setPrompt(prompt);
+        execution.setPromptMarkdownContent(resolvePromptMarkdownContent(prompt, promptMarkdownContent));
+        execution.setSchemaJson(schemaJson);
+        execution.setOpenAiRequestBody(requestBodyJson);
+        execution.setOpenAiJobId(openAiJobId);
+        execution.setProcessingStartedAt(Instant.now());
+        execution.setStatus(STATUS_WAITING_OPENAI_DISPATCH);
+
+        executionRepository.save(execution);
+    }
+
+    /** Resolve o markdown bruto do prompt mantendo compatibilidade com clientes antigos que enviavam esse conteúdo em prompt. */
+    private String resolvePromptMarkdownContent(String prompt, String promptMarkdownContent) {
+        if (promptMarkdownContent != null && !promptMarkdownContent.isBlank()) {
+            return promptMarkdownContent;
+        }
+        return prompt;
+    }
+
+    /** Conclui ou falha a execução da etapa image generation com a resposta devolvida pelo Worker AI. */
+    @Transactional
+    public void markCompletedFromResponse(
+            String idJob,
+            Long experimentId,
+            String stageCode,
+            String modelResponse,
+            Integer inputTokens,
+            Integer outputTokens,
+            BigDecimal costUsd,
+            String openAiJobId,
+            String errorMessage,
+            String errorDetail) {
+        GeraLandingStageExecution execution = executionRepository
+                .findTopByIdJobOrderByExecutionRequestedAtDesc(toDatabaseIdJob(idJob))
+                .or(() -> executionRepository.findTopByExperimentIdAndStageCodeOrderByExecutionRequestedAtDesc(
+                        experimentId,
+                        stageCode))
+                .orElseThrow(() -> new EntityNotFoundException("GeraLanding execution not found for idJob: " + idJob));
+        try {
+            execution.setModelResponse(modelResponse);
+            if (StringUtils.hasText(openAiJobId)) {
+                execution.setOpenAiJobId(openAiJobId);
+            }
+            execution.setInputTokens(inputTokens);
+            execution.setOutputTokens(outputTokens);
+            execution.setCostUsd(costUsd);
+            String normalizedErrorDetail = StringUtils.hasText(errorDetail) ? errorDetail.trim() : null;
+            String normalizedErrorMessage = normalizeErrorMessage(errorMessage, normalizedErrorDetail);
+            execution.setErrorMessage(normalizedErrorMessage);
+            execution.setErrorDetail(normalizedErrorDetail);
+            execution.setCompletedAt(Instant.now());
+            execution.setStatus(normalizedErrorMessage != null ? STATUS_FAILED : STATUS_COMPLETED);
+
+            executionRepository.save(execution);
+        } catch (RuntimeException ex) {
+            log.error(
+                    "Erro ao concluir resposta image generation (idJob={}, experimentId={}, stageCode={}, openAiJobId={}, modelResponseLength={}, errorMessage={})",
+                    idJob,
+                    experimentId,
+                    stageCode,
+                    openAiJobId,
+                    modelResponse != null ? modelResponse.length() : 0,
+                    errorMessage,
+                    ex);
+            throw ex;
+        }
+    }
+
+    /** Normaliza a mensagem de erro e garante status FALHA quando o callback traz apenas detalhe técnico. */
+    private String normalizeErrorMessage(String errorMessage, String normalizedErrorDetail) {
+        if (StringUtils.hasText(errorMessage)) {
+            return errorMessage.trim();
+        }
+        if (StringUtils.hasText(normalizedErrorDetail)) {
+            return "Falha ao processar etapa image generation";
+        }
+        return null;
+    }
+
+    /** Converte o experimento da execução para os dados expostos na fila pending. */
+    private RecordImageGenerationExperiment toPendingExperiment(Experiment experiment) {
+        if (experiment == null) {
+            return null;
+        }
+        return new RecordImageGenerationExperiment(
+                experiment.getId(),
+                experiment.getName(),
+                experiment.getHypothesis(),
+                enumValueToText(experiment.getStatus()),
+                enumValueToText(experiment.getStage()),
+                experiment.getCreativeTextPrompt(),
+                experiment.getCreativeImagePrompt(),
+                resolveJsonArtifact(experiment.getId(), "campaignAngle", experiment.getCampaignAngle()),
+                resolveJsonArtifact(experiment.getId(), "adCopy", experiment.getAdCopy()),
+                resolveJsonArtifact(experiment.getId(), "adImageBriefing", experiment.getAdImageBriefing()),
+                resolveJsonArtifact(experiment.getId(), "landingPageCopy", experiment.getLandingPageCopy()),
+                resolveJsonArtifact(experiment.getId(), "landingPageWireframe", experiment.getLandingPageWireframe()),
+                resolveJsonArtifact(experiment.getId(), "landingPageImagePlanning", experiment.getLandingPageImagePlanning()),
+                resolveJsonArtifact(experiment.getId(), "landingPageDesignPreset", experiment.getLandingPageDesignPreset()),
+                resolveJsonArtifact(experiment.getId(), "landingPageDeliverables", experiment.getLandingPageDeliverables()),
+                experiment.getHtmlGeraLanding());
+    }
+
+    /** Preserva artefatos JSON como objetos estruturados na fila pending, mantendo textos não JSON intactos. */
+    private Object resolveJsonArtifact(Long experimentId, String fieldName, String rawValue) {
+        if (rawValue == null || rawValue.isBlank()) {
+            return rawValue;
+        }
+        String trimmed = rawValue.trim();
+        if (!trimmed.startsWith("{") && !trimmed.startsWith("[")) {
+            return rawValue;
+        }
+        try {
+            return objectMapper.readValue(trimmed, Object.class);
+        } catch (JsonProcessingException ex) {
+            log.warn(
+                    "Falha ao ler artefato JSON no pending image generation; mantendo texto bruto. experimentId={} fieldName={}",
+                    experimentId,
+                    fieldName,
+                    ex);
+            return rawValue;
+        }
+    }
+
+    /** Converte a hipótese associada ao experimento para o framework exposto na fila pending. */
+    private RecordImageGenerationHypothesis toPendingHypothesis(Experiment experiment) {
+        if (experiment == null) {
+            return null;
+        }
+        return new RecordImageGenerationHypothesis(
+                experiment.getHypothesisRefIdForPending(),
+                experiment.getHypothesisRefTitleForPending(),
+                resolveFramework(experiment.getId(), experiment.getHypothesisFrameworkJsonForPending()));
+    }
+
+    /** Resolve o JSON do framework da hipótese como objeto estruturado com todos os blocos canônicos. */
+    private Map<String, Object> resolveFramework(Long experimentId, String frameworkJson) {
+        Map<String, Object> framework = new LinkedHashMap<>();
+        if (frameworkJson != null && !frameworkJson.isBlank()) {
+            try {
+                framework.putAll(objectMapper.readValue(frameworkJson, FRAMEWORK_TYPE));
+            } catch (JsonProcessingException ex) {
+                log.warn("Falha ao ler framework da hipótese no pending image generation. experimentId={}", experimentId, ex);
+            }
+        }
+        ensureFrameworkSections(framework);
+        return framework;
+    }
+
+    /** Garante presença dos itens canônicos Dor, Resultado, Mecanismo, Prova, Oferta e checklist. */
+    private void ensureFrameworkSections(Map<String, Object> framework) {
+        framework.putIfAbsent("pain", new LinkedHashMap<String, Object>());
+        framework.putIfAbsent("result", new LinkedHashMap<String, Object>());
+        framework.putIfAbsent("mechanism", new LinkedHashMap<String, Object>());
+        framework.putIfAbsent("proof", new LinkedHashMap<String, Object>());
+        framework.putIfAbsent("offer", new LinkedHashMap<String, Object>());
+        framework.putIfAbsent("checklist", new LinkedHashMap<String, Object>());
+    }
+
+    /** Converte um enum de experimento para texto sem acoplar o serviço às classes concretas do enum. */
+    private String enumValueToText(Object value) {
+        return value != null ? String.valueOf(value) : null;
+    }
+
+    @Transactional(readOnly = true)
+    /** Retorna o detalhe da execução convertido para o DTO local da etapa. */
+    public RecordBackendImageGenerationDetalheDto getStageExecutionDetail(Long experimentId, String idJob) {
+        GeraLandingStageExecution execution = executionRepository
+                .findTopByExperimentIdAndIdJobOrderByExecutionRequestedAtDesc(experimentId, toDatabaseIdJob(idJob))
+                .orElseThrow(() -> new EntityNotFoundException("GeraLanding execution not found for idJob: " + idJob));
+        return toDetailResponse(execution);
+    }
+
+    /** Converte o resumo transversal para o resumo local da etapa. */
+    private GeraLandingImageGenerationExecutionSummaryResponse toSummaryResponse(GeraLandingStageExecution execution) {
+        return new GeraLandingImageGenerationExecutionSummaryResponse(
+                fromDatabaseIdJob(execution.getIdJob()),
+                execution.getStatus(),
+                execution.getExecutionRequestedAt(),
+                execution.getCostUsd());
+    }
+
+    /** Converte o detalhe transversal para o detalhe local da etapa. */
+    private RecordBackendImageGenerationDetalheDto toDetailResponse(GeraLandingStageExecution execution) {
+        return new RecordBackendImageGenerationDetalheDto(
+                fromDatabaseIdJob(execution.getIdJob()),
+                execution.getExperimentId(),
+                execution.getStageCode(),
+                execution.getExecutionRequestedAt(),
+                execution.getCreatedAt(),
+                execution.getProcessingStartedAt(),
+                execution.getCompletedAt(),
+                execution.getPromptTemplateId(),
+                execution.getPromptContent(),
+                execution.getPrompt(),
+                execution.getOpenAiRequestBody(),
+                execution.getOpenAiModel(),
+                execution.getSchemaJson(),
+                execution.getPromptMarkdownContent(),
+                execution.getStatus(),
+                execution.getOpenAiJobId(),
+                execution.getModelResponse(),
+                execution.getProvisionalHtml(),
+                execution.getErrorMessage(),
+                execution.getErrorDetail(),
+                execution.getInputTokens(),
+                execution.getOutputTokens(),
+                execution.getCostUsd());
+    }
+
+    /** Converte o id_job textual para o formato persistido em banco. */
+    private byte[] toDatabaseIdJob(String idJob) {
+        return idJob.getBytes(StandardCharsets.UTF_8);
+    }
+
+    /** Converte o id_job persistido em banco para texto. */
+    private String fromDatabaseIdJob(byte[] idJob) {
+        return new String(idJob, StandardCharsets.UTF_8);
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/imagegeneration/service/GeraLandingImageGenerationStartResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/imagegeneration/service/GeraLandingImageGenerationStartResponse.java
@@ -1,0 +1,4 @@
+package com.marketinghub.geralanding.imagegeneration.service;
+
+/** Representa a resposta de início da etapa de image generation do GeraLanding. */
+public record GeraLandingImageGenerationStartResponse(String idJob, String status) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/imagegeneration/service/detailStageExecution/RecordBackendImageGenerationDetalheDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/imagegeneration/service/detailStageExecution/RecordBackendImageGenerationDetalheDto.java
@@ -1,0 +1,31 @@
+package com.marketinghub.geralanding.imagegeneration.service.detailStageExecution;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+
+/** Responsável por representar os detalhes de uma execução da etapa image generation. */
+public record RecordBackendImageGenerationDetalheDto(
+        String idJob,
+        Long experimentId,
+        String stageCode,
+        Instant executionRequestedAt,
+        Instant createdAt,
+        Instant processingStartedAt,
+        Instant completedAt,
+        String promptTemplateId,
+        String promptContent,
+        String prompt,
+        String openAiRequestBody,
+        String openAiModel,
+        String schemaJson,
+        String promptMarkdownContent,
+        String status,
+        String openAiJobId,
+        String modelResponse,
+        String provisionalHtml,
+        String errorMessage,
+        String errorDetail,
+        Integer inputTokens,
+        Integer outputTokens,
+        BigDecimal costUsd) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/imagegeneration/service/listStageExecutions/GeraLandingImageGenerationExecutionSummaryResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/imagegeneration/service/listStageExecutions/GeraLandingImageGenerationExecutionSummaryResponse.java
@@ -1,0 +1,12 @@
+package com.marketinghub.geralanding.imagegeneration.service.listStageExecutions;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+
+/** Responsável por representar o resumo de uma execução da etapa image generation. */
+public record GeraLandingImageGenerationExecutionSummaryResponse(
+        String idJob,
+        String status,
+        Instant executionRequestedAt,
+        BigDecimal costUsd) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/imagegeneration/service/pending/RecordImageGenerationExperiment.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/imagegeneration/service/pending/RecordImageGenerationExperiment.java
@@ -1,0 +1,22 @@
+package com.marketinghub.geralanding.imagegeneration.service.pending;
+
+/** Representa os dados do experimento expostos na fila interna da etapa image generation. */
+public record RecordImageGenerationExperiment(
+        Long id,
+        String name,
+        String hypothesis,
+        String status,
+        String stage,
+        String creativeTextPrompt,
+        String creativeImagePrompt,
+        Object campaignAngle,
+        Object adCopy,
+        Object adImageBriefing,
+        Object landingPageCopy,
+        Object landingPageWireframe,
+        Object landingPageImagePlanning,
+        Object landingPageDesignPreset,
+        Object landingPageDeliverables,
+        String htmlGeraLanding
+) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/imagegeneration/service/pending/RecordImageGenerationHypothesis.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/imagegeneration/service/pending/RecordImageGenerationHypothesis.java
@@ -1,0 +1,12 @@
+package com.marketinghub.geralanding.imagegeneration.service.pending;
+
+import java.util.Map;
+import java.util.UUID;
+
+/** Representa a hipótese e o framework usados na fila interna da etapa image generation. */
+public record RecordImageGenerationHypothesis(
+        UUID id,
+        String title,
+        Map<String, Object> framework
+) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/imagegeneration/service/pending/RecordImageGenerationPending.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/imagegeneration/service/pending/RecordImageGenerationPending.java
@@ -1,0 +1,11 @@
+package com.marketinghub.geralanding.imagegeneration.service.pending;
+
+/** Representa o item mínimo de pendência da etapa image generation consumido pelo Worker AI. */
+public record RecordImageGenerationPending(
+        Long experimentId,
+        String jobid,
+        String stageCode,
+        RecordImageGenerationExperiment experiment,
+        RecordImageGenerationHypothesis hypothesis
+) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/imagegeneration/service/recebePrompt/RecebePromptRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/imagegeneration/service/recebePrompt/RecebePromptRequest.java
@@ -1,0 +1,12 @@
+package com.marketinghub.geralanding.imagegeneration.service.recebePrompt;
+
+import com.fasterxml.jackson.annotation.JsonAlias;
+import jakarta.validation.constraints.NotBlank;
+
+/** Representa o payload interno com prompt, schema e request cru enviados ao provedor de IA. */
+public record RecebePromptRequest(
+        @NotBlank String prompt,
+        String promptMarkdownContent,
+        @NotBlank String schemaJson,
+        @NotBlank @JsonAlias("openAiRequestBody") String requestBodyJson,
+        @NotBlank String jobidopenai) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/imagegeneration/service/recebeResposta/RecebeRespostaRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/imagegeneration/service/recebeResposta/RecebeRespostaRequest.java
@@ -1,0 +1,17 @@
+package com.marketinghub.geralanding.imagegeneration.service.recebeResposta;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.math.BigDecimal;
+
+/** Representa o payload enviado pelo Worker AI para concluir ou falhar a resposta da etapa image generation. */
+public record RecebeRespostaRequest(
+        @NotNull Long experimentId,
+        @NotBlank String stageCode,
+        String modelResponse,
+        Integer inputTokens,
+        Integer outputTokens,
+        BigDecimal costUsd,
+        String openAiJobId,
+        String errorMessage,
+        String errorDetail) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/imagegeneration/web/BackendImageGenerationController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/imagegeneration/web/BackendImageGenerationController.java
@@ -1,0 +1,118 @@
+package com.marketinghub.geralanding.imagegeneration.web;
+
+import com.marketinghub.geralanding.imagegeneration.service.BackendImageGenerationService;
+import com.marketinghub.geralanding.imagegeneration.service.listStageExecutions.GeraLandingImageGenerationExecutionSummaryResponse;
+import com.marketinghub.geralanding.imagegeneration.service.GeraLandingImageGenerationStartResponse;
+import com.marketinghub.geralanding.imagegeneration.service.detailStageExecution.RecordBackendImageGenerationDetalheDto;
+import com.marketinghub.geralanding.imagegeneration.service.recebePrompt.RecebePromptRequest;
+import com.marketinghub.geralanding.imagegeneration.service.recebeResposta.RecebeRespostaRequest;
+import com.marketinghub.geralanding.imagegeneration.service.pending.RecordImageGenerationPending;
+import jakarta.validation.Valid;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/** Responsável por expor os endpoints de backend da etapa landing-page-image-generation no GeraLanding. */
+@RestController
+@RequestMapping("/api")
+public class BackendImageGenerationController {
+  private static final Logger LOGGER = LoggerFactory.getLogger(BackendImageGenerationController.class);
+  private static final String STAGE_CODE = "landing-page-image-generation";
+
+  private final BackendImageGenerationService executionService;
+
+  /** Inicializa o controller com o serviço backend da etapa image generation. */
+  public BackendImageGenerationController(BackendImageGenerationService executionService) {
+    this.executionService = executionService;
+  }
+
+  /** Registra uma execução inicial da etapa landing-page-image-generation. */
+  @PostMapping("/experiments/{experimentId}/geralanding/image-generation/start")
+  public ResponseEntity<GeraLandingImageGenerationStartResponse> start(@PathVariable Long experimentId) {
+    GeraLandingImageGenerationStartResponse response = executionService.start(experimentId);
+    return ResponseEntity.accepted().body(response);
+  }
+
+  /** Lista as execuções da etapa para o experimento. */
+  @GetMapping("/experiments/{experimentId}/geralanding/image-generation/stage-executions")
+  public ResponseEntity<List<GeraLandingImageGenerationExecutionSummaryResponse>> listStageExecutions(
+      @PathVariable Long experimentId,
+      @RequestParam(defaultValue = "true") boolean includeCompleted) {
+    List<GeraLandingImageGenerationExecutionSummaryResponse> response =
+        executionService.listExperimentStageExecutions(experimentId, STAGE_CODE, includeCompleted);
+    return ResponseEntity.ok(response);
+  }
+
+  /** Lista os jobs pendentes iniciados da etapa image generation para processamento pelo Worker AI. */
+  @GetMapping("/internal/geralanding/image-generation/stage-executions/pending")
+  public List<RecordImageGenerationPending> pending() {
+    return executionService.listPending(STAGE_CODE);
+  }
+
+  /** Recebe prompt, schema e request cru enviados para IA e marca a execução aguardando retorno da OpenAI. */
+  @PostMapping("/internal/geralanding/image-generation/stage-executions/{idJob}/recebe-prompt")
+  public ResponseEntity<Void> recebePrompt(
+      @PathVariable String idJob, @Valid @RequestBody RecebePromptRequest payload) {
+    LOGGER.info(
+        "[GeraLanding][ImageGeneration] Recebido request enviado para IA idJob={} jobidopenai={} promptLength={} promptMarkdownLength={} schemaLength={} requestBodyLength={}",
+        idJob,
+        payload.jobidopenai(),
+        payload.prompt().length(),
+        payload.promptMarkdownContent() != null ? payload.promptMarkdownContent().length() : 0,
+        payload.schemaJson().length(),
+        payload.requestBodyJson().length());
+    executionService.markWaitingOpenAiDispatch(
+        idJob,
+        payload.prompt(),
+        payload.promptMarkdownContent(),
+        payload.schemaJson(),
+        payload.requestBodyJson(),
+        payload.jobidopenai());
+    return ResponseEntity.accepted().build();
+  }
+
+  /** Recebe a resposta da IA para a etapa image generation e conclui a execução do job. */
+  @PostMapping("/internal/geralanding/image-generation/stage-executions/{idJob}/recebe-resposta")
+  public ResponseEntity<Void> recebeResposta(
+      @PathVariable String idJob, @Valid @RequestBody RecebeRespostaRequest payload) {
+    LOGGER.info(
+        "[GeraLanding][ImageGeneration] Recebida resposta da IA idJob={} experimentId={} stageCode={} openAiJobId={} inputTokens={} outputTokens={} costUsd={} hasError={}",
+        idJob,
+        payload.experimentId(),
+        payload.stageCode(),
+        payload.openAiJobId(),
+        payload.inputTokens(),
+        payload.outputTokens(),
+        payload.costUsd(),
+        payload.errorMessage() != null && !payload.errorMessage().isBlank());
+    executionService.markCompletedFromResponse(
+        idJob,
+        payload.experimentId(),
+        payload.stageCode(),
+        payload.modelResponse(),
+        payload.inputTokens(),
+        payload.outputTokens(),
+        payload.costUsd(),
+        payload.openAiJobId(),
+        payload.errorMessage(),
+        payload.errorDetail());
+    return ResponseEntity.accepted().build();
+  }
+
+  /** Retorna os detalhes de uma execução específica da etapa. */
+  @GetMapping("/experiments/{experimentId}/geralanding/image-generation/stage-executions/{idJob}")
+  public ResponseEntity<RecordBackendImageGenerationDetalheDto> detailStageExecution(
+      @PathVariable Long experimentId, @PathVariable String idJob) {
+    RecordBackendImageGenerationDetalheDto response =
+        executionService.getStageExecutionDetail(experimentId, idJob);
+    return ResponseEntity.ok(response);
+  }
+}

--- a/backend/ads-service/src/test/java/com/marketinghub/geralanding/imagegeneration/service/BackendImageGenerationServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/geralanding/imagegeneration/service/BackendImageGenerationServiceTest.java
@@ -1,0 +1,303 @@
+package com.marketinghub.geralanding.imagegeneration.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marketinghub.experiment.Experiment;
+import com.marketinghub.experiment.repository.ExperimentRepository;
+import com.marketinghub.geralanding.GeraLandingStageExecution;
+import com.marketinghub.geralanding.GeraLandingStageExecutionRepository;
+import com.marketinghub.geralanding.imagegeneration.service.pending.RecordImageGenerationPending;
+import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+/** Valida as consultas de execução específicas da etapa image generation. */
+class BackendImageGenerationServiceTest {
+
+    /** Deve registrar o início usando o código canônico da etapa image generation. */
+    @Test
+    void startShouldRegisterInitialExecutionForImageGenerationStage() {
+        ExperimentRepository experimentRepository = mock(ExperimentRepository.class);
+        GeraLandingStageExecutionRepository executionRepository = mock(GeraLandingStageExecutionRepository.class);
+        BackendImageGenerationService service =
+                new BackendImageGenerationService(experimentRepository, executionRepository, new ObjectMapper());
+        Experiment experiment = mock(Experiment.class);
+        when(experiment.getId()).thenReturn(91L);
+        when(experimentRepository.findById(91L)).thenReturn(Optional.of(experiment));
+        when(executionRepository.save(any(GeraLandingStageExecution.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        GeraLandingImageGenerationStartResponse response = service.start(91L);
+
+        assertNotNull(response.idJob());
+        assertEquals("INICIADO", response.status());
+        verify(experimentRepository).findById(91L);
+        verify(executionRepository).save(argThat(execution ->
+                execution.getExperimentId().equals(91L)
+                        && execution.getExperiment() == experiment
+                        && execution.getStageCode().equals("landing-page-image-generation")
+                        && execution.getStatus().equals("INICIADO")
+                        && execution.getPromptTemplateId().equals("manual/start")
+                        && execution.getIdJob() != null));
+    }
+
+    /** Deve buscar somente jobs iniciados da etapa image generation para o endpoint interno pending. */
+    @Test
+    void listPendingShouldQueryStartedJobsForStage() {
+        ExperimentRepository experimentRepository = mock(ExperimentRepository.class);
+        GeraLandingStageExecutionRepository executionRepository = mock(GeraLandingStageExecutionRepository.class);
+        BackendImageGenerationService service =
+                new BackendImageGenerationService(experimentRepository, executionRepository, new ObjectMapper());
+        Experiment experiment = mock(Experiment.class);
+        when(experiment.getId()).thenReturn(77L);
+        when(experiment.getName()).thenReturn("Experimento Image Generation");
+        when(experiment.getHypothesis()).thenReturn("Hipótese de valor");
+        when(experiment.getCreativeTextPrompt()).thenReturn("Prompt texto");
+        when(experiment.getCreativeImagePrompt()).thenReturn("Prompt imagem");
+        when(experiment.getCampaignAngle()).thenReturn("{\"campaignAngle\":{\"singleMindedPromise\":\"Promessa clara\"}}");
+        when(experiment.getAdCopy()).thenReturn("{\"adCopy\":{\"headline\":\"Headline\"}}");
+        when(experiment.getAdImageBriefing()).thenReturn("Briefing imagem");
+        when(experiment.getLandingPageCopy()).thenReturn("{\"landingPageCopy\":{\"hero\":{\"headline\":\"Hero\"}}}");
+        when(experiment.getLandingPageWireframe()).thenReturn("{\"landingPageWireframe\":{\"sectionOrder\":[\"hero\"]}}");
+        when(experiment.getLandingPageImagePlanning()).thenReturn("Planejamento imagem");
+        when(experiment.getLandingPageDesignPreset()).thenReturn("Preset design");
+        when(experiment.getLandingPageDeliverables()).thenReturn("Entregáveis landing");
+        when(experiment.getHtmlGeraLanding()).thenReturn("<html>GeraLanding</html>");
+        UUID hypothesisId = UUID.fromString("11111111-1111-1111-1111-111111111111");
+        when(experiment.getHypothesisRefIdForPending()).thenReturn(hypothesisId);
+        when(experiment.getHypothesisRefTitleForPending()).thenReturn("Hipótese Framework");
+        when(experiment.getHypothesisFrameworkJsonForPending()).thenReturn("""
+                {
+                  "version": "v1",
+                  "pain": {"surface": "Dor superficial", "root": "Dor raiz"},
+                  "result": {"desiredResult": "Resultado desejado"},
+                  "mechanism": {"core": "Mecanismo central"},
+                  "proof": {"type": "Prova"},
+                  "offer": {"name": "Oferta"},
+                  "checklist": {"painReady": true}
+                }
+                """);
+        GeraLandingStageExecution execution = GeraLandingStageExecution.builder()
+                .experimentId(77L)
+                .experiment(experiment)
+                .stageCode("landing-page-image-generation")
+                .executionRequestedAt(Instant.parse("2026-05-28T10:00:00Z"))
+                .createdAt(Instant.parse("2026-05-28T10:00:00Z"))
+                .status("INICIADO")
+                .idJob("job-77".getBytes(StandardCharsets.UTF_8))
+                .build();
+        when(executionRepository.findTop20ByStageCodeAndStatusOrderByExecutionRequestedAtAsc(
+                "landing-page-image-generation", "INICIADO"))
+                .thenReturn(List.of(execution));
+
+        List<RecordImageGenerationPending> response = service.listPending("landing-page-image-generation");
+
+        assertEquals(1, response.size());
+        assertEquals(77L, response.get(0).experimentId());
+        assertEquals("job-77", response.get(0).jobid());
+        assertEquals("landing-page-image-generation", response.get(0).stageCode());
+        assertNotNull(response.get(0).experiment());
+        assertEquals(77L, response.get(0).experiment().id());
+        assertEquals("Experimento Image Generation", response.get(0).experiment().name());
+        assertEquals("Hipótese de valor", response.get(0).experiment().hypothesis());
+        assertEquals("Prompt texto", response.get(0).experiment().creativeTextPrompt());
+        assertEquals("Prompt imagem", response.get(0).experiment().creativeImagePrompt());
+        Map<?, ?> campaignAngle = (Map<?, ?>) response.get(0).experiment().campaignAngle();
+        assertEquals("Promessa clara", ((Map<?, ?>) campaignAngle.get("campaignAngle")).get("singleMindedPromise"));
+        Map<?, ?> adCopy = (Map<?, ?>) response.get(0).experiment().adCopy();
+        assertEquals("Headline", ((Map<?, ?>) adCopy.get("adCopy")).get("headline"));
+        assertEquals("Briefing imagem", response.get(0).experiment().adImageBriefing());
+        Map<?, ?> landingPageCopy = (Map<?, ?>) response.get(0).experiment().landingPageCopy();
+        assertEquals(
+                "Hero",
+                ((Map<?, ?>) ((Map<?, ?>) landingPageCopy.get("landingPageCopy")).get("hero")).get("headline"));
+        Map<?, ?> landingPageWireframe = (Map<?, ?>) response.get(0).experiment().landingPageWireframe();
+        assertEquals(List.of("hero"), ((Map<?, ?>) landingPageWireframe.get("landingPageWireframe")).get("sectionOrder"));
+        assertEquals("Planejamento imagem", response.get(0).experiment().landingPageImagePlanning());
+        assertEquals("Preset design", response.get(0).experiment().landingPageDesignPreset());
+        assertEquals("Entregáveis landing", response.get(0).experiment().landingPageDeliverables());
+        assertEquals("<html>GeraLanding</html>", response.get(0).experiment().htmlGeraLanding());
+        assertNotNull(response.get(0).hypothesis());
+        assertEquals(hypothesisId, response.get(0).hypothesis().id());
+        assertEquals("Hipótese Framework", response.get(0).hypothesis().title());
+        assertEquals("v1", response.get(0).hypothesis().framework().get("version"));
+        assertEquals("Dor superficial", ((Map<?, ?>) response.get(0).hypothesis().framework().get("pain")).get("surface"));
+        assertEquals("Resultado desejado", ((Map<?, ?>) response.get(0).hypothesis().framework().get("result")).get("desiredResult"));
+        assertTrue(response.get(0).hypothesis().framework().containsKey("mechanism"));
+        assertTrue(response.get(0).hypothesis().framework().containsKey("proof"));
+        assertTrue(response.get(0).hypothesis().framework().containsKey("offer"));
+        assertTrue(response.get(0).hypothesis().framework().containsKey("checklist"));
+    }
+
+    /** Deve persistir prompt, job OpenAI e status de espera quando o Worker AI informa o despacho. */
+    @Test
+    void markWaitingOpenAiDispatchShouldPersistPromptOpenAiJobAndWaitingStatus() {
+        ExperimentRepository experimentRepository = mock(ExperimentRepository.class);
+        GeraLandingStageExecutionRepository executionRepository = mock(GeraLandingStageExecutionRepository.class);
+        BackendImageGenerationService service =
+                new BackendImageGenerationService(experimentRepository, executionRepository, new ObjectMapper());
+        GeraLandingStageExecution execution = GeraLandingStageExecution.builder()
+                .idJob("job-ia-1".getBytes(StandardCharsets.UTF_8))
+                .executionRequestedAt(Instant.parse("2026-05-28T10:00:00Z"))
+                .status("INICIADO")
+                .build();
+        when(executionRepository.findTopByIdJobOrderByExecutionRequestedAtDesc(any(byte[].class)))
+                .thenReturn(Optional.of(execution));
+
+        service.markWaitingOpenAiDispatch(
+                "job-ia-1",
+                "Prompt para IA",
+                "# Prompt markdown bruto",
+                "{\"type\":\"object\"}",
+                "{\"model\":\"gpt-test\"}",
+                "openai-job-1");
+
+        assertEquals("Prompt para IA", execution.getPrompt());
+        assertEquals("# Prompt markdown bruto", execution.getPromptMarkdownContent());
+        assertEquals("{\"type\":\"object\"}", execution.getSchemaJson());
+        assertEquals("{\"model\":\"gpt-test\"}", execution.getOpenAiRequestBody());
+        assertEquals("openai-job-1", execution.getOpenAiJobId());
+        assertNotNull(execution.getProcessingStartedAt());
+        assertEquals("AGUARDANDO_RETORNO_OPENAI", execution.getStatus());
+        verify(executionRepository).save(execution);
+    }
+
+    /** Deve concluir a execução e manter a resposta da geração de imagens na auditoria da execução. */
+    @Test
+    void markCompletedFromResponseShouldPersistExecutionAuditOnly() {
+        ExperimentRepository experimentRepository = mock(ExperimentRepository.class);
+        GeraLandingStageExecutionRepository executionRepository = mock(GeraLandingStageExecutionRepository.class);
+        BackendImageGenerationService service =
+                new BackendImageGenerationService(experimentRepository, executionRepository, new ObjectMapper());
+        Experiment experiment = mock(Experiment.class);
+        GeraLandingStageExecution execution = GeraLandingStageExecution.builder()
+                .experimentId(88L)
+                .experiment(experiment)
+                .stageCode("landing-page-image-generation")
+                .idJob("job-ia-1".getBytes(StandardCharsets.UTF_8))
+                .status("AGUARDANDO_RETORNO_OPENAI")
+                .build();
+        String modelResponse = "{\"landingPageWireframe\":{\"sectionOrder\":[\"hero\"]}}";
+        when(executionRepository.findTopByIdJobOrderByExecutionRequestedAtDesc(any(byte[].class)))
+                .thenReturn(Optional.of(execution));
+
+        service.markCompletedFromResponse(
+                "job-ia-1",
+                88L,
+                "landing-page-image-generation",
+                modelResponse,
+                321,
+                123,
+                new BigDecimal("0.045600"),
+                "openai-job-final",
+                null,
+                null);
+
+        assertEquals(modelResponse, execution.getModelResponse());
+        assertEquals("openai-job-final", execution.getOpenAiJobId());
+        assertEquals(321, execution.getInputTokens());
+        assertEquals(123, execution.getOutputTokens());
+        assertEquals(new BigDecimal("0.045600"), execution.getCostUsd());
+        assertNotNull(execution.getCompletedAt());
+        assertEquals("CONCLUIDO", execution.getStatus());
+        verify(executionRepository).save(execution);
+        verify(experiment, never()).setLandingPageWireframe(any());
+        verify(experimentRepository, never()).save(experiment);
+        verify(experimentRepository, never()).findById(88L);
+    }
+
+    /** Deve marcar a execução como falha sem gravar artefato quando o Worker AI retorna erro. */
+    @Test
+    void markCompletedFromResponseShouldPersistFailureWithoutExperimentArtifact() {
+        ExperimentRepository experimentRepository = mock(ExperimentRepository.class);
+        GeraLandingStageExecutionRepository executionRepository = mock(GeraLandingStageExecutionRepository.class);
+        BackendImageGenerationService service =
+                new BackendImageGenerationService(experimentRepository, executionRepository, new ObjectMapper());
+        Experiment experiment = mock(Experiment.class);
+        GeraLandingStageExecution execution = GeraLandingStageExecution.builder()
+                .experimentId(88L)
+                .experiment(experiment)
+                .stageCode("landing-page-image-generation")
+                .idJob("job-ia-erro".getBytes(StandardCharsets.UTF_8))
+                .status("AGUARDANDO_RETORNO_OPENAI")
+                .build();
+        when(executionRepository.findTopByIdJobOrderByExecutionRequestedAtDesc(any(byte[].class)))
+                .thenReturn(Optional.of(execution));
+
+        service.markCompletedFromResponse(
+                "job-ia-erro",
+                88L,
+                "landing-page-image-generation",
+                null,
+                null,
+                null,
+                null,
+                null,
+                " Falha OpenAI ",
+                " Detalhe técnico ");
+
+        assertEquals("Falha OpenAI", execution.getErrorMessage());
+        assertEquals("Detalhe técnico", execution.getErrorDetail());
+        assertNotNull(execution.getCompletedAt());
+        assertEquals("FALHA", execution.getStatus());
+        verify(executionRepository).save(execution);
+        verify(experiment, never()).setLandingPageWireframe(any());
+        verify(experimentRepository, never()).save(experiment);
+    }
+
+
+    /** Deve marcar falha mesmo quando o callback recebe apenas detalhe técnico do erro. */
+    @Test
+    void markCompletedFromResponseShouldFailWhenOnlyErrorDetailIsPresent() {
+        ExperimentRepository experimentRepository = mock(ExperimentRepository.class);
+        GeraLandingStageExecutionRepository executionRepository = mock(GeraLandingStageExecutionRepository.class);
+        BackendImageGenerationService service =
+                new BackendImageGenerationService(experimentRepository, executionRepository, new ObjectMapper());
+        Experiment experiment = mock(Experiment.class);
+        GeraLandingStageExecution execution = GeraLandingStageExecution.builder()
+                .experimentId(88L)
+                .experiment(experiment)
+                .stageCode("landing-page-image-generation")
+                .idJob("job-ia-detalhe".getBytes(StandardCharsets.UTF_8))
+                .status("AGUARDANDO_RETORNO_OPENAI")
+                .build();
+        when(executionRepository.findTopByIdJobOrderByExecutionRequestedAtDesc(any(byte[].class)))
+                .thenReturn(Optional.of(execution));
+
+        service.markCompletedFromResponse(
+                "job-ia-detalhe",
+                88L,
+                "landing-page-image-generation",
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                " Stack trace sem mensagem principal ");
+
+        assertEquals("Falha ao processar etapa image generation", execution.getErrorMessage());
+        assertEquals("Stack trace sem mensagem principal", execution.getErrorDetail());
+        assertNotNull(execution.getCompletedAt());
+        assertEquals("FALHA", execution.getStatus());
+        verify(executionRepository).save(execution);
+        verify(experiment, never()).setLandingPageWireframe(any());
+        verify(experimentRepository, never()).save(experiment);
+    }
+
+
+}

--- a/backend/ads-service/src/test/java/com/marketinghub/geralanding/imagegeneration/web/BackendImageGenerationControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/geralanding/imagegeneration/web/BackendImageGenerationControllerTest.java
@@ -1,0 +1,233 @@
+package com.marketinghub.geralanding.imagegeneration.web;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marketinghub.geralanding.imagegeneration.service.BackendImageGenerationService;
+import com.marketinghub.geralanding.imagegeneration.service.GeraLandingImageGenerationStartResponse;
+import com.marketinghub.geralanding.imagegeneration.service.pending.RecordImageGenerationExperiment;
+import com.marketinghub.geralanding.imagegeneration.service.pending.RecordImageGenerationHypothesis;
+import com.marketinghub.geralanding.imagegeneration.service.pending.RecordImageGenerationPending;
+import com.marketinghub.geralanding.imagegeneration.service.recebePrompt.RecebePromptRequest;
+import com.marketinghub.geralanding.imagegeneration.service.recebeResposta.RecebeRespostaRequest;
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
+
+/** Valida o contrato do controller de backend da etapa image generation. */
+@ExtendWith(OutputCaptureExtension.class)
+class BackendImageGenerationControllerTest {
+
+    /** Deve delegar o início da etapa diretamente para o BackendImageGenerationService. */
+    @Test
+    void startShouldDelegateToBackendImageGenerationService() {
+        BackendImageGenerationService executionService = mock(BackendImageGenerationService.class);
+        BackendImageGenerationController controller = new BackendImageGenerationController(executionService);
+        GeraLandingImageGenerationStartResponse startResponse =
+                new GeraLandingImageGenerationStartResponse("job-start", "INICIADO");
+        when(executionService.start(44L)).thenReturn(startResponse);
+
+        var response = controller.start(44L);
+
+        assertEquals(202, response.getStatusCode().value());
+        assertEquals(startResponse, response.getBody());
+        verify(executionService).start(44L);
+    }
+
+    /** Deve delegar a listagem pendente para a etapa canônica de image generation. */
+    @Test
+    void pendingShouldReturnStartedImageGenerationJobs() {
+        BackendImageGenerationService executionService = mock(BackendImageGenerationService.class);
+        BackendImageGenerationController controller = new BackendImageGenerationController(executionService);
+        List<RecordImageGenerationPending> pending = List.of(
+                new RecordImageGenerationPending(
+                        12L,
+                        "job-12",
+                        "landing-page-image-generation",
+                        pendingExperiment(12L, "Experimento 12", "Hipótese"),
+                        pendingHypothesis()));
+        when(executionService.listPending("landing-page-image-generation")).thenReturn(pending);
+
+        List<RecordImageGenerationPending> response = controller.pending();
+
+        assertEquals(pending, response);
+        verify(executionService).listPending("landing-page-image-generation");
+    }
+
+    /** Deve receber o prompt enviado para IA e delegar marcação de espera pelo retorno OpenAI. */
+    @Test
+    void recebePromptShouldMarkExecutionWaitingOpenAiDispatch(CapturedOutput output) {
+        BackendImageGenerationService executionService = mock(BackendImageGenerationService.class);
+        BackendImageGenerationController controller = new BackendImageGenerationController(executionService);
+        RecebePromptRequest payload = new RecebePromptRequest(
+                "Prompt para IA",
+                "# Prompt markdown bruto",
+                "{\"type\":\"object\"}",
+                "{\"model\":\"gpt-test\"}",
+                "openai-job-1");
+
+        var response = controller.recebePrompt("job-ia-1", payload);
+
+        assertEquals(202, response.getStatusCode().value());
+        assertEquals("Prompt para IA", payload.prompt());
+        assertEquals("openai-job-1", payload.jobidopenai());
+        assertEquals("# Prompt markdown bruto", payload.promptMarkdownContent());
+        assertEquals("{\"type\":\"object\"}", payload.schemaJson());
+        assertEquals("{\"model\":\"gpt-test\"}", payload.requestBodyJson());
+        verify(executionService).markWaitingOpenAiDispatch(
+                "job-ia-1",
+                "Prompt para IA",
+                "# Prompt markdown bruto",
+                "{\"type\":\"object\"}",
+                "{\"model\":\"gpt-test\"}",
+                "openai-job-1");
+        assertTrue(output.getOut().contains("requestBodyLength="));
+    }
+
+    /** Deve receber a resposta da IA e delegar a conclusão da execução image generation. */
+    @Test
+    void recebeRespostaShouldDelegatePayloadToImageGenerationService() {
+        BackendImageGenerationService executionService = mock(BackendImageGenerationService.class);
+        BackendImageGenerationController controller = new BackendImageGenerationController(executionService);
+        RecebeRespostaRequest payload = new RecebeRespostaRequest(
+                44L,
+                "landing-page-image-generation",
+                "{\"landingPageWireframe\":{}}",
+                120,
+                80,
+                new BigDecimal("0.012300"),
+                "openai-job-1",
+                null,
+                null);
+
+        var response = controller.recebeResposta("job-ia-1", payload);
+
+        assertEquals(202, response.getStatusCode().value());
+        verify(executionService).markCompletedFromResponse(
+                "job-ia-1",
+                44L,
+                "landing-page-image-generation",
+                "{\"landingPageWireframe\":{}}",
+                120,
+                80,
+                new BigDecimal("0.012300"),
+                "openai-job-1",
+                null,
+                null);
+    }
+
+
+    /** Deve receber payload de erro e delegar a falha para o serviço da etapa image generation. */
+    @Test
+    void recebeRespostaShouldDelegateErrorPayloadToImageGenerationService() {
+        BackendImageGenerationService executionService = mock(BackendImageGenerationService.class);
+        BackendImageGenerationController controller = new BackendImageGenerationController(executionService);
+        RecebeRespostaRequest payload = new RecebeRespostaRequest(
+                44L,
+                "landing-page-image-generation",
+                null,
+                null,
+                null,
+                null,
+                null,
+                "Falha OpenAI",
+                "Stack trace resumido");
+
+        var response = controller.recebeResposta("job-ia-erro", payload);
+
+        assertEquals(202, response.getStatusCode().value());
+        verify(executionService).markCompletedFromResponse(
+                "job-ia-erro",
+                44L,
+                "landing-page-image-generation",
+                null,
+                null,
+                null,
+                null,
+                null,
+                "Falha OpenAI",
+                "Stack trace resumido");
+    }
+
+    /** Deve serializar pending como lista com atributos experiment e jobid em cada item. */
+    @Test
+    void pendingShouldSerializeListItemsWithExperimentAndJobid() throws Exception {
+        BackendImageGenerationService executionService = mock(BackendImageGenerationService.class);
+        BackendImageGenerationController controller = new BackendImageGenerationController(executionService);
+        when(executionService.listPending("landing-page-image-generation")).thenReturn(List.of(
+                new RecordImageGenerationPending(
+                        33L,
+                        "bbed57d0-dcc7-40ab-b936-20a19e21c7fe",
+                        "landing-page-image-generation",
+                        pendingExperiment(33L, "Experimento 33", "Hipótese 33"),
+                        pendingHypothesis())));
+
+        JsonNode json = new ObjectMapper().valueToTree(controller.pending());
+
+        assertTrue(json.isArray());
+        assertEquals(1, json.size());
+        assertTrue(json.get(0).has("experiment"));
+        assertTrue(json.get(0).has("jobid"));
+        assertEquals("bbed57d0-dcc7-40ab-b936-20a19e21c7fe", json.get(0).get("jobid").asText());
+        assertEquals(33L, json.get(0).get("experiment").get("id").asLong());
+        assertEquals("Prompt texto", json.get(0).get("experiment").get("creativeTextPrompt").asText());
+        assertTrue(json.get(0).get("experiment").get("campaignAngle").isObject());
+        assertEquals(
+                "Promessa clara",
+                json.get(0).get("experiment").get("campaignAngle").get("campaignAngle").get("singleMindedPromise").asText());
+        assertEquals("<html>GeraLanding</html>", json.get(0).get("experiment").get("htmlGeraLanding").asText());
+        assertTrue(json.get(0).has("hypothesis"));
+        assertEquals("Hipótese Framework", json.get(0).get("hypothesis").get("title").asText());
+        assertEquals("Dor superficial", json.get(0).get("hypothesis").get("framework").get("pain").get("surface").asText());
+        assertTrue(json.get(0).get("hypothesis").get("framework").has("result"));
+        assertTrue(json.get(0).get("hypothesis").get("framework").has("mechanism"));
+        assertTrue(json.get(0).get("hypothesis").get("framework").has("proof"));
+        assertTrue(json.get(0).get("hypothesis").get("framework").has("offer"));
+        assertTrue(json.get(0).get("hypothesis").get("framework").has("checklist"));
+    }
+
+    /** Cria a hipótese usada pelos testes de contrato pending. */
+    private RecordImageGenerationHypothesis pendingHypothesis() {
+        return new RecordImageGenerationHypothesis(
+                UUID.fromString("11111111-1111-1111-1111-111111111111"),
+                "Hipótese Framework",
+                Map.of(
+                        "pain", Map.of("surface", "Dor superficial"),
+                        "result", Map.of("desiredResult", "Resultado desejado"),
+                        "mechanism", Map.of("core", "Mecanismo central"),
+                        "proof", Map.of("type", "Prova"),
+                        "offer", Map.of("name", "Oferta"),
+                        "checklist", Map.of("painReady", true)));
+    }
+
+    /** Cria o resumo de experimento usado pelos testes de contrato pending. */
+    private RecordImageGenerationExperiment pendingExperiment(Long id, String name, String hypothesis) {
+        return new RecordImageGenerationExperiment(
+                id,
+                name,
+                hypothesis,
+                "PLANNED",
+                "LANDING",
+                "Prompt texto",
+                "Prompt imagem",
+                Map.of("campaignAngle", Map.of("singleMindedPromise", "Promessa clara")),
+                Map.of("adCopy", Map.of("headline", "Headline")),
+                "Briefing imagem",
+                "Copy landing",
+                "ImageGeneration landing",
+                "Planejamento imagem",
+                "Preset design",
+                "Entregáveis landing",
+                "<html>GeraLanding</html>");
+    }
+}

--- a/docs/canonical/procedimento-experimento-canon.v1.md
+++ b/docs/canonical/procedimento-experimento-canon.v1.md
@@ -183,7 +183,7 @@ A interface de Experimentos deve manter abas/visões que permitam acompanhar, de
 
 1. Criar experimento na tela.
 2. Entrar no detalhe e executar etapas do pipeline inicial (`campaign angle` → `ad copy` → `ad image briefing`).
-3. Executar etapas do Gera Landing (`wireframe` → `copy` → `image planning` + geração de imagens → `design preset` → `landing html`).
+3. Executar etapas do Gera Landing (`wireframe` → `copy` → `image planning` → `image generation` → `design preset` → `landing html`).
 4. Gerar anúncios com IA.
 5. Aprovar anúncios.
 6. Ir para aba Landing, revisar/aprovar/publicar landing e confirmar URL final para campanha.
@@ -214,9 +214,10 @@ Este documento passa a ser a **única fonte canônica** para definição operaci
 
 1. `landing-page-wireframe`
 2. `landing-page-copy`
-3. `landing-page-image-planning` (+ geração de imagens)
-4. `landing-page-design-preset`
-5. `landing-page-deliverables`
+3. `landing-page-image-planning`
+4. `landing-page-image-generation`
+5. `landing-page-design-preset`
+6. `landing-page-deliverables`
 
 ### 15.2 Regra mandatória para HTML provisório da etapa preset design
 

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -2804,3 +2804,13 @@
   - o scheduler legado de `framework-image` passou a ficar desligado por padrão e disponível apenas por fallback explícito via `framework-image.legacy-scheduler.enabled`;
   - adicionadas propriedades `imagegeneration.worker.*` para operar a etapa pelo padrão novo sem quebrar as chaves existentes de rollout e habilitação.
 - impacto esperado: a etapa **Gera imagens** passa a seguir o mesmo modelo operacional das outras etapas do Worker AI core, com logs de request/resposta OpenAI e payload ao backend, reduzindo divergência entre etapas e mantendo foco em gerar ativos visuais úteis para conversão.
+
+## 2026-05-31 — Backend GeraLanding image generation
+
+- tarefa: criar no backend a estrutura `com.marketinghub.geralanding.imagegeneration` espelhando o padrão operacional da etapa `geralanding.wireframe`.
+- implementação:
+  - adicionados controller, service e DTOs/records da etapa `landing-page-image-generation` com endpoints de início, listagem, pending, recebimento de prompt, recebimento de resposta e detalhe de execução;
+  - a fila pending expõe os mesmos artefatos necessários ao Worker AI que a etapa wireframe já disponibiliza, incluindo framework da hipótese e artefatos consolidados do experimento;
+  - a conclusão da etapa registra auditoria, tokens, custo e erro/sucesso em `GeraLandingStageExecution`, sem criar coluna consolidada nova em `experiment` porque a geração de imagens possui persistência própria por job/asset;
+  - atualizada a ordem canônica do Gera Landing para explicitar `landing-page-image-generation` após `landing-page-image-planning`.
+- validação: adicionados testes unitários específicos para service e controller da nova etapa.


### PR DESCRIPTION
### Motivation
- Introduce a new GeraLanding stage `landing-page-image-generation` mirroring the existing `wireframe` structure to support a dedicated image-generation step in the experiment pipeline.
- Provide the Worker AI with the same canonical pending queue and payload shape used by other GeraLanding stages, keeping the backend-side artifact handling consistent with existing patterns.
- Keep experiment-level persistence unchanged (no new experiment column) and record image-generation output as execution/audit data to preserve existing storage responsibilities and avoid contaminating experiment DTOs.

### Description
- Added a new backend package `com.marketinghub.geralanding.imagegeneration` with controller `BackendImageGenerationController`, service `BackendImageGenerationService`, DTOs/records (`RecordImageGenerationPending`, `RecordImageGenerationExperiment`, `RecordBackendImageGenerationDetalheDto`, `GeraLandingImageGenerationStartResponse`, etc.) and request records for prompt/response payloads mirroring the wireframe layout.
- Exposed canonical endpoints for the stage: `start`, `listStageExecutions`, internal `pending`, internal `recebe-prompt`, internal `recebe-resposta` and `detailStageExecution` under the `/api` prefix using the stage code `landing-page-image-generation` and path segments `/geralanding/image-generation/...`.
- Added unit tests for the new stage by adapting the wireframe tests into `BackendImageGenerationServiceTest` and `BackendImageGenerationControllerTest`, and updated docs to include `landing-page-image-generation` in the canonical Gera Landing order and added an experiments registry entry describing the change (`docs/canonical/procedimento-experimento-canon.v1.md` and `docs/registros/experimentos.md`).

### Testing
- Ran the new unit tests with `mvn -Dtest='BackendImageGenerationServiceTest,BackendImageGenerationControllerTest' test` inside `backend/ads-service` and verified the tests for the new package executed successfully.
- Executed the module test suite with `cd backend/ads-service && mvn test` to validate integration with existing backend tests and observed test execution logs showing the new controller/service exercised by tests without introducing compile-time or runtime failures in the module test run.
- Captured test output and logs during the run (integration logs and controller/service INFO lines) to confirm endpoints and service methods are wired and the pending payload serialization behaves analogously to the wireframe stage.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1c907770f88321ab1b2e5968054589)