### PR TITLE
Add device-type breakdown (Mobile/Desktop/Tablet) to landing analytics

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/funnel/ExperimentFunnelService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/funnel/ExperimentFunnelService.java
@@ -1,19 +1,20 @@
 package com.marketinghub.experiment.funnel;
 
-import com.marketinghub.repository.jpa.experiment.funnel.ExperimentFunnelEventRepository;
 import com.marketinghub.experiment.Experiment;
 import com.marketinghub.experiment.funnel.dto.ExperimentFunnelStageDto;
+import com.marketinghub.experiment.funnel.dto.RegisterExperimentFunnelEventRequest;
+import com.marketinghub.experiment.funnel.service.analytics.ExperimentLandingAnalyticsDeviceDto;
 import com.marketinghub.experiment.funnel.service.analytics.ExperimentLandingAnalyticsDto;
 import com.marketinghub.experiment.funnel.service.analytics.ExperimentLandingAnalyticsSectionDto;
 import com.marketinghub.experiment.funnel.service.analytics.ExperimentLandingAnalyticsSessionDto;
-import com.marketinghub.experiment.funnel.dto.RegisterExperimentFunnelEventRequest;
-import com.marketinghub.repository.jpa.experiment.funnel.ExperimentFunnelEventRepository.StageAggregation;
 import com.marketinghub.leadportal.dto.LeadPortalSubmissionEngagementContractV1;
-import com.marketinghub.repository.jpa.experiment.ExperimentRepository;
+import com.marketinghub.leadportal.dto.RegisterLandingPageAnalyticsEventRequest;
+import com.marketinghub.leadportal.dto.RegisterLeadPortalSubmissionRequest;
 import com.marketinghub.model.Lead;
 import com.marketinghub.repository.jpa.core.LeadRepository;
-import com.marketinghub.leadportal.dto.RegisterLeadPortalSubmissionRequest;
-import com.marketinghub.leadportal.dto.RegisterLandingPageAnalyticsEventRequest;
+import com.marketinghub.repository.jpa.experiment.ExperimentRepository;
+import com.marketinghub.repository.jpa.experiment.funnel.ExperimentFunnelEventRepository;
+import com.marketinghub.repository.jpa.experiment.funnel.ExperimentFunnelEventRepository.StageAggregation;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.PageRequest;
@@ -97,11 +98,12 @@ public class ExperimentFunnelService {
             String sectionId = payload.get("sectionId");
             String pageUrl = payload.get("pageUrl");
             String userAgent = payload.get("userAgent");
+            String deviceType = normalizeLandingAnalyticsDeviceType(payload.get("deviceType"), userAgent);
             long elapsedMs = parseLong(payload.get("elapsedMs"));
 
             LandingAnalyticsSessionAccumulator session = sessions.computeIfAbsent(
                     sessionId, LandingAnalyticsSessionAccumulator::new);
-            session.record(row.occurredAt(), eventType, sectionId, elapsedMs, pageUrl, userAgent);
+            session.record(row.occurredAt(), eventType, sectionId, elapsedMs, pageUrl, userAgent, deviceType);
 
             if ("page_view".equalsIgnoreCase(eventType)) {
                 pageViews++;
@@ -120,6 +122,7 @@ public class ExperimentFunnelService {
                 .map(LandingAnalyticsSessionAccumulator::toDto)
                 .toList();
         long averageVisibleMsPerSession = sessions.isEmpty() ? 0 : totalVisibleMs / sessions.size();
+        List<ExperimentLandingAnalyticsDeviceDto> deviceBreakdown = buildDeviceBreakdown(sessions);
         return new ExperimentLandingAnalyticsDto(
                 rows.size(),
                 sessions.size(),
@@ -128,6 +131,7 @@ public class ExperimentFunnelService {
                 totalVisibleMs,
                 averageVisibleMsPerSession,
                 lastEventAt,
+                deviceBreakdown,
                 sessionDtos);
     }
 
@@ -279,7 +283,7 @@ public class ExperimentFunnelService {
         Instant occurredAt = Optional.ofNullable(request.occurredAt()).orElse(Instant.now());
         String payload = buildLandingAnalyticsPayload(request, elapsedMs);
 
-        log.info("landing_page_analytics experimentId={} flowSlug={} eventId={} eventType={} sectionId={} elapsedMs={} sessionId={} pageUrl={} occurredAt={} userAgent={}",
+        log.info("landing_page_analytics experimentId={} flowSlug={} eventId={} eventType={} sectionId={} elapsedMs={} sessionId={} pageUrl={} occurredAt={} userAgent={} deviceType={}",
                 experiment.getId(),
                 flowSlug.trim(),
                 request.eventId().trim(),
@@ -289,7 +293,8 @@ public class ExperimentFunnelService {
                 request.sessionId(),
                 request.pageUrl(),
                 occurredAt,
-                request.userAgent());
+                request.userAgent(),
+                normalizeLandingAnalyticsDeviceType(request.deviceType(), request.userAgent()));
 
         ExperimentFunnelStage stage = resolveStageForLandingAnalyticsEvent(eventType);
         if (stage != null) {
@@ -336,6 +341,8 @@ public class ExperimentFunnelService {
         String sessionId = sanitizePayloadValue(request.sessionId());
         String url = sanitizePayloadValue(request.pageUrl());
         String userAgent = sanitizePayloadValue(request.userAgent());
+        String deviceType = sanitizePayloadValue(
+                normalizeLandingAnalyticsDeviceType(request.deviceType(), request.userAgent()));
         String duration = elapsedMs == null ? "" : elapsedMs.toString();
         return "eventId=" + sanitizePayloadValue(request.eventId())
                 + ";eventType=" + sanitizePayloadValue(request.eventType())
@@ -343,7 +350,8 @@ public class ExperimentFunnelService {
                 + ";sectionId=" + sectionId
                 + ";elapsedMs=" + duration
                 + ";pageUrl=" + url
-                + ";userAgent=" + userAgent;
+                + ";userAgent=" + userAgent
+                + ";deviceType=" + deviceType;
     }
 
     private Lead resolveLead(UUID leadId) {
@@ -616,6 +624,70 @@ public class ExperimentFunnelService {
     }
 
     /**
+     * Consolida a distribuição percentual de sessões por tipo de dispositivo.
+     */
+    private List<ExperimentLandingAnalyticsDeviceDto> buildDeviceBreakdown(
+            Map<String, LandingAnalyticsSessionAccumulator> sessions) {
+        long totalSessions = sessions.size();
+        Map<String, Long> counts = new LinkedHashMap<>();
+        counts.put("mobile", 0L);
+        counts.put("desktop", 0L);
+        counts.put("tablet", 0L);
+        sessions.values().forEach(session -> counts.compute(
+                session.deviceType(),
+                (key, count) -> (count == null ? 0 : count) + 1));
+        return counts.entrySet().stream()
+                .filter(entry -> "mobile".equals(entry.getKey())
+                        || "desktop".equals(entry.getKey())
+                        || "tablet".equals(entry.getKey()))
+                .map(entry -> new ExperimentLandingAnalyticsDeviceDto(
+                        entry.getKey(),
+                        landingAnalyticsDeviceLabel(entry.getKey()),
+                        entry.getValue(),
+                        totalSessions == 0 ? 0 : Math.round((entry.getValue() * 10000.0) / totalSessions) / 100.0))
+                .toList();
+    }
+
+    /**
+     * Normaliza o tipo de dispositivo enviado pela landing, usando user-agent como fallback.
+     */
+    private static String normalizeLandingAnalyticsDeviceType(String rawDeviceType, String userAgent) {
+        if (rawDeviceType != null && !rawDeviceType.isBlank()) {
+            String normalized = rawDeviceType.trim().toLowerCase();
+            if ("mobile".equals(normalized) || "tablet".equals(normalized) || "desktop".equals(normalized)) {
+                return normalized;
+            }
+            if ("computador".equals(normalized) || "computer".equals(normalized)) {
+                return "desktop";
+            }
+        }
+        String normalizedUserAgent = userAgent == null ? "" : userAgent.toLowerCase();
+        if (normalizedUserAgent.contains("ipad")
+                || normalizedUserAgent.contains("tablet")
+                || (normalizedUserAgent.contains("android") && !normalizedUserAgent.contains("mobile"))) {
+            return "tablet";
+        }
+        if (normalizedUserAgent.contains("mobi")
+                || normalizedUserAgent.contains("iphone")
+                || normalizedUserAgent.contains("ipod")
+                || normalizedUserAgent.contains("android")) {
+            return "mobile";
+        }
+        return "desktop";
+    }
+
+    /**
+     * Retorna o rótulo do dispositivo exibido no painel de analytics.
+     */
+    private static String landingAnalyticsDeviceLabel(String deviceType) {
+        return switch (normalizeLandingAnalyticsDeviceType(deviceType, null)) {
+            case "mobile" -> "Mobile";
+            case "tablet" -> "Tablet";
+            default -> "Computador";
+        };
+    }
+
+    /**
      * Busca no repositório centralizado os eventos de analytics da landing para o marco temporal atual.
      */
     private List<LandingAnalyticsEventRow> fetchLandingAnalyticsEvents(Long experimentId, Instant baseline) {
@@ -692,6 +764,7 @@ public class ExperimentFunnelService {
         private Instant lastEventAt;
         private String lastPageUrl;
         private String lastUserAgent;
+        private String deviceType = "desktop";
         private final Map<String, SectionAccumulator> sections = new LinkedHashMap<>();
 
         private LandingAnalyticsSessionAccumulator(String sessionId) {
@@ -702,7 +775,7 @@ public class ExperimentFunnelService {
          * Acrescenta um evento recebido na sessão e atualiza contadores de página e seção.
          */
         private void record(Instant occurredAt, String eventType, String sectionId, long elapsedMs,
-                            String pageUrl, String userAgent) {
+                            String pageUrl, String userAgent, String deviceType) {
             eventCount++;
             if (firstEventAt == null || (occurredAt != null && occurredAt.isBefore(firstEventAt))) {
                 firstEventAt = occurredAt;
@@ -716,6 +789,7 @@ public class ExperimentFunnelService {
                     lastUserAgent = userAgent;
                 }
             }
+            this.deviceType = normalizeLandingAnalyticsDeviceType(deviceType, userAgent);
             if ("page_view".equalsIgnoreCase(eventType)) {
                 pageViews++;
             }
@@ -732,6 +806,13 @@ public class ExperimentFunnelService {
          */
         private Instant lastEventAt() {
             return lastEventAt;
+        }
+
+        /**
+         * Retorna o tipo de dispositivo normalizado da sessão para agregação percentual.
+         */
+        private String deviceType() {
+            return deviceType;
         }
 
         /**
@@ -753,6 +834,8 @@ public class ExperimentFunnelService {
                     lastEventAt,
                     lastPageUrl,
                     lastUserAgent,
+                    deviceType,
+                    landingAnalyticsDeviceLabel(deviceType),
                     topSections);
         }
     }

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/funnel/service/analytics/ExperimentLandingAnalyticsDeviceDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/funnel/service/analytics/ExperimentLandingAnalyticsDeviceDto.java
@@ -1,0 +1,11 @@
+package com.marketinghub.experiment.funnel.service.analytics;
+
+/**
+ * Resume a participação de um tipo de dispositivo nos acessos da landing.
+ */
+public record ExperimentLandingAnalyticsDeviceDto(
+        String deviceType,
+        String label,
+        long sessions,
+        double percentage) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/funnel/service/analytics/ExperimentLandingAnalyticsDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/funnel/service/analytics/ExperimentLandingAnalyticsDto.java
@@ -14,5 +14,6 @@ public record ExperimentLandingAnalyticsDto(
         long totalVisibleMs,
         long averageVisibleMsPerSession,
         Instant lastEventAt,
+        List<ExperimentLandingAnalyticsDeviceDto> deviceBreakdown,
         List<ExperimentLandingAnalyticsSessionDto> sessions) {
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/funnel/service/analytics/ExperimentLandingAnalyticsSessionDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/funnel/service/analytics/ExperimentLandingAnalyticsSessionDto.java
@@ -16,5 +16,7 @@ public record ExperimentLandingAnalyticsSessionDto(
         Instant lastEventAt,
         String lastPageUrl,
         String lastUserAgent,
+        String deviceType,
+        String deviceLabel,
         List<ExperimentLandingAnalyticsSectionDto> topSections) {
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/leadportal/dto/RegisterLandingPageAnalyticsEventRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/leadportal/dto/RegisterLandingPageAnalyticsEventRequest.java
@@ -4,6 +4,9 @@ import jakarta.validation.constraints.NotBlank;
 
 import java.time.Instant;
 
+/**
+ * Contrato público para registrar eventos de analytics emitidos pela landing publicada.
+ */
 public record RegisterLandingPageAnalyticsEventRequest(
         @NotBlank String eventId,
         @NotBlank String eventType,
@@ -13,5 +16,6 @@ public record RegisterLandingPageAnalyticsEventRequest(
         Long elapsedMs,
         String pageUrl,
         Instant occurredAt,
-        String userAgent) {
+        String userAgent,
+        String deviceType) {
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/leadportal/web/LeadPortalFlowEngagementController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/leadportal/web/LeadPortalFlowEngagementController.java
@@ -99,8 +99,9 @@ public class LeadPortalFlowEngagementController {
             @RequestBody(required = false) String requestBody) {
         log.info("Lead Portal page-analytics raw recebido no backend. slug={}, rawPayload={}", slug, requestBody);
         RegisterLandingPageAnalyticsEventRequest request = parsePageAnalyticsRequest(slug, requestBody);
-        log.info("Lead Portal page-analytics parseado no backend. slug={}, eventId={}, eventType={}, sectionId={}, sessionId={}, pageUrl={}",
-                slug, request.eventId(), request.eventType(), request.sectionId(), request.sessionId(), request.pageUrl());
+        log.info("Lead Portal page-analytics parseado no backend. slug={}, eventId={}, eventType={}, sectionId={}, sessionId={}, pageUrl={}, deviceType={}",
+                slug, request.eventId(), request.eventType(), request.sectionId(), request.sessionId(), request.pageUrl(),
+                request.deviceType());
         experimentFunnelService.registerLandingPageAnalyticsEvent(slug, request);
         return ResponseEntity.ok(new LeadPortalEngagementAckResponse(
                 LeadPortalSubmissionEngagementContractV1.VERSION,

--- a/backend/ads-service/src/main/java/com/marketinghub/leadportal/web/LeadPortalPublicFlowController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/leadportal/web/LeadPortalPublicFlowController.java
@@ -235,6 +235,14 @@ public class LeadPortalPublicFlowController {
                   const sessionKey = 'mh_lp_session_' + slugValue;
                   const sessionId = sessionStorage.getItem(sessionKey) || (Date.now().toString(36) + '-' + Math.random().toString(36).slice(2));
                   sessionStorage.setItem(sessionKey, sessionId);
+                  const resolveDeviceType = function(){
+                    const userAgent = navigator.userAgent || '';
+                    const isTablet = /ipad|tablet/i.test(userAgent) || (/android/i.test(userAgent) && !/mobile/i.test(userAgent));
+                    if (isTablet) return 'tablet';
+                    const isMobile = /mobi|iphone|ipod|android/i.test(userAgent);
+                    return isMobile ? 'mobile' : 'desktop';
+                  };
+                  const deviceType = resolveDeviceType();
                   const sendEvent = function(eventType, sectionId, elapsedMs){
                     const payload = {
                       eventId: crypto.randomUUID ? crypto.randomUUID() : (Date.now().toString(36) + '-' + Math.random().toString(36).slice(2)),
@@ -245,7 +253,8 @@ public class LeadPortalPublicFlowController {
                       visibleMs: typeof elapsedMs === 'number' ? Math.round(elapsedMs) : null,
                       pageUrl: window.location.href,
                       occurredAt: new Date().toISOString(),
-                      userAgent: navigator.userAgent
+                      userAgent: navigator.userAgent,
+                      deviceType: deviceType
                     };
                     if (navigator.sendBeacon) {
                       navigator.sendBeacon(endpoint, new Blob([JSON.stringify(payload)], {type: 'application/json'}));

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/funnel/ExperimentFunnelServiceRenderCompleteTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/funnel/ExperimentFunnelServiceRenderCompleteTest.java
@@ -1,7 +1,9 @@
 package com.marketinghub.experiment.funnel;
 
-import com.marketinghub.repository.jpa.experiment.funnel.ExperimentFunnelEventRepository;
 import com.marketinghub.experiment.Experiment;
+import com.marketinghub.experiment.funnel.service.analytics.ExperimentLandingAnalyticsDeviceDto;
+import com.marketinghub.repository.jpa.experiment.funnel.ExperimentFunnelEventRepository;
+import com.marketinghub.repository.jpa.experiment.funnel.ExperimentFunnelEventRepository.LandingAnalyticsEventProjection;
 import com.marketinghub.repository.jpa.experiment.ExperimentRepository;
 import com.marketinghub.repository.jpa.core.LeadRepository;
 import com.marketinghub.leadportal.dto.RegisterLandingPageAnalyticsEventRequest;
@@ -23,6 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
@@ -108,7 +111,8 @@ class ExperimentFunnelServiceRenderCompleteTest {
                         null,
                         "https://oportunidadebrasil.shop/api/flows/exp-36-landing-geralanding/page",
                         Instant.parse("2026-06-04T21:00:00Z"),
-                        "JUnit"));
+                        "JUnit",
+                        "desktop"));
 
         ArgumentCaptor<ExperimentFunnelEvent> eventCaptor = ArgumentCaptor.forClass(ExperimentFunnelEvent.class);
         verify(eventRepository).save(eventCaptor.capture());
@@ -141,6 +145,44 @@ class ExperimentFunnelServiceRenderCompleteTest {
         assertEquals(0, summary.totalSessions());
         assertEquals(0, summary.pageViews());
         assertEquals(0, summary.sectionViewEvents());
+        assertEquals(3, summary.deviceBreakdown().size());
+        assertTrue(summary.deviceBreakdown().stream().allMatch(device -> device.percentage() == 0));
+    }
+
+    /**
+     * Valida que o resumo de analytics calcula percentuais de sessões por dispositivo.
+     */
+    @Test
+    void summarizeLandingAnalyticsCalculatesDevicePercentages() {
+        Experiment experiment = Experiment.builder().id(39L).build();
+        when(experimentRepository.findById(39L)).thenReturn(Optional.of(experiment));
+        when(eventRepository.findLandingAnalyticsEvents(
+                eq(39L),
+                eq(ExperimentFunnelEventRepository.LANDING_PAGE_ANALYTICS_SOURCE),
+                eq(null),
+                any(Pageable.class)))
+                .thenReturn(List.of(
+                        landingEvent(1L, "eventId=e1;eventType=page_view;sessionId=s1;deviceType=mobile;userAgent=Mobile",
+                                Instant.parse("2026-06-04T21:00:00Z")),
+                        landingEvent(2L, "eventId=e2;eventType=page_view;sessionId=s2;deviceType=desktop;userAgent=Desktop",
+                                Instant.parse("2026-06-04T21:01:00Z")),
+                        landingEvent(3L, "eventId=e3;eventType=page_view;sessionId=s3;deviceType=tablet;userAgent=iPad",
+                                Instant.parse("2026-06-04T21:02:00Z")),
+                        landingEvent(4L, "eventId=e4;eventType=section_view_time;sessionId=s1;elapsedMs=1500;deviceType=mobile",
+                                Instant.parse("2026-06-04T21:03:00Z"))));
+
+        var summary = service.summarizeLandingAnalytics(39L);
+
+        assertEquals(3, summary.totalSessions());
+        assertEquals(4, summary.totalEvents());
+        assertEquals(33.33, findDevicePercentage(summary.deviceBreakdown(), "mobile"));
+        assertEquals(33.33, findDevicePercentage(summary.deviceBreakdown(), "desktop"));
+        assertEquals(33.33, findDevicePercentage(summary.deviceBreakdown(), "tablet"));
+        assertEquals("Mobile", summary.sessions().stream()
+                .filter(session -> "s1".equals(session.sessionId()))
+                .findFirst()
+                .orElseThrow()
+                .deviceLabel());
     }
 
     /**
@@ -183,4 +225,40 @@ class ExperimentFunnelServiceRenderCompleteTest {
 
         assertEquals("Slug do fluxo é obrigatório", ex.getMessage());
     }
+
+    /**
+     * Cria uma projeção mínima de evento de analytics para testes de consolidação.
+     */
+    private LandingAnalyticsEventProjection landingEvent(Long id, String payload, Instant occurredAt) {
+        return new LandingAnalyticsEventProjection() {
+            @Override
+            public Long getId() {
+                return id;
+            }
+
+            @Override
+            public String getPayload() {
+                return payload;
+            }
+
+            @Override
+            public Instant getOccurredAt() {
+                return occurredAt;
+            }
+        };
+    }
+
+    /**
+     * Localiza o percentual de um dispositivo no resumo retornado pelo serviço.
+     */
+    private double findDevicePercentage(
+            List<ExperimentLandingAnalyticsDeviceDto> devices,
+            String deviceType) {
+        return devices.stream()
+                .filter(device -> deviceType.equals(device.deviceType()))
+                .findFirst()
+                .orElseThrow()
+                .percentage();
+    }
+
 }

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -3937,3 +3937,21 @@
   - AGENTS.md
   - frontend/AGENTS.md
   - docs/registros/experimentos.md
+
+## 2026-06-07 — Percentuais de acesso por dispositivo no analytics da landing
+
+- solicitação: coletar e mostrar na aba Analytics os percentuais de acesso Mobile x Computador x Tablet.
+- causa-raiz/decisão: o endpoint público já recebia user-agent, mas não persistia um tipo de dispositivo normalizado nem retornava uma distribuição percentual própria para a tela.
+- correção aplicada: o script público da landing passou a enviar `deviceType`; o backend normaliza `mobile`, `desktop` e `tablet` com fallback por user-agent, inclui esse dado no payload rastreável e retorna `deviceBreakdown` com sessões e percentual; a aba Analytics passou a exibir cards com barras percentuais por dispositivo.
+- arquivos alterados:
+  - `backend/ads-service/src/main/java/com/marketinghub/leadportal/web/LeadPortalPublicFlowController.java`
+  - `backend/ads-service/src/main/java/com/marketinghub/leadportal/dto/RegisterLandingPageAnalyticsEventRequest.java`
+  - `backend/ads-service/src/main/java/com/marketinghub/leadportal/web/LeadPortalFlowEngagementController.java`
+  - `backend/ads-service/src/main/java/com/marketinghub/experiment/funnel/ExperimentFunnelService.java`
+  - `backend/ads-service/src/main/java/com/marketinghub/experiment/funnel/service/analytics/ExperimentLandingAnalyticsDto.java`
+  - `backend/ads-service/src/main/java/com/marketinghub/experiment/funnel/service/analytics/ExperimentLandingAnalyticsDeviceDto.java`
+  - `backend/ads-service/src/main/java/com/marketinghub/experiment/funnel/service/analytics/ExperimentLandingAnalyticsSessionDto.java`
+  - `frontend/src/api/experiment/useExperimentLandingAnalytics.ts`
+  - `frontend/src/pages/experiment/ExperimentLandingAnalyticsTab.tsx`
+  - `docs/swagger/openapi.yaml`
+  - `docs/swagger/lead-portal-swagger.yaml`

--- a/docs/swagger/lead-portal-swagger.yaml
+++ b/docs/swagger/lead-portal-swagger.yaml
@@ -665,6 +665,13 @@ components:
           type: string
           format: date-time
           nullable: true
+        userAgent:
+          type: string
+          nullable: true
+        deviceType:
+          type: string
+          nullable: true
+          enum: [mobile, desktop, tablet]
     CreateLeadMultipartRequest:
       type: object
       required: [name, email, image]

--- a/docs/swagger/openapi.yaml
+++ b/docs/swagger/openapi.yaml
@@ -1060,6 +1060,10 @@ components:
           type: string
           format: date-time
           nullable: true
+        deviceBreakdown:
+          type: array
+          items:
+            $ref: '#/components/schemas/ExperimentLandingAnalyticsDevice'
         sessions:
           type: array
           items:
@@ -1095,10 +1099,29 @@ components:
         lastUserAgent:
           type: string
           nullable: true
+        deviceType:
+          type: string
+          enum: [mobile, desktop, tablet]
+        deviceLabel:
+          type: string
         topSections:
           type: array
           items:
             $ref: '#/components/schemas/ExperimentLandingAnalyticsSection'
+    ExperimentLandingAnalyticsDevice:
+      type: object
+      properties:
+        deviceType:
+          type: string
+          enum: [mobile, desktop, tablet]
+        label:
+          type: string
+        sessions:
+          type: integer
+          format: int64
+        percentage:
+          type: number
+          format: double
     ExperimentLandingAnalyticsSection:
       type: object
       properties:

--- a/frontend/src/api/experiment/useExperimentLandingAnalytics.ts
+++ b/frontend/src/api/experiment/useExperimentLandingAnalytics.ts
@@ -7,6 +7,13 @@ export interface ExperimentLandingAnalyticsSection {
   events: number;
 }
 
+export interface ExperimentLandingAnalyticsDevice {
+  deviceType: "mobile" | "desktop" | "tablet" | string;
+  label: string;
+  sessions: number;
+  percentage: number;
+}
+
 export interface ExperimentLandingAnalyticsSession {
   sessionId: string;
   eventCount: number;
@@ -17,6 +24,8 @@ export interface ExperimentLandingAnalyticsSession {
   lastEventAt?: string | null;
   lastPageUrl?: string | null;
   lastUserAgent?: string | null;
+  deviceType?: string | null;
+  deviceLabel?: string | null;
   topSections: ExperimentLandingAnalyticsSection[];
 }
 
@@ -28,6 +37,7 @@ export interface ExperimentLandingAnalytics {
   totalVisibleMs: number;
   averageVisibleMsPerSession: number;
   lastEventAt?: string | null;
+  deviceBreakdown: ExperimentLandingAnalyticsDevice[];
   sessions: ExperimentLandingAnalyticsSession[];
 }
 

--- a/frontend/src/pages/experiment/ExperimentLandingAnalyticsTab.tsx
+++ b/frontend/src/pages/experiment/ExperimentLandingAnalyticsTab.tsx
@@ -1,4 +1,14 @@
-import { Activity, Clock, Eye, MousePointer2, Timer, Users } from "lucide-react";
+import {
+  Activity,
+  Clock,
+  Eye,
+  Monitor,
+  MousePointer2,
+  Smartphone,
+  Tablet,
+  Timer,
+  Users,
+} from "lucide-react";
 import { useExperimentLandingAnalytics } from "../../api/experiment/useExperimentLandingAnalytics";
 
 interface ExperimentLandingAnalyticsTabProps {
@@ -38,7 +48,8 @@ function shortUrl(value?: string | null) {
 export default function ExperimentLandingAnalyticsTab({
   experimentId,
 }: ExperimentLandingAnalyticsTabProps) {
-  const { data, isLoading, isError } = useExperimentLandingAnalytics(experimentId);
+  const { data, isLoading, isError } =
+    useExperimentLandingAnalytics(experimentId);
 
   if (isLoading) {
     return (
@@ -59,6 +70,12 @@ export default function ExperimentLandingAnalyticsTab({
   }
 
   const sessions = data?.sessions ?? [];
+  const deviceBreakdown = data?.deviceBreakdown ?? [];
+  const deviceIcons = {
+    mobile: Smartphone,
+    desktop: Monitor,
+    tablet: Tablet,
+  } as const;
   const cards = [
     {
       label: "Sessões",
@@ -94,8 +111,8 @@ export default function ExperimentLandingAnalyticsTab({
             <Activity size={18} /> Analytics de sessões da landing
           </h5>
           <p className="text-muted small mb-0">
-            Dados capturados pelo endpoint público de analytics da landing e salvos em
-            experiment_funnel_event com source landing-page-analytics.
+            Dados capturados pelo endpoint público de analytics da landing e
+            salvos em experiment_funnel_event com source landing-page-analytics.
           </p>
         </div>
         <span className="badge text-bg-light border d-inline-flex align-items-center gap-1">
@@ -127,12 +144,70 @@ export default function ExperimentLandingAnalyticsTab({
         <div className="card-body">
           <div className="d-flex flex-wrap align-items-center justify-content-between gap-2 mb-3">
             <div>
-              <h5 className="card-title mb-1">Sessões recentes</h5>
+              <h5 className="card-title mb-1">Acessos por dispositivo</h5>
               <p className="text-muted small mb-0">
-                Mostra até 50 sessões mais recentes com páginas acessadas e seções mais vistas.
+                Percentual de sessões identificadas como Mobile, Computador ou
+                Tablet.
               </p>
             </div>
-            <span className="badge text-bg-primary">{data?.totalEvents ?? 0} eventos</span>
+            <span className="badge text-bg-light border">
+              {data?.totalSessions ?? 0} sessões
+            </span>
+          </div>
+          <div className="row g-3">
+            {deviceBreakdown.map((device) => {
+              const Icon =
+                deviceIcons[device.deviceType as keyof typeof deviceIcons] ??
+                Monitor;
+              return (
+                <div className="col-12 col-md-4" key={device.deviceType}>
+                  <div className="border rounded-3 p-3 h-100">
+                    <div className="d-flex align-items-center justify-content-between gap-2 mb-2">
+                      <span className="fw-semibold d-inline-flex align-items-center gap-2">
+                        <Icon size={18} className="text-primary" />{" "}
+                        {device.label}
+                      </span>
+                      <strong>{device.percentage.toFixed(1)}%</strong>
+                    </div>
+                    <div
+                      className="progress"
+                      role="progressbar"
+                      aria-label={`Percentual de ${device.label}`}
+                      aria-valuenow={device.percentage}
+                      aria-valuemin={0}
+                      aria-valuemax={100}
+                    >
+                      <div
+                        className="progress-bar"
+                        style={{
+                          width: `${Math.min(100, Math.max(0, device.percentage))}%`,
+                        }}
+                      />
+                    </div>
+                    <div className="text-muted small mt-2">
+                      {device.sessions} sessões
+                    </div>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      </div>
+
+      <div className="card">
+        <div className="card-body">
+          <div className="d-flex flex-wrap align-items-center justify-content-between gap-2 mb-3">
+            <div>
+              <h5 className="card-title mb-1">Sessões recentes</h5>
+              <p className="text-muted small mb-0">
+                Mostra até 50 sessões mais recentes com páginas acessadas e
+                seções mais vistas.
+              </p>
+            </div>
+            <span className="badge text-bg-primary">
+              {data?.totalEvents ?? 0} eventos
+            </span>
           </div>
 
           {sessions.length === 0 ? (
@@ -140,8 +215,8 @@ export default function ExperimentLandingAnalyticsTab({
               <Activity size={32} />
               <h6 className="mb-1">Nenhum analytics capturado ainda</h6>
               <p className="mb-0">
-                Publique a landing do experimento e acesse a URL pública para gerar page_view e
-                tempos por seção.
+                Publique a landing do experimento e acesse a URL pública para
+                gerar page_view e tempos por seção.
               </p>
             </div>
           ) : (
@@ -163,18 +238,32 @@ export default function ExperimentLandingAnalyticsTab({
                     <tr key={session.sessionId}>
                       <td>
                         <code className="small">{session.sessionId}</code>
-                        <div className="text-muted small">{session.eventCount} eventos</div>
+                        <div className="text-muted small">
+                          {session.eventCount} eventos
+                        </div>
+                        <div className="text-muted small">
+                          {session.deviceLabel ?? "Computador"}
+                        </div>
                       </td>
                       <td className="small">
                         <div>{formatDate(session.firstEventAt)}</div>
-                        <div className="text-muted">até {formatDate(session.lastEventAt)}</div>
+                        <div className="text-muted">
+                          até {formatDate(session.lastEventAt)}
+                        </div>
                       </td>
-                      <td className="text-end fw-semibold">{session.pageViews}</td>
-                      <td className="text-end fw-semibold">{session.sectionViewEvents}</td>
+                      <td className="text-end fw-semibold">
+                        {session.pageViews}
+                      </td>
+                      <td className="text-end fw-semibold">
+                        {session.sectionViewEvents}
+                      </td>
                       <td className="text-end fw-semibold">
                         {formatDuration(session.totalVisibleMs)}
                       </td>
-                      <td className="small text-break" title={session.lastPageUrl ?? undefined}>
+                      <td
+                        className="small text-break"
+                        title={session.lastPageUrl ?? undefined}
+                      >
                         {shortUrl(session.lastPageUrl)}
                       </td>
                       <td>
@@ -187,7 +276,8 @@ export default function ExperimentLandingAnalyticsTab({
                                 key={`${session.sessionId}-${section.sectionId}`}
                                 className="badge text-bg-light border text-start"
                               >
-                                {section.sectionId}: {formatDuration(section.visibleMs)}
+                                {section.sectionId}:{" "}
+                                {formatDuration(section.visibleMs)}
                               </span>
                             ))
                           )}


### PR DESCRIPTION
### Motivation
- Provide visibility of traffic composition by device on the Experiment Analytics tab as requested: show percent distribution Mobile x Computador x Tablet. 
- The public landing analytics previously sent `userAgent` only and did not expose a normalized device classification or a distribution useful for the UI. 
- This change collects a normalized `deviceType` at the page, persists it in the analytics payload and returns a device breakdown to the frontend for presentation. 

### Description
- Public landing script now computes a `deviceType` (`mobile|tablet|desktop`) and includes it in the analytics payload sent to the backend (updated `LeadPortalPublicFlowController` JS injection). 
- Backend accepts `deviceType` in `RegisterLandingPageAnalyticsEventRequest`, normalizes it with `normalizeLandingAnalyticsDeviceType(...)` (falling back to `userAgent`), includes `deviceType` in the saved payload and parsing flow, and logs it with incoming events. 
- New DTO `ExperimentLandingAnalyticsDeviceDto` and `deviceBreakdown` were added to the analytics contract (`ExperimentLandingAnalyticsDto`); per-session DTOs now expose `deviceType` and `deviceLabel`; the service computes counts and percentages with `buildDeviceBreakdown(...)`. 
- Frontend types and UI updated: `useExperimentLandingAnalytics` adds `deviceBreakdown` typing and `ExperimentLandingAnalyticsTab` renders a new “Acessos por dispositivo” card group with percentage bars and shows device label per recent session; Swagger (`docs/swagger/*`) and experiment registry updated; unit test added to cover the device-percentage aggregation. 

### Testing
- Ran the backend unit tests targeting the analytics flow with `mvn -Dtest=ExperimentFunnelServiceRenderCompleteTest,LeadPortalFlowEngagementControllerTest test` and they passed (tests run: 11, failures: 0). 
- Ran frontend checks and build: `npm ci`, `npm run typecheck` and `npm run build` (Vite) succeeded (typecheck/install/build completed). 
- End-to-end verification: exercised the public script parsing path in controller tests and added a unit test `summarizeLandingAnalyticsCalculatesDevicePercentages` covering mobile/desktop/tablet distribution which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a24e54979f0832187ab0de3f5d3a2d7)