### PR TITLE
Add raw-HTML capture pipeline: DB table, backend endpoints and worker integration

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/dto/MoisSalesLibraryDtos.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/dto/MoisSalesLibraryDtos.java
@@ -61,6 +61,52 @@ public final class MoisSalesLibraryDtos {
     private MoisSalesLibraryDtos() {
     }
 
+
+    public record CollectedReferenceHtmlClaimRequest(
+            @NotBlank String workspaceId,
+            @NotBlank String source
+    ) {
+    }
+
+    public record CollectedReferenceHtmlCaptureJob(
+            long captureId,
+            long collectedReferenceId,
+            String collectionJobId,
+            String referenceId,
+            String source,
+            String title,
+            String url,
+            String urlSource
+    ) {
+    }
+
+    public record CollectedReferenceHtmlClaimResponse(
+            boolean claimed,
+            CollectedReferenceHtmlCaptureJob job
+    ) {
+    }
+
+    public record CollectedReferenceHtmlCompleteRequest(
+            @NotBlank String rawHtml,
+            String finalUrl,
+            Integer httpStatus,
+            String contentType,
+            Instant fetchedAt
+    ) {
+    }
+
+    public record CollectedReferenceHtmlFailRequest(
+            String errorCategory,
+            String errorMessage
+    ) {
+    }
+
+    public record CollectedReferenceHtmlPersistResponse(
+            long captureId,
+            String status
+    ) {
+    }
+
     public record SalesLibraryIngestRequest(
             @NotBlank String workspaceId,
             @NotBlank String source,

--- a/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryService.java
@@ -2,6 +2,9 @@ package com.marketinghub.mois.bibliotecapaginavenda.worker.v1.service;
 
 import com.marketinghub.mois.bibliotecapaginavenda.worker.v1.dto.MoisSalesLibraryDtos;
 import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.net.URI;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -11,9 +14,12 @@ import java.time.LocalDateTime;
 import java.time.ZoneOffset;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.HexFormat;
 import java.util.Locale;
+import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.dao.DataAccessException;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -133,6 +139,116 @@ public class MoisSalesLibraryService {
                 counters.jobsCreated(),
                 skippedWithoutUrl + counters.skippedWithoutUrl()
         );
+    }
+
+    /**
+     * Reserva uma referência coletada para a primeira etapa do pipeline de captura de HTML bruto.
+     */
+    @Transactional
+    public MoisSalesLibraryDtos.CollectedReferenceHtmlClaimResponse claimCollectedReferenceHtml(
+            MoisSalesLibraryDtos.CollectedReferenceHtmlClaimRequest request
+    ) {
+        String normalizedSource = request.source().trim().toUpperCase(Locale.ROOT);
+        String claimedBy = UUID.randomUUID().toString();
+        try {
+            int inserted = jdbcTemplate.update(
+                    """
+                            INSERT INTO mois_collected_reference_html_capture
+                              (collected_reference_id, workspace_id, source, collection_job_id, reference_id, title,
+                               url_source, url_original, status, claimed_by, claimed_at, created_at, updated_at)
+                            SELECT r.id, r.workspace_id, r.source, r.job_id, r.reference_id,
+                                   COALESCE(NULLIF(r.product_name, ''), NULLIF(r.title, ''), r.reference_id),
+                                   CASE
+                                     WHEN r.sales_page_url IS NOT NULL AND r.sales_page_url <> '' THEN 'SALES_PAGE_URL'
+                                     WHEN r.product_url IS NOT NULL AND r.product_url <> '' THEN 'PRODUCT_URL'
+                                     ELSE 'URL'
+                                   END,
+                                   COALESCE(NULLIF(r.sales_page_url, ''), NULLIF(r.product_url, ''), NULLIF(r.url, '')),
+                                   'CLAIMED', ?, UTC_TIMESTAMP(), UTC_TIMESTAMP(), UTC_TIMESTAMP()
+                            FROM mois_collected_reference r
+                            WHERE r.workspace_id = ?
+                              AND r.source = ?
+                              AND COALESCE(NULLIF(r.sales_page_url, ''), NULLIF(r.product_url, ''), NULLIF(r.url, '')) IS NOT NULL
+                              AND NOT EXISTS (
+                                SELECT 1 FROM mois_collected_reference_html_capture c
+                                WHERE c.collected_reference_id = r.id
+                              )
+                            ORDER BY r.collected_at ASC, r.id ASC
+                            LIMIT 1
+                            """,
+                    claimedBy,
+                    request.workspaceId(),
+                    normalizedSource);
+            if (inserted == 0) {
+                return new MoisSalesLibraryDtos.CollectedReferenceHtmlClaimResponse(false, null);
+            }
+            return findClaimedCollectedReferenceHtml(claimedBy)
+                    .map(job -> new MoisSalesLibraryDtos.CollectedReferenceHtmlClaimResponse(true, job))
+                    .orElseGet(() -> new MoisSalesLibraryDtos.CollectedReferenceHtmlClaimResponse(false, null));
+        } catch (DataAccessException ex) {
+            log.warn("Falha ao reservar HTML bruto de referência coletada. operacao=claimCollectedReferenceHtml, workspaceId={}, source={}, claimedBy={}, erroClasse={}, erro={}",
+                    request.workspaceId(), normalizedSource, claimedBy, ex.getClass().getName(), ex.getMessage(), ex);
+            return new MoisSalesLibraryDtos.CollectedReferenceHtmlClaimResponse(false, null);
+        }
+    }
+
+    /**
+     * Persiste o HTML bruto capturado pelo worker MOIS para uma referência coletada.
+     */
+    @Transactional
+    public MoisSalesLibraryDtos.CollectedReferenceHtmlPersistResponse completeCollectedReferenceHtml(
+            long captureId,
+            MoisSalesLibraryDtos.CollectedReferenceHtmlCompleteRequest request
+    ) {
+        String rawHtml = request.rawHtml() == null ? "" : request.rawHtml();
+        byte[] rawHtmlBytes = rawHtml.getBytes(StandardCharsets.UTF_8);
+        jdbcTemplate.update(
+                """
+                        UPDATE mois_collected_reference_html_capture
+                        SET status = 'CAPTURED',
+                            url_final = ?,
+                            http_status = ?,
+                            content_type = ?,
+                            raw_html = ?,
+                            raw_html_sha256 = ?,
+                            raw_html_bytes = ?,
+                            error_message = NULL,
+                            fetched_at = ?,
+                            updated_at = UTC_TIMESTAMP()
+                        WHERE id = ?
+                        """,
+                truncate(request.finalUrl(), 1024),
+                request.httpStatus(),
+                truncate(request.contentType(), 255),
+                rawHtml,
+                sha256(rawHtml),
+                rawHtmlBytes.length,
+                Timestamp.from(request.fetchedAt() == null ? Instant.now() : request.fetchedAt()),
+                captureId);
+        return new MoisSalesLibraryDtos.CollectedReferenceHtmlPersistResponse(captureId, "CAPTURED");
+    }
+
+    /**
+     * Registra falha terminal da captura de HTML bruto de uma referência coletada.
+     */
+    @Transactional
+    public MoisSalesLibraryDtos.CollectedReferenceHtmlPersistResponse failCollectedReferenceHtml(
+            long captureId,
+            MoisSalesLibraryDtos.CollectedReferenceHtmlFailRequest request
+    ) {
+        String message = coalesceNotBlank(request.errorMessage(), request.errorCategory(), "Falha sem detalhe");
+        jdbcTemplate.update(
+                """
+                        UPDATE mois_collected_reference_html_capture
+                        SET status = 'FAILED',
+                            error_message = ?,
+                            fetched_at = UTC_TIMESTAMP(),
+                            updated_at = UTC_TIMESTAMP()
+                        WHERE id = ?
+                        """,
+                truncate(message, 1000),
+                captureId);
+        return new MoisSalesLibraryDtos.CollectedReferenceHtmlPersistResponse(captureId, "FAILED");
     }
 
     /**
@@ -381,6 +497,56 @@ public class MoisSalesLibraryService {
             persisted++;
         }
         return new IngestCounters(persisted, inserted, updated, jobsCreated, skippedWithoutUrl);
+    }
+
+
+    /**
+     * Localiza o item recém-reservado pelo token de claim do worker.
+     */
+    private java.util.Optional<MoisSalesLibraryDtos.CollectedReferenceHtmlCaptureJob> findClaimedCollectedReferenceHtml(String claimedBy) {
+        return jdbcTemplate.query(
+                """
+                        SELECT id, collected_reference_id, collection_job_id, reference_id, source, title, url_original, url_source
+                        FROM mois_collected_reference_html_capture
+                        WHERE claimed_by = ?
+                          AND status = 'CLAIMED'
+                        ORDER BY claimed_at DESC, id DESC
+                        LIMIT 1
+                        """,
+                (rs, rowNum) -> new MoisSalesLibraryDtos.CollectedReferenceHtmlCaptureJob(
+                        rs.getLong("id"),
+                        rs.getLong("collected_reference_id"),
+                        rs.getString("collection_job_id"),
+                        rs.getString("reference_id"),
+                        rs.getString("source"),
+                        rs.getString("title"),
+                        rs.getString("url_original"),
+                        rs.getString("url_source")),
+                claimedBy)
+                .stream()
+                .findFirst();
+    }
+
+    /**
+     * Calcula SHA-256 do HTML bruto para deduplicação e auditoria.
+     */
+    private String sha256(String value) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            return HexFormat.of().formatHex(digest.digest(value.getBytes(StandardCharsets.UTF_8)));
+        } catch (NoSuchAlgorithmException ex) {
+            throw new IllegalStateException("SHA-256 indisponível", ex);
+        }
+    }
+
+    /**
+     * Limita textos persistidos em colunas de tamanho fixo.
+     */
+    private String truncate(String value, int maxLength) {
+        if (value == null) {
+            return null;
+        }
+        return value.length() <= maxLength ? value : value.substring(0, maxLength);
     }
 
     /**

--- a/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/web/MoisSalesLibraryController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/web/MoisSalesLibraryController.java
@@ -32,6 +32,39 @@ public class MoisSalesLibraryController {
     private final MoisSalesLibraryService service;
     private final MoisSalesLibrarySnapshotService snapshotService;
 
+
+    /**
+     * Reserva a próxima URL de referência coletada para captura de HTML bruto pelo worker MOIS.
+     */
+    @PostMapping("/collected-reference-html:claim")
+    public MoisSalesLibraryDtos.CollectedReferenceHtmlClaimResponse claimCollectedReferenceHtml(
+            @Valid @RequestBody MoisSalesLibraryDtos.CollectedReferenceHtmlClaimRequest request
+    ) {
+        return service.claimCollectedReferenceHtml(request);
+    }
+
+    /**
+     * Recebe o HTML bruto capturado pelo worker MOIS para a referência reservada.
+     */
+    @PostMapping("/collected-reference-html/{captureId}:complete")
+    public MoisSalesLibraryDtos.CollectedReferenceHtmlPersistResponse completeCollectedReferenceHtml(
+            @PathVariable long captureId,
+            @Valid @RequestBody MoisSalesLibraryDtos.CollectedReferenceHtmlCompleteRequest request
+    ) {
+        return service.completeCollectedReferenceHtml(captureId, request);
+    }
+
+    /**
+     * Registra falha na captura de HTML bruto de uma referência reservada.
+     */
+    @PostMapping("/collected-reference-html/{captureId}:fail")
+    public MoisSalesLibraryDtos.CollectedReferenceHtmlPersistResponse failCollectedReferenceHtml(
+            @PathVariable long captureId,
+            @RequestBody MoisSalesLibraryDtos.CollectedReferenceHtmlFailRequest request
+    ) {
+        return service.failCollectedReferenceHtml(captureId, request);
+    }
+
     /**
      * Lista entradas de URLs ingeridas pela biblioteca.
      */

--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-03-mois-collected-reference-html-capture.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-03-mois-collected-reference-html-capture.yaml
@@ -1,0 +1,50 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-06-03-mois-collected-reference-html-capture-01
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - onError: HALT
+        - dbms:
+            type: mysql
+        - tableExists:
+            tableName: mois_collected_reference
+        - not:
+            tableExists:
+              tableName: mois_collected_reference_html_capture
+      changes:
+        - sql:
+            splitStatements: true
+            stripComments: true
+            sql: |
+              CREATE TABLE mois_collected_reference_html_capture (
+                id BIGINT NOT NULL AUTO_INCREMENT,
+                collected_reference_id BIGINT NOT NULL,
+                workspace_id VARCHAR(80) NOT NULL,
+                source VARCHAR(64) NOT NULL,
+                collection_job_id VARCHAR(80) NOT NULL,
+                reference_id VARCHAR(80) NOT NULL,
+                title VARCHAR(512) NULL,
+                url_source VARCHAR(40) NOT NULL,
+                url_original VARCHAR(1024) NOT NULL,
+                url_final VARCHAR(1024) NULL,
+                status VARCHAR(32) NOT NULL,
+                claimed_by VARCHAR(80) NULL,
+                http_status INT NULL,
+                content_type VARCHAR(255) NULL,
+                raw_html LONGTEXT NULL,
+                raw_html_sha256 VARCHAR(64) NULL,
+                raw_html_bytes BIGINT NOT NULL DEFAULT 0,
+                error_message VARCHAR(1000) NULL,
+                claimed_at DATETIME NULL,
+                fetched_at DATETIME NULL,
+                created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+                PRIMARY KEY (id),
+                UNIQUE KEY uk_mois_collected_reference_html_ref (collected_reference_id),
+                KEY idx_mois_collected_reference_html_status (workspace_id, source, status, updated_at),
+                KEY idx_mois_collected_reference_html_job (collection_job_id, reference_id),
+                CONSTRAINT fk_mois_collected_reference_html_ref
+                  FOREIGN KEY (collected_reference_id) REFERENCES mois_collected_reference(id)
+                  ON DELETE CASCADE
+              ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -836,3 +836,6 @@ databaseChangeLog:
       file: changesets/2026-06-01-epm-sprint2-api-fields.yaml
       relativeToChangelogFile: true
 
+  - include:
+      file: changesets/2026-06-03-mois-collected-reference-html-capture.yaml
+      relativeToChangelogFile: true

--- a/backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryServiceTest.java
@@ -110,6 +110,68 @@ class MoisSalesLibraryServiceTest {
     }
 
     /**
+     * Garante que o claim de HTML bruto lê a tabela de referências coletadas e retorna a URL reservada.
+     */
+    @Test
+    void shouldClaimCollectedReferenceHtmlFromCollectedReferenceTable() throws Exception {
+        MoisSalesLibraryDtos.CollectedReferenceHtmlClaimRequest request =
+                new MoisSalesLibraryDtos.CollectedReferenceHtmlClaimRequest("workspace-001", "hotmart");
+
+        given(jdbcTemplate.update(contains("INSERT INTO mois_collected_reference_html_capture"), any(), eq("workspace-001"), eq("HOTMART")))
+                .willReturn(1);
+        given(jdbcTemplate.query(contains("FROM mois_collected_reference_html_capture"), isA(RowMapper.class), any()))
+                .willAnswer(invocation -> {
+                    RowMapper<?> mapper = invocation.getArgument(1);
+                    ResultSet row = htmlCaptureRow();
+                    return List.of(mapper.mapRow(row, 0));
+                });
+
+        MoisSalesLibraryDtos.CollectedReferenceHtmlClaimResponse response = service.claimCollectedReferenceHtml(request);
+
+        org.assertj.core.api.Assertions.assertThat(response.claimed()).isTrue();
+        org.assertj.core.api.Assertions.assertThat(response.job().url()).isEqualTo("https://go.hotmart.com/A1");
+        org.assertj.core.api.Assertions.assertThat(response.job().urlSource()).isEqualTo("SALES_PAGE_URL");
+    }
+
+    /**
+     * Garante persistência de HTML bruto capturado com status final CAPTURED.
+     */
+    @Test
+    void shouldCompleteCollectedReferenceHtmlCapture() {
+        MoisSalesLibraryDtos.CollectedReferenceHtmlCompleteRequest request =
+                new MoisSalesLibraryDtos.CollectedReferenceHtmlCompleteRequest(
+                        "<html><body>Oferta</body></html>",
+                        "https://final.example/oferta",
+                        200,
+                        "text/html",
+                        Instant.parse("2026-06-03T10:00:00Z"));
+
+        MoisSalesLibraryDtos.CollectedReferenceHtmlPersistResponse response = service.completeCollectedReferenceHtml(10L, request);
+
+        verify(jdbcTemplate).update(contains("UPDATE mois_collected_reference_html_capture"),
+                eq("https://final.example/oferta"), eq(200), eq("text/html"), eq("<html><body>Oferta</body></html>"),
+                any(), eq(32), any(), eq(10L));
+        org.assertj.core.api.Assertions.assertThat(response.status()).isEqualTo("CAPTURED");
+    }
+
+
+    /**
+     * Monta uma linha simulada de captura de HTML bruto reservada.
+     */
+    private ResultSet htmlCaptureRow() throws Exception {
+        ResultSet resultSet = org.mockito.Mockito.mock(ResultSet.class);
+        given(resultSet.getLong("id")).willReturn(10L);
+        given(resultSet.getLong("collected_reference_id")).willReturn(20L);
+        given(resultSet.getString("collection_job_id")).willReturn("hotmart-job-400");
+        given(resultSet.getString("reference_id")).willReturn("ref-1");
+        given(resultSet.getString("source")).willReturn("HOTMART");
+        given(resultSet.getString("title")).willReturn("Produto");
+        given(resultSet.getString("url_original")).willReturn("https://go.hotmart.com/A1");
+        given(resultSet.getString("url_source")).willReturn("SALES_PAGE_URL");
+        return resultSet;
+    }
+
+    /**
      * Monta uma linha simulada de produto Hotmart coletado para o mapper JDBC.
      */
     private ResultSet collectedReferenceRow(

--- a/docs/canonical/mois-worker-canon.v1.md
+++ b/docs/canonical/mois-worker-canon.v1.md
@@ -462,3 +462,19 @@ Fonte externa] -->|Coleta de produtos/URLs| CC[mois-clickbank-collector\npackage
 ### 12.6 Diagrama de arquitetura por módulo/pacote — Gera Landing (movido)
 
 Este diagrama foi movido para o cânone de experimento em `docs/canonical/procedimento-experimento-canon.v1.md`, seção **15.4**, para centralizar as regras canônicas do fluxo Gera Landing em um único documento.
+
+### 13.7 Pipeline de captura de HTML bruto a partir de referências coletadas
+
+A primeira etapa do pipeline de páginas de venda deve separar responsabilidades:
+
+1. **Backend**: lê `mois_collected_reference`, reserva a próxima URL elegível e persiste o resultado bruto em `mois_collected_reference_html_capture`.
+2. **Worker MOIS**: executa o processamento externo, buscando na internet o HTML completo da URL recebida e devolvendo o payload bruto ao backend.
+3. A seleção da URL segue a prioridade `sales_page_url`, depois `product_url`, depois `url`.
+4. O HTML bruto persistido em `mois_collected_reference_html_capture.raw_html` é a entrada canônica para uma etapa posterior de parsing/análise, sem obrigar o worker a acessar diretamente o banco.
+5. A tabela `mois_collected_reference` permanece como fonte de produtos coletados; ela não deve armazenar o HTML bruto capturado.
+
+Contratos operacionais do backend:
+
+- `POST /api/mois/sales-library/collected-reference-html:claim` reserva uma referência coletada para captura.
+- `POST /api/mois/sales-library/collected-reference-html/{captureId}:complete` persiste HTML bruto, URL final, status HTTP, content type, hash e tamanho.
+- `POST /api/mois/sales-library/collected-reference-html/{captureId}:fail` registra falha de captura para auditoria e reprocessamento futuro.

--- a/docs/registros/mois1.md
+++ b/docs/registros/mois1.md
@@ -810,3 +810,8 @@ Arquivos alterados:
 - `frontend/src/pages/mois/MoisSalesPagesLibraryPage.tsx`
 - `frontend/src/pages/mois/MoisSalesPagesPipelinePage.tsx`
 - `frontend/src/App.tsx`
+
+## 2026-06-03 — Pipeline de captura de HTML bruto a partir de `mois_collected_reference`
+- criado backend como dono da leitura/persistência da primeira etapa do novo pipeline, com endpoints `POST /api/mois/sales-library/collected-reference-html:claim`, `POST /api/mois/sales-library/collected-reference-html/{captureId}:complete` e `POST /api/mois/sales-library/collected-reference-html/{captureId}:fail`.
+- adicionada tabela `mois_collected_reference_html_capture` para reservar URLs de `mois_collected_reference`, guardar URL original/final, status, HTTP status, content type, hash, tamanho e HTML bruto completo.
+- ajustado o `mois-sales-library-worker` para executar a captura na internet: reserva uma referência no backend, faz GET da URL priorizada (`sales_page_url`, fallback `product_url`, fallback `url`) e devolve o HTML bruto ao backend para a próxima etapa.

--- a/docs/swagger/mois-sales-library-swagger.yaml
+++ b/docs/swagger/mois-sales-library-swagger.yaml
@@ -1,0 +1,141 @@
+openapi: 3.0.3
+info:
+  title: Marketing Hub - MOIS Sales Library
+  version: 0.2.0
+  description: Contratos operacionais da Biblioteca de Páginas de Vendas do MOIS.
+servers:
+  - url: /api/mois/sales-library
+paths:
+  /collected-reference-html:claim:
+    post:
+      summary: Reserva uma referência coletada para captura de HTML bruto
+      tags: [MOIS Sales Library]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CollectedReferenceHtmlClaimRequest'
+      responses:
+        '200':
+          description: Resultado da reserva
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CollectedReferenceHtmlClaimResponse'
+  /collected-reference-html/{captureId}:complete:
+    post:
+      summary: Persiste HTML bruto capturado para a referência reservada
+      tags: [MOIS Sales Library]
+      parameters:
+        - $ref: '#/components/parameters/CaptureId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CollectedReferenceHtmlCompleteRequest'
+      responses:
+        '200':
+          description: Captura persistida
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CollectedReferenceHtmlPersistResponse'
+  /collected-reference-html/{captureId}:fail:
+    post:
+      summary: Registra falha de captura de HTML bruto
+      tags: [MOIS Sales Library]
+      parameters:
+        - $ref: '#/components/parameters/CaptureId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CollectedReferenceHtmlFailRequest'
+      responses:
+        '200':
+          description: Falha persistida
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CollectedReferenceHtmlPersistResponse'
+components:
+  parameters:
+    CaptureId:
+      in: path
+      name: captureId
+      required: true
+      schema:
+        type: integer
+        format: int64
+  schemas:
+    CollectedReferenceHtmlClaimRequest:
+      type: object
+      required: [workspaceId, source]
+      properties:
+        workspaceId:
+          type: string
+          example: workspace-001
+        source:
+          type: string
+          example: HOTMART
+    CollectedReferenceHtmlCaptureJob:
+      type: object
+      properties:
+        captureId:
+          type: integer
+          format: int64
+        collectedReferenceId:
+          type: integer
+          format: int64
+        collectionJobId:
+          type: string
+        referenceId:
+          type: string
+        source:
+          type: string
+        title:
+          type: string
+        url:
+          type: string
+        urlSource:
+          type: string
+    CollectedReferenceHtmlClaimResponse:
+      type: object
+      properties:
+        claimed:
+          type: boolean
+        job:
+          $ref: '#/components/schemas/CollectedReferenceHtmlCaptureJob'
+    CollectedReferenceHtmlCompleteRequest:
+      type: object
+      required: [rawHtml]
+      properties:
+        rawHtml:
+          type: string
+        finalUrl:
+          type: string
+        httpStatus:
+          type: integer
+        contentType:
+          type: string
+        fetchedAt:
+          type: string
+          format: date-time
+    CollectedReferenceHtmlFailRequest:
+      type: object
+      properties:
+        errorCategory:
+          type: string
+        errorMessage:
+          type: string
+    CollectedReferenceHtmlPersistResponse:
+      type: object
+      properties:
+        captureId:
+          type: integer
+          format: int64
+        status:
+          type: string

--- a/mois-sales-library-worker/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/client/BackendClient.java
+++ b/mois-sales-library-worker/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/client/BackendClient.java
@@ -6,12 +6,24 @@ import org.springframework.http.MediaType;
 import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
 
+/**
+ * Encapsula chamadas HTTP do worker MOIS para o backend principal.
+ */
 @Component
 @Slf4j
 public class BackendClient {
     private final RestClient restClient;
-    public BackendClient(RestClient restClient) { this.restClient = restClient; }
 
+    /**
+     * Cria o cliente usando o RestClient configurado com a URL base do backend.
+     */
+    public BackendClient(RestClient restClient) {
+        this.restClient = restClient;
+    }
+
+    /**
+     * Reserva um job de análise de página de vendas na biblioteca.
+     */
     public ClaimResponse claim(ClaimRequest request) {
         log.info("MOIS sales-library worker calling backend claim endpoint. workspaceId={}, source={}", request.workspaceId(), request.source());
         ClaimResponse response = restClient.post()
@@ -25,6 +37,57 @@ public class BackendClient {
                 response != null && response.job() != null);
         return response;
     }
+
+    /**
+     * Reserva uma referência coletada para captura de HTML bruto.
+     */
+    public CollectedReferenceHtmlClaimResponse claimCollectedReferenceHtml(CollectedReferenceHtmlClaimRequest request) {
+        log.info("MOIS raw-html worker calling backend claim endpoint. workspaceId={}, source={}", request.workspaceId(), request.source());
+        CollectedReferenceHtmlClaimResponse response = restClient.post()
+                .uri("/api/mois/sales-library/collected-reference-html:claim")
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(request)
+                .retrieve()
+                .body(CollectedReferenceHtmlClaimResponse.class);
+        log.info("MOIS raw-html worker claim response received. claimed={}, hasJob={}",
+                response != null && response.claimed(),
+                response != null && response.job() != null);
+        return response;
+    }
+
+    /**
+     * Persiste no backend o HTML bruto capturado de uma referência coletada.
+     */
+    public void completeCollectedReferenceHtml(long captureId, CollectedReferenceHtmlCompleteRequest request) {
+        log.info("MOIS raw-html worker calling backend complete endpoint. captureId={}, httpStatus={}, bytes={}",
+                captureId, request.httpStatus(), request.rawHtml() == null ? 0 : request.rawHtml().length());
+        var entity = restClient.post()
+                .uri("/api/mois/sales-library/collected-reference-html/{captureId}:complete", captureId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(request)
+                .retrieve()
+                .toBodilessEntity();
+        log.info("MOIS raw-html worker complete response received. captureId={}, status={}", captureId, entity.getStatusCode());
+    }
+
+    /**
+     * Registra no backend uma falha na captura de HTML bruto.
+     */
+    public void failCollectedReferenceHtml(long captureId, CollectedReferenceHtmlFailRequest request) {
+        log.warn("MOIS raw-html worker calling backend fail endpoint. captureId={}, errorCategory={}, errorMessage={}",
+                captureId, request.errorCategory(), request.errorMessage());
+        var entity = restClient.post()
+                .uri("/api/mois/sales-library/collected-reference-html/{captureId}:fail", captureId)
+                .contentType(MediaType.APPLICATION_JSON)
+                .body(request)
+                .retrieve()
+                .toBodilessEntity();
+        log.info("MOIS raw-html worker fail response received. captureId={}, status={}", captureId, entity.getStatusCode());
+    }
+
+    /**
+     * Persiste no backend o resultado final de análise de um job.
+     */
     public void complete(long jobId, CompleteRequest request) {
         log.info("MOIS sales-library worker calling backend complete endpoint. jobId={}, scoreTotal={}", jobId, request.scoreTotal());
         var entity = restClient.post()
@@ -35,6 +98,10 @@ public class BackendClient {
                 .toBodilessEntity();
         log.info("MOIS sales-library worker complete response received. jobId={}, status={}", jobId, entity.getStatusCode());
     }
+
+    /**
+     * Registra no backend uma falha terminal de análise de job.
+     */
     public void fail(long jobId, FailRequest request) {
         log.warn("MOIS sales-library worker calling backend fail endpoint. jobId={}, errorCategory={}, errorMessage={}",
                 jobId, request.errorCategory(), request.errorMessage());

--- a/mois-sales-library-worker/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/config/WorkerProperties.java
+++ b/mois-sales-library-worker/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/config/WorkerProperties.java
@@ -2,11 +2,17 @@ package com.marketinghub.mois.bibliotecapaginavenda.worker.v1.config;
 
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
+/**
+ * Centraliza parâmetros operacionais do worker MOIS de Biblioteca de Páginas de Vendas.
+ */
 @ConfigurationProperties(prefix = "worker")
 public record WorkerProperties(
         String backendBaseUrl,
         String workspaceId,
         String source,
         String sources,
+        String rawHtmlSource,
+        String rawHtmlSources,
         long pollIntervalMs,
+        long rawHtmlPollIntervalMs,
         int requestTimeoutMs) {}

--- a/mois-sales-library-worker/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/model/WorkerDtos.java
+++ b/mois-sales-library-worker/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/model/WorkerDtos.java
@@ -2,13 +2,26 @@ package com.marketinghub.mois.bibliotecapaginavenda.worker.v1.model;
 
 import java.math.BigDecimal;
 import java.time.Instant;
-import java.util.Map;
 
+/**
+ * Agrupa contratos usados pelo worker MOIS para conversar com o backend principal.
+ */
 public final class WorkerDtos {
+    /**
+     * Impede instanciação do agrupador de DTOs.
+     */
     private WorkerDtos() {}
+
     public record ClaimRequest(String workspaceId, String source) {}
     public record ClaimedJob(Long jobId, Long pageId, String urlCanonical, String title) {}
     public record ClaimResponse(boolean claimed, ClaimedJob job) {}
     public record CompleteRequest(BigDecimal scoreTotal, String sectionsJson, String copyJson, String visualJson, String imageJson, String analysisNotes, String requestPayloadJson, String parserVersion, String promptVersion, String modelName, Instant analyzedAt) {}
     public record FailRequest(String errorCategory, String errorMessage) {}
+
+    public record CollectedReferenceHtmlClaimRequest(String workspaceId, String source) {}
+    public record CollectedReferenceHtmlCaptureJob(Long captureId, Long collectedReferenceId, String collectionJobId, String referenceId, String source, String title, String url, String urlSource) {}
+    public record CollectedReferenceHtmlClaimResponse(boolean claimed, CollectedReferenceHtmlCaptureJob job) {}
+    public record CollectedReferenceHtmlCompleteRequest(String rawHtml, String finalUrl, Integer httpStatus, String contentType, Instant fetchedAt) {}
+    public record CollectedReferenceHtmlFailRequest(String errorCategory, String errorMessage) {}
+    public record CollectedReferenceHtmlPersistResponse(Long captureId, String status) {}
 }

--- a/mois-sales-library-worker/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/PipelineRunner.java
+++ b/mois-sales-library-worker/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/PipelineRunner.java
@@ -12,10 +12,14 @@ import java.util.Locale;
 import java.util.concurrent.atomic.AtomicInteger;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.jsoup.Connection;
 import org.jsoup.Jsoup;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Service;
 
+/**
+ * Executa os ciclos assíncronos do worker MOIS para captura de HTML bruto e análise de páginas de vendas.
+ */
 @Service
 @Slf4j
 @RequiredArgsConstructor
@@ -24,7 +28,56 @@ public class PipelineRunner {
     private final WorkerProperties properties;
     private final OpenAiSalesPageAnalyzer openAiSalesPageAnalyzer;
     private final AtomicInteger sourceCursor = new AtomicInteger(0);
+    private final AtomicInteger rawHtmlSourceCursor = new AtomicInteger(0);
 
+    /**
+     * Executa um ciclo da primeira etapa: reservar URL coletada, buscar HTML completo na internet e persistir no backend.
+     */
+    @Scheduled(fixedDelayString = "${worker.raw-html-poll-interval-ms:30000}")
+    public void runRawHtmlCaptureCycle() {
+        String sourceForCycle = resolveRawHtmlSourceForCycle();
+        log.info("MOIS raw-html capture cycle started. workspaceId={}, source={}, rawHtmlPollIntervalMs={}, requestTimeoutMs={}",
+                properties.workspaceId(), sourceForCycle, properties.rawHtmlPollIntervalMs(), properties.requestTimeoutMs());
+        CollectedReferenceHtmlClaimResponse claim = backendClient.claimCollectedReferenceHtml(
+                new CollectedReferenceHtmlClaimRequest(properties.workspaceId(), sourceForCycle));
+        if (claim == null || !claim.claimed() || claim.job() == null) {
+            log.info("MOIS raw-html capture cycle finished without claimed reference.");
+            return;
+        }
+
+        long captureId = claim.job().captureId();
+        try {
+            log.info("MOIS raw-html worker claimed reference. captureId={}, collectedReferenceId={}, collectionJobId={}, referenceId={}, url={}",
+                    captureId, claim.job().collectedReferenceId(), claim.job().collectionJobId(), claim.job().referenceId(), claim.job().url());
+            Connection.Response response = Jsoup.connect(claim.job().url())
+                    .timeout(properties.requestTimeoutMs())
+                    .ignoreContentType(true)
+                    .followRedirects(true)
+                    .maxBodySize(0)
+                    .execute();
+            String rawHtml = response.body() == null ? "" : response.body();
+            if (rawHtml.isBlank()) {
+                throw new IllegalStateException("Resposta sem HTML bruto capturável");
+            }
+            String finalUrl = response.url() == null ? claim.job().url() : response.url().toString();
+            backendClient.completeCollectedReferenceHtml(captureId, new CollectedReferenceHtmlCompleteRequest(
+                    rawHtml,
+                    finalUrl,
+                    response.statusCode(),
+                    response.contentType(),
+                    Instant.now()));
+            log.info("MOIS raw-html capture completed. captureId={}, httpStatus={}, finalUrl={}, rawHtmlChars={}",
+                    captureId, response.statusCode(), finalUrl, rawHtml.length());
+        } catch (Exception ex) {
+            backendClient.failCollectedReferenceHtml(captureId, new CollectedReferenceHtmlFailRequest("RAW_HTML_FETCH_ERROR", ex.getMessage()));
+            log.warn("MOIS raw-html capture failed. captureId={}, url={}, errorClass={}, errorMessage={}",
+                    captureId, claim.job().url(), ex.getClass().getName(), ex.getMessage(), ex);
+        }
+    }
+
+    /**
+     * Executa um ciclo da etapa de análise de páginas já ingeridas na biblioteca.
+     */
     @Scheduled(fixedDelayString = "${worker.poll-interval-ms:15000}")
     public void runCycle() {
         String sourceForCycle = resolveSourceForCycle();
@@ -63,6 +116,22 @@ public class PipelineRunner {
         }
     }
 
+
+    /**
+     * Escolhe a fonte do ciclo de captura de HTML bruto, com padrão independente da etapa de análise.
+     */
+    String resolveRawHtmlSourceForCycle() {
+        List<String> configuredSources = parseSources(properties.rawHtmlSources());
+        if (!configuredSources.isEmpty()) {
+            int index = Math.floorMod(rawHtmlSourceCursor.getAndIncrement(), configuredSources.size());
+            return configuredSources.get(index);
+        }
+        return normalizeSource(properties.rawHtmlSource());
+    }
+
+    /**
+     * Escolhe a fonte de marketplace do ciclo, alternando quando houver múltiplas configuradas.
+     */
     String resolveSourceForCycle() {
         List<String> configuredSources = parseSources(properties.sources());
         if (!configuredSources.isEmpty()) {
@@ -72,6 +141,9 @@ public class PipelineRunner {
         return normalizeSource(properties.source());
     }
 
+    /**
+     * Converte a lista textual de fontes em valores normalizados e únicos.
+     */
     static List<String> parseSources(String rawSources) {
         if (rawSources == null || rawSources.isBlank()) {
             return List.of();
@@ -83,6 +155,9 @@ public class PipelineRunner {
                 .toList();
     }
 
+    /**
+     * Normaliza a fonte para o padrão usado no backend.
+     */
     private static String normalizeSource(String source) {
         return source == null ? "" : source.trim().toUpperCase(Locale.ROOT);
     }

--- a/mois-sales-library-worker/src/main/resources/application.yml
+++ b/mois-sales-library-worker/src/main/resources/application.yml
@@ -6,7 +6,10 @@ worker:
   workspace-id: ${MOIS_WORKSPACE_ID:workspace-001}
   source: ${MOIS_SOURCE:CLICKBANK}
   sources: ${MOIS_SOURCES:}
+  raw-html-source: ${MOIS_RAW_HTML_SOURCE:HOTMART}
+  raw-html-sources: ${MOIS_RAW_HTML_SOURCES:}
   poll-interval-ms: ${MOIS_POLL_INTERVAL_MS:15000}
+  raw-html-poll-interval-ms: ${MOIS_RAW_HTML_POLL_INTERVAL_MS:30000}
   request-timeout-ms: ${MOIS_REQUEST_TIMEOUT_MS:30000}
 
 openai:


### PR DESCRIPTION
### Motivation
- Introduce a first-stage pipeline to fetch and persist raw HTML for previously collected references so workers do not access the DB directly for fetching HTML. 
- Provide auditable storage (raw HTML, final URL, HTTP status, content type, size, SHA-256) and lifecycle (CLAIMED → CAPTURED/FAILED) for captured pages. 
- Allow the existing sales-library worker ecosystem to coordinate reservation, fetch and persist operations via explicit backend contracts. 

### Description
- Added a new changelog `2026-06-03-mois-collected-reference-html-capture.yaml` that creates the `mois_collected_reference_html_capture` table with columns for status, raw HTML, `raw_html_sha256`, `raw_html_bytes`, indexes and foreign key. 
- Added DTOs and HTTP endpoints in the backend: `CollectedReferenceHtmlClaimRequest/Response`, `CollectedReferenceHtmlCompleteRequest/FailRequest/PersistResponse`, controller paths `POST /collected-reference-html:claim`, `/collected-reference-html/{captureId}:complete` and `/collected-reference-html/{captureId}:fail`. 
- Implemented service-side flows in `MoisSalesLibraryService`: `claimCollectedReferenceHtml(...)` to reserve one eligible `mois_collected_reference` row in `mois_collected_reference_html_capture`, `completeCollectedReferenceHtml(...)` to persist raw HTML (with SHA-256, byte count and truncated fields), and `failCollectedReferenceHtml(...)` to record terminal failures, plus helper methods `findClaimedCollectedReferenceHtml`, `sha256` and `truncate`. 
- Extended worker-side contracts and runtime: worker DTOs, `BackendClient` methods (`claimCollectedReferenceHtml`, `completeCollectedReferenceHtml`, `failCollectedReferenceHtml`), `WorkerProperties` config for raw-html polling, and `PipelineRunner` scheduled cycle `runRawHtmlCaptureCycle()` which claims a reference, fetches HTML via `Jsoup`, and calls backend complete/fail endpoints. 
- Added OpenAPI/Swagger snapshot `mois-sales-library-swagger.yaml` and documentation updates describing the new pipeline and contracts. 

### Testing
- Updated unit tests in `MoisSalesLibraryServiceTest` with `shouldClaimCollectedReferenceHtmlFromCollectedReferenceTable` that stubs JDBC interactions and asserts a successful claim, and `shouldCompleteCollectedReferenceHtmlCapture` that asserts the `UPDATE` call and returned status; these unit tests passed. 
- Existing ingestion and job tests in `MoisSalesLibraryServiceTest` were retained and ran as part of the same test class; they passed. 
- No integration or database migration run is included here, but Liquibase changelog was added to `db.changelog-master.yaml` for deployment-time schema migration.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1fa2d799288321825502e129315190)