### PR TITLE
Migrate MOIS sales library to operational tables `mois_sales_page` and `mois_sales_page_job_execution` (Phase 5)

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryService.java
@@ -702,7 +702,7 @@ public class MoisSalesLibraryService {
 
 
     /**
-     * Executa a gravação comum de itens de URL e consolida contadores de inserção, atualização e jobs.
+     * Executa a gravação comum de itens de URL usando mois_sales_page como escrita principal.
      */
     private IngestCounters ingestUrlItems(String workspaceId, String source, List<MoisSalesLibraryDtos.SalesLibraryUrlItem> urls) {
         int persisted = 0;
@@ -719,58 +719,114 @@ public class MoisSalesLibraryService {
             }
             Instant capturedAt = item.capturedAt() == null ? Instant.now() : item.capturedAt();
             LocalDateTime capturedAtUtc = LocalDateTime.ofInstant(capturedAt, ZoneOffset.UTC);
-            int ingestUpsertResult = jdbcTemplate.update(
+            int pageUpsertResult = jdbcTemplate.update(
                     """
-                            INSERT INTO mois_sales_library_url_ingest
-                            (workspace_id, source, url_original, url_canonical, title, first_captured_at, last_captured_at, ingest_count, created_at, updated_at)
-                            VALUES (?, ?, ?, ?, ?, ?, ?, 1, UTC_TIMESTAMP(), UTC_TIMESTAMP())
+                            INSERT INTO mois_sales_page
+                            (workspace_id, source, title, url_original, url_canonical, current_stage, current_status,
+                             analysis_status, ingest_count, first_seen_at, last_collected_at, created_at, updated_at)
+                            VALUES (?, ?, ?, ?, ?, 'ANALYSIS', 'PENDING', 'PENDING', 1, ?, ?, UTC_TIMESTAMP(), UTC_TIMESTAMP())
                             ON DUPLICATE KEY UPDATE
                                 source = VALUES(source),
-                                url_original = VALUES(url_original),
                                 title = COALESCE(NULLIF(VALUES(title), ''), title),
-                                last_captured_at = GREATEST(COALESCE(last_captured_at, VALUES(last_captured_at)), VALUES(last_captured_at)),
+                                url_original = VALUES(url_original),
+                                current_stage = CASE
+                                  WHEN current_status IN ('DONE', 'ANALYZED', 'CAPTURED', 'DUPLICATE', 'FETCHING', 'FAILED') THEN current_stage
+                                  ELSE 'ANALYSIS'
+                                END,
+                                current_status = CASE
+                                  WHEN current_status IN ('DONE', 'ANALYZED', 'CAPTURED', 'DUPLICATE', 'FETCHING', 'FAILED') THEN current_status
+                                  ELSE 'PENDING'
+                                END,
+                                analysis_status = CASE
+                                  WHEN analysis_status IN ('DONE', 'FETCHING', 'FAILED') THEN analysis_status
+                                  ELSE 'PENDING'
+                                END,
                                 ingest_count = ingest_count + 1,
+                                last_collected_at = GREATEST(COALESCE(last_collected_at, VALUES(last_collected_at)), VALUES(last_collected_at)),
                                 updated_at = UTC_TIMESTAMP()
                             """,
                     workspaceId,
                     normalizedSource,
+                    item.title(),
                     item.url(),
                     canonical,
-                    item.title(),
                     capturedAtUtc,
                     capturedAtUtc
             );
 
-            if (ingestUpsertResult == 1) {
+            Long pageId = findSalesPageIdByCanonical(workspaceId, canonical);
+            if (pageId == null) {
+                log.warn("MOIS sales-library não localizou página após upsert principal. modulo=MOIS, operacao=ingestUrlItems, workspaceId={}, canonical={}",
+                        workspaceId, canonical);
+                skippedWithoutUrl++;
+                continue;
+            }
+
+            Long executionId = null;
+            if (pageUpsertResult == 1) {
                 inserted++;
-                Long urlIngestId = jdbcTemplate.queryForObject(
-                        """
-                                SELECT id
-                                FROM mois_sales_library_url_ingest
-                                WHERE workspace_id = ? AND url_canonical = ?
-                                LIMIT 1
-                                """,
-                        Long.class,
-                        workspaceId,
-                        canonical
-                );
-                if (urlIngestId != null) {
-                    long jobId = createPendingJob(urlIngestId);
-                    dualWriteGateway.syncUrlIngest(urlIngestId, jobId);
-                    jobsCreated++;
-                }
+                executionId = createOperationalAnalysisExecution(pageId, "INGESTION");
+                jobsCreated++;
             } else {
                 updated++;
-                Long urlIngestId = findUrlIngestIdByCanonical(workspaceId, canonical);
-                if (urlIngestId != null) {
-                    dualWriteGateway.syncUrlIngest(urlIngestId, null);
-                }
             }
+            mirrorOperationalIngestToLegacyAudit(pageId, executionId, capturedAtUtc);
             persisted++;
         }
         return new IngestCounters(persisted, inserted, updated, jobsCreated, skippedWithoutUrl);
     }
 
+
+
+    /**
+     * Localiza a página operacional pelo workspace e URL canônica.
+     */
+    private Long findSalesPageIdByCanonical(String workspaceId, String canonical) {
+        return jdbcTemplate.query(
+                """
+                        SELECT id
+                        FROM mois_sales_page
+                        WHERE workspace_id = ? AND url_canonical = ?
+                        LIMIT 1
+                        """,
+                (rs, rowNum) -> rs.getLong("id"),
+                workspaceId,
+                canonical
+        ).stream().findFirst().orElse(null);
+    }
+
+    /**
+     * Espelha a ingestão principal nova em tabelas legadas apenas para auditoria de transição.
+     */
+    private void mirrorOperationalIngestToLegacyAudit(long pageId, Long executionId, LocalDateTime capturedAtUtc) {
+        MoisSalesLibraryDtos.SalesLibraryPageResponse page = getPage(pageId);
+        jdbcTemplate.update(
+                """
+                        INSERT INTO mois_sales_library_url_ingest
+                        (workspace_id, source, url_original, url_canonical, title, first_captured_at, last_captured_at, ingest_count, created_at, updated_at)
+                        VALUES (?, ?, ?, ?, ?, ?, ?, 1, UTC_TIMESTAMP(), UTC_TIMESTAMP())
+                        ON DUPLICATE KEY UPDATE
+                            source = VALUES(source),
+                            url_original = VALUES(url_original),
+                            title = COALESCE(NULLIF(VALUES(title), ''), title),
+                            last_captured_at = GREATEST(COALESCE(last_captured_at, VALUES(last_captured_at)), VALUES(last_captured_at)),
+                            ingest_count = ingest_count + 1,
+                            updated_at = UTC_TIMESTAMP()
+                        """,
+                page.workspaceId(), page.source(), page.urlCanonical(), page.urlCanonical(), page.title(), capturedAtUtc, capturedAtUtc);
+        Long urlIngestId = findUrlIngestIdByCanonical(page.workspaceId(), page.urlCanonical());
+        if (urlIngestId != null && executionId != null) {
+            jdbcTemplate.update(
+                    """
+                            INSERT INTO mois_sales_library_processing_job
+                            (url_ingest_id, status, attempts, created_at, updated_at)
+                            VALUES (?, 'PENDING', 0, UTC_TIMESTAMP(), UTC_TIMESTAMP())
+                            """,
+                    urlIngestId);
+        }
+        log.info("MOIS sales-library espelhou ingestão nova no legado para auditoria. modulo=MOIS, operacao=mirrorOperationalIngestToLegacyAudit, pageId={}, executionId={}, legacyUrlIngestId={}",
+                pageId, executionId, urlIngestId);
+    }
 
     /**
      * Localiza o item recém-reservado pelo token de claim do worker.

--- a/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibrarySnapshotService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibrarySnapshotService.java
@@ -1,7 +1,6 @@
 package com.marketinghub.mois.bibliotecapaginavenda.worker.v1.service;
 
 import com.marketinghub.mois.bibliotecapaginavenda.worker.v1.dto.MoisSalesLibraryDtos;
-import com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1.MoisSalesPageDualWriteGateway;
 import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Graphics2D;
@@ -20,6 +19,7 @@ import java.time.Duration;
 import java.time.Instant;
 import java.util.HexFormat;
 import java.util.List;
+import java.util.UUID;
 import javax.imageio.ImageIO;
 import javax.swing.JEditorPane;
 import lombok.RequiredArgsConstructor;
@@ -31,7 +31,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 /**
- * Gerencia snapshots HTML das páginas de venda canônicas da biblioteca MOIS.
+ * Gerencia capturas HTML das páginas de venda canônicas da biblioteca MOIS usando o modelo operacional consolidado.
  */
 @Service
 @RequiredArgsConstructor
@@ -40,20 +40,17 @@ public class MoisSalesLibrarySnapshotService {
 
     private static final int DEFAULT_LIMIT = 5;
     private static final int MAX_LIMIT = 20;
-    private static final String ARTIFACT_RAW_HTML = "RAW_HTML";
-    private static final String ARTIFACT_SCREENSHOT_PNG = "SCREENSHOT_PNG";
     private static final Duration FAILED_RETRY_COOLDOWN = Duration.ofHours(24);
     private static final int MAX_FAILED_ATTEMPTS_WITHOUT_FORCE = 3;
 
     private final JdbcTemplate jdbcTemplate;
-    private final MoisSalesPageDualWriteGateway dualWriteGateway;
     private final HttpClient httpClient = HttpClient.newBuilder()
             .connectTimeout(Duration.ofSeconds(15))
             .followRedirects(HttpClient.Redirect.NORMAL)
             .build();
 
     /**
-     * Captura snapshots diretamente pelo backend para acionamentos manuais ou legados.
+     * Captura páginas diretamente pelo backend para acionamentos manuais sobre o modelo operacional novo.
      */
     public MoisSalesLibraryDtos.SalesLibrarySnapshotCaptureResponse captureSnapshots(
             MoisSalesLibraryDtos.SalesLibrarySnapshotCaptureRequest request
@@ -71,42 +68,34 @@ public class MoisSalesLibrarySnapshotService {
     }
 
     /**
-     * Lista os snapshots já persistidos para uma página da biblioteca.
+     * Lista as capturas registradas para uma página no histórico consolidado de execuções.
      */
     public List<MoisSalesLibraryDtos.SalesLibraryPageSnapshotResponse> listSnapshots(long pageId) {
         return jdbcTemplate.query("""
-                SELECT s.id, s.url_ingest_id, s.snapshot_hash, s.status, s.http_status, s.content_type,
-                       s.redirect_destination_url, s.redirect_root_url,
-                       COALESCE(raw.size_bytes, 0) AS raw_html_bytes,
-                       COALESCE(png.size_bytes, 0) AS screenshot_bytes,
-                       s.captured_at, s.updated_at
-                FROM mois_sales_library_page_snapshot s
-                LEFT JOIN mois_sales_library_snapshot_artifact raw
-                  ON raw.snapshot_id = s.id AND raw.artifact_type = 'RAW_HTML'
-                LEFT JOIN mois_sales_library_snapshot_artifact png
-                  ON png.snapshot_id = s.id AND png.artifact_type = 'SCREENSHOT_PNG'
-                WHERE s.url_ingest_id = ?
-                ORDER BY s.captured_at DESC, s.id DESC
+                SELECT id, sales_page_id, raw_html_sha256, status, http_status, content_type,
+                       final_url, redirect_root_url, raw_html_bytes, screenshot_bytes, finished_at, updated_at
+                FROM mois_sales_page_job_execution
+                WHERE sales_page_id = ? AND stage = 'CAPTURE'
+                ORDER BY COALESCE(finished_at, updated_at) DESC, id DESC
                 LIMIT 20
                 """, (rs, rowNum) -> new MoisSalesLibraryDtos.SalesLibraryPageSnapshotResponse(
                 rs.getLong("id"),
-                rs.getLong("url_ingest_id"),
-                rs.getString("snapshot_hash"),
+                rs.getLong("sales_page_id"),
+                rs.getString("raw_html_sha256"),
                 rs.getString("status"),
                 (Integer) rs.getObject("http_status"),
                 rs.getString("content_type"),
-                rs.getString("redirect_destination_url"),
+                rs.getString("final_url"),
                 rs.getString("redirect_root_url"),
                 rs.getLong("raw_html_bytes"),
                 rs.getLong("screenshot_bytes"),
-                toInstant(rs.getTimestamp("captured_at")),
+                toInstant(rs.getTimestamp("finished_at")),
                 toInstant(rs.getTimestamp("updated_at"))
         ), pageId);
     }
 
-
     /**
-     * Reserva a próxima URL normalizada da biblioteca para a etapa worker de obtenção de HTML bruto.
+     * Reserva a próxima página consolidada para a etapa worker de obtenção de HTML bruto.
      */
     @Transactional
     public MoisSalesLibraryDtos.HtmlCaptureClaimResponse claimHtmlCapture(
@@ -119,96 +108,121 @@ public class MoisSalesLibrarySnapshotService {
             return new MoisSalesLibraryDtos.HtmlCaptureClaimResponse(false, null);
         }
         PageToCapture page = pages.get(0);
-        Long snapshotId = insertFetchingSnapshot(page);
-        dualWriteGateway.syncSnapshot(snapshotId);
+        String claimedBy = UUID.randomUUID().toString();
+        long executionId = insertFetchingCaptureExecution(page, claimedBy);
+        updatePageForCaptureClaim(page.pageId(), executionId);
+        log.info("MOIS sales-library captura reservada no modelo operacional novo. modulo=MOIS, operacao=claimHtmlCapture, workspaceId={}, pageId={}, executionId={}",
+                request.workspaceId(), page.pageId(), executionId);
         return new MoisSalesLibraryDtos.HtmlCaptureClaimResponse(
                 true,
-                new MoisSalesLibraryDtos.HtmlCaptureJobResponse(snapshotId, page.pageId(), page.urlCanonical(), page.title()));
+                new MoisSalesLibraryDtos.HtmlCaptureJobResponse(executionId, page.pageId(), page.urlCanonical(), page.title()));
     }
 
     /**
-     * Persiste o HTML bruto capturado pelo worker como artefato RAW_HTML versionado.
+     * Persiste o HTML bruto capturado pelo worker diretamente na execução operacional consolidada.
      */
     @Transactional
     public MoisSalesLibraryDtos.HtmlCapturePersistResponse completeHtmlCapture(
-            long snapshotId,
+            long executionId,
             MoisSalesLibraryDtos.HtmlCaptureCompleteRequest request
     ) {
+        CaptureExecution execution = findCaptureExecution(executionId);
         String rawHtml = request.rawHtml() == null ? "" : request.rawHtml();
         byte[] rawHtmlBytes = rawHtml.getBytes(StandardCharsets.UTF_8);
         String hash = request.sha256() == null || request.sha256().isBlank() ? sha256(rawHtml) : request.sha256();
-        Long duplicateSnapshotId = findDuplicateSnapshot(snapshotId, hash);
-        if (duplicateSnapshotId != null) {
+        Instant capturedAt = request.capturedAt() == null ? Instant.now() : request.capturedAt();
+        Long duplicateExecutionId = findDuplicateCaptureExecution(executionId, execution.pageId(), hash);
+        if (duplicateExecutionId != null) {
+            String duplicateMessage = "HTML idêntico à execução " + duplicateExecutionId;
             jdbcTemplate.update("""
-                    UPDATE mois_sales_library_page_snapshot
-                    SET status = 'DUPLICATE', http_status = ?, content_type = ?, redirect_destination_url = ?, redirect_root_url = ?, error_message = ?, captured_at = ?, updated_at = UTC_TIMESTAMP()
+                    UPDATE mois_sales_page_job_execution
+                    SET status = 'DUPLICATE', http_status = ?, content_type = ?, final_url = ?, redirect_root_url = ?,
+                        raw_html_sha256 = ?, raw_html_bytes = ?, error_category = NULL, error_message = ?, finished_at = ?, updated_at = UTC_TIMESTAMP()
                     WHERE id = ?
-                    """, request.httpStatus(), truncate(request.contentType(), 255), truncate(request.redirectDestinationUrl(), 1024),
-                    truncate(request.redirectRootUrl(), 1024), "HTML idêntico ao snapshot " + duplicateSnapshotId,
-                    Timestamp.from(request.capturedAt() == null ? Instant.now() : request.capturedAt()), snapshotId);
-            dualWriteGateway.syncSnapshot(snapshotId);
-            return new MoisSalesLibraryDtos.HtmlCapturePersistResponse(snapshotId, "DUPLICATE");
+                    """, request.httpStatus(), truncate(request.contentType(), 255), truncate(resolveFinalUrl(request), 1024),
+                    truncate(request.redirectRootUrl(), 1024), hash, rawHtmlBytes.length, duplicateMessage, Timestamp.from(capturedAt), executionId);
+            updatePageForCaptureCompletion(execution.pageId(), executionId, "DUPLICATE", request, hash, rawHtmlBytes.length, null, capturedAt);
+            return new MoisSalesLibraryDtos.HtmlCapturePersistResponse(executionId, "DUPLICATE");
         }
+        byte[] screenshot = renderBasicScreenshot(rawHtml, resolveFinalUrl(request));
         jdbcTemplate.update("""
-                UPDATE mois_sales_library_page_snapshot
-                SET snapshot_hash = ?, status = 'CAPTURED', http_status = ?, content_type = ?, redirect_destination_url = ?, redirect_root_url = ?, error_message = NULL, captured_at = ?, updated_at = UTC_TIMESTAMP()
+                UPDATE mois_sales_page_job_execution
+                SET status = 'CAPTURED', final_url = ?, redirect_root_url = ?, http_status = ?, content_type = ?, raw_html = ?,
+                    raw_html_sha256 = ?, raw_html_bytes = ?, screenshot_blob = ?, screenshot_bytes = ?, error_category = NULL,
+                    error_message = NULL, finished_at = ?, updated_at = UTC_TIMESTAMP()
                 WHERE id = ?
-                """, hash, request.httpStatus(), truncate(request.contentType(), 255), truncate(request.redirectDestinationUrl(), 1024),
-                truncate(request.redirectRootUrl(), 1024), Timestamp.from(request.capturedAt() == null ? Instant.now() : request.capturedAt()), snapshotId);
-        insertTextArtifact(snapshotId, ARTIFACT_RAW_HTML, request.contentType() == null ? "text/html" : request.contentType(), rawHtml, rawHtmlBytes.length);
-        dualWriteGateway.syncSnapshot(snapshotId);
-        return new MoisSalesLibraryDtos.HtmlCapturePersistResponse(snapshotId, "CAPTURED");
+                """, truncate(resolveFinalUrl(request), 1024), truncate(request.redirectRootUrl(), 1024), request.httpStatus(),
+                truncate(request.contentType(), 255), rawHtml, hash, rawHtmlBytes.length, screenshot, screenshot.length,
+                Timestamp.from(capturedAt), executionId);
+        updatePageForCaptureCompletion(execution.pageId(), executionId, "CAPTURED", request, hash, rawHtmlBytes.length, null, capturedAt);
+        log.info("MOIS sales-library captura concluída no modelo operacional novo. modulo=MOIS, operacao=completeHtmlCapture, pageId={}, executionId={}, status=CAPTURED, bytes={}",
+                execution.pageId(), executionId, rawHtmlBytes.length);
+        return new MoisSalesLibraryDtos.HtmlCapturePersistResponse(executionId, "CAPTURED");
     }
 
     /**
-     * Registra falha da etapa worker de obtenção de HTML bruto preservando contexto de auditoria.
+     * Registra falha da etapa worker de obtenção de HTML bruto no histórico operacional consolidado.
      */
     @Transactional
     public MoisSalesLibraryDtos.HtmlCapturePersistResponse failHtmlCapture(
-            long snapshotId,
+            long executionId,
             MoisSalesLibraryDtos.HtmlCaptureFailRequest request
     ) {
+        CaptureExecution execution = findCaptureExecution(executionId);
         String message = request.errorMessage() == null || request.errorMessage().isBlank()
                 ? request.errorCategory()
                 : request.errorMessage();
         jdbcTemplate.update("""
-                UPDATE mois_sales_library_page_snapshot
-                SET status = 'FAILED', http_status = ?, redirect_destination_url = ?, redirect_root_url = ?, error_message = ?, captured_at = UTC_TIMESTAMP(), updated_at = UTC_TIMESTAMP()
+                UPDATE mois_sales_page_job_execution
+                SET status = 'FAILED', http_status = ?, final_url = ?, redirect_root_url = ?, error_category = ?, error_message = ?,
+                    finished_at = UTC_TIMESTAMP(), updated_at = UTC_TIMESTAMP()
                 WHERE id = ?
                 """, request.httpStatus(), truncate(request.redirectDestinationUrl(), 1024), truncate(request.redirectRootUrl(), 1024),
-                truncate(message, 1000), snapshotId);
-        dualWriteGateway.syncSnapshot(snapshotId);
-        return new MoisSalesLibraryDtos.HtmlCapturePersistResponse(snapshotId, "FAILED");
+                truncate(request.errorCategory(), 120), truncate(message, 1000), executionId);
+        jdbcTemplate.update("""
+                UPDATE mois_sales_page
+                SET current_stage = 'CAPTURE', current_status = 'FAILED', capture_status = 'FAILED', http_status = ?,
+                    url_final = ?, redirect_root_url = ?, last_error_category = ?, last_error_message = ?, last_job_execution_id = ?,
+                    updated_at = UTC_TIMESTAMP()
+                WHERE id = ?
+                """, request.httpStatus(), truncate(request.redirectDestinationUrl(), 1024), truncate(request.redirectRootUrl(), 1024),
+                truncate(request.errorCategory(), 120), truncate(message, 1000), executionId, execution.pageId());
+        log.info("MOIS sales-library captura falhou no modelo operacional novo. modulo=MOIS, operacao=failHtmlCapture, pageId={}, executionId={}, errorCategory={}",
+                execution.pageId(), executionId, request.errorCategory());
+        return new MoisSalesLibraryDtos.HtmlCapturePersistResponse(executionId, "FAILED");
     }
 
     /**
-     * Seleciona páginas da biblioteca elegíveis para captura de HTML bruto, evitando reprocessar falhas recentes ou recorrentes.
+     * Seleciona páginas da biblioteca elegíveis para captura de HTML bruto usando somente as tabelas consolidadas.
      */
     private List<PageToCapture> findPagesToCapture(String workspaceId, int limit, boolean force) {
         String forceClause = force ? "" : """
                 AND NOT EXISTS (
-                    SELECT 1 FROM mois_sales_library_page_snapshot s
-                    WHERE s.url_ingest_id = i.id AND s.status IN ('CAPTURED', 'FETCHING')
+                    SELECT 1 FROM mois_sales_page_job_execution e
+                    WHERE e.sales_page_id = sp.id AND e.stage = 'CAPTURE' AND e.status IN ('CAPTURED', 'FETCHING')
                 )
                 AND NOT EXISTS (
-                    SELECT 1 FROM mois_sales_library_page_snapshot recent_failure
-                    WHERE recent_failure.url_ingest_id = i.id
+                    SELECT 1 FROM mois_sales_page_job_execution recent_failure
+                    WHERE recent_failure.sales_page_id = sp.id
+                      AND recent_failure.stage = 'CAPTURE'
                       AND recent_failure.status = 'FAILED'
-                      AND recent_failure.captured_at >= ?
+                      AND recent_failure.finished_at >= ?
                 )
                 AND (
                     SELECT COUNT(1)
-                    FROM mois_sales_library_page_snapshot repeated_failure
-                    WHERE repeated_failure.url_ingest_id = i.id
+                    FROM mois_sales_page_job_execution repeated_failure
+                    WHERE repeated_failure.sales_page_id = sp.id
+                      AND repeated_failure.stage = 'CAPTURE'
                       AND repeated_failure.status = 'FAILED'
                 ) < ?
                 """;
         String query = """
-                SELECT i.id, i.url_canonical, i.title
-                FROM mois_sales_library_url_ingest i
-                WHERE i.workspace_id = ?
+                SELECT sp.id, sp.url_canonical, sp.title
+                FROM mois_sales_page sp
+                WHERE sp.workspace_id = ?
+                  AND sp.current_status NOT IN ('FETCHING', 'CAPTURING', 'DISCARDED')
                 """ + forceClause + """
-                ORDER BY i.updated_at DESC, i.id DESC
+                ORDER BY sp.updated_at DESC, sp.id DESC
                 LIMIT ?
                 """;
         if (force) {
@@ -224,170 +238,197 @@ public class MoisSalesLibrarySnapshotService {
                 limit);
     }
 
-    /** Converte uma linha JDBC da URL ingerida na estrutura interna de captura. */
+    /** Converte uma linha JDBC da página consolidada na estrutura interna de captura. */
     private PageToCapture mapPageToCapture(java.sql.ResultSet rs, int rowNum) throws java.sql.SQLException {
         return new PageToCapture(rs.getLong("id"), rs.getString("url_canonical"), rs.getString("title"));
     }
 
-    /** Executa uma captura isolada convertendo qualquer exceção em snapshot FAILED auditável. */
+    /** Executa uma captura isolada convertendo qualquer exceção em execução FAILED auditável. */
     private MoisSalesLibraryDtos.SalesLibrarySnapshotCaptureItem captureOneSafely(PageToCapture page) {
+        long executionId = insertFetchingCaptureExecution(page, "backend-capture");
+        updatePageForCaptureClaim(page.pageId(), executionId);
         try {
-            return captureOne(page);
+            return captureOne(page, executionId);
         } catch (Exception ex) {
             String errorMessage = categorizeExceptionFailure(ex);
-            log.warn("Falha ao capturar snapshot bruto da sales page MOIS. pageId={}, url={}, categoria={}",
-                    page.pageId(), page.urlCanonical(), errorMessage, ex);
-            Long snapshotId = persistFailedSnapshot(page, errorMessage, null, null, null, null);
-            syncSnapshotWhenPresent(snapshotId);
+            log.warn("Falha ao capturar HTML bruto da sales page MOIS. pageId={}, executionId={}, url={}, categoria={}",
+                    page.pageId(), executionId, page.urlCanonical(), errorMessage, ex);
+            failCaptureExecution(page, executionId, errorMessage, null, null, null, null);
             return new MoisSalesLibraryDtos.SalesLibrarySnapshotCaptureItem(
-                    page.pageId(), snapshotId, page.urlCanonical(), null, null, "FAILED", null, null, 0L, 0L, errorMessage);
+                    page.pageId(), executionId, page.urlCanonical(), null, null, "FAILED", null, null, 0L, 0L, errorMessage);
         }
     }
 
-    /** Busca a URL canônica, tenta fallback pela raiz do redirecionamento e persiste os artefatos quando a captura é útil. */
-    private MoisSalesLibraryDtos.SalesLibrarySnapshotCaptureItem captureOne(PageToCapture page) throws Exception {
+    /** Busca a URL canônica, tenta fallback pela raiz do redirecionamento e persiste a execução quando a captura é útil. */
+    private MoisSalesLibraryDtos.SalesLibrarySnapshotCaptureItem captureOne(PageToCapture page, long executionId) throws Exception {
         CaptureResponse primary = fetchUrl(page.urlCanonical());
         String redirectDestinationUrl = primary.finalUrl();
         String redirectRootUrl = rootUrl(redirectDestinationUrl);
         CaptureResponse effective = primary;
         if (!primary.isCapturable() && shouldTryRedirectRoot(page.urlCanonical(), redirectDestinationUrl, redirectRootUrl)) {
-            log.info("MOIS sales-library snapshot tentando raiz do redirecionamento. pageId={}, urlCanonical={}, redirectDestinationUrl={}, redirectRootUrl={}",
-                    page.pageId(), page.urlCanonical(), redirectDestinationUrl, redirectRootUrl);
+            log.info("MOIS sales-library captura tentando raiz do redirecionamento. pageId={}, executionId={}, urlCanonical={}, redirectDestinationUrl={}, redirectRootUrl={}",
+                    page.pageId(), executionId, page.urlCanonical(), redirectDestinationUrl, redirectRootUrl);
             effective = fetchUrl(redirectRootUrl);
         }
 
-        log.info("MOIS sales-library snapshot payload bruto recebido. pageId={}, url={}, redirectDestinationUrl={}, redirectRootUrl={}, effectiveUrl={}, httpStatus={}, contentType={}, htmlPreview={}",
-                page.pageId(), page.urlCanonical(), redirectDestinationUrl, redirectRootUrl, effective.finalUrl(), effective.statusCode(),
+        log.info("MOIS sales-library captura payload bruto recebido. pageId={}, executionId={}, url={}, redirectDestinationUrl={}, redirectRootUrl={}, effectiveUrl={}, httpStatus={}, contentType={}, htmlPreview={}",
+                page.pageId(), executionId, page.urlCanonical(), redirectDestinationUrl, redirectRootUrl, effective.finalUrl(), effective.statusCode(),
                 effective.contentType(), truncate(effective.rawHtml(), 4000));
 
         if (!effective.isCapturable()) {
             String errorMessage = categorizeHttpFailure(effective.statusCode(), effective.rawHtml());
-            Long snapshotId = persistFailedSnapshot(page, errorMessage, effective.statusCode(), effective.contentType(), redirectDestinationUrl, redirectRootUrl);
-            syncSnapshotWhenPresent(snapshotId);
+            failCaptureExecution(page, executionId, errorMessage, effective.statusCode(), effective.contentType(), redirectDestinationUrl, redirectRootUrl);
             return new MoisSalesLibraryDtos.SalesLibrarySnapshotCaptureItem(
-                    page.pageId(), snapshotId, page.urlCanonical(), redirectDestinationUrl, redirectRootUrl, "FAILED", null, effective.statusCode(), 0L, 0L,
+                    page.pageId(), executionId, page.urlCanonical(), redirectDestinationUrl, redirectRootUrl, "FAILED", null, effective.statusCode(), 0L, 0L,
                     errorMessage);
         }
 
         String rawHtml = effective.rawHtml();
         String hash = sha256(rawHtml);
-        Long existingSnapshotId = findExistingSnapshot(page.pageId(), hash);
-        if (existingSnapshotId != null) {
+        byte[] rawHtmlBytes = rawHtml.getBytes(StandardCharsets.UTF_8);
+        Long existingExecutionId = findExistingCaptureExecution(page.pageId(), hash);
+        if (existingExecutionId != null) {
+            markCaptureDuplicate(page, executionId, existingExecutionId, hash, rawHtmlBytes.length, effective.statusCode(), effective.contentType(), redirectDestinationUrl, redirectRootUrl);
             return new MoisSalesLibraryDtos.SalesLibrarySnapshotCaptureItem(
-                    page.pageId(), existingSnapshotId, page.urlCanonical(), redirectDestinationUrl, redirectRootUrl, "DUPLICATE", hash,
-                    effective.statusCode(), rawHtml.getBytes(StandardCharsets.UTF_8).length, 0L, null);
+                    page.pageId(), executionId, page.urlCanonical(), redirectDestinationUrl, redirectRootUrl, "DUPLICATE", hash,
+                    effective.statusCode(), rawHtmlBytes.length, 0L, null);
         }
 
-        long snapshotId = insertSnapshot(page, hash, effective.statusCode(), effective.contentType(), redirectDestinationUrl, redirectRootUrl);
-        byte[] rawHtmlBytes = rawHtml.getBytes(StandardCharsets.UTF_8);
-        insertTextArtifact(snapshotId, ARTIFACT_RAW_HTML, "text/html; charset=UTF-8", rawHtml, rawHtmlBytes.length);
         byte[] screenshot = renderBasicScreenshot(rawHtml, effective.finalUrl());
-        insertBinaryArtifact(snapshotId, ARTIFACT_SCREENSHOT_PNG, "image/png", screenshot);
-        dualWriteGateway.syncSnapshot(snapshotId);
+        jdbcTemplate.update("""
+                UPDATE mois_sales_page_job_execution
+                SET status = 'CAPTURED', final_url = ?, redirect_root_url = ?, http_status = ?, content_type = ?, raw_html = ?,
+                    raw_html_sha256 = ?, raw_html_bytes = ?, screenshot_blob = ?, screenshot_bytes = ?, error_category = NULL,
+                    error_message = NULL, finished_at = UTC_TIMESTAMP(), updated_at = UTC_TIMESTAMP()
+                WHERE id = ?
+                """, truncate(redirectDestinationUrl, 1024), truncate(redirectRootUrl, 1024), effective.statusCode(),
+                truncate(effective.contentType(), 255), rawHtml, hash, rawHtmlBytes.length, screenshot, screenshot.length, executionId);
+        updatePageCaptureState(page.pageId(), executionId, "CAPTURED", effective.statusCode(), effective.contentType(), redirectDestinationUrl,
+                redirectRootUrl, hash, rawHtmlBytes.length, null, null, Instant.now());
         return new MoisSalesLibraryDtos.SalesLibrarySnapshotCaptureItem(
-                page.pageId(), snapshotId, page.urlCanonical(), redirectDestinationUrl, redirectRootUrl, "CAPTURED", hash,
+                page.pageId(), executionId, page.urlCanonical(), redirectDestinationUrl, redirectRootUrl, "CAPTURED", hash,
                 effective.statusCode(), rawHtmlBytes.length, screenshot.length, null);
     }
 
-    /** Sincroniza um snapshot no modelo consolidado apenas quando a falha gerou identificador válido. */
-    private void syncSnapshotWhenPresent(Long snapshotId) {
-        if (snapshotId != null) {
-            dualWriteGateway.syncSnapshot(snapshotId);
-        }
-    }
-
-    /** Persiste uma falha de captura preservando URLs de redirecionamento, categoria, HTTP e tipo de conteúdo quando disponíveis. */
-    private Long persistFailedSnapshot(PageToCapture page, String errorMessage, Integer httpStatus, String contentType, String redirectDestinationUrl, String redirectRootUrl) {
-        try {
-            return insertFailedSnapshot(page, truncate(errorMessage, 1000), httpStatus, contentType, redirectDestinationUrl, redirectRootUrl);
-        } catch (Exception persistEx) {
-            log.warn("Falha ao persistir snapshot FAILED da sales page MOIS. pageId={}", page.pageId(), persistEx);
-            return null;
-        }
-    }
-
-    /** Insere os metadados principais de um snapshot capturado com sucesso, incluindo URLs de redirecionamento. */
-    private long insertSnapshot(PageToCapture page, String hash, int httpStatus, String contentType, String redirectDestinationUrl, String redirectRootUrl) {
+    /** Registra a execução de captura com status FETCHING e retorna sua chave. */
+    private long insertFetchingCaptureExecution(PageToCapture page, String claimedBy) {
         KeyHolder keyHolder = new GeneratedKeyHolder();
         jdbcTemplate.update(connection -> {
             PreparedStatement ps = connection.prepareStatement("""
-                    INSERT INTO mois_sales_library_page_snapshot
-                    (url_ingest_id, snapshot_hash, status, http_status, content_type, redirect_destination_url, redirect_root_url, captured_at, created_at, updated_at)
-                    VALUES (?, ?, 'CAPTURED', ?, ?, ?, ?, UTC_TIMESTAMP(), UTC_TIMESTAMP(), UTC_TIMESTAMP())
+                    INSERT INTO mois_sales_page_job_execution
+                    (sales_page_id, workspace_id, job_type, stage, status, attempt, claimed_by, input_url, started_at, created_at, updated_at)
+                    SELECT id, workspace_id, 'HTML_CAPTURE', 'CAPTURE', 'FETCHING', 1, ?, url_canonical, UTC_TIMESTAMP(), UTC_TIMESTAMP(), UTC_TIMESTAMP()
+                    FROM mois_sales_page
+                    WHERE id = ?
                     """, Statement.RETURN_GENERATED_KEYS);
-            ps.setLong(1, page.pageId());
-            ps.setString(2, hash);
-            ps.setInt(3, httpStatus);
-            ps.setString(4, truncate(contentType, 255));
-            ps.setString(5, truncate(redirectDestinationUrl, 1024));
-            ps.setString(6, truncate(redirectRootUrl, 1024));
+            ps.setString(1, claimedBy);
+            ps.setLong(2, page.pageId());
             return ps;
         }, keyHolder);
         return generatedId(keyHolder);
     }
 
-    /** Insere um snapshot FAILED com URLs de redirecionamento e metadados suficientes para auditoria. */
-    private long insertFailedSnapshot(PageToCapture page, String errorMessage, Integer httpStatus, String contentType, String redirectDestinationUrl, String redirectRootUrl) {
-        KeyHolder keyHolder = new GeneratedKeyHolder();
-        jdbcTemplate.update(connection -> {
-            PreparedStatement ps = connection.prepareStatement("""
-                    INSERT INTO mois_sales_library_page_snapshot
-                    (url_ingest_id, status, http_status, content_type, redirect_destination_url, redirect_root_url, error_message, captured_at, created_at, updated_at)
-                    VALUES (?, 'FAILED', ?, ?, ?, ?, ?, UTC_TIMESTAMP(), UTC_TIMESTAMP(), UTC_TIMESTAMP())
-                    """, Statement.RETURN_GENERATED_KEYS);
-            ps.setLong(1, page.pageId());
-            if (httpStatus == null) {
-                ps.setNull(2, java.sql.Types.INTEGER);
-            } else {
-                ps.setInt(2, httpStatus);
-            }
-            ps.setString(3, truncate(contentType, 255));
-            ps.setString(4, truncate(redirectDestinationUrl, 1024));
-            ps.setString(5, truncate(redirectRootUrl, 1024));
-            ps.setString(6, errorMessage);
-            return ps;
-        }, keyHolder);
-        return generatedId(keyHolder);
+    /** Atualiza o estado atual da página quando uma captura é reservada. */
+    private void updatePageForCaptureClaim(long pageId, long executionId) {
+        jdbcTemplate.update("""
+                UPDATE mois_sales_page
+                SET current_stage = 'CAPTURE', current_status = 'FETCHING', capture_status = 'FETCHING',
+                    last_error_category = NULL, last_error_message = NULL, last_job_execution_id = ?, updated_at = UTC_TIMESTAMP()
+                WHERE id = ?
+                """, executionId, pageId);
     }
 
-    /** Cria o registro de snapshot reservado para evitar reprocessamento concorrente. */
-    private Long insertFetchingSnapshot(PageToCapture page) {
-        KeyHolder keyHolder = new GeneratedKeyHolder();
-        jdbcTemplate.update(connection -> {
-            PreparedStatement ps = connection.prepareStatement("""
-                    INSERT INTO mois_sales_library_page_snapshot
-                    (url_ingest_id, status, captured_at, created_at, updated_at)
-                    VALUES (?, 'FETCHING', UTC_TIMESTAMP(), UTC_TIMESTAMP(), UTC_TIMESTAMP())
-                    """, Statement.RETURN_GENERATED_KEYS);
-            ps.setLong(1, page.pageId());
-            return ps;
-        }, keyHolder);
-        return generatedId(keyHolder);
-    }
-
-    /** Localiza snapshot anterior da mesma página com hash idêntico ao capturado. */
-    private Long findDuplicateSnapshot(long snapshotId, String hash) {
-        List<Long> rows = jdbcTemplate.query("""
-                SELECT existing.id
-                FROM mois_sales_library_page_snapshot current
-                JOIN mois_sales_library_page_snapshot existing
-                  ON existing.url_ingest_id = current.url_ingest_id
-                 AND existing.snapshot_hash = ?
-                 AND existing.id <> current.id
-                WHERE current.id = ?
+    /** Localiza a execução de captura ainda manipulável pelo endpoint do worker. */
+    private CaptureExecution findCaptureExecution(long executionId) {
+        List<CaptureExecution> rows = jdbcTemplate.query("""
+                SELECT id, sales_page_id
+                FROM mois_sales_page_job_execution
+                WHERE id = ? AND stage = 'CAPTURE' AND status IN ('FETCHING', 'PENDING')
                 LIMIT 1
-                """, (rs, rowNum) -> rs.getLong("id"), hash, snapshotId);
+                """, (rs, rowNum) -> new CaptureExecution(rs.getLong("id"), rs.getLong("sales_page_id")), executionId);
+        if (rows.isEmpty()) {
+            throw new IllegalArgumentException("Capture execution not found: " + executionId);
+        }
+        return rows.get(0);
+    }
+
+    /** Atualiza a execução e a página para falha em capturas backend/manuais. */
+    private void failCaptureExecution(PageToCapture page, long executionId, String errorMessage, Integer httpStatus, String contentType, String finalUrl, String redirectRootUrl) {
+        jdbcTemplate.update("""
+                UPDATE mois_sales_page_job_execution
+                SET status = 'FAILED', http_status = ?, content_type = ?, final_url = ?, redirect_root_url = ?, error_category = 'CAPTURE_FAILED',
+                    error_message = ?, finished_at = UTC_TIMESTAMP(), updated_at = UTC_TIMESTAMP()
+                WHERE id = ?
+                """, httpStatus, truncate(contentType, 255), truncate(finalUrl, 1024), truncate(redirectRootUrl, 1024), truncate(errorMessage, 1000), executionId);
+        updatePageCaptureState(page.pageId(), executionId, "FAILED", httpStatus, contentType, finalUrl, redirectRootUrl, null, 0L,
+                "CAPTURE_FAILED", errorMessage, Instant.now());
+    }
+
+    /** Marca uma execução como duplicada e atualiza o estado atual da página. */
+    private void markCaptureDuplicate(PageToCapture page, long executionId, long existingExecutionId, String hash, long rawHtmlBytes, int httpStatus, String contentType, String finalUrl, String redirectRootUrl) {
+        String duplicateMessage = "HTML idêntico à execução " + existingExecutionId;
+        jdbcTemplate.update("""
+                UPDATE mois_sales_page_job_execution
+                SET status = 'DUPLICATE', http_status = ?, content_type = ?, final_url = ?, redirect_root_url = ?,
+                    raw_html_sha256 = ?, raw_html_bytes = ?, error_category = NULL, error_message = ?, finished_at = UTC_TIMESTAMP(), updated_at = UTC_TIMESTAMP()
+                WHERE id = ?
+                """, httpStatus, truncate(contentType, 255), truncate(finalUrl, 1024), truncate(redirectRootUrl, 1024),
+                hash, rawHtmlBytes, duplicateMessage, executionId);
+        updatePageCaptureState(page.pageId(), executionId, "DUPLICATE", httpStatus, contentType, finalUrl, redirectRootUrl, hash, rawHtmlBytes,
+                null, duplicateMessage, Instant.now());
+    }
+
+    /** Atualiza a página para refletir a conclusão da captura feita pelo endpoint worker. */
+    private void updatePageForCaptureCompletion(long pageId, long executionId, String status, MoisSalesLibraryDtos.HtmlCaptureCompleteRequest request,
+                                                String hash, long rawHtmlBytes, String errorMessage, Instant capturedAt) {
+        updatePageCaptureState(pageId, executionId, status, request.httpStatus(), request.contentType(), resolveFinalUrl(request), request.redirectRootUrl(),
+                hash, rawHtmlBytes, null, errorMessage, capturedAt);
+    }
+
+    /** Atualiza os campos consolidados de captura na página operacional. */
+    private void updatePageCaptureState(long pageId, long executionId, String status, Integer httpStatus, String contentType, String finalUrl,
+                                        String redirectRootUrl, String hash, long rawHtmlBytes, String errorCategory, String errorMessage, Instant capturedAt) {
+        jdbcTemplate.update("""
+                UPDATE mois_sales_page
+                SET current_stage = 'CAPTURE', current_status = ?, capture_status = ?, http_status = ?, content_type = ?, url_final = ?,
+                    redirect_root_url = ?, html_sha256 = COALESCE(?, html_sha256), html_bytes = ?, last_error_category = ?, last_error_message = ?,
+                    last_job_execution_id = ?, last_captured_at = ?, updated_at = UTC_TIMESTAMP()
+                WHERE id = ?
+                """, status, status, httpStatus, truncate(contentType, 255), truncate(finalUrl, 1024), truncate(redirectRootUrl, 1024),
+                hash, rawHtmlBytes, truncate(errorCategory, 120), truncate(errorMessage, 1000), executionId, Timestamp.from(capturedAt), pageId);
+    }
+
+    /** Localiza outra captura concluída com o mesmo hash para a mesma página. */
+    private Long findDuplicateCaptureExecution(long executionId, long pageId, String hash) {
+        List<Long> rows = jdbcTemplate.query("""
+                SELECT id
+                FROM mois_sales_page_job_execution
+                WHERE sales_page_id = ? AND stage = 'CAPTURE' AND raw_html_sha256 = ? AND id <> ? AND status IN ('CAPTURED', 'DUPLICATE')
+                ORDER BY id DESC
+                LIMIT 1
+                """, (rs, rowNum) -> rs.getLong("id"), pageId, hash, executionId);
         return rows.isEmpty() ? null : rows.get(0);
     }
 
-    /** Localiza snapshot já persistido para a mesma página e mesmo hash antes de criar duplicidade. */
-    private Long findExistingSnapshot(long pageId, String hash) {
+    /** Localiza captura existente com hash idêntico antes de armazenar conteúdo duplicado. */
+    private Long findExistingCaptureExecution(long pageId, String hash) {
         List<Long> rows = jdbcTemplate.query("""
-                SELECT id FROM mois_sales_library_page_snapshot
-                WHERE url_ingest_id = ? AND snapshot_hash = ?
+                SELECT id
+                FROM mois_sales_page_job_execution
+                WHERE sales_page_id = ? AND stage = 'CAPTURE' AND raw_html_sha256 = ? AND status IN ('CAPTURED', 'DUPLICATE')
+                ORDER BY id DESC
                 LIMIT 1
                 """, (rs, rowNum) -> rs.getLong("id"), pageId, hash);
         return rows.isEmpty() ? null : rows.get(0);
+    }
+
+    /** Resolve a URL final preferindo o destino efetivo informado pelo worker. */
+    private String resolveFinalUrl(MoisSalesLibraryDtos.HtmlCaptureCompleteRequest request) {
+        String finalUrl = request.finalUrl();
+        if (finalUrl != null && !finalUrl.isBlank()) {
+            return finalUrl;
+        }
+        return request.redirectDestinationUrl();
     }
 
     /** Extrai a chave gerada pelo banco após um INSERT com GeneratedKeyHolder. */
@@ -399,62 +440,42 @@ public class MoisSalesLibrarySnapshotService {
         return key == null ? 0L : key.longValue();
     }
 
-    /** Persiste um artefato textual associado ao snapshot. */
-    private void insertTextArtifact(long snapshotId, String artifactType, String contentType, String contentText, long sizeBytes) {
-        jdbcTemplate.update("""
-                INSERT INTO mois_sales_library_snapshot_artifact
-                (snapshot_id, artifact_type, content_type, storage_kind, content_text, size_bytes, created_at)
-                VALUES (?, ?, ?, 'DATABASE_TEXT', ?, ?, UTC_TIMESTAMP())
-                """, snapshotId, artifactType, contentType, contentText, sizeBytes);
-    }
-
-    /** Persiste um artefato binário associado ao snapshot. */
-    private void insertBinaryArtifact(long snapshotId, String artifactType, String contentType, byte[] contentBlob) {
-        jdbcTemplate.update("""
-                INSERT INTO mois_sales_library_snapshot_artifact
-                (snapshot_id, artifact_type, content_type, storage_kind, content_blob, size_bytes, created_at)
-                VALUES (?, ?, ?, 'DATABASE_BLOB', ?, ?, UTC_TIMESTAMP())
-                """, snapshotId, artifactType, contentType, contentBlob, contentBlob.length);
-    }
-
     /** Renderiza uma prévia PNG básica do HTML para auditoria visual da captura. */
-    private byte[] renderBasicScreenshot(String rawHtml, String url) throws Exception {
-        int width = 1280;
-        int height = 1800;
-        JEditorPane pane = new JEditorPane("text/html", rawHtml);
-        pane.setEditable(false);
-        pane.setSize(new Dimension(width, height));
-        Dimension preferred = pane.getPreferredSize();
-        int renderHeight = Math.max(900, Math.min(2400, preferred.height + 80));
-        pane.setSize(new Dimension(width, renderHeight));
-        BufferedImage image = new BufferedImage(width, renderHeight, BufferedImage.TYPE_INT_RGB);
-        Graphics2D graphics = image.createGraphics();
-        graphics.setColor(Color.WHITE);
-        graphics.fillRect(0, 0, width, renderHeight);
-        pane.paint(graphics);
-        graphics.setColor(new Color(245, 245, 245));
-        graphics.fillRect(0, 0, width, 32);
-        graphics.setColor(Color.DARK_GRAY);
-        graphics.drawString("Marketing Hub snapshot: " + url, 12, 21);
-        graphics.dispose();
-        ByteArrayOutputStream output = new ByteArrayOutputStream();
-        ImageIO.write(image, "png", output);
-        return output.toByteArray();
+    private byte[] renderBasicScreenshot(String rawHtml, String baseUrl) {
+        try {
+            JEditorPane editorPane = new JEditorPane("text/html", rawHtml);
+            editorPane.setEditable(false);
+            editorPane.setSize(new Dimension(1200, 1600));
+            BufferedImage image = new BufferedImage(1200, 1600, BufferedImage.TYPE_INT_RGB);
+            Graphics2D graphics = image.createGraphics();
+            graphics.setColor(Color.WHITE);
+            graphics.fillRect(0, 0, image.getWidth(), image.getHeight());
+            editorPane.printAll(graphics);
+            graphics.dispose();
+            ByteArrayOutputStream baos = new ByteArrayOutputStream();
+            ImageIO.write(image, "png", baos);
+            return baos.toByteArray();
+        } catch (Exception ex) {
+            log.warn("Falha ao renderizar screenshot básico da sales page MOIS. baseUrl={}, erroClasse={}, erro={}",
+                    baseUrl, ex.getClass().getName(), ex.getMessage(), ex);
+            return new byte[0];
+        }
     }
 
-    /** Normaliza o limite de captura para manter a execução curta e previsível. */
-    private int normalizeLimit(Integer limit) {
-        if (limit == null) return DEFAULT_LIMIT;
-        return Math.max(1, Math.min(limit, MAX_LIMIT));
+    /** Normaliza o limite solicitado para evitar lotes grandes demais no backend. */
+    private int normalizeLimit(Integer requestedLimit) {
+        if (requestedLimit == null) {
+            return DEFAULT_LIMIT;
+        }
+        return Math.max(1, Math.min(requestedLimit, MAX_LIMIT));
     }
 
-
-    /** Executa GET com redirecionamentos e encapsula HTML, URL final, HTTP status e content type. */
+    /** Executa GET HTTP com follow redirect para obter o HTML efetivo. */
     private CaptureResponse fetchUrl(String url) throws Exception {
         HttpRequest request = HttpRequest.newBuilder(URI.create(url))
                 .timeout(Duration.ofSeconds(30))
-                .header("User-Agent", "MarketingHub-MOIS-SalesLibrarySnapshot/1.0")
                 .GET()
+                .header("User-Agent", "MarketingHub-MOIS-SalesLibrary/1.0")
                 .build();
         HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8));
         String rawHtml = response.body() == null ? "" : response.body();
@@ -534,9 +555,9 @@ public class MoisSalesLibrarySnapshotService {
             MessageDigest digest = MessageDigest.getInstance("SHA-256");
             return HexFormat.of().formatHex(digest.digest(value.getBytes(StandardCharsets.UTF_8)));
         } catch (Exception ex) {
-            log.warn("Falha ao calcular hash de snapshot HTML MOIS. operacao=sha256, erroClasse={}, erro={}",
+            log.warn("Falha ao calcular hash de captura HTML MOIS. operacao=sha256, erroClasse={}, erro={}",
                     ex.getClass().getName(), ex.getMessage(), ex);
-            throw new IllegalStateException("Falha ao calcular hash de snapshot HTML", ex);
+            throw new IllegalStateException("Falha ao calcular hash de captura HTML", ex);
         }
     }
 
@@ -552,6 +573,9 @@ public class MoisSalesLibrarySnapshotService {
     }
 
     private record PageToCapture(long pageId, String urlCanonical, String title) {
+    }
+
+    private record CaptureExecution(long executionId, long pageId) {
     }
 
     private record CaptureResponse(String rawHtml, String finalUrl, int statusCode, String contentType) {

--- a/backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryServiceTest.java
@@ -8,12 +8,14 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.lenient;
 
 import com.marketinghub.mois.bibliotecapaginavenda.worker.v1.dto.MoisSalesLibraryDtos;
 import com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1.MoisSalesPageDualWriteGateway;
 import java.sql.ResultSet;
 import java.sql.Timestamp;
 import java.time.Instant;
+import java.math.BigDecimal;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -49,13 +51,11 @@ class MoisSalesLibraryServiceTest {
                 List.of(new MoisSalesLibraryDtos.SalesLibraryUrlItem("https://example.com/pagina", "Title", Instant.parse("2026-05-19T00:00:00Z")))
         );
 
-        given(jdbcTemplate.update(contains("INSERT INTO mois_sales_library_url_ingest"), any(), any(), any(), any(), any(), any(), any()))
-                .willReturn(1);
-        given(jdbcTemplate.queryForObject(anyString(), eq(Long.class), any(), any())).willReturn(99L);
+        stubOperationalIngest(1);
 
         service.ingestUrls(request);
 
-        verify(jdbcTemplate).update(contains("INSERT INTO mois_sales_library_processing_job"), eq(99L), eq("PENDING"));
+        verify(jdbcTemplate).update(contains("INSERT INTO mois_sales_page_job_execution"), eq(99L), any(), any(), any());
     }
 
     /**
@@ -69,13 +69,11 @@ class MoisSalesLibraryServiceTest {
                 List.of(new MoisSalesLibraryDtos.SalesLibraryUrlItem("https://example.com/pagina", "Title", Instant.parse("2026-05-19T00:00:00Z")))
         );
 
-        given(jdbcTemplate.update(contains("INSERT INTO mois_sales_library_url_ingest"), any(), any(), any(), any(), any(), any(), any()))
-                .willReturn(2);
+        stubOperationalIngest(2);
 
         service.ingestUrls(request);
 
-        verify(jdbcTemplate, never()).queryForObject(anyString(), eq(Long.class), any());
-        verify(jdbcTemplate, never()).update(contains("INSERT INTO mois_sales_library_processing_job"), any(), any());
+        verify(jdbcTemplate, never()).update(contains("INSERT INTO mois_sales_page_job_execution"), any(), any(), any(), any());
     }
 
     /**
@@ -97,14 +95,12 @@ class MoisSalesLibraryServiceTest {
                             "ref-2", "Produto com fallback", null, "https://produto.example/pagina", null);
                     return List.of(mapper.mapRow(firstRow, 0), mapper.mapRow(secondRow, 1));
                 });
-        given(jdbcTemplate.update(contains("INSERT INTO mois_sales_library_url_ingest"), any(), any(), any(), any(), any(), any(), any()))
-                .willReturn(1, 2);
-        given(jdbcTemplate.queryForObject(contains("SELECT id"), eq(Long.class), any(), any())).willReturn(77L);
+        stubOperationalIngest(1, 2);
 
         MoisSalesLibraryDtos.SalesLibraryHotmartCollectedIngestResponse response =
                 service.ingestHotmartCollectedProducts(request);
 
-        verify(jdbcTemplate).update(contains("INSERT INTO mois_sales_library_processing_job"), eq(77L), eq("PENDING"));
+        verify(jdbcTemplate).update(contains("INSERT INTO mois_sales_page_job_execution"), eq(99L), any(), any(), any());
         org.assertj.core.api.Assertions.assertThat(response.jobId()).isEqualTo("hotmart-job-400");
         org.assertj.core.api.Assertions.assertThat(response.collectedReferencesRead()).isEqualTo(2);
         org.assertj.core.api.Assertions.assertThat(response.eligibleUrls()).isEqualTo(2);
@@ -158,6 +154,24 @@ class MoisSalesLibraryServiceTest {
         org.assertj.core.api.Assertions.assertThat(response.status()).isEqualTo("CAPTURED");
     }
 
+
+    /**
+     * Configura mocks comuns da ingestão operacional principal em mois_sales_page.
+     */
+    private void stubOperationalIngest(int... upsertResults) {
+        lenient().when(jdbcTemplate.update(contains("INSERT INTO mois_sales_page"), any(), any(), any(), any(), any(), any(), any()))
+                .thenReturn(upsertResults.length == 0 ? 1 : upsertResults[0], java.util.Arrays.stream(upsertResults).skip(1).boxed().toArray(Integer[]::new));
+        lenient().when(jdbcTemplate.query(contains("WHERE workspace_id = ? AND url_canonical = ?"), isA(RowMapper.class), any(), any()))
+                .thenReturn(List.of(99L));
+        lenient().when(jdbcTemplate.query(contains("SELECT id, workspace_id, source"), isA(RowMapper.class), any()))
+                .thenReturn(List.of(new MoisSalesLibraryDtos.SalesLibraryPageResponse(99L, "10", "HOTMART", "https://example.com/pagina", "Title",
+                        "ANALYSIS", "PENDING", null, "PENDING", null, null, null, 0L, BigDecimal.ZERO, null, null, null, null, null, null, null, null, null, Instant.now())));
+        lenient().when(jdbcTemplate.update(contains("INSERT INTO mois_sales_page_job_execution"), any(), any(), any())).thenReturn(1);
+        lenient().when(jdbcTemplate.queryForObject(contains("SELECT LAST_INSERT_ID()"), eq(Long.class))).thenReturn(123L);
+        lenient().when(jdbcTemplate.update(contains("UPDATE mois_sales_page"), any(), any())).thenReturn(1);
+        lenient().when(jdbcTemplate.update(contains("INSERT INTO mois_sales_library_url_ingest"), any(), any(), any(), any(), any(), any(), any())).thenReturn(1);
+        lenient().when(jdbcTemplate.update(contains("INSERT INTO mois_sales_library_processing_job"), isA(Long.class))).thenReturn(1);
+    }
 
     /**
      * Monta uma linha simulada de captura de HTML bruto reservada.

--- a/backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibrarySnapshotServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibrarySnapshotServiceTest.java
@@ -3,7 +3,6 @@ package com.marketinghub.mois.bibliotecapaginavenda.worker.v1.service;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.marketinghub.mois.bibliotecapaginavenda.worker.v1.dto.MoisSalesLibraryDtos;
-import com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1.MoisSalesPageDualWriteGateway;
 import com.sun.net.httpserver.HttpServer;
 import java.io.IOException;
 import java.net.InetSocketAddress;
@@ -34,7 +33,7 @@ public class MoisSalesLibrarySnapshotServiceTest {
         jdbcTemplate = new JdbcTemplate(dataSource);
         jdbcTemplate.execute("CREATE ALIAS IF NOT EXISTS UTC_TIMESTAMP FOR \"com.marketinghub.mois.bibliotecapaginavenda.worker.v1.service.MoisSalesLibrarySnapshotServiceTest.utcTimestamp\"");
         createSchema();
-        service = new MoisSalesLibrarySnapshotService(jdbcTemplate, new NoOpDualWriteGateway());
+        service = new MoisSalesLibrarySnapshotService(jdbcTemplate);
         server = HttpServer.create(new InetSocketAddress(0), 0);
         server.createContext("/sales", exchange -> {
             byte[] body = """
@@ -87,11 +86,7 @@ public class MoisSalesLibrarySnapshotServiceTest {
     @Test
     void shouldCaptureRawHtmlAndScreenshotArtifacts() {
         String url = "http://localhost:" + server.getAddress().getPort() + "/sales";
-        jdbcTemplate.update("""
-                INSERT INTO mois_sales_library_url_ingest
-                (id, workspace_id, source, url_original, url_canonical, title, ingest_count, created_at, updated_at)
-                VALUES (1, 'workspace-001', 'TEST', ?, ?, 'Oferta Teste', 1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
-                """, url, url);
+        insertPage(1L, url);
 
         var response = service.captureSnapshots(
                 new MoisSalesLibraryDtos.SalesLibrarySnapshotCaptureRequest("workspace-001", 5, false));
@@ -104,31 +99,31 @@ public class MoisSalesLibrarySnapshotServiceTest {
         assertThat(response.items().getFirst().rawHtmlBytes()).isPositive();
         assertThat(response.items().getFirst().screenshotBytes()).isPositive();
 
-        Integer snapshotCount = jdbcTemplate.queryForObject(
-                "SELECT COUNT(*) FROM mois_sales_library_page_snapshot",
-                Integer.class);
-        Integer artifactCount = jdbcTemplate.queryForObject(
-                "SELECT COUNT(*) FROM mois_sales_library_snapshot_artifact",
+        Integer executionCount = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM mois_sales_page_job_execution WHERE sales_page_id = 1 AND stage = 'CAPTURE' AND status = 'CAPTURED'",
                 Integer.class);
         Integer htmlCount = jdbcTemplate.queryForObject(
                 """
                         SELECT COUNT(*)
-                        FROM mois_sales_library_snapshot_artifact
-                        WHERE artifact_type = 'RAW_HTML' AND content_text LIKE '%Oferta Teste%'
+                        FROM mois_sales_page_job_execution
+                        WHERE sales_page_id = 1 AND raw_html LIKE '%Oferta Teste%'
                         """,
                 Integer.class);
         Integer screenshotCount = jdbcTemplate.queryForObject(
                 """
                         SELECT COUNT(*)
-                        FROM mois_sales_library_snapshot_artifact
-                        WHERE artifact_type = 'SCREENSHOT_PNG' AND content_blob IS NOT NULL
+                        FROM mois_sales_page_job_execution
+                        WHERE sales_page_id = 1 AND screenshot_blob IS NOT NULL
                         """,
                 Integer.class);
+        Integer pageCaptured = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM mois_sales_page WHERE id = 1 AND current_stage = 'CAPTURE' AND current_status = 'CAPTURED'",
+                Integer.class);
 
-        assertThat(snapshotCount).isEqualTo(1);
-        assertThat(artifactCount).isEqualTo(2);
+        assertThat(executionCount).isEqualTo(1);
         assertThat(htmlCount).isEqualTo(1);
         assertThat(screenshotCount).isEqualTo(1);
+        assertThat(pageCaptured).isEqualTo(1);
         assertThat(service.listSnapshots(1)).hasSize(1);
     }
 
@@ -148,10 +143,10 @@ public class MoisSalesLibrarySnapshotServiceTest {
         assertThat(response.items().getFirst().httpStatus()).isEqualTo(404);
         assertThat(response.items().getFirst().errorMessage()).startsWith("HTTP_404");
         String persistedError = jdbcTemplate.queryForObject(
-                "SELECT error_message FROM mois_sales_library_page_snapshot WHERE url_ingest_id = 2",
+                "SELECT error_message FROM mois_sales_page_job_execution WHERE sales_page_id = 2 AND stage = 'CAPTURE'",
                 String.class);
         Integer persistedHttpStatus = jdbcTemplate.queryForObject(
-                "SELECT http_status FROM mois_sales_library_page_snapshot WHERE url_ingest_id = 2",
+                "SELECT http_status FROM mois_sales_page_job_execution WHERE sales_page_id = 2 AND stage = 'CAPTURE'",
                 Integer.class);
         assertThat(persistedError).startsWith("HTTP_404");
         assertThat(persistedHttpStatus).isEqualTo(404);
@@ -226,42 +221,13 @@ public class MoisSalesLibrarySnapshotServiceTest {
         assertThat(response.items().getFirst().redirectDestinationUrl()).isEqualTo(baseUrl + "/missing");
         assertThat(response.items().getFirst().redirectRootUrl()).isEqualTo(baseUrl);
         String capturedHtml = jdbcTemplate.queryForObject(
-                "SELECT content_text FROM mois_sales_library_snapshot_artifact WHERE artifact_type = 'RAW_HTML'",
+                "SELECT raw_html FROM mois_sales_page_job_execution WHERE sales_page_id = 8 AND stage = 'CAPTURE'",
                 String.class);
         assertThat(capturedHtml).contains("Oferta Raiz");
         var storedUrls = jdbcTemplate.queryForMap(
-                "SELECT redirect_destination_url, redirect_root_url FROM mois_sales_library_page_snapshot WHERE url_ingest_id = 8");
-        assertThat(storedUrls.get("redirect_destination_url")).isEqualTo(baseUrl + "/missing");
+                "SELECT final_url, redirect_root_url FROM mois_sales_page_job_execution WHERE sales_page_id = 8 AND stage = 'CAPTURE'");
+        assertThat(storedUrls.get("final_url")).isEqualTo(baseUrl + "/missing");
         assertThat(storedUrls.get("redirect_root_url")).isEqualTo(baseUrl);
-    }
-
-    /** Ignora a escrita dupla nos testes focados apenas no comportamento legado de snapshots. */
-    private static class NoOpDualWriteGateway implements MoisSalesPageDualWriteGateway {
-
-        /** Não sincroniza URLs ingeridas no teste de snapshot. */
-        @Override
-        public void syncUrlIngest(long urlIngestId, Long processingJobId) {
-        }
-
-        /** Não sincroniza jobs no teste de snapshot. */
-        @Override
-        public void syncProcessingJob(long processingJobId) {
-        }
-
-        /** Não sincroniza análises no teste de snapshot. */
-        @Override
-        public void syncLatestAnalysis(long urlIngestId) {
-        }
-
-        /** Não sincroniza snapshots no teste de snapshot legado. */
-        @Override
-        public void syncSnapshot(long snapshotId) {
-        }
-
-        /** Não sincroniza capturas de referências coletadas no teste de snapshot. */
-        @Override
-        public void syncCollectedReferenceHtmlCapture(long captureId) {
-        }
     }
 
     /** Fornece timestamp UTC compatível com a função usada no SQL MySQL dos testes. */
@@ -269,72 +235,86 @@ public class MoisSalesLibrarySnapshotServiceTest {
         return Timestamp.from(Instant.now());
     }
 
-    /** Insere uma URL de biblioteca para os testes de seleção e captura. */
+    /** Insere uma página operacional para os testes de seleção e captura. */
     private void insertPage(long pageId, String url) {
         jdbcTemplate.update("""
-                INSERT INTO mois_sales_library_url_ingest
-                (id, workspace_id, source, url_original, url_canonical, title, ingest_count, created_at, updated_at)
-                VALUES (?, 'workspace-001', 'TEST', ?, ?, 'Oferta Teste', 1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+                INSERT INTO mois_sales_page
+                (id, workspace_id, source, url_original, url_canonical, title, current_stage, current_status, ingest_count, created_at, updated_at)
+                VALUES (?, 'workspace-001', 'TEST', ?, ?, 'Oferta Teste', 'ANALYSIS', 'PENDING', 1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
                 """, pageId, url, url);
     }
 
     /** Insere uma falha prévia para validar cooldown e limite de tentativas. */
     private void insertFailedSnapshot(long pageId, Timestamp capturedAt) {
         jdbcTemplate.update("""
-                INSERT INTO mois_sales_library_page_snapshot
-                (url_ingest_id, status, error_message, captured_at, created_at, updated_at)
-                VALUES (?, 'FAILED', 'HTTP_404: página final não encontrada', ?, ?, ?)
-                """, pageId, capturedAt, capturedAt, capturedAt);
+                INSERT INTO mois_sales_page_job_execution
+                (sales_page_id, workspace_id, job_type, stage, status, attempt, input_url, error_category, error_message, finished_at, created_at, updated_at)
+                SELECT id, workspace_id, 'HTML_CAPTURE', 'CAPTURE', 'FAILED', 1, url_canonical, 'CAPTURE_FAILED',
+                       'HTTP_404: página final não encontrada', ?, ?, ?
+                FROM mois_sales_page
+                WHERE id = ?
+                """, capturedAt, capturedAt, capturedAt, pageId);
     }
 
-    /** Cria o schema mínimo usado pelos testes de snapshots. */
+    /** Cria o schema mínimo usado pelos testes de capturas no modelo consolidado. */
     private void createSchema() {
-        jdbcTemplate.execute("DROP TABLE IF EXISTS mois_sales_library_snapshot_artifact");
-        jdbcTemplate.execute("DROP TABLE IF EXISTS mois_sales_library_page_snapshot");
-        jdbcTemplate.execute("DROP TABLE IF EXISTS mois_sales_library_url_ingest");
+        jdbcTemplate.execute("DROP TABLE IF EXISTS mois_sales_page_job_execution");
+        jdbcTemplate.execute("DROP TABLE IF EXISTS mois_sales_page");
         jdbcTemplate.execute("""
-                CREATE TABLE mois_sales_library_url_ingest (
+                CREATE TABLE mois_sales_page (
                   id BIGINT AUTO_INCREMENT PRIMARY KEY,
                   workspace_id VARCHAR(120) NOT NULL,
                   source VARCHAR(40) NOT NULL,
+                  title VARCHAR(512),
                   url_original VARCHAR(1024) NOT NULL,
                   url_canonical VARCHAR(1024) NOT NULL,
-                  title VARCHAR(512),
-                  first_captured_at TIMESTAMP,
-                  last_captured_at TIMESTAMP,
+                  url_final VARCHAR(1024),
+                  redirect_root_url VARCHAR(1024),
+                  current_stage VARCHAR(40) NOT NULL,
+                  current_status VARCHAR(40) NOT NULL,
+                  capture_status VARCHAR(40),
+                  http_status INT,
+                  content_type VARCHAR(255),
+                  html_sha256 VARCHAR(64),
+                  html_bytes BIGINT NOT NULL DEFAULT 0,
+                  last_error_category VARCHAR(120),
+                  last_error_message VARCHAR(1000),
+                  last_job_execution_id BIGINT,
                   ingest_count INT NOT NULL DEFAULT 1,
+                  last_captured_at TIMESTAMP,
                   created_at TIMESTAMP NOT NULL,
                   updated_at TIMESTAMP NOT NULL
                 )
                 """);
         jdbcTemplate.execute("""
-                CREATE TABLE mois_sales_library_page_snapshot (
+                CREATE TABLE mois_sales_page_job_execution (
                   id BIGINT AUTO_INCREMENT PRIMARY KEY,
-                  url_ingest_id BIGINT NOT NULL,
-                  snapshot_hash VARCHAR(128),
-                  status VARCHAR(32) NOT NULL,
+                  sales_page_id BIGINT NOT NULL,
+                  workspace_id VARCHAR(120) NOT NULL,
+                  job_type VARCHAR(40) NOT NULL,
+                  stage VARCHAR(40) NOT NULL,
+                  status VARCHAR(40) NOT NULL,
+                  attempt INT NOT NULL DEFAULT 1,
+                  claimed_by VARCHAR(120),
+                  input_url VARCHAR(1024),
+                  final_url VARCHAR(1024),
+                  redirect_root_url VARCHAR(1024),
                   http_status INT,
                   content_type VARCHAR(255),
-                  redirect_destination_url VARCHAR(1024),
-                  redirect_root_url VARCHAR(1024),
+                  raw_html LONGTEXT,
+                  raw_html_sha256 VARCHAR(64),
+                  raw_html_bytes BIGINT NOT NULL DEFAULT 0,
+                  screenshot_blob BLOB,
+                  screenshot_bytes BIGINT NOT NULL DEFAULT 0,
+                  score_total DECIMAL(6,2),
+                  error_category VARCHAR(120),
                   error_message VARCHAR(1000),
-                  captured_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                  started_at TIMESTAMP,
+                  finished_at TIMESTAMP,
                   created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP,
                   updated_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
                 )
                 """);
-        jdbcTemplate.execute("""
-                CREATE TABLE mois_sales_library_snapshot_artifact (
-                  id BIGINT AUTO_INCREMENT PRIMARY KEY,
-                  snapshot_id BIGINT NOT NULL,
-                  artifact_type VARCHAR(40) NOT NULL,
-                  content_type VARCHAR(255) NOT NULL,
-                  storage_kind VARCHAR(40) NOT NULL,
-                  content_text LONGTEXT,
-                  content_blob LONGBLOB,
-                  size_bytes BIGINT NOT NULL DEFAULT 0,
-                  created_at TIMESTAMP NOT NULL DEFAULT CURRENT_TIMESTAMP
-                )
-                """);
     }
+
 }

--- a/docs/novos-modulos/MOIS/mois_sales_page_pipeline_simplificacao_duas_tabelas.md
+++ b/docs/novos-modulos/MOIS/mois_sales_page_pipeline_simplificacao_duas_tabelas.md
@@ -350,6 +350,14 @@ Critério de aceite:
 - UI não depende mais de joins com as tabelas antigas;
 - logs indicam claramente cada transição de etapa.
 
+#### Implementação realizada em 2026-06-04
+
+- A ingestão explícita (`/urls:ingest`) e a ingestão Hotmart (`/hotmart-products:ingest`) passaram a gravar primariamente em `mois_sales_page`; páginas novas criam execução pendente `PAGE_ANALYSIS` em `mois_sales_page_job_execution`.
+- A reserva/conclusão/falha de análise (`/jobs:claim`, `/jobs/{jobId}:complete`, `/jobs/{jobId}:fail`) usa `mois_sales_page_job_execution` como identificador operacional do worker e atualiza o estado consolidado da página em `mois_sales_page`.
+- A captura HTML (`/html-captures:claim`, `/html-captures/{snapshotId}:complete`, `/html-captures/{snapshotId}:fail` e `/snapshots:capture`) passou a gravar o HTML bruto, hash, screenshot, redirecionamento, erro e transições diretamente em `mois_sales_page_job_execution`, atualizando `mois_sales_page` a cada transição.
+- As tabelas antigas permanecem em modo legado/auditoria; a UI principal e os detalhes operacionais devem continuar lendo `mois_sales_page` e `mois_sales_page_job_execution`.
+- O Swagger do módulo foi atualizado para explicitar que `snapshotId` nos endpoints de captura é identificador compatível de execução `HTML_CAPTURE` no histórico novo.
+
 ### Fase 6 — Congelamento e desativação gradual do legado
 
 Objetivo: reduzir manutenção do modelo antigo sem perder auditoria.

--- a/docs/registros/mois1.md
+++ b/docs/registros/mois1.md
@@ -962,3 +962,11 @@ Arquivos alterados:
 - `docs/canonical/mois-worker-canon.v1.md`
 - `docs/swagger/mois-sales-library-swagger.yaml`
 - `docs/registros/mois1.md`
+
+## 2026-06-04 — MOIS Biblioteca de Páginas de Vendas — Fase 5 do modelo em duas tabelas
+
+- executada a Fase 5 do plano `docs/novos-modulos/MOIS/mois_sales_page_pipeline_simplificacao_duas_tabelas.md`.
+- ingestão explícita e ingestão Hotmart agora escrevem primariamente em `mois_sales_page` e criam execução pendente `PAGE_ANALYSIS` em `mois_sales_page_job_execution` para páginas novas.
+- captura HTML por worker/backend agora cria e conclui execuções `HTML_CAPTURE` diretamente em `mois_sales_page_job_execution`, atualizando `mois_sales_page` em claim, sucesso, duplicidade e falha.
+- tabelas legadas permanecem apenas como auditoria transitória quando houver espelhamento compatível; leitura operacional permanece concentrada nas duas tabelas novas.
+- Swagger `docs/swagger/mois-sales-library-swagger.yaml` atualizado para documentar ingestão, análise e captura como contratos do modelo operacional novo.

--- a/docs/swagger/mois-sales-library-swagger.yaml
+++ b/docs/swagger/mois-sales-library-swagger.yaml
@@ -1,11 +1,47 @@
 openapi: 3.0.3
 info:
   title: Marketing Hub - MOIS Sales Library
-  version: 0.3.0
-  description: Contratos operacionais da Biblioteca de Páginas de Vendas do MOIS. Na Fase 5, os endpoints de jobs de análise usam `mois_sales_page` e `mois_sales_page_job_execution` como fonte operacional principal; tabelas legadas são mantidas apenas para auditoria transitória.
+  version: 0.4.0
+  description: Contratos operacionais da Biblioteca de Páginas de Vendas do MOIS. Na Fase 5, ingestão, captura HTML e análise usam `mois_sales_page` e `mois_sales_page_job_execution` como fonte operacional principal; tabelas legadas são mantidas apenas para auditoria transitória.
 servers:
   - url: /api/mois/sales-library
 paths:
+  /urls:ingest:
+    post:
+      summary: Ingere URLs externas no modelo operacional novo
+      description: Cria/atualiza primariamente `mois_sales_page`; quando a URL é nova, cria execução `PAGE_ANALYSIS` pendente em `mois_sales_page_job_execution`. O legado recebe espelho apenas para auditoria.
+      tags: [MOIS Sales Library]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SalesLibraryIngestRequest'
+      responses:
+        '202':
+          description: URLs aceitas para ingestão
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SalesLibraryIngestResponse'
+  /hotmart-products:ingest:
+    post:
+      summary: Ingere URLs de produtos Hotmart coletados no modelo operacional novo
+      description: Lê `mois_collected_reference` como origem bruta e grava o estado operacional em `mois_sales_page` com execução pendente em `mois_sales_page_job_execution` para páginas novas.
+      tags: [MOIS Sales Library]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/SalesLibraryHotmartCollectedIngestRequest'
+      responses:
+        '202':
+          description: Produtos avaliados para ingestão operacional
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SalesLibraryHotmartCollectedIngestResponse'
   /jobs:claim:
     post:
       summary: Reserva a próxima execução de análise pelo modelo operacional novo
@@ -111,9 +147,67 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/CollectedReferenceHtmlPersistResponse'
+  /html-captures:claim:
+    post:
+      summary: Reserva uma execução de captura HTML pelo modelo operacional novo
+      description: Retorna `snapshotId` como identificador compatível da execução `HTML_CAPTURE` em `mois_sales_page_job_execution`; `pageId` identifica `mois_sales_page`.
+      tags: [MOIS Sales Library]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/HtmlCaptureClaimRequest'
+      responses:
+        '200':
+          description: Resultado da reserva de captura
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HtmlCaptureClaimResponse'
+  /html-captures/{snapshotId}:complete:
+    post:
+      summary: Conclui uma execução de captura HTML operacional
+      description: Atualiza `mois_sales_page_job_execution` com HTML bruto, hash, screenshot e metadados de redirecionamento; atualiza também o estado atual de `mois_sales_page`.
+      tags: [MOIS Sales Library]
+      parameters:
+        - $ref: '#/components/parameters/SnapshotId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/HtmlCaptureCompleteRequest'
+      responses:
+        '200':
+          description: Captura concluída
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HtmlCapturePersistResponse'
+  /html-captures/{snapshotId}:fail:
+    post:
+      summary: Registra falha de uma execução de captura HTML operacional
+      description: Atualiza falha em `mois_sales_page_job_execution` e reflete causa-raiz no estado atual de `mois_sales_page`.
+      tags: [MOIS Sales Library]
+      parameters:
+        - $ref: '#/components/parameters/SnapshotId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/HtmlCaptureFailRequest'
+      responses:
+        '200':
+          description: Falha registrada
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HtmlCapturePersistResponse'
   /snapshots:capture:
     post:
-      summary: Executa captura de snapshots HTML para páginas sem captura recente
+      summary: Executa captura HTML backend para páginas sem captura recente usando o modelo operacional novo
       tags: [MOIS Sales Library]
       requestBody:
         required: true
@@ -141,6 +235,14 @@ components:
       in: path
       name: captureId
       required: true
+      schema:
+        type: integer
+        format: int64
+    SnapshotId:
+      in: path
+      name: snapshotId
+      required: true
+      description: Identificador compatível da execução `HTML_CAPTURE` em `mois_sales_page_job_execution`.
       schema:
         type: integer
         format: int64
@@ -278,6 +380,163 @@ components:
           format: int64
         status:
           type: string
+    SalesLibraryIngestRequest:
+      type: object
+      required: [workspaceId, source, urls]
+      properties:
+        workspaceId:
+          type: string
+        source:
+          type: string
+        urls:
+          type: array
+          items:
+            $ref: '#/components/schemas/SalesLibraryUrlItem'
+    SalesLibraryUrlItem:
+      type: object
+      required: [url]
+      properties:
+        url:
+          type: string
+        title:
+          type: string
+        capturedAt:
+          type: string
+          format: date-time
+    SalesLibraryIngestResponse:
+      type: object
+      properties:
+        workspaceId:
+          type: string
+        source:
+          type: string
+        received:
+          type: integer
+        persisted:
+          type: integer
+    SalesLibraryHotmartCollectedIngestRequest:
+      type: object
+      required: [workspaceId]
+      properties:
+        workspaceId:
+          type: string
+        jobId:
+          type: string
+          nullable: true
+        limit:
+          type: integer
+          maximum: 400
+          nullable: true
+    SalesLibraryHotmartCollectedIngestResponse:
+      type: object
+      properties:
+        workspaceId:
+          type: string
+        jobId:
+          type: string
+          nullable: true
+        collectedReferencesRead:
+          type: integer
+        eligibleUrls:
+          type: integer
+        insertedUrls:
+          type: integer
+        updatedUrls:
+          type: integer
+        jobsCreated:
+          type: integer
+        skippedWithoutUrl:
+          type: integer
+    HtmlCaptureClaimRequest:
+      type: object
+      required: [workspaceId]
+      properties:
+        workspaceId:
+          type: string
+        limit:
+          type: integer
+          minimum: 1
+          maximum: 20
+        force:
+          type: boolean
+    HtmlCaptureJobResponse:
+      type: object
+      properties:
+        snapshotId:
+          type: integer
+          format: int64
+          description: Identificador compatível da execução `HTML_CAPTURE`.
+        pageId:
+          type: integer
+          format: int64
+        urlCanonical:
+          type: string
+        title:
+          type: string
+    HtmlCaptureClaimResponse:
+      type: object
+      properties:
+        claimed:
+          type: boolean
+        job:
+          $ref: '#/components/schemas/HtmlCaptureJobResponse'
+    HtmlCaptureCompleteRequest:
+      type: object
+      required: [rawHtml]
+      properties:
+        rawHtml:
+          type: string
+        finalUrl:
+          type: string
+          nullable: true
+        redirectDestinationUrl:
+          type: string
+          nullable: true
+        redirectRootUrl:
+          type: string
+          nullable: true
+        httpStatus:
+          type: integer
+          nullable: true
+        contentType:
+          type: string
+          nullable: true
+        sha256:
+          type: string
+          nullable: true
+        sizeBytes:
+          type: integer
+          format: int64
+          nullable: true
+        capturedAt:
+          type: string
+          format: date-time
+          nullable: true
+    HtmlCaptureFailRequest:
+      type: object
+      properties:
+        errorCategory:
+          type: string
+        errorMessage:
+          type: string
+        redirectDestinationUrl:
+          type: string
+          nullable: true
+        redirectRootUrl:
+          type: string
+          nullable: true
+        httpStatus:
+          type: integer
+          nullable: true
+    HtmlCapturePersistResponse:
+      type: object
+      properties:
+        snapshotId:
+          type: integer
+          format: int64
+          description: Identificador compatível da execução `HTML_CAPTURE`.
+        status:
+          type: string
     SalesLibrarySnapshotCaptureRequest:
       type: object
       required: [workspaceId]
@@ -292,7 +551,7 @@ components:
           example: 5
         force:
           type: boolean
-          description: Quando verdadeiro, recaptura páginas mesmo que já possuam snapshot CAPTURED/FETCHING ou estejam em cooldown por falha recente/recorrente.
+          description: Quando verdadeiro, recaptura páginas mesmo que já possuam captura CAPTURED/FETCHING ou estejam em cooldown por falha recente/recorrente.
     SalesLibrarySnapshotCaptureItem:
       type: object
       properties:
@@ -303,6 +562,7 @@ components:
           type: integer
           format: int64
           nullable: true
+          description: Identificador compatível da execução `HTML_CAPTURE` em `mois_sales_page_job_execution`.
         urlCanonical:
           type: string
         redirectDestinationUrl:


### PR DESCRIPTION
### Motivation

- Consolidate the operational source-of-truth for MOIS sales pages into two tables: `mois_sales_page` and `mois_sales_page_job_execution` so workers and backend use a single model for ingestion, capture and analysis.
- Stop writing business-critical state into legacy tables and keep them only as transitional/audit mirrors.

### Description

- Reworked ingestion to write primarily into `mois_sales_page`, create analysis executions in `mois_sales_page_job_execution`, and mirror legacy artifacts for audit via `mirrorOperationalIngestToLegacyAudit`.
- Replaced legacy snapshot flow with an execution-based capture pipeline: claim/insert/update of `HTML_CAPTURE` executions in `mois_sales_page_job_execution`, and consolidated page state updates in `mois_sales_page` (methods added: `insertFetchingCaptureExecution`, `findCaptureExecution`, `updatePageForCaptureClaim`, `updatePageForCaptureCompletion`, `updatePageCaptureState`, `markCaptureDuplicate`, etc.).
- Updated the HTML capture implementation to persist raw HTML, SHA-256, screenshot blob, redirect metadata and finished timestamps into the new execution table and to update the page row with capture metadata; added a basic screenshot renderer and helpers like `sha256`, `resolveFinalUrl`, and `normalizeLimit`.
- Adjusted tests and test schema to the new model, removed the dual-write gateway from snapshot tests, and updated the Swagger and docs to reflect Phase 5 contract/behavior changes (new endpoints and semantics for `snapshotId`/`jobId`).

### Testing

- Updated and ran unit tests covering ingestion and capture flows: `MoisSalesLibraryServiceTest` and `MoisSalesLibrarySnapshotServiceTest`, both completed successfully.
- Exercise performed: unit test suite for the modified classes was executed and assertions for capture, duplicate detection, failure handling and job creation passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a21bd06677883219fbf98bc4176ca26)