### PR TITLE
Implementa etapa 2 seed builder do OPRM nichocnae

### DIFF
--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -219,3 +219,11 @@
 - 2026-06-02 14:25:00 (UTC-3): documentada na metodologia de pipeline por etapas a necessidade obrigatória de etapas concretas plugáveis e removíveis, explicitando que etapas podem depender do núcleo/infra compartilhada permitida, mas não de outras etapas concretas, para permitir inclusão, remoção e substituição sem dano colateral.
 
 - 2026-06-02 00:00:00 (UTC): implementada no coletor OPRM MEI a etapa 1 `oprmRoutineResearchCycle` no pacote `com.marketinghub.nichocnae`, com cliente backend, processor pelo `PipelineWorker`, endpoints manuais de acompanhamento/processamento e testes unitários sem agendamento automático.
+
+
+## 2026-06-02 — OPRM nichocnae etapa 2 seed builder no coletor MEI
+
+- Implementada no `oprm-coletor-mei` a etapa `oprmNicheResearchSeedBuilder` no pacote `com.marketinghub.nichocnae.nicheresearchseedbuilder`, seguindo o padrão de etapa plugável do motor `pipeline`.
+- A etapa lista ciclos pendentes no backend, chama a OpenAI Responses API com schema JSON estrito, valida seed e 12 a 15 queries específicas, persiste a conclusão no backend e registra falha operacional quando necessário.
+- Expostos endpoints manuais do coletor em `/api/oprm-mei/nichocnae/niche-research-seed-builder` para listar pendências, detalhar ciclo e processar pendentes.
+- Atualizada a documentação Swagger OPRM nichocnae com os contratos backend esperados para pending, complete, fail e detail da etapa dois.

--- a/docs/swagger/oprm-nichocnae-swagger.yaml
+++ b/docs/swagger/oprm-nichocnae-swagger.yaml
@@ -60,3 +60,57 @@ paths:
       responses:
         '200':
           description: Detalhe do ciclo.
+
+  /api/internal/oprm/nichocnae/niche-research-seed-builder/stage-executions/pending:
+    get:
+      summary: Lista ciclos pendentes para geração do seed e queries da etapa dois.
+      tags:
+        - OPRM Nicho CNAE
+      responses:
+        '200':
+          description: Ciclos em execução sem seed de pesquisa gerado.
+  /api/internal/oprm/nichocnae/niche-research-seed-builder/stage-executions/{researchCycleId}/complete:
+    post:
+      summary: Persiste a saída validada da etapa dois com seed e queries.
+      tags:
+        - OPRM Nicho CNAE
+      parameters:
+        - name: researchCycleId
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: Seed e queries gravados para o ciclo.
+  /api/internal/oprm/nichocnae/niche-research-seed-builder/stage-executions/{researchCycleId}/fail:
+    post:
+      summary: Registra falha operacional da etapa dois.
+      tags:
+        - OPRM Nicho CNAE
+      parameters:
+        - name: researchCycleId
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '204':
+          description: Falha registrada.
+  /api/oprm/nichocnae/niche-research-seed-builder/stage-executions/{researchCycleId}:
+    get:
+      summary: Detalha o seed e as queries gerados na etapa dois.
+      tags:
+        - OPRM Nicho CNAE
+      parameters:
+        - name: researchCycleId
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: Seed e queries do ciclo.

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnae/nicheresearchseedbuilder/NicheResearchSeed.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnae/nicheresearchseedbuilder/NicheResearchSeed.java
@@ -1,0 +1,15 @@
+package com.marketinghub.nichocnae.nicheresearchseedbuilder;
+
+/** Descreve o nicho operacional identificado pela etapa dois antes da execução das buscas. */
+public record NicheResearchSeed(
+        Long researchCycleId,
+        String cnaeCode,
+        String cnaeDescription,
+        String nicheName,
+        String businessType,
+        String operationType,
+        String customerType,
+        String commercialObjects,
+        String initialAssumptions,
+        String confidenceLevel,
+        String createdBy) {}

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnae/nicheresearchseedbuilder/NicheResearchSeedBuilderBackendClient.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnae/nicheresearchseedbuilder/NicheResearchSeedBuilderBackendClient.java
@@ -1,0 +1,121 @@
+package com.marketinghub.nichocnae.nicheresearchseedbuilder;
+
+import com.marketinghub.oprmcoletormei.marketimport.config.OprmMarketImportCollectorProperties;
+import java.util.Arrays;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
+
+/** Chama exclusivamente endpoints OPRM nichocnae do backend para persistir a etapa dois do pipeline. */
+@Component
+public class NicheResearchSeedBuilderBackendClient {
+    private static final Logger log = LoggerFactory.getLogger(NicheResearchSeedBuilderBackendClient.class);
+    private static final String PENDING_PATH = "/api/internal/oprm/nichocnae/niche-research-seed-builder/stage-executions/pending";
+    private static final String DETAIL_PATH_PREFIX = "/api/oprm/nichocnae/niche-research-seed-builder/stage-executions/";
+    private static final String COMPLETE_PATH_PREFIX = "/api/internal/oprm/nichocnae/niche-research-seed-builder/stage-executions/";
+    private static final String COMPLETE_PATH_SUFFIX = "/complete";
+    private static final String FAIL_PATH_SUFFIX = "/fail";
+
+    private final OprmMarketImportCollectorProperties collectorProperties;
+    private final RestClient restClient;
+
+    /** Inicializa o cliente com a URL base do backend e o RestClient compartilhado do coletor. */
+    public NicheResearchSeedBuilderBackendClient(
+            OprmMarketImportCollectorProperties collectorProperties,
+            RestClient restClient) {
+        this.collectorProperties = collectorProperties;
+        this.restClient = restClient;
+    }
+
+    /** Lista ciclos em execução que ainda precisam de seed e queries de pesquisa na etapa dois. */
+    public List<NicheResearchSeedBuilderPending> listPendingSeeds() {
+        String url = collectorProperties.backendBaseUrl() + PENDING_PATH;
+        try {
+            NicheResearchSeedBuilderPending[] response = restClient.get()
+                    .uri(url)
+                    .retrieve()
+                    .body(NicheResearchSeedBuilderPending[].class);
+            return response == null ? List.of() : Arrays.asList(response);
+        } catch (RestClientException ex) {
+            log.error("Erro ao listar pendências da etapa dois OPRM nichocnae (endpoint={})", url, ex);
+            throw ex;
+        }
+    }
+
+    /** Detalha o seed e as queries já persistidos para um ciclo de pesquisa de rotina. */
+    public NicheResearchSeedBuilderOutput detailStageExecution(Long researchCycleId) {
+        String url = collectorProperties.backendBaseUrl() + DETAIL_PATH_PREFIX + researchCycleId;
+        try {
+            NicheResearchSeedBuilderOutput response = restClient.get()
+                    .uri(url)
+                    .retrieve()
+                    .body(NicheResearchSeedBuilderOutput.class);
+            if (response == null) {
+                throw new IllegalStateException("Backend OPRM nichocnae retornou corpo vazio ao detalhar etapa dois.");
+            }
+            return response;
+        } catch (RestClientException | IllegalStateException ex) {
+            log.error(
+                    "Erro ao detalhar etapa dois OPRM nichocnae (endpoint={}, researchCycleId={})",
+                    url,
+                    researchCycleId,
+                    ex);
+            throw ex;
+        }
+    }
+
+    /** Envia ao backend a saída validada da IA para gravar oprm_niche_research_seed e oprm_research_query. */
+    public NicheResearchSeedBuilderOutput completeStageExecution(OpenAiSeedBuilderResult result) {
+        Long researchCycleId = result.output().researchCycleId();
+        String url = collectorProperties.backendBaseUrl() + COMPLETE_PATH_PREFIX + researchCycleId + COMPLETE_PATH_SUFFIX;
+        NicheResearchSeedBuilderCompletionRequest request = new NicheResearchSeedBuilderCompletionRequest(
+                result.output(),
+                result.model(),
+                result.rawModelResponse(),
+                result.inputTokens(),
+                result.outputTokens(),
+                result.openAiResponseId());
+        try {
+            NicheResearchSeedBuilderOutput response = restClient.post()
+                    .uri(url)
+                    .body(request)
+                    .retrieve()
+                    .body(NicheResearchSeedBuilderOutput.class);
+            if (response == null) {
+                throw new IllegalStateException("Backend OPRM nichocnae retornou corpo vazio ao concluir etapa dois.");
+            }
+            return response;
+        } catch (RestClientException | IllegalStateException ex) {
+            log.error(
+                    "Erro ao concluir etapa dois OPRM nichocnae no backend (endpoint={}, researchCycleId={}, queryCount={})",
+                    url,
+                    researchCycleId,
+                    result.output().queries() == null ? null : result.output().queries().size(),
+                    ex);
+            throw ex;
+        }
+    }
+
+    /** Notifica o backend que a etapa dois falhou para preservar rastreabilidade do ciclo. */
+    public void failStageExecution(Long researchCycleId, RuntimeException error) {
+        String url = collectorProperties.backendBaseUrl() + COMPLETE_PATH_PREFIX + researchCycleId + FAIL_PATH_SUFFIX;
+        NicheResearchSeedBuilderFailureRequest request = new NicheResearchSeedBuilderFailureRequest(
+                researchCycleId,
+                "oprmNicheResearchSeedBuilder",
+                error.getMessage(),
+                error.toString());
+        try {
+            restClient.post().uri(url).body(request).retrieve().toBodilessEntity();
+        } catch (RestClientException ex) {
+            log.error(
+                    "Erro ao notificar falha da etapa dois OPRM nichocnae no backend (endpoint={}, researchCycleId={})",
+                    url,
+                    researchCycleId,
+                    ex);
+            throw ex;
+        }
+    }
+}

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnae/nicheresearchseedbuilder/NicheResearchSeedBuilderCompletionRequest.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnae/nicheresearchseedbuilder/NicheResearchSeedBuilderCompletionRequest.java
@@ -1,0 +1,10 @@
+package com.marketinghub.nichocnae.nicheresearchseedbuilder;
+
+/** Envia ao backend a saída validada da etapa dois junto com metadados mínimos de auditoria da IA. */
+public record NicheResearchSeedBuilderCompletionRequest(
+        NicheResearchSeedBuilderOutput output,
+        String model,
+        String rawModelResponse,
+        Integer inputTokens,
+        Integer outputTokens,
+        String openAiResponseId) {}

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnae/nicheresearchseedbuilder/NicheResearchSeedBuilderFailureRequest.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnae/nicheresearchseedbuilder/NicheResearchSeedBuilderFailureRequest.java
@@ -1,0 +1,8 @@
+package com.marketinghub.nichocnae.nicheresearchseedbuilder;
+
+/** Comunica ao backend uma falha da etapa dois com contexto suficiente para diagnóstico operacional. */
+public record NicheResearchSeedBuilderFailureRequest(
+        Long researchCycleId,
+        String stageCode,
+        String errorMessage,
+        String errorDetail) {}

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnae/nicheresearchseedbuilder/NicheResearchSeedBuilderOpenAiProperties.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnae/nicheresearchseedbuilder/NicheResearchSeedBuilderOpenAiProperties.java
@@ -1,0 +1,18 @@
+package com.marketinghub.nichocnae.nicheresearchseedbuilder;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/** Centraliza as configurações da OpenAI usadas exclusivamente pela etapa dois de seed do nicho CNAE. */
+@ConfigurationProperties(prefix = "oprm.nichocnae.seed-builder.openai")
+public record NicheResearchSeedBuilderOpenAiProperties(
+        String baseUrl,
+        String apiKey,
+        String model) {
+
+    /** Normaliza valores padrão seguros para a chamada síncrona da Responses API. */
+    public NicheResearchSeedBuilderOpenAiProperties {
+        baseUrl = baseUrl == null || baseUrl.isBlank() ? "https://api.openai.com/v1" : baseUrl;
+        apiKey = apiKey == null ? "" : apiKey;
+        model = model == null || model.isBlank() ? "gpt-4.1-mini" : model;
+    }
+}

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnae/nicheresearchseedbuilder/NicheResearchSeedBuilderOutput.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnae/nicheresearchseedbuilder/NicheResearchSeedBuilderOutput.java
@@ -1,0 +1,9 @@
+package com.marketinghub.nichocnae.nicheresearchseedbuilder;
+
+import java.util.List;
+
+/** Agrupa o seed operacional do nicho e as queries geradas pela IA na etapa dois. */
+public record NicheResearchSeedBuilderOutput(
+        Long researchCycleId,
+        NicheResearchSeed seed,
+        List<ResearchQuery> queries) {}

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnae/nicheresearchseedbuilder/NicheResearchSeedBuilderPending.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnae/nicheresearchseedbuilder/NicheResearchSeedBuilderPending.java
@@ -1,0 +1,17 @@
+package com.marketinghub.nichocnae.nicheresearchseedbuilder;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+
+/** Representa um ciclo em execução pronto para a etapa dois gerar seed e queries de pesquisa do nicho. */
+public record NicheResearchSeedBuilderPending(
+        Long researchCycleId,
+        Long sourceNicheId,
+        String cnaeCode,
+        String cnaeDescription,
+        String nicheName,
+        BigDecimal sourceScore,
+        String triggerSource,
+        String status,
+        Instant startedAt,
+        Instant createdAt) {}

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnae/nicheresearchseedbuilder/NicheResearchSeedBuilderProcessor.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnae/nicheresearchseedbuilder/NicheResearchSeedBuilderProcessor.java
@@ -1,0 +1,36 @@
+package com.marketinghub.nichocnae.nicheresearchseedbuilder;
+
+import com.marketinghub.nichocnae.pipeline.StageContext;
+import com.marketinghub.nichocnae.pipeline.StageProcessor;
+import com.marketinghub.nichocnae.pipeline.StageResult;
+import java.util.List;
+import java.util.Map;
+import org.springframework.stereotype.Component;
+
+/** Processa a etapa dois usando IA para gerar o seed do nicho e as queries de pesquisa auditáveis. */
+@Component
+public class NicheResearchSeedBuilderProcessor implements StageProcessor<NicheResearchSeedBuilderPending, NicheResearchSeedBuilderOutput> {
+    private final OpenAiNicheResearchSeedBuilderClient openAiClient;
+    private final NicheResearchSeedBuilderBackendClient backendClient;
+
+    /** Inicializa o processor com a integração de IA e a borda backend específica da etapa dois. */
+    public NicheResearchSeedBuilderProcessor(
+            OpenAiNicheResearchSeedBuilderClient openAiClient,
+            NicheResearchSeedBuilderBackendClient backendClient) {
+        this.openAiClient = openAiClient;
+        this.backendClient = backendClient;
+    }
+
+    /** Gera, valida e persiste no backend o seed e as queries da etapa dois do ciclo informado. */
+    @Override
+    public StageResult<NicheResearchSeedBuilderOutput> process(StageContext<NicheResearchSeedBuilderPending> context) {
+        NicheResearchSeedBuilderPending input = context.input();
+        OpenAiSeedBuilderResult generated = openAiClient.generate(input);
+        NicheResearchSeedBuilderOutput output = backendClient.completeStageExecution(generated);
+        Map<String, Object> metrics = Map.of(
+                "researchCycleId", output.researchCycleId(),
+                "queryCount", output.queries() == null ? 0 : output.queries().size(),
+                "model", generated.model());
+        return new StageResult<>(output, List.of(), metrics);
+    }
+}

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnae/nicheresearchseedbuilder/NicheResearchSeedBuilderPromptBuilder.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnae/nicheresearchseedbuilder/NicheResearchSeedBuilderPromptBuilder.java
@@ -1,0 +1,41 @@
+package com.marketinghub.nichocnae.nicheresearchseedbuilder;
+
+import java.util.StringJoiner;
+import org.springframework.stereotype.Component;
+
+/** Monta o prompt da etapa dois mantendo a fronteira OPRM de conhecer o nicho sem criar oferta comercial. */
+@Component
+public class NicheResearchSeedBuilderPromptBuilder {
+
+    /** Cria instruções objetivas para a IA transformar CNAE em seed operacional e queries não genéricas. */
+    public String buildPrompt(NicheResearchSeedBuilderPending input) {
+        StringJoiner prompt = new StringJoiner("\n");
+        prompt.add("Você é o construtor da etapa 2 do pipeline OPRM nichocnae.");
+        prompt.add("Objetivo: conhecer como o nicho funciona na rotina, sem criar oferta, produto, campanha ou landing page.");
+        prompt.add("Use o eixo Dor → Resultado → Mecanismo → Prova → Oferta apenas como referência distante; nesta etapa gere apenas seed e frases de pesquisa.");
+        prompt.add("");
+        prompt.add("Dados do ciclo:");
+        prompt.add("researchCycleId: " + input.researchCycleId());
+        prompt.add("cnaeCode: " + safe(input.cnaeCode()));
+        prompt.add("cnaeDescription: " + safe(input.cnaeDescription()));
+        prompt.add("nicheName: " + safe(input.nicheName()));
+        prompt.add("sourceScore: " + input.sourceScore());
+        prompt.add("");
+        prompt.add("Regras obrigatórias:");
+        prompt.add("1. Responda somente JSON válido aderente ao schema solicitado.");
+        prompt.add("2. Gere um seed que responda quem é o nicho pesquisado.");
+        prompt.add("3. Gere de 12 a 15 queries, cada uma em linha lógica própria no array queries.");
+        prompt.add("4. Cada query deve conter o nome do nicho ou algum objeto comercial específico do nicho.");
+        prompt.add("5. Não gere query genérica como 'como vender mais'.");
+        prompt.add("6. Cubra rotina, perguntas do profissional, perguntas do cliente final, dores comerciais e produtos/serviços.");
+        prompt.add("7. Todas as queries devem sair com status PENDING e createdBy AI.");
+        prompt.add("8. Use queryGoal somente entre ROUTINE_DISCOVERY, NICHE_OWNER_QUESTION_DISCOVERY, FINAL_CUSTOMER_QUESTION_DISCOVERY, SALES_PAIN_DISCOVERY, PRODUCT_SERVICE_DISCOVERY e OFFER_PATTERN_DISCOVERY.");
+        prompt.add("9. Não inclua metadado técnico, comentário operacional, debugInfo ou JSON serializado dentro de texto funcional.");
+        return prompt.toString();
+    }
+
+    /** Devolve texto seguro para evitar valores nulos no prompt enviado à IA. */
+    private String safe(String value) {
+        return value == null || value.isBlank() ? "não informado" : value;
+    }
+}

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnae/nicheresearchseedbuilder/NicheResearchSeedBuilderSchema.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnae/nicheresearchseedbuilder/NicheResearchSeedBuilderSchema.java
@@ -1,0 +1,100 @@
+package com.marketinghub.nichocnae.nicheresearchseedbuilder;
+
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.springframework.stereotype.Component;
+
+/** Fornece o schema JSON estrito usado pela Responses API para a saída da etapa dois. */
+@Component
+public class NicheResearchSeedBuilderSchema {
+
+    /** Monta o schema aceito pela OpenAI para seed do nicho e queries de pesquisa auditáveis. */
+    public Map<String, Object> buildSchema() {
+        Map<String, Object> schema = object("researchCycleId", "seed", "queries");
+        schema.put("properties", Map.of(
+                "researchCycleId", integer(),
+                "seed", seedSchema(),
+                "queries", array(querySchema())));
+        return schema;
+    }
+
+    /** Monta o schema do artefato que identifica o nicho operacional. */
+    private Map<String, Object> seedSchema() {
+        Map<String, Object> schema = object(
+                "researchCycleId",
+                "cnaeCode",
+                "cnaeDescription",
+                "nicheName",
+                "businessType",
+                "operationType",
+                "customerType",
+                "commercialObjects",
+                "initialAssumptions",
+                "confidenceLevel",
+                "createdBy");
+        schema.put("properties", Map.ofEntries(
+                Map.entry("researchCycleId", integer()),
+                Map.entry("cnaeCode", string()),
+                Map.entry("cnaeDescription", string()),
+                Map.entry("nicheName", string()),
+                Map.entry("businessType", string()),
+                Map.entry("operationType", string()),
+                Map.entry("customerType", string()),
+                Map.entry("commercialObjects", string()),
+                Map.entry("initialAssumptions", string()),
+                Map.entry("confidenceLevel", enumString("INFERRED_FROM_CNAE", "LOW_CONFIDENCE", "NEEDS_RESEARCH")),
+                Map.entry("createdBy", enumString("AI"))));
+        return schema;
+    }
+
+    /** Monta o schema da frase de pesquisa que será executada nas próximas etapas. */
+    private Map<String, Object> querySchema() {
+        Map<String, Object> schema = object(
+                "researchCycleId", "queryText", "queryGoal", "sourceGroup", "priority", "status", "createdBy");
+        schema.put("properties", Map.of(
+                "researchCycleId", integer(),
+                "queryText", string(),
+                "queryGoal", enumString(
+                        "ROUTINE_DISCOVERY",
+                        "NICHE_OWNER_QUESTION_DISCOVERY",
+                        "FINAL_CUSTOMER_QUESTION_DISCOVERY",
+                        "SALES_PAIN_DISCOVERY",
+                        "PRODUCT_SERVICE_DISCOVERY",
+                        "OFFER_PATTERN_DISCOVERY"),
+                "sourceGroup", string(),
+                "priority", integer(),
+                "status", enumString("PENDING"),
+                "createdBy", enumString("AI")));
+        return schema;
+    }
+
+    /** Cria um objeto JSON Schema com propriedades adicionais bloqueadas. */
+    private Map<String, Object> object(String... required) {
+        Map<String, Object> schema = new LinkedHashMap<>();
+        schema.put("type", "object");
+        schema.put("additionalProperties", false);
+        schema.put("required", List.of(required));
+        return schema;
+    }
+
+    /** Cria um campo textual simples para o schema da etapa dois. */
+    private Map<String, Object> string() {
+        return Map.of("type", "string");
+    }
+
+    /** Cria um campo inteiro simples para o schema da etapa dois. */
+    private Map<String, Object> integer() {
+        return Map.of("type", "integer");
+    }
+
+    /** Cria um campo textual restrito aos valores permitidos pela regra da etapa dois. */
+    private Map<String, Object> enumString(String... values) {
+        return Map.of("type", "string", "enum", List.of(values));
+    }
+
+    /** Cria um array tipado para a coleção de queries geradas pela IA. */
+    private Map<String, Object> array(Map<String, Object> itemSchema) {
+        return Map.of("type", "array", "minItems", 12, "maxItems", 15, "items", itemSchema);
+    }
+}

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnae/nicheresearchseedbuilder/NicheResearchSeedBuilderService.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnae/nicheresearchseedbuilder/NicheResearchSeedBuilderService.java
@@ -1,0 +1,72 @@
+package com.marketinghub.nichocnae.nicheresearchseedbuilder;
+
+import com.marketinghub.nichocnae.pipeline.ArtifactStore;
+import com.marketinghub.nichocnae.pipeline.PipelineWorker;
+import com.marketinghub.nichocnae.pipeline.StageExecution;
+import com.marketinghub.nichocnae.pipeline.StageResult;
+import java.util.List;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+/** Orquestra manualmente a etapa dois do submódulo nichocnae para gerar seed e queries por IA. */
+@Service
+public class NicheResearchSeedBuilderService {
+    private static final Logger log = LoggerFactory.getLogger(NicheResearchSeedBuilderService.class);
+
+    private final NicheResearchSeedBuilderBackendClient backendClient;
+    private final NicheResearchSeedBuilderProcessor processor;
+    private final ArtifactStore artifactStore;
+
+    /** Inicializa o serviço com a borda backend, processor concreto e armazenamento genérico de artefatos. */
+    public NicheResearchSeedBuilderService(
+            NicheResearchSeedBuilderBackendClient backendClient,
+            NicheResearchSeedBuilderProcessor processor,
+            ArtifactStore artifactStore) {
+        this.backendClient = backendClient;
+        this.processor = processor;
+        this.artifactStore = artifactStore;
+    }
+
+    /** Lista ciclos em execução que ainda não possuem seed de pesquisa gerado pela etapa dois. */
+    public List<NicheResearchSeedBuilderPending> listPendingSeeds() {
+        return backendClient.listPendingSeeds();
+    }
+
+    /** Detalha o seed e as queries já gravados no backend para o ciclo informado. */
+    public NicheResearchSeedBuilderOutput detailStageExecution(Long researchCycleId) {
+        return backendClient.detailStageExecution(researchCycleId);
+    }
+
+    /** Processa sob demanda os ciclos pendentes pela etapa dois e retorna os seeds gerados. */
+    public List<NicheResearchSeedBuilderOutput> processPending(String requestedBy) {
+        List<NicheResearchSeedBuilderPending> pendingSeeds = backendClient.listPendingSeeds();
+        return pendingSeeds.stream()
+                .map(pending -> processOne(pending, requestedBy))
+                .toList();
+    }
+
+    /** Executa o worker genérico para uma unidade da etapa dois e registra falha contextual no backend. */
+    private NicheResearchSeedBuilderOutput processOne(NicheResearchSeedBuilderPending pending, String requestedBy) {
+        StageExecution<NicheResearchSeedBuilderPending> execution = new StageExecution<>(
+                "oprm-niche-research-seed-builder-" + pending.researchCycleId(),
+                pending,
+                Map.of("stage", "oprmNicheResearchSeedBuilder", "requestedBy", requestedBy));
+        try {
+            PipelineWorker<NicheResearchSeedBuilderPending, NicheResearchSeedBuilderOutput> worker = new PipelineWorker<>(
+                    processor, artifactStore);
+            StageResult<NicheResearchSeedBuilderOutput> result = worker.processResult(execution);
+            return result.output();
+        } catch (RuntimeException ex) {
+            log.error(
+                    "Erro ao executar sob demanda a etapa dois OPRM nichocnae (researchCycleId={}, sourceNicheId={}, requestedBy={})",
+                    pending.researchCycleId(),
+                    pending.sourceNicheId(),
+                    requestedBy,
+                    ex);
+            backendClient.failStageExecution(pending.researchCycleId(), ex);
+            throw ex;
+        }
+    }
+}

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnae/nicheresearchseedbuilder/NicheResearchSeedBuilderValidator.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnae/nicheresearchseedbuilder/NicheResearchSeedBuilderValidator.java
@@ -1,0 +1,138 @@
+package com.marketinghub.nichocnae.nicheresearchseedbuilder;
+
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import org.springframework.stereotype.Component;
+
+/** Valida regras determinísticas da etapa dois antes de enviar o seed e as queries ao backend. */
+@Component
+public class NicheResearchSeedBuilderValidator {
+    private static final int MIN_QUERIES = 12;
+    private static final int MAX_QUERIES = 15;
+    private static final Set<String> ALLOWED_GOALS = Set.of(
+            "ROUTINE_DISCOVERY",
+            "NICHE_OWNER_QUESTION_DISCOVERY",
+            "FINAL_CUSTOMER_QUESTION_DISCOVERY",
+            "SALES_PAIN_DISCOVERY",
+            "PRODUCT_SERVICE_DISCOVERY",
+            "OFFER_PATTERN_DISCOVERY");
+
+    /** Garante que o modelo produziu seed completo e queries específicas, pendentes e sem duplicidade. */
+    public void validate(NicheResearchSeedBuilderPending input, NicheResearchSeedBuilderOutput output) {
+        if (output == null) {
+            throw new IllegalArgumentException("Saída da etapa dois não pode ser nula.");
+        }
+        if (!input.researchCycleId().equals(output.researchCycleId())) {
+            throw new IllegalArgumentException("researchCycleId da saída não corresponde ao ciclo processado.");
+        }
+        validateSeed(input, output.seed());
+        validateQueries(output.seed(), output.queries());
+    }
+
+    /** Valida os campos essenciais do seed que identificam o nicho operacional pesquisado. */
+    private void validateSeed(NicheResearchSeedBuilderPending input, NicheResearchSeed seed) {
+        if (seed == null) {
+            throw new IllegalArgumentException("Seed da etapa dois não pode ser nulo.");
+        }
+        if (!input.researchCycleId().equals(seed.researchCycleId())) {
+            throw new IllegalArgumentException("researchCycleId do seed não corresponde ao ciclo processado.");
+        }
+        requireText(seed.nicheName(), "nicheName");
+        requireText(seed.businessType(), "businessType");
+        requireText(seed.operationType(), "operationType");
+        requireText(seed.customerType(), "customerType");
+        requireText(seed.commercialObjects(), "commercialObjects");
+        requireText(seed.initialAssumptions(), "initialAssumptions");
+        if (!"AI".equals(seed.createdBy())) {
+            throw new IllegalArgumentException("createdBy do seed deve ser AI.");
+        }
+    }
+
+    /** Valida quantidade, status, objetivo e especificidade básica das queries de pesquisa. */
+    private void validateQueries(NicheResearchSeed seed, List<ResearchQuery> queries) {
+        if (queries == null || queries.size() < MIN_QUERIES || queries.size() > MAX_QUERIES) {
+            throw new IllegalArgumentException("A etapa dois deve gerar entre 12 e 15 queries.");
+        }
+
+        Set<String> uniqueTexts = new HashSet<>();
+        Set<String> anchors = buildAnchors(seed);
+        for (ResearchQuery query : queries) {
+            validateQuery(seed, query, uniqueTexts, anchors);
+        }
+    }
+
+    /** Valida uma query individual antes de ela ser persistida como linha própria no backend. */
+    private void validateQuery(
+            NicheResearchSeed seed,
+            ResearchQuery query,
+            Set<String> uniqueTexts,
+            Set<String> anchors) {
+        if (query == null) {
+            throw new IllegalArgumentException("Query da etapa dois não pode ser nula.");
+        }
+        if (!seed.researchCycleId().equals(query.researchCycleId())) {
+            throw new IllegalArgumentException("researchCycleId da query não corresponde ao seed.");
+        }
+        requireText(query.queryText(), "queryText");
+        String normalized = normalize(query.queryText());
+        if (!uniqueTexts.add(normalized)) {
+            throw new IllegalArgumentException("Query duplicada na etapa dois: " + query.queryText());
+        }
+        if ("como vender mais".equals(normalized)) {
+            throw new IllegalArgumentException("Query genérica proibida: " + query.queryText());
+        }
+        if (anchors.stream().noneMatch(normalized::contains)) {
+            throw new IllegalArgumentException("Query sem nicho ou objeto comercial específico: " + query.queryText());
+        }
+        if (!ALLOWED_GOALS.contains(query.queryGoal())) {
+            throw new IllegalArgumentException("queryGoal inválido na etapa dois: " + query.queryGoal());
+        }
+        if (!"PENDING".equals(query.status())) {
+            throw new IllegalArgumentException("Query da etapa dois deve iniciar com status PENDING.");
+        }
+        if (!"AI".equals(query.createdBy())) {
+            throw new IllegalArgumentException("Query da etapa dois deve iniciar com createdBy AI.");
+        }
+    }
+
+    /** Extrai termos âncora do nicho e objetos comerciais para bloquear queries genéricas. */
+    private Set<String> buildAnchors(NicheResearchSeed seed) {
+        Set<String> anchors = new HashSet<>();
+        addWords(anchors, seed.nicheName());
+        addWords(anchors, seed.commercialObjects());
+        return anchors;
+    }
+
+    /** Adiciona palavras relevantes como âncoras de especificidade das queries. */
+    private void addWords(Set<String> anchors, String value) {
+        if (value == null) {
+            return;
+        }
+        String normalized = normalize(value);
+        for (String rawExpression : normalized.split(",")) {
+            String expression = rawExpression.trim();
+            if (!expression.isBlank()) {
+                anchors.add(expression);
+            }
+        }
+        for (String rawWord : normalized.split("[^a-z0-9áàâãéêíóôõúç]+")) {
+            if (rawWord.length() >= 5) {
+                anchors.add(rawWord);
+            }
+        }
+    }
+
+    /** Exige texto funcional preenchido para campos obrigatórios da etapa dois. */
+    private void requireText(String value, String fieldName) {
+        if (value == null || value.isBlank()) {
+            throw new IllegalArgumentException("Campo obrigatório vazio na etapa dois: " + fieldName);
+        }
+    }
+
+    /** Normaliza texto para comparação simples de duplicidade e especificidade. */
+    private String normalize(String value) {
+        return value == null ? "" : value.toLowerCase(Locale.ROOT).trim().replaceAll("\\s+", " ");
+    }
+}

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnae/nicheresearchseedbuilder/OpenAiNicheResearchSeedBuilderClient.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnae/nicheresearchseedbuilder/OpenAiNicheResearchSeedBuilderClient.java
@@ -1,0 +1,171 @@
+package com.marketinghub.nichocnae.nicheresearchseedbuilder;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.net.URI;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
+
+/** Executa a chamada síncrona à OpenAI Responses API para gerar o seed e as queries da etapa dois. */
+@Component
+public class OpenAiNicheResearchSeedBuilderClient {
+    private static final Logger log = LoggerFactory.getLogger(OpenAiNicheResearchSeedBuilderClient.class);
+    private static final String RESPONSES_PATH = "/responses";
+    private static final String SCHEMA_NAME = "oprm_niche_research_seed_builder";
+
+    private final RestClient restClient;
+    private final ObjectMapper objectMapper;
+    private final NicheResearchSeedBuilderOpenAiProperties properties;
+    private final NicheResearchSeedBuilderPromptBuilder promptBuilder;
+    private final NicheResearchSeedBuilderSchema schema;
+    private final NicheResearchSeedBuilderValidator validator;
+
+    /** Inicializa o client da OpenAI com dependências de prompt, schema e validação da etapa dois. */
+    public OpenAiNicheResearchSeedBuilderClient(
+            RestClient restClient,
+            ObjectMapper objectMapper,
+            NicheResearchSeedBuilderOpenAiProperties properties,
+            NicheResearchSeedBuilderPromptBuilder promptBuilder,
+            NicheResearchSeedBuilderSchema schema,
+            NicheResearchSeedBuilderValidator validator) {
+        this.restClient = restClient;
+        this.objectMapper = objectMapper;
+        this.properties = properties;
+        this.promptBuilder = promptBuilder;
+        this.schema = schema;
+        this.validator = validator;
+    }
+
+    /** Gera seed e queries por IA, extrai o JSON estruturado e valida regras de contrato antes do retorno. */
+    public OpenAiSeedBuilderResult generate(NicheResearchSeedBuilderPending input) {
+        if (properties.apiKey().isBlank()) {
+            throw new IllegalStateException("OPRM nichocnae seed builder OpenAI API key não configurada.");
+        }
+
+        String prompt = promptBuilder.buildPrompt(input);
+        Map<String, Object> requestBody = buildRequestBody(prompt);
+        String url = properties.baseUrl() + RESPONSES_PATH;
+        try {
+            Map<String, Object> raw = responseBody(url, requestBody);
+            if (raw == null) {
+                throw new IllegalStateException("OpenAI retornou corpo vazio para a etapa dois OPRM nichocnae.");
+            }
+            String rawModelResponse = extractModelResponse(raw);
+            NicheResearchSeedBuilderOutput output = objectMapper.readValue(rawModelResponse, NicheResearchSeedBuilderOutput.class);
+            validator.validate(input, output);
+            return new OpenAiSeedBuilderResult(
+                    output,
+                    rawModelResponse,
+                    extractInteger(raw, "usage", "input_tokens"),
+                    extractInteger(raw, "usage", "output_tokens"),
+                    stringValue(raw.get("id")),
+                    properties.model());
+        } catch (RestClientException | JsonProcessingException | IllegalStateException | IllegalArgumentException ex) {
+            log.error(
+                    "Erro ao gerar seed da etapa dois OPRM nichocnae com OpenAI (endpoint={}, researchCycleId={}, cnaeCode={})",
+                    url,
+                    input.researchCycleId(),
+                    input.cnaeCode(),
+                    ex);
+            throw new IllegalStateException("Falha ao gerar seed da etapa dois OPRM nichocnae.", ex);
+        }
+    }
+
+    /** Executa a requisição HTTP e isola o cast seguro do corpo retornado pelo RestClient. */
+    @SuppressWarnings("unchecked")
+    private Map<String, Object> responseBody(String url, Map<String, Object> requestBody) {
+        Map<?, ?> response = restClient.post()
+                .uri(URI.create(url))
+                .header("Authorization", "Bearer " + properties.apiKey())
+                .header("Content-Type", "application/json")
+                .body(requestBody)
+                .retrieve()
+                .body(Map.class);
+        return response == null ? null : (Map<String, Object>) response;
+    }
+
+    /** Monta o corpo da Responses API com schema JSON estrito para evitar saída ambígua ou fora do contrato. */
+    private Map<String, Object> buildRequestBody(String prompt) {
+        Map<String, Object> format = new LinkedHashMap<>();
+        format.put("type", "json_schema");
+        format.put("name", SCHEMA_NAME);
+        format.put("schema", schema.buildSchema());
+        format.put("strict", true);
+
+        Map<String, Object> text = new LinkedHashMap<>();
+        text.put("format", format);
+
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("model", properties.model());
+        body.put("input", prompt);
+        body.put("text", text);
+        return body;
+    }
+
+    /** Extrai o texto principal da resposta da OpenAI, aceitando output_text ou conteúdo textual estruturado. */
+    private String extractModelResponse(Map<String, Object> raw) {
+        Object outputText = raw.get("output_text");
+        if (outputText != null && !outputText.toString().isBlank()) {
+            return outputText.toString();
+        }
+
+        Object output = raw.get("output");
+        if (output instanceof List<?> list) {
+            StringBuilder builder = new StringBuilder();
+            for (Object item : list) {
+                appendOutputItemText(builder, item);
+            }
+            if (!builder.isEmpty()) {
+                return builder.toString();
+            }
+        }
+
+        throw new IllegalStateException("Não foi possível extrair texto da resposta OpenAI da etapa dois.");
+    }
+
+    /** Acrescenta textos encontrados em um item de output da Responses API ao buffer de resposta. */
+    private void appendOutputItemText(StringBuilder builder, Object item) {
+        if (!(item instanceof Map<?, ?> itemMap)) {
+            return;
+        }
+        Object content = itemMap.get("content");
+        if (!(content instanceof List<?> contentList)) {
+            return;
+        }
+        for (Object contentItem : contentList) {
+            if (contentItem instanceof Map<?, ?> contentMap) {
+                Object text = contentMap.get("text");
+                if (text != null) {
+                    builder.append(text);
+                }
+            }
+        }
+    }
+
+    /** Extrai contadores inteiros de uso da resposta para auditoria de custo e volume. */
+    private Integer extractInteger(Map<String, Object> raw, String parentKey, String childKey) {
+        Object parent = raw.get(parentKey);
+        if (!(parent instanceof Map<?, ?> map)) {
+            return null;
+        }
+        Object value = map.get(childKey);
+        if (value instanceof Number number) {
+            return number.intValue();
+        }
+        if (value instanceof String text && !text.isBlank()) {
+            return Integer.parseInt(text);
+        }
+        return null;
+    }
+
+    /** Converte qualquer valor opcional de metadado da OpenAI para texto simples. */
+    private String stringValue(Object value) {
+        return value == null ? null : value.toString();
+    }
+}

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnae/nicheresearchseedbuilder/OpenAiSeedBuilderResult.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnae/nicheresearchseedbuilder/OpenAiSeedBuilderResult.java
@@ -1,0 +1,10 @@
+package com.marketinghub.nichocnae.nicheresearchseedbuilder;
+
+/** Preserva a resposta da OpenAI já convertida para saída de domínio e seus metadados de consumo. */
+public record OpenAiSeedBuilderResult(
+        NicheResearchSeedBuilderOutput output,
+        String rawModelResponse,
+        Integer inputTokens,
+        Integer outputTokens,
+        String openAiResponseId,
+        String model) {}

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnae/nicheresearchseedbuilder/ResearchQuery.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnae/nicheresearchseedbuilder/ResearchQuery.java
@@ -1,0 +1,11 @@
+package com.marketinghub.nichocnae.nicheresearchseedbuilder;
+
+/** Representa uma frase objetiva que será pesquisada individualmente nas próximas etapas do pipeline. */
+public record ResearchQuery(
+        Long researchCycleId,
+        String queryText,
+        String queryGoal,
+        String sourceGroup,
+        Integer priority,
+        String status,
+        String createdBy) {}

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnae/nicheresearchseedbuilder/package-info.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnae/nicheresearchseedbuilder/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Contém a etapa dois que usa IA para gerar o seed do nicho CNAE e as queries iniciais de pesquisa.
+ */
+package com.marketinghub.nichocnae.nicheresearchseedbuilder;

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnae/nicheresearchseedbuilder/web/NicheResearchSeedBuilderController.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnae/nicheresearchseedbuilder/web/NicheResearchSeedBuilderController.java
@@ -1,0 +1,44 @@
+package com.marketinghub.nichocnae.nicheresearchseedbuilder.web;
+
+import com.marketinghub.nichocnae.nicheresearchseedbuilder.NicheResearchSeedBuilderOutput;
+import com.marketinghub.nichocnae.nicheresearchseedbuilder.NicheResearchSeedBuilderPending;
+import com.marketinghub.nichocnae.nicheresearchseedbuilder.NicheResearchSeedBuilderService;
+import java.util.List;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestHeader;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/** Expõe acionamento manual da etapa dois nichocnae no coletor OPRM, sem agendamento automático. */
+@RestController
+@RequestMapping("/api/oprm-mei/nichocnae/niche-research-seed-builder")
+public class NicheResearchSeedBuilderController {
+    private final NicheResearchSeedBuilderService seedBuilderService;
+
+    /** Inicializa o controller com o serviço de execução sob demanda da etapa dois. */
+    public NicheResearchSeedBuilderController(NicheResearchSeedBuilderService seedBuilderService) {
+        this.seedBuilderService = seedBuilderService;
+    }
+
+    /** Lista ciclos pendentes de geração de seed e queries da etapa dois. */
+    @GetMapping("/pending")
+    public ResponseEntity<List<NicheResearchSeedBuilderPending>> pending() {
+        return ResponseEntity.ok(seedBuilderService.listPendingSeeds());
+    }
+
+    /** Detalha o seed e as queries gerados para o ciclo informado. */
+    @GetMapping("/{researchCycleId}")
+    public ResponseEntity<NicheResearchSeedBuilderOutput> detail(@PathVariable Long researchCycleId) {
+        return ResponseEntity.ok(seedBuilderService.detailStageExecution(researchCycleId));
+    }
+
+    /** Executa manualmente a etapa dois para todos os ciclos pendentes retornados pelo backend. */
+    @PostMapping("/process-pending")
+    public ResponseEntity<List<NicheResearchSeedBuilderOutput>> processPending(
+            @RequestHeader(value = "X-Requested-By", required = false, defaultValue = "MANUAL_API") String requestedBy) {
+        return ResponseEntity.accepted().body(seedBuilderService.processPending(requestedBy));
+    }
+}

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnae/nicheresearchseedbuilder/web/package-info.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnae/nicheresearchseedbuilder/web/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Expõe endpoints manuais do coletor para a etapa dois do pipeline OPRM nichocnae.
+ */
+package com.marketinghub.nichocnae.nicheresearchseedbuilder.web;

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/oprmcoletormei/marketimport/config/OprmMarketImportConfig.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/oprmcoletormei/marketimport/config/OprmMarketImportConfig.java
@@ -1,5 +1,6 @@
 package com.marketinghub.oprmcoletormei.marketimport.config;
 
+import com.marketinghub.nichocnae.nicheresearchseedbuilder.NicheResearchSeedBuilderOpenAiProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -8,7 +9,8 @@ import org.springframework.web.client.RestClient;
 @Configuration
 @EnableConfigurationProperties({
         OprmMarketImportScheduleProperties.class,
-        OprmMarketImportCollectorProperties.class
+        OprmMarketImportCollectorProperties.class,
+        NicheResearchSeedBuilderOpenAiProperties.class
 })
 public class OprmMarketImportConfig {
 

--- a/oprm-coletor-mei/src/main/resources/application.yml
+++ b/oprm-coletor-mei/src/main/resources/application.yml
@@ -16,6 +16,12 @@ management:
         enabled: true
 
 oprm:
+  nichocnae:
+    seed-builder:
+      openai:
+        base-url: ${OPRM_NICHO_CNAE_SEED_BUILDER_OPENAI_BASE_URL:https://api.openai.com/v1}
+        api-key: ${OPRM_NICHO_CNAE_SEED_BUILDER_OPENAI_API_KEY:${OPENAI_API_KEY:}}
+        model: ${OPRM_NICHO_CNAE_SEED_BUILDER_OPENAI_MODEL:gpt-4.1-mini}
   market-import:
     collector:
       backend-base-url: ${OPRM_COLLECTOR_BACKEND_BASE_URL:http://191.252.181.168:8000}

--- a/oprm-coletor-mei/src/test/java/com/marketinghub/nichocnae/nicheresearchseedbuilder/NicheResearchSeedBuilderProcessorTest.java
+++ b/oprm-coletor-mei/src/test/java/com/marketinghub/nichocnae/nicheresearchseedbuilder/NicheResearchSeedBuilderProcessorTest.java
@@ -1,0 +1,76 @@
+package com.marketinghub.nichocnae.nicheresearchseedbuilder;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.marketinghub.nichocnae.pipeline.StageContext;
+import com.marketinghub.nichocnae.pipeline.StageExecution;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/** Responsabilidade: validar a orquestração da etapa dois entre OpenAI, backend e contrato StageProcessor. */
+class NicheResearchSeedBuilderProcessorTest {
+
+    /** Deve persistir no backend a saída gerada pela IA e devolver métricas estruturadas da etapa dois. */
+    @Test
+    void shouldGenerateAndCompleteSeedBuilderOutput() {
+        OpenAiNicheResearchSeedBuilderClient openAiClient = mock(OpenAiNicheResearchSeedBuilderClient.class);
+        NicheResearchSeedBuilderBackendClient backendClient = mock(NicheResearchSeedBuilderBackendClient.class);
+        NicheResearchSeedBuilderProcessor processor = new NicheResearchSeedBuilderProcessor(openAiClient, backendClient);
+        NicheResearchSeedBuilderPending pending = pending();
+        NicheResearchSeedBuilderOutput output = output();
+        OpenAiSeedBuilderResult generated = new OpenAiSeedBuilderResult(output, "{}", 10, 20, "resp_123", "gpt-test");
+        when(openAiClient.generate(pending)).thenReturn(generated);
+        when(backendClient.completeStageExecution(generated)).thenReturn(output);
+
+        var result = processor.process(new StageContext<>(
+                new StageExecution<>("job-1", pending, Map.of()),
+                pending,
+                (artifact, content) -> artifact,
+                Map.of()));
+
+        assertThat(result.output()).isEqualTo(output);
+        assertThat(result.metrics()).containsEntry("researchCycleId", 1001L).containsEntry("queryCount", 1);
+        verify(backendClient).completeStageExecution(generated);
+    }
+
+    /** Cria uma pendência mínima para a etapa dois. */
+    private NicheResearchSeedBuilderPending pending() {
+        return new NicheResearchSeedBuilderPending(
+                1001L,
+                55L,
+                "9602501",
+                "Cabeleireiros, manicure e pedicure",
+                "Cabeleireiros, manicure e pedicure",
+                BigDecimal.valueOf(92),
+                "AUTO_SCORE_QUEUE",
+                "RUNNING",
+                Instant.now(),
+                Instant.now());
+    }
+
+    /** Cria uma saída mínima suficiente para validar o processor. */
+    private NicheResearchSeedBuilderOutput output() {
+        NicheResearchSeed seed = new NicheResearchSeed(
+                1001L,
+                "9602501",
+                "Cabeleireiros, manicure e pedicure",
+                "Cabeleireiros, manicures e pedicures",
+                "serviço local de beleza",
+                "atendimento com agenda",
+                "consumidor final",
+                "manicure",
+                "depende de recorrência",
+                "INFERRED_FROM_CNAE",
+                "AI");
+        return new NicheResearchSeedBuilderOutput(
+                1001L,
+                seed,
+                List.of(new ResearchQuery(1001L, "manicure rotina", "ROUTINE_DISCOVERY", "GENERAL_WEB", 1, "PENDING", "AI")));
+    }
+}

--- a/oprm-coletor-mei/src/test/java/com/marketinghub/nichocnae/nicheresearchseedbuilder/NicheResearchSeedBuilderValidatorTest.java
+++ b/oprm-coletor-mei/src/test/java/com/marketinghub/nichocnae/nicheresearchseedbuilder/NicheResearchSeedBuilderValidatorTest.java
@@ -1,0 +1,115 @@
+package com.marketinghub.nichocnae.nicheresearchseedbuilder;
+
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+/** Responsabilidade: validar as regras determinísticas da etapa dois antes da persistência no backend. */
+class NicheResearchSeedBuilderValidatorTest {
+    private final NicheResearchSeedBuilderValidator validator = new NicheResearchSeedBuilderValidator();
+
+    /** Deve aceitar seed completo com doze queries específicas vinculadas a objetos comerciais do nicho. */
+    @Test
+    void shouldAcceptSpecificPendingQueries() {
+        NicheResearchSeedBuilderPending pending = pending();
+        NicheResearchSeedBuilderOutput output = outputWithQueries(List.of(
+                "manicure rotina de atendimento",
+                "manicure responsabilidades agenda",
+                "cliente unha em gel dúvidas",
+                "unha em gel quanto tempo dura",
+                "pacote manicure mensal como funciona",
+                "agenda manicure horários vazios",
+                "salão beleza divulgar whatsapp",
+                "hidratação cabelo cliente pergunta",
+                "cabeleireiro rotina salão pequeno",
+                "pedicure biossegurança atendimento",
+                "manicure preço unha decorada",
+                "salão beleza pacote fidelidade"));
+
+        assertThatNoException().isThrownBy(() -> validator.validate(pending, output));
+    }
+
+    /** Deve rejeitar query genérica porque ela não ajuda a pesquisar a rotina concreta do nicho. */
+    @Test
+    void shouldRejectGenericQuery() {
+        NicheResearchSeedBuilderPending pending = pending();
+        List<String> texts = new ArrayList<>(List.of(
+                "manicure rotina de atendimento",
+                "manicure responsabilidades agenda",
+                "cliente unha em gel dúvidas",
+                "unha em gel quanto tempo dura",
+                "pacote manicure mensal como funciona",
+                "agenda manicure horários vazios",
+                "salão beleza divulgar whatsapp",
+                "hidratação cabelo cliente pergunta",
+                "cabeleireiro rotina salão pequeno",
+                "pedicure biossegurança atendimento",
+                "manicure preço unha decorada",
+                "salão beleza pacote fidelidade"));
+        texts.set(0, "como vender mais");
+        NicheResearchSeedBuilderOutput output = outputWithQueries(texts);
+
+        assertThatThrownBy(() -> validator.validate(pending, output))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Query genérica proibida");
+    }
+
+    /** Deve rejeitar saída com menos de doze queries para manter cobertura mínima do MVP. */
+    @Test
+    void shouldRejectTooFewQueries() {
+        NicheResearchSeedBuilderPending pending = pending();
+        NicheResearchSeedBuilderOutput output = outputWithQueries(List.of("manicure rotina de atendimento"));
+
+        assertThatThrownBy(() -> validator.validate(pending, output))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("entre 12 e 15 queries");
+    }
+
+    /** Cria uma pendência padrão equivalente ao ciclo RUNNING retornado pelo backend. */
+    private NicheResearchSeedBuilderPending pending() {
+        return new NicheResearchSeedBuilderPending(
+                1001L,
+                55L,
+                "9602501",
+                "Cabeleireiros, manicure e pedicure",
+                "Cabeleireiros, manicure e pedicure",
+                BigDecimal.valueOf(92),
+                "AUTO_SCORE_QUEUE",
+                "RUNNING",
+                Instant.now(),
+                Instant.now());
+    }
+
+    /** Cria uma saída com seed de beleza e queries com objetivos alternados para validação. */
+    private NicheResearchSeedBuilderOutput outputWithQueries(List<String> queryTexts) {
+        NicheResearchSeed seed = new NicheResearchSeed(
+                1001L,
+                "9602501",
+                "Cabeleireiros, manicure e pedicure",
+                "Cabeleireiros, manicures e pedicures",
+                "serviço local de beleza",
+                "atendimento com agenda e recorrência por WhatsApp",
+                "consumidor final recorrente",
+                "manicure, unha em gel, salão beleza, hidratação cabelo, pedicure, cabeleireiro, pacote fidelidade, agenda",
+                "O nicho depende de agenda cheia, recorrência e indicação.",
+                "INFERRED_FROM_CNAE",
+                "AI");
+        List<ResearchQuery> queries = new ArrayList<>();
+        for (int index = 0; index < queryTexts.size(); index++) {
+            queries.add(new ResearchQuery(
+                    1001L,
+                    queryTexts.get(index),
+                    index % 2 == 0 ? "ROUTINE_DISCOVERY" : "SALES_PAIN_DISCOVERY",
+                    "GENERAL_WEB",
+                    index + 1,
+                    "PENDING",
+                    "AI"));
+        }
+        return new NicheResearchSeedBuilderOutput(1001L, seed, queries);
+    }
+}


### PR DESCRIPTION
### Motivation
- Implementar a Etapa 2 do pipeline OPRM (`oprmNicheResearchSeedBuilder`) para transformar um ciclo CNAE em um `oprm_niche_research_seed` e em frases de pesquisa auditáveis que alimentarão as próximas etapas do pipeline. 
- Seguir o padrão de arquitetura por etapas já adotado (`com.marketinghub.nichocnae.pipeline`) para manter etapas concretas plugáveis e sem acoplamento cruzado. 
- Garantir contrato estrito entre IA e backend usando schema JSON e validações determinísticas para evitar queries genéricas e metadados técnicos no payload final. 

### Description
- Adiciona o pacote de etapa `com.marketinghub.nichocnae.nicheresearchseedbuilder` com classes principais: `NicheResearchSeedBuilderProcessor`, `NicheResearchSeedBuilderService`, `NicheResearchSeedBuilderBackendClient` e `NicheResearchSeedBuilderController` (endpoints manuais em `/api/oprm-mei/nichocnae/niche-research-seed-builder`). 
- Implementa integração com OpenAI Responses API via `OpenAiNicheResearchSeedBuilderClient` e schema estrito gerado por `NicheResearchSeedBuilderSchema`, além de `OpenAiSeedBuilderResult` para preservar metadados de uso. 
- Inclui validações determinísticas em `NicheResearchSeedBuilderValidator` (regras MVP: `12–15` queries, evitar queries genéricas, cada query deve conter nicho/objeto comercial, `PENDING` status, `createdBy = AI`, objetivos permitidos etc.). 
- Introduz DTOs/records e artefatos de contrato: `NicheResearchSeed`, `ResearchQuery`, `NicheResearchSeedBuilderPending`, `NicheResearchSeedBuilderOutput`, `NicheResearchSeedBuilderCompletionRequest` e `NicheResearchSeedBuilderFailureRequest`. 
- Registra propriedades OpenAI específicas da etapa (`NicheResearchSeedBuilderOpenAiProperties`) e as expõe em `application.yml`, e registra a `ConfigurationProperties` no `OprmMarketImportConfig`. 
- Atualiza documentação Swagger `docs/swagger/oprm-nichocnae-swagger.yaml` com os endpoints backend esperados (`pending`, `complete`, `fail`, `detail`) e acrescenta entrada no registro operacional `docs/registros/oprm1.md`. 
- Inclui testes unitários: `NicheResearchSeedBuilderValidatorTest` (valida regras determinísticas) e `NicheResearchSeedBuilderProcessorTest` (valida orquestração OpenAI → backend via `StageProcessor`). 

### Testing
- Executei os testes do módulo coletor com `mvn -f oprm-coletor-mei/pom.xml test` e corrigi uma condição detectada pelo teste (âncoras de especificidade) durante o ciclo de desenvolvimento. 
- Após ajuste, a suíte do módulo `oprm-coletor-mei` executou com sucesso e todos os testes do submódulo passaram (`18` testes executados, `0` falhas). 
- Testes relevantes executados: `NicheResearchSeedBuilderValidatorTest` e `NicheResearchSeedBuilderProcessorTest`, além dos testes já existentes de `routineresearchcycle` e das verificações ArchUnit do pacote `nichocnae`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f3d2a89988321899a189384e7a347)