### PR TITLE
Add compatibility endpoint to accept GeraLanding public submission and forward to Marketing Hub

### DIFF
--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -3566,3 +3566,11 @@
 - correção aplicada: a etapa de aprovação/publicação da landing pública agora injeta, quando detecta controles mínimos de captura e ausência de contrato existente, o script de submissão canônico `lead-portal-submission-engagement.v1`, enviando nome/e-mail para o endpoint público do Lead Portal antes de republicar o HTML final.
 - cânone atualizado: `docs/canonical/procedimento-experimento-canon.v1.md` registra que a aprovação deve injetar submissão canônica idempotente na cópia publicável quando houver controles mínimos de captura.
 - validação automatizada: adicionado teste unitário no `BackendPublicLandingServiceTest` garantindo que a aprovação injeta contrato, endpoint de submissão e handler de clique no artefato publicado.
+
+## 2026-06-05 — Compatibilidade do endpoint de submissão pública no Lead Portal
+
+- solicitação: investigar o erro exibido na landing do experimento 37 ao clicar em “Receber minha prévia”.
+- causa-raiz identificada: o HTML publicável do GeraLanding enviava o contrato `lead-portal-submission-engagement.v1` para `/api/public/lead-portal/flows/{slug}/submission` usando URL relativa ao domínio `oportunidadebrasil.shop`; esse domínio é atendido pelo Lead Portal, mas o endpoint existia apenas no backend principal, então a requisição caía no handler de recurso estático e retornava `500` com `No static resource .../submission`.
+- correção aplicada: o Lead Portal ganhou um endpoint de compatibilidade para receber essa rota pública, validar divergência de slug, extrair `submissionId`, `submittedAt` e `contato`, e encaminhar a submissão ao Marketing Hub pelo `ExperimentFunnelTrackingClient`, preservando o contrato já publicado nas landings.
+- documentação atualizada: `docs/swagger/lead-portal-swagger.yaml` registra a rota pública de compatibilidade do Lead Portal.
+- validação automatizada: adicionado teste MVC cobrindo o payload real do GeraLanding e rejeição de slug divergente.

--- a/docs/swagger/lead-portal-swagger.yaml
+++ b/docs/swagger/lead-portal-swagger.yaml
@@ -1,0 +1,85 @@
+openapi: 3.1.0
+info:
+  title: Lead Portal Public API
+  version: 1.0.0
+  description: |
+    Endpoints públicos expostos pelo Lead Portal para páginas publicadas e
+    compatibilidade de tracking com o Marketing Hub.
+servers:
+  - url: https://oportunidadebrasil.shop
+    description: Produção do Lead Portal
+  - url: http://localhost:8080
+    description: Desenvolvimento local do Lead Portal
+tags:
+  - name: Public lead submissions
+    description: Recepção de submissões públicas e encaminhamento ao funil do Marketing Hub.
+paths:
+  /api/public/lead-portal/flows/{slug}/submission:
+    post:
+      tags: [Public lead submissions]
+      summary: Receber submissão pública publicada pelo GeraLanding
+      description: |
+        Endpoint de compatibilidade para landings publicadas no domínio do Lead Portal
+        que enviam o contrato `lead-portal-submission-engagement.v1` para a rota
+        pública do Marketing Hub usando URL relativa. O Lead Portal valida o slug,
+        extrai os dados de contato e encaminha a submissão ao Marketing Hub pelo
+        cliente de tracking configurado.
+      parameters:
+        - name: slug
+          in: path
+          required: true
+          description: Slug do fluxo publicado no Lead Portal.
+          schema:
+            type: string
+            example: exp-37-landing-geralanding
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              type: object
+              required: [contractVersion, slug, submissionId, submittedAt, contato]
+              properties:
+                contractVersion:
+                  type: string
+                  const: lead-portal-submission-engagement.v1
+                slug:
+                  type: string
+                submissionId:
+                  type: string
+                  description: UUID idempotente gerado pela landing; texto legado também é aceito e convertido de forma determinística.
+                submittedAt:
+                  type: string
+                  format: date-time
+                campaignCode:
+                  type: string
+                  nullable: true
+                contato:
+                  type: object
+                  required: [nome, email]
+                  properties:
+                    nome:
+                      type: string
+                    email:
+                      type: string
+                      format: email
+                    telefone:
+                      type: string
+                      nullable: true
+            example:
+              contractVersion: lead-portal-submission-engagement.v1
+              slug: exp-37-landing-geralanding
+              submissionId: f04e8042-b50f-493a-9be2-e3d73a761321
+              submittedAt: '2026-06-05T15:03:13.127Z'
+              contato:
+                nome: Paulo Forestieri
+                email: paulofore@gmail.com
+      responses:
+        '202':
+          description: Submissão encaminhada ao Marketing Hub.
+        '204':
+          description: Marketing Hub rejeitou a submissão como evento ignorável/idempotente.
+        '400':
+          description: Slug do payload diverge do slug da rota ou payload inválido.
+        '502':
+          description: Falha ao encaminhar a submissão ao Marketing Hub.

--- a/lead-portal/backend/src/main/java/com/marketinghub/leadportal/controller/PublicLeadPortalSubmissionController.java
+++ b/lead-portal/backend/src/main/java/com/marketinghub/leadportal/controller/PublicLeadPortalSubmissionController.java
@@ -1,0 +1,165 @@
+package com.marketinghub.leadportal.controller;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marketinghub.leadportal.service.ExperimentFunnelTrackingClient;
+import com.marketinghub.leadportal.service.ExperimentFunnelTrackingClient.TrackingResult;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.time.format.DateTimeParseException;
+import java.util.Map;
+import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.util.StringUtils;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * Controller de compatibilidade que recebe submissões públicas publicadas no host do Lead Portal.
+ */
+@RestController
+@RequestMapping("/api/public/lead-portal/flows")
+public class PublicLeadPortalSubmissionController {
+
+    private static final Logger log = LoggerFactory.getLogger(PublicLeadPortalSubmissionController.class);
+
+    private final ExperimentFunnelTrackingClient trackingClient;
+    private final ObjectMapper objectMapper;
+
+    /**
+     * Inicializa o controller com cliente de tracking e parser JSON.
+     */
+    public PublicLeadPortalSubmissionController(
+            ExperimentFunnelTrackingClient trackingClient,
+            ObjectMapper objectMapper) {
+        this.trackingClient = trackingClient;
+        this.objectMapper = objectMapper;
+    }
+
+    /**
+     * Recebe o contrato canônico de submissão gerado pelo GeraLanding e encaminha ao Marketing Hub.
+     */
+    @PostMapping("/{slug}/submission")
+    public ResponseEntity<Void> registerSubmission(
+            @PathVariable("slug") String slug,
+            @RequestBody(required = false) String requestBody) {
+        Map<String, Object> payload = parseSubmissionRequest(slug, requestBody);
+        String payloadSlug = textValue(payload.get("slug"));
+        if (payloadSlug != null && !payloadSlug.equals(slug)) {
+            log.warn("Submission com slug divergente recebida no Lead Portal. routeSlug={}, payloadSlug={}", slug, payloadSlug);
+            return ResponseEntity.badRequest().build();
+        }
+
+        Map<String, Object> contato = objectMap(payload.get("contato"));
+        UUID submissionId = resolveSubmissionId(textValue(payload.get("submissionId")));
+        Instant submittedAt = parseSubmittedAt(textValue(payload.get("submittedAt")));
+        String campaignCode = textValue(payload.get("campaignCode"));
+        String contactName = textValue(contato.get("nome"));
+        String contactEmail = textValue(contato.get("email"));
+        String contactPhone = textValue(contato.get("telefone"));
+
+        log.info("Submission pública recebida no Lead Portal. slug={}, submissionId={}, emailPresent={}",
+                slug, submissionId, StringUtils.hasText(contactEmail));
+        TrackingResult result = trackingClient.registerSubmission(
+                slug,
+                submissionId,
+                submittedAt,
+                campaignCode,
+                contactName,
+                contactEmail,
+                contactPhone);
+        return toResponse(result);
+    }
+
+    /**
+     * Faz o parse do payload cru de submissão preservando contexto operacional em caso de JSON inválido.
+     */
+    private Map<String, Object> parseSubmissionRequest(String slug, String requestBody) {
+        if (!StringUtils.hasText(requestBody)) {
+            throw new IllegalArgumentException("Payload de submissão é obrigatório");
+        }
+        try {
+            return objectMapper.readValue(requestBody, new TypeReference<>() {});
+        } catch (JsonProcessingException ex) {
+            log.warn("Payload inválido em submission pública do Lead Portal. slug={}, rawPayload={}", slug, requestBody, ex);
+            throw new IllegalArgumentException("Payload de submissão inválido", ex);
+        }
+    }
+
+    /**
+     * Resolve o identificador idempotente da submissão aceitando UUID nativo ou texto legado determinístico.
+     */
+    private UUID resolveSubmissionId(String submissionId) {
+        if (!StringUtils.hasText(submissionId)) {
+            throw new IllegalArgumentException("submissionId é obrigatório");
+        }
+        String sanitized = submissionId.trim();
+        try {
+            return UUID.fromString(sanitized);
+        } catch (IllegalArgumentException ex) {
+            UUID deterministicId = UUID.nameUUIDFromBytes(sanitized.getBytes(StandardCharsets.UTF_8));
+            log.warn("submissionId textual convertido para UUID determinístico no Lead Portal. submissionId={}, deterministicId={}",
+                    sanitized, deterministicId, ex);
+            return deterministicId;
+        }
+    }
+
+    /**
+     * Converte submittedAt para Instant e usa o momento atual quando a origem não envia valor válido.
+     */
+    private Instant parseSubmittedAt(String submittedAt) {
+        if (!StringUtils.hasText(submittedAt)) {
+            return Instant.now();
+        }
+        try {
+            return Instant.parse(submittedAt.trim());
+        } catch (DateTimeParseException ex) {
+            log.warn("submittedAt inválido em submission pública do Lead Portal. submittedAt={}", submittedAt, ex);
+            return Instant.now();
+        }
+    }
+
+    /**
+     * Converte valor genérico em mapa quando o JSON contém objeto aninhado.
+     */
+    private Map<String, Object> objectMap(Object value) {
+        if (value instanceof Map<?, ?> rawMap) {
+            return rawMap.entrySet().stream()
+                    .filter(entry -> entry.getKey() != null)
+                    .collect(java.util.stream.Collectors.toMap(
+                            entry -> entry.getKey().toString(),
+                            Map.Entry::getValue,
+                            (left, right) -> right));
+        }
+        return Map.of();
+    }
+
+    /**
+     * Extrai texto normalizado de valores JSON simples.
+     */
+    private String textValue(Object value) {
+        if (value == null) {
+            return null;
+        }
+        String text = value.toString().trim();
+        return text.isEmpty() ? null : text;
+    }
+
+    /**
+     * Converte o resultado do encaminhamento para resposta HTTP pública do Lead Portal.
+     */
+    private ResponseEntity<Void> toResponse(TrackingResult result) {
+        return switch (result) {
+            case FORWARDED -> ResponseEntity.accepted().build();
+            case SKIPPED -> ResponseEntity.noContent().build();
+            case FAILED -> ResponseEntity.status(HttpStatus.BAD_GATEWAY).build();
+        };
+    }
+}

--- a/lead-portal/backend/src/test/java/com/marketinghub/leadportal/controller/PublicLeadPortalSubmissionControllerTest.java
+++ b/lead-portal/backend/src/test/java/com/marketinghub/leadportal/controller/PublicLeadPortalSubmissionControllerTest.java
@@ -1,0 +1,88 @@
+package com.marketinghub.leadportal.controller;
+
+import com.marketinghub.leadportal.service.ExperimentFunnelTrackingClient;
+import com.marketinghub.leadportal.service.ExperimentFunnelTrackingClient.TrackingResult;
+import java.time.Instant;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Testa o endpoint de compatibilidade que recebe submissões públicas no host do Lead Portal.
+ */
+@WebMvcTest(PublicLeadPortalSubmissionController.class)
+class PublicLeadPortalSubmissionControllerTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    @MockBean
+    private ExperimentFunnelTrackingClient trackingClient;
+
+    /**
+     * Valida que o contrato canônico publicado pelo GeraLanding é encaminhado ao Marketing Hub.
+     */
+    @Test
+    void registerSubmissionForwardsGeraLandingContract() throws Exception {
+        UUID submissionId = UUID.fromString("f04e8042-b50f-493a-9be2-e3d73a761321");
+        Instant submittedAt = Instant.parse("2026-06-05T15:03:13.127Z");
+        when(trackingClient.registerSubmission(
+                eq("exp-37-landing-geralanding"),
+                eq(submissionId),
+                eq(submittedAt),
+                eq(null),
+                eq("Paulo Forestieri"),
+                eq("paulofore@gmail.com"),
+                eq(null)))
+                .thenReturn(TrackingResult.FORWARDED);
+
+        mockMvc.perform(post("/api/public/lead-portal/flows/exp-37-landing-geralanding/submission")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "contractVersion":"lead-portal-submission-engagement.v1",
+                                  "slug":"exp-37-landing-geralanding",
+                                  "submissionId":"f04e8042-b50f-493a-9be2-e3d73a761321",
+                                  "submittedAt":"2026-06-05T15:03:13.127Z",
+                                  "contato":{"nome":"Paulo Forestieri","email":"paulofore@gmail.com"}
+                                }
+                                """))
+                .andExpect(status().isAccepted());
+
+        verify(trackingClient).registerSubmission(
+                eq("exp-37-landing-geralanding"),
+                eq(submissionId),
+                eq(submittedAt),
+                eq(null),
+                eq("Paulo Forestieri"),
+                eq("paulofore@gmail.com"),
+                eq(null));
+    }
+
+    /**
+     * Valida bloqueio de payload com slug divergente para evitar atribuição incorreta de funil.
+     */
+    @Test
+    void registerSubmissionRejectsDivergentSlug() throws Exception {
+        mockMvc.perform(post("/api/public/lead-portal/flows/route-slug/submission")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "slug":"payload-slug",
+                                  "submissionId":"f04e8042-b50f-493a-9be2-e3d73a761321",
+                                  "contato":{"nome":"Cliente","email":"cliente@example.com"}
+                                }
+                                """))
+                .andExpect(status().isBadRequest());
+    }
+}


### PR DESCRIPTION
### Motivation
- Published GeraLanding HTML can include a canonical lead submission contract that must be accepted by the Lead Portal host and forwarded to the Marketing Hub funnel service for processing and idempotent handling.

### Description
- Add `PublicLeadPortalSubmissionController` at `POST /api/public/lead-portal/flows/{slug}/submission` to accept the `lead-portal-submission-engagement.v1` contract, parse and validate the payload, and forward it to `ExperimentFunnelTrackingClient.registerSubmission`.
- Implement robust payload helpers including `parseSubmissionRequest`, `resolveSubmissionId` (accepts UUID or generates name-based UUID), `parseSubmittedAt`, `objectMap` and `textValue` to normalize inputs and preserve logs on invalid JSON.
- Map `ExperimentFunnelTrackingClient.TrackingResult` to appropriate HTTP responses (`202 Accepted`, `204 No Content`, `502 Bad Gateway`) and log operational context for observability.
- Add `PublicLeadPortalSubmissionControllerTest` to validate happy path forwarding and rejection of divergent `slug` in the payload.

### Testing
- Executed the lead-portal backend unit tests for the changed area with `mvn test -Dtest=PublicLeadPortalSubmissionControllerTest,FlowEngagementControllerTest` in the `lead-portal/backend` module.  
- The new test `PublicLeadPortalSubmissionControllerTest` (happy path and divergent-slug case) was included in the run; the Maven test invocation and dependency resolution started in the session but the full test output was truncated in the rollout transcript and the run could not be observed to completion here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a22e56c855c83218f9fd76e11f319ba)