### PR TITLE
Add GeraLanding Quality Gate (landing-page-quality-review) with persistence and endpoints

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/Experiment.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/Experiment.java
@@ -218,6 +218,9 @@ public class Experiment {
     @Column(name = "html_geralanding", columnDefinition = "LONGTEXT")
     private String htmlGeraLanding;
 
+    @Column(name = "landing_page_quality_review", columnDefinition = "LONGTEXT")
+    private String landingPageQualityReview;
+
     @Column(name = "landing_page_deliverables", columnDefinition = "LONGTEXT")
     private String landingPageDeliverables;
 

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/dto/ExperimentDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/dto/ExperimentDto.java
@@ -37,6 +37,7 @@ public class ExperimentDto {
     private String landingPageImageAssets;
     private String landingPageDesignPreset;
     private String htmlGeraLanding;
+    private String landingPageQualityReview;
     private String landingPageDeliverables;
     private String landingPageHtml;
     private InstagramAccountDto instagramAccount;

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/ExperimentPipelineSection.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/ExperimentPipelineSection.java
@@ -2,6 +2,7 @@ package com.marketinghub.experiment.pipeline;
 
 import org.springframework.util.StringUtils;
 
+/** Define as seções canônicas e a precedência operacional do pipeline de experimento. */
 public enum ExperimentPipelineSection {
     CAMPAIGN_ANGLE("campaign-angle", null),
     AD_COPY("ad-copy", CAMPAIGN_ANGLE),
@@ -20,14 +21,17 @@ public enum ExperimentPipelineSection {
         this.predecessor = predecessor;
     }
 
+    /** Retorna o path canônico usado em rotas, prompts e persistência da seção. */
     public String path() {
         return path;
     }
 
+    /** Retorna a seção que deve estar concluída antes da seção atual. */
     public ExperimentPipelineSection predecessor() {
         return predecessor;
     }
 
+    /** Retorna a primeira seção sucessora direta quando existir. */
     public ExperimentPipelineSection successor() {
         for (ExperimentPipelineSection section : values()) {
             if (section.predecessor == this) {
@@ -37,6 +41,7 @@ public enum ExperimentPipelineSection {
         return null;
     }
 
+    /** Converte o path recebido pela API para a seção canônica correspondente. */
     public static ExperimentPipelineSection fromPath(String raw) {
         if (!StringUtils.hasText(raw)) {
             throw new IllegalArgumentException("Section is required");

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationService.java
@@ -868,6 +868,7 @@ public class ExperimentPipelineGenerationService {
         }
     }
 
+    /** Valida se a seção anterior obrigatória está preenchida antes de iniciar a próxima etapa. */
     private void validatePredecessor(Experiment experiment, ExperimentPipelineSection section) {
         ExperimentPipelineSection predecessor = section.predecessor();
         if (predecessor == null) {
@@ -1348,6 +1349,7 @@ public class ExperimentPipelineGenerationService {
         return firstNonBlank(completedJob.getResponseContent(), completedJob.getRawResponse());
     }
 
+    /** Persiste o conteúdo normalizado da seção atual no campo canônico correspondente do experimento. */
     private void applySectionContent(Experiment experiment,
                                      ExperimentPipelineSection section,
                                      String content) {
@@ -2725,6 +2727,7 @@ public class ExperimentPipelineGenerationService {
         }
     }
 
+    /** Retorna o schema JSON usado para validar a resposta estruturada da seção solicitada. */
     private Map<String, Object> sectionSchema(ExperimentPipelineSection section) {
         Map<String, Object> metadataSchema = experimentMetadataSchema();
         return switch (section) {

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/presetdesign/service/BackendPresetDesignService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/presetdesign/service/BackendPresetDesignService.java
@@ -8,6 +8,7 @@ import com.marketinghub.repository.jpa.experiment.ExperimentRepository;
 import com.marketinghub.geralanding.GeraLandingStageExecution;
 import com.marketinghub.repository.jpa.geralanding.GeraLandingStageExecutionRepository;
 import com.marketinghub.geralanding.presetdesign.provisorio.DesignPresetProvisionalHtmlAssembler;
+import com.marketinghub.geralanding.qualityreview.service.BackendQualityReviewService;
 import com.marketinghub.geralanding.presetdesign.service.detailStageExecution.RecordBackendPresetDesignDetalheDto;
 import com.marketinghub.geralanding.presetdesign.service.listStageExecutions.GeraLandingPresetDesignExecutionSummaryResponse;
 import com.marketinghub.geralanding.presetdesign.service.pending.RecordPresetDesignExperiment;
@@ -42,17 +43,20 @@ public class BackendPresetDesignService {
     private final GeraLandingStageExecutionRepository executionRepository;
     private final ObjectMapper objectMapper;
     private final DesignPresetProvisionalHtmlAssembler designPresetProvisionalHtmlAssembler;
+    private final BackendQualityReviewService qualityReviewService;
 
     /** Inicializa o serviço com os repositórios e montador necessários para consultar e finalizar execuções de design preset. */
     public BackendPresetDesignService(
             ExperimentRepository experimentRepository,
             GeraLandingStageExecutionRepository executionRepository,
             ObjectMapper objectMapper,
-            DesignPresetProvisionalHtmlAssembler designPresetProvisionalHtmlAssembler) {
+            DesignPresetProvisionalHtmlAssembler designPresetProvisionalHtmlAssembler,
+            BackendQualityReviewService qualityReviewService) {
         this.experimentRepository = experimentRepository;
         this.executionRepository = executionRepository;
         this.objectMapper = objectMapper;
         this.designPresetProvisionalHtmlAssembler = designPresetProvisionalHtmlAssembler;
+        this.qualityReviewService = qualityReviewService;
     }
 
 
@@ -236,6 +240,7 @@ public class BackendPresetDesignService {
             execution.setProvisionalHtml(htmlGeraLanding);
             executionRepository.save(execution);
             experimentRepository.save(experiment);
+            qualityReviewService.reviewAfterHtmlGeneration(experiment);
         }
     }
 

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/qualityreview/controller/BackendQualityReviewController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/qualityreview/controller/BackendQualityReviewController.java
@@ -1,0 +1,49 @@
+package com.marketinghub.geralanding.qualityreview.controller;
+
+import com.marketinghub.geralanding.qualityreview.service.BackendQualityReviewService;
+import com.marketinghub.geralanding.qualityreview.service.GeraLandingQualityReviewStartResponse;
+import com.marketinghub.geralanding.qualityreview.service.detailStageExecution.RecordBackendQualityReviewDetalheDto;
+import com.marketinghub.geralanding.qualityreview.service.listStageExecutions.GeraLandingQualityReviewExecutionSummaryResponse;
+import java.util.List;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+/** Responsável pelos endpoints da etapa Quality Gate da landing do GeraLanding. */
+@RestController
+@RequestMapping("/api")
+public class BackendQualityReviewController {
+
+    private final BackendQualityReviewService executionService;
+
+    /** Inicializa o controller com o serviço da etapa de revisão de qualidade. */
+    public BackendQualityReviewController(BackendQualityReviewService executionService) {
+        this.executionService = executionService;
+    }
+
+    /** Executa a revisão de qualidade da landing atual do experimento. */
+    @PostMapping("/experiments/{experimentId}/geralanding/quality-review/start")
+    public ResponseEntity<GeraLandingQualityReviewStartResponse> start(@PathVariable Long experimentId) {
+        return ResponseEntity.accepted().body(executionService.start(experimentId));
+    }
+
+    /** Lista as execuções da etapa de revisão de qualidade para o experimento. */
+    @GetMapping("/experiments/{experimentId}/geralanding/quality-review/stage-executions")
+    public ResponseEntity<List<GeraLandingQualityReviewExecutionSummaryResponse>> listStageExecutions(
+            @PathVariable Long experimentId,
+            @RequestParam(defaultValue = "true") boolean includeCompleted) {
+        return ResponseEntity.ok(executionService.listExperimentStageExecutions(experimentId, includeCompleted));
+    }
+
+    /** Retorna os detalhes de uma execução específica da revisão de qualidade. */
+    @GetMapping("/experiments/{experimentId}/geralanding/quality-review/stage-executions/{idJob}")
+    public ResponseEntity<RecordBackendQualityReviewDetalheDto> detailStageExecution(
+            @PathVariable Long experimentId,
+            @PathVariable String idJob) {
+        return ResponseEntity.ok(executionService.getStageExecutionDetail(experimentId, idJob));
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/qualityreview/service/BackendQualityReviewService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/qualityreview/service/BackendQualityReviewService.java
@@ -1,0 +1,315 @@
+package com.marketinghub.geralanding.qualityreview.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marketinghub.experiment.Experiment;
+import com.marketinghub.geralanding.GeraLandingStageExecution;
+import com.marketinghub.geralanding.qualityreview.service.detailStageExecution.RecordBackendQualityReviewDetalheDto;
+import com.marketinghub.geralanding.qualityreview.service.listStageExecutions.GeraLandingQualityReviewExecutionSummaryResponse;
+import com.marketinghub.repository.jpa.experiment.ExperimentRepository;
+import com.marketinghub.repository.jpa.geralanding.GeraLandingStageExecutionRepository;
+import jakarta.persistence.EntityNotFoundException;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+/** Responsável por executar e persistir o Quality Gate comercial da landing gerada. */
+@Service
+public class BackendQualityReviewService {
+
+    private static final Logger log = LoggerFactory.getLogger(BackendQualityReviewService.class);
+    private static final String STAGE_CODE = "landing-page-quality-review";
+    private static final String STATUS_COMPLETED = "CONCLUIDO";
+    private static final String STATUS_FAILED = "FALHA";
+    private static final int APPROVAL_SCORE = 80;
+
+    private final ExperimentRepository experimentRepository;
+    private final GeraLandingStageExecutionRepository executionRepository;
+    private final ObjectMapper objectMapper;
+
+    /** Inicializa o serviço com repositórios e serializador usados pela revisão de qualidade. */
+    public BackendQualityReviewService(
+            ExperimentRepository experimentRepository,
+            GeraLandingStageExecutionRepository executionRepository,
+            ObjectMapper objectMapper) {
+        this.experimentRepository = experimentRepository;
+        this.executionRepository = executionRepository;
+        this.objectMapper = objectMapper;
+    }
+
+    /** Cria uma execução síncrona do Quality Gate, avalia a landing atual e persiste o diagnóstico. */
+    @Transactional
+    public GeraLandingQualityReviewStartResponse start(Long experimentId) {
+        Experiment experiment = experimentRepository.findById(experimentId)
+                .orElseThrow(() -> new EntityNotFoundException("Experiment not found: " + experimentId));
+        GeraLandingStageExecution execution = createExecution(experiment, "manual/start");
+        return completeQualityReview(experiment, execution);
+    }
+
+    /** Executa automaticamente o Quality Gate após a montagem do HTML final do GeraLanding. */
+    @Transactional
+    public String reviewAfterHtmlGeneration(Experiment experiment) {
+        GeraLandingStageExecution execution = createExecution(experiment, "auto/html-geralanding");
+        return completeQualityReview(experiment, execution).qualityReview();
+    }
+
+    /** Lista execuções da etapa de revisão de qualidade para o experimento informado. */
+    @Transactional(readOnly = true)
+    public List<GeraLandingQualityReviewExecutionSummaryResponse> listExperimentStageExecutions(Long experimentId, boolean includeCompleted) {
+        List<GeraLandingStageExecution> executions = includeCompleted
+                ? executionRepository.findTop20ByExperimentIdAndStageCodeOrderByExecutionRequestedAtDesc(experimentId, STAGE_CODE)
+                : executionRepository.findTop20ByExperimentIdAndStageCodeAndStatusNotOrderByExecutionRequestedAtDesc(
+                        experimentId,
+                        STAGE_CODE,
+                        STATUS_COMPLETED);
+        return executions.stream()
+                .map(this::toSummaryResponse)
+                .toList();
+    }
+
+    /** Retorna o detalhe persistido de uma execução específica da revisão de qualidade. */
+    @Transactional(readOnly = true)
+    public RecordBackendQualityReviewDetalheDto getStageExecutionDetail(Long experimentId, String idJob) {
+        GeraLandingStageExecution execution = executionRepository
+                .findTopByExperimentIdAndIdJobOrderByExecutionRequestedAtDesc(experimentId, toDatabaseIdJob(idJob))
+                .orElseThrow(() -> new EntityNotFoundException("GeraLanding quality review execution not found for idJob: " + idJob));
+        return toDetailResponse(execution);
+    }
+
+    /** Cria o registro inicial da execução de Quality Gate com status preparado para conclusão síncrona. */
+    private GeraLandingStageExecution createExecution(Experiment experiment, String promptTemplateId) {
+        Instant now = Instant.now();
+        GeraLandingStageExecution execution = GeraLandingStageExecution.builder()
+                .experimentId(experiment.getId())
+                .experiment(experiment)
+                .stageCode(STAGE_CODE)
+                .executionRequestedAt(now)
+                .createdAt(now)
+                .processingStartedAt(now)
+                .promptTemplateId(promptTemplateId)
+                .promptContent("Quality Gate comercial automático da landing final.")
+                .status(STATUS_COMPLETED)
+                .idJob(toDatabaseIdJob(UUID.randomUUID().toString()))
+                .build();
+        return executionRepository.save(execution);
+    }
+
+    /** Avalia, serializa e grava o diagnóstico da landing no experimento e na execução. */
+    private GeraLandingQualityReviewStartResponse completeQualityReview(Experiment experiment, GeraLandingStageExecution execution) {
+        try {
+            String qualityReview = buildQualityReviewJson(experiment);
+            execution.setModelResponse(qualityReview);
+            execution.setProvisionalHtml(qualityReview);
+            execution.setCompletedAt(Instant.now());
+            execution.setStatus(STATUS_COMPLETED);
+            experiment.setLandingPageQualityReview(qualityReview);
+            experimentRepository.save(experiment);
+            executionRepository.save(execution);
+            return new GeraLandingQualityReviewStartResponse(fromDatabaseIdJob(execution.getIdJob()), execution.getStatus(), qualityReview);
+        } catch (RuntimeException ex) {
+            log.error(
+                    "Erro ao executar Quality Gate da landing. experimentId={}, idJob={}",
+                    experiment.getId(),
+                    fromDatabaseIdJob(execution.getIdJob()),
+                    ex);
+            execution.setCompletedAt(Instant.now());
+            execution.setStatus(STATUS_FAILED);
+            execution.setErrorMessage("Falha ao avaliar qualidade comercial da landing");
+            execution.setErrorDetail(ex.getMessage());
+            executionRepository.save(execution);
+            throw ex;
+        }
+    }
+
+    /** Monta o JSON de saída do Quality Gate com score, bloqueios e etapas recomendadas para regeneração. */
+    private String buildQualityReviewJson(Experiment experiment) {
+        ReviewAccumulator review = evaluate(experiment);
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("score", review.score());
+        payload.put("targetAudienceSpecificity", review.targetAudienceSpecificity());
+        payload.put("blockingIssues", review.blockingIssues());
+        payload.put("recommendedRegeneration", review.recommendedRegeneration());
+        payload.put("approvalRecommendation", review.score() >= APPROVAL_SCORE && review.blockingIssues().isEmpty()
+                ? "APPROVE_FOR_PUBLICATION"
+                : "REGENERATE_BEFORE_PUBLICATION");
+        return writeJson(payload);
+    }
+
+    /** Calcula penalidades objetivas usando os artefatos canônicos e o HTML final disponível. */
+    private ReviewAccumulator evaluate(Experiment experiment) {
+        int score = 100;
+        List<String> issues = new ArrayList<>();
+        List<String> regeneration = new ArrayList<>();
+        String html = normalizeText(firstText(experiment.getHtmlGeraLanding(), experiment.getLandingPageHtml()));
+        String copy = normalizeText(experiment.getLandingPageCopy());
+        String wireframe = normalizeText(experiment.getLandingPageWireframe());
+        String imagePlanning = normalizeText(experiment.getLandingPageImagePlanning());
+        String designPreset = normalizeText(experiment.getLandingPageDesignPreset());
+        String all = String.join(" ", html, copy, wireframe, imagePlanning, designPreset).toLowerCase(Locale.ROOT);
+
+        if (!StringUtils.hasText(html)) {
+            score -= 30;
+            addIssue(issues, regeneration, "A landing não possui HTML final para revisão publicável", "LANDING_PAGE_HTML");
+        }
+        if (!containsAny(all, "dor", "problema", "dificuldade", "frustração", "medo", "travado")) {
+            score -= 12;
+            addIssue(issues, regeneration, "A página não deixa explícita a dor específica que o produto remove", "LANDING_PAGE_COPY");
+        }
+        if (!containsAny(all, "resultado", "transformação", "benefício", "ganho", "clareza", "facilidade")) {
+            score -= 12;
+            addIssue(issues, regeneration, "A primeira dobra e a copy não vendem claramente a transformação principal", "LANDING_PAGE_COPY");
+        }
+        if (!containsAny(all, "mecanismo", "método", "processo", "passo", "roteiro", "diagnóstico", "plano")) {
+            score -= 10;
+            addIssue(issues, regeneration, "O mecanismo de entrega não está plausível ou não foi explicado em passos concretos", "LANDING_PAGE_WIREFRAME");
+        }
+        if (!containsAny(all, "preview", "exemplo", "amostra", "antes", "depois", "mockup", "relatório", "checklist")) {
+            score -= 14;
+            addIssue(issues, regeneration, "A prova visual é genérica ou não demonstra a entrega aplicada", "LANDING_PAGE_IMAGE_PLANNING");
+        }
+        if (!containsAny(all, "receba", "começar", "quero", "acessar", "preencher", "solicitar", "garantir")) {
+            score -= 10;
+            addIssue(issues, regeneration, "O CTA não orienta o avanço do usuário com benefício imediato", "LANDING_PAGE_COPY");
+        }
+        if (!containsAny(html.toLowerCase(Locale.ROOT), "<form", "type=\"email\"", "name=\"email\"", "data-field=\"email\"")) {
+            score -= 10;
+            addIssue(issues, regeneration, "O formulário não está evidente como ponto principal de conversão", "LANDING_PAGE_DESIGN_PRESET");
+        }
+        if (containsAny(html.toLowerCase(Locale.ROOT), "<!-- auto:", "debuginfo", "legacypreviewhtml", "rendermode")) {
+            score -= 20;
+            addIssue(issues, regeneration, "O HTML final contém metadado técnico proibido no artefato publicável", "LANDING_PAGE_HTML");
+        }
+
+        return new ReviewAccumulator(Math.max(0, score), resolveSpecificity(all), List.copyOf(issues), List.copyOf(regeneration));
+    }
+
+    /** Adiciona problema e etapa recomendada sem duplicar valores na saída final. */
+    private void addIssue(List<String> issues, List<String> regeneration, String issue, String stage) {
+        if (!issues.contains(issue)) {
+            issues.add(issue);
+        }
+        if (!regeneration.contains(stage)) {
+            regeneration.add(stage);
+        }
+    }
+
+    /** Classifica especificidade de público por sinais textuais de nicho, persona e contexto operacional. */
+    private String resolveSpecificity(String text) {
+        int signals = 0;
+        signals += containsAny(text, "para ", "profissional", "cliente", "negócio", "rotina") ? 1 : 0;
+        signals += containsAny(text, "mei", "empresa", "equipe", "paciente", "aluno", "lead") ? 1 : 0;
+        signals += containsAny(text, "quando", "sem precisar", "mesmo que", "em minutos", "passo a passo") ? 1 : 0;
+        if (signals >= 3) {
+            return "high";
+        }
+        if (signals == 2) {
+            return "medium";
+        }
+        return "low";
+    }
+
+    /** Verifica se o texto contém pelo menos uma das opções informadas. */
+    private boolean containsAny(String text, String... candidates) {
+        if (!StringUtils.hasText(text)) {
+            return false;
+        }
+        for (String candidate : candidates) {
+            if (text.contains(candidate)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /** Retorna o primeiro texto preenchido entre valores candidatos. */
+    private String firstText(String... values) {
+        for (String value : values) {
+            if (StringUtils.hasText(value)) {
+                return value;
+            }
+        }
+        return "";
+    }
+
+    /** Normaliza texto nulo para vazio, preservando conteúdo para análise textual. */
+    private String normalizeText(String value) {
+        return value != null ? value : "";
+    }
+
+    /** Serializa a saída estruturada do Quality Gate em JSON. */
+    private String writeJson(Map<String, Object> payload) {
+        try {
+            return objectMapper.writeValueAsString(payload);
+        } catch (JsonProcessingException ex) {
+            throw new IllegalStateException("Não foi possível serializar Quality Gate da landing", ex);
+        }
+    }
+
+    /** Converte o resumo persistido para o DTO público da etapa. */
+    private GeraLandingQualityReviewExecutionSummaryResponse toSummaryResponse(GeraLandingStageExecution execution) {
+        return new GeraLandingQualityReviewExecutionSummaryResponse(
+                fromDatabaseIdJob(execution.getIdJob()),
+                execution.getStatus(),
+                execution.getExecutionRequestedAt(),
+                execution.getCostUsd());
+    }
+
+    /** Converte a execução persistida para o detalhe público da etapa. */
+    private RecordBackendQualityReviewDetalheDto toDetailResponse(GeraLandingStageExecution execution) {
+        return new RecordBackendQualityReviewDetalheDto(
+                fromDatabaseIdJob(execution.getIdJob()),
+                execution.getExperimentId(),
+                execution.getStageCode(),
+                execution.getExecutionRequestedAt(),
+                execution.getCreatedAt(),
+                execution.getProcessingStartedAt(),
+                execution.getCompletedAt(),
+                execution.getPromptTemplateId(),
+                execution.getPromptContent(),
+                execution.getPrompt(),
+                execution.getOpenAiRequestBody(),
+                execution.getOpenAiModel(),
+                execution.getSchemaJson(),
+                execution.getPromptMarkdownContent(),
+                execution.getStatus(),
+                execution.getOpenAiJobId(),
+                execution.getModelResponse(),
+                execution.getProvisionalHtml(),
+                execution.getErrorMessage(),
+                execution.getErrorDetail(),
+                execution.getInputTokens(),
+                execution.getOutputTokens(),
+                execution.getCostUsd());
+    }
+
+    /** Converte o id_job textual para o formato persistido em banco. */
+    private byte[] toDatabaseIdJob(String idJob) {
+        return idJob.getBytes(StandardCharsets.UTF_8);
+    }
+
+    /** Converte o id_job persistido em banco para texto. */
+    private String fromDatabaseIdJob(byte[] idJob) {
+        return new String(idJob, StandardCharsets.UTF_8);
+    }
+
+    /** Representa o resultado intermediário calculado antes da serialização JSON. */
+    private record ReviewAccumulator(
+            int score,
+            String targetAudienceSpecificity,
+            List<String> blockingIssues,
+            List<String> recommendedRegeneration
+    ) {
+        /** Mantém o contrato interno imutável do acumulador de revisão. */
+        private ReviewAccumulator {}
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/qualityreview/service/GeraLandingQualityReviewStartResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/qualityreview/service/GeraLandingQualityReviewStartResponse.java
@@ -1,0 +1,11 @@
+package com.marketinghub.geralanding.qualityreview.service;
+
+/** Resposta do início síncrono da etapa de revisão de qualidade da landing. */
+public record GeraLandingQualityReviewStartResponse(
+        String idJob,
+        String status,
+        String qualityReview
+) {
+    /** Mantém o contrato imutável da resposta da etapa. */
+    public GeraLandingQualityReviewStartResponse {}
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/qualityreview/service/detailStageExecution/RecordBackendQualityReviewDetalheDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/qualityreview/service/detailStageExecution/RecordBackendQualityReviewDetalheDto.java
@@ -1,0 +1,34 @@
+package com.marketinghub.geralanding.qualityreview.service.detailStageExecution;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+
+/** Detalhe completo de uma execução da revisão de qualidade da landing. */
+public record RecordBackendQualityReviewDetalheDto(
+        String idJob,
+        Long experimentId,
+        String stageCode,
+        Instant executionRequestedAt,
+        Instant createdAt,
+        Instant processingStartedAt,
+        Instant completedAt,
+        String promptTemplateId,
+        String promptContent,
+        String prompt,
+        String openAiRequestBody,
+        String openAiModel,
+        String schemaJson,
+        String promptMarkdownContent,
+        String status,
+        String openAiJobId,
+        String modelResponse,
+        String provisionalHtml,
+        String errorMessage,
+        String errorDetail,
+        Integer inputTokens,
+        Integer outputTokens,
+        BigDecimal costUsd
+) {
+    /** Mantém o contrato imutável do detalhe de execução. */
+    public RecordBackendQualityReviewDetalheDto {}
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/qualityreview/service/listStageExecutions/GeraLandingQualityReviewExecutionSummaryResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/qualityreview/service/listStageExecutions/GeraLandingQualityReviewExecutionSummaryResponse.java
@@ -1,0 +1,15 @@
+package com.marketinghub.geralanding.qualityreview.service.listStageExecutions;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+
+/** Resumo de uma execução da revisão de qualidade da landing. */
+public record GeraLandingQualityReviewExecutionSummaryResponse(
+        String idJob,
+        String status,
+        Instant executionRequestedAt,
+        BigDecimal costUsd
+) {
+    /** Mantém o contrato imutável do resumo de execução. */
+    public GeraLandingQualityReviewExecutionSummaryResponse {}
+}

--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-03-experiment-landing-quality-review.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-03-experiment-landing-quality-review.yaml
@@ -1,0 +1,25 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-06-03-experiment-landing-quality-review
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - onError: HALT
+        - dbms:
+            type: mysql
+        - sqlCheck:
+            expectedResult: "0"
+            sql: |
+              SELECT COUNT(*)
+              FROM information_schema.COLUMNS
+              WHERE TABLE_SCHEMA = DATABASE()
+                AND TABLE_NAME = 'experiment'
+                AND COLUMN_NAME = 'landing_page_quality_review'
+      changes:
+        - sql:
+            splitStatements: true
+            stripComments: true
+            sql: |
+              ALTER TABLE experiment
+                ADD COLUMN landing_page_quality_review LONGTEXT NULL
+                AFTER html_geralanding;

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -1,5 +1,8 @@
 databaseChangeLog:
   - include:
+      file: changesets/2026-06-03-experiment-landing-quality-review.yaml
+      relativeToChangelogFile: true
+  - include:
       file: changesets/2026-06-02-oprm-nichocnae-source-fetcher.yaml
       relativeToChangelogFile: true
   - include:

--- a/backend/ads-service/src/test/java/com/marketinghub/geralanding/presetdesign/service/BackendPresetDesignServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/geralanding/presetdesign/service/BackendPresetDesignServiceTest.java
@@ -17,6 +17,7 @@ import com.marketinghub.repository.jpa.experiment.ExperimentRepository;
 import com.marketinghub.geralanding.GeraLandingStageExecution;
 import com.marketinghub.repository.jpa.geralanding.GeraLandingStageExecutionRepository;
 import com.marketinghub.geralanding.presetdesign.provisorio.DesignPresetProvisionalHtmlAssembler;
+import com.marketinghub.geralanding.qualityreview.service.BackendQualityReviewService;
 import com.marketinghub.geralanding.presetdesign.service.detailStageExecution.RecordBackendPresetDesignDetalheDto;
 import com.marketinghub.geralanding.presetdesign.service.listStageExecutions.GeraLandingPresetDesignExecutionSummaryResponse;
 import com.marketinghub.geralanding.presetdesign.service.pending.RecordPresetDesignPending;
@@ -37,7 +38,7 @@ class BackendPresetDesignServiceTest {
         ExperimentRepository experimentRepository = mock(ExperimentRepository.class);
         GeraLandingStageExecutionRepository executionRepository = mock(GeraLandingStageExecutionRepository.class);
         BackendPresetDesignService service =
-                new BackendPresetDesignService(experimentRepository, executionRepository, new ObjectMapper(), mock(DesignPresetProvisionalHtmlAssembler.class));
+                new BackendPresetDesignService(experimentRepository, executionRepository, new ObjectMapper(), mock(DesignPresetProvisionalHtmlAssembler.class), mock(BackendQualityReviewService.class));
         Experiment experiment = mock(Experiment.class);
         when(experiment.getId()).thenReturn(91L);
         when(experimentRepository.findById(91L)).thenReturn(Optional.of(experiment));
@@ -64,7 +65,7 @@ class BackendPresetDesignServiceTest {
         ExperimentRepository experimentRepository = mock(ExperimentRepository.class);
         GeraLandingStageExecutionRepository executionRepository = mock(GeraLandingStageExecutionRepository.class);
         BackendPresetDesignService service =
-                new BackendPresetDesignService(experimentRepository, executionRepository, new ObjectMapper(), mock(DesignPresetProvisionalHtmlAssembler.class));
+                new BackendPresetDesignService(experimentRepository, executionRepository, new ObjectMapper(), mock(DesignPresetProvisionalHtmlAssembler.class), mock(BackendQualityReviewService.class));
         Experiment experiment = mock(Experiment.class);
         when(experiment.getId()).thenReturn(77L);
         when(experiment.getName()).thenReturn("Experimento DesignPreset");
@@ -125,7 +126,7 @@ class BackendPresetDesignServiceTest {
         ExperimentRepository experimentRepository = mock(ExperimentRepository.class);
         GeraLandingStageExecutionRepository executionRepository = mock(GeraLandingStageExecutionRepository.class);
         BackendPresetDesignService service =
-                new BackendPresetDesignService(experimentRepository, executionRepository, new ObjectMapper(), mock(DesignPresetProvisionalHtmlAssembler.class));
+                new BackendPresetDesignService(experimentRepository, executionRepository, new ObjectMapper(), mock(DesignPresetProvisionalHtmlAssembler.class), mock(BackendQualityReviewService.class));
         GeraLandingStageExecution execution = GeraLandingStageExecution.builder()
                 .idJob("job-design-preset".getBytes(StandardCharsets.UTF_8))
                 .status("INICIADO")
@@ -150,8 +151,9 @@ class BackendPresetDesignServiceTest {
         ExperimentRepository experimentRepository = mock(ExperimentRepository.class);
         GeraLandingStageExecutionRepository executionRepository = mock(GeraLandingStageExecutionRepository.class);
         DesignPresetProvisionalHtmlAssembler htmlAssembler = mock(DesignPresetProvisionalHtmlAssembler.class);
+        BackendQualityReviewService qualityReviewService = mock(BackendQualityReviewService.class);
         BackendPresetDesignService service =
-                new BackendPresetDesignService(experimentRepository, executionRepository, new ObjectMapper(), htmlAssembler);
+                new BackendPresetDesignService(experimentRepository, executionRepository, new ObjectMapper(), htmlAssembler, qualityReviewService);
         Experiment experiment = mock(Experiment.class);
         when(experiment.getLandingPageWireframe()).thenReturn("{\"landingPageWireframe\":{}}");
         when(experiment.getLandingPageCopy()).thenReturn("{\"landingPageCopy\":{}}");
@@ -191,6 +193,7 @@ class BackendPresetDesignServiceTest {
         verify(experiment).setHtmlGeraLanding("<html>GeraLanding Design Preset</html>");
         assertEquals("<html>GeraLanding Design Preset</html>", execution.getProvisionalHtml());
         verify(experimentRepository, times(2)).save(experiment);
+        verify(qualityReviewService).reviewAfterHtmlGeneration(experiment);
     }
 
     /** Deve marcar falha sem sobrescrever o artefato final de design preset no experimento. */
@@ -199,7 +202,7 @@ class BackendPresetDesignServiceTest {
         ExperimentRepository experimentRepository = mock(ExperimentRepository.class);
         GeraLandingStageExecutionRepository executionRepository = mock(GeraLandingStageExecutionRepository.class);
         BackendPresetDesignService service =
-                new BackendPresetDesignService(experimentRepository, executionRepository, new ObjectMapper(), mock(DesignPresetProvisionalHtmlAssembler.class));
+                new BackendPresetDesignService(experimentRepository, executionRepository, new ObjectMapper(), mock(DesignPresetProvisionalHtmlAssembler.class), mock(BackendQualityReviewService.class));
         Experiment experiment = mock(Experiment.class);
         GeraLandingStageExecution execution = GeraLandingStageExecution.builder()
                 .experimentId(88L)

--- a/backend/ads-service/src/test/java/com/marketinghub/geralanding/qualityreview/service/BackendQualityReviewServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/geralanding/qualityreview/service/BackendQualityReviewServiceTest.java
@@ -1,0 +1,105 @@
+package com.marketinghub.geralanding.qualityreview.service;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.argThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marketinghub.experiment.Experiment;
+import com.marketinghub.geralanding.GeraLandingStageExecution;
+import com.marketinghub.repository.jpa.experiment.ExperimentRepository;
+import com.marketinghub.repository.jpa.geralanding.GeraLandingStageExecutionRepository;
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+/** Valida a execução determinística do Quality Gate da landing gerada. */
+class BackendQualityReviewServiceTest {
+
+    /** Deve aprovar uma landing com sinais comerciais completos e persistir o diagnóstico no experimento. */
+    @Test
+    void startShouldPersistApprovedQualityReviewWhenLandingHasCommercialSignals() throws Exception {
+        ExperimentRepository experimentRepository = mock(ExperimentRepository.class);
+        GeraLandingStageExecutionRepository executionRepository = mock(GeraLandingStageExecutionRepository.class);
+        ObjectMapper objectMapper = new ObjectMapper();
+        BackendQualityReviewService service = new BackendQualityReviewService(experimentRepository, executionRepository, objectMapper);
+        Experiment experiment = mock(Experiment.class);
+        when(experiment.getId()).thenReturn(36L);
+        when(experiment.getHtmlGeraLanding()).thenReturn("""
+                <html><body><section>Para profissional MEI, remova a dor da rotina e conquiste resultado com transformação clara.</section>
+                <section>Nosso método em passo a passo entrega diagnóstico, plano e checklist com preview antes e depois.</section>
+                <form><input type=\"email\" name=\"email\"><button>Quero receber meu plano</button></form></body></html>
+                """);
+        when(experiment.getLandingPageCopy()).thenReturn("Dor, resultado, mecanismo, prova e oferta para cliente específico.");
+        when(experimentRepository.findById(36L)).thenReturn(Optional.of(experiment));
+        when(executionRepository.save(any(GeraLandingStageExecution.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        GeraLandingQualityReviewStartResponse response = service.start(36L);
+
+        JsonNode review = objectMapper.readTree(response.qualityReview());
+        assertEquals("CONCLUIDO", response.status());
+        assertEquals("APPROVE_FOR_PUBLICATION", review.get("approvalRecommendation").asText());
+        assertTrue(review.get("score").asInt() >= 80);
+        verify(experiment).setLandingPageQualityReview(response.qualityReview());
+        verify(executionRepository, times(2)).save(argThat(execution ->
+                execution.getStageCode().equals("landing-page-quality-review")
+                        && execution.getStatus().equals("CONCLUIDO")
+                        && execution.getIdJob() != null));
+    }
+
+    /** Deve bloquear uma landing fraca e recomendar explicitamente as etapas de regeneração necessárias. */
+    @Test
+    void reviewAfterHtmlGenerationShouldRecommendRegenerationForWeakLanding() throws Exception {
+        ExperimentRepository experimentRepository = mock(ExperimentRepository.class);
+        GeraLandingStageExecutionRepository executionRepository = mock(GeraLandingStageExecutionRepository.class);
+        ObjectMapper objectMapper = new ObjectMapper();
+        BackendQualityReviewService service = new BackendQualityReviewService(experimentRepository, executionRepository, objectMapper);
+        Experiment experiment = mock(Experiment.class);
+        when(experiment.getId()).thenReturn(37L);
+        when(experiment.getHtmlGeraLanding()).thenReturn("<html><body><h1>Material digital</h1><!-- AUTO: debug --></body></html>");
+        when(executionRepository.save(any(GeraLandingStageExecution.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        String qualityReview = service.reviewAfterHtmlGeneration(experiment);
+
+        JsonNode review = objectMapper.readTree(qualityReview);
+        assertEquals("REGENERATE_BEFORE_PUBLICATION", review.get("approvalRecommendation").asText());
+        assertTrue(review.get("score").asInt() < 80);
+        assertTrue(review.get("blockingIssues").toString().contains("metadado técnico"));
+        assertTrue(review.get("recommendedRegeneration").toString().contains("LANDING_PAGE_COPY"));
+        assertTrue(review.get("recommendedRegeneration").toString().contains("LANDING_PAGE_HTML"));
+        verify(experiment).setLandingPageQualityReview(qualityReview);
+    }
+
+    /** Deve retornar detalhes de execução já persistidos usando o id textual do job. */
+    @Test
+    void getStageExecutionDetailShouldReturnPersistedQualityReviewExecution() {
+        ExperimentRepository experimentRepository = mock(ExperimentRepository.class);
+        GeraLandingStageExecutionRepository executionRepository = mock(GeraLandingStageExecutionRepository.class);
+        BackendQualityReviewService service = new BackendQualityReviewService(experimentRepository, executionRepository, new ObjectMapper());
+        GeraLandingStageExecution execution = GeraLandingStageExecution.builder()
+                .experimentId(38L)
+                .stageCode("landing-page-quality-review")
+                .status("CONCLUIDO")
+                .idJob("job-quality".getBytes(StandardCharsets.UTF_8))
+                .modelResponse("{\"score\":90}")
+                .build();
+        when(executionRepository.findTopByExperimentIdAndIdJobOrderByExecutionRequestedAtDesc(
+                38L,
+                "job-quality".getBytes(StandardCharsets.UTF_8)))
+                .thenReturn(Optional.of(execution));
+
+        var detail = service.getStageExecutionDetail(38L, "job-quality");
+
+        assertEquals("job-quality", detail.idJob());
+        assertEquals("landing-page-quality-review", detail.stageCode());
+        assertEquals("{\"score\":90}", detail.modelResponse());
+    }
+}

--- a/docs/gera-landing/melhorias-qualidade-paginas-venda-produtos-digitais.md
+++ b/docs/gera-landing/melhorias-qualidade-paginas-venda-produtos-digitais.md
@@ -222,10 +222,20 @@ Entregável do Passo 2:
 
 ### Passo 3 — Criar o Quality Gate
 
+**Status: executado em 2026-06-03.**
+
 - Definir schema de avaliação da landing.
 - Implementar a etapa `LANDING_PAGE_QUALITY_REVIEW` ou validação equivalente.
 - Persistir score, diagnóstico, bloqueios e recomendações.
 - Recomendar explicitamente quais etapas devem ser reexecutadas.
+
+Entregável do Passo 3:
+
+- criada a validação equivalente `landing-page-quality-review` dentro do módulo backend `geralanding.qualityreview`, como Quality Gate comercial após o HTML final;
+- persistência adicionada em `experiment.landing_page_quality_review` e nas execuções da etapa em `gera_landing_stage_execution`;
+- saída padronizada com `score`, `targetAudienceSpecificity`, `blockingIssues`, `recommendedRegeneration` e `approvalRecommendation`;
+- execução automática após a montagem do `htmlGeraLanding` e endpoint manual próprio do GeraLanding para reavaliar a landing;
+- recomendações de regeneração passaram a apontar explicitamente `LANDING_PAGE_COPY`, `LANDING_PAGE_IMAGE_PLANNING`, `LANDING_PAGE_DESIGN_PRESET`, `LANDING_PAGE_HTML` ou etapas correlatas conforme o bloqueio encontrado.
 
 ### Passo 4 — Exibir diagnóstico na interface administrativa
 

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -3143,3 +3143,11 @@
 - registro do que foi feito:
   - removido o método de teste obsoleto da suíte `ExperimentPipelineOpenAiClientTest`;
   - mantidos os demais testes do cliente OpenAI do pipeline de experimentos sem alterar o comportamento de produção.
+
+## 2026-06-03 — Quality Gate automático do GeraLanding
+- solicitação: executar o Passo 3 do plano de melhorias de qualidade de páginas de venda de produtos digitais, criando o Quality Gate da landing.
+- causa-raiz/objetivo: após o HTML final do GeraLanding, faltava uma validação persistida para medir qualidade comercial, bloquear publicações fracas e apontar quais etapas precisam ser reexecutadas.
+- foi feito: criada a etapa `landing-page-quality-review`, com schema JSON persistido em `experiment.landing_page_quality_review` e em `gera_landing_stage_execution.model_response`, contendo `score`, `targetAudienceSpecificity`, `blockingIssues`, `recommendedRegeneration` e `approvalRecommendation`.
+- integração: o Quality Gate passou a ser executado automaticamente após a montagem do `htmlGeraLanding` na conclusão do design preset, além de expor endpoint manual em `/api/experiments/{experimentId}/geralanding/quality-review/start`.
+- governança: a etapa ficou isolada no pacote backend `geralanding.qualityreview`, sem acoplar a revisão ao pipeline legado de experimento; o contrato público foi documentado no Swagger do GeraLanding.
+- testes: adicionados testes unitários cobrindo aprovação, bloqueio com recomendações de regeneração e consulta de detalhe da execução.

--- a/docs/swagger/geralanding-backend-swagger.v1.yaml
+++ b/docs/swagger/geralanding-backend-swagger.v1.yaml
@@ -1,17 +1,18 @@
 openapi: 3.0.3
 info:
   title: Marketing Hub Backend - GeraLanding API
-  version: v1.2.0
+  version: v1.3.0
   description: |
     Contrato canônico dos endpoints HTTP implementados no backend `ads-service`
     para o módulo GeraLanding.
 
-    Fonte de verdade revisada em código em 2026-06-02:
+    Fonte de verdade revisada em código em 2026-06-03:
     - `backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/web/BackendWireframeController.java`
     - `backend/ads-service/src/main/java/com/marketinghub/geralanding/copy/web/GeraLandingCopyController.java`
     - `backend/ads-service/src/main/java/com/marketinghub/geralanding/imageplanning/web/GeraLandingImagePlanningController.java`
     - `backend/ads-service/src/main/java/com/marketinghub/geralanding/imagegeneration/web/BackendImageGenerationController.java`
     - `backend/ads-service/src/main/java/com/marketinghub/geralanding/presetdesign/web/BackendPresetDesignController.java`
+    - `backend/ads-service/src/main/java/com/marketinghub/geralanding/qualityreview/controller/BackendQualityReviewController.java`
     - `backend/ads-service/src/main/java/com/marketinghub/geralanding/deliverables/web/GeraLandingDeliverablesController.java`
     - `backend/ads-service/src/main/java/com/marketinghub/geralanding/publiclanding/web/BackendPublicLandingController.java`
 
@@ -34,6 +35,8 @@ tags:
     description: Etapa de geração dos assets de imagem.
   - name: landing-page-design-preset
     description: Etapa de preset visual da landing.
+  - name: landing-page-quality-review
+    description: Quality Gate comercial da landing gerada.
   - name: landing-page-deliverables
     description: Etapa de empacotamento dos entregáveis da landing.
   - name: landing-page-publication
@@ -609,6 +612,48 @@ paths:
           description: HTML da landing ainda não foi gerado.
         '502':
           description: Lead Portal indisponível ou base URL não configurada.
+  /api/experiments/{experimentId}/geralanding/quality-review/start:
+    post:
+      tags: [landing-page-quality-review]
+      summary: Executa manualmente o Quality Gate comercial da landing atual.
+      operationId: startGeraLandingQualityReviewExecution
+      parameters:
+        - $ref: '#/components/parameters/ExperimentId'
+      responses:
+        '202':
+          description: Revisão de qualidade executada e persistida.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/QualityReviewStartResponse'
+        '404':
+          description: Experimento não encontrado.
+  /api/experiments/{experimentId}/geralanding/quality-review/stage-executions:
+    get:
+      tags: [landing-page-quality-review]
+      summary: Lista execuções da etapa landing-page-quality-review.
+      operationId: listGeraLandingQualityReviewExecutions
+      parameters:
+        - $ref: '#/components/parameters/ExperimentId'
+        - $ref: '#/components/parameters/IncludeCompleted'
+      responses:
+        '200':
+          $ref: '#/components/responses/StageExecutionSummaryList'
+        '404':
+          description: Experimento não encontrado.
+  /api/experiments/{experimentId}/geralanding/quality-review/stage-executions/{idJob}:
+    get:
+      tags: [landing-page-quality-review]
+      summary: Detalha uma execução da etapa landing-page-quality-review.
+      operationId: detailGeraLandingQualityReviewExecution
+      parameters:
+        - $ref: '#/components/parameters/ExperimentId'
+        - $ref: '#/components/parameters/IdJob'
+      responses:
+        '200':
+          $ref: '#/components/responses/StageExecutionDetail'
+        '404':
+          description: Experimento ou execução não encontrada.
   /api/experiments/{experimentId}/geralanding/landing/approve-and-publish:
     post:
       tags: [landing-page-publication]
@@ -798,6 +843,17 @@ components:
       required:
         - idJob
         - status
+    QualityReviewStartResponse:
+      allOf:
+        - $ref: '#/components/schemas/StageStartResponse'
+        - type: object
+          additionalProperties: false
+          properties:
+            qualityReview:
+              type: string
+              description: JSON serializado com score, bloqueios e recomendações de regeneração.
+          required:
+            - qualityReview
     StageExecutionSummary:
       type: object
       additionalProperties: false


### PR DESCRIPTION
### Motivation
- Introduce an automated Quality Gate to evaluate the commercial quality of generated landing pages and persist a structured diagnosis to prevent publishing weak pages.
- Surface a programmatic contract and administrative endpoints so the review can run both automatically after HTML assembly and manually through the API.

### Description
- Added `landingPageQualityReview` to `Experiment` and `ExperimentDto` and created a Liquibase changeset to add the `landing_page_quality_review` column to the `experiment` table and include it in the master changelog.
- Implemented a new `geralanding.qualityreview` module with `BackendQualityReviewService`, controller, start/detail/summary DTOs, and logic that computes a score, blocking issues, recommended regeneration stages and an approval recommendation serialized as JSON.
- Integrated the Quality Gate into the preset-design flow by calling `qualityReviewService.reviewAfterHtmlGeneration(experiment)` after assembling `htmlGeraLanding` in `BackendPresetDesignService`, and documented the new endpoints and schema in the Swagger file and docs.
- Minor pipeline and code cleanup: canonical pipeline section utilities and comments were clarified and various helper methods received brief Javadoc-style comments.

### Testing
- Ran unit tests `BackendPresetDesignServiceTest` (updated to mock and verify `BackendQualityReviewService`) which passed.
- Added and ran `BackendQualityReviewServiceTest` covering approved landing, rejection with recommendations, and execution detail retrieval which passed.
- No automated DB migration run in unit tests, but a Liquibase changeset (`changesets/2026-06-03-experiment-landing-quality-review.yaml`) was added and included in `db.changelog-master.yaml`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f7e7d0250832195b129054851c905)