### PR TITLE
Adiciona card 'Obtenção dos HTML' na tela de pipeline MOIS

### DIFF
--- a/docs/novos-modulos/mois-biblioteca-pagina-venda/guia-secoes-biblioteca-paginas-vendas.md
+++ b/docs/novos-modulos/mois-biblioteca-pagina-venda/guia-secoes-biblioteca-paginas-vendas.md
@@ -93,3 +93,16 @@ A página permite:
 3. acompanhar score/status por página;
 4. reprocessar rapidamente itens com problema;
 5. inspecionar os artefatos JSON gerados na análise.
+
+## Tela de pipeline da biblioteca
+
+### 1) Primeira etapa — Obtenção dos HTML
+Objetivo: orientar a operação sobre a primeira camada necessária para qualquer análise confiável da biblioteca: capturar o HTML bruto das URLs ingeridas.
+
+Informações exibidas no card:
+- entrada esperada: URLs normalizadas da biblioteca;
+- saída esperada: HTML bruto versionado em snapshot;
+- critério de qualidade: conteúdo útil para análise, sem marcador técnico interno;
+- itens de acompanhamento: URLs pendentes, snapshots salvos, falhas de acesso, hash, tamanho e data da última captura.
+
+Resultado prático: a equipe consegue enxergar que a análise de copy, estrutura, prova, oferta e visual depende primeiro da existência de snapshots brutos rastreáveis.

--- a/docs/registros/mois1.md
+++ b/docs/registros/mois1.md
@@ -815,3 +815,15 @@ Arquivos alterados:
 - criado backend como dono da leitura/persistência da primeira etapa do novo pipeline, com endpoints `POST /api/mois/sales-library/collected-reference-html:claim`, `POST /api/mois/sales-library/collected-reference-html/{captureId}:complete` e `POST /api/mois/sales-library/collected-reference-html/{captureId}:fail`.
 - adicionada tabela `mois_collected_reference_html_capture` para reservar URLs de `mois_collected_reference`, guardar URL original/final, status, HTTP status, content type, hash, tamanho e HTML bruto completo.
 - ajustado o `mois-sales-library-worker` para executar a captura na internet: reserva uma referência no backend, faz GET da URL priorizada (`sales_page_url`, fallback `product_url`, fallback `url`) e devolve o HTML bruto ao backend para a próxima etapa.
+
+## 2026-06-03 07:38:12 UTC-3
+- adicionada a primeira etapa visual do pipeline da Biblioteca de Páginas de Vendas do MOIS para orientar a obtenção dos HTML.
+- a solução foi mantida simples e estática porque a tela de pipeline ainda não possui contrato específico de métricas agregadas para este card.
+- o card agora apresenta entrada, saída esperada, critério de qualidade e informações operacionais que devem ser acompanhadas na captura de HTML bruto.
+- documentos lidos para tratar a situação:
+  - docs/novos-modulos/mois-biblioteca-pagina-venda/especificacao-biblioteca-sales-pages.md
+  - docs/novos-modulos/mois-biblioteca-pagina-venda/guia-secoes-biblioteca-paginas-vendas.md
+- arquivos alterados:
+  - frontend/src/pages/mois/MoisSalesPagesPipelinePage.tsx
+  - docs/novos-modulos/mois-biblioteca-pagina-venda/guia-secoes-biblioteca-paginas-vendas.md
+  - docs/registros/mois1.md

--- a/frontend/src/pages/mois/MoisSalesPagesPipelinePage.tsx
+++ b/frontend/src/pages/mois/MoisSalesPagesPipelinePage.tsx
@@ -1,6 +1,13 @@
 import { Link } from "react-router-dom";
 import PageTitle from "../../components/PageTitle";
 
+const htmlAcquisitionChecklist = [
+  "URLs pendentes para captura",
+  "Snapshots com HTML bruto salvo",
+  "Falhas de acesso, bloqueio ou timeout",
+  "Hash, tamanho e data da última captura",
+];
+
 export default function MoisSalesPagesPipelinePage() {
   return (
     <div className="d-flex flex-column gap-4">
@@ -8,20 +15,85 @@ export default function MoisSalesPagesPipelinePage() {
         <div>
           <PageTitle>Pipeline de Páginas de Vendas</PageTitle>
           <p className="text-secondary mb-0">
-            Área reservada para construirmos juntos a visão de pipeline da biblioteca de páginas de vendas.
+            Área reservada para construirmos juntos a visão de pipeline da
+            biblioteca de páginas de vendas.
           </p>
         </div>
-        <Link className="btn btn-outline-secondary" to="/mois/sales-pages-library">
+        <Link
+          className="btn btn-outline-secondary"
+          to="/mois/sales-pages-library"
+        >
           Voltar à biblioteca
         </Link>
       </header>
 
       <section className="card border-0 shadow-sm">
-        <div className="card-body">
-          <h2 className="h5">Tela em construção</h2>
-          <p className="text-secondary mb-0">
-            O botão Pipeline já direciona para esta rota. Os próximos blocos, fases e ações serão definidos na próxima etapa.
-          </p>
+        <div className="card-body d-flex flex-column gap-4">
+          <div className="d-flex flex-wrap align-items-start justify-content-between gap-3">
+            <div>
+              <span className="badge text-bg-primary mb-2">Etapa 1</span>
+              <h2 className="h4 mb-2">Obtenção dos HTML</h2>
+              <p className="text-secondary mb-0">
+                Primeiro bloco operacional do pipeline: transformar URLs
+                ingeridas em snapshots brutos rastreáveis para permitir análise
+                de copy, estrutura, prova, oferta e padrões visuais com base em
+                evidência real.
+              </p>
+            </div>
+            <span className="badge text-bg-warning align-self-start">
+              Em implantação
+            </span>
+          </div>
+
+          <div className="row g-3">
+            <div className="col-12 col-lg-4">
+              <div className="border rounded-3 p-3 h-100 bg-light">
+                <p className="text-uppercase text-secondary small fw-semibold mb-1">
+                  Entrada
+                </p>
+                <h3 className="h6 mb-2">URLs normalizadas da biblioteca</h3>
+                <p className="text-secondary small mb-0">
+                  A etapa deve partir das páginas já ingeridas, priorizando URLs
+                  sem snapshot ou com captura desatualizada.
+                </p>
+              </div>
+            </div>
+            <div className="col-12 col-lg-4">
+              <div className="border rounded-3 p-3 h-100 bg-light">
+                <p className="text-uppercase text-secondary small fw-semibold mb-1">
+                  Saída esperada
+                </p>
+                <h3 className="h6 mb-2">HTML bruto versionado</h3>
+                <p className="text-secondary small mb-0">
+                  Cada captura precisa gerar snapshot com hash, tamanho,
+                  data/hora e status para auditoria e reprocessamento.
+                </p>
+              </div>
+            </div>
+            <div className="col-12 col-lg-4">
+              <div className="border rounded-3 p-3 h-100 bg-light">
+                <p className="text-uppercase text-secondary small fw-semibold mb-1">
+                  Critério de qualidade
+                </p>
+                <h3 className="h6 mb-2">HTML útil para análise</h3>
+                <p className="text-secondary small mb-0">
+                  O conteúdo deve conter corpo relevante da página, sem marcador
+                  técnico interno nem payload contaminado.
+                </p>
+              </div>
+            </div>
+          </div>
+
+          <div>
+            <h3 className="h6 mb-2">
+              Informações que este card deve acompanhar
+            </h3>
+            <ul className="mb-0 text-secondary">
+              {htmlAcquisitionChecklist.map((item) => (
+                <li key={item}>{item}</li>
+              ))}
+            </ul>
+          </div>
         </div>
       </section>
     </div>


### PR DESCRIPTION
### Motivation
- Tornar visível e operacional a primeira etapa do pipeline da Biblioteca de Páginas de Vendas (MOIS): capturar HTML bruto das URLs ingeridas para permitir análises confiáveis. 
- Alinhar a UI com a especificação canônica da biblioteca e fornecer informações práticas de acompanhamento para operação.

### Description
- Adiciona o card da Etapa 1 (Obtenção dos HTML) em `frontend/src/pages/mois/MoisSalesPagesPipelinePage.tsx`, incluindo objetivo, status, entrada, saída esperada, critério de qualidade e checklist operacional. 
- Introduz a constante `htmlAcquisitionChecklist` com os itens a acompanhar (`URLs pendentes para captura`, `Snapshots com HTML bruto salvo`, `Falhas de acesso, bloqueio ou timeout`, `Hash, tamanho e data da última captura`).
- Atualiza a documentação de guia da biblioteca em `docs/novos-modulos/mois-biblioteca-pagina-venda/guia-secoes-biblioteca-paginas-vendas.md` para descrever o card e suas informações exibidas. 
- Registra a alteração operacional em `docs/registros/mois1.md` conforme política de registros do módulo.

### Testing
- Executado `npm run typecheck` no frontend e a checagem TypeScript concluiu sem erros.
- Verificada a formatação com `npx prettier --check src/pages/mois/MoisSalesPagesPipelinePage.tsx` e o arquivo está conforme Prettier. 
- Geração de screenshot da rota `/mois/sales-pages-library/pipeline` via Playwright em headless para validação visual da tela e do conteúdo do card, com execução automatizada bem-sucedida.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2003d85f788321a21646e305c779fe)