### PR TITLE
Add Pipeline navigation and placeholder for MOIS sales pages library

### DIFF
--- a/docs/registros/mois1.md
+++ b/docs/registros/mois1.md
@@ -799,3 +799,14 @@ Arquivos alterados:
 - `mois-hotmart-collector/src/main/java/com/marketinghub/moishotmart/service/HotmartCollectorScheduler.java`
 - `mois-hotmart-collector/src/test/java/com/marketinghub/moishotmart/service/HotmartCollectorSchedulerTest.java`
 - `docs/canonical/mois-hotmart-mapeamento-ciclos-campos-banco.md`
+
+## 2026-06-03 — Atalho Pipeline na biblioteca de páginas de vendas
+
+- Adicionado botão **Pipeline** no cabeçalho da Biblioteca de Páginas de Vendas do MOIS.
+- Criada rota inicial `/mois/sales-pages-library/pipeline` com tela placeholder para direcionar o usuário à visão de pipeline que será construída na próxima etapa.
+- Mantido o fluxo simples e sem novo contrato de backend, pois a alteração atual é apenas navegação/placeholder sem consumo de dados.
+
+Arquivos alterados:
+- `frontend/src/pages/mois/MoisSalesPagesLibraryPage.tsx`
+- `frontend/src/pages/mois/MoisSalesPagesPipelinePage.tsx`
+- `frontend/src/App.tsx`

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -115,6 +115,7 @@ import MoisReferenceIntakePage from "./pages/mois/MoisReferenceIntakePage";
 import MoisExtractionPage from "./pages/mois/MoisExtractionPage";
 import MoisLibraryPage from "./pages/mois/MoisLibraryPage";
 import MoisSalesPagesLibraryPage from "./pages/mois/MoisSalesPagesLibraryPage";
+import MoisSalesPagesPipelinePage from "./pages/mois/MoisSalesPagesPipelinePage";
 import MoisSalesPageLibraryDetailPage from "./pages/mois/MoisSalesPageLibraryDetailPage";
 import MoisComparisonPage from "./pages/mois/MoisComparisonPage";
 import MoisOfferBuilderPage from "./pages/mois/MoisOfferBuilderPage";
@@ -286,6 +287,7 @@ export default function App() {
               <Route path="/mois/extraction" element={<MoisExtractionPage />} />
               <Route path="/mois/library" element={<MoisLibraryPage />} />
               <Route path="/mois/sales-pages-library" element={<MoisSalesPagesLibraryPage />} />
+              <Route path="/mois/sales-pages-library/pipeline" element={<MoisSalesPagesPipelinePage />} />
               <Route path="/mois/sales-pages-library/:pageId" element={<MoisSalesPageLibraryDetailPage />} />
               <Route path="/mois/comparison" element={<MoisComparisonPage />} />
               <Route path="/mois/builder" element={<MoisOfferBuilderPage />} />

--- a/frontend/src/pages/mois/MoisSalesPagesLibraryPage.tsx
+++ b/frontend/src/pages/mois/MoisSalesPagesLibraryPage.tsx
@@ -52,9 +52,14 @@ export default function MoisSalesPagesLibraryPage() {
           <PageTitle>Biblioteca de Páginas de Vendas</PageTitle>
           <p className="text-secondary mb-0">Tabela consolidada com cada produto coletado e a fase atual no fluxo canônico.</p>
         </div>
-        <Link className="btn btn-outline-secondary" to="/mois">
-          Voltar ao workspace
-        </Link>
+        <div className="d-flex flex-wrap gap-2">
+          <Link className="btn btn-primary" to="/mois/sales-pages-library/pipeline">
+            Pipeline
+          </Link>
+          <Link className="btn btn-outline-secondary" to="/mois">
+            Voltar ao workspace
+          </Link>
+        </div>
       </header>
 
       {summary ? (

--- a/frontend/src/pages/mois/MoisSalesPagesPipelinePage.tsx
+++ b/frontend/src/pages/mois/MoisSalesPagesPipelinePage.tsx
@@ -1,0 +1,29 @@
+import { Link } from "react-router-dom";
+import PageTitle from "../../components/PageTitle";
+
+export default function MoisSalesPagesPipelinePage() {
+  return (
+    <div className="d-flex flex-column gap-4">
+      <header className="d-flex flex-wrap align-items-start justify-content-between gap-3">
+        <div>
+          <PageTitle>Pipeline de Páginas de Vendas</PageTitle>
+          <p className="text-secondary mb-0">
+            Área reservada para construirmos juntos a visão de pipeline da biblioteca de páginas de vendas.
+          </p>
+        </div>
+        <Link className="btn btn-outline-secondary" to="/mois/sales-pages-library">
+          Voltar à biblioteca
+        </Link>
+      </header>
+
+      <section className="card border-0 shadow-sm">
+        <div className="card-body">
+          <h2 className="h5">Tela em construção</h2>
+          <p className="text-secondary mb-0">
+            O botão Pipeline já direciona para esta rota. Os próximos blocos, fases e ações serão definidos na próxima etapa.
+          </p>
+        </div>
+      </section>
+    </div>
+  );
+}


### PR DESCRIPTION
### Motivation
- Provide a quick navigation path from the MOIS Sales Pages Library to a dedicated Pipeline screen so the pipeline UI can be developed in a follow-up task.
- Keep the change frontend-only and non-invasive to avoid backend contract changes at this stage.

### Description
- Added a `Pipeline` button to the MOIS Sales Pages Library header that links to `/mois/sales-pages-library/pipeline` in `frontend/src/pages/mois/MoisSalesPagesLibraryPage.tsx`.
- Implemented a placeholder pipeline page `MoisSalesPagesPipelinePage` at `frontend/src/pages/mois/MoisSalesPagesPipelinePage.tsx` with a brief message and a back link to the library.
- Registered the new route in `frontend/src/App.tsx` and added an entry in the MOIS register `docs/registros/mois1.md` describing the change.
- No backend/API or data contracts were changed; this is navigation/UI scaffolding only.

### Testing
- Ran `npm run typecheck` in the frontend and it completed successfully (TypeScript typecheck passed).
- Captured a visual smoke check using `npx playwright screenshot http://127.0.0.1:5173/mois/sales-pages-library/pipeline /tmp/mois-sales-pages-pipeline-placeholder.png` which completed and produced the placeholder screenshot.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1f9b8915c08321ae8caeac55cb9f17)