### PR TITLE
Make landing-page-design-preset JSON Schema strict for OpenAI Structured Outputs and add validation tests

### DIFF
--- a/ai-worker/src/main/resources/prompts/geralanding/landing-page-design-preset-schema.json
+++ b/ai-worker/src/main/resources/prompts/geralanding/landing-page-design-preset-schema.json
@@ -65,41 +65,74 @@
     },
     "pagina": {
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
-        "body": {
+        "head": {
           "type": "object",
-          "additionalProperties": true,
+          "additionalProperties": false,
           "properties": {
-            "estilos": {
-              "type": "array",
-              "items": {
-                "type": "string",
-                "minLength": 1
-              }
+            "texto": {
+              "type": "string"
             }
-          }
+          },
+          "required": [
+            "texto"
+          ]
         },
         "corpo": {
           "type": "object",
-          "additionalProperties": true,
+          "additionalProperties": false,
           "properties": {
             "estilos": {
               "type": "array",
+              "minItems": 4,
+              "maxItems": 4,
               "items": {
                 "type": "string",
-                "minLength": 1
+                "enum": [
+                  "bgBody",
+                  "fontBase",
+                  "textPrimary",
+                  "marginReset"
+                ]
               }
             },
             "secoes": {
               "type": "array",
+              "minItems": 4,
               "items": {
-                "$ref": "#/$defs/paginaNode"
+                "$ref": "#/$defs/secao"
               }
             }
-          }
+          },
+          "required": [
+            "estilos",
+            "secoes"
+          ]
+        },
+        "body": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "estilos": {
+              "type": "array",
+              "minItems": 1,
+              "items": {
+                "type": "string",
+                "minLength": 1
+              }
+            }
+          },
+          "required": [
+            "estilos"
+          ]
         }
-      }
+      },
+      "required": [
+        "head",
+        "body",
+        "corpo"
+      ]
     }
   },
   "$defs": {
@@ -220,30 +253,288 @@
         }
       }
     },
-    "paginaNode": {
+    "secao": {
       "type": "object",
-      "additionalProperties": true,
+      "additionalProperties": false,
       "properties": {
-        "estilos": {
-          "type": "array",
-          "items": {
-            "type": "string",
-            "minLength": 1
-          }
+        "nome": {
+          "type": "string"
+        },
+        "objetivo": {
+          "type": "string"
+        },
+        "id": {
+          "type": "string"
         },
         "elementosSeccao": {
           "type": "array",
+          "minItems": 1,
           "items": {
-            "$ref": "#/$defs/paginaNode"
+            "$ref": "#/$defs/elementoSecao"
           }
+        },
+        "oQueQuerProvocarNoUsuario": {
+          "type": "string"
+        },
+        "papelComercial": {
+          "type": "string"
+        },
+        "fasePersuasao": {
+          "type": "string"
+        },
+        "objeçãoQueRemove": {
+          "type": "string"
+        },
+        "prioridadeConversao": {
+          "type": "integer",
+          "minimum": 1,
+          "maximum": 10
+        },
+        "acaoEsperada": {
+          "type": "string"
+        },
+        "fonteContexto": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "string"
+          }
+        },
+        "estilos": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "required": [
+        "nome",
+        "objetivo",
+        "oQueQuerProvocarNoUsuario",
+        "papelComercial",
+        "fasePersuasao",
+        "objeçãoQueRemove",
+        "prioridadeConversao",
+        "acaoEsperada",
+        "fonteContexto",
+        "id",
+        "estilos",
+        "elementosSeccao"
+      ]
+    },
+    "textoElemento": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "tamMaximo": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "tamMinimo": {
+          "type": "integer",
+          "minimum": 1
+        },
+        "conteudo": {
+          "type": "string",
+          "maxLength": 0
+        }
+      },
+      "required": [
+        "tamMaximo",
+        "tamMinimo",
+        "conteudo"
+      ]
+    },
+    "elementoSecao": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "id": {
+          "type": "string"
+        },
+        "tag": {
+          "type": "string"
+        },
+        "texto": {
+          "$ref": "#/$defs/textoElemento"
         },
         "elementosInternos": {
           "type": "array",
           "items": {
-            "$ref": "#/$defs/paginaNode"
+            "$ref": "#/$defs/elementoSecao"
           }
+        },
+        "estilos": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "briefingVisual": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "$ref": "#/$defs/briefingVisual"
+            }
+          ]
+        },
+        "componente": {
+          "type": "string",
+          "enum": [
+            "none",
+            "buttonPrimary",
+            "buttonSecondary",
+            "formInput",
+            "card"
+          ]
+        },
+        "interacao": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "intencaoAcao": {
+              "type": "string"
+            },
+            "targetSectionId": {
+              "type": [
+                "string",
+                "null"
+              ],
+              "pattern": "^#"
+            },
+            "hrefEsperado": {
+              "type": [
+                "string",
+                "null"
+              ]
+            }
+          },
+          "required": [
+            "intencaoAcao",
+            "targetSectionId",
+            "hrefEsperado"
+          ]
+        },
+        "asset": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "src": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "alt": {
+                  "type": "string",
+                  "minLength": 1
+                },
+                "width": {
+                  "type": "integer",
+                  "minimum": 1
+                },
+                "height": {
+                  "type": "integer",
+                  "minimum": 1
+                }
+              },
+              "required": [
+                "src",
+                "alt",
+                "width",
+                "height"
+              ]
+            }
+          ]
+        },
+        "contratoCampo": {
+          "anyOf": [
+            {
+              "type": "null"
+            },
+            {
+              "type": "object",
+              "additionalProperties": false,
+              "properties": {
+                "type": {
+                  "type": "string"
+                },
+                "name": {
+                  "type": "string"
+                },
+                "autocomplete": {
+                  "type": "string"
+                },
+                "required": {
+                  "type": "boolean"
+                },
+                "placeholder": {
+                  "type": "string"
+                }
+              },
+              "required": [
+                "type",
+                "name",
+                "autocomplete",
+                "required",
+                "placeholder"
+              ]
+            }
+          ]
         }
-      }
+      },
+      "required": [
+        "id",
+        "tag",
+        "texto",
+        "estilos",
+        "briefingVisual",
+        "elementosInternos",
+        "interacao",
+        "asset",
+        "contratoCampo",
+        "componente"
+      ]
+    },
+    "briefingVisual": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "ondeEntraNoVisual": {
+          "type": "string"
+        },
+        "tipoVisualEsperado": {
+          "type": "string"
+        },
+        "funcaoComercial": {
+          "type": "string"
+        },
+        "objecaoQueRemove": {
+          "type": "string"
+        },
+        "classificacaoVisual": {
+          "type": "string",
+          "enum": [
+            "mockup",
+            "foto",
+            "ilustração",
+            "diagrama",
+            "print conceitual"
+          ]
+        }
+      },
+      "required": [
+        "ondeEntraNoVisual",
+        "tipoVisualEsperado",
+        "funcaoComercial",
+        "objecaoQueRemove",
+        "classificacaoVisual"
+      ]
     }
   }
 }

--- a/ai-worker/src/main/resources/prompts/geralanding/landing-page-design-preset.md
+++ b/ai-worker/src/main/resources/prompts/geralanding/landing-page-design-preset.md
@@ -199,7 +199,39 @@ Formato esperado de saída:
     "animações": { "desktop": [], "mobile": [] }
   },
   "pagina": {
+    "head": { "texto": "" },
     "body": { "estilos": ["pageRoot", "bgBody", "fontBase", "textPrimary"] },
-    "corpo": { "secoes": [ { "id": "sec-hero", "estilos": ["sectionHero", "surfaceBand"], "elementosSeccao": [] } ] }
+    "corpo": {
+      "estilos": ["bgBody", "fontBase", "textPrimary", "marginReset"],
+      "secoes": [
+        {
+          "nome": "Hero",
+          "objetivo": "Apresentar a promessa central",
+          "oQueQuerProvocarNoUsuario": "percepção de valor imediato",
+          "papelComercial": "atração",
+          "fasePersuasao": "atenção",
+          "objeçãoQueRemove": "falta de clareza",
+          "prioridadeConversao": 10,
+          "acaoEsperada": "avançar para o CTA",
+          "fonteContexto": ["landingPageWireframe"],
+          "id": "sec-hero",
+          "estilos": ["sectionHero", "surfaceBand"],
+          "elementosSeccao": [
+            {
+              "id": "hero-title",
+              "tag": "h1",
+              "texto": { "tamMaximo": 90, "tamMinimo": 45, "conteudo": "" },
+              "estilos": ["headlineHero", "textPrimary"],
+              "briefingVisual": null,
+              "elementosInternos": [],
+              "interacao": { "intencaoAcao": "", "targetSectionId": null, "hrefEsperado": null },
+              "asset": null,
+              "contratoCampo": null,
+              "componente": "none"
+            }
+          ]
+        }
+      ]
+    }
   }
 }

--- a/ai-worker/src/test/java/com/marketinghub/worker/openai/core/presetdesign/PresetDesignBackendClientTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/openai/core/presetdesign/PresetDesignBackendClientTest.java
@@ -8,15 +8,19 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marketinghub.worker.openai.core.exception.OpenAiHttpException;
 import com.marketinghub.worker.openai.core.model.OpenAiDispatch;
 import com.marketinghub.worker.openai.core.model.StageExecution;
+import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Map;
-import java.math.BigDecimal;
 import okhttp3.mockwebserver.MockResponse;
 import okhttp3.mockwebserver.MockWebServer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.springframework.core.io.ClassPathResource;
 import org.springframework.web.reactive.function.client.WebClient;
 
 /** Responsabilidade: validar o contrato HTTP do client design-preset do core OpenAI. */
@@ -179,6 +183,124 @@ class PresetDesignBackendClientTest {
         assertThat(body.path("text").path("format").path("name").asText())
                 .isEqualTo("experiment_pipeline_landing_page_design_preset");
         assertThat(body.path("text").path("format").path("strict").asBoolean()).isTrue();
+    }
+
+    /** Deve manter o schema de design-preset compatível com Structured Outputs estrito da OpenAI. */
+    @Test
+    void presetDesignSchemaShouldDeclareAdditionalPropertiesFalseForEveryObject() throws Exception {
+        String schemaJson = new ClassPathResource("prompts/geralanding/landing-page-design-preset-schema.json")
+                .getContentAsString(StandardCharsets.UTF_8);
+        JsonNode schema = objectMapper.readTree(schemaJson);
+        List<String> invalidPaths = new ArrayList<>();
+
+        collectObjectSchemasWithoutStrictAdditionalProperties(schema, "$", invalidPaths);
+
+        assertThat(invalidPaths).isEmpty();
+    }
+
+
+    /** Deve manter required com todas as propriedades para cumprir Structured Outputs estrito. */
+    @Test
+    void presetDesignSchemaShouldRequireEveryDeclaredObjectProperty() throws Exception {
+        String schemaJson = new ClassPathResource("prompts/geralanding/landing-page-design-preset-schema.json")
+                .getContentAsString(StandardCharsets.UTF_8);
+        JsonNode schema = objectMapper.readTree(schemaJson);
+        List<String> invalidPaths = new ArrayList<>();
+
+        collectObjectSchemasWithoutCompleteRequired(schema, "$", invalidPaths);
+
+        assertThat(invalidPaths).isEmpty();
+    }
+
+    /** Deve manter o schema de design-preset sem palavras-chave rejeitadas pela OpenAI Structured Outputs. */
+    @Test
+    void presetDesignSchemaShouldNotContainUnsupportedOpenAiStructuredOutputKeywords() throws Exception {
+        String schemaJson = new ClassPathResource("prompts/geralanding/landing-page-design-preset-schema.json")
+                .getContentAsString(StandardCharsets.UTF_8);
+
+        assertThat(schemaJson)
+                .doesNotContain("\"allOf\"")
+                .doesNotContain("\"if\"")
+                .doesNotContain("\"then\"")
+                .doesNotContain("\"not\"");
+    }
+
+    /** Percorre recursivamente o schema e lista objetos que não bloqueiam propriedades extras. */
+    private void collectObjectSchemasWithoutStrictAdditionalProperties(JsonNode node, String path, List<String> invalidPaths) {
+        if (node == null || node.isMissingNode()) {
+            return;
+        }
+        if (node.isObject()) {
+            JsonNode type = node.path("type");
+            if (isObjectSchemaType(type) && !hasExplicitFalseAdditionalProperties(node)) {
+                invalidPaths.add(path);
+            }
+            node.fields().forEachRemaining(entry ->
+                    collectObjectSchemasWithoutStrictAdditionalProperties(
+                            entry.getValue(), path + "." + entry.getKey(), invalidPaths));
+            return;
+        }
+        if (node.isArray()) {
+            for (int index = 0; index < node.size(); index++) {
+                collectObjectSchemasWithoutStrictAdditionalProperties(node.get(index), path + "[" + index + "]", invalidPaths);
+            }
+        }
+    }
+
+
+    /** Percorre recursivamente o schema e lista objetos cujo required não cobre todas as properties. */
+    private void collectObjectSchemasWithoutCompleteRequired(JsonNode node, String path, List<String> invalidPaths) {
+        if (node == null || node.isMissingNode()) {
+            return;
+        }
+        if (node.isObject()) {
+            if (isObjectSchemaType(node.path("type")) && !hasRequiredForEveryProperty(node)) {
+                invalidPaths.add(path);
+            }
+            node.fields().forEachRemaining(entry ->
+                    collectObjectSchemasWithoutCompleteRequired(entry.getValue(), path + "." + entry.getKey(), invalidPaths));
+            return;
+        }
+        if (node.isArray()) {
+            for (int index = 0; index < node.size(); index++) {
+                collectObjectSchemasWithoutCompleteRequired(node.get(index), path + "[" + index + "]", invalidPaths);
+            }
+        }
+    }
+
+    /** Verifica se required contém exatamente todos os nomes de properties do objeto. */
+    private boolean hasRequiredForEveryProperty(JsonNode node) {
+        JsonNode properties = node.path("properties");
+        JsonNode required = node.path("required");
+        if (!properties.isObject() || !required.isArray()) {
+            return false;
+        }
+        List<String> propertyNames = new ArrayList<>();
+        properties.fieldNames().forEachRemaining(propertyNames::add);
+        List<String> requiredNames = new ArrayList<>();
+        required.forEach(item -> requiredNames.add(item.asText()));
+        return requiredNames.containsAll(propertyNames) && propertyNames.containsAll(requiredNames);
+    }
+
+    /** Confirma que objetos declaram additionalProperties explicitamente como false. */
+    private boolean hasExplicitFalseAdditionalProperties(JsonNode node) {
+        JsonNode additionalProperties = node.path("additionalProperties");
+        return additionalProperties.isBoolean() && !additionalProperties.asBoolean();
+    }
+
+    /** Identifica declarações de schema JSON para tipo object em formato textual ou lista de tipos. */
+    private boolean isObjectSchemaType(JsonNode type) {
+        if (type.isTextual()) {
+            return "object".equals(type.asText());
+        }
+        if (type.isArray()) {
+            for (JsonNode candidate : type) {
+                if (candidate.isTextual() && "object".equals(candidate.asText())) {
+                    return true;
+                }
+            }
+        }
+        return false;
     }
 
 }

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -2857,3 +2857,13 @@
   - ajustada a regra ArchUnit para exigir o assembler em `presetdesign.provisorio` e permitir dependências de `geralanding.<etapa>.service` para `geralanding.<etapa>.provisorio` da mesma etapa;
   - sincronizados os documentos canônicos de arquitetura e procedimento do experimento.
 - impacto esperado: a etapa `landing-page-design-preset` mantém o HTML provisório dentro da própria fronteira da etapa, reduzindo acoplamento indevido e preservando a montagem necessária para gerar landing pages vendáveis.
+
+## 2026-06-01 — Schema estrito do PresetDesign para OpenAI Responses
+- tarefa: corrigir o erro HTTP 400 `invalid_json_schema` retornado pela OpenAI na etapa `landing-page-design-preset`.
+- causa-raiz: o schema `landing-page-design-preset-schema.json` ainda permitia objetos flexíveis com `additionalProperties: true`, incompatíveis com Structured Outputs em `strict=true` usado pelo Worker AI core.
+- correção aplicada:
+  - o schema da etapa passou a declarar `additionalProperties: false` em todos os objetos, incluindo `pagina`, `body`, `corpo` e nós internos reutilizados da estrutura de wireframe;
+  - o contrato de `pagina` foi explicitado com `head`, `body` e `corpo`, preservando a hierarquia do wireframe e adicionando o bloco global de estilos do body exigido pelo prompt;
+  - o exemplo do prompt foi sincronizado com o schema estrito;
+  - adicionados testes regressivos para impedir retorno de `additionalProperties` permissivo e palavras-chave rejeitadas no schema da etapa.
+- impacto esperado: novas execuções do PresetDesign deixam de ser recusadas antes da geração pela OpenAI e mantêm a etapa disponível para concluir o Gera Landing com acabamento visual consistente e voltado à conversão.


### PR DESCRIPTION
### Motivation
- Fix OpenAI `invalid_json_schema` errors by making the preset design schema compatible with Structured Outputs in `strict=true` mode. 
- Preserve a clear, explicit `pagina`/wireframe contract so the Worker AI and backend can reliably assemble landing pages. 
- Prevent regressions by adding automated checks that detect permissive schema constructs and unsupported OpenAI keywords.

### Description
- Updated `prompts/geralanding/landing-page-design-preset-schema.json` to declare `additionalProperties: false` for object schemas, add explicit `required` arrays, and restructure `pagina` into `head`, `body` and `corpo` with required fields. 
- Introduced new `$defs`: `secao`, `elementoSecao`, `textoElemento`, and `briefingVisual`, and enriched element properties (interaction, asset, componente, contratoCampo, estilos, etc.). 
- Synchronized the example in `prompts/geralanding/landing-page-design-preset.md` with the new strict schema shape (adds `head`, `corpo.estilos`, full `secoes` example and section/element structure). 
- Added schema-regression unit tests in `PresetDesignBackendClientTest` to assert `additionalProperties:false`, that every object lists all its properties in `required`, and that the schema does not contain OpenAI-rejected keywords (`allOf`, `if`, `then`, `not`).

### Testing
- Executed `PresetDesignBackendClientTest`, including `presetDesignSchemaShouldDeclareAdditionalPropertiesFalseForEveryObject`, `presetDesignSchemaShouldRequireEveryDeclaredObjectProperty`, `presetDesignSchemaShouldNotContainUnsupportedOpenAiStructuredOutputKeywords`, and `markDispatchedShouldSendPromptSchemaAndRawRequestToRecebePrompt`, and all assertions passed. 
- Ran the project's unit test suite (`mvn -DskipTests=false test`) and observed successful completion of the tests that cover the modified code paths.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ce340be548321935b773e70917769)