### PR TITLE
Fix MCP logs test properties

### DIFF
--- a/mcp-server/src/test/java/com/marketinghub/mcpserver/service/MetaToolsServiceTest.java
+++ b/mcp-server/src/test/java/com/marketinghub/mcpserver/service/MetaToolsServiceTest.java
@@ -18,11 +18,17 @@ import static org.springframework.test.web.client.match.MockRestRequestMatchers.
 import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
 import static org.springframework.http.HttpMethod.GET;
 
+/**
+ * Valida as integrações auxiliares da Meta expostas pelo servidor MCP.
+ */
 class MetaToolsServiceTest {
 
     private MetaToolsService service;
     private MockRestServiceServer server;
 
+    /**
+     * Prepara o serviço da Meta com dependências mockadas para cada teste.
+     */
     @BeforeEach
     void setUp() {
         RestTemplate restTemplate = new RestTemplate();
@@ -32,7 +38,7 @@ class MetaToolsServiceTest {
                 "marketing-hub-mcp",
                 "1.0.0",
                 null,
-                new McpProperties.Logs("a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", 45, 3, 400, 500, 262144),
+                new McpProperties.Logs("a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", 45, 3, 400, 500, 262144),
                 new McpProperties.Meta(
                         true,
                         "https://graph.facebook.com",
@@ -52,6 +58,9 @@ class MetaToolsServiceTest {
         service = new MetaToolsService(properties, restTemplate, new ObjectMapper());
     }
 
+    /**
+     * Garante que a documentação da Meta seja carregada apenas de host permitido.
+     */
     @Test
     void shouldFetchMetaDocumentationFromAllowedHost() {
         server.expect(requestTo("https://developers.facebook.com/docs/marketing-apis/"))
@@ -66,6 +75,9 @@ class MetaToolsServiceTest {
         server.verify();
     }
 
+    /**
+     * Garante rejeição de URLs de documentação fora da lista permitida.
+     */
     @Test
     void shouldRejectDocumentationHostOutsideAllowlist() {
         assertThatThrownBy(() -> service.getDocumentationPage("https://example.org/meta-docs"))
@@ -73,6 +85,9 @@ class MetaToolsServiceTest {
                 .hasMessage("host not allowed for meta_docs_get: example.org");
     }
 
+    /**
+     * Garante mascaramento do token de acesso nos metadados da resposta Graph.
+     */
     @Test
     void shouldMaskAccessTokenOnGraphResponseMetadata() {
         server.expect(requestTo("https://graph.facebook.com/v22.0/me?fields=id,name&access_token=system-token"))

--- a/mcp-server/src/test/java/com/marketinghub/mcpserver/service/ModuleLogServiceTest.java
+++ b/mcp-server/src/test/java/com/marketinghub/mcpserver/service/ModuleLogServiceTest.java
@@ -14,10 +14,16 @@ import java.util.concurrent.atomic.AtomicInteger;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+/**
+ * Valida a leitura resiliente de logs dos módulos Java pelo servidor MCP.
+ */
 class ModuleLogServiceTest {
 
     private HttpServer server;
 
+    /**
+     * Encerra o servidor HTTP local usado pelos testes.
+     */
     @AfterEach
     void tearDown() {
         if (server != null) {
@@ -25,6 +31,9 @@ class ModuleLogServiceTest {
         }
     }
 
+    /**
+     * Garante retentativas em falha temporária e retorno apenas das últimas linhas solicitadas.
+     */
     @Test
     void shouldRetryWhenEndpointFailsAndReturnTailLines() throws Exception {
         AtomicInteger calls = new AtomicInteger(0);
@@ -54,8 +63,12 @@ class ModuleLogServiceTest {
         assertEquals(List.of("line-2", "line-3"), result.get("lines"));
     }
 
+    /**
+     * Monta propriedades MCP apontando todos os módulos para a URL local informada.
+     */
     private McpProperties buildProperties(String logUrl) {
         McpProperties.Logs logs = new McpProperties.Logs(
+                logUrl,
                 logUrl,
                 logUrl,
                 logUrl,


### PR DESCRIPTION
### Motivation
- The record `McpProperties.Logs` signature was extended with a new `oprmColetorReceitaPath` parameter, causing test constructors to no longer match and breaking `testCompile`.
- The repository enforces Java responsibility comments for changed classes/methods, so tests needed documentation updates to comply.

### Description
- Updated `mcp-server/src/test/java/com/marketinghub/mcpserver/service/MetaToolsServiceTest.java` to pass the additional string argument to `new McpProperties.Logs(...)` and added class/method responsibility comments.
- Updated `mcp-server/src/test/java/com/marketinghub/mcpserver/service/ModuleLogServiceTest.java` to include the extra log URL for all modules when constructing `new McpProperties.Logs(...)` and added class/method responsibility comments.
- Changes are limited to test files and do not modify production code or public APIs.

### Testing
- Ran `mvn test` in the `mcp-server` module and observed `BUILD SUCCESS` with `Tests run: 24, Failures: 0, Errors: 0, Skipped: 0`.
- The earlier compilation error from `maven-compiler-plugin` caused by the missing constructor argument was resolved by aligning the test instantiations with the updated `McpProperties.Logs` signature.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a23b48663688321b92d3336cde161aa)