### PR TITLE
Increase HTML capture timeout to 5 minutes for backend and worker

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibrarySnapshotService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibrarySnapshotService.java
@@ -42,10 +42,11 @@ public class MoisSalesLibrarySnapshotService {
     private static final int MAX_LIMIT = 20;
     private static final Duration FAILED_RETRY_COOLDOWN = Duration.ofHours(24);
     private static final int MAX_FAILED_ATTEMPTS_WITHOUT_FORCE = 3;
+    private static final Duration CAPTURE_REQUEST_TIMEOUT = Duration.ofMinutes(5);
 
     private final JdbcTemplate jdbcTemplate;
     private final HttpClient httpClient = HttpClient.newBuilder()
-            .connectTimeout(Duration.ofSeconds(15))
+            .connectTimeout(CAPTURE_REQUEST_TIMEOUT)
             .followRedirects(HttpClient.Redirect.NORMAL)
             .build();
 
@@ -474,7 +475,7 @@ public class MoisSalesLibrarySnapshotService {
     /** Executa GET HTTP com follow redirect para obter o HTML efetivo. */
     private CaptureResponse fetchUrl(String url) throws Exception {
         HttpRequest request = HttpRequest.newBuilder(URI.create(url))
-                .timeout(Duration.ofSeconds(30))
+                .timeout(CAPTURE_REQUEST_TIMEOUT)
                 .GET()
                 .header("User-Agent", "MarketingHub-MOIS-SalesLibrary/1.0")
                 .build();

--- a/docs/canonical/mois-worker-canon.v1.md
+++ b/docs/canonical/mois-worker-canon.v1.md
@@ -58,7 +58,7 @@ O worker seleciona a fonte por ciclo com a seguinte ordem canônica:
 - `worker.source` → `${MOIS_SOURCE:CLICKBANK}`
 - `worker.sources` → `${MOIS_SOURCES:}`
 - `worker.poll-interval-ms` → `${MOIS_POLL_INTERVAL_MS:15000}`
-- `worker.request-timeout-ms` → `${MOIS_REQUEST_TIMEOUT_MS:30000}`
+- `worker.request-timeout-ms` → `${MOIS_REQUEST_TIMEOUT_MS:300000}`
 
 ### 7.2 OpenAI
 - `openai.model` → `${OPENAI_MODEL:gpt-5.2}`
@@ -569,6 +569,7 @@ A primeira etapa do pipeline de páginas de venda deve separar responsabilidades
 8. URLs com 3 ou mais snapshots `FAILED` devem sair da seleção automática normal até uma revisão/acionamento forçado, preservando capacidade do pipeline para páginas que realmente entregam HTML útil.
 9. Falhas de captura devem ser categorizadas no `error_message` com prefixo operacional claro, por exemplo `HTTP_404`, `DESTINATION_DNS_FAILURE`, `REDIRECT_WITHOUT_HTML`, `TIMEOUT`, `FINAL_URL_UNAVAILABLE` ou `CAPTURE_EXCEPTION`.
 10. O acionamento `force=true` é reservado para revisão operacional e pode ignorar cooldown/limite de falhas, mantendo a decisão explícita e auditável.
+11. O timeout operacional padrão para captura HTTP/HTML da Biblioteca de Páginas de Vendas é de **5 minutos** (`300000 ms` / `PT5M`) tanto no backend quanto no worker, para reduzir falhas falsas em páginas lentas sem remover a auditoria de falhas reais.
 
 Contratos operacionais do backend:
 

--- a/docs/novos-modulos/mois-biblioteca-pagina-venda/especificacao-worker-biblioteca-sales-pages.md
+++ b/docs/novos-modulos/mois-biblioteca-pagina-venda/especificacao-worker-biblioteca-sales-pages.md
@@ -113,7 +113,7 @@ Defaults atuais no projeto:
 - `MOIS_WORKSPACE_ID=workspace-001`
 - `MOIS_SOURCE=CLICKBANK`
 - `MOIS_POLL_INTERVAL_MS=15000`
-- `MOIS_REQUEST_TIMEOUT_MS=30000`
+- `MOIS_REQUEST_TIMEOUT_MS=300000`
 
 ## 8. Observabilidade (obrigatório)
 

--- a/docs/registros/mois1.md
+++ b/docs/registros/mois1.md
@@ -1,3 +1,14 @@
+## 2026-06-07 — Timeout de captura HTML ampliado para 5 minutos
+
+- aumentado o timeout de captura HTTP/HTML da Biblioteca de Páginas de Vendas do MOIS para 5 minutos (`300000 ms`) no backend e no worker.
+- atualizado o cânone MOIS para registrar o novo timeout operacional padrão de captura, mantendo cooldown e limite de falhas como proteção contra loops improdutivos.
+- atualizado o documento de especificação do worker para refletir o novo valor padrão de `MOIS_REQUEST_TIMEOUT_MS`.
+- documentos/códigos consultados:
+  - backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibrarySnapshotService.java
+  - mois-sales-library-worker/src/main/resources/application.yml
+  - docs/canonical/mois-worker-canon.v1.md
+  - docs/novos-modulos/mois-biblioteca-pagina-venda/especificacao-worker-biblioteca-sales-pages.md
+
 
 ## 2026-06-03 — Bootstrap Hotmart 400 para Biblioteca de Páginas de Vendas
 

--- a/mois-sales-library-worker/src/main/resources/application.yml
+++ b/mois-sales-library-worker/src/main/resources/application.yml
@@ -32,7 +32,7 @@ worker:
   html-capture-poll-interval-ms: ${MOIS_HTML_CAPTURE_POLL_INTERVAL_MS:20000}
   html-capture-limit: ${MOIS_HTML_CAPTURE_LIMIT:1}
   html-capture-force: ${MOIS_HTML_CAPTURE_FORCE:false}
-  request-timeout-ms: ${MOIS_REQUEST_TIMEOUT_MS:30000}
+  request-timeout-ms: ${MOIS_REQUEST_TIMEOUT_MS:300000}
 
 openai:
   api-key: ${OPENAI_API_KEY:}


### PR DESCRIPTION
### Motivation
- Reduce false negatives on slow sales pages by increasing the HTTP/HTML capture timeout from 30 seconds to 5 minutes across the capture pipeline.
- Preserve existing operational protections such as the 24-hour failed-retry cooldown and the max-failed-attempts limit to avoid retry storms.
- Keep canonical documentation and worker specification aligned with the operational timeout change.

### Description
- Add `CAPTURE_REQUEST_TIMEOUT` (`Duration.ofMinutes(5)`) in `MoisSalesLibrarySnapshotService` and apply it to the `HttpClient` `connectTimeout` and the `HttpRequest` `.timeout()` calls in the capture flow.
- Update the worker default `worker.request-timeout-ms` in `application.yml` to `300000` (5 minutes) and reflect the same default in `docs/canonical/mois-worker-canon.v1.md` and the worker specification document.
- Record the change in `docs/registros/mois1.md` to document the operational update.

### Testing
- No automated tests were added or modified for this change and no automated test run was included with this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a25aad033808321821d08c54b7dff59)