### PR TITLE
Paginar experimentos de campanhas do Facebook

### DIFF
--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -3695,3 +3695,14 @@
   - frontend/src/pages/pipeline/PipelineCrudPage.tsx
   - frontend/src/api/pipeline/types.ts
   - frontend/src/api/pipeline/usePipelines.ts
+
+## 2026-06-06 02:07:00 UTC
+- solicitação: ajustar a tela `/facebook-campaigns` para mostrar os registros mais recentes no começo e paginar a listagem com 25 itens por página.
+- raciocínio para a solução: o endpoint atual já fornece todos os experimentos necessários por status; a causa do esforço visual estava na ordenação e volume renderizado no frontend, então a correção foi aplicada na apresentação sem criar novo contrato backend.
+- foi feito: a tela de Experimentos para Campanha passou a ordenar por ID decrescente como proxy dos cadastros mais recentes, exibir o contador de intervalo da página, limitar a tabela a 25 experimentos e oferecer navegação anterior/próxima e por número de página.
+- documentos lidos para pesquisar e resolver o problema:
+  - AGENTS.md
+  - frontend/AGENTS.md
+  - docs/registros/experimentos.md
+  - frontend/src/pages/facebook/FacebookCampaignExperimentsPage.tsx
+  - frontend/src/api/useFacebookCampaignExperiments.ts

--- a/frontend/src/pages/facebook/FacebookCampaignExperimentsPage.test.tsx
+++ b/frontend/src/pages/facebook/FacebookCampaignExperimentsPage.test.tsx
@@ -1,0 +1,110 @@
+import "@testing-library/jest-dom/vitest";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  within,
+} from "@testing-library/react";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import FacebookCampaignExperimentsPage from "./FacebookCampaignExperimentsPage";
+import type { ExperimentSummary } from "../../api/useFacebookCampaignExperiments";
+
+const useFacebookCampaignExperimentsMock = vi.fn();
+const useFacebookConfigurationStatusMock = vi.fn();
+
+vi.mock("../../api/useFacebookCampaignExperiments", () => ({
+  useFacebookCampaignExperiments: (status: string) =>
+    useFacebookCampaignExperimentsMock(status),
+}));
+
+vi.mock("../../api/useFacebookConfigurationStatus", () => ({
+  useFacebookConfigurationStatus: () => useFacebookConfigurationStatusMock(),
+}));
+
+function makeExperiment(id: number): ExperimentSummary {
+  return {
+    id,
+    name: `Experimento ${id}`,
+    hypothesis: `Hipótese ${id}`,
+    kpiTargetCpl: null,
+    startDate: null,
+    endDate: null,
+    nicheName: null,
+    hypothesisTitle: null,
+    missingConfiguration: [],
+  };
+}
+
+function setup(experiments: ExperimentSummary[]) {
+  useFacebookCampaignExperimentsMock.mockReturnValue({
+    data: experiments,
+    isLoading: false,
+  });
+  useFacebookConfigurationStatusMock.mockReturnValue({
+    data: { hasConfiguredPages: true },
+  });
+
+  return render(
+    <MemoryRouter>
+      <FacebookCampaignExperimentsPage />
+    </MemoryRouter>,
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+afterEach(() => {
+  cleanup();
+});
+
+describe("FacebookCampaignExperimentsPage", () => {
+  it("mostra os experimentos mais recentes primeiro e limita a página a 25 itens", () => {
+    const experiments = Array.from({ length: 30 }, (_, index) =>
+      makeExperiment(index + 1),
+    );
+
+    setup(experiments);
+
+    const table = screen.getByRole("table");
+    const rows = within(table).getAllByRole("row").slice(1);
+
+    expect(rows).toHaveLength(25);
+    expect(
+      within(rows[0]).getByRole("link", { name: "Experimento 30" }),
+    ).toBeInTheDocument();
+    expect(
+      within(rows[24]).getByRole("link", { name: "Experimento 6" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Mais recentes primeiro · exibindo 1-25 de 30"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("25 por página")).toBeInTheDocument();
+  });
+
+  it("avança para a próxima página mantendo a ordenação decrescente", () => {
+    const experiments = Array.from({ length: 30 }, (_, index) =>
+      makeExperiment(index + 1),
+    );
+
+    setup(experiments);
+    fireEvent.click(screen.getByRole("button", { name: /próxima/i }));
+
+    const table = screen.getByRole("table");
+    const rows = within(table).getAllByRole("row").slice(1);
+
+    expect(rows).toHaveLength(5);
+    expect(
+      within(rows[0]).getByRole("link", { name: "Experimento 5" }),
+    ).toBeInTheDocument();
+    expect(
+      within(rows[4]).getByRole("link", { name: "Experimento 1" }),
+    ).toBeInTheDocument();
+    expect(
+      screen.getByText("Mais recentes primeiro · exibindo 26-30 de 30"),
+    ).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/facebook/FacebookCampaignExperimentsPage.tsx
+++ b/frontend/src/pages/facebook/FacebookCampaignExperimentsPage.tsx
@@ -1,20 +1,49 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { Link } from "react-router-dom";
-import { AlertTriangle, CheckCircle2 } from "lucide-react";
+import {
+  AlertTriangle,
+  CheckCircle2,
+  ChevronLeft,
+  ChevronRight,
+} from "lucide-react";
 import { useFacebookCampaignExperiments } from "../../api/useFacebookCampaignExperiments";
 import PageTitle from "../../components/PageTitle";
 import { useFacebookConfigurationStatus } from "../../api/useFacebookConfigurationStatus";
 import { MissingConfigurationList } from "./MissingConfigurationList";
 
+const EXPERIMENTS_PER_PAGE = 25;
+
 export default function FacebookCampaignExperimentsPage() {
   const [status, setStatus] = useState("PLANNED");
+  const [currentPage, setCurrentPage] = useState(1);
   const { data, isLoading } = useFacebookCampaignExperiments(status);
   const { data: configuration } = useFacebookConfigurationStatus();
-  const experiments = Array.isArray(data) ? data : [];
+  const experiments = useMemo(
+    () =>
+      (Array.isArray(data) ? [...data] : []).sort(
+        (current, next) => next.id - current.id,
+      ),
+    [data],
+  );
+  const totalPages = Math.max(
+    1,
+    Math.ceil(experiments.length / EXPERIMENTS_PER_PAGE),
+  );
+  const firstExperimentIndex = (currentPage - 1) * EXPERIMENTS_PER_PAGE;
+  const paginatedExperiments = experiments.slice(
+    firstExperimentIndex,
+    firstExperimentIndex + EXPERIMENTS_PER_PAGE,
+  );
+  const pageStart = experiments.length === 0 ? 0 : firstExperimentIndex + 1;
+  const pageEnd = Math.min(
+    firstExperimentIndex + EXPERIMENTS_PER_PAGE,
+    experiments.length,
+  );
   const requiresPageSetup = configuration && !configuration.hasConfiguredPages;
   const numberFormatter = useMemo(() => new Intl.NumberFormat("pt-BR"), []);
   const currencyFormatter = useMemo(
-    () => new Intl.NumberFormat("pt-BR", { style: "currency", currency: "BRL" }),
+    () =>
+      new Intl.NumberFormat("pt-BR", { style: "currency", currency: "BRL" }),
     [],
   );
   const formatNumber = (value?: number | null) =>
@@ -23,6 +52,14 @@ export default function FacebookCampaignExperimentsPage() {
     typeof value === "number" ? currencyFormatter.format(value) : "--";
   const formatDateTime = (value?: string | null) =>
     value ? new Date(value).toLocaleString("pt-BR") : "--";
+
+  useEffect(() => {
+    setCurrentPage(1);
+  }, [status]);
+
+  useEffect(() => {
+    setCurrentPage((page) => Math.min(page, totalPages));
+  }, [totalPages]);
 
   const renderMetrics = (experiment: (typeof experiments)[number]) => {
     if (status !== "RUNNING") {
@@ -58,10 +95,12 @@ export default function FacebookCampaignExperimentsPage() {
           {leadPortalFunnel ? (
             <>
               <span>
-                <strong>Form visto</strong> {formatNumber(leadPortalFunnel.formAccesses)}
+                <strong>Form visto</strong>{" "}
+                {formatNumber(leadPortalFunnel.formAccesses)}
               </span>
               <span>
-                <strong>Form enviado</strong> {formatNumber(leadPortalFunnel.formSubmissions)}
+                <strong>Form enviado</strong>{" "}
+                {formatNumber(leadPortalFunnel.formSubmissions)}
               </span>
             </>
           ) : null}
@@ -72,7 +111,9 @@ export default function FacebookCampaignExperimentsPage() {
               ? `Atualizado em ${formatDateTime(metrics.lastSyncedAt)}`
               : "Última atualização indisponível"}
             {metrics.lastSyncError ? (
-              <span className="text-danger ms-2">Erro: {metrics.lastSyncError}</span>
+              <span className="text-danger ms-2">
+                Erro: {metrics.lastSyncError}
+              </span>
             ) : null}
           </div>
         ) : null}
@@ -83,7 +124,10 @@ export default function FacebookCampaignExperimentsPage() {
     <div>
       <PageTitle>Experimentos para Campanha</PageTitle>
       {requiresPageSetup ? (
-        <div className="alert alert-warning d-flex align-items-center gap-2" role="alert">
+        <div
+          className="alert alert-warning d-flex align-items-center gap-2"
+          role="alert"
+        >
           <AlertTriangle size={18} />
           <div>
             Configure ao menos uma página do Facebook para continuar publicando
@@ -115,6 +159,13 @@ export default function FacebookCampaignExperimentsPage() {
         <p>Carregando...</p>
       ) : (
         <div className="table-responsive">
+          <div className="d-flex flex-wrap justify-content-between align-items-center gap-2 mb-2">
+            <span className="text-muted small">
+              Mais recentes primeiro · exibindo {pageStart}-{pageEnd} de{" "}
+              {experiments.length}
+            </span>
+            <span className="badge text-bg-light border">25 por página</span>
+          </div>
           <table className="table table-hover">
             <thead>
               <tr>
@@ -128,7 +179,7 @@ export default function FacebookCampaignExperimentsPage() {
               </tr>
             </thead>
             <tbody>
-              {experiments.map((e) => (
+              {paginatedExperiments.map((e) => (
                 <tr key={e.id}>
                   <td>
                     <Link to={`/experiments/${e.id}`}>{e.name}</Link>
@@ -161,6 +212,60 @@ export default function FacebookCampaignExperimentsPage() {
               ))}
             </tbody>
           </table>
+          {totalPages > 1 ? (
+            <nav aria-label="Paginação de experimentos para campanha">
+              <ul className="pagination justify-content-end mb-0">
+                <li
+                  className={`page-item${currentPage === 1 ? " disabled" : ""}`}
+                >
+                  <button
+                    type="button"
+                    className="page-link d-inline-flex align-items-center gap-1"
+                    onClick={() =>
+                      setCurrentPage((page) => Math.max(1, page - 1))
+                    }
+                    disabled={currentPage === 1}
+                  >
+                    <ChevronLeft size={16} aria-hidden="true" />
+                    Anterior
+                  </button>
+                </li>
+                {Array.from(
+                  { length: totalPages },
+                  (_, index) => index + 1,
+                ).map((page) => (
+                  <li
+                    key={page}
+                    className={`page-item${page === currentPage ? " active" : ""}`}
+                  >
+                    <button
+                      type="button"
+                      className="page-link"
+                      onClick={() => setCurrentPage(page)}
+                      aria-current={page === currentPage ? "page" : undefined}
+                    >
+                      {page}
+                    </button>
+                  </li>
+                ))}
+                <li
+                  className={`page-item${currentPage === totalPages ? " disabled" : ""}`}
+                >
+                  <button
+                    type="button"
+                    className="page-link d-inline-flex align-items-center gap-1"
+                    onClick={() =>
+                      setCurrentPage((page) => Math.min(totalPages, page + 1))
+                    }
+                    disabled={currentPage === totalPages}
+                  >
+                    Próxima
+                    <ChevronRight size={16} aria-hidden="true" />
+                  </button>
+                </li>
+              </ul>
+            </nav>
+          ) : null}
         </div>
       )}
     </div>


### PR DESCRIPTION
### Motivation
- A tela `/facebook-campaigns` exibia muitos registros sem ordenação por recência, dificultando a operação; a intenção é mostrar os mais recentes primeiro e limitar o volume por página. 

### Description
- A interface passou a ordenar os experimentos por ID decrescente e a usar paginação com `25` itens por página, implementado em `frontend/src/pages/facebook/FacebookCampaignExperimentsPage.tsx`. 
- Adicionado indicador de intervalo e selo `25 por página` e controles de navegação (anterior/próxima e números de página) na mesma página. 
- Incluídos testes de regressão em `frontend/src/pages/facebook/FacebookCampaignExperimentsPage.test.tsx` que verificam ordenação decrescente e paginação, e registrado o trabalho em `docs/registros/experimentos.md`. 

### Testing
- Executado `cd frontend && npm test -- --run src/pages/facebook/FacebookCampaignExperimentsPage.test.tsx` e os testes unitários passaram com sucesso. 
- Executado `cd frontend && npm run typecheck` e o `tsc --noEmit` completou sem erros no ambiente após instalação de dependências. 
- Executado `cd frontend && npm run build` e o build de produção com `vite` foi gerado com sucesso. 
- Tentativa de captura de tela com Playwright (`npx playwright screenshot`) falhou por dependência nativa ausente no ambiente (`libatk-1.0.so.0`), sem impacto nas alterações de frontend e testes unitários.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a237fe9659c832197c4e07fcdc3ee61)