### PR TITLE
Selecionar modelo oficial da OpenAI antes de salvar (autocomplete + validação)

### DIFF
--- a/frontend/src/pages/openaiModel/NewOpenAiModelPage.tsx
+++ b/frontend/src/pages/openaiModel/NewOpenAiModelPage.tsx
@@ -1,5 +1,6 @@
 import { useNavigate } from "react-router-dom";
 import { useCreateOpenAiModel } from "../../api/openAiModel/useCreateOpenAiModel";
+import { useOpenAiModelCatalog } from "../../api/openAiModel/useOpenAiModelCatalog";
 import PageTitle from "../../components/PageTitle";
 import OpenAiModelForm, { OpenAiModelFormValues } from "./OpenAiModelForm";
 
@@ -12,6 +13,12 @@ function toPayload(values: OpenAiModelFormValues) {
 export default function NewOpenAiModelPage() {
   const navigate = useNavigate();
   const create = useCreateOpenAiModel();
+  const { data: catalog, isLoading: isLoadingCatalog } =
+    useOpenAiModelCatalog();
+  const officialModelCodes = [
+    ...(catalog?.textModels ?? []),
+    ...(catalog?.imageModels ?? []),
+  ];
 
   const handleSubmit = (values: OpenAiModelFormValues) => {
     create.mutate(toPayload(values), {
@@ -26,6 +33,8 @@ export default function NewOpenAiModelPage() {
         onSubmit={handleSubmit}
         isSubmitting={create.isPending}
         submitLabel="Buscar na OpenAI e salvar"
+        officialModelCodes={officialModelCodes}
+        isLoadingOfficialModels={isLoadingCatalog}
         nameOnly
       />
     </div>

--- a/frontend/src/pages/openaiModel/OpenAiModelForm.test.tsx
+++ b/frontend/src/pages/openaiModel/OpenAiModelForm.test.tsx
@@ -1,0 +1,59 @@
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import OpenAiModelForm from "./OpenAiModelForm";
+
+describe("OpenAiModelForm", () => {
+  afterEach(() => cleanup());
+  it("mostra modelos oficiais filtrados e exige seleção antes de salvar uma busca parcial", () => {
+    const onSubmit = vi.fn();
+    render(
+      <OpenAiModelForm
+        onSubmit={onSubmit}
+        submitLabel="Buscar na OpenAI e salvar"
+        officialModelCodes={["gpt-5.5", "gpt-5.5-mini", "gpt-4o-mini"]}
+        nameOnly
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText(/Nome do modelo/i), {
+      target: { value: "5.5" },
+    });
+
+    expect(screen.getByText("gpt-5.5")).toBeTruthy();
+    expect(screen.getByText("gpt-5.5-mini")).toBeTruthy();
+    expect(screen.queryByText("gpt-4o-mini")).toBeNull();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /Buscar na OpenAI e salvar/i }),
+    );
+
+    expect(onSubmit).not.toHaveBeenCalled();
+    expect(
+      screen.getByText(/Escolha um modelo oficial da lista/i),
+    ).toBeTruthy();
+  });
+
+  it("salva o código oficial após o usuário escolher um modelo da lista", () => {
+    const onSubmit = vi.fn();
+    render(
+      <OpenAiModelForm
+        onSubmit={onSubmit}
+        submitLabel="Buscar na OpenAI e salvar"
+        officialModelCodes={["gpt-5.5", "gpt-5.5-mini"]}
+        nameOnly
+      />,
+    );
+
+    fireEvent.change(screen.getByLabelText(/Nome do modelo/i), {
+      target: { value: "5.5" },
+    });
+    fireEvent.click(screen.getByRole("button", { name: /gpt-5\.5-mini/i }));
+    fireEvent.click(
+      screen.getByRole("button", { name: /Buscar na OpenAI e salvar/i }),
+    );
+
+    expect(onSubmit).toHaveBeenCalledWith(
+      expect.objectContaining({ name: "gpt-5.5-mini" }),
+    );
+  });
+});

--- a/frontend/src/pages/openaiModel/OpenAiModelForm.tsx
+++ b/frontend/src/pages/openaiModel/OpenAiModelForm.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, type ChangeEvent } from "react";
+import { useEffect, useMemo, useState, type ChangeEvent } from "react";
 
 export type OpenAiModelFormValues = {
   name: string;
@@ -26,6 +26,8 @@ interface Props {
   isSubmitting?: boolean;
   submitLabel?: string;
   nameOnly?: boolean;
+  officialModelCodes?: string[];
+  isLoadingOfficialModels?: boolean;
 }
 
 const DEFAULT_VALUES: OpenAiModelFormValues = {
@@ -46,8 +48,11 @@ export default function OpenAiModelForm({
   isSubmitting = false,
   submitLabel = "Salvar",
   nameOnly = false,
+  officialModelCodes = [],
+  isLoadingOfficialModels = false,
 }: Props) {
   const [values, setValues] = useState<OpenAiModelFormValues>(initialValues);
+  const [showSelectionWarning, setShowSelectionWarning] = useState(false);
 
   useEffect(() => {
     setValues(initialValues);
@@ -60,10 +65,35 @@ export default function OpenAiModelForm({
         event.target.type === "checkbox"
           ? event.target.checked
           : event.target.value;
+      setShowSelectionWarning(false);
       setValues((prev) => ({ ...prev, [field]: nextValue }));
     };
 
-  const handleSubmit = () => onSubmit(values);
+  const normalizedQuery = values.name.trim().toLowerCase();
+  const matchingOfficialModels = useMemo(() => {
+    if (!nameOnly || !normalizedQuery) return [];
+    return officialModelCodes
+      .filter((modelCode) => modelCode.toLowerCase().includes(normalizedQuery))
+      .sort((left, right) => left.localeCompare(right));
+  }, [nameOnly, normalizedQuery, officialModelCodes]);
+  const hasExactOfficialModel = matchingOfficialModels.some(
+    (modelCode) => modelCode.toLowerCase() === normalizedQuery,
+  );
+  const mustChooseOfficialModel =
+    nameOnly && matchingOfficialModels.length > 0 && !hasExactOfficialModel;
+
+  const selectOfficialModel = (modelCode: string) => {
+    setShowSelectionWarning(false);
+    setValues((prev) => ({ ...prev, name: modelCode }));
+  };
+
+  const handleSubmit = () => {
+    if (mustChooseOfficialModel) {
+      setShowSelectionWarning(true);
+      return;
+    }
+    onSubmit(values);
+  };
 
   const submitDisabled = isSubmitting || !values.name.trim();
 
@@ -118,6 +148,58 @@ export default function OpenAiModelForm({
                 onChange={handleChange("code")}
                 placeholder="ex: gpt-4o-mini"
               />
+            </div>
+          ) : null}
+          {nameOnly && values.name.trim() ? (
+            <div className="col-12">
+              <div className="border rounded p-3 bg-light">
+                <div className="d-flex align-items-center justify-content-between gap-2 flex-wrap mb-2">
+                  <strong>Modelos oficiais encontrados</strong>
+                  {isLoadingOfficialModels ? (
+                    <span className="text-body-secondary small">
+                      <span
+                        className="spinner-border spinner-border-sm me-2"
+                        aria-hidden="true"
+                      />
+                      Consultando OpenAI...
+                    </span>
+                  ) : null}
+                </div>
+                {matchingOfficialModels.length > 0 ? (
+                  <div className="d-flex flex-column gap-2">
+                    {matchingOfficialModels.map((modelCode) => (
+                      <button
+                        key={modelCode}
+                        type="button"
+                        className={`btn text-start ${
+                          modelCode.toLowerCase() === normalizedQuery
+                            ? "btn-primary"
+                            : "btn-outline-primary"
+                        }`}
+                        onClick={() => selectOfficialModel(modelCode)}
+                      >
+                        <code>{modelCode}</code>
+                        <span className="ms-2 small">
+                          {modelCode.toLowerCase() === normalizedQuery
+                            ? "selecionado"
+                            : "selecionar"}
+                        </span>
+                      </button>
+                    ))}
+                  </div>
+                ) : (
+                  <p className="text-body-secondary mb-0">
+                    Nenhum modelo oficial encontrado para esse texto. Verifique
+                    o nome ou código antes de salvar.
+                  </p>
+                )}
+                {showSelectionWarning ? (
+                  <div className="alert alert-warning mt-3 mb-0">
+                    Escolha um modelo oficial da lista antes de inserir no
+                    catálogo administrativo.
+                  </div>
+                ) : null}
+              </div>
             </div>
           ) : null}
           {!nameOnly ? (


### PR DESCRIPTION
### Motivation
- Permitir que buscas parciais como `5.5` mostrem opções oficiais para o usuário escolher o código canônico antes de inserir no catálogo administrativo.
- Evitar salvar nomes/parciais ambíguas e garantir que o backend receba códigos oficiais reconhecidos pela API `/models` da OpenAI.

### Description
- A tela de novo modelo passa o catálogo oficial para o formulário adicionando `officialModelCodes` e `isLoadingOfficialModels` em `frontend/src/pages/openaiModel/NewOpenAiModelPage.tsx`.
- O formulário `OpenAiModelForm` agora filtra `officialModelCodes`, exibe uma lista de correspondências e exige seleção de um código oficial quando a entrada é parcial, atualizando o campo `name` com o código escolhido (`frontend/src/pages/openaiModel/OpenAiModelForm.tsx`).
- O envio é bloqueado enquanto houver correspondências oficiais múltiplas sem correspondência exata, exibindo um aviso até que o usuário selecione um item da lista.
- Adicionado teste unitário `OpenAiModelForm.test.tsx` cobrindo filtragem, bloqueio de envio e seleção do código oficial (`frontend/src/pages/openaiModel/OpenAiModelForm.test.tsx`).

### Testing
- Executado `npm run test -- src/pages/openaiModel/OpenAiModelForm.test.tsx --run` e os testes unitários passaram com sucesso.
- Executado `npm run typecheck` e `npm run build` com sucesso sem erros de TypeScript ou build.
- Gerei uma captura para demonstração (mock da API de catálogo) em `/tmp/openai-model-selector.png` para validar a interface de seleção visual durante testes manuais/automatizados.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a225740e4848321bcaa8744383ef0c2)