### PR TITLE
Record redirect URLs and fallback to redirect-root when capturing HTML snapshots

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/dto/MoisSalesLibraryDtos.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/dto/MoisSalesLibraryDtos.java
@@ -269,6 +269,8 @@ public final class MoisSalesLibraryDtos {
             long pageId,
             Long snapshotId,
             String urlCanonical,
+            String redirectDestinationUrl,
+            String redirectRootUrl,
             String status,
             String snapshotHash,
             Integer httpStatus,
@@ -297,6 +299,8 @@ public final class MoisSalesLibraryDtos {
             String status,
             Integer httpStatus,
             String contentType,
+            String redirectDestinationUrl,
+            String redirectRootUrl,
             long rawHtmlBytes,
             long screenshotBytes,
             Instant capturedAt,
@@ -328,6 +332,8 @@ public final class MoisSalesLibraryDtos {
     public record HtmlCaptureCompleteRequest(
             @NotBlank String rawHtml,
             String finalUrl,
+            String redirectDestinationUrl,
+            String redirectRootUrl,
             Integer httpStatus,
             String contentType,
             String sha256,
@@ -338,7 +344,10 @@ public final class MoisSalesLibraryDtos {
 
     public record HtmlCaptureFailRequest(
             String errorCategory,
-            String errorMessage
+            String errorMessage,
+            String redirectDestinationUrl,
+            String redirectRootUrl,
+            Integer httpStatus
     ) {
     }
 

--- a/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibrarySnapshotService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibrarySnapshotService.java
@@ -74,6 +74,7 @@ public class MoisSalesLibrarySnapshotService {
     public List<MoisSalesLibraryDtos.SalesLibraryPageSnapshotResponse> listSnapshots(long pageId) {
         return jdbcTemplate.query("""
                 SELECT s.id, s.url_ingest_id, s.snapshot_hash, s.status, s.http_status, s.content_type,
+                       s.redirect_destination_url, s.redirect_root_url,
                        COALESCE(raw.size_bytes, 0) AS raw_html_bytes,
                        COALESCE(png.size_bytes, 0) AS screenshot_bytes,
                        s.captured_at, s.updated_at
@@ -92,6 +93,8 @@ public class MoisSalesLibrarySnapshotService {
                 rs.getString("status"),
                 (Integer) rs.getObject("http_status"),
                 rs.getString("content_type"),
+                rs.getString("redirect_destination_url"),
+                rs.getString("redirect_root_url"),
                 rs.getLong("raw_html_bytes"),
                 rs.getLong("screenshot_bytes"),
                 toInstant(rs.getTimestamp("captured_at")),
@@ -135,19 +138,19 @@ public class MoisSalesLibrarySnapshotService {
         if (duplicateSnapshotId != null) {
             jdbcTemplate.update("""
                     UPDATE mois_sales_library_page_snapshot
-                    SET status = 'DUPLICATE', http_status = ?, content_type = ?, error_message = ?, captured_at = ?, updated_at = UTC_TIMESTAMP()
+                    SET status = 'DUPLICATE', http_status = ?, content_type = ?, redirect_destination_url = ?, redirect_root_url = ?, error_message = ?, captured_at = ?, updated_at = UTC_TIMESTAMP()
                     WHERE id = ?
-                    """, request.httpStatus(), truncate(request.contentType(), 255),
-                    "HTML idêntico ao snapshot " + duplicateSnapshotId,
+                    """, request.httpStatus(), truncate(request.contentType(), 255), truncate(request.redirectDestinationUrl(), 1024),
+                    truncate(request.redirectRootUrl(), 1024), "HTML idêntico ao snapshot " + duplicateSnapshotId,
                     Timestamp.from(request.capturedAt() == null ? Instant.now() : request.capturedAt()), snapshotId);
             return new MoisSalesLibraryDtos.HtmlCapturePersistResponse(snapshotId, "DUPLICATE");
         }
         jdbcTemplate.update("""
                 UPDATE mois_sales_library_page_snapshot
-                SET snapshot_hash = ?, status = 'CAPTURED', http_status = ?, content_type = ?, error_message = NULL, captured_at = ?, updated_at = UTC_TIMESTAMP()
+                SET snapshot_hash = ?, status = 'CAPTURED', http_status = ?, content_type = ?, redirect_destination_url = ?, redirect_root_url = ?, error_message = NULL, captured_at = ?, updated_at = UTC_TIMESTAMP()
                 WHERE id = ?
-                """, hash, request.httpStatus(), truncate(request.contentType(), 255),
-                Timestamp.from(request.capturedAt() == null ? Instant.now() : request.capturedAt()), snapshotId);
+                """, hash, request.httpStatus(), truncate(request.contentType(), 255), truncate(request.redirectDestinationUrl(), 1024),
+                truncate(request.redirectRootUrl(), 1024), Timestamp.from(request.capturedAt() == null ? Instant.now() : request.capturedAt()), snapshotId);
         insertTextArtifact(snapshotId, ARTIFACT_RAW_HTML, request.contentType() == null ? "text/html" : request.contentType(), rawHtml, rawHtmlBytes.length);
         return new MoisSalesLibraryDtos.HtmlCapturePersistResponse(snapshotId, "CAPTURED");
     }
@@ -165,9 +168,10 @@ public class MoisSalesLibrarySnapshotService {
                 : request.errorMessage();
         jdbcTemplate.update("""
                 UPDATE mois_sales_library_page_snapshot
-                SET status = 'FAILED', error_message = ?, captured_at = UTC_TIMESTAMP(), updated_at = UTC_TIMESTAMP()
+                SET status = 'FAILED', http_status = ?, redirect_destination_url = ?, redirect_root_url = ?, error_message = ?, captured_at = UTC_TIMESTAMP(), updated_at = UTC_TIMESTAMP()
                 WHERE id = ?
-                """, truncate(message, 1000), snapshotId);
+                """, request.httpStatus(), truncate(request.redirectDestinationUrl(), 1024), truncate(request.redirectRootUrl(), 1024),
+                truncate(message, 1000), snapshotId);
         return new MoisSalesLibraryDtos.HtmlCapturePersistResponse(snapshotId, "FAILED");
     }
 
@@ -227,85 +231,93 @@ public class MoisSalesLibrarySnapshotService {
             String errorMessage = categorizeExceptionFailure(ex);
             log.warn("Falha ao capturar snapshot bruto da sales page MOIS. pageId={}, url={}, categoria={}",
                     page.pageId(), page.urlCanonical(), errorMessage, ex);
-            Long snapshotId = persistFailedSnapshot(page, errorMessage, null, null);
+            Long snapshotId = persistFailedSnapshot(page, errorMessage, null, null, null, null);
             return new MoisSalesLibraryDtos.SalesLibrarySnapshotCaptureItem(
-                    page.pageId(), snapshotId, page.urlCanonical(), "FAILED", null, null, 0L, 0L, errorMessage);
+                    page.pageId(), snapshotId, page.urlCanonical(), null, null, "FAILED", null, null, 0L, 0L, errorMessage);
         }
     }
 
-    /** Busca a URL canônica, valida o HTML recebido e persiste os artefatos de snapshot quando a captura é útil. */
+    /** Busca a URL canônica, tenta fallback pela raiz do redirecionamento e persiste os artefatos quando a captura é útil. */
     private MoisSalesLibraryDtos.SalesLibrarySnapshotCaptureItem captureOne(PageToCapture page) throws Exception {
-        HttpRequest request = HttpRequest.newBuilder(URI.create(page.urlCanonical()))
-                .timeout(Duration.ofSeconds(30))
-                .header("User-Agent", "MarketingHub-MOIS-SalesLibrarySnapshot/1.0")
-                .GET()
-                .build();
-        HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8));
-        String rawHtml = response.body() == null ? "" : response.body();
-        String contentType = response.headers().firstValue("content-type").orElse("text/html");
-        log.info("MOIS sales-library snapshot payload bruto recebido. pageId={}, url={}, httpStatus={}, contentType={}, htmlPreview={}",
-                page.pageId(), page.urlCanonical(), response.statusCode(), contentType, truncate(rawHtml, 4000));
+        CaptureResponse primary = fetchUrl(page.urlCanonical());
+        String redirectDestinationUrl = primary.finalUrl();
+        String redirectRootUrl = rootUrl(redirectDestinationUrl);
+        CaptureResponse effective = primary;
+        if (!primary.isCapturable() && shouldTryRedirectRoot(page.urlCanonical(), redirectDestinationUrl, redirectRootUrl)) {
+            log.info("MOIS sales-library snapshot tentando raiz do redirecionamento. pageId={}, urlCanonical={}, redirectDestinationUrl={}, redirectRootUrl={}",
+                    page.pageId(), page.urlCanonical(), redirectDestinationUrl, redirectRootUrl);
+            effective = fetchUrl(redirectRootUrl);
+        }
 
-        if (response.statusCode() < 200 || response.statusCode() >= 400 || rawHtml.isBlank()) {
-            String errorMessage = categorizeHttpFailure(response.statusCode(), rawHtml);
-            Long snapshotId = persistFailedSnapshot(page, errorMessage, response.statusCode(), contentType);
+        log.info("MOIS sales-library snapshot payload bruto recebido. pageId={}, url={}, redirectDestinationUrl={}, redirectRootUrl={}, effectiveUrl={}, httpStatus={}, contentType={}, htmlPreview={}",
+                page.pageId(), page.urlCanonical(), redirectDestinationUrl, redirectRootUrl, effective.finalUrl(), effective.statusCode(),
+                effective.contentType(), truncate(effective.rawHtml(), 4000));
+
+        if (!effective.isCapturable()) {
+            String errorMessage = categorizeHttpFailure(effective.statusCode(), effective.rawHtml());
+            Long snapshotId = persistFailedSnapshot(page, errorMessage, effective.statusCode(), effective.contentType(), redirectDestinationUrl, redirectRootUrl);
             return new MoisSalesLibraryDtos.SalesLibrarySnapshotCaptureItem(
-                    page.pageId(), snapshotId, page.urlCanonical(), "FAILED", null, response.statusCode(), 0L, 0L,
+                    page.pageId(), snapshotId, page.urlCanonical(), redirectDestinationUrl, redirectRootUrl, "FAILED", null, effective.statusCode(), 0L, 0L,
                     errorMessage);
         }
 
+        String rawHtml = effective.rawHtml();
         String hash = sha256(rawHtml);
         Long existingSnapshotId = findExistingSnapshot(page.pageId(), hash);
         if (existingSnapshotId != null) {
             return new MoisSalesLibraryDtos.SalesLibrarySnapshotCaptureItem(
-                    page.pageId(), existingSnapshotId, page.urlCanonical(), "DUPLICATE", hash, response.statusCode(), rawHtml.getBytes(StandardCharsets.UTF_8).length, 0L, null);
+                    page.pageId(), existingSnapshotId, page.urlCanonical(), redirectDestinationUrl, redirectRootUrl, "DUPLICATE", hash,
+                    effective.statusCode(), rawHtml.getBytes(StandardCharsets.UTF_8).length, 0L, null);
         }
 
-        long snapshotId = insertSnapshot(page, hash, response.statusCode(), contentType);
+        long snapshotId = insertSnapshot(page, hash, effective.statusCode(), effective.contentType(), redirectDestinationUrl, redirectRootUrl);
         byte[] rawHtmlBytes = rawHtml.getBytes(StandardCharsets.UTF_8);
         insertTextArtifact(snapshotId, ARTIFACT_RAW_HTML, "text/html; charset=UTF-8", rawHtml, rawHtmlBytes.length);
-        byte[] screenshot = renderBasicScreenshot(rawHtml, page.urlCanonical());
+        byte[] screenshot = renderBasicScreenshot(rawHtml, effective.finalUrl());
         insertBinaryArtifact(snapshotId, ARTIFACT_SCREENSHOT_PNG, "image/png", screenshot);
         return new MoisSalesLibraryDtos.SalesLibrarySnapshotCaptureItem(
-                page.pageId(), snapshotId, page.urlCanonical(), "CAPTURED", hash, response.statusCode(), rawHtmlBytes.length, screenshot.length, null);
+                page.pageId(), snapshotId, page.urlCanonical(), redirectDestinationUrl, redirectRootUrl, "CAPTURED", hash,
+                effective.statusCode(), rawHtmlBytes.length, screenshot.length, null);
     }
 
-    /** Persiste uma falha de captura preservando categoria, HTTP e tipo de conteúdo quando disponíveis. */
-    private Long persistFailedSnapshot(PageToCapture page, String errorMessage, Integer httpStatus, String contentType) {
+    /** Persiste uma falha de captura preservando URLs de redirecionamento, categoria, HTTP e tipo de conteúdo quando disponíveis. */
+    private Long persistFailedSnapshot(PageToCapture page, String errorMessage, Integer httpStatus, String contentType, String redirectDestinationUrl, String redirectRootUrl) {
         try {
-            return insertFailedSnapshot(page, truncate(errorMessage, 1000), httpStatus, contentType);
+            return insertFailedSnapshot(page, truncate(errorMessage, 1000), httpStatus, contentType, redirectDestinationUrl, redirectRootUrl);
         } catch (Exception persistEx) {
             log.warn("Falha ao persistir snapshot FAILED da sales page MOIS. pageId={}", page.pageId(), persistEx);
             return null;
         }
     }
 
-    /** Insere os metadados principais de um snapshot capturado com sucesso. */
-    private long insertSnapshot(PageToCapture page, String hash, int httpStatus, String contentType) {
+    /** Insere os metadados principais de um snapshot capturado com sucesso, incluindo URLs de redirecionamento. */
+    private long insertSnapshot(PageToCapture page, String hash, int httpStatus, String contentType, String redirectDestinationUrl, String redirectRootUrl) {
         KeyHolder keyHolder = new GeneratedKeyHolder();
         jdbcTemplate.update(connection -> {
             PreparedStatement ps = connection.prepareStatement("""
                     INSERT INTO mois_sales_library_page_snapshot
-                    (url_ingest_id, snapshot_hash, status, http_status, content_type, captured_at, created_at, updated_at)
-                    VALUES (?, ?, 'CAPTURED', ?, ?, UTC_TIMESTAMP(), UTC_TIMESTAMP(), UTC_TIMESTAMP())
+                    (url_ingest_id, snapshot_hash, status, http_status, content_type, redirect_destination_url, redirect_root_url, captured_at, created_at, updated_at)
+                    VALUES (?, ?, 'CAPTURED', ?, ?, ?, ?, UTC_TIMESTAMP(), UTC_TIMESTAMP(), UTC_TIMESTAMP())
                     """, Statement.RETURN_GENERATED_KEYS);
             ps.setLong(1, page.pageId());
             ps.setString(2, hash);
             ps.setInt(3, httpStatus);
             ps.setString(4, truncate(contentType, 255));
+            ps.setString(5, truncate(redirectDestinationUrl, 1024));
+            ps.setString(6, truncate(redirectRootUrl, 1024));
             return ps;
         }, keyHolder);
         return generatedId(keyHolder);
     }
 
-    /** Insere um snapshot FAILED com metadados suficientes para auditoria e cooldown de reprocessamento. */
-    private long insertFailedSnapshot(PageToCapture page, String errorMessage, Integer httpStatus, String contentType) {
+    /** Insere um snapshot FAILED com URLs de redirecionamento e metadados suficientes para auditoria. */
+    private long insertFailedSnapshot(PageToCapture page, String errorMessage, Integer httpStatus, String contentType, String redirectDestinationUrl, String redirectRootUrl) {
         KeyHolder keyHolder = new GeneratedKeyHolder();
         jdbcTemplate.update(connection -> {
             PreparedStatement ps = connection.prepareStatement("""
                     INSERT INTO mois_sales_library_page_snapshot
-                    (url_ingest_id, status, http_status, content_type, error_message, captured_at, created_at, updated_at)
-                    VALUES (?, 'FAILED', ?, ?, ?, UTC_TIMESTAMP(), UTC_TIMESTAMP(), UTC_TIMESTAMP())
+                    (url_ingest_id, status, http_status, content_type, redirect_destination_url, redirect_root_url, error_message, captured_at, created_at, updated_at)
+                    VALUES (?, 'FAILED', ?, ?, ?, ?, ?, UTC_TIMESTAMP(), UTC_TIMESTAMP(), UTC_TIMESTAMP())
                     """, Statement.RETURN_GENERATED_KEYS);
             ps.setLong(1, page.pageId());
             if (httpStatus == null) {
@@ -314,7 +326,9 @@ public class MoisSalesLibrarySnapshotService {
                 ps.setInt(2, httpStatus);
             }
             ps.setString(3, truncate(contentType, 255));
-            ps.setString(4, errorMessage);
+            ps.setString(4, truncate(redirectDestinationUrl, 1024));
+            ps.setString(5, truncate(redirectRootUrl, 1024));
+            ps.setString(6, errorMessage);
             return ps;
         }, keyHolder);
         return generatedId(keyHolder);
@@ -418,6 +432,49 @@ public class MoisSalesLibrarySnapshotService {
         return Math.max(1, Math.min(limit, MAX_LIMIT));
     }
 
+
+    /** Executa GET com redirecionamentos e encapsula HTML, URL final, HTTP status e content type. */
+    private CaptureResponse fetchUrl(String url) throws Exception {
+        HttpRequest request = HttpRequest.newBuilder(URI.create(url))
+                .timeout(Duration.ofSeconds(30))
+                .header("User-Agent", "MarketingHub-MOIS-SalesLibrarySnapshot/1.0")
+                .GET()
+                .build();
+        HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8));
+        String rawHtml = response.body() == null ? "" : response.body();
+        String contentType = response.headers().firstValue("content-type").orElse("text/html");
+        String finalUrl = response.uri() == null ? url : response.uri().toString();
+        return new CaptureResponse(rawHtml, finalUrl, response.statusCode(), contentType);
+    }
+
+    /** Decide se vale tentar a raiz do domínio de destino quando a URL redirecionada falha. */
+    private boolean shouldTryRedirectRoot(String originalUrl, String redirectDestinationUrl, String redirectRootUrl) {
+        return redirectDestinationUrl != null
+                && redirectRootUrl != null
+                && !redirectDestinationUrl.equals(originalUrl)
+                && !redirectRootUrl.equals(redirectDestinationUrl)
+                && !redirectRootUrl.equals(originalUrl);
+    }
+
+    /** Extrai a raiz scheme://host[:port] da URL final de redirecionamento. */
+    private String rootUrl(String url) {
+        if (url == null || url.isBlank()) {
+            return null;
+        }
+        try {
+            URI uri = URI.create(url);
+            if (uri.getScheme() == null || uri.getHost() == null) {
+                return null;
+            }
+            String port = uri.getPort() < 0 ? "" : ":" + uri.getPort();
+            return uri.getScheme() + "://" + uri.getHost() + port;
+        } catch (IllegalArgumentException ex) {
+            log.warn("Falha ao extrair raiz da URL redirecionada MOIS. url={}, erroClasse={}, erro={}",
+                    url, ex.getClass().getName(), ex.getMessage(), ex);
+            return null;
+        }
+    }
+
     /** Classifica falhas HTTP para impedir que URLs indisponíveis sejam tratadas como pendência normal. */
     private String categorizeHttpFailure(int httpStatus, String rawHtml) {
         String preview = truncate(rawHtml == null ? "" : rawHtml.strip(), 200);
@@ -479,5 +536,13 @@ public class MoisSalesLibrarySnapshotService {
     }
 
     private record PageToCapture(long pageId, String urlCanonical, String title) {
+    }
+
+    private record CaptureResponse(String rawHtml, String finalUrl, int statusCode, String contentType) {
+
+        /** Informa se a resposta capturada possui corpo aproveitável para análise. */
+        private boolean isCapturable() {
+            return statusCode >= 200 && statusCode < 400 && rawHtml != null && !rawHtml.isBlank();
+        }
     }
 }

--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-03-mois-sales-library-snapshot-redirect-urls.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-03-mois-sales-library-snapshot-redirect-urls.yaml
@@ -1,0 +1,23 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-06-03-mois-sales-library-snapshot-redirect-urls-01
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - onError: HALT
+        - dbms:
+            type: mysql
+        - tableExists:
+            tableName: mois_sales_library_page_snapshot
+        - not:
+            columnExists:
+              tableName: mois_sales_library_page_snapshot
+              columnName: redirect_destination_url
+      changes:
+        - sql:
+            splitStatements: true
+            stripComments: true
+            sql: |
+              ALTER TABLE mois_sales_library_page_snapshot
+                ADD COLUMN redirect_destination_url VARCHAR(1024) NULL AFTER content_type,
+                ADD COLUMN redirect_root_url VARCHAR(1024) NULL AFTER redirect_destination_url;

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -812,6 +812,9 @@ databaseChangeLog:
   - include:
       file: changesets/2026-05-18-mois-sales-library-page-snapshot.yaml
       relativeToChangelogFile: true
+  - include:
+      file: changesets/2026-06-03-mois-sales-library-snapshot-redirect-urls.yaml
+      relativeToChangelogFile: true
 
   - include:
       file: changesets/2026-05-17-experiment-create-simplification-columns.yaml

--- a/backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibrarySnapshotServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibrarySnapshotServiceTest.java
@@ -54,6 +54,23 @@ public class MoisSalesLibrarySnapshotServiceTest {
             exchange.getResponseBody().write(body);
             exchange.close();
         });
+        server.createContext("/redirect-to-missing", exchange -> {
+            exchange.getResponseHeaders().add("Location", "/missing");
+            exchange.sendResponseHeaders(302, -1);
+            exchange.close();
+        });
+        server.createContext("/", exchange -> {
+            byte[] body = """
+                    <html>
+                      <head><title>Oferta Raiz</title></head>
+                      <body><h1>Oferta Raiz</h1><p>Fallback comercial disponível na raiz.</p></body>
+                    </html>
+                    """.getBytes(StandardCharsets.UTF_8);
+            exchange.getResponseHeaders().add("Content-Type", "text/html; charset=UTF-8");
+            exchange.sendResponseHeaders(200, body.length);
+            exchange.getResponseBody().write(body);
+            exchange.close();
+        });
         server.start();
     }
 
@@ -190,6 +207,33 @@ public class MoisSalesLibrarySnapshotServiceTest {
         assertThat(response.items().getFirst().status()).isEqualTo("CAPTURED");
     }
 
+
+    /** Garante que o pipeline registre o destino redirecionado e capture a raiz quando o caminho final falha. */
+    @Test
+    void shouldTryRedirectRootWhenRedirectDestinationIsNotCapturable() {
+        String baseUrl = "http://localhost:" + server.getAddress().getPort();
+        String url = baseUrl + "/redirect-to-missing";
+        insertPage(8L, url);
+
+        var response = service.captureSnapshots(
+                new MoisSalesLibraryDtos.SalesLibrarySnapshotCaptureRequest("workspace-001", 5, false));
+
+        assertThat(response.processed()).isEqualTo(1);
+        assertThat(response.captured()).isEqualTo(1);
+        assertThat(response.failed()).isZero();
+        assertThat(response.items().getFirst().status()).isEqualTo("CAPTURED");
+        assertThat(response.items().getFirst().redirectDestinationUrl()).isEqualTo(baseUrl + "/missing");
+        assertThat(response.items().getFirst().redirectRootUrl()).isEqualTo(baseUrl);
+        String capturedHtml = jdbcTemplate.queryForObject(
+                "SELECT content_text FROM mois_sales_library_snapshot_artifact WHERE artifact_type = 'RAW_HTML'",
+                String.class);
+        assertThat(capturedHtml).contains("Oferta Raiz");
+        var storedUrls = jdbcTemplate.queryForMap(
+                "SELECT redirect_destination_url, redirect_root_url FROM mois_sales_library_page_snapshot WHERE url_ingest_id = 8");
+        assertThat(storedUrls.get("redirect_destination_url")).isEqualTo(baseUrl + "/missing");
+        assertThat(storedUrls.get("redirect_root_url")).isEqualTo(baseUrl);
+    }
+
     /** Fornece timestamp UTC compatível com a função usada no SQL MySQL dos testes. */
     public static Timestamp utcTimestamp() {
         return Timestamp.from(Instant.now());
@@ -241,6 +285,8 @@ public class MoisSalesLibrarySnapshotServiceTest {
                   status VARCHAR(32) NOT NULL,
                   http_status INT,
                   content_type VARCHAR(255),
+                  redirect_destination_url VARCHAR(1024),
+                  redirect_root_url VARCHAR(1024),
                   error_message VARCHAR(1000),
                   captured_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
                   created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,

--- a/backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/web/MoisSalesLibraryControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/web/MoisSalesLibraryControllerTest.java
@@ -50,6 +50,8 @@ class MoisSalesLibraryControllerTest {
                                 10L,
                                 20L,
                                 "https://example.test/sales",
+                                "https://example.test/sales",
+                                "https://example.test",
                                 "CAPTURED",
                                 "abc123",
                                 200,
@@ -73,6 +75,8 @@ class MoisSalesLibraryControllerTest {
                 .andExpect(jsonPath("$.workspaceId").value("workspace-001"))
                 .andExpect(jsonPath("$.captured").value(1))
                 .andExpect(jsonPath("$.items[0].status").value("CAPTURED"))
+                .andExpect(jsonPath("$.items[0].redirectDestinationUrl").value("https://example.test/sales"))
+                .andExpect(jsonPath("$.items[0].redirectRootUrl").value("https://example.test"))
                 .andExpect(jsonPath("$.items[0].rawHtmlBytes").value(512))
                 .andExpect(jsonPath("$.items[0].screenshotBytes").value(1024));
     }
@@ -87,6 +91,8 @@ class MoisSalesLibraryControllerTest {
                         "CAPTURED",
                         200,
                         "text/html; charset=UTF-8",
+                        "https://example.test/sales",
+                        "https://example.test",
                         512L,
                         1024L,
                         Instant.parse("2026-05-18T22:00:00Z"),

--- a/docs/canonical/mois-worker-canon.v1.md
+++ b/docs/canonical/mois-worker-canon.v1.md
@@ -315,7 +315,8 @@ erDiagram
 #### 13.3.4 `mois_sales_library_page_snapshot`
 - **Papel no fluxo**: guardar snapshots/versionamento da página capturada para comparação temporal.
 - **Função operacional**: registrar mudanças de conteúdo entre capturas e apoiar trilha de auditoria.
-- **Campos de destaque**: `id`, `url_ingest_id`, `snapshot_hash`, `status`, `http_status`, `content_type`, `raw_html_bytes`, `screenshot_bytes`, `captured_at`, `updated_at`.
+- **Campos de destaque**: `id`, `url_ingest_id`, `snapshot_hash`, `status`, `http_status`, `content_type`, `redirect_destination_url`, `redirect_root_url`, `raw_html_bytes`, `screenshot_bytes`, `captured_at`, `updated_at`.
+- **Regra de fallback por redirecionamento**: quando a URL canônica redirecionar para um caminho que não entrega HTML capturável (ex.: 404/5xx/corpo vazio), a captura deve registrar `redirect_destination_url` com o destino final observado e `redirect_root_url` com a raiz `scheme://host[:port]`; em seguida, deve tentar capturar essa raiz antes de persistir falha terminal.
 
 #### 13.3.5 `mois_sales_library_snapshot_artifact`
 - **Papel no fluxo**: armazenar artefatos derivados por snapshot (ex.: sumários ou classificações por tipo).

--- a/docs/registros/mois1.md
+++ b/docs/registros/mois1.md
@@ -857,3 +857,15 @@ Arquivos alterados:
 - `docs/swagger/mois-sales-library-swagger.yaml`
 - `docs/canonical/mois-worker-canon.v1.md`
 - `docs/registros/mois1.md`
+
+## 2026-06-03 — Fallback pela raiz do redirecionamento na etapa 1 da Biblioteca Sales Pages
+- Adicionada inteligência operacional na etapa **Obtenção dos HTML** para registrar, em `mois_sales_library_page_snapshot`, a URL final após redirecionamento (`redirect_destination_url`) e a raiz do destino (`redirect_root_url`).
+- Quando o destino redirecionado não entrega HTML capturável, o pipeline tenta a raiz do domínio antes de registrar falha terminal, permitindo aproveitar casos como `/secarapido` indisponível mas domínio raiz ativo.
+- Atualizados DTOs, Swagger, testes e cânone MOIS para preservar a rastreabilidade do redirecionamento e reduzir descarte indevido de páginas de vendas potencialmente úteis.
+
+Arquivos alterados:
+- `backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-03-mois-sales-library-snapshot-redirect-urls.yaml`
+- `backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibrarySnapshotService.java`
+- `mois-sales-library-worker/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/pipeline/htmlcapture/HtmlCaptureProcessor.java`
+- `frontend/src/pages/mois/MoisSalesPagesPipelinePage.tsx`
+- `docs/canonical/mois-worker-canon.v1.md`

--- a/docs/swagger/mois-sales-library-swagger.yaml
+++ b/docs/swagger/mois-sales-library-swagger.yaml
@@ -183,6 +183,14 @@ components:
           nullable: true
         urlCanonical:
           type: string
+        redirectDestinationUrl:
+          type: string
+          nullable: true
+          description: URL final após redirecionamentos da URL canônica original.
+        redirectRootUrl:
+          type: string
+          nullable: true
+          description: Raiz scheme://host[:port] derivada do destino redirecionado e usada como fallback quando o caminho final não entrega HTML capturável.
         status:
           type: string
           enum: [CAPTURED, DUPLICATE, FAILED]

--- a/frontend/src/api/mois/types.ts
+++ b/frontend/src/api/mois/types.ts
@@ -296,6 +296,8 @@ export interface MoisSalesLibrarySnapshotCaptureItem {
   pageId: number;
   snapshotId?: number;
   urlCanonical: string;
+  redirectDestinationUrl?: string;
+  redirectRootUrl?: string;
   status: string;
   snapshotHash?: string;
   httpStatus?: number;
@@ -322,6 +324,8 @@ export interface MoisSalesLibraryPageSnapshot {
   status: string;
   httpStatus?: number;
   contentType?: string;
+  redirectDestinationUrl?: string;
+  redirectRootUrl?: string;
   rawHtmlBytes: number;
   screenshotBytes: number;
   capturedAt?: string;

--- a/frontend/src/pages/mois/MoisSalesPagesPipelinePage.tsx
+++ b/frontend/src/pages/mois/MoisSalesPagesPipelinePage.tsx
@@ -46,13 +46,20 @@ function getSnapshotStatusBadgeClass(status: string) {
 }
 
 function getResultMessage(item: MoisSalesLibrarySnapshotCaptureItem) {
+  const redirectInfo = item.redirectDestinationUrl
+    ? `Destino: ${item.redirectDestinationUrl}${
+        item.redirectRootUrl ? ` · Raiz: ${item.redirectRootUrl}` : ""
+      }`
+    : "";
   if (item.errorMessage) {
-    return item.errorMessage;
+    return [item.errorMessage, redirectInfo].filter(Boolean).join(" · ");
   }
   if (item.snapshotHash) {
-    return `hash ${item.snapshotHash.slice(0, 12)}...`;
+    return [`hash ${item.snapshotHash.slice(0, 12)}...`, redirectInfo]
+      .filter(Boolean)
+      .join(" · ");
   }
-  return "Sem detalhe adicional";
+  return redirectInfo || "Sem detalhe adicional";
 }
 
 export default function MoisSalesPagesPipelinePage() {
@@ -230,7 +237,14 @@ export default function MoisSalesPagesPipelinePage() {
                     })
                   }
                 >
-                  {isRunning ? "Executando..." : "Executar etapa 1"}
+                  {isRunning ? (
+                    <>
+                      <span className="spinner-border spinner-border-sm me-2" aria-hidden="true" />
+                      Executando...
+                    </>
+                  ) : (
+                    "Executar etapa 1"
+                  )}
                 </button>
               </div>
             </div>

--- a/mois-sales-library-worker/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/model/WorkerDtos.java
+++ b/mois-sales-library-worker/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/model/WorkerDtos.java
@@ -28,7 +28,7 @@ public final class WorkerDtos {
     public record HtmlCaptureClaimRequest(String workspaceId, Integer limit, Boolean force) {}
     public record HtmlCaptureJob(Long snapshotId, Long pageId, String urlCanonical, String title) {}
     public record HtmlCaptureClaimResponse(boolean claimed, HtmlCaptureJob job) {}
-    public record HtmlCaptureCompleteRequest(String rawHtml, String finalUrl, Integer httpStatus, String contentType, String sha256, Long sizeBytes, Instant capturedAt) {}
-    public record HtmlCaptureFailRequest(String errorCategory, String errorMessage) {}
+    public record HtmlCaptureCompleteRequest(String rawHtml, String finalUrl, String redirectDestinationUrl, String redirectRootUrl, Integer httpStatus, String contentType, String sha256, Long sizeBytes, Instant capturedAt) {}
+    public record HtmlCaptureFailRequest(String errorCategory, String errorMessage, String redirectDestinationUrl, String redirectRootUrl, Integer httpStatus) {}
     public record HtmlCapturePersistResponse(Long snapshotId, String status) {}
 }

--- a/mois-sales-library-worker/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/pipeline/htmlcapture/HtmlCaptureBackendPort.java
+++ b/mois-sales-library-worker/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/pipeline/htmlcapture/HtmlCaptureBackendPort.java
@@ -39,12 +39,21 @@ public class HtmlCaptureBackendPort implements StageBackendPort<HtmlCaptureInput
     public void markCompleted(StageExecution<HtmlCaptureInput> execution, StageResult<HtmlCaptureOutput> result) {
         HtmlCaptureOutput output = result.output();
         backendClient.completeHtmlCapture(execution.idJob(), new HtmlCaptureCompleteRequest(
-                output.rawHtml(), output.finalUrl(), output.httpStatus(), output.contentType(), output.sha256(), output.sizeBytes(), output.capturedAt()));
+                output.rawHtml(), output.finalUrl(), output.redirectDestinationUrl(), output.redirectRootUrl(), output.httpStatus(), output.contentType(), output.sha256(), output.sizeBytes(), output.capturedAt()));
     }
 
     /** Envia ao backend a falha terminal da captura da URL reservada. */
     @Override
     public void markFailed(StageExecution<HtmlCaptureInput> execution, Exception error) {
-        backendClient.failHtmlCapture(execution.idJob(), new HtmlCaptureFailRequest("HTML_CAPTURE_ERROR", error.getMessage()));
+        if (error instanceof HtmlCaptureFailureException captureError) {
+            backendClient.failHtmlCapture(execution.idJob(), new HtmlCaptureFailRequest(
+                    "HTML_CAPTURE_ERROR",
+                    captureError.getMessage(),
+                    captureError.redirectDestinationUrl(),
+                    captureError.redirectRootUrl(),
+                    captureError.httpStatus()));
+            return;
+        }
+        backendClient.failHtmlCapture(execution.idJob(), new HtmlCaptureFailRequest("HTML_CAPTURE_ERROR", error.getMessage(), null, null, null));
     }
 }

--- a/mois-sales-library-worker/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/pipeline/htmlcapture/HtmlCaptureFailureException.java
+++ b/mois-sales-library-worker/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/pipeline/htmlcapture/HtmlCaptureFailureException.java
@@ -1,0 +1,32 @@
+package com.marketinghub.mois.bibliotecapaginavenda.worker.v1.pipeline.htmlcapture;
+
+/** Representa falha de captura HTML preservando URLs de redirecionamento auditáveis. */
+public class HtmlCaptureFailureException extends Exception {
+
+    private final String redirectDestinationUrl;
+    private final String redirectRootUrl;
+    private final Integer httpStatus;
+
+    /** Cria a falha com mensagem operacional, destino redirecionado, raiz de fallback e status HTTP efetivo. */
+    public HtmlCaptureFailureException(String message, String redirectDestinationUrl, String redirectRootUrl, Integer httpStatus) {
+        super(message);
+        this.redirectDestinationUrl = redirectDestinationUrl;
+        this.redirectRootUrl = redirectRootUrl;
+        this.httpStatus = httpStatus;
+    }
+
+    /** Retorna a URL final observada após redirecionamentos da URL canônica. */
+    public String redirectDestinationUrl() {
+        return redirectDestinationUrl;
+    }
+
+    /** Retorna a raiz derivada da URL final para fallback. */
+    public String redirectRootUrl() {
+        return redirectRootUrl;
+    }
+
+    /** Retorna o status HTTP efetivo que causou a falha, quando disponível. */
+    public Integer httpStatus() {
+        return httpStatus;
+    }
+}

--- a/mois-sales-library-worker/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/pipeline/htmlcapture/HtmlCaptureOutput.java
+++ b/mois-sales-library-worker/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/pipeline/htmlcapture/HtmlCaptureOutput.java
@@ -6,6 +6,8 @@ import java.time.Instant;
 public record HtmlCaptureOutput(
         String rawHtml,
         String finalUrl,
+        String redirectDestinationUrl,
+        String redirectRootUrl,
         Integer httpStatus,
         String contentType,
         String sha256,

--- a/mois-sales-library-worker/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/pipeline/htmlcapture/HtmlCaptureProcessor.java
+++ b/mois-sales-library-worker/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/pipeline/htmlcapture/HtmlCaptureProcessor.java
@@ -5,6 +5,7 @@ import com.marketinghub.mois.bibliotecapaginavenda.worker.v1.pipeline.StageArtif
 import com.marketinghub.mois.bibliotecapaginavenda.worker.v1.pipeline.StageContext;
 import com.marketinghub.mois.bibliotecapaginavenda.worker.v1.pipeline.StageProcessor;
 import com.marketinghub.mois.bibliotecapaginavenda.worker.v1.pipeline.StageResult;
+import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.time.Instant;
@@ -27,27 +28,31 @@ public class HtmlCaptureProcessor implements StageProcessor<HtmlCaptureInput, Ht
 
     private final WorkerProperties properties;
 
-    /** Busca a URL na internet, valida conteúdo útil e devolve HTML bruto com hash, tamanho e metadados HTTP. */
+    /** Busca a URL, tenta fallback pela raiz redirecionada e devolve HTML bruto com hash, tamanho e metadados HTTP. */
     @Override
     public StageResult<HtmlCaptureOutput> process(StageContext<HtmlCaptureInput> context) throws Exception {
         HtmlCaptureInput input = context.input();
-        Connection.Response response = Jsoup.connect(input.urlCanonical())
-                .timeout(properties.requestTimeoutMs())
-                .userAgent("MarketingHub-MOIS-HtmlCapture/1.0")
-                .ignoreContentType(true)
-                .followRedirects(true)
-                .maxBodySize(0)
-                .execute();
-        String rawHtml = response.body() == null ? "" : response.body();
-        if (response.statusCode() < 200 || response.statusCode() >= 400 || rawHtml.isBlank()) {
-            throw new IllegalStateException("HTTP " + response.statusCode() + " sem HTML bruto útil");
+        Connection.Response primary = fetch(input.urlCanonical());
+        String redirectDestinationUrl = finalUrl(primary, input.urlCanonical());
+        String redirectRootUrl = rootUrl(redirectDestinationUrl);
+        Connection.Response effective = primary;
+        if (!isCapturable(primary) && shouldTryRedirectRoot(input.urlCanonical(), redirectDestinationUrl, redirectRootUrl)) {
+            log.info("MOIS pipeline htmlcapture tentando raiz do redirecionamento. snapshotId={}, pageId={}, redirectDestinationUrl={}, redirectRootUrl={}",
+                    context.execution().idJob(), input.pageId(), redirectDestinationUrl, redirectRootUrl);
+            effective = fetch(redirectRootUrl);
+        }
+        String rawHtml = effective.body() == null ? "" : effective.body();
+        if (!isCapturable(effective)) {
+            throw new HtmlCaptureFailureException("HTTP " + effective.statusCode() + " sem HTML bruto útil", redirectDestinationUrl, redirectRootUrl, effective.statusCode());
         }
         byte[] bytes = rawHtml.getBytes(StandardCharsets.UTF_8);
         String sha256 = sha256(bytes);
-        String finalUrl = response.url() == null ? input.urlCanonical() : response.url().toString();
-        String contentType = response.contentType() == null ? "text/html" : response.contentType();
+        String finalUrl = finalUrl(effective, input.urlCanonical());
+        String contentType = effective.contentType() == null ? "text/html" : effective.contentType();
         String storageKey = context.artifactStore().putText(context.execution().idJob(), ARTIFACT_TYPE_RAW_HTML, contentType, rawHtml);
-        HtmlCaptureOutput output = new HtmlCaptureOutput(rawHtml, finalUrl, response.statusCode(), contentType, sha256, bytes.length, Instant.now());
+        HtmlCaptureOutput output = new HtmlCaptureOutput(rawHtml, finalUrl, redirectDestinationUrl, redirectRootUrl, effective.statusCode(), contentType, sha256, bytes.length, Instant.now());
+        String safeRedirectDestinationUrl = redirectDestinationUrl == null ? "" : redirectDestinationUrl;
+        String safeRedirectRootUrl = redirectRootUrl == null ? "" : redirectRootUrl;
         StageArtifact artifact = new StageArtifact(
                 ARTIFACT_TYPE_RAW_HTML,
                 "sales-page-" + input.pageId() + ".html",
@@ -55,13 +60,57 @@ public class HtmlCaptureProcessor implements StageProcessor<HtmlCaptureInput, Ht
                 storageKey,
                 sha256,
                 bytes.length,
-                Map.of("pageId", input.pageId(), "finalUrl", finalUrl, "httpStatus", response.statusCode()));
-        log.info("MOIS pipeline htmlcapture capturou HTML bruto. snapshotId={}, pageId={}, httpStatus={}, bytes={}, sha256={}",
-                context.execution().idJob(), input.pageId(), response.statusCode(), bytes.length, sha256);
+                Map.of("pageId", input.pageId(), "finalUrl", finalUrl, "redirectDestinationUrl", safeRedirectDestinationUrl, "redirectRootUrl", safeRedirectRootUrl, "httpStatus", effective.statusCode()));
+        log.info("MOIS pipeline htmlcapture capturou HTML bruto. snapshotId={}, pageId={}, httpStatus={}, finalUrl={}, redirectDestinationUrl={}, redirectRootUrl={}, bytes={}, sha256={}",
+                context.execution().idJob(), input.pageId(), effective.statusCode(), finalUrl, redirectDestinationUrl, redirectRootUrl, bytes.length, sha256);
         return new StageResult<>(output, List.of(artifact), Map.of(
-                "httpStatus", response.statusCode(),
+                "httpStatus", effective.statusCode(),
                 "contentLength", bytes.length,
                 "rawHtmlSha256", sha256));
+    }
+
+    /** Executa GET com redirecionamentos habilitados para a URL informada. */
+    private Connection.Response fetch(String url) throws Exception {
+        return Jsoup.connect(url)
+                .timeout(properties.requestTimeoutMs())
+                .userAgent("MarketingHub-MOIS-HtmlCapture/1.0")
+                .ignoreContentType(true)
+                .followRedirects(true)
+                .maxBodySize(0)
+                .execute();
+    }
+
+    /** Indica se a resposta HTTP possui corpo HTML aproveitável. */
+    private boolean isCapturable(Connection.Response response) {
+        String rawHtml = response.body() == null ? "" : response.body();
+        return response.statusCode() >= 200 && response.statusCode() < 400 && !rawHtml.isBlank();
+    }
+
+    /** Decide se a raiz do domínio redirecionado deve ser tentada como fallback. */
+    private boolean shouldTryRedirectRoot(String originalUrl, String redirectDestinationUrl, String redirectRootUrl) {
+        return redirectDestinationUrl != null
+                && redirectRootUrl != null
+                && !redirectDestinationUrl.equals(originalUrl)
+                && !redirectRootUrl.equals(redirectDestinationUrl)
+                && !redirectRootUrl.equals(originalUrl);
+    }
+
+    /** Resolve a URL final reportada pela resposta HTTP. */
+    private String finalUrl(Connection.Response response, String fallbackUrl) {
+        return response.url() == null ? fallbackUrl : response.url().toString();
+    }
+
+    /** Extrai a raiz scheme://host[:port] da URL final de redirecionamento. */
+    private String rootUrl(String url) {
+        if (url == null || url.isBlank()) {
+            return null;
+        }
+        URI uri = URI.create(url);
+        if (uri.getScheme() == null || uri.getHost() == null) {
+            return null;
+        }
+        String port = uri.getPort() < 0 ? "" : ":" + uri.getPort();
+        return uri.getScheme() + "://" + uri.getHost() + port;
     }
 
     /** Calcula o hash SHA-256 do HTML bruto capturado. */


### PR DESCRIPTION
### Motivation
- Reduce false negative failures when a canonical URL redirects to a path that doesn't deliver HTML by recording the final redirect and attempting the domain root as a fallback.
- Preserve redirect telemetry for auditing and diagnostics by storing `redirect_destination_url` and `redirect_root_url` with snapshots.
- Propagate redirect metadata through the worker pipeline, backend DTOs, API, docs and UI so operators can see why a capture was retried or failed.

### Description
- Added DB changelog `changesets/2026-06-03-mois-sales-library-snapshot-redirect-urls.yaml` to alter `mois_sales_library_page_snapshot` with `redirect_destination_url` and `redirect_root_url` columns. 
- Extended DTOs and API contract to include `redirectDestinationUrl` and `redirectRootUrl` across backend, worker and frontend types, and updated Swagger and canonical docs accordingly. 
- Enhanced `MoisSalesLibrarySnapshotService` with `fetchUrl`, `rootUrl` and `shouldTryRedirectRoot` helpers and updated `captureOne`/persistence paths to record redirect URLs, try root fallback when the redirected path is not capturable, and persist redirect metadata on both success and failure. 
- Updated worker pipeline (`HtmlCaptureProcessor`, `HtmlCaptureBackendPort`, worker DTOs) to attempt the same redirect-root fallback, include redirect fields in capture output, and introduced `HtmlCaptureFailureException` to carry redirect context on terminal failures. 
- Updated frontend pipeline UI to show redirect info in capture results and added a small UI spinner while capture runs. 

### Testing
- Ran unit tests in `MoisSalesLibrarySnapshotServiceTest`, including the new `shouldTryRedirectRootWhenRedirectDestinationIsNotCapturable` scenario, and they passed. 
- Ran controller tests in `MoisSalesLibraryControllerTest` (API snapshot capture and page snapshots endpoints) and they passed. 
- Existing snapshot selection/cooldown tests in `MoisSalesLibrarySnapshotServiceTest` were kept and passed after changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2083e2713483218e400b26d3e0c3a0)