### PR TITLE
Prefer `htmlGeraLanding` for preview/approval in Landing tab; add resolver and tests

### DIFF
--- a/docs/canonical/procedimento-experimento-canon.v1.md
+++ b/docs/canonical/procedimento-experimento-canon.v1.md
@@ -168,6 +168,7 @@ Fluxo obrigatório executado após a aprovação:
 6. resolver URLs finais de publicação (`iframe` e `standalone`) e persistir no experimento a `follow_up_action_url`.
 
 Regras adicionais:
+- a aba Landing do frontend deve usar o mesmo critério de disponibilidade do backend: `experiment.html_geralanding` preenchido é suficiente para exibir a prévia e habilitar o botão de aprovação/publicação; `experiment.landing_page_html` fica apenas como fallback legado;
 - a injeção de tracking deve ser idempotente (não duplicar quando já existir no HTML);
 - falhas de contrato na publicação para Lead Portal devem ser tratadas pela exception canônica de violação de contrato do GeraLanding.
 

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -3005,3 +3005,20 @@
   - reforçado o prompt de copy para vender transformação antes do formato da amostra, orientar nome/e-mail quando houver labels/placeholders/microcopy e conectar entregável a benefício prático;
   - reforçado o prompt de preset design para evitar aparência de página mobile esticada, usando containers comerciais, duas colunas no hero e hierarquia visual mais clara.
 - impacto esperado: próximas regenerações da landing devem produzir páginas mais fortes para venda, com primeira dobra mais convincente, formulário mais claro e percepção de valor maior antes do pedido de lead.
+
+## 2026-06-01 18:37:14 UTC-3
+- solicitação: corrigir a aba Landing do experimento para exigir apenas `htmlGeraLanding` preenchido antes de liberar a aprovação/publicação.
+- causa-raiz identificada: o frontend bloqueava a prévia e o botão usando somente `experiment.landingPageHtml`, enquanto o fluxo canônico/backend já prioriza `experiment.html_geralanding` e usa `landing_page_html` apenas como fallback legado.
+- registro do que foi feito:
+  - a aba Landing passou a resolver o HTML por `htmlGeraLanding` com fallback para `landingPageHtml`;
+  - foi adicionado teste unitário para garantir que `htmlGeraLanding` é suficiente, `landingPageHtml` continua como fallback e ambos vazios bloqueiam a aprovação;
+  - o procedimento canônico de Experimentos foi atualizado para declarar a mesma regra de disponibilidade na interface.
+- documentos lidos para pesquisar e resolver o problema:
+  - AGENTS.md
+  - frontend/AGENTS.md
+  - docs/canonical/procedimento-experimento-canon.v1.md
+  - docs/registros/experimentos.md
+  - frontend/src/pages/experiment/LandingTab.tsx
+  - frontend/src/api/experiment/useExperiments.ts
+  - frontend/src/api/experiment/useApproveAndPublishLanding.ts
+  - backend/ads-service/src/main/java/com/marketinghub/geralanding/GeraLandingStageExecutionService.java

--- a/frontend/src/pages/experiment/LandingTab.test.ts
+++ b/frontend/src/pages/experiment/LandingTab.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from "vitest";
+import { resolveLandingHtml } from "./LandingTab";
+
+describe("LandingTab", () => {
+  it("usa htmlGeraLanding como HTML suficiente para liberar a aprovação", () => {
+    expect(
+      resolveLandingHtml({
+        htmlGeraLanding: "<html><body>GeraLanding</body></html>",
+        landingPageHtml: null,
+      }),
+    ).toBe("<html><body>GeraLanding</body></html>");
+  });
+
+  it("mantém landingPageHtml como fallback legado", () => {
+    expect(
+      resolveLandingHtml({
+        htmlGeraLanding: null,
+        landingPageHtml: "<html><body>Landing legado</body></html>",
+      }),
+    ).toBe("<html><body>Landing legado</body></html>");
+  });
+
+  it("bloqueia aprovação quando ambos os campos de HTML estão vazios", () => {
+    expect(
+      resolveLandingHtml({ htmlGeraLanding: "   ", landingPageHtml: null }),
+    ).toBeNull();
+  });
+});

--- a/frontend/src/pages/experiment/LandingTab.tsx
+++ b/frontend/src/pages/experiment/LandingTab.tsx
@@ -27,17 +27,33 @@ function normalizeUrl(url?: string | null) {
   return (url ?? "").trim().replace(/\/$/, "");
 }
 
-export default function LandingTab({ experiment }: LandingTabProps) {
-  const approveAndPublishLanding = useApproveAndPublishLanding(Number(experiment.id));
-  const [feedback, setFeedback] = useState<FeedbackState | null>(null);
-  const landingHtml = useMemo(() => {
-    const raw = experiment.landingPageHtml;
-    return typeof raw === "string" && raw.trim().length > 0 ? raw : null;
-  }, [experiment.landingPageHtml]);
+export function resolveLandingHtml(
+  experiment: Pick<Experiment, "htmlGeraLanding" | "landingPageHtml">,
+) {
+  const raw = experiment.htmlGeraLanding ?? experiment.landingPageHtml;
+  return typeof raw === "string" && raw.trim().length > 0 ? raw : null;
+}
 
-  const [publishedUrls, setPublishedUrls] = useState<{ iframeUrl: string | null; standaloneUrl: string | null } | null>(null);
-  const selectedDestinationUrl = normalizeUrl(publishedUrls?.standaloneUrl ?? experiment.followUpActionUrl);
-  const campaignDestinationUrl = resolveStandaloneLandingUrl(`/landing/${experiment.id}`);
+export default function LandingTab({ experiment }: LandingTabProps) {
+  const approveAndPublishLanding = useApproveAndPublishLanding(
+    Number(experiment.id),
+  );
+  const [feedback, setFeedback] = useState<FeedbackState | null>(null);
+  const landingHtml = useMemo(
+    () => resolveLandingHtml(experiment),
+    [experiment.htmlGeraLanding, experiment.landingPageHtml],
+  );
+
+  const [publishedUrls, setPublishedUrls] = useState<{
+    iframeUrl: string | null;
+    standaloneUrl: string | null;
+  } | null>(null);
+  const selectedDestinationUrl = normalizeUrl(
+    publishedUrls?.standaloneUrl ?? experiment.followUpActionUrl,
+  );
+  const campaignDestinationUrl = resolveStandaloneLandingUrl(
+    `/landing/${experiment.id}`,
+  );
 
   const handleApproveLanding = async () => {
     setFeedback(null);
@@ -46,12 +62,18 @@ export default function LandingTab({ experiment }: LandingTabProps) {
       const publication = await approveAndPublishLanding.mutateAsync();
       const primaryVariant = publication.variantLinks?.[0] ?? null;
       setPublishedUrls({
-        iframeUrl: primaryVariant?.iframeUrl ?? publication.iframeUrl ?? publication.publicUrl ?? null,
-        standaloneUrl: primaryVariant?.standaloneUrl ?? publication.standaloneUrl ?? null,
+        iframeUrl:
+          primaryVariant?.iframeUrl ??
+          publication.iframeUrl ??
+          publication.publicUrl ??
+          null,
+        standaloneUrl:
+          primaryVariant?.standaloneUrl ?? publication.standaloneUrl ?? null,
       });
       setFeedback({
         variant: "success",
-        message: publication.message || "Landing aprovada e publicada no Lead Portal.",
+        message:
+          publication.message || "Landing aprovada e publicada no Lead Portal.",
       });
     } catch {
       setFeedback({
@@ -67,7 +89,9 @@ export default function LandingTab({ experiment }: LandingTabProps) {
       <div className="card border-0 shadow-sm">
         <div className="card-body">
           <h5 className="card-title mb-1">Landing do experimento</h5>
-          <p className="text-muted mb-0">Pré-visualização do HTML salvo no experimento.</p>
+          <p className="text-muted mb-0">
+            Pré-visualização do HTML salvo no experimento.
+          </p>
         </div>
       </div>
 
@@ -90,22 +114,34 @@ export default function LandingTab({ experiment }: LandingTabProps) {
             <div className="d-flex flex-wrap align-items-center gap-2">
               <span className="fw-semibold">Destino atual:</span>
               {selectedDestinationUrl ? (
-                <span className="badge text-bg-success">URL de campanha definida</span>
+                <span className="badge text-bg-success">
+                  URL de campanha definida
+                </span>
               ) : (
-                <span className="badge text-bg-secondary">Sem URL aprovada</span>
+                <span className="badge text-bg-secondary">
+                  Sem URL aprovada
+                </span>
               )}
             </div>
             <div className="small text-body-secondary">
               <div>
                 <strong>URL usada na campanha:</strong>{" "}
-                <a href={campaignDestinationUrl} target="_blank" rel="noreferrer">
+                <a
+                  href={campaignDestinationUrl}
+                  target="_blank"
+                  rel="noreferrer"
+                >
                   {campaignDestinationUrl}
                 </a>
               </div>
               {publishedUrls?.iframeUrl ? (
                 <div>
                   <strong>URL do iframe (Lead Portal):</strong>{" "}
-                  <a href={publishedUrls.iframeUrl} target="_blank" rel="noreferrer">
+                  <a
+                    href={publishedUrls.iframeUrl}
+                    target="_blank"
+                    rel="noreferrer"
+                  >
                     {publishedUrls.iframeUrl}
                   </a>
                 </div>
@@ -113,7 +149,11 @@ export default function LandingTab({ experiment }: LandingTabProps) {
               {selectedDestinationUrl ? (
                 <div>
                   <strong>URL standalone (usar na campanha):</strong>{" "}
-                  <a href={selectedDestinationUrl} target="_blank" rel="noreferrer">
+                  <a
+                    href={selectedDestinationUrl}
+                    target="_blank"
+                    rel="noreferrer"
+                  >
                     {selectedDestinationUrl}
                   </a>
                 </div>
@@ -122,7 +162,12 @@ export default function LandingTab({ experiment }: LandingTabProps) {
             <iframe
               title="Prévia da landing do experimento"
               srcDoc={landingHtml}
-              style={{ width: "100%", minHeight: 560, border: "1px solid #dee2e6", borderRadius: 8 }}
+              style={{
+                width: "100%",
+                minHeight: 560,
+                border: "1px solid #dee2e6",
+                borderRadius: 8,
+              }}
             />
           </div>
         </div>
@@ -132,14 +177,16 @@ export default function LandingTab({ experiment }: LandingTabProps) {
         <button
           type="button"
           className="btn btn-success"
-          onClick={() =>
-            handleApproveLanding()
-          }
+          onClick={() => handleApproveLanding()}
           disabled={approveAndPublishLanding.isPending || !landingHtml}
         >
           {approveAndPublishLanding.isPending ? (
             <span className="d-inline-flex align-items-center gap-2">
-              <span className="spinner-border spinner-border-sm" role="status" aria-hidden="true" />
+              <span
+                className="spinner-border spinner-border-sm"
+                role="status"
+                aria-hidden="true"
+              />
               Aprovando...
             </span>
           ) : (


### PR DESCRIPTION
### Motivation
- The frontend was blocking landing preview and approval by only checking the legacy `landingPageHtml` field while the canonical/backend flow uses `html_geralanding` first. 
- The intent is to align the UI availability criteria with the backend contract so previews and approvals work when `htmlGeraLanding` is populated.

### Description
- Added `resolveLandingHtml` exported helper that returns `htmlGeraLanding` with fallback to `landingPageHtml` or `null` when empty, and used it in `LandingTab` instead of the legacy-only lookup. 
- Updated `LandingTab.tsx` to use the new resolver, wired the component `useMemo` dependency to both fields, and kept existing UI behaviour (disable approve button when no HTML). 
- Added unit tests in `frontend/src/pages/experiment/LandingTab.test.ts` covering `htmlGeraLanding` preference, `landingPageHtml` fallback, and blocking when both are empty. 
- Updated documentation: `docs/canonical/procedimento-experimento-canon.v1.md` and `docs/registros/experimentos.md` to declare the frontend/backend availability rule and recorded the fix and files inspected.

### Testing
- Added and ran the unit tests in `frontend/src/pages/experiment/LandingTab.test.ts` with `vitest`, and the new tests passed. 
- Ran the frontend unit test suite including the modified `LandingTab` tests, and the suite passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1df9ba497c83219c3bfdc71f4a6b06)