### PR TITLE
Add Hotmart bootstrap ingest and refactor Sales Library ingestion pipeline

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/dto/MoisSalesLibraryDtos.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/dto/MoisSalesLibraryDtos.java
@@ -7,6 +7,9 @@ import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.List;
 
+/**
+ * Agrupa contratos HTTP da Biblioteca de Páginas de Vendas do MOIS.
+ */
 public final class MoisSalesLibraryDtos {
 
 
@@ -52,6 +55,9 @@ public final class MoisSalesLibraryDtos {
     }
 
 
+    /**
+     * Impede instanciação do agrupador de contratos.
+     */
     private MoisSalesLibraryDtos() {
     }
 
@@ -74,6 +80,25 @@ public final class MoisSalesLibraryDtos {
             String source,
             int received,
             int persisted
+    ) {
+    }
+
+    public record SalesLibraryHotmartCollectedIngestRequest(
+            @NotBlank String workspaceId,
+            String jobId,
+            Integer limit
+    ) {
+    }
+
+    public record SalesLibraryHotmartCollectedIngestResponse(
+            String workspaceId,
+            String jobId,
+            int collectedReferencesRead,
+            int eligibleUrls,
+            int insertedUrls,
+            int updatedUrls,
+            int jobsCreated,
+            int skippedWithoutUrl
     ) {
     }
 

--- a/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryService.java
@@ -3,19 +3,27 @@ package com.marketinghub.mois.bibliotecapaginavenda.worker.v1.service;
 import com.marketinghub.mois.bibliotecapaginavenda.worker.v1.dto.MoisSalesLibraryDtos;
 import java.math.BigDecimal;
 import java.net.URI;
+import java.sql.ResultSet;
+import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.time.Instant;
 import java.time.LocalDateTime;
 import java.time.ZoneOffset;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+/**
+ * Coordena a ingestão, consulta e processamento das páginas de vendas da biblioteca MOIS.
+ */
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class MoisSalesLibraryService {
 
     private static final String JOB_STATUS_PENDING = "PENDING";
@@ -23,8 +31,9 @@ public class MoisSalesLibraryService {
 
     private final JdbcTemplate jdbcTemplate;
 
-
-
+    /**
+     * Reserva o próximo job pendente da biblioteca para processamento pelo worker.
+     */
     @Transactional
     public MoisSalesLibraryDtos.SalesLibraryClaimResponse claimJob(MoisSalesLibraryDtos.SalesLibraryClaimRequest request) {
         List<MoisSalesLibraryDtos.SalesLibraryClaimedJob> rows = jdbcTemplate.query("""
@@ -45,6 +54,9 @@ public class MoisSalesLibraryService {
         return new MoisSalesLibraryDtos.SalesLibraryClaimResponse(true, job);
     }
 
+    /**
+     * Registra a análise concluída de uma página e finaliza o job correspondente.
+     */
     @Transactional
     public void completeJob(long jobId, MoisSalesLibraryDtos.SalesLibraryCompleteRequest request) {
         Long pageId = jdbcTemplate.queryForObject("SELECT url_ingest_id FROM mois_sales_library_processing_job WHERE id = ? LIMIT 1", Long.class, jobId);
@@ -57,71 +69,76 @@ public class MoisSalesLibraryService {
         jdbcTemplate.update("UPDATE mois_sales_library_processing_job SET status='DONE', finished_at=UTC_TIMESTAMP(), updated_at=UTC_TIMESTAMP() WHERE id=?", jobId);
     }
 
+    /**
+     * Marca um job como falho preservando a categoria e a mensagem de erro operacional.
+     */
     @Transactional
     public void failJob(long jobId, MoisSalesLibraryDtos.SalesLibraryFailRequest request) {
         jdbcTemplate.update("UPDATE mois_sales_library_processing_job SET status='FAILED', error_category=?, error_message=?, finished_at=UTC_TIMESTAMP(), updated_at=UTC_TIMESTAMP() WHERE id=?", request.errorCategory(), request.errorMessage(), jobId);
     }
 
+    /**
+     * Ingere URLs informadas explicitamente e cria jobs apenas para páginas novas.
+     */
     @Transactional
     public MoisSalesLibraryDtos.SalesLibraryIngestResponse ingestUrls(MoisSalesLibraryDtos.SalesLibraryIngestRequest request) {
-        int persisted = 0;
-        String normalizedSource = request.source().trim().toUpperCase(Locale.ROOT);
-        for (MoisSalesLibraryDtos.SalesLibraryUrlItem item : request.urls()) {
-            String canonical = canonicalize(item.url());
-            if (canonical == null || canonical.isBlank()) {
-                continue;
-            }
-            Instant capturedAt = item.capturedAt() == null ? Instant.now() : item.capturedAt();
-            LocalDateTime capturedAtUtc = LocalDateTime.ofInstant(capturedAt, ZoneOffset.UTC);
-            int ingestUpsertResult = jdbcTemplate.update(
-                    """
-                            INSERT INTO mois_sales_library_url_ingest
-                            (workspace_id, source, url_original, url_canonical, title, first_captured_at, last_captured_at, ingest_count, created_at, updated_at)
-                            VALUES (?, ?, ?, ?, ?, ?, ?, 1, UTC_TIMESTAMP(), UTC_TIMESTAMP())
-                            ON DUPLICATE KEY UPDATE
-                                source = VALUES(source),
-                                url_original = VALUES(url_original),
-                                title = COALESCE(NULLIF(VALUES(title), ''), title),
-                                last_captured_at = GREATEST(COALESCE(last_captured_at, VALUES(last_captured_at)), VALUES(last_captured_at)),
-                                ingest_count = ingest_count + 1,
-                                updated_at = UTC_TIMESTAMP()
-                            """,
-                    request.workspaceId(),
-                    normalizedSource,
-                    item.url(),
-                    canonical,
-                    item.title(),
-                    capturedAtUtc,
-                    capturedAtUtc
-            );
-
-            if (ingestUpsertResult == 1) {
-                Long urlIngestId = jdbcTemplate.queryForObject(
-                        """
-                                SELECT id
-                                FROM mois_sales_library_url_ingest
-                                WHERE url_canonical = ?
-                                LIMIT 1
-                                """,
-                        Long.class,
-                        canonical
-                );
-                if (urlIngestId != null) {
-                    createPendingJob(urlIngestId);
-                }
-            }
-            persisted++;
-        }
+        log.info("Biblioteca de páginas de vendas recebeu payload bruto de ingestão explícita. request={}", request);
+        IngestCounters counters = ingestUrlItems(request.workspaceId(), request.source(), request.urls());
 
         return new MoisSalesLibraryDtos.SalesLibraryIngestResponse(
                 request.workspaceId(),
-                normalizedSource,
+                request.source().trim().toUpperCase(Locale.ROOT),
                 request.urls().size(),
-                persisted
+                counters.persisted()
         );
     }
 
-    public MoisSalesLibraryDtos.SalesLibraryJobResponse getJob(long jobId) { /* unchanged simplified */
+    /**
+     * Ingere na biblioteca as URLs dos produtos Hotmart já coletados, priorizando o lote de 400 produtos mais recente.
+     */
+    @Transactional
+    public MoisSalesLibraryDtos.SalesLibraryHotmartCollectedIngestResponse ingestHotmartCollectedProducts(
+            MoisSalesLibraryDtos.SalesLibraryHotmartCollectedIngestRequest request
+    ) {
+        log.info("Biblioteca de páginas de vendas recebeu payload bruto para ingestir produtos Hotmart coletados. request={}", request);
+        int normalizedLimit = Math.max(1, Math.min(request.limit() == null ? 400 : request.limit(), 400));
+        String effectiveJobId = resolveHotmartJobId(request.workspaceId(), request.jobId());
+        if (effectiveJobId == null) {
+            return new MoisSalesLibraryDtos.SalesLibraryHotmartCollectedIngestResponse(
+                    request.workspaceId(), null, 0, 0, 0, 0, 0, 0
+            );
+        }
+
+        List<CollectedReferenceForIngest> references = findHotmartCollectedReferences(request.workspaceId(), effectiveJobId, normalizedLimit);
+        List<MoisSalesLibraryDtos.SalesLibraryUrlItem> urls = new ArrayList<>();
+        int skippedWithoutUrl = 0;
+        for (CollectedReferenceForIngest reference : references) {
+            String url = coalesceNotBlank(reference.salesPageUrl(), reference.productUrl(), reference.url());
+            if (url == null || url.isBlank()) {
+                skippedWithoutUrl++;
+                continue;
+            }
+            String title = coalesceNotBlank(reference.productName(), reference.title(), reference.referenceId());
+            urls.add(new MoisSalesLibraryDtos.SalesLibraryUrlItem(url, title, reference.collectedAt()));
+        }
+
+        IngestCounters counters = ingestUrlItems(request.workspaceId(), "HOTMART", urls);
+        return new MoisSalesLibraryDtos.SalesLibraryHotmartCollectedIngestResponse(
+                request.workspaceId(),
+                effectiveJobId,
+                references.size(),
+                urls.size(),
+                counters.inserted(),
+                counters.updated(),
+                counters.jobsCreated(),
+                skippedWithoutUrl + counters.skippedWithoutUrl()
+        );
+    }
+
+    /**
+     * Busca os metadados operacionais de um job da biblioteca.
+     */
+    public MoisSalesLibraryDtos.SalesLibraryJobResponse getJob(long jobId) {
         List<MoisSalesLibraryDtos.SalesLibraryJobResponse> rows = jdbcTemplate.query("""
                         SELECT id, url_ingest_id, status, attempts, error_category, error_message,
                                next_retry_at, created_at, updated_at, started_at, finished_at
@@ -140,6 +157,9 @@ public class MoisSalesLibraryService {
         return rows.get(0);
     }
 
+    /**
+     * Lista jobs da biblioteca por workspace, com filtro opcional por status.
+     */
     public MoisSalesLibraryDtos.SalesLibraryJobPageResponse listJobs(String workspaceId, String status, int page, int pageSize) {
         int normalizedPage = Math.max(1, page);
         int normalizedPageSize = Math.max(1, Math.min(pageSize, 100));
@@ -168,7 +188,10 @@ public class MoisSalesLibraryService {
         return new MoisSalesLibraryDtos.SalesLibraryJobPageResponse(normalizedPage, normalizedPageSize, total == null ? 0 : total, items);
     }
 
-    public MoisSalesLibraryDtos.SalesLibraryEntryPageResponse listEntries(String workspaceId, int page, int pageSize) { /* keep */
+    /**
+     * Lista entradas de URL ingeridas na biblioteca para auditoria operacional.
+     */
+    public MoisSalesLibraryDtos.SalesLibraryEntryPageResponse listEntries(String workspaceId, int page, int pageSize) {
         int normalizedPage = Math.max(1, page); int normalizedPageSize = Math.max(1, Math.min(pageSize, 100)); int offset = (normalizedPage - 1) * normalizedPageSize;
         Long total = jdbcTemplate.queryForObject("SELECT COUNT(*) FROM mois_sales_library_url_ingest WHERE workspace_id = ?", Long.class, workspaceId);
         List<MoisSalesLibraryDtos.SalesLibraryEntryResponse> items = jdbcTemplate.query("""
@@ -184,6 +207,9 @@ public class MoisSalesLibraryService {
         return new MoisSalesLibraryDtos.SalesLibraryEntryPageResponse(normalizedPage, normalizedPageSize, total == null ? 0 : total, items);
     }
 
+    /**
+     * Lista páginas canônicas da biblioteca junto com a análise mais recente.
+     */
     public MoisSalesLibraryDtos.SalesLibraryPageListResponse listPages(String workspaceId, int page, int pageSize) {
         int normalizedPage = Math.max(1, page); int normalizedPageSize = Math.max(1, Math.min(pageSize, 100)); int offset = (normalizedPage - 1) * normalizedPageSize;
         Long total = jdbcTemplate.queryForObject("SELECT COUNT(*) FROM mois_sales_library_url_ingest WHERE workspace_id = ?", Long.class, workspaceId);
@@ -204,6 +230,9 @@ public class MoisSalesLibraryService {
         return new MoisSalesLibraryDtos.SalesLibraryPageListResponse(normalizedPage, normalizedPageSize, total == null ? 0 : total, items);
     }
 
+    /**
+     * Busca uma página canônica da biblioteca pelo identificador interno.
+     */
     public MoisSalesLibraryDtos.SalesLibraryPageResponse getPage(long pageId) {
         List<MoisSalesLibraryDtos.SalesLibraryPageResponse> rows = jdbcTemplate.query("""
                 SELECT i.id, i.workspace_id, i.source, i.url_canonical, i.title, i.updated_at,
@@ -222,6 +251,9 @@ public class MoisSalesLibraryService {
         return rows.get(0);
     }
 
+    /**
+     * Busca a análise mais recente de uma página da biblioteca.
+     */
     public MoisSalesLibraryDtos.SalesLibraryPageAnalysisResponse getPageAnalysis(long pageId) {
         List<MoisSalesLibraryDtos.SalesLibraryPageAnalysisResponse> rows = jdbcTemplate.query("""
                 SELECT a.id, a.url_ingest_id, a.job_id, a.status, a.score_total, a.parser_version,
@@ -270,6 +302,9 @@ public class MoisSalesLibraryService {
         return new MoisSalesLibraryDtos.SalesLibraryStatusUpdateResponse(pageId, jobId, normalizedStatus, notes, Instant.now());
     }
 
+    /**
+     * Cria um novo job pendente para reanalisar uma página existente.
+     */
     @Transactional
     public MoisSalesLibraryDtos.SalesLibraryReanalyzeResponse reanalyzePage(long pageId) {
         Long exists = jdbcTemplate.queryForObject("SELECT COUNT(*) FROM mois_sales_library_url_ingest WHERE id = ?", Long.class, pageId);
@@ -283,12 +318,198 @@ public class MoisSalesLibraryService {
         return new MoisSalesLibraryDtos.SalesLibraryReanalyzeResponse(pageId, jobId, JOB_STATUS_PENDING, Instant.now());
     }
 
+
+    /**
+     * Executa a gravação comum de itens de URL e consolida contadores de inserção, atualização e jobs.
+     */
+    private IngestCounters ingestUrlItems(String workspaceId, String source, List<MoisSalesLibraryDtos.SalesLibraryUrlItem> urls) {
+        int persisted = 0;
+        int inserted = 0;
+        int updated = 0;
+        int jobsCreated = 0;
+        int skippedWithoutUrl = 0;
+        String normalizedSource = source.trim().toUpperCase(Locale.ROOT);
+        for (MoisSalesLibraryDtos.SalesLibraryUrlItem item : urls) {
+            String canonical = canonicalize(item.url());
+            if (canonical == null || canonical.isBlank()) {
+                skippedWithoutUrl++;
+                continue;
+            }
+            Instant capturedAt = item.capturedAt() == null ? Instant.now() : item.capturedAt();
+            LocalDateTime capturedAtUtc = LocalDateTime.ofInstant(capturedAt, ZoneOffset.UTC);
+            int ingestUpsertResult = jdbcTemplate.update(
+                    """
+                            INSERT INTO mois_sales_library_url_ingest
+                            (workspace_id, source, url_original, url_canonical, title, first_captured_at, last_captured_at, ingest_count, created_at, updated_at)
+                            VALUES (?, ?, ?, ?, ?, ?, ?, 1, UTC_TIMESTAMP(), UTC_TIMESTAMP())
+                            ON DUPLICATE KEY UPDATE
+                                source = VALUES(source),
+                                url_original = VALUES(url_original),
+                                title = COALESCE(NULLIF(VALUES(title), ''), title),
+                                last_captured_at = GREATEST(COALESCE(last_captured_at, VALUES(last_captured_at)), VALUES(last_captured_at)),
+                                ingest_count = ingest_count + 1,
+                                updated_at = UTC_TIMESTAMP()
+                            """,
+                    workspaceId,
+                    normalizedSource,
+                    item.url(),
+                    canonical,
+                    item.title(),
+                    capturedAtUtc,
+                    capturedAtUtc
+            );
+
+            if (ingestUpsertResult == 1) {
+                inserted++;
+                Long urlIngestId = jdbcTemplate.queryForObject(
+                        """
+                                SELECT id
+                                FROM mois_sales_library_url_ingest
+                                WHERE url_canonical = ?
+                                LIMIT 1
+                                """,
+                        Long.class,
+                        canonical
+                );
+                if (urlIngestId != null) {
+                    createPendingJob(urlIngestId);
+                    jobsCreated++;
+                }
+            } else {
+                updated++;
+            }
+            persisted++;
+        }
+        return new IngestCounters(persisted, inserted, updated, jobsCreated, skippedWithoutUrl);
+    }
+
+    /**
+     * Resolve o job Hotmart solicitado ou, quando ausente, identifica o job mais recente do workspace.
+     */
+    private String resolveHotmartJobId(String workspaceId, String requestedJobId) {
+        if (requestedJobId != null && !requestedJobId.isBlank()) {
+            return requestedJobId.trim();
+        }
+        return jdbcTemplate.query(
+                """
+                        SELECT job_id
+                        FROM mois_collected_reference
+                        WHERE workspace_id = ?
+                          AND source = 'HOTMART'
+                        GROUP BY job_id
+                        ORDER BY MAX(updated_at) DESC
+                        LIMIT 1
+                        """,
+                (rs, rowNum) -> rs.getString("job_id"),
+                workspaceId
+        ).stream().findFirst().orElse(null);
+    }
+
+    /**
+     * Busca produtos Hotmart coletados no lote escolhido para transformá-los em URLs da biblioteca.
+     */
+    private List<CollectedReferenceForIngest> findHotmartCollectedReferences(String workspaceId, String jobId, int limit) {
+        return jdbcTemplate.query(
+                """
+                        SELECT reference_id, title, product_name, url, product_url, sales_page_url, collected_at
+                        FROM mois_collected_reference
+                        WHERE workspace_id = ?
+                          AND source = 'HOTMART'
+                          AND job_id = ?
+                        ORDER BY collected_at ASC, id ASC
+                        LIMIT ?
+                        """,
+                (rs, rowNum) -> mapCollectedReferenceForIngest(rs),
+                workspaceId,
+                jobId,
+                limit
+        );
+    }
+
+    /**
+     * Mapeia uma linha de referência coletada para a estrutura interna de ingestão.
+     */
+    private CollectedReferenceForIngest mapCollectedReferenceForIngest(ResultSet rs) throws SQLException {
+        Timestamp collectedAt = rs.getTimestamp("collected_at");
+        return new CollectedReferenceForIngest(
+                rs.getString("reference_id"),
+                rs.getString("title"),
+                rs.getString("product_name"),
+                rs.getString("url"),
+                rs.getString("product_url"),
+                rs.getString("sales_page_url"),
+                collectedAt == null ? null : collectedAt.toInstant()
+        );
+    }
+
+    /**
+     * Retorna o primeiro texto não vazio para aplicar fallbacks de URL e título.
+     */
+    private String coalesceNotBlank(String... values) {
+        if (values == null) {
+            return null;
+        }
+        for (String value : values) {
+            if (value != null && !value.isBlank()) {
+                return value.trim();
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Cria um job pendente para uma URL ingerida e retorna o identificador criado.
+     */
     private long createPendingJob(long urlIngestId) {
-        jdbcTemplate.update("INSERT INTO mois_sales_library_processing_job (url_ingest_id, status, attempts, created_at, updated_at) VALUES (?, ?, 0, UTC_TIMESTAMP(), UTC_TIMESTAMP())", urlIngestId, JOB_STATUS_PENDING);
+        jdbcTemplate.update(
+                "INSERT INTO mois_sales_library_processing_job (url_ingest_id, status, attempts, created_at, updated_at) VALUES (?, ?, 0, UTC_TIMESTAMP(), UTC_TIMESTAMP())",
+                urlIngestId,
+                JOB_STATUS_PENDING
+        );
         Long id = jdbcTemplate.queryForObject("SELECT LAST_INSERT_ID()", Long.class);
         return id == null ? 0L : id;
     }
 
-    private String canonicalize(String rawUrl) { if (rawUrl == null || rawUrl.isBlank()) return null; try { URI uri = URI.create(rawUrl.trim()); String scheme = uri.getScheme() == null ? "https" : uri.getScheme().toLowerCase(Locale.ROOT); String host = uri.getHost(); if (host == null || host.isBlank()) return rawUrl.trim(); String path = (uri.getPath() == null || uri.getPath().isBlank()) ? "/" : uri.getPath(); return scheme + "://" + host.toLowerCase(Locale.ROOT) + path; } catch (Exception ignored) { return rawUrl.trim(); } }
-    private Instant toInstant(Timestamp timestamp) { return timestamp == null ? null : timestamp.toInstant(); }
+    /**
+     * Normaliza uma URL para deduplicação por esquema, host e caminho.
+     */
+    private String canonicalize(String rawUrl) {
+        if (rawUrl == null || rawUrl.isBlank()) {
+            return null;
+        }
+        try {
+            URI uri = URI.create(rawUrl.trim());
+            String scheme = uri.getScheme() == null ? "https" : uri.getScheme().toLowerCase(Locale.ROOT);
+            String host = uri.getHost();
+            if (host == null || host.isBlank()) {
+                return rawUrl.trim();
+            }
+            String path = (uri.getPath() == null || uri.getPath().isBlank()) ? "/" : uri.getPath();
+            return scheme + "://" + host.toLowerCase(Locale.ROOT) + path;
+        } catch (Exception ex) {
+            log.warn("Biblioteca de páginas de vendas não conseguiu canonicalizar URL. operacao=canonicalize, rawUrl={}", rawUrl, ex);
+            return rawUrl.trim();
+        }
+    }
+
+    /**
+     * Converte timestamp JDBC em Instant preservando nulos.
+     */
+    private Instant toInstant(Timestamp timestamp) {
+        return timestamp == null ? null : timestamp.toInstant();
+    }
+
+    private record IngestCounters(int persisted, int inserted, int updated, int jobsCreated, int skippedWithoutUrl) {
+    }
+
+    private record CollectedReferenceForIngest(
+            String referenceId,
+            String title,
+            String productName,
+            String url,
+            String productUrl,
+            String salesPageUrl,
+            Instant collectedAt
+    ) {
+    }
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/web/MoisSalesLibraryController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/web/MoisSalesLibraryController.java
@@ -6,6 +6,7 @@ import com.marketinghub.mois.bibliotecapaginavenda.worker.v1.service.MoisSalesLi
 import jakarta.validation.Valid;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -18,15 +19,22 @@ import org.springframework.web.bind.annotation.ResponseStatus;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.server.ResponseStatusException;
 
+/**
+ * Expõe os contratos HTTP da Biblioteca de Páginas de Vendas do MOIS.
+ */
 @RestController
 @RequestMapping("/api/mois/sales-library")
 @RequiredArgsConstructor
 @Validated
+@Slf4j
 public class MoisSalesLibraryController {
 
     private final MoisSalesLibraryService service;
     private final MoisSalesLibrarySnapshotService snapshotService;
 
+    /**
+     * Lista entradas de URLs ingeridas pela biblioteca.
+     */
     @GetMapping("/entries")
     public MoisSalesLibraryDtos.SalesLibraryEntryPageResponse listEntries(
             @RequestParam String workspaceId,
@@ -36,6 +44,9 @@ public class MoisSalesLibraryController {
         return service.listEntries(workspaceId, page, pageSize);
     }
 
+    /**
+     * Lista jobs de processamento da biblioteca.
+     */
     @GetMapping("/jobs")
     public MoisSalesLibraryDtos.SalesLibraryJobPageResponse listJobs(
             @RequestParam String workspaceId,
@@ -46,15 +57,22 @@ public class MoisSalesLibraryController {
         return service.listJobs(workspaceId, status, page, pageSize);
     }
 
+    /**
+     * Busca um job de processamento pelo identificador.
+     */
     @GetMapping("/jobs/{jobId}")
     public MoisSalesLibraryDtos.SalesLibraryJobResponse getJob(@PathVariable long jobId) {
         try {
             return service.getJob(jobId);
         } catch (IllegalArgumentException ex) {
+            log.warn("Biblioteca de páginas de vendas não encontrou job solicitado. operacao=getJob, jobId={}, erro={}", jobId, ex.getMessage(), ex);
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, ex.getMessage(), ex);
         }
     }
 
+    /**
+     * Lista páginas canônicas registradas na biblioteca.
+     */
     @GetMapping("/pages")
     public MoisSalesLibraryDtos.SalesLibraryPageListResponse listPages(
             @RequestParam String workspaceId,
@@ -64,30 +82,42 @@ public class MoisSalesLibraryController {
         return service.listPages(workspaceId, page, pageSize);
     }
 
+    /**
+     * Busca os dados básicos de uma página canônica.
+     */
     @GetMapping("/pages/{pageId}")
     public MoisSalesLibraryDtos.SalesLibraryPageResponse getPage(@PathVariable long pageId) {
         try {
             return service.getPage(pageId);
         } catch (IllegalArgumentException ex) {
+            log.warn("Biblioteca de páginas de vendas não encontrou página solicitada. operacao=getPage, pageId={}, erro={}", pageId, ex.getMessage(), ex);
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, ex.getMessage(), ex);
         }
     }
 
+    /**
+     * Busca a análise mais recente de uma página canônica.
+     */
     @GetMapping("/pages/{pageId}/analysis")
     public MoisSalesLibraryDtos.SalesLibraryPageAnalysisResponse getPageAnalysis(@PathVariable long pageId) {
         try {
             return service.getPageAnalysis(pageId);
         } catch (IllegalArgumentException ex) {
+            log.warn("Biblioteca de páginas de vendas não encontrou análise solicitada. operacao=getPageAnalysis, pageId={}, erro={}", pageId, ex.getMessage(), ex);
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, ex.getMessage(), ex);
         }
     }
 
+    /**
+     * Solicita reanálise de uma página existente.
+     */
     @PostMapping("/pages/{pageId}:reanalyze")
     @ResponseStatus(HttpStatus.ACCEPTED)
     public MoisSalesLibraryDtos.SalesLibraryReanalyzeResponse reanalyzePage(@PathVariable long pageId) {
         try {
             return service.reanalyzePage(pageId);
         } catch (IllegalArgumentException ex) {
+            log.warn("Biblioteca de páginas de vendas não conseguiu solicitar reanálise. operacao=reanalyzePage, pageId={}, erro={}", pageId, ex.getMessage(), ex);
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, ex.getMessage(), ex);
         }
     }
@@ -105,10 +135,14 @@ public class MoisSalesLibraryController {
         try {
             return service.updatePageStatus(pageId, request);
         } catch (IllegalArgumentException ex) {
+            log.warn("Biblioteca de páginas de vendas rejeitou atualização manual de status. operacao=updatePageStatus, pageId={}, status={}, erro={}", pageId, request.status(), ex.getMessage(), ex);
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, ex.getMessage(), ex);
         }
     }
 
+    /**
+     * Solicita captura de snapshots para páginas sem captura recente.
+     */
     @PostMapping("/snapshots:capture")
     @ResponseStatus(HttpStatus.ACCEPTED)
     public MoisSalesLibraryDtos.SalesLibrarySnapshotCaptureResponse captureSnapshots(
@@ -117,11 +151,17 @@ public class MoisSalesLibraryController {
         return snapshotService.captureSnapshots(request);
     }
 
+    /**
+     * Lista snapshots já capturados para uma página.
+     */
     @GetMapping("/pages/{pageId}/snapshots")
     public List<MoisSalesLibraryDtos.SalesLibraryPageSnapshotResponse> listPageSnapshots(@PathVariable long pageId) {
         return snapshotService.listSnapshots(pageId);
     }
 
+    /**
+     * Reserva o próximo job pendente para o worker.
+     */
     @PostMapping("/jobs:claim")
     public MoisSalesLibraryDtos.SalesLibraryClaimResponse claimJob(
             @Valid @RequestBody MoisSalesLibraryDtos.SalesLibraryClaimRequest request
@@ -129,6 +169,9 @@ public class MoisSalesLibraryController {
         return service.claimJob(request);
     }
 
+    /**
+     * Recebe o resultado final de análise de um job.
+     */
     @PostMapping("/jobs/{jobId}:complete")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void completeJob(
@@ -138,6 +181,9 @@ public class MoisSalesLibraryController {
         service.completeJob(jobId, request);
     }
 
+    /**
+     * Registra falha terminal de um job do worker.
+     */
     @PostMapping("/jobs/{jobId}:fail")
     @ResponseStatus(HttpStatus.NO_CONTENT)
     public void failJob(
@@ -147,11 +193,25 @@ public class MoisSalesLibraryController {
         service.failJob(jobId, request);
     }
 
+    /**
+     * Ingere URLs externas já selecionadas para a biblioteca.
+     */
     @PostMapping("/urls:ingest")
     @ResponseStatus(HttpStatus.ACCEPTED)
     public MoisSalesLibraryDtos.SalesLibraryIngestResponse ingestUrls(
             @Valid @RequestBody MoisSalesLibraryDtos.SalesLibraryIngestRequest request
     ) {
         return service.ingestUrls(request);
+    }
+
+    /**
+     * Dispara a ingestão das URLs dos produtos Hotmart já coletados para iniciar o MVP com até 400 produtos.
+     */
+    @PostMapping("/hotmart-products:ingest")
+    @ResponseStatus(HttpStatus.ACCEPTED)
+    public MoisSalesLibraryDtos.SalesLibraryHotmartCollectedIngestResponse ingestHotmartCollectedProducts(
+            @Valid @RequestBody MoisSalesLibraryDtos.SalesLibraryHotmartCollectedIngestRequest request
+    ) {
+        return service.ingestHotmartCollectedProducts(request);
     }
 }

--- a/backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryServiceTest.java
@@ -3,12 +3,15 @@ package com.marketinghub.mois.bibliotecapaginavenda.worker.v1.service;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 import com.marketinghub.mois.bibliotecapaginavenda.worker.v1.dto.MoisSalesLibraryDtos;
+import java.sql.ResultSet;
+import java.sql.Timestamp;
 import java.time.Instant;
 import java.util.List;
 import org.junit.jupiter.api.Test;
@@ -17,7 +20,11 @@ import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
 
+/**
+ * Valida regras de ingestão e criação de jobs da Biblioteca de Páginas de Vendas.
+ */
 @ExtendWith(MockitoExtension.class)
 class MoisSalesLibraryServiceTest {
 
@@ -27,6 +34,9 @@ class MoisSalesLibraryServiceTest {
     @InjectMocks
     private MoisSalesLibraryService service;
 
+    /**
+     * Garante criação de job quando a URL ingerida ainda não existe.
+     */
     @Test
     void shouldCreatePendingJobWhenUrlIsNew() {
         MoisSalesLibraryDtos.SalesLibraryIngestRequest request = new MoisSalesLibraryDtos.SalesLibraryIngestRequest(
@@ -44,6 +54,9 @@ class MoisSalesLibraryServiceTest {
         verify(jdbcTemplate).update(contains("INSERT INTO mois_sales_library_processing_job"), eq(99L), eq("PENDING"));
     }
 
+    /**
+     * Garante que URLs já existentes não geram jobs duplicados.
+     */
     @Test
     void shouldNotCreatePendingJobWhenUrlAlreadyExists() {
         MoisSalesLibraryDtos.SalesLibraryIngestRequest request = new MoisSalesLibraryDtos.SalesLibraryIngestRequest(
@@ -60,4 +73,61 @@ class MoisSalesLibraryServiceTest {
         verify(jdbcTemplate, never()).queryForObject(anyString(), eq(Long.class), any());
         verify(jdbcTemplate, never()).update(contains("INSERT INTO mois_sales_library_processing_job"), any(), any());
     }
+
+    /**
+     * Garante que o bootstrap Hotmart usa o job mais recente e limita o lote inicial a 400 produtos.
+     */
+    @Test
+    void shouldIngestLatestHotmartCollectedProductsWithLimitOf400() throws Exception {
+        MoisSalesLibraryDtos.SalesLibraryHotmartCollectedIngestRequest request =
+                new MoisSalesLibraryDtos.SalesLibraryHotmartCollectedIngestRequest("workspace-001", null, null);
+
+        given(jdbcTemplate.query(contains("GROUP BY job_id"), isA(RowMapper.class), eq("workspace-001")))
+                .willReturn(List.of("hotmart-job-400"));
+        given(jdbcTemplate.query(contains("SELECT reference_id"), isA(RowMapper.class), eq("workspace-001"), eq("hotmart-job-400"), eq(400)))
+                .willAnswer(invocation -> {
+                    RowMapper<?> mapper = invocation.getArgument(1);
+                    ResultSet firstRow = collectedReferenceRow(
+                            "ref-1", "Produto com sales page", "https://go.hotmart.com/A1", null, null);
+                    ResultSet secondRow = collectedReferenceRow(
+                            "ref-2", "Produto com fallback", null, "https://produto.example/pagina", null);
+                    return List.of(mapper.mapRow(firstRow, 0), mapper.mapRow(secondRow, 1));
+                });
+        given(jdbcTemplate.update(contains("INSERT INTO mois_sales_library_url_ingest"), any(), any(), any(), any(), any(), any(), any()))
+                .willReturn(1, 2);
+        given(jdbcTemplate.queryForObject(contains("SELECT id"), eq(Long.class), any())).willReturn(77L);
+
+        MoisSalesLibraryDtos.SalesLibraryHotmartCollectedIngestResponse response =
+                service.ingestHotmartCollectedProducts(request);
+
+        verify(jdbcTemplate).update(contains("INSERT INTO mois_sales_library_processing_job"), eq(77L), eq("PENDING"));
+        org.assertj.core.api.Assertions.assertThat(response.jobId()).isEqualTo("hotmart-job-400");
+        org.assertj.core.api.Assertions.assertThat(response.collectedReferencesRead()).isEqualTo(2);
+        org.assertj.core.api.Assertions.assertThat(response.eligibleUrls()).isEqualTo(2);
+        org.assertj.core.api.Assertions.assertThat(response.insertedUrls()).isEqualTo(1);
+        org.assertj.core.api.Assertions.assertThat(response.updatedUrls()).isEqualTo(1);
+        org.assertj.core.api.Assertions.assertThat(response.jobsCreated()).isEqualTo(1);
+    }
+
+    /**
+     * Monta uma linha simulada de produto Hotmart coletado para o mapper JDBC.
+     */
+    private ResultSet collectedReferenceRow(
+            String referenceId,
+            String productName,
+            String salesPageUrl,
+            String productUrl,
+            String url
+    ) throws Exception {
+        ResultSet resultSet = org.mockito.Mockito.mock(ResultSet.class);
+        given(resultSet.getString("reference_id")).willReturn(referenceId);
+        given(resultSet.getString("title")).willReturn(productName);
+        given(resultSet.getString("product_name")).willReturn(productName);
+        given(resultSet.getString("url")).willReturn(url);
+        given(resultSet.getString("product_url")).willReturn(productUrl);
+        given(resultSet.getString("sales_page_url")).willReturn(salesPageUrl);
+        given(resultSet.getTimestamp("collected_at")).willReturn(Timestamp.from(Instant.parse("2026-06-01T21:00:24Z")));
+        return resultSet;
+    }
+
 }

--- a/docs/canonical/mois-worker-canon.v1.md
+++ b/docs/canonical/mois-worker-canon.v1.md
@@ -329,6 +329,20 @@ erDiagram
 4. Persistência de análise final deve ficar em `mois_sales_library_page_analysis`, mantendo rastreabilidade por `job_id` e `url_ingest_id`.
 5. Snapshots e artefatos complementares não substituem a análise principal; eles enriquecem histórico e diagnóstico.
 
+### 13.6 Bootstrap operacional Hotmart com lote de até 400 produtos
+
+Para iniciar o MVP da biblioteca com a base Hotmart já coletada, o backend expõe o contrato operacional:
+
+- `POST /api/mois/sales-library/hotmart-products:ingest`
+- payload: `{ "workspaceId": "workspace-001", "jobId"?: "...", "limit"?: 400 }`
+- quando `jobId` não é informado, o backend seleciona o job Hotmart mais recente em `mois_collected_reference` para o workspace;
+- o limite padrão e máximo é `400`, para manter o primeiro ciclo aderente ao plano de usar a base inicial de aproximadamente 400 produtos;
+- a URL priorizada é `sales_page_url`, com fallback em `product_url` e depois `url`;
+- cada URL elegível é inserida/atualizada em `mois_sales_library_url_ingest` e somente URLs novas geram job `PENDING` em `mois_sales_library_processing_job`;
+- a resposta retorna contadores de referências lidas, URLs elegíveis, URLs inseridas, URLs atualizadas, jobs criados e itens ignorados sem URL.
+
+Esse bootstrap é a ponte entre a coleta Hotmart já persistida e o MVP 1 do plano de pipeline da Biblioteca de Páginas de Vendas, sem escrita direta por workers no banco.
+
 
 ### 13.5 Diagrama de dados (somente chaves)
 ```mermaid

--- a/docs/novos-modulos/mois-biblioteca-pagina-venda/plano-pipeline-biblioteca-paginas-venda-gerado-por-chatgpt.md
+++ b/docs/novos-modulos/mois-biblioteca-pagina-venda/plano-pipeline-biblioteca-paginas-venda-gerado-por-chatgpt.md
@@ -632,3 +632,15 @@ banco estruturado + vector store + biblioteca de padrões + validação forte
 O vector store ajuda a encontrar referências semanticamente parecidas. O banco estruturado ajuda a filtrar por características objetivas. A biblioteca de padrões transforma as referências em conhecimento reutilizável. O assembler continua determinístico e não inventa nada.
 
 Essa combinação deve melhorar a qualidade das páginas geradas, reduzir retrabalho e criar uma vantagem acumulativa: quanto mais páginas analisadas e quanto mais páginas próprias forem geradas e medidas, melhor a inteligência comercial do sistema fica.
+
+## 20. Execução inicial no Marketing Hub — lote Hotmart de 400 produtos
+
+Primeiro passo implementado para começar pelo lote Hotmart já coletado:
+
+- endpoint operacional: `POST /api/mois/sales-library/hotmart-products:ingest`;
+- entrada mínima: `{ "workspaceId": "workspace-001", "limit": 400 }`;
+- quando `jobId` não é informado, o backend escolhe o job Hotmart mais recente persistido em `mois_collected_reference`;
+- origem dos dados: `mois_collected_reference` com `source = 'HOTMART'`;
+- URL priorizada: `sales_page_url`, com fallback em `product_url` e `url`;
+- destino: `mois_sales_library_url_ingest`, com criação de job `PENDING` em `mois_sales_library_processing_job` apenas quando a URL ainda não existia;
+- objetivo deste passo: transformar o lote bruto de produtos Hotmart em fila deduplicada de páginas para análise do MVP 1.

--- a/docs/registros/mois1.md
+++ b/docs/registros/mois1.md
@@ -1,3 +1,18 @@
+
+## 2026-06-03 — Bootstrap Hotmart 400 para Biblioteca de Páginas de Vendas
+
+- implementado endpoint backend `POST /api/mois/sales-library/hotmart-products:ingest` para ingerir até 400 produtos Hotmart já persistidos em `mois_collected_reference` na Biblioteca de Páginas de Vendas.
+- o fluxo usa `sales_page_url` com fallback em `product_url` e `url`, grava/deduplica em `mois_sales_library_url_ingest` e cria jobs `PENDING` apenas para URLs novas.
+- atualizado o cânone MOIS para registrar o contrato de bootstrap operacional do MVP 1 da biblioteca.
+
+Arquivos alterados:
+- `backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/dto/MoisSalesLibraryDtos.java`
+- `backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryService.java`
+- `backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/web/MoisSalesLibraryController.java`
+- `backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryServiceTest.java`
+- `docs/canonical/mois-worker-canon.v1.md`
+- `docs/novos-modulos/mois-biblioteca-pagina-venda/plano-pipeline-biblioteca-paginas-venda-gerado-por-chatgpt.md`
+
 # Registros — Mois
 
 > 🔴 **Arquivo canônico principal (atual)** para registro operacional dos módulos coletores do MOIS.


### PR DESCRIPTION
### Motivation
- Provide an operational bootstrap to seed the Sales Library from already-collected Hotmart products and avoid direct DB writes by collectors via a backend endpoint.
- Consolidate ingestion logic to properly deduplicate URLs, create `PENDING` jobs only for new canonical URLs and support fallback URL/title heuristics for collected references.
- Improve observability and robustness of canonicalization and JDBC mapping during ingestion flows.

### Description
- Adds a new endpoint `POST /api/mois/sales-library/hotmart-products:ingest` and DTOs `SalesLibraryHotmartCollectedIngestRequest` / `SalesLibraryHotmartCollectedIngestResponse` to trigger ingestion of up to 400 Hotmart products.
- Refactors explicit URL ingestion into a shared private method `ingestUrlItems(...)` that returns an `IngestCounters` record and centralizes upsert semantics, job creation via `createPendingJob(...)`, and counters for inserted/updated/jobs/skipped.
- Implements Hotmart-specific helpers: `resolveHotmartJobId(...)`, `findHotmartCollectedReferences(...)`, `mapCollectedReferenceForIngest(...)`, and `coalesceNotBlank(...)` to map `mois_collected_reference` rows to ingestable URLs with prioritized fallbacks (`sales_page_url`, `product_url`, `url`).
- Adds logging (`@Slf4j`) and safer `canonicalize(...)` with a warning on failures, plus small DTO/controller/service javadoc updates and canonical docs and records updates to document the Hotmart bootstrap flow.

### Testing
- Added/updated unit tests in `MoisSalesLibraryServiceTest` including `shouldCreatePendingJobWhenUrlIsNew`, `shouldNotCreatePendingJobWhenUrlAlreadyExists`, and `shouldIngestLatestHotmartCollectedProductsWithLimitOf400` which exercise per-URL upsert, job creation and Hotmart mapping logic.
- Ran the modified unit tests (`MoisSalesLibraryServiceTest`) and they passed locally (all green).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f7fae8ccc83218a54f76e16911760)