### PR TITLE
Restrict GeraLanding services to allowed repositories and update architecture docs

### DIFF
--- a/backend/ads-service/src/test/java/com/marketinghub/architecture/ArquiteturaTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/architecture/ArquiteturaTest.java
@@ -1,7 +1,9 @@
 package com.marketinghub.architecture;
 
 import com.marketinghub.repository.jpa.experiment.ExperimentRepository;
+import com.marketinghub.repository.jpa.experiment.frameworkimage.FrameworkImageGenerationJobRepository;
 import com.marketinghub.repository.jpa.geralanding.GeraLandingStageExecutionRepository;
+import com.marketinghub.repository.jpa.hypothesis.HypothesisRepository;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
 
@@ -41,10 +43,13 @@ class ArquiteturaTest {
 
     private static final String MOIS_SALES_LIBRARY_PACKAGE = "com.marketinghub.mois.bibliotecapaginavenda.worker.v1";
     private static final String EXPERIMENT_CLASS = "com.marketinghub.experiment.Experiment";
-    private static final String EXPERIMENT_REPOSITORY_CLASS = "com.marketinghub.repository.jpa.experiment.ExperimentRepository";
+    private static final String EXPERIMENT_REPOSITORY_CLASS = ExperimentRepository.class.getName();
+    private static final String HYPOTHESIS_REPOSITORY_CLASS = HypothesisRepository.class.getName();
+    private static final String FRAMEWORK_IMAGE_GENERATION_JOB_REPOSITORY_CLASS =
+            FrameworkImageGenerationJobRepository.class.getName();
     private static final String GERALANDING_STAGE_EXECUTION_CLASS = "com.marketinghub.geralanding.GeraLandingStageExecution";
     private static final String GERALANDING_STAGE_EXECUTION_REPOSITORY_CLASS =
-            "com.marketinghub.repository.jpa.geralanding.GeraLandingStageExecutionRepository";
+            GeraLandingStageExecutionRepository.class.getName();
     private static final String GERALANDING_STAGE_EXECUTION_BUILDER_CLASS =
             "com.marketinghub.geralanding.GeraLandingStageExecution$GeraLandingStageExecutionBuilder";
     private static final Pattern SALES_LIBRARY_LAYER_PATTERN = Pattern.compile(
@@ -83,6 +88,11 @@ class ArquiteturaTest {
             "updateFinancialPlan");
     private static final List<String> REQUIRED_BACKEND_CONTROLLER_METHODS = List.of(
             "start", "listStageExecutions", "pending", "recebePrompt", "recebeResposta", "detailStageExecution");
+    private static final List<String> ALLOWED_GERALANDING_SERVICE_REPOSITORIES = List.of(
+            EXPERIMENT_REPOSITORY_CLASS,
+            HYPOTHESIS_REPOSITORY_CLASS,
+            FRAMEWORK_IMAGE_GENERATION_JOB_REPOSITORY_CLASS,
+            GERALANDING_STAGE_EXECUTION_REPOSITORY_CLASS);
 
     @ArchTest
     static final ArchRule moisMustNotDependOnOtherMarketingHubPackages = noClasses()
@@ -975,9 +985,8 @@ class ArquiteturaTest {
                     if (isSameStageServiceDependency(item, targetClass)
                             || isSameStageProvisorioDependency(item, targetClass)
                             || targetName.equals(EXPERIMENT_CLASS)
-                            || targetName.equals(EXPERIMENT_REPOSITORY_CLASS)
+                            || isAllowedGeraLandingServiceRepository(targetName)
                             || targetName.equals(GERALANDING_STAGE_EXECUTION_CLASS)
-                            || targetName.equals(GERALANDING_STAGE_EXECUTION_REPOSITORY_CLASS)
                             || targetName.equals(GERALANDING_STAGE_EXECUTION_BUILDER_CLASS)) {
                         return;
                     }
@@ -987,14 +996,21 @@ class ArquiteturaTest {
                             + " | regra: serviços em geralanding.*.service só podem acessar "
                             + "pacotes internos geralanding.<etapa>.service.* e geralanding.<etapa>.provisorio.* da mesma etapa, "
                             + EXPERIMENT_CLASS + ", "
-                            + EXPERIMENT_REPOSITORY_CLASS + ", "
                             + GERALANDING_STAGE_EXECUTION_CLASS + ", "
-                            + GERALANDING_STAGE_EXECUTION_REPOSITORY_CLASS + " e "
-                            + GERALANDING_STAGE_EXECUTION_BUILDER_CLASS;
+                            + GERALANDING_STAGE_EXECUTION_BUILDER_CLASS
+                            + " e somente repositories das tabelas experiment, hypothesis, framework_image_generation_job e gera_landing_stage_execution: "
+                            + ALLOWED_GERALANDING_SERVICE_REPOSITORIES;
                     events.add(SimpleConditionEvent.violated(item, message));
                 });
             }
         };
+    }
+
+    /**
+     * Verifica se a dependência alvo é um repository liberado para services do GeraLanding.
+     */
+    private static boolean isAllowedGeraLandingServiceRepository(String targetName) {
+        return ALLOWED_GERALANDING_SERVICE_REPOSITORIES.contains(targetName);
     }
 
     /**

--- a/docs/canonical/geralanding-arquitetura-canon.v1.md
+++ b/docs/canonical/geralanding-arquitetura-canon.v1.md
@@ -12,16 +12,22 @@ flowchart LR
     SERV["Pacote: geralanding.<etapa>.service"]
     SERV_INT["Pacotes internos: geralanding.<etapa>.service.*"]
     PROV["Pacote: geralanding.<etapa>.provisorio"]
-    EXP["Pacote: com.marketinghub.experiment (Experiment + ExperimentRepository)"]
-    EXEC["Pacote: com.marketinghub.geralanding.execution (GeraLandingStageExecution + GeraLandingStageExecutionRepository)"]
+    EXP["Tabela experiment: Experiment + ExperimentRepository"]
+    HYP["Tabela hypothesis: HypothesisRepository"]
+    IMG["Tabela framework_image_generation_job: FrameworkImageGenerationJobRepository"]
+    EXEC["Tabela gera_landing_stage_execution: GeraLandingStageExecution + GeraLandingStageExecutionRepository"]
 
     WEB -->|pode usar| SERV
     SERV -->|pode usar| SERV_INT
     SERV_INT -->|pode usar| SERV
     SERV_INT -->|pode usar| SERV_INT
     SERV -->|pode usar| EXP
+    SERV -->|pode usar| HYP
+    SERV -->|pode usar| IMG
     SERV -->|pode usar| EXEC
     SERV_INT -->|pode usar| EXP
+    SERV_INT -->|pode usar| HYP
+    SERV_INT -->|pode usar| IMG
     SERV_INT -->|pode usar| EXEC
 ```
 
@@ -32,11 +38,11 @@ Regras arquiteturais refletidas (ArchUnit):
 - `GeraLandingStageExecutionService` não pode chamar assinaturas legadas dos assemblers de wireframe/copy/design preset.
 - `GeraLandingStageExecutionService` deve chamar explicitamente as assinaturas canônicas dos assemblers.
 - `WireframeProvisionalHtmlAssembler` deve residir em `geralanding.wireframe`, `DesignPresetProvisionalHtmlAssembler` deve residir em `geralanding.presetdesign.provisorio` para manter o montador provisório dentro da etapa preset design, e os endpoints/serviços backend da etapa devem residir em `geralanding.presetdesign` seguindo a estrutura canônica de `wireframe`.
-- Serviços em `com.marketinghub.geralanding..service..` podem depender de classes da árvore interna de serviço da mesma etapa (`geralanding.<etapa>.service` e `geralanding.<etapa>.service.*`), de classes provisórias da mesma etapa (`geralanding.<etapa>.provisorio` e `geralanding.<etapa>.provisorio.*`) e de `Experiment`, `ExperimentRepository`, `GeraLandingStageExecution`, `GeraLandingStageExecutionRepository` e do builder de `GeraLandingStageExecution` no domínio `com.marketinghub`.
+- Serviços em `com.marketinghub.geralanding..service..` podem depender de classes da árvore interna de serviço da mesma etapa (`geralanding.<etapa>.service` e `geralanding.<etapa>.service.*`), de classes provisórias da mesma etapa (`geralanding.<etapa>.provisorio` e `geralanding.<etapa>.provisorio.*`), de `Experiment`, de `GeraLandingStageExecution`, do builder de `GeraLandingStageExecution` e somente dos repositories das quatro tabelas canônicas do GeraLanding: `ExperimentRepository` (`experiment`), `HypothesisRepository` (`hypothesis`), `FrameworkImageGenerationJobRepository` (`framework_image_generation_job`) e `GeraLandingStageExecutionRepository` (`gera_landing_stage_execution`).
 - `geralanding.*.web` só pode acessar `geralanding.*.web` e `geralanding.*.service` da mesma etapa.
 - Cada pacote direto `geralanding.<etapa>.web` de backend deve conter uma única classe canônica `Backend<Etapa>Controller`, anotada com `@RestController` e `@RequestMapping("/api")`.
 - `geralanding.*.provisorio` só pode acessar `geralanding.*.provisorio` da mesma etapa.
-- `geralanding.*.service` só pode acessar classes `com.marketinghub` permitidas: classes da árvore interna `service` da mesma etapa (`service` e `service.*`), classes da árvore `provisorio` da mesma etapa (`provisorio` e `provisorio.*`), `Experiment`, `ExperimentRepository`, `GeraLandingStageExecution`, `GeraLandingStageExecutionRepository` e o builder de `GeraLandingStageExecution`.
+- `geralanding.*.service` só pode acessar classes `com.marketinghub` permitidas: classes da árvore interna `service` da mesma etapa (`service` e `service.*`), classes da árvore `provisorio` da mesma etapa (`provisorio` e `provisorio.*`), `Experiment`, `GeraLandingStageExecution`, o builder de `GeraLandingStageExecution` e somente os repositories das tabelas `experiment`, `hypothesis`, `framework_image_generation_job` e `gera_landing_stage_execution`.
 - Cada pacote direto `geralanding.<etapa>.service` de backend deve conter a classe canônica `Backend<Etapa>Service`, anotada com `@Service`.
 - Cada pacote direto `geralanding.<etapa>.service` de backend deve possuir os subpacotes obrigatórios `detailStageExecution`, `listStageExecutions`, `pending`, `recebePrompt` e `recebeResposta`.
 - Os subpacotes obrigatórios `detailStageExecution`, `listStageExecutions`, `pending`, `recebePrompt` e `recebeResposta` devem conter somente tipos Java declarados como `record`, preservando DTOs contratuais imutáveis para as bordas de cada etapa.

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -3307,3 +3307,10 @@
 - correção aplicada: a conclusão bem-sucedida da etapa `landing-page-image-planning` agora persiste o planejamento de imagens e cria automaticamente uma execução `landing-page-image-generation` com `promptTemplateId` `auto/image-planning` e status `INICIADO`.
 - cânone atualizado: `docs/canonical/procedimento-experimento-canon.v1.md` passou a declarar que o Gera Imagem deve ser enfileirado automaticamente após o Gera Prompt Imagem.
 - validação automatizada: teste unitário do `BackendImagePlanningService` atualizado para garantir criação da próxima execução automática somente no caminho de sucesso.
+
+## 2026-06-04 — Restrição arquitetural de repositories nos services do GeraLanding
+
+- solicitação: reforçar no teste de arquitetura do backend que os pacotes `geralanding.*.service` só possam acessar repositories das quatro tabelas usadas pelo GeraLanding.
+- causa-raiz/objetivo: evitar acoplamento acidental dos services do GeraLanding com persistências de outros módulos/tabelas, preservando o modelo central do fluxo de landing.
+- correção aplicada: `ArquiteturaTest` passou a manter lista explícita dos repositories permitidos para services do GeraLanding: `ExperimentRepository`, `HypothesisRepository`, `FrameworkImageGenerationJobRepository` e `GeraLandingStageExecutionRepository`.
+- cânone atualizado: `docs/canonical/geralanding-arquitetura-canon.v1.md` documenta que apenas repositories das tabelas `experiment`, `hypothesis`, `framework_image_generation_job` e `gera_landing_stage_execution` são permitidos nessa camada.


### PR DESCRIPTION
### Motivation
- Enforce architectural isolation by preventing `geralanding.*.service` classes from depending on arbitrary repositories outside the GeraLanding flow.
- Avoid accidental coupling of GeraLanding services with persistence from other modules by explicitly whitelisting the four canonical repositories used by the flow.
- Keep the canonical architecture documentation in sync with the enforced rule so the diagram and textual canon reflect the allowed dependencies.

### Description
- Updated `ArquiteturaTest` to replace string literals with `ExperimentRepository.class.getName()`, `HypothesisRepository.class.getName()` and `FrameworkImageGenerationJobRepository.class.getName()` and to compute `GeraLandingStageExecutionRepository` via `GeraLandingStageExecutionRepository.class.getName()`.
- Added `ALLOWED_GERALANDING_SERVICE_REPOSITORIES` containing the four allowed repository class names and a helper `isAllowedGeraLandingServiceRepository` used by the ArchUnit condition to permit only those repositories from `geralanding.*.service`.
- Adjusted the violation message to list the four allowed repositories and updated the logic in `onlyDependOnAllowedMarketingHubClasses()` to call `isAllowedGeraLandingServiceRepository()`.
- Updated documentation `docs/canonical/geralanding-arquitetura-canon.v1.md` to include the three additional canonical tables (`hypothesis`, `framework_image_generation_job`, `gera_landing_stage_execution`) in the diagram and rules, and added a record in `docs/registros/experimentos.md` describing the change.

### Testing
- Ran the project's automated test suite including the ArchUnit architecture tests and unit tests that validate GeraLanding rules; all tests completed successfully.
- Verified the updated ArchUnit rule `ArquiteturaTest` accepts only the whitelisted repository classes and reports violations for other repositories via the updated message.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a20ec6de57c8321a9ca8342eefdde7d)