### PR TITLE
Corrige assinatura dos testes de analytics da landing

### DIFF
--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/funnel/ExperimentFunnelServiceRenderCompleteTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/funnel/ExperimentFunnelServiceRenderCompleteTest.java
@@ -174,7 +174,10 @@ class ExperimentFunnelServiceRenderCompleteTest {
                         "https://oportunidadebrasil.shop/page",
                         Instant.parse("2026-06-07T10:00:00Z"),
                         "JUnit Browser",
-                        "desktop"));
+                        "desktop",
+                        "other",
+                        null,
+                        null));
 
         ArgumentCaptor<ExperimentLandingAnalyticsEvent> normalizedCaptor =
                 ArgumentCaptor.forClass(ExperimentLandingAnalyticsEvent.class);
@@ -213,7 +216,10 @@ class ExperimentFunnelServiceRenderCompleteTest {
                         "https://oportunidadebrasil.shop/page",
                         Instant.parse("2026-06-07T10:01:00Z"),
                         "JUnit Browser",
-                        "desktop"));
+                        "desktop",
+                        "other",
+                        null,
+                        null));
 
         ArgumentCaptor<ExperimentLandingAnalyticsEvent> normalizedCaptor =
                 ArgumentCaptor.forClass(ExperimentLandingAnalyticsEvent.class);
@@ -253,7 +259,10 @@ class ExperimentFunnelServiceRenderCompleteTest {
                         "https://oportunidadebrasil.shop/page",
                         Instant.parse("2026-06-07T10:02:00Z"),
                         "JUnit Browser",
-                        "desktop"));
+                        "desktop",
+                        "other",
+                        null,
+                        null));
 
         verify(eventRepository).save(any(ExperimentFunnelEvent.class));
         verify(landingAnalyticsEventRepository).existsPageViewInDeduplicationWindow(

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -4051,3 +4051,10 @@
 - foi feito: o resumo backend do funil passou a consolidar percentuais por sistema operacional dentro das sessões mobile e as principais resoluções de tela capturadas.
 - foi feito: a aba Analytics do experimento passou a mostrar cards específicos para iOS/Android/outros e para resoluções de tela, além de detalhar esses dados nas sessões recentes.
 - impacto esperado: a decisão comercial sobre páginas e criativos mobile fica mais precisa, permitindo detectar predominância de iOS/Android e adaptar layout/oferta aos tamanhos reais de tela.
+
+## 2026-06-07 — Correção de compilação dos testes de analytics da landing
+
+- solicitação: corrigir a falha de compilação em `ExperimentFunnelServiceRenderCompleteTest` causada pela assinatura atual do contrato `RegisterLandingPageAnalyticsEventRequest`.
+- causa-raiz: três cenários de teste ainda instanciavam o record com a assinatura antiga de 11 campos, enquanto o contrato público de analytics passou a exigir também `operatingSystem`, `screenWidth` e `screenHeight`.
+- foi feito: os testes foram atualizados para enviar o sistema operacional e dimensões ausentes como parte do contrato atual, preservando os cenários de evento normalizado, evento legado sem `visitorId` e deduplicação de `page_view`.
+- validação: executados o teste específico de analytics do funil e a suíte unitária do módulo `ads-service`.


### PR DESCRIPTION
### Motivation
- Os testes de `ExperimentFunnelServiceRenderCompleteTest` falharam na compilação porque o `record` `RegisterLandingPageAnalyticsEventRequest` passou a exigir os campos `operatingSystem`, `screenWidth` e `screenHeight`, e três instâncias de teste ainda utilizavam a assinatura antiga.

### Description
- Atualizei as três instâncias de `new RegisterLandingPageAnalyticsEventRequest(...)` em `backend/ads-service/src/test/java/com/marketinghub/experiment/funnel/ExperimentFunnelServiceRenderCompleteTest.java` para enviar `operatingSystem`, `screenWidth` e `screenHeight` (uso de `"other"` e `null` para valores ausentes quando apropriado).
- Mantive os cenários de teste originais (evento normalizado com `visitorId`, evento legado sem `visitorId` e deduplicação de `page_view`) exatamente como eram, apenas ajustando a assinatura.
- Adicionei entrada em `docs/registros/experimentos.md` documentando a correção, a causa-raiz e a validação executada.

### Testing
- Executei o teste isolado com `mvn -q -Dtest=ExperimentFunnelServiceRenderCompleteTest test` e o teste específico passou com sucesso.
- Executei a suíte de testes do módulo com `mvn -q test` e a execução completa do módulo `ads-service` foi concluída com sucesso (sem erro de compilação relacionado ao ajuste). 
- Tentei rodar `mvn -q spotless:check`, mas o comando falhou porque o plugin Spotless não está disponível/configurado no ambiente Maven (`No plugin found for prefix 'spotless'`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a258cdca770832185ab51cb581cf7e3)