### PR TITLE
MOIS: show analysis date, limit list to 20 recent analyses and order by analysis date

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryService.java
@@ -438,7 +438,7 @@ public class MoisSalesLibraryService {
     }
 
     /**
-     * Lista páginas canônicas a partir do estado consolidado do modelo novo da Fase 4.
+     * Lista páginas canônicas consolidadas priorizando as análises mais recentes para a UI operacional.
      */
     public MoisSalesLibraryDtos.SalesLibraryPageListResponse listPages(String workspaceId, int page, int pageSize) {
         int normalizedPage = Math.max(1, page);
@@ -452,7 +452,7 @@ public class MoisSalesLibraryService {
                        last_error_category, last_error_message, last_job_execution_id, last_captured_at, last_analyzed_at, updated_at
                 FROM mois_sales_page
                 WHERE workspace_id = ?
-                ORDER BY updated_at DESC, id DESC LIMIT ? OFFSET ?
+                ORDER BY last_analyzed_at DESC, updated_at DESC, id DESC LIMIT ? OFFSET ?
                 """, this::mapSalesPageResponse, workspaceId, normalizedPageSize, offset);
         return new MoisSalesLibraryDtos.SalesLibraryPageListResponse(normalizedPage, normalizedPageSize, total == null ? 0 : total, items);
     }

--- a/backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryServiceTest.java
@@ -134,6 +134,28 @@ class MoisSalesLibraryServiceTest {
     }
 
     /**
+     * Garante que a listagem de páginas prioriza as análises mais recentes.
+     */
+    @Test
+    void shouldListPagesOrderedByMostRecentAnalysisDate() {
+        given(jdbcTemplate.queryForObject(
+                eq("SELECT COUNT(*) FROM mois_sales_page WHERE workspace_id = ?"),
+                eq(Long.class),
+                eq("workspace-001")))
+                .willReturn(42L);
+        given(jdbcTemplate.query(any(String.class), isA(RowMapper.class), eq("workspace-001"), eq(20), eq(0)))
+                .willReturn(List.of());
+
+        MoisSalesLibraryDtos.SalesLibraryPageListResponse response = service.listPages("workspace-001", 1, 20);
+
+        org.assertj.core.api.Assertions.assertThat(response.pageSize()).isEqualTo(20);
+        ArgumentCaptor<String> sqlCaptor = ArgumentCaptor.forClass(String.class);
+        verify(jdbcTemplate).query(sqlCaptor.capture(), isA(RowMapper.class), eq("workspace-001"), eq(20), eq(0));
+        org.assertj.core.api.Assertions.assertThat(sqlCaptor.getValue())
+                .contains("ORDER BY last_analyzed_at DESC, updated_at DESC, id DESC LIMIT ? OFFSET ?");
+    }
+
+    /**
      * Garante que o claim de HTML bruto lê a tabela de referências coletadas e retorna a URL reservada.
      */
     @Test

--- a/docs/registros/mois1.md
+++ b/docs/registros/mois1.md
@@ -1125,3 +1125,16 @@ Arquivos alterados:
 Arquivos alterados:
 - `frontend/src/pages/mois/MoisSalesPagesPipelinePage.tsx`
 - `docs/registros/mois1.md`
+
+## 2026-06-08 — Listagem das 20 análises mais recentes na biblioteca MOIS
+
+- ajustada a tela `/mois/sales-pages-library` para exibir somente 20 páginas por requisição, com coluna explícita de data da análise.
+- ajustada a ordenação do endpoint de páginas operacionais para priorizar `last_analyzed_at` em ordem decrescente, preservando `updated_at` e `id` como desempate.
+- adicionada cobertura unitária e documentação Swagger para proteger a ordenação por data de análise mais recente.
+
+Arquivos alterados:
+- `frontend/src/pages/mois/MoisSalesPagesLibraryPage.tsx`
+- `backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryService.java`
+- `backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryServiceTest.java`
+- `docs/swagger/mois-sales-library-swagger.yaml`
+- `docs/registros/mois1.md`

--- a/docs/swagger/mois-sales-library-swagger.yaml
+++ b/docs/swagger/mois-sales-library-swagger.yaml
@@ -91,6 +91,37 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/CollectedReferenceUrlSummaryResponse'
+  /pages:
+    get:
+      summary: Lista páginas operacionais consolidadas
+      description: Retorna páginas de `mois_sales_page` ordenadas por `last_analyzed_at` decrescente, com `updated_at` e `id` como desempate; a UI principal consome as 20 análises mais recentes usando `pageSize=20`.
+      tags: [MOIS Sales Library]
+      parameters:
+        - in: query
+          name: workspaceId
+          required: true
+          schema:
+            type: string
+        - in: query
+          name: page
+          schema:
+            type: integer
+            default: 1
+            minimum: 1
+        - in: query
+          name: pageSize
+          schema:
+            type: integer
+            default: 20
+            minimum: 1
+            maximum: 100
+      responses:
+        '200':
+          description: Páginas consolidadas ordenadas da análise mais recente para a mais antiga
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SalesLibraryPageListResponse'
   /pages/summary:
     get:
       summary: Resume páginas operacionais consolidadas
@@ -604,6 +635,96 @@ components:
           type: array
           items:
             $ref: '#/components/schemas/CollectedReferenceUrlTypeBreakdown'
+    SalesLibraryPageResponse:
+      type: object
+      properties:
+        pageId:
+          type: integer
+          format: int64
+        workspaceId:
+          type: string
+        source:
+          type: string
+        urlCanonical:
+          type: string
+        title:
+          type: string
+          nullable: true
+        currentStage:
+          type: string
+          nullable: true
+        currentStatus:
+          type: string
+          nullable: true
+        captureStatus:
+          type: string
+          nullable: true
+        analysisStatus:
+          type: string
+          nullable: true
+        urlFinal:
+          type: string
+          nullable: true
+        httpStatus:
+          type: integer
+          nullable: true
+        htmlSha256:
+          type: string
+          nullable: true
+        htmlBytes:
+          type: integer
+          format: int64
+        scoreTotal:
+          type: number
+          nullable: true
+        offerSummary:
+          type: string
+          nullable: true
+        mechanismSummary:
+          type: string
+          nullable: true
+        promiseSummary:
+          type: string
+          nullable: true
+        proofSummary:
+          type: string
+          nullable: true
+        lastErrorCategory:
+          type: string
+          nullable: true
+        lastErrorMessage:
+          type: string
+          nullable: true
+        lastJobExecutionId:
+          type: integer
+          format: int64
+          nullable: true
+        lastCapturedAt:
+          type: string
+          format: date-time
+          nullable: true
+        analyzedAt:
+          type: string
+          format: date-time
+          nullable: true
+          description: Data da análise comercial mais recente, derivada de `mois_sales_page.last_analyzed_at`.
+        updatedAt:
+          type: string
+          format: date-time
+    SalesLibraryPageListResponse:
+      type: object
+      properties:
+        page:
+          type: integer
+        pageSize:
+          type: integer
+        total:
+          type: integer
+          format: int64
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/SalesLibraryPageResponse'
     SalesLibraryPageSummaryResponse:
       type: object
       properties:

--- a/frontend/src/pages/mois/MoisSalesPagesLibraryPage.tsx
+++ b/frontend/src/pages/mois/MoisSalesPagesLibraryPage.tsx
@@ -7,7 +7,7 @@ import {
 } from "../../api/mois/useMoisSalesLibrary";
 
 const WORKSPACE_ID = "workspace-001";
-const PAGE_SIZE = 100;
+const PAGE_SIZE = 20;
 
 function getPipelinePhase(stage?: string | null, status?: string | null) {
   if (stage === "CAPTURE" && status === "FAILED") {
@@ -26,6 +26,16 @@ function getPipelinePhase(stage?: string | null, status?: string | null) {
     return "Bloqueada por cooldown";
   }
   return stage && status ? `${stage} — ${status}` : "Sem fase definida";
+}
+
+function formatAnalysisDate(value?: string | null) {
+  if (!value) {
+    return "—";
+  }
+  return new Intl.DateTimeFormat("pt-BR", {
+    dateStyle: "short",
+    timeStyle: "short",
+  }).format(new Date(value));
 }
 
 export default function MoisSalesPagesLibraryPage() {
@@ -112,6 +122,7 @@ export default function MoisSalesPagesLibraryPage() {
                   <th>Produto</th>
                   <th>Origem</th>
                   <th>Status</th>
+                  <th>Data da análise</th>
                   <th>Fase no diagrama</th>
                   <th>Ações</th>
                 </tr>
@@ -119,7 +130,7 @@ export default function MoisSalesPagesLibraryPage() {
               <tbody>
                 {pagesQuery.data.items.length === 0 ? (
                   <tr>
-                    <td colSpan={5} className="text-secondary">
+                    <td colSpan={6} className="text-secondary">
                       Nenhum produto coletado encontrado.
                     </td>
                   </tr>
@@ -138,6 +149,9 @@ export default function MoisSalesPagesLibraryPage() {
                             item.analysisStatus ||
                             "SEM STATUS"}
                         </span>
+                      </td>
+                      <td className="text-nowrap">
+                        {formatAnalysisDate(item.analyzedAt)}
                       </td>
                       <td>
                         {getPipelinePhase(


### PR DESCRIPTION
### Motivation
- Make the MOIS sales-pages library show the analysis timestamp to help prioritize recently analyzed pages and reduce list size for quicker decision making.
- Ensure the UI displays the 20 most relevant (most recently analyzed) pages and that backend ordering cannot be accidentally regressed.

### Description
- Frontend: limit list page size to 20, add a `Data da análise` column and `formatAnalysisDate` helper, and display `item.analyzedAt` in `frontend/src/pages/mois/MoisSalesPagesLibraryPage.tsx`.
- Backend: change `listPages` SQL ordering to `ORDER BY last_analyzed_at DESC, updated_at DESC, id DESC` and update the method comment in `backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryService.java`.
- Tests & docs: add a unit test verifying the ordering SQL in `MoisSalesLibraryServiceTest.java` and document the `/pages` contract and `SalesLibraryPageResponse` schema in `docs/swagger/mois-sales-library-swagger.yaml` and record the change in `docs/registros/mois1.md`.

### Testing
- Ran Java unit tests: `mvn -Dtest=MoisSalesLibraryServiceTest test` and the targeted test class passed (10 tests, 0 failures).
- Ran frontend typecheck: `npm run typecheck` (after `npm ci`) and TypeScript checks completed successfully.
- Attempted visual verification with Playwright screenshot (`npx playwright screenshot ...`) but it failed in this environment due to a missing native dependency (`libatk-1.0.so.0`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2613a175708321b3f97309c94454dc)