### PR TITLE
Add collected-reference URL summary endpoint, service and UI for unique URL coverage

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/dto/MoisSalesLibraryDtos.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/dto/MoisSalesLibraryDtos.java
@@ -242,6 +242,42 @@ public final class MoisSalesLibraryDtos {
     ) {
     }
 
+
+    /**
+     * Representa a cobertura de URLs únicas vindas da origem bruta mois_collected_reference.
+     */
+    public record CollectedReferenceUrlSummaryResponse(
+            String workspaceId,
+            long uniqueEffectiveUrls,
+            long explicitSalesPageUrls,
+            long fallbackProductUrls,
+            long operationalLibraryUrls,
+            long missingFromOperationalLibrary,
+            List<CollectedReferenceUrlSourceBreakdown> bySource,
+            List<CollectedReferenceUrlTypeBreakdown> byUrlType
+    ) {
+    }
+
+    /**
+     * Representa o desdobramento de URLs únicas coletadas por marketplace/origem.
+     */
+    public record CollectedReferenceUrlSourceBreakdown(
+            String source,
+            long uniqueEffectiveUrls,
+            long operationalLibraryUrls,
+            long missingFromOperationalLibrary
+    ) {
+    }
+
+    /**
+     * Representa o desdobramento de URLs únicas coletadas por tipo de URL usada.
+     */
+    public record CollectedReferenceUrlTypeBreakdown(
+            String urlType,
+            long uniqueUrls
+    ) {
+    }
+
     /**
      * Representa uma execução auditável da página no histórico consolidado.
      */

--- a/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryService.java
@@ -2,18 +2,23 @@ package com.marketinghub.mois.bibliotecapaginavenda.worker.v1.service;
 
 import com.marketinghub.mois.bibliotecapaginavenda.worker.v1.dto.MoisSalesLibraryDtos;
 import java.math.BigDecimal;
+import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
-import java.net.URI;
 import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.time.Instant;
 import java.util.ArrayList;
-import java.util.List;
+import java.util.Comparator;
+import java.util.HashSet;
 import java.util.HexFormat;
+import java.util.LinkedHashMap;
+import java.util.List;
 import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -337,6 +342,92 @@ public class MoisSalesLibraryService {
                         toInstant(rs.getTimestamp("first_seen_at")), toInstant(rs.getTimestamp("last_captured_at")),
                         toInstant(rs.getTimestamp("updated_at"))), workspaceId, normalizedPageSize, offset);
         return new MoisSalesLibraryDtos.SalesLibraryEntryPageResponse(normalizedPage, normalizedPageSize, total == null ? 0 : total, items);
+    }
+
+    /**
+     * Resume URLs únicas de páginas de venda vindas da origem bruta mois_collected_reference.
+     */
+    public MoisSalesLibraryDtos.CollectedReferenceUrlSummaryResponse summarizeCollectedReferenceUrls(String workspaceId) {
+        List<CollectedReferenceUrlCandidate> collectedUrls = jdbcTemplate.query("""
+                        SELECT DISTINCT source, url_source, effective_url
+                        FROM (
+                          SELECT source,
+                                 CASE
+                                   WHEN sales_page_url IS NOT NULL AND TRIM(sales_page_url) <> '' THEN 'SALES_PAGE_URL'
+                                   WHEN product_url IS NOT NULL AND TRIM(product_url) <> '' THEN 'PRODUCT_URL'
+                                   WHEN url IS NOT NULL AND TRIM(url) <> '' THEN 'URL'
+                                   ELSE 'NONE'
+                                 END AS url_source,
+                                 COALESCE(NULLIF(TRIM(sales_page_url), ''), NULLIF(TRIM(product_url), ''), NULLIF(TRIM(url), '')) AS effective_url
+                          FROM mois_collected_reference
+                          WHERE workspace_id = ?
+                        ) collected
+                        WHERE effective_url IS NOT NULL
+                        """,
+                (rs, rowNum) -> new CollectedReferenceUrlCandidate(
+                        normalizeSource(rs.getString("source")),
+                        rs.getString("url_source"),
+                        canonicalize(rs.getString("effective_url"))),
+                workspaceId);
+
+        Set<String> operationalUrls = new HashSet<>(jdbcTemplate.query(
+                "SELECT url_canonical FROM mois_sales_page WHERE workspace_id = ?",
+                (rs, rowNum) -> canonicalize(rs.getString("url_canonical")),
+                workspaceId));
+        operationalUrls.remove(null);
+
+        Map<String, Set<String>> urlsBySource = new LinkedHashMap<>();
+        Map<String, Set<String>> urlsByType = new LinkedHashMap<>();
+        Set<String> allCollectedUrls = new HashSet<>();
+        for (CollectedReferenceUrlCandidate candidate : collectedUrls) {
+            if (candidate.canonicalUrl() == null || candidate.canonicalUrl().isBlank()) {
+                continue;
+            }
+            allCollectedUrls.add(candidate.canonicalUrl());
+            urlsBySource.computeIfAbsent(candidate.source(), ignored -> new HashSet<>()).add(candidate.canonicalUrl());
+            urlsByType.computeIfAbsent(candidate.urlSource(), ignored -> new HashSet<>()).add(candidate.canonicalUrl());
+        }
+
+        List<MoisSalesLibraryDtos.CollectedReferenceUrlSourceBreakdown> bySource = urlsBySource.entrySet().stream()
+                .map(entry -> buildCollectedReferenceSourceBreakdown(entry.getKey(), entry.getValue(), operationalUrls))
+                .sorted(Comparator.comparing(MoisSalesLibraryDtos.CollectedReferenceUrlSourceBreakdown::uniqueEffectiveUrls).reversed())
+                .toList();
+        List<MoisSalesLibraryDtos.CollectedReferenceUrlTypeBreakdown> byUrlType = urlsByType.entrySet().stream()
+                .map(entry -> new MoisSalesLibraryDtos.CollectedReferenceUrlTypeBreakdown(entry.getKey(), entry.getValue().size()))
+                .sorted(Comparator.comparing(MoisSalesLibraryDtos.CollectedReferenceUrlTypeBreakdown::uniqueUrls).reversed())
+                .toList();
+
+        long operationalOverlap = allCollectedUrls.stream().filter(operationalUrls::contains).count();
+        return new MoisSalesLibraryDtos.CollectedReferenceUrlSummaryResponse(
+                workspaceId,
+                allCollectedUrls.size(),
+                sizeOf(urlsByType, "SALES_PAGE_URL"),
+                sizeOf(urlsByType, "PRODUCT_URL"),
+                operationalOverlap,
+                allCollectedUrls.size() - operationalOverlap,
+                bySource,
+                byUrlType);
+    }
+
+    /**
+     * Monta o desdobramento de cobertura operacional para uma origem de marketplace.
+     */
+    private MoisSalesLibraryDtos.CollectedReferenceUrlSourceBreakdown buildCollectedReferenceSourceBreakdown(
+            String source,
+            Set<String> sourceUrls,
+            Set<String> operationalUrls
+    ) {
+        long operationalOverlap = sourceUrls.stream().filter(operationalUrls::contains).count();
+        return new MoisSalesLibraryDtos.CollectedReferenceUrlSourceBreakdown(
+                source, sourceUrls.size(), operationalOverlap, sourceUrls.size() - operationalOverlap);
+    }
+
+    /**
+     * Retorna a quantidade de URLs únicas de um agrupamento de tipo, preservando zero para ausentes.
+     */
+    private long sizeOf(Map<String, Set<String>> groupedUrls, String key) {
+        Set<String> values = groupedUrls.get(key);
+        return values == null ? 0 : values.size();
     }
 
     /**
@@ -917,6 +1008,13 @@ public class MoisSalesLibraryService {
     }
 
     /**
+     * Normaliza a origem coletada para manter agrupamentos estáveis na tela.
+     */
+    private String normalizeSource(String source) {
+        return source == null || source.isBlank() ? "UNKNOWN" : source.trim().toUpperCase(Locale.ROOT);
+    }
+
+    /**
      * Converte timestamp JDBC em Instant preservando nulos.
      */
     private Instant toInstant(Timestamp timestamp) {
@@ -927,6 +1025,9 @@ public class MoisSalesLibraryService {
     }
 
     private record CaptureExecution(long executionId, long salesPageId) {
+    }
+
+    private record CollectedReferenceUrlCandidate(String source, String urlSource, String canonicalUrl) {
     }
 
     private record CollectedReferenceForIngest(

--- a/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/web/MoisSalesLibraryController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/web/MoisSalesLibraryController.java
@@ -124,6 +124,14 @@ public class MoisSalesLibraryController {
     }
 
     /**
+     * Retorna o resumo de URLs únicas disponíveis na origem bruta de referências coletadas.
+     */
+    @GetMapping("/collected-references/url-summary")
+    public MoisSalesLibraryDtos.CollectedReferenceUrlSummaryResponse summarizeCollectedReferenceUrls(@RequestParam String workspaceId) {
+        return service.summarizeCollectedReferenceUrls(workspaceId);
+    }
+
+    /**
      * Busca os dados básicos de uma página canônica.
      */
     @GetMapping("/pages/{pageId}")

--- a/backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryServiceTest.java
@@ -163,6 +163,39 @@ class MoisSalesLibraryServiceTest {
     }
 
 
+
+    /**
+     * Garante que o resumo de referências coletadas expõe apenas URLs únicas relevantes.
+     */
+    @Test
+    void shouldSummarizeUniqueCollectedReferenceUrlsWithoutRawLineCounts() throws Exception {
+        given(jdbcTemplate.query(contains("SELECT DISTINCT source, url_source, effective_url"), isA(RowMapper.class), eq("workspace-001")))
+                .willAnswer(invocation -> {
+                    RowMapper<?> mapper = invocation.getArgument(1);
+                    return List.of(
+                            mapper.mapRow(collectedReferenceUrlSummaryRow("HOTMART", "SALES_PAGE_URL", "https://offer.example/a?utm=1"), 0),
+                            mapper.mapRow(collectedReferenceUrlSummaryRow("HOTMART", "PRODUCT_URL", "https://product.example/p?ref=1"), 1),
+                            mapper.mapRow(collectedReferenceUrlSummaryRow("CLICKBANK", "SALES_PAGE_URL", "https://hop.clickbank.net/?affiliate=abc&vendor=x"), 2)
+                    );
+                });
+        given(jdbcTemplate.query(contains("SELECT url_canonical FROM mois_sales_page"), isA(RowMapper.class), eq("workspace-001")))
+                .willAnswer(invocation -> {
+                    RowMapper<?> mapper = invocation.getArgument(1);
+                    return List.of(mapper.mapRow(operationalUrlRow("https://offer.example/a"), 0));
+                });
+
+        MoisSalesLibraryDtos.CollectedReferenceUrlSummaryResponse response = service.summarizeCollectedReferenceUrls("workspace-001");
+
+        org.assertj.core.api.Assertions.assertThat(response.uniqueEffectiveUrls()).isEqualTo(3);
+        org.assertj.core.api.Assertions.assertThat(response.explicitSalesPageUrls()).isEqualTo(2);
+        org.assertj.core.api.Assertions.assertThat(response.fallbackProductUrls()).isEqualTo(1);
+        org.assertj.core.api.Assertions.assertThat(response.operationalLibraryUrls()).isEqualTo(1);
+        org.assertj.core.api.Assertions.assertThat(response.missingFromOperationalLibrary()).isEqualTo(2);
+        org.assertj.core.api.Assertions.assertThat(response.bySource())
+                .extracting(MoisSalesLibraryDtos.CollectedReferenceUrlSourceBreakdown::source)
+                .containsExactly("HOTMART", "CLICKBANK");
+    }
+
     /**
      * Garante que a listagem de entradas usa a tabela operacional nova, sem ler a tabela legada de URL.
      */
@@ -202,6 +235,26 @@ class MoisSalesLibraryServiceTest {
         lenient().when(jdbcTemplate.update(contains("UPDATE mois_sales_page"), any(), any())).thenReturn(1);
     }
 
+
+    /**
+     * Monta uma linha simulada de URL efetiva única da origem bruta coletada.
+     */
+    private ResultSet collectedReferenceUrlSummaryRow(String source, String urlSource, String effectiveUrl) throws Exception {
+        ResultSet resultSet = org.mockito.Mockito.mock(ResultSet.class);
+        given(resultSet.getString("source")).willReturn(source);
+        given(resultSet.getString("url_source")).willReturn(urlSource);
+        given(resultSet.getString("effective_url")).willReturn(effectiveUrl);
+        return resultSet;
+    }
+
+    /**
+     * Monta uma linha simulada de URL já consolidada na biblioteca operacional.
+     */
+    private ResultSet operationalUrlRow(String urlCanonical) throws Exception {
+        ResultSet resultSet = org.mockito.Mockito.mock(ResultSet.class);
+        given(resultSet.getString("url_canonical")).willReturn(urlCanonical);
+        return resultSet;
+    }
     /**
      * Monta uma linha simulada de entrada operacional de página consolidada.
      */

--- a/docs/registros/mois1.md
+++ b/docs/registros/mois1.md
@@ -998,3 +998,21 @@ Arquivos alterados:
 - `docs/novos-modulos/MOIS/mois_sales_page_pipeline_simplificacao_duas_tabelas.md`
 - `docs/swagger/mois-sales-library-swagger.yaml`
 - `backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/schema/MoisSalesLibraryLegacyFreezeTest.java`
+
+## 2026-06-04 — Exibição de URLs únicas coletadas na tela do pipeline MOIS
+
+- criado endpoint de resumo de URLs únicas vindas da origem bruta de referências coletadas, usando a prioridade `sales_page_url`, `product_url` e `url`, sem expor contagem de linhas brutas repetidas.
+- adicionada cobertura operacional do resumo: total único coletado, URLs já consolidadas na biblioteca, URLs ainda faltantes, páginas explícitas e desdobramentos por origem/tipo de URL.
+- atualizada a tela `/mois/sales-pages-library/pipeline` para exibir esses números antes dos cards operacionais de captura/análise, mantendo o foco nos indicadores úteis para decisão.
+- atualizado o Swagger da Biblioteca MOIS e adicionado teste unitário para proteger a contagem por URLs únicas canônicas.
+
+Arquivos alterados:
+- `backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/dto/MoisSalesLibraryDtos.java`
+- `backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryService.java`
+- `backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/web/MoisSalesLibraryController.java`
+- `backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryServiceTest.java`
+- `frontend/src/api/mois/types.ts`
+- `frontend/src/api/mois/useMoisSalesLibrary.ts`
+- `frontend/src/pages/mois/MoisSalesPagesPipelinePage.tsx`
+- `docs/swagger/mois-sales-library-swagger.yaml`
+- `docs/registros/mois1.md`

--- a/docs/swagger/mois-sales-library-swagger.yaml
+++ b/docs/swagger/mois-sales-library-swagger.yaml
@@ -73,6 +73,24 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SalesLibraryEntryPageResponse'
+  /collected-references/url-summary:
+    get:
+      summary: Resume URLs únicas da origem bruta coletada
+      description: Lê `mois_collected_reference` somente como origem bruta e retorna contadores de URLs únicas efetivas, cobertura em `mois_sales_page` e desdobramento por origem/tipo sem expor contagem de linhas brutas.
+      tags: [MOIS Sales Library]
+      parameters:
+        - in: query
+          name: workspaceId
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Cobertura de URLs únicas coletadas
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/CollectedReferenceUrlSummaryResponse'
   /jobs:
     get:
       summary: Lista execuções operacionais consolidadas
@@ -534,6 +552,61 @@ components:
           type: integer
         skippedWithoutUrl:
           type: integer
+    CollectedReferenceUrlSummaryResponse:
+      type: object
+      properties:
+        workspaceId:
+          type: string
+        uniqueEffectiveUrls:
+          type: integer
+          format: int64
+          description: Total de URLs únicas efetivas usando prioridade sales_page_url, product_url e url.
+        explicitSalesPageUrls:
+          type: integer
+          format: int64
+          description: Total de URLs únicas quando havia sales_page_url explícita.
+        fallbackProductUrls:
+          type: integer
+          format: int64
+          description: Total de URLs únicas obtidas por fallback em product_url.
+        operationalLibraryUrls:
+          type: integer
+          format: int64
+          description: URLs únicas coletadas que já existem em mois_sales_page.
+        missingFromOperationalLibrary:
+          type: integer
+          format: int64
+          description: URLs únicas coletadas ainda não consolidadas em mois_sales_page.
+        bySource:
+          type: array
+          items:
+            $ref: '#/components/schemas/CollectedReferenceUrlSourceBreakdown'
+        byUrlType:
+          type: array
+          items:
+            $ref: '#/components/schemas/CollectedReferenceUrlTypeBreakdown'
+    CollectedReferenceUrlSourceBreakdown:
+      type: object
+      properties:
+        source:
+          type: string
+        uniqueEffectiveUrls:
+          type: integer
+          format: int64
+        operationalLibraryUrls:
+          type: integer
+          format: int64
+        missingFromOperationalLibrary:
+          type: integer
+          format: int64
+    CollectedReferenceUrlTypeBreakdown:
+      type: object
+      properties:
+        urlType:
+          type: string
+        uniqueUrls:
+          type: integer
+          format: int64
     SalesLibraryJobResponse:
       type: object
       properties:

--- a/frontend/src/api/mois/types.ts
+++ b/frontend/src/api/mois/types.ts
@@ -295,6 +295,30 @@ export interface MoisSalesLibraryPageSummary {
   updatedAt?: string;
 }
 
+
+export interface MoisCollectedReferenceUrlSourceBreakdown {
+  source: string;
+  uniqueEffectiveUrls: number;
+  operationalLibraryUrls: number;
+  missingFromOperationalLibrary: number;
+}
+
+export interface MoisCollectedReferenceUrlTypeBreakdown {
+  urlType: string;
+  uniqueUrls: number;
+}
+
+export interface MoisCollectedReferenceUrlSummary {
+  workspaceId: string;
+  uniqueEffectiveUrls: number;
+  explicitSalesPageUrls: number;
+  fallbackProductUrls: number;
+  operationalLibraryUrls: number;
+  missingFromOperationalLibrary: number;
+  bySource: MoisCollectedReferenceUrlSourceBreakdown[];
+  byUrlType: MoisCollectedReferenceUrlTypeBreakdown[];
+}
+
 export interface MoisSalesLibraryPageExecution {
   executionId: number;
   pageId: number;

--- a/frontend/src/api/mois/useMoisSalesLibrary.ts
+++ b/frontend/src/api/mois/useMoisSalesLibrary.ts
@@ -1,6 +1,7 @@
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import axios from "axios";
 import type {
+  MoisCollectedReferenceUrlSummary,
   MoisSalesLibraryEntryPageResponse,
   MoisSalesLibraryJobPageResponse,
   MoisSalesLibraryPage,
@@ -86,6 +87,19 @@ export function useMoisSalesLibraryPageSummary(workspaceId: string) {
     queryFn: async () => {
       const { data } = await axios.get<MoisSalesLibraryPageSummary>(
         "/api/mois/sales-library/pages/summary",
+        { params: { workspaceId } },
+      );
+      return data;
+    },
+  });
+}
+
+export function useMoisCollectedReferenceUrlSummary(workspaceId: string) {
+  return useQuery({
+    queryKey: ["mois", "sales-library", "collected-reference-url-summary", workspaceId],
+    queryFn: async () => {
+      const { data } = await axios.get<MoisCollectedReferenceUrlSummary>(
+        "/api/mois/sales-library/collected-references/url-summary",
         { params: { workspaceId } },
       );
       return data;

--- a/frontend/src/pages/mois/MoisSalesPagesPipelinePage.tsx
+++ b/frontend/src/pages/mois/MoisSalesPagesPipelinePage.tsx
@@ -3,6 +3,7 @@ import { Link } from "react-router-dom";
 import PageTitle from "../../components/PageTitle";
 import {
   useCaptureMoisSalesLibrarySnapshots,
+  useMoisCollectedReferenceUrlSummary,
   useMoisSalesLibraryPageSummary,
 } from "../../api/mois/useMoisSalesLibrary";
 import type { MoisSalesLibrarySnapshotCaptureItem } from "../../api/mois/types";
@@ -61,11 +62,23 @@ function getResultMessage(item: MoisSalesLibrarySnapshotCaptureItem) {
   return redirectInfo || "Sem detalhe adicional";
 }
 
+function formatUrlTypeLabel(urlType: string) {
+  if (urlType === "SALES_PAGE_URL") {
+    return "URLs explícitas de página de venda";
+  }
+  if (urlType === "PRODUCT_URL") {
+    return "Fallback por URL de produto";
+  }
+  return urlType;
+}
+
 export default function MoisSalesPagesPipelinePage() {
   const [forceCapture, setForceCapture] = useState(false);
   const summaryQuery = useMoisSalesLibraryPageSummary(WORKSPACE_ID);
+  const collectedUrlSummaryQuery = useMoisCollectedReferenceUrlSummary(WORKSPACE_ID);
   const captureMutation = useCaptureMoisSalesLibrarySnapshots(WORKSPACE_ID);
   const summary = summaryQuery.data;
+  const collectedUrlSummary = collectedUrlSummaryQuery.data;
 
   const lastRun = captureMutation.data;
   const isRunning = captureMutation.isPending;
@@ -144,6 +157,110 @@ export default function MoisSalesPagesPipelinePage() {
                 </p>
               </div>
             </div>
+          </div>
+
+          <div className="border rounded-3 p-3">
+            <div className="d-flex flex-wrap align-items-start justify-content-between gap-3 mb-3">
+              <div>
+                <h3 className="h6 mb-1">Cobertura da origem bruta coletada</h3>
+                <p className="text-secondary small mb-0">
+                  URLs únicas vindas dos coletores, sem contar registros repetidos
+                  ou ruidosos.
+                </p>
+              </div>
+              {collectedUrlSummaryQuery.isLoading ? (
+                <span className="badge text-bg-secondary">Carregando...</span>
+              ) : null}
+            </div>
+
+            {collectedUrlSummaryQuery.isError ? (
+              <div className="alert alert-warning mb-0">
+                Não foi possível carregar o resumo de URLs únicas coletadas.
+              </div>
+            ) : null}
+
+            {collectedUrlSummary ? (
+              <div className="d-flex flex-column gap-3">
+                <div className="row g-3">
+                  <div className="col-sm-6 col-lg-3">
+                    <div className="bg-light rounded-3 p-3 h-100">
+                      <p className="text-secondary mb-1">URLs únicas coletadas</p>
+                      <h3 className="mb-0">
+                        {collectedUrlSummary.uniqueEffectiveUrls}
+                      </h3>
+                    </div>
+                  </div>
+                  <div className="col-sm-6 col-lg-3">
+                    <div className="bg-light rounded-3 p-3 h-100">
+                      <p className="text-secondary mb-1">Já na biblioteca</p>
+                      <h3 className="mb-0">
+                        {collectedUrlSummary.operationalLibraryUrls}
+                      </h3>
+                    </div>
+                  </div>
+                  <div className="col-sm-6 col-lg-3">
+                    <div className="bg-light rounded-3 p-3 h-100">
+                      <p className="text-secondary mb-1">Faltam consolidar</p>
+                      <h3 className="mb-0 text-warning">
+                        {collectedUrlSummary.missingFromOperationalLibrary}
+                      </h3>
+                    </div>
+                  </div>
+                  <div className="col-sm-6 col-lg-3">
+                    <div className="bg-light rounded-3 p-3 h-100">
+                      <p className="text-secondary mb-1">Páginas explícitas</p>
+                      <h3 className="mb-0">
+                        {collectedUrlSummary.explicitSalesPageUrls}
+                      </h3>
+                    </div>
+                  </div>
+                </div>
+
+                <div className="row g-3">
+                  <div className="col-12 col-lg-7">
+                    <div className="table-responsive">
+                      <table className="table table-sm align-middle mb-0">
+                        <thead>
+                          <tr>
+                            <th>Origem</th>
+                            <th>URLs únicas</th>
+                            <th>Na biblioteca</th>
+                            <th>Faltam</th>
+                          </tr>
+                        </thead>
+                        <tbody>
+                          {collectedUrlSummary.bySource.map((item) => (
+                            <tr key={item.source}>
+                              <td>{item.source}</td>
+                              <td>{item.uniqueEffectiveUrls}</td>
+                              <td>{item.operationalLibraryUrls}</td>
+                              <td className="fw-semibold text-warning">
+                                {item.missingFromOperationalLibrary}
+                              </td>
+                            </tr>
+                          ))}
+                        </tbody>
+                      </table>
+                    </div>
+                  </div>
+                  <div className="col-12 col-lg-5">
+                    <div className="d-flex flex-column gap-2">
+                      {collectedUrlSummary.byUrlType.map((item) => (
+                        <div
+                          className="d-flex justify-content-between gap-3 border rounded-3 p-2"
+                          key={item.urlType}
+                        >
+                          <span className="text-secondary small">
+                            {formatUrlTypeLabel(item.urlType)}
+                          </span>
+                          <strong>{item.uniqueUrls}</strong>
+                        </div>
+                      ))}
+                    </div>
+                  </div>
+                </div>
+              </div>
+            ) : null}
           </div>
 
           <div className="row g-3">


### PR DESCRIPTION
### Motivation
- Provide a concise, de-duplicated view of unique URLs coming from the raw `mois_collected_reference` source to help prioritize consolidation into the operational `mois_sales_page` table. 
- Avoid exposing noisy raw line counts and instead surface unique effective URLs and their coverage in the operational library. 
- Expose the data via API and show it in the pipeline UI so operators can quickly see gaps and distribution by source and URL type. 

### Description
- Added DTOs to represent the summary and breakdowns: `CollectedReferenceUrlSummaryResponse`, `CollectedReferenceUrlSourceBreakdown`, and `CollectedReferenceUrlTypeBreakdown` in `MoisSalesLibraryDtos`. 
- Implemented `summarizeCollectedReferenceUrls` in `MoisSalesLibraryService` which reads distinct effective URLs from `mois_collected_reference` (priority `sales_page_url`, then `product_url`, then `url`), canonicalizes URLs, normalizes sources, computes unique totals, operational overlap against `mois_sales_page`, and builds per-source and per-url-type breakdowns. 
- Exposed a new controller endpoint `GET /api/mois/sales-library/collected-references/url-summary` via `MoisSalesLibraryController` and added Swagger schema and path entries in `docs/swagger/mois-sales-library-swagger.yaml`. 
- Frontend additions include new types in `frontend/src/api/mois/types.ts`, a new hook `useMoisCollectedReferenceUrlSummary` in `useMoisSalesLibrary.ts`, and UI rendering for the summary in `MoisSalesPagesPipelinePage.tsx` including summary cards, per-source table and per-type counts. 
- Added a unit test `shouldSummarizeUniqueCollectedReferenceUrlsWithoutRawLineCounts` in `MoisSalesLibraryServiceTest` and helper mocks used by the test, and updated docs (`docs/registros/mois1.md`). 

### Testing
- Ran the backend unit tests in `MoisSalesLibraryServiceTest`, including the new test `shouldSummarizeUniqueCollectedReferenceUrlsWithoutRawLineCounts`, and they passed. 
- The new service test mocks JDBC results for both collected references and operational URLs and verifies counts and ordering, and it succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a21fb853a808321a4dc22674fd7117c)