### PR TITLE
Migrate imagegeneration worker to GeraLanding endpoints and consolidate multi-image flow

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/openai/core/imagegeneration/ImageGenerationBackendClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/openai/core/imagegeneration/ImageGenerationBackendClient.java
@@ -1,10 +1,9 @@
 package com.marketinghub.worker.openai.core.imagegeneration;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marketinghub.worker.creative.CreativeImageOptimizer;
-import com.marketinghub.worker.frameworkimage.FrameworkImageBackendClient;
-import com.marketinghub.worker.frameworkimage.FrameworkImageJobCompletionPayload;
-import com.marketinghub.worker.frameworkimage.FrameworkImageJobDto;
-import com.marketinghub.worker.frameworkimage.FrameworkImageJobStage;
 import com.marketinghub.worker.frameworkimage.FrameworkImageStorageClient;
 import com.marketinghub.worker.openai.core.model.OpenAiDispatch;
 import com.marketinghub.worker.openai.core.model.OpenAiResult;
@@ -12,43 +11,46 @@ import com.marketinghub.worker.openai.core.model.StageExecution;
 import com.marketinghub.worker.openai.core.port.StageBackendPort;
 import java.net.InetAddress;
 import java.time.Instant;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.UUID;
+import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.util.StringUtils;
 import org.springframework.web.reactive.function.client.WebClient;
 
-/** Responsabilidade: integrar a etapa imagegeneration do core OpenAI aos endpoints de framework-image do backend. */
+/** Responsabilidade: integrar a etapa imagegeneration do core OpenAI aos endpoints novos do GeraLanding. */
 public class ImageGenerationBackendClient implements StageBackendPort<ImageGenerationInput, ImageGenerationOutput> {
 
     private static final Logger log = LoggerFactory.getLogger(ImageGenerationBackendClient.class);
-    private static final String STAGE_CODE = "framework-image-generation";
+    private static final String STATUS_STARTED = "INICIADO";
 
-    private final FrameworkImageBackendClient backendClient;
     private final FrameworkImageStorageClient storageClient;
     private final CreativeImageOptimizer imageOptimizer;
     private final WebClient webClient;
+    private final ObjectMapper objectMapper;
     private final ImageGenerationWorkerProperties properties;
     private final String workerId;
 
-    /** Inicializa o adapter com clientes de backend, storage, otimização e propriedades da etapa. */
+    /** Inicializa o adapter com storage, otimização, cliente HTTP e propriedades da etapa GeraLanding imagegeneration. */
     public ImageGenerationBackendClient(
-            FrameworkImageBackendClient backendClient,
             FrameworkImageStorageClient storageClient,
             CreativeImageOptimizer imageOptimizer,
             WebClient.Builder webClientBuilder,
+            ObjectMapper objectMapper,
             ImageGenerationWorkerProperties properties
     ) {
-        this.backendClient = backendClient;
         this.storageClient = storageClient;
         this.imageOptimizer = imageOptimizer;
         this.webClient = webClientBuilder.build();
+        this.objectMapper = objectMapper;
         this.properties = properties;
         this.workerId = resolveWorkerId(properties.workerId());
     }
 
-    /** Busca jobs pendentes, aplica rollout e faz claim antes de devolver execuções ao worker genérico. */
+    /** Busca jobs pendentes no endpoint novo do GeraLanding e monta execuções para o worker genérico. */
     @Override
     public List<StageExecution<ImageGenerationInput>> listPending(int limit) {
         if (properties.rolloutPercentage() <= 0) {
@@ -56,111 +58,196 @@ public class ImageGenerationBackendClient implements StageBackendPort<ImageGener
             return List.of();
         }
 
-        return backendClient.listPending(Math.max(1, limit)).stream()
-                .filter(job -> job != null && job.id() != null)
-                .filter(job -> isRolloutEligible(job.experimentId()))
-                .map(this::claim)
-                .filter(job -> job != null && job.id() != null)
+        int effectiveLimit = Math.max(1, limit);
+        List<Map<String, Object>> payload = webClient.get()
+                .uri(stageExecutionBaseUrl() + "/pending")
+                .retrieve()
+                .bodyToMono(new ParameterizedTypeReference<List<Map<String, Object>>>() {})
+                .block(properties.timeout());
+        if (payload == null || payload.isEmpty()) {
+            return List.of();
+        }
+
+        return payload.stream()
                 .map(this::toStageExecution)
+                .filter(execution -> execution.aggregateId() != null && execution.idJob() != null)
+                .filter(execution -> isRolloutEligible(execution.aggregateId()))
+                .limit(effectiveLimit)
                 .toList();
     }
 
-    /** Registra no backend que o request bruto foi despachado para a OpenAI pela etapa imagegeneration. */
+    /** Envia ao backend GeraLanding o prompt consolidado, schema e request cru despachados para a OpenAI. */
     @Override
     public void markDispatched(StageExecution<ImageGenerationInput> execution, OpenAiDispatch dispatch) {
-        UUID jobId = execution.input().job().id();
-        backendClient.updateStage(jobId, FrameworkImageJobStage.SENT_TO_OPENAI_BATCH);
-        backendClient.updateStage(jobId, FrameworkImageJobStage.WAITING_OPENAI_BATCH);
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("prompt", dispatch.prompt());
+        body.put("promptMarkdownContent", dispatch.promptMarkdownContent());
+        body.put("schemaJson", dispatch.schemaJson());
+        body.put("requestBodyJson", dispatch.requestBodyJson());
+        body.put("jobidopenai", dispatch.openAiJobId());
+
         log.info(
-                "Envio para backend após despacho OpenAI [jobId={}, experimentId={}, payload={stage={}, openAiJobId={}, requestBodyJson={}}]",
-                jobId,
+                "Envio para backend GeraLanding após despacho imagegeneration [jobId={}, experimentId={}, payload={}]",
+                execution.idJob(),
                 execution.aggregateId(),
-                FrameworkImageJobStage.WAITING_OPENAI_BATCH,
-                dispatch.openAiJobId(),
-                dispatch.requestBodyJson()
+                body
         );
+        webClient.post()
+                .uri(stageExecutionBaseUrl() + "/{idJob}/recebe-prompt", execution.idJob())
+                .bodyValue(body)
+                .retrieve()
+                .bodyToMono(Void.class)
+                .block(properties.timeout());
     }
 
-    /** Publica a imagem validada no storage e conclui o job no backend com o payload contratual. */
+    /** Publica as imagens validadas no storage e conclui o job GeraLanding com manifesto contratual. */
     @Override
     public void markCompleted(StageExecution<ImageGenerationInput> execution, OpenAiResult<ImageGenerationOutput> result) {
-        FrameworkImageJobDto job = execution.input().job();
-        backendClient.updateStage(job.id(), FrameworkImageJobStage.OPENAI_IMAGE_READY);
-        byte[] imageContent = resolveImageContent(result.parsedResponse(), job.id());
-        CreativeImageOptimizer.OptimizedImage optimized = imageOptimizer.optimize(imageContent);
-        FrameworkImageStorageClient.UploadedFrameworkImage uploaded = uploadWithRetry(optimized.content(), buildFilename(job));
-        backendClient.updateStage(job.id(), FrameworkImageJobStage.UPLOADED_TO_CLOUDFLARE);
+        List<Map<String, Object>> manifestImages = new ArrayList<>();
+        for (ImageGenerationOutput.GeneratedImage generated : result.parsedResponse().images()) {
+            byte[] imageContent = resolveImageContent(generated, execution.idJob());
+            CreativeImageOptimizer.OptimizedImage optimized = imageOptimizer.optimize(imageContent);
+            FrameworkImageStorageClient.UploadedFrameworkImage uploaded = uploadWithRetry(
+                    optimized.content(),
+                    buildFilename(execution.idJob(), generated)
+            );
+            manifestImages.add(toManifestImage(generated, result.openAiJobId(), uploaded));
+        }
 
-        FrameworkImageJobCompletionPayload completionPayload = new FrameworkImageJobCompletionPayload(
-                FrameworkImageJobStage.NOTIFIED_BACKEND.name(),
-                firstText(result.parsedResponse().model(), job.model(), properties.imageModel()),
-                firstText(result.parsedResponse().prompt(), job.prompt()),
-                result.openAiJobId(),
-                job.assetId(),
-                uploaded.publicUrl(),
-                job.webUrl()
-        );
+        String manifest = buildManifest(execution, result, manifestImages);
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("experimentId", execution.aggregateId());
+        body.put("stageCode", execution.stageCode());
+        body.put("modelResponse", manifest);
+        body.put("inputTokens", result.inputTokens());
+        body.put("outputTokens", result.outputTokens());
+        body.put("costUsd", result.costUsd());
+        body.put("openAiJobId", result.openAiJobId());
+        body.put("errorMessage", null);
+        body.put("errorDetail", null);
+
         log.info(
-                "Envio para backend concluindo imagegeneration [jobId={}, experimentId={}, payload={}]",
-                job.id(),
-                job.experimentId(),
-                completionPayload
+                "Envio para backend GeraLanding concluindo imagegeneration [jobId={}, experimentId={}, payload={}]",
+                execution.idJob(),
+                execution.aggregateId(),
+                body
         );
-        backendClient.complete(job.id(), completionPayload);
-        log.info(
-                "ImageGeneration job completed. jobId={}, experimentId={}, assetId={}, openAiJobId={}, objectKey={}",
-                job.id(),
-                job.experimentId(),
-                job.assetId(),
-                result.openAiJobId(),
-                uploaded.objectKey()
-        );
+        webClient.post()
+                .uri(stageExecutionBaseUrl() + "/{idJob}/recebe-resposta", execution.idJob())
+                .bodyValue(body)
+                .retrieve()
+                .bodyToMono(Void.class)
+                .block(properties.timeout());
     }
 
-    /** Envia ao backend os dados de falha quando a etapa imagegeneration não é concluída. */
+    /** Envia ao backend GeraLanding os dados de falha quando a etapa imagegeneration não é concluída. */
     @Override
     public void markFailed(StageExecution<ImageGenerationInput> execution, Throwable error) {
-        FrameworkImageJobDto job = execution.input().job();
-        String reason = buildFailureReason(error);
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("experimentId", execution.aggregateId());
+        body.put("stageCode", execution.stageCode());
+        body.put("modelResponse", null);
+        body.put("inputTokens", null);
+        body.put("outputTokens", null);
+        body.put("costUsd", null);
+        body.put("openAiJobId", null);
+        body.put("errorMessage", buildFailureReason(error));
+        body.put("errorDetail", error != null ? stackTraceSummary(error) : null);
+
         log.info(
-                "Envio para backend falhando imagegeneration [jobId={}, experimentId={}, payload={errorMessage={}}]",
-                job.id(),
-                job.experimentId(),
-                reason
+                "Envio para backend GeraLanding falhando imagegeneration [jobId={}, experimentId={}, payload={}]",
+                execution.idJob(),
+                execution.aggregateId(),
+                body
         );
-        backendClient.fail(job.id(), reason);
+        webClient.post()
+                .uri(stageExecutionBaseUrl() + "/{idJob}/recebe-resposta", execution.idJob())
+                .bodyValue(body)
+                .retrieve()
+                .bodyToMono(Void.class)
+                .block(properties.timeout());
     }
 
-    /** Faz claim do job no backend para evitar processamento concorrente por outro worker. */
-    private FrameworkImageJobDto claim(FrameworkImageJobDto job) {
-        FrameworkImageJobDto claimed = backendClient.claim(job.id(), workerId);
-        if (claimed == null) {
-            log.info("ImageGeneration job {} could not be claimed by worker {}", job.id(), workerId);
-        }
-        return claimed;
-    }
-
-    /** Converte o DTO do backend em execução padronizada do core OpenAI. */
-    private StageExecution<ImageGenerationInput> toStageExecution(FrameworkImageJobDto job) {
-        Instant requestedAt = job.createdAt() != null ? job.createdAt() : Instant.now();
+    /** Converte o payload pendente do GeraLanding para o modelo interno de execução da etapa. */
+    private StageExecution<ImageGenerationInput> toStageExecution(Map<String, Object> item) {
+        Long experimentId = asLong(item.get("experimentId"));
+        String stageCode = asString(item.get("stageCode"));
+        String idJob = asString(firstNonNull(item.get("jobid"), item.get("idJob")));
+        ImageGenerationInput input = new ImageGenerationInput(
+                experimentId,
+                stageCode,
+                idJob,
+                extractImagePromptItems(item)
+        );
         return new StageExecution<>(
-                job.id().toString(),
-                job.experimentId(),
-                STAGE_CODE,
-                job.status(),
-                requestedAt,
-                new ImageGenerationInput(job)
+                idJob,
+                experimentId,
+                stageCode,
+                STATUS_STARTED,
+                asInstant(item.get("executionRequestedAt")),
+                input
         );
+    }
+
+    /** Extrai prompts de landingPageImagePlanning preservando sectionId, elementId e chaves de vínculo. */
+    private List<ImageGenerationInput.ImageGenerationPromptItem> extractImagePromptItems(Map<String, Object> pending) {
+        Map<String, Object> experiment = asMap(pending.get("experiment"));
+        Object normalizedPlanning = normalizeJsonArtifact(experiment.get("landingPageImagePlanning"));
+        Map<String, Object> planningRoot = asMap(normalizedPlanning);
+        Object rawPlanning = firstNonNull(planningRoot.get("landingPageImagePlanning"), planningRoot);
+        Map<String, Object> planning = asMap(rawPlanning);
+        Object rawImages = planning.get("images");
+        if (!(rawImages instanceof List<?> images)) {
+            return List.of();
+        }
+
+        List<ImageGenerationInput.ImageGenerationPromptItem> result = new ArrayList<>();
+        for (Object rawImage : images) {
+            Map<String, Object> image = asMap(rawImage);
+            String prompt = asString(firstNonNull(image.get("imagePrompt"), image.get("prompt")));
+            if (!StringUtils.hasText(prompt)) {
+                continue;
+            }
+            result.add(new ImageGenerationInput.ImageGenerationPromptItem(
+                    asString(firstNonNull(image.get("planningItemKey"), image.get("imageBindingKey"), image.get("elementId"), image.get("sectionId"))),
+                    asString(image.get("sectionId")),
+                    asString(image.get("elementId")),
+                    asString(image.get("imageGoal")),
+                    prompt
+            ));
+        }
+        return result;
+    }
+
+    /** Normaliza artefatos que podem chegar como JSON textual, objeto estruturado ou valor simples. */
+    private Object normalizeJsonArtifact(Object value) {
+        if (value instanceof String text) {
+            return parseJsonField(text);
+        }
+        return value != null ? value : Map.of();
+    }
+
+    /** Interpreta um campo textual JSON quando possível, preservando mapa vazio em caso de ausência. */
+    private Object parseJsonField(String raw) {
+        if (!StringUtils.hasText(raw)) {
+            return Map.of();
+        }
+        try {
+            return objectMapper.readValue(raw, new TypeReference<Map<String, Object>>() {});
+        } catch (JsonProcessingException error) {
+            log.warn("Image generation artifact is not valid JSON; preserving raw text. rawLength={}", raw.length(), error);
+            return raw;
+        }
     }
 
     /** Resolve os bytes da imagem usando o base64 retornado ou baixando a URL informada pela OpenAI. */
-    private byte[] resolveImageContent(ImageGenerationOutput output, UUID jobId) {
-        if (output.imageContent() != null && output.imageContent().length > 0) {
-            return output.imageContent();
+    private byte[] resolveImageContent(ImageGenerationOutput.GeneratedImage generated, String jobId) {
+        if (generated.imageContent() != null && generated.imageContent().length > 0) {
+            return generated.imageContent();
         }
-        if (StringUtils.hasText(output.imageUrl())) {
+        if (StringUtils.hasText(generated.imageUrl())) {
             byte[] downloaded = webClient.get()
-                    .uri(output.imageUrl())
+                    .uri(generated.imageUrl())
                     .retrieve()
                     .bodyToMono(byte[].class)
                     .block(properties.timeout());
@@ -168,7 +255,7 @@ public class ImageGenerationBackendClient implements StageBackendPort<ImageGener
                 return downloaded;
             }
         }
-        throw new IllegalStateException("OpenAI did not provide image bytes for job " + jobId);
+        throw new IllegalStateException("OpenAI did not provide image bytes for GeraLanding job " + jobId);
     }
 
     /** Faz upload com retentativas simples para reduzir falhas transitórias de storage. */
@@ -216,18 +303,66 @@ public class ImageGenerationBackendClient implements StageBackendPort<ImageGener
         }
     }
 
-    /** Monta um nome de arquivo estável para o item planejado da landing. */
-    private String buildFilename(FrameworkImageJobDto job) {
-        String planningItemKey = StringUtils.hasText(job.planningItemKey()) ? job.planningItemKey() : "item";
-        String normalized = planningItemKey.toLowerCase()
-                .replaceAll("[^a-z0-9._-]", "-")
-                .replaceAll("-{2,}", "-");
-        return job.id() + "-" + normalized + ".jpg";
+    /** Monta um item do manifesto final de imagens com URLs definitivas publicáveis. */
+    private Map<String, Object> toManifestImage(
+            ImageGenerationOutput.GeneratedImage generated,
+            String openAiJobId,
+            FrameworkImageStorageClient.UploadedFrameworkImage uploaded
+    ) {
+        Map<String, Object> image = new LinkedHashMap<>();
+        putIfPresent(image, "planningItemKey", firstText(generated.planningItemKey(), generated.elementId(), generated.sectionId()));
+        putIfPresent(image, "sectionId", generated.sectionId());
+        putIfPresent(image, "elementId", generated.elementId());
+        putIfPresent(image, "imageGoal", generated.imageGoal());
+        putIfPresent(image, "prompt", generated.prompt());
+        putIfPresent(image, "model", generated.model());
+        putIfPresent(image, "openAiJobId", openAiJobId);
+        putIfPresent(image, "sourceUrl", uploaded.publicUrl());
+        putIfPresent(image, "resolvedUrl", uploaded.publicUrl());
+        image.put("status", "COMPLETED");
+        return image;
     }
 
-    /** Resolve o identificador operacional deste worker para claim no backend. */
+    /** Serializa o manifesto de imagens consumido pelas próximas etapas do GeraLanding. */
+    private String buildManifest(
+            StageExecution<ImageGenerationInput> execution,
+            OpenAiResult<ImageGenerationOutput> result,
+            List<Map<String, Object>> images
+    ) {
+        try {
+            Map<String, Object> root = new LinkedHashMap<>();
+            root.put("version", 1);
+            root.put("experimentId", execution.aggregateId());
+            root.put("stageCode", execution.stageCode());
+            root.put("idJob", execution.idJob());
+            root.put("openAiJobId", result.openAiJobId());
+            root.put("generatedAt", Instant.now().toString());
+            root.put("images", images);
+            return objectMapper.writeValueAsString(root);
+        } catch (JsonProcessingException error) {
+            log.error(
+                    "Erro ao serializar manifesto GeraLanding imagegeneration (jobId={}, experimentId={}, imageCount={})",
+                    execution.idJob(),
+                    execution.aggregateId(),
+                    images.size(),
+                    error
+            );
+            throw new IllegalStateException("Falha ao serializar manifesto GeraLanding imagegeneration", error);
+        }
+    }
+
+    /** Monta um nome de arquivo estável para o item planejado da landing. */
+    private String buildFilename(String jobId, ImageGenerationOutput.GeneratedImage generated) {
+        String key = firstText(generated.planningItemKey(), generated.elementId(), generated.sectionId(), "item");
+        String normalized = key.toLowerCase()
+                .replaceAll("[^a-z0-9._-]", "-")
+                .replaceAll("-{2,}", "-");
+        return jobId + "-" + normalized + ".jpg";
+    }
+
+    /** Resolve o identificador operacional deste worker para logs de rollout. */
     private String resolveWorkerId(String configuredWorkerId) {
-        if (configuredWorkerId != null && !configuredWorkerId.isBlank()) {
+        if (StringUtils.hasText(configuredWorkerId)) {
             return configuredWorkerId.trim();
         }
         try {
@@ -241,20 +376,22 @@ public class ImageGenerationBackendClient implements StageBackendPort<ImageGener
     /** Gera uma mensagem curta de erro adequada para persistência no backend. */
     private String buildFailureReason(Throwable error) {
         String message = error != null ? error.getMessage() : null;
-        if (message == null || message.isBlank()) {
+        if (!StringUtils.hasText(message)) {
             return "Falha desconhecida no processamento do job de imagem";
         }
         return message.length() > 500 ? message.substring(0, 500) : message;
     }
 
-    /** Retorna o primeiro texto preenchido entre os candidatos informados. */
-    private String firstText(String... candidates) {
-        for (String candidate : candidates) {
-            if (StringUtils.hasText(candidate)) {
-                return candidate;
+    /** Resume a stack trace em texto para envio controlado ao backend. */
+    private String stackTraceSummary(Throwable error) {
+        StringBuilder builder = new StringBuilder(error.toString());
+        for (StackTraceElement element : error.getStackTrace()) {
+            builder.append("\n    at ").append(element);
+            if (builder.length() > 4000) {
+                break;
             }
         }
-        return null;
+        return builder.toString();
     }
 
     /** Verifica se o experimento pertence ao bucket de rollout configurado. */
@@ -274,5 +411,99 @@ public class ImageGenerationBackendClient implements StageBackendPort<ImageGener
             );
         }
         return eligible;
+    }
+
+    /** Monta a URL base dos endpoints internos novos de execução imagegeneration do GeraLanding. */
+    private String stageExecutionBaseUrl() {
+        return joinPath(
+                properties.backendBaseUrl(),
+                properties.apiPrefix(),
+                "/internal/geralanding/image-generation/stage-executions"
+        );
+    }
+
+    /** Extrai um mapa tipado quando o valor recebido é um objeto JSON. */
+    private Map<String, Object> asMap(Object value) {
+        if (value instanceof Map<?, ?> rawMap) {
+            Map<String, Object> converted = new LinkedHashMap<>();
+            rawMap.forEach((key, rawValue) -> {
+                if (key != null) {
+                    converted.put(String.valueOf(key), rawValue);
+                }
+            });
+            return converted;
+        }
+        return Map.of();
+    }
+
+    /** Converte um valor genérico para Long quando possível. */
+    private Long asLong(Object value) {
+        if (value instanceof Number number) {
+            return number.longValue();
+        }
+        if (value instanceof String text && !text.isBlank()) {
+            return Long.parseLong(text.trim());
+        }
+        return null;
+    }
+
+    /** Converte um valor genérico para texto preservando nulo quando ausente. */
+    private String asString(Object value) {
+        return value != null ? value.toString() : null;
+    }
+
+    /** Converte um valor genérico para Instant quando possível. */
+    private Instant asInstant(Object value) {
+        if (value instanceof Instant instant) {
+            return instant;
+        }
+        if (value instanceof String text && !text.isBlank()) {
+            return Instant.parse(text.trim());
+        }
+        return null;
+    }
+
+    /** Retorna o primeiro valor não nulo entre os candidatos informados. */
+    private Object firstNonNull(Object... candidates) {
+        for (Object candidate : candidates) {
+            if (candidate != null) {
+                return candidate;
+            }
+        }
+        return null;
+    }
+
+    /** Retorna o primeiro texto preenchido entre os candidatos informados. */
+    private String firstText(String... candidates) {
+        for (String candidate : candidates) {
+            if (StringUtils.hasText(candidate)) {
+                return candidate.trim();
+            }
+        }
+        return null;
+    }
+
+    /** Adiciona um campo textual ao payload somente quando há valor útil. */
+    private void putIfPresent(Map<String, Object> payload, String fieldName, String value) {
+        if (StringUtils.hasText(value)) {
+            payload.put(fieldName, value.trim());
+        }
+    }
+
+    /** Junta partes de URL evitando barras duplicadas entre segmentos. */
+    private String joinPath(String... parts) {
+        StringBuilder builder = new StringBuilder();
+        for (String part : parts) {
+            if (part == null || part.isBlank()) {
+                continue;
+            }
+            String normalized = part.trim();
+            if (builder.length() == 0) {
+                builder.append(normalized.replaceAll("/+$", ""));
+            } else {
+                builder.append('/').append(normalized.replaceAll("^/+", "").replaceAll("/+$", ""));
+            }
+        }
+        return builder.toString();
     }
 }

--- a/ai-worker/src/main/java/com/marketinghub/worker/openai/core/imagegeneration/ImageGenerationInput.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/openai/core/imagegeneration/ImageGenerationInput.java
@@ -1,12 +1,60 @@
 package com.marketinghub.worker.openai.core.imagegeneration;
 
-import com.marketinghub.worker.frameworkimage.FrameworkImageJobDto;
+import java.util.List;
 import java.util.Objects;
 
-/** Responsabilidade: transportar o job de imagem do framework para a etapa imagegeneration do core OpenAI. */
-public record ImageGenerationInput(FrameworkImageJobDto job) {
-    /** Garante que a etapa sempre receba um job de imagem válido. */
+/** Responsabilidade: transportar os prompts de imagem do GeraLanding para a etapa imagegeneration do core OpenAI. */
+public record ImageGenerationInput(
+        Long experimentId,
+        String stageCode,
+        String idJob,
+        List<ImageGenerationPromptItem> images
+) {
+    /** Garante que a etapa sempre receba identificadores e uma lista segura de imagens planejadas. */
     public ImageGenerationInput {
-        Objects.requireNonNull(job, "job must not be null");
+        Objects.requireNonNull(idJob, "idJob must not be null");
+        images = images == null ? List.of() : List.copyOf(images);
+    }
+
+    /** Responsabilidade: representar um item planejado de imagem com prompt e chaves de vinculação da landing. */
+    public record ImageGenerationPromptItem(
+            String planningItemKey,
+            String sectionId,
+            String elementId,
+            String imageGoal,
+            String prompt
+    ) {
+        /** Normaliza campos textuais opcionais do item planejado preservando o prompt funcional. */
+        public ImageGenerationPromptItem {
+            planningItemKey = normalize(planningItemKey);
+            sectionId = normalize(sectionId);
+            elementId = normalize(elementId);
+            imageGoal = normalize(imageGoal);
+            prompt = normalize(prompt);
+        }
+
+        /** Retorna a melhor chave operacional para correlacionar imagem, prompt e manifesto. */
+        public String effectiveKey() {
+            if (hasText(planningItemKey)) {
+                return planningItemKey;
+            }
+            if (hasText(elementId)) {
+                return elementId;
+            }
+            if (hasText(sectionId)) {
+                return sectionId;
+            }
+            return "item";
+        }
+
+        /** Normaliza texto vazio para nulo antes de persistir metadados no payload. */
+        private static String normalize(String value) {
+            return hasText(value) ? value.trim() : null;
+        }
+
+        /** Verifica se o texto possui conteúdo útil após trim. */
+        private static boolean hasText(String value) {
+            return value != null && !value.trim().isEmpty();
+        }
     }
 }

--- a/ai-worker/src/main/java/com/marketinghub/worker/openai/core/imagegeneration/ImageGenerationOpenAiClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/openai/core/imagegeneration/ImageGenerationOpenAiClient.java
@@ -12,6 +12,9 @@ import com.marketinghub.worker.openai.core.model.OpenAiResult;
 import com.marketinghub.worker.openai.core.port.OpenAiClientPort;
 import java.math.BigDecimal;
 import java.time.Instant;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
@@ -22,7 +25,7 @@ import org.springframework.util.StringUtils;
 import org.springframework.web.reactive.function.client.WebClient;
 import org.springframework.web.reactive.function.client.WebClientResponseException;
 
-/** Responsabilidade: adaptar a Images API da OpenAI ao contrato genérico OpenAiClientPort do core. */
+/** Responsabilidade: executar chamadas síncronas na OpenAI Images API para a etapa imagegeneration. */
 public class ImageGenerationOpenAiClient implements OpenAiClientPort {
 
     private static final Logger log = LoggerFactory.getLogger(ImageGenerationOpenAiClient.class);
@@ -31,9 +34,9 @@ public class ImageGenerationOpenAiClient implements OpenAiClientPort {
     private final ObjectMapper objectMapper;
     private final ImageGenerationWorkerProperties properties;
     private final boolean enabled;
-    private final Map<String, OpenAiResult<String>> resultCache = new ConcurrentHashMap<>();
+    private final Map<String, PendingImageDispatch> pendingDispatches = new ConcurrentHashMap<>();
 
-    /** Inicializa o cliente de imagens com WebClient, ObjectMapper, propriedades e credenciais OpenAI. */
+    /** Inicializa o client de imagens com credenciais, base URL e limites de payload da OpenAI. */
     public ImageGenerationOpenAiClient(
             WebClient.Builder webClientBuilder,
             ObjectMapper objectMapper,
@@ -54,7 +57,7 @@ public class ImageGenerationOpenAiClient implements OpenAiClientPort {
         this.webClient = builder.build();
     }
 
-    /** Envia uma requisição síncrona para a OpenAI Images API e guarda a resposta para o awaitResult do core. */
+    /** Registra o despacho lógico para permitir que o backend marque o job como processando antes da chamada longa. */
     @Override
     public OpenAiDispatch dispatch(OpenAiRequest request) {
         if (!enabled) {
@@ -62,83 +65,140 @@ public class ImageGenerationOpenAiClient implements OpenAiClientPort {
         }
 
         String marketingHubJobId = marketingHubJobId(request);
-        String requestBodyJson = request.requestBodyJson();
+        String openAiJobId = "image-" + UUID.randomUUID();
+        pendingDispatches.put(openAiJobId, new PendingImageDispatch(request));
+        log.info(
+                "Envio preparado para OpenAI Images API [jobId={}, openAiJobId={}, requestBodyJson={}]",
+                marketingHubJobId,
+                openAiJobId,
+                request.requestBodyJson()
+        );
+        return new OpenAiDispatch(
+                openAiJobId,
+                request.prompt(),
+                request.schemaJson(),
+                request.requestBodyJson(),
+                request.promptMarkdownContent(),
+                Instant.now()
+        );
+    }
+
+    /** Executa uma chamada Images API por prompt planejado e consolida a resposta crua em um manifesto único. */
+    @Override
+    public OpenAiResult<String> awaitResult(OpenAiDispatch dispatch) {
+        if (dispatch.openAiJobId() == null) {
+            throw new StageWorkerException("Cannot await OpenAI image result without openAiJobId");
+        }
+        PendingImageDispatch pending = pendingDispatches.remove(dispatch.openAiJobId());
+        if (pending == null) {
+            throw new StageWorkerException("OpenAI image dispatch not found in local cache: " + dispatch.openAiJobId());
+        }
+
+        OpenAiRequest request = pending.request();
+        String marketingHubJobId = marketingHubJobId(request);
         try {
-            Map<String, Object> requestBody = objectMapper.readValue(requestBodyJson, new TypeReference<>() {});
-            log.info(
-                    "Envio cru para OpenAI Images API [jobId={}, requestBodyJson={}]",
-                    marketingHubJobId,
-                    requestBodyJson
-            );
-
-            JsonNode raw = webClient.post()
-                    .uri("/images/generations")
-                    .bodyValue(requestBody)
-                    .retrieve()
-                    .bodyToMono(JsonNode.class)
-                    .block(properties.timeout());
-
-            if (raw == null) {
-                throw new StageWorkerException("OpenAI returned an empty image generation response");
+            Map<String, Object> requestBody = objectMapper.readValue(request.requestBodyJson(), new TypeReference<>() {});
+            String model = asString(requestBody.get("model"));
+            String responseFormat = asString(requestBody.get("responseFormat"));
+            List<Map<String, Object>> images = asMapList(requestBody.get("images"));
+            if (images.isEmpty()) {
+                throw new StageWorkerException("GeraLanding image request has no image prompts");
             }
 
-            String rawJson = objectMapper.writeValueAsString(raw);
-            log.info(
-                    "Resposta crua recebida da OpenAI Images API [jobId={}, rawResponseJson={}]",
-                    marketingHubJobId,
-                    rawJson
-            );
-            String openAiJobId = "image-" + UUID.randomUUID();
-            OpenAiResult<String> result = new OpenAiResult<>(
-                    openAiJobId,
+            List<Map<String, Object>> generated = new ArrayList<>();
+            Integer totalInputTokens = null;
+            Integer totalOutputTokens = null;
+            for (Map<String, Object> image : images) {
+                Map<String, Object> openAiBody = buildOpenAiImageBody(model, asString(image.get("prompt")), responseFormat);
+                String openAiBodyJson = objectMapper.writeValueAsString(openAiBody);
+                log.info(
+                        "Envio cru para OpenAI Images API [jobId={}, openAiJobId={}, planningItemKey={}, requestBodyJson={}]",
+                        marketingHubJobId,
+                        dispatch.openAiJobId(),
+                        image.get("planningItemKey"),
+                        openAiBodyJson
+                );
+
+                JsonNode raw = webClient.post()
+                        .uri("/images/generations")
+                        .bodyValue(openAiBody)
+                        .retrieve()
+                        .bodyToMono(JsonNode.class)
+                        .block(properties.timeout());
+                if (raw == null) {
+                    throw new StageWorkerException("OpenAI returned an empty image generation response");
+                }
+
+                String rawJson = objectMapper.writeValueAsString(raw);
+                log.info(
+                        "Resposta crua recebida da OpenAI Images API [jobId={}, openAiJobId={}, planningItemKey={}, rawResponseJson={}]",
+                        marketingHubJobId,
+                        dispatch.openAiJobId(),
+                        image.get("planningItemKey"),
+                        rawJson
+                );
+
+                Map<String, Object> generatedImage = new LinkedHashMap<>(image);
+                generatedImage.put("model", model);
+                generatedImage.put("rawResponse", objectMapper.readValue(rawJson, new TypeReference<Map<String, Object>>() {}));
+                generated.add(generatedImage);
+                totalInputTokens = addNullable(totalInputTokens, extractUsageToken(raw, "input_tokens"));
+                totalOutputTokens = addNullable(totalOutputTokens, extractUsageToken(raw, "output_tokens"));
+            }
+
+            String rawJson = buildConsolidatedRawResponse(request, generated);
+            return new OpenAiResult<>(
+                    dispatch.openAiJobId(),
                     rawJson,
                     rawJson,
                     rawJson,
-                    extractUsageToken(raw, "input_tokens"),
-                    extractUsageToken(raw, "output_tokens"),
-                    BigDecimal.valueOf(Math.max(0d, properties.costPerImageUsd()))
-            );
-            resultCache.put(openAiJobId, result);
-            return new OpenAiDispatch(
-                    openAiJobId,
-                    request.prompt(),
-                    request.schemaJson(),
-                    requestBodyJson,
-                    request.promptMarkdownContent(),
-                    Instant.now()
+                    totalInputTokens,
+                    totalOutputTokens,
+                    BigDecimal.valueOf(Math.max(0d, properties.costPerImageUsd()) * generated.size())
             );
         } catch (WebClientResponseException error) {
             log.error(
-                    "Falha HTTP na OpenAI Images API [jobId={}, status={}, responseBody={}, requestBodyJson={}]",
+                    "Falha HTTP na OpenAI Images API [jobId={}, openAiJobId={}, status={}, responseBody={}, requestBodyJson={}]",
                     marketingHubJobId,
+                    dispatch.openAiJobId(),
                     error.getStatusCode().value(),
                     error.getResponseBodyAsString(),
-                    requestBodyJson,
+                    request.requestBodyJson(),
                     error
             );
             throw new OpenAiHttpException(error.getStatusCode().value(), error.getResponseBodyAsString(), error);
         } catch (JsonProcessingException error) {
             log.error(
-                    "Falha ao preparar request JSON da OpenAI Images API [jobId={}, requestBodyJson={}]",
+                    "Falha ao preparar request JSON da OpenAI Images API [jobId={}, openAiJobId={}, requestBodyJson={}]",
                     marketingHubJobId,
-                    requestBodyJson,
+                    dispatch.openAiJobId(),
+                    request.requestBodyJson(),
                     error
             );
             throw new StageWorkerException("Invalid OpenAI image request or response JSON", error);
         }
     }
 
-    /** Recupera a resposta bruta da Images API armazenada localmente após o despacho síncrono. */
-    @Override
-    public OpenAiResult<String> awaitResult(OpenAiDispatch dispatch) {
-        if (dispatch.openAiJobId() == null) {
-            throw new StageWorkerException("Cannot await OpenAI image result without openAiJobId");
+    /** Monta o payload real da Images API para um único prompt planejado. */
+    private Map<String, Object> buildOpenAiImageBody(String model, String prompt, String responseFormat) {
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("model", model);
+        payload.put("prompt", prompt);
+        if ("b64_json".equals(responseFormat)) {
+            payload.put("response_format", "b64_json");
         }
-        OpenAiResult<String> result = resultCache.remove(dispatch.openAiJobId());
-        if (result == null) {
-            throw new StageWorkerException("OpenAI image result not found in local cache: " + dispatch.openAiJobId());
-        }
-        return result;
+        return payload;
+    }
+
+    /** Serializa a resposta consolidada usada pelo validador e pelo detalhe do GeraLanding. */
+    private String buildConsolidatedRawResponse(OpenAiRequest request, List<Map<String, Object>> generated) throws JsonProcessingException {
+        Map<String, Object> root = new LinkedHashMap<>();
+        root.put("model", request.model());
+        root.put("stageCode", request.metadata().get("stageCode"));
+        root.put("idJob", request.metadata().get("idJob"));
+        root.put("experimentId", request.metadata().get("experimentId"));
+        root.put("images", generated);
+        return objectMapper.writeValueAsString(root);
     }
 
     /** Recupera o idJob do Marketing Hub a partir dos metadados para correlacionar logs operacionais. */
@@ -162,5 +222,48 @@ public class ImageGenerationOpenAiClient implements OpenAiClientPort {
             return total.intValue();
         }
         return null;
+    }
+
+    /** Soma inteiros que podem estar ausentes preservando nulo quando nenhuma parcela existe. */
+    private Integer addNullable(Integer current, Integer increment) {
+        if (increment == null) {
+            return current;
+        }
+        return current == null ? increment : current + increment;
+    }
+
+    /** Converte lista genérica de objetos JSON em lista de mapas textualmente indexados. */
+    private List<Map<String, Object>> asMapList(Object value) {
+        if (!(value instanceof List<?> rawList)) {
+            return List.of();
+        }
+        List<Map<String, Object>> converted = new ArrayList<>();
+        for (Object item : rawList) {
+            if (item instanceof Map<?, ?> rawMap) {
+                Map<String, Object> map = new LinkedHashMap<>();
+                rawMap.forEach((key, rawValue) -> {
+                    if (key != null) {
+                        map.put(String.valueOf(key), rawValue);
+                    }
+                });
+                converted.add(map);
+            }
+        }
+        return converted;
+    }
+
+    /** Converte valor genérico para texto preservando nulo quando ausente. */
+    private String asString(Object value) {
+        return value != null ? value.toString() : null;
+    }
+
+    /** Responsabilidade: manter o request lógico enquanto o backend registra o despacho da etapa. */
+    private record PendingImageDispatch(OpenAiRequest request) {
+        /** Garante que o request pendente exista antes da execução longa na OpenAI. */
+        private PendingImageDispatch {
+            if (request == null) {
+                throw new IllegalArgumentException("request must not be null");
+            }
+        }
     }
 }

--- a/ai-worker/src/main/java/com/marketinghub/worker/openai/core/imagegeneration/ImageGenerationOutput.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/openai/core/imagegeneration/ImageGenerationOutput.java
@@ -1,22 +1,42 @@
 package com.marketinghub.worker.openai.core.imagegeneration;
 
+import java.util.List;
 import java.util.Objects;
 
-/** Responsabilidade: representar a imagem retornada pela OpenAI antes da publicação em storage. */
-public record ImageGenerationOutput(
-        String model,
-        String prompt,
-        byte[] imageContent,
-        String imageUrl
-) {
-    /** Valida que a resposta contém ao menos bytes ou URL de imagem para publicação posterior. */
+/** Responsabilidade: representar as imagens retornadas pela OpenAI antes da publicação em storage. */
+public record ImageGenerationOutput(List<GeneratedImage> images) {
+    /** Valida que a resposta contém ao menos uma imagem útil para publicação posterior. */
     public ImageGenerationOutput {
-        boolean hasBytes = imageContent != null && imageContent.length > 0;
-        boolean hasUrl = imageUrl != null && !imageUrl.isBlank();
-        if (!hasBytes && !hasUrl) {
-            throw new IllegalArgumentException("imageContent or imageUrl must be present");
+        images = images == null ? List.of() : List.copyOf(images);
+        if (images.isEmpty()) {
+            throw new IllegalArgumentException("images must not be empty");
         }
-        model = Objects.toString(model, null);
-        prompt = Objects.toString(prompt, null);
+    }
+
+    /** Responsabilidade: transportar uma imagem gerada com suas chaves de vinculação ao planejamento da landing. */
+    public record GeneratedImage(
+            String planningItemKey,
+            String sectionId,
+            String elementId,
+            String imageGoal,
+            String prompt,
+            String model,
+            byte[] imageContent,
+            String imageUrl
+    ) {
+        /** Valida que cada item gerado contém bytes ou URL para upload/publicação. */
+        public GeneratedImage {
+            boolean hasBytes = imageContent != null && imageContent.length > 0;
+            boolean hasUrl = imageUrl != null && !imageUrl.isBlank();
+            if (!hasBytes && !hasUrl) {
+                throw new IllegalArgumentException("imageContent or imageUrl must be present");
+            }
+            planningItemKey = Objects.toString(planningItemKey, null);
+            sectionId = Objects.toString(sectionId, null);
+            elementId = Objects.toString(elementId, null);
+            imageGoal = Objects.toString(imageGoal, null);
+            prompt = Objects.toString(prompt, null);
+            model = Objects.toString(model, null);
+        }
     }
 }

--- a/ai-worker/src/main/java/com/marketinghub/worker/openai/core/imagegeneration/ImageGenerationPromptBuilder.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/openai/core/imagegeneration/ImageGenerationPromptBuilder.java
@@ -2,12 +2,12 @@ package com.marketinghub.worker.openai.core.imagegeneration;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.marketinghub.worker.frameworkimage.FrameworkImageJobDto;
 import com.marketinghub.worker.openai.core.exception.StageWorkerException;
 import com.marketinghub.worker.openai.core.model.OpenAiRequest;
 import com.marketinghub.worker.openai.core.model.StageExecution;
 import com.marketinghub.worker.openai.core.port.StagePromptBuilder;
 import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Map;
 import org.springframework.util.StringUtils;
 
@@ -23,51 +23,80 @@ public class ImageGenerationPromptBuilder implements StagePromptBuilder<ImageGen
         this.properties = properties;
     }
 
-    /** Monta o request bruto para o endpoint de geração de imagens da OpenAI. */
+    /** Monta o request bruto com todos os prompts de imagens planejadas para o endpoint novo do GeraLanding. */
     @Override
     public OpenAiRequest build(StageExecution<ImageGenerationInput> execution) {
-        FrameworkImageJobDto job = execution.input().job();
-        String selectedModel = resolveModel(job.model());
-        String prompt = job.prompt();
-        String requestBodyJson = buildImagesApiRequest(selectedModel, prompt);
+        ImageGenerationInput input = execution.input();
+        String selectedModel = resolveModel(properties.imageModel());
+        List<Map<String, Object>> imagePayload = input.images().stream()
+                .filter(item -> StringUtils.hasText(item.prompt()))
+                .map(this::toImageRequestItem)
+                .toList();
+        if (imagePayload.isEmpty()) {
+            throw new StageWorkerException("GeraLanding image generation has no planned image prompts");
+        }
+
+        String prompt = buildPromptSummary(imagePayload);
+        String requestBodyJson = buildImagesApiRequest(selectedModel, imagePayload);
 
         return new OpenAiRequest(
                 selectedModel,
                 prompt,
                 requestBodyJson,
-                "framework_image_generation",
+                "geralanding_image_generation",
                 "{}",
                 prompt,
                 Map.of(
                         "stageCode", execution.stageCode(),
                         "idJob", execution.idJob(),
                         "experimentId", execution.aggregateId(),
-                        "assetId", job.assetId() == null ? "" : job.assetId()
+                        "imageCount", imagePayload.size()
                 )
         );
     }
 
-    /** Serializa o corpo compatível com a Images API preservando o prompt funcional da etapa. */
-    private String buildImagesApiRequest(String selectedModel, String prompt) {
+    /** Converte um item planejado no formato auditável consumido pelo client de imagens. */
+    private Map<String, Object> toImageRequestItem(ImageGenerationInput.ImageGenerationPromptItem item) {
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("planningItemKey", item.effectiveKey());
+        putIfPresent(payload, "sectionId", item.sectionId());
+        putIfPresent(payload, "elementId", item.elementId());
+        putIfPresent(payload, "imageGoal", item.imageGoal());
+        payload.put("prompt", item.prompt());
+        return payload;
+    }
+
+    /** Serializa o corpo auditável contendo uma requisição lógica por imagem planejada. */
+    private String buildImagesApiRequest(String selectedModel, List<Map<String, Object>> images) {
         try {
             Map<String, Object> payload = new LinkedHashMap<>();
             payload.put("model", selectedModel);
-            payload.put("prompt", prompt);
-            if (supportsResponseFormat(selectedModel)) {
-                payload.put("response_format", "b64_json");
-            }
+            payload.put("images", images);
+            payload.put("responseFormat", supportsResponseFormat(selectedModel) ? "b64_json" : "default");
             return objectMapper.writeValueAsString(payload);
         } catch (JsonProcessingException error) {
             throw new StageWorkerException("Could not build OpenAI Images API request", error);
         }
     }
 
-    /** Resolve o modelo efetivo de imagem usando o padrão configurado quando o job não informa modelo atual. */
+    /** Monta um resumo textual dos prompts para auditoria no detalhe da execução GeraLanding. */
+    private String buildPromptSummary(List<Map<String, Object>> images) {
+        StringBuilder builder = new StringBuilder("Geração de imagens GeraLanding:\n");
+        for (Map<String, Object> image : images) {
+            builder.append("\n- ")
+                    .append(image.get("planningItemKey"))
+                    .append(": ")
+                    .append(image.get("prompt"));
+        }
+        return builder.toString();
+    }
+
+    /** Resolve o modelo efetivo de imagem usando o padrão configurado quando o valor está ausente. */
     private String resolveModel(String requestedModel) {
         if (!StringUtils.hasText(requestedModel)
                 || "gpt-image-1".equalsIgnoreCase(requestedModel.trim())
                 || "gpt-image-1.0".equalsIgnoreCase(requestedModel.trim())) {
-            return properties.imageModel().trim();
+            return "gpt-image-1.5";
         }
         return requestedModel.trim();
     }
@@ -78,5 +107,12 @@ public class ImageGenerationPromptBuilder implements StagePromptBuilder<ImageGen
             return true;
         }
         return !selectedModel.toLowerCase(java.util.Locale.ROOT).startsWith("gpt-image-");
+    }
+
+    /** Adiciona campos opcionais ao payload somente quando há conteúdo textual útil. */
+    private void putIfPresent(Map<String, Object> payload, String fieldName, String value) {
+        if (StringUtils.hasText(value)) {
+            payload.put(fieldName, value.trim());
+        }
     }
 }

--- a/ai-worker/src/main/java/com/marketinghub/worker/openai/core/imagegeneration/ImageGenerationResponseValidator.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/openai/core/imagegeneration/ImageGenerationResponseValidator.java
@@ -4,7 +4,9 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marketinghub.worker.openai.core.exception.InvalidModelResponseException;
 import com.marketinghub.worker.openai.core.port.StageResponseValidator;
+import java.util.ArrayList;
 import java.util.Base64;
+import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.util.StringUtils;
@@ -21,31 +23,16 @@ public class ImageGenerationResponseValidator implements StageResponseValidator<
         this.objectMapper = objectMapper;
     }
 
-    /** Valida que a resposta contém uma imagem utilizável em base64 ou URL. */
+    /** Valida que a resposta consolidada contém imagens utilizáveis em base64 ou URL. */
     @Override
     public ImageGenerationOutput validateAndParse(String modelResponse) {
         try {
             JsonNode root = objectMapper.readTree(modelResponse);
-            JsonNode first = root.path("data").isArray() && !root.path("data").isEmpty()
-                    ? root.path("data").get(0)
-                    : null;
-            if (first == null || first.isMissingNode() || first.isNull()) {
-                throw new InvalidModelResponseException("OpenAI image response did not include data[0]");
+            JsonNode imagesNode = root.path("images");
+            if (imagesNode.isArray()) {
+                return parseConsolidatedResponse(root, imagesNode);
             }
-
-            String base64 = text(first.path("b64_json"));
-            String imageUrl = text(first.path("url"));
-            byte[] imageContent = decodeBase64(base64);
-            if ((imageContent == null || imageContent.length == 0) && !StringUtils.hasText(imageUrl)) {
-                throw new InvalidModelResponseException("OpenAI image response did not include b64_json or url");
-            }
-
-            return new ImageGenerationOutput(
-                    text(root.path("model")),
-                    text(root.path("prompt")),
-                    imageContent,
-                    imageUrl
-            );
+            return parseSingleOpenAiResponse(root);
         } catch (InvalidModelResponseException error) {
             log.error("Invalid OpenAI image response contract. rawResponse={}", modelResponse, error);
             throw error;
@@ -53,6 +40,65 @@ public class ImageGenerationResponseValidator implements StageResponseValidator<
             log.error("Could not parse OpenAI image response. rawResponse={}", modelResponse, error);
             throw new InvalidModelResponseException("Could not parse OpenAI image response", error);
         }
+    }
+
+    /** Interpreta o manifesto consolidado produzido pelo client quando há múltiplos prompts planejados. */
+    private ImageGenerationOutput parseConsolidatedResponse(JsonNode root, JsonNode imagesNode) {
+        List<ImageGenerationOutput.GeneratedImage> images = new ArrayList<>();
+        for (JsonNode imageNode : imagesNode) {
+            JsonNode raw = imageNode.path("rawResponse");
+            if (raw.isMissingNode() || raw.isNull()) {
+                raw = imageNode;
+            }
+            ImageContent imageContent = extractImageContent(raw);
+            images.add(new ImageGenerationOutput.GeneratedImage(
+                    text(imageNode.path("planningItemKey")),
+                    text(imageNode.path("sectionId")),
+                    text(imageNode.path("elementId")),
+                    text(imageNode.path("imageGoal")),
+                    text(imageNode.path("prompt")),
+                    firstText(text(imageNode.path("model")), text(root.path("model"))),
+                    imageContent.bytes(),
+                    imageContent.url()
+            ));
+        }
+        if (images.isEmpty()) {
+            throw new InvalidModelResponseException("OpenAI image response did not include images");
+        }
+        return new ImageGenerationOutput(images);
+    }
+
+    /** Mantém compatibilidade com respostas diretas da Images API contendo data[0]. */
+    private ImageGenerationOutput parseSingleOpenAiResponse(JsonNode root) {
+        ImageContent imageContent = extractImageContent(root);
+        return new ImageGenerationOutput(List.of(new ImageGenerationOutput.GeneratedImage(
+                null,
+                null,
+                null,
+                null,
+                text(root.path("prompt")),
+                text(root.path("model")),
+                imageContent.bytes(),
+                imageContent.url()
+        )));
+    }
+
+    /** Extrai bytes ou URL do primeiro item de data retornado pela Images API. */
+    private ImageContent extractImageContent(JsonNode root) {
+        JsonNode first = root.path("data").isArray() && !root.path("data").isEmpty()
+                ? root.path("data").get(0)
+                : null;
+        if (first == null || first.isMissingNode() || first.isNull()) {
+            throw new InvalidModelResponseException("OpenAI image response did not include data[0]");
+        }
+
+        String base64 = text(first.path("b64_json"));
+        String imageUrl = text(first.path("url"));
+        byte[] imageContent = decodeBase64(base64);
+        if ((imageContent == null || imageContent.length == 0) && !StringUtils.hasText(imageUrl)) {
+            throw new InvalidModelResponseException("OpenAI image response did not include b64_json or url");
+        }
+        return new ImageContent(imageContent, imageUrl);
     }
 
     /** Decodifica o conteúdo base64 quando a OpenAI retorna bytes inline. */
@@ -74,5 +120,22 @@ public class ImageGenerationResponseValidator implements StageResponseValidator<
             return null;
         }
         return node.asText();
+    }
+
+    /** Retorna o primeiro texto preenchido entre os candidatos informados. */
+    private String firstText(String... candidates) {
+        for (String candidate : candidates) {
+            if (StringUtils.hasText(candidate)) {
+                return candidate.trim();
+            }
+        }
+        return null;
+    }
+
+    /** Responsabilidade: transportar o conteúdo extraído da resposta de imagem. */
+    private record ImageContent(byte[] bytes, String url) {
+        /** Preserva bytes ou URL extraídos sem transformação adicional. */
+        private ImageContent {
+        }
     }
 }

--- a/ai-worker/src/main/java/com/marketinghub/worker/openai/core/imagegeneration/ImageGenerationWorkerConfiguration.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/openai/core/imagegeneration/ImageGenerationWorkerConfiguration.java
@@ -2,7 +2,6 @@ package com.marketinghub.worker.openai.core.imagegeneration;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marketinghub.worker.creative.CreativeImageOptimizer;
-import com.marketinghub.worker.frameworkimage.FrameworkImageBackendClient;
 import com.marketinghub.worker.frameworkimage.FrameworkImageStorageClient;
 import com.marketinghub.worker.openai.core.StageWorker;
 import org.springframework.beans.factory.annotation.Value;
@@ -26,13 +25,13 @@ public class ImageGenerationWorkerConfiguration {
     /** Cria o adapter HTTP/storage da etapa imagegeneration para consultar, atualizar e publicar imagens. */
     @Bean
     public ImageGenerationBackendClient imageGenerationBackendClient(
-            FrameworkImageBackendClient backendClient,
             FrameworkImageStorageClient storageClient,
             CreativeImageOptimizer imageOptimizer,
             WebClient.Builder webClientBuilder,
+            ObjectMapper objectMapper,
             ImageGenerationWorkerProperties properties
     ) {
-        return new ImageGenerationBackendClient(backendClient, storageClient, imageOptimizer, webClientBuilder, properties);
+        return new ImageGenerationBackendClient(storageClient, imageOptimizer, webClientBuilder, objectMapper, properties);
     }
 
     /** Cria o builder responsável por montar o request de imagem da OpenAI para a etapa imagegeneration. */

--- a/ai-worker/src/test/java/com/marketinghub/worker/openai/core/imagegeneration/ImageGenerationBackendClientTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/openai/core/imagegeneration/ImageGenerationBackendClientTest.java
@@ -1,0 +1,97 @@
+package com.marketinghub.worker.openai.core.imagegeneration;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marketinghub.worker.creative.CreativeImageOptimizer;
+import com.marketinghub.worker.frameworkimage.FrameworkImageStorageClient;
+import com.marketinghub.worker.openai.core.model.StageExecution;
+import java.time.Duration;
+import java.util.List;
+import java.util.Map;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.reactive.function.client.WebClient;
+
+/** Responsabilidade: validar o contrato HTTP do client imagegeneration do core OpenAI com GeraLanding. */
+class ImageGenerationBackendClientTest {
+
+    private MockWebServer server;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    /** Inicializa o backend simulado usado para capturar os payloads enviados pelo client. */
+    @BeforeEach
+    void setUp() throws Exception {
+        server = new MockWebServer();
+        server.start();
+    }
+
+    /** Encerra o backend simulado após cada teste do client. */
+    @AfterEach
+    void tearDown() throws Exception {
+        server.shutdown();
+    }
+
+    /** Deve consumir o endpoint novo de pendências do GeraLanding e extrair prompts planejados de imagem. */
+    @Test
+    void listPendingShouldUseGeraLandingImageGenerationEndpoint() throws Exception {
+        Map<String, Object> pendingExecution = Map.of(
+                "experimentId", 36,
+                "stageCode", "landing-page-image-generation",
+                "jobid", "job-geralanding-image-1",
+                "executionRequestedAt", "2026-06-02T04:38:04.746Z",
+                "experiment", Map.of(
+                        "landingPageImagePlanning", Map.of(
+                                "landingPageImagePlanning", Map.of(
+                                        "images", List.of(Map.of(
+                                                "sectionId", "hero",
+                                                "elementId", "hero-img",
+                                                "imageGoal", "Mostrar entrega",
+                                                "imagePrompt", "Mockup premium da amostra personalizada"))))));
+        server.enqueue(new MockResponse()
+                .setResponseCode(200)
+                .setHeader("Content-Type", "application/json")
+                .setBody(objectMapper.writeValueAsString(List.of(pendingExecution))));
+        ImageGenerationBackendClient client = newClient();
+
+        List<StageExecution<ImageGenerationInput>> result = client.listPending(5);
+
+        assertThat(server.takeRequest().getPath())
+                .isEqualTo("/api/internal/geralanding/image-generation/stage-executions/pending");
+        assertThat(result).hasSize(1);
+        StageExecution<ImageGenerationInput> execution = result.getFirst();
+        assertThat(execution.idJob()).isEqualTo("job-geralanding-image-1");
+        assertThat(execution.stageCode()).isEqualTo("landing-page-image-generation");
+        assertThat(execution.aggregateId()).isEqualTo(36L);
+        assertThat(execution.input().images()).singleElement().satisfies(image -> {
+            assertThat(image.sectionId()).isEqualTo("hero");
+            assertThat(image.elementId()).isEqualTo("hero-img");
+            assertThat(image.prompt()).isEqualTo("Mockup premium da amostra personalizada");
+        });
+    }
+
+    /** Cria o client imagegeneration apontando para o backend simulado do teste. */
+    private ImageGenerationBackendClient newClient() {
+        return new ImageGenerationBackendClient(
+                mock(FrameworkImageStorageClient.class),
+                mock(CreativeImageOptimizer.class),
+                WebClient.builder(),
+                objectMapper,
+                new ImageGenerationWorkerProperties(
+                        true,
+                        5,
+                        server.url("/").toString(),
+                        "/api",
+                        "gpt-image-1.5",
+                        Duration.ofSeconds(5),
+                        3,
+                        Duration.ofMillis(300),
+                        "worker-test",
+                        100,
+                        0.01d));
+    }
+}

--- a/ai-worker/src/test/java/com/marketinghub/worker/openai/core/imagegeneration/ImageGenerationPromptBuilderTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/openai/core/imagegeneration/ImageGenerationPromptBuilderTest.java
@@ -4,13 +4,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.marketinghub.worker.frameworkimage.FrameworkImageJobDto;
 import com.marketinghub.worker.openai.core.model.OpenAiRequest;
 import com.marketinghub.worker.openai.core.model.StageExecution;
 import java.time.Duration;
 import java.time.Instant;
+import java.util.List;
 import java.util.Map;
-import java.util.UUID;
 import org.junit.jupiter.api.Test;
 
 /** Responsabilidade: validar a montagem do request de geração de imagens no padrão core OpenAI. */
@@ -18,47 +17,43 @@ class ImageGenerationPromptBuilderTest {
 
     private final ObjectMapper objectMapper = new ObjectMapper();
 
-    /** Deve montar payload da Images API usando o modelo padrão quando o job vem com alias legado. */
+    /** Deve montar payload auditável usando os prompts planejados recebidos do endpoint GeraLanding. */
     @Test
-    void buildShouldUseConfiguredImageModelForLegacyAlias() throws Exception {
-        UUID jobId = UUID.randomUUID();
-        FrameworkImageJobDto job = new FrameworkImageJobDto(
-                jobId,
-                33L,
-                "hero",
-                "INICIADO",
-                "WAITING_AI_WORKER",
-                null,
-                "gpt-image-1",
-                "Crie imagem hero de transformação real",
-                null,
-                77L,
-                null,
-                null,
-                null,
-                null,
-                null,
-                Instant.parse("2026-05-31T10:00:00Z"),
-                null);
+    void buildShouldUseGeraLandingPlannedImagePrompts() throws Exception {
         ImageGenerationPromptBuilder builder = new ImageGenerationPromptBuilder(objectMapper, properties());
 
         OpenAiRequest request = builder.build(new StageExecution<>(
-                jobId.toString(),
+                "job-123",
                 33L,
-                "framework-image-generation",
+                "landing-page-image-generation",
                 "INICIADO",
                 Instant.parse("2026-05-31T10:00:00Z"),
-                new ImageGenerationInput(job)));
+                new ImageGenerationInput(
+                        33L,
+                        "landing-page-image-generation",
+                        "job-123",
+                        List.of(new ImageGenerationInput.ImageGenerationPromptItem(
+                                "hero-img",
+                                "hero",
+                                "hero-img",
+                                "Mostrar produto digital",
+                                "Crie imagem hero de transformação real")))));
 
         Map<String, Object> body = objectMapper.readValue(request.requestBodyJson(), new TypeReference<>() {});
         assertThat(body)
                 .containsEntry("model", "gpt-image-1.5")
-                .containsEntry("prompt", "Crie imagem hero de transformação real");
-        assertThat(body).doesNotContainKey("response_format");
+                .containsEntry("responseFormat", "default");
+        assertThat((List<Map<String, Object>>) body.get("images"))
+                .singleElement()
+                .satisfies(image -> assertThat(image)
+                        .containsEntry("planningItemKey", "hero-img")
+                        .containsEntry("sectionId", "hero")
+                        .containsEntry("elementId", "hero-img")
+                        .containsEntry("prompt", "Crie imagem hero de transformação real"));
         assertThat(request.metadata())
-                .containsEntry("stageCode", "framework-image-generation")
+                .containsEntry("stageCode", "landing-page-image-generation")
                 .containsEntry("experimentId", 33L)
-                .containsEntry("assetId", 77L);
+                .containsEntry("imageCount", 1);
     }
 
     /** Cria propriedades mínimas para o builder de imagegeneration. */

--- a/ai-worker/src/test/java/com/marketinghub/worker/openai/core/imagegeneration/ImageGenerationResponseValidatorTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/openai/core/imagegeneration/ImageGenerationResponseValidatorTest.java
@@ -22,10 +22,41 @@ class ImageGenerationResponseValidatorTest {
 
         ImageGenerationOutput output = validator.validateAndParse(response);
 
-        assertThat(output.model()).isEqualTo("gpt-image-1.5");
-        assertThat(output.prompt()).isEqualTo("hero");
-        assertThat(output.imageContent()).isEqualTo("fake-image".getBytes(StandardCharsets.UTF_8));
-        assertThat(output.imageUrl()).isNull();
+        assertThat(output.images()).singleElement().satisfies(image -> {
+            assertThat(image.model()).isEqualTo("gpt-image-1.5");
+            assertThat(image.prompt()).isEqualTo("hero");
+            assertThat(image.imageContent()).isEqualTo("fake-image".getBytes(StandardCharsets.UTF_8));
+            assertThat(image.imageUrl()).isNull();
+        });
+    }
+
+    /** Deve converter resposta consolidada com metadados de planejamento em imagens geradas. */
+    @Test
+    void validateAndParseShouldDecodeConsolidatedGeraLandingResponse() {
+        String payload = Base64.getEncoder().encodeToString("hero-image".getBytes(StandardCharsets.UTF_8));
+        String response = """
+                {
+                  "model": "gpt-image-1.5",
+                  "images": [
+                    {
+                      "planningItemKey": "hero-img",
+                      "sectionId": "hero",
+                      "elementId": "hero-img",
+                      "prompt": "hero",
+                      "rawResponse": {"data":[{"b64_json":"%s"}]}
+                    }
+                  ]
+                }
+                """.formatted(payload);
+
+        ImageGenerationOutput output = validator.validateAndParse(response);
+
+        assertThat(output.images()).singleElement().satisfies(image -> {
+            assertThat(image.planningItemKey()).isEqualTo("hero-img");
+            assertThat(image.sectionId()).isEqualTo("hero");
+            assertThat(image.elementId()).isEqualTo("hero-img");
+            assertThat(image.imageContent()).isEqualTo("hero-image".getBytes(StandardCharsets.UTF_8));
+        });
     }
 
     /** Deve rejeitar resposta sem bytes ou URL para bloquear publicação sem imagem final. */

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/imagegeneration/service/BackendImageGenerationService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/imagegeneration/service/BackendImageGenerationService.java
@@ -175,6 +175,7 @@ public class BackendImageGenerationService {
             execution.setStatus(normalizedErrorMessage != null ? STATUS_FAILED : STATUS_COMPLETED);
 
             executionRepository.save(execution);
+            persistImageAssetsArtifactOnExperiment(execution, modelResponse, normalizedErrorMessage);
         } catch (RuntimeException ex) {
             log.error(
                     "Erro ao concluir resposta image generation (idJob={}, experimentId={}, stageCode={}, openAiJobId={}, modelResponseLength={}, errorMessage={})",
@@ -187,6 +188,24 @@ public class BackendImageGenerationService {
                     ex);
             throw ex;
         }
+    }
+
+    /** Persiste o manifesto de imagens gerado no experimento para consumo das etapas seguintes do GeraLanding. */
+    private void persistImageAssetsArtifactOnExperiment(
+            GeraLandingStageExecution execution,
+            String modelResponse,
+            String normalizedErrorMessage) {
+        if (!StringUtils.hasText(modelResponse) || normalizedErrorMessage != null) {
+            return;
+        }
+        Experiment experiment = execution.getExperiment();
+        if (experiment == null) {
+            experiment = experimentRepository.findById(execution.getExperimentId())
+                    .orElseThrow(() -> new EntityNotFoundException(
+                            "Experiment not found: " + execution.getExperimentId()));
+        }
+        experiment.setLandingPageImageAssets(modelResponse);
+        experimentRepository.save(experiment);
     }
 
     /** Normaliza a mensagem de erro e garante status FALHA quando o callback traz apenas detalhe técnico. */

--- a/backend/ads-service/src/test/java/com/marketinghub/geralanding/imagegeneration/service/BackendImageGenerationServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/geralanding/imagegeneration/service/BackendImageGenerationServiceTest.java
@@ -176,9 +176,9 @@ class BackendImageGenerationServiceTest {
         verify(executionRepository).save(execution);
     }
 
-    /** Deve concluir a execução e manter a resposta da geração de imagens na auditoria da execução. */
+    /** Deve concluir a execução e gravar o manifesto de imagens no experimento para as próximas etapas. */
     @Test
-    void markCompletedFromResponseShouldPersistExecutionAuditOnly() {
+    void markCompletedFromResponseShouldPersistImageAssetsManifestOnExperiment() {
         ExperimentRepository experimentRepository = mock(ExperimentRepository.class);
         GeraLandingStageExecutionRepository executionRepository = mock(GeraLandingStageExecutionRepository.class);
         BackendImageGenerationService service =
@@ -191,7 +191,7 @@ class BackendImageGenerationServiceTest {
                 .idJob("job-ia-1".getBytes(StandardCharsets.UTF_8))
                 .status("AGUARDANDO_RETORNO_OPENAI")
                 .build();
-        String modelResponse = "{\"landingPageWireframe\":{\"sectionOrder\":[\"hero\"]}}";
+        String modelResponse = "{\"images\":[{\"planningItemKey\":\"hero-img\",\"resolvedUrl\":\"https://cdn/hero.jpg\"}]}";
         when(executionRepository.findTopByIdJobOrderByExecutionRequestedAtDesc(any(byte[].class)))
                 .thenReturn(Optional.of(execution));
 
@@ -215,8 +215,9 @@ class BackendImageGenerationServiceTest {
         assertNotNull(execution.getCompletedAt());
         assertEquals("CONCLUIDO", execution.getStatus());
         verify(executionRepository).save(execution);
+        verify(experiment).setLandingPageImageAssets(modelResponse);
         verify(experiment, never()).setLandingPageWireframe(any());
-        verify(experimentRepository, never()).save(experiment);
+        verify(experimentRepository).save(experiment);
         verify(experimentRepository, never()).findById(88L);
     }
 

--- a/docs/canonical/geralanding-arquitetura-canon.v1.md
+++ b/docs/canonical/geralanding-arquitetura-canon.v1.md
@@ -71,6 +71,7 @@ Regras arquiteturais refletidas (ArchUnit):
 ## 3) Contrato HTTP canônico
 
 - O Swagger/OpenAPI canônico dos endpoints HTTP do backend GeraLanding por etapa fica em `docs/canonical/geralanding-backend-swagger.v1.yaml`.
+- A etapa `landing-page-image-generation` deve ser consumida pelo Worker AI exclusivamente pelos endpoints internos do próprio GeraLanding: `/api/internal/geralanding/image-generation/stage-executions/pending`, `/api/internal/geralanding/image-generation/stage-executions/{idJob}/recebe-prompt` e `/api/internal/geralanding/image-generation/stage-executions/{idJob}/recebe-resposta`; não usar a fila legada `/api/internal/framework-image/jobs/pending` para jobs iniciados pelo card GeraLanding.
 - Qualquer criação, remoção ou mudança de endpoint em `com.marketinghub.geralanding.*.web` deve manter esse Swagger sincronizado no mesmo PR.
 
 ## 4) Regras de integração

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -3047,3 +3047,15 @@
   - os testes unitários foram ajustados para separar ausência de prévia local da possibilidade de tentar aprovação pelo backend.
 - validações operacionais:
   - `SELECT id, LENGTH(html_geralanding), LENGTH(landing_page_html), follow_up_action_url, status FROM experiment WHERE id = 35` retornou `html_geralanding` preenchido e `landing_page_html` nulo, confirmando que a landing gerada existe no registro canônico do GeraLanding.
+
+## 2026-06-02 — GeraLanding ImageGeneration consumindo endpoint novo
+
+- solicitação: alterar o Worker AI para usar o endpoint novo do GeraLanding na etapa `landing-page-image-generation`.
+- causa-raiz/objetivo: jobs iniciados pelo card `4 - Gera Imagem` ficavam presos em `INICIADO` na tabela `gera_landing_stage_execution`, porque o worker de `imagegeneration` ainda consultava a fila antiga `/internal/framework-image/jobs/pending` em vez de `/internal/geralanding/image-generation/stage-executions/pending`.
+- correção aplicada:
+  - o adapter `ImageGenerationBackendClient` passou a consumir pendências, `recebe-prompt` e `recebe-resposta` diretamente pelos endpoints internos novos do GeraLanding;
+  - o client de OpenAI Images API agora prepara o despacho, deixa o backend marcar o job como aguardando retorno e só então executa as chamadas de imagem, evitando reprocessamento enquanto a chamada síncrona está em andamento;
+  - a etapa gera manifesto de imagens com URLs publicáveis, preservando `planningItemKey`, `sectionId`, `elementId`, prompt, modelo e `openAiJobId`;
+  - o backend persiste o manifesto recebido em `landingPageImageAssets`, permitindo que o preset design use as URLs geradas nas próximas etapas;
+  - testes unitários foram ajustados para proteger o consumo do endpoint novo, o payload auditável de prompts e a resposta consolidada de imagens.
+- impacto esperado: jobs de `landing-page-image-generation` iniciados pela tela de experimento passam a sair de `INICIADO`, registrar prompt/request/resposta no detalhe do GeraLanding e fornecer manifesto de imagens para o HTML final.


### PR DESCRIPTION
### Motivation
- Move the image generation worker off the legacy framework-image endpoints to the new GeraLanding internal HTTP contract to ensure jobs started from the GeraLanding UI progress correctly. 
- Support multi-image planned prompts per experiment (preserve planning keys and binding metadata) so the worker can generate, upload and return a manifest consumable by the rest of the GeraLanding pipeline. 
- Make OpenAI Images calls safe for long synchronous requests by separating logical `dispatch` from the actual `awaitResult` execution to allow the backend to mark jobs as processing before the long call.

### Description
- Replaced the old framework-image backend adapter with `ImageGenerationBackendClient` that polls and posts to the new endpoints under `/api/internal/geralanding/image-generation/stage-executions` and translates payloads to `StageExecution<ImageGenerationInput>`. 
- Changed input/outputs to support multiple planned images: `ImageGenerationInput` now carries `ImageGenerationPromptItem` entries and `ImageGenerationOutput` wraps a list of `GeneratedImage` records with planning keys and image bytes/URLs. 
- Updated `ImageGenerationPromptBuilder` to emit an audit-able images payload (one logical request per planned image) and to produce an informative prompt summary; the builder now targets `geralanding_image_generation` stage metadata. 
- Reworked `ImageGenerationOpenAiClient` to separate `dispatch` (register logical dispatch and return `OpenAiDispatch`) from `awaitResult` (actually call OpenAI per planned image, consolidate raw responses, aggregate token counts and cost). Pending dispatches are cached locally until `awaitResult`. 
- `ImageGenerationResponseValidator` now parses both single OpenAI `data[0]` responses and the consolidated manifest with `images[...]` entries, decoding `b64_json` or using returned URLs. 
- `ImageGenerationBackendClient` now uploads each generated image, builds a JSON manifest containing `planningItemKey`, `sectionId`, `elementId`, `prompt`, `model`, `openAiJobId`, `resolvedUrl` and posts completion/failure payloads to `/{idJob}/recebe-resposta`; dispatched prompts are posted to `/{idJob}/recebe-prompt`. 
- Backend service (`BackendImageGenerationService`) now persists the received image manifest into the experiment as `landingPageImageAssets` when completing a stage. 
- Wiring updated in `ImageGenerationWorkerConfiguration` to use the new backend client signature. 
- Utility helpers added for JSON normalization, payload building, URL joining and small conversions used across the new flow. 
- Documentation (`docs/...`) updated to record the new canonical endpoints and the migration rationale. 

### Testing
- Added unit test `ImageGenerationBackendClientTest` using `MockWebServer` to assert polling of `/api/internal/geralanding/image-generation/stage-executions/pending` and extraction of planned image prompts; the test passed. 
- Updated `ImageGenerationPromptBuilderTest` to validate the audit-able `images` payload and metadata (`imageCount`, `stageCode`) emitted by the builder; the test passed. 
- Extended `ImageGenerationResponseValidatorTest` to cover decoding a single `b64_json` image and the consolidated `images[...]` manifest parsing; the tests passed. 
- Updated backend unit test `BackendImageGenerationServiceTest` to verify that completed responses persist `landingPageImageAssets` on the `Experiment`; the test passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1e6631bb5483218cdda2370ee3d4ae)