### PR TITLE
Agenda ciclo 1 Hotmart para 1 de junho às 04h

### DIFF
--- a/docs/registros/mois1.md
+++ b/docs/registros/mois1.md
@@ -699,3 +699,12 @@ Arquivos alterados:
   - mois-hotmart-collector/AGENTS.md
   - docs/canonical/mois-hotmart-mapeamento-ciclos-campos-banco.md
   - docs/registros/mois1.md
+
+## 2026-06-01 00:07:55 UTC-3
+- ajuste operacional solicitado para agendar a próxima execução do ciclo 1 Hotmart para 01/06 às 04:00 no timezone `America/Sao_Paulo`.
+- o agendamento do ciclo 1 é definido no código do `mois-hotmart-collector` por cron literal em `@Scheduled`, então a solução foi atualizar a expressão pontual do ciclo 1 em vez de criar configuração paralela.
+- mantido o ciclo 2 sem alteração.
+- documentos lidos para tratar a situação:
+  - docs/canonical/mois-hotmart-mapeamento-ciclos-campos-banco.md
+  - mois-hotmart-collector/AGENTS.md
+  - docs/registros/mois1.md

--- a/mois-hotmart-collector/src/main/java/com/marketinghub/moishotmart/service/HotmartCollectorScheduler.java
+++ b/mois-hotmart-collector/src/main/java/com/marketinghub/moishotmart/service/HotmartCollectorScheduler.java
@@ -8,10 +8,10 @@ import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
-@Component
 /**
  * Responsável por agendar e disparar os ciclos automáticos de coleta Hotmart.
  */
+@Component
 public class HotmartCollectorScheduler {
 
     private static final Logger log = LoggerFactory.getLogger(HotmartCollectorScheduler.class);
@@ -21,6 +21,9 @@ public class HotmartCollectorScheduler {
     private final String source;
     private final int maxProducts;
 
+    /**
+     * Inicializa o agendador com o serviço de coleta e parâmetros operacionais configurados.
+     */
     public HotmartCollectorScheduler(
             HotmartCollectorService collectorService,
             @Value("${collector.scheduler.enabled:true}") boolean enabled,
@@ -34,17 +37,17 @@ public class HotmartCollectorScheduler {
     }
 
     /**
-     * Executa o ciclo 1 de listagem de produtos às 20:40 no dia 31 de maio, no horário de São Paulo.
+     * Executa o ciclo 1 de listagem de produtos às 04:00 no dia 1 de junho, no horário de São Paulo.
      */
-    @Scheduled(cron = "0 40 20 31 5 *", zone = "America/Sao_Paulo")
-    public void collectFirstCycleAtTwentyFortyOnMayThirtyFirst() {
+    @Scheduled(cron = "0 0 4 1 6 *", zone = "America/Sao_Paulo")
+    public void collectFirstCycleAtFourOnJuneFirst() {
         if (!enabled) {
             log.info("Hotmart scheduler desabilitado por configuração.");
             return;
         }
         HotmartCollectionRequest request = new HotmartCollectionRequest(source, maxProducts);
         HotmartCollectionResponse response = collectorService.collectFirstCycle(request);
-        log.info("Hotmart scheduler executado hora=20:40 dia=31/05 timezone=America/Sao_Paulo ciclo={} status={} produtos={} mensagem={}",
+        log.info("Hotmart scheduler executado hora=04:00 dia=01/06 timezone=America/Sao_Paulo ciclo={} status={} produtos={} mensagem={}",
                 "CICLO_1_LISTAGEM",
                 response.status(),
                 response.products().size(),


### PR DESCRIPTION
### Motivation
- Agendar pontualmente a próxima execução do Ciclo 1 do coletor Hotmart para 2026-06-01 04:00 (America/Sao_Paulo) conforme solicitação operacional.

### Description
- Atualiza o cron literal do scheduler para o ciclo 1 em `mois-hotmart-collector/src/main/java/com/marketinghub/moishotmart/service/HotmartCollectorScheduler.java` para `@Scheduled(cron = "0 0 4 1 6 *", zone = "America/Sao_Paulo")` e ajusta a mensagem de log associada para refletir o novo horário operacional.
- Adiciona comentário de responsabilidade no construtor e organiza o javadoc da classe `HotmartCollectorScheduler` para manter a documentação de código obrigatória.
- Registra a ação operacional no histórico `docs/registros/mois1.md` com timestamp e documentos consultados.

### Testing
- Executado `mvn test` no módulo `mois-hotmart-collector` e todos os testes unitários passaram com `BUILD SUCCESS`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1cf74ca15483219d05a01d583ed3af)