### PR TITLE
Add mobile OS and screen-size analytics to experiment landing reports

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/funnel/ExperimentFunnelService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/funnel/ExperimentFunnelService.java
@@ -5,6 +5,8 @@ import com.marketinghub.experiment.funnel.dto.ExperimentFunnelStageDto;
 import com.marketinghub.experiment.funnel.dto.RegisterExperimentFunnelEventRequest;
 import com.marketinghub.experiment.funnel.service.analytics.ExperimentLandingAnalyticsDeviceDto;
 import com.marketinghub.experiment.funnel.service.analytics.ExperimentLandingAnalyticsDto;
+import com.marketinghub.experiment.funnel.service.analytics.ExperimentLandingAnalyticsOperatingSystemDto;
+import com.marketinghub.experiment.funnel.service.analytics.ExperimentLandingAnalyticsScreenSizeDto;
 import com.marketinghub.experiment.funnel.service.analytics.ExperimentLandingAnalyticsSectionDto;
 import com.marketinghub.experiment.funnel.service.analytics.ExperimentLandingAnalyticsSessionDto;
 import com.marketinghub.leadportal.dto.LeadPortalSubmissionEngagementContractV1;
@@ -99,11 +101,15 @@ public class ExperimentFunnelService {
             String pageUrl = payload.get("pageUrl");
             String userAgent = payload.get("userAgent");
             String deviceType = normalizeLandingAnalyticsDeviceType(payload.get("deviceType"), userAgent);
+            String operatingSystem = normalizeLandingAnalyticsOperatingSystem(payload.get("operatingSystem"), userAgent);
+            Integer screenWidth = parsePositiveInteger(payload.get("screenWidth"));
+            Integer screenHeight = parsePositiveInteger(payload.get("screenHeight"));
             long elapsedMs = parseLong(payload.get("elapsedMs"));
 
             LandingAnalyticsSessionAccumulator session = sessions.computeIfAbsent(
                     sessionId, LandingAnalyticsSessionAccumulator::new);
-            session.record(row.occurredAt(), eventType, sectionId, elapsedMs, pageUrl, userAgent, deviceType);
+            session.record(row.occurredAt(), eventType, sectionId, elapsedMs, pageUrl, userAgent, deviceType,
+                    operatingSystem, screenWidth, screenHeight);
 
             if ("page_view".equalsIgnoreCase(eventType)) {
                 pageViews++;
@@ -123,6 +129,9 @@ public class ExperimentFunnelService {
                 .toList();
         long averageVisibleMsPerSession = sessions.isEmpty() ? 0 : totalVisibleMs / sessions.size();
         List<ExperimentLandingAnalyticsDeviceDto> deviceBreakdown = buildDeviceBreakdown(sessions);
+        List<ExperimentLandingAnalyticsOperatingSystemDto> mobileOperatingSystemBreakdown =
+                buildMobileOperatingSystemBreakdown(sessions);
+        List<ExperimentLandingAnalyticsScreenSizeDto> screenSizeBreakdown = buildScreenSizeBreakdown(sessions);
         return new ExperimentLandingAnalyticsDto(
                 rows.size(),
                 sessions.size(),
@@ -132,6 +141,8 @@ public class ExperimentFunnelService {
                 averageVisibleMsPerSession,
                 lastEventAt,
                 deviceBreakdown,
+                mobileOperatingSystemBreakdown,
+                screenSizeBreakdown,
                 sessionDtos);
     }
 
@@ -343,6 +354,10 @@ public class ExperimentFunnelService {
         String userAgent = sanitizePayloadValue(request.userAgent());
         String deviceType = sanitizePayloadValue(
                 normalizeLandingAnalyticsDeviceType(request.deviceType(), request.userAgent()));
+        String operatingSystem = sanitizePayloadValue(
+                normalizeLandingAnalyticsOperatingSystem(request.operatingSystem(), request.userAgent()));
+        String screenWidth = request.screenWidth() == null ? "" : request.screenWidth().toString();
+        String screenHeight = request.screenHeight() == null ? "" : request.screenHeight().toString();
         String duration = elapsedMs == null ? "" : elapsedMs.toString();
         return "eventId=" + sanitizePayloadValue(request.eventId())
                 + ";eventType=" + sanitizePayloadValue(request.eventType())
@@ -351,7 +366,10 @@ public class ExperimentFunnelService {
                 + ";elapsedMs=" + duration
                 + ";pageUrl=" + url
                 + ";userAgent=" + userAgent
-                + ";deviceType=" + deviceType;
+                + ";deviceType=" + deviceType
+                + ";operatingSystem=" + operatingSystem
+                + ";screenWidth=" + sanitizePayloadValue(screenWidth)
+                + ";screenHeight=" + sanitizePayloadValue(screenHeight);
     }
 
     private Lead resolveLead(UUID leadId) {
@@ -649,6 +667,60 @@ public class ExperimentFunnelService {
     }
 
     /**
+     * Consolida a distribuição percentual de sessões mobile por sistema operacional.
+     */
+    private List<ExperimentLandingAnalyticsOperatingSystemDto> buildMobileOperatingSystemBreakdown(
+            Map<String, LandingAnalyticsSessionAccumulator> sessions) {
+        Map<String, Long> counts = new LinkedHashMap<>();
+        counts.put("ios", 0L);
+        counts.put("android", 0L);
+        counts.put("other", 0L);
+        sessions.values().stream()
+                .filter(session -> "mobile".equals(session.deviceType()))
+                .forEach(session -> counts.compute(
+                        session.operatingSystem(),
+                        (key, count) -> (count == null ? 0 : count) + 1));
+        long mobileSessions = counts.values().stream().mapToLong(Long::longValue).sum();
+        return counts.entrySet().stream()
+                .map(entry -> new ExperimentLandingAnalyticsOperatingSystemDto(
+                        entry.getKey(),
+                        landingAnalyticsOperatingSystemLabel(entry.getKey()),
+                        entry.getValue(),
+                        mobileSessions == 0 ? 0 : Math.round((entry.getValue() * 10000.0) / mobileSessions) / 100.0))
+                .toList();
+    }
+
+    /**
+     * Consolida a distribuição percentual das principais resoluções de tela por sessão.
+     */
+    private List<ExperimentLandingAnalyticsScreenSizeDto> buildScreenSizeBreakdown(
+            Map<String, LandingAnalyticsSessionAccumulator> sessions) {
+        long totalSessionsWithScreen = sessions.values().stream()
+                .filter(LandingAnalyticsSessionAccumulator::hasScreenSize)
+                .count();
+        Map<String, ScreenSizeAccumulator> counts = new LinkedHashMap<>();
+        sessions.values().stream()
+                .filter(LandingAnalyticsSessionAccumulator::hasScreenSize)
+                .forEach(session -> counts.computeIfAbsent(
+                        session.screenSizeKey(),
+                        key -> new ScreenSizeAccumulator(session.screenWidth(), session.screenHeight()))
+                        .record());
+        return counts.values().stream()
+                .sorted(Comparator.comparingLong(ScreenSizeAccumulator::sessions).reversed())
+                .limit(8)
+                .map(screen -> new ExperimentLandingAnalyticsScreenSizeDto(
+                        screen.key(),
+                        screen.label(),
+                        screen.width(),
+                        screen.height(),
+                        screen.sessions(),
+                        totalSessionsWithScreen == 0
+                                ? 0
+                                : Math.round((screen.sessions() * 10000.0) / totalSessionsWithScreen) / 100.0))
+                .toList();
+    }
+
+    /**
      * Normaliza o tipo de dispositivo enviado pela landing, usando user-agent como fallback.
      */
     private static String normalizeLandingAnalyticsDeviceType(String rawDeviceType, String userAgent) {
@@ -674,6 +746,41 @@ public class ExperimentFunnelService {
             return "mobile";
         }
         return "desktop";
+    }
+
+    /**
+     * Normaliza o sistema operacional mobile enviado pela landing, usando user-agent como fallback.
+     */
+    private static String normalizeLandingAnalyticsOperatingSystem(String rawOperatingSystem, String userAgent) {
+        if (rawOperatingSystem != null && !rawOperatingSystem.isBlank()) {
+            String normalized = rawOperatingSystem.trim().toLowerCase();
+            if ("ios".equals(normalized) || "iphone".equals(normalized) || "ipad".equals(normalized)) {
+                return "ios";
+            }
+            if ("android".equals(normalized)) {
+                return "android";
+            }
+        }
+        String normalizedUserAgent = userAgent == null ? "" : userAgent.toLowerCase();
+        if (normalizedUserAgent.contains("iphone") || normalizedUserAgent.contains("ipod")
+                || normalizedUserAgent.contains("ipad")) {
+            return "ios";
+        }
+        if (normalizedUserAgent.contains("android")) {
+            return "android";
+        }
+        return "other";
+    }
+
+    /**
+     * Retorna o rótulo do sistema operacional mobile exibido no painel de analytics.
+     */
+    private static String landingAnalyticsOperatingSystemLabel(String operatingSystem) {
+        return switch (normalizeLandingAnalyticsOperatingSystem(operatingSystem, null)) {
+            case "ios" -> "iOS";
+            case "android" -> "Android";
+            default -> "Outros";
+        };
     }
 
     /**
@@ -746,6 +853,22 @@ public class ExperimentFunnelService {
     }
 
     /**
+     * Converte números textuais positivos de tela para Integer, retornando null quando ausentes ou inválidos.
+     */
+    private Integer parsePositiveInteger(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        try {
+            int parsed = Integer.parseInt(value.trim());
+            return parsed > 0 ? parsed : null;
+        } catch (NumberFormatException ex) {
+            log.warn("Landing analytics dimensão de tela inválida. valor={}", value, ex);
+            return null;
+        }
+    }
+
+    /**
      * Linha mínima de evento de analytics retornada da tabela de eventos do funil.
      */
     private record LandingAnalyticsEventRow(long id, String payload, Instant occurredAt) {
@@ -765,6 +888,9 @@ public class ExperimentFunnelService {
         private String lastPageUrl;
         private String lastUserAgent;
         private String deviceType = "desktop";
+        private String operatingSystem = "other";
+        private Integer screenWidth;
+        private Integer screenHeight;
         private final Map<String, SectionAccumulator> sections = new LinkedHashMap<>();
 
         private LandingAnalyticsSessionAccumulator(String sessionId) {
@@ -775,7 +901,8 @@ public class ExperimentFunnelService {
          * Acrescenta um evento recebido na sessão e atualiza contadores de página e seção.
          */
         private void record(Instant occurredAt, String eventType, String sectionId, long elapsedMs,
-                            String pageUrl, String userAgent, String deviceType) {
+                            String pageUrl, String userAgent, String deviceType, String operatingSystem,
+                            Integer screenWidth, Integer screenHeight) {
             eventCount++;
             if (firstEventAt == null || (occurredAt != null && occurredAt.isBefore(firstEventAt))) {
                 firstEventAt = occurredAt;
@@ -790,6 +917,11 @@ public class ExperimentFunnelService {
                 }
             }
             this.deviceType = normalizeLandingAnalyticsDeviceType(deviceType, userAgent);
+            this.operatingSystem = normalizeLandingAnalyticsOperatingSystem(operatingSystem, userAgent);
+            if (screenWidth != null && screenHeight != null) {
+                this.screenWidth = screenWidth;
+                this.screenHeight = screenHeight;
+            }
             if ("page_view".equalsIgnoreCase(eventType)) {
                 pageViews++;
             }
@@ -816,6 +948,48 @@ public class ExperimentFunnelService {
         }
 
         /**
+         * Retorna o sistema operacional mobile normalizado da sessão para agregação percentual.
+         */
+        private String operatingSystem() {
+            return operatingSystem;
+        }
+
+        /**
+         * Informa se a sessão tem dimensões de tela válidas capturadas pelo script público.
+         */
+        private boolean hasScreenSize() {
+            return screenWidth != null && screenHeight != null;
+        }
+
+        /**
+         * Retorna a largura de tela da sessão para agregação de resoluções.
+         */
+        private Integer screenWidth() {
+            return screenWidth;
+        }
+
+        /**
+         * Retorna a altura de tela da sessão para agregação de resoluções.
+         */
+        private Integer screenHeight() {
+            return screenHeight;
+        }
+
+        /**
+         * Retorna a chave textual de resolução da sessão.
+         */
+        private String screenSizeKey() {
+            return screenWidth + "x" + screenHeight;
+        }
+
+        /**
+         * Retorna o rótulo textual da resolução da sessão.
+         */
+        private String screenSizeLabel() {
+            return hasScreenSize() ? screenSizeKey() + " px" : null;
+        }
+
+        /**
          * Converte o acumulador interno em DTO serializável pela API.
          */
         private ExperimentLandingAnalyticsSessionDto toDto() {
@@ -836,7 +1010,68 @@ public class ExperimentFunnelService {
                     lastUserAgent,
                     deviceType,
                     landingAnalyticsDeviceLabel(deviceType),
+                    operatingSystem,
+                    landingAnalyticsOperatingSystemLabel(operatingSystem),
+                    screenWidth,
+                    screenHeight,
+                    screenSizeLabel(),
                     topSections);
+        }
+    }
+
+    /**
+     * Acumula sessões por resolução de tela capturada na landing.
+     */
+    private static final class ScreenSizeAccumulator {
+        private final Integer width;
+        private final Integer height;
+        private long sessions;
+
+        private ScreenSizeAccumulator(Integer width, Integer height) {
+            this.width = width;
+            this.height = height;
+        }
+
+        /**
+         * Soma uma sessão à resolução de tela.
+         */
+        private void record() {
+            sessions++;
+        }
+
+        /**
+         * Retorna a chave canônica da resolução para a API.
+         */
+        private String key() {
+            return width + "x" + height;
+        }
+
+        /**
+         * Retorna o rótulo amigável da resolução para a UI.
+         */
+        private String label() {
+            return key() + " px";
+        }
+
+        /**
+         * Retorna a largura da tela em pixels CSS.
+         */
+        private Integer width() {
+            return width;
+        }
+
+        /**
+         * Retorna a altura da tela em pixels CSS.
+         */
+        private Integer height() {
+            return height;
+        }
+
+        /**
+         * Retorna a quantidade de sessões nesta resolução.
+         */
+        private long sessions() {
+            return sessions;
         }
     }
 

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/funnel/service/analytics/ExperimentLandingAnalyticsDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/funnel/service/analytics/ExperimentLandingAnalyticsDto.java
@@ -15,5 +15,7 @@ public record ExperimentLandingAnalyticsDto(
         long averageVisibleMsPerSession,
         Instant lastEventAt,
         List<ExperimentLandingAnalyticsDeviceDto> deviceBreakdown,
+        List<ExperimentLandingAnalyticsOperatingSystemDto> mobileOperatingSystemBreakdown,
+        List<ExperimentLandingAnalyticsScreenSizeDto> screenSizeBreakdown,
         List<ExperimentLandingAnalyticsSessionDto> sessions) {
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/funnel/service/analytics/ExperimentLandingAnalyticsOperatingSystemDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/funnel/service/analytics/ExperimentLandingAnalyticsOperatingSystemDto.java
@@ -1,0 +1,11 @@
+package com.marketinghub.experiment.funnel.service.analytics;
+
+/**
+ * Resume a participação de um sistema operacional mobile nas sessões da landing.
+ */
+public record ExperimentLandingAnalyticsOperatingSystemDto(
+        String operatingSystem,
+        String label,
+        long sessions,
+        double percentage) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/funnel/service/analytics/ExperimentLandingAnalyticsScreenSizeDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/funnel/service/analytics/ExperimentLandingAnalyticsScreenSizeDto.java
@@ -1,0 +1,13 @@
+package com.marketinghub.experiment.funnel.service.analytics;
+
+/**
+ * Resume a participação de uma resolução de tela nas sessões da landing.
+ */
+public record ExperimentLandingAnalyticsScreenSizeDto(
+        String screenSize,
+        String label,
+        Integer width,
+        Integer height,
+        long sessions,
+        double percentage) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/funnel/service/analytics/ExperimentLandingAnalyticsSessionDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/funnel/service/analytics/ExperimentLandingAnalyticsSessionDto.java
@@ -18,5 +18,10 @@ public record ExperimentLandingAnalyticsSessionDto(
         String lastUserAgent,
         String deviceType,
         String deviceLabel,
+        String operatingSystem,
+        String operatingSystemLabel,
+        Integer screenWidth,
+        Integer screenHeight,
+        String screenSizeLabel,
         List<ExperimentLandingAnalyticsSectionDto> topSections) {
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/leadportal/dto/RegisterLandingPageAnalyticsEventRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/leadportal/dto/RegisterLandingPageAnalyticsEventRequest.java
@@ -17,5 +17,8 @@ public record RegisterLandingPageAnalyticsEventRequest(
         String pageUrl,
         Instant occurredAt,
         String userAgent,
-        String deviceType) {
+        String deviceType,
+        String operatingSystem,
+        Integer screenWidth,
+        Integer screenHeight) {
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/leadportal/web/LeadPortalPublicFlowController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/leadportal/web/LeadPortalPublicFlowController.java
@@ -26,16 +26,25 @@ public class LeadPortalPublicFlowController {
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
     private final LeadPortalFlowService flowService;
 
+    /**
+     * Inicializa o controller público com o serviço de fluxos aprovados.
+     */
     public LeadPortalPublicFlowController(LeadPortalFlowService flowService) {
         this.flowService = flowService;
     }
 
+    /**
+     * Retorna o contrato público de publicação do fluxo aprovado pelo slug.
+     */
     @GetMapping("/{slug}")
     public LeadPortalFlowPublicationRequest getBySlug(@PathVariable String slug) {
         LeadPortalFlow flow = flowService.getApprovedBySlug(slug);
         return LeadPortalFlowPublicationRequest.from(flow);
     }
 
+    /**
+     * Entrega a landing standalone aprovada já instrumentada com analytics público.
+     */
     @GetMapping(value = "/{slug}/page", produces = MediaType.TEXT_HTML_VALUE)
     public ResponseEntity<String> getLandingPageBySlug(@PathVariable String slug) {
         LeadPortalFlow flow = flowService.getApprovedBySlug(slug);
@@ -45,6 +54,9 @@ public class LeadPortalPublicFlowController {
                 .body(htmlDocument);
     }
 
+    /**
+     * Extrai o documento HTML final de fontes salvas como HTML direto, JSON ou híbrido.
+     */
     private String extractHtmlDocument(String sourceHtml) {
         if (!StringUtils.hasText(sourceHtml)) {
             return "";
@@ -67,6 +79,9 @@ public class LeadPortalPublicFlowController {
         return sourceHtml;
     }
 
+    /**
+     * Tenta localizar um documento HTML completo dentro de uma string textual.
+     */
     private String tryExtractInlineHtmlDocument(String value) {
         if (!StringUtils.hasText(value)) {
             return null;
@@ -83,6 +98,9 @@ public class LeadPortalPublicFlowController {
         return null;
     }
 
+    /**
+     * Verifica se o conteúdo tem formato provável de payload JSON.
+     */
     private boolean looksLikeJsonPayload(String value) {
         if (!StringUtils.hasText(value)) {
             return false;
@@ -91,6 +109,9 @@ public class LeadPortalPublicFlowController {
         return firstChar == '{' || firstChar == '[';
     }
 
+    /**
+     * Tenta extrair HTML de um conteúdo híbrido que contém JSON serializado.
+     */
     private String tryExtractFromHybridHtml(String html) {
         if (!StringUtils.hasText(html)) {
             return null;
@@ -109,11 +130,17 @@ public class LeadPortalPublicFlowController {
         return null;
     }
 
+    /**
+     * Verifica se um candidato textual contém indícios de HTML de landing.
+     */
     private boolean containsLandingPageSignature(String candidate) {
         String lowered = candidate.toLowerCase();
         return lowered.contains("landingpagehtml") || lowered.contains("htmldocument");
     }
 
+    /**
+     * Extrai um bloco JSON balanceado a partir do índice informado.
+     */
     private String extractJsonCandidate(String source, int startIndex) {
         if (startIndex < 0 || startIndex >= source.length() || source.charAt(startIndex) != '{') {
             return null;
@@ -147,6 +174,9 @@ public class LeadPortalPublicFlowController {
         return null;
     }
 
+    /**
+     * Tenta extrair o HTML final de campos conhecidos dentro de um payload JSON.
+     */
     private String tryExtractFromJsonPayload(String payload) {
         if (!StringUtils.hasText(payload)) {
             return null;
@@ -163,6 +193,9 @@ public class LeadPortalPublicFlowController {
         return null;
     }
 
+    /**
+     * Percorre um nó JSON em busca do primeiro documento HTML publicável.
+     */
     private String extractHtmlDocumentFromNode(JsonNode node) throws java.io.IOException {
         if (node == null || node.isNull()) {
             return null;
@@ -216,10 +249,16 @@ public class LeadPortalPublicFlowController {
         return null;
     }
 
+    /**
+     * Extrai o HTML a partir do nó específico de landingPageHtml.
+     */
     private String extractFromLandingPageNode(JsonNode landingPageHtmlNode) throws java.io.IOException {
         return extractHtmlDocumentFromNode(landingPageHtmlNode);
     }
 
+    /**
+     * Injeta o script público que mede sessão, dispositivo, sistema operacional e tamanho de tela.
+     */
     private String injectLandingAnalyticsScript(String slug, String htmlDocument) {
         if (!StringUtils.hasText(htmlDocument)) {
             return htmlDocument;
@@ -242,7 +281,22 @@ public class LeadPortalPublicFlowController {
                     const isMobile = /mobi|iphone|ipod|android/i.test(userAgent);
                     return isMobile ? 'mobile' : 'desktop';
                   };
+                  const resolveOperatingSystem = function(){
+                    const userAgent = navigator.userAgent || '';
+                    if (/iphone|ipad|ipod/i.test(userAgent)) return 'ios';
+                    if (/android/i.test(userAgent)) return 'android';
+                    return 'other';
+                  };
+                  const resolveScreenSize = function(){
+                    const width = window.innerWidth || document.documentElement.clientWidth || screen.width || null;
+                    const height = window.innerHeight || document.documentElement.clientHeight || screen.height || null;
+                    return {
+                      width: typeof width === 'number' ? Math.round(width) : null,
+                      height: typeof height === 'number' ? Math.round(height) : null
+                    };
+                  };
                   const deviceType = resolveDeviceType();
+                  const operatingSystem = resolveOperatingSystem();
                   const sendEvent = function(eventType, sectionId, elapsedMs){
                     const payload = {
                       eventId: crypto.randomUUID ? crypto.randomUUID() : (Date.now().toString(36) + '-' + Math.random().toString(36).slice(2)),
@@ -254,7 +308,10 @@ public class LeadPortalPublicFlowController {
                       pageUrl: window.location.href,
                       occurredAt: new Date().toISOString(),
                       userAgent: navigator.userAgent,
-                      deviceType: deviceType
+                      deviceType: deviceType,
+                      operatingSystem: operatingSystem,
+                      screenWidth: resolveScreenSize().width,
+                      screenHeight: resolveScreenSize().height
                     };
                     if (navigator.sendBeacon) {
                       navigator.sendBeacon(endpoint, new Blob([JSON.stringify(payload)], {type: 'application/json'}));
@@ -292,6 +349,9 @@ public class LeadPortalPublicFlowController {
         return htmlDocument + "\n" + analyticsScript;
     }
 
+    /**
+     * Escapa um valor Java para uso seguro como literal de string JavaScript.
+     */
     private String toJsStringLiteral(String rawValue) {
         String safeValue = rawValue == null ? "" : rawValue;
         return "\"" + safeValue
@@ -299,6 +359,9 @@ public class LeadPortalPublicFlowController {
                 .replace("\"", "\\\"") + "\"";
     }
 
+    /**
+     * Verifica presença textual ignorando caixa e valores ausentes.
+     */
     private boolean containsIgnoreCase(String source, String token) {
         return source.toLowerCase(Locale.ROOT).contains(token.toLowerCase(Locale.ROOT));
     }

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/funnel/ExperimentFunnelServiceRenderCompleteTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/funnel/ExperimentFunnelServiceRenderCompleteTest.java
@@ -112,7 +112,10 @@ class ExperimentFunnelServiceRenderCompleteTest {
                         "https://oportunidadebrasil.shop/api/flows/exp-36-landing-geralanding/page",
                         Instant.parse("2026-06-04T21:00:00Z"),
                         "JUnit",
-                        "desktop"));
+                        "desktop",
+                        "other",
+                        1366,
+                        768));
 
         ArgumentCaptor<ExperimentFunnelEvent> eventCaptor = ArgumentCaptor.forClass(ExperimentFunnelEvent.class);
         verify(eventRepository).save(eventCaptor.capture());
@@ -147,6 +150,9 @@ class ExperimentFunnelServiceRenderCompleteTest {
         assertEquals(0, summary.sectionViewEvents());
         assertEquals(3, summary.deviceBreakdown().size());
         assertTrue(summary.deviceBreakdown().stream().allMatch(device -> device.percentage() == 0));
+        assertEquals(3, summary.mobileOperatingSystemBreakdown().size());
+        assertTrue(summary.mobileOperatingSystemBreakdown().stream().allMatch(os -> os.percentage() == 0));
+        assertTrue(summary.screenSizeBreakdown().isEmpty());
     }
 
     /**
@@ -162,13 +168,13 @@ class ExperimentFunnelServiceRenderCompleteTest {
                 eq(null),
                 any(Pageable.class)))
                 .thenReturn(List.of(
-                        landingEvent(1L, "eventId=e1;eventType=page_view;sessionId=s1;deviceType=mobile;userAgent=Mobile",
+                        landingEvent(1L, "eventId=e1;eventType=page_view;sessionId=s1;deviceType=mobile;operatingSystem=ios;screenWidth=390;screenHeight=844;userAgent=iPhone",
                                 Instant.parse("2026-06-04T21:00:00Z")),
-                        landingEvent(2L, "eventId=e2;eventType=page_view;sessionId=s2;deviceType=desktop;userAgent=Desktop",
+                        landingEvent(2L, "eventId=e2;eventType=page_view;sessionId=s2;deviceType=desktop;operatingSystem=other;screenWidth=1366;screenHeight=768;userAgent=Desktop",
                                 Instant.parse("2026-06-04T21:01:00Z")),
-                        landingEvent(3L, "eventId=e3;eventType=page_view;sessionId=s3;deviceType=tablet;userAgent=iPad",
+                        landingEvent(3L, "eventId=e3;eventType=page_view;sessionId=s3;deviceType=tablet;operatingSystem=ios;screenWidth=820;screenHeight=1180;userAgent=iPad",
                                 Instant.parse("2026-06-04T21:02:00Z")),
-                        landingEvent(4L, "eventId=e4;eventType=section_view_time;sessionId=s1;elapsedMs=1500;deviceType=mobile",
+                        landingEvent(4L, "eventId=e4;eventType=section_view_time;sessionId=s1;elapsedMs=1500;deviceType=mobile;operatingSystem=ios;screenWidth=390;screenHeight=844",
                                 Instant.parse("2026-06-04T21:03:00Z"))));
 
         var summary = service.summarizeLandingAnalytics(39L);
@@ -178,11 +184,15 @@ class ExperimentFunnelServiceRenderCompleteTest {
         assertEquals(33.33, findDevicePercentage(summary.deviceBreakdown(), "mobile"));
         assertEquals(33.33, findDevicePercentage(summary.deviceBreakdown(), "desktop"));
         assertEquals(33.33, findDevicePercentage(summary.deviceBreakdown(), "tablet"));
-        assertEquals("Mobile", summary.sessions().stream()
+        var mobileSession = summary.sessions().stream()
                 .filter(session -> "s1".equals(session.sessionId()))
                 .findFirst()
-                .orElseThrow()
-                .deviceLabel());
+                .orElseThrow();
+        assertEquals("Mobile", mobileSession.deviceLabel());
+        assertEquals("iOS", mobileSession.operatingSystemLabel());
+        assertEquals("390x844 px", mobileSession.screenSizeLabel());
+        assertEquals(100.0, findOperatingSystemPercentage(summary.mobileOperatingSystemBreakdown(), "ios"));
+        assertEquals(33.33, findScreenSizePercentage(summary.screenSizeBreakdown(), "390x844"));
     }
 
     /**
@@ -246,6 +256,32 @@ class ExperimentFunnelServiceRenderCompleteTest {
                 return occurredAt;
             }
         };
+    }
+
+    /**
+     * Localiza o percentual de um sistema operacional mobile no resumo de analytics.
+     */
+    private double findOperatingSystemPercentage(
+            List<com.marketinghub.experiment.funnel.service.analytics.ExperimentLandingAnalyticsOperatingSystemDto> systems,
+            String operatingSystem) {
+        return systems.stream()
+                .filter(system -> operatingSystem.equals(system.operatingSystem()))
+                .map(com.marketinghub.experiment.funnel.service.analytics.ExperimentLandingAnalyticsOperatingSystemDto::percentage)
+                .findFirst()
+                .orElseThrow();
+    }
+
+    /**
+     * Localiza o percentual de uma resolução de tela no resumo de analytics.
+     */
+    private double findScreenSizePercentage(
+            List<com.marketinghub.experiment.funnel.service.analytics.ExperimentLandingAnalyticsScreenSizeDto> screens,
+            String screenSize) {
+        return screens.stream()
+                .filter(screen -> screenSize.equals(screen.screenSize()))
+                .map(com.marketinghub.experiment.funnel.service.analytics.ExperimentLandingAnalyticsScreenSizeDto::percentage)
+                .findFirst()
+                .orElseThrow();
     }
 
     /**

--- a/backend/ads-service/src/test/java/com/marketinghub/leadportal/web/LeadPortalFlowEngagementControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/leadportal/web/LeadPortalFlowEngagementControllerTest.java
@@ -101,7 +101,10 @@ class LeadPortalFlowEngagementControllerTest {
                                   "eventId":"evt-1",
                                   "eventType":"page_view",
                                   "sessionId":"session-1",
-                                  "pageUrl":"https://oportunidadebrasil.shop/api/flows/flow-slug/page"
+                                  "pageUrl":"https://oportunidadebrasil.shop/api/flows/flow-slug/page",
+                                  "operatingSystem":"ios",
+                                  "screenWidth":390,
+                                  "screenHeight":844
                                 }
                                 """))
                 .andExpect(status().isOk());
@@ -111,7 +114,10 @@ class LeadPortalFlowEngagementControllerTest {
                 org.mockito.ArgumentMatchers.argThat((RegisterLandingPageAnalyticsEventRequest request) ->
                         "evt-1".equals(request.eventId())
                                 && "page_view".equals(request.eventType())
-                                && "session-1".equals(request.sessionId())));
+                                && "session-1".equals(request.sessionId())
+                                && "ios".equals(request.operatingSystem())
+                                && Integer.valueOf(390).equals(request.screenWidth())
+                                && Integer.valueOf(844).equals(request.screenHeight())));
     }
 
 }

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -4035,3 +4035,11 @@
 - causa-raiz: o changelog atualizava `pipeline_stage` e `pipeline_stage_definition` enquanto consultava as mesmas tabelas em subconsultas `NOT EXISTS`, padrão bloqueado pelo MySQL 5.7 com o erro 1093 (`You can't specify target table ... for update in FROM clause`).
 - foi feito: as validações de existência/conflito foram reescritas para `LEFT JOIN ... IS NULL`, evitando subconsultas sobre a tabela-alvo durante `UPDATE` e mantendo a idempotência das inserções das etapas GeraLanding.
 - impacto esperado: o backend deve conseguir concluir a execução do Liquibase e subir sem interromper o contexto Spring por essa migração.
+
+## 2026-06-07 — Percentuais mobile e tamanho de tela no analytics do experimento
+
+- solicitação: exibir no analytics do experimento os percentuais de sistemas operacionais mobile (`iOS`/`Android`) e, quando possível, o tamanho de tela dos visitantes.
+- foi feito: o script público de analytics da landing passou a enviar `operatingSystem`, `screenWidth` e `screenHeight` junto com `deviceType`, `userAgent` e sessão.
+- foi feito: o resumo backend do funil passou a consolidar percentuais por sistema operacional dentro das sessões mobile e as principais resoluções de tela capturadas.
+- foi feito: a aba Analytics do experimento passou a mostrar cards específicos para iOS/Android/outros e para resoluções de tela, além de detalhar esses dados nas sessões recentes.
+- impacto esperado: a decisão comercial sobre páginas e criativos mobile fica mais precisa, permitindo detectar predominância de iOS/Android e adaptar layout/oferta aos tamanhos reais de tela.

--- a/docs/swagger/lead-portal-swagger.yaml
+++ b/docs/swagger/lead-portal-swagger.yaml
@@ -672,6 +672,18 @@ components:
           type: string
           nullable: true
           enum: [mobile, desktop, tablet]
+        operatingSystem:
+          type: string
+          nullable: true
+          enum: [ios, android, other]
+        screenWidth:
+          type: integer
+          nullable: true
+          minimum: 1
+        screenHeight:
+          type: integer
+          nullable: true
+          minimum: 1
     CreateLeadMultipartRequest:
       type: object
       required: [name, email, image]

--- a/docs/swagger/openapi.yaml
+++ b/docs/swagger/openapi.yaml
@@ -1064,6 +1064,14 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/ExperimentLandingAnalyticsDevice'
+        mobileOperatingSystemBreakdown:
+          type: array
+          items:
+            $ref: '#/components/schemas/ExperimentLandingAnalyticsOperatingSystem'
+        screenSizeBreakdown:
+          type: array
+          items:
+            $ref: '#/components/schemas/ExperimentLandingAnalyticsScreenSize'
         sessions:
           type: array
           items:
@@ -1104,6 +1112,20 @@ components:
           enum: [mobile, desktop, tablet]
         deviceLabel:
           type: string
+        operatingSystem:
+          type: string
+          enum: [ios, android, other]
+        operatingSystemLabel:
+          type: string
+        screenWidth:
+          type: integer
+          nullable: true
+        screenHeight:
+          type: integer
+          nullable: true
+        screenSizeLabel:
+          type: string
+          nullable: true
         topSections:
           type: array
           items:
@@ -1116,6 +1138,40 @@ components:
           enum: [mobile, desktop, tablet]
         label:
           type: string
+        sessions:
+          type: integer
+          format: int64
+        percentage:
+          type: number
+          format: double
+    ExperimentLandingAnalyticsOperatingSystem:
+      type: object
+      properties:
+        operatingSystem:
+          type: string
+          enum: [ios, android, other]
+        label:
+          type: string
+        sessions:
+          type: integer
+          format: int64
+        percentage:
+          type: number
+          format: double
+    ExperimentLandingAnalyticsScreenSize:
+      type: object
+      properties:
+        screenSize:
+          type: string
+          example: 390x844
+        label:
+          type: string
+        width:
+          type: integer
+          nullable: true
+        height:
+          type: integer
+          nullable: true
         sessions:
           type: integer
           format: int64

--- a/frontend/src/api/experiment/useExperimentLandingAnalytics.ts
+++ b/frontend/src/api/experiment/useExperimentLandingAnalytics.ts
@@ -14,6 +14,22 @@ export interface ExperimentLandingAnalyticsDevice {
   percentage: number;
 }
 
+export interface ExperimentLandingAnalyticsOperatingSystem {
+  operatingSystem: "ios" | "android" | "other" | string;
+  label: string;
+  sessions: number;
+  percentage: number;
+}
+
+export interface ExperimentLandingAnalyticsScreenSize {
+  screenSize: string;
+  label: string;
+  width?: number | null;
+  height?: number | null;
+  sessions: number;
+  percentage: number;
+}
+
 export interface ExperimentLandingAnalyticsSession {
   sessionId: string;
   eventCount: number;
@@ -26,6 +42,11 @@ export interface ExperimentLandingAnalyticsSession {
   lastUserAgent?: string | null;
   deviceType?: string | null;
   deviceLabel?: string | null;
+  operatingSystem?: string | null;
+  operatingSystemLabel?: string | null;
+  screenWidth?: number | null;
+  screenHeight?: number | null;
+  screenSizeLabel?: string | null;
   topSections: ExperimentLandingAnalyticsSection[];
 }
 
@@ -38,6 +59,8 @@ export interface ExperimentLandingAnalytics {
   averageVisibleMsPerSession: number;
   lastEventAt?: string | null;
   deviceBreakdown: ExperimentLandingAnalyticsDevice[];
+  mobileOperatingSystemBreakdown: ExperimentLandingAnalyticsOperatingSystem[];
+  screenSizeBreakdown: ExperimentLandingAnalyticsScreenSize[];
   sessions: ExperimentLandingAnalyticsSession[];
 }
 

--- a/frontend/src/pages/experiment/ExperimentLandingAnalyticsTab.tsx
+++ b/frontend/src/pages/experiment/ExperimentLandingAnalyticsTab.tsx
@@ -71,6 +71,9 @@ export default function ExperimentLandingAnalyticsTab({
 
   const sessions = data?.sessions ?? [];
   const deviceBreakdown = data?.deviceBreakdown ?? [];
+  const mobileOperatingSystemBreakdown =
+    data?.mobileOperatingSystemBreakdown ?? [];
+  const screenSizeBreakdown = data?.screenSizeBreakdown ?? [];
   const deviceIcons = {
     mobile: Smartphone,
     desktop: Monitor,
@@ -195,6 +198,109 @@ export default function ExperimentLandingAnalyticsTab({
         </div>
       </div>
 
+      <div className="row g-3">
+        <div className="col-12 col-lg-5">
+          <div className="card h-100">
+            <div className="card-body">
+              <div className="d-flex flex-wrap align-items-center justify-content-between gap-2 mb-3">
+                <div>
+                  <h5 className="card-title mb-1">
+                    Mobile por sistema operacional
+                  </h5>
+                  <p className="text-muted small mb-0">
+                    Percentual calculado somente sobre as sessões mobile
+                    identificadas como iOS, Android ou outros.
+                  </p>
+                </div>
+                <span className="badge text-bg-light border">
+                  iOS / Android
+                </span>
+              </div>
+              <div className="d-flex flex-column gap-3">
+                {mobileOperatingSystemBreakdown.map((system) => (
+                  <div key={system.operatingSystem}>
+                    <div className="d-flex align-items-center justify-content-between gap-2 mb-2">
+                      <span className="fw-semibold">{system.label}</span>
+                      <strong>{system.percentage.toFixed(1)}%</strong>
+                    </div>
+                    <div
+                      className="progress"
+                      role="progressbar"
+                      aria-label={`Percentual mobile ${system.label}`}
+                      aria-valuenow={system.percentage}
+                      aria-valuemin={0}
+                      aria-valuemax={100}
+                    >
+                      <div
+                        className="progress-bar"
+                        style={{
+                          width: `${Math.min(100, Math.max(0, system.percentage))}%`,
+                        }}
+                      />
+                    </div>
+                    <div className="text-muted small mt-1">
+                      {system.sessions} sessões mobile
+                    </div>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </div>
+        </div>
+        <div className="col-12 col-lg-7">
+          <div className="card h-100">
+            <div className="card-body">
+              <div className="d-flex flex-wrap align-items-center justify-content-between gap-2 mb-3">
+                <div>
+                  <h5 className="card-title mb-1">Tamanho de tela</h5>
+                  <p className="text-muted small mb-0">
+                    Principais resoluções capturadas em pixels CSS da janela
+                    visível no momento do evento.
+                  </p>
+                </div>
+                <span className="badge text-bg-light border">
+                  {screenSizeBreakdown.length} resoluções
+                </span>
+              </div>
+              {screenSizeBreakdown.length === 0 ? (
+                <p className="text-muted small mb-0">
+                  Nenhuma resolução capturada ainda. Novos acessos da landing
+                  passarão a enviar largura e altura da tela.
+                </p>
+              ) : (
+                <div className="d-flex flex-column gap-3">
+                  {screenSizeBreakdown.map((screen) => (
+                    <div key={screen.screenSize}>
+                      <div className="d-flex align-items-center justify-content-between gap-2 mb-2">
+                        <span className="fw-semibold">{screen.label}</span>
+                        <strong>{screen.percentage.toFixed(1)}%</strong>
+                      </div>
+                      <div
+                        className="progress"
+                        role="progressbar"
+                        aria-label={`Percentual de tela ${screen.label}`}
+                        aria-valuenow={screen.percentage}
+                        aria-valuemin={0}
+                        aria-valuemax={100}
+                      >
+                        <div
+                          className="progress-bar"
+                          style={{
+                            width: `${Math.min(100, Math.max(0, screen.percentage))}%`,
+                          }}
+                        />
+                      </div>
+                      <div className="text-muted small mt-1">
+                        {screen.sessions} sessões
+                      </div>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
       <div className="card">
         <div className="card-body">
           <div className="d-flex flex-wrap align-items-center justify-content-between gap-2 mb-3">
@@ -243,6 +349,13 @@ export default function ExperimentLandingAnalyticsTab({
                         </div>
                         <div className="text-muted small">
                           {session.deviceLabel ?? "Computador"}
+                        </div>
+                        <div className="text-muted small">
+                          {session.operatingSystemLabel ??
+                            "SO não identificado"}
+                        </div>
+                        <div className="text-muted small">
+                          {session.screenSizeLabel ?? "Tela não capturada"}
                         </div>
                       </td>
                       <td className="small">

--- a/lead-portal/backend/src/main/java/com/marketinghub/leadportal/controller/FlowController.java
+++ b/lead-portal/backend/src/main/java/com/marketinghub/leadportal/controller/FlowController.java
@@ -191,6 +191,29 @@ public class FlowController {
                   const buildEventId = function(){
                     return crypto.randomUUID ? crypto.randomUUID() : (Date.now().toString(36) + '-' + Math.random().toString(36).slice(2));
                   };
+                  const resolveDeviceType = function(){
+                    const userAgent = navigator.userAgent || '';
+                    const isTablet = /ipad|tablet/i.test(userAgent) || (/android/i.test(userAgent) && !/mobile/i.test(userAgent));
+                    if (isTablet) return 'tablet';
+                    const isMobile = /mobi|iphone|ipod|android/i.test(userAgent);
+                    return isMobile ? 'mobile' : 'desktop';
+                  };
+                  const resolveOperatingSystem = function(){
+                    const userAgent = navigator.userAgent || '';
+                    if (/iphone|ipad|ipod/i.test(userAgent)) return 'ios';
+                    if (/android/i.test(userAgent)) return 'android';
+                    return 'other';
+                  };
+                  const resolveScreenSize = function(){
+                    const width = window.innerWidth || document.documentElement.clientWidth || screen.width || null;
+                    const height = window.innerHeight || document.documentElement.clientHeight || screen.height || null;
+                    return {
+                      width: typeof width === 'number' ? Math.round(width) : null,
+                      height: typeof height === 'number' ? Math.round(height) : null
+                    };
+                  };
+                  const deviceType = resolveDeviceType();
+                  const operatingSystem = resolveOperatingSystem();
                   const sendEvent = function(eventType, sectionId, elapsedMs){
                     const roundedElapsed = typeof elapsedMs === 'number' ? Math.round(elapsedMs) : null;
                     const payload = {
@@ -202,7 +225,11 @@ public class FlowController {
                       visibleMs: roundedElapsed,
                       pageUrl: window.location.href,
                       occurredAt: new Date().toISOString(),
-                      userAgent: navigator.userAgent
+                      userAgent: navigator.userAgent,
+                      deviceType: deviceType,
+                      operatingSystem: operatingSystem,
+                      screenWidth: resolveScreenSize().width,
+                      screenHeight: resolveScreenSize().height
                     };
                     debugLog('enviando evento', {endpoint: endpoint, payload: payload});
                     if (navigator.sendBeacon) {

--- a/lead-portal/backend/src/test/java/com/marketinghub/leadportal/controller/FlowControllerTest.java
+++ b/lead-portal/backend/src/test/java/com/marketinghub/leadportal/controller/FlowControllerTest.java
@@ -277,7 +277,9 @@ class FlowControllerTest {
                 .andExpect(content().string(containsString("/api/flows/")))
                 .andExpect(content().string(containsString("/page-analytics")))
                 .andExpect(content().string(containsString("mhAnalyticsDebug")))
-                .andExpect(content().string(containsString("[MH Landing Analytics]")));
+                .andExpect(content().string(containsString("[MH Landing Analytics]")))
+                .andExpect(content().string(containsString("operatingSystem")))
+                .andExpect(content().string(containsString("screenWidth")));
     }
 
     /**

--- a/lead-portal/backend/src/test/java/com/marketinghub/leadportal/controller/FlowEngagementControllerTest.java
+++ b/lead-portal/backend/src/test/java/com/marketinghub/leadportal/controller/FlowEngagementControllerTest.java
@@ -51,18 +51,22 @@ class FlowEngagementControllerTest {
         when(trackingClient.registerPageAnalytics(
                 org.mockito.ArgumentMatchers.eq("flow-slug"),
                 argThat(payload -> "page_view".equals(payload.get("eventType"))
-                        && "evt-1".equals(payload.get("eventId")))))
+                        && "evt-1".equals(payload.get("eventId"))
+                        && "android".equals(payload.get("operatingSystem"))
+                        && Integer.valueOf(390).equals(payload.get("screenWidth")))))
                 .thenReturn(TrackingResult.FORWARDED);
 
         mockMvc.perform(post("/api/flows/flow-slug/page-analytics")
                         .contentType(MediaType.APPLICATION_JSON)
-                        .content("{\"eventId\":\"evt-1\",\"eventType\":\"page_view\"}"))
+                        .content("{\"eventId\":\"evt-1\",\"eventType\":\"page_view\",\"operatingSystem\":\"android\",\"screenWidth\":390,\"screenHeight\":844}"))
                 .andExpect(status().isAccepted());
 
         verify(trackingClient).registerPageAnalytics(
                 org.mockito.ArgumentMatchers.eq("flow-slug"),
                 argThat(payload -> "page_view".equals(payload.get("eventType"))
-                        && "evt-1".equals(payload.get("eventId"))));
+                        && "evt-1".equals(payload.get("eventId"))
+                        && "android".equals(payload.get("operatingSystem"))
+                        && Integer.valueOf(390).equals(payload.get("screenWidth"))));
     }
 
     /**


### PR DESCRIPTION
### Motivation
- Expose mobile operating system share (iOS / Android / other) and common screen resolutions in experiment landing analytics so operators can make better mobile creative/layout decisions. 

### Description
- Capture `operatingSystem`, `screenWidth` and `screenHeight` in the public landing analytics contract by extending `RegisterLandingPageAnalyticsEventRequest` and updating the injected analytics scripts in both the main backend (`LeadPortalPublicFlowController`) and the Lead Portal (`FlowController`) to send these fields. 
- Aggregate and normalize the new fields in the experiment backend by extending `ExperimentFunnelService`: parse the additional payload keys, accumulate per-session OS/screen info, compute mobile-OS percentages and top screen-size breakdowns, and add helper methods (`buildMobileOperatingSystemBreakdown`, `buildScreenSizeBreakdown`, `parsePositiveInteger`, etc.). 
- Add two new DTOs: `ExperimentLandingAnalyticsOperatingSystemDto` and `ExperimentLandingAnalyticsScreenSizeDto`, extend `ExperimentLandingAnalyticsDto` and `ExperimentLandingAnalyticsSessionDto` to include OS and screen info, and update Swagger (`docs/swagger/openapi.yaml`, `docs/swagger/lead-portal-swagger.yaml`). 
- Update frontend contract `useExperimentLandingAnalytics` and the experiment Analytics tab (`ExperimentLandingAnalyticsTab.tsx`) to render OS percentage cards, screen-size breakdown and per-session OS/screen details; format changes applied with `prettier`. 
- Update tests and documentation: backend unit tests adjusted to include OS/screen values, Lead Portal controller tests updated, and the change recorded in `docs/registros/experimentos.md`.

### Testing
- Backend unit tests: ran `mvn -q -Dtest=ExperimentFunnelServiceRenderCompleteTest,LeadPortalFlowEngagementControllerTest test` in `backend/ads-service` and `mvn -q -Dtest=FlowControllerTest,FlowEngagementControllerTest test` in `lead-portal/backend`, both executed successfully. 
- Frontend verification: ran `npm ci`, `npm run typecheck`, and `npm run build` in `frontend`, and formatted changed files with `npx prettier --write`; the build and typecheck completed successfully. 
- Commands used during validation included `mvn -Dtest=... test`, `npm run typecheck`, and `npm run build`, all reported successful runs in the rollout logs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a25768305708321955f8df2b6307436)