### PR TITLE
Ordena modelos OpenAI por maior preço

### DIFF
--- a/docs/registros/modelos-openai.md
+++ b/docs/registros/modelos-openai.md
@@ -6,3 +6,8 @@
 - Confirmado via MCP que a rotina das 04:00 America/Sao_Paulo executou em 2026-06-06 07:00 UTC e atualizou o modelo-base `gpt-5.5`, mas não atualizou a variante cadastrada `gpt-5.5-2026-04-23`, que permaneceu com preços zerados.
 - Corrigida a causa-raiz na sincronização diária: além de criar/atualizar os modelos-base publicados na fonte oficial de preços, a rotina agora percorre os modelos já cadastrados e aplica o preço-base mais específico às variantes datadas sem sobrescrever nome ou código da variante.
 - Adicionado teste unitário garantindo que `gpt-5.5-2026-04-23` herda os preços oficiais de `gpt-5.5` e preserva sua identidade operacional.
+
+## 2026-06-07 — Ordenação da listagem por preço
+
+- Ajustada a tela `/openai-models` para ordenar os modelos do mais caro para o mais barato usando o maior preço cadastrado entre as colunas standard e batch, preservando desempate determinístico por nome.
+- Adicionado teste unitário para garantir a ordenação decrescente por preço e o desempate por nome.

--- a/frontend/src/pages/openaiModel/OpenAiModelListPage.test.tsx
+++ b/frontend/src/pages/openaiModel/OpenAiModelListPage.test.tsx
@@ -1,0 +1,48 @@
+import { describe, expect, it } from "vitest";
+import type { OpenAiModel } from "../../api/openAiModel/useOpenAiModels";
+import { sortOpenAiModelsByHighestPrice } from "./OpenAiModelListPage";
+
+function model(overrides: Partial<OpenAiModel>): OpenAiModel {
+  return {
+    id: 1,
+    name: "Modelo base",
+    code: "modelo-base",
+    priceInputStandard: 0,
+    priceInputCachedStandard: 0,
+    priceOutputStandard: 0,
+    priceInputBatch: 0,
+    priceInputCachedBatch: 0,
+    priceOutputBatch: 0,
+    acceptsImageInput: false,
+    ...overrides,
+  };
+}
+
+describe("sortOpenAiModelsByHighestPrice", () => {
+  it("ordena os modelos do mais caro para o mais barato pelo maior preço cadastrado", () => {
+    const cheap = model({ id: 1, name: "Barato", priceOutputStandard: 2 });
+    const expensive = model({ id: 2, name: "Caro", priceOutputBatch: 30 });
+    const medium = model({
+      id: 3,
+      name: "Intermediário",
+      priceInputStandard: 10,
+    });
+
+    const sorted = sortOpenAiModelsByHighestPrice([cheap, expensive, medium]);
+
+    expect(sorted.map((item) => item.name)).toEqual([
+      "Caro",
+      "Intermediário",
+      "Barato",
+    ]);
+  });
+
+  it("mantém ordenação determinística por nome quando o maior preço empata", () => {
+    const beta = model({ id: 1, name: "Beta", priceOutputStandard: 10 });
+    const alpha = model({ id: 2, name: "Alpha", priceInputBatch: 10 });
+
+    const sorted = sortOpenAiModelsByHighestPrice([beta, alpha]);
+
+    expect(sorted.map((item) => item.name)).toEqual(["Alpha", "Beta"]);
+  });
+});

--- a/frontend/src/pages/openaiModel/OpenAiModelListPage.tsx
+++ b/frontend/src/pages/openaiModel/OpenAiModelListPage.tsx
@@ -1,6 +1,10 @@
+import { useMemo } from "react";
 import { Link, useNavigate } from "react-router-dom";
 import PageTitle from "../../components/PageTitle";
-import { useOpenAiModels } from "../../api/openAiModel/useOpenAiModels";
+import {
+  OpenAiModel,
+  useOpenAiModels,
+} from "../../api/openAiModel/useOpenAiModels";
 
 const priceFormatter = new Intl.NumberFormat("pt-BR", {
   minimumFractionDigits: 5,
@@ -12,10 +16,37 @@ function formatPrice(value?: number | null) {
   return priceFormatter.format(value);
 }
 
+function getHighestModelPrice(model: OpenAiModel) {
+  return Math.max(
+    model.priceInputStandard ?? 0,
+    model.priceInputCachedStandard ?? 0,
+    model.priceOutputStandard ?? 0,
+    model.priceInputBatch ?? 0,
+    model.priceInputCachedBatch ?? 0,
+    model.priceOutputBatch ?? 0,
+  );
+}
+
+export function sortOpenAiModelsByHighestPrice(models: OpenAiModel[]) {
+  return [...models].sort((first, second) => {
+    const priceDifference =
+      getHighestModelPrice(second) - getHighestModelPrice(first);
+
+    if (priceDifference !== 0) return priceDifference;
+
+    return first.name.localeCompare(second.name, "pt-BR", {
+      sensitivity: "base",
+    });
+  });
+}
+
 export default function OpenAiModelListPage() {
   const navigate = useNavigate();
   const { data, isLoading } = useOpenAiModels();
-  const models = Array.isArray(data) ? data : [];
+  const models = useMemo(
+    () => sortOpenAiModelsByHighestPrice(Array.isArray(data) ? data : []),
+    [data],
+  );
 
   if (isLoading) return <p>Carregando...</p>;
 


### PR DESCRIPTION
### Motivation
- A interface `/openai-models` precisava exibir os modelos do mais caro para o mais barato conforme solicitado pela tela, usando o maior preço disponível entre as colunas Standard e Batch.
- Garantir ordenação determinística quando há empate de preço para evitar flutuação visual na lista.

### Description
- Adiciona a função `getHighestModelPrice` e `sortOpenAiModelsByHighestPrice` em `frontend/src/pages/openaiModel/OpenAiModelListPage.tsx` para calcular o maior preço de cada modelo e ordenar decrescentemente por esse valor, com desempate por `name` (locale `pt-BR`).
- Usa `useMemo` para aplicar a ordenação sobre os dados retornados por `useOpenAiModels` antes de renderizar a tabela.
- Inclui teste unitário `frontend/src/pages/openaiModel/OpenAiModelListPage.test.tsx` cobrindo ordenação decrescente por preço e desempate por nome.
- Registra a alteração no histórico em `docs/registros/modelos-openai.md`.

### Testing
- Executado o teste de unidade com `npm --prefix frontend test -- OpenAiModelListPage.test.tsx --run` e todos os testes passaram (2 tests). ✅
- Verificação de tipagem com `npm --prefix frontend run typecheck` completou sem erros. ✅
- Build de produção com `npm --prefix frontend run build` completou com sucesso. ✅

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a25a67f56d4832197147bae3e266ffb)