### PR TITLE
Quality Review: prioritize mobile screenshots, extend Playwright timeout, and add tests

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/openai/core/qualityreview/PlaywrightQualityReviewScreenshotService.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/openai/core/qualityreview/PlaywrightQualityReviewScreenshotService.java
@@ -23,8 +23,8 @@ public class PlaywrightQualityReviewScreenshotService implements QualityReviewSc
 
     private static final Logger log = LoggerFactory.getLogger(PlaywrightQualityReviewScreenshotService.class);
     private static final List<ViewportSpec> VIEWPORTS = List.of(
-            new ViewportSpec("desktop", 1440, 1200),
-            new ViewportSpec("mobile", 390, 1200)
+            new ViewportSpec("mobile", 390, 1200, true),
+            new ViewportSpec("desktop", 1440, 1200, false)
     );
 
     private final FrameworkImageStorageClient storageClient;
@@ -39,7 +39,7 @@ public class PlaywrightQualityReviewScreenshotService implements QualityReviewSc
         this.properties = properties;
     }
 
-    /** Renderiza o HTML final em viewports desktop e mobile e publica os screenshots no storage. */
+    /** Renderiza o HTML final priorizando mobile e publica os screenshots disponíveis no storage. */
     @Override
     public List<String> renderScreenshots(QualityReviewInput input) {
         if (input == null || !StringUtils.hasText(input.landingHtml())) {
@@ -48,7 +48,7 @@ public class PlaywrightQualityReviewScreenshotService implements QualityReviewSc
         try (Playwright playwright = Playwright.create(); Browser browser = launchBrowser(playwright)) {
             List<String> screenshotUrls = new ArrayList<>();
             for (ViewportSpec viewport : VIEWPORTS) {
-                screenshotUrls.add(renderAndUpload(browser, input, viewport));
+                renderAndUploadPrioritized(browser, input, viewport, screenshotUrls);
             }
             return List.copyOf(screenshotUrls);
         } catch (RuntimeException error) {
@@ -59,6 +59,34 @@ public class PlaywrightQualityReviewScreenshotService implements QualityReviewSc
                     input != null && input.landingHtml() != null ? input.landingHtml().length() : 0,
                     error);
             throw error;
+        }
+    }
+
+    /** Informa a ordem operacional de captura para testes e auditoria da prioridade mobile. */
+    static List<String> capturePriorityViewportNames() {
+        return VIEWPORTS.stream().map(ViewportSpec::name).toList();
+    }
+
+    /** Executa a captura da viewport e mantém o fluxo com mobile quando uma viewport secundária falha. */
+    private void renderAndUploadPrioritized(
+            Browser browser,
+            QualityReviewInput input,
+            ViewportSpec viewport,
+            List<String> screenshotUrls
+    ) {
+        try {
+            screenshotUrls.add(renderAndUpload(browser, input, viewport));
+        } catch (RuntimeException error) {
+            if (viewport.required() || screenshotUrls.isEmpty()) {
+                throw error;
+            }
+            log.warn(
+                    "Viewport secundária do Quality Review falhou; prosseguindo com screenshots prioritários [jobId={}, experimentId={}, viewport={}, screenshotsDisponiveis={}]",
+                    input.idJob(),
+                    input.experimentId(),
+                    viewport.name(),
+                    screenshotUrls.size(),
+                    error);
         }
     }
 
@@ -74,7 +102,7 @@ public class PlaywrightQualityReviewScreenshotService implements QualityReviewSc
         return playwright.chromium().launch(options);
     }
 
-    /** Renderiza uma viewport específica, captura JPEG full-page e publica no storage. */
+    /** Renderiza uma viewport específica, captura JPEG full-page sem recortar a landing e publica no storage. */
     private String renderAndUpload(Browser browser, QualityReviewInput input, ViewportSpec viewport) {
         Page page = browser.newPage(new Browser.NewPageOptions()
                 .setViewportSize(viewport.width(), viewport.height())
@@ -86,16 +114,18 @@ public class PlaywrightQualityReviewScreenshotService implements QualityReviewSc
             waitForNetworkIdle(page, input, viewport);
             byte[] screenshot = page.screenshot(new Page.ScreenshotOptions()
                     .setFullPage(true)
+                    .setTimeout(properties.screenshotTimeout().toMillis())
                     .setType(ScreenshotType.JPEG)
                     .setQuality(82));
             FrameworkImageStorageClient.UploadedFrameworkImage uploaded = storageClient.upload(
                     screenshot,
                     buildScreenshotFilename(input, viewport));
             log.info(
-                    "Screenshot do Quality Review publicado [jobId={}, experimentId={}, viewport={}, publicUrl={}, bytes={}]",
+                    "Screenshot full-page do Quality Review publicado [jobId={}, experimentId={}, viewport={}, screenshotTimeoutMs={}, publicUrl={}, bytes={}]",
                     input.idJob(),
                     input.experimentId(),
                     viewport.name(),
+                    properties.screenshotTimeout().toMillis(),
                     uploaded.publicUrl(),
                     screenshot.length);
             return uploaded.publicUrl();
@@ -123,9 +153,9 @@ public class PlaywrightQualityReviewScreenshotService implements QualityReviewSc
         return jobId + "-quality-review-" + viewport.name() + ".jpg";
     }
 
-    /** Responsabilidade: representar uma viewport de screenshot da landing. */
-    private record ViewportSpec(String name, int width, int height) {
-        /** Preserva nome e dimensões da viewport para renderização do browser. */
+    /** Responsabilidade: representar uma viewport de screenshot da landing e sua prioridade operacional. */
+    private record ViewportSpec(String name, int width, int height, boolean required) {
+        /** Preserva nome, dimensões e obrigatoriedade da viewport para renderização do browser. */
         private ViewportSpec {
         }
     }

--- a/ai-worker/src/main/java/com/marketinghub/worker/openai/core/qualityreview/QualityReviewWorkerProperties.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/openai/core/qualityreview/QualityReviewWorkerProperties.java
@@ -48,7 +48,7 @@ public record QualityReviewWorkerProperties(
             chromiumExecutablePath = "/usr/bin/chromium";
         }
         if (screenshotTimeout == null || screenshotTimeout.isNegative() || screenshotTimeout.isZero()) {
-            screenshotTimeout = Duration.ofSeconds(30);
+            screenshotTimeout = Duration.ofMinutes(2);
         }
     }
 }

--- a/ai-worker/src/main/resources/application.properties
+++ b/ai-worker/src/main/resources/application.properties
@@ -117,4 +117,4 @@ qualityreview.worker.vision-model=${QUALITYREVIEW_WORKER_VISION_MODEL:gpt-5.5}
 qualityreview.worker.image-detail=${QUALITYREVIEW_WORKER_IMAGE_DETAIL:original}
 qualityreview.worker.timeout=${QUALITYREVIEW_WORKER_TIMEOUT:PT30M}
 qualityreview.worker.chromium-executable-path=${QUALITYREVIEW_WORKER_CHROMIUM_EXECUTABLE_PATH:/usr/bin/chromium}
-qualityreview.worker.screenshot-timeout=${QUALITYREVIEW_WORKER_SCREENSHOT_TIMEOUT:PT30S}
+qualityreview.worker.screenshot-timeout=${QUALITYREVIEW_WORKER_SCREENSHOT_TIMEOUT:PT2M}

--- a/ai-worker/src/test/java/com/marketinghub/worker/openai/core/qualityreview/PlaywrightQualityReviewScreenshotServiceTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/openai/core/qualityreview/PlaywrightQualityReviewScreenshotServiceTest.java
@@ -1,0 +1,16 @@
+package com.marketinghub.worker.openai.core.qualityreview;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+/** Responsabilidade: validar a prioridade operacional dos screenshots visuais do Quality Review. */
+class PlaywrightQualityReviewScreenshotServiceTest {
+
+    /** Deve capturar mobile antes de desktop para preservar a evidência visual prioritária. */
+    @Test
+    void capturePriorityViewportNamesShouldStartWithMobile() {
+        assertThat(PlaywrightQualityReviewScreenshotService.capturePriorityViewportNames())
+                .containsExactly("mobile", "desktop");
+    }
+}

--- a/ai-worker/src/test/java/com/marketinghub/worker/openai/core/qualityreview/QualityReviewWorkerPropertiesTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/openai/core/qualityreview/QualityReviewWorkerPropertiesTest.java
@@ -1,0 +1,30 @@
+package com.marketinghub.worker.openai.core.qualityreview;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.time.Duration;
+import org.junit.jupiter.api.Test;
+
+/** Responsabilidade: validar os defaults operacionais da etapa Quality Review. */
+class QualityReviewWorkerPropertiesTest {
+
+    /** Deve usar timeout maior para permitir screenshots full-page sem limitar o tamanho da imagem. */
+    @Test
+    void shouldDefaultScreenshotTimeoutToTwoMinutes() {
+        QualityReviewWorkerProperties properties = new QualityReviewWorkerProperties(
+                true,
+                5,
+                "http://backend.test",
+                "/api",
+                "prompts/geralanding/landing-page-quality-review.md",
+                "prompts/geralanding/landing-page-quality-review-schema.json",
+                "experiment_pipeline_landing_page_quality_review",
+                "gpt-5.5",
+                "original",
+                Duration.ofMinutes(30),
+                "/usr/bin/chromium",
+                null);
+
+        assertThat(properties.screenshotTimeout()).isEqualTo(Duration.ofMinutes(2));
+    }
+}

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -3207,3 +3207,41 @@
   - o request multimodal da etapa passou a preencher o campo `model` com o modelo visual dedicado e a aplicar o nível de detalhe configurado em cada `input_image`;
   - o cânone do GeraLanding passou a exigir modelo de visão dedicado para `landing-page-quality-review`.
 - impacto esperado: novas execuções do Quality Review deixam de depender de modelo textual global e passam a enviar screenshots renderizados para um modelo multimodal/visão configurado explicitamente.
+
+## 2026-06-03 14:17:15 UTC-3
+- solicitação para corrigir timeout do Playwright ao gerar screenshot da etapa visual `landing-page-quality-review`.
+- causa-raiz identificada: o serviço usava captura `fullPage` sem limite operacional, o que deixa o Chromium tentar rasterizar landings muito longas ou expandidas e pode estourar o timeout padrão de 30s durante `Page.screenshot`.
+- correção aplicada: a captura passou a medir a altura renderizada, limitar a área relevante do screenshot e usar explicitamente o timeout configurado da etapa, reduzindo risco de travamento sem remover a evidência visual desktop/mobile para o modelo de visão.
+- validação automatizada adicionada para garantir o limite máximo de captura e a preservação mínima da altura da viewport.
+- documentos/arquivos lidos para tratar a situação:
+  - AGENTS.md
+  - ai-worker/AGENTS.md
+  - ai-worker/src/main/java/com/marketinghub/worker/openai/core/qualityreview/PlaywrightQualityReviewScreenshotService.java
+  - ai-worker/src/main/java/com/marketinghub/worker/openai/core/qualityreview/QualityReviewPromptBuilder.java
+  - ai-worker/src/main/java/com/marketinghub/worker/openai/core/qualityreview/QualityReviewWorkerProperties.java
+  - docs/registros/experimentos.md
+
+## 2026-06-03 14:25:52 UTC-3
+- solicitação para ajustar a captura do Quality Review priorizando mobile.
+- causa-raiz/objetivo: a experiência mobile é a evidência visual mais crítica para tráfego pago e deve ser capturada antes da desktop, evitando que falhas de uma viewport secundária impeçam o envio da evidência principal ao modelo de visão.
+- correção aplicada: a ordem operacional de screenshots passou a ser mobile antes de desktop, com mobile como viewport obrigatória e desktop como complementar; se a desktop falhar após o mobile, o fluxo prossegue com o screenshot prioritário disponível e registra log de aviso com contexto.
+- validação automatizada adicionada para garantir explicitamente a ordem de prioridade mobile/desktop.
+- documentos/arquivos lidos para tratar a situação:
+  - AGENTS.md
+  - ai-worker/AGENTS.md
+  - ai-worker/src/main/java/com/marketinghub/worker/openai/core/qualityreview/PlaywrightQualityReviewScreenshotService.java
+  - ai-worker/src/test/java/com/marketinghub/worker/openai/core/qualityreview/PlaywrightQualityReviewScreenshotServiceTest.java
+  - docs/registros/experimentos.md
+
+## 2026-06-03 14:36:31 UTC-3
+- solicitação para remover a limitação de tamanho da imagem no screenshot do Quality Review e, se necessário, aumentar o timeout.
+- causa-raiz/objetivo: recortar a captura compromete a evidência visual completa da landing; o problema operacional correto é tempo insuficiente para screenshot full-page, não tamanho da imagem.
+- correção aplicada: a captura voltou a usar `fullPage(true)` sem `clip` e sem limite de altura, mantendo prioridade mobile antes de desktop; o timeout padrão de screenshot foi aumentado para 2 minutos e continua configurável por `QUALITYREVIEW_WORKER_SCREENSHOT_TIMEOUT`.
+- validação automatizada ajustada para remover testes de limite de altura e adicionar teste do timeout padrão de 2 minutos.
+- documentos/arquivos lidos para tratar a situação:
+  - AGENTS.md
+  - ai-worker/AGENTS.md
+  - ai-worker/src/main/java/com/marketinghub/worker/openai/core/qualityreview/PlaywrightQualityReviewScreenshotService.java
+  - ai-worker/src/main/java/com/marketinghub/worker/openai/core/qualityreview/QualityReviewWorkerProperties.java
+  - ai-worker/src/main/resources/application.properties
+  - docs/registros/experimentos.md


### PR DESCRIPTION
### Motivation
- Ensure the Quality Review captures the mobile screenshot first as the primary visual evidence and tolerate failure of a secondary viewport. 
- Reduce false failures and timeouts when capturing full-page screenshots by increasing the Playwright screenshot timeout. 
- Make the new behavior testable and document the changes in experiment logs.

### Description
- Reordered `VIEWPORTS` and extended `ViewportSpec` with a `required` flag so mobile is captured first and marked mandatory, while desktop is complementary. 
- Added `capturePriorityViewportNames()` and `renderAndUploadPrioritized(...)` to enforce mobile-first capture and continue when a non-required viewport fails, with contextual warnings logged. 
- Propagated the configured screenshot timeout into `page.screenshot(...)` and updated log messages to include the timeout value. 
- Changed the default `screenshotTimeout` from 30 seconds to 2 minutes in `QualityReviewWorkerProperties` and updated `application.properties` default. 
- Added unit tests `PlaywrightQualityReviewScreenshotServiceTest` and `QualityReviewWorkerPropertiesTest` and updated `docs/registros/experimentos.md` to record the changes.

### Testing
- Ran unit tests including `PlaywrightQualityReviewScreenshotServiceTest` which asserts `capturePriorityViewportNames()` yields `mobile` then `desktop`, and it passed. 
- Ran `QualityReviewWorkerPropertiesTest` which asserts the default screenshot timeout is two minutes, and it passed. 
- All automated tests executed (`mvn test`) succeeded for the modified modules.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a205fb9853c8321913ed5ffcdeaebdd)