### PR TITLE
feat(oprm): show enriched niche candidates

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/cnae/service/OprmCnaeOpportunityPersistenceService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/cnae/service/OprmCnaeOpportunityPersistenceService.java
@@ -174,6 +174,17 @@ public class OprmCnaeOpportunityPersistenceService {
     }
 
     /**
+     * Lista os nichos já enriquecidos pelo OPRM para consulta direta no frontend.
+     */
+    @Transactional(readOnly = true)
+    public List<OprmNicheCandidateResponseDto> listEnrichedCandidates(int limit) {
+        return candidateRepository.findAllByOrderByCreatedAtDesc(PageRequest.of(0, normalizeLimit(limit)))
+                .stream()
+                .map(this::toCandidateResponse)
+                .toList();
+    }
+
+    /**
      * Marca um candidato como aprovado e opcionalmente vincula um nicho oficial já existente.
      */
     @Transactional

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/cnae/web/OprmCnaeOpportunityController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/cnae/web/OprmCnaeOpportunityController.java
@@ -127,6 +127,14 @@ public class OprmCnaeOpportunityController {
     }
 
     /**
+     * Lista nichos já enriquecidos pelo OPRM para acompanhamento direto do usuário.
+     */
+    @GetMapping("/cnae-niche-candidates/enriched")
+    public List<OprmNicheCandidateResponseDto> listEnrichedCandidates(@RequestParam(defaultValue = "100") int limit) {
+        return service.listEnrichedCandidates(limit);
+    }
+
+    /**
      * Aprova candidato de nicho e opcionalmente vincula um nicho oficial já existente.
      */
     @PostMapping("/cnae-niche-candidates/{id}/approve")

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/oprm/cnae/OprmNicheCandidateRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/oprm/cnae/OprmNicheCandidateRepository.java
@@ -2,6 +2,7 @@ package com.marketinghub.repository.jpa.oprm.cnae;
 
 import com.marketinghub.oprm.cnae.OprmNicheCandidate;
 import java.util.List;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 /**
@@ -12,4 +13,10 @@ public interface OprmNicheCandidateRepository extends JpaRepository<OprmNicheCan
      * Lista candidatos de nicho vinculados a um CNAE específico.
      */
     List<OprmNicheCandidate> findByCnaeCodeOrderByOpportunityScoreDescCreatedAtDesc(String cnaeCode);
+
+    /**
+     * Lista candidatos de nicho enriquecidos mais recentes para acompanhamento no frontend.
+     */
+    List<OprmNicheCandidate> findAllByOrderByCreatedAtDesc(Pageable pageable);
 }
+

--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -207,3 +207,5 @@
 - 2026-06-01 00:00:00 (UTC): planejadas novas telas de acompanhamento operacional do OPRM para dar visibilidade ao usuário sobre ingestão de mercado, ciclos CNAE, enriquecimento, candidatos de nicho, fila de decisão e diagnóstico, preservando o eixo Dados de mercado → Score → Enriquecimento → Nicho candidato → Decisão humana → Oferta vendável.
 
 - 2026-06-01 00:00:00 (UTC): adicionados wireframes SVG das telas de acompanhamento operacional do OPRM para facilitar validação visual do Painel OPRM, Ingestão de Mercado, Ciclos CNAE, Candidatos de Nicho, Fila de Decisão e Diagnóstico antes da implementação frontend.
+
+- 2026-06-01 00:00:00 (UTC): adicionado botão na tela `/oprm/cnaes-volume` para o usuário consultar diretamente os nichos já enriquecidos pelo OPRM; backend recebeu endpoint de leitura dos candidatos enriquecidos mais recentes e frontend passou a exibir tabela com nicho, CNAE, dor, resultado, mecanismo, score, status e data de enriquecimento.

--- a/frontend/src/__tests__/OprmNavigation.test.tsx
+++ b/frontend/src/__tests__/OprmNavigation.test.tsx
@@ -19,10 +19,11 @@ afterEach(() => {
 });
 
 describe("OPRM navigation", () => {
-  it("renders loading state on /oprm route", async () => {
+  it("renders CNAE score page on /oprm route", () => {
     setup(<App />, ["/oprm"]);
+    expect(screen.getByText(/^CNAEs por Score OPRM$/)).toBeTruthy();
     expect(
-      await screen.findByText(/carregando ocupações do oprm/i),
+      screen.getByRole("button", { name: /ver nichos enriquecidos/i }),
     ).toBeTruthy();
   });
 
@@ -33,12 +34,11 @@ describe("OPRM navigation", () => {
     expect(link.getAttribute("href")).toBe("/oprm");
   });
 
-
-  it("has menu link to /oprm/cnaes-volume", () => {
+  it("has menu link to /oprm for CNAEs", () => {
     setup(<App />, ["/"]);
     const link = screen.getByRole("link", { name: /^cnaes$/i });
     expect(link).toBeTruthy();
-    expect(link.getAttribute("href")).toBe("/oprm/cnaes-volume");
+    expect(link.getAttribute("href")).toBe("/oprm");
   });
 
   it("renders loading state on /oprm/operations route", async () => {
@@ -48,6 +48,8 @@ describe("OPRM navigation", () => {
 
   it("renders loading state on /oprm/occupations route", async () => {
     setup(<App />, ["/oprm/occupations"]);
-    expect(await screen.findByText(/carregando catálogo de ocupações/i)).toBeTruthy();
+    expect(
+      await screen.findByText(/carregando catálogo de ocupações/i),
+    ).toBeTruthy();
   });
 });

--- a/frontend/src/api/oprm/useOprmEnrichedNicheCandidates.ts
+++ b/frontend/src/api/oprm/useOprmEnrichedNicheCandidates.ts
@@ -1,0 +1,46 @@
+import { useQuery } from "@tanstack/react-query";
+import { buildApiUrl } from "../../utils/buildApiUrl";
+
+export interface OprmEnrichedNicheCandidate {
+  id: number;
+  cnaeCode: string;
+  cnaeDescription: string;
+  candidateNicheName: string;
+  persona: string | null;
+  painHypothesis: string | null;
+  desiredOutcome: string | null;
+  mechanismHypothesis: string | null;
+  proofDirection: string | null;
+  offerIdea: string | null;
+  marketVolumeSignals: string | null;
+  opportunityScore: number;
+  scoreCycleId: string;
+  enrichmentCycleId: string;
+  status: string;
+  sourceArtifacts: string | null;
+  marketNicheId: number | null;
+  createdAt: string;
+  updatedAt: string;
+}
+
+async function fetchEnrichedNicheCandidates(
+  limit = 100,
+): Promise<OprmEnrichedNicheCandidate[]> {
+  const response = await fetch(
+    buildApiUrl(`/api/oprm/cnae-niche-candidates/enriched?limit=${limit}`),
+  );
+  if (!response.ok) {
+    throw new Error(
+      `Não foi possível carregar os nichos enriquecidos do OPRM (status ${response.status}).`,
+    );
+  }
+  return (await response.json()) as OprmEnrichedNicheCandidate[];
+}
+
+export function useOprmEnrichedNicheCandidates(limit = 100, enabled = false) {
+  return useQuery({
+    queryKey: ["oprm", "cnae-niche-candidates", "enriched", limit],
+    queryFn: () => fetchEnrichedNicheCandidates(limit),
+    enabled,
+  });
+}

--- a/frontend/src/pages/oprm/OprmCnaeVolumePage.tsx
+++ b/frontend/src/pages/oprm/OprmCnaeVolumePage.tsx
@@ -3,6 +3,7 @@ import OprmModuleNavigation from "./OprmModuleNavigation";
 import { useOprmTopCnaeMarketVolume } from "../../api/oprm/useOprmTopCnaeMarketVolume";
 import { useOprmCnaeCatalog } from "../../api/oprm/useOprmCnaeCatalog";
 import { useOprmCnaeCycles } from "../../api/oprm/useOprmCnaeCycles";
+import { useOprmEnrichedNicheCandidates } from "../../api/oprm/useOprmEnrichedNicheCandidates";
 import { useState } from "react";
 
 function formatNumber(value: number) {
@@ -25,10 +26,15 @@ function formatDateTime(value: string | null | undefined) {
 export default function OprmCnaeVolumePage() {
   const pageSize = 50;
   const [currentPage, setCurrentPage] = useState(1);
+  const [showEnrichedNiches, setShowEnrichedNiches] = useState(false);
   const { data, isLoading, isError, refetch, isFetching } =
     useOprmTopCnaeMarketVolume(currentPage - 1, pageSize);
   const cnaeCatalogQuery = useOprmCnaeCatalog();
   const cycleQuery = useOprmCnaeCycles(5);
+  const enrichedNichesQuery = useOprmEnrichedNicheCandidates(
+    100,
+    showEnrichedNiches,
+  );
   const hasVolumeData = (data ?? []).length > 0;
   const hasCatalogData = (cnaeCatalogQuery.data ?? []).length > 0;
   const volumeData = data ?? [];
@@ -56,21 +62,40 @@ export default function OprmCnaeVolumePage() {
               apenas acompanha ciclos, candidatos e decisões.
             </p>
           </div>
-          <button
-            type="button"
-            className="btn btn-outline-primary"
-            onClick={() => refetch()}
-            disabled={isFetching}
-          >
-            {isFetching ? (
-              <span
-                className="spinner-border spinner-border-sm"
-                aria-hidden="true"
-              />
-            ) : (
-              "Atualizar"
-            )}
-          </button>
+          <div className="d-flex gap-2">
+            <button
+              type="button"
+              className="btn btn-outline-primary"
+              onClick={() => setShowEnrichedNiches((current) => !current)}
+              disabled={enrichedNichesQuery.isFetching}
+            >
+              {enrichedNichesQuery.isFetching ? (
+                <span
+                  className="spinner-border spinner-border-sm"
+                  aria-hidden="true"
+                />
+              ) : showEnrichedNiches ? (
+                "Ocultar enriquecidos"
+              ) : (
+                "Ver nichos enriquecidos"
+              )}
+            </button>
+            <button
+              type="button"
+              className="btn btn-outline-primary"
+              onClick={() => refetch()}
+              disabled={isFetching}
+            >
+              {isFetching ? (
+                <span
+                  className="spinner-border spinner-border-sm"
+                  aria-hidden="true"
+                />
+              ) : (
+                "Atualizar"
+              )}
+            </button>
+          </div>
         </div>
       </section>
 
@@ -148,6 +173,89 @@ export default function OprmCnaeVolumePage() {
           ) : null}
         </div>
       </section>
+
+      {showEnrichedNiches ? (
+        <section className="card border-0 shadow-sm">
+          <div className="card-body">
+            <div className="d-flex justify-content-between align-items-start gap-3 mb-3">
+              <div>
+                <h2 className="h5 mb-1">Nichos já enriquecidos</h2>
+                <p className="text-secondary mb-0">
+                  Lista dos candidatos de nicho que já receberam enriquecimento
+                  do OPRM, com dor, resultado e mecanismo para decisão do
+                  usuário.
+                </p>
+              </div>
+              <button
+                type="button"
+                className="btn btn-sm btn-outline-secondary"
+                onClick={() => enrichedNichesQuery.refetch()}
+                disabled={enrichedNichesQuery.isFetching}
+              >
+                {enrichedNichesQuery.isFetching ? (
+                  <span
+                    className="spinner-border spinner-border-sm"
+                    aria-hidden="true"
+                  />
+                ) : (
+                  "Atualizar nichos"
+                )}
+              </button>
+            </div>
+            {enrichedNichesQuery.isError ? (
+              <div className="alert alert-warning mb-0">
+                Não foi possível carregar os nichos enriquecidos.
+              </div>
+            ) : null}
+            {!enrichedNichesQuery.isError ? (
+              <div className="table-responsive">
+                <table className="table table-sm align-middle mb-0">
+                  <thead>
+                    <tr>
+                      <th>Nicho</th>
+                      <th>CNAE</th>
+                      <th>Dor</th>
+                      <th>Resultado</th>
+                      <th>Mecanismo</th>
+                      <th>Score</th>
+                      <th>Status</th>
+                      <th>Enriquecido em</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {(enrichedNichesQuery.data ?? []).length > 0 ? (
+                      (enrichedNichesQuery.data ?? []).map((candidate) => (
+                        <tr key={candidate.id}>
+                          <td>{candidate.candidateNicheName}</td>
+                          <td>
+                            <strong>{candidate.cnaeCode}</strong>
+                            <br />
+                            <span className="small text-secondary">
+                              {candidate.cnaeDescription}
+                            </span>
+                          </td>
+                          <td>{candidate.painHypothesis ?? "-"}</td>
+                          <td>{candidate.desiredOutcome ?? "-"}</td>
+                          <td>{candidate.mechanismHypothesis ?? "-"}</td>
+                          <td>{formatScore(candidate.opportunityScore)}</td>
+                          <td>{candidate.status}</td>
+                          <td>{formatDateTime(candidate.createdAt)}</td>
+                        </tr>
+                      ))
+                    ) : (
+                      <tr>
+                        <td colSpan={8} className="text-secondary">
+                          Nenhum nicho enriquecido registrado ainda.
+                        </td>
+                      </tr>
+                    )}
+                  </tbody>
+                </table>
+              </div>
+            ) : null}
+          </div>
+        </section>
+      ) : null}
 
       {!isLoading && !isError ? (
         <section className="card border-0 shadow-sm">


### PR DESCRIPTION
### Motivation
- Dar ao usuário visibilidade imediata sobre os nichos que já receberam enriquecimento automático pelo OPRM para apoiar decisões de produto/negócio. 
- Integrar observabilidade do fluxo CNAE → Score → Enriquecimento na UI sem exigir navegação cruzada nem chamadas manuais fora do painel CNAE.

### Description
- Adiciona endpoint backend `GET /api/oprm/cnae-niche-candidates/enriched` e método de serviço `listEnrichedCandidates(int limit)` para retornar candidatos de nicho ordenados por `createdAt` decrescente usando paginação via `PageRequest` (service/controller/repository). 
- Estende o repositório com `findAllByOrderByCreatedAtDesc(Pageable)` para suportar a consulta de nichos enriquecidos. 
- Cria hook frontend `useOprmEnrichedNicheCandidates(limit, enabled)` que consome o novo endpoint e pode ficar desativado até ação do usuário. 
- Atualiza a tela `/oprm` (`OprmCnaeVolumePage`) para incluir o botão `Ver nichos enriquecidos` que alterna uma tabela com nicho, CNAE, dor, resultado, mecanismo, score, status e data de enriquecimento, incluindo estados de carregamento e atualização; também atualiza teste de navegação OPRM e registra a alteração em `docs/registros/oprm1.md`.

### Testing
- Executei `cd backend/ads-service && mvn -DskipTests compile` e a compilação do backend foi bem-sucedida. 
- Executei `cd frontend && npm run typecheck` e o TypeScript passou sem erros. 
- Executei `cd frontend && npm test -- --run src/__tests__/OprmNavigation.test.tsx` e o teste atualizado passou localmente (verifica presença do botão/estrutura nova). 
- Executei `cd backend/ads-service && mvn test -DskipITs` e a suíte de testes do backend falhou em um teste existente (`CreativeControllerTest`) por violação de integridade referencial no H2 durante limpeza de fixtures; esse erro é pré-existente e não está relacionado às mudanças de OPRM introduzidas aqui.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1d99206aa083219c0ef9e4e28210c5)