### PR TITLE
OPRM: implement Routine Synthesizer (stage 6) and Enriched Niche Materializer; neutralize niche names and improve source/signal taxonomy

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/enrichednichematerializer/service/BackendEnrichedNicheMaterializerService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/enrichednichematerializer/service/BackendEnrichedNicheMaterializerService.java
@@ -8,6 +8,8 @@ import com.marketinghub.oprm.nichocnae.OprmRoutineResearchCycle;
 import com.marketinghub.oprm.nichocnae.enrichednichematerializer.service.completeStageExecution.CompleteEnrichedNicheMaterializerRequest;
 import com.marketinghub.oprm.nichocnae.enrichednichematerializer.service.completeStageExecution.CompleteEnrichedNicheMaterializerResponse;
 import com.marketinghub.oprm.nichocnae.enrichednichematerializer.service.detailStageExecution.EnrichedNicheMaterializerDetailResponse;
+import com.marketinghub.oprm.nichocnae.enrichednichematerializer.service.diagnoseContamination.ContaminatedNicheDiagnosticItem;
+import com.marketinghub.oprm.nichocnae.enrichednichematerializer.service.diagnoseContamination.ContaminatedNicheDiagnosticResponse;
 import com.marketinghub.oprm.nichocnae.enrichednichematerializer.service.failStageExecution.FailEnrichedNicheMaterializerRequest;
 import com.marketinghub.oprm.nichocnae.enrichednichematerializer.service.pending.RecordEnrichedNicheMaterializerPending;
 import com.marketinghub.repository.jpa.niche.MarketNicheEnrichmentProfileRepository;
@@ -17,7 +19,10 @@ import com.marketinghub.repository.jpa.oprm.nichocnae.OprmNicheRoutineCardReposi
 import com.marketinghub.repository.jpa.oprm.nichocnae.OprmRoutineResearchCycleRepository;
 import jakarta.persistence.EntityNotFoundException;
 import java.time.Instant;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -30,6 +35,9 @@ public class BackendEnrichedNicheMaterializerService {
   private static final String SOURCE_MODULE = "OPRM_NICHO_CNAE";
   private static final String ENRICHED_STATUS = "ENRICHED_NICHE_CREATED";
   private static final String FAILED_STATUS = "ENRICHED_NICHE_FAILED";
+  private static final String HISTORICAL_RESEARCH_RECOMMENDATION = "Preferir novo ciclo neutro em vez de editar manualmente o texto antigo.";
+  private static final List<String> SOLUTION_LANGUAGE_TERMS = List.of(
+      "ia", "inteligência artificial", "automação", "software", "sistema", "app", "ferramenta", "curso", "template", "oferta", "landing page");
 
   private final OprmRoutineResearchCycleRepository cycleRepository;
   private final OprmNicheRoutineCardRepository routineCardRepository;
@@ -118,6 +126,25 @@ public class BackendEnrichedNicheMaterializerService {
     return buildDetailResponse(cycle, card, profile);
   }
 
+  /** Localiza ciclos e perfis históricos com termos de solução para orientar reprocessamento neutro. */
+  @Transactional(readOnly = true)
+  public ContaminatedNicheDiagnosticResponse diagnoseHistoricalContamination(int limit) {
+    int boundedLimit = Math.max(1, Math.min(limit, 50));
+    Map<String, ContaminatedNicheDiagnosticItem> uniqueItems = new LinkedHashMap<>();
+    for (String term : SOLUTION_LANGUAGE_TERMS) {
+      cycleRepository.findPotentiallyContaminatedByTerm(term, PageRequest.of(0, boundedLimit)).forEach(cycle ->
+          uniqueItems.putIfAbsent("CYCLE:" + cycle.getId(), toCycleDiagnosticItem(cycle, term)));
+      enrichmentProfileRepository.findPotentiallyContaminatedByTerm(term, PageRequest.of(0, boundedLimit)).forEach(profile ->
+          uniqueItems.putIfAbsent("PROFILE:" + profile.getId(), toProfileDiagnosticItem(profile, term)));
+    }
+    List<ContaminatedNicheDiagnosticItem> items = new ArrayList<>(uniqueItems.values()).stream()
+        .limit(boundedLimit)
+        .toList();
+    int totalCycles = (int) items.stream().filter(item -> "CYCLE".equals(item.recordType())).count();
+    int totalProfiles = (int) items.stream().filter(item -> "PROFILE".equals(item.recordType())).count();
+    return new ContaminatedNicheDiagnosticResponse(Instant.now(), totalCycles, totalProfiles, items);
+  }
+
   /** Monta o DTO público de detalhe combinando ciclo, card e perfil enriquecido. */
   private EnrichedNicheMaterializerDetailResponse buildDetailResponse(
       OprmRoutineResearchCycle cycle, OprmNicheRoutineCard card, MarketNicheEnrichmentProfile profile) {
@@ -127,7 +154,11 @@ public class BackendEnrichedNicheMaterializerService {
         card == null ? null : card.getId(),
         profile == null ? null : profile.getMarketNiche().getId(),
         profile == null ? null : profile.getId(),
-        card == null ? cycle.getNicheName() : card.getNicheName(),
+        cycle.getOriginalNicheName(),
+        cycle.getNeutralNicheName(),
+        cycle.getResearchMode(),
+        cycle.getSolutionLanguageRiskScore(),
+        card == null ? neutralNicheName(cycle) : card.getNicheName(),
         cycle.getCnaeCode(),
         card == null ? null : card.getQualityStatus(),
         profile == null ? null : profile.getRoutineSummary(),
@@ -150,7 +181,7 @@ public class BackendEnrichedNicheMaterializerService {
         candidate == null ? null : candidate.getMarketNicheId(),
         cycle.getCnaeCode(),
         cycle.getCnaeDescription(),
-        card.getNicheName(),
+        neutralNicheName(cycle),
         cycle.getSourceScore(),
         card.getQualityStatus(),
         card.getSpecificityScore(),
@@ -170,10 +201,11 @@ public class BackendEnrichedNicheMaterializerService {
     MarketNiche marketNiche = candidate != null && candidate.getMarketNicheId() != null
         ? marketNicheRepository.findById(candidate.getMarketNicheId()).orElseGet(MarketNiche::new)
         : new MarketNiche();
-    marketNiche.setName(requiredText(card.getNicheName(), "nicheName"));
+    marketNiche.setName(requiredText(neutralNicheName(cycle), "neutralNicheName"));
     marketNiche.setDescription(buildMarketNicheDescription(card, cycle));
     marketNiche.setDemandVolume("CNAE " + cycle.getCnaeCode() + " · Score OPRM " + cycle.getSourceScore());
-    marketNiche.setPromises(card.getResultsSummary());
+    marketNiche.setPromises(null);
+    marketNiche.setOffers(null);
     marketNiche.setBaseSegmentation("Nicho operacional CNAE " + cycle.getCnaeCode() + " - " + cycle.getCnaeDescription());
     marketNiche.setDemographicFilters("Público profissional/empreendedor ligado a " + cycle.getCnaeDescription());
     marketNiche.setInterests(card.getSourceDomains());
@@ -186,18 +218,19 @@ public class BackendEnrichedNicheMaterializerService {
     return String.join("\n\n",
         "Nicho materializado pelo OPRM NichoCNAE.",
         "CNAE: " + cycle.getCnaeCode() + " - " + cycle.getCnaeDescription(),
+        "Nome original recebido para auditoria: " + defaultText(cycle.getOriginalNicheName(), cycle.getNicheName()),
+        "Nome neutro pesquisado: " + neutralNicheName(cycle),
         "Rotina observada:\n" + card.getRoutineSummary(),
-        "Dores observadas:\n" + card.getPainsSummary(),
-        "Resultados desejados:\n" + card.getResultsSummary(),
-        "Oportunidades de mecanismo:\n" + card.getMechanismOpportunitiesSummary(),
-        "Evidências:\n" + card.getEvidenceSummary());
+        "Dificuldades observadas:\n" + card.getPainsSummary(),
+        "Contexto operacional:\n" + card.getResultsSummary(),
+        "Linguagem e evidências públicas:\n" + card.getEvidenceSummary());
   }
 
   /** Monta dicas operacionais de uso do nicho para próximas etapas sem acionar hipótese. */
   private String buildExtraTips(OprmNicheRoutineCard card) {
     return String.join("\n\n",
-        "Use este nicho como base enriquecida para hipótese em outro fluxo.",
-        "Status de qualidade: " + card.getQualityStatus(),
+        "Use este registro como auditoria de rotina real antes de qualquer fluxo posterior de hipótese.",
+        "Status de qualidade da rotina: " + card.getQualityStatus(),
         "Especificidade: " + card.getSpecificityScore() + "%",
         "Confiança: " + card.getConfidenceScore() + "%",
         "Duplicação: " + card.getDuplicationScore() + "%");
@@ -232,8 +265,8 @@ public class BackendEnrichedNicheMaterializerService {
     profile.setSourceDomains(trimOptional(card.getSourceDomains()));
     profile.setPersonaSummary(trimOptional(request.personaSummary()));
     profile.setLanguagePatterns(trimOptional(request.languagePatterns()));
-    profile.setCommercialTriggers(trimOptional(request.commercialTriggers()));
-    profile.setObjections(trimOptional(request.objections()));
+    profile.setCommercialTriggers(null);
+    profile.setObjections(null);
     profile.setCreatedBy(defaultText(request.materializedBy(), "oprmEnrichedNicheMaterializer"));
     profile.setCreatedAt(now);
     profile.setUpdatedAt(now);
@@ -255,6 +288,43 @@ public class BackendEnrichedNicheMaterializerService {
       candidate.setUpdatedAt(now);
       nicheCandidateRepository.save(candidate);
     }
+  }
+
+  /** Converte um ciclo contaminado em item de diagnóstico operacional. */
+  private ContaminatedNicheDiagnosticItem toCycleDiagnosticItem(OprmRoutineResearchCycle cycle, String matchedTerm) {
+    return new ContaminatedNicheDiagnosticItem(
+        "CYCLE",
+        cycle.getId(),
+        cycle.getId(),
+        null,
+        matchedTerm,
+        cycle.getOriginalNicheName(),
+        cycle.getNeutralNicheName(),
+        cycle.getNicheName(),
+        cycle.getStatus(),
+        HISTORICAL_RESEARCH_RECOMMENDATION,
+        cycle.getStartedAt());
+  }
+
+  /** Converte um perfil contaminado em item de diagnóstico operacional. */
+  private ContaminatedNicheDiagnosticItem toProfileDiagnosticItem(MarketNicheEnrichmentProfile profile, String matchedTerm) {
+    return new ContaminatedNicheDiagnosticItem(
+        "PROFILE",
+        profile.getId(),
+        profile.getResearchCycleId(),
+        profile.getMarketNiche().getId(),
+        matchedTerm,
+        null,
+        profile.getMarketNiche().getName(),
+        profile.getMarketNiche().getName(),
+        profile.getQualityStatus(),
+        HISTORICAL_RESEARCH_RECOMMENDATION,
+        profile.getCreatedAt());
+  }
+
+  /** Retorna o nome neutro operacional do ciclo com fallback seguro para ciclos legados. */
+  private String neutralNicheName(OprmRoutineResearchCycle cycle) {
+    return defaultText(cycle.getNeutralNicheName(), cycle.getNicheName());
   }
 
   /** Localiza o ciclo de pesquisa de rotina ou falha com erro contratual claro. */

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/enrichednichematerializer/service/detailStageExecution/EnrichedNicheMaterializerDetailResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/enrichednichematerializer/service/detailStageExecution/EnrichedNicheMaterializerDetailResponse.java
@@ -1,5 +1,6 @@
 package com.marketinghub.oprm.nichocnae.enrichednichematerializer.service.detailStageExecution;
 
+import java.math.BigDecimal;
 import java.time.Instant;
 
 /** Detalhe público da materialização de nicho enriquecido para a tela do pipeline. */
@@ -9,6 +10,10 @@ public record EnrichedNicheMaterializerDetailResponse(
     Long routineCardId,
     Long marketNicheId,
     Long enrichedNicheProfileId,
+    String originalNicheName,
+    String neutralNicheName,
+    String researchMode,
+    BigDecimal solutionLanguageRiskScore,
     String nicheName,
     String cnaeCode,
     String qualityStatus,

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/enrichednichematerializer/service/diagnoseContamination/ContaminatedNicheDiagnosticItem.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/enrichednichematerializer/service/diagnoseContamination/ContaminatedNicheDiagnosticItem.java
@@ -1,0 +1,17 @@
+package com.marketinghub.oprm.nichocnae.enrichednichematerializer.service.diagnoseContamination;
+
+import java.time.Instant;
+
+/** Representa um ciclo ou perfil histórico com possível contaminação por linguagem de solução. */
+public record ContaminatedNicheDiagnosticItem(
+    String recordType,
+    Long recordId,
+    Long researchCycleId,
+    Long marketNicheId,
+    String matchedTerm,
+    String originalNicheName,
+    String neutralNicheName,
+    String displayedName,
+    String status,
+    String recommendation,
+    Instant createdAt) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/enrichednichematerializer/service/diagnoseContamination/ContaminatedNicheDiagnosticResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/enrichednichematerializer/service/diagnoseContamination/ContaminatedNicheDiagnosticResponse.java
@@ -1,0 +1,11 @@
+package com.marketinghub.oprm.nichocnae.enrichednichematerializer.service.diagnoseContamination;
+
+import java.time.Instant;
+import java.util.List;
+
+/** Resposta do diagnóstico que lista registros antigos potencialmente contaminados por solução. */
+public record ContaminatedNicheDiagnosticResponse(
+    Instant generatedAt,
+    int totalCycles,
+    int totalProfiles,
+    List<ContaminatedNicheDiagnosticItem> items) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/enrichednichematerializer/web/BackendEnrichedNicheMaterializerController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/enrichednichematerializer/web/BackendEnrichedNicheMaterializerController.java
@@ -4,6 +4,7 @@ import com.marketinghub.oprm.nichocnae.enrichednichematerializer.service.Backend
 import com.marketinghub.oprm.nichocnae.enrichednichematerializer.service.completeStageExecution.CompleteEnrichedNicheMaterializerRequest;
 import com.marketinghub.oprm.nichocnae.enrichednichematerializer.service.completeStageExecution.CompleteEnrichedNicheMaterializerResponse;
 import com.marketinghub.oprm.nichocnae.enrichednichematerializer.service.detailStageExecution.EnrichedNicheMaterializerDetailResponse;
+import com.marketinghub.oprm.nichocnae.enrichednichematerializer.service.diagnoseContamination.ContaminatedNicheDiagnosticResponse;
 import com.marketinghub.oprm.nichocnae.enrichednichematerializer.service.failStageExecution.FailEnrichedNicheMaterializerRequest;
 import com.marketinghub.oprm.nichocnae.enrichednichematerializer.service.pending.RecordEnrichedNicheMaterializerPending;
 import java.util.List;
@@ -12,6 +13,7 @@ import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -57,4 +59,12 @@ public class BackendEnrichedNicheMaterializerController {
   public ResponseEntity<EnrichedNicheMaterializerDetailResponse> detailByProfileId(@PathVariable Long profileId) {
     return ResponseEntity.ok(executionService.detailByProfileId(profileId));
   }
+
+  /** Diagnostica ciclos e perfis históricos com linguagem de solução para reprocessamento neutro. */
+  @GetMapping("/api/oprm/nichocnae/enriched-niche-materializer/diagnostics/solution-contamination")
+  public ResponseEntity<ContaminatedNicheDiagnosticResponse> diagnoseContamination(
+      @RequestParam(defaultValue = "20") int limit) {
+    return ResponseEntity.ok(executionService.diagnoseHistoricalContamination(limit));
+  }
+
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/niche/MarketNicheEnrichmentProfileRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/niche/MarketNicheEnrichmentProfileRepository.java
@@ -27,4 +27,18 @@ public interface MarketNicheEnrichmentProfileRepository extends JpaRepository<Ma
         )
       """)
   List<MarketNicheEnrichmentProfile> findLatestByMarketNicheIds(@Param("marketNicheIds") List<Long> marketNicheIds);
+
+  /** Lista perfis recentes cujo nome ou conteúdo principal ainda contém linguagem de solução. */
+  @Query("""
+      select p from MarketNicheEnrichmentProfile p
+      join fetch p.marketNiche n
+      where lower(coalesce(n.name, '')) like lower(concat('%', :term, '%'))
+         or lower(coalesce(p.routineSummary, '')) like lower(concat('%', :term, '%'))
+         or lower(coalesce(p.painsSummary, '')) like lower(concat('%', :term, '%'))
+         or lower(coalesce(p.resultsSummary, '')) like lower(concat('%', :term, '%'))
+         or lower(coalesce(p.mechanismOpportunitiesSummary, '')) like lower(concat('%', :term, '%'))
+      order by p.createdAt desc, p.id desc
+      """)
+  List<MarketNicheEnrichmentProfile> findPotentiallyContaminatedByTerm(@Param("term") String term, org.springframework.data.domain.Pageable pageable);
+
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/oprm/nichocnae/OprmRoutineResearchCycleRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/oprm/nichocnae/OprmRoutineResearchCycleRepository.java
@@ -51,4 +51,14 @@ public interface OprmRoutineResearchCycleRepository extends JpaRepository<OprmRo
             @Param("retryableErrorFragment") String retryableErrorFragment,
             @Param("completePathFragment") String completePathFragment,
             Pageable pageable);
+    /** Lista ciclos recentes cujo nome ou conteúdo principal ainda contém linguagem de solução. */
+    @Query("""
+            select cycle
+            from OprmRoutineResearchCycle cycle
+            where lower(coalesce(cycle.originalNicheName, '')) like lower(concat('%', :term, '%'))
+               or lower(coalesce(cycle.nicheName, '')) like lower(concat('%', :term, '%'))
+               or lower(coalesce(cycle.errorMessage, '')) like lower(concat('%', :term, '%'))
+            order by cycle.startedAt desc
+            """)
+    List<OprmRoutineResearchCycle> findPotentiallyContaminatedByTerm(@Param("term") String term, Pageable pageable);
 }

--- a/backend/ads-service/src/test/java/com/marketinghub/oprm/nichocnae/enrichednichematerializer/service/BackendEnrichedNicheMaterializerServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/oprm/nichocnae/enrichednichematerializer/service/BackendEnrichedNicheMaterializerServiceTest.java
@@ -52,6 +52,7 @@ class BackendEnrichedNicheMaterializerServiceTest {
     assertThat(pending.getFirst().routineCardId()).isEqualTo(10L);
     assertThat(pending.getFirst().sourceNicheCandidateId()).isEqualTo(77L);
     assertThat(pending.getFirst().existingMarketNicheId()).isNull();
+    assertThat(pending.getFirst().nicheName()).isEqualTo("Salões pequenos");
     assertThat(pending.getFirst().mechanismOpportunitiesSummary()).contains("agenda");
   }
 
@@ -83,8 +84,30 @@ class BackendEnrichedNicheMaterializerServiceTest {
     assertThat(response.enrichedNicheProfileId()).isEqualTo(300L);
     assertThat(cycle.getStatus()).isEqualTo("ENRICHED_NICHE_CREATED");
     assertThat(candidate.getMarketNicheId()).isEqualTo(200L);
-    verify(marketNicheRepository).save(any(MarketNiche.class));
-    verify(profileRepository).save(any(MarketNicheEnrichmentProfile.class));
+    verify(marketNicheRepository).save(org.mockito.ArgumentMatchers.argThat(niche ->
+        "Salões pequenos".equals(niche.getName())
+            && niche.getPromises() == null
+            && niche.getOffers() == null
+            && niche.getDescription().contains("Nome original recebido para auditoria: IA para salões pequenos")
+            && niche.getDescription().contains("Nome neutro pesquisado: Salões pequenos")
+            && !niche.getDescription().contains("Oportunidades de mecanismo:")));
+    verify(profileRepository).save(org.mockito.ArgumentMatchers.argThat(profile ->
+        profile.getCommercialTriggers() == null && profile.getObjections() == null));
+  }
+
+  /** Deve localizar registros históricos contaminados para orientar novo ciclo neutro. */
+  @Test
+  void shouldDiagnoseHistoricalContamination() {
+    OprmRoutineResearchCycle cycle = cycle();
+    when(cycleRepository.findPotentiallyContaminatedByTerm(org.mockito.ArgumentMatchers.eq("ia"), any(Pageable.class))).thenReturn(List.of(cycle));
+    when(profileRepository.findPotentiallyContaminatedByTerm(org.mockito.ArgumentMatchers.eq("ia"), any(Pageable.class))).thenReturn(List.of());
+
+    var diagnostic = service.diagnoseHistoricalContamination(10);
+
+    assertThat(diagnostic.totalCycles()).isEqualTo(1);
+    assertThat(diagnostic.items()).hasSize(1);
+    assertThat(diagnostic.items().getFirst().matchedTerm()).isEqualTo("ia");
+    assertThat(diagnostic.items().getFirst().recommendation()).contains("novo ciclo neutro");
   }
 
   /** Cria um cartão aprovado mínimo para testes da etapa final. */
@@ -118,6 +141,10 @@ class BackendEnrichedNicheMaterializerServiceTest {
     cycle.setCnaeCode("9602501");
     cycle.setCnaeDescription("Cabeleireiros, manicure e pedicure");
     cycle.setNicheName("IA para salões pequenos");
+    cycle.setOriginalNicheName("IA para salões pequenos");
+    cycle.setNeutralNicheName("Salões pequenos");
+    cycle.setResearchMode("ROUTINE_REALITY_RESEARCH");
+    cycle.setSolutionLanguageRiskScore(new BigDecimal("65.00"));
     cycle.setSourceScore(new BigDecimal("90.00"));
     cycle.setStatus("LIGHTLY_RESEARCHED");
     cycle.setStartedAt(Instant.parse("2026-06-04T00:00:00Z"));

--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -286,3 +286,4 @@
 
 ## 2026-06-05 — Correção de include Liquibase para scores de qualidade da rotina OPRM
 - Ajustado o changelog master do backend para resolver o changeset `2026-06-05-oprm-routine-quality-scores.yaml` de forma relativa ao arquivo master, evitando falha de bootstrap quando o Liquibase não encontra `changesets/...` no search path configurado.
+- 2026-06-06 00:00:00 (UTC): executada a fase 6 do plano de ajuste NichoCNAE sem viés: materialização passou a usar nome neutro no `market_niche`, preservar nome original apenas na descrição de auditoria, não preencher campos comerciais de promessa/oferta/gatilhos/objeções na etapa inicial de rotina, expor diagnóstico de registros históricos com linguagem de solução e ampliar a tela `/oprm/pipeline` com nome original, nome neutro, modo de pesquisa, mix de objetivos/fontes, risco de linguagem de solução e motivo do gate.

--- a/frontend/src/api/oprm/useOprmEnrichedNicheMaterializerDetail.ts
+++ b/frontend/src/api/oprm/useOprmEnrichedNicheMaterializerDetail.ts
@@ -7,6 +7,10 @@ export interface OprmEnrichedNicheMaterializerDetail {
   routineCardId?: number | null;
   marketNicheId?: number | null;
   enrichedNicheProfileId?: number | null;
+  originalNicheName?: string | null;
+  neutralNicheName?: string | null;
+  researchMode?: string | null;
+  solutionLanguageRiskScore?: number | null;
   nicheName?: string | null;
   cnaeCode?: string | null;
   qualityStatus?: string | null;

--- a/frontend/src/api/oprm/useOprmRoutineQualityGateDetail.ts
+++ b/frontend/src/api/oprm/useOprmRoutineQualityGateDetail.ts
@@ -10,6 +10,10 @@ export interface OprmRoutineQualityGateDetail {
   specificityScore: number | null;
   confidenceScore: number | null;
   duplicationScore: number | null;
+  routineEvidenceScore?: number | null;
+  difficultyEvidenceScore?: number | null;
+  sourceDiversityScore?: number | null;
+  solutionLanguageRiskScore?: number | null;
   qualityNotes: string | null;
   checkedBy: string | null;
   checkedAt: string | null;

--- a/frontend/src/api/oprm/useOprmRoutineResearchOrchestratorRecent.ts
+++ b/frontend/src/api/oprm/useOprmRoutineResearchOrchestratorRecent.ts
@@ -7,6 +7,10 @@ export interface OprmRoutineResearchOrchestratorRecent {
   cnaeCode: string;
   cnaeDescription: string;
   nicheName: string;
+  originalNicheName?: string | null;
+  neutralNicheName?: string | null;
+  researchMode?: string | null;
+  solutionLanguageRiskScore?: number | null;
   sourceScore: number;
   triggerSource: string;
   cycleStatus: string;

--- a/frontend/src/api/oprm/useOprmRoutineSynthesizerDetail.ts
+++ b/frontend/src/api/oprm/useOprmRoutineSynthesizerDetail.ts
@@ -12,6 +12,10 @@ export interface OprmRoutineCard {
   evidenceSummary: string;
   sourceDomains: string;
   confidenceScore: number;
+  routineEvidenceScore: number;
+  difficultyEvidenceScore: number;
+  sourceDiversityScore: number;
+  solutionLanguageRiskScore: number;
   synthesizedBy: string;
   createdAt: string;
 }

--- a/frontend/src/api/oprm/useOprmSourceFetcherDetail.ts
+++ b/frontend/src/api/oprm/useOprmSourceFetcherDetail.ts
@@ -9,6 +9,10 @@ export interface OprmSourceSnapshotDetail {
   sourceDomain: string;
   sourceTitle: string;
   sourceType: string;
+  sourceIntent?: string | null;
+  routineEvidenceScore?: number | null;
+  commercialPageRisk?: boolean | null;
+  solutionLanguageRisk?: boolean | null;
   snippet?: string | null;
   shortExcerpt: string;
   fetchedAt: string;

--- a/frontend/src/api/oprm/useOprmSourceSearcherDetail.ts
+++ b/frontend/src/api/oprm/useOprmSourceSearcherDetail.ts
@@ -13,6 +13,10 @@ export interface OprmSourceCandidateDetail {
   searchProvider: string;
   searchPosition: number;
   status: string;
+  sourceIntent?: string | null;
+  routineEvidenceScore?: number | null;
+  commercialPageRisk?: boolean | null;
+  solutionLanguageRisk?: boolean | null;
   createdAt: string;
   updatedAt: string;
 }

--- a/frontend/src/pages/oprm/OprmPipelinePage.test.tsx
+++ b/frontend/src/pages/oprm/OprmPipelinePage.test.tsx
@@ -40,6 +40,11 @@ describe("OprmPipelinePage", () => {
               cnaeDescription: "Cabeleireiros, manicure e pedicure",
               nicheName:
                 "IA para crescimento de Cabeleireiros, manicure e pedicure",
+              originalNicheName:
+                "IA para crescimento de Cabeleireiros, manicure e pedicure",
+              neutralNicheName: "Cabeleireiros, manicure e pedicure",
+              researchMode: "ROUTINE_REALITY_RESEARCH",
+              solutionLanguageRiskScore: 65,
               sourceScore: 90,
               triggerSource: "AUTO_SCORE_QUEUE",
               cycleStatus: "RUNNING",
@@ -70,6 +75,12 @@ describe("OprmPipelinePage", () => {
     expect(await screen.findByText("Execução mais recente")).toBeTruthy();
     expect(screen.getByText("#1")).toBeTruthy();
     expect(screen.getAllByText("9602501").length).toBeGreaterThan(0);
+    expect(
+      screen.getAllByText("Cabeleireiros, manicure e pedicure").length,
+    ).toBeGreaterThan(0);
+    expect(
+      screen.getAllByText("ROUTINE_REALITY_RESEARCH").length,
+    ).toBeGreaterThan(0);
     expect(screen.getAllByText("Em execução").length).toBeGreaterThan(0);
 
     await waitFor(() => {
@@ -109,6 +120,11 @@ describe("OprmPipelinePage", () => {
               cnaeDescription: "Cabeleireiros, manicure e pedicure",
               nicheName:
                 "IA para crescimento de Cabeleireiros, manicure e pedicure",
+              originalNicheName:
+                "IA para crescimento de Cabeleireiros, manicure e pedicure",
+              neutralNicheName: "Cabeleireiros, manicure e pedicure",
+              researchMode: "ROUTINE_REALITY_RESEARCH",
+              solutionLanguageRiskScore: 65,
               sourceScore: 90,
               triggerSource: "AUTO_SCORE_QUEUE",
               cycleStatus: "RUNNING",
@@ -191,6 +207,7 @@ describe("OprmPipelinePage", () => {
     expect(
       screen.getByText("Profissionais enfrentam desafios na gestão de agenda."),
     ).toBeTruthy();
+    expect(screen.getByText("ROUTINE_DISCOVERY: 1")).toBeTruthy();
     expect(
       screen.getByText(
         "1 queries geradas para as próximas etapas. Abra o detalhe para ver a requisição enviada à IA e o JSON completo gerado.",

--- a/frontend/src/pages/oprm/OprmPipelinePage.tsx
+++ b/frontend/src/pages/oprm/OprmPipelinePage.tsx
@@ -25,9 +25,9 @@ const pipelineStages = [
     title: "Seed de Pesquisa do Nicho",
     technicalName: "oprmNicheResearchSeedBuilder",
     description:
-      "Usa IA para transformar o CNAE em nicho operacional, objetos comerciais, suposições iniciais e queries de pesquisa.",
+      "Usa IA para transformar o CNAE em nicho operacional, contexto de rotina e queries sem procurar solução.",
     output:
-      "Seed do nicho e frases de pesquisa para rotina, dores, perguntas e ofertas.",
+      "Seed do nicho e frases de pesquisa para rotina, tarefas, dificuldades, perguntas e linguagem pública.",
   },
   {
     number: "3",
@@ -50,7 +50,7 @@ const pipelineStages = [
     title: "Extração de Sinais",
     technicalName: "oprmSignalExtractor",
     description:
-      "Extrai sinais estruturados sobre rotina, tarefas comerciais, dores, perguntas, linguagem e oportunidades de mecanismo.",
+      "Extrai sinais estruturados sobre rotina, tarefas recorrentes, dificuldades, perguntas, linguagem e risco de solução.",
     output: "Sinais classificados para sustentar a síntese da rotina.",
   },
   {
@@ -67,9 +67,9 @@ const pipelineStages = [
     title: "Gate de Qualidade",
     technicalName: "oprmRoutineQualityGate",
     description:
-      "Avalia se o card tem fontes, sinais, especificidade e confiança suficientes para seguir para hipótese comercial.",
+      "Avalia se o card representa a rotina e as dificuldades com fontes suficientes, baixa duplicação e baixo risco de solução.",
     output:
-      "Decisão: pronto para hipótese, precisa de mais pesquisa ou ficou genérico.",
+      "Decisão operacional: rotina pesquisada, precisa de mais pesquisa ou ficou genérica/contaminada.",
   },
   {
     number: "8",
@@ -78,9 +78,53 @@ const pipelineStages = [
     description:
       "Etapa final que alimenta a tabela de nicho e a tabela de nicho enriquecido a partir do card aprovado.",
     output:
-      "market_niche + market_niche_enrichment_profile prontos para uso posterior em hipótese.",
+      "market_niche + market_niche_enrichment_profile com nome neutro, rotina, dificuldades, linguagem e evidências auditáveis.",
   },
 ];
+
+function getOperationalName(item: {
+  neutralNicheName?: string | null;
+  nicheName: string;
+}) {
+  return item.neutralNicheName?.trim() || item.nicheName;
+}
+
+function getOriginalName(item: {
+  originalNicheName?: string | null;
+  nicheName: string;
+}) {
+  return item.originalNicheName?.trim() || item.nicheName;
+}
+
+function countByValue<T>(
+  items: T[],
+  selector: (item: T) => string | null | undefined,
+) {
+  return items.reduce<Record<string, number>>((acc, item) => {
+    const rawValue = selector(item)?.trim();
+    const value = rawValue || "Não classificado";
+    acc[value] = (acc[value] ?? 0) + 1;
+    return acc;
+  }, {});
+}
+
+function formatMix(mix: Record<string, number>) {
+  const entries = Object.entries(mix);
+  if (entries.length === 0) {
+    return "Sem dados";
+  }
+  return entries
+    .sort(([, leftCount], [, rightCount]) => rightCount - leftCount)
+    .map(([label, count]) => `${label}: ${count}`)
+    .join(" · ");
+}
+
+function formatRiskScore(value?: number | null) {
+  if (value === null || value === undefined || Number.isNaN(Number(value))) {
+    return "Sem score";
+  }
+  return `${Number(value).toLocaleString("pt-BR", { maximumFractionDigits: 2 })}%`;
+}
 
 function formatProcessedAt(value: string) {
   const date = new Date(value);
@@ -240,6 +284,24 @@ export default function OprmPipelinePage() {
     isError: isEnrichedNicheMaterializerDetailError,
     isFetching: isEnrichedNicheMaterializerDetailFetching,
   } = useOprmEnrichedNicheMaterializerDetail(latestCycle?.researchCycleId);
+  const queryGoalMix = countByValue(
+    generatedSeed?.queries ?? [],
+    (query) => query.queryGoal,
+  );
+  const sourceIntentMix = countByValue(
+    sourceSearcherDetail?.candidates ?? [],
+    (candidate) => candidate.sourceIntent,
+  );
+  const snapshotIntentMix = countByValue(
+    sourceSnapshots,
+    (snapshot) => snapshot.sourceIntent,
+  );
+  const sourceSolutionRiskCount = (
+    sourceSearcherDetail?.candidates ?? []
+  ).filter((candidate) => candidate.solutionLanguageRisk).length;
+  const snapshotSolutionRiskCount = sourceSnapshots.filter(
+    (snapshot) => snapshot.solutionLanguageRisk,
+  ).length;
 
   return (
     <div className="d-flex flex-column gap-4">
@@ -249,8 +311,8 @@ export default function OprmPipelinePage() {
           Esta tela mostra o pipeline OPRM que transforma um nicho CNAE já
           priorizado em um cartão de rotina pesquisado. Ingestão de mercado,
           cálculo de score e enriquecimento CNAE ficam na aba CNAEs; aqui o foco
-          é conhecer como o nicho funciona no dia a dia antes da hipótese
-          comercial.
+          é conhecer como o nicho funciona no dia a dia antes de qualquer
+          solução, produto ou oferta.
         </p>
       </header>
 
@@ -261,9 +323,9 @@ export default function OprmPipelinePage() {
           <h2 className="h5 mb-2">Fluxo do pipeline de pesquisa da rotina</h2>
           <p className="text-secondary mb-0">
             Entrada: nicho CNAE com score alto. Saída esperada:
-            <strong> oprm_niche_routine_card</strong>, que será usado depois
-            pelo pipeline de hipótese comercial para trabalhar dor, resultado,
-            mecanismo, prova e oferta.
+            <strong> oprm_niche_routine_card</strong>, usado para entender
+            rotina, dificuldades, perguntas e evidências antes de qualquer fluxo
+            posterior de hipótese ou oferta.
           </p>
         </div>
       </section>
@@ -323,10 +385,14 @@ export default function OprmPipelinePage() {
                       </td>
                       <td>
                         <span className="fw-semibold d-block">
-                          {item.nicheName}
+                          {getOperationalName(item)}
+                        </span>
+                        <span className="text-secondary small d-block">
+                          Original: {getOriginalName(item)}
                         </span>
                         <span className="text-secondary small">
-                          Ciclo #{item.researchCycleId}
+                          Ciclo #{item.researchCycleId} ·{" "}
+                          {item.researchMode ?? "modo não informado"}
                         </span>
                       </td>
                       <td>
@@ -427,6 +493,30 @@ export default function OprmPipelinePage() {
                           </span>
                         </dd>
                         <dt className="col-5 text-secondary fw-normal">
+                          Nome neutro
+                        </dt>
+                        <dd className="col-7 mb-0">
+                          {getOperationalName(latestCycle)}
+                        </dd>
+                        <dt className="col-5 text-secondary fw-normal">
+                          Nome original
+                        </dt>
+                        <dd className="col-7 mb-0">
+                          {getOriginalName(latestCycle)}
+                        </dd>
+                        <dt className="col-5 text-secondary fw-normal">Modo</dt>
+                        <dd className="col-7 mb-0">
+                          {latestCycle.researchMode ?? "Não informado"}
+                        </dd>
+                        <dt className="col-5 text-secondary fw-normal">
+                          Risco solução
+                        </dt>
+                        <dd className="col-7 mb-0">
+                          {formatRiskScore(
+                            latestCycle.solutionLanguageRiskScore,
+                          )}
+                        </dd>
+                        <dt className="col-5 text-secondary fw-normal">
                           Score
                         </dt>
                         <dd className="col-7 mb-0">
@@ -500,6 +590,12 @@ export default function OprmPipelinePage() {
                             </dt>
                             <dd className="col-7 mb-0">
                               {generatedSeed.nicheName}
+                            </dd>
+                            <dt className="col-5 text-secondary fw-normal">
+                              Mix objetivos
+                            </dt>
+                            <dd className="col-7 mb-0">
+                              {formatMix(queryGoalMix)}
                             </dd>
                             <dt className="col-5 text-secondary fw-normal">
                               Tipo
@@ -594,6 +690,18 @@ export default function OprmPipelinePage() {
                                 sourceSearcherDetail.cycleTotalSourceCandidates,
                               )}
                             </dd>
+                            <dt className="col-6 text-secondary fw-normal">
+                              Mix intenção
+                            </dt>
+                            <dd className="col-6 mb-0">
+                              {formatMix(sourceIntentMix)}
+                            </dd>
+                            <dt className="col-6 text-secondary fw-normal">
+                              Risco solução
+                            </dt>
+                            <dd className="col-6 mb-0 fw-semibold">
+                              {sourceSolutionRiskCount}
+                            </dd>
                             {sourceSearcherDetail.lastExecutedAt ? (
                               <>
                                 <dt className="col-6 text-secondary fw-normal">
@@ -680,6 +788,18 @@ export default function OprmPipelinePage() {
                               {formatStageCount(
                                 sourceFetcherDetail.cycleTotalSourceSnapshots,
                               )}
+                            </dd>
+                            <dt className="col-6 text-secondary fw-normal">
+                              Mix intenção
+                            </dt>
+                            <dd className="col-6 mb-0">
+                              {formatMix(snapshotIntentMix)}
+                            </dd>
+                            <dt className="col-6 text-secondary fw-normal">
+                              Risco solução
+                            </dt>
+                            <dd className="col-6 mb-0 fw-semibold">
+                              {snapshotSolutionRiskCount}
                             </dd>
                             <dt className="col-6 text-secondary fw-normal">
                               Status do ciclo
@@ -882,6 +1002,18 @@ export default function OprmPipelinePage() {
                               {routineCard.confidenceScore}%
                             </dd>
                             <dt className="col-6 text-secondary fw-normal">
+                              Evidência rotina
+                            </dt>
+                            <dd className="col-6 mb-0 fw-semibold">
+                              {routineCard.routineEvidenceScore}%
+                            </dd>
+                            <dt className="col-6 text-secondary fw-normal">
+                              Risco solução
+                            </dt>
+                            <dd className="col-6 mb-0 fw-semibold">
+                              {routineCard.solutionLanguageRiskScore}%
+                            </dd>
+                            <dt className="col-6 text-secondary fw-normal">
                               Status do ciclo
                             </dt>
                             <dd className="col-6 mb-0">
@@ -995,6 +1127,26 @@ export default function OprmPipelinePage() {
                               )}
                               %
                             </dd>
+                            <dt className="col-6 text-secondary fw-normal">
+                              Evidência rotina
+                            </dt>
+                            <dd className="col-6 mb-0 fw-semibold">
+                              {formatStageCount(
+                                routineQualityGateDetail.routineEvidenceScore ??
+                                  undefined,
+                              )}
+                              %
+                            </dd>
+                            <dt className="col-6 text-secondary fw-normal">
+                              Risco solução
+                            </dt>
+                            <dd className="col-6 mb-0 fw-semibold">
+                              {formatStageCount(
+                                routineQualityGateDetail.solutionLanguageRiskScore ??
+                                  undefined,
+                              )}
+                              %
+                            </dd>
                             {routineQualityGateDetail.checkedAt ? (
                               <>
                                 <dt className="col-6 text-secondary fw-normal">
@@ -1095,16 +1247,27 @@ export default function OprmPipelinePage() {
                             ) : null}
                           </dl>
                           <p className="mb-2 fw-semibold">
-                            {enrichedNicheMaterializerDetail.nicheName}
+                            {enrichedNicheMaterializerDetail.neutralNicheName ??
+                              enrichedNicheMaterializerDetail.nicheName}
+                          </p>
+                          <p className="text-secondary mb-2">
+                            Original:{" "}
+                            {enrichedNicheMaterializerDetail.originalNicheName ??
+                              "Não informado"}{" "}
+                            · Modo:{" "}
+                            {enrichedNicheMaterializerDetail.researchMode ??
+                              "Não informado"}{" "}
+                            · Risco solução:{" "}
+                            {formatRiskScore(
+                              enrichedNicheMaterializerDetail.solutionLanguageRiskScore,
+                            )}
                           </p>
                           <p className="text-secondary mb-2 text-truncate">
                             {enrichedNicheMaterializerDetail.painsSummary}
                           </p>
                           <p className="text-secondary mb-0">
-                            Mecanismos:{" "}
-                            {
-                              enrichedNicheMaterializerDetail.mechanismOpportunitiesSummary
-                            }
+                            Evidências:{" "}
+                            {enrichedNicheMaterializerDetail.evidenceSummary}
                           </p>
                         </div>
                       ) : routineQualityGateDetail?.readyForHypothesis ? (

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnae/enrichednichematerializer/EnrichedNicheMaterializerEngine.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnae/enrichednichematerializer/EnrichedNicheMaterializerEngine.java
@@ -1,20 +1,19 @@
 package com.marketinghub.nichocnae.enrichednichematerializer;
 
-import java.util.ArrayList;
 import java.util.List;
 import org.springframework.stereotype.Component;
 import org.springframework.util.StringUtils;
 
-/** Monta campos complementares determinísticos do nicho enriquecido sem gerar hipótese ou oferta. */
+/** Monta campos complementares determinísticos de rotina real sem gerar hipótese, oferta ou gatilho comercial. */
 @Component
 public class EnrichedNicheMaterializerEngine {
-    /** Deriva persona, linguagem, gatilhos e objeções a partir do card aprovado no NichoCNAE. */
+    /** Deriva apenas persona e linguagem operacional auditável a partir do card aprovado no NichoCNAE. */
     public EnrichedNicheProfileDraft buildDraft(EnrichedNicheMaterializerPending pending) {
         return new EnrichedNicheProfileDraft(
                 buildPersonaSummary(pending),
                 buildLanguagePatterns(pending),
-                buildCommercialTriggers(pending),
-                buildObjections(pending));
+                null,
+                null);
     }
 
     /** Resume a persona operacional observada sem inventar uma hipótese comercial. */
@@ -29,30 +28,6 @@ public class EnrichedNicheMaterializerEngine {
                 firstUsefulSentence(pending.painsSummary()),
                 firstUsefulSentence(pending.routineSummary()),
                 firstUsefulSentence(pending.resultsSummary())));
-    }
-
-    /** Identifica gatilhos comerciais seguros a partir de rotina, dores e resultados observados. */
-    private String buildCommercialTriggers(EnrichedNicheMaterializerPending pending) {
-        List<String> triggers = new ArrayList<>();
-        triggers.add("Redução de esforço na rotina operacional");
-        if (hasText(pending.painsSummary())) {
-            triggers.add("Dor observada: " + firstUsefulSentence(pending.painsSummary()));
-        }
-        if (hasText(pending.resultsSummary())) {
-            triggers.add("Resultado buscado: " + firstUsefulSentence(pending.resultsSummary()));
-        }
-        return String.join("\n", triggers);
-    }
-
-    /** Registra objeções prováveis sem criar oferta, preço ou promessa de hipótese. */
-    private String buildObjections(EnrichedNicheMaterializerPending pending) {
-        List<String> objections = new ArrayList<>();
-        objections.add("Precisa enxergar aplicação prática no dia a dia antes de investir tempo.");
-        objections.add("Pode desconfiar de solução genérica que não respeite a rotina do CNAE " + pending.cnaeCode() + ".");
-        if (hasText(pending.evidenceSummary())) {
-            objections.add("Exige evidência concreta: " + firstUsefulSentence(pending.evidenceSummary()));
-        }
-        return String.join("\n", objections);
     }
 
     /** Junta apenas frases com conteúdo útil. */

--- a/oprm-coletor-mei/src/test/java/com/marketinghub/nichocnae/enrichednichematerializer/EnrichedNicheMaterializerEngineTest.java
+++ b/oprm-coletor-mei/src/test/java/com/marketinghub/nichocnae/enrichednichematerializer/EnrichedNicheMaterializerEngineTest.java
@@ -25,7 +25,8 @@ class EnrichedNicheMaterializerEngineTest {
                 Instant.parse("2026-06-05T00:00:00Z")));
 
         assertThat(draft.personaSummary()).contains("Cabeleireiros");
-        assertThat(draft.commercialTriggers()).contains("Redução de esforço");
-        assertThat(draft.objections()).doesNotContain("hipótese");
+        assertThat(draft.languagePatterns()).contains("Dores de falta de tempo");
+        assertThat(draft.commercialTriggers()).isNull();
+        assertThat(draft.objections()).isNull();
     }
 }


### PR DESCRIPTION
### Motivation
- Prevent research contamination by solution-language and provide a clean, auditable path from CNAE candidate → routine card → enriched niche, enabling the pipeline to synthesize real daily routine evidence without proposing products or offers.
- Deliver the synthesis (stage 6) and final materialization (enriched niche) so approved routine cards can become canonical `market_niche` + `market_niche_enrichment_profile` records for downstream flows.
- Improve source/signal classification and seed validation so queries, search results and snapshots favor routine evidence and flag (not reward) solution-language terms.

### Description
- Added and wired the Routine Synthesizer stage: backend `BackendRoutineSynthesizerService`, controller endpoints, DTOs and collector-side artifacts to persist `oprm_niche_routine_card` from extracted signals and mark cycles as `ROUTINE_SYNTHESIZED`.
- Implemented final materializer `BackendEnrichedNicheMaterializerService` + controller to create/update `MarketNiche` and `MarketNicheEnrichmentProfile` from approved routine cards while whitelisting contract fields and preserving original audit data.
- Neutralized niche input and introduced contamination metrics via `RoutineResearchNicheNameNormalizer` and new cycle fields (`original_niche_name`, `neutral_niche_name`, `research_mode`, `solution_language_risk_score`) used by the orchestrator when creating cycles.
- Hardened earlier stages and persistence: seed-builder validation blocks solution terms and restricts allowed query goals; source/search/fetch artifacts now carry `sourceIntent`, `routineEvidenceScore`, `commercialPageRisk` and `solutionLanguageRisk`; signal taxonomy and quality gate logic were adjusted so solution-language terms increment risk counters rather than count as positive signals.
- Frontend `/oprm/pipeline` was updated to show the new stage outputs (synthesis and enrichment) and to surface the neutral/original niche names, stage metrics and materialization results.
- Small architecture changes: repository queries and an ArchUnit exception were added to permit the materializer to access only the specific `market_niche` artifacts it needs while preserving module isolation.

### Testing
- Unit tests added/updated and executed: `RoutineResearchNicheNameNormalizerTest`, `BackendNicheResearchSeedBuilderServiceTest`, `BackendRoutineSynthesizerService` / synthesizer tests, `EnrichedNicheMaterializerEngineTest` and `BackendRoutineQualityGateServiceTest` ran as part of the module tests and passed locally. 
- Frontend component tests including `OprmPipelinePage.test.tsx` were executed and passed, validating UI behavior for seed, synthesis and pipeline continuity error handling. 
- Integration-level checks: repository queries and DTO contracts exercised by the backend tests completed without failures, and the pipeline cards appear on `/oprm/pipeline` in the test harness as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a237f01b09c83219ab9b917f3e32bec)