### PR TITLE
Oculta botões 'Iniciar' em Gera Landing para experimentos publicados

### DIFF
--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -3882,3 +3882,12 @@
   - `facebook-ads-worker/src/test/java/com/marketinghub/facebookadsworker/testsupport/FailFastMockWebServer.java`
   - `facebook-ads-worker/src/test/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignServiceTest.java`
   - `docs/registros/experimentos.md`
+
+## 2026-06-07 — Ocultação de iniciar Gera Landing em experimento publicado
+
+- solicitação: em experimentos já publicados, ocultar os botões `Iniciar` das etapas do Gera Landing, mantendo o histórico e o acompanhamento das execuções visíveis.
+- causa-raiz: a tela já bloqueava alterações depois da liberação/publicação do experimento, mas ainda exibia os botões `Iniciar` desabilitados, criando ruído visual para um experimento que não deve mais receber novas execuções manuais.
+- correção aplicada: a aba `Gera landing` agora só renderiza os botões de início enquanto `facebookReleaseRequestedAt` não estiver preenchido; após a publicação/liberação, permanecem apenas totais, jobs em andamento e histórico das etapas.
+- arquivos alterados:
+  - `frontend/src/pages/experiment/ExperimentDetailPage.tsx`
+  - `docs/registros/experimentos.md`

--- a/frontend/src/pages/experiment/ExperimentDetailPage.tsx
+++ b/frontend/src/pages/experiment/ExperimentDetailPage.tsx
@@ -1571,6 +1571,7 @@ export default function ExperimentDetailPage() {
   if (isLoading) return <p>Carregando...</p>;
   if (!data) return <p>Não encontrado</p>;
   const alterationLocked = isExperimentAlterationLocked(data);
+  const showGeraLandingStartButtons = !Boolean(data.facebookReleaseRequestedAt);
   const preset = presets?.find((p) => p.id === data.metricPresetId);
   const resetPreviewSummary: ExperimentCampaignResetSummary =
     resetPreviewData ?? { campaigns: 0, adSets: 0, ads: 0, creatives: 0 };
@@ -2466,29 +2467,31 @@ export default function ExperimentDetailPage() {
                     </span>
                   </div>
                   <div className="d-flex flex-column gap-3">
-                    <button
-                      type="button"
-                      className="btn btn-primary align-self-start"
-                      onClick={handleStartWireframe}
-                      disabled={
-                        alterationLocked ||
-                        isStartingWireframe ||
-                        hasRunningGeraLandingExecution
-                      }
-                    >
-                      {isStartingWireframe ? (
-                        <>
-                          <span
-                            className="spinner-border spinner-border-sm me-2"
-                            role="status"
-                            aria-hidden="true"
-                          />
-                          Iniciando...
-                        </>
-                      ) : (
-                        "Iniciar"
-                      )}
-                    </button>
+                    {showGeraLandingStartButtons ? (
+                      <button
+                        type="button"
+                        className="btn btn-primary align-self-start"
+                        onClick={handleStartWireframe}
+                        disabled={
+                          alterationLocked ||
+                          isStartingWireframe ||
+                          hasRunningGeraLandingExecution
+                        }
+                      >
+                        {isStartingWireframe ? (
+                          <>
+                            <span
+                              className="spinner-border spinner-border-sm me-2"
+                              role="status"
+                              aria-hidden="true"
+                            />
+                            Iniciando...
+                          </>
+                        ) : (
+                          "Iniciar"
+                        )}
+                      </button>
+                    ) : null}
                     {isLoadingPendingGeraLandingExecutions ? (
                       <p className="text-muted mb-0">
                         Carregando jobs da etapa...
@@ -2597,29 +2600,31 @@ export default function ExperimentDetailPage() {
                     </span>
                   </div>
                   <div className="d-flex flex-column gap-3">
-                    <button
-                      type="button"
-                      className="btn btn-primary align-self-start"
-                      onClick={handleStartCopy}
-                      disabled={
-                        alterationLocked ||
-                        isStartingCopy ||
-                        hasRunningGeraLandingCopyExecution
-                      }
-                    >
-                      {isStartingCopy ? (
-                        <>
-                          <span
-                            className="spinner-border spinner-border-sm me-2"
-                            role="status"
-                            aria-hidden="true"
-                          />
-                          Iniciando...
-                        </>
-                      ) : (
-                        "Iniciar"
-                      )}
-                    </button>
+                    {showGeraLandingStartButtons ? (
+                      <button
+                        type="button"
+                        className="btn btn-primary align-self-start"
+                        onClick={handleStartCopy}
+                        disabled={
+                          alterationLocked ||
+                          isStartingCopy ||
+                          hasRunningGeraLandingCopyExecution
+                        }
+                      >
+                        {isStartingCopy ? (
+                          <>
+                            <span
+                              className="spinner-border spinner-border-sm me-2"
+                              role="status"
+                              aria-hidden="true"
+                            />
+                            Iniciando...
+                          </>
+                        ) : (
+                          "Iniciar"
+                        )}
+                      </button>
+                    ) : null}
                     {isLoadingPendingGeraLandingCopyExecutions ? (
                       <p className="text-muted mb-0">
                         Carregando jobs da etapa...
@@ -2737,29 +2742,31 @@ export default function ExperimentDetailPage() {
                   </div>
                   <div className="rounded border bg-light-subtle p-3 d-flex flex-column gap-3">
                     <h6 className="mb-0">Execução dos prompts de imagem</h6>
-                    <button
-                      type="button"
-                      className="btn btn-primary align-self-start"
-                      onClick={handleStartImagePrompts}
-                      disabled={
-                        alterationLocked ||
-                        isStartingImagePrompts ||
-                        hasRunningGeraLandingImagePromptsExecution
-                      }
-                    >
-                      {isStartingImagePrompts ? (
-                        <>
-                          <span
-                            className="spinner-border spinner-border-sm me-2"
-                            role="status"
-                            aria-hidden="true"
-                          />
-                          Iniciando...
-                        </>
-                      ) : (
-                        "Iniciar"
-                      )}
-                    </button>
+                    {showGeraLandingStartButtons ? (
+                      <button
+                        type="button"
+                        className="btn btn-primary align-self-start"
+                        onClick={handleStartImagePrompts}
+                        disabled={
+                          alterationLocked ||
+                          isStartingImagePrompts ||
+                          hasRunningGeraLandingImagePromptsExecution
+                        }
+                      >
+                        {isStartingImagePrompts ? (
+                          <>
+                            <span
+                              className="spinner-border spinner-border-sm me-2"
+                              role="status"
+                              aria-hidden="true"
+                            />
+                            Iniciando...
+                          </>
+                        ) : (
+                          "Iniciar"
+                        )}
+                      </button>
+                    ) : null}
                     {isLoadingPendingGeraLandingImagePromptsExecutions ? (
                       <p className="text-muted mb-0">
                         Carregando jobs da etapa...
@@ -2926,29 +2933,31 @@ export default function ExperimentDetailPage() {
                     >
                       Ver detalhes das imagens
                     </Link>
-                    <button
-                      type="button"
-                      className="btn btn-primary align-self-start"
-                      onClick={handleStartImageGeneration}
-                      disabled={
-                        alterationLocked ||
-                        isStartingImageGeneration ||
-                        hasRunningGeraLandingImageGenerationExecution
-                      }
-                    >
-                      {isStartingImageGeneration ? (
-                        <>
-                          <span
-                            className="spinner-border spinner-border-sm me-2"
-                            role="status"
-                            aria-hidden="true"
-                          />
-                          Iniciando...
-                        </>
-                      ) : (
-                        "Iniciar"
-                      )}
-                    </button>
+                    {showGeraLandingStartButtons ? (
+                      <button
+                        type="button"
+                        className="btn btn-primary align-self-start"
+                        onClick={handleStartImageGeneration}
+                        disabled={
+                          alterationLocked ||
+                          isStartingImageGeneration ||
+                          hasRunningGeraLandingImageGenerationExecution
+                        }
+                      >
+                        {isStartingImageGeneration ? (
+                          <>
+                            <span
+                              className="spinner-border spinner-border-sm me-2"
+                              role="status"
+                              aria-hidden="true"
+                            />
+                            Iniciando...
+                          </>
+                        ) : (
+                          "Iniciar"
+                        )}
+                      </button>
+                    ) : null}
                     <span className="small text-muted">
                       Acompanhe a timeline detalhada na aba{" "}
                       <strong>Conteúdo</strong>, bloco{" "}
@@ -3126,29 +3135,31 @@ export default function ExperimentDetailPage() {
                     </span>
                   </div>
                   <div className="d-flex flex-column gap-3">
-                    <button
-                      type="button"
-                      className="btn btn-primary align-self-start"
-                      onClick={handleStartDesignPreset}
-                      disabled={
-                        alterationLocked ||
-                        isStartingDesignPreset ||
-                        hasRunningGeraLandingDesignPresetExecution
-                      }
-                    >
-                      {isStartingDesignPreset ? (
-                        <>
-                          <span
-                            className="spinner-border spinner-border-sm me-2"
-                            role="status"
-                            aria-hidden="true"
-                          />
-                          Iniciando...
-                        </>
-                      ) : (
-                        "Iniciar"
-                      )}
-                    </button>
+                    {showGeraLandingStartButtons ? (
+                      <button
+                        type="button"
+                        className="btn btn-primary align-self-start"
+                        onClick={handleStartDesignPreset}
+                        disabled={
+                          alterationLocked ||
+                          isStartingDesignPreset ||
+                          hasRunningGeraLandingDesignPresetExecution
+                        }
+                      >
+                        {isStartingDesignPreset ? (
+                          <>
+                            <span
+                              className="spinner-border spinner-border-sm me-2"
+                              role="status"
+                              aria-hidden="true"
+                            />
+                            Iniciando...
+                          </>
+                        ) : (
+                          "Iniciar"
+                        )}
+                      </button>
+                    ) : null}
                     {isLoadingPendingGeraLandingDesignPresetExecutions ? (
                       <p className="text-muted mb-0">
                         Carregando jobs da etapa...
@@ -3297,29 +3308,31 @@ export default function ExperimentDetailPage() {
                       </span>
                     </div>
                   </div>
-                  <button
-                    type="button"
-                    className="btn btn-primary align-self-start"
-                    onClick={handleStartQualityReview}
-                    disabled={
-                      alterationLocked ||
-                      isStartingQualityReview ||
-                      hasRunningGeraLandingQualityReviewExecution
-                    }
-                  >
-                    {isStartingQualityReview ? (
-                      <>
-                        <span
-                          className="spinner-border spinner-border-sm me-2"
-                          role="status"
-                          aria-hidden="true"
-                        />
-                        Iniciando...
-                      </>
-                    ) : (
-                      "Iniciar"
-                    )}
-                  </button>
+                  {showGeraLandingStartButtons ? (
+                    <button
+                      type="button"
+                      className="btn btn-primary align-self-start"
+                      onClick={handleStartQualityReview}
+                      disabled={
+                        alterationLocked ||
+                        isStartingQualityReview ||
+                        hasRunningGeraLandingQualityReviewExecution
+                      }
+                    >
+                      {isStartingQualityReview ? (
+                        <>
+                          <span
+                            className="spinner-border spinner-border-sm me-2"
+                            role="status"
+                            aria-hidden="true"
+                          />
+                          Iniciando...
+                        </>
+                      ) : (
+                        "Iniciar"
+                      )}
+                    </button>
+                  ) : null}
                   {isLoadingPendingGeraLandingQualityReviewExecutions ? (
                     <p className="text-muted mb-0">
                       Carregando jobs da etapa...
@@ -3434,29 +3447,31 @@ export default function ExperimentDetailPage() {
                       )}
                     </span>
                   </div>
-                  <button
-                    type="button"
-                    className="btn btn-primary align-self-start"
-                    onClick={handleStartDeliverables}
-                    disabled={
-                      alterationLocked ||
-                      isStartingDeliverables ||
-                      hasRunningGeraLandingDeliverablesExecution
-                    }
-                  >
-                    {isStartingDeliverables ? (
-                      <>
-                        <span
-                          className="spinner-border spinner-border-sm me-2"
-                          role="status"
-                          aria-hidden="true"
-                        />
-                        Iniciando...
-                      </>
-                    ) : (
-                      "Iniciar"
-                    )}
-                  </button>
+                  {showGeraLandingStartButtons ? (
+                    <button
+                      type="button"
+                      className="btn btn-primary align-self-start"
+                      onClick={handleStartDeliverables}
+                      disabled={
+                        alterationLocked ||
+                        isStartingDeliverables ||
+                        hasRunningGeraLandingDeliverablesExecution
+                      }
+                    >
+                      {isStartingDeliverables ? (
+                        <>
+                          <span
+                            className="spinner-border spinner-border-sm me-2"
+                            role="status"
+                            aria-hidden="true"
+                          />
+                          Iniciando...
+                        </>
+                      ) : (
+                        "Iniciar"
+                      )}
+                    </button>
+                  ) : null}
                   {isLoadingPendingGeraLandingDeliverablesExecutions ? (
                     <p className="text-muted mb-0">
                       Carregando jobs da etapa...


### PR DESCRIPTION
### Motivation
- Evitar ruído visual e ações manuais em experimentos que já foram liberados/publicados, removendo botões de início redundantes nas etapas de `Gera landing` quando o experimento tem `facebookReleaseRequestedAt` preenchido.
- Preservar visualização de totais, jobs em andamento e histórico sem permitir iniciar novas execuções manuais após publicação.

### Description
- Calcula `showGeraLandingStartButtons` como `!Boolean(data.facebookReleaseRequestedAt)` em `frontend/src/pages/experiment/ExperimentDetailPage.tsx` e usa essa flag para condicionalmente renderizar/ocultar os botões `Iniciar` das etapas WireFrame, Copy, Image Prompts, Image Generation, Design Preset, Quality Review e Deliverables.
- Mantém inalterada a exibição de totais, tabelas de jobs pendentes/executando e histórico de execuções para consulta.
- Atualiza o registro de mudanças em `docs/registros/experimentos.md` com a descrição da alteração.

### Testing
- Executado `npm ci` no `frontend` e a instalação de dependências foi concluída com sucesso.
- Executado `npm run typecheck` e a checagem TypeScript passou sem erros (após instalar dependências).
- Executado `npm run build` e o build de produção do frontend foi gerado com sucesso (warnings de chunk grandes, mas build concluído).
- Verificado `git diff --check` para garantir ausência de problemas de formatação/whitespace; verificação passou.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a24d900b6088321be0b09e81e331c5d)