### PR TITLE
Simplifica lista de pipelines: remove badges e botões, alinha botão "Ver etapas"

### DIFF
--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -3882,3 +3882,12 @@
   - `facebook-ads-worker/src/test/java/com/marketinghub/facebookadsworker/testsupport/FailFastMockWebServer.java`
   - `facebook-ads-worker/src/test/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignServiceTest.java`
   - `docs/registros/experimentos.md`
+
+## 2026-06-07 — Simplificação visual da lista de pipelines
+
+- solicitação: limpar a lista de pipelines removendo os rótulos `Oficial`, `Ativo` e `Contrato`, retirar os botões `Editar` e `Excluir`, e manter o botão `Ver etapas` sempre alinhado na mesma posição entre os pipelines.
+- correção aplicada: a listagem passou a exibir apenas nome, módulo, código, quantidade de etapas e descrição, com uma única ação para abrir as etapas; a linha do pipeline usa grade com coluna fixa de ação para evitar deslocamento vertical/horizontal do botão quando a descrição varia de tamanho.
+- arquivos alterados:
+  - `frontend/src/pages/pipeline/PipelineCrudPage.tsx`
+  - `frontend/src/pages/pipeline/PipelineCrudPage.css`
+  - `docs/registros/experimentos.md`

--- a/frontend/src/pages/pipeline/PipelineCrudPage.css
+++ b/frontend/src/pages/pipeline/PipelineCrudPage.css
@@ -341,3 +341,34 @@
     padding: 1.15rem 1.1rem 1.15rem 1.45rem;
   }
 }
+
+.pipeline-list-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 1rem;
+  align-items: start;
+}
+
+.pipeline-list-content {
+  min-width: 0;
+}
+
+.pipeline-list-action {
+  display: flex;
+  justify-content: flex-end;
+}
+
+.pipeline-list-stage-button {
+  min-width: 5.6rem;
+  white-space: nowrap;
+}
+
+@media (max-width: 575.98px) {
+  .pipeline-list-row {
+    grid-template-columns: 1fr;
+  }
+
+  .pipeline-list-action {
+    justify-content: flex-start;
+  }
+}

--- a/frontend/src/pages/pipeline/PipelineCrudPage.tsx
+++ b/frontend/src/pages/pipeline/PipelineCrudPage.tsx
@@ -13,7 +13,6 @@ import type {
   PipelineStagePayload,
 } from "../../api/pipeline/types";
 import {
-  useDeletePipeline,
   useRebuildOfficialPipelineStages,
   useUpdatePipeline,
   useUpdatePipelineStage,
@@ -98,7 +97,6 @@ export default function PipelineCrudPage() {
   const { data: openAiModels, isLoading: isLoadingOpenAiModels } =
     useOpenAiModels();
   const updatePipeline = useUpdatePipeline();
-  const deletePipeline = useDeletePipeline();
   const updateStage = useUpdatePipelineStage();
   const rebuildOfficialStages = useRebuildOfficialPipelineStages();
 
@@ -976,33 +974,12 @@ export default function PipelineCrudPage() {
           </div>
           <div className="list-group list-group-flush">
             {pipelines.map((pipeline) => {
-              const diagnostic = diagnosticsByPipelineId.get(pipeline.id);
-              const isOfficialPipeline = officialPipelines.some(
-                (official) =>
-                  normalizeCode(official.code) === normalizeCode(pipeline.code),
-              );
-
               return (
                 <article className="list-group-item" key={pipeline.id}>
-                  <div className="d-flex flex-wrap justify-content-between align-items-start gap-3">
-                    <div className="flex-grow-1">
+                  <div className="pipeline-list-row">
+                    <div className="pipeline-list-content">
                       <div className="d-flex flex-wrap align-items-center gap-2 mb-1">
                         <h3 className="h5 mb-0">{pipeline.name}</h3>
-                        {isOfficialPipeline ? (
-                          <span className="badge text-bg-primary">Oficial</span>
-                        ) : null}
-                        <span
-                          className={`badge ${pipeline.active ? "text-bg-success" : "text-bg-secondary"}`}
-                        >
-                          {pipeline.active ? "Ativo" : "Inativo"}
-                        </span>
-                        {diagnostic ? (
-                          <span
-                            className={`badge ${statusBadgeClass(diagnostic.status)}`}
-                          >
-                            Contrato {diagnostic.status}
-                          </span>
-                        ) : null}
                       </div>
                       <div className="d-flex flex-wrap gap-2 small text-body-secondary">
                         <span>{pipeline.module}</span>
@@ -1020,36 +997,13 @@ export default function PipelineCrudPage() {
                         </p>
                       ) : null}
                     </div>
-                    <div className="d-flex flex-wrap gap-2">
+                    <div className="pipeline-list-action">
                       <button
                         type="button"
-                        className="btn btn-primary btn-sm"
+                        className="btn btn-primary btn-sm pipeline-list-stage-button"
                         onClick={() => openPipelineStages(pipeline.id)}
                       >
                         Ver etapas
-                      </button>
-                      <button
-                        className="btn btn-sm btn-outline-primary"
-                        onClick={() => startPipelineEdit(pipeline)}
-                      >
-                        Editar
-                      </button>
-                      <button
-                        className="btn btn-sm btn-outline-danger"
-                        disabled={
-                          deletePipeline.isPending || isOfficialPipeline
-                        }
-                        onClick={() => {
-                          if (
-                            confirm(
-                              "Deseja remover este pipeline e todas as etapas?",
-                            )
-                          ) {
-                            deletePipeline.mutate(pipeline.id);
-                          }
-                        }}
-                      >
-                        {deletePipeline.isPending ? "Excluindo..." : "Excluir"}
                       </button>
                     </div>
                   </div>


### PR DESCRIPTION
### Motivation

- Tornar a lista de pipelines mais limpa e estável visualmente removendo rótulos operacionais redundantes e ações perigosas na listagem.  
- Garantir que o botão `Ver etapas` permaneça sempre na mesma posição entre linhas para evitar deslocamento da UI quando descrições têm tamanhos diferentes.

### Description

- Remove os badges `Oficial`, `Ativo/Inativo` e `Contrato` da listagem no arquivo `frontend/src/pages/pipeline/PipelineCrudPage.tsx`.  
- Remove os botões `Editar` e `Excluir` da listagem e elimina a dependência de `useDeletePipeline` do mesmo arquivo.  
- Altera o markup da listagem para uma grid com duas colunas (conteúdo + coluna de ação) e adiciona classes CSS (`.pipeline-list-row`, `.pipeline-list-content`, `.pipeline-list-action`, `.pipeline-list-stage-button`) em `frontend/src/pages/pipeline/PipelineCrudPage.css` para fixar a posição do botão `Ver etapas` e manter responsividade.  
- Registra a mudança no histórico `docs/registros/experimentos.md` com a descrição da alteração.

### Testing

- Executado `npm --prefix frontend ci` para instalar dependências; comando completou com sucesso.  
- Executado `npm --prefix frontend run typecheck` (TypeScript `tsc --noEmit`) e não foram encontrados erros.  
- Executado `npx --prefix frontend prettier --write` para normalizar formatação e confirmar mudanças de estilo; comando completou com sucesso.  
- Validação visual automatizada com Playwright: `node /tmp/screenshot-pipeline-page.js` (rota mockada das APIs) gerou screenshot `/tmp/pipelines-screen.png` confirmando alinhamento uniforme do botão `Ver etapas`; o teste com acesso ao backend real não pôde ser estabilizado no ambiente por conexão ao host remoto, portanto a verificação final usou rotas mockadas e foi bem-sucedida.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a24da71234c8321b55b02d7c882d255)