### PR TITLE
Remover bloco "Catálogo oficial (OpenAI)" da tela de Modelos OpenAI

### DIFF
--- a/frontend/src/pages/openaiModel/OpenAiModelListPage.tsx
+++ b/frontend/src/pages/openaiModel/OpenAiModelListPage.tsx
@@ -1,6 +1,5 @@
 import { Link, useNavigate } from "react-router-dom";
 import PageTitle from "../../components/PageTitle";
-import { useOpenAiModelCatalog } from "../../api/openAiModel/useOpenAiModelCatalog";
 import { useOpenAiModels } from "../../api/openAiModel/useOpenAiModels";
 
 const priceFormatter = new Intl.NumberFormat("pt-BR", {
@@ -16,12 +15,6 @@ function formatPrice(value?: number | null) {
 export default function OpenAiModelListPage() {
   const navigate = useNavigate();
   const { data, isLoading } = useOpenAiModels();
-  const {
-    data: catalog,
-    isLoading: isCatalogLoading,
-    refetch: refetchCatalog,
-    isFetching: isRefreshingCatalog,
-  } = useOpenAiModelCatalog();
   const models = Array.isArray(data) ? data : [];
 
   if (isLoading) return <p>Carregando...</p>;
@@ -37,67 +30,6 @@ export default function OpenAiModelListPage() {
         <Link className="btn btn-primary" to="/openai-models/new">
           Novo modelo
         </Link>
-      </div>
-
-      <div className="card mb-4">
-        <div className="card-body">
-          <div className="d-flex justify-content-between align-items-start gap-3 flex-wrap">
-            <div>
-              <h2 className="h5 mb-1">Catálogo oficial (OpenAI)</h2>
-              <p className="text-body-secondary mb-0">
-                Modelos consultados diretamente da API /models da OpenAI,
-                separados em texto e imagem.
-              </p>
-            </div>
-            <button
-              className="btn btn-outline-primary"
-              type="button"
-              onClick={() => refetchCatalog()}
-              disabled={isRefreshingCatalog}
-            >
-              {isRefreshingCatalog ? (
-                <span
-                  className="spinner-border spinner-border-sm me-2"
-                  aria-hidden="true"
-                />
-              ) : null}
-              Atualizar catálogo
-            </button>
-          </div>
-
-          {isCatalogLoading ? (
-            <p className="mt-3 mb-0 text-body-secondary">
-              Carregando catálogo oficial...
-            </p>
-          ) : (
-            <div className="row mt-3 g-3">
-              <div className="col-12 col-lg-6">
-                <h3 className="h6">
-                  Modelos de texto ({catalog?.textModels?.length ?? 0})
-                </h3>
-                <ul className="mb-0">
-                  {(catalog?.textModels ?? []).map((model) => (
-                    <li key={model}>
-                      <code>{model}</code>
-                    </li>
-                  ))}
-                </ul>
-              </div>
-              <div className="col-12 col-lg-6">
-                <h3 className="h6">
-                  Modelos de imagem ({catalog?.imageModels?.length ?? 0})
-                </h3>
-                <ul className="mb-0">
-                  {(catalog?.imageModels ?? []).map((model) => (
-                    <li key={model}>
-                      <code>{model}</code>
-                    </li>
-                  ))}
-                </ul>
-              </div>
-            </div>
-          )}
-        </div>
       </div>
 
       <div className="table-responsive">


### PR DESCRIPTION
### Motivation
- Simplificar a tela de "Modelos da OpenAI" removendo o bloco de "Catálogo oficial (OpenAI)" que não é necessário nesta visualização, deixando a UI focada apenas no cadastro/listagem de modelos e preços.

### Description
- Remove a importação e uso do hook `useOpenAiModelCatalog` e elimina o card que exibia o "Catálogo oficial (OpenAI)" com o botão "Atualizar catálogo" na página de listagem.
- Mantém a tabela principal de modelos (campos de preço Standard/Batch e ação de edição) inalterada para preservar o fluxo de cadastro/edição.
- Arquivo alterado: `frontend/src/pages/openaiModel/OpenAiModelListPage.tsx`.

### Testing
- Executado `npm run typecheck` e o processo finalizou sem erros.
- Executado `npm run build` e a build de produção foi gerada com sucesso.
- Executado `npm test -- --run` (Vitest) e todos os testes unitários passaram (`103 tests passed`).
- Captura visual gerada para validação manual em `/tmp/openai-models.png` confirmando a remoção do bloco oficial.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a24b64f2e74832194eee81c74cb5d38)