### PR TITLE
Implementa visitorId no analytics público da landing

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/leadportal/web/LeadPortalPublicFlowController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/leadportal/web/LeadPortalPublicFlowController.java
@@ -5,6 +5,8 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marketinghub.leadportal.LeadPortalFlow;
 import com.marketinghub.leadportal.integration.LeadPortalFlowPublicationRequest;
 import com.marketinghub.leadportal.service.LeadPortalFlowService;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.util.StringUtils;
@@ -23,19 +25,29 @@ import java.util.Locale;
 @RequestMapping("/api/flows")
 public class LeadPortalPublicFlowController {
 
+    private static final Logger log = LoggerFactory.getLogger(LeadPortalPublicFlowController.class);
     private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
     private final LeadPortalFlowService flowService;
 
+    /**
+     * Creates the controller with the service used to resolve approved public flows.
+     */
     public LeadPortalPublicFlowController(LeadPortalFlowService flowService) {
         this.flowService = flowService;
     }
 
+    /**
+     * Returns the approved public flow contract for the given slug.
+     */
     @GetMapping("/{slug}")
     public LeadPortalFlowPublicationRequest getBySlug(@PathVariable String slug) {
         LeadPortalFlow flow = flowService.getApprovedBySlug(slug);
         return LeadPortalFlowPublicationRequest.from(flow);
     }
 
+    /**
+     * Returns the approved landing page HTML with runtime analytics instrumentation.
+     */
     @GetMapping(value = "/{slug}/page", produces = MediaType.TEXT_HTML_VALUE)
     public ResponseEntity<String> getLandingPageBySlug(@PathVariable String slug) {
         LeadPortalFlow flow = flowService.getApprovedBySlug(slug);
@@ -45,6 +57,9 @@ public class LeadPortalPublicFlowController {
                 .body(htmlDocument);
     }
 
+    /**
+     * Resolves the publishable HTML document from raw, JSON or hybrid stored flow content.
+     */
     private String extractHtmlDocument(String sourceHtml) {
         if (!StringUtils.hasText(sourceHtml)) {
             return "";
@@ -67,6 +82,9 @@ public class LeadPortalPublicFlowController {
         return sourceHtml;
     }
 
+    /**
+     * Extracts an inline HTML document that starts at a doctype or html tag.
+     */
     private String tryExtractInlineHtmlDocument(String value) {
         if (!StringUtils.hasText(value)) {
             return null;
@@ -83,6 +101,9 @@ public class LeadPortalPublicFlowController {
         return null;
     }
 
+    /**
+     * Indicates whether the stored value appears to be a JSON object or array payload.
+     */
     private boolean looksLikeJsonPayload(String value) {
         if (!StringUtils.hasText(value)) {
             return false;
@@ -91,6 +112,9 @@ public class LeadPortalPublicFlowController {
         return firstChar == '{' || firstChar == '[';
     }
 
+    /**
+     * Searches hybrid HTML/text content for an embedded landing JSON payload.
+     */
     private String tryExtractFromHybridHtml(String html) {
         if (!StringUtils.hasText(html)) {
             return null;
@@ -109,11 +133,17 @@ public class LeadPortalPublicFlowController {
         return null;
     }
 
+    /**
+     * Checks whether a JSON candidate contains fields that may hold landing HTML.
+     */
     private boolean containsLandingPageSignature(String candidate) {
         String lowered = candidate.toLowerCase();
         return lowered.contains("landingpagehtml") || lowered.contains("htmldocument");
     }
 
+    /**
+     * Extracts a balanced JSON object candidate starting at the provided index.
+     */
     private String extractJsonCandidate(String source, int startIndex) {
         if (startIndex < 0 || startIndex >= source.length() || source.charAt(startIndex) != '{') {
             return null;
@@ -147,6 +177,9 @@ public class LeadPortalPublicFlowController {
         return null;
     }
 
+    /**
+     * Attempts to extract the HTML document from a JSON payload stored in the flow.
+     */
     private String tryExtractFromJsonPayload(String payload) {
         if (!StringUtils.hasText(payload)) {
             return null;
@@ -157,12 +190,17 @@ public class LeadPortalPublicFlowController {
             if (StringUtils.hasText(extracted)) {
                 return extracted;
             }
-        } catch (Exception ignored) {
+        } catch (Exception ex) {
+            log.warn("module=lead-portal operation=extract-public-flow-html errorClass={} message={} payloadLength={}",
+                    ex.getClass().getName(), ex.getMessage(), payload.length(), ex);
             return null;
         }
         return null;
     }
 
+    /**
+     * Recursively reads a JSON node tree to locate the first embedded HTML document.
+     */
     private String extractHtmlDocumentFromNode(JsonNode node) throws java.io.IOException {
         if (node == null || node.isNull()) {
             return null;
@@ -216,10 +254,16 @@ public class LeadPortalPublicFlowController {
         return null;
     }
 
+    /**
+     * Delegates landingPageHtml node extraction through the generic HTML node resolver.
+     */
     private String extractFromLandingPageNode(JsonNode landingPageHtmlNode) throws java.io.IOException {
         return extractHtmlDocumentFromNode(landingPageHtmlNode);
     }
 
+    /**
+     * Injects the public landing analytics script into the rendered HTML without altering the pure source artifact.
+     */
     private String injectLandingAnalyticsScript(String slug, String htmlDocument) {
         if (!StringUtils.hasText(htmlDocument)) {
             return htmlDocument;
@@ -230,49 +274,102 @@ public class LeadPortalPublicFlowController {
         String analyticsScript = """
                 <script data-mh-landing-analytics="true">
                 (function(){
-                  const slugValue = %s;
-                  const endpoint = '/api/public/lead-portal/flows/' + encodeURIComponent(slugValue) + '/page-analytics';
-                  const sessionKey = 'mh_lp_session_' + slugValue;
-                  const sessionId = sessionStorage.getItem(sessionKey) || (Date.now().toString(36) + '-' + Math.random().toString(36).slice(2));
-                  sessionStorage.setItem(sessionKey, sessionId);
-                  const resolveDeviceType = function(){
-                    const userAgent = navigator.userAgent || '';
-                    const isTablet = /ipad|tablet/i.test(userAgent) || (/android/i.test(userAgent) && !/mobile/i.test(userAgent));
+                  var slugValue = %s;
+                  var endpoint = '/api/public/lead-portal/flows/' + encodeURIComponent(slugValue) + '/page-analytics';
+                  var memoryStore = {};
+                  var safeGet = function(storageName, key){
+                    try { return window[storageName] ? window[storageName].getItem(key) : null; } catch (e) { return null; }
+                  };
+                  var safeSet = function(storageName, key, value){
+                    try { if (window[storageName]) window[storageName].setItem(key, value); } catch (e) {}
+                  };
+                  var cookieName = function(key){ return key.replace(/[^a-zA-Z0-9_\\-]/g, '_'); };
+                  var readCookie = function(name){
+                    try {
+                      var parts = ('; ' + document.cookie).split('; ' + name + '=');
+                      if (parts.length === 2) return decodeURIComponent(parts.pop().split(';').shift());
+                    } catch (e) {}
+                    return null;
+                  };
+                  var writeCookie = function(name, value){
+                    try {
+                      document.cookie = name + '=' + encodeURIComponent(value) + '; Max-Age=31536000; Path=/; SameSite=Lax';
+                    } catch (e) {}
+                  };
+                  var randomId = function(prefix){
+                    try {
+                      if (window.crypto && typeof window.crypto.randomUUID === 'function') return prefix + '-' + window.crypto.randomUUID();
+                      if (window.crypto && typeof window.crypto.getRandomValues === 'function') {
+                        var bytes = new Uint8Array(16);
+                        window.crypto.getRandomValues(bytes);
+                        return prefix + '-' + Array.prototype.map.call(bytes, function(byte){ return byte.toString(16).padStart(2, '0'); }).join('');
+                      }
+                    } catch (e) {}
+                    return prefix + '-' + Date.now().toString(36) + '-' + Math.random().toString(36).slice(2);
+                  };
+                  var resolvePersistentId = function(key){
+                    var cookieKey = cookieName(key);
+                    var existing = safeGet('localStorage', key) || readCookie(cookieKey) || memoryStore[key];
+                    if (existing) return existing;
+                    var created = randomId('visitor');
+                    memoryStore[key] = created;
+                    safeSet('localStorage', key, created);
+                    writeCookie(cookieKey, created);
+                    return created;
+                  };
+                  var resolveSessionId = function(key){
+                    var existing = safeGet('sessionStorage', key) || memoryStore[key];
+                    if (existing) return existing;
+                    var created = randomId('session');
+                    memoryStore[key] = created;
+                    safeSet('sessionStorage', key, created);
+                    return created;
+                  };
+                  var visitorId = resolvePersistentId('mh_lp_visitor_' + slugValue);
+                  var sessionId = resolveSessionId('mh_lp_session_' + slugValue);
+                  var resolveDeviceType = function(){
+                    var userAgent = navigator.userAgent || '';
+                    var isTablet = /ipad|tablet/i.test(userAgent) || (/android/i.test(userAgent) && !/mobile/i.test(userAgent));
                     if (isTablet) return 'tablet';
-                    const isMobile = /mobi|iphone|ipod|android/i.test(userAgent);
+                    var isMobile = /mobi|iphone|ipod|android/i.test(userAgent);
                     return isMobile ? 'mobile' : 'desktop';
                   };
-                  const deviceType = resolveDeviceType();
-                  const sendEvent = function(eventType, sectionId, elapsedMs){
-                    const payload = {
-                      eventId: crypto.randomUUID ? crypto.randomUUID() : (Date.now().toString(36) + '-' + Math.random().toString(36).slice(2)),
+                  var nowMs = function(){ return window.performance && typeof window.performance.now === 'function' ? window.performance.now() : Date.now(); };
+                  var deviceType = resolveDeviceType();
+                  var sendEvent = function(eventType, sectionId, elapsedMs){
+                    var payload = {
+                      eventId: randomId('event'),
                       eventType: eventType,
+                      visitorId: visitorId,
                       sessionId: sessionId,
                       sectionId: sectionId || null,
                       elapsedMs: typeof elapsedMs === 'number' ? Math.round(elapsedMs) : null,
                       visibleMs: typeof elapsedMs === 'number' ? Math.round(elapsedMs) : null,
                       pageUrl: window.location.href,
                       occurredAt: new Date().toISOString(),
-                      userAgent: navigator.userAgent,
+                      userAgent: navigator.userAgent || '',
                       deviceType: deviceType
                     };
-                    if (navigator.sendBeacon) {
-                      navigator.sendBeacon(endpoint, new Blob([JSON.stringify(payload)], {type: 'application/json'}));
-                      return;
+                    if (navigator.sendBeacon && window.Blob) {
+                      try {
+                        navigator.sendBeacon(endpoint, new Blob([JSON.stringify(payload)], {type: 'application/json'}));
+                        return;
+                      } catch (e) {}
                     }
-                    fetch(endpoint, {method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify(payload), keepalive: true}).catch(function(){});
+                    if (window.fetch) fetch(endpoint, {method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify(payload), keepalive: true}).catch(function(){});
                   };
                   sendEvent('page_view', null, null);
-                  const visibleSince = new Map();
-                  const observer = new IntersectionObserver(function(entries){
-                    const now = performance.now();
+                  if (!('IntersectionObserver' in window) || !window.Map) return;
+                  var visibleSince = new Map();
+                  var observer = new IntersectionObserver(function(entries){
+                    var now = nowMs();
                     entries.forEach(function(entry){
-                      const sectionId = entry.target.id || entry.target.getAttribute('data-section-id') || entry.target.getAttribute('data-track-section');
+                      var sectionId = entry.target.id || entry.target.getAttribute('data-section-id') || entry.target.getAttribute('data-track-section');
                       if (!sectionId) return;
                       if (entry.isIntersecting && entry.intersectionRatio >= 0.5) {
                         if (!visibleSince.has(sectionId)) visibleSince.set(sectionId, now);
                       } else if (visibleSince.has(sectionId)) {
-                        const startedAt = visibleSince.get(sectionId);
+                        var startedAt = visibleSince.get(sectionId);
                         visibleSince.delete(sectionId);
                         sendEvent('section_view_time', sectionId, now - startedAt);
                       }
@@ -280,7 +377,7 @@ public class LeadPortalPublicFlowController {
                   }, {threshold:[0.5]});
                   document.querySelectorAll('section[id], [data-section-id], [data-track-section]').forEach(function(el){ observer.observe(el); });
                   window.addEventListener('beforeunload', function(){
-                    const now = performance.now();
+                    var now = nowMs();
                     visibleSince.forEach(function(startedAt, sectionId){ sendEvent('section_view_time', sectionId, now - startedAt); });
                   });
                 })();
@@ -292,6 +389,9 @@ public class LeadPortalPublicFlowController {
         return htmlDocument + "\n" + analyticsScript;
     }
 
+    /**
+     * Escapes a Java value for safe insertion as a JavaScript string literal.
+     */
     private String toJsStringLiteral(String rawValue) {
         String safeValue = rawValue == null ? "" : rawValue;
         return "\"" + safeValue
@@ -299,6 +399,9 @@ public class LeadPortalPublicFlowController {
                 .replace("\"", "\\\"") + "\"";
     }
 
+    /**
+     * Checks whether a source string contains a token without case sensitivity.
+     */
     private boolean containsIgnoreCase(String source, String token) {
         return source.toLowerCase(Locale.ROOT).contains(token.toLowerCase(Locale.ROOT));
     }

--- a/backend/ads-service/src/test/java/com/marketinghub/leadportal/web/LeadPortalPublicFlowControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/leadportal/web/LeadPortalPublicFlowControllerTest.java
@@ -17,11 +17,15 @@ import org.springframework.test.web.servlet.MockMvc;
 
 import java.util.List;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.content;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+/**
+ * Verifies the public lead portal flow endpoints and the rendered landing HTML contract.
+ */
 @SpringBootTest(classes = AdsServiceApplication.class)
 @AutoConfigureMockMvc
 @TestPropertySource(properties = {
@@ -41,12 +45,18 @@ class LeadPortalPublicFlowControllerTest {
     @Autowired
     MarketNicheRepository marketNicheRepository;
 
+    /**
+     * Cleans persisted test data before each public flow endpoint verification.
+     */
     @BeforeEach
     void cleanDatabase() {
         flowRepository.deleteAll();
         marketNicheRepository.deleteAll();
     }
 
+    /**
+     * Verifies that an approved flow is returned through the public JSON endpoint.
+     */
     @Test
     void getBySlugReturnsApprovedFlow() throws Exception {
         MarketNiche niche = marketNicheRepository.save(MarketNiche.builder().name("Nicho Teste").build());
@@ -78,6 +88,49 @@ class LeadPortalPublicFlowControllerTest {
                 .andExpect(jsonPath("$.questions[0].dataKey").value("nome"));
     }
 
+
+    /**
+     * Verifica que a landing pública injeta visitorId first-party sem contaminar o HTML com metadados técnicos.
+     */
+    @Test
+    void getLandingPageBySlugInjectsVisitorAnalyticsWithoutTechnicalMetadata() throws Exception {
+        MarketNiche niche = marketNicheRepository.save(MarketNiche.builder().name("Nicho Teste").build());
+        flowRepository.save(LeadPortalFlow.builder()
+                .name("Fluxo Landing")
+                .slug("exp-10-landing")
+                .approved(true)
+                .customFormHtml("<html><head><title>Landing</title></head><body><section id=\"hero\"></section></body></html>")
+                .marketNiche(niche)
+                .build());
+
+        String html = mockMvc.perform(get("/api/flows/exp-10-landing/page"))
+                .andExpect(status().isOk())
+                .andExpect(content().contentTypeCompatibleWith("text/html"))
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+
+        assertThat(html).contains("data-mh-landing-analytics=\"true\"");
+        assertThat(html).contains("var visitorId = resolvePersistentId('mh_lp_visitor_' + slugValue);");
+        assertThat(html).contains("var sessionId = resolveSessionId('mh_lp_session_' + slugValue);");
+        assertThat(html).contains("visitorId: visitorId");
+        assertThat(html).contains("sessionId: sessionId");
+        assertThat(html).contains("pageUrl: window.location.href");
+        assertThat(html).contains("occurredAt: new Date().toISOString()");
+        assertThat(html).contains("userAgent: navigator.userAgent || ''");
+        assertThat(html).contains("safeGet('localStorage', key)");
+        assertThat(html).contains("safeGet('sessionStorage', key)");
+        assertThat(html).contains("window.crypto.randomUUID");
+        assertThat(html).contains("window.crypto.getRandomValues");
+        assertThat(html).doesNotContain("<!-- AUTO:");
+        assertThat(html).doesNotContain("debugInfo");
+        assertThat(html).doesNotContain("legacyPreviewHtml");
+        assertThat(html).doesNotContain("renderMode");
+    }
+
+    /**
+     * Verifies that a non-approved flow remains unavailable in the public JSON endpoint.
+     */
     @Test
     void getBySlugReturnsNotFoundWhenFlowIsNotApproved() throws Exception {
         MarketNiche niche = marketNicheRepository.save(MarketNiche.builder().name("Nicho Teste").build());

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -4043,3 +4043,14 @@
 - causa-raiz: o changelog atualizava `pipeline_stage` e `pipeline_stage_definition` enquanto consultava as mesmas tabelas em subconsultas `NOT EXISTS`, padrão bloqueado pelo MySQL 5.7 com o erro 1093 (`You can't specify target table ... for update in FROM clause`).
 - foi feito: as validações de existência/conflito foram reescritas para `LEFT JOIN ... IS NULL`, evitando subconsultas sobre a tabela-alvo durante `UPDATE` e mantendo a idempotência das inserções das etapas GeraLanding.
 - impacto esperado: o backend deve conseguir concluir a execução do Liquibase e subir sem interromper o contexto Spring por essa migração.
+
+## 2026-06-07 11:08:39 UTC-3
+- solicitação: executar a etapa 4 do plano de identificação de visitante da landing de experimento, focada na geração de `visitorId` no script público da landing.
+- raciocínio: a landing publicada precisava emitir o contrato canônico novo de analytics com `visitorId` persistente first-party e `sessionId` de sessão sem depender de storage sempre disponível, preservando a ausência de metadados técnicos no artefato final.
+- registro do que foi feito: atualizado o script público injetado em `/api/flows/{slug}/page` para gerar `visitorId` via `localStorage` com fallback para cookie first-party e memória, manter `sessionId` em `sessionStorage` com fallback seguro, enviar ambos em todos os eventos, usar fallback para geração de IDs quando `crypto.randomUUID` não existir e cobrir a ausência de contaminação técnica com teste de regressão.
+- documentos lidos para pesquisar e resolver o problema:
+  - AGENTS.md
+  - backend/AGENTS.md
+  - docs/implementação/plano-identificacao-visitante-landing-experimento.md
+  - docs/canonical/procedimento-experimento-canon.v1.md
+  - docs/registros/experimentos.md


### PR DESCRIPTION
### Motivation
- Permitir identificar visitantes prováveis recorrentes da landing usando um identificador first‑party (`visitorId`) persistente no mesmo navegador/dispositivo para melhorar a rastreabilidade sem afirmar identidade civil.
- Garantir compatibilidade com eventos legados que só reportam `sessionId` e evitar contaminação do artefato final com metadados técnicos.
- Tornar o script público robusto a navegadores com storage restrito e prover fallback seguro para geração/armazenamento de IDs.

### Description
- Atualiza o script injetado pelo endpoint de publicação `/api/flows/{slug}/page` para gerar `visitorId` persistente (prioriza `localStorage`, fallback para cookie first‑party e memória) e manter `sessionId` em `sessionStorage` com fallback seguro, além de enviar `visitorId`, `sessionId`, `pageUrl`, `occurredAt`, `userAgent` e `eventId` em todos os eventos (`page_view` e `section_view_time`). (arquivo: `backend/ads-service/src/main/java/com/marketinghub/leadportal/web/LeadPortalPublicFlowController.java`).
- Implementa fallback de geração de IDs utilizando `crypto.randomUUID` → `crypto.getRandomValues` → timestamp+random, e adaptaenvio com `navigator.sendBeacon`/`Blob` → `fetch`, protegendo contra ausência de APIs (`IntersectionObserver`, `Map`, `Blob`, `fetch`).
- Adiciona logs de advertência ao extrair HTML de payloads JSON para registrar exceções com contexto operacional, e insere comentários de responsabilidade nas partes Java alteradas conforme convenção do projeto. (mesmo arquivo).
- Adiciona teste de regressão verificando que o HTML publicado contém a instrumentação esperada (`visitorId`/`sessionId`), os campos do payload e que não contém marcadores técnicos proibidos; e registra a execução no arquivo operacional `docs/registros/experimentos.md`. (arquivo: `backend/ads-service/src/test/java/com/marketinghub/leadportal/web/LeadPortalPublicFlowControllerTest.java` e `docs/registros/experimentos.md`).

### Testing
- Executado o teste de unidade específico com `../mvnw -Dtest=LeadPortalPublicFlowControllerTest test` dentro do módulo `ads-service` e os testes passaram: `Tests run: 3, Failures: 0, Errors: 0`.
- O teste novo valida a presença do script injetado, geração/envio de `visitorId`/`sessionId` e a ausência de metadados técnicos indevidos no HTML publicado.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a257a508ab483218a4cf6a70d7622a9)