### PR TITLE
Add visitor-recurrence API for landing analytics (GET /api/experiments/{id}/funnel/analytics/visitors)

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/funnel/ExperimentFunnelService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/funnel/ExperimentFunnelService.java
@@ -9,6 +9,8 @@ import com.marketinghub.experiment.funnel.service.analytics.ExperimentLandingAna
 import com.marketinghub.experiment.funnel.service.analytics.ExperimentLandingAnalyticsScreenSizeDto;
 import com.marketinghub.experiment.funnel.service.analytics.ExperimentLandingAnalyticsSectionDto;
 import com.marketinghub.experiment.funnel.service.analytics.ExperimentLandingAnalyticsSessionDto;
+import com.marketinghub.experiment.funnel.service.analytics.ExperimentLandingAnalyticsVisitorDto;
+import com.marketinghub.experiment.funnel.service.analytics.ExperimentLandingAnalyticsVisitorsDto;
 import com.marketinghub.leadportal.dto.LeadPortalSubmissionEngagementContractV1;
 import com.marketinghub.leadportal.dto.RegisterLandingPageAnalyticsEventRequest;
 import com.marketinghub.leadportal.dto.RegisterLeadPortalSubmissionRequest;
@@ -26,6 +28,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
 import java.sql.Timestamp;
+import java.time.Duration;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -135,6 +138,7 @@ public class ExperimentFunnelService {
         List<ExperimentLandingAnalyticsOperatingSystemDto> mobileOperatingSystemBreakdown =
                 buildMobileOperatingSystemBreakdown(sessions);
         List<ExperimentLandingAnalyticsScreenSizeDto> screenSizeBreakdown = buildScreenSizeBreakdown(sessions);
+        ExperimentLandingAnalyticsVisitorsDto visitors = summarizeLandingAnalyticsVisitors(experiment, baseline);
         return new ExperimentLandingAnalyticsDto(
                 rows.size(),
                 sessions.size(),
@@ -146,7 +150,85 @@ public class ExperimentFunnelService {
                 deviceBreakdown,
                 mobileOperatingSystemBreakdown,
                 screenSizeBreakdown,
+                visitors,
                 sessionDtos);
+    }
+
+    /**
+     * Consolida visitantes prováveis recorrentes da landing para apoiar decisão comercial do experimento.
+     */
+    public ExperimentLandingAnalyticsVisitorsDto summarizeLandingAnalyticsVisitors(Long experimentId) {
+        Experiment experiment = experimentRepository.findById(experimentId).orElseThrow();
+        Instant baseline = resolveBaseline(experiment);
+        return summarizeLandingAnalyticsVisitors(experiment, baseline);
+    }
+
+    /**
+     * Agrega visitantes prováveis a partir dos page_views normalizados já deduplicados.
+     */
+    private ExperimentLandingAnalyticsVisitorsDto summarizeLandingAnalyticsVisitors(Experiment experiment,
+                                                                                     Instant baseline) {
+        List<ExperimentLandingAnalyticsVisitorDto> visitors = landingAnalyticsEventRepository
+                .aggregateVisitorsByExperiment(experiment.getId(), baseline)
+                .stream()
+                .map(this::toVisitorDto)
+                .toList();
+        long recurrentVisitors = visitors.stream()
+                .filter(ExperimentLandingAnalyticsVisitorDto::recurrent)
+                .count();
+        return new ExperimentLandingAnalyticsVisitorsDto(
+                visitors.size(),
+                recurrentVisitors,
+                visitors.size() - recurrentVisitors,
+                visitors);
+    }
+
+    /**
+     * Converte a agregação SQL em DTO público, mascarando o visitorId antes de responder à API.
+     */
+    private ExperimentLandingAnalyticsVisitorDto toVisitorDto(
+            ExperimentLandingAnalyticsEventRepository.VisitorRecurrenceProjection projection) {
+        long intervalSeconds = secondsBetween(projection.getFirstAccessAt(), projection.getLastAccessAt());
+        boolean recurrent = projection.getTotalSessions() >= 2
+                || (projection.getValidPageViews() >= 2
+                        && intervalSeconds > PAGE_VIEW_DEDUPLICATION_WINDOW_SECONDS);
+        String deviceType = normalizeLandingAnalyticsDeviceType(null, projection.getLastUserAgent());
+        return new ExperimentLandingAnalyticsVisitorDto(
+                maskVisitorId(projection.getVisitorId()),
+                projection.getTotalSessions(),
+                projection.getValidPageViews(),
+                projection.getFirstAccessAt(),
+                projection.getLastAccessAt(),
+                intervalSeconds,
+                projection.getDistinctPages(),
+                projection.getLastUserAgent(),
+                deviceType,
+                landingAnalyticsDeviceLabel(deviceType),
+                recurrent);
+    }
+
+    /**
+     * Calcula o intervalo em segundos entre primeiro e último acesso válido do visitante provável.
+     */
+    private long secondsBetween(Instant firstAccessAt, Instant lastAccessAt) {
+        if (firstAccessAt == null || lastAccessAt == null) {
+            return 0;
+        }
+        return Math.max(0, Duration.between(firstAccessAt, lastAccessAt).getSeconds());
+    }
+
+    /**
+     * Mascara o identificador first-party para evitar exposição completa em resposta administrativa.
+     */
+    private String maskVisitorId(String visitorId) {
+        if (visitorId == null || visitorId.isBlank()) {
+            return "sem-visitante";
+        }
+        String normalized = visitorId.trim();
+        if (normalized.length() <= 8) {
+            return normalized.charAt(0) + "…" + normalized.charAt(normalized.length() - 1);
+        }
+        return normalized.substring(0, 4) + "…" + normalized.substring(normalized.length() - 4);
     }
 
     /**

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/funnel/service/analytics/ExperimentLandingAnalyticsDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/funnel/service/analytics/ExperimentLandingAnalyticsDto.java
@@ -17,5 +17,6 @@ public record ExperimentLandingAnalyticsDto(
         List<ExperimentLandingAnalyticsDeviceDto> deviceBreakdown,
         List<ExperimentLandingAnalyticsOperatingSystemDto> mobileOperatingSystemBreakdown,
         List<ExperimentLandingAnalyticsScreenSizeDto> screenSizeBreakdown,
+        ExperimentLandingAnalyticsVisitorsDto visitors,
         List<ExperimentLandingAnalyticsSessionDto> sessions) {
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/funnel/service/analytics/ExperimentLandingAnalyticsVisitorDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/funnel/service/analytics/ExperimentLandingAnalyticsVisitorDto.java
@@ -1,0 +1,20 @@
+package com.marketinghub.experiment.funnel.service.analytics;
+
+import java.time.Instant;
+
+/**
+ * Resume a recorrência de um visitante provável identificado por navegador/dispositivo first-party.
+ */
+public record ExperimentLandingAnalyticsVisitorDto(
+        String visitorId,
+        long totalSessions,
+        long validPageViews,
+        Instant firstAccessAt,
+        Instant lastAccessAt,
+        long intervalSeconds,
+        long distinctPages,
+        String lastUserAgent,
+        String deviceType,
+        String deviceLabel,
+        boolean recurrent) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/funnel/service/analytics/ExperimentLandingAnalyticsVisitorsDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/funnel/service/analytics/ExperimentLandingAnalyticsVisitorsDto.java
@@ -1,0 +1,13 @@
+package com.marketinghub.experiment.funnel.service.analytics;
+
+import java.util.List;
+
+/**
+ * Consolida visitantes prováveis e recorrentes capturados pela landing do experimento.
+ */
+public record ExperimentLandingAnalyticsVisitorsDto(
+        long probableVisitors,
+        long recurrentVisitors,
+        long singleVisitVisitors,
+        List<ExperimentLandingAnalyticsVisitorDto> visitors) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/web/ExperimentFunnelController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/web/ExperimentFunnelController.java
@@ -7,6 +7,7 @@ import com.marketinghub.experiment.funnel.dto.ExperimentFunnelResetResponse;
 import com.marketinghub.experiment.funnel.dto.ExperimentFunnelStageDto;
 import com.marketinghub.experiment.funnel.service.analytics.ExperimentLandingAnalyticsDto;
 import com.marketinghub.experiment.funnel.dto.RegisterExperimentFunnelEventRequest;
+import com.marketinghub.experiment.funnel.service.analytics.ExperimentLandingAnalyticsVisitorsDto;
 import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.*;
 
@@ -39,6 +40,13 @@ public class ExperimentFunnelController {
         return experimentFunnelService.summarizeLandingAnalytics(experimentId);
     }
 
+    /**
+     * Retorna os visitantes prováveis e a recorrência capturada pela landing publicada.
+     */
+    @GetMapping("/analytics/visitors")
+    public ExperimentLandingAnalyticsVisitorsDto landingAnalyticsVisitors(@PathVariable Long experimentId) {
+        return experimentFunnelService.summarizeLandingAnalyticsVisitors(experimentId);
+    }
 
     /**
      * Retorna os diagnósticos de qualidade e disponibilidade das métricas do funil.

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/experiment/funnel/ExperimentLandingAnalyticsEventRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/experiment/funnel/ExperimentLandingAnalyticsEventRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.time.Instant;
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -39,6 +40,82 @@ public interface ExperimentLandingAnalyticsEventRepository extends JpaRepository
                                                 @Param("pageUrl") String pageUrl,
                                                 @Param("windowStart") Instant windowStart,
                                                 @Param("windowEnd") Instant windowEnd);
+
+    /**
+     * Agrega page_views normalizados por visitante provável para análise de recorrência.
+     */
+    @Query(value = """
+            SELECT e.visitor_id AS visitorId,
+                   COUNT(DISTINCT e.session_id) AS totalSessions,
+                   SUM(CASE WHEN LOWER(e.event_type) = 'page_view' THEN 1 ELSE 0 END) AS validPageViews,
+                   MIN(e.occurred_at) AS firstAccessAt,
+                   MAX(e.occurred_at) AS lastAccessAt,
+                   COUNT(DISTINCT CASE
+                       WHEN LOWER(e.event_type) = 'page_view' AND e.page_url IS NOT NULL AND e.page_url <> ''
+                       THEN e.page_url
+                       ELSE NULL
+                   END) AS distinctPages,
+                   (
+                       SELECT e2.user_agent
+                       FROM experiment_landing_analytics_event e2
+                       WHERE e2.experiment_id = e.experiment_id
+                         AND e2.visitor_id = e.visitor_id
+                         AND (:baseline IS NULL OR e2.occurred_at > :baseline)
+                       ORDER BY e2.occurred_at DESC, e2.id DESC
+                       LIMIT 1
+                   ) AS lastUserAgent
+            FROM experiment_landing_analytics_event e
+            WHERE e.experiment_id = :experimentId
+              AND e.visitor_id IS NOT NULL
+              AND e.visitor_id <> ''
+              AND LOWER(e.event_type) = 'page_view'
+              AND (:baseline IS NULL OR e.occurred_at > :baseline)
+            GROUP BY e.experiment_id, e.visitor_id
+            ORDER BY MAX(e.occurred_at) DESC
+            """, nativeQuery = true)
+    List<VisitorRecurrenceProjection> aggregateVisitorsByExperiment(@Param("experimentId") Long experimentId,
+                                                                    @Param("baseline") Instant baseline);
+
+    /**
+     * Projeção agregada de recorrência por visitante provável da landing.
+     */
+    interface VisitorRecurrenceProjection {
+
+        /**
+         * Retorna o identificador first-party bruto usado apenas para mascaramento de resposta.
+         */
+        String getVisitorId();
+
+        /**
+         * Retorna a quantidade de sessões distintas associadas ao visitante provável.
+         */
+        long getTotalSessions();
+
+        /**
+         * Retorna a quantidade de page_views válidos após deduplicação operacional.
+         */
+        long getValidPageViews();
+
+        /**
+         * Retorna o primeiro acesso válido do visitante provável.
+         */
+        Instant getFirstAccessAt();
+
+        /**
+         * Retorna o último acesso válido do visitante provável.
+         */
+        Instant getLastAccessAt();
+
+        /**
+         * Retorna a quantidade de páginas distintas visualizadas pelo visitante provável.
+         */
+        long getDistinctPages();
+
+        /**
+         * Retorna o último user-agent observado para diagnóstico de dispositivo.
+         */
+        String getLastUserAgent();
+    }
 
     /**
      * Apaga eventos normalizados de analytics de um experimento antes de remover os eventos brutos vinculados.

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/funnel/ExperimentFunnelServiceRenderCompleteTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/funnel/ExperimentFunnelServiceRenderCompleteTest.java
@@ -5,6 +5,7 @@ import com.marketinghub.experiment.funnel.service.analytics.ExperimentLandingAna
 import com.marketinghub.repository.jpa.experiment.funnel.ExperimentFunnelEventRepository;
 import com.marketinghub.repository.jpa.experiment.funnel.ExperimentLandingAnalyticsEventRepository;
 import com.marketinghub.repository.jpa.experiment.funnel.ExperimentFunnelEventRepository.LandingAnalyticsEventProjection;
+import com.marketinghub.repository.jpa.experiment.funnel.ExperimentLandingAnalyticsEventRepository.VisitorRecurrenceProjection;
 import com.marketinghub.repository.jpa.experiment.ExperimentRepository;
 import com.marketinghub.repository.jpa.core.LeadRepository;
 import com.marketinghub.leadportal.dto.RegisterLandingPageAnalyticsEventRequest;
@@ -66,6 +67,8 @@ class ExperimentFunnelServiceRenderCompleteTest {
     void setUp() {
         lenient().when(landingAnalyticsEventRepository.findFirstByExperimentIdAndEventId(any(), any()))
                 .thenReturn(Optional.empty());
+        lenient().when(landingAnalyticsEventRepository.aggregateVisitorsByExperiment(any(), any()))
+                .thenReturn(List.of());
     }
 
     /**
@@ -344,6 +347,82 @@ class ExperimentFunnelServiceRenderCompleteTest {
         assertEquals(33.33, findScreenSizePercentage(summary.screenSizeBreakdown(), "390x844"));
     }
 
+
+    /**
+     * Valida que visitantes com sessões diferentes são marcados como recorrentes prováveis.
+     */
+    @Test
+    void summarizeLandingAnalyticsVisitorsMarksVisitorWithMultipleSessionsAsRecurrent() {
+        Experiment experiment = Experiment.builder().id(45L).build();
+        when(experimentRepository.findById(45L)).thenReturn(Optional.of(experiment));
+        when(landingAnalyticsEventRepository.aggregateVisitorsByExperiment(45L, null))
+                .thenReturn(List.of(visitorProjection(
+                        "visitor-recurrent-123",
+                        2,
+                        2,
+                        Instant.parse("2026-06-07T10:00:00Z"),
+                        Instant.parse("2026-06-07T11:00:00Z"),
+                        2,
+                        "Mozilla/5.0 (iPhone)")));
+
+        var summary = service.summarizeLandingAnalyticsVisitors(45L);
+
+        assertEquals(1, summary.probableVisitors());
+        assertEquals(1, summary.recurrentVisitors());
+        assertEquals(0, summary.singleVisitVisitors());
+        var visitor = summary.visitors().get(0);
+        assertEquals("visi…-123", visitor.visitorId());
+        assertEquals(2, visitor.totalSessions());
+        assertEquals(2, visitor.validPageViews());
+        assertEquals(3600, visitor.intervalSeconds());
+        assertEquals(2, visitor.distinctPages());
+        assertEquals("mobile", visitor.deviceType());
+        assertTrue(visitor.recurrent());
+    }
+
+    /**
+     * Valida que visitante com uma sessão e um page_view permanece classificado como único.
+     */
+    @Test
+    void summarizeLandingAnalyticsVisitorsKeepsSingleVisitorAsNotRecurrent() {
+        Experiment experiment = Experiment.builder().id(46L).build();
+        when(experimentRepository.findById(46L)).thenReturn(Optional.of(experiment));
+        when(landingAnalyticsEventRepository.aggregateVisitorsByExperiment(46L, null))
+                .thenReturn(List.of(visitorProjection(
+                        "visitor-single-456",
+                        1,
+                        1,
+                        Instant.parse("2026-06-07T10:00:00Z"),
+                        Instant.parse("2026-06-07T10:00:00Z"),
+                        1,
+                        "Mozilla/5.0 (X11; Linux x86_64)")));
+
+        var summary = service.summarizeLandingAnalyticsVisitors(46L);
+
+        assertEquals(1, summary.probableVisitors());
+        assertEquals(0, summary.recurrentVisitors());
+        assertEquals(1, summary.singleVisitVisitors());
+        assertEquals("visi…-456", summary.visitors().get(0).visitorId());
+        assertEquals(0, summary.visitors().get(0).intervalSeconds());
+        assertTrue(!summary.visitors().get(0).recurrent());
+    }
+
+    /**
+     * Valida que eventos legados sem visitorId não aparecem na lista de visitantes prováveis.
+     */
+    @Test
+    void summarizeLandingAnalyticsVisitorsIgnoresLegacyEventsWithoutVisitorId() {
+        Experiment experiment = Experiment.builder().id(47L).build();
+        when(experimentRepository.findById(47L)).thenReturn(Optional.of(experiment));
+        when(landingAnalyticsEventRepository.aggregateVisitorsByExperiment(47L, null)).thenReturn(List.of());
+
+        var summary = service.summarizeLandingAnalyticsVisitors(47L);
+
+        assertEquals(0, summary.probableVisitors());
+        assertEquals(0, summary.recurrentVisitors());
+        assertTrue(summary.visitors().isEmpty());
+    }
+
     /**
      * Valida que o resumo consolida page_view da landing junto com render-complete na visualização do formulário.
      */
@@ -412,6 +491,76 @@ class ExperimentFunnelServiceRenderCompleteTest {
             @Override
             public Instant getOccurredAt() {
                 return occurredAt;
+            }
+        };
+    }
+
+
+    /**
+     * Cria uma projeção agregada de visitante provável para testes de recorrência.
+     */
+    private VisitorRecurrenceProjection visitorProjection(String visitorId,
+                                                          long totalSessions,
+                                                          long validPageViews,
+                                                          Instant firstAccessAt,
+                                                          Instant lastAccessAt,
+                                                          long distinctPages,
+                                                          String lastUserAgent) {
+        return new VisitorRecurrenceProjection() {
+            /**
+             * Retorna o visitorId sintético do teste.
+             */
+            @Override
+            public String getVisitorId() {
+                return visitorId;
+            }
+
+            /**
+             * Retorna o total sintético de sessões do teste.
+             */
+            @Override
+            public long getTotalSessions() {
+                return totalSessions;
+            }
+
+            /**
+             * Retorna o total sintético de page_views válidos do teste.
+             */
+            @Override
+            public long getValidPageViews() {
+                return validPageViews;
+            }
+
+            /**
+             * Retorna o primeiro acesso sintético do teste.
+             */
+            @Override
+            public Instant getFirstAccessAt() {
+                return firstAccessAt;
+            }
+
+            /**
+             * Retorna o último acesso sintético do teste.
+             */
+            @Override
+            public Instant getLastAccessAt() {
+                return lastAccessAt;
+            }
+
+            /**
+             * Retorna a quantidade sintética de páginas distintas do teste.
+             */
+            @Override
+            public long getDistinctPages() {
+                return distinctPages;
+            }
+
+            /**
+             * Retorna o user-agent sintético do teste.
+             */
+            @Override
+            public String getLastUserAgent() {
+                return lastUserAgent;
             }
         };
     }

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -4075,3 +4075,17 @@
 - causa-raiz: três cenários de teste ainda instanciavam o record com a assinatura antiga de 11 campos, enquanto o contrato público de analytics passou a exigir também `operatingSystem`, `screenWidth` e `screenHeight`.
 - foi feito: os testes foram atualizados para enviar o sistema operacional e dimensões ausentes como parte do contrato atual, preservando os cenários de evento normalizado, evento legado sem `visitorId` e deduplicação de `page_view`.
 - validação: executados o teste específico de analytics do funil e a suíte unitária do módulo `ads-service`.
+
+## 2026-06-07 — Etapa 5 da identificação de visitante da landing
+
+- solicitação: executar a etapa 5 do plano de identificação de visitante da landing de experimento, focada na API backend de recorrência por visitante provável.
+- raciocínio: o analytics precisava responder se o mesmo `visitorId` first-party voltou em sessões ou horários diferentes, sem afirmar identidade civil ou pessoa comprovada.
+- foi feito: o backend passou a expor a recorrência em `GET /api/experiments/{experimentId}/funnel/analytics/visitors` e também inclui a seção `visitors` no resumo atual de analytics da landing.
+- foi feito: a consulta usa agregação SQL sobre `experiment_landing_analytics_event`, filtra `visitorId` nulo/legado no banco, conta sessões, `page_view`s válidos, páginas distintas, primeiro/último acesso, intervalo e último `userAgent`, retornando `visitorId` mascarado.
+- foi feito: testes unitários cobrem visitante recorrente, visitante único e ausência de visitantes prováveis quando só há eventos legados sem `visitorId`.
+- documentos lidos para pesquisar e resolver o problema:
+  - AGENTS.md
+  - backend/AGENTS.md
+  - docs/implementação/plano-identificacao-visitante-landing-experimento.md
+  - docs/canonical/procedimento-experimento-canon.v1.md
+  - docs/registros/experimentos.md

--- a/docs/swagger/openapi.yaml
+++ b/docs/swagger/openapi.yaml
@@ -127,6 +127,24 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/ExperimentLandingAnalytics'
+  /api/experiments/{experimentId}/funnel/analytics/visitors:
+    get:
+      tags: [Experiments]
+      summary: Consultar recorrência de visitantes prováveis da landing do experimento
+      parameters:
+        - in: path
+          name: experimentId
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: Visitantes prováveis agrupados por visitorId mascarado
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ExperimentLandingAnalyticsVisitors'
   /api/experiments/{id}/creatives:
     post:
       tags: [Creatives]
@@ -1072,10 +1090,65 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/ExperimentLandingAnalyticsScreenSize'
+        visitors:
+          $ref: '#/components/schemas/ExperimentLandingAnalyticsVisitors'
         sessions:
           type: array
           items:
             $ref: '#/components/schemas/ExperimentLandingAnalyticsSession'
+    ExperimentLandingAnalyticsVisitors:
+      type: object
+      properties:
+        probableVisitors:
+          type: integer
+          format: int64
+        recurrentVisitors:
+          type: integer
+          format: int64
+        singleVisitVisitors:
+          type: integer
+          format: int64
+        visitors:
+          type: array
+          items:
+            $ref: '#/components/schemas/ExperimentLandingAnalyticsVisitor'
+    ExperimentLandingAnalyticsVisitor:
+      type: object
+      properties:
+        visitorId:
+          type: string
+          description: visitorId mascarado/abreviado; não identifica pessoa comprovada.
+          example: visi…-123
+        totalSessions:
+          type: integer
+          format: int64
+        validPageViews:
+          type: integer
+          format: int64
+        firstAccessAt:
+          type: string
+          format: date-time
+          nullable: true
+        lastAccessAt:
+          type: string
+          format: date-time
+          nullable: true
+        intervalSeconds:
+          type: integer
+          format: int64
+        distinctPages:
+          type: integer
+          format: int64
+        lastUserAgent:
+          type: string
+          nullable: true
+        deviceType:
+          type: string
+          enum: [mobile, desktop, tablet]
+        deviceLabel:
+          type: string
+        recurrent:
+          type: boolean
     ExperimentLandingAnalyticsSession:
       type: object
       properties:


### PR DESCRIPTION
### Motivation
- Provide a backend API to answer whether a probable first-party visitor (visitorId) returned across different sessions for an experiment's landing, without claiming deterministic identity. 
- Enable analytics consumers and the experiment UI to see aggregated recurrence metrics per masked visitorId for safer commercial decisions.

### Description
- Added a visitors aggregation query to `ExperimentLandingAnalyticsEventRepository` (`aggregateVisitorsByExperiment`) with a projection that returns sessions, page_views, first/last access, distinct pages and last user-agent. 
- Implemented service-side aggregation and DTOs: new `ExperimentLandingAnalyticsVisitorDto` and `ExperimentLandingAnalyticsVisitorsDto`, plus `summarizeLandingAnalyticsVisitors(...)` and helper methods in `ExperimentFunnelService` (masking, interval calc and conversion). 
- Exposed the new endpoint `GET /api/experiments/{experimentId}/funnel/analytics/visitors` in `ExperimentFunnelController` and included a `visitors` section in the existing landing analytics DTO/response. 
- Updated OpenAPI/Swagger (`docs/swagger/openapi.yaml`) and implementation docs (`docs/registros/experimentos.md`) to document the new contract and added unit tests that cover visitor recurrence scenarios.

### Testing
- Ran `ExperimentFunnelServiceRenderCompleteTest` (13 tests) and it passed (13/13, 0 failures). 
- Executed the `ads-service` unit test suite via Maven (`./mvnw test` for the module) and the build/tests completed successfully with no failing tests. 
- Added unit tests for visitor recurrence covering: recurrent visitor (multiple sessions), single-visit visitor, and ignoring legacy events without `visitorId`, and these tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a25a770d40083219a5a8b2043686181)