### PR TITLE
Increase Hotmart collector target to 500 products and reschedule cycle 1 to 18:15; update tests and docs

### DIFF
--- a/docs/canonical/mois-hotmart-mapeamento-ciclos-campos-banco.md
+++ b/docs/canonical/mois-hotmart-mapeamento-ciclos-campos-banco.md
@@ -184,14 +184,14 @@ Em resumo: o erro normalmente não está na UI; ele nasce na qualidade do campo 
 
 Agendamento operacional vigente no `mois-hotmart-collector`:
 
-- **Ciclo 1 (listagem):** execução pontual em **1 de junho de 2026 às 16:15**, no fuso `America/Sao_Paulo`.
+- **Ciclo 1 (listagem):** execução pontual em **1 de junho de 2026 às 18:15**, no fuso `America/Sao_Paulo`.
 - **Ciclo 2 (detalhes):** execução diária às **17:00**, conforme scheduler vigente do coletor.
 - O cron do ciclo 1 fica hardcoded no `HotmartCollectorScheduler` para manter rastreabilidade operacional do horário combinado.
 
 Sequência operacional consolidada:
 
 1. Obter token JWT da Hotmart via configuração geral no backend.
-2. No ciclo 1, chamar `POST https://api-affiliation-market.hotmart.com/v2/market/search` e persistir snapshots base, percorrendo até 20 páginas de 20 itens por execução (alvo operacional padrão de 400 produtos), salvo se a Hotmart retornar menos itens antes desse limite.
+2. No ciclo 1, chamar `POST https://api-affiliation-market.hotmart.com/v2/market/search` e persistir snapshots base, percorrendo até 25 páginas de 20 itens por execução (alvo operacional padrão de 500 produtos), salvo se a Hotmart retornar menos itens antes desse limite.
 3. No ciclo 2, buscar produtos já persistidos em `/api/v1/mois/hotmart/products`.
 4. Para cada produto do ciclo 2, chamar `GET https://api-affiliation-market.hotmart.com/v1/market/product/{id}/details?userSessionId={session}`.
 5. Persistir novamente no backend para atualizar as referências com foco em `salesPageUrl`.

--- a/docs/registros/mois1.md
+++ b/docs/registros/mois1.md
@@ -733,3 +733,24 @@ Arquivos alterados:
 - atualizado o `HotmartCollectorScheduler` para disparar o ciclo 1 com cron literal `0 15 16 1 6 *`, com guarda operacional para executar somente no ano de 2026.
 - atualizado o cânone Hotmart para registrar o horário operacional do ciclo 1 e manter rastreabilidade da decisão.
 - mantido o ciclo 2 sem alteração.
+
+## 2026-06-01 - Aumento do alvo operacional do ciclo 1 Hotmart para 500 produtos
+
+- Ajustado o limite do ciclo 1 do `mois-hotmart-collector` para percorrer até 25 páginas de 20 itens, totalizando alvo operacional padrão de 500 produtos por execução.
+- Atualizado o padrão `collector.scheduler.max-products` para 500, mantendo possibilidade de override por `COLLECTOR_SCHEDULER_MAX_PRODUCTS`.
+- Sincronizado o documento canônico do fluxo Hotmart e o teste unitário que valida o limite operacional do ciclo 1.
+
+Arquivos alterados:
+- `mois-hotmart-collector/src/main/java/com/marketinghub/moishotmart/service/HotmartCollectorService.java`
+- `mois-hotmart-collector/src/main/java/com/marketinghub/moishotmart/service/HotmartCollectorScheduler.java`
+- `mois-hotmart-collector/src/main/resources/application.properties`
+- `mois-hotmart-collector/src/test/java/com/marketinghub/moishotmart/service/HotmartCollectorServiceTest.java`
+- `docs/canonical/mois-hotmart-mapeamento-ciclos-campos-banco.md`
+
+
+## 2026-06-01 — Hotmart ciclo 1 reagendado para 18:15
+
+- ajuste operacional solicitado para alterar a execução do ciclo 1 Hotmart de **01/06/2026 às 16:15** para **01/06/2026 às 18:15** no timezone `America/Sao_Paulo`.
+- atualizado o `HotmartCollectorScheduler` para disparar o ciclo 1 com cron literal `0 15 18 1 6 *`, mantendo guarda operacional para executar somente no ano de 2026.
+- atualizado o cânone Hotmart para refletir o novo horário vigente do ciclo 1.
+- mantido o alvo operacional de 500 produtos e o ciclo 2 sem alteração.

--- a/mois-hotmart-collector/src/main/java/com/marketinghub/moishotmart/service/HotmartCollectorScheduler.java
+++ b/mois-hotmart-collector/src/main/java/com/marketinghub/moishotmart/service/HotmartCollectorScheduler.java
@@ -32,7 +32,7 @@ public class HotmartCollectorScheduler {
             HotmartCollectorService collectorService,
             @Value("${collector.scheduler.enabled:true}") boolean enabled,
             @Value("${collector.scheduler.source:hotmart-market}") String source,
-            @Value("${collector.scheduler.max-products:400}") int maxProducts
+            @Value("${collector.scheduler.max-products:500}") int maxProducts
     ) {
         this.collectorService = collectorService;
         this.enabled = enabled;
@@ -41,10 +41,10 @@ public class HotmartCollectorScheduler {
     }
 
     /**
-     * Executa o ciclo 1 de listagem de produtos às 16:15 em 1 de junho de 2026, no horário de São Paulo.
+     * Executa o ciclo 1 de listagem de produtos às 18:15 em 1 de junho de 2026, no horário de São Paulo.
      */
-    @Scheduled(cron = "0 15 16 1 6 *", zone = "America/Sao_Paulo")
-    public void collectFirstCycleAtSixteenFifteenOnJuneFirst2026() {
+    @Scheduled(cron = "0 15 18 1 6 *", zone = "America/Sao_Paulo")
+    public void collectFirstCycleAtEighteenFifteenOnJuneFirst2026() {
         if (!enabled) {
             log.info("Hotmart scheduler desabilitado por configuração.");
             return;
@@ -58,7 +58,7 @@ public class HotmartCollectorScheduler {
         }
         HotmartCollectionRequest request = new HotmartCollectionRequest(source, maxProducts);
         HotmartCollectionResponse response = collectorService.collectFirstCycle(request);
-        log.info("Hotmart scheduler executado hora=16:15 dia=01/06 ano=2026 "
+        log.info("Hotmart scheduler executado hora=18:15 dia=01/06 ano=2026 "
                         + "timezone=America/Sao_Paulo ciclo={} status={} produtos={} mensagem={}",
                 "CICLO_1_LISTAGEM",
                 response.status(),

--- a/mois-hotmart-collector/src/main/java/com/marketinghub/moishotmart/service/HotmartCollectorService.java
+++ b/mois-hotmart-collector/src/main/java/com/marketinghub/moishotmart/service/HotmartCollectorService.java
@@ -40,7 +40,7 @@ public class HotmartCollectorService {
     private static final int LOGIN_SUBMIT_RETRIES = 3;
     private static final int COOKIE_RETRY_ATTEMPTS = 3;
     static final int HOTMART_ROWS_PER_PAGE = 20;
-    static final int HOTMART_MAX_PAGES_PER_RUN = 20;
+    static final int HOTMART_MAX_PAGES_PER_RUN = 25;
     static final int HOTMART_MAX_PRODUCTS_PER_RUN = HOTMART_ROWS_PER_PAGE * HOTMART_MAX_PAGES_PER_RUN;
     private static final String HOTMART_MARKET_API_URL = "https://api-affiliation-market.hotmart.com/v2/market/search";
     private static final String HOTMART_PRODUCT_DETAILS_API_URL = "https://api-affiliation-market.hotmart.com/v1/market/product/%s/details?userSessionId=%s";

--- a/mois-hotmart-collector/src/main/resources/application.properties
+++ b/mois-hotmart-collector/src/main/resources/application.properties
@@ -20,8 +20,8 @@ collector.hotmart.password=FQ3nW5*c.KnrdLY
 collector.hotmart.username-fallback=paulofore@gmail.com
 collector.hotmart.password-fallback=FQ3nW5*c.KnrdLY
 
-# Automatic hourly execution
+# Automatic scheduler execution
 collector.scheduler.enabled=${COLLECTOR_SCHEDULER_ENABLED:true}
 collector.scheduler.cron=${COLLECTOR_SCHEDULER_CRON:0 0 * * * *}
 collector.scheduler.source=${COLLECTOR_SCHEDULER_SOURCE:hotmart-market}
-collector.scheduler.max-products=${COLLECTOR_SCHEDULER_MAX_PRODUCTS:400}
+collector.scheduler.max-products=${COLLECTOR_SCHEDULER_MAX_PRODUCTS:500}

--- a/mois-hotmart-collector/src/test/java/com/marketinghub/moishotmart/service/HotmartCollectorSchedulerTest.java
+++ b/mois-hotmart-collector/src/test/java/com/marketinghub/moishotmart/service/HotmartCollectorSchedulerTest.java
@@ -12,15 +12,15 @@ import org.springframework.scheduling.annotation.Scheduled;
 class HotmartCollectorSchedulerTest {
 
     /**
-     * Garante que o ciclo 1 esteja agendado para 16:15 de 1 de junho de 2026 no fuso de São Paulo.
+     * Garante que o ciclo 1 esteja agendado para 18:15 de 1 de junho de 2026 no fuso de São Paulo.
      */
     @Test
-    void shouldScheduleFirstCycleAtSixteenFifteenOnJuneFirst() throws NoSuchMethodException {
+    void shouldScheduleFirstCycleAtEighteenFifteenOnJuneFirst() throws NoSuchMethodException {
         Method method = HotmartCollectorScheduler.class
-                .getDeclaredMethod("collectFirstCycleAtSixteenFifteenOnJuneFirst2026");
+                .getDeclaredMethod("collectFirstCycleAtEighteenFifteenOnJuneFirst2026");
         Scheduled scheduled = method.getAnnotation(Scheduled.class);
 
-        assertEquals("0 15 16 1 6 *", scheduled.cron());
+        assertEquals("0 15 18 1 6 *", scheduled.cron());
         assertEquals("America/Sao_Paulo", scheduled.zone());
     }
 }

--- a/mois-hotmart-collector/src/test/java/com/marketinghub/moishotmart/service/HotmartCollectorServiceTest.java
+++ b/mois-hotmart-collector/src/test/java/com/marketinghub/moishotmart/service/HotmartCollectorServiceTest.java
@@ -53,13 +53,13 @@ class HotmartCollectorServiceTest {
     }
 
     /**
-     * Garante que o ciclo 1 esteja configurado para percorrer vinte páginas completas da Hotmart.
+     * Garante que o ciclo 1 esteja configurado para percorrer vinte e cinco páginas completas da Hotmart.
      */
     @Test
-    void shouldConfigureFirstCycleForTwentyHotmartPages() {
+    void shouldConfigureFirstCycleForTwentyFiveHotmartPages() {
         assertEquals(20, HotmartCollectorService.HOTMART_ROWS_PER_PAGE);
-        assertEquals(20, HotmartCollectorService.HOTMART_MAX_PAGES_PER_RUN);
-        assertEquals(400, HotmartCollectorService.HOTMART_MAX_PRODUCTS_PER_RUN);
+        assertEquals(25, HotmartCollectorService.HOTMART_MAX_PAGES_PER_RUN);
+        assertEquals(500, HotmartCollectorService.HOTMART_MAX_PRODUCTS_PER_RUN);
     }
 
 }


### PR DESCRIPTION
### Motivation

- Increase the operational target for the Hotmart cycle 1 collector to process more products per run (from 400 to 500) to broaden coverage of market search results.
- Align runtime configuration defaults and scheduler metadata with the increased target to avoid mismatches between code, configuration and documentation.
- Adjust the one-off scheduled execution time for cycle 1 to the agreed operational hour on 01/06/2026.

### Description

- Bumped `HOTMART_MAX_PAGES_PER_RUN` from `20` to `25` and updated `HOTMART_MAX_PRODUCTS_PER_RUN` accordingly in `HotmartCollectorService` so the run target becomes `25 * 20 = 500` products.
- Updated the default constructor value for `collector.scheduler.max-products` to `500` in `HotmartCollectorScheduler` and `application.properties` so the scheduler uses the new default limit.
- Changed the cycle 1 scheduled cron from `0 15 16 1 6 *` to `0 15 18 1 6 *` and renamed the scheduler method and log text to reflect the new `18:15` execution time in `HotmartCollectorScheduler`.
- Synchronized unit tests to the new behavior by updating `HotmartCollectorServiceTest` to assert `25` pages and `500` products and updating `HotmartCollectorSchedulerTest` to assert the new cron and method name.
- Updated canonical and operational docs (`docs/canonical/mois-hotmart-mapeamento-ciclos-campos-banco.md` and `docs/registros/mois1.md`) to reflect the new page/product target and the rescheduled execution time.

### Testing

- Ran the unit tests including `HotmartCollectorServiceTest` and `HotmartCollectorSchedulerTest`, and all updated assertions passed.
- Ran the full automated test suite (`mvn test`), and the suite completed successfully with no test failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1de834da8c8321affa141e8f5c34f1)