### PR TITLE
Agendar ciclo 1 Hotmart para 20:40 (31/05)

### DIFF
--- a/docs/registros/mois1.md
+++ b/docs/registros/mois1.md
@@ -673,3 +673,12 @@ Arquivos alterados:
 - `mois-hotmart-collector/src/main/java/com/marketinghub/moishotmart/service/HotmartCollectorService.java`
 - `mois-hotmart-collector/src/test/java/com/marketinghub/moishotmart/service/HotmartCollectorServiceTest.java`
 - `frontend/src/pages/hotmart/HotmartPage.tsx`
+
+## 2026-05-31 20:12:49 UTC-3
+- solicitado novo agendamento operacional do ciclo 1 do coletor Hotmart para 20:40 de 31 de maio, no horário de São Paulo.
+- a causa-raiz operacional era que o agendamento especial vigente estava fixado para 18:15 do mesmo dia, horário já inadequado para a nova janela solicitada.
+- atualizado o `HotmartCollectorScheduler` para disparar o ciclo 1 com cron `0 40 20 31 5 *`, mantendo `zone = "America/Sao_Paulo"` e log operacional alinhado para `hora=20:40`.
+- documentos lidos para tratar a situação:
+  - docs/canonical/mois-hotmart-mapeamento-ciclos-campos-banco.md
+  - mois-hotmart-collector/AGENTS.md
+  - docs/registros/mois1.md

--- a/mois-hotmart-collector/src/main/java/com/marketinghub/moishotmart/service/HotmartCollectorScheduler.java
+++ b/mois-hotmart-collector/src/main/java/com/marketinghub/moishotmart/service/HotmartCollectorScheduler.java
@@ -34,17 +34,17 @@ public class HotmartCollectorScheduler {
     }
 
     /**
-     * Executa o ciclo 1 de listagem de produtos às 18:15 no dia 31 de maio, no horário de São Paulo.
+     * Executa o ciclo 1 de listagem de produtos às 20:40 no dia 31 de maio, no horário de São Paulo.
      */
-    @Scheduled(cron = "0 15 18 31 5 *", zone = "America/Sao_Paulo")
-    public void collectFirstCycleAtEighteenFifteenOnMayThirtyFirst() {
+    @Scheduled(cron = "0 40 20 31 5 *", zone = "America/Sao_Paulo")
+    public void collectFirstCycleAtTwentyFortyOnMayThirtyFirst() {
         if (!enabled) {
             log.info("Hotmart scheduler desabilitado por configuração.");
             return;
         }
         HotmartCollectionRequest request = new HotmartCollectionRequest(source, maxProducts);
         HotmartCollectionResponse response = collectorService.collectFirstCycle(request);
-        log.info("Hotmart scheduler executado hora=18:15 dia=31/05 timezone=America/Sao_Paulo ciclo={} status={} produtos={} mensagem={}",
+        log.info("Hotmart scheduler executado hora=20:40 dia=31/05 timezone=America/Sao_Paulo ciclo={} status={} produtos={} mensagem={}",
                 "CICLO_1_LISTAGEM",
                 response.status(),
                 response.products().size(),


### PR DESCRIPTION
### Motivation
- Ajustar o agendamento operacional do coletor Hotmart para a nova janela solicitada do dia 31/05, pois o agendamento pontual anterior às 18:15 já não era adequado.
- Registrar a mudança no arquivo canônico de operações do MOIS para manter rastreabilidade e conformidade com as regras do módulo.

### Description
- Altera o scheduler em `mois-hotmart-collector/src/main/java/com/marketinghub/moishotmart/service/HotmartCollectorScheduler.java` trocando o `@Scheduled` do ciclo 1 para o cron `0 40 20 31 5 *` (fuso `America/Sao_Paulo`) e renomeando o método para `collectFirstCycleAtTwentyFortyOnMayThirtyFirst`.
- Atualiza a mensagem de log do disparo para refletir `hora=20:40 dia=31/05 timezone=America/Sao_Paulo` quando o ciclo 1 for executado.
- Adiciona registro operacional em `docs/registros/mois1.md` com data/hora `2026-05-31 20:12:49 UTC-3` documentando a solicitação e a alteração aplicada.

### Testing
- Executado `mvn test` no módulo `mois-hotmart-collector` e todos os testes unitários passaram com sucesso (`Tests run: 4, Failures: 0, Errors: 0`).
- A build do módulo finalizou com `BUILD SUCCESS` após recompilação das fontes alteradas.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1cc03d0eb483218ff863ccd7c40d0c)