### PR TITLE
Add OPRM nichocnae package and initial routineresearchcycle stage

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/package-info.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Agrupa o pipeline OPRM que transforma nichos CNAE priorizados em artefatos de pesquisa de rotina.
+ */
+package com.marketinghub.oprm.nichocnae;

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/routineresearchcycle/package-info.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/routineresearchcycle/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Contém a primeira etapa do pipeline de pesquisa de rotina do nicho: controle do ciclo de pesquisa.
+ */
+package com.marketinghub.oprm.nichocnae.routineresearchcycle;

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/routineresearchcycle/service/BackendRoutineResearchCycleService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/routineresearchcycle/service/BackendRoutineResearchCycleService.java
@@ -1,0 +1,41 @@
+package com.marketinghub.oprm.nichocnae.routineresearchcycle.service;
+
+import com.marketinghub.oprm.nichocnae.routineresearchcycle.service.detailStageExecution.RecordBackendRoutineResearchCycleDetalheDto;
+import com.marketinghub.oprm.nichocnae.routineresearchcycle.service.listStageExecutions.RoutineResearchCycleExecutionSummaryResponse;
+import com.marketinghub.oprm.nichocnae.routineresearchcycle.service.pending.RecordRoutineResearchCyclePending;
+import java.util.List;
+import org.springframework.stereotype.Service;
+
+/** Responsável por expor a borda backend da etapa de ciclo da pesquisa de rotina de nicho CNAE. */
+@Service
+public class BackendRoutineResearchCycleService {
+
+  /** Lista ciclos de pesquisa de rotina pendentes para processamento assíncrono da etapa. */
+  public List<RecordRoutineResearchCyclePending> listPending() {
+    return List.of();
+  }
+
+  /** Lista execuções do ciclo de pesquisa de rotina associadas a um nicho CNAE de origem. */
+  public List<RoutineResearchCycleExecutionSummaryResponse> listStageExecutions(Long sourceNicheId) {
+    return List.of();
+  }
+
+  /** Retorna os detalhes operacionais de uma execução específica do ciclo de pesquisa de rotina. */
+  public RecordBackendRoutineResearchCycleDetalheDto detailStageExecution(Long researchCycleId) {
+    return new RecordBackendRoutineResearchCycleDetalheDto(
+        researchCycleId,
+        null,
+        null,
+        null,
+        null,
+        null,
+        null,
+        0,
+        0,
+        0,
+        0,
+        null,
+        null,
+        null);
+  }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/routineresearchcycle/service/detailStageExecution/RecordBackendRoutineResearchCycleDetalheDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/routineresearchcycle/service/detailStageExecution/RecordBackendRoutineResearchCycleDetalheDto.java
@@ -1,0 +1,21 @@
+package com.marketinghub.oprm.nichocnae.routineresearchcycle.service.detailStageExecution;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+
+/** Detalha o estado operacional completo de uma execução da etapa de ciclo de pesquisa de rotina. */
+public record RecordBackendRoutineResearchCycleDetalheDto(
+    Long researchCycleId,
+    Long sourceNicheId,
+    String cnaeCode,
+    String cnaeDescription,
+    String nicheName,
+    BigDecimal sourceScore,
+    String status,
+    Integer totalQueries,
+    Integer totalSourceCandidates,
+    Integer totalSourceSnapshots,
+    Integer totalExtractedSignals,
+    Instant startedAt,
+    Instant finishedAt,
+    String errorMessage) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/routineresearchcycle/service/listStageExecutions/RoutineResearchCycleExecutionSummaryResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/routineresearchcycle/service/listStageExecutions/RoutineResearchCycleExecutionSummaryResponse.java
@@ -1,0 +1,17 @@
+package com.marketinghub.oprm.nichocnae.routineresearchcycle.service.listStageExecutions;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+
+/** Resume uma execução do ciclo de pesquisa de rotina para listagem operacional no backend OPRM. */
+public record RoutineResearchCycleExecutionSummaryResponse(
+    Long researchCycleId,
+    Long sourceNicheId,
+    String cnaeCode,
+    String nicheName,
+    BigDecimal sourceScore,
+    String status,
+    Integer totalQueries,
+    Integer totalExtractedSignals,
+    Instant startedAt,
+    Instant finishedAt) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/routineresearchcycle/service/pending/RecordRoutineResearchCyclePending.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/routineresearchcycle/service/pending/RecordRoutineResearchCyclePending.java
@@ -1,0 +1,17 @@
+package com.marketinghub.oprm.nichocnae.routineresearchcycle.service.pending;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+
+/** Representa uma unidade de trabalho fechada para iniciar/controlar a pesquisa de rotina do nicho CNAE. */
+public record RecordRoutineResearchCyclePending(
+    Long researchCycleId,
+    Long sourceNicheId,
+    String cnaeCode,
+    String cnaeDescription,
+    String nicheName,
+    BigDecimal sourceScore,
+    String triggerSource,
+    String status,
+    Instant startedAt,
+    Instant createdAt) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/routineresearchcycle/service/recebePrompt/RecebePromptRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/routineresearchcycle/service/recebePrompt/RecebePromptRequest.java
@@ -1,0 +1,5 @@
+package com.marketinghub.oprm.nichocnae.routineresearchcycle.service.recebePrompt;
+
+/** Contrato para registrar o prompt enviado à IA quando a etapa passar a usar processamento inteligente. */
+public record RecebePromptRequest(
+    String prompt, String promptMarkdownContent, String schemaJson, String requestBodyJson, String jobidopenai) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/routineresearchcycle/service/recebeResposta/RecebeRespostaRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/routineresearchcycle/service/recebeResposta/RecebeRespostaRequest.java
@@ -1,0 +1,15 @@
+package com.marketinghub.oprm.nichocnae.routineresearchcycle.service.recebeResposta;
+
+import java.math.BigDecimal;
+
+/** Contrato para registrar a resposta da IA quando a etapa passar a receber callbacks assíncronos. */
+public record RecebeRespostaRequest(
+    Long researchCycleId,
+    String stageCode,
+    String modelResponse,
+    Integer inputTokens,
+    Integer outputTokens,
+    BigDecimal costUsd,
+    String openAiJobId,
+    String errorMessage,
+    String errorDetail) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/routineresearchcycle/web/BackendRoutineResearchCycleController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/routineresearchcycle/web/BackendRoutineResearchCycleController.java
@@ -1,0 +1,44 @@
+package com.marketinghub.oprm.nichocnae.routineresearchcycle.web;
+
+import com.marketinghub.oprm.nichocnae.routineresearchcycle.service.BackendRoutineResearchCycleService;
+import com.marketinghub.oprm.nichocnae.routineresearchcycle.service.detailStageExecution.RecordBackendRoutineResearchCycleDetalheDto;
+import com.marketinghub.oprm.nichocnae.routineresearchcycle.service.listStageExecutions.RoutineResearchCycleExecutionSummaryResponse;
+import com.marketinghub.oprm.nichocnae.routineresearchcycle.service.pending.RecordRoutineResearchCyclePending;
+import java.util.List;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/** Responsável por expor os endpoints backend da etapa de ciclo da pesquisa de rotina de nicho CNAE. */
+@RestController
+@RequestMapping("/api")
+public class BackendRoutineResearchCycleController {
+  private final BackendRoutineResearchCycleService executionService;
+
+  /** Inicializa o controller com o serviço backend da etapa de ciclo da pesquisa de rotina. */
+  public BackendRoutineResearchCycleController(BackendRoutineResearchCycleService executionService) {
+    this.executionService = executionService;
+  }
+
+  /** Lista ciclos de pesquisa de rotina pendentes para processamento interno pelo Worker AI. */
+  @GetMapping("/internal/oprm/nichocnae/routine-research-cycle/stage-executions/pending")
+  public List<RecordRoutineResearchCyclePending> pending() {
+    return executionService.listPending();
+  }
+
+  /** Lista execuções do ciclo de pesquisa de rotina vinculadas ao nicho CNAE informado. */
+  @GetMapping("/oprm/nichocnae/{sourceNicheId}/routine-research-cycle/stage-executions")
+  public ResponseEntity<List<RoutineResearchCycleExecutionSummaryResponse>> listStageExecutions(
+      @PathVariable Long sourceNicheId) {
+    return ResponseEntity.ok(executionService.listStageExecutions(sourceNicheId));
+  }
+
+  /** Retorna detalhes de uma execução específica do ciclo de pesquisa de rotina. */
+  @GetMapping("/oprm/nichocnae/routine-research-cycle/stage-executions/{researchCycleId}")
+  public ResponseEntity<RecordBackendRoutineResearchCycleDetalheDto> detailStageExecution(
+      @PathVariable Long researchCycleId) {
+    return ResponseEntity.ok(executionService.detailStageExecution(researchCycleId));
+  }
+}

--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -210,3 +210,5 @@
 
 - 2026-06-01 00:00:00 (UTC): adicionado botão na tela `/oprm/cnaes-volume` para o usuário consultar diretamente os nichos já enriquecidos pelo OPRM; backend recebeu endpoint de leitura dos candidatos enriquecidos mais recentes e frontend passou a exibir tabela com nicho, CNAE, dor, resultado, mecanismo, score, status e data de enriquecimento.
 - 2026-06-01 18:52:03 (UTC-3): ajuste na tela de CNAEs por Score OPRM para que a lista "Nichos já enriquecidos" seja carregada pelo backend em ordem decrescente de `opportunityScore`, com `createdAt` como desempate, deixando os maiores scores no começo para priorizar decisões com maior potencial de venda.
+
+- 2026-06-02 00:00:00 (UTC): criado no backend o novo pacote `com.marketinghub.oprm.nichocnae` para o pipeline OPRM de pesquisa de rotina por nicho CNAE, com a primeira etapa `routineresearchcycle` estruturada no padrão canônico por etapa (`web`, `service`, `pending`, `listStageExecutions`, `detailStageExecution`, `recebePrompt`, `recebeResposta`) para preparar a evolução até o `oprm_niche_routine_card`.


### PR DESCRIPTION
### Motivation
- Prepare backend scaffolding for the new OPRM pipeline that will transform prioritized CNAE/niche entries into routine-research artifacts and allow Worker AI integration following the canonical per-stage pattern.
- Provide the minimal backend contract and endpoints so future stages (seed builder, searcher, fetcher, extractor, synthesizer, quality gate) can be implemented incrementally and consumed by the Worker AI core.

### Description
- Add new package `com.marketinghub.oprm.nichocnae` and subpackage `routineresearchcycle` implementing the first pipeline stage with package-info files.
- Add `BackendRoutineResearchCycleController` exposing internal endpoint `GET /internal/oprm/nichocnae/routine-research-cycle/stage-executions/pending` plus listing and detail endpoints for the stage.
- Add `BackendRoutineResearchCycleService` with stubbed methods `listPending()`, `listStageExecutions(...)` and `detailStageExecution(...)` following the backend per-stage canonical pattern.
- Add immutable contract records for the stage: `RecordRoutineResearchCyclePending`, `RoutineResearchCycleExecutionSummaryResponse`, `RecordBackendRoutineResearchCycleDetalheDto`, `RecebePromptRequest`, and `RecebeRespostaRequest` and register an entry in `docs/registros/oprm1.md`.

### Testing
- Ran the module test suite with `cd backend/ads-service && ../mvnw test`, which completed successfully (build success; tests run: 517, failures: 0, errors: 0, skipped: 1).
- Attempted `cd backend/ads-service && ../mvnw spotless:check`, which failed because the `spotless` plugin was not available in the current Maven configuration (`No plugin found for prefix 'spotless'`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1e5b58e6d88321be4be6e0b56a16a1)