### PR TITLE
Present Pipeline NichoCNAE UI and update tests/docs

### DIFF
--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -228,3 +228,4 @@
 - A etapa lista ciclos pendentes no backend, chama a OpenAI Responses API com schema JSON estrito, valida seed e 12 a 15 queries específicas, persiste a conclusão no backend e registra falha operacional quando necessário.
 - Expostos endpoints manuais do coletor em `/api/oprm-mei/nichocnae/niche-research-seed-builder` para listar pendências, detalhar ciclo e processar pendentes.
 - Atualizada a documentação Swagger OPRM nichocnae com os contratos backend esperados para pending, complete, fail e detail da etapa dois.
+- 2026-06-02 00:00:00 (UTC): ajustada a tela `/oprm/pipeline` para remover os cards de ingestão/score/enriquecimento CNAE e apresentar os cards corretos do pipeline NichoCNAE: orquestrador de pesquisa, ciclo de pesquisa de rotina, seed de pesquisa, busca/coleta de fontes, extração de sinais, síntese da rotina e gate de qualidade.

--- a/frontend/src/__tests__/OprmNavigation.test.tsx
+++ b/frontend/src/__tests__/OprmNavigation.test.tsx
@@ -44,10 +44,11 @@ describe("OPRM navigation", () => {
 
   it("renders Pipeline page on /oprm/pipeline route", () => {
     setup(<App />, ["/oprm/pipeline"]);
-    expect(screen.getByText(/^Pipeline OPRM$/)).toBeTruthy();
-    expect(screen.getByText(/^Ingestão de Mercado$/)).toBeTruthy();
-    expect(screen.getByText(/^Score OPRM$/)).toBeTruthy();
-    expect(screen.getByText(/^Enriquecimento Comercial$/)).toBeTruthy();
+    expect(screen.getByText(/^Pipeline NichoCNAE$/)).toBeTruthy();
+    expect(screen.getByText(/^Orquestrador de Pesquisa$/)).toBeTruthy();
+    expect(screen.getByText(/^Ciclo de Pesquisa de Rotina$/)).toBeTruthy();
+    expect(screen.getByText(/^Seed de Pesquisa do Nicho$/)).toBeTruthy();
+    expect(screen.getByText(/^Gate de Qualidade$/)).toBeTruthy();
   });
 
   it("renders loading state on /oprm/operations route", async () => {

--- a/frontend/src/pages/oprm/OprmPipelinePage.tsx
+++ b/frontend/src/pages/oprm/OprmPipelinePage.tsx
@@ -3,22 +3,68 @@ import OprmModuleNavigation from "./OprmModuleNavigation";
 
 const pipelineStages = [
   {
-    number: "1",
-    title: "Ingestão de Mercado",
+    number: "0",
+    title: "Orquestrador de Pesquisa",
+    technicalName: "oprmRoutineResearchOrchestrator",
     description:
-      "Coleta e organiza os dados de mercado que sustentam a leitura de CNAEs e volume de oportunidade.",
+      "Seleciona automaticamente o próximo nicho CNAE enriquecido com maior score e ainda sem pesquisa de rotina concluída.",
+    output: "Nicho marcado como RESEARCH_RUNNING e ciclo de pesquisa criado.",
+  },
+  {
+    number: "1",
+    title: "Ciclo de Pesquisa de Rotina",
+    technicalName: "oprmRoutineResearchCycle",
+    description:
+      "Controla a execução completa da pesquisa de rotina do nicho, mantendo CNAE, score, status, contadores e rastreabilidade.",
+    output: "Ciclo pai do pipeline pronto para receber as próximas etapas.",
   },
   {
     number: "2",
-    title: "Score OPRM",
+    title: "Seed de Pesquisa do Nicho",
+    technicalName: "oprmNicheResearchSeedBuilder",
     description:
-      "Prioriza os CNAEs com maior potencial para gerar oportunidades vendáveis, usando o Score OPRM como referência.",
+      "Usa IA para transformar o CNAE em nicho operacional, objetos comerciais, suposições iniciais e queries de pesquisa.",
+    output: "Seed do nicho e frases de pesquisa para rotina, dores, perguntas e ofertas.",
   },
   {
     number: "3",
-    title: "Enriquecimento Comercial",
+    title: "Busca de Fontes",
+    technicalName: "oprmSourceSearcher",
     description:
-      "Transforma os CNAEs priorizados em candidatos de nicho com dor, resultado e mecanismo para decisão humana.",
+      "Executa as queries planejadas em provedor de busca e registra páginas, documentos e conteúdos públicos candidatos.",
+    output: "Fontes candidatas vinculadas ao ciclo e às queries pesquisadas.",
+  },
+  {
+    number: "4",
+    title: "Coleta de Fontes",
+    technicalName: "oprmSourceFetcher",
+    description:
+      "Seleciona fontes relevantes e coleta metadados, snippets e trechos curtos sem armazenar HTML completo no MVP.",
+    output: "Snapshots leves das fontes para extração de sinais.",
+  },
+  {
+    number: "5",
+    title: "Extração de Sinais",
+    technicalName: "oprmSignalExtractor",
+    description:
+      "Extrai sinais estruturados sobre rotina, tarefas comerciais, dores, perguntas, linguagem e oportunidades de mecanismo.",
+    output: "Sinais classificados para sustentar a síntese da rotina.",
+  },
+  {
+    number: "6",
+    title: "Síntese da Rotina",
+    technicalName: "oprmRoutineSynthesizer",
+    description:
+      "Monta o cartão de rotina do nicho a partir dos sinais extraídos, sem criar oferta, campanha ou landing page.",
+    output: "oprm_niche_routine_card com rotina, dores, resultados e evidências.",
+  },
+  {
+    number: "7",
+    title: "Gate de Qualidade",
+    technicalName: "oprmRoutineQualityGate",
+    description:
+      "Avalia se o card tem fontes, sinais, especificidade e confiança suficientes para seguir para hipótese comercial.",
+    output: "Decisão: pronto para hipótese, precisa de mais pesquisa ou ficou genérico.",
   },
 ];
 
@@ -26,31 +72,56 @@ export default function OprmPipelinePage() {
   return (
     <div className="d-flex flex-column gap-4">
       <header className="d-flex flex-column gap-2">
-        <PageTitle>Pipeline OPRM</PageTitle>
+        <PageTitle>Pipeline NichoCNAE</PageTitle>
         <p className="text-secondary mb-0">
-          Visão inicial das etapas do pipeline OPRM. Por enquanto, esta tela
-          apresenta apenas os cards das fases principais para orientar a próxima
-          evolução do fluxo.
+          Esta tela mostra o pipeline OPRM que transforma um nicho CNAE já
+          priorizado em um cartão de rotina pesquisado. Ingestão de mercado,
+          cálculo de score e enriquecimento CNAE ficam na aba CNAEs; aqui o foco
+          é conhecer como o nicho funciona no dia a dia antes da hipótese
+          comercial.
         </p>
       </header>
 
       <OprmModuleNavigation />
 
-      <section className="row g-3" aria-label="Etapas do pipeline OPRM">
+      <section className="card border-0 shadow-sm">
+        <div className="card-body">
+          <h2 className="h5 mb-2">Fluxo do pipeline de pesquisa da rotina</h2>
+          <p className="text-secondary mb-0">
+            Entrada: nicho CNAE com score alto. Saída esperada:
+            <strong> oprm_niche_routine_card</strong>, que será usado depois pelo
+            pipeline de hipótese comercial para trabalhar dor, resultado,
+            mecanismo, prova e oferta.
+          </p>
+        </div>
+      </section>
+
+      <section className="row g-3" aria-label="Etapas do pipeline NichoCNAE">
         {pipelineStages.map((stage) => (
-          <div className="col-12 col-lg-4" key={stage.number}>
+          <div className="col-12 col-lg-3" key={stage.number}>
             <article className="card border-0 shadow-sm h-100">
               <div className="card-body d-flex flex-column gap-3">
-                <div
-                  className="rounded-circle bg-primary text-white d-inline-flex align-items-center justify-content-center fw-bold"
-                  style={{ width: 44, height: 44 }}
-                  aria-hidden="true"
-                >
-                  {stage.number}
+                <div className="d-flex align-items-start justify-content-between gap-3">
+                  <div
+                    className="rounded-circle bg-primary text-white d-inline-flex align-items-center justify-content-center fw-bold flex-shrink-0"
+                    style={{ width: 44, height: 44 }}
+                    aria-hidden="true"
+                  >
+                    {stage.number}
+                  </div>
+                  <span className="badge text-bg-light border text-secondary text-wrap">
+                    {stage.technicalName}
+                  </span>
                 </div>
                 <div>
                   <h2 className="h5 mb-2">{stage.title}</h2>
-                  <p className="text-secondary mb-0">{stage.description}</p>
+                  <p className="text-secondary mb-3">{stage.description}</p>
+                  <div className="border-top pt-3">
+                    <span className="d-block small fw-semibold text-secondary text-uppercase mb-1">
+                      Saída da etapa
+                    </span>
+                    <p className="mb-0 small">{stage.output}</p>
+                  </div>
                 </div>
               </div>
             </article>


### PR DESCRIPTION
### Motivation
- Align the frontend pipeline overview with the new backend NichoCNAE research pipeline so stage names, technical identifiers and expected outputs are visible to reviewers and integrators.
- Improve the pipeline page layout to surface metadata about each stage and make the cards more informative for future implementation work.

### Description
- Renamed the page title to `Pipeline NichoCNAE` and updated explanatory copy in `frontend/src/pages/oprm/OprmPipelinePage.tsx`.
- Replaced and expanded the `pipelineStages` array to include stages 0–7 with `technicalName`, `description` and `output` fields that reflect the NichoCNAE research flow.
- Updated the page layout to use a card header, show a badge with the `technicalName`, include a stepped output section, and change column sizing (`col-lg-3`) for denser grid presentation.
- Updated the navigation tests in `frontend/src/__tests__/OprmNavigation.test.tsx` to assert the new headings and stage labels, and adjusted the changelog entry in `docs/registros/oprm1.md` to note the UI change.

### Testing
- Ran frontend unit tests via `yarn test` and the updated `OprmNavigation.test.tsx` assertions passed.
- No other automated tests were run as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f47b93bf08321b64edcf2ae5862f0)