### PR TITLE
Quality Review: use only htmlGeraLanding as canonical HTML source

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/openai/core/qualityreview/QualityReviewBackendClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/openai/core/qualityreview/QualityReviewBackendClient.java
@@ -85,26 +85,29 @@ public class QualityReviewBackendClient implements StageBackendPort<QualityRevie
         return new StageExecution<>(idJob, experimentId, stageCode, STATUS_STARTED, asInstant(item.get("executionRequestedAt")), input);
     }
 
-    /** Monta o contexto textual enviado ao modelo com os artefatos fonte usados para diagnosticar o que ficou ruim. */
+    /** Monta o contexto textual enviado ao modelo usando somente o HTML final consolidado do GeraLanding. */
     private Map<String, Object> buildPromptDataFromPending(Map<String, Object> pending) {
         Map<String, Object> experiment = asMap(pending.get("experiment"));
         Map<String, Object> payload = new LinkedHashMap<>();
-        payload.put("experimentId", experiment.get("id"));
-        payload.put("experimentName", experiment.get("name"));
-        payload.put("landingPageWireframe", experiment.get("landingPageWireframe"));
-        payload.put("landingPageDesignPreset", experiment.get("landingPageDesignPreset"));
-        payload.put("htmlGeraLanding", experiment.get("htmlGeraLanding"));
-        payload.put("landingPageHtml", experiment.get("landingPageHtml"));
+        putIfPresent(payload, "htmlGeraLanding", resolveHtmlGeraLanding(experiment));
         return payload;
     }
 
-    /** Resolve o HTML final que deve ser renderizado em browser para gerar screenshots do Quality Review. */
+    /** Resolve exclusivamente o htmlGeraLanding usado como fonte visual canônica do Quality Review. */
     private String resolveLandingHtml(Map<String, Object> promptData) {
-        String htmlGeraLanding = asString(promptData.get("htmlGeraLanding"));
-        if (htmlGeraLanding != null && !htmlGeraLanding.isBlank()) {
-            return htmlGeraLanding;
+        return asString(promptData.get("htmlGeraLanding"));
+    }
+
+    /** Resolve o campo canônico htmlGeraLanding recebido do backend sem usar fallback legado de landingPageHtml. */
+    private String resolveHtmlGeraLanding(Map<String, Object> experiment) {
+        return asString(experiment.get("htmlGeraLanding"));
+    }
+
+    /** Adiciona ao payload somente campos com valor real para preservar compatibilidade com Map.copyOf. */
+    private void putIfPresent(Map<String, Object> payload, String key, Object value) {
+        if (value != null) {
+            payload.put(key, value);
         }
-        return asString(promptData.get("landingPageHtml"));
     }
 
     /** Envia o callback de resposta ou falha da revisão visual ao backend. */

--- a/ai-worker/src/main/resources/prompts/geralanding/landing-page-quality-review.md
+++ b/ai-worker/src/main/resources/prompts/geralanding/landing-page-quality-review.md
@@ -17,21 +17,9 @@ A landing do GeraLanding não deve apenas parecer bonita. Ela precisa cumprir um
 
 Use as imagens como evidência principal. Avalie o que aparece na tela, não o que provavelmente estava no briefing. Não recompense intenção invisível.
 
-Além dos screenshots, você receberá três arquivos fonte da execução: o JSON da etapa `landing-page-wireframe`, o JSON da etapa `landing-page-design-preset` e o HTML final `htmlGeraLanding`. Use esses arquivos para identificar **o que ficou ruim nos próprios arquivos enviados** e separar causa-raiz de sintoma: problema estrutural do wireframe, problema de preset visual ou problema de montagem/renderização do HTML.
+Além dos screenshots, você receberá somente o HTML final consolidado `htmlGeraLanding`. Use esse HTML para identificar **o que ficou ruim no artefato final publicado ou publicável**, sem depender de briefing, wireframe, preset visual ou fallback legado.
 
-## Arquivos enviados para avaliação de causa-raiz
-
-### JSON da etapa wireframe (`landingPageWireframe`)
-
-```json
-{{landingPageWireframe}}
-```
-
-### JSON da etapa preset design (`landingPageDesignPreset`)
-
-```json
-{{landingPageDesignPreset}}
-```
+## Arquivo enviado para avaliação de causa-raiz
 
 ### HTML final do GeraLanding (`htmlGeraLanding`)
 
@@ -45,7 +33,7 @@ Além dos screenshots, você receberá três arquivos fonte da execução: o JSO
 {{renderedLandingScreenshots}}
 ```
 
-Ao preencher `blockingIssues` e `recommendedRegeneration`, cite o arquivo/etapa que provavelmente originou a falha quando a evidência permitir. Se o HTML renderizado está ruim por copiar uma decisão ruim do wireframe ou do preset, recomende regenerar a etapa de origem, não apenas o HTML.
+Ao preencher `blockingIssues` e `recommendedRegeneration`, cite problemas observáveis no `htmlGeraLanding` e nos screenshots renderizados. Se a evidência visual indicar falha estrutural, textual ou visual, recomende a regeneração necessária sem assumir dados que não estejam presentes no HTML final.
 
 ## O que a landing precisa provar
 

--- a/ai-worker/src/test/java/com/marketinghub/worker/openai/core/qualityreview/QualityReviewBackendClientTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/openai/core/qualityreview/QualityReviewBackendClientTest.java
@@ -32,9 +32,9 @@ class QualityReviewBackendClientTest {
         server.shutdown();
     }
 
-    /** Deve expor o HTML final para que o prompt builder gere screenshots renderizados em browser. */
+    /** Deve expor somente o htmlGeraLanding para que o prompt builder gere screenshots renderizados em browser. */
     @Test
-    void listPendingShouldExposeFinalLandingHtmlForScreenshotRendering() {
+    void listPendingShouldExposeOnlyHtmlGeraLandingForScreenshotRendering() {
         server.enqueue(new MockResponse()
                 .setHeader("Content-Type", "application/json")
                 .setBody("""
@@ -68,14 +68,44 @@ class QualityReviewBackendClientTest {
         assertThat(pending.getFirst().input().landingHtml())
                 .isEqualTo("<!doctype html><html><body><h1>Landing final</h1></body></html>");
         assertThat(pending.getFirst().input().promptData())
-                .containsEntry("experimentId", 36)
-                .containsEntry("experimentName", "Experimento visual")
-                .containsKeys("landingPageWireframe", "landingPageDesignPreset", "htmlGeraLanding")
-                .doesNotContainKeys("CASE_DATA_BLOCK", "landingPageImageAssets");
-        assertThat(pending.getFirst().input().promptData().get("landingPageWireframe").toString())
-                .contains("sectionOrder");
-        assertThat(pending.getFirst().input().promptData().get("landingPageDesignPreset").toString())
-                .contains("premium");
+                .containsOnlyKeys("htmlGeraLanding")
+                .containsEntry("htmlGeraLanding", "<!doctype html><html><body><h1>Landing final</h1></body></html>")
+                .doesNotContainKeys("experimentId", "experimentName", "landingPageWireframe", "landingPageDesignPreset", "landingPageHtml", "CASE_DATA_BLOCK", "landingPageImageAssets");
+    }
+
+    /** Deve ignorar landingPageHtml nulo porque o Quality Review usa somente htmlGeraLanding. */
+    @Test
+    void listPendingShouldIgnoreNullLegacyLandingPageHtml() {
+        server.enqueue(new MockResponse()
+                .setHeader("Content-Type", "application/json")
+                .setBody("""
+                        [
+                          {
+                            "experimentId": 37,
+                            "jobid": "job-quality-2",
+                            "stageCode": "landing-page-quality-review",
+                            "executionRequestedAt": "2026-06-04T22:32:02Z",
+                            "experiment": {
+                              "id": 37,
+                              "htmlGeraLanding": "<!doctype html><html><body><h1>HTML canônico</h1></body></html>",
+                              "landingPageHtml": null
+                            }
+                          }
+                        ]
+                        """));
+        QualityReviewBackendClient client = new QualityReviewBackendClient(
+                WebClient.builder(),
+                properties(),
+                objectMapper);
+
+        List<StageExecution<QualityReviewInput>> pending = client.listPending(5);
+
+        assertThat(pending).hasSize(1);
+        assertThat(pending.getFirst().input().landingHtml())
+                .isEqualTo("<!doctype html><html><body><h1>HTML canônico</h1></body></html>");
+        assertThat(pending.getFirst().input().promptData())
+                .containsOnlyKeys("htmlGeraLanding")
+                .doesNotContainKeys("landingPageHtml");
     }
 
     /** Monta propriedades mínimas para o client quality-review usado no teste. */

--- a/ai-worker/src/test/java/com/marketinghub/worker/openai/core/qualityreview/QualityReviewPromptBuilderTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/openai/core/qualityreview/QualityReviewPromptBuilderTest.java
@@ -44,12 +44,7 @@ class QualityReviewPromptBuilderTest {
                         36L,
                         "landing-page-quality-review",
                         "job-quality-1",
-                        Map.of(
-                                "landingPageWireframe", Map.of("sectionOrder", List.of(Map.of("sectionId", "hero", "purpose", "Promessa"))),
-                                "landingPageDesignPreset", Map.of("presetId", "premium", "sectionPresets", List.of(Map.of("sectionId", "hero"))),
-                                "htmlGeraLanding", "<!doctype html><html><body>Landing</body></html>",
-                                "CASE_DATA_BLOCK", "[CASE_DATA_BEGIN]\nlandingPageImageAssets: https://cdn.example.com/asset-hero.jpg\n[CASE_DATA_END]",
-                                "landingPageImageAssets", Map.of("sourceUrl", "https://cdn.example.com/asset-hero.jpg")),
+                        Map.of("htmlGeraLanding", "<!doctype html><html><body>Landing</body></html>"),
                         "<!doctype html><html><body>Landing</body></html>"));
 
         OpenAiRequest request = builder.build(execution);
@@ -72,13 +67,13 @@ class QualityReviewPromptBuilderTest {
                 .extracting(item -> item.get("detail"))
                 .containsOnly("original");
         assertThat(request.prompt())
-                .contains("JSON da etapa wireframe")
-                .contains("sectionOrder")
-                .contains("JSON da etapa preset design")
-                .contains("premium")
                 .contains("HTML final do GeraLanding")
                 .contains("<!doctype html><html><body>Landing</body></html>")
                 .contains("https://cdn.example.com/screens/job-quality-1-desktop.jpg")
+                .doesNotContain("JSON da etapa wireframe")
+                .doesNotContain("JSON da etapa preset design")
+                .doesNotContain("landingPageWireframe")
+                .doesNotContain("landingPageDesignPreset")
                 .doesNotContain("CASE_DATA_BEGIN")
                 .doesNotContain("https://cdn.example.com/asset-hero.jpg");
         assertThat(body.get("model")).isEqualTo("gpt-5.5");

--- a/docs/canonical/procedimento-experimento-canon.v1.md
+++ b/docs/canonical/procedimento-experimento-canon.v1.md
@@ -113,7 +113,16 @@ Regras:
 2. Enriquecimentos transversais (ex.: injeção de URLs finais de imagem) devem ocorrer em serviço auxiliar dedicado e orquestrados pelo serviço da etapa, sem transferir a responsabilidade de etapa entre processadores.
 3. A etapa de geração de imagens deve persistir o manifesto consolidado `experiment.landing_page_image_assets`; a etapa de preset design deve consumir esse manifesto para substituir placeholders/URLs provisórias por URLs finais antes de persistir o HTML.
 
-### 5.5 Worker AI — divisão equivalente por etapa (obrigatória)
+### 5.5 Quality Review visual — fonte canônica do prompt
+
+A etapa `landing-page-quality-review` deve avaliar o artefato final publicável com base somente em:
+
+1. `experiment.html_geralanding`, exposto ao Worker AI como `htmlGeraLanding`;
+2. screenshots renderizados a partir desse mesmo HTML.
+
+O prompt textual do Quality Review não deve receber `experiment.landing_page_html` como fallback legado, nem JSONs intermediários de wireframe, copy, image planning, image generation ou design preset. A causa-raiz apontada pelo Quality Review deve ser inferida apenas a partir do HTML final e da evidência visual renderizada, preservando o foco no artefato que será publicado e evitando falhas quando `landing_page_html` ainda estiver nulo antes da aprovação/publicação.
+
+### 5.6 Worker AI — divisão equivalente por etapa (obrigatória)
 
 No `ai-worker`, a mesma divisão por etapa deve ser mantida para evitar acoplamento entre execução,
 prompt e schema. A arquitetura canônica vigente para qualquer etapa de landing no Worker AI é o núcleo

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -3485,3 +3485,11 @@
   - backend/ads-service/src/main/java/com/marketinghub/pipeline/PipelineStageConfig.java
   - backend/ads-service/src/main/java/com/marketinghub/pipeline/service/PipelinePersistentContractSynchronizer.java
   - backend/ads-service/src/test/java/com/marketinghub/pipeline/service/PipelineServiceTest.java
+
+## 2026-06-04 — Quality Review usa somente html_geralanding
+
+- solicitação: o prompt da etapa `landing-page-quality-review` deve considerar apenas o HTML consolidado `html_geralanding`, sem usar `landing_page_html` legado, wireframe ou preset design como contexto textual.
+- causa-raiz/objetivo: o Quality Review avalia o artefato final publicável e o fallback `landing_page_html` pode estar nulo por contrato; incluir campos nulos ou fontes intermediárias derrubava o worker antes do despacho e confundia a análise de qualidade do HTML final.
+- correção aplicada: o Worker AI passou a montar `promptData` da revisão visual somente com `htmlGeraLanding`, ignorando `landingPageHtml` e artefatos intermediários; o prompt markdown foi simplificado para orientar avaliação apenas pelo HTML final e screenshots renderizados.
+- cânone atualizado: `docs/canonical/procedimento-experimento-canon.v1.md` registra que o Quality Review visual usa exclusivamente `experiment.html_geralanding` como HTML fonte.
+- validação automatizada: testes do `QualityReviewBackendClient` cobrem ausência de fallback legado e `landingPageHtml` nulo; teste do `QualityReviewPromptBuilder` garante que o prompt não inclui wireframe/preset.


### PR DESCRIPTION
### Motivation
- The visual Quality Review must evaluate the final publishable artifact and should rely exclusively on the consolidated HTML (`htmlGeraLanding`) rather than legacy fallbacks or intermediate JSONs, because `landing_page_html` can be null and intermediate artifacts can confuse or break the worker.

### Description
- `QualityReviewBackendClient` now builds `promptData` containing only `htmlGeraLanding` and ignores legacy `landingPageHtml`, wireframe and design preset fields, and adds helper methods `resolveHtmlGeraLanding` and `putIfPresent` to preserve compatibility with `Map.copyOf`.
- `resolveLandingHtml` was simplified to return `htmlGeraLanding` from the prompt data and prompt-building flow no longer uses fallback legacy fields.
- The prompt template `prompts/geralanding/landing-page-quality-review.md` was rewritten to instruct the model to use only the final consolidated HTML (`htmlGeraLanding`) and rendered screenshots as evidence for root-cause analysis.
- Tests were updated: `QualityReviewBackendClientTest` assertions now expect only `htmlGeraLanding` in `promptData` and added a case verifying `landingPageHtml` null is ignored; `QualityReviewPromptBuilderTest` was adjusted to ensure screenshots are used as vision inputs and that wireframe/preset/payloads are not included in the prompt or images.
- Documentation was updated in `docs/canonical/procedimento-experimento-canon.v1.md` and `docs/registros/experimentos.md` to record the canonical behavior that the Quality Review uses exclusively `experiment.html_geralanding`.

### Testing
- Ran updated unit tests `QualityReviewBackendClientTest` and `QualityReviewPromptBuilderTest`, which assert the client exposes only `htmlGeraLanding` and the prompt builder excludes legacy/intermediate artifacts, and they passed.
- The modified test suite changes were executed as part of the CI unit test run and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a220b06fba883219fb10b339a0a1eba)