### PR TITLE
Use gpt-5.4 for GeraLanding wireframe step (ai-worker)

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineOpenAiClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineOpenAiClient.java
@@ -37,6 +37,7 @@ import org.springframework.web.reactive.function.client.WebClientResponseExcepti
 public class ExperimentPipelineOpenAiClient {
     private static final Logger log = LoggerFactory.getLogger(ExperimentPipelineOpenAiClient.class);
     private static final String REQUIRED_TEXT_MODEL = "gpt-5.2";
+    private static final String REQUIRED_LANDING_WIREFRAME_MODEL = "gpt-5.4";
     private static final String REQUIRED_LANDING_DESIGN_PRESET_MODEL = "gpt-5.5";
     private static final String REQUIRED_LANDING_HTML_MODEL = "gpt-5.1-codex";
     private static final int TRANSIENT_ERROR_MAX_ATTEMPTS = 3;
@@ -1448,6 +1449,9 @@ public class ExperimentPipelineOpenAiClient {
     private String requiredModelForSection(ExperimentPipelineJobDto job) {
         if (isLandingHtmlSection(job)) {
             return REQUIRED_LANDING_HTML_MODEL;
+        }
+        if (isLandingLayoutSection(job)) {
+            return REQUIRED_LANDING_WIREFRAME_MODEL;
         }
         if (isLandingDesignPresetSection(job)) {
             return REQUIRED_LANDING_DESIGN_PRESET_MODEL;

--- a/ai-worker/src/main/java/com/marketinghub/worker/openai/core/wireframe/WireframePromptBuilder.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/openai/core/wireframe/WireframePromptBuilder.java
@@ -5,7 +5,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marketinghub.worker.openai.core.exception.StageWorkerException;
 import com.marketinghub.worker.openai.core.model.OpenAiRequest;
 import com.marketinghub.worker.openai.core.model.StageExecution;
-import com.marketinghub.worker.openai.core.openai.OpenAiClientProperties;
 import com.marketinghub.worker.openai.core.port.StagePromptBuilder;
 import com.marketinghub.worker.openai.core.prompt.PromptTemplateResolver;
 
@@ -19,18 +18,15 @@ import org.springframework.core.io.ClassPathResource;
 public class WireframePromptBuilder implements StagePromptBuilder<WireframeInput> {
 
     private final ObjectMapper objectMapper;
-    private final OpenAiClientProperties openAiProperties;
     private final WireframeWorkerProperties wireframeProperties;
     private final PromptTemplateResolver promptTemplateResolver;
 
-    /** Inicializa o builder com serializador, propriedades OpenAI e propriedades da etapa wireframe. */
+    /** Inicializa o builder com serializador e propriedades da etapa wireframe. */
     public WireframePromptBuilder(
             ObjectMapper objectMapper,
-            OpenAiClientProperties openAiProperties,
             WireframeWorkerProperties wireframeProperties
     ) {
         this.objectMapper = objectMapper;
-        this.openAiProperties = openAiProperties;
         this.wireframeProperties = wireframeProperties;
         this.promptTemplateResolver = new PromptTemplateResolver(this::loadResource, this::toJsonOrText);
     }
@@ -47,7 +43,7 @@ public class WireframePromptBuilder implements StagePromptBuilder<WireframeInput
         String requestBodyJson = buildResponsesApiRequest(prompt, schemaJson);
 
         return new OpenAiRequest(
-                openAiProperties.model(),
+                wireframeProperties.model(),
                 prompt,
                 requestBodyJson,
                 wireframeProperties.schemaName(),
@@ -76,7 +72,7 @@ public class WireframePromptBuilder implements StagePromptBuilder<WireframeInput
             text.put("format", format);
 
             Map<String, Object> body = new LinkedHashMap<>();
-            body.put("model", openAiProperties.model());
+            body.put("model", wireframeProperties.model());
             body.put("input", prompt);
             body.put("text", text);
 

--- a/ai-worker/src/main/java/com/marketinghub/worker/openai/core/wireframe/WireframeWorkerConfiguration.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/openai/core/wireframe/WireframeWorkerConfiguration.java
@@ -41,10 +41,9 @@ public class WireframeWorkerConfiguration {
     @Bean
     public WireframePromptBuilder wireframePromptBuilder(
             ObjectMapper objectMapper,
-            OpenAiClientProperties openAiProperties,
             WireframeWorkerProperties wireframeProperties
     ) {
-        return new WireframePromptBuilder(objectMapper, openAiProperties, wireframeProperties);
+        return new WireframePromptBuilder(objectMapper, wireframeProperties);
     }
 
     /** Cria o validador da resposta JSON retornada pela OpenAI para a etapa wireframe. */

--- a/ai-worker/src/main/java/com/marketinghub/worker/openai/core/wireframe/WireframeWorkerProperties.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/openai/core/wireframe/WireframeWorkerProperties.java
@@ -31,6 +31,9 @@ public record WireframeWorkerProperties(
         @NotBlank
         String schemaName,
 
+        @NotBlank
+        String model,
+
         @NotNull
         Duration timeout
 ) {
@@ -38,6 +41,9 @@ public record WireframeWorkerProperties(
     public WireframeWorkerProperties {
         if (apiPrefix == null || apiPrefix.isBlank()) {
             apiPrefix = "/api";
+        }
+        if (model == null || model.isBlank()) {
+            model = "gpt-5.4";
         }
         if (timeout == null) {
             timeout = Duration.ofMinutes(30);

--- a/ai-worker/src/main/resources/application.properties
+++ b/ai-worker/src/main/resources/application.properties
@@ -81,6 +81,7 @@ wireframe.worker.api-prefix=${WIREFRAME_WORKER_API_PREFIX:${backend.api-prefix}}
 wireframe.worker.prompt-resource=${WIREFRAME_WORKER_PROMPT_RESOURCE:prompts/geralanding/landing-page-wireframe.md}
 wireframe.worker.schema-resource=${WIREFRAME_WORKER_SCHEMA_RESOURCE:prompts/geralanding/landing-page-wireframe-schema.json}
 wireframe.worker.schema-name=${WIREFRAME_WORKER_SCHEMA_NAME:experiment_pipeline_landing_page_wireframe}
+wireframe.worker.model=${WIREFRAME_WORKER_MODEL:gpt-5.4}
 wireframe.worker.timeout=${WIREFRAME_WORKER_TIMEOUT:PT30M}
 presetdesign.worker.enabled=${PRESETDESIGN_WORKER_ENABLED:true}
 presetdesign.worker.pending-limit=${PRESETDESIGN_WORKER_PENDING_LIMIT:5}

--- a/ai-worker/src/test/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineOpenAiClientTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/experimentpipeline/ExperimentPipelineOpenAiClientTest.java
@@ -884,6 +884,47 @@ class ExperimentPipelineOpenAiClientTest {
     }
 
     @Test
+    void enforcesGpt54ModelForLandingWireframePipelineCall() throws Exception {
+        AtomicReference<Map<String, Object>> payloadRef = new AtomicReference<>();
+        String openAiText = MAPPER.writeValueAsString(Map.of(
+                "landingPageWireframe", Map.of(
+                        "pageGoal", "captura",
+                        "variantLayoutId", "form-first",
+                        "sectionOrder", List.of(
+                                Map.of("sectionId", "hero", "surfaceSpec", Map.of(
+                                        "surfaceToken", "surface-hero",
+                                        "style", "band",
+                                        "contrastMode", "high"))),
+                        "consistencyChecks", List.of())));
+        ExperimentPipelineOpenAiClient client = new ExperimentPipelineOpenAiClient(
+                WebClient.builder().exchangeFunction(capturePayloadExchange(payloadRef, openAiText)),
+                MAPPER,
+                "test-key",
+                "http://openai");
+
+        ExperimentPipelineJobDto job = new ExperimentPipelineJobDto(
+                UUID.randomUUID(),
+                16L,
+                "landing-page-wireframe",
+                "gpt-4o-mini",
+                "prompt",
+                """
+                        {
+                          "model": "gpt-4o-mini",
+                          "input": [
+                            {"role": "user", "content": "Prompt de wireframe"}
+                          ]
+                        }
+                        """,
+                Instant.now());
+
+        client.generate(job);
+
+        Map<String, Object> payload = payloadRef.get();
+        assertThat(payload.get("model")).isEqualTo("gpt-5.4");
+    }
+
+    @Test
     void enforcesGpt51CodexModelForLandingHtmlPipelineCall() {
         AtomicReference<Map<String, Object>> payloadRef = new AtomicReference<>();
         ExperimentPipelineOpenAiClient client = new ExperimentPipelineOpenAiClient(

--- a/ai-worker/src/test/java/com/marketinghub/worker/openai/core/wireframe/WireframeBackendClientTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/openai/core/wireframe/WireframeBackendClientTest.java
@@ -53,6 +53,7 @@ class WireframeBackendClientTest {
                         "prompts/geralanding/landing-page-wireframe.md",
                         "prompts/geralanding/landing-page-wireframe-schema.json",
                         "experiment_pipeline_landing_page_wireframe",
+                        "gpt-5.4",
                         Duration.ofSeconds(5)),
                 objectMapper);
         StageExecution<WireframeInput> execution = new StageExecution<>(
@@ -99,6 +100,7 @@ class WireframeBackendClientTest {
                         "prompts/geralanding/landing-page-wireframe.md",
                         "prompts/geralanding/landing-page-wireframe-schema.json",
                         "experiment_pipeline_landing_page_wireframe",
+                        "gpt-5.4",
                         Duration.ofSeconds(5)),
                 objectMapper);
         StageExecution<WireframeInput> execution = new StageExecution<>(
@@ -208,6 +210,37 @@ class WireframeBackendClientTest {
                 .contains("maxVisualHeight")
                 .contains("layoutRole")
                 .contains("relacaoComCta");
+    }
+
+    /** Deve montar o request da etapa wireframe usando o modelo dedicado gpt-5.4. */
+    @Test
+    void wireframePromptBuilderShouldUseDedicatedGpt54Model() throws Exception {
+        WireframeWorkerProperties properties = new WireframeWorkerProperties(
+                true,
+                5,
+                "http://backend",
+                "/api",
+                "prompts/geralanding/landing-page-wireframe.md",
+                "prompts/geralanding/landing-page-wireframe-schema.json",
+                "experiment_pipeline_landing_page_wireframe",
+                "gpt-5.4",
+                Duration.ofSeconds(5));
+        WireframePromptBuilder builder = new WireframePromptBuilder(objectMapper, properties);
+        StageExecution<WireframeInput> execution = new StageExecution<>(
+                "job-ia-1",
+                12L,
+                "landing-page-wireframe",
+                "INICIADO",
+                Instant.parse("2026-05-29T10:00:00Z"),
+                new WireframeInput(12L, "landing-page-wireframe", "job-ia-1", Map.of(
+                        "NICHE_NAME", "nicho",
+                        "PERSONA_NAME", "persona")));
+
+        var request = builder.build(execution);
+        JsonNode body = objectMapper.readTree(request.requestBodyJson());
+
+        assertThat(request.model()).isEqualTo("gpt-5.4");
+        assertThat(body.path("model").asText()).isEqualTo("gpt-5.4");
     }
 
 }

--- a/docs/canonical/geralanding-arquitetura-canon.v1.md
+++ b/docs/canonical/geralanding-arquitetura-canon.v1.md
@@ -53,6 +53,7 @@ Regras arquiteturais refletidas (ArchUnit):
 - O catálogo administrativo de pipelines e etapas é persistido em `pipeline` e `pipeline_stage` e deve ser usado como fonte operacional para configurar a escolha padrão de modelo por etapa.
 - Cada registro de `pipeline_stage` pode apontar para um modelo da tabela `openai_model` por meio de `openai_model_id`; quando o campo estiver nulo, a etapa deve manter o fallback técnico já definido no executor/worker correspondente.
 - Para o GeraLanding, a configuração de modelo por etapa deve priorizar a finalidade comercial da etapa e o foco em vendas, evitando parâmetros técnicos avançados na tela principal.
+- A etapa `landing-page-wireframe` deve usar configuração dedicada `wireframe.worker.model`, com padrão `gpt-5.4`, porque define a estrutura comercial de baixa fricção que orienta copy, imagens, preset visual e HTML final.
 - A tela administrativa de pipelines deve exibir uma seleção simples de modelo OpenAI por etapa, usando os modelos cadastrados em `openai_model`.
 - O cadastro administrativo de `openai_model` deve manter a flag `accepts_image_input` para sinalizar modelos que aceitam imagem + prompt; etapas visuais como `landing-page-quality-review` devem escolher modelos com essa capacidade.
 

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -3422,3 +3422,10 @@
 - tela ajustada: `/pipelines` passou a exibir status `OK`, `ATENÇÃO` ou `BLOQUEADO`, contagem esperada/configurada, divergências com causa-raiz e ação recomendada, código do banco e código canônico lado a lado, além de campos estruturais protegidos para pipelines oficiais.
 - documentação de contrato: criado `docs/swagger/pipeline-swagger.yaml` e atualizado o índice `docs/swagger/README.md`.
 - validação automatizada: testes unitários de `PipelineServiceTest` cobrem exclusão de pipeline oficial, remoção/alteração de etapa oficial, diagnóstico de etapa ausente/extra, aliases canônicos e modelo OpenAI inexistente.
+
+## 2026-06-04 — Modelo 5.4 no Wireframe do GeraLanding
+
+- solicitação: configurar a etapa `landing-page-wireframe` do GeraLanding para ser gerada pelo modelo `gpt-5.4`.
+- causa-raiz/objetivo: o wireframe define a estrutura comercial que reduz esforço de entendimento e orienta copy, imagens, preset visual e HTML final; por isso precisa de modelo dedicado em vez de depender do `openai.model` global.
+- correção aplicada: o Worker AI passou a ter `wireframe.worker.model` com padrão `gpt-5.4`, o builder da etapa usa esse modelo no `OpenAiRequest` e no corpo da Responses API, e o cliente legado do pipeline também força `gpt-5.4` quando a seção é `landing-page-wireframe`.
+- validação automatizada: testes cobrem o payload dedicado do `WireframePromptBuilder` e o enforcement do modelo `gpt-5.4` no cliente legado do pipeline.


### PR DESCRIPTION
### Motivation
- Establish a dedicated, stronger model for the GeraLanding wireframe stage so the structural/layout artifact is produced by a model tuned for that role instead of the global default.
- Keep generation responsibilities explicit per-step and preserve traceability between prompt/schema, model and resulting artifact.
- Update canon and records to reflect the operational decision to use `gpt-5.4` for wireframes.

### Description
- Added `model` property to `WireframeWorkerProperties` with default `gpt-5.4` and normalized it in the record constructor (`ai-worker/src/main/java/.../WireframeWorkerProperties.java`).
- Updated `WireframePromptBuilder` to use `wireframeProperties.model()` when building the `OpenAiRequest` and the Responses API body instead of the global `OpenAiClientProperties` model (`ai-worker/src/main/java/.../WireframePromptBuilder.java`).
- Adjusted `WireframeWorkerConfiguration` bean signature to construct `WireframePromptBuilder` with the new properties shape (`WireframeWorkerConfiguration.java`).
- Added `wireframe.worker.model=${WIREFRAME_WORKER_MODEL:gpt-5.4}` to `ai-worker/src/main/resources/application.properties` to expose the configuration.
- Enforced the `gpt-5.4` requirement in the legacy pipeline client by adding a required-section model for `landing-page-wireframe` in `ExperimentPipelineOpenAiClient` and updated constants and resolution logic to treat wireframe as a dedicated-model section (`ai-worker/src/main/java/.../ExperimentPipelineOpenAiClient.java`).
- Updated and added unit tests to cover the change: adjusted `WireframeBackendClientTest` to pass the new `model` constructor argument and added `wireframePromptBuilderShouldUseDedicatedGpt54Model`; added `enforcesGpt54ModelForLandingWireframePipelineCall` to `ExperimentPipelineOpenAiClientTest` to validate enforcement of `gpt-5.4` in pipeline calls (`ai-worker/src/test/...`).
- Documented the decision in the canonical architecture doc and in experiment records: `docs/canonical/geralanding-arquitetura-canon.v1.md` and `docs/registros/experimentos.md` updated to reflect the wireframe model change.

### Testing
- Ran unit tests in the ai-worker module for the affected areas with `mvn test -Dtest=WireframeBackendClientTest,ExperimentPipelineOpenAiClientTest` from `ai-worker`, which executed the updated `WireframeBackendClientTest` and `ExperimentPipelineOpenAiClientTest` suites and completed successfully. 
- The change includes new/adjusted tests that assert the prompt builder emits `model: gpt-5.4` and that the pipeline client enforces `gpt-5.4` for `landing-page-wireframe` jobs; those assertions are exercised by the aforementioned tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a21be30aff883219cdec44b98f1035e)