### PR TITLE
Add GeraLanding public landing approve-and-publish endpoint and service

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/publiclanding/service/BackendPublicLandingService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/publiclanding/service/BackendPublicLandingService.java
@@ -1,0 +1,372 @@
+package com.marketinghub.geralanding.publiclanding.service;
+
+import com.marketinghub.experiment.Experiment;
+import com.marketinghub.geralanding.publiclanding.service.approveEndPublish.PublicLandingLeadPortalPublishRequest;
+import com.marketinghub.geralanding.publiclanding.service.approveEndPublish.PublicLandingPublicationResponse;
+import com.marketinghub.geralanding.publiclanding.service.pending.RecordPublicLandingPending;
+import com.marketinghub.repository.jpa.experiment.ExperimentRepository;
+import jakarta.persistence.EntityNotFoundException;
+import java.net.URI;
+import java.util.List;
+import java.util.Locale;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.parser.Parser;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpEntity;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.server.ResponseStatusException;
+import org.springframework.web.util.UriComponentsBuilder;
+
+/** Orquestra a aprovação e publicação da landing pública gerada pelo GeraLanding. */
+@Service
+public class BackendPublicLandingService {
+    private static final Logger log = LoggerFactory.getLogger(BackendPublicLandingService.class);
+
+    private final ExperimentRepository experimentRepository;
+    private final RestTemplate restTemplate;
+    private final String leadPortalBaseUrl;
+
+    /** Cria o service com repositório de experimentos, cliente HTTP e URL base do Lead Portal. */
+    public BackendPublicLandingService(
+            ExperimentRepository experimentRepository,
+            RestTemplate restTemplate,
+            @Value("${integrations.lead-portal.base-url:}") String leadPortalBaseUrl) {
+        this.experimentRepository = experimentRepository;
+        this.restTemplate = restTemplate;
+        this.leadPortalBaseUrl = leadPortalBaseUrl;
+    }
+
+    /** Aprova a landing do experimento, publica no Lead Portal e grava a URL pública oficial. */
+    @Transactional
+    public PublicLandingPublicationResponse approveEndPublish(Long experimentId) {
+        log.info("GeraLanding public landing publish approval started (experimentId={})", experimentId);
+        try {
+            Experiment experiment = experimentRepository.findById(experimentId)
+                    .orElseThrow(() -> new EntityNotFoundException("Experiment not found: " + experimentId));
+            log.info("GeraLanding public landing publish approval loaded experiment (experimentId={}, experimentName={})",
+                    experimentId, experiment.getName());
+
+            String landingPageHtml = resolveLandingPageHtml(experiment, experimentId);
+            String slug = "exp-" + experimentId + "-landing-geralanding";
+            log.info("GeraLanding public landing publish approval resolved slug (experimentId={}, slug={})", experimentId, slug);
+
+            String finalHtml = buildFinalPublicHtml(experiment, experimentId, landingPageHtml);
+            publishToLeadPortal(slug, "Landing GeraLanding - Experimento " + experimentId, finalHtml.trim());
+            log.info("GeraLanding public landing publish approval sent flow to Lead Portal successfully (experimentId={}, slug={})",
+                    experimentId, slug);
+
+            String iframeUrl = resolveIframeUrl(slug);
+            String standaloneUrl = resolveStandaloneLandingUrl(iframeUrl);
+            log.info("GeraLanding public landing publish approval resolved publication URLs (experimentId={}, iframeUrl={}, standaloneUrl={})",
+                    experimentId, iframeUrl, standaloneUrl);
+
+            experiment.setLandingPageHtml(finalHtml.trim());
+            experiment.setFollowUpActionUrl(standaloneUrl);
+            experimentRepository.save(experiment);
+            log.info("GeraLanding public landing publish approval saved follow-up URL (experimentId={}, followUpActionUrl={})",
+                    experimentId, standaloneUrl);
+            return new PublicLandingPublicationResponse(
+                    experimentId,
+                    null,
+                    iframeUrl,
+                    standaloneUrl,
+                    "Landing publicada com sucesso pelo GeraLanding.");
+        } catch (RuntimeException ex) {
+            log.error(
+                    "GeraLanding public landing publish approval failed (experimentId={}, errorClass={}, message={})",
+                    experimentId,
+                    ex.getClass().getName(),
+                    ex.getMessage(),
+                    ex);
+            throw ex;
+        }
+    }
+
+    /** Método canônico de etapa reutilizado para publicar a landing pública pelo endpoint approve-end-publish. */
+    public PublicLandingPublicationResponse start(Long experimentId) {
+        return approveEndPublish(experimentId);
+    }
+
+    /** Bloqueia listagem de execuções porque landing pública não possui fila própria. */
+    public Object listStageExecutions(Long experimentId) {
+        throw new ResponseStatusException(HttpStatus.GONE, "Landing pública não possui stage-executions próprias");
+    }
+
+    /** Retorna lista vazia porque a landing pública publica de forma síncrona e não possui pendências internas. */
+    public List<RecordPublicLandingPending> pending() {
+        return List.of();
+    }
+
+    /** Bloqueia recebimento de prompt porque landing pública não aciona IA diretamente. */
+    public void recebePrompt(String idJob, Object payload) {
+        throw new ResponseStatusException(HttpStatus.GONE, "Landing pública não recebe prompt de IA");
+    }
+
+    /** Bloqueia recebimento de resposta porque landing pública não aciona IA diretamente. */
+    public void recebeResposta(String idJob, Object payload) {
+        throw new ResponseStatusException(HttpStatus.GONE, "Landing pública não recebe resposta de IA");
+    }
+
+    /** Bloqueia detalhe de execução porque landing pública não possui job assíncrono próprio. */
+    public Object detailStageExecution(Long experimentId, String idJob) {
+        throw new ResponseStatusException(HttpStatus.GONE, "Landing pública não possui detalhe de execução próprio");
+    }
+
+    /** Seleciona o HTML canônico da landing, priorizando html_geralanding e usando landing_page_html como fallback. */
+    private String resolveLandingPageHtml(Experiment experiment, Long experimentId) {
+        String landingPageHtml = experiment.getHtmlGeraLanding();
+        if (!StringUtils.hasText(landingPageHtml)) {
+            landingPageHtml = experiment.getLandingPageHtml();
+        }
+        if (!StringUtils.hasText(landingPageHtml)) {
+            log.warn("GeraLanding public landing publish approval blocked because landing HTML is missing (experimentId={})",
+                    experimentId);
+            throw new ResponseStatusException(HttpStatus.CONFLICT, "Landing HTML ainda não foi gerado para este experimento");
+        }
+        log.info("GeraLanding public landing publish approval found landing HTML (experimentId={}, htmlLength={})",
+                experimentId, landingPageHtml.length());
+        return landingPageHtml;
+    }
+
+    /** Monta o HTML final publicável com tracking, controles de funil e pixel do Facebook. */
+    private String buildFinalPublicHtml(Experiment experiment, Long experimentId, String landingPageHtml) {
+        String htmlWithTracking = injectBehaviorTrackingAttributesAndScript(landingPageHtml);
+        String htmlWithFunnelControls = injectFunnelControls(htmlWithTracking);
+        log.info("GeraLanding public landing publish approval injected funnel controls (experimentId={}, htmlLengthBefore={}, htmlLengthAfter={})",
+                experimentId, landingPageHtml.length(), htmlWithFunnelControls.length());
+
+        String facebookPixelId = resolveFacebookPixelId(experiment);
+        log.info("GeraLanding public landing publish approval resolved Facebook Pixel (experimentId={}, hasPixelId={})",
+                experimentId, StringUtils.hasText(facebookPixelId));
+        String htmlWithFacebookPixel = injectFacebookPixel(htmlWithFunnelControls, facebookPixelId);
+        log.info("GeraLanding public landing publish approval injected Facebook Pixel (experimentId={}, htmlLengthBefore={}, htmlLengthAfter={})",
+                experimentId, htmlWithFunnelControls.length(), htmlWithFacebookPixel.length());
+        return htmlWithFacebookPixel;
+    }
+
+    /** Publica o HTML final no Lead Portal usando o contrato oficial de flow público. */
+    private void publishToLeadPortal(String slug, String name, String html) {
+        if (!StringUtils.hasText(leadPortalBaseUrl)) {
+            log.warn("GeraLanding public landing Lead Portal publication blocked because base URL is not configured (slug={})", slug);
+            throw new ResponseStatusException(HttpStatus.BAD_GATEWAY, "Lead Portal base URL não configurada");
+        }
+        URI uri = UriComponentsBuilder.fromHttpUrl(leadPortalBaseUrl).path("/api/flows/{slug}").buildAndExpand(slug).toUri();
+        log.info("GeraLanding public landing Lead Portal publication request prepared (slug={}, uri={}, name={}, htmlLength={})",
+                slug, uri, name, html == null ? 0 : html.length());
+        HttpHeaders headers = new HttpHeaders();
+        headers.setContentType(MediaType.APPLICATION_JSON);
+        PublicLandingLeadPortalPublishRequest payload = new PublicLandingLeadPortalPublishRequest(
+                slug, name, "Fluxo publicado pelo módulo GeraLanding", html);
+        log.info("GeraLanding public landing Lead Portal publication request parameters (slug={}, uri={}, headers={}, payload={})",
+                slug, uri, headers, payload);
+        try {
+            restTemplate.put(uri, new HttpEntity<>(payload, headers));
+            log.info("GeraLanding public landing Lead Portal publication request completed (slug={}, uri={})", slug, uri);
+        } catch (RestClientException ex) {
+            log.error("GeraLanding public landing Lead Portal publication request failed (slug={}, uri={}, endpoint={}, errorClass={}, message={})",
+                    slug, uri, uri, ex.getClass().getName(), ex.getMessage(), ex);
+            throw new ResponseStatusException(HttpStatus.BAD_GATEWAY, "Falha ao publicar landing no Lead Portal", ex);
+        }
+    }
+
+    /** Resolve a URL iframe pública retornada ao frontend após publicação. */
+    private String resolveIframeUrl(String slug) {
+        return UriComponentsBuilder.fromHttpUrl(leadPortalBaseUrl)
+                .path("/api/public/flows/{slug}")
+                .buildAndExpand(slug)
+                .toUriString();
+    }
+
+    /** Injeta o script interno de controle de funil quando ainda não está presente. */
+    private String injectFunnelControls(String html) {
+        String controls = """
+                <script data-mh-funnel-controls=\"true\">
+                  window.__MH_FUNNEL_CONTROLS__ = { enabled: true, source: 'geralanding' };
+                </script>
+                """;
+        if (html.toLowerCase(Locale.ROOT).contains("data-mh-funnel-controls")) {
+            return html;
+        }
+        if (html.toLowerCase(Locale.ROOT).contains("</head>")) {
+            return html.replaceFirst("(?i)</head>", controls + "\n</head>");
+        }
+        return controls + "\n" + html;
+    }
+
+    /** Obtém por reflexão o identificador do Facebook Pixel configurado no nicho do experimento. */
+    private String resolveFacebookPixelId(Experiment experiment) {
+        if (experiment == null) {
+            return null;
+        }
+        try {
+            Object niche = Experiment.class.getMethod("getNiche").invoke(experiment);
+            if (niche == null) {
+                return null;
+            }
+            Object pixelId = niche.getClass().getMethod("getFacebookPixelId").invoke(niche);
+            return pixelId instanceof String value && StringUtils.hasText(value) ? value.trim() : null;
+        } catch (ReflectiveOperationException ex) {
+            log.warn("GeraLanding public landing Facebook Pixel resolution failed (experimentId={})", experiment.getId(), ex);
+            return null;
+        }
+    }
+
+    /** Injeta o snippet do Facebook Pixel quando há pixel configurado e ele ainda não existe no HTML. */
+    private String injectFacebookPixel(String html, String facebookPixelId) {
+        if (!StringUtils.hasText(html) || !StringUtils.hasText(facebookPixelId)) {
+            return html;
+        }
+        if (html.contains("data-mh-facebook-pixel")) {
+            return html;
+        }
+        String pixelSnippet = """
+                <script data-mh-facebook-pixel="true">
+                  !function(f,b,e,v,n,t,s){if(f.fbq)return;n=f.fbq=function(){n.callMethod?
+                  n.callMethod.apply(n,arguments):n.queue.push(arguments)};if(!f._fbq)f._fbq=n;
+                  n.push=n;n.loaded=!0;n.version='2.0';n.queue=[];t=b.createElement(e);t.async=!0;
+                  t.src=v;s=b.getElementsByTagName(e)[0];s.parentNode.insertBefore(t,s)}(window, document,'script',
+                  'https://connect.facebook.net/en_US/fbevents.js');
+                  fbq('init', '%s');
+                  fbq('track', 'PageView');
+                </script>
+                <noscript><img height="1" width="1" style="display:none"
+                  src="https://www.facebook.com/tr?id=%s&ev=PageView&noscript=1"
+                /></noscript>
+                """.formatted(facebookPixelId, facebookPixelId).trim();
+        if (html.toLowerCase(Locale.ROOT).contains("</head>")) {
+            return html.replaceFirst("(?i)</head>", pixelSnippet + "\n</head>");
+        }
+        if (html.toLowerCase(Locale.ROOT).contains("<body")) {
+            return html.replaceFirst("(?i)<body", pixelSnippet + "\n<body");
+        }
+        return pixelSnippet + "\n" + html;
+    }
+
+    /** Converte a URL iframe do Lead Portal na URL standalone usada como destino oficial da campanha. */
+    private String resolveStandaloneLandingUrl(String iframeUrl) {
+        if (!StringUtils.hasText(iframeUrl)) {
+            return null;
+        }
+        try {
+            URI parsed = URI.create(iframeUrl);
+            String[] segments = parsed.getPath().split("/");
+            String slug = segments.length == 0 ? "" : segments[segments.length - 1];
+            if (!StringUtils.hasText(slug)) {
+                return null;
+            }
+            return UriComponentsBuilder.newInstance()
+                    .scheme(parsed.getScheme())
+                    .host(parsed.getHost())
+                    .port(parsed.getPort())
+                    .path("/api/flows/{slug}/page")
+                    .buildAndExpand(slug)
+                    .toUriString();
+        } catch (RuntimeException ex) {
+            log.warn("GeraLanding public landing standalone URL resolution failed (iframeUrl={})", iframeUrl, ex);
+            return null;
+        }
+    }
+
+    /** Injeta atributos e script de telemetria de comportamento nas seções da landing. */
+    private String injectBehaviorTrackingAttributesAndScript(String html) {
+        if (!StringUtils.hasText(html) || html.contains("data-mh-funnel-tracking")) {
+            return html;
+        }
+        Document document = Jsoup.parse(html, "", Parser.htmlParser());
+        document.outputSettings().prettyPrint(false);
+
+        for (Element section : document.select("section[data-section-id], section[id], [data-section-id]")) {
+            String sectionId = section.hasAttr("data-section-id") ? section.attr("data-section-id") : section.id();
+            if (!StringUtils.hasText(sectionId)) {
+                continue;
+            }
+            section.attr("data-track-section", sectionId.trim());
+        }
+
+        String script = """
+                <script data-mh-funnel-tracking="true">
+                (function(){
+                  if (window.__mhFunnelTrackingInstalled) return;
+                  window.__mhFunnelTrackingInstalled = true;
+                  var debugPrefix = '[MH funnel tracking]';
+                  window.dataLayer = window.dataLayer || [];
+
+                  function emit(name, payload){
+                    var eventPayload = Object.assign({event:name, source:'landing-page-design-preset'}, payload||{});
+                    console.debug(debugPrefix, 'emit', eventPayload);
+                    window.dataLayer.push(eventPayload);
+                  }
+
+                  function initTracking(){
+                    console.debug(debugPrefix, 'bootstrap');
+                    emit('page_view', {ts: Date.now()});
+                    var sections = Array.prototype.slice.call(document.querySelectorAll('[data-track-section]'));
+                    console.debug(debugPrefix, 'sections-found', {count: sections.length});
+                    var stats = {};
+                    sections.forEach(function(node){
+                      var id = node.getAttribute('data-track-section');
+                      stats[id] = {visibleSince:null, elapsedMs:0};
+                    });
+                    function flushSection(id, reason){
+                      var s = stats[id];
+                      if (!s || s.visibleSince === null) return;
+                      s.elapsedMs += Date.now() - s.visibleSince;
+                      s.visibleSince = null;
+                      console.debug(debugPrefix, 'section-flush', {sectionId:id, elapsedMs:s.elapsedMs, reason: reason || 'hidden'});
+                      emit('section_view_time', {sectionId:id, elapsedMs:s.elapsedMs, reason: reason || 'hidden'});
+                    }
+                    var observer = new IntersectionObserver(function(entries){
+                      entries.forEach(function(entry){
+                        var id = entry.target.getAttribute('data-track-section');
+                        if (!id || !stats[id]) return;
+                        if (entry.isIntersecting && entry.intersectionRatio >= 0.5) {
+                          if (stats[id].visibleSince === null) {
+                            stats[id].visibleSince = Date.now();
+                            console.debug(debugPrefix, 'section-visible', {sectionId:id, ts:stats[id].visibleSince});
+                            emit('section_view_start', {sectionId:id});
+                          }
+                        } else {
+                          flushSection(id, 'intersection-change');
+                        }
+                      });
+                    }, {threshold:[0,0.5,1]});
+                    sections.forEach(function(node){ observer.observe(node); });
+                    document.addEventListener('visibilitychange', function(){
+                      if (document.hidden) {
+                        console.debug(debugPrefix, 'visibility-hidden');
+                        Object.keys(stats).forEach(function(id){ flushSection(id, 'tab-hidden'); });
+                      }
+                    });
+                    window.addEventListener('beforeunload', function(){
+                      console.debug(debugPrefix, 'beforeunload-flush');
+                      Object.keys(stats).forEach(function(id){ flushSection(id, 'before-unload'); });
+                    });
+                  }
+
+                  if (document.readyState === 'loading') {
+                    document.addEventListener('DOMContentLoaded', initTracking);
+                  } else {
+                    initTracking();
+                  }
+                })();
+                </script>
+                """;
+        if (document.head() != null) {
+            document.head().append(script);
+        } else {
+            document.prepend(script);
+        }
+        return document.outerHtml();
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/publiclanding/service/approveEndPublish/PublicLandingLeadPortalPublishRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/publiclanding/service/approveEndPublish/PublicLandingLeadPortalPublishRequest.java
@@ -1,0 +1,9 @@
+package com.marketinghub.geralanding.publiclanding.service.approveEndPublish;
+
+/** Payload enviado ao Lead Portal para publicar o HTML final da landing pública. */
+public record PublicLandingLeadPortalPublishRequest(
+        String slug,
+        String name,
+        String description,
+        String customFormHtml) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/publiclanding/service/approveEndPublish/PublicLandingPublicationResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/publiclanding/service/approveEndPublish/PublicLandingPublicationResponse.java
@@ -1,0 +1,10 @@
+package com.marketinghub.geralanding.publiclanding.service.approveEndPublish;
+
+/** Resposta da aprovação e publicação da landing pública do GeraLanding. */
+public record PublicLandingPublicationResponse(
+        Long experimentId,
+        Long flowId,
+        String iframeUrl,
+        String standaloneUrl,
+        String message) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/publiclanding/service/detailStageExecution/PublicLandingDetailStageExecutionPlaceholder.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/publiclanding/service/detailStageExecution/PublicLandingDetailStageExecutionPlaceholder.java
@@ -1,0 +1,5 @@
+package com.marketinghub.geralanding.publiclanding.service.detailStageExecution;
+
+/** Marcador contratual do subpacote canônico detailStageExecution da landing pública. */
+public record PublicLandingDetailStageExecutionPlaceholder(String message) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/publiclanding/service/listStageExecutions/PublicLandingListStageExecutionsPlaceholder.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/publiclanding/service/listStageExecutions/PublicLandingListStageExecutionsPlaceholder.java
@@ -1,0 +1,5 @@
+package com.marketinghub.geralanding.publiclanding.service.listStageExecutions;
+
+/** Marcador contratual do subpacote canônico listStageExecutions da landing pública. */
+public record PublicLandingListStageExecutionsPlaceholder(String message) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/publiclanding/service/pending/PublicLandingPendingPlaceholder.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/publiclanding/service/pending/PublicLandingPendingPlaceholder.java
@@ -1,0 +1,5 @@
+package com.marketinghub.geralanding.publiclanding.service.pending;
+
+/** Marcador contratual do subpacote canônico pending da landing pública. */
+public record PublicLandingPendingPlaceholder(String message) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/publiclanding/service/pending/RecordPublicLandingPending.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/publiclanding/service/pending/RecordPublicLandingPending.java
@@ -1,0 +1,5 @@
+package com.marketinghub.geralanding.publiclanding.service.pending;
+
+/** Pendência canônica da landing pública, mantida vazia porque a publicação é síncrona. */
+public record RecordPublicLandingPending(Long experimentId, String idJob, String stageCode) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/publiclanding/service/recebePrompt/PublicLandingRecebePromptPlaceholder.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/publiclanding/service/recebePrompt/PublicLandingRecebePromptPlaceholder.java
@@ -1,0 +1,5 @@
+package com.marketinghub.geralanding.publiclanding.service.recebePrompt;
+
+/** Marcador contratual do subpacote canônico recebePrompt da landing pública. */
+public record PublicLandingRecebePromptPlaceholder(String message) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/publiclanding/service/recebeResposta/PublicLandingRecebeRespostaPlaceholder.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/publiclanding/service/recebeResposta/PublicLandingRecebeRespostaPlaceholder.java
@@ -1,0 +1,5 @@
+package com.marketinghub.geralanding.publiclanding.service.recebeResposta;
+
+/** Marcador contratual do subpacote canônico recebeResposta da landing pública. */
+public record PublicLandingRecebeRespostaPlaceholder(String message) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/publiclanding/web/BackendPublicLandingController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/publiclanding/web/BackendPublicLandingController.java
@@ -1,0 +1,66 @@
+package com.marketinghub.geralanding.publiclanding.web;
+
+import com.marketinghub.geralanding.publiclanding.service.BackendPublicLandingService;
+import com.marketinghub.geralanding.publiclanding.service.approveEndPublish.PublicLandingPublicationResponse;
+import com.marketinghub.geralanding.publiclanding.service.pending.RecordPublicLandingPending;
+import java.util.List;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/** Expõe endpoints públicos de aprovação e publicação da landing final do GeraLanding. */
+@RestController
+@RequestMapping("/api")
+public class BackendPublicLandingController {
+    private final BackendPublicLandingService service;
+
+    /** Cria o controller com o service responsável pela publicação da landing pública. */
+    public BackendPublicLandingController(BackendPublicLandingService service) {
+        this.service = service;
+    }
+
+    /** Aprova e publica a landing final no Lead Portal, mantendo alias legado com `and` para compatibilidade. */
+    @PostMapping({
+        "/experiments/{experimentId}/geralanding/landing/approve-end-publish",
+        "/experiments/{experimentId}/geralanding/landing/approve-and-publish"
+    })
+    public ResponseEntity<PublicLandingPublicationResponse> start(@PathVariable Long experimentId) {
+        return ResponseEntity.ok(service.start(experimentId));
+    }
+
+    /** Responde à rota canônica de listagem informando que a landing pública não possui fila própria. */
+    @GetMapping("/experiments/{experimentId}/geralanding/landing/stage-executions")
+    public ResponseEntity<Object> listStageExecutions(@PathVariable Long experimentId) {
+        return ResponseEntity.ok(service.listStageExecutions(experimentId));
+    }
+
+    /** Responde à rota canônica interna informando que não há pendências assíncronas para landing pública. */
+    @GetMapping("/internal/geralanding/landing/stage-executions/pending")
+    public List<RecordPublicLandingPending> pending() {
+        return service.pending();
+    }
+
+    /** Responde à rota canônica interna informando que a landing pública não recebe prompt de IA. */
+    @PostMapping("/internal/geralanding/landing/stage-executions/{idJob}/recebe-prompt")
+    public ResponseEntity<Void> recebePrompt(@PathVariable String idJob, @RequestBody(required = false) Object payload) {
+        service.recebePrompt(idJob, payload);
+        return ResponseEntity.accepted().build();
+    }
+
+    /** Responde à rota canônica interna informando que a landing pública não recebe resposta de IA. */
+    @PostMapping("/internal/geralanding/landing/stage-executions/{idJob}/recebe-resposta")
+    public ResponseEntity<Void> recebeResposta(@PathVariable String idJob, @RequestBody(required = false) Object payload) {
+        service.recebeResposta(idJob, payload);
+        return ResponseEntity.accepted().build();
+    }
+
+    /** Responde à rota canônica de detalhe informando que a landing pública não possui job próprio. */
+    @GetMapping("/experiments/{experimentId}/geralanding/landing/stage-executions/{idJob}")
+    public ResponseEntity<Object> detailStageExecution(@PathVariable Long experimentId, @PathVariable String idJob) {
+        return ResponseEntity.ok(service.detailStageExecution(experimentId, idJob));
+    }
+}

--- a/backend/ads-service/src/test/java/com/marketinghub/geralanding/publiclanding/BackendPublicLandingServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/geralanding/publiclanding/BackendPublicLandingServiceTest.java
@@ -1,0 +1,95 @@
+package com.marketinghub.geralanding.publiclanding;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.marketinghub.experiment.Experiment;
+import com.marketinghub.geralanding.publiclanding.service.BackendPublicLandingService;
+import com.marketinghub.geralanding.publiclanding.service.approveEndPublish.PublicLandingLeadPortalPublishRequest;
+import com.marketinghub.niche.MarketNiche;
+import com.marketinghub.repository.jpa.experiment.ExperimentRepository;
+import java.net.URI;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.HttpEntity;
+import org.springframework.web.client.RestTemplate;
+import org.springframework.web.server.ResponseStatusException;
+
+/** Valida a orquestração da publicação da landing pública do GeraLanding. */
+@ExtendWith(MockitoExtension.class)
+class BackendPublicLandingServiceTest {
+    @Mock
+    private ExperimentRepository experimentRepository;
+
+    @Mock
+    private RestTemplate restTemplate;
+
+    /** Deve publicar html_geralanding com tracking, controles de funil, pixel e URL standalone oficial. */
+    @Test
+    void approveEndPublishShouldPublishGeraLandingHtmlAndPersistStandaloneUrl() {
+        BackendPublicLandingService service = new BackendPublicLandingService(
+                experimentRepository,
+                restTemplate,
+                "http://lead-portal");
+        MarketNiche niche = new MarketNiche();
+        niche.setFacebookPixelId("123456789");
+        Experiment experiment = new Experiment();
+        experiment.setId(35L);
+        experiment.setName("Experimento 35");
+        experiment.setNiche(niche);
+        experiment.setHtmlGeraLanding("<html><head><title>LP</title></head><body><section id=\"hero\">Oferta</section></body></html>");
+        when(experimentRepository.findById(35L)).thenReturn(Optional.of(experiment));
+
+        var response = service.approveEndPublish(35L);
+
+        assertEquals(35L, response.experimentId());
+        assertEquals("http://lead-portal/api/public/flows/exp-35-landing-geralanding", response.iframeUrl());
+        assertEquals("http://lead-portal/api/flows/exp-35-landing-geralanding/page", response.standaloneUrl());
+        assertEquals(response.standaloneUrl(), experiment.getFollowUpActionUrl());
+        assertTrue(experiment.getLandingPageHtml().contains("data-mh-funnel-tracking"));
+        assertTrue(experiment.getLandingPageHtml().contains("data-mh-funnel-controls"));
+        assertTrue(experiment.getLandingPageHtml().contains("data-mh-facebook-pixel"));
+        assertTrue(experiment.getLandingPageHtml().contains("data-track-section=\"hero\""));
+        verify(experimentRepository).save(experiment);
+
+        ArgumentCaptor<URI> uriCaptor = ArgumentCaptor.forClass(URI.class);
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<HttpEntity<PublicLandingLeadPortalPublishRequest>> entityCaptor =
+                ArgumentCaptor.forClass(HttpEntity.class);
+        verify(restTemplate).put(uriCaptor.capture(), entityCaptor.capture());
+        assertEquals(URI.create("http://lead-portal/api/flows/exp-35-landing-geralanding"), uriCaptor.getValue());
+        PublicLandingLeadPortalPublishRequest payload = entityCaptor.getValue().getBody();
+        assertNotNull(payload);
+        assertEquals("exp-35-landing-geralanding", payload.slug());
+        assertEquals("Landing GeraLanding - Experimento 35", payload.name());
+        assertTrue(payload.customFormHtml().contains("data-mh-facebook-pixel"));
+    }
+
+    /** Deve bloquear publicação quando o experimento ainda não possui HTML de landing. */
+    @Test
+    void approveEndPublishShouldThrowConflictWhenLandingHtmlIsMissing() {
+        BackendPublicLandingService service = new BackendPublicLandingService(
+                experimentRepository,
+                restTemplate,
+                "http://lead-portal");
+        Experiment experiment = new Experiment();
+        experiment.setId(88L);
+        experiment.setName("Sem HTML");
+        when(experimentRepository.findById(88L)).thenReturn(Optional.of(experiment));
+
+        ResponseStatusException exception = org.junit.jupiter.api.Assertions.assertThrows(
+                ResponseStatusException.class,
+                () -> service.approveEndPublish(88L));
+
+        assertEquals(409, exception.getStatusCode().value());
+        verify(restTemplate, org.mockito.Mockito.never()).put(any(URI.class), any());
+    }
+}

--- a/backend/ads-service/src/test/java/com/marketinghub/geralanding/publiclanding/web/BackendPublicLandingControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/geralanding/publiclanding/web/BackendPublicLandingControllerTest.java
@@ -1,0 +1,34 @@
+package com.marketinghub.geralanding.publiclanding.web;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.marketinghub.geralanding.publiclanding.service.BackendPublicLandingService;
+import com.marketinghub.geralanding.publiclanding.service.approveEndPublish.PublicLandingPublicationResponse;
+import org.junit.jupiter.api.Test;
+
+/** Valida o contrato HTTP do controller de publicação da landing pública do GeraLanding. */
+class BackendPublicLandingControllerTest {
+
+    /** Deve delegar a aprovação e publicação para o service de landing pública. */
+    @Test
+    void startShouldDelegateApproveEndPublishToService() {
+        BackendPublicLandingService service = mock(BackendPublicLandingService.class);
+        BackendPublicLandingController controller = new BackendPublicLandingController(service);
+        PublicLandingPublicationResponse publication = new PublicLandingPublicationResponse(
+                35L,
+                null,
+                "http://lead/api/public/flows/exp-35-landing-geralanding",
+                "http://lead/api/flows/exp-35-landing-geralanding/page",
+                "ok");
+        when(service.start(35L)).thenReturn(publication);
+
+        var response = controller.start(35L);
+
+        assertEquals(200, response.getStatusCode().value());
+        assertEquals(publication, response.getBody());
+        verify(service).start(35L);
+    }
+}

--- a/docs/gera-landing/swagger-gera-landing-etapas.yaml
+++ b/docs/gera-landing/swagger-gera-landing-etapas.yaml
@@ -198,6 +198,52 @@ paths:
                 items:
                   $ref: "#/components/schemas/GeraLandingPendingExecutionResponse"
 
+  /api/experiments/{experimentId}/geralanding/landing/approve-end-publish:
+    post:
+      tags:
+        - Gera Landing Public Landing
+      summary: Aprova e publica a landing pública do GeraLanding
+      description: |
+        Publica o HTML final do GeraLanding no Lead Portal, injeta telemetria/controles/pixel e grava a URL standalone como destino oficial de campanha.
+      parameters:
+        - $ref: "#/components/parameters/ExperimentIdPath"
+      responses:
+        "200":
+          description: Landing aprovada e publicada com sucesso.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PublicLandingPublicationResponse"
+        "404":
+          description: Experimento não encontrado.
+        "409":
+          description: HTML da landing ainda não foi gerado.
+        "502":
+          description: Lead Portal indisponível ou base URL não configurada.
+
+  /api/experiments/{experimentId}/geralanding/landing/approve-and-publish:
+    post:
+      tags:
+        - Gera Landing Public Landing
+      summary: Alias compatível para aprovação e publicação da landing pública
+      description: |
+        Alias temporário de compatibilidade para o contrato anterior com `and`; executa a mesma operação de `approve-end-publish`.
+      parameters:
+        - $ref: "#/components/parameters/ExperimentIdPath"
+      responses:
+        "200":
+          description: Landing aprovada e publicada com sucesso.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PublicLandingPublicationResponse"
+        "404":
+          description: Experimento não encontrado.
+        "409":
+          description: HTML da landing ainda não foi gerado.
+        "502":
+          description: Lead Portal indisponível ou base URL não configurada.
+
 components:
   parameters:
     ExperimentIdPath:
@@ -217,6 +263,31 @@ components:
         type: string
 
   schemas:
+
+    PublicLandingPublicationResponse:
+      type: object
+      properties:
+        experimentId:
+          type: integer
+          format: int64
+          description: ID do experimento publicado.
+        flowId:
+          type: integer
+          format: int64
+          nullable: true
+          description: ID do flow quando disponível no contrato de publicação.
+        iframeUrl:
+          type: string
+          nullable: true
+          description: URL pública para renderização iframe da landing.
+        standaloneUrl:
+          type: string
+          nullable: true
+          description: URL standalone gravada como destino oficial da campanha.
+        message:
+          type: string
+          description: Mensagem operacional da publicação.
+
     GeraLandingWireframeStartResponse:
       type: object
       properties:

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -1,4 +1,18 @@
 
+## 2026-06-02 00:00:00 UTC
+- solicitação: criar endpoint de aprovação/publicação da landing final no pacote `geralanding.publiclanding.web`, com controller `BackendPublicLandingController` e operação `approve-end-publish`.
+- foi feito: criado `BackendPublicLandingController` com `POST /api/experiments/{experimentId}/geralanding/landing/approve-end-publish` e alias de compatibilidade `approve-and-publish`, além de `BackendPublicLandingService` com lógica semelhante ao fluxo deprecated para publicar no Lead Portal, injetar tracking/controles/pixel e persistir `follow_up_action_url`.
+- frontend: hook de aprovação/publicação da landing atualizado para chamar `approve-end-publish`.
+- documentação: Swagger do Gera Landing atualizado com o novo endpoint de landing pública.
+- arquivos alterados:
+  - backend/ads-service/src/main/java/com/marketinghub/geralanding/publiclanding/web/BackendPublicLandingController.java
+  - backend/ads-service/src/main/java/com/marketinghub/geralanding/publiclanding/service/BackendPublicLandingService.java
+  - backend/ads-service/src/main/java/com/marketinghub/geralanding/publiclanding/service/approveEndPublish/PublicLandingPublicationResponse.java
+  - frontend/src/api/experiment/useApproveAndPublishLanding.ts
+  - docs/gera-landing/swagger-gera-landing-etapas.yaml
+  - docs/registros/experimentos.md
+
+
 ## 2026-05-23 00:00:00 UTC
 - solicitação para corrigir falha de typecheck no frontend em `ExperimentDetailPage` por ausência do campo `htmlGeraLanding` no tipo `Experiment`.
 - causa-raiz identificada: o componente já consome `experiment.htmlGeraLanding`, porém a interface TypeScript compartilhada em `useExperiments.ts` não declarava esse atributo.

--- a/frontend/src/api/experiment/useApproveAndPublishLanding.ts
+++ b/frontend/src/api/experiment/useApproveAndPublishLanding.ts
@@ -26,7 +26,7 @@ export function useApproveAndPublishLanding(experimentId: number) {
   return useMutation({
     mutationFn: async () => {
       const { data } = await axios.post<LandingPublicationResult>(
-        `/api/experiments/${experimentId}/geralanding/landing/approve-and-publish`,
+        `/api/experiments/${experimentId}/geralanding/landing/approve-end-publish`,
       );
       return data;
     },


### PR DESCRIPTION
### Motivation
- Provide an endpoint to approve and publish the final GeraLanding HTML to the Lead Portal and persist the official standalone campaign URL. 
- Ensure published pages include telemetry, funnel controls and optional Facebook Pixel automatically before publishing. 
- Keep backward compatibility by providing the legacy `approve-and-publish` alias while standardizing on `approve-end-publish`.

### Description
- Added `BackendPublicLandingService` which resolves the canonical landing HTML (prefers `htmlGeraLanding`), injects behavior tracking, funnel controls and Facebook Pixel, publishes the final HTML to the Lead Portal via `RestTemplate`, and persists `landingPageHtml` and `followUpActionUrl` on the `Experiment` entity. 
- Exposed `POST /api/experiments/{experimentId}/geralanding/landing/approve-end-publish` with an alias `approve-and-publish` via `BackendPublicLandingController`. 
- Introduced request/response records `PublicLandingLeadPortalPublishRequest` and `PublicLandingPublicationResponse` and small placeholder records for the canonical subpackages. 
- Updated OpenAPI (`docs/gera-landing/swagger-gera-landing-etapas.yaml`) and frontend hook `useApproveAndPublishLanding` to call the new `approve-end-publish` route. 
- Added unit tests `BackendPublicLandingServiceTest` and `BackendPublicLandingControllerTest` that validate HTML injection, Lead Portal publish invocation, persistence of standalone URL, and error behavior when HTML is missing.

### Testing
- Ran `BackendPublicLandingServiceTest` which asserts tracking, funnel controls, Facebook Pixel and section tracking are present and that Lead Portal `put` is called, and it passed. 
- Ran `BackendPublicLandingServiceTest` case that asserts a `409` is thrown when landing HTML is missing and it passed. 
- Ran `BackendPublicLandingControllerTest` which verifies controller delegation to the service and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1e07642f148321beb6f8f95c25553b)