### PR TITLE
fix: qualifica upsert de mois_sales_page para evitar ambiguidade em 'title'

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryService.java
@@ -829,10 +829,10 @@ public class MoisSalesLibraryService {
                         FROM mois_collected_reference r
                         WHERE r.id = ?
                         ON DUPLICATE KEY UPDATE
-                            collected_reference_id = COALESCE(collected_reference_id, VALUES(collected_reference_id)),
-                            source_job_id = COALESCE(source_job_id, VALUES(source_job_id)),
-                            source_reference_id = COALESCE(source_reference_id, VALUES(source_reference_id)),
-                            title = COALESCE(NULLIF(VALUES(title), ''), title),
+                            collected_reference_id = COALESCE(mois_sales_page.collected_reference_id, VALUES(collected_reference_id)),
+                            source_job_id = COALESCE(mois_sales_page.source_job_id, VALUES(source_job_id)),
+                            source_reference_id = COALESCE(mois_sales_page.source_reference_id, VALUES(source_reference_id)),
+                            title = COALESCE(NULLIF(VALUES(title), ''), mois_sales_page.title),
                             current_stage = 'CAPTURE',
                             current_status = 'FETCHING',
                             capture_status = 'FETCHING',

--- a/backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryServiceTest.java
@@ -141,6 +141,13 @@ class MoisSalesLibraryServiceTest {
         org.assertj.core.api.Assertions.assertThat(sqlCaptor.getValue())
                 .contains("GROUP BY effective_url")
                 .contains("TRIM(sales_page_url)");
+
+        ArgumentCaptor<String> upsertSqlCaptor = ArgumentCaptor.forClass(String.class);
+        verify(jdbcTemplate).update(upsertSqlCaptor.capture(), any(), any(), eq(20L));
+        org.assertj.core.api.Assertions.assertThat(upsertSqlCaptor.getValue())
+                .contains("mois_sales_page.title")
+                .contains("mois_sales_page.collected_reference_id")
+                .doesNotContain("NULLIF(VALUES(title), ''), title");
     }
 
     /**

--- a/docs/registros/mois1.md
+++ b/docs/registros/mois1.md
@@ -1056,3 +1056,14 @@ Arquivos alterados:
 - `mcp-server/README.md`
 - `mcp-server/AGENTS.md`
 - `docs/registros/mois1.md`
+
+## 2026-06-06 — Correção de ambiguidade SQL no claim de referências coletadas MOIS
+
+- corrigida a causa-raiz do erro `Column 'title' in field list is ambiguous` no claim `POST /api/mois/sales-library/collected-reference-html:claim`.
+- o `ON DUPLICATE KEY UPDATE` do upsert em `mois_sales_page` agora referencia explicitamente os campos atuais da tabela alvo (`mois_sales_page.title`, `mois_sales_page.collected_reference_id`, `mois_sales_page.source_job_id`, `mois_sales_page.source_reference_id`) ao combinar dados já existentes com `VALUES(...)` vindos da referência coletada.
+- adicionada cobertura unitária para impedir regressão para referência não qualificada de `title` no SQL de reserva de captura.
+
+Arquivos alterados:
+- `backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryService.java`
+- `backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryServiceTest.java`
+- `docs/registros/mois1.md`


### PR DESCRIPTION
### Motivation
- Corrigir erro SQL `Column 'title' in field list is ambiguous` observado durante o claim de `collected-reference-html` ao inserir/upsert em `mois_sales_page` a partir de `mois_collected_reference`. 
- Evitar regressão futura garantindo que o `ON DUPLICATE KEY UPDATE` referencie explicitamente as colunas existentes da tabela alvo em vez de usar identificadores não qualificados que conflitam com a tabela fonte.

### Description
- Altere `MoisSalesLibraryService.claimCollectedReferenceCandidate` para qualificar colunas no `ON DUPLICATE KEY UPDATE`, por exemplo usando `mois_sales_page.collected_reference_id`, `mois_sales_page.source_job_id`, `mois_sales_page.source_reference_id` e `mois_sales_page.title` ao compor os `COALESCE(...)` no upsert. 
- Atualizei o teste unitário `MoisSalesLibraryServiceTest` para capturar o SQL de upsert e verificar que ele contém `mois_sales_page.title` e `mois_sales_page.collected_reference_id` e não contém a forma ambígua anterior. 
- Registrei a correção operacional em `docs/registros/mois1.md`.

### Testing
- Executei os testes unitários do módulo afetado com `mvn -Dtest=MoisSalesLibraryServiceTest test` dentro de `backend/ads-service`, que passaram com `Tests run: 8, Failures: 0, Errors: 0`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a23af0b9a988321a66772e2e1fe8822)