### PR TITLE
Corrige consulta e parsing de preços oficiais OpenAI

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/openai/OpenAiPricingPageClient.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/openai/OpenAiPricingPageClient.java
@@ -6,6 +6,8 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
@@ -19,6 +21,7 @@ import org.springframework.web.reactive.function.client.WebClient;
 @Component
 public class OpenAiPricingPageClient {
     private static final Logger log = LoggerFactory.getLogger(OpenAiPricingPageClient.class);
+    private static final Pattern MONEY_PATTERN = Pattern.compile("[0-9]+(?:\\.[0-9]+)?");
 
     private final WebClient.Builder webClientBuilder;
     private final OpenAiProperties properties;
@@ -35,7 +38,7 @@ public class OpenAiPricingPageClient {
         return parseTextModelPricing(html);
     }
 
-    /** Extrai os preços das duas primeiras tabelas textuais: standard e batch. */
+    /** Extrai os preços oficiais textuais, aceitando tabela legada standard/batch ou tabela atual short/long context. */
     public List<OpenAiModelPricing> parseTextModelPricing(String html) {
         if (html == null || html.isBlank()) {
             return List.of();
@@ -94,15 +97,26 @@ public class OpenAiPricingPageClient {
             if (!isTextModelCode(code)) {
                 continue;
             }
-            BigDecimal input = parseMoney(cells.get(1).text());
-            BigDecimal cachedInput = parseMoney(cells.get(2).text());
-            BigDecimal output = parseMoney(cells.get(3).text());
-            if (input == null || output == null) {
-                continue;
+            PriceTriple price = parsePriceTriple(cells, 1, code);
+            if (price != null) {
+                tablePrices.put(code, price);
             }
-            tablePrices.put(code, new PriceTriple(code, input, zeroIfNull(cachedInput), output));
         }
         return tablePrices;
+    }
+
+    /** Extrai um trio input/cache/output a partir da posição inicial informada na linha da tabela. */
+    private PriceTriple parsePriceTriple(Elements cells, int firstPriceCell, String code) {
+        if (cells.size() <= firstPriceCell + 2) {
+            return null;
+        }
+        BigDecimal input = parseMoney(cells.get(firstPriceCell).text());
+        BigDecimal cachedInput = parseMoney(cells.get(firstPriceCell + 1).text());
+        BigDecimal output = parseMoney(cells.get(firstPriceCell + 2).text());
+        if (input == null || output == null) {
+            return null;
+        }
+        return new PriceTriple(code, input, zeroIfNull(cachedInput), output);
     }
 
     /** Remove observações de contexto e normaliza o código do modelo para comparação e persistência. */
@@ -117,11 +131,12 @@ public class OpenAiPricingPageClient {
 
     /** Converte valores monetários da tabela oficial para decimal por 1 milhão de tokens. */
     private BigDecimal parseMoney(String value) {
-        String normalized = value == null ? "" : value.replace("$", "").replace(",", "").trim();
-        if (normalized.isBlank() || normalized.equals("-")) {
+        String normalized = value == null ? "" : value.replace(",", "").trim();
+        Matcher matcher = MONEY_PATTERN.matcher(normalized);
+        if (!matcher.find()) {
             return null;
         }
-        return new BigDecimal(normalized);
+        return new BigDecimal(matcher.group());
     }
 
     /** Garante valor zero para campos de preço não publicados, preservando restrição NOT NULL do banco. */

--- a/backend/ads-service/src/main/java/com/marketinghub/openai/OpenAiProperties.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/openai/OpenAiProperties.java
@@ -12,7 +12,7 @@ public class OpenAiProperties {
 
     private String apiKey;
     private String apiKeyFile = "/root/infra/openai-token/openai_api_key";
-    private String pricingUrl = "https://platform.openai.com/docs/pricing";
+    private String pricingUrl = "https://developers.openai.com/api/docs/pricing";
     private String baseUrl = "https://api.openai.com/v1";
     private Duration connectTimeout = Duration.ofSeconds(10);
     private Duration requestTimeout = Duration.ofSeconds(90);

--- a/backend/ads-service/src/main/java/com/marketinghub/openai/service/OpenAiModelPricingSyncService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/openai/service/OpenAiModelPricingSyncService.java
@@ -15,7 +15,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 public class OpenAiModelPricingSyncService {
     private static final Logger log = LoggerFactory.getLogger(OpenAiModelPricingSyncService.class);
-    private static final String PRICING_SOURCE = "https://platform.openai.com/docs/pricing";
+    private static final String PRICING_SOURCE = "https://developers.openai.com/api/docs/pricing";
 
     private final OpenAiPricingPageClient pricingPageClient;
     private final OpenAiModelRepository repository;

--- a/backend/ads-service/src/main/java/com/marketinghub/openai/service/OpenAiModelService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/openai/service/OpenAiModelService.java
@@ -27,7 +27,7 @@ import org.springframework.util.StringUtils;
 @Service
 public class OpenAiModelService {
     private static final Logger log = LoggerFactory.getLogger(OpenAiModelService.class);
-    private static final String PRICING_SOURCE = "https://platform.openai.com/docs/pricing";
+    private static final String PRICING_SOURCE = "https://developers.openai.com/api/docs/pricing";
     private static final BigDecimal ZERO_PRICE = BigDecimal.ZERO.setScale(5);
 
     private final OpenAiModelRepository repository;

--- a/backend/ads-service/src/main/resources/application.properties
+++ b/backend/ads-service/src/main/resources/application.properties
@@ -128,7 +128,7 @@ lead-portal.worker.processing-guard.initial-delay=${LEAD_PORTAL_PROCESSING_GUARD
 # OpenAI batch generation
 openai.api-key=${OPENAI_API_KEY:}
 openai.api-key-file=${OPENAI_API_KEY_FILE:/root/infra/openai-token/openai_api_key}
-openai.pricing-url=${OPENAI_PRICING_URL:https://platform.openai.com/docs/pricing}
+openai.pricing-url=${OPENAI_PRICING_URL:https://developers.openai.com/api/docs/pricing}
 openai.base-url=${OPENAI_BASE_URL:https://api.openai.com/v1}
 openai.connect-timeout=${OPENAI_CONNECT_TIMEOUT:PT10S}
 openai.request-timeout=${OPENAI_REQUEST_TIMEOUT:PT90S}

--- a/backend/ads-service/src/test/java/com/marketinghub/openai/OpenAiPricingPageClientTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/openai/OpenAiPricingPageClientTest.java
@@ -62,4 +62,34 @@ class OpenAiPricingPageClientTest {
         assertThat(pricing.priceInputCachedBatch()).isEqualByComparingTo(new BigDecimal("0.1375"));
         assertThat(pricing.priceOutputBatch()).isEqualByComparingTo(new BigDecimal("2.20"));
     }
+
+    @Test
+    void shouldParsePricesFromCurrentShortAndLongContextTable() {
+        OpenAiProperties properties = new OpenAiProperties();
+        OpenAiPricingPageClient client = new OpenAiPricingPageClient(WebClient.builder(), properties);
+
+        List<OpenAiModelPricing> prices = client.parseTextModelPricing("""
+                <table>
+                  <thead>
+                    <tr><th></th><th colspan="3">Short context</th><th colspan="3">Long context</th></tr>
+                    <tr><th>Model</th><th>Input</th><th>Cached input</th><th>Output</th><th>Input</th><th>Cached input</th><th>Output</th></tr>
+                  </thead>
+                  <tbody>
+                    <tr><td>gpt-5.4</td><td>$2.50</td><td>$0.25</td><td>$15.00</td><td>$5.00</td><td>$0.50</td><td>$22.50</td></tr>
+                    <tr><td>gpt-5.4-mini</td><td>$0.75</td><td>$0.075</td><td>$4.50</td><td>-</td><td>-</td><td>-</td></tr>
+                  </tbody>
+                </table>
+                """);
+
+        assertThat(prices).hasSize(2);
+        OpenAiModelPricing pricing = prices.get(0);
+        assertThat(pricing.code()).isEqualTo("gpt-5.4");
+        assertThat(pricing.priceInputStandard()).isEqualByComparingTo(new BigDecimal("2.50"));
+        assertThat(pricing.priceInputCachedStandard()).isEqualByComparingTo(new BigDecimal("0.25"));
+        assertThat(pricing.priceOutputStandard()).isEqualByComparingTo(new BigDecimal("15.00"));
+        assertThat(pricing.priceInputBatch()).isEqualByComparingTo(new BigDecimal("1.25"));
+        assertThat(pricing.priceInputCachedBatch()).isEqualByComparingTo(new BigDecimal("0.125"));
+        assertThat(pricing.priceOutputBatch()).isEqualByComparingTo(new BigDecimal("7.50"));
+    }
+
 }

--- a/backend/ads-service/src/test/java/com/marketinghub/openai/service/OpenAiModelPricingSyncServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/openai/service/OpenAiModelPricingSyncServiceTest.java
@@ -38,7 +38,7 @@ class OpenAiModelPricingSyncServiceTest {
         assertThat(existing.getCode()).isEqualTo("gpt-5.5");
         assertThat(existing.getPriceInputStandard()).isEqualByComparingTo(new BigDecimal("5.00"));
         assertThat(existing.getPriceOutputBatch()).isEqualByComparingTo(new BigDecimal("15.00"));
-        assertThat(existing.getPricingSource()).isEqualTo("https://platform.openai.com/docs/pricing");
+        assertThat(existing.getPricingSource()).isEqualTo("https://developers.openai.com/api/docs/pricing");
         assertThat(existing.getLastPricingSyncAt()).isNotNull();
         verify(repository).save(existing);
     }

--- a/backend/ads-service/src/test/java/com/marketinghub/openai/service/OpenAiModelServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/openai/service/OpenAiModelServiceTest.java
@@ -57,7 +57,7 @@ class OpenAiModelServiceTest {
         assertThat(created.getPriceInputStandard()).isEqualByComparingTo("5.00");
         assertThat(created.getPriceOutputBatch()).isEqualByComparingTo("15.00");
         assertThat(created.isAcceptsImageInput()).isFalse();
-        assertThat(created.getPricingSource()).isEqualTo("https://platform.openai.com/docs/pricing");
+        assertThat(created.getPricingSource()).isEqualTo("https://developers.openai.com/api/docs/pricing");
         assertThat(created.getLastPricingSyncAt()).isNotNull();
         verify(catalogService).fetchAndPersistCatalog();
     }


### PR DESCRIPTION
### Motivation
- Corrigir a ausência de preços oficiais exibidos na UI causada pela falha na obtenção/parse da página de preços da OpenAI. 
- Tornar o parser mais tolerante ao formato atual da página (tabelas with short/long context) e a valores monetários com texto adicional.

### Description
- Atualiza a URL canônica de preços para `https://developers.openai.com/api/docs/pricing` nas propriedades e serviços que persistem/registram a fonte. 
- Torna o `OpenAiPricingPageClient` mais robusto adicionando extração tolerante de trio `input/cached/output`, suporte a tabelas com short/long context e extração de números via regex (`MONEY_PATTERN`).
- Refatora o parsing extraindo `parsePriceTriple(...)` e preservando fallback de batch como metade do preço standard quando necessário. 
- Atualiza/expande testes unitários em `OpenAiPricingPageClientTest`, `OpenAiModelPricingSyncServiceTest` e `OpenAiModelServiceTest` para cobrir o novo formato e a expectativa da fonte de preços.

### Testing
- Executado `./backend/mvnw -f backend/ads-service/pom.xml -Dtest=OpenAiPricingPageClientTest,OpenAiModelPricingSyncServiceTest,OpenAiModelServiceTest test` e todos os testes especificados passaram com sucesso. 
- Verificado `git diff --check` e não há erros de diff. 
- `./backend/mvnw -f backend/ads-service/pom.xml spotless:check` não concluiu porque o ambiente não resolve o plugin com prefixo `spotless` (falha de execução do plugin, não falha de código alterado).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a233a888ea8832199a8700f8309857d)