### PR TITLE
Oculta 'Gerar com IA' em experimentos já enviados para campanha

### DIFF
--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -3891,3 +3891,13 @@
 - arquivos alterados:
   - `frontend/src/pages/experiment/ExperimentDetailPage.tsx`
   - `docs/registros/experimentos.md`
+
+## 2026-06-07 — Ocultação de Gerar com IA em experimento enviado para campanha
+
+- solicitação: em experimentos já enviados para campanha, remover o botão `Gerar com IA` da aba de estrutura de conteúdo.
+- causa-raiz: a tela bloqueava a ação em alguns estados do experimento, mas ainda podia renderizar o comando de geração quando já existiam campanhas Facebook vinculadas, deixando uma ação inadequada para conteúdo já publicado.
+- correção aplicada: a aba `Estrutura de conteúdo` agora recebe a informação de campanhas Facebook publicadas e oculta os botões de geração com IA quando o experimento já foi enviado para campanha, mantendo apenas a visualização do conteúdo e um aviso explicativo.
+- arquivos alterados:
+  - `frontend/src/pages/experiment/ExperimentDetailPage.tsx`
+  - `frontend/src/pages/experiment/ExperimentContentGenerationTab.tsx`
+  - `docs/registros/experimentos.md`

--- a/frontend/src/pages/experiment/ExperimentContentGenerationTab.tsx
+++ b/frontend/src/pages/experiment/ExperimentContentGenerationTab.tsx
@@ -630,6 +630,8 @@ interface ExperimentContentGenerationTabProps {
   campaignAngle?: string | null;
   adCopy?: string | null;
   alterationLocked?: boolean;
+  hasPublishedFacebookCampaigns?: boolean;
+  isCheckingPublishedFacebookCampaigns?: boolean;
 }
 
 interface AiGenerationRecord {
@@ -1210,6 +1212,8 @@ export default function ExperimentContentGenerationTab({
   campaignAngle,
   adCopy,
   alterationLocked = false,
+  hasPublishedFacebookCampaigns = false,
+  isCheckingPublishedFacebookCampaigns = false,
 }: ExperimentContentGenerationTabProps) {
   const [activeSection, setActiveSection] =
     useState<ContentGenerationSectionKey>(CONTENT_GENERATION_SECTIONS[0].key);
@@ -1218,6 +1222,10 @@ export default function ExperimentContentGenerationTab({
     CampaignAngleGenerationRow[]
   >([]);
   const [isLoadingCampaignAngles, setIsLoadingCampaignAngles] = useState(false);
+  const aiGenerationActionsHidden =
+    alterationLocked ||
+    hasPublishedFacebookCampaigns ||
+    isCheckingPublishedFacebookCampaigns;
   const [adCopyGenerations, setAdCopyGenerations] = useState<
     AdCopyGenerationRow[]
   >([]);
@@ -1908,6 +1916,15 @@ export default function ExperimentContentGenerationTab({
   ]);
 
   async function requestSectionGeneration(section: ContentGenerationSection) {
+    if (aiGenerationActionsHidden) {
+      toast.info(
+        hasPublishedFacebookCampaigns
+          ? "Experimento já enviado para campanha; geração com IA bloqueada."
+          : "Experimento bloqueado para alteração; geração com IA bloqueada.",
+      );
+      return false;
+    }
+
     const nowIso = new Date().toISOString();
     setPendingGenerationSection(section.key);
     setIsGeneratingSection(true);
@@ -2143,10 +2160,13 @@ export default function ExperimentContentGenerationTab({
 
   return (
     <div className="mt-3 d-flex flex-column gap-3">
-      {alterationLocked ? (
+      {aiGenerationActionsHidden ? (
         <div className="alert alert-secondary mb-0" role="status">
-          Gerações de conteúdo bloqueadas para alteração porque o experimento já
-          foi liberado ou está em execução.
+          {isCheckingPublishedFacebookCampaigns
+            ? "Verificando se o experimento já foi enviado para campanha antes de liberar novas gerações."
+            : hasPublishedFacebookCampaigns
+              ? "Gerações de conteúdo bloqueadas porque o experimento já foi enviado para campanha."
+              : "Gerações de conteúdo bloqueadas para alteração porque o experimento já foi liberado ou está em execução."}
         </div>
       ) : null}
       <div className="d-flex justify-content-end">
@@ -2281,7 +2301,8 @@ export default function ExperimentContentGenerationTab({
                         ) : null}
                       </div>
                       <div className="d-flex align-items-start flex-wrap gap-2">
-                        {section.key === "landing-html" ? (
+                        {aiGenerationActionsHidden ? null : section.key ===
+                          "landing-html" ? (
                           <>
                             <button
                               type="button"

--- a/frontend/src/pages/experiment/ExperimentDetailPage.tsx
+++ b/frontend/src/pages/experiment/ExperimentDetailPage.tsx
@@ -1571,6 +1571,7 @@ export default function ExperimentDetailPage() {
   if (isLoading) return <p>Carregando...</p>;
   if (!data) return <p>Não encontrado</p>;
   const alterationLocked = isExperimentAlterationLocked(data);
+  const hasPublishedFacebookCampaigns = Boolean(facebookCampaigns?.length);
   const showGeraLandingStartButtons = !Boolean(data.facebookReleaseRequestedAt);
   const preset = presets?.find((p) => p.id === data.metricPresetId);
   const resetPreviewSummary: ExperimentCampaignResetSummary =
@@ -3580,6 +3581,8 @@ export default function ExperimentDetailPage() {
               campaignAngle={data?.campaignAngle}
               adCopy={data?.adCopy}
               alterationLocked={alterationLocked}
+              hasPublishedFacebookCampaigns={hasPublishedFacebookCampaigns}
+              isCheckingPublishedFacebookCampaigns={isLoadingFacebookCampaigns}
             />
           </Tabs.Content>
           <Tabs.Content value="publico" asChild>


### PR DESCRIPTION
### Motivation
- Evitar que usuários tentem gerar novo conteúdo com IA em experimentos que já foram publicados/enviados para campanha, reduzindo ações inválidas após publicação. 
- Eliminar ruído visual causado por botões de geração desabilitados quando a ação não deve mais ser permitida. 
- Garantir comportamento defensivo para impedir chamadas ao Worker IA quando o experimento estiver bloqueado por estado ou por campanhas já publicadas.

### Description
- A aba de `Estrutura de conteúdo` passa a receber duas props (`hasPublishedFacebookCampaigns` e `isCheckingPublishedFacebookCampaigns`) vindas de `ExperimentDetailPage` para indicar publicação em Facebook e estado de carregamento. 
- Foi adicionada a flag `aiGenerationActionsHidden` em `ExperimentContentGenerationTab.tsx` que combina `alterationLocked`, `hasPublishedFacebookCampaigns` e `isCheckingPublishedFacebookCampaigns` para controlar exibição/visibilidade das ações de IA. 
- Os botões de `Gerar com IA` (incluindo o branch `landing-html`) foram ocultados quando `aiGenerationActionsHidden` é verdadeiro, e um aviso explicativo é exibido no topo da aba. 
- Foi adicionada uma trava defensiva em `requestSectionGeneration` que impede a chamada de geração ao backend quando as ações de IA estão ocultas e mostra um `toast` informativo; o registro da mudança foi adicionado em `docs/registros/experimentos.md`.

### Testing
- Executado `cd frontend && npm run typecheck` no frontend para validação de tipos e a verificação completou sem erros reportados. 
- Executado `cd frontend && npx prettier --check src/pages/experiment/ExperimentContentGenerationTab.tsx src/pages/experiment/ExperimentDetailPage.tsx` e todos os arquivos mantiveram o estilo Prettier sem alterações necessárias.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a24dd01f11883219793d9e9eed89d42)