### PR TITLE
fix: desbloqueia aprovação de landing via backend

### DIFF
--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -3022,3 +3022,14 @@
   - frontend/src/api/experiment/useExperiments.ts
   - frontend/src/api/experiment/useApproveAndPublishLanding.ts
   - backend/ads-service/src/main/java/com/marketinghub/geralanding/GeraLandingStageExecutionService.java
+
+## 2026-06-01 21:56:00 UTC — Desbloqueio da aprovação quando a prévia local não carrega
+
+- solicitação: experimento 35 continuava com o botão "Aprovar landing para campanha" desabilitado mesmo tendo HTML salvo em `html_geralanding`.
+- causa-raiz identificada: a verificação operacional via MCP confirmou que o banco possui `html_geralanding` preenchido para o experimento 35, mas a interface ainda podia depender da prévia local carregada no navegador para habilitar a ação; isso criava falso bloqueio de frontend enquanto o endpoint backend já consulta o registro atualizado e consegue validar o HTML no servidor.
+- registro do que foi feito:
+  - a aba Landing passou a habilitar a tentativa de aprovação quando existe `id` do experimento, deixando o backend como fonte de verdade para aceitar ou recusar a publicação;
+  - quando a prévia local não encontra HTML, a tela mostra aviso explicando que a publicação consulta o registro atualizado no backend;
+  - os testes unitários foram ajustados para separar ausência de prévia local da possibilidade de tentar aprovação pelo backend.
+- validações operacionais:
+  - `SELECT id, LENGTH(html_geralanding), LENGTH(landing_page_html), follow_up_action_url, status FROM experiment WHERE id = 35` retornou `html_geralanding` preenchido e `landing_page_html` nulo, confirmando que a landing gerada existe no registro canônico do GeraLanding.

--- a/frontend/src/pages/experiment/LandingTab.test.ts
+++ b/frontend/src/pages/experiment/LandingTab.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { resolveLandingHtml } from "./LandingTab";
+import { canAttemptLandingApproval, resolveLandingHtml } from "./LandingTab";
 
 describe("LandingTab", () => {
   it("usa htmlGeraLanding como HTML suficiente para liberar a aprovação", () => {
@@ -20,9 +20,17 @@ describe("LandingTab", () => {
     ).toBe("<html><body>Landing legado</body></html>");
   });
 
-  it("bloqueia aprovação quando ambos os campos de HTML estão vazios", () => {
+  it("não encontra prévia quando ambos os campos de HTML estão vazios", () => {
     expect(
       resolveLandingHtml({ htmlGeraLanding: "   ", landingPageHtml: null }),
     ).toBeNull();
+  });
+
+  it("permite tentar aprovação pelo backend mesmo sem prévia local", () => {
+    expect(canAttemptLandingApproval({ id: "35" })).toBe(true);
+  });
+
+  it("bloqueia aprovação apenas quando o experimento não tem id", () => {
+    expect(canAttemptLandingApproval({ id: "" })).toBe(false);
   });
 });

--- a/frontend/src/pages/experiment/LandingTab.tsx
+++ b/frontend/src/pages/experiment/LandingTab.tsx
@@ -34,6 +34,10 @@ export function resolveLandingHtml(
   return typeof raw === "string" && raw.trim().length > 0 ? raw : null;
 }
 
+export function canAttemptLandingApproval(experiment: Pick<Experiment, "id">) {
+  return String(experiment.id ?? "").trim().length > 0;
+}
+
 export default function LandingTab({ experiment }: LandingTabProps) {
   const approveAndPublishLanding = useApproveAndPublishLanding(
     Number(experiment.id),
@@ -48,6 +52,7 @@ export default function LandingTab({ experiment }: LandingTabProps) {
     iframeUrl: string | null;
     standaloneUrl: string | null;
   } | null>(null);
+  const canApproveLanding = canAttemptLandingApproval(experiment);
   const selectedDestinationUrl = normalizeUrl(
     publishedUrls?.standaloneUrl ?? experiment.followUpActionUrl,
   );
@@ -105,9 +110,11 @@ export default function LandingTab({ experiment }: LandingTabProps) {
       ) : null}
 
       {!landingHtml ? (
-        <p className="text-muted mb-0">
-          Nenhum HTML de landing encontrado no registro do experimento.
-        </p>
+        <div className="alert alert-warning mb-0" role="alert">
+          A prévia não carregou o HTML no navegador, mas a aprovação consulta o
+          registro atualizado no backend. Se o HTML já existir em
+          <code>html_geralanding</code>, use o botão para publicar a landing.
+        </div>
       ) : (
         <div className="card border-0 shadow-sm">
           <div className="card-body d-flex flex-column gap-3">
@@ -178,7 +185,7 @@ export default function LandingTab({ experiment }: LandingTabProps) {
           type="button"
           className="btn btn-success"
           onClick={() => handleApproveLanding()}
-          disabled={approveAndPublishLanding.isPending || !landingHtml}
+          disabled={approveAndPublishLanding.isPending || !canApproveLanding}
         >
           {approveAndPublishLanding.isPending ? (
             <span className="d-inline-flex align-items-center gap-2">


### PR DESCRIPTION
### Motivation
- Experimento 35 não permitia aprovar a landing porque a UI bloqueava o botão quando a pré-visualização não carregava, mesmo com `html_geralanding` preenchido no banco; o backend já é a fonte de verdade para validar o HTML.

### Description
- Ajusta a aba de Landing para permitir tentar a aprovação quando existe `experiment.id` adicionando a função `canAttemptLandingApproval` e usando-a no `disabled` do botão de aprovação (`frontend/src/pages/experiment/LandingTab.tsx`).
- Mantém `htmlGeraLanding` com fallback para `landingPageHtml` via `resolveLandingHtml`, e exibe um aviso quando a prévia local não está disponível para explicar que a publicação consulta o backend.
- Atualiza testes unitários em `frontend/src/pages/experiment/LandingTab.test.ts` para separar ausência de prévia local da possibilidade de tentar aprovação pelo backend.
- Registra a investigação operacional no `docs/registros/experimentos.md` (caso do experimento 35) e comita as mudanças relacionadas.

### Testing
- Executado `npx prettier --check` sobre os arquivos alterados e a verificação passou sem problemas.
- Executado `npm run typecheck` (`tsc --noEmit`) e o typecheck passou com sucesso após instalar dependências.
- Executado `npx vitest run src/pages/experiment/LandingTab.test.ts` e todos os testes unitários relacionados passaram (5 tests, 5 passed).
- Executado `npm run build` e a build de produção do frontend completou com sucesso.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1dff4d6970832192aabaa3339a1918)