### PR TITLE
Zerar imagens ao reexecutar prompt de imagem

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/frameworkimage/repository/FrameworkImageGenerationJobRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/frameworkimage/repository/FrameworkImageGenerationJobRepository.java
@@ -9,32 +9,48 @@ import java.util.Optional;
 import java.util.UUID;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
+/** Responsável por consultar e remover jobs de geração de imagem do framework por experimento e status operacional. */
 public interface FrameworkImageGenerationJobRepository extends JpaRepository<FrameworkImageGenerationJob, UUID> {
+    /** Lista jobs por status em ordem de criação para consumo pelos workers. */
     List<FrameworkImageGenerationJob> findByStatusOrderByCreatedAtAsc(FrameworkImageGenerationJobStatus status,
                                                                       Pageable pageable);
 
+    /** Busca o job ativo mais recente para um item planejado de um experimento. */
     Optional<FrameworkImageGenerationJob> findFirstByExperimentIdAndPlanningItemKeyAndStatusInOrderByCreatedAtDesc(
             Long experimentId,
             String planningItemKey,
             Collection<FrameworkImageGenerationJobStatus> statuses);
 
+    /** Lista todos os jobs de um experimento do mais recente para o mais antigo. */
     List<FrameworkImageGenerationJob> findByExperimentIdOrderByCreatedAtDesc(Long experimentId);
 
+    /** Lista jobs de itens planejados específicos por experimento e status. */
     List<FrameworkImageGenerationJob> findByExperimentIdAndPlanningItemKeyInAndStatusOrderByCreatedAtDesc(
             Long experimentId,
             Collection<String> planningItemKeys,
             FrameworkImageGenerationJobStatus status);
 
+    /** Lista assets concluídos que ainda precisam receber URL web definitiva. */
     List<FrameworkImageGenerationJob> findByStatusAndStageInAndAssetIdIsNotNullAndSourceUrlIsNotNullAndWebUrlIsNullOrderByUpdatedAtAsc(
             FrameworkImageGenerationJobStatus status,
             Collection<FrameworkImageGenerationJobStage> stages,
             Pageable pageable);
 
+    /** Busca o job mais recente associado a um asset gerado. */
     Optional<FrameworkImageGenerationJob> findFirstByAssetIdOrderByCreatedAtDesc(Long assetId);
 
+    /** Lista jobs em processamento iniciados antes de uma data para marcação de timeout. */
     List<FrameworkImageGenerationJob> findByStatusAndStartedAtBeforeOrderByStartedAtAsc(
             FrameworkImageGenerationJobStatus status,
             java.time.Instant startedAt,
             Pageable pageable);
+
+    /** Remove todos os jobs de geração de imagens vinculados a um experimento. */
+    @Modifying
+    @Query("delete from FrameworkImageGenerationJob job where job.experiment.id = :experimentId")
+    void deleteByExperimentId(@Param("experimentId") Long experimentId);
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/imageplanning/service/BackendImagePlanningService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/imageplanning/service/BackendImagePlanningService.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marketinghub.experiment.Experiment;
+import com.marketinghub.experiment.frameworkimage.repository.FrameworkImageGenerationJobRepository;
 import com.marketinghub.experiment.repository.ExperimentRepository;
 import com.marketinghub.geralanding.GeraLandingStageExecution;
 import com.marketinghub.geralanding.GeraLandingStageExecutionRepository;
@@ -39,15 +40,18 @@ public class BackendImagePlanningService {
     private static final String STATUS_FAILED = "FALHA";
     private final ExperimentRepository experimentRepository;
     private final GeraLandingStageExecutionRepository executionRepository;
+    private final FrameworkImageGenerationJobRepository frameworkImageGenerationJobRepository;
     private final ObjectMapper objectMapper;
 
     /** Inicializa o serviço com os repositórios e montadores necessários para a etapa image planning. */
     public BackendImagePlanningService(
             ExperimentRepository experimentRepository,
             GeraLandingStageExecutionRepository executionRepository,
+            FrameworkImageGenerationJobRepository frameworkImageGenerationJobRepository,
             ObjectMapper objectMapper) {
         this.experimentRepository = experimentRepository;
         this.executionRepository = executionRepository;
+        this.frameworkImageGenerationJobRepository = frameworkImageGenerationJobRepository;
         this.objectMapper = objectMapper;
     }
 
@@ -62,6 +66,7 @@ public class BackendImagePlanningService {
         Instant now = Instant.now();
         var experiment = experimentRepository.findById(experimentId)
                 .orElseThrow(() -> new EntityNotFoundException("Experiment not found: " + experimentId));
+        resetImageArtifactsForNewPlanning(experiment);
 
         GeraLandingStageExecution execution = GeraLandingStageExecution.builder()
                 .experimentId(experiment.getId())
@@ -76,6 +81,14 @@ public class BackendImagePlanningService {
                 .build();
         GeraLandingStageExecution saved = executionRepository.save(execution);
         return new GeraLandingImagePlanningStartResponse(fromDatabaseIdJob(saved.getIdJob()), saved.getStatus());
+    }
+
+    /** Limpa o planejamento anterior, manifesto e jobs reais de imagem antes de gerar novos prompts. */
+    private void resetImageArtifactsForNewPlanning(Experiment experiment) {
+        experiment.setLandingPageImagePlanning(null);
+        experiment.setLandingPageImageAssets(null);
+        frameworkImageGenerationJobRepository.deleteByExperimentId(experiment.getId());
+        experimentRepository.save(experiment);
     }
 
     /** Lista execuções da etapa convertendo para o DTO local da etapa. */

--- a/backend/ads-service/src/test/java/com/marketinghub/geralanding/imageplanning/service/BackendImagePlanningServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/geralanding/imageplanning/service/BackendImagePlanningServiceTest.java
@@ -11,6 +11,7 @@ import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marketinghub.experiment.Experiment;
+import com.marketinghub.experiment.frameworkimage.repository.FrameworkImageGenerationJobRepository;
 import com.marketinghub.experiment.repository.ExperimentRepository;
 import com.marketinghub.geralanding.GeraLandingStageExecution;
 import com.marketinghub.geralanding.GeraLandingStageExecutionRepository;
@@ -31,10 +32,14 @@ class BackendImagePlanningServiceTest {
     void startShouldRegisterInitialExecutionForImagePlanningStage() {
         ExperimentRepository experimentRepository = mock(ExperimentRepository.class);
         GeraLandingStageExecutionRepository executionRepository = mock(GeraLandingStageExecutionRepository.class);
+        FrameworkImageGenerationJobRepository jobRepository = mock(FrameworkImageGenerationJobRepository.class);
         BackendImagePlanningService service =
-                new BackendImagePlanningService(experimentRepository, executionRepository, new ObjectMapper());
-        Experiment experiment = mock(Experiment.class);
-        when(experiment.getId()).thenReturn(91L);
+                new BackendImagePlanningService(
+                        experimentRepository, executionRepository, jobRepository, new ObjectMapper());
+        Experiment experiment = new Experiment();
+        experiment.setId(91L);
+        experiment.setLandingPageImagePlanning("{\"images\":[{\"imageUrl\":\"old\"}]}");
+        experiment.setLandingPageImageAssets("{\"images\":[{\"resolvedUrl\":\"old\"}]}");
         when(experimentRepository.findById(91L)).thenReturn(Optional.of(experiment));
         when(executionRepository.save(any(GeraLandingStageExecution.class)))
                 .thenAnswer(invocation -> invocation.getArgument(0));
@@ -50,6 +55,10 @@ class BackendImagePlanningServiceTest {
                         && execution.getStatus().equals("INICIADO")
                         && execution.getPromptTemplateId().equals("manual/start")
                         && execution.getIdJob() != null));
+        assertEquals(null, experiment.getLandingPageImagePlanning());
+        assertEquals(null, experiment.getLandingPageImageAssets());
+        verify(jobRepository).deleteByExperimentId(91L);
+        verify(experimentRepository).save(experiment);
     }
 
     /** Deve buscar somente jobs iniciados da etapa image planning para o endpoint interno pending. */
@@ -58,7 +67,11 @@ class BackendImagePlanningServiceTest {
         ExperimentRepository experimentRepository = mock(ExperimentRepository.class);
         GeraLandingStageExecutionRepository executionRepository = mock(GeraLandingStageExecutionRepository.class);
         BackendImagePlanningService service =
-                new BackendImagePlanningService(experimentRepository, executionRepository, new ObjectMapper());
+                new BackendImagePlanningService(
+                        experimentRepository,
+                        executionRepository,
+                        mock(FrameworkImageGenerationJobRepository.class),
+                        new ObjectMapper());
         Experiment experiment = mock(Experiment.class);
         when(experiment.getId()).thenReturn(77L);
         when(experiment.getName()).thenReturn("Experimento Image Planning");
@@ -94,7 +107,11 @@ class BackendImagePlanningServiceTest {
         ExperimentRepository experimentRepository = mock(ExperimentRepository.class);
         GeraLandingStageExecutionRepository executionRepository = mock(GeraLandingStageExecutionRepository.class);
         BackendImagePlanningService service =
-                new BackendImagePlanningService(experimentRepository, executionRepository, new ObjectMapper());
+                new BackendImagePlanningService(
+                        experimentRepository,
+                        executionRepository,
+                        mock(FrameworkImageGenerationJobRepository.class),
+                        new ObjectMapper());
         Experiment experiment = new Experiment();
         experiment.setId(44L);
         GeraLandingStageExecution execution = GeraLandingStageExecution.builder()

--- a/docs/canonical/openai-informacoes-tratadas-canon.v1.md
+++ b/docs/canonical/openai-informacoes-tratadas-canon.v1.md
@@ -311,7 +311,8 @@ A tabela `experiment` armazena o experimento e os artefatos funcionais consolida
 - `experiment` não é a tabela de auditoria completa das chamadas à IA.
 - Auditoria de chamada, request, resposta bruta, tokens e custo por etapa ficam em `experiment_pipeline_generation_job`.
 - Jobs de imagem por item planejado ficam em `framework_image_generation_job`.
-- O manifesto consolidado consumível pelas etapas seguintes fica em `experiment.landing_page_image_assets`, sem sobrescrever o planejamento/prompt original em `experiment.landing_page_image_planning`.
+- Ao reiniciar manualmente a etapa de planejamento de imagens da landing, os jobs antigos de `framework_image_generation_job` daquele experimento devem ser removidos para evitar reutilização de imagens obsoletas.
+- O manifesto consolidado consumível pelas etapas seguintes fica em `experiment.landing_page_image_assets`, sem sobrescrever o planejamento/prompt original em `experiment.landing_page_image_planning` durante a geração de imagens; quando o próprio planejamento é reexecutado, o planejamento e o manifesto anteriores devem ser zerados antes do novo processamento.
 
 ## 7. Tabela `experiment_pipeline_generation_job`
 

--- a/docs/canonical/procedimento-experimento-canon.v1.md
+++ b/docs/canonical/procedimento-experimento-canon.v1.md
@@ -51,6 +51,7 @@ No fluxo atual, a geração da landing segue as etapas:
 1. gerar wireframe (`LANDING_PAGE_WIREFRAME`);
 2. gerar copy (`LANDING_PAGE_COPY`);
 3. gerar planejamento/prompt de imagens (`LANDING_PAGE_IMAGE_PLANNING`) e gerar imagens, materializando `experiment.landing_page_image_assets` com as URLs finais;
+   - ao reexecutar manualmente `LANDING_PAGE_IMAGE_PLANNING`, o backend deve zerar o planejamento anterior, o manifesto `experiment.landing_page_image_assets` e os jobs de imagem já associados ao experimento antes de registrar o novo job;
 4. gerar preset de design (`LANDING_PAGE_DESIGN_PRESET`);
 5. gerar entregável HTML da landing (`LANDING_PAGE_HTML`).
 

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -2906,3 +2906,13 @@
   - o AGENTS do `ai-worker` substituiu a orientação antiga de isolamento de GeraLanding por uma regra de isolamento por etapa no OpenAI core;
   - a orientação de novos serviços no `ai-worker` passou a separar serviços de domínio simples de etapas OpenAI assíncronas.
 - impacto esperado: próximos trabalhos no Worker AI seguem o padrão `openai.core` também pelas instruções operacionais dos agentes, mantendo coerência com os cânones e reduzindo risco de retrabalho.
+
+## 2026-06-01 — Reset das imagens ao reexecutar Gera Prompt Imagem
+- solicitação: ao executar novamente o prompt de imagem no experimento, as imagens anteriores precisam ser zeradas.
+- causa-raiz/objetivo: o início da etapa `landing-page-image-planning` registrava um novo job de prompt, mas preservava o planejamento anterior, o manifesto `landing_page_image_assets` e os jobs reais de imagem já criados; isso mantinha contadores e URLs antigas no fluxo de Gera Imagem.
+- correção aplicada:
+  - o backend agora limpa `landingPageImagePlanning` e `landingPageImageAssets` antes de registrar uma nova execução manual de Gera Prompt Imagem;
+  - os jobs de geração real de imagem do experimento são removidos no mesmo fluxo, garantindo que a próxima geração em lote parta de estado zerado;
+  - o teste unitário da etapa image planning foi atualizado para validar a limpeza dos artefatos e jobs antigos;
+  - os documentos canônicos de procedimento e informações tratadas foram atualizados para explicitar a regra de reset na reexecução do planejamento de imagens.
+- impacto esperado: a reexecução do prompt de imagem deixa de carregar imagens antigas, evitando decisões e HTML baseados em assets obsoletos e mantendo o fluxo comercial de landing mais confiável.


### PR DESCRIPTION
### Motivation
- Evitar que reexecuções manuais da etapa de geração de prompts (`landing-page-image-planning`) reutilizem planejamento, manifesto ou jobs de imagem antigos que poluem contadores e HTML gerado.
- Garantir que uma nova geração de imagens comece de um estado limpo para manter a consistência do fluxo de Gera Landing e a integridade comercial do artefato final.

### Description
- Adiciona método de remoção de jobs por experimento em `FrameworkImageGenerationJobRepository` com `@Modifying`/`@Query` e a assinatura `deleteByExperimentId(Long experimentId)`.
- Injeta o repositório de jobs em `BackendImagePlanningService` e chama `resetImageArtifactsForNewPlanning(experiment)` ao iniciar manualmente o `landing-page-image-planning`, que limpa `landingPageImagePlanning`, `landingPageImageAssets`, remove os `framework_image_generation_job` do experimento e persiste o experimento limpo.
- Atualiza o teste unitário `BackendImagePlanningServiceTest` para validar que o planejamento antigo, o manifesto e os jobs são zerados/removidos ao iniciar um novo job.
- Atualiza documentos canônicos (`procedimento-experimento-canon.v1.md`, `openai-informacoes-tratadas-canon.v1.md`) e o log de alteração em `docs/registros/experimentos.md` para explicitar a regra de reset na reexecução do planejamento de imagens.

### Testing
- Executado `../mvnw -Dtest=BackendImagePlanningServiceTest test` no módulo `backend/ads-service`, com resultado: `Tests run: 3, Failures: 0, Errors: 0` (sucesso).
- Executado `git diff --check` sem problemas (sucesso).
- Tentado `../mvnw spotless:check -Dspotless.check.skip=false` no mesmo módulo, que falhou porque o prefixo/plugin `spotless` não foi resolvido no ambiente Maven (informativo, não bloqueante).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d9680ee6c8321bbb86600b999cf61)