### PR TITLE
Skip already-consolidated collected references when claiming HTML and add candidate scan + logs

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryService.java
@@ -36,6 +36,7 @@ public class MoisSalesLibraryService {
 
     private static final String JOB_STATUS_PENDING = "PENDING";
     private static final String ANALYSIS_STATUS_CANCELED = "ANULADO";
+    private static final int COLLECTED_REFERENCE_HTML_CANDIDATE_SCAN_LIMIT = 2000;
 
     private final JdbcTemplate jdbcTemplate;
 
@@ -204,9 +205,15 @@ public class MoisSalesLibraryService {
     ) {
         String normalizedSource = request.source().trim().toUpperCase(Locale.ROOT);
         String claimedBy = UUID.randomUUID().toString();
+        log.info("MOIS sales-library claim de referência coletada recebido. modulo=MOIS, operacao=claimCollectedReferenceHtml, workspaceId={}, source={}",
+                request.workspaceId(), normalizedSource);
         return findNextCollectedReferenceHtmlCandidate(request.workspaceId(), normalizedSource)
                 .map(candidate -> claimCollectedReferenceCandidate(candidate, claimedBy))
-                .orElseGet(() -> new MoisSalesLibraryDtos.CollectedReferenceHtmlClaimResponse(false, null));
+                .orElseGet(() -> {
+                    log.info("MOIS sales-library claim de referência coletada sem candidato elegível. modulo=MOIS, operacao=claimCollectedReferenceHtml, workspaceId={}, source={}",
+                            request.workspaceId(), normalizedSource);
+                    return new MoisSalesLibraryDtos.CollectedReferenceHtmlClaimResponse(false, null);
+                });
     }
 
     /**
@@ -710,10 +717,10 @@ public class MoisSalesLibraryService {
     }
 
     /**
-     * Localiza a próxima referência bruta ainda elegível para captura operacional.
+     * Localiza a próxima referência bruta ainda elegível para captura operacional, pulando URLs já consolidadas.
      */
     private java.util.Optional<MoisSalesLibraryDtos.CollectedReferenceHtmlCaptureJob> findNextCollectedReferenceHtmlCandidate(String workspaceId, String source) {
-        return jdbcTemplate.query(
+        List<MoisSalesLibraryDtos.CollectedReferenceHtmlCaptureJob> candidates = jdbcTemplate.query(
                 """
                         SELECT r.id AS collected_reference_id, r.job_id AS collection_job_id, r.reference_id, r.source,
                                COALESCE(NULLIF(r.product_name, ''), NULLIF(r.title, ''), r.reference_id) AS title,
@@ -736,7 +743,7 @@ public class MoisSalesLibraryService {
                               AND e.status IN ('FETCHING', 'CAPTURED')
                           )
                         ORDER BY r.collected_at ASC, r.id ASC
-                        LIMIT 1
+                        LIMIT ?
                         """,
                 (rs, rowNum) -> new MoisSalesLibraryDtos.CollectedReferenceHtmlCaptureJob(
                         0L,
@@ -748,9 +755,41 @@ public class MoisSalesLibraryService {
                         rs.getString("url_original"),
                         rs.getString("url_source")),
                 workspaceId,
-                source)
-                .stream()
-                .findFirst();
+                source,
+                COLLECTED_REFERENCE_HTML_CANDIDATE_SCAN_LIMIT);
+        Set<String> operationalUrls = findOperationalCanonicalUrls(workspaceId);
+        int skippedAlreadyConsolidated = 0;
+        int skippedWithoutCanonical = 0;
+        for (MoisSalesLibraryDtos.CollectedReferenceHtmlCaptureJob candidate : candidates) {
+            String canonical = canonicalize(candidate.url());
+            if (canonical == null || canonical.isBlank()) {
+                skippedWithoutCanonical++;
+                continue;
+            }
+            if (operationalUrls.contains(canonical)) {
+                skippedAlreadyConsolidated++;
+                continue;
+            }
+            log.info("MOIS sales-library referência coletada elegível localizada. modulo=MOIS, operacao=findNextCollectedReferenceHtmlCandidate, workspaceId={}, source={}, collectedReferenceId={}, urlSource={}, canonicalUrl={}, scanned={}, skippedAlreadyConsolidated={}, skippedWithoutCanonical={}",
+                    workspaceId, source, candidate.collectedReferenceId(), candidate.urlSource(), canonical, candidates.size(), skippedAlreadyConsolidated,
+                    skippedWithoutCanonical);
+            return java.util.Optional.of(candidate);
+        }
+        log.info("MOIS sales-library não encontrou referência bruta faltante para consolidar. modulo=MOIS, operacao=findNextCollectedReferenceHtmlCandidate, workspaceId={}, source={}, scanned={}, skippedAlreadyConsolidated={}, skippedWithoutCanonical={}",
+                workspaceId, source, candidates.size(), skippedAlreadyConsolidated, skippedWithoutCanonical);
+        return java.util.Optional.empty();
+    }
+
+    /**
+     * Carrega as URLs canônicas já consolidadas para evitar reprocessar duplicatas da origem bruta.
+     */
+    private Set<String> findOperationalCanonicalUrls(String workspaceId) {
+        Set<String> urls = new HashSet<>(jdbcTemplate.query(
+                "SELECT url_canonical FROM mois_sales_page WHERE workspace_id = ? AND url_canonical IS NOT NULL",
+                (rs, rowNum) -> canonicalize(rs.getString("url_canonical")),
+                workspaceId));
+        urls.remove(null);
+        return urls;
     }
 
     /**
@@ -803,8 +842,8 @@ public class MoisSalesLibraryService {
         Long executionId = jdbcTemplate.queryForObject("SELECT LAST_INSERT_ID()", Long.class);
         long captureId = executionId == null ? 0L : executionId;
         jdbcTemplate.update("UPDATE mois_sales_page SET last_job_execution_id = ?, updated_at = UTC_TIMESTAMP() WHERE id = ?", captureId, pageId);
-        log.info("MOIS sales-library referência coletada reservada no modelo operacional novo. modulo=MOIS, operacao=claimCollectedReferenceHtml, pageId={}, executionId={}, collectedReferenceId={}",
-                pageId, captureId, candidate.collectedReferenceId());
+        log.info("MOIS sales-library referência coletada reservada no modelo operacional novo. modulo=MOIS, operacao=claimCollectedReferenceHtml, pageId={}, executionId={}, collectedReferenceId={}, canonicalUrl={}, urlSource={}",
+                pageId, captureId, candidate.collectedReferenceId(), canonical, candidate.urlSource());
         return new MoisSalesLibraryDtos.CollectedReferenceHtmlClaimResponse(
                 true,
                 new MoisSalesLibraryDtos.CollectedReferenceHtmlCaptureJob(captureId, candidate.collectedReferenceId(), candidate.collectionJobId(),

--- a/backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryServiceTest.java
@@ -112,12 +112,14 @@ class MoisSalesLibraryServiceTest {
         MoisSalesLibraryDtos.CollectedReferenceHtmlClaimRequest request =
                 new MoisSalesLibraryDtos.CollectedReferenceHtmlClaimRequest("workspace-001", "hotmart");
 
-        given(jdbcTemplate.query(contains("FROM mois_collected_reference r"), isA(RowMapper.class), eq("workspace-001"), eq("HOTMART")))
+        given(jdbcTemplate.query(contains("FROM mois_collected_reference r"), isA(RowMapper.class), eq("workspace-001"), eq("HOTMART"), eq(2000)))
                 .willAnswer(invocation -> {
                     RowMapper<?> mapper = invocation.getArgument(1);
                     ResultSet row = htmlCaptureRow();
                     return List.of(mapper.mapRow(row, 0));
                 });
+        given(jdbcTemplate.query(contains("SELECT url_canonical FROM mois_sales_page WHERE workspace_id = ? AND url_canonical IS NOT NULL"),
+                isA(RowMapper.class), eq("workspace-001"))).willReturn(List.of());
         given(jdbcTemplate.update(contains("INSERT INTO mois_sales_page"), any(), any(), eq(20L))).willReturn(1);
         given(jdbcTemplate.query(contains("SELECT workspace_id FROM mois_collected_reference"), isA(RowMapper.class), eq(20L)))
                 .willReturn(List.of("workspace-001"));
@@ -132,6 +134,43 @@ class MoisSalesLibraryServiceTest {
         org.assertj.core.api.Assertions.assertThat(response.claimed()).isTrue();
         org.assertj.core.api.Assertions.assertThat(response.job().url()).isEqualTo("https://go.hotmart.com/A1");
         org.assertj.core.api.Assertions.assertThat(response.job().urlSource()).isEqualTo("SALES_PAGE_URL");
+    }
+
+    /**
+     * Garante que o claim pula referências brutas cuja URL canônica já está consolidada na biblioteca.
+     */
+    @Test
+    void shouldSkipAlreadyConsolidatedCollectedReferenceHtmlCandidate() throws Exception {
+        MoisSalesLibraryDtos.CollectedReferenceHtmlClaimRequest request =
+                new MoisSalesLibraryDtos.CollectedReferenceHtmlClaimRequest("workspace-001", "hotmart");
+
+        given(jdbcTemplate.query(contains("FROM mois_collected_reference r"), isA(RowMapper.class), eq("workspace-001"), eq("HOTMART"), eq(2000)))
+                .willAnswer(invocation -> {
+                    RowMapper<?> mapper = invocation.getArgument(1);
+                    ResultSet alreadyConsolidated = htmlCaptureRow(20L, "ref-1", "https://go.hotmart.com/A1");
+                    ResultSet missing = htmlCaptureRow(21L, "ref-2", "https://go.hotmart.com/B2");
+                    return List.of(mapper.mapRow(alreadyConsolidated, 0), mapper.mapRow(missing, 1));
+                });
+        given(jdbcTemplate.query(contains("SELECT url_canonical FROM mois_sales_page WHERE workspace_id = ? AND url_canonical IS NOT NULL"),
+                isA(RowMapper.class), eq("workspace-001")))
+                .willAnswer(invocation -> {
+                    RowMapper<?> mapper = invocation.getArgument(1);
+                    return List.of(mapper.mapRow(operationalUrlRow("https://go.hotmart.com/A1"), 0));
+                });
+        given(jdbcTemplate.update(contains("INSERT INTO mois_sales_page"), any(), any(), eq(21L))).willReturn(1);
+        given(jdbcTemplate.query(contains("SELECT workspace_id FROM mois_collected_reference"), isA(RowMapper.class), eq(21L)))
+                .willReturn(List.of("workspace-001"));
+        given(jdbcTemplate.query(contains("WHERE workspace_id = ? AND url_canonical = ?"), isA(RowMapper.class), eq("workspace-001"), eq("https://go.hotmart.com/B2")))
+                .willReturn(List.of(100L));
+        given(jdbcTemplate.update(contains("INSERT INTO mois_sales_page_job_execution"), any(), eq(100L))).willReturn(1);
+        given(jdbcTemplate.queryForObject(contains("SELECT LAST_INSERT_ID()"), eq(Long.class))).willReturn(11L);
+        given(jdbcTemplate.update(contains("UPDATE mois_sales_page SET last_job_execution_id"), eq(11L), eq(100L))).willReturn(1);
+
+        MoisSalesLibraryDtos.CollectedReferenceHtmlClaimResponse response = service.claimCollectedReferenceHtml(request);
+
+        org.assertj.core.api.Assertions.assertThat(response.claimed()).isTrue();
+        org.assertj.core.api.Assertions.assertThat(response.job().collectedReferenceId()).isEqualTo(21L);
+        org.assertj.core.api.Assertions.assertThat(response.job().url()).isEqualTo("https://go.hotmart.com/B2");
     }
 
     /**
@@ -287,13 +326,20 @@ class MoisSalesLibraryServiceTest {
      * Monta uma linha simulada de captura de HTML bruto reservada.
      */
     private ResultSet htmlCaptureRow() throws Exception {
+        return htmlCaptureRow(20L, "ref-1", "https://go.hotmart.com/A1");
+    }
+
+    /**
+     * Monta uma linha simulada de captura de HTML bruto reservada com URL variável.
+     */
+    private ResultSet htmlCaptureRow(long collectedReferenceId, String referenceId, String url) throws Exception {
         ResultSet resultSet = org.mockito.Mockito.mock(ResultSet.class);
-        given(resultSet.getLong("collected_reference_id")).willReturn(20L);
+        given(resultSet.getLong("collected_reference_id")).willReturn(collectedReferenceId);
         given(resultSet.getString("collection_job_id")).willReturn("hotmart-job-400");
-        given(resultSet.getString("reference_id")).willReturn("ref-1");
+        given(resultSet.getString("reference_id")).willReturn(referenceId);
         given(resultSet.getString("source")).willReturn("HOTMART");
         given(resultSet.getString("title")).willReturn("Produto");
-        given(resultSet.getString("url_original")).willReturn("https://go.hotmart.com/A1");
+        given(resultSet.getString("url_original")).willReturn(url);
         given(resultSet.getString("url_source")).willReturn("SALES_PAGE_URL");
         return resultSet;
     }

--- a/docs/canonical/mois-worker-canon.v1.md
+++ b/docs/canonical/mois-worker-canon.v1.md
@@ -563,10 +563,11 @@ A primeira etapa do pipeline de páginas de venda deve separar responsabilidades
 3. A seleção da URL segue a prioridade `sales_page_url`, depois `product_url`, depois `url`.
 4. O HTML bruto persistido em `mois_sales_page_job_execution.raw_html` é a entrada canônica para uma etapa posterior de parsing/análise, sem obrigar o worker a acessar diretamente o banco.
 5. A tabela `mois_collected_reference` permanece como fonte de produtos coletados; ela não deve armazenar o HTML bruto capturado.
-6. URLs com snapshot `FAILED` recente não devem ser reprocessadas imediatamente pelo fluxo automático; o cooldown operacional mínimo é de 24 horas para evitar loop improdutivo em destinos indisponíveis.
-7. URLs com 3 ou mais snapshots `FAILED` devem sair da seleção automática normal até uma revisão/acionamento forçado, preservando capacidade do pipeline para páginas que realmente entregam HTML útil.
-8. Falhas de captura devem ser categorizadas no `error_message` com prefixo operacional claro, por exemplo `HTTP_404`, `DESTINATION_DNS_FAILURE`, `REDIRECT_WITHOUT_HTML`, `TIMEOUT`, `FINAL_URL_UNAVAILABLE` ou `CAPTURE_EXCEPTION`.
-9. O acionamento `force=true` é reservado para revisão operacional e pode ignorar cooldown/limite de falhas, mantendo a decisão explícita e auditável.
+6. A seleção automática deve comparar a URL efetiva canonicalizada contra `mois_sales_page.url_canonical` e pular referências brutas cuja URL já esteja consolidada, mesmo que `collected_reference_id` seja diferente. O objetivo é reduzir o indicador `missingFromOperationalLibrary` por URL única, evitando gastar ciclos com duplicatas históricas.
+7. URLs com snapshot `FAILED` recente não devem ser reprocessadas imediatamente pelo fluxo automático; o cooldown operacional mínimo é de 24 horas para evitar loop improdutivo em destinos indisponíveis.
+8. URLs com 3 ou mais snapshots `FAILED` devem sair da seleção automática normal até uma revisão/acionamento forçado, preservando capacidade do pipeline para páginas que realmente entregam HTML útil.
+9. Falhas de captura devem ser categorizadas no `error_message` com prefixo operacional claro, por exemplo `HTTP_404`, `DESTINATION_DNS_FAILURE`, `REDIRECT_WITHOUT_HTML`, `TIMEOUT`, `FINAL_URL_UNAVAILABLE` ou `CAPTURE_EXCEPTION`.
+10. O acionamento `force=true` é reservado para revisão operacional e pode ignorar cooldown/limite de falhas, mantendo a decisão explícita e auditável.
 
 Contratos operacionais do backend:
 

--- a/docs/registros/mois1.md
+++ b/docs/registros/mois1.md
@@ -1016,3 +1016,17 @@ Arquivos alterados:
 - `frontend/src/pages/mois/MoisSalesPagesPipelinePage.tsx`
 - `docs/swagger/mois-sales-library-swagger.yaml`
 - `docs/registros/mois1.md`
+
+## 2026-06-05 — Diagnóstico do claim automático de referências brutas MOIS
+
+- investigada a estagnação do indicador `Faltam consolidar` em 276 URLs no pipeline da Biblioteca de Páginas de Vendas.
+- causa-raiz identificada: o claim automático de `collected-reference-html` filtrava apenas por `collected_reference_id` com execução `FETCHING`/`CAPTURED`, permitindo gastar ciclos em referências brutas duplicadas cuja URL canônica já existia em `mois_sales_page`.
+- ajustado o backend para escanear candidatos da origem bruta, canonicalizar a URL efetiva e pular URLs já consolidadas antes de reservar a próxima referência faltante.
+- adicionados logs operacionais no recebimento do claim, seleção de candidato, ausência de candidato e reserva final para confirmar se o worker está chamando o backend e quantas referências foram puladas por já estarem consolidadas.
+- atualizado o cânone MOIS para explicitar que a seleção automática deve reduzir faltantes por URL única canonicalizada, e não por linha/referência histórica.
+
+Arquivos alterados:
+- `backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryService.java`
+- `backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryServiceTest.java`
+- `docs/canonical/mois-worker-canon.v1.md`
+- `docs/registros/mois1.md`


### PR DESCRIPTION
### Motivation
- The automatic claim for `collected-reference-html` was spending cycles on duplicate historical references whose canonical URL is already consolidated in `mois_sales_page`, inflating the "missing from operational library" metric. 
- The change aims to avoid reprocessing duplicates by comparing canonicalized URLs against the operational table before reserving a capture job.

### Description
- Added `COLLECTED_REFERENCE_HTML_CANDIDATE_SCAN_LIMIT` and changed `findNextCollectedReferenceHtmlCandidate` to fetch up to that many candidates, canonicalize each candidate URL, and skip ones already present in `mois_sales_page.url_canonical`.
- Introduced helper `findOperationalCanonicalUrls` to load canonicalized URLs from the operational table and used it to short-circuit duplicates.
- Added logging in `claimCollectedReferenceHtml`, `findNextCollectedReferenceHtmlCandidate`, and `claimCollectedReferenceCandidate` to record claim attempts, candidate scanning metrics and reserved page details (including `canonicalUrl` and `urlSource`).
- Updated unit tests and test utilities in `MoisSalesLibraryServiceTest` to assert the new query parameter, handle variable captured-reference rows, and added `shouldSkipAlreadyConsolidatedCollectedReferenceHtmlCandidate` to cover the skip behavior.
- Updated canonical documentation (`docs/canonical/mois-worker-canon.v1.md`) and release notes (`docs/registros/mois1.md`) to reflect the operational rule that selection should compare canonical URLs and skip already-consolidated references.

### Testing
- Ran unit tests in `MoisSalesLibraryServiceTest` including `shouldClaimCollectedReferenceHtmlFromCollectedReferenceTable`, `shouldSkipAlreadyConsolidatedCollectedReferenceHtmlCandidate` and `shouldCompleteCollectedReferenceHtmlCapture`. 
- All modified and existing unit tests against `MoisSalesLibraryService` passed locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a22ee0aa018832181a0b3b731a3e1a0)