### PR TITLE
fix: bloquear base OpenAI local acidental

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/openai/core/imagegeneration/ImageGenerationOpenAiClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/openai/core/imagegeneration/ImageGenerationOpenAiClient.java
@@ -7,6 +7,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marketinghub.worker.openai.core.exception.OpenAiHttpException;
 import com.marketinghub.worker.openai.core.exception.StageWorkerException;
 import com.marketinghub.worker.openai.core.model.OpenAiDispatch;
+import com.marketinghub.worker.openai.core.openai.OpenAiBaseUrlGuard;
 import com.marketinghub.worker.openai.core.model.OpenAiRequest;
 import com.marketinghub.worker.openai.core.model.OpenAiResult;
 import com.marketinghub.worker.openai.core.port.OpenAiClientPort;
@@ -43,13 +44,22 @@ public class ImageGenerationOpenAiClient implements OpenAiClientPort {
             ImageGenerationWorkerProperties properties,
             String apiKey,
             String baseUrl,
+            boolean allowLocalBaseUrl,
             int maxInMemorySizeBytes
     ) {
         this.objectMapper = objectMapper;
         this.properties = properties;
         this.enabled = StringUtils.hasText(apiKey);
+        String effectiveBaseUrl = OpenAiBaseUrlGuard.resolve(baseUrl, allowLocalBaseUrl);
+        if (!effectiveBaseUrl.equals(baseUrl)) {
+            log.warn(
+                    "OpenAI Images API base URL local rejeitada; usando endpoint oficial [configuredBaseUrl={}, effectiveBaseUrl={}]",
+                    baseUrl,
+                    effectiveBaseUrl
+            );
+        }
         WebClient.Builder builder = webClientBuilder.clone()
-                .baseUrl(baseUrl)
+                .baseUrl(effectiveBaseUrl)
                 .codecs(configurer -> configurer.defaultCodecs().maxInMemorySize(Math.max(1, maxInMemorySizeBytes)));
         if (enabled) {
             builder.defaultHeader(HttpHeaders.AUTHORIZATION, "Bearer " + apiKey);

--- a/ai-worker/src/main/java/com/marketinghub/worker/openai/core/imagegeneration/ImageGenerationWorkerConfiguration.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/openai/core/imagegeneration/ImageGenerationWorkerConfiguration.java
@@ -67,6 +67,7 @@ public class ImageGenerationWorkerConfiguration {
             ImageGenerationWorkerProperties properties,
             @Value("${openai.api-key:}") String apiKey,
             @Value("${openai.base-url:https://api.openai.com/v1}") String baseUrl,
+            @Value("${openai.allow-local-base-url:false}") boolean allowLocalBaseUrl,
             @Value("${openai.max-in-memory-size-bytes:52428800}") int maxInMemorySizeBytes
     ) {
         ImageGenerationOpenAiClient openAiClient = new ImageGenerationOpenAiClient(
@@ -75,6 +76,7 @@ public class ImageGenerationWorkerConfiguration {
                 properties,
                 apiKey,
                 baseUrl,
+                allowLocalBaseUrl,
                 maxInMemorySizeBytes
         );
         return new StageWorker<>(backendClient, promptBuilder, openAiClient, responseValidator, responseHandler);

--- a/ai-worker/src/main/java/com/marketinghub/worker/openai/core/openai/OpenAiBaseUrlGuard.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/openai/core/openai/OpenAiBaseUrlGuard.java
@@ -1,0 +1,47 @@
+package com.marketinghub.worker.openai.core.openai;
+
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.util.Locale;
+import org.springframework.util.StringUtils;
+
+/** Responsabilidade: impedir que clientes OpenAI usem URLs locais por engano em execução produtiva. */
+public final class OpenAiBaseUrlGuard {
+
+    public static final String DEFAULT_OPENAI_BASE_URL = "https://api.openai.com/v1";
+
+    /** Impede instanciação porque a classe expõe apenas validações utilitárias de base URL. */
+    private OpenAiBaseUrlGuard() {
+    }
+
+    /** Resolve a base URL efetiva da OpenAI, substituindo localhost por endpoint oficial quando não permitido. */
+    public static String resolve(String configuredBaseUrl, boolean allowLocalBaseUrl) {
+        String candidate = StringUtils.hasText(configuredBaseUrl) ? configuredBaseUrl.trim() : DEFAULT_OPENAI_BASE_URL;
+        if (!allowLocalBaseUrl && isLocalBaseUrl(candidate)) {
+            return DEFAULT_OPENAI_BASE_URL;
+        }
+        return candidate;
+    }
+
+    /** Indica se a base URL aponta para loopback/localhost e, portanto, depende de permissão explícita. */
+    public static boolean isLocalBaseUrl(String configuredBaseUrl) {
+        if (!StringUtils.hasText(configuredBaseUrl)) {
+            return false;
+        }
+        try {
+            URI uri = new URI(configuredBaseUrl.trim());
+            String host = uri.getHost();
+            if (!StringUtils.hasText(host)) {
+                return false;
+            }
+            String normalizedHost = host.toLowerCase(Locale.ROOT);
+            return "localhost".equals(normalizedHost)
+                    || "127.0.0.1".equals(normalizedHost)
+                    || "0.0.0.0".equals(normalizedHost)
+                    || "::1".equals(normalizedHost)
+                    || "[::1]".equals(normalizedHost);
+        } catch (URISyntaxException error) {
+            return false;
+        }
+    }
+}

--- a/ai-worker/src/main/java/com/marketinghub/worker/openai/core/openai/OpenAiClientProperties.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/openai/core/openai/OpenAiClientProperties.java
@@ -8,6 +8,7 @@ import org.springframework.validation.annotation.Validated;
 import java.math.BigDecimal;
 import java.time.Duration;
 
+/** Responsabilidade: centralizar credenciais, modelo, custo e URL efetiva dos clientes OpenAI. */
 @Validated
 @ConfigurationProperties(prefix = "openai")
 public record OpenAiClientProperties(
@@ -25,12 +26,13 @@ public record OpenAiClientProperties(
 
         BigDecimal inputUsdPerMillionTokens,
 
-        BigDecimal outputUsdPerMillionTokens
+        BigDecimal outputUsdPerMillionTokens,
+
+        boolean allowLocalBaseUrl
 ) {
+    /** Normaliza valores opcionais e bloqueia base URL local salvo permissão explícita. */
     public OpenAiClientProperties {
-        if (baseUrl == null || baseUrl.isBlank()) {
-            baseUrl = "https://api.openai.com/v1";
-        }
+        baseUrl = OpenAiBaseUrlGuard.resolve(baseUrl, allowLocalBaseUrl);
         if (timeout == null) {
             timeout = Duration.ofMinutes(30);
         }

--- a/ai-worker/src/main/resources/application.properties
+++ b/ai-worker/src/main/resources/application.properties
@@ -12,6 +12,7 @@ openai.api-key=${OPENAI_API_KEY:}
 openai.model=${OPENAI_MODEL:gpt-5.2}
 openai.targeting-request-model=${OPENAI_TARGETING_REQUEST_MODEL:gpt-4.1}
 openai.base-url=${OPENAI_BASE_URL:https://api.openai.com/v1}
+openai.allow-local-base-url=${OPENAI_ALLOW_LOCAL_BASE_URL:false}
 openai.batch-timeout=${OPENAI_BATCH_TIMEOUT:PT30M}
 openai.batch-poll-interval=${OPENAI_BATCH_POLL_INTERVAL:PT0.5S}
 openai.image-model=${OPENAI_IMAGE_MODEL:gpt-image-1.5}

--- a/ai-worker/src/test/java/com/marketinghub/worker/niche/NicheHypothesisServiceTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/niche/NicheHypothesisServiceTest.java
@@ -103,6 +103,7 @@ class NicheHypothesisServiceTest {
         mockWebServer = new MockWebServer();
         mockWebServer.start();
         registry.add("openai.base-url", () -> mockWebServer.url("/").toString());
+        registry.add("openai.allow-local-base-url", () -> "true");
         registry.add("openai.api-key", () -> "test-key");
     }
 

--- a/ai-worker/src/test/java/com/marketinghub/worker/openai/core/openai/OpenAiBaseUrlGuardTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/openai/core/openai/OpenAiBaseUrlGuardTest.java
@@ -1,0 +1,33 @@
+package com.marketinghub.worker.openai.core.openai;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+/** Responsabilidade: validar o bloqueio de base URL local acidental para clientes OpenAI. */
+class OpenAiBaseUrlGuardTest {
+
+    /** Deve trocar localhost pelo endpoint oficial quando a permissão local não estiver habilitada. */
+    @Test
+    void resolveShouldReplaceLocalhostWhenLocalBaseUrlIsNotAllowed() {
+        String resolved = OpenAiBaseUrlGuard.resolve("http://localhost:34303", false);
+
+        assertThat(resolved).isEqualTo(OpenAiBaseUrlGuard.DEFAULT_OPENAI_BASE_URL);
+    }
+
+    /** Deve preservar localhost apenas quando a execução de teste/desenvolvimento permitir explicitamente. */
+    @Test
+    void resolveShouldKeepLocalhostWhenLocalBaseUrlIsAllowed() {
+        String resolved = OpenAiBaseUrlGuard.resolve("http://127.0.0.1:34303", true);
+
+        assertThat(resolved).isEqualTo("http://127.0.0.1:34303");
+    }
+
+    /** Deve preservar a URL oficial da OpenAI usada em produção. */
+    @Test
+    void resolveShouldKeepOfficialOpenAiUrl() {
+        String resolved = OpenAiBaseUrlGuard.resolve("https://api.openai.com/v1", false);
+
+        assertThat(resolved).isEqualTo("https://api.openai.com/v1");
+    }
+}

--- a/ai-worker/src/test/java/com/marketinghub/worker/openai/core/openai/ResponsesApiOpenAiClientTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/openai/core/openai/ResponsesApiOpenAiClientTest.java
@@ -68,7 +68,8 @@ class ResponsesApiOpenAiClientTest {
                         "gpt-test",
                         Duration.ofSeconds(5),
                         BigDecimal.ZERO,
-                        BigDecimal.ZERO));
+                        BigDecimal.ZERO,
+                        true));
         String requestBodyJson = "{\"model\":\"gpt-test\",\"input\":\"Prompt\"}";
         OpenAiRequest request = new OpenAiRequest(
                 "gpt-test",
@@ -131,7 +132,8 @@ class ResponsesApiOpenAiClientTest {
                         "gpt-test",
                         Duration.ofSeconds(5),
                         BigDecimal.ZERO,
-                        BigDecimal.ZERO));
+                        BigDecimal.ZERO,
+                        true));
         OpenAiRequest request = new OpenAiRequest(
                 "gpt-test",
                 "Prompt",

--- a/ai-worker/src/test/java/com/marketinghub/worker/openai/core/presetdesign/PresetDesignBackendClientTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/openai/core/presetdesign/PresetDesignBackendClientTest.java
@@ -156,7 +156,8 @@ class PresetDesignBackendClientTest {
                 "gpt-test",
                 Duration.ofMinutes(30),
                 BigDecimal.ZERO,
-                BigDecimal.ZERO);
+                BigDecimal.ZERO,
+                true);
         PresetDesignPromptBuilder builder = new PresetDesignPromptBuilder(objectMapper, openAiProperties, properties);
         StageExecution<PresetDesignInput> execution = new StageExecution<>(
                 "job-ia-1",

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -3081,3 +3081,14 @@
   - o backend persiste o manifesto recebido em `landingPageImageAssets`, permitindo que o preset design use as URLs geradas nas próximas etapas;
   - testes unitários foram ajustados para proteger o consumo do endpoint novo, o payload auditável de prompts e a resposta consolidada de imagens.
 - impacto esperado: jobs de `landing-page-image-generation` iniciados pela tela de experimento passam a sair de `INICIADO`, registrar prompt/request/resposta no detalhe do GeraLanding e fornecer manifesto de imagens para o HTML final.
+
+## 2026-06-02 — Bloqueio de base OpenAI local acidental no Worker AI
+
+- solicitação: investigar por que a etapa `landing-page-image-generation` tentou acessar `localhost/127.0.0.1:34303` no experimento 36.
+- causa-raiz identificada: o registro `gera_landing_stage_execution` do job `1b16da07-5926-406e-bc06-e1d02750cd07` falhou com `finishConnect(..) failed: Connection refused: localhost/127.0.0.1:34303`, indicando que a base URL efetiva do cliente OpenAI Images API foi contaminada por configuração local em vez de usar `https://api.openai.com/v1`.
+- correção aplicada:
+  - criado um guardião de base URL OpenAI no Worker AI para substituir automaticamente URLs locais (`localhost`, `127.0.0.1`, `0.0.0.0`, `::1`) pelo endpoint oficial quando `openai.allow-local-base-url=false`;
+  - a mesma proteção passou a valer para o client textual de Responses API e para o client de Images API usado no GeraLanding;
+  - adicionado `OPENAI_ALLOW_LOCAL_BASE_URL` apenas como escape explícito para testes/desenvolvimento controlado;
+  - testes unitários cobrem a substituição de localhost, a preservação quando explicitamente permitido e a preservação da URL oficial.
+- impacto esperado: execuções produtivas do GeraLanding não devem mais tentar chamar portas locais acidentais para gerar imagens; se uma configuração local escapar para produção, o Worker AI usa a OpenAI oficial em vez de quebrar o job com conexão recusada em localhost.


### PR DESCRIPTION
### Motivation
- Um job da etapa `landing-page-image-generation` falhou com `Connection refused: localhost/127.0.0.1:34303`, indicando que o Worker AI tentou usar uma `openai.base-url` local por engano.
- Chamar endpoints locais a partir de ambientes produtivos quebra execuções longas e impede que o pipeline de imagens registre prompts/respostas corretamente.
- É necessário garantir que, por padrão, clientes OpenAI usem o endpoint oficial salvo permissão explícita para ambientes de teste/desenvolvimento.

### Description
- Adicionado o guardião `OpenAiBaseUrlGuard` que detecta hosts locais (`localhost`, `127.0.0.1`, `0.0.0.0`, `::1`) e, quando `openai.allow-local-base-url=false`, substitui a URL por `https://api.openai.com/v1` e retorna a URL efetiva.
- Centralizada a normalização em `OpenAiClientProperties` (novo campo `allowLocalBaseUrl`) para aplicar a proteção a clientes textuais da Responses API; incluiu documentação breve da responsabilidade do record.
- Aplicada a proteção ao client de imagens `ImageGenerationOpenAiClient` e à `ImageGenerationWorkerConfiguration`, com `openai.allow-local-base-url` como escape explícito e log de aviso quando uma URL local for rejeitada.
- Ajustados testes e configuração de teste para permitir `openai.allow-local-base-url=true` em ambientes controlados, e adicionados testes unitários (`OpenAiBaseUrlGuardTest`) cobrindo bloqueio/permissão/preservação da URL oficial; registrado o ajuste em `docs/registros/experimentos.md`.

### Testing
- Executado `mvn -q -DskipTests install` no módulo `backend/ads-service` para disponibilizar a dependência local `ads-service`, e o comando completou com sucesso.
- Executados os testes unitários do `ai-worker` com `mvn -q -Dtest=OpenAiBaseUrlGuardTest,ResponsesApiOpenAiClientTest,PresetDesignBackendClientTest test` dentro do diretório `ai-worker`, e os testes terminaram com sucesso.
- Verificado `git diff --check` sem erros e adicionado registro da investigação em `docs/registros/experimentos.md`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f07c531548321a4de23c660486f8f)