### PR TITLE
Publica Swagger/OpenAPI dinâmico no backend

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/config/OpenApiConfig.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/config/OpenApiConfig.java
@@ -1,0 +1,44 @@
+package com.marketinghub.config;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.servers.Server;
+import java.util.List;
+import org.springdoc.core.models.GroupedOpenApi;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * Configura a publicação da documentação OpenAPI do backend principal pelo próprio Spring Boot.
+ */
+@Configuration
+public class OpenApiConfig {
+
+    private static final String BACKEND_DESCRIPTION = "Documentação dinâmica dos endpoints publicados pelo backend principal do Marketing Hub.";
+
+    /**
+     * Define os metadados exibidos no Swagger UI e no documento OpenAPI dinâmico.
+     */
+    @Bean
+    public OpenAPI marketingHubOpenApi() {
+        return new OpenAPI()
+                .info(new Info()
+                        .title("Marketing Hub Backend API")
+                        .version("v1")
+                        .description(BACKEND_DESCRIPTION))
+                .servers(List.of(
+                        new Server().url("/").description("Servidor atual do backend Spring Boot")));
+    }
+
+    /**
+     * Publica todos os endpoints HTTP do backend principal no grupo padrão do Swagger UI.
+     */
+    @Bean
+    public GroupedOpenApi marketingHubBackendApi() {
+        return GroupedOpenApi.builder()
+                .group("marketing-hub-backend")
+                .pathsToMatch("/**")
+                .pathsToExclude("/ops-mh-observability-v2/**", "/error")
+                .build();
+    }
+}

--- a/backend/ads-service/src/test/java/com/marketinghub/config/OpenApiConfigTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/config/OpenApiConfigTest.java
@@ -1,0 +1,41 @@
+package com.marketinghub.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.swagger.v3.oas.models.OpenAPI;
+import org.junit.jupiter.api.Test;
+import org.springdoc.core.models.GroupedOpenApi;
+
+/**
+ * Valida a configuração de publicação Swagger/OpenAPI do backend principal.
+ */
+class OpenApiConfigTest {
+
+    private final OpenApiConfig config = new OpenApiConfig();
+
+    /**
+     * Verifica os metadados expostos no documento OpenAPI dinâmico do backend principal.
+     */
+    @Test
+    void marketingHubOpenApiShouldDescribeBackendSwagger() {
+        OpenAPI openAPI = config.marketingHubOpenApi();
+
+        assertThat(openAPI.getInfo().getTitle()).isEqualTo("Marketing Hub Backend API");
+        assertThat(openAPI.getInfo().getVersion()).isEqualTo("v1");
+        assertThat(openAPI.getServers())
+                .singleElement()
+                .satisfies(server -> assertThat(server.getUrl()).isEqualTo("/"));
+    }
+
+    /**
+     * Verifica o grupo do Swagger UI usado para publicar os endpoints do backend principal.
+     */
+    @Test
+    void marketingHubBackendApiShouldPublishBackendGroup() {
+        GroupedOpenApi groupedOpenApi = config.marketingHubBackendApi();
+
+        assertThat(groupedOpenApi.getGroup()).isEqualTo("marketing-hub-backend");
+        assertThat(groupedOpenApi.getPathsToMatch()).containsExactly("/**");
+        assertThat(groupedOpenApi.getPathsToExclude()).contains("/ops-mh-observability-v2/**", "/error");
+    }
+}

--- a/docs/swagger/README.md
+++ b/docs/swagger/README.md
@@ -20,3 +20,12 @@ Esta pasta é o local único para contratos Swagger/OpenAPI do Marketing Hub.
 - `docs/swagger/oprm-backend-integration-openapi.v1.yaml` — integração OPRM ↔ backend.
 - `docs/swagger/oprm-backend-required-endpoints.swagger.yaml` — endpoints obrigatórios do backend para OPRM.
 - `docs/swagger/oprm-nichocnae-swagger.yaml` — pipeline OPRM Nicho CNAE.
+
+## Publicação dinâmica pelo backend Spring Boot
+
+O backend principal também publica a documentação dinâmica gerada pelo Springdoc no próprio serviço Spring Boot:
+
+- Swagger UI: `http://191.252.181.168/swagger-ui.html` ou, em ambiente local, `http://localhost:8000/swagger-ui.html`.
+- OpenAPI JSON: `http://191.252.181.168/v3/api-docs/marketing-hub-backend` ou, em ambiente local, `http://localhost:8000/v3/api-docs/marketing-hub-backend`.
+
+Essa publicação dinâmica facilita inspeção operacional dos endpoints efetivamente carregados pela aplicação, sem substituir os contratos versionados desta pasta.


### PR DESCRIPTION
### Motivation
- Permitir que o próprio serviço Spring Boot publique a documentação OpenAPI/Swagger operacional para inspeção rápida dos endpoints carregados em runtime.
- Expor um grupo dedicado para os endpoints do backend (sem incluir endpoints operacionais/observability) e fornecer metadados claros da API para o Swagger UI.
- Registrar na documentação central `docs/swagger/README.md` que a publicação dinâmica existe sem substituir os contratos versionados em `docs/swagger`.

### Description
- Adiciona a configuração Springdoc em `backend/ads-service/src/main/java/com/marketinghub/config/OpenApiConfig.java` que cria um `OpenAPI` bean com título `Marketing Hub Backend API` e um `GroupedOpenApi` chamado `marketing-hub-backend` cobrindo `/**` e excluindo `/ops-mh-observability-v2/**` e `/error`.
- Inclui teste unitário em `backend/ads-service/src/test/java/com/marketinghub/config/OpenApiConfigTest.java` que valida os metadados do `OpenAPI` e que o grupo publicado corresponde às paths/pathsToExclude esperadas.
- Atualiza `docs/swagger/README.md` para documentar as URLs de acesso ao Swagger UI e ao JSON OpenAPI dinâmico (`/swagger-ui.html` e `/v3/api-docs/marketing-hub-backend`) tanto em produção quanto local.

### Testing
- Executei `../../backend/mvnw -Dtest=OpenApiConfigTest test` e o teste criado passou com sucesso.
- Executei a suíte de testes completa com `../../backend/mvnw test` e a execução terminou com falha em testes existentes (`FacebookInstantFormControllerTest.setup`) por violação de integridade referencial no H2 entre `creative` e `experiment`, que é uma falha pré-existente e não relacionada à configuração OpenAPI adicionada.
- Os artefatos alterados são apenas a configuração OpenAPI, o teste unitário e a documentação em `docs/swagger/README.md`, e os testes específicos desta alteração passaram localmente antes do commit.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f07f5238083219bc7dd5db32b2ca0)