### PR TITLE
Add executionModule and rootPackage to pipeline stages (DB, backend, frontend, docs)

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/pipeline/PipelineStage.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/pipeline/PipelineStage.java
@@ -54,6 +54,12 @@ public class PipelineStage {
     @Column(columnDefinition = "TEXT")
     private String description;
 
+    @Column(name = "execution_module", length = 80)
+    private String executionModule;
+
+    @Column(name = "root_package", length = 200)
+    private String rootPackage;
+
     @Column(nullable = false)
     @Builder.Default
     private boolean required = true;

--- a/backend/ads-service/src/main/java/com/marketinghub/pipeline/PipelineStageDefinitionEntity.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/pipeline/PipelineStageDefinitionEntity.java
@@ -63,6 +63,12 @@ public class PipelineStageDefinitionEntity {
     @Column(nullable = false, length = 80)
     private String implementedStageEnum;
 
+    @Column(name = "execution_module", length = 80)
+    private String executionModule;
+
+    @Column(name = "root_package", length = 200)
+    private String rootPackage;
+
     @Column(nullable = false)
     @Builder.Default
     private boolean requiresOpenAiModel = true;

--- a/backend/ads-service/src/main/java/com/marketinghub/pipeline/definition/PipelineDefinitionRegistry.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/pipeline/definition/PipelineDefinitionRegistry.java
@@ -19,6 +19,7 @@ public class PipelineDefinitionRegistry {
     private static final String EXPERIMENT_PIPELINE_CODE = "experiment-pipeline";
     private static final String EXPERIMENT_MODULE = "EXPERIMENT";
     private static final String EXPERIMENT_CANONICAL_VERSION = "procedimento-experimento-canon.v1";
+    private static final String EXPERIMENT_BACKEND_ROOT_PACKAGE = "com.marketinghub.experiment.pipeline";
 
     private final List<PipelineDefinition> officialPipelines;
     private final Set<String> validModules;
@@ -94,6 +95,8 @@ public class PipelineDefinitionRegistry {
                         section.ordinal() + 1,
                         true,
                         true,
+                        null,
+                        EXPERIMENT_BACKEND_ROOT_PACKAGE,
                         Set.of(section.path(), section.name(), section.name().toLowerCase(Locale.ROOT))))
                 .toList();
         return new PipelineDefinition(
@@ -203,6 +206,8 @@ public class PipelineDefinitionRegistry {
             int position,
             boolean required,
             boolean configurable,
+            String executionModule,
+            String rootPackage,
             Set<String> aliases) {
         /**
          * Informa se o código recebido é o código operacional ou alias da etapa.

--- a/backend/ads-service/src/main/java/com/marketinghub/pipeline/dto/OfficialPipelineStageDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/pipeline/dto/OfficialPipelineStageDto.java
@@ -14,5 +14,7 @@ public record OfficialPipelineStageDto(
         int position,
         boolean required,
         boolean configurable,
+        String executionModule,
+        String rootPackage,
         StageFieldPolicyDto fieldPolicy,
         List<String> aliases) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/pipeline/dto/PipelineStageDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/pipeline/dto/PipelineStageDto.java
@@ -20,6 +20,8 @@ public class PipelineStageDto {
     private String name;
     private String code;
     private String description;
+    private String executionModule;
+    private String rootPackage;
     private boolean required;
     private boolean active;
     private Long openAiModelId;

--- a/backend/ads-service/src/main/java/com/marketinghub/pipeline/dto/PipelineStageRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/pipeline/dto/PipelineStageRequest.java
@@ -24,6 +24,13 @@ public class PipelineStageRequest {
     private String code;
 
     private String description;
+
+    @Size(max = 80)
+    private String executionModule;
+
+    @Size(max = 200)
+    private String rootPackage;
+
     private boolean required = true;
     private boolean active = true;
     private Long openAiModelId;

--- a/backend/ads-service/src/main/java/com/marketinghub/pipeline/mapper/PipelineMapper.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/pipeline/mapper/PipelineMapper.java
@@ -40,6 +40,8 @@ public class PipelineMapper {
                 .name(stage.getName())
                 .code(stage.getCode())
                 .description(stage.getDescription())
+                .executionModule(stage.getExecutionModule())
+                .rootPackage(stage.getRootPackage())
                 .required(stage.isRequired())
                 .active(stage.isActive())
                 .openAiModelId(stage.getOpenAiModel() != null ? stage.getOpenAiModel().getId() : null)

--- a/backend/ads-service/src/main/java/com/marketinghub/pipeline/service/PipelineDefinitionSynchronizer.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/pipeline/service/PipelineDefinitionSynchronizer.java
@@ -228,7 +228,22 @@ public class PipelineDefinitionSynchronizer {
             stage.setRequired(stageDefinition.required());
             appliedActions.add("Obrigatoriedade estrutural da etapa corrigida: " + stageDefinition.operationalCode());
         }
+        if (!sameText(stageDefinition.executionModule(), stage.getExecutionModule())) {
+            stage.setExecutionModule(stageDefinition.executionModule());
+            appliedActions.add("Módulo executor da etapa corrigido: " + stageDefinition.operationalCode());
+        }
+        if (!sameText(stageDefinition.rootPackage(), stage.getRootPackage())) {
+            stage.setRootPackage(stageDefinition.rootPackage());
+            appliedActions.add("Pacote raiz da etapa corrigido: " + stageDefinition.operationalCode());
+        }
         stageRepository.save(stage);
+    }
+
+    /**
+     * Compara textos opcionais para detectar divergência estrutural de localização de código.
+     */
+    private boolean sameText(String expected, String actual) {
+        return java.util.Objects.equals(expected, actual);
     }
 
     /**
@@ -253,6 +268,8 @@ public class PipelineDefinitionSynchronizer {
                 .position(stageDefinition.position())
                 .name(stageDefinition.name())
                 .code(stageDefinition.operationalCode())
+                .executionModule(stageDefinition.executionModule())
+                .rootPackage(stageDefinition.rootPackage())
                 .required(stageDefinition.required())
                 .active(true)
                 .build();
@@ -276,6 +293,8 @@ public class PipelineDefinitionSynchronizer {
                 .name(stageDefinition.name())
                 .code(stageDefinition.operationalCode())
                 .description(configuredStage.map(PipelineStage::getDescription).orElse(null))
+                .executionModule(stageDefinition.executionModule())
+                .rootPackage(stageDefinition.rootPackage())
                 .required(stageDefinition.required())
                 .active(true)
                 .openAiModel(configuredStage.map(PipelineStage::getOpenAiModel).orElse(null))

--- a/backend/ads-service/src/main/java/com/marketinghub/pipeline/service/PipelinePersistentContractSynchronizer.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/pipeline/service/PipelinePersistentContractSynchronizer.java
@@ -116,6 +116,8 @@ public class PipelinePersistentContractSynchronizer {
                 .position(stageDefinition.position())
                 .required(stageDefinition.required())
                 .implementedStageEnum(stageDefinition.canonicalCode())
+                .executionModule(stageDefinition.executionModule())
+                .rootPackage(stageDefinition.rootPackage())
                 .requiresOpenAiModel(true)
                 .configurable(stageDefinition.configurable())
                 .build();
@@ -142,6 +144,14 @@ public class PipelinePersistentContractSynchronizer {
         }
         if (!stageDefinition.canonicalCode().equals(entity.getImplementedStageEnum())) {
             entity.setImplementedStageEnum(stageDefinition.canonicalCode());
+            changed = true;
+        }
+        if (!java.util.Objects.equals(stageDefinition.executionModule(), entity.getExecutionModule())) {
+            entity.setExecutionModule(stageDefinition.executionModule());
+            changed = true;
+        }
+        if (!java.util.Objects.equals(stageDefinition.rootPackage(), entity.getRootPackage())) {
+            entity.setRootPackage(stageDefinition.rootPackage());
             changed = true;
         }
         if (stageDefinition.configurable() != entity.isConfigurable()) {

--- a/backend/ads-service/src/main/java/com/marketinghub/pipeline/service/PipelineService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/pipeline/service/PipelineService.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Set;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
 
@@ -289,6 +290,12 @@ public class PipelineService {
         if (requestedDefinition.required() && !request.isActive()) {
             throw badRequest("Etapa obrigatória oficial não pode ser desativada sem regra explícita: " + request.getCode());
         }
+        if (!java.util.Objects.equals(requestedDefinition.executionModule(), normalizeOptionalText(request.getExecutionModule()))) {
+            throw badRequest("Módulo executor de etapa oficial não pode divergir do contrato: " + request.getCode());
+        }
+        if (!java.util.Objects.equals(requestedDefinition.rootPackage(), normalizeOptionalText(request.getRootPackage()))) {
+            throw badRequest("Pacote raiz de etapa oficial não pode divergir do contrato: " + request.getCode());
+        }
     }
 
     /**
@@ -419,6 +426,8 @@ public class PipelineService {
                 .position(definition.position())
                 .required(definition.required())
                 .configurable(definition.configurable())
+                .executionModule(definition.executionModule())
+                .rootPackage(definition.rootPackage())
                 .fieldPolicy(toStageFieldPolicyDto(pipelineDefinition))
                 .aliases(definition.aliases().stream().sorted().toList())
                 .build();
@@ -478,9 +487,18 @@ public class PipelineService {
         stage.setName(request.getName());
         stage.setCode(request.getCode());
         stage.setDescription(request.getDescription());
+        stage.setExecutionModule(normalizeOptionalText(request.getExecutionModule()));
+        stage.setRootPackage(normalizeOptionalText(request.getRootPackage()));
         stage.setRequired(request.isRequired());
         stage.setActive(request.isActive());
         stage.setOpenAiModel(resolveOpenAiModel(request.getOpenAiModelId()));
+    }
+
+    /**
+     * Normaliza texto opcional para não persistir strings vazias em campos de localização técnica.
+     */
+    private String normalizeOptionalText(String value) {
+        return StringUtils.hasText(value) ? value.trim() : null;
     }
 
     /**

--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-05-pipeline-stage-implementation-location.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-05-pipeline-stage-implementation-location.yaml
@@ -1,0 +1,65 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-06-05-pipeline-stage-implementation-location
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - onError: MARK_RAN
+        - dbms:
+            type: mysql
+        - not:
+            - columnExists:
+                tableName: pipeline_stage
+                columnName: execution_module
+      changes:
+        - addColumn:
+            tableName: pipeline_stage
+            columns:
+              - column:
+                  name: execution_module
+                  type: VARCHAR(80)
+              - column:
+                  name: root_package
+                  type: VARCHAR(200)
+        - sql:
+            splitStatements: true
+            stripComments: true
+            sql: |
+              UPDATE pipeline_stage ps
+              INNER JOIN pipeline p ON p.id = ps.pipeline_id
+              SET ps.root_package = 'com.marketinghub.experiment.pipeline'
+              WHERE p.code = 'experiment-pipeline'
+                AND ps.root_package IS NULL;
+  - changeSet:
+      id: 2026-06-05-pipeline-stage-definition-implementation-location
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - onError: MARK_RAN
+        - dbms:
+            type: mysql
+        - tableExists:
+            tableName: pipeline_stage_definition
+        - not:
+            - columnExists:
+                tableName: pipeline_stage_definition
+                columnName: execution_module
+      changes:
+        - addColumn:
+            tableName: pipeline_stage_definition
+            columns:
+              - column:
+                  name: execution_module
+                  type: VARCHAR(80)
+              - column:
+                  name: root_package
+                  type: VARCHAR(200)
+        - sql:
+            splitStatements: true
+            stripComments: true
+            sql: |
+              UPDATE pipeline_stage_definition psd
+              INNER JOIN pipeline_definition pd ON pd.id = psd.pipeline_definition_id
+              SET psd.root_package = 'com.marketinghub.experiment.pipeline'
+              WHERE pd.code = 'experiment-pipeline'
+                AND psd.root_package IS NULL;

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -1,5 +1,8 @@
 databaseChangeLog:
   - include:
+      file: changesets/2026-06-05-pipeline-stage-implementation-location.yaml
+      relativeToChangelogFile: true
+  - include:
       file: changesets/2026-06-05-oprm-enriched-niche-materializer.yaml
       relativeToChangelogFile: true
   - include:

--- a/backend/ads-service/src/test/java/com/marketinghub/pipeline/service/PipelineServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/pipeline/service/PipelineServiceTest.java
@@ -111,6 +111,8 @@ class PipelineServiceTest {
         assertThat(created.getPipeline()).isEqualTo(pipeline);
         assertThat(created.getPosition()).isEqualTo(1);
         assertThat(created.getName()).isEqualTo("Campaign Angle");
+        assertThat(created.getExecutionModule()).isNull();
+        assertThat(created.getRootPackage()).isNull();
         assertThat(created.isRequired()).isTrue();
         ArgumentCaptor<PipelineStage> captor = ArgumentCaptor.forClass(PipelineStage.class);
         verify(stageRepository).save(captor.capture());
@@ -252,6 +254,8 @@ class PipelineServiceTest {
                     .allSatisfy(stage -> {
                         assertThat(stage.canonicalCode()).isNotBlank();
                         assertThat(stage.operationalCode()).isNotBlank();
+                        assertThat(stage.executionModule()).isNull();
+                        assertThat(stage.rootPackage()).isEqualTo("com.marketinghub.experiment.pipeline");
                         assertThat(definitionRegistry.findStage(pipeline, stage.canonicalCode())).contains(stage);
                         assertThat(definitionRegistry.findStage(pipeline, stage.operationalCode())).contains(stage);
                     });
@@ -290,6 +294,8 @@ class PipelineServiceTest {
         assertThat(result.appliedActions()).anyMatch(action -> action.contains("Etapa oficial ausente criada"));
         assertThat(pipeline.getStages()).hasSize(8);
         assertThat(pipeline.getStages()).extracting(PipelineStage::getCode).contains("landing-page-html");
+        assertThat(pipeline.getStages())
+                .allSatisfy(stage -> assertThat(stage.getRootPackage()).isEqualTo("com.marketinghub.experiment.pipeline"));
     }
 
     /**
@@ -313,6 +319,7 @@ class PipelineServiceTest {
         assertThat(configured.getName()).isEqualTo("Campaign Angle");
         assertThat(configured.getDescription()).isEqualTo("Descrição operacional do usuário");
         assertThat(configured.getOpenAiModel()).isEqualTo(model);
+        assertThat(configured.getRootPackage()).isEqualTo("com.marketinghub.experiment.pipeline");
     }
 
     /**
@@ -378,6 +385,7 @@ class PipelineServiceTest {
                 .satisfies(stage -> {
                     assertThat(stage.getDescription()).isEqualTo("Descrição operacional preservada");
                     assertThat(stage.getOpenAiModel()).isEqualTo(model);
+                    assertThat(stage.getRootPackage()).isEqualTo("com.marketinghub.experiment.pipeline");
                 });
         assertThat(result.appliedActions()).anyMatch(action -> action.contains("Etapas operacionais antigas removidas"));
         verify(stageRepository).flush();

--- a/docs/canonical/procedimento-experimento-canon.v1.md
+++ b/docs/canonical/procedimento-experimento-canon.v1.md
@@ -40,7 +40,7 @@ Essas seções e suas dependências fazem parte do enum oficial do backend.
 
 ### 4.1 Contrato operacional administrativo do pipeline
 
-O pipeline oficial de experimento usa a versão canônica `procedimento-experimento-canon.v1` no backend administrativo de pipelines. A sincronização segura deve considerar estruturais os campos `code`, `module` e `name` do pipeline, além de `code`, `position`, `name` e `required` das etapas oficiais. Os campos `description`, `active` e `openAiModelId` das etapas são configuração operacional e não podem ser sobrescritos pela sincronização sem regra explícita.
+O pipeline oficial de experimento usa a versão canônica `procedimento-experimento-canon.v1` no backend administrativo de pipelines. A sincronização segura deve considerar estruturais os campos `code`, `module` e `name` do pipeline, além de `code`, `position`, `name`, `required`, `executionModule` e `rootPackage` das etapas oficiais. Os campos `description`, `active` e `openAiModelId` das etapas são configuração operacional e não podem ser sobrescritos pela sincronização sem regra explícita. A etapa deve informar `executionModule` somente quando for executada fora do backend principal; `rootPackage` deve sempre indicar o pacote raiz no backend ou no módulo executor onde a implementação da etapa vive.
 
 Endpoints administrativos vigentes:
 - `GET /api/pipelines/metadata` expõe versão canônica, aliases e política de campos;

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -3595,3 +3595,11 @@
 - correção aplicada: o Lead Portal ganhou um endpoint de compatibilidade para receber essa rota pública, validar divergência de slug, extrair `submissionId`, `submittedAt` e `contato`, e encaminhar a submissão ao Marketing Hub pelo `ExperimentFunnelTrackingClient`, preservando o contrato já publicado nas landings.
 - documentação atualizada: `docs/swagger/lead-portal-swagger.yaml` registra a rota pública de compatibilidade do Lead Portal.
 - validação automatizada: adicionado teste MVC cobrindo o payload real do GeraLanding e rejeição de slug divergente.
+
+## 2026-06-05 — Localização técnica das etapas do pipeline administrativo
+
+- solicitação: exibir nas etapas do pipeline o módulo executor quando a etapa roda fora do backend e o pacote raiz da implementação no backend ou no módulo executor.
+- causa-raiz: a tela administrativa de pipelines mostrava código, descrição, modelo e proteção, mas não persistia nem expunha a localização técnica da implementação da etapa, dificultando rastrear rapidamente onde corrigir ou evoluir cada etapa.
+- correção aplicada: adicionados os campos `executionModule` e `rootPackage` ao contrato de etapa, com persistência em `pipeline_stage` e `pipeline_stage_definition`, sincronização canônica para o pipeline de experimento e exibição/edição na tela `/pipelines`.
+- documentação atualizada: o cânone do procedimento de experimento e o Swagger de governança de pipelines agora registram os campos de localização técnica das etapas.
+- validação automatizada: atualizado `PipelineServiceTest` para cobrir a exposição/sincronização do pacote raiz oficial e executado teste unitário do módulo de pipelines.

--- a/docs/swagger/pipeline-swagger.yaml
+++ b/docs/swagger/pipeline-swagger.yaml
@@ -157,6 +157,16 @@ components:
         configurable:
           type: boolean
           example: true
+        executionModule:
+          type: string
+          nullable: true
+          description: Módulo executor quando a etapa roda fora do backend; nulo significa backend principal.
+          example: ai-worker
+        rootPackage:
+          type: string
+          nullable: true
+          description: Pacote raiz no backend ou no módulo executor onde a etapa é implementada.
+          example: com.marketinghub.experiment.pipeline
         fieldPolicy:
           $ref: "#/components/schemas/StageFieldPolicy"
         aliases:

--- a/frontend/src/api/pipeline/types.ts
+++ b/frontend/src/api/pipeline/types.ts
@@ -5,6 +5,8 @@ export interface PipelineStage {
   name: string;
   code: string;
   description?: string | null;
+  executionModule?: string | null;
+  rootPackage?: string | null;
   required: boolean;
   active: boolean;
   openAiModelId?: number | null;
@@ -37,6 +39,8 @@ export type PipelineStagePayload = Pick<
   | "name"
   | "code"
   | "description"
+  | "executionModule"
+  | "rootPackage"
   | "required"
   | "active"
   | "openAiModelId"
@@ -49,6 +53,8 @@ export interface OfficialPipelineStageMetadata {
   position: number;
   required: boolean;
   configurable: boolean;
+  executionModule?: string | null;
+  rootPackage?: string | null;
   aliases: string[];
 }
 

--- a/frontend/src/pages/pipeline/PipelineCrudPage.tsx
+++ b/frontend/src/pages/pipeline/PipelineCrudPage.tsx
@@ -34,6 +34,8 @@ const emptyStage: PipelineStagePayload = {
   name: "",
   code: "",
   description: "",
+  executionModule: "",
+  rootPackage: "",
   required: true,
   active: true,
   openAiModelId: null,
@@ -65,6 +67,8 @@ function stageToPayload(stage: PipelineStage): PipelineStagePayload {
     name: stage.name,
     code: stage.code,
     description: stage.description ?? "",
+    executionModule: stage.executionModule ?? "",
+    rootPackage: stage.rootPackage ?? "",
     required: stage.required,
     active: stage.active,
     openAiModelId: stage.openAiModelId ?? null,
@@ -150,6 +154,8 @@ export default function PipelineCrudPage() {
       ...payload,
       code: payload.code.trim(),
       name: payload.name.trim(),
+      executionModule: payload.executionModule?.trim() || null,
+      rootPackage: payload.rootPackage?.trim() || null,
     };
     if (editingStageId) {
       updateStage.mutate(
@@ -477,6 +483,8 @@ export default function PipelineCrudPage() {
                         <th>Código banco</th>
                         <th>Código canônico</th>
                         <th>Descrição</th>
+                        <th>Módulo</th>
+                        <th>Pacote raiz</th>
                         <th>Obrigatória</th>
                         <th>Modelo OpenAI</th>
                         <th>Status</th>
@@ -511,6 +519,16 @@ export default function PipelineCrudPage() {
                               )}
                             </td>
                             <td>{stage.description || "-"}</td>
+                            <td style={{ minWidth: 160 }}>
+                              {stage.executionModule ? (
+                                <code>{stage.executionModule}</code>
+                              ) : (
+                                <span className="text-body-secondary">Backend</span>
+                              )}
+                            </td>
+                            <td style={{ minWidth: 260 }}>
+                              {stage.rootPackage ? <code>{stage.rootPackage}</code> : "-"}
+                            </td>
                             <td>{stage.required ? "Sim" : "Não"}</td>
                             <td>
                               {stage.openAiModelCode ? (
@@ -647,6 +665,10 @@ export default function PipelineCrudPage() {
                                   selected?.position ?? stageForm.position,
                                 required:
                                   selected?.required ?? stageForm.required,
+                                executionModule:
+                                  selected?.executionModule ?? stageForm.executionModule,
+                                rootPackage:
+                                  selected?.rootPackage ?? stageForm.rootPackage,
                                 active: true,
                               },
                             }));
@@ -679,6 +701,48 @@ export default function PipelineCrudPage() {
                           placeholder="campaign-angle"
                         />
                       )}
+                    </div>
+                    <div className="col-md-3">
+                      <label className="form-label">Módulo da etapa</label>
+                      <input
+                        className="form-control"
+                        disabled={Boolean(stageDefinition)}
+                        value={stageForm.executionModule ?? ""}
+                        onChange={(event) =>
+                          setStageForms((current) => ({
+                            ...current,
+                            [pipeline.id]: {
+                              ...stageForm,
+                              executionModule: event.target.value,
+                            },
+                          }))
+                        }
+                        placeholder="Ex.: ai-worker (vazio = backend)"
+                      />
+                      <div className="form-text">
+                        Preencha somente quando a etapa for executada fora do backend.
+                      </div>
+                    </div>
+                    <div className="col-md-5">
+                      <label className="form-label">Pacote raiz</label>
+                      <input
+                        className="form-control"
+                        disabled={Boolean(stageDefinition)}
+                        value={stageForm.rootPackage ?? ""}
+                        onChange={(event) =>
+                          setStageForms((current) => ({
+                            ...current,
+                            [pipeline.id]: {
+                              ...stageForm,
+                              rootPackage: event.target.value,
+                            },
+                          }))
+                        }
+                        placeholder="Ex.: com.marketinghub.experiment.pipeline"
+                      />
+                      <div className="form-text">
+                        Informe o pacote raiz no backend ou no módulo executor.
+                      </div>
                     </div>
                     <div className="col-md-4">
                       <label className="form-label">


### PR DESCRIPTION
### Motivation
- The pipeline administration needs to show where a stage is executed (module when outside backend) and the backend package root to quickly locate implementation and reduce investigation effort.
- The canonical experiment pipeline must include these technical location fields so synchronization and rebuild operations can preserve or correct implementation location consistently.

### Description
- Persisted two new columns `execution_module` and `root_package` in `pipeline_stage` and `pipeline_stage_definition` with a Liquibase changeset `2026-06-05-pipeline-stage-implementation-location.yaml`, seeding `root_package` for the `experiment-pipeline` stages.  
- Backend: added fields to entities/DTOs/requests (`PipelineStage`, `PipelineStageDefinitionEntity`, `PipelineStageDto`, `PipelineStageRequest`, `OfficialPipelineStageDto`), normalized optional text, validated official-stage invariants and prevented divergence for official `executionModule`/`rootPackage`, and updated synchronizer/persistent synchronizer to copy/sync these fields.  
- Frontend: extended TypeScript types, UI and form on `/pipelines` to display/edit `Módulo` (executionModule) and `Pacote raiz` (rootPackage), auto-fill when selecting official stage, and send the trimmed values to backend.  
- Documentation & contract: updated `docs/swagger/pipeline-swagger.yaml`, `docs/canonical/procedimento-experimento-canon.v1.md` and `docs/registros/experimentos.md` to record the new fields and the rule that `executionModule` is filled only when stage runs outside backend and `rootPackage` indicates the package root. 

### Testing
- Ran backend unit tests for the pipeline module with `mvn -Dtest=PipelineServiceTest test` (ads-service) and the tests passed: 18 tests run, 0 failures.  
- Ran frontend typecheck `npm run typecheck` after installing dependencies (npm install) and it completed without type errors.  
- Built the frontend with `npm run build` and the build completed successfully producing `dist/`.  
- Verified repository hygiene with `git diff --check` and ensured changes staged/committed; all checks passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a22ec4de97083219012a303dad84eb5)