### PR TITLE
Fase 1: Governança do contrato de Pipelines — metadata e diagnóstico

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/pipeline/definition/PipelineDefinitionRegistry.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/pipeline/definition/PipelineDefinitionRegistry.java
@@ -1,0 +1,182 @@
+package com.marketinghub.pipeline.definition;
+
+import com.marketinghub.experiment.pipeline.ExperimentPipelineSection;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+/**
+ * Registro oficial que define os pipelines, módulos e etapas estruturais conhecidos pelo backend.
+ */
+@Component
+public class PipelineDefinitionRegistry {
+    private static final String EXPERIMENT_PIPELINE_CODE = "experiment-pipeline";
+    private static final String EXPERIMENT_MODULE = "EXPERIMENT";
+
+    private final List<PipelineDefinition> officialPipelines;
+    private final Set<String> validModules;
+
+    /**
+     * Inicializa o registro oficial a partir das etapas canônicas implementadas no código.
+     */
+    public PipelineDefinitionRegistry() {
+        this.officialPipelines = List.of(buildExperimentPipeline());
+        this.validModules = Set.of(EXPERIMENT_MODULE, "GERALANDING", "MDS", "MOIS", "OPRM");
+    }
+
+    /**
+     * Lista todos os pipelines oficiais que a tela pode consultar como contrato permitido.
+     */
+    public List<PipelineDefinition> officialPipelines() {
+        return officialPipelines;
+    }
+
+    /**
+     * Lista os módulos válidos conhecidos para pipelines administráveis.
+     */
+    public Set<String> validModules() {
+        return validModules;
+    }
+
+    /**
+     * Localiza a definição oficial associada ao código operacional do banco.
+     */
+    public Optional<PipelineDefinition> findByPipelineCode(String code) {
+        String normalized = normalize(code);
+        return officialPipelines.stream()
+                .filter(definition -> definition.matchesCode(normalized))
+                .findFirst();
+    }
+
+    /**
+     * Indica se o código informado pertence a um pipeline oficial protegido.
+     */
+    public boolean isOfficialPipelineCode(String code) {
+        return findByPipelineCode(code).isPresent();
+    }
+
+    /**
+     * Localiza uma etapa canônica pelo código operacional ou por alias explícito.
+     */
+    public Optional<PipelineStageDefinition> findStage(PipelineDefinition pipelineDefinition, String stageCode) {
+        String normalized = normalize(stageCode);
+        return pipelineDefinition.stages().stream()
+                .filter(stage -> stage.matchesCode(normalized))
+                .findFirst();
+    }
+
+    /**
+     * Normaliza códigos estruturais para comparação sem variações de caixa ou separador.
+     */
+    public String normalize(String code) {
+        if (!StringUtils.hasText(code)) {
+            return "";
+        }
+        return code.trim().toLowerCase(Locale.ROOT).replace('_', '-');
+    }
+
+    /**
+     * Monta a definição oficial do pipeline de experimento a partir do enum canônico implementado.
+     */
+    private PipelineDefinition buildExperimentPipeline() {
+        List<PipelineStageDefinition> stages = Arrays.stream(ExperimentPipelineSection.values())
+                .map(section -> new PipelineStageDefinition(
+                        section.name(),
+                        section.path(),
+                        displayName(section.path()),
+                        section.ordinal() + 1,
+                        true,
+                        true,
+                        Set.of(section.path(), section.name(), section.name().toLowerCase(Locale.ROOT))))
+                .toList();
+        return new PipelineDefinition(
+                EXPERIMENT_MODULE,
+                EXPERIMENT_PIPELINE_CODE,
+                "Pipeline de Experimento",
+                true,
+                Set.of(EXPERIMENT_PIPELINE_CODE, "experiment_pipeline"),
+                stages);
+    }
+
+    /**
+     * Converte um código canônico em nome legível para diagnóstico e metadados da tela.
+     */
+    private String displayName(String code) {
+        return Arrays.stream(code.split("-"))
+                .map(part -> part.substring(0, 1).toUpperCase(Locale.ROOT) + part.substring(1))
+                .collect(Collectors.joining(" "));
+    }
+
+    /**
+     * Definição oficial de um pipeline protegido pelo contrato operacional.
+     */
+    public record PipelineDefinition(
+            String module,
+            String code,
+            String name,
+            boolean official,
+            Set<String> aliases,
+            List<PipelineStageDefinition> stages) {
+        /**
+         * Informa se o código recebido é o código oficial ou um alias permitido.
+         */
+        public boolean matchesCode(String normalizedCode) {
+            return normalizeLocal(code).equals(normalizedCode)
+                    || aliases.stream().map(PipelineDefinition::normalizeLocal).anyMatch(normalizedCode::equals);
+        }
+
+        /**
+         * Retorna um mapa de etapas por posição canônica.
+         */
+        public Map<Integer, PipelineStageDefinition> stagesByPosition() {
+            return stages.stream().collect(Collectors.toUnmodifiableMap(PipelineStageDefinition::position, stage -> stage));
+        }
+
+        /**
+         * Normaliza códigos locais do record sem depender da instância do registry.
+         */
+        private static String normalizeLocal(String code) {
+            if (!StringUtils.hasText(code)) {
+                return "";
+            }
+            return code.trim().toLowerCase(Locale.ROOT).replace('_', '-');
+        }
+    }
+
+    /**
+     * Definição oficial de uma etapa implementada no código para um pipeline protegido.
+     */
+    public record PipelineStageDefinition(
+            String canonicalCode,
+            String operationalCode,
+            String name,
+            int position,
+            boolean required,
+            boolean configurable,
+            Set<String> aliases) {
+        /**
+         * Informa se o código recebido é o código operacional ou alias da etapa.
+         */
+        public boolean matchesCode(String normalizedCode) {
+            return normalizeLocal(operationalCode).equals(normalizedCode)
+                    || normalizeLocal(canonicalCode).equals(normalizedCode)
+                    || aliases.stream().map(PipelineStageDefinition::normalizeLocal).anyMatch(normalizedCode::equals);
+        }
+
+        /**
+         * Normaliza códigos locais do record sem depender da instância do registry.
+         */
+        private static String normalizeLocal(String code) {
+            if (!StringUtils.hasText(code)) {
+                return "";
+            }
+            return code.trim().toLowerCase(Locale.ROOT).replace('_', '-');
+        }
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/pipeline/dto/OfficialPipelineDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/pipeline/dto/OfficialPipelineDto.java
@@ -1,0 +1,16 @@
+package com.marketinghub.pipeline.dto;
+
+import java.util.List;
+import lombok.Builder;
+
+/**
+ * DTO que descreve um pipeline oficial protegido contra edição estrutural perigosa.
+ */
+@Builder
+public record OfficialPipelineDto(
+        String module,
+        String code,
+        String name,
+        boolean official,
+        List<String> aliases,
+        List<OfficialPipelineStageDto> stages) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/pipeline/dto/OfficialPipelineStageDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/pipeline/dto/OfficialPipelineStageDto.java
@@ -1,0 +1,17 @@
+package com.marketinghub.pipeline.dto;
+
+import java.util.List;
+import lombok.Builder;
+
+/**
+ * DTO que descreve uma etapa oficial e seus aliases canônicos para a tela administrativa.
+ */
+@Builder
+public record OfficialPipelineStageDto(
+        String canonicalCode,
+        String operationalCode,
+        String name,
+        int position,
+        boolean required,
+        boolean configurable,
+        List<String> aliases) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/pipeline/dto/PipelineDiagnosticsDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/pipeline/dto/PipelineDiagnosticsDto.java
@@ -1,0 +1,17 @@
+package com.marketinghub.pipeline.dto;
+
+import java.util.List;
+import lombok.Builder;
+
+/**
+ * DTO que resume o diagnóstico de aderência entre banco e contrato oficial do pipeline.
+ */
+@Builder
+public record PipelineDiagnosticsDto(
+        Long pipelineId,
+        String pipelineCode,
+        String canonicalPipelineCode,
+        String status,
+        int expectedStages,
+        int configuredStages,
+        List<PipelineDiagnosticsIssueDto> issues) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/pipeline/dto/PipelineDiagnosticsIssueDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/pipeline/dto/PipelineDiagnosticsIssueDto.java
@@ -1,0 +1,15 @@
+package com.marketinghub.pipeline.dto;
+
+import lombok.Builder;
+
+/**
+ * DTO que descreve uma divergência específica encontrada no contrato operacional do pipeline.
+ */
+@Builder
+public record PipelineDiagnosticsIssueDto(
+        String severity,
+        String stageCode,
+        String canonicalCode,
+        String message,
+        String rootCause,
+        String recommendedAction) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/pipeline/dto/PipelineMetadataDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/pipeline/dto/PipelineMetadataDto.java
@@ -1,0 +1,10 @@
+package com.marketinghub.pipeline.dto;
+
+import java.util.List;
+import lombok.Builder;
+
+/**
+ * DTO que expõe à tela os módulos, pipelines e etapas permitidos pelo contrato oficial.
+ */
+@Builder
+public record PipelineMetadataDto(List<String> validModules, List<OfficialPipelineDto> officialPipelines) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/pipeline/service/PipelineService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/pipeline/service/PipelineService.java
@@ -3,16 +3,29 @@ package com.marketinghub.pipeline.service;
 import com.marketinghub.openai.OpenAiModel;
 import com.marketinghub.pipeline.Pipeline;
 import com.marketinghub.pipeline.PipelineStage;
+import com.marketinghub.pipeline.definition.PipelineDefinitionRegistry;
+import com.marketinghub.pipeline.definition.PipelineDefinitionRegistry.PipelineDefinition;
+import com.marketinghub.pipeline.definition.PipelineDefinitionRegistry.PipelineStageDefinition;
+import com.marketinghub.pipeline.dto.OfficialPipelineDto;
+import com.marketinghub.pipeline.dto.OfficialPipelineStageDto;
+import com.marketinghub.pipeline.dto.PipelineDiagnosticsDto;
+import com.marketinghub.pipeline.dto.PipelineDiagnosticsIssueDto;
+import com.marketinghub.pipeline.dto.PipelineMetadataDto;
 import com.marketinghub.pipeline.dto.PipelineRequest;
 import com.marketinghub.pipeline.dto.PipelineStageRequest;
 import com.marketinghub.repository.jpa.openai.OpenAiModelRepository;
 import com.marketinghub.repository.jpa.pipeline.PipelineRepository;
 import com.marketinghub.repository.jpa.pipeline.PipelineStageRepository;
 import jakarta.persistence.EntityNotFoundException;
+import java.util.ArrayList;
 import java.util.Comparator;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
 
 /**
  * Serviço responsável por manter pipelines e etapas usados pela operação do Marketing Hub.
@@ -22,6 +35,7 @@ public class PipelineService {
     private final PipelineRepository pipelineRepository;
     private final PipelineStageRepository stageRepository;
     private final OpenAiModelRepository openAiModelRepository;
+    private final PipelineDefinitionRegistry definitionRegistry;
 
     /**
      * Inicializa o serviço com os repositórios centralizados de pipelines, etapas e modelos OpenAI.
@@ -29,10 +43,12 @@ public class PipelineService {
     public PipelineService(
             PipelineRepository pipelineRepository,
             PipelineStageRepository stageRepository,
-            OpenAiModelRepository openAiModelRepository) {
+            OpenAiModelRepository openAiModelRepository,
+            PipelineDefinitionRegistry definitionRegistry) {
         this.pipelineRepository = pipelineRepository;
         this.stageRepository = stageRepository;
         this.openAiModelRepository = openAiModelRepository;
+        this.definitionRegistry = definitionRegistry;
     }
 
     /**
@@ -55,39 +71,47 @@ public class PipelineService {
     }
 
     /**
-     * Cria um novo pipeline operacional.
+     * Cria um novo pipeline operacional validando módulo e contrato conhecido.
      */
     @Transactional
     public Pipeline create(PipelineRequest request) {
+        validatePipelineModule(request.getModule());
         Pipeline pipeline = new Pipeline();
         applyPipelineRequest(pipeline, request);
         return pipelineRepository.save(pipeline);
     }
 
     /**
-     * Atualiza os dados básicos de um pipeline existente.
+     * Atualiza os dados básicos de um pipeline existente sem permitir mudanças estruturais oficiais.
      */
     @Transactional
     public Pipeline update(Long id, PipelineRequest request) {
         Pipeline pipeline = findPipeline(id);
+        validatePipelineModule(request.getModule());
+        validateOfficialPipelineUpdate(pipeline, request);
         applyPipelineRequest(pipeline, request);
         return pipelineRepository.save(pipeline);
     }
 
     /**
-     * Remove um pipeline e suas etapas vinculadas.
+     * Remove um pipeline configurável, bloqueando exclusão de contratos oficiais.
      */
     @Transactional
     public void delete(Long id) {
-        pipelineRepository.delete(findPipeline(id));
+        Pipeline pipeline = findPipeline(id);
+        if (definitionRegistry.isOfficialPipelineCode(pipeline.getCode())) {
+            throw badRequest("Pipeline oficial não pode ser excluído: " + pipeline.getCode());
+        }
+        pipelineRepository.delete(pipeline);
     }
 
     /**
-     * Cria uma etapa dentro de um pipeline existente.
+     * Cria uma etapa dentro de um pipeline existente validando contrato oficial quando aplicável.
      */
     @Transactional
     public PipelineStage createStage(Long pipelineId, PipelineStageRequest request) {
         Pipeline pipeline = findPipeline(pipelineId);
+        validateStageRequest(pipeline, null, request);
         PipelineStage stage = new PipelineStage();
         stage.setPipeline(pipeline);
         applyStageRequest(stage, request);
@@ -95,21 +119,88 @@ public class PipelineService {
     }
 
     /**
-     * Atualiza uma etapa, preservando o vínculo com o pipeline informado na rota.
+     * Atualiza uma etapa, preservando o vínculo e bloqueando alterações estruturais oficiais.
      */
     @Transactional
     public PipelineStage updateStage(Long pipelineId, Long stageId, PipelineStageRequest request) {
         PipelineStage stage = findStageInPipeline(pipelineId, stageId);
+        validateStageRequest(stage.getPipeline(), stage, request);
         applyStageRequest(stage, request);
         return stageRepository.save(stage);
     }
 
     /**
-     * Remove uma etapa específica de um pipeline.
+     * Remove uma etapa específica, bloqueando remoção de etapa obrigatória oficial.
      */
     @Transactional
     public void deleteStage(Long pipelineId, Long stageId) {
-        stageRepository.delete(findStageInPipeline(pipelineId, stageId));
+        PipelineStage stage = findStageInPipeline(pipelineId, stageId);
+        PipelineDefinition definition = definitionRegistry.findByPipelineCode(stage.getPipeline().getCode()).orElse(null);
+        if (definition != null && definitionRegistry.findStage(definition, stage.getCode()).filter(PipelineStageDefinition::required).isPresent()) {
+            throw badRequest("Etapa obrigatória oficial não pode ser excluída: " + stage.getCode());
+        }
+        stageRepository.delete(stage);
+    }
+
+
+    /**
+     * Retorna os metadados oficiais que orientam os campos editáveis e protegidos na tela.
+     */
+    public PipelineMetadataDto metadata() {
+        return PipelineMetadataDto.builder()
+                .validModules(definitionRegistry.validModules().stream().sorted().toList())
+                .officialPipelines(definitionRegistry.officialPipelines().stream().map(this::toOfficialDto).toList())
+                .build();
+    }
+
+    /**
+     * Compara as etapas salvas no banco com a definição oficial conhecida pelo backend.
+     */
+    public PipelineDiagnosticsDto diagnostics(Long id) {
+        Pipeline pipeline = get(id);
+        PipelineDefinition definition = definitionRegistry.findByPipelineCode(pipeline.getCode()).orElse(null);
+        if (definition == null) {
+            return PipelineDiagnosticsDto.builder()
+                    .pipelineId(pipeline.getId())
+                    .pipelineCode(pipeline.getCode())
+                    .canonicalPipelineCode(null)
+                    .status("ATENÇÃO")
+                    .expectedStages(0)
+                    .configuredStages(pipeline.getStages().size())
+                    .issues(List.of(issue("WARN", null, null, "Pipeline não possui definição oficial no backend.",
+                            "Pipeline foi criado como configuração livre ou ainda não foi canonizado.",
+                            "Criar definição oficial no backend antes de usar como pipeline estrutural.")))
+                    .build();
+        }
+
+        List<PipelineDiagnosticsIssueDto> issues = new ArrayList<>();
+        Set<String> configuredCodes = new HashSet<>();
+        Set<Integer> configuredPositions = new HashSet<>();
+        for (PipelineStage stage : pipeline.getStages()) {
+            validateStageAgainstDefinition(definition, stage, configuredCodes, configuredPositions, issues);
+        }
+        for (PipelineStageDefinition expected : definition.stages()) {
+            boolean present = pipeline.getStages().stream()
+                    .anyMatch(stage -> definitionRegistry.findStage(definition, stage.getCode())
+                            .map(expected::equals)
+                            .orElse(false));
+            if (!present) {
+                issues.add(issue("ERROR", expected.operationalCode(), expected.canonicalCode(),
+                        "Etapa obrigatória está ausente no banco.",
+                        "Banco foi alterado manualmente ou o pipeline foi criado sem sincronização oficial.",
+                        "Cadastrar a etapa conforme definição oficial antes de executar o pipeline."));
+            }
+        }
+        String status = resolveDiagnosticsStatus(issues);
+        return PipelineDiagnosticsDto.builder()
+                .pipelineId(pipeline.getId())
+                .pipelineCode(pipeline.getCode())
+                .canonicalPipelineCode(definition.code())
+                .status(status)
+                .expectedStages(definition.stages().size())
+                .configuredStages(pipeline.getStages().size())
+                .issues(issues)
+                .build();
     }
 
     /**
@@ -130,6 +221,194 @@ public class PipelineService {
             throw new EntityNotFoundException("Etapa não pertence ao pipeline informado: " + pipelineId);
         }
         return stage;
+    }
+
+
+    /**
+     * Garante que o módulo informado pertence aos módulos oficiais conhecidos.
+     */
+    private void validatePipelineModule(String module) {
+        if (!definitionRegistry.validModules().contains(module)) {
+            throw badRequest("Módulo de pipeline desconhecido: " + module);
+        }
+    }
+
+    /**
+     * Bloqueia alteração de código ou módulo estrutural em pipeline oficial já existente.
+     */
+    private void validateOfficialPipelineUpdate(Pipeline pipeline, PipelineRequest request) {
+        if (!definitionRegistry.isOfficialPipelineCode(pipeline.getCode())) {
+            return;
+        }
+        PipelineDefinition definition = definitionRegistry.findByPipelineCode(pipeline.getCode()).orElseThrow();
+        if (!definitionRegistry.normalize(pipeline.getCode()).equals(definitionRegistry.normalize(request.getCode()))) {
+            throw badRequest("Código de pipeline oficial não pode ser alterado: " + pipeline.getCode());
+        }
+        if (!definition.module().equals(request.getModule())) {
+            throw badRequest("Módulo de pipeline oficial não pode ser alterado: " + pipeline.getCode());
+        }
+    }
+
+    /**
+     * Valida duplicidade operacional e aderência da etapa ao contrato oficial quando existir.
+     */
+    private void validateStageRequest(Pipeline pipeline, PipelineStage currentStage, PipelineStageRequest request) {
+        ensureUniqueStagePositionAndCode(pipeline, currentStage, request);
+        PipelineDefinition definition = definitionRegistry.findByPipelineCode(pipeline.getCode()).orElse(null);
+        if (definition == null) {
+            return;
+        }
+        PipelineStageDefinition requestedDefinition = definitionRegistry.findStage(definition, request.getCode())
+                .orElseThrow(() -> badRequest("Etapa não mapeia para definição canônica oficial: " + request.getCode()));
+        if (currentStage != null) {
+            PipelineStageDefinition currentDefinition = definitionRegistry.findStage(definition, currentStage.getCode())
+                    .orElseThrow(() -> badRequest("Etapa atual não mapeia para definição canônica oficial: " + currentStage.getCode()));
+            if (!currentDefinition.equals(requestedDefinition)) {
+                throw badRequest("Código estrutural de etapa oficial não pode ser alterado: " + currentStage.getCode());
+            }
+        }
+        if (requestedDefinition.required() && !request.isRequired()) {
+            throw badRequest("Etapa obrigatória oficial não pode deixar de ser obrigatória: " + request.getCode());
+        }
+        if (requestedDefinition.required() && !request.isActive()) {
+            throw badRequest("Etapa obrigatória oficial não pode ser desativada sem regra explícita: " + request.getCode());
+        }
+    }
+
+    /**
+     * Impede duplicidade de posição ou código operacional antes da constraint do banco.
+     */
+    private void ensureUniqueStagePositionAndCode(Pipeline pipeline, PipelineStage currentStage, PipelineStageRequest request) {
+        for (PipelineStage existing : pipeline.getStages()) {
+            if (currentStage != null && existing.getId().equals(currentStage.getId())) {
+                continue;
+            }
+            if (existing.getPosition().equals(request.getPosition())) {
+                throw badRequest("Já existe etapa com a posição operacional " + request.getPosition());
+            }
+            if (definitionRegistry.normalize(existing.getCode()).equals(definitionRegistry.normalize(request.getCode()))) {
+                throw badRequest("Já existe etapa com o código operacional " + request.getCode());
+            }
+        }
+    }
+
+    /**
+     * Adiciona divergências específicas de uma etapa comparando banco e definição oficial.
+     */
+    private void validateStageAgainstDefinition(
+            PipelineDefinition definition,
+            PipelineStage stage,
+            Set<String> configuredCodes,
+            Set<Integer> configuredPositions,
+            List<PipelineDiagnosticsIssueDto> issues) {
+        PipelineStageDefinition stageDefinition = definitionRegistry.findStage(definition, stage.getCode()).orElse(null);
+        String normalizedCode = definitionRegistry.normalize(stage.getCode());
+        if (!configuredCodes.add(normalizedCode)) {
+            issues.add(issue("ERROR", stage.getCode(), stageDefinition == null ? null : stageDefinition.canonicalCode(),
+                    "Código operacional duplicado no banco.",
+                    "Banco recebeu alteração duplicada antes da validação estrutural.",
+                    "Manter apenas uma etapa por código operacional."));
+        }
+        if (!configuredPositions.add(stage.getPosition())) {
+            issues.add(issue("ERROR", stage.getCode(), stageDefinition == null ? null : stageDefinition.canonicalCode(),
+                    "Posição operacional duplicada no banco.",
+                    "Banco recebeu alteração duplicada antes da validação estrutural.",
+                    "Manter apenas uma etapa por posição operacional."));
+        }
+        if (stageDefinition == null) {
+            issues.add(issue("ERROR", stage.getCode(), null,
+                    "Etapa extra não possui mapeamento canônico conhecido.",
+                    "Banco foi alterado manualmente ou a tela salvou código fora do contrato oficial.",
+                    "Remover a etapa extra ou criar alias oficial no backend."));
+            return;
+        }
+        if (!stage.getPosition().equals(stageDefinition.position())) {
+            issues.add(issue("ERROR", stage.getCode(), stageDefinition.canonicalCode(),
+                    "Etapa obrigatória está fora da posição canônica.",
+                    "Banco foi alterado manualmente ou por tela sem validação estrutural.",
+                    "Corrigir posição conforme definição oficial."));
+        }
+        if (stageDefinition.required() && !stage.isRequired()) {
+            issues.add(issue("ERROR", stage.getCode(), stageDefinition.canonicalCode(),
+                    "Etapa obrigatória está marcada como opcional no banco.",
+                    "Configuração operacional removeu obrigação estrutural do pipeline oficial.",
+                    "Marcar a etapa como obrigatória."));
+        }
+        if (stageDefinition.required() && !stage.isActive()) {
+            issues.add(issue("ERROR", stage.getCode(), stageDefinition.canonicalCode(),
+                    "Etapa obrigatória está inativa no banco.",
+                    "Configuração operacional desativou etapa necessária para execução do contrato.",
+                    "Reativar a etapa obrigatória ou formalizar regra explícita."));
+        }
+    }
+
+    /**
+     * Resolve o status agregado do diagnóstico a partir da maior severidade encontrada.
+     */
+    private String resolveDiagnosticsStatus(List<PipelineDiagnosticsIssueDto> issues) {
+        if (issues.stream().anyMatch(issue -> "ERROR".equals(issue.severity()))) {
+            return "BLOQUEADO";
+        }
+        if (issues.stream().anyMatch(issue -> "WARN".equals(issue.severity()))) {
+            return "ATENÇÃO";
+        }
+        return "OK";
+    }
+
+    /**
+     * Cria uma divergência padronizada com causa-raiz e ação recomendada para a tela.
+     */
+    private PipelineDiagnosticsIssueDto issue(
+            String severity,
+            String stageCode,
+            String canonicalCode,
+            String message,
+            String rootCause,
+            String recommendedAction) {
+        return PipelineDiagnosticsIssueDto.builder()
+                .severity(severity)
+                .stageCode(stageCode)
+                .canonicalCode(canonicalCode)
+                .message(message)
+                .rootCause(rootCause)
+                .recommendedAction(recommendedAction)
+                .build();
+    }
+
+    /**
+     * Converte definição oficial interna para DTO de metadados consumido pela tela.
+     */
+    private OfficialPipelineDto toOfficialDto(PipelineDefinition definition) {
+        return OfficialPipelineDto.builder()
+                .module(definition.module())
+                .code(definition.code())
+                .name(definition.name())
+                .official(definition.official())
+                .aliases(definition.aliases().stream().sorted().toList())
+                .stages(definition.stages().stream().map(this::toOfficialStageDto).toList())
+                .build();
+    }
+
+    /**
+     * Converte definição oficial de etapa para DTO de metadados consumido pela tela.
+     */
+    private OfficialPipelineStageDto toOfficialStageDto(PipelineStageDefinition definition) {
+        return OfficialPipelineStageDto.builder()
+                .canonicalCode(definition.canonicalCode())
+                .operationalCode(definition.operationalCode())
+                .name(definition.name())
+                .position(definition.position())
+                .required(definition.required())
+                .configurable(definition.configurable())
+                .aliases(definition.aliases().stream().sorted().toList())
+                .build();
+    }
+
+    /**
+     * Cria erro HTTP 400 para violações do contrato operacional editável.
+     */
+    private ResponseStatusException badRequest(String message) {
+        return new ResponseStatusException(HttpStatus.BAD_REQUEST, message);
     }
 
     /**

--- a/backend/ads-service/src/main/java/com/marketinghub/pipeline/web/PipelineController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/pipeline/web/PipelineController.java
@@ -2,7 +2,9 @@ package com.marketinghub.pipeline.web;
 
 import com.marketinghub.pipeline.Pipeline;
 import com.marketinghub.pipeline.PipelineStage;
+import com.marketinghub.pipeline.dto.PipelineDiagnosticsDto;
 import com.marketinghub.pipeline.dto.PipelineDto;
+import com.marketinghub.pipeline.dto.PipelineMetadataDto;
 import com.marketinghub.pipeline.dto.PipelineRequest;
 import com.marketinghub.pipeline.dto.PipelineStageDto;
 import com.marketinghub.pipeline.dto.PipelineStageRequest;
@@ -45,11 +47,27 @@ public class PipelineController {
     }
 
     /**
+     * Obtém metadados oficiais que governam campos editáveis na tela.
+     */
+    @GetMapping("/metadata")
+    public PipelineMetadataDto metadata() {
+        return service.metadata();
+    }
+
+    /**
      * Obtém um pipeline específico com suas etapas ordenadas.
      */
     @GetMapping("/{id}")
     public PipelineDto get(@PathVariable Long id) {
         return mapper.toDto(service.get(id));
+    }
+
+    /**
+     * Diagnostica divergências entre banco e definição oficial do backend.
+     */
+    @GetMapping("/{id}/diagnostics")
+    public PipelineDiagnosticsDto diagnostics(@PathVariable Long id) {
+        return service.diagnostics(id);
     }
 
     /**

--- a/backend/ads-service/src/test/java/com/marketinghub/pipeline/service/PipelineServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/pipeline/service/PipelineServiceTest.java
@@ -1,24 +1,30 @@
 package com.marketinghub.pipeline.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.marketinghub.pipeline.Pipeline;
 import com.marketinghub.pipeline.PipelineStage;
+import com.marketinghub.pipeline.definition.PipelineDefinitionRegistry;
+import com.marketinghub.pipeline.dto.PipelineDiagnosticsDto;
+import com.marketinghub.pipeline.dto.PipelineRequest;
 import com.marketinghub.pipeline.dto.PipelineStageRequest;
+import com.marketinghub.repository.jpa.openai.OpenAiModelRepository;
 import com.marketinghub.repository.jpa.pipeline.PipelineRepository;
 import com.marketinghub.repository.jpa.pipeline.PipelineStageRepository;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import jakarta.persistence.EntityNotFoundException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.server.ResponseStatusException;
 
 /**
  * Testa as regras de manutenção de pipelines e etapas configuráveis.
@@ -31,8 +37,20 @@ class PipelineServiceTest {
     @Mock
     private PipelineStageRepository stageRepository;
 
-    @InjectMocks
+    @Mock
+    private OpenAiModelRepository openAiModelRepository;
+
+    private final PipelineDefinitionRegistry definitionRegistry = new PipelineDefinitionRegistry();
+
     private PipelineService service;
+
+    /**
+     * Inicializa o serviço com registry real para validar regras canônicas.
+     */
+    @org.junit.jupiter.api.BeforeEach
+    void setUp() {
+        service = new PipelineService(pipelineRepository, stageRepository, openAiModelRepository, definitionRegistry);
+    }
 
     /**
      * Garante que a listagem devolve pipelines e etapas em ordem operacional previsível.
@@ -86,16 +104,194 @@ class PipelineServiceTest {
         assertThat(captor.getValue().getCode()).isEqualTo("campaign-angle");
     }
 
+
+    /**
+     * Garante que pipeline oficial não pode ser excluído pela tela administrativa.
+     */
+    @Test
+    void shouldNotDeleteOfficialPipeline() {
+        Pipeline pipeline = Pipeline.builder()
+                .id(10L)
+                .name("Pipeline de Experimento")
+                .code("experiment-pipeline")
+                .module("EXPERIMENT")
+                .stages(new ArrayList<>())
+                .build();
+        when(pipelineRepository.findById(10L)).thenReturn(Optional.of(pipeline));
+
+        assertThatThrownBy(() -> service.delete(10L))
+                .isInstanceOf(ResponseStatusException.class)
+                .hasMessageContaining("Pipeline oficial não pode ser excluído");
+    }
+
+    /**
+     * Garante que a atualização de pipeline oficial preserva código e módulo estruturais.
+     */
+    @Test
+    void shouldNotChangeOfficialPipelineCodeOrModule() {
+        Pipeline pipeline = Pipeline.builder()
+                .id(10L)
+                .name("Pipeline de Experimento")
+                .code("experiment-pipeline")
+                .module("EXPERIMENT")
+                .stages(new ArrayList<>())
+                .build();
+        PipelineRequest request = new PipelineRequest();
+        request.setName("Pipeline editado");
+        request.setCode("outro-pipeline");
+        request.setModule("EXPERIMENT");
+        request.setActive(true);
+        when(pipelineRepository.findById(10L)).thenReturn(Optional.of(pipeline));
+
+        assertThatThrownBy(() -> service.update(10L, request))
+                .isInstanceOf(ResponseStatusException.class)
+                .hasMessageContaining("Código de pipeline oficial não pode ser alterado");
+    }
+
+    /**
+     * Garante que etapa obrigatória oficial não pode ser removida.
+     */
+    @Test
+    void shouldNotDeleteRequiredOfficialStage() {
+        Pipeline pipeline = officialPipelineWith(stage(1L, 1, "campaign-angle"));
+        when(stageRepository.findById(1L)).thenReturn(Optional.of(pipeline.getStages().getFirst()));
+
+        assertThatThrownBy(() -> service.deleteStage(10L, 1L))
+                .isInstanceOf(ResponseStatusException.class)
+                .hasMessageContaining("Etapa obrigatória oficial não pode ser excluída");
+    }
+
+    /**
+     * Garante que etapa oficial não aceita troca de código estrutural para outra etapa canônica.
+     */
+    @Test
+    void shouldNotChangeOfficialStageStructuralCode() {
+        Pipeline pipeline = officialPipelineWith(stage(1L, 1, "campaign-angle"));
+        PipelineStageRequest request = stageRequest(1, "Ad Copy", "ad-copy");
+        when(stageRepository.findById(1L)).thenReturn(Optional.of(pipeline.getStages().getFirst()));
+
+        assertThatThrownBy(() -> service.updateStage(10L, 1L, request))
+                .isInstanceOf(ResponseStatusException.class)
+                .hasMessageContaining("Código estrutural de etapa oficial não pode ser alterado");
+    }
+
+    /**
+     * Garante que o diagnóstico acusa etapa obrigatória ausente no banco.
+     */
+    @Test
+    void shouldDiagnoseMissingRequiredOfficialStage() {
+        Pipeline pipeline = officialPipelineWith(stage(1L, 1, "campaign-angle"));
+        when(pipelineRepository.findById(10L)).thenReturn(Optional.of(pipeline));
+
+        PipelineDiagnosticsDto diagnostics = service.diagnostics(10L);
+
+        assertThat(diagnostics.status()).isEqualTo("BLOQUEADO");
+        assertThat(diagnostics.expectedStages()).isEqualTo(8);
+        assertThat(diagnostics.configuredStages()).isEqualTo(1);
+        assertThat(diagnostics.issues())
+                .anySatisfy(issue -> {
+                    assertThat(issue.severity()).isEqualTo("ERROR");
+                    assertThat(issue.message()).isEqualTo("Etapa obrigatória está ausente no banco.");
+                });
+    }
+
+    /**
+     * Garante que o diagnóstico acusa etapa extra sem mapeamento canônico.
+     */
+    @Test
+    void shouldDiagnoseExtraStageWithoutCanonicalMapping() {
+        Pipeline pipeline = officialPipelineWith(stage(1L, 1, "unknown-stage"));
+        when(pipelineRepository.findById(10L)).thenReturn(Optional.of(pipeline));
+
+        PipelineDiagnosticsDto diagnostics = service.diagnostics(10L);
+
+        assertThat(diagnostics.status()).isEqualTo("BLOQUEADO");
+        assertThat(diagnostics.issues())
+                .anySatisfy(issue -> assertThat(issue.message())
+                        .isEqualTo("Etapa extra não possui mapeamento canônico conhecido."));
+    }
+
+    /**
+     * Garante que cada etapa oficial possui código operacional e alias canônico reconhecido.
+     */
+    @Test
+    void shouldExposeOfficialStageAliasesAndCanonicalCodes() {
+        assertThat(definitionRegistry.officialPipelines()).singleElement().satisfies(pipeline -> {
+            assertThat(pipeline.code()).isEqualTo("experiment-pipeline");
+            assertThat(pipeline.stages()).hasSize(8);
+            assertThat(pipeline.stages())
+                    .allSatisfy(stage -> {
+                        assertThat(stage.canonicalCode()).isNotBlank();
+                        assertThat(stage.operationalCode()).isNotBlank();
+                        assertThat(definitionRegistry.findStage(pipeline, stage.canonicalCode())).contains(stage);
+                        assertThat(definitionRegistry.findStage(pipeline, stage.operationalCode())).contains(stage);
+                    });
+        });
+    }
+
+    /**
+     * Garante que o serviço rejeita modelo OpenAI inexistente na etapa.
+     */
+    @Test
+    void shouldRejectMissingOpenAiModel() {
+        Pipeline pipeline = Pipeline.builder().id(10L).name("Pipeline").code("custom").module("EXPERIMENT").stages(new ArrayList<>()).build();
+        PipelineStageRequest request = stageRequest(1, "Campaign Angle", "campaign-angle");
+        request.setOpenAiModelId(99L);
+        when(pipelineRepository.findById(10L)).thenReturn(Optional.of(pipeline));
+        when(openAiModelRepository.findById(99L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.createStage(10L, request))
+                .isInstanceOf(EntityNotFoundException.class)
+                .hasMessageContaining("Modelo OpenAI não encontrado");
+    }
+
     /**
      * Cria uma etapa sintética para validar ordenação no serviço.
      */
     private PipelineStage stage(Long id, Integer position) {
+        return stage(id, position, "stage-" + position);
+    }
+
+    /**
+     * Cria uma etapa sintética com código explícito para validar contrato oficial.
+     */
+    private PipelineStage stage(Long id, Integer position, String code) {
         return PipelineStage.builder()
                 .id(id)
                 .position(position)
                 .name("Etapa " + position)
-                .code("stage-" + position)
+                .code(code)
+                .required(true)
+                .active(true)
                 .build();
+    }
+
+    /**
+     * Cria payload sintético de etapa para testes de validação.
+     */
+    private PipelineStageRequest stageRequest(Integer position, String name, String code) {
+        PipelineStageRequest request = new PipelineStageRequest();
+        request.setPosition(position);
+        request.setName(name);
+        request.setCode(code);
+        request.setRequired(true);
+        request.setActive(true);
+        return request;
+    }
+
+    /**
+     * Cria pipeline oficial sintético com as etapas informadas já vinculadas.
+     */
+    private Pipeline officialPipelineWith(PipelineStage... stages) {
+        Pipeline pipeline = Pipeline.builder()
+                .id(10L)
+                .name("Pipeline de Experimento")
+                .code("experiment-pipeline")
+                .module("EXPERIMENT")
+                .stages(new ArrayList<>(List.of(stages)))
+                .build();
+        pipeline.getStages().forEach(stage -> stage.setPipeline(pipeline));
+        return pipeline;
     }
 
 }

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -3413,3 +3413,12 @@
 - causa-raiz/objetivo: a tela de pipelines configura dados operacionais críticos e precisa ser governada pelo backend como contrato, não como CRUD livre, preservando a aderência entre frontend, banco, backend, workers e documentos canônicos.
 - registro aplicado: criado `docs/implementacao/plano-pipelines-contrato-operacional.md` com estratégia em três fases: governança sem novas tabelas, contrato forte com sincronização segura e separação persistente entre definição e configuração somente se houver necessidade comprovada.
 - decisão operacional: iniciar pela Fase 1 sem criar tabelas novas, mantendo as tabelas atuais e fortalecendo validação, metadados e diagnóstico no backend.
+
+## 2026-06-04 — Fase 1 do contrato operacional da tela de Pipelines
+
+- solicitação: executar a Fase 1 de `docs/implementacao/plano-pipelines-contrato-operacional.md` sem criar tabelas novas.
+- causa-raiz/objetivo: reduzir divergência silenciosa entre tela, banco e código, tornando o backend guardião do contrato oficial dos pipelines antes da execução operacional.
+- correção aplicada: criado registry oficial de pipelines/etapas no backend, endpoints `GET /api/pipelines/metadata` e `GET /api/pipelines/{id}/diagnostics`, bloqueios de exclusão/alteração estrutural em pipeline oficial, validações de duplicidade, modelo OpenAI inexistente, etapa obrigatória removida/inativa e etapa sem mapeamento canônico.
+- tela ajustada: `/pipelines` passou a exibir status `OK`, `ATENÇÃO` ou `BLOQUEADO`, contagem esperada/configurada, divergências com causa-raiz e ação recomendada, código do banco e código canônico lado a lado, além de campos estruturais protegidos para pipelines oficiais.
+- documentação de contrato: criado `docs/swagger/pipeline-swagger.yaml` e atualizado o índice `docs/swagger/README.md`.
+- validação automatizada: testes unitários de `PipelineServiceTest` cobrem exclusão de pipeline oficial, remoção/alteração de etapa oficial, diagnóstico de etapa ausente/extra, aliases canônicos e modelo OpenAI inexistente.

--- a/docs/swagger/README.md
+++ b/docs/swagger/README.md
@@ -17,6 +17,7 @@ Esta pasta é o local único para contratos Swagger/OpenAPI do Marketing Hub.
 - `docs/swagger/openapi.yaml` — superfície geral da API Marketing Hub.
 - `docs/swagger/openapi_mds_backend_stub.yaml` — stub de integração MDS.
 - `docs/swagger/openapi_mois_backend_stub.yaml` — stub de integração MOIS.
+- `docs/swagger/pipeline-swagger.yaml` — governança administrativa de pipelines e etapas.
 - `docs/swagger/oprm-backend-integration-openapi.v1.yaml` — integração OPRM ↔ backend.
 - `docs/swagger/oprm-backend-required-endpoints.swagger.yaml` — endpoints obrigatórios do backend para OPRM.
 - `docs/swagger/oprm-nichocnae-swagger.yaml` — pipeline OPRM Nicho CNAE.

--- a/docs/swagger/pipeline-swagger.yaml
+++ b/docs/swagger/pipeline-swagger.yaml
@@ -1,0 +1,143 @@
+openapi: 3.0.3
+info:
+  title: Marketing Hub Pipeline Governance API
+  version: "1.0.0"
+  description: Endpoints administrativos para governança de pipelines e etapas sem criar tabelas novas.
+servers:
+  - url: /api
+paths:
+  /pipelines/metadata:
+    get:
+      summary: Lista metadados oficiais de pipelines, módulos e etapas permitidas.
+      responses:
+        "200":
+          description: Metadados oficiais para controlar campos editáveis na tela.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PipelineMetadata"
+  /pipelines/{id}/diagnostics:
+    get:
+      summary: Diagnostica aderência do pipeline salvo no banco à definição oficial do backend.
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        "200":
+          description: Status do contrato operacional e divergências acionáveis.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PipelineDiagnostics"
+        "404":
+          description: Pipeline não encontrado.
+components:
+  schemas:
+    PipelineMetadata:
+      type: object
+      required: [validModules, officialPipelines]
+      properties:
+        validModules:
+          type: array
+          items:
+            type: string
+        officialPipelines:
+          type: array
+          items:
+            $ref: "#/components/schemas/OfficialPipeline"
+    OfficialPipeline:
+      type: object
+      required: [module, code, name, official, aliases, stages]
+      properties:
+        module:
+          type: string
+          example: EXPERIMENT
+        code:
+          type: string
+          example: experiment-pipeline
+        name:
+          type: string
+          example: Pipeline de Experimento
+        official:
+          type: boolean
+          example: true
+        aliases:
+          type: array
+          items:
+            type: string
+        stages:
+          type: array
+          items:
+            $ref: "#/components/schemas/OfficialPipelineStage"
+    OfficialPipelineStage:
+      type: object
+      required: [canonicalCode, operationalCode, name, position, required, configurable, aliases]
+      properties:
+        canonicalCode:
+          type: string
+          example: LANDING_PAGE_WIREFRAME
+        operationalCode:
+          type: string
+          example: landing-page-wireframe
+        name:
+          type: string
+          example: Landing Page Wireframe
+        position:
+          type: integer
+          example: 4
+        required:
+          type: boolean
+          example: true
+        configurable:
+          type: boolean
+          example: true
+        aliases:
+          type: array
+          items:
+            type: string
+    PipelineDiagnostics:
+      type: object
+      required: [pipelineId, pipelineCode, status, expectedStages, configuredStages, issues]
+      properties:
+        pipelineId:
+          type: integer
+          format: int64
+        pipelineCode:
+          type: string
+        canonicalPipelineCode:
+          type: string
+          nullable: true
+        status:
+          type: string
+          enum: [OK, ATENÇÃO, BLOQUEADO]
+        expectedStages:
+          type: integer
+        configuredStages:
+          type: integer
+        issues:
+          type: array
+          items:
+            $ref: "#/components/schemas/PipelineDiagnosticsIssue"
+    PipelineDiagnosticsIssue:
+      type: object
+      required: [severity, message, rootCause, recommendedAction]
+      properties:
+        severity:
+          type: string
+          enum: [ERROR, WARN, INFO]
+        stageCode:
+          type: string
+          nullable: true
+        canonicalCode:
+          type: string
+          nullable: true
+        message:
+          type: string
+        rootCause:
+          type: string
+        recommendedAction:
+          type: string

--- a/frontend/src/api/pipeline/types.ts
+++ b/frontend/src/api/pipeline/types.ts
@@ -41,3 +41,48 @@ export type PipelineStagePayload = Pick<
   | "active"
   | "openAiModelId"
 >;
+
+export interface OfficialPipelineStageMetadata {
+  canonicalCode: string;
+  operationalCode: string;
+  name: string;
+  position: number;
+  required: boolean;
+  configurable: boolean;
+  aliases: string[];
+}
+
+export interface OfficialPipelineMetadata {
+  module: string;
+  code: string;
+  name: string;
+  official: boolean;
+  aliases: string[];
+  stages: OfficialPipelineStageMetadata[];
+}
+
+export interface PipelineMetadata {
+  validModules: string[];
+  officialPipelines: OfficialPipelineMetadata[];
+}
+
+export type PipelineDiagnosticsStatus = "OK" | "ATENÇÃO" | "BLOQUEADO";
+
+export interface PipelineDiagnosticsIssue {
+  severity: "ERROR" | "WARN" | "INFO";
+  stageCode?: string | null;
+  canonicalCode?: string | null;
+  message: string;
+  rootCause: string;
+  recommendedAction: string;
+}
+
+export interface PipelineDiagnostics {
+  pipelineId: number;
+  pipelineCode: string;
+  canonicalPipelineCode?: string | null;
+  status: PipelineDiagnosticsStatus;
+  expectedStages: number;
+  configuredStages: number;
+  issues: PipelineDiagnosticsIssue[];
+}

--- a/frontend/src/api/pipeline/usePipelineDiagnostics.ts
+++ b/frontend/src/api/pipeline/usePipelineDiagnostics.ts
@@ -1,0 +1,18 @@
+import { useQueries } from "@tanstack/react-query";
+import axios from "axios";
+import type { Pipeline, PipelineDiagnostics } from "./types";
+
+export function usePipelineDiagnostics(pipelines: Pipeline[]) {
+  return useQueries({
+    queries: pipelines.map((pipeline) => ({
+      queryKey: ["pipelines", pipeline.id, "diagnostics"],
+      queryFn: async () => {
+        const { data } = await axios.get<PipelineDiagnostics>(
+          `/api/pipelines/${pipeline.id}/diagnostics`,
+        );
+        return data;
+      },
+      enabled: pipelines.length > 0,
+    })),
+  });
+}

--- a/frontend/src/api/pipeline/usePipelineMetadata.ts
+++ b/frontend/src/api/pipeline/usePipelineMetadata.ts
@@ -1,0 +1,15 @@
+import { useQuery } from "@tanstack/react-query";
+import axios from "axios";
+import type { PipelineMetadata } from "./types";
+
+export function usePipelineMetadata() {
+  return useQuery({
+    queryKey: ["pipelines", "metadata"],
+    queryFn: async () => {
+      const { data } = await axios.get<PipelineMetadata>(
+        "/api/pipelines/metadata",
+      );
+      return data;
+    },
+  });
+}

--- a/frontend/src/pages/pipeline/PipelineCrudPage.tsx
+++ b/frontend/src/pages/pipeline/PipelineCrudPage.tsx
@@ -2,10 +2,13 @@ import { useMemo, useState } from "react";
 import PageTitle from "../../components/PageTitle";
 import { useOpenAiModels } from "../../api/openAiModel/useOpenAiModels";
 import { usePipelines } from "../../api/pipeline/usePipelines";
+import { usePipelineDiagnostics } from "../../api/pipeline/usePipelineDiagnostics";
+import { usePipelineMetadata } from "../../api/pipeline/usePipelineMetadata";
 import type {
   Pipeline,
   PipelinePayload,
   PipelineStage,
+  PipelineDiagnostics,
   PipelineStagePayload,
 } from "../../api/pipeline/types";
 import {
@@ -35,6 +38,16 @@ const emptyStage: PipelineStagePayload = {
   openAiModelId: null,
 };
 
+function normalizeCode(code?: string | null) {
+  return (code ?? "").trim().toLowerCase().replace(/_/g, "-");
+}
+
+function statusBadgeClass(status?: PipelineDiagnostics["status"]) {
+  if (status === "OK") return "text-bg-success";
+  if (status === "BLOQUEADO") return "text-bg-danger";
+  return "text-bg-warning";
+}
+
 function pipelineToPayload(pipeline: Pipeline): PipelinePayload {
   return {
     name: pipeline.name,
@@ -59,6 +72,8 @@ function stageToPayload(stage: PipelineStage): PipelineStagePayload {
 
 export default function PipelineCrudPage() {
   const { data, isLoading, isError } = usePipelines();
+  const { data: metadata, isLoading: isLoadingMetadata } =
+    usePipelineMetadata();
   const { data: openAiModels, isLoading: isLoadingOpenAiModels } =
     useOpenAiModels();
   const createPipeline = useCreatePipeline();
@@ -69,7 +84,25 @@ export default function PipelineCrudPage() {
   const deleteStage = useDeletePipelineStage();
 
   const pipelines = useMemo(() => data ?? [], [data]);
+  const diagnosticsQueries = usePipelineDiagnostics(pipelines);
   const modelOptions = useMemo(() => openAiModels ?? [], [openAiModels]);
+  const officialPipelines = useMemo(
+    () => metadata?.officialPipelines ?? [],
+    [metadata],
+  );
+  const validModules = useMemo(
+    () => metadata?.validModules ?? ["EXPERIMENT"],
+    [metadata],
+  );
+  const diagnosticsByPipelineId = useMemo(() => {
+    const entries = diagnosticsQueries
+      .map((query) => query.data)
+      .filter((diagnostic): diagnostic is PipelineDiagnostics =>
+        Boolean(diagnostic),
+      )
+      .map((diagnostic) => [diagnostic.pipelineId, diagnostic] as const);
+    return new Map(entries);
+  }, [diagnosticsQueries]);
   const [pipelineForm, setPipelineForm] =
     useState<PipelinePayload>(emptyPipeline);
   const [editingPipelineId, setEditingPipelineId] = useState<number | null>(
@@ -82,6 +115,10 @@ export default function PipelineCrudPage() {
 
   const isSavingPipeline = createPipeline.isPending || updatePipeline.isPending;
   const isSavingStage = createStage.isPending || updateStage.isPending;
+  const editingOfficialPipeline = officialPipelines.find(
+    (official) =>
+      normalizeCode(official.code) === normalizeCode(pipelineForm.code),
+  );
 
   const submitPipeline = () => {
     const payload = {
@@ -170,6 +207,7 @@ export default function PipelineCrudPage() {
               <label className="form-label">Código *</label>
               <input
                 className="form-control"
+                disabled={Boolean(editingOfficialPipeline)}
                 value={pipelineForm.code}
                 onChange={(event) =>
                   setPipelineForm((current) => ({
@@ -182,17 +220,23 @@ export default function PipelineCrudPage() {
             </div>
             <div className="col-md-3">
               <label className="form-label">Módulo *</label>
-              <input
-                className="form-control"
+              <select
+                className="form-select"
                 value={pipelineForm.module}
+                disabled={Boolean(editingOfficialPipeline) || isLoadingMetadata}
                 onChange={(event) =>
                   setPipelineForm((current) => ({
                     ...current,
                     module: event.target.value,
                   }))
                 }
-                placeholder="EXPERIMENT"
-              />
+              >
+                {validModules.map((module) => (
+                  <option key={module} value={module}>
+                    {module}
+                  </option>
+                ))}
+              </select>
             </div>
             <div className="col-md-2 d-flex align-items-end">
               <div className="form-check form-switch mb-2">
@@ -228,6 +272,15 @@ export default function PipelineCrudPage() {
                 placeholder="Objetivo comercial e resultado esperado do pipeline."
               />
             </div>
+            {editingOfficialPipeline ? (
+              <div className="col-12">
+                <div className="alert alert-info mb-0">
+                  Pipeline oficial protegido: código e módulo são estruturais e
+                  só o backend pode redefinir. A tela edita apenas configuração
+                  operacional segura.
+                </div>
+              </div>
+            ) : null}
           </div>
           <div className="d-flex gap-2 mt-3">
             <button
@@ -264,6 +317,26 @@ export default function PipelineCrudPage() {
       <div className="d-grid gap-4">
         {pipelines.map((pipeline) => {
           const stageForm = stageForms[pipeline.id] ?? emptyStage;
+          const diagnostic = diagnosticsByPipelineId.get(pipeline.id);
+          const officialPipeline = officialPipelines.find(
+            (official) =>
+              normalizeCode(official.code) === normalizeCode(pipeline.code),
+          );
+          const stageDefinition = officialPipeline?.stages.find(
+            (stage) =>
+              normalizeCode(stage.operationalCode) ===
+                normalizeCode(stageForm.code) ||
+              normalizeCode(stage.canonicalCode) ===
+                normalizeCode(stageForm.code) ||
+              stage.aliases.some(
+                (alias) =>
+                  normalizeCode(alias) === normalizeCode(stageForm.code),
+              ),
+          );
+          const isOfficialPipeline = Boolean(officialPipeline);
+          const isEditingOfficialStage = Boolean(
+            editingStageId && stageDefinition,
+          );
           return (
             <section className="card" key={pipeline.id}>
               <div className="card-header d-flex flex-wrap justify-content-between align-items-start gap-3">
@@ -275,10 +348,25 @@ export default function PipelineCrudPage() {
                     >
                       {pipeline.active ? "Ativo" : "Inativo"}
                     </span>
+                    <span
+                      className={`badge ${statusBadgeClass(diagnostic?.status)}`}
+                    >
+                      Contrato: {diagnostic?.status ?? "ATENÇÃO"}
+                    </span>
+                    {isOfficialPipeline ? (
+                      <span className="badge text-bg-primary">Oficial</span>
+                    ) : null}
                   </div>
                   <div className="small text-body-secondary">
                     {pipeline.module} · {pipeline.code} ·{" "}
                     {pipeline.stages.length} etapas
+                    {diagnostic ? (
+                      <>
+                        {" "}
+                        · esperado no código: {diagnostic.expectedStages} ·
+                        configurado no banco: {diagnostic.configuredStages}
+                      </>
+                    ) : null}
                   </div>
                   {pipeline.description ? (
                     <p className="mb-0 mt-2">{pipeline.description}</p>
@@ -296,7 +384,7 @@ export default function PipelineCrudPage() {
                   </button>
                   <button
                     className="btn btn-sm btn-outline-danger"
-                    disabled={deletePipeline.isPending}
+                    disabled={deletePipeline.isPending || isOfficialPipeline}
                     onClick={() => {
                       if (
                         confirm(
@@ -312,77 +400,147 @@ export default function PipelineCrudPage() {
                 </div>
               </div>
               <div className="card-body">
+                {diagnostic ? (
+                  <div
+                    className={`alert ${diagnostic.status === "BLOQUEADO" ? "alert-danger" : diagnostic.status === "OK" ? "alert-success" : "alert-warning"}`}
+                  >
+                    <div className="fw-semibold">
+                      Status do contrato operacional: {diagnostic.status}
+                    </div>
+                    <div>
+                      Etapas esperadas no código: {diagnostic.expectedStages} ·
+                      etapas configuradas no banco:{" "}
+                      {diagnostic.configuredStages}
+                    </div>
+                    {diagnostic.issues.length > 0 ? (
+                      <ul className="mb-0 mt-2">
+                        {diagnostic.issues.map((issue, index) => (
+                          <li key={`${issue.stageCode ?? "pipeline"}-${index}`}>
+                            <strong>{issue.severity}</strong> ·{" "}
+                            {issue.stageCode ? (
+                              <code>{issue.stageCode}</code>
+                            ) : (
+                              "pipeline"
+                            )}
+                            {issue.canonicalCode ? (
+                              <>
+                                {" "}
+                                → <code>{issue.canonicalCode}</code>
+                              </>
+                            ) : null}
+                            : {issue.message} Causa-raiz: {issue.rootCause}{" "}
+                            Ação: {issue.recommendedAction}
+                          </li>
+                        ))}
+                      </ul>
+                    ) : null}
+                  </div>
+                ) : null}
                 <div className="table-responsive mb-4">
                   <table className="table align-middle">
                     <thead>
                       <tr>
                         <th style={{ width: 90 }}>Etapa</th>
                         <th>Nome</th>
-                        <th>Código</th>
+                        <th>Código banco</th>
+                        <th>Código canônico</th>
                         <th>Descrição</th>
                         <th>Obrigatória</th>
                         <th>Modelo OpenAI</th>
                         <th>Status</th>
+                        <th>Proteção</th>
                         <th>Ações</th>
                       </tr>
                     </thead>
                     <tbody>
-                      {pipeline.stages.map((stage) => (
-                        <tr key={stage.id}>
-                          <td>Etapa {stage.position}</td>
-                          <td>{stage.name}</td>
-                          <td>
-                            <code>{stage.code}</code>
-                          </td>
-                          <td>{stage.description || "-"}</td>
-                          <td>{stage.required ? "Sim" : "Não"}</td>
-                          <td>
-                            {stage.openAiModelCode ? (
-                              <span title={stage.openAiModelName ?? undefined}>
-                                {stage.openAiModelName ?? stage.openAiModelCode}{" "}
-                                (<code>{stage.openAiModelCode}</code>)
-                              </span>
-                            ) : (
-                              "—"
-                            )}
-                          </td>
-                          <td>{stage.active ? "Ativa" : "Inativa"}</td>
-                          <td className="d-flex gap-2">
-                            <button
-                              className="btn btn-sm btn-outline-primary"
-                              onClick={() => {
-                                setEditingStageId(stage.id);
-                                setStageForms((current) => ({
-                                  ...current,
-                                  [pipeline.id]: stageToPayload(stage),
-                                }));
-                              }}
-                            >
-                              Editar
-                            </button>
-                            <button
-                              className="btn btn-sm btn-outline-danger"
-                              disabled={deleteStage.isPending}
-                              onClick={() => {
-                                if (confirm("Deseja remover esta etapa?")) {
-                                  deleteStage.mutate({
-                                    pipelineId: pipeline.id,
-                                    stageId: stage.id,
-                                  });
+                      {pipeline.stages.map((stage) => {
+                        const rowDefinition = officialPipeline?.stages.find(
+                          (definition) =>
+                            normalizeCode(definition.operationalCode) ===
+                              normalizeCode(stage.code) ||
+                            definition.aliases.some(
+                              (alias) =>
+                                normalizeCode(alias) ===
+                                normalizeCode(stage.code),
+                            ),
+                        );
+                        return (
+                          <tr key={stage.id}>
+                            <td>Etapa {stage.position}</td>
+                            <td>{stage.name}</td>
+                            <td>
+                              <code>{stage.code}</code>
+                            </td>
+                            <td>
+                              {rowDefinition ? (
+                                <code>{rowDefinition.canonicalCode}</code>
+                              ) : (
+                                "—"
+                              )}
+                            </td>
+                            <td>{stage.description || "-"}</td>
+                            <td>{stage.required ? "Sim" : "Não"}</td>
+                            <td>
+                              {stage.openAiModelCode ? (
+                                <span
+                                  title={stage.openAiModelName ?? undefined}
+                                >
+                                  {stage.openAiModelName ??
+                                    stage.openAiModelCode}{" "}
+                                  (<code>{stage.openAiModelCode}</code>)
+                                </span>
+                              ) : (
+                                "—"
+                              )}
+                            </td>
+                            <td>{stage.active ? "Ativa" : "Inativa"}</td>
+                            <td>
+                              {rowDefinition?.required
+                                ? "Estrutural"
+                                : isOfficialPipeline
+                                  ? "Não mapeada"
+                                  : "Editável"}
+                            </td>
+                            <td className="d-flex gap-2">
+                              <button
+                                className="btn btn-sm btn-outline-primary"
+                                onClick={() => {
+                                  setEditingStageId(stage.id);
+                                  setStageForms((current) => ({
+                                    ...current,
+                                    [pipeline.id]: stageToPayload(stage),
+                                  }));
+                                }}
+                              >
+                                Editar
+                              </button>
+                              <button
+                                className="btn btn-sm btn-outline-danger"
+                                disabled={
+                                  deleteStage.isPending ||
+                                  Boolean(rowDefinition?.required)
                                 }
-                              }}
-                            >
-                              {deleteStage.isPending
-                                ? "Excluindo..."
-                                : "Excluir"}
-                            </button>
-                          </td>
-                        </tr>
-                      ))}
+                                onClick={() => {
+                                  if (confirm("Deseja remover esta etapa?")) {
+                                    deleteStage.mutate({
+                                      pipelineId: pipeline.id,
+                                      stageId: stage.id,
+                                    });
+                                  }
+                                }}
+                              >
+                                {deleteStage.isPending
+                                  ? "Excluindo..."
+                                  : "Excluir"}
+                              </button>
+                            </td>
+                          </tr>
+                        );
+                      })}
                       {pipeline.stages.length === 0 ? (
                         <tr>
                           <td
-                            colSpan={8}
+                            colSpan={10}
                             className="text-center text-body-secondary"
                           >
                             Nenhuma etapa cadastrada para este pipeline.
@@ -404,6 +562,7 @@ export default function PipelineCrudPage() {
                         type="number"
                         min={1}
                         className="form-control"
+                        disabled={isEditingOfficialStage}
                         value={stageForm.position}
                         onChange={(event) =>
                           setStageForms((current) => ({
@@ -420,6 +579,7 @@ export default function PipelineCrudPage() {
                       <label className="form-label">Nome *</label>
                       <input
                         className="form-control"
+                        disabled={isEditingOfficialStage}
                         value={stageForm.name}
                         onChange={(event) =>
                           setStageForms((current) => ({
@@ -435,20 +595,58 @@ export default function PipelineCrudPage() {
                     </div>
                     <div className="col-md-3">
                       <label className="form-label">Código *</label>
-                      <input
-                        className="form-control"
-                        value={stageForm.code}
-                        onChange={(event) =>
-                          setStageForms((current) => ({
-                            ...current,
-                            [pipeline.id]: {
-                              ...stageForm,
-                              code: event.target.value,
-                            },
-                          }))
-                        }
-                        placeholder="campaign-angle"
-                      />
+                      {isOfficialPipeline && officialPipeline ? (
+                        <select
+                          className="form-select"
+                          value={stageForm.code}
+                          disabled={isEditingOfficialStage}
+                          onChange={(event) => {
+                            const selected = officialPipeline.stages.find(
+                              (stage) =>
+                                stage.operationalCode === event.target.value,
+                            );
+                            setStageForms((current) => ({
+                              ...current,
+                              [pipeline.id]: {
+                                ...stageForm,
+                                code: event.target.value,
+                                name: selected?.name ?? stageForm.name,
+                                position:
+                                  selected?.position ?? stageForm.position,
+                                required:
+                                  selected?.required ?? stageForm.required,
+                                active: true,
+                              },
+                            }));
+                          }}
+                        >
+                          <option value="">Selecione etapa oficial</option>
+                          {officialPipeline.stages.map((stage) => (
+                            <option
+                              key={stage.operationalCode}
+                              value={stage.operationalCode}
+                            >
+                              {stage.position}. {stage.name} (
+                              {stage.operationalCode})
+                            </option>
+                          ))}
+                        </select>
+                      ) : (
+                        <input
+                          className="form-control"
+                          value={stageForm.code}
+                          onChange={(event) =>
+                            setStageForms((current) => ({
+                              ...current,
+                              [pipeline.id]: {
+                                ...stageForm,
+                                code: event.target.value,
+                              },
+                            }))
+                          }
+                          placeholder="campaign-angle"
+                        />
+                      )}
                     </div>
                     <div className="col-md-4">
                       <label className="form-label">
@@ -493,6 +691,10 @@ export default function PipelineCrudPage() {
                           className="form-check-input"
                           type="checkbox"
                           checked={stageForm.required}
+                          disabled={
+                            isEditingOfficialStage ||
+                            Boolean(stageDefinition?.required)
+                          }
                           onChange={(event) =>
                             setStageForms((current) => ({
                               ...current,
@@ -518,6 +720,7 @@ export default function PipelineCrudPage() {
                           className="form-check-input"
                           type="checkbox"
                           checked={stageForm.active}
+                          disabled={Boolean(stageDefinition?.required)}
                           onChange={(event) =>
                             setStageForms((current) => ({
                               ...current,


### PR DESCRIPTION
### Motivation
- Evitar divergência silenciosa entre UI, banco e código tornando o backend o guardião do contrato operacional de pipelines. 
- Implementar rapidamente validações e diagnósticos sem criar novas tabelas, conforme o plano em `docs/implementacao/plano-pipelines-contrato-operacional.md` (Fase 1).

### Description
- Adiciona `PipelineDefinitionRegistry` no backend para declarar pipelines/etapas oficiais, aliases canônicos e validação/normalização de códigos. 
- Novo conjunto de DTOs (`PipelineMetadataDto`, `OfficialPipelineDto`, `OfficialPipelineStageDto`, `PipelineDiagnosticsDto`, `PipelineDiagnosticsIssueDto`) e endpoints administrativos `GET /api/pipelines/metadata` e `GET /api/pipelines/{id}/diagnostics` para a UI consultar contrato e diagnósticos. 
- Estende `PipelineService` com: validações de módulo, bloqueios para pipelines/etapas oficiais (não permitir exclusão/alteração estrutural), checagem de duplicidade de posição/código, validação de `openAiModelId`, geração de metadados e diagnóstico comparando banco × definição canônica, e helpers de erro HTTP (`badRequest`). 
- Atualiza `PipelineController` para expor os novos endpoints de metadata e diagnostics. 
- Frontend: adiciona hooks `usePipelineMetadata` e `usePipelineDiagnostics`, amplia `PipelineCrudPage` para mostrar status do contrato (`OK`/`ATENÇÃO`/`BLOQUEADO`), contagens esperadas/configuradas, divergências acionáveis (mensagem, causa-raiz, ação recomendada), código canônico lado a lado e proteção de campos estruturais para pipelines oficiais. 
- Documentação: novo OpenAPI em `docs/swagger/pipeline-swagger.yaml` e registro da execução da Fase 1 em `docs/registros/experimentos.md`.
- Testes: amplia `PipelineServiceTest` cobrindo exclusão/alteração de pipeline oficial, proteção de etapa obrigatória, diagnósticos de etapa ausente/extra, aliases canônicos e validação de modelo OpenAI inexistente.

### Testing
- `../mvnw -Dtest=PipelineServiceTest test` — testes unitários do backend executados (10 tests) e passaram com `BUILD SUCCESS`.
- `npm run typecheck` — verificação TypeScript no frontend executada e passou after fixes to code.
- `npm run build` — frontend build executed successfully (`vite build` produced `dist/` bundle).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a21b93705048321b481fe14f72dc081)