### PR TITLE
Add experiment.landing_page_image_assets manifest and apply it in PresetDesign pipeline

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/Experiment.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/Experiment.java
@@ -209,6 +209,9 @@ public class Experiment {
     @Column(name = "landing_page_image_planning", columnDefinition = "LONGTEXT")
     private String landingPageImagePlanning;
 
+    @Column(name = "landing_page_image_assets", columnDefinition = "LONGTEXT")
+    private String landingPageImageAssets;
+
     @Column(name = "landing_page_design_preset", columnDefinition = "LONGTEXT")
     private String landingPageDesignPreset;
 

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/dto/ExperimentDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/dto/ExperimentDto.java
@@ -34,6 +34,7 @@ public class ExperimentDto {
     private String landingPageCopy;
     private String landingPageWireframe;
     private String landingPageImagePlanning;
+    private String landingPageImageAssets;
     private String landingPageDesignPreset;
     private String htmlGeraLanding;
     private String landingPageDeliverables;

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/frameworkimage/FrameworkImageGenerationJob.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/frameworkimage/FrameworkImageGenerationJob.java
@@ -20,6 +20,9 @@ import org.hibernate.annotations.CreationTimestamp;
 import org.hibernate.annotations.UpdateTimestamp;
 import org.hibernate.annotations.UuidGenerator;
 
+/**
+ * Representa um job de geração de imagem ligado a um item planejado do experimento.
+ */
 @Entity
 @Data
 @Builder

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/frameworkimage/service/FrameworkImageGenerationService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/frameworkimage/service/FrameworkImageGenerationService.java
@@ -1,7 +1,10 @@
 package com.marketinghub.experiment.frameworkimage.service;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.marketinghub.experiment.Experiment;
 import com.marketinghub.experiment.frameworkimage.FrameworkImageGenerationJob;
 import com.marketinghub.experiment.frameworkimage.FrameworkImageGenerationJobStage;
@@ -21,6 +24,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.Set;
 import java.util.UUID;
+import java.util.stream.Collectors;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
 import org.slf4j.Logger;
@@ -31,6 +35,9 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 import org.springframework.web.server.ResponseStatusException;
 
+/**
+ * Gerencia a fila de geração de imagens da landing e materializa o manifesto consolidado de assets do experimento.
+ */
 @Service
 public class FrameworkImageGenerationService {
     private static final Logger log = LoggerFactory.getLogger(FrameworkImageGenerationService.class);
@@ -40,6 +47,7 @@ public class FrameworkImageGenerationService {
     private final boolean rolloutEnabled;
     private final int rolloutPercentage;
 
+    /** Inicializa o serviço com repositórios, mapper JSON e configuração de rollout da geração de imagens. */
     public FrameworkImageGenerationService(FrameworkImageGenerationJobRepository jobRepository,
                                            ExperimentRepository experimentRepository,
                                            ObjectMapper objectMapper,
@@ -104,6 +112,7 @@ public class FrameworkImageGenerationService {
         job.setStage(stage != null ? stage : job.getStage());
     }
 
+    /** Finaliza um job de imagem e atualiza o manifesto consolidado de assets do experimento. */
     @Transactional
     public void completeJob(UUID jobId, FrameworkImageGenerationJobCompletionRequest request) {
         FrameworkImageGenerationJob job = findJob(jobId);
@@ -128,8 +137,10 @@ public class FrameworkImageGenerationService {
         log.info("framework-image-job-completed jobId={} experimentId={} stage={} workerId={} assetId={} batchId={} model={}",
                 job.getId(), job.getExperiment().getId(), job.getStage(), job.getWorkerId(),
                 job.getAssetId(), job.getBatchId(), job.getModel());
+        refreshLandingPageImageAssets(job.getExperiment());
     }
 
+    /** Marca um job de imagem como falho e atualiza o manifesto consolidado com o erro operacional. */
     @Transactional
     public void failJob(UUID jobId, String errorMessage) {
         FrameworkImageGenerationJob job = findJob(jobId);
@@ -144,8 +155,10 @@ public class FrameworkImageGenerationService {
         log.warn("framework-image-job-failed jobId={} experimentId={} stage={} workerId={} assetId={} batchId={} error={}",
                 job.getId(), job.getExperiment().getId(), job.getStage(), job.getWorkerId(),
                 job.getAssetId(), job.getBatchId(), job.getErrorMessage());
+        refreshLandingPageImageAssets(job.getExperiment());
     }
 
+    /** Registra a URL web definitiva de um asset e atualiza o manifesto consolidado do experimento. */
     @Transactional
     public void markAssetAsWebReady(Long assetId, String webUrl) {
         FrameworkImageGenerationJob job = jobRepository.findFirstByAssetIdOrderByCreatedAtDesc(assetId)
@@ -153,6 +166,7 @@ public class FrameworkImageGenerationService {
         String normalizedWebUrl = normalizeRequired(webUrl, "webUrl é obrigatório");
 
         if (normalizedWebUrl.equals(job.getWebUrl()) && job.getStage() == FrameworkImageGenerationJobStage.WEB_READY) {
+            refreshLandingPageImageAssets(job.getExperiment());
             return;
         }
 
@@ -167,6 +181,7 @@ public class FrameworkImageGenerationService {
         job.setErrorMessage(null);
         log.info("framework-image-asset-web-ready jobId={} experimentId={} stage={} assetId={} webUrl={}",
                 job.getId(), job.getExperiment().getId(), job.getStage(), job.getAssetId(), job.getWebUrl());
+        refreshLandingPageImageAssets(job.getExperiment());
     }
 
     @Transactional
@@ -302,6 +317,8 @@ public class FrameworkImageGenerationService {
             response.add(toItemStatusDto(new PlanningItem(
                             remainingJob.getPlanningItemKey(),
                             null,
+                            null,
+                            null,
                             remainingJob.getPrompt()),
                     remainingJob));
         }
@@ -381,6 +398,113 @@ public class FrameworkImageGenerationService {
         return bucket < rolloutPercentage;
     }
 
+    /** Recria e persiste o manifesto consolidado de URLs de imagens da landing para consumo das etapas seguintes. */
+    private void refreshLandingPageImageAssets(Experiment experiment) {
+        if (experiment == null || experiment.getId() == null) {
+            return;
+        }
+        List<PlanningItem> planningItems = parsePlanningItems(experiment);
+        List<FrameworkImageGenerationJob> jobs = jobRepository.findByExperimentIdOrderByCreatedAtDesc(experiment.getId());
+        String manifest = buildLandingPageImageAssetsManifest(experiment.getId(), planningItems, jobs);
+        experiment.setLandingPageImageAssets(manifest);
+        experimentRepository.save(experiment);
+    }
+
+    /** Monta o JSON versionado com o último job conhecido de cada item planejado de imagem. */
+    private String buildLandingPageImageAssetsManifest(Long experimentId,
+                                                       List<PlanningItem> planningItems,
+                                                       List<FrameworkImageGenerationJob> jobs) {
+        Map<String, FrameworkImageGenerationJob> latestByItem = jobs.stream()
+                .filter(job -> job != null && StringUtils.hasText(job.getPlanningItemKey()))
+                .collect(Collectors.toMap(
+                        FrameworkImageGenerationJob::getPlanningItemKey,
+                        job -> job,
+                        (first, ignored) -> first,
+                        LinkedHashMap::new));
+
+        ObjectNode root = objectMapper.createObjectNode();
+        root.put("version", 1);
+        root.put("experimentId", experimentId);
+        root.put("generatedAt", Instant.now().toString());
+        ArrayNode images = root.putArray("images");
+
+        for (PlanningItem item : planningItems) {
+            FrameworkImageGenerationJob job = latestByItem.remove(item.planningItemKey());
+            images.add(toManifestImageNode(item, job));
+        }
+        for (FrameworkImageGenerationJob job : latestByItem.values()) {
+            images.add(toManifestImageNode(new PlanningItem(job.getPlanningItemKey(), null, null, null, null), job));
+        }
+
+        try {
+            return objectMapper.writeValueAsString(root);
+        } catch (JsonProcessingException ex) {
+            log.error("Erro ao serializar manifesto de imagens da landing (experimentId={}, imageCount={})",
+                    experimentId,
+                    images.size(),
+                    ex);
+            throw new IllegalStateException("Falha ao serializar manifesto de imagens da landing", ex);
+        }
+    }
+
+    /** Converte item planejado e último job em um nó do manifesto consolidado de imagens. */
+    private ObjectNode toManifestImageNode(PlanningItem item, FrameworkImageGenerationJob job) {
+        ObjectNode image = objectMapper.createObjectNode();
+        image.put("planningItemKey", item.planningItemKey());
+        putIfPresent(image, "sectionId", item.sectionId());
+        putIfPresent(image, "sectionName", item.sectionName());
+        putIfPresent(image, "elementId", item.elementId());
+        putIfPresent(image, "prompt", item.prompt());
+        if (job != null) {
+            if (job.getId() != null) {
+                image.put("jobId", job.getId().toString());
+            }
+            if (job.getStatus() != null) {
+                image.put("status", job.getStatus().name());
+            }
+            if (job.getStage() != null) {
+                image.put("stage", job.getStage().name());
+            }
+            putIfPresent(image, "model", job.getModel());
+            if (job.getAssetId() != null) {
+                image.put("assetId", job.getAssetId());
+            }
+            putIfPresent(image, "sourceUrl", job.getSourceUrl());
+            putIfPresent(image, "webUrl", job.getWebUrl());
+            putIfPresent(image, "resolvedUrl", firstNonBlank(job.getWebUrl(), job.getSourceUrl()));
+            putIfPresent(image, "errorMessage", job.getErrorMessage());
+            putIfPresent(image, "createdAt", instantToString(job.getCreatedAt()));
+            putIfPresent(image, "startedAt", instantToString(job.getStartedAt()));
+            putIfPresent(image, "finishedAt", instantToString(job.getFinishedAt()));
+        } else {
+            image.put("status", "PLANNED");
+        }
+        return image;
+    }
+
+    /** Adiciona um campo textual ao JSON somente quando houver valor útil. */
+    private void putIfPresent(ObjectNode node, String fieldName, String value) {
+        if (StringUtils.hasText(value)) {
+            node.put(fieldName, value.trim());
+        }
+    }
+
+    /** Converte Instant para texto ISO-8601 mantendo nulo quando não há data. */
+    private String instantToString(Instant value) {
+        return value != null ? value.toString() : null;
+    }
+
+    /** Retorna o primeiro texto preenchido entre os candidatos informados. */
+    private String firstNonBlank(String primary, String fallback) {
+        if (StringUtils.hasText(primary)) {
+            return primary.trim();
+        }
+        if (StringUtils.hasText(fallback)) {
+            return fallback.trim();
+        }
+        return null;
+    }
+
     private FrameworkImageGenerationJobDto toDto(FrameworkImageGenerationJob job) {
         return FrameworkImageGenerationJobDto.builder()
                 .id(job.getId())
@@ -440,10 +564,13 @@ public class FrameworkImageGenerationService {
                 if (imageNode == null || !imageNode.isObject()) {
                     continue;
                 }
-                String planningItemKey = normalizePlanningItemKey(imageNode.path("sectionId").asText(null), index);
+                String sectionId = normalize(imageNode.path("sectionId").asText(null));
+                String planningItemKey = normalizePlanningItemKey(sectionId, index);
                 items.add(new PlanningItem(
                         planningItemKey,
+                        sectionId,
                         normalize(imageNode.path("sectionName").asText(null)),
+                        normalize(imageNode.path("elementId").asText(null)),
                         normalize(promptFrom(imageNode))));
             }
             return deduplicatePlanningItems(items);
@@ -645,7 +772,9 @@ public class FrameworkImageGenerationService {
             }
             normalizedItems.add(new PlanningItem(
                     item.planningItemKey() + "-" + occurrence,
+                    item.sectionId(),
                     item.sectionName(),
+                    item.elementId(),
                     item.prompt()));
         }
         return normalizedItems;
@@ -659,7 +788,8 @@ public class FrameworkImageGenerationService {
         return "item-" + (index + 1);
     }
 
-    private record PlanningItem(String planningItemKey, String sectionName, String prompt) {
+    /** Representa um item planejado de imagem normalizado para filas e manifesto consolidado. */
+    private record PlanningItem(String planningItemKey, String sectionId, String sectionName, String elementId, String prompt) {
         private PlanningItem {
             Objects.requireNonNull(planningItemKey);
         }

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/presetdesign/provisorio/DesignPresetProvisionalHtmlAssembler.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/presetdesign/provisorio/DesignPresetProvisionalHtmlAssembler.java
@@ -1,6 +1,9 @@
 package com.marketinghub.geralanding.presetdesign.provisorio;
 
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ArrayNode;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.util.LinkedHashMap;
 import java.util.Map;
 import org.slf4j.Logger;
@@ -40,10 +43,22 @@ public class DesignPresetProvisionalHtmlAssembler {
     /**
      * Consolida wireframe/copy com o resultado do design preset para produzir o HTML provisório da etapa.
      */
+    public String assemble(String wireframeJson,
+                           String copyJson,
+                           String imagePlanningJson,
+                           String designPresetOutputJson,
+                           String jobId) {
+        return assemble(wireframeJson, copyJson, imagePlanningJson, null, designPresetOutputJson, jobId);
+    }
+
+    /**
+     * Consolida os artefatos da landing aplicando o manifesto de imagens finais antes de montar o HTML provisório.
+     */
     @SuppressWarnings("unchecked")
     public String assemble(String wireframeJson,
                            String copyJson,
                            String imagePlanningJson,
+                           String imageAssetsJson,
                            String designPresetOutputJson,
                            String jobId) {
         if (!StringUtils.hasText(wireframeJson)
@@ -55,20 +70,22 @@ public class DesignPresetProvisionalHtmlAssembler {
         try {
             Map<String, Object> wireframePayload = normalizePayload(wireframeJson, "landingPageWireframe");
             Map<String, Object> copyPayload = normalizePayload(copyJson, "landingPageCopy");
+            String enrichedImagePlanningJson = enrichImagePlanningWithAssets(imagePlanningJson, imageAssetsJson);
             String html = processor.process(
                     objectMapper.writeValueAsString(wireframePayload),
                     objectMapper.writeValueAsString(copyPayload),
-                    imagePlanningJson,
+                    enrichedImagePlanningJson,
                     designPresetOutputJson);
             return preserveCanonicalHtml(html, jobId);
         } catch (Exception e) {
             String errorDetails = buildErrorDetails(e);
             log.error("Falha ao montar HTML provisório da fase landing-page-design-preset "
-                            + "(jobId={}, wireframeLength={}, copyLength={}, imagePlanningLength={}, designPresetLength={}, errorDetails={})",
+                            + "(jobId={}, wireframeLength={}, copyLength={}, imagePlanningLength={}, imageAssetsLength={}, designPresetLength={}, errorDetails={})",
                     normalizeJobId(jobId),
                     lengthOf(wireframeJson),
                     lengthOf(copyJson),
                     lengthOf(imagePlanningJson),
+                    lengthOf(imageAssetsJson),
                     lengthOf(designPresetOutputJson),
                     errorDetails,
                     e);
@@ -78,6 +95,7 @@ public class DesignPresetProvisionalHtmlAssembler {
                             + ", wireframeLength=" + lengthOf(wireframeJson)
                             + ", copyLength=" + lengthOf(copyJson)
                             + ", imagePlanningLength=" + lengthOf(imagePlanningJson)
+                            + ", imageAssetsLength=" + lengthOf(imageAssetsJson)
                             + ", designPresetLength=" + lengthOf(designPresetOutputJson)
                             + ", errorDetails=" + errorDetails,
                     e);
@@ -120,6 +138,121 @@ public class DesignPresetProvisionalHtmlAssembler {
             return (Map<String, Object>) nested;
         }
         return new LinkedHashMap<>(root);
+    }
+
+    /** Enriquecer o planejamento de imagens com URLs definitivas vindas do manifesto consolidado do experimento. */
+    private String enrichImagePlanningWithAssets(String imagePlanningJson, String imageAssetsJson) throws Exception {
+        if (!StringUtils.hasText(imagePlanningJson) || !StringUtils.hasText(imageAssetsJson)) {
+            return imagePlanningJson;
+        }
+        JsonNode planningRoot = objectMapper.readTree(imagePlanningJson);
+        if (!(planningRoot instanceof ObjectNode planningRootObject)) {
+            return imagePlanningJson;
+        }
+        ObjectNode planningNode = resolvePlanningNode(planningRootObject);
+        JsonNode imagesNode = planningNode.path("images");
+        if (!(imagesNode instanceof ArrayNode planningImages)) {
+            return imagePlanningJson;
+        }
+        Map<String, JsonNode> assetsByKey = collectImageAssetsByKey(imageAssetsJson);
+        if (assetsByKey.isEmpty()) {
+            return imagePlanningJson;
+        }
+        boolean changed = false;
+        for (JsonNode imageNode : planningImages) {
+            if (!(imageNode instanceof ObjectNode imageObject)) {
+                continue;
+            }
+            JsonNode asset = resolveAssetForPlanningImage(imageObject, assetsByKey);
+            String resolvedUrl = firstText(asset, "resolvedUrl", "webUrl", "sourceUrl", "imageUrl", "url", "src");
+            if (!StringUtils.hasText(resolvedUrl)) {
+                continue;
+            }
+            imageObject.put("imageUrl", resolvedUrl.trim());
+            copyTextIfAbsent(imageObject, asset, "sourceUrl");
+            copyTextIfAbsent(imageObject, asset, "webUrl");
+            changed = true;
+        }
+        return changed ? objectMapper.writeValueAsString(planningRootObject) : imagePlanningJson;
+    }
+
+    /** Localiza o objeto canônico do planejamento de imagens dentro dos formatos aceitos pelo pipeline. */
+    private ObjectNode resolvePlanningNode(ObjectNode planningRootObject) {
+        JsonNode directPlanning = planningRootObject.path("landingPageImagePlanning");
+        if (directPlanning instanceof ObjectNode objectNode) {
+            return objectNode;
+        }
+        JsonNode imagePlan = planningRootObject.path("imagePlan");
+        if (imagePlan instanceof ObjectNode objectNode) {
+            return objectNode;
+        }
+        return planningRootObject;
+    }
+
+    /** Indexa assets do manifesto por chaves úteis para casar seção, elemento e item planejado. */
+    private Map<String, JsonNode> collectImageAssetsByKey(String imageAssetsJson) throws Exception {
+        JsonNode root = objectMapper.readTree(imageAssetsJson);
+        JsonNode imagesNode = root.path("images");
+        if (!(imagesNode instanceof ArrayNode images)) {
+            return Map.of();
+        }
+        Map<String, JsonNode> result = new LinkedHashMap<>();
+        for (JsonNode asset : images) {
+            addAssetKey(result, asset.path("planningItemKey").asText(null), asset);
+            addAssetKey(result, asset.path("sectionId").asText(null), asset);
+            addAssetKey(result, asset.path("elementId").asText(null), asset);
+        }
+        return result;
+    }
+
+    /** Registra uma chave normalizada do manifesto quando ela estiver preenchida. */
+    private void addAssetKey(Map<String, JsonNode> result, String rawKey, JsonNode asset) {
+        String key = normalizeAssetKey(rawKey);
+        if (StringUtils.hasText(key)) {
+            result.putIfAbsent(key, asset);
+        }
+    }
+
+    /** Resolve o asset correspondente a uma imagem planejada por elementId, sectionId ou planningItemKey. */
+    private JsonNode resolveAssetForPlanningImage(ObjectNode imageObject, Map<String, JsonNode> assetsByKey) {
+        String[] candidateFields = {"elementId", "sectionId", "planningItemKey", "imageBindingKey", "slotId"};
+        for (String field : candidateFields) {
+            JsonNode asset = assetsByKey.get(normalizeAssetKey(imageObject.path(field).asText(null)));
+            if (asset != null) {
+                return asset;
+            }
+        }
+        return null;
+    }
+
+    /** Retorna o primeiro campo textual preenchido dentro de um nó JSON. */
+    private String firstText(JsonNode node, String... fields) {
+        if (node == null) {
+            return null;
+        }
+        for (String field : fields) {
+            String value = node.path(field).asText(null);
+            if (StringUtils.hasText(value)) {
+                return value;
+            }
+        }
+        return null;
+    }
+
+    /** Copia metadado textual do asset para o planejamento sem sobrescrever valores já definidos. */
+    private void copyTextIfAbsent(ObjectNode target, JsonNode source, String fieldName) {
+        if (StringUtils.hasText(target.path(fieldName).asText(null))) {
+            return;
+        }
+        String value = firstText(source, fieldName);
+        if (StringUtils.hasText(value)) {
+            target.put(fieldName, value.trim());
+        }
+    }
+
+    /** Normaliza chaves de casamento entre planejamento e manifesto de imagens. */
+    private String normalizeAssetKey(String rawKey) {
+        return rawKey == null ? "" : rawKey.trim().toLowerCase();
     }
 
     /**

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/presetdesign/service/BackendPresetDesignService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/presetdesign/service/BackendPresetDesignService.java
@@ -246,6 +246,7 @@ public class BackendPresetDesignService {
                 experiment.getLandingPageWireframe(),
                 experiment.getLandingPageCopy(),
                 experiment.getLandingPageImagePlanning(),
+                experiment.getLandingPageImageAssets(),
                 modelResponse,
                 fromDatabaseIdJob(execution.getIdJob()));
     }

--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-01-experiment-landing-image-assets.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-01-experiment-landing-image-assets.yaml
@@ -1,0 +1,25 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-06-01-experiment-landing-image-assets
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - onError: HALT
+        - dbms:
+            type: mysql
+        - sqlCheck:
+            expectedResult: "0"
+            sql: |
+              SELECT COUNT(*)
+              FROM information_schema.COLUMNS
+              WHERE TABLE_SCHEMA = DATABASE()
+                AND TABLE_NAME = 'experiment'
+                AND COLUMN_NAME = 'landing_page_image_assets'
+      changes:
+        - sql:
+            splitStatements: true
+            stripComments: true
+            sql: |
+              ALTER TABLE experiment
+                ADD COLUMN landing_page_image_assets LONGTEXT NULL
+                AFTER landing_page_image_planning;

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -1,5 +1,9 @@
 databaseChangeLog:
   - include:
+      file: changesets/2026-06-01-experiment-landing-image-assets.yaml
+      relativeToChangelogFile: true
+
+  - include:
       file: changesets/2026-06-01-oprm-cnae-opportunity-flow.yaml
       relativeToChangelogFile: true
 

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/frameworkimage/service/FrameworkImageGenerationServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/frameworkimage/service/FrameworkImageGenerationServiceTest.java
@@ -121,6 +121,43 @@ class FrameworkImageGenerationServiceTest {
         assertThat(job.getErrorMessage()).isNull();
     }
 
+
+    @Test
+    void completeJobPersistsLandingPageImageAssetsManifest() {
+        UUID jobId = UUID.randomUUID();
+        Experiment experiment = Experiment.builder()
+                .id(56L)
+                .landingPageImagePlanning("""
+                        {"images":[{"sectionId":"sec-hero","sectionName":"Hero","elementId":"hero-img","imagePrompt":"Prompt Hero"}]}
+                        """)
+                .build();
+        FrameworkImageGenerationJob job = FrameworkImageGenerationJob.builder()
+                .id(jobId)
+                .experiment(experiment)
+                .planningItemKey("sec-hero")
+                .status(FrameworkImageGenerationJobStatus.PROCESSING)
+                .stage(FrameworkImageGenerationJobStage.WAITING_OPENAI_BATCH)
+                .createdAt(Instant.parse("2026-06-01T10:00:00Z"))
+                .build();
+
+        when(jobRepository.findById(jobId)).thenReturn(Optional.of(job));
+        when(jobRepository.findByExperimentIdOrderByCreatedAtDesc(56L)).thenReturn(List.of(job));
+
+        service.completeJob(jobId, new FrameworkImageGenerationJobCompletionRequest(
+                FrameworkImageGenerationJobStage.NOTIFIED_BACKEND,
+                "gpt-image-1",
+                "Prompt Hero final",
+                "batch_1",
+                99L,
+                "https://cdn/source.jpg",
+                "https://cdn/web.jpg"));
+
+        assertThat(experiment.getLandingPageImageAssets()).contains("\"planningItemKey\":\"sec-hero\"");
+        assertThat(experiment.getLandingPageImageAssets()).contains("\"elementId\":\"hero-img\"");
+        assertThat(experiment.getLandingPageImageAssets()).contains("\"resolvedUrl\":\"https://cdn/web.jpg\"");
+        verify(experimentRepository).save(experiment);
+    }
+
     @Test
     void claimJobRejectsNonPendingJob() {
         UUID jobId = UUID.randomUUID();

--- a/backend/ads-service/src/test/java/com/marketinghub/geralanding/DesignPresetProvisionalHtmlAssemblerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/geralanding/DesignPresetProvisionalHtmlAssemblerTest.java
@@ -7,8 +7,10 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
 
 /**
  * Valida a montagem do HTML provisório da etapa de design preset sem inserir metadados técnicos no resultado.
@@ -40,4 +42,40 @@ class DesignPresetProvisionalHtmlAssemblerTest {
         assertFalse(html.contains("data-track-section=\"hero\""));
         assertFalse(html.contains("<!-- jobId = job-123 -->"));
     }
+
+    /** Garante que o manifesto consolidado de imagens seja aplicado ao planejamento antes do processador montar o HTML. */
+    @Test
+    void shouldEnrichImagePlanningWithFinalAssetManifest() {
+        DesignPresetProvisionalHtmlProcessor processor = mock(DesignPresetProvisionalHtmlProcessor.class);
+        when(processor.process(anyString(), anyString(), anyString(), anyString()))
+                .thenReturn("<html><body><img id='hero-img' src='https://cdn/final.jpg'></body></html>");
+        DesignPresetProvisionalHtmlAssembler assembler = new DesignPresetProvisionalHtmlAssembler(
+                processor,
+                new ObjectMapper());
+
+        assembler.assemble(
+                """
+                        {"landingPageWireframe":{"sectionOrder":[]}}
+                        """,
+                """
+                        {"landingPageCopy":{"bodySections":[]}}
+                        """,
+                """
+                        {"landingPageImagePlanning":{"images":[{"sectionId":"sec-hero","elementId":"hero-img"}]}}
+                        """,
+                """
+                        {"images":[{"planningItemKey":"sec-hero","elementId":"hero-img","resolvedUrl":"https://cdn/final.jpg"}]}
+                        """,
+                """
+                        {"landingPageDesignPreset":{"sectionPresets":[]}}
+                        """,
+                "job-456");
+
+        verify(processor).process(
+                anyString(),
+                anyString(),
+                argThat(payload -> payload.contains("\"imageUrl\":\"https://cdn/final.jpg\"")),
+                anyString());
+    }
+
 }

--- a/backend/ads-service/src/test/java/com/marketinghub/geralanding/presetdesign/service/BackendPresetDesignServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/geralanding/presetdesign/service/BackendPresetDesignServiceTest.java
@@ -156,10 +156,12 @@ class BackendPresetDesignServiceTest {
         when(experiment.getLandingPageWireframe()).thenReturn("{\"landingPageWireframe\":{}}");
         when(experiment.getLandingPageCopy()).thenReturn("{\"landingPageCopy\":{}}");
         when(experiment.getLandingPageImagePlanning()).thenReturn("{\"landingPageImagePlanning\":{}}");
+        when(experiment.getLandingPageImageAssets()).thenReturn("{\"images\":[]}");
         when(htmlAssembler.assemble(
                 "{\"landingPageWireframe\":{}}",
                 "{\"landingPageCopy\":{}}",
                 "{\"landingPageImagePlanning\":{}}",
+                "{\"images\":[]}",
                 "{\"landingPageDesignPreset\":{}}",
                 "job-design-preset"))
                 .thenReturn("<html>GeraLanding Design Preset</html>");
@@ -183,6 +185,7 @@ class BackendPresetDesignServiceTest {
                 "{\"landingPageWireframe\":{}}",
                 "{\"landingPageCopy\":{}}",
                 "{\"landingPageImagePlanning\":{}}",
+                "{\"images\":[]}",
                 "{\"landingPageDesignPreset\":{}}",
                 "job-design-preset");
         verify(experiment).setHtmlGeraLanding("<html>GeraLanding Design Preset</html>");

--- a/docs/canonical/geralanding-backend-swagger.v1.yaml
+++ b/docs/canonical/geralanding-backend-swagger.v1.yaml
@@ -406,6 +406,8 @@ components:
           $ref: '#/components/schemas/JsonBackedArtifact'
         landingPageImagePlanning:
           $ref: '#/components/schemas/JsonBackedArtifact'
+        landingPageImageAssets:
+          $ref: '#/components/schemas/JsonBackedArtifact'
         landingPageDesignPreset:
           $ref: '#/components/schemas/JsonBackedArtifact'
         landingPageDeliverables:

--- a/docs/canonical/openai-informacoes-tratadas-canon.v1.md
+++ b/docs/canonical/openai-informacoes-tratadas-canon.v1.md
@@ -283,6 +283,7 @@ A tabela `experiment` armazena o experimento e os artefatos funcionais consolida
 | `landing_page_copy` | `LONGTEXT` | artefato funcional | Copy consolidada da landing page. |
 | `landing_page_copy_job_id` | `BINARY(36)` | vínculo técnico | Job que originou/atualizou a copy. |
 | `landing_page_image_planning` | `LONGTEXT` | artefato funcional | Planejamento de imagens da landing page. |
+| `landing_page_image_assets` | `LONGTEXT` | artefato funcional consolidado | Manifesto JSON com URLs finais das imagens da landing por item planejado, materializado a partir de `framework_image_generation_job`. |
 | `landing_page_design_preset` | `LONGTEXT` | artefato funcional estruturado | Preset de design da landing page. |
 | `html_geralanding` | `LONGTEXT` | artefato funcional | HTML operacional consolidado do Gera Landing. |
 | `landing_page_deliverables` | `LONGTEXT` | artefato funcional | Entregáveis associados à landing/produto. |
@@ -310,6 +311,7 @@ A tabela `experiment` armazena o experimento e os artefatos funcionais consolida
 - `experiment` não é a tabela de auditoria completa das chamadas à IA.
 - Auditoria de chamada, request, resposta bruta, tokens e custo por etapa ficam em `experiment_pipeline_generation_job`.
 - Jobs de imagem por item planejado ficam em `framework_image_generation_job`.
+- O manifesto consolidado consumível pelas etapas seguintes fica em `experiment.landing_page_image_assets`, sem sobrescrever o planejamento/prompt original em `experiment.landing_page_image_planning`.
 
 ## 7. Tabela `experiment_pipeline_generation_job`
 
@@ -445,7 +447,7 @@ A tabela `ai_worker_generation` armazena registros genéricos de geração por I
 2. **Histórico de geração/refinamento de framework da hipótese** fica em `hypothesis_framework_generation_job`.
 3. **Experimento e artefatos consolidados do pipeline** ficam em `experiment`.
 4. **Histórico de chamadas textuais/estruturais do pipeline do experimento** fica em `experiment_pipeline_generation_job`.
-5. **Jobs de imagem por item planejado** ficam em `framework_image_generation_job`.
+5. **Jobs de imagem por item planejado** ficam em `framework_image_generation_job`; o snapshot consolidado de URLs finais fica em `experiment.landing_page_image_assets`.
 6. **Gerações genéricas não cobertas por filas especializadas** ficam em `ai_worker_generation`.
 7. **Resposta bruta do modelo** deve ficar em coluna `raw_response` de tabela de job/auditoria, não em coluna de artefato consolidado.
 8. **Conteúdo normalizado de uma chamada** deve ficar em `response_content` quando existir tabela de job especializada.

--- a/docs/canonical/procedimento-experimento-canon.v1.md
+++ b/docs/canonical/procedimento-experimento-canon.v1.md
@@ -50,7 +50,7 @@ Local canônico vigente:
 No fluxo atual, a geração da landing segue as etapas:
 1. gerar wireframe (`LANDING_PAGE_WIREFRAME`);
 2. gerar copy (`LANDING_PAGE_COPY`);
-3. gerar planejamento/prompt de imagens (`LANDING_PAGE_IMAGE_PLANNING`) e gerar imagens;
+3. gerar planejamento/prompt de imagens (`LANDING_PAGE_IMAGE_PLANNING`) e gerar imagens, materializando `experiment.landing_page_image_assets` com as URLs finais;
 4. gerar preset de design (`LANDING_PAGE_DESIGN_PRESET`);
 5. gerar entregável HTML da landing (`LANDING_PAGE_HTML`).
 
@@ -98,6 +98,7 @@ Cada conjunto de montagem de HTML deve atuar **exclusivamente** na sua etapa can
 Regras:
 1. Um conjunto de etapa não pode consolidar regras de outra etapa.
 2. Enriquecimentos transversais (ex.: injeção de URLs finais de imagem) devem ocorrer em serviço auxiliar dedicado e orquestrados pelo serviço da etapa, sem transferir a responsabilidade de etapa entre processadores.
+3. A etapa de geração de imagens deve persistir o manifesto consolidado `experiment.landing_page_image_assets`; a etapa de preset design deve consumir esse manifesto para substituir placeholders/URLs provisórias por URLs finais antes de persistir o HTML.
 
 ### 5.5 Worker AI — divisão equivalente por etapa (obrigatória)
 
@@ -226,7 +227,7 @@ Para a etapa `landing-page-design-preset`, o HTML provisório **deve** ser gerad
 Persistência esperada na conclusão da etapa:
 - `gera_landing_stage_execution.provisional_html` recebe o HTML provisório da etapa;
 - `experiment.landing_page_design_preset` recebe o JSON de resposta da etapa;
-- `experiment.html_geralanding` recebe o HTML consolidado da etapa (com injeções aplicáveis).
+- `experiment.html_geralanding` recebe o HTML consolidado da etapa com imagens resolvidas a partir de `experiment.landing_page_image_assets` quando disponível.
 
 `experiment.landing_page_html` permanece reservado para fluxo de aprovação/publicação final.
 

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -2867,3 +2867,14 @@
   - o exemplo do prompt foi sincronizado com o schema estrito;
   - adicionados testes regressivos para impedir retorno de `additionalProperties` permissivo e palavras-chave rejeitadas no schema da etapa.
 - impacto esperado: novas execuções do PresetDesign deixam de ser recusadas antes da geração pela OpenAI e mantêm a etapa disponível para concluir o Gera Landing com acabamento visual consistente e voltado à conversão.
+
+## 2026-05-31 23:55:25 UTC-3
+- solicitação: criar um campo consolidado no experimento para armazenar o JSON com URLs finais das imagens geradas e fazer o preset design consumir esse JSON.
+- raciocínio: manter `landing_page_image_planning` como planejamento/prompt e separar a saída final das imagens em um manifesto próprio evita misturar entrada e resultado, além de permitir que o HTML consolidado use URLs reais sem depender de placeholders do modelo.
+- registro do que foi feito: adicionado o contrato de `landing_page_image_assets`, atualização do fluxo canônico de geração de imagens e consumo do manifesto pelo preset design.
+- documentos lidos para pesquisar e resolver o problema:
+  - AGENTS.md
+  - backend/AGENTS.md
+  - docs/canonical/openai-informacoes-tratadas-canon.v1.md
+  - docs/canonical/procedimento-experimento-canon.v1.md
+  - docs/canonical/geralanding-backend-swagger.v1.yaml

--- a/frontend/src/api/experiment/useExperiments.ts
+++ b/frontend/src/api/experiment/useExperiments.ts
@@ -76,6 +76,7 @@ export interface Experiment {
   landingPageCopy?: string | null;
   landingPageWireframe?: string | null;
   landingPageImagePlanning?: string | null;
+  landingPageImageAssets?: string | null;
   landingPageDesignPreset?: string | null;
   landingPageDeliverables?: string | null;
   landingPageHtml?: string | null;


### PR DESCRIPTION
### Motivation
- Separate image planning (input/prompts) from generated image results by materializing a consolidated JSON manifest of final image URLs on the experiment model.
- Ensure image-generation jobs persist a consumable snapshot of final asset URLs so downstream steps can resolve placeholders before producing provisional HTML.
- Allow the PresetDesign assembler to enrich the image planning with resolved URLs from the manifest, avoiding mixing input and output in `landing_page_image_planning`.

### Description
- Adds a new nullable `landing_page_image_assets` LONGTEXT column via a Liquibase changeset and exposes it on `Experiment`, DTOs and frontend types.
- Extends `FrameworkImageGenerationService` to build a versioned JSON manifest of latest jobs per planning item (`refreshLandingPageImageAssets`, `buildLandingPageImageAssetsManifest`, helpers) and to call it from `completeJob`, `failJob` and `markAssetAsWebReady`.
- Enhances planning parsing and job tracking by including `sectionId` and `elementId` in `PlanningItem`, and indexes latest jobs by planning key when building the manifest.
- Updates `DesignPresetProvisionalHtmlAssembler` to enrich `landingPageImagePlanning` with resolved asset URLs taken from the manifest (`enrichImagePlanningWithAssets`) and wires this through `BackendPresetDesignService` when assembling provisional HTML.
- Updates documentation and OpenAPI canonical contract to include `landingPageImageAssets`, adjusts tests to cover the new behavior, and updates frontend type definitions.

### Testing
- Added/updated unit tests: `FrameworkImageGenerationServiceTest` (including `completeJobPersistsLandingPageImageAssetsManifest`), `DesignPresetProvisionalHtmlAssemblerTest` (asset enrichment test), and adjustments in `BackendPresetDesignServiceTest` to pass the assets manifest to the assembler.
- Ran the unit test suite for the modified modules and the new/updated tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ceefcb88c8321bb803c244b630385)