### PR TITLE
Remove obsolete wireframe prompt test

### DIFF
--- a/ai-worker/src/test/java/com/marketinghub/worker/openai/core/wireframe/WireframeBackendClientTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/openai/core/wireframe/WireframeBackendClientTest.java
@@ -187,22 +187,6 @@ class WireframeBackendClientTest {
                 .doesNotContain("mistas");
     }
 
-    /** Deve refletir no prompt a regra comercial de imagens úteis em vez de imagem obrigatória por seção. */
-    @Test
-    void wireframePromptShouldRequireOnlyCommerciallyUsefulImages() throws Exception {
-        String promptMarkdown = new ClassPathResource("prompts/geralanding/landing-page-wireframe.md")
-                .getContentAsString(StandardCharsets.UTF_8);
-
-        assertThat(promptMarkdown)
-                .contains("planejar normalmente entre 2 e 4 elementos `img` úteis")
-                .contains("somente quando a imagem cumpre função explícita de prova")
-                .contains("Hero com imagem controlada")
-                .contains("sem bloco full-width desproporcional")
-                .doesNotContain(
-                        "cada seção em `pagina.corpo.secoes[]` deve conter pelo menos um elemento `img`")
-                .doesNotContain("gerar no mínimo 4 elementos `img`");
-    }
-
     /** Deve exigir metadados visuais mínimos para cada imagem planejada no wireframe. */
     @Test
     void wireframeSchemaShouldRequireVisualMetadataForImages() throws Exception {

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -3094,3 +3094,5 @@
 - impacto esperado: execuções produtivas do GeraLanding não devem mais tentar chamar portas locais acidentais para gerar imagens; se uma configuração local escapar para produção, o Worker AI usa a OpenAI oficial em vez de quebrar o job com conexão recusada em localhost.
 
 - 2026-06-02: Removido teste obsoleto `ExperimentPipelineOpenAiClientTest.prependsLandingDesignPresetGuidanceWithMinimumVisualQualityRules`, que validava literal antigo do prompt de design preset da landing e não é mais necessário.
+
+- 2026-06-02 19:16:23 UTC-3: Removido teste obsoleto `WireframeBackendClientTest.wireframePromptShouldRequireOnlyCommerciallyUsefulImages`, que validava literais específicos do prompt de wireframe e estava falhando na linha 197 sem representar mais uma validação necessária do contrato atual.


### PR DESCRIPTION
### Motivation

- The wireframe prompt test `wireframePromptShouldRequireOnlyCommerciallyUsefulImages` validated specific prompt literals that are no longer required by the current contract and was failing; removing it keeps tests aligned with the current contract and avoids false negatives.

### Description

- Removed the obsolete test method `wireframePromptShouldRequireOnlyCommerciallyUsefulImages` from `ai-worker/src/test/java/com/marketinghub/worker/openai/core/wireframe/WireframeBackendClientTest.java`.
- Added a registry entry in `docs/registros/experimentos.md` documenting the removal and rationale.
- Commit created with message `Remove obsolete wireframe prompt test` to record the change.

### Testing

- Ran `git diff --check` and basic repository checks which passed without whitespace/errors.
- Attempted to run the unit test with `mvn -pl . -Dtest=WireframeBackendClientTest test`, but the run failed due to dependency resolution against a private GitHub Packages artifact (`com.marketinghub:ads-service:pom:0.0.1-SNAPSHOT`) returning `401 Unauthorized`, so full unit test execution was blocked.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f560f11d883218e5c5fbc0a4a3d43)