### PR TITLE
Simplifica cards de etapas do pipeline (remove ações manuais e controla modelo OpenAI)

### DIFF
--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -3847,3 +3847,12 @@
   - `facebook-ads-worker/src/test/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignServiceTest.java`
   - `docs/canonical/facebook-campaign-publication-canon.v1.md`
   - `docs/registros/experimentos.md`
+
+## 2026-06-07 — Simplificação dos cards de etapas do pipeline
+
+- solicitação: remover ações manuais e rótulos operacionais redundantes dos cards de etapas, ocultar módulo executor ausente e permitir trocar modelo OpenAI diretamente no card apenas em etapas com acesso de IA.
+- correção aplicada: os cards não exibem mais botões de editar/excluir nem badges `Ativa`, `Obrigatória` e `Estrutural`; o módulo executor só aparece quando há valor cadastrado; e o modelo OpenAI virou uma seleção com confirmação explícita antes de persistir a alteração via contrato existente de atualização da etapa.
+- arquivos alterados:
+  - `frontend/src/pages/pipeline/PipelineCrudPage.tsx`
+  - `frontend/src/api/pipeline/types.ts`
+  - `docs/registros/experimentos.md`

--- a/frontend/src/api/pipeline/types.ts
+++ b/frontend/src/api/pipeline/types.ts
@@ -55,7 +55,18 @@ export interface OfficialPipelineStageMetadata {
   configurable: boolean;
   executionModule?: string | null;
   rootPackage?: string | null;
+  fieldPolicy?: StageFieldPolicy;
   aliases: string[];
+}
+
+export interface StageFieldPolicy {
+  codeStructural: boolean;
+  positionStructural: boolean;
+  nameStructural: boolean;
+  requiredStructural: boolean;
+  descriptionOperational: boolean;
+  activeOperational: boolean;
+  openAiModelOperational: boolean;
 }
 
 export interface OfficialPipelineMetadata {

--- a/frontend/src/pages/pipeline/PipelineCrudPage.css
+++ b/frontend/src/pages/pipeline/PipelineCrudPage.css
@@ -318,6 +318,16 @@
   overflow-wrap: anywhere;
 }
 
+.pipeline-stage-model-control label {
+  display: block;
+  margin-bottom: 0.35rem;
+  color: var(--pipeline-muted);
+  font-size: 0.76rem;
+  font-weight: 800;
+  letter-spacing: 0.04em;
+  text-transform: uppercase;
+}
+
 @media (max-width: 767.98px) {
   .pipeline-contract-grid {
     grid-template-columns: 1fr;

--- a/frontend/src/pages/pipeline/PipelineCrudPage.tsx
+++ b/frontend/src/pages/pipeline/PipelineCrudPage.tsx
@@ -14,7 +14,6 @@ import type {
 } from "../../api/pipeline/types";
 import {
   useDeletePipeline,
-  useDeletePipelineStage,
   useRebuildOfficialPipelineStages,
   useUpdatePipeline,
   useUpdatePipelineStage,
@@ -80,6 +79,18 @@ function stageToPayload(stage: PipelineStage): PipelineStagePayload {
   };
 }
 
+function stageUsesOpenAi(
+  stage: PipelineStage,
+  stageDefinition?: { fieldPolicy?: { openAiModelOperational: boolean } },
+) {
+  if (stageDefinition?.fieldPolicy?.openAiModelOperational) return true;
+  if (stage.openAiModelId || stage.openAiModelName || stage.openAiModelCode) {
+    return true;
+  }
+  const executionContext = `${stage.executionModule ?? ""} ${stage.rootPackage ?? ""}`;
+  return /\b(ai|openai)\b/i.test(executionContext);
+}
+
 export default function PipelineCrudPage() {
   const { data, isLoading, isError } = usePipelines();
   const { data: metadata, isLoading: isLoadingMetadata } =
@@ -89,7 +100,6 @@ export default function PipelineCrudPage() {
   const updatePipeline = useUpdatePipeline();
   const deletePipeline = useDeletePipeline();
   const updateStage = useUpdatePipelineStage();
-  const deleteStage = useDeletePipelineStage();
   const rebuildOfficialStages = useRebuildOfficialPipelineStages();
 
   const pipelines = useMemo(() => data ?? [], [data]);
@@ -201,6 +211,37 @@ export default function PipelineCrudPage() {
     ) {
       rebuildOfficialStages.mutate(pipeline.id);
     }
+  };
+
+  const confirmOpenAiModelChange = (
+    pipelineId: number,
+    stage: PipelineStage,
+    openAiModelId: number | null,
+  ) => {
+    const selectedModel = modelOptions.find(
+      (model) => model.id === openAiModelId,
+    );
+    const targetLabel = selectedModel
+      ? `${selectedModel.name} (${selectedModel.code})`
+      : "Sem modelo fixo";
+
+    if (
+      !confirm(
+        `Deseja alterar o modelo OpenAI da etapa "${stage.name}" para "${targetLabel}"?`,
+      )
+    ) {
+      return false;
+    }
+
+    updateStage.mutate({
+      pipelineId,
+      stageId: stage.id,
+      payload: {
+        ...stageToPayload(stage),
+        openAiModelId,
+      },
+    });
+    return true;
   };
 
   if (isLoading) return <p>Carregando pipelines...</p>;
@@ -391,11 +432,10 @@ export default function PipelineCrudPage() {
                         normalizeCode(alias) === normalizeCode(stage.code),
                     ),
                 );
-                const protectionLabel = rowDefinition?.required
-                  ? "Estrutural"
-                  : isOfficialPipeline
-                    ? "Não mapeada"
-                    : "Editável";
+                const showExecutionModule = Boolean(
+                  stage.executionModule?.trim(),
+                );
+                const showOpenAiModel = stageUsesOpenAi(stage, rowDefinition);
 
                 return (
                   <div className="pipeline-stage-grid-item" key={stage.id}>
@@ -418,58 +458,10 @@ export default function PipelineCrudPage() {
                               </h4>
                             </div>
                           </div>
-                          <div className="pipeline-stage-actions">
-                            <button
-                              type="button"
-                              className="btn btn-sm btn-outline-primary"
-                              onClick={() => {
-                                setEditingStageId(stage.id);
-                                setStageForms((current) => ({
-                                  ...current,
-                                  [pipeline.id]: stageToPayload(stage),
-                                }));
-                              }}
-                            >
-                              Editar
-                            </button>
-                            <button
-                              type="button"
-                              className="btn btn-sm btn-outline-danger"
-                              disabled={
-                                deleteStage.isPending ||
-                                Boolean(rowDefinition?.required)
-                              }
-                              onClick={() => {
-                                if (confirm("Deseja remover esta etapa?")) {
-                                  deleteStage.mutate({
-                                    pipelineId: pipeline.id,
-                                    stageId: stage.id,
-                                  });
-                                }
-                              }}
-                            >
-                              {deleteStage.isPending
-                                ? "Excluindo..."
-                                : "Excluir"}
-                            </button>
-                          </div>
                         </div>
                         <div className="pipeline-stage-badges">
                           <span className="badge text-bg-light border">
                             {stage.code}
-                          </span>
-                          <span
-                            className={`badge ${stage.active ? "text-bg-success" : "text-bg-secondary"}`}
-                          >
-                            {stage.active ? "Ativa" : "Inativa"}
-                          </span>
-                          {stage.required ? (
-                            <span className="badge text-bg-primary">
-                              Obrigatória
-                            </span>
-                          ) : null}
-                          <span className="badge text-bg-light border">
-                            {protectionLabel}
                           </span>
                         </div>
                         {stage.description ? (
@@ -479,26 +471,63 @@ export default function PipelineCrudPage() {
                           </div>
                         ) : null}
                         <div className="pipeline-stage-meta">
-                          <div>
-                            <span>Módulo executor</span>
-                            <strong>
-                              {stage.executionModule || "Não informado"}
-                            </strong>
-                          </div>
+                          {showExecutionModule ? (
+                            <div>
+                              <span>Módulo executor</span>
+                              <strong>{stage.executionModule}</strong>
+                            </div>
+                          ) : null}
                           <div>
                             <span>Pacote raiz</span>
                             <strong>
                               {stage.rootPackage || "Não informado"}
                             </strong>
                           </div>
-                          <div>
-                            <span>Modelo OpenAI</span>
-                            <strong>
-                              {stage.openAiModelName
-                                ? `${stage.openAiModelName} (${stage.openAiModelCode})`
-                                : "Sem modelo fixo"}
-                            </strong>
-                          </div>
+                          {showOpenAiModel ? (
+                            <div className="pipeline-stage-model-control">
+                              <label htmlFor={`stage-model-${stage.id}`}>
+                                Modelo OpenAI
+                              </label>
+                              <select
+                                id={`stage-model-${stage.id}`}
+                                className="form-select form-select-sm"
+                                disabled={
+                                  isLoadingOpenAiModels ||
+                                  (updateStage.isPending &&
+                                    updateStage.variables?.stageId === stage.id)
+                                }
+                                value={stage.openAiModelId ?? ""}
+                                onChange={(event) => {
+                                  const confirmed = confirmOpenAiModelChange(
+                                    pipeline.id,
+                                    stage,
+                                    event.target.value
+                                      ? Number(event.target.value)
+                                      : null,
+                                  );
+                                  if (!confirmed) {
+                                    event.currentTarget.value = String(
+                                      stage.openAiModelId ?? "",
+                                    );
+                                  }
+                                }}
+                              >
+                                <option value="">
+                                  {isLoadingOpenAiModels
+                                    ? "Carregando modelos..."
+                                    : "Sem modelo fixo"}
+                                </option>
+                                {modelOptions.map((model) => (
+                                  <option key={model.id} value={model.id}>
+                                    {model.name} ({model.code})
+                                    {model.acceptsImageInput
+                                      ? " · aceita imagem"
+                                      : ""}
+                                  </option>
+                                ))}
+                              </select>
+                            </div>
+                          ) : null}
                         </div>
                       </div>
                     </article>


### PR DESCRIPTION
### Motivation
- Reduzir ruído e evitar edição manual de etapas no frontend, preservando configuração persistida apenas via contrato backend e proteção canônica das etapas oficiais.
- Tornar explícita e segura a alteração do `openAiModel` por etapa, exibindo seleção apenas quando a etapa indica acesso à IA e obrigando confirmação antes de persistir.

### Description
- Remove os botões de `Editar` e `Excluir` dos cards de etapa e também oculta as badges `Ativa`, `Obrigatória` e `Estrutural` para simplificar a UI dos cards. (files: `frontend/src/pages/pipeline/PipelineCrudPage.tsx`)
- Oculta o bloco `Módulo executor` quando não há valor cadastrado para `executionModule` e mantém apenas código, nome, propósito e metadados relevantes no card. (files: `frontend/src/pages/pipeline/PipelineCrudPage.tsx`)
- Exibe o `Modelo OpenAI` como um `select` diretamente no card somente quando a etapa indica uso de IA (via `fieldPolicy.openAiModelOperational`, presença de modelo ou contexto de execução), e pede confirmação antes de chamar a mutation `useUpdatePipelineStage` para persistir a alteração. (files: `frontend/src/pages/pipeline/PipelineCrudPage.tsx`)
- Atualiza os tipos para expor `fieldPolicy` / `StageFieldPolicy` no metadata consumido pela tela para decidir visibilidade/operacionalidade do campo de modelo. (files: `frontend/src/api/pipeline/types.ts`)
- Ajusta estilo do label do novo controle de modelo para manter hierarquia visual. (files: `frontend/src/pages/pipeline/PipelineCrudPage.css`)
- Registra a mudança em `docs/registros/experimentos.md` conforme fluxo operacional do projeto. (files: `docs/registros/experimentos.md`)

### Testing
- `npx prettier --write` foi executado para formatar os arquivos e teve sucesso. (succeeded)
- `npm ci` foi executado para instalar dependências do frontend e teve sucesso. (succeeded)
- `npm run typecheck` (TypeScript `tsc --noEmit`) foi executado e completou sem erros. (succeeded)
- `npm run build` (Vite build) foi executado e completou com sucesso, retornando apenas o aviso padrão de chunks grandes; artefato de `dist/` gerado. (succeeded)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a24b61595448321a41df30f52f24155)