### PR TITLE
Zera imagens ao reexecutar prompt de imagem

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/frameworkimage/service/FrameworkImageGenerationService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/frameworkimage/service/FrameworkImageGenerationService.java
@@ -14,6 +14,7 @@ import com.marketinghub.experiment.frameworkimage.dto.FrameworkImageGenerationSu
 import com.marketinghub.experiment.frameworkimage.dto.internal.FrameworkImageGenerationJobCompletionRequest;
 import com.marketinghub.experiment.frameworkimage.dto.internal.FrameworkImageGenerationJobDto;
 import com.marketinghub.experiment.frameworkimage.dto.internal.FrameworkImageWebnizationPendingAssetDto;
+import com.marketinghub.geralanding.imageplanning.service.BackendImagePlanningService.ImagePromptRegenerationStartedEvent;
 import com.marketinghub.repository.jpa.experiment.frameworkimage.FrameworkImageGenerationJobRepository;
 import com.marketinghub.repository.jpa.experiment.ExperimentRepository;
 import java.time.Instant;
@@ -30,6 +31,7 @@ import org.springframework.http.HttpStatus;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
@@ -230,6 +232,27 @@ public class FrameworkImageGenerationService {
                 .filter(item -> StringUtils.hasText(item.prompt()))
                 .map(item -> enqueueJob(experimentId, item.planningItemKey(), null, item.prompt()))
                 .toList();
+    }
+
+
+    /** Recebe o evento de regeneração do prompt de imagem e dispara a limpeza dos artefatos antigos. */
+    @EventListener
+    public void resetImagesWhenPromptRegenerationStarts(ImagePromptRegenerationStartedEvent event) {
+        resetImagesForPromptRegeneration(event.experimentId());
+    }
+
+    /** Remove jobs e artefatos de imagens quando o planejamento de prompts será regenerado. */
+    @Transactional
+    public void resetImagesForPromptRegeneration(Long experimentId) {
+        Experiment experiment = experimentRepository.findById(experimentId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Experimento não encontrado"));
+        long deletedJobs = jobRepository.deleteByExperimentId(experimentId);
+        experiment.setLandingPageImagePlanning(null);
+        experiment.setLandingPageImageAssets(null);
+        experimentRepository.save(experiment);
+        log.info("framework-image-reset-for-prompt-regeneration experimentId={} deletedJobs={}",
+                experimentId,
+                deletedJobs);
     }
 
     @Transactional(readOnly = true)

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/imageplanning/service/BackendImagePlanningService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/imageplanning/service/BackendImagePlanningService.java
@@ -22,6 +22,7 @@ import java.util.Map;
 import java.util.UUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
@@ -40,21 +41,29 @@ public class BackendImagePlanningService {
     private final ExperimentRepository experimentRepository;
     private final GeraLandingStageExecutionRepository executionRepository;
     private final ObjectMapper objectMapper;
+    private final ApplicationEventPublisher eventPublisher;
 
     /** Inicializa o serviço com os repositórios e montadores necessários para a etapa image planning. */
     public BackendImagePlanningService(
             ExperimentRepository experimentRepository,
             GeraLandingStageExecutionRepository executionRepository,
-            ObjectMapper objectMapper) {
+            ObjectMapper objectMapper,
+            ApplicationEventPublisher eventPublisher) {
         this.experimentRepository = experimentRepository;
         this.executionRepository = executionRepository;
         this.objectMapper = objectMapper;
+        this.eventPublisher = eventPublisher;
     }
 
-    /** Inicia a execução manual da etapa image planning usando o código canônico da etapa. */
+    /** Inicia a execução manual da etapa image planning e publica o reset de imagens antigas antes de gerar novos prompts. */
     @Transactional
     public GeraLandingImagePlanningStartResponse start(Long experimentId) {
+        eventPublisher.publishEvent(new ImagePromptRegenerationStartedEvent(experimentId));
         return registerInitialExecution(experimentId, STAGE_CODE);
+    }
+
+    /** Evento síncrono que sinaliza a necessidade de zerar imagens antes da regeneração dos prompts. */
+    public record ImagePromptRegenerationStartedEvent(Long experimentId) {
     }
 
     /** Registra a execução inicial da etapa convertendo para o DTO local de início. */

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/experiment/frameworkimage/FrameworkImageGenerationJobRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/experiment/frameworkimage/FrameworkImageGenerationJobRepository.java
@@ -24,6 +24,9 @@ public interface FrameworkImageGenerationJobRepository extends JpaRepository<Fra
 
     List<FrameworkImageGenerationJob> findByExperimentIdOrderByCreatedAtDesc(Long experimentId);
 
+    /** Remove todos os jobs de geração de imagem vinculados ao experimento informado. */
+    long deleteByExperimentId(Long experimentId);
+
     List<FrameworkImageGenerationJob> findByExperimentIdAndPlanningItemKeyInAndStatusOrderByCreatedAtDesc(
             Long experimentId,
             Collection<String> planningItemKeys,

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/frameworkimage/service/FrameworkImageGenerationServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/frameworkimage/service/FrameworkImageGenerationServiceTest.java
@@ -17,6 +17,7 @@ import com.marketinghub.experiment.frameworkimage.dto.FrameworkImageGenerationIt
 import com.marketinghub.experiment.frameworkimage.dto.internal.FrameworkImageGenerationJobCompletionRequest;
 import com.marketinghub.experiment.frameworkimage.dto.internal.FrameworkImageGenerationJobDto;
 import com.marketinghub.experiment.frameworkimage.dto.internal.FrameworkImageWebnizationPendingAssetDto;
+import com.marketinghub.geralanding.imageplanning.service.BackendImagePlanningService.ImagePromptRegenerationStartedEvent;
 import com.marketinghub.repository.jpa.experiment.frameworkimage.FrameworkImageGenerationJobRepository;
 import com.marketinghub.repository.jpa.experiment.ExperimentRepository;
 import java.time.Instant;
@@ -156,6 +157,43 @@ class FrameworkImageGenerationServiceTest {
         assertThat(experiment.getLandingPageImageAssets()).contains("\"elementId\":\"hero-img\"");
         assertThat(experiment.getLandingPageImageAssets()).contains("\"resolvedUrl\":\"https://cdn/web.jpg\"");
         verify(experimentRepository).save(experiment);
+    }
+
+
+    @Test
+    void resetImagesForPromptRegenerationClearsPlanningAssetsAndJobs() {
+        Experiment experiment = Experiment.builder()
+                .id(88L)
+                .landingPageImagePlanning("{\"images\":[{}]}")
+                .landingPageImageAssets("{\"images\":[{\"resolvedUrl\":\"https://cdn/old.jpg\"}]}")
+                .build();
+        when(experimentRepository.findById(88L)).thenReturn(Optional.of(experiment));
+        when(jobRepository.deleteByExperimentId(88L)).thenReturn(3L);
+
+        service.resetImagesForPromptRegeneration(88L);
+
+        assertThat(experiment.getLandingPageImagePlanning()).isNull();
+        assertThat(experiment.getLandingPageImageAssets()).isNull();
+        verify(jobRepository).deleteByExperimentId(88L);
+        verify(experimentRepository).save(experiment);
+    }
+
+
+    @Test
+    void resetImagesWhenPromptRegenerationStartsUsesEventExperimentId() {
+        Experiment experiment = Experiment.builder()
+                .id(89L)
+                .landingPageImagePlanning("{\"images\":[{}]}")
+                .landingPageImageAssets("{\"images\":[{}]}")
+                .build();
+        when(experimentRepository.findById(89L)).thenReturn(Optional.of(experiment));
+        when(jobRepository.deleteByExperimentId(89L)).thenReturn(1L);
+
+        service.resetImagesWhenPromptRegenerationStarts(new ImagePromptRegenerationStartedEvent(89L));
+
+        assertThat(experiment.getLandingPageImagePlanning()).isNull();
+        assertThat(experiment.getLandingPageImageAssets()).isNull();
+        verify(jobRepository).deleteByExperimentId(89L);
     }
 
     @Test

--- a/backend/ads-service/src/test/java/com/marketinghub/geralanding/imageplanning/service/BackendImagePlanningServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/geralanding/imageplanning/service/BackendImagePlanningServiceTest.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
+import org.springframework.context.ApplicationEventPublisher;
 
 /** Valida as consultas de execução específicas da etapa image planning. */
 class BackendImagePlanningServiceTest {
@@ -31,8 +32,12 @@ class BackendImagePlanningServiceTest {
     void startShouldRegisterInitialExecutionForImagePlanningStage() {
         ExperimentRepository experimentRepository = mock(ExperimentRepository.class);
         GeraLandingStageExecutionRepository executionRepository = mock(GeraLandingStageExecutionRepository.class);
-        BackendImagePlanningService service =
-                new BackendImagePlanningService(experimentRepository, executionRepository, new ObjectMapper());
+        ApplicationEventPublisher eventPublisher = mock(ApplicationEventPublisher.class);
+        BackendImagePlanningService service = new BackendImagePlanningService(
+                experimentRepository,
+                executionRepository,
+                new ObjectMapper(),
+                eventPublisher);
         Experiment experiment = mock(Experiment.class);
         when(experiment.getId()).thenReturn(91L);
         when(experimentRepository.findById(91L)).thenReturn(Optional.of(experiment));
@@ -43,6 +48,7 @@ class BackendImagePlanningServiceTest {
 
         assertNotNull(response.idJob());
         assertEquals("INICIADO", response.status());
+        verify(eventPublisher).publishEvent(new BackendImagePlanningService.ImagePromptRegenerationStartedEvent(91L));
         verify(executionRepository).save(argThat(execution ->
                 execution.getExperimentId().equals(91L)
                         && execution.getExperiment() == experiment
@@ -57,8 +63,11 @@ class BackendImagePlanningServiceTest {
     void listPendingShouldQueryStartedJobsForStage() {
         ExperimentRepository experimentRepository = mock(ExperimentRepository.class);
         GeraLandingStageExecutionRepository executionRepository = mock(GeraLandingStageExecutionRepository.class);
-        BackendImagePlanningService service =
-                new BackendImagePlanningService(experimentRepository, executionRepository, new ObjectMapper());
+        BackendImagePlanningService service = new BackendImagePlanningService(
+                experimentRepository,
+                executionRepository,
+                new ObjectMapper(),
+                mock(ApplicationEventPublisher.class));
         Experiment experiment = mock(Experiment.class);
         when(experiment.getId()).thenReturn(77L);
         when(experiment.getName()).thenReturn("Experimento Image Planning");
@@ -93,8 +102,11 @@ class BackendImagePlanningServiceTest {
     void markCompletedFromResponseShouldPersistImagePlanningArtifact() {
         ExperimentRepository experimentRepository = mock(ExperimentRepository.class);
         GeraLandingStageExecutionRepository executionRepository = mock(GeraLandingStageExecutionRepository.class);
-        BackendImagePlanningService service =
-                new BackendImagePlanningService(experimentRepository, executionRepository, new ObjectMapper());
+        BackendImagePlanningService service = new BackendImagePlanningService(
+                experimentRepository,
+                executionRepository,
+                new ObjectMapper(),
+                mock(ApplicationEventPublisher.class));
         Experiment experiment = new Experiment();
         experiment.setId(44L);
         GeraLandingStageExecution execution = GeraLandingStageExecution.builder()

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -2906,3 +2906,12 @@
   - o AGENTS do `ai-worker` substituiu a orientação antiga de isolamento de GeraLanding por uma regra de isolamento por etapa no OpenAI core;
   - a orientação de novos serviços no `ai-worker` passou a separar serviços de domínio simples de etapas OpenAI assíncronas.
 - impacto esperado: próximos trabalhos no Worker AI seguem o padrão `openai.core` também pelas instruções operacionais dos agentes, mantendo coerência com os cânones e reduzindo risco de retrabalho.
+
+## 2026-06-01 — Reset das imagens ao reexecutar Gera Prompt Imagem
+- tarefa: garantir que uma nova execução do prompt de imagem zere as imagens geradas anteriormente no experimento.
+- causa-raiz/objetivo: o fluxo permitia iniciar novamente `landing-page-image-planning` mantendo jobs e manifesto de imagens da execução anterior, o que podia deixar a tela de Gera Imagem com contadores/URLs antigos e induzir o usuário a usar imagens incompatíveis com os novos prompts.
+- correção aplicada:
+  - o início manual do Gera Prompt Imagem agora chama a limpeza canônica de imagens antes de registrar o novo job da etapa;
+  - a limpeza remove os jobs `framework_image_generation_job` do experimento e apaga `landingPageImagePlanning` e `landingPageImageAssets`, forçando a próxima geração de imagens a partir do novo planejamento;
+  - adicionados testes unitários para validar o reset ao iniciar a etapa e a limpeza dos artefatos/jobs.
+- impacto esperado: reexecutar o prompt de imagem deixa o bloco de imagens sem resultados antigos, preservando consistência entre prompts, imagens reais e etapas seguintes do Gera Landing.


### PR DESCRIPTION
### Motivation
- Evitar que reexecuções do fluxo de geração de prompt de imagem mantenham jobs e URLs antigos, o que poderia exibir contadores/preview inconsistentes no frontend. 
- Garantir que uma nova execução parte de um estado limpo (sem `landingPageImagePlanning` nem `landingPageImageAssets`) para preservar coerência entre prompt e imagens geradas. 
- Registrar a ação no histórico de experimentos para auditoria e rastreabilidade do comportamento operacional.

### Description
- Ao iniciar manualmente o `Gera Prompt Imagem` o serviço agora publica um evento `ImagePromptRegenerationStartedEvent` em `BackendImagePlanningService.start(...)` para sinalizar a necessidade de limpeza prévia. 
- Implementado um listener em `FrameworkImageGenerationService` que responde ao evento e chama `resetImagesForPromptRegeneration(Long experimentId)`, que remove jobs via o novo repositório `deleteByExperimentId(Long experimentId)`, zera `landingPageImagePlanning` e `landingPageImageAssets` e persiste o experimento; o processo também gera log operacional com o total de jobs removidos. 
- Alteradas as assinaturas e injeções necessárias: `BackendImagePlanningService` passou a usar `ApplicationEventPublisher` para publicar o evento, e `FrameworkImageGenerationJobRepository` ganhou o método `deleteByExperimentId(...)`. 
- Adicionados/atualizados testes unitários cobrindo a publicação do evento, a limpeza de jobs/artefatos e o tratamento do evento; e atualizada a entrada em `docs/registros/experimentos.md` descrevendo a modificação.

### Testing
- Executado o conjunto de testes relevantes com `../mvnw -Dtest=BackendImagePlanningServiceTest,FrameworkImageGenerationServiceTest,ArquiteturaTest test` e todos os testes passaram (nenhuma falha reportada). 
- Observou-se uma tentativa inicial com `./mvnw -pl ads-service -Dtest=...` que falhou por motivo de seleção de módulo no reactor, mas a execução correta do módulo `ads-service` retornou `BUILD SUCCESS` e testes verdes. 
- Verificado `git diff --check` para garantir ausência de artefatos de formatação/erro antes do commit.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d99091cd483218ddd83591a94ab59)