### PR TITLE
Add `mois-sales-library-worker` to MCP `java_module_logs` (config, service, docs, tests)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,7 +100,7 @@ O Marketing Hub é uma fábrica automatizada de produtos digitais: descobre dore
 
 - **MCP Server — filtros disponíveis para pesquisa de logs (referência operacional)**:
   - Tool de logs dos módulos Java: `java_module_logs`.
-  - Módulos aceitos em `module`: `backend`, `ai-worker`, `lead-portal`, `facebook-ads`, `email-service`, `lead-portal-payment`, `mds`, `mois`, `mois-hotmart`, `clickbank-coletor-mois`, `oprm-coletor-receita`.
+  - Módulos aceitos em `module`: `backend`, `ai-worker`, `lead-portal`, `facebook-ads`, `email-service`, `lead-portal-payment`, `mds`, `mois`, `mois-sales-library-worker`, `mois-hotmart`, `clickbank-coletor-mois`, `oprm-coletor-receita`.
   - Observação importante de nomenclatura: para o coletor OPRM de MEI/CNPJ, a aplicação/serviço no projeto está nomeada como `oprm-coletor-mei`, porém no MCP o identificador aceito em `module` continua sendo `oprm-coletor-receita` (alias legado de integração do módulo de logs).
   - Filtros/parâmetros disponíveis:
     1. `module` (**obrigatório**): módulo Java de origem do log.

--- a/docs/registros/mois1.md
+++ b/docs/registros/mois1.md
@@ -1056,3 +1056,20 @@ Arquivos alterados:
 - `mcp-server/README.md`
 - `mcp-server/AGENTS.md`
 - `docs/registros/mois1.md`
+
+## 2026-06-06 — Alias de logs MCP para MOIS Sales Library Worker
+
+- adicionado o módulo `mois-sales-library-worker` ao tool MCP `java_module_logs`, apontando para o logfile público `http://191.252.120.96:8097/actuator/logfile`.
+- preservado o módulo `mois` existente e criada configuração dedicada `MCP_LOG_MOIS_SALES_LIBRARY_WORKER_PATH` para permitir ajuste independente no ambiente.
+- atualizadas a documentação do MCP e a referência operacional de módulos aceitos para investigação de logs.
+
+Arquivos alterados:
+- `mcp-server/src/main/resources/application.yml`
+- `mcp-server/src/main/java/com/marketinghub/mcpserver/config/McpProperties.java`
+- `mcp-server/src/main/java/com/marketinghub/mcpserver/service/ModuleLogService.java`
+- `mcp-server/src/main/java/com/marketinghub/mcpserver/controller/McpController.java`
+- `mcp-server/src/test/java/com/marketinghub/mcpserver/controller/McpControllerTest.java`
+- `mcp-server/README.md`
+- `mcp-server/AGENTS.md`
+- `AGENTS.md`
+- `docs/registros/mois1.md`

--- a/mcp-server/AGENTS.md
+++ b/mcp-server/AGENTS.md
@@ -10,7 +10,8 @@ Manter os seguintes endpoints como defaults de origem de logs no módulo `mcp-se
 - Facebook Ads Worker: `http://191.252.120.96:8082/public/runtime-logs/tail?lines=300`
 - Lead Portal: `http://191.252.120.96:8082/public/runtime-logs/tail?lines=300`
 - Portal Pagamentos (Lead Portal): `http://191.252.102.54:8092/api/v1/logs/runtime?lines=200`
-- MOIS Sales Library Worker: `http://191.252.120.96:8097/actuator/logfile`
+- MOIS: `http://191.252.120.96:8097/actuator/logfile`
+- MOIS Sales Library Worker (`mois-sales-library-worker`): `http://191.252.120.96:8097/actuator/logfile`
 - Mois Coletor Hotmart: `http://177.153.62.107:8096/ops-monitor/mois-hotmart-log`
 - Clickbank Coletor Mois: `http://177.153.62.107:9096/internal/ops-monitor/logfile`
 - OPRM Coletor Receita: `http://177.153.62.107:8094/actuator/logfile`

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -17,7 +17,7 @@ Servidor MCP (Model Context Protocol) do Marketing Hub para execução de ferram
 - `db_list_tables`: lista todas as tabelas disponíveis no schema atual.
 - `db_read_table`: lê dados de uma tabela com paginação (`table`, `limit`, `offset`).
 - `db_query`: executa SQL de leitura (`SELECT`/`WITH`) com limite de linhas.
-- `java_module_logs`: retorna logs do Spring Boot com filtros opcionais por texto/intervalo e paginação (`lines`, `contains`, `from`, `to`, `offset`, `cursor`) para os módulos Java (`backend`, `ai-worker`, `lead-portal`, `facebook-ads`, `email-service`, `lead-portal-payment`, `mds`, `mois`, `mois-hotmart`, `clickbank-coletor-mois`, `oprm-coletor-receita`).
+- `java_module_logs`: retorna logs do Spring Boot com filtros opcionais por texto/intervalo e paginação (`lines`, `contains`, `from`, `to`, `offset`, `cursor`) para os módulos Java (`backend`, `ai-worker`, `lead-portal`, `facebook-ads`, `email-service`, `lead-portal-payment`, `mds`, `mois`, `mois-sales-library-worker`, `mois-hotmart`, `clickbank-coletor-mois`, `oprm-coletor-receita`).
 - `meta_docs_get`: busca páginas de documentação da Meta em hosts aprovados.
 - `meta_graph_get`: executa leitura (`GET`) da Graph API com token configurado no MCP.
 - `meta_graph_debug_token`: executa `debug_token` para validar tokens.
@@ -54,7 +54,8 @@ O tool `java_module_logs` lê logs do Spring Boot a partir de arquivo local **ou
 - `MCP_LOG_EMAIL_SERVICE_PATH` (default `http://191.252.120.96:8086/ops-email-gateway-7xk9/email-service-audit-log`);
 - `MCP_LOG_LEAD_PORTAL_PAYMENT_PATH` (default `http://191.252.102.54:8092/api/v1/logs/runtime?lines=200`);
 - `MCP_LOG_MDS_PATH` (default `http://177.153.62.107:8091/actuator/logfile`);
-- `MCP_LOG_MOIS_PATH` (MOIS Sales Library Worker; default `http://191.252.120.96:8097/actuator/logfile`);
+- `MCP_LOG_MOIS_PATH` (default `http://191.252.120.96:8097/actuator/logfile`);
+- `MCP_LOG_MOIS_SALES_LIBRARY_WORKER_PATH` (MOIS Sales Library Worker; default `http://191.252.120.96:8097/actuator/logfile`);
 - `MCP_LOG_MOIS_HOTMART_PATH` (default `http://177.153.62.107:8096/ops-monitor/mois-hotmart-log`);
 - `MCP_LOG_CLICKBANK_COLETOR_MOIS_PATH` (default `http://177.153.62.107:9096/internal/ops-monitor/logfile`);
 - `MCP_LOG_OPRM_COLETOR_RECEITA_PATH` (default `http://177.153.62.107:8094/actuator/logfile`).

--- a/mcp-server/src/main/java/com/marketinghub/mcpserver/config/McpProperties.java
+++ b/mcp-server/src/main/java/com/marketinghub/mcpserver/config/McpProperties.java
@@ -1,8 +1,8 @@
 package com.marketinghub.mcpserver.config;
 
 import jakarta.validation.Valid;
-import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 import org.springframework.boot.context.properties.ConfigurationProperties;
@@ -10,6 +10,9 @@ import org.springframework.validation.annotation.Validated;
 
 import java.util.List;
 
+/**
+ * Centraliza as propriedades de configuração usadas pelo servidor MCP.
+ */
 @Validated
 @ConfigurationProperties(prefix = "mcp")
 public record McpProperties(
@@ -20,6 +23,9 @@ public record McpProperties(
         @NotNull @Valid Meta meta,
         @NotNull @Valid Github github
 ) {
+    /**
+     * Define os caminhos e limites usados para leitura de logs dos módulos Java.
+     */
     public record Logs(
             @NotBlank String backendPath,
             @NotBlank String aiWorkerPath,
@@ -29,6 +35,7 @@ public record McpProperties(
             @NotBlank String leadPortalPaymentPath,
             @NotBlank String mdsPath,
             @NotBlank String moisPath,
+            @NotBlank String moisSalesLibraryWorkerPath,
             @NotBlank String moisHotmartPath,
             @NotBlank String clickbankColetorMoisPath,
             @NotBlank String oprmColetorReceitaPath,
@@ -40,6 +47,9 @@ public record McpProperties(
     ) {
     }
 
+    /**
+     * Define as credenciais e destinos permitidos para ferramentas Meta.
+     */
     public record Meta(
             boolean enabled,
             @NotBlank String graphBaseUrl,
@@ -50,22 +60,30 @@ public record McpProperties(
     ) {
     }
 
-        public record Github(
+    /**
+     * Define as credenciais e repositório usados pelas ferramentas GitHub Actions.
+     */
+    public record Github(
             boolean enabled,
             @NotBlank String apiBaseUrl,
             String owner,
             String repo,
             String token
     ) {
+        /**
+         * Valida que o owner do GitHub foi configurado quando as ferramentas GitHub estão ativas.
+         */
         @jakarta.validation.constraints.AssertTrue(message = "mcp.github.owner must not be blank when mcp.github.enabled=true")
         private boolean isOwnerValid() {
             return !enabled || (owner != null && !owner.isBlank());
         }
 
+        /**
+         * Valida que o repositório do GitHub foi configurado quando as ferramentas GitHub estão ativas.
+         */
         @jakarta.validation.constraints.AssertTrue(message = "mcp.github.repo must not be blank when mcp.github.enabled=true")
         private boolean isRepoValid() {
             return !enabled || (repo != null && !repo.isBlank());
         }
     }
 }
-

--- a/mcp-server/src/main/java/com/marketinghub/mcpserver/controller/McpController.java
+++ b/mcp-server/src/main/java/com/marketinghub/mcpserver/controller/McpController.java
@@ -22,6 +22,9 @@ import java.util.LinkedHashMap;
 import java.util.Map;
 import java.util.stream.Collectors;
 
+/**
+ * Expõe o endpoint JSON-RPC do MCP e roteia chamadas para ferramentas operacionais.
+ */
 @RestController
 @RequestMapping("/mcp")
 public class McpController {
@@ -33,6 +36,9 @@ public class McpController {
     private static final int DEFAULT_LIMIT = 50;
     private static final int MAX_LIMIT = 200;
     private static final int MAX_QUERY_LIMIT = 500;
+    private static final List<String> JAVA_LOG_MODULES = List.of("backend", "ai-worker", "lead-portal", "facebook-ads",
+            "email-service", "lead-portal-payment", "mds", "mois", "mois-sales-library-worker",
+            "mois-hotmart", "clickbank-coletor-mois", "oprm-coletor-receita");
 
     private final McpProperties properties;
     private final DatabaseDiagnosticsService databaseDiagnosticsService;
@@ -40,6 +46,9 @@ public class McpController {
     private final MetaDiagnosticsService metaDiagnosticsService;
     private final GithubActionsService githubActionsService;
 
+    /**
+     * Inicializa o controller com os serviços responsáveis pelas ferramentas MCP.
+     */
     public McpController(McpProperties properties,
                          DatabaseDiagnosticsService databaseDiagnosticsService,
                          ModuleLogService moduleLogService,
@@ -52,6 +61,9 @@ public class McpController {
         this.githubActionsService = githubActionsService;
     }
 
+    /**
+     * Descreve o endpoint MCP para verificações simples de reachability.
+     */
     @GetMapping(produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<Map<String, Object>> describeEndpoint() {
         return ResponseEntity.ok(Map.of(
@@ -63,6 +75,9 @@ public class McpController {
         ));
     }
 
+    /**
+     * Processa requisições JSON-RPC de inicialização, listagem de tools e execução de tools.
+     */
     @PostMapping(consumes = MediaType.APPLICATION_JSON_VALUE, produces = MediaType.APPLICATION_JSON_VALUE)
     public ResponseEntity<Map<String, Object>> handleRequest(@RequestBody Map<String, Object> request,
                                                              HttpServletRequest httpServletRequest) {
@@ -128,13 +143,12 @@ public class McpController {
                     ),
                     Map.of(
                             "name", "java_module_logs",
-                            "description", "Retorna as últimas linhas de logs do Spring Boot dos módulos Java (backend, ai-worker, lead-portal, facebook-ads, email-service, lead-portal-payment, mds, mois, mois-hotmart, clickbank-coletor-mois, oprm-coletor-receita).",
+                            "description", "Retorna as últimas linhas de logs do Spring Boot dos módulos Java (backend, ai-worker, lead-portal, facebook-ads, email-service, lead-portal-payment, mds, mois, mois-sales-library-worker, mois-hotmart, clickbank-coletor-mois, oprm-coletor-receita).",
                             "inputSchema", Map.of(
                                     "type", "object",
                                     "properties", Map.of(
                                             "module", Map.of("type", "string",
-                                                    "enum", List.of("backend", "ai-worker", "lead-portal", "facebook-ads",
-                                                            "email-service", "lead-portal-payment", "mds", "mois", "mois-hotmart", "clickbank-coletor-mois", "oprm-coletor-receita"),
+                                                    "enum", JAVA_LOG_MODULES,
                                                     "description", "Módulo Java para consultar logs."),
                                             "lines", Map.of("type", "integer", "minimum", 1,
                                                     "maximum", moduleLogService.maxLines(),
@@ -231,6 +245,9 @@ public class McpController {
         };
     }
 
+    /**
+     * Valida o bearer token quando a chave MCP está configurada.
+     */
     private boolean isAuthorized(HttpServletRequest request) {
         if (!StringUtils.hasText(properties.apiKey())) {
             return true;
@@ -242,6 +259,9 @@ public class McpController {
                 && properties.apiKey().equals(authHeader.substring(BEARER_PREFIX.length()));
     }
 
+    /**
+     * Executa a tool solicitada e converte falhas em respostas JSON-RPC.
+     */
     private Map<String, Object> callTool(Object id, Map<String, Object> request) {
         Object paramsObject = request.get("params");
         if (!(paramsObject instanceof Map<?, ?> params)) {
@@ -280,6 +300,9 @@ public class McpController {
         }
     }
 
+    /**
+     * Executa a leitura paginada de uma tabela do banco.
+     */
     private Map<String, Object> callReadTable(Object id, Map<String, Object> arguments) {
         String table = stringArgument(arguments, "table");
 
@@ -300,12 +323,17 @@ public class McpController {
             return successToolResult(id, result,
                     "Read " + result.get("returnedRows") + " rows from table " + table);
         } catch (IllegalArgumentException ex) {
+            logger.warn("MCP db_read_table inválido: requestId={} table={} motivo={}", id, table, ex.getMessage());
             return error(id, -32602, ex.getMessage());
         } catch (Exception ex) {
+            logger.error("Falha ao executar db_read_table: requestId={} table={} limit={} offset={}", id, table, limit, offset, ex);
             return error(id, -32603, "Failed to read table: " + ex.getMessage());
         }
     }
 
+    /**
+     * Executa uma consulta SQL somente leitura com limite controlado.
+     */
     private Map<String, Object> callQueryTool(Object id, Map<String, Object> arguments) {
         String query = stringArgument(arguments, "query");
 
@@ -320,12 +348,17 @@ public class McpController {
             return successToolResult(id, result,
                     "Query executed with " + result.get("returnedRows") + " rows returned");
         } catch (IllegalArgumentException ex) {
+            logger.warn("MCP db_query inválido: requestId={} limit={} motivo={}", id, limit, ex.getMessage());
             return error(id, -32602, ex.getMessage());
         } catch (Exception ex) {
+            logger.error("Falha ao executar db_query: requestId={} limit={}", id, limit, ex);
             return error(id, -32603, "Failed to execute query: " + ex.getMessage());
         }
     }
 
+    /**
+     * Lê logs do módulo Java solicitado com filtros opcionais.
+     */
     private Map<String, Object> callJavaModuleLogsTool(Object id, Map<String, Object> arguments) {
         String module = stringArgument(arguments, "module");
         Integer lines = intArgument(arguments, "lines");
@@ -339,12 +372,18 @@ public class McpController {
             Map<String, Object> result = moduleLogService.readModuleLogs(module, lines, contains, from, to, offset, cursor);
             return successToolResult(id, result, buildJavaModuleLogsText(result));
         } catch (IllegalArgumentException ex) {
+            logger.warn("MCP java_module_logs inválido: requestId={} module={} motivo={}", id, module, ex.getMessage());
             return error(id, -32602, ex.getMessage());
         } catch (Exception ex) {
+            logger.error("Falha ao executar java_module_logs: requestId={} module={} lines={} contains={} from={} to={}",
+                    id, module, lines, contains, from, to, ex);
             return error(id, -32603, "Failed to read module logs: " + ex.getMessage());
         }
     }
 
+    /**
+     * Formata a resposta textual do tool de logs a partir das linhas retornadas.
+     */
     @SuppressWarnings("unchecked")
     private String buildJavaModuleLogsText(Map<String, Object> result) {
         String header = "Read " + result.get("returnedLines") + " log lines from module " + result.get("module");
@@ -358,6 +397,9 @@ public class McpController {
         return header + "\n" + logLines;
     }
 
+    /**
+     * Busca documentação Meta aprovada quando as ferramentas Meta estão ativas.
+     */
     private Map<String, Object> callMetaDocsTool(Object id, Map<String, Object> arguments) {
         String url = stringArgument(arguments, "url");
 
@@ -365,12 +407,17 @@ public class McpController {
             Map<String, Object> result = metaDiagnosticsService.getDocumentationPage(url);
             return successToolResult(id, result, "Fetched Meta docs page");
         } catch (IllegalArgumentException ex) {
+            logger.warn("MCP meta_docs_get inválido: requestId={} url={} motivo={}", id, url, ex.getMessage());
             return error(id, -32602, ex.getMessage());
         } catch (Exception ex) {
+            logger.error("Falha ao executar meta_docs_get: requestId={} url={}", id, url, ex);
             return error(id, -32603, "Failed to fetch Meta docs page: " + ex.getMessage());
         }
     }
 
+    /**
+     * Executa uma chamada GET na Graph API da Meta.
+     */
     @SuppressWarnings("unchecked")
     private Map<String, Object> callMetaGraphGetTool(Object id, Map<String, Object> arguments) {
         String path = stringArgument(arguments, "path");
@@ -386,12 +433,17 @@ public class McpController {
             Map<String, Object> result = metaDiagnosticsService.graphGet(path, query);
             return successToolResult(id, result, "Meta Graph GET executed");
         } catch (IllegalArgumentException ex) {
+            logger.warn("MCP meta_graph_get inválido: requestId={} path={} motivo={}", id, path, ex.getMessage());
             return error(id, -32602, ex.getMessage());
         } catch (Exception ex) {
+            logger.error("Falha ao executar meta_graph_get: requestId={} path={} queryKeys={}", id, path, query.keySet(), ex);
             return error(id, -32603, "Failed to execute Meta Graph GET: " + ex.getMessage());
         }
     }
 
+    /**
+     * Executa debug_token na Graph API da Meta.
+     */
     private Map<String, Object> callMetaGraphDebugTokenTool(Object id, Map<String, Object> arguments) {
         String inputToken = stringArgument(arguments, "input_token");
 
@@ -399,13 +451,18 @@ public class McpController {
             Map<String, Object> result = metaDiagnosticsService.debugToken(inputToken);
             return successToolResult(id, result, "Meta debug_token executed");
         } catch (IllegalArgumentException ex) {
+            logger.warn("MCP meta_graph_debug_token inválido: requestId={} motivo={}", id, ex.getMessage());
             return error(id, -32602, ex.getMessage());
         } catch (Exception ex) {
+            logger.error("Falha ao executar meta_graph_debug_token: requestId={}", id, ex);
             return error(id, -32603, "Failed to execute Meta debug_token: " + ex.getMessage());
         }
     }
 
 
+    /**
+     * Lista workflows do GitHub Actions configurado.
+     */
     private Map<String, Object> callGithubActionsListWorkflows(Object id, Map<String, Object> arguments) {
         Integer perPage = intArgument(arguments, "per_page");
 
@@ -413,12 +470,17 @@ public class McpController {
             Map<String, Object> result = githubActionsService.listWorkflows(perPage);
             return successToolResult(id, result, "GitHub workflows listed");
         } catch (IllegalArgumentException ex) {
+            logger.warn("MCP github_actions_list_workflows inválido: requestId={} perPage={} motivo={}", id, perPage, ex.getMessage());
             return error(id, -32602, ex.getMessage());
         } catch (Exception ex) {
+            logger.error("Falha ao executar github_actions_list_workflows: requestId={} perPage={}", id, perPage, ex);
             return error(id, -32603, "Failed to list GitHub workflows: " + ex.getMessage());
         }
     }
 
+    /**
+     * Lista execuções do GitHub Actions com filtros opcionais.
+     */
     private Map<String, Object> callGithubActionsListRuns(Object id, Map<String, Object> arguments) {
         String branch = stringArgument(arguments, "branch");
         String status = stringArgument(arguments, "status");
@@ -428,13 +490,18 @@ public class McpController {
             Map<String, Object> result = githubActionsService.listRuns(branch, status, perPage);
             return successToolResult(id, result, "GitHub workflow runs listed");
         } catch (IllegalArgumentException ex) {
+            logger.warn("MCP github_actions_list_runs inválido: requestId={} branch={} status={} perPage={} motivo={}", id, branch, status, perPage, ex.getMessage());
             return error(id, -32602, ex.getMessage());
         } catch (Exception ex) {
+            logger.error("Falha ao executar github_actions_list_runs: requestId={} branch={} status={} perPage={}", id, branch, status, perPage, ex);
             return error(id, -32603, "Failed to list GitHub workflow runs: " + ex.getMessage());
         }
     }
 
 
+    /**
+     * Retorna o resumo operacional de uma execução do GitHub Actions.
+     */
     private Map<String, Object> callGithubActionsGetRunSummary(Object id, Map<String, Object> arguments) {
         Integer runIdArg = intArgument(arguments, "run_id");
         Long runId = runIdArg == null ? null : runIdArg.longValue();
@@ -444,14 +511,19 @@ public class McpController {
             return successToolResult(id, result,
                     Boolean.TRUE.equals(result.get("failed")) ? "Workflow run FAILED" : "Workflow run status fetched");
         } catch (IllegalArgumentException ex) {
+            logger.warn("MCP github_actions_get_run_summary inválido: requestId={} runId={} motivo={}", id, runId, ex.getMessage());
             return error(id, -32602, ex.getMessage());
         } catch (Exception ex) {
+            logger.error("Falha ao executar github_actions_get_run_summary: requestId={} runId={}", id, runId, ex);
             return error(id, -32603, "Failed to fetch workflow run summary: " + ex.getMessage());
         }
     }
 
 
 
+    /**
+     * Retorna um trecho dos logs de uma execução do GitHub Actions.
+     */
     private Map<String, Object> callGithubActionsGetRunLogs(Object id, Map<String, Object> arguments) {
         Integer runIdArg = intArgument(arguments, "run_id");
         Long runId = runIdArg == null ? null : runIdArg.longValue();
@@ -460,12 +532,17 @@ public class McpController {
             Map<String, Object> result = githubActionsService.getRunLogs(runId);
             return successToolResult(id, result, "GitHub workflow run logs fetched");
         } catch (IllegalArgumentException ex) {
+            logger.warn("MCP github_actions_get_run_logs inválido: requestId={} runId={} motivo={}", id, runId, ex.getMessage());
             return error(id, -32602, ex.getMessage());
         } catch (Exception ex) {
+            logger.error("Falha ao executar github_actions_get_run_logs: requestId={} runId={}", id, runId, ex);
             return error(id, -32603, "Failed to fetch workflow run logs: " + ex.getMessage());
         }
     }
 
+    /**
+     * Extrai e valida o objeto de argumentos enviado em tools/call.
+     */
     private Map<String, Object> extractArguments(Map<?, ?> params) {
         Object argumentsObject = params.get("arguments");
         if (argumentsObject == null) {
@@ -482,11 +559,17 @@ public class McpController {
                         Map.Entry::getValue));
     }
 
+    /**
+     * Lê um argumento textual opcional removendo espaços excedentes.
+     */
     private String stringArgument(Map<String, Object> arguments, String name) {
         Object value = arguments.get(name);
         return value == null ? null : String.valueOf(value);
     }
 
+    /**
+     * Lê um argumento inteiro aceitando números ou strings numéricas.
+     */
     private Integer intArgument(Map<String, Object> arguments, String name) {
         Object value = arguments.get(name);
         if (value == null) {
@@ -500,10 +583,14 @@ public class McpController {
         try {
             return Integer.parseInt(String.valueOf(value));
         } catch (NumberFormatException ex) {
+            logger.warn("MCP intArgument inválido: name={} value={}", name, value, ex);
             throw new IllegalArgumentException(name + " must be an integer");
         }
     }
 
+    /**
+     * Lê um argumento de mapa opcional usado por tools com query params.
+     */
     @SuppressWarnings("unchecked")
     private Map<String, Object> mapArgument(Map<String, Object> arguments, String name) {
         Object value = arguments.get(name);
@@ -516,6 +603,9 @@ public class McpController {
         throw new IllegalArgumentException(name + " must be an object");
     }
 
+    /**
+     * Monta uma resposta JSON-RPC de sucesso para tools com conteúdo textual e estruturado.
+     */
     private Map<String, Object> successToolResult(Object id, Map<String, Object> data, String text) {
         return success(id, Map.of(
                 "content", List.of(Map.of(
@@ -525,6 +615,9 @@ public class McpController {
         ));
     }
 
+    /**
+     * Monta uma resposta JSON-RPC de sucesso genérica.
+     */
     private Map<String, Object> success(Object id, Map<String, Object> result) {
         Map<String, Object> response = new LinkedHashMap<>();
         response.put("jsonrpc", "2.0");
@@ -533,6 +626,9 @@ public class McpController {
         return response;
     }
 
+    /**
+     * Monta uma resposta JSON-RPC de erro preservando o id da requisição.
+     */
     private Map<String, Object> error(Object id, int code, String message) {
         Map<String, Object> errorPayload = new LinkedHashMap<>();
         errorPayload.put("code", code);

--- a/mcp-server/src/main/java/com/marketinghub/mcpserver/service/ModuleLogService.java
+++ b/mcp-server/src/main/java/com/marketinghub/mcpserver/service/ModuleLogService.java
@@ -1,6 +1,8 @@
 package com.marketinghub.mcpserver.service;
 
 import com.marketinghub.mcpserver.config.McpProperties;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
 
@@ -22,8 +24,12 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Stream;
 
+/**
+ * Lê e filtra logs operacionais dos módulos Java expostos ao MCP.
+ */
 @Service
 public class ModuleLogService {
+    private static final Logger logger = LoggerFactory.getLogger(ModuleLogService.class);
     private static final int DEFAULT_LINES = 200;
     private final McpProperties properties;
     private final HttpClient httpClient;
@@ -32,6 +38,9 @@ public class ModuleLogService {
     private final int fetchAttempts;
     private final int fetchRetryDelayMillis;
 
+    /**
+     * Inicializa o leitor de logs com timeouts e limites definidos em configuração.
+     */
     public ModuleLogService(McpProperties properties) {
         this.properties = properties;
         this.logFetchTimeout = Duration.ofSeconds(properties.logs().fetchTimeoutSeconds());
@@ -41,8 +50,14 @@ public class ModuleLogService {
         this.httpClient = HttpClient.newBuilder().connectTimeout(logFetchTimeout).build();
     }
 
+    /**
+     * Retorna o limite máximo de linhas permitido por chamada do tool de logs.
+     */
     public int maxLines() { return properties.logs().maxLines(); }
 
+    /**
+     * Lê os logs do módulo solicitado aplicando filtros de texto, período e paginação.
+     */
     public Map<String, Object> readModuleLogs(String module, Integer requestedLines, String contains, String from, String to, Integer offset, String cursor) {
         String normalizedModule = normalizeModule(module);
         int lines = sanitizeLines(requestedLines);
@@ -62,10 +77,14 @@ public class ModuleLogService {
         try (Stream<String> stream = Files.lines(path, StandardCharsets.UTF_8)) {
             return buildFilteredResponse(stream.toList(), lines, contains, from, to, offset, cursor, response, Files.size(path));
         } catch (IOException ex) {
+            logger.error("mcp-server readModuleLogs failed to read local log file for module={} path={}", normalizedModule, path, ex);
             throw new IllegalArgumentException("Failed to read log file: " + ex.getMessage());
         }
     }
 
+    /**
+     * Busca logs em uma URL HTTP/HTTPS e monta a resposta filtrada.
+     */
     private Map<String, Object> readLogsFromUrl(String configuredUrl, int lines, String contains, String from, String to, Integer offset, String cursor, Map<String, Object> response) {
         response.put("path", configuredUrl); response.put("source", "http");
         HttpRequest request = buildTailRequest(configuredUrl, true);
@@ -82,10 +101,14 @@ public class ModuleLogService {
             return buildFilteredResponse(httpResponse.body().lines().toList(), lines, contains, from, to, offset, cursor, response, null);
         } catch (IOException | InterruptedException ex) {
             if (ex instanceof InterruptedException) Thread.currentThread().interrupt();
+            logger.error("mcp-server readLogsFromUrl failed to read log stream url={} attempts={}", configuredUrl, errors, ex);
             throw new IllegalArgumentException("Failed to read log stream URL: " + ex.getMessage());
         }
     }
 
+    /**
+     * Constrói a resposta final após aplicar filtros e resolver a janela de paginação.
+     */
     private Map<String, Object> buildFilteredResponse(List<String> allLines, int lines, String contains, String from, String to, Integer offset, String cursor, Map<String, Object> response, Long sizeBytes) {
         List<String> filtered = applyFilters(allLines, contains, from, to);
         boolean defaultTailMode = !StringUtils.hasText(contains) && !StringUtils.hasText(from) && !StringUtils.hasText(to) && offset == null && !StringUtils.hasText(cursor);
@@ -102,6 +125,9 @@ public class ModuleLogService {
         return response;
     }
 
+    /**
+     * Aplica filtros opcionais por texto literal e intervalo ISO-8601.
+     */
     private List<String> applyFilters(List<String> lines, String contains, String from, String to) {
         Instant fromTs = parseInstant(from, "from"); Instant toTs = parseInstant(to, "to");
         return lines.stream().filter(line -> {
@@ -114,22 +140,37 @@ public class ModuleLogService {
         }).toList();
     }
 
+    /**
+     * Resolve o deslocamento de paginação a partir de offset explícito ou cursor.
+     */
     private int resolveOffset(Integer offset, String cursor) {
         if (StringUtils.hasText(cursor)) {
             try {
                 String decoded = new String(Base64.getDecoder().decode(cursor), StandardCharsets.UTF_8);
                 if (!decoded.startsWith("offset:")) throw new IllegalArgumentException("invalid cursor");
                 return Integer.parseInt(decoded.substring(7));
-            } catch (Exception ex) { throw new IllegalArgumentException("invalid cursor"); }
+            } catch (Exception ex) {
+                logger.error("mcp-server resolveOffset failed to decode pagination cursor={}", cursor, ex);
+                throw new IllegalArgumentException("invalid cursor");
+            }
         }
         return offset == null ? 0 : offset;
     }
 
+    /**
+     * Converte uma string ISO-8601 para Instant validando o nome do campo informado.
+     */
     private Instant parseInstant(String value, String fieldName) {
         if (!StringUtils.hasText(value)) return null;
-        try { return Instant.parse(value); } catch (DateTimeParseException ex) { throw new IllegalArgumentException(fieldName + " must be in ISO-8601 UTC format, e.g. 2026-05-21T04:35:00Z"); }
+        try { return Instant.parse(value); } catch (DateTimeParseException ex) {
+            logger.error("mcp-server parseInstant failed for field={} value={}", fieldName, value, ex);
+            throw new IllegalArgumentException(fieldName + " must be in ISO-8601 UTC format, e.g. 2026-05-21T04:35:00Z");
+        }
     }
 
+    /**
+     * Extrai o primeiro timestamp ISO-8601 encontrado em uma linha de log.
+     */
     private Instant extractFirstInstant(String line) {
         for (String token : line.split("[\\s\\[\\]]+")) {
             try { return Instant.parse(token); } catch (DateTimeParseException ignored) { }
@@ -137,33 +178,113 @@ public class ModuleLogService {
         return null;
     }
 
-    private HttpResponse<String> sendWithRetry(HttpRequest request, List<String> errors) throws IOException, InterruptedException { /* unchanged logic */
-        IOException lastIo = null; InterruptedException lastInterrupt = null;
+    /**
+     * Executa a requisição HTTP de logs com retentativas configuradas.
+     */
+    private HttpResponse<String> sendWithRetry(HttpRequest request, List<String> errors)
+            throws IOException, InterruptedException {
+        IOException lastIo = null;
+        InterruptedException lastInterrupt = null;
         for (int attempt = 1; attempt <= fetchAttempts; attempt++) {
             try {
-                HttpResponse<String> response = httpClient.send(request, HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8));
+                HttpResponse<String> response = httpClient.send(request,
+                        HttpResponse.BodyHandlers.ofString(StandardCharsets.UTF_8));
                 errors.add("attempt " + attempt + " status " + response.statusCode());
-                if (response.statusCode() >= 500 || response.statusCode() == 429) { if (attempt < fetchAttempts) { Thread.sleep(fetchRetryDelayMillis); continue; } }
+                if ((response.statusCode() >= 500 || response.statusCode() == 429) && attempt < fetchAttempts) {
+                    Thread.sleep(fetchRetryDelayMillis);
+                    continue;
+                }
                 return response;
-            } catch (IOException ex) { lastIo = ex; errors.add("attempt " + attempt + " io-error: " + ex.getClass().getSimpleName() + " - " + ex.getMessage()); }
-            catch (InterruptedException ex) { lastInterrupt = ex; errors.add("attempt " + attempt + " interrupted: " + ex.getMessage()); break; }
-            if (attempt < fetchAttempts) Thread.sleep(fetchRetryDelayMillis);
+            } catch (IOException ex) {
+                lastIo = ex;
+                errors.add("attempt " + attempt + " io-error: " + ex.getClass().getSimpleName() + " - "
+                        + ex.getMessage());
+                logger.error("mcp-server sendWithRetry failed attempt={} uri={}", attempt, request.uri(), ex);
+            } catch (InterruptedException ex) {
+                lastInterrupt = ex;
+                errors.add("attempt " + attempt + " interrupted: " + ex.getMessage());
+                logger.error("mcp-server sendWithRetry interrupted attempt={} uri={}", attempt, request.uri(), ex);
+                break;
+            }
+            if (attempt < fetchAttempts) {
+                Thread.sleep(fetchRetryDelayMillis);
+            }
         }
-        if (lastInterrupt != null) throw lastInterrupt; if (lastIo != null) throw lastIo; throw new IOException("Failed to read log stream URL after retries");
+        if (lastInterrupt != null) {
+            throw lastInterrupt;
+        }
+        if (lastIo != null) {
+            throw lastIo;
+        }
+        throw new IOException("Failed to read log stream URL after retries");
     }
 
+    /**
+     * Monta a requisição HTTP para leitura completa ou parcial do arquivo de logs.
+     */
     private HttpRequest buildTailRequest(String configuredUrl, boolean withRange) {
         HttpRequest.Builder builder = HttpRequest.newBuilder(URI.create(configuredUrl)).timeout(logFetchTimeout).GET();
-        if (withRange) builder.header("Range", "bytes=-" + httpTailRangeBytes);
+        if (withRange) {
+            builder.header("Range", "bytes=-" + httpTailRangeBytes);
+        }
         return builder.build();
     }
-    private boolean isHttpUrl(String value) { String normalized = value.trim().toLowerCase(); return normalized.startsWith("http://") || normalized.startsWith("https://"); }
-    private String modulePath(String module) { return switch (module) {
-        case "backend" -> properties.logs().backendPath(); case "ai-worker" -> properties.logs().aiWorkerPath(); case "lead-portal" -> properties.logs().leadPortalPath(); case "facebook-ads" -> properties.logs().facebookAdsPath(); case "email-service" -> properties.logs().emailServicePath(); case "lead-portal-payment" -> properties.logs().leadPortalPaymentPath(); case "mds" -> properties.logs().mdsPath(); case "mois" -> properties.logs().moisPath(); case "mois-hotmart" -> properties.logs().moisHotmartPath(); case "clickbank-coletor-mois" -> properties.logs().clickbankColetorMoisPath(); case "oprm-coletor-receita" -> properties.logs().oprmColetorReceitaPath(); default -> throw new IllegalArgumentException("Unknown module: " + module); }; }
-    private String normalizeModule(String module) {
-        if (!StringUtils.hasText(module)) throw new IllegalArgumentException("module is required");
-        String normalized = module.trim().toLowerCase();
-        return switch (normalized) { case "backend", "ai-worker", "lead-portal", "facebook-ads", "email-service", "lead-portal-payment", "mds", "mois", "mois-hotmart", "clickbank-coletor-mois", "oprm-coletor-receita" -> normalized; default -> throw new IllegalArgumentException("module must be one of: backend, ai-worker, lead-portal, facebook-ads, email-service, lead-portal-payment, mds, mois, mois-hotmart, clickbank-coletor-mois, oprm-coletor-receita"); };
+
+    /**
+     * Indica se o caminho configurado é uma URL HTTP/HTTPS.
+     */
+    private boolean isHttpUrl(String value) {
+        String normalized = value.trim().toLowerCase();
+        return normalized.startsWith("http://") || normalized.startsWith("https://");
     }
-    private int sanitizeLines(Integer requestedLines) { int lines = requestedLines == null ? DEFAULT_LINES : requestedLines; if (lines < 1 || lines > maxLines()) throw new IllegalArgumentException("lines must be between 1 and " + maxLines()); return lines; }
+
+    /**
+     * Resolve o caminho de logs configurado para o módulo normalizado.
+     */
+    private String modulePath(String module) {
+        return switch (module) {
+            case "backend" -> properties.logs().backendPath();
+            case "ai-worker" -> properties.logs().aiWorkerPath();
+            case "lead-portal" -> properties.logs().leadPortalPath();
+            case "facebook-ads" -> properties.logs().facebookAdsPath();
+            case "email-service" -> properties.logs().emailServicePath();
+            case "lead-portal-payment" -> properties.logs().leadPortalPaymentPath();
+            case "mds" -> properties.logs().mdsPath();
+            case "mois" -> properties.logs().moisPath();
+            case "mois-sales-library-worker" -> properties.logs().moisSalesLibraryWorkerPath();
+            case "mois-hotmart" -> properties.logs().moisHotmartPath();
+            case "clickbank-coletor-mois" -> properties.logs().clickbankColetorMoisPath();
+            case "oprm-coletor-receita" -> properties.logs().oprmColetorReceitaPath();
+            default -> throw new IllegalArgumentException("Unknown module: " + module);
+        };
+    }
+
+    /**
+     * Normaliza e valida o identificador do módulo solicitado pelo tool MCP.
+     */
+    private String normalizeModule(String module) {
+        if (!StringUtils.hasText(module)) {
+            throw new IllegalArgumentException("module is required");
+        }
+        String normalized = module.trim().toLowerCase();
+        return switch (normalized) {
+            case "backend", "ai-worker", "lead-portal", "facebook-ads", "email-service", "lead-portal-payment",
+                    "mds", "mois", "mois-sales-library-worker", "mois-hotmart", "clickbank-coletor-mois",
+                    "oprm-coletor-receita" -> normalized;
+            default -> throw new IllegalArgumentException("module must be one of: backend, ai-worker, lead-portal, "
+                    + "facebook-ads, email-service, lead-portal-payment, mds, mois, mois-sales-library-worker, "
+                    + "mois-hotmart, clickbank-coletor-mois, oprm-coletor-receita");
+        };
+    }
+
+    /**
+     * Valida a quantidade de linhas solicitada contra os limites configurados.
+     */
+    private int sanitizeLines(Integer requestedLines) {
+        int lines = requestedLines == null ? DEFAULT_LINES : requestedLines;
+        if (lines < 1 || lines > maxLines()) {
+            throw new IllegalArgumentException("lines must be between 1 and " + maxLines());
+        }
+        return lines;
+    }
 }

--- a/mcp-server/src/main/resources/application.yml
+++ b/mcp-server/src/main/resources/application.yml
@@ -50,6 +50,7 @@ mcp:
     lead-portal-payment-path: ${MCP_LOG_LEAD_PORTAL_PAYMENT_PATH:http://191.252.102.54:8092/api/v1/logs/runtime?lines=200}
     mds-path: ${MCP_LOG_MDS_PATH:http://177.153.62.107:8091/actuator/logfile}
     mois-path: ${MCP_LOG_MOIS_PATH:http://191.252.120.96:8097/actuator/logfile}
+    mois-sales-library-worker-path: ${MCP_LOG_MOIS_SALES_LIBRARY_WORKER_PATH:http://191.252.120.96:8097/actuator/logfile}
     mois-hotmart-path: ${MCP_LOG_MOIS_HOTMART_PATH:http://177.153.62.107:8096/ops-monitor/mois-hotmart-log}
     clickbank-coletor-mois-path: ${MCP_LOG_CLICKBANK_COLETOR_MOIS_PATH:http://177.153.62.107:9096/internal/ops-monitor/logfile}
     oprm-coletor-receita-path: ${MCP_LOG_OPRM_COLETOR_RECEITA_PATH:http://177.153.62.107:8094/actuator/logfile}

--- a/mcp-server/src/test/java/com/marketinghub/mcpserver/controller/McpControllerTest.java
+++ b/mcp-server/src/test/java/com/marketinghub/mcpserver/controller/McpControllerTest.java
@@ -47,6 +47,8 @@ class McpControllerTest {
                 () -> TEST_LOG_DIR.resolve("lead-portal-payment.log").toString());
         registry.add("mcp.logs.mds-path", () -> TEST_LOG_DIR.resolve("mds.log").toString());
         registry.add("mcp.logs.mois-path", () -> TEST_LOG_DIR.resolve("mois.log").toString());
+        registry.add("mcp.logs.mois-sales-library-worker-path",
+                () -> TEST_LOG_DIR.resolve("mois-sales-library-worker.log").toString());
         registry.add("mcp.logs.mois-hotmart-path", () -> TEST_LOG_DIR.resolve("mois-hotmart.log").toString());
         registry.add("mcp.logs.oprm-coletor-receita-path", () -> TEST_LOG_DIR.resolve("oprm-coletor-receita.log").toString());
         registry.add("mcp.logs.max-lines", () -> "500");
@@ -70,6 +72,9 @@ class McpControllerTest {
         Files.createDirectories(TEST_LOG_DIR);
         Files.writeString(TEST_LOG_DIR.resolve("backend.log"),
                 "line-1\nline-2\nline-3\n",
+                StandardCharsets.UTF_8);
+        Files.writeString(TEST_LOG_DIR.resolve("mois-sales-library-worker.log"),
+                "mois-sales-library-worker-line-1\nmois-sales-library-worker-line-2\n",
                 StandardCharsets.UTF_8);
     }
 
@@ -180,6 +185,21 @@ class McpControllerTest {
     }
 
     @Test
+    void shouldReadMoisSalesLibraryWorkerLogs() throws Exception {
+        mockMvc.perform(post("/mcp")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"jsonrpc":"2.0","id":16,"method":"tools/call","params":{"name":"java_module_logs","arguments":{"module":"mois-sales-library-worker","lines":1}}}
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result.structuredContent.module").value("mois-sales-library-worker"))
+                .andExpect(jsonPath("$.result.structuredContent.path")
+                        .value(TEST_LOG_DIR.resolve("mois-sales-library-worker.log").toString()))
+                .andExpect(jsonPath("$.result.structuredContent.lines[0]")
+                        .value("mois-sales-library-worker-line-2"));
+    }
+
+    @Test
     void shouldRejectInvalidJavaModuleName() throws Exception {
         mockMvc.perform(post("/mcp")
                         .contentType(MediaType.APPLICATION_JSON)
@@ -189,7 +209,7 @@ class McpControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.error.code").value(-32602))
                 .andExpect(jsonPath("$.error.message")
-                        .value("module must be one of: backend, ai-worker, lead-portal, facebook-ads, email-service, lead-portal-payment, mds, mois, mois-hotmart, clickbank-coletor-mois, oprm-coletor-receita"));
+                        .value("module must be one of: backend, ai-worker, lead-portal, facebook-ads, email-service, lead-portal-payment, mds, mois, mois-sales-library-worker, mois-hotmart, clickbank-coletor-mois, oprm-coletor-receita"));
     }
 
 
@@ -283,6 +303,8 @@ class McpControllerApiKeyEnabledTest {
                 () -> TEST_LOG_DIR.resolve("lead-portal-payment.log").toString());
         registry.add("mcp.logs.mds-path", () -> TEST_LOG_DIR.resolve("mds.log").toString());
         registry.add("mcp.logs.mois-path", () -> TEST_LOG_DIR.resolve("mois.log").toString());
+        registry.add("mcp.logs.mois-sales-library-worker-path",
+                () -> TEST_LOG_DIR.resolve("mois-sales-library-worker.log").toString());
         registry.add("mcp.logs.mois-hotmart-path", () -> TEST_LOG_DIR.resolve("mois-hotmart.log").toString());
         registry.add("mcp.logs.oprm-coletor-receita-path", () -> TEST_LOG_DIR.resolve("oprm-coletor-receita.log").toString());
         registry.add("mcp.logs.max-lines", () -> "500");


### PR DESCRIPTION
### Motivation
- Expose the MOIS Sales Library Worker logs to the MCP `java_module_logs` tool so operators can inspect the worker's Spring Boot `logfile` at `http://191.252.120.96:8097/actuator/logfile`.
- Provide a dedicated, configurable path for the `mois-sales-library-worker` so its logs can be managed independently from the existing `mois` entry.
- Improve observability and diagnostic messages in the MCP server when reading remote/local module logs.

### Description
- Added new configuration property `mcp.logs.mois-sales-library-worker-path` in `mcp-server/src/main/resources/application.yml` and expanded `McpProperties.Logs` to include `moisSalesLibraryWorkerPath`.
- Updated `ModuleLogService` to resolve `mois-sales-library-worker` in `modulePath`/`normalizeModule`, added structured logging and improved HTTP retry/error handling for remote logfile fetches, and added JavaDoc comments for key methods.
- Updated `McpController` to include `mois-sales-library-worker` in the accepted `java_module_logs` schema, added related logging, and introduced `JAVA_LOG_MODULES` constant used by the tool schema.
- Updated documentation and operational references in `mcp-server/README.md`, `mcp-server/AGENTS.md`, top-level `AGENTS.md`, and added a registry entry in `docs/registros/mois1.md` describing the change.
- Added test coverage in `mcp-server/src/test/java/com/marketinghub/mcpserver/controller/McpControllerTest.java` to assert reading logs for `mois-sales-library-worker` and updated test properties to provide a test logfile.

### Testing
- Ran repository checks and assertions including `git diff --check` and a Python assertion verifying the new `application.yml` entry for `mois-sales-library-worker-path`, both succeeded.
- Attempted to run `mvn -s settings.xml test` but the run failed due to inability to download the Spring Boot parent POM from Maven Central (`Network is unreachable`).
- Attempted `mvn -o -s settings.xml test` in offline mode but it failed because the Spring Boot parent artifact is not present in the local Maven cache.
- Performed an HTTP probe `curl -I http://191.252.120.96:8097/actuator/logfile` which returned `HTTP/1.1 503 Service Unavailable` at the time of verification, and the new unit test was added but not executed due to the Maven parent resolution issue.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a23af86c0508321928a480bfaad4df7)