### PR TITLE
GeraLanding: faster polling and unified optimistic-execution merge in frontend

### DIFF
--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -2925,3 +2925,12 @@
   - atualizado o cânone de etapas para explicitar que wireframe e design preset seguem a mesma regra;
   - adicionado teste unitário garantindo que o schema de design preset aceita apenas `pagina.corpo` para a estrutura visual.
 - impacto esperado: a resposta da etapa de preset fica mais simples, sem campos duplicados, facilitando leitura na tela, validação do contrato e geração posterior do HTML.
+
+## 2026-06-01 — Atualização de status GeraLanding no frontend
+- tarefa: corrigir a tela do experimento para refletir rapidamente a transição dos jobs GeraLanding de `INICIADO` para `AGUARDANDO_RETORNO_OPENAI` e limpar itens otimistas quando o backend já retornou o job persistido ou concluído.
+- causa-raiz/objetivo: a UI mantinha uma execução otimista local em `INICIADO` quando a lista pendente/histórico ainda não havia sido sincronizada, dando a impressão de que o job não mudava de estado apesar de o backend gravar `AGUARDANDO_RETORNO_OPENAI`/`CONCLUIDO`.
+- correção aplicada:
+  - reduzido o intervalo de atualização das listas não concluídas de GeraLanding para 3 segundos;
+  - ativada atualização periódica do histórico para remover execuções otimistas que já concluíram antes da próxima leitura de pendentes;
+  - centralizada a mesclagem de execução otimista com pendentes/histórico para wireframe, copy, design preset, prompt de imagem e deliverables.
+- impacto esperado: o usuário passa a ver a evolução operacional real do job no frontend, reduzindo falsa percepção de travamento e facilitando decisão sobre próximas etapas da landing.

--- a/frontend/src/api/experiment/useGeraLandingStageExecutions.ts
+++ b/frontend/src/api/experiment/useGeraLandingStageExecutions.ts
@@ -51,7 +51,7 @@ export function useGeraLandingStageExecutions(
   return useQuery({
     queryKey: ["geralanding-stage-executions", experimentId, stageCode, includeCompleted],
     enabled: Boolean(experimentId),
-    refetchInterval: includeCompleted ? false : 10000,
+    refetchInterval: includeCompleted ? 10000 : 3000,
     queryFn: async () => {
       const { data } = await axios.get<GeraLandingStageExecutionItem[]>(
         `/api/experiments/${experimentId}/geralanding/${resolveStageExecutionsEndpointSegment(stageCode)}/stage-executions`,

--- a/frontend/src/pages/experiment/ExperimentDetailPage.tsx
+++ b/frontend/src/pages/experiment/ExperimentDetailPage.tsx
@@ -137,6 +137,30 @@ function resolveJobNumberFromStageContent(content: string) {
   }
 }
 
+function hasExecutionWithJobId(
+  executions: GeraLandingStageExecutionItem[] | undefined,
+  jobId: string,
+) {
+  return (executions ?? []).some((execution) => execution.idJob === jobId);
+}
+
+function mergeOptimisticExecution(
+  optimisticExecution: GeraLandingStageExecutionItem | null,
+  pendingExecutions: GeraLandingStageExecutionItem[] | undefined,
+  completedExecutions: GeraLandingStageExecutionItem[] | undefined,
+) {
+  if (!optimisticExecution) {
+    return pendingExecutions ?? [];
+  }
+  const persistedExecution =
+    hasExecutionWithJobId(pendingExecutions, optimisticExecution.idJob) ||
+    hasExecutionWithJobId(completedExecutions, optimisticExecution.idJob);
+  if (persistedExecution) {
+    return pendingExecutions ?? [];
+  }
+  return [optimisticExecution, ...(pendingExecutions ?? [])];
+}
+
 export default function ExperimentDetailPage() {
   const { id } = useParams();
   const expId = id as string;
@@ -622,33 +646,41 @@ export default function ExperimentDetailPage() {
       "DONE",
     ].includes(normalizedStatus);
   };
-  const mergedPendingGeraLandingExecutions = useMemo(() => {
-    if (!optimisticWireframeExecution) {
-      return pendingGeraLandingExecutions ?? [];
-    }
-    const alreadyPresent = (pendingGeraLandingExecutions ?? []).some(
-      (execution) => execution.idJob === optimisticWireframeExecution.idJob,
-    );
-    if (alreadyPresent) {
-      return pendingGeraLandingExecutions ?? [];
-    }
-    return [
+  const mergedPendingGeraLandingExecutions = useMemo(
+    () =>
+      mergeOptimisticExecution(
+        optimisticWireframeExecution,
+        pendingGeraLandingExecutions,
+        completedGeraLandingExecutions,
+      ),
+    [
       optimisticWireframeExecution,
-      ...(pendingGeraLandingExecutions ?? []),
-    ];
-  }, [optimisticWireframeExecution, pendingGeraLandingExecutions]);
+      pendingGeraLandingExecutions,
+      completedGeraLandingExecutions,
+    ],
+  );
 
   useEffect(() => {
     if (!optimisticWireframeExecution) {
       return;
     }
-    const persistedExecution = (pendingGeraLandingExecutions ?? []).some(
-      (execution) => execution.idJob === optimisticWireframeExecution.idJob,
-    );
+    const persistedExecution =
+      hasExecutionWithJobId(
+        pendingGeraLandingExecutions,
+        optimisticWireframeExecution.idJob,
+      ) ||
+      hasExecutionWithJobId(
+        completedGeraLandingExecutions,
+        optimisticWireframeExecution.idJob,
+      );
     if (persistedExecution) {
       setOptimisticWireframeExecution(null);
     }
-  }, [optimisticWireframeExecution, pendingGeraLandingExecutions]);
+  }, [
+    optimisticWireframeExecution,
+    pendingGeraLandingExecutions,
+    completedGeraLandingExecutions,
+  ]);
 
   const hasRunningGeraLandingExecution =
     mergedPendingGeraLandingExecutions.some((execution) =>
@@ -702,33 +734,41 @@ export default function ExperimentDetailPage() {
     );
   }, [completedGeraLandingExecutions, pendingGeraLandingExecutions]);
 
-  const mergedPendingGeraLandingCopyExecutions = useMemo(() => {
-    if (!optimisticCopyExecution) {
-      return pendingGeraLandingCopyExecutions ?? [];
-    }
-    const alreadyPresent = (pendingGeraLandingCopyExecutions ?? []).some(
-      (execution) => execution.idJob === optimisticCopyExecution.idJob,
-    );
-    if (alreadyPresent) {
-      return pendingGeraLandingCopyExecutions ?? [];
-    }
-    return [
+  const mergedPendingGeraLandingCopyExecutions = useMemo(
+    () =>
+      mergeOptimisticExecution(
+        optimisticCopyExecution,
+        pendingGeraLandingCopyExecutions,
+        completedGeraLandingCopyExecutions,
+      ),
+    [
       optimisticCopyExecution,
-      ...(pendingGeraLandingCopyExecutions ?? []),
-    ];
-  }, [optimisticCopyExecution, pendingGeraLandingCopyExecutions]);
+      pendingGeraLandingCopyExecutions,
+      completedGeraLandingCopyExecutions,
+    ],
+  );
 
   useEffect(() => {
     if (!optimisticCopyExecution) {
       return;
     }
-    const persistedExecution = (pendingGeraLandingCopyExecutions ?? []).some(
-      (execution) => execution.idJob === optimisticCopyExecution.idJob,
-    );
+    const persistedExecution =
+      hasExecutionWithJobId(
+        pendingGeraLandingCopyExecutions,
+        optimisticCopyExecution.idJob,
+      ) ||
+      hasExecutionWithJobId(
+        completedGeraLandingCopyExecutions,
+        optimisticCopyExecution.idJob,
+      );
     if (persistedExecution) {
       setOptimisticCopyExecution(null);
     }
-  }, [optimisticCopyExecution, pendingGeraLandingCopyExecutions]);
+  }, [
+    optimisticCopyExecution,
+    pendingGeraLandingCopyExecutions,
+    completedGeraLandingCopyExecutions,
+  ]);
 
   const hasRunningGeraLandingCopyExecution =
     mergedPendingGeraLandingCopyExecutions.some((execution) =>
@@ -777,42 +817,40 @@ export default function ExperimentDetailPage() {
         ) === index,
     );
   }, [completedGeraLandingCopyExecutions, pendingGeraLandingCopyExecutions]);
-  const mergedPendingGeraLandingDesignPresetExecutions = useMemo(() => {
-    if (!optimisticDesignPresetExecution) {
-      return pendingGeraLandingDesignPresetExecutions ?? [];
-    }
-    const alreadyPresent = (
-      pendingGeraLandingDesignPresetExecutions ?? []
-    ).some(
-      (execution) => execution.idJob === optimisticDesignPresetExecution.idJob,
-    );
-    if (alreadyPresent) {
-      return pendingGeraLandingDesignPresetExecutions ?? [];
-    }
-    return [
+  const mergedPendingGeraLandingDesignPresetExecutions = useMemo(
+    () =>
+      mergeOptimisticExecution(
+        optimisticDesignPresetExecution,
+        pendingGeraLandingDesignPresetExecutions,
+        completedGeraLandingDesignPresetExecutions,
+      ),
+    [
       optimisticDesignPresetExecution,
-      ...(pendingGeraLandingDesignPresetExecutions ?? []),
-    ];
-  }, [
-    optimisticDesignPresetExecution,
-    pendingGeraLandingDesignPresetExecutions,
-  ]);
+      pendingGeraLandingDesignPresetExecutions,
+      completedGeraLandingDesignPresetExecutions,
+    ],
+  );
 
   useEffect(() => {
     if (!optimisticDesignPresetExecution) {
       return;
     }
-    const persistedExecution = (
-      pendingGeraLandingDesignPresetExecutions ?? []
-    ).some(
-      (execution) => execution.idJob === optimisticDesignPresetExecution.idJob,
-    );
+    const persistedExecution =
+      hasExecutionWithJobId(
+        pendingGeraLandingDesignPresetExecutions,
+        optimisticDesignPresetExecution.idJob,
+      ) ||
+      hasExecutionWithJobId(
+        completedGeraLandingDesignPresetExecutions,
+        optimisticDesignPresetExecution.idJob,
+      );
     if (persistedExecution) {
       setOptimisticDesignPresetExecution(null);
     }
   }, [
     optimisticDesignPresetExecution,
     pendingGeraLandingDesignPresetExecutions,
+    completedGeraLandingDesignPresetExecutions,
   ]);
 
   const hasRunningGeraLandingDesignPresetExecution =
@@ -868,42 +906,40 @@ export default function ExperimentDetailPage() {
     pendingGeraLandingDesignPresetExecutions,
   ]);
 
-  const mergedPendingGeraLandingImagePromptsExecutions = useMemo(() => {
-    if (!optimisticImagePromptsExecution) {
-      return pendingGeraLandingImagePromptsExecutions ?? [];
-    }
-    const alreadyPresent = (
-      pendingGeraLandingImagePromptsExecutions ?? []
-    ).some(
-      (execution) => execution.idJob === optimisticImagePromptsExecution.idJob,
-    );
-    if (alreadyPresent) {
-      return pendingGeraLandingImagePromptsExecutions ?? [];
-    }
-    return [
+  const mergedPendingGeraLandingImagePromptsExecutions = useMemo(
+    () =>
+      mergeOptimisticExecution(
+        optimisticImagePromptsExecution,
+        pendingGeraLandingImagePromptsExecutions,
+        completedGeraLandingImagePromptsExecutions,
+      ),
+    [
       optimisticImagePromptsExecution,
-      ...(pendingGeraLandingImagePromptsExecutions ?? []),
-    ];
-  }, [
-    optimisticImagePromptsExecution,
-    pendingGeraLandingImagePromptsExecutions,
-  ]);
+      pendingGeraLandingImagePromptsExecutions,
+      completedGeraLandingImagePromptsExecutions,
+    ],
+  );
 
   useEffect(() => {
     if (!optimisticImagePromptsExecution) {
       return;
     }
-    const persistedExecution = (
-      pendingGeraLandingImagePromptsExecutions ?? []
-    ).some(
-      (execution) => execution.idJob === optimisticImagePromptsExecution.idJob,
-    );
+    const persistedExecution =
+      hasExecutionWithJobId(
+        pendingGeraLandingImagePromptsExecutions,
+        optimisticImagePromptsExecution.idJob,
+      ) ||
+      hasExecutionWithJobId(
+        completedGeraLandingImagePromptsExecutions,
+        optimisticImagePromptsExecution.idJob,
+      );
     if (persistedExecution) {
       setOptimisticImagePromptsExecution(null);
     }
   }, [
     optimisticImagePromptsExecution,
     pendingGeraLandingImagePromptsExecutions,
+    completedGeraLandingImagePromptsExecutions,
   ]);
 
   const hasRunningGeraLandingImagePromptsExecution =
@@ -958,42 +994,40 @@ export default function ExperimentDetailPage() {
     completedGeraLandingImagePromptsExecutions,
     pendingGeraLandingImagePromptsExecutions,
   ]);
-  const mergedPendingGeraLandingDeliverablesExecutions = useMemo(() => {
-    if (!optimisticDeliverablesExecution) {
-      return pendingGeraLandingDeliverablesExecutions ?? [];
-    }
-    const alreadyPresent = (
-      pendingGeraLandingDeliverablesExecutions ?? []
-    ).some(
-      (execution) => execution.idJob === optimisticDeliverablesExecution.idJob,
-    );
-    if (alreadyPresent) {
-      return pendingGeraLandingDeliverablesExecutions ?? [];
-    }
-    return [
+  const mergedPendingGeraLandingDeliverablesExecutions = useMemo(
+    () =>
+      mergeOptimisticExecution(
+        optimisticDeliverablesExecution,
+        pendingGeraLandingDeliverablesExecutions,
+        completedGeraLandingDeliverablesExecutions,
+      ),
+    [
       optimisticDeliverablesExecution,
-      ...(pendingGeraLandingDeliverablesExecutions ?? []),
-    ];
-  }, [
-    optimisticDeliverablesExecution,
-    pendingGeraLandingDeliverablesExecutions,
-  ]);
+      pendingGeraLandingDeliverablesExecutions,
+      completedGeraLandingDeliverablesExecutions,
+    ],
+  );
 
   useEffect(() => {
     if (!optimisticDeliverablesExecution) {
       return;
     }
-    const persistedExecution = (
-      pendingGeraLandingDeliverablesExecutions ?? []
-    ).some(
-      (execution) => execution.idJob === optimisticDeliverablesExecution.idJob,
-    );
+    const persistedExecution =
+      hasExecutionWithJobId(
+        pendingGeraLandingDeliverablesExecutions,
+        optimisticDeliverablesExecution.idJob,
+      ) ||
+      hasExecutionWithJobId(
+        completedGeraLandingDeliverablesExecutions,
+        optimisticDeliverablesExecution.idJob,
+      );
     if (persistedExecution) {
       setOptimisticDeliverablesExecution(null);
     }
   }, [
     optimisticDeliverablesExecution,
     pendingGeraLandingDeliverablesExecutions,
+    completedGeraLandingDeliverablesExecutions,
   ]);
 
   const hasRunningGeraLandingDeliverablesExecution =


### PR DESCRIPTION
### Motivation
- Fix UI inconsistency where optimistic local executions remained in `INICIADO` even after the backend changed the job status to `AGUARDANDO_RETORNO_OPENAI`/`CONCLUIDO`, causing users to perceive a stuck job. 
- Reduce duplicated merging logic across multiple GeraLanding stages and make optimistic execution handling deterministic and maintainable. 

### Description
- Adjusted polling in `useGeraLandingStageExecutions` to use shorter intervals by setting `refetchInterval` to `includeCompleted ? 10000 : 3000` in `frontend/src/api/experiment/useGeraLandingStageExecutions.ts` to refresh pending lists more frequently. 
- Added `hasExecutionWithJobId` and `mergeOptimisticExecution` helpers and replaced multiple duplicated `useMemo` merges with a single `mergeOptimisticExecution` call for wireframe, copy, design preset, image prompts and deliverables in `frontend/src/pages/experiment/ExperimentDetailPage.tsx`. 
- Updated `useEffect` cleanup logic to clear optimistic executions when a matching job appears either in pending or completed lists and added `completed*` lists to dependency arrays so optimistic entries are removed promptly. 
- Documented the frontend status update behavior in `docs/registros/experimentos.md` under "Atualização de status GeraLanding no frontend". 

### Testing
- Ran the frontend test suite with `yarn test`, and all tests passed. 
- Performed TypeScript build/check with `yarn build`/typecheck without errors. 
- Verified the affected UI flows locally to ensure optimistic executions are removed when the backend returns persisted or completed jobs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1dd28ccf388321bc938c1475e033a7)