### PR TITLE
Hotmart: detect expired JWT and show actionable token-update alert (collector + frontend + tests)

### DIFF
--- a/docs/registros/mois1.md
+++ b/docs/registros/mois1.md
@@ -662,3 +662,14 @@ Arquivos alterados:
   - mois-hotmart-collector/AGENTS.md
   - docs/canonical/mois-hotmart-mapeamento-ciclos-campos-banco.md
   - docs/registros/mois1.md
+
+## 2026-05-31 — Hotmart ciclo 1: alerta acionável para token JWT expirado
+
+- Corrigida a causa-raiz do ciclo 1 da Hotmart persistir `COLLECTION_EXECUTED` mesmo quando a API retornava `401 invalid_token` por JWT expirado.
+- O coletor agora classifica respostas `401/403`, `invalid_token`, `Expired JWT` e `BadJWTException` como falha acionável, persiste o job como `COLLECTION_ERROR` e grava mensagem explícita orientando o usuário a atualizar o token na tela Hotmart.
+- A tela `/hotmart` passou a destacar a ação necessária com alerta vermelho quando a última execução indicar erro de token Hotmart.
+
+Arquivos alterados:
+- `mois-hotmart-collector/src/main/java/com/marketinghub/moishotmart/service/HotmartCollectorService.java`
+- `mois-hotmart-collector/src/test/java/com/marketinghub/moishotmart/service/HotmartCollectorServiceTest.java`
+- `frontend/src/pages/hotmart/HotmartPage.tsx`

--- a/frontend/src/pages/hotmart/HotmartPage.tsx
+++ b/frontend/src/pages/hotmart/HotmartPage.tsx
@@ -9,6 +9,21 @@ import {
   useHotmartCollectionJobs,
 } from "../../api/settings/useHotmartCollectedProducts";
 
+function shouldShowHotmartTokenAlert(
+  status?: string | null,
+  message?: string | null,
+) {
+  const normalizedStatus = status ?? "";
+  const normalizedMessage = (message ?? "").toLowerCase();
+  return (
+    normalizedStatus === "COLLECTION_ERROR" ||
+    normalizedStatus === "HOTMART_TOKEN_EXPIRED" ||
+    normalizedMessage.includes("token jwt da hotmart") ||
+    normalizedMessage.includes("invalid_token") ||
+    normalizedMessage.includes("expired jwt")
+  );
+}
+
 function formatUpdatedAt(value?: string | null) {
   if (!value) return "—";
   const date = new Date(value);
@@ -37,7 +52,10 @@ export default function HotmartPage() {
     }
   }, [data?.value]);
 
-  const updatedAt = useMemo(() => formatUpdatedAt(data?.updatedAt), [data?.updatedAt]);
+  const updatedAt = useMemo(
+    () => formatUpdatedAt(data?.updatedAt),
+    [data?.updatedAt],
+  );
   const latestHotmartJob = useMemo(() => {
     const firstItem = hotmartProductsQuery.data?.[0];
     return {
@@ -46,7 +64,14 @@ export default function HotmartPage() {
     };
   }, [hotmartProductsQuery.data]);
 
-  const latestHotmartExecution = useMemo(() => hotmartJobsQuery.data?.[0], [hotmartJobsQuery.data]);
+  const latestHotmartExecution = useMemo(
+    () => hotmartJobsQuery.data?.[0],
+    [hotmartJobsQuery.data],
+  );
+  const showHotmartTokenAlert = shouldShowHotmartTokenAlert(
+    latestHotmartExecution?.status,
+    latestHotmartExecution?.message,
+  );
 
   const hotmartCycleStats = useMemo(() => {
     const products = hotmartProductsQuery.data ?? [];
@@ -54,7 +79,10 @@ export default function HotmartPage() {
 
     const productsByCycle = new Map<string, number>();
     for (const product of products) {
-      productsByCycle.set(product.jobId, (productsByCycle.get(product.jobId) ?? 0) + 1);
+      productsByCycle.set(
+        product.jobId,
+        (productsByCycle.get(product.jobId) ?? 0) + 1,
+      );
     }
 
     return {
@@ -95,19 +123,29 @@ export default function HotmartPage() {
         <div className="card-header">
           <h5 className="mb-1">Token de acesso</h5>
           <p className="text-muted small mb-0">
-            Cole aqui o JWT obtido no login da Hotmart para uso nas integrações deste módulo.
+            Cole aqui o JWT obtido no login da Hotmart para uso nas integrações
+            deste módulo.
           </p>
         </div>
         <div className="card-body">
           {isLoading ? <p className="mb-0">Carregando token...</p> : null}
           {isError ? (
-            <p className="text-danger mb-0">Não foi possível carregar o token salvo.</p>
+            <p className="text-danger mb-0">
+              Não foi possível carregar o token salvo.
+            </p>
           ) : null}
 
           {!isLoading && !isError ? (
-            <form onSubmit={handleSubmit} className="d-flex flex-column gap-3" noValidate>
+            <form
+              onSubmit={handleSubmit}
+              className="d-flex flex-column gap-3"
+              noValidate
+            >
               <div>
-                <label htmlFor="hotmartAccessToken" className="form-label fw-semibold">
+                <label
+                  htmlFor="hotmartAccessToken"
+                  className="form-label fw-semibold"
+                >
                   JWT Hotmart <span className="text-danger">*</span>
                 </label>
                 <textarea
@@ -130,7 +168,11 @@ export default function HotmartPage() {
                 >
                   {updateSetting.isPending ? (
                     <>
-                      <span className="spinner-border spinner-border-sm me-2" role="status" aria-hidden="true" />
+                      <span
+                        className="spinner-border spinner-border-sm me-2"
+                        role="status"
+                        aria-hidden="true"
+                      />
                       Salvando...
                     </>
                   ) : (
@@ -141,22 +183,28 @@ export default function HotmartPage() {
             </form>
           ) : null}
 
-          {feedback ? <div className="alert alert-info mt-3 mb-0">{feedback}</div> : null}
-          {latestHotmartExecution?.status === "COLLECTION_ERROR" ? (
-            <div className="alert alert-warning mt-3 mb-0" role="alert">
-              <strong>Falha na última coleta:</strong> {latestHotmartExecution.message || "Verifique o token JWT da Hotmart."}
+          {feedback ? (
+            <div className="alert alert-info mt-3 mb-0">{feedback}</div>
+          ) : null}
+          {showHotmartTokenAlert ? (
+            <div
+              className="alert alert-danger border border-danger mt-3 mb-0"
+              role="alert"
+            >
+              <strong>Ação necessária: atualize o token Hotmart.</strong>{" "}
+              {latestHotmartExecution?.message ||
+                "A última coleta não conseguiu autenticar na Hotmart."}
             </div>
           ) : null}
-
         </div>
       </section>
-
 
       <section className="card mt-3 shadow-sm border-0">
         <div className="card-header">
           <h5 className="mb-1">Resumo de ciclos Hotmart</h5>
           <p className="text-muted small mb-0">
-            Mostra a quantidade de jobs executados e o total de produtos coletados no período carregado.
+            Mostra a quantidade de jobs executados e o total de produtos
+            coletados no período carregado.
           </p>
         </div>
         <div className="card-body">
@@ -165,7 +213,9 @@ export default function HotmartPage() {
           ) : null}
 
           {hotmartJobsQuery.isError || hotmartProductsQuery.isError ? (
-            <p className="text-danger mb-0">Não foi possível carregar o resumo de ciclos.</p>
+            <p className="text-danger mb-0">
+              Não foi possível carregar o resumo de ciclos.
+            </p>
           ) : null}
 
           {!hotmartJobsQuery.isLoading &&
@@ -177,13 +227,19 @@ export default function HotmartPage() {
                 <div className="col-12 col-md-6">
                   <div className="border rounded p-3 h-100">
                     <div className="text-muted small">Jobs executados</div>
-                    <div className="fs-4 fw-semibold">{hotmartCycleStats.totalExecutedJobs}</div>
+                    <div className="fs-4 fw-semibold">
+                      {hotmartCycleStats.totalExecutedJobs}
+                    </div>
                   </div>
                 </div>
                 <div className="col-12 col-md-6">
                   <div className="border rounded p-3 h-100">
-                    <div className="text-muted small">Total de produtos (geral)</div>
-                    <div className="fs-4 fw-semibold">{hotmartCycleStats.totalProducts}</div>
+                    <div className="text-muted small">
+                      Total de produtos (geral)
+                    </div>
+                    <div className="fs-4 fw-semibold">
+                      {hotmartCycleStats.totalProducts}
+                    </div>
                   </div>
                 </div>
               </div>
@@ -205,14 +261,18 @@ export default function HotmartPage() {
                           <td className="small">{cycle.jobId}</td>
                           <td>{cycle.status}</td>
                           <td>{cycle.createdAt}</td>
-                          <td className="text-end fw-semibold">{cycle.productsCount}</td>
+                          <td className="text-end fw-semibold">
+                            {cycle.productsCount}
+                          </td>
                         </tr>
                       ))}
                     </tbody>
                   </table>
                 </div>
               ) : (
-                <p className="mb-0 text-secondary">Nenhum ciclo encontrado para o workspace.</p>
+                <p className="mb-0 text-secondary">
+                  Nenhum ciclo encontrado para o workspace.
+                </p>
               )}
             </>
           ) : null}
@@ -223,28 +283,37 @@ export default function HotmartPage() {
         <div className="card-header">
           <h5 className="mb-1">Produtos coletados da Hotmart</h5>
           <p className="text-muted small mb-0">
-            Exibe os produtos da última coleta automática registrada para o workspace.
+            Exibe os produtos da última coleta automática registrada para o
+            workspace.
           </p>
         </div>
         <div className="card-body">
-          {hotmartProductsQuery.isLoading ? <p className="mb-0">Carregando produtos...</p> : null}
+          {hotmartProductsQuery.isLoading ? (
+            <p className="mb-0">Carregando produtos...</p>
+          ) : null}
           {hotmartProductsQuery.isError ? (
-            <p className="text-danger mb-0">Não foi possível carregar os produtos coletados.</p>
+            <p className="text-danger mb-0">
+              Não foi possível carregar os produtos coletados.
+            </p>
           ) : null}
           {!hotmartProductsQuery.isLoading &&
           !hotmartProductsQuery.isError &&
           hotmartProductsQuery.data &&
           hotmartProductsQuery.data.length === 0 ? (
-            <p className="mb-0 text-secondary">Nenhuma coleta Hotmart encontrada até o momento.</p>
+            <p className="mb-0 text-secondary">
+              Nenhuma coleta Hotmart encontrada até o momento.
+            </p>
           ) : null}
 
           {hotmartProductsQuery.data && hotmartProductsQuery.data.length > 0 ? (
             <>
               <p className="small text-muted mb-3">
-                Job mais recente: <strong>{latestHotmartJob.id}</strong> · Data/hora: <strong>{latestHotmartJob.collectedAt}</strong>
+                Job mais recente: <strong>{latestHotmartJob.id}</strong> ·
+                Data/hora: <strong>{latestHotmartJob.collectedAt}</strong>
               </p>
 
-              {hotmartProductsQuery.data && hotmartProductsQuery.data.length > 0 ? (
+              {hotmartProductsQuery.data &&
+              hotmartProductsQuery.data.length > 0 ? (
                 <div className="row g-3">
                   {hotmartProductsQuery.data.map((item) => {
                     const imageUrl = item.imageUrl;
@@ -254,7 +323,10 @@ export default function HotmartPage() {
                     const salesPageUrl = item.salesPageUrl?.trim() || null;
 
                     return (
-                      <article key={item.referenceId} className="col-12 col-md-6 col-lg-4">
+                      <article
+                        key={item.referenceId}
+                        className="col-12 col-md-6 col-lg-4"
+                      >
                         <div className="card h-100 border">
                           {imageUrl ? (
                             <img
@@ -266,14 +338,21 @@ export default function HotmartPage() {
                           ) : null}
                           <div className="card-body d-flex flex-column">
                             <h6 className="card-title">{item.title}</h6>
-                            <p className="small text-muted mb-2">Produtor: {producer || "Não informado"}</p>
+                            <p className="small text-muted mb-2">
+                              Produtor: {producer || "Não informado"}
+                            </p>
                             <p className="small mb-2">
-                              Temperatura: <strong>{item.temperature ?? "—"}</strong>
+                              Temperatura:{" "}
+                              <strong>{item.temperature ?? "—"}</strong>
                             </p>
                             <p className="small mb-2">
                               Página de vendas:{" "}
                               {salesPageUrl ? (
-                                <a href={salesPageUrl} target="_blank" rel="noreferrer">
+                                <a
+                                  href={salesPageUrl}
+                                  target="_blank"
+                                  rel="noreferrer"
+                                >
                                   {salesPageUrl}
                                 </a>
                               ) : (
@@ -283,7 +362,9 @@ export default function HotmartPage() {
                             <p className="small mb-3">
                               Preço:{" "}
                               <strong>
-                                {price ? `${currency} ${price}` : "Não informado"}
+                                {price
+                                  ? `${currency} ${price}`
+                                  : "Não informado"}
                               </strong>
                             </p>
                             {salesPageUrl ? (
@@ -296,7 +377,11 @@ export default function HotmartPage() {
                                 Ver página de vendas
                               </a>
                             ) : (
-                              <button type="button" className="btn btn-outline-secondary btn-sm mt-auto" disabled>
+                              <button
+                                type="button"
+                                className="btn btn-outline-secondary btn-sm mt-auto"
+                                disabled
+                              >
                                 Página de vendas indisponível
                               </button>
                             )}

--- a/mois-hotmart-collector/src/main/java/com/marketinghub/moishotmart/service/HotmartCollectorService.java
+++ b/mois-hotmart-collector/src/main/java/com/marketinghub/moishotmart/service/HotmartCollectorService.java
@@ -30,6 +30,9 @@ import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Service;
 
+/**
+ * Responsável por coletar produtos da Hotmart, diagnosticar falhas do token e persistir o estado operacional no backend MOIS.
+ */
 @Service
 public class HotmartCollectorService {
     private static final Logger log = LoggerFactory.getLogger(HotmartCollectorService.class);
@@ -86,10 +89,16 @@ public class HotmartCollectorService {
         this.defaultMarketTheme = defaultMarketTheme;
     }
 
+    /**
+     * Executa a coleta padrão delegando para o ciclo 1 de listagem.
+     */
     public HotmartCollectionResponse collect(HotmartCollectionRequest request) {
         return collectFirstCycle(request);
     }
 
+    /**
+     * Executa o ciclo 1 de listagem da Hotmart e marca erro acionável quando a API rejeita o JWT salvo.
+     */
     public HotmartCollectionResponse collectFirstCycle(HotmartCollectionRequest request) {
         int boundedMax = request.maxProducts() <= 0 ? 10 : Math.min(request.maxProducts(), HOTMART_MAX_PRODUCTS_PER_RUN);
 
@@ -120,11 +129,21 @@ public class HotmartCollectorService {
         );
         logTokenDiagnostics(hotmartAccessToken);
 
+        StringBuilder apiFailureMessage = new StringBuilder();
+        boolean[] tokenUpdateRequired = new boolean[] {false};
         try (Playwright ignored = Playwright.create()) {
-            int apiCollected = collectProductsViaMarketApi(hotmartAccessToken, boundedMax, products);
+            int apiCollected = collectProductsViaMarketApi(hotmartAccessToken, boundedMax, products, apiFailureMessage, tokenUpdateRequired);
             log.info("Coleta API Hotmart finalizada. produtosColetadosViaApi={}", apiCollected);
-            status = "COLLECTION_EXECUTED";
-            message = "Coleta executada via API da Hotmart usando JWT salvo em configurações gerais.";
+            if (apiFailureMessage.isEmpty()) {
+                status = "COLLECTION_EXECUTED";
+                message = "Coleta executada via API da Hotmart usando JWT salvo em configurações gerais.";
+            } else {
+                status = "COLLECTION_ERROR";
+                message = apiFailureMessage.toString();
+                if (tokenUpdateRequired[0]) {
+                    log.warn("Hotmart ciclo 1 requer atualização do token JWT pelo usuário. mensagem={}", message);
+                }
+            }
         } catch (Exception ex) {
             status = "COLLECTION_ERROR";
             message = "Falha na coleta API: " + ex.getMessage();
@@ -134,6 +153,9 @@ public class HotmartCollectorService {
         return new HotmartCollectionResponse(status, message, products);
     }
 
+    /**
+     * Executa o ciclo 2 enriquecendo detalhes dos produtos já persistidos pelo ciclo 1.
+     */
     public HotmartCollectionResponse collectSecondCycleFromBackend(HotmartCollectionRequest request) {
         List<HotmartProductSnapshot> enrichedProducts = new ArrayList<>();
         String status = "COLLECTION_EXECUTED";
@@ -376,7 +398,40 @@ public class HotmartCollectorService {
         }
     }
 
-    private int collectProductsViaMarketApi(String accessToken, int boundedMax, List<HotmartProductSnapshot> products) {
+    /**
+     * Monta a mensagem operacional que será exibida ao usuário quando a Hotmart rejeitar a coleta.
+     */
+    static String buildHotmartApiFailureMessage(int statusCode, String body) {
+        if (isHotmartTokenUpdateRequired(statusCode, body)) {
+            return "Token JWT da Hotmart expirado ou inválido. Atualize o token na tela Hotmart para liberar o próximo ciclo de coleta.";
+        }
+        return "Falha na API da Hotmart durante a coleta. status=" + statusCode
+                + ". Revise o token JWT e tente novamente.";
+    }
+
+    /**
+     * Identifica respostas da Hotmart que exigem ação do usuário para renovar o JWT salvo.
+     */
+    static boolean isHotmartTokenUpdateRequired(int statusCode, String body) {
+        if (statusCode == 401 || statusCode == 403) {
+            return true;
+        }
+        String normalizedBody = body == null ? "" : body.toLowerCase(java.util.Locale.ROOT);
+        return normalizedBody.contains("invalid_token")
+                || normalizedBody.contains("expired jwt")
+                || normalizedBody.contains("badjwtexception");
+    }
+
+    /**
+     * Percorre a API de marketplace da Hotmart e devolve mensagem de falha quando uma página não pode ser coletada.
+     */
+    private int collectProductsViaMarketApi(
+            String accessToken,
+            int boundedMax,
+            List<HotmartProductSnapshot> products,
+            StringBuilder apiFailureMessage,
+            boolean[] tokenUpdateRequired
+    ) {
         try {
             int targetProducts = Math.min(boundedMax, HOTMART_MAX_PRODUCTS_PER_RUN);
             int page = 1;
@@ -413,6 +468,14 @@ public class HotmartCollectorService {
                         response.statusCode(),
                         truncateForLog(body, 10_000));
                 if (response.statusCode() < 200 || response.statusCode() >= 300) {
+                    String userMessage = buildHotmartApiFailureMessage(response.statusCode(), body);
+                    apiFailureMessage.append(userMessage);
+                    tokenUpdateRequired[0] = isHotmartTokenUpdateRequired(response.statusCode(), body);
+                    log.warn("Hotmart ciclo 1 interrompido por falha da API. page={}, status={}, tokenUpdateRequired={}, mensagem={}",
+                            page,
+                            response.statusCode(),
+                            tokenUpdateRequired[0],
+                            userMessage);
                     break;
                 }
                 JsonNode data = objectMapper.readTree(body);
@@ -486,6 +549,9 @@ public class HotmartCollectorService {
                     targetProducts);
             return products.size();
         } catch (Exception ex) {
+            if (apiFailureMessage.isEmpty()) {
+                apiFailureMessage.append("Falha técnica na API da Hotmart durante a coleta. Revise o token JWT e tente novamente.");
+            }
             log.warn("Falha na coleta de produtos via API Hotmart.", ex);
             return 0;
         }

--- a/mois-hotmart-collector/src/test/java/com/marketinghub/moishotmart/service/HotmartCollectorServiceTest.java
+++ b/mois-hotmart-collector/src/test/java/com/marketinghub/moishotmart/service/HotmartCollectorServiceTest.java
@@ -1,12 +1,19 @@
 package com.marketinghub.moishotmart.service;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import com.marketinghub.moishotmart.dto.HotmartDtos.HotmartCollectionRequest;
 import org.junit.jupiter.api.Test;
 
+/**
+ * Valida os estados operacionais do coletor Hotmart em cenários de token ausente ou expirado.
+ */
 class HotmartCollectorServiceTest {
 
+    /**
+     * Garante que a coleta é ignorada quando não há token configurado no backend.
+     */
     @Test
     void shouldSkipWhenSessionAndCredentialsAreMissing() {
         HotmartCollectorService service = new HotmartCollectorService(
@@ -29,5 +36,19 @@ class HotmartCollectorServiceTest {
         var response = service.collect(new HotmartCollectionRequest("hotmart-market", 10));
 
         assertEquals("COLLECTION_SKIPPED", response.status());
+    }
+
+    /**
+     * Garante que a resposta 401 com JWT expirado gera mensagem acionável para atualização do token.
+     */
+    @Test
+    void shouldClassifyExpiredJwtAsTokenUpdateRequired() {
+        String body = "{\"error\":\"invalid_token\",\"error_description\":\"Expired JWT\"}";
+
+        assertTrue(HotmartCollectorService.isHotmartTokenUpdateRequired(401, body));
+        assertEquals(
+                "Token JWT da Hotmart expirado ou inválido. Atualize o token na tela Hotmart para liberar o próximo ciclo de coleta.",
+                HotmartCollectorService.buildHotmartApiFailureMessage(401, body)
+        );
     }
 }


### PR DESCRIPTION
### Motivation
- The Hotmart collector was treating API 401/403 `invalid_token`/expired JWT responses as successful runs and therefore the UI did not prompt the user to update the token. This change makes token expiry an actionable error so users are informed to update the JWT.

### Description
- Updated `mois-hotmart-collector/src/main/java/com/marketinghub/moishotmart/service/HotmartCollectorService.java` to classify Hotmart API failures (401/403, `invalid_token`, `Expired JWT`, `BadJWTException`) as `COLLECTION_ERROR`, persist an explanatory message and mark when a token update is required, and added helper methods `buildHotmartApiFailureMessage` and `isHotmartTokenUpdateRequired` for the detection and user message.
- Changed the `collectProductsViaMarketApi` signature to accept `StringBuilder apiFailureMessage` and `boolean[] tokenUpdateRequired` and to populate them when the Hotmart API rejects the JWT; adjusted the collector flow to set `status`/`message` accordingly before persisting via the backend endpoint.
- Frontend: updated `frontend/src/pages/hotmart/HotmartPage.tsx` to add `shouldShowHotmartTokenAlert(...)` and to display a prominent red alert on the `/hotmart` page when the latest collection job indicates a token problem, instructing the user to update the Hotmart JWT.
- Tests and docs: added/updated unit test `mois-hotmart-collector/src/test/java/com/marketinghub/moishotmart/service/HotmartCollectorServiceTest.java` to validate the token-detection helpers and updated `docs/registros/mois1.md` with the operational record.

### Testing
- Added unit tests in `mois-hotmart-collector` and started automated test execution with `mvn test` in `mois-hotmart-collector`; the Maven run was initiated in the rollout but did not complete in the transcript, so test results are not available here. 
- No frontend automated tests were executed during this rollout (manual code changes only to `frontend/src/pages/hotmart/HotmartPage.tsx`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1caa14a36483218d0394bf7b856674)