### PR TITLE
Add API and UI action to rebuild official pipeline stages preserving compatible operational config

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/pipeline/service/PipelineDefinitionSynchronizer.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/pipeline/service/PipelineDefinitionSynchronizer.java
@@ -11,8 +11,11 @@ import com.marketinghub.pipeline.dto.PipelineSyncResultDto;
 import com.marketinghub.repository.jpa.pipeline.PipelineRepository;
 import com.marketinghub.repository.jpa.pipeline.PipelineStageRepository;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
@@ -90,6 +93,52 @@ public class PipelineDefinitionSynchronizer {
         for (PipelineStageDefinition stageDefinition : definition.stages()) {
             synchronizeStage(pipeline, definition, stageDefinition, appliedActions);
         }
+        pipelineRepository.save(pipeline);
+        if (persistentContractSynchronizer != null) {
+            appliedActions.addAll(persistentContractSynchronizer.sync(definition, pipeline));
+        }
+
+        PipelineDiagnosticsDto diagnostics = pipelineService.diagnostics(pipelineId);
+        return PipelineSyncResultDto.builder()
+                .status(diagnostics.status())
+                .synchronizedSafely("OK".equals(diagnostics.status()))
+                .pipelineId(diagnostics.pipelineId())
+                .pipelineCode(diagnostics.pipelineCode())
+                .canonicalPipelineCode(diagnostics.canonicalPipelineCode())
+                .expectedStages(diagnostics.expectedStages())
+                .configuredStages(diagnostics.configuredStages())
+                .appliedActions(appliedActions)
+                .issues(diagnostics.issues())
+                .build();
+    }
+
+    /**
+     * Recria explicitamente as etapas de um pipeline oficial a partir do contrato canônico,
+     * preservando configuração operacional compatível.
+     */
+    @Transactional
+    public PipelineSyncResultDto rebuildOfficialStages(Long pipelineId) {
+        Pipeline pipeline = pipelineService.get(pipelineId);
+        PipelineDefinition definition = definitionRegistry.findByPipelineCode(pipeline.getCode()).orElse(null);
+        if (definition == null) {
+            PipelineDiagnosticsDto diagnostics = pipelineService.diagnostics(pipelineId);
+            return blockedResult(diagnostics, List.of());
+        }
+
+        List<PipelineStage> existingStages = new ArrayList<>(pipeline.getStages());
+        List<String> appliedActions = new ArrayList<>();
+        synchronizePipelineFields(pipeline, definition, appliedActions);
+        stageRepository.deleteAll(existingStages);
+        stageRepository.flush();
+        pipeline.getStages().clear();
+        appliedActions.add("Etapas operacionais antigas removidas para recriação oficial controlada pela tela.");
+
+        definition.stages().stream()
+                .sorted(Comparator.comparingInt(PipelineStageDefinition::position))
+                .forEach(stageDefinition -> {
+                    PipelineStage stage = createStageFromSnapshot(pipeline, definition, stageDefinition, existingStages);
+                    appliedActions.add("Etapa oficial recriada: " + stage.getCode());
+                });
         pipelineRepository.save(pipeline);
         if (persistentContractSynchronizer != null) {
             appliedActions.addAll(persistentContractSynchronizer.sync(definition, pipeline));
@@ -209,6 +258,65 @@ public class PipelineDefinitionSynchronizer {
                 .build();
         pipeline.getStages().add(stage);
         return stageRepository.save(stage);
+    }
+
+    /**
+     * Cria uma etapa oficial reutilizando descrição e modelo OpenAI de uma etapa compatível anterior quando existir.
+     */
+    private PipelineStage createStageFromSnapshot(
+            Pipeline pipeline,
+            PipelineDefinition definition,
+            PipelineStageDefinition stageDefinition,
+            List<PipelineStage> existingStages) {
+        Optional<PipelineStage> configuredStage =
+                findConfiguredStageSnapshot(definition, stageDefinition, existingStages);
+        PipelineStage stage = PipelineStage.builder()
+                .pipeline(pipeline)
+                .position(stageDefinition.position())
+                .name(stageDefinition.name())
+                .code(stageDefinition.operationalCode())
+                .description(configuredStage.map(PipelineStage::getDescription).orElse(null))
+                .required(stageDefinition.required())
+                .active(true)
+                .openAiModel(configuredStage.map(PipelineStage::getOpenAiModel).orElse(null))
+                .build();
+        pipeline.getStages().add(stage);
+        return stageRepository.save(stage);
+    }
+
+    /**
+     * Localiza uma etapa anterior equivalente pelo contrato atual ou por aliases legados conhecidos
+     * do pipeline de experimento.
+     */
+    private Optional<PipelineStage> findConfiguredStageSnapshot(
+            PipelineDefinition definition, PipelineStageDefinition stageDefinition, List<PipelineStage> existingStages) {
+        Optional<PipelineStage> officialMatch = existingStages.stream()
+                .filter(stage -> definitionRegistry.findStage(definition, stage.getCode())
+                        .map(stageDefinition::equals)
+                        .orElse(false))
+                .findFirst();
+        if (officialMatch.isPresent()) {
+            return officialMatch;
+        }
+        return legacyStageAliases(stageDefinition).stream()
+                .flatMap(alias -> existingStages.stream()
+                        .filter(stage -> definitionRegistry.normalize(alias)
+                                .equals(definitionRegistry.normalize(stage.getCode()))))
+                .findFirst();
+    }
+
+    /**
+     * Lista aliases operacionais legados usados antes do contrato canônico atual para preservar
+     * configuração durante recriação.
+     */
+    private List<String> legacyStageAliases(PipelineStageDefinition stageDefinition) {
+        Map<String, List<String>> aliases = Map.of(
+                "LANDING_PAGE_WIREFRAME", List.of("landing-wireframe"),
+                "LANDING_PAGE_COPY", List.of("landing-copy"),
+                "LANDING_PAGE_IMAGE_PLANNING", List.of("image-planning"),
+                "LANDING_PAGE_DESIGN_PRESET", List.of("preset-design"),
+                "LANDING_PAGE_HTML", List.of("landing-html", "geralanding-html"));
+        return aliases.getOrDefault(stageDefinition.canonicalCode(), List.of());
     }
 
     /**

--- a/backend/ads-service/src/main/java/com/marketinghub/pipeline/web/PipelineController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/pipeline/web/PipelineController.java
@@ -84,6 +84,14 @@ public class PipelineController {
     }
 
     /**
+     * Recria explicitamente as etapas oficiais do pipeline informado quando o usuário confirmar o reparo destrutivo.
+     */
+    @PostMapping("/{id}/rebuild-official-stages")
+    public PipelineSyncResultDto rebuildOfficialStages(@PathVariable Long id) {
+        return synchronizer.rebuildOfficialStages(id);
+    }
+
+    /**
      * Cria ou sincroniza com segurança um pipeline oficial pelo código canônico.
      */
     @PostMapping("/official/{code}/sync")

--- a/backend/ads-service/src/test/java/com/marketinghub/pipeline/service/PipelineServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/pipeline/service/PipelineServiceTest.java
@@ -333,6 +333,54 @@ class PipelineServiceTest {
         });
     }
 
+    /**
+     * Garante que a recriação explícita remove etapas legadas e recria somente etapas oficiais preservando configuração compatível.
+     */
+    @Test
+    void shouldRebuildOfficialStagesFromScreenAction() {
+        OpenAiModel model = OpenAiModel.builder().id(99L).name("GPT 5.2").code("gpt-5.2").build();
+        PipelineStage legacyWireframe = stage(3L, 3, "landing-wireframe");
+        legacyWireframe.setDescription("Descrição operacional preservada");
+        legacyWireframe.setOpenAiModel(model);
+        Pipeline pipeline = officialPipelineWith(
+                stage(1L, 1, "campaign-angle"),
+                stage(2L, 2, "ad-copy"),
+                legacyWireframe,
+                stage(4L, 4, "landing-copy"),
+                stage(5L, 5, "image-planning"),
+                stage(6L, 6, "preset-design"),
+                stage(7L, 7, "geralanding-html"),
+                stage(8L, 8, "landing-html"),
+                stage(9L, 9, "landing-page-deliverables"));
+        when(pipelineRepository.findById(10L)).thenReturn(Optional.of(pipeline));
+        when(stageRepository.save(any(PipelineStage.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        when(pipelineRepository.save(any(Pipeline.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        PipelineSyncResultDto result = synchronizer.rebuildOfficialStages(10L);
+
+        assertThat(result.status()).isEqualTo("OK");
+        assertThat(result.synchronizedSafely()).isTrue();
+        assertThat(pipeline.getStages()).hasSize(8);
+        assertThat(pipeline.getStages()).extracting(PipelineStage::getCode)
+                .containsExactly(
+                        "campaign-angle",
+                        "ad-copy",
+                        "ad-image-briefing",
+                        "landing-page-wireframe",
+                        "landing-page-copy",
+                        "landing-page-image-planning",
+                        "landing-page-design-preset",
+                        "landing-page-html");
+        assertThat(pipeline.getStages())
+                .filteredOn(stage -> stage.getCode().equals("landing-page-wireframe"))
+                .singleElement()
+                .satisfies(stage -> {
+                    assertThat(stage.getDescription()).isEqualTo("Descrição operacional preservada");
+                    assertThat(stage.getOpenAiModel()).isEqualTo(model);
+                });
+        assertThat(result.appliedActions()).anyMatch(action -> action.contains("Etapas operacionais antigas removidas"));
+        verify(stageRepository).deleteAll(any());
+    }
 
     /**
      * Garante que a sincronização cria pipeline oficial ausente pelo código canônico.

--- a/docs/canonical/procedimento-experimento-canon.v1.md
+++ b/docs/canonical/procedimento-experimento-canon.v1.md
@@ -46,6 +46,7 @@ Endpoints administrativos vigentes:
 - `GET /api/pipelines/metadata` expõe versão canônica, aliases e política de campos;
 - `GET /api/pipelines/{id}/diagnostics` compara banco e contrato oficial com causa-raiz e ação recomendada;
 - `POST /api/pipelines/{id}/sync` sincroniza de forma idempotente um pipeline existente, sem aceitar payload da tela;
+- `POST /api/pipelines/{id}/rebuild-official-stages` permite que a tela, após confirmação explícita do usuário, remova etapas operacionais atuais de um pipeline oficial e recrie somente as etapas do contrato canônico, reaproveitando configurações compatíveis como descrição e modelo OpenAI quando houver mapeamento seguro;
 - `POST /api/pipelines/official/{code}/sync` cria ou sincroniza um pipeline oficial ausente pelo código canônico, sem aceitar payload da tela.
 
 A sincronização segura pode criar pipeline/etapas oficiais ausentes e corrigir campos estruturais permitidos, mas deve bloquear divergências destrutivas, como etapa extra sem mapeamento canônico ou duplicidade operacional, para evitar perda de histórico e preservar a causa-raiz para decisão humana.

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -3500,3 +3500,11 @@
 - ajuste aplicado: o Worker AI passou a ter propriedades dedicadas `copy.worker.model` e `imageplanning.worker.model`, ambas com default `gpt-5.4`, e os builders dessas etapas passaram a gravar esse modelo no `OpenAiRequest` e no corpo da Responses API, sem depender do `openai.model` global.
 - cânone atualizado: `docs/canonical/geralanding-arquitetura-canon.v1.md` registra os defaults dedicados `gpt-5.4` para Copy e Image Planning.
 - validação automatizada: adicionados testes garantindo que os requests das etapas Copy e Image Planning usam `gpt-5.4` no modelo auditado e no payload enviado à OpenAI.
+
+## 2026-06-05 — Ajuste controlado de etapas oficiais pela tela de Pipelines
+
+- solicitação: permitir que o usuário resolva divergências de contrato do Pipeline de Experimento pela própria tela, com um botão de ajuste/recriação das etapas oficiais.
+- causa-raiz/objetivo: o diagnóstico bloqueava corretamente etapas extras e ausentes, mas a tela ainda não oferecia uma ação explícita para o usuário confirmar a correção destrutiva e voltar o pipeline ao contrato canônico sem intervenção manual no banco.
+- correção aplicada: criado endpoint `POST /api/pipelines/{id}/rebuild-official-stages` para remover as etapas operacionais atuais de um pipeline oficial e recriar somente as etapas canônicas, preservando descrição e modelo OpenAI quando houver mapeamento seguro de códigos legados; a tela `/pipelines` ganhou o botão “Ajustar etapas oficiais” com confirmação e indicador de carregamento.
+- documentação atualizada: cânone do procedimento de experimento e Swagger de pipelines passaram a registrar o novo endpoint de recriação controlada.
+- validação automatizada: teste unitário cobre a recriação de 9 etapas legadas para as 8 etapas oficiais, com preservação de configuração compatível em `landing-page-wireframe`.

--- a/docs/swagger/pipeline-swagger.yaml
+++ b/docs/swagger/pipeline-swagger.yaml
@@ -55,6 +55,26 @@ paths:
                 $ref: "#/components/schemas/PipelineSyncResult"
         "404":
           description: Pipeline não encontrado.
+  /pipelines/{id}/rebuild-official-stages:
+    post:
+      summary: Recria etapas oficiais de um pipeline após confirmação explícita do usuário.
+      description: Não aceita payload; remove as etapas operacionais atuais do pipeline oficial e recria somente as etapas canônicas, reaproveitando descrição e modelo OpenAI quando houver mapeamento seguro.
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        "200":
+          description: Resultado da recriação controlada das etapas oficiais.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/PipelineSyncResult"
+        "404":
+          description: Pipeline não encontrado.
   /pipelines/official/{code}/sync:
     post:
       summary: Cria ou sincroniza um pipeline oficial ausente pelo código canônico.

--- a/frontend/src/api/pipeline/types.ts
+++ b/frontend/src/api/pipeline/types.ts
@@ -86,3 +86,15 @@ export interface PipelineDiagnostics {
   configuredStages: number;
   issues: PipelineDiagnosticsIssue[];
 }
+
+export interface PipelineSyncResult {
+  status: PipelineDiagnosticsStatus;
+  synchronizedSafely: boolean;
+  pipelineId?: number | null;
+  pipelineCode?: string | null;
+  canonicalPipelineCode?: string | null;
+  expectedStages: number;
+  configuredStages: number;
+  appliedActions: string[];
+  issues: PipelineDiagnosticsIssue[];
+}

--- a/frontend/src/api/pipeline/usePipelineMutations.ts
+++ b/frontend/src/api/pipeline/usePipelineMutations.ts
@@ -5,6 +5,7 @@ import type {
   PipelinePayload,
   PipelineStage,
   PipelineStagePayload,
+  PipelineSyncResult,
 } from "./types";
 
 export function useCreatePipeline() {
@@ -101,6 +102,19 @@ export function useDeletePipelineStage() {
       stageId: number;
     }) => {
       await axios.delete(`/api/pipelines/${pipelineId}/stages/${stageId}`);
+    },
+    onSuccess: () => queryClient.invalidateQueries({ queryKey: ["pipelines"] }),
+  });
+}
+
+export function useRebuildOfficialPipelineStages() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (pipelineId: number) => {
+      const { data } = await axios.post<PipelineSyncResult>(
+        `/api/pipelines/${pipelineId}/rebuild-official-stages`,
+      );
+      return data;
     },
     onSuccess: () => queryClient.invalidateQueries({ queryKey: ["pipelines"] }),
   });

--- a/frontend/src/pages/pipeline/PipelineCrudPage.tsx
+++ b/frontend/src/pages/pipeline/PipelineCrudPage.tsx
@@ -16,6 +16,7 @@ import {
   useCreatePipelineStage,
   useDeletePipeline,
   useDeletePipelineStage,
+  useRebuildOfficialPipelineStages,
   useUpdatePipeline,
   useUpdatePipelineStage,
 } from "../../api/pipeline/usePipelineMutations";
@@ -82,6 +83,7 @@ export default function PipelineCrudPage() {
   const createStage = useCreatePipelineStage();
   const updateStage = useUpdatePipelineStage();
   const deleteStage = useDeletePipelineStage();
+  const rebuildOfficialStages = useRebuildOfficialPipelineStages();
 
   const pipelines = useMemo(() => data ?? [], [data]);
   const diagnosticsQueries = usePipelineDiagnostics(pipelines);
@@ -166,6 +168,16 @@ export default function PipelineCrudPage() {
   const resetStageForm = (pipelineId: number) => {
     setStageForms((current) => ({ ...current, [pipelineId]: emptyStage }));
     setEditingStageId(null);
+  };
+
+  const confirmOfficialStageRebuild = (pipeline: Pipeline) => {
+    if (
+      confirm(
+        "Deseja excluir as etapas atuais e recriar as etapas oficiais deste pipeline? Configurações compatíveis, como modelo OpenAI e descrição, serão reaproveitadas quando possível.",
+      )
+    ) {
+      rebuildOfficialStages.mutate(pipeline.id);
+    }
   };
 
   if (isLoading) return <p>Carregando pipelines...</p>;
@@ -372,7 +384,27 @@ export default function PipelineCrudPage() {
                     <p className="mb-0 mt-2">{pipeline.description}</p>
                   ) : null}
                 </div>
-                <div className="d-flex gap-2">
+                <div className="d-flex flex-wrap gap-2">
+                  {isOfficialPipeline ? (
+                    <button
+                      className="btn btn-sm btn-outline-warning"
+                      disabled={
+                        rebuildOfficialStages.isPending ||
+                        !diagnostic ||
+                        diagnostic.status === "OK"
+                      }
+                      onClick={() => confirmOfficialStageRebuild(pipeline)}
+                    >
+                      {rebuildOfficialStages.isPending &&
+                      rebuildOfficialStages.variables === pipeline.id ? (
+                        <span
+                          className="spinner-border spinner-border-sm me-2"
+                          aria-hidden="true"
+                        />
+                      ) : null}
+                      Ajustar etapas oficiais
+                    </button>
+                  ) : null}
                   <button
                     className="btn btn-sm btn-outline-primary"
                     onClick={() => {


### PR DESCRIPTION
### Motivation

- Provide a controlled, user-confirmed way to repair destructive divergences between an official pipeline contract and operational data by recreating official stages from the canonical definition.  
- Preserve compatible operational configuration such as `description` and `openAiModel` when mapping legacy/aliased stage codes to the canonical stages.  
- Expose the action in the UI and document the endpoint in Swagger and canonical docs so operators can self-service the repair.

### Description

- Added `rebuildOfficialStages(Long pipelineId)` in `PipelineDefinitionSynchronizer` which deletes current operational stages and recreates canonical stages, reusing `description` and `openAiModel` from compatible legacy stages when found.  
- Implemented helper methods `createStageFromSnapshot`, `findConfiguredStageSnapshot`, and `legacyStageAliases` to locate compatible prior configuration and map legacy aliases to canonical codes.  
- Exposed a new controller endpoint `POST /api/pipelines/{id}/rebuild-official-stages` in `PipelineController` that calls the new synchronizer method.  
- Updated API documentation in `docs/swagger/pipeline-swagger.yaml` and canonical procedure `docs/canonical/procedimento-experimento-canon.v1.md` describing the controlled rebuild flow.  
- Frontend additions: extended types with `PipelineSyncResult`, added `useRebuildOfficialPipelineStages` mutation, and wired a confirmation button `Ajustar etapas oficiais` into `PipelineCrudPage.tsx` that invokes the new endpoint and shows a loading spinner.  
- Added unit test `shouldRebuildOfficialStagesFromScreenAction` to `PipelineServiceTest` that verifies legacy aliases are consolidated into canonical stages and that `description` and `openAiModel` are preserved when mapped.

### Testing

- Ran unit tests for the pipeline service; `PipelineServiceTest` including the new test `shouldRebuildOfficialStagesFromScreenAction` passed.  
- Verified the new endpoint is declared in the Swagger spec and matches the frontend `useRebuildOfficialPipelineStages` hook usage.  
- No other automated test failures observed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a221f1a789083219e6a32fc19aea1c8)