### PR TITLE
Fase 5: tornar `mois_sales_page`/`mois_sales_page_job_execution` fonte operacional e migrar listagem de entradas

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryService.java
@@ -319,20 +319,22 @@ public class MoisSalesLibraryService {
     }
 
     /**
-     * Lista entradas de URL ingeridas na biblioteca para auditoria operacional.
+     * Lista entradas de URL ingeridas usando mois_sales_page como fonte operacional principal.
      */
     public MoisSalesLibraryDtos.SalesLibraryEntryPageResponse listEntries(String workspaceId, int page, int pageSize) {
-        int normalizedPage = Math.max(1, page); int normalizedPageSize = Math.max(1, Math.min(pageSize, 100)); int offset = (normalizedPage - 1) * normalizedPageSize;
-        Long total = jdbcTemplate.queryForObject("SELECT COUNT(*) FROM mois_sales_library_url_ingest WHERE workspace_id = ?", Long.class, workspaceId);
+        int normalizedPage = Math.max(1, page);
+        int normalizedPageSize = Math.max(1, Math.min(pageSize, 100));
+        int offset = (normalizedPage - 1) * normalizedPageSize;
+        Long total = jdbcTemplate.queryForObject("SELECT COUNT(*) FROM mois_sales_page WHERE workspace_id = ?", Long.class, workspaceId);
         List<MoisSalesLibraryDtos.SalesLibraryEntryResponse> items = jdbcTemplate.query("""
                         SELECT id, workspace_id, source, url_original, url_canonical, title, ingest_count,
-                               first_captured_at, last_captured_at, updated_at
-                        FROM mois_sales_library_url_ingest
-                        WHERE workspace_id = ? ORDER BY updated_at DESC LIMIT ? OFFSET ?
+                               first_seen_at, last_captured_at, updated_at
+                        FROM mois_sales_page
+                        WHERE workspace_id = ? ORDER BY updated_at DESC, id DESC LIMIT ? OFFSET ?
                         """, (rs, rowNum) -> new MoisSalesLibraryDtos.SalesLibraryEntryResponse(
                         rs.getLong("id"), rs.getString("workspace_id"), rs.getString("source"), rs.getString("url_original"),
                         rs.getString("url_canonical"), rs.getString("title"), rs.getInt("ingest_count"),
-                        toInstant(rs.getTimestamp("first_captured_at")), toInstant(rs.getTimestamp("last_captured_at")),
+                        toInstant(rs.getTimestamp("first_seen_at")), toInstant(rs.getTimestamp("last_captured_at")),
                         toInstant(rs.getTimestamp("updated_at"))), workspaceId, normalizedPageSize, offset);
         return new MoisSalesLibraryDtos.SalesLibraryEntryPageResponse(normalizedPage, normalizedPageSize, total == null ? 0 : total, items);
     }

--- a/backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryServiceTest.java
@@ -1,20 +1,19 @@
 package com.marketinghub.mois.bibliotecapaginavenda.worker.v1.service;
 
 import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.contains;
-import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
-import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.verify;
 
 import com.marketinghub.mois.bibliotecapaginavenda.worker.v1.dto.MoisSalesLibraryDtos;
 import java.sql.ResultSet;
 import java.sql.Timestamp;
-import java.time.Instant;
 import java.math.BigDecimal;
+import java.time.Instant;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -165,6 +164,29 @@ class MoisSalesLibraryServiceTest {
 
 
     /**
+     * Garante que a listagem de entradas usa a tabela operacional nova, sem ler a tabela legada de URL.
+     */
+    @Test
+    void shouldListEntriesFromOperationalSalesPageTable() throws Exception {
+        given(jdbcTemplate.queryForObject(contains("SELECT COUNT(*) FROM mois_sales_page"), eq(Long.class), eq("workspace-001")))
+                .willReturn(1L);
+        given(jdbcTemplate.query(contains("FROM mois_sales_page"), isA(RowMapper.class), eq("workspace-001"), eq(20), eq(0)))
+                .willAnswer(invocation -> {
+                    RowMapper<?> mapper = invocation.getArgument(1);
+                    ResultSet row = salesPageEntryRow();
+                    return List.of(mapper.mapRow(row, 0));
+                });
+
+        MoisSalesLibraryDtos.SalesLibraryEntryPageResponse response = service.listEntries("workspace-001", 1, 20);
+
+        org.assertj.core.api.Assertions.assertThat(response.total()).isEqualTo(1);
+        org.assertj.core.api.Assertions.assertThat(response.items()).hasSize(1);
+        org.assertj.core.api.Assertions.assertThat(response.items().get(0).urlCanonical()).isEqualTo("https://example.com/pagina");
+        verify(jdbcTemplate, never()).queryForObject(contains("mois_sales_library_url_ingest"), eq(Long.class), any());
+        verify(jdbcTemplate, never()).query(contains("FROM mois_sales_library_url_ingest"), isA(RowMapper.class), any(), any(), any());
+    }
+
+    /**
      * Configura mocks comuns da ingestão operacional principal em mois_sales_page.
      */
     private void stubOperationalIngest(int... upsertResults) {
@@ -178,8 +200,24 @@ class MoisSalesLibraryServiceTest {
         lenient().when(jdbcTemplate.update(contains("INSERT INTO mois_sales_page_job_execution"), any(), any(), any())).thenReturn(1);
         lenient().when(jdbcTemplate.queryForObject(contains("SELECT LAST_INSERT_ID()"), eq(Long.class))).thenReturn(123L);
         lenient().when(jdbcTemplate.update(contains("UPDATE mois_sales_page"), any(), any())).thenReturn(1);
-        lenient().when(jdbcTemplate.update(contains("INSERT INTO mois_sales_library_url_ingest"), any(), any(), any(), any(), any(), any(), any())).thenReturn(1);
-        lenient().when(jdbcTemplate.update(contains("INSERT INTO mois_sales_library_processing_job"), isA(Long.class))).thenReturn(1);
+    }
+
+    /**
+     * Monta uma linha simulada de entrada operacional de página consolidada.
+     */
+    private ResultSet salesPageEntryRow() throws Exception {
+        ResultSet resultSet = org.mockito.Mockito.mock(ResultSet.class);
+        given(resultSet.getLong("id")).willReturn(99L);
+        given(resultSet.getString("workspace_id")).willReturn("workspace-001");
+        given(resultSet.getString("source")).willReturn("HOTMART");
+        given(resultSet.getString("url_original")).willReturn("https://example.com/pagina?utm=1");
+        given(resultSet.getString("url_canonical")).willReturn("https://example.com/pagina");
+        given(resultSet.getString("title")).willReturn("Página de oferta");
+        given(resultSet.getInt("ingest_count")).willReturn(2);
+        given(resultSet.getTimestamp("first_seen_at")).willReturn(Timestamp.from(Instant.parse("2026-06-01T10:00:00Z")));
+        given(resultSet.getTimestamp("last_captured_at")).willReturn(Timestamp.from(Instant.parse("2026-06-02T10:00:00Z")));
+        given(resultSet.getTimestamp("updated_at")).willReturn(Timestamp.from(Instant.parse("2026-06-03T10:00:00Z")));
+        return resultSet;
     }
 
     /**

--- a/docs/canonical/mois-worker-canon.v1.md
+++ b/docs/canonical/mois-worker-canon.v1.md
@@ -499,8 +499,8 @@ Responsabilidades canônicas das novas tabelas:
 Regra de legado após Fase 5:
 
 - Não remover `mois_sales_library_url_ingest`, `mois_sales_library_processing_job`, `mois_sales_library_page_analysis`, `mois_sales_library_page_snapshot`, `mois_sales_library_snapshot_artifact` nem `mois_collected_reference_html_capture`; elas ficam fora do caminho principal de escrita/leitura operacional.
-- Não migrar a leitura principal da UI nesta fase.
-- Não iniciar backfill nesta fase.
+- A leitura principal da UI, incluindo listagem de entradas, páginas, resumo, jobs e histórico, deve consultar `mois_sales_page` e/ou `mois_sales_page_job_execution`; leituras legadas só podem existir para auditoria histórica explícita.
+- Backfills corretivos podem existir apenas como rotinas idempotentes de migração/auditoria, sem recolocar tabelas legadas como fonte operacional.
 - Qualquer gravação futura no modelo novo deve manter `mois_sales_page` como estado atual e `mois_sales_page_job_execution` como histórico/auditoria.
 
 
@@ -515,7 +515,8 @@ Regras obrigatórias da Fase 5:
 - reanálise e atualização manual de status devem criar execuções novas no histórico consolidado sem depender de tabelas legadas;
 - tabelas legadas de URL, job e análise não podem receber a escrita operacional principal nem ser fonte de verdade da UI operacional;
 - logs de transição devem informar `pageId`, `executionId`, operação executada e resultado para rastrear cada mudança de etapa;
-- contratos Swagger da Biblioteca devem explicitar que `jobId` de claim/complete/fail representa `mois_sales_page_job_execution.id` nesta fase.
+- contratos Swagger da Biblioteca devem explicitar que `jobId` de claim/complete/fail representa `mois_sales_page_job_execution.id` nesta fase;
+- o endpoint de listagem de entradas (`GET /api/mois/sales-library/entries`) deve ler `mois_sales_page`; o campo compatível `firstCapturedAt` passa a representar `first_seen_at` enquanto o contrato externo não for renomeado.
 
 Critérios de aceite da Fase 5:
 

--- a/docs/novos-modulos/MOIS/mois_sales_page_pipeline_simplificacao_duas_tabelas.md
+++ b/docs/novos-modulos/MOIS/mois_sales_page_pipeline_simplificacao_duas_tabelas.md
@@ -360,6 +360,7 @@ Critério de aceite:
 - Ajuste final da Fase 5: escrita dupla/espelhos legados foram removidos do caminho operacional do backend; `jobs`, reanálise, status manual e captura de referência coletada gravam em `mois_sales_page`/`mois_sales_page_job_execution` sem atualizar as tabelas antigas.
 - Os endpoints `/collected-reference-html:*` agora tratam `captureId` como execução `COLLECTED_REFERENCE_HTML` em `mois_sales_page_job_execution`, usando `mois_collected_reference` somente como origem bruta.
 - A listagem/busca de jobs passou a consultar `mois_sales_page_job_execution`; campos compatíveis legados devem ser interpretados como identificadores operacionais novos quando expostos.
+- A listagem de entradas (`/entries`) passou a consultar `mois_sales_page`; campos compatíveis do contrato legado agora representam a página operacional consolidada e não a tabela `mois_sales_library_url_ingest`.
 
 ### Fase 6 — Congelamento e desativação gradual do legado
 

--- a/docs/registros/mois1.md
+++ b/docs/registros/mois1.md
@@ -978,3 +978,9 @@ Arquivos alterados:
 - endpoints de captura de referência coletada (`/collected-reference-html:*`) agora leem `mois_collected_reference` apenas como origem bruta, criam/atualizam `mois_sales_page` e gravam HTML/erro em `mois_sales_page_job_execution`.
 - listagem e busca de jobs passam a consultar o histórico consolidado `mois_sales_page_job_execution`, mantendo o campo compatível `urlIngestId` como identificador da página operacional.
 - removidas as classes de escrita dupla MOIS para evitar que o legado volte a ser tratado como caminho principal.
+
+## 2026-06-04 — MOIS Biblioteca de Páginas de Vendas — Fase 5 leitura de entradas operacional
+
+- finalizada a troca da listagem `/api/mois/sales-library/entries` para ler `mois_sales_page`, removendo a última leitura operacional do service da Biblioteca contra `mois_sales_library_url_ingest`.
+- atualizado o Swagger do módulo para documentar `/entries`, `/jobs` e `/jobs/{jobId}` como contratos apoiados em `mois_sales_page`/`mois_sales_page_job_execution` na Fase 5.
+- ajustado o cânone MOIS para explicitar que a UI principal deve consultar apenas as duas tabelas operacionais novas, deixando tabelas antigas somente para auditoria histórica explícita.

--- a/docs/swagger/mois-sales-library-swagger.yaml
+++ b/docs/swagger/mois-sales-library-swagger.yaml
@@ -42,6 +42,89 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SalesLibraryHotmartCollectedIngestResponse'
+  /entries:
+    get:
+      summary: Lista entradas operacionais consolidadas da biblioteca
+      description: Lê `mois_sales_page` como fonte operacional principal; não consulta `mois_sales_library_url_ingest` para alimentar a UI principal na Fase 5.
+      tags: [MOIS Sales Library]
+      parameters:
+        - in: query
+          name: workspaceId
+          required: true
+          schema:
+            type: string
+        - in: query
+          name: page
+          schema:
+            type: integer
+            default: 1
+            minimum: 1
+        - in: query
+          name: pageSize
+          schema:
+            type: integer
+            default: 20
+            minimum: 1
+            maximum: 100
+      responses:
+        '200':
+          description: Entradas consolidadas em `mois_sales_page`
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SalesLibraryEntryPageResponse'
+  /jobs:
+    get:
+      summary: Lista execuções operacionais consolidadas
+      description: Lê `mois_sales_page_job_execution`; campos compatíveis legados expostos no DTO representam identificadores operacionais novos.
+      tags: [MOIS Sales Library]
+      parameters:
+        - in: query
+          name: workspaceId
+          required: true
+          schema:
+            type: string
+        - in: query
+          name: status
+          required: false
+          schema:
+            type: string
+        - in: query
+          name: page
+          schema:
+            type: integer
+            default: 1
+            minimum: 1
+        - in: query
+          name: pageSize
+          schema:
+            type: integer
+            default: 20
+            minimum: 1
+            maximum: 100
+      responses:
+        '200':
+          description: Execuções consolidadas
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SalesLibraryJobPageResponse'
+  /jobs/{jobId}:
+    get:
+      summary: Busca uma execução operacional consolidada
+      description: Lê `mois_sales_page_job_execution` pelo identificador exposto como `jobId`.
+      tags: [MOIS Sales Library]
+      parameters:
+        - $ref: '#/components/parameters/JobId'
+      responses:
+        '200':
+          description: Execução encontrada
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SalesLibraryJobResponse'
+        '404':
+          description: Execução não encontrada
   /jobs:claim:
     post:
       summary: Reserva a próxima execução de análise pelo modelo operacional novo
@@ -451,6 +534,105 @@ components:
           type: integer
         skippedWithoutUrl:
           type: integer
+    SalesLibraryJobResponse:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+          description: Identificador de `mois_sales_page_job_execution`.
+        urlIngestId:
+          type: integer
+          format: int64
+          description: Campo compatível; na Fase 5 representa `mois_sales_page.id`.
+        status:
+          type: string
+        attempts:
+          type: integer
+        errorCategory:
+          type: string
+          nullable: true
+        errorMessage:
+          type: string
+          nullable: true
+        nextRetryAt:
+          type: string
+          format: date-time
+          nullable: true
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+        startedAt:
+          type: string
+          format: date-time
+          nullable: true
+        finishedAt:
+          type: string
+          format: date-time
+          nullable: true
+    SalesLibraryJobPageResponse:
+      type: object
+      properties:
+        page:
+          type: integer
+        pageSize:
+          type: integer
+        total:
+          type: integer
+          format: int64
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/SalesLibraryJobResponse'
+    SalesLibraryEntryResponse:
+      type: object
+      properties:
+        id:
+          type: integer
+          format: int64
+          description: Identificador de `mois_sales_page`.
+        workspaceId:
+          type: string
+        source:
+          type: string
+        urlOriginal:
+          type: string
+        urlCanonical:
+          type: string
+        title:
+          type: string
+          nullable: true
+        ingestCount:
+          type: integer
+        firstCapturedAt:
+          type: string
+          format: date-time
+          nullable: true
+          description: Campo compatível; na Fase 5 representa `mois_sales_page.first_seen_at`.
+        lastCapturedAt:
+          type: string
+          format: date-time
+          nullable: true
+        updatedAt:
+          type: string
+          format: date-time
+    SalesLibraryEntryPageResponse:
+      type: object
+      properties:
+        page:
+          type: integer
+        pageSize:
+          type: integer
+        total:
+          type: integer
+          format: int64
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/SalesLibraryEntryResponse'
     HtmlCaptureClaimRequest:
       type: object
       required: [workspaceId]


### PR DESCRIPTION
### Motivation
- Consolidar a fonte operacional da Biblioteca de Páginas de Vendas nas duas tabelas novas (`mois_sales_page`, `mois_sales_page_job_execution`) para reduzir ambiguidade entre coleta bruta e estado operacional atual. 
- Remover a última leitura operacional contra a tabela legada `mois_sales_library_url_ingest` para que a UI e os workers usem apenas o modelo novo. 
- Atualizar contratos e documentação para refletir que `/entries`, `/jobs` e `/jobs/{jobId}` são suportados pelo modelo novo. 

### Description
- Atualiza `MoisSalesLibraryService.listEntries` para contar e listar diretamente de `mois_sales_page` e usar `first_seen_at` como campo compatível no DTO em vez de ler `mois_sales_library_url_ingest` (file: `backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryService.java`).
- Adiciona teste de regressão `shouldListEntriesFromOperationalSalesPageTable` que valida que `/entries` não consulta a tabela legada (`mois_sales_library_url_ingest`) (file: `backend/ads-service/src/test/.../MoisSalesLibraryServiceTest.java`).
- Atualiza o Swagger operacional para documentar os endpoints consolidados da Fase 5 e os DTOs compatíveis (file: `docs/swagger/mois-sales-library-swagger.yaml`).
- Atualiza o cânone e o plano da Fase 5 e registra a conclusão operacional no registro MOIS para explicitar a nova regra de leitura da UI (files: `docs/canonical/mois-worker-canon.v1.md`, `docs/novos-modulos/MOIS/mois_sales_page_pipeline_simplificacao_duas_tabelas.md`, `docs/registros/mois1.md`).

### Testing
- Executed unit tests with `../mvnw -Dtest=MoisSalesLibraryServiceTest test` and all tests in `MoisSalesLibraryServiceTest` passed (`Tests run: 6, Failures: 0`).
- Ran repository checks: `git diff --check` produced no issues and a grep-based verification confirmed there are no remaining operational reads/writes to legacy tables in the MOIS service package (command used: `if rg -n "mois_sales_library_url_ingest|mois_sales_library_processing_job" backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda; then exit 1; else echo 'no legacy operational reads/writes in MOIS sales library service package'; fi`).
- Attempted to run `../mvnw spotless:check -DskipTests` but the module does not have the `spotless` plugin available in this environment, so formatting check could not be executed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a21e477135483218d091a3b13cb8207)