### PR TITLE
OPRM: add operational monitoring screens spec and wireframes

### DIFF
--- a/docs/novos-modulos/OPRM/oprm-telas-acompanhamento-operacional.md
+++ b/docs/novos-modulos/OPRM/oprm-telas-acompanhamento-operacional.md
@@ -1,0 +1,604 @@
+# OPRM — Plano de Telas para Acompanhamento Operacional pelo Usuário
+
+## 1. Objetivo
+
+Este documento planeja as novas telas para o usuário acompanhar **o que está sendo feito no OPRM** sem precisar ler logs, consultar banco ou entender nomes internos de worker.
+
+O foco é transformar a operação automática do OPRM em uma experiência clara de acompanhamento:
+
+- o que está rodando agora;
+- qual etapa já terminou;
+- qual etapa está pendente;
+- onde houve falha;
+- qual impacto de negócio foi produzido;
+- qual próxima decisão humana é necessária.
+
+A UI deve preservar o eixo central do Marketing Hub: **Dor → Resultado → Mecanismo → Prova → Oferta**. O acompanhamento operacional só é útil se deixar claro como a execução do OPRM aproxima o sistema de uma oportunidade vendável.
+
+---
+
+## 2. Princípios das novas telas
+
+### 2.1 Visão de usuário antes de visão técnica
+
+A tela deve responder primeiro perguntas humanas:
+
+1. O OPRM está trabalhando?
+2. Em qual fase ele está?
+3. O que já foi encontrado?
+4. O que precisa da minha decisão?
+5. Existe algum bloqueio que impede geração de oportunidade?
+
+Detalhes técnicos como `cycleId`, `runId`, `fileId` e `correlationId` devem aparecer, mas como rastreabilidade secundária, não como título principal da experiência.
+
+### 2.2 Fluxo único de acompanhamento
+
+O usuário deve enxergar o OPRM como uma esteira:
+
+1. ingestão de dados de mercado;
+2. consolidação de CNAEs;
+3. cálculo de Score OPRM;
+4. enriquecimento comercial;
+5. geração de candidatos de nicho;
+6. aprovação humana;
+7. envio para oferta/experimento.
+
+### 2.3 Sem botões que quebrem automação
+
+Como os ciclos de score e enriquecimento são automáticos, as telas devem priorizar acompanhamento, auditoria e decisão humana. Botões manuais só devem existir quando forem seguros e necessários, por exemplo: atualizar tela, aprovar candidato, rejeitar candidato, copiar identificador ou abrir detalhes.
+
+### 2.4 Sem poluição técnica no artefato final
+
+Nenhuma tela deve incentivar publicação de payload com metadado operacional, comentário técnico, flag de debug ou JSON textual dentro de campo funcional. O usuário pode ver metadados de execução em painéis operacionais, mas o artefato comercial final deve conter somente campos contratuais.
+
+---
+
+## 3. Mapa proposto de navegação
+
+A navegação do OPRM deve ganhar um grupo chamado **Acompanhamento**.
+
+Ordem sugerida no módulo:
+
+1. **Painel OPRM** — visão executiva do que está acontecendo agora.
+2. **Ingestão de Mercado** — importação CNPJ/CNAE e arquivos do snapshot.
+3. **Ciclos CNAE** — score, enriquecimento e status por ciclo.
+4. **Candidatos de Nicho** — oportunidades geradas para decisão humana.
+5. **Fila de Decisão** — itens que exigem ação do usuário.
+6. **Diagnóstico** — falhas, bloqueios, logs resumidos e rastreabilidade.
+
+A rota `/oprm` pode continuar abrindo o ranking de CNAEs enquanto o MVP novo não estiver pronto, mas a evolução recomendada é transformar `/oprm` no **Painel OPRM** e mover o ranking atual para uma aba explícita como `/oprm/cnaes-volume` ou `/oprm/ciclos-cnae`.
+
+---
+
+## 4. Tela 1 — Painel OPRM
+
+### Objetivo
+
+Ser a tela inicial para o usuário entender, em menos de um minuto, o estado atual do OPRM.
+
+### Perguntas que responde
+
+- O OPRM está ativo?
+- Qual foi a última execução relevante?
+- Há ciclo em andamento?
+- Quantos CNAEs já têm score?
+- Quantos CNAEs já foram enriquecidos?
+- Quantos candidatos de nicho aguardam decisão?
+- Existe falha bloqueante?
+
+### Blocos principais
+
+1. **Status geral**
+   - `Operando normalmente`
+   - `Processando agora`
+   - `Aguardando próxima execução`
+   - `Com falha parcial`
+   - `Bloqueado`
+
+2. **Esteira visual**
+   - Ingestão
+   - Consolidação
+   - Score
+   - Enriquecimento
+   - Candidatos
+   - Decisão humana
+   - Oferta/Experimento
+
+3. **Últimos resultados de negócio**
+   - CNAEs com maior Score OPRM;
+   - candidatos de nicho mais recentes;
+   - oportunidades prontas para avaliação;
+   - sinais de dor/resultado/mecanismo encontrados.
+
+4. **Pendências para o usuário**
+   - candidatos aguardando aprovação;
+   - enriquecimentos com confiança baixa;
+   - falhas que exigem reprocessamento;
+   - runs incompletas de ingestão.
+
+### Ações principais
+
+- Atualizar dados.
+- Abrir ciclo em andamento.
+- Abrir candidatos pendentes.
+- Abrir diagnóstico de falhas.
+- Ir para ranking de CNAEs.
+
+### Dados necessários
+
+- Últimos ciclos de `/api/oprm/cnae-cycles`.
+- Ranking de CNAEs de `/api/oprm/market/import-runs/cnaes/top-volume`.
+- Lista de runs de `/api/oprm/market/import-runs`.
+- Contagem de candidatos pendentes por status.
+- Últimos artefatos rejeitados de `/api/oprm/artifacts?status=REJECTED`.
+
+### Critério de pronto
+
+A tela é considerada pronta quando o usuário consegue identificar se o OPRM está avançando para gerar oportunidades vendáveis ou se existe bloqueio operacional.
+
+---
+
+## 5. Tela 2 — Ingestão de Mercado
+
+### Objetivo
+
+Mostrar a importação CNPJ/CNAE de forma rastreável e compreensível, especialmente porque essa etapa alimenta o tamanho de mercado e o ranking de CNAEs.
+
+### Perguntas que responde
+
+- Qual snapshot está sendo usado?
+- A run está aberta, concluída ou falhou?
+- Quais arquivos foram processados?
+- Existe arquivo `STARTED` impedindo fechamento correto?
+- Quantas linhas foram lidas, válidas e ignoradas?
+- O market size foi publicado?
+
+### Blocos principais
+
+1. **Snapshot atual**
+   - data canônica do snapshot;
+   - origem dos arquivos;
+   - horário da última validação;
+   - status dos arquivos mínimos esperados.
+
+2. **Runs de importação**
+   - `runId`;
+   - status;
+   - início/fim;
+   - linhas lidas;
+   - linhas válidas;
+   - linhas ignoradas;
+   - erro resumido.
+
+3. **Detalhe por arquivo**
+   - tipo do dataset;
+   - nome do arquivo;
+   - status;
+   - linhas lidas;
+   - CNAEs consolidados;
+   - duração;
+   - último evento.
+
+4. **Alertas canônicos**
+   - arquivo `ESTABELECIMENTOS` em `STARTED`;
+   - fechamento antecipado bloqueado;
+   - falha por memória/capacidade;
+   - ausência de resumo final ou progresso.
+
+### Ações principais
+
+- Atualizar lista.
+- Abrir arquivos da run.
+- Copiar `runId`.
+- Ver erro detalhado.
+- Abrir diagnóstico filtrado pela run.
+
+### Dados necessários
+
+- `/api/oprm/market/import-runs`.
+- `/api/oprm/market/import-runs/{runId}/files`.
+- Logs resumidos do módulo `oprm-coletor-receita` via MCP para diagnóstico quando houver falha.
+
+### Critério de pronto
+
+A tela é considerada pronta quando o usuário consegue saber se a base de mercado está confiável para alimentar decisão comercial.
+
+---
+
+## 6. Tela 3 — Ciclos CNAE
+
+### Objetivo
+
+Acompanhar os ciclos automáticos de Score OPRM e enriquecimento sem confundir o usuário com execução manual.
+
+### Perguntas que responde
+
+- Qual ciclo rodou por último?
+- O ciclo foi de score ou enriquecimento?
+- Quantos CNAEs foram processados?
+- Quantos falharam?
+- Qual critério de seleção foi usado?
+- Qual resumo de negócio foi produzido?
+
+### Blocos principais
+
+1. **Timeline de ciclos**
+   - ciclo;
+   - tipo;
+   - status;
+   - processados;
+   - falhas;
+   - início;
+   - fim;
+   - duração.
+
+2. **Detalhe do ciclo selecionado**
+   - critério de seleção;
+   - resumo;
+   - erro, se houver;
+   - lista de CNAEs impactados quando disponível.
+
+3. **Ranking operacional**
+   - CNAE;
+   - descrição;
+   - Score OPRM;
+   - status do score;
+   - volume total;
+   - empresas MEI;
+   - empresas Simples;
+   - enriquecido ou pendente.
+
+4. **Sinal de valor comercial**
+   - top dores identificadas;
+   - top resultados desejados;
+   - top mecanismos sugeridos;
+   - nível de prontidão para virar nicho/oferta.
+
+### Ações principais
+
+- Atualizar ciclos.
+- Abrir CNAE no detalhe.
+- Filtrar por ciclo com falha.
+- Filtrar por `notEnriched`.
+- Ir para candidatos gerados daquele CNAE.
+
+### Dados necessários
+
+- `/api/oprm/cnae-cycles`.
+- `/api/oprm/market/import-runs/cnaes/top-volume`.
+- `/api/oprm/cnae-niche-candidates?cnaeCode={cnaeCode}`.
+
+### Critério de pronto
+
+A tela é considerada pronta quando o usuário consegue acompanhar a evolução automática dos CNAEs até virarem oportunidades analisáveis.
+
+---
+
+## 7. Tela 4 — Candidatos de Nicho
+
+### Objetivo
+
+Transformar o enriquecimento do OPRM em decisão humana clara, evitando criação automática de nicho sem validação.
+
+### Perguntas que responde
+
+- Quais candidatos de nicho foram gerados?
+- De qual CNAE vieram?
+- Qual dor principal foi detectada?
+- Qual resultado desejado foi identificado?
+- Qual mecanismo parece plausível?
+- Qual prova inicial sustenta a oportunidade?
+- O candidato deve ser aprovado, rejeitado ou revisado?
+
+### Blocos principais
+
+1. **Lista de candidatos**
+   - status: `PENDING`, `APPROVED`, `REJECTED`;
+   - CNAE;
+   - nome sugerido do nicho;
+   - score/prioridade;
+   - data de geração;
+   - decisão pendente.
+
+2. **Card de oportunidade**
+   - Dor;
+   - Resultado;
+   - Mecanismo;
+   - Prova;
+   - Oferta preliminar.
+
+3. **Evidência resumida**
+   - origem do sinal;
+   - confiança;
+   - resumo sem JSON textual;
+   - observações do enriquecimento.
+
+4. **Decisão humana**
+   - aprovar;
+   - rejeitar;
+   - enviar para revisão;
+   - vincular a nicho oficial existente, quando aplicável.
+
+### Ações principais
+
+- Aprovar candidato.
+- Rejeitar candidato.
+- Abrir CNAE de origem.
+- Enviar para construção de oferta.
+- Copiar trilha de decisão.
+
+### Dados necessários
+
+- `/api/oprm/cnae-niche-candidates?cnaeCode={cnaeCode}`.
+- `/api/oprm/cnae-niche-candidates/{id}/approve`.
+- `/api/oprm/cnae-niche-candidates/{id}/reject`.
+- Endpoint agregado futuro recomendado: `GET /api/oprm/cnae-niche-candidates?status=PENDING&page=0&size=50`.
+
+### Critério de pronto
+
+A tela é considerada pronta quando o usuário consegue converter saídas automáticas em decisões comerciais controladas.
+
+---
+
+## 8. Tela 5 — Fila de Decisão
+
+### Objetivo
+
+Centralizar tudo que precisa de ação humana no OPRM.
+
+### Perguntas que responde
+
+- O que depende de mim agora?
+- Qual ação gera mais impacto comercial?
+- Qual item está parado há mais tempo?
+- Qual candidato está pronto para virar oferta?
+
+### Blocos principais
+
+1. **Pendências priorizadas**
+   - candidatos pendentes;
+   - CNAEs de alto score sem enriquecimento;
+   - candidatos com baixa confiança;
+   - falhas recorrentes que impedem avanço.
+
+2. **Prioridade comercial**
+   - Score OPRM;
+   - tamanho de mercado;
+   - aderência MEI/Simples;
+   - clareza da dor;
+   - plausibilidade do mecanismo.
+
+3. **Ação recomendada**
+   - aprovar;
+   - revisar evidência;
+   - aguardar enriquecimento;
+   - descartar;
+   - abrir diagnóstico.
+
+### Ações principais
+
+- Resolver item.
+- Abrir detalhe.
+- Ignorar temporariamente.
+- Enviar para oferta.
+
+### Dados necessários
+
+- Agregação de candidatos por status.
+- Ranking de CNAEs por Score OPRM.
+- Ciclos recentes.
+- Falhas recentes de artefato e enriquecimento.
+
+### Critério de pronto
+
+A tela é considerada pronta quando o usuário não precisa procurar em várias telas para saber qual decisão tomar primeiro.
+
+---
+
+## 9. Tela 6 — Diagnóstico
+
+### Objetivo
+
+Dar rastreabilidade suficiente para entender bloqueios sem expor o usuário a uma parede de logs.
+
+### Perguntas que responde
+
+- O que falhou?
+- Em qual módulo?
+- Qual identificador devo usar para investigação?
+- A falha é de ingestão, score, enriquecimento, persistência ou frontend?
+- Qual é a ação recomendada para resolver causa-raiz?
+
+### Blocos principais
+
+1. **Falhas recentes**
+   - tipo;
+   - módulo;
+   - severidade;
+   - mensagem resumida;
+   - data/hora;
+   - identificador rastreável.
+
+2. **Busca por identificador**
+   - `runId`;
+   - `fileId`;
+   - `cycleId`;
+   - `cnaeCode`;
+   - `candidateId`;
+   - `correlationId`.
+
+3. **Rastro de execução**
+   - evento inicial;
+   - eventos intermediários;
+   - último evento;
+   - erro raiz conhecido;
+   - recomendação objetiva.
+
+4. **Contratos e endpoints envolvidos**
+   - endpoint chamado;
+   - método;
+   - status HTTP;
+   - payload resumido sem secrets;
+   - resposta resumida.
+
+### Ações principais
+
+- Copiar identificador.
+- Abrir run.
+- Abrir ciclo.
+- Abrir candidato.
+- Filtrar logs resumidos.
+
+### Dados necessários
+
+- `/api/oprm/artifacts?status=REJECTED`.
+- `/api/oprm/artifacts?correlationId={correlationId}`.
+- `/api/oprm/cnae-cycles`.
+- `/api/oprm/market/import-runs`.
+- MCP `java_module_logs` para consultas de suporte operacional, mantendo a UI com resumo e não com log bruto interminável.
+
+### Critério de pronto
+
+A tela é considerada pronta quando o usuário consegue sair de “deu erro” para “sei onde falhou e qual é o próximo passo”.
+
+---
+
+## 10. Endpoints já disponíveis e lacunas
+
+### 10.1 Disponíveis hoje
+
+- `GET /api/oprm/market/import-runs` — lista runs de importação.
+- `GET /api/oprm/market/import-runs/{runId}/files` — lista arquivos de uma run.
+- `GET /api/oprm/market/import-runs/cnaes/top-volume?page=&size=` — ranking paginado de CNAEs por Score OPRM.
+- `GET /api/oprm/cnae-cycles?limit=` — ciclos operacionais recentes.
+- `GET /api/oprm/cnae-niche-candidates?cnaeCode=` — candidatos de nicho por CNAE.
+- `POST /api/oprm/cnae-niche-candidates/{id}/approve` — aprova candidato.
+- `POST /api/oprm/cnae-niche-candidates/{id}/reject` — rejeita candidato.
+- `GET /api/oprm/artifacts?status=REJECTED` — artefatos rejeitados.
+- `GET /api/oprm/artifacts?correlationId=` — rastreio por correlação.
+
+### 10.2 Lacunas recomendadas para o backend
+
+1. `GET /api/oprm/dashboard/summary`
+   - status geral;
+   - ciclo atual;
+   - contadores por etapa;
+   - pendências humanas;
+   - falhas bloqueantes.
+
+2. `GET /api/oprm/cnae-niche-candidates?status=&page=&size=`
+   - listagem paginada por status, sem exigir `cnaeCode`.
+
+3. `GET /api/oprm/decision-queue`
+   - fila priorizada de ações humanas.
+
+4. `GET /api/oprm/diagnostics/recent-failures`
+   - falhas resumidas por módulo/etapa com identificadores rastreáveis.
+
+5. `GET /api/oprm/cnaes/{cnaeCode}/timeline`
+   - linha do tempo do CNAE desde ingestão até candidatos.
+
+Essas lacunas devem ser criadas no backend OPRM antes de qualquer frontend que dependa delas, respeitando a regra de que o frontend não deve inventar contratos inexistentes.
+
+---
+
+## 11. MVP recomendado
+
+### Sprint A — Painel OPRM + Ciclos CNAE
+
+Entregar primeiro:
+
+- novo Painel OPRM;
+- cards de status geral;
+- últimos ciclos;
+- top CNAEs por Score OPRM;
+- pendências básicas;
+- link para ranking atual.
+
+Motivo: aproveita endpoints já existentes e melhora imediatamente a capacidade do usuário de acompanhar o trabalho automático.
+
+### Sprint B — Ingestão de Mercado
+
+Entregar:
+
+- runs de importação;
+- arquivos da run;
+- alertas de `STARTED`, `FAILED` e fechamento bloqueado;
+- resumo de linhas e consolidação.
+
+Motivo: reduz risco operacional, principalmente nas rotinas grandes de `Estabelecimentos`.
+
+### Sprint C — Candidatos de Nicho + Fila de Decisão
+
+Entregar:
+
+- listagem de candidatos por status;
+- cards Dor → Resultado → Mecanismo → Prova → Oferta;
+- aprovar/rejeitar;
+- fila priorizada.
+
+Motivo: conecta a automação do OPRM com decisão comercial e geração de vendas.
+
+### Sprint D — Diagnóstico
+
+Entregar:
+
+- falhas recentes;
+- busca por identificador;
+- trilha resumida;
+- recomendação de causa-raiz.
+
+Motivo: melhora suporte e evita correções por consequência.
+
+---
+
+## 12. Regras de design para as novas telas
+
+1. Toda tela deve mostrar **próxima ação recomendada**.
+2. Todo status técnico deve ter tradução operacional simples.
+3. Todo erro deve apontar identificador rastreável.
+4. Nenhuma tela deve exibir excesso de JSON bruto.
+5. Nenhum campo final de oferta deve receber metadado técnico.
+6. A ordenação padrão deve priorizar impacto comercial, não apenas data.
+7. Estados vazios devem explicar o motivo provável e o próximo passo.
+8. Estados de falha devem separar erro bloqueante de falha parcial.
+
+---
+
+## 13. Resultado esperado
+
+Com essas telas, o usuário deixa de ver o OPRM como uma caixa-preta técnica e passa a acompanhar uma esteira de criação de oportunidade:
+
+**Dados de mercado → Score → Enriquecimento → Nicho candidato → Decisão humana → Oferta vendável**.
+
+A experiência proposta reforça o objetivo comercial do Marketing Hub: gerar produtos digitais vendáveis a partir de necessidades reais, dores concretas, mecanismos plausíveis e oportunidades com sustentação operacional.
+
+---
+
+## 14. Wireframes visuais das telas
+
+As imagens abaixo materializam o planejamento das telas para facilitar validação visual antes da implementação no frontend. Elas são **wireframes SVG**, portanto podem ser abertas diretamente no navegador, versionadas no Git e convertidas para PNG quando necessário.
+
+### 14.1 Painel OPRM
+
+![Wireframe do Painel OPRM](wireframes/oprm-painel.svg)
+
+### 14.2 Ingestão de Mercado
+
+![Wireframe da tela Ingestão de Mercado](wireframes/oprm-ingestao-mercado.svg)
+
+### 14.3 Ciclos CNAE
+
+![Wireframe da tela Ciclos CNAE](wireframes/oprm-ciclos-cnae.svg)
+
+### 14.4 Candidatos de Nicho
+
+![Wireframe da tela Candidatos de Nicho](wireframes/oprm-candidatos-nicho.svg)
+
+### 14.5 Fila de Decisão
+
+![Wireframe da tela Fila de Decisão](wireframes/oprm-fila-decisao.svg)
+
+### 14.6 Diagnóstico OPRM
+
+![Wireframe da tela Diagnóstico OPRM](wireframes/oprm-diagnostico.svg)

--- a/docs/novos-modulos/OPRM/oprm_especificacao_telas_menu_com_sprints.md
+++ b/docs/novos-modulos/OPRM/oprm_especificacao_telas_menu_com_sprints.md
@@ -663,3 +663,13 @@ Conteúdo sugerido:
 - estados de loading/erro/vazio
 - ações por tela
 - integração frontend ↔ backend
+
+---
+
+## 15. Complemento — telas de acompanhamento operacional do OPRM
+
+Para a evolução do OPRM como módulo operável pelo usuário, a especificação de telas deve ser complementada pelo plano dedicado em:
+
+- `docs/novos-modulos/OPRM/oprm-telas-acompanhamento-operacional.md`
+
+Esse complemento detalha as novas telas de **Painel OPRM**, **Ingestão de Mercado**, **Ciclos CNAE**, **Candidatos de Nicho**, **Fila de Decisão** e **Diagnóstico**, com foco em permitir que o usuário acompanhe o que o OPRM está fazendo em cada etapa até gerar oportunidade comercial validável.

--- a/docs/novos-modulos/OPRM/wireframes/oprm-candidatos-nicho.svg
+++ b/docs/novos-modulos/OPRM/wireframes/oprm-candidatos-nicho.svg
@@ -1,0 +1,74 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1440" height="900" viewBox="0 0 1440 900" role="img" aria-labelledby="title desc">
+  <title id="title">Candidatos de Nicho</title>
+  <desc id="desc">Wireframe visual da tela Candidatos de Nicho do módulo OPRM.</desc>
+  <defs>
+    <filter id="shadow" x="-10%" y="-10%" width="120%" height="120%"><feDropShadow dx="0" dy="8" stdDeviation="10" flood-color="#0f172a" flood-opacity="0.10"/></filter>
+    <style><![CDATA[text{font-family:Inter,Arial,sans-serif}.small{font-size:18px}.tiny{font-size:15px}.title{font-size:34px;font-weight:700}.h2{font-size:24px;font-weight:700}.h3{font-size:19px;font-weight:700}.muted{fill:#6b7280}.label{font-size:14px;font-weight:700;text-transform:uppercase;letter-spacing:.08em}]]></style>
+  </defs>
+  <rect width="1440" height="900" fill="#f5f7fb"/>
+  <rect x="0" y="0" width="250" height="900" fill="#172033"/>
+  <text x="32" y="54" fill="#fff" font-size="26" font-weight="800">Marketing Hub</text>
+  <text x="32" y="92" fill="#93a4bd" font-size="16">OPRM</text>
+  <rect x="18" y="119" width="214" height="44" rx="12" fill="transparent"/>
+  <circle cx="42" cy="141" r="6" fill="#64748b"/>
+  <text x="62" y="147" fill="#cbd5e1" font-size="17" font-weight="500">Painel OPRM</text>
+  <rect x="18" y="177" width="214" height="44" rx="12" fill="transparent"/>
+  <circle cx="42" cy="199" r="6" fill="#64748b"/>
+  <text x="62" y="205" fill="#cbd5e1" font-size="17" font-weight="500">Ingestão</text>
+  <rect x="18" y="235" width="214" height="44" rx="12" fill="transparent"/>
+  <circle cx="42" cy="257" r="6" fill="#64748b"/>
+  <text x="62" y="263" fill="#cbd5e1" font-size="17" font-weight="500">Ciclos CNAE</text>
+  <rect x="18" y="293" width="214" height="44" rx="12" fill="#26344f"/>
+  <circle cx="42" cy="315" r="6" fill="#2563eb"/>
+  <text x="62" y="321" fill="#fff" font-size="17" font-weight="700">Candidatos</text>
+  <rect x="18" y="351" width="214" height="44" rx="12" fill="transparent"/>
+  <circle cx="42" cy="373" r="6" fill="#64748b"/>
+  <text x="62" y="379" fill="#cbd5e1" font-size="17" font-weight="500">Fila decisão</text>
+  <rect x="18" y="409" width="214" height="44" rx="12" fill="transparent"/>
+  <circle cx="42" cy="431" r="6" fill="#64748b"/>
+  <text x="62" y="437" fill="#cbd5e1" font-size="17" font-weight="500">Diagnóstico</text>
+  <text x="290" y="62" class="title" fill="#111827">Candidatos de Nicho</text>
+  <text x="290" y="94" class="small muted">Oportunidades geradas pelo enriquecimento para aprovação humana.</text>
+  <rect x="1210" y="40" width="160" height="44" rx="14" fill="#2563eb"/>
+  <text x="1248" y="68" fill="#fff" font-size="16" font-weight="700">Atualizar</text>
+  <rect x="290" y="125" width="430" height="650" rx="20" fill="#ffffff" filter="url(#shadow)"/>
+  <text x="314" y="163" class="h3" fill="#111827">Lista de candidatos</text>
+  <text x="314" y="191" class="tiny muted">Filtrar por PENDING, APPROVED ou REJECTED</text>
+  <rect x="320" y="169" width="360" height="70" rx="16" fill="#f8fafc"/>
+  <text x="340" y="197" class="small" fill="#111827" font-weight="700">Salões solo com agenda cheia</text>
+  <rect x="340" y="207" width="97" height="32" rx="16" fill="#f59e0b" opacity="0.12"/>
+  <text x="357" y="229" fill="#f59e0b" font-size="15" font-weight="700">PENDING</text>
+  <rect x="320" y="264" width="360" height="70" rx="16" fill="#f8fafc"/>
+  <text x="340" y="292" class="small" fill="#111827" font-weight="700">Cursos rápidos para MEI</text>
+  <rect x="340" y="302" width="97" height="32" rx="16" fill="#f59e0b" opacity="0.12"/>
+  <text x="357" y="324" fill="#f59e0b" font-size="15" font-weight="700">PENDING</text>
+  <rect x="320" y="359" width="360" height="70" rx="16" fill="#f8fafc"/>
+  <text x="340" y="387" class="small" fill="#111827" font-weight="700">Assistente administrativo local</text>
+  <rect x="340" y="397" width="106" height="32" rx="16" fill="#10b981" opacity="0.12"/>
+  <text x="357" y="419" fill="#10b981" font-size="15" font-weight="700">APPROVED</text>
+  <rect x="320" y="454" width="360" height="70" rx="16" fill="#f8fafc"/>
+  <text x="340" y="482" class="small" fill="#111827" font-weight="700">Promoção porta a porta</text>
+  <rect x="340" y="492" width="106" height="32" rx="16" fill="#ef4444" opacity="0.12"/>
+  <text x="357" y="514" fill="#ef4444" font-size="15" font-weight="700">REJECTED</text>
+  <rect x="760" y="125" width="620" height="650" rx="20" fill="#ffffff" filter="url(#shadow)"/>
+  <text x="784" y="163" class="h3" fill="#111827">Card de oportunidade</text>
+  <text x="784" y="191" class="tiny muted">Dor → Resultado → Mecanismo → Prova → Oferta</text>
+  <text x="800" y="205" class="label" fill="#2563eb">Dor</text>
+  <rect x="800" y="219" width="520" height="48" rx="12" fill="#f8fafc"/>
+  <text x="820" y="250" class="small" fill="#111827">Cliente some depois do primeiro atendimento</text>
+  <text x="800" y="297" class="label" fill="#2563eb">Resultado</text>
+  <rect x="800" y="311" width="520" height="48" rx="12" fill="#f8fafc"/>
+  <text x="820" y="342" class="small" fill="#111827">Agenda recorrente e previsível</text>
+  <text x="800" y="389" class="label" fill="#2563eb">Mecanismo</text>
+  <rect x="800" y="403" width="520" height="48" rx="12" fill="#f8fafc"/>
+  <text x="820" y="434" class="small" fill="#111827">Sequência de retorno automatizada por IA</text>
+  <text x="800" y="481" class="label" fill="#2563eb">Prova</text>
+  <rect x="800" y="495" width="520" height="48" rx="12" fill="#f8fafc"/>
+  <text x="820" y="526" class="small" fill="#111827">CNAE com alto volume MEI ativo</text>
+  <text x="800" y="573" class="label" fill="#2563eb">Oferta</text>
+  <rect x="800" y="587" width="520" height="48" rx="12" fill="#f8fafc"/>
+  <text x="820" y="618" class="small" fill="#111827">Kit de retenção para profissional de beleza</text>
+  <rect x="800" y="690" width="150" height="48" rx="14" fill="#10b981"/><text x="845" y="721" fill="#fff" font-size="16" font-weight="800">Aprovar</text>
+  <rect x="970" y="690" width="150" height="48" rx="14" fill="#ef4444"/><text x="1016" y="721" fill="#fff" font-size="16" font-weight="800">Rejeitar</text>
+  <rect x="1140" y="690" width="180" height="48" rx="14" fill="#2563eb"/><text x="1182" y="721" fill="#fff" font-size="16" font-weight="800">Criar oferta</text>
+</svg>

--- a/docs/novos-modulos/OPRM/wireframes/oprm-ciclos-cnae.svg
+++ b/docs/novos-modulos/OPRM/wireframes/oprm-ciclos-cnae.svg
@@ -1,0 +1,82 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1440" height="900" viewBox="0 0 1440 900" role="img" aria-labelledby="title desc">
+  <title id="title">Ciclos CNAE</title>
+  <desc id="desc">Wireframe visual da tela Ciclos CNAE do módulo OPRM.</desc>
+  <defs>
+    <filter id="shadow" x="-10%" y="-10%" width="120%" height="120%"><feDropShadow dx="0" dy="8" stdDeviation="10" flood-color="#0f172a" flood-opacity="0.10"/></filter>
+    <style><![CDATA[text{font-family:Inter,Arial,sans-serif}.small{font-size:18px}.tiny{font-size:15px}.title{font-size:34px;font-weight:700}.h2{font-size:24px;font-weight:700}.h3{font-size:19px;font-weight:700}.muted{fill:#6b7280}.label{font-size:14px;font-weight:700;text-transform:uppercase;letter-spacing:.08em}]]></style>
+  </defs>
+  <rect width="1440" height="900" fill="#f5f7fb"/>
+  <rect x="0" y="0" width="250" height="900" fill="#172033"/>
+  <text x="32" y="54" fill="#fff" font-size="26" font-weight="800">Marketing Hub</text>
+  <text x="32" y="92" fill="#93a4bd" font-size="16">OPRM</text>
+  <rect x="18" y="119" width="214" height="44" rx="12" fill="transparent"/>
+  <circle cx="42" cy="141" r="6" fill="#64748b"/>
+  <text x="62" y="147" fill="#cbd5e1" font-size="17" font-weight="500">Painel OPRM</text>
+  <rect x="18" y="177" width="214" height="44" rx="12" fill="transparent"/>
+  <circle cx="42" cy="199" r="6" fill="#64748b"/>
+  <text x="62" y="205" fill="#cbd5e1" font-size="17" font-weight="500">Ingestão</text>
+  <rect x="18" y="235" width="214" height="44" rx="12" fill="#26344f"/>
+  <circle cx="42" cy="257" r="6" fill="#2563eb"/>
+  <text x="62" y="263" fill="#fff" font-size="17" font-weight="700">Ciclos CNAE</text>
+  <rect x="18" y="293" width="214" height="44" rx="12" fill="transparent"/>
+  <circle cx="42" cy="315" r="6" fill="#64748b"/>
+  <text x="62" y="321" fill="#cbd5e1" font-size="17" font-weight="500">Candidatos</text>
+  <rect x="18" y="351" width="214" height="44" rx="12" fill="transparent"/>
+  <circle cx="42" cy="373" r="6" fill="#64748b"/>
+  <text x="62" y="379" fill="#cbd5e1" font-size="17" font-weight="500">Fila decisão</text>
+  <rect x="18" y="409" width="214" height="44" rx="12" fill="transparent"/>
+  <circle cx="42" cy="431" r="6" fill="#64748b"/>
+  <text x="62" y="437" fill="#cbd5e1" font-size="17" font-weight="500">Diagnóstico</text>
+  <text x="290" y="62" class="title" fill="#111827">Ciclos CNAE</text>
+  <text x="290" y="94" class="small muted">Timeline de ciclos automáticos de score e enriquecimento CNAE.</text>
+  <rect x="1210" y="40" width="160" height="44" rx="14" fill="#2563eb"/>
+  <text x="1248" y="68" fill="#fff" font-size="16" font-weight="700">Atualizar</text>
+  <rect x="290" y="125" width="1090" height="170" rx="20" fill="#ffffff" filter="url(#shadow)"/>
+  <text x="314" y="163" class="h3" fill="#111827">Ciclos automáticos recentes</text>
+  <text x="314" y="191" class="tiny muted">Sem botão manual: o usuário acompanha score e enriquecimento</text>
+  <rect x="320" y="185" width="320" height="82" rx="16" fill="#f8fafc"/>
+  <text x="340" y="218" class="small" fill="#111827" font-weight="800">CNAE_ENRICHMENT #18</text>
+  <text x="340" y="248" class="tiny muted">35 processados • 2 falhas</text>
+  <rect x="518" y="205" width="97" height="32" rx="16" fill="#10b981" opacity="0.12"/>
+  <text x="535" y="227" fill="#10b981" font-size="15" font-weight="700">RUNNING</text>
+  <rect x="665" y="185" width="320" height="82" rx="16" fill="#f8fafc"/>
+  <text x="685" y="218" class="small" fill="#111827" font-weight="800">CNAE_SCORE #42</text>
+  <text x="685" y="248" class="tiny muted">50 processados • 0 falhas</text>
+  <rect x="863" y="205" width="115" height="32" rx="16" fill="#2563eb" opacity="0.12"/>
+  <text x="880" y="227" fill="#2563eb" font-size="15" font-weight="700">COMPLETED</text>
+  <rect x="1010" y="185" width="320" height="82" rx="16" fill="#f8fafc"/>
+  <text x="1030" y="218" class="small" fill="#111827" font-weight="800">CNAE_ENRICHMENT #17</text>
+  <text x="1030" y="248" class="tiny muted">25 processados • 1 falha</text>
+  <rect x="1208" y="205" width="115" height="32" rx="16" fill="#2563eb" opacity="0.12"/>
+  <text x="1225" y="227" fill="#2563eb" font-size="15" font-weight="700">COMPLETED</text>
+  <rect x="290" y="330" width="650" height="430" rx="20" fill="#ffffff" filter="url(#shadow)"/>
+  <text x="314" y="368" class="h3" fill="#111827">Ranking operacional</text>
+  <text x="314" y="396" class="tiny muted">CNAEs priorizados por Score OPRM</text>
+  <text x="325" y="400" class="small" fill="#111827" font-weight="700">9602-5/01</text><text x="520" y="400" class="small" fill="#2563eb" font-weight="800">94,2</text>
+  <rect x="650" y="376" width="133" height="32" rx="16" fill="#10b981" opacity="0.12"/>
+  <text x="667" y="398" fill="#10b981" font-size="15" font-weight="700">Enriquecido</text>
+  <line x1="320" y1="422" x2="900" y2="422" stroke="#e5e7eb"/>
+  <text x="325" y="474" class="small" fill="#111827" font-weight="700">8599-6/04</text><text x="520" y="474" class="small" fill="#2563eb" font-weight="800">91,8</text>
+  <rect x="650" y="450" width="106" height="32" rx="16" fill="#f59e0b" opacity="0.12"/>
+  <text x="667" y="472" fill="#f59e0b" font-size="15" font-weight="700">Pendente</text>
+  <line x1="320" y1="496" x2="900" y2="496" stroke="#e5e7eb"/>
+  <text x="325" y="548" class="small" fill="#111827" font-weight="700">8211-3/00</text><text x="520" y="548" class="small" fill="#2563eb" font-weight="800">88,4</text>
+  <rect x="650" y="524" width="133" height="32" rx="16" fill="#10b981" opacity="0.12"/>
+  <text x="667" y="546" fill="#10b981" font-size="15" font-weight="700">Enriquecido</text>
+  <line x1="320" y1="570" x2="900" y2="570" stroke="#e5e7eb"/>
+  <text x="325" y="622" class="small" fill="#111827" font-weight="700">7319-0/02</text><text x="520" y="622" class="small" fill="#2563eb" font-weight="800">85,9</text>
+  <rect x="650" y="598" width="106" height="32" rx="16" fill="#f59e0b" opacity="0.12"/>
+  <text x="667" y="620" fill="#f59e0b" font-size="15" font-weight="700">Pendente</text>
+  <line x1="320" y1="644" x2="900" y2="644" stroke="#e5e7eb"/>
+  <rect x="980" y="330" width="400" height="430" rx="20" fill="#ffffff" filter="url(#shadow)"/>
+  <text x="1004" y="368" class="h3" fill="#111827">Sinal de valor comercial</text>
+  <text x="1004" y="396" class="tiny muted">Resumo do ciclo selecionado</text>
+  <rect x="1010" y="395" width="320" height="48" rx="12" fill="#ecfdf5"/>
+  <text x="1030" y="425" class="small" fill="#111827">Dor: agenda e recorrência</text>
+  <rect x="1010" y="467" width="320" height="48" rx="12" fill="#ecfdf5"/>
+  <text x="1030" y="497" class="small" fill="#111827">Resultado: previsibilidade mensal</text>
+  <rect x="1010" y="539" width="320" height="48" rx="12" fill="#ecfdf5"/>
+  <text x="1030" y="569" class="small" fill="#111827">Mecanismo: rotina guiada por IA</text>
+  <rect x="1010" y="611" width="320" height="48" rx="12" fill="#ecfdf5"/>
+  <text x="1030" y="641" class="small" fill="#111827">Prova: alto volume MEI ativo</text>
+</svg>

--- a/docs/novos-modulos/OPRM/wireframes/oprm-diagnostico.svg
+++ b/docs/novos-modulos/OPRM/wireframes/oprm-diagnostico.svg
@@ -1,0 +1,65 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1440" height="900" viewBox="0 0 1440 900" role="img" aria-labelledby="title desc">
+  <title id="title">Diagnóstico OPRM</title>
+  <desc id="desc">Wireframe visual da tela Diagnóstico OPRM do módulo OPRM.</desc>
+  <defs>
+    <filter id="shadow" x="-10%" y="-10%" width="120%" height="120%"><feDropShadow dx="0" dy="8" stdDeviation="10" flood-color="#0f172a" flood-opacity="0.10"/></filter>
+    <style><![CDATA[text{font-family:Inter,Arial,sans-serif}.small{font-size:18px}.tiny{font-size:15px}.title{font-size:34px;font-weight:700}.h2{font-size:24px;font-weight:700}.h3{font-size:19px;font-weight:700}.muted{fill:#6b7280}.label{font-size:14px;font-weight:700;text-transform:uppercase;letter-spacing:.08em}]]></style>
+  </defs>
+  <rect width="1440" height="900" fill="#f5f7fb"/>
+  <rect x="0" y="0" width="250" height="900" fill="#172033"/>
+  <text x="32" y="54" fill="#fff" font-size="26" font-weight="800">Marketing Hub</text>
+  <text x="32" y="92" fill="#93a4bd" font-size="16">OPRM</text>
+  <rect x="18" y="119" width="214" height="44" rx="12" fill="transparent"/>
+  <circle cx="42" cy="141" r="6" fill="#64748b"/>
+  <text x="62" y="147" fill="#cbd5e1" font-size="17" font-weight="500">Painel OPRM</text>
+  <rect x="18" y="177" width="214" height="44" rx="12" fill="transparent"/>
+  <circle cx="42" cy="199" r="6" fill="#64748b"/>
+  <text x="62" y="205" fill="#cbd5e1" font-size="17" font-weight="500">Ingestão</text>
+  <rect x="18" y="235" width="214" height="44" rx="12" fill="transparent"/>
+  <circle cx="42" cy="257" r="6" fill="#64748b"/>
+  <text x="62" y="263" fill="#cbd5e1" font-size="17" font-weight="500">Ciclos CNAE</text>
+  <rect x="18" y="293" width="214" height="44" rx="12" fill="transparent"/>
+  <circle cx="42" cy="315" r="6" fill="#64748b"/>
+  <text x="62" y="321" fill="#cbd5e1" font-size="17" font-weight="500">Candidatos</text>
+  <rect x="18" y="351" width="214" height="44" rx="12" fill="transparent"/>
+  <circle cx="42" cy="373" r="6" fill="#64748b"/>
+  <text x="62" y="379" fill="#cbd5e1" font-size="17" font-weight="500">Fila decisão</text>
+  <rect x="18" y="409" width="214" height="44" rx="12" fill="#26344f"/>
+  <circle cx="42" cy="431" r="6" fill="#2563eb"/>
+  <text x="62" y="437" fill="#fff" font-size="17" font-weight="700">Diagnóstico</text>
+  <text x="290" y="62" class="title" fill="#111827">Diagnóstico OPRM</text>
+  <text x="290" y="94" class="small muted">Falhas, rastreabilidade e próximos passos de causa-raiz.</text>
+  <rect x="1210" y="40" width="160" height="44" rx="14" fill="#2563eb"/>
+  <text x="1248" y="68" fill="#fff" font-size="16" font-weight="700">Atualizar</text>
+  <rect x="290" y="125" width="1090" height="90" rx="20" fill="#ffffff" filter="url(#shadow)"/>
+  <text x="314" y="163" class="h3" fill="#111827">Busca por identificador</text>
+  <text x="314" y="191" class="tiny muted">runId, fileId, cycleId, cnaeCode, candidateId ou correlationId</text>
+  <rect x="320" y="168" width="760" height="42" rx="12" fill="#f8fafc" stroke="#e5e7eb"/><text x="345" y="195" class="small muted">Ex.: cycle-CNAE_ENRICHMENT-18</text>
+  <rect x="1100" y="168" width="180" height="42" rx="12" fill="#2563eb"/><text x="1150" y="195" fill="#fff" font-size="16" font-weight="800">Buscar</text>
+  <rect x="290" y="255" width="500" height="520" rx="20" fill="#ffffff" filter="url(#shadow)"/>
+  <text x="314" y="293" class="h3" fill="#111827">Falhas recentes</text>
+  <text x="314" y="321" class="tiny muted">Resumo sem parede de logs</text>
+  <rect x="320" y="300" width="420" height="72" rx="16" fill="#f8fafc"/>
+  <text x="345" y="329" class="small" fill="#111827" font-weight="800">Enriquecimento CNAE 7319</text><text x="345" y="357" class="tiny muted">Falha parcial</text>
+  <circle cx="710" cy="330" r="10" fill="#f59e0b"/>
+  <rect x="320" y="395" width="420" height="72" rx="16" fill="#f8fafc"/>
+  <text x="345" y="424" class="small" fill="#111827" font-weight="800">Arquivo Estab2.zip</text><text x="345" y="452" class="tiny muted">Em processamento</text>
+  <circle cx="710" cy="425" r="10" fill="#2563eb"/>
+  <rect x="320" y="490" width="420" height="72" rx="16" fill="#f8fafc"/>
+  <text x="345" y="519" class="small" fill="#111827" font-weight="800">Artefato rejeitado</text><text x="345" y="547" class="tiny muted">Contrato inválido</text>
+  <circle cx="710" cy="520" r="10" fill="#ef4444"/>
+  <rect x="830" y="255" width="550" height="520" rx="20" fill="#ffffff" filter="url(#shadow)"/>
+  <text x="854" y="293" class="h3" fill="#111827">Rastro de execução</text>
+  <text x="854" y="321" class="tiny muted">Evento inicial → último evento → ação recomendada</text>
+  <circle cx="875" cy="335" r="22" fill="#2563eb"/><text x="875" y="342" fill="#fff" font-size="18" font-weight="800" text-anchor="middle">1</text>
+  <line x1="875" y1="359" x2="875" y2="405" stroke="#e5e7eb" stroke-width="5"/>
+  <text x="920" y="330" class="small" fill="#111827" font-weight="800">Ciclo iniciado</text><text x="920" y="358" class="tiny muted">CNAE_ENRICHMENT #18</text>
+  <circle cx="875" cy="430" r="22" fill="#2563eb"/><text x="875" y="437" fill="#fff" font-size="18" font-weight="800" text-anchor="middle">2</text>
+  <line x1="875" y1="454" x2="875" y2="500" stroke="#e5e7eb" stroke-width="5"/>
+  <text x="920" y="425" class="small" fill="#111827" font-weight="800">CNAE processado</text><text x="920" y="453" class="tiny muted">7319-0/02</text>
+  <circle cx="875" cy="525" r="22" fill="#ef4444"/><text x="875" y="532" fill="#fff" font-size="18" font-weight="800" text-anchor="middle">3</text>
+  <line x1="875" y1="549" x2="875" y2="595" stroke="#e5e7eb" stroke-width="5"/>
+  <text x="920" y="520" class="small" fill="#111827" font-weight="800">Erro capturado</text><text x="920" y="548" class="tiny muted">payload de candidato incompleto</text>
+  <circle cx="875" cy="620" r="22" fill="#2563eb"/><text x="875" y="627" fill="#fff" font-size="18" font-weight="800" text-anchor="middle">4</text>
+  <text x="920" y="615" class="small" fill="#111827" font-weight="800">Próximo passo</text><text x="920" y="643" class="tiny muted">reprocessar após corrigir contrato</text>
+</svg>

--- a/docs/novos-modulos/OPRM/wireframes/oprm-fila-decisao.svg
+++ b/docs/novos-modulos/OPRM/wireframes/oprm-fila-decisao.svg
@@ -1,0 +1,60 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1440" height="900" viewBox="0 0 1440 900" role="img" aria-labelledby="title desc">
+  <title id="title">Fila de Decisão</title>
+  <desc id="desc">Wireframe visual da tela Fila de Decisão do módulo OPRM.</desc>
+  <defs>
+    <filter id="shadow" x="-10%" y="-10%" width="120%" height="120%"><feDropShadow dx="0" dy="8" stdDeviation="10" flood-color="#0f172a" flood-opacity="0.10"/></filter>
+    <style><![CDATA[text{font-family:Inter,Arial,sans-serif}.small{font-size:18px}.tiny{font-size:15px}.title{font-size:34px;font-weight:700}.h2{font-size:24px;font-weight:700}.h3{font-size:19px;font-weight:700}.muted{fill:#6b7280}.label{font-size:14px;font-weight:700;text-transform:uppercase;letter-spacing:.08em}]]></style>
+  </defs>
+  <rect width="1440" height="900" fill="#f5f7fb"/>
+  <rect x="0" y="0" width="250" height="900" fill="#172033"/>
+  <text x="32" y="54" fill="#fff" font-size="26" font-weight="800">Marketing Hub</text>
+  <text x="32" y="92" fill="#93a4bd" font-size="16">OPRM</text>
+  <rect x="18" y="119" width="214" height="44" rx="12" fill="transparent"/>
+  <circle cx="42" cy="141" r="6" fill="#64748b"/>
+  <text x="62" y="147" fill="#cbd5e1" font-size="17" font-weight="500">Painel OPRM</text>
+  <rect x="18" y="177" width="214" height="44" rx="12" fill="transparent"/>
+  <circle cx="42" cy="199" r="6" fill="#64748b"/>
+  <text x="62" y="205" fill="#cbd5e1" font-size="17" font-weight="500">Ingestão</text>
+  <rect x="18" y="235" width="214" height="44" rx="12" fill="transparent"/>
+  <circle cx="42" cy="257" r="6" fill="#64748b"/>
+  <text x="62" y="263" fill="#cbd5e1" font-size="17" font-weight="500">Ciclos CNAE</text>
+  <rect x="18" y="293" width="214" height="44" rx="12" fill="transparent"/>
+  <circle cx="42" cy="315" r="6" fill="#64748b"/>
+  <text x="62" y="321" fill="#cbd5e1" font-size="17" font-weight="500">Candidatos</text>
+  <rect x="18" y="351" width="214" height="44" rx="12" fill="#26344f"/>
+  <circle cx="42" cy="373" r="6" fill="#2563eb"/>
+  <text x="62" y="379" fill="#fff" font-size="17" font-weight="700">Fila decisão</text>
+  <rect x="18" y="409" width="214" height="44" rx="12" fill="transparent"/>
+  <circle cx="42" cy="431" r="6" fill="#64748b"/>
+  <text x="62" y="437" fill="#cbd5e1" font-size="17" font-weight="500">Diagnóstico</text>
+  <text x="290" y="62" class="title" fill="#111827">Fila de Decisão</text>
+  <text x="290" y="94" class="small muted">Central de decisões humanas priorizadas por impacto comercial.</text>
+  <rect x="1210" y="40" width="160" height="44" rx="14" fill="#2563eb"/>
+  <text x="1248" y="68" fill="#fff" font-size="16" font-weight="700">Atualizar</text>
+  <rect x="290" y="125" width="1090" height="110" rx="20" fill="#ffffff" filter="url(#shadow)"/>
+  <text x="314" y="163" class="h3" fill="#111827">Resumo da fila</text>
+  <text x="314" y="191" class="tiny muted">O que depende do usuário agora</text>
+  <text x="320" y="178" class="tiny muted">Aprovar candidatos</text><text x="320" y="215" fill="#f59e0b" font-size="34" font-weight="900">27</text>
+  <text x="580" y="178" class="tiny muted">Revisar baixa confiança</text><text x="580" y="215" fill="#2563eb" font-size="34" font-weight="900">8</text>
+  <text x="840" y="178" class="tiny muted">Bloqueios operacionais</text><text x="840" y="215" fill="#ef4444" font-size="34" font-weight="900">1</text>
+  <text x="1100" y="178" class="tiny muted">Prontos para oferta</text><text x="1100" y="215" fill="#10b981" font-size="34" font-weight="900">12</text>
+  <rect x="290" y="275" width="1090" height="520" rx="20" fill="#ffffff" filter="url(#shadow)"/>
+  <text x="314" y="313" class="h3" fill="#111827">Pendências priorizadas</text>
+  <text x="314" y="341" class="tiny muted">Ordenação por impacto: Score, mercado, clareza da dor e plausibilidade do mecanismo</text>
+  <rect x="330" y="323" width="990" height="74" rx="16" fill="#f8fafc"/>
+  <circle cx="365" cy="360" r="22" fill="#10b981"/><text x="365" y="367" fill="#fff" font-size="18" font-weight="800" text-anchor="middle">1</text>
+  <text x="405" y="355" class="small" fill="#111827" font-weight="800">Salões solo com agenda cheia</text><text x="405" y="383" class="tiny muted">Score 94,2 • alto MEI</text>
+  <rect x="1090" y="337" width="190" height="44" rx="14" fill="#10b981"/><text x="1115" y="365" fill="#fff" font-size="15" font-weight="800">Aprovar candidato</text>
+  <rect x="330" y="421" width="990" height="74" rx="16" fill="#f8fafc"/>
+  <circle cx="365" cy="458" r="22" fill="#f59e0b"/><text x="365" y="465" fill="#fff" font-size="18" font-weight="800" text-anchor="middle">2</text>
+  <text x="405" y="453" class="small" fill="#111827" font-weight="800">Treinamento profissional local</text><text x="405" y="481" class="tiny muted">Score 91,8 • confiança média</text>
+  <rect x="1090" y="435" width="190" height="44" rx="14" fill="#f59e0b"/><text x="1115" y="463" fill="#fff" font-size="15" font-weight="800">Revisar evidência</text>
+  <rect x="330" y="519" width="990" height="74" rx="16" fill="#f8fafc"/>
+  <circle cx="365" cy="556" r="22" fill="#2563eb"/><text x="365" y="563" fill="#fff" font-size="18" font-weight="800" text-anchor="middle">3</text>
+  <text x="405" y="551" class="small" fill="#111827" font-weight="800">Apoio administrativo para MEI</text><text x="405" y="579" class="tiny muted">Score 88,4 • pronto</text>
+  <rect x="1090" y="533" width="190" height="44" rx="14" fill="#2563eb"/><text x="1115" y="561" fill="#fff" font-size="15" font-weight="800">Criar oferta</text>
+  <rect x="330" y="617" width="990" height="74" rx="16" fill="#f8fafc"/>
+  <circle cx="365" cy="654" r="22" fill="#ef4444"/><text x="365" y="661" fill="#fff" font-size="18" font-weight="800" text-anchor="middle">4</text>
+  <text x="405" y="649" class="small" fill="#111827" font-weight="800">Falha no enriquecimento 7319</text><text x="405" y="677" class="tiny muted">erro recorrente</text>
+  <rect x="1090" y="631" width="190" height="44" rx="14" fill="#ef4444"/><text x="1115" y="659" fill="#fff" font-size="15" font-weight="800">Abrir diagnóstico</text>
+</svg>

--- a/docs/novos-modulos/OPRM/wireframes/oprm-ingestao-mercado.svg
+++ b/docs/novos-modulos/OPRM/wireframes/oprm-ingestao-mercado.svg
@@ -1,0 +1,80 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1440" height="900" viewBox="0 0 1440 900" role="img" aria-labelledby="title desc">
+  <title id="title">Ingestão de Mercado</title>
+  <desc id="desc">Wireframe visual da tela Ingestão de Mercado do módulo OPRM.</desc>
+  <defs>
+    <filter id="shadow" x="-10%" y="-10%" width="120%" height="120%"><feDropShadow dx="0" dy="8" stdDeviation="10" flood-color="#0f172a" flood-opacity="0.10"/></filter>
+    <style><![CDATA[text{font-family:Inter,Arial,sans-serif}.small{font-size:18px}.tiny{font-size:15px}.title{font-size:34px;font-weight:700}.h2{font-size:24px;font-weight:700}.h3{font-size:19px;font-weight:700}.muted{fill:#6b7280}.label{font-size:14px;font-weight:700;text-transform:uppercase;letter-spacing:.08em}]]></style>
+  </defs>
+  <rect width="1440" height="900" fill="#f5f7fb"/>
+  <rect x="0" y="0" width="250" height="900" fill="#172033"/>
+  <text x="32" y="54" fill="#fff" font-size="26" font-weight="800">Marketing Hub</text>
+  <text x="32" y="92" fill="#93a4bd" font-size="16">OPRM</text>
+  <rect x="18" y="119" width="214" height="44" rx="12" fill="transparent"/>
+  <circle cx="42" cy="141" r="6" fill="#64748b"/>
+  <text x="62" y="147" fill="#cbd5e1" font-size="17" font-weight="500">Painel OPRM</text>
+  <rect x="18" y="177" width="214" height="44" rx="12" fill="#26344f"/>
+  <circle cx="42" cy="199" r="6" fill="#2563eb"/>
+  <text x="62" y="205" fill="#fff" font-size="17" font-weight="700">Ingestão</text>
+  <rect x="18" y="235" width="214" height="44" rx="12" fill="transparent"/>
+  <circle cx="42" cy="257" r="6" fill="#64748b"/>
+  <text x="62" y="263" fill="#cbd5e1" font-size="17" font-weight="500">Ciclos CNAE</text>
+  <rect x="18" y="293" width="214" height="44" rx="12" fill="transparent"/>
+  <circle cx="42" cy="315" r="6" fill="#64748b"/>
+  <text x="62" y="321" fill="#cbd5e1" font-size="17" font-weight="500">Candidatos</text>
+  <rect x="18" y="351" width="214" height="44" rx="12" fill="transparent"/>
+  <circle cx="42" cy="373" r="6" fill="#64748b"/>
+  <text x="62" y="379" fill="#cbd5e1" font-size="17" font-weight="500">Fila decisão</text>
+  <rect x="18" y="409" width="214" height="44" rx="12" fill="transparent"/>
+  <circle cx="42" cy="431" r="6" fill="#64748b"/>
+  <text x="62" y="437" fill="#cbd5e1" font-size="17" font-weight="500">Diagnóstico</text>
+  <text x="290" y="62" class="title" fill="#111827">Ingestão de Mercado</text>
+  <text x="290" y="94" class="small muted">Acompanhamento de snapshot, runs e arquivos CNPJ/CNAE.</text>
+  <rect x="1210" y="40" width="160" height="44" rx="14" fill="#2563eb"/>
+  <text x="1248" y="68" fill="#fff" font-size="16" font-weight="700">Atualizar</text>
+  <rect x="290" y="125" width="520" height="145" rx="20" fill="#ffffff" filter="url(#shadow)"/>
+  <text x="314" y="163" class="h3" fill="#111827">Snapshot canônico</text>
+  <text x="314" y="191" class="tiny muted">Base oficial usada para market size</text>
+  <text x="320" y="210" fill="#2563eb" font-size="38" font-weight="800">2026-05-10</text>
+  <rect x="620" y="178" width="205" height="32" rx="16" fill="#10b981" opacity="0.12"/>
+  <text x="637" y="200" fill="#10b981" font-size="15" font-weight="700">Arquivos mínimos OK</text>
+  <rect x="840" y="125" width="540" height="145" rx="20" fill="#ffffff" filter="url(#shadow)"/>
+  <text x="864" y="163" class="h3" fill="#111827">Alertas canônicos</text>
+  <text x="864" y="191" class="tiny muted">Bloqueios que impedem fechamento prematuro</text>
+  <rect x="870" y="183" width="295" height="32" rx="16" fill="#10b981" opacity="0.12"/>
+  <text x="887" y="205" fill="#10b981" font-size="15" font-weight="700">0 ESTABELECIMENTOS em STARTED</text>
+  <rect x="870" y="225" width="250" height="32" rx="16" fill="#2563eb" opacity="0.12"/>
+  <text x="887" y="247" fill="#2563eb" font-size="15" font-weight="700">Resumo final obrigatório</text>
+  <rect x="290" y="305" width="500" height="470" rx="20" fill="#ffffff" filter="url(#shadow)"/>
+  <text x="314" y="343" class="h3" fill="#111827">Runs de importação</text>
+  <text x="314" y="371" class="tiny muted">Status resumido por execução</text>
+  <rect x="320" y="352" width="430" height="58" rx="14" fill="#f8fafc"/>
+  <text x="345" y="380" class="small" fill="#111827" font-weight="800">#184</text>
+  <rect x="405" y="358" width="97" height="32" rx="16" fill="#f59e0b" opacity="0.12"/>
+  <text x="422" y="380" fill="#f59e0b" font-size="15" font-weight="700">STARTED</text>
+  <text x="560" y="380" class="tiny muted">2.8M linhas • Em andamento</text>
+  <rect x="320" y="434" width="430" height="58" rx="14" fill="#f8fafc"/>
+  <text x="345" y="462" class="small" fill="#111827" font-weight="800">#183</text>
+  <rect x="405" y="440" width="115" height="32" rx="16" fill="#10b981" opacity="0.12"/>
+  <text x="422" y="462" fill="#10b981" font-size="15" font-weight="700">COMPLETED</text>
+  <text x="560" y="462" class="tiny muted">48.2M linhas • Finalizada</text>
+  <rect x="320" y="516" width="430" height="58" rx="14" fill="#f8fafc"/>
+  <text x="345" y="544" class="small" fill="#111827" font-weight="800">#182</text>
+  <rect x="405" y="522" width="88" height="32" rx="16" fill="#ef4444" opacity="0.12"/>
+  <text x="422" y="544" fill="#ef4444" font-size="15" font-weight="700">FAILED</text>
+  <text x="560" y="544" class="tiny muted">13.1M linhas • Erro arquivo 7</text>
+  <rect x="820" y="305" width="560" height="470" rx="20" fill="#ffffff" filter="url(#shadow)"/>
+  <text x="844" y="343" class="h3" fill="#111827">Arquivos da run #184</text>
+  <text x="844" y="371" class="tiny muted">Progresso por dataset</text>
+  <text x="850" y="380" class="small" fill="#111827">Estabelecimentos0.zip</text>
+  <rect x="850" y="394" width="360" height="12" rx="6" fill="#e5e7eb"/><rect x="850" y="394" width="360.0" height="12" rx="6" fill="#10b981"/>
+  <text x="1235" y="404" class="tiny" fill="#10b981" font-weight="800">COMPLETED</text>
+  <text x="850" y="460" class="small" fill="#111827">Estabelecimentos1.zip</text>
+  <rect x="850" y="474" width="360" height="12" rx="6" fill="#e5e7eb"/><rect x="850" y="474" width="360.0" height="12" rx="6" fill="#10b981"/>
+  <text x="1235" y="484" class="tiny" fill="#10b981" font-weight="800">COMPLETED</text>
+  <text x="850" y="540" class="small" fill="#111827">Estabelecimentos2.zip</text>
+  <rect x="850" y="554" width="360" height="12" rx="6" fill="#e5e7eb"/><rect x="850" y="554" width="223.20000000000002" height="12" rx="6" fill="#f59e0b"/>
+  <text x="1235" y="564" class="tiny" fill="#f59e0b" font-weight="800">STARTED</text>
+  <text x="850" y="620" class="small" fill="#111827">Simples.zip</text>
+  <rect x="850" y="634" width="360" height="12" rx="6" fill="#e5e7eb"/><rect x="850" y="634" width="0.0" height="12" rx="6" fill="#94a3b8"/>
+  <text x="1235" y="644" class="tiny" fill="#94a3b8" font-weight="800">PENDING</text>
+</svg>

--- a/docs/novos-modulos/OPRM/wireframes/oprm-painel.svg
+++ b/docs/novos-modulos/OPRM/wireframes/oprm-painel.svg
@@ -1,0 +1,103 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="1440" height="900" viewBox="0 0 1440 900" role="img" aria-labelledby="title desc">
+  <title id="title">Painel OPRM</title>
+  <desc id="desc">Wireframe visual da tela Painel OPRM do módulo OPRM.</desc>
+  <defs>
+    <filter id="shadow" x="-10%" y="-10%" width="120%" height="120%"><feDropShadow dx="0" dy="8" stdDeviation="10" flood-color="#0f172a" flood-opacity="0.10"/></filter>
+    <style><![CDATA[text{font-family:Inter,Arial,sans-serif}.small{font-size:18px}.tiny{font-size:15px}.title{font-size:34px;font-weight:700}.h2{font-size:24px;font-weight:700}.h3{font-size:19px;font-weight:700}.muted{fill:#6b7280}.label{font-size:14px;font-weight:700;text-transform:uppercase;letter-spacing:.08em}]]></style>
+  </defs>
+  <rect width="1440" height="900" fill="#f5f7fb"/>
+  <rect x="0" y="0" width="250" height="900" fill="#172033"/>
+  <text x="32" y="54" fill="#fff" font-size="26" font-weight="800">Marketing Hub</text>
+  <text x="32" y="92" fill="#93a4bd" font-size="16">OPRM</text>
+  <rect x="18" y="119" width="214" height="44" rx="12" fill="#26344f"/>
+  <circle cx="42" cy="141" r="6" fill="#2563eb"/>
+  <text x="62" y="147" fill="#fff" font-size="17" font-weight="700">Painel OPRM</text>
+  <rect x="18" y="177" width="214" height="44" rx="12" fill="transparent"/>
+  <circle cx="42" cy="199" r="6" fill="#64748b"/>
+  <text x="62" y="205" fill="#cbd5e1" font-size="17" font-weight="500">Ingestão</text>
+  <rect x="18" y="235" width="214" height="44" rx="12" fill="transparent"/>
+  <circle cx="42" cy="257" r="6" fill="#64748b"/>
+  <text x="62" y="263" fill="#cbd5e1" font-size="17" font-weight="500">Ciclos CNAE</text>
+  <rect x="18" y="293" width="214" height="44" rx="12" fill="transparent"/>
+  <circle cx="42" cy="315" r="6" fill="#64748b"/>
+  <text x="62" y="321" fill="#cbd5e1" font-size="17" font-weight="500">Candidatos</text>
+  <rect x="18" y="351" width="214" height="44" rx="12" fill="transparent"/>
+  <circle cx="42" cy="373" r="6" fill="#64748b"/>
+  <text x="62" y="379" fill="#cbd5e1" font-size="17" font-weight="500">Fila decisão</text>
+  <rect x="18" y="409" width="214" height="44" rx="12" fill="transparent"/>
+  <circle cx="42" cy="431" r="6" fill="#64748b"/>
+  <text x="62" y="437" fill="#cbd5e1" font-size="17" font-weight="500">Diagnóstico</text>
+  <text x="290" y="62" class="title" fill="#111827">Painel OPRM</text>
+  <text x="290" y="94" class="small muted">Visão executiva do trabalho atual do OPRM até oportunidade vendável.</text>
+  <rect x="1210" y="40" width="160" height="44" rx="14" fill="#2563eb"/>
+  <text x="1248" y="68" fill="#fff" font-size="16" font-weight="700">Atualizar</text>
+  <rect x="290" y="125" width="250" height="118" rx="20" fill="#ffffff" filter="url(#shadow)"/>
+  <text x="314" y="163" class="h3" fill="#111827">Status geral</text>
+  <text x="314" y="198" fill="#10b981" font-size="28" font-weight="800">Processando agora</text>
+  <rect x="565" y="125" width="250" height="118" rx="20" fill="#ffffff" filter="url(#shadow)"/>
+  <text x="589" y="163" class="h3" fill="#111827">Ciclo atual</text>
+  <text x="589" y="198" fill="#2563eb" font-size="28" font-weight="800">CNAE_ENRICHMENT #18</text>
+  <rect x="840" y="125" width="250" height="118" rx="20" fill="#ffffff" filter="url(#shadow)"/>
+  <text x="864" y="163" class="h3" fill="#111827">Pendências humanas</text>
+  <text x="864" y="198" fill="#f59e0b" font-size="28" font-weight="800">27 candidatos</text>
+  <rect x="1115" y="125" width="250" height="118" rx="20" fill="#ffffff" filter="url(#shadow)"/>
+  <text x="1139" y="163" class="h3" fill="#111827">Falhas bloqueantes</text>
+  <text x="1139" y="198" fill="#10b981" font-size="28" font-weight="800">0 críticas</text>
+  <rect x="290" y="275" width="760" height="210" rx="20" fill="#ffffff" filter="url(#shadow)"/>
+  <text x="314" y="313" class="h3" fill="#111827">Esteira OPRM</text>
+  <text x="314" y="341" class="tiny muted">Dados de mercado até decisão humana</text>
+  <circle cx="335" cy="372" r="28" fill="#10b981"/>
+  <text x="335" y="379" fill="#fff" font-size="18" font-weight="800" text-anchor="middle">1</text>
+  <text x="335" y="426" fill="#111827" font-size="15" font-weight="700" text-anchor="middle">Ingestão</text>
+  <line x1="365" y1="372" x2="407" y2="372" stroke="#e5e7eb" stroke-width="6"/>
+  <circle cx="437" cy="372" r="28" fill="#10b981"/>
+  <text x="437" y="379" fill="#fff" font-size="18" font-weight="800" text-anchor="middle">2</text>
+  <text x="437" y="426" fill="#111827" font-size="15" font-weight="700" text-anchor="middle">Consolidação</text>
+  <line x1="467" y1="372" x2="509" y2="372" stroke="#e5e7eb" stroke-width="6"/>
+  <circle cx="539" cy="372" r="28" fill="#10b981"/>
+  <text x="539" y="379" fill="#fff" font-size="18" font-weight="800" text-anchor="middle">3</text>
+  <text x="539" y="426" fill="#111827" font-size="15" font-weight="700" text-anchor="middle">Score</text>
+  <line x1="569" y1="372" x2="611" y2="372" stroke="#e5e7eb" stroke-width="6"/>
+  <circle cx="641" cy="372" r="28" fill="#10b981"/>
+  <text x="641" y="379" fill="#fff" font-size="18" font-weight="800" text-anchor="middle">4</text>
+  <text x="641" y="426" fill="#111827" font-size="15" font-weight="700" text-anchor="middle">Enriquecimento</text>
+  <line x1="671" y1="372" x2="713" y2="372" stroke="#e5e7eb" stroke-width="6"/>
+  <circle cx="743" cy="372" r="28" fill="#10b981"/>
+  <text x="743" y="379" fill="#fff" font-size="18" font-weight="800" text-anchor="middle">5</text>
+  <text x="743" y="426" fill="#111827" font-size="15" font-weight="700" text-anchor="middle">Candidatos</text>
+  <line x1="773" y1="372" x2="815" y2="372" stroke="#e5e7eb" stroke-width="6"/>
+  <circle cx="845" cy="372" r="28" fill="#f59e0b"/>
+  <text x="845" y="379" fill="#fff" font-size="18" font-weight="800" text-anchor="middle">6</text>
+  <text x="845" y="426" fill="#111827" font-size="15" font-weight="700" text-anchor="middle">Decisão</text>
+  <line x1="875" y1="372" x2="917" y2="372" stroke="#e5e7eb" stroke-width="6"/>
+  <circle cx="947" cy="372" r="28" fill="#94a3b8"/>
+  <text x="947" y="379" fill="#fff" font-size="18" font-weight="800" text-anchor="middle">7</text>
+  <text x="947" y="426" fill="#111827" font-size="15" font-weight="700" text-anchor="middle">Oferta</text>
+  <rect x="1080" y="275" width="300" height="210" rx="20" fill="#ffffff" filter="url(#shadow)"/>
+  <text x="1104" y="313" class="h3" fill="#111827">Próxima ação</text>
+  <text x="1104" y="341" class="tiny muted">Prioridade para o usuário</text>
+  <rect x="1104" y="352" width="187" height="32" rx="16" fill="#f59e0b" opacity="0.12"/>
+  <text x="1121" y="374" fill="#f59e0b" font-size="15" font-weight="700">Aprovar 12 nichos</text>
+  <rect x="1104" y="398" width="241" height="32" rx="16" fill="#2563eb" opacity="0.12"/>
+  <text x="1121" y="420" fill="#2563eb" font-size="15" font-weight="700">Revisar baixa confiança</text>
+  <rect x="290" y="515" width="520" height="300" rx="20" fill="#ffffff" filter="url(#shadow)"/>
+  <text x="314" y="553" class="h3" fill="#111827">Top CNAEs por Score</text>
+  <text x="314" y="581" class="tiny muted">Ranking de oportunidade</text>
+  <text x="320" y="580" class="small" fill="#111827">9602-5/01</text><text x="445" y="580" class="small muted">Cabeleireiros</text><text x="735" y="580" class="small" fill="#2563eb" font-weight="800">94,2</text>
+  <line x1="315" y1="598" x2="780" y2="598" stroke="#e5e7eb"/>
+  <text x="320" y="635" class="small" fill="#111827">8599-6/04</text><text x="445" y="635" class="small muted">Treinamento</text><text x="735" y="635" class="small" fill="#2563eb" font-weight="800">91,8</text>
+  <line x1="315" y1="653" x2="780" y2="653" stroke="#e5e7eb"/>
+  <text x="320" y="690" class="small" fill="#111827">8211-3/00</text><text x="445" y="690" class="small muted">Apoio administrativo</text><text x="735" y="690" class="small" fill="#2563eb" font-weight="800">88,4</text>
+  <line x1="315" y1="708" x2="780" y2="708" stroke="#e5e7eb"/>
+  <text x="320" y="745" class="small" fill="#111827">7319-0/02</text><text x="445" y="745" class="small muted">Promoção vendas</text><text x="735" y="745" class="small" fill="#2563eb" font-weight="800">85,9</text>
+  <line x1="315" y1="763" x2="780" y2="763" stroke="#e5e7eb"/>
+  <rect x="840" y="515" width="540" height="300" rx="20" fill="#ffffff" filter="url(#shadow)"/>
+  <text x="864" y="553" class="h3" fill="#111827">Oportunidades recentes</text>
+  <text x="864" y="581" class="tiny muted">Dor → Resultado → Mecanismo → Prova → Oferta</text>
+  <rect x="870" y="562" width="470" height="48" rx="12" fill="#eff6ff"/>
+  <text x="895" y="592" class="small" fill="#111827">Agenda cheia e baixa recorrência</text>
+  <rect x="870" y="626" width="470" height="48" rx="12" fill="#eff6ff"/>
+  <text x="895" y="656" class="small" fill="#111827">Dificuldade de precificar serviço</text>
+  <rect x="870" y="690" width="470" height="48" rx="12" fill="#eff6ff"/>
+  <text x="895" y="720" class="small" fill="#111827">Captação local inconsistente</text>
+</svg>

--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -203,3 +203,7 @@
 
 - 2026-06-01 03:25:00 (UTC): implementação do próximo passo de geração de vendas no OPRM CNAE: o enriquecimento automático passou a executar catch-up na subida do coletor para processar scores sem `enriched_at`, registrar falhas críticas sem derrubar a aplicação e usar `OprmCnaeRoutineSignalBuilder` para transformar CNAEs priorizados em sinais concretos de rotina, dor, resultado, mecanismo, prova e oferta por arquétipo operacional. Também foram adicionados testes unitários cobrindo enriquecimento de beleza e serviços técnicos, garantindo ausência de JSON textual nos sinais funcionais.
 - 2026-06-01 00:15:00 (UTC): ajustada a tela `/oprm/cnaes-volume` para ordenar CNAEs por Score OPRM decrescente diretamente no backend, mantendo paginação de 50 registros e exibindo volume de mercado como contexto para decisão comercial. Atualizado o cânone OPRM para refletir a nova regra de ordenação por score.
+
+- 2026-06-01 00:00:00 (UTC): planejadas novas telas de acompanhamento operacional do OPRM para dar visibilidade ao usuário sobre ingestão de mercado, ciclos CNAE, enriquecimento, candidatos de nicho, fila de decisão e diagnóstico, preservando o eixo Dados de mercado → Score → Enriquecimento → Nicho candidato → Decisão humana → Oferta vendável.
+
+- 2026-06-01 00:00:00 (UTC): adicionados wireframes SVG das telas de acompanhamento operacional do OPRM para facilitar validação visual do Painel OPRM, Ingestão de Mercado, Ciclos CNAE, Candidatos de Nicho, Fila de Decisão e Diagnóstico antes da implementação frontend.


### PR DESCRIPTION
### Motivation

- Provide a user-facing specification to allow tracking of OPRM execution as a business-oriented pipeline (Ingestão → Score → Enriquecimento → Candidatos → Decisão → Oferta). 
- Reduce operator friction by translating technical state into clear next actions and avoiding exposure of raw JSON or debug metadata in commercial artifacts.
- Create a prioritized MVP and backend contract gaps so frontend and backend teams can implement screens consistently.

### Description

- Added a detailed specification for operational monitoring screens at `docs/novos-modulos/OPRM/oprm-telas-acompanhamento-operacional.md` describing objectives, UX principles, navigation map, six screens, endpoints and an MVP/sprint plan. 
- Added wireframe SVG assets for each screen under `docs/novos-modulos/OPRM/wireframes/` (`oprm-painel.svg`, `oprm-ingestao-mercado.svg`, `oprm-ciclos-cnae.svg`, `oprm-candidatos-nicho.svg`, `oprm-fila-decisao.svg`, `oprm-diagnostico.svg`).
- Updated the existing specification `docs/novos-modulos/OPRM/oprm_especificacao_telas_menu_com_sprints.md` to reference the new complement document and appended the complement section. 
- Recorded the planning addition to `docs/registros/oprm1.md` noting the creation of the new screens and inclusion of SVG wireframes for visual validation.

### Testing

- This is a documentation-only change; no automated tests were executed for this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1cfd442f988321ad920bbe3288fac4)