### PR TITLE
Implement dual-write bridge to mirror legacy MOIS library into consolidated sales_page model

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryService.java
@@ -1,6 +1,7 @@
 package com.marketinghub.mois.bibliotecapaginavenda.worker.v1.service;
 
 import com.marketinghub.mois.bibliotecapaginavenda.worker.v1.dto.MoisSalesLibraryDtos;
+import com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1.MoisSalesPageDualWriteGateway;
 import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
@@ -36,6 +37,7 @@ public class MoisSalesLibraryService {
     private static final String ANALYSIS_STATUS_CANCELED = "ANULADO";
 
     private final JdbcTemplate jdbcTemplate;
+    private final MoisSalesPageDualWriteGateway dualWriteGateway;
 
     /**
      * Reserva o próximo job pendente da biblioteca para processamento pelo worker.
@@ -57,6 +59,7 @@ public class MoisSalesLibraryService {
         }
         MoisSalesLibraryDtos.SalesLibraryClaimedJob job = rows.get(0);
         jdbcTemplate.update("UPDATE mois_sales_library_processing_job SET status='FETCHING', started_at=UTC_TIMESTAMP(), updated_at=UTC_TIMESTAMP() WHERE id=? AND status='PENDING'", job.jobId());
+        dualWriteGateway.syncProcessingJob(job.jobId());
         return new MoisSalesLibraryDtos.SalesLibraryClaimResponse(true, job);
     }
 
@@ -73,6 +76,8 @@ public class MoisSalesLibraryService {
                 VALUES (?, ?, 'DONE', ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, UTC_TIMESTAMP(), UTC_TIMESTAMP())
                 """, pageId, jobId, request.scoreTotal(), request.parserVersion(), request.promptVersion(), request.modelName(), request.sectionsJson(), request.copyJson(), request.visualJson(), request.imageJson(), request.analysisNotes(), request.requestPayloadJson(), request.analyzedAt() == null ? Instant.now() : request.analyzedAt());
         jdbcTemplate.update("UPDATE mois_sales_library_processing_job SET status='DONE', finished_at=UTC_TIMESTAMP(), updated_at=UTC_TIMESTAMP() WHERE id=?", jobId);
+        dualWriteGateway.syncProcessingJob(jobId);
+        dualWriteGateway.syncLatestAnalysis(pageId);
     }
 
     /**
@@ -81,6 +86,7 @@ public class MoisSalesLibraryService {
     @Transactional
     public void failJob(long jobId, MoisSalesLibraryDtos.SalesLibraryFailRequest request) {
         jdbcTemplate.update("UPDATE mois_sales_library_processing_job SET status='FAILED', error_category=?, error_message=?, finished_at=UTC_TIMESTAMP(), updated_at=UTC_TIMESTAMP() WHERE id=?", request.errorCategory(), request.errorMessage(), jobId);
+        dualWriteGateway.syncProcessingJob(jobId);
     }
 
     /**
@@ -225,6 +231,7 @@ public class MoisSalesLibraryService {
                 rawHtmlBytes.length,
                 Timestamp.from(request.fetchedAt() == null ? Instant.now() : request.fetchedAt()),
                 captureId);
+        dualWriteGateway.syncCollectedReferenceHtmlCapture(captureId);
         return new MoisSalesLibraryDtos.CollectedReferenceHtmlPersistResponse(captureId, "CAPTURED");
     }
 
@@ -248,6 +255,7 @@ public class MoisSalesLibraryService {
                         """,
                 truncate(message, 1000),
                 captureId);
+        dualWriteGateway.syncCollectedReferenceHtmlCapture(captureId);
         return new MoisSalesLibraryDtos.CollectedReferenceHtmlPersistResponse(captureId, "FAILED");
     }
 
@@ -414,6 +422,10 @@ public class MoisSalesLibraryService {
                 (url_ingest_id, job_id, status, analysis_notes, created_at, updated_at)
                 VALUES (?, ?, ?, ?, UTC_TIMESTAMP(), UTC_TIMESTAMP())
                 """, pageId, jobId, normalizedStatus, notes);
+        if (jobId != null) {
+            dualWriteGateway.syncProcessingJob(jobId);
+        }
+        dualWriteGateway.syncLatestAnalysis(pageId);
 
         return new MoisSalesLibraryDtos.SalesLibraryStatusUpdateResponse(pageId, jobId, normalizedStatus, notes, Instant.now());
     }
@@ -431,6 +443,8 @@ public class MoisSalesLibraryService {
                 (url_ingest_id, job_id, status, analysis_notes, created_at, updated_at)
                 VALUES (?, ?, 'PENDING', 'Reanálise solicitada via API', UTC_TIMESTAMP(), UTC_TIMESTAMP())
                 """, pageId, jobId);
+        dualWriteGateway.syncProcessingJob(jobId);
+        dualWriteGateway.syncLatestAnalysis(pageId);
         return new MoisSalesLibraryDtos.SalesLibraryReanalyzeResponse(pageId, jobId, JOB_STATUS_PENDING, Instant.now());
     }
 
@@ -481,18 +495,24 @@ public class MoisSalesLibraryService {
                         """
                                 SELECT id
                                 FROM mois_sales_library_url_ingest
-                                WHERE url_canonical = ?
+                                WHERE workspace_id = ? AND url_canonical = ?
                                 LIMIT 1
                                 """,
                         Long.class,
+                        workspaceId,
                         canonical
                 );
                 if (urlIngestId != null) {
-                    createPendingJob(urlIngestId);
+                    long jobId = createPendingJob(urlIngestId);
+                    dualWriteGateway.syncUrlIngest(urlIngestId, jobId);
                     jobsCreated++;
                 }
             } else {
                 updated++;
+                Long urlIngestId = findUrlIngestIdByCanonical(workspaceId, canonical);
+                if (urlIngestId != null) {
+                    dualWriteGateway.syncUrlIngest(urlIngestId, null);
+                }
             }
             persisted++;
         }
@@ -621,6 +641,23 @@ public class MoisSalesLibraryService {
             }
         }
         return null;
+    }
+
+    /**
+     * Localiza uma URL ingerida pelo workspace e identificador canônico para espelhar atualizações no modelo novo.
+     */
+    private Long findUrlIngestIdByCanonical(String workspaceId, String canonical) {
+        return jdbcTemplate.query(
+                """
+                        SELECT id
+                        FROM mois_sales_library_url_ingest
+                        WHERE workspace_id = ? AND url_canonical = ?
+                        LIMIT 1
+                        """,
+                (rs, rowNum) -> rs.getLong("id"),
+                workspaceId,
+                canonical
+        ).stream().findFirst().orElse(null);
     }
 
     /**

--- a/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibrarySnapshotService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibrarySnapshotService.java
@@ -1,6 +1,7 @@
 package com.marketinghub.mois.bibliotecapaginavenda.worker.v1.service;
 
 import com.marketinghub.mois.bibliotecapaginavenda.worker.v1.dto.MoisSalesLibraryDtos;
+import com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1.MoisSalesPageDualWriteGateway;
 import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Graphics2D;
@@ -45,6 +46,7 @@ public class MoisSalesLibrarySnapshotService {
     private static final int MAX_FAILED_ATTEMPTS_WITHOUT_FORCE = 3;
 
     private final JdbcTemplate jdbcTemplate;
+    private final MoisSalesPageDualWriteGateway dualWriteGateway;
     private final HttpClient httpClient = HttpClient.newBuilder()
             .connectTimeout(Duration.ofSeconds(15))
             .followRedirects(HttpClient.Redirect.NORMAL)
@@ -118,6 +120,7 @@ public class MoisSalesLibrarySnapshotService {
         }
         PageToCapture page = pages.get(0);
         Long snapshotId = insertFetchingSnapshot(page);
+        dualWriteGateway.syncSnapshot(snapshotId);
         return new MoisSalesLibraryDtos.HtmlCaptureClaimResponse(
                 true,
                 new MoisSalesLibraryDtos.HtmlCaptureJobResponse(snapshotId, page.pageId(), page.urlCanonical(), page.title()));
@@ -143,6 +146,7 @@ public class MoisSalesLibrarySnapshotService {
                     """, request.httpStatus(), truncate(request.contentType(), 255), truncate(request.redirectDestinationUrl(), 1024),
                     truncate(request.redirectRootUrl(), 1024), "HTML idêntico ao snapshot " + duplicateSnapshotId,
                     Timestamp.from(request.capturedAt() == null ? Instant.now() : request.capturedAt()), snapshotId);
+            dualWriteGateway.syncSnapshot(snapshotId);
             return new MoisSalesLibraryDtos.HtmlCapturePersistResponse(snapshotId, "DUPLICATE");
         }
         jdbcTemplate.update("""
@@ -152,6 +156,7 @@ public class MoisSalesLibrarySnapshotService {
                 """, hash, request.httpStatus(), truncate(request.contentType(), 255), truncate(request.redirectDestinationUrl(), 1024),
                 truncate(request.redirectRootUrl(), 1024), Timestamp.from(request.capturedAt() == null ? Instant.now() : request.capturedAt()), snapshotId);
         insertTextArtifact(snapshotId, ARTIFACT_RAW_HTML, request.contentType() == null ? "text/html" : request.contentType(), rawHtml, rawHtmlBytes.length);
+        dualWriteGateway.syncSnapshot(snapshotId);
         return new MoisSalesLibraryDtos.HtmlCapturePersistResponse(snapshotId, "CAPTURED");
     }
 
@@ -172,6 +177,7 @@ public class MoisSalesLibrarySnapshotService {
                 WHERE id = ?
                 """, request.httpStatus(), truncate(request.redirectDestinationUrl(), 1024), truncate(request.redirectRootUrl(), 1024),
                 truncate(message, 1000), snapshotId);
+        dualWriteGateway.syncSnapshot(snapshotId);
         return new MoisSalesLibraryDtos.HtmlCapturePersistResponse(snapshotId, "FAILED");
     }
 
@@ -232,6 +238,7 @@ public class MoisSalesLibrarySnapshotService {
             log.warn("Falha ao capturar snapshot bruto da sales page MOIS. pageId={}, url={}, categoria={}",
                     page.pageId(), page.urlCanonical(), errorMessage, ex);
             Long snapshotId = persistFailedSnapshot(page, errorMessage, null, null, null, null);
+            syncSnapshotWhenPresent(snapshotId);
             return new MoisSalesLibraryDtos.SalesLibrarySnapshotCaptureItem(
                     page.pageId(), snapshotId, page.urlCanonical(), null, null, "FAILED", null, null, 0L, 0L, errorMessage);
         }
@@ -256,6 +263,7 @@ public class MoisSalesLibrarySnapshotService {
         if (!effective.isCapturable()) {
             String errorMessage = categorizeHttpFailure(effective.statusCode(), effective.rawHtml());
             Long snapshotId = persistFailedSnapshot(page, errorMessage, effective.statusCode(), effective.contentType(), redirectDestinationUrl, redirectRootUrl);
+            syncSnapshotWhenPresent(snapshotId);
             return new MoisSalesLibraryDtos.SalesLibrarySnapshotCaptureItem(
                     page.pageId(), snapshotId, page.urlCanonical(), redirectDestinationUrl, redirectRootUrl, "FAILED", null, effective.statusCode(), 0L, 0L,
                     errorMessage);
@@ -275,9 +283,17 @@ public class MoisSalesLibrarySnapshotService {
         insertTextArtifact(snapshotId, ARTIFACT_RAW_HTML, "text/html; charset=UTF-8", rawHtml, rawHtmlBytes.length);
         byte[] screenshot = renderBasicScreenshot(rawHtml, effective.finalUrl());
         insertBinaryArtifact(snapshotId, ARTIFACT_SCREENSHOT_PNG, "image/png", screenshot);
+        dualWriteGateway.syncSnapshot(snapshotId);
         return new MoisSalesLibraryDtos.SalesLibrarySnapshotCaptureItem(
                 page.pageId(), snapshotId, page.urlCanonical(), redirectDestinationUrl, redirectRootUrl, "CAPTURED", hash,
                 effective.statusCode(), rawHtmlBytes.length, screenshot.length, null);
+    }
+
+    /** Sincroniza um snapshot no modelo consolidado apenas quando a falha gerou identificador válido. */
+    private void syncSnapshotWhenPresent(Long snapshotId) {
+        if (snapshotId != null) {
+            dualWriteGateway.syncSnapshot(snapshotId);
+        }
     }
 
     /** Persiste uma falha de captura preservando URLs de redirecionamento, categoria, HTTP e tipo de conteúdo quando disponíveis. */

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/mois/bibliotecapaginavenda/worker/v1/MoisSalesPageDualWriteGateway.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/mois/bibliotecapaginavenda/worker/v1/MoisSalesPageDualWriteGateway.java
@@ -1,0 +1,32 @@
+package com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1;
+
+/**
+ * Define operações de escrita dupla entre o modelo legado da biblioteca MOIS e as novas tabelas consolidadas.
+ */
+public interface MoisSalesPageDualWriteGateway {
+
+    /**
+     * Sincroniza uma URL ingerida e, quando informado, o job pendente recém-criado no modelo consolidado.
+     */
+    void syncUrlIngest(long urlIngestId, Long processingJobId);
+
+    /**
+     * Sincroniza o estado atual de um job de processamento legado no histórico consolidado.
+     */
+    void syncProcessingJob(long processingJobId);
+
+    /**
+     * Sincroniza a análise mais recente vinculada a uma página legada no modelo consolidado.
+     */
+    void syncLatestAnalysis(long urlIngestId);
+
+    /**
+     * Sincroniza um snapshot legado específico no histórico consolidado.
+     */
+    void syncSnapshot(long snapshotId);
+
+    /**
+     * Sincroniza uma captura bruta de referência coletada quando ela estiver vinculada a uma página consolidada.
+     */
+    void syncCollectedReferenceHtmlCapture(long captureId);
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/mois/bibliotecapaginavenda/worker/v1/MoisSalesPageDualWriteRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/mois/bibliotecapaginavenda/worker/v1/MoisSalesPageDualWriteRepository.java
@@ -1,0 +1,493 @@
+package com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1;
+
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+
+/**
+ * Executa as escritas espelhadas do pipeline legado da biblioteca MOIS nas tabelas consolidadas de páginas de venda.
+ */
+@Repository
+@RequiredArgsConstructor
+@Slf4j
+public class MoisSalesPageDualWriteRepository implements MoisSalesPageDualWriteGateway {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    /**
+     * Sincroniza a URL legada e o job de análise inicial no modelo consolidado.
+     */
+    @Override
+    public void syncUrlIngest(long urlIngestId, Long processingJobId) {
+        try {
+            syncSalesPageFromLegacyUrlIngest(urlIngestId);
+            if (processingJobId != null) {
+                insertProcessingJobExecution(processingJobId);
+            }
+            updateLastJobExecutionPointer(urlIngestId);
+            logDivergenceForUrlIngest(urlIngestId);
+        } catch (RuntimeException ex) {
+            log.error("Falha na escrita dupla de ingestão MOIS. modulo=MOIS, operacao=syncUrlIngest, urlIngestId={}, processingJobId={}, erroClasse={}, erro={}",
+                    urlIngestId, processingJobId, ex.getClass().getName(), ex.getMessage(), ex);
+            throw ex;
+        }
+    }
+
+    /**
+     * Sincroniza o job legado atualizado no modelo consolidado.
+     */
+    @Override
+    public void syncProcessingJob(long processingJobId) {
+        try {
+            Long urlIngestId = findUrlIngestIdByProcessingJob(processingJobId);
+            if (urlIngestId == null) {
+                log.warn("Divergência MOIS sales page: job legado sem URL para escrita dupla. modulo=MOIS, operacao=syncProcessingJob, processingJobId={}", processingJobId);
+                return;
+            }
+            syncSalesPageFromLegacyUrlIngest(urlIngestId);
+            insertProcessingJobExecution(processingJobId);
+            updateLastJobExecutionPointer(urlIngestId);
+            logDivergenceForUrlIngest(urlIngestId);
+        } catch (RuntimeException ex) {
+            log.error("Falha na escrita dupla de job MOIS. modulo=MOIS, operacao=syncProcessingJob, processingJobId={}, erroClasse={}, erro={}",
+                    processingJobId, ex.getClass().getName(), ex.getMessage(), ex);
+            throw ex;
+        }
+    }
+
+    /**
+     * Sincroniza a análise legada mais recente no modelo consolidado.
+     */
+    @Override
+    public void syncLatestAnalysis(long urlIngestId) {
+        try {
+            syncSalesPageFromLegacyUrlIngest(urlIngestId);
+            insertLatestAnalysisExecution(urlIngestId);
+            updateLastJobExecutionPointer(urlIngestId);
+            logDivergenceForUrlIngest(urlIngestId);
+        } catch (RuntimeException ex) {
+            log.error("Falha na escrita dupla de análise MOIS. modulo=MOIS, operacao=syncLatestAnalysis, urlIngestId={}, erroClasse={}, erro={}",
+                    urlIngestId, ex.getClass().getName(), ex.getMessage(), ex);
+            throw ex;
+        }
+    }
+
+    /**
+     * Sincroniza o snapshot legado no histórico consolidado e atualiza o estado atual da página.
+     */
+    @Override
+    public void syncSnapshot(long snapshotId) {
+        try {
+            Long urlIngestId = findUrlIngestIdBySnapshot(snapshotId);
+            if (urlIngestId == null) {
+                log.warn("Divergência MOIS sales page: snapshot legado sem URL para escrita dupla. modulo=MOIS, operacao=syncSnapshot, snapshotId={}", snapshotId);
+                return;
+            }
+            syncSalesPageFromLegacyUrlIngest(urlIngestId);
+            insertSnapshotExecution(snapshotId);
+            updateLastJobExecutionPointer(urlIngestId);
+            logDivergenceForUrlIngest(urlIngestId);
+        } catch (RuntimeException ex) {
+            log.error("Falha na escrita dupla de snapshot MOIS. modulo=MOIS, operacao=syncSnapshot, snapshotId={}, erroClasse={}, erro={}",
+                    snapshotId, ex.getClass().getName(), ex.getMessage(), ex);
+            throw ex;
+        }
+    }
+
+    /**
+     * Sincroniza a captura bruta de referência coletada no histórico consolidado quando houver página vinculada.
+     */
+    @Override
+    public void syncCollectedReferenceHtmlCapture(long captureId) {
+        try {
+            List<Long> urlIngestIds = findUrlIngestIdsByCollectedCapture(captureId);
+            for (Long urlIngestId : urlIngestIds) {
+                syncSalesPageFromLegacyUrlIngest(urlIngestId);
+            }
+            insertCollectedReferenceHtmlExecution(captureId);
+            for (Long urlIngestId : urlIngestIds) {
+                updateLastJobExecutionPointer(urlIngestId);
+                logDivergenceForUrlIngest(urlIngestId);
+            }
+        } catch (RuntimeException ex) {
+            log.error("Falha na escrita dupla de captura bruta MOIS. modulo=MOIS, operacao=syncCollectedReferenceHtmlCapture, captureId={}, erroClasse={}, erro={}",
+                    captureId, ex.getClass().getName(), ex.getMessage(), ex);
+            throw ex;
+        }
+    }
+
+    /**
+     * Recalcula o estado consolidado de uma página a partir das tabelas legadas ainda oficiais nesta fase.
+     */
+    private void syncSalesPageFromLegacyUrlIngest(long urlIngestId) {
+        jdbcTemplate.update("""
+                INSERT INTO mois_sales_page
+                (workspace_id, source, source_job_id, source_reference_id, collected_reference_id, product_name, title,
+                 url_original, url_canonical, sales_page_url, product_url, url_final, redirect_root_url,
+                 current_stage, current_status, capture_status, analysis_status, http_status, content_type,
+                 html_sha256, html_bytes, score_total, last_error_category, last_error_message, last_job_execution_id,
+                 ingest_count, first_seen_at, last_collected_at, last_captured_at, last_analyzed_at, created_at, updated_at)
+                SELECT
+                  i.workspace_id,
+                  i.source,
+                  COALESCE(r.job_id, c.collection_job_id) AS source_job_id,
+                  COALESCE(r.reference_id, c.reference_id) AS source_reference_id,
+                  r.id AS collected_reference_id,
+                  r.product_name,
+                  COALESCE(NULLIF(r.product_name, ''), NULLIF(i.title, ''), NULLIF(r.title, ''), i.url_canonical) AS title,
+                  i.url_original,
+                  i.url_canonical,
+                  r.sales_page_url,
+                  r.product_url,
+                  COALESCE(s.redirect_destination_url, c.url_final, i.url_canonical) AS url_final,
+                  s.redirect_root_url,
+                  CASE
+                    WHEN a.id IS NOT NULL THEN 'ANALYSIS'
+                    WHEN s.id IS NOT NULL OR c.id IS NOT NULL THEN 'CAPTURE'
+                    WHEN j.id IS NOT NULL THEN 'ANALYSIS'
+                    ELSE 'INGEST'
+                  END AS current_stage,
+                  COALESCE(a.status, s.status, c.status, j.status, 'INGESTED') AS current_status,
+                  COALESCE(s.status, c.status) AS capture_status,
+                  a.status AS analysis_status,
+                  COALESCE(s.http_status, c.http_status) AS http_status,
+                  COALESCE(s.content_type, c.content_type) AS content_type,
+                  COALESCE(s.snapshot_hash, c.raw_html_sha256) AS html_sha256,
+                  COALESCE(raw.size_bytes, c.raw_html_bytes, 0) AS html_bytes,
+                  a.score_total,
+                  COALESCE(j.error_category,
+                           CASE WHEN s.status = 'FAILED' THEN 'CAPTURE_FAILED' END,
+                           CASE WHEN c.status = 'FAILED' THEN 'CAPTURE_FAILED' END) AS last_error_category,
+                  COALESCE(j.error_message, s.error_message, c.error_message,
+                           CASE WHEN a.status NOT IN ('DONE', 'PENDING') THEN a.analysis_notes END) AS last_error_message,
+                  NULL AS last_job_execution_id,
+                  i.ingest_count,
+                  COALESCE(i.first_captured_at, i.created_at) AS first_seen_at,
+                  COALESCE(r.collected_at, i.last_captured_at) AS last_collected_at,
+                  COALESCE(s.captured_at, c.fetched_at) AS last_captured_at,
+                  a.analyzed_at AS last_analyzed_at,
+                  i.created_at,
+                  UTC_TIMESTAMP() AS updated_at
+                FROM mois_sales_library_url_ingest i
+                LEFT JOIN mois_sales_library_processing_job j ON j.id = (
+                  SELECT j2.id FROM mois_sales_library_processing_job j2
+                  WHERE j2.url_ingest_id = i.id
+                  ORDER BY j2.updated_at DESC, j2.id DESC LIMIT 1
+                )
+                LEFT JOIN mois_sales_library_page_analysis a ON a.id = (
+                  SELECT a2.id FROM mois_sales_library_page_analysis a2
+                  WHERE a2.url_ingest_id = i.id
+                  ORDER BY a2.updated_at DESC, a2.id DESC LIMIT 1
+                )
+                LEFT JOIN mois_sales_library_page_snapshot s ON s.id = (
+                  SELECT s2.id FROM mois_sales_library_page_snapshot s2
+                  WHERE s2.url_ingest_id = i.id
+                  ORDER BY s2.captured_at DESC, s2.id DESC LIMIT 1
+                )
+                LEFT JOIN mois_sales_library_snapshot_artifact raw
+                  ON raw.snapshot_id = s.id AND raw.artifact_type = 'RAW_HTML'
+                LEFT JOIN mois_collected_reference r ON r.id = (
+                  SELECT r2.id FROM mois_collected_reference r2
+                  WHERE r2.workspace_id = i.workspace_id
+                    AND r2.source = i.source
+                    AND (r2.sales_page_url IN (i.url_original, i.url_canonical)
+                      OR r2.product_url IN (i.url_original, i.url_canonical)
+                      OR r2.url IN (i.url_original, i.url_canonical))
+                  ORDER BY r2.collected_at DESC, r2.id DESC LIMIT 1
+                )
+                LEFT JOIN mois_collected_reference_html_capture c ON c.id = (
+                  SELECT c2.id FROM mois_collected_reference_html_capture c2
+                  WHERE (r.id IS NOT NULL AND c2.collected_reference_id = r.id)
+                     OR (r.id IS NULL
+                       AND c2.workspace_id = i.workspace_id
+                       AND c2.source = i.source
+                       AND c2.url_original IN (i.url_original, i.url_canonical))
+                  ORDER BY c2.updated_at DESC, c2.id DESC LIMIT 1
+                )
+                WHERE i.id = ?
+                ON DUPLICATE KEY UPDATE
+                  source = VALUES(source),
+                  source_job_id = VALUES(source_job_id),
+                  source_reference_id = VALUES(source_reference_id),
+                  collected_reference_id = VALUES(collected_reference_id),
+                  product_name = VALUES(product_name),
+                  title = VALUES(title),
+                  url_original = VALUES(url_original),
+                  sales_page_url = VALUES(sales_page_url),
+                  product_url = VALUES(product_url),
+                  url_final = VALUES(url_final),
+                  redirect_root_url = VALUES(redirect_root_url),
+                  current_stage = VALUES(current_stage),
+                  current_status = VALUES(current_status),
+                  capture_status = VALUES(capture_status),
+                  analysis_status = VALUES(analysis_status),
+                  http_status = VALUES(http_status),
+                  content_type = VALUES(content_type),
+                  html_sha256 = VALUES(html_sha256),
+                  html_bytes = VALUES(html_bytes),
+                  score_total = VALUES(score_total),
+                  last_error_category = VALUES(last_error_category),
+                  last_error_message = VALUES(last_error_message),
+                  ingest_count = VALUES(ingest_count),
+                  first_seen_at = VALUES(first_seen_at),
+                  last_collected_at = VALUES(last_collected_at),
+                  last_captured_at = VALUES(last_captured_at),
+                  last_analyzed_at = VALUES(last_analyzed_at),
+                  updated_at = UTC_TIMESTAMP()
+                """, urlIngestId);
+    }
+
+    /**
+     * Insere o estado atual do job legado como evento auditável do novo histórico.
+     */
+    private void insertProcessingJobExecution(long processingJobId) {
+        jdbcTemplate.update("""
+                INSERT INTO mois_sales_page_job_execution
+                (sales_page_id, workspace_id, job_type, stage, status, attempt, input_url, error_category, error_message,
+                 started_at, finished_at, created_at, updated_at)
+                SELECT sp.id, i.workspace_id, 'PROCESSING_JOB', 'ANALYSIS', j.status,
+                       GREATEST(COALESCE(j.attempts, 0), 1), i.url_canonical, j.error_category, j.error_message,
+                       j.started_at, j.finished_at, j.created_at, j.updated_at
+                FROM mois_sales_library_processing_job j
+                JOIN mois_sales_library_url_ingest i ON i.id = j.url_ingest_id
+                JOIN mois_sales_page sp ON sp.workspace_id = i.workspace_id AND sp.url_canonical = i.url_canonical
+                WHERE j.id = ?
+                  AND NOT EXISTS (
+                    SELECT 1 FROM mois_sales_page_job_execution e
+                    WHERE e.sales_page_id = sp.id
+                      AND e.job_type = 'PROCESSING_JOB'
+                      AND e.stage = 'ANALYSIS'
+                      AND e.status = j.status
+                      AND e.created_at = j.created_at
+                      AND e.updated_at = j.updated_at
+                  )
+                """, processingJobId);
+    }
+
+    /**
+     * Insere a análise legada mais recente da página como evento auditável do novo histórico.
+     */
+    private void insertLatestAnalysisExecution(long urlIngestId) {
+        jdbcTemplate.update("""
+                INSERT INTO mois_sales_page_job_execution
+                (sales_page_id, workspace_id, job_type, stage, status, attempt, input_url, score_total,
+                 sections_json, copy_json, visual_json, image_json, request_payload_json, error_message,
+                 finished_at, created_at, updated_at)
+                SELECT sp.id, i.workspace_id, 'PAGE_ANALYSIS', 'ANALYSIS', a.status, 1, i.url_canonical, a.score_total,
+                       a.sections_json, a.copy_json, a.visual_json, a.image_json, a.request_payload_json,
+                       CASE WHEN a.status NOT IN ('DONE', 'PENDING') THEN a.analysis_notes END,
+                       a.analyzed_at, a.created_at, a.updated_at
+                FROM mois_sales_library_page_analysis a
+                JOIN mois_sales_library_url_ingest i ON i.id = a.url_ingest_id
+                JOIN mois_sales_page sp ON sp.workspace_id = i.workspace_id AND sp.url_canonical = i.url_canonical
+                WHERE i.id = ?
+                  AND a.id = (
+                    SELECT a2.id FROM mois_sales_library_page_analysis a2
+                    WHERE a2.url_ingest_id = i.id
+                    ORDER BY a2.updated_at DESC, a2.id DESC LIMIT 1
+                  )
+                  AND NOT EXISTS (
+                    SELECT 1 FROM mois_sales_page_job_execution e
+                    WHERE e.sales_page_id = sp.id
+                      AND e.job_type = 'PAGE_ANALYSIS'
+                      AND e.stage = 'ANALYSIS'
+                      AND e.status = a.status
+                      AND e.created_at = a.created_at
+                      AND e.updated_at = a.updated_at
+                  )
+                """, urlIngestId);
+    }
+
+    /**
+     * Insere o snapshot legado como evento auditável do novo histórico de captura.
+     */
+    private void insertSnapshotExecution(long snapshotId) {
+        jdbcTemplate.update("""
+                INSERT INTO mois_sales_page_job_execution
+                (sales_page_id, workspace_id, job_type, stage, status, attempt, input_url, final_url, redirect_root_url,
+                 http_status, content_type, raw_html, raw_html_sha256, raw_html_bytes, screenshot_blob, screenshot_bytes,
+                 error_category, error_message, started_at, finished_at, created_at, updated_at)
+                SELECT sp.id, i.workspace_id, 'PAGE_SNAPSHOT', 'CAPTURE', s.status, 1, i.url_canonical,
+                       s.redirect_destination_url, s.redirect_root_url, s.http_status, s.content_type,
+                       raw.content_text, s.snapshot_hash, COALESCE(raw.size_bytes, 0), png.content_blob, COALESCE(png.size_bytes, 0),
+                       CASE WHEN s.status = 'FAILED' THEN 'CAPTURE_FAILED' END, s.error_message,
+                       s.created_at, s.captured_at, s.created_at, s.updated_at
+                FROM mois_sales_library_page_snapshot s
+                JOIN mois_sales_library_url_ingest i ON i.id = s.url_ingest_id
+                JOIN mois_sales_page sp ON sp.workspace_id = i.workspace_id AND sp.url_canonical = i.url_canonical
+                LEFT JOIN mois_sales_library_snapshot_artifact raw
+                  ON raw.snapshot_id = s.id AND raw.artifact_type = 'RAW_HTML'
+                LEFT JOIN mois_sales_library_snapshot_artifact png
+                  ON png.snapshot_id = s.id AND png.artifact_type = 'SCREENSHOT_PNG'
+                WHERE s.id = ?
+                  AND NOT EXISTS (
+                    SELECT 1 FROM mois_sales_page_job_execution e
+                    WHERE e.sales_page_id = sp.id
+                      AND e.job_type = 'PAGE_SNAPSHOT'
+                      AND e.stage = 'CAPTURE'
+                      AND e.status = s.status
+                      AND e.created_at = s.created_at
+                      AND e.updated_at = s.updated_at
+                  )
+                """, snapshotId);
+    }
+
+    /**
+     * Insere a captura bruta de referência coletada como evento auditável quando já houver página consolidada relacionada.
+     */
+    private void insertCollectedReferenceHtmlExecution(long captureId) {
+        jdbcTemplate.update("""
+                INSERT INTO mois_sales_page_job_execution
+                (sales_page_id, workspace_id, job_type, stage, status, attempt, claimed_by, input_url, final_url,
+                 http_status, content_type, raw_html, raw_html_sha256, raw_html_bytes, error_category, error_message,
+                 started_at, finished_at, created_at, updated_at)
+                SELECT sp.id, c.workspace_id, 'COLLECTED_REFERENCE_HTML', 'CAPTURE', c.status, 1, c.claimed_by,
+                       c.url_original, c.url_final, c.http_status, c.content_type, c.raw_html, c.raw_html_sha256,
+                       COALESCE(c.raw_html_bytes, 0), CASE WHEN c.status = 'FAILED' THEN 'CAPTURE_FAILED' END,
+                       c.error_message, c.claimed_at, c.fetched_at, c.created_at, c.updated_at
+                FROM mois_collected_reference_html_capture c
+                JOIN mois_sales_page sp ON sp.collected_reference_id = c.collected_reference_id
+                WHERE c.id = ?
+                  AND NOT EXISTS (
+                    SELECT 1 FROM mois_sales_page_job_execution e
+                    WHERE e.sales_page_id = sp.id
+                      AND e.job_type = 'COLLECTED_REFERENCE_HTML'
+                      AND e.stage = 'CAPTURE'
+                      AND e.status = c.status
+                      AND e.created_at = c.created_at
+                      AND e.updated_at = c.updated_at
+                  )
+                """, captureId);
+    }
+
+    /**
+     * Atualiza a página consolidada com a execução mais recente vinculada à URL legada.
+     */
+    private void updateLastJobExecutionPointer(long urlIngestId) {
+        jdbcTemplate.update("""
+                UPDATE mois_sales_page sp
+                SET sp.last_job_execution_id = (
+                  SELECT e.id FROM mois_sales_page_job_execution e
+                  WHERE e.sales_page_id = sp.id
+                  ORDER BY e.updated_at DESC, e.id DESC LIMIT 1
+                ),
+                sp.updated_at = UTC_TIMESTAMP()
+                WHERE EXISTS (
+                  SELECT 1 FROM mois_sales_library_url_ingest i
+                  WHERE i.id = ?
+                    AND i.workspace_id = sp.workspace_id
+                    AND i.url_canonical = sp.url_canonical
+                )
+                  AND EXISTS (SELECT 1 FROM mois_sales_page_job_execution e2 WHERE e2.sales_page_id = sp.id)
+                """, urlIngestId);
+    }
+
+    /**
+     * Compara o estado atual legado com o consolidado e registra divergências para diagnóstico da transição.
+     */
+    private void logDivergenceForUrlIngest(long urlIngestId) {
+        List<StateComparison> rows = jdbcTemplate.query("""
+                SELECT i.id AS url_ingest_id,
+                       CASE
+                         WHEN a.id IS NOT NULL THEN 'ANALYSIS'
+                         WHEN s.id IS NOT NULL OR c.id IS NOT NULL THEN 'CAPTURE'
+                         WHEN j.id IS NOT NULL THEN 'ANALYSIS'
+                         ELSE 'INGEST'
+                       END AS legacy_stage,
+                       COALESCE(a.status, s.status, c.status, j.status, 'INGESTED') AS legacy_status,
+                       sp.current_stage AS new_stage,
+                       sp.current_status AS new_status
+                FROM mois_sales_library_url_ingest i
+                LEFT JOIN mois_sales_page sp ON sp.workspace_id = i.workspace_id AND sp.url_canonical = i.url_canonical
+                LEFT JOIN mois_sales_library_processing_job j ON j.id = (
+                  SELECT j2.id FROM mois_sales_library_processing_job j2
+                  WHERE j2.url_ingest_id = i.id
+                  ORDER BY j2.updated_at DESC, j2.id DESC LIMIT 1
+                )
+                LEFT JOIN mois_sales_library_page_analysis a ON a.id = (
+                  SELECT a2.id FROM mois_sales_library_page_analysis a2
+                  WHERE a2.url_ingest_id = i.id
+                  ORDER BY a2.updated_at DESC, a2.id DESC LIMIT 1
+                )
+                LEFT JOIN mois_sales_library_page_snapshot s ON s.id = (
+                  SELECT s2.id FROM mois_sales_library_page_snapshot s2
+                  WHERE s2.url_ingest_id = i.id
+                  ORDER BY s2.captured_at DESC, s2.id DESC LIMIT 1
+                )
+                LEFT JOIN mois_collected_reference_html_capture c ON c.id = (
+                  SELECT c2.id FROM mois_collected_reference_html_capture c2
+                  WHERE c2.workspace_id = i.workspace_id
+                    AND c2.source = i.source
+                    AND c2.url_original IN (i.url_original, i.url_canonical)
+                  ORDER BY c2.updated_at DESC, c2.id DESC LIMIT 1
+                )
+                WHERE i.id = ?
+                LIMIT 1
+                """, (rs, rowNum) -> new StateComparison(
+                rs.getLong("url_ingest_id"),
+                rs.getString("legacy_stage"),
+                rs.getString("legacy_status"),
+                rs.getString("new_stage"),
+                rs.getString("new_status")), urlIngestId);
+        if (rows.isEmpty()) {
+            log.warn("Divergência MOIS sales page: URL legada ausente após escrita dupla. modulo=MOIS, operacao=logDivergenceForUrlIngest, urlIngestId={}", urlIngestId);
+            return;
+        }
+        StateComparison comparison = rows.get(0);
+        if (!comparison.legacyStage().equals(comparison.newStage()) || !comparison.legacyStatus().equals(comparison.newStatus())) {
+            log.warn("Divergência MOIS sales page: estado legado não bate com modelo novo. modulo=MOIS, operacao=logDivergenceForUrlIngest, urlIngestId={}, legacyStage={}, legacyStatus={}, newStage={}, newStatus={}",
+                    comparison.urlIngestId(), comparison.legacyStage(), comparison.legacyStatus(), comparison.newStage(), comparison.newStatus());
+        }
+    }
+
+    /**
+     * Localiza a URL legada de um job de processamento.
+     */
+    private Long findUrlIngestIdByProcessingJob(long processingJobId) {
+        List<Long> rows = jdbcTemplate.query("SELECT url_ingest_id FROM mois_sales_library_processing_job WHERE id = ? LIMIT 1",
+                (rs, rowNum) -> rs.getLong("url_ingest_id"), processingJobId);
+        return rows.isEmpty() ? null : rows.get(0);
+    }
+
+    /**
+     * Localiza a URL legada de um snapshot.
+     */
+    private Long findUrlIngestIdBySnapshot(long snapshotId) {
+        List<Long> rows = jdbcTemplate.query("SELECT url_ingest_id FROM mois_sales_library_page_snapshot WHERE id = ? LIMIT 1",
+                (rs, rowNum) -> rs.getLong("url_ingest_id"), snapshotId);
+        return rows.isEmpty() ? null : rows.get(0);
+    }
+
+    /**
+     * Localiza URLs legadas que podem estar relacionadas a uma captura bruta de referência coletada.
+     */
+    private List<Long> findUrlIngestIdsByCollectedCapture(long captureId) {
+        return jdbcTemplate.query("""
+                SELECT i.id
+                FROM mois_collected_reference_html_capture c
+                JOIN mois_sales_library_url_ingest i
+                  ON i.workspace_id = c.workspace_id
+                 AND i.source = c.source
+                 AND i.url_canonical = c.url_original
+                WHERE c.id = ?
+                UNION
+                SELECT i.id
+                FROM mois_collected_reference_html_capture c
+                JOIN mois_collected_reference r ON r.id = c.collected_reference_id
+                JOIN mois_sales_library_url_ingest i
+                  ON i.workspace_id = r.workspace_id
+                 AND i.source = r.source
+                 AND (i.url_original IN (r.sales_page_url, r.product_url, r.url)
+                   OR i.url_canonical IN (r.sales_page_url, r.product_url, r.url))
+                WHERE c.id = ?
+                """, (rs, rowNum) -> rs.getLong("id"), captureId, captureId);
+    }
+
+    /**
+     * Guarda os dados comparados entre legado e modelo novo.
+     */
+    private record StateComparison(long urlIngestId, String legacyStage, String legacyStatus, String newStage, String newStatus) {
+    }
+}

--- a/backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibrarySnapshotServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibrarySnapshotServiceTest.java
@@ -3,6 +3,7 @@ package com.marketinghub.mois.bibliotecapaginavenda.worker.v1.service;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.marketinghub.mois.bibliotecapaginavenda.worker.v1.dto.MoisSalesLibraryDtos;
+import com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1.MoisSalesPageDualWriteGateway;
 import com.sun.net.httpserver.HttpServer;
 import java.io.IOException;
 import java.net.InetSocketAddress;
@@ -33,7 +34,7 @@ public class MoisSalesLibrarySnapshotServiceTest {
         jdbcTemplate = new JdbcTemplate(dataSource);
         jdbcTemplate.execute("CREATE ALIAS IF NOT EXISTS UTC_TIMESTAMP FOR \"com.marketinghub.mois.bibliotecapaginavenda.worker.v1.service.MoisSalesLibrarySnapshotServiceTest.utcTimestamp\"");
         createSchema();
-        service = new MoisSalesLibrarySnapshotService(jdbcTemplate);
+        service = new MoisSalesLibrarySnapshotService(jdbcTemplate, new NoOpDualWriteGateway());
         server = HttpServer.create(new InetSocketAddress(0), 0);
         server.createContext("/sales", exchange -> {
             byte[] body = """
@@ -232,6 +233,35 @@ public class MoisSalesLibrarySnapshotServiceTest {
                 "SELECT redirect_destination_url, redirect_root_url FROM mois_sales_library_page_snapshot WHERE url_ingest_id = 8");
         assertThat(storedUrls.get("redirect_destination_url")).isEqualTo(baseUrl + "/missing");
         assertThat(storedUrls.get("redirect_root_url")).isEqualTo(baseUrl);
+    }
+
+    /** Ignora a escrita dupla nos testes focados apenas no comportamento legado de snapshots. */
+    private static class NoOpDualWriteGateway implements MoisSalesPageDualWriteGateway {
+
+        /** Não sincroniza URLs ingeridas no teste de snapshot. */
+        @Override
+        public void syncUrlIngest(long urlIngestId, Long processingJobId) {
+        }
+
+        /** Não sincroniza jobs no teste de snapshot. */
+        @Override
+        public void syncProcessingJob(long processingJobId) {
+        }
+
+        /** Não sincroniza análises no teste de snapshot. */
+        @Override
+        public void syncLatestAnalysis(long urlIngestId) {
+        }
+
+        /** Não sincroniza snapshots no teste de snapshot legado. */
+        @Override
+        public void syncSnapshot(long snapshotId) {
+        }
+
+        /** Não sincroniza capturas de referências coletadas no teste de snapshot. */
+        @Override
+        public void syncCollectedReferenceHtmlCapture(long captureId) {
+        }
     }
 
     /** Fornece timestamp UTC compatível com a função usada no SQL MySQL dos testes. */

--- a/backend/ads-service/src/test/java/com/marketinghub/repository/jpa/mois/bibliotecapaginavenda/worker/v1/MoisSalesPageDualWriteRepositoryTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/repository/jpa/mois/bibliotecapaginavenda/worker/v1/MoisSalesPageDualWriteRepositoryTest.java
@@ -1,0 +1,211 @@
+package com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.sql.Timestamp;
+import java.time.Instant;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.datasource.DriverManagerDataSource;
+
+/**
+ * Valida a escrita dupla temporária da biblioteca MOIS para o modelo consolidado de páginas de venda.
+ */
+public class MoisSalesPageDualWriteRepositoryTest {
+
+    private JdbcTemplate jdbcTemplate;
+    private MoisSalesPageDualWriteRepository repository;
+
+    /**
+     * Prepara schema mínimo em H2 compatível com MySQL para exercitar a sincronização consolidada.
+     */
+    @BeforeEach
+    void setUp() {
+        DriverManagerDataSource dataSource = new DriverManagerDataSource(
+                "jdbc:h2:mem:mois_dual_write;MODE=MySQL;DATABASE_TO_UPPER=false;DB_CLOSE_DELAY=-1",
+                "sa",
+                ""
+        );
+        jdbcTemplate = new JdbcTemplate(dataSource);
+        jdbcTemplate.execute("CREATE ALIAS IF NOT EXISTS UTC_TIMESTAMP FOR \"com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1.MoisSalesPageDualWriteRepositoryTest.utcTimestamp\"");
+        createSchema();
+        repository = new MoisSalesPageDualWriteRepository(jdbcTemplate);
+    }
+
+    /**
+     * Garante que ingestão e job pendente sejam espelhados em página consolidada e execução nova.
+     */
+    @Test
+    void shouldMirrorUrlIngestAndProcessingJob() {
+        insertLegacyUrlAndJob("PENDING");
+
+        repository.syncUrlIngest(1L, 10L);
+
+        var page = jdbcTemplate.queryForMap("SELECT current_stage, current_status, last_job_execution_id FROM mois_sales_page WHERE url_canonical = 'https://offer.test/'");
+        Integer executions = jdbcTemplate.queryForObject("SELECT COUNT(*) FROM mois_sales_page_job_execution WHERE job_type = 'PROCESSING_JOB' AND status = 'PENDING'", Integer.class);
+        assertThat(page.get("current_stage")).isEqualTo("ANALYSIS");
+        assertThat(page.get("current_status")).isEqualTo("PENDING");
+        assertThat(page.get("last_job_execution_id")).isNotNull();
+        assertThat(executions).isEqualTo(1);
+    }
+
+    /**
+     * Garante que análise concluída atualize o estado consolidado e registre execução PAGE_ANALYSIS.
+     */
+    @Test
+    void shouldMirrorLatestAnalysisState() {
+        insertLegacyUrlAndJob("DONE");
+        jdbcTemplate.update("""
+                INSERT INTO mois_sales_library_page_analysis
+                (id, url_ingest_id, job_id, status, score_total, sections_json, copy_json, visual_json, image_json, request_payload_json, analyzed_at, created_at, updated_at)
+                VALUES (20, 1, 10, 'DONE', 88.50, '{}', '{}', '{}', '{}', '{}', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+                """);
+
+        repository.syncLatestAnalysis(1L);
+
+        var page = jdbcTemplate.queryForMap("SELECT current_stage, current_status, analysis_status, score_total FROM mois_sales_page WHERE url_canonical = 'https://offer.test/'");
+        Integer executions = jdbcTemplate.queryForObject("SELECT COUNT(*) FROM mois_sales_page_job_execution WHERE job_type = 'PAGE_ANALYSIS' AND status = 'DONE'", Integer.class);
+        assertThat(page.get("current_stage")).isEqualTo("ANALYSIS");
+        assertThat(page.get("current_status")).isEqualTo("DONE");
+        assertThat(page.get("analysis_status")).isEqualTo("DONE");
+        assertThat(page.get("score_total").toString()).isEqualTo("88.50");
+        assertThat(executions).isEqualTo(1);
+    }
+
+    /**
+     * Garante que snapshot capturado alimente status de captura e histórico consolidado com HTML bruto.
+     */
+    @Test
+    void shouldMirrorCapturedSnapshot() {
+        insertLegacyUrlAndJob("DONE");
+        jdbcTemplate.update("""
+                INSERT INTO mois_sales_library_page_snapshot
+                (id, url_ingest_id, snapshot_hash, status, http_status, content_type, redirect_destination_url, redirect_root_url, captured_at, created_at, updated_at)
+                VALUES (30, 1, 'abc123', 'CAPTURED', 200, 'text/html', 'https://offer.test/final', 'https://offer.test', CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+                """);
+        jdbcTemplate.update("""
+                INSERT INTO mois_sales_library_snapshot_artifact
+                (id, snapshot_id, artifact_type, content_type, storage_kind, content_text, size_bytes, created_at)
+                VALUES (40, 30, 'RAW_HTML', 'text/html', 'DATABASE_TEXT', '<html>Oferta</html>', 19, CURRENT_TIMESTAMP)
+                """);
+
+        repository.syncSnapshot(30L);
+
+        var page = jdbcTemplate.queryForMap("SELECT current_stage, current_status, capture_status, html_sha256, html_bytes FROM mois_sales_page WHERE url_canonical = 'https://offer.test/'");
+        String rawHtml = jdbcTemplate.queryForObject("SELECT raw_html FROM mois_sales_page_job_execution WHERE job_type = 'PAGE_SNAPSHOT'", String.class);
+        assertThat(page.get("current_stage")).isEqualTo("CAPTURE");
+        assertThat(page.get("current_status")).isEqualTo("CAPTURED");
+        assertThat(page.get("capture_status")).isEqualTo("CAPTURED");
+        assertThat(page.get("html_sha256")).isEqualTo("abc123");
+        assertThat(page.get("html_bytes")).isEqualTo(19L);
+        assertThat(rawHtml).contains("Oferta");
+    }
+
+    /**
+     * Insere a URL e o job legados compartilhados pelos cenários de escrita dupla.
+     */
+    private void insertLegacyUrlAndJob(String jobStatus) {
+        jdbcTemplate.update("""
+                INSERT INTO mois_sales_library_url_ingest
+                (id, workspace_id, source, url_original, url_canonical, title, ingest_count, first_captured_at, last_captured_at, created_at, updated_at)
+                VALUES (1, 'workspace-001', 'HOTMART', 'https://offer.test/', 'https://offer.test/', 'Oferta', 1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+                """);
+        jdbcTemplate.update("""
+                INSERT INTO mois_sales_library_processing_job
+                (id, url_ingest_id, status, attempts, created_at, updated_at, started_at, finished_at)
+                VALUES (10, 1, ?, 1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+                """, jobStatus);
+    }
+
+    /**
+     * Cria as tabelas mínimas acessadas pelos SQLs de escrita dupla.
+     */
+    private void createSchema() {
+        jdbcTemplate.execute("DROP TABLE IF EXISTS mois_sales_page_job_execution");
+        jdbcTemplate.execute("DROP TABLE IF EXISTS mois_sales_page");
+        jdbcTemplate.execute("DROP TABLE IF EXISTS mois_sales_library_snapshot_artifact");
+        jdbcTemplate.execute("DROP TABLE IF EXISTS mois_sales_library_page_snapshot");
+        jdbcTemplate.execute("DROP TABLE IF EXISTS mois_sales_library_page_analysis");
+        jdbcTemplate.execute("DROP TABLE IF EXISTS mois_sales_library_processing_job");
+        jdbcTemplate.execute("DROP TABLE IF EXISTS mois_sales_library_url_ingest");
+        jdbcTemplate.execute("DROP TABLE IF EXISTS mois_collected_reference_html_capture");
+        jdbcTemplate.execute("DROP TABLE IF EXISTS mois_collected_reference");
+        jdbcTemplate.execute("""
+                CREATE TABLE mois_sales_library_url_ingest (
+                  id BIGINT PRIMARY KEY,
+                  workspace_id VARCHAR(120), source VARCHAR(40), url_original VARCHAR(1024), url_canonical VARCHAR(1024), title VARCHAR(512),
+                  first_captured_at TIMESTAMP, last_captured_at TIMESTAMP, ingest_count INT, created_at TIMESTAMP, updated_at TIMESTAMP
+                )
+                """);
+        jdbcTemplate.execute("""
+                CREATE TABLE mois_sales_library_processing_job (
+                  id BIGINT PRIMARY KEY, url_ingest_id BIGINT, status VARCHAR(40), attempts INT, error_category VARCHAR(120), error_message VARCHAR(1000),
+                  next_retry_at TIMESTAMP, created_at TIMESTAMP, updated_at TIMESTAMP, started_at TIMESTAMP, finished_at TIMESTAMP
+                )
+                """);
+        jdbcTemplate.execute("""
+                CREATE TABLE mois_sales_library_page_analysis (
+                  id BIGINT PRIMARY KEY, url_ingest_id BIGINT, job_id BIGINT, status VARCHAR(40), score_total DECIMAL(6,2), parser_version VARCHAR(40),
+                  prompt_version VARCHAR(40), model_name VARCHAR(120), sections_json LONGTEXT, copy_json LONGTEXT, visual_json LONGTEXT, image_json LONGTEXT,
+                  analysis_notes VARCHAR(1000), request_payload_json LONGTEXT, analyzed_at TIMESTAMP, created_at TIMESTAMP, updated_at TIMESTAMP
+                )
+                """);
+        jdbcTemplate.execute("""
+                CREATE TABLE mois_sales_library_page_snapshot (
+                  id BIGINT PRIMARY KEY, url_ingest_id BIGINT, snapshot_hash VARCHAR(64), status VARCHAR(40), http_status INT, content_type VARCHAR(255),
+                  redirect_destination_url VARCHAR(1024), redirect_root_url VARCHAR(1024), error_message VARCHAR(1000), captured_at TIMESTAMP,
+                  created_at TIMESTAMP, updated_at TIMESTAMP
+                )
+                """);
+        jdbcTemplate.execute("""
+                CREATE TABLE mois_sales_library_snapshot_artifact (
+                  id BIGINT PRIMARY KEY, snapshot_id BIGINT, artifact_type VARCHAR(40), content_type VARCHAR(255), storage_kind VARCHAR(40),
+                  content_text LONGTEXT, content_blob LONGBLOB, size_bytes BIGINT, created_at TIMESTAMP
+                )
+                """);
+        jdbcTemplate.execute("""
+                CREATE TABLE mois_collected_reference (
+                  id BIGINT PRIMARY KEY, workspace_id VARCHAR(120), source VARCHAR(40), job_id VARCHAR(120), reference_id VARCHAR(120), title VARCHAR(512),
+                  product_name VARCHAR(512), url VARCHAR(1024), product_url VARCHAR(1024), sales_page_url VARCHAR(1024), collected_at TIMESTAMP, updated_at TIMESTAMP
+                )
+                """);
+        jdbcTemplate.execute("""
+                CREATE TABLE mois_collected_reference_html_capture (
+                  id BIGINT PRIMARY KEY, collected_reference_id BIGINT, workspace_id VARCHAR(120), source VARCHAR(40), collection_job_id VARCHAR(120),
+                  reference_id VARCHAR(120), title VARCHAR(512), url_source VARCHAR(40), url_original VARCHAR(1024), url_final VARCHAR(1024), status VARCHAR(40),
+                  claimed_by VARCHAR(120), claimed_at TIMESTAMP, http_status INT, content_type VARCHAR(255), raw_html LONGTEXT, raw_html_sha256 VARCHAR(64),
+                  raw_html_bytes BIGINT, error_message VARCHAR(1000), fetched_at TIMESTAMP, created_at TIMESTAMP, updated_at TIMESTAMP
+                )
+                """);
+        jdbcTemplate.execute("""
+                CREATE TABLE mois_sales_page (
+                  id BIGINT AUTO_INCREMENT PRIMARY KEY, workspace_id VARCHAR(120), source VARCHAR(40), source_job_id VARCHAR(120), source_reference_id VARCHAR(120),
+                  collected_reference_id BIGINT, product_name VARCHAR(512), title VARCHAR(512), url_original VARCHAR(1024), url_canonical VARCHAR(1024),
+                  sales_page_url VARCHAR(1024), product_url VARCHAR(1024), url_final VARCHAR(1024), redirect_root_url VARCHAR(1024), current_stage VARCHAR(40),
+                  current_status VARCHAR(40), capture_status VARCHAR(40), analysis_status VARCHAR(40), http_status INT, content_type VARCHAR(255),
+                  html_sha256 VARCHAR(64), html_bytes BIGINT, score_total DECIMAL(6,2), offer_summary VARCHAR(1000), mechanism_summary VARCHAR(1000),
+                  promise_summary VARCHAR(1000), proof_summary VARCHAR(1000), last_error_category VARCHAR(120), last_error_message VARCHAR(1000),
+                  last_job_execution_id BIGINT, ingest_count INT, first_seen_at TIMESTAMP, last_collected_at TIMESTAMP, last_captured_at TIMESTAMP,
+                  last_analyzed_at TIMESTAMP, created_at TIMESTAMP, updated_at TIMESTAMP, UNIQUE (workspace_id, url_canonical)
+                )
+                """);
+        jdbcTemplate.execute("""
+                CREATE TABLE mois_sales_page_job_execution (
+                  id BIGINT AUTO_INCREMENT PRIMARY KEY, sales_page_id BIGINT, workspace_id VARCHAR(120), job_type VARCHAR(40), stage VARCHAR(40), status VARCHAR(40),
+                  attempt INT, claimed_by VARCHAR(120), input_url VARCHAR(1024), final_url VARCHAR(1024), redirect_root_url VARCHAR(1024), http_status INT,
+                  content_type VARCHAR(255), raw_html LONGTEXT, raw_html_sha256 VARCHAR(64), raw_html_bytes BIGINT, screenshot_blob LONGBLOB, screenshot_bytes BIGINT,
+                  score_total DECIMAL(6,2), sections_json LONGTEXT, copy_json LONGTEXT, visual_json LONGTEXT, image_json LONGTEXT, request_payload_json LONGTEXT,
+                  response_payload_json LONGTEXT, error_category VARCHAR(120), error_message VARCHAR(1000), started_at TIMESTAMP, finished_at TIMESTAMP,
+                  created_at TIMESTAMP, updated_at TIMESTAMP
+                )
+                """);
+    }
+
+    /**
+     * Fornece timestamp UTC compatível com a função usada nos SQLs MySQL dos testes.
+     */
+    public static Timestamp utcTimestamp() {
+        return Timestamp.from(Instant.now());
+    }
+}

--- a/docs/registros/mois1.md
+++ b/docs/registros/mois1.md
@@ -905,3 +905,19 @@ Arquivos alterados:
 - `backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesPageBackfillServiceTest.java`
 - `backend/ads-service/src/main/resources/application.properties`
 - `docs/registros/mois1.md`
+
+## 2026-06-04 — Fase 3 do pipeline de páginas de vendas em duas tabelas
+- implementada escrita dupla temporária para manter o modelo legado da Biblioteca de Páginas de Vendas e o modelo consolidado `mois_sales_page`/`mois_sales_page_job_execution` sincronizados durante a transição.
+- a ingestão de URLs agora espelha inserções e atualizações em `mois_sales_page`, criando execução consolidada do job pendente quando uma página nova gera processamento.
+- alterações de job/análise (`FETCHING`, `DONE`, `FAILED`, reanálise e atualização manual de status) passam a registrar execuções no modelo novo e recalcular o estado atual consolidado da página.
+- capturas de HTML/snapshots e capturas brutas vinculadas a referências coletadas passam a registrar histórico em `mois_sales_page_job_execution` e atualizar o estado atual de captura em `mois_sales_page`.
+- adicionados logs de divergência para sinalizar quando estágio/status calculados a partir do legado não batem com o estado gravado no modelo novo.
+
+Arquivos alterados:
+- `backend/ads-service/src/main/java/com/marketinghub/repository/jpa/mois/bibliotecapaginavenda/worker/v1/MoisSalesPageDualWriteGateway.java`
+- `backend/ads-service/src/main/java/com/marketinghub/repository/jpa/mois/bibliotecapaginavenda/worker/v1/MoisSalesPageDualWriteRepository.java`
+- `backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryService.java`
+- `backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibrarySnapshotService.java`
+- `backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibrarySnapshotServiceTest.java`
+- `backend/ads-service/src/test/java/com/marketinghub/repository/jpa/mois/bibliotecapaginavenda/worker/v1/MoisSalesPageDualWriteRepositoryTest.java`
+- `docs/registros/mois1.md`


### PR DESCRIPTION
### Motivation

- Introduce a temporary dual-write/synchronization layer to keep the legacy MOIS library pipeline compatible while populating and exercising the new consolidated `mois_sales_page` / `mois_sales_page_job_execution` model during the migration phase.

### Description

- Added `MoisSalesPageDualWriteGateway` interface and `MoisSalesPageDualWriteRepository` implementation that perform idempotent SQL to mirror legacy rows into `mois_sales_page` and insert corresponding audit events into `mois_sales_page_job_execution` (processing jobs, page analysis, snapshots and collected reference captures). 
- Wired `MoisSalesPageDualWriteGateway` into the legacy services by injecting `dualWriteGateway` into `MoisSalesLibraryService` and `MoisSalesLibrarySnapshotService` and calling it at key points (`syncUrlIngest`, `syncProcessingJob`, `syncLatestAnalysis`, `syncSnapshot`, `syncCollectedReferenceHtmlCapture`) for ingest, job lifecycle, analysis completion/failure, snapshot capture and collected-reference capture flows. 
- Implemented SQL routines in the repository to compute consolidated state from legacy tables, insert execution events, update `last_job_execution_id`, and log divergence when legacy and consolidated states differ. Added small helpers: `findUrlIngestIdByCanonical` and `syncSnapshotWhenPresent`.
- Updated snapshot unit test to provide a `NoOpDualWriteGateway` and added `MoisSalesPageDualWriteRepositoryTest` exercising the dual-write behavior against an H2 (MySQL mode) in-memory schema.

### Testing

- Ran `MoisSalesLibrarySnapshotServiceTest` after adapting it to use a `NoOpDualWriteGateway` and it passed in the H2 environment used by the test harness.
- Added and ran `MoisSalesPageDualWriteRepositoryTest` against H2 (MySQL mode) covering `syncUrlIngest`, `syncLatestAnalysis`, and `syncSnapshot` scenarios and the tests passed.
- All new and modified unit tests executed in the local CI-like H2 environment and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a21465c629483218079eb3dcbea6249)