### PR TITLE
Simplifica OPRM para iniciar por CNAEs

### DIFF
--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -198,3 +198,5 @@
 
 - 2026-05-31: Revisado o documento `docs/novos-modulos/OPRM/oprm-cnae-para-nichos-arquitetura.md` para refletir que o score e o enriquecimento CNAE serão executados por schedulers do módulo OPRM, com ciclos rastreáveis, enquanto o backend ficará restrito a leitura/gravação e persistência. Atualizado o cânone OPRM com a regra de responsabilidade do OPRM no fluxo CNAE → oportunidade.
 - 2026-06-01 00:00:00 (UTC): implementada a primeira versão operacional do fluxo CNAE → score → enriquecimento → candidatos: backend recebeu tabelas, entidades, DTOs e endpoints OPRM apenas para leitura/gravação; `oprm-coletor-mei` recebeu schedulers automáticos `CNAE_SCORE` e `CNAE_ENRICHMENT` com `cycleId`, `cycleType` e `cycleNumber`; frontend `/oprm/cnaes-volume` passou a exibir score e últimos ciclos sem botão de geração manual.
+
+- 2026-05-31 23:12:12 (UTC-3): simplificada a navegação inicial do OPRM no frontend para manter somente a entrada de CNAEs; a rota `/oprm` agora abre diretamente o ranking de CNAEs, removendo da tela inicial os atalhos de workspace, rotina, oferta, evidências, feedback, catálogo e operações para permitir reinício do fluxo OPRM por CNAE.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -101,7 +101,6 @@ import PromptDomainListPage from "./pages/promptDomain/PromptDomainListPage";
 import NewPromptDomainPage from "./pages/promptDomain/NewPromptDomainPage";
 import EditPromptDomainPage from "./pages/promptDomain/EditPromptDomainPage";
 import TargetingRecentQueriesPage from "./pages/targeting/TargetingRecentQueriesPage";
-import OprmWorkspacePage from "./pages/oprm/OprmWorkspacePage";
 import OprmRoutinePage from "./pages/oprm/OprmRoutinePage";
 import OprmOfferPage from "./pages/oprm/OprmOfferPage";
 import OprmEvidencePage from "./pages/oprm/OprmEvidencePage";
@@ -274,7 +273,7 @@ export default function App() {
                 path="/targeting/recent-queries"
                 element={<TargetingRecentQueriesPage />}
               />
-              <Route path="/oprm" element={<OprmWorkspacePage />} />
+              <Route path="/oprm" element={<OprmCnaeVolumePage />} />
               <Route path="/mois" element={<MoisWorkspacePage />} />
               <Route path="/mois/references/new" element={<MoisReferenceIntakePage />} />
               <Route path="/mois/research-sources" element={<MoisResearchSourcesPage />} />

--- a/frontend/src/components/MainNavigation.tsx
+++ b/frontend/src/components/MainNavigation.tsx
@@ -113,9 +113,10 @@ const NAV_SECTIONS: NavSection[] = [
         icon: Workflow,
         children: [
           {
-            to: "/oprm/cnaes-volume",
+            to: "/oprm",
             label: "CNAEs",
             icon: Workflow,
+            end: true,
           },
         ],
       },

--- a/frontend/src/pages/oprm/OprmModuleNavigation.tsx
+++ b/frontend/src/pages/oprm/OprmModuleNavigation.tsx
@@ -4,63 +4,24 @@ interface OprmModuleNavigationProps {
   occupationSeedRef?: string;
 }
 
-interface OprmNavItem {
-  label: string;
-  to?: string;
-}
-
-const baseItems: OprmNavItem[] = [
-  { label: "Workspace", to: "/oprm" },
-  { label: "Catálogo", to: "/oprm/occupations" },
-  { label: "Operações", to: "/oprm/operations" },
-  { label: "CNAEs", to: "/oprm/cnaes-volume" },
-];
+const cnaeItem = { label: "CNAEs", to: "/oprm" };
 
 export default function OprmModuleNavigation({
-  occupationSeedRef,
+  occupationSeedRef: _occupationSeedRef,
 }: OprmModuleNavigationProps) {
-  const scopedItems: OprmNavItem[] = occupationSeedRef
-    ? [
-        {
-          label: "Rotina",
-          to: `/oprm/routine/${encodeURIComponent(occupationSeedRef)}`,
-        },
-        {
-          label: "Oferta",
-          to: `/oprm/offer/${encodeURIComponent(occupationSeedRef)}`,
-        },
-        {
-          label: "Evidências",
-          to: `/oprm/evidence/${encodeURIComponent(occupationSeedRef)}`,
-        },
-        {
-          label: "Feedback",
-          to: `/oprm/feedback/${encodeURIComponent(occupationSeedRef)}`,
-        },
-      ]
-    : [{ label: "Rotina" }, { label: "Oferta" }, { label: "Evidências" }, { label: "Feedback" }];
-
-  const items: OprmNavItem[] = [baseItems[0], ...scopedItems, ...baseItems.slice(1)];
-
   return (
     <nav aria-label="Navegação interna do OPRM">
       <ul className="nav nav-pills gap-2">
-        {items.map((item) => (
-          <li className="nav-item" key={item.label}>
-            {item.to ? (
-              <NavLink
-                to={item.to}
-                className={({ isActive }) =>
-                  isActive ? "nav-link active" : "nav-link"
-                }
-              >
-                {item.label}
-              </NavLink>
-            ) : (
-              <span className="nav-link disabled">{item.label}</span>
-            )}
-          </li>
-        ))}
+        <li className="nav-item">
+          <NavLink
+            to={cnaeItem.to}
+            className={({ isActive }) =>
+              isActive ? "nav-link active" : "nav-link"
+            }
+          >
+            {cnaeItem.label}
+          </NavLink>
+        </li>
       </ul>
     </nav>
   );


### PR DESCRIPTION
### Motivation
- Reiniciar o fluxo do módulo OPRM priorizando a entrada por CNAEs para simplificar a experiência e reiniciar o trabalho do OPRM a partir desse ranking.
- Reduzir elementos de navegação e roteamento não necessários para o começo do fluxo (workspace, rotina, oferta, evidências, feedback, catálogo, operações) para evitar distrações e facilitar validações operacionais.

### Description
- Altera a rota inicial `/oprm` para renderizar `OprmCnaeVolumePage` em vez da antiga `OprmWorkspacePage` (`frontend/src/App.tsx`).
- Atualiza o menu lateral para apontar o item CNAEs para `/oprm` e marcar o link como `end` (`frontend/src/components/MainNavigation.tsx`).
- Simplifica a navegação interna do OPRM deixando apenas a aba CNAEs em `OprmModuleNavigation` (`frontend/src/pages/oprm/OprmModuleNavigation.tsx`).
- Registra a alteração no histórico operacional do OPRM adicionando entrada em `docs/registros/oprm1.md`.

### Testing
- Rodei `npm ci` no frontend e a instalação de dependências concluiu com sucesso.
- Executei `npm run typecheck` e `npm run build` sem erros de compilação/typing.
- Instalei navegadores e dependências do Playwright com `npx playwright install chromium` e `npx playwright install-deps chromium` com sucesso.
- Capturei uma screenshot da rota `/oprm` com `npx playwright screenshot --browser=chromium --viewport-size=1365,768 http://127.0.0.1:5173/oprm /tmp/marketing-hub-screenshots/oprm-cnaes.png` para validação visual e o comando concluiu corretamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1cea32830c83219fe31ec7e16b8f58)