### PR TITLE
Simplify pipeline stages screen

### DIFF
--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -3683,3 +3683,15 @@
 - Causa-raiz no worker: falhas capturadas durante a geração eram apenas logadas e mantinham a solicitação pendente, permitindo travamento indefinido e nova tentativa automática sem feedback claro ao usuário.
 - Correção aplicada: ao capturar falha na geração, o Worker AI registra contexto da causa-raiz, limpa `creativesToGenerate`, restaura o modo para `DEFAULT` quando era pipeline e salva o experimento, liberando a tela para nova solicitação consciente após corrigir a causa operacional.
 - Mitigação operacional imediata no experimento 37: executado `PATCH /api/experiments/37/creatives-to-generate?quantity=0` para remover a pendência atual e destravar a tela antes do deploy da correção definitiva.
+
+## 2026-06-05 21:05:08 UTC-3
+- solicitação: reduzir a confusão visual da tela `/pipelines`, separando a lista de pipelines da visualização/edição das etapas de um pipeline específico.
+- raciocínio para a solução: a tela atual misturava cadastro de pipeline, diagnóstico, lista de etapas e formulário de etapas para todos os pipelines ao mesmo tempo; a causa-raiz da poluição era renderizar todos os detalhes simultaneamente, então a correção foi condicionar a interface entre tela de lista e tela de etapas do pipeline selecionado.
+- foi feito: a tela principal agora mostra uma lista limpa de pipelines com resumo e ação `Ver etapas`; ao clicar, a interface alterna para uma tela focada no pipeline selecionado, mantendo diagnóstico, cards de etapas e formulário de etapa apenas daquele pipeline, com botão de retorno para a lista.
+- documentos lidos para pesquisar e resolver o problema:
+  - AGENTS.md
+  - frontend/AGENTS.md
+  - docs/registros/experimentos.md
+  - frontend/src/pages/pipeline/PipelineCrudPage.tsx
+  - frontend/src/api/pipeline/types.ts
+  - frontend/src/api/pipeline/usePipelines.ts

--- a/frontend/src/pages/pipeline/PipelineCrudPage.tsx
+++ b/frontend/src/pages/pipeline/PipelineCrudPage.tsx
@@ -109,6 +109,9 @@ export default function PipelineCrudPage() {
       .map((diagnostic) => [diagnostic.pipelineId, diagnostic] as const);
     return new Map(entries);
   }, [diagnosticsQueries]);
+  const [selectedPipelineId, setSelectedPipelineId] = useState<number | null>(
+    null,
+  );
   const [pipelineForm, setPipelineForm] =
     useState<PipelinePayload>(emptyPipeline);
   const [editingPipelineId, setEditingPipelineId] = useState<number | null>(
@@ -119,6 +122,9 @@ export default function PipelineCrudPage() {
   >({});
   const [editingStageId, setEditingStageId] = useState<number | null>(null);
 
+  const selectedPipeline = pipelines.find(
+    (pipeline) => pipeline.id === selectedPipelineId,
+  );
   const isSavingPipeline = createPipeline.isPending || updatePipeline.isPending;
   const isSavingStage = createStage.isPending || updateStage.isPending;
   const editingOfficialPipeline = officialPipelines.find(
@@ -146,6 +152,23 @@ export default function PipelineCrudPage() {
   const resetPipelineForm = () => {
     setPipelineForm(emptyPipeline);
     setEditingPipelineId(null);
+  };
+
+  const startPipelineEdit = (pipeline: Pipeline) => {
+    setSelectedPipelineId(null);
+    setEditingPipelineId(pipeline.id);
+    setPipelineForm(pipelineToPayload(pipeline));
+  };
+
+  const openPipelineStages = (pipelineId: number) => {
+    resetPipelineForm();
+    setEditingStageId(null);
+    setSelectedPipelineId(pipelineId);
+  };
+
+  const returnToPipelineList = () => {
+    setSelectedPipelineId(null);
+    setEditingStageId(null);
   };
 
   const submitStage = (pipelineId: number) => {
@@ -192,13 +215,555 @@ export default function PipelineCrudPage() {
       <p className="text-danger">Não foi possível carregar os pipelines.</p>
     );
 
+  if (selectedPipeline) {
+    const pipeline = selectedPipeline;
+    const stageForm = stageForms[pipeline.id] ?? emptyStage;
+    const diagnostic = diagnosticsByPipelineId.get(pipeline.id);
+    const officialPipeline = officialPipelines.find(
+      (official) =>
+        normalizeCode(official.code) === normalizeCode(pipeline.code),
+    );
+    const stageDefinition = officialPipeline?.stages.find(
+      (stage) =>
+        normalizeCode(stage.operationalCode) ===
+          normalizeCode(stageForm.code) ||
+        stage.aliases.some(
+          (alias) => normalizeCode(alias) === normalizeCode(stageForm.code),
+        ),
+    );
+    const isEditingOfficialStage = Boolean(
+      editingStageId && stageDefinition?.required,
+    );
+    const isOfficialPipeline = Boolean(officialPipeline);
+
+    return (
+      <div>
+        <div className="d-flex flex-wrap justify-content-between align-items-start gap-3 mb-3">
+          <div>
+            <PageTitle>Etapas do pipeline</PageTitle>
+            <p className="text-body-secondary mb-0">
+              Tela focada nas etapas de um único pipeline para reduzir poluição
+              visual e manter o fluxo operacional claro.
+            </p>
+          </div>
+          <button
+            type="button"
+            className="btn btn-outline-secondary"
+            onClick={returnToPipelineList}
+          >
+            ← Voltar para lista
+          </button>
+        </div>
+
+        <section className="card mb-4 border-primary">
+          <div className="card-body">
+            <div className="d-flex flex-wrap justify-content-between align-items-start gap-3">
+              <div>
+                <div className="small text-uppercase text-body-secondary fw-semibold">
+                  Pipeline selecionado
+                </div>
+                <h2 className="h4 mb-1">{pipeline.name}</h2>
+                <div className="d-flex flex-wrap gap-2">
+                  <span className="badge text-bg-light border">
+                    {pipeline.module}
+                  </span>
+                  <span className="badge text-bg-light border">
+                    {pipeline.code}
+                  </span>
+                  <span
+                    className={`badge ${pipeline.active ? "text-bg-success" : "text-bg-secondary"}`}
+                  >
+                    {pipeline.active ? "Ativo" : "Inativo"}
+                  </span>
+                  <span className="badge text-bg-light border">
+                    {pipeline.stages.length} etapa
+                    {pipeline.stages.length === 1 ? "" : "s"}
+                  </span>
+                  {diagnostic ? (
+                    <span
+                      className={`badge ${statusBadgeClass(diagnostic.status)}`}
+                    >
+                      Contrato {diagnostic.status}
+                    </span>
+                  ) : null}
+                </div>
+              </div>
+              <button
+                type="button"
+                className="btn btn-outline-primary btn-sm"
+                onClick={() => startPipelineEdit(pipeline)}
+              >
+                Editar dados do pipeline
+              </button>
+            </div>
+            {pipeline.description ? (
+              <p className="text-body-secondary mt-3 mb-0">
+                {pipeline.description}
+              </p>
+            ) : null}
+          </div>
+        </section>
+
+        {diagnostic ? (
+          <div
+            className={`alert ${diagnostic.status === "BLOQUEADO" ? "alert-danger" : diagnostic.status === "OK" ? "alert-success" : "alert-warning"}`}
+          >
+            <div className="fw-semibold">
+              Status do contrato operacional: {diagnostic.status}
+            </div>
+            <div>
+              Etapas esperadas no código: {diagnostic.expectedStages} · etapas
+              configuradas no banco: {diagnostic.configuredStages}
+            </div>
+            {diagnostic.issues.length > 0 ? (
+              <ul className="mb-0 mt-2">
+                {diagnostic.issues.map((issue, index) => (
+                  <li key={`${issue.stageCode ?? "pipeline"}-${index}`}>
+                    <strong>{issue.severity}</strong> ·{" "}
+                    {issue.stageCode ? (
+                      <code>{issue.stageCode}</code>
+                    ) : (
+                      "pipeline"
+                    )}
+                    {issue.canonicalCode ? (
+                      <>
+                        {" "}
+                        → <code>{issue.canonicalCode}</code>
+                      </>
+                    ) : null}
+                    : {issue.message} Causa-raiz: {issue.rootCause} Ação:{" "}
+                    {issue.recommendedAction}
+                  </li>
+                ))}
+              </ul>
+            ) : null}
+          </div>
+        ) : null}
+
+        <section className="mb-4">
+          <div className="d-flex flex-wrap justify-content-between align-items-center gap-2 mb-3">
+            <h3 className="h5 mb-0">Etapas configuradas</h3>
+            {isOfficialPipeline ? (
+              <button
+                className="btn btn-sm btn-outline-warning"
+                disabled={
+                  rebuildOfficialStages.isPending ||
+                  !diagnostic ||
+                  diagnostic.status === "OK"
+                }
+                onClick={() => confirmOfficialStageRebuild(pipeline)}
+              >
+                {rebuildOfficialStages.isPending &&
+                rebuildOfficialStages.variables === pipeline.id ? (
+                  <span
+                    className="spinner-border spinner-border-sm me-2"
+                    aria-hidden="true"
+                  />
+                ) : null}
+                Ajustar etapas oficiais
+              </button>
+            ) : null}
+          </div>
+
+          {pipeline.stages.length === 0 ? (
+            <div className="alert alert-info">
+              Nenhuma etapa cadastrada para este pipeline.
+            </div>
+          ) : (
+            <div className="row g-3">
+              {pipeline.stages.map((stage) => {
+                const rowDefinition = officialPipeline?.stages.find(
+                  (definition) =>
+                    normalizeCode(definition.operationalCode) ===
+                      normalizeCode(stage.code) ||
+                    definition.aliases.some(
+                      (alias) =>
+                        normalizeCode(alias) === normalizeCode(stage.code),
+                    ),
+                );
+                const protectionLabel = rowDefinition?.required
+                  ? "Estrutural"
+                  : isOfficialPipeline
+                    ? "Não mapeada"
+                    : "Editável";
+
+                return (
+                  <div className="col-12 col-xl-6" key={stage.id}>
+                    <article className="card h-100 border shadow-sm">
+                      <div className="card-body d-flex flex-column gap-3">
+                        <div className="d-flex flex-wrap justify-content-between align-items-start gap-2">
+                          <div>
+                            <div className="small fw-semibold text-primary text-uppercase">
+                              Etapa {stage.position}
+                            </div>
+                            <h4 className="h5 mb-1">{stage.name}</h4>
+                            <div className="d-flex flex-wrap gap-2">
+                              <span className="badge text-bg-light border">
+                                {stage.code}
+                              </span>
+                              <span
+                                className={`badge ${stage.active ? "text-bg-success" : "text-bg-secondary"}`}
+                              >
+                                {stage.active ? "Ativa" : "Inativa"}
+                              </span>
+                              {stage.required ? (
+                                <span className="badge text-bg-primary">
+                                  Obrigatória
+                                </span>
+                              ) : null}
+                              <span className="badge text-bg-light border">
+                                {protectionLabel}
+                              </span>
+                            </div>
+                          </div>
+                          <div className="d-flex gap-2">
+                            <button
+                              className="btn btn-sm btn-outline-primary"
+                              onClick={() => {
+                                setEditingStageId(stage.id);
+                                setStageForms((current) => ({
+                                  ...current,
+                                  [pipeline.id]: stageToPayload(stage),
+                                }));
+                              }}
+                            >
+                              Editar
+                            </button>
+                            <button
+                              className="btn btn-sm btn-outline-danger"
+                              disabled={
+                                deleteStage.isPending ||
+                                Boolean(rowDefinition?.required)
+                              }
+                              onClick={() => {
+                                if (confirm("Deseja remover esta etapa?")) {
+                                  deleteStage.mutate({
+                                    pipelineId: pipeline.id,
+                                    stageId: stage.id,
+                                  });
+                                }
+                              }}
+                            >
+                              {deleteStage.isPending
+                                ? "Excluindo..."
+                                : "Excluir"}
+                            </button>
+                          </div>
+                        </div>
+                        {stage.description ? (
+                          <p className="text-body-secondary mb-0">
+                            {stage.description}
+                          </p>
+                        ) : null}
+                        <div className="small text-body-secondary">
+                          <div>
+                            <strong>Módulo executor:</strong>{" "}
+                            {stage.executionModule || "Não informado"}
+                          </div>
+                          <div>
+                            <strong>Pacote raiz:</strong>{" "}
+                            {stage.rootPackage || "Não informado"}
+                          </div>
+                          <div>
+                            <strong>Modelo OpenAI:</strong>{" "}
+                            {stage.openAiModelName
+                              ? `${stage.openAiModelName} (${stage.openAiModelCode})`
+                              : "Sem modelo fixo"}
+                          </div>
+                        </div>
+                      </div>
+                    </article>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+        </section>
+
+        <section className="card">
+          <div className="card-body">
+            <h3 className="h5">
+              {editingStageId ? "Editar etapa" : "Adicionar etapa"}
+            </h3>
+            {stageDefinition?.required ? (
+              <div className="alert alert-warning">
+                Etapa oficial estrutural: código, posição, módulo executor,
+                pacote raiz e obrigatoriedade ficam protegidos para evitar
+                divergência do contrato operacional.
+              </div>
+            ) : null}
+            {isOfficialPipeline && officialPipeline ? (
+              <div className="mb-3">
+                <label className="form-label">Modelo de etapa oficial</label>
+                <select
+                  className="form-select"
+                  value={stageDefinition?.operationalCode ?? ""}
+                  onChange={(event) => {
+                    const selected = officialPipeline.stages.find(
+                      (stage) => stage.operationalCode === event.target.value,
+                    );
+                    if (!selected) return;
+                    setStageForms((current) => ({
+                      ...current,
+                      [pipeline.id]: {
+                        ...stageForm,
+                        position: selected.position,
+                        name: selected.name,
+                        code: selected.operationalCode,
+                        executionModule: selected.executionModule ?? "",
+                        rootPackage: selected.rootPackage ?? "",
+                        required: selected.required,
+                      },
+                    }));
+                  }}
+                >
+                  <option value="">Etapa personalizada</option>
+                  {officialPipeline.stages.map((stage) => (
+                    <option
+                      key={stage.operationalCode}
+                      value={stage.operationalCode}
+                    >
+                      {stage.position}. {stage.name} ({stage.operationalCode})
+                    </option>
+                  ))}
+                </select>
+              </div>
+            ) : null}
+            <div className="row g-3">
+              <div className="col-md-2">
+                <label className="form-label">Posição *</label>
+                <input
+                  className="form-control"
+                  type="number"
+                  min={1}
+                  value={stageForm.position}
+                  disabled={Boolean(stageDefinition?.required)}
+                  onChange={(event) =>
+                    setStageForms((current) => ({
+                      ...current,
+                      [pipeline.id]: {
+                        ...stageForm,
+                        position: Number(event.target.value),
+                      },
+                    }))
+                  }
+                />
+              </div>
+              <div className="col-md-4">
+                <label className="form-label">Nome *</label>
+                <input
+                  className="form-control"
+                  value={stageForm.name}
+                  onChange={(event) =>
+                    setStageForms((current) => ({
+                      ...current,
+                      [pipeline.id]: { ...stageForm, name: event.target.value },
+                    }))
+                  }
+                  placeholder="Campaign Angle"
+                />
+              </div>
+              <div className="col-md-3">
+                <label className="form-label">Código *</label>
+                <input
+                  className="form-control"
+                  disabled={Boolean(stageDefinition?.required)}
+                  value={stageForm.code}
+                  onChange={(event) =>
+                    setStageForms((current) => ({
+                      ...current,
+                      [pipeline.id]: { ...stageForm, code: event.target.value },
+                    }))
+                  }
+                  placeholder="campaign-angle"
+                />
+              </div>
+              <div className="col-md-3">
+                <label className="form-label">Módulo executor</label>
+                <input
+                  className="form-control"
+                  disabled={Boolean(stageDefinition?.required)}
+                  value={stageForm.executionModule ?? ""}
+                  onChange={(event) =>
+                    setStageForms((current) => ({
+                      ...current,
+                      [pipeline.id]: {
+                        ...stageForm,
+                        executionModule: event.target.value,
+                      },
+                    }))
+                  }
+                  placeholder="ai-worker"
+                />
+              </div>
+              <div className="col-md-4">
+                <label className="form-label">Pacote raiz</label>
+                <input
+                  className="form-control"
+                  disabled={Boolean(stageDefinition?.required)}
+                  value={stageForm.rootPackage ?? ""}
+                  onChange={(event) =>
+                    setStageForms((current) => ({
+                      ...current,
+                      [pipeline.id]: {
+                        ...stageForm,
+                        rootPackage: event.target.value,
+                      },
+                    }))
+                  }
+                  placeholder="com.marketinghub.worker.openai.core"
+                />
+              </div>
+              <div className="col-md-4">
+                <label className="form-label">Modelo OpenAI</label>
+                <select
+                  className="form-select"
+                  value={stageForm.openAiModelId ?? ""}
+                  onChange={(event) =>
+                    setStageForms((current) => ({
+                      ...current,
+                      [pipeline.id]: {
+                        ...stageForm,
+                        openAiModelId: event.target.value
+                          ? Number(event.target.value)
+                          : null,
+                      },
+                    }))
+                  }
+                >
+                  <option value="">
+                    {isLoadingOpenAiModels
+                      ? "Carregando modelos..."
+                      : "Sem modelo fixo"}
+                  </option>
+                  {modelOptions.map((model) => (
+                    <option key={model.id} value={model.id}>
+                      {model.name} ({model.code})
+                      {model.acceptsImageInput ? " · aceita imagem" : ""}
+                    </option>
+                  ))}
+                </select>
+                <div className="form-text">
+                  Use modelos com imagem para etapas visuais, como Quality
+                  Review, e mantenha foco em venda por etapa.
+                </div>
+              </div>
+              <div className="col-md-2 d-flex align-items-end">
+                <div className="form-check form-switch mb-2">
+                  <input
+                    className="form-check-input"
+                    type="checkbox"
+                    checked={stageForm.required}
+                    disabled={
+                      isEditingOfficialStage ||
+                      Boolean(stageDefinition?.required)
+                    }
+                    onChange={(event) =>
+                      setStageForms((current) => ({
+                        ...current,
+                        [pipeline.id]: {
+                          ...stageForm,
+                          required: event.target.checked,
+                        },
+                      }))
+                    }
+                    id={`stage-required-${pipeline.id}`}
+                  />
+                  <label
+                    className="form-check-label"
+                    htmlFor={`stage-required-${pipeline.id}`}
+                  >
+                    Obrigatória
+                  </label>
+                </div>
+              </div>
+              <div className="col-md-2 d-flex align-items-end">
+                <div className="form-check form-switch mb-2">
+                  <input
+                    className="form-check-input"
+                    type="checkbox"
+                    checked={stageForm.active}
+                    disabled={Boolean(stageDefinition?.required)}
+                    onChange={(event) =>
+                      setStageForms((current) => ({
+                        ...current,
+                        [pipeline.id]: {
+                          ...stageForm,
+                          active: event.target.checked,
+                        },
+                      }))
+                    }
+                    id={`stage-active-${pipeline.id}`}
+                  />
+                  <label
+                    className="form-check-label"
+                    htmlFor={`stage-active-${pipeline.id}`}
+                  >
+                    Ativa
+                  </label>
+                </div>
+              </div>
+              <div className="col-12">
+                <label className="form-label">Descrição</label>
+                <textarea
+                  className="form-control"
+                  rows={2}
+                  value={stageForm.description ?? ""}
+                  onChange={(event) =>
+                    setStageForms((current) => ({
+                      ...current,
+                      [pipeline.id]: {
+                        ...stageForm,
+                        description: event.target.value,
+                      },
+                    }))
+                  }
+                  placeholder="Explique o objetivo prático desta etapa."
+                />
+              </div>
+            </div>
+            <div className="d-flex gap-2 mt-3">
+              <button
+                className="btn btn-outline-primary"
+                disabled={
+                  isSavingStage ||
+                  !stageForm.name.trim() ||
+                  !stageForm.code.trim() ||
+                  stageForm.position < 1
+                }
+                onClick={() => submitStage(pipeline.id)}
+              >
+                {isSavingStage ? (
+                  <span
+                    className="spinner-border spinner-border-sm me-2"
+                    aria-hidden="true"
+                  />
+                ) : null}
+                {editingStageId ? "Salvar etapa" : "Adicionar etapa"}
+              </button>
+              {editingStageId ? (
+                <button
+                  className="btn btn-outline-secondary"
+                  disabled={isSavingStage}
+                  onClick={() => resetStageForm(pipeline.id)}
+                >
+                  Cancelar edição
+                </button>
+              ) : null}
+            </div>
+          </div>
+        </section>
+      </div>
+    );
+  }
+
   return (
     <div>
-      <PageTitle>Pipelines e etapas</PageTitle>
+      <PageTitle>Pipelines</PageTitle>
       <p className="text-body-secondary">
-        Configure os pipelines operacionais que transformam oportunidades em
-        produtos digitais vendáveis. Exemplo: Pipeline de Experimento com etapas
-        como Campaign Angle, Ad Copy e Landing Wireframe.
+        Lista limpa dos pipelines operacionais. Clique em{" "}
+        <strong>Ver etapas</strong> para abrir a tela focada somente no fluxo
+        daquele pipeline.
       </p>
 
       <section className="card mb-4">
@@ -332,615 +897,103 @@ export default function PipelineCrudPage() {
         </div>
       </section>
 
-      <div className="d-grid gap-4">
-        {pipelines.map((pipeline) => {
-          const stageForm = stageForms[pipeline.id] ?? emptyStage;
-          const diagnostic = diagnosticsByPipelineId.get(pipeline.id);
-          const officialPipeline = officialPipelines.find(
-            (official) =>
-              normalizeCode(official.code) === normalizeCode(pipeline.code),
-          );
-          const stageDefinition = officialPipeline?.stages.find(
-            (stage) =>
-              normalizeCode(stage.operationalCode) ===
-                normalizeCode(stageForm.code) ||
-              normalizeCode(stage.canonicalCode) ===
-                normalizeCode(stageForm.code) ||
-              stage.aliases.some(
-                (alias) =>
-                  normalizeCode(alias) === normalizeCode(stageForm.code),
-              ),
-          );
-          const isOfficialPipeline = Boolean(officialPipeline);
-          const isEditingOfficialStage = Boolean(
-            editingStageId && stageDefinition,
-          );
-          return (
-            <section className="card" key={pipeline.id}>
-              <div className="card-header d-flex flex-wrap justify-content-between align-items-start gap-3">
-                <div>
-                  <div className="d-flex align-items-center gap-2">
-                    <h2 className="h5 mb-0">{pipeline.name}</h2>
-                    <span
-                      className={`badge ${pipeline.active ? "text-bg-success" : "text-bg-secondary"}`}
-                    >
-                      {pipeline.active ? "Ativo" : "Inativo"}
-                    </span>
-                    <span
-                      className={`badge ${statusBadgeClass(diagnostic?.status)}`}
-                    >
-                      Contrato: {diagnostic?.status ?? "ATENÇÃO"}
-                    </span>
-                    {isOfficialPipeline ? (
-                      <span className="badge text-bg-primary">Oficial</span>
-                    ) : null}
-                  </div>
-                  <div className="small text-body-secondary">
-                    {pipeline.module} · {pipeline.code} ·{" "}
-                    {pipeline.stages.length} etapas
-                    {diagnostic ? (
-                      <>
-                        {" "}
-                        · esperado no código: {diagnostic.expectedStages} ·
-                        configurado no banco: {diagnostic.configuredStages}
-                      </>
-                    ) : null}
-                  </div>
-                  {pipeline.description ? (
-                    <p className="mb-0 mt-2">{pipeline.description}</p>
-                  ) : null}
-                </div>
-                <div className="d-flex flex-wrap gap-2">
-                  {isOfficialPipeline ? (
-                    <button
-                      className="btn btn-sm btn-outline-warning"
-                      disabled={
-                        rebuildOfficialStages.isPending ||
-                        !diagnostic ||
-                        diagnostic.status === "OK"
-                      }
-                      onClick={() => confirmOfficialStageRebuild(pipeline)}
-                    >
-                      {rebuildOfficialStages.isPending &&
-                      rebuildOfficialStages.variables === pipeline.id ? (
-                        <span
-                          className="spinner-border spinner-border-sm me-2"
-                          aria-hidden="true"
-                        />
-                      ) : null}
-                      Ajustar etapas oficiais
-                    </button>
-                  ) : null}
-                  <button
-                    className="btn btn-sm btn-outline-primary"
-                    onClick={() => {
-                      setEditingPipelineId(pipeline.id);
-                      setPipelineForm(pipelineToPayload(pipeline));
-                    }}
-                  >
-                    Editar
-                  </button>
-                  <button
-                    className="btn btn-sm btn-outline-danger"
-                    disabled={deletePipeline.isPending || isOfficialPipeline}
-                    onClick={() => {
-                      if (
-                        confirm(
-                          "Deseja remover este pipeline e todas as etapas?",
-                        )
-                      ) {
-                        deletePipeline.mutate(pipeline.id);
-                      }
-                    }}
-                  >
-                    {deletePipeline.isPending ? "Excluindo..." : "Excluir"}
-                  </button>
-                </div>
-              </div>
-              <div className="card-body">
-                {diagnostic ? (
-                  <div
-                    className={`alert ${diagnostic.status === "BLOQUEADO" ? "alert-danger" : diagnostic.status === "OK" ? "alert-success" : "alert-warning"}`}
-                  >
-                    <div className="fw-semibold">
-                      Status do contrato operacional: {diagnostic.status}
-                    </div>
-                    <div>
-                      Etapas esperadas no código: {diagnostic.expectedStages} ·
-                      etapas configuradas no banco:{" "}
-                      {diagnostic.configuredStages}
-                    </div>
-                    {diagnostic.issues.length > 0 ? (
-                      <ul className="mb-0 mt-2">
-                        {diagnostic.issues.map((issue, index) => (
-                          <li key={`${issue.stageCode ?? "pipeline"}-${index}`}>
-                            <strong>{issue.severity}</strong> ·{" "}
-                            {issue.stageCode ? (
-                              <code>{issue.stageCode}</code>
-                            ) : (
-                              "pipeline"
-                            )}
-                            {issue.canonicalCode ? (
-                              <>
-                                {" "}
-                                → <code>{issue.canonicalCode}</code>
-                              </>
-                            ) : null}
-                            : {issue.message} Causa-raiz: {issue.rootCause}{" "}
-                            Ação: {issue.recommendedAction}
-                          </li>
-                        ))}
-                      </ul>
-                    ) : null}
-                  </div>
-                ) : null}
-                <div className="mb-4">
-                  <div className="d-flex flex-wrap justify-content-between align-items-center gap-2 mb-3">
-                    <h3 className="h6 mb-0">Etapas configuradas</h3>
-                    <span className="badge text-bg-light border">
-                      {pipeline.stages.length} etapa
-                      {pipeline.stages.length === 1 ? "" : "s"}
-                    </span>
-                  </div>
-
-                  {pipeline.stages.length === 0 ? (
-                    <div className="alert alert-info mb-0">
-                      Nenhuma etapa cadastrada para este pipeline.
-                    </div>
-                  ) : (
-                    <div className="row g-3">
-                      {pipeline.stages.map((stage) => {
-                        const rowDefinition = officialPipeline?.stages.find(
-                          (definition) =>
-                            normalizeCode(definition.operationalCode) ===
-                              normalizeCode(stage.code) ||
-                            definition.aliases.some(
-                              (alias) =>
-                                normalizeCode(alias) ===
-                                normalizeCode(stage.code),
-                            ),
-                        );
-                        const protectionLabel = rowDefinition?.required
-                          ? "Estrutural"
-                          : isOfficialPipeline
-                            ? "Não mapeada"
-                            : "Editável";
-
-                        return (
-                          <div className="col-12 col-xl-6" key={stage.id}>
-                            <article className="card h-100 border shadow-sm">
-                              <div className="card-body d-flex flex-column gap-3">
-                                <div className="d-flex flex-wrap justify-content-between align-items-start gap-2">
-                                  <div>
-                                    <div className="small fw-semibold text-primary text-uppercase">
-                                      Etapa {stage.position}
-                                    </div>
-                                    <h4 className="h5 mb-1">{stage.name}</h4>
-                                    <div className="d-flex flex-wrap gap-2">
-                                      <span
-                                        className={`badge ${stage.active ? "text-bg-success" : "text-bg-secondary"}`}
-                                      >
-                                        {stage.active ? "Ativa" : "Inativa"}
-                                      </span>
-                                      <span
-                                        className={`badge ${stage.required ? "text-bg-warning" : "text-bg-light border"}`}
-                                      >
-                                        {stage.required
-                                          ? "Obrigatória"
-                                          : "Opcional"}
-                                      </span>
-                                      <span className="badge text-bg-light border">
-                                        {protectionLabel}
-                                      </span>
-                                    </div>
-                                  </div>
-
-                                  <div className="d-flex gap-2">
-                                    <button
-                                      className="btn btn-sm btn-outline-primary"
-                                      onClick={() => {
-                                        setEditingStageId(stage.id);
-                                        setStageForms((current) => ({
-                                          ...current,
-                                          [pipeline.id]: stageToPayload(stage),
-                                        }));
-                                      }}
-                                    >
-                                      Editar
-                                    </button>
-                                    <button
-                                      className="btn btn-sm btn-outline-danger"
-                                      disabled={
-                                        deleteStage.isPending ||
-                                        Boolean(rowDefinition?.required)
-                                      }
-                                      onClick={() => {
-                                        if (
-                                          confirm("Deseja remover esta etapa?")
-                                        ) {
-                                          deleteStage.mutate({
-                                            pipelineId: pipeline.id,
-                                            stageId: stage.id,
-                                          });
-                                        }
-                                      }}
-                                    >
-                                      {deleteStage.isPending
-                                        ? "Excluindo..."
-                                        : "Excluir"}
-                                    </button>
-                                  </div>
-                                </div>
-
-                                <p className="mb-0 text-body-secondary">
-                                  {stage.description ||
-                                    "Sem descrição operacional cadastrada."}
-                                </p>
-
-                                <div className="row g-2 small">
-                                  <div className="col-md-6">
-                                    <div className="text-body-secondary">
-                                      Código banco
-                                    </div>
-                                    <code>{stage.code}</code>
-                                  </div>
-                                  <div className="col-md-6">
-                                    <div className="text-body-secondary">
-                                      Código canônico
-                                    </div>
-                                    {rowDefinition ? (
-                                      <code>{rowDefinition.canonicalCode}</code>
-                                    ) : (
-                                      <span>—</span>
-                                    )}
-                                  </div>
-                                  <div className="col-md-6">
-                                    <div className="text-body-secondary">
-                                      Módulo executor
-                                    </div>
-                                    {stage.executionModule ? (
-                                      <code>{stage.executionModule}</code>
-                                    ) : (
-                                      <span>Backend</span>
-                                    )}
-                                  </div>
-                                  <div className="col-md-6">
-                                    <div className="text-body-secondary">
-                                      Modelo OpenAI
-                                    </div>
-                                    {stage.openAiModelCode ? (
-                                      <span
-                                        title={
-                                          stage.openAiModelName ?? undefined
-                                        }
-                                      >
-                                        {stage.openAiModelName ??
-                                          stage.openAiModelCode}{" "}
-                                        (<code>{stage.openAiModelCode}</code>)
-                                      </span>
-                                    ) : (
-                                      <span>—</span>
-                                    )}
-                                  </div>
-                                  <div className="col-12">
-                                    <div className="text-body-secondary">
-                                      Pacote raiz
-                                    </div>
-                                    {stage.rootPackage ? (
-                                      <code className="text-break">
-                                        {stage.rootPackage}
-                                      </code>
-                                    ) : (
-                                      <span>—</span>
-                                    )}
-                                  </div>
-                                </div>
-                              </div>
-                            </article>
-                          </div>
-                        );
-                      })}
-                    </div>
-                  )}
-                </div>
-
-                <div className="border rounded p-3 bg-light">
-                  <h3 className="h6">
-                    {editingStageId ? "Editar etapa" : "Nova etapa"}
-                  </h3>
-                  <div className="row g-3">
-                    <div className="col-md-1">
-                      <label className="form-label">Ordem *</label>
-                      <input
-                        type="number"
-                        min={1}
-                        className="form-control"
-                        disabled={isEditingOfficialStage}
-                        value={stageForm.position}
-                        onChange={(event) =>
-                          setStageForms((current) => ({
-                            ...current,
-                            [pipeline.id]: {
-                              ...stageForm,
-                              position: Number(event.target.value),
-                            },
-                          }))
-                        }
-                      />
-                    </div>
-                    <div className="col-md-3">
-                      <label className="form-label">Nome *</label>
-                      <input
-                        className="form-control"
-                        disabled={isEditingOfficialStage}
-                        value={stageForm.name}
-                        onChange={(event) =>
-                          setStageForms((current) => ({
-                            ...current,
-                            [pipeline.id]: {
-                              ...stageForm,
-                              name: event.target.value,
-                            },
-                          }))
-                        }
-                        placeholder="Campaign Angle"
-                      />
-                    </div>
-                    <div className="col-md-3">
-                      <label className="form-label">Código *</label>
-                      {isOfficialPipeline && officialPipeline ? (
-                        <select
-                          className="form-select"
-                          value={stageForm.code}
-                          disabled={isEditingOfficialStage}
-                          onChange={(event) => {
-                            const selected = officialPipeline.stages.find(
-                              (stage) =>
-                                stage.operationalCode === event.target.value,
-                            );
-                            setStageForms((current) => ({
-                              ...current,
-                              [pipeline.id]: {
-                                ...stageForm,
-                                code: event.target.value,
-                                name: selected?.name ?? stageForm.name,
-                                position:
-                                  selected?.position ?? stageForm.position,
-                                required:
-                                  selected?.required ?? stageForm.required,
-                                executionModule:
-                                  selected?.executionModule ??
-                                  stageForm.executionModule,
-                                rootPackage:
-                                  selected?.rootPackage ??
-                                  stageForm.rootPackage,
-                                active: true,
-                              },
-                            }));
-                          }}
-                        >
-                          <option value="">Selecione etapa oficial</option>
-                          {officialPipeline.stages.map((stage) => (
-                            <option
-                              key={stage.operationalCode}
-                              value={stage.operationalCode}
-                            >
-                              {stage.position}. {stage.name} (
-                              {stage.operationalCode})
-                            </option>
-                          ))}
-                        </select>
-                      ) : (
-                        <input
-                          className="form-control"
-                          value={stageForm.code}
-                          onChange={(event) =>
-                            setStageForms((current) => ({
-                              ...current,
-                              [pipeline.id]: {
-                                ...stageForm,
-                                code: event.target.value,
-                              },
-                            }))
-                          }
-                          placeholder="campaign-angle"
-                        />
-                      )}
-                    </div>
-                    <div className="col-md-3">
-                      <label className="form-label">Módulo da etapa</label>
-                      <input
-                        className="form-control"
-                        disabled={Boolean(stageDefinition)}
-                        value={stageForm.executionModule ?? ""}
-                        onChange={(event) =>
-                          setStageForms((current) => ({
-                            ...current,
-                            [pipeline.id]: {
-                              ...stageForm,
-                              executionModule: event.target.value,
-                            },
-                          }))
-                        }
-                        placeholder="Ex.: ai-worker (vazio = backend)"
-                      />
-                      <div className="form-text">
-                        Preencha somente quando a etapa for executada fora do
-                        backend.
-                      </div>
-                    </div>
-                    <div className="col-md-5">
-                      <label className="form-label">Pacote raiz</label>
-                      <input
-                        className="form-control"
-                        disabled={Boolean(stageDefinition)}
-                        value={stageForm.rootPackage ?? ""}
-                        onChange={(event) =>
-                          setStageForms((current) => ({
-                            ...current,
-                            [pipeline.id]: {
-                              ...stageForm,
-                              rootPackage: event.target.value,
-                            },
-                          }))
-                        }
-                        placeholder="Ex.: com.marketinghub.experiment.pipeline"
-                      />
-                      <div className="form-text">
-                        Informe o pacote raiz no backend ou no módulo executor.
-                      </div>
-                    </div>
-                    <div className="col-md-4">
-                      <label className="form-label">
-                        Modelo OpenAI da etapa
-                      </label>
-                      <select
-                        className="form-select"
-                        value={stageForm.openAiModelId ?? ""}
-                        disabled={isLoadingOpenAiModels}
-                        onChange={(event) =>
-                          setStageForms((current) => ({
-                            ...current,
-                            [pipeline.id]: {
-                              ...stageForm,
-                              openAiModelId: event.target.value
-                                ? Number(event.target.value)
-                                : null,
-                            },
-                          }))
-                        }
-                      >
-                        <option value="">
-                          {isLoadingOpenAiModels
-                            ? "Carregando modelos..."
-                            : "Sem modelo fixo"}
-                        </option>
-                        {modelOptions.map((model) => (
-                          <option key={model.id} value={model.id}>
-                            {model.name} ({model.code})
-                            {model.acceptsImageInput ? " · aceita imagem" : ""}
-                          </option>
-                        ))}
-                      </select>
-                      <div className="form-text">
-                        Use modelos com imagem para etapas visuais, como Quality
-                        Review, e mantenha foco em venda por etapa.
-                      </div>
-                    </div>
-                    <div className="col-md-2 d-flex align-items-end">
-                      <div className="form-check form-switch mb-2">
-                        <input
-                          className="form-check-input"
-                          type="checkbox"
-                          checked={stageForm.required}
-                          disabled={
-                            isEditingOfficialStage ||
-                            Boolean(stageDefinition?.required)
-                          }
-                          onChange={(event) =>
-                            setStageForms((current) => ({
-                              ...current,
-                              [pipeline.id]: {
-                                ...stageForm,
-                                required: event.target.checked,
-                              },
-                            }))
-                          }
-                          id={`stage-required-${pipeline.id}`}
-                        />
-                        <label
-                          className="form-check-label"
-                          htmlFor={`stage-required-${pipeline.id}`}
-                        >
-                          Obrigatória
-                        </label>
-                      </div>
-                    </div>
-                    <div className="col-md-2 d-flex align-items-end">
-                      <div className="form-check form-switch mb-2">
-                        <input
-                          className="form-check-input"
-                          type="checkbox"
-                          checked={stageForm.active}
-                          disabled={Boolean(stageDefinition?.required)}
-                          onChange={(event) =>
-                            setStageForms((current) => ({
-                              ...current,
-                              [pipeline.id]: {
-                                ...stageForm,
-                                active: event.target.checked,
-                              },
-                            }))
-                          }
-                          id={`stage-active-${pipeline.id}`}
-                        />
-                        <label
-                          className="form-check-label"
-                          htmlFor={`stage-active-${pipeline.id}`}
-                        >
-                          Ativa
-                        </label>
-                      </div>
-                    </div>
-                    <div className="col-12">
-                      <label className="form-label">Descrição</label>
-                      <textarea
-                        className="form-control"
-                        rows={2}
-                        value={stageForm.description ?? ""}
-                        onChange={(event) =>
-                          setStageForms((current) => ({
-                            ...current,
-                            [pipeline.id]: {
-                              ...stageForm,
-                              description: event.target.value,
-                            },
-                          }))
-                        }
-                        placeholder="Explique o objetivo prático desta etapa."
-                      />
-                    </div>
-                  </div>
-                  <div className="d-flex gap-2 mt-3">
-                    <button
-                      className="btn btn-outline-primary"
-                      disabled={
-                        isSavingStage ||
-                        !stageForm.name.trim() ||
-                        !stageForm.code.trim() ||
-                        stageForm.position < 1
-                      }
-                      onClick={() => submitStage(pipeline.id)}
-                    >
-                      {isSavingStage ? (
-                        <span
-                          className="spinner-border spinner-border-sm me-2"
-                          aria-hidden="true"
-                        />
-                      ) : null}
-                      {editingStageId ? "Salvar etapa" : "Adicionar etapa"}
-                    </button>
-                    {editingStageId ? (
-                      <button
-                        className="btn btn-outline-secondary"
-                        disabled={isSavingStage}
-                        onClick={() => resetStageForm(pipeline.id)}
-                      >
-                        Cancelar edição
-                      </button>
-                    ) : null}
-                  </div>
-                </div>
-              </div>
-            </section>
-          );
-        })}
-        {pipelines.length === 0 ? (
-          <div className="alert alert-info">
-            Nenhum pipeline cadastrado ainda. Crie o primeiro pipeline acima.
+      {pipelines.length === 0 ? (
+        <div className="alert alert-info">
+          Nenhum pipeline cadastrado ainda. Crie o primeiro pipeline acima.
+        </div>
+      ) : (
+        <section className="card">
+          <div className="card-header bg-white d-flex flex-wrap justify-content-between align-items-center gap-2">
+            <h2 className="h5 mb-0">Lista de pipelines</h2>
+            <span className="badge text-bg-light border">
+              {pipelines.length} pipeline{pipelines.length === 1 ? "" : "s"}
+            </span>
           </div>
-        ) : null}
-      </div>
+          <div className="list-group list-group-flush">
+            {pipelines.map((pipeline) => {
+              const diagnostic = diagnosticsByPipelineId.get(pipeline.id);
+              const isOfficialPipeline = officialPipelines.some(
+                (official) =>
+                  normalizeCode(official.code) === normalizeCode(pipeline.code),
+              );
+
+              return (
+                <article className="list-group-item" key={pipeline.id}>
+                  <div className="d-flex flex-wrap justify-content-between align-items-start gap-3">
+                    <div className="flex-grow-1">
+                      <div className="d-flex flex-wrap align-items-center gap-2 mb-1">
+                        <h3 className="h5 mb-0">{pipeline.name}</h3>
+                        {isOfficialPipeline ? (
+                          <span className="badge text-bg-primary">Oficial</span>
+                        ) : null}
+                        <span
+                          className={`badge ${pipeline.active ? "text-bg-success" : "text-bg-secondary"}`}
+                        >
+                          {pipeline.active ? "Ativo" : "Inativo"}
+                        </span>
+                        {diagnostic ? (
+                          <span
+                            className={`badge ${statusBadgeClass(diagnostic.status)}`}
+                          >
+                            Contrato {diagnostic.status}
+                          </span>
+                        ) : null}
+                      </div>
+                      <div className="d-flex flex-wrap gap-2 small text-body-secondary">
+                        <span>{pipeline.module}</span>
+                        <span>•</span>
+                        <code>{pipeline.code}</code>
+                        <span>•</span>
+                        <span>
+                          {pipeline.stages.length} etapa
+                          {pipeline.stages.length === 1 ? "" : "s"}
+                        </span>
+                      </div>
+                      {pipeline.description ? (
+                        <p className="text-body-secondary mb-0 mt-2">
+                          {pipeline.description}
+                        </p>
+                      ) : null}
+                    </div>
+                    <div className="d-flex flex-wrap gap-2">
+                      <button
+                        type="button"
+                        className="btn btn-primary btn-sm"
+                        onClick={() => openPipelineStages(pipeline.id)}
+                      >
+                        Ver etapas
+                      </button>
+                      <button
+                        className="btn btn-sm btn-outline-primary"
+                        onClick={() => startPipelineEdit(pipeline)}
+                      >
+                        Editar
+                      </button>
+                      <button
+                        className="btn btn-sm btn-outline-danger"
+                        disabled={
+                          deletePipeline.isPending || isOfficialPipeline
+                        }
+                        onClick={() => {
+                          if (
+                            confirm(
+                              "Deseja remover este pipeline e todas as etapas?",
+                            )
+                          ) {
+                            deletePipeline.mutate(pipeline.id);
+                          }
+                        }}
+                      >
+                        {deletePipeline.isPending ? "Excluindo..." : "Excluir"}
+                      </button>
+                    </div>
+                  </div>
+                </article>
+              );
+            })}
+          </div>
+        </section>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
### Motivation
- The `/pipelines` page was visually noisy because it rendered pipeline CRUD, diagnostics, every pipeline's stages and the stage form simultaneously, causing user confusion.  
- The intent is to reduce visual clutter and focus operations by showing a clean list of pipelines and switching to a focused screen for a single pipeline's stages when requested.  

### Description
- Split the UI into two states in `frontend/src/pages/pipeline/PipelineCrudPage.tsx`: a compact pipelines list and a focused selected-pipeline stages view, controlled by a new `selectedPipelineId` state.  
- Moved stage diagnostics, stage cards and the stage creation/edit form to the focused pipeline view and kept pipeline create/edit on the list view.  
- Added helper actions `openPipelineStages`, `returnToPipelineList` and `startPipelineEdit` to manage navigation between list and single-pipeline views.  
- Recorded the operational change in `docs/registros/experimentos.md` as required by project conventions.  

### Testing
- Ran type checking with `npm run typecheck --prefix frontend` and it completed successfully.  
- Built the frontend with `npm run build --prefix frontend` and the production build completed successfully.  
- Captured a visual verification with `npx playwright screenshot --full-page http://127.0.0.1:5173/pipelines /tmp/pipelines-list.png` which produced the screenshot (used to validate the new list view).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a236303fcb88321b19b78df660b40a8)