### PR TITLE
Agendar ciclo 1 Hotmart para 13h30

### DIFF
--- a/docs/registros/mois1.md
+++ b/docs/registros/mois1.md
@@ -718,9 +718,9 @@ Arquivos alterados:
   - valor padrão de `collector.scheduler.max-products` atualizado para 400;
   - cânone Hotmart atualizado para documentar o alvo operacional padrão de 20 páginas.
 
-## 2026-06-01 — Hotmart ciclo 1 reagendado para 13:30
-- ajuste operacional solicitado para agendar a próxima execução do ciclo 1 Hotmart para 01/06 às 13:30 no timezone `America/Sao_Paulo`.
-- atualizado o `HotmartCollectorScheduler` para disparar o ciclo 1 com cron literal `0 30 13 1 6 *`, mantendo a regra de `@Scheduled` com string direta e sem alterar o ciclo 2.
+## 2026-06-01 — Hotmart ciclo 1 reagendado para 14:00
+- ajuste operacional solicitado para agendar a próxima execução do ciclo 1 Hotmart para 01/06 às 14:00 no timezone `America/Sao_Paulo`.
+- atualizado o `HotmartCollectorScheduler` para disparar o ciclo 1 com cron literal `0 0 14 1 6 *`, mantendo a regra de `@Scheduled` com string direta e sem alterar o ciclo 2.
 - mantido o foco operacional do ciclo 1 em listagem/search Hotmart para alimentar a base MOIS com snapshots comerciais úteis.
 - documentos lidos para tratar a situação:
   - AGENTS.md

--- a/docs/registros/mois1.md
+++ b/docs/registros/mois1.md
@@ -717,3 +717,13 @@ Arquivos alterados:
   - alvo máximo por execução derivado de 20 páginas x 20 itens = 400 produtos;
   - valor padrão de `collector.scheduler.max-products` atualizado para 400;
   - cânone Hotmart atualizado para documentar o alvo operacional padrão de 20 páginas.
+
+## 2026-06-01 — Hotmart ciclo 1 reagendado para 13:30
+- ajuste operacional solicitado para agendar a próxima execução do ciclo 1 Hotmart para 01/06 às 13:30 no timezone `America/Sao_Paulo`.
+- atualizado o `HotmartCollectorScheduler` para disparar o ciclo 1 com cron literal `0 30 13 1 6 *`, mantendo a regra de `@Scheduled` com string direta e sem alterar o ciclo 2.
+- mantido o foco operacional do ciclo 1 em listagem/search Hotmart para alimentar a base MOIS com snapshots comerciais úteis.
+- documentos lidos para tratar a situação:
+  - AGENTS.md
+  - mois-hotmart-collector/AGENTS.md
+  - docs/canonical/mois-hotmart-mapeamento-ciclos-campos-banco.md
+  - docs/registros/mois1.md

--- a/mois-hotmart-collector/src/main/java/com/marketinghub/moishotmart/service/HotmartCollectorScheduler.java
+++ b/mois-hotmart-collector/src/main/java/com/marketinghub/moishotmart/service/HotmartCollectorScheduler.java
@@ -37,17 +37,17 @@ public class HotmartCollectorScheduler {
     }
 
     /**
-     * Executa o próximo ciclo 1 de listagem de produtos às 13:30 no dia 1 de junho, no horário de São Paulo.
+     * Executa o próximo ciclo 1 de listagem de produtos às 14:00 no dia 1 de junho, no horário de São Paulo.
      */
-    @Scheduled(cron = "0 30 13 1 6 *", zone = "America/Sao_Paulo")
-    public void collectFirstCycleAtThirteenThirtyOnJuneFirst() {
+    @Scheduled(cron = "0 0 14 1 6 *", zone = "America/Sao_Paulo")
+    public void collectFirstCycleAtFourteenOnJuneFirst() {
         if (!enabled) {
             log.info("Hotmart scheduler desabilitado por configuração.");
             return;
         }
         HotmartCollectionRequest request = new HotmartCollectionRequest(source, maxProducts);
         HotmartCollectionResponse response = collectorService.collectFirstCycle(request);
-        log.info("Hotmart scheduler executado hora=13:30 dia=01/06 timezone=America/Sao_Paulo ciclo={} status={} produtos={} mensagem={}",
+        log.info("Hotmart scheduler executado hora=14:00 dia=01/06 timezone=America/Sao_Paulo ciclo={} status={} produtos={} mensagem={}",
                 "CICLO_1_LISTAGEM",
                 response.status(),
                 response.products().size(),

--- a/mois-hotmart-collector/src/main/java/com/marketinghub/moishotmart/service/HotmartCollectorScheduler.java
+++ b/mois-hotmart-collector/src/main/java/com/marketinghub/moishotmart/service/HotmartCollectorScheduler.java
@@ -37,17 +37,17 @@ public class HotmartCollectorScheduler {
     }
 
     /**
-     * Executa o ciclo 1 de listagem de produtos às 04:00 no dia 1 de junho, no horário de São Paulo.
+     * Executa o próximo ciclo 1 de listagem de produtos às 13:30 no dia 1 de junho, no horário de São Paulo.
      */
-    @Scheduled(cron = "0 0 4 1 6 *", zone = "America/Sao_Paulo")
-    public void collectFirstCycleAtFourOnJuneFirst() {
+    @Scheduled(cron = "0 30 13 1 6 *", zone = "America/Sao_Paulo")
+    public void collectFirstCycleAtThirteenThirtyOnJuneFirst() {
         if (!enabled) {
             log.info("Hotmart scheduler desabilitado por configuração.");
             return;
         }
         HotmartCollectionRequest request = new HotmartCollectionRequest(source, maxProducts);
         HotmartCollectionResponse response = collectorService.collectFirstCycle(request);
-        log.info("Hotmart scheduler executado hora=04:00 dia=01/06 timezone=America/Sao_Paulo ciclo={} status={} produtos={} mensagem={}",
+        log.info("Hotmart scheduler executado hora=13:30 dia=01/06 timezone=America/Sao_Paulo ciclo={} status={} produtos={} mensagem={}",
                 "CICLO_1_LISTAGEM",
                 response.status(),
                 response.products().size(),


### PR DESCRIPTION
### Motivation
- Agendar a próxima execução do Ciclo 1 do coletor Hotmart para 01/06 às 13:30 (fuso `America/Sao_Paulo`) conforme solicitação operacional. 

### Description
- Atualiza `HotmartCollectorScheduler` trocando o `@Scheduled` do método do ciclo 1 para o cron literal `0 30 13 1 6 *` e renomeando o método para `collectFirstCycleAtThirteenThirtyOnJuneFirst` para refletir o horário. 
- Ajusta a mensagem de log do agendador para registrar `hora=13:30 dia=01/06 timezone=America/Sao_Paulo`. 
- Registra o ajuste no histórico operacional em `docs/registros/mois1.md` para documentar a mudança de agendamento. 

### Testing
- Executado `mvn test` no módulo `mois-hotmart-collector`, com resultado `BUILD SUCCESS` e `Tests run: 5, Failures: 0, Errors: 0, Skipped: 0`. 
- Verificado `git diff --check` sem problemas após as alterações.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1da445bcf88321828ffb05c11a4829)