### PR TITLE
Fase 3: Separação persistente do contrato de Pipelines (Liquibase, entidades JPA, sincronizador e testes)

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/pipeline/PipelineDefinitionEntity.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/pipeline/PipelineDefinitionEntity.java
@@ -1,0 +1,68 @@
+package com.marketinghub.pipeline;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.OneToMany;
+import jakarta.persistence.OrderBy;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+/**
+ * Entidade que persiste a versão canônica de um pipeline oficial separada da configuração operacional.
+ */
+@Entity
+@Table(
+        name = "pipeline_definition",
+        uniqueConstraints = @UniqueConstraint(
+                name = "uk_pipeline_definition_code_version",
+                columnNames = {"code", "canonical_version"}))
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PipelineDefinitionEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, length = 60)
+    private String module;
+
+    @Column(nullable = false, length = 80)
+    private String code;
+
+    @Column(nullable = false, length = 120)
+    private String name;
+
+    @Column(nullable = false, length = 120)
+    private String canonicalVersion;
+
+    @Column(nullable = false)
+    @Builder.Default
+    private boolean active = true;
+
+    @OneToMany(mappedBy = "pipelineDefinition", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    @OrderBy("position ASC, id ASC")
+    @Builder.Default
+    private List<PipelineStageDefinitionEntity> stageDefinitions = new ArrayList<>();
+
+    @CreationTimestamp
+    private Instant createdAt;
+
+    @UpdateTimestamp
+    private Instant updatedAt;
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/pipeline/PipelineStageConfig.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/pipeline/PipelineStageConfig.java
@@ -1,0 +1,59 @@
+package com.marketinghub.pipeline;
+
+import com.marketinghub.openai.OpenAiModel;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+/**
+ * Entidade que guarda somente a configuração operacional editável de uma etapa definida no contrato canônico.
+ */
+@Entity
+@Table(name = "pipeline_stage_config")
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PipelineStageConfig {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @OneToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "pipeline_stage_definition_id", nullable = false, unique = true)
+    private PipelineStageDefinitionEntity pipelineStageDefinition;
+
+    @Column(nullable = false)
+    @Builder.Default
+    private boolean active = true;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "openai_model_id")
+    private OpenAiModel openAiModel;
+
+    @Column(columnDefinition = "TEXT")
+    private String descriptionOverride;
+
+    @Column(length = 120)
+    private String updatedBy;
+
+    @CreationTimestamp
+    private Instant createdAt;
+
+    @UpdateTimestamp
+    private Instant updatedAt;
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/pipeline/PipelineStageDefinitionEntity.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/pipeline/PipelineStageDefinitionEntity.java
@@ -1,0 +1,82 @@
+package com.marketinghub.pipeline;
+
+import jakarta.persistence.CascadeType;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import java.time.Instant;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+/**
+ * Entidade que persiste regras estruturais de uma etapa implementada no contrato canônico de pipeline.
+ */
+@Entity
+@Table(
+        name = "pipeline_stage_definition",
+        uniqueConstraints = {
+            @UniqueConstraint(
+                    name = "uk_pipeline_stage_definition_code",
+                    columnNames = {"pipeline_definition_id", "canonical_code"}),
+            @UniqueConstraint(
+                    name = "uk_pipeline_stage_definition_position",
+                    columnNames = {"pipeline_definition_id", "position"})
+        })
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class PipelineStageDefinitionEntity {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "pipeline_definition_id", nullable = false)
+    private PipelineDefinitionEntity pipelineDefinition;
+
+    @Column(nullable = false, length = 80)
+    private String canonicalCode;
+
+    @Column(nullable = false, length = 120)
+    private String displayName;
+
+    @Column(nullable = false)
+    private Integer position;
+
+    @Column(nullable = false)
+    @Builder.Default
+    private boolean required = true;
+
+    @Column(nullable = false, length = 80)
+    private String implementedStageEnum;
+
+    @Column(nullable = false)
+    @Builder.Default
+    private boolean requiresOpenAiModel = true;
+
+    @Column(nullable = false)
+    @Builder.Default
+    private boolean configurable = true;
+
+    @OneToOne(mappedBy = "pipelineStageDefinition", cascade = CascadeType.ALL, orphanRemoval = true, fetch = FetchType.LAZY)
+    private PipelineStageConfig config;
+
+    @CreationTimestamp
+    private Instant createdAt;
+
+    @UpdateTimestamp
+    private Instant updatedAt;
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/pipeline/service/PipelineDefinitionSynchronizer.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/pipeline/service/PipelineDefinitionSynchronizer.java
@@ -14,6 +14,7 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -26,19 +27,34 @@ public class PipelineDefinitionSynchronizer {
     private final PipelineStageRepository stageRepository;
     private final PipelineDefinitionRegistry definitionRegistry;
     private final PipelineService pipelineService;
+    private final PipelinePersistentContractSynchronizer persistentContractSynchronizer;
 
     /**
      * Inicializa o sincronizador com persistência centralizada, registry canônico e diagnóstico do serviço.
+     */
+    @Autowired
+    public PipelineDefinitionSynchronizer(
+            PipelineRepository pipelineRepository,
+            PipelineStageRepository stageRepository,
+            PipelineDefinitionRegistry definitionRegistry,
+            PipelineService pipelineService,
+            PipelinePersistentContractSynchronizer persistentContractSynchronizer) {
+        this.pipelineRepository = pipelineRepository;
+        this.stageRepository = stageRepository;
+        this.definitionRegistry = definitionRegistry;
+        this.pipelineService = pipelineService;
+        this.persistentContractSynchronizer = persistentContractSynchronizer;
+    }
+
+    /**
+     * Inicializa o sincronizador em testes que não exercitam a persistência separada da fase 3.
      */
     public PipelineDefinitionSynchronizer(
             PipelineRepository pipelineRepository,
             PipelineStageRepository stageRepository,
             PipelineDefinitionRegistry definitionRegistry,
             PipelineService pipelineService) {
-        this.pipelineRepository = pipelineRepository;
-        this.stageRepository = stageRepository;
-        this.definitionRegistry = definitionRegistry;
-        this.pipelineService = pipelineService;
+        this(pipelineRepository, stageRepository, definitionRegistry, pipelineService, null);
     }
 
     /**
@@ -75,6 +91,9 @@ public class PipelineDefinitionSynchronizer {
             synchronizeStage(pipeline, definition, stageDefinition, appliedActions);
         }
         pipelineRepository.save(pipeline);
+        if (persistentContractSynchronizer != null) {
+            appliedActions.addAll(persistentContractSynchronizer.sync(definition, pipeline));
+        }
 
         PipelineDiagnosticsDto diagnostics = pipelineService.diagnostics(pipelineId);
         return PipelineSyncResultDto.builder()

--- a/backend/ads-service/src/main/java/com/marketinghub/pipeline/service/PipelinePersistentContractSynchronizer.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/pipeline/service/PipelinePersistentContractSynchronizer.java
@@ -1,0 +1,181 @@
+package com.marketinghub.pipeline.service;
+
+import com.marketinghub.pipeline.Pipeline;
+import com.marketinghub.pipeline.PipelineDefinitionEntity;
+import com.marketinghub.pipeline.PipelineStage;
+import com.marketinghub.pipeline.PipelineStageConfig;
+import com.marketinghub.pipeline.PipelineStageDefinitionEntity;
+import com.marketinghub.pipeline.definition.PipelineDefinitionRegistry.PipelineDefinition;
+import com.marketinghub.pipeline.definition.PipelineDefinitionRegistry.PipelineStageDefinition;
+import com.marketinghub.repository.jpa.pipeline.PipelineDefinitionEntityRepository;
+import com.marketinghub.repository.jpa.pipeline.PipelineStageConfigRepository;
+import com.marketinghub.repository.jpa.pipeline.PipelineStageDefinitionEntityRepository;
+import java.util.List;
+import org.springframework.stereotype.Component;
+
+/**
+ * Sincroniza a separação persistente entre definição canônica de pipeline e configuração operacional editável.
+ */
+@Component
+public class PipelinePersistentContractSynchronizer {
+    private final PipelineDefinitionEntityRepository definitionRepository;
+    private final PipelineStageDefinitionEntityRepository stageDefinitionRepository;
+    private final PipelineStageConfigRepository configRepository;
+
+    /**
+     * Inicializa o sincronizador persistente com repositórios centralizados de definição e configuração.
+     */
+    public PipelinePersistentContractSynchronizer(
+            PipelineDefinitionEntityRepository definitionRepository,
+            PipelineStageDefinitionEntityRepository stageDefinitionRepository,
+            PipelineStageConfigRepository configRepository) {
+        this.definitionRepository = definitionRepository;
+        this.stageDefinitionRepository = stageDefinitionRepository;
+        this.configRepository = configRepository;
+    }
+
+    /**
+     * Sincroniza uma definição oficial persistente e cria configurações operacionais sem sobrescrever escolhas do usuário.
+     */
+    public List<String> sync(PipelineDefinition definition, Pipeline pipeline) {
+        PipelineDefinitionEntity persistedDefinition = definitionRepository
+                .findByCodeAndCanonicalVersion(definition.code(), definition.canonicalVersion())
+                .orElseGet(() -> createPipelineDefinition(definition));
+        boolean changed = applyPipelineDefinitionFields(persistedDefinition, definition);
+        if (changed) {
+            definitionRepository.save(persistedDefinition);
+        }
+        for (PipelineStageDefinition stageDefinition : definition.stages()) {
+            syncStageDefinition(persistedDefinition, stageDefinition, pipeline);
+        }
+        return List.of("Definição persistente e configurações operacionais sincronizadas sem sobrescrever campos editáveis.");
+    }
+
+    /**
+     * Cria a definição persistente mínima para o pipeline oficial informado pelo registry.
+     */
+    private PipelineDefinitionEntity createPipelineDefinition(PipelineDefinition definition) {
+        PipelineDefinitionEntity entity = PipelineDefinitionEntity.builder()
+                .module(definition.module())
+                .code(definition.code())
+                .name(definition.name())
+                .canonicalVersion(definition.canonicalVersion())
+                .active(true)
+                .build();
+        return definitionRepository.save(entity);
+    }
+
+    /**
+     * Atualiza somente campos estruturais da definição persistente quando o registry oficial mudar.
+     */
+    private boolean applyPipelineDefinitionFields(
+            PipelineDefinitionEntity entity, PipelineDefinition definition) {
+        boolean changed = false;
+        if (!definition.module().equals(entity.getModule())) {
+            entity.setModule(definition.module());
+            changed = true;
+        }
+        if (!definition.name().equals(entity.getName())) {
+            entity.setName(definition.name());
+            changed = true;
+        }
+        if (!entity.isActive()) {
+            entity.setActive(true);
+            changed = true;
+        }
+        return changed;
+    }
+
+    /**
+     * Sincroniza definição persistente de etapa e garante uma configuração operacional editável para ela.
+     */
+    private void syncStageDefinition(
+            PipelineDefinitionEntity pipelineDefinition,
+            PipelineStageDefinition stageDefinition,
+            Pipeline pipeline) {
+        PipelineStageDefinitionEntity entity = stageDefinitionRepository
+                .findByPipelineDefinitionIdAndCanonicalCode(pipelineDefinition.getId(), stageDefinition.canonicalCode())
+                .orElseGet(() -> createStageDefinition(pipelineDefinition, stageDefinition));
+        boolean changed = applyStageDefinitionFields(entity, stageDefinition);
+        if (changed) {
+            stageDefinitionRepository.save(entity);
+        }
+        PipelineStage configuredStage = findConfiguredStage(pipeline, stageDefinition);
+        syncStageConfig(entity, configuredStage);
+    }
+
+    /**
+     * Cria a definição persistente mínima para uma etapa oficial do registry.
+     */
+    private PipelineStageDefinitionEntity createStageDefinition(
+            PipelineDefinitionEntity pipelineDefinition, PipelineStageDefinition stageDefinition) {
+        PipelineStageDefinitionEntity entity = PipelineStageDefinitionEntity.builder()
+                .pipelineDefinition(pipelineDefinition)
+                .canonicalCode(stageDefinition.canonicalCode())
+                .displayName(stageDefinition.name())
+                .position(stageDefinition.position())
+                .required(stageDefinition.required())
+                .implementedStageEnum(stageDefinition.canonicalCode())
+                .requiresOpenAiModel(true)
+                .configurable(stageDefinition.configurable())
+                .build();
+        return stageDefinitionRepository.save(entity);
+    }
+
+    /**
+     * Atualiza campos estruturais persistentes da etapa, preservando configuração operacional em tabela separada.
+     */
+    private boolean applyStageDefinitionFields(
+            PipelineStageDefinitionEntity entity, PipelineStageDefinition stageDefinition) {
+        boolean changed = false;
+        if (!stageDefinition.name().equals(entity.getDisplayName())) {
+            entity.setDisplayName(stageDefinition.name());
+            changed = true;
+        }
+        if (stageDefinition.position() != entity.getPosition()) {
+            entity.setPosition(stageDefinition.position());
+            changed = true;
+        }
+        if (stageDefinition.required() != entity.isRequired()) {
+            entity.setRequired(stageDefinition.required());
+            changed = true;
+        }
+        if (!stageDefinition.canonicalCode().equals(entity.getImplementedStageEnum())) {
+            entity.setImplementedStageEnum(stageDefinition.canonicalCode());
+            changed = true;
+        }
+        if (stageDefinition.configurable() != entity.isConfigurable()) {
+            entity.setConfigurable(stageDefinition.configurable());
+            changed = true;
+        }
+        return changed;
+    }
+
+    /**
+     * Cria ou mantém configuração operacional, copiando valores legados apenas quando ainda não existe configuração.
+     */
+    private void syncStageConfig(PipelineStageDefinitionEntity stageDefinition, PipelineStage configuredStage) {
+        configRepository.findByPipelineStageDefinitionId(stageDefinition.getId()).orElseGet(() -> {
+            PipelineStageConfig config = PipelineStageConfig.builder()
+                    .pipelineStageDefinition(stageDefinition)
+                    .active(configuredStage == null || configuredStage.isActive())
+                    .openAiModel(configuredStage == null ? null : configuredStage.getOpenAiModel())
+                    .descriptionOverride(configuredStage == null ? null : configuredStage.getDescription())
+                    .updatedBy("pipeline-sync")
+                    .build();
+            return configRepository.save(config);
+        });
+    }
+
+    /**
+     * Localiza a etapa operacional legada equivalente para migrar configuração sem tocar nos campos estruturais.
+     */
+    private PipelineStage findConfiguredStage(Pipeline pipeline, PipelineStageDefinition stageDefinition) {
+        return pipeline.getStages().stream()
+                .filter(stage -> stageDefinition.operationalCode().equals(stage.getCode())
+                        || stageDefinition.aliases().contains(stage.getCode())
+                        || stageDefinition.canonicalCode().equals(stage.getCode()))
+                .findFirst()
+                .orElse(null);
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/pipeline/PipelineDefinitionEntityRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/pipeline/PipelineDefinitionEntityRepository.java
@@ -1,0 +1,15 @@
+package com.marketinghub.repository.jpa.pipeline;
+
+import com.marketinghub.pipeline.PipelineDefinitionEntity;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * Repositório JPA centralizado para definições persistentes de pipelines oficiais.
+ */
+public interface PipelineDefinitionEntityRepository extends JpaRepository<PipelineDefinitionEntity, Long> {
+    /**
+     * Busca uma definição persistida pelo código canônico e versão canônica.
+     */
+    Optional<PipelineDefinitionEntity> findByCodeAndCanonicalVersion(String code, String canonicalVersion);
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/pipeline/PipelineStageConfigRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/pipeline/PipelineStageConfigRepository.java
@@ -1,0 +1,15 @@
+package com.marketinghub.repository.jpa.pipeline;
+
+import com.marketinghub.pipeline.PipelineStageConfig;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * Repositório JPA centralizado para configurações operacionais editáveis de etapas de pipeline.
+ */
+public interface PipelineStageConfigRepository extends JpaRepository<PipelineStageConfig, Long> {
+    /**
+     * Busca a configuração operacional ligada a uma definição persistente de etapa.
+     */
+    Optional<PipelineStageConfig> findByPipelineStageDefinitionId(Long pipelineStageDefinitionId);
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/pipeline/PipelineStageDefinitionEntityRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/pipeline/PipelineStageDefinitionEntityRepository.java
@@ -1,0 +1,16 @@
+package com.marketinghub.repository.jpa.pipeline;
+
+import com.marketinghub.pipeline.PipelineStageDefinitionEntity;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * Repositório JPA centralizado para definições persistentes de etapas oficiais de pipeline.
+ */
+public interface PipelineStageDefinitionEntityRepository extends JpaRepository<PipelineStageDefinitionEntity, Long> {
+    /**
+     * Busca uma definição de etapa pelo pipeline persistido e código canônico.
+     */
+    Optional<PipelineStageDefinitionEntity> findByPipelineDefinitionIdAndCanonicalCode(
+            Long pipelineDefinitionId, String canonicalCode);
+}

--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-04-pipeline-persistent-contract.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-04-pipeline-persistent-contract.yaml
@@ -1,0 +1,217 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-06-04-pipeline-persistent-contract
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - onError: HALT
+        - dbms:
+            type: mysql
+        - not:
+            - tableExists:
+                tableName: pipeline_definition
+      changes:
+        - createTable:
+            tableName: pipeline_definition
+            columns:
+              - column:
+                  name: id
+                  type: BIGINT
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: module
+                  type: VARCHAR(60)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: code
+                  type: VARCHAR(80)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: name
+                  type: VARCHAR(120)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: canonical_version
+                  type: VARCHAR(120)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: active
+                  type: BOOLEAN
+                  defaultValueBoolean: true
+                  constraints:
+                    nullable: false
+              - column:
+                  name: created_at
+                  type: TIMESTAMP
+              - column:
+                  name: updated_at
+                  type: TIMESTAMP
+        - createTable:
+            tableName: pipeline_stage_definition
+            columns:
+              - column:
+                  name: id
+                  type: BIGINT
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: pipeline_definition_id
+                  type: BIGINT
+                  constraints:
+                    nullable: false
+              - column:
+                  name: canonical_code
+                  type: VARCHAR(80)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: display_name
+                  type: VARCHAR(120)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: position
+                  type: INT
+                  constraints:
+                    nullable: false
+              - column:
+                  name: required
+                  type: BOOLEAN
+                  defaultValueBoolean: true
+                  constraints:
+                    nullable: false
+              - column:
+                  name: implemented_stage_enum
+                  type: VARCHAR(80)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: requires_openai_model
+                  type: BOOLEAN
+                  defaultValueBoolean: true
+                  constraints:
+                    nullable: false
+              - column:
+                  name: configurable
+                  type: BOOLEAN
+                  defaultValueBoolean: true
+                  constraints:
+                    nullable: false
+              - column:
+                  name: created_at
+                  type: TIMESTAMP
+              - column:
+                  name: updated_at
+                  type: TIMESTAMP
+        - createTable:
+            tableName: pipeline_stage_config
+            columns:
+              - column:
+                  name: id
+                  type: BIGINT
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: pipeline_stage_definition_id
+                  type: BIGINT
+                  constraints:
+                    nullable: false
+              - column:
+                  name: active
+                  type: BOOLEAN
+                  defaultValueBoolean: true
+                  constraints:
+                    nullable: false
+              - column:
+                  name: openai_model_id
+                  type: BIGINT
+              - column:
+                  name: description_override
+                  type: TEXT
+              - column:
+                  name: updated_by
+                  type: VARCHAR(120)
+              - column:
+                  name: created_at
+                  type: TIMESTAMP
+              - column:
+                  name: updated_at
+                  type: TIMESTAMP
+        - addUniqueConstraint:
+            tableName: pipeline_definition
+            columnNames: code, canonical_version
+            constraintName: uk_pipeline_definition_code_version
+        - addUniqueConstraint:
+            tableName: pipeline_stage_definition
+            columnNames: pipeline_definition_id, canonical_code
+            constraintName: uk_pipeline_stage_definition_code
+        - addUniqueConstraint:
+            tableName: pipeline_stage_definition
+            columnNames: pipeline_definition_id, position
+            constraintName: uk_pipeline_stage_definition_position
+        - addUniqueConstraint:
+            tableName: pipeline_stage_config
+            columnNames: pipeline_stage_definition_id
+            constraintName: uk_pipeline_stage_config_definition
+        - addForeignKeyConstraint:
+            baseTableName: pipeline_stage_definition
+            baseColumnNames: pipeline_definition_id
+            constraintName: fk_pipeline_stage_definition_pipeline_definition
+            referencedTableName: pipeline_definition
+            referencedColumnNames: id
+            onDelete: CASCADE
+        - addForeignKeyConstraint:
+            baseTableName: pipeline_stage_config
+            baseColumnNames: pipeline_stage_definition_id
+            constraintName: fk_pipeline_stage_config_stage_definition
+            referencedTableName: pipeline_stage_definition
+            referencedColumnNames: id
+            onDelete: CASCADE
+        - addForeignKeyConstraint:
+            baseTableName: pipeline_stage_config
+            baseColumnNames: openai_model_id
+            constraintName: fk_pipeline_stage_config_openai_model
+            referencedTableName: openai_model
+            referencedColumnNames: id
+            onDelete: SET NULL
+        - createIndex:
+            tableName: pipeline_definition
+            indexName: idx_pipeline_definition_module
+            columns:
+              - column:
+                  name: module
+        - createIndex:
+            tableName: pipeline_stage_config
+            indexName: idx_pipeline_stage_config_openai_model
+            columns:
+              - column:
+                  name: openai_model_id
+        - sql:
+            splitStatements: true
+            stripComments: true
+            sql: |
+              INSERT INTO pipeline_definition (module, code, name, canonical_version, active, created_at, updated_at)
+              SELECT p.module, p.code, p.name, 'legacy-operational-import', p.active, NOW(), NOW()
+              FROM pipeline p;
+              INSERT INTO pipeline_stage_definition (pipeline_definition_id, canonical_code, display_name, position, required, implemented_stage_enum, requires_openai_model, configurable, created_at, updated_at)
+              SELECT pd.id, UPPER(REPLACE(ps.code, '-', '_')), ps.name, ps.position, ps.required, UPPER(REPLACE(ps.code, '-', '_')), 1, 1, NOW(), NOW()
+              FROM pipeline_stage ps
+              INNER JOIN pipeline p ON p.id = ps.pipeline_id
+              INNER JOIN pipeline_definition pd ON pd.code = p.code AND pd.canonical_version = 'legacy-operational-import';
+              INSERT INTO pipeline_stage_config (pipeline_stage_definition_id, active, openai_model_id, description_override, updated_by, created_at, updated_at)
+              SELECT psd.id, ps.active, ps.openai_model_id, ps.description, 'liquibase-migration', NOW(), NOW()
+              FROM pipeline_stage ps
+              INNER JOIN pipeline p ON p.id = ps.pipeline_id
+              INNER JOIN pipeline_definition pd ON pd.code = p.code AND pd.canonical_version = 'legacy-operational-import'
+              INNER JOIN pipeline_stage_definition psd ON psd.pipeline_definition_id = pd.id AND psd.position = ps.position;

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -605,6 +605,9 @@ databaseChangeLog:
   - include:
       file: changesets/2026-06-04-pipeline-stage-openai-model.yaml
       relativeToChangelogFile: true
+  - include:
+      file: changesets/2026-06-04-pipeline-persistent-contract.yaml
+      relativeToChangelogFile: true
 
   - include:
       file: changesets/2026-06-04-openai-model-accepts-image-input.yaml

--- a/backend/ads-service/src/test/java/com/marketinghub/pipeline/service/PipelineServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/pipeline/service/PipelineServiceTest.java
@@ -3,19 +3,27 @@ package com.marketinghub.pipeline.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.marketinghub.openai.OpenAiModel;
 import com.marketinghub.pipeline.Pipeline;
+import com.marketinghub.pipeline.PipelineDefinitionEntity;
 import com.marketinghub.pipeline.PipelineStage;
+import com.marketinghub.pipeline.PipelineStageConfig;
+import com.marketinghub.pipeline.PipelineStageDefinitionEntity;
 import com.marketinghub.pipeline.definition.PipelineDefinitionRegistry;
 import com.marketinghub.pipeline.dto.PipelineDiagnosticsDto;
 import com.marketinghub.pipeline.dto.PipelineRequest;
 import com.marketinghub.pipeline.dto.PipelineStageRequest;
 import com.marketinghub.pipeline.dto.PipelineSyncResultDto;
 import com.marketinghub.repository.jpa.openai.OpenAiModelRepository;
+import com.marketinghub.repository.jpa.pipeline.PipelineDefinitionEntityRepository;
 import com.marketinghub.repository.jpa.pipeline.PipelineRepository;
+import com.marketinghub.repository.jpa.pipeline.PipelineStageConfigRepository;
+import com.marketinghub.repository.jpa.pipeline.PipelineStageDefinitionEntityRepository;
 import com.marketinghub.repository.jpa.pipeline.PipelineStageRepository;
 import java.util.ArrayList;
 import java.util.List;
@@ -367,6 +375,73 @@ class PipelineServiceTest {
             assertThat(pipeline.pipelineFieldPolicy().codeStructural()).isTrue();
             assertThat(pipeline.stageFieldPolicy().openAiModelOperational()).isTrue();
         });
+    }
+
+    /**
+     * Garante que a fase 3 persiste definição canônica separada da configuração operacional herdada.
+     */
+    @Test
+    void shouldPersistDefinitionSeparatedFromOperationalConfig() {
+        PipelineDefinitionEntityRepository definitionRepository = mock(PipelineDefinitionEntityRepository.class);
+        PipelineStageDefinitionEntityRepository stageDefinitionRepository = mock(PipelineStageDefinitionEntityRepository.class);
+        PipelineStageConfigRepository configRepository = mock(PipelineStageConfigRepository.class);
+        PipelinePersistentContractSynchronizer persistentSynchronizer = new PipelinePersistentContractSynchronizer(
+                definitionRepository, stageDefinitionRepository, configRepository);
+        OpenAiModel model = OpenAiModel.builder().id(99L).name("GPT 5.2").code("gpt-5.2").build();
+        PipelineStage configured = stage(1L, 1, "campaign-angle");
+        configured.setDescription("Descrição operacional preservada");
+        configured.setOpenAiModel(model);
+        Pipeline pipeline = officialPipelineWith(configured);
+        PipelineDefinitionEntity persistedDefinition = PipelineDefinitionEntity.builder()
+                .id(7L)
+                .code("experiment-pipeline")
+                .module("EXPERIMENT")
+                .name("Pipeline de Experimento")
+                .canonicalVersion("procedimento-experimento-canon.v1")
+                .active(true)
+                .build();
+        PipelineStageDefinitionEntity persistedStage = PipelineStageDefinitionEntity.builder()
+                .id(8L)
+                .pipelineDefinition(persistedDefinition)
+                .canonicalCode("CAMPAIGN_ANGLE")
+                .displayName("Campaign Angle")
+                .position(1)
+                .required(true)
+                .implementedStageEnum("CAMPAIGN_ANGLE")
+                .requiresOpenAiModel(true)
+                .configurable(true)
+                .build();
+        when(definitionRepository.findByCodeAndCanonicalVersion(
+                        "experiment-pipeline", "procedimento-experimento-canon.v1"))
+                .thenReturn(Optional.of(persistedDefinition));
+        when(stageDefinitionRepository.findByPipelineDefinitionIdAndCanonicalCode(7L, "CAMPAIGN_ANGLE"))
+                .thenReturn(Optional.of(persistedStage));
+        when(stageDefinitionRepository.save(any(PipelineStageDefinitionEntity.class))).thenAnswer(invocation -> {
+            PipelineStageDefinitionEntity saved = invocation.getArgument(0);
+            if (saved.getId() == null) {
+                saved.setId(90L + saved.getPosition());
+            }
+            return saved;
+        });
+        when(configRepository.findByPipelineStageDefinitionId(8L)).thenReturn(Optional.empty());
+        when(configRepository.save(any(PipelineStageConfig.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        List<String> actions = persistentSynchronizer.sync(
+                definitionRegistry.findByPipelineCode("experiment-pipeline").orElseThrow(), pipeline);
+
+        assertThat(actions)
+                .containsExactly(
+                        "Definição persistente e configurações operacionais sincronizadas sem sobrescrever campos editáveis.");
+        ArgumentCaptor<PipelineStageConfig> configCaptor = ArgumentCaptor.forClass(PipelineStageConfig.class);
+        verify(configRepository, atLeastOnce()).save(configCaptor.capture());
+        PipelineStageConfig migratedConfig = configCaptor.getAllValues().stream()
+                .filter(config -> config.getPipelineStageDefinition().getId().equals(8L))
+                .findFirst()
+                .orElseThrow();
+        assertThat(migratedConfig.getPipelineStageDefinition()).isEqualTo(persistedStage);
+        assertThat(migratedConfig.getDescriptionOverride()).isEqualTo("Descrição operacional preservada");
+        assertThat(migratedConfig.getOpenAiModel()).isEqualTo(model);
+        assertThat(migratedConfig.isActive()).isTrue();
     }
 
     /**

--- a/docs/canonical/geralanding-arquitetura-canon.v1.md
+++ b/docs/canonical/geralanding-arquitetura-canon.v1.md
@@ -50,8 +50,10 @@ Regras arquiteturais refletidas (ArchUnit):
 
 ## Catálogo operacional de pipeline e modelo por etapa
 
-- O catálogo administrativo de pipelines e etapas é persistido em `pipeline` e `pipeline_stage` e deve ser usado como fonte operacional para configurar a escolha padrão de modelo por etapa.
-- Cada registro de `pipeline_stage` pode apontar para um modelo da tabela `openai_model` por meio de `openai_model_id`; quando o campo estiver nulo, a etapa deve manter o fallback técnico já definido no executor/worker correspondente.
+- O catálogo administrativo legado de pipelines e etapas permanece em `pipeline` e `pipeline_stage` durante a transição operacional.
+- A definição persistente oficial deve ficar separada em `pipeline_definition` e `pipeline_stage_definition`, enquanto os campos editáveis pela operação ficam em `pipeline_stage_config`.
+- Cada configuração operacional de etapa pode apontar para um modelo da tabela `openai_model` por meio de `pipeline_stage_config.openai_model_id`; enquanto a transição estiver ativa, `pipeline_stage.openai_model_id` continua compatível e deve ser migrado sem sobrescrever a escolha do usuário.
+- Quando não houver modelo OpenAI configurado para a etapa, a execução deve manter o fallback técnico já definido no executor/worker correspondente.
 - Para o GeraLanding, a configuração de modelo por etapa deve priorizar a finalidade comercial da etapa e o foco em vendas, evitando parâmetros técnicos avançados na tela principal.
 - A etapa `landing-page-wireframe` deve usar configuração dedicada `wireframe.worker.model`, com padrão `gpt-5.4`, porque define a estrutura comercial de baixa fricção que orienta copy, imagens, preset visual e HTML final.
 - A tela administrativa de pipelines deve exibir uma seleção simples de modelo OpenAI por etapa, usando os modelos cadastrados em `openai_model`.

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -3461,3 +3461,21 @@
 - causa-raiz endereçada: a fase 1 diagnosticava divergências, mas ainda não havia um mecanismo idempotente para reparar divergências simples e bloquear alterações destrutivas com rastreabilidade.
 - correção aplicada: evoluído o registry oficial com versão canônica e política explícita de campos estruturais versus operacionais; criado `PipelineDefinitionSynchronizer` para criar pipeline/etapas oficiais ausentes, corrigir nome/posição/obrigatoriedade estruturais e preservar `openAiModel`, `active` e descrições operacionais; adicionados endpoints `POST /api/pipelines/{id}/sync` e `POST /api/pipelines/official/{code}/sync` sem payload da tela; documentação Swagger e cânone de experimento sincronizados.
 - validação automatizada: adicionados testes para criação de etapa oficial ausente, preservação de modelo OpenAI configurado, bloqueio de divergência destrutiva, criação de pipeline oficial ausente por código e aderência do registry à versão canônica.
+
+## 2026-06-04 — Fase 3 do contrato operacional da tela de Pipelines
+
+- solicitação: executar a Fase 3 do plano `docs/implementacao/backend/plano-pipelines-contrato-operacional.md`, separando definição persistente e configuração operacional.
+- causa-raiz/objetivo: permitir versionamento/auditoria futura e reduzir risco de divergência entre contrato estrutural de pipeline e campos editáveis da operação.
+- foi feito:
+  - adicionadas tabelas `pipeline_definition`, `pipeline_stage_definition` e `pipeline_stage_config` via changelog Liquibase incremental, com FKs, uniques e migração inicial das configurações atuais de `pipeline_stage` para `pipeline_stage_config`;
+  - criadas entidades JPA e repositories centralizados em `com.marketinghub.repository.jpa.pipeline` para a persistência separada do contrato;
+  - criado `PipelinePersistentContractSynchronizer` para sincronizar definições oficiais do registry e criar configuração operacional sem sobrescrever modelo OpenAI, descrição ou status configurados;
+  - integrado o sincronizador persistente ao fluxo seguro já existente de sincronização de pipelines oficiais;
+  - adicionada cobertura unitária para preservar configuração operacional na separação persistente.
+- arquivos principais:
+  - backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-04-pipeline-persistent-contract.yaml
+  - backend/ads-service/src/main/java/com/marketinghub/pipeline/PipelineDefinitionEntity.java
+  - backend/ads-service/src/main/java/com/marketinghub/pipeline/PipelineStageDefinitionEntity.java
+  - backend/ads-service/src/main/java/com/marketinghub/pipeline/PipelineStageConfig.java
+  - backend/ads-service/src/main/java/com/marketinghub/pipeline/service/PipelinePersistentContractSynchronizer.java
+  - backend/ads-service/src/test/java/com/marketinghub/pipeline/service/PipelineServiceTest.java


### PR DESCRIPTION
### Motivation
- Evitar divergência silenciosa entre definição canônica de pipeline e configuração operacional ao persistir separadamente a definição e a configuração.
- Viabilizar versionamento e auditoria das definições oficiais de pipeline quando necessário no futuro.
- Preservar escolhas operacionais (modelo OpenAI, descrições, ativo) ao migrar a configuração legada.
- Integrar a persistência ao fluxo de sincronização seguro já existente para permitir reparos idempotentes e não-destrutivos.

### Description
- Adiciona changelog Liquibase incremental `changesets/2026-06-04-pipeline-persistent-contract.yaml` que cria as tabelas `pipeline_definition`, `pipeline_stage_definition` e `pipeline_stage_config` com constraints, FKs e migração inicial dos dados legados de `pipeline`/`pipeline_stage` para `pipeline_stage_config`.
- Cria entidades JPA `PipelineDefinitionEntity`, `PipelineStageDefinitionEntity` e `PipelineStageConfig` e repositórios JPA centralizados em `com.marketinghub.repository.jpa.pipeline` para a nova persistência de fase 3.
- Implementa `PipelinePersistentContractSynchronizer` que sincroniza definições canônicas do `PipelineDefinitionRegistry` para a persistência e cria/retém configurações operacionais sem sobrescrever `openAiModel`, `description` ou `active` já configurados.
- Integra o sincronizador persistente ao fluxo existente em `PipelineDefinitionSynchronizer` e adiciona cobertura de teste unitário em `PipelineServiceTest` para validar que a configuração operacional é preservada durante a sincronização/migração; também atualiza cânone e registros operacionais (docs).

### Testing
- Executado o teste unitário focado: `mvn -Dtest=PipelineServiceTest test` no módulo `backend/ads-service`, que compilou e passou com sucesso (`Tests run: 17, Failures: 0, Errors: 0`).
- Foram corrigidos erros de compilação e assertions dos testes durante a implementação para garantir execução verde da suíte modificada.
- Validação adicional: checagem de `git diff --check` (sem problemas de diff-check) e execução local dos testes de serviço afetados.
- Observação: tentativa de rodar `mvn spotless:apply -Dspotless.check.skip=false` falhou por ausência de plugin `spotless` resolvível no escopo do módulo, portanto a formatação foi mantida consistente manualmente durante a implementação.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a21e992305883218e3c31e00d821fe6)