### PR TITLE
Estimate OpenAI costs from backend pricing catalog

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/openai/core/openai/OpenAiClientProperties.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/openai/core/openai/OpenAiClientProperties.java
@@ -5,10 +5,9 @@ import jakarta.validation.constraints.NotNull;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.validation.annotation.Validated;
 
-import java.math.BigDecimal;
 import java.time.Duration;
 
-/** Responsabilidade: centralizar credenciais, modelo, custo e URL efetiva dos clientes OpenAI. */
+/** Responsabilidade: centralizar credenciais, modelo, catálogo de preços e URL efetiva dos clientes OpenAI. */
 @Validated
 @ConfigurationProperties(prefix = "openai")
 public record OpenAiClientProperties(
@@ -24,9 +23,8 @@ public record OpenAiClientProperties(
         @NotNull
         Duration timeout,
 
-        BigDecimal inputUsdPerMillionTokens,
-
-        BigDecimal outputUsdPerMillionTokens,
+        @NotBlank
+        String pricingCatalogUrl,
 
         boolean allowLocalBaseUrl
 ) {
@@ -36,11 +34,8 @@ public record OpenAiClientProperties(
         if (timeout == null) {
             timeout = Duration.ofMinutes(30);
         }
-        if (inputUsdPerMillionTokens == null) {
-            inputUsdPerMillionTokens = BigDecimal.ZERO;
-        }
-        if (outputUsdPerMillionTokens == null) {
-            outputUsdPerMillionTokens = BigDecimal.ZERO;
+        if (pricingCatalogUrl == null || pricingCatalogUrl.isBlank()) {
+            pricingCatalogUrl = "http://191.252.181.168/api/modelos/openai/catalogo/v1/modelos";
         }
     }
 }

--- a/ai-worker/src/main/java/com/marketinghub/worker/openai/core/openai/OpenAiCostEstimator.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/openai/core/openai/OpenAiCostEstimator.java
@@ -1,30 +1,49 @@
 package com.marketinghub.worker.openai.core.openai;
 
+import com.marketinghub.worker.openai.core.exception.StageWorkerException;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
+import java.util.Objects;
 
+/** Responsabilidade: calcular custo de uso OpenAI com preços obtidos do catálogo persistido no backend. */
 public class OpenAiCostEstimator {
 
-    private final BigDecimal inputUsdPerMillionTokens;
-    private final BigDecimal outputUsdPerMillionTokens;
+    private static final BigDecimal ONE_MILLION = BigDecimal.valueOf(1_000_000);
 
-    public OpenAiCostEstimator(
-            BigDecimal inputUsdPerMillionTokens,
-            BigDecimal outputUsdPerMillionTokens
-    ) {
-        this.inputUsdPerMillionTokens = inputUsdPerMillionTokens == null ? BigDecimal.ZERO : inputUsdPerMillionTokens;
-        this.outputUsdPerMillionTokens = outputUsdPerMillionTokens == null ? BigDecimal.ZERO : outputUsdPerMillionTokens;
+    private final OpenAiModelPricingCatalogClient pricingCatalogClient;
+
+    /** Inicializa o estimador com o cliente que consulta o catálogo de preços persistido no banco pelo backend. */
+    public OpenAiCostEstimator(OpenAiModelPricingCatalogClient pricingCatalogClient) {
+        this.pricingCatalogClient = Objects.requireNonNull(pricingCatalogClient, "pricingCatalogClient must not be null");
     }
 
-    public BigDecimal estimate(Integer inputTokens, Integer outputTokens) {
+    /** Estima o custo usando o modelo efetivo do request e os preços batch/flex cadastrados no banco. */
+    public BigDecimal estimate(String model, Integer inputTokens, Integer outputTokens) {
+        OpenAiModelPricingCatalogClient.OpenAiModelPricing pricing = pricingCatalogClient.findByCode(model)
+                .orElseThrow(() -> new StageWorkerException(
+                        "Modelo OpenAI não encontrado no catálogo persistido para cálculo de custo: " + model));
+        return estimateWithPricing(pricing, inputTokens, outputTokens);
+    }
+
+    /** Aplica a tarifa por milhão de tokens aos totais de entrada e saída retornados pela OpenAI. */
+    private BigDecimal estimateWithPricing(
+            OpenAiModelPricingCatalogClient.OpenAiModelPricing pricing,
+            Integer inputTokens,
+            Integer outputTokens
+    ) {
         BigDecimal input = BigDecimal.valueOf(inputTokens == null ? 0 : inputTokens)
-                .multiply(inputUsdPerMillionTokens)
-                .divide(BigDecimal.valueOf(1_000_000), 8, RoundingMode.HALF_UP);
+                .multiply(nullToZero(pricing.priceInputBatch()))
+                .divide(ONE_MILLION, 8, RoundingMode.HALF_UP);
 
         BigDecimal output = BigDecimal.valueOf(outputTokens == null ? 0 : outputTokens)
-                .multiply(outputUsdPerMillionTokens)
-                .divide(BigDecimal.valueOf(1_000_000), 8, RoundingMode.HALF_UP);
+                .multiply(nullToZero(pricing.priceOutputBatch()))
+                .divide(ONE_MILLION, 8, RoundingMode.HALF_UP);
 
         return input.add(output).setScale(8, RoundingMode.HALF_UP);
+    }
+
+    /** Normaliza preços ausentes no catálogo para zero sem mascarar a ausência do modelo. */
+    private BigDecimal nullToZero(BigDecimal value) {
+        return value == null ? BigDecimal.ZERO : value;
     }
 }

--- a/ai-worker/src/main/java/com/marketinghub/worker/openai/core/openai/OpenAiModelPricingCatalogClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/openai/core/openai/OpenAiModelPricingCatalogClient.java
@@ -1,0 +1,99 @@
+package com.marketinghub.worker.openai.core.openai;
+
+import com.marketinghub.worker.openai.core.exception.StageWorkerException;
+import java.math.BigDecimal;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.web.reactive.function.client.WebClient;
+
+/** Responsabilidade: consultar no backend o catálogo de modelos OpenAI persistido no banco de dados. */
+public class OpenAiModelPricingCatalogClient {
+
+    private static final Logger log = LoggerFactory.getLogger(OpenAiModelPricingCatalogClient.class);
+
+    private final WebClient webClient;
+    private final OpenAiClientProperties properties;
+    private final AtomicReference<Map<String, OpenAiModelPricing>> cachedPricingByCode = new AtomicReference<>(Map.of());
+
+    /** Inicializa o cliente HTTP com a URL do endpoint backend que expõe a tabela openai_model. */
+    public OpenAiModelPricingCatalogClient(WebClient.Builder builder, OpenAiClientProperties properties) {
+        this.webClient = Objects.requireNonNull(builder, "builder must not be null").build();
+        this.properties = Objects.requireNonNull(properties, "properties must not be null");
+    }
+
+    /** Busca o preço do modelo por código, recarregando o catálogo do backend quando o cache ainda não contém o modelo. */
+    public Optional<OpenAiModelPricing> findByCode(String modelCode) {
+        String normalizedCode = normalizeModelCode(modelCode);
+        if (normalizedCode == null) {
+            return Optional.empty();
+        }
+
+        OpenAiModelPricing cached = cachedPricingByCode.get().get(normalizedCode);
+        if (cached != null) {
+            return Optional.of(cached);
+        }
+
+        Map<String, OpenAiModelPricing> refreshed = refreshCatalog();
+        return Optional.ofNullable(refreshed.get(normalizedCode));
+    }
+
+    /** Recarrega do backend os modelos e preços cadastrados na tabela openai_model. */
+    private Map<String, OpenAiModelPricing> refreshCatalog() {
+        String catalogUrl = properties.pricingCatalogUrl();
+        if (catalogUrl == null || catalogUrl.isBlank()) {
+            throw new StageWorkerException("URL do catálogo de preços OpenAI do backend não configurada");
+        }
+
+        try {
+            List<OpenAiModelPricing> models = webClient.get()
+                    .uri(catalogUrl)
+                    .retrieve()
+                    .bodyToFlux(OpenAiModelPricing.class)
+                    .collectList()
+                    .block(properties.timeout());
+
+            Map<String, OpenAiModelPricing> pricingByCode = (models == null ? List.<OpenAiModelPricing>of() : models)
+                    .stream()
+                    .filter(model -> normalizeModelCode(model.code()) != null)
+                    .collect(Collectors.toUnmodifiableMap(
+                            model -> normalizeModelCode(model.code()),
+                            Function.identity(),
+                            (first, ignored) -> first));
+            cachedPricingByCode.set(pricingByCode);
+            log.info(
+                    "Catálogo de preços OpenAI carregado do backend [pricingCatalogUrl={}, modelCount={}]",
+                    catalogUrl,
+                    pricingByCode.size());
+            return pricingByCode;
+        } catch (RuntimeException ex) {
+            log.error(
+                    "Falha ao consultar catálogo de preços OpenAI no backend [pricingCatalogUrl={}]",
+                    catalogUrl,
+                    ex);
+            throw ex;
+        }
+    }
+
+    /** Normaliza o código de modelo para comparar com o cadastro persistido no banco. */
+    private String normalizeModelCode(String modelCode) {
+        if (modelCode == null || modelCode.isBlank()) {
+            return null;
+        }
+        return modelCode.trim().toLowerCase(Locale.ROOT);
+    }
+
+    /** DTO mínimo do catálogo backend com preços batch/flex por milhão de tokens. */
+    public record OpenAiModelPricing(
+            String code,
+            BigDecimal priceInputBatch,
+            BigDecimal priceOutputBatch
+    ) {}
+}

--- a/ai-worker/src/main/java/com/marketinghub/worker/openai/core/openai/ResponsesApiOpenAiClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/openai/core/openai/ResponsesApiOpenAiClient.java
@@ -40,11 +40,8 @@ public class ResponsesApiOpenAiClient implements OpenAiClientPort {
     ) {
         this.objectMapper = Objects.requireNonNull(objectMapper, "objectMapper must not be null");
         this.properties = Objects.requireNonNull(properties, "properties must not be null");
-        this.costEstimator = new OpenAiCostEstimator(
-                properties.inputUsdPerMillionTokens(),
-                properties.outputUsdPerMillionTokens()
-        );
-        this.webClient = builder
+        this.costEstimator = new OpenAiCostEstimator(new OpenAiModelPricingCatalogClient(builder.clone(), properties));
+        this.webClient = builder.clone()
                 .baseUrl(properties.baseUrl())
                 .defaultHeader("Authorization", "Bearer " + properties.apiKey())
                 .defaultHeader("Content-Type", "application/json")
@@ -91,7 +88,7 @@ public class ResponsesApiOpenAiClient implements OpenAiClientPort {
                     modelResponse,
                     inputTokens,
                     outputTokens,
-                    costEstimator.estimate(inputTokens, outputTokens)
+                    costEstimator.estimate(request.model(), inputTokens, outputTokens)
             );
 
             if (openAiJobId != null) {

--- a/ai-worker/src/main/resources/application.properties
+++ b/ai-worker/src/main/resources/application.properties
@@ -12,6 +12,7 @@ openai.api-key=${OPENAI_API_KEY:}
 openai.model=${OPENAI_MODEL:gpt-5.2}
 openai.targeting-request-model=${OPENAI_TARGETING_REQUEST_MODEL:gpt-4.1}
 openai.base-url=${OPENAI_BASE_URL:https://api.openai.com/v1}
+openai.pricing-catalog-url=${OPENAI_PRICING_CATALOG_URL:${backend.base-url}${backend.api-prefix}/modelos/openai/catalogo/v1/modelos}
 openai.allow-local-base-url=${OPENAI_ALLOW_LOCAL_BASE_URL:false}
 openai.batch-timeout=${OPENAI_BATCH_TIMEOUT:PT30M}
 openai.batch-poll-interval=${OPENAI_BATCH_POLL_INTERVAL:PT0.5S}

--- a/ai-worker/src/test/java/com/marketinghub/worker/openai/core/openai/ResponsesApiOpenAiClientTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/openai/core/openai/ResponsesApiOpenAiClientTest.java
@@ -10,6 +10,7 @@ import ch.qos.logback.core.read.ListAppender;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marketinghub.worker.openai.core.exception.OpenAiHttpException;
+import com.marketinghub.worker.openai.core.exception.StageWorkerException;
 import com.marketinghub.worker.openai.core.model.OpenAiRequest;
 import java.math.BigDecimal;
 import java.time.Duration;
@@ -62,14 +63,7 @@ class ResponsesApiOpenAiClientTest {
         ResponsesApiOpenAiClient client = new ResponsesApiOpenAiClient(
                 WebClient.builder(),
                 new ObjectMapper(),
-                new OpenAiClientProperties(
-                        "test-key",
-                        server.url("/").toString(),
-                        "gpt-test",
-                        Duration.ofSeconds(5),
-                        BigDecimal.ZERO,
-                        BigDecimal.ZERO,
-                        true));
+                properties("gpt-test"));
         String requestBodyJson = "{\"model\":\"gpt-test\",\"input\":\"Prompt\"}";
         OpenAiRequest request = new OpenAiRequest(
                 "gpt-test",
@@ -123,17 +117,11 @@ class ResponsesApiOpenAiClientTest {
                           "usage": {"input_tokens": 10, "output_tokens": 5}
                         }
                         """));
+        enqueuePricingCatalog("gpt-test", "1.00", "4.00");
         ResponsesApiOpenAiClient client = new ResponsesApiOpenAiClient(
                 WebClient.builder(),
                 new ObjectMapper(),
-                new OpenAiClientProperties(
-                        "test-key",
-                        server.url("/").toString(),
-                        "gpt-test",
-                        Duration.ofSeconds(5),
-                        BigDecimal.ZERO,
-                        BigDecimal.ZERO,
-                        true));
+                properties("gpt-test"));
         OpenAiRequest request = new OpenAiRequest(
                 "gpt-test",
                 "Prompt",
@@ -157,4 +145,109 @@ class ResponsesApiOpenAiClientTest {
                 new TypeReference<>() {});
         assertThat(dispatchPayload).containsEntry("service_tier", "flex");
     }
+
+    /** Deve estimar custo em modo flex pelo modelo do request quando a configuração não informa tarifa explícita. */
+    @Test
+    void dispatchShouldEstimateFlexCostFromRequestModelWhenPricingPropertiesAreUnset() throws Exception {
+        server.enqueue(new MockResponse()
+                .setResponseCode(200)
+                .setHeader("Content-Type", "application/json")
+                .setBody("""
+                        {
+                          "id": "resp-cost",
+                          "output": [
+                            {
+                              "type": "message",
+                              "content": [
+                                {"type": "output_text", "text": "{\\"ok\\":true}"}
+                              ]
+                            }
+                          ],
+                          "usage": {"input_tokens": 1000000, "output_tokens": 1000000}
+                        }
+                        """));
+        enqueuePricingCatalog("gpt-5.4", "1.25", "7.50");
+        ResponsesApiOpenAiClient client = new ResponsesApiOpenAiClient(
+                WebClient.builder(),
+                new ObjectMapper(),
+                properties("gpt-5.4"));
+        OpenAiRequest request = new OpenAiRequest(
+                "gpt-5.4",
+                "Prompt",
+                "{\"model\":\"gpt-5.4\",\"input\":\"Prompt\"}",
+                "schema-wireframe",
+                "{\"type\":\"object\"}",
+                "# Prompt markdown bruto",
+                Map.of("idJob", "job-cost"));
+
+        var dispatch = client.dispatch(request);
+        var result = client.awaitResult(dispatch);
+
+        assertThat(result.inputTokens()).isEqualTo(1000000);
+        assertThat(result.outputTokens()).isEqualTo(1000000);
+        assertThat(result.costUsd()).isEqualByComparingTo(new BigDecimal("8.75000000"));
+    }
+
+    /** Deve falhar quando o modelo efetivo não existir no catálogo persistido do backend. */
+    @Test
+    void dispatchShouldFailWhenRequestModelIsMissingFromBackendPricingCatalog() throws Exception {
+        server.enqueue(new MockResponse()
+                .setResponseCode(200)
+                .setHeader("Content-Type", "application/json")
+                .setBody("""
+                        {
+                          "id": "resp-missing-cost",
+                          "output_text": "{\\"ok\\":true}",
+                          "usage": {"input_tokens": 1000, "output_tokens": 2000}
+                        }
+                        """));
+        enqueuePricingCatalog("gpt-other", "10", "20");
+        ResponsesApiOpenAiClient client = new ResponsesApiOpenAiClient(
+                WebClient.builder(),
+                new ObjectMapper(),
+                properties("gpt-test"));
+        OpenAiRequest request = new OpenAiRequest(
+                "gpt-test",
+                "Prompt",
+                "{\"model\":\"gpt-test\",\"input\":\"Prompt\"}",
+                "schema-wireframe",
+                "{\"type\":\"object\"}",
+                "# Prompt markdown bruto",
+                Map.of("idJob", "job-missing-cost"));
+
+        Throwable thrown = catchThrowable(() -> client.dispatch(request));
+
+        assertThat(thrown)
+                .isInstanceOf(StageWorkerException.class)
+                .hasMessageContaining("Modelo OpenAI não encontrado no catálogo persistido")
+                .hasMessageContaining("gpt-test");
+    }
+
+    /** Monta propriedades OpenAI apontando o catálogo de preços para o mock do backend. */
+    private OpenAiClientProperties properties(String model) {
+        return new OpenAiClientProperties(
+                "test-key",
+                server.url("/").toString(),
+                model,
+                Duration.ofSeconds(5),
+                server.url("/api/modelos/openai/catalogo/v1/modelos").toString(),
+                true);
+    }
+
+    /** Simula o endpoint backend que lista os modelos persistidos na tabela openai_model. */
+    private void enqueuePricingCatalog(String code, String inputBatchPrice, String outputBatchPrice) {
+        server.enqueue(new MockResponse()
+                .setResponseCode(200)
+                .setHeader("Content-Type", "application/json")
+                .setBody("""
+                        [
+                          {
+                            "code": "%s",
+                            "priceInputBatch": %s,
+                            "priceOutputBatch": %s
+                          }
+                        ]
+                        """.formatted(code, inputBatchPrice, outputBatchPrice)));
+    }
+
 }

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -4089,3 +4089,13 @@
   - docs/implementação/plano-identificacao-visitante-landing-experimento.md
   - docs/canonical/procedimento-experimento-canon.v1.md
   - docs/registros/experimentos.md
+
+## 2026-06-07 — Correção do cálculo de custo OpenAI no Worker AI
+
+- solicitação: verificar por que o custo das execuções do GeraLanding aparecia como `$0.00` mesmo com modelo selecionado e resposta concluída.
+- causa-raiz: o cliente compartilhado da Responses API forçava `service_tier=flex`, mas o estimador de custo dependia apenas das propriedades `openai.inputUsdPerMillionTokens` e `openai.outputUsdPerMillionTokens`; como essas propriedades não estavam configuradas, o construtor normalizava ambas para zero e persistia `costUsd=0` nas conclusões enviadas ao backend.
+- foi feito: removida a tabela hardcoded de preços do Worker AI; o estimador passou a identificar o modelo efetivo do request e consultar o catálogo persistido no backend, que lê a tabela `openai_model`.
+- foi feito: configurado `openai.pricing-catalog-url` apontando para `GET /api/modelos/openai/catalogo/v1/modelos`, preservando a regra de que o Worker AI não acessa o banco diretamente.
+- foi feito: o cliente Responses API agora calcula o custo com `priceInputBatch` e `priceOutputBatch` retornados do banco para o modelo efetivo, mantendo a auditoria de tokens (`inputTokens`/`outputTokens`) e enviando `costUsd` calculado ao backend.
+- validação: adicionados testes unitários para confirmar cálculo via catálogo backend, URL de catálogo configurada e falha explícita quando o modelo não existe na tabela de preços.
+- observação operacional: os jobs já concluídos com `costUsd=0` não são recalculados automaticamente por essa alteração; novas execuções passam a gravar o custo correto a partir dos tokens retornados pela OpenAI.


### PR DESCRIPTION
### Motivation

- Corrigir cálculo de custo que vinha sendo registrado como `$0.00` quando as propriedades de tarifa não eram configuradas, passando a usar o catálogo de preços persistido no backend por modelo.

### Description

- Substituído os campos `inputUsdPerMillionTokens`/`outputUsdPerMillionTokens` em `OpenAiClientProperties` por `pricingCatalogUrl` e adicionada uma URL padrão configurável via `openai.pricing-catalog-url`.
- Adicionado `OpenAiModelPricingCatalogClient` que consulta e faz cache do catálogo de preços exposto pelo backend em `GET /api/modelos/openai/catalogo/v1/modelos` e fornece o DTO `OpenAiModelPricing`.
- Refatorado `OpenAiCostEstimator` para receber um `OpenAiModelPricingCatalogClient`, expor `estimate(String model, Integer inputTokens, Integer outputTokens)` e aplicar `priceInputBatch`/`priceOutputBatch` por milhão de tokens tratando valores nulos como zero; lança `StageWorkerException` quando o modelo não é encontrado no catálogo.
- Atualizado `ResponsesApiOpenAiClient` para construir o estimador com o novo cliente de catálogo e chamar `costEstimator.estimate(request.model(), ...)` ao construir o `OpenAiResult`.
- Atualizado `application.properties` com a chave `openai.pricing-catalog-url` e estendidos os testes em `ResponsesApiOpenAiClientTest` para mockar o catálogo do backend e validar cálculo e falha quando o modelo não existe.

### Testing

- Executados os testes unitários em `ResponsesApiOpenAiClientTest`, incluindo `dispatchShouldLogFlexOpenAiRequestWhenHttpErrorHappens` e `dispatchShouldForceFlexServiceTierInOpenAiPayloadAndDispatch`, além dos novos `dispatchShouldEstimateFlexCostFromRequestModelWhenPricingPropertiesAreUnset` e `dispatchShouldFailWhenRequestModelIsMissingFromBackendPricingCatalog`, todos passando com sucesso.
- Asserções de tokens, `costUsd` calculado e comportamento de falha por modelo ausente foram verificadas nas execuções dos testes automatizados.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a25aca4fe188321b8eeb34bb651b2cb)