### PR TITLE
Add Playwright screenshot rendering for Quality Review and send rendered images to OpenAI

### DIFF
--- a/ai-worker/Dockerfile
+++ b/ai-worker/Dockerfile
@@ -22,7 +22,7 @@ RUN mvn -s settings.xml -B package -DskipTests
 ########################################
 # Runtime stage
 ########################################
-FROM eclipse-temurin:21-jre
+FROM mcr.microsoft.com/playwright/java:v1.49.0-jammy
 WORKDIR /app
 
 COPY --from=build /workspace/target/app.jar ./app.jar

--- a/ai-worker/pom.xml
+++ b/ai-worker/pom.xml
@@ -60,6 +60,11 @@
             <version>2.3.32</version>
         </dependency>
         <dependency>
+            <groupId>com.microsoft.playwright</groupId>
+            <artifactId>playwright</artifactId>
+            <version>1.49.0</version>
+        </dependency>
+        <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <version>1.18.30</version>

--- a/ai-worker/src/main/java/com/marketinghub/worker/openai/core/qualityreview/PlaywrightQualityReviewScreenshotService.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/openai/core/qualityreview/PlaywrightQualityReviewScreenshotService.java
@@ -1,0 +1,132 @@
+package com.marketinghub.worker.openai.core.qualityreview;
+
+import com.marketinghub.worker.frameworkimage.FrameworkImageStorageClient;
+import com.marketinghub.worker.openai.core.exception.StageWorkerException;
+import com.microsoft.playwright.Browser;
+import com.microsoft.playwright.BrowserType;
+import com.microsoft.playwright.Page;
+import com.microsoft.playwright.Playwright;
+import com.microsoft.playwright.PlaywrightException;
+import com.microsoft.playwright.options.LoadState;
+import com.microsoft.playwright.options.ScreenshotType;
+import com.microsoft.playwright.options.WaitUntilState;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.ArrayList;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.util.StringUtils;
+
+/** Responsabilidade: renderizar HTML em Chromium headless, salvar screenshots públicos e expô-los para a OpenAI. */
+public class PlaywrightQualityReviewScreenshotService implements QualityReviewScreenshotService {
+
+    private static final Logger log = LoggerFactory.getLogger(PlaywrightQualityReviewScreenshotService.class);
+    private static final List<ViewportSpec> VIEWPORTS = List.of(
+            new ViewportSpec("desktop", 1440, 1200),
+            new ViewportSpec("mobile", 390, 1200)
+    );
+
+    private final FrameworkImageStorageClient storageClient;
+    private final QualityReviewWorkerProperties properties;
+
+    /** Inicializa o serviço com storage público e propriedades operacionais do Quality Review. */
+    public PlaywrightQualityReviewScreenshotService(
+            FrameworkImageStorageClient storageClient,
+            QualityReviewWorkerProperties properties
+    ) {
+        this.storageClient = storageClient;
+        this.properties = properties;
+    }
+
+    /** Renderiza o HTML final em viewports desktop e mobile e publica os screenshots no storage. */
+    @Override
+    public List<String> renderScreenshots(QualityReviewInput input) {
+        if (input == null || !StringUtils.hasText(input.landingHtml())) {
+            throw new StageWorkerException("Quality review cannot render screenshot without landing HTML");
+        }
+        try (Playwright playwright = Playwright.create(); Browser browser = launchBrowser(playwright)) {
+            List<String> screenshotUrls = new ArrayList<>();
+            for (ViewportSpec viewport : VIEWPORTS) {
+                screenshotUrls.add(renderAndUpload(browser, input, viewport));
+            }
+            return List.copyOf(screenshotUrls);
+        } catch (RuntimeException error) {
+            log.error(
+                    "Falha ao renderizar screenshots do Quality Review [jobId={}, experimentId={}, htmlLength={}]",
+                    input != null ? input.idJob() : null,
+                    input != null ? input.experimentId() : null,
+                    input != null && input.landingHtml() != null ? input.landingHtml().length() : 0,
+                    error);
+            throw error;
+        }
+    }
+
+    /** Inicializa Chromium headless usando o binário configurado quando disponível. */
+    private Browser launchBrowser(Playwright playwright) {
+        BrowserType.LaunchOptions options = new BrowserType.LaunchOptions()
+                .setHeadless(true)
+                .setArgs(List.of("--no-sandbox", "--disable-dev-shm-usage", "--disable-gpu"));
+        String executablePath = properties.chromiumExecutablePath();
+        if (StringUtils.hasText(executablePath) && Files.exists(Path.of(executablePath))) {
+            options.setExecutablePath(Path.of(executablePath));
+        }
+        return playwright.chromium().launch(options);
+    }
+
+    /** Renderiza uma viewport específica, captura JPEG full-page e publica no storage. */
+    private String renderAndUpload(Browser browser, QualityReviewInput input, ViewportSpec viewport) {
+        Page page = browser.newPage(new Browser.NewPageOptions()
+                .setViewportSize(viewport.width(), viewport.height())
+                .setDeviceScaleFactor(1));
+        try {
+            page.setContent(input.landingHtml(), new Page.SetContentOptions()
+                    .setWaitUntil(WaitUntilState.DOMCONTENTLOADED)
+                    .setTimeout(properties.screenshotTimeout().toMillis()));
+            waitForNetworkIdle(page, input, viewport);
+            byte[] screenshot = page.screenshot(new Page.ScreenshotOptions()
+                    .setFullPage(true)
+                    .setType(ScreenshotType.JPEG)
+                    .setQuality(82));
+            FrameworkImageStorageClient.UploadedFrameworkImage uploaded = storageClient.upload(
+                    screenshot,
+                    buildScreenshotFilename(input, viewport));
+            log.info(
+                    "Screenshot do Quality Review publicado [jobId={}, experimentId={}, viewport={}, publicUrl={}, bytes={}]",
+                    input.idJob(),
+                    input.experimentId(),
+                    viewport.name(),
+                    uploaded.publicUrl(),
+                    screenshot.length);
+            return uploaded.publicUrl();
+        } finally {
+            page.close();
+        }
+    }
+
+    /** Aguarda estabilidade de rede sem bloquear a revisão quando scripts externos mantêm conexões abertas. */
+    private void waitForNetworkIdle(Page page, QualityReviewInput input, ViewportSpec viewport) {
+        try {
+            page.waitForLoadState(LoadState.NETWORKIDLE, new Page.WaitForLoadStateOptions().setTimeout(5000));
+        } catch (PlaywrightException error) {
+            log.warn(
+                    "Network idle não atingido antes do screenshot do Quality Review; prosseguindo com DOM renderizado [jobId={}, viewport={}]",
+                    input.idJob(),
+                    viewport.name(),
+                    error);
+        }
+    }
+
+    /** Gera nome estável para o screenshot publicado no storage. */
+    private String buildScreenshotFilename(QualityReviewInput input, ViewportSpec viewport) {
+        String jobId = StringUtils.hasText(input.idJob()) ? input.idJob() : "quality-review";
+        return jobId + "-quality-review-" + viewport.name() + ".jpg";
+    }
+
+    /** Responsabilidade: representar uma viewport de screenshot da landing. */
+    private record ViewportSpec(String name, int width, int height) {
+        /** Preserva nome e dimensões da viewport para renderização do browser. */
+        private ViewportSpec {
+        }
+    }
+}

--- a/ai-worker/src/main/java/com/marketinghub/worker/openai/core/qualityreview/QualityReviewBackendClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/openai/core/qualityreview/QualityReviewBackendClient.java
@@ -1,5 +1,6 @@
 package com.marketinghub.worker.openai.core.qualityreview;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marketinghub.worker.openai.core.model.OpenAiDispatch;
 import com.marketinghub.worker.openai.core.model.OpenAiResult;
@@ -8,16 +9,18 @@ import com.marketinghub.worker.openai.core.port.StageBackendPort;
 import java.io.PrintWriter;
 import java.io.StringWriter;
 import java.time.Instant;
-import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.web.reactive.function.client.WebClient;
 
 /** Responsabilidade: integrar a revisão visual do core OpenAI aos endpoints internos do backend. */
 public class QualityReviewBackendClient implements StageBackendPort<QualityReviewInput, QualityReviewOutput> {
 
+    private static final Logger log = LoggerFactory.getLogger(QualityReviewBackendClient.class);
     private static final String STATUS_STARTED = "INICIADO";
 
     private final WebClient webClient;
@@ -84,7 +87,7 @@ public class QualityReviewBackendClient implements StageBackendPort<QualityRevie
         String stageCode = asString(item.get("stageCode"));
         String idJob = asString(item.get("jobid"));
         Map<String, Object> promptData = buildPromptDataFromPending(item);
-        QualityReviewInput input = new QualityReviewInput(experimentId, stageCode, idJob, promptData, extractImageUrls(promptData));
+        QualityReviewInput input = new QualityReviewInput(experimentId, stageCode, idJob, promptData, resolveLandingHtml(promptData));
         return new StageExecution<>(idJob, experimentId, stageCode, STATUS_STARTED, asInstant(item.get("executionRequestedAt")), input);
     }
 
@@ -119,39 +122,13 @@ public class QualityReviewBackendClient implements StageBackendPort<QualityRevie
         return builder.toString();
     }
 
-    /** Extrai URLs de imagens públicas dos artefatos da landing para entrada visual do modelo. */
-    private List<String> extractImageUrls(Map<String, Object> promptData) {
-        List<String> urls = new ArrayList<>();
-        collectUrls(promptData.get("landingPageImageAssets"), urls);
-        collectUrls(promptData.get("htmlGeraLanding"), urls);
-        collectUrls(promptData.get("landingPageHtml"), urls);
-        return urls.stream().distinct().limit(12).toList();
-    }
-
-    /** Coleta URLs http(s) de strings, listas e mapas aninhados. */
-    private void collectUrls(Object value, List<String> urls) {
-        if (value instanceof String text) {
-            if (text.trim().startsWith("{") || text.trim().startsWith("[")) {
-                try {
-                    collectUrls(objectMapper.readValue(text, Object.class), urls);
-                    return;
-                } catch (Exception ignored) {
-                    // continua com extração textual simples abaixo
-                }
-            }
-            java.util.regex.Matcher matcher = java.util.regex.Pattern.compile("https?://[^\\s\\\"'<>]+", java.util.regex.Pattern.CASE_INSENSITIVE).matcher(text);
-            while (matcher.find()) {
-                urls.add(matcher.group());
-            }
-            return;
+    /** Resolve o HTML final que deve ser renderizado em browser para gerar screenshots do Quality Review. */
+    private String resolveLandingHtml(Map<String, Object> promptData) {
+        String htmlGeraLanding = asString(promptData.get("htmlGeraLanding"));
+        if (htmlGeraLanding != null && !htmlGeraLanding.isBlank()) {
+            return htmlGeraLanding;
         }
-        if (value instanceof Map<?, ?> map) {
-            map.values().forEach(child -> collectUrls(child, urls));
-            return;
-        }
-        if (value instanceof Iterable<?> iterable) {
-            iterable.forEach(child -> collectUrls(child, urls));
-        }
+        return asString(promptData.get("landingPageHtml"));
     }
 
     /** Envia o callback de resposta ou falha da revisão visual ao backend. */
@@ -189,7 +166,8 @@ public class QualityReviewBackendClient implements StageBackendPort<QualityRevie
         }
         try {
             return objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(value);
-        } catch (Exception error) {
+        } catch (JsonProcessingException error) {
+            log.warn("Falha ao renderizar valor estruturado no contexto da revisão visual; usando toString como fallback", error);
             return value.toString();
         }
     }

--- a/ai-worker/src/main/java/com/marketinghub/worker/openai/core/qualityreview/QualityReviewInput.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/openai/core/qualityreview/QualityReviewInput.java
@@ -1,6 +1,5 @@
 package com.marketinghub.worker.openai.core.qualityreview;
 
-import java.util.List;
 import java.util.Map;
 
 /** Responsabilidade: transportar o payload de entrada da revisão visual de qualidade no core OpenAI. */
@@ -9,11 +8,10 @@ public record QualityReviewInput(
         String stageCode,
         String idJob,
         Map<String, Object> promptData,
-        List<String> imageUrls
+        String landingHtml
 ) {
     /** Normaliza dados opcionais para evitar coleções nulas durante a montagem do prompt visual. */
     public QualityReviewInput {
         promptData = promptData == null ? Map.of() : Map.copyOf(promptData);
-        imageUrls = imageUrls == null ? List.of() : List.copyOf(imageUrls);
     }
 }

--- a/ai-worker/src/main/java/com/marketinghub/worker/openai/core/qualityreview/QualityReviewPromptBuilder.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/openai/core/qualityreview/QualityReviewPromptBuilder.java
@@ -14,35 +14,47 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.core.io.ClassPathResource;
 
 /** Responsabilidade: montar prompt, schema e request multimodal OpenAI da revisão visual. */
 public class QualityReviewPromptBuilder implements StagePromptBuilder<QualityReviewInput> {
 
+    private static final Logger log = LoggerFactory.getLogger(QualityReviewPromptBuilder.class);
+
     private final ObjectMapper objectMapper;
     private final OpenAiClientProperties openAiProperties;
     private final QualityReviewWorkerProperties properties;
+    private final QualityReviewScreenshotService screenshotService;
     private final PromptTemplateResolver promptTemplateResolver;
 
-    /** Inicializa o builder com serializador, propriedades OpenAI e configurações da revisão visual. */
+    /** Inicializa o builder com serializador, propriedades OpenAI, screenshots e configurações da revisão visual. */
     public QualityReviewPromptBuilder(
             ObjectMapper objectMapper,
             OpenAiClientProperties openAiProperties,
-            QualityReviewWorkerProperties properties) {
+            QualityReviewWorkerProperties properties,
+            QualityReviewScreenshotService screenshotService) {
         this.objectMapper = objectMapper;
         this.openAiProperties = openAiProperties;
         this.properties = properties;
+        this.screenshotService = screenshotService;
         this.promptTemplateResolver = new PromptTemplateResolver(this::loadResource, this::toJsonOrText);
     }
 
-    /** Monta o request multimodal com texto e imagens disponíveis da landing para a Responses API. */
+    /** Monta o request multimodal com texto e screenshots renderizados da landing para a Responses API. */
     @Override
     public OpenAiRequest build(StageExecution<QualityReviewInput> execution) {
+        List<String> screenshotUrls = screenshotService.renderScreenshots(execution.input());
+        if (screenshotUrls.isEmpty()) {
+            throw new StageWorkerException("Quality review screenshot rendering did not produce images");
+        }
         String promptResource = properties.promptResource();
         String promptMarkdownContent = loadResource(promptResource);
-        String prompt = promptTemplateResolver.resolve(promptMarkdownContent, execution.input().promptData(), promptResource);
+        Map<String, Object> promptData = withScreenshotContext(execution.input().promptData(), screenshotUrls);
+        String prompt = promptTemplateResolver.resolve(promptMarkdownContent, promptData, promptResource);
         String schemaJson = loadResource(properties.schemaResource());
-        String requestBodyJson = buildResponsesApiRequest(prompt, schemaJson, execution.input().imageUrls());
+        String requestBodyJson = buildResponsesApiRequest(prompt, schemaJson, screenshotUrls);
         return new OpenAiRequest(
                 openAiProperties.model(),
                 prompt,
@@ -53,8 +65,18 @@ public class QualityReviewPromptBuilder implements StagePromptBuilder<QualityRev
                 Map.of("stageCode", execution.stageCode(), "idJob", execution.idJob(), "experimentId", execution.aggregateId()));
     }
 
-    /** Serializa o corpo compatível com Responses API usando schema estrito e entradas visuais por URL. */
-    private String buildResponsesApiRequest(String prompt, String schemaJson, List<String> imageUrls) {
+    /** Acrescenta as URLs dos screenshots renderizados ao contexto textual auditável do prompt. */
+    private Map<String, Object> withScreenshotContext(Map<String, Object> originalPromptData, List<String> screenshotUrls) {
+        Map<String, Object> promptData = new LinkedHashMap<>(originalPromptData);
+        promptData.put("renderedLandingScreenshots", screenshotUrls);
+        Object caseDataBlock = promptData.get("CASE_DATA_BLOCK");
+        String screenshotBlock = "\nrenderedLandingScreenshots: " + toJsonOrText(screenshotUrls).trim();
+        promptData.put("CASE_DATA_BLOCK", (caseDataBlock != null ? caseDataBlock.toString() : "") + screenshotBlock);
+        return promptData;
+    }
+
+    /** Serializa o corpo compatível com Responses API usando schema estrito e screenshots renderizados por URL. */
+    private String buildResponsesApiRequest(String prompt, String schemaJson, List<String> screenshotUrls) {
         try {
             Object schema = objectMapper.readValue(schemaJson, Object.class);
             Map<String, Object> format = new LinkedHashMap<>();
@@ -68,8 +90,8 @@ public class QualityReviewPromptBuilder implements StagePromptBuilder<QualityRev
 
             List<Map<String, Object>> content = new ArrayList<>();
             content.add(Map.of("type", "input_text", "text", prompt));
-            for (String imageUrl : imageUrls) {
-                content.add(Map.of("type", "input_image", "image_url", imageUrl, "detail", "high"));
+            for (String screenshotUrl : screenshotUrls) {
+                content.add(Map.of("type", "input_image", "image_url", screenshotUrl, "detail", "high"));
             }
 
             Map<String, Object> message = new LinkedHashMap<>();
@@ -97,6 +119,7 @@ public class QualityReviewPromptBuilder implements StagePromptBuilder<QualityRev
         try {
             return objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(value);
         } catch (JsonProcessingException error) {
+            log.warn("Falha ao renderizar placeholder do prompt quality-review; usando toString como fallback", error);
             return value.toString();
         }
     }

--- a/ai-worker/src/main/java/com/marketinghub/worker/openai/core/qualityreview/QualityReviewResponseHandler.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/openai/core/qualityreview/QualityReviewResponseHandler.java
@@ -15,10 +15,10 @@ public class QualityReviewResponseHandler implements StageResponseHandler<Qualit
     @Override
     public void handleSuccess(StageExecution<QualityReviewInput> execution, OpenAiResult<QualityReviewOutput> result) {
         log.info(
-                "Quality review execution completed. idJob={}, experimentId={}, imageCount={}, inputTokens={}, outputTokens={}, costUsd={}",
+                "Quality review execution completed. idJob={}, experimentId={}, htmlLength={}, inputTokens={}, outputTokens={}, costUsd={}",
                 execution.idJob(),
                 execution.aggregateId(),
-                execution.input().imageUrls().size(),
+                execution.input().landingHtml() != null ? execution.input().landingHtml().length() : 0,
                 result.inputTokens(),
                 result.outputTokens(),
                 result.costUsd());

--- a/ai-worker/src/main/java/com/marketinghub/worker/openai/core/qualityreview/QualityReviewScreenshotService.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/openai/core/qualityreview/QualityReviewScreenshotService.java
@@ -1,0 +1,10 @@
+package com.marketinghub.worker.openai.core.qualityreview;
+
+import java.util.List;
+
+/** Responsabilidade: produzir imagens renderizadas da landing para avaliação visual do Quality Review. */
+public interface QualityReviewScreenshotService {
+
+    /** Renderiza o HTML da landing e devolve URLs públicas dos screenshots gerados. */
+    List<String> renderScreenshots(QualityReviewInput input);
+}

--- a/ai-worker/src/main/java/com/marketinghub/worker/openai/core/qualityreview/QualityReviewWorkerConfiguration.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/openai/core/qualityreview/QualityReviewWorkerConfiguration.java
@@ -1,6 +1,7 @@
 package com.marketinghub.worker.openai.core.qualityreview;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marketinghub.worker.frameworkimage.FrameworkImageStorageClient;
 import com.marketinghub.worker.openai.core.StageWorker;
 import com.marketinghub.worker.openai.core.openai.OpenAiClientProperties;
 import com.marketinghub.worker.openai.core.openai.ResponsesApiOpenAiClient;
@@ -24,10 +25,20 @@ public class QualityReviewWorkerConfiguration {
         return new QualityReviewBackendClient(webClientBuilder, properties, objectMapper);
     }
 
+    /** Cria o serviço que renderiza o HTML final em Chromium e publica screenshots públicos. */
+    @Bean
+    public QualityReviewScreenshotService qualityReviewScreenshotService(FrameworkImageStorageClient storageClient, QualityReviewWorkerProperties properties) {
+        return new PlaywrightQualityReviewScreenshotService(storageClient, properties);
+    }
+
     /** Cria o builder responsável por montar prompt, schema e request OpenAI multimodal da revisão visual. */
     @Bean
-    public QualityReviewPromptBuilder qualityReviewPromptBuilder(ObjectMapper objectMapper, OpenAiClientProperties openAiProperties, QualityReviewWorkerProperties properties) {
-        return new QualityReviewPromptBuilder(objectMapper, openAiProperties, properties);
+    public QualityReviewPromptBuilder qualityReviewPromptBuilder(
+            ObjectMapper objectMapper,
+            OpenAiClientProperties openAiProperties,
+            QualityReviewWorkerProperties properties,
+            QualityReviewScreenshotService screenshotService) {
+        return new QualityReviewPromptBuilder(objectMapper, openAiProperties, properties, screenshotService);
     }
 
     /** Cria o validador da resposta JSON retornada pela OpenAI para a revisão visual. */

--- a/ai-worker/src/main/java/com/marketinghub/worker/openai/core/qualityreview/QualityReviewWorkerProperties.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/openai/core/qualityreview/QualityReviewWorkerProperties.java
@@ -18,7 +18,9 @@ public record QualityReviewWorkerProperties(
         @NotBlank String promptResource,
         @NotBlank String schemaResource,
         @NotBlank String schemaName,
-        @NotNull Duration timeout
+        @NotNull Duration timeout,
+        String chromiumExecutablePath,
+        @NotNull Duration screenshotTimeout
 ) {
     /** Normaliza valores opcionais usados pelo worker de revisão visual quando a configuração externa omite o campo. */
     public QualityReviewWorkerProperties {
@@ -27,6 +29,12 @@ public record QualityReviewWorkerProperties(
         }
         if (timeout == null) {
             timeout = Duration.ofMinutes(30);
+        }
+        if (chromiumExecutablePath == null || chromiumExecutablePath.isBlank()) {
+            chromiumExecutablePath = "/usr/bin/chromium";
+        }
+        if (screenshotTimeout == null || screenshotTimeout.isNegative() || screenshotTimeout.isZero()) {
+            screenshotTimeout = Duration.ofSeconds(30);
         }
     }
 }

--- a/ai-worker/src/main/resources/application.properties
+++ b/ai-worker/src/main/resources/application.properties
@@ -114,3 +114,5 @@ qualityreview.worker.prompt-resource=${QUALITYREVIEW_WORKER_PROMPT_RESOURCE:prom
 qualityreview.worker.schema-resource=${QUALITYREVIEW_WORKER_SCHEMA_RESOURCE:prompts/geralanding/landing-page-quality-review-schema.json}
 qualityreview.worker.schema-name=${QUALITYREVIEW_WORKER_SCHEMA_NAME:experiment_pipeline_landing_page_quality_review}
 qualityreview.worker.timeout=${QUALITYREVIEW_WORKER_TIMEOUT:PT30M}
+qualityreview.worker.chromium-executable-path=${QUALITYREVIEW_WORKER_CHROMIUM_EXECUTABLE_PATH:/usr/bin/chromium}
+qualityreview.worker.screenshot-timeout=${QUALITYREVIEW_WORKER_SCREENSHOT_TIMEOUT:PT30S}

--- a/ai-worker/src/main/resources/prompts/geralanding/landing-page-quality-review.md
+++ b/ai-worker/src/main/resources/prompts/geralanding/landing-page-quality-review.md
@@ -4,6 +4,8 @@ template_id: landing-page-quality-review
 
 Você é o avaliador comercial visual final do GeraLanding. Avalie a landing como usuário real, priorizando percepção visual, clareza da oferta e potencial de conversão.
 
+Você receberá screenshots renderizados da landing final em browser headless (desktop e mobile). Use esses screenshots como evidência visual principal; os demais artefatos textuais servem apenas como contexto para entender a intenção comercial.
+
 Use o eixo obrigatório: Dor → Resultado → Mecanismo → Prova → Oferta.
 
 Contexto do experimento:

--- a/ai-worker/src/test/java/com/marketinghub/worker/openai/core/qualityreview/QualityReviewBackendClientTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/openai/core/qualityreview/QualityReviewBackendClientTest.java
@@ -1,0 +1,85 @@
+package com.marketinghub.worker.openai.core.qualityreview;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marketinghub.worker.openai.core.model.StageExecution;
+import java.time.Duration;
+import java.util.List;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.reactive.function.client.WebClient;
+
+/** Responsabilidade: validar o contrato HTTP do client quality-review. */
+class QualityReviewBackendClientTest {
+
+    private MockWebServer server;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    /** Inicializa o backend simulado usado para retornar jobs pendentes de quality-review. */
+    @BeforeEach
+    void setUp() throws Exception {
+        server = new MockWebServer();
+        server.start();
+    }
+
+    /** Encerra o backend simulado após cada teste do client quality-review. */
+    @AfterEach
+    void tearDown() throws Exception {
+        server.shutdown();
+    }
+
+    /** Deve expor o HTML final para que o prompt builder gere screenshots renderizados em browser. */
+    @Test
+    void listPendingShouldExposeFinalLandingHtmlForScreenshotRendering() {
+        server.enqueue(new MockResponse()
+                .setHeader("Content-Type", "application/json")
+                .setBody("""
+                        [
+                          {
+                            "experimentId": 36,
+                            "jobid": "job-quality-1",
+                            "stageCode": "landing-page-quality-review",
+                            "executionRequestedAt": "2026-06-03T03:30:00Z",
+                            "hypothesis": {"framework": {"pain": {}}},
+                            "experiment": {
+                              "htmlGeraLanding": "<!doctype html><html><body><h1>Landing final</h1></body></html>",
+                              "landingPageHtml": "<html><body>Fallback antigo</body></html>",
+                              "landingPageImageAssets": {"images": [{"sourceUrl": "https://cdn.example.com/hero.jpg"}]}
+                            }
+                          }
+                        ]
+                        """));
+        QualityReviewBackendClient client = new QualityReviewBackendClient(
+                WebClient.builder(),
+                properties(),
+                objectMapper);
+
+        List<StageExecution<QualityReviewInput>> pending = client.listPending(5);
+
+        assertThat(pending).hasSize(1);
+        assertThat(pending.getFirst().input().landingHtml())
+                .isEqualTo("<!doctype html><html><body><h1>Landing final</h1></body></html>");
+        assertThat(pending.getFirst().input().promptData())
+                .containsKey("CASE_DATA_BLOCK")
+                .containsEntry("landingPageImageAssets", java.util.Map.of("images", List.of(java.util.Map.of("sourceUrl", "https://cdn.example.com/hero.jpg"))));
+    }
+
+    /** Monta propriedades mínimas para o client quality-review usado no teste. */
+    private QualityReviewWorkerProperties properties() {
+        return new QualityReviewWorkerProperties(
+                true,
+                5,
+                server.url("/").toString(),
+                "/api",
+                "prompts/geralanding/landing-page-quality-review.md",
+                "prompts/geralanding/landing-page-quality-review-schema.json",
+                "experiment_pipeline_landing_page_quality_review",
+                Duration.ofSeconds(5),
+                "/usr/bin/chromium",
+                Duration.ofSeconds(5));
+    }
+}

--- a/ai-worker/src/test/java/com/marketinghub/worker/openai/core/qualityreview/QualityReviewPromptBuilderTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/openai/core/qualityreview/QualityReviewPromptBuilderTest.java
@@ -1,0 +1,90 @@
+package com.marketinghub.worker.openai.core.qualityreview;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marketinghub.worker.openai.core.model.OpenAiRequest;
+import com.marketinghub.worker.openai.core.model.StageExecution;
+import com.marketinghub.worker.openai.core.openai.OpenAiClientProperties;
+import java.math.BigDecimal;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/** Responsabilidade: validar o request multimodal da etapa quality-review. */
+class QualityReviewPromptBuilderTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    /** Deve enviar somente screenshots renderizados como imagens do request OpenAI, não URLs soltas do HTML. */
+    @Test
+    void buildShouldSendRenderedScreenshotsAsVisionInputs() throws Exception {
+        QualityReviewPromptBuilder builder = new QualityReviewPromptBuilder(
+                objectMapper,
+                openAiProperties(),
+                workerProperties(),
+                input -> List.of(
+                        "https://cdn.example.com/screens/job-quality-1-desktop.jpg",
+                        "https://cdn.example.com/screens/job-quality-1-mobile.jpg"));
+        StageExecution<QualityReviewInput> execution = new StageExecution<>(
+                "job-quality-1",
+                36L,
+                "landing-page-quality-review",
+                "INICIADO",
+                Instant.parse("2026-06-03T03:30:00Z"),
+                new QualityReviewInput(
+                        36L,
+                        "landing-page-quality-review",
+                        "job-quality-1",
+                        Map.of(
+                                "CASE_DATA_BLOCK", "[CASE_DATA_BEGIN]\nlandingPageImageAssets: https://cdn.example.com/asset-hero.jpg\n[CASE_DATA_END]",
+                                "landingPageImageAssets", Map.of("sourceUrl", "https://cdn.example.com/asset-hero.jpg")),
+                        "<!doctype html><html><body>Landing</body></html>"));
+
+        OpenAiRequest request = builder.build(execution);
+
+        Map<String, Object> body = objectMapper.readValue(request.requestBodyJson(), new TypeReference<>() {});
+        List<Map<String, Object>> input = (List<Map<String, Object>>) body.get("input");
+        List<Map<String, Object>> content = (List<Map<String, Object>>) input.getFirst().get("content");
+        assertThat(content)
+                .filteredOn(item -> "input_image".equals(item.get("type")))
+                .extracting(item -> item.get("image_url"))
+                .containsExactly(
+                        "https://cdn.example.com/screens/job-quality-1-desktop.jpg",
+                        "https://cdn.example.com/screens/job-quality-1-mobile.jpg");
+        assertThat(content)
+                .filteredOn(item -> "input_image".equals(item.get("type")))
+                .extracting(item -> item.get("image_url"))
+                .doesNotContain("https://cdn.example.com/asset-hero.jpg");
+    }
+
+    /** Cria propriedades OpenAI mínimas para montar o request do teste. */
+    private OpenAiClientProperties openAiProperties() {
+        return new OpenAiClientProperties(
+                "test-key",
+                "https://api.openai.com/v1",
+                "gpt-5.2",
+                Duration.ofSeconds(5),
+                BigDecimal.ZERO,
+                BigDecimal.ZERO,
+                false);
+    }
+
+    /** Cria propriedades operacionais mínimas para o builder quality-review. */
+    private QualityReviewWorkerProperties workerProperties() {
+        return new QualityReviewWorkerProperties(
+                true,
+                5,
+                "http://backend.test",
+                "/api",
+                "prompts/geralanding/landing-page-quality-review.md",
+                "prompts/geralanding/landing-page-quality-review-schema.json",
+                "experiment_pipeline_landing_page_quality_review",
+                Duration.ofSeconds(5),
+                "/usr/bin/chromium",
+                Duration.ofSeconds(5));
+    }
+}

--- a/docs/canonical/geralanding-arquitetura-canon.v1.md
+++ b/docs/canonical/geralanding-arquitetura-canon.v1.md
@@ -44,8 +44,8 @@ Regras arquiteturais refletidas (ArchUnit):
 ## Quality Review visual
 
 - A etapa `landing-page-quality-review` é o Quality Gate comercial final do GeraLanding e deve usar modelo de visão da OpenAI como avaliador principal da experiência renderizada.
-- O backend deve produzir ou disponibilizar screenshots desktop e mobile da landing após a montagem do `htmlGeraLanding`, mantendo validações determinísticas apenas como pré-check técnico de HTML, renderização e ausência de metadados proibidos.
-- O Worker AI deve processar a etapa pelo contrato canônico `pending` → `recebePrompt` → `recebeResposta`, enviando ao modelo de visão os screenshots e contexto textual mínimo dos artefatos canônicos para avaliar Dor → Resultado → Mecanismo → Prova → Oferta.
+- O backend deve disponibilizar o `htmlGeraLanding` final na fila da etapa; a renderização visual deve produzir screenshots desktop e mobile em browser/headless antes da chamada ao modelo, mantendo validações determinísticas apenas como pré-check técnico de HTML, renderização e ausência de metadados proibidos.
+- O Worker AI deve processar a etapa pelo contrato canônico `pending` → `recebePrompt` → `recebeResposta`, renderizar o HTML final em browser/headless quando o backend ainda não trouxer screenshots prontos, publicar os screenshots e enviá-los ao modelo de visão com contexto textual mínimo dos artefatos canônicos para avaliar Dor → Resultado → Mecanismo → Prova → Oferta.
 - A resposta da etapa deve permanecer estruturada com `score`, `targetAudienceSpecificity`, `blockingIssues`, `recommendedRegeneration` e `approvalRecommendation`, indicando explicitamente as etapas que precisam ser reexecutadas.
 
 ## 2) Worker AI — núcleo OpenAI (`ai-worker / com.marketinghub.worker.openai.core`)

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -3173,3 +3173,26 @@
   - incluído o card `6 - Quality Review` entre `5 - Gera Preset Design` e `7 - Gera Entregáveis`, com botão de início, estado de carregamento, jobs em execução, histórico e custo total;
   - o total consolidado das etapas do GeraLanding passou a considerar também o custo das execuções de Quality Review.
 - impacto esperado: o usuário consegue executar e auditar o Quality Gate comercial visual na ordem correta antes de gerar os entregáveis finais.
+
+## 2026-06-03 — Correção de URL vazia no Quality Review visual
+
+- solicitação: investigar e corrigir falha do job `2608e1e4-0689-4d9b-9868-0c82f0f3361b` na etapa `landing-page-quality-review`, onde a OpenAI Responses API retornou HTTP 400 por arquivo baixado sem dados.
+- causa-raiz: o Worker AI extraía qualquer URL HTTP encontrada no HTML final da landing e enviava todas como `input_image`; no Experimento 36 isso incluiu o pixel `<noscript>` do Facebook (`https://www.facebook.com/tr?...`), que responde HTTP 200 com corpo vazio e fez a OpenAI tentar baixar uma “imagem” sem bytes.
+- registro do que foi feito:
+  - filtragem da extração visual no `QualityReviewBackendClient` para manter somente URLs de imagem reais ou campos canônicos de assets (`sourceUrl`, `resolvedUrl`, `imageUrl`, etc.);
+  - descarte de scripts, pixels de tracking e endpoints sem extensão de imagem no HTML antes da montagem do request multimodal;
+  - adicionado teste de regressão cobrindo HTML com `fbevents.js` e pixel vazio do Facebook, garantindo que apenas imagens válidas entrem no `imageUrls` do Quality Review.
+- impacto esperado: novas execuções do Quality Review não devem mais falhar por URLs de tracking/analytics ou recursos externos sem dados enviados como imagem para a OpenAI.
+
+## 2026-06-03 — Quality Review visual por screenshot renderizado
+
+- solicitação: corrigir a abordagem da etapa `landing-page-quality-review`, pois revisar imagens soltas da landing não representa a experiência real do usuário; a etapa deve carregar o HTML em um browser/headless, gerar print da página e enviar esse screenshot ao modelo de visão da OpenAI.
+- causa-raiz/objetivo: a implementação anterior extraía URLs de imagens/assets do HTML, mas isso avalia componentes isolados e ainda corre risco de capturar URLs não visuais; o Quality Gate comercial precisa avaliar a landing renderizada como o usuário enxerga.
+- registro do que foi feito:
+  - o Worker AI passou a manter o HTML final (`htmlGeraLanding`, com fallback para `landingPageHtml`) no input da etapa;
+  - criado serviço de screenshot com Chromium/Playwright para renderizar o HTML em viewports desktop e mobile, capturar JPEG full-page, publicar no storage público e enviar apenas esses screenshots como `input_image` da Responses API;
+  - atualizado o prompt do Quality Review para tratar os screenshots renderizados como evidência visual principal e os artefatos textuais apenas como contexto;
+  - atualizado o Dockerfile do AI Worker para disponibilizar Chromium no runtime;
+  - atualizado o cânone de arquitetura do GeraLanding para explicitar que o Worker AI pode renderizar o HTML em browser/headless quando o backend disponibiliza o HTML final;
+  - substituídos testes de filtragem de URL por testes que validam exposição do HTML final e uso exclusivo dos screenshots renderizados no request multimodal.
+- impacto esperado: o Quality Review passa a avaliar a experiência visual real da landing final, reduzindo falso diagnóstico por imagens isoladas e evitando enviar pixels/scripts como imagens ao modelo.


### PR DESCRIPTION
### Motivation

- Provide a reliable visual representation of the final landing by rendering the final HTML in a headless browser and sending screenshots to the OpenAI Responses API instead of sending raw image URLs extracted from HTML.
- Avoid failures caused by non-image URLs (tracking pixels / scripts) and improve the commercial quality gate by evaluating the real rendered experience.

### Description

- Added a `QualityReviewScreenshotService` and a `PlaywrightQualityReviewScreenshotService` that launches Chromium via Playwright, renders `htmlGeraLanding` (with fallback to `landingPageHtml`) in desktop and mobile viewports, captures full-page JPEG screenshots and uploads them via `FrameworkImageStorageClient` for public URLs.
- Switched the prompt pipeline to use rendered screenshots: `QualityReviewPromptBuilder` now requests screenshots from `QualityReviewScreenshotService`, injects `renderedLandingScreenshots` into the prompt context and includes those URLs as `input_image` entries in the Responses API request.
- Replaced previous image-URL-extraction logic in `QualityReviewBackendClient` with `resolveLandingHtml(...)` so the backend exposes final HTML to be rendered; added logging and safer JSON serialization handling.
- Exposed new properties `qualityreview.worker.chromium-executable-path` and `qualityreview.worker.screenshot-timeout` via `QualityReviewWorkerProperties` with sane defaults, and registered the screenshot service bean in `QualityReviewWorkerConfiguration`.
- Updated runtime image in the `ai-worker/Dockerfile` to `mcr.microsoft.com/playwright/java:v1.49.0-jammy` and added `com.microsoft.playwright:playwright:1.49.0` to `pom.xml` so Chromium is available at runtime.
- Added unit tests `QualityReviewBackendClientTest` and `QualityReviewPromptBuilderTest`, updated prompt template and docs to describe the screenshot-based approach and recorded the rationale and regressions fixed.

### Testing

- Ran new unit tests `QualityReviewBackendClientTest` and `QualityReviewPromptBuilderTest`, and both tests passed.
- Ran module unit test suite for `ai-worker` locally and no regressions were observed in the modified area.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1fa16a89308321bda3455252057536)