### PR TITLE
Auto-enqueue landing-page-design-preset after image generation completes

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/imagegeneration/service/BackendImageGenerationService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/imagegeneration/service/BackendImageGenerationService.java
@@ -33,6 +33,7 @@ public class BackendImageGenerationService {
     private static final Logger log = LoggerFactory.getLogger(BackendImageGenerationService.class);
     private static final TypeReference<LinkedHashMap<String, Object>> FRAMEWORK_TYPE = new TypeReference<>() {};
     private static final String STAGE_CODE = "landing-page-image-generation";
+    private static final String NEXT_STAGE_DESIGN_PRESET = "landing-page-design-preset";
     private static final String STATUS_STARTED = "INICIADO";
     private static final String STATUS_WAITING_OPENAI_DISPATCH = "AGUARDANDO_RETORNO_OPENAI";
     private static final String STATUS_COMPLETED = "CONCLUIDO";
@@ -206,6 +207,24 @@ public class BackendImageGenerationService {
         }
         experiment.setLandingPageImageAssets(modelResponse);
         experimentRepository.save(experiment);
+        createDesignPresetExecution(experiment);
+    }
+
+    /** Agenda o preset de design como próxima etapa automática após a materialização dos assets de imagem. */
+    private void createDesignPresetExecution(Experiment experiment) {
+        Instant now = Instant.now();
+        GeraLandingStageExecution designExecution = GeraLandingStageExecution.builder()
+                .experimentId(experiment.getId())
+                .experiment(experiment)
+                .stageCode(NEXT_STAGE_DESIGN_PRESET)
+                .executionRequestedAt(now)
+                .createdAt(now)
+                .promptTemplateId("auto/image-generation")
+                .promptContent("Preset de design da landing iniciado automaticamente após o Gera Imagem.")
+                .status(STATUS_STARTED)
+                .idJob(toDatabaseIdJob(UUID.randomUUID().toString()))
+                .build();
+        executionRepository.save(designExecution);
     }
 
     /** Normaliza a mensagem de erro e garante status FALHA quando o callback traz apenas detalhe técnico. */

--- a/backend/ads-service/src/test/java/com/marketinghub/geralanding/imagegeneration/service/BackendImageGenerationServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/geralanding/imagegeneration/service/BackendImageGenerationServiceTest.java
@@ -184,6 +184,7 @@ class BackendImageGenerationServiceTest {
         BackendImageGenerationService service =
                 new BackendImageGenerationService(experimentRepository, executionRepository, new ObjectMapper());
         Experiment experiment = mock(Experiment.class);
+        when(experiment.getId()).thenReturn(88L);
         GeraLandingStageExecution execution = GeraLandingStageExecution.builder()
                 .experimentId(88L)
                 .experiment(experiment)
@@ -218,6 +219,15 @@ class BackendImageGenerationServiceTest {
         verify(experiment).setLandingPageImageAssets(modelResponse);
         verify(experiment, never()).setLandingPageWireframe(any());
         verify(experimentRepository).save(experiment);
+        verify(executionRepository).save(argThat(designExecution ->
+                designExecution != execution
+                        && Long.valueOf(88L).equals(designExecution.getExperimentId())
+                        && designExecution.getExperiment() == experiment
+                        && "landing-page-design-preset".equals(designExecution.getStageCode())
+                        && "INICIADO".equals(designExecution.getStatus())
+                        && "auto/image-generation".equals(designExecution.getPromptTemplateId())
+                        && designExecution.getPromptContent().contains("Gera Imagem")
+                        && designExecution.getIdJob() != null));
         verify(experimentRepository, never()).findById(88L);
     }
 

--- a/docs/canonical/procedimento-experimento-canon.v1.md
+++ b/docs/canonical/procedimento-experimento-canon.v1.md
@@ -51,11 +51,11 @@ No fluxo atual, a geração da landing segue as etapas:
 1. gerar wireframe (`LANDING_PAGE_WIREFRAME`);
 2. gerar copy (`LANDING_PAGE_COPY`);
 3. gerar planejamento/prompt de imagens (`LANDING_PAGE_IMAGE_PLANNING`) e gerar imagens, materializando `experiment.landing_page_image_assets` com as URLs finais;
-4. gerar preset de design (`LANDING_PAGE_DESIGN_PRESET`);
+4. gerar preset de design (`LANDING_PAGE_DESIGN_PRESET`), que deve ser enfileirado automaticamente após a conclusão bem-sucedida do Gera Imagem;
 5. gerar entregável HTML da landing (`LANDING_PAGE_HTML`).
 
 ### 5.1 Observação obrigatória — HTML provisório por etapa
-Durante o pipeline de Gera Landing, existe produção incremental/provisória de conteúdo para permitir evolução etapa a etapa. No estágio de design preset é consolidada a base visual e ocorre a etapa usada para ingestão do pixel no fluxo atual.
+Durante o pipeline de Gera Landing, existe produção incremental/provisória de conteúdo para permitir evolução etapa a etapa. No estágio de design preset é consolidada a base visual e ocorre a etapa usada para ingestão do pixel no fluxo atual. Ao concluir o Gera Imagem com sucesso e persistir `experiment.landing_page_image_assets`, o backend deve criar automaticamente uma execução `landing-page-design-preset` com `promptTemplateId` operacional `auto/image-generation`, mantendo a continuidade do fluxo sem exigir novo clique do usuário.
 
 ### 5.2 Instrumentação obrigatória de funil no assembler do design preset
 Para a etapa `LANDING_PAGE_DESIGN_PRESET`, o assembler de HTML provisório deve injetar instrumentação mínima de comportamento para diagnóstico de avanço de funil na landing:

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -3291,3 +3291,11 @@
   - `ai-worker/src/main/resources/prompts/geralanding/landing-page-wireframe.md`
   - `ai-worker/src/main/resources/prompts/geralanding/landing-page-design-preset.md`
   - `docs/registros/experimentos.md`
+
+## 2026-06-04 — Automação do Preset Design após Gera Imagem
+
+- solicitação: aplicar para o Preset Design o mesmo encadeamento automático observado entre Design Preset e Quality Review.
+- causa-raiz/objetivo: após o Gera Imagem concluir e materializar `landing_page_image_assets`, o fluxo ainda dependia de clique manual para iniciar `landing-page-design-preset`, quebrando a continuidade operacional do GeraLanding.
+- correção aplicada: a conclusão bem-sucedida da etapa `landing-page-image-generation` agora persiste o manifesto de imagens e cria automaticamente uma execução `landing-page-design-preset` com `promptTemplateId` `auto/image-generation` e status `INICIADO`.
+- cânone atualizado: `docs/canonical/procedimento-experimento-canon.v1.md` passou a declarar que o Preset Design deve ser enfileirado automaticamente após o Gera Imagem.
+- validação automatizada: teste unitário do `BackendImageGenerationService` atualizado para garantir criação da próxima execução automática somente no caminho de sucesso.


### PR DESCRIPTION
### Motivation
- Ensure continuity of the GeraLanding pipeline by automatically starting the design preset step after image assets are materialized, removing a manual step and keeping the flow deterministic.
- Keep the canonical docs and experiment records consistent with the intended pipeline behavior for `landing-page-image-generation` -> `landing-page-design-preset`.

### Description
- Added a constant `NEXT_STAGE_DESIGN_PRESET` and logic in `BackendImageGenerationService.persistImageAssetsArtifactOnExperiment` to create a new `GeraLandingStageExecution` for the design preset after successfully persisting `experiment.landing_page_image_assets`.
- Implemented `createDesignPresetExecution(Experiment)` which builds and saves a `GeraLandingStageExecution` with `stageCode` set to `landing-page-design-preset`, `promptTemplateId` set to `auto/image-generation`, initial `status` `INICIADO`, and a generated `idJob`.
- Updated `BackendImageGenerationServiceTest` to assert that a distinct design preset execution is saved with the expected fields when image generation completes successfully.
- Documentation updated in the canonical pipeline docs and experiment records to declare the automatic enqueueing behavior for the design preset.

### Testing
- Ran unit tests for `BackendImageGenerationServiceTest`, including `markCompletedFromResponseShouldPersistImageAssetsManifestOnExperiment`, and they succeeded with the new assertion verifying the automatic creation and persistence of the design preset execution.
- Existing tests that assert persistence of `landing_page_image_assets` and execution status continue to pass under the updated behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a20e13769148321ae9cfe300393a196)