### PR TITLE
Ordena nichos enriquecidos OPRM por score

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/cnae/service/OprmCnaeOpportunityPersistenceService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/cnae/service/OprmCnaeOpportunityPersistenceService.java
@@ -174,11 +174,11 @@ public class OprmCnaeOpportunityPersistenceService {
     }
 
     /**
-     * Lista os nichos já enriquecidos pelo OPRM para consulta direta no frontend.
+     * Lista os nichos já enriquecidos pelo OPRM priorizando maiores scores para consulta direta no frontend.
      */
     @Transactional(readOnly = true)
     public List<OprmNicheCandidateResponseDto> listEnrichedCandidates(int limit) {
-        return candidateRepository.findAllByOrderByCreatedAtDesc(PageRequest.of(0, normalizeLimit(limit)))
+        return candidateRepository.findAllByOrderByOpportunityScoreDescCreatedAtDesc(PageRequest.of(0, normalizeLimit(limit)))
                 .stream()
                 .map(this::toCandidateResponse)
                 .toList();

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/cnae/web/OprmCnaeOpportunityController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/cnae/web/OprmCnaeOpportunityController.java
@@ -127,7 +127,7 @@ public class OprmCnaeOpportunityController {
     }
 
     /**
-     * Lista nichos já enriquecidos pelo OPRM para acompanhamento direto do usuário.
+     * Lista nichos já enriquecidos pelo OPRM em ordem decrescente de score para acompanhamento direto do usuário.
      */
     @GetMapping("/cnae-niche-candidates/enriched")
     public List<OprmNicheCandidateResponseDto> listEnrichedCandidates(@RequestParam(defaultValue = "100") int limit) {

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/oprm/cnae/OprmNicheCandidateRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/oprm/cnae/OprmNicheCandidateRepository.java
@@ -15,8 +15,8 @@ public interface OprmNicheCandidateRepository extends JpaRepository<OprmNicheCan
     List<OprmNicheCandidate> findByCnaeCodeOrderByOpportunityScoreDescCreatedAtDesc(String cnaeCode);
 
     /**
-     * Lista candidatos de nicho enriquecidos mais recentes para acompanhamento no frontend.
+     * Lista candidatos de nicho enriquecidos priorizando maiores scores para acompanhamento no frontend.
      */
-    List<OprmNicheCandidate> findAllByOrderByCreatedAtDesc(Pageable pageable);
+    List<OprmNicheCandidate> findAllByOrderByOpportunityScoreDescCreatedAtDesc(Pageable pageable);
 }
 

--- a/backend/ads-service/src/test/java/com/marketinghub/oprm/cnae/service/OprmCnaeOpportunityPersistenceServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/oprm/cnae/service/OprmCnaeOpportunityPersistenceServiceTest.java
@@ -1,0 +1,99 @@
+package com.marketinghub.oprm.cnae.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.marketinghub.oprm.cnae.OprmNicheCandidate;
+import com.marketinghub.oprm.cnae.dto.OprmNicheCandidateResponseDto;
+import com.marketinghub.oprm.cnae.repository.OprmCnaeOpportunityReadRepository;
+import com.marketinghub.repository.jpa.oprm.cnae.OprmCnaeEnrichmentArtifactRepository;
+import com.marketinghub.repository.jpa.oprm.cnae.OprmCnaeOpportunityScoreRepository;
+import com.marketinghub.repository.jpa.oprm.cnae.OprmCnaeProcessingCycleRepository;
+import com.marketinghub.repository.jpa.oprm.cnae.OprmNicheCandidateRepository;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Pageable;
+
+/**
+ * Teste responsável por validar a persistência consultiva do fluxo CNAE de oportunidade do OPRM.
+ */
+@ExtendWith(MockitoExtension.class)
+class OprmCnaeOpportunityPersistenceServiceTest {
+
+    @Mock
+    private OprmCnaeOpportunityReadRepository opportunityReadRepository;
+
+    @Mock
+    private OprmCnaeOpportunityScoreRepository scoreRepository;
+
+    @Mock
+    private OprmCnaeProcessingCycleRepository cycleRepository;
+
+    @Mock
+    private OprmCnaeEnrichmentArtifactRepository artifactRepository;
+
+    @Mock
+    private OprmNicheCandidateRepository candidateRepository;
+
+    private OprmCnaeOpportunityPersistenceService service;
+
+    /**
+     * Inicializa o serviço com dependências mockadas para isolar a consulta de candidatos enriquecidos.
+     */
+    @BeforeEach
+    void setUp() {
+        service = new OprmCnaeOpportunityPersistenceService(
+                opportunityReadRepository,
+                scoreRepository,
+                cycleRepository,
+                artifactRepository,
+                candidateRepository);
+    }
+
+    /**
+     * Garante que a listagem de nichos enriquecidos usa a consulta priorizada por maior score.
+     */
+    @Test
+    void shouldListEnrichedCandidatesByHighestOpportunityScoreFirst() {
+        OprmNicheCandidate topCandidate = candidate(1L, "8599604", "Mentoria infantil com IA", "90.00");
+        OprmNicheCandidate lowerCandidate = candidate(2L, "8511200", "Playbook creche", "30.00");
+        when(candidateRepository.findAllByOrderByOpportunityScoreDescCreatedAtDesc(any(Pageable.class)))
+                .thenReturn(List.of(topCandidate, lowerCandidate));
+
+        List<OprmNicheCandidateResponseDto> response = service.listEnrichedCandidates(100);
+
+        assertThat(response)
+                .extracting(OprmNicheCandidateResponseDto::opportunityScore)
+                .containsExactly(new BigDecimal("90.00"), new BigDecimal("30.00"));
+        verify(candidateRepository).findAllByOrderByOpportunityScoreDescCreatedAtDesc(any(Pageable.class));
+    }
+
+    /**
+     * Cria um candidato mínimo para validar o mapeamento de resposta do serviço.
+     */
+    private OprmNicheCandidate candidate(Long id, String cnaeCode, String nicheName, String opportunityScore) {
+        OprmNicheCandidate candidate = new OprmNicheCandidate();
+        candidate.setId(id);
+        candidate.setCnaeCode(cnaeCode);
+        candidate.setCnaeDescription("Educação infantil");
+        candidate.setCandidateNicheName(nicheName);
+        candidate.setPainHypothesis("Dor principal");
+        candidate.setDesiredOutcome("Resultado desejado");
+        candidate.setMechanismHypothesis("Mecanismo");
+        candidate.setOpportunityScore(new BigDecimal(opportunityScore));
+        candidate.setScoreCycleId("OPRM-CNAE-SCORE-20260601-001");
+        candidate.setEnrichmentCycleId("OPRM-CNAE-ENRICHMENT-20260601-001");
+        candidate.setStatus("ENRICHED");
+        candidate.setCreatedAt(Instant.parse("2026-06-01T21:15:03Z"));
+        candidate.setUpdatedAt(Instant.parse("2026-06-01T21:15:03Z"));
+        return candidate;
+    }
+}

--- a/docs/canonical/oprm-canon.v1.md
+++ b/docs/canonical/oprm-canon.v1.md
@@ -81,6 +81,17 @@ Evitar fechamento prematuro de `import run` que destrói a totalização de mark
 - Ao navegar entre páginas, a ordenação deve permanecer estável por `Score OPRM` decrescente.
 - O texto de apoio na tela deve deixar explícito para o usuário que o ranking está ordenado por Score OPRM e paginado.
 
+## Regra obrigatória — lista de nichos enriquecidos por score
+
+- A lista de nichos enriquecidos exibida na tela de CNAEs por Score OPRM deve priorizar os candidatos com maior `opportunityScore` no começo.
+- A ordenação deve ser aplicada no backend, com `opportunityScore` em ordem decrescente e `createdAt` em ordem decrescente como desempate estável.
+- O frontend deve informar ao usuário que a lista está ordenada pelos maiores scores, mantendo dor, resultado e mecanismo como contexto de decisão.
+
+## Critério de efetividade — nichos enriquecidos por score
+
+- Ao abrir "Nichos já enriquecidos", o primeiro item retornado deve ter score maior ou igual aos demais itens da página.
+- Em caso de scores iguais, candidatos enriquecidos mais recentemente aparecem primeiro para preservar rastreabilidade operacional.
+
 ## Regra obrigatória — responsabilidade do OPRM no fluxo CNAE → oportunidade
 
 - No fluxo CNAE → score → enriquecimento → candidatos de nicho, o **módulo OPRM** é o único responsável por cálculo de score de oportunidade, seleção de CNAEs prioritários para enriquecimento, pesquisa externa, acionamento de MDS/Worker AI e geração de candidatos de nicho.

--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -209,3 +209,4 @@
 - 2026-06-01 00:00:00 (UTC): adicionados wireframes SVG das telas de acompanhamento operacional do OPRM para facilitar validação visual do Painel OPRM, Ingestão de Mercado, Ciclos CNAE, Candidatos de Nicho, Fila de Decisão e Diagnóstico antes da implementação frontend.
 
 - 2026-06-01 00:00:00 (UTC): adicionado botão na tela `/oprm/cnaes-volume` para o usuário consultar diretamente os nichos já enriquecidos pelo OPRM; backend recebeu endpoint de leitura dos candidatos enriquecidos mais recentes e frontend passou a exibir tabela com nicho, CNAE, dor, resultado, mecanismo, score, status e data de enriquecimento.
+- 2026-06-01 18:52:03 (UTC-3): ajuste na tela de CNAEs por Score OPRM para que a lista "Nichos já enriquecidos" seja carregada pelo backend em ordem decrescente de `opportunityScore`, com `createdAt` como desempate, deixando os maiores scores no começo para priorizar decisões com maior potencial de venda.

--- a/frontend/src/pages/oprm/OprmCnaeVolumePage.tsx
+++ b/frontend/src/pages/oprm/OprmCnaeVolumePage.tsx
@@ -182,8 +182,8 @@ export default function OprmCnaeVolumePage() {
                 <h2 className="h5 mb-1">Nichos já enriquecidos</h2>
                 <p className="text-secondary mb-0">
                   Lista dos candidatos de nicho que já receberam enriquecimento
-                  do OPRM, com dor, resultado e mecanismo para decisão do
-                  usuário.
+                  do OPRM, ordenada pelos maiores scores, com dor, resultado e
+                  mecanismo para decisão do usuário.
                 </p>
               </div>
               <button


### PR DESCRIPTION
### Motivation
- The UI requirement is to surface the highest-opportunity candidates first in the "Nichos já enriquecidos" view to prioritize decisions with greater commercial potential.
- The canonical rules require ordering by score on the backend rather than sorting client-side for stability and pagination compliance.

### Description
- Backend: changed the `OprmNicheCandidateRepository` query to `findAllByOrderByOpportunityScoreDescCreatedAtDesc` and updated `OprmCnaeOpportunityPersistenceService.listEnrichedCandidates` to use it so results are returned ordered by `opportunityScore` (desc) with `createdAt` as tiebreaker.
- Controller: updated the `OprmCnaeOpportunityController` documentation comment to reflect the new descending-score contract for `GET /api/oprm/cnae-niche-candidates/enriched`.
- Frontend: updated the help text in `OprmCnaeVolumePage.tsx` to inform users that the enriched niches list is ordered by highest scores.
- Docs & audit: added the rule to `docs/canonical/oprm-canon.v1.md` and recorded the change in `docs/registros/oprm1.md`.
- Tests: added `OprmCnaeOpportunityPersistenceServiceTest` to assert the repository/service returns candidates ordered by `opportunityScore`.

### Testing
- Ran the focused unit test with `../mvnw -q -Dtest=OprmCnaeOpportunityPersistenceServiceTest test` which executed successfully.
- Installed frontend dependencies with `npm ci` which completed successfully and then ran `npm run typecheck` which passed (no type errors).
- Attempted `../mvnw -q spotless:check` which did not run due to Spotless plugin not being available in the current Maven reactor (reported as a tooling/plugin issue).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1dfe7adb0c8321a728f2c605ba6e88)