### PR TITLE
Implementa etapa 2 (Seed Builder) do pipeline OPRM nichocnae

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/OprmNicheResearchSeed.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/OprmNicheResearchSeed.java
@@ -1,0 +1,58 @@
+package com.marketinghub.oprm.nichocnae;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import lombok.Data;
+
+/**
+ * Entidade responsável por guardar o perfil operacional do nicho identificado para uma pesquisa CNAE.
+ */
+@Entity
+@Data
+@Table(name = "oprm_niche_research_seed")
+public class OprmNicheResearchSeed {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "research_cycle_id", nullable = false)
+    private Long researchCycleId;
+
+    @Column(name = "cnae_code", nullable = false, length = 7)
+    private String cnaeCode;
+
+    @Column(name = "cnae_description", nullable = false, length = 255)
+    private String cnaeDescription;
+
+    @Column(name = "niche_name", nullable = false, length = 255)
+    private String nicheName;
+
+    @Column(name = "business_type", nullable = false, length = 255)
+    private String businessType;
+
+    @Column(name = "operation_type", columnDefinition = "LONGTEXT", nullable = false)
+    private String operationType;
+
+    @Column(name = "customer_type", columnDefinition = "LONGTEXT", nullable = false)
+    private String customerType;
+
+    @Column(name = "commercial_objects", columnDefinition = "LONGTEXT", nullable = false)
+    private String commercialObjects;
+
+    @Column(name = "initial_assumptions", columnDefinition = "LONGTEXT", nullable = false)
+    private String initialAssumptions;
+
+    @Column(name = "confidence_level", nullable = false, length = 64)
+    private String confidenceLevel;
+
+    @Column(name = "created_by", nullable = false, length = 32)
+    private String createdBy;
+
+    @Column(name = "created_at", nullable = false)
+    private Instant createdAt;
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/OprmResearchQuery.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/OprmResearchQuery.java
@@ -1,0 +1,58 @@
+package com.marketinghub.oprm.nichocnae;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import lombok.Data;
+
+/**
+ * Entidade responsável por guardar uma frase de pesquisa executável da pesquisa de rotina de nicho CNAE.
+ */
+@Entity
+@Data
+@Table(name = "oprm_research_query")
+public class OprmResearchQuery {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "research_cycle_id", nullable = false)
+    private Long researchCycleId;
+
+    @Column(name = "niche_research_seed_id", nullable = false)
+    private Long nicheResearchSeedId;
+
+    @Column(name = "query_text", nullable = false, length = 500)
+    private String queryText;
+
+    @Column(name = "query_goal", nullable = false, length = 64)
+    private String queryGoal;
+
+    @Column(name = "source_group", length = 64)
+    private String sourceGroup;
+
+    @Column(name = "priority", nullable = false)
+    private Integer priority;
+
+    @Column(name = "status", nullable = false, length = 32)
+    private String status;
+
+    @Column(name = "result_count", nullable = false)
+    private Integer resultCount;
+
+    @Column(name = "error_message", columnDefinition = "LONGTEXT")
+    private String errorMessage;
+
+    @Column(name = "created_by", nullable = false, length = 32)
+    private String createdBy;
+
+    @Column(name = "created_at", nullable = false)
+    private Instant createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/nicheresearchseedbuilder/package-info.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/nicheresearchseedbuilder/package-info.java
@@ -1,0 +1,2 @@
+/** Pacote da etapa dois do pipeline OPRM nichocnae para geração de seed e queries de pesquisa. */
+package com.marketinghub.oprm.nichocnae.nicheresearchseedbuilder;

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/nicheresearchseedbuilder/service/BackendNicheResearchSeedBuilderService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/nicheresearchseedbuilder/service/BackendNicheResearchSeedBuilderService.java
@@ -1,0 +1,296 @@
+package com.marketinghub.oprm.nichocnae.nicheresearchseedbuilder.service;
+
+import com.marketinghub.oprm.nichocnae.OprmNicheResearchSeed;
+import com.marketinghub.oprm.nichocnae.OprmResearchQuery;
+import com.marketinghub.oprm.nichocnae.OprmRoutineResearchCycle;
+import com.marketinghub.oprm.nichocnae.nicheresearchseedbuilder.service.completeStageExecution.CompleteNicheResearchSeedBuilderRequest;
+import com.marketinghub.oprm.nichocnae.nicheresearchseedbuilder.service.completeStageExecution.CompleteNicheResearchSeedBuilderResponse;
+import com.marketinghub.oprm.nichocnae.nicheresearchseedbuilder.service.completeStageExecution.NicheResearchQueryRequest;
+import com.marketinghub.oprm.nichocnae.nicheresearchseedbuilder.service.completeStageExecution.NicheResearchQueryResponse;
+import com.marketinghub.oprm.nichocnae.nicheresearchseedbuilder.service.detailStageExecution.NicheResearchSeedBuilderDetailResponse;
+import com.marketinghub.oprm.nichocnae.nicheresearchseedbuilder.service.failStageExecution.FailNicheResearchSeedBuilderRequest;
+import com.marketinghub.oprm.nichocnae.nicheresearchseedbuilder.service.pending.RecordNicheResearchSeedBuilderPending;
+import com.marketinghub.repository.jpa.oprm.nichocnae.OprmNicheResearchSeedRepository;
+import com.marketinghub.repository.jpa.oprm.nichocnae.OprmResearchQueryRepository;
+import com.marketinghub.repository.jpa.oprm.nichocnae.OprmRoutineResearchCycleRepository;
+import jakarta.persistence.EntityNotFoundException;
+import java.time.Instant;
+import java.util.Comparator;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+/** Responsável por persistir o seed operacional e as frases de pesquisa da etapa dois do OPRM nicho CNAE. */
+@Service
+public class BackendNicheResearchSeedBuilderService {
+  private static final Logger LOGGER = LoggerFactory.getLogger(BackendNicheResearchSeedBuilderService.class);
+  private static final String CYCLE_STATUS_RUNNING = "RUNNING";
+  private static final String CYCLE_STATUS_FAILED = "FAILED";
+  private static final String QUERY_STATUS_PENDING = "PENDING";
+  private static final String DEFAULT_CREATED_BY = "AI";
+  private static final int MIN_QUERY_COUNT = 1;
+  private static final int MAX_QUERY_COUNT = 15;
+  private static final Set<String> ALLOWED_QUERY_GOALS = Set.of(
+      "ROUTINE_DISCOVERY",
+      "NICHE_OWNER_QUESTION_DISCOVERY",
+      "FINAL_CUSTOMER_QUESTION_DISCOVERY",
+      "SALES_PAIN_DISCOVERY",
+      "PRODUCT_SERVICE_DISCOVERY",
+      "OFFER_PATTERN_DISCOVERY",
+      "LANGUAGE_DISCOVERY",
+      "WORKAROUND_DISCOVERY",
+      "MECHANISM_DISCOVERY");
+
+  private final OprmRoutineResearchCycleRepository routineResearchCycleRepository;
+  private final OprmNicheResearchSeedRepository nicheResearchSeedRepository;
+  private final OprmResearchQueryRepository researchQueryRepository;
+
+  /** Inicializa o serviço com os repositórios canônicos da etapa dois do pipeline. */
+  public BackendNicheResearchSeedBuilderService(
+      OprmRoutineResearchCycleRepository routineResearchCycleRepository,
+      OprmNicheResearchSeedRepository nicheResearchSeedRepository,
+      OprmResearchQueryRepository researchQueryRepository) {
+    this.routineResearchCycleRepository = routineResearchCycleRepository;
+    this.nicheResearchSeedRepository = nicheResearchSeedRepository;
+    this.researchQueryRepository = researchQueryRepository;
+  }
+
+  /** Lista ciclos em execução que ainda precisam receber seed operacional e queries de pesquisa. */
+  @Transactional(readOnly = true)
+  public List<RecordNicheResearchSeedBuilderPending> listPending() {
+    return routineResearchCycleRepository.findSeedBuilderPendingByStatus(CYCLE_STATUS_RUNNING, PageRequest.of(0, 20))
+        .stream()
+        .map(this::toPending)
+        .toList();
+  }
+
+  /** Grava o seed operacional e as queries geradas pela IA para um ciclo de pesquisa. */
+  @Transactional
+  public CompleteNicheResearchSeedBuilderResponse complete(
+      Long researchCycleId, CompleteNicheResearchSeedBuilderRequest request) {
+    try {
+      OprmRoutineResearchCycle cycle = findCycle(researchCycleId);
+      validateCompletionRequest(researchCycleId, request);
+      if (nicheResearchSeedRepository.existsByResearchCycleId(researchCycleId)) {
+        throw new IllegalStateException("Niche research seed already exists for cycle: " + researchCycleId);
+      }
+
+      Instant now = Instant.now();
+      OprmNicheResearchSeed savedSeed = nicheResearchSeedRepository.save(createSeed(cycle, request, now));
+      List<OprmResearchQuery> savedQueries = researchQueryRepository.saveAll(createQueries(
+          researchCycleId, savedSeed.getId(), request.queries(), normalizeCreatedBy(request.createdBy()), now));
+      cycle.setTotalQueries(savedQueries.size());
+      cycle.setUpdatedAt(now);
+      routineResearchCycleRepository.save(cycle);
+      return toResponse(savedSeed, savedQueries);
+    } catch (RuntimeException ex) {
+      LOGGER.error(
+          "Erro ao concluir etapa dois do OPRM nichocnae (researchCycleId={}, queryCount={})",
+          researchCycleId,
+          request == null || request.queries() == null ? null : request.queries().size(),
+          ex);
+      throw ex;
+    }
+  }
+
+  /** Registra falha da etapa dois no ciclo de pesquisa para interromper o avanço operacional. */
+  @Transactional
+  public void fail(Long researchCycleId, FailNicheResearchSeedBuilderRequest request) {
+    try {
+      OprmRoutineResearchCycle cycle = findCycle(researchCycleId);
+      Instant now = Instant.now();
+      cycle.setStatus(CYCLE_STATUS_FAILED);
+      cycle.setErrorMessage(requiredText(request == null ? null : request.errorMessage(), "errorMessage"));
+      cycle.setFinishedAt(now);
+      cycle.setUpdatedAt(now);
+      routineResearchCycleRepository.save(cycle);
+    } catch (RuntimeException ex) {
+      LOGGER.error("Erro ao registrar falha da etapa dois do OPRM nichocnae (researchCycleId={})", researchCycleId, ex);
+      throw ex;
+    }
+  }
+
+  /** Retorna o seed e as queries gravados para um ciclo de pesquisa de rotina. */
+  @Transactional(readOnly = true)
+  public NicheResearchSeedBuilderDetailResponse detail(Long researchCycleId) {
+    OprmRoutineResearchCycle cycle = findCycle(researchCycleId);
+    CompleteNicheResearchSeedBuilderResponse seed = nicheResearchSeedRepository
+        .findByResearchCycleId(researchCycleId)
+        .map(foundSeed -> toResponse(
+            foundSeed, researchQueryRepository.findByResearchCycleIdOrderByPriorityAscIdAsc(researchCycleId)))
+        .orElse(null);
+    return new NicheResearchSeedBuilderDetailResponse(
+        cycle.getId(), cycle.getStatus(), cycle.getTotalQueries(), cycle.getErrorMessage(), seed);
+  }
+
+  /** Busca o ciclo de pesquisa ou interrompe a operação com erro explícito. */
+  private OprmRoutineResearchCycle findCycle(Long researchCycleId) {
+    return routineResearchCycleRepository
+        .findById(researchCycleId)
+        .orElseThrow(() -> new EntityNotFoundException("Routine research cycle not found: " + researchCycleId));
+  }
+
+  /** Valida o contrato mínimo da saída de IA antes de gravar artefatos da etapa dois. */
+  private void validateCompletionRequest(Long researchCycleId, CompleteNicheResearchSeedBuilderRequest request) {
+    if (request == null) {
+      throw new IllegalArgumentException("Request body is required for cycle: " + researchCycleId);
+    }
+    requiredText(request.nicheName(), "nicheName");
+    requiredText(request.businessType(), "businessType");
+    requiredText(request.operationType(), "operationType");
+    requiredText(request.customerType(), "customerType");
+    requiredText(request.commercialObjects(), "commercialObjects");
+    requiredText(request.initialAssumptions(), "initialAssumptions");
+    requiredText(request.confidenceLevel(), "confidenceLevel");
+    validateQueries(request.queries());
+  }
+
+  /** Valida quantidade, objetivos, duplicidade e texto mínimo das queries geradas para pesquisa. */
+  private void validateQueries(List<NicheResearchQueryRequest> queries) {
+    if (queries == null || queries.size() < MIN_QUERY_COUNT || queries.size() > MAX_QUERY_COUNT) {
+      throw new IllegalArgumentException("queries must contain between 1 and 15 items");
+    }
+    Set<String> uniqueQueryTexts = new HashSet<>();
+    for (NicheResearchQueryRequest query : queries) {
+      String queryText = requiredText(query == null ? null : query.queryText(), "queryText").toLowerCase(Locale.ROOT);
+      if (!uniqueQueryTexts.add(queryText)) {
+        throw new IllegalArgumentException("Duplicate queryText is not allowed: " + query.queryText());
+      }
+      String queryGoal = requiredText(query.queryGoal(), "queryGoal");
+      if (!ALLOWED_QUERY_GOALS.contains(queryGoal)) {
+        throw new IllegalArgumentException("Unsupported queryGoal: " + queryGoal);
+      }
+    }
+  }
+
+  /** Cria a entidade de seed do nicho usando o ciclo canônico como fonte dos dados CNAE. */
+  private OprmNicheResearchSeed createSeed(
+      OprmRoutineResearchCycle cycle, CompleteNicheResearchSeedBuilderRequest request, Instant now) {
+    OprmNicheResearchSeed seed = new OprmNicheResearchSeed();
+    seed.setResearchCycleId(cycle.getId());
+    seed.setCnaeCode(cycle.getCnaeCode());
+    seed.setCnaeDescription(cycle.getCnaeDescription());
+    seed.setNicheName(requiredText(request.nicheName(), "nicheName"));
+    seed.setBusinessType(requiredText(request.businessType(), "businessType"));
+    seed.setOperationType(requiredText(request.operationType(), "operationType"));
+    seed.setCustomerType(requiredText(request.customerType(), "customerType"));
+    seed.setCommercialObjects(requiredText(request.commercialObjects(), "commercialObjects"));
+    seed.setInitialAssumptions(requiredText(request.initialAssumptions(), "initialAssumptions"));
+    seed.setConfidenceLevel(requiredText(request.confidenceLevel(), "confidenceLevel"));
+    seed.setCreatedBy(normalizeCreatedBy(request.createdBy()));
+    seed.setCreatedAt(now);
+    return seed;
+  }
+
+  /** Cria as entidades de query com status pendente para execução pela próxima etapa do pipeline. */
+  private List<OprmResearchQuery> createQueries(
+      Long researchCycleId,
+      Long nicheResearchSeedId,
+      List<NicheResearchQueryRequest> queryRequests,
+      String createdBy,
+      Instant now) {
+    return queryRequests.stream()
+        .map(queryRequest -> createQuery(researchCycleId, nicheResearchSeedId, queryRequest, createdBy, now))
+        .sorted(Comparator.comparing(OprmResearchQuery::getPriority).thenComparing(OprmResearchQuery::getQueryText))
+        .toList();
+  }
+
+  /** Cria uma query individual aplicando defaults operacionais definidos para o MVP. */
+  private OprmResearchQuery createQuery(
+      Long researchCycleId,
+      Long nicheResearchSeedId,
+      NicheResearchQueryRequest queryRequest,
+      String createdBy,
+      Instant now) {
+    OprmResearchQuery query = new OprmResearchQuery();
+    query.setResearchCycleId(researchCycleId);
+    query.setNicheResearchSeedId(nicheResearchSeedId);
+    query.setQueryText(requiredText(queryRequest.queryText(), "queryText"));
+    query.setQueryGoal(requiredText(queryRequest.queryGoal(), "queryGoal"));
+    query.setSourceGroup(trimToNull(queryRequest.sourceGroup()));
+    query.setPriority(queryRequest.priority() == null ? 100 : queryRequest.priority());
+    query.setStatus(QUERY_STATUS_PENDING);
+    query.setResultCount(0);
+    query.setCreatedBy(createdBy);
+    query.setCreatedAt(now);
+    query.setUpdatedAt(now);
+    return query;
+  }
+
+  /** Converte um ciclo pendente no contrato interno de unidade de trabalho da etapa dois. */
+  private RecordNicheResearchSeedBuilderPending toPending(OprmRoutineResearchCycle cycle) {
+    return new RecordNicheResearchSeedBuilderPending(
+        cycle.getId(),
+        cycle.getSourceNicheId(),
+        cycle.getCnaeCode(),
+        cycle.getCnaeDescription(),
+        cycle.getNicheName(),
+        cycle.getSourceScore(),
+        cycle.getStatus(),
+        cycle.getStartedAt(),
+        cycle.getCreatedAt());
+  }
+
+  /** Converte as entidades persistidas no contrato público de resultado da etapa dois. */
+  private CompleteNicheResearchSeedBuilderResponse toResponse(
+      OprmNicheResearchSeed seed, List<OprmResearchQuery> queries) {
+    return new CompleteNicheResearchSeedBuilderResponse(
+        seed.getResearchCycleId(),
+        seed.getId(),
+        seed.getCnaeCode(),
+        seed.getCnaeDescription(),
+        seed.getNicheName(),
+        seed.getBusinessType(),
+        seed.getOperationType(),
+        seed.getCustomerType(),
+        seed.getCommercialObjects(),
+        seed.getInitialAssumptions(),
+        seed.getConfidenceLevel(),
+        seed.getCreatedBy(),
+        seed.getCreatedAt(),
+        queries.size(),
+        queries.stream().map(this::toQueryResponse).toList());
+  }
+
+  /** Converte uma query persistida no contrato de leitura da etapa dois. */
+  private NicheResearchQueryResponse toQueryResponse(OprmResearchQuery query) {
+    return new NicheResearchQueryResponse(
+        query.getId(),
+        query.getResearchCycleId(),
+        query.getNicheResearchSeedId(),
+        query.getQueryText(),
+        query.getQueryGoal(),
+        query.getSourceGroup(),
+        query.getPriority(),
+        query.getStatus(),
+        query.getResultCount(),
+        query.getCreatedBy(),
+        query.getCreatedAt(),
+        query.getUpdatedAt());
+  }
+
+  /** Normaliza o autor do artefato para manter o contrato simples quando a origem não for informada. */
+  private String normalizeCreatedBy(String createdBy) {
+    return StringUtils.hasText(createdBy) ? createdBy.trim() : DEFAULT_CREATED_BY;
+  }
+
+  /** Garante que um campo textual obrigatório exista e remove espaços laterais antes da persistência. */
+  private String requiredText(String value, String fieldName) {
+    if (!StringUtils.hasText(value)) {
+      throw new IllegalArgumentException(fieldName + " is required");
+    }
+    return value.trim();
+  }
+
+  /** Converte strings vazias em nulo para campos opcionais persistidos. */
+  private String trimToNull(String value) {
+    return StringUtils.hasText(value) ? value.trim() : null;
+  }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/nicheresearchseedbuilder/service/completeStageExecution/CompleteNicheResearchSeedBuilderRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/nicheresearchseedbuilder/service/completeStageExecution/CompleteNicheResearchSeedBuilderRequest.java
@@ -1,0 +1,15 @@
+package com.marketinghub.oprm.nichocnae.nicheresearchseedbuilder.service.completeStageExecution;
+
+import java.util.List;
+
+/** Contrato de entrada para gravar o seed e as queries gerados pela IA na etapa dois. */
+public record CompleteNicheResearchSeedBuilderRequest(
+    String nicheName,
+    String businessType,
+    String operationType,
+    String customerType,
+    String commercialObjects,
+    String initialAssumptions,
+    String confidenceLevel,
+    String createdBy,
+    List<NicheResearchQueryRequest> queries) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/nicheresearchseedbuilder/service/completeStageExecution/CompleteNicheResearchSeedBuilderResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/nicheresearchseedbuilder/service/completeStageExecution/CompleteNicheResearchSeedBuilderResponse.java
@@ -1,0 +1,22 @@
+package com.marketinghub.oprm.nichocnae.nicheresearchseedbuilder.service.completeStageExecution;
+
+import java.time.Instant;
+import java.util.List;
+
+/** Informa o seed e as frases de pesquisa gravadas como saída validada da etapa dois. */
+public record CompleteNicheResearchSeedBuilderResponse(
+    Long researchCycleId,
+    Long nicheResearchSeedId,
+    String cnaeCode,
+    String cnaeDescription,
+    String nicheName,
+    String businessType,
+    String operationType,
+    String customerType,
+    String commercialObjects,
+    String initialAssumptions,
+    String confidenceLevel,
+    String createdBy,
+    Instant createdAt,
+    Integer totalQueries,
+    List<NicheResearchQueryResponse> queries) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/nicheresearchseedbuilder/service/completeStageExecution/NicheResearchQueryRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/nicheresearchseedbuilder/service/completeStageExecution/NicheResearchQueryRequest.java
@@ -1,0 +1,4 @@
+package com.marketinghub.oprm.nichocnae.nicheresearchseedbuilder.service.completeStageExecution;
+
+/** Contrato de entrada de uma frase de pesquisa gerada para a etapa dois. */
+public record NicheResearchQueryRequest(String queryText, String queryGoal, String sourceGroup, Integer priority) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/nicheresearchseedbuilder/service/completeStageExecution/NicheResearchQueryResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/nicheresearchseedbuilder/service/completeStageExecution/NicheResearchQueryResponse.java
@@ -1,0 +1,18 @@
+package com.marketinghub.oprm.nichocnae.nicheresearchseedbuilder.service.completeStageExecution;
+
+import java.time.Instant;
+
+/** Representa uma frase de pesquisa persistida para execução pelas próximas etapas do pipeline. */
+public record NicheResearchQueryResponse(
+    Long queryId,
+    Long researchCycleId,
+    Long nicheResearchSeedId,
+    String queryText,
+    String queryGoal,
+    String sourceGroup,
+    Integer priority,
+    String status,
+    Integer resultCount,
+    String createdBy,
+    Instant createdAt,
+    Instant updatedAt) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/nicheresearchseedbuilder/service/detailStageExecution/NicheResearchSeedBuilderDetailResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/nicheresearchseedbuilder/service/detailStageExecution/NicheResearchSeedBuilderDetailResponse.java
@@ -1,0 +1,11 @@
+package com.marketinghub.oprm.nichocnae.nicheresearchseedbuilder.service.detailStageExecution;
+
+import com.marketinghub.oprm.nichocnae.nicheresearchseedbuilder.service.completeStageExecution.CompleteNicheResearchSeedBuilderResponse;
+
+/** Detalha o resultado persistido da etapa dois para consulta operacional no backend OPRM. */
+public record NicheResearchSeedBuilderDetailResponse(
+    Long researchCycleId,
+    String cycleStatus,
+    Integer cycleTotalQueries,
+    String cycleErrorMessage,
+    CompleteNicheResearchSeedBuilderResponse seed) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/nicheresearchseedbuilder/service/failStageExecution/FailNicheResearchSeedBuilderRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/nicheresearchseedbuilder/service/failStageExecution/FailNicheResearchSeedBuilderRequest.java
@@ -1,0 +1,4 @@
+package com.marketinghub.oprm.nichocnae.nicheresearchseedbuilder.service.failStageExecution;
+
+/** Contrato para registrar o motivo de falha operacional da etapa dois. */
+public record FailNicheResearchSeedBuilderRequest(String errorMessage) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/nicheresearchseedbuilder/service/pending/RecordNicheResearchSeedBuilderPending.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/nicheresearchseedbuilder/service/pending/RecordNicheResearchSeedBuilderPending.java
@@ -1,0 +1,16 @@
+package com.marketinghub.oprm.nichocnae.nicheresearchseedbuilder.service.pending;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+
+/** Representa um ciclo CNAE aguardando geração de seed e frases de pesquisa da etapa dois. */
+public record RecordNicheResearchSeedBuilderPending(
+    Long researchCycleId,
+    Long sourceNicheId,
+    String cnaeCode,
+    String cnaeDescription,
+    String nicheName,
+    BigDecimal sourceScore,
+    String status,
+    Instant startedAt,
+    Instant createdAt) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/nicheresearchseedbuilder/web/BackendNicheResearchSeedBuilderController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/nicheresearchseedbuilder/web/BackendNicheResearchSeedBuilderController.java
@@ -1,0 +1,55 @@
+package com.marketinghub.oprm.nichocnae.nicheresearchseedbuilder.web;
+
+import com.marketinghub.oprm.nichocnae.nicheresearchseedbuilder.service.BackendNicheResearchSeedBuilderService;
+import com.marketinghub.oprm.nichocnae.nicheresearchseedbuilder.service.completeStageExecution.CompleteNicheResearchSeedBuilderRequest;
+import com.marketinghub.oprm.nichocnae.nicheresearchseedbuilder.service.completeStageExecution.CompleteNicheResearchSeedBuilderResponse;
+import com.marketinghub.oprm.nichocnae.nicheresearchseedbuilder.service.detailStageExecution.NicheResearchSeedBuilderDetailResponse;
+import com.marketinghub.oprm.nichocnae.nicheresearchseedbuilder.service.failStageExecution.FailNicheResearchSeedBuilderRequest;
+import com.marketinghub.oprm.nichocnae.nicheresearchseedbuilder.service.pending.RecordNicheResearchSeedBuilderPending;
+import java.util.List;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/** Responsável por expor os endpoints backend da etapa dois do pipeline OPRM nichocnae. */
+@RestController
+@RequestMapping("/api")
+public class BackendNicheResearchSeedBuilderController {
+  private final BackendNicheResearchSeedBuilderService executionService;
+
+  /** Inicializa o controller com o serviço backend da etapa dois de seed e queries. */
+  public BackendNicheResearchSeedBuilderController(BackendNicheResearchSeedBuilderService executionService) {
+    this.executionService = executionService;
+  }
+
+  /** Lista ciclos de pesquisa prontos para geração de seed operacional e frases de pesquisa. */
+  @GetMapping("/internal/oprm/nichocnae/niche-research-seed-builder/stage-executions/pending")
+  public List<RecordNicheResearchSeedBuilderPending> pending() {
+    return executionService.listPending();
+  }
+
+  /** Persiste a saída validada da IA para seed operacional e queries da etapa dois. */
+  @PostMapping("/internal/oprm/nichocnae/niche-research-seed-builder/stage-executions/{researchCycleId}/complete")
+  public ResponseEntity<CompleteNicheResearchSeedBuilderResponse> complete(
+      @PathVariable Long researchCycleId, @RequestBody CompleteNicheResearchSeedBuilderRequest request) {
+    return ResponseEntity.ok(executionService.complete(researchCycleId, request));
+  }
+
+  /** Registra falha operacional da etapa dois em um ciclo de pesquisa de rotina. */
+  @PostMapping("/internal/oprm/nichocnae/niche-research-seed-builder/stage-executions/{researchCycleId}/fail")
+  public ResponseEntity<Void> fail(
+      @PathVariable Long researchCycleId, @RequestBody FailNicheResearchSeedBuilderRequest request) {
+    executionService.fail(researchCycleId, request);
+    return ResponseEntity.noContent().build();
+  }
+
+  /** Detalha o seed e as frases de pesquisa geradas para uma execução da etapa dois. */
+  @GetMapping("/oprm/nichocnae/niche-research-seed-builder/stage-executions/{researchCycleId}")
+  public ResponseEntity<NicheResearchSeedBuilderDetailResponse> detail(@PathVariable Long researchCycleId) {
+    return ResponseEntity.ok(executionService.detail(researchCycleId));
+  }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/oprm/nichocnae/OprmNicheResearchSeedRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/oprm/nichocnae/OprmNicheResearchSeedRepository.java
@@ -1,0 +1,16 @@
+package com.marketinghub.repository.jpa.oprm.nichocnae;
+
+import com.marketinghub.oprm.nichocnae.OprmNicheResearchSeed;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * Repositório responsável por persistir e consultar seeds de pesquisa de nicho CNAE.
+ */
+public interface OprmNicheResearchSeedRepository extends JpaRepository<OprmNicheResearchSeed, Long> {
+    /** Verifica se um ciclo já possui seed de pesquisa operacional gerado. */
+    boolean existsByResearchCycleId(Long researchCycleId);
+
+    /** Busca o seed operacional gerado para um ciclo de pesquisa. */
+    Optional<OprmNicheResearchSeed> findByResearchCycleId(Long researchCycleId);
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/oprm/nichocnae/OprmResearchQueryRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/oprm/nichocnae/OprmResearchQueryRepository.java
@@ -1,0 +1,13 @@
+package com.marketinghub.repository.jpa.oprm.nichocnae;
+
+import com.marketinghub.oprm.nichocnae.OprmResearchQuery;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * Repositório responsável por persistir e consultar frases de pesquisa do pipeline OPRM nicho CNAE.
+ */
+public interface OprmResearchQueryRepository extends JpaRepository<OprmResearchQuery, Long> {
+    /** Lista as frases de pesquisa de um ciclo em ordem de prioridade operacional. */
+    List<OprmResearchQuery> findByResearchCycleIdOrderByPriorityAscIdAsc(Long researchCycleId);
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/oprm/nichocnae/OprmRoutineResearchCycleRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/oprm/nichocnae/OprmRoutineResearchCycleRepository.java
@@ -4,6 +4,7 @@ import com.marketinghub.oprm.nichocnae.OprmRoutineResearchCycle;
 import java.util.List;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
 
 /**
  * Repositório responsável por persistir e consultar ciclos de pesquisa de rotina de nicho CNAE.
@@ -14,4 +15,18 @@ public interface OprmRoutineResearchCycleRepository extends JpaRepository<OprmRo
 
     /** Lista ciclos por status para filas internas do pipeline de pesquisa de rotina. */
     List<OprmRoutineResearchCycle> findByStatusOrderByStartedAtAsc(String status, Pageable pageable);
+
+    /** Lista ciclos em execução que ainda não possuem seed de pesquisa de nicho gravado. */
+    @Query("""
+            select cycle
+            from OprmRoutineResearchCycle cycle
+            where cycle.status = :status
+              and not exists (
+                  select 1
+                  from OprmNicheResearchSeed seed
+                  where seed.researchCycleId = cycle.id
+              )
+            order by cycle.startedAt asc
+            """)
+    List<OprmRoutineResearchCycle> findSeedBuilderPendingByStatus(String status, Pageable pageable);
 }

--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-02-oprm-nichocnae-seed-builder.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-02-oprm-nichocnae-seed-builder.yaml
@@ -1,0 +1,71 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-06-02-05-oprm-niche-research-seed
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - onError: HALT
+        - dbms:
+            type: mysql
+        - not:
+            tableExists:
+              tableName: oprm_niche_research_seed
+      changes:
+        - sql:
+            splitStatements: true
+            stripComments: true
+            sql: |
+              CREATE TABLE oprm_niche_research_seed (
+                id BIGINT NOT NULL AUTO_INCREMENT,
+                research_cycle_id BIGINT NOT NULL,
+                cnae_code VARCHAR(7) NOT NULL,
+                cnae_description VARCHAR(255) NOT NULL,
+                niche_name VARCHAR(255) NOT NULL,
+                business_type VARCHAR(255) NOT NULL,
+                operation_type LONGTEXT NOT NULL,
+                customer_type LONGTEXT NOT NULL,
+                commercial_objects LONGTEXT NOT NULL,
+                initial_assumptions LONGTEXT NOT NULL,
+                confidence_level VARCHAR(64) NOT NULL,
+                created_by VARCHAR(32) NOT NULL,
+                created_at DATETIME NOT NULL,
+                CONSTRAINT pk_oprm_niche_research_seed PRIMARY KEY (id),
+                CONSTRAINT uk_oprm_niche_research_seed_cycle UNIQUE (research_cycle_id)
+              );
+              CREATE INDEX idx_oprm_niche_research_seed_cnae ON oprm_niche_research_seed (cnae_code);
+
+  - changeSet:
+      id: 2026-06-02-06-oprm-research-query
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - onError: HALT
+        - dbms:
+            type: mysql
+        - not:
+            tableExists:
+              tableName: oprm_research_query
+      changes:
+        - sql:
+            splitStatements: true
+            stripComments: true
+            sql: |
+              CREATE TABLE oprm_research_query (
+                id BIGINT NOT NULL AUTO_INCREMENT,
+                research_cycle_id BIGINT NOT NULL,
+                niche_research_seed_id BIGINT NOT NULL,
+                query_text VARCHAR(500) NOT NULL,
+                query_goal VARCHAR(64) NOT NULL,
+                source_group VARCHAR(64) NULL,
+                priority INT NOT NULL DEFAULT 100,
+                status VARCHAR(32) NOT NULL,
+                result_count INT NOT NULL DEFAULT 0,
+                error_message LONGTEXT NULL,
+                created_by VARCHAR(32) NOT NULL,
+                created_at DATETIME NOT NULL,
+                updated_at DATETIME NOT NULL,
+                CONSTRAINT pk_oprm_research_query PRIMARY KEY (id)
+              );
+              CREATE INDEX idx_oprm_research_query_cycle_priority ON oprm_research_query (research_cycle_id, priority, id);
+              CREATE INDEX idx_oprm_research_query_status_priority ON oprm_research_query (status, priority, id);
+              CREATE INDEX idx_oprm_research_query_seed ON oprm_research_query (niche_research_seed_id);

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -3,6 +3,9 @@ databaseChangeLog:
       file: changesets/2026-06-02-oprm-nichocnae-routine-research-cycle.yaml
       relativeToChangelogFile: true
   - include:
+      file: changesets/2026-06-02-oprm-nichocnae-seed-builder.yaml
+      relativeToChangelogFile: true
+  - include:
       file: changesets/2026-06-01-pipeline-crud.yaml
       relativeToChangelogFile: true
   - include:

--- a/backend/ads-service/src/test/java/com/marketinghub/oprm/nichocnae/nicheresearchseedbuilder/service/BackendNicheResearchSeedBuilderServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/oprm/nichocnae/nicheresearchseedbuilder/service/BackendNicheResearchSeedBuilderServiceTest.java
@@ -1,0 +1,167 @@
+package com.marketinghub.oprm.nichocnae.nicheresearchseedbuilder.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.marketinghub.oprm.nichocnae.OprmNicheResearchSeed;
+import com.marketinghub.oprm.nichocnae.OprmResearchQuery;
+import com.marketinghub.oprm.nichocnae.OprmRoutineResearchCycle;
+import com.marketinghub.oprm.nichocnae.nicheresearchseedbuilder.service.completeStageExecution.CompleteNicheResearchSeedBuilderRequest;
+import com.marketinghub.oprm.nichocnae.nicheresearchseedbuilder.service.completeStageExecution.CompleteNicheResearchSeedBuilderResponse;
+import com.marketinghub.oprm.nichocnae.nicheresearchseedbuilder.service.completeStageExecution.NicheResearchQueryRequest;
+import com.marketinghub.oprm.nichocnae.nicheresearchseedbuilder.service.failStageExecution.FailNicheResearchSeedBuilderRequest;
+import com.marketinghub.repository.jpa.oprm.nichocnae.OprmNicheResearchSeedRepository;
+import com.marketinghub.repository.jpa.oprm.nichocnae.OprmResearchQueryRepository;
+import com.marketinghub.repository.jpa.oprm.nichocnae.OprmRoutineResearchCycleRepository;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Pageable;
+
+/** Valida a persistência do seed operacional e das queries da etapa dois do OPRM nichocnae. */
+@ExtendWith(MockitoExtension.class)
+class BackendNicheResearchSeedBuilderServiceTest {
+  @Mock private OprmRoutineResearchCycleRepository routineResearchCycleRepository;
+  @Mock private OprmNicheResearchSeedRepository nicheResearchSeedRepository;
+  @Mock private OprmResearchQueryRepository researchQueryRepository;
+
+  @InjectMocks private BackendNicheResearchSeedBuilderService service;
+
+  /** Deve listar apenas ciclos em execução que ainda não possuem seed gerado para a etapa dois. */
+  @Test
+  void listPendingUsesSeedBuilderRepositoryFilter() {
+    OprmRoutineResearchCycle cycle = cycle();
+    when(routineResearchCycleRepository.findSeedBuilderPendingByStatus(eq("RUNNING"), any(Pageable.class)))
+        .thenReturn(List.of(cycle));
+
+    var result = service.listPending();
+
+    assertThat(result).hasSize(1);
+    assertThat(result.getFirst().researchCycleId()).isEqualTo(1001L);
+    assertThat(result.getFirst().cnaeCode()).isEqualTo("9602501");
+  }
+
+  /** Deve gravar seed, queries pendentes e total de queries no ciclo quando o payload é válido. */
+  @Test
+  void completePersistsSeedQueriesAndCycleTotals() {
+    OprmRoutineResearchCycle cycle = cycle();
+    when(routineResearchCycleRepository.findById(1001L)).thenReturn(Optional.of(cycle));
+    when(nicheResearchSeedRepository.existsByResearchCycleId(1001L)).thenReturn(false);
+    when(nicheResearchSeedRepository.save(any(OprmNicheResearchSeed.class)))
+        .thenAnswer(invocation -> {
+          OprmNicheResearchSeed seed = invocation.getArgument(0);
+          seed.setId(44L);
+          return seed;
+        });
+    when(researchQueryRepository.saveAll(any()))
+        .thenAnswer(invocation -> {
+          @SuppressWarnings("unchecked")
+          List<OprmResearchQuery> queries = invocation.getArgument(0);
+          for (int i = 0; i < queries.size(); i++) {
+            queries.get(i).setId((long) i + 1);
+          }
+          return queries;
+        });
+
+    CompleteNicheResearchSeedBuilderResponse response = service.complete(1001L, validRequest());
+
+    assertThat(response.nicheResearchSeedId()).isEqualTo(44L);
+    assertThat(response.totalQueries()).isEqualTo(2);
+    assertThat(response.queries()).extracting("status").containsOnly("PENDING");
+    assertThat(response.queries()).extracting("resultCount").containsOnly(0);
+
+    ArgumentCaptor<OprmRoutineResearchCycle> cycleCaptor = ArgumentCaptor.forClass(OprmRoutineResearchCycle.class);
+    verify(routineResearchCycleRepository).save(cycleCaptor.capture());
+    assertThat(cycleCaptor.getValue().getTotalQueries()).isEqualTo(2);
+  }
+
+  /** Deve rejeitar payloads com mais de quinze queries para preservar o MVP documentado. */
+  @Test
+  void completeRejectsMoreThanFifteenQueries() {
+    OprmRoutineResearchCycle cycle = cycle();
+    when(routineResearchCycleRepository.findById(1001L)).thenReturn(Optional.of(cycle));
+    List<NicheResearchQueryRequest> manyQueries = java.util.stream.IntStream.rangeClosed(1, 16)
+        .mapToObj(index -> new NicheResearchQueryRequest(
+            "manicure rotina " + index, "ROUTINE_DISCOVERY", "web", index))
+        .toList();
+    CompleteNicheResearchSeedBuilderRequest request = new CompleteNicheResearchSeedBuilderRequest(
+        "Cabeleireiros, manicures e pedicures",
+        "serviço local de beleza",
+        "agenda e atendimento recorrente",
+        "consumidor final recorrente",
+        "manicure, pedicure, escova",
+        "depende de agenda cheia",
+        "INFERRED_FROM_CNAE",
+        "AI",
+        manyQueries);
+
+    assertThatThrownBy(() -> service.complete(1001L, request))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("between 1 and 15");
+    verify(nicheResearchSeedRepository, never()).save(any());
+  }
+
+  /** Deve marcar o ciclo como falho e registrar a mensagem operacional da falha da etapa dois. */
+  @Test
+  void failMarksCycleAsFailed() {
+    OprmRoutineResearchCycle cycle = cycle();
+    when(routineResearchCycleRepository.findById(1001L)).thenReturn(Optional.of(cycle));
+
+    service.fail(1001L, new FailNicheResearchSeedBuilderRequest("IA retornou queries genéricas."));
+
+    ArgumentCaptor<OprmRoutineResearchCycle> cycleCaptor = ArgumentCaptor.forClass(OprmRoutineResearchCycle.class);
+    verify(routineResearchCycleRepository).save(cycleCaptor.capture());
+    assertThat(cycleCaptor.getValue().getStatus()).isEqualTo("FAILED");
+    assertThat(cycleCaptor.getValue().getErrorMessage()).isEqualTo("IA retornou queries genéricas.");
+    assertThat(cycleCaptor.getValue().getFinishedAt()).isNotNull();
+  }
+
+  /** Monta um payload válido de etapa dois com dois objetivos de pesquisa distintos. */
+  private CompleteNicheResearchSeedBuilderRequest validRequest() {
+    return new CompleteNicheResearchSeedBuilderRequest(
+        "Cabeleireiros, manicures e pedicures",
+        "serviço local de beleza",
+        "agenda e atendimento recorrente",
+        "consumidor final recorrente",
+        "manicure, pedicure, escova",
+        "depende de agenda cheia",
+        "INFERRED_FROM_CNAE",
+        null,
+        List.of(
+            new NicheResearchQueryRequest("manicure responsabilidades rotina", "ROUTINE_DISCOVERY", "web", 1),
+            new NicheResearchQueryRequest("como lotar agenda de manicure", "SALES_PAIN_DISCOVERY", "web", 2)));
+  }
+
+  /** Monta um ciclo de pesquisa em execução usado pelos cenários da etapa dois. */
+  private OprmRoutineResearchCycle cycle() {
+    OprmRoutineResearchCycle cycle = new OprmRoutineResearchCycle();
+    cycle.setId(1001L);
+    cycle.setSourceNicheId(77L);
+    cycle.setCnaeCode("9602501");
+    cycle.setCnaeDescription("Cabeleireiros, manicure e pedicure");
+    cycle.setNicheName("Cabeleireiros, manicures e pedicures");
+    cycle.setSourceScore(new BigDecimal("91.50"));
+    cycle.setTriggerSource("AUTO_SCORE_QUEUE");
+    cycle.setStatus("RUNNING");
+    cycle.setTotalQueries(0);
+    cycle.setTotalSourceCandidates(0);
+    cycle.setTotalSourceSnapshots(0);
+    cycle.setTotalExtractedSignals(0);
+    cycle.setStartedAt(Instant.parse("2026-06-02T10:00:00Z"));
+    cycle.setCreatedAt(Instant.parse("2026-06-02T10:00:00Z"));
+    cycle.setUpdatedAt(Instant.parse("2026-06-02T10:00:00Z"));
+    return cycle;
+  }
+}

--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -228,3 +228,5 @@
 - A etapa lista ciclos pendentes no backend, chama a OpenAI Responses API com schema JSON estrito, valida seed e 12 a 15 queries específicas, persiste a conclusão no backend e registra falha operacional quando necessário.
 - Expostos endpoints manuais do coletor em `/api/oprm-mei/nichocnae/niche-research-seed-builder` para listar pendências, detalhar ciclo e processar pendentes.
 - Atualizada a documentação Swagger OPRM nichocnae com os contratos backend esperados para pending, complete, fail e detail da etapa dois.
+
+- 2026-06-02 00:00:00 (UTC): evoluído o backend do OPRM `oprm/nichocnae` com a etapa 2 `oprmNicheResearchSeedBuilder`, incluindo persistência das tabelas `oprm_niche_research_seed` e `oprm_research_query`, endpoints internos de pending/complete/fail, endpoint de detalhe operacional, validação de 1 a 15 queries com objetivos permitidos e atualização do Swagger `docs/swagger/oprm-nichocnae-swagger.yaml`.

--- a/docs/swagger/oprm-nichocnae-swagger.yaml
+++ b/docs/swagger/oprm-nichocnae-swagger.yaml
@@ -1,22 +1,20 @@
 openapi: 3.0.3
 info:
   title: OPRM Nicho CNAE Pipeline API
-  version: 0.1.0
+  version: 0.2.0
   description: Endpoints internos do backend para o pipeline OPRM de pesquisa de rotina por nicho CNAE.
 paths:
   /api/internal/oprm/nichocnae/routine-research-orchestrator/stage-executions/pending:
     get:
       summary: Lista o próximo nicho CNAE pendente para a etapa zero.
-      tags:
-        - OPRM Nicho CNAE
+      tags: [OPRM Nicho CNAE]
       responses:
         '200':
           description: Próximo nicho pendente, quando existir.
   /api/internal/oprm/nichocnae/routine-research-orchestrator/run-next:
     post:
       summary: Executa a etapa zero e abre o próximo ciclo de pesquisa de rotina.
-      tags:
-        - OPRM Nicho CNAE
+      tags: [OPRM Nicho CNAE]
       responses:
         '202':
           description: Ciclo criado e nicho marcado como em pesquisa.
@@ -25,38 +23,25 @@ paths:
   /api/internal/oprm/nichocnae/routine-research-cycle/stage-executions/pending:
     get:
       summary: Lista ciclos de pesquisa de rotina em execução para continuidade do pipeline.
-      tags:
-        - OPRM Nicho CNAE
+      tags: [OPRM Nicho CNAE]
       responses:
         '200':
           description: Ciclos em execução.
   /api/oprm/nichocnae/{sourceNicheId}/routine-research-cycle/stage-executions:
     get:
       summary: Lista ciclos de pesquisa de rotina por nicho CNAE de origem.
-      tags:
-        - OPRM Nicho CNAE
+      tags: [OPRM Nicho CNAE]
       parameters:
-        - name: sourceNicheId
-          in: path
-          required: true
-          schema:
-            type: integer
-            format: int64
+        - $ref: '#/components/parameters/SourceNicheId'
       responses:
         '200':
           description: Lista de ciclos vinculados ao nicho.
   /api/oprm/nichocnae/routine-research-cycle/stage-executions/{researchCycleId}:
     get:
       summary: Detalha um ciclo de pesquisa de rotina.
-      tags:
-        - OPRM Nicho CNAE
+      tags: [OPRM Nicho CNAE]
       parameters:
-        - name: researchCycleId
-          in: path
-          required: true
-          schema:
-            type: integer
-            format: int64
+        - $ref: '#/components/parameters/ResearchCycleId'
       responses:
         '200':
           description: Detalhe do ciclo.
@@ -64,53 +49,280 @@ paths:
   /api/internal/oprm/nichocnae/niche-research-seed-builder/stage-executions/pending:
     get:
       summary: Lista ciclos pendentes para geração do seed e queries da etapa dois.
-      tags:
-        - OPRM Nicho CNAE
+      tags: [OPRM Nicho CNAE]
       responses:
         '200':
           description: Ciclos em execução sem seed de pesquisa gerado.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/NicheResearchSeedBuilderPending'
   /api/internal/oprm/nichocnae/niche-research-seed-builder/stage-executions/{researchCycleId}/complete:
     post:
       summary: Persiste a saída validada da etapa dois com seed e queries.
-      tags:
-        - OPRM Nicho CNAE
+      tags: [OPRM Nicho CNAE]
       parameters:
-        - name: researchCycleId
-          in: path
-          required: true
-          schema:
-            type: integer
-            format: int64
+        - $ref: '#/components/parameters/ResearchCycleId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CompleteNicheResearchSeedBuilderRequest'
       responses:
         '200':
           description: Seed e queries gravados para o ciclo.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CompleteNicheResearchSeedBuilderResponse'
+        '400':
+          description: Payload inválido, query duplicada, objetivo não suportado ou mais de 15 queries.
+        '404':
+          description: Ciclo de pesquisa não encontrado.
   /api/internal/oprm/nichocnae/niche-research-seed-builder/stage-executions/{researchCycleId}/fail:
     post:
       summary: Registra falha operacional da etapa dois.
-      tags:
-        - OPRM Nicho CNAE
+      tags: [OPRM Nicho CNAE]
       parameters:
-        - name: researchCycleId
-          in: path
-          required: true
-          schema:
-            type: integer
-            format: int64
+        - $ref: '#/components/parameters/ResearchCycleId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/FailNicheResearchSeedBuilderRequest'
       responses:
         '204':
           description: Falha registrada.
+        '404':
+          description: Ciclo de pesquisa não encontrado.
   /api/oprm/nichocnae/niche-research-seed-builder/stage-executions/{researchCycleId}:
     get:
       summary: Detalha o seed e as queries gerados na etapa dois.
-      tags:
-        - OPRM Nicho CNAE
+      tags: [OPRM Nicho CNAE]
       parameters:
-        - name: researchCycleId
-          in: path
-          required: true
-          schema:
-            type: integer
-            format: int64
+        - $ref: '#/components/parameters/ResearchCycleId'
       responses:
         '200':
           description: Seed e queries do ciclo.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NicheResearchSeedBuilderDetailResponse'
+        '404':
+          description: Ciclo de pesquisa não encontrado.
+components:
+  parameters:
+    ResearchCycleId:
+      name: researchCycleId
+      in: path
+      required: true
+      schema:
+        type: integer
+        format: int64
+    SourceNicheId:
+      name: sourceNicheId
+      in: path
+      required: true
+      schema:
+        type: integer
+        format: int64
+  schemas:
+    NicheResearchSeedBuilderPending:
+      type: object
+      properties:
+        researchCycleId:
+          type: integer
+          format: int64
+        sourceNicheId:
+          type: integer
+          format: int64
+        cnaeCode:
+          type: string
+          example: '9602501'
+        cnaeDescription:
+          type: string
+          example: Cabeleireiros, manicure e pedicure
+        nicheName:
+          type: string
+          example: Cabeleireiros, manicures e pedicures
+        sourceScore:
+          type: number
+          format: double
+        status:
+          type: string
+          example: RUNNING
+        startedAt:
+          type: string
+          format: date-time
+        createdAt:
+          type: string
+          format: date-time
+    CompleteNicheResearchSeedBuilderRequest:
+      type: object
+      required:
+        - nicheName
+        - businessType
+        - operationType
+        - customerType
+        - commercialObjects
+        - initialAssumptions
+        - confidenceLevel
+        - queries
+      properties:
+        nicheName:
+          type: string
+          example: Cabeleireiros, manicures e pedicures
+        businessType:
+          type: string
+          example: serviço local de beleza
+        operationType:
+          type: string
+          example: atendimento com agenda, recorrência, indicação e relacionamento por WhatsApp
+        customerType:
+          type: string
+          example: consumidor final, principalmente clientes recorrentes
+        commercialObjects:
+          type: string
+          example: corte de cabelo, escova, manicure, pedicure, unhas em gel, pacotes de beleza
+        initialAssumptions:
+          type: string
+          example: O nicho depende de agenda cheia, recorrência, indicação e retenção de clientes.
+        confidenceLevel:
+          type: string
+          example: INFERRED_FROM_CNAE
+        createdBy:
+          type: string
+          default: AI
+        queries:
+          type: array
+          minItems: 1
+          maxItems: 15
+          items:
+            $ref: '#/components/schemas/NicheResearchQueryRequest'
+    NicheResearchQueryRequest:
+      type: object
+      required: [queryText, queryGoal]
+      properties:
+        queryText:
+          type: string
+          example: como lotar agenda de manicure
+        queryGoal:
+          type: string
+          enum:
+            - ROUTINE_DISCOVERY
+            - NICHE_OWNER_QUESTION_DISCOVERY
+            - FINAL_CUSTOMER_QUESTION_DISCOVERY
+            - SALES_PAIN_DISCOVERY
+            - PRODUCT_SERVICE_DISCOVERY
+            - OFFER_PATTERN_DISCOVERY
+            - LANGUAGE_DISCOVERY
+            - WORKAROUND_DISCOVERY
+            - MECHANISM_DISCOVERY
+        sourceGroup:
+          type: string
+          nullable: true
+          example: web_search
+        priority:
+          type: integer
+          default: 100
+    CompleteNicheResearchSeedBuilderResponse:
+      type: object
+      properties:
+        researchCycleId:
+          type: integer
+          format: int64
+        nicheResearchSeedId:
+          type: integer
+          format: int64
+        cnaeCode:
+          type: string
+        cnaeDescription:
+          type: string
+        nicheName:
+          type: string
+        businessType:
+          type: string
+        operationType:
+          type: string
+        customerType:
+          type: string
+        commercialObjects:
+          type: string
+        initialAssumptions:
+          type: string
+        confidenceLevel:
+          type: string
+        createdBy:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+        totalQueries:
+          type: integer
+        queries:
+          type: array
+          items:
+            $ref: '#/components/schemas/NicheResearchQueryResponse'
+    NicheResearchQueryResponse:
+      type: object
+      properties:
+        queryId:
+          type: integer
+          format: int64
+        researchCycleId:
+          type: integer
+          format: int64
+        nicheResearchSeedId:
+          type: integer
+          format: int64
+        queryText:
+          type: string
+        queryGoal:
+          type: string
+        sourceGroup:
+          type: string
+          nullable: true
+        priority:
+          type: integer
+        status:
+          type: string
+          example: PENDING
+        resultCount:
+          type: integer
+          example: 0
+        createdBy:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+    FailNicheResearchSeedBuilderRequest:
+      type: object
+      required: [errorMessage]
+      properties:
+        errorMessage:
+          type: string
+          example: IA retornou queries genéricas e fora do contrato da etapa dois.
+    NicheResearchSeedBuilderDetailResponse:
+      type: object
+      properties:
+        researchCycleId:
+          type: integer
+          format: int64
+        cycleStatus:
+          type: string
+        cycleTotalQueries:
+          type: integer
+        cycleErrorMessage:
+          type: string
+          nullable: true
+        seed:
+          allOf:
+            - $ref: '#/components/schemas/CompleteNicheResearchSeedBuilderResponse'
+          nullable: true


### PR DESCRIPTION
### Motivation
- Implementar a Etapa 2 do documento de pipeline `oprm/pipeline-pesquisa-rotina-nicho-implementacao.md` para transformar CNAE em seed de pesquisa e frases executáveis. 
- Fornecer borda backend clara para o Worker/collector (fila de pending → complete/fail → detail) e publicar os contratos no Swagger do módulo. 

### Description
- Adiciona entidades JPA `OprmNicheResearchSeed` e `OprmResearchQuery` e repositórios `OprmNicheResearchSeedRepository` e `OprmResearchQueryRepository` para persistir seed e queries. 
- Cria changelog Liquibase `changesets/2026-06-02-oprm-nichocnae-seed-builder.yaml` para criar as tabelas `oprm_niche_research_seed` e `oprm_research_query` (MySQL 5.7, `splitStatements: true`, `stripComments: true`). 
- Implementa `BackendNicheResearchSeedBuilderService` com APIs de negócio `listPending()`, `complete(researchCycleId, request)`, `fail(researchCycleId, request)` e `detail(researchCycleId)`, incluindo validações: campos obrigatórios, limite de `1..15` queries, objetivos permitidos, proibição de queries duplicadas, defaults (`status=PENDING`, `resultCount=0`, `priority` default `100`, `createdBy` default `AI`). 
- Expõe endpoints backend no controller `BackendNicheResearchSeedBuilderController` sob `/api` com rotas internas `.../niche-research-seed-builder/stage-executions/pending`, `.../{researchCycleId}/complete`, `.../{researchCycleId}/fail` e rota de detalhe pública `.../stage-executions/{researchCycleId}`; atualiza `docs/swagger/oprm-nichocnae-swagger.yaml` (versão `0.2.0`) com contratos request/response. 
- Adiciona consulta customizada no repositório de ciclos `findSeedBuilderPendingByStatus(...)` para retornar apenas ciclos `RUNNING` que ainda não possuem seed gerado. 

### Testing
- Executado o teste unitário de serviço específico com `../mvnw -Dtest=BackendNicheResearchSeedBuilderServiceTest test` (executado no módulo `ads-service`) e os 4 testes passaram com `BUILD SUCCESS`.
- Validação dos arquivos YAML/Swagger realizada com `ruby -e "require 'yaml'; ... YAML.load_file(...)"` e os arquivos `docs/swagger/oprm-nichocnae-swagger.yaml` e os changelogs Liquibase foram carregados com sucesso. 
- Tentativa de aplicar formatação com `../mvnw spotless:apply` falhou porque o plugin Spotless não está disponível/resolvido no build atual. 
- Tentativa de executar `./mvnw -pl ads-service -Dtest=... test` a partir do agregador inicialmente retornou erro por seleção de projeto no reactor (comando incorreto no contexto), e não foi usado para validação final.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f57c70f1883219e11e57e9436c5e2)