### PR TITLE
Corrige testes da biblioteca MOIS: injeta gateway de escrita dupla e ajusta stubs JdbcTemplate

### DIFF
--- a/backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryServiceTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 import com.marketinghub.mois.bibliotecapaginavenda.worker.v1.dto.MoisSalesLibraryDtos;
+import com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1.MoisSalesPageDualWriteGateway;
 import java.sql.ResultSet;
 import java.sql.Timestamp;
 import java.time.Instant;
@@ -31,6 +32,9 @@ class MoisSalesLibraryServiceTest {
     @Mock
     private JdbcTemplate jdbcTemplate;
 
+    @Mock
+    private MoisSalesPageDualWriteGateway dualWriteGateway;
+
     @InjectMocks
     private MoisSalesLibraryService service;
 
@@ -47,7 +51,7 @@ class MoisSalesLibraryServiceTest {
 
         given(jdbcTemplate.update(contains("INSERT INTO mois_sales_library_url_ingest"), any(), any(), any(), any(), any(), any(), any()))
                 .willReturn(1);
-        given(jdbcTemplate.queryForObject(anyString(), eq(Long.class), any())).willReturn(99L);
+        given(jdbcTemplate.queryForObject(anyString(), eq(Long.class), any(), any())).willReturn(99L);
 
         service.ingestUrls(request);
 
@@ -95,7 +99,7 @@ class MoisSalesLibraryServiceTest {
                 });
         given(jdbcTemplate.update(contains("INSERT INTO mois_sales_library_url_ingest"), any(), any(), any(), any(), any(), any(), any()))
                 .willReturn(1, 2);
-        given(jdbcTemplate.queryForObject(contains("SELECT id"), eq(Long.class), any())).willReturn(77L);
+        given(jdbcTemplate.queryForObject(contains("SELECT id"), eq(Long.class), any(), any())).willReturn(77L);
 
         MoisSalesLibraryDtos.SalesLibraryHotmartCollectedIngestResponse response =
                 service.ingestHotmartCollectedProducts(request);

--- a/docs/registros/mois1.md
+++ b/docs/registros/mois1.md
@@ -921,3 +921,12 @@ Arquivos alterados:
 - `backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibrarySnapshotServiceTest.java`
 - `backend/ads-service/src/test/java/com/marketinghub/repository/jpa/mois/bibliotecapaginavenda/worker/v1/MoisSalesPageDualWriteRepositoryTest.java`
 - `docs/registros/mois1.md`
+
+## 2026-06-04 — Correção dos testes da escrita dupla da Biblioteca de Páginas de Vendas
+- corrigidos os testes unitários de `MoisSalesLibraryServiceTest` para injetar o gateway de escrita dupla usado pela Fase 3 do pipeline, eliminando `NullPointerException` nos fluxos que sincronizam capturas HTML coletadas.
+- ajustados os stubs Mockito de `JdbcTemplate.queryForObject` para refletirem os dois parâmetros reais enviados pela busca de URL canônica (`workspace_id` e `url_canonical`), eliminando falsos erros de `PotentialStubbingProblem` em modo strict.
+- verificado o teste unitário específico da Biblioteca de Páginas de Vendas e a suíte unitária completa do `ads-service` após a correção.
+
+Arquivos alterados:
+- `backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryServiceTest.java`
+- `docs/registros/mois1.md`


### PR DESCRIPTION
### Motivation
- Tests in `MoisSalesLibraryServiceTest` were failing with a `NullPointerException` and `PotentialStubbingProblem` because the new dual-write gateway used by the service was not mocked in the test and Mockito stubs had the wrong `queryForObject` signature. 

### Description
- Add a `@Mock` for `MoisSalesPageDualWriteGateway` and let Mockito inject it into `MoisSalesLibraryServiceTest` so calls like `dualWriteGateway.syncCollectedReferenceHtmlCapture(...)` do not NPE. 
- Update Mockito stubs for `JdbcTemplate.queryForObject` to match the actual call sites that pass two bind parameters (`workspace_id` and `url_canonical`) by changing calls from three-arg stubs to the correct four-arg form. 
- Document the change in `docs/registros/mois1.md` describing the root cause and the verification performed.

### Testing
- Ran `../mvnw -Dtest=MoisSalesLibraryServiceTest test` and the specific test class passed. 
- Ran the full `../mvnw test` for the `ads-service` module and the test suite completed successfully (build success).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a214e8fd13083218e67d7f09af4fe3e)