### PR TITLE
Enforce JPA repository package architecture

### DIFF
--- a/backend/ads-service/src/test/java/com/marketinghub/architecture/ArquiteturaTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/architecture/ArquiteturaTest.java
@@ -28,6 +28,7 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -96,6 +97,13 @@ class ArquiteturaTest {
             .dependOnClassesThat()
             .resideInAPackage(MOIS_SALES_LIBRARY_PACKAGE + "..")
             .because("[ARQUITETURA][MOIS] nenhum outro pacote interno deve depender da biblioteca de páginas de vendas do MOIS");
+
+    @ArchTest
+    static final ArchRule springDataJpaRepositoriesMustResideInRepositoryJpaSubpackages = classes()
+            .that()
+            .areAssignableTo(JpaRepository.class)
+            .should(resideInRepositoryJpaSubpackage())
+            .because("[ARQUITETURA] [BACKEND][Repository] todo repository Spring Data JPA deve ficar em subpacote de com.marketinghub.repository.jpa");
 
     @ArchTest
     static final ArchRule geralandingWebPackagesShouldOnlyDependOnWebOrServiceInSameStage =
@@ -625,6 +633,25 @@ class ArquiteturaTest {
         }
         String actualTypeName = typeArguments[0].getTypeName();
         return actualTypeName.endsWith("." + expectedRecordName);
+    }
+
+    /**
+     * Garante que repositories Spring Data JPA residam em subpacotes da raiz canônica de JPA.
+     */
+    private static ArchCondition<JavaClass> resideInRepositoryJpaSubpackage() {
+        return new ArchCondition<>(
+                "[ARQUITETURA] [BACKEND][Repository] reside in com.marketinghub.repository.jpa subpackage") {
+            @Override
+            public void check(JavaClass item, ConditionEvents events) {
+                if (item.getPackageName().startsWith("com.marketinghub.repository.jpa.")) {
+                    return;
+                }
+                String message = "[ARQUITETURA] [BACKEND][Repository] classe=" + item.getName()
+                        + " acessa JPA via Spring Data JpaRepository e deve ficar em algum subpacote dentro de "
+                        + "com.marketinghub.repository.jpa";
+                events.add(SimpleConditionEvent.violated(item, message));
+            }
+        };
     }
 
     /**

--- a/docs/canonical/arquitetura-etapas.md
+++ b/docs/canonical/arquitetura-etapas.md
@@ -4,6 +4,18 @@ Este documento consolida as regras canônicas de arquitetura por etapa que são 
 `ArquiteturaTest` do backend e do Worker AI. Toda alteração estrutural deve preservar estas regras ou alterar
 primeiro este cânone e, em seguida, sincronizar os testes de arquitetura correspondentes.
 
+## Regra global — persistência JPA do backend
+
+Todo acesso Spring Data JPA ao banco de dados do backend deve ficar centralizado em algum subpacote de
+`com.marketinghub.repository.jpa`. Interfaces que estendem `JpaRepository` não podem ser criadas em
+pacotes funcionais como `service`, `web`, `oprm`, `mois`, `mds`, `geralanding` ou similares. Quando uma
+funcionalidade precisar de persistência JPA, ela deve consumir o repository canônico nessa raiz de
+persistência, preservando o backend como fonte única do modelo de dados e evitando gateways locais por
+módulo.
+
+Essa regra é protegida pelo `ArquiteturaTest`: qualquer novo repository Spring Data JPA fora de um
+subpacote de `com.marketinghub.repository.jpa` deve falhar com mensagem prefixada por `[ARQUITETURA]`.
+
 ## Backend por etapa
 
 Todo controller interno de backend criado para uma etapa operacional deve ficar no pacote direto


### PR DESCRIPTION
### Motivation
- Centralize Spring Data JPA persistence in the canonical backend package to keep DB access in `com.marketinghub.repository.jpa` and avoid repository/DAO leakage into functional packages.

### Description
- Add an ArchUnit rule `springDataJpaRepositoriesMustResideInRepositoryJpaSubpackages` in `backend/ads-service/src/test/java/com/marketinghub/architecture/ArquiteturaTest.java` that targets types assignable to `JpaRepository` and enforces their package location.
- Implement `resideInRepositoryJpaSubpackage()` ArchCondition to validate package prefix and emit violation messages prefixed with `[ARQUITETURA]` when a repository is outside `com.marketinghub.repository.jpa`.
- Add the `org.springframework.data.jpa.repository.JpaRepository` import used by the new rule.
- Document the new canonical rule in `docs/canonical/arquitetura-etapas.md` under `Regra global — persistência JPA do backend`.

### Testing
- Executed `cd backend/ads-service && ../mvnw -Dtest=ArquiteturaTest test`, which ran `ArquiteturaTest` (25 tests) with no failures and the build completed successfully.
- Executed `cd backend/ads-service && ../mvnw spotless:check`, which failed in this environment due to a missing/unsupported `spotless` plugin prefix (plugin resolution error).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1de7ec3e848321a99ce3ab0819b8fd)