### PR TITLE
Enforce pipeline contract and return HTTP 400 for missing OpenAI model

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/pipeline/service/PipelineService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/pipeline/service/PipelineService.java
@@ -76,6 +76,7 @@ public class PipelineService {
     @Transactional
     public Pipeline create(PipelineRequest request) {
         validatePipelineModule(request.getModule());
+        validateOfficialPipelineCreate(request);
         Pipeline pipeline = new Pipeline();
         applyPipelineRequest(pipeline, request);
         return pipelineRepository.save(pipeline);
@@ -230,6 +231,19 @@ public class PipelineService {
     private void validatePipelineModule(String module) {
         if (!definitionRegistry.validModules().contains(module)) {
             throw badRequest("Módulo de pipeline desconhecido: " + module);
+        }
+    }
+
+    /**
+     * Bloqueia criação de pipeline oficial com módulo divergente do contrato canônico.
+     */
+    private void validateOfficialPipelineCreate(PipelineRequest request) {
+        PipelineDefinition definition = definitionRegistry.findByPipelineCode(request.getCode()).orElse(null);
+        if (definition != null && !definition.module().equals(request.getModule())) {
+            throw badRequest("Pipeline oficial deve usar o módulo canônico "
+                    + definition.module()
+                    + ": "
+                    + request.getCode());
         }
     }
 
@@ -443,7 +457,7 @@ public class PipelineService {
             return null;
         }
         return openAiModelRepository.findById(openAiModelId)
-                .orElseThrow(() -> new EntityNotFoundException("Modelo OpenAI não encontrado: " + openAiModelId));
+                .orElseThrow(() -> badRequest("Modelo OpenAI não encontrado: " + openAiModelId));
     }
 
     /**

--- a/backend/ads-service/src/test/java/com/marketinghub/pipeline/service/PipelineServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/pipeline/service/PipelineServiceTest.java
@@ -18,7 +18,6 @@ import com.marketinghub.repository.jpa.pipeline.PipelineStageRepository;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import jakarta.persistence.EntityNotFoundException;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.ArgumentCaptor;
@@ -149,6 +148,22 @@ class PipelineServiceTest {
     }
 
     /**
+     * Garante que criação de pipeline oficial não permite módulo divergente do contrato.
+     */
+    @Test
+    void shouldNotCreateOfficialPipelineWithDifferentModule() {
+        PipelineRequest request = new PipelineRequest();
+        request.setName("Pipeline de Experimento");
+        request.setCode("experiment-pipeline");
+        request.setModule("MDS");
+        request.setActive(true);
+
+        assertThatThrownBy(() -> service.create(request))
+                .isInstanceOf(ResponseStatusException.class)
+                .hasMessageContaining("Pipeline oficial deve usar o módulo canônico EXPERIMENT");
+    }
+
+    /**
      * Garante que etapa obrigatória oficial não pode ser removida.
      */
     @Test
@@ -241,7 +256,7 @@ class PipelineServiceTest {
         when(openAiModelRepository.findById(99L)).thenReturn(Optional.empty());
 
         assertThatThrownBy(() -> service.createStage(10L, request))
-                .isInstanceOf(EntityNotFoundException.class)
+                .isInstanceOf(ResponseStatusException.class)
                 .hasMessageContaining("Modelo OpenAI não encontrado");
     }
 

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -3443,3 +3443,14 @@
 - causa-raiz/objetivo: o diagnóstico sozinho indica problemas, mas o modelo precisa enxergar o preset anterior para localizar quais definições/classes geraram a falha e produzir uma versão melhor com menos tentativa e erro.
 - correção aplicada: o Worker AI passou a incluir `landingPageDesignPreset` no contexto do prompt do preset design e o prompt agora exibe o preset anterior junto do Quality Review, instruindo comparação causal entre ambos antes de gerar o novo JSON.
 - cânone atualizado: `docs/canonical/geralanding-arquitetura-canon.v1.md` passou a exigir o envio conjunto de `landing_page_design_preset` anterior e `landing_page_quality_review` na reexecução do preset design quando existirem.
+
+## 2026-06-04 17:37:55 UTC-3
+- solicitação: executar a fase 1 do plano de governança de contrato operacional de pipelines sem criar novas tabelas.
+- raciocínio: a causa-raiz das divergências entre tela, banco e código deve ser bloqueada no backend por contrato oficial e exposta pela tela por metadados/diagnóstico antes de virar falha tardia na execução do pipeline.
+- foi feito: reforço das travas da fase 1 para impedir criação de pipeline oficial com módulo divergente do cânone e para tratar associação a modelo OpenAI inexistente como violação HTTP 400 do contrato operacional, com cobertura unitária adicional.
+- documentos lidos para pesquisar e resolver o problema:
+  - AGENTS.md
+  - backend/AGENTS.md
+  - frontend/AGENTS.md
+  - docs/implementacao/backend/plano-pipelines-contrato-operacional.md
+  - docs/registros/experimentos.md


### PR DESCRIPTION
### Motivation
- Prevent silent divergences between UI/configured pipelines and the backend canonical definitions by enforcing contract rules at creation time and making invalid OpenAI model references a client error.

### Description
- Added `validateOfficialPipelineCreate(PipelineRequest)` to `PipelineService` and call it from `create()` to block creating an official pipeline when the `module` does not match the canonical module for that pipeline code. 
- Changed `resolveOpenAiModel` to throw a `ResponseStatusException` (HTTP 400) instead of `EntityNotFoundException` when an OpenAI model id is not found, making model-related violations part of the operational contract.
- Updated tests in `PipelineServiceTest` to cover the new creation validation (`shouldNotCreateOfficialPipelineWithDifferentModule`) and to expect `ResponseStatusException` for missing OpenAI model.
- Added an operational record to `docs/registros/experimentos.md` describing the change and the execution timestamp.

### Testing
- Ran the unit tests for the pipeline service with `./mvnw -f ads-service/pom.xml -Dtest=PipelineServiceTest test` and the test class passed (11 tests, 0 failures). 
- Executed the full `ads-service` test suite with `./mvnw -f ads-service/pom.xml test`, which completed successfully (`BUILD SUCCESS`) and ran the module's tests without failures.
- Updated documentation entry `docs/registros/experimentos.md` to record the action and rationale.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a21e14d2f708321907e20aa4bd7d16f)