### PR TITLE
Add daily OpenAI model pricing sync (parser, scheduler, db + tests)

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/openai/OpenAiApiKeyResolver.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/openai/OpenAiApiKeyResolver.java
@@ -1,0 +1,40 @@
+package com.marketinghub.openai;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+/** Responsabilidade: resolver o token OpenAI a partir de variável de ambiente/propriedade ou arquivo seguro montado no host. */
+@Component
+public class OpenAiApiKeyResolver {
+    private static final Logger log = LoggerFactory.getLogger(OpenAiApiKeyResolver.class);
+
+    /** Resolve o token priorizando a propriedade explícita e usando o arquivo configurado como fallback operacional. */
+    public String resolve(OpenAiProperties properties) {
+        if (StringUtils.hasText(properties.getApiKey())) {
+            return properties.getApiKey().trim();
+        }
+        if (!StringUtils.hasText(properties.getApiKeyFile())) {
+            return null;
+        }
+        Path tokenPath = Path.of(properties.getApiKeyFile());
+        if (!Files.isRegularFile(tokenPath)) {
+            log.debug("Token OpenAI não encontrado no arquivo configurado; operation=openai-api-key-resolve path={}", tokenPath);
+            return null;
+        }
+        try {
+            return Files.readString(tokenPath, StandardCharsets.UTF_8).trim();
+        } catch (IOException ex) {
+            log.error(
+                    "Falha ao ler token OpenAI do arquivo configurado; operation=openai-api-key-resolve path={}",
+                    tokenPath,
+                    ex);
+            return null;
+        }
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/openai/OpenAiConfiguration.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/openai/OpenAiConfiguration.java
@@ -10,15 +10,18 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.http.client.reactive.ReactorClientHttpConnector;
+import org.springframework.util.StringUtils;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.netty.http.client.HttpClient;
 
+/** Responsabilidade: configurar clientes HTTP usados na integração backend com a OpenAI. */
 @Configuration
 @EnableConfigurationProperties(OpenAiProperties.class)
 public class OpenAiConfiguration {
 
+    /** Cria o WebClient autenticado da OpenAI usando token direto ou arquivo seguro configurado. */
     @Bean(name = "openAiWebClient")
-    public WebClient openAiWebClient(WebClient.Builder builder, OpenAiProperties properties) {
+    public WebClient openAiWebClient(WebClient.Builder builder, OpenAiProperties properties, OpenAiApiKeyResolver apiKeyResolver) {
         HttpClient httpClient = HttpClient.create()
                 .option(ChannelOption.CONNECT_TIMEOUT_MILLIS, (int) properties.getConnectTimeout().toMillis())
                 .responseTimeout(properties.getRequestTimeout())
@@ -34,8 +37,9 @@ public class OpenAiConfiguration {
                 .clientConnector(new ReactorClientHttpConnector(httpClient))
                 .defaultHeader(HttpHeaders.CONTENT_TYPE, MediaType.APPLICATION_JSON_VALUE);
 
-        if (properties.isEnabled()) {
-            configured.defaultHeader(HttpHeaders.AUTHORIZATION, "Bearer " + properties.getApiKey());
+        String apiKey = apiKeyResolver.resolve(properties);
+        if (StringUtils.hasText(apiKey)) {
+            configured.defaultHeader(HttpHeaders.AUTHORIZATION, "Bearer " + apiKey);
         }
 
         return configured.build();

--- a/backend/ads-service/src/main/java/com/marketinghub/openai/OpenAiModel.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/openai/OpenAiModel.java
@@ -58,6 +58,12 @@ public class OpenAiModel {
     @Builder.Default
     private boolean acceptsImageInput = false;
 
+    @Column(name = "pricing_source", length = 255)
+    private String pricingSource;
+
+    @Column(name = "last_pricing_sync_at")
+    private Instant lastPricingSyncAt;
+
     @CreationTimestamp
     @Column(name = "created_at", updatable = false)
     private Instant createdAt;

--- a/backend/ads-service/src/main/java/com/marketinghub/openai/OpenAiModelPricing.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/openai/OpenAiModelPricing.java
@@ -1,0 +1,14 @@
+package com.marketinghub.openai;
+
+import java.math.BigDecimal;
+
+/** Responsabilidade: transportar os preços oficiais por 1 milhão de tokens de um modelo OpenAI. */
+public record OpenAiModelPricing(
+        String code,
+        String name,
+        BigDecimal priceInputStandard,
+        BigDecimal priceInputCachedStandard,
+        BigDecimal priceOutputStandard,
+        BigDecimal priceInputBatch,
+        BigDecimal priceInputCachedBatch,
+        BigDecimal priceOutputBatch) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/openai/OpenAiModelPricingScheduler.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/openai/OpenAiModelPricingScheduler.java
@@ -1,0 +1,37 @@
+package com.marketinghub.openai;
+
+import com.marketinghub.openai.service.OpenAiModelPricingSyncService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/** Responsabilidade: disparar a sincronização diária dos preços financeiros dos modelos OpenAI. */
+@Component
+public class OpenAiModelPricingScheduler {
+    private static final Logger log = LoggerFactory.getLogger(OpenAiModelPricingScheduler.class);
+
+    private final OpenAiModelPricingSyncService syncService;
+
+    /** Inicializa o agendador com o serviço transacional de sincronização de preços. */
+    public OpenAiModelPricingScheduler(OpenAiModelPricingSyncService syncService) {
+        this.syncService = syncService;
+    }
+
+    /** Executa diariamente às 04:00 no fuso de São Paulo para manter os preços dos modelos atualizados. */
+    @Scheduled(cron = "0 0 4 * * *", zone = "America/Sao_Paulo")
+    public void syncDailyPricing() {
+        try {
+            int updated = syncService.syncOfficialPricing();
+            log.info("Rotina diária de preços OpenAI concluída; operation=openai-pricing-daily-sync modelsUpdated={}", updated);
+        } catch (RuntimeException ex) {
+            StackTraceElement line = ex.getStackTrace().length > 0 ? ex.getStackTrace()[0] : null;
+            log.error(
+                    "Falha na rotina diária de preços OpenAI; operation=openai-pricing-daily-sync line={} errorClass={} errorMessage={}",
+                    line,
+                    ex.getClass().getName(),
+                    ex.getMessage(),
+                    ex);
+        }
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/openai/OpenAiPricingPageClient.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/openai/OpenAiPricingPageClient.java
@@ -1,0 +1,143 @@
+package com.marketinghub.openai;
+
+import java.math.BigDecimal;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
+
+/** Responsabilidade: consultar a página oficial de preços da OpenAI e extrair preços de modelos de texto. */
+@Component
+public class OpenAiPricingPageClient {
+    private static final Logger log = LoggerFactory.getLogger(OpenAiPricingPageClient.class);
+
+    private final WebClient.Builder webClientBuilder;
+    private final OpenAiProperties properties;
+
+    /** Inicializa o cliente com WebClient e propriedades de URL/timeout da integração OpenAI. */
+    public OpenAiPricingPageClient(WebClient.Builder webClientBuilder, OpenAiProperties properties) {
+        this.webClientBuilder = webClientBuilder;
+        this.properties = properties;
+    }
+
+    /** Busca a página oficial de preços e retorna os modelos com preços standard e batch consolidados. */
+    public List<OpenAiModelPricing> fetchTextModelPricing() {
+        String html = webClientBuilder.build().get().uri(properties.getPricingUrl()).retrieve().bodyToMono(String.class).block();
+        return parseTextModelPricing(html);
+    }
+
+    /** Extrai os preços das duas primeiras tabelas textuais: standard e batch. */
+    public List<OpenAiModelPricing> parseTextModelPricing(String html) {
+        if (html == null || html.isBlank()) {
+            return List.of();
+        }
+        List<Map<String, PriceTriple>> tables = parseTextPricingTables(html);
+        if (tables.isEmpty()) {
+            log.warn("Nenhuma tabela de preço de texto OpenAI encontrada; operation=openai-pricing-parse source={}", properties.getPricingUrl());
+            return List.of();
+        }
+        Map<String, PriceTriple> standard = tables.get(0);
+        Map<String, PriceTriple> batch = tables.size() > 1 ? tables.get(1) : Map.of();
+        List<OpenAiModelPricing> result = new ArrayList<>();
+        for (Map.Entry<String, PriceTriple> entry : standard.entrySet()) {
+            PriceTriple standardPrice = entry.getValue();
+            PriceTriple batchPrice = batch.getOrDefault(entry.getKey(), standardPrice.half());
+            result.add(new OpenAiModelPricing(
+                    entry.getKey(),
+                    standardPrice.name(),
+                    standardPrice.input(),
+                    standardPrice.cachedInput(),
+                    standardPrice.output(),
+                    batchPrice.input(),
+                    batchPrice.cachedInput(),
+                    batchPrice.output()));
+        }
+        return result;
+    }
+
+    /** Localiza tabelas com colunas de modelo, input, cached input e output e converte suas linhas em preços. */
+    private List<Map<String, PriceTriple>> parseTextPricingTables(String html) {
+        Document document = Jsoup.parse(html);
+        List<Map<String, PriceTriple>> parsedTables = new ArrayList<>();
+        for (Element table : document.select("table")) {
+            String headerText = table.select("thead").text().toLowerCase(Locale.ROOT);
+            if (!headerText.contains("model") || !headerText.contains("input") || !headerText.contains("output")) {
+                continue;
+            }
+            Map<String, PriceTriple> rows = parseRows(table.select("tbody tr"));
+            if (!rows.isEmpty()) {
+                parsedTables.add(rows);
+            }
+        }
+        return parsedTables;
+    }
+
+    /** Converte linhas HTML de preço em mapa por código canônico do modelo. */
+    private Map<String, PriceTriple> parseRows(Elements rows) {
+        Map<String, PriceTriple> tablePrices = new LinkedHashMap<>();
+        for (Element row : rows) {
+            Elements cells = row.select("td");
+            if (cells.size() < 4) {
+                continue;
+            }
+            String displayName = cells.get(0).text().trim();
+            String code = normalizeModelCode(displayName);
+            if (!isTextModelCode(code)) {
+                continue;
+            }
+            BigDecimal input = parseMoney(cells.get(1).text());
+            BigDecimal cachedInput = parseMoney(cells.get(2).text());
+            BigDecimal output = parseMoney(cells.get(3).text());
+            if (input == null || output == null) {
+                continue;
+            }
+            tablePrices.put(code, new PriceTriple(code, input, zeroIfNull(cachedInput), output));
+        }
+        return tablePrices;
+    }
+
+    /** Remove observações de contexto e normaliza o código do modelo para comparação e persistência. */
+    private String normalizeModelCode(String value) {
+        return value.replaceAll("\\s*\\(.*$", "").trim().toLowerCase(Locale.ROOT);
+    }
+
+    /** Indica se o código extraído representa modelo de texto/reasoning suportado no catálogo financeiro. */
+    private boolean isTextModelCode(String code) {
+        return code.startsWith("gpt-") || code.startsWith("o1") || code.startsWith("o3") || code.startsWith("o4");
+    }
+
+    /** Converte valores monetários da tabela oficial para decimal por 1 milhão de tokens. */
+    private BigDecimal parseMoney(String value) {
+        String normalized = value == null ? "" : value.replace("$", "").replace(",", "").trim();
+        if (normalized.isBlank() || normalized.equals("-")) {
+            return null;
+        }
+        return new BigDecimal(normalized);
+    }
+
+    /** Garante valor zero para campos de preço não publicados, preservando restrição NOT NULL do banco. */
+    private BigDecimal zeroIfNull(BigDecimal value) {
+        return value == null ? BigDecimal.ZERO : value;
+    }
+
+    /** Responsabilidade: manter um trio de preços input/cache/output por modo de processamento. */
+    private record PriceTriple(String name, BigDecimal input, BigDecimal cachedInput, BigDecimal output) {
+        /** Calcula fallback batch como metade do preço standard quando a página não expõe tabela batch separada. */
+        private PriceTriple half() {
+            return new PriceTriple(
+                    name,
+                    input.divide(BigDecimal.valueOf(2)),
+                    cachedInput.divide(BigDecimal.valueOf(2)),
+                    output.divide(BigDecimal.valueOf(2)));
+        }
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/openai/OpenAiProperties.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/openai/OpenAiProperties.java
@@ -1,13 +1,18 @@
 package com.marketinghub.openai;
 
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.time.Duration;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.util.StringUtils;
 
+/** Responsabilidade: concentrar propriedades de autenticação, timeouts e fontes oficiais da integração OpenAI. */
 @ConfigurationProperties(prefix = "openai")
 public class OpenAiProperties {
 
     private String apiKey;
+    private String apiKeyFile = "/root/infra/openai-token/openai_api_key";
+    private String pricingUrl = "https://platform.openai.com/docs/pricing";
     private String baseUrl = "https://api.openai.com/v1";
     private Duration connectTimeout = Duration.ofSeconds(10);
     private Duration requestTimeout = Duration.ofSeconds(90);
@@ -15,63 +20,98 @@ public class OpenAiProperties {
     private Duration batchTimeout = Duration.ofMinutes(2);
     private String batchCompletionWindow = "24h";
 
+    /** Retorna o token OpenAI configurado diretamente por propriedade ou variável de ambiente. */
     public String getApiKey() {
         return apiKey;
     }
 
+    /** Define o token OpenAI configurado diretamente por propriedade ou variável de ambiente. */
     public void setApiKey(String apiKey) {
         this.apiKey = apiKey;
     }
 
+    /** Retorna o caminho do arquivo seguro usado como fallback para carregar o token OpenAI. */
+    public String getApiKeyFile() {
+        return apiKeyFile;
+    }
+
+    /** Define o caminho do arquivo seguro usado como fallback para carregar o token OpenAI. */
+    public void setApiKeyFile(String apiKeyFile) {
+        this.apiKeyFile = apiKeyFile;
+    }
+
+    /** Retorna a URL oficial consultada para sincronizar preços dos modelos OpenAI. */
+    public String getPricingUrl() {
+        return pricingUrl;
+    }
+
+    /** Define a URL oficial consultada para sincronizar preços dos modelos OpenAI. */
+    public void setPricingUrl(String pricingUrl) {
+        this.pricingUrl = pricingUrl;
+    }
+
+    /** Retorna a URL base da API OpenAI usada nas chamadas autenticadas. */
     public String getBaseUrl() {
         return baseUrl;
     }
 
+    /** Define a URL base da API OpenAI usada nas chamadas autenticadas. */
     public void setBaseUrl(String baseUrl) {
         this.baseUrl = baseUrl;
     }
 
+    /** Retorna o timeout de conexão da integração OpenAI. */
     public Duration getConnectTimeout() {
         return connectTimeout;
     }
 
+    /** Define o timeout de conexão da integração OpenAI. */
     public void setConnectTimeout(Duration connectTimeout) {
         this.connectTimeout = connectTimeout;
     }
 
+    /** Retorna o timeout total de leitura/resposta da integração OpenAI. */
     public Duration getRequestTimeout() {
         return requestTimeout;
     }
 
+    /** Define o timeout total de leitura/resposta da integração OpenAI. */
     public void setRequestTimeout(Duration requestTimeout) {
         this.requestTimeout = requestTimeout;
     }
 
+    /** Retorna o intervalo de consulta para acompanhamento de batches OpenAI. */
     public Duration getBatchPollInterval() {
         return batchPollInterval;
     }
 
+    /** Define o intervalo de consulta para acompanhamento de batches OpenAI. */
     public void setBatchPollInterval(Duration batchPollInterval) {
         this.batchPollInterval = batchPollInterval;
     }
 
+    /** Retorna o timeout máximo para conclusão de batches OpenAI. */
     public Duration getBatchTimeout() {
         return batchTimeout;
     }
 
+    /** Define o timeout máximo para conclusão de batches OpenAI. */
     public void setBatchTimeout(Duration batchTimeout) {
         this.batchTimeout = batchTimeout;
     }
 
+    /** Retorna a janela de conclusão declarada ao criar batches OpenAI. */
     public String getBatchCompletionWindow() {
         return batchCompletionWindow;
     }
 
+    /** Define a janela de conclusão declarada ao criar batches OpenAI. */
     public void setBatchCompletionWindow(String batchCompletionWindow) {
         this.batchCompletionWindow = batchCompletionWindow;
     }
 
+    /** Indica se existe token direto ou arquivo seguro realmente disponível para chamadas autenticadas à OpenAI. */
     public boolean isEnabled() {
-        return StringUtils.hasText(apiKey);
+        return StringUtils.hasText(apiKey) || (StringUtils.hasText(apiKeyFile) && Files.isRegularFile(Path.of(apiKeyFile)));
     }
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/openai/dto/OpenAiModelDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/openai/dto/OpenAiModelDto.java
@@ -1,6 +1,7 @@
 package com.marketinghub.openai.dto;
 
 import java.math.BigDecimal;
+import java.time.Instant;
 
 /** Responsabilidade: transportar dados de modelo OpenAI para as telas administrativas e seletores. */
 public record OpenAiModelDto(
@@ -13,4 +14,6 @@ public record OpenAiModelDto(
         BigDecimal priceInputBatch,
         BigDecimal priceInputCachedBatch,
         BigDecimal priceOutputBatch,
-        boolean acceptsImageInput) {}
+        boolean acceptsImageInput,
+        String pricingSource,
+        Instant lastPricingSyncAt) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/openai/service/OpenAiModelPricingSyncService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/openai/service/OpenAiModelPricingSyncService.java
@@ -1,0 +1,61 @@
+package com.marketinghub.openai.service;
+
+import com.marketinghub.openai.OpenAiModel;
+import com.marketinghub.openai.OpenAiModelPricing;
+import com.marketinghub.openai.OpenAiPricingPageClient;
+import com.marketinghub.repository.jpa.openai.OpenAiModelRepository;
+import java.time.Instant;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/** Responsabilidade: sincronizar no banco os preços oficiais dos modelos OpenAI usados no cálculo financeiro. */
+@Service
+public class OpenAiModelPricingSyncService {
+    private static final Logger log = LoggerFactory.getLogger(OpenAiModelPricingSyncService.class);
+    private static final String PRICING_SOURCE = "https://platform.openai.com/docs/pricing";
+
+    private final OpenAiPricingPageClient pricingPageClient;
+    private final OpenAiModelRepository repository;
+
+    /** Inicializa a sincronização com cliente da fonte oficial e repositório centralizado dos modelos. */
+    public OpenAiModelPricingSyncService(OpenAiPricingPageClient pricingPageClient, OpenAiModelRepository repository) {
+        this.pricingPageClient = pricingPageClient;
+        this.repository = repository;
+    }
+
+    /** Consulta a fonte oficial e persiste os preços atuais dos modelos encontrados. */
+    @Transactional
+    public int syncOfficialPricing() {
+        List<OpenAiModelPricing> prices = pricingPageClient.fetchTextModelPricing();
+        Instant syncedAt = Instant.now();
+        int updated = 0;
+        for (OpenAiModelPricing price : prices) {
+            OpenAiModel model = repository.findByCode(price.code()).orElseGet(OpenAiModel::new);
+            applyPrice(model, price, syncedAt);
+            repository.save(model);
+            updated++;
+        }
+        log.info(
+                "Preços oficiais OpenAI sincronizados; operation=openai-pricing-sync modelsUpdated={} source={}",
+                updated,
+                PRICING_SOURCE);
+        return updated;
+    }
+
+    /** Aplica preços e metadados de sincronização na entidade persistida. */
+    private void applyPrice(OpenAiModel model, OpenAiModelPricing price, Instant syncedAt) {
+        model.setName(price.name());
+        model.setCode(price.code());
+        model.setPriceInputStandard(price.priceInputStandard());
+        model.setPriceInputCachedStandard(price.priceInputCachedStandard());
+        model.setPriceOutputStandard(price.priceOutputStandard());
+        model.setPriceInputBatch(price.priceInputBatch());
+        model.setPriceInputCachedBatch(price.priceInputCachedBatch());
+        model.setPriceOutputBatch(price.priceOutputBatch());
+        model.setPricingSource(PRICING_SOURCE);
+        model.setLastPricingSyncAt(syncedAt);
+    }
+}

--- a/backend/ads-service/src/main/resources/application.properties
+++ b/backend/ads-service/src/main/resources/application.properties
@@ -127,6 +127,8 @@ lead-portal.worker.processing-guard.initial-delay=${LEAD_PORTAL_PROCESSING_GUARD
 
 # OpenAI batch generation
 openai.api-key=${OPENAI_API_KEY:}
+openai.api-key-file=${OPENAI_API_KEY_FILE:/root/infra/openai-token/openai_api_key}
+openai.pricing-url=${OPENAI_PRICING_URL:https://platform.openai.com/docs/pricing}
 openai.base-url=${OPENAI_BASE_URL:https://api.openai.com/v1}
 openai.connect-timeout=${OPENAI_CONNECT_TIMEOUT:PT10S}
 openai.request-timeout=${OPENAI_REQUEST_TIMEOUT:PT90S}

--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-04-openai-model-pricing-sync-metadata.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-04-openai-model-pricing-sync-metadata.yaml
@@ -1,0 +1,26 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-06-04-openai-model-pricing-sync-metadata
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - onError: HALT
+        - dbms:
+            type: mysql
+        - not:
+            columnExists:
+              tableName: openai_model
+              columnName: last_pricing_sync_at
+      changes:
+        - sql:
+            dbms: mysql
+            splitStatements: true
+            stripComments: true
+            sql: >
+              ALTER TABLE openai_model
+              ADD COLUMN pricing_source VARCHAR(255) NULL
+              COMMENT 'Fonte oficial usada na ultima sincronizacao automatica de precos'
+              AFTER accepts_image_input,
+              ADD COLUMN last_pricing_sync_at DATETIME(6) NULL
+              COMMENT 'Data e hora da ultima sincronizacao automatica de precos'
+              AFTER pricing_source;

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -608,6 +608,10 @@ databaseChangeLog:
       relativeToChangelogFile: true
 
   - include:
+      file: changesets/2026-06-04-openai-model-pricing-sync-metadata.yaml
+      relativeToChangelogFile: true
+
+  - include:
       file: V2030_10_20__hypothesis_model_and_cost.sql
       relativeToChangelogFile: true
 

--- a/backend/ads-service/src/test/java/com/marketinghub/openai/OpenAiApiKeyResolverTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/openai/OpenAiApiKeyResolverTest.java
@@ -1,0 +1,39 @@
+package com.marketinghub.openai;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.io.TempDir;
+
+class OpenAiApiKeyResolverTest {
+    @TempDir
+    Path tempDir;
+
+    @Test
+    void shouldPreferDirectApiKeyOverFile() throws Exception {
+        Path tokenFile = tempDir.resolve("openai_api_key");
+        Files.writeString(tokenFile, "file-token\n");
+        OpenAiProperties properties = new OpenAiProperties();
+        properties.setApiKey("direct-token");
+        properties.setApiKeyFile(tokenFile.toString());
+
+        String token = new OpenAiApiKeyResolver().resolve(properties);
+
+        assertThat(token).isEqualTo("direct-token");
+    }
+
+    @Test
+    void shouldReadApiKeyFromConfiguredFileWhenDirectKeyIsBlank() throws Exception {
+        Path tokenFile = tempDir.resolve("openai_api_key");
+        Files.writeString(tokenFile, "file-token\n");
+        OpenAiProperties properties = new OpenAiProperties();
+        properties.setApiKey("");
+        properties.setApiKeyFile(tokenFile.toString());
+
+        String token = new OpenAiApiKeyResolver().resolve(properties);
+
+        assertThat(token).isEqualTo("file-token");
+    }
+}

--- a/backend/ads-service/src/test/java/com/marketinghub/openai/OpenAiPricingPageClientTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/openai/OpenAiPricingPageClientTest.java
@@ -1,0 +1,65 @@
+package com.marketinghub.openai;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.math.BigDecimal;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.reactive.function.client.WebClient;
+
+class OpenAiPricingPageClientTest {
+
+    @Test
+    void shouldParseStandardAndBatchPricesFromOfficialPricingTables() {
+        OpenAiProperties properties = new OpenAiProperties();
+        OpenAiPricingPageClient client = new OpenAiPricingPageClient(WebClient.builder(), properties);
+
+        List<OpenAiModelPricing> prices = client.parseTextModelPricing("""
+                <html><body>
+                  <table>
+                    <thead><tr><th>Model</th><th>Input</th><th>Cached input</th><th>Output</th></tr></thead>
+                    <tbody>
+                      <tr><td>gpt-5.5 (&lt;272K context length)</td><td>$5.00</td><td>$0.50</td><td>$30.00</td></tr>
+                      <tr><td>gpt-image-1</td><td>$5.00</td><td>$1.25</td><td>-</td></tr>
+                    </tbody>
+                  </table>
+                  <table>
+                    <thead><tr><th>Model</th><th>Input</th><th>Cached input</th><th>Output</th></tr></thead>
+                    <tbody>
+                      <tr><td>gpt-5.5 (&lt;272K context length)</td><td>$2.50</td><td>$0.25</td><td>$15.00</td></tr>
+                    </tbody>
+                  </table>
+                </body></html>
+                """);
+
+        assertThat(prices).hasSize(1);
+        OpenAiModelPricing pricing = prices.get(0);
+        assertThat(pricing.code()).isEqualTo("gpt-5.5");
+        assertThat(pricing.priceInputStandard()).isEqualByComparingTo(new BigDecimal("5.00"));
+        assertThat(pricing.priceInputCachedStandard()).isEqualByComparingTo(new BigDecimal("0.50"));
+        assertThat(pricing.priceOutputStandard()).isEqualByComparingTo(new BigDecimal("30.00"));
+        assertThat(pricing.priceInputBatch()).isEqualByComparingTo(new BigDecimal("2.50"));
+        assertThat(pricing.priceInputCachedBatch()).isEqualByComparingTo(new BigDecimal("0.25"));
+        assertThat(pricing.priceOutputBatch()).isEqualByComparingTo(new BigDecimal("15.00"));
+    }
+
+    @Test
+    void shouldUseHalfStandardAsBatchFallbackWhenBatchTableIsMissing() {
+        OpenAiProperties properties = new OpenAiProperties();
+        OpenAiPricingPageClient client = new OpenAiPricingPageClient(WebClient.builder(), properties);
+
+        List<OpenAiModelPricing> prices = client.parseTextModelPricing("""
+                <table>
+                  <thead><tr><th>Model</th><th>Input</th><th>Cached input</th><th>Output</th></tr></thead>
+                  <tbody><tr><td>o4-mini</td><td>$1.10</td><td>$0.275</td><td>$4.40</td></tr></tbody>
+                </table>
+                """);
+
+        assertThat(prices).hasSize(1);
+        OpenAiModelPricing pricing = prices.get(0);
+        assertThat(pricing.code()).isEqualTo("o4-mini");
+        assertThat(pricing.priceInputBatch()).isEqualByComparingTo(new BigDecimal("0.55"));
+        assertThat(pricing.priceInputCachedBatch()).isEqualByComparingTo(new BigDecimal("0.1375"));
+        assertThat(pricing.priceOutputBatch()).isEqualByComparingTo(new BigDecimal("2.20"));
+    }
+}

--- a/backend/ads-service/src/test/java/com/marketinghub/openai/service/OpenAiModelPricingSyncServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/openai/service/OpenAiModelPricingSyncServiceTest.java
@@ -1,0 +1,45 @@
+package com.marketinghub.openai.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.marketinghub.openai.OpenAiModel;
+import com.marketinghub.openai.OpenAiModelPricing;
+import com.marketinghub.openai.OpenAiPricingPageClient;
+import com.marketinghub.repository.jpa.openai.OpenAiModelRepository;
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+class OpenAiModelPricingSyncServiceTest {
+
+    @Test
+    void shouldUpsertOfficialPricingByModelCode() {
+        OpenAiPricingPageClient client = mock(OpenAiPricingPageClient.class);
+        OpenAiModelRepository repository = mock(OpenAiModelRepository.class);
+        OpenAiModel existing = new OpenAiModel();
+        when(client.fetchTextModelPricing()).thenReturn(List.of(new OpenAiModelPricing(
+                "gpt-5.5",
+                "gpt-5.5",
+                new BigDecimal("5.00"),
+                new BigDecimal("0.50"),
+                new BigDecimal("30.00"),
+                new BigDecimal("2.50"),
+                new BigDecimal("0.25"),
+                new BigDecimal("15.00"))));
+        when(repository.findByCode("gpt-5.5")).thenReturn(Optional.of(existing));
+
+        int updated = new OpenAiModelPricingSyncService(client, repository).syncOfficialPricing();
+
+        assertThat(updated).isEqualTo(1);
+        assertThat(existing.getCode()).isEqualTo("gpt-5.5");
+        assertThat(existing.getPriceInputStandard()).isEqualByComparingTo(new BigDecimal("5.00"));
+        assertThat(existing.getPriceOutputBatch()).isEqualByComparingTo(new BigDecimal("15.00"));
+        assertThat(existing.getPricingSource()).isEqualTo("https://platform.openai.com/docs/pricing");
+        assertThat(existing.getLastPricingSyncAt()).isNotNull();
+        verify(repository).save(existing);
+    }
+}

--- a/docs/canonical/openai-informacoes-tratadas-canon.v1.md
+++ b/docs/canonical/openai-informacoes-tratadas-canon.v1.md
@@ -416,7 +416,34 @@ A tabela `ai_worker_generation` armazena registros genéricos de geração por I
 | PK | `id` | Identificação do registro. |
 | Índice | `domain`, `created_at DESC` | Consulta por domínio e recência. |
 
-## 10. Separação canônica por tipo de dado persistido
+## 10. Tabela `openai_model`
+
+A tabela `openai_model` mantém o catálogo financeiro dos modelos OpenAI usado para estimar custo antes/depois das chamadas de IA. Os preços são valores oficiais por 1 milhão de tokens e devem ser sincronizados automaticamente todos os dias às 04:00 pelo backend, usando a página oficial de preços da OpenAI como fonte.
+
+| Coluna | Tipo lógico | Natureza do dado de IA | Finalidade no modelo |
+|---|---|---|---|
+| `id` | `BIGINT` | chave | Identificador do modelo no catálogo interno. |
+| `name` | `VARCHAR(255)` | metadado técnico | Nome exibido do modelo. |
+| `code` | `VARCHAR(128)` | metadado técnico | Código oficial do modelo usado em chamadas OpenAI. |
+| `price_input_standard` | `DECIMAL(12,5)` | telemetria financeira | Preço standard de entrada por 1 milhão de tokens. |
+| `price_input_cached_standard` | `DECIMAL(12,5)` | telemetria financeira | Preço standard de entrada em cache por 1 milhão de tokens. |
+| `price_output_standard` | `DECIMAL(12,5)` | telemetria financeira | Preço standard de saída por 1 milhão de tokens. |
+| `price_input_batch` | `DECIMAL(12,5)` | telemetria financeira | Preço batch de entrada por 1 milhão de tokens. |
+| `price_input_cached_batch` | `DECIMAL(12,5)` | telemetria financeira | Preço batch de entrada em cache por 1 milhão de tokens. |
+| `price_output_batch` | `DECIMAL(12,5)` | telemetria financeira | Preço batch de saída por 1 milhão de tokens. |
+| `accepts_image_input` | `BOOLEAN` | capacidade operacional | Indica se o modelo aceita imagem como entrada. |
+| `pricing_source` | `VARCHAR(255)` | auditoria | Fonte oficial usada na última sincronização automática de preços. |
+| `last_pricing_sync_at` | `DATETIME(6)` | auditoria | Data/hora da última sincronização automática de preços. |
+| `created_at`, `updated_at` | `DATETIME` | auditoria | Datas de criação e atualização do cadastro. |
+
+### 10.1 Regras operacionais do catálogo financeiro
+
+1. A sincronização automática deve atualizar modelos existentes por `code` e criar novos modelos textuais/reasoning quando aparecerem na fonte oficial.
+2. O backend deve ler o token OpenAI de `OPENAI_API_KEY` ou, quando ausente, do arquivo seguro `/root/infra/openai-token/openai_api_key`.
+3. Quando a fonte oficial não publicar preço de cache, persistir `0` para manter o contrato numérico explícito e evitar JSON dentro de JSON ou metadado ambíguo.
+4. A rotina deve registrar logs de sucesso e logs com stack trace completo em caso de falha, sem expor o token.
+
+## 11. Separação canônica por tipo de dado persistido
 
 | Tipo de dado | Colunas/tabelas principais | Observação de modelo |
 |---|---|---|
@@ -430,7 +457,7 @@ A tabela `ai_worker_generation` armazena registros genéricos de geração por I
 | Estado operacional | `status`, `stage`, `worker_id`, `error_message`, `started_at`, `finished_at` | Controle de fila, execução e diagnóstico. |
 | Vínculo de origem | `hypothesis_id`, `experiment_id`, `section`, `planning_item_key`, `reference_id`, `domain` | Permite rastrear a que objeto a geração pertence. |
 
-## 11. Cardinalidades canônicas
+## 12. Cardinalidades canônicas
 
 | Relação | Cardinalidade | Significado no modelo |
 |---|---|---|
@@ -441,7 +468,7 @@ A tabela `ai_worker_generation` armazena registros genéricos de geração por I
 | `experiment -> framework_image_generation_job` | 1:N | Um experimento pode ter vários jobs de imagem. |
 | `ai_worker_generation.domain/reference_id -> objeto de domínio` | N:1 lógico | Vínculo genérico, sem FK física canônica obrigatória. |
 
-## 12. Regras canônicas de localização de dados
+## 13. Regras canônicas de localização de dados
 
 1. **Hipótese consolidada** fica em `hypothesis`.
 2. **Histórico de geração/refinamento de framework da hipótese** fica em `hypothesis_framework_generation_job`.
@@ -452,9 +479,10 @@ A tabela `ai_worker_generation` armazena registros genéricos de geração por I
 7. **Resposta bruta do modelo** deve ficar em coluna `raw_response` de tabela de job/auditoria, não em coluna de artefato consolidado.
 8. **Conteúdo normalizado de uma chamada** deve ficar em `response_content` quando existir tabela de job especializada.
 9. **Artefato funcional atual do domínio** deve ficar no campo consolidado do objeto de domínio (`hypothesis` ou `experiment`).
-10. **Modelo, tokens, custo, worker, status e erro** são metadados técnicos e pertencem às colunas de auditoria/job, exceto campos agregados já existentes em `hypothesis` e `experiment`.
+10. **Catálogo financeiro de modelos OpenAI** deve ficar em `openai_model`, com preços por 1 milhão de tokens, fonte e data da última sincronização.
+11. **Modelo, tokens, custo, worker, status e erro** são metadados técnicos e pertencem às colunas de auditoria/job, exceto campos agregados já existentes em `hypothesis` e `experiment`.
 
-## 13. Documentos relacionados de modelo de dados
+## 14. Documentos relacionados de modelo de dados
 
 - `docs/modelo-dados-hipotese.md`
 - `docs/modelo-dados-experimento.md`


### PR DESCRIPTION
### Motivation

- Keep the internal `openai_model` catalog in sync with official OpenAI published prices so cost calculations use an authoritative, up-to-date source. 

### Description

- Added a lightweight HTML pricing parser and client `OpenAiPricingPageClient` that fetches and parses the OpenAI pricing page (uses `Jsoup`) and produces `OpenAiModelPricing` records. 
- Implemented `OpenAiApiKeyResolver` and extended `OpenAiProperties` to support reading the OpenAI token from `OPENAI_API_KEY` or a host file (default `/root/infra/openai-token/openai_api_key`), and wired the resolver into `OpenAiConfiguration` so `openAiWebClient` uses the resolved token. 
- Added `OpenAiModelPricingSyncService` to upsert parsed prices into `openai_model` and a scheduled `OpenAiModelPricingScheduler` with `@Scheduled(cron = "0 0 4 * * *", zone = "America/Sao_Paulo")` to run daily at 04:00 (São Paulo) and update `pricing_source` / `last_pricing_sync_at`. 
- Extended `OpenAiModel` + DTOs with `pricingSource` and `lastPricingSyncAt`, added a Liquibase changeset `changesets/2026-06-04-openai-model-pricing-sync-metadata.yaml` and updated `db.changelog-master.yaml`, and added `openai.api-key-file` / `openai.pricing-url` properties to `application.properties`. 

### Testing

- Added unit tests `OpenAiPricingPageClientTest`, `OpenAiApiKeyResolverTest` and `OpenAiModelPricingSyncServiceTest` and ran them; they passed. 
- Ran the module test suite with Maven (`../mvnw test` in `backend/ads-service`) which executed the new tests along with the service tests and completed with `BUILD SUCCESS` and all automated tests passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a21e790dda8832187a7da96c35064a6)