### PR TITLE
Corrige sincronização de preços OpenAI para variantes datadas

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/openai/service/OpenAiModelPricingSyncService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/openai/service/OpenAiModelPricingSyncService.java
@@ -26,18 +26,13 @@ public class OpenAiModelPricingSyncService {
         this.repository = repository;
     }
 
-    /** Consulta a fonte oficial e persiste os preços atuais dos modelos encontrados. */
+    /** Consulta a fonte oficial e persiste preços atuais, inclusive para variantes datadas já cadastradas. */
     @Transactional
     public int syncOfficialPricing() {
         List<OpenAiModelPricing> prices = pricingPageClient.fetchTextModelPricing();
         Instant syncedAt = Instant.now();
-        int updated = 0;
-        for (OpenAiModelPricing price : prices) {
-            OpenAiModel model = repository.findByCode(price.code()).orElseGet(OpenAiModel::new);
-            applyPrice(model, price, syncedAt);
-            repository.save(model);
-            updated++;
-        }
+        int updated = upsertOfficialBaseModels(prices, syncedAt);
+        updated += refreshExistingModelVariants(prices, syncedAt);
         log.info(
                 "Preços oficiais OpenAI sincronizados; operation=openai-pricing-sync modelsUpdated={} source={}",
                 updated,
@@ -45,10 +40,41 @@ public class OpenAiModelPricingSyncService {
         return updated;
     }
 
+    /** Cria ou atualiza os modelos-base publicados diretamente na fonte oficial de preços. */
+    private int upsertOfficialBaseModels(List<OpenAiModelPricing> prices, Instant syncedAt) {
+        int updated = 0;
+        for (OpenAiModelPricing price : prices) {
+            OpenAiModel model = repository.findByCode(price.code()).orElseGet(OpenAiModel::new);
+            applyPrice(model, price, syncedAt, true);
+            repository.save(model);
+            updated++;
+        }
+        return updated;
+    }
+
+    /** Atualiza modelos existentes que são variantes datadas de códigos-base publicados pela OpenAI. */
+    private int refreshExistingModelVariants(List<OpenAiModelPricing> prices, Instant syncedAt) {
+        int updated = 0;
+        for (OpenAiModel model : repository.findAll()) {
+            if (prices.stream().anyMatch(price -> price.code().equals(model.getCode()))) {
+                continue;
+            }
+            var pricing = pricingPageClient.findBestTextModelPricing(prices, model.getCode());
+            if (pricing.isPresent()) {
+                applyPrice(model, pricing.get(), syncedAt, false);
+                repository.save(model);
+                updated++;
+            }
+        }
+        return updated;
+    }
+
     /** Aplica preços e metadados de sincronização na entidade persistida. */
-    private void applyPrice(OpenAiModel model, OpenAiModelPricing price, Instant syncedAt) {
-        model.setName(price.name());
-        model.setCode(price.code());
+    private void applyPrice(OpenAiModel model, OpenAiModelPricing price, Instant syncedAt, boolean updateIdentity) {
+        if (updateIdentity) {
+            model.setName(price.name());
+            model.setCode(price.code());
+        }
         model.setPriceInputStandard(price.priceInputStandard());
         model.setPriceInputCachedStandard(price.priceInputCachedStandard());
         model.setPriceOutputStandard(price.priceOutputStandard());

--- a/backend/ads-service/src/test/java/com/marketinghub/openai/OpenAiModelPricingSyncServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/openai/OpenAiModelPricingSyncServiceTest.java
@@ -1,0 +1,100 @@
+package com.marketinghub.openai;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.marketinghub.openai.service.OpenAiModelPricingSyncService;
+import com.marketinghub.repository.jpa.openai.OpenAiModelRepository;
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/** Responsabilidade: validar a sincronização de preços oficiais OpenAI no catálogo financeiro local. */
+@ExtendWith(MockitoExtension.class)
+class OpenAiModelPricingSyncServiceTest {
+
+    @Mock
+    private OpenAiPricingPageClient pricingPageClient;
+
+    @Mock
+    private OpenAiModelRepository repository;
+
+    /** Garante que variantes datadas recebem preços do código-base oficial mais específico sem perder identidade. */
+    @Test
+    void shouldRefreshDatedModelVariantWithBestOfficialBasePricing() {
+        OpenAiModelPricing basePrice = new OpenAiModelPricing(
+                "gpt-5.5",
+                "gpt-5.5",
+                new BigDecimal("5.00"),
+                new BigDecimal("0.50"),
+                new BigDecimal("30.00"),
+                new BigDecimal("2.50"),
+                new BigDecimal("0.25"),
+                new BigDecimal("15.00"));
+        OpenAiModel datedVariant = OpenAiModel.builder()
+                .id(11L)
+                .name("GPT 5.5 2026 04 23")
+                .code("gpt-5.5-2026-04-23")
+                .priceInputStandard(BigDecimal.ZERO)
+                .priceInputCachedStandard(BigDecimal.ZERO)
+                .priceOutputStandard(BigDecimal.ZERO)
+                .priceInputBatch(BigDecimal.ZERO)
+                .priceInputCachedBatch(BigDecimal.ZERO)
+                .priceOutputBatch(BigDecimal.ZERO)
+                .build();
+        when(pricingPageClient.fetchTextModelPricing()).thenReturn(List.of(basePrice));
+        when(pricingPageClient.findBestTextModelPricing(List.of(basePrice), datedVariant.getCode()))
+                .thenReturn(Optional.of(basePrice));
+        when(repository.findByCode("gpt-5.5")).thenReturn(Optional.empty());
+        when(repository.findAll()).thenReturn(List.of(datedVariant));
+
+        OpenAiModelPricingSyncService service = new OpenAiModelPricingSyncService(pricingPageClient, repository);
+        int updated = service.syncOfficialPricing();
+
+        assertThat(updated).isEqualTo(2);
+        assertThat(datedVariant.getCode()).isEqualTo("gpt-5.5-2026-04-23");
+        assertThat(datedVariant.getName()).isEqualTo("GPT 5.5 2026 04 23");
+        assertThat(datedVariant.getPriceInputStandard()).isEqualByComparingTo(new BigDecimal("5.00"));
+        assertThat(datedVariant.getPriceInputCachedStandard()).isEqualByComparingTo(new BigDecimal("0.50"));
+        assertThat(datedVariant.getPriceOutputStandard()).isEqualByComparingTo(new BigDecimal("30.00"));
+        assertThat(datedVariant.getPriceInputBatch()).isEqualByComparingTo(new BigDecimal("2.50"));
+        assertThat(datedVariant.getPriceInputCachedBatch()).isEqualByComparingTo(new BigDecimal("0.25"));
+        assertThat(datedVariant.getPriceOutputBatch()).isEqualByComparingTo(new BigDecimal("15.00"));
+        assertThat(datedVariant.getPricingSource()).isEqualTo("https://developers.openai.com/api/docs/pricing");
+        assertThat(datedVariant.getLastPricingSyncAt()).isNotNull();
+        verify(repository).save(datedVariant);
+    }
+
+    /** Garante que modelos-base oficiais continuam sendo criados com identidade publicada na tabela de preços. */
+    @Test
+    void shouldPreserveBaseModelIdentityWhenUpsertingOfficialPrice() {
+        OpenAiModelPricing basePrice = new OpenAiModelPricing(
+                "gpt-5.5",
+                "gpt-5.5",
+                new BigDecimal("5.00"),
+                new BigDecimal("0.50"),
+                new BigDecimal("30.00"),
+                new BigDecimal("2.50"),
+                new BigDecimal("0.25"),
+                new BigDecimal("15.00"));
+        when(pricingPageClient.fetchTextModelPricing()).thenReturn(List.of(basePrice));
+        when(repository.findByCode("gpt-5.5")).thenReturn(Optional.empty());
+        when(repository.findAll()).thenReturn(List.of());
+
+        OpenAiModelPricingSyncService service = new OpenAiModelPricingSyncService(pricingPageClient, repository);
+        service.syncOfficialPricing();
+
+        ArgumentCaptor<OpenAiModel> captor = ArgumentCaptor.forClass(OpenAiModel.class);
+        verify(repository).save(captor.capture());
+        OpenAiModel savedBase = captor.getValue();
+        assertThat(savedBase.getCode()).isEqualTo("gpt-5.5");
+        assertThat(savedBase.getName()).isEqualTo("gpt-5.5");
+        assertThat(savedBase.getPriceOutputStandard()).isEqualByComparingTo(new BigDecimal("30.00"));
+    }
+}

--- a/docs/registros/modelos-openai.md
+++ b/docs/registros/modelos-openai.md
@@ -1,0 +1,8 @@
+# Registros — Modelos OpenAI
+
+## 2026-06-06 — Correção da atualização diária de preços para variantes datadas
+
+- Investigada a tela `/openai-models`, alimentada pelo endpoint backend `GET /api/modelos/openai/catalogo/v1/modelos` e pela tabela `openai_model`.
+- Confirmado via MCP que a rotina das 04:00 America/Sao_Paulo executou em 2026-06-06 07:00 UTC e atualizou o modelo-base `gpt-5.5`, mas não atualizou a variante cadastrada `gpt-5.5-2026-04-23`, que permaneceu com preços zerados.
+- Corrigida a causa-raiz na sincronização diária: além de criar/atualizar os modelos-base publicados na fonte oficial de preços, a rotina agora percorre os modelos já cadastrados e aplica o preço-base mais específico às variantes datadas sem sobrescrever nome ou código da variante.
+- Adicionado teste unitário garantindo que `gpt-5.5-2026-04-23` herda os preços oficiais de `gpt-5.5` e preserva sua identidade operacional.


### PR DESCRIPTION
### Motivation
- A rotina diária de sincronização de preços OpenAI estava atualizando apenas os códigos publicados na fonte oficial, deixando variantes datadas (ex.: `gpt-5.5-2026-04-23`) com preços zerados; é necessário propagar preços base para essas variantes sem sobrescrever sua identidade.

### Description
- Atualiza `OpenAiModelPricingSyncService` para executar a criação/atualização dos modelos-base oficiais e, em seguida, percorrer modelos já cadastrados aplicando o preço-base mais específico nas variantes datadas, preservando nome e código; mudanças em `backend/ads-service/src/main/java/com/marketinghub/openai/service/OpenAiModelPricingSyncService.java`.
- Introduz os helpers `upsertOfficialBaseModels` e `refreshExistingModelVariants` e altera `applyPrice` para aceitar o flag `updateIdentity` para controlar quando nome/código devem ser sobrescritos.
- Adiciona teste unitário `OpenAiModelPricingSyncServiceTest` cobrindo o caso `gpt-5.5-2026-04-23` herdando preços de `gpt-5.5` sem perder identidade em `backend/ads-service/src/test/java/com/marketinghub/openai/OpenAiModelPricingSyncServiceTest.java`.
- Registra a investigação e a correção em `docs/registros/modelos-openai.md`.

### Testing
- Executei `mvn -q -Dtest=OpenAiPricingPageClientTest,OpenAiModelPricingSyncServiceTest test` e os testes direcionados passaram com sucesso.
- Executei `mvn -q test` no módulo `backend/ads-service` e a suíte completa terminou sem falhas críticas nas classes afetadas.
- Executei `git diff --check` para validação de estilo/consistência e não foram encontradas quebras.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a245276ccd08321991b86c53fa4d266)