### PR TITLE
Use gpt-5.5 for GeraLanding preset-design and enforce model by pipeline section

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineOpenAiClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineOpenAiClient.java
@@ -37,6 +37,7 @@ import org.springframework.web.reactive.function.client.WebClientResponseExcepti
 public class ExperimentPipelineOpenAiClient {
     private static final Logger log = LoggerFactory.getLogger(ExperimentPipelineOpenAiClient.class);
     private static final String REQUIRED_TEXT_MODEL = "gpt-5.2";
+    private static final String REQUIRED_LANDING_DESIGN_PRESET_MODEL = "gpt-5.5";
     private static final String REQUIRED_LANDING_HTML_MODEL = "gpt-5.1-codex";
     private static final int TRANSIENT_ERROR_MAX_ATTEMPTS = 3;
     private static final long TRANSIENT_ERROR_RETRY_DELAY_MS = 1_500L;
@@ -1423,8 +1424,9 @@ public class ExperimentPipelineOpenAiClient {
     }
 
 
+    /** Define o modelo obrigatório por seção antes do envio do job para a OpenAI. */
     private String enforceRequiredModel(Map<String, Object> payload, ExperimentPipelineJobDto job) {
-        String requiredModel = isLandingHtmlSection(job) ? REQUIRED_LANDING_HTML_MODEL : REQUIRED_TEXT_MODEL;
+        String requiredModel = requiredModelForSection(job);
         if (payload == null) {
             return requiredModel;
         }
@@ -1440,6 +1442,17 @@ public class ExperimentPipelineOpenAiClient {
         }
         payload.put("model", requiredModel);
         return requiredModel;
+    }
+
+    /** Resolve o modelo obrigatório conforme a etapa do pipeline de experimento. */
+    private String requiredModelForSection(ExperimentPipelineJobDto job) {
+        if (isLandingHtmlSection(job)) {
+            return REQUIRED_LANDING_HTML_MODEL;
+        }
+        if (isLandingDesignPresetSection(job)) {
+            return REQUIRED_LANDING_DESIGN_PRESET_MODEL;
+        }
+        return REQUIRED_TEXT_MODEL;
     }
 
     private OpenAiResponse requestWithTransientRetries(Map<String, Object> payload, ExperimentPipelineJobDto job) {

--- a/ai-worker/src/main/java/com/marketinghub/worker/openai/core/presetdesign/PresetDesignPromptBuilder.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/openai/core/presetdesign/PresetDesignPromptBuilder.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marketinghub.worker.openai.core.exception.StageWorkerException;
 import com.marketinghub.worker.openai.core.model.OpenAiRequest;
 import com.marketinghub.worker.openai.core.model.StageExecution;
-import com.marketinghub.worker.openai.core.openai.OpenAiClientProperties;
 import com.marketinghub.worker.openai.core.port.StagePromptBuilder;
 import com.marketinghub.worker.openai.core.prompt.PromptTemplateResolver;
 
@@ -19,18 +18,15 @@ import org.springframework.core.io.ClassPathResource;
 public class PresetDesignPromptBuilder implements StagePromptBuilder<PresetDesignInput> {
 
     private final ObjectMapper objectMapper;
-    private final OpenAiClientProperties openAiProperties;
     private final PresetDesignWorkerProperties presetdesignProperties;
     private final PromptTemplateResolver promptTemplateResolver;
 
-    /** Inicializa o builder com serializador, propriedades OpenAI e propriedades da etapa presetdesign. */
+    /** Inicializa o builder com serializador e propriedades da etapa presetdesign. */
     public PresetDesignPromptBuilder(
             ObjectMapper objectMapper,
-            OpenAiClientProperties openAiProperties,
             PresetDesignWorkerProperties presetdesignProperties
     ) {
         this.objectMapper = objectMapper;
-        this.openAiProperties = openAiProperties;
         this.presetdesignProperties = presetdesignProperties;
         this.promptTemplateResolver = new PromptTemplateResolver(this::loadResource, this::toJsonOrText);
     }
@@ -47,7 +43,7 @@ public class PresetDesignPromptBuilder implements StagePromptBuilder<PresetDesig
         String requestBodyJson = buildResponsesApiRequest(prompt, schemaJson);
 
         return new OpenAiRequest(
-                openAiProperties.model(),
+                presetdesignProperties.model(),
                 prompt,
                 requestBodyJson,
                 presetdesignProperties.schemaName(),
@@ -76,7 +72,7 @@ public class PresetDesignPromptBuilder implements StagePromptBuilder<PresetDesig
             text.put("format", format);
 
             Map<String, Object> body = new LinkedHashMap<>();
-            body.put("model", openAiProperties.model());
+            body.put("model", presetdesignProperties.model());
             body.put("input", prompt);
             body.put("text", text);
 

--- a/ai-worker/src/main/java/com/marketinghub/worker/openai/core/presetdesign/PresetDesignWorkerConfiguration.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/openai/core/presetdesign/PresetDesignWorkerConfiguration.java
@@ -41,10 +41,9 @@ public class PresetDesignWorkerConfiguration {
     @Bean
     public PresetDesignPromptBuilder presetdesignPromptBuilder(
             ObjectMapper objectMapper,
-            OpenAiClientProperties openAiProperties,
             PresetDesignWorkerProperties presetdesignProperties
     ) {
-        return new PresetDesignPromptBuilder(objectMapper, openAiProperties, presetdesignProperties);
+        return new PresetDesignPromptBuilder(objectMapper, presetdesignProperties);
     }
 
     /** Cria o validador da resposta JSON retornada pela OpenAI para a etapa presetdesign. */

--- a/ai-worker/src/main/java/com/marketinghub/worker/openai/core/presetdesign/PresetDesignWorkerProperties.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/openai/core/presetdesign/PresetDesignWorkerProperties.java
@@ -31,6 +31,9 @@ public record PresetDesignWorkerProperties(
         @NotBlank
         String schemaName,
 
+        @NotBlank
+        String model,
+
         @NotNull
         Duration timeout
 ) {
@@ -38,6 +41,9 @@ public record PresetDesignWorkerProperties(
     public PresetDesignWorkerProperties {
         if (apiPrefix == null || apiPrefix.isBlank()) {
             apiPrefix = "/api";
+        }
+        if (model == null || model.isBlank()) {
+            model = "gpt-5.5";
         }
         if (timeout == null) {
             timeout = Duration.ofMinutes(30);

--- a/ai-worker/src/main/resources/application.properties
+++ b/ai-worker/src/main/resources/application.properties
@@ -89,6 +89,7 @@ presetdesign.worker.api-prefix=${PRESETDESIGN_WORKER_API_PREFIX:${backend.api-pr
 presetdesign.worker.prompt-resource=${PRESETDESIGN_WORKER_PROMPT_RESOURCE:prompts/geralanding/landing-page-design-preset.md}
 presetdesign.worker.schema-resource=${PRESETDESIGN_WORKER_SCHEMA_RESOURCE:prompts/geralanding/landing-page-design-preset-schema.json}
 presetdesign.worker.schema-name=${PRESETDESIGN_WORKER_SCHEMA_NAME:experiment_pipeline_landing_page_design_preset}
+presetdesign.worker.model=${PRESETDESIGN_WORKER_MODEL:gpt-5.5}
 presetdesign.worker.timeout=${PRESETDESIGN_WORKER_TIMEOUT:PT30M}
 copy.worker.enabled=${COPY_WORKER_ENABLED:true}
 copy.worker.pending-limit=${COPY_WORKER_PENDING_LIMIT:5}

--- a/ai-worker/src/test/java/com/marketinghub/worker/openai/core/presetdesign/PresetDesignBackendClientTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/openai/core/presetdesign/PresetDesignBackendClientTest.java
@@ -8,7 +8,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marketinghub.worker.openai.core.exception.OpenAiHttpException;
 import com.marketinghub.worker.openai.core.model.OpenAiDispatch;
 import com.marketinghub.worker.openai.core.model.StageExecution;
-import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.Instant;
@@ -56,6 +55,7 @@ class PresetDesignBackendClientTest {
                         "prompts/geralanding/landing-page-design-preset.md",
                         "prompts/geralanding/landing-page-design-preset-schema.json",
                         "experiment_pipeline_landing_page_design_preset",
+                        "gpt-5.5",
                         Duration.ofSeconds(5)),
                 objectMapper);
         StageExecution<PresetDesignInput> execution = new StageExecution<>(
@@ -102,6 +102,7 @@ class PresetDesignBackendClientTest {
                         "prompts/geralanding/landing-page-design-preset.md",
                         "prompts/geralanding/landing-page-design-preset-schema.json",
                         "experiment_pipeline_landing_page_design_preset",
+                        "gpt-5.5",
                         Duration.ofSeconds(5)),
                 objectMapper);
         StageExecution<PresetDesignInput> execution = new StageExecution<>(
@@ -149,16 +150,9 @@ class PresetDesignBackendClientTest {
                 "prompts/geralanding/landing-page-design-preset.md",
                 "prompts/geralanding/landing-page-design-preset-schema.json",
                 "experiment_pipeline_landing_page_design_preset",
+                "gpt-5.5",
                 Duration.ofSeconds(5));
-        var openAiProperties = new com.marketinghub.worker.openai.core.openai.OpenAiClientProperties(
-                "test-key",
-                "https://api.openai.com/v1",
-                "gpt-test",
-                Duration.ofMinutes(30),
-                BigDecimal.ZERO,
-                BigDecimal.ZERO,
-                true);
-        PresetDesignPromptBuilder builder = new PresetDesignPromptBuilder(objectMapper, openAiProperties, properties);
+        PresetDesignPromptBuilder builder = new PresetDesignPromptBuilder(objectMapper, properties);
         StageExecution<PresetDesignInput> execution = new StageExecution<>(
                 "job-ia-1",
                 12L,
@@ -180,7 +174,7 @@ class PresetDesignBackendClientTest {
 
         assertThat(request.schemaName()).isEqualTo("experiment_pipeline_landing_page_design_preset");
         assertThat(request.prompt()).contains("gestores");
-        assertThat(body.path("model").asText()).isEqualTo("gpt-test");
+        assertThat(body.path("model").asText()).isEqualTo("gpt-5.5");
         assertThat(body.path("text").path("format").path("name").asText())
                 .isEqualTo("experiment_pipeline_landing_page_design_preset");
         assertThat(body.path("text").path("format").path("strict").asBoolean()).isTrue();

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -3393,3 +3393,10 @@
 - causa-raiz/objetivo: o endpoint `/models` da OpenAI exige autenticação Bearer; manter o botão ativo criava uma ação que aparentava sincronizar dados oficiais, mas falhava quando `OPENAI_API_KEY` não estava configurada.
 - correção aplicada: removido o card “Catálogo oficial (OpenAI)” e a chamada frontend `/api/modelos/openai/catalogo/v1`, preservando apenas a tabela do catálogo interno `openai_model`, que é a fonte operacional dos preços por 1 milhão de tokens.
 - impacto esperado: a tela fica mais simples e evita uma ação indisponível, mantendo foco no cadastro interno de preços usado nos cálculos de custo dos experimentos.
+
+## 2026-06-04 — Modelo 5.5 no Preset Design do GeraLanding
+
+- solicitação: configurar a etapa `landing-page-design-preset` do GeraLanding para usar o modelo `gpt-5.5`.
+- causa-raiz/objetivo: o preset visual precisa de maior capacidade de julgamento para transformar wireframe, copy e imagens em acabamento comercial mais premium, preservando o eixo Dor → Resultado → Mecanismo → Prova → Oferta.
+- correção aplicada: o Worker AI passou a ter modelo específico `presetdesign.worker.model`, com padrão `gpt-5.5`, e o builder da etapa usa esse modelo no `OpenAiRequest` e no corpo da Responses API; o cliente legado do pipeline também força `gpt-5.5` quando a seção é `landing-page-design-preset`.
+- validação automatizada: teste do `PresetDesignPromptBuilder` atualizado para garantir que o payload enviado à OpenAI declara `gpt-5.5` na etapa de preset design.


### PR DESCRIPTION
### Motivation
- Improve visual judgment and commercial finish of the GeraLanding "landing-page-design-preset" step by using a stronger model for that stage. 
- Ensure pipeline jobs send the correct model per section so Responses API payloads and downstream validators/assemblers receive the expected capabilities.

### Description
- Added a `model` property to `PresetDesignWorkerProperties` and wired it into the prompt builder so `PresetDesignPromptBuilder` uses `presetdesignProperties.model()` when building `OpenAiRequest` and the Responses API body. 
- Introduced `presetdesign.worker.model` default (`gpt-5.5`) in `ai-worker/src/main/resources/application.properties`. 
- Updated `ExperimentPipelineOpenAiClient` to enforce a required model per section by adding `REQUIRED_LANDING_DESIGN_PRESET_MODEL = "gpt-5.5"` and a `requiredModelForSection(...)` helper so jobs for `landing-page-design-preset` are forced to use `gpt-5.5`. 
- Updated unit test `PresetDesignBackendClientTest` to include the new `model` property in `PresetDesignWorkerProperties` and to assert the payload declares `gpt-5.5`; and added a short entry to `docs/registros/experimentos.md` documenting the change.

### Testing
- Built and installed the backend artifact with `mvn -DskipTests install` in `backend/ads-service`, which completed successfully (`BUILD SUCCESS`).
- Ran the ai-worker unit test `PresetDesignBackendClientTest` with `mvn -Dtest=PresetDesignBackendClientTest test` after installing the backend artifact; the test executed and validated the generated OpenAI payload now declares `gpt-5.5` as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a21b4097be083219f4f0f26d1112cb7)