### PR TITLE
Agenda ciclo 1 Hotmart para 18:15 de 31/05

### DIFF
--- a/docs/registros/mois1.md
+++ b/docs/registros/mois1.md
@@ -649,3 +649,16 @@ Arquivos alterados:
   - mois-hotmart-collector/AGENTS.md
   - docs/canonical/mois-hotmart-mapeamento-ciclos-campos-banco.md
   - docs/registros/mois1.md
+
+## 2026-05-31 — Agendamento do ciclo 1 Hotmart para 18:15 em 31 de maio
+- Ajustado o scheduler do ciclo 1 do coletor Hotmart para executar às 18:15 no dia 31 de maio, no horário de São Paulo.
+- Causa-raiz: necessidade operacional de executar a listagem Hotmart hoje em janela específica solicitada pelo operador.
+- Correção aplicada:
+  - `@Scheduled(cron = "0 15 18 31 5 *", zone = "America/Sao_Paulo")` no método do ciclo 1;
+  - renomeado o método para refletir o novo agendamento pontual;
+  - atualizado o log operacional para explicitar `hora=18:15`, `dia=31/05` e `timezone=America/Sao_Paulo`.
+- Documentos lidos para execução:
+  - AGENTS.md
+  - mois-hotmart-collector/AGENTS.md
+  - docs/canonical/mois-hotmart-mapeamento-ciclos-campos-banco.md
+  - docs/registros/mois1.md

--- a/mois-hotmart-collector/src/main/java/com/marketinghub/moishotmart/service/HotmartCollectorScheduler.java
+++ b/mois-hotmart-collector/src/main/java/com/marketinghub/moishotmart/service/HotmartCollectorScheduler.java
@@ -34,17 +34,17 @@ public class HotmartCollectorScheduler {
     }
 
     /**
-     * Executa o ciclo 1 de listagem de produtos às 19:30 no dia 29 de maio, no horário de São Paulo.
+     * Executa o ciclo 1 de listagem de produtos às 18:15 no dia 31 de maio, no horário de São Paulo.
      */
-    @Scheduled(cron = "0 30 19 29 5 *", zone = "America/Sao_Paulo")
-    public void collectFirstCycleAtNineteenThirtyOnMayTwentyNinth() {
+    @Scheduled(cron = "0 15 18 31 5 *", zone = "America/Sao_Paulo")
+    public void collectFirstCycleAtEighteenFifteenOnMayThirtyFirst() {
         if (!enabled) {
             log.info("Hotmart scheduler desabilitado por configuração.");
             return;
         }
         HotmartCollectionRequest request = new HotmartCollectionRequest(source, maxProducts);
         HotmartCollectionResponse response = collectorService.collectFirstCycle(request);
-        log.info("Hotmart scheduler executado hora=19:30 dia=29/05 timezone=America/Sao_Paulo ciclo={} status={} produtos={} mensagem={}",
+        log.info("Hotmart scheduler executado hora=18:15 dia=31/05 timezone=America/Sao_Paulo ciclo={} status={} produtos={} mensagem={}",
                 "CICLO_1_LISTAGEM",
                 response.status(),
                 response.products().size(),


### PR DESCRIPTION
### Motivation
- Realizar execução pontual do Ciclo 1 do coletor Hotmart em janela operacional específica para observação e análise de paginação hoje (31/05) no fuso `America/Sao_Paulo`.

### Description
- Atualiza o scheduler em `mois-hotmart-collector/src/main/java/com/marketinghub/moishotmart/service/HotmartCollectorScheduler.java` para agendar o ciclo 1 pontualmente com `@Scheduled(cron = "0 15 18 31 5 *", zone = "America/Sao_Paulo")` e renomear o método para refletir o horário. 
- Ajusta a mensagem de log do agendador para registrar `hora=18:15`, `dia=31/05` e `timezone=America/Sao_Paulo`, e adiciona entrada de registro operacional em `docs/registros/mois1.md` documentando causa-raiz e ações aplicadas.

### Testing
- Executado `mvn test` em `mois-hotmart-collector` com resultado `BUILD SUCCESS` (`Tests run: 3, Failures: 0, Errors: 0`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ca09508f88321b9ad68260b53be96)