### PR TITLE
Migrate sales library read model to consolidated `mois_sales_page`; add summary and executions API and UI support

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/dto/MoisSalesLibraryDtos.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/dto/MoisSalesLibraryDtos.java
@@ -193,15 +193,78 @@ public final class MoisSalesLibraryDtos {
     ) {
     }
 
+    /**
+     * Representa o estado atual consolidado de uma página de venda no modelo novo.
+     */
     public record SalesLibraryPageResponse(
             long pageId,
             String workspaceId,
             String source,
             String urlCanonical,
             String title,
+            String currentStage,
+            String currentStatus,
+            String captureStatus,
             String analysisStatus,
+            String urlFinal,
+            Integer httpStatus,
+            String htmlSha256,
+            long htmlBytes,
             BigDecimal scoreTotal,
+            String offerSummary,
+            String mechanismSummary,
+            String promiseSummary,
+            String proofSummary,
+            String lastErrorCategory,
+            String lastErrorMessage,
+            Long lastJobExecutionId,
+            Instant lastCapturedAt,
             Instant analyzedAt,
+            Instant updatedAt
+    ) {
+    }
+
+    /**
+     * Representa os contadores globais consolidados da Biblioteca de Páginas de Vendas.
+     */
+    public record SalesLibraryPageSummaryResponse(
+            String workspaceId,
+            long total,
+            long pending,
+            long capturing,
+            long captured,
+            long analyzed,
+            long failed,
+            long blockedCooldown,
+            long hotmart,
+            long clickbank,
+            Instant updatedAt
+    ) {
+    }
+
+    /**
+     * Representa uma execução auditável da página no histórico consolidado.
+     */
+    public record SalesLibraryPageExecutionResponse(
+            long executionId,
+            long pageId,
+            String jobType,
+            String stage,
+            String status,
+            int attempt,
+            String inputUrl,
+            String finalUrl,
+            String redirectRootUrl,
+            Integer httpStatus,
+            String contentType,
+            long rawHtmlBytes,
+            long screenshotBytes,
+            BigDecimal scoreTotal,
+            String errorCategory,
+            String errorMessage,
+            Instant startedAt,
+            Instant finishedAt,
+            Instant createdAt,
             Instant updatedAt
     ) {
     }

--- a/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryService.java
@@ -332,67 +332,105 @@ public class MoisSalesLibraryService {
     }
 
     /**
-     * Lista páginas canônicas da biblioteca junto com a análise mais recente.
+     * Lista páginas canônicas a partir do estado consolidado do modelo novo da Fase 4.
      */
     public MoisSalesLibraryDtos.SalesLibraryPageListResponse listPages(String workspaceId, int page, int pageSize) {
-        int normalizedPage = Math.max(1, page); int normalizedPageSize = Math.max(1, Math.min(pageSize, 100)); int offset = (normalizedPage - 1) * normalizedPageSize;
-        Long total = jdbcTemplate.queryForObject("SELECT COUNT(*) FROM mois_sales_library_url_ingest WHERE workspace_id = ?", Long.class, workspaceId);
+        int normalizedPage = Math.max(1, page);
+        int normalizedPageSize = Math.max(1, Math.min(pageSize, 100));
+        int offset = (normalizedPage - 1) * normalizedPageSize;
+        Long total = jdbcTemplate.queryForObject("SELECT COUNT(*) FROM mois_sales_page WHERE workspace_id = ?", Long.class, workspaceId);
         List<MoisSalesLibraryDtos.SalesLibraryPageResponse> items = jdbcTemplate.query("""
-                SELECT i.id, i.workspace_id, i.source, i.url_canonical, i.title, i.updated_at,
-                       a.status AS analysis_status, a.score_total, a.analyzed_at
-                FROM mois_sales_library_url_ingest i
-                LEFT JOIN mois_sales_library_page_analysis a ON a.id = (
-                    SELECT a2.id FROM mois_sales_library_page_analysis a2
-                    WHERE a2.url_ingest_id = i.id ORDER BY a2.updated_at DESC LIMIT 1
-                )
-                WHERE i.workspace_id = ?
-                ORDER BY i.updated_at DESC LIMIT ? OFFSET ?
-                """, (rs, rn) -> new MoisSalesLibraryDtos.SalesLibraryPageResponse(
-                rs.getLong("id"), rs.getString("workspace_id"), rs.getString("source"), rs.getString("url_canonical"),
-                rs.getString("title"), rs.getString("analysis_status"), rs.getBigDecimal("score_total"),
-                toInstant(rs.getTimestamp("analyzed_at")), toInstant(rs.getTimestamp("updated_at"))), workspaceId, normalizedPageSize, offset);
+                SELECT id, workspace_id, source, url_canonical, title, current_stage, current_status, capture_status,
+                       COALESCE(analysis_status, current_status) AS analysis_status, url_final, http_status, html_sha256,
+                       html_bytes, score_total, offer_summary, mechanism_summary, promise_summary, proof_summary,
+                       last_error_category, last_error_message, last_job_execution_id, last_captured_at, last_analyzed_at, updated_at
+                FROM mois_sales_page
+                WHERE workspace_id = ?
+                ORDER BY updated_at DESC, id DESC LIMIT ? OFFSET ?
+                """, this::mapSalesPageResponse, workspaceId, normalizedPageSize, offset);
         return new MoisSalesLibraryDtos.SalesLibraryPageListResponse(normalizedPage, normalizedPageSize, total == null ? 0 : total, items);
     }
 
     /**
-     * Busca uma página canônica da biblioteca pelo identificador interno.
+     * Calcula os contadores globais da biblioteca diretamente em mois_sales_page para eliminar paginação ambígua.
+     */
+    public MoisSalesLibraryDtos.SalesLibraryPageSummaryResponse summarizePages(String workspaceId) {
+        return jdbcTemplate.queryForObject("""
+                SELECT COUNT(*) AS total,
+                       SUM(current_status = 'PENDING') AS pending,
+                       SUM(current_status IN ('FETCHING', 'CAPTURING')) AS capturing,
+                       SUM(current_status IN ('CAPTURED', 'DUPLICATE')) AS captured,
+                       SUM(current_status IN ('DONE', 'ANALYZED')) AS analyzed,
+                       SUM(current_status = 'FAILED') AS failed,
+                       SUM(current_status = 'BLOCKED_COOLDOWN') AS blocked_cooldown,
+                       SUM(source = 'HOTMART') AS hotmart,
+                       SUM(source = 'CLICKBANK') AS clickbank,
+                       MAX(updated_at) AS updated_at
+                FROM mois_sales_page
+                WHERE workspace_id = ?
+                """, (rs, rn) -> new MoisSalesLibraryDtos.SalesLibraryPageSummaryResponse(
+                workspaceId, rs.getLong("total"), rs.getLong("pending"), rs.getLong("capturing"),
+                rs.getLong("captured"), rs.getLong("analyzed"), rs.getLong("failed"),
+                rs.getLong("blocked_cooldown"), rs.getLong("hotmart"), rs.getLong("clickbank"),
+                toInstant(rs.getTimestamp("updated_at"))), workspaceId);
+    }
+
+    /**
+     * Busca uma página canônica pelo identificador consolidado em mois_sales_page.
      */
     public MoisSalesLibraryDtos.SalesLibraryPageResponse getPage(long pageId) {
         List<MoisSalesLibraryDtos.SalesLibraryPageResponse> rows = jdbcTemplate.query("""
-                SELECT i.id, i.workspace_id, i.source, i.url_canonical, i.title, i.updated_at,
-                       a.status AS analysis_status, a.score_total, a.analyzed_at
-                FROM mois_sales_library_url_ingest i
-                LEFT JOIN mois_sales_library_page_analysis a ON a.id = (
-                    SELECT a2.id FROM mois_sales_library_page_analysis a2
-                    WHERE a2.url_ingest_id = i.id ORDER BY a2.updated_at DESC LIMIT 1
-                )
-                WHERE i.id = ? LIMIT 1
-                """, (rs, rn) -> new MoisSalesLibraryDtos.SalesLibraryPageResponse(
-                rs.getLong("id"), rs.getString("workspace_id"), rs.getString("source"), rs.getString("url_canonical"),
-                rs.getString("title"), rs.getString("analysis_status"), rs.getBigDecimal("score_total"),
-                toInstant(rs.getTimestamp("analyzed_at")), toInstant(rs.getTimestamp("updated_at"))), pageId);
+                SELECT id, workspace_id, source, url_canonical, title, current_stage, current_status, capture_status,
+                       COALESCE(analysis_status, current_status) AS analysis_status, url_final, http_status, html_sha256,
+                       html_bytes, score_total, offer_summary, mechanism_summary, promise_summary, proof_summary,
+                       last_error_category, last_error_message, last_job_execution_id, last_captured_at, last_analyzed_at, updated_at
+                FROM mois_sales_page
+                WHERE id = ? LIMIT 1
+                """, this::mapSalesPageResponse, pageId);
         if (rows.isEmpty()) throw new IllegalArgumentException("Page not found: " + pageId);
         return rows.get(0);
     }
 
     /**
-     * Busca a análise mais recente de uma página da biblioteca.
+     * Busca a análise mais recente registrada no histórico consolidado da página.
      */
     public MoisSalesLibraryDtos.SalesLibraryPageAnalysisResponse getPageAnalysis(long pageId) {
         List<MoisSalesLibraryDtos.SalesLibraryPageAnalysisResponse> rows = jdbcTemplate.query("""
-                SELECT a.id, a.url_ingest_id, a.job_id, a.status, a.score_total, a.parser_version,
-                       a.prompt_version, a.model_name, a.sections_json, a.copy_json, a.visual_json,
-                       a.image_json, a.analysis_notes, a.request_payload_json, a.analyzed_at, a.updated_at
-                FROM mois_sales_library_page_analysis a
-                WHERE a.url_ingest_id = ? ORDER BY a.updated_at DESC LIMIT 1
+                SELECT e.id, e.sales_page_id, e.status, e.score_total, e.sections_json, e.copy_json, e.visual_json,
+                       e.image_json, e.request_payload_json, e.error_message, e.finished_at, e.updated_at
+                FROM mois_sales_page_job_execution e
+                WHERE e.sales_page_id = ? AND e.job_type = 'PAGE_ANALYSIS'
+                ORDER BY e.updated_at DESC, e.id DESC LIMIT 1
                 """, (rs, rn) -> new MoisSalesLibraryDtos.SalesLibraryPageAnalysisResponse(
-                rs.getLong("id"), rs.getLong("url_ingest_id"), rs.getObject("job_id", Long.class),
-                rs.getString("status"), rs.getBigDecimal("score_total"), rs.getString("parser_version"),
-                rs.getString("prompt_version"), rs.getString("model_name"), rs.getString("sections_json"),
+                rs.getLong("id"), rs.getLong("sales_page_id"), null, rs.getString("status"),
+                rs.getBigDecimal("score_total"), null, null, null, rs.getString("sections_json"),
                 rs.getString("copy_json"), rs.getString("visual_json"), rs.getString("image_json"),
-                rs.getString("analysis_notes"), rs.getString("request_payload_json"), toInstant(rs.getTimestamp("analyzed_at")), toInstant(rs.getTimestamp("updated_at"))), pageId);
+                rs.getString("error_message"), rs.getString("request_payload_json"),
+                toInstant(rs.getTimestamp("finished_at")), toInstant(rs.getTimestamp("updated_at"))), pageId);
         if (rows.isEmpty()) throw new IllegalArgumentException("Analysis not found for page: " + pageId);
         return rows.get(0);
+    }
+
+    /**
+     * Lista o histórico auditável de execuções da página a partir de mois_sales_page_job_execution.
+     */
+    public List<MoisSalesLibraryDtos.SalesLibraryPageExecutionResponse> listPageExecutions(long pageId) {
+        return jdbcTemplate.query("""
+                SELECT id, sales_page_id, job_type, stage, status, attempt, input_url, final_url, redirect_root_url,
+                       http_status, content_type, raw_html_bytes, screenshot_bytes, score_total, error_category,
+                       error_message, started_at, finished_at, created_at, updated_at
+                FROM mois_sales_page_job_execution
+                WHERE sales_page_id = ?
+                ORDER BY updated_at DESC, id DESC
+                LIMIT 50
+                """, (rs, rn) -> new MoisSalesLibraryDtos.SalesLibraryPageExecutionResponse(
+                rs.getLong("id"), rs.getLong("sales_page_id"), rs.getString("job_type"), rs.getString("stage"),
+                rs.getString("status"), rs.getInt("attempt"), rs.getString("input_url"), rs.getString("final_url"),
+                rs.getString("redirect_root_url"), (Integer) rs.getObject("http_status"), rs.getString("content_type"),
+                rs.getLong("raw_html_bytes"), rs.getLong("screenshot_bytes"), rs.getBigDecimal("score_total"),
+                rs.getString("error_category"), rs.getString("error_message"), toInstant(rs.getTimestamp("started_at")),
+                toInstant(rs.getTimestamp("finished_at")), toInstant(rs.getTimestamp("created_at")),
+                toInstant(rs.getTimestamp("updated_at"))), pageId);
     }
 
     /**
@@ -403,8 +441,7 @@ public class MoisSalesLibraryService {
             long pageId,
             MoisSalesLibraryDtos.SalesLibraryStatusUpdateRequest request
     ) {
-        Long exists = jdbcTemplate.queryForObject("SELECT COUNT(*) FROM mois_sales_library_url_ingest WHERE id = ?", Long.class, pageId);
-        if (exists == null || exists == 0) throw new IllegalArgumentException("Page not found: " + pageId);
+        long urlIngestId = findUrlIngestIdForOperationalPage(pageId);
 
         String normalizedStatus = request.status().trim().toUpperCase(Locale.ROOT);
         if (!JOB_STATUS_PENDING.equals(normalizedStatus) && !ANALYSIS_STATUS_CANCELED.equals(normalizedStatus)) {
@@ -414,18 +451,18 @@ public class MoisSalesLibraryService {
         Long jobId = null;
         String notes = request.reason() == null || request.reason().isBlank() ? "Status atualizado manualmente via API" : request.reason().trim();
         if (JOB_STATUS_PENDING.equals(normalizedStatus)) {
-            jobId = createPendingJob(pageId);
+            jobId = createPendingJob(urlIngestId);
         }
 
         jdbcTemplate.update("""
                 INSERT INTO mois_sales_library_page_analysis
                 (url_ingest_id, job_id, status, analysis_notes, created_at, updated_at)
                 VALUES (?, ?, ?, ?, UTC_TIMESTAMP(), UTC_TIMESTAMP())
-                """, pageId, jobId, normalizedStatus, notes);
+                """, urlIngestId, jobId, normalizedStatus, notes);
         if (jobId != null) {
             dualWriteGateway.syncProcessingJob(jobId);
         }
-        dualWriteGateway.syncLatestAnalysis(pageId);
+        dualWriteGateway.syncLatestAnalysis(urlIngestId);
 
         return new MoisSalesLibraryDtos.SalesLibraryStatusUpdateResponse(pageId, jobId, normalizedStatus, notes, Instant.now());
     }
@@ -435,16 +472,15 @@ public class MoisSalesLibraryService {
      */
     @Transactional
     public MoisSalesLibraryDtos.SalesLibraryReanalyzeResponse reanalyzePage(long pageId) {
-        Long exists = jdbcTemplate.queryForObject("SELECT COUNT(*) FROM mois_sales_library_url_ingest WHERE id = ?", Long.class, pageId);
-        if (exists == null || exists == 0) throw new IllegalArgumentException("Page not found: " + pageId);
-        long jobId = createPendingJob(pageId);
+        long urlIngestId = findUrlIngestIdForOperationalPage(pageId);
+        long jobId = createPendingJob(urlIngestId);
         jdbcTemplate.update("""
                 INSERT INTO mois_sales_library_page_analysis
                 (url_ingest_id, job_id, status, analysis_notes, created_at, updated_at)
                 VALUES (?, ?, 'PENDING', 'Reanálise solicitada via API', UTC_TIMESTAMP(), UTC_TIMESTAMP())
-                """, pageId, jobId);
+                """, urlIngestId, jobId);
         dualWriteGateway.syncProcessingJob(jobId);
-        dualWriteGateway.syncLatestAnalysis(pageId);
+        dualWriteGateway.syncLatestAnalysis(urlIngestId);
         return new MoisSalesLibraryDtos.SalesLibraryReanalyzeResponse(pageId, jobId, JOB_STATUS_PENDING, Instant.now());
     }
 
@@ -641,6 +677,60 @@ public class MoisSalesLibraryService {
             }
         }
         return null;
+    }
+
+    /**
+     * Converte uma linha de mois_sales_page para o contrato de página consolidada usado pela UI.
+     */
+    private MoisSalesLibraryDtos.SalesLibraryPageResponse mapSalesPageResponse(ResultSet rs, int rowNum) throws SQLException {
+        return new MoisSalesLibraryDtos.SalesLibraryPageResponse(
+                rs.getLong("id"),
+                rs.getString("workspace_id"),
+                rs.getString("source"),
+                rs.getString("url_canonical"),
+                rs.getString("title"),
+                rs.getString("current_stage"),
+                rs.getString("current_status"),
+                rs.getString("capture_status"),
+                rs.getString("analysis_status"),
+                rs.getString("url_final"),
+                (Integer) rs.getObject("http_status"),
+                rs.getString("html_sha256"),
+                rs.getLong("html_bytes"),
+                rs.getBigDecimal("score_total"),
+                rs.getString("offer_summary"),
+                rs.getString("mechanism_summary"),
+                rs.getString("promise_summary"),
+                rs.getString("proof_summary"),
+                rs.getString("last_error_category"),
+                rs.getString("last_error_message"),
+                rs.getObject("last_job_execution_id", Long.class),
+                toInstant(rs.getTimestamp("last_captured_at")),
+                toInstant(rs.getTimestamp("last_analyzed_at")),
+                toInstant(rs.getTimestamp("updated_at"))
+        );
+    }
+
+    /**
+     * Resolve o identificador legado de URL a partir do identificador operacional novo para ações ainda em escrita dupla.
+     */
+    private long findUrlIngestIdForOperationalPage(long pageId) {
+        List<Long> rows = jdbcTemplate.query("""
+                SELECT i.id
+                FROM mois_sales_page sp
+                JOIN mois_sales_library_url_ingest i
+                  ON i.workspace_id = sp.workspace_id AND i.url_canonical = sp.url_canonical
+                WHERE sp.id = ?
+                LIMIT 1
+                """, (rs, rowNum) -> rs.getLong("id"), pageId);
+        if (!rows.isEmpty()) {
+            return rows.get(0);
+        }
+        Long legacyExists = jdbcTemplate.queryForObject("SELECT COUNT(*) FROM mois_sales_library_url_ingest WHERE id = ?", Long.class, pageId);
+        if (legacyExists != null && legacyExists > 0) {
+            return pageId;
+        }
+        throw new IllegalArgumentException("Page not found: " + pageId);
     }
 
     /**

--- a/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/web/MoisSalesLibraryController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/web/MoisSalesLibraryController.java
@@ -104,7 +104,7 @@ public class MoisSalesLibraryController {
     }
 
     /**
-     * Lista páginas canônicas registradas na biblioteca.
+     * Lista páginas canônicas registradas no modelo consolidado da biblioteca.
      */
     @GetMapping("/pages")
     public MoisSalesLibraryDtos.SalesLibraryPageListResponse listPages(
@@ -113,6 +113,14 @@ public class MoisSalesLibraryController {
             @RequestParam(defaultValue = "20") int pageSize
     ) {
         return service.listPages(workspaceId, page, pageSize);
+    }
+
+    /**
+     * Retorna contadores globais das páginas consolidadas sem depender da paginação da listagem.
+     */
+    @GetMapping("/pages/summary")
+    public MoisSalesLibraryDtos.SalesLibraryPageSummaryResponse summarizePages(@RequestParam String workspaceId) {
+        return service.summarizePages(workspaceId);
     }
 
     /**
@@ -218,11 +226,19 @@ public class MoisSalesLibraryController {
     }
 
     /**
-     * Lista snapshots já capturados para uma página.
+     * Lista snapshots legados já capturados para uma página durante a transição.
      */
     @GetMapping("/pages/{pageId}/snapshots")
     public List<MoisSalesLibraryDtos.SalesLibraryPageSnapshotResponse> listPageSnapshots(@PathVariable long pageId) {
         return snapshotService.listSnapshots(pageId);
+    }
+
+    /**
+     * Lista o histórico consolidado de execuções da página no modelo novo.
+     */
+    @GetMapping("/pages/{pageId}/executions")
+    public List<MoisSalesLibraryDtos.SalesLibraryPageExecutionResponse> listPageExecutions(@PathVariable long pageId) {
+        return service.listPageExecutions(pageId);
     }
 
     /**

--- a/backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/web/MoisSalesLibraryControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/web/MoisSalesLibraryControllerTest.java
@@ -20,6 +20,9 @@ import org.springframework.boot.test.mock.mockito.MockBean;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
+/**
+ * Valida os contratos HTTP expostos pela Biblioteca de Páginas de Vendas do MOIS.
+ */
 @WebMvcTest(MoisSalesLibraryController.class)
 class MoisSalesLibraryControllerTest {
 
@@ -106,4 +109,74 @@ class MoisSalesLibraryControllerTest {
                 .andExpect(jsonPath("$[0].rawHtmlBytes").value(512))
                 .andExpect(jsonPath("$[0].screenshotBytes").value(1024));
     }
+
+    /**
+     * Garante que o resumo global consolidado da Fase 4 seja exposto ao frontend.
+     */
+    @Test
+    void shouldExposeConsolidatedPagesSummaryEndpoint() throws Exception {
+        when(service.summarizePages("workspace-001"))
+                .thenReturn(new MoisSalesLibraryDtos.SalesLibraryPageSummaryResponse(
+                        "workspace-001",
+                        145L,
+                        4L,
+                        0L,
+                        20L,
+                        105L,
+                        16L,
+                        0L,
+                        126L,
+                        19L,
+                        Instant.parse("2026-06-04T16:00:09Z")
+                ));
+
+        mockMvc.perform(get("/api/mois/sales-library/pages/summary")
+                        .param("workspaceId", "workspace-001"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.total").value(145))
+                .andExpect(jsonPath("$.pending").value(4))
+                .andExpect(jsonPath("$.captured").value(20))
+                .andExpect(jsonPath("$.analyzed").value(105))
+                .andExpect(jsonPath("$.failed").value(16))
+                .andExpect(jsonPath("$.blockedCooldown").value(0));
+    }
+
+    /**
+     * Garante que o histórico consolidado da Fase 4 seja exposto ao frontend.
+     */
+    @Test
+    void shouldExposeConsolidatedPageExecutionsEndpoint() throws Exception {
+        when(service.listPageExecutions(10L))
+                .thenReturn(List.of(new MoisSalesLibraryDtos.SalesLibraryPageExecutionResponse(
+                        99L,
+                        10L,
+                        "PAGE_ANALYSIS",
+                        "ANALYSIS",
+                        "DONE",
+                        1,
+                        "https://example.test/sales",
+                        "https://example.test/final",
+                        "https://example.test",
+                        200,
+                        "text/html",
+                        512L,
+                        1024L,
+                        java.math.BigDecimal.valueOf(88.5),
+                        null,
+                        null,
+                        Instant.parse("2026-05-18T21:59:00Z"),
+                        Instant.parse("2026-05-18T22:00:00Z"),
+                        Instant.parse("2026-05-18T21:59:00Z"),
+                        Instant.parse("2026-05-18T22:00:01Z")
+                )));
+
+        mockMvc.perform(get("/api/mois/sales-library/pages/10/executions"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].executionId").value(99))
+                .andExpect(jsonPath("$[0].jobType").value("PAGE_ANALYSIS"))
+                .andExpect(jsonPath("$[0].stage").value("ANALYSIS"))
+                .andExpect(jsonPath("$[0].status").value("DONE"))
+                .andExpect(jsonPath("$[0].rawHtmlBytes").value(512));
+    }
+
 }

--- a/docs/registros/mois1.md
+++ b/docs/registros/mois1.md
@@ -930,3 +930,22 @@ Arquivos alterados:
 Arquivos alterados:
 - `backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryServiceTest.java`
 - `docs/registros/mois1.md`
+
+## 2026-06-04 — Fase 4 do pipeline de páginas de vendas em duas tabelas
+- migrada a leitura operacional da Biblioteca de Páginas de Vendas para o modelo consolidado `mois_sales_page`, incluindo listagem, detalhe e resumo global de páginas por workspace.
+- criado endpoint de resumo global baseado em `mois_sales_page` para total de páginas, pendentes, em captura, capturadas, analisadas, falhas, bloqueadas por cooldown e totais por fonte Hotmart/ClickBank, eliminando contadores derivados apenas da página carregada no frontend.
+- criado endpoint de histórico consolidado baseado em `mois_sales_page_job_execution` para explicar as execuções de captura/análise por página a partir do modelo novo.
+- atualizadas as telas `/mois/sales-pages-library`, `/mois/sales-pages-library/pipeline` e `/mois/sales-pages-library/:pageId` para usar os dados consolidados, exibir contadores globais reais e montar o histórico a partir das execuções novas.
+- preservadas ações transicionais de reanálise e atualização manual com resolução do identificador legado enquanto a escrita dupla ainda estiver ativa.
+
+Arquivos alterados:
+- `backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/dto/MoisSalesLibraryDtos.java`
+- `backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryService.java`
+- `backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/web/MoisSalesLibraryController.java`
+- `backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/web/MoisSalesLibraryControllerTest.java`
+- `frontend/src/api/mois/types.ts`
+- `frontend/src/api/mois/useMoisSalesLibrary.ts`
+- `frontend/src/pages/mois/MoisSalesPageLibraryDetailPage.tsx`
+- `frontend/src/pages/mois/MoisSalesPagesLibraryPage.tsx`
+- `frontend/src/pages/mois/MoisSalesPagesPipelinePage.tsx`
+- `docs/registros/mois1.md`

--- a/frontend/src/api/mois/types.ts
+++ b/frontend/src/api/mois/types.ts
@@ -260,9 +260,61 @@ export interface MoisSalesLibraryPage {
   source: string;
   urlCanonical: string;
   title?: string;
+  currentStage?: string;
+  currentStatus?: string;
+  captureStatus?: string;
   analysisStatus?: string;
+  urlFinal?: string;
+  httpStatus?: number;
+  htmlSha256?: string;
+  htmlBytes: number;
   scoreTotal?: number;
+  offerSummary?: string;
+  mechanismSummary?: string;
+  promiseSummary?: string;
+  proofSummary?: string;
+  lastErrorCategory?: string;
+  lastErrorMessage?: string;
+  lastJobExecutionId?: number;
+  lastCapturedAt?: string;
   analyzedAt?: string;
+  updatedAt: string;
+}
+
+export interface MoisSalesLibraryPageSummary {
+  workspaceId: string;
+  total: number;
+  pending: number;
+  capturing: number;
+  captured: number;
+  analyzed: number;
+  failed: number;
+  blockedCooldown: number;
+  hotmart: number;
+  clickbank: number;
+  updatedAt?: string;
+}
+
+export interface MoisSalesLibraryPageExecution {
+  executionId: number;
+  pageId: number;
+  jobType: string;
+  stage: string;
+  status: string;
+  attempt: number;
+  inputUrl?: string;
+  finalUrl?: string;
+  redirectRootUrl?: string;
+  httpStatus?: number;
+  contentType?: string;
+  rawHtmlBytes: number;
+  screenshotBytes: number;
+  scoreTotal?: number;
+  errorCategory?: string;
+  errorMessage?: string;
+  startedAt?: string;
+  finishedAt?: string;
+  createdAt: string;
   updatedAt: string;
 }
 

--- a/frontend/src/api/mois/useMoisSalesLibrary.ts
+++ b/frontend/src/api/mois/useMoisSalesLibrary.ts
@@ -5,8 +5,10 @@ import type {
   MoisSalesLibraryJobPageResponse,
   MoisSalesLibraryPage,
   MoisSalesLibraryPageAnalysis,
+  MoisSalesLibraryPageExecution,
   MoisSalesLibraryPageListResponse,
   MoisSalesLibraryPageSnapshot,
+  MoisSalesLibraryPageSummary,
   MoisSalesLibraryReanalyzeResponse,
   MoisSalesLibrarySnapshotCaptureResponse,
   MoisSalesLibraryStatusUpdateResponse,
@@ -78,6 +80,19 @@ export function useMoisSalesLibraryPages(
   });
 }
 
+export function useMoisSalesLibraryPageSummary(workspaceId: string) {
+  return useQuery({
+    queryKey: ["mois", "sales-library", "pages-summary", workspaceId],
+    queryFn: async () => {
+      const { data } = await axios.get<MoisSalesLibraryPageSummary>(
+        "/api/mois/sales-library/pages/summary",
+        { params: { workspaceId } },
+      );
+      return data;
+    },
+  });
+}
+
 export function useMoisSalesLibraryPageAnalysis(pageId?: number) {
   return useQuery({
     queryKey: ["mois", "sales-library", "analysis", pageId],
@@ -107,6 +122,9 @@ export function useReanalyzeMoisSalesLibraryPage(workspaceId: string) {
       void queryClient.invalidateQueries({
         queryKey: ["mois", "sales-library", "jobs", workspaceId],
       });
+      void queryClient.invalidateQueries({
+        queryKey: ["mois", "sales-library", "pages-summary", workspaceId],
+      });
     },
   });
 }
@@ -134,6 +152,17 @@ export function useUpdateMoisSalesLibraryPageStatus(workspaceId: string) {
       void queryClient.invalidateQueries({
         queryKey: ["mois", "sales-library", "analysis", variables.pageId],
       });
+      void queryClient.invalidateQueries({
+        queryKey: [
+          "mois",
+          "sales-library",
+          "page-executions",
+          variables.pageId,
+        ],
+      });
+      void queryClient.invalidateQueries({
+        queryKey: ["mois", "sales-library", "pages-summary", workspaceId],
+      });
     },
   });
 }
@@ -153,6 +182,9 @@ export function useCaptureMoisSalesLibrarySnapshots(workspaceId: string) {
       void queryClient.invalidateQueries({
         queryKey: ["mois", "sales-library", "pages", workspaceId],
       });
+      void queryClient.invalidateQueries({
+        queryKey: ["mois", "sales-library", "pages-summary", workspaceId],
+      });
     },
   });
 }
@@ -163,12 +195,16 @@ export function getSalesLibraryJobBadgeClass(job: {
 }) {
   switch (job.status || job.analysisStatus) {
     case "DONE":
+    case "CAPTURED":
+    case "ANALYZED":
       return "bg-success-subtle text-success-emphasis";
     case "FAILED":
       return "bg-danger-subtle text-danger-emphasis";
     case "FETCHING":
+    case "CAPTURING":
       return "bg-primary-subtle text-primary-emphasis";
     case "PENDING":
+    case "BLOCKED_COOLDOWN":
       return "bg-warning-subtle text-warning-emphasis";
     default:
       return "bg-secondary-subtle text-secondary-emphasis";
@@ -195,6 +231,19 @@ export function useMoisSalesLibraryPageSnapshots(pageId?: number) {
     queryFn: async () => {
       const { data } = await axios.get<MoisSalesLibraryPageSnapshot[]>(
         `/api/mois/sales-library/pages/${pageId}/snapshots`,
+      );
+      return data;
+    },
+  });
+}
+
+export function useMoisSalesLibraryPageExecutions(pageId?: number) {
+  return useQuery({
+    queryKey: ["mois", "sales-library", "page-executions", pageId],
+    enabled: Boolean(pageId),
+    queryFn: async () => {
+      const { data } = await axios.get<MoisSalesLibraryPageExecution[]>(
+        `/api/mois/sales-library/pages/${pageId}/executions`,
       );
       return data;
     },

--- a/frontend/src/pages/mois/MoisSalesPageLibraryDetailPage.tsx
+++ b/frontend/src/pages/mois/MoisSalesPageLibraryDetailPage.tsx
@@ -1,6 +1,12 @@
 import { Link, useParams } from "react-router-dom";
 import PageTitle from "../../components/PageTitle";
-import { useMoisSalesLibraryPage, useMoisSalesLibraryPageAnalysis, useMoisSalesLibraryPageSnapshots, useMoisSalesLibraryPages, useUpdateMoisSalesLibraryPageStatus } from "../../api/mois/useMoisSalesLibrary";
+import {
+  useMoisSalesLibraryPage,
+  useMoisSalesLibraryPageAnalysis,
+  useMoisSalesLibraryPageExecutions,
+  useMoisSalesLibraryPages,
+  useUpdateMoisSalesLibraryPageStatus,
+} from "../../api/mois/useMoisSalesLibrary";
 
 const WORKSPACE_ID = "workspace-001";
 const PAGE_SIZE = 100;
@@ -8,14 +14,24 @@ const PAGE_SIZE = 100;
 function formatDate(value?: string) {
   if (!value) return "—";
   const date = new Date(value);
-  return Number.isNaN(date.getTime()) ? "—" : date.toLocaleString("pt-BR", { dateStyle: "short", timeStyle: "short" });
+  return Number.isNaN(date.getTime())
+    ? "—"
+    : date.toLocaleString("pt-BR", { dateStyle: "short", timeStyle: "short" });
 }
 
 function isObjectLike(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
 }
 
-function JsonTreeNode({ label, value, defaultOpen = false }: { label: string; value: unknown; defaultOpen?: boolean }) {
+function JsonTreeNode({
+  label,
+  value,
+  defaultOpen = false,
+}: {
+  label: string;
+  value: unknown;
+  defaultOpen?: boolean;
+}) {
   if (Array.isArray(value)) {
     return (
       <details open={defaultOpen} className="ms-2">
@@ -23,9 +39,15 @@ function JsonTreeNode({ label, value, defaultOpen = false }: { label: string; va
           <strong>{label}</strong>: [{value.length}]
         </summary>
         <div className="mt-1 ms-3 d-flex flex-column gap-1">
-          {value.length === 0 ? <span className="text-secondary">[]</span> : null}
+          {value.length === 0 ? (
+            <span className="text-secondary">[]</span>
+          ) : null}
           {value.map((item, index) => (
-            <JsonTreeNode key={`${label}-${index}`} label={`[${index}]`} value={item} />
+            <JsonTreeNode
+              key={`${label}-${index}`}
+              label={`[${index}]`}
+              value={item}
+            />
           ))}
         </div>
       </details>
@@ -43,9 +65,15 @@ function JsonTreeNode({ label, value, defaultOpen = false }: { label: string; va
           {"}"}
         </summary>
         <div className="mt-1 ms-3 d-flex flex-column gap-1">
-          {entries.length === 0 ? <span className="text-secondary">{"{}"}</span> : null}
+          {entries.length === 0 ? (
+            <span className="text-secondary">{"{}"}</span>
+          ) : null}
           {entries.map(([entryLabel, entryValue]) => (
-            <JsonTreeNode key={`${label}-${entryLabel}`} label={entryLabel} value={entryValue} />
+            <JsonTreeNode
+              key={`${label}-${entryLabel}`}
+              label={entryLabel}
+              value={entryValue}
+            />
           ))}
         </div>
       </details>
@@ -66,7 +94,9 @@ function JsonCollapse({ title, content }: { title: string; content?: string }) {
         <summary className="fw-semibold" style={{ cursor: "pointer" }}>
           {title}
         </summary>
-        <div className="mt-2 small text-secondary">Não disponível neste registro.</div>
+        <div className="mt-2 small text-secondary">
+          Não disponível neste registro.
+        </div>
       </details>
     );
   }
@@ -89,7 +119,11 @@ function JsonCollapse({ title, content }: { title: string; content?: string }) {
         {title}
       </summary>
       <div className="mt-2">
-        {parseError ? <pre className="mb-0 small text-break">{String(parsed)}</pre> : <JsonTreeNode label="root" value={parsed} defaultOpen />}
+        {parseError ? (
+          <pre className="mb-0 small text-break">{String(parsed)}</pre>
+        ) : (
+          <JsonTreeNode label="root" value={parsed} defaultOpen />
+        )}
       </div>
     </details>
   );
@@ -108,33 +142,54 @@ export default function MoisSalesPageLibraryDetailPage() {
   const validPageId = Number.isFinite(pageId) ? pageId : undefined;
   const pageQuery = useMoisSalesLibraryPage(validPageId);
   const analysisQuery = useMoisSalesLibraryPageAnalysis(validPageId);
-  const snapshotsQuery = useMoisSalesLibraryPageSnapshots(validPageId);
+  const executionsQuery = useMoisSalesLibraryPageExecutions(validPageId);
   const pagesQuery = useMoisSalesLibraryPages(WORKSPACE_ID, 1, PAGE_SIZE);
-  const updateStatusMutation = useUpdateMoisSalesLibraryPageStatus(WORKSPACE_ID);
+  const updateStatusMutation =
+    useUpdateMoisSalesLibraryPageStatus(WORKSPACE_ID);
 
-  const currentIndex = pagesQuery.data?.items.findIndex((item) => item.pageId === validPageId) ?? -1;
-  const nextItem = currentIndex >= 0 ? pagesQuery.data?.items[currentIndex + 1] : undefined;
+  const currentIndex =
+    pagesQuery.data?.items.findIndex((item) => item.pageId === validPageId) ??
+    -1;
+  const nextItem =
+    currentIndex >= 0 ? pagesQuery.data?.items[currentIndex + 1] : undefined;
   const isMutating = updateStatusMutation.isPending;
 
-  const history: HistoryItem[] = (snapshotsQuery.data ?? []).map((item) => ({
-    key: String(item.snapshotId),
-    stage: `Snapshot ${item.status}`,
-    date: item.capturedAt ?? item.updatedAt,
-    detail: `HTTP ${item.httpStatus ?? "—"} • content-type: ${item.contentType ?? "—"} • html bytes: ${item.rawHtmlBytes} • screenshot bytes: ${item.screenshotBytes}`,
+  const history: HistoryItem[] = (executionsQuery.data ?? []).map((item) => ({
+    key: String(item.executionId),
+    stage: `${item.stage} • ${item.jobType} • ${item.status}`,
+    date: item.finishedAt ?? item.updatedAt ?? item.createdAt,
+    detail: [
+      `tentativa ${item.attempt}`,
+      `HTTP ${item.httpStatus ?? "—"}`,
+      `content-type: ${item.contentType ?? "—"}`,
+      `html bytes: ${item.rawHtmlBytes}`,
+      `screenshot bytes: ${item.screenshotBytes}`,
+      item.scoreTotal != null ? `score: ${item.scoreTotal}` : null,
+      item.errorCategory ? `erro: ${item.errorCategory}` : null,
+      item.errorMessage,
+    ]
+      .filter(Boolean)
+      .join(" • "),
   }));
 
   return (
     <div className="d-flex flex-column gap-4">
       <header className="d-flex flex-wrap justify-content-between gap-3">
         <div>
-          <PageTitle>{pageQuery.data?.title || "Detalhe da análise da página"}</PageTitle>
+          <PageTitle>
+            {pageQuery.data?.title || "Detalhe da análise da página"}
+          </PageTitle>
           <p className="text-secondary mb-0">
             Coletor usado: <strong>{pageQuery.data?.source || "—"}</strong>
           </p>
           <p className="text-secondary mb-0">
             URL da página de venda usada no modelo:{" "}
             {pageQuery.data?.urlCanonical ? (
-              <a href={pageQuery.data.urlCanonical} target="_blank" rel="noreferrer">
+              <a
+                href={pageQuery.data.urlCanonical}
+                target="_blank"
+                rel="noreferrer"
+              >
                 {pageQuery.data.urlCanonical}
               </a>
             ) : (
@@ -144,11 +199,17 @@ export default function MoisSalesPageLibraryDetailPage() {
         </div>
         <div className="d-flex flex-wrap gap-2">
           {nextItem ? (
-            <Link className="btn btn-outline-primary" to={`/mois/sales-pages-library/${nextItem.pageId}`}>
+            <Link
+              className="btn btn-outline-primary"
+              to={`/mois/sales-pages-library/${nextItem.pageId}`}
+            >
               Próximo →
             </Link>
           ) : null}
-          <Link className="btn btn-outline-secondary" to="/mois/sales-pages-library">
+          <Link
+            className="btn btn-outline-secondary"
+            to="/mois/sales-pages-library"
+          >
             Voltar para biblioteca
           </Link>
         </div>
@@ -159,45 +220,113 @@ export default function MoisSalesPageLibraryDetailPage() {
           type="button"
           className="btn btn-outline-warning"
           disabled={!validPageId || isMutating}
-          onClick={() => validPageId && updateStatusMutation.mutate({ pageId: validPageId, status: "PENDING" })}
+          onClick={() =>
+            validPageId &&
+            updateStatusMutation.mutate({
+              pageId: validPageId,
+              status: "PENDING",
+            })
+          }
         >
-          {isMutating ? <span className="spinner-border spinner-border-sm me-2" role="status" aria-hidden="true" /> : null}
+          {isMutating ? (
+            <span
+              className="spinner-border spinner-border-sm me-2"
+              role="status"
+              aria-hidden="true"
+            />
+          ) : null}
           Voltar para pendente
         </button>
         <button
           type="button"
           className="btn btn-outline-danger"
           disabled={!validPageId || isMutating}
-          onClick={() => validPageId && updateStatusMutation.mutate({ pageId: validPageId, status: "ANULADO" })}
+          onClick={() =>
+            validPageId &&
+            updateStatusMutation.mutate({
+              pageId: validPageId,
+              status: "ANULADO",
+            })
+          }
         >
-          {isMutating ? <span className="spinner-border spinner-border-sm me-2" role="status" aria-hidden="true" /> : null}
+          {isMutating ? (
+            <span
+              className="spinner-border spinner-border-sm me-2"
+              role="status"
+              aria-hidden="true"
+            />
+          ) : null}
           Marcar como anulado
         </button>
       </div>
 
-      {updateStatusMutation.isError ? <div className="alert alert-danger mb-0">Falha ao atualizar status da página.</div> : null}
+      {updateStatusMutation.isError ? (
+        <div className="alert alert-danger mb-0">
+          Falha ao atualizar status da página.
+        </div>
+      ) : null}
 
-      {analysisQuery.isLoading ? <p className="text-secondary mb-0">Carregando detalhe...</p> : null}
-      {analysisQuery.isError ? <div className="alert alert-danger mb-0">Falha ao carregar detalhe da análise.</div> : null}
+      {analysisQuery.isLoading ? (
+        <p className="text-secondary mb-0">Carregando detalhe...</p>
+      ) : null}
+      {analysisQuery.isError ? (
+        <div className="alert alert-danger mb-0">
+          Falha ao carregar detalhe da análise.
+        </div>
+      ) : null}
 
       {analysisQuery.data ? (
         <section className="card border-0 shadow-sm">
           <div className="card-body d-flex flex-column gap-3">
             <div className="row g-3">
-              <div className="col-md-4"><strong>Status:</strong> {analysisQuery.data.status}</div>
-              <div className="col-md-4"><strong>Modelo:</strong> {analysisQuery.data.modelName || "—"}</div>
-              <div className="col-md-4"><strong>Atualizado:</strong> {formatDate(analysisQuery.data.updatedAt)}</div>
-              <div className="col-md-6"><strong>Prompt version:</strong> {analysisQuery.data.promptVersion || "—"}</div>
-              <div className="col-md-6"><strong>Parser version:</strong> {analysisQuery.data.parserVersion || "—"}</div>
+              <div className="col-md-4">
+                <strong>Status:</strong> {analysisQuery.data.status}
+              </div>
+              <div className="col-md-4">
+                <strong>Modelo:</strong> {analysisQuery.data.modelName || "—"}
+              </div>
+              <div className="col-md-4">
+                <strong>Atualizado:</strong>{" "}
+                {formatDate(analysisQuery.data.updatedAt)}
+              </div>
+              <div className="col-md-6">
+                <strong>Prompt version:</strong>{" "}
+                {analysisQuery.data.promptVersion || "—"}
+              </div>
+              <div className="col-md-6">
+                <strong>Parser version:</strong>{" "}
+                {analysisQuery.data.parserVersion || "—"}
+              </div>
             </div>
 
-            <JsonCollapse title="Resposta do modelo (sectionsJson)" content={analysisQuery.data.sectionsJson} />
-            <JsonCollapse title="Resposta do modelo (copyJson)" content={analysisQuery.data.copyJson} />
-            <JsonCollapse title="Resposta do modelo (visualJson)" content={analysisQuery.data.visualJson} />
-            <JsonCollapse title="Resposta do modelo (imageJson)" content={analysisQuery.data.imageJson} />
-            <JsonCollapse title="Notas de análise retornadas pelo worker" content={analysisQuery.data.analysisNotes} />
-            <JsonCollapse title="Request enviado ao modelo" content={analysisQuery.data.requestPayloadJson} />
-            <JsonCollapse title="Prompt usado no modelo" content={analysisQuery.data.promptVersion} />
+            <JsonCollapse
+              title="Resposta do modelo (sectionsJson)"
+              content={analysisQuery.data.sectionsJson}
+            />
+            <JsonCollapse
+              title="Resposta do modelo (copyJson)"
+              content={analysisQuery.data.copyJson}
+            />
+            <JsonCollapse
+              title="Resposta do modelo (visualJson)"
+              content={analysisQuery.data.visualJson}
+            />
+            <JsonCollapse
+              title="Resposta do modelo (imageJson)"
+              content={analysisQuery.data.imageJson}
+            />
+            <JsonCollapse
+              title="Notas de análise retornadas pelo worker"
+              content={analysisQuery.data.analysisNotes}
+            />
+            <JsonCollapse
+              title="Request enviado ao modelo"
+              content={analysisQuery.data.requestPayloadJson}
+            />
+            <JsonCollapse
+              title="Prompt usado no modelo"
+              content={analysisQuery.data.promptVersion}
+            />
           </div>
         </section>
       ) : null}
@@ -205,15 +334,32 @@ export default function MoisSalesPageLibraryDetailPage() {
       <section className="card border-0 shadow-sm">
         <div className="card-body">
           <h2 className="h5 mb-3">Histórico da página</h2>
+          {executionsQuery.isLoading ? (
+            <p className="text-secondary mb-3">
+              Carregando histórico consolidado...
+            </p>
+          ) : null}
+          {executionsQuery.isError ? (
+            <div className="alert alert-danger">
+              Falha ao carregar histórico consolidado.
+            </div>
+          ) : null}
           {history.length === 0 ? (
-            <p className="text-secondary mb-0">Ainda não há eventos registrados para esta página.</p>
+            <p className="text-secondary mb-0">
+              Ainda não há eventos registrados para esta página.
+            </p>
           ) : (
             <div className="d-flex flex-column gap-3">
               {history.map((item) => (
-                <div key={item.key} className="border rounded p-3 bg-light-subtle">
+                <div
+                  key={item.key}
+                  className="border rounded p-3 bg-light-subtle"
+                >
                   <div className="d-flex flex-wrap justify-content-between gap-2">
                     <strong>{item.stage}</strong>
-                    <span className="text-secondary small">{formatDate(item.date)}</span>
+                    <span className="text-secondary small">
+                      {formatDate(item.date)}
+                    </span>
                   </div>
                   <p className="mb-0 mt-2 small">{item.detail}</p>
                 </div>

--- a/frontend/src/pages/mois/MoisSalesPagesLibraryPage.tsx
+++ b/frontend/src/pages/mois/MoisSalesPagesLibraryPage.tsx
@@ -1,59 +1,53 @@
 import { Link } from "react-router-dom";
 import PageTitle from "../../components/PageTitle";
-import { getSalesLibraryJobBadgeClass, useMoisSalesLibraryPages } from "../../api/mois/useMoisSalesLibrary";
+import {
+  getSalesLibraryJobBadgeClass,
+  useMoisSalesLibraryPages,
+  useMoisSalesLibraryPageSummary,
+} from "../../api/mois/useMoisSalesLibrary";
 
 const WORKSPACE_ID = "workspace-001";
 const PAGE_SIZE = 100;
 
-function getPipelinePhase(status?: string | null) {
-  switch (status) {
-    case "PENDING":
-      return "Fase 2 — URL disponível na biblioteca";
-    case "FETCHING":
-      return "Fase 3 — Worker coletando conteúdo da página";
-    case "ANALYZING":
-      return "Fase 4 — Análise com OpenAI em andamento";
-    case "RETRY_WAIT":
-      return "Fase 4 — Aguardando nova tentativa de análise";
-    case "DONE":
-      return "Fase 5 — Resultado persistido no banco";
-    case "FAILED":
-      return "Fase 5 — Falha terminal registrada";
-    default:
-      return "Sem fase definida";
+function getPipelinePhase(stage?: string | null, status?: string | null) {
+  if (stage === "CAPTURE" && status === "FAILED") {
+    return "Captura falhou — revisar URL ou cooldown";
   }
+  if (stage === "CAPTURE" && status === "CAPTURED") {
+    return "HTML capturado — pronto para análise";
+  }
+  if (stage === "ANALYSIS" && status === "DONE") {
+    return "Análise concluída — priorizar ofertas vencedoras";
+  }
+  if (stage === "ANALYSIS" && status === "PENDING") {
+    return "Aguardando análise comercial";
+  }
+  if (status === "BLOCKED_COOLDOWN") {
+    return "Bloqueada por cooldown";
+  }
+  return stage && status ? `${stage} — ${status}` : "Sem fase definida";
 }
 
 export default function MoisSalesPagesLibraryPage() {
   const pagesQuery = useMoisSalesLibraryPages(WORKSPACE_ID, 1, PAGE_SIZE);
-  const summary = pagesQuery.data?.items.reduce(
-    (acc, item) => {
-      const source = item.source?.toUpperCase();
-      const hasAnalysis = item.analysisStatus && item.analysisStatus !== "PENDING";
-      acc.totalCollected += 1;
-      if (source === "HOTMART") {
-        acc.totalHotmart += 1;
-      }
-      if (source === "CLICKBANK") {
-        acc.totalClickbank += 1;
-      }
-      if (hasAnalysis) {
-        acc.totalWithAnalysis += 1;
-      }
-      return acc;
-    },
-    { totalCollected: 0, totalHotmart: 0, totalClickbank: 0, totalWithAnalysis: 0 },
-  );
+  const summaryQuery = useMoisSalesLibraryPageSummary(WORKSPACE_ID);
+  const summary = summaryQuery.data;
 
   return (
     <div className="d-flex flex-column gap-4">
       <header className="d-flex flex-wrap justify-content-between gap-3">
         <div>
           <PageTitle>Biblioteca de Páginas de Vendas</PageTitle>
-          <p className="text-secondary mb-0">Tabela consolidada com cada produto coletado e a fase atual no fluxo canônico.</p>
+          <p className="text-secondary mb-0">
+            Tabela consolidada com cada produto coletado e a fase atual no fluxo
+            canônico.
+          </p>
         </div>
         <div className="d-flex flex-wrap gap-2">
-          <Link className="btn btn-primary" to="/mois/sales-pages-library/pipeline">
+          <Link
+            className="btn btn-primary"
+            to="/mois/sales-pages-library/pipeline"
+          >
             Pipeline
           </Link>
           <Link className="btn btn-outline-secondary" to="/mois">
@@ -67,8 +61,8 @@ export default function MoisSalesPagesLibraryPage() {
           <div className="col-sm-6 col-lg-3">
             <div className="card border-0 shadow-sm h-100">
               <div className="card-body">
-                <p className="text-secondary mb-1">Total coletados</p>
-                <h3 className="mb-0">{summary.totalCollected}</h3>
+                <p className="text-secondary mb-1">Total de páginas</p>
+                <h3 className="mb-0">{summary.total}</h3>
               </div>
             </div>
           </div>
@@ -76,7 +70,7 @@ export default function MoisSalesPagesLibraryPage() {
             <div className="card border-0 shadow-sm h-100">
               <div className="card-body">
                 <p className="text-secondary mb-1">Produtos Hotmart</p>
-                <h3 className="mb-0">{summary.totalHotmart}</h3>
+                <h3 className="mb-0">{summary.hotmart}</h3>
               </div>
             </div>
           </div>
@@ -84,15 +78,15 @@ export default function MoisSalesPagesLibraryPage() {
             <div className="card border-0 shadow-sm h-100">
               <div className="card-body">
                 <p className="text-secondary mb-1">Produtos Clickbank</p>
-                <h3 className="mb-0">{summary.totalClickbank}</h3>
+                <h3 className="mb-0">{summary.clickbank}</h3>
               </div>
             </div>
           </div>
           <div className="col-sm-6 col-lg-3">
             <div className="card border-0 shadow-sm h-100">
               <div className="card-body">
-                <p className="text-secondary mb-1">Total com análise</p>
-                <h3 className="mb-0">{summary.totalWithAnalysis}</h3>
+                <p className="text-secondary mb-1">Analisadas</p>
+                <h3 className="mb-0">{summary.analyzed}</h3>
               </div>
             </div>
           </div>
@@ -101,8 +95,16 @@ export default function MoisSalesPagesLibraryPage() {
 
       <section className="card border-0 shadow-sm">
         <div className="card-body table-responsive">
-          {pagesQuery.isLoading ? <p className="text-secondary mb-0">Carregando produtos coletados...</p> : null}
-          {pagesQuery.isError ? <div className="alert alert-danger mb-0">Falha ao carregar produtos da biblioteca.</div> : null}
+          {pagesQuery.isLoading ? (
+            <p className="text-secondary mb-0">
+              Carregando produtos coletados...
+            </p>
+          ) : null}
+          {pagesQuery.isError ? (
+            <div className="alert alert-danger mb-0">
+              Falha ao carregar produtos da biblioteca.
+            </div>
+          ) : null}
           {pagesQuery.data ? (
             <table className="table table-sm align-middle mb-0">
               <thead>
@@ -124,15 +126,31 @@ export default function MoisSalesPagesLibraryPage() {
                 ) : (
                   pagesQuery.data.items.map((item) => (
                     <tr key={item.pageId}>
-                      <td className="text-break">{item.title || item.urlCanonical}</td>
+                      <td className="text-break">
+                        {item.title || item.urlCanonical}
+                      </td>
                       <td>{item.source || "—"}</td>
                       <td>
-                        <span className={`badge ${getSalesLibraryJobBadgeClass(item)}`}>{item.analysisStatus || "SEM ANÁLISE"}</span>
+                        <span
+                          className={`badge ${getSalesLibraryJobBadgeClass({ status: item.currentStatus })}`}
+                        >
+                          {item.currentStatus ||
+                            item.analysisStatus ||
+                            "SEM STATUS"}
+                        </span>
                       </td>
-                      <td>{getPipelinePhase(item.analysisStatus)}</td>
+                      <td>
+                        {getPipelinePhase(
+                          item.currentStage,
+                          item.currentStatus,
+                        )}
+                      </td>
                       <td>
                         <div className="d-flex flex-wrap gap-2">
-                          <Link className="btn btn-outline-primary btn-sm" to={`/mois/sales-pages-library/${item.pageId}`}>
+                          <Link
+                            className="btn btn-outline-primary btn-sm"
+                            to={`/mois/sales-pages-library/${item.pageId}`}
+                          >
                             Ver detalhe
                           </Link>
                           <a

--- a/frontend/src/pages/mois/MoisSalesPagesPipelinePage.tsx
+++ b/frontend/src/pages/mois/MoisSalesPagesPipelinePage.tsx
@@ -1,14 +1,13 @@
-import { useMemo, useState } from "react";
+import { useState } from "react";
 import { Link } from "react-router-dom";
 import PageTitle from "../../components/PageTitle";
 import {
   useCaptureMoisSalesLibrarySnapshots,
-  useMoisSalesLibraryPages,
+  useMoisSalesLibraryPageSummary,
 } from "../../api/mois/useMoisSalesLibrary";
 import type { MoisSalesLibrarySnapshotCaptureItem } from "../../api/mois/types";
 
 const WORKSPACE_ID = "workspace-001";
-const PAGE_SIZE = 100;
 const DEFAULT_CAPTURE_LIMIT = 5;
 
 const htmlAcquisitionChecklist = [
@@ -64,28 +63,9 @@ function getResultMessage(item: MoisSalesLibrarySnapshotCaptureItem) {
 
 export default function MoisSalesPagesPipelinePage() {
   const [forceCapture, setForceCapture] = useState(false);
-  const pagesQuery = useMoisSalesLibraryPages(WORKSPACE_ID, 1, PAGE_SIZE);
+  const summaryQuery = useMoisSalesLibraryPageSummary(WORKSPACE_ID);
   const captureMutation = useCaptureMoisSalesLibrarySnapshots(WORKSPACE_ID);
-
-  const summary = useMemo(() => {
-    const items = pagesQuery.data?.items ?? [];
-    return items.reduce(
-      (acc, item) => {
-        acc.total += 1;
-        if (item.analysisStatus === "PENDING" || !item.analysisStatus) {
-          acc.pending += 1;
-        }
-        if (item.analysisStatus === "DONE") {
-          acc.done += 1;
-        }
-        if (item.analysisStatus === "FAILED") {
-          acc.failed += 1;
-        }
-        return acc;
-      },
-      { total: 0, pending: 0, done: 0, failed: 0 },
-    );
-  }, [pagesQuery.data?.items]);
+  const summary = summaryQuery.data;
 
   const lastRun = captureMutation.data;
   const isRunning = captureMutation.isPending;
@@ -171,7 +151,7 @@ export default function MoisSalesPagesPipelinePage() {
               <div className="border rounded-3 p-3 h-100">
                 <p className="text-secondary mb-1">URLs na biblioteca</p>
                 <h3 className="mb-0">
-                  {pagesQuery.isLoading ? "..." : summary.total}
+                  {summaryQuery.isLoading ? "..." : (summary?.total ?? 0)}
                 </h3>
               </div>
             </div>
@@ -179,22 +159,41 @@ export default function MoisSalesPagesPipelinePage() {
               <div className="border rounded-3 p-3 h-100">
                 <p className="text-secondary mb-1">Pendentes/análise inicial</p>
                 <h3 className="mb-0">
-                  {pagesQuery.isLoading ? "..." : summary.pending}
+                  {summaryQuery.isLoading ? "..." : (summary?.pending ?? 0)}
                 </h3>
               </div>
             </div>
             <div className="col-sm-6 col-lg-3">
               <div className="border rounded-3 p-3 h-100">
-                <p className="text-secondary mb-1">
-                  Capturadas na última execução
-                </p>
-                <h3 className="mb-0">{lastRun?.captured ?? 0}</h3>
+                <p className="text-secondary mb-1">Capturadas no modelo novo</p>
+                <h3 className="mb-0">{summary?.captured ?? 0}</h3>
               </div>
             </div>
             <div className="col-sm-6 col-lg-3">
               <div className="border rounded-3 p-3 h-100">
-                <p className="text-secondary mb-1">Falhas na última execução</p>
-                <h3 className="mb-0">{lastRun?.failed ?? 0}</h3>
+                <p className="text-secondary mb-1">Falhas globais</p>
+                <h3 className="mb-0">{summary?.failed ?? 0}</h3>
+              </div>
+            </div>
+          </div>
+
+          <div className="row g-3">
+            <div className="col-sm-6 col-lg-4">
+              <div className="border rounded-3 p-3 h-100">
+                <p className="text-secondary mb-1">Em captura</p>
+                <h3 className="mb-0">{summary?.capturing ?? 0}</h3>
+              </div>
+            </div>
+            <div className="col-sm-6 col-lg-4">
+              <div className="border rounded-3 p-3 h-100">
+                <p className="text-secondary mb-1">Analisadas</p>
+                <h3 className="mb-0">{summary?.analyzed ?? 0}</h3>
+              </div>
+            </div>
+            <div className="col-sm-6 col-lg-4">
+              <div className="border rounded-3 p-3 h-100">
+                <p className="text-secondary mb-1">Bloqueadas por cooldown</p>
+                <h3 className="mb-0">{summary?.blockedCooldown ?? 0}</h3>
               </div>
             </div>
           </div>
@@ -239,7 +238,10 @@ export default function MoisSalesPagesPipelinePage() {
                 >
                   {isRunning ? (
                     <>
-                      <span className="spinner-border spinner-border-sm me-2" aria-hidden="true" />
+                      <span
+                        className="spinner-border spinner-border-sm me-2"
+                        aria-hidden="true"
+                      />
                       Executando...
                     </>
                   ) : (


### PR DESCRIPTION
### Motivation
- Move operational read paths from the legacy ingest table to the consolidated `mois_sales_page`/`mois_sales_page_job_execution` model so the UI observes the canonical state for pages, pipeline and counts.
- Expose global counters and execution history so the frontend can show accurate pipeline metrics and an audit trail during the two-table transition.
- Preserve transitional write-double behavior by resolving legacy `url_ingest_id` for write operations until dual-write is retired.

### Description
- Added new DTOs for the consolidated model: `SalesLibraryPageResponse`, `SalesLibraryPageSummaryResponse` and `SalesLibraryPageExecutionResponse` in `MoisSalesLibraryDtos`. 
- Reworked service read paths to query `mois_sales_page` and `mois_sales_page_job_execution`: `listPages`, `getPage`, `getPageAnalysis`, plus new `summarizePages` and `listPageExecutions`, and added `mapSalesPageResponse` and `findUrlIngestIdForOperationalPage` helpers in `MoisSalesLibraryService`. 
- Kept transitional behavior for reanalyze/update flows by resolving legacy `url_ingest_id` when creating jobs and writing analysis rows, and updated dual-write sync calls accordingly. 
- Controller changes: `MoisSalesLibraryController` now exposes `GET /pages/summary` and `GET /pages/{pageId}/executions` and documents that pages are read from the consolidated model. 
- Frontend changes: updated API types and hooks to support summary and executions (`types.ts`, `useMoisSalesLibrary.ts`), and updated UI pages (`MoisSalesPagesLibraryPage.tsx`, `MoisSalesPagesPipelinePage.tsx`, `MoisSalesPageLibraryDetailPage.tsx`) to display consolidated counters, pipeline stage/status and execution history. 
- Added/updated unit tests for the controller contract (`MoisSalesLibraryControllerTest`) to cover the new endpoints. 
- Updated project changelog `docs/registros/mois1.md` with Phase 4 notes. 

### Testing
- Ran backend unit tests for the `ads-service` module (including updated `MoisSalesLibraryControllerTest` and existing service tests) and they passed. 
- Executed frontend type-check and build (`yarn`/`tsc` checks) to validate the updated API types and components and the build succeeded. 
- Verified the modified controller test suite for the new endpoints passed locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2199def544832192bea0f36967b4dd)