### PR TITLE
Landing analytics: adiciona debug de browser e atualização de instrumentação legada

### DIFF
--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -3527,3 +3527,15 @@
 - solicitação: adicionar logs nos endpoints chamados pelos scripts da landing porque o navegador do usuário não mostrava funcionamento claro dos eventos do funil.
 - causa-raiz/objetivo: aumentar a observabilidade do caminho completo `landing page script → Lead Portal /api/flows/{slug}/page-analytics → Marketing Hub /api/public/lead-portal/flows/{slug}/page-analytics → experiment_funnel_event`, registrando payload cru, payload parseado, endpoint de encaminhamento, status retornado e contexto operacional (`slug`, `eventId`, `eventType`, `sectionId`, `sessionId`, `pageUrl`).
 - correção aplicada: Lead Portal e backend principal passaram a logar os payloads recebidos e o resultado de encaminhamento/persistência dos eventos `page-analytics`, preservando stack trace em payload inválido e falhas de integração.
+
+## 2026-06-05 — Diagnóstico de carregamento do script de analytics da landing no browser
+
+- solicitação: procurar os logs dos eventos `page-analytics` do experimento 37 e, como os logs textuais não apareceram na janela consultada, adicionar logs no browser para validar se o script da landing está carregando e disparando `page_view` corretamente.
+- diagnóstico operacional: a consulta via MCP não encontrou linhas `Page-analytics` no Lead Portal nem `landing_page_analytics experimentId=37` no backend no intervalo pesquisado, apesar de eventos do experimento 37 existirem em `experiment_funnel_event`; isso indica necessidade de observabilidade no navegador para confirmar execução do script, endpoint usado e mecanismo de envio (`sendBeacon` ou `fetch`).
+- ajuste aplicado: o script injetado nas landings standalone agora possui logs de console ativados por `?mhAnalyticsDebug=1` ou por `localStorage.mhLandingAnalyticsDebug=true`, cobrindo carregamento do script, início do tracking, envio de `page_view`, status do `sendBeacon`/`fetch`, seções monitoradas e processamento no `beforeunload`.
+
+## 2026-06-05 — Atualização de instrumentação legada para debug de analytics no browser
+
+- solicitação: validar o print do navegador com `?mhAnalyticsDebug=1` sem mensagens `[MH Landing Analytics]` no console.
+- causa-raiz identificada: páginas já publicadas podem conter `data-mh-landing-analytics` antigo no HTML salvo; a entrega standalone retornava o HTML sem reinjetar o script, portanto o parâmetro `mhAnalyticsDebug=1` não tinha efeito nessas publicações legadas.
+- correção aplicada: quando a landing já possui script `data-mh-landing-analytics` sem `mhAnalyticsDebug`, o Lead Portal agora substitui a instrumentação legada pelo script atualizado com logs de browser, preservando um único script de analytics e evitando duplicação.

--- a/lead-portal/backend/src/main/java/com/marketinghub/leadportal/controller/FlowController.java
+++ b/lead-portal/backend/src/main/java/com/marketinghub/leadportal/controller/FlowController.java
@@ -136,20 +136,58 @@ public class FlowController {
     }
 
     /**
-     * Injeta o script de analytics do Lead Portal sem alterar landings que já possuem a instrumentação.
+     * Injeta ou atualiza o script de analytics do Lead Portal com diagnóstico opcional no browser.
      */
     private String injectLandingAnalyticsScript(String slug, String html) {
-        if (html == null || html.toLowerCase(Locale.ROOT).contains("data-mh-landing-analytics")) {
+        if (html == null) {
+            return null;
+        }
+        if (html.toLowerCase(Locale.ROOT).contains("data-mh-landing-analytics")) {
+            return refreshLandingAnalyticsScriptWhenMissingDebug(slug, html);
+        }
+
+        String analyticsScript = buildLandingAnalyticsScript(slug);
+        if (html.toLowerCase(Locale.ROOT).contains("</body>")) {
+            return html.replaceFirst("(?i)</body>", java.util.regex.Matcher.quoteReplacement(analyticsScript + "\n</body>"));
+        }
+        return html + "\n" + analyticsScript;
+    }
+
+    /**
+     * Atualiza a instrumentação legada já existente para incluir logs de diagnóstico sem duplicar scripts.
+     */
+    private String refreshLandingAnalyticsScriptWhenMissingDebug(String slug, String html) {
+        if (html.contains("mhAnalyticsDebug")) {
             return html;
         }
-        String analyticsScript = """
+        String analyticsScript = buildLandingAnalyticsScript(slug);
+        return java.util.regex.Pattern
+                .compile("<script\\b(?=[^>]*data-mh-landing-analytics)[\\s\\S]*?</script>",
+                        java.util.regex.Pattern.CASE_INSENSITIVE)
+                .matcher(html)
+                .replaceFirst(java.util.regex.Matcher.quoteReplacement(analyticsScript));
+    }
+
+    /**
+     * Monta o script de analytics que envia page_view e expõe logs de console somente quando o debug é ativado.
+     */
+    private String buildLandingAnalyticsScript(String slug) {
+        return """
                 <script data-mh-landing-analytics="true">
                 (function(){
                   const slugValue = %s;
                   const endpoint = '/api/flows/' + encodeURIComponent(slugValue) + '/page-analytics';
+                  const debugParam = new URLSearchParams(window.location.search).get('mhAnalyticsDebug') === '1';
+                  const debugStorage = localStorage.getItem('mhLandingAnalyticsDebug') === 'true';
+                  const debugEnabled = debugParam || debugStorage;
+                  const debugLog = function(message, details){
+                    if (!debugEnabled || !window.console || !window.console.log) return;
+                    window.console.log('[MH Landing Analytics] ' + message, details || {});
+                  };
                   const sessionKey = 'mh_lp_session_' + slugValue;
                   const sessionId = sessionStorage.getItem(sessionKey) || (Date.now().toString(36) + '-' + Math.random().toString(36).slice(2));
                   sessionStorage.setItem(sessionKey, sessionId);
+                  debugLog('script carregado', {slug: slugValue, endpoint: endpoint, sessionId: sessionId, readyState: document.readyState});
                   const buildEventId = function(){
                     return crypto.randomUUID ? crypto.randomUUID() : (Date.now().toString(36) + '-' + Math.random().toString(36).slice(2));
                   };
@@ -166,13 +204,18 @@ public class FlowController {
                       occurredAt: new Date().toISOString(),
                       userAgent: navigator.userAgent
                     };
+                    debugLog('enviando evento', {endpoint: endpoint, payload: payload});
                     if (navigator.sendBeacon) {
-                      navigator.sendBeacon(endpoint, new Blob([JSON.stringify(payload)], {type: 'application/json'}));
+                      const accepted = navigator.sendBeacon(endpoint, new Blob([JSON.stringify(payload)], {type: 'application/json'}));
+                      debugLog('sendBeacon executado', {eventId: payload.eventId, eventType: eventType, accepted: accepted});
                       return;
                     }
-                    fetch(endpoint, {method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify(payload), keepalive: true}).catch(function(){});
+                    fetch(endpoint, {method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify(payload), keepalive: true})
+                      .then(function(response){ debugLog('fetch concluído', {eventId: payload.eventId, eventType: eventType, status: response.status}); })
+                      .catch(function(error){ debugLog('fetch falhou', {eventId: payload.eventId, eventType: eventType, error: error && error.message ? error.message : String(error)}); });
                   };
                   const startTracking = function(){
+                    debugLog('tracking iniciado', {slug: slugValue});
                     sendEvent('page_view', null, null);
                     const visibleSince = new Map();
                     const observer = new IntersectionObserver(function(entries){
@@ -181,7 +224,10 @@ public class FlowController {
                         const sectionId = entry.target.id || entry.target.getAttribute('data-section-id') || entry.target.getAttribute('data-track-section');
                         if (!sectionId) return;
                         if (entry.isIntersecting && entry.intersectionRatio >= 0.5) {
-                          if (!visibleSince.has(sectionId)) visibleSince.set(sectionId, now);
+                          if (!visibleSince.has(sectionId)) {
+                            visibleSince.set(sectionId, now);
+                            debugLog('seção visível', {sectionId: sectionId});
+                          }
                         } else if (visibleSince.has(sectionId)) {
                           const startedAt = visibleSince.get(sectionId);
                           visibleSince.delete(sectionId);
@@ -189,13 +235,17 @@ public class FlowController {
                         }
                       });
                     }, {threshold:[0.5]});
-                    document.querySelectorAll('section[id], [data-section-id], [data-track-section]').forEach(function(el){ observer.observe(el); });
+                    const trackedSections = document.querySelectorAll('section[id], [data-section-id], [data-track-section]');
+                    debugLog('seções monitoradas', {count: trackedSections.length});
+                    trackedSections.forEach(function(el){ observer.observe(el); });
                     window.addEventListener('beforeunload', function(){
                       const now = performance.now();
+                      debugLog('beforeunload processando seções visíveis', {count: visibleSince.size});
                       visibleSince.forEach(function(startedAt, sectionId){ sendEvent('section_view_time', sectionId, now - startedAt); });
                     });
                   };
                   if (document.readyState === 'loading') {
+                    debugLog('aguardando DOMContentLoaded', {readyState: document.readyState});
                     document.addEventListener('DOMContentLoaded', startTracking);
                   } else {
                     startTracking();
@@ -203,10 +253,6 @@ public class FlowController {
                 })();
                 </script>
                 """.formatted(toJsStringLiteral(slug));
-        if (html.toLowerCase(Locale.ROOT).contains("</body>")) {
-            return html.replaceFirst("(?i)</body>", java.util.regex.Matcher.quoteReplacement(analyticsScript + "\n</body>"));
-        }
-        return html + "\n" + analyticsScript;
     }
 
     /**

--- a/lead-portal/backend/src/test/java/com/marketinghub/leadportal/controller/FlowControllerTest.java
+++ b/lead-portal/backend/src/test/java/com/marketinghub/leadportal/controller/FlowControllerTest.java
@@ -20,6 +20,7 @@ import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.http.MediaType;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.MvcResult;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.hamcrest.Matchers.hasSize;
@@ -274,7 +275,40 @@ class FlowControllerTest {
                 .andExpect(content().string(containsString("Landing direta")))
                 .andExpect(content().string(containsString("data-mh-landing-analytics=\"true\"")))
                 .andExpect(content().string(containsString("/api/flows/")))
-                .andExpect(content().string(containsString("/page-analytics")));
+                .andExpect(content().string(containsString("/page-analytics")))
+                .andExpect(content().string(containsString("mhAnalyticsDebug")))
+                .andExpect(content().string(containsString("[MH Landing Analytics]")));
+    }
+
+    /**
+     * Valida atualização de instrumentação legada para exibir diagnóstico no browser sem duplicar analytics.
+     */
+    @Test
+    void getStandaloneFlowPageRefreshesLegacyAnalyticsScriptWithBrowserDebug() throws Exception {
+        UpsertFlowRequest request = buildRequest();
+        request.setCustomFormHtml("""
+                <!doctype html><html><body>
+                <main>Landing ja publicada</main>
+                <script data-mh-landing-analytics="true">console.log('analytics antigo');</script>
+                </body></html>
+                """);
+
+        mockMvc.perform(put("/api/flows/landing-legada")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk());
+
+        MvcResult result = mockMvc.perform(get("/api/flows/landing-legada/page"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith(MediaType.TEXT_HTML))
+                .andReturn();
+
+        String body = result.getResponse().getContentAsString();
+        assertThat(body).contains("Landing ja publicada");
+        assertThat(body).contains("mhAnalyticsDebug");
+        assertThat(body).contains("[MH Landing Analytics]");
+        assertThat(body).doesNotContain("analytics antigo");
+        assertThat(body.split("data-mh-landing-analytics", -1).length - 1).isEqualTo(1);
     }
 
     /**


### PR DESCRIPTION
### Motivation

- Investigar ausência de eventos `page-analytics` no backend adicionando observabilidade no navegador para confirmar carregamento do script, endpoint usado e mecanismo de envio (`sendBeacon`/`fetch`).
- Garantir que landings publicadas com instrumentação legada passem a exibir logs de debug sem duplicar scripts e sem exigir re-publicação manual.

### Description

- Atualiza `FlowController` para injetar ou atualizar a instrumentação de analytics através de `injectLandingAnalyticsScript`, extraindo `refreshLandingAnalyticsScriptWhenMissingDebug` e `buildLandingAnalyticsScript` para compor/atualizar o script em HTML standalone. 
- O script injetado passa a habilitar logs no console quando o debug é ativado por `?mhAnalyticsDebug=1` ou por `localStorage.mhLandingAnalyticsDebug=true`, e registra carregamento, envio de eventos, resultado de `sendBeacon`/`fetch`, seções monitoradas e processamento em `beforeunload` com prefixo `[MH Landing Analytics]`.
- Quando o HTML já contém um `<script data-mh-landing-analytics="true">` sem `mhAnalyticsDebug`, o código substitui o script legado pelo novo script com logs, preservando apenas uma ocorrência e evitando duplicação; a injeção respeita presença de `</body>` ou anexa ao final do documento.
- Ajusta e adiciona testes em `FlowControllerTest` para validar que o HTML entregue contém o script com `data-mh-landing-analytics`, o parâmetro `mhAnalyticsDebug` e as mensagens de debug, e que o script legado é substituído sem duplicação.

### Testing

- Executados testes unitários de `lead-portal` via suíte de testes do projeto incluindo `FlowControllerTest`; todos os testes da suíte foram aprovados.
- Testes específicos executados foram `getStandaloneFlowPageReturnsHtmlDocumentWithoutJsonFetch` (expectativas atualizadas) e o novo `getStandaloneFlowPageRefreshesLegacyAnalyticsScriptWithBrowserDebug`, ambos passando com sucesso.
- A cobertura verifica presença do script injetado, tokens de debug (`mhAnalyticsDebug`), mensagens de console e garante que não haja duplicação de `data-mh-landing-analytics` no HTML.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a223dc0413883219a409a085464c88d)