### PR TITLE
Implementa etapa 1 do pipeline nichocnae no coletor OPRM

### DIFF
--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -215,3 +215,5 @@
 
 - 2026-06-02 00:00:00 (UTC): implementada a etapa 0 do novo pipeline OPRM `com.marketinghub.oprm.nichocnae`, com orquestrador backend para selecionar o próximo candidato de nicho CNAE pendente por maior score, criar `oprm_routine_research_cycle`, marcar o candidato como `RESEARCH_RUNNING` e expor contratos internos para acompanhamento e início do ciclo.
 - 2026-06-02 12:05:00 (UTC-3): iniciado no `oprm-coletor-mei` o submódulo `com.marketinghub.nichocnae` para a etapa 0 do pipeline de pesquisa de rotina do nicho CNAE, sem agendamento automático; criado núcleo genérico de pipeline por etapa, processor/cliente/controller manual do `oprmRoutineResearchOrchestrator` e teste ArchUnit para proteger o isolamento do núcleo conforme a nova metodologia.
+
+- 2026-06-02 00:00:00 (UTC): implementada no coletor OPRM MEI a etapa 1 `oprmRoutineResearchCycle` no pacote `com.marketinghub.nichocnae`, com cliente backend, processor pelo `PipelineWorker`, endpoints manuais de acompanhamento/processamento e testes unitários sem agendamento automático.

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnae/routineresearchcycle/RoutineResearchCycleBackendClient.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnae/routineresearchcycle/RoutineResearchCycleBackendClient.java
@@ -1,0 +1,90 @@
+package com.marketinghub.nichocnae.routineresearchcycle;
+
+import com.marketinghub.oprmcoletormei.marketimport.config.OprmMarketImportCollectorProperties;
+import java.util.Arrays;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
+
+/** Chama exclusivamente endpoints OPRM nichocnae do backend para consultar e controlar a etapa um do pipeline. */
+@Component
+public class RoutineResearchCycleBackendClient {
+    private static final Logger log = LoggerFactory.getLogger(RoutineResearchCycleBackendClient.class);
+    private static final String PENDING_PATH = "/api/internal/oprm/nichocnae/routine-research-cycle/stage-executions/pending";
+    private static final String LIST_BY_SOURCE_PATH_PREFIX = "/api/oprm/nichocnae/";
+    private static final String LIST_BY_SOURCE_PATH_SUFFIX = "/routine-research-cycle/stage-executions";
+    private static final String DETAIL_PATH_PREFIX = "/api/oprm/nichocnae/routine-research-cycle/stage-executions/";
+
+    private final OprmMarketImportCollectorProperties collectorProperties;
+    private final RestClient restClient;
+
+    /** Inicializa o cliente com a URL base do backend e o RestClient compartilhado do coletor. */
+    public RoutineResearchCycleBackendClient(
+            OprmMarketImportCollectorProperties collectorProperties,
+            RestClient restClient) {
+        this.collectorProperties = collectorProperties;
+        this.restClient = restClient;
+    }
+
+    /** Lista ciclos em execução que estão prontos para a etapa um controlar e encaminhar no pipeline. */
+    public List<RoutineResearchCyclePending> listPendingCycles() {
+        String url = collectorProperties.backendBaseUrl() + PENDING_PATH;
+        try {
+            RoutineResearchCyclePending[] response = restClient.get()
+                    .uri(url)
+                    .retrieve()
+                    .body(RoutineResearchCyclePending[].class);
+            return response == null ? List.of() : Arrays.asList(response);
+        } catch (RestClientException ex) {
+            log.error("Erro ao listar pendências da etapa um OPRM nichocnae (endpoint={})", url, ex);
+            throw ex;
+        }
+    }
+
+    /** Lista os ciclos de pesquisa de rotina vinculados ao nicho CNAE de origem informado. */
+    public List<RoutineResearchCycleSummary> listBySourceNicheId(Long sourceNicheId) {
+        String url = collectorProperties.backendBaseUrl()
+                + LIST_BY_SOURCE_PATH_PREFIX
+                + sourceNicheId
+                + LIST_BY_SOURCE_PATH_SUFFIX;
+        try {
+            RoutineResearchCycleSummary[] response = restClient.get()
+                    .uri(url)
+                    .retrieve()
+                    .body(RoutineResearchCycleSummary[].class);
+            return response == null ? List.of() : Arrays.asList(response);
+        } catch (RestClientException ex) {
+            log.error(
+                    "Erro ao listar ciclos da etapa um OPRM nichocnae por nicho (endpoint={}, sourceNicheId={})",
+                    url,
+                    sourceNicheId,
+                    ex);
+            throw ex;
+        }
+    }
+
+    /** Detalha uma execução específica da etapa um para validar o estado canônico do ciclo no backend. */
+    public RoutineResearchCycleDetail detailStageExecution(Long researchCycleId) {
+        String url = collectorProperties.backendBaseUrl() + DETAIL_PATH_PREFIX + researchCycleId;
+        try {
+            RoutineResearchCycleDetail response = restClient.get()
+                    .uri(url)
+                    .retrieve()
+                    .body(RoutineResearchCycleDetail.class);
+            if (response == null) {
+                throw new IllegalStateException("Backend OPRM nichocnae retornou corpo vazio ao detalhar etapa um.");
+            }
+            return response;
+        } catch (RestClientException | IllegalStateException ex) {
+            log.error(
+                    "Erro ao detalhar ciclo da etapa um OPRM nichocnae (endpoint={}, researchCycleId={})",
+                    url,
+                    researchCycleId,
+                    ex);
+            throw ex;
+        }
+    }
+}

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnae/routineresearchcycle/RoutineResearchCycleDetail.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnae/routineresearchcycle/RoutineResearchCycleDetail.java
@@ -1,0 +1,21 @@
+package com.marketinghub.nichocnae.routineresearchcycle;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+
+/** Detalha uma execução completa da etapa um de ciclo de pesquisa de rotina do nicho CNAE. */
+public record RoutineResearchCycleDetail(
+        Long researchCycleId,
+        Long sourceNicheId,
+        String cnaeCode,
+        String cnaeDescription,
+        String nicheName,
+        BigDecimal sourceScore,
+        String status,
+        Integer totalQueries,
+        Integer totalSourceCandidates,
+        Integer totalSourceSnapshots,
+        Integer totalExtractedSignals,
+        Instant startedAt,
+        Instant finishedAt,
+        String errorMessage) {}

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnae/routineresearchcycle/RoutineResearchCyclePending.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnae/routineresearchcycle/RoutineResearchCyclePending.java
@@ -1,0 +1,17 @@
+package com.marketinghub.nichocnae.routineresearchcycle;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+
+/** Representa uma unidade de trabalho da etapa um criada pelo backend para controlar o ciclo de rotina. */
+public record RoutineResearchCyclePending(
+        Long researchCycleId,
+        Long sourceNicheId,
+        String cnaeCode,
+        String cnaeDescription,
+        String nicheName,
+        BigDecimal sourceScore,
+        String triggerSource,
+        String status,
+        Instant startedAt,
+        Instant createdAt) {}

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnae/routineresearchcycle/RoutineResearchCycleProcessor.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnae/routineresearchcycle/RoutineResearchCycleProcessor.java
@@ -1,0 +1,34 @@
+package com.marketinghub.nichocnae.routineresearchcycle;
+
+import com.marketinghub.nichocnae.pipeline.StageContext;
+import com.marketinghub.nichocnae.pipeline.StageProcessor;
+import com.marketinghub.nichocnae.pipeline.StageResult;
+import java.util.List;
+import java.util.Map;
+import org.springframework.stereotype.Component;
+
+/** Processa a etapa um confirmando no backend o ciclo de pesquisa de rotina que seguirá para a próxima etapa. */
+@Component
+public class RoutineResearchCycleProcessor implements StageProcessor<RoutineResearchCyclePending, RoutineResearchCycleDetail> {
+    private final RoutineResearchCycleBackendClient backendClient;
+
+    /** Inicializa o processor com o cliente backend específico da etapa um. */
+    public RoutineResearchCycleProcessor(RoutineResearchCycleBackendClient backendClient) {
+        this.backendClient = backendClient;
+    }
+
+    /** Detalha o ciclo em execução e devolve métricas estruturadas para auditoria da etapa um. */
+    @Override
+    public StageResult<RoutineResearchCycleDetail> process(StageContext<RoutineResearchCyclePending> context) {
+        RoutineResearchCyclePending input = context.input();
+        RoutineResearchCycleDetail output = backendClient.detailStageExecution(input.researchCycleId());
+        Map<String, Object> metrics = Map.of(
+                "researchCycleId", output.researchCycleId(),
+                "status", output.status(),
+                "totalQueries", output.totalQueries(),
+                "totalSourceCandidates", output.totalSourceCandidates(),
+                "totalSourceSnapshots", output.totalSourceSnapshots(),
+                "totalExtractedSignals", output.totalExtractedSignals());
+        return new StageResult<>(output, List.of(), metrics);
+    }
+}

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnae/routineresearchcycle/RoutineResearchCycleService.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnae/routineresearchcycle/RoutineResearchCycleService.java
@@ -1,0 +1,76 @@
+package com.marketinghub.nichocnae.routineresearchcycle;
+
+import com.marketinghub.nichocnae.pipeline.ArtifactStore;
+import com.marketinghub.nichocnae.pipeline.PipelineWorker;
+import com.marketinghub.nichocnae.pipeline.StageExecution;
+import com.marketinghub.nichocnae.pipeline.StageResult;
+import java.util.List;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+/** Orquestra manualmente a etapa um do submódulo nichocnae sem criar agendamento automático. */
+@Service
+public class RoutineResearchCycleService {
+    private static final Logger log = LoggerFactory.getLogger(RoutineResearchCycleService.class);
+
+    private final RoutineResearchCycleBackendClient backendClient;
+    private final RoutineResearchCycleProcessor processor;
+    private final ArtifactStore artifactStore;
+
+    /** Inicializa o serviço com a borda backend, processor concreto e armazenamento genérico de artefatos. */
+    public RoutineResearchCycleService(
+            RoutineResearchCycleBackendClient backendClient,
+            RoutineResearchCycleProcessor processor,
+            ArtifactStore artifactStore) {
+        this.backendClient = backendClient;
+        this.processor = processor;
+        this.artifactStore = artifactStore;
+    }
+
+    /** Lista ciclos em execução disponíveis para continuidade do pipeline de pesquisa de rotina. */
+    public List<RoutineResearchCyclePending> listPendingCycles() {
+        return backendClient.listPendingCycles();
+    }
+
+    /** Lista o histórico operacional de ciclos associados ao nicho CNAE de origem. */
+    public List<RoutineResearchCycleSummary> listBySourceNicheId(Long sourceNicheId) {
+        return backendClient.listBySourceNicheId(sourceNicheId);
+    }
+
+    /** Detalha diretamente um ciclo de pesquisa de rotina mantido como fonte de verdade no backend. */
+    public RoutineResearchCycleDetail detailStageExecution(Long researchCycleId) {
+        return backendClient.detailStageExecution(researchCycleId);
+    }
+
+    /** Processa sob demanda os ciclos pendentes pela etapa um e retorna detalhes auditáveis de cada ciclo. */
+    public List<RoutineResearchCycleDetail> processPending(String requestedBy) {
+        List<RoutineResearchCyclePending> pendingCycles = backendClient.listPendingCycles();
+        return pendingCycles.stream()
+                .map(pending -> processOne(pending, requestedBy))
+                .toList();
+    }
+
+    /** Executa o worker genérico para uma unidade de trabalho da etapa um e preserva log contextual em falha. */
+    private RoutineResearchCycleDetail processOne(RoutineResearchCyclePending pending, String requestedBy) {
+        StageExecution<RoutineResearchCyclePending> execution = new StageExecution<>(
+                "oprm-routine-research-cycle-" + pending.researchCycleId(),
+                pending,
+                Map.of("stage", "oprmRoutineResearchCycle", "requestedBy", requestedBy));
+        try {
+            PipelineWorker<RoutineResearchCyclePending, RoutineResearchCycleDetail> worker = new PipelineWorker<>(
+                    processor, artifactStore);
+            StageResult<RoutineResearchCycleDetail> result = worker.processResult(execution);
+            return result.output();
+        } catch (RuntimeException ex) {
+            log.error(
+                    "Erro ao executar sob demanda a etapa um OPRM nichocnae (researchCycleId={}, sourceNicheId={}, requestedBy={})",
+                    pending.researchCycleId(),
+                    pending.sourceNicheId(),
+                    requestedBy,
+                    ex);
+            throw ex;
+        }
+    }
+}

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnae/routineresearchcycle/RoutineResearchCycleSummary.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnae/routineresearchcycle/RoutineResearchCycleSummary.java
@@ -1,0 +1,17 @@
+package com.marketinghub.nichocnae.routineresearchcycle;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+
+/** Resume uma execução da etapa um para acompanhamento operacional por nicho CNAE de origem. */
+public record RoutineResearchCycleSummary(
+        Long researchCycleId,
+        Long sourceNicheId,
+        String cnaeCode,
+        String nicheName,
+        BigDecimal sourceScore,
+        String status,
+        Integer totalQueries,
+        Integer totalExtractedSignals,
+        Instant startedAt,
+        Instant finishedAt) {}

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnae/routineresearchcycle/package-info.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnae/routineresearchcycle/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Contém a etapa um que controla ciclos de pesquisa de rotina de nichos CNAE já abertos pelo orquestrador.
+ */
+package com.marketinghub.nichocnae.routineresearchcycle;

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnae/routineresearchcycle/web/RoutineResearchCycleController.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnae/routineresearchcycle/web/RoutineResearchCycleController.java
@@ -1,0 +1,51 @@
+package com.marketinghub.nichocnae.routineresearchcycle.web;
+
+import com.marketinghub.nichocnae.routineresearchcycle.RoutineResearchCycleDetail;
+import com.marketinghub.nichocnae.routineresearchcycle.RoutineResearchCyclePending;
+import com.marketinghub.nichocnae.routineresearchcycle.RoutineResearchCycleService;
+import com.marketinghub.nichocnae.routineresearchcycle.RoutineResearchCycleSummary;
+import java.util.List;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/** Expõe acompanhamento e acionamento manual da etapa um nichocnae no coletor OPRM. */
+@RestController
+@RequestMapping("/api/oprm-mei/nichocnae/routine-research-cycle")
+public class RoutineResearchCycleController {
+    private final RoutineResearchCycleService routineResearchCycleService;
+
+    /** Inicializa o controller com o serviço de execução sob demanda da etapa um. */
+    public RoutineResearchCycleController(RoutineResearchCycleService routineResearchCycleService) {
+        this.routineResearchCycleService = routineResearchCycleService;
+    }
+
+    /** Lista ciclos em execução que a etapa um pode controlar para continuidade do pipeline. */
+    @GetMapping("/pending")
+    public ResponseEntity<List<RoutineResearchCyclePending>> pending() {
+        return ResponseEntity.ok(routineResearchCycleService.listPendingCycles());
+    }
+
+    /** Lista ciclos de pesquisa de rotina vinculados ao nicho CNAE de origem informado. */
+    @GetMapping("/source-niches/{sourceNicheId}/stage-executions")
+    public ResponseEntity<List<RoutineResearchCycleSummary>> listBySourceNicheId(@PathVariable Long sourceNicheId) {
+        return ResponseEntity.ok(routineResearchCycleService.listBySourceNicheId(sourceNicheId));
+    }
+
+    /** Retorna detalhes de uma execução específica do ciclo de pesquisa de rotina. */
+    @GetMapping("/stage-executions/{researchCycleId}")
+    public ResponseEntity<RoutineResearchCycleDetail> detailStageExecution(@PathVariable Long researchCycleId) {
+        return ResponseEntity.ok(routineResearchCycleService.detailStageExecution(researchCycleId));
+    }
+
+    /** Executa manualmente a etapa um para todos os ciclos pendentes retornados pelo backend. */
+    @PostMapping("/process-pending")
+    public ResponseEntity<List<RoutineResearchCycleDetail>> processPending(
+            @RequestHeader(value = "X-Requested-By", required = false, defaultValue = "MANUAL_API") String requestedBy) {
+        return ResponseEntity.accepted().body(routineResearchCycleService.processPending(requestedBy));
+    }
+}

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnae/routineresearchcycle/web/package-info.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnae/routineresearchcycle/web/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Expõe endpoints manuais do coletor para acompanhamento e execução da etapa um do pipeline OPRM nichocnae.
+ */
+package com.marketinghub.nichocnae.routineresearchcycle.web;

--- a/oprm-coletor-mei/src/test/java/com/marketinghub/nichocnae/routineresearchcycle/RoutineResearchCycleProcessorTest.java
+++ b/oprm-coletor-mei/src/test/java/com/marketinghub/nichocnae/routineresearchcycle/RoutineResearchCycleProcessorTest.java
@@ -1,0 +1,66 @@
+package com.marketinghub.nichocnae.routineresearchcycle;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import com.marketinghub.nichocnae.pipeline.NoopArtifactStore;
+import com.marketinghub.nichocnae.pipeline.StageContext;
+import com.marketinghub.nichocnae.pipeline.StageExecution;
+import com.marketinghub.nichocnae.pipeline.StageResult;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/** Valida o processor da etapa um nichocnae sem chamadas reais ao backend. */
+@ExtendWith(MockitoExtension.class)
+class RoutineResearchCycleProcessorTest {
+    @Mock private RoutineResearchCycleBackendClient backendClient;
+
+    /** Garante que a etapa um detalha o ciclo em execução e registra métricas de controle. */
+    @Test
+    void shouldDetailCycleAndReturnControlMetrics() {
+        RoutineResearchCyclePending pending = new RoutineResearchCyclePending(
+                1001L,
+                55L,
+                "9602501",
+                "Cabeleireiros, manicure e pedicure",
+                "Kit Agenda Cheia com IA para manicures",
+                BigDecimal.valueOf(92),
+                "AUTO_SCORE_QUEUE",
+                "RUNNING",
+                Instant.parse("2026-06-02T03:00:00Z"),
+                Instant.parse("2026-06-02T03:00:00Z"));
+        RoutineResearchCycleDetail detail = new RoutineResearchCycleDetail(
+                1001L,
+                55L,
+                "9602501",
+                "Cabeleireiros, manicure e pedicure",
+                "Kit Agenda Cheia com IA para manicures",
+                BigDecimal.valueOf(92),
+                "RUNNING",
+                0,
+                0,
+                0,
+                0,
+                Instant.parse("2026-06-02T03:00:00Z"),
+                null,
+                null);
+        when(backendClient.detailStageExecution(1001L)).thenReturn(detail);
+        RoutineResearchCycleProcessor processor = new RoutineResearchCycleProcessor(backendClient);
+        StageExecution<RoutineResearchCyclePending> execution = new StageExecution<>("stage-1", pending, Map.of());
+
+        StageResult<RoutineResearchCycleDetail> result = processor.process(
+                new StageContext<>(execution, execution.input(), new NoopArtifactStore(), execution.config()));
+
+        assertThat(result.output()).isEqualTo(detail);
+        assertThat(result.artifacts()).isEmpty();
+        assertThat(result.metrics())
+                .containsEntry("researchCycleId", 1001L)
+                .containsEntry("status", "RUNNING")
+                .containsEntry("totalExtractedSignals", 0);
+    }
+}

--- a/oprm-coletor-mei/src/test/java/com/marketinghub/nichocnae/routineresearchcycle/RoutineResearchCycleServiceTest.java
+++ b/oprm-coletor-mei/src/test/java/com/marketinghub/nichocnae/routineresearchcycle/RoutineResearchCycleServiceTest.java
@@ -1,0 +1,122 @@
+package com.marketinghub.nichocnae.routineresearchcycle;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.marketinghub.nichocnae.pipeline.NoopArtifactStore;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/** Valida o serviço manual da etapa um do pipeline OPRM nichocnae. */
+@ExtendWith(MockitoExtension.class)
+class RoutineResearchCycleServiceTest {
+    @Mock private RoutineResearchCycleBackendClient backendClient;
+
+    /** Confirma que a listagem de pendências é delegada para o contrato backend correto. */
+    @Test
+    void shouldListPendingCycles() {
+        RoutineResearchCyclePending pending = pendingCycle();
+        when(backendClient.listPendingCycles()).thenReturn(List.of(pending));
+        RoutineResearchCycleService service = newService();
+
+        List<RoutineResearchCyclePending> result = service.listPendingCycles();
+
+        assertThat(result).containsExactly(pending);
+    }
+
+    /** Confirma que a etapa um processa pendências usando o worker genérico e devolve detalhes canônicos. */
+    @Test
+    void shouldProcessPendingCyclesWithoutScheduler() {
+        RoutineResearchCyclePending pending = pendingCycle();
+        RoutineResearchCycleDetail detail = detailCycle();
+        when(backendClient.listPendingCycles()).thenReturn(List.of(pending));
+        when(backendClient.detailStageExecution(1001L)).thenReturn(detail);
+        RoutineResearchCycleService service = newService();
+
+        List<RoutineResearchCycleDetail> result = service.processPending("TEST");
+
+        assertThat(result).containsExactly(detail);
+        verify(backendClient).listPendingCycles();
+        verify(backendClient).detailStageExecution(1001L);
+    }
+
+    /** Confirma que o detalhe direto preserva a fonte de verdade do backend. */
+    @Test
+    void shouldDetailStageExecution() {
+        RoutineResearchCycleDetail detail = detailCycle();
+        when(backendClient.detailStageExecution(1001L)).thenReturn(detail);
+        RoutineResearchCycleService service = newService();
+
+        RoutineResearchCycleDetail result = service.detailStageExecution(1001L);
+
+        assertThat(result).isEqualTo(detail);
+    }
+
+    /** Confirma que o histórico por nicho é delegado para o backend OPRM. */
+    @Test
+    void shouldListBySourceNicheId() {
+        RoutineResearchCycleSummary summary = new RoutineResearchCycleSummary(
+                1001L,
+                55L,
+                "9602501",
+                "Kit Agenda Cheia com IA para manicures",
+                BigDecimal.valueOf(92),
+                "RUNNING",
+                0,
+                0,
+                Instant.parse("2026-06-02T03:00:00Z"),
+                null);
+        when(backendClient.listBySourceNicheId(55L)).thenReturn(List.of(summary));
+        RoutineResearchCycleService service = newService();
+
+        List<RoutineResearchCycleSummary> result = service.listBySourceNicheId(55L);
+
+        assertThat(result).containsExactly(summary);
+    }
+
+    /** Monta uma unidade de trabalho pendente reutilizável para os testes da etapa um. */
+    private RoutineResearchCyclePending pendingCycle() {
+        return new RoutineResearchCyclePending(
+                1001L,
+                55L,
+                "9602501",
+                "Cabeleireiros, manicure e pedicure",
+                "Kit Agenda Cheia com IA para manicures",
+                BigDecimal.valueOf(92),
+                "AUTO_SCORE_QUEUE",
+                "RUNNING",
+                Instant.parse("2026-06-02T03:00:00Z"),
+                Instant.parse("2026-06-02T03:00:00Z"));
+    }
+
+    /** Monta o detalhe canônico reutilizável de ciclo retornado pelo backend OPRM. */
+    private RoutineResearchCycleDetail detailCycle() {
+        return new RoutineResearchCycleDetail(
+                1001L,
+                55L,
+                "9602501",
+                "Cabeleireiros, manicure e pedicure",
+                "Kit Agenda Cheia com IA para manicures",
+                BigDecimal.valueOf(92),
+                "RUNNING",
+                0,
+                0,
+                0,
+                0,
+                Instant.parse("2026-06-02T03:00:00Z"),
+                null,
+                null);
+    }
+
+    /** Monta o serviço com processor real e cliente mockado para manter o teste focado na etapa um. */
+    private RoutineResearchCycleService newService() {
+        RoutineResearchCycleProcessor processor = new RoutineResearchCycleProcessor(backendClient);
+        return new RoutineResearchCycleService(backendClient, processor, new NoopArtifactStore());
+    }
+}


### PR DESCRIPTION
### Motivation
- Implementar a etapa 1 `oprmRoutineResearchCycle` do pipeline OPRM para controlar execuções de pesquisa de rotina de nichos CNAE e manter o contrato com o backend como fonte de verdade.
- Seguir o novo padrão de arquitetura por etapa (`com.marketinghub.nichocnae.pipeline`) para garantir isolamento, auditabilidade de artefatos e evolução posterior das demais etapas do pipeline.

### Description
- Adiciona contratos/DTOs de borda: `RoutineResearchCyclePending`, `RoutineResearchCycleDetail` e `RoutineResearchCycleSummary` no pacote `com.marketinghub.nichocnae.routineresearchcycle`.
- Implementa `RoutineResearchCycleBackendClient` que chama apenas os endpoints backend canônicos para pendências, histórico por nicho e detalhe de ciclo com log contextual de erro.
- Implementa `RoutineResearchCycleProcessor` como `StageProcessor` concreto que confirma o detalhe do ciclo no backend e retorna métricas auditáveis, e `RoutineResearchCycleService` que orquestra o processamento usando o `PipelineWorker` sem agendamento automático.
- Expõe endpoints manuais no coletor para acompanhamento e acionamento (`/api/oprm-mei/nichocnae/routine-research-cycle/*`) e adiciona `package-info` e registro em `docs/registros/oprm1.md`.
- Adiciona testes unitários: `RoutineResearchCycleProcessorTest` e `RoutineResearchCycleServiceTest` cobrindo comportamento do processor, delegação ao backend e processamento manual de pendências.

### Testing
- Executado `mvn -q test` dentro do módulo `oprm-coletor-mei`, onde os testes unitários do módulo foram executados com sucesso.
- Tentativa de executar `mvn -q test -pl oprm-coletor-mei` a partir do root falhou por configuração do reactor Maven (o comando não localizou o projeto no reactor).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f0c67ded08321ab49e0ed2d93e0b3)