### PR TITLE
Experiment list: add 'Data de criação' column and pagination (25 per page)

### DIFF
--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -1,3 +1,23 @@
+## 2026-06-07 — Coluna de data de criação na lista de Testes de Nicho
+
+- solicitação: adicionar a coluna Data de criação na lista paginada de Testes de Nicho.
+- foi feito: a tabela passou a exibir a data de criação formatada em pt-BR entre o nome do experimento e o nicho.
+- validação: teste de frontend atualizado para garantir a presença da coluna e o valor formatado na linha paginada.
+- arquivos alterados:
+  - frontend/src/pages/experiment/ExperimentListPage.tsx
+  - frontend/src/pages/experiment/ExperimentListPage.test.tsx
+  - docs/registros/experimentos.md
+
+## 2026-06-07 — Lista de Testes de Nicho com paginação
+
+- solicitação: reorganizar a lista de Testes de Nicho para exibir os 25 experimentos mais recentes com paginação.
+- foi feito: a tela de experimentos agora ordena por data mais recente com desempate por ID, mostra 25 itens por página e substitui as colunas por ID do experimento, nome do experimento, nicho, hipótese, valor, status e botões/ações.
+- validação: teste de frontend adicionado para garantir colunas solicitadas, primeira página com 25 itens mais recentes e navegação para a próxima página.
+- arquivos alterados:
+  - frontend/src/pages/experiment/ExperimentListPage.tsx
+  - frontend/src/pages/experiment/ExperimentListPage.test.tsx
+  - docs/registros/experimentos.md
+
 ## 2026-06-04 — GeraLanding: disparo automático de Gera Prompt Imagem após Gera Copy
 
 - solicitação: no pipeline do GeraLanding, disparar automaticamente a etapa `Gera Prompt Imagem` ao final bem-sucedido da etapa `Gera Copy`, seguindo o padrão já existente de `Gera Prompt Imagem` para `Gera Imagem`.

--- a/frontend/src/pages/experiment/ExperimentListPage.test.tsx
+++ b/frontend/src/pages/experiment/ExperimentListPage.test.tsx
@@ -1,24 +1,131 @@
-import { render, screen } from "@testing-library/react";
+import { cleanup, render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter } from "react-router-dom";
-import { describe, it, expect, vi } from "vitest";
+import { afterEach, describe, it, expect, vi } from "vitest";
 import ExperimentListPage from "./ExperimentListPage";
 import axios from "axios";
 
 vi.mock("axios");
 
+afterEach(() => {
+  cleanup();
+  vi.resetAllMocks();
+});
+
+function renderPage() {
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+    },
+  });
+  return render(
+    <QueryClientProvider client={client}>
+      <BrowserRouter>
+        <ExperimentListPage />
+      </BrowserRouter>
+    </QueryClientProvider>,
+  );
+}
+
 describe("ExperimentListPage", () => {
   it("renders table", async () => {
     (axios.get as any).mockResolvedValueOnce({ data: [] });
     (axios.get as any).mockResolvedValueOnce({ data: [] });
-    const client = new QueryClient();
-    render(
-      <QueryClientProvider client={client}>
-        <BrowserRouter>
-          <ExperimentListPage />
-        </BrowserRouter>
-      </QueryClientProvider>,
-    );
+
+    renderPage();
+
     expect(await screen.findByText(/Novo Teste/)).toBeTruthy();
+  });
+
+  it("shows the 25 most recent experiments with requested columns and pagination", async () => {
+    const experiments = Array.from({ length: 26 }, (_, index) => {
+      const id = index + 1;
+      return {
+        id: String(id),
+        nicheId: 10,
+        hypothesisId: `hypothesis-${id}`,
+        name: `Experimento ${id}`,
+        hypothesis: `Hipótese ${id}`,
+        unitPrice: id,
+        startDate: `2026-06-${String(id).padStart(2, "0")}`,
+        endDate: null,
+        creativeApproved: false,
+        status: "PLANNED",
+        platform: "FACEBOOK",
+        stage: "AD",
+        createdAt: `2026-06-${String(id).padStart(2, "0")}T00:00:00Z`,
+        updatedAt: `2026-06-${String(id).padStart(2, "0")}T00:00:00Z`,
+      };
+    });
+
+    (axios.get as any).mockImplementation((url: string) => {
+      if (url === "/api/experiments")
+        return Promise.resolve({ data: experiments });
+      if (url === "/api/niches") {
+        return Promise.resolve({
+          data: [
+            {
+              id: 10,
+              name: "Nicho Principal",
+              description: "",
+              demandVolume: "",
+              promises: "",
+              offers: "",
+              baseSegmentation: "",
+              interests: "",
+              demographicFilters: "",
+              extraTips: "",
+            },
+          ],
+        });
+      }
+      return Promise.resolve({ data: [] });
+    });
+
+    renderPage();
+
+    expect(
+      await screen.findByRole("columnheader", { name: "ID do experimento" }),
+    ).toBeTruthy();
+    expect(
+      screen.getByRole("columnheader", { name: "Nome do experimento" }),
+    ).toBeTruthy();
+    expect(
+      screen.getByRole("columnheader", { name: "Data de criação" }),
+    ).toBeTruthy();
+    expect(screen.getByRole("columnheader", { name: "Nicho" })).toBeTruthy();
+    expect(screen.getByRole("columnheader", { name: "Hipótese" })).toBeTruthy();
+    expect(screen.getByRole("columnheader", { name: "Valor" })).toBeTruthy();
+    expect(screen.getByRole("columnheader", { name: "Status" })).toBeTruthy();
+    expect(
+      screen.getByRole("columnheader", { name: "Botões/Ações" }),
+    ).toBeTruthy();
+    expect(await screen.findByText("Experimento 26")).toBeTruthy();
+    expect(
+      screen.getByText((content) =>
+        content.includes(
+          "Exibindo 1-25 de 26 experimentos, com 25 por página.",
+        ),
+      ),
+    ).toBeTruthy();
+    expect(screen.queryByText("Experimento 1")).toBeNull();
+
+    await userEvent.click(screen.getByRole("button", { name: "Próxima" }));
+
+    expect(screen.getByText("Página 2 de 2")).toBeTruthy();
+    expect(screen.getByText("Experimento 1")).toBeTruthy();
+    expect(screen.queryByText("Experimento 26")).toBeNull();
+    const row = screen.getByText("Experimento 1").closest("tr");
+    expect(row).not.toBeNull();
+    expect(
+      within(row as HTMLTableRowElement).getByText("01/06/2026"),
+    ).toBeTruthy();
+    expect(
+      within(row as HTMLTableRowElement).getByText("Nicho Principal"),
+    ).toBeTruthy();
+    expect(
+      within(row as HTMLTableRowElement).getByText("R$ 1,00"),
+    ).toBeTruthy();
   });
 });

--- a/frontend/src/pages/experiment/ExperimentListPage.tsx
+++ b/frontend/src/pages/experiment/ExperimentListPage.tsx
@@ -5,15 +5,26 @@ import { useUpdateExperimentStatus } from "../../api/experiment/useUpdateExperim
 import { useCloseExperimentPipelineJobs } from "../../api/experiment/useCloseExperimentPipelineJobs";
 import PageTitle from "../../components/PageTitle";
 import experimentIcon from "../../assets/icons/experiment-icon.svg";
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { toast } from "react-toastify";
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import axios from "axios";
+
+const PAGE_SIZE = 25;
 
 function parseDate(date?: string | null) {
   if (!date) return 0;
   const timestamp = new Date(date).getTime();
   return Number.isNaN(timestamp) ? 0 : timestamp;
+}
+
+function formatDate(value?: string | null) {
+  if (!value) return "—";
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return value;
+  return new Intl.DateTimeFormat("pt-BR", {
+    dateStyle: "short",
+  }).format(date);
 }
 
 function formatCurrency(value?: number | null) {
@@ -49,29 +60,47 @@ export default function ExperimentListPage() {
   const [search, setSearch] = useState("");
   const [status, setStatus] = useState("");
   const [niche, setNiche] = useState("");
-  const [stoppingExperimentId, setStoppingExperimentId] = useState<string | null>(null);
-  const [retryingExperimentId, setRetryingExperimentId] = useState<string | null>(null);
+  const [currentPage, setCurrentPage] = useState(1);
+  const [stoppingExperimentId, setStoppingExperimentId] = useState<
+    string | null
+  >(null);
+  const [retryingExperimentId, setRetryingExperimentId] = useState<
+    string | null
+  >(null);
   const retryRelease = useMutation({
     mutationFn: async (experimentId: string) => {
-      const { data } = await axios.post(`/api/experiments/${experimentId}/facebook-release`);
+      const { data } = await axios.post(
+        `/api/experiments/${experimentId}/facebook-release`,
+      );
       return data;
     },
     onSuccess: async (_, experimentId) => {
       await Promise.all([
         queryClient.invalidateQueries({ queryKey: ["experiments"] }),
-        queryClient.invalidateQueries({ queryKey: ["experiment", experimentId] }),
-        queryClient.invalidateQueries({ queryKey: ["experiment-readiness", experimentId] }),
-        queryClient.invalidateQueries({ queryKey: ["experiment", experimentId, "funnel"] }),
+        queryClient.invalidateQueries({
+          queryKey: ["experiment", experimentId],
+        }),
+        queryClient.invalidateQueries({
+          queryKey: ["experiment-readiness", experimentId],
+        }),
+        queryClient.invalidateQueries({
+          queryKey: ["experiment", experimentId, "funnel"],
+        }),
       ]);
     },
   });
   const experiments = Array.isArray(data) ? data : [];
+  const nicheNameById = useMemo(() => {
+    if (!Array.isArray(niches)) return new Map<number, string>();
+    return new Map(niches.map((item) => [item.id, item.name]));
+  }, [niches]);
 
   const nicheTotalCostMap = useMemo(() => {
     return experiments.reduce<Record<number, number>>((acc, experiment) => {
       if (typeof experiment.nicheId !== "number") return acc;
       const experimentCost = resolveExperimentCost(experiment);
-      if (typeof experimentCost !== "number" || Number.isNaN(experimentCost)) return acc;
+      if (typeof experimentCost !== "number" || Number.isNaN(experimentCost))
+        return acc;
       acc[experiment.nicheId] = (acc[experiment.nicheId] ?? 0) + experimentCost;
       return acc;
     }, {});
@@ -90,19 +119,61 @@ export default function ExperimentListPage() {
     return [...filtered].sort((a, b) => {
       const bDate = parseDate(b.startDate ?? b.createdAt);
       const aDate = parseDate(a.startDate ?? a.createdAt);
-      return bDate - aDate;
+      const dateComparison = bDate - aDate;
+      if (dateComparison !== 0) return dateComparison;
+      return Number(b.id) - Number(a.id);
     });
   }, [filtered]);
+
+  const totalPages = Math.max(1, Math.ceil(sorted.length / PAGE_SIZE));
+  const pageStart = (currentPage - 1) * PAGE_SIZE;
+  const paginated = sorted.slice(pageStart, pageStart + PAGE_SIZE);
+  const visibleStart = sorted.length === 0 ? 0 : pageStart + 1;
+  const visibleEnd = Math.min(pageStart + PAGE_SIZE, sorted.length);
+  const paginationItems = useMemo(() => {
+    if (totalPages <= 7) {
+      return Array.from({ length: totalPages }, (_, index) => index + 1);
+    }
+
+    const middleStart = Math.max(2, currentPage - 1);
+    const middleEnd = Math.min(totalPages - 1, currentPage + 1);
+    const items: Array<number | string> = [1];
+
+    if (middleStart > 2) items.push("start-ellipsis");
+    for (let page = middleStart; page <= middleEnd; page += 1) {
+      items.push(page);
+    }
+    if (middleEnd < totalPages - 1) items.push("end-ellipsis");
+    items.push(totalPages);
+
+    return items;
+  }, [currentPage, totalPages]);
+
+  useEffect(() => {
+    setCurrentPage(1);
+  }, [search, status, niche]);
+
+  useEffect(() => {
+    if (currentPage > totalPages) {
+      setCurrentPage(totalPages);
+    }
+  }, [currentPage, totalPages]);
 
   async function handleUserStop(experimentId: string) {
     setStoppingExperimentId(experimentId);
     try {
-      await updateStatus.mutateAsync({ id: experimentId, status: "USER_STOPPED" });
+      await updateStatus.mutateAsync({
+        id: experimentId,
+        status: "USER_STOPPED",
+      });
       await closePipelineJobs.mutateAsync({
         experimentId,
-        reason: "Encerrado pela ação de parada do usuário na tela de experimentos",
+        reason:
+          "Encerrado pela ação de parada do usuário na tela de experimentos",
       });
-      toast.success("Experimento encerrado e jobs de pipeline abertos foram finalizados.");
+      toast.success(
+        "Experimento encerrado e jobs de pipeline abertos foram finalizados.",
+      );
     } catch {
       toast.error("Não foi possível concluir a parada do usuário.");
     } finally {
@@ -114,7 +185,9 @@ export default function ExperimentListPage() {
     setRetryingExperimentId(experimentId);
     try {
       await retryRelease.mutateAsync(experimentId);
-      toast.success("Experimento reenviado para a fila do Facebook Ads Worker.");
+      toast.success(
+        "Experimento reenviado para a fila do Facebook Ads Worker.",
+      );
     } catch {
       toast.error("Não foi possível reenviar o experimento para a fila.");
     } finally {
@@ -140,7 +213,11 @@ export default function ExperimentListPage() {
           />
         </div>
         <div className="col">
-          <select className="form-select" value={niche} onChange={(e) => setNiche(e.target.value)}>
+          <select
+            className="form-select"
+            value={niche}
+            onChange={(e) => setNiche(e.target.value)}
+          >
             <option value="">Todos Nichos</option>
             {Array.isArray(niches) &&
               niches.map((n) => (
@@ -151,7 +228,11 @@ export default function ExperimentListPage() {
           </select>
         </div>
         <div className="col">
-          <select className="form-select" value={status} onChange={(e) => setStatus(e.target.value)}>
+          <select
+            className="form-select"
+            value={status}
+            onChange={(e) => setStatus(e.target.value)}
+          >
             <option value="">Todos Status</option>
             <option value="PLANNED">PLANNED</option>
             <option value="RUNNING">RUNNING</option>
@@ -162,34 +243,52 @@ export default function ExperimentListPage() {
           </select>
         </div>
       </div>
+      <div className="d-flex flex-column flex-md-row justify-content-between align-items-md-center gap-2 mb-2">
+        <span className="text-muted small">
+          Exibindo {visibleStart}-{visibleEnd} de {sorted.length} experimentos,
+          com {PAGE_SIZE} por página.
+        </span>
+        <span className="badge text-bg-light align-self-start align-self-md-center">
+          Mais recentes primeiro
+        </span>
+      </div>
       <div className="table-responsive">
-        <table className="table">
+        <table className="table align-middle">
           <thead>
             <tr>
-              <th>Nome</th>
+              <th>ID do experimento</th>
+              <th>Nome do experimento</th>
+              <th>Data de criação</th>
+              <th>Nicho</th>
               <th>Hipótese</th>
-              <th>Variável</th>
-              <th>Custo</th>
+              <th>Valor</th>
               <th>Status</th>
-              <th>Início</th>
-              <th>Ações</th>
+              <th>Botões/Ações</th>
             </tr>
           </thead>
           <tbody>
-            {sorted.map((e) => {
+            {paginated.map((e) => {
               const canStop = e.status === "RUNNING";
               const isStopping = stoppingExperimentId === String(e.id);
               const isRetrying = retryingExperimentId === String(e.id);
               return (
                 <tr key={e.id}>
+                  <td className="text-nowrap">{e.id}</td>
                   <td>{e.name}</td>
-                  <td>{e.hypothesis || "—"}</td>
-                  <td>{e.primaryVariable || "—"}</td>
-                  <td>{formatCurrency(resolveExperimentCost(e))}</td>
-                  <td>{e.status}</td>
-                  <td>{e.startDate}</td>
+                  <td className="text-nowrap">{formatDate(e.createdAt)}</td>
                   <td>
-                    <Link className="btn btn-sm btn-outline-primary" to={`/experiments/${e.id}`}>
+                    {nicheNameById.get(e.nicheId) || `Nicho #${e.nicheId}`}
+                  </td>
+                  <td>{e.hypothesis || "—"}</td>
+                  <td>
+                    {formatCurrency(e.unitPrice ?? resolveExperimentCost(e))}
+                  </td>
+                  <td>{e.status}</td>
+                  <td>
+                    <Link
+                      className="btn btn-sm btn-outline-primary"
+                      to={`/experiments/${e.id}`}
+                    >
                       Visualizar
                     </Link>
                     {canStop && (
@@ -233,6 +332,72 @@ export default function ExperimentListPage() {
           </tbody>
         </table>
       </div>
+      {sorted.length === 0 && (
+        <div className="alert alert-light border" role="status">
+          Nenhum experimento encontrado para os filtros selecionados.
+        </div>
+      )}
+      {totalPages > 1 && (
+        <nav
+          className="d-flex flex-column flex-md-row justify-content-between align-items-md-center gap-2"
+          aria-label="Paginação dos experimentos"
+        >
+          <span className="text-muted small">
+            Página {currentPage} de {totalPages}
+          </span>
+          <ul className="pagination mb-0">
+            <li className={`page-item${currentPage === 1 ? " disabled" : ""}`}>
+              <button
+                type="button"
+                className="page-link"
+                disabled={currentPage === 1}
+                onClick={() => setCurrentPage((page) => Math.max(1, page - 1))}
+              >
+                Anterior
+              </button>
+            </li>
+            {paginationItems.map((page) =>
+              typeof page === "number" ? (
+                <li
+                  key={page}
+                  className={`page-item${page === currentPage ? " active" : ""}`}
+                >
+                  <button
+                    type="button"
+                    className="page-link"
+                    aria-current={page === currentPage ? "page" : undefined}
+                    onClick={() => setCurrentPage(page)}
+                  >
+                    {page}
+                  </button>
+                </li>
+              ) : (
+                <li
+                  key={page}
+                  className="page-item disabled"
+                  aria-hidden="true"
+                >
+                  <span className="page-link">…</span>
+                </li>
+              ),
+            )}
+            <li
+              className={`page-item${currentPage === totalPages ? " disabled" : ""}`}
+            >
+              <button
+                type="button"
+                className="page-link"
+                disabled={currentPage === totalPages}
+                onClick={() =>
+                  setCurrentPage((page) => Math.min(totalPages, page + 1))
+                }
+              >
+                Próxima
+              </button>
+            </li>
+          </ul>
+        </nav>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
### Motivation
- Improve the Experiment list UX by showing creation date and supporting paginated viewing of recent experiments to avoid extremely long tables and surface the most relevant items first.
- Make the list deterministic by ordering by most recent date with a tie-breaker by ID and expose useful columns requested by product (ID, name, creation date, niche, hypothesis, value, status, actions).
- Keep frontend behavior covered by tests to prevent regressions.

### Description
- Added pagination with `PAGE_SIZE = 25`, sorting by most recent date then by ID, page navigation, and page state management in `ExperimentListPage.tsx`.
- Added `Data de criação` column formatted in `pt-BR` via a new `formatDate` helper and replaced the previous columns with the requested set (ID, Nome, Data de criação, Nicho, Hipótese, Valor, Status, Botões/Ações).
- Added a `nicheNameById` map to show niche names and updated cost display to prefer `unitPrice` then fallback to resolved experiment cost, using `formatCurrency` for localized currency formatting.
- Introduced UI elements for visible range summary, empty-state message, and paginated navigation with ellipses for many pages; ensured filters reset pagination appropriately.
- Updated `ExperimentListPage.test.tsx` to mock API responses, assert new columns, verify the first page contains 25 most recent experiments, check navigation to page 2, and validate formatted creation date and niche/currency cells.
- Updated `docs/registros/experimentos.md` with entries describing the new column and the pagination change.

### Testing
- Ran frontend unit tests with `vitest` that include the updated `ExperimentListPage.test.tsx` and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a24dca0f9c88321a4c0a70b6676c9d6)