### PR TITLE
Fase 2: Sincronização segura e contrato canônico de Pipelines

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/pipeline/definition/PipelineDefinitionRegistry.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/pipeline/definition/PipelineDefinitionRegistry.java
@@ -18,6 +18,7 @@ import org.springframework.util.StringUtils;
 public class PipelineDefinitionRegistry {
     private static final String EXPERIMENT_PIPELINE_CODE = "experiment-pipeline";
     private static final String EXPERIMENT_MODULE = "EXPERIMENT";
+    private static final String EXPERIMENT_CANONICAL_VERSION = "procedimento-experimento-canon.v1";
 
     private final List<PipelineDefinition> officialPipelines;
     private final Set<String> validModules;
@@ -99,8 +100,11 @@ public class PipelineDefinitionRegistry {
                 EXPERIMENT_MODULE,
                 EXPERIMENT_PIPELINE_CODE,
                 "Pipeline de Experimento",
+                EXPERIMENT_CANONICAL_VERSION,
                 true,
                 Set.of(EXPERIMENT_PIPELINE_CODE, "experiment_pipeline"),
+                PipelineFieldPolicy.officialDefault(),
+                StageFieldPolicy.officialDefault(),
                 stages);
     }
 
@@ -120,8 +124,11 @@ public class PipelineDefinitionRegistry {
             String module,
             String code,
             String name,
+            String canonicalVersion,
             boolean official,
             Set<String> aliases,
+            PipelineFieldPolicy pipelineFieldPolicy,
+            StageFieldPolicy stageFieldPolicy,
             List<PipelineStageDefinition> stages) {
         /**
          * Informa se o código recebido é o código oficial ou um alias permitido.
@@ -146,6 +153,43 @@ public class PipelineDefinitionRegistry {
                 return "";
             }
             return code.trim().toLowerCase(Locale.ROOT).replace('_', '-');
+        }
+    }
+
+
+    /**
+     * Política que separa campos estruturais de pipeline dos campos operacionais editáveis.
+     */
+    public record PipelineFieldPolicy(
+            boolean codeStructural,
+            boolean moduleStructural,
+            boolean nameStructural,
+            boolean descriptionOperational,
+            boolean activeOperational) {
+        /**
+         * Retorna a política padrão para pipelines oficiais versionados no código.
+         */
+        public static PipelineFieldPolicy officialDefault() {
+            return new PipelineFieldPolicy(true, true, true, true, true);
+        }
+    }
+
+    /**
+     * Política que separa campos estruturais de etapa dos campos operacionais configuráveis.
+     */
+    public record StageFieldPolicy(
+            boolean codeStructural,
+            boolean positionStructural,
+            boolean nameStructural,
+            boolean requiredStructural,
+            boolean descriptionOperational,
+            boolean activeOperational,
+            boolean openAiModelOperational) {
+        /**
+         * Retorna a política padrão para etapas oficiais versionadas no código.
+         */
+        public static StageFieldPolicy officialDefault() {
+            return new StageFieldPolicy(true, true, true, true, true, true, true);
         }
     }
 

--- a/backend/ads-service/src/main/java/com/marketinghub/pipeline/dto/OfficialPipelineDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/pipeline/dto/OfficialPipelineDto.java
@@ -11,6 +11,8 @@ public record OfficialPipelineDto(
         String module,
         String code,
         String name,
+        String canonicalVersion,
         boolean official,
         List<String> aliases,
+        PipelineFieldPolicyDto fieldPolicy,
         List<OfficialPipelineStageDto> stages) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/pipeline/dto/OfficialPipelineStageDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/pipeline/dto/OfficialPipelineStageDto.java
@@ -14,4 +14,5 @@ public record OfficialPipelineStageDto(
         int position,
         boolean required,
         boolean configurable,
+        StageFieldPolicyDto fieldPolicy,
         List<String> aliases) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/pipeline/dto/PipelineFieldPolicyDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/pipeline/dto/PipelineFieldPolicyDto.java
@@ -1,0 +1,14 @@
+package com.marketinghub.pipeline.dto;
+
+import lombok.Builder;
+
+/**
+ * DTO que explicita quais campos de pipeline são estruturais ou operacionais.
+ */
+@Builder
+public record PipelineFieldPolicyDto(
+        boolean codeStructural,
+        boolean moduleStructural,
+        boolean nameStructural,
+        boolean descriptionOperational,
+        boolean activeOperational) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/pipeline/dto/PipelineSyncResultDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/pipeline/dto/PipelineSyncResultDto.java
@@ -1,0 +1,19 @@
+package com.marketinghub.pipeline.dto;
+
+import java.util.List;
+import lombok.Builder;
+
+/**
+ * DTO que resume uma sincronização segura entre contrato oficial e banco operacional.
+ */
+@Builder
+public record PipelineSyncResultDto(
+        String status,
+        boolean synchronizedSafely,
+        Long pipelineId,
+        String pipelineCode,
+        String canonicalPipelineCode,
+        int expectedStages,
+        int configuredStages,
+        List<String> appliedActions,
+        List<PipelineDiagnosticsIssueDto> issues) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/pipeline/dto/StageFieldPolicyDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/pipeline/dto/StageFieldPolicyDto.java
@@ -1,0 +1,16 @@
+package com.marketinghub.pipeline.dto;
+
+import lombok.Builder;
+
+/**
+ * DTO que explicita quais campos de etapa são estruturais ou operacionais.
+ */
+@Builder
+public record StageFieldPolicyDto(
+        boolean codeStructural,
+        boolean positionStructural,
+        boolean nameStructural,
+        boolean requiredStructural,
+        boolean descriptionOperational,
+        boolean activeOperational,
+        boolean openAiModelOperational) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/pipeline/service/PipelineDefinitionSynchronizer.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/pipeline/service/PipelineDefinitionSynchronizer.java
@@ -1,0 +1,277 @@
+package com.marketinghub.pipeline.service;
+
+import com.marketinghub.pipeline.Pipeline;
+import com.marketinghub.pipeline.PipelineStage;
+import com.marketinghub.pipeline.definition.PipelineDefinitionRegistry;
+import com.marketinghub.pipeline.definition.PipelineDefinitionRegistry.PipelineDefinition;
+import com.marketinghub.pipeline.definition.PipelineDefinitionRegistry.PipelineStageDefinition;
+import com.marketinghub.pipeline.dto.PipelineDiagnosticsDto;
+import com.marketinghub.pipeline.dto.PipelineDiagnosticsIssueDto;
+import com.marketinghub.pipeline.dto.PipelineSyncResultDto;
+import com.marketinghub.repository.jpa.pipeline.PipelineRepository;
+import com.marketinghub.repository.jpa.pipeline.PipelineStageRepository;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Sincronizador idempotente que repara divergências simples entre contrato oficial e banco operacional.
+ */
+@Component
+public class PipelineDefinitionSynchronizer {
+    private final PipelineRepository pipelineRepository;
+    private final PipelineStageRepository stageRepository;
+    private final PipelineDefinitionRegistry definitionRegistry;
+    private final PipelineService pipelineService;
+
+    /**
+     * Inicializa o sincronizador com persistência centralizada, registry canônico e diagnóstico do serviço.
+     */
+    public PipelineDefinitionSynchronizer(
+            PipelineRepository pipelineRepository,
+            PipelineStageRepository stageRepository,
+            PipelineDefinitionRegistry definitionRegistry,
+            PipelineService pipelineService) {
+        this.pipelineRepository = pipelineRepository;
+        this.stageRepository = stageRepository;
+        this.definitionRegistry = definitionRegistry;
+        this.pipelineService = pipelineService;
+    }
+
+    /**
+     * Sincroniza com segurança um pipeline já existente, preservando campos operacionais configuráveis.
+     */
+    @Transactional
+    public PipelineSyncResultDto sync(Long pipelineId) {
+        Pipeline pipeline = pipelineService.get(pipelineId);
+        PipelineDefinition definition = definitionRegistry.findByPipelineCode(pipeline.getCode()).orElse(null);
+        if (definition == null) {
+            PipelineDiagnosticsDto diagnostics = pipelineService.diagnostics(pipelineId);
+            return blockedResult(diagnostics, List.of());
+        }
+
+        List<String> appliedActions = new ArrayList<>();
+        List<PipelineDiagnosticsIssueDto> blockingIssues = destructiveIssues(pipeline, definition);
+        if (!blockingIssues.isEmpty()) {
+            PipelineDiagnosticsDto diagnostics = pipelineService.diagnostics(pipelineId);
+            return PipelineSyncResultDto.builder()
+                    .status("BLOQUEADO")
+                    .synchronizedSafely(false)
+                    .pipelineId(diagnostics.pipelineId())
+                    .pipelineCode(diagnostics.pipelineCode())
+                    .canonicalPipelineCode(diagnostics.canonicalPipelineCode())
+                    .expectedStages(diagnostics.expectedStages())
+                    .configuredStages(diagnostics.configuredStages())
+                    .appliedActions(appliedActions)
+                    .issues(blockingIssues)
+                    .build();
+        }
+
+        synchronizePipelineFields(pipeline, definition, appliedActions);
+        for (PipelineStageDefinition stageDefinition : definition.stages()) {
+            synchronizeStage(pipeline, definition, stageDefinition, appliedActions);
+        }
+        pipelineRepository.save(pipeline);
+
+        PipelineDiagnosticsDto diagnostics = pipelineService.diagnostics(pipelineId);
+        return PipelineSyncResultDto.builder()
+                .status(diagnostics.status())
+                .synchronizedSafely("OK".equals(diagnostics.status()))
+                .pipelineId(diagnostics.pipelineId())
+                .pipelineCode(diagnostics.pipelineCode())
+                .canonicalPipelineCode(diagnostics.canonicalPipelineCode())
+                .expectedStages(diagnostics.expectedStages())
+                .configuredStages(diagnostics.configuredStages())
+                .appliedActions(appliedActions)
+                .issues(diagnostics.issues())
+                .build();
+    }
+
+    /**
+     * Cria o pipeline oficial ausente pelo código canônico sem sobrescrever configuração existente.
+     */
+    @Transactional
+    public PipelineSyncResultDto syncOfficialByCode(String code) {
+        PipelineDefinition definition = definitionRegistry.findByPipelineCode(code).orElse(null);
+        if (definition == null) {
+            return PipelineSyncResultDto.builder()
+                    .status("BLOQUEADO")
+                    .synchronizedSafely(false)
+                    .pipelineCode(code)
+                    .canonicalPipelineCode(null)
+                    .expectedStages(0)
+                    .configuredStages(0)
+                    .appliedActions(List.of())
+                    .issues(List.of(issue("ERROR", null, null,
+                            "Pipeline informado não possui definição oficial no backend.",
+                            "A tela solicitou sincronização de código fora do contrato canônico.",
+                            "Selecionar um pipeline oficial conhecido em /api/pipelines/metadata.")))
+                    .build();
+        }
+        Pipeline pipeline = findExistingOfficialPipeline(code, definition);
+        return sync(pipeline.getId());
+    }
+
+    /**
+     * Localiza pipeline oficial já salvo pelo código canônico ou alias recebido antes de criar novo registro.
+     */
+    private Pipeline findExistingOfficialPipeline(String requestedCode, PipelineDefinition definition) {
+        return pipelineRepository.findByCode(definition.code())
+                .or(() -> pipelineRepository.findByCode(requestedCode))
+                .orElseGet(() -> createPipeline(definition));
+    }
+
+    /**
+     * Corrige campos estruturais do pipeline quando a política oficial permite reparo automático.
+     */
+    private void synchronizePipelineFields(Pipeline pipeline, PipelineDefinition definition, List<String> appliedActions) {
+        if (definition.pipelineFieldPolicy().nameStructural() && !definition.name().equals(pipeline.getName())) {
+            pipeline.setName(definition.name());
+            appliedActions.add("Nome do pipeline corrigido para o contrato canônico.");
+        }
+    }
+
+    /**
+     * Cria ou corrige uma etapa oficial sem alterar modelo OpenAI, descrição operacional ou ativo configurado.
+     */
+    private void synchronizeStage(
+            Pipeline pipeline,
+            PipelineDefinition definition,
+            PipelineStageDefinition stageDefinition,
+            List<String> appliedActions) {
+        PipelineStage stage = findConfiguredStage(pipeline, definition, stageDefinition);
+        if (stage == null) {
+            stage = createStage(pipeline, stageDefinition);
+            appliedActions.add("Etapa oficial ausente criada: " + stageDefinition.operationalCode());
+            return;
+        }
+        if (definition.stageFieldPolicy().nameStructural() && !stageDefinition.name().equals(stage.getName())) {
+            stage.setName(stageDefinition.name());
+            appliedActions.add("Nome da etapa corrigido: " + stageDefinition.operationalCode());
+        }
+        if (definition.stageFieldPolicy().positionStructural() && !stage.getPosition().equals(stageDefinition.position())) {
+            stage.setPosition(stageDefinition.position());
+            appliedActions.add("Posição canônica da etapa corrigida: " + stageDefinition.operationalCode());
+        }
+        if (definition.stageFieldPolicy().requiredStructural() && stage.isRequired() != stageDefinition.required()) {
+            stage.setRequired(stageDefinition.required());
+            appliedActions.add("Obrigatoriedade estrutural da etapa corrigida: " + stageDefinition.operationalCode());
+        }
+        stageRepository.save(stage);
+    }
+
+    /**
+     * Localiza no banco a etapa correspondente ao código operacional ou aliases oficiais.
+     */
+    private PipelineStage findConfiguredStage(
+            Pipeline pipeline, PipelineDefinition definition, PipelineStageDefinition stageDefinition) {
+        return pipeline.getStages().stream()
+                .filter(stage -> definitionRegistry.findStage(definition, stage.getCode())
+                        .map(stageDefinition::equals)
+                        .orElse(false))
+                .findFirst()
+                .orElse(null);
+    }
+
+    /**
+     * Cria uma etapa oficial mínima, deixando campos operacionais sem configuração específica do usuário.
+     */
+    private PipelineStage createStage(Pipeline pipeline, PipelineStageDefinition stageDefinition) {
+        PipelineStage stage = PipelineStage.builder()
+                .pipeline(pipeline)
+                .position(stageDefinition.position())
+                .name(stageDefinition.name())
+                .code(stageDefinition.operationalCode())
+                .required(stageDefinition.required())
+                .active(true)
+                .build();
+        pipeline.getStages().add(stage);
+        return stageRepository.save(stage);
+    }
+
+    /**
+     * Cria pipeline oficial ausente com todos os campos estruturais canônicos básicos.
+     */
+    private Pipeline createPipeline(PipelineDefinition definition) {
+        Pipeline pipeline = Pipeline.builder()
+                .name(definition.name())
+                .code(definition.code())
+                .module(definition.module())
+                .description("Pipeline oficial sincronizado a partir de " + definition.canonicalVersion())
+                .active(true)
+                .stages(new ArrayList<>())
+                .build();
+        return pipelineRepository.save(pipeline);
+    }
+
+    /**
+     * Detecta divergências que poderiam causar perda de histórico ou sobrescrita operacional perigosa.
+     */
+    private List<PipelineDiagnosticsIssueDto> destructiveIssues(Pipeline pipeline, PipelineDefinition definition) {
+        List<PipelineDiagnosticsIssueDto> issues = new ArrayList<>();
+        Set<String> codes = new HashSet<>();
+        Set<Integer> positions = new HashSet<>();
+        for (PipelineStage stage : pipeline.getStages()) {
+            PipelineStageDefinition stageDefinition = definitionRegistry.findStage(definition, stage.getCode()).orElse(null);
+            if (!codes.add(definitionRegistry.normalize(stage.getCode()))) {
+                issues.add(issue("ERROR", stage.getCode(), stageDefinition == null ? null : stageDefinition.canonicalCode(),
+                        "Código operacional duplicado impede sincronização segura.",
+                        "Há duas etapas gravadas com o mesmo código dentro do pipeline oficial.",
+                        "Resolver a duplicidade manualmente antes de sincronizar."));
+            }
+            if (!positions.add(stage.getPosition())) {
+                issues.add(issue("ERROR", stage.getCode(), stageDefinition == null ? null : stageDefinition.canonicalCode(),
+                        "Posição operacional duplicada impede sincronização segura.",
+                        "Há duas etapas gravadas com a mesma posição dentro do pipeline oficial.",
+                        "Resolver a duplicidade manualmente antes de sincronizar."));
+            }
+            if (stageDefinition == null) {
+                issues.add(issue("ERROR", stage.getCode(), null,
+                        "Etapa extra com possível histórico impede sincronização destrutiva.",
+                        "Banco contém etapa que não existe no contrato canônico atual.",
+                        "Analisar histórico da etapa e decidir manualmente se ela deve ser removida ou canonizada."));
+            }
+        }
+        return issues;
+    }
+
+    /**
+     * Constrói resultado bloqueado a partir do diagnóstico já calculado pelo serviço principal.
+     */
+    private PipelineSyncResultDto blockedResult(PipelineDiagnosticsDto diagnostics, List<String> appliedActions) {
+        return PipelineSyncResultDto.builder()
+                .status("BLOQUEADO")
+                .synchronizedSafely(false)
+                .pipelineId(diagnostics.pipelineId())
+                .pipelineCode(diagnostics.pipelineCode())
+                .canonicalPipelineCode(diagnostics.canonicalPipelineCode())
+                .expectedStages(diagnostics.expectedStages())
+                .configuredStages(diagnostics.configuredStages())
+                .appliedActions(appliedActions)
+                .issues(diagnostics.issues())
+                .build();
+    }
+
+    /**
+     * Cria uma divergência padronizada com causa-raiz e ação recomendada.
+     */
+    private PipelineDiagnosticsIssueDto issue(
+            String severity,
+            String stageCode,
+            String canonicalCode,
+            String message,
+            String rootCause,
+            String recommendedAction) {
+        return PipelineDiagnosticsIssueDto.builder()
+                .severity(severity)
+                .stageCode(stageCode)
+                .canonicalCode(canonicalCode)
+                .message(message)
+                .rootCause(rootCause)
+                .recommendedAction(recommendedAction)
+                .build();
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/pipeline/service/PipelineService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/pipeline/service/PipelineService.java
@@ -10,9 +10,11 @@ import com.marketinghub.pipeline.dto.OfficialPipelineDto;
 import com.marketinghub.pipeline.dto.OfficialPipelineStageDto;
 import com.marketinghub.pipeline.dto.PipelineDiagnosticsDto;
 import com.marketinghub.pipeline.dto.PipelineDiagnosticsIssueDto;
+import com.marketinghub.pipeline.dto.PipelineFieldPolicyDto;
 import com.marketinghub.pipeline.dto.PipelineMetadataDto;
 import com.marketinghub.pipeline.dto.PipelineRequest;
 import com.marketinghub.pipeline.dto.PipelineStageRequest;
+import com.marketinghub.pipeline.dto.StageFieldPolicyDto;
 import com.marketinghub.repository.jpa.openai.OpenAiModelRepository;
 import com.marketinghub.repository.jpa.pipeline.PipelineRepository;
 import com.marketinghub.repository.jpa.pipeline.PipelineStageRepository;
@@ -397,16 +399,19 @@ public class PipelineService {
                 .module(definition.module())
                 .code(definition.code())
                 .name(definition.name())
+                .canonicalVersion(definition.canonicalVersion())
                 .official(definition.official())
                 .aliases(definition.aliases().stream().sorted().toList())
-                .stages(definition.stages().stream().map(this::toOfficialStageDto).toList())
+                .fieldPolicy(toPipelineFieldPolicyDto(definition))
+                .stages(definition.stages().stream().map(stage -> toOfficialStageDto(definition, stage)).toList())
                 .build();
     }
 
     /**
      * Converte definição oficial de etapa para DTO de metadados consumido pela tela.
      */
-    private OfficialPipelineStageDto toOfficialStageDto(PipelineStageDefinition definition) {
+    private OfficialPipelineStageDto toOfficialStageDto(
+            PipelineDefinition pipelineDefinition, PipelineStageDefinition definition) {
         return OfficialPipelineStageDto.builder()
                 .canonicalCode(definition.canonicalCode())
                 .operationalCode(definition.operationalCode())
@@ -414,7 +419,36 @@ public class PipelineService {
                 .position(definition.position())
                 .required(definition.required())
                 .configurable(definition.configurable())
+                .fieldPolicy(toStageFieldPolicyDto(pipelineDefinition))
                 .aliases(definition.aliases().stream().sorted().toList())
+                .build();
+    }
+
+    /**
+     * Converte política oficial de pipeline para DTO de metadados consumido pela tela.
+     */
+    private PipelineFieldPolicyDto toPipelineFieldPolicyDto(PipelineDefinition definition) {
+        return PipelineFieldPolicyDto.builder()
+                .codeStructural(definition.pipelineFieldPolicy().codeStructural())
+                .moduleStructural(definition.pipelineFieldPolicy().moduleStructural())
+                .nameStructural(definition.pipelineFieldPolicy().nameStructural())
+                .descriptionOperational(definition.pipelineFieldPolicy().descriptionOperational())
+                .activeOperational(definition.pipelineFieldPolicy().activeOperational())
+                .build();
+    }
+
+    /**
+     * Converte política oficial de etapa para DTO de metadados consumido pela tela.
+     */
+    private StageFieldPolicyDto toStageFieldPolicyDto(PipelineDefinition definition) {
+        return StageFieldPolicyDto.builder()
+                .codeStructural(definition.stageFieldPolicy().codeStructural())
+                .positionStructural(definition.stageFieldPolicy().positionStructural())
+                .nameStructural(definition.stageFieldPolicy().nameStructural())
+                .requiredStructural(definition.stageFieldPolicy().requiredStructural())
+                .descriptionOperational(definition.stageFieldPolicy().descriptionOperational())
+                .activeOperational(definition.stageFieldPolicy().activeOperational())
+                .openAiModelOperational(definition.stageFieldPolicy().openAiModelOperational())
                 .build();
     }
 

--- a/backend/ads-service/src/main/java/com/marketinghub/pipeline/web/PipelineController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/pipeline/web/PipelineController.java
@@ -8,7 +8,9 @@ import com.marketinghub.pipeline.dto.PipelineMetadataDto;
 import com.marketinghub.pipeline.dto.PipelineRequest;
 import com.marketinghub.pipeline.dto.PipelineStageDto;
 import com.marketinghub.pipeline.dto.PipelineStageRequest;
+import com.marketinghub.pipeline.dto.PipelineSyncResultDto;
 import com.marketinghub.pipeline.mapper.PipelineMapper;
+import com.marketinghub.pipeline.service.PipelineDefinitionSynchronizer;
 import com.marketinghub.pipeline.service.PipelineService;
 import jakarta.validation.Valid;
 import java.util.List;
@@ -28,13 +30,16 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/api/pipelines")
 public class PipelineController {
     private final PipelineService service;
+    private final PipelineDefinitionSynchronizer synchronizer;
     private final PipelineMapper mapper;
 
     /**
-     * Inicializa o controller com o serviço de domínio e mapper de contratos.
+     * Inicializa o controller com serviço, sincronizador seguro e mapper de contratos.
      */
-    public PipelineController(PipelineService service, PipelineMapper mapper) {
+    public PipelineController(
+            PipelineService service, PipelineDefinitionSynchronizer synchronizer, PipelineMapper mapper) {
         this.service = service;
+        this.synchronizer = synchronizer;
         this.mapper = mapper;
     }
 
@@ -68,6 +73,22 @@ public class PipelineController {
     @GetMapping("/{id}/diagnostics")
     public PipelineDiagnosticsDto diagnostics(@PathVariable Long id) {
         return service.diagnostics(id);
+    }
+
+    /**
+     * Sincroniza com segurança o pipeline informado contra sua definição oficial.
+     */
+    @PostMapping("/{id}/sync")
+    public PipelineSyncResultDto sync(@PathVariable Long id) {
+        return synchronizer.sync(id);
+    }
+
+    /**
+     * Cria ou sincroniza com segurança um pipeline oficial pelo código canônico.
+     */
+    @PostMapping("/official/{code}/sync")
+    public PipelineSyncResultDto syncOfficial(@PathVariable String code) {
+        return synchronizer.syncOfficialByCode(code);
     }
 
     /**

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/pipeline/PipelineRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/pipeline/PipelineRepository.java
@@ -1,10 +1,15 @@
 package com.marketinghub.repository.jpa.pipeline;
 
 import com.marketinghub.pipeline.Pipeline;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 /**
  * Repositório JPA centralizado para persistir pipelines operacionais.
  */
 public interface PipelineRepository extends JpaRepository<Pipeline, Long> {
+    /**
+     * Localiza um pipeline pelo código operacional único.
+     */
+    Optional<Pipeline> findByCode(String code);
 }

--- a/backend/ads-service/src/test/java/com/marketinghub/pipeline/service/PipelineServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/pipeline/service/PipelineServiceTest.java
@@ -6,12 +6,14 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.marketinghub.openai.OpenAiModel;
 import com.marketinghub.pipeline.Pipeline;
 import com.marketinghub.pipeline.PipelineStage;
 import com.marketinghub.pipeline.definition.PipelineDefinitionRegistry;
 import com.marketinghub.pipeline.dto.PipelineDiagnosticsDto;
 import com.marketinghub.pipeline.dto.PipelineRequest;
 import com.marketinghub.pipeline.dto.PipelineStageRequest;
+import com.marketinghub.pipeline.dto.PipelineSyncResultDto;
 import com.marketinghub.repository.jpa.openai.OpenAiModelRepository;
 import com.marketinghub.repository.jpa.pipeline.PipelineRepository;
 import com.marketinghub.repository.jpa.pipeline.PipelineStageRepository;
@@ -42,6 +44,7 @@ class PipelineServiceTest {
     private final PipelineDefinitionRegistry definitionRegistry = new PipelineDefinitionRegistry();
 
     private PipelineService service;
+    private PipelineDefinitionSynchronizer synchronizer;
 
     /**
      * Inicializa o serviço com registry real para validar regras canônicas.
@@ -49,6 +52,8 @@ class PipelineServiceTest {
     @org.junit.jupiter.api.BeforeEach
     void setUp() {
         service = new PipelineService(pipelineRepository, stageRepository, openAiModelRepository, definitionRegistry);
+        synchronizer = new PipelineDefinitionSynchronizer(
+                pipelineRepository, stageRepository, definitionRegistry, service);
     }
 
     /**
@@ -258,6 +263,110 @@ class PipelineServiceTest {
         assertThatThrownBy(() -> service.createStage(10L, request))
                 .isInstanceOf(ResponseStatusException.class)
                 .hasMessageContaining("Modelo OpenAI não encontrado");
+    }
+
+
+    /**
+     * Garante que a sincronização cria etapas oficiais ausentes de forma idempotente.
+     */
+    @Test
+    void shouldSynchronizeMissingOfficialStage() {
+        Pipeline pipeline = officialPipelineWith(stage(1L, 1, "campaign-angle"));
+        when(pipelineRepository.findById(10L)).thenReturn(Optional.of(pipeline));
+        when(stageRepository.save(any(PipelineStage.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        when(pipelineRepository.save(any(Pipeline.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        PipelineSyncResultDto result = synchronizer.sync(10L);
+
+        assertThat(result.appliedActions()).anyMatch(action -> action.contains("Etapa oficial ausente criada"));
+        assertThat(pipeline.getStages()).hasSize(8);
+        assertThat(pipeline.getStages()).extracting(PipelineStage::getCode).contains("landing-page-html");
+    }
+
+    /**
+     * Garante que a sincronização preserva modelo OpenAI e descrição operacional já configurados.
+     */
+    @Test
+    void shouldPreserveConfiguredOpenAiModelDuringSynchronization() {
+        OpenAiModel model = OpenAiModel.builder().id(99L).name("GPT 5.2").code("gpt-5.2").build();
+        PipelineStage configured = stage(1L, 2, "campaign-angle");
+        configured.setName("Nome antigo");
+        configured.setDescription("Descrição operacional do usuário");
+        configured.setOpenAiModel(model);
+        Pipeline pipeline = officialPipelineWith(configured);
+        when(pipelineRepository.findById(10L)).thenReturn(Optional.of(pipeline));
+        when(stageRepository.save(any(PipelineStage.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        when(pipelineRepository.save(any(Pipeline.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        synchronizer.sync(10L);
+
+        assertThat(configured.getPosition()).isEqualTo(1);
+        assertThat(configured.getName()).isEqualTo("Campaign Angle");
+        assertThat(configured.getDescription()).isEqualTo("Descrição operacional do usuário");
+        assertThat(configured.getOpenAiModel()).isEqualTo(model);
+    }
+
+    /**
+     * Garante que a sincronização bloqueia divergência destrutiva antes de remover etapa extra.
+     */
+    @Test
+    void shouldBlockDestructiveSynchronization() {
+        Pipeline pipeline = officialPipelineWith(stage(1L, 1, "unknown-stage"));
+        when(pipelineRepository.findById(10L)).thenReturn(Optional.of(pipeline));
+
+        PipelineSyncResultDto result = synchronizer.sync(10L);
+
+        assertThat(result.status()).isEqualTo("BLOQUEADO");
+        assertThat(result.synchronizedSafely()).isFalse();
+        assertThat(result.issues()).anySatisfy(issue -> {
+            assertThat(issue.message()).isEqualTo("Etapa extra com possível histórico impede sincronização destrutiva.");
+            assertThat(issue.rootCause()).contains("não existe no contrato canônico");
+            assertThat(issue.recommendedAction()).contains("Analisar histórico");
+        });
+    }
+
+
+    /**
+     * Garante que a sincronização cria pipeline oficial ausente pelo código canônico.
+     */
+    @Test
+    void shouldCreateMissingOfficialPipelineByCode() {
+        when(pipelineRepository.findByCode("experiment-pipeline")).thenReturn(Optional.empty());
+        when(pipelineRepository.save(any(Pipeline.class))).thenAnswer(invocation -> {
+            Pipeline saved = invocation.getArgument(0);
+            if (saved.getId() == null) {
+                saved.setId(10L);
+            }
+            return saved;
+        });
+        when(pipelineRepository.findById(10L)).thenAnswer(invocation -> {
+            Pipeline pipeline = Pipeline.builder()
+                    .id(10L)
+                    .name("Pipeline de Experimento")
+                    .code("experiment-pipeline")
+                    .module("EXPERIMENT")
+                    .stages(new ArrayList<>())
+                    .build();
+            return Optional.of(pipeline);
+        });
+        when(stageRepository.save(any(PipelineStage.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        PipelineSyncResultDto result = synchronizer.syncOfficialByCode("experiment-pipeline");
+
+        assertThat(result.appliedActions()).hasSize(8);
+        assertThat(result.canonicalPipelineCode()).isEqualTo("experiment-pipeline");
+    }
+
+    /**
+     * Garante que o registry expõe versão canônica e política explícita de campos estruturais.
+     */
+    @Test
+    void shouldExposeCanonicalVersionAndFieldPolicies() {
+        assertThat(definitionRegistry.officialPipelines()).singleElement().satisfies(pipeline -> {
+            assertThat(pipeline.canonicalVersion()).isEqualTo("procedimento-experimento-canon.v1");
+            assertThat(pipeline.pipelineFieldPolicy().codeStructural()).isTrue();
+            assertThat(pipeline.stageFieldPolicy().openAiModelOperational()).isTrue();
+        });
     }
 
     /**

--- a/docs/canonical/procedimento-experimento-canon.v1.md
+++ b/docs/canonical/procedimento-experimento-canon.v1.md
@@ -38,7 +38,19 @@ A sequência canônica de seções do pipeline inclui:
 
 Essas seções e suas dependências fazem parte do enum oficial do backend.
 
-### 4.1 Prompts dessas etapas
+### 4.1 Contrato operacional administrativo do pipeline
+
+O pipeline oficial de experimento usa a versão canônica `procedimento-experimento-canon.v1` no backend administrativo de pipelines. A sincronização segura deve considerar estruturais os campos `code`, `module` e `name` do pipeline, além de `code`, `position`, `name` e `required` das etapas oficiais. Os campos `description`, `active` e `openAiModelId` das etapas são configuração operacional e não podem ser sobrescritos pela sincronização sem regra explícita.
+
+Endpoints administrativos vigentes:
+- `GET /api/pipelines/metadata` expõe versão canônica, aliases e política de campos;
+- `GET /api/pipelines/{id}/diagnostics` compara banco e contrato oficial com causa-raiz e ação recomendada;
+- `POST /api/pipelines/{id}/sync` sincroniza de forma idempotente um pipeline existente, sem aceitar payload da tela;
+- `POST /api/pipelines/official/{code}/sync` cria ou sincroniza um pipeline oficial ausente pelo código canônico, sem aceitar payload da tela.
+
+A sincronização segura pode criar pipeline/etapas oficiais ausentes e corrigir campos estruturais permitidos, mas deve bloquear divergências destrutivas, como etapa extra sem mapeamento canônico ou duplicidade operacional, para evitar perda de histórico e preservar a causa-raiz para decisão humana.
+
+### 4.2 Prompts dessas etapas
 Os prompts do pipeline ficam versionados no repositório, em `resources` do Worker AI.
 
 Local canônico vigente:

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -3454,3 +3454,10 @@
   - frontend/AGENTS.md
   - docs/implementacao/backend/plano-pipelines-contrato-operacional.md
   - docs/registros/experimentos.md
+
+## 2026-06-04 — Fase 2 do contrato operacional da tela de Pipelines
+
+- solicitação: executar a fase 2 do plano `docs/implementacao/backend/plano-pipelines-contrato-operacional.md` para contrato forte e sincronização segura dos pipelines oficiais.
+- causa-raiz endereçada: a fase 1 diagnosticava divergências, mas ainda não havia um mecanismo idempotente para reparar divergências simples e bloquear alterações destrutivas com rastreabilidade.
+- correção aplicada: evoluído o registry oficial com versão canônica e política explícita de campos estruturais versus operacionais; criado `PipelineDefinitionSynchronizer` para criar pipeline/etapas oficiais ausentes, corrigir nome/posição/obrigatoriedade estruturais e preservar `openAiModel`, `active` e descrições operacionais; adicionados endpoints `POST /api/pipelines/{id}/sync` e `POST /api/pipelines/official/{code}/sync` sem payload da tela; documentação Swagger e cânone de experimento sincronizados.
+- validação automatizada: adicionados testes para criação de etapa oficial ausente, preservação de modelo OpenAI configurado, bloqueio de divergência destrutiva, criação de pipeline oficial ausente por código e aderência do registry à versão canônica.

--- a/docs/swagger/pipeline-swagger.yaml
+++ b/docs/swagger/pipeline-swagger.yaml
@@ -35,6 +35,43 @@ paths:
                 $ref: "#/components/schemas/PipelineDiagnostics"
         "404":
           description: Pipeline não encontrado.
+  /pipelines/{id}/sync:
+    post:
+      summary: Sincroniza com segurança um pipeline existente contra a definição oficial.
+      description: Não aceita payload; repara somente campos estruturais seguros e preserva configuração operacional.
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        "200":
+          description: Resultado da sincronização segura com ações aplicadas e divergências restantes.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PipelineSyncResult"
+        "404":
+          description: Pipeline não encontrado.
+  /pipelines/official/{code}/sync:
+    post:
+      summary: Cria ou sincroniza um pipeline oficial ausente pelo código canônico.
+      description: Não aceita payload; usa exclusivamente o contrato oficial exposto em metadata.
+      parameters:
+        - name: code
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Resultado da criação/sincronização segura do pipeline oficial.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PipelineSyncResult"
 components:
   schemas:
     PipelineMetadata:
@@ -51,7 +88,7 @@ components:
             $ref: "#/components/schemas/OfficialPipeline"
     OfficialPipeline:
       type: object
-      required: [module, code, name, official, aliases, stages]
+      required: [module, code, name, canonicalVersion, official, aliases, fieldPolicy, stages]
       properties:
         module:
           type: string
@@ -62,6 +99,9 @@ components:
         name:
           type: string
           example: Pipeline de Experimento
+        canonicalVersion:
+          type: string
+          example: procedimento-experimento-canon.v1
         official:
           type: boolean
           example: true
@@ -69,13 +109,15 @@ components:
           type: array
           items:
             type: string
+        fieldPolicy:
+          $ref: "#/components/schemas/PipelineFieldPolicy"
         stages:
           type: array
           items:
             $ref: "#/components/schemas/OfficialPipelineStage"
     OfficialPipelineStage:
       type: object
-      required: [canonicalCode, operationalCode, name, position, required, configurable, aliases]
+      required: [canonicalCode, operationalCode, name, position, required, configurable, fieldPolicy, aliases]
       properties:
         canonicalCode:
           type: string
@@ -95,6 +137,8 @@ components:
         configurable:
           type: boolean
           example: true
+        fieldPolicy:
+          $ref: "#/components/schemas/StageFieldPolicy"
         aliases:
           type: array
           items:
@@ -141,3 +185,55 @@ components:
           type: string
         recommendedAction:
           type: string
+
+    PipelineFieldPolicy:
+      type: object
+      required: [codeStructural, moduleStructural, nameStructural, descriptionOperational, activeOperational]
+      properties:
+        codeStructural: { type: boolean }
+        moduleStructural: { type: boolean }
+        nameStructural: { type: boolean }
+        descriptionOperational: { type: boolean }
+        activeOperational: { type: boolean }
+    StageFieldPolicy:
+      type: object
+      required: [codeStructural, positionStructural, nameStructural, requiredStructural, descriptionOperational, activeOperational, openAiModelOperational]
+      properties:
+        codeStructural: { type: boolean }
+        positionStructural: { type: boolean }
+        nameStructural: { type: boolean }
+        requiredStructural: { type: boolean }
+        descriptionOperational: { type: boolean }
+        activeOperational: { type: boolean }
+        openAiModelOperational: { type: boolean }
+    PipelineSyncResult:
+      type: object
+      required: [status, synchronizedSafely, expectedStages, configuredStages, appliedActions, issues]
+      properties:
+        status:
+          type: string
+          enum: [OK, ATENÇÃO, BLOQUEADO]
+        synchronizedSafely:
+          type: boolean
+        pipelineId:
+          type: integer
+          format: int64
+          nullable: true
+        pipelineCode:
+          type: string
+          nullable: true
+        canonicalPipelineCode:
+          type: string
+          nullable: true
+        expectedStages:
+          type: integer
+        configuredStages:
+          type: integer
+        appliedActions:
+          type: array
+          items:
+            type: string
+        issues:
+          type: array
+          items:
+            $ref: "#/components/schemas/PipelineDiagnosticsIssue"


### PR DESCRIPTION
### Motivation
- Implementar a Fase 2 do plano de governança de Pipelines para evitar divergências silenciosas entre UI, banco e código, permitindo reparos idempotentes e bloqueio de alterações destrutivas.
- Garantir que o backend seja a fonte de verdade (versão canônica) e ofereça mecanismos administrativos para sincronizar e reparar pipelines oficiais sem sobrescrever configurações operacionais do usuário.

### Description
- Evolução do registry oficial: `PipelineDefinitionRegistry` passa a expor `canonicalVersion` e políticas explícitas de campos estruturais vs operacionais (`PipelineFieldPolicy` e `StageFieldPolicy`).
- Sincronizador seguro: adicionado `PipelineDefinitionSynchronizer` que cria pipelines/etapas oficiais ausentes, corrige campos estruturais permitidos (nome, posição, obrigatoriedade) e preserva `openAiModel`, `active` e descrições operacionais; bloqueia divergências destrutivas (duplicidade, etapas extras sem mapeamento).
- Endpoints administrativos: adicionados `POST /api/pipelines/{id}/sync` e `POST /api/pipelines/official/{code}/sync` (sem payload da tela) via `PipelineController` para executar a sincronização segura.
- Contrato e modelos de dados: introduzidos DTOs `PipelineFieldPolicyDto`, `StageFieldPolicyDto` e `PipelineSyncResultDto`, ajuste em `OfficialPipelineDto`/`OfficialPipelineStageDto`, e adição de `PipelineRepository.findByCode` para suportar criação/sincronização por código canônico.
- Documentação: atualizado o Swagger `docs/swagger/pipeline-swagger.yaml` e o cânone `docs/canonical/procedimento-experimento-canon.v1.md` para refletir versão canônica, políticas de campo e novos endpoints.
- Testes e cobertura: adicionados testes unitários em `PipelineServiceTest` que cobrem criação de etapa oficial ausente, preservação de modelo OpenAI, bloqueio de sincronização destrutiva, criação de pipeline oficial por código e exposição da versão canônica/políticas.

### Testing
- Executado o teste unitário específico: `../mvnw -Dtest=PipelineServiceTest test` no diretório `backend/ads-service`, com sucesso (16 tests, 0 failures). 
- Executado `git diff --check` para validar diffs; sem erros restantes após correção de EOF newline.
- Tentativa de rodar `../mvnw spotless:apply` falhou porque o plugin/prefixo `spotless` não está disponível no módulo; isso não afetou a execução dos testes unitários que validaram o comportamento.
- Observação operacional: um comando de build/execução inicial com `-pl` no root não funcionou; os testes foram executados com sucesso ao rodar o wrapper a partir do módulo `backend/ads-service` (`../mvnw`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a21e4857c10832190d912cbf5264c2f)