### PR TITLE
Fix OpenAI pricing: fetch pricing via Jsoup and resolve dated model variants

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/modelos/openai/catalogo/v1/service/OpenAiModelCatalogV1Service.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/modelos/openai/catalogo/v1/service/OpenAiModelCatalogV1Service.java
@@ -73,6 +73,13 @@ public class OpenAiModelCatalogV1Service {
             for (OpenAiModelPricing pricing : pricingRows) {
                 pricingByModel.put(pricing.code(), toPriceResponse(pricing));
             }
+            List<OpenAiCatalogModelV1> catalogModels = repository.findAll();
+            for (OpenAiCatalogModelV1 catalogModel : catalogModels) {
+                pricingPageClient
+                        .findBestTextModelPricing(pricingRows, catalogModel.getCode())
+                        .ifPresent(pricing -> pricingByModel.putIfAbsent(
+                                catalogModel.getCode(), toPriceResponse(pricing)));
+            }
             return pricingByModel;
         } catch (RuntimeException ex) {
             log.error(

--- a/backend/ads-service/src/main/java/com/marketinghub/openai/OpenAiPricingPageClient.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/openai/OpenAiPricingPageClient.java
@@ -1,11 +1,13 @@
 package com.marketinghub.openai;
 
+import java.io.IOException;
 import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
+import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.jsoup.Jsoup;
@@ -15,7 +17,6 @@ import org.jsoup.select.Elements;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
-import org.springframework.web.reactive.function.client.WebClient;
 
 /** Responsabilidade: consultar a página oficial de preços da OpenAI e extrair preços de modelos de texto. */
 @Component
@@ -23,19 +24,60 @@ public class OpenAiPricingPageClient {
     private static final Logger log = LoggerFactory.getLogger(OpenAiPricingPageClient.class);
     private static final Pattern MONEY_PATTERN = Pattern.compile("[0-9]+(?:\\.[0-9]+)?");
 
-    private final WebClient.Builder webClientBuilder;
     private final OpenAiProperties properties;
 
-    /** Inicializa o cliente com WebClient e propriedades de URL/timeout da integração OpenAI. */
-    public OpenAiPricingPageClient(WebClient.Builder webClientBuilder, OpenAiProperties properties) {
-        this.webClientBuilder = webClientBuilder;
+    /** Inicializa o cliente com as propriedades de URL/timeout da integração OpenAI. */
+    public OpenAiPricingPageClient(OpenAiProperties properties) {
         this.properties = properties;
     }
 
     /** Busca a página oficial de preços e retorna os modelos com preços standard e batch consolidados. */
     public List<OpenAiModelPricing> fetchTextModelPricing() {
-        String html = webClientBuilder.build().get().uri(properties.getPricingUrl()).retrieve().bodyToMono(String.class).block();
-        return parseTextModelPricing(html);
+        try {
+            String html = Jsoup.connect(properties.getPricingUrl())
+                    .userAgent("MarketingHub/1.0 (+https://oportunidadebrasil.shop)")
+                    .timeout(toRequestTimeoutMillis())
+                    .ignoreContentType(true)
+                    .followRedirects(true)
+                    .execute()
+                    .body();
+            return parseTextModelPricing(html);
+        } catch (IOException ex) {
+            log.error(
+                    "Falha de IO ao buscar página oficial de preços OpenAI; operation=openai-pricing-fetch source={}",
+                    properties.getPricingUrl(),
+                    ex);
+            throw new IllegalStateException("Não foi possível consultar a página oficial de preços da OpenAI.", ex);
+        } catch (RuntimeException ex) {
+            log.error(
+                    "Falha inesperada ao buscar página oficial de preços OpenAI; operation=openai-pricing-fetch source={}",
+                    properties.getPricingUrl(),
+                    ex);
+            throw ex;
+        }
+    }
+
+    /** Seleciona preço exato ou preço-base mais específico para variantes datadas retornadas por /models. */
+    public Optional<OpenAiModelPricing> findBestTextModelPricing(List<OpenAiModelPricing> prices, String modelCode) {
+        if (prices == null || modelCode == null || modelCode.isBlank()) {
+            return Optional.empty();
+        }
+        String normalizedCode = modelCode.trim().toLowerCase(Locale.ROOT);
+        Optional<OpenAiModelPricing> exact = prices.stream()
+                .filter(price -> normalizedCode.equals(price.code()))
+                .findFirst();
+        if (exact.isPresent()) {
+            return exact;
+        }
+        return prices.stream()
+                .filter(price -> isVersionVariantOf(normalizedCode, price.code()))
+                .max((left, right) -> Integer.compare(left.code().length(), right.code().length()));
+    }
+
+    /** Converte o timeout configurado para milissegundos aceitos pelo cliente HTTP de preços. */
+    private int toRequestTimeoutMillis() {
+        long millis = properties.getRequestTimeout().toMillis();
+        return millis > Integer.MAX_VALUE ? Integer.MAX_VALUE : Math.max(1, (int) millis);
     }
 
     /** Extrai os preços oficiais textuais, aceitando tabela legada standard/batch ou tabela atual short/long context. */
@@ -127,6 +169,14 @@ public class OpenAiPricingPageClient {
     /** Indica se o código extraído representa modelo de texto/reasoning suportado no catálogo financeiro. */
     private boolean isTextModelCode(String code) {
         return code.startsWith("gpt-") || code.startsWith("o1") || code.startsWith("o3") || code.startsWith("o4");
+    }
+
+    /** Verifica se o código de /models é uma variante datada do código-base publicado na página de preços. */
+    private boolean isVersionVariantOf(String requestedCode, String pricedCode) {
+        if (requestedCode == null || pricedCode == null || requestedCode.equals(pricedCode)) {
+            return false;
+        }
+        return requestedCode.startsWith(pricedCode + "-");
     }
 
     /** Converte valores monetários da tabela oficial para decimal por 1 milhão de tokens. */

--- a/backend/ads-service/src/main/java/com/marketinghub/openai/service/OpenAiModelService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/openai/service/OpenAiModelService.java
@@ -11,7 +11,6 @@ import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.List;
 import java.util.Locale;
-import java.util.Objects;
 import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
@@ -120,9 +119,8 @@ public class OpenAiModelService {
 
     /** Aplica na entidade persistida os dados oficiais resolvidos a partir da API e da página de preços da OpenAI. */
     private void applyOfficialData(OpenAiModel model, String requestedName, String code, boolean imageModel) {
-        Optional<OpenAiModelPricing> pricing = pricingPageClient.fetchTextModelPricing().stream()
-                .filter(price -> Objects.equals(price.code(), code))
-                .findFirst();
+        List<OpenAiModelPricing> prices = pricingPageClient.fetchTextModelPricing();
+        Optional<OpenAiModelPricing> pricing = pricingPageClient.findBestTextModelPricing(prices, code);
         model.setName(toDisplayName(requestedName, code));
         model.setCode(code);
         if (pricing.isPresent()) {

--- a/backend/ads-service/src/test/java/com/marketinghub/openai/OpenAiPricingPageClientTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/openai/OpenAiPricingPageClientTest.java
@@ -5,14 +5,13 @@ import static org.assertj.core.api.Assertions.assertThat;
 import java.math.BigDecimal;
 import java.util.List;
 import org.junit.jupiter.api.Test;
-import org.springframework.web.reactive.function.client.WebClient;
 
 class OpenAiPricingPageClientTest {
 
     @Test
     void shouldParseStandardAndBatchPricesFromOfficialPricingTables() {
         OpenAiProperties properties = new OpenAiProperties();
-        OpenAiPricingPageClient client = new OpenAiPricingPageClient(WebClient.builder(), properties);
+        OpenAiPricingPageClient client = new OpenAiPricingPageClient(properties);
 
         List<OpenAiModelPricing> prices = client.parseTextModelPricing("""
                 <html><body>
@@ -46,7 +45,7 @@ class OpenAiPricingPageClientTest {
     @Test
     void shouldUseHalfStandardAsBatchFallbackWhenBatchTableIsMissing() {
         OpenAiProperties properties = new OpenAiProperties();
-        OpenAiPricingPageClient client = new OpenAiPricingPageClient(WebClient.builder(), properties);
+        OpenAiPricingPageClient client = new OpenAiPricingPageClient(properties);
 
         List<OpenAiModelPricing> prices = client.parseTextModelPricing("""
                 <table>
@@ -66,7 +65,7 @@ class OpenAiPricingPageClientTest {
     @Test
     void shouldParsePricesFromCurrentShortAndLongContextTable() {
         OpenAiProperties properties = new OpenAiProperties();
-        OpenAiPricingPageClient client = new OpenAiPricingPageClient(WebClient.builder(), properties);
+        OpenAiPricingPageClient client = new OpenAiPricingPageClient(properties);
 
         List<OpenAiModelPricing> prices = client.parseTextModelPricing("""
                 <table>
@@ -90,6 +89,38 @@ class OpenAiPricingPageClientTest {
         assertThat(pricing.priceInputBatch()).isEqualByComparingTo(new BigDecimal("1.25"));
         assertThat(pricing.priceInputCachedBatch()).isEqualByComparingTo(new BigDecimal("0.125"));
         assertThat(pricing.priceOutputBatch()).isEqualByComparingTo(new BigDecimal("7.50"));
+    }
+
+    @Test
+    void shouldResolvePricingForDatedModelVariantUsingMostSpecificBaseCode() {
+        OpenAiProperties properties = new OpenAiProperties();
+        OpenAiPricingPageClient client = new OpenAiPricingPageClient(properties);
+        List<OpenAiModelPricing> prices = List.of(
+                new OpenAiModelPricing(
+                        "gpt-5.4",
+                        "gpt-5.4",
+                        new BigDecimal("2.50"),
+                        new BigDecimal("0.25"),
+                        new BigDecimal("15.00"),
+                        new BigDecimal("1.25"),
+                        new BigDecimal("0.125"),
+                        new BigDecimal("7.50")),
+                new OpenAiModelPricing(
+                        "gpt-5.4-pro",
+                        "gpt-5.4-pro",
+                        new BigDecimal("30.00"),
+                        BigDecimal.ZERO,
+                        new BigDecimal("180.00"),
+                        new BigDecimal("15.00"),
+                        BigDecimal.ZERO,
+                        new BigDecimal("90.00")));
+
+        OpenAiModelPricing pricing = client
+                .findBestTextModelPricing(prices, "gpt-5.4-pro-2026-03-05")
+                .orElseThrow();
+
+        assertThat(pricing.code()).isEqualTo("gpt-5.4-pro");
+        assertThat(pricing.priceInputStandard()).isEqualByComparingTo(new BigDecimal("30.00"));
     }
 
 }

--- a/backend/ads-service/src/test/java/com/marketinghub/openai/service/OpenAiModelServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/openai/service/OpenAiModelServiceTest.java
@@ -37,7 +37,7 @@ class OpenAiModelServiceTest {
                 Map.of(),
                 "openai:/models",
                 "2026-06-05T00:00:00Z"));
-        when(pricingPageClient.fetchTextModelPricing()).thenReturn(List.of(new OpenAiModelPricing(
+        OpenAiModelPricing pricing = new OpenAiModelPricing(
                 "gpt-5.5",
                 "gpt-5.5",
                 new BigDecimal("5.00"),
@@ -45,7 +45,10 @@ class OpenAiModelServiceTest {
                 new BigDecimal("30.00"),
                 new BigDecimal("2.50"),
                 new BigDecimal("0.25"),
-                new BigDecimal("15.00"))));
+                new BigDecimal("15.00"));
+        List<OpenAiModelPricing> prices = List.of(pricing);
+        when(pricingPageClient.fetchTextModelPricing()).thenReturn(prices);
+        when(pricingPageClient.findBestTextModelPricing(prices, "gpt-5.5")).thenReturn(Optional.of(pricing));
         when(repository.findByCode("gpt-5.5")).thenReturn(Optional.empty());
         when(repository.save(org.mockito.ArgumentMatchers.any(OpenAiModel.class)))
                 .thenAnswer(invocation -> invocation.getArgument(0));
@@ -60,6 +63,45 @@ class OpenAiModelServiceTest {
         assertThat(created.getPricingSource()).isEqualTo("https://developers.openai.com/api/docs/pricing");
         assertThat(created.getLastPricingSyncAt()).isNotNull();
         verify(catalogService).fetchAndPersistCatalog();
+    }
+
+    /** Garante que a criação de variante datada use o preço-base oficial mais específico. */
+    @Test
+    void createShouldPriceDatedVariantFromMostSpecificBaseModel() {
+        OpenAiModelRepository repository = mock(OpenAiModelRepository.class);
+        OpenAiModelCatalogV1Service catalogService = mock(OpenAiModelCatalogV1Service.class);
+        OpenAiPricingPageClient pricingPageClient = mock(OpenAiPricingPageClient.class);
+        OpenAiModelService service = new OpenAiModelService(repository, catalogService, pricingPageClient);
+        CreateOpenAiModelRequest request = new CreateOpenAiModelRequest();
+        request.setName("gpt-5.4-pro-2026-03-05");
+        when(catalogService.fetchAndPersistCatalog()).thenReturn(new OpenAiModelCatalogResponse(
+                List.of("gpt-5.4-pro-2026-03-05"),
+                List.of(),
+                Map.of(),
+                "openai:/models",
+                "2026-06-05T00:00:00Z"));
+        OpenAiModelPricing pricing = new OpenAiModelPricing(
+                "gpt-5.4-pro",
+                "gpt-5.4-pro",
+                new BigDecimal("30.00"),
+                BigDecimal.ZERO,
+                new BigDecimal("180.00"),
+                new BigDecimal("15.00"),
+                BigDecimal.ZERO,
+                new BigDecimal("90.00"));
+        List<OpenAiModelPricing> prices = List.of(pricing);
+        when(pricingPageClient.fetchTextModelPricing()).thenReturn(prices);
+        when(pricingPageClient.findBestTextModelPricing(prices, "gpt-5.4-pro-2026-03-05"))
+                .thenReturn(Optional.of(pricing));
+        when(repository.findByCode("gpt-5.4-pro-2026-03-05")).thenReturn(Optional.empty());
+        when(repository.save(org.mockito.ArgumentMatchers.any(OpenAiModel.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        OpenAiModel created = service.create(request);
+
+        assertThat(created.getCode()).isEqualTo("gpt-5.4-pro-2026-03-05");
+        assertThat(created.getPriceInputStandard()).isEqualByComparingTo("30.00");
+        assertThat(created.getPriceOutputBatch()).isEqualByComparingTo("90.00");
     }
 
     /** Garante que a criação bloqueie modelos inexistentes na API oficial /models. */


### PR DESCRIPTION
### Motivation
- The frontend stopped showing official prices for new OpenAI models because the backend failed to reliably obtain/assign official pricing for model codes (including dated variants like `gpt-5.4-pro-2026-03-05`).

### Description
- Replace the previous WebClient-based fetch with a Jsoup-based HTML fetch in `OpenAiPricingPageClient` to reliably retrieve and parse the OpenAI pricing page and add robust IO/error logging. 
- Add `findBestTextModelPricing` and `isVersionVariantOf` to `OpenAiPricingPageClient` to resolve dated `/models` variants to the most specific base pricing row. 
- Use the new pricing resolution when creating/saving models in `OpenAiModelService` so newly saved models receive the correct official prices. 
- Enrich the catalog response in `OpenAiModelCatalogV1Service` by filling missing prices for persisted catalog models using the variant-resolution logic. 
- Add regression/unit tests covering dated-variant pricing resolution and model creation price enrichment (`OpenAiPricingPageClientTest` and `OpenAiModelServiceTest`).

### Testing
- Ran unit tests for the ads-service module covering pricing parsing and model creation (`OpenAiPricingPageClientTest`, `OpenAiModelServiceTest`) via Maven and all tests passed. 
- Ran `git diff --check` to ensure no whitespace/errors in diffs and the repository state is clean.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a23943939ec832187de5de33e24c60e)