### PR TITLE
Melhora hierarquia visual das etapas do pipeline

### DIFF
--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -3796,3 +3796,14 @@
 - solicitação: ajustar a confirmação da nova publicação de campanha para que o Facebook Ads Worker informe sucesso completo ao backend e o backend atualize o status da campanha.
 - correção aplicada: o worker passou a enviar `status=ACTIVE` no `POST /api/facebook-campaigns` somente após criar campanha, ad set, criativo e anúncio com sucesso; o backend passou a persistir esse status na tabela `facebook_ads_campaign`, inclusive em retry idempotente do mesmo `campaignId`.
 - documentação sincronizada: atualizado o cânone de publicação de campanha, Swagger do contrato Facebook Ads e documentação operacional do `facebook-ads-worker`.
+
+## 2026-06-06 — Hierarquia visual da tela de etapas do pipeline
+
+- solicitação: reduzir a confusão visual da tela `/pipelines` ao abrir as etapas de um pipeline, criando hierarquia de informação por cores, tamanhos de letra e organização dos blocos.
+- causa-raiz: a tela usava cartões Bootstrap genéricos com pouco contraste entre identificação do pipeline, diagnóstico do contrato, objetivo da etapa e metadados técnicos, exigindo esforço do usuário para entender a prioridade operacional.
+- correção aplicada: a tela de etapas passou a ter painel de contexto do pipeline com destaque visual, bloco de contrato operacional com status e contadores em hierarquia própria, grade de cards responsiva com número grande da etapa, cores por cartão, objetivo destacado e metadados técnicos separados em blocos menores.
+- validação visual: foi gerado screenshot local com Playwright e APIs mockadas para confirmar a renderização da nova hierarquia sem depender do backend remoto.
+- arquivos alterados:
+  - `frontend/src/pages/pipeline/PipelineCrudPage.tsx`
+  - `frontend/src/pages/pipeline/PipelineCrudPage.css`
+  - `docs/registros/experimentos.md`

--- a/frontend/src/pages/pipeline/PipelineCrudPage.css
+++ b/frontend/src/pages/pipeline/PipelineCrudPage.css
@@ -1,0 +1,333 @@
+.pipeline-stage-page {
+  --pipeline-blue: #2f5bea;
+  --pipeline-indigo: #4f46e5;
+  --pipeline-green: #138a52;
+  --pipeline-amber: #b7791f;
+  --pipeline-ink: #172033;
+  --pipeline-muted: #667085;
+  --pipeline-soft-blue: #eef4ff;
+  --pipeline-soft-green: #e9f8f0;
+  --pipeline-soft-amber: #fff7e6;
+  color: var(--pipeline-ink);
+}
+
+.pipeline-stage-toolbar,
+.pipeline-section-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 1rem;
+  margin-bottom: 1.5rem;
+}
+
+.pipeline-stage-subtitle {
+  max-width: 760px;
+  color: var(--pipeline-muted);
+  font-size: 1rem;
+  line-height: 1.55;
+}
+
+.pipeline-stage-back-button {
+  background: var(--bs-body-bg, #fff);
+  font-weight: 600;
+}
+
+.pipeline-overview-card {
+  overflow: hidden;
+  border: 1px solid rgba(47, 91, 234, 0.22);
+  border-radius: 1.1rem;
+  background: linear-gradient(
+    135deg,
+    #ffffff 0%,
+    var(--pipeline-soft-blue) 100%
+  );
+  box-shadow: 0 18px 42px -32px rgba(47, 91, 234, 0.65);
+}
+
+.pipeline-overview-body {
+  position: relative;
+  padding: 1.35rem 1.5rem 1.35rem 1.75rem;
+}
+
+.pipeline-overview-body::before {
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 0.45rem;
+  content: "";
+  background: linear-gradient(
+    180deg,
+    var(--pipeline-blue),
+    var(--pipeline-indigo)
+  );
+}
+
+.pipeline-eyebrow,
+.pipeline-stage-label,
+.pipeline-contract-kicker {
+  color: var(--pipeline-blue);
+  font-size: 0.75rem;
+  font-weight: 800;
+  letter-spacing: 0.06em;
+  text-transform: uppercase;
+}
+
+.pipeline-overview-title,
+.pipeline-section-title,
+.pipeline-stage-title {
+  margin: 0;
+  color: var(--pipeline-ink);
+  font-weight: 800;
+  letter-spacing: -0.02em;
+}
+
+.pipeline-overview-title {
+  margin-top: 0.2rem;
+  font-size: clamp(1.35rem, 2vw, 1.85rem);
+}
+
+.pipeline-badge-row,
+.pipeline-stage-badges {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.45rem;
+  margin-top: 0.65rem;
+}
+
+.pipeline-overview-description {
+  max-width: 980px;
+  margin: 1rem 0 0;
+  color: #344054;
+  font-size: 1rem;
+  line-height: 1.6;
+}
+
+.pipeline-contract-panel {
+  margin-bottom: 1.5rem;
+  padding: 1.15rem 1.25rem;
+  border: 1px solid transparent;
+  border-radius: 1rem;
+  box-shadow: 0 16px 34px -30px rgba(23, 32, 51, 0.5);
+}
+
+.pipeline-contract-ok {
+  border-color: rgba(19, 138, 82, 0.28);
+  background: var(--pipeline-soft-green);
+}
+
+.pipeline-contract-bloqueado {
+  border-color: rgba(220, 53, 69, 0.28);
+  background: #fff1f2;
+}
+
+.pipeline-contract-atencao,
+.pipeline-contract-pendente {
+  border-color: rgba(183, 121, 31, 0.3);
+  background: var(--pipeline-soft-amber);
+}
+
+.pipeline-contract-grid {
+  display: grid;
+  grid-template-columns: minmax(180px, 0.45fr) 1fr;
+  gap: 1rem;
+  align-items: center;
+  margin-top: 0.35rem;
+}
+
+.pipeline-contract-status {
+  color: var(--pipeline-green);
+  font-size: clamp(1.5rem, 3vw, 2.2rem);
+  font-weight: 900;
+  line-height: 1;
+}
+
+.pipeline-contract-bloqueado .pipeline-contract-status {
+  color: var(--bs-danger, #dc3545);
+}
+
+.pipeline-contract-atencao .pipeline-contract-status,
+.pipeline-contract-pendente .pipeline-contract-status {
+  color: var(--pipeline-amber);
+}
+
+.pipeline-contract-caption,
+.pipeline-contract-counts span {
+  color: #344054;
+  font-size: 0.92rem;
+}
+
+.pipeline-contract-counts {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
+}
+
+.pipeline-contract-counts span {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.35rem;
+  padding: 0.55rem 0.75rem;
+  border-radius: 999px;
+  background: rgba(255, 255, 255, 0.72);
+}
+
+.pipeline-stage-section {
+  padding-top: 0.25rem;
+}
+
+.pipeline-section-title {
+  margin-top: 0.15rem;
+  font-size: 1.35rem;
+}
+
+.pipeline-stage-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 1.25rem;
+}
+
+.pipeline-stage-card {
+  height: 100%;
+  overflow: hidden;
+  border: 1px solid var(--bs-border-color, rgba(0, 0, 0, 0.1));
+  border-radius: 1.1rem;
+  background: var(--bs-body-bg, #fff);
+  box-shadow: 0 18px 34px -28px rgba(23, 32, 51, 0.6);
+  transition:
+    transform 0.18s ease,
+    box-shadow 0.18s ease,
+    border-color 0.18s ease;
+}
+
+.pipeline-stage-card:hover {
+  transform: translateY(-3px);
+  border-color: rgba(47, 91, 234, 0.28);
+  box-shadow: 0 22px 42px -28px rgba(47, 91, 234, 0.7);
+}
+
+.pipeline-stage-grid-item:nth-child(4n + 1) .pipeline-stage-card {
+  border-top: 0.45rem solid var(--pipeline-blue);
+}
+
+.pipeline-stage-grid-item:nth-child(4n + 2) .pipeline-stage-card {
+  border-top: 0.45rem solid var(--pipeline-green);
+}
+
+.pipeline-stage-grid-item:nth-child(4n + 3) .pipeline-stage-card {
+  border-top: 0.45rem solid var(--pipeline-amber);
+}
+
+.pipeline-stage-grid-item:nth-child(4n) .pipeline-stage-card {
+  border-top: 0.45rem solid var(--pipeline-indigo);
+}
+
+.pipeline-stage-card-body {
+  display: flex;
+  flex-direction: column;
+  gap: 1rem;
+  padding: 1.15rem;
+}
+
+.pipeline-stage-card-header,
+.pipeline-stage-title-block,
+.pipeline-stage-actions {
+  display: flex;
+  gap: 0.75rem;
+}
+
+.pipeline-stage-card-header {
+  flex-wrap: wrap;
+  align-items: flex-start;
+  justify-content: space-between;
+}
+
+.pipeline-stage-title-block {
+  min-width: 0;
+  align-items: center;
+}
+
+.pipeline-stage-number {
+  display: inline-flex;
+  flex: 0 0 auto;
+  align-items: center;
+  justify-content: center;
+  width: 2.7rem;
+  height: 2.7rem;
+  border-radius: 0.9rem;
+  background: linear-gradient(
+    135deg,
+    var(--pipeline-blue),
+    var(--pipeline-indigo)
+  );
+  color: #fff;
+  font-size: 1.35rem;
+  font-weight: 900;
+  box-shadow: 0 12px 20px -14px rgba(47, 91, 234, 0.9);
+}
+
+.pipeline-stage-title {
+  margin-top: 0.1rem;
+  font-size: 1.12rem;
+}
+
+.pipeline-stage-actions {
+  flex-wrap: wrap;
+}
+
+.pipeline-stage-purpose {
+  padding: 0.8rem 0.9rem;
+  border-radius: 0.85rem;
+  background: var(--bs-tertiary-bg, #f8f9fa);
+}
+
+.pipeline-stage-purpose span,
+.pipeline-stage-meta span {
+  display: block;
+  margin-bottom: 0.2rem;
+  color: var(--pipeline-muted);
+  font-size: 0.76rem;
+  font-weight: 800;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
+.pipeline-stage-purpose p {
+  margin: 0;
+  color: #344054;
+  line-height: 1.55;
+}
+
+.pipeline-stage-meta {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(150px, 1fr));
+  gap: 0.75rem;
+}
+
+.pipeline-stage-meta div {
+  padding: 0.75rem;
+  border: 1px solid var(--bs-border-color, rgba(0, 0, 0, 0.1));
+  border-radius: 0.85rem;
+  background: #fff;
+}
+
+.pipeline-stage-meta strong {
+  display: block;
+  color: var(--pipeline-ink);
+  font-size: 0.9rem;
+  line-height: 1.35;
+  overflow-wrap: anywhere;
+}
+
+@media (max-width: 767.98px) {
+  .pipeline-contract-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .pipeline-stage-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .pipeline-overview-body {
+    padding: 1.15rem 1.1rem 1.15rem 1.45rem;
+  }
+}

--- a/frontend/src/pages/pipeline/PipelineCrudPage.tsx
+++ b/frontend/src/pages/pipeline/PipelineCrudPage.tsx
@@ -1,5 +1,6 @@
 import { useMemo, useState } from "react";
 import PageTitle from "../../components/PageTitle";
+import "./PipelineCrudPage.css";
 import { useOpenAiModels } from "../../api/openAiModel/useOpenAiModels";
 import { usePipelines } from "../../api/pipeline/usePipelines";
 import { usePipelineDiagnostics } from "../../api/pipeline/usePipelineDiagnostics";
@@ -47,6 +48,12 @@ function statusBadgeClass(status?: PipelineDiagnostics["status"]) {
   if (status === "OK") return "text-bg-success";
   if (status === "BLOQUEADO") return "text-bg-danger";
   return "text-bg-warning";
+}
+
+function diagnosticPanelClass(status: PipelineDiagnostics["status"]) {
+  if (status === "OK") return "pipeline-contract-ok";
+  if (status === "BLOQUEADO") return "pipeline-contract-bloqueado";
+  return "pipeline-contract-atencao";
 }
 
 function pipelineToPayload(pipeline: Pipeline): PipelinePayload {
@@ -224,33 +231,31 @@ export default function PipelineCrudPage() {
     const isOfficialPipeline = Boolean(officialPipeline);
 
     return (
-      <div>
-        <div className="d-flex flex-wrap justify-content-between align-items-start gap-3 mb-3">
+      <div className="pipeline-stage-page">
+        <div className="pipeline-stage-toolbar">
           <div>
             <PageTitle>Etapas do pipeline</PageTitle>
-            <p className="text-body-secondary mb-0">
-              Tela focada nas etapas de um único pipeline para reduzir poluição
-              visual e manter o fluxo operacional claro.
+            <p className="pipeline-stage-subtitle mb-0">
+              Ordem visual clara: primeiro o contrato, depois o fluxo das etapas
+              e por último os detalhes técnicos de execução.
             </p>
           </div>
           <button
             type="button"
-            className="btn btn-outline-secondary"
+            className="btn btn-outline-secondary pipeline-stage-back-button"
             onClick={returnToPipelineList}
           >
             ← Voltar para lista
           </button>
         </div>
 
-        <section className="card mb-4 border-primary">
-          <div className="card-body">
+        <section className="pipeline-overview-card mb-4">
+          <div className="pipeline-overview-body">
             <div className="d-flex flex-wrap justify-content-between align-items-start gap-3">
               <div>
-                <div className="small text-uppercase text-body-secondary fw-semibold">
-                  Pipeline selecionado
-                </div>
-                <h2 className="h4 mb-1">{pipeline.name}</h2>
-                <div className="d-flex flex-wrap gap-2">
+                <div className="pipeline-eyebrow">Pipeline selecionado</div>
+                <h2 className="pipeline-overview-title">{pipeline.name}</h2>
+                <div className="pipeline-badge-row">
                   <span className="badge text-bg-light border">
                     {pipeline.module}
                   </span>
@@ -284,7 +289,7 @@ export default function PipelineCrudPage() {
               </button>
             </div>
             {pipeline.description ? (
-              <p className="text-body-secondary mt-3 mb-0">
+              <p className="pipeline-overview-description">
                 {pipeline.description}
               </p>
             ) : null}
@@ -293,14 +298,28 @@ export default function PipelineCrudPage() {
 
         {diagnostic ? (
           <div
-            className={`alert ${diagnostic.status === "BLOQUEADO" ? "alert-danger" : diagnostic.status === "OK" ? "alert-success" : "alert-warning"}`}
+            className={`pipeline-contract-panel ${diagnosticPanelClass(diagnostic.status)}`}
           >
-            <div className="fw-semibold">
-              Status do contrato operacional: {diagnostic.status}
-            </div>
-            <div>
-              Etapas esperadas no código: {diagnostic.expectedStages} · etapas
-              configuradas no banco: {diagnostic.configuredStages}
+            <div className="pipeline-contract-kicker">Contrato operacional</div>
+            <div className="pipeline-contract-grid">
+              <div>
+                <div className="pipeline-contract-status">
+                  {diagnostic.status}
+                </div>
+                <div className="pipeline-contract-caption">
+                  Status atual do fluxo
+                </div>
+              </div>
+              <div className="pipeline-contract-counts">
+                <span>
+                  <strong>{diagnostic.expectedStages}</strong> esperadas no
+                  código
+                </span>
+                <span>
+                  <strong>{diagnostic.configuredStages}</strong> configuradas no
+                  banco
+                </span>
+              </div>
             </div>
             {diagnostic.issues.length > 0 ? (
               <ul className="mb-0 mt-2">
@@ -327,9 +346,12 @@ export default function PipelineCrudPage() {
           </div>
         ) : null}
 
-        <section className="mb-4">
-          <div className="d-flex flex-wrap justify-content-between align-items-center gap-2 mb-3">
-            <h3 className="h5 mb-0">Etapas configuradas</h3>
+        <section className="pipeline-stage-section mb-4">
+          <div className="pipeline-section-header">
+            <div>
+              <div className="pipeline-eyebrow">Fluxo operacional</div>
+              <h3 className="pipeline-section-title">Etapas configuradas</h3>
+            </div>
             {isOfficialPipeline ? (
               <button
                 type="button"
@@ -358,7 +380,7 @@ export default function PipelineCrudPage() {
               Nenhuma etapa cadastrada para este pipeline.
             </div>
           ) : (
-            <div className="row g-3">
+            <div className="pipeline-stage-grid">
               {pipeline.stages.map((stage) => {
                 const rowDefinition = officialPipeline?.stages.find(
                   (definition) =>
@@ -376,35 +398,27 @@ export default function PipelineCrudPage() {
                     : "Editável";
 
                 return (
-                  <div className="col-12 col-xl-6" key={stage.id}>
-                    <article className="card h-100 border shadow-sm">
-                      <div className="card-body d-flex flex-column gap-3">
-                        <div className="d-flex flex-wrap justify-content-between align-items-start gap-2">
-                          <div>
-                            <div className="small fw-semibold text-primary text-uppercase">
-                              Etapa {stage.position}
+                  <div className="pipeline-stage-grid-item" key={stage.id}>
+                    <article className="pipeline-stage-card">
+                      <div className="pipeline-stage-card-body">
+                        <div className="pipeline-stage-card-header">
+                          <div className="pipeline-stage-title-block">
+                            <div
+                              className="pipeline-stage-number"
+                              aria-label={`Etapa ${stage.position}`}
+                            >
+                              {stage.position}
                             </div>
-                            <h4 className="h5 mb-1">{stage.name}</h4>
-                            <div className="d-flex flex-wrap gap-2">
-                              <span className="badge text-bg-light border">
-                                {stage.code}
-                              </span>
-                              <span
-                                className={`badge ${stage.active ? "text-bg-success" : "text-bg-secondary"}`}
-                              >
-                                {stage.active ? "Ativa" : "Inativa"}
-                              </span>
-                              {stage.required ? (
-                                <span className="badge text-bg-primary">
-                                  Obrigatória
-                                </span>
-                              ) : null}
-                              <span className="badge text-bg-light border">
-                                {protectionLabel}
-                              </span>
+                            <div>
+                              <div className="pipeline-stage-label">
+                                Etapa {stage.position}
+                              </div>
+                              <h4 className="pipeline-stage-title">
+                                {stage.name}
+                              </h4>
                             </div>
                           </div>
-                          <div className="d-flex gap-2">
+                          <div className="pipeline-stage-actions">
                             <button
                               type="button"
                               className="btn btn-sm btn-outline-primary"
@@ -440,25 +454,50 @@ export default function PipelineCrudPage() {
                             </button>
                           </div>
                         </div>
+                        <div className="pipeline-stage-badges">
+                          <span className="badge text-bg-light border">
+                            {stage.code}
+                          </span>
+                          <span
+                            className={`badge ${stage.active ? "text-bg-success" : "text-bg-secondary"}`}
+                          >
+                            {stage.active ? "Ativa" : "Inativa"}
+                          </span>
+                          {stage.required ? (
+                            <span className="badge text-bg-primary">
+                              Obrigatória
+                            </span>
+                          ) : null}
+                          <span className="badge text-bg-light border">
+                            {protectionLabel}
+                          </span>
+                        </div>
                         {stage.description ? (
-                          <p className="text-body-secondary mb-0">
-                            {stage.description}
-                          </p>
+                          <div className="pipeline-stage-purpose">
+                            <span>Objetivo da etapa</span>
+                            <p>{stage.description}</p>
+                          </div>
                         ) : null}
-                        <div className="small text-body-secondary">
+                        <div className="pipeline-stage-meta">
                           <div>
-                            <strong>Módulo executor:</strong>{" "}
-                            {stage.executionModule || "Não informado"}
+                            <span>Módulo executor</span>
+                            <strong>
+                              {stage.executionModule || "Não informado"}
+                            </strong>
                           </div>
                           <div>
-                            <strong>Pacote raiz:</strong>{" "}
-                            {stage.rootPackage || "Não informado"}
+                            <span>Pacote raiz</span>
+                            <strong>
+                              {stage.rootPackage || "Não informado"}
+                            </strong>
                           </div>
                           <div>
-                            <strong>Modelo OpenAI:</strong>{" "}
-                            {stage.openAiModelName
-                              ? `${stage.openAiModelName} (${stage.openAiModelCode})`
-                              : "Sem modelo fixo"}
+                            <span>Modelo OpenAI</span>
+                            <strong>
+                              {stage.openAiModelName
+                                ? `${stage.openAiModelName} (${stage.openAiModelCode})`
+                                : "Sem modelo fixo"}
+                            </strong>
                           </div>
                         </div>
                       </div>


### PR DESCRIPTION
### Motivation
- A tela de etapas estava visualmente confusa e exigia esforço para identificar o contexto do pipeline, o status do contrato e os objetivos/metadados de cada etapa.  
- A intenção é explicitar a ordem de leitura (contexto → contrato operacional → fluxo de etapas) usando cores, tipografia e organização para reduzir atrito operacional.

### Description
- Reestruturei o componente de etapas para introduzir um toolbar e um painel de overview do pipeline com destaque visual e badges resumidas, extraindo estilos dedicados em `frontend/src/pages/pipeline/PipelineCrudPage.css`.  
- Substituí os cartões genéricos por cards de etapa com número grande, badges separadas, bloco de objetivo destacado e metadados técnicos em blocos menores para hierarquia clara.  
- Criei a função `diagnosticPanelClass` para mapear status de diagnóstico a classes CSS seguras (`pipeline-contract-ok|bloqueado|atencao`) e evitar dependência de nomes acentuados/variáveis nos nomes de classe.  
- Arquivos alterados/criados: `frontend/src/pages/pipeline/PipelineCrudPage.tsx` (markup e lógica) e `frontend/src/pages/pipeline/PipelineCrudPage.css` (novo CSS); também registrei a mudança em `docs/registros/experimentos.md`.

### Testing
- Executado `npm run typecheck` no frontend e não foram reportados erros após instalar dependências, indicando tipagem consistente. (sucesso)  
- Executado `npm run build` (Vite) para validar bundle e detectar regressões de runtime; build completou com sucesso (avisos de chunk-size apenas). (sucesso)  
- Validada renderização visual com script Playwright mockando APIs e gerando screenshot (`node /tmp/pipeline-screenshot.cjs`), confirmando a nova hierarquia sem depender do backend remoto. (sucesso)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2451de666c8321b9d1205ae0095b2d)