### PR TITLE
Fix OpenAI model catalog typecheck

### DIFF
--- a/frontend/src/api/openAiModel/useOpenAiModelCatalog.ts
+++ b/frontend/src/api/openAiModel/useOpenAiModelCatalog.ts
@@ -1,0 +1,23 @@
+import { useQuery, useQueryClient } from "@tanstack/react-query";
+import axios from "axios";
+
+export interface OpenAiModelCatalog {
+  textModels: string[];
+  imageModels: string[];
+  source: string;
+  fetchedAt: string;
+}
+
+export function useOpenAiModelCatalog() {
+  const queryClient = useQueryClient();
+  return useQuery({
+    queryKey: ["openAiModelCatalog"],
+    queryFn: async () => {
+      const { data } = await axios.get<OpenAiModelCatalog>(
+        "/api/modelos/openai/catalogo/v1",
+      );
+      queryClient.invalidateQueries({ queryKey: ["openAiModels"] });
+      return data;
+    },
+  });
+}

--- a/frontend/src/pages/openaiModel/OpenAiModelListPage.tsx
+++ b/frontend/src/pages/openaiModel/OpenAiModelListPage.tsx
@@ -1,5 +1,6 @@
 import { Link, useNavigate } from "react-router-dom";
 import PageTitle from "../../components/PageTitle";
+import { useOpenAiModelCatalog } from "../../api/openAiModel/useOpenAiModelCatalog";
 import { useOpenAiModels } from "../../api/openAiModel/useOpenAiModels";
 
 const priceFormatter = new Intl.NumberFormat("pt-BR", {


### PR DESCRIPTION
### Motivation
- Fix TypeScript typecheck errors in `OpenAiModelListPage.tsx` caused by a missing `useOpenAiModelCatalog` hook and implicit `any` in `.map` callbacks by providing a typed catalog hook.

### Description
- Add `frontend/src/api/openAiModel/useOpenAiModelCatalog.ts` with the `OpenAiModelCatalog` interface and `useOpenAiModelCatalog` hook that fetches `/api/modelos/openai/catalogo/v1` and invalidates the `["openAiModels"]` query.
- Update `frontend/src/pages/openaiModel/OpenAiModelListPage.tsx` to import and use `useOpenAiModelCatalog`, enabling correct typing for `catalog.textModels` and `catalog.imageModels`.

### Testing
- Ran `npm --prefix frontend install` which completed successfully.
- Formatted the files with `npx --prefix frontend prettier --write frontend/src/api/openAiModel/useOpenAiModelCatalog.ts frontend/src/pages/openaiModel/OpenAiModelListPage.tsx` successfully.
- Ran type checking with `npm --prefix frontend run typecheck` and it completed without TypeScript errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a21ab3903d08321be2e893c4388e7fb)