### PR TITLE
MOIS: Fase 1 — criar tabelas `mois_sales_page` e `mois_sales_page_job_execution` (changelogs + testes)

### DIFF
--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-04-mois-sales-page-job-execution.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-04-mois-sales-page-job-execution.yaml
@@ -1,0 +1,58 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-06-04-mois-sales-page-job-execution-01
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - onError: HALT
+        - dbms:
+            type: mysql
+        - tableExists:
+            tableName: mois_sales_page
+        - not:
+            tableExists:
+              tableName: mois_sales_page_job_execution
+      changes:
+        - sql:
+            splitStatements: true
+            stripComments: true
+            sql: |
+              CREATE TABLE mois_sales_page_job_execution (
+                id BIGINT NOT NULL AUTO_INCREMENT,
+                sales_page_id BIGINT NOT NULL,
+                workspace_id VARCHAR(120) NOT NULL,
+                job_type VARCHAR(40) NOT NULL,
+                stage VARCHAR(40) NOT NULL,
+                status VARCHAR(40) NOT NULL,
+                attempt INT NOT NULL DEFAULT 1,
+                claimed_by VARCHAR(120) NULL,
+                input_url VARCHAR(1024) NULL,
+                final_url VARCHAR(1024) NULL,
+                redirect_root_url VARCHAR(1024) NULL,
+                http_status INT NULL,
+                content_type VARCHAR(255) NULL,
+                raw_html LONGTEXT NULL,
+                raw_html_sha256 VARCHAR(64) NULL,
+                raw_html_bytes BIGINT NOT NULL DEFAULT 0,
+                screenshot_blob LONGBLOB NULL,
+                screenshot_bytes BIGINT NOT NULL DEFAULT 0,
+                score_total DECIMAL(6,2) NULL,
+                sections_json LONGTEXT NULL,
+                copy_json LONGTEXT NULL,
+                visual_json LONGTEXT NULL,
+                image_json LONGTEXT NULL,
+                request_payload_json LONGTEXT NULL,
+                response_payload_json LONGTEXT NULL,
+                error_category VARCHAR(120) NULL,
+                error_message VARCHAR(1000) NULL,
+                started_at DATETIME NULL,
+                finished_at DATETIME NULL,
+                created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+                PRIMARY KEY (id),
+                KEY idx_mois_sales_page_job_page_created (sales_page_id, created_at),
+                KEY idx_mois_sales_page_job_status (workspace_id, stage, status, updated_at),
+                KEY idx_mois_sales_page_job_type_status (workspace_id, job_type, status, updated_at),
+                CONSTRAINT fk_mois_sales_page_job_execution_page
+                  FOREIGN KEY (sales_page_id) REFERENCES mois_sales_page(id)
+              ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-04-mois-sales-page.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-04-mois-sales-page.yaml
@@ -1,0 +1,68 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-06-04-mois-sales-page-01
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - onError: HALT
+        - dbms:
+            type: mysql
+        - tableExists:
+            tableName: mois_collected_reference
+        - not:
+            tableExists:
+              tableName: mois_sales_page
+      changes:
+        - sql:
+            splitStatements: true
+            stripComments: true
+            sql: |
+              CREATE TABLE mois_sales_page (
+                id BIGINT NOT NULL AUTO_INCREMENT,
+                workspace_id VARCHAR(120) NOT NULL,
+                source VARCHAR(40) NOT NULL,
+                source_job_id VARCHAR(120) NULL,
+                source_reference_id VARCHAR(120) NULL,
+                collected_reference_id BIGINT NULL,
+                product_name VARCHAR(512) NULL,
+                title VARCHAR(512) NULL,
+                url_original VARCHAR(1024) NOT NULL,
+                url_canonical VARCHAR(1024) NOT NULL,
+                sales_page_url VARCHAR(1024) NULL,
+                product_url VARCHAR(1024) NULL,
+                url_final VARCHAR(1024) NULL,
+                redirect_root_url VARCHAR(1024) NULL,
+                current_stage VARCHAR(40) NOT NULL,
+                current_status VARCHAR(40) NOT NULL,
+                capture_status VARCHAR(40) NULL,
+                analysis_status VARCHAR(40) NULL,
+                http_status INT NULL,
+                content_type VARCHAR(255) NULL,
+                html_sha256 VARCHAR(64) NULL,
+                html_bytes BIGINT NOT NULL DEFAULT 0,
+                score_total DECIMAL(6,2) NULL,
+                offer_summary VARCHAR(1000) NULL,
+                mechanism_summary VARCHAR(1000) NULL,
+                promise_summary VARCHAR(1000) NULL,
+                proof_summary VARCHAR(1000) NULL,
+                last_error_category VARCHAR(120) NULL,
+                last_error_message VARCHAR(1000) NULL,
+                last_job_execution_id BIGINT NULL,
+                ingest_count INT NOT NULL DEFAULT 1,
+                first_seen_at DATETIME NULL,
+                last_collected_at DATETIME NULL,
+                last_captured_at DATETIME NULL,
+                last_analyzed_at DATETIME NULL,
+                created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+                PRIMARY KEY (id),
+                UNIQUE KEY uk_mois_sales_page_workspace_url (workspace_id, url_canonical(512)),
+                KEY idx_mois_sales_page_source_status (workspace_id, source, current_status, updated_at),
+                KEY idx_mois_sales_page_stage_status (workspace_id, current_stage, current_status, updated_at),
+                KEY idx_mois_sales_page_score (workspace_id, score_total),
+                KEY idx_mois_sales_page_source_reference (workspace_id, source, source_job_id, source_reference_id),
+                KEY idx_mois_sales_page_collected_reference (collected_reference_id),
+                CONSTRAINT fk_mois_sales_page_collected_reference
+                  FOREIGN KEY (collected_reference_id) REFERENCES mois_collected_reference(id)
+                  ON DELETE SET NULL
+              ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -842,3 +842,12 @@ databaseChangeLog:
   - include:
       file: changesets/2026-06-03-mois-collected-reference-html-capture.yaml
       relativeToChangelogFile: true
+
+
+  - include:
+      file: changesets/2026-06-04-mois-sales-page.yaml
+      relativeToChangelogFile: true
+
+  - include:
+      file: changesets/2026-06-04-mois-sales-page-job-execution.yaml
+      relativeToChangelogFile: true

--- a/backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/schema/MoisSalesPageSchemaChangelogTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/schema/MoisSalesPageSchemaChangelogTest.java
@@ -1,0 +1,86 @@
+package com.marketinghub.mois.bibliotecapaginavenda.worker.v1.schema;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Valida o contrato estrutural dos changelogs Liquibase do modelo consolidado de páginas de venda do MOIS.
+ */
+class MoisSalesPageSchemaChangelogTest {
+
+    private static final Path CHANGELOG_ROOT = Path.of("src/main/resources/db/changelog");
+    private static final Path SALES_PAGE_CHANGELOG = CHANGELOG_ROOT.resolve(
+            "changesets/2026-06-04-mois-sales-page.yaml");
+    private static final Path JOB_EXECUTION_CHANGELOG = CHANGELOG_ROOT.resolve(
+            "changesets/2026-06-04-mois-sales-page-job-execution.yaml");
+    private static final Path MASTER_CHANGELOG = CHANGELOG_ROOT.resolve("db.changelog-master.yaml");
+
+    /**
+     * Garante que a tabela de estado atual da página contém campos e índices canônicos da fase 1.
+     */
+    @Test
+    void salesPageChangelogDefinesCurrentStateTableAndOperationalIndexes() throws IOException {
+        String changelog = read(SALES_PAGE_CHANGELOG);
+
+        assertThat(changelog)
+                .contains("CREATE TABLE mois_sales_page")
+                .contains("workspace_id VARCHAR(120) NOT NULL")
+                .contains("url_canonical VARCHAR(1024) NOT NULL")
+                .contains("current_stage VARCHAR(40) NOT NULL")
+                .contains("current_status VARCHAR(40) NOT NULL")
+                .contains("last_job_execution_id BIGINT NULL")
+                .contains("UNIQUE KEY uk_mois_sales_page_workspace_url (workspace_id, url_canonical(512))")
+                .contains("KEY idx_mois_sales_page_source_status (workspace_id, source, current_status, updated_at)")
+                .contains("KEY idx_mois_sales_page_stage_status (workspace_id, current_stage, current_status, updated_at)")
+                .contains("KEY idx_mois_sales_page_score (workspace_id, score_total)")
+                .contains(
+                        "KEY idx_mois_sales_page_source_reference (workspace_id, source, source_job_id, source_reference_id)");
+    }
+
+    /**
+     * Garante que a tabela de histórico guarda auditoria, payloads e índices operacionais por página/job.
+     */
+    @Test
+    void jobExecutionChangelogDefinesAuditTableAndOperationalIndexes() throws IOException {
+        String changelog = read(JOB_EXECUTION_CHANGELOG);
+
+        assertThat(changelog)
+                .contains("CREATE TABLE mois_sales_page_job_execution")
+                .contains("sales_page_id BIGINT NOT NULL")
+                .contains("job_type VARCHAR(40) NOT NULL")
+                .contains("stage VARCHAR(40) NOT NULL")
+                .contains("status VARCHAR(40) NOT NULL")
+                .contains("raw_html LONGTEXT NULL")
+                .contains("request_payload_json LONGTEXT NULL")
+                .contains("response_payload_json LONGTEXT NULL")
+                .contains("CONSTRAINT fk_mois_sales_page_job_execution_page")
+                .contains("KEY idx_mois_sales_page_job_page_created (sales_page_id, created_at)")
+                .contains("KEY idx_mois_sales_page_job_status (workspace_id, stage, status, updated_at)")
+                .contains("KEY idx_mois_sales_page_job_type_status (workspace_id, job_type, status, updated_at)");
+    }
+
+    /**
+     * Garante que o changelog master aplica a tabela consolidada antes do histórico que depende dela.
+     */
+    @Test
+    void masterChangelogIncludesSalesPageBeforeJobExecution() throws IOException {
+        String master = read(MASTER_CHANGELOG);
+
+        assertThat(master).contains("changesets/2026-06-04-mois-sales-page.yaml");
+        assertThat(master).contains("changesets/2026-06-04-mois-sales-page-job-execution.yaml");
+        assertThat(master.indexOf("changesets/2026-06-04-mois-sales-page.yaml"))
+                .isLessThan(master.indexOf("changesets/2026-06-04-mois-sales-page-job-execution.yaml"));
+    }
+
+    /**
+     * Lê um arquivo de changelog como texto UTF-8 para validações estruturais de contrato.
+     */
+    private String read(Path path) throws IOException {
+        return Files.readString(path, StandardCharsets.UTF_8);
+    }
+}

--- a/docs/canonical/mois-worker-canon.v1.md
+++ b/docs/canonical/mois-worker-canon.v1.md
@@ -477,6 +477,34 @@ Durante a transição, as tabelas atuais (`mois_sales_library_url_ingest`, `mois
 
 O plano faseado obrigatório para essa migração está documentado em `docs/novos-modulos/MOIS/mois_sales_page_pipeline_simplificacao_duas_tabelas.md`.
 
+#### 13.7.1 Modelo operacional canonizado — Fase 1 (duas tabelas)
+
+A Fase 1 da simplificação canoniza somente o preparo estrutural do banco e da documentação, sem remover nem substituir tabelas legadas. O backend deve subir mantendo os endpoints atuais e as leituras/escritas existentes da Biblioteca de Páginas de Vendas até as fases seguintes.
+
+Responsabilidades canônicas das novas tabelas:
+
+- `mois_sales_page`: guarda o estado atual consolidado de cada página de venda por `workspace_id` + `url_canonical`, incluindo origem, URLs observadas, etapa/status atuais, resumo da última captura, resumo da última análise, último erro, score e ponteiro lógico para a última execução que alterou a página.
+- `mois_sales_page_job_execution`: guarda o histórico/auditoria de execuções operacionais de uma página, incluindo tipo de job, etapa, status, tentativa, URLs usadas, HTTP/content type, HTML bruto do MVP, screenshot bruto opcional, payloads técnicos de auditoria, JSONs de análise, erro e timestamps de início/fim.
+
+Índices mínimos obrigatórios para leitura operacional:
+
+- `uk_mois_sales_page_workspace_url (workspace_id, url_canonical(512))` para deduplicação consolidada por workspace.
+- `idx_mois_sales_page_source_status (workspace_id, source, current_status, updated_at)` para contadores por fonte/status.
+- `idx_mois_sales_page_stage_status (workspace_id, current_stage, current_status, updated_at)` para fila operacional por etapa/status.
+- `idx_mois_sales_page_score (workspace_id, score_total)` para priorização comercial.
+- `idx_mois_sales_page_source_reference (workspace_id, source, source_job_id, source_reference_id)` para rastrear a origem coletada.
+- `idx_mois_sales_page_job_page_created (sales_page_id, created_at)` para histórico por página.
+- `idx_mois_sales_page_job_status (workspace_id, stage, status, updated_at)` para filas e diagnósticos por etapa.
+- `idx_mois_sales_page_job_type_status (workspace_id, job_type, status, updated_at)` para filas e diagnósticos por tipo de execução.
+
+Regra de transição da Fase 1:
+
+- Não remover `mois_sales_library_url_ingest`, `mois_sales_library_processing_job`, `mois_sales_library_page_analysis`, `mois_sales_library_page_snapshot`, `mois_sales_library_snapshot_artifact` nem `mois_collected_reference_html_capture`.
+- Não migrar a leitura principal da UI nesta fase.
+- Não iniciar backfill nesta fase.
+- Qualquer gravação futura no modelo novo deve manter `mois_sales_page` como estado atual e `mois_sales_page_job_execution` como histórico/auditoria.
+
+
 ### 13.8 Pipeline de captura de HTML bruto a partir de referências coletadas
 
 A primeira etapa do pipeline de páginas de venda deve separar responsabilidades:

--- a/docs/registros/mois1.md
+++ b/docs/registros/mois1.md
@@ -879,3 +879,14 @@ Arquivos alterados:
 - `docs/novos-modulos/MOIS/mois_sales_page_pipeline_simplificacao_duas_tabelas.md`
 - `docs/canonical/mois-worker-canon.v1.md`
 - `docs/registros/mois1.md`
+
+## 2026-06-04 00:08:14 UTC-3
+- execução da Fase 1 do plano de simplificação do pipeline da Biblioteca de Páginas de Vendas do MOIS em duas tabelas operacionais.
+- foi mantida a compatibilidade com o fluxo atual, sem remoção de tabelas legadas, preparando apenas o modelo estrutural novo para backfill e escrita dupla nas próximas fases.
+- criados changelogs Liquibase incrementais para `mois_sales_page` e `mois_sales_page_job_execution`, com índices operacionais de leitura e teste de contrato de schema.
+- atualizado o cânone MOIS para registrar responsabilidades, índices obrigatórios e regra de transição da Fase 1.
+- documentos lidos para tratar a situação:
+  - docs/novos-modulos/MOIS/mois_sales_page_pipeline_simplificacao_duas_tabelas.md
+  - docs/canonical/mois-worker-canon.v1.md
+  - backend/AGENTS.md
+  - AGENTS.md


### PR DESCRIPTION
### Motivation
- Simplificar o pipeline da Biblioteca de Páginas de Vendas do MOIS consolidando o estado atual em `mois_sales_page` e o histórico/auditoria em `mois_sales_page_job_execution` para reduzir ambiguidade entre coletores, snapshots e análises. 
- Preparar a base e a documentação para migração incremental (backfill / escrita dupla / cutover) mantendo compatibilidade com as tabelas legadas nesta fase inicial.

### Description
- Adicionado changelog Liquibase `changesets/2026-06-04-mois-sales-page.yaml` que cria a tabela `mois_sales_page` com colunas de estado consolidado, índices operacionais e FK para `mois_collected_reference` quando aplicável. 
- Adicionado changelog Liquibase `changesets/2026-06-04-mois-sales-page-job-execution.yaml` que cria a tabela `mois_sales_page_job_execution` contendo histórico, payloads (HTML/JSON), screenshots e índices por página/etapa/tipo. 
- Incluídos os dois changelogs em `db/changelog/db.changelog-master.yaml` na ordem correta (primeiro `mois_sales_page`, depois `mois_sales_page_job_execution`) e criado o teste de contrato de schema `MoisSalesPageSchemaChangelogTest.java` para validar campos/índices e ordem de inclusão. 
- Atualizado o cânone MOIS (`docs/canonical/mois-worker-canon.v1.md`) com a descrição da Fase 1 e registrado a execução em `docs/registros/mois1.md`.

### Testing
- Executei o teste de contrato de schema com `mvn -Dtest=MoisSalesPageSchemaChangelogTest test` no módulo `backend/ads-service`, que passou com sucesso. 
- Executei a suíte de testes do backend com `mvn test` no `backend/ads-service`, que finalizou com `BUILD SUCCESS` (tests run: 552, failures: 0, errors: 0, skipped: 1). 
- O changelog adicionado foi verificado por inspeção textual via testes e pelo `MoisSalesPageSchemaChangelogTest` garantindo a presença de campos, índices e a inclusão no master.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a20eb88a4fc8321ad713425bf55b632)