### PR TITLE
Remove obsolete landing-copy template-version test and update experiment log

### DIFF
--- a/ai-worker/src/test/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineOpenAiClientTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineOpenAiClientTest.java
@@ -963,42 +963,6 @@ class ExperimentPipelineOpenAiClientTest {
         assertThat(payload.get("model")).isEqualTo("gpt-5.1-codex");
     }
 
-    /** Confirma que o rastreio do template de copy reflete a versão atual do prompt carregado. */
-    @Test
-    void storesTemplateTraceInTrackedRequestBodyForLandingCopy() throws Exception {
-        AtomicReference<Map<String, Object>> payloadRef = new AtomicReference<>();
-        ExperimentPipelineOpenAiClient client = new ExperimentPipelineOpenAiClient(
-                WebClient.builder().exchangeFunction(capturePayloadExchange(payloadRef)),
-                MAPPER,
-                "test-key",
-                "http://openai");
-
-        ExperimentPipelineJobDto job = new ExperimentPipelineJobDto(
-                UUID.randomUUID(),
-                22L,
-                "landing-page-copy",
-                "gpt-5.2",
-                "prompt",
-                """
-                        {
-                          "model": "gpt-5.2",
-                          "input": [
-                            {"role": "user", "content": "Prompt da landing"}
-                          ]
-                        }
-                        """,
-                Instant.now());
-
-        ExperimentPipelineJobCompletionPayload completionPayload = client.generate(job);
-        Map<String, Object> trackedRequest = MAPPER.readValue(completionPayload.requestBodyJson(), new TypeReference<>() {});
-        @SuppressWarnings("unchecked")
-        Map<String, Object> templateTrace = (Map<String, Object>) trackedRequest.get("templateTrace");
-        assertThat(templateTrace)
-                .containsEntry("template_id", "landing-page-copy")
-                .containsEntry("template_version", "v4")
-                .containsEntry("artifact_target", "landingPageCopy")
-                .containsEntry("model", "gpt-5.2");
-    }
 
     @Test
     void stripsTemplateHeaderFromPromptSentToOpenAi() {

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -3135,3 +3135,11 @@
   - atualizado o prompt `landing-page-image-planning.md` para priorizar mockups funcionais, previews e provas visuais conforme a categoria do produto digital;
   - atualizado o prompt `landing-page-design-preset.md` para materializar a hierarquia comercial universal com destaque visual para hero, dor, mecanismo, prova, oferta e formulário;
   - atualizado o plano `docs/gera-landing/melhorias-qualidade-paginas-venda-produtos-digitais.md` para marcar o Passo 2 como executado.
+
+## 2026-06-03 — Remoção de teste obsoleto de rastreio de versão do template de landing copy
+
+- solicitação: excluir o teste `ExperimentPipelineOpenAiClientTest.storesTemplateTraceInTrackedRequestBodyForLandingCopy`, que falhava ao validar uma versão antiga do template de copy da landing.
+- causa-raiz/objetivo: o teste estava acoplado ao literal `template_version: v4`, enquanto o prompt atual `landing-page-copy.md` já declara `template_version: v5`; a validação deixou de representar uma regra útil de negócio e bloqueava a suíte por expectativa obsoleta.
+- registro do que foi feito:
+  - removido o método de teste obsoleto da suíte `ExperimentPipelineOpenAiClientTest`;
+  - mantidos os demais testes do cliente OpenAI do pipeline de experimentos sem alterar o comportamento de produção.


### PR DESCRIPTION
### Motivation
- The unit test `storesTemplateTraceInTrackedRequestBodyForLandingCopy` asserted an outdated `template_version` (v4) while the prompt moved to v5, making the test brittle and blocking the suite.

### Description
- Deleted the obsolete test method from `ExperimentPipelineOpenAiClientTest` and updated `docs/registros/experimentos.md` to document the removal and its rationale, without changing production behavior.

### Testing
- Ran the unit test suite with `./gradlew test` and the tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f76b38d1483219872486a5be3661e)