### PR TITLE
Bloqueia alterações em experimentos publicados

### DIFF
--- a/docs/canonical/procedimento-experimento-canon.v1.md
+++ b/docs/canonical/procedimento-experimento-canon.v1.md
@@ -159,6 +159,14 @@ Com a landing gerada:
 2. faz visualização e aprovação/publicação;
 3. nesse ponto é consolidada a URL final usada na campanha.
 
+### 7.1 Bloqueio de alterações após liberação/publicação
+
+Depois que o experimento for liberado para publicação/execução, a interface administrativa deve tratar o experimento como operacionalmente bloqueado para alterações. O bloqueio começa quando `facebook_release_requested_at` estiver preenchido ou quando o status já representar execução ou pós-execução (`RUNNING`, `PAUSED`, `USER_STOPPED`, `VALIDATED`, `INVALIDATED`, `INCONCLUSIVE` ou `FINISHED`).
+
+Enquanto bloqueado, o frontend deve manter disponíveis as visões de acompanhamento e auditoria (Overview, Funil, Analytics, Chamadas Meta, Jobs e prévias), mas deve desabilitar comandos e campos que alterem artefatos ou configuração do experimento, incluindo edição do experimento, reset de campanhas, geração/regeneração de landing, aprovação/publicação de landing, geração/aprovação/exclusão de criativos, seleção de público e registros manuais no funil.
+
+A regra existe para impedir divergência entre o que já foi publicado/executado no Meta/Lead Portal e os artefatos canônicos usados para mensuração comercial do experimento. Correções após publicação devem seguir fluxo operacional explícito (ex.: duplicar/republicar novo experimento ou rotina de parada/correção autorizada), não edição silenciosa dos ativos em execução.
+
 ## 8. Regras de integração com OpenAI
 
 ### 8.1 Worker AI como camada obrigatória

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -3807,3 +3807,18 @@
   - `frontend/src/pages/pipeline/PipelineCrudPage.tsx`
   - `frontend/src/pages/pipeline/PipelineCrudPage.css`
   - `docs/registros/experimentos.md`
+
+## 2026-06-06 — Bloqueio de alterações após publicação/execução do experimento
+
+- solicitação: depois que o experimento estiver publicado e em execução, tudo relacionado a alterações deve ficar desabilitado no frontend.
+- regra canônica atualizada: o procedimento de experimento passou a bloquear alterações quando `facebook_release_requested_at` estiver preenchido ou quando o status já representar execução/pós-execução.
+- correção aplicada: a tela de detalhe do experimento agora calcula o bloqueio operacional e repassa a trava para abas de Criativos, Landing, Gera Landing, Estrutura de conteúdo, Funil e Público, mantendo consultas e prévias disponíveis, mas desabilitando comandos de edição, reset, geração, aprovação/publicação e seleção.
+- arquivos alterados:
+  - `frontend/src/pages/experiment/ExperimentDetailPage.tsx`
+  - `frontend/src/pages/experiment/CriativosTab.tsx`
+  - `frontend/src/pages/experiment/LandingTab.tsx`
+  - `frontend/src/pages/experiment/ExperimentFunnelTab.tsx`
+  - `frontend/src/pages/experiment/ExperimentContentGenerationTab.tsx`
+  - `frontend/src/pages/experiment/ExperimentAudienceTab.tsx`
+  - `docs/canonical/procedimento-experimento-canon.v1.md`
+  - `docs/registros/experimentos.md`

--- a/frontend/src/pages/experiment/CriativosTab.tsx
+++ b/frontend/src/pages/experiment/CriativosTab.tsx
@@ -21,16 +21,18 @@ import {
 } from "lucide-react";
 import "./CriativosTab.css";
 import { hasAdCopyContent, parseAdCopyPayload } from "./adCopyParser";
-import { hasImagePromptContent, parseImagePromptPayload } from "./imageBriefingParser";
+import {
+  hasImagePromptContent,
+  parseImagePromptPayload,
+} from "./imageBriefingParser";
 import { useRequestPipelineCreatives } from "../../api/experiment/useRequestPipelineCreatives";
 
 interface Props {
   experimentId: string;
+  alterationLocked?: boolean;
 }
 
-
 const ICON_SIZE = 16;
-
 
 type FeedbackVariant = "success" | "warning" | "error";
 
@@ -151,7 +153,9 @@ const PIPELINE_PROMPT_SOURCE_FIELDS: PromptSourceField[] = [
 
 const resolvePromptSourceStatus = (prompt?: string | null) => {
   const normalizedPrompt = prompt?.trim() ?? "";
-  const allMarkers = PIPELINE_PROMPT_SOURCE_FIELDS.flatMap((field) => field.markers);
+  const allMarkers = PIPELINE_PROMPT_SOURCE_FIELDS.flatMap(
+    (field) => field.markers,
+  );
 
   const extractContentValue = (markers: string[]) => {
     if (!normalizedPrompt) {
@@ -172,7 +176,9 @@ const resolvePromptSourceStatus = (prompt?: string | null) => {
 
       const rawValue = normalizedPrompt.slice(
         contentStart,
-        nextMarkerIndex === undefined ? normalizedPrompt.length : nextMarkerIndex,
+        nextMarkerIndex === undefined
+          ? normalizedPrompt.length
+          : nextMarkerIndex,
       );
 
       const cleanedValue = rawValue
@@ -219,22 +225,42 @@ const statusLabel = (status: string) => {
   }
 };
 
-export default function CriativosTab({ experimentId }: Props) {
+export default function CriativosTab({
+  experimentId,
+  alterationLocked = false,
+}: Props) {
   const { data, isLoading } = useCreatives(experimentId);
   const creatives = Array.isArray(data) ? data : [];
   const { data: experiment } = useExperiment(experimentId);
   const pipelineRequest = useRequestPipelineCreatives(experimentId);
-  const adCopyContent = useMemo(() => parseAdCopyPayload(experiment?.adCopy ?? null), [experiment?.adCopy]);
-  const imageBriefingContent = useMemo(() => parseImagePromptPayload(experiment?.adImageBriefing ?? null), [experiment?.adImageBriefing]);
+  const adCopyContent = useMemo(
+    () => parseAdCopyPayload(experiment?.adCopy ?? null),
+    [experiment?.adCopy],
+  );
+  const imageBriefingContent = useMemo(
+    () => parseImagePromptPayload(experiment?.adImageBriefing ?? null),
+    [experiment?.adImageBriefing],
+  );
   const pipelineHasAdCopy = hasAdCopyContent(adCopyContent);
   const pipelineHasBriefing = hasImagePromptContent(imageBriefingContent);
-  const pipelineVariantCount = pipelineHasAdCopy ? adCopyContent.primaryTextVariants.length : 0;
-  const pipelineBriefingCount = pipelineHasBriefing ? imageBriefingContent.briefings.length : 0;
+  const pipelineVariantCount = pipelineHasAdCopy
+    ? adCopyContent.primaryTextVariants.length
+    : 0;
+  const pipelineBriefingCount = pipelineHasBriefing
+    ? imageBriefingContent.briefings.length
+    : 0;
   const pipelinePairs = Math.min(pipelineVariantCount, pipelineBriefingCount);
   const pipelineAvailable = pipelinePairs > 0;
   const pendingCreativeRequests = experiment?.creativesToGenerate ?? 0;
-  const pipelineInProgress = experiment?.creativeGenerationMode === "PIPELINE_ADS" && pendingCreativeRequests > 0;
-  const pipelineButtonDisabled = pipelineRequest.isPending || pipelineInProgress || pendingCreativeRequests > 0 || !pipelineAvailable;
+  const pipelineInProgress =
+    experiment?.creativeGenerationMode === "PIPELINE_ADS" &&
+    pendingCreativeRequests > 0;
+  const pipelineButtonDisabled =
+    alterationLocked ||
+    pipelineRequest.isPending ||
+    pipelineInProgress ||
+    pendingCreativeRequests > 0 ||
+    !pipelineAvailable;
   const updateExperimentMutation = useUpdateExperiment(experimentId);
   const [editing, setEditing] = useState<Creative | null>(null);
   const [feedback, setFeedback] = useState<FeedbackState | null>(null);
@@ -247,16 +273,20 @@ export default function CriativosTab({ experimentId }: Props) {
   const update = useUpdateCreative(experimentId);
   const del = useDeleteCreative(experimentId);
   const [showPreview, setShowPreview] = useState(false);
-  const [processingCreativeId, setProcessingCreativeId] = useState<number | null>(
-    null,
-  );
+  const [processingCreativeId, setProcessingCreativeId] = useState<
+    number | null
+  >(null);
   const [expandedPromptByCreativeId, setExpandedPromptByCreativeId] = useState<
     Record<number, boolean>
   >({});
-  const [expandedPreviousPromptByCreativeId, setExpandedPreviousPromptByCreativeId] =
-    useState<Record<number, boolean>>({});
-  const [expandedIntermediatePromptByCreativeId, setExpandedIntermediatePromptByCreativeId] =
-    useState<Record<number, boolean>>({});
+  const [
+    expandedPreviousPromptByCreativeId,
+    setExpandedPreviousPromptByCreativeId,
+  ] = useState<Record<number, boolean>>({});
+  const [
+    expandedIntermediatePromptByCreativeId,
+    setExpandedIntermediatePromptByCreativeId,
+  ] = useState<Record<number, boolean>>({});
   const { data: facebookPages, isLoading: isLoadingFacebookPages } =
     useAllFacebookPages();
   const { data: instagramAccounts, isLoading: isLoadingInstagramAccounts } =
@@ -368,14 +398,16 @@ export default function CriativosTab({ experimentId }: Props) {
       const selectedPage =
         parsedPageId === null
           ? null
-          : facebookPages?.find((page) => page.id === parsedPageId) ?? null;
+          : (facebookPages?.find((page) => page.id === parsedPageId) ?? null);
       const selectedInstagramAccount = Array.isArray(instagramAccounts)
-        ? instagramAccounts.find(
+        ? (instagramAccounts.find(
             (account) => account.id === Number(experimentInstagramAccountId),
-          ) ?? null
+          ) ?? null)
         : null;
       const rawHandle =
-        selectedInstagramAccount?.handle ?? experiment.instagramAccount?.handle ?? "";
+        selectedInstagramAccount?.handle ??
+        experiment.instagramAccount?.handle ??
+        "";
       const formattedHandle = rawHandle
         ? rawHandle.startsWith("@")
           ? rawHandle
@@ -436,14 +468,14 @@ export default function CriativosTab({ experimentId }: Props) {
         format: c.format || "LINK",
         headline: c.headline,
         primaryText: c.primaryText,
-      imageUrl: c.imageUrl,
-      description: c.description || "",
-      cta: c.cta || "LEARN_MORE",
-      destinationUrl: c.destinationUrl || "",
-      leadGenFormId: c.leadGenFormId || "",
-      instagramUserId: c.instagramUserId || "",
-      status: "READY",
-    });
+        imageUrl: c.imageUrl,
+        description: c.description || "",
+        cta: c.cta || "LEARN_MORE",
+        destinationUrl: c.destinationUrl || "",
+        leadGenFormId: c.leadGenFormId || "",
+        instagramUserId: c.instagramUserId || "",
+        status: "READY",
+      });
     } catch {
       setFeedback({
         variant: "error",
@@ -499,7 +531,9 @@ export default function CriativosTab({ experimentId }: Props) {
     const isPreviousPromptExpanded = Boolean(
       expandedPreviousPromptByCreativeId[c.id],
     );
-    const hasIntermediateImagePrompt = Boolean(c.imageIntermediatePrompt?.trim());
+    const hasIntermediateImagePrompt = Boolean(
+      c.imageIntermediatePrompt?.trim(),
+    );
     const isIntermediatePromptExpanded = Boolean(
       expandedIntermediatePromptByCreativeId[c.id],
     );
@@ -579,7 +613,9 @@ export default function CriativosTab({ experimentId }: Props) {
                 </a>
               )}
               {c.leadGenFormId && (
-                <span className="d-block mt-1">Formulário: {c.leadGenFormId}</span>
+                <span className="d-block mt-1">
+                  Formulário: {c.leadGenFormId}
+                </span>
               )}
             </div>
           )}
@@ -590,7 +626,7 @@ export default function CriativosTab({ experimentId }: Props) {
               type="button"
               className="btn btn-outline-primary btn-sm d-flex align-items-center justify-content-center gap-1"
               onClick={() => openEdit(c)}
-              disabled={isProcessing}
+              disabled={isProcessing || alterationLocked}
             >
               <Edit3 size={ICON_SIZE} />
               <span>Editar</span>
@@ -599,7 +635,7 @@ export default function CriativosTab({ experimentId }: Props) {
               type="button"
               className="btn btn-outline-danger btn-sm d-flex align-items-center justify-content-center gap-1"
               onClick={() => remove(c)}
-              disabled={isProcessing}
+              disabled={isProcessing || alterationLocked}
             >
               <Trash2 size={ICON_SIZE} />
               <span>Excluir</span>
@@ -609,7 +645,7 @@ export default function CriativosTab({ experimentId }: Props) {
                 type="button"
                 className="btn btn-outline-success btn-sm d-flex align-items-center justify-content-center gap-1"
                 onClick={() => approve(c)}
-                disabled={isProcessing}
+                disabled={isProcessing || alterationLocked}
               >
                 <CheckCircle2 size={ICON_SIZE} />
                 <span>Aprovar</span>
@@ -654,14 +690,17 @@ export default function CriativosTab({ experimentId }: Props) {
                           <code>{field.source}</code>
                           <span
                             className={`badge rounded-pill ${
-                              field.hasContent ? "text-bg-success" : "text-bg-secondary"
+                              field.hasContent
+                                ? "text-bg-success"
+                                : "text-bg-secondary"
                             }`}
                           >
                             {field.hasContent ? "Com conteúdo" : "Sem conteúdo"}
                           </span>
                           {field.hasContent && (
                             <small className="creative-card-prompt-source-value">
-                              {field.contentValue ?? "Trecho identificado no prompt (sem valor explícito)."}
+                              {field.contentValue ??
+                                "Trecho identificado no prompt (sem valor explícito)."}
                             </small>
                           )}
                         </li>
@@ -735,7 +774,9 @@ export default function CriativosTab({ experimentId }: Props) {
           <div className="creative-feedback-content">
             <p className="creative-feedback-title">{feedback.title}</p>
             {feedback.description && (
-              <p className="creative-feedback-description">{feedback.description}</p>
+              <p className="creative-feedback-description">
+                {feedback.description}
+              </p>
             )}
           </div>
           <button
@@ -749,6 +790,12 @@ export default function CriativosTab({ experimentId }: Props) {
         </div>
       )}
       <div className="mb-4">
+        {alterationLocked ? (
+          <div className="alert alert-secondary" role="status">
+            Criativos e configurações de publicação bloqueados para alteração
+            porque o experimento já foi liberado ou está em execução.
+          </div>
+        ) : null}
         <label className="form-label" htmlFor="experiment-instagram-id">
           Conta do Instagram <span className="text-danger">*</span>
         </label>
@@ -758,7 +805,10 @@ export default function CriativosTab({ experimentId }: Props) {
           value={experimentInstagramAccountId}
           onChange={(e) => setExperimentInstagramAccountId(e.target.value)}
           disabled={
-            isSavingPageId || isLoadingInstagramAccounts || noInstagramAccounts
+            alterationLocked ||
+            isSavingPageId ||
+            isLoadingInstagramAccounts ||
+            noInstagramAccounts
           }
         >
           <option value="">
@@ -776,7 +826,8 @@ export default function CriativosTab({ experimentId }: Props) {
             ))}
         </select>
         <div className="form-text mb-2">
-          O worker utilizará esta conta como identidade do Instagram nas campanhas.
+          O worker utilizará esta conta como identidade do Instagram nas
+          campanhas.
         </div>
         {noInstagramAccounts && (
           <div className="alert alert-warning" role="alert">
@@ -801,7 +852,9 @@ export default function CriativosTab({ experimentId }: Props) {
             className="form-select"
             value={experimentPageId}
             onChange={(e) => setExperimentPageId(e.target.value)}
-            disabled={isSavingPageId || isLoadingFacebookPages}
+            disabled={
+              isSavingPageId || isLoadingFacebookPages || alterationLocked
+            }
           >
             <option value="">
               {isLoadingFacebookPages
@@ -819,7 +872,12 @@ export default function CriativosTab({ experimentId }: Props) {
             type="button"
             className="btn btn-primary d-flex align-items-center gap-2"
             onClick={handleSavePageId}
-            disabled={isSavingPageId || !experiment || noInstagramAccounts}
+            disabled={
+              isSavingPageId ||
+              !experiment ||
+              noInstagramAccounts ||
+              alterationLocked
+            }
           >
             {isSavingPageId ? (
               <>
@@ -845,8 +903,10 @@ export default function CriativosTab({ experimentId }: Props) {
           <div>
             <h4 className="h6 mb-1">Anúncios do pipeline prontos</h4>
             <p className="mb-0 small text-muted">
-              Encontramos {pipelinePairs} {pipelinePairs === 1 ? "variação" : "variações"} com texto e briefing estruturados.
-              O Worker AI usará o modelo gpt-imagem-1.5 para gerar as imagens alinhadas ao experimento.
+              Encontramos {pipelinePairs}{" "}
+              {pipelinePairs === 1 ? "variação" : "variações"} com texto e
+              briefing estruturados. O Worker AI usará o modelo gpt-imagem-1.5
+              para gerar as imagens alinhadas ao experimento.
             </p>
           </div>
           <div className="d-flex flex-column align-items-lg-end gap-2 w-100 w-lg-auto">
@@ -857,11 +917,18 @@ export default function CriativosTab({ experimentId }: Props) {
               disabled={pipelineButtonDisabled}
             >
               {pipelineRequest.isPending ? (
-                <span className="spinner-border spinner-border-sm" role="status" />
+                <span
+                  className="spinner-border spinner-border-sm"
+                  role="status"
+                />
               ) : (
                 <Sparkles size={ICON_SIZE} />
               )}
-              <span>{pipelineInProgress ? "Gerando anúncios..." : "Gerar anúncios do pipeline"}</span>
+              <span>
+                {pipelineInProgress
+                  ? "Gerando anúncios..."
+                  : "Gerar anúncios do pipeline"}
+              </span>
             </button>
             {pipelineInProgress && (
               <span className="badge text-bg-info-subtle text-info-emphasis">
@@ -872,7 +939,8 @@ export default function CriativosTab({ experimentId }: Props) {
         </div>
       ) : pipelineInProgress ? (
         <div className="alert alert-info mt-3">
-          <strong>Worker AI em produção.</strong> Estamos finalizando os anúncios solicitados com os ativos do pipeline.
+          <strong>Worker AI em produção.</strong> Estamos finalizando os
+          anúncios solicitados com os ativos do pipeline.
         </div>
       ) : null}
 
@@ -894,9 +962,7 @@ export default function CriativosTab({ experimentId }: Props) {
           </p>
         </div>
       ) : creativeSections.length === 0 ? (
-        <div className="creative-grid">
-          {creatives.map(renderCreativeCard)}
-        </div>
+        <div className="creative-grid">{creatives.map(renderCreativeCard)}</div>
       ) : (
         <div className="creative-sections">
           {creativeSections.map((section) => (
@@ -906,7 +972,10 @@ export default function CriativosTab({ experimentId }: Props) {
               aria-labelledby={`${section.id}-title`}
             >
               <div className="creative-section-header">
-                <h3 id={`${section.id}-title`} className="creative-section-title">
+                <h3
+                  id={`${section.id}-title`}
+                  className="creative-section-title"
+                >
                   {section.title}
                 </h3>
                 <span className={`badge rounded-pill ${section.badgeClass}`}>

--- a/frontend/src/pages/experiment/ExperimentAudienceTab.tsx
+++ b/frontend/src/pages/experiment/ExperimentAudienceTab.tsx
@@ -1,11 +1,18 @@
 import { useEffect, useMemo, useState } from "react";
-import { useExperimentTargetingSelections, useSaveExperimentTargetingSelections } from "../../api/experiment/useExperimentTargetingSelections";
+import {
+  useExperimentTargetingSelections,
+  useSaveExperimentTargetingSelections,
+} from "../../api/experiment/useExperimentTargetingSelections";
 import { useTargetingElementsByNiche } from "../../api/targeting/useTargetingElementsByNiche";
-import type { TargetingCandidateType, TargetingElement } from "../../api/targeting/types";
+import type {
+  TargetingCandidateType,
+  TargetingElement,
+} from "../../api/targeting/types";
 
 interface ExperimentAudienceTabProps {
   experimentId: number;
   nicheId?: number | null;
+  alterationLocked?: boolean;
 }
 
 const TYPE_LABEL: Record<TargetingElement["type"], string> = {
@@ -14,7 +21,9 @@ const TYPE_LABEL: Record<TargetingElement["type"], string> = {
   BEHAVIOR: "Comportamento",
 };
 
-function toCandidateType(type: TargetingElement["type"]): TargetingCandidateType {
+function toCandidateType(
+  type: TargetingElement["type"],
+): TargetingCandidateType {
   return type === "JOB_TITLE" ? "WORK_POSITION" : type;
 }
 
@@ -22,14 +31,25 @@ function buildKey(element: TargetingElement) {
   return `${element.type}::${element.id}`;
 }
 
-export function ExperimentAudienceTab({ experimentId, nicheId }: ExperimentAudienceTabProps) {
+export function ExperimentAudienceTab({
+  experimentId,
+  nicheId,
+  alterationLocked = false,
+}: ExperimentAudienceTabProps) {
   const nicheIdAsString = nicheId != null ? String(nicheId) : undefined;
-  const { data: elements, isLoading } = useTargetingElementsByNiche(nicheIdAsString, { status: "APPROVED" });
-  const { data: savedSelections } = useExperimentTargetingSelections(experimentId);
+  const { data: elements, isLoading } = useTargetingElementsByNiche(
+    nicheIdAsString,
+    { status: "APPROVED" },
+  );
+  const { data: savedSelections } =
+    useExperimentTargetingSelections(experimentId);
   const saveSelections = useSaveExperimentTargetingSelections(experimentId);
 
   const availableOptions = useMemo(
-    () => (elements ?? []).filter((item) => item.type === "JOB_TITLE" || item.type === "BEHAVIOR"),
+    () =>
+      (elements ?? []).filter(
+        (item) => item.type === "JOB_TITLE" || item.type === "BEHAVIOR",
+      ),
     [elements],
   );
 
@@ -60,6 +80,7 @@ export function ExperimentAudienceTab({ experimentId, nicheId }: ExperimentAudie
   }, [availableOptions]);
 
   const toggleSelection = (item: TargetingElement) => {
+    if (alterationLocked) return;
     setSelected((prev) => {
       const next = new Set(prev);
       const key = buildKey(item);
@@ -70,7 +91,10 @@ export function ExperimentAudienceTab({ experimentId, nicheId }: ExperimentAudie
   };
 
   const handleSave = async () => {
-    const selectedItems = availableOptions.filter((item) => selected.has(buildKey(item)));
+    if (alterationLocked) return;
+    const selectedItems = availableOptions.filter((item) =>
+      selected.has(buildKey(item)),
+    );
     await saveSelections.mutateAsync({
       items: selectedItems.map((item) => ({
         candidateType: toCandidateType(item.type),
@@ -81,7 +105,11 @@ export function ExperimentAudienceTab({ experimentId, nicheId }: ExperimentAudie
   };
 
   if (nicheId == null) {
-    return <div className="alert alert-warning mt-3 mb-0">Experimento sem nicho vinculado.</div>;
+    return (
+      <div className="alert alert-warning mt-3 mb-0">
+        Experimento sem nicho vinculado.
+      </div>
+    );
   }
 
   return (
@@ -89,13 +117,23 @@ export function ExperimentAudienceTab({ experimentId, nicheId }: ExperimentAudie
       <div className="card-body d-flex flex-column gap-3">
         <div>
           <h5 className="card-title mb-1">Público</h5>
-          <p className="text-muted mb-0 small">Marque somente cargos e comportamentos já aprovados para o nicho.</p>
+          <p className="text-muted mb-0 small">
+            Marque somente cargos e comportamentos já aprovados para o nicho.
+          </p>
+          {alterationLocked ? (
+            <div className="alert alert-secondary mt-3 mb-0" role="status">
+              Público bloqueado para alteração porque o experimento já foi
+              liberado ou está em execução.
+            </div>
+          ) : null}
         </div>
 
         {isLoading ? (
           <div className="text-muted small">Carregando opções do nicho...</div>
         ) : availableOptions.length === 0 ? (
-          <div className="text-muted small">Nenhum cargo/comportamento aprovado foi encontrado para este nicho.</div>
+          <div className="text-muted small">
+            Nenhum cargo/comportamento aprovado foi encontrado para este nicho.
+          </div>
         ) : (
           <div className="row g-3">
             {(["JOB_TITLE", "BEHAVIOR"] as const).map((type) => (
@@ -113,7 +151,9 @@ export function ExperimentAudienceTab({ experimentId, nicheId }: ExperimentAudie
                             type="checkbox"
                             checked={selected.has(key)}
                             onChange={() => toggleSelection(item)}
-                            disabled={saveSelections.isPending}
+                            disabled={
+                              saveSelections.isPending || alterationLocked
+                            }
                           />
                           <label htmlFor={key} className="form-check-label">
                             {item.term}
@@ -129,10 +169,17 @@ export function ExperimentAudienceTab({ experimentId, nicheId }: ExperimentAudie
         )}
 
         <div className="d-flex justify-content-end">
-          <button className="btn btn-primary" onClick={handleSave} disabled={saveSelections.isPending || isLoading}>
+          <button
+            className="btn btn-primary"
+            onClick={handleSave}
+            disabled={saveSelections.isPending || isLoading || alterationLocked}
+          >
             {saveSelections.isPending ? (
               <span className="d-inline-flex align-items-center gap-2">
-                <span className="spinner-border spinner-border-sm" aria-hidden="true" />
+                <span
+                  className="spinner-border spinner-border-sm"
+                  aria-hidden="true"
+                />
                 Salvando...
               </span>
             ) : (

--- a/frontend/src/pages/experiment/ExperimentContentGenerationTab.tsx
+++ b/frontend/src/pages/experiment/ExperimentContentGenerationTab.tsx
@@ -142,7 +142,11 @@ interface AutoQueueState {
   pending: ContentGenerationSectionKey[];
 }
 
-type LandingImageFlowStatus = "NOT_STARTED" | "STARTED" | "PROCESSING" | "COMPLETED";
+type LandingImageFlowStatus =
+  | "NOT_STARTED"
+  | "STARTED"
+  | "PROCESSING"
+  | "COMPLETED";
 
 const ALL_CONTENT_GENERATION_SECTION_KEYS: ContentGenerationSectionKey[] = [
   "campaign-angle",
@@ -205,17 +209,19 @@ const STAGE_LABELS: Record<string, string> = {
   FAILED: "Falhou",
 };
 
-const EXECUTION_SOURCE_LABELS: Record<"WORKER_IA" | "LHM" | "LHM_IA", string> = {
-  WORKER_IA: "Worker IA",
-  LHM: "LHM inline",
-  LHM_IA: "LHM + IA",
-};
+const EXECUTION_SOURCE_LABELS: Record<"WORKER_IA" | "LHM" | "LHM_IA", string> =
+  {
+    WORKER_IA: "Worker IA",
+    LHM: "LHM inline",
+    LHM_IA: "LHM + IA",
+  };
 
-const EXECUTION_SOURCE_BADGES: Record<"WORKER_IA" | "LHM" | "LHM_IA", string> = {
-  WORKER_IA: "primary",
-  LHM: "info",
-  LHM_IA: "dark",
-};
+const EXECUTION_SOURCE_BADGES: Record<"WORKER_IA" | "LHM" | "LHM_IA", string> =
+  {
+    WORKER_IA: "primary",
+    LHM: "info",
+    LHM_IA: "dark",
+  };
 
 const LANDING_IMAGE_FLOW_LABELS: Record<LandingImageFlowStatus, string> = {
   NOT_STARTED: "Não iniciado",
@@ -596,7 +602,6 @@ artifact {
   }
 }`;
 
-
 const SECTION_PROMPT_DEFAULTS: Partial<
   Record<ContentGenerationSectionKey, string>
 > = {
@@ -624,6 +629,7 @@ interface ExperimentContentGenerationTabProps {
   hypothesis?: Hypothesis;
   campaignAngle?: string | null;
   adCopy?: string | null;
+  alterationLocked?: boolean;
 }
 
 interface AiGenerationRecord {
@@ -1203,6 +1209,7 @@ export default function ExperimentContentGenerationTab({
   hypothesis,
   campaignAngle,
   adCopy,
+  alterationLocked = false,
 }: ExperimentContentGenerationTabProps) {
   const [activeSection, setActiveSection] =
     useState<ContentGenerationSectionKey>(CONTENT_GENERATION_SECTIONS[0].key);
@@ -1574,7 +1581,9 @@ export default function ExperimentContentGenerationTab({
               latestTimestamp: parsedTimestamp,
               models: new Set(model ? [model] : []),
               jobIds: [item.id],
-              openAiResponseIds: new Set(openAiResponseId ? [openAiResponseId] : []),
+              openAiResponseIds: new Set(
+                openAiResponseId ? [openAiResponseId] : [],
+              ),
             });
             return;
           }
@@ -1624,26 +1633,28 @@ export default function ExperimentContentGenerationTab({
     () =>
       CONTENT_GENERATION_SECTIONS.reduce<
         Record<ContentGenerationSectionKey, ContentGenerationSection>
-      >((acc, section) => {
-        acc[section.key] = section;
-        return acc;
-      }, {} as Record<ContentGenerationSectionKey, ContentGenerationSection>),
+      >(
+        (acc, section) => {
+          acc[section.key] = section;
+          return acc;
+        },
+        {} as Record<ContentGenerationSectionKey, ContentGenerationSection>,
+      ),
     [],
   );
 
   const loadCampaignAngles = useCallback(async () => {
     try {
       setIsLoadingCampaignAngles(true);
-      const { data: response } = await axios.get<PageResponse<AiGenerationRecord>>(
-        "/api/ai/generations",
-        {
-          params: {
-            referenceId: experimentId,
-            domain: "experiment.pipeline.campaign-angle",
-            size: 20,
-          },
+      const { data: response } = await axios.get<
+        PageResponse<AiGenerationRecord>
+      >("/api/ai/generations", {
+        params: {
+          referenceId: experimentId,
+          domain: "experiment.pipeline.campaign-angle",
+          size: 20,
         },
-      );
+      });
 
       const orderedByLatest = [...(response.content ?? [])]
         .map((generation) => ({
@@ -1707,16 +1718,15 @@ export default function ExperimentContentGenerationTab({
   const loadAdCopy = useCallback(async () => {
     try {
       setIsLoadingAdCopy(true);
-      const { data: response } = await axios.get<PageResponse<AiGenerationRecord>>(
-        "/api/ai/generations",
-        {
-          params: {
-            referenceId: experimentId,
-            domain: "experiment.pipeline.ad-copy",
-            size: 20,
-          },
+      const { data: response } = await axios.get<
+        PageResponse<AiGenerationRecord>
+      >("/api/ai/generations", {
+        params: {
+          referenceId: experimentId,
+          domain: "experiment.pipeline.ad-copy",
+          size: 20,
         },
-      );
+      });
 
       const orderedByLatest = [...(response.content ?? [])]
         .map((generation) => ({
@@ -1827,7 +1837,9 @@ export default function ExperimentContentGenerationTab({
     if (autoQueue.pending.length === 0) {
       setAutoQueue(AUTO_QUEUE_INITIAL_STATE);
       imageGenerationWaitToastRef.current = null;
-      toast.success("Fila automática finalizada. Todas as etapas foram solicitadas.");
+      toast.success(
+        "Fila automática finalizada. Todas as etapas foram solicitadas.",
+      );
       return;
     }
 
@@ -1838,7 +1850,8 @@ export default function ExperimentContentGenerationTab({
       nextSectionKey === "landing-design-preset"
     ) {
       const stillLoadingImageStatuses =
-        frameworkImageStatusQuery.isLoading || frameworkImageStatusQuery.isFetching;
+        frameworkImageStatusQuery.isLoading ||
+        frameworkImageStatusQuery.isFetching;
       const mustWaitForImages =
         stillLoadingImageStatuses ||
         !hasFrameworkImages ||
@@ -2130,6 +2143,12 @@ export default function ExperimentContentGenerationTab({
 
   return (
     <div className="mt-3 d-flex flex-column gap-3">
+      {alterationLocked ? (
+        <div className="alert alert-secondary mb-0" role="status">
+          Gerações de conteúdo bloqueadas para alteração porque o experimento já
+          foi liberado ou está em execução.
+        </div>
+      ) : null}
       <div className="d-flex justify-content-end">
         <button
           type="button"
@@ -2211,7 +2230,9 @@ export default function ExperimentContentGenerationTab({
           >
             {LANDING_IMAGE_FLOW_LABELS[landingImageFlowStatus]}
           </span>
-          <span className="small text-body-secondary">{landingImageFlowMessage}</span>
+          <span className="small text-body-secondary">
+            {landingImageFlowMessage}
+          </span>
         </div>
       </div>
 
@@ -2246,174 +2267,194 @@ export default function ExperimentContentGenerationTab({
                 (frameworkImageStatusQuery.isLoading ||
                   hasFrameworkImagesInFlight);
               return (
-            <section className="card">
-              <div className="card-body">
-                <div className="d-flex justify-content-between align-items-start flex-wrap gap-2">
-                  <div>
-                    <h5 className="card-title mb-1">{section.label}</h5>
-                    <p className="text-muted mb-0">{section.description}</p>
-                    {section.key === "landing-html" ? (
-                      <p className="small text-body-secondary mt-2 mb-0">
-                        Geração manual do HTML final da landing. Execute LHM e IA em botões separados.
-                      </p>
-                    ) : null}
-                  </div>
-                  <div className="d-flex align-items-start flex-wrap gap-2">
-                    {section.key === "landing-html" ? (
-                      <>
-                        <button
-                          type="button"
-                          className="btn btn-outline-info btn-sm"
-                          onClick={() => void handleGenerateLandingLhm()}
-                          disabled={
-                            isGeneratingWithLhm ||
-                            isGeneratingSection ||
-                            autoQueue.isActive ||
-                            isLandingFlowBlockedByImageGeneration
-                          }
-                          title="Gera somente a variante determinística com LHM."
-                        >
-                          {isGeneratingWithLhm ? "Gerando com LHM..." : "Gerar com LHM"}
-                        </button>
-                        <button
-                          type="button"
-                          className="btn btn-outline-primary btn-sm"
-                          onClick={() => void handleGenerateSection(section)}
-                          disabled={
-                            isGeneratingSection ||
-                            isGeneratingWithLhm ||
-                            autoQueue.isActive ||
-                            isLandingFlowBlockedByImageGeneration
-                          }
-                          title='Solicita ao Worker IA a geração da etapa "HTML da Landing".'
-                        >
-                          {isGeneratingSection &&
-                          pendingGenerationSection === section.key ? "Gerando com IA..." : "Gerar com IA"}
-                        </button>
-                      </>
-                    ) : (
-                      <button
-                        type="button"
-                        className="btn btn-outline-primary btn-sm"
-                        onClick={() => void handleGenerateSection(section)}
-                        disabled={
-                          isGeneratingSection ||
-                          isGeneratingWithLhm ||
-                          autoQueue.isActive ||
-                          isLandingFlowBlockedByImageGeneration
-                        }
-                        title={`Solicita ao Worker IA a geração da etapa "${section.label}" com prompt canônico do pipeline.`}
-                      >
-                        {isGeneratingSection &&
-                        pendingGenerationSection === section.key ? (
-                          <span className="d-inline-flex align-items-center gap-1">
-                            <span
-                              className="spinner-border spinner-border-sm"
-                              role="status"
-                              aria-hidden="true"
-                            />
-                            Gerando com IA...
-                          </span>
-                        ) : autoQueue.isActive ? (
-                          <span className="d-inline-flex align-items-center gap-1">
-                            <span
-                              className="spinner-border spinner-border-sm"
-                              role="status"
-                              aria-hidden="true"
-                            />
-                            Fila em execução...
-                          </span>
-                        ) : isLandingFlowBlockedByImageGeneration ? (
-                          <span className="d-inline-flex align-items-center gap-1">
-                            <span
-                              className="spinner-border spinner-border-sm"
-                              role="status"
-                              aria-hidden="true"
-                            />
-                            Gerando imagens...
-                          </span>
-                        ) : (
-                          "Gerar com IA"
-                        )}
-                      </button>
-                    )}
-                    <span className="badge text-bg-light">
-                      Estrutura pronta para prompt
-                    </span>
-                  </div>
-                </div>
-
-                <div className="row g-3 mt-1">
-                  <div className="col-12">
-                    {section.key === "campaign-angle" ? (
-                      <>
-                        <CampaignAngleSummaryPanel
-                          isLoading={isLoadingCampaignAngles}
-                          savedAngle={persistedCampaignAngle}
-                          fallbackAngle={campaignAngleGenerations[0]?.fields}
-                          fallbackTimestamp={
-                            campaignAngleGenerations[0]?.createdAt
-                          }
-                          rawContent={campaignAngle}
-                        />
-                        <CampaignAngleHistoryList
-                          generations={campaignAngleGenerations}
-                          isLoading={isLoadingCampaignAngles}
-                        />
-                      </>
-                    ) : section.key === "ad-copy" ? (
-                      <>
-                        <AdCopySummaryPanel
-                          isLoading={isLoadingAdCopy}
-                          savedCopy={persistedAdCopy}
-                          fallbackCopy={adCopyGenerations[0]?.fields}
-                          fallbackTimestamp={adCopyGenerations[0]?.createdAt}
-                          rawContent={adCopy}
-                        />
-                        <AdCopyHistoryList
-                          generations={adCopyGenerations}
-                          isLoading={isLoadingAdCopy}
-                        />
-                      </>
-                    ) : (
-                      <>
-                        <GenericGenerationSummaryPanel
-                          experimentId={experimentId}
-                          section={section}
-                          isLoading={isLoadingSectionGenerations[section.key]}
-                          latestGeneration={sectionGenerations[section.key][0]}
-                          sourceJobId={latestJobIdBySection[section.key]}
-                        />
-                        <GenericGenerationHistoryList
-                          section={section}
-                          generations={sectionGenerations[section.key]}
-                          isLoading={isLoadingSectionGenerations[section.key]}
-                        />
-                        {section.key === "landing-image-planning" ? (
-                          <FrameworkImageGenerationPanel
-                            onGenerate={async () => {
-                              try {
-                                await generateFrameworkImages.mutateAsync();
-                                toast.success(
-                                  "Solicitação de geração das imagens enviada para o Worker IA.",
-                                );
-                              } catch (error) {
-                                toast.error(getErrorMessage(error));
-                              }
-                            }}
-                            isGenerating={generateFrameworkImages.isPending}
-                            statuses={frameworkImageStatusQuery.data ?? []}
-                            isLoading={frameworkImageStatusQuery.isLoading}
-                            isError={frameworkImageStatusQuery.isError}
-                          />
+                <section className="card">
+                  <div className="card-body">
+                    <div className="d-flex justify-content-between align-items-start flex-wrap gap-2">
+                      <div>
+                        <h5 className="card-title mb-1">{section.label}</h5>
+                        <p className="text-muted mb-0">{section.description}</p>
+                        {section.key === "landing-html" ? (
+                          <p className="small text-body-secondary mt-2 mb-0">
+                            Geração manual do HTML final da landing. Execute LHM
+                            e IA em botões separados.
+                          </p>
                         ) : null}
-                      </>
-                    )}
-                  </div>
-                </div>
+                      </div>
+                      <div className="d-flex align-items-start flex-wrap gap-2">
+                        {section.key === "landing-html" ? (
+                          <>
+                            <button
+                              type="button"
+                              className="btn btn-outline-info btn-sm"
+                              onClick={() => void handleGenerateLandingLhm()}
+                              disabled={
+                                alterationLocked ||
+                                isGeneratingWithLhm ||
+                                isGeneratingSection ||
+                                autoQueue.isActive ||
+                                isLandingFlowBlockedByImageGeneration
+                              }
+                              title="Gera somente a variante determinística com LHM."
+                            >
+                              {isGeneratingWithLhm
+                                ? "Gerando com LHM..."
+                                : "Gerar com LHM"}
+                            </button>
+                            <button
+                              type="button"
+                              className="btn btn-outline-primary btn-sm"
+                              onClick={() =>
+                                void handleGenerateSection(section)
+                              }
+                              disabled={
+                                alterationLocked ||
+                                isGeneratingSection ||
+                                isGeneratingWithLhm ||
+                                autoQueue.isActive ||
+                                isLandingFlowBlockedByImageGeneration
+                              }
+                              title='Solicita ao Worker IA a geração da etapa "HTML da Landing".'
+                            >
+                              {isGeneratingSection &&
+                              pendingGenerationSection === section.key
+                                ? "Gerando com IA..."
+                                : "Gerar com IA"}
+                            </button>
+                          </>
+                        ) : (
+                          <button
+                            type="button"
+                            className="btn btn-outline-primary btn-sm"
+                            onClick={() => void handleGenerateSection(section)}
+                            disabled={
+                              alterationLocked ||
+                              isGeneratingSection ||
+                              isGeneratingWithLhm ||
+                              autoQueue.isActive ||
+                              isLandingFlowBlockedByImageGeneration
+                            }
+                            title={`Solicita ao Worker IA a geração da etapa "${section.label}" com prompt canônico do pipeline.`}
+                          >
+                            {isGeneratingSection &&
+                            pendingGenerationSection === section.key ? (
+                              <span className="d-inline-flex align-items-center gap-1">
+                                <span
+                                  className="spinner-border spinner-border-sm"
+                                  role="status"
+                                  aria-hidden="true"
+                                />
+                                Gerando com IA...
+                              </span>
+                            ) : autoQueue.isActive ? (
+                              <span className="d-inline-flex align-items-center gap-1">
+                                <span
+                                  className="spinner-border spinner-border-sm"
+                                  role="status"
+                                  aria-hidden="true"
+                                />
+                                Fila em execução...
+                              </span>
+                            ) : isLandingFlowBlockedByImageGeneration ? (
+                              <span className="d-inline-flex align-items-center gap-1">
+                                <span
+                                  className="spinner-border spinner-border-sm"
+                                  role="status"
+                                  aria-hidden="true"
+                                />
+                                Gerando imagens...
+                              </span>
+                            ) : (
+                              "Gerar com IA"
+                            )}
+                          </button>
+                        )}
+                        <span className="badge text-bg-light">
+                          Estrutura pronta para prompt
+                        </span>
+                      </div>
+                    </div>
 
-              </div>
-            </section>
+                    <div className="row g-3 mt-1">
+                      <div className="col-12">
+                        {section.key === "campaign-angle" ? (
+                          <>
+                            <CampaignAngleSummaryPanel
+                              isLoading={isLoadingCampaignAngles}
+                              savedAngle={persistedCampaignAngle}
+                              fallbackAngle={
+                                campaignAngleGenerations[0]?.fields
+                              }
+                              fallbackTimestamp={
+                                campaignAngleGenerations[0]?.createdAt
+                              }
+                              rawContent={campaignAngle}
+                            />
+                            <CampaignAngleHistoryList
+                              generations={campaignAngleGenerations}
+                              isLoading={isLoadingCampaignAngles}
+                            />
+                          </>
+                        ) : section.key === "ad-copy" ? (
+                          <>
+                            <AdCopySummaryPanel
+                              isLoading={isLoadingAdCopy}
+                              savedCopy={persistedAdCopy}
+                              fallbackCopy={adCopyGenerations[0]?.fields}
+                              fallbackTimestamp={
+                                adCopyGenerations[0]?.createdAt
+                              }
+                              rawContent={adCopy}
+                            />
+                            <AdCopyHistoryList
+                              generations={adCopyGenerations}
+                              isLoading={isLoadingAdCopy}
+                            />
+                          </>
+                        ) : (
+                          <>
+                            <GenericGenerationSummaryPanel
+                              experimentId={experimentId}
+                              section={section}
+                              isLoading={
+                                isLoadingSectionGenerations[section.key]
+                              }
+                              latestGeneration={
+                                sectionGenerations[section.key][0]
+                              }
+                              sourceJobId={latestJobIdBySection[section.key]}
+                            />
+                            <GenericGenerationHistoryList
+                              section={section}
+                              generations={sectionGenerations[section.key]}
+                              isLoading={
+                                isLoadingSectionGenerations[section.key]
+                              }
+                            />
+                            {section.key === "landing-image-planning" ? (
+                              <FrameworkImageGenerationPanel
+                                onGenerate={async () => {
+                                  try {
+                                    await generateFrameworkImages.mutateAsync();
+                                    toast.success(
+                                      "Solicitação de geração das imagens enviada para o Worker IA.",
+                                    );
+                                  } catch (error) {
+                                    toast.error(getErrorMessage(error));
+                                  }
+                                }}
+                                isGenerating={generateFrameworkImages.isPending}
+                                alterationLocked={alterationLocked}
+                                statuses={frameworkImageStatusQuery.data ?? []}
+                                isLoading={frameworkImageStatusQuery.isLoading}
+                                isError={frameworkImageStatusQuery.isError}
+                              />
+                            ) : null}
+                          </>
+                        )}
+                      </div>
+                    </div>
+                  </div>
+                </section>
               );
             })()}
           </Tabs.Content>
@@ -2459,15 +2500,14 @@ export default function ExperimentContentGenerationTab({
                   ? "PROCESSING"
                   : request.status;
               const waitingDependency = invalidation?.requiresRefresh === true;
-              const displayStatus: RequestUiStatus =
-                waitingDependency
+              const displayStatus: RequestUiStatus = waitingDependency
+                ? "PROCESSING"
+                : effectiveRequestStatus === "PROCESSING" ||
+                    effectiveRequestStatus === "PENDING"
                   ? "PROCESSING"
-                  : effectiveRequestStatus === "PROCESSING" ||
-                      effectiveRequestStatus === "PENDING"
-                    ? "PROCESSING"
-                    : invalidation
-                      ? "INVALIDATED"
-                      : effectiveRequestStatus;
+                  : invalidation
+                    ? "INVALIDATED"
+                    : effectiveRequestStatus;
               const workerStatus = getWorkerStatus(request);
               const executionSource = request.executionSource ?? "WORKER_IA";
               const backendError = parseBackendError(request.errorMessage);
@@ -2528,10 +2568,10 @@ export default function ExperimentContentGenerationTab({
                             ? `última execução finalizada em ${formatDateTime(request.completedAt)}`
                             : "aguardando nova execução"
                           : request.startedAt
-                          ? `iniciado em ${formatDateTime(request.startedAt)}`
-                          : request.status === "PENDING"
-                            ? "aguardando início"
-                            : "sem início registrado"}
+                            ? `iniciado em ${formatDateTime(request.startedAt)}`
+                            : request.status === "PENDING"
+                              ? "aguardando início"
+                              : "sem início registrado"}
                       </span>
                     </div>
                     <div>
@@ -2539,13 +2579,13 @@ export default function ExperimentContentGenerationTab({
                       {waitingDependency
                         ? `aguardando conclusão de ${invalidation?.sourceSection} para atualizar esta etapa.`
                         : isLandingImagePlanningSection &&
-                      landingImageFlowStatus !== "COMPLETED"
-                        ? "aguardando conclusão da geração das imagens planejadas."
-                        : request.completedAt
-                        ? `finalizada em ${formatDateTime(request.completedAt)}.`
-                        : request.status === "FAILED"
-                          ? "fluxo encerrado com erro."
-                          : "aguardando finalização."}
+                            landingImageFlowStatus !== "COMPLETED"
+                          ? "aguardando conclusão da geração das imagens planejadas."
+                          : request.completedAt
+                            ? `finalizada em ${formatDateTime(request.completedAt)}.`
+                            : request.status === "FAILED"
+                              ? "fluxo encerrado com erro."
+                              : "aguardando finalização."}
                     </div>
                   </div>
                   {isLandingImagePlanningSection ? (
@@ -2657,7 +2697,9 @@ export default function ExperimentContentGenerationTab({
                         {historyGroup.description}
                       </p>
                     </div>
-                    <span className={`badge text-bg-${historyGroup.badgeClass}`}>
+                    <span
+                      className={`badge text-bg-${historyGroup.badgeClass}`}
+                    >
                       {historyGroup.badgeLabel}
                     </span>
                   </div>
@@ -2684,27 +2726,42 @@ export default function ExperimentContentGenerationTab({
                           >
                             <div className="d-flex flex-wrap align-items-center gap-2">
                               <strong>Tentativa #{job.id.slice(0, 8)}</strong>
-                              <span className={`badge text-bg-${statusBadge}`}>{statusLabel}</span>
+                              <span className={`badge text-bg-${statusBadge}`}>
+                                {statusLabel}
+                              </span>
                             </div>
                             <div className="small mt-1 d-flex flex-column gap-1">
                               <span>
                                 Solicitação registrada:{" "}
-                                <strong>{formatDateTimeWithTimezone(job.createdAt)}</strong>
+                                <strong>
+                                  {formatDateTimeWithTimezone(job.createdAt)}
+                                </strong>
                               </span>
                               <span>
-                                Início: <strong>{formatDateTimeWithTimezone(job.startedAt)}</strong>
+                                Início:{" "}
+                                <strong>
+                                  {formatDateTimeWithTimezone(job.startedAt)}
+                                </strong>
                                 {" · "}
-                                Fim: <strong>{formatDateTimeWithTimezone(job.finishedAt)}</strong>
+                                Fim:{" "}
+                                <strong>
+                                  {formatDateTimeWithTimezone(job.finishedAt)}
+                                </strong>
                               </span>
                               {parsedError?.timestamp ? (
                                 <span>
                                   Erro retornado pelo backend em{" "}
-                                  <strong>{formatDateTimeWithTimezone(parsedError.timestamp)}</strong>
+                                  <strong>
+                                    {formatDateTimeWithTimezone(
+                                      parsedError.timestamp,
+                                    )}
+                                  </strong>
                                 </span>
                               ) : null}
                               {job.errorMessage ? (
                                 <span className="text-danger">
-                                  Motivo: {parsedError?.message ?? job.errorMessage}
+                                  Motivo:{" "}
+                                  {parsedError?.message ?? job.errorMessage}
                                 </span>
                               ) : null}
                             </div>
@@ -3256,7 +3313,10 @@ function PipelinePromptVersionsPanel({
 
         {isLoading ? (
           <div className="d-flex align-items-center gap-2 text-muted small">
-            <span className="spinner-border spinner-border-sm" aria-hidden="true" />
+            <span
+              className="spinner-border spinner-border-sm"
+              aria-hidden="true"
+            />
             Carregando versões de prompts...
           </div>
         ) : null}
@@ -3280,15 +3340,21 @@ function PipelinePromptVersionsPanel({
                   </div>
                   <div className="d-flex flex-column gap-2">
                     {section.versions.map((version, index) => (
-                      <details key={`${section.key}-${index}`} className="border rounded p-2 bg-body">
+                      <details
+                        key={`${section.key}-${index}`}
+                        className="border rounded p-2 bg-body"
+                      >
                         <summary className="small fw-semibold" role="button">
-                          Versão {index + 1} · {version.occurrences} execução(ões)
+                          Versão {index + 1} · {version.occurrences}{" "}
+                          execução(ões)
                         </summary>
                         <p className="small mb-1 mt-2">
-                          <strong>Último uso:</strong> {formatDateTime(version.latestUsedAt)}
+                          <strong>Último uso:</strong>{" "}
+                          {formatDateTime(version.latestUsedAt)}
                         </p>
                         <p className="small mb-2">
-                          <strong>Modelos:</strong> {version.models.join(", ") || "—"}
+                          <strong>Modelos:</strong>{" "}
+                          {version.models.join(", ") || "—"}
                         </p>
                         <p className="small mb-2">
                           <strong>Jobs:</strong> {version.jobIds.join(", ")}
@@ -3315,6 +3381,7 @@ function PipelinePromptVersionsPanel({
 
 interface FrameworkImageGenerationPanelProps {
   statuses: FrameworkImageStatusItem[];
+  alterationLocked?: boolean;
   isLoading: boolean;
   isError: boolean;
   isGenerating: boolean;
@@ -3371,6 +3438,7 @@ function FrameworkImageGenerationPanel({
   isError,
   isGenerating,
   onGenerate,
+  alterationLocked = false,
 }: FrameworkImageGenerationPanelProps) {
   const sortedStatuses = useMemo(
     () =>
@@ -3396,20 +3464,24 @@ function FrameworkImageGenerationPanel({
       <div className="card-body">
         <div className="d-flex justify-content-between align-items-start flex-wrap gap-2">
           <div>
-            <h6 className="card-title mb-1">Gerar imagens em lote (AI Worker)</h6>
+            <h6 className="card-title mb-1">
+              Gerar imagens em lote (AI Worker)
+            </h6>
             <p className="text-muted small mb-0">
-              Após a etapa de prompt de imagem, esta etapa envia todos os prompts
-              pendentes para o AI Worker em modo batch na OpenAI e mostra a
-              timeline operacional completa.
+              Após a etapa de prompt de imagem, esta etapa envia todos os
+              prompts pendentes para o AI Worker em modo batch na OpenAI e
+              mostra a timeline operacional completa.
             </p>
           </div>
           <div className="d-flex align-items-center gap-2">
-            <span className="badge text-bg-light">{readyToGenerateCount} pendente(s)</span>
+            <span className="badge text-bg-light">
+              {readyToGenerateCount} pendente(s)
+            </span>
             <button
               type="button"
               className="btn btn-success btn-sm"
               onClick={() => void onGenerate()}
-              disabled={isGenerating}
+              disabled={isGenerating || alterationLocked}
             >
               {isGenerating ? (
                 <span className="d-inline-flex align-items-center gap-1">
@@ -3429,7 +3501,10 @@ function FrameworkImageGenerationPanel({
 
         {isLoading ? (
           <div className="d-flex align-items-center gap-2 text-muted mt-3">
-            <span className="spinner-border spinner-border-sm" aria-hidden="true" />
+            <span
+              className="spinner-border spinner-border-sm"
+              aria-hidden="true"
+            />
             Carregando status de geração...
           </div>
         ) : null}
@@ -3461,25 +3536,35 @@ function FrameworkImageGenerationPanel({
               </thead>
               <tbody>
                 {sortedStatuses.map((item) => {
-                  const normalizedStatus = item.status?.toUpperCase() ?? "PLANNED";
+                  const normalizedStatus =
+                    item.status?.toUpperCase() ?? "PLANNED";
                   const statusLabel =
-                    normalizedStatus === "PLANNED" ? "Planejada" : normalizedStatus;
-                  const badge = FRAMEWORK_IMAGE_STATUS_BADGE[normalizedStatus] ?? "light";
+                    normalizedStatus === "PLANNED"
+                      ? "Planejada"
+                      : normalizedStatus;
+                  const badge =
+                    FRAMEWORK_IMAGE_STATUS_BADGE[normalizedStatus] ?? "light";
                   const stageLabel = item.stage
-                    ? FRAMEWORK_IMAGE_STAGE_LABEL[item.stage] ?? item.stage
+                    ? (FRAMEWORK_IMAGE_STAGE_LABEL[item.stage] ?? item.stage)
                     : "Aguardando processamento";
 
                   return (
                     <tr key={item.planningItemKey}>
                       <td>
-                        <div className="fw-semibold">{item.sectionName ?? item.planningItemKey}</div>
+                        <div className="fw-semibold">
+                          {item.sectionName ?? item.planningItemKey}
+                        </div>
                         {item.sectionName &&
                         item.planningItemKey !== item.sectionName ? (
-                          <div className="small text-muted">{item.planningItemKey}</div>
+                          <div className="small text-muted">
+                            {item.planningItemKey}
+                          </div>
                         ) : null}
                       </td>
                       <td>
-                        <span className={`badge text-bg-${badge}`}>{statusLabel}</span>
+                        <span className={`badge text-bg-${badge}`}>
+                          {statusLabel}
+                        </span>
                         {item.errorMessage ? (
                           <div className="small text-danger mt-1">
                             Erro: {item.errorMessage}
@@ -3490,7 +3575,11 @@ function FrameworkImageGenerationPanel({
                       <td className="small">{item.model ?? "—"}</td>
                       <td className="small">
                         {item.sourceUrl ? (
-                          <a href={item.sourceUrl} target="_blank" rel="noreferrer">
+                          <a
+                            href={item.sourceUrl}
+                            target="_blank"
+                            rel="noreferrer"
+                          >
                             Ver origem
                           </a>
                         ) : (
@@ -3499,7 +3588,11 @@ function FrameworkImageGenerationPanel({
                       </td>
                       <td className="small">
                         {item.webUrl ? (
-                          <a href={item.webUrl} target="_blank" rel="noreferrer">
+                          <a
+                            href={item.webUrl}
+                            target="_blank"
+                            rel="noreferrer"
+                          >
                             Ver versão final
                           </a>
                         ) : (
@@ -3507,7 +3600,9 @@ function FrameworkImageGenerationPanel({
                         )}
                       </td>
                       <td className="small">
-                        {formatDateTime(item.updatedAt ?? item.finishedAt ?? item.startedAt)}
+                        {formatDateTime(
+                          item.updatedAt ?? item.finishedAt ?? item.startedAt,
+                        )}
                       </td>
                     </tr>
                   );
@@ -3865,8 +3960,8 @@ function LandingHtmlPreview({
   const frameworkImageStatusQuery = useFrameworkImageStatuses(experimentId);
   const resolvedGeneratedImages = useMemo(
     () =>
-      (frameworkImageStatusQuery.data ?? []).filter(
-        (item) => Boolean(item.webUrl || item.sourceUrl),
+      (frameworkImageStatusQuery.data ?? []).filter((item) =>
+        Boolean(item.webUrl || item.sourceUrl),
       ),
     [frameworkImageStatusQuery.data],
   );
@@ -3889,9 +3984,9 @@ function LandingHtmlPreview({
         </div>
       ) : null}
       <div className="alert alert-light border py-2 mb-0">
-        <strong>Procedimento canônico:</strong> esta etapa trabalha com duas versões
-        públicas da landing (LHM determinístico + IA) usando a mesma entrada
-        canônica e validações equivalentes.
+        <strong>Procedimento canônico:</strong> esta etapa trabalha com duas
+        versões públicas da landing (LHM determinístico + IA) usando a mesma
+        entrada canônica e validações equivalentes.
       </div>
       {deterministicUrl || aiUrl ? (
         <div className="card border-0 shadow-sm">
@@ -3916,7 +4011,8 @@ function LandingHtmlPreview({
               ) : null}
               {content.canonicalInputHash ? (
                 <div className="text-muted">
-                  Hash da entrada canônica: <code>{content.canonicalInputHash}</code>
+                  Hash da entrada canônica:{" "}
+                  <code>{content.canonicalInputHash}</code>
                 </div>
               ) : null}
             </div>
@@ -3924,7 +4020,8 @@ function LandingHtmlPreview({
         </div>
       ) : null}
       <div className="alert alert-info py-2 mb-0 small" role="status">
-        A aprovação final da landing para campanha acontece exclusivamente na aba
+        A aprovação final da landing para campanha acontece exclusivamente na
+        aba
         <strong> Landing</strong> deste experimento.
       </div>
       {canRender ? (
@@ -3945,7 +4042,9 @@ function LandingHtmlPreview({
         <div className="card-body">
           <div className="d-flex justify-content-between align-items-start flex-wrap gap-2">
             <div>
-              <h6 className="card-title mb-1">Visão final: landing + imagens</h6>
+              <h6 className="card-title mb-1">
+                Visão final: landing + imagens
+              </h6>
               <p className="text-muted small mb-0">
                 Centraliza o HTML final com as imagens geradas para revisão
                 antes da aprovação.
@@ -3988,14 +4087,20 @@ function LandingHtmlPreview({
                   </div>
                 ) : null}
                 {frameworkImageStatusQuery.isError ? (
-                  <div className="alert alert-danger py-2 mb-0 small" role="alert">
+                  <div
+                    className="alert alert-danger py-2 mb-0 small"
+                    role="alert"
+                  >
                     Não foi possível carregar as imagens geradas.
                   </div>
                 ) : null}
                 {!frameworkImageStatusQuery.isLoading &&
                 !frameworkImageStatusQuery.isError &&
                 resolvedGeneratedImages.length === 0 ? (
-                  <div className="alert alert-secondary py-2 mb-0 small" role="status">
+                  <div
+                    className="alert alert-secondary py-2 mb-0 small"
+                    role="status"
+                  >
                     Nenhuma imagem final disponível ainda. Gere as imagens no
                     bloco de planejamento.
                   </div>
@@ -4016,7 +4121,11 @@ function LandingHtmlPreview({
                             src={imageUrl}
                             alt={item.sectionName ?? item.planningItemKey}
                             className="img-fluid rounded border"
-                            style={{ maxHeight: "140px", width: "100%", objectFit: "cover" }}
+                            style={{
+                              maxHeight: "140px",
+                              width: "100%",
+                              objectFit: "cover",
+                            }}
                           />
                           <p className="small fw-semibold mb-1 mt-2">
                             {item.sectionName ?? item.planningItemKey}

--- a/frontend/src/pages/experiment/ExperimentDetailPage.tsx
+++ b/frontend/src/pages/experiment/ExperimentDetailPage.tsx
@@ -203,6 +203,27 @@ function resolveQualityReviewApprovalBadgeClass(
   return "text-bg-secondary";
 }
 
+const EXPERIMENT_ALTERATION_LOCK_STATUSES = new Set([
+  "RUNNING",
+  "PAUSED",
+  "USER_STOPPED",
+  "VALIDATED",
+  "INVALIDATED",
+  "INCONCLUSIVE",
+  "FINISHED",
+]);
+
+function isExperimentAlterationLocked(experiment: {
+  status?: string | null;
+  facebookReleaseRequestedAt?: string | null;
+}) {
+  const normalizedStatus = (experiment.status ?? "").trim().toUpperCase();
+  return (
+    Boolean(experiment.facebookReleaseRequestedAt) ||
+    EXPERIMENT_ALTERATION_LOCK_STATUSES.has(normalizedStatus)
+  );
+}
+
 export default function ExperimentDetailPage() {
   const { id } = useParams();
   const expId = id as string;
@@ -1549,6 +1570,7 @@ export default function ExperimentDetailPage() {
   }, [hasRunningGeraLandingExecution, refetchCompletedGeraLandingExecutions]);
   if (isLoading) return <p>Carregando...</p>;
   if (!data) return <p>Não encontrado</p>;
+  const alterationLocked = isExperimentAlterationLocked(data);
   const preset = presets?.find((p) => p.id === data.metricPresetId);
   const resetPreviewSummary: ExperimentCampaignResetSummary =
     resetPreviewData ?? { campaigns: 0, adSets: 0, ads: 0, creatives: 0 };
@@ -1564,6 +1586,7 @@ export default function ExperimentDetailPage() {
       : "Não foi possível carregar a prévia do reset."
     : null;
   const confirmResetDisabled =
+    alterationLocked ||
     isFetchingResetPreview ||
     !hasItemsToReset ||
     Boolean(previewErrorMessage) ||
@@ -1591,9 +1614,10 @@ export default function ExperimentDetailPage() {
     diagnosticsUpdatedAt > 0
       ? formatDateTimeValue(new Date(diagnosticsUpdatedAt).toISOString())
       : null;
+  const diagnosticsArtifacts = diagnostics?.artifacts ?? [];
   const shouldShowDiagnostics =
     !!diagnostics &&
-    diagnostics.headline.trim().toLowerCase() !==
+    (diagnostics.headline ?? "").trim().toLowerCase() !==
       "nenhuma inconsistência detectada";
   const baseKpi = data.kpiTarget ?? data.kpiTargetCpl;
   const stopLossFactor = preset?.stopLossFactor;
@@ -1665,7 +1689,10 @@ export default function ExperimentDetailPage() {
   const canReleaseExperiment =
     isReadyForFacebook && data.platform === "FACEBOOK";
   const releaseButtonDisabled =
-    releaseInProgress || !canReleaseExperiment || isLoadingReadiness;
+    releaseInProgress ||
+    !canReleaseExperiment ||
+    isLoadingReadiness ||
+    alterationLocked;
 
   const configurationChecklist: ChecklistItem[] = [
     {
@@ -1918,12 +1945,32 @@ export default function ExperimentDetailPage() {
           <p className="text-muted mb-0">{data.hypothesis}</p>
         </div>
         <div className="d-flex align-items-center">
-          <Link to="edit" className="btn btn-outline-secondary me-2">
-            Editar
-          </Link>
-          <Link to="adset-workflow" className="btn btn-outline-primary me-2">
-            Playbook de Ad Sets
-          </Link>
+          {alterationLocked ? (
+            <span
+              className="btn btn-outline-secondary disabled me-2"
+              aria-disabled="true"
+              title="Alterações desabilitadas após a liberação/publicação do experimento."
+            >
+              Editar
+            </span>
+          ) : (
+            <Link to="edit" className="btn btn-outline-secondary me-2">
+              Editar
+            </Link>
+          )}
+          {alterationLocked ? (
+            <span
+              className="btn btn-outline-primary disabled me-2"
+              aria-disabled="true"
+              title="Playbook bloqueado após a liberação/publicação do experimento."
+            >
+              Playbook de Ad Sets
+            </span>
+          ) : (
+            <Link to="adset-workflow" className="btn btn-outline-primary me-2">
+              Playbook de Ad Sets
+            </Link>
+          )}
           <Link to="facebook-api-logs" className="btn btn-outline-info me-2">
             Chamadas Meta
           </Link>
@@ -1934,7 +1981,7 @@ export default function ExperimentDetailPage() {
             type="button"
             className="btn btn-outline-danger me-2"
             onClick={openResetModal}
-            disabled={resetCampaigns.isPending}
+            disabled={resetCampaigns.isPending || alterationLocked}
           >
             {resetCampaigns.isPending ? (
               <>
@@ -2035,13 +2082,13 @@ export default function ExperimentDetailPage() {
               {diagnostics.severity}
             </span>
           </div>
-          {diagnostics.artifacts.length > 0 ? (
+          {diagnosticsArtifacts.length > 0 ? (
             <>
               <p className="mb-2 mt-2 small">
                 <strong>Itens com pendência para corrigir:</strong>
               </p>
               <ul className="mb-0 small ps-3">
-                {diagnostics.artifacts.map((artifact) => (
+                {diagnosticsArtifacts.map((artifact) => (
                   <li key={`${artifact.type}-${artifact.id}`}>
                     <strong>{artifact.type}</strong> ·{" "}
                     {artifact.name || artifact.id} — ID interno: {artifact.id}
@@ -2380,16 +2427,20 @@ export default function ExperimentDetailPage() {
               experimentId={expId}
               totalSpend={data?.campaignMetric?.spend}
               spendLastSyncedAt={data?.campaignMetric?.lastSyncedAt}
+              alterationLocked={alterationLocked}
             />
           </Tabs.Content>
           <Tabs.Content value="analytics" asChild>
             <ExperimentLandingAnalyticsTab experimentId={expId} />
           </Tabs.Content>
           <Tabs.Content value="creatives" asChild>
-            <CriativosTab experimentId={expId} />
+            <CriativosTab
+              experimentId={expId}
+              alterationLocked={alterationLocked}
+            />
           </Tabs.Content>
           <Tabs.Content value="landing" asChild>
-            <LandingTab experiment={data} />
+            <LandingTab experiment={data} alterationLocked={alterationLocked} />
           </Tabs.Content>
           <Tabs.Content value="gera-landing" asChild>
             <div className="d-flex flex-column gap-3">
@@ -2420,7 +2471,9 @@ export default function ExperimentDetailPage() {
                       className="btn btn-primary align-self-start"
                       onClick={handleStartWireframe}
                       disabled={
-                        isStartingWireframe || hasRunningGeraLandingExecution
+                        alterationLocked ||
+                        isStartingWireframe ||
+                        hasRunningGeraLandingExecution
                       }
                     >
                       {isStartingWireframe ? (
@@ -2549,7 +2602,9 @@ export default function ExperimentDetailPage() {
                       className="btn btn-primary align-self-start"
                       onClick={handleStartCopy}
                       disabled={
-                        isStartingCopy || hasRunningGeraLandingCopyExecution
+                        alterationLocked ||
+                        isStartingCopy ||
+                        hasRunningGeraLandingCopyExecution
                       }
                     >
                       {isStartingCopy ? (
@@ -2687,6 +2742,7 @@ export default function ExperimentDetailPage() {
                       className="btn btn-primary align-self-start"
                       onClick={handleStartImagePrompts}
                       disabled={
+                        alterationLocked ||
                         isStartingImagePrompts ||
                         hasRunningGeraLandingImagePromptsExecution
                       }
@@ -2809,6 +2865,7 @@ export default function ExperimentDetailPage() {
                                           )
                                         }
                                         disabled={
+                                          alterationLocked ||
                                           isGeneratingLandingHtml ||
                                           frameworkImagePendingCount > 0
                                         }
@@ -2874,6 +2931,7 @@ export default function ExperimentDetailPage() {
                       className="btn btn-primary align-self-start"
                       onClick={handleStartImageGeneration}
                       disabled={
+                        alterationLocked ||
                         isStartingImageGeneration ||
                         hasRunningGeraLandingImageGenerationExecution
                       }
@@ -3073,6 +3131,7 @@ export default function ExperimentDetailPage() {
                       className="btn btn-primary align-self-start"
                       onClick={handleStartDesignPreset}
                       disabled={
+                        alterationLocked ||
                         isStartingDesignPreset ||
                         hasRunningGeraLandingDesignPresetExecution
                       }
@@ -3243,6 +3302,7 @@ export default function ExperimentDetailPage() {
                     className="btn btn-primary align-self-start"
                     onClick={handleStartQualityReview}
                     disabled={
+                      alterationLocked ||
                       isStartingQualityReview ||
                       hasRunningGeraLandingQualityReviewExecution
                     }
@@ -3379,6 +3439,7 @@ export default function ExperimentDetailPage() {
                     className="btn btn-primary align-self-start"
                     onClick={handleStartDeliverables}
                     disabled={
+                      alterationLocked ||
                       isStartingDeliverables ||
                       hasRunningGeraLandingDeliverablesExecution
                     }
@@ -3503,12 +3564,14 @@ export default function ExperimentDetailPage() {
               hypothesis={hyp}
               campaignAngle={data?.campaignAngle}
               adCopy={data?.adCopy}
+              alterationLocked={alterationLocked}
             />
           </Tabs.Content>
           <Tabs.Content value="publico" asChild>
             <ExperimentAudienceTab
               experimentId={Number(expId)}
               nicheId={data?.nicheId}
+              alterationLocked={alterationLocked}
             />
           </Tabs.Content>
           <Tabs.Content value="conteudo" asChild>

--- a/frontend/src/pages/experiment/ExperimentFunnelTab.tsx
+++ b/frontend/src/pages/experiment/ExperimentFunnelTab.tsx
@@ -1,10 +1,16 @@
 import { useState, type FormEvent } from "react";
 import axios from "axios";
 import { toast } from "react-toastify";
-import { useExperimentFunnel, type ExperimentFunnelStageSummary } from "../../api/experiment/useExperimentFunnel";
+import {
+  useExperimentFunnel,
+  type ExperimentFunnelStageSummary,
+} from "../../api/experiment/useExperimentFunnel";
 import { useRegisterExperimentFunnelEvent } from "../../api/experiment/useRegisterExperimentFunnelEvent";
 import { useResetExperimentFunnel } from "../../api/experiment/useResetExperimentFunnel";
-import { useExperimentFunnelDiagnostics, type FunnelDiagnosticStatus } from "../../api/experiment/useExperimentFunnelDiagnostics";
+import {
+  useExperimentFunnelDiagnostics,
+  type FunnelDiagnosticStatus,
+} from "../../api/experiment/useExperimentFunnelDiagnostics";
 
 const currencyFormatter = new Intl.NumberFormat("pt-BR", {
   style: "currency",
@@ -22,6 +28,7 @@ interface ExperimentFunnelTabProps {
   experimentId: string;
   totalSpend?: number | null;
   spendLastSyncedAt?: string | null;
+  alterationLocked?: boolean;
 }
 
 function formatDate(value?: string | null) {
@@ -38,6 +45,7 @@ export default function ExperimentFunnelTab({
   experimentId,
   totalSpend,
   spendLastSyncedAt,
+  alterationLocked = false,
 }: ExperimentFunnelTabProps) {
   const { data, isLoading, isError } = useExperimentFunnel(experimentId);
   const diagnosticsQuery = useExperimentFunnelDiagnostics(experimentId);
@@ -149,8 +157,9 @@ export default function ExperimentFunnelTab({
     label: stage.label,
     quantity: stage.totalCount,
   }));
-  const maxOutcomeQuantity = outcomeQuantities.reduce((max, item) =>
-    Math.max(max, item.quantity), 0,
+  const maxOutcomeQuantity = outcomeQuantities.reduce(
+    (max, item) => Math.max(max, item.quantity),
+    0,
   );
   const totalOutcomes = outcomeQuantities.reduce(
     (accumulator, item) => accumulator + item.quantity,
@@ -185,16 +194,23 @@ export default function ExperimentFunnelTab({
     if (resetFunnel.isPending) {
       return;
     }
-    if (!window.confirm(`Deseja zerar as contagens e analytics somente deste experimento (${experimentId}) a partir de agora?`)) {
+    if (
+      !window.confirm(
+        `Deseja zerar as contagens e analytics somente deste experimento (${experimentId}) a partir de agora?`,
+      )
+    ) {
       return;
     }
     try {
       await resetFunnel.mutateAsync();
-      toast.success("Funil e analytics deste experimento foram reiniciados. Novos eventos passarão a ser contabilizados a partir deste momento.");
+      toast.success(
+        "Funil e analytics deste experimento foram reiniciados. Novos eventos passarão a ser contabilizados a partir deste momento.",
+      );
     } catch (error) {
       const message = axios.isAxiosError(error)
-        ? error.response?.data?.message ?? error.response?.data?.detail ??
-          "Não foi possível zerar o funil."
+        ? (error.response?.data?.message ??
+          error.response?.data?.detail ??
+          "Não foi possível zerar o funil.")
         : "Não foi possível zerar o funil.";
       toast.error(message);
     }
@@ -207,18 +223,23 @@ export default function ExperimentFunnelTab({
           <div>
             <h5 className="card-title mb-1">Funil de vendas do experimento</h5>
             <p className="text-muted small mb-0">
-              Cada etapa consolida os eventos da jornada (anúncios, Lead Portal e
-              e-mails) para dar visibilidade ao avanço das leads no experimento.
+              Cada etapa consolida os eventos da jornada (anúncios, Lead Portal
+              e e-mails) para dar visibilidade ao avanço das leads no
+              experimento.
             </p>
           </div>
           <button
             type="button"
             className="btn btn-outline-danger btn-sm"
             onClick={handleReset}
-            disabled={resetFunnel.isPending}
+            disabled={resetFunnel.isPending || alterationLocked}
           >
             {resetFunnel.isPending ? (
-              <span className="spinner-border spinner-border-sm" role="status" aria-hidden="true" />
+              <span
+                className="spinner-border spinner-border-sm"
+                role="status"
+                aria-hidden="true"
+              />
             ) : (
               "Zerar contagens"
             )}
@@ -255,7 +276,9 @@ export default function ExperimentFunnelTab({
               <div className="fs-2 fw-bold">{totalOutcomes}</div>
             </div>
             <div className="text-end">
-              <div className="text-muted small">Meta ideal: {BACKTEST_TARGET_TOTAL}</div>
+              <div className="text-muted small">
+                Meta ideal: {BACKTEST_TARGET_TOTAL}
+              </div>
               <div className="fs-5 fw-semibold">
                 {formatPercentage(outcomeTargetPercent)} da meta
               </div>
@@ -263,19 +286,26 @@ export default function ExperimentFunnelTab({
           </div>
           <div className="d-flex flex-column gap-2">
             {outcomeQuantities.map((item) => {
-              const widthPercent = maxOutcomeQuantity > 0
-                ? (item.quantity / maxOutcomeQuantity) * 100
-                : 0;
+              const widthPercent =
+                maxOutcomeQuantity > 0
+                  ? (item.quantity / maxOutcomeQuantity) * 100
+                  : 0;
               return (
                 <div key={item.label}>
                   <div className="d-flex justify-content-between small">
                     <span>{item.label}</span>
                     <strong>{item.quantity}</strong>
                   </div>
-                  <div className="progress" role="img" aria-label={`Quantidade do outcome ${item.label}: ${item.quantity}`}>
+                  <div
+                    className="progress"
+                    role="img"
+                    aria-label={`Quantidade do outcome ${item.label}: ${item.quantity}`}
+                  >
                     <div
                       className="progress-bar"
-                      style={{ width: `${Math.max(widthPercent, item.quantity > 0 ? 4 : 0)}%` }}
+                      style={{
+                        width: `${Math.max(widthPercent, item.quantity > 0 ? 4 : 0)}%`,
+                      }}
                     />
                   </div>
                 </div>
@@ -319,9 +349,17 @@ export default function ExperimentFunnelTab({
                     <td>
                       <strong>{stage.totalCount}</strong>
                     </td>
-                    <td>{formatRateComparedToPreviousStage(stage.totalCount, selectableStages[index - 1]?.totalCount)}</td>
                     <td>
-                      {formatCostPerConversion(normalizedTotalSpend, stage.totalCount)}
+                      {formatRateComparedToPreviousStage(
+                        stage.totalCount,
+                        selectableStages[index - 1]?.totalCount,
+                      )}
+                    </td>
+                    <td>
+                      {formatCostPerConversion(
+                        normalizedTotalSpend,
+                        stage.totalCount,
+                      )}
                     </td>
                     <td>{stage.uniqueCount ?? "—"}</td>
                     <td>{formatDate(stage.lastEventAt)}</td>
@@ -355,16 +393,25 @@ export default function ExperimentFunnelTab({
                       <div className="small text-muted">{item.message}</div>
                       <div className="small text-muted">
                         Tentativas: {item.attempts} · Sucessos: {item.successes}
-                        {item.minAcceptableRate != null ? ` · Mín. aceitável: ${formatPercent(item.minAcceptableRate)}` : ""}
-                        {item.upper95RateIfZero != null ? ` · Limite 95% (0 sucessos): ${formatPercent(item.upper95RateIfZero)}` : ""}
+                        {item.minAcceptableRate != null
+                          ? ` · Mín. aceitável: ${formatPercent(item.minAcceptableRate)}`
+                          : ""}
+                        {item.upper95RateIfZero != null
+                          ? ` · Limite 95% (0 sucessos): ${formatPercent(item.upper95RateIfZero)}`
+                          : ""}
                       </div>
                       {item.thresholdChecks?.map((thresholdCheck) => (
                         <div
                           key={`${item.stageKey}-${thresholdCheck.minAcceptableRate}`}
                           className={`small ${thresholdCheck.statisticallyFailed ? "text-danger" : "text-muted"}`}
                         >
-                          Limite {formatPercent(thresholdCheck.minAcceptableRate)} · Tentativas mín. (95%, 0 sucessos): {thresholdCheck.attemptsFor95Confidence}
-                          {thresholdCheck.upper95RateIfZero != null ? ` · Limite 95% atual: ${formatPercent(thresholdCheck.upper95RateIfZero)}` : ""}
+                          Limite{" "}
+                          {formatPercent(thresholdCheck.minAcceptableRate)} ·
+                          Tentativas mín. (95%, 0 sucessos):{" "}
+                          {thresholdCheck.attemptsFor95Confidence}
+                          {thresholdCheck.upper95RateIfZero != null
+                            ? ` · Limite 95% atual: ${formatPercent(thresholdCheck.upper95RateIfZero)}`
+                            : ""}
                           {thresholdCheck.statisticallyFailed
                             ? " · Reprovada"
                             : thresholdCheck.attemptsTargetReached
@@ -373,13 +420,23 @@ export default function ExperimentFunnelTab({
                         </div>
                       ))}
                     </div>
-                    <span className={`badge ${statusBadgeClass(item.status)}`} title="Diagnóstico calculado no backend">
+                    <span
+                      className={`badge ${statusBadgeClass(item.status)}`}
+                      title="Diagnóstico calculado no backend"
+                    >
                       {statusLabel(item.status)}
                     </span>
                   </div>
                 </div>
               ))}
             </div>
+          </div>
+        ) : null}
+
+        {alterationLocked ? (
+          <div className="alert alert-secondary mb-0" role="status">
+            Funil bloqueado para alteração manual porque o experimento já foi
+            liberado ou está em execução.
           </div>
         ) : null}
 
@@ -394,6 +451,7 @@ export default function ExperimentFunnelTab({
               className="form-select"
               value={form.stage}
               onChange={(e) => setForm({ ...form, stage: e.target.value })}
+              disabled={alterationLocked}
             >
               {stages.map((stage) => (
                 <option key={stage.stage} value={stage.stage}>
@@ -413,6 +471,7 @@ export default function ExperimentFunnelTab({
               placeholder="00000000-0000-0000-0000-000000000000"
               value={form.leadId}
               onChange={(e) => setForm({ ...form, leadId: e.target.value })}
+              disabled={alterationLocked}
             />
           </div>
           <div className="col-12 col-lg-3">
@@ -426,6 +485,7 @@ export default function ExperimentFunnelTab({
               placeholder="manual, integração, etc"
               value={form.source}
               onChange={(e) => setForm({ ...form, source: e.target.value })}
+              disabled={alterationLocked}
             />
           </div>
           <div className="col-12 col-lg-3">
@@ -438,17 +498,21 @@ export default function ExperimentFunnelTab({
               className="form-control"
               placeholder="ex.: 123456789012345"
               value={form.campaignCode}
-              onChange={(e) => setForm({ ...form, campaignCode: e.target.value })}
+              onChange={(e) =>
+                setForm({ ...form, campaignCode: e.target.value })
+              }
+              disabled={alterationLocked}
             />
             <div className="form-text">
-              Use o mesmo valor configurado nos parâmetros da URL/UTM do anúncio.
+              Use o mesmo valor configurado nos parâmetros da URL/UTM do
+              anúncio.
             </div>
           </div>
           <div className="col-12 col-lg-3 d-flex align-items-end">
             <button
               type="submit"
               className="btn btn-primary w-100"
-              disabled={registerEvent.isPending}
+              disabled={registerEvent.isPending || alterationLocked}
             >
               {registerEvent.isPending ? "Registrando..." : "Registrar evento"}
             </button>
@@ -464,6 +528,7 @@ export default function ExperimentFunnelTab({
               placeholder="Detalhes adicionais para rastreabilidade"
               value={form.payload}
               onChange={(e) => setForm({ ...form, payload: e.target.value })}
+              disabled={alterationLocked}
             />
             {registerEvent.isSuccess ? (
               <div className="text-success small mt-1">
@@ -484,7 +549,10 @@ export default function ExperimentFunnelTab({
           <ul className="mb-0 small ps-3">
             <li>1) Impressões do anúncio.</li>
             <li>2) Cliques que levaram ao formulário do experimento.</li>
-            <li>3) Renderizações completas do formulário (evento lead-portal-render-complete).</li>
+            <li>
+              3) Renderizações completas do formulário (evento
+              lead-portal-render-complete).
+            </li>
             <li>4) Envios de formulário (lead_portal_submission).</li>
             <li>5) Abertura do e-mail de amostra.</li>
             <li>6) Acessos ao checkout no Mercado Pago.</li>
@@ -516,8 +584,15 @@ function formatCurrency(value?: number | null) {
   return currencyFormatter.format(value);
 }
 
-function calculateCostPerConversion(totalSpend: number | null, totalConversions?: number | null) {
-  if (totalSpend === null || totalSpend === undefined || Number.isNaN(totalSpend)) {
+function calculateCostPerConversion(
+  totalSpend: number | null,
+  totalConversions?: number | null,
+) {
+  if (
+    totalSpend === null ||
+    totalSpend === undefined ||
+    Number.isNaN(totalSpend)
+  ) {
     return null;
   }
   if (!totalConversions || totalConversions <= 0) {
@@ -526,7 +601,10 @@ function calculateCostPerConversion(totalSpend: number | null, totalConversions?
   return totalSpend / totalConversions;
 }
 
-function formatCostPerConversion(totalSpend: number | null, totalConversions?: number | null) {
+function formatCostPerConversion(
+  totalSpend: number | null,
+  totalConversions?: number | null,
+) {
   const cost = calculateCostPerConversion(totalSpend, totalConversions);
   return cost === null ? "—" : formatCurrency(cost);
 }

--- a/frontend/src/pages/experiment/LandingTab.tsx
+++ b/frontend/src/pages/experiment/LandingTab.tsx
@@ -4,6 +4,7 @@ import { useApproveAndPublishLanding } from "../../api/experiment/useApproveAndP
 
 interface LandingTabProps {
   experiment: Experiment;
+  alterationLocked?: boolean;
 }
 
 type FeedbackState = {
@@ -38,7 +39,10 @@ export function canAttemptLandingApproval(experiment: Pick<Experiment, "id">) {
   return String(experiment.id ?? "").trim().length > 0;
 }
 
-export default function LandingTab({ experiment }: LandingTabProps) {
+export default function LandingTab({
+  experiment,
+  alterationLocked = false,
+}: LandingTabProps) {
   const approveAndPublishLanding = useApproveAndPublishLanding(
     Number(experiment.id),
   );
@@ -52,7 +56,8 @@ export default function LandingTab({ experiment }: LandingTabProps) {
     iframeUrl: string | null;
     standaloneUrl: string | null;
   } | null>(null);
-  const canApproveLanding = canAttemptLandingApproval(experiment);
+  const canApproveLanding =
+    !alterationLocked && canAttemptLandingApproval(experiment);
   const selectedDestinationUrl = normalizeUrl(
     publishedUrls?.standaloneUrl ?? experiment.followUpActionUrl,
   );
@@ -179,6 +184,13 @@ export default function LandingTab({ experiment }: LandingTabProps) {
           </div>
         </div>
       )}
+
+      {alterationLocked ? (
+        <div className="alert alert-secondary mb-0" role="status">
+          Landing bloqueada para alteração porque o experimento já foi liberado
+          ou está em execução.
+        </div>
+      ) : null}
 
       <div className="d-flex justify-content-end">
         <button

--- a/frontend/src/test-setup.ts
+++ b/frontend/src/test-setup.ts
@@ -1,0 +1,1 @@
+import "@testing-library/jest-dom/vitest";

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -25,6 +25,7 @@ export default defineConfig(async () => {
     },
     test: {
       environment: "jsdom",
+      setupFiles: "./src/test-setup.ts",
     },
   };
 });


### PR DESCRIPTION
### Motivation
- Evitar que, após a liberação/publicação de um experimento, operadores editem artefatos que já estejam em execução/publicação e causem divergência entre o estado publicado e os artefatos canônicos. 
- Garantir consistência operacional quando `facebook_release_requested_at` estiver preenchido ou o `status` estiver em execução/pós-execução (`RUNNING`, `PAUSED`, `USER_STOPPED`, `VALIDATED`, `INVALIDATED`, `INCONCLUSIVE`, `FINISHED`). 
- Permitir que as telas continuem exibindo visualizações e logs, mas tornar os controles de alteração/geraçã o/edição/destruição indisponíveis para proteger o fluxo em produção.

### Description
- Adiciona a função `isExperimentAlterationLocked` e o conjunto `EXPERIMENT_ALTERATION_LOCK_STATUSES` em `ExperimentDetailPage.tsx` e calcula `alterationLocked` a partir de `facebook_release_requested_at` ou `status`. 
- Propaga a flag `alterationLocked` para as abas e componentes relevantes e desabilita ações/inputs críticos (edição, reset de campanhas, geração de etapas do GeraLanding, geração de HTML provisório, gerar/imprimir imagens, aprovar/publicar landing, editar/Excluir/Aprovar criativos, salvar público, registrar eventos manuais no funil) em: `CriativosTab.tsx`, `LandingTab.tsx`, `ExperimentFunnelTab.tsx`, `ExperimentContentGenerationTab.tsx`, `ExperimentAudienceTab.tsx` e `ExperimentDetailPage.tsx`. 
- Atualiza documentos canônicos e de registro: `docs/canonical/procedimento-experimento-canon.v1.md` (seção 7.1) e `docs/registros/experimentos.md` com a regra operacional do bloqueio. 
- Adiciona integração de testes: cria `frontend/src/test-setup.ts` e ajusta `frontend/vite.config.ts` para carregar `@testing-library/jest-dom/vitest`, além de pequenas higienizações/format fixes em componentes afetados.

### Testing
- Executado `npm run typecheck` na pasta `frontend` e sem erros de tipagem detectados. 
- Executado a suíte de testes com `npm test -- --run` (Vitest) e a execução automatizada concluiu com todos os testes passando (`103` testes no ambiente do frontend). 
- Validação de build/test harness mínima: `git diff --check` foi executado para garantir ausência de conflitos simples no diff.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2457f990288321b8543de6f2a8d403)