### PR TITLE
EPM Sprint 1: persistência (migrations, entidades, repositórios e testes)

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/epm/ExperimentBudget.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/epm/ExperimentBudget.java
@@ -1,0 +1,65 @@
+package com.marketinghub.epm;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.Instant;
+import java.time.LocalDate;
+
+/**
+ * Representa a verba planejada para executar um experimento financeiro do EPM.
+ */
+@Entity
+@Table(name = "experiment_budget")
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ExperimentBudget {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(optional = false, fetch = FetchType.LAZY)
+    @JoinColumn(name = "financial_plan_hypothesis_id", nullable = false)
+    private FinancialPlanHypothesis financialPlanHypothesis;
+
+    @Column(name = "external_experiment_id")
+    private Long externalExperimentId;
+
+    @Column(nullable = false, length = 191)
+    private String name;
+
+    @Column(name = "planned_daily_budget_cents", nullable = false)
+    private Long plannedDailyBudgetCents;
+
+    @Column(name = "planned_duration_days", nullable = false)
+    private Integer plannedDurationDays;
+
+    @Column(name = "planned_total_budget_cents", nullable = false)
+    private Long plannedTotalBudgetCents;
+
+    @Column(name = "start_date")
+    private LocalDate startDate;
+
+    @Column(name = "end_date")
+    private LocalDate endDate;
+
+    @Builder.Default
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 32)
+    private ExperimentBudgetStatus status = ExperimentBudgetStatus.PLANNED;
+
+    @Column(columnDefinition = "TEXT")
+    private String notes;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/epm/ExperimentBudgetStatus.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/epm/ExperimentBudgetStatus.java
@@ -1,0 +1,11 @@
+package com.marketinghub.epm;
+
+/**
+ * Representa o estado do orçamento financeiro de um experimento.
+ */
+public enum ExperimentBudgetStatus {
+    PLANNED,
+    RUNNING,
+    COMPLETED,
+    CANCELLED
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/epm/ExperimentFinancialDecision.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/epm/ExperimentFinancialDecision.java
@@ -1,0 +1,48 @@
+package com.marketinghub.epm;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.Instant;
+
+/**
+ * Registra uma decisão financeira tomada sobre um experimento ou hipótese acompanhada pelo EPM.
+ */
+@Entity
+@Table(name = "experiment_financial_decision")
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ExperimentFinancialDecision {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(optional = false, fetch = FetchType.LAZY)
+    @JoinColumn(name = "experiment_budget_id", nullable = false)
+    private ExperimentBudget experimentBudget;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "decision_type", nullable = false, length = 64)
+    private ExperimentFinancialDecisionType decisionType;
+
+    @Column(nullable = false, columnDefinition = "TEXT")
+    private String reason;
+
+    @Column(name = "decided_at", nullable = false)
+    private Instant decidedAt;
+
+    @Column(name = "decided_by", length = 191)
+    private String decidedBy;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/epm/ExperimentFinancialDecisionType.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/epm/ExperimentFinancialDecisionType.java
@@ -1,0 +1,16 @@
+package com.marketinghub.epm;
+
+/**
+ * Representa as decisões financeiras iniciais permitidas para experimentos e hipóteses.
+ */
+public enum ExperimentFinancialDecisionType {
+    CONTINUE,
+    ITERATE_CREATIVE,
+    ITERATE_LANDING,
+    ITERATE_OFFER,
+    SCALE_CONTROLLED,
+    KILL_EXPERIMENT,
+    REFORMULATE_HYPOTHESIS,
+    KILL_HYPOTHESIS,
+    INCONCLUSIVE
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/epm/ExperimentFinancialMetric.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/epm/ExperimentFinancialMetric.java
@@ -1,0 +1,77 @@
+package com.marketinghub.epm;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.Instant;
+
+/**
+ * Consolida métricas financeiras manuais observadas em um experimento do EPM.
+ */
+@Entity
+@Table(name = "experiment_financial_metric")
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ExperimentFinancialMetric {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(optional = false, fetch = FetchType.LAZY)
+    @JoinColumn(name = "experiment_budget_id", nullable = false)
+    private ExperimentBudget experimentBudget;
+
+    @Column(name = "measured_at", nullable = false)
+    private Instant measuredAt;
+
+    @Column(nullable = false)
+    private Integer visitors;
+
+    @Column(nullable = false)
+    private Integer leads;
+
+    @Column(name = "checkout_clicks", nullable = false)
+    private Integer checkoutClicks;
+
+    @Column(nullable = false)
+    private Integer purchases;
+
+    @Column(name = "ad_spend_cents", nullable = false)
+    private Long adSpendCents;
+
+    @Column(name = "revenue_cents", nullable = false)
+    private Long revenueCents;
+
+    @Column(name = "payment_fee_cents", nullable = false)
+    private Long paymentFeeCents;
+
+    @Column(name = "platform_fee_cents", nullable = false)
+    private Long platformFeeCents;
+
+    @Column(name = "ai_cost_cents", nullable = false)
+    private Long aiCostCents;
+
+    @Column(name = "tax_estimate_cents", nullable = false)
+    private Long taxEstimateCents;
+
+    @Column(name = "gross_profit_cents", nullable = false)
+    private Long grossProfitCents;
+
+    @Column(name = "estimated_net_profit_cents", nullable = false)
+    private Long estimatedNetProfitCents;
+
+    @Column(columnDefinition = "TEXT")
+    private String notes;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/epm/FinancialPlan.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/epm/FinancialPlan.java
@@ -1,0 +1,61 @@
+package com.marketinghub.epm;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.Instant;
+import java.time.LocalDate;
+
+/**
+ * Representa o plano financeiro de um período para controlar a verba total de experimentos do EPM.
+ */
+@Entity
+@Table(name = "financial_plan")
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class FinancialPlan {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 191)
+    private String name;
+
+    @Column(name = "cycle_start_date", nullable = false)
+    private LocalDate cycleStartDate;
+
+    @Column(name = "cycle_end_date", nullable = false)
+    private LocalDate cycleEndDate;
+
+    @Column(name = "total_budget_cents", nullable = false)
+    private Long totalBudgetCents;
+
+    @Column(name = "default_daily_budget_cents")
+    private Long defaultDailyBudgetCents;
+
+    @Column(name = "default_experiment_duration_days")
+    private Integer defaultExperimentDurationDays;
+
+    @Column(name = "default_experiments_per_hypothesis")
+    private Integer defaultExperimentsPerHypothesis;
+
+    @Builder.Default
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 32)
+    private FinancialPlanStatus status = FinancialPlanStatus.DRAFT;
+
+    @Column(columnDefinition = "TEXT")
+    private String notes;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/epm/FinancialPlanHypothesis.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/epm/FinancialPlanHypothesis.java
@@ -1,0 +1,58 @@
+package com.marketinghub.epm;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.Instant;
+
+/**
+ * Representa uma hipótese comercial com limite financeiro dentro de um nicho planejado.
+ */
+@Entity
+@Table(name = "financial_plan_hypothesis")
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class FinancialPlanHypothesis {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(optional = false, fetch = FetchType.LAZY)
+    @JoinColumn(name = "financial_plan_niche_id", nullable = false)
+    private FinancialPlanNiche financialPlanNiche;
+
+    @Column(name = "external_hypothesis_id", length = 36)
+    private String externalHypothesisId;
+
+    @Column(nullable = false, length = 191)
+    private String title;
+
+    @Column(name = "planned_experiments", nullable = false)
+    private Integer plannedExperiments;
+
+    @Column(name = "planned_cost_per_experiment_cents", nullable = false)
+    private Long plannedCostPerExperimentCents;
+
+    @Column(name = "loss_limit_cents", nullable = false)
+    private Long lossLimitCents;
+
+    @Builder.Default
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 32)
+    private FinancialPlanHypothesisStatus status = FinancialPlanHypothesisStatus.PLANNED;
+
+    @Column(columnDefinition = "TEXT")
+    private String notes;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/epm/FinancialPlanHypothesisStatus.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/epm/FinancialPlanHypothesisStatus.java
@@ -1,0 +1,13 @@
+package com.marketinghub.epm;
+
+/**
+ * Representa o estado financeiro de uma hipótese planejada no EPM.
+ */
+public enum FinancialPlanHypothesisStatus {
+    PLANNED,
+    TESTING,
+    VALIDATED,
+    REFORMULATE,
+    KILLED,
+    INCONCLUSIVE
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/epm/FinancialPlanNiche.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/epm/FinancialPlanNiche.java
@@ -1,0 +1,55 @@
+package com.marketinghub.epm;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.Instant;
+
+/**
+ * Representa um nicho planejado dentro de um plano financeiro do EPM.
+ */
+@Entity
+@Table(name = "financial_plan_niche")
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class FinancialPlanNiche {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(optional = false, fetch = FetchType.LAZY)
+    @JoinColumn(name = "financial_plan_id", nullable = false)
+    private FinancialPlan financialPlan;
+
+    @Column(name = "external_niche_id")
+    private Long externalNicheId;
+
+    @Column(name = "niche_name", nullable = false, length = 191)
+    private String nicheName;
+
+    @Column(name = "planned_budget_cents", nullable = false)
+    private Long plannedBudgetCents;
+
+    @Column(name = "spend_limit_cents", nullable = false)
+    private Long spendLimitCents;
+
+    @Builder.Default
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false, length = 32)
+    private FinancialPlanNicheStatus status = FinancialPlanNicheStatus.PLANNED;
+
+    @Column(columnDefinition = "TEXT")
+    private String notes;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/epm/FinancialPlanNicheStatus.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/epm/FinancialPlanNicheStatus.java
@@ -1,0 +1,11 @@
+package com.marketinghub.epm;
+
+/**
+ * Representa o estado de validação financeira de um nicho dentro de um plano.
+ */
+public enum FinancialPlanNicheStatus {
+    PLANNED,
+    TESTING,
+    PAUSED,
+    CLOSED
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/epm/FinancialPlanStatus.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/epm/FinancialPlanStatus.java
@@ -1,0 +1,11 @@
+package com.marketinghub.epm;
+
+/**
+ * Representa o estado operacional de um plano financeiro do EPM.
+ */
+public enum FinancialPlanStatus {
+    DRAFT,
+    ACTIVE,
+    CLOSED,
+    CANCELLED
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/epm/ProductPriceScenario.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/epm/ProductPriceScenario.java
@@ -1,0 +1,62 @@
+package com.marketinghub.epm;
+
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.Instant;
+
+/**
+ * Representa uma simulação de preço e ponto de equilíbrio para o plano financeiro do EPM.
+ */
+@Entity
+@Table(name = "product_price_scenario")
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ProductPriceScenario {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(optional = false, fetch = FetchType.LAZY)
+    @JoinColumn(name = "financial_plan_id", nullable = false)
+    private FinancialPlan financialPlan;
+
+    @Column(nullable = false, length = 191)
+    private String name;
+
+    @Column(name = "price_cents", nullable = false)
+    private Long priceCents;
+
+    @Column(name = "expected_payment_fee_cents", nullable = false)
+    private Long expectedPaymentFeeCents;
+
+    @Column(name = "expected_platform_fee_cents", nullable = false)
+    private Long expectedPlatformFeeCents;
+
+    @Column(name = "expected_tax_cents", nullable = false)
+    private Long expectedTaxCents;
+
+    @Column(name = "expected_net_revenue_per_sale_cents", nullable = false)
+    private Long expectedNetRevenuePerSaleCents;
+
+    @Column(name = "total_budget_cents", nullable = false)
+    private Long totalBudgetCents;
+
+    @Column(name = "break_even_sales", nullable = false)
+    private Integer breakEvenSales;
+
+    @Column(columnDefinition = "TEXT")
+    private String notes;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/epm/ExperimentBudgetRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/epm/ExperimentBudgetRepository.java
@@ -1,0 +1,10 @@
+package com.marketinghub.repository.jpa.epm;
+
+import com.marketinghub.epm.ExperimentBudget;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * Repositório JPA para persistir e consultar registros ExperimentBudget do EPM.
+ */
+public interface ExperimentBudgetRepository extends JpaRepository<ExperimentBudget, Long> {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/epm/ExperimentFinancialDecisionRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/epm/ExperimentFinancialDecisionRepository.java
@@ -1,0 +1,10 @@
+package com.marketinghub.repository.jpa.epm;
+
+import com.marketinghub.epm.ExperimentFinancialDecision;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * Repositório JPA para persistir e consultar registros ExperimentFinancialDecision do EPM.
+ */
+public interface ExperimentFinancialDecisionRepository extends JpaRepository<ExperimentFinancialDecision, Long> {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/epm/ExperimentFinancialMetricRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/epm/ExperimentFinancialMetricRepository.java
@@ -1,0 +1,10 @@
+package com.marketinghub.repository.jpa.epm;
+
+import com.marketinghub.epm.ExperimentFinancialMetric;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * Repositório JPA para persistir e consultar registros ExperimentFinancialMetric do EPM.
+ */
+public interface ExperimentFinancialMetricRepository extends JpaRepository<ExperimentFinancialMetric, Long> {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/epm/FinancialPlanHypothesisRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/epm/FinancialPlanHypothesisRepository.java
@@ -1,0 +1,10 @@
+package com.marketinghub.repository.jpa.epm;
+
+import com.marketinghub.epm.FinancialPlanHypothesis;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * Repositório JPA para persistir e consultar registros FinancialPlanHypothesis do EPM.
+ */
+public interface FinancialPlanHypothesisRepository extends JpaRepository<FinancialPlanHypothesis, Long> {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/epm/FinancialPlanNicheRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/epm/FinancialPlanNicheRepository.java
@@ -1,0 +1,10 @@
+package com.marketinghub.repository.jpa.epm;
+
+import com.marketinghub.epm.FinancialPlanNiche;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * Repositório JPA para persistir e consultar registros FinancialPlanNiche do EPM.
+ */
+public interface FinancialPlanNicheRepository extends JpaRepository<FinancialPlanNiche, Long> {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/epm/FinancialPlanRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/epm/FinancialPlanRepository.java
@@ -1,0 +1,10 @@
+package com.marketinghub.repository.jpa.epm;
+
+import com.marketinghub.epm.FinancialPlan;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * Repositório JPA para persistir e consultar registros FinancialPlan do EPM.
+ */
+public interface FinancialPlanRepository extends JpaRepository<FinancialPlan, Long> {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/epm/ProductPriceScenarioRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/epm/ProductPriceScenarioRepository.java
@@ -1,0 +1,10 @@
+package com.marketinghub.repository.jpa.epm;
+
+import com.marketinghub.epm.ProductPriceScenario;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * Repositório JPA para persistir e consultar registros ProductPriceScenario do EPM.
+ */
+public interface ProductPriceScenarioRepository extends JpaRepository<ProductPriceScenario, Long> {
+}

--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-01-epm-sprint1-base.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-01-epm-sprint1-base.yaml
@@ -1,0 +1,138 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-06-01-epm-sprint1-base
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - onError: HALT
+        - dbms:
+            type: mysql
+      changes:
+        - sql:
+            dbms: mysql
+            splitStatements: true
+            stripComments: true
+            sql: |
+              CREATE TABLE financial_plan (
+                  id BIGINT AUTO_INCREMENT PRIMARY KEY,
+                  name VARCHAR(191) NOT NULL,
+                  cycle_start_date DATE NOT NULL,
+                  cycle_end_date DATE NOT NULL,
+                  total_budget_cents BIGINT NOT NULL,
+                  default_daily_budget_cents BIGINT NULL,
+                  default_experiment_duration_days INT NULL,
+                  default_experiments_per_hypothesis INT NULL,
+                  status VARCHAR(32) NOT NULL,
+                  notes TEXT NULL,
+                  created_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+                  updated_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6)
+              ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+              CREATE TABLE financial_plan_niche (
+                  id BIGINT AUTO_INCREMENT PRIMARY KEY,
+                  financial_plan_id BIGINT NOT NULL,
+                  external_niche_id BIGINT NULL,
+                  niche_name VARCHAR(191) NOT NULL,
+                  planned_budget_cents BIGINT NOT NULL,
+                  spend_limit_cents BIGINT NOT NULL,
+                  status VARCHAR(32) NOT NULL,
+                  notes TEXT NULL,
+                  created_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+                  updated_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+                  CONSTRAINT fk_financial_plan_niche_plan FOREIGN KEY (financial_plan_id) REFERENCES financial_plan(id)
+              ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+              CREATE TABLE financial_plan_hypothesis (
+                  id BIGINT AUTO_INCREMENT PRIMARY KEY,
+                  financial_plan_niche_id BIGINT NOT NULL,
+                  external_hypothesis_id VARCHAR(36) NULL,
+                  title VARCHAR(191) NOT NULL,
+                  planned_experiments INT NOT NULL,
+                  planned_cost_per_experiment_cents BIGINT NOT NULL,
+                  loss_limit_cents BIGINT NOT NULL,
+                  status VARCHAR(32) NOT NULL,
+                  notes TEXT NULL,
+                  created_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+                  updated_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+                  CONSTRAINT fk_financial_plan_hypothesis_niche FOREIGN KEY (financial_plan_niche_id) REFERENCES financial_plan_niche(id)
+              ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+              CREATE TABLE experiment_budget (
+                  id BIGINT AUTO_INCREMENT PRIMARY KEY,
+                  financial_plan_hypothesis_id BIGINT NOT NULL,
+                  external_experiment_id BIGINT NULL,
+                  name VARCHAR(191) NOT NULL,
+                  planned_daily_budget_cents BIGINT NOT NULL,
+                  planned_duration_days INT NOT NULL,
+                  planned_total_budget_cents BIGINT NOT NULL,
+                  start_date DATE NULL,
+                  end_date DATE NULL,
+                  status VARCHAR(32) NOT NULL,
+                  notes TEXT NULL,
+                  created_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+                  updated_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+                  CONSTRAINT fk_experiment_budget_hypothesis FOREIGN KEY (financial_plan_hypothesis_id) REFERENCES financial_plan_hypothesis(id)
+              ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+              CREATE TABLE experiment_financial_metric (
+                  id BIGINT AUTO_INCREMENT PRIMARY KEY,
+                  experiment_budget_id BIGINT NOT NULL,
+                  measured_at DATETIME(6) NOT NULL,
+                  visitors INT NOT NULL,
+                  leads INT NOT NULL,
+                  checkout_clicks INT NOT NULL,
+                  purchases INT NOT NULL,
+                  ad_spend_cents BIGINT NOT NULL,
+                  revenue_cents BIGINT NOT NULL,
+                  payment_fee_cents BIGINT NOT NULL,
+                  platform_fee_cents BIGINT NOT NULL,
+                  ai_cost_cents BIGINT NOT NULL,
+                  tax_estimate_cents BIGINT NOT NULL,
+                  gross_profit_cents BIGINT NOT NULL,
+                  estimated_net_profit_cents BIGINT NOT NULL,
+                  notes TEXT NULL,
+                  created_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+                  updated_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+                  CONSTRAINT fk_experiment_financial_metric_budget FOREIGN KEY (experiment_budget_id) REFERENCES experiment_budget(id)
+              ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+              CREATE TABLE experiment_financial_decision (
+                  id BIGINT AUTO_INCREMENT PRIMARY KEY,
+                  experiment_budget_id BIGINT NOT NULL,
+                  decision_type VARCHAR(64) NOT NULL,
+                  reason TEXT NOT NULL,
+                  decided_at DATETIME(6) NOT NULL,
+                  decided_by VARCHAR(191) NULL,
+                  created_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+                  updated_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+                  CONSTRAINT fk_experiment_financial_decision_budget FOREIGN KEY (experiment_budget_id) REFERENCES experiment_budget(id)
+              ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+              CREATE TABLE product_price_scenario (
+                  id BIGINT AUTO_INCREMENT PRIMARY KEY,
+                  financial_plan_id BIGINT NOT NULL,
+                  name VARCHAR(191) NOT NULL,
+                  price_cents BIGINT NOT NULL,
+                  expected_payment_fee_cents BIGINT NOT NULL,
+                  expected_platform_fee_cents BIGINT NOT NULL,
+                  expected_tax_cents BIGINT NOT NULL,
+                  expected_net_revenue_per_sale_cents BIGINT NOT NULL,
+                  total_budget_cents BIGINT NOT NULL,
+                  break_even_sales INT NOT NULL,
+                  notes TEXT NULL,
+                  created_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+                  updated_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+                  CONSTRAINT fk_product_price_scenario_plan FOREIGN KEY (financial_plan_id) REFERENCES financial_plan(id)
+              ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4;
+
+              CREATE INDEX idx_financial_plan_status ON financial_plan (status);
+              CREATE INDEX idx_financial_plan_niche_plan ON financial_plan_niche (financial_plan_id);
+              CREATE INDEX idx_financial_plan_niche_external ON financial_plan_niche (external_niche_id);
+              CREATE INDEX idx_financial_plan_hypothesis_niche ON financial_plan_hypothesis (financial_plan_niche_id);
+              CREATE INDEX idx_financial_plan_hypothesis_external ON financial_plan_hypothesis (external_hypothesis_id);
+              CREATE INDEX idx_experiment_budget_hypothesis ON experiment_budget (financial_plan_hypothesis_id);
+              CREATE INDEX idx_experiment_budget_external ON experiment_budget (external_experiment_id);
+              CREATE INDEX idx_experiment_financial_metric_budget ON experiment_financial_metric (experiment_budget_id);
+              CREATE INDEX idx_experiment_financial_metric_measured ON experiment_financial_metric (measured_at);
+              CREATE INDEX idx_experiment_financial_decision_budget ON experiment_financial_decision (experiment_budget_id);
+              CREATE INDEX idx_product_price_scenario_plan ON product_price_scenario (financial_plan_id);

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -813,3 +813,7 @@ databaseChangeLog:
   - include:
       file: changesets/2026-05-28-oprm-estabelecimento-cnae-raiz-mei-simples.yaml
       relativeToChangelogFile: true
+
+  - include:
+      file: changesets/2026-06-01-epm-sprint1-base.yaml
+      relativeToChangelogFile: true

--- a/backend/ads-service/src/test/java/com/marketinghub/epm/EpmRepositoryTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/epm/EpmRepositoryTest.java
@@ -1,0 +1,179 @@
+package com.marketinghub.epm;
+
+import com.marketinghub.repository.jpa.epm.ExperimentBudgetRepository;
+import com.marketinghub.repository.jpa.epm.ExperimentFinancialDecisionRepository;
+import com.marketinghub.repository.jpa.epm.ExperimentFinancialMetricRepository;
+import com.marketinghub.repository.jpa.epm.FinancialPlanHypothesisRepository;
+import com.marketinghub.repository.jpa.epm.FinancialPlanNicheRepository;
+import com.marketinghub.repository.jpa.epm.FinancialPlanRepository;
+import com.marketinghub.repository.jpa.epm.ProductPriceScenarioRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.test.context.TestPropertySource;
+
+import java.time.Instant;
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Valida a persistência básica das entidades e repositórios da Sprint 1 do EPM.
+ */
+@DataJpaTest
+@TestPropertySource(properties = "spring.liquibase.enabled=false")
+class EpmRepositoryTest {
+
+    @Autowired
+    FinancialPlanRepository financialPlanRepository;
+
+    @Autowired
+    FinancialPlanNicheRepository financialPlanNicheRepository;
+
+    @Autowired
+    FinancialPlanHypothesisRepository financialPlanHypothesisRepository;
+
+    @Autowired
+    ExperimentBudgetRepository experimentBudgetRepository;
+
+    @Autowired
+    ExperimentFinancialMetricRepository experimentFinancialMetricRepository;
+
+    @Autowired
+    ExperimentFinancialDecisionRepository experimentFinancialDecisionRepository;
+
+    @Autowired
+    ProductPriceScenarioRepository productPriceScenarioRepository;
+
+    /** Verifica se a hierarquia financeira do EPM persiste valores monetários em centavos. */
+    @Test
+    void shouldPersistFinancialHierarchyWithBudgetInCents() {
+        FinancialPlan plan = financialPlanRepository.save(FinancialPlan.builder()
+                .name("Plano Junho 2026")
+                .cycleStartDate(LocalDate.of(2026, 6, 1))
+                .cycleEndDate(LocalDate.of(2026, 6, 30))
+                .totalBudgetCents(300_000L)
+                .defaultDailyBudgetCents(2_000L)
+                .defaultExperimentDurationDays(3)
+                .defaultExperimentsPerHypothesis(3)
+                .status(FinancialPlanStatus.ACTIVE)
+                .build());
+
+        FinancialPlanNiche niche = financialPlanNicheRepository.save(FinancialPlanNiche.builder()
+                .financialPlan(plan)
+                .externalNicheId(15L)
+                .nicheName("Personal trainers")
+                .plannedBudgetCents(60_000L)
+                .spendLimitCents(60_000L)
+                .status(FinancialPlanNicheStatus.TESTING)
+                .build());
+
+        FinancialPlanHypothesis hypothesis = financialPlanHypothesisRepository.save(FinancialPlanHypothesis.builder()
+                .financialPlanNiche(niche)
+                .externalHypothesisId("8f35c480-6f4d-4bc3-8f09-2bd911f4a928")
+                .title("Agenda cheia sem desconto")
+                .plannedExperiments(3)
+                .plannedCostPerExperimentCents(6_000L)
+                .lossLimitCents(18_000L)
+                .status(FinancialPlanHypothesisStatus.TESTING)
+                .build());
+
+        ExperimentBudget budget = experimentBudgetRepository.save(ExperimentBudget.builder()
+                .financialPlanHypothesis(hypothesis)
+                .externalExperimentId(42L)
+                .name("Experimento 1")
+                .plannedDailyBudgetCents(2_000L)
+                .plannedDurationDays(3)
+                .plannedTotalBudgetCents(6_000L)
+                .status(ExperimentBudgetStatus.RUNNING)
+                .build());
+
+        ExperimentBudget saved = experimentBudgetRepository.findById(budget.getId()).orElseThrow();
+
+        assertThat(saved.getPlannedTotalBudgetCents()).isEqualTo(6_000L);
+        assertThat(saved.getFinancialPlanHypothesis().getLossLimitCents()).isEqualTo(18_000L);
+        assertThat(saved.getFinancialPlanHypothesis().getFinancialPlanNiche().getPlannedBudgetCents()).isEqualTo(60_000L);
+        assertThat(saved.getFinancialPlanHypothesis().getFinancialPlanNiche().getFinancialPlan().getTotalBudgetCents())
+                .isEqualTo(300_000L);
+    }
+
+    /** Verifica se métricas, decisões e cenários de preço persistem com os vínculos corretos. */
+    @Test
+    void shouldPersistFinancialMetricsDecisionAndPriceScenario() {
+        FinancialPlan plan = financialPlanRepository.save(FinancialPlan.builder()
+                .name("Plano Validação")
+                .cycleStartDate(LocalDate.of(2026, 6, 1))
+                .cycleEndDate(LocalDate.of(2026, 6, 15))
+                .totalBudgetCents(120_000L)
+                .status(FinancialPlanStatus.ACTIVE)
+                .build());
+        FinancialPlanNiche niche = financialPlanNicheRepository.save(FinancialPlanNiche.builder()
+                .financialPlan(plan)
+                .nicheName("Nutricionistas")
+                .plannedBudgetCents(30_000L)
+                .spendLimitCents(30_000L)
+                .build());
+        FinancialPlanHypothesis hypothesis = financialPlanHypothesisRepository.save(FinancialPlanHypothesis.builder()
+                .financialPlanNiche(niche)
+                .title("Cardápio rápido para pacientes")
+                .plannedExperiments(2)
+                .plannedCostPerExperimentCents(5_000L)
+                .lossLimitCents(10_000L)
+                .build());
+        ExperimentBudget budget = experimentBudgetRepository.save(ExperimentBudget.builder()
+                .financialPlanHypothesis(hypothesis)
+                .name("Criativo benefício direto")
+                .plannedDailyBudgetCents(2_500L)
+                .plannedDurationDays(2)
+                .plannedTotalBudgetCents(5_000L)
+                .build());
+
+        ExperimentFinancialMetric metric = experimentFinancialMetricRepository.save(ExperimentFinancialMetric.builder()
+                .experimentBudget(budget)
+                .measuredAt(Instant.parse("2026-06-01T12:00:00Z"))
+                .visitors(100)
+                .leads(12)
+                .checkoutClicks(3)
+                .purchases(1)
+                .adSpendCents(5_000L)
+                .revenueCents(9_700L)
+                .paymentFeeCents(800L)
+                .platformFeeCents(0L)
+                .aiCostCents(200L)
+                .taxEstimateCents(600L)
+                .grossProfitCents(4_700L)
+                .estimatedNetProfitCents(4_100L)
+                .build());
+        ExperimentFinancialDecision decision = experimentFinancialDecisionRepository.save(ExperimentFinancialDecision.builder()
+                .experimentBudget(budget)
+                .decisionType(ExperimentFinancialDecisionType.SCALE_CONTROLLED)
+                .reason("Experimento gerou compra real com lucro bruto positivo.")
+                .decidedAt(Instant.parse("2026-06-01T13:00:00Z"))
+                .decidedBy("codex-test")
+                .build());
+        ProductPriceScenario scenario = productPriceScenarioRepository.save(ProductPriceScenario.builder()
+                .financialPlan(plan)
+                .name("Produto R$97")
+                .priceCents(9_700L)
+                .expectedPaymentFeeCents(800L)
+                .expectedPlatformFeeCents(0L)
+                .expectedTaxCents(600L)
+                .expectedNetRevenuePerSaleCents(8_300L)
+                .totalBudgetCents(120_000L)
+                .breakEvenSales(15)
+                .build());
+
+        assertThat(experimentFinancialMetricRepository.findById(metric.getId()))
+                .get()
+                .extracting(ExperimentFinancialMetric::getEstimatedNetProfitCents)
+                .isEqualTo(4_100L);
+        assertThat(experimentFinancialDecisionRepository.findById(decision.getId()))
+                .get()
+                .extracting(ExperimentFinancialDecision::getDecisionType)
+                .isEqualTo(ExperimentFinancialDecisionType.SCALE_CONTROLLED);
+        assertThat(productPriceScenarioRepository.findById(scenario.getId()))
+                .get()
+                .extracting(ProductPriceScenario::getBreakEvenSales)
+                .isEqualTo(15);
+    }
+}


### PR DESCRIPTION
### Motivation
- Implementar a base persistente mínima do módulo EPM para controlar orçamento e decidir sobre experimentos, seguindo o plano de implantação da Sprint 1.
- Garantir compatibilidade MySQL 5.7 e armazenar valores monetários em centavos para evitar problemas de arredondamento e compatibilidade.
- Centralizar persistência no backend seguindo a convenção do projeto (`com.marketinghub.repository.jpa`) e manter responsabilidade única nas entidades.

### Description
- Adiciona migration Liquibase MySQL 5.7 `changesets/2026-06-01-epm-sprint1-base.yaml` com tabelas: `financial_plan`, `financial_plan_niche`, `financial_plan_hypothesis`, `experiment_budget`, `experiment_financial_metric`, `experiment_financial_decision` e `product_price_scenario`, usando `dbms:mysql`, `splitStatements: true` e `stripComments: true` e índices/constraints adequados.
- Registra o changelog do EPM no `db.changelog-master.yaml` para inclusão na cadeia de migrations do backend.
- Cria entidades JPA em `com.marketinghub.epm` (`FinancialPlan`, `FinancialPlanNiche`, `FinancialPlanHypothesis`, `ExperimentBudget`, `ExperimentFinancialMetric`, `ExperimentFinancialDecision`, `ProductPriceScenario`) com comentários de responsabilidade, campos de timestamp e campos monetários em centavos (`BIGINT`/`Long`).
- Cria repositórios Spring Data em `com.marketinghub.repository.jpa.epm` para todas as entidades e adiciona testes de persistência em `backend/ads-service/src/test/java/com/marketinghub/epm/EpmRepositoryTest.java` validando hierarquia, armazenamento em centavos e vínculos entre métricas, decisões e cenários de preço.

### Testing
- Executado o teste de unidade específico `EpmRepositoryTest` com `cd backend/ads-service && ../mvnw test -Dtest=EpmRepositoryTest`, que passou com sucesso (2 testes, 0 falhas).
- Executada a suíte de testes do módulo backend com `cd backend/ads-service && ../mvnw test`, que completou com sucesso (build e testes concluídos, resumo: todos os testes passaram, 1 teste ignorado).
- Validado o YAML das changelogs com `ruby -e "require 'yaml'; %w[..., db.changelog-master.yaml].each { |p| YAML.load_file(p); puts \"#{p} OK\" }"`, que retornou OK para os arquivos adicionados.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1de62ec09c8321931174655c4141c7)