### PR TITLE
Show Quality Review sent screenshots in execution detail

### DIFF
--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -3307,3 +3307,10 @@
 - correção aplicada: a conclusão bem-sucedida da etapa `landing-page-image-planning` agora persiste o planejamento de imagens e cria automaticamente uma execução `landing-page-image-generation` com `promptTemplateId` `auto/image-planning` e status `INICIADO`.
 - cânone atualizado: `docs/canonical/procedimento-experimento-canon.v1.md` passou a declarar que o Gera Imagem deve ser enfileirado automaticamente após o Gera Prompt Imagem.
 - validação automatizada: teste unitário do `BackendImagePlanningService` atualizado para garantir criação da próxima execução automática somente no caminho de sucesso.
+
+## 2026-06-04 — Screenshots enviados no detalhe do Quality Review
+
+- solicitação: na tela de detalhe da execução Gera Landing, quando a etapa for `landing-page-quality-review`, exibir os screenshots das imagens enviadas ao modelo de visão.
+- causa-raiz/objetivo: o diagnóstico de qualidade depende diretamente das evidências visuais enviadas; sem prévia na tela, o usuário precisava abrir o JSON bruto para conferir quais imagens foram avaliadas.
+- correção aplicada: o detalhe da execução agora identifica imagens anexadas no `openAiRequestBody` da etapa Quality Review, renderiza as prévias em cards com link para abrir cada imagem em nova aba e mantém mensagem explícita quando não houver imagem no payload.
+- validação automatizada: adicionados testes unitários para extração de imagens em payload OpenAI Responses API e payload bruto com data URLs duplicadas.

--- a/frontend/src/pages/experiment/ExperimentGeraLandingExecutionDetailPage.test.ts
+++ b/frontend/src/pages/experiment/ExperimentGeraLandingExecutionDetailPage.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from "vitest";
+import { extractQualityReviewSentScreenshots } from "./ExperimentGeraLandingExecutionDetailPage";
+
+const MOBILE_IMAGE = "data:image/png;base64,aGVyb19tb2JpbGU=";
+const DESKTOP_IMAGE =
+  "https://cdn.example.com/generated/signed-image?id=desktop";
+
+describe("extractQualityReviewSentScreenshots", () => {
+  it("extrai screenshots enviados no formato Responses API da OpenAI", () => {
+    const rawRequestBody = JSON.stringify({
+      model: "gpt-5.5",
+      input: [
+        {
+          role: "user",
+          content: [
+            { type: "input_text", text: "avalie a landing" },
+            {
+              type: "input_image",
+              detail: "mobile",
+              image_url: MOBILE_IMAGE,
+            },
+            {
+              type: "input_image",
+              label: "desktop completo",
+              image_url: { url: DESKTOP_IMAGE },
+            },
+          ],
+        },
+      ],
+    });
+
+    expect(extractQualityReviewSentScreenshots(rawRequestBody)).toEqual([
+      { src: MOBILE_IMAGE, label: "mobile" },
+      { src: DESKTOP_IMAGE, label: "desktop completo" },
+    ]);
+  });
+
+  it("remove imagens duplicadas e também extrai data URLs de payload bruto", () => {
+    const rawRequestBody = `payload quebrado ${MOBILE_IMAGE} texto ${MOBILE_IMAGE}`;
+
+    expect(extractQualityReviewSentScreenshots(rawRequestBody)).toEqual([
+      { src: MOBILE_IMAGE, label: "Screenshot 1" },
+    ]);
+  });
+});

--- a/frontend/src/pages/experiment/ExperimentGeraLandingExecutionDetailPage.tsx
+++ b/frontend/src/pages/experiment/ExperimentGeraLandingExecutionDetailPage.tsx
@@ -28,6 +28,123 @@ function extractModelFromRequestBody(raw?: string) {
   }
 }
 
+export interface QualityReviewSentScreenshot {
+  src: string;
+  label: string;
+}
+
+function isDisplayableImageReference(value: string) {
+  const trimmed = value.trim();
+  return (
+    /^data:image\/[a-zA-Z0-9.+-]+;base64,/.test(trimmed) ||
+    /^https?:\/\//i.test(trimmed)
+  );
+}
+
+function imageUrlFromUnknown(value: unknown): string | null {
+  if (typeof value === "string" && isDisplayableImageReference(value)) {
+    return value.trim();
+  }
+
+  if (value && typeof value === "object" && !Array.isArray(value)) {
+    const record = value as Record<string, unknown>;
+    return imageUrlFromUnknown(record.url ?? record.href ?? record.src);
+  }
+
+  return null;
+}
+
+function labelFromImageNode(
+  node: Record<string, unknown>,
+  fallbackIndex: number,
+) {
+  const labelCandidates = [
+    node.label,
+    node.name,
+    node.title,
+    node.viewport,
+    node.device,
+    node.detail,
+  ];
+  const label = labelCandidates.find(
+    (candidate): candidate is string =>
+      typeof candidate === "string" && candidate.trim().length > 0,
+  );
+  return label ? label.trim() : `Screenshot ${fallbackIndex}`;
+}
+
+export function extractQualityReviewSentScreenshots(
+  raw?: string | null,
+): QualityReviewSentScreenshot[] {
+  if (!raw?.trim()) return [];
+
+  const screenshots: QualityReviewSentScreenshot[] = [];
+  const seen = new Set<string>();
+
+  const addScreenshot = (src: string, label?: string) => {
+    if (seen.has(src)) return;
+    seen.add(src);
+    screenshots.push({
+      src,
+      label: label?.trim() || `Screenshot ${screenshots.length + 1}`,
+    });
+  };
+
+  const visit = (value: unknown, keyHint?: string) => {
+    if (typeof value === "string") {
+      if (isDisplayableImageReference(value)) {
+        addScreenshot(value.trim(), keyHint);
+      }
+      return;
+    }
+
+    if (Array.isArray(value)) {
+      value.forEach((item) => visit(item, keyHint));
+      return;
+    }
+
+    if (!value || typeof value !== "object") return;
+
+    const record = value as Record<string, unknown>;
+    const type =
+      typeof record.type === "string" ? record.type.toLowerCase() : "";
+    const nodeLooksLikeImage =
+      type.includes("image") ||
+      Object.keys(record).some((key) => /image|screenshot/i.test(key));
+
+    const directImage =
+      imageUrlFromUnknown(record.image_url) ??
+      imageUrlFromUnknown(record.imageUrl) ??
+      imageUrlFromUnknown(record.screenshotUrl) ??
+      imageUrlFromUnknown(record.screenshot_url) ??
+      (nodeLooksLikeImage
+        ? imageUrlFromUnknown(record.url ?? record.src)
+        : null);
+
+    if (directImage) {
+      addScreenshot(
+        directImage,
+        labelFromImageNode(record, screenshots.length + 1),
+      );
+    }
+
+    Object.entries(record).forEach(([key, child]) => visit(child, key));
+  };
+
+  try {
+    visit(JSON.parse(raw));
+  } catch {
+    const dataImageMatches = raw.match(
+      /data:image\/[a-zA-Z0-9.+-]+;base64,[A-Za-z0-9+/=\r\n_-]+/g,
+    );
+    dataImageMatches?.forEach((match) =>
+      addScreenshot(match.replace(/\s/g, "")),
+    );
+  }
+
+  return screenshots;
+}
+
 function extractErrorFileContent(raw?: string) {
   if (!raw) return undefined;
 
@@ -96,6 +213,12 @@ export default function ExperimentGeraLandingExecutionDetailPage() {
   const errorFileContent = extractErrorFileContent(
     detailQuery.data?.errorDetail,
   );
+  const isQualityReviewStage =
+    (detailQuery.data?.stageCode ?? stageCode) ===
+    "landing-page-quality-review";
+  const qualityReviewSentScreenshots = isQualityReviewStage
+    ? extractQualityReviewSentScreenshots(detailQuery.data?.openAiRequestBody)
+    : [];
 
   const buildJsonDownloadProps = (fieldName: string, value?: string | null) => {
     if (!value) return null;
@@ -292,6 +415,61 @@ export default function ExperimentGeraLandingExecutionDetailPage() {
                   <strong>Custo USD:</strong> {detailQuery.data.costUsd ?? "—"}
                 </div>
               </div>
+
+              {isQualityReviewStage ? (
+                <div>
+                  <div className="d-flex align-items-center justify-content-between gap-2 mb-2 flex-wrap">
+                    <div>
+                      <h6 className="mb-1">Screenshots das imagens enviadas</h6>
+                      <p className="text-muted small mb-0">
+                        Imagens anexadas ao request visual enviado para o
+                        Quality Gate.
+                      </p>
+                    </div>
+                    <span className="badge text-bg-light border border-secondary-subtle text-dark">
+                      {qualityReviewSentScreenshots.length} imagem
+                      {qualityReviewSentScreenshots.length === 1 ? "" : "s"}
+                    </span>
+                  </div>
+                  {qualityReviewSentScreenshots.length > 0 ? (
+                    <div className="row g-3">
+                      {qualityReviewSentScreenshots.map((screenshot, index) => (
+                        <div className="col-12 col-xl-6" key={screenshot.src}>
+                          <div className="border rounded bg-light p-2 h-100">
+                            <div className="d-flex justify-content-between align-items-center gap-2 mb-2">
+                              <strong className="small">
+                                {screenshot.label || `Screenshot ${index + 1}`}
+                              </strong>
+                              <a
+                                href={screenshot.src}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                                className="btn btn-sm btn-outline-secondary"
+                              >
+                                Abrir imagem
+                              </a>
+                            </div>
+                            <img
+                              src={screenshot.src}
+                              alt={`Screenshot enviado ao Quality Gate ${index + 1}`}
+                              className="img-fluid rounded border bg-white d-block mx-auto"
+                              style={{
+                                maxHeight: "520px",
+                                objectFit: "contain",
+                              }}
+                            />
+                          </div>
+                        </div>
+                      ))}
+                    </div>
+                  ) : (
+                    <p className="text-muted mb-0">
+                      Nenhuma imagem enviada foi encontrada no request visual
+                      desta execução.
+                    </p>
+                  )}
+                </div>
+              ) : null}
 
               <div>
                 <div className="d-flex align-items-center gap-2 mb-2">


### PR DESCRIPTION
### Motivation
- The Quality Review diagnosis depends on the visual evidence sent to the model, and users previously had to inspect raw JSON to see which images were evaluated. 
- The change aims to surface those images directly in the execution detail for `landing-page-quality-review` so reviewers can faster confirm what was evaluated.

### Description
- Add `extractQualityReviewSentScreenshots` to `frontend/src/pages/experiment/ExperimentGeraLandingExecutionDetailPage.tsx` to parse image references from `openAiRequestBody`, handling `data:image` URLs, `http(s)` URLs and nested `image_url`/`imageUrl`/`screenshotUrl` objects. 
- Render a new section in the execution detail UI when `stageCode === "landing-page-quality-review"` that shows a counter, preview cards and links to open each sent image. 
- Add unit tests `frontend/src/pages/experiment/ExperimentGeraLandingExecutionDetailPage.test.ts` covering OpenAI Responses API payloads, raw data URLs and duplicate filtering, and update `docs/registros/experimentos.md` with the task record. 

### Testing
- Ran the unit tests with `npm test -- --run src/pages/experiment/ExperimentGeraLandingExecutionDetailPage.test.ts` and both tests passed. 
- Ran type checking with `npm run typecheck` (`tsc --noEmit`) and it completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a20ed62987083219d6e76f68ceca798)