### PR TITLE
feat(mois): habilita execução manual da etapa de captura de HTML no pipeline

### DIFF
--- a/docs/registros/mois1.md
+++ b/docs/registros/mois1.md
@@ -832,3 +832,15 @@ Arquivos alterados:
 - implementada a etapa `htmlcapture` no `mois-sales-library-worker` seguindo o padrão de núcleo genérico `pipeline` + etapa concreta `pipeline.htmlcapture`, com `StageProcessor`, `StageResult`, `StageArtifact`, `PipelineWorker` e proteção ArchUnit contra acoplamento entre etapas.
 - criados endpoints backend `POST /api/mois/sales-library/html-captures:claim`, `POST /api/mois/sales-library/html-captures/{snapshotId}:complete` e `POST /api/mois/sales-library/html-captures/{snapshotId}:fail` para reservar URLs normalizadas da biblioteca e persistir HTML bruto versionado em `mois_sales_library_page_snapshot` + `mois_sales_library_snapshot_artifact`.
 - a etapa registra hash SHA-256, tamanho, status HTTP, content type, URL final e data da captura, preservando falhas de acesso/bloqueio/timeout como snapshots `FAILED` para auditoria e reprocessamento.
+
+## 2026-06-03 — Pipeline de páginas de vendas com execução manual da etapa 1
+- Corrigida a causa-raiz da tela `/mois/sales-pages-library/pipeline` aparentar não executar: ela ainda estava como placeholder visual, embora o backend já possuísse contrato operacional de captura de snapshots.
+- A tela agora consome `POST /api/mois/sales-library/snapshots:capture`, permite executar a etapa **Obtenção dos HTML**, exibe contadores da execução e lista o resultado por URL com status, HTTP, tamanho do HTML e detalhe/hash.
+- Atualizado o contrato Swagger da Biblioteca de Páginas de Vendas para documentar o endpoint de captura manual utilizado pelo frontend.
+
+Arquivos alterados:
+- `frontend/src/api/mois/types.ts`
+- `frontend/src/api/mois/useMoisSalesLibrary.ts`
+- `frontend/src/pages/mois/MoisSalesPagesPipelinePage.tsx`
+- `docs/swagger/mois-sales-library-swagger.yaml`
+- `docs/registros/mois1.md`

--- a/docs/swagger/mois-sales-library-swagger.yaml
+++ b/docs/swagger/mois-sales-library-swagger.yaml
@@ -61,6 +61,23 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/CollectedReferenceHtmlPersistResponse'
+  /snapshots:capture:
+    post:
+      summary: Executa captura de snapshots HTML para páginas sem captura recente
+      tags: [MOIS Sales Library]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SalesLibrarySnapshotCaptureRequest'
+      responses:
+        '202':
+          description: Captura executada
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SalesLibrarySnapshotCaptureResponse'
 components:
   parameters:
     CaptureId:
@@ -139,3 +156,70 @@ components:
           format: int64
         status:
           type: string
+    SalesLibrarySnapshotCaptureRequest:
+      type: object
+      required: [workspaceId]
+      properties:
+        workspaceId:
+          type: string
+          example: workspace-001
+        limit:
+          type: integer
+          minimum: 1
+          maximum: 20
+          example: 5
+        force:
+          type: boolean
+          description: Quando verdadeiro, recaptura páginas mesmo que já possuam snapshot CAPTURED ou FETCHING.
+    SalesLibrarySnapshotCaptureItem:
+      type: object
+      properties:
+        pageId:
+          type: integer
+          format: int64
+        snapshotId:
+          type: integer
+          format: int64
+          nullable: true
+        urlCanonical:
+          type: string
+        status:
+          type: string
+          enum: [CAPTURED, DUPLICATE, FAILED]
+        snapshotHash:
+          type: string
+          nullable: true
+        httpStatus:
+          type: integer
+          nullable: true
+        rawHtmlBytes:
+          type: integer
+          format: int64
+        screenshotBytes:
+          type: integer
+          format: int64
+        errorMessage:
+          type: string
+          nullable: true
+    SalesLibrarySnapshotCaptureResponse:
+      type: object
+      properties:
+        workspaceId:
+          type: string
+        requestedLimit:
+          type: integer
+        force:
+          type: boolean
+        processed:
+          type: integer
+        captured:
+          type: integer
+        failed:
+          type: integer
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/SalesLibrarySnapshotCaptureItem'
+        capturedAt:
+          type: string
+          format: date-time

--- a/frontend/src/api/mois/types.ts
+++ b/frontend/src/api/mois/types.ts
@@ -213,7 +213,6 @@ export interface MoisCollectedReferenceLineageResponse {
   updatedAt: string;
 }
 
-
 export interface MoisSalesLibraryEntry {
   id: number;
   workspaceId: string;
@@ -233,7 +232,6 @@ export interface MoisSalesLibraryEntryPageResponse {
   total: number;
   items: MoisSalesLibraryEntry[];
 }
-
 
 export interface MoisSalesLibraryJob {
   id: number;
@@ -294,6 +292,28 @@ export interface MoisSalesLibraryPageAnalysis {
   updatedAt: string;
 }
 
+export interface MoisSalesLibrarySnapshotCaptureItem {
+  pageId: number;
+  snapshotId?: number;
+  urlCanonical: string;
+  status: string;
+  snapshotHash?: string;
+  httpStatus?: number;
+  rawHtmlBytes: number;
+  screenshotBytes: number;
+  errorMessage?: string;
+}
+
+export interface MoisSalesLibrarySnapshotCaptureResponse {
+  workspaceId: string;
+  requestedLimit: number;
+  force: boolean;
+  processed: number;
+  captured: number;
+  failed: number;
+  items: MoisSalesLibrarySnapshotCaptureItem[];
+  capturedAt: string;
+}
 
 export interface MoisSalesLibraryPageSnapshot {
   snapshotId: number;

--- a/frontend/src/api/mois/useMoisSalesLibrary.ts
+++ b/frontend/src/api/mois/useMoisSalesLibrary.ts
@@ -8,40 +8,71 @@ import type {
   MoisSalesLibraryPageListResponse,
   MoisSalesLibraryPageSnapshot,
   MoisSalesLibraryReanalyzeResponse,
+  MoisSalesLibrarySnapshotCaptureResponse,
   MoisSalesLibraryStatusUpdateResponse,
 } from "./types";
 
-export function useMoisSalesLibraryEntries(workspaceId: string, page: number, pageSize: number) {
+export function useMoisSalesLibraryEntries(
+  workspaceId: string,
+  page: number,
+  pageSize: number,
+) {
   return useQuery({
     queryKey: ["mois", "sales-library", "entries", workspaceId, page, pageSize],
     queryFn: async () => {
-      const { data } = await axios.get<MoisSalesLibraryEntryPageResponse>("/api/mois/sales-library/entries", {
-        params: { workspaceId, page, pageSize },
-      });
+      const { data } = await axios.get<MoisSalesLibraryEntryPageResponse>(
+        "/api/mois/sales-library/entries",
+        {
+          params: { workspaceId, page, pageSize },
+        },
+      );
       return data;
     },
   });
 }
 
-export function useMoisSalesLibraryJobs(workspaceId: string, page: number, pageSize: number, status?: string) {
+export function useMoisSalesLibraryJobs(
+  workspaceId: string,
+  page: number,
+  pageSize: number,
+  status?: string,
+) {
   return useQuery({
-    queryKey: ["mois", "sales-library", "jobs", workspaceId, page, pageSize, status],
+    queryKey: [
+      "mois",
+      "sales-library",
+      "jobs",
+      workspaceId,
+      page,
+      pageSize,
+      status,
+    ],
     queryFn: async () => {
-      const { data } = await axios.get<MoisSalesLibraryJobPageResponse>("/api/mois/sales-library/jobs", {
-        params: { workspaceId, page, pageSize, status: status || undefined },
-      });
+      const { data } = await axios.get<MoisSalesLibraryJobPageResponse>(
+        "/api/mois/sales-library/jobs",
+        {
+          params: { workspaceId, page, pageSize, status: status || undefined },
+        },
+      );
       return data;
     },
   });
 }
 
-export function useMoisSalesLibraryPages(workspaceId: string, page: number, pageSize: number) {
+export function useMoisSalesLibraryPages(
+  workspaceId: string,
+  page: number,
+  pageSize: number,
+) {
   return useQuery({
     queryKey: ["mois", "sales-library", "pages", workspaceId, page, pageSize],
     queryFn: async () => {
-      const { data } = await axios.get<MoisSalesLibraryPageListResponse>("/api/mois/sales-library/pages", {
-        params: { workspaceId, page, pageSize },
-      });
+      const { data } = await axios.get<MoisSalesLibraryPageListResponse>(
+        "/api/mois/sales-library/pages",
+        {
+          params: { workspaceId, page, pageSize },
+        },
+      );
       return data;
     },
   });
@@ -52,7 +83,9 @@ export function useMoisSalesLibraryPageAnalysis(pageId?: number) {
     queryKey: ["mois", "sales-library", "analysis", pageId],
     enabled: Boolean(pageId),
     queryFn: async () => {
-      const { data } = await axios.get<MoisSalesLibraryPageAnalysis>(`/api/mois/sales-library/pages/${pageId}/analysis`);
+      const { data } = await axios.get<MoisSalesLibraryPageAnalysis>(
+        `/api/mois/sales-library/pages/${pageId}/analysis`,
+      );
       return data;
     },
   });
@@ -62,32 +95,72 @@ export function useReanalyzeMoisSalesLibraryPage(workspaceId: string) {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: async (pageId: number) => {
-      const { data } = await axios.post<MoisSalesLibraryReanalyzeResponse>(`/api/mois/sales-library/pages/${pageId}:reanalyze`);
+      const { data } = await axios.post<MoisSalesLibraryReanalyzeResponse>(
+        `/api/mois/sales-library/pages/${pageId}:reanalyze`,
+      );
       return data;
     },
     onSuccess: () => {
-      void queryClient.invalidateQueries({ queryKey: ["mois", "sales-library", "pages", workspaceId] });
-      void queryClient.invalidateQueries({ queryKey: ["mois", "sales-library", "jobs", workspaceId] });
+      void queryClient.invalidateQueries({
+        queryKey: ["mois", "sales-library", "pages", workspaceId],
+      });
+      void queryClient.invalidateQueries({
+        queryKey: ["mois", "sales-library", "jobs", workspaceId],
+      });
     },
   });
 }
-
 
 export function useUpdateMoisSalesLibraryPageStatus(workspaceId: string) {
   const queryClient = useQueryClient();
   return useMutation({
-    mutationFn: async ({ pageId, status }: { pageId: number; status: "PENDING" | "ANULADO" }) => {
-      const { data } = await axios.post<MoisSalesLibraryStatusUpdateResponse>(`/api/mois/sales-library/pages/${pageId}:status`, { status });
+    mutationFn: async ({
+      pageId,
+      status,
+    }: {
+      pageId: number;
+      status: "PENDING" | "ANULADO";
+    }) => {
+      const { data } = await axios.post<MoisSalesLibraryStatusUpdateResponse>(
+        `/api/mois/sales-library/pages/${pageId}:status`,
+        { status },
+      );
       return data;
     },
     onSuccess: (_, variables) => {
-      void queryClient.invalidateQueries({ queryKey: ["mois", "sales-library", "pages", workspaceId] });
-      void queryClient.invalidateQueries({ queryKey: ["mois", "sales-library", "analysis", variables.pageId] });
+      void queryClient.invalidateQueries({
+        queryKey: ["mois", "sales-library", "pages", workspaceId],
+      });
+      void queryClient.invalidateQueries({
+        queryKey: ["mois", "sales-library", "analysis", variables.pageId],
+      });
     },
   });
 }
 
-export function getSalesLibraryJobBadgeClass(job: { status?: string; analysisStatus?: string }) {
+export function useCaptureMoisSalesLibrarySnapshots(workspaceId: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async ({ limit, force }: { limit: number; force: boolean }) => {
+      const { data } =
+        await axios.post<MoisSalesLibrarySnapshotCaptureResponse>(
+          "/api/mois/sales-library/snapshots:capture",
+          { workspaceId, limit, force },
+        );
+      return data;
+    },
+    onSuccess: () => {
+      void queryClient.invalidateQueries({
+        queryKey: ["mois", "sales-library", "pages", workspaceId],
+      });
+    },
+  });
+}
+
+export function getSalesLibraryJobBadgeClass(job: {
+  status?: string;
+  analysisStatus?: string;
+}) {
   switch (job.status || job.analysisStatus) {
     case "DONE":
       return "bg-success-subtle text-success-emphasis";
@@ -102,13 +175,14 @@ export function getSalesLibraryJobBadgeClass(job: { status?: string; analysisSta
   }
 }
 
-
 export function useMoisSalesLibraryPage(pageId?: number) {
   return useQuery({
     queryKey: ["mois", "sales-library", "page", pageId],
     enabled: Boolean(pageId),
     queryFn: async () => {
-      const { data } = await axios.get<MoisSalesLibraryPage>(`/api/mois/sales-library/pages/${pageId}`);
+      const { data } = await axios.get<MoisSalesLibraryPage>(
+        `/api/mois/sales-library/pages/${pageId}`,
+      );
       return data;
     },
   });
@@ -119,7 +193,9 @@ export function useMoisSalesLibraryPageSnapshots(pageId?: number) {
     queryKey: ["mois", "sales-library", "page-snapshots", pageId],
     enabled: Boolean(pageId),
     queryFn: async () => {
-      const { data } = await axios.get<MoisSalesLibraryPageSnapshot[]>(`/api/mois/sales-library/pages/${pageId}/snapshots`);
+      const { data } = await axios.get<MoisSalesLibraryPageSnapshot[]>(
+        `/api/mois/sales-library/pages/${pageId}/snapshots`,
+      );
       return data;
     },
   });

--- a/frontend/src/pages/mois/MoisSalesPagesPipelinePage.tsx
+++ b/frontend/src/pages/mois/MoisSalesPagesPipelinePage.tsx
@@ -1,5 +1,15 @@
+import { useMemo, useState } from "react";
 import { Link } from "react-router-dom";
 import PageTitle from "../../components/PageTitle";
+import {
+  useCaptureMoisSalesLibrarySnapshots,
+  useMoisSalesLibraryPages,
+} from "../../api/mois/useMoisSalesLibrary";
+import type { MoisSalesLibrarySnapshotCaptureItem } from "../../api/mois/types";
+
+const WORKSPACE_ID = "workspace-001";
+const PAGE_SIZE = 100;
+const DEFAULT_CAPTURE_LIMIT = 5;
 
 const htmlAcquisitionChecklist = [
   "URLs pendentes para captura",
@@ -8,15 +18,79 @@ const htmlAcquisitionChecklist = [
   "Hash, tamanho e data da última captura",
 ];
 
+function formatBytes(value: number) {
+  if (!value) {
+    return "0 B";
+  }
+  if (value < 1024) {
+    return `${value} B`;
+  }
+  if (value < 1024 * 1024) {
+    return `${(value / 1024).toFixed(1)} KB`;
+  }
+  return `${(value / (1024 * 1024)).toFixed(1)} MB`;
+}
+
+function getSnapshotStatusBadgeClass(status: string) {
+  switch (status) {
+    case "CAPTURED":
+    case "DUPLICATE":
+      return "bg-success-subtle text-success-emphasis";
+    case "FAILED":
+      return "bg-danger-subtle text-danger-emphasis";
+    case "FETCHING":
+      return "bg-primary-subtle text-primary-emphasis";
+    default:
+      return "bg-secondary-subtle text-secondary-emphasis";
+  }
+}
+
+function getResultMessage(item: MoisSalesLibrarySnapshotCaptureItem) {
+  if (item.errorMessage) {
+    return item.errorMessage;
+  }
+  if (item.snapshotHash) {
+    return `hash ${item.snapshotHash.slice(0, 12)}...`;
+  }
+  return "Sem detalhe adicional";
+}
+
 export default function MoisSalesPagesPipelinePage() {
+  const [forceCapture, setForceCapture] = useState(false);
+  const pagesQuery = useMoisSalesLibraryPages(WORKSPACE_ID, 1, PAGE_SIZE);
+  const captureMutation = useCaptureMoisSalesLibrarySnapshots(WORKSPACE_ID);
+
+  const summary = useMemo(() => {
+    const items = pagesQuery.data?.items ?? [];
+    return items.reduce(
+      (acc, item) => {
+        acc.total += 1;
+        if (item.analysisStatus === "PENDING" || !item.analysisStatus) {
+          acc.pending += 1;
+        }
+        if (item.analysisStatus === "DONE") {
+          acc.done += 1;
+        }
+        if (item.analysisStatus === "FAILED") {
+          acc.failed += 1;
+        }
+        return acc;
+      },
+      { total: 0, pending: 0, done: 0, failed: 0 },
+    );
+  }, [pagesQuery.data?.items]);
+
+  const lastRun = captureMutation.data;
+  const isRunning = captureMutation.isPending;
+
   return (
     <div className="d-flex flex-column gap-4">
       <header className="d-flex flex-wrap align-items-start justify-content-between gap-3">
         <div>
           <PageTitle>Pipeline de Páginas de Vendas</PageTitle>
           <p className="text-secondary mb-0">
-            Área reservada para construirmos juntos a visão de pipeline da
-            biblioteca de páginas de vendas.
+            Execute e acompanhe a primeira etapa operacional: obter HTML bruto
+            versionado das URLs normalizadas da biblioteca.
           </p>
         </div>
         <Link
@@ -40,8 +114,8 @@ export default function MoisSalesPagesPipelinePage() {
                 evidência real.
               </p>
             </div>
-            <span className="badge text-bg-warning align-self-start">
-              Em implantação
+            <span className="badge text-bg-success align-self-start">
+              Pronto para execução
             </span>
           </div>
 
@@ -53,8 +127,9 @@ export default function MoisSalesPagesPipelinePage() {
                 </p>
                 <h3 className="h6 mb-2">URLs normalizadas da biblioteca</h3>
                 <p className="text-secondary small mb-0">
-                  A etapa deve partir das páginas já ingeridas, priorizando URLs
-                  sem snapshot ou com captura desatualizada.
+                  A etapa parte das páginas ingeridas, priorizando URLs sem
+                  snapshot capturado ou, se solicitado, recapturando páginas já
+                  processadas.
                 </p>
               </div>
             </div>
@@ -65,8 +140,8 @@ export default function MoisSalesPagesPipelinePage() {
                 </p>
                 <h3 className="h6 mb-2">HTML bruto versionado</h3>
                 <p className="text-secondary small mb-0">
-                  Cada captura precisa gerar snapshot com hash, tamanho,
-                  data/hora e status para auditoria e reprocessamento.
+                  Cada captura gera snapshot com hash, tamanho, data/hora,
+                  status HTTP e status operacional para auditoria.
                 </p>
               </div>
             </div>
@@ -84,10 +159,99 @@ export default function MoisSalesPagesPipelinePage() {
             </div>
           </div>
 
+          <div className="row g-3">
+            <div className="col-sm-6 col-lg-3">
+              <div className="border rounded-3 p-3 h-100">
+                <p className="text-secondary mb-1">URLs na biblioteca</p>
+                <h3 className="mb-0">
+                  {pagesQuery.isLoading ? "..." : summary.total}
+                </h3>
+              </div>
+            </div>
+            <div className="col-sm-6 col-lg-3">
+              <div className="border rounded-3 p-3 h-100">
+                <p className="text-secondary mb-1">Pendentes/análise inicial</p>
+                <h3 className="mb-0">
+                  {pagesQuery.isLoading ? "..." : summary.pending}
+                </h3>
+              </div>
+            </div>
+            <div className="col-sm-6 col-lg-3">
+              <div className="border rounded-3 p-3 h-100">
+                <p className="text-secondary mb-1">
+                  Capturadas na última execução
+                </p>
+                <h3 className="mb-0">{lastRun?.captured ?? 0}</h3>
+              </div>
+            </div>
+            <div className="col-sm-6 col-lg-3">
+              <div className="border rounded-3 p-3 h-100">
+                <p className="text-secondary mb-1">Falhas na última execução</p>
+                <h3 className="mb-0">{lastRun?.failed ?? 0}</h3>
+              </div>
+            </div>
+          </div>
+
+          <div className="border rounded-3 p-3">
+            <div className="d-flex flex-wrap align-items-center justify-content-between gap-3">
+              <div>
+                <h3 className="h6 mb-1">Executar captura agora</h3>
+                <p className="text-secondary small mb-0">
+                  O acionamento usa o backend existente e processa até{" "}
+                  {DEFAULT_CAPTURE_LIMIT} URLs por execução para evitar
+                  bloqueios e timeouts longos.
+                </p>
+              </div>
+              <div className="d-flex flex-wrap align-items-center gap-3">
+                <div className="form-check form-switch mb-0">
+                  <input
+                    className="form-check-input"
+                    id="forceCapture"
+                    type="checkbox"
+                    checked={forceCapture}
+                    onChange={(event) => setForceCapture(event.target.checked)}
+                    disabled={isRunning}
+                  />
+                  <label
+                    className="form-check-label small"
+                    htmlFor="forceCapture"
+                  >
+                    Recapturar mesmo com snapshot
+                  </label>
+                </div>
+                <button
+                  className="btn btn-primary"
+                  type="button"
+                  disabled={isRunning}
+                  onClick={() =>
+                    captureMutation.mutate({
+                      limit: DEFAULT_CAPTURE_LIMIT,
+                      force: forceCapture,
+                    })
+                  }
+                >
+                  {isRunning ? "Executando..." : "Executar etapa 1"}
+                </button>
+              </div>
+            </div>
+            {captureMutation.isError ? (
+              <div className="alert alert-danger mt-3 mb-0">
+                Falha ao executar a captura. Verifique se o backend está
+                acessível e tente novamente.
+              </div>
+            ) : null}
+            {lastRun ? (
+              <div className="alert alert-success mt-3 mb-0">
+                Execução concluída em{" "}
+                {new Date(lastRun.capturedAt).toLocaleString()}:{" "}
+                {lastRun.processed} URL(s) processada(s), {lastRun.captured}{" "}
+                captura(s) útil(is) e {lastRun.failed} falha(s).
+              </div>
+            ) : null}
+          </div>
+
           <div>
-            <h3 className="h6 mb-2">
-              Informações que este card deve acompanhar
-            </h3>
+            <h3 className="h6 mb-2">Informações que este card acompanha</h3>
             <ul className="mb-0 text-secondary">
               {htmlAcquisitionChecklist.map((item) => (
                 <li key={item}>{item}</li>
@@ -96,6 +260,58 @@ export default function MoisSalesPagesPipelinePage() {
           </div>
         </div>
       </section>
+
+      {lastRun ? (
+        <section className="card border-0 shadow-sm">
+          <div className="card-body table-responsive">
+            <h2 className="h5 mb-3">Resultado da última execução</h2>
+            <table className="table table-sm align-middle mb-0">
+              <thead>
+                <tr>
+                  <th>Página</th>
+                  <th>Status</th>
+                  <th>HTTP</th>
+                  <th>HTML</th>
+                  <th>Detalhe</th>
+                </tr>
+              </thead>
+              <tbody>
+                {lastRun.items.length === 0 ? (
+                  <tr>
+                    <td colSpan={5} className="text-secondary">
+                      Nenhuma URL elegível encontrada para esta execução.
+                    </td>
+                  </tr>
+                ) : (
+                  lastRun.items.map((item) => (
+                    <tr
+                      key={`${item.pageId}-${item.snapshotId ?? "sem-snapshot"}`}
+                    >
+                      <td className="text-break">
+                        <Link to={`/mois/sales-pages-library/${item.pageId}`}>
+                          {item.urlCanonical}
+                        </Link>
+                      </td>
+                      <td>
+                        <span
+                          className={`badge ${getSnapshotStatusBadgeClass(item.status)}`}
+                        >
+                          {item.status}
+                        </span>
+                      </td>
+                      <td>{item.httpStatus ?? "—"}</td>
+                      <td>{formatBytes(item.rawHtmlBytes)}</td>
+                      <td className="text-secondary small text-break">
+                        {getResultMessage(item)}
+                      </td>
+                    </tr>
+                  ))
+                )}
+              </tbody>
+            </table>
+          </div>
+        </section>
+      ) : null}
     </div>
   );
 }


### PR DESCRIPTION
### Motivation
- A tela do pipeline estava apenas como placeholder e não permitia executar a primeira etapa operacional de obtenção do HTML bruto; era necessário oferecer um controle operacional simples para disparo manual e inspeção do resultado. 
- É necessário manter o frontend alinhado ao contrato já existente no backend para permitir execução segura e auditoria das capturas. 

### Description
- Atualiza a UI da rota `/mois/sales-pages-library/pipeline` para permitir execução manual da etapa 1 e exibir contadores, resultados por URL (status, HTTP, tamanho do HTML e detalhe/hash) em `frontend/src/pages/mois/MoisSalesPagesPipelinePage.tsx`. 
- Adiciona o hook `useCaptureMoisSalesLibrarySnapshots(workspaceId)` e integração com `POST /api/mois/sales-library/snapshots:capture` em `frontend/src/api/mois/useMoisSalesLibrary.ts`. 
- Inclui os tipos TypeScript para o payload de captura (`MoisSalesLibrarySnapshotCaptureItem` / `MoisSalesLibrarySnapshotCaptureResponse`) em `frontend/src/api/mois/types.ts`. 
- Documenta o endpoint de captura manual no `docs/swagger/mois-sales-library-swagger.yaml` e registra a mudança operacional em `docs/registros/mois1.md`. 

### Testing
- Executado `npm ci` no frontend com sucesso para instalar dependências. 
- Executado `npm run typecheck` (inicialmente falhou antes de instalar `node_modules`, depois passou após `npm ci`). 
- Executado `npm run build` com sucesso (vite produziu `dist/`). 
- Validação visual automatizada: instalado browsers com `npx playwright install chromium` e dependências com `npx playwright install-deps chromium`, e capturada screenshot da página com `npx playwright screenshot http://127.0.0.1:5173/mois/sales-pages-library/pipeline /tmp/mois-pipeline.png` com sucesso. 
- Consultas rápidas ao banco via MCP (`tools/db_query`) confirmaram existência de URLs e snapshots nas tabelas relevantes (contagens retornadas), e a tentativa de leitura de logs pelo filtro específico exigiu reexecução com timeout maior mas não bloqueou a entrega da alteração.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a205d3a1c748321b12bf9f145b8bc51)