### PR TITLE
Show IA model (flex) pricing, defaults and generated-asset type in Gera Landing UI

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/pipeline/dto/GeraLandingStageModelDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/pipeline/dto/GeraLandingStageModelDto.java
@@ -1,5 +1,6 @@
 package com.marketinghub.pipeline.dto;
 
+import java.math.BigDecimal;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -21,4 +22,10 @@ public class GeraLandingStageModelDto {
     private Long openAiModelId;
     private String openAiModelName;
     private String openAiModelCode;
+    private BigDecimal priceInputFlex;
+    private BigDecimal priceInputCachedFlex;
+    private BigDecimal priceOutputFlex;
+    private String pricingMode;
+    private String generatedAssetType;
+    private boolean defaultModelApplied;
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/pipeline/service/PipelineService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/pipeline/service/PipelineService.java
@@ -20,6 +20,7 @@ import com.marketinghub.repository.jpa.openai.OpenAiModelRepository;
 import com.marketinghub.repository.jpa.pipeline.PipelineRepository;
 import com.marketinghub.repository.jpa.pipeline.PipelineStageRepository;
 import jakarta.persistence.EntityNotFoundException;
+import java.math.BigDecimal;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashSet;
@@ -40,6 +41,11 @@ import org.springframework.web.server.ResponseStatusException;
 @Service
 public class PipelineService {
     private static final Map<String, List<String>> GERA_LANDING_STAGE_ALIASES = buildGeraLandingStageAliases();
+    private static final String TEXT_DEFAULT_MODEL_CODE = "gpt-5.2";
+    private static final String TEXT_DEFAULT_MODEL_NAME = "GPT-5.2";
+    private static final String IMAGE_DEFAULT_MODEL_CODE = "gpt-image-1.5";
+    private static final String IMAGE_DEFAULT_MODEL_NAME = "GPT Image 1.5";
+    private static final String PRICING_MODE_FLEX = "flex";
 
     private final PipelineRepository pipelineRepository;
     private final PipelineStageRepository stageRepository;
@@ -536,19 +542,62 @@ public class PipelineService {
                 .filter(stage -> matchesGeraLandingStage(stage, stageCode))
                 .filter(stage -> stage.getOpenAiModel() != null)
                 .findFirst()
-                .map(stage -> GeraLandingStageModelDto.builder()
-                        .stageCode(stageCode)
-                        .pipelineId(stage.getPipeline().getId())
-                        .pipelineCode(stage.getPipeline().getCode())
-                        .pipelineStageId(stage.getId())
-                        .pipelineStageCode(stage.getCode())
-                        .openAiModelId(stage.getOpenAiModel().getId())
-                        .openAiModelName(stage.getOpenAiModel().getName())
-                        .openAiModelCode(stage.getOpenAiModel().getCode())
-                        .build())
-                .orElseGet(() -> GeraLandingStageModelDto.builder()
-                        .stageCode(stageCode)
+                .map(stage -> buildGeraLandingStageModelDto(stageCode, stage, stage.getOpenAiModel(), false))
+                .orElseGet(() -> buildDefaultGeraLandingStageModelDto(stageCode));
+    }
+
+    /** Monta o DTO de modelo da etapa preenchendo os custos do modo flex e o tipo de artefato gerado. */
+    private GeraLandingStageModelDto buildGeraLandingStageModelDto(
+            String stageCode, PipelineStage stage, OpenAiModel openAiModel, boolean defaultModelApplied) {
+        GeraLandingStageModelDto.GeraLandingStageModelDtoBuilder builder = GeraLandingStageModelDto.builder()
+                .stageCode(stageCode)
+                .generatedAssetType(resolveGeneratedAssetType(stageCode))
+                .pricingMode(PRICING_MODE_FLEX)
+                .defaultModelApplied(defaultModelApplied)
+                .openAiModelId(openAiModel.getId())
+                .openAiModelName(openAiModel.getName())
+                .openAiModelCode(openAiModel.getCode())
+                .priceInputFlex(openAiModel.getPriceInputBatch())
+                .priceInputCachedFlex(openAiModel.getPriceInputCachedBatch())
+                .priceOutputFlex(openAiModel.getPriceOutputBatch());
+
+        if (stage != null) {
+            builder.pipelineId(stage.getPipeline().getId())
+                    .pipelineCode(stage.getPipeline().getCode())
+                    .pipelineStageId(stage.getId())
+                    .pipelineStageCode(stage.getCode());
+        }
+
+        return builder.build();
+    }
+
+    /** Monta o DTO usando o modelo default quando a etapa não possui modelo associado no pipeline. */
+    private GeraLandingStageModelDto buildDefaultGeraLandingStageModelDto(String stageCode) {
+        String defaultCode = resolveDefaultModelCode(stageCode);
+        OpenAiModel fallbackModel = openAiModelRepository.findByCode(defaultCode)
+                .orElseGet(() -> OpenAiModel.builder()
+                        .name(resolveDefaultModelName(stageCode))
+                        .code(defaultCode)
+                        .priceInputBatch(BigDecimal.ZERO)
+                        .priceInputCachedBatch(BigDecimal.ZERO)
+                        .priceOutputBatch(BigDecimal.ZERO)
                         .build());
+        return buildGeraLandingStageModelDto(stageCode, null, fallbackModel, true);
+    }
+
+    /** Resolve o modelo default conforme o tipo de geração da etapa. */
+    private String resolveDefaultModelCode(String stageCode) {
+        return "landing-page-image-generation".equals(stageCode) ? IMAGE_DEFAULT_MODEL_CODE : TEXT_DEFAULT_MODEL_CODE;
+    }
+
+    /** Resolve o nome legível do modelo default quando o catálogo ainda não possui o registro. */
+    private String resolveDefaultModelName(String stageCode) {
+        return "landing-page-image-generation".equals(stageCode) ? IMAGE_DEFAULT_MODEL_NAME : TEXT_DEFAULT_MODEL_NAME;
+    }
+
+    /** Classifica o tipo de artefato gerado por cada etapa com uso de IA. */
+    private String resolveGeneratedAssetType(String stageCode) {
+        return "landing-page-image-generation".equals(stageCode) ? "imagem" : "texto";
     }
 
     /**

--- a/backend/ads-service/src/test/java/com/marketinghub/pipeline/service/PipelineServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/pipeline/service/PipelineServiceTest.java
@@ -28,6 +28,7 @@ import com.marketinghub.repository.jpa.pipeline.PipelineStageConfigRepository;
 import com.marketinghub.repository.jpa.pipeline.PipelineStageDefinitionEntityRepository;
 import com.marketinghub.repository.jpa.pipeline.PipelineStageRepository;
 import java.util.ArrayList;
+import java.math.BigDecimal;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
@@ -102,7 +103,19 @@ class PipelineServiceTest {
                 .id(77L)
                 .name("GPT Vendas")
                 .code("gpt-vendas")
+                .priceInputBatch(new BigDecimal("0.50"))
+                .priceInputCachedBatch(new BigDecimal("0.05"))
+                .priceOutputBatch(new BigDecimal("2.00"))
                 .build();
+        OpenAiModel defaultTextModel = OpenAiModel.builder()
+                .id(88L)
+                .name("GPT-5.2")
+                .code("gpt-5.2")
+                .priceInputBatch(new BigDecimal("0.875"))
+                .priceInputCachedBatch(new BigDecimal("0.0875"))
+                .priceOutputBatch(new BigDecimal("7.00"))
+                .build();
+        when(openAiModelRepository.findByCode("gpt-5.2")).thenReturn(Optional.of(defaultTextModel));
         PipelineStage wireframe = stage(1L, 1, "LANDING_PAGE_WIREFRAME");
         wireframe.setOpenAiModel(model);
         PipelineStage copyWithoutModel = stage(2L, 2, "landing-page-copy");
@@ -123,11 +136,20 @@ class PipelineServiceTest {
         assertThat(wireframeModel.getOpenAiModelId()).isEqualTo(77L);
         assertThat(wireframeModel.getOpenAiModelName()).isEqualTo("GPT Vendas");
         assertThat(wireframeModel.getOpenAiModelCode()).isEqualTo("gpt-vendas");
+        assertThat(wireframeModel.getPricingMode()).isEqualTo("flex");
+        assertThat(wireframeModel.getGeneratedAssetType()).isEqualTo("texto");
+        assertThat(wireframeModel.getPriceInputFlex()).isEqualByComparingTo("0.50");
+        assertThat(wireframeModel.getPriceInputCachedFlex()).isEqualByComparingTo("0.05");
+        assertThat(wireframeModel.getPriceOutputFlex()).isEqualByComparingTo("2.00");
+        assertThat(wireframeModel.isDefaultModelApplied()).isFalse();
         GeraLandingStageModelDto copyModel = result.stream()
                 .filter(stageModel -> stageModel.getStageCode().equals("landing-page-copy"))
                 .findFirst()
                 .orElseThrow();
-        assertThat(copyModel.getOpenAiModelId()).isNull();
+        assertThat(copyModel.getOpenAiModelId()).isEqualTo(88L);
+        assertThat(copyModel.getOpenAiModelCode()).isEqualTo("gpt-5.2");
+        assertThat(copyModel.getPriceInputFlex()).isEqualByComparingTo("0.875");
+        assertThat(copyModel.isDefaultModelApplied()).isTrue();
     }
 
     /**

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -4043,3 +4043,11 @@
 - causa-raiz: o changelog atualizava `pipeline_stage` e `pipeline_stage_definition` enquanto consultava as mesmas tabelas em subconsultas `NOT EXISTS`, padrão bloqueado pelo MySQL 5.7 com o erro 1093 (`You can't specify target table ... for update in FROM clause`).
 - foi feito: as validações de existência/conflito foram reescritas para `LEFT JOIN ... IS NULL`, evitando subconsultas sobre a tabela-alvo durante `UPDATE` e mantendo a idempotência das inserções das etapas GeraLanding.
 - impacto esperado: o backend deve conseguir concluir a execução do Liquibase e subir sem interromper o contexto Spring por essa migração.
+
+## 2026-06-07 — Custos flex e defaults de modelo na tela Gera Landing
+
+- solicitação: na aba Gera landing do experimento, exibir ao lado do modelo os custos em modo flex, calcular e totalizar custos por execução, por etapa e no total do experimento, além de explicitar se a etapa gera texto, imagem, vídeo ou áudio.
+- foi feito: o contrato `GET /api/pipelines/geralanding/stage-models` passou a retornar preços flex por 1M tokens, tipo de artefato gerado, modo de preço e indicação de modelo default aplicado quando a etapa não possui modelo associado.
+- foi feito: a tela passou a mostrar modelo, badge de default, tipo gerado, modo FLEX e custos de entrada/cache/saída; as totalizações já existentes por execução, etapa e total Gera Landing continuam somando `costUsd` das execuções concluídas/falhas retornadas pelos endpoints de histórico.
+- decisão operacional: quando a etapa não tem modelo configurado no pipeline, o backend usa `gpt-5.2` para etapas de texto e `gpt-image-1.5` para a etapa de geração de imagem; se o catálogo ainda não tiver o registro, o contrato mantém o código/nome default e retorna preços zerados para não quebrar a UI.
+- impacto esperado: o operador passa a enxergar antes de executar qual modelo/custo flex será usado e consegue acompanhar o custo acumulado no fluxo de geração da landing do experimento.

--- a/docs/swagger/pipeline-swagger.yaml
+++ b/docs/swagger/pipeline-swagger.yaml
@@ -142,6 +142,37 @@ components:
           type: string
           nullable: true
           example: gpt-vendas
+        priceInputFlex:
+          type: number
+          format: decimal
+          nullable: true
+          description: Preço flex por 1 milhão de tokens de entrada.
+          example: 0.875
+        priceInputCachedFlex:
+          type: number
+          format: decimal
+          nullable: true
+          description: Preço flex por 1 milhão de tokens de entrada em cache.
+          example: 0.0875
+        priceOutputFlex:
+          type: number
+          format: decimal
+          nullable: true
+          description: Preço flex por 1 milhão de tokens de saída.
+          example: 7.0
+        pricingMode:
+          type: string
+          nullable: true
+          example: flex
+        generatedAssetType:
+          type: string
+          nullable: true
+          enum: [texto, imagem, video, audio]
+          example: texto
+        defaultModelApplied:
+          type: boolean
+          description: Indica se o backend aplicou o modelo default por ausência de associação na etapa.
+          example: false
     PipelineMetadata:
       type: object
       required: [validModules, officialPipelines]

--- a/frontend/src/api/pipeline/useGeraLandingStageModels.ts
+++ b/frontend/src/api/pipeline/useGeraLandingStageModels.ts
@@ -10,6 +10,12 @@ export interface GeraLandingStageModel {
   openAiModelId?: number | null;
   openAiModelName?: string | null;
   openAiModelCode?: string | null;
+  priceInputFlex?: number | string | null;
+  priceInputCachedFlex?: number | string | null;
+  priceOutputFlex?: number | string | null;
+  pricingMode?: string | null;
+  generatedAssetType?: "texto" | "imagem" | "video" | "audio" | string | null;
+  defaultModelApplied?: boolean | null;
 }
 
 export function useGeraLandingStageModels() {

--- a/frontend/src/pages/experiment/ExperimentDetailPage.tsx
+++ b/frontend/src/pages/experiment/ExperimentDetailPage.tsx
@@ -44,15 +44,52 @@ import {
 } from "../../api/pipeline/useGeraLandingStageModels";
 
 function formatPipelineStageModel(stageModel?: GeraLandingStageModel) {
-  if (!stageModel?.openAiModelId) {
-    return null;
-  }
-  const name = stageModel.openAiModelName?.trim();
-  const code = stageModel.openAiModelCode?.trim();
+  const name = stageModel?.openAiModelName?.trim();
+  const code = stageModel?.openAiModelCode?.trim();
   if (name && code) {
     return `${name} (${code})`;
   }
-  return name || code || `Modelo #${stageModel.openAiModelId}`;
+  return (
+    name ||
+    code ||
+    (stageModel?.openAiModelId ? `Modelo #${stageModel.openAiModelId}` : null)
+  );
+}
+
+function parseCostValue(value?: number | string | null) {
+  if (value == null) return null;
+  if (typeof value === "number") return Number.isFinite(value) ? value : null;
+  const normalizedValue = value.replace(",", ".").trim();
+  if (!normalizedValue) return null;
+  const parsedValue = Number(normalizedValue);
+  return Number.isFinite(parsedValue) ? parsedValue : null;
+}
+
+function formatModelCostPerMillion(value?: number | string | null) {
+  const parsedValue = parseCostValue(value);
+  return parsedValue == null
+    ? "—"
+    : new Intl.NumberFormat("en-US", {
+        style: "currency",
+        currency: "USD",
+        minimumFractionDigits: 2,
+        maximumFractionDigits: 5,
+      }).format(parsedValue);
+}
+
+function formatGeneratedAssetType(value?: string | null) {
+  switch (value) {
+    case "texto":
+      return "Texto";
+    case "imagem":
+      return "Imagem";
+    case "video":
+      return "Vídeo";
+    case "audio":
+      return "Áudio";
+    default:
+      return value?.trim() || "Texto";
+  }
 }
 
 type ChecklistItem = {
@@ -1444,18 +1481,51 @@ export default function ExperimentDetailPage() {
   }, [geraLandingStageModels]);
 
   const renderSelectedGeraLandingModel = (stageCode: string) => {
-    const selectedModelLabel = formatPipelineStageModel(
-      selectedGeraLandingModelByStage.get(stageCode),
-    );
+    const selectedStageModel = selectedGeraLandingModelByStage.get(stageCode);
+    const selectedModelLabel = formatPipelineStageModel(selectedStageModel);
+    const pricingModeLabel = selectedStageModel?.pricingMode
+      ? selectedStageModel.pricingMode.toUpperCase()
+      : "FLEX";
 
     return (
-      <div className="small text-muted">
-        Modelo selecionado no pipeline:{" "}
-        <span className="fw-semibold text-body">
-          {isLoadingStageModels
-            ? "Carregando..."
-            : (selectedModelLabel ?? "Sem modelo fixo configurado")}
-        </span>
+      <div className="small text-muted d-flex flex-column gap-1">
+        <div>
+          Modelo selecionado no pipeline:{" "}
+          <span className="fw-semibold text-body">
+            {isLoadingStageModels
+              ? "Carregando..."
+              : (selectedModelLabel ?? "GPT-5.2 (gpt-5.2)")}
+          </span>
+          {!isLoadingStageModels && selectedStageModel?.defaultModelApplied ? (
+            <span className="badge text-bg-secondary ms-2">default</span>
+          ) : null}
+        </div>
+        <div className="d-flex flex-wrap align-items-center gap-2">
+          <span className="badge text-bg-light border">
+            Gera:{" "}
+            {formatGeneratedAssetType(selectedStageModel?.generatedAssetType)}
+          </span>
+          <span className="badge text-bg-light border">
+            Modo: {pricingModeLabel}
+          </span>
+          <span>
+            Entrada:{" "}
+            {formatModelCostPerMillion(selectedStageModel?.priceInputFlex)}/1M
+            tokens
+          </span>
+          <span>
+            Cache:{" "}
+            {formatModelCostPerMillion(
+              selectedStageModel?.priceInputCachedFlex,
+            )}
+            /1M tokens
+          </span>
+          <span>
+            Saída:{" "}
+            {formatModelCostPerMillion(selectedStageModel?.priceOutputFlex)}/1M
+            tokens
+          </span>
+        </div>
       </div>
     );
   };


### PR DESCRIPTION
### Motivation
- Make costs and model info visible on the Gera Landing tab so operators see which OpenAI model will be used (mode: flex), the per-1M-token prices and what asset the stage generates, and provide sensible defaults when no model is configured. 
- Allow the UI to compute/aggregate execution costs per execution, per pipeline stage and for the whole experiment while preserving existing cost accumulation from `costUsd` on executions.

### Description
- Backend: extended `GeraLandingStageModelDto` with `priceInputFlex`, `priceInputCachedFlex`, `priceOutputFlex`, `pricingMode`, `generatedAssetType` and `defaultModelApplied` fields and updated `PipelineService` to return stage-level model info including flex pricing and defaults; when a stage has no model the service now falls back to `gpt-5.2` for text stages and `gpt-image-1.5` for image stage and marks `defaultModelApplied=true`.
- Frontend API/types: added the new fields to `GeraLandingStageModel` interface (`frontend/src/api/pipeline/useGeraLandingStageModels.ts`).
- Frontend UI: enhanced `ExperimentDetailPage.tsx` to render model label plus badges showing pricing mode, generated asset type and formatted flex prices (input/cache/output), and kept existing cost totals that aggregate `costUsd` from stage executions.
- OpenAPI/docs: updated `docs/swagger/pipeline-swagger.yaml` and `docs/registros/experimentos.md` to document the new fields and the operational decision about defaults.
- Tests: adapted `PipelineServiceTest` to assert the new DTO values when available and the default model behavior when absent.

### Testing
- Ran targeted backend unit test `mvn -Dtest=PipelineServiceTest test` in `backend/ads-service`, which executed and validated the `listGeraLandingStageModels` behavior (passed).
- Ran full backend test suite `mvn test` in `backend/ads-service`; the build executed but the full suite produced runtime test errors in unrelated integration tests (scheduled tasks / lead-portal flows) while exercising many modules (observed failures/errors in the full run). The changes under test (pipeline model listing) are covered by the targeted unit test above which passed.
- Frontend: ran `npm install`, `npm run typecheck` (TS typecheck passed) and `npm run build` (Vite production build succeeded and produced `dist/`), and used Playwright to capture a screenshot of the updated Gera Landing UI (screenshot saved to `/tmp/geralanding-costs.png`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a257a1237388321ae83a4ae7a1800f3)