### PR TITLE
Implement EPM Sprint 2 — operational API, persistence fields, DTOs and tests

### DIFF
--- a/backend/ads-service/docs/epm-swagger.yaml
+++ b/backend/ads-service/docs/epm-swagger.yaml
@@ -1,0 +1,101 @@
+openapi: 3.0.3
+info:
+  title: EPM - Experiment Profit Manager API
+  version: 0.2.0
+  description: API operacional manual do EPM para planos financeiros, nichos, hipóteses, experimentos, métricas, decisões e cenários de preço.
+paths:
+  /api/epm/plans:
+    post:
+      summary: Cria plano financeiro
+      responses: { '201': { description: Plano criado } }
+    get:
+      summary: Lista planos financeiros
+      responses: { '200': { description: Lista de planos } }
+  /api/epm/plans/{planId}:
+    get:
+      summary: Busca plano financeiro
+      parameters: [ { name: planId, in: path, required: true, schema: { type: integer, format: int64 } } ]
+      responses: { '200': { description: Plano encontrado }, '404': { description: Plano inexistente } }
+    put:
+      summary: Atualiza plano financeiro
+      parameters: [ { name: planId, in: path, required: true, schema: { type: integer, format: int64 } } ]
+      responses: { '200': { description: Plano atualizado } }
+  /api/epm/plans/{planId}/niches:
+    post:
+      summary: Cria nicho financeiro no plano
+      parameters: [ { name: planId, in: path, required: true, schema: { type: integer, format: int64 } } ]
+      responses: { '201': { description: Nicho criado } }
+    get:
+      summary: Lista nichos financeiros do plano
+      parameters: [ { name: planId, in: path, required: true, schema: { type: integer, format: int64 } } ]
+      responses: { '200': { description: Lista de nichos } }
+  /api/epm/niches/{planNicheId}:
+    get:
+      summary: Busca nicho financeiro
+      parameters: [ { name: planNicheId, in: path, required: true, schema: { type: integer, format: int64 } } ]
+      responses: { '200': { description: Nicho encontrado } }
+  /api/epm/niches/{planNicheId}/hypotheses:
+    post:
+      summary: Cria hipótese financeira no nicho
+      parameters: [ { name: planNicheId, in: path, required: true, schema: { type: integer, format: int64 } } ]
+      responses: { '201': { description: Hipótese criada } }
+    get:
+      summary: Lista hipóteses financeiras do nicho
+      parameters: [ { name: planNicheId, in: path, required: true, schema: { type: integer, format: int64 } } ]
+      responses: { '200': { description: Lista de hipóteses } }
+  /api/epm/hypotheses/{planHypothesisId}:
+    get:
+      summary: Busca hipótese financeira
+      parameters: [ { name: planHypothesisId, in: path, required: true, schema: { type: integer, format: int64 } } ]
+      responses: { '200': { description: Hipótese encontrada } }
+  /api/epm/hypotheses/{planHypothesisId}/experiments:
+    post:
+      summary: Cria orçamento de experimento
+      parameters: [ { name: planHypothesisId, in: path, required: true, schema: { type: integer, format: int64 } } ]
+      responses: { '201': { description: Experimento criado } }
+    get:
+      summary: Lista orçamentos de experimento da hipótese
+      parameters: [ { name: planHypothesisId, in: path, required: true, schema: { type: integer, format: int64 } } ]
+      responses: { '200': { description: Lista de experimentos } }
+  /api/epm/experiments/{experimentBudgetId}:
+    get:
+      summary: Busca orçamento de experimento
+      parameters: [ { name: experimentBudgetId, in: path, required: true, schema: { type: integer, format: int64 } } ]
+      responses: { '200': { description: Experimento encontrado } }
+    put:
+      summary: Atualiza orçamento e gasto do experimento
+      parameters: [ { name: experimentBudgetId, in: path, required: true, schema: { type: integer, format: int64 } } ]
+      responses: { '200': { description: Experimento atualizado } }
+  /api/epm/experiments/{experimentBudgetId}/metrics:
+    post:
+      summary: Registra métricas manuais e calcula lucro, ROAS, CPL, CPA e conversões
+      parameters: [ { name: experimentBudgetId, in: path, required: true, schema: { type: integer, format: int64 } } ]
+      responses: { '201': { description: Métrica registrada } }
+  /api/epm/experiments/{experimentBudgetId}/metrics/latest:
+    get:
+      summary: Busca métrica manual mais recente
+      parameters: [ { name: experimentBudgetId, in: path, required: true, schema: { type: integer, format: int64 } } ]
+      responses: { '200': { description: Métrica encontrada }, '404': { description: Métrica inexistente } }
+  /api/epm/experiments/{experimentBudgetId}/decisions:
+    post:
+      summary: Registra decisão financeira
+      parameters: [ { name: experimentBudgetId, in: path, required: true, schema: { type: integer, format: int64 } } ]
+      responses: { '201': { description: Decisão criada } }
+    get:
+      summary: Lista decisões financeiras do experimento
+      parameters: [ { name: experimentBudgetId, in: path, required: true, schema: { type: integer, format: int64 } } ]
+      responses: { '200': { description: Lista de decisões } }
+  /api/epm/plans/{planId}/price-scenarios:
+    post:
+      summary: Cria cenário de preço e calcula vendas para empatar
+      parameters: [ { name: planId, in: path, required: true, schema: { type: integer, format: int64 } } ]
+      responses: { '201': { description: Cenário criado } }
+    get:
+      summary: Lista cenários de preço do plano
+      parameters: [ { name: planId, in: path, required: true, schema: { type: integer, format: int64 } } ]
+      responses: { '200': { description: Lista de cenários } }
+  /api/epm/plans/{planId}/summary:
+    get:
+      summary: Consolida resumo financeiro do plano
+      parameters: [ { name: planId, in: path, required: true, schema: { type: integer, format: int64 } } ]
+      responses: { '200': { description: Resumo do plano } }

--- a/backend/ads-service/src/main/java/com/marketinghub/epm/ExperimentBudget.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/epm/ExperimentBudget.java
@@ -41,6 +41,16 @@ public class ExperimentBudget {
     @Column(name = "planned_total_budget_cents", nullable = false)
     private Long plannedTotalBudgetCents;
 
+    @Column(name = "spend_limit_cents")
+    private Long spendLimitCents;
+
+    @Builder.Default
+    @Column(name = "actual_spend_cents")
+    private Long actualSpendCents = 0L;
+
+    @Column(name = "remaining_budget_cents")
+    private Long remainingBudgetCents;
+
     @Column(name = "start_date")
     private LocalDate startDate;
 

--- a/backend/ads-service/src/main/java/com/marketinghub/epm/ExperimentFinancialMetric.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/epm/ExperimentFinancialMetric.java
@@ -31,8 +31,20 @@ public class ExperimentFinancialMetric {
     @Column(nullable = false)
     private Integer visitors;
 
+    @Builder.Default
+    @Column(nullable = false)
+    private Long impressions = 0L;
+
+    @Builder.Default
+    @Column(nullable = false)
+    private Long clicks = 0L;
+
     @Column(nullable = false)
     private Integer leads;
+
+    @Builder.Default
+    @Column(name = "sample_requests", nullable = false)
+    private Integer sampleRequests = 0;
 
     @Column(name = "checkout_clicks", nullable = false)
     private Integer checkoutClicks;
@@ -63,6 +75,27 @@ public class ExperimentFinancialMetric {
 
     @Column(name = "estimated_net_profit_cents", nullable = false)
     private Long estimatedNetProfitCents;
+
+    @Column(name = "ctr_decimal", precision = 10, scale = 6)
+    private java.math.BigDecimal ctrDecimal;
+
+    @Column(name = "cpc_cents")
+    private Long cpcCents;
+
+    @Column(name = "cpl_cents")
+    private Long cplCents;
+
+    @Column(name = "cpa_cents")
+    private Long cpaCents;
+
+    @Column(name = "roas_decimal", precision = 10, scale = 4)
+    private java.math.BigDecimal roasDecimal;
+
+    @Column(name = "landing_conversion_decimal", precision = 10, scale = 6)
+    private java.math.BigDecimal landingConversionDecimal;
+
+    @Column(name = "purchase_conversion_decimal", precision = 10, scale = 6)
+    private java.math.BigDecimal purchaseConversionDecimal;
 
     @Column(columnDefinition = "TEXT")
     private String notes;

--- a/backend/ads-service/src/main/java/com/marketinghub/epm/controller/EpmController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/epm/controller/EpmController.java
@@ -1,0 +1,175 @@
+package com.marketinghub.epm.controller;
+
+import com.marketinghub.epm.service.EpmService;
+import com.marketinghub.epm.service.createExperimentBudget.CreateExperimentBudgetRequest;
+import com.marketinghub.epm.service.createExperimentDecision.CreateExperimentDecisionRequest;
+import com.marketinghub.epm.service.createExperimentMetric.CreateExperimentMetricRequest;
+import com.marketinghub.epm.service.createFinancialPlan.CreateFinancialPlanRequest;
+import com.marketinghub.epm.service.createPlanHypothesis.CreatePlanHypothesisRequest;
+import com.marketinghub.epm.service.createPlanNiche.CreatePlanNicheRequest;
+import com.marketinghub.epm.service.createProductPriceScenario.CreateProductPriceScenarioRequest;
+import com.marketinghub.epm.service.getExperimentBudget.ExperimentBudgetResponse;
+import com.marketinghub.epm.service.getFinancialPlan.FinancialPlanResponse;
+import com.marketinghub.epm.service.getFinancialPlanSummary.FinancialPlanSummaryResponse;
+import com.marketinghub.epm.service.getLatestExperimentMetric.ExperimentMetricResponse;
+import com.marketinghub.epm.service.getPlanHypothesis.FinancialPlanHypothesisResponse;
+import com.marketinghub.epm.service.getPlanNiche.FinancialPlanNicheResponse;
+import com.marketinghub.epm.service.listExperimentBudgets.ExperimentBudgetListResponse;
+import com.marketinghub.epm.service.listExperimentDecisions.ExperimentDecisionListResponse;
+import com.marketinghub.epm.service.listExperimentDecisions.ExperimentDecisionResponse;
+import com.marketinghub.epm.service.listFinancialPlans.FinancialPlanListResponse;
+import com.marketinghub.epm.service.listPlanHypotheses.FinancialPlanHypothesisListResponse;
+import com.marketinghub.epm.service.listPlanNiches.FinancialPlanNicheListResponse;
+import com.marketinghub.epm.service.listProductPriceScenarios.ProductPriceScenarioListResponse;
+import com.marketinghub.epm.service.listProductPriceScenarios.ProductPriceScenarioResponse;
+import com.marketinghub.epm.service.updateExperimentBudget.UpdateExperimentBudgetRequest;
+import com.marketinghub.epm.service.updateFinancialPlan.UpdateFinancialPlanRequest;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.validation.annotation.Validated;
+import org.springframework.web.bind.annotation.*;
+
+/**
+ * Expõe os endpoints operacionais do módulo EPM para planejamento, métricas, decisões e simulação financeira.
+ */
+@RestController
+@RequestMapping("/api/epm")
+@RequiredArgsConstructor
+@Validated
+public class EpmController {
+    private final EpmService epmService;
+
+    /** Cria um plano financeiro do EPM. */
+    @PostMapping("/plans")
+    @ResponseStatus(HttpStatus.CREATED)
+    public FinancialPlanResponse createFinancialPlan(@Valid @RequestBody CreateFinancialPlanRequest request) {
+        return epmService.createFinancialPlan(request);
+    }
+
+    /** Lista os planos financeiros do EPM. */
+    @GetMapping("/plans")
+    public FinancialPlanListResponse listFinancialPlans() {
+        return epmService.listFinancialPlans();
+    }
+
+    /** Busca um plano financeiro pelo identificador. */
+    @GetMapping("/plans/{planId}")
+    public FinancialPlanResponse getFinancialPlan(@PathVariable Long planId) {
+        return epmService.getFinancialPlan(planId);
+    }
+
+    /** Atualiza um plano financeiro existente. */
+    @PutMapping("/plans/{planId}")
+    public FinancialPlanResponse updateFinancialPlan(@PathVariable Long planId, @Valid @RequestBody UpdateFinancialPlanRequest request) {
+        return epmService.updateFinancialPlan(planId, request);
+    }
+
+    /** Cria um nicho financeiro dentro de um plano. */
+    @PostMapping("/plans/{planId}/niches")
+    @ResponseStatus(HttpStatus.CREATED)
+    public FinancialPlanNicheResponse createPlanNiche(@PathVariable Long planId, @Valid @RequestBody CreatePlanNicheRequest request) {
+        return epmService.createPlanNiche(planId, request);
+    }
+
+    /** Lista os nichos financeiros de um plano. */
+    @GetMapping("/plans/{planId}/niches")
+    public FinancialPlanNicheListResponse listPlanNiches(@PathVariable Long planId) {
+        return epmService.listPlanNiches(planId);
+    }
+
+    /** Busca um nicho financeiro pelo identificador. */
+    @GetMapping("/niches/{planNicheId}")
+    public FinancialPlanNicheResponse getPlanNiche(@PathVariable Long planNicheId) {
+        return epmService.getPlanNiche(planNicheId);
+    }
+
+    /** Cria uma hipótese financeira dentro de um nicho. */
+    @PostMapping("/niches/{planNicheId}/hypotheses")
+    @ResponseStatus(HttpStatus.CREATED)
+    public FinancialPlanHypothesisResponse createPlanHypothesis(@PathVariable Long planNicheId, @Valid @RequestBody CreatePlanHypothesisRequest request) {
+        return epmService.createPlanHypothesis(planNicheId, request);
+    }
+
+    /** Lista as hipóteses financeiras de um nicho. */
+    @GetMapping("/niches/{planNicheId}/hypotheses")
+    public FinancialPlanHypothesisListResponse listPlanHypotheses(@PathVariable Long planNicheId) {
+        return epmService.listPlanHypotheses(planNicheId);
+    }
+
+    /** Busca uma hipótese financeira pelo identificador. */
+    @GetMapping("/hypotheses/{planHypothesisId}")
+    public FinancialPlanHypothesisResponse getPlanHypothesis(@PathVariable Long planHypothesisId) {
+        return epmService.getPlanHypothesis(planHypothesisId);
+    }
+
+    /** Cria um orçamento de experimento dentro de uma hipótese. */
+    @PostMapping("/hypotheses/{planHypothesisId}/experiments")
+    @ResponseStatus(HttpStatus.CREATED)
+    public ExperimentBudgetResponse createExperimentBudget(@PathVariable Long planHypothesisId, @Valid @RequestBody CreateExperimentBudgetRequest request) {
+        return epmService.createExperimentBudget(planHypothesisId, request);
+    }
+
+    /** Lista os orçamentos de experimento de uma hipótese. */
+    @GetMapping("/hypotheses/{planHypothesisId}/experiments")
+    public ExperimentBudgetListResponse listExperimentBudgets(@PathVariable Long planHypothesisId) {
+        return epmService.listExperimentBudgets(planHypothesisId);
+    }
+
+    /** Busca um orçamento de experimento pelo identificador. */
+    @GetMapping("/experiments/{experimentBudgetId}")
+    public ExperimentBudgetResponse getExperimentBudget(@PathVariable Long experimentBudgetId) {
+        return epmService.getExperimentBudget(experimentBudgetId);
+    }
+
+    /** Atualiza orçamento, limite e gasto real de um experimento. */
+    @PutMapping("/experiments/{experimentBudgetId}")
+    public ExperimentBudgetResponse updateExperimentBudget(@PathVariable Long experimentBudgetId, @Valid @RequestBody UpdateExperimentBudgetRequest request) {
+        return epmService.updateExperimentBudget(experimentBudgetId, request);
+    }
+
+    /** Registra métricas manuais de um experimento. */
+    @PostMapping("/experiments/{experimentBudgetId}/metrics")
+    @ResponseStatus(HttpStatus.CREATED)
+    public ExperimentMetricResponse createExperimentMetric(@PathVariable Long experimentBudgetId, @Valid @RequestBody CreateExperimentMetricRequest request) {
+        return epmService.createExperimentMetric(experimentBudgetId, request);
+    }
+
+    /** Busca a métrica manual mais recente de um experimento. */
+    @GetMapping("/experiments/{experimentBudgetId}/metrics/latest")
+    public ExperimentMetricResponse getLatestExperimentMetric(@PathVariable Long experimentBudgetId) {
+        return epmService.getLatestExperimentMetric(experimentBudgetId);
+    }
+
+    /** Registra uma decisão financeira para um experimento. */
+    @PostMapping("/experiments/{experimentBudgetId}/decisions")
+    @ResponseStatus(HttpStatus.CREATED)
+    public ExperimentDecisionResponse createExperimentDecision(@PathVariable Long experimentBudgetId, @Valid @RequestBody CreateExperimentDecisionRequest request) {
+        return epmService.createExperimentDecision(experimentBudgetId, request);
+    }
+
+    /** Lista as decisões financeiras de um experimento. */
+    @GetMapping("/experiments/{experimentBudgetId}/decisions")
+    public ExperimentDecisionListResponse listExperimentDecisions(@PathVariable Long experimentBudgetId) {
+        return epmService.listExperimentDecisions(experimentBudgetId);
+    }
+
+    /** Cria cenário de preço e ponto de equilíbrio para um plano. */
+    @PostMapping("/plans/{planId}/price-scenarios")
+    @ResponseStatus(HttpStatus.CREATED)
+    public ProductPriceScenarioResponse createProductPriceScenario(@PathVariable Long planId, @Valid @RequestBody CreateProductPriceScenarioRequest request) {
+        return epmService.createProductPriceScenario(planId, request);
+    }
+
+    /** Lista cenários de preço e ponto de equilíbrio de um plano. */
+    @GetMapping("/plans/{planId}/price-scenarios")
+    public ProductPriceScenarioListResponse listProductPriceScenarios(@PathVariable Long planId) {
+        return epmService.listProductPriceScenarios(planId);
+    }
+
+    /** Busca o resumo financeiro consolidado de um plano. */
+    @GetMapping("/plans/{planId}/summary")
+    public FinancialPlanSummaryResponse getFinancialPlanSummary(@PathVariable Long planId) {
+        return epmService.getFinancialPlanSummary(planId);
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/epm/service/EpmService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/epm/service/EpmService.java
@@ -1,0 +1,385 @@
+package com.marketinghub.epm.service;
+
+import com.marketinghub.epm.*;
+import com.marketinghub.epm.service.createExperimentBudget.CreateExperimentBudgetRequest;
+import com.marketinghub.epm.service.createExperimentDecision.CreateExperimentDecisionRequest;
+import com.marketinghub.epm.service.createExperimentMetric.CreateExperimentMetricRequest;
+import com.marketinghub.epm.service.createFinancialPlan.CreateFinancialPlanRequest;
+import com.marketinghub.epm.service.createPlanHypothesis.CreatePlanHypothesisRequest;
+import com.marketinghub.epm.service.createPlanNiche.CreatePlanNicheRequest;
+import com.marketinghub.epm.service.createProductPriceScenario.CreateProductPriceScenarioRequest;
+import com.marketinghub.epm.service.getExperimentBudget.ExperimentBudgetResponse;
+import com.marketinghub.epm.service.getFinancialPlan.FinancialPlanResponse;
+import com.marketinghub.epm.service.getFinancialPlanSummary.FinancialPlanSummaryResponse;
+import com.marketinghub.epm.service.getLatestExperimentMetric.ExperimentMetricResponse;
+import com.marketinghub.epm.service.getPlanHypothesis.FinancialPlanHypothesisResponse;
+import com.marketinghub.epm.service.getPlanNiche.FinancialPlanNicheResponse;
+import com.marketinghub.epm.service.listExperimentBudgets.ExperimentBudgetListResponse;
+import com.marketinghub.epm.service.listExperimentDecisions.ExperimentDecisionListResponse;
+import com.marketinghub.epm.service.listExperimentDecisions.ExperimentDecisionResponse;
+import com.marketinghub.epm.service.listFinancialPlans.FinancialPlanListResponse;
+import com.marketinghub.epm.service.listPlanHypotheses.FinancialPlanHypothesisListResponse;
+import com.marketinghub.epm.service.listPlanNiches.FinancialPlanNicheListResponse;
+import com.marketinghub.epm.service.listProductPriceScenarios.ProductPriceScenarioListResponse;
+import com.marketinghub.epm.service.listProductPriceScenarios.ProductPriceScenarioResponse;
+import com.marketinghub.epm.service.updateExperimentBudget.UpdateExperimentBudgetRequest;
+import com.marketinghub.epm.service.updateFinancialPlan.UpdateFinancialPlanRequest;
+import com.marketinghub.repository.jpa.epm.*;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.Instant;
+import java.util.List;
+import java.util.Objects;
+
+import static org.springframework.http.HttpStatus.NOT_FOUND;
+
+/**
+ * Orquestra as operações manuais do Experiment Profit Manager com cálculos financeiros simples.
+ */
+@Service
+@RequiredArgsConstructor
+public class EpmService {
+    private final FinancialPlanRepository financialPlanRepository;
+    private final FinancialPlanNicheRepository financialPlanNicheRepository;
+    private final FinancialPlanHypothesisRepository financialPlanHypothesisRepository;
+    private final ExperimentBudgetRepository experimentBudgetRepository;
+    private final ExperimentFinancialMetricRepository experimentFinancialMetricRepository;
+    private final ExperimentFinancialDecisionRepository experimentFinancialDecisionRepository;
+    private final ProductPriceScenarioRepository productPriceScenarioRepository;
+
+    /** Cria um plano financeiro para controlar a verba de um ciclo de experimentos. */
+    @Transactional
+    public FinancialPlanResponse createFinancialPlan(CreateFinancialPlanRequest request) {
+        FinancialPlan plan = FinancialPlan.builder()
+                .name(request.name())
+                .cycleStartDate(request.cycleStartDate())
+                .cycleEndDate(request.cycleEndDate())
+                .totalBudgetCents(value(request.totalBudgetCents()))
+                .defaultDailyBudgetCents(request.defaultDailyBudgetCents())
+                .defaultExperimentDurationDays(request.defaultExperimentDurationDays())
+                .defaultExperimentsPerHypothesis(request.defaultExperimentsPerHypothesis())
+                .status(request.status() == null ? FinancialPlanStatus.DRAFT : request.status())
+                .notes(request.notes())
+                .build();
+        return toPlan(financialPlanRepository.save(plan));
+    }
+
+    /** Lista todos os planos financeiros existentes. */
+    @Transactional(readOnly = true)
+    public FinancialPlanListResponse listFinancialPlans() {
+        return new FinancialPlanListResponse(financialPlanRepository.findAll().stream().map(this::toPlan).toList());
+    }
+
+    /** Busca um plano financeiro pelo identificador. */
+    @Transactional(readOnly = true)
+    public FinancialPlanResponse getFinancialPlan(Long planId) {
+        return toPlan(findPlan(planId));
+    }
+
+    /** Atualiza os dados operacionais de um plano financeiro existente. */
+    @Transactional
+    public FinancialPlanResponse updateFinancialPlan(Long planId, UpdateFinancialPlanRequest request) {
+        FinancialPlan plan = findPlan(planId);
+        plan.setName(request.name());
+        plan.setCycleStartDate(request.cycleStartDate());
+        plan.setCycleEndDate(request.cycleEndDate());
+        plan.setTotalBudgetCents(value(request.totalBudgetCents()));
+        plan.setDefaultDailyBudgetCents(request.defaultDailyBudgetCents());
+        plan.setDefaultExperimentDurationDays(request.defaultExperimentDurationDays());
+        plan.setDefaultExperimentsPerHypothesis(request.defaultExperimentsPerHypothesis());
+        plan.setStatus(request.status() == null ? plan.getStatus() : request.status());
+        plan.setNotes(request.notes());
+        return toPlan(financialPlanRepository.save(plan));
+    }
+
+    /** Cria um nicho planejado dentro de um plano financeiro. */
+    @Transactional
+    public FinancialPlanNicheResponse createPlanNiche(Long planId, CreatePlanNicheRequest request) {
+        FinancialPlanNiche niche = FinancialPlanNiche.builder()
+                .financialPlan(findPlan(planId))
+                .externalNicheId(request.externalNicheId())
+                .nicheName(request.nicheName())
+                .plannedBudgetCents(value(request.plannedBudgetCents()))
+                .spendLimitCents(request.spendLimitCents() == null ? value(request.plannedBudgetCents()) : value(request.spendLimitCents()))
+                .status(request.status() == null ? FinancialPlanNicheStatus.PLANNED : request.status())
+                .notes(request.notes())
+                .build();
+        return toNiche(financialPlanNicheRepository.save(niche));
+    }
+
+    /** Lista os nichos planejados de um plano financeiro. */
+    @Transactional(readOnly = true)
+    public FinancialPlanNicheListResponse listPlanNiches(Long planId) {
+        findPlan(planId);
+        return new FinancialPlanNicheListResponse(financialPlanNicheRepository.findByFinancialPlanIdOrderByIdAsc(planId).stream().map(this::toNiche).toList());
+    }
+
+    /** Busca um nicho planejado pelo identificador. */
+    @Transactional(readOnly = true)
+    public FinancialPlanNicheResponse getPlanNiche(Long planNicheId) {
+        return toNiche(findNiche(planNicheId));
+    }
+
+    /** Cria uma hipótese financeira dentro de um nicho planejado. */
+    @Transactional
+    public FinancialPlanHypothesisResponse createPlanHypothesis(Long planNicheId, CreatePlanHypothesisRequest request) {
+        FinancialPlanNiche niche = findNiche(planNicheId);
+        long costPerExperiment = request.plannedCostPerExperimentCents() == null ? 0L : request.plannedCostPerExperimentCents();
+        long lossLimit = request.lossLimitCents() == null ? costPerExperiment * request.plannedExperiments() : request.lossLimitCents();
+        FinancialPlanHypothesis hypothesis = FinancialPlanHypothesis.builder()
+                .financialPlanNiche(niche)
+                .externalHypothesisId(request.externalHypothesisId())
+                .title(request.title())
+                .plannedExperiments(request.plannedExperiments())
+                .plannedCostPerExperimentCents(costPerExperiment)
+                .lossLimitCents(lossLimit)
+                .status(request.status() == null ? FinancialPlanHypothesisStatus.PLANNED : request.status())
+                .notes(request.notes())
+                .build();
+        return toHypothesis(financialPlanHypothesisRepository.save(hypothesis));
+    }
+
+    /** Lista as hipóteses financeiras de um nicho planejado. */
+    @Transactional(readOnly = true)
+    public FinancialPlanHypothesisListResponse listPlanHypotheses(Long planNicheId) {
+        findNiche(planNicheId);
+        return new FinancialPlanHypothesisListResponse(financialPlanHypothesisRepository.findByFinancialPlanNicheIdOrderByIdAsc(planNicheId).stream().map(this::toHypothesis).toList());
+    }
+
+    /** Busca uma hipótese financeira pelo identificador. */
+    @Transactional(readOnly = true)
+    public FinancialPlanHypothesisResponse getPlanHypothesis(Long planHypothesisId) {
+        return toHypothesis(findHypothesis(planHypothesisId));
+    }
+
+    /** Cria um orçamento para executar experimento financeiro dentro de uma hipótese. */
+    @Transactional
+    public ExperimentBudgetResponse createExperimentBudget(Long planHypothesisId, CreateExperimentBudgetRequest request) {
+        long plannedTotal = value(request.plannedDailyBudgetCents()) * request.plannedDurationDays();
+        long spendLimit = request.spendLimitCents() == null ? plannedTotal : value(request.spendLimitCents());
+        ExperimentBudget budget = ExperimentBudget.builder()
+                .financialPlanHypothesis(findHypothesis(planHypothesisId))
+                .externalExperimentId(request.externalExperimentId())
+                .name(request.name())
+                .plannedDailyBudgetCents(value(request.plannedDailyBudgetCents()))
+                .plannedDurationDays(request.plannedDurationDays())
+                .plannedTotalBudgetCents(plannedTotal)
+                .spendLimitCents(spendLimit)
+                .actualSpendCents(0L)
+                .remainingBudgetCents(spendLimit)
+                .startDate(request.startDate())
+                .endDate(request.endDate())
+                .status(request.status() == null ? ExperimentBudgetStatus.PLANNED : request.status())
+                .notes(request.notes())
+                .build();
+        return toBudget(experimentBudgetRepository.save(budget));
+    }
+
+    /** Lista os orçamentos de experimento de uma hipótese financeira. */
+    @Transactional(readOnly = true)
+    public ExperimentBudgetListResponse listExperimentBudgets(Long planHypothesisId) {
+        findHypothesis(planHypothesisId);
+        return new ExperimentBudgetListResponse(experimentBudgetRepository.findByFinancialPlanHypothesisIdOrderByIdAsc(planHypothesisId).stream().map(this::toBudget).toList());
+    }
+
+    /** Busca um orçamento de experimento pelo identificador. */
+    @Transactional(readOnly = true)
+    public ExperimentBudgetResponse getExperimentBudget(Long experimentBudgetId) {
+        return toBudget(findBudget(experimentBudgetId));
+    }
+
+    /** Atualiza orçamento e gasto real de um experimento financeiro. */
+    @Transactional
+    public ExperimentBudgetResponse updateExperimentBudget(Long experimentBudgetId, UpdateExperimentBudgetRequest request) {
+        ExperimentBudget budget = findBudget(experimentBudgetId);
+        long plannedTotal = value(request.plannedDailyBudgetCents()) * request.plannedDurationDays();
+        long spendLimit = request.spendLimitCents() == null ? plannedTotal : value(request.spendLimitCents());
+        long actualSpend = value(request.actualSpendCents());
+        budget.setExternalExperimentId(request.externalExperimentId());
+        budget.setName(request.name());
+        budget.setPlannedDailyBudgetCents(value(request.plannedDailyBudgetCents()));
+        budget.setPlannedDurationDays(request.plannedDurationDays());
+        budget.setPlannedTotalBudgetCents(plannedTotal);
+        budget.setSpendLimitCents(spendLimit);
+        budget.setActualSpendCents(actualSpend);
+        budget.setRemainingBudgetCents(spendLimit - actualSpend);
+        budget.setStartDate(request.startDate());
+        budget.setEndDate(request.endDate());
+        budget.setStatus(request.status() == null ? budget.getStatus() : request.status());
+        budget.setNotes(request.notes());
+        return toBudget(experimentBudgetRepository.save(budget));
+    }
+
+    /** Registra métricas manuais e calcula lucro, ROAS, CPL, CPA e conversões. */
+    @Transactional
+    public ExperimentMetricResponse createExperimentMetric(Long experimentBudgetId, CreateExperimentMetricRequest request) {
+        ExperimentBudget budget = findBudget(experimentBudgetId);
+        long adSpend = value(request.adSpendCents());
+        long revenue = value(request.revenueCents());
+        long grossProfit = revenue - adSpend;
+        long netProfit = grossProfit - value(request.paymentFeeCents()) - value(request.platformFeeCents()) - value(request.aiCostCents()) - value(request.taxEstimateCents());
+        ExperimentFinancialMetric metric = ExperimentFinancialMetric.builder()
+                .experimentBudget(budget)
+                .measuredAt(request.measuredAt() == null ? Instant.now() : request.measuredAt())
+                .impressions(value(request.impressions()))
+                .clicks(value(request.clicks()))
+                .visitors(request.visitors() == null ? 0 : request.visitors())
+                .leads(request.leads() == null ? 0 : request.leads())
+                .sampleRequests(request.sampleRequests() == null ? 0 : request.sampleRequests())
+                .checkoutClicks(request.checkoutClicks() == null ? 0 : request.checkoutClicks())
+                .purchases(request.purchases() == null ? 0 : request.purchases())
+                .adSpendCents(adSpend)
+                .revenueCents(revenue)
+                .paymentFeeCents(value(request.paymentFeeCents()))
+                .platformFeeCents(value(request.platformFeeCents()))
+                .aiCostCents(value(request.aiCostCents()))
+                .taxEstimateCents(value(request.taxEstimateCents()))
+                .grossProfitCents(grossProfit)
+                .estimatedNetProfitCents(netProfit)
+                .ctrDecimal(ratio(value(request.clicks()), value(request.impressions()), 6))
+                .cpcCents(centsPer(adSpend, value(request.clicks())))
+                .cplCents(centsPer(adSpend, request.leads() == null ? 0 : request.leads()))
+                .cpaCents(centsPer(adSpend, request.purchases() == null ? 0 : request.purchases()))
+                .roasDecimal(ratio(revenue, adSpend, 4))
+                .landingConversionDecimal(ratio(request.leads() == null ? 0 : request.leads(), request.visitors() == null ? 0 : request.visitors(), 6))
+                .purchaseConversionDecimal(ratio(request.purchases() == null ? 0 : request.purchases(), request.visitors() == null ? 0 : request.visitors(), 6))
+                .notes(request.notes())
+                .build();
+        budget.setActualSpendCents(adSpend);
+        budget.setRemainingBudgetCents(value(budget.getSpendLimitCents()) - adSpend);
+        experimentBudgetRepository.save(budget);
+        return toMetric(experimentFinancialMetricRepository.save(metric));
+    }
+
+    /** Busca a métrica manual mais recente de um experimento. */
+    @Transactional(readOnly = true)
+    public ExperimentMetricResponse getLatestExperimentMetric(Long experimentBudgetId) {
+        findBudget(experimentBudgetId);
+        return experimentFinancialMetricRepository.findFirstByExperimentBudgetIdOrderByMeasuredAtDesc(experimentBudgetId).map(this::toMetric).orElseThrow(() -> notFound("Métrica financeira não encontrada"));
+    }
+
+    /** Registra uma decisão financeira para um experimento. */
+    @Transactional
+    public ExperimentDecisionResponse createExperimentDecision(Long experimentBudgetId, CreateExperimentDecisionRequest request) {
+        ExperimentFinancialDecision decision = ExperimentFinancialDecision.builder()
+                .experimentBudget(findBudget(experimentBudgetId))
+                .decisionType(request.decisionType())
+                .reason(request.reason())
+                .decidedAt(request.decidedAt() == null ? Instant.now() : request.decidedAt())
+                .decidedBy(request.decidedBy())
+                .build();
+        return toDecision(experimentFinancialDecisionRepository.save(decision));
+    }
+
+    /** Lista as decisões financeiras registradas para um experimento. */
+    @Transactional(readOnly = true)
+    public ExperimentDecisionListResponse listExperimentDecisions(Long experimentBudgetId) {
+        findBudget(experimentBudgetId);
+        return new ExperimentDecisionListResponse(experimentFinancialDecisionRepository.findByExperimentBudgetIdOrderByDecidedAtDesc(experimentBudgetId).stream().map(this::toDecision).toList());
+    }
+
+    /** Cria um cenário de preço calculando receita líquida por venda e vendas para empatar. */
+    @Transactional
+    public ProductPriceScenarioResponse createProductPriceScenario(Long planId, CreateProductPriceScenarioRequest request) {
+        FinancialPlan plan = findPlan(planId);
+        long totalBudget = request.totalBudgetCents() == null ? value(plan.getTotalBudgetCents()) : value(request.totalBudgetCents());
+        long netRevenue = value(request.priceCents()) - value(request.expectedPaymentFeeCents()) - value(request.expectedPlatformFeeCents()) - value(request.expectedTaxCents());
+        ProductPriceScenario scenario = ProductPriceScenario.builder()
+                .financialPlan(plan)
+                .name(request.name())
+                .priceCents(value(request.priceCents()))
+                .expectedPaymentFeeCents(value(request.expectedPaymentFeeCents()))
+                .expectedPlatformFeeCents(value(request.expectedPlatformFeeCents()))
+                .expectedTaxCents(value(request.expectedTaxCents()))
+                .expectedNetRevenuePerSaleCents(netRevenue)
+                .totalBudgetCents(totalBudget)
+                .breakEvenSales(ceilSales(totalBudget, netRevenue))
+                .notes(request.notes())
+                .build();
+        return toScenario(productPriceScenarioRepository.save(scenario));
+    }
+
+    /** Lista os cenários de preço de um plano financeiro. */
+    @Transactional(readOnly = true)
+    public ProductPriceScenarioListResponse listProductPriceScenarios(Long planId) {
+        findPlan(planId);
+        return new ProductPriceScenarioListResponse(productPriceScenarioRepository.findByFinancialPlanIdOrderByIdAsc(planId).stream().map(this::toScenario).toList());
+    }
+
+    /** Consolida o resumo financeiro de um plano com base nos experimentos e métricas manuais. */
+    @Transactional(readOnly = true)
+    public FinancialPlanSummaryResponse getFinancialPlanSummary(Long planId) {
+        FinancialPlan plan = findPlan(planId);
+        List<FinancialPlanNiche> niches = financialPlanNicheRepository.findByFinancialPlanIdOrderByIdAsc(planId);
+        List<FinancialPlanHypothesis> hypotheses = niches.stream().flatMap(n -> financialPlanHypothesisRepository.findByFinancialPlanNicheIdOrderByIdAsc(n.getId()).stream()).toList();
+        List<ExperimentBudget> budgets = hypotheses.stream().flatMap(h -> experimentBudgetRepository.findByFinancialPlanHypothesisIdOrderByIdAsc(h.getId()).stream()).toList();
+        List<ExperimentFinancialMetric> latestMetrics = budgets.stream().map(b -> experimentFinancialMetricRepository.findFirstByExperimentBudgetIdOrderByMeasuredAtDesc(b.getId()).orElse(null)).filter(Objects::nonNull).toList();
+        long actualSpend = latestMetrics.stream().mapToLong(ExperimentFinancialMetric::getAdSpendCents).sum();
+        long revenue = latestMetrics.stream().mapToLong(ExperimentFinancialMetric::getRevenueCents).sum();
+        long grossProfit = latestMetrics.stream().mapToLong(ExperimentFinancialMetric::getGrossProfitCents).sum();
+        long netProfit = latestMetrics.stream().mapToLong(ExperimentFinancialMetric::getEstimatedNetProfitCents).sum();
+        int withPurchase = (int) latestMetrics.stream().filter(m -> m.getPurchases() > 0).count();
+        int withoutSignal = (int) latestMetrics.stream().filter(m -> m.getPurchases() == 0 && m.getLeads() == 0 && m.getCheckoutClicks() == 0).count();
+        long plannedExperimentBudget = budgets.stream().mapToLong(ExperimentBudget::getPlannedTotalBudgetCents).sum();
+        return new FinancialPlanSummaryResponse(planId, plan.getTotalBudgetCents(), plannedExperimentBudget, actualSpend, revenue, grossProfit, netProfit, niches.size(), hypotheses.size(), budgets.size(), withPurchase, withoutSignal);
+    }
+
+    /** Converte plano financeiro em DTO de resposta. */
+    private FinancialPlanResponse toPlan(FinancialPlan plan) {
+        return new FinancialPlanResponse(plan.getId(), plan.getName(), plan.getCycleStartDate(), plan.getCycleEndDate(), plan.getTotalBudgetCents(), plan.getDefaultDailyBudgetCents(), plan.getDefaultExperimentDurationDays(), plan.getDefaultExperimentsPerHypothesis(), plan.getStatus(), plan.getNotes(), plan.getCreatedAt(), plan.getUpdatedAt());
+    }
+
+    /** Converte nicho financeiro em DTO de resposta. */
+    private FinancialPlanNicheResponse toNiche(FinancialPlanNiche niche) {
+        return new FinancialPlanNicheResponse(niche.getId(), niche.getFinancialPlan().getId(), niche.getExternalNicheId(), niche.getNicheName(), niche.getPlannedBudgetCents(), niche.getSpendLimitCents(), niche.getStatus(), niche.getNotes(), niche.getCreatedAt(), niche.getUpdatedAt());
+    }
+
+    /** Converte hipótese financeira em DTO de resposta. */
+    private FinancialPlanHypothesisResponse toHypothesis(FinancialPlanHypothesis hypothesis) {
+        return new FinancialPlanHypothesisResponse(hypothesis.getId(), hypothesis.getFinancialPlanNiche().getId(), hypothesis.getExternalHypothesisId(), hypothesis.getTitle(), hypothesis.getPlannedExperiments(), hypothesis.getPlannedCostPerExperimentCents(), hypothesis.getLossLimitCents(), hypothesis.getStatus(), hypothesis.getNotes(), hypothesis.getCreatedAt(), hypothesis.getUpdatedAt());
+    }
+
+    /** Converte orçamento de experimento em DTO de resposta. */
+    private ExperimentBudgetResponse toBudget(ExperimentBudget budget) {
+        return new ExperimentBudgetResponse(budget.getId(), budget.getFinancialPlanHypothesis().getId(), budget.getExternalExperimentId(), budget.getName(), budget.getPlannedDailyBudgetCents(), budget.getPlannedDurationDays(), budget.getPlannedTotalBudgetCents(), budget.getSpendLimitCents(), budget.getActualSpendCents(), budget.getRemainingBudgetCents(), budget.getStartDate(), budget.getEndDate(), budget.getStatus(), budget.getNotes(), budget.getCreatedAt(), budget.getUpdatedAt());
+    }
+
+    /** Converte métrica financeira em DTO de resposta. */
+    private ExperimentMetricResponse toMetric(ExperimentFinancialMetric metric) {
+        return new ExperimentMetricResponse(metric.getId(), metric.getExperimentBudget().getId(), metric.getMeasuredAt(), metric.getImpressions(), metric.getClicks(), metric.getVisitors(), metric.getLeads(), metric.getSampleRequests(), metric.getCheckoutClicks(), metric.getPurchases(), metric.getAdSpendCents(), metric.getRevenueCents(), metric.getPaymentFeeCents(), metric.getPlatformFeeCents(), metric.getAiCostCents(), metric.getTaxEstimateCents(), metric.getGrossProfitCents(), metric.getEstimatedNetProfitCents(), metric.getCtrDecimal(), metric.getCpcCents(), metric.getCplCents(), metric.getCpaCents(), metric.getRoasDecimal(), metric.getLandingConversionDecimal(), metric.getPurchaseConversionDecimal(), metric.getNotes(), metric.getCreatedAt());
+    }
+
+    /** Converte decisão financeira em DTO de resposta. */
+    private ExperimentDecisionResponse toDecision(ExperimentFinancialDecision decision) {
+        return new ExperimentDecisionResponse(decision.getId(), decision.getExperimentBudget().getId(), decision.getDecisionType(), decision.getReason(), decision.getDecidedAt(), decision.getDecidedBy(), decision.getCreatedAt());
+    }
+
+    /** Converte cenário de preço em DTO de resposta. */
+    private ProductPriceScenarioResponse toScenario(ProductPriceScenario scenario) {
+        return new ProductPriceScenarioResponse(scenario.getId(), scenario.getFinancialPlan().getId(), scenario.getName(), scenario.getPriceCents(), scenario.getExpectedPaymentFeeCents(), scenario.getExpectedPlatformFeeCents(), scenario.getExpectedTaxCents(), scenario.getExpectedNetRevenuePerSaleCents(), scenario.getTotalBudgetCents(), scenario.getBreakEvenSales(), scenario.getNotes(), scenario.getCreatedAt(), scenario.getUpdatedAt());
+    }
+
+    /** Busca plano financeiro ou retorna erro HTTP 404. */
+    private FinancialPlan findPlan(Long id) { return financialPlanRepository.findById(id).orElseThrow(() -> notFound("Plano financeiro não encontrado")); }
+    /** Busca nicho financeiro ou retorna erro HTTP 404. */
+    private FinancialPlanNiche findNiche(Long id) { return financialPlanNicheRepository.findById(id).orElseThrow(() -> notFound("Nicho financeiro não encontrado")); }
+    /** Busca hipótese financeira ou retorna erro HTTP 404. */
+    private FinancialPlanHypothesis findHypothesis(Long id) { return financialPlanHypothesisRepository.findById(id).orElseThrow(() -> notFound("Hipótese financeira não encontrada")); }
+    /** Busca orçamento de experimento ou retorna erro HTTP 404. */
+    private ExperimentBudget findBudget(Long id) { return experimentBudgetRepository.findById(id).orElseThrow(() -> notFound("Orçamento de experimento não encontrado")); }
+    /** Cria erro padronizado de recurso inexistente. */
+    private ResponseStatusException notFound(String message) { return new ResponseStatusException(NOT_FOUND, message); }
+    /** Normaliza valores nulos para zero. */
+    private long value(Number value) { return value == null ? 0L : value.longValue(); }
+    /** Calcula proporção decimal ou retorna nulo quando o denominador é zero. */
+    private BigDecimal ratio(long numerator, long denominator, int scale) { return denominator == 0 ? null : BigDecimal.valueOf(numerator).divide(BigDecimal.valueOf(denominator), scale, RoundingMode.HALF_UP); }
+    /** Calcula custo médio em centavos ou retorna nulo quando a quantidade é zero. */
+    private Long centsPer(long cents, long quantity) { return quantity == 0 ? null : BigDecimal.valueOf(cents).divide(BigDecimal.valueOf(quantity), 0, RoundingMode.HALF_UP).longValue(); }
+    /** Calcula vendas necessárias para empatar com arredondamento para cima. */
+    private int ceilSales(long totalBudget, long netRevenuePerSale) { return netRevenuePerSale <= 0 ? 0 : BigDecimal.valueOf(totalBudget).divide(BigDecimal.valueOf(netRevenuePerSale), 0, RoundingMode.CEILING).intValue(); }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/epm/service/createExperimentBudget/CreateExperimentBudgetRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/epm/service/createExperimentBudget/CreateExperimentBudgetRequest.java
@@ -1,0 +1,8 @@
+package com.marketinghub.epm.service.createExperimentBudget;
+
+import com.marketinghub.epm.ExperimentBudgetStatus;
+import jakarta.validation.constraints.*;
+import java.time.LocalDate;
+
+/** Dados para criar um orçamento de experimento do EPM. */
+public record CreateExperimentBudgetRequest(Long externalExperimentId, @NotBlank String name, @NotNull @PositiveOrZero Long plannedDailyBudgetCents, @NotNull @Positive Integer plannedDurationDays, Long spendLimitCents, LocalDate startDate, LocalDate endDate, ExperimentBudgetStatus status, String notes) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/epm/service/createExperimentDecision/CreateExperimentDecisionRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/epm/service/createExperimentDecision/CreateExperimentDecisionRequest.java
@@ -1,0 +1,8 @@
+package com.marketinghub.epm.service.createExperimentDecision;
+
+import com.marketinghub.epm.ExperimentFinancialDecisionType;
+import jakarta.validation.constraints.*;
+import java.time.Instant;
+
+/** Dados para registrar uma decisão financeira sobre um experimento. */
+public record CreateExperimentDecisionRequest(@NotNull ExperimentFinancialDecisionType decisionType, @NotBlank String reason, Instant decidedAt, String decidedBy) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/epm/service/createExperimentMetric/CreateExperimentMetricRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/epm/service/createExperimentMetric/CreateExperimentMetricRequest.java
@@ -1,0 +1,7 @@
+package com.marketinghub.epm.service.createExperimentMetric;
+
+import jakarta.validation.constraints.*;
+import java.time.Instant;
+
+/** Dados manuais para registrar métricas financeiras de um experimento. */
+public record CreateExperimentMetricRequest(Instant measuredAt, Long impressions, Long clicks, Integer visitors, Integer leads, Integer sampleRequests, Integer checkoutClicks, Integer purchases, Long adSpendCents, Long revenueCents, Long paymentFeeCents, Long platformFeeCents, Long aiCostCents, Long taxEstimateCents, String notes) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/epm/service/createFinancialPlan/CreateFinancialPlanRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/epm/service/createFinancialPlan/CreateFinancialPlanRequest.java
@@ -1,0 +1,8 @@
+package com.marketinghub.epm.service.createFinancialPlan;
+
+import com.marketinghub.epm.FinancialPlanStatus;
+import jakarta.validation.constraints.*;
+import java.time.LocalDate;
+
+/** Dados para criar um plano financeiro do EPM. */
+public record CreateFinancialPlanRequest(@NotBlank String name, @NotNull LocalDate cycleStartDate, @NotNull LocalDate cycleEndDate, @NotNull @PositiveOrZero Long totalBudgetCents, Long defaultDailyBudgetCents, Integer defaultExperimentDurationDays, Integer defaultExperimentsPerHypothesis, FinancialPlanStatus status, String notes) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/epm/service/createPlanHypothesis/CreatePlanHypothesisRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/epm/service/createPlanHypothesis/CreatePlanHypothesisRequest.java
@@ -1,0 +1,7 @@
+package com.marketinghub.epm.service.createPlanHypothesis;
+
+import com.marketinghub.epm.FinancialPlanHypothesisStatus;
+import jakarta.validation.constraints.*;
+
+/** Dados para criar uma hipótese financeira dentro de um nicho do EPM. */
+public record CreatePlanHypothesisRequest(String externalHypothesisId, @NotBlank String title, @NotNull @Positive Integer plannedExperiments, Long plannedCostPerExperimentCents, Long lossLimitCents, FinancialPlanHypothesisStatus status, String notes) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/epm/service/createPlanNiche/CreatePlanNicheRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/epm/service/createPlanNiche/CreatePlanNicheRequest.java
@@ -1,0 +1,7 @@
+package com.marketinghub.epm.service.createPlanNiche;
+
+import com.marketinghub.epm.FinancialPlanNicheStatus;
+import jakarta.validation.constraints.*;
+
+/** Dados para criar um nicho financeiro dentro de um plano do EPM. */
+public record CreatePlanNicheRequest(Long externalNicheId, @NotBlank String nicheName, @NotNull @PositiveOrZero Long plannedBudgetCents, Long spendLimitCents, FinancialPlanNicheStatus status, String notes) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/epm/service/createProductPriceScenario/CreateProductPriceScenarioRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/epm/service/createProductPriceScenario/CreateProductPriceScenarioRequest.java
@@ -1,0 +1,6 @@
+package com.marketinghub.epm.service.createProductPriceScenario;
+
+import jakarta.validation.constraints.*;
+
+/** Dados para criar um cenário de preço e ponto de equilíbrio do EPM. */
+public record CreateProductPriceScenarioRequest(@NotBlank String name, @NotNull @Positive Long priceCents, Long expectedPaymentFeeCents, Long expectedPlatformFeeCents, Long expectedTaxCents, Long totalBudgetCents, String notes) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/epm/service/getExperimentBudget/ExperimentBudgetResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/epm/service/getExperimentBudget/ExperimentBudgetResponse.java
@@ -1,0 +1,7 @@
+package com.marketinghub.epm.service.getExperimentBudget;
+
+import com.marketinghub.epm.ExperimentBudgetStatus;
+import java.time.*;
+
+/** Resposta com os dados de um orçamento de experimento do EPM. */
+public record ExperimentBudgetResponse(Long id, Long financialPlanHypothesisId, Long externalExperimentId, String name, Long plannedDailyBudgetCents, Integer plannedDurationDays, Long plannedTotalBudgetCents, Long spendLimitCents, Long actualSpendCents, Long remainingBudgetCents, LocalDate startDate, LocalDate endDate, ExperimentBudgetStatus status, String notes, Instant createdAt, Instant updatedAt) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/epm/service/getFinancialPlan/FinancialPlanResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/epm/service/getFinancialPlan/FinancialPlanResponse.java
@@ -1,0 +1,7 @@
+package com.marketinghub.epm.service.getFinancialPlan;
+
+import com.marketinghub.epm.FinancialPlanStatus;
+import java.time.*;
+
+/** Resposta com os dados básicos de um plano financeiro do EPM. */
+public record FinancialPlanResponse(Long id, String name, LocalDate cycleStartDate, LocalDate cycleEndDate, Long totalBudgetCents, Long defaultDailyBudgetCents, Integer defaultExperimentDurationDays, Integer defaultExperimentsPerHypothesis, FinancialPlanStatus status, String notes, Instant createdAt, Instant updatedAt) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/epm/service/getFinancialPlanSummary/FinancialPlanSummaryResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/epm/service/getFinancialPlanSummary/FinancialPlanSummaryResponse.java
@@ -1,0 +1,4 @@
+package com.marketinghub.epm.service.getFinancialPlanSummary;
+
+/** Resposta consolidada com métricas financeiras operacionais de um plano EPM. */
+public record FinancialPlanSummaryResponse(Long planId, Long totalBudgetCents, Long plannedExperimentBudgetCents, Long actualSpendCents, Long revenueCents, Long grossProfitCents, Long estimatedNetProfitCents, Integer niches, Integer hypotheses, Integer experiments, Integer experimentsWithPurchase, Integer experimentsWithoutSignal) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/epm/service/getLatestExperimentMetric/ExperimentMetricResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/epm/service/getLatestExperimentMetric/ExperimentMetricResponse.java
@@ -1,0 +1,7 @@
+package com.marketinghub.epm.service.getLatestExperimentMetric;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+
+/** Resposta com métricas financeiras calculadas de um experimento. */
+public record ExperimentMetricResponse(Long id, Long experimentBudgetId, Instant measuredAt, Long impressions, Long clicks, Integer visitors, Integer leads, Integer sampleRequests, Integer checkoutClicks, Integer purchases, Long adSpendCents, Long revenueCents, Long paymentFeeCents, Long platformFeeCents, Long aiCostCents, Long taxEstimateCents, Long grossProfitCents, Long estimatedNetProfitCents, BigDecimal ctrDecimal, Long cpcCents, Long cplCents, Long cpaCents, BigDecimal roasDecimal, BigDecimal landingConversionDecimal, BigDecimal purchaseConversionDecimal, String notes, Instant createdAt) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/epm/service/getPlanHypothesis/FinancialPlanHypothesisResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/epm/service/getPlanHypothesis/FinancialPlanHypothesisResponse.java
@@ -1,0 +1,7 @@
+package com.marketinghub.epm.service.getPlanHypothesis;
+
+import com.marketinghub.epm.FinancialPlanHypothesisStatus;
+import java.time.Instant;
+
+/** Resposta com os dados de uma hipótese financeira planejada. */
+public record FinancialPlanHypothesisResponse(Long id, Long financialPlanNicheId, String externalHypothesisId, String title, Integer plannedExperiments, Long plannedCostPerExperimentCents, Long lossLimitCents, FinancialPlanHypothesisStatus status, String notes, Instant createdAt, Instant updatedAt) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/epm/service/getPlanNiche/FinancialPlanNicheResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/epm/service/getPlanNiche/FinancialPlanNicheResponse.java
@@ -1,0 +1,7 @@
+package com.marketinghub.epm.service.getPlanNiche;
+
+import com.marketinghub.epm.FinancialPlanNicheStatus;
+import java.time.Instant;
+
+/** Resposta com os dados de um nicho financeiro planejado. */
+public record FinancialPlanNicheResponse(Long id, Long financialPlanId, Long externalNicheId, String nicheName, Long plannedBudgetCents, Long spendLimitCents, FinancialPlanNicheStatus status, String notes, Instant createdAt, Instant updatedAt) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/epm/service/listExperimentBudgets/ExperimentBudgetListResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/epm/service/listExperimentBudgets/ExperimentBudgetListResponse.java
@@ -1,0 +1,7 @@
+package com.marketinghub.epm.service.listExperimentBudgets;
+
+import com.marketinghub.epm.service.getExperimentBudget.ExperimentBudgetResponse;
+import java.util.List;
+
+/** Resposta com os orçamentos de experimento de uma hipótese. */
+public record ExperimentBudgetListResponse(List<ExperimentBudgetResponse> experiments) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/epm/service/listExperimentDecisions/ExperimentDecisionListResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/epm/service/listExperimentDecisions/ExperimentDecisionListResponse.java
@@ -1,0 +1,6 @@
+package com.marketinghub.epm.service.listExperimentDecisions;
+
+import java.util.List;
+
+/** Resposta com as decisões financeiras de um experimento. */
+public record ExperimentDecisionListResponse(List<ExperimentDecisionResponse> decisions) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/epm/service/listExperimentDecisions/ExperimentDecisionResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/epm/service/listExperimentDecisions/ExperimentDecisionResponse.java
@@ -1,0 +1,7 @@
+package com.marketinghub.epm.service.listExperimentDecisions;
+
+import com.marketinghub.epm.ExperimentFinancialDecisionType;
+import java.time.Instant;
+
+/** Resposta com uma decisão financeira registrada para um experimento. */
+public record ExperimentDecisionResponse(Long id, Long experimentBudgetId, ExperimentFinancialDecisionType decisionType, String reason, Instant decidedAt, String decidedBy, Instant createdAt) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/epm/service/listFinancialPlans/FinancialPlanListResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/epm/service/listFinancialPlans/FinancialPlanListResponse.java
@@ -1,0 +1,7 @@
+package com.marketinghub.epm.service.listFinancialPlans;
+
+import com.marketinghub.epm.service.getFinancialPlan.FinancialPlanResponse;
+import java.util.List;
+
+/** Resposta com a lista de planos financeiros do EPM. */
+public record FinancialPlanListResponse(List<FinancialPlanResponse> plans) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/epm/service/listPlanHypotheses/FinancialPlanHypothesisListResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/epm/service/listPlanHypotheses/FinancialPlanHypothesisListResponse.java
@@ -1,0 +1,7 @@
+package com.marketinghub.epm.service.listPlanHypotheses;
+
+import com.marketinghub.epm.service.getPlanHypothesis.FinancialPlanHypothesisResponse;
+import java.util.List;
+
+/** Resposta com as hipóteses financeiras de um nicho. */
+public record FinancialPlanHypothesisListResponse(List<FinancialPlanHypothesisResponse> hypotheses) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/epm/service/listPlanNiches/FinancialPlanNicheListResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/epm/service/listPlanNiches/FinancialPlanNicheListResponse.java
@@ -1,0 +1,7 @@
+package com.marketinghub.epm.service.listPlanNiches;
+
+import com.marketinghub.epm.service.getPlanNiche.FinancialPlanNicheResponse;
+import java.util.List;
+
+/** Resposta com os nichos financeiros de um plano. */
+public record FinancialPlanNicheListResponse(List<FinancialPlanNicheResponse> niches) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/epm/service/listProductPriceScenarios/ProductPriceScenarioListResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/epm/service/listProductPriceScenarios/ProductPriceScenarioListResponse.java
@@ -1,0 +1,6 @@
+package com.marketinghub.epm.service.listProductPriceScenarios;
+
+import java.util.List;
+
+/** Resposta com os cenários de preço de um plano financeiro. */
+public record ProductPriceScenarioListResponse(List<ProductPriceScenarioResponse> scenarios) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/epm/service/listProductPriceScenarios/ProductPriceScenarioResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/epm/service/listProductPriceScenarios/ProductPriceScenarioResponse.java
@@ -1,0 +1,6 @@
+package com.marketinghub.epm.service.listProductPriceScenarios;
+
+import java.time.Instant;
+
+/** Resposta com um cenário de preço e ponto de equilíbrio do EPM. */
+public record ProductPriceScenarioResponse(Long id, Long financialPlanId, String name, Long priceCents, Long expectedPaymentFeeCents, Long expectedPlatformFeeCents, Long expectedTaxCents, Long expectedNetRevenuePerSaleCents, Long totalBudgetCents, Integer breakEvenSales, String notes, Instant createdAt, Instant updatedAt) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/epm/service/updateExperimentBudget/UpdateExperimentBudgetRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/epm/service/updateExperimentBudget/UpdateExperimentBudgetRequest.java
@@ -1,0 +1,8 @@
+package com.marketinghub.epm.service.updateExperimentBudget;
+
+import com.marketinghub.epm.ExperimentBudgetStatus;
+import jakarta.validation.constraints.*;
+import java.time.LocalDate;
+
+/** Dados para atualizar um orçamento de experimento do EPM. */
+public record UpdateExperimentBudgetRequest(Long externalExperimentId, @NotBlank String name, @NotNull @PositiveOrZero Long plannedDailyBudgetCents, @NotNull @Positive Integer plannedDurationDays, Long spendLimitCents, Long actualSpendCents, LocalDate startDate, LocalDate endDate, ExperimentBudgetStatus status, String notes) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/epm/service/updateFinancialPlan/UpdateFinancialPlanRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/epm/service/updateFinancialPlan/UpdateFinancialPlanRequest.java
@@ -1,0 +1,8 @@
+package com.marketinghub.epm.service.updateFinancialPlan;
+
+import com.marketinghub.epm.FinancialPlanStatus;
+import jakarta.validation.constraints.*;
+import java.time.LocalDate;
+
+/** Dados para atualizar um plano financeiro do EPM. */
+public record UpdateFinancialPlanRequest(@NotBlank String name, @NotNull LocalDate cycleStartDate, @NotNull LocalDate cycleEndDate, @NotNull @PositiveOrZero Long totalBudgetCents, Long defaultDailyBudgetCents, Integer defaultExperimentDurationDays, Integer defaultExperimentsPerHypothesis, FinancialPlanStatus status, String notes) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/epm/ExperimentBudgetRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/epm/ExperimentBudgetRepository.java
@@ -3,8 +3,12 @@ package com.marketinghub.repository.jpa.epm;
 import com.marketinghub.epm.ExperimentBudget;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 /**
  * Repositório JPA para persistir e consultar registros ExperimentBudget do EPM.
  */
 public interface ExperimentBudgetRepository extends JpaRepository<ExperimentBudget, Long> {
+    /** Lista os orçamentos de experimento vinculados à hipótese informada. */
+    List<ExperimentBudget> findByFinancialPlanHypothesisIdOrderByIdAsc(Long financialPlanHypothesisId);
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/epm/ExperimentFinancialDecisionRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/epm/ExperimentFinancialDecisionRepository.java
@@ -3,8 +3,12 @@ package com.marketinghub.repository.jpa.epm;
 import com.marketinghub.epm.ExperimentFinancialDecision;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 /**
  * Repositório JPA para persistir e consultar registros ExperimentFinancialDecision do EPM.
  */
 public interface ExperimentFinancialDecisionRepository extends JpaRepository<ExperimentFinancialDecision, Long> {
+    /** Lista as decisões financeiras vinculadas ao orçamento de experimento informado. */
+    List<ExperimentFinancialDecision> findByExperimentBudgetIdOrderByDecidedAtDesc(Long experimentBudgetId);
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/epm/ExperimentFinancialMetricRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/epm/ExperimentFinancialMetricRepository.java
@@ -3,8 +3,16 @@ package com.marketinghub.repository.jpa.epm;
 import com.marketinghub.epm.ExperimentFinancialMetric;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+import java.util.Optional;
+
 /**
  * Repositório JPA para persistir e consultar registros ExperimentFinancialMetric do EPM.
  */
 public interface ExperimentFinancialMetricRepository extends JpaRepository<ExperimentFinancialMetric, Long> {
+    /** Lista as métricas financeiras vinculadas ao orçamento de experimento informado. */
+    List<ExperimentFinancialMetric> findByExperimentBudgetIdOrderByMeasuredAtDesc(Long experimentBudgetId);
+
+    /** Busca a métrica financeira manual mais recente do orçamento de experimento informado. */
+    Optional<ExperimentFinancialMetric> findFirstByExperimentBudgetIdOrderByMeasuredAtDesc(Long experimentBudgetId);
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/epm/FinancialPlanHypothesisRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/epm/FinancialPlanHypothesisRepository.java
@@ -3,8 +3,12 @@ package com.marketinghub.repository.jpa.epm;
 import com.marketinghub.epm.FinancialPlanHypothesis;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 /**
  * Repositório JPA para persistir e consultar registros FinancialPlanHypothesis do EPM.
  */
 public interface FinancialPlanHypothesisRepository extends JpaRepository<FinancialPlanHypothesis, Long> {
+    /** Lista as hipóteses financeiras vinculadas ao nicho informado. */
+    List<FinancialPlanHypothesis> findByFinancialPlanNicheIdOrderByIdAsc(Long financialPlanNicheId);
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/epm/FinancialPlanNicheRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/epm/FinancialPlanNicheRepository.java
@@ -3,8 +3,12 @@ package com.marketinghub.repository.jpa.epm;
 import com.marketinghub.epm.FinancialPlanNiche;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 /**
  * Repositório JPA para persistir e consultar registros FinancialPlanNiche do EPM.
  */
 public interface FinancialPlanNicheRepository extends JpaRepository<FinancialPlanNiche, Long> {
+    /** Lista os nichos financeiros vinculados ao plano informado. */
+    List<FinancialPlanNiche> findByFinancialPlanIdOrderByIdAsc(Long financialPlanId);
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/epm/ProductPriceScenarioRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/epm/ProductPriceScenarioRepository.java
@@ -3,8 +3,12 @@ package com.marketinghub.repository.jpa.epm;
 import com.marketinghub.epm.ProductPriceScenario;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 /**
  * Repositório JPA para persistir e consultar registros ProductPriceScenario do EPM.
  */
 public interface ProductPriceScenarioRepository extends JpaRepository<ProductPriceScenario, Long> {
+    /** Lista os cenários de preço vinculados ao plano financeiro informado. */
+    List<ProductPriceScenario> findByFinancialPlanIdOrderByIdAsc(Long financialPlanId);
 }

--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-01-epm-sprint2-api-fields.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-01-epm-sprint2-api-fields.yaml
@@ -1,0 +1,59 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-06-01-epm-sprint2-api-fields-budget
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - onError: HALT
+        - dbms:
+            type: mysql
+        - not:
+            - columnExists:
+                tableName: experiment_budget
+                columnName: spend_limit_cents
+      changes:
+        - sql:
+            dbms: mysql
+            splitStatements: true
+            stripComments: true
+            sql: |
+              ALTER TABLE experiment_budget
+                ADD COLUMN spend_limit_cents BIGINT NULL AFTER planned_total_budget_cents,
+                ADD COLUMN actual_spend_cents BIGINT NULL AFTER spend_limit_cents,
+                ADD COLUMN remaining_budget_cents BIGINT NULL AFTER actual_spend_cents;
+
+              UPDATE experiment_budget
+                 SET spend_limit_cents = planned_total_budget_cents,
+                     actual_spend_cents = 0,
+                     remaining_budget_cents = planned_total_budget_cents
+               WHERE spend_limit_cents IS NULL;
+
+  - changeSet:
+      id: 2026-06-01-epm-sprint2-api-fields-metric
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - onError: HALT
+        - dbms:
+            type: mysql
+        - not:
+            - columnExists:
+                tableName: experiment_financial_metric
+                columnName: impressions
+      changes:
+        - sql:
+            dbms: mysql
+            splitStatements: true
+            stripComments: true
+            sql: |
+              ALTER TABLE experiment_financial_metric
+                ADD COLUMN impressions BIGINT NOT NULL DEFAULT 0 AFTER measured_at,
+                ADD COLUMN clicks BIGINT NOT NULL DEFAULT 0 AFTER impressions,
+                ADD COLUMN sample_requests INT NOT NULL DEFAULT 0 AFTER leads,
+                ADD COLUMN ctr_decimal DECIMAL(10,6) NULL AFTER estimated_net_profit_cents,
+                ADD COLUMN cpc_cents BIGINT NULL AFTER ctr_decimal,
+                ADD COLUMN cpl_cents BIGINT NULL AFTER cpc_cents,
+                ADD COLUMN cpa_cents BIGINT NULL AFTER cpl_cents,
+                ADD COLUMN roas_decimal DECIMAL(10,4) NULL AFTER cpa_cents,
+                ADD COLUMN landing_conversion_decimal DECIMAL(10,6) NULL AFTER roas_decimal,
+                ADD COLUMN purchase_conversion_decimal DECIMAL(10,6) NULL AFTER landing_conversion_decimal;

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -817,3 +817,7 @@ databaseChangeLog:
   - include:
       file: changesets/2026-06-01-epm-sprint1-base.yaml
       relativeToChangelogFile: true
+  - include:
+      file: changesets/2026-06-01-epm-sprint2-api-fields.yaml
+      relativeToChangelogFile: true
+

--- a/backend/ads-service/src/test/java/com/marketinghub/epm/EpmControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/epm/EpmControllerTest.java
@@ -1,0 +1,50 @@
+package com.marketinghub.epm;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marketinghub.epm.controller.EpmController;
+import com.marketinghub.epm.service.EpmService;
+import com.marketinghub.epm.service.createFinancialPlan.CreateFinancialPlanRequest;
+import com.marketinghub.epm.service.getFinancialPlan.FinancialPlanResponse;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.LocalDate;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Valida o contrato HTTP mínimo do controller único do módulo EPM.
+ */
+@WebMvcTest(EpmController.class)
+class EpmControllerTest {
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @MockBean
+    EpmService epmService;
+
+    /** Verifica se o endpoint de criação de plano aceita payload válido e retorna HTTP 201. */
+    @Test
+    void shouldCreateFinancialPlanThroughApi() throws Exception {
+        when(epmService.createFinancialPlan(any())).thenReturn(new FinancialPlanResponse(1L, "Plano Junho", LocalDate.of(2026, 6, 1), LocalDate.of(2026, 6, 30), 300_000L, 2_000L, 3, 3, FinancialPlanStatus.ACTIVE, null, null, null));
+        CreateFinancialPlanRequest request = new CreateFinancialPlanRequest("Plano Junho", LocalDate.of(2026, 6, 1), LocalDate.of(2026, 6, 30), 300_000L, 2_000L, 3, 3, FinancialPlanStatus.ACTIVE, null);
+
+        mockMvc.perform(post("/api/epm/plans")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isCreated())
+                .andExpect(jsonPath("$.id").value(1))
+                .andExpect(jsonPath("$.totalBudgetCents").value(300_000));
+    }
+}

--- a/backend/ads-service/src/test/java/com/marketinghub/epm/EpmServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/epm/EpmServiceTest.java
@@ -1,0 +1,101 @@
+package com.marketinghub.epm;
+
+import com.marketinghub.epm.service.EpmService;
+import com.marketinghub.epm.service.createExperimentBudget.CreateExperimentBudgetRequest;
+import com.marketinghub.epm.service.createExperimentMetric.CreateExperimentMetricRequest;
+import com.marketinghub.epm.service.createProductPriceScenario.CreateProductPriceScenarioRequest;
+import com.marketinghub.repository.jpa.epm.*;
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.*;
+
+/**
+ * Valida os cálculos operacionais da Sprint 2 do serviço EPM.
+ */
+class EpmServiceTest {
+
+    /** Verifica se orçamento total e restante são calculados ao criar um experimento. */
+    @Test
+    void shouldCalculatePlannedTotalAndRemainingBudget() {
+        FinancialPlanHypothesisRepository hypothesisRepository = mock(FinancialPlanHypothesisRepository.class);
+        ExperimentBudgetRepository budgetRepository = mock(ExperimentBudgetRepository.class);
+        EpmService service = service(null, null, hypothesisRepository, budgetRepository, null, null, null);
+        FinancialPlanHypothesis hypothesis = FinancialPlanHypothesis.builder().id(3L).build();
+        when(hypothesisRepository.findById(3L)).thenReturn(Optional.of(hypothesis));
+        when(budgetRepository.save(any())).thenAnswer(invocation -> {
+            ExperimentBudget budget = invocation.getArgument(0);
+            budget.setId(9L);
+            return budget;
+        });
+
+        var response = service.createExperimentBudget(3L, new CreateExperimentBudgetRequest(42L, "Experimento", 2_000L, 3, null, LocalDate.of(2026, 6, 1), null, ExperimentBudgetStatus.RUNNING, null));
+
+        assertThat(response.plannedTotalBudgetCents()).isEqualTo(6_000L);
+        assertThat(response.remainingBudgetCents()).isEqualTo(6_000L);
+        assertThat(response.status()).isEqualTo(ExperimentBudgetStatus.RUNNING);
+    }
+
+    /** Verifica se lucro, ROAS e métricas por custo são calculados sem dividir por zero. */
+    @Test
+    void shouldCalculateManualMetricProfitAndRatios() {
+        ExperimentBudgetRepository budgetRepository = mock(ExperimentBudgetRepository.class);
+        ExperimentFinancialMetricRepository metricRepository = mock(ExperimentFinancialMetricRepository.class);
+        EpmService service = service(null, null, null, budgetRepository, metricRepository, null, null);
+        ExperimentBudget budget = ExperimentBudget.builder().id(5L).spendLimitCents(6_000L).actualSpendCents(0L).remainingBudgetCents(6_000L).build();
+        when(budgetRepository.findById(5L)).thenReturn(Optional.of(budget));
+        when(metricRepository.save(any())).thenAnswer(invocation -> {
+            ExperimentFinancialMetric metric = invocation.getArgument(0);
+            metric.setId(7L);
+            metric.setCreatedAt(Instant.parse("2026-06-01T12:00:00Z"));
+            return metric;
+        });
+
+        var response = service.createExperimentMetric(5L, new CreateExperimentMetricRequest(Instant.parse("2026-06-01T10:00:00Z"), 1_000L, 50L, 100, 10, 2, 3, 1, 6_000L, 9_700L, 800L, 0L, 200L, 600L, null));
+
+        assertThat(response.grossProfitCents()).isEqualTo(3_700L);
+        assertThat(response.estimatedNetProfitCents()).isEqualTo(2_100L);
+        assertThat(response.cplCents()).isEqualTo(600L);
+        assertThat(response.cpaCents()).isEqualTo(6_000L);
+        assertThat(response.roasDecimal()).isEqualByComparingTo("1.6167");
+        assertThat(response.landingConversionDecimal()).isEqualByComparingTo("0.100000");
+        assertThat(budget.getRemainingBudgetCents()).isZero();
+    }
+
+    /** Verifica se cenário de preço calcula receita líquida por venda e ponto de equilíbrio. */
+    @Test
+    void shouldCalculateBreakEvenSalesForPriceScenario() {
+        FinancialPlanRepository planRepository = mock(FinancialPlanRepository.class);
+        ProductPriceScenarioRepository scenarioRepository = mock(ProductPriceScenarioRepository.class);
+        EpmService service = service(planRepository, null, null, null, null, null, scenarioRepository);
+        FinancialPlan plan = FinancialPlan.builder().id(2L).totalBudgetCents(120_000L).build();
+        when(planRepository.findById(2L)).thenReturn(Optional.of(plan));
+        when(scenarioRepository.save(any())).thenAnswer(invocation -> {
+            ProductPriceScenario scenario = invocation.getArgument(0);
+            scenario.setId(4L);
+            return scenario;
+        });
+
+        var response = service.createProductPriceScenario(2L, new CreateProductPriceScenarioRequest("R$97", 9_700L, 800L, 0L, 600L, null, null));
+
+        assertThat(response.expectedNetRevenuePerSaleCents()).isEqualTo(8_300L);
+        assertThat(response.breakEvenSales()).isEqualTo(15);
+    }
+
+    /** Monta o serviço com mocks para isolar as regras de cálculo. */
+    private EpmService service(FinancialPlanRepository planRepository, FinancialPlanNicheRepository nicheRepository, FinancialPlanHypothesisRepository hypothesisRepository, ExperimentBudgetRepository budgetRepository, ExperimentFinancialMetricRepository metricRepository, ExperimentFinancialDecisionRepository decisionRepository, ProductPriceScenarioRepository scenarioRepository) {
+        return new EpmService(
+                planRepository == null ? mock(FinancialPlanRepository.class) : planRepository,
+                nicheRepository == null ? mock(FinancialPlanNicheRepository.class) : nicheRepository,
+                hypothesisRepository == null ? mock(FinancialPlanHypothesisRepository.class) : hypothesisRepository,
+                budgetRepository == null ? mock(ExperimentBudgetRepository.class) : budgetRepository,
+                metricRepository == null ? mock(ExperimentFinancialMetricRepository.class) : metricRepository,
+                decisionRepository == null ? mock(ExperimentFinancialDecisionRepository.class) : decisionRepository,
+                scenarioRepository == null ? mock(ProductPriceScenarioRepository.class) : scenarioRepository);
+    }
+}

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -2988,3 +2988,10 @@
   - criado o card `4 - Gera Imagem` com botão de início, link para detalhe das imagens, job id clicável para a página de detalhe da execução e histórico específico de `landing-page-image-generation`;
   - ajustado o mapeamento frontend da etapa `landing-page-image-generation` para usar os endpoints canônicos `/geralanding/image-generation/stage-executions`;
   - renumerados os cards seguintes para manter a sequência visual após a nova etapa dedicada.
+
+## 2026-06-01 — EPM Sprint 2 API operacional
+
+- Implementada a API operacional manual do Experiment Profit Manager no backend principal.
+- Endpoints cobertos: planos financeiros, nichos, hipóteses, experimentos, métricas manuais, decisões financeiras, cenários de preço e resumo do plano.
+- Cálculos mínimos adicionados: orçamento planejado, orçamento restante, lucro bruto, lucro líquido estimado, CTR, CPC, CPL, CPA, ROAS, conversão da landing, conversão de compra e vendas para ponto de equilíbrio.
+- Documentação Swagger do módulo adicionada em `backend/ads-service/docs/epm-swagger.yaml`.


### PR DESCRIPTION
### Motivation
- Provide a minimal operational API to run the Experiment Profit Manager (EPM) manually so the Marketing Hub can plan budgets, ingest metrics and make decisions without frontend or external integrations.
- Add the persistence and calculated fields required by Sprint 2 so metrics and budgets can be stored and summarized consistently.
- Keep the backend as the single source of truth and follow project conventions for repositories, DTO packaging and Liquibase migrations.

### Description
- Added a single controller exposing the operational API at `/api/epm` with endpoints for plans, plan niches, hypotheses, experiment budgets, metrics (manual), decisions, price scenarios and plan summary (`backend/ads-service/src/main/java/com/marketinghub/epm/controller/EpmController.java`).
- Implemented one application service `EpmService` that orchestrates creation/updates and performs financial calculations (planned/remaining budget, gross/net profit, CTR, CPC, CPL, CPA, ROAS, conversions, break-even sales and plan summary) (`backend/ads-service/src/main/java/com/marketinghub/epm/service/EpmService.java`).
- Extended entities and JPA repositories: added budget fields (`spend_limit_cents`, `actual_spend_cents`, `remaining_budget_cents`) and richer metric fields (`impressions`, `clicks`, `sample_requests`, `ctr_decimal`, `cpc_cents`, `cpl_cents`, `cpa_cents`, `roas_decimal`, `landing_conversion_decimal`, `purchase_conversion_decimal`) and corresponding repository query methods under `com.marketinghub.repository.jpa.epm`.
- Added DTOs organized in operation-specific subpackages under `com.marketinghub.epm.service.*` for requests and responses (create/update/list operations per the backend package convention).
- Added Liquibase changelog `2026-06-01-epm-sprint2-api-fields.yaml` with MySQL-compatible changesets using `databaseChangeLog`, `dbms:mysql`, `splitStatements: true` and `stripComments: true` to add the new columns and populate defaults.
- Added OpenAPI/Swagger doc `backend/ads-service/docs/epm-swagger.yaml` describing the new API surface.
- Added unit/integration style tests: repository persistence tests and service/controller tests to cover budget calculations, metric calculations and the create-plan HTTP contract.

### Testing
- Ran the module tests with: `cd backend/ads-service && ../mvnw test -Dtest=EpmRepositoryTest,EpmServiceTest,EpmControllerTest` which executed the newly added tests together with repository checks.
- Result: tests passed (`BUILD SUCCESS`) and all added tests succeeded (6 tests run, 0 failures, 0 errors).
- Liquibase migration file added and referenced in the module `db.changelog-master.yaml` to ensure incremental schema changes are applied on deployment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1def3a6fc88321900e3fbebf8ab622)