### PR TITLE
CRUD de Pipelines (backend + frontend) e seed do Pipeline de Experimento

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/pipeline/Pipeline.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/pipeline/Pipeline.java
@@ -1,0 +1,63 @@
+package com.marketinghub.pipeline;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OrderBy;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+/**
+ * Entidade que representa um pipeline operacional usado para organizar etapas de criação de produtos digitais.
+ */
+@Entity
+@Table(name = "pipeline")
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class Pipeline {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 120)
+    private String name;
+
+    @Column(nullable = false, unique = true, length = 80)
+    private String code;
+
+    @Column(nullable = false, length = 60)
+    private String module;
+
+    @Column(columnDefinition = "TEXT")
+    private String description;
+
+    @Column(nullable = false)
+    @Builder.Default
+    private boolean active = true;
+
+    @OneToMany(mappedBy = "pipeline", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    @OrderBy("position ASC, id ASC")
+    @Builder.Default
+    private List<PipelineStage> stages = new ArrayList<>();
+
+    @CreationTimestamp
+    private Instant createdAt;
+
+    @UpdateTimestamp
+    private Instant updatedAt;
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/pipeline/PipelineStage.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/pipeline/PipelineStage.java
@@ -1,0 +1,69 @@
+package com.marketinghub.pipeline;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.time.Instant;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+/**
+ * Entidade que representa uma etapa ordenada dentro de um pipeline operacional.
+ */
+@Entity
+@Table(
+        name = "pipeline_stage",
+        uniqueConstraints = {
+            @UniqueConstraint(name = "uk_pipeline_stage_code", columnNames = {"pipeline_id", "code"}),
+            @UniqueConstraint(name = "uk_pipeline_stage_position", columnNames = {"pipeline_id", "position"})
+        })
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PipelineStage {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "pipeline_id", nullable = false)
+    private Pipeline pipeline;
+
+    @Column(nullable = false)
+    private Integer position;
+
+    @Column(nullable = false, length = 120)
+    private String name;
+
+    @Column(nullable = false, length = 80)
+    private String code;
+
+    @Column(columnDefinition = "TEXT")
+    private String description;
+
+    @Column(nullable = false)
+    @Builder.Default
+    private boolean required = true;
+
+    @Column(nullable = false)
+    @Builder.Default
+    private boolean active = true;
+
+    @CreationTimestamp
+    private Instant createdAt;
+
+    @UpdateTimestamp
+    private Instant updatedAt;
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/pipeline/dto/PipelineDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/pipeline/dto/PipelineDto.java
@@ -1,0 +1,27 @@
+package com.marketinghub.pipeline.dto;
+
+import java.time.Instant;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * DTO que expõe um pipeline com suas etapas para a tela administrativa.
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PipelineDto {
+    private Long id;
+    private String name;
+    private String code;
+    private String module;
+    private String description;
+    private boolean active;
+    private List<PipelineStageDto> stages;
+    private Instant createdAt;
+    private Instant updatedAt;
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/pipeline/dto/PipelineRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/pipeline/dto/PipelineRequest.java
@@ -1,0 +1,26 @@
+package com.marketinghub.pipeline.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+
+/**
+ * Requisição usada para criar ou atualizar um pipeline operacional.
+ */
+@Data
+public class PipelineRequest {
+    @NotBlank
+    @Size(max = 120)
+    private String name;
+
+    @NotBlank
+    @Size(max = 80)
+    private String code;
+
+    @NotBlank
+    @Size(max = 60)
+    private String module;
+
+    private String description;
+    private boolean active = true;
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/pipeline/dto/PipelineStageDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/pipeline/dto/PipelineStageDto.java
@@ -1,0 +1,27 @@
+package com.marketinghub.pipeline.dto;
+
+import java.time.Instant;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+/**
+ * DTO que expõe uma etapa ordenada de pipeline para a tela administrativa.
+ */
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PipelineStageDto {
+    private Long id;
+    private Long pipelineId;
+    private Integer position;
+    private String name;
+    private String code;
+    private String description;
+    private boolean required;
+    private boolean active;
+    private Instant createdAt;
+    private Instant updatedAt;
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/pipeline/dto/PipelineStageRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/pipeline/dto/PipelineStageRequest.java
@@ -1,0 +1,29 @@
+package com.marketinghub.pipeline.dto;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+import lombok.Data;
+
+/**
+ * Requisição usada para criar ou atualizar uma etapa de pipeline.
+ */
+@Data
+public class PipelineStageRequest {
+    @NotNull
+    @Min(1)
+    private Integer position;
+
+    @NotBlank
+    @Size(max = 120)
+    private String name;
+
+    @NotBlank
+    @Size(max = 80)
+    private String code;
+
+    private String description;
+    private boolean required = true;
+    private boolean active = true;
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/pipeline/mapper/PipelineMapper.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/pipeline/mapper/PipelineMapper.java
@@ -1,0 +1,56 @@
+package com.marketinghub.pipeline.mapper;
+
+import com.marketinghub.pipeline.Pipeline;
+import com.marketinghub.pipeline.PipelineStage;
+import com.marketinghub.pipeline.dto.PipelineDto;
+import com.marketinghub.pipeline.dto.PipelineStageDto;
+import java.util.List;
+import org.springframework.stereotype.Component;
+
+/**
+ * Mapper responsável por converter entidades de pipeline em DTOs de contrato da API.
+ */
+@Component
+public class PipelineMapper {
+    /**
+     * Converte um pipeline completo em DTO com etapas ordenadas.
+     */
+    public PipelineDto toDto(Pipeline pipeline) {
+        return PipelineDto.builder()
+                .id(pipeline.getId())
+                .name(pipeline.getName())
+                .code(pipeline.getCode())
+                .module(pipeline.getModule())
+                .description(pipeline.getDescription())
+                .active(pipeline.isActive())
+                .stages(toStageDtos(pipeline.getStages()))
+                .createdAt(pipeline.getCreatedAt())
+                .updatedAt(pipeline.getUpdatedAt())
+                .build();
+    }
+
+    /**
+     * Converte uma etapa de pipeline em DTO de resposta.
+     */
+    public PipelineStageDto toStageDto(PipelineStage stage) {
+        return PipelineStageDto.builder()
+                .id(stage.getId())
+                .pipelineId(stage.getPipeline().getId())
+                .position(stage.getPosition())
+                .name(stage.getName())
+                .code(stage.getCode())
+                .description(stage.getDescription())
+                .required(stage.isRequired())
+                .active(stage.isActive())
+                .createdAt(stage.getCreatedAt())
+                .updatedAt(stage.getUpdatedAt())
+                .build();
+    }
+
+    /**
+     * Converte uma lista de etapas em DTOs de resposta.
+     */
+    public List<PipelineStageDto> toStageDtos(List<PipelineStage> stages) {
+        return stages.stream().map(this::toStageDto).toList();
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/pipeline/service/PipelineService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/pipeline/service/PipelineService.java
@@ -1,0 +1,157 @@
+package com.marketinghub.pipeline.service;
+
+import com.marketinghub.pipeline.Pipeline;
+import com.marketinghub.pipeline.PipelineStage;
+import com.marketinghub.pipeline.dto.PipelineRequest;
+import com.marketinghub.pipeline.dto.PipelineStageRequest;
+import com.marketinghub.repository.jpa.pipeline.PipelineRepository;
+import com.marketinghub.repository.jpa.pipeline.PipelineStageRepository;
+import jakarta.persistence.EntityNotFoundException;
+import java.util.Comparator;
+import java.util.List;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Serviço responsável por manter pipelines e etapas usados pela operação do Marketing Hub.
+ */
+@Service
+public class PipelineService {
+    private final PipelineRepository pipelineRepository;
+    private final PipelineStageRepository stageRepository;
+
+    /**
+     * Inicializa o serviço com os repositórios centralizados de pipelines e etapas.
+     */
+    public PipelineService(PipelineRepository pipelineRepository, PipelineStageRepository stageRepository) {
+        this.pipelineRepository = pipelineRepository;
+        this.stageRepository = stageRepository;
+    }
+
+    /**
+     * Lista todos os pipelines cadastrados com etapas ordenadas para administração.
+     */
+    public List<Pipeline> list() {
+        return pipelineRepository.findAll().stream()
+                .peek(this::sortStages)
+                .sorted(Comparator.comparing(Pipeline::getModule).thenComparing(Pipeline::getName))
+                .toList();
+    }
+
+    /**
+     * Busca um pipeline pelo identificador, garantindo erro claro quando não existe.
+     */
+    public Pipeline get(Long id) {
+        Pipeline pipeline = findPipeline(id);
+        sortStages(pipeline);
+        return pipeline;
+    }
+
+    /**
+     * Cria um novo pipeline operacional.
+     */
+    @Transactional
+    public Pipeline create(PipelineRequest request) {
+        Pipeline pipeline = new Pipeline();
+        applyPipelineRequest(pipeline, request);
+        return pipelineRepository.save(pipeline);
+    }
+
+    /**
+     * Atualiza os dados básicos de um pipeline existente.
+     */
+    @Transactional
+    public Pipeline update(Long id, PipelineRequest request) {
+        Pipeline pipeline = findPipeline(id);
+        applyPipelineRequest(pipeline, request);
+        return pipelineRepository.save(pipeline);
+    }
+
+    /**
+     * Remove um pipeline e suas etapas vinculadas.
+     */
+    @Transactional
+    public void delete(Long id) {
+        pipelineRepository.delete(findPipeline(id));
+    }
+
+    /**
+     * Cria uma etapa dentro de um pipeline existente.
+     */
+    @Transactional
+    public PipelineStage createStage(Long pipelineId, PipelineStageRequest request) {
+        Pipeline pipeline = findPipeline(pipelineId);
+        PipelineStage stage = new PipelineStage();
+        stage.setPipeline(pipeline);
+        applyStageRequest(stage, request);
+        return stageRepository.save(stage);
+    }
+
+    /**
+     * Atualiza uma etapa, preservando o vínculo com o pipeline informado na rota.
+     */
+    @Transactional
+    public PipelineStage updateStage(Long pipelineId, Long stageId, PipelineStageRequest request) {
+        PipelineStage stage = findStageInPipeline(pipelineId, stageId);
+        applyStageRequest(stage, request);
+        return stageRepository.save(stage);
+    }
+
+    /**
+     * Remove uma etapa específica de um pipeline.
+     */
+    @Transactional
+    public void deleteStage(Long pipelineId, Long stageId) {
+        stageRepository.delete(findStageInPipeline(pipelineId, stageId));
+    }
+
+    /**
+     * Localiza um pipeline pelo identificador interno.
+     */
+    private Pipeline findPipeline(Long id) {
+        return pipelineRepository.findById(id)
+                .orElseThrow(() -> new EntityNotFoundException("Pipeline não encontrado: " + id));
+    }
+
+    /**
+     * Localiza uma etapa validando que ela pertence ao pipeline da rota.
+     */
+    private PipelineStage findStageInPipeline(Long pipelineId, Long stageId) {
+        PipelineStage stage = stageRepository.findById(stageId)
+                .orElseThrow(() -> new EntityNotFoundException("Etapa de pipeline não encontrada: " + stageId));
+        if (!stage.getPipeline().getId().equals(pipelineId)) {
+            throw new EntityNotFoundException("Etapa não pertence ao pipeline informado: " + pipelineId);
+        }
+        return stage;
+    }
+
+    /**
+     * Aplica o payload validado nos campos básicos de pipeline.
+     */
+    private void applyPipelineRequest(Pipeline pipeline, PipelineRequest request) {
+        pipeline.setName(request.getName());
+        pipeline.setCode(request.getCode());
+        pipeline.setModule(request.getModule());
+        pipeline.setDescription(request.getDescription());
+        pipeline.setActive(request.isActive());
+    }
+
+    /**
+     * Aplica o payload validado nos campos de configuração da etapa.
+     */
+    private void applyStageRequest(PipelineStage stage, PipelineStageRequest request) {
+        stage.setPosition(request.getPosition());
+        stage.setName(request.getName());
+        stage.setCode(request.getCode());
+        stage.setDescription(request.getDescription());
+        stage.setRequired(request.isRequired());
+        stage.setActive(request.isActive());
+    }
+
+    /**
+     * Ordena as etapas carregadas para manter consistência visual e operacional.
+     */
+    private void sortStages(Pipeline pipeline) {
+        pipeline.getStages().sort(Comparator.comparing(PipelineStage::getPosition).thenComparing(PipelineStage::getId));
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/pipeline/web/PipelineController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/pipeline/web/PipelineController.java
@@ -1,0 +1,110 @@
+package com.marketinghub.pipeline.web;
+
+import com.marketinghub.pipeline.Pipeline;
+import com.marketinghub.pipeline.PipelineStage;
+import com.marketinghub.pipeline.dto.PipelineDto;
+import com.marketinghub.pipeline.dto.PipelineRequest;
+import com.marketinghub.pipeline.dto.PipelineStageDto;
+import com.marketinghub.pipeline.dto.PipelineStageRequest;
+import com.marketinghub.pipeline.mapper.PipelineMapper;
+import com.marketinghub.pipeline.service.PipelineService;
+import jakarta.validation.Valid;
+import java.util.List;
+import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Controller REST para administrar pipelines e etapas configuráveis do Marketing Hub.
+ */
+@RestController
+@RequestMapping("/api/pipelines")
+public class PipelineController {
+    private final PipelineService service;
+    private final PipelineMapper mapper;
+
+    /**
+     * Inicializa o controller com o serviço de domínio e mapper de contratos.
+     */
+    public PipelineController(PipelineService service, PipelineMapper mapper) {
+        this.service = service;
+        this.mapper = mapper;
+    }
+
+    /**
+     * Lista pipelines com etapas para a tela de CRUD.
+     */
+    @GetMapping
+    public List<PipelineDto> list() {
+        return service.list().stream().map(mapper::toDto).toList();
+    }
+
+    /**
+     * Obtém um pipeline específico com suas etapas ordenadas.
+     */
+    @GetMapping("/{id}")
+    public PipelineDto get(@PathVariable Long id) {
+        return mapper.toDto(service.get(id));
+    }
+
+    /**
+     * Cria um pipeline operacional configurável.
+     */
+    @PostMapping
+    public PipelineDto create(@Valid @RequestBody PipelineRequest request) {
+        Pipeline pipeline = service.create(request);
+        return mapper.toDto(pipeline);
+    }
+
+    /**
+     * Atualiza os dados básicos de um pipeline configurável.
+     */
+    @PutMapping("/{id}")
+    public PipelineDto update(@PathVariable Long id, @Valid @RequestBody PipelineRequest request) {
+        Pipeline pipeline = service.update(id, request);
+        return mapper.toDto(pipeline);
+    }
+
+    /**
+     * Remove um pipeline configurável e suas etapas.
+     */
+    @DeleteMapping("/{id}")
+    public void delete(@PathVariable Long id) {
+        service.delete(id);
+    }
+
+    /**
+     * Cria uma etapa dentro de um pipeline configurável.
+     */
+    @PostMapping("/{pipelineId}/stages")
+    public PipelineStageDto createStage(
+            @PathVariable Long pipelineId, @Valid @RequestBody PipelineStageRequest request) {
+        PipelineStage stage = service.createStage(pipelineId, request);
+        return mapper.toStageDto(stage);
+    }
+
+    /**
+     * Atualiza uma etapa de um pipeline configurável.
+     */
+    @PutMapping("/{pipelineId}/stages/{stageId}")
+    public PipelineStageDto updateStage(
+            @PathVariable Long pipelineId,
+            @PathVariable Long stageId,
+            @Valid @RequestBody PipelineStageRequest request) {
+        PipelineStage stage = service.updateStage(pipelineId, stageId, request);
+        return mapper.toStageDto(stage);
+    }
+
+    /**
+     * Remove uma etapa de um pipeline configurável.
+     */
+    @DeleteMapping("/{pipelineId}/stages/{stageId}")
+    public void deleteStage(@PathVariable Long pipelineId, @PathVariable Long stageId) {
+        service.deleteStage(pipelineId, stageId);
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/pipeline/PipelineRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/pipeline/PipelineRepository.java
@@ -1,0 +1,10 @@
+package com.marketinghub.repository.jpa.pipeline;
+
+import com.marketinghub.pipeline.Pipeline;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * Repositório JPA centralizado para persistir pipelines operacionais.
+ */
+public interface PipelineRepository extends JpaRepository<Pipeline, Long> {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/pipeline/PipelineStageRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/pipeline/PipelineStageRepository.java
@@ -1,0 +1,15 @@
+package com.marketinghub.repository.jpa.pipeline;
+
+import com.marketinghub.pipeline.PipelineStage;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * Repositório JPA centralizado para persistir etapas de pipelines operacionais.
+ */
+public interface PipelineStageRepository extends JpaRepository<PipelineStage, Long> {
+    /**
+     * Lista as etapas de um pipeline na ordem operacional configurada.
+     */
+    List<PipelineStage> findByPipelineIdOrderByPositionAscIdAsc(Long pipelineId);
+}

--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-01-pipeline-crud.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-01-pipeline-crud.yaml
@@ -1,0 +1,243 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-06-01-pipeline-crud
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - onError: MARK_RAN
+        - dbms:
+            type: mysql
+      changes:
+        - createTable:
+            tableName: pipeline
+            columns:
+              - column:
+                  name: id
+                  type: BIGINT
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: name
+                  type: VARCHAR(120)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: code
+                  type: VARCHAR(80)
+                  constraints:
+                    nullable: false
+                    unique: true
+                    uniqueConstraintName: uk_pipeline_code
+              - column:
+                  name: module
+                  type: VARCHAR(60)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: description
+                  type: TEXT
+              - column:
+                  name: active
+                  type: BOOLEAN
+                  defaultValueBoolean: true
+                  constraints:
+                    nullable: false
+              - column:
+                  name: created_at
+                  type: TIMESTAMP
+              - column:
+                  name: updated_at
+                  type: TIMESTAMP
+        - createTable:
+            tableName: pipeline_stage
+            columns:
+              - column:
+                  name: id
+                  type: BIGINT
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: pipeline_id
+                  type: BIGINT
+                  constraints:
+                    nullable: false
+              - column:
+                  name: position
+                  type: INT
+                  constraints:
+                    nullable: false
+              - column:
+                  name: name
+                  type: VARCHAR(120)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: code
+                  type: VARCHAR(80)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: description
+                  type: TEXT
+              - column:
+                  name: required
+                  type: BOOLEAN
+                  defaultValueBoolean: true
+                  constraints:
+                    nullable: false
+              - column:
+                  name: active
+                  type: BOOLEAN
+                  defaultValueBoolean: true
+                  constraints:
+                    nullable: false
+              - column:
+                  name: created_at
+                  type: TIMESTAMP
+              - column:
+                  name: updated_at
+                  type: TIMESTAMP
+        - addForeignKeyConstraint:
+            baseTableName: pipeline_stage
+            baseColumnNames: pipeline_id
+            constraintName: fk_pipeline_stage_pipeline
+            referencedTableName: pipeline
+            referencedColumnNames: id
+            onDelete: CASCADE
+        - addUniqueConstraint:
+            tableName: pipeline_stage
+            columnNames: pipeline_id, code
+            constraintName: uk_pipeline_stage_code
+        - addUniqueConstraint:
+            tableName: pipeline_stage
+            columnNames: pipeline_id, position
+            constraintName: uk_pipeline_stage_position
+        - createIndex:
+            tableName: pipeline
+            indexName: idx_pipeline_module
+            columns:
+              - column:
+                  name: module
+        - createIndex:
+            tableName: pipeline_stage
+            indexName: idx_pipeline_stage_pipeline_position
+            columns:
+              - column:
+                  name: pipeline_id
+              - column:
+                  name: position
+        - insert:
+            tableName: pipeline
+            columns:
+              - column:
+                  name: id
+                  valueNumeric: 1
+              - column:
+                  name: name
+                  value: Pipeline de Experimento
+              - column:
+                  name: code
+                  value: experiment-pipeline
+              - column:
+                  name: module
+                  value: EXPERIMENT
+              - column:
+                  name: description
+                  value: Fluxo principal de criação e publicação de experimento comercial, do ângulo da campanha aos entregáveis da landing page.
+              - column:
+                  name: active
+                  valueBoolean: true
+        - insert:
+            tableName: pipeline_stage
+            columns:
+              - column: { name: pipeline_id, valueNumeric: 1 }
+              - column: { name: position, valueNumeric: 1 }
+              - column: { name: name, value: Campaign Angle }
+              - column: { name: code, value: campaign-angle }
+              - column: { name: description, value: Define o ângulo central de campanha alinhado à dor, resultado, mecanismo, prova e oferta. }
+              - column: { name: required, valueBoolean: true }
+              - column: { name: active, valueBoolean: true }
+        - insert:
+            tableName: pipeline_stage
+            columns:
+              - column: { name: pipeline_id, valueNumeric: 1 }
+              - column: { name: position, valueNumeric: 2 }
+              - column: { name: name, value: Ad Copy }
+              - column: { name: code, value: ad-copy }
+              - column: { name: description, value: Cria as variações de anúncios para testar promessas, provas e chamadas de ação. }
+              - column: { name: required, valueBoolean: true }
+              - column: { name: active, valueBoolean: true }
+        - insert:
+            tableName: pipeline_stage
+            columns:
+              - column: { name: pipeline_id, valueNumeric: 1 }
+              - column: { name: position, valueNumeric: 3 }
+              - column: { name: name, value: Landing Wireframe }
+              - column: { name: code, value: landing-wireframe }
+              - column: { name: description, value: Estrutura a página de captura/vendas antes da copy final e do design. }
+              - column: { name: required, valueBoolean: true }
+              - column: { name: active, valueBoolean: true }
+        - insert:
+            tableName: pipeline_stage
+            columns:
+              - column: { name: pipeline_id, valueNumeric: 1 }
+              - column: { name: position, valueNumeric: 4 }
+              - column: { name: name, value: Landing Copy }
+              - column: { name: code, value: landing-copy }
+              - column: { name: description, value: Transforma a estrutura em copy persuasiva focada em conversão e clareza da oferta. }
+              - column: { name: required, valueBoolean: true }
+              - column: { name: active, valueBoolean: true }
+        - insert:
+            tableName: pipeline_stage
+            columns:
+              - column: { name: pipeline_id, valueNumeric: 1 }
+              - column: { name: position, valueNumeric: 5 }
+              - column: { name: name, value: Planejamento de Imagens }
+              - column: { name: code, value: image-planning }
+              - column: { name: description, value: Planeja imagens e ativos visuais coerentes com o mecanismo, prova e oferta. }
+              - column: { name: required, valueBoolean: true }
+              - column: { name: active, valueBoolean: true }
+        - insert:
+            tableName: pipeline_stage
+            columns:
+              - column: { name: pipeline_id, valueNumeric: 1 }
+              - column: { name: position, valueNumeric: 6 }
+              - column: { name: name, value: Preset Design }
+              - column: { name: code, value: preset-design }
+              - column: { name: description, value: Seleciona uma direção visual simples e eficaz para acelerar a landing. }
+              - column: { name: required, valueBoolean: true }
+              - column: { name: active, valueBoolean: true }
+        - insert:
+            tableName: pipeline_stage
+            columns:
+              - column: { name: pipeline_id, valueNumeric: 1 }
+              - column: { name: position, valueNumeric: 7 }
+              - column: { name: name, value: GeraLanding HTML }
+              - column: { name: code, value: geralanding-html }
+              - column: { name: description, value: Gera o HTML inicial da landing a partir dos artefatos aprovados. }
+              - column: { name: required, valueBoolean: true }
+              - column: { name: active, valueBoolean: true }
+        - insert:
+            tableName: pipeline_stage
+            columns:
+              - column: { name: pipeline_id, valueNumeric: 1 }
+              - column: { name: position, valueNumeric: 8 }
+              - column: { name: name, value: Landing HTML }
+              - column: { name: code, value: landing-html }
+              - column: { name: description, value: Consolida o HTML final publicável da landing sem metadados técnicos. }
+              - column: { name: required, valueBoolean: true }
+              - column: { name: active, valueBoolean: true }
+        - insert:
+            tableName: pipeline_stage
+            columns:
+              - column: { name: pipeline_id, valueNumeric: 1 }
+              - column: { name: position, valueNumeric: 9 }
+              - column: { name: name, value: Landing Page Deliverables }
+              - column: { name: code, value: landing-page-deliverables }
+              - column: { name: description, value: Organiza os entregáveis digitais da oferta para uso no funil e no portal do lead. }
+              - column: { name: required, valueBoolean: true }
+              - column: { name: active, valueBoolean: true }

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -1,5 +1,8 @@
 databaseChangeLog:
   - include:
+      file: changesets/2026-06-01-pipeline-crud.yaml
+      relativeToChangelogFile: true
+  - include:
       file: changesets/2026-06-01-experiment-landing-image-assets.yaml
       relativeToChangelogFile: true
 

--- a/backend/ads-service/src/test/java/com/marketinghub/pipeline/service/PipelineServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/pipeline/service/PipelineServiceTest.java
@@ -1,0 +1,101 @@
+package com.marketinghub.pipeline.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.marketinghub.pipeline.Pipeline;
+import com.marketinghub.pipeline.PipelineStage;
+import com.marketinghub.pipeline.dto.PipelineStageRequest;
+import com.marketinghub.repository.jpa.pipeline.PipelineRepository;
+import com.marketinghub.repository.jpa.pipeline.PipelineStageRepository;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * Testa as regras de manutenção de pipelines e etapas configuráveis.
+ */
+@ExtendWith(MockitoExtension.class)
+class PipelineServiceTest {
+    @Mock
+    private PipelineRepository pipelineRepository;
+
+    @Mock
+    private PipelineStageRepository stageRepository;
+
+    @InjectMocks
+    private PipelineService service;
+
+    /**
+     * Garante que a listagem devolve pipelines e etapas em ordem operacional previsível.
+     */
+    @Test
+    void shouldListPipelinesWithOrderedStages() {
+        Pipeline first = Pipeline.builder()
+                .id(1L)
+                .module("EXPERIMENT")
+                .name("Pipeline B")
+                .code("pipeline-b")
+                .stages(new ArrayList<>(List.of(stage(2L, 2), stage(1L, 1))))
+                .build();
+        Pipeline second = Pipeline.builder()
+                .id(2L)
+                .module("EXPERIMENT")
+                .name("Pipeline A")
+                .code("pipeline-a")
+                .stages(new ArrayList<>())
+                .build();
+        when(pipelineRepository.findAll()).thenReturn(List.of(first, second));
+
+        List<Pipeline> result = service.list();
+
+        assertThat(result).extracting(Pipeline::getName).containsExactly("Pipeline A", "Pipeline B");
+        assertThat(first.getStages()).extracting(PipelineStage::getPosition).containsExactly(1, 2);
+    }
+
+    /**
+     * Garante que a criação de etapa vincula a etapa ao pipeline informado na rota.
+     */
+    @Test
+    void shouldCreateStageLinkedToPipeline() {
+        Pipeline pipeline = Pipeline.builder().id(10L).name("Pipeline").code("pipeline").module("EXPERIMENT").build();
+        PipelineStageRequest request = new PipelineStageRequest();
+        request.setPosition(1);
+        request.setName("Campaign Angle");
+        request.setCode("campaign-angle");
+        request.setDescription("Ângulo da campanha");
+        when(pipelineRepository.findById(10L)).thenReturn(Optional.of(pipeline));
+        when(stageRepository.save(any(PipelineStage.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        PipelineStage created = service.createStage(10L, request);
+
+        assertThat(created.getPipeline()).isEqualTo(pipeline);
+        assertThat(created.getPosition()).isEqualTo(1);
+        assertThat(created.getName()).isEqualTo("Campaign Angle");
+        assertThat(created.isRequired()).isTrue();
+        ArgumentCaptor<PipelineStage> captor = ArgumentCaptor.forClass(PipelineStage.class);
+        verify(stageRepository).save(captor.capture());
+        assertThat(captor.getValue().getCode()).isEqualTo("campaign-angle");
+    }
+
+    /**
+     * Cria uma etapa sintética para validar ordenação no serviço.
+     */
+    private PipelineStage stage(Long id, Integer position) {
+        return PipelineStage.builder()
+                .id(id)
+                .position(position)
+                .name("Etapa " + position)
+                .code("stage-" + position)
+                .build();
+    }
+
+}

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -2925,3 +2925,9 @@
   - atualizado o cânone de etapas para explicitar que wireframe e design preset seguem a mesma regra;
   - adicionado teste unitário garantindo que o schema de design preset aceita apenas `pagina.corpo` para a estrutura visual.
 - impacto esperado: a resposta da etapa de preset fica mais simples, sem campos duplicados, facilitando leitura na tela, validação do contrato e geração posterior do HTML.
+
+## 2026-06-01 — CRUD de pipelines e etapas
+
+- Criada base administrativa para cadastrar pipelines e etapas reutilizáveis, começando pelo Pipeline de Experimento.
+- Seed inicial inclui as etapas Campaign Angle, Ad Copy, Landing Wireframe, Landing Copy, Planejamento de Imagens, Preset Design, GeraLanding HTML, Landing HTML e Landing Page Deliverables.
+- A tela permite criar, editar, ativar/inativar e remover pipelines e etapas, mantendo o fluxo Dor → Resultado → Mecanismo → Prova → Oferta como referência operacional.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -35,6 +35,7 @@ import DifferentiatedTechnologyListPage from "./pages/differentiatedTechnology/D
 import NewDifferentiatedTechnologyPage from "./pages/differentiatedTechnology/NewDifferentiatedTechnologyPage";
 import EditDifferentiatedTechnologyPage from "./pages/differentiatedTechnology/EditDifferentiatedTechnologyPage";
 import MicroserviceExceptionListPage from "./pages/microservice/MicroserviceExceptionListPage";
+import PipelineCrudPage from "./pages/pipeline/PipelineCrudPage";
 import ExperimentListPage from "./pages/experiment/ExperimentListPage";
 import NewExperimentPage from "./pages/experiment/NewExperimentPage";
 import ExperimentDetailPage from "./pages/experiment/ExperimentDetailPage";
@@ -249,6 +250,7 @@ export default function App() {
                 path="/microservices/:id/edit"
                 element={<EditMicroservicePage />}
               />
+              <Route path="/pipelines" element={<PipelineCrudPage />} />
               <Route
                 path="/differentiated-technologies"
                 element={<DifferentiatedTechnologyListPage />}

--- a/frontend/src/api/pipeline/types.ts
+++ b/frontend/src/api/pipeline/types.ts
@@ -1,0 +1,34 @@
+export interface PipelineStage {
+  id: number;
+  pipelineId: number;
+  position: number;
+  name: string;
+  code: string;
+  description?: string | null;
+  required: boolean;
+  active: boolean;
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+export interface Pipeline {
+  id: number;
+  name: string;
+  code: string;
+  module: string;
+  description?: string | null;
+  active: boolean;
+  stages: PipelineStage[];
+  createdAt?: string;
+  updatedAt?: string;
+}
+
+export type PipelinePayload = Pick<
+  Pipeline,
+  "name" | "code" | "module" | "description" | "active"
+>;
+
+export type PipelineStagePayload = Pick<
+  PipelineStage,
+  "position" | "name" | "code" | "description" | "required" | "active"
+>;

--- a/frontend/src/api/pipeline/usePipelineMutations.ts
+++ b/frontend/src/api/pipeline/usePipelineMutations.ts
@@ -1,0 +1,107 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import axios from "axios";
+import type {
+  Pipeline,
+  PipelinePayload,
+  PipelineStage,
+  PipelineStagePayload,
+} from "./types";
+
+export function useCreatePipeline() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (payload: PipelinePayload) => {
+      const { data } = await axios.post<Pipeline>("/api/pipelines", payload);
+      return data;
+    },
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["pipelines"] }),
+  });
+}
+
+export function useUpdatePipeline() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({
+      id,
+      payload,
+    }: {
+      id: number;
+      payload: PipelinePayload;
+    }) => {
+      const { data } = await axios.put<Pipeline>(
+        `/api/pipelines/${id}`,
+        payload,
+      );
+      return data;
+    },
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["pipelines"] }),
+  });
+}
+
+export function useDeletePipeline() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (id: number) => {
+      await axios.delete(`/api/pipelines/${id}`);
+    },
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["pipelines"] }),
+  });
+}
+
+export function useCreatePipelineStage() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({
+      pipelineId,
+      payload,
+    }: {
+      pipelineId: number;
+      payload: PipelineStagePayload;
+    }) => {
+      const { data } = await axios.post<PipelineStage>(
+        `/api/pipelines/${pipelineId}/stages`,
+        payload,
+      );
+      return data;
+    },
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["pipelines"] }),
+  });
+}
+
+export function useUpdatePipelineStage() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({
+      pipelineId,
+      stageId,
+      payload,
+    }: {
+      pipelineId: number;
+      stageId: number;
+      payload: PipelineStagePayload;
+    }) => {
+      const { data } = await axios.put<PipelineStage>(
+        `/api/pipelines/${pipelineId}/stages/${stageId}`,
+        payload,
+      );
+      return data;
+    },
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["pipelines"] }),
+  });
+}
+
+export function useDeletePipelineStage() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({
+      pipelineId,
+      stageId,
+    }: {
+      pipelineId: number;
+      stageId: number;
+    }) => {
+      await axios.delete(`/api/pipelines/${pipelineId}/stages/${stageId}`);
+    },
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["pipelines"] }),
+  });
+}

--- a/frontend/src/api/pipeline/usePipelines.ts
+++ b/frontend/src/api/pipeline/usePipelines.ts
@@ -1,0 +1,13 @@
+import { useQuery } from "@tanstack/react-query";
+import axios from "axios";
+import type { Pipeline } from "./types";
+
+export function usePipelines() {
+  return useQuery({
+    queryKey: ["pipelines"],
+    queryFn: async () => {
+      const { data } = await axios.get<Pipeline[]>("/api/pipelines");
+      return data;
+    },
+  });
+}

--- a/frontend/src/components/MainNavigation.tsx
+++ b/frontend/src/components/MainNavigation.tsx
@@ -134,6 +134,7 @@ const NAV_SECTIONS: NavSection[] = [
       { to: "/agent-themes", label: "Temas de agente", icon: Layers },
       { to: "/differentiated-technologies", label: "Tecnologias diferenciadas", icon: Cpu },
       { to: "/microservices", label: "Microserviços", icon: Server },
+      { to: "/pipelines", label: "Pipelines", icon: Workflow },
       { to: "/microservices/errors", label: "Erros de microserviço", icon: AlertTriangle },
       { to: "/chat-dialogs", label: "ChatGPT", icon: MessageSquare },
       { to: "/prompt-entities", label: "Objetos de Prompt", icon: Shapes },

--- a/frontend/src/pages/pipeline/PipelineCrudPage.tsx
+++ b/frontend/src/pages/pipeline/PipelineCrudPage.tsx
@@ -1,0 +1,547 @@
+import { useMemo, useState } from "react";
+import PageTitle from "../../components/PageTitle";
+import { usePipelines } from "../../api/pipeline/usePipelines";
+import type {
+  Pipeline,
+  PipelinePayload,
+  PipelineStage,
+  PipelineStagePayload,
+} from "../../api/pipeline/types";
+import {
+  useCreatePipeline,
+  useCreatePipelineStage,
+  useDeletePipeline,
+  useDeletePipelineStage,
+  useUpdatePipeline,
+  useUpdatePipelineStage,
+} from "../../api/pipeline/usePipelineMutations";
+
+const emptyPipeline: PipelinePayload = {
+  name: "",
+  code: "",
+  module: "EXPERIMENT",
+  description: "",
+  active: true,
+};
+
+const emptyStage: PipelineStagePayload = {
+  position: 1,
+  name: "",
+  code: "",
+  description: "",
+  required: true,
+  active: true,
+};
+
+function pipelineToPayload(pipeline: Pipeline): PipelinePayload {
+  return {
+    name: pipeline.name,
+    code: pipeline.code,
+    module: pipeline.module,
+    description: pipeline.description ?? "",
+    active: pipeline.active,
+  };
+}
+
+function stageToPayload(stage: PipelineStage): PipelineStagePayload {
+  return {
+    position: stage.position,
+    name: stage.name,
+    code: stage.code,
+    description: stage.description ?? "",
+    required: stage.required,
+    active: stage.active,
+  };
+}
+
+export default function PipelineCrudPage() {
+  const { data, isLoading, isError } = usePipelines();
+  const createPipeline = useCreatePipeline();
+  const updatePipeline = useUpdatePipeline();
+  const deletePipeline = useDeletePipeline();
+  const createStage = useCreatePipelineStage();
+  const updateStage = useUpdatePipelineStage();
+  const deleteStage = useDeletePipelineStage();
+
+  const pipelines = useMemo(() => data ?? [], [data]);
+  const [pipelineForm, setPipelineForm] =
+    useState<PipelinePayload>(emptyPipeline);
+  const [editingPipelineId, setEditingPipelineId] = useState<number | null>(
+    null,
+  );
+  const [stageForms, setStageForms] = useState<
+    Record<number, PipelineStagePayload>
+  >({});
+  const [editingStageId, setEditingStageId] = useState<number | null>(null);
+
+  const isSavingPipeline = createPipeline.isPending || updatePipeline.isPending;
+  const isSavingStage = createStage.isPending || updateStage.isPending;
+
+  const submitPipeline = () => {
+    const payload = {
+      ...pipelineForm,
+      code: pipelineForm.code.trim(),
+      name: pipelineForm.name.trim(),
+    };
+    if (editingPipelineId) {
+      updatePipeline.mutate(
+        { id: editingPipelineId, payload },
+        { onSuccess: () => resetPipelineForm() },
+      );
+      return;
+    }
+
+    createPipeline.mutate(payload, { onSuccess: () => resetPipelineForm() });
+  };
+
+  const resetPipelineForm = () => {
+    setPipelineForm(emptyPipeline);
+    setEditingPipelineId(null);
+  };
+
+  const submitStage = (pipelineId: number) => {
+    const payload = stageForms[pipelineId] ?? emptyStage;
+    const normalizedPayload = {
+      ...payload,
+      code: payload.code.trim(),
+      name: payload.name.trim(),
+    };
+    if (editingStageId) {
+      updateStage.mutate(
+        { pipelineId, stageId: editingStageId, payload: normalizedPayload },
+        { onSuccess: () => resetStageForm(pipelineId) },
+      );
+      return;
+    }
+
+    createStage.mutate(
+      { pipelineId, payload: normalizedPayload },
+      { onSuccess: () => resetStageForm(pipelineId) },
+    );
+  };
+
+  const resetStageForm = (pipelineId: number) => {
+    setStageForms((current) => ({ ...current, [pipelineId]: emptyStage }));
+    setEditingStageId(null);
+  };
+
+  if (isLoading) return <p>Carregando pipelines...</p>;
+  if (isError)
+    return (
+      <p className="text-danger">Não foi possível carregar os pipelines.</p>
+    );
+
+  return (
+    <div>
+      <PageTitle>Pipelines e etapas</PageTitle>
+      <p className="text-body-secondary">
+        Configure os pipelines operacionais que transformam oportunidades em
+        produtos digitais vendáveis. Exemplo: Pipeline de Experimento com etapas
+        como Campaign Angle, Ad Copy e Landing Wireframe.
+      </p>
+
+      <section className="card mb-4">
+        <div className="card-body">
+          <h2 className="h5">
+            {editingPipelineId ? "Editar pipeline" : "Novo pipeline"}
+          </h2>
+          <div className="row g-3">
+            <div className="col-md-4">
+              <label className="form-label">Nome *</label>
+              <input
+                className="form-control"
+                value={pipelineForm.name}
+                onChange={(event) =>
+                  setPipelineForm((current) => ({
+                    ...current,
+                    name: event.target.value,
+                  }))
+                }
+                placeholder="Pipeline de Experimento"
+              />
+            </div>
+            <div className="col-md-3">
+              <label className="form-label">Código *</label>
+              <input
+                className="form-control"
+                value={pipelineForm.code}
+                onChange={(event) =>
+                  setPipelineForm((current) => ({
+                    ...current,
+                    code: event.target.value,
+                  }))
+                }
+                placeholder="experiment-pipeline"
+              />
+            </div>
+            <div className="col-md-3">
+              <label className="form-label">Módulo *</label>
+              <input
+                className="form-control"
+                value={pipelineForm.module}
+                onChange={(event) =>
+                  setPipelineForm((current) => ({
+                    ...current,
+                    module: event.target.value,
+                  }))
+                }
+                placeholder="EXPERIMENT"
+              />
+            </div>
+            <div className="col-md-2 d-flex align-items-end">
+              <div className="form-check form-switch mb-2">
+                <input
+                  className="form-check-input"
+                  type="checkbox"
+                  checked={pipelineForm.active}
+                  onChange={(event) =>
+                    setPipelineForm((current) => ({
+                      ...current,
+                      active: event.target.checked,
+                    }))
+                  }
+                  id="pipeline-active"
+                />
+                <label className="form-check-label" htmlFor="pipeline-active">
+                  Ativo
+                </label>
+              </div>
+            </div>
+            <div className="col-12">
+              <label className="form-label">Descrição</label>
+              <textarea
+                className="form-control"
+                rows={2}
+                value={pipelineForm.description ?? ""}
+                onChange={(event) =>
+                  setPipelineForm((current) => ({
+                    ...current,
+                    description: event.target.value,
+                  }))
+                }
+                placeholder="Objetivo comercial e resultado esperado do pipeline."
+              />
+            </div>
+          </div>
+          <div className="d-flex gap-2 mt-3">
+            <button
+              className="btn btn-primary"
+              onClick={submitPipeline}
+              disabled={
+                isSavingPipeline ||
+                !pipelineForm.name.trim() ||
+                !pipelineForm.code.trim() ||
+                !pipelineForm.module.trim()
+              }
+            >
+              {isSavingPipeline ? (
+                <span
+                  className="spinner-border spinner-border-sm me-2"
+                  aria-hidden="true"
+                />
+              ) : null}
+              {editingPipelineId ? "Salvar pipeline" : "Criar pipeline"}
+            </button>
+            {editingPipelineId ? (
+              <button
+                className="btn btn-outline-secondary"
+                onClick={resetPipelineForm}
+                disabled={isSavingPipeline}
+              >
+                Cancelar edição
+              </button>
+            ) : null}
+          </div>
+        </div>
+      </section>
+
+      <div className="d-grid gap-4">
+        {pipelines.map((pipeline) => {
+          const stageForm = stageForms[pipeline.id] ?? emptyStage;
+          return (
+            <section className="card" key={pipeline.id}>
+              <div className="card-header d-flex flex-wrap justify-content-between align-items-start gap-3">
+                <div>
+                  <div className="d-flex align-items-center gap-2">
+                    <h2 className="h5 mb-0">{pipeline.name}</h2>
+                    <span
+                      className={`badge ${pipeline.active ? "text-bg-success" : "text-bg-secondary"}`}
+                    >
+                      {pipeline.active ? "Ativo" : "Inativo"}
+                    </span>
+                  </div>
+                  <div className="small text-body-secondary">
+                    {pipeline.module} · {pipeline.code} ·{" "}
+                    {pipeline.stages.length} etapas
+                  </div>
+                  {pipeline.description ? (
+                    <p className="mb-0 mt-2">{pipeline.description}</p>
+                  ) : null}
+                </div>
+                <div className="d-flex gap-2">
+                  <button
+                    className="btn btn-sm btn-outline-primary"
+                    onClick={() => {
+                      setEditingPipelineId(pipeline.id);
+                      setPipelineForm(pipelineToPayload(pipeline));
+                    }}
+                  >
+                    Editar
+                  </button>
+                  <button
+                    className="btn btn-sm btn-outline-danger"
+                    disabled={deletePipeline.isPending}
+                    onClick={() => {
+                      if (
+                        confirm(
+                          "Deseja remover este pipeline e todas as etapas?",
+                        )
+                      ) {
+                        deletePipeline.mutate(pipeline.id);
+                      }
+                    }}
+                  >
+                    {deletePipeline.isPending ? "Excluindo..." : "Excluir"}
+                  </button>
+                </div>
+              </div>
+              <div className="card-body">
+                <div className="table-responsive mb-4">
+                  <table className="table align-middle">
+                    <thead>
+                      <tr>
+                        <th style={{ width: 90 }}>Etapa</th>
+                        <th>Nome</th>
+                        <th>Código</th>
+                        <th>Descrição</th>
+                        <th>Obrigatória</th>
+                        <th>Status</th>
+                        <th>Ações</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {pipeline.stages.map((stage) => (
+                        <tr key={stage.id}>
+                          <td>Etapa {stage.position}</td>
+                          <td>{stage.name}</td>
+                          <td>
+                            <code>{stage.code}</code>
+                          </td>
+                          <td>{stage.description || "-"}</td>
+                          <td>{stage.required ? "Sim" : "Não"}</td>
+                          <td>{stage.active ? "Ativa" : "Inativa"}</td>
+                          <td className="d-flex gap-2">
+                            <button
+                              className="btn btn-sm btn-outline-primary"
+                              onClick={() => {
+                                setEditingStageId(stage.id);
+                                setStageForms((current) => ({
+                                  ...current,
+                                  [pipeline.id]: stageToPayload(stage),
+                                }));
+                              }}
+                            >
+                              Editar
+                            </button>
+                            <button
+                              className="btn btn-sm btn-outline-danger"
+                              disabled={deleteStage.isPending}
+                              onClick={() => {
+                                if (confirm("Deseja remover esta etapa?")) {
+                                  deleteStage.mutate({
+                                    pipelineId: pipeline.id,
+                                    stageId: stage.id,
+                                  });
+                                }
+                              }}
+                            >
+                              {deleteStage.isPending
+                                ? "Excluindo..."
+                                : "Excluir"}
+                            </button>
+                          </td>
+                        </tr>
+                      ))}
+                      {pipeline.stages.length === 0 ? (
+                        <tr>
+                          <td
+                            colSpan={7}
+                            className="text-center text-body-secondary"
+                          >
+                            Nenhuma etapa cadastrada para este pipeline.
+                          </td>
+                        </tr>
+                      ) : null}
+                    </tbody>
+                  </table>
+                </div>
+
+                <div className="border rounded p-3 bg-light">
+                  <h3 className="h6">
+                    {editingStageId ? "Editar etapa" : "Nova etapa"}
+                  </h3>
+                  <div className="row g-3">
+                    <div className="col-md-1">
+                      <label className="form-label">Ordem *</label>
+                      <input
+                        type="number"
+                        min={1}
+                        className="form-control"
+                        value={stageForm.position}
+                        onChange={(event) =>
+                          setStageForms((current) => ({
+                            ...current,
+                            [pipeline.id]: {
+                              ...stageForm,
+                              position: Number(event.target.value),
+                            },
+                          }))
+                        }
+                      />
+                    </div>
+                    <div className="col-md-3">
+                      <label className="form-label">Nome *</label>
+                      <input
+                        className="form-control"
+                        value={stageForm.name}
+                        onChange={(event) =>
+                          setStageForms((current) => ({
+                            ...current,
+                            [pipeline.id]: {
+                              ...stageForm,
+                              name: event.target.value,
+                            },
+                          }))
+                        }
+                        placeholder="Campaign Angle"
+                      />
+                    </div>
+                    <div className="col-md-3">
+                      <label className="form-label">Código *</label>
+                      <input
+                        className="form-control"
+                        value={stageForm.code}
+                        onChange={(event) =>
+                          setStageForms((current) => ({
+                            ...current,
+                            [pipeline.id]: {
+                              ...stageForm,
+                              code: event.target.value,
+                            },
+                          }))
+                        }
+                        placeholder="campaign-angle"
+                      />
+                    </div>
+                    <div className="col-md-2 d-flex align-items-end">
+                      <div className="form-check form-switch mb-2">
+                        <input
+                          className="form-check-input"
+                          type="checkbox"
+                          checked={stageForm.required}
+                          onChange={(event) =>
+                            setStageForms((current) => ({
+                              ...current,
+                              [pipeline.id]: {
+                                ...stageForm,
+                                required: event.target.checked,
+                              },
+                            }))
+                          }
+                          id={`stage-required-${pipeline.id}`}
+                        />
+                        <label
+                          className="form-check-label"
+                          htmlFor={`stage-required-${pipeline.id}`}
+                        >
+                          Obrigatória
+                        </label>
+                      </div>
+                    </div>
+                    <div className="col-md-2 d-flex align-items-end">
+                      <div className="form-check form-switch mb-2">
+                        <input
+                          className="form-check-input"
+                          type="checkbox"
+                          checked={stageForm.active}
+                          onChange={(event) =>
+                            setStageForms((current) => ({
+                              ...current,
+                              [pipeline.id]: {
+                                ...stageForm,
+                                active: event.target.checked,
+                              },
+                            }))
+                          }
+                          id={`stage-active-${pipeline.id}`}
+                        />
+                        <label
+                          className="form-check-label"
+                          htmlFor={`stage-active-${pipeline.id}`}
+                        >
+                          Ativa
+                        </label>
+                      </div>
+                    </div>
+                    <div className="col-12">
+                      <label className="form-label">Descrição</label>
+                      <textarea
+                        className="form-control"
+                        rows={2}
+                        value={stageForm.description ?? ""}
+                        onChange={(event) =>
+                          setStageForms((current) => ({
+                            ...current,
+                            [pipeline.id]: {
+                              ...stageForm,
+                              description: event.target.value,
+                            },
+                          }))
+                        }
+                        placeholder="Explique o objetivo prático desta etapa."
+                      />
+                    </div>
+                  </div>
+                  <div className="d-flex gap-2 mt-3">
+                    <button
+                      className="btn btn-outline-primary"
+                      disabled={
+                        isSavingStage ||
+                        !stageForm.name.trim() ||
+                        !stageForm.code.trim() ||
+                        stageForm.position < 1
+                      }
+                      onClick={() => submitStage(pipeline.id)}
+                    >
+                      {isSavingStage ? (
+                        <span
+                          className="spinner-border spinner-border-sm me-2"
+                          aria-hidden="true"
+                        />
+                      ) : null}
+                      {editingStageId ? "Salvar etapa" : "Adicionar etapa"}
+                    </button>
+                    {editingStageId ? (
+                      <button
+                        className="btn btn-outline-secondary"
+                        disabled={isSavingStage}
+                        onClick={() => resetStageForm(pipeline.id)}
+                      >
+                        Cancelar edição
+                      </button>
+                    ) : null}
+                  </div>
+                </div>
+              </div>
+            </section>
+          );
+        })}
+        {pipelines.length === 0 ? (
+          <div className="alert alert-info">
+            Nenhum pipeline cadastrado ainda. Crie o primeiro pipeline acima.
+          </div>
+        ) : null}
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
### Motivation

- Permitir administração reutilizável de pipelines operacionais (ex.: pipeline de experimento: Campaign Angle → Ad Copy → Landing Wireframe …) para apoiar fluxo Dor → Resultado → Mecanismo → Prova → Oferta.

### Description

- Backend: adicionadas entidades `Pipeline` e `PipelineStage`, repositórios JPA `PipelineRepository`/`PipelineStageRepository`, serviço `PipelineService`, mapper `PipelineMapper` e controller REST `/api/pipelines` com endpoints para criar/atualizar/listar/excluir pipelines e suas etapas; DTOs e requests de validação incluídos em `com.marketinghub.pipeline`.
- Banco: novo changelog Liquibase `2026-06-01-pipeline-crud.yaml` incluído no `db.changelog-master.yaml`, que cria tabelas `pipeline` e `pipeline_stage`, índices, constraints e faz seed do `Pipeline de Experimento` com 9 etapas (Campaign Angle, Ad Copy, Landing Wireframe, Landing Copy, Planejamento de Imagens, Preset Design, GeraLanding HTML, Landing HTML, Landing Page Deliverables).
- Frontend: adicionados tipos e hooks (`frontend/src/api/pipeline/*`), mutações para CRUD, e a página administrativa `PipelineCrudPage` (`frontend/src/pages/pipeline/PipelineCrudPage.tsx`) com UI para criar/editar/remover pipelines e etapas; rota `/pipelines` adicionada ao `App.tsx` e link no `MainNavigation`.
- Documentação: registro da mudança em `docs/registros/experimentos.md` descrevendo o novo CRUD e o seed inicial.

### Testing

- Executed backend unit tests with `../mvnw test` inside `backend/ads-service`, running the module test suite and reporting all tests passed (multiple test classes executed, 0 failures). 
- Ran frontend typecheck with `npm run typecheck` in `frontend` which failed due to missing type definition packages (`@testing-library/jest-dom`, `vite/client`, `vitest/globals`) and deprecation warnings from `tsconfig.json`, so frontend type checking needs dependency install/config adjustment. 
- No end-to-end or UI automated tests were added for the new frontend page in this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1dd0c7ff048321baea7d9c9c159f03)