### PR TITLE
Diferencia cards de pipeline por uso de IA e remove bloco de objetivo

### DIFF
--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -3908,3 +3908,12 @@
   - `frontend/src/pages/experiment/ExperimentDetailPage.tsx`
   - `frontend/src/pages/experiment/ExperimentContentGenerationTab.tsx`
   - `docs/registros/experimentos.md`
+
+## 2026-06-07 00:04:00 UTC-3
+- solicitação: ajustar a tela de etapas de pipelines para usar a borda superior dos cards como indicação visual de etapas que usam IA e remover o bloco de objetivo dos cards.
+- raciocínio para a solução: a própria tela já calcula se a etapa opera com OpenAI/modelo de IA, então a diferenciação visual deve partir desse estado em vez de alternar cores por posição; remover o objetivo reduz excesso de informação no card.
+- registro do que foi feito: os cards de etapas passaram a receber classes distintas para etapas com IA e sem IA, o CSS passou a aplicar uma cor fixa para cada tipo e o bloco "Objetivo da etapa" deixou de ser renderizado.
+- documentos lidos para pesquisar e resolver o problema:
+  - AGENTS.md
+  - frontend/AGENTS.md
+  - docs/registros/experimentos.md

--- a/frontend/src/pages/pipeline/PipelineCrudPage.css
+++ b/frontend/src/pages/pipeline/PipelineCrudPage.css
@@ -205,20 +205,12 @@
   box-shadow: 0 22px 42px -28px rgba(47, 91, 234, 0.7);
 }
 
-.pipeline-stage-grid-item:nth-child(4n + 1) .pipeline-stage-card {
-  border-top: 0.45rem solid var(--pipeline-blue);
-}
-
-.pipeline-stage-grid-item:nth-child(4n + 2) .pipeline-stage-card {
-  border-top: 0.45rem solid var(--pipeline-green);
-}
-
-.pipeline-stage-grid-item:nth-child(4n + 3) .pipeline-stage-card {
-  border-top: 0.45rem solid var(--pipeline-amber);
-}
-
-.pipeline-stage-grid-item:nth-child(4n) .pipeline-stage-card {
+.pipeline-stage-card-ai {
   border-top: 0.45rem solid var(--pipeline-indigo);
+}
+
+.pipeline-stage-card-manual {
+  border-top: 0.45rem solid var(--pipeline-amber);
 }
 
 .pipeline-stage-card-body {

--- a/frontend/src/pages/pipeline/PipelineCrudPage.tsx
+++ b/frontend/src/pages/pipeline/PipelineCrudPage.tsx
@@ -437,7 +437,9 @@ export default function PipelineCrudPage() {
 
                 return (
                   <div className="pipeline-stage-grid-item" key={stage.id}>
-                    <article className="pipeline-stage-card">
+                    <article
+                      className={`pipeline-stage-card ${showOpenAiModel ? "pipeline-stage-card-ai" : "pipeline-stage-card-manual"}`}
+                    >
                       <div className="pipeline-stage-card-body">
                         <div className="pipeline-stage-card-header">
                           <div className="pipeline-stage-title-block">
@@ -462,12 +464,6 @@ export default function PipelineCrudPage() {
                             {stage.code}
                           </span>
                         </div>
-                        {stage.description ? (
-                          <div className="pipeline-stage-purpose">
-                            <span>Objetivo da etapa</span>
-                            <p>{stage.description}</p>
-                          </div>
-                        ) : null}
                         <div className="pipeline-stage-meta">
                           {showExecutionModule ? (
                             <div>


### PR DESCRIPTION
### Motivation
- Tornar a tela de etapas mais informativa: usar a borda superior dos cards para indicar se a etapa usa IA (OpenAI) ou é manual em vez de variar por posição. 
- Reduzir ruído visual removendo o bloco "Objetivo da etapa" dos cards conforme solicitado na especificação da tela.

### Description
- Os artigos de etapa agora recebem classes condicionais `pipeline-stage-card-ai` ou `pipeline-stage-card-manual` com base em `stageUsesOpenAi(...)` (arquivo `frontend/src/pages/pipeline/PipelineCrudPage.tsx`).
- O JSX que renderizava o bloco `pipeline-stage-purpose` foi removido para ocultar o objetivo dentro do card (arquivo `frontend/src/pages/pipeline/PipelineCrudPage.tsx`).
- O CSS deixou de alternar cores por posição e aplica uma cor fixa para cada tipo de card (`.pipeline-stage-card-ai` e `.pipeline-stage-card-manual`) em `frontend/src/pages/pipeline/PipelineCrudPage.css`.
- Adicionado registro operacional no log de Experimentos (`docs/registros/experimentos.md`) documentando a mudança.

### Testing
- Executado `npx prettier --write src/pages/pipeline/PipelineCrudPage.tsx src/pages/pipeline/PipelineCrudPage.css` e formatado com sucesso.
- Executado `npm run typecheck` no `frontend` e a checagem TypeScript passou com sucesso após instalar dependências no ambiente de build.
- Build de produção gerado com `npm run build` (`vite build`) sem erros e artifacts criados com sucesso.
- Verificação de lint/cheks com `git diff --check` não apresentou problemas.
- Teste visual automatizado: captura via Playwright com mocks de API gerando `/tmp/pipeline-screen.png` confirmou presença das classes `pipeline-stage-card-ai` e `pipeline-stage-card-manual` e a remoção do bloco de objetivo.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a24df6b5688832194391c8e1cb5353c)