### PR TITLE
Automate Gera Imagem after Gera Prompt Imagem

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/imageplanning/service/BackendImagePlanningService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/imageplanning/service/BackendImagePlanningService.java
@@ -34,6 +34,7 @@ public class BackendImagePlanningService {
     private static final Logger log = LoggerFactory.getLogger(BackendImagePlanningService.class);
     private static final TypeReference<LinkedHashMap<String, Object>> FRAMEWORK_TYPE = new TypeReference<>() {};
     private static final String STAGE_CODE = "landing-page-image-planning";
+    private static final String NEXT_STAGE_IMAGE_GENERATION = "landing-page-image-generation";
     private static final String STATUS_STARTED = "INICIADO";
     private static final String STATUS_WAITING_OPENAI_DISPATCH = "AGUARDANDO_RETORNO_OPENAI";
     private static final String STATUS_COMPLETED = "CONCLUIDO";
@@ -246,6 +247,24 @@ public class BackendImagePlanningService {
             experiment.setLandingPageHtml(provisionalHtml);
         }
         experimentRepository.save(experiment);
+        createImageGenerationExecution(experiment);
+    }
+
+    /** Agenda a geração de imagens como próxima etapa automática após salvar o planejamento de prompts de imagem. */
+    private void createImageGenerationExecution(Experiment experiment) {
+        Instant now = Instant.now();
+        GeraLandingStageExecution imageGenerationExecution = GeraLandingStageExecution.builder()
+                .experimentId(experiment.getId())
+                .experiment(experiment)
+                .stageCode(NEXT_STAGE_IMAGE_GENERATION)
+                .executionRequestedAt(now)
+                .createdAt(now)
+                .promptTemplateId("auto/image-planning")
+                .promptContent("Gera Imagem iniciado automaticamente após o Gera Prompt Imagem.")
+                .status(STATUS_STARTED)
+                .idJob(toDatabaseIdJob(UUID.randomUUID().toString()))
+                .build();
+        executionRepository.save(imageGenerationExecution);
     }
 
     /** Resolve o experimento da execução, buscando no repositório quando a associação não estiver carregada. */

--- a/backend/ads-service/src/test/java/com/marketinghub/geralanding/imageplanning/service/BackendImagePlanningServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/geralanding/imageplanning/service/BackendImagePlanningServiceTest.java
@@ -6,6 +6,8 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.argThat;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -22,6 +24,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
 import org.springframework.context.ApplicationEventPublisher;
 
 /** Valida as consultas de execução específicas da etapa image planning. */
@@ -97,9 +100,9 @@ class BackendImagePlanningServiceTest {
         assertTrue(pending.get(0).hypothesis().framework().containsKey("checklist"));
     }
 
-    /** Deve concluir resposta com sucesso e persistir o artefato de image planning no experimento. */
+    /** Deve concluir resposta com sucesso, persistir o artefato e iniciar automaticamente a geração de imagens. */
     @Test
-    void markCompletedFromResponseShouldPersistImagePlanningArtifact() {
+    void markCompletedFromResponseShouldPersistImagePlanningArtifactAndStartImageGeneration() {
         ExperimentRepository experimentRepository = mock(ExperimentRepository.class);
         GeraLandingStageExecutionRepository executionRepository = mock(GeraLandingStageExecutionRepository.class);
         BackendImagePlanningService service = new BackendImagePlanningService(
@@ -138,5 +141,57 @@ class BackendImagePlanningServiceTest {
         assertEquals("{\"landingPageImagePlanning\":{}}", experiment.getLandingPageImagePlanning());
         assertEquals("<html>preview</html>", experiment.getLandingPageHtml());
         verify(experimentRepository).save(experiment);
+        ArgumentCaptor<GeraLandingStageExecution> saveCaptor = ArgumentCaptor.forClass(GeraLandingStageExecution.class);
+        verify(executionRepository, times(2)).save(saveCaptor.capture());
+        GeraLandingStageExecution imageGenerationExecution = saveCaptor.getAllValues().get(1);
+        assertEquals(44L, imageGenerationExecution.getExperimentId());
+        assertEquals(experiment, imageGenerationExecution.getExperiment());
+        assertEquals("landing-page-image-generation", imageGenerationExecution.getStageCode());
+        assertEquals("auto/image-planning", imageGenerationExecution.getPromptTemplateId());
+        assertEquals("Gera Imagem iniciado automaticamente após o Gera Prompt Imagem.", imageGenerationExecution.getPromptContent());
+        assertEquals("INICIADO", imageGenerationExecution.getStatus());
+        assertNotNull(imageGenerationExecution.getIdJob());
+    }
+
+    /** Deve falhar resposta com erro sem persistir artefato nem iniciar automaticamente a geração de imagens. */
+    @Test
+    void markCompletedFromResponseShouldNotStartImageGenerationWhenResponseFails() {
+        ExperimentRepository experimentRepository = mock(ExperimentRepository.class);
+        GeraLandingStageExecutionRepository executionRepository = mock(GeraLandingStageExecutionRepository.class);
+        BackendImagePlanningService service = new BackendImagePlanningService(
+                experimentRepository,
+                executionRepository,
+                new ObjectMapper(),
+                mock(ApplicationEventPublisher.class));
+        Experiment experiment = new Experiment();
+        experiment.setId(45L);
+        GeraLandingStageExecution execution = GeraLandingStageExecution.builder()
+                .experimentId(45L)
+                .experiment(experiment)
+                .stageCode("landing-page-image-planning")
+                .idJob("job-45".getBytes(StandardCharsets.UTF_8))
+                .status("AGUARDANDO_RETORNO_OPENAI")
+                .build();
+        when(executionRepository.findTopByIdJobOrderByExecutionRequestedAtDesc("job-45".getBytes(StandardCharsets.UTF_8)))
+                .thenReturn(Optional.of(execution));
+        when(executionRepository.save(any(GeraLandingStageExecution.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        service.markCompletedFromResponse(
+                "job-45",
+                45L,
+                "landing-page-image-planning",
+                "{\"landingPageImagePlanning\":{}}",
+                "<html>preview</html>",
+                120,
+                80,
+                new BigDecimal("0.012300"),
+                "openai-job-2",
+                "falha externa",
+                null);
+
+        assertEquals("FALHA", execution.getStatus());
+        verify(experimentRepository, never()).save(any(Experiment.class));
+        verify(executionRepository, times(1)).save(any(GeraLandingStageExecution.class));
     }
 }

--- a/docs/canonical/procedimento-experimento-canon.v1.md
+++ b/docs/canonical/procedimento-experimento-canon.v1.md
@@ -50,12 +50,13 @@ Local canônico vigente:
 No fluxo atual, a geração da landing segue as etapas:
 1. gerar wireframe (`LANDING_PAGE_WIREFRAME`);
 2. gerar copy (`LANDING_PAGE_COPY`);
-3. gerar planejamento/prompt de imagens (`LANDING_PAGE_IMAGE_PLANNING`) e gerar imagens, materializando `experiment.landing_page_image_assets` com as URLs finais;
-4. gerar preset de design (`LANDING_PAGE_DESIGN_PRESET`), que deve ser enfileirado automaticamente após a conclusão bem-sucedida do Gera Imagem;
-5. gerar entregável HTML da landing (`LANDING_PAGE_HTML`).
+3. gerar planejamento/prompt de imagens (`LANDING_PAGE_IMAGE_PLANNING`), que deve enfileirar automaticamente o Gera Imagem após conclusão bem-sucedida;
+4. gerar imagens (`LANDING_PAGE_IMAGE_GENERATION`), materializando `experiment.landing_page_image_assets` com as URLs finais;
+5. gerar preset de design (`LANDING_PAGE_DESIGN_PRESET`), que deve ser enfileirado automaticamente após a conclusão bem-sucedida do Gera Imagem;
+6. gerar entregável HTML da landing (`LANDING_PAGE_HTML`).
 
 ### 5.1 Observação obrigatória — HTML provisório por etapa
-Durante o pipeline de Gera Landing, existe produção incremental/provisória de conteúdo para permitir evolução etapa a etapa. No estágio de design preset é consolidada a base visual e ocorre a etapa usada para ingestão do pixel no fluxo atual. Ao concluir o Gera Imagem com sucesso e persistir `experiment.landing_page_image_assets`, o backend deve criar automaticamente uma execução `landing-page-design-preset` com `promptTemplateId` operacional `auto/image-generation`, mantendo a continuidade do fluxo sem exigir novo clique do usuário.
+Durante o pipeline de Gera Landing, existe produção incremental/provisória de conteúdo para permitir evolução etapa a etapa. No estágio de design preset é consolidada a base visual e ocorre a etapa usada para ingestão do pixel no fluxo atual. Ao concluir o Gera Prompt Imagem com sucesso e persistir `experiment.landing_page_image_planning`, o backend deve criar automaticamente uma execução `landing-page-image-generation` com `promptTemplateId` operacional `auto/image-planning`. Ao concluir o Gera Imagem com sucesso e persistir `experiment.landing_page_image_assets`, o backend deve criar automaticamente uma execução `landing-page-design-preset` com `promptTemplateId` operacional `auto/image-generation`, mantendo a continuidade do fluxo sem exigir novo clique do usuário.
 
 ### 5.2 Instrumentação obrigatória de funil no assembler do design preset
 Para a etapa `LANDING_PAGE_DESIGN_PRESET`, o assembler de HTML provisório deve injetar instrumentação mínima de comportamento para diagnóstico de avanço de funil na landing:

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -3299,3 +3299,11 @@
 - correção aplicada: a conclusão bem-sucedida da etapa `landing-page-image-generation` agora persiste o manifesto de imagens e cria automaticamente uma execução `landing-page-design-preset` com `promptTemplateId` `auto/image-generation` e status `INICIADO`.
 - cânone atualizado: `docs/canonical/procedimento-experimento-canon.v1.md` passou a declarar que o Preset Design deve ser enfileirado automaticamente após o Gera Imagem.
 - validação automatizada: teste unitário do `BackendImageGenerationService` atualizado para garantir criação da próxima execução automática somente no caminho de sucesso.
+
+## 2026-06-04 — Automação do Gera Imagem após Gera Prompt Imagem
+
+- solicitação: criar entre `Gera Prompt Imagem` e `Gera Imagem` o mesmo mecanismo de disparo automático já existente entre `Gera Imagem` e `Gera Preset Design`.
+- causa-raiz/objetivo: após concluir `landing-page-image-planning`, o fluxo ainda dependia de clique manual para iniciar `landing-page-image-generation`, interrompendo a sequência operacional de criação da landing.
+- correção aplicada: a conclusão bem-sucedida da etapa `landing-page-image-planning` agora persiste o planejamento de imagens e cria automaticamente uma execução `landing-page-image-generation` com `promptTemplateId` `auto/image-planning` e status `INICIADO`.
+- cânone atualizado: `docs/canonical/procedimento-experimento-canon.v1.md` passou a declarar que o Gera Imagem deve ser enfileirado automaticamente após o Gera Prompt Imagem.
+- validação automatizada: teste unitário do `BackendImagePlanningService` atualizado para garantir criação da próxima execução automática somente no caminho de sucesso.


### PR DESCRIPTION
### Motivation
- Garantir continuidade operacional do pipeline Gera Landing: quando o Gera Prompt Imagem (`landing-page-image-planning`) conclui com sucesso, enfileirar automaticamente a etapa de geração de imagens (`landing-page-image-generation`) sem clique manual.

### Description
- Adiciona constante `NEXT_STAGE_IMAGE_GENERATION` e método `createImageGenerationExecution(...)` que cria `GeraLandingStageExecution` com `promptTemplateId = "auto/image-planning"`, `status = INICIADO` e `idJob` próprio; esse método é chamado ao persistir com sucesso o artefato `landingPageImagePlanning` em `BackendImagePlanningService`. (file: `backend/ads-service/src/main/java/com/marketinghub/geralanding/imageplanning/service/BackendImagePlanningService.java`)
- Atualiza os testes unitários da etapa `imageplanning` para validar o novo comportamento de encadeamento automático no caminho de sucesso e garantir que falhas não disparem a próxima etapa. (file: `backend/ads-service/src/test/java/com/marketinghub/geralanding/imageplanning/service/BackendImagePlanningServiceTest.java`)
- Atualiza a documentação canônica do procedimento (`docs/canonical/procedimento-experimento-canon.v1.md`) para declarar o novo encadeamento `Gera Prompt Imagem → Gera Imagem` e adiciona registro operacional em `docs/registros/experimentos.md`.

### Testing
- Executed unit tests for the modified module with `mvn -Dtest=BackendImagePlanningServiceTest test` (run in `backend/ads-service`) and the test class `BackendImagePlanningServiceTest` ran successfully with `Tests run: 4, Failures: 0, Errors: 0`.
- Built the `ads-service` module during test execution and the Maven test phase completed successfully for the module.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a20eaafddd88321b6b498ef5aa94cf9)