### PR TITLE
Encadeia Gera Prompt Imagem após Gera Copy

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/copy/service/GeraLandingCopyStageExecutionService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/copy/service/GeraLandingCopyStageExecutionService.java
@@ -33,6 +33,7 @@ public class GeraLandingCopyStageExecutionService {
     private static final Logger log = LoggerFactory.getLogger(GeraLandingCopyStageExecutionService.class);
     private static final TypeReference<LinkedHashMap<String, Object>> FRAMEWORK_TYPE = new TypeReference<>() {};
     private static final String STAGE_CODE = "landing-page-copy";
+    private static final String NEXT_STAGE_IMAGE_PLANNING = "landing-page-image-planning";
     private static final String STATUS_STARTED = "INICIADO";
     private static final String STATUS_WAITING_OPENAI_DISPATCH = "AGUARDANDO_RETORNO_OPENAI";
     private static final String STATUS_COMPLETED = "CONCLUIDO";
@@ -153,7 +154,7 @@ public class GeraLandingCopyStageExecutionService {
         return prompt;
     }
 
-    /** Conclui ou falha a execução da etapa copy com a resposta devolvida pelo Worker AI. */
+    /** Conclui ou falha a execução da etapa copy com a resposta do Worker AI e avança para prompts de imagem quando há sucesso. */
     @Transactional
     public void markCompletedFromResponse(
             String idJob,
@@ -232,18 +233,42 @@ public class GeraLandingCopyStageExecutionService {
         return null;
     }
 
-    /** Persiste o artefato JSON final do copy no experimento associado à execução concluída. */
+    /** Persiste o artefato JSON final do copy e agenda a próxima etapa automática no experimento associado à execução concluída. */
     private void persistCopyArtifactOnExperiment(GeraLandingStageExecution execution, String modelResponse) {
         if (!StringUtils.hasText(modelResponse)) {
             return;
         }
+        Experiment experiment = resolveExperiment(execution);
+        experiment.setLandingPageCopy(modelResponse);
+        experimentRepository.save(experiment);
+        createImagePlanningExecution(experiment);
+    }
+
+    /** Agenda o Gera Prompt Imagem como próxima etapa automática após salvar a copy da landing. */
+    private void createImagePlanningExecution(Experiment experiment) {
+        Instant now = Instant.now();
+        GeraLandingStageExecution imagePlanningExecution = GeraLandingStageExecution.builder()
+                .experimentId(experiment.getId())
+                .experiment(experiment)
+                .stageCode(NEXT_STAGE_IMAGE_PLANNING)
+                .executionRequestedAt(now)
+                .createdAt(now)
+                .promptTemplateId("auto/copy")
+                .promptContent("Gera Prompt Imagem iniciado automaticamente após o Gera Copy.")
+                .status(STATUS_STARTED)
+                .idJob(toDatabaseIdJob(UUID.randomUUID().toString()))
+                .build();
+        executionRepository.save(imagePlanningExecution);
+    }
+
+    /** Resolve o experimento da execução, buscando no repositório quando a associação não estiver carregada. */
+    private Experiment resolveExperiment(GeraLandingStageExecution execution) {
         Experiment experiment = execution.getExperiment();
         if (experiment == null) {
             experiment = experimentRepository.findById(execution.getExperimentId())
                     .orElseThrow(() -> new EntityNotFoundException("Experiment not found: " + execution.getExperimentId()));
         }
-        experiment.setLandingPageCopy(modelResponse);
-        experimentRepository.save(experiment);
+        return experiment;
     }
 
     /** Converte o experimento da execução para os dados expostos na fila pending. */

--- a/backend/ads-service/src/test/java/com/marketinghub/geralanding/copy/service/GeraLandingCopyStageExecutionServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/geralanding/copy/service/GeraLandingCopyStageExecutionServiceTest.java
@@ -142,7 +142,7 @@ class GeraLandingCopyStageExecutionServiceTest {
         verify(executionRepository).save(execution);
     }
 
-    /** Deve concluir com sucesso, gravar métricas e persistir o artefato final de copy no experimento. */
+    /** Deve concluir com sucesso, gravar métricas, persistir o artefato final de copy e enfileirar prompts de imagem. */
     @Test
     void markCompletedFromResponseShouldPersistCopyArtifactOnSuccess() {
         ExperimentRepository experimentRepository = mock(ExperimentRepository.class);
@@ -150,6 +150,7 @@ class GeraLandingCopyStageExecutionServiceTest {
         GeraLandingCopyStageExecutionService service =
                 new GeraLandingCopyStageExecutionService(experimentRepository, executionRepository, new ObjectMapper());
         Experiment experiment = mock(Experiment.class);
+        when(experiment.getId()).thenReturn(88L);
         GeraLandingStageExecution execution = GeraLandingStageExecution.builder()
                 .experimentId(88L)
                 .experiment(experiment)
@@ -167,6 +168,14 @@ class GeraLandingCopyStageExecutionServiceTest {
         assertEquals("CONCLUIDO", execution.getStatus());
         verify(experiment).setLandingPageCopy("{\"landingPageCopy\":{}}");
         verify(experimentRepository).save(experiment);
+        verify(executionRepository).save(argThat(nextExecution ->
+                nextExecution.getExperimentId().equals(88L)
+                        && nextExecution.getExperiment() == experiment
+                        && nextExecution.getStageCode().equals("landing-page-image-planning")
+                        && nextExecution.getStatus().equals("INICIADO")
+                        && nextExecution.getPromptTemplateId().equals("auto/copy")
+                        && nextExecution.getPromptContent().equals("Gera Prompt Imagem iniciado automaticamente após o Gera Copy.")
+                        && nextExecution.getIdJob() != null));
     }
 
     /** Deve marcar falha sem sobrescrever o artefato final de copy no experimento. */

--- a/docs/canonical/geralanding-arquitetura-canon.v1.md
+++ b/docs/canonical/geralanding-arquitetura-canon.v1.md
@@ -92,6 +92,7 @@ Regras arquiteturais refletidas (ArchUnit):
 
 ## 4) Regras de integração
 
+- A progressão automática do backend deve preservar o encadeamento operacional do GeraLanding: ao concluir com sucesso `landing-page-copy`, o backend enfileira automaticamente `landing-page-image-planning`; ao concluir com sucesso `landing-page-image-planning`, o backend enfileira automaticamente `landing-page-image-generation`. Falhas ou callbacks com erro não devem iniciar a próxima etapa.
 - O **Worker AI não acessa banco**; toda leitura/gravação de estado da execução passa pelo backend GeraLanding.
 - O polling e os callbacks internos consumidos pelo Worker AI devem usar adapters específicos por etapa dentro de `openai.core.<etapa>`; cada adapter chama somente os endpoints HTTP do backend correspondentes à sua etapa.
 - Ajustes no Worker AI não devem criar controller interno genérico no backend para atender todas as etapas do GeraLanding.

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -1,3 +1,15 @@
+## 2026-06-04 — GeraLanding: disparo automático de Gera Prompt Imagem após Gera Copy
+
+- solicitação: no pipeline do GeraLanding, disparar automaticamente a etapa `Gera Prompt Imagem` ao final bem-sucedido da etapa `Gera Copy`, seguindo o padrão já existente de `Gera Prompt Imagem` para `Gera Imagem`.
+- causa-raiz: a etapa `landing-page-image-planning` só era iniciada por comando manual ou por jobs já enfileirados, enquanto `landing-page-image-generation` já era encadeada automaticamente após `landing-page-image-planning`; isso deixava uma quebra operacional entre copy e prompts de imagem.
+- foi feito: ao concluir `landing-page-copy` sem erro, o backend salva o artefato de copy no experimento e cria uma nova execução `INICIADO` para `landing-page-image-planning` com `promptTemplateId=auto/copy`.
+- validação: teste unitário da etapa copy atualizado para garantir que o callback de sucesso persiste o artefato e enfileira a próxima etapa automática, preservando o comportamento de não avançar em falha.
+- arquivos alterados:
+  - backend/ads-service/src/main/java/com/marketinghub/geralanding/copy/service/GeraLandingCopyStageExecutionService.java
+  - backend/ads-service/src/test/java/com/marketinghub/geralanding/copy/service/GeraLandingCopyStageExecutionServiceTest.java
+  - docs/canonical/geralanding-arquitetura-canon.v1.md
+  - docs/registros/experimentos.md
+
 
 ## 2026-06-03 — Decisão de Quality Gate visual do GeraLanding
 - solicitação: registrar no plano que a validação de qualidade da landing deve usar um modelo de visão.


### PR DESCRIPTION
### Motivation
- Fechar uma quebra operacional no pipeline GeraLanding garantindo que, ao finalizar com sucesso `Gera Copy`, o sistema automaticamente dispare a etapa de planejamento de prompts de imagem (`Gera Prompt Imagem`) para manter continuidade do fluxo sem intervenção manual.
- Documentar e validar essa mudança no cânone de arquitetura do GeraLanding para preservar a ordem automática: Copy → Prompt Imagem → Gera Imagem.

### Description
- Ao concluir com sucesso a etapa `landing-page-copy`, o backend agora persiste o artefato de copy e cria uma nova execução `INICIADO` para `landing-page-image-planning` com `promptTemplateId="auto/copy"` (implementado em `GeraLandingCopyStageExecutionService`).
- Adicionada constante `NEXT_STAGE_IMAGE_PLANNING`, método `createImagePlanningExecution(...)` e ajuste em `persistCopyArtifactOnExperiment(...)` para agendar a etapa seguinte automaticamente (arquivo modificado: `backend/ads-service/src/main/java/com/marketinghub/geralanding/copy/service/GeraLandingCopyStageExecutionService.java`).
- Atualizado o teste unitário da etapa copy para verificar que, em sucesso, o artefato é salvo e a execução de `landing-page-image-planning` é criada (`backend/ads-service/src/test/java/com/marketinghub/geralanding/copy/service/GeraLandingCopyStageExecutionServiceTest.java`).
- Atualizados documentos canônicos e registros para declarar a regra de progressão automática (`docs/canonical/geralanding-arquitetura-canon.v1.md` e `docs/registros/experimentos.md`).

### Testing
- Executado unitário focado: `cd backend/ads-service && mvn -q -Dtest=com.marketinghub.geralanding.copy.service.GeraLandingCopyStageExecutionServiceTest test`, que passou com sucesso validating the new behavior.
- Executado suíte completa do módulo: `cd backend/ads-service && mvn -q test`, que falhou por erros pré-existentes não relacionados (ex.: `FacebookInstantFormControllerTest` com violações de integridade referencial ao limpar `experiment`), indicando testes de integração/ambiente existentes que precisam investigação separada.
- Verificação de formatação: `cd backend/ads-service && mvn -q spotless:check` não pôde ser executada no ambiente devido ao plugin `spotless` não resolvido no projeto Maven atual.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a214903547c8321ad5c19aaf67c65c0)