### PR TITLE
Corrige claim de referências MOIS para deduplicar por URL efetiva

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryService.java
@@ -724,17 +724,35 @@ public class MoisSalesLibraryService {
                 """
                         SELECT r.id AS collected_reference_id, r.job_id AS collection_job_id, r.reference_id, r.source,
                                COALESCE(NULLIF(r.product_name, ''), NULLIF(r.title, ''), r.reference_id) AS title,
-                               COALESCE(NULLIF(r.sales_page_url, ''), NULLIF(r.product_url, ''), NULLIF(r.url, '')) AS url_original,
-                               CASE
-                                 WHEN r.sales_page_url IS NOT NULL AND r.sales_page_url <> '' THEN 'SALES_PAGE_URL'
-                                 WHEN r.product_url IS NOT NULL AND r.product_url <> '' THEN 'PRODUCT_URL'
+                               candidate.effective_url AS url_original,
+                               CASE candidate.url_source_priority
+                                 WHEN 1 THEN 'SALES_PAGE_URL'
+                                 WHEN 2 THEN 'PRODUCT_URL'
                                  ELSE 'URL'
                                END AS url_source
                         FROM mois_collected_reference r
-                        WHERE r.workspace_id = ?
-                          AND r.source = ?
-                          AND COALESCE(NULLIF(r.sales_page_url, ''), NULLIF(r.product_url, ''), NULLIF(r.url, '')) IS NOT NULL
-                          AND NOT EXISTS (
+                        JOIN (
+                            SELECT MIN(id) AS collected_reference_id,
+                                   effective_url,
+                                   MIN(url_source_priority) AS url_source_priority,
+                                   MIN(collected_at) AS first_collected_at
+                            FROM (
+                                SELECT id,
+                                       collected_at,
+                                       COALESCE(NULLIF(TRIM(sales_page_url), ''), NULLIF(TRIM(product_url), ''), NULLIF(TRIM(url), '')) AS effective_url,
+                                       CASE
+                                         WHEN sales_page_url IS NOT NULL AND TRIM(sales_page_url) <> '' THEN 1
+                                         WHEN product_url IS NOT NULL AND TRIM(product_url) <> '' THEN 2
+                                         ELSE 3
+                                       END AS url_source_priority
+                                FROM mois_collected_reference
+                                WHERE workspace_id = ?
+                                  AND source = ?
+                                  AND COALESCE(NULLIF(TRIM(sales_page_url), ''), NULLIF(TRIM(product_url), ''), NULLIF(TRIM(url), '')) IS NOT NULL
+                            ) raw_urls
+                            GROUP BY effective_url
+                        ) candidate ON candidate.collected_reference_id = r.id
+                        WHERE NOT EXISTS (
                             SELECT 1
                             FROM mois_sales_page sp
                             JOIN mois_sales_page_job_execution e ON e.sales_page_id = sp.id
@@ -742,7 +760,7 @@ public class MoisSalesLibraryService {
                               AND e.stage = 'CAPTURE'
                               AND e.status IN ('FETCHING', 'CAPTURED')
                           )
-                        ORDER BY r.collected_at ASC, r.id ASC
+                        ORDER BY candidate.first_collected_at ASC, r.id ASC
                         LIMIT ?
                         """,
                 (rs, rowNum) -> new MoisSalesLibraryDtos.CollectedReferenceHtmlCaptureJob(

--- a/backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryServiceTest.java
@@ -17,6 +17,7 @@ import java.time.Instant;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -134,6 +135,12 @@ class MoisSalesLibraryServiceTest {
         org.assertj.core.api.Assertions.assertThat(response.claimed()).isTrue();
         org.assertj.core.api.Assertions.assertThat(response.job().url()).isEqualTo("https://go.hotmart.com/A1");
         org.assertj.core.api.Assertions.assertThat(response.job().urlSource()).isEqualTo("SALES_PAGE_URL");
+
+        ArgumentCaptor<String> sqlCaptor = ArgumentCaptor.forClass(String.class);
+        verify(jdbcTemplate).query(sqlCaptor.capture(), isA(RowMapper.class), eq("workspace-001"), eq("HOTMART"), eq(2000));
+        org.assertj.core.api.Assertions.assertThat(sqlCaptor.getValue())
+                .contains("GROUP BY effective_url")
+                .contains("TRIM(sales_page_url)");
     }
 
     /**

--- a/docs/registros/mois1.md
+++ b/docs/registros/mois1.md
@@ -1030,3 +1030,13 @@ Arquivos alterados:
 - `backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryServiceTest.java`
 - `docs/canonical/mois-worker-canon.v1.md`
 - `docs/registros/mois1.md`
+
+## 2026-06-05 — Correção do claim de HTML da biblioteca de páginas de venda MOIS
+
+- diagnosticado via MCP que a tela de pipeline mostrava 276 URLs Hotmart faltantes porque a busca de candidatos do backend varria as primeiras 2000 linhas brutas por data, mas esse recorte continha apenas 20 URLs únicas já consolidadas, deixando as URLs faltantes fora da janela de processamento.
+- ajustado o claim `POST /api/mois/sales-library/collected-reference-html:claim` para deduplicar a origem bruta por URL efetiva antes do limite de varredura, usando `GROUP BY effective_url` e campos normalizados com `TRIM`, permitindo que as 276 URLs faltantes entrem na fila operacional.
+- adicionado teste unitário garantindo que o SQL do claim usa URLs efetivas únicas e não apenas contagem de linhas brutas repetidas.
+
+Arquivos alterados:
+- `backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryService.java`
+- `backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryServiceTest.java`


### PR DESCRIPTION
### Motivation
- Resolver a causa-raiz que fazia 276 URLs Hotmart “faltantes” não entrarem na fila porque o claim varria linhas brutas (primeiras 2000) e essas linhas continham poucas URLs únicas já consolidadas. 

### Description
- Alterado o SQL em `findNextCollectedReferenceHtmlCandidate` para agrupar (`GROUP BY`) por `effective_url` (com `TRIM`) antes de aplicar o `LIMIT`, preservando prioridade de fonte (`SALES_PAGE_URL > PRODUCT_URL > URL`) e ordenando por primeiro `collected_at` por URL única. 
- Mantida a verificação que pula URLs já consolidadas em `mois_sales_page` para evitar reprocessamento de duplicatas. 
- Adicionado um assertion unitário que captura o SQL executado e valida que a query usa `GROUP BY effective_url` e `TRIM(sales_page_url)`. 
- Arquivos alterados: `MoisSalesLibraryService.java`, `MoisSalesLibraryServiceTest.java` e atualização de registro operacional em `docs/registros/mois1.md`.

### Testing
- Executado o teste unitário do serviço afetado: `MoisSalesLibraryServiceTest` (módulo `backend/ads-service`), que rodou localmente com sucesso; resultados: `Tests run: 8, Failures: 0, Errors: 0, Skipped: 0`.
- Observações de diagnóstico: consultas via MCP confirmaram que havia 402 URLs únicas Hotmart no workspace e que, após a mudança, a seleção de candidatos passa a considerar URLs únicas (402) em vez de linhas repetidas nas primeiras 2000 linhas.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a233be6dda48321af8c7eb169ea616b)