### PR TITLE
Add OPRM pipeline navigation and static pipeline page

### DIFF
--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -219,3 +219,5 @@
 - 2026-06-02 14:25:00 (UTC-3): documentada na metodologia de pipeline por etapas a necessidade obrigatória de etapas concretas plugáveis e removíveis, explicitando que etapas podem depender do núcleo/infra compartilhada permitida, mas não de outras etapas concretas, para permitir inclusão, remoção e substituição sem dano colateral.
 
 - 2026-06-02 00:00:00 (UTC): implementada no coletor OPRM MEI a etapa 1 `oprmRoutineResearchCycle` no pacote `com.marketinghub.nichocnae`, com cliente backend, processor pelo `PipelineWorker`, endpoints manuais de acompanhamento/processamento e testes unitários sem agendamento automático.
+
+- 2026-06-02 00:00:00 (UTC): adicionada navegação frontend do OPRM com botão `Pipeline` ao lado de `CNAEs` e criada a tela estática `/oprm/pipeline` com três cards iniciais das etapas Ingestão de Mercado, Score OPRM e Enriquecimento Comercial para preparar a evolução visual do pipeline sem acionar novos endpoints.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -109,6 +109,7 @@ import OprmFeedbackPage from "./pages/oprm/OprmFeedbackPage";
 import OprmOperationsPage from "./pages/oprm/OprmOperationsPage";
 import OprmOccupationCatalogPage from "./pages/oprm/OprmOccupationCatalogPage";
 import OprmCnaeVolumePage from "./pages/oprm/OprmCnaeVolumePage";
+import OprmPipelinePage from "./pages/oprm/OprmPipelinePage";
 import MoisWorkspacePage from "./pages/mois/MoisWorkspacePage";
 import MoisReferenceIntakePage from "./pages/mois/MoisReferenceIntakePage";
 import MoisExtractionPage from "./pages/mois/MoisExtractionPage";
@@ -314,6 +315,7 @@ export default function App() {
                 path="/oprm/operations"
                 element={<OprmOperationsPage />}
               />
+              <Route path="/oprm/pipeline" element={<OprmPipelinePage />} />
               <Route
                 path="/oprm/occupations"
                 element={<OprmOccupationCatalogPage />}

--- a/frontend/src/__tests__/OprmNavigation.test.tsx
+++ b/frontend/src/__tests__/OprmNavigation.test.tsx
@@ -25,6 +25,7 @@ describe("OPRM navigation", () => {
     expect(
       screen.getByRole("button", { name: /ver nichos enriquecidos/i }),
     ).toBeTruthy();
+    expect(screen.getByRole("link", { name: /^pipeline$/i })).toBeTruthy();
   });
 
   it("has menu link to /oprm", () => {
@@ -39,6 +40,14 @@ describe("OPRM navigation", () => {
     const link = screen.getByRole("link", { name: /^cnaes$/i });
     expect(link).toBeTruthy();
     expect(link.getAttribute("href")).toBe("/oprm");
+  });
+
+  it("renders Pipeline page on /oprm/pipeline route", () => {
+    setup(<App />, ["/oprm/pipeline"]);
+    expect(screen.getByText(/^Pipeline OPRM$/)).toBeTruthy();
+    expect(screen.getByText(/^Ingestão de Mercado$/)).toBeTruthy();
+    expect(screen.getByText(/^Score OPRM$/)).toBeTruthy();
+    expect(screen.getByText(/^Enriquecimento Comercial$/)).toBeTruthy();
   });
 
   it("renders loading state on /oprm/operations route", async () => {

--- a/frontend/src/pages/oprm/OprmModuleNavigation.tsx
+++ b/frontend/src/pages/oprm/OprmModuleNavigation.tsx
@@ -4,7 +4,10 @@ interface OprmModuleNavigationProps {
   occupationSeedRef?: string;
 }
 
-const cnaeItem = { label: "CNAEs", to: "/oprm" };
+const navigationItems = [
+  { label: "CNAEs", to: "/oprm" },
+  { label: "Pipeline", to: "/oprm/pipeline" },
+];
 
 export default function OprmModuleNavigation({
   occupationSeedRef: _occupationSeedRef,
@@ -12,16 +15,18 @@ export default function OprmModuleNavigation({
   return (
     <nav aria-label="Navegação interna do OPRM">
       <ul className="nav nav-pills gap-2">
-        <li className="nav-item">
-          <NavLink
-            to={cnaeItem.to}
-            className={({ isActive }) =>
-              isActive ? "nav-link active" : "nav-link"
-            }
-          >
-            {cnaeItem.label}
-          </NavLink>
-        </li>
+        {navigationItems.map((item) => (
+          <li className="nav-item" key={item.to}>
+            <NavLink
+              to={item.to}
+              className={({ isActive }) =>
+                isActive ? "nav-link active" : "nav-link"
+              }
+            >
+              {item.label}
+            </NavLink>
+          </li>
+        ))}
       </ul>
     </nav>
   );

--- a/frontend/src/pages/oprm/OprmPipelinePage.tsx
+++ b/frontend/src/pages/oprm/OprmPipelinePage.tsx
@@ -1,0 +1,62 @@
+import PageTitle from "../../components/PageTitle";
+import OprmModuleNavigation from "./OprmModuleNavigation";
+
+const pipelineStages = [
+  {
+    number: "1",
+    title: "Ingestão de Mercado",
+    description:
+      "Coleta e organiza os dados de mercado que sustentam a leitura de CNAEs e volume de oportunidade.",
+  },
+  {
+    number: "2",
+    title: "Score OPRM",
+    description:
+      "Prioriza os CNAEs com maior potencial para gerar oportunidades vendáveis, usando o Score OPRM como referência.",
+  },
+  {
+    number: "3",
+    title: "Enriquecimento Comercial",
+    description:
+      "Transforma os CNAEs priorizados em candidatos de nicho com dor, resultado e mecanismo para decisão humana.",
+  },
+];
+
+export default function OprmPipelinePage() {
+  return (
+    <div className="d-flex flex-column gap-4">
+      <header className="d-flex flex-column gap-2">
+        <PageTitle>Pipeline OPRM</PageTitle>
+        <p className="text-secondary mb-0">
+          Visão inicial das etapas do pipeline OPRM. Por enquanto, esta tela
+          apresenta apenas os cards das fases principais para orientar a próxima
+          evolução do fluxo.
+        </p>
+      </header>
+
+      <OprmModuleNavigation />
+
+      <section className="row g-3" aria-label="Etapas do pipeline OPRM">
+        {pipelineStages.map((stage) => (
+          <div className="col-12 col-lg-4" key={stage.number}>
+            <article className="card border-0 shadow-sm h-100">
+              <div className="card-body d-flex flex-column gap-3">
+                <div
+                  className="rounded-circle bg-primary text-white d-inline-flex align-items-center justify-content-center fw-bold"
+                  style={{ width: 44, height: 44 }}
+                  aria-hidden="true"
+                >
+                  {stage.number}
+                </div>
+                <div>
+                  <h2 className="h5 mb-2">{stage.title}</h2>
+                  <p className="text-secondary mb-0">{stage.description}</p>
+                </div>
+              </div>
+            </article>
+          </div>
+        ))}
+      </section>
+    </div>
+  );
+}


### PR DESCRIPTION
### Motivation
- Add a visible entry point for the new OPRM pipeline in the frontend navigation and provide a simple placeholder screen to guide the next steps of the feature.
- Provide three initial cards (Ingestão de Mercado, Score OPRM, Enriquecimento Comercial) as a minimal, non-destructive UI to be evolved later without introducing backend changes.

### Description
- Added a new static page `frontend/src/pages/oprm/OprmPipelinePage.tsx` that renders three pipeline stage cards and the OPRM internal navigation.
- Updated `frontend/src/pages/oprm/OprmModuleNavigation.tsx` to include a `Pipeline` tab next to `CNAEs` that links to `/oprm/pipeline`.
- Registered the route in `frontend/src/App.tsx` so the page is reachable at `/oprm/pipeline` and kept the change frontend-only (no new backend endpoints).
- Updated the navigation test `frontend/src/__tests__/OprmNavigation.test.tsx` and recorded the change in `docs/registros/oprm1.md`.

### Testing
- Ran unit tests with `npm test -- --run src/__tests__/OprmNavigation.test.tsx`, and the suite passed (6 tests).
- Ran TypeScript check with `npm run typecheck`, and it completed successfully.
- Performed a visual smoke check with `npx playwright screenshot --viewport-size=1365,768 http://127.0.0.1:5173/oprm/pipeline /tmp/oprm-pipeline.png`, producing a screenshot (`/tmp/oprm-pipeline.png`) confirming the page renders.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f3e42da4c8321ba55fede065d7a65)