### PR TITLE
docs: update Facebook Ads Swagger contract

### DIFF
--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -3767,3 +3767,21 @@
   - `frontend/src/pages/pipeline/PipelineCrudPage.tsx`
   - `docs/canonical/procedimento-experimento-canon.v1.md`
   - `docs/registros/experimentos.md`
+
+## 2026-06-06 01:14:15 UTC-3
+- solicitação: verificar se os endpoints revisados de Facebook Ads tinham Swagger versionado e ajustar a documentação quando necessário.
+- raciocínio para solução: comparei os mappings dos controllers `com.marketinghub.facebookads.controller` com `docs/swagger/facebook-ads-swagger.yaml` e identifiquei que o contrato existia, mas precisava ficar mais explícito e incluir rotas operacionais legadas do fluxo Facebook Ads, como liberação do experimento, criação/listagem de ad sets e sincronização Meta Ads de targeting.
+- registro do que foi feito: atualizei `docs/swagger/facebook-ads-swagger.yaml` para versão 1.1.0 com servidores, componentes reutilizáveis, bodies principais e todos os paths atuais do pacote Facebook Ads, além das rotas operacionais relacionadas; também registrei o contrato na lista de `docs/swagger/README.md`.
+- documentos lidos para pesquisar e resolver o problema:
+  - backend/AGENTS.md
+  - docs/swagger/README.md
+  - docs/swagger/facebook-ads-swagger.yaml
+  - backend/ads-service/src/main/java/com/marketinghub/facebookads/controller/FacebookAccountController.java
+  - backend/ads-service/src/main/java/com/marketinghub/facebookads/controller/FacebookAdSetController.java
+  - backend/ads-service/src/main/java/com/marketinghub/facebookads/controller/FacebookAdsCampaignController.java
+  - backend/ads-service/src/main/java/com/marketinghub/facebookads/controller/FacebookCampaignStopController.java
+  - backend/ads-service/src/main/java/com/marketinghub/facebookads/controller/FacebookInstantFormController.java
+  - backend/ads-service/src/main/java/com/marketinghub/facebookads/controller/FacebookPixelController.java
+  - backend/ads-service/src/main/java/com/marketinghub/experiment/web/AdSetController.java
+  - backend/ads-service/src/main/java/com/marketinghub/experiment/web/ExperimentController.java
+  - backend/ads-service/src/main/java/com/marketinghub/targeting/web/TargetingInternalController.java

--- a/docs/swagger/README.md
+++ b/docs/swagger/README.md
@@ -13,6 +13,7 @@ Esta pasta é o local único para contratos Swagger/OpenAPI do Marketing Hub.
 
 - `docs/swagger/avatar-sales-video-integration-swagger.yaml` — integração Avatar Sales Video.
 - `docs/swagger/epm-swagger.yaml` — Experiment Profit Manager.
+- `docs/swagger/facebook-ads-swagger.yaml` — integração Facebook Ads/Meta Ads do backend principal.
 - `docs/swagger/geralanding-backend-swagger.v1.yaml` — backend GeraLanding.
 - `docs/swagger/lead-portal-swagger.yaml` — API pública e operacional do Lead Portal.
 - `docs/swagger/openapi.yaml` — superfície geral da API Marketing Hub.

--- a/docs/swagger/facebook-ads-swagger.yaml
+++ b/docs/swagger/facebook-ads-swagger.yaml
@@ -1,12 +1,18 @@
 openapi: 3.0.3
 info:
   title: Marketing Hub - Facebook Ads API
-  version: 1.0.0
+  version: 1.1.0
   description: |
-    Contrato dos endpoints do backend que atendem a integração com Facebook Ads.
+    Contrato versionado dos endpoints do backend que atendem a integração com Facebook Ads/Meta Ads.
     A implementação canônica dos controllers fica concentrada no pacote
-    `com.marketinghub.facebookads.controller`, mantendo as rotas públicas legadas
-    para compatibilidade com frontend e workers.
+    `com.marketinghub.facebookads.controller`, com rotas legadas de Experimentos,
+    Ad Sets e Targeting mantidas no contrato porque fazem parte do fluxo operacional
+    de publicação e enriquecimento de campanhas.
+servers:
+  - url: http://191.252.181.168
+    description: Backend principal usado pelo Codex e integrações operacionais.
+  - url: http://localhost:8000
+    description: Backend local de desenvolvimento.
 tags:
   - name: Facebook Accounts
   - name: Facebook Pages
@@ -17,272 +23,651 @@ tags:
   - name: Facebook Pixels
   - name: Facebook Configuration
   - name: Facebook Playbook
+  - name: Meta Targeting
 paths:
   /api/accounts/facebook:
     get:
       tags: [Facebook Accounts]
       summary: Lista contas do Facebook cadastradas.
-      responses: { '200': { description: Contas retornadas. } }
+      responses:
+        '200': { description: Contas retornadas. }
     post:
       tags: [Facebook Accounts]
       summary: Cria uma conta do Facebook preservando campos operacionais enviados.
-      responses: { '200': { description: Conta criada. } }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/FacebookAccountUpsertRequest' }
+      responses:
+        '200': { description: Conta criada. }
   /api/accounts/facebook/{id}:
     put:
       tags: [Facebook Accounts]
       summary: Atualiza uma conta do Facebook sem descartar campos não enviados pela UI.
-      parameters: [ { name: id, in: path, required: true, schema: { type: integer, format: int64 } } ]
-      responses: { '200': { description: Conta atualizada. } }
+      parameters:
+        - $ref: '#/components/parameters/NumericId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/FacebookAccountUpsertRequest' }
+      responses:
+        '200': { description: Conta atualizada. }
     delete:
       tags: [Facebook Accounts]
       summary: Remove uma conta do Facebook.
-      parameters: [ { name: id, in: path, required: true, schema: { type: integer, format: int64 } } ]
-      responses: { '204': { description: Conta removida. } }
+      parameters:
+        - $ref: '#/components/parameters/NumericId'
+      responses:
+        '204': { description: Conta removida. }
   /api/accounts/facebook/worker-config:
     get:
       tags: [Facebook Accounts]
       summary: Retorna a conta habilitada para o Facebook Ads Worker.
-      responses: { '200': { description: Configuração operacional do worker. } }
+      responses:
+        '200': { description: Configuração operacional do worker. }
   /api/accounts/facebook/renewal/eligible:
     get:
       tags: [Facebook Accounts]
       summary: Lista contas elegíveis para renovação de token.
-      responses: { '200': { description: Candidatas retornadas. } }
+      responses:
+        '200': { description: Candidatas retornadas. }
   /api/accounts/facebook/{id}/token/renewal:
     post:
       tags: [Facebook Accounts]
       summary: Registra resultado de renovação do token da conta.
-      parameters: [ { name: id, in: path, required: true, schema: { type: integer, format: int64 } } ]
-      responses: { '200': { description: Renovação registrada. } }
+      parameters:
+        - $ref: '#/components/parameters/NumericId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/FacebookTokenRenewalRequest' }
+      responses:
+        '200': { description: Renovação registrada. }
   /api/accounts/facebook/{id}/token/revalidation:
     post:
       tags: [Facebook Accounts]
       summary: Revalida o token da conta com a integração Meta.
-      parameters: [ { name: id, in: path, required: true, schema: { type: integer, format: int64 } } ]
-      responses: { '200': { description: Revalidação registrada. } }
+      parameters:
+        - $ref: '#/components/parameters/NumericId'
+      responses:
+        '200': { description: Revalidação registrada. }
   /api/accounts/facebook/{accountId}/pages:
     get:
       tags: [Facebook Pages]
       summary: Lista páginas vinculadas à conta Facebook.
-      parameters: [ { name: accountId, in: path, required: true, schema: { type: integer, format: int64 } } ]
-      responses: { '200': { description: Páginas retornadas. } }
+      parameters:
+        - $ref: '#/components/parameters/AccountId'
+      responses:
+        '200': { description: Páginas retornadas. }
     post:
       tags: [Facebook Pages]
       summary: Vincula uma página à conta Facebook.
-      parameters: [ { name: accountId, in: path, required: true, schema: { type: integer, format: int64 } } ]
-      responses: { '200': { description: Página criada. } }
+      parameters:
+        - $ref: '#/components/parameters/AccountId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/FacebookPageRequest' }
+      responses:
+        '200': { description: Página criada. }
   /api/accounts/facebook/{accountId}/pages/{pageRecordId}:
     put:
       tags: [Facebook Pages]
       summary: Atualiza uma página vinculada à conta Facebook.
       parameters:
-        - { name: accountId, in: path, required: true, schema: { type: integer, format: int64 } }
-        - { name: pageRecordId, in: path, required: true, schema: { type: integer, format: int64 } }
-      responses: { '200': { description: Página atualizada. } }
+        - $ref: '#/components/parameters/AccountId'
+        - $ref: '#/components/parameters/PageRecordId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/FacebookPageRequest' }
+      responses:
+        '200': { description: Página atualizada. }
     delete:
       tags: [Facebook Pages]
       summary: Remove uma página vinculada quando não houver experimentos dependentes.
       parameters:
-        - { name: accountId, in: path, required: true, schema: { type: integer, format: int64 } }
-        - { name: pageRecordId, in: path, required: true, schema: { type: integer, format: int64 } }
-      responses: { '204': { description: Página removida. } }
+        - $ref: '#/components/parameters/AccountId'
+        - $ref: '#/components/parameters/PageRecordId'
+      responses:
+        '204': { description: Página removida. }
   /api/facebook-interests/pending:
     get:
       tags: [Facebook Interests]
       summary: Lista interesses pendentes de ID da Meta.
-      responses: { '200': { description: Interesses pendentes retornados. } }
+      responses:
+        '200': { description: Interesses pendentes retornados. }
   /api/facebook-interests:
     post:
       tags: [Facebook Interests]
       summary: Cria interesse Facebook para enriquecimento.
-      responses: { '201': { description: Interesse criado. } }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/CreateFacebookInterestRequest' }
+      responses:
+        '201': { description: Interesse criado. }
   /api/facebook-interests/{id}:
     patch:
       tags: [Facebook Interests]
       summary: Atualiza ID/status de um interesse Facebook.
-      parameters: [ { name: id, in: path, required: true, schema: { type: integer, format: int64 } } ]
-      responses: { '200': { description: Interesse atualizado. } }
+      parameters:
+        - $ref: '#/components/parameters/NumericId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/FacebookInterestUpdateRequest' }
+      responses:
+        '200': { description: Interesse atualizado. }
   /api/hypotheses/{hypothesisId}/instant-forms:
     get:
       tags: [Facebook Instant Forms]
       summary: Lista formulários instantâneos por hipótese.
-      parameters: [ { name: hypothesisId, in: path, required: true, schema: { type: string, format: uuid } } ]
-      responses: { '200': { description: Formulários retornados. } }
+      parameters:
+        - $ref: '#/components/parameters/HypothesisId'
+      responses:
+        '200': { description: Formulários retornados. }
     post:
       tags: [Facebook Instant Forms]
       summary: Cria rascunho de formulário instantâneo para hipótese.
-      parameters: [ { name: hypothesisId, in: path, required: true, schema: { type: string, format: uuid } } ]
-      responses: { '201': { description: Formulário criado. } }
+      parameters:
+        - $ref: '#/components/parameters/HypothesisId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/CreateFacebookInstantFormRequest' }
+      responses:
+        '201': { description: Formulário criado. }
   /api/instant-forms/ready-to-publish:
     get:
       tags: [Facebook Instant Forms]
       summary: Lista formulários aprovados prontos para publicação pelo worker.
-      responses: { '200': { description: Formulários prontos retornados. } }
+      responses:
+        '200': { description: Formulários prontos retornados. }
   /api/instant-forms/approved-drafts:
     get:
       tags: [Facebook Instant Forms]
       summary: Lista rascunhos aprovados para publicação.
-      responses: { '200': { description: Rascunhos aprovados retornados. } }
+      responses:
+        '200': { description: Rascunhos aprovados retornados. }
   /api/instant-forms/{id}:
     get:
       tags: [Facebook Instant Forms]
-      summary: Busca formulário instantâneo por ID.
-      parameters: [ { name: id, in: path, required: true, schema: { type: integer, format: int64 } } ]
-      responses: { '200': { description: Formulário retornado. } }
+      summary: Consulta um formulário instantâneo pelo identificador interno.
+      parameters:
+        - $ref: '#/components/parameters/NumericId'
+      responses:
+        '200': { description: Formulário retornado. }
     delete:
       tags: [Facebook Instant Forms]
-      summary: Remove formulário instantâneo.
-      parameters: [ { name: id, in: path, required: true, schema: { type: integer, format: int64 } } ]
-      responses: { '204': { description: Formulário removido. } }
+      summary: Remove um formulário instantâneo em rascunho.
+      parameters:
+        - $ref: '#/components/parameters/NumericId'
+      responses:
+        '204': { description: Formulário removido. }
   /api/instant-forms/{id}/approval:
     patch:
       tags: [Facebook Instant Forms]
       summary: Atualiza aprovação do formulário instantâneo.
-      parameters: [ { name: id, in: path, required: true, schema: { type: integer, format: int64 } } ]
-      responses: { '200': { description: Aprovação atualizada. } }
+      parameters:
+        - $ref: '#/components/parameters/NumericId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/UpdateFacebookInstantFormApprovalRequest' }
+      responses:
+        '200': { description: Aprovação atualizada. }
   /api/instant-forms/{id}/publication:
     patch:
       tags: [Facebook Instant Forms]
       summary: Atualiza dados de publicação do formulário instantâneo.
-      parameters: [ { name: id, in: path, required: true, schema: { type: integer, format: int64 } } ]
-      responses: { '200': { description: Publicação atualizada. } }
+      parameters:
+        - $ref: '#/components/parameters/NumericId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/UpdateFacebookInstantFormPublicationRequest' }
+      responses:
+        '200': { description: Publicação atualizada. }
+  /api/experiments/{id}/facebook-release:
+    post:
+      tags: [Facebook Campaigns]
+      summary: Libera experimento para publicação de campanha no Facebook Ads.
+      parameters:
+        - name: id
+          in: path
+          required: true
+          schema: { type: integer, format: int64 }
+      responses:
+        '200': { description: Experimento liberado. }
   /api/facebook-campaigns/experiments-ready:
     get:
       tags: [Facebook Campaigns]
       summary: Lista experimentos liberados para publicação de campanhas.
-      responses: { '200': { description: Experimentos prontos retornados. } }
+      responses:
+        '200': { description: Experimentos prontos retornados. }
   /api/facebook-campaigns/experiments:
     get:
       tags: [Facebook Campaigns]
       summary: Lista experimentos por status para leitura do worker.
-      responses: { '200': { description: Experimentos retornados. } }
+      parameters:
+        - name: status
+          in: query
+          required: false
+          schema: { type: string }
+      responses:
+        '200': { description: Experimentos retornados. }
   /api/facebook-campaigns/metrics/sync-targets:
     get:
       tags: [Facebook Campaigns]
       summary: Lista campanhas que precisam sincronizar métricas da Meta.
-      responses: { '200': { description: Alvos de sincronização retornados. } }
+      responses:
+        '200': { description: Alvos de sincronização retornados. }
   /api/facebook-campaigns:
     post:
       tags: [Facebook Campaigns]
       summary: Registra campanha publicada pelo Facebook Ads Worker.
-      responses: { '200': { description: Campanha registrada. } }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/CreateCampaignRequest' }
+      responses:
+        '200': { description: Campanha registrada. }
   /api/facebook-campaigns/{campaignId}/metrics:
     post:
       tags: [Facebook Campaigns]
       summary: Atualiza métricas sincronizadas para a campanha.
-      parameters: [ { name: campaignId, in: path, required: true, schema: { type: string } } ]
-      responses: { '202': { description: Métricas aceitas. } }
+      parameters:
+        - $ref: '#/components/parameters/CampaignId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/CampaignMetricsUpdateRequest' }
+      responses:
+        '202': { description: Métricas aceitas. }
   /api/facebook-campaigns/{campaignId}/metrics-error:
     post:
       tags: [Facebook Campaigns]
       summary: Registra falha de sincronização de métricas da campanha.
-      parameters: [ { name: campaignId, in: path, required: true, schema: { type: string } } ]
-      responses: { '202': { description: Erro registrado. } }
+      parameters:
+        - $ref: '#/components/parameters/CampaignId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/CampaignMetricsErrorRequest' }
+      responses:
+        '202': { description: Erro registrado. }
   /api/facebook-campaigns/stop-requests:
     get:
       tags: [Facebook Campaigns]
       summary: Lista campanhas com solicitação de parada pendente.
-      responses: { '200': { description: Solicitações retornadas. } }
+      responses:
+        '200': { description: Solicitações retornadas. }
   /api/facebook-campaigns/{campaignId}/stop-results:
     post:
       tags: [Facebook Campaigns]
       summary: Registra resultado de parada de campanha na Meta.
-      parameters: [ { name: campaignId, in: path, required: true, schema: { type: string } } ]
-      responses: { '202': { description: Resultado aceito. } }
+      parameters:
+        - $ref: '#/components/parameters/CampaignId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/FacebookCampaignStopResultRequest' }
+      responses:
+        '202': { description: Resultado aceito. }
   /api/experiments/{experimentId}/facebook-campaigns:
     get:
       tags: [Facebook Campaigns]
       summary: Lista campanhas Facebook vinculadas ao experimento.
-      parameters: [ { name: experimentId, in: path, required: true, schema: { type: integer, format: int64 } } ]
-      responses: { '200': { description: Campanhas retornadas. } }
+      parameters:
+        - $ref: '#/components/parameters/ExperimentId'
+      responses:
+        '200': { description: Campanhas retornadas. }
   /api/experiments/{experimentId}/facebook-campaigns/reset-preview:
     get:
       tags: [Facebook Campaigns]
       summary: Simula reset das campanhas Facebook do experimento.
-      parameters: [ { name: experimentId, in: path, required: true, schema: { type: integer, format: int64 } } ]
-      responses: { '200': { description: Prévia retornada. } }
+      parameters:
+        - $ref: '#/components/parameters/ExperimentId'
+      responses:
+        '200': { description: Prévia retornada. }
   /api/experiments/{experimentId}/facebook-campaigns/reset:
     post:
       tags: [Facebook Campaigns]
       summary: Executa reset das campanhas Facebook do experimento.
-      parameters: [ { name: experimentId, in: path, required: true, schema: { type: integer, format: int64 } } ]
-      responses: { '200': { description: Reset executado. } }
+      parameters:
+        - $ref: '#/components/parameters/ExperimentId'
+      responses:
+        '200': { description: Reset executado. }
   /api/facebook-adsets/experiments-ready:
     get:
       tags: [Facebook Ad Sets]
       summary: Lista experimentos prontos para criação de conjuntos de anúncios.
-      responses: { '200': { description: Experimentos retornados. } }
+      responses:
+        '200': { description: Experimentos retornados. }
+  /api/adsets:
+    get:
+      tags: [Facebook Ad Sets]
+      summary: Lista conjuntos de anúncios planejados por experimento.
+      parameters:
+        - name: experimentId
+          in: query
+          required: true
+          schema: { type: integer, format: int64 }
+      responses:
+        '200': { description: Ad sets retornados. }
+    post:
+      tags: [Facebook Ad Sets]
+      summary: Cria conjunto de anúncios planejado para publicação na Meta.
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/CreateAdSetRequest' }
+      responses:
+        '200': { description: Ad set criado. }
   /api/facebook-pixels/niches-ready:
     get:
       tags: [Facebook Pixels]
       summary: Lista nichos prontos para criação de pixel.
-      responses: { '200': { description: Nichos retornados. } }
+      responses:
+        '200': { description: Nichos retornados. }
   /api/facebook-pixels:
     post:
       tags: [Facebook Pixels]
       summary: Registra pixel criado para um nicho.
-      responses: { '200': { description: Nicho atualizado. } }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/CreateFacebookPixelRequest' }
+      responses:
+        '200': { description: Nicho atualizado. }
   /api/facebook-pixels/conversions-ready:
     get:
       tags: [Facebook Pixels]
       summary: Lista conversões prontas para envio à Meta.
-      responses: { '200': { description: Conversões retornadas. } }
+      responses:
+        '200': { description: Conversões retornadas. }
   /api/facebook-pixels/conversions/{purchaseId}/ack:
     post:
       tags: [Facebook Pixels]
       summary: Confirma envio de conversão à Meta.
-      parameters: [ { name: purchaseId, in: path, required: true, schema: { type: integer, format: int64 } } ]
-      responses: { '202': { description: Conversão confirmada. } }
+      parameters:
+        - name: purchaseId
+          in: path
+          required: true
+          schema: { type: integer, format: int64 }
+      responses:
+        '202': { description: Conversão confirmada. }
   /api/facebook/configuration-status:
     get:
       tags: [Facebook Configuration]
       summary: Retorna diagnóstico de configuração da integração Facebook Ads.
-      responses: { '200': { description: Diagnóstico retornado. } }
+      responses:
+        '200': { description: Diagnóstico retornado. }
   /api/experiments/{experimentId}/adset-playbook:
     get:
       tags: [Facebook Playbook]
       summary: Consulta workflow do playbook de adsets por experimento.
-      parameters: [ { name: experimentId, in: path, required: true, schema: { type: integer, format: int64 } } ]
-      responses: { '200': { description: Workflow retornado. } }
+      parameters:
+        - $ref: '#/components/parameters/ExperimentId'
+      responses:
+        '200': { description: Workflow retornado. }
   /api/experiments/{experimentId}/adset-playbook/start:
     post:
       tags: [Facebook Playbook]
       summary: Inicia workflow do playbook de adsets.
-      parameters: [ { name: experimentId, in: path, required: true, schema: { type: integer, format: int64 } } ]
-      responses: { '202': { description: Workflow iniciado. } }
+      parameters:
+        - $ref: '#/components/parameters/ExperimentId'
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/StartExperimentAdSetWorkflowRequest' }
+      responses:
+        '202': { description: Workflow iniciado. }
   /api/experiments/{experimentId}/adset-playbook/jobs/{jobId}:
     get:
       tags: [Facebook Playbook]
       summary: Consulta detalhes de job do playbook de adsets.
       parameters:
-        - { name: experimentId, in: path, required: true, schema: { type: integer, format: int64 } }
-        - { name: jobId, in: path, required: true, schema: { type: integer, format: int64 } }
-      responses: { '200': { description: Job retornado. } }
+        - $ref: '#/components/parameters/ExperimentId'
+        - $ref: '#/components/parameters/JobId'
+      responses:
+        '200': { description: Job retornado. }
   /internal/adset-playbook/jobs/claim:
     post:
       tags: [Facebook Playbook]
       summary: Permite que workers internos reivindiquem jobs do playbook.
-      responses: { '200': { description: Jobs reivindicados. } }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/ExperimentAdSetJobClaimRequest' }
+      responses:
+        '200': { description: Jobs reivindicados. }
   /internal/adset-playbook/jobs/{jobId}/complete:
     post:
       tags: [Facebook Playbook]
       summary: Marca job interno do playbook como concluído.
-      parameters: [ { name: jobId, in: path, required: true, schema: { type: integer, format: int64 } } ]
-      responses: { '202': { description: Job concluído. } }
+      parameters:
+        - $ref: '#/components/parameters/JobId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/ExperimentAdSetJobResultRequest' }
+      responses:
+        '202': { description: Job concluído. }
   /internal/adset-playbook/jobs/{jobId}/fail:
     post:
       tags: [Facebook Playbook]
       summary: Marca job interno do playbook como falho.
-      parameters: [ { name: jobId, in: path, required: true, schema: { type: integer, format: int64 } } ]
-      responses: { '202': { description: Job falho registrado. } }
+      parameters:
+        - $ref: '#/components/parameters/JobId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/ExperimentAdSetJobFailureRequest' }
+      responses:
+        '202': { description: Job falho registrado. }
   /api/experiments/{experimentId}/facebook-api-logs:
     get:
       tags: [Facebook Playbook]
       summary: Lista logs da API Facebook associados ao experimento.
-      parameters: [ { name: experimentId, in: path, required: true, schema: { type: integer, format: int64 } } ]
-      responses: { '200': { description: Logs retornados. } }
+      parameters:
+        - $ref: '#/components/parameters/ExperimentId'
+      responses:
+        '200': { description: Logs retornados. }
     post:
       tags: [Facebook Playbook]
       summary: Ingere logs brutos da API Facebook para auditoria operacional.
-      parameters: [ { name: experimentId, in: path, required: true, schema: { type: integer, format: int64 } } ]
-      responses: { '202': { description: Logs aceitos. } }
+      parameters:
+        - $ref: '#/components/parameters/ExperimentId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/ExperimentFacebookApiLogIngestionRequest' }
+      responses:
+        '202': { description: Logs aceitos. }
+  /api/internal/targeting/elements/metaads-pending:
+    get:
+      tags: [Meta Targeting]
+      summary: Lista elementos de segmentação pendentes de resolução na Meta Ads.
+      parameters:
+        - name: limit
+          in: query
+          required: false
+          schema: { type: integer, default: 50, minimum: 1 }
+      responses:
+        '200': { description: Elementos pendentes retornados. }
+  /api/internal/targeting/elements/{id}/metaads:
+    patch:
+      tags: [Meta Targeting]
+      summary: Atualiza dados oficiais Meta Ads de um elemento de segmentação.
+      parameters:
+        - $ref: '#/components/parameters/NumericId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/UpdateTargetingMetaAdsDataRequest' }
+      responses:
+        '200': { description: Dados Meta Ads atualizados. }
+components:
+  parameters:
+    NumericId:
+      name: id
+      in: path
+      required: true
+      schema: { type: integer, format: int64 }
+    AccountId:
+      name: accountId
+      in: path
+      required: true
+      schema: { type: integer, format: int64 }
+    PageRecordId:
+      name: pageRecordId
+      in: path
+      required: true
+      schema: { type: integer, format: int64 }
+    CampaignId:
+      name: campaignId
+      in: path
+      required: true
+      schema: { type: string }
+    ExperimentId:
+      name: experimentId
+      in: path
+      required: true
+      schema: { type: integer, format: int64 }
+    HypothesisId:
+      name: hypothesisId
+      in: path
+      required: true
+      schema: { type: string, format: uuid }
+    JobId:
+      name: jobId
+      in: path
+      required: true
+      schema: { type: integer, format: int64 }
+  schemas:
+    FacebookAccountUpsertRequest:
+      type: object
+      additionalProperties: true
+      description: Payload de criação/atualização de conta Facebook; campos omitidos em atualização são preservados pelo backend.
+    FacebookTokenRenewalRequest:
+      type: object
+      properties:
+        accessToken: { type: string }
+        expiresAt: { type: string, format: date-time, nullable: true }
+        renewalStatus: { type: string, nullable: true }
+        errorMessage: { type: string, nullable: true }
+      additionalProperties: true
+    FacebookPageRequest:
+      type: object
+      properties:
+        pageId: { type: string }
+        name: { type: string }
+        accessToken: { type: string }
+      additionalProperties: true
+    CreateFacebookInterestRequest:
+      type: object
+      properties:
+        name: { type: string }
+        model: { type: string }
+        prompt: { type: string }
+      required: [name]
+    FacebookInterestUpdateRequest:
+      type: object
+      properties:
+        facebookId: { type: string, nullable: true }
+        status: { type: string, nullable: true }
+        errorMessage: { type: string, nullable: true }
+      additionalProperties: true
+    CreateFacebookInstantFormRequest:
+      type: object
+      additionalProperties: true
+      description: Dados comerciais do rascunho de formulário instantâneo vinculado à hipótese.
+    UpdateFacebookInstantFormApprovalRequest:
+      type: object
+      properties:
+        approved: { type: boolean }
+      required: [approved]
+    UpdateFacebookInstantFormPublicationRequest:
+      type: object
+      additionalProperties: true
+      description: IDs e status retornados pela publicação do formulário na Meta.
+    CreateCampaignRequest:
+      type: object
+      additionalProperties: true
+      description: Payload do worker com campanha, ad sets, ads, criativos e métricas iniciais publicadas na Meta.
+    CampaignMetricsUpdateRequest:
+      type: object
+      additionalProperties: true
+      description: Métricas agregadas e timestamps sincronizados da campanha Meta.
+    CampaignMetricsErrorRequest:
+      type: object
+      properties:
+        message: { type: string }
+      required: [message]
+    FacebookCampaignStopResultRequest:
+      type: object
+      properties:
+        stopped: { type: boolean }
+        message: { type: string, nullable: true }
+      additionalProperties: true
+    CreateAdSetRequest:
+      type: object
+      additionalProperties: true
+      description: Planejamento do conjunto de anúncios, incluindo experimento, orçamento, duração, localização, interesses e targetingJson.
+    CreateFacebookPixelRequest:
+      type: object
+      additionalProperties: true
+      description: Dados de pixel criado para nicho e conta Meta.
+    StartExperimentAdSetWorkflowRequest:
+      type: object
+      properties:
+        restart: { type: boolean, default: false }
+    ExperimentAdSetJobClaimRequest:
+      type: object
+      additionalProperties: true
+      description: Critérios usados por workers internos para reivindicar jobs pendentes.
+    ExperimentAdSetJobResultRequest:
+      type: object
+      additionalProperties: true
+      description: Resultado estruturado de execução do job de playbook.
+    ExperimentAdSetJobFailureRequest:
+      type: object
+      additionalProperties: true
+      description: Contexto de falha do job de playbook, com mensagem operacional e detalhes quando disponíveis.
+    ExperimentFacebookApiLogIngestionRequest:
+      type: object
+      additionalProperties: true
+      description: Payload bruto ou normalizado de logs da API Facebook para auditoria.
+    UpdateTargetingMetaAdsDataRequest:
+      type: object
+      properties:
+        metaId: { type: string, nullable: true }
+        metaName: { type: string, nullable: true }
+        metaType: { type: string, nullable: true }
+        status: { type: string, nullable: true }
+        errorMessage: { type: string, nullable: true }
+      additionalProperties: true


### PR DESCRIPTION
### Motivation
- Ensure the Swagger/OpenAPI contract mirrors recent backend changes to Facebook Ads endpoints so workers and frontend keep using a single canonical, versioned spec. 
- Make operational legacy routes (AdSets, experiment Facebook release, internal targeting sync) explicit in the versioned contract so automation and workers can rely on documented contracts.

### Description
- Updated `docs/swagger/facebook-ads-swagger.yaml` to version `1.1.0`, adding `servers`, tags, reusable `components` (parameters and schemas) and explicit request bodies for main operations. 
- Added/expanded paths to cover current controllers, including `/api/adsets`, `/api/experiments/{id}/facebook-release`, Facebook campaigns endpoints, playbook/internal job endpoints and internal targeting endpoints `/api/internal/targeting/elements/metaads-pending` and `/api/internal/targeting/elements/{id}/metaads`. 
- Registered the Swagger file in `docs/swagger/README.md` and appended an operational record in `docs/registros/experimentos.md` describing the change. 
- Ensured the YAML remains permissive for additional properties where backend preserves operational fields to avoid contract-breaking behavior for fields preserved by the server.

### Testing
- Loaded the YAML with `ruby -e "require 'yaml'; YAML.load_file('docs/swagger/facebook-ads-swagger.yaml')"` to validate parseability, which succeeded. 
- Ran a custom Ruby coverage check that verified the expected 53 Facebook Ads operations exist in `docs/swagger/facebook-ads-swagger.yaml`, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a239dbb81388321b2e943fea245f789)