### PR TITLE
Melhora geração comercial das landings GeraLanding: hero mais forte, formulário claro e preset visual

### DIFF
--- a/ai-worker/src/main/resources/prompts/geralanding/landing-page-copy.md
+++ b/ai-worker/src/main/resources/prompts/geralanding/landing-page-copy.md
@@ -40,6 +40,9 @@ Objetivo principal desta etapa:
 
 Regra central de contrato:
 - O wireframe é a única fonte de verdade estrutural.
+- Qualidade comercial obrigatória: a copy deve vender a transformação antes de explicar o formato da amostra. Evite abrir com frases como “gere uma amostra/PDF”; abra com o resultado que o público quer e o problema que ele quer remover, usando a amostra como prova concreta e sem risco.
+- Clareza de formulário obrigatória: se o wireframe trouxer labels, placeholders, microcopy ou botão do formulário, escreva textos explícitos para `nome`, `email` e CTA, para que o usuário não veja campos vazios sem orientação.
+- Prova de valor rápida: em listas e cards, prefira frases que conectem item entregue → benefício prático → redução de esforço/dor, sem depender de termos genéricos como “mini-kit”, “amostra” ou “material” isoladamente.
 - A etapa copy não decide estrutura, não adiciona seções, não adiciona blocos e não cria metadados.
 - A etapa copy apenas escreve o valor `texto` para ids textuais existentes no wireframe.
 - Princípio de pouco esforço obrigatório: o usuário não quer fazer esforço para entender a comunicação da página; portanto, cada texto deve ser claro em leitura rápida, reduzir carga cognitiva, evitar explicação longa sem necessidade e conduzir naturalmente para o próximo CTA ou próximo passo definido pelo wireframe.

--- a/ai-worker/src/main/resources/prompts/geralanding/landing-page-design-preset.md
+++ b/ai-worker/src/main/resources/prompts/geralanding/landing-page-design-preset.md
@@ -78,6 +78,8 @@ Regras obrigatórias:
 
 Qualidade visual mínima da landing (obrigatório):
 - `body` deve ter `margin: 0`, fonte legível, background consistente e texto com contraste suficiente para leitura imediata.
+- Layout desktop deve parecer landing comercial acabada: usar containers com largura entre 1040px e 1200px, hero em duas colunas quando houver conteúdo visual/card, espaçamento vertical generoso e cards com contraste/sombra leve. Evite aparência de página mobile esticada ou coluna estreita no desktop.
+- Primeira dobra deve destacar uma ação principal, uma prova visual e uma hierarquia clara (headline maior, subtítulo legível, bullets escaneáveis, CTA evidente).
 - Seções e containers principais devem usar `max-width` e centralização com `margin-left: auto` e `margin-right: auto` quando o conteúdo não precisar ocupar toda a largura.
 - Hero deve ficar em layout de duas colunas no desktop e uma coluna no mobile, preservando hierarquia clara entre promessa, prova, CTA e visual.
 - CTA primário deve ter aparência real de botão: `padding`, `background`, `border-radius`, `font-weight`, `display: inline-flex`, estados `:hover` e contraste claro entre texto e fundo.

--- a/ai-worker/src/main/resources/prompts/geralanding/landing-page-wireframe.md
+++ b/ai-worker/src/main/resources/prompts/geralanding/landing-page-wireframe.md
@@ -126,6 +126,11 @@ Trecho obrigatório do contrato de seção/elementos (manter):
 
 Regras comerciais e estruturais obrigatórias (mantidas):
 - Mobile-first obrigatório: priorize leitura vertical e CTA claro nas primeiras seções.
+- Primeira dobra forte obrigatória: o hero deve abrir com resultado comercial desejado pelo nicho + dor removida + mecanismo plausível, e não com uma descrição operacional da amostra. A amostra/PDF/mini-kit deve aparecer como prova concreta do mecanismo, não como promessa principal.
+- Desktop comercial obrigatório: no desktop, o hero deve ser pensado em duas colunas dentro de um container centralizado; coluna esquerda com headline, subtítulo, 3 bullets de valor e CTA primário; coluna direita com card visual/prova do produto ou card de captura curta. É proibido gerar uma página estreita de coluna única no desktop quando houver espaço para hierarquia visual.
+- Formulário com contexto claro: a seção de captura deve conter rótulos ou microcopy textual visível para `nome` e `email`, além de CTA específico; inputs não podem depender apenas de campos vazios/sem placeholder para o usuário entender o que preencher.
+- Sequência persuasiva mínima obrigatória: depois do hero, estruturar seções que respondam nesta ordem lógica: (1) por que a situação atual custa venda/renovação; (2) como o mecanismo resolve com pouco esforço; (3) o que a pessoa recebe na amostra e no próximo passo; (4) formulário/ação; (5) dúvidas/objeções essenciais.
+- Menos CTAs redundantes: usar CTAs nos pontos de decisão, evitando repetir o mesmo botão após blocos que ainda não agregaram argumento novo.
 - Princípio de pouco esforço obrigatório: o usuário não quer fazer esforço para entender a comunicação da página; portanto, cada seção deve reduzir carga cognitiva, deixar a mensagem principal evidente em leitura rápida, usar poucos caminhos de decisão, evitar excesso de informações simultâneas e conduzir naturalmente para o próximo CTA.
 - Objetivo comercial obrigatório: estruturar a página para venda com foco na coleta de informação para envio de amostra/prova do produto (ex.: formulário/CTA de captura).
 - Fase wireframe NÃO preenche copy: em TODOS os elementos, `texto.conteudo` deve ser string vazia (`""`) nesta etapa.

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -2995,3 +2995,13 @@
 - Endpoints cobertos: planos financeiros, nichos, hipóteses, experimentos, métricas manuais, decisões financeiras, cenários de preço e resumo do plano.
 - Cálculos mínimos adicionados: orçamento planejado, orçamento restante, lucro bruto, lucro líquido estimado, CTR, CPC, CPL, CPA, ROAS, conversão da landing, conversão de compra e vendas para ponto de equilíbrio.
 - Documentação Swagger do módulo adicionada em `backend/ads-service/docs/epm-swagger.yaml`.
+
+## 2026-06-01 — Reforço comercial da landing do experimento 35
+
+- solicitação: melhorar a página gerada para o experimento 35, considerada fraca na primeira avaliação visual.
+- causa-raiz/objetivo: a geração aceitava uma landing muito centrada no formato da amostra (“PDF/mini-kit”) antes de vender a transformação, com aparência de coluna estreita no desktop, CTAs repetidos e formulário pouco orientado.
+- foi feito:
+  - reforçado o prompt de wireframe para exigir primeira dobra com resultado comercial, dor removida, mecanismo plausível, hero desktop em duas colunas, sequência persuasiva mínima, formulário com contexto visível e menos CTAs redundantes;
+  - reforçado o prompt de copy para vender transformação antes do formato da amostra, orientar nome/e-mail quando houver labels/placeholders/microcopy e conectar entregável a benefício prático;
+  - reforçado o prompt de preset design para evitar aparência de página mobile esticada, usando containers comerciais, duas colunas no hero e hierarquia visual mais clara.
+- impacto esperado: próximas regenerações da landing devem produzir páginas mais fortes para venda, com primeira dobra mais convincente, formulário mais claro e percepção de valor maior antes do pedido de lead.


### PR DESCRIPTION
### Motivation
- A landing gerada para o experimento estava fraca porque abria com formato da amostra (PDF/mini-kit) em vez de vender a transformação e apresentava aparência de coluna estreita no desktop, CTAs redundantes e formulário pouco orientado.
- Objetivo das mudanças é aumentar percepção de valor na primeira dobra, favorecer conversão por clareza do resultado e reduzir esforço do usuário antes do pedido de lead.

### Description
- Atualizei o prompt de wireframe `ai-worker/src/main/resources/prompts/geralanding/landing-page-wireframe.md` para exigir uma "primeira dobra" forte (resultado + dor removida + mecanismo), hero em duas colunas no desktop, formulário com rótulos/contexto visível, sequência persuasiva mínima e menos CTAs redundantes.
- Atualizei o prompt de copy `ai-worker/src/main/resources/prompts/geralanding/landing-page-copy.md` para priorizar vender a transformação antes de descrever o formato da amostra e para assegurar orientações explícitas para `nome`, `email` e CTA quando o wireframe trouxer labels/placeholders.
- Atualizei o prompt de preset design `ai-worker/src/main/resources/prompts/geralanding/landing-page-design-preset.md` para exigir layout comercial acabado no desktop (containers 1040–1200px, hero duas colunas, hierarquia visual clara, formulário em card) e critérios visuais mínimos (CTA, contraste, imagens controladas).
- Registrei a mudança e o contexto operacional em `docs/registros/experimentos.md` descrevendo causa-raiz, alterações aplicadas e impacto esperado.

### Testing
- Executei as buscas de verificação `rg -n "Primeira dobra forte obrigatória|Qualidade comercial obrigatória|Layout desktop deve parecer landing comercial acabada|Reforço comercial da landing do experimento 35" ai-worker/src/main/resources/prompts/geralanding docs/registros/experimentos.md` e confirmei presença das regras novas (sucesso).
- Rodei `git diff --check` para validar que não há problemas de formatação no diff (sucesso).
- Tentei `mvn test` em `ai-worker` para validar a build, mas a execução falhou por resolução de dependência externa devido a autenticação no repositório Maven do GitHub (`com.marketinghub:ads-service:pom:0.0.1-SNAPSHOT` retornou HTTP 401), portanto testes de unidade não concluíram por limitação de infraestrutura externa (falha inesperada, não relacionada às alterações de prompt).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1df2e5baa883218df303bb9b6b3967)