### PR TITLE
feat(ads-service): add landing analytics visitor schema

### DIFF
--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-07-experiment-landing-analytics-event.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-07-experiment-landing-analytics-event.yaml
@@ -1,0 +1,45 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-06-07-experiment-landing-analytics-event
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - onError: HALT
+        - dbms:
+            type: mysql
+        - not:
+            tableExists:
+              tableName: experiment_landing_analytics_event
+      changes:
+        - sql:
+            splitStatements: true
+            stripComments: true
+            sql: |
+              CREATE TABLE experiment_landing_analytics_event (
+                id BIGINT AUTO_INCREMENT NOT NULL,
+                experiment_id BIGINT NOT NULL,
+                funnel_event_id BIGINT NOT NULL,
+                event_id VARCHAR(128) NULL,
+                visitor_id VARCHAR(128) NULL,
+                session_id VARCHAR(128) NULL,
+                event_type VARCHAR(64) NOT NULL,
+                section_id VARCHAR(190) NULL,
+                page_url VARCHAR(2048) NULL,
+                user_agent VARCHAR(512) NULL,
+                occurred_at DATETIME(6) NOT NULL,
+                created_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+                CONSTRAINT pk_experiment_landing_analytics_event PRIMARY KEY (id),
+                CONSTRAINT fk_landing_analytics_event_experiment FOREIGN KEY (experiment_id) REFERENCES experiment(id),
+                CONSTRAINT fk_landing_analytics_event_funnel_event FOREIGN KEY (funnel_event_id) REFERENCES experiment_funnel_event(id),
+                CONSTRAINT uk_landing_analytics_event_funnel_event UNIQUE (funnel_event_id),
+                CONSTRAINT uk_landing_analytics_event_event_id UNIQUE (experiment_id, event_id)
+              );
+
+              CREATE INDEX idx_landing_analytics_experiment_visitor_occurred
+                ON experiment_landing_analytics_event (experiment_id, visitor_id, occurred_at);
+
+              CREATE INDEX idx_landing_analytics_experiment_session_occurred
+                ON experiment_landing_analytics_event (experiment_id, session_id, occurred_at);
+
+              CREATE INDEX idx_landing_analytics_experiment_type_occurred
+                ON experiment_landing_analytics_event (experiment_id, event_type, occurred_at);

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -263,6 +263,9 @@ databaseChangeLog:
       file: changesets/2025-10-30-experiment-funnel-events.yaml
       relativeToChangelogFile: true
   - include:
+      file: changesets/2026-06-07-experiment-landing-analytics-event.yaml
+      relativeToChangelogFile: true
+  - include:
       file: changesets/2025-11-05-hypothesis-framework-json.yaml
       relativeToChangelogFile: true
   - include:

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -4004,3 +4004,12 @@
 
 - Formalizado no cânone do procedimento de experimento o contrato público de analytics da landing com `visitorId`, `sessionId`, eventos, deduplicação de `page_view` em 3 segundos e compatibilidade com eventos legados sem `visitorId`.
 - Reforçada a regra de que `visitorId` identifica apenas visitante provável por navegador/dispositivo, sem comprovar pessoa real.
+
+## 2026-06-07 00:00:00 UTC
+- solicitação: executar a etapa 2 do plano `docs/implementação/plano-identificacao-visitante-landing-experimento.md` para preparar o modelo de banco dos analytics de visitante recorrente na landing do experimento.
+- decisão técnica: criada tabela derivada `experiment_landing_analytics_event`, vinculada por `funnel_event_id` ao evento bruto em `experiment_funnel_event`, em vez de adicionar colunas normalizadas diretamente na tabela legada; essa escolha preserva compatibilidade com eventos existentes, mantém a auditoria bruta intacta e permite consultas relacionais eficientes para recorrência por `visitorId`/`sessionId`.
+- foi feito:
+  - criado changelog Liquibase YAML MySQL 5.7 com `databaseChangeLog`, `preConditions` de `dbms:mysql`, `splitStatements: true` e `stripComments: true`;
+  - adicionados campos normalizados para `experiment_id`, `funnel_event_id`, `event_id`, `visitor_id`, `session_id`, `event_type`, `section_id`, `page_url`, `user_agent`, `occurred_at` e `created_at`;
+  - adicionados índices `(experiment_id, visitor_id, occurred_at)`, `(experiment_id, session_id, occurred_at)` e `(experiment_id, event_type, occurred_at)` para sustentar a etapa futura de API de recorrência.
+- impacto esperado: a etapa 3 poderá manter a gravação legada em `experiment_funnel_event` e gravar a estrutura normalizada sem quebrar analytics históricos sem `visitorId`.


### PR DESCRIPTION
### Motivation
- Provide a relational model to identify probable recurring visitors on experiment landings without changing legacy `experiment_funnel_event`, enabling reliable recurrence queries by `visitorId`/`sessionId`.
- Ensure queries for recurrence are efficient by adding targeted indexes and preserving raw event auditability.

### Description
- Added a MySQL 5.7 compatible Liquibase changelog `backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-07-experiment-landing-analytics-event.yaml` that creates `experiment_landing_analytics_event` with normalized fields (`experiment_id`, `funnel_event_id`, `event_id`, `visitor_id`, `session_id`, `event_type`, `section_id`, `page_url`, `user_agent`, `occurred_at`, `created_at`) plus FKs and uniqueness constraints.
- Created indexes `(experiment_id, visitor_id, occurred_at)`, `(experiment_id, session_id, occurred_at)` and `(experiment_id, event_type, occurred_at)` to support recurrence/API queries.
- Registered the new changeset in the Liquibase master `backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml` and recorded the implementation decision in `docs/registros/experimentos.md`.

### Testing
- Verified YAML validity with `ruby -e "require 'yaml'..."` which reported OK for both the new changelog and the master include.
- Built the module with `mvn -q -DskipTests compile` and the build completed successfully.
- Ran the backend test suite with `mvn -q test` and the test run executed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a24f8be1c108321ae7b5e2b3ef71f21)