### PR TITLE
docs: destacar estrutura obrigatória de repositories do backend

### DIFF
--- a/backend/AGENTS.md
+++ b/backend/AGENTS.md
@@ -1,6 +1,16 @@
 # AGENTS.md — Backend
 
 - Todo o modelo de dados deve estar definido aqui no projeto **backend**.
+
+## Estrutura obrigatória de repositories
+
+> **DESTAQUE — regra obrigatória de acesso ao banco:** todas as classes que conectam diretamente com banco de dados devem ficar exclusivamente dentro do pacote `com.marketinghub.repository`. Não crie repositories, DAOs, gateways JDBC/JPA ou qualquer classe com acesso direto ao banco dentro dos pacotes funcionais dos módulos.
+
+- **Base única:** use `com.marketinghub.repository` como raiz única para toda persistência do backend.
+- **Subdivisão por tecnologia:** repositories Spring Data/JPA devem ficar em `com.marketinghub.repository.jpa`. Se outra tecnologia de persistência for necessária, crie uma subdivisão explícita dentro de `com.marketinghub.repository` (ex.: `jdbc`, `jooq`), mantendo a mesma regra de centralização.
+- **Subdivisão por módulo:** dentro da tecnologia, organize por módulo/assunto seguindo a estrutura existente, por exemplo `com.marketinghub.repository.jpa.oprm`, `com.marketinghub.repository.jpa.mois`, `com.marketinghub.repository.jpa.experiment`, `com.marketinghub.repository.jpa.leadportal`.
+- **Pacotes funcionais:** pacotes como `service`, `web`, `mapper`, `dto` e pacotes de módulos (`oprm`, `mois`, `mds`, etc.) devem consumir interfaces/classes do pacote `repository`, mas não devem conter classes que executem SQL, estendam `JpaRepository` ou acessem `EntityManager`, `JdbcTemplate`, `DataSource` ou conexões diretamente.
+- **Ao criar ou mover persistência:** preserve a coerência com o módulo de domínio, atualize imports e testes, e não duplique repositories em pacotes locais do módulo.
 - O projeto **ai-worker** e os demais modulos devem usar este modelo sem manter uma cópia própria.
 - Em classes do Spring com mais de um construtor (por exemplo handlers que recebem `RestTemplateBuilder`), marque explicitamente o construtor usado para injeção com `@Autowired` e certifique-se de importar a anotação, evitando que o container selecione um construtor incorreto.
 - Liquibase: nunca altere arquivos de changelog já aplicados para evitar erros de checksum. Em vez disso, crie um novo changelog incremental e, se necessário, atualize os `include` do master.


### PR DESCRIPTION
### Motivation
- Centralizar e garantir que todas as classes com acesso direto ao banco residam em `com.marketinghub.repository` para evitar dispersão de DAOs/JPA em pacotes funcionais e melhorar manutenção e governança.

### Description
- Atualizei `backend/AGENTS.md` adicionando a seção `## Estrutura obrigatória de repositories` que exige `com.marketinghub.repository` como raiz, define `com.marketinghub.repository.jpa` para JPA, recomenda subdivisão por módulo (ex.: `com.marketinghub.repository.jpa.oprm`) e proíbe criação de repositories/DAOs/SQL direto em pacotes `service`, `web`, `mapper`, `dto` ou em pacotes de módulos funcionais.

### Testing
- Alteração documental; confirmei a diferença com `git diff` e o estado com `git status` e comitei a mudança (`docs: destacar estrutura obrigatoria de repositories`), sem execução de testes automatizados por se tratar apenas de documentação.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1dcf045dec8321b223a7e33b1f3e29)