### PR TITLE
Prevent duplicate Facebook campaign publication (dedupe & idempotency)

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/facebookads/controller/FacebookAdsCampaignController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/facebookads/controller/FacebookAdsCampaignController.java
@@ -9,6 +9,7 @@ import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.marketinghub.ads.FacebookAccount;
 import com.marketinghub.repository.jpa.ads.FacebookAccountRepository;
 import com.marketinghub.experiment.Experiment;
+import com.marketinghub.experiment.ExperimentStatus;
 import com.marketinghub.experiment.ExperimentCampaignMetric;
 import com.marketinghub.experiment.service.ExperimentCampaignMetricService;
 import com.marketinghub.experiment.service.ExperimentService;
@@ -103,6 +104,7 @@ public class FacebookAdsCampaignController {
                         com.marketinghub.experiment.ExperimentPlatform.FACEBOOK)
                 .stream()
                 .filter(experiment -> experiment.getFacebookReleaseRequestedAt() != null)
+                .filter(experiment -> !campaignRepository.existsByExperimentId(experiment.getId()))
                 .filter(experimentReadinessService::isReadyForCampaign)
                 .map(experiment -> toSummary(experiment, leadPortalMetrics.get(experiment.getId())))
                 .toList();
@@ -154,6 +156,14 @@ public class FacebookAdsCampaignController {
             throw new ResponseStatusException(HttpStatus.NOT_FOUND,
                     "Experiment not found: " + req.experimentId(), ex);
         }
+        if (campaignRepository.existsById(req.id())) {
+            experiment.setStatus(ExperimentStatus.RUNNING);
+            return;
+        }
+        if (campaignRepository.existsByExperimentId(req.experimentId())) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT,
+                    "Experiment already has a Facebook campaign: " + req.experimentId());
+        }
         FacebookAccount account = accountRepository.findById(req.facebookAccountId())
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND,
                         "Facebook account not found: " + req.facebookAccountId()));
@@ -199,6 +209,7 @@ public class FacebookAdsCampaignController {
                 adRepository.save(mapAd(adRequest, savedAdSet, creative));
             }
         }
+        experiment.setStatus(ExperimentStatus.RUNNING);
     }
 
     @PostMapping("/{campaignId}/metrics")

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/facebookads/FacebookAdsCampaignRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/facebookads/FacebookAdsCampaignRepository.java
@@ -13,6 +13,9 @@ import java.util.List;
  */
 public interface FacebookAdsCampaignRepository extends JpaRepository<FacebookAdsCampaign, String> {
 
+    /**
+     * Lists campaigns whose owning experiment currently has the requested status.
+     */
     @Query("""
             select c from FacebookAdsCampaign c
             join fetch c.experiment e
@@ -20,6 +23,9 @@ public interface FacebookAdsCampaignRepository extends JpaRepository<FacebookAds
             """)
     List<FacebookAdsCampaign> findAllByExperimentStatus(@Param("status") ExperimentStatus status);
 
+    /**
+     * Lists campaigns with their ad sets for one experiment in creation order.
+     */
     @Query("""
             select distinct c from FacebookAdsCampaign c
             left join fetch c.adSets s
@@ -29,8 +35,19 @@ public interface FacebookAdsCampaignRepository extends JpaRepository<FacebookAds
             """)
     List<FacebookAdsCampaign> findDetailedByExperimentId(@Param("experimentId") Long experimentId);
 
+    /**
+     * Checks whether an experiment already has a campaign persisted in the backend.
+     */
+    boolean existsByExperimentId(Long experimentId);
+
+    /**
+     * Lists campaigns persisted for one experiment without forcing fetch joins.
+     */
     List<FacebookAdsCampaign> findByExperimentId(Long experimentId);
 
+    /**
+     * Lists campaigns with pending stop requests for the Facebook worker.
+     */
     @Query("""
             select distinct c from FacebookAdsCampaign c
             left join fetch c.experiment e

--- a/backend/ads-service/src/test/java/com/marketinghub/facebookads/controller/FacebookAdsCampaignControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/facebookads/controller/FacebookAdsCampaignControllerTest.java
@@ -11,6 +11,8 @@ import com.marketinghub.ads.InstagramAccount;
 import com.marketinghub.repository.jpa.experiment.ExperimentTargetingSelectionRepository;
 import com.marketinghub.experiment.AdSet;
 import com.marketinghub.experiment.Experiment;
+import com.marketinghub.experiment.ExperimentPlatform;
+import com.marketinghub.experiment.ExperimentStatus;
 import com.marketinghub.journey.model.JourneyTemplate;
 import com.marketinghub.hypothesis.Hypothesis;
 import com.marketinghub.niche.MarketNiche;
@@ -40,6 +42,7 @@ import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.http.MediaType;
 
 import java.math.BigDecimal;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.util.List;
 import java.util.Optional;
@@ -49,6 +52,7 @@ import org.mockito.ArgumentCaptor;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.any;
 import static org.mockito.Mockito.times;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
@@ -191,6 +195,27 @@ class FacebookAdsCampaignControllerTest {
     }
 
     @Test
+    void experimentsReadyExcludesExperimentsThatAlreadyHaveCampaign() throws Exception {
+        var experiment = Experiment.builder()
+                .id(37L)
+                .name("Experimento 37")
+                .platform(ExperimentPlatform.FACEBOOK)
+                .status(ExperimentStatus.PLANNED)
+                .facebookReleaseRequestedAt(Instant.parse("2026-06-05T23:56:48Z"))
+                .followUpActionUrl("https://landing.example.com/37")
+                .creativeApproved(true)
+                .build();
+        when(experimentService.listByStatusAndPlatform(ExperimentStatus.PLANNED, ExperimentPlatform.FACEBOOK))
+                .thenReturn(List.of(experiment));
+        when(campaignRepository.existsByExperimentId(37L)).thenReturn(true);
+        when(leadPortalMetricsService.listExperimentMetrics()).thenReturn(List.of());
+
+        mockMvc.perform(get("/api/facebook-campaigns/experiments-ready"))
+                .andExpect(status().isOk())
+                .andExpect(content().json("[]"));
+    }
+
+    @Test
     void createCampaignPersistsHierarchy() throws Exception {
         var experiment = Experiment.builder()
                 .id(42L)
@@ -281,6 +306,7 @@ class FacebookAdsCampaignControllerTest {
         FacebookAdsCampaign savedCampaign = campaignCaptor.getValue();
         assertThat(savedCampaign.getId()).isEqualTo("cmp123");
         assertThat(savedCampaign.getExternalId()).isEqualTo("meta-campaign-123");
+        assertThat(experiment.getStatus()).isEqualTo(ExperimentStatus.RUNNING);
 
         ArgumentCaptor<FacebookAdsAdSet> adSetCaptor = ArgumentCaptor.forClass(FacebookAdsAdSet.class);
         verify(adSetRepository).save(adSetCaptor.capture());
@@ -314,6 +340,65 @@ class FacebookAdsCampaignControllerTest {
         assertThat(savedAd.getExternalId()).isEqualTo("meta-ad-123");
         assertThat(savedAd.getAdSet().getId()).isEqualTo("adset123");
         assertThat(savedAd.getCreative().getId()).isEqualTo("creative123");
+    }
+
+    @Test
+    void createCampaignAcceptsRetryForSameCampaignIdWithoutDuplicatingHierarchy() throws Exception {
+        var experiment = Experiment.builder()
+                .id(37L)
+                .name("Experimento 37")
+                .build();
+        when(experimentService.get(37L)).thenReturn(experiment);
+        when(campaignRepository.existsById("cmp-existente")).thenReturn(true);
+
+        String payload = """
+            {
+              "id": "cmp-existente",
+              "adAccountId": "act_888",
+              "name": "Experimento 37",
+              "objective": "OUTCOME_TRAFFIC",
+              "budgetMode": "CAMPAIGN",
+              "experimentId": 37,
+              "facebookAccountId": 88
+            }
+            """;
+
+        mockMvc.perform(post("/api/facebook-campaigns")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(payload))
+                .andExpect(status().isCreated());
+
+        assertThat(experiment.getStatus()).isEqualTo(ExperimentStatus.RUNNING);
+        verify(campaignRepository, never()).save(any());
+    }
+
+    @Test
+    void createCampaignRejectsAnotherCampaignForSameExperiment() throws Exception {
+        var experiment = Experiment.builder()
+                .id(37L)
+                .name("Experimento 37")
+                .build();
+        when(experimentService.get(37L)).thenReturn(experiment);
+        when(campaignRepository.existsByExperimentId(37L)).thenReturn(true);
+
+        String payload = """
+            {
+              "id": "cmp-duplicada",
+              "adAccountId": "act_888",
+              "name": "Experimento 37",
+              "objective": "OUTCOME_TRAFFIC",
+              "budgetMode": "CAMPAIGN",
+              "experimentId": 37,
+              "facebookAccountId": 88
+            }
+            """;
+
+        mockMvc.perform(post("/api/facebook-campaigns")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(payload))
+                .andExpect(status().isConflict());
+
+        verify(campaignRepository, never()).save(any());
     }
 
     @Test

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -3785,3 +3785,9 @@
   - backend/ads-service/src/main/java/com/marketinghub/experiment/web/AdSetController.java
   - backend/ads-service/src/main/java/com/marketinghub/experiment/web/ExperimentController.java
   - backend/ads-service/src/main/java/com/marketinghub/targeting/web/TargetingInternalController.java
+
+## 2026-06-06 04:52:00 UTC
+- solicitação: corrigir a geração repetida da campanha do Experimento 37 no Gerenciador de Anúncios da Meta.
+- causa-raiz verificada: via MCP/banco, o experimento 37 permanecia com `status='PLANNED'` e `facebook_release_requested_at` preenchido mesmo após 22 campanhas persistidas em `facebook_ads_campaign`; por isso `/api/facebook-campaigns/experiments-ready` continuava recolocando o mesmo experimento na fila do Facebook Ads Worker.
+- correção aplicada: o backend passou a excluir da fila de publicação qualquer experimento que já tenha campanha persistida, tornou o `POST /api/facebook-campaigns` idempotente para o mesmo ID de campanha, bloqueou nova campanha para o mesmo `experimentId` com `409 Conflict` e marca o experimento como `RUNNING` no registro canônico da campanha.
+- testes: executado `mvn -Dtest=FacebookAdsCampaignControllerTest test` em `backend/ads-service`, validando a deduplicação da fila, o bloqueio de duplicidade por experimento e a transição do experimento para `RUNNING` após registro da campanha.


### PR DESCRIPTION
### Motivation
- Experimento 37 estava sendo publicado repetidamente porque `/api/facebook-campaigns/experiments-ready` continuava retornando experiments com `status = PLANNED` e `facebook_release_requested_at` mesmo após várias campanhas persistidas.
- É necessário garantir invariância: um experimento não deve gerar múltiplas campanhas ativas na mesma plataforma e retries devem ser idempotentes. 
- Evitar publicações duplicadas no worker reduz custo, risco e inconsistência no fluxo de liberação/publicação.

### Description
- Exclui da fila de publicação experiments que já têm campanha persistida adicionando um filtro em `/api/facebook-campaigns/experiments-ready` que usa `existsByExperimentId(experimentId)` antes de retornar o experimento. (arquivo modificado: `FacebookAdsCampaignController.java`).
- Adiciona `boolean existsByExperimentId(Long experimentId)` no repositório JPA `FacebookAdsCampaignRepository` para apoio à regra de unicidade e consultas eficientes. (arquivo modificado: `FacebookAdsCampaignRepository.java`).
- Torna `POST /api/facebook-campaigns` idempotente: quando o `campaignId` já existe, o endpoint reconhece o retry, marca o `experiment` como `RUNNING` e não recria a hierarquia; quando já existe campanha para o mesmo `experimentId` com outro `id`, responde com `409 Conflict`; ao gravar com sucesso marca o `experiment` como `RUNNING`. (arquivo modificado: `FacebookAdsCampaignController.java`).
- Adiciona/atualiza testes de regressão cobrindo: exclusão da fila quando já existe campanha, aceitação de retry idempotente pelo mesmo `campaignId`, rejeição de nova campanha para `experimentId` já publicado, e a transição do experimento para `RUNNING`. (arquivo modificado: `FacebookAdsCampaignControllerTest.java`).
- Documenta o incidente e a correção em `docs/registros/experimentos.md`.

### Testing
- Executado `mvn -Dtest=FacebookAdsCampaignControllerTest test` dentro do módulo `backend/ads-service`, com todos os testes relevantes passando (6 tests, 0 failures). ✅
- Verificado `git diff --check` sem problemas. ✅
- Rodado `mvn spotless:check` como verificação de estilo; essa checagem falhou por não haver plugin Spotless configurado com prefixo Maven no módulo (informação registrada como aviso, não bloqueante para a correção). ⚠️

Modified files:
- `backend/ads-service/src/main/java/com/marketinghub/facebookads/controller/FacebookAdsCampaignController.java`
- `backend/ads-service/src/main/java/com/marketinghub/repository/jpa/facebookads/FacebookAdsCampaignRepository.java`
- `backend/ads-service/src/test/java/com/marketinghub/facebookads/controller/FacebookAdsCampaignControllerTest.java`
- `docs/registros/experimentos.md`

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a23a60a6ac88321a8168817465d5475)