### PR TITLE
Fix official pipeline rebuild deletion (materialize orphanRemoval deletes before recreate)

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/pipeline/service/PipelineDefinitionSynchronizer.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/pipeline/service/PipelineDefinitionSynchronizer.java
@@ -128,10 +128,10 @@ public class PipelineDefinitionSynchronizer {
         List<PipelineStage> existingStages = new ArrayList<>(pipeline.getStages());
         List<String> appliedActions = new ArrayList<>();
         synchronizePipelineFields(pipeline, definition, appliedActions);
-        stageRepository.deleteAll(existingStages);
-        stageRepository.flush();
         pipeline.getStages().clear();
-        appliedActions.add("Etapas operacionais antigas removidas para recriação oficial controlada pela tela.");
+        stageRepository.flush();
+        appliedActions.add(
+                "Etapas operacionais antigas removidas por orphanRemoval antes da recriação oficial controlada pela tela.");
 
         definition.stages().stream()
                 .sorted(Comparator.comparingInt(PipelineStageDefinition::position))

--- a/backend/ads-service/src/test/java/com/marketinghub/pipeline/service/PipelineServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/pipeline/service/PipelineServiceTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -379,7 +380,8 @@ class PipelineServiceTest {
                     assertThat(stage.getOpenAiModel()).isEqualTo(model);
                 });
         assertThat(result.appliedActions()).anyMatch(action -> action.contains("Etapas operacionais antigas removidas"));
-        verify(stageRepository).deleteAll(any());
+        verify(stageRepository).flush();
+        verify(stageRepository, never()).deleteAll(any());
     }
 
     /**

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -3539,3 +3539,16 @@
 - solicitação: validar o print do navegador com `?mhAnalyticsDebug=1` sem mensagens `[MH Landing Analytics]` no console.
 - causa-raiz identificada: páginas já publicadas podem conter `data-mh-landing-analytics` antigo no HTML salvo; a entrega standalone retornava o HTML sem reinjetar o script, portanto o parâmetro `mhAnalyticsDebug=1` não tinha efeito nessas publicações legadas.
 - correção aplicada: quando a landing já possui script `data-mh-landing-analytics` sem `mhAnalyticsDebug`, o Lead Portal agora substitui a instrumentação legada pelo script atualizado com logs de browser, preservando um único script de analytics e evitando duplicação.
+
+## 2026-06-05 01:25:33 UTC-3
+- erro observado na tela de Pipelines ao acionar `POST /api/pipelines/1/rebuild-official-stages`, com resposta 500 por `Duplicate entry '1-campaign-angle' for key 'uk_pipeline_stage_code'`.
+- causa-raiz identificada: a recriação destrutiva tentava excluir as etapas via repositório enquanto a coleção `Pipeline.stages` ainda mantinha os filhos associados ao aggregate JPA com `orphanRemoval`, permitindo que a inserção das novas etapas ocorresse sem a remoção efetiva prévia da linha antiga no flush.
+- correção aplicada: o rebuild agora remove as etapas pelo aggregate (`pipeline.getStages().clear()`), força `flush()` para materializar os deletes por orphanRemoval antes dos inserts e só então recria as etapas oficiais, preservando descrição e modelo OpenAI por snapshot.
+- documentos lidos para pesquisar e resolver o problema:
+  - AGENTS.md
+  - backend/AGENTS.md
+  - docs/registros/experimentos.md
+  - backend/ads-service/src/main/java/com/marketinghub/pipeline/service/PipelineDefinitionSynchronizer.java
+  - backend/ads-service/src/main/java/com/marketinghub/pipeline/Pipeline.java
+  - backend/ads-service/src/main/java/com/marketinghub/pipeline/PipelineStage.java
+  - backend/ads-service/src/test/java/com/marketinghub/pipeline/service/PipelineServiceTest.java


### PR DESCRIPTION
### Motivation
- Corrigir erro 500 ao acionar `POST /api/pipelines/{id}/rebuild-official-stages` causado por `Duplicate entry ... uk_pipeline_stage_code` quando novas etapas são inseridas antes das deletes por `orphanRemoval` serem materializadas. 
- Garantir que a recriação das etapas oficiais preserve configurações operacionais (descrição e `OpenAiModel`) e não provoque inconsistências/duplicidades no banco. 

### Description
- Ajustado `PipelineDefinitionSynchronizer.rebuildOfficialStages` para limpar a coleção gerenciada via `pipeline.getStages().clear()` e dar `flush()` no `stageRepository` antes de recriar as etapas oficiais, removendo a chamada anterior que usava `deleteAll(existingStages)`, e atualizada a mensagem de ação aplicada. 
- Atualizado o teste `PipelineServiceTest` para esperar `flush()` e garantir que `deleteAll` não seja usado, preservando validação de preservação de `description` e `openAiModel`. 
- Adicionado registro operacional no `docs/registros/experimentos.md` documentando o erro observado, causa-raiz e correção aplicada. 

### Testing
- Executado o teste unitário focado com `mvn -f pom.xml -Dtest=PipelineServiceTest test`, resultado: `BUILD SUCCESS` e `Tests run: 18, Failures: 0, Errors: 0`. 
- Executada verificação de formatação `mvn -f pom.xml spotless:check`, resultado: falha por plugin não encontrado (`No plugin found for prefix 'spotless'`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a224f40656083219d11766e68fe4cb4)