### PR TITLE
Auto start Gera Copy after WireFrame

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/service/BackendWireframeService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/service/BackendWireframeService.java
@@ -33,6 +33,7 @@ public class BackendWireframeService {
     private static final Logger log = LoggerFactory.getLogger(BackendWireframeService.class);
     private static final TypeReference<LinkedHashMap<String, Object>> FRAMEWORK_TYPE = new TypeReference<>() {};
     private static final String STAGE_CODE = "landing-page-wireframe";
+    private static final String NEXT_STAGE_COPY = "landing-page-copy";
     private static final String STATUS_STARTED = "INICIADO";
     private static final String STATUS_WAITING_OPENAI_DISPATCH = "AGUARDANDO_RETORNO_OPENAI";
     private static final String STATUS_COMPLETED = "CONCLUIDO";
@@ -215,6 +216,24 @@ public class BackendWireframeService {
         }
         experiment.setLandingPageWireframe(modelResponse);
         experimentRepository.save(experiment);
+        createCopyExecution(experiment);
+    }
+
+    /** Agenda o Gera Copy como próxima etapa automática após salvar o wireframe da landing. */
+    private void createCopyExecution(Experiment experiment) {
+        Instant now = Instant.now();
+        GeraLandingStageExecution copyExecution = GeraLandingStageExecution.builder()
+                .experimentId(experiment.getId())
+                .experiment(experiment)
+                .stageCode(NEXT_STAGE_COPY)
+                .executionRequestedAt(now)
+                .createdAt(now)
+                .promptTemplateId("auto/wireframe")
+                .promptContent("Gera Copy iniciado automaticamente após o Gera WireFrame.")
+                .status(STATUS_STARTED)
+                .idJob(toDatabaseIdJob(UUID.randomUUID().toString()))
+                .build();
+        executionRepository.save(copyExecution);
     }
 
     /** Converte o experimento da execução para os dados expostos na fila pending. */

--- a/backend/ads-service/src/test/java/com/marketinghub/geralanding/wireframe/service/BackendWireframeServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/geralanding/wireframe/service/BackendWireframeServiceTest.java
@@ -176,7 +176,7 @@ class BackendWireframeServiceTest {
         verify(executionRepository).save(execution);
     }
 
-    /** Deve concluir a execução e gravar o artefato wireframe recebido do Worker AI. */
+    /** Deve concluir a execução, gravar o wireframe e agendar o Gera Copy automático. */
     @Test
     void markCompletedFromResponseShouldPersistExecutionAndExperimentArtifact() {
         ExperimentRepository experimentRepository = mock(ExperimentRepository.class);
@@ -184,6 +184,7 @@ class BackendWireframeServiceTest {
         BackendWireframeService service =
                 new BackendWireframeService(experimentRepository, executionRepository, new ObjectMapper());
         Experiment experiment = mock(Experiment.class);
+        when(experiment.getId()).thenReturn(88L);
         GeraLandingStageExecution execution = GeraLandingStageExecution.builder()
                 .experimentId(88L)
                 .experiment(experiment)
@@ -218,6 +219,16 @@ class BackendWireframeServiceTest {
         verify(experiment).setLandingPageWireframe(modelResponse);
         verify(experimentRepository).save(experiment);
         verify(experimentRepository, never()).findById(88L);
+        verify(executionRepository).save(argThat(nextExecution ->
+                nextExecution.getExperimentId().equals(88L)
+                        && nextExecution.getExperiment() == experiment
+                        && nextExecution.getStageCode().equals("landing-page-copy")
+                        && nextExecution.getStatus().equals("INICIADO")
+                        && nextExecution.getPromptTemplateId().equals("auto/wireframe")
+                        && nextExecution.getPromptContent().equals("Gera Copy iniciado automaticamente após o Gera WireFrame.")
+                        && nextExecution.getExecutionRequestedAt() != null
+                        && nextExecution.getCreatedAt() != null
+                        && nextExecution.getIdJob() != null));
     }
 
     /** Deve marcar a execução como falha sem gravar artefato quando o Worker AI retorna erro. */

--- a/docs/canonical/geralanding-arquitetura-canon.v1.md
+++ b/docs/canonical/geralanding-arquitetura-canon.v1.md
@@ -100,7 +100,7 @@ Regras arquiteturais refletidas (ArchUnit):
 
 ## 4) Regras de integração
 
-- A progressão automática do backend deve preservar o encadeamento operacional do GeraLanding: ao concluir com sucesso `landing-page-copy`, o backend enfileira automaticamente `landing-page-image-planning`; ao concluir com sucesso `landing-page-image-planning`, o backend enfileira automaticamente `landing-page-image-generation`. Falhas ou callbacks com erro não devem iniciar a próxima etapa.
+- A progressão automática do backend deve preservar o encadeamento operacional do GeraLanding: ao concluir com sucesso `landing-page-wireframe`, o backend enfileira automaticamente `landing-page-copy`; ao concluir com sucesso `landing-page-copy`, o backend enfileira automaticamente `landing-page-image-planning`; ao concluir com sucesso `landing-page-image-planning`, o backend enfileira automaticamente `landing-page-image-generation`. Falhas ou callbacks com erro não devem iniciar a próxima etapa.
 - O **Worker AI não acessa banco**; toda leitura/gravação de estado da execução passa pelo backend GeraLanding.
 - O polling e os callbacks internos consumidos pelo Worker AI devem usar adapters específicos por etapa dentro de `openai.core.<etapa>`; cada adapter chama somente os endpoints HTTP do backend correspondentes à sua etapa.
 - Ajustes no Worker AI não devem criar controller interno genérico no backend para atender todas as etapas do GeraLanding.

--- a/docs/canonical/procedimento-experimento-canon.v1.md
+++ b/docs/canonical/procedimento-experimento-canon.v1.md
@@ -48,7 +48,7 @@ Local canônico vigente:
 ## 5. Pipeline Gera Landing (núcleo da landing)
 
 No fluxo atual, a geração da landing segue as etapas:
-1. gerar wireframe (`LANDING_PAGE_WIREFRAME`);
+1. gerar wireframe (`LANDING_PAGE_WIREFRAME`), que deve enfileirar automaticamente o Gera Copy após conclusão bem-sucedida;
 2. gerar copy (`LANDING_PAGE_COPY`);
 3. gerar planejamento/prompt de imagens (`LANDING_PAGE_IMAGE_PLANNING`), que deve enfileirar automaticamente o Gera Imagem após conclusão bem-sucedida;
 4. gerar imagens (`LANDING_PAGE_IMAGE_GENERATION`), materializando `experiment.landing_page_image_assets` com as URLs finais;
@@ -56,7 +56,7 @@ No fluxo atual, a geração da landing segue as etapas:
 6. gerar entregável HTML da landing (`LANDING_PAGE_HTML`).
 
 ### 5.1 Observação obrigatória — HTML provisório por etapa
-Durante o pipeline de Gera Landing, existe produção incremental/provisória de conteúdo para permitir evolução etapa a etapa. No estágio de design preset é consolidada a base visual e ocorre a etapa usada para ingestão do pixel no fluxo atual. Ao concluir o Gera Prompt Imagem com sucesso e persistir `experiment.landing_page_image_planning`, o backend deve criar automaticamente uma execução `landing-page-image-generation` com `promptTemplateId` operacional `auto/image-planning`. Ao concluir o Gera Imagem com sucesso e persistir `experiment.landing_page_image_assets`, o backend deve criar automaticamente uma execução `landing-page-design-preset` com `promptTemplateId` operacional `auto/image-generation`, mantendo a continuidade do fluxo sem exigir novo clique do usuário.
+Durante o pipeline de Gera Landing, existe produção incremental/provisória de conteúdo para permitir evolução etapa a etapa. No estágio de design preset é consolidada a base visual e ocorre a etapa usada para ingestão do pixel no fluxo atual. Ao concluir o Gera WireFrame com sucesso e persistir `experiment.landing_page_wireframe`, o backend deve criar automaticamente uma execução `landing-page-copy` com `promptTemplateId` operacional `auto/wireframe`. Ao concluir o Gera Prompt Imagem com sucesso e persistir `experiment.landing_page_image_planning`, o backend deve criar automaticamente uma execução `landing-page-image-generation` com `promptTemplateId` operacional `auto/image-planning`. Ao concluir o Gera Imagem com sucesso e persistir `experiment.landing_page_image_assets`, o backend deve criar automaticamente uma execução `landing-page-design-preset` com `promptTemplateId` operacional `auto/image-generation`, mantendo a continuidade do fluxo sem exigir novo clique do usuário.
 
 ### 5.2 Instrumentação obrigatória de funil no assembler do design preset
 Para a etapa `LANDING_PAGE_DESIGN_PRESET`, o assembler de HTML provisório deve injetar instrumentação mínima de comportamento para diagnóstico de avanço de funil na landing:

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -3360,3 +3360,10 @@
 - causa-raiz/objetivo: permitir que o Quality Review diferencie sintoma visual renderizado de problema de origem no wireframe, no preset de design ou na montagem HTML, recomendando regeneração da etapa correta.
 - correção aplicada: o Worker AI passou a montar o contexto textual da revisão com os artefatos fonte e o prompt foi atualizado para pedir análise de causa-raiz por arquivo/etapa, mantendo screenshots renderizados como evidência visual.
 - cânone atualizado: `docs/canonical/geralanding-arquitetura-canon.v1.md`.
+## 2026-06-04 — Disparo automático do Gera Copy após WireFrame
+
+- solicitação: no pipeline do GeraLanding, disparar automaticamente a etapa `landing-page-copy` ao final bem-sucedido do Gera WireFrame, seguindo o padrão já usado no fim do Gera Preset Design para iniciar o Quality Review.
+- causa-raiz/objetivo: a criação da landing ainda tinha uma interrupção manual entre estrutura e copy, reduzindo fluidez operacional e atrasando a sequência que leva à oferta publicável.
+- correção aplicada: a conclusão sem erro da etapa `landing-page-wireframe` agora persiste `experiment.landing_page_wireframe` e cria uma execução `landing-page-copy` com `promptTemplateId` `auto/wireframe`, `status` `INICIADO` e novo `idJob`.
+- cânones atualizados: `docs/canonical/procedimento-experimento-canon.v1.md` e `docs/canonical/geralanding-arquitetura-canon.v1.md` passaram a declarar o encadeamento automático WireFrame → Copy.
+- validação automatizada: teste unitário do `BackendWireframeService` atualizado para garantir criação da próxima execução automática somente no caminho de sucesso.


### PR DESCRIPTION
### Motivation
- Remove an operational gap in the GeraLanding pipeline by making the system automatically continue from `landing-page-wireframe` to `landing-page-copy` when the wireframe completes successfully.

### Description
- Added automatic scheduling in `BackendWireframeService` by introducing `NEXT_STAGE_COPY` and a new `createCopyExecution(Experiment)` method that creates a `GeraLandingStageExecution` with `promptTemplateId = "auto/wireframe"` and `status = "INICIADO"` after persisting the wireframe artifact in `persistWireframeArtifactOnExperiment`.
- Updated the wireframe unit test `BackendWireframeServiceTest` to assert the new automatic `landing-page-copy` execution metadata is created on successful completion.
- Synchronized canonical documentation to reflect the new progression rule WireFrame → Copy in `docs/canonical/procedimento-experimento-canon.v1.md` and `docs/canonical/geralanding-arquitetura-canon.v1.md`, and logged the change in `docs/registros/experimentos.md`.
- Key files changed: `backend/ads-service/src/main/java/com/marketinghub/geralanding/wireframe/service/BackendWireframeService.java`, `backend/ads-service/src/test/java/com/marketinghub/geralanding/wireframe/service/BackendWireframeServiceTest.java`, `docs/canonical/procedimento-experimento-canon.v1.md`, `docs/canonical/geralanding-arquitetura-canon.v1.md`, and `docs/registros/experimentos.md`.

### Testing
- Ran the wireframe unit test class with `../mvnw -Dtest=com.marketinghub.geralanding.wireframe.service.BackendWireframeServiceTest test` and the test class completed successfully (6 tests run, 0 failures). 
- During iteration there were transient execution attempts with different Maven wrapper invocations that failed due to runner/project selection issues, which were tooling invocations and not test regressions; those were resolved and the final unit test run passed. 
- Ran `git diff --check` to ensure no obvious whitespace/git-diff issues remain and it returned clean results.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a21989f10688321b264684a1c7e6a0c)