### PR TITLE
Persist GeraLanding HTML after design preset response

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/presetdesign/service/BackendPresetDesignService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/presetdesign/service/BackendPresetDesignService.java
@@ -7,6 +7,7 @@ import com.marketinghub.experiment.Experiment;
 import com.marketinghub.experiment.repository.ExperimentRepository;
 import com.marketinghub.geralanding.GeraLandingStageExecution;
 import com.marketinghub.geralanding.GeraLandingStageExecutionRepository;
+import com.marketinghub.geralanding.designpreset.DesignPresetProvisionalHtmlAssembler;
 import com.marketinghub.geralanding.presetdesign.service.detailStageExecution.RecordBackendPresetDesignDetalheDto;
 import com.marketinghub.geralanding.presetdesign.service.listStageExecutions.GeraLandingPresetDesignExecutionSummaryResponse;
 import com.marketinghub.geralanding.presetdesign.service.pending.RecordPresetDesignExperiment;
@@ -40,15 +41,18 @@ public class BackendPresetDesignService {
     private final ExperimentRepository experimentRepository;
     private final GeraLandingStageExecutionRepository executionRepository;
     private final ObjectMapper objectMapper;
+    private final DesignPresetProvisionalHtmlAssembler designPresetProvisionalHtmlAssembler;
 
-    /** Inicializa o serviço com os repositórios necessários para consultar execuções de design preset. */
+    /** Inicializa o serviço com os repositórios e montador necessários para consultar e finalizar execuções de design preset. */
     public BackendPresetDesignService(
             ExperimentRepository experimentRepository,
             GeraLandingStageExecutionRepository executionRepository,
-            ObjectMapper objectMapper) {
+            ObjectMapper objectMapper,
+            DesignPresetProvisionalHtmlAssembler designPresetProvisionalHtmlAssembler) {
         this.experimentRepository = experimentRepository;
         this.executionRepository = executionRepository;
         this.objectMapper = objectMapper;
+        this.designPresetProvisionalHtmlAssembler = designPresetProvisionalHtmlAssembler;
     }
 
 
@@ -225,6 +229,25 @@ public class BackendPresetDesignService {
         }
         experiment.setLandingPageDesignPreset(modelResponse);
         experimentRepository.save(experiment);
+
+        String htmlGeraLanding = assembleHtmlGeraLanding(execution, experiment, modelResponse);
+        if (StringUtils.hasText(htmlGeraLanding)) {
+            experiment.setHtmlGeraLanding(htmlGeraLanding);
+            execution.setProvisionalHtml(htmlGeraLanding);
+            executionRepository.save(execution);
+            experimentRepository.save(experiment);
+        }
+    }
+
+
+    /** Monta o HTML final do GeraLanding usando os artefatos canônicos disponíveis no experimento. */
+    private String assembleHtmlGeraLanding(GeraLandingStageExecution execution, Experiment experiment, String modelResponse) {
+        return designPresetProvisionalHtmlAssembler.assemble(
+                experiment.getLandingPageWireframe(),
+                experiment.getLandingPageCopy(),
+                experiment.getLandingPageImagePlanning(),
+                modelResponse,
+                fromDatabaseIdJob(execution.getIdJob()));
     }
 
     /** Converte o experimento da execução para os dados expostos na fila pending. */

--- a/backend/ads-service/src/test/java/com/marketinghub/geralanding/presetdesign/service/BackendPresetDesignServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/geralanding/presetdesign/service/BackendPresetDesignServiceTest.java
@@ -7,6 +7,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -15,6 +16,7 @@ import com.marketinghub.experiment.Experiment;
 import com.marketinghub.experiment.repository.ExperimentRepository;
 import com.marketinghub.geralanding.GeraLandingStageExecution;
 import com.marketinghub.geralanding.GeraLandingStageExecutionRepository;
+import com.marketinghub.geralanding.designpreset.DesignPresetProvisionalHtmlAssembler;
 import com.marketinghub.geralanding.presetdesign.service.detailStageExecution.RecordBackendPresetDesignDetalheDto;
 import com.marketinghub.geralanding.presetdesign.service.listStageExecutions.GeraLandingPresetDesignExecutionSummaryResponse;
 import com.marketinghub.geralanding.presetdesign.service.pending.RecordPresetDesignPending;
@@ -35,7 +37,7 @@ class BackendPresetDesignServiceTest {
         ExperimentRepository experimentRepository = mock(ExperimentRepository.class);
         GeraLandingStageExecutionRepository executionRepository = mock(GeraLandingStageExecutionRepository.class);
         BackendPresetDesignService service =
-                new BackendPresetDesignService(experimentRepository, executionRepository, new ObjectMapper());
+                new BackendPresetDesignService(experimentRepository, executionRepository, new ObjectMapper(), mock(DesignPresetProvisionalHtmlAssembler.class));
         Experiment experiment = mock(Experiment.class);
         when(experiment.getId()).thenReturn(91L);
         when(experimentRepository.findById(91L)).thenReturn(Optional.of(experiment));
@@ -62,7 +64,7 @@ class BackendPresetDesignServiceTest {
         ExperimentRepository experimentRepository = mock(ExperimentRepository.class);
         GeraLandingStageExecutionRepository executionRepository = mock(GeraLandingStageExecutionRepository.class);
         BackendPresetDesignService service =
-                new BackendPresetDesignService(experimentRepository, executionRepository, new ObjectMapper());
+                new BackendPresetDesignService(experimentRepository, executionRepository, new ObjectMapper(), mock(DesignPresetProvisionalHtmlAssembler.class));
         Experiment experiment = mock(Experiment.class);
         when(experiment.getId()).thenReturn(77L);
         when(experiment.getName()).thenReturn("Experimento DesignPreset");
@@ -123,7 +125,7 @@ class BackendPresetDesignServiceTest {
         ExperimentRepository experimentRepository = mock(ExperimentRepository.class);
         GeraLandingStageExecutionRepository executionRepository = mock(GeraLandingStageExecutionRepository.class);
         BackendPresetDesignService service =
-                new BackendPresetDesignService(experimentRepository, executionRepository, new ObjectMapper());
+                new BackendPresetDesignService(experimentRepository, executionRepository, new ObjectMapper(), mock(DesignPresetProvisionalHtmlAssembler.class));
         GeraLandingStageExecution execution = GeraLandingStageExecution.builder()
                 .idJob("job-design-preset".getBytes(StandardCharsets.UTF_8))
                 .status("INICIADO")
@@ -147,9 +149,20 @@ class BackendPresetDesignServiceTest {
     void markCompletedFromResponseShouldPersistDesignPresetArtifactOnSuccess() {
         ExperimentRepository experimentRepository = mock(ExperimentRepository.class);
         GeraLandingStageExecutionRepository executionRepository = mock(GeraLandingStageExecutionRepository.class);
+        DesignPresetProvisionalHtmlAssembler htmlAssembler = mock(DesignPresetProvisionalHtmlAssembler.class);
         BackendPresetDesignService service =
-                new BackendPresetDesignService(experimentRepository, executionRepository, new ObjectMapper());
+                new BackendPresetDesignService(experimentRepository, executionRepository, new ObjectMapper(), htmlAssembler);
         Experiment experiment = mock(Experiment.class);
+        when(experiment.getLandingPageWireframe()).thenReturn("{\"landingPageWireframe\":{}}");
+        when(experiment.getLandingPageCopy()).thenReturn("{\"landingPageCopy\":{}}");
+        when(experiment.getLandingPageImagePlanning()).thenReturn("{\"landingPageImagePlanning\":{}}");
+        when(htmlAssembler.assemble(
+                "{\"landingPageWireframe\":{}}",
+                "{\"landingPageCopy\":{}}",
+                "{\"landingPageImagePlanning\":{}}",
+                "{\"landingPageDesignPreset\":{}}",
+                "job-design-preset"))
+                .thenReturn("<html>GeraLanding Design Preset</html>");
         GeraLandingStageExecution execution = GeraLandingStageExecution.builder()
                 .experimentId(88L)
                 .experiment(experiment)
@@ -166,7 +179,15 @@ class BackendPresetDesignServiceTest {
 
         assertEquals("CONCLUIDO", execution.getStatus());
         verify(experiment).setLandingPageDesignPreset("{\"landingPageDesignPreset\":{}}");
-        verify(experimentRepository).save(experiment);
+        verify(htmlAssembler).assemble(
+                "{\"landingPageWireframe\":{}}",
+                "{\"landingPageCopy\":{}}",
+                "{\"landingPageImagePlanning\":{}}",
+                "{\"landingPageDesignPreset\":{}}",
+                "job-design-preset");
+        verify(experiment).setHtmlGeraLanding("<html>GeraLanding Design Preset</html>");
+        assertEquals("<html>GeraLanding Design Preset</html>", execution.getProvisionalHtml());
+        verify(experimentRepository, times(2)).save(experiment);
     }
 
     /** Deve marcar falha sem sobrescrever o artefato final de design preset no experimento. */
@@ -175,7 +196,7 @@ class BackendPresetDesignServiceTest {
         ExperimentRepository experimentRepository = mock(ExperimentRepository.class);
         GeraLandingStageExecutionRepository executionRepository = mock(GeraLandingStageExecutionRepository.class);
         BackendPresetDesignService service =
-                new BackendPresetDesignService(experimentRepository, executionRepository, new ObjectMapper());
+                new BackendPresetDesignService(experimentRepository, executionRepository, new ObjectMapper(), mock(DesignPresetProvisionalHtmlAssembler.class));
         Experiment experiment = mock(Experiment.class);
         GeraLandingStageExecution execution = GeraLandingStageExecution.builder()
                 .experimentId(88L)

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -2835,3 +2835,15 @@
 - impacto esperado: a etapa PresetDesign passa a operar no padrão novo do Worker AI core, com rastreabilidade uniforme e menos risco de duplicidade operacional, fortalecendo a criação de landing pages mais vendáveis e consistentes.
 - ajuste complementar: criado no backend o contrato interno da etapa `design-preset` com fila pending e callbacks `recebe-prompt`/`recebe-resposta`, para que o novo Worker AI core tenha endpoints reais equivalentes aos da etapa wireframe.
 - 2026-05-31 UTC — Reestruturada a etapa backend de preset design do GeraLanding para o pacote canônico `geralanding.presetdesign`, em paridade com `geralanding.wireframe`: controller `BackendPresetDesignController`, serviço `BackendPresetDesignService` e DTOs em subpacotes `detailStageExecution`, `listStageExecutions`, `pending`, `recebePrompt` e `recebeResposta`, preservando os endpoints HTTP existentes de `design-preset`.
+
+## 2026-05-31 20:14:52 UTC-3
+- solicitação: no backend, acionar o assembler de HTML do módulo design preset após o callback de resposta do Worker AI, persistindo o HTML gerado em `html_geralanding`/`htmlGeraLanding`.
+- raciocínio: a etapa específica `landing-page-design-preset` já persistia o JSON canônico recebido do Worker AI, mas o novo serviço backend da etapa não consolidava automaticamente wireframe, copy, planejamento de imagem e preset em HTML final para uso pelo GeraLanding.
+- foi feito: `BackendPresetDesignService` passou a receber `DesignPresetProvisionalHtmlAssembler`, montar o HTML após salvar o design preset no experimento, persistir o resultado em `htmlGeraLanding` e registrar o mesmo HTML em `provisionalHtml` da execução; o teste unitário da etapa foi ajustado para cobrir essa montagem e persistência.
+- documentos lidos para pesquisar e resolver o problema:
+  - AGENTS.md
+  - backend/AGENTS.md
+  - docs/registros/experimentos.md
+  - backend/ads-service/src/main/java/com/marketinghub/geralanding/presetdesign/service/BackendPresetDesignService.java
+  - backend/ads-service/src/main/java/com/marketinghub/geralanding/designpreset/DesignPresetProvisionalHtmlAssembler.java
+  - backend/ads-service/src/test/java/com/marketinghub/geralanding/presetdesign/service/BackendPresetDesignServiceTest.java


### PR DESCRIPTION
### Motivation
- Ensure the backend assembles and persists the consolidated GeraLanding HTML immediately after a successful `landing-page-design-preset` Worker AI response instead of only saving the JSON preset artifact. 
- This enables downstream flows (previews, publish, Lead Portal) to consume a ready-to-use HTML payload stored in `html_geralanding` / `htmlGeraLanding` and avoids duplication of assembly logic in other modules.

### Description
- Injected `DesignPresetProvisionalHtmlAssembler` into `BackendPresetDesignService` and added an `assembleHtmlGeraLanding(...)` helper to produce the consolidated HTML from wireframe, copy, image planning and design preset. 
- After persisting the design preset JSON in `persistDesignPresetArtifactOnExperiment(...)` the service now calls the assembler and, when HTML is produced, sets `experiment.setHtmlGeraLanding(...)`, mirrors it to the execution `provisionalHtml` and saves both the execution and the experiment. 
- Updated `BackendPresetDesignServiceTest` to mock the assembler and verify the assembler call, persistence of `htmlGeraLanding`, and update of the execution `provisionalHtml`. 
- Added an operational entry in `docs/registros/experimentos.md` documenting the change. 

### Testing
- Ran the unit test class `BackendPresetDesignServiceTest` using `../mvnw -Dtest=BackendPresetDesignServiceTest test` in the `backend/ads-service` module and all tests passed (`Tests run: 5, Failures: 0`). 
- Existing unit coverage for the preset design flow was updated and the modified tests succeeded locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1cc00495848321ad4ade44bf3c28d0)