### PR TITLE
Use html_bytes>0 as canonical criterion for captured pages and avoid recapturing useful HTML

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryService.java
@@ -458,14 +458,14 @@ public class MoisSalesLibraryService {
     }
 
     /**
-     * Calcula os contadores globais da biblioteca diretamente em mois_sales_page para eliminar paginação ambígua.
+     * Calcula os contadores globais da biblioteca usando html_bytes > 0 como critério canônico de página capturada.
      */
     public MoisSalesLibraryDtos.SalesLibraryPageSummaryResponse summarizePages(String workspaceId) {
         return jdbcTemplate.queryForObject("""
                 SELECT COUNT(*) AS total,
                        SUM(current_status = 'PENDING') AS pending,
                        SUM(current_status IN ('FETCHING', 'CAPTURING')) AS capturing,
-                       SUM(current_status IN ('CAPTURED', 'DUPLICATE')) AS captured,
+                       SUM(COALESCE(html_bytes, 0) > 0) AS captured,
                        SUM(current_status IN ('DONE', 'ANALYZED')) AS analyzed,
                        SUM(current_status = 'FAILED') AS failed,
                        SUM(current_status = 'BLOCKED_COOLDOWN') AS blocked_cooldown,

--- a/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibrarySnapshotService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibrarySnapshotService.java
@@ -193,13 +193,13 @@ public class MoisSalesLibrarySnapshotService {
     }
 
     /**
-     * Seleciona páginas da biblioteca elegíveis para captura de HTML bruto usando somente as tabelas consolidadas.
+     * Seleciona páginas sem HTML útil, usando html_bytes = 0 como critério para processamento da etapa 1.
      */
     private List<PageToCapture> findPagesToCapture(String workspaceId, int limit, boolean force) {
         String forceClause = force ? "" : """
                 AND NOT EXISTS (
                     SELECT 1 FROM mois_sales_page_job_execution e
-                    WHERE e.sales_page_id = sp.id AND e.stage = 'CAPTURE' AND e.status IN ('CAPTURED', 'FETCHING')
+                    WHERE e.sales_page_id = sp.id AND e.stage = 'CAPTURE' AND e.status = 'FETCHING'
                 )
                 AND NOT EXISTS (
                     SELECT 1 FROM mois_sales_page_job_execution recent_failure
@@ -221,6 +221,7 @@ public class MoisSalesLibrarySnapshotService {
                 FROM mois_sales_page sp
                 WHERE sp.workspace_id = ?
                   AND sp.current_status NOT IN ('FETCHING', 'CAPTURING', 'DISCARDED')
+                  AND COALESCE(sp.html_bytes, 0) = 0
                 """ + forceClause + """
                 ORDER BY sp.updated_at DESC, sp.id DESC
                 LIMIT ?

--- a/backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryServiceTest.java
@@ -106,6 +106,34 @@ class MoisSalesLibraryServiceTest {
     }
 
     /**
+     * Garante que o resumo operacional considera captura correta somente quando html_bytes é maior que zero.
+     */
+    @Test
+    void shouldSummarizeCapturedPagesByUsefulHtmlBytes() {
+        given(jdbcTemplate.queryForObject(
+                contains("SUM(COALESCE(html_bytes, 0) > 0) AS captured"),
+                isA(RowMapper.class),
+                eq("workspace-001")))
+                .willReturn(new MoisSalesLibraryDtos.SalesLibraryPageSummaryResponse(
+                        "workspace-001",
+                        421L,
+                        0L,
+                        0L,
+                        327L,
+                        106L,
+                        91L,
+                        0L,
+                        402L,
+                        19L,
+                        Instant.parse("2026-06-07T05:38:13Z")
+                ));
+
+        MoisSalesLibraryDtos.SalesLibraryPageSummaryResponse response = service.summarizePages("workspace-001");
+
+        org.assertj.core.api.Assertions.assertThat(response.captured()).isEqualTo(327L);
+    }
+
+    /**
      * Garante que o claim de HTML bruto lê a tabela de referências coletadas e retorna a URL reservada.
      */
     @Test

--- a/backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibrarySnapshotServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibrarySnapshotServiceTest.java
@@ -230,6 +230,40 @@ public class MoisSalesLibrarySnapshotServiceTest {
         assertThat(storedUrls.get("redirect_root_url")).isEqualTo(baseUrl);
     }
 
+    /** Garante que páginas com html_bytes > 0 não sejam recapturadas nem em acionamento forçado da etapa 1. */
+    @Test
+    void shouldSkipPagesWithUsefulHtmlBytesEvenWhenForceIsEnabled() {
+        String url = "http://localhost:" + server.getAddress().getPort() + "/sales";
+        insertPageWithState(9L, url, "CAPTURE", "CAPTURED", 128L);
+
+        var response = service.captureSnapshots(
+                new MoisSalesLibraryDtos.SalesLibrarySnapshotCaptureRequest("workspace-001", 5, true));
+
+        assertThat(response.processed()).isZero();
+        Integer executions = jdbcTemplate.queryForObject(
+                "SELECT COUNT(*) FROM mois_sales_page_job_execution WHERE sales_page_id = 9 AND stage = 'CAPTURE'",
+                Integer.class);
+        assertThat(executions).isZero();
+    }
+
+    /** Garante que a etapa 1 reprocesse páginas sem HTML útil mesmo quando o status anterior dizia CAPTURED. */
+    @Test
+    void shouldProcessCapturedStatusWhenHtmlBytesIsZero() {
+        String url = "http://localhost:" + server.getAddress().getPort() + "/sales";
+        insertPageWithState(10L, url, "CAPTURE", "CAPTURED", 0L);
+
+        var response = service.captureSnapshots(
+                new MoisSalesLibraryDtos.SalesLibrarySnapshotCaptureRequest("workspace-001", 5, false));
+
+        assertThat(response.processed()).isEqualTo(1);
+        assertThat(response.items().getFirst().pageId()).isEqualTo(10L);
+        assertThat(response.items().getFirst().rawHtmlBytes()).isPositive();
+        Long persistedHtmlBytes = jdbcTemplate.queryForObject(
+                "SELECT html_bytes FROM mois_sales_page WHERE id = 10",
+                Long.class);
+        assertThat(persistedHtmlBytes).isPositive();
+    }
+
     /** Fornece timestamp UTC compatível com a função usada no SQL MySQL dos testes. */
     public static Timestamp utcTimestamp() {
         return Timestamp.from(Instant.now());
@@ -237,11 +271,17 @@ public class MoisSalesLibrarySnapshotServiceTest {
 
     /** Insere uma página operacional para os testes de seleção e captura. */
     private void insertPage(long pageId, String url) {
+        insertPageWithState(pageId, url, "ANALYSIS", "PENDING", 0L);
+    }
+
+    /** Insere uma página operacional com estado e bytes de HTML controlados pelo cenário de teste. */
+    private void insertPageWithState(long pageId, String url, String currentStage, String currentStatus, long htmlBytes) {
         jdbcTemplate.update("""
                 INSERT INTO mois_sales_page
-                (id, workspace_id, source, url_original, url_canonical, title, current_stage, current_status, ingest_count, created_at, updated_at)
-                VALUES (?, 'workspace-001', 'TEST', ?, ?, 'Oferta Teste', 'ANALYSIS', 'PENDING', 1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
-                """, pageId, url, url);
+                (id, workspace_id, source, url_original, url_canonical, title, current_stage, current_status, capture_status, html_bytes,
+                 ingest_count, created_at, updated_at)
+                VALUES (?, 'workspace-001', 'TEST', ?, ?, 'Oferta Teste', ?, ?, ?, ?, 1, CURRENT_TIMESTAMP, CURRENT_TIMESTAMP)
+                """, pageId, url, url, currentStage, currentStatus, currentStatus, htmlBytes);
     }
 
     /** Insere uma falha prévia para validar cooldown e limite de tentativas. */

--- a/docs/canonical/mois-worker-canon.v1.md
+++ b/docs/canonical/mois-worker-canon.v1.md
@@ -301,6 +301,7 @@ erDiagram
 - **Papel no fluxo**: fonte operacional principal do estado atual da página de venda.
 - **Função operacional**: deduplicar URLs, manter metadados de origem, status atual, captura atual, score e último erro.
 - **Campos de destaque**: `id`, `workspace_id`, `source`, `source_job_id`, `source_reference_id`, `collected_reference_id`, `url_original`, `url_canonical`, `url_final`, `current_stage`, `current_status`, `capture_status`, `analysis_status`, `html_sha256`, `html_bytes`, `score_total`, `last_job_execution_id`, `created_at`, `updated_at`.
+- **Critério canônico de captura correta**: uma página só deve ser considerada com HTML útil obtido quando `html_bytes > 0`; status como `CAPTURED`, `DUPLICATE`, `DONE` ou `ANALYZED` não substituem esse critério. A etapa 1 deve priorizar/processar páginas com `COALESCE(html_bytes, 0) = 0`, respeitando cooldown/limite de falhas quando não houver acionamento forçado.
 
 #### 13.3.2 `mois_sales_page_job_execution`
 - **Papel no fluxo**: histórico/auditoria de cada execução operacional sobre uma página.

--- a/docs/registros/mois1.md
+++ b/docs/registros/mois1.md
@@ -1092,3 +1092,17 @@ Arquivos alterados:
 Arquivos alterados:
 - `frontend/src/pages/mois/MoisSalesPagesPipelinePage.tsx`
 - `docs/registros/mois1.md`
+
+## 2026-06-07 — Critério canônico de captura correta por html_bytes
+
+- definido `html_bytes > 0` como critério operacional para considerar captura de página correta na Biblioteca de Páginas de Vendas MOIS.
+- ajustada a etapa 1 para selecionar páginas sem HTML útil (`COALESCE(html_bytes, 0) = 0`) e evitar recapturar páginas já úteis mesmo em execução forçada.
+- atualizado o resumo do pipeline para exibir páginas com HTML útil em vez de somar status operacionais.
+
+Arquivos alterados:
+- `docs/canonical/mois-worker-canon.v1.md`
+- `docs/swagger/mois-sales-library-swagger.yaml`
+- `backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryService.java`
+- `backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibrarySnapshotService.java`
+- `backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibrarySnapshotServiceTest.java`
+- `frontend/src/pages/mois/MoisSalesPagesPipelinePage.tsx`

--- a/docs/swagger/mois-sales-library-swagger.yaml
+++ b/docs/swagger/mois-sales-library-swagger.yaml
@@ -91,6 +91,24 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/CollectedReferenceUrlSummaryResponse'
+  /pages/summary:
+    get:
+      summary: Resume páginas operacionais consolidadas
+      description: Retorna contadores de `mois_sales_page`; o campo `captured` usa `html_bytes > 0` como critério canônico de HTML útil obtido para a etapa 1.
+      tags: [MOIS Sales Library]
+      parameters:
+        - in: query
+          name: workspaceId
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Contadores globais da biblioteca operacional
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SalesLibraryPageSummaryResponse'
   /jobs:
     get:
       summary: Lista execuções operacionais consolidadas
@@ -311,7 +329,8 @@ paths:
                 $ref: '#/components/schemas/HtmlCapturePersistResponse'
   /snapshots:capture:
     post:
-      summary: Executa captura HTML backend para páginas sem captura recente usando o modelo operacional novo
+      summary: Executa captura HTML backend para páginas sem HTML útil usando o modelo operacional novo
+      description: A etapa 1 seleciona páginas com `COALESCE(html_bytes, 0) = 0`; quando `force=true`, ignora cooldown/limite de falhas, mas continua sem recapturar páginas com `html_bytes > 0`.
       tags: [MOIS Sales Library]
       requestBody:
         required: true
@@ -585,6 +604,44 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/CollectedReferenceUrlTypeBreakdown'
+    SalesLibraryPageSummaryResponse:
+      type: object
+      properties:
+        workspaceId:
+          type: string
+        total:
+          type: integer
+          format: int64
+        pending:
+          type: integer
+          format: int64
+        capturing:
+          type: integer
+          format: int64
+        captured:
+          type: integer
+          format: int64
+          description: Total de páginas com HTML útil consolidado, calculado por `html_bytes > 0`.
+        analyzed:
+          type: integer
+          format: int64
+          description: Total por status de análise (`DONE` ou `ANALYZED`), mantido como métrica complementar.
+        failed:
+          type: integer
+          format: int64
+        blockedCooldown:
+          type: integer
+          format: int64
+        hotmart:
+          type: integer
+          format: int64
+        clickbank:
+          type: integer
+          format: int64
+        updatedAt:
+          type: string
+          format: date-time
+          nullable: true
     CollectedReferenceUrlSourceBreakdown:
       type: object
       properties:

--- a/frontend/src/pages/mois/MoisSalesPagesPipelinePage.tsx
+++ b/frontend/src/pages/mois/MoisSalesPagesPipelinePage.tsx
@@ -191,12 +191,10 @@ export default function MoisSalesPagesPipelinePage() {
               <div className="col-sm-6 col-lg-4">
                 <div className="bg-light rounded-3 p-3 h-100">
                   <p className="text-secondary mb-1">
-                    Total com página obtida (HTML/imagem)
+                    Total com HTML útil (html_bytes &gt; 0)
                   </p>
                   <h3 className="mb-0">
-                    {summaryQuery.isLoading
-                      ? "..."
-                      : (summary?.captured ?? 0) + (summary?.analyzed ?? 0)}
+                    {summaryQuery.isLoading ? "..." : (summary?.captured ?? 0)}
                   </h3>
                 </div>
               </div>
@@ -209,8 +207,8 @@ export default function MoisSalesPagesPipelinePage() {
                 <h3 className="h6 mb-1">Executar captura agora</h3>
                 <p className="text-secondary small mb-0">
                   O acionamento usa o backend existente e processa até{" "}
-                  {DEFAULT_CAPTURE_LIMIT} URLs por execução para evitar
-                  bloqueios e timeouts longos.
+                  {DEFAULT_CAPTURE_LIMIT} URLs sem HTML útil por execução para
+                  evitar bloqueios e timeouts longos.
                 </p>
               </div>
               <div className="d-flex flex-wrap align-items-center gap-3">
@@ -227,7 +225,7 @@ export default function MoisSalesPagesPipelinePage() {
                     className="form-check-label small"
                     htmlFor="forceCapture"
                   >
-                    Recapturar mesmo com snapshot
+                    Forçar URLs sem HTML (ignorar cooldown)
                   </label>
                 </div>
                 <button


### PR DESCRIPTION
### Motivation
- Remove ambiguity between operational status and whether a page actually has useful HTML by treating `html_bytes > 0` as the canonical signal that a page was successfully captured.\
- Prevent unnecessary recapture of pages that already contain useful HTML while still allowing recovery of pages that claim `CAPTURED` but have zero bytes.\

### Description
- Update `summarizePages` to compute `captured` using `SUM(COALESCE(html_bytes, 0) > 0)` instead of summing status values.\
- Change page selection in `findPagesToCapture` to only consider pages with `COALESCE(html_bytes, 0) = 0` and relax the exclusion of prior executions so `CAPTURED` status does not prevent reprocessing when bytes are zero.\
- Adjust SQL force clause to not treat `CAPTURED` as a blocker for processing attempts (it now only checks for `FETCHING`).\
- Update schema documentation (`docs/canonical/mois-worker-canon.v1.md`), Swagger (`docs/swagger/mois-sales-library-swagger.yaml`), and frontend pipeline UI (`MoisSalesPagesPipelinePage.tsx`) to reflect that `captured` means `html_bytes > 0`, and to show the pipeline only counting pages with useful HTML.\
- Add tests and test helpers: `insertPageWithState` and new unit tests in `MoisSalesLibraryServiceTest` and `MoisSalesLibrarySnapshotServiceTest` covering the new canonical criterion and forced capture behavior.\

### Testing
- Ran unit test `MoisSalesLibraryServiceTest#shouldSummarizeCapturedPagesByUsefulHtmlBytes` which asserted the `captured` value is computed from `html_bytes > 0`, and it passed.\
- Ran snapshot tests `MoisSalesLibrarySnapshotServiceTest#shouldSkipPagesWithUsefulHtmlBytesEvenWhenForceIsEnabled` and `MoisSalesLibrarySnapshotServiceTest#shouldProcessCapturedStatusWhenHtmlBytesIsZero`, both of which passed.\
- Executed the existing test suite related to sales library ingestion and capture flows and verified no regressions in the modified areas (all affected tests passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a24d9f89f0083219ddeefc9c71bf71b)