### PR TITLE
Introduce generic pipeline framework and deliverables worker with backend endpoints

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/pipeline/ArtifactStore.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/pipeline/ArtifactStore.java
@@ -1,0 +1,9 @@
+package com.marketinghub.worker.pipeline;
+
+import java.util.Map;
+
+/** Responsabilidade: abstrair a gravação ou referência dos artefatos produzidos pelas etapas do pipeline. */
+public interface ArtifactStore {
+    /** Registra um artefato textual ou JSON e devolve sua referência auditável. */
+    StageArtifact save(String type, String name, String contentType, String content, Map<String, Object> metadata);
+}

--- a/ai-worker/src/main/java/com/marketinghub/worker/pipeline/InMemoryArtifactStore.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/pipeline/InMemoryArtifactStore.java
@@ -1,0 +1,33 @@
+package com.marketinghub.worker.pipeline;
+
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.HexFormat;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/** Responsabilidade: manter referências auditáveis em memória para artefatos já persistidos nos contratos do backend. */
+public class InMemoryArtifactStore implements ArtifactStore {
+    private final Map<String, String> contentByStorageKey = new ConcurrentHashMap<>();
+
+    /** Calcula hash, guarda o conteúdo em memória e retorna uma referência auditável para o ciclo atual. */
+    @Override
+    public StageArtifact save(String type, String name, String contentType, String content, Map<String, Object> metadata) {
+        String safeContent = content == null ? "" : content;
+        String sha256 = sha256(safeContent);
+        String storageKey = "memory://pipeline/" + type + "/" + sha256 + "/" + name;
+        contentByStorageKey.put(storageKey, safeContent);
+        return new StageArtifact(type, name, contentType, storageKey, sha256, metadata);
+    }
+
+    /** Calcula o SHA-256 textual usado para rastrear igualdade entre artefatos do pipeline. */
+    private String sha256(String content) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            return HexFormat.of().formatHex(digest.digest(content.getBytes(StandardCharsets.UTF_8)));
+        } catch (NoSuchAlgorithmException ex) {
+            throw new IllegalStateException("SHA-256 indisponível para ArtifactStore", ex);
+        }
+    }
+}

--- a/ai-worker/src/main/java/com/marketinghub/worker/pipeline/PipelineWorker.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/pipeline/PipelineWorker.java
@@ -1,0 +1,44 @@
+package com.marketinghub.worker.pipeline;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+
+/** Responsabilidade: orquestrar execuções de etapas sem conhecer tecnologias ou etapas concretas. */
+public class PipelineWorker<I, O> {
+    private final StageBackendPort<I, O> backendPort;
+    private final StageProcessor<I, O> processor;
+    private final ArtifactStore artifactStore;
+
+    /** Inicializa o worker genérico com port de backend, processor concreto e store de artefatos. */
+    public PipelineWorker(StageBackendPort<I, O> backendPort, StageProcessor<I, O> processor, ArtifactStore artifactStore) {
+        this.backendPort = Objects.requireNonNull(backendPort, "backendPort must not be null");
+        this.processor = Objects.requireNonNull(processor, "processor must not be null");
+        this.artifactStore = Objects.requireNonNull(artifactStore, "artifactStore must not be null");
+    }
+
+    /** Processa até o limite de execuções pendentes retornadas pelo backend da etapa. */
+    public ProcessingSummary processPending(int limit) {
+        List<StageExecution<I>> pending = backendPort.listPending(limit);
+        List<StageWorkerResult> results = new ArrayList<>();
+        for (StageExecution<I> execution : pending) {
+            results.add(process(execution));
+        }
+        return ProcessingSummary.from(results);
+    }
+
+    /** Processa uma execução individual, atualizando status de sucesso ou falha no backend. */
+    public StageWorkerResult process(StageExecution<I> execution) {
+        Objects.requireNonNull(execution, "execution must not be null");
+        try {
+            backendPort.markRunning(execution);
+            StageContext<I> context = new StageContext<>(execution, execution.input(), artifactStore, execution.config());
+            StageResult<O> result = processor.process(context);
+            backendPort.markCompleted(execution, result);
+            return StageWorkerResult.success(execution.idJob());
+        } catch (Exception error) {
+            backendPort.markFailed(execution, error);
+            return StageWorkerResult.failure(execution.idJob(), error);
+        }
+    }
+}

--- a/ai-worker/src/main/java/com/marketinghub/worker/pipeline/ProcessingSummary.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/pipeline/ProcessingSummary.java
@@ -1,0 +1,14 @@
+package com.marketinghub.worker.pipeline;
+
+import java.time.Instant;
+import java.util.List;
+
+/** Responsabilidade: consolidar a quantidade de execuções processadas pelo ciclo do worker. */
+public record ProcessingSummary(boolean enabled, int total, int succeeded, int failed, Instant processedAt) {
+    /** Consolida resultados individuais do worker em um resumo operacional. */
+    public static ProcessingSummary from(List<StageWorkerResult> results) {
+        int succeeded = (int) results.stream().filter(StageWorkerResult::success).count();
+        int failed = results.size() - succeeded;
+        return new ProcessingSummary(true, results.size(), succeeded, failed, Instant.now());
+    }
+}

--- a/ai-worker/src/main/java/com/marketinghub/worker/pipeline/StageArtifact.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/pipeline/StageArtifact.java
@@ -1,0 +1,18 @@
+package com.marketinghub.worker.pipeline;
+
+import java.util.Map;
+
+/** Responsabilidade: referenciar um artefato auditável usado ou gerado por uma etapa do pipeline. */
+public record StageArtifact(
+        String type,
+        String name,
+        String contentType,
+        String storageKey,
+        String sha256,
+        Map<String, Object> metadata
+) {
+    /** Normaliza metadados opcionais para evitar nulos na auditoria do pipeline. */
+    public StageArtifact {
+        metadata = metadata == null ? Map.of() : Map.copyOf(metadata);
+    }
+}

--- a/ai-worker/src/main/java/com/marketinghub/worker/pipeline/StageBackendPort.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/pipeline/StageBackendPort.java
@@ -1,0 +1,18 @@
+package com.marketinghub.worker.pipeline;
+
+import java.util.List;
+
+/** Responsabilidade: abstrair a comunicação do worker genérico com o backend dono do estado da etapa. */
+public interface StageBackendPort<I, O> {
+    /** Lista execuções pendentes para processamento. */
+    List<StageExecution<I>> listPending(int limit);
+
+    /** Marca uma execução como em processamento antes da etapa chamar integrações externas. */
+    void markRunning(StageExecution<I> execution);
+
+    /** Persiste a conclusão bem-sucedida da etapa. */
+    void markCompleted(StageExecution<I> execution, StageResult<O> result);
+
+    /** Persiste a falha da etapa com contexto suficiente para diagnóstico. */
+    void markFailed(StageExecution<I> execution, Throwable error);
+}

--- a/ai-worker/src/main/java/com/marketinghub/worker/pipeline/StageContext.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/pipeline/StageContext.java
@@ -1,0 +1,20 @@
+package com.marketinghub.worker.pipeline;
+
+import java.util.Map;
+import java.util.Objects;
+
+/** Responsabilidade: agrupar execução, entrada, store de artefatos e configuração para um processor de etapa. */
+public record StageContext<I>(
+        StageExecution<I> execution,
+        I input,
+        ArtifactStore artifactStore,
+        Map<String, Object> config
+) {
+    /** Garante que o processor receba execução, entrada, artifact store e configuração não nulos. */
+    public StageContext {
+        Objects.requireNonNull(execution, "execution must not be null");
+        Objects.requireNonNull(input, "input must not be null");
+        Objects.requireNonNull(artifactStore, "artifactStore must not be null");
+        config = config == null ? Map.of() : Map.copyOf(config);
+    }
+}

--- a/ai-worker/src/main/java/com/marketinghub/worker/pipeline/StageExecution.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/pipeline/StageExecution.java
@@ -1,0 +1,24 @@
+package com.marketinghub.worker.pipeline;
+
+import java.time.Instant;
+import java.util.Map;
+import java.util.Objects;
+
+/** Responsabilidade: transportar os dados de uma execução de etapa independente de tecnologia concreta. */
+public record StageExecution<I>(
+        String idJob,
+        Long aggregateId,
+        String stageCode,
+        String status,
+        Instant executionRequestedAt,
+        I input,
+        Map<String, Object> config
+) {
+    /** Valida campos obrigatórios e normaliza configuração opcional da execução. */
+    public StageExecution {
+        Objects.requireNonNull(idJob, "idJob must not be null");
+        Objects.requireNonNull(stageCode, "stageCode must not be null");
+        Objects.requireNonNull(input, "input must not be null");
+        config = config == null ? Map.of() : Map.copyOf(config);
+    }
+}

--- a/ai-worker/src/main/java/com/marketinghub/worker/pipeline/StageProcessor.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/pipeline/StageProcessor.java
@@ -1,0 +1,7 @@
+package com.marketinghub.worker.pipeline;
+
+/** Responsabilidade: definir o contrato único de execução de uma etapa concreta do pipeline. */
+public interface StageProcessor<I, O> {
+    /** Processa a entrada da etapa e retorna saída estruturada com artefatos e métricas. */
+    StageResult<O> process(StageContext<I> context);
+}

--- a/ai-worker/src/main/java/com/marketinghub/worker/pipeline/StageResult.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/pipeline/StageResult.java
@@ -1,0 +1,17 @@
+package com.marketinghub.worker.pipeline;
+
+import java.util.List;
+import java.util.Map;
+
+/** Responsabilidade: transportar saída estruturada, artefatos e métricas de uma execução de etapa. */
+public record StageResult<O>(
+        O output,
+        List<StageArtifact> artifacts,
+        Map<String, Object> metrics
+) {
+    /** Normaliza listas e mapas opcionais para simplificar consumidores do resultado. */
+    public StageResult {
+        artifacts = artifacts == null ? List.of() : List.copyOf(artifacts);
+        metrics = metrics == null ? Map.of() : Map.copyOf(metrics);
+    }
+}

--- a/ai-worker/src/main/java/com/marketinghub/worker/pipeline/StageWorkerResult.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/pipeline/StageWorkerResult.java
@@ -1,0 +1,14 @@
+package com.marketinghub.worker.pipeline;
+
+/** Responsabilidade: resumir o resultado operacional do processamento de uma execução de etapa. */
+public record StageWorkerResult(String idJob, boolean success, String errorMessage) {
+    /** Cria resultado de sucesso para uma execução processada. */
+    public static StageWorkerResult success(String idJob) {
+        return new StageWorkerResult(idJob, true, null);
+    }
+
+    /** Cria resultado de falha para uma execução processada. */
+    public static StageWorkerResult failure(String idJob, Throwable error) {
+        return new StageWorkerResult(idJob, false, error != null ? error.getMessage() : "Unknown error");
+    }
+}

--- a/ai-worker/src/main/java/com/marketinghub/worker/pipeline/deliverables/DeliverablesBackendClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/pipeline/deliverables/DeliverablesBackendClient.java
@@ -1,0 +1,325 @@
+package com.marketinghub.worker.pipeline.deliverables;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marketinghub.worker.openai.core.model.OpenAiRequest;
+import com.marketinghub.worker.openai.core.model.OpenAiResult;
+import com.marketinghub.worker.pipeline.StageBackendPort;
+import com.marketinghub.worker.pipeline.StageExecution;
+import com.marketinghub.worker.pipeline.StageResult;
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.springframework.core.ParameterizedTypeReference;
+import org.springframework.web.reactive.function.client.WebClient;
+
+/** Responsabilidade: integrar a etapa deliverables do pipeline aos endpoints internos do backend. */
+public class DeliverablesBackendClient implements StageBackendPort<DeliverablesInput, DeliverablesOutput> {
+    private static final String STATUS_STARTED = "INICIADO";
+    private final WebClient webClient;
+    private final DeliverablesWorkerProperties properties;
+    private final ObjectMapper objectMapper;
+
+    /** Inicializa o cliente com WebClient, propriedades de deliverables e ObjectMapper para normalizar artefatos. */
+    public DeliverablesBackendClient(WebClient.Builder builder, DeliverablesWorkerProperties properties, ObjectMapper objectMapper) {
+        this.webClient = builder.build();
+        this.properties = properties;
+        this.objectMapper = objectMapper;
+    }
+
+    /** Busca no backend os jobs de deliverables iniciados e aptos para processamento. */
+    @Override
+    public List<StageExecution<DeliverablesInput>> listPending(int limit) {
+        int effectiveLimit = Math.max(1, limit);
+        String uri = joinPath(properties.backendBaseUrl(), properties.apiPrefix(), "/internal/geralanding/deliverables/stage-executions/pending");
+        List<Map<String, Object>> payload = webClient.get()
+                .uri(uri)
+                .retrieve()
+                .bodyToMono(new ParameterizedTypeReference<List<Map<String, Object>>>() {})
+                .block(properties.timeout());
+        if (payload == null || payload.isEmpty()) {
+            return List.of();
+        }
+        return payload.stream()
+                .map(this::toStageExecution)
+                .filter(item -> item.aggregateId() != null && item.idJob() != null)
+                .limit(effectiveLimit)
+                .toList();
+    }
+
+    /** Marca a execução como em processamento para impedir recaptura em ciclos concorrentes. */
+    @Override
+    public void markRunning(StageExecution<DeliverablesInput> execution) {
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("experimentId", execution.aggregateId());
+        body.put("stageCode", execution.stageCode());
+        webClient.post()
+                .uri(stageExecutionBaseUrl() + "/{idJob}/running", execution.idJob())
+                .bodyValue(body)
+                .retrieve()
+                .bodyToMono(Void.class)
+                .block(properties.timeout());
+    }
+
+    /** Persiste no backend o prompt renderizado, schema e request bruto enviados para OpenAI. */
+    public void saveOpenAiRequest(StageExecution<DeliverablesInput> execution, OpenAiRequest request) {
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("experimentId", execution.aggregateId());
+        body.put("stageCode", execution.stageCode());
+        body.put("prompt", request.prompt());
+        body.put("promptMarkdownContent", request.promptMarkdownContent());
+        body.put("schemaJson", request.schemaJson());
+        body.put("requestBodyJson", request.requestBodyJson());
+        body.put("openAiModel", request.model());
+        webClient.post()
+                .uri(stageExecutionBaseUrl() + "/{idJob}/recebe-prompt", execution.idJob())
+                .bodyValue(body)
+                .retrieve()
+                .bodyToMono(Void.class)
+                .block(properties.timeout());
+    }
+
+    /** Envia ao backend a resposta validada da OpenAI para concluir a etapa deliverables. */
+    @Override
+    public void markCompleted(StageExecution<DeliverablesInput> execution, StageResult<DeliverablesOutput> result) {
+        OpenAiResult<String> openAiResult = openAiResult(result);
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("experimentId", execution.aggregateId());
+        body.put("stageCode", execution.stageCode());
+        body.put("modelResponse", openAiResult.modelResponse());
+        body.put("inputTokens", openAiResult.inputTokens());
+        body.put("outputTokens", openAiResult.outputTokens());
+        body.put("costUsd", openAiResult.costUsd());
+        body.put("openAiJobId", openAiResult.openAiJobId());
+        body.put("errorMessage", null);
+        body.put("errorDetail", null);
+        webClient.post()
+                .uri(stageExecutionBaseUrl() + "/{idJob}/recebe-resposta", execution.idJob())
+                .bodyValue(body)
+                .retrieve()
+                .bodyToMono(Void.class)
+                .block(properties.timeout());
+    }
+
+    /** Envia ao backend os dados de falha quando a etapa deliverables não é concluída. */
+    @Override
+    public void markFailed(StageExecution<DeliverablesInput> execution, Throwable error) {
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("experimentId", execution.aggregateId());
+        body.put("stageCode", execution.stageCode());
+        body.put("modelResponse", null);
+        body.put("inputTokens", null);
+        body.put("outputTokens", null);
+        body.put("costUsd", null);
+        body.put("openAiJobId", null);
+        body.put("errorMessage", error != null ? error.getMessage() : "Unknown error");
+        body.put("errorDetail", error != null ? stackTraceSummary(error) : null);
+        webClient.post()
+                .uri(stageExecutionBaseUrl() + "/{idJob}/recebe-resposta", execution.idJob())
+                .bodyValue(body)
+                .retrieve()
+                .bodyToMono(Void.class)
+                .block(properties.timeout());
+    }
+
+    /** Converte o payload pendente do backend para o modelo interno de execução da etapa. */
+    private StageExecution<DeliverablesInput> toStageExecution(Map<String, Object> item) {
+        Long experimentId = asLong(item.get("experimentId"));
+        String stageCode = asString(item.get("stageCode"));
+        String idJob = asString(firstPresent(item.get("jobid"), item.get("idJob")));
+        DeliverablesInput input = new DeliverablesInput(experimentId, stageCode, idJob, buildPromptDataFromPending(item));
+        return new StageExecution<>(idJob, experimentId, stageCode, STATUS_STARTED, asInstant(item.get("executionRequestedAt")), input, Map.of());
+    }
+
+    /** Monta os dados do prompt com os artefatos e informações de framework disponíveis no backend. */
+    private Map<String, Object> buildPromptDataFromPending(Map<String, Object> pending) {
+        Map<String, Object> experiment = asMap(pending.get("experiment"));
+        Map<String, Object> hypothesis = asMap(pending.get("hypothesis"));
+        Map<String, Object> framework = asMap(hypothesis.get("framework"));
+        Map<String, Object> payload = new LinkedHashMap<>();
+        payload.put("experimentId", pending.get("experimentId"));
+        payload.put("experimentName", experiment.get("name"));
+        payload.put("hypothesisTitle", hypothesis.get("title"));
+        payload.put("campaignAngle", normalizeJsonArtifact(experiment.get("campaignAngle")));
+        payload.put("adCopy", normalizeJsonArtifact(experiment.get("adCopy")));
+        payload.put("adImageBriefing", normalizeJsonArtifact(experiment.get("adImageBriefing")));
+        payload.put("landingPageWireframe", normalizeJsonArtifact(experiment.get("landingPageWireframe")));
+        payload.put("landingPageCopy", normalizeJsonArtifact(experiment.get("landingPageCopy")));
+        payload.put("landingPageImagePlanning", normalizeJsonArtifact(experiment.get("landingPageImagePlanning")));
+        payload.put("landingPageDesignPreset", normalizeJsonArtifact(experiment.get("landingPageDesignPreset")));
+        payload.put("landingPageQualityReview", experiment.get("landingPageQualityReview"));
+        payload.put("htmlGeraLanding", experiment.get("htmlGeraLanding"));
+        payload.put("PAIN_JSON", framework.getOrDefault("pain", Map.of()));
+        payload.put("RESULT_JSON", framework.getOrDefault("result", Map.of()));
+        payload.put("MECHANISM_JSON", framework.getOrDefault("mechanism", Map.of()));
+        payload.put("PROOF_JSON", framework.getOrDefault("proof", Map.of()));
+        payload.put("OFFER_JSON", framework.getOrDefault("offer", Map.of()));
+        payload.put("CASE_DATA_BLOCK", buildCaseDataBlock(payload));
+        return payload;
+    }
+
+    /** Monta o bloco textual de contexto estratégico exigido pelo prompt da etapa deliverables. */
+    private String buildCaseDataBlock(Map<String, Object> payload) {
+        StringBuilder builder = new StringBuilder("[CASE_DATA_BEGIN]\n");
+        appendCaseData(builder, "experimentId", payload.get("experimentId"));
+        appendCaseData(builder, "experimentName", payload.get("experimentName"));
+        appendCaseData(builder, "hypothesisTitle", payload.get("hypothesisTitle"));
+        appendCaseData(builder, "PAIN_JSON", payload.get("PAIN_JSON"));
+        appendCaseData(builder, "RESULT_JSON", payload.get("RESULT_JSON"));
+        appendCaseData(builder, "MECHANISM_JSON", payload.get("MECHANISM_JSON"));
+        appendCaseData(builder, "PROOF_JSON", payload.get("PROOF_JSON"));
+        appendCaseData(builder, "OFFER_JSON", payload.get("OFFER_JSON"));
+        appendCaseData(builder, "campaignAngle", payload.get("campaignAngle"));
+        appendCaseData(builder, "adCopy", payload.get("adCopy"));
+        appendCaseData(builder, "landingPageCopy", payload.get("landingPageCopy"));
+        appendCaseData(builder, "landingPageQualityReview", payload.get("landingPageQualityReview"));
+        builder.append("[CASE_DATA_END]");
+        return builder.toString();
+    }
+
+    /** Acrescenta uma chave do contexto no bloco CASE_DATA com renderização segura. */
+    private void appendCaseData(StringBuilder builder, String key, Object value) {
+        builder.append(key).append(": ").append(toJsonOrText(value).trim()).append('\n');
+    }
+
+    /** Extrai o resultado OpenAI bruto armazenado nas métricas do resultado da etapa. */
+    private OpenAiResult<String> openAiResult(StageResult<DeliverablesOutput> result) {
+        Object value = result.metrics().get("openAiResult");
+        if (value instanceof OpenAiResult<?> raw) {
+            return new OpenAiResult<>(raw.openAiJobId(), raw.rawResponse(), raw.modelResponse(), raw.modelResponse(), raw.inputTokens(), raw.outputTokens(), raw.costUsd());
+        }
+        throw new IllegalStateException("Resultado da etapa deliverables sem métrica openAiResult");
+    }
+
+    /** Renderiza objetos estruturados como JSON formatado e preserva textos simples. */
+    private String toJsonOrText(Object value) {
+        if (value == null) {
+            return "";
+        }
+        if (value instanceof String text) {
+            return text;
+        }
+        try {
+            return objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(value);
+        } catch (Exception error) {
+            return value.toString();
+        }
+    }
+
+    /** Normaliza artefatos que podem chegar como JSON textual, objeto estruturado ou valor simples. */
+    private Object normalizeJsonArtifact(Object value) {
+        if (value instanceof String text) {
+            return parseJsonField(text);
+        }
+        return value != null ? value : Map.of();
+    }
+
+    /** Interpreta um campo textual JSON quando possível, preservando o texto original em caso de formato inválido. */
+    private Object parseJsonField(String raw) {
+        if (raw == null || raw.isBlank()) {
+            return Map.of();
+        }
+        try {
+            return objectMapper.readValue(raw, Map.class);
+        } catch (Exception error) {
+            return raw;
+        }
+    }
+
+    /** Extrai um mapa tipado quando o valor recebido é um objeto JSON. */
+    private Map<String, Object> asMap(Object value) {
+        if (value instanceof Map<?, ?> rawMap) {
+            Map<String, Object> converted = new LinkedHashMap<>();
+            rawMap.forEach((key, rawValue) -> {
+                if (key != null) {
+                    converted.put(String.valueOf(key), rawValue);
+                }
+            });
+            return converted;
+        }
+        return Map.of();
+    }
+
+    /** Converte um valor genérico para Long quando possível. */
+    private Long asLong(Object value) {
+        if (value instanceof Number number) {
+            return number.longValue();
+        }
+        if (value instanceof String text && !text.isBlank()) {
+            return Long.parseLong(text.trim());
+        }
+        return null;
+    }
+
+    /** Converte um valor genérico para texto preservando nulo quando ausente. */
+    private String asString(Object value) {
+        return value != null ? value.toString() : null;
+    }
+
+    /** Retorna o primeiro valor presente entre duas opções. */
+    private Object firstPresent(Object first, Object second) {
+        return first != null ? first : second;
+    }
+
+    /** Converte um valor genérico para Instant quando possível. */
+    private Instant asInstant(Object value) {
+        if (value instanceof Instant instant) {
+            return instant;
+        }
+        if (value instanceof String text && !text.isBlank()) {
+            return Instant.parse(text.trim());
+        }
+        return null;
+    }
+
+    /** Monta a URL base dos endpoints internos de execução da etapa deliverables. */
+    private String stageExecutionBaseUrl() {
+        return joinPath(properties.backendBaseUrl(), properties.apiPrefix(), "/internal/geralanding/deliverables/stage-executions");
+    }
+
+    /** Resume a stack trace em texto para envio controlado ao backend. */
+    private String stackTraceSummary(Throwable error) {
+        StringBuilder builder = new StringBuilder(error.toString());
+        for (StackTraceElement element : error.getStackTrace()) {
+            builder.append("\n    at ").append(element);
+            if (builder.length() > 4000) {
+                break;
+            }
+        }
+        return builder.toString();
+    }
+
+    /** Junta partes de URL evitando barras duplicadas entre segmentos. */
+    private String joinPath(String... parts) {
+        StringBuilder builder = new StringBuilder();
+        for (String part : parts) {
+            if (part == null || part.isBlank()) {
+                continue;
+            }
+            String normalized = part.trim();
+            if (builder.isEmpty()) {
+                builder.append(stripTrailingSlash(normalized));
+            } else {
+                builder.append("/").append(stripSlashes(normalized));
+            }
+        }
+        return builder.toString();
+    }
+
+    /** Remove a barra final de um segmento de URL quando presente. */
+    private String stripTrailingSlash(String value) {
+        return value.endsWith("/") ? value.substring(0, value.length() - 1) : value;
+    }
+
+    /** Remove barras iniciais e finais de um segmento intermediário de URL. */
+    private String stripSlashes(String value) {
+        String result = value;
+        while (result.startsWith("/")) {
+            result = result.substring(1);
+        }
+        while (result.endsWith("/")) {
+            result = result.substring(0, result.length() - 1);
+        }
+        return result;
+    }
+}

--- a/ai-worker/src/main/java/com/marketinghub/worker/pipeline/deliverables/DeliverablesExecutionScheduler.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/pipeline/deliverables/DeliverablesExecutionScheduler.java
@@ -1,0 +1,33 @@
+package com.marketinghub.worker.pipeline.deliverables;
+
+import com.marketinghub.worker.pipeline.PipelineWorker;
+import com.marketinghub.worker.pipeline.ProcessingSummary;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Scheduled;
+
+/** Responsabilidade: agendar o processamento periódico dos jobs pendentes da etapa deliverables no pipeline genérico. */
+public class DeliverablesExecutionScheduler {
+    private static final Logger log = LoggerFactory.getLogger(DeliverablesExecutionScheduler.class);
+    private final PipelineWorker<DeliverablesInput, DeliverablesOutput> worker;
+    private final DeliverablesWorkerProperties properties;
+
+    /** Recebe o worker e as propriedades usadas pelo ciclo agendado de deliverables. */
+    public DeliverablesExecutionScheduler(PipelineWorker<DeliverablesInput, DeliverablesOutput> worker, DeliverablesWorkerProperties properties) {
+        this.worker = worker;
+        this.properties = properties;
+    }
+
+    /** Executa a cada um minuto o ciclo de processamento dos jobs pendentes de deliverables. */
+    @Scheduled(cron = "0 */1 * * * *")
+    public void run() {
+        ProcessingSummary summary = worker.processPending(properties.pendingLimit());
+        log.info(
+                "Deliverables pipeline worker cycle finished. enabled={} total={} succeeded={} failed={} processedAt={}",
+                summary.enabled(),
+                summary.total(),
+                summary.succeeded(),
+                summary.failed(),
+                summary.processedAt());
+    }
+}

--- a/ai-worker/src/main/java/com/marketinghub/worker/pipeline/deliverables/DeliverablesInput.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/pipeline/deliverables/DeliverablesInput.java
@@ -1,0 +1,16 @@
+package com.marketinghub.worker.pipeline.deliverables;
+
+import java.util.Map;
+
+/** Responsabilidade: transportar o payload de entrada da etapa landing-page-deliverables. */
+public record DeliverablesInput(
+        Long experimentId,
+        String stageCode,
+        String idJob,
+        Map<String, Object> promptData
+) {
+    /** Normaliza os dados de prompt para evitar mapas nulos durante o processamento da etapa. */
+    public DeliverablesInput {
+        promptData = promptData == null ? Map.of() : Map.copyOf(promptData);
+    }
+}

--- a/ai-worker/src/main/java/com/marketinghub/worker/pipeline/deliverables/DeliverablesOutput.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/pipeline/deliverables/DeliverablesOutput.java
@@ -1,0 +1,11 @@
+package com.marketinghub.worker.pipeline.deliverables;
+
+import java.util.Map;
+
+/** Responsabilidade: transportar o JSON validado com entregáveis da amostra e do produto final. */
+public record DeliverablesOutput(Map<String, Object> payload) {
+    /** Normaliza o payload para manter contrato imutável e não nulo. */
+    public DeliverablesOutput {
+        payload = payload == null ? Map.of() : Map.copyOf(payload);
+    }
+}

--- a/ai-worker/src/main/java/com/marketinghub/worker/pipeline/deliverables/DeliverablesProcessor.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/pipeline/deliverables/DeliverablesProcessor.java
@@ -1,0 +1,155 @@
+package com.marketinghub.worker.pipeline.deliverables;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marketinghub.worker.openai.core.exception.StageWorkerException;
+import com.marketinghub.worker.openai.core.model.OpenAiDispatch;
+import com.marketinghub.worker.openai.core.model.OpenAiRequest;
+import com.marketinghub.worker.openai.core.model.OpenAiResult;
+import com.marketinghub.worker.openai.core.port.OpenAiClientPort;
+import com.marketinghub.worker.openai.core.prompt.PromptTemplateResolver;
+import com.marketinghub.worker.pipeline.StageArtifact;
+import com.marketinghub.worker.pipeline.StageContext;
+import com.marketinghub.worker.pipeline.StageProcessor;
+import com.marketinghub.worker.pipeline.StageResult;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.core.io.ClassPathResource;
+
+/** Responsabilidade: gerar os entregáveis de amostra e produto final da landing usando uma etapa OpenAI isolada. */
+public class DeliverablesProcessor implements StageProcessor<DeliverablesInput, DeliverablesOutput> {
+    private static final Logger log = LoggerFactory.getLogger(DeliverablesProcessor.class);
+    private final ObjectMapper objectMapper;
+    private final DeliverablesWorkerProperties properties;
+    private final OpenAiClientPort openAiClient;
+    private final DeliverablesResponseValidator responseValidator;
+    private final DeliverablesBackendClient backendClient;
+    private final PromptTemplateResolver promptTemplateResolver;
+
+    /** Inicializa o processor com dependências específicas da etapa deliverables. */
+    public DeliverablesProcessor(
+            ObjectMapper objectMapper,
+            DeliverablesWorkerProperties properties,
+            OpenAiClientPort openAiClient,
+            DeliverablesResponseValidator responseValidator,
+            DeliverablesBackendClient backendClient) {
+        this.objectMapper = objectMapper;
+        this.properties = properties;
+        this.openAiClient = openAiClient;
+        this.responseValidator = responseValidator;
+        this.backendClient = backendClient;
+        this.promptTemplateResolver = new PromptTemplateResolver(this::loadResource, this::toJsonOrText);
+    }
+
+    /** Processa a etapa criando prompt, enviando para OpenAI, validando JSON e registrando artefatos. */
+    @Override
+    public StageResult<DeliverablesOutput> process(StageContext<DeliverablesInput> context) {
+        OpenAiRequest request = buildOpenAiRequest(context);
+        backendClient.saveOpenAiRequest(context.execution(), request);
+        log.info("Enviando request cru para OpenAI na etapa deliverables. jobId={} requestBodyJson={}", context.execution().idJob(), request.requestBodyJson());
+        OpenAiDispatch dispatch = openAiClient.dispatch(request);
+        OpenAiResult<String> rawResult = openAiClient.awaitResult(dispatch);
+        log.info("Resposta crua da OpenAI recebida na etapa deliverables. jobId={} rawResponse={}", context.execution().idJob(), rawResult.rawResponse());
+        DeliverablesOutput output = responseValidator.validateAndParse(rawResult.modelResponse());
+        StageArtifact requestArtifact = context.artifactStore().save(
+                "OPENAI_REQUEST",
+                "landing-page-deliverables-request.json",
+                "application/json",
+                request.requestBodyJson(),
+                Map.of("idJob", context.execution().idJob(), "stageCode", context.execution().stageCode()));
+        StageArtifact responseArtifact = context.artifactStore().save(
+                "OPENAI_RESPONSE",
+                "landing-page-deliverables-response.json",
+                "application/json",
+                rawResult.rawResponse(),
+                Map.of("idJob", context.execution().idJob(), "stageCode", context.execution().stageCode()));
+        StageArtifact outputArtifact = context.artifactStore().save(
+                "NORMALIZED_JSON",
+                "landing-page-deliverables-output.json",
+                "application/json",
+                rawResult.modelResponse(),
+                Map.of("idJob", context.execution().idJob(), "stageCode", context.execution().stageCode()));
+        return new StageResult<>(
+                output,
+                List.of(requestArtifact, responseArtifact, outputArtifact),
+                Map.of(
+                        "openAiResult", rawResult,
+                        "openAiJobId", rawResult.openAiJobId() == null ? "" : rawResult.openAiJobId(),
+                        "inputTokens", rawResult.inputTokens() == null ? 0 : rawResult.inputTokens(),
+                        "outputTokens", rawResult.outputTokens() == null ? 0 : rawResult.outputTokens()));
+    }
+
+    /** Monta o request completo da OpenAI mantendo prompt markdown, schema e metadados de auditoria. */
+    private OpenAiRequest buildOpenAiRequest(StageContext<DeliverablesInput> context) {
+        Map<String, Object> data = context.input().promptData();
+        String promptResource = properties.promptResource();
+        String promptMarkdownContent = loadResource(promptResource);
+        String prompt = promptTemplateResolver.resolve(promptMarkdownContent, data, promptResource);
+        String schemaJson = loadResource(properties.schemaResource());
+        String requestBodyJson = buildResponsesApiRequest(prompt, schemaJson);
+        return new OpenAiRequest(
+                properties.model(),
+                prompt,
+                requestBodyJson,
+                properties.schemaName(),
+                schemaJson,
+                promptMarkdownContent,
+                Map.of(
+                        "stageCode", context.execution().stageCode(),
+                        "idJob", context.execution().idJob(),
+                        "experimentId", context.execution().aggregateId()));
+    }
+
+    /** Serializa o corpo compatível com Responses API usando schema JSON estrito. */
+    private String buildResponsesApiRequest(String prompt, String schemaJson) {
+        try {
+            Object schema = objectMapper.readValue(schemaJson, Object.class);
+            Map<String, Object> format = new LinkedHashMap<>();
+            format.put("type", "json_schema");
+            format.put("name", properties.schemaName());
+            format.put("schema", schema);
+            format.put("strict", true);
+            Map<String, Object> text = new LinkedHashMap<>();
+            text.put("format", format);
+            Map<String, Object> body = new LinkedHashMap<>();
+            body.put("model", properties.model());
+            body.put("input", prompt);
+            body.put("text", text);
+            return objectMapper.writeValueAsString(body);
+        } catch (JsonProcessingException ex) {
+            log.error("Could not build OpenAI Responses API request for deliverables. schemaName={}", properties.schemaName(), ex);
+            throw new StageWorkerException("Could not build OpenAI Responses API request for deliverables", ex);
+        }
+    }
+
+    /** Converte valores de placeholder para texto ou JSON formatado antes da substituição. */
+    private String toJsonOrText(Object value) {
+        if (value == null) {
+            return "";
+        }
+        if (value instanceof String text) {
+            return text;
+        }
+        try {
+            return objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(value);
+        } catch (JsonProcessingException ex) {
+            log.warn("Could not serialize deliverables prompt value; using toString fallback. valueType={}", value.getClass().getName(), ex);
+            return value.toString();
+        }
+    }
+
+    /** Lê recursos do classpath usados como prompt markdown ou schema da etapa. */
+    private String loadResource(String path) {
+        try {
+            return new ClassPathResource(path).getContentAsString(StandardCharsets.UTF_8);
+        } catch (IOException ex) {
+            log.error("Could not load deliverables resource from classpath. path={}", path, ex);
+            throw new StageWorkerException("Could not load resource from classpath: " + path, ex);
+        }
+    }
+}

--- a/ai-worker/src/main/java/com/marketinghub/worker/pipeline/deliverables/DeliverablesResponseValidator.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/pipeline/deliverables/DeliverablesResponseValidator.java
@@ -1,0 +1,39 @@
+package com.marketinghub.worker.pipeline.deliverables;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.List;
+import java.util.Map;
+
+/** Responsabilidade: validar e converter a resposta JSON da OpenAI para o contrato da etapa deliverables. */
+public class DeliverablesResponseValidator {
+    private final ObjectMapper objectMapper;
+
+    /** Inicializa o validador com ObjectMapper para parse seguro do JSON da etapa. */
+    public DeliverablesResponseValidator(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    /** Valida que a resposta tem listas não vazias para amostra e produto final. */
+    public DeliverablesOutput validateAndParse(String modelResponse) {
+        if (modelResponse == null || modelResponse.isBlank()) {
+            throw new IllegalArgumentException("Deliverables model response is blank");
+        }
+        try {
+            Map<String, Object> payload = objectMapper.readValue(modelResponse, new TypeReference<Map<String, Object>>() {});
+            requireNonEmptyList(payload, "sampleDeliverables");
+            requireNonEmptyList(payload, "finalProductDeliverables");
+            return new DeliverablesOutput(payload);
+        } catch (Exception ex) {
+            throw new IllegalArgumentException("Deliverables model response is not valid JSON with sampleDeliverables and finalProductDeliverables", ex);
+        }
+    }
+
+    /** Garante que o campo informado existe e possui ao menos um item. */
+    private void requireNonEmptyList(Map<String, Object> payload, String field) {
+        Object value = payload.get(field);
+        if (!(value instanceof List<?> list) || list.isEmpty()) {
+            throw new IllegalArgumentException("Deliverables field is missing or empty: " + field);
+        }
+    }
+}

--- a/ai-worker/src/main/java/com/marketinghub/worker/pipeline/deliverables/DeliverablesWorkerConfiguration.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/pipeline/deliverables/DeliverablesWorkerConfiguration.java
@@ -1,0 +1,75 @@
+package com.marketinghub.worker.pipeline.deliverables;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marketinghub.worker.openai.core.openai.OpenAiClientProperties;
+import com.marketinghub.worker.openai.core.openai.ResponsesApiOpenAiClient;
+import com.marketinghub.worker.openai.core.port.OpenAiClientPort;
+import com.marketinghub.worker.pipeline.ArtifactStore;
+import com.marketinghub.worker.pipeline.InMemoryArtifactStore;
+import com.marketinghub.worker.pipeline.PipelineWorker;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
+
+/** Responsabilidade: declarar os beans Spring necessários para executar a etapa deliverables no pipeline genérico. */
+@Configuration
+@EnableConfigurationProperties({DeliverablesWorkerProperties.class, OpenAiClientProperties.class})
+@ConditionalOnProperty(prefix = "deliverables.worker", name = "enabled", havingValue = "true", matchIfMissing = false)
+public class DeliverablesWorkerConfiguration {
+    /** Cria o adapter HTTP da etapa deliverables para consultar e atualizar execuções no backend. */
+    @Bean
+    public DeliverablesBackendClient deliverablesBackendClient(WebClient.Builder webClientBuilder, DeliverablesWorkerProperties properties, ObjectMapper objectMapper) {
+        return new DeliverablesBackendClient(webClientBuilder, properties, objectMapper);
+    }
+
+    /** Cria o validador da resposta JSON retornada pela OpenAI para a etapa deliverables. */
+    @Bean
+    public DeliverablesResponseValidator deliverablesResponseValidator(ObjectMapper objectMapper) {
+        return new DeliverablesResponseValidator(objectMapper);
+    }
+
+    /** Cria o cliente OpenAI compartilhado quando nenhuma outra etapa já o registrou. */
+    @Bean
+    @ConditionalOnMissingBean(OpenAiClientPort.class)
+    public OpenAiClientPort pipelineOpenAiClientPort(WebClient.Builder webClientBuilder, ObjectMapper objectMapper, OpenAiClientProperties properties) {
+        return new ResponsesApiOpenAiClient(webClientBuilder, objectMapper, properties);
+    }
+
+    /** Cria o ArtifactStore genérico usado para referenciar request, response e JSON normalizado da etapa. */
+    @Bean
+    @ConditionalOnMissingBean(ArtifactStore.class)
+    public ArtifactStore artifactStore() {
+        return new InMemoryArtifactStore();
+    }
+
+    /** Cria o processor específico responsável por gerar os entregáveis via OpenAI. */
+    @Bean
+    public DeliverablesProcessor deliverablesProcessor(
+            ObjectMapper objectMapper,
+            DeliverablesWorkerProperties properties,
+            OpenAiClientPort openAiClient,
+            DeliverablesResponseValidator responseValidator,
+            DeliverablesBackendClient backendClient) {
+        return new DeliverablesProcessor(objectMapper, properties, openAiClient, responseValidator, backendClient);
+    }
+
+    /** Compõe o worker genérico com o port e processor específicos da etapa deliverables. */
+    @Bean
+    public PipelineWorker<DeliverablesInput, DeliverablesOutput> deliverablesPipelineWorker(
+            DeliverablesBackendClient backendClient,
+            DeliverablesProcessor processor,
+            ArtifactStore artifactStore) {
+        return new PipelineWorker<>(backendClient, processor, artifactStore);
+    }
+
+    /** Cria o agendador periódico que aciona o worker da etapa deliverables. */
+    @Bean
+    public DeliverablesExecutionScheduler deliverablesExecutionScheduler(
+            PipelineWorker<DeliverablesInput, DeliverablesOutput> worker,
+            DeliverablesWorkerProperties properties) {
+        return new DeliverablesExecutionScheduler(worker, properties);
+    }
+}

--- a/ai-worker/src/main/java/com/marketinghub/worker/pipeline/deliverables/DeliverablesWorkerProperties.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/pipeline/deliverables/DeliverablesWorkerProperties.java
@@ -1,0 +1,51 @@
+package com.marketinghub.worker.pipeline.deliverables;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.time.Duration;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+/** Responsabilidade: concentrar as propriedades operacionais da etapa pipeline deliverables. */
+@Validated
+@ConfigurationProperties(prefix = "deliverables.worker")
+public record DeliverablesWorkerProperties(
+        boolean enabled,
+
+        @Min(1)
+        int pendingLimit,
+
+        @NotBlank
+        String backendBaseUrl,
+
+        String apiPrefix,
+
+        @NotBlank
+        String promptResource,
+
+        @NotBlank
+        String schemaResource,
+
+        @NotBlank
+        String schemaName,
+
+        @NotBlank
+        String model,
+
+        @NotNull
+        Duration timeout
+) {
+    /** Normaliza valores opcionais usados pelo worker quando a configuração externa omite o campo. */
+    public DeliverablesWorkerProperties {
+        if (apiPrefix == null || apiPrefix.isBlank()) {
+            apiPrefix = "/api";
+        }
+        if (model == null || model.isBlank()) {
+            model = "gpt-5.5";
+        }
+        if (timeout == null) {
+            timeout = Duration.ofMinutes(30);
+        }
+    }
+}

--- a/ai-worker/src/main/resources/application.properties
+++ b/ai-worker/src/main/resources/application.properties
@@ -123,3 +123,13 @@ qualityreview.worker.image-detail=${QUALITYREVIEW_WORKER_IMAGE_DETAIL:original}
 qualityreview.worker.timeout=${QUALITYREVIEW_WORKER_TIMEOUT:PT30M}
 qualityreview.worker.chromium-executable-path=${QUALITYREVIEW_WORKER_CHROMIUM_EXECUTABLE_PATH:/usr/bin/chromium}
 qualityreview.worker.screenshot-timeout=${QUALITYREVIEW_WORKER_SCREENSHOT_TIMEOUT:PT2M}
+
+deliverables.worker.enabled=${DELIVERABLES_WORKER_ENABLED:true}
+deliverables.worker.pending-limit=${DELIVERABLES_WORKER_PENDING_LIMIT:5}
+deliverables.worker.backend-base-url=${DELIVERABLES_WORKER_BACKEND_BASE_URL:${backend.base-url}}
+deliverables.worker.api-prefix=${DELIVERABLES_WORKER_API_PREFIX:${backend.api-prefix}}
+deliverables.worker.prompt-resource=${DELIVERABLES_WORKER_PROMPT_RESOURCE:prompts/geralanding/landing-page-deliverables.md}
+deliverables.worker.schema-resource=${DELIVERABLES_WORKER_SCHEMA_RESOURCE:prompts/geralanding/landing-page-deliverables-schema.json}
+deliverables.worker.schema-name=${DELIVERABLES_WORKER_SCHEMA_NAME:experiment_pipeline_landing_page_deliverables}
+deliverables.worker.model=${DELIVERABLES_WORKER_MODEL:gpt-5.5}
+deliverables.worker.timeout=${DELIVERABLES_WORKER_TIMEOUT:PT30M}

--- a/ai-worker/src/main/resources/prompts/geralanding/landing-page-deliverables.md
+++ b/ai-worker/src/main/resources/prompts/geralanding/landing-page-deliverables.md
@@ -1,22 +1,43 @@
 # Etapa: landing-page-deliverables
 
+template_id: landing-page-deliverables
+
 Objetivo: gerar um JSON final com os entregáveis que serão oferecidos ao lead em dois níveis:
 1) amostra gratuita (prova/degustação);
 2) produto final completo (oferta principal).
 
 Regras obrigatórias:
 - Responda SOMENTE no JSON do schema.
+- O JSON precisa conter exatamente `sampleDeliverables` e `finalProductDeliverables`.
+- `sampleDeliverables` deve mostrar o que será produzido para a AMOSTRA gratuita.
+- `finalProductDeliverables` deve mostrar o que será produzido para a ENTREGA DO PRODUTO FINAL.
 - Foque em entregáveis concretos, verificáveis e úteis para o nicho.
 - Cada entregável deve explicar transformação prática (dor -> resultado).
 - Evite promessas vagas e termos genéricos.
+- Não prometa consultoria, call, acompanhamento humano, gestão manual ou serviço fora do produto digital automatizado.
 - Não use markdown.
-
-Contexto disponível:
-- framework da hipótese (dor, resultado, mecanismo, prova, oferta)
-- campanha/copy/imagem
-- wireframe, copy da landing, planejamento de imagem e preset de design
 
 Critérios de qualidade:
 - A AMOSTRA deve ser rápida de consumir e já gerar percepção real de valor.
 - O PRODUTO FINAL deve ser claramente mais profundo e completo que a amostra.
 - Os nomes devem ser autoexplicativos para uso comercial.
+- O conjunto precisa reforçar Dor → Resultado → Mecanismo → Prova → Oferta.
+
+Contexto estratégico e artefatos disponíveis:
+{{CASE_DATA_BLOCK}}
+
+Artefatos complementares:
+- Wireframe da landing:
+{{landingPageWireframe}}
+
+- Copy da landing:
+{{landingPageCopy}}
+
+- Planejamento de imagens:
+{{landingPageImagePlanning}}
+
+- Preset de design:
+{{landingPageDesignPreset}}
+
+- HTML final do GeraLanding:
+{{htmlGeraLanding}}

--- a/ai-worker/src/test/java/com/marketinghub/worker/architecture/PipelineArchitectureTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/architecture/PipelineArchitectureTest.java
@@ -1,0 +1,85 @@
+package com.marketinghub.worker.architecture;
+
+import com.marketinghub.worker.pipeline.StageProcessor;
+import com.tngtech.archunit.base.DescribedPredicate;
+import com.tngtech.archunit.core.domain.JavaClass;
+import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.junit.AnalyzeClasses;
+import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.lang.ArchRule;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
+import static com.tngtech.archunit.library.dependencies.SlicesRuleDefinition.slices;
+
+/** Guarda arquitetural do motor genérico com.marketinghub.worker.pipeline. */
+@AnalyzeClasses(
+        packages = "com.marketinghub.worker",
+        importOptions = ImportOption.DoNotIncludeTests.class
+)
+class PipelineArchitectureTest {
+    private static final String PIPELINE_ROOT = "com.marketinghub.worker.pipeline";
+
+    private static final DescribedPredicate<JavaClass> CLASSES_DE_ETAPA =
+            new DescribedPredicate<>("classes dentro de pipeline.<etapa>") {
+                /** Identifica classes que pertencem a subpacotes concretos do pipeline. */
+                @Override
+                public boolean test(JavaClass javaClass) {
+                    String packageName = javaClass.getPackageName();
+                    return packageName.startsWith(PIPELINE_ROOT + ".");
+                }
+            };
+
+    @ArchTest
+    static final ArchRule pacote_pipeline_raiz_nao_deve_depender_de_etapas =
+            noClasses()
+                    .that()
+                    .resideInAPackage(PIPELINE_ROOT)
+                    .should()
+                    .dependOnClassesThat(CLASSES_DE_ETAPA)
+                    .because("[ARQUITETURA] o pacote pipeline é o núcleo genérico e não pode conhecer etapas concretas");
+
+    @ArchTest
+    static final ArchRule etapas_nao_devem_depender_umas_das_outras =
+            slices()
+                    .matching("com.marketinghub.worker.pipeline.(*)..")
+                    .should()
+                    .notDependOnEachOther()
+                    .because("[ARQUITETURA] cada pipeline.<etapa> deve ser independente das outras etapas");
+
+    @ArchTest
+    static final ArchRule etapas_nao_devem_ter_ciclos =
+            slices()
+                    .matching("com.marketinghub.worker.pipeline.(*)..")
+                    .should()
+                    .beFreeOfCycles()
+                    .because("[ARQUITETURA] etapas do pipeline não devem formar ciclos de dependência");
+
+    @ArchTest
+    static final ArchRule processors_de_etapa_devem_implementar_stage_processor =
+            classes()
+                    .that()
+                    .resideInAPackage("com.marketinghub.worker.pipeline..")
+                    .and()
+                    .resideOutsideOfPackage(PIPELINE_ROOT)
+                    .and()
+                    .haveSimpleNameEndingWith("Processor")
+                    .should()
+                    .implement(StageProcessor.class)
+                    .because("[ARQUITETURA] toda etapa concreta deve entrar no pipeline através do contrato StageProcessor");
+
+    @ArchTest
+    static final ArchRule pipeline_raiz_nao_deve_depender_de_tecnologias_concretas =
+            noClasses()
+                    .that()
+                    .resideInAPackage(PIPELINE_ROOT)
+                    .should()
+                    .dependOnClassesThat()
+                    .resideInAnyPackage(
+                            "org.springframework.web.reactive.function.client..",
+                            "org.jsoup..",
+                            "com.microsoft.playwright..",
+                            "software.amazon.awssdk..",
+                            "okhttp3..")
+                    .because("[ARQUITETURA] o núcleo do pipeline deve depender de abstrações, não de tecnologias concretas");
+}

--- a/ai-worker/src/test/java/com/marketinghub/worker/pipeline/PipelineWorkerTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/pipeline/PipelineWorkerTest.java
@@ -1,0 +1,60 @@
+package com.marketinghub.worker.pipeline;
+
+import org.junit.jupiter.api.Test;
+
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PipelineWorkerTest {
+
+    /** Valida o fluxo feliz do worker genérico marcando running e completed. */
+    @Test
+    void processPendingMarcaRunningECompletedQuandoProcessorRetornaSucesso() {
+        FakeBackend backend = new FakeBackend();
+        ArtifactStore artifactStore = new InMemoryArtifactStore();
+        PipelineWorker<String, String> worker = new PipelineWorker<>(backend, context -> new StageResult<>("ok", List.of(), Map.of()), artifactStore);
+
+        ProcessingSummary summary = worker.processPending(5);
+
+        assertThat(summary.total()).isEqualTo(1);
+        assertThat(summary.succeeded()).isEqualTo(1);
+        assertThat(summary.failed()).isZero();
+        assertThat(backend.running).containsExactly("job-1");
+        assertThat(backend.completed).containsExactly("job-1");
+        assertThat(backend.failed).isEmpty();
+    }
+
+    private static class FakeBackend implements StageBackendPort<String, String> {
+        private final List<String> running = new ArrayList<>();
+        private final List<String> completed = new ArrayList<>();
+        private final List<String> failed = new ArrayList<>();
+
+        /** Retorna uma execução pendente fixa para o teste do worker. */
+        @Override
+        public List<StageExecution<String>> listPending(int limit) {
+            return List.of(new StageExecution<>("job-1", 38L, "landing-page-deliverables", "INICIADO", Instant.now(), "input", Map.of()));
+        }
+
+        /** Registra que a execução foi marcada como em processamento. */
+        @Override
+        public void markRunning(StageExecution<String> execution) {
+            running.add(execution.idJob());
+        }
+
+        /** Registra que a execução foi concluída com sucesso. */
+        @Override
+        public void markCompleted(StageExecution<String> execution, StageResult<String> result) {
+            completed.add(execution.idJob());
+        }
+
+        /** Registra que a execução falhou. */
+        @Override
+        public void markFailed(StageExecution<String> execution, Throwable error) {
+            failed.add(execution.idJob());
+        }
+    }
+}

--- a/ai-worker/src/test/java/com/marketinghub/worker/pipeline/deliverables/DeliverablesResponseValidatorTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/pipeline/deliverables/DeliverablesResponseValidatorTest.java
@@ -1,0 +1,54 @@
+package com.marketinghub.worker.pipeline.deliverables;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+class DeliverablesResponseValidatorTest {
+    private final DeliverablesResponseValidator validator = new DeliverablesResponseValidator(new ObjectMapper());
+
+    /** Valida que o contrato aceito contém entregáveis de amostra e produto final. */
+    @Test
+    void validateAndParseAceitaJsonComAmostraEProdutoFinal() {
+        String json = """
+                {
+                  "sampleDeliverables": [
+                    {
+                      "id": "sample-plan",
+                      "name": "Plano rápido de retenção",
+                      "format": "PDF",
+                      "description": "Mapa prático para aplicar o primeiro check-in do aluno.",
+                      "painAddressed": "Falta de percepção de progresso inicial.",
+                      "expectedOutcome": "Aluno entende o próximo passo e percebe cuidado."
+                    }
+                  ],
+                  "finalProductDeliverables": [
+                    {
+                      "id": "full-system",
+                      "name": "Sistema completo de onboarding",
+                      "format": "Kit digital",
+                      "description": "Sequência completa de comunicação, marcos e check-ins.",
+                      "painAddressed": "Renovação depende de improviso e indicação.",
+                      "expectedOutcome": "Processo repetível para aumentar percepção de valor."
+                    }
+                  ]
+                }
+                """;
+
+        DeliverablesOutput output = validator.validateAndParse(json);
+
+        assertThat(output.payload()).containsKeys("sampleDeliverables", "finalProductDeliverables");
+    }
+
+    /** Valida que respostas sem produto final são rejeitadas. */
+    @Test
+    void validateAndParseRejeitaJsonSemProdutoFinal() {
+        String json = "{\"sampleDeliverables\":[{\"id\":\"a\"}]}";
+
+        assertThatThrownBy(() -> validator.validateAndParse(json))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("sampleDeliverables and finalProductDeliverables");
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/deliverables/service/GeraLandingDeliverablesStageExecutionService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/deliverables/service/GeraLandingDeliverablesStageExecutionService.java
@@ -1,35 +1,55 @@
 package com.marketinghub.geralanding.deliverables.service;
 
-import com.marketinghub.repository.jpa.experiment.ExperimentRepository;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marketinghub.experiment.Experiment;
 import com.marketinghub.geralanding.GeraLandingStageExecution;
+import com.marketinghub.geralanding.deliverables.service.pending.RecordDeliverablesExperiment;
+import com.marketinghub.geralanding.deliverables.service.pending.RecordDeliverablesHypothesis;
+import com.marketinghub.geralanding.deliverables.service.pending.RecordDeliverablesPending;
+import com.marketinghub.repository.jpa.experiment.ExperimentRepository;
 import com.marketinghub.repository.jpa.geralanding.GeraLandingStageExecutionRepository;
 import jakarta.persistence.EntityNotFoundException;
+import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
 
-/** Responsável por adaptar consultas de execução para o contrato da etapa deliverables. */
+/** Responsável por adaptar consultas e callbacks de execução para o contrato da etapa deliverables. */
 @Service
 public class GeraLandingDeliverablesStageExecutionService {
 
+    private static final Logger log = LoggerFactory.getLogger(GeraLandingDeliverablesStageExecutionService.class);
+    private static final TypeReference<LinkedHashMap<String, Object>> FRAMEWORK_TYPE = new TypeReference<>() {};
     private static final String STATUS_STARTED = "INICIADO";
+    private static final String STATUS_WAITING_OPENAI_DISPATCH = "AGUARDANDO_RETORNO_OPENAI";
     private static final String STATUS_COMPLETED = "CONCLUIDO";
+    private static final String STATUS_FAILED = "FALHA";
     private final ExperimentRepository experimentRepository;
     private final GeraLandingStageExecutionRepository executionRepository;
+    private final ObjectMapper objectMapper;
 
+    /** Inicializa o serviço com repositórios e serializador usados pela etapa deliverables. */
     public GeraLandingDeliverablesStageExecutionService(
             ExperimentRepository experimentRepository,
-            GeraLandingStageExecutionRepository executionRepository) {
+            GeraLandingStageExecutionRepository executionRepository,
+            ObjectMapper objectMapper) {
         this.experimentRepository = experimentRepository;
         this.executionRepository = executionRepository;
+        this.objectMapper = objectMapper;
     }
 
-
-    @Transactional
     /** Registra a execução inicial da etapa convertendo para o DTO local de início. */
+    @Transactional
     public GeraLandingDeliverablesStartResponse registerInitialExecution(Long experimentId, String stageCode) {
         Instant now = Instant.now();
         var experiment = experimentRepository.findById(experimentId)
@@ -50,8 +70,8 @@ public class GeraLandingDeliverablesStageExecutionService {
         return new GeraLandingDeliverablesStartResponse(fromDatabaseIdJob(saved.getIdJob()), saved.getStatus());
     }
 
-    @Transactional(readOnly = true)
     /** Lista execuções da etapa convertendo para o DTO local da etapa. */
+    @Transactional(readOnly = true)
     public List<GeraLandingDeliverablesExecutionSummaryResponse> listExperimentStageExecutions(Long experimentId, String stageCode, boolean includeCompleted) {
         List<GeraLandingStageExecution> executions = includeCompleted
                 ? executionRepository.findTop20ByExperimentIdAndStageCodeOrderByExecutionRequestedAtDesc(experimentId, stageCode)
@@ -64,13 +84,256 @@ public class GeraLandingDeliverablesStageExecutionService {
                 .toList();
     }
 
+    /** Lista os jobs iniciados da etapa deliverables para processamento independente de experimento. */
     @Transactional(readOnly = true)
+    public List<RecordDeliverablesPending> listPending(String stageCode) {
+        return executionRepository.findTop20ByStageCodeAndStatusOrderByExecutionRequestedAtAsc(stageCode, STATUS_STARTED)
+                .stream()
+                .map(execution -> new RecordDeliverablesPending(
+                        execution.getExperimentId(),
+                        fromDatabaseIdJob(execution.getIdJob()),
+                        fromDatabaseIdJob(execution.getIdJob()),
+                        execution.getStageCode(),
+                        execution.getStatus(),
+                        execution.getExecutionRequestedAt(),
+                        toPendingExperiment(execution.getExperiment()),
+                        toPendingHypothesis(execution.getExperiment())))
+                .toList();
+    }
+
+    /** Marca a execução como em processamento para removê-la da fila de pendentes antes da chamada externa. */
+    @Transactional
+    public void markRunning(String idJob) {
+        GeraLandingStageExecution execution = findByJob(idJob);
+        execution.setProcessingStartedAt(Instant.now());
+        execution.setStatus(STATUS_WAITING_OPENAI_DISPATCH);
+        executionRepository.save(execution);
+    }
+
+    /** Marca a execução como preparada após receber prompt, schema e request cru despachados para IA. */
+    @Transactional
+    public void markPromptReceived(
+            String idJob,
+            String prompt,
+            String promptMarkdownContent,
+            String schemaJson,
+            String openAiRequestBody,
+            String openAiModel,
+            String openAiJobId) {
+        GeraLandingStageExecution execution = findByJob(idJob);
+        execution.setPrompt(prompt);
+        execution.setPromptMarkdownContent(resolvePromptMarkdownContent(prompt, promptMarkdownContent));
+        execution.setSchemaJson(schemaJson);
+        execution.setOpenAiRequestBody(openAiRequestBody);
+        execution.setOpenAiModel(openAiModel);
+        if (StringUtils.hasText(openAiJobId)) {
+            execution.setOpenAiJobId(openAiJobId);
+            execution.setProcessingStartedAt(Instant.now());
+            execution.setStatus(STATUS_WAITING_OPENAI_DISPATCH);
+        }
+        executionRepository.save(execution);
+    }
+
+    /** Marca a execução como aguardando retorno da OpenAI após receber o identificador do job remoto. */
+    @Transactional
+    public void markWaitingOpenAiDispatch(String idJob, String openAiJobId) {
+        GeraLandingStageExecution execution = findByJob(idJob);
+        if (StringUtils.hasText(openAiJobId)) {
+            execution.setOpenAiJobId(openAiJobId);
+        }
+        execution.setProcessingStartedAt(Instant.now());
+        execution.setStatus(STATUS_WAITING_OPENAI_DISPATCH);
+        executionRepository.save(execution);
+    }
+
+    /** Conclui ou falha a execução da etapa deliverables com a resposta do Worker AI. */
+    @Transactional
+    public void markCompletedFromResponse(
+            String idJob,
+            Long experimentId,
+            String stageCode,
+            String modelResponse,
+            Integer inputTokens,
+            Integer outputTokens,
+            BigDecimal costUsd,
+            String openAiJobId,
+            String errorMessage,
+            String errorDetail) {
+        GeraLandingStageExecution execution = executionRepository
+                .findTopByIdJobOrderByExecutionRequestedAtDesc(toDatabaseIdJob(idJob))
+                .or(() -> executionRepository.findTopByExperimentIdAndStageCodeOrderByExecutionRequestedAtDesc(
+                        experimentId,
+                        stageCode))
+                .orElseThrow(() -> new EntityNotFoundException("GeraLanding execution not found for idJob: " + idJob));
+        try {
+            execution.setModelResponse(modelResponse);
+            if (StringUtils.hasText(openAiJobId)) {
+                execution.setOpenAiJobId(openAiJobId);
+            }
+            execution.setInputTokens(inputTokens);
+            execution.setOutputTokens(outputTokens);
+            execution.setCostUsd(costUsd);
+            String normalizedErrorDetail = StringUtils.hasText(errorDetail) ? errorDetail.trim() : null;
+            String normalizedErrorMessage = normalizeErrorMessage(errorMessage, normalizedErrorDetail);
+            execution.setErrorMessage(normalizedErrorMessage);
+            execution.setErrorDetail(normalizedErrorDetail);
+            execution.setCompletedAt(Instant.now());
+            execution.setStatus(normalizedErrorMessage != null ? STATUS_FAILED : STATUS_COMPLETED);
+
+            executionRepository.save(execution);
+            if (normalizedErrorMessage == null) {
+                persistDeliverablesArtifactOnExperiment(execution, modelResponse);
+            }
+        } catch (RuntimeException ex) {
+            log.error(
+                    "Erro ao concluir resposta deliverables (idJob={}, experimentId={}, stageCode={}, openAiJobId={}, modelResponseLength={}, errorMessage={})",
+                    idJob,
+                    experimentId,
+                    stageCode,
+                    openAiJobId,
+                    modelResponse != null ? modelResponse.length() : 0,
+                    errorMessage,
+                    ex);
+            throw ex;
+        }
+    }
+
     /** Retorna o detalhe da execução convertido para o DTO local da etapa. */
+    @Transactional(readOnly = true)
     public GeraLandingDeliverablesStageExecutionDetailResponse getStageExecutionDetail(Long experimentId, String idJob) {
         GeraLandingStageExecution execution = executionRepository
                 .findTopByExperimentIdAndIdJobOrderByExecutionRequestedAtDesc(experimentId, toDatabaseIdJob(idJob))
                 .orElseThrow(() -> new EntityNotFoundException("GeraLanding execution not found for idJob: " + idJob));
         return toDetailResponse(execution);
+    }
+
+    /** Busca uma execução pelo identificador textual do job. */
+    private GeraLandingStageExecution findByJob(String idJob) {
+        return executionRepository
+                .findTopByIdJobOrderByExecutionRequestedAtDesc(toDatabaseIdJob(idJob))
+                .orElseThrow(() -> new EntityNotFoundException("GeraLanding execution not found for idJob: " + idJob));
+    }
+
+    /** Resolve o markdown bruto do prompt mantendo compatibilidade com clientes antigos que enviavam esse conteúdo em prompt. */
+    private String resolvePromptMarkdownContent(String prompt, String promptMarkdownContent) {
+        if (StringUtils.hasText(promptMarkdownContent)) {
+            return promptMarkdownContent;
+        }
+        return prompt;
+    }
+
+    /** Normaliza a mensagem de erro e garante status FALHA quando o callback traz apenas detalhe técnico. */
+    private String normalizeErrorMessage(String errorMessage, String normalizedErrorDetail) {
+        if (StringUtils.hasText(errorMessage)) {
+            return errorMessage.trim();
+        }
+        if (StringUtils.hasText(normalizedErrorDetail)) {
+            return "Falha ao processar etapa deliverables";
+        }
+        return null;
+    }
+
+    /** Persiste o JSON de entregáveis no experimento associado à execução concluída. */
+    private void persistDeliverablesArtifactOnExperiment(GeraLandingStageExecution execution, String modelResponse) {
+        Experiment experiment = resolveExperiment(execution);
+        experiment.setLandingPageDeliverables(modelResponse);
+        experimentRepository.save(experiment);
+    }
+
+    /** Resolve o experimento da execução, buscando no repositório quando a associação não estiver carregada. */
+    private Experiment resolveExperiment(GeraLandingStageExecution execution) {
+        Experiment experiment = execution.getExperiment();
+        if (experiment == null) {
+            experiment = experimentRepository.findById(execution.getExperimentId())
+                    .orElseThrow(() -> new EntityNotFoundException("Experiment not found: " + execution.getExperimentId()));
+        }
+        return experiment;
+    }
+
+    /** Converte o experimento da execução para os dados expostos na fila pending. */
+    private RecordDeliverablesExperiment toPendingExperiment(Experiment experiment) {
+        if (experiment == null) {
+            return null;
+        }
+        return new RecordDeliverablesExperiment(
+                experiment.getId(),
+                experiment.getName(),
+                experiment.getHypothesis(),
+                enumValueToText(experiment.getStatus()),
+                enumValueToText(experiment.getStage()),
+                experiment.getCreativeTextPrompt(),
+                experiment.getCreativeImagePrompt(),
+                resolveJsonArtifact(experiment.getId(), "campaignAngle", experiment.getCampaignAngle()),
+                resolveJsonArtifact(experiment.getId(), "adCopy", experiment.getAdCopy()),
+                resolveJsonArtifact(experiment.getId(), "adImageBriefing", experiment.getAdImageBriefing()),
+                resolveJsonArtifact(experiment.getId(), "landingPageCopy", experiment.getLandingPageCopy()),
+                resolveJsonArtifact(experiment.getId(), "landingPageWireframe", experiment.getLandingPageWireframe()),
+                resolveJsonArtifact(experiment.getId(), "landingPageImagePlanning", experiment.getLandingPageImagePlanning()),
+                resolveJsonArtifact(experiment.getId(), "landingPageDesignPreset", experiment.getLandingPageDesignPreset()),
+                resolveJsonArtifact(experiment.getId(), "landingPageDeliverables", experiment.getLandingPageDeliverables()),
+                experiment.getLandingPageQualityReview(),
+                experiment.getHtmlGeraLanding());
+    }
+
+    /** Preserva artefatos JSON como objetos estruturados na fila pending, mantendo textos não JSON intactos. */
+    private Object resolveJsonArtifact(Long experimentId, String fieldName, String rawValue) {
+        if (!StringUtils.hasText(rawValue)) {
+            return rawValue;
+        }
+        String trimmed = rawValue.trim();
+        if (!trimmed.startsWith("{") && !trimmed.startsWith("[")) {
+            return rawValue;
+        }
+        try {
+            return objectMapper.readValue(trimmed, Object.class);
+        } catch (JsonProcessingException ex) {
+            log.warn(
+                    "Falha ao ler artefato JSON no pending deliverables; mantendo texto bruto. experimentId={} fieldName={}",
+                    experimentId,
+                    fieldName,
+                    ex);
+            return rawValue;
+        }
+    }
+
+    /** Converte a hipótese associada ao experimento para o framework exposto na fila pending. */
+    private RecordDeliverablesHypothesis toPendingHypothesis(Experiment experiment) {
+        if (experiment == null) {
+            return null;
+        }
+        return new RecordDeliverablesHypothesis(
+                experiment.getHypothesisRefIdForPending(),
+                experiment.getHypothesisRefTitleForPending(),
+                resolveFramework(experiment.getId(), experiment.getHypothesisFrameworkJsonForPending()));
+    }
+
+    /** Resolve o JSON do framework da hipótese como objeto estruturado com todos os blocos canônicos. */
+    private Map<String, Object> resolveFramework(Long experimentId, String frameworkJson) {
+        Map<String, Object> framework = new LinkedHashMap<>();
+        if (StringUtils.hasText(frameworkJson)) {
+            try {
+                framework.putAll(objectMapper.readValue(frameworkJson, FRAMEWORK_TYPE));
+            } catch (JsonProcessingException ex) {
+                log.warn("Falha ao ler framework da hipótese no pending deliverables. experimentId={}", experimentId, ex);
+            }
+        }
+        ensureFrameworkSections(framework);
+        return framework;
+    }
+
+    /** Garante presença dos itens canônicos Dor, Resultado, Mecanismo, Prova, Oferta e checklist. */
+    private void ensureFrameworkSections(Map<String, Object> framework) {
+        framework.putIfAbsent("pain", new LinkedHashMap<String, Object>());
+        framework.putIfAbsent("result", new LinkedHashMap<String, Object>());
+        framework.putIfAbsent("mechanism", new LinkedHashMap<String, Object>());
+        framework.putIfAbsent("proof", new LinkedHashMap<String, Object>());
+        framework.putIfAbsent("offer", new LinkedHashMap<String, Object>());
+        framework.putIfAbsent("checklist", new LinkedHashMap<String, Object>());
+    }
+
+    /** Converte um enum de experimento para texto sem acoplar o serviço às classes concretas do enum. */
+    private String enumValueToText(Object value) {
+        return value != null ? String.valueOf(value) : null;
     }
 
     /** Converte o resumo transversal para o resumo local da etapa. */

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/deliverables/service/pending/RecordDeliverablesExperiment.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/deliverables/service/pending/RecordDeliverablesExperiment.java
@@ -1,0 +1,23 @@
+package com.marketinghub.geralanding.deliverables.service.pending;
+
+/** Representa os dados do experimento expostos na fila interna da etapa deliverables. */
+public record RecordDeliverablesExperiment(
+        Long id,
+        String name,
+        String hypothesis,
+        String status,
+        String stage,
+        String creativeTextPrompt,
+        String creativeImagePrompt,
+        Object campaignAngle,
+        Object adCopy,
+        Object adImageBriefing,
+        Object landingPageCopy,
+        Object landingPageWireframe,
+        Object landingPageImagePlanning,
+        Object landingPageDesignPreset,
+        Object landingPageDeliverables,
+        String landingPageQualityReview,
+        String htmlGeraLanding
+) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/deliverables/service/pending/RecordDeliverablesHypothesis.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/deliverables/service/pending/RecordDeliverablesHypothesis.java
@@ -1,0 +1,12 @@
+package com.marketinghub.geralanding.deliverables.service.pending;
+
+import java.util.Map;
+import java.util.UUID;
+
+/** Representa a hipótese e o framework usados na fila interna da etapa deliverables. */
+public record RecordDeliverablesHypothesis(
+        UUID id,
+        String title,
+        Map<String, Object> framework
+) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/deliverables/service/pending/RecordDeliverablesPending.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/deliverables/service/pending/RecordDeliverablesPending.java
@@ -1,0 +1,16 @@
+package com.marketinghub.geralanding.deliverables.service.pending;
+
+import java.time.Instant;
+
+/** Representa o item mínimo de pendência da etapa deliverables consumido pelo Worker AI. */
+public record RecordDeliverablesPending(
+        Long experimentId,
+        String jobid,
+        String idJob,
+        String stageCode,
+        String status,
+        Instant executionRequestedAt,
+        RecordDeliverablesExperiment experiment,
+        RecordDeliverablesHypothesis hypothesis
+) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/deliverables/service/recebePrompt/RecebeDispatchRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/deliverables/service/recebePrompt/RecebeDispatchRequest.java
@@ -1,0 +1,7 @@
+package com.marketinghub.geralanding.deliverables.service.recebePrompt;
+
+/** Representa o callback interno que informa o início do processamento ou o identificador remoto no provedor de IA. */
+public record RecebeDispatchRequest(
+        Long experimentId,
+        String stageCode,
+        String openAiJobId) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/deliverables/service/recebePrompt/RecebePromptRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/deliverables/service/recebePrompt/RecebePromptRequest.java
@@ -1,0 +1,15 @@
+package com.marketinghub.geralanding.deliverables.service.recebePrompt;
+
+import com.fasterxml.jackson.annotation.JsonAlias;
+import jakarta.validation.constraints.NotBlank;
+
+/** Representa o payload interno com prompt, schema e request cru enviados ao provedor de IA. */
+public record RecebePromptRequest(
+        Long experimentId,
+        String stageCode,
+        @NotBlank String prompt,
+        String promptMarkdownContent,
+        @NotBlank String schemaJson,
+        @NotBlank @JsonAlias("requestBodyJson") String openAiRequestBody,
+        String openAiModel,
+        @JsonAlias("jobidopenai") String openAiJobId) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/deliverables/service/recebeResposta/RecebeRespostaRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/deliverables/service/recebeResposta/RecebeRespostaRequest.java
@@ -1,0 +1,17 @@
+package com.marketinghub.geralanding.deliverables.service.recebeResposta;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.math.BigDecimal;
+
+/** Representa o payload enviado pelo Worker AI para concluir ou falhar a resposta da etapa deliverables. */
+public record RecebeRespostaRequest(
+        @NotNull Long experimentId,
+        @NotBlank String stageCode,
+        String modelResponse,
+        Integer inputTokens,
+        Integer outputTokens,
+        BigDecimal costUsd,
+        String openAiJobId,
+        String errorMessage,
+        String errorDetail) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/geralanding/deliverables/web/GeraLandingDeliverablesController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geralanding/deliverables/web/GeraLandingDeliverablesController.java
@@ -5,38 +5,48 @@ import com.marketinghub.geralanding.deliverables.service.GeraLandingDeliverables
 import com.marketinghub.geralanding.deliverables.service.GeraLandingDeliverablesStageExecutionService;
 import com.marketinghub.geralanding.deliverables.service.GeraLandingDeliverablesStageService;
 import com.marketinghub.geralanding.deliverables.service.GeraLandingDeliverablesStartResponse;
+import com.marketinghub.geralanding.deliverables.service.pending.RecordDeliverablesPending;
+import com.marketinghub.geralanding.deliverables.service.recebePrompt.RecebeDispatchRequest;
+import com.marketinghub.geralanding.deliverables.service.recebePrompt.RecebePromptRequest;
+import com.marketinghub.geralanding.deliverables.service.recebeResposta.RecebeRespostaRequest;
+import jakarta.validation.Valid;
 import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-/** Responsável por iniciar a etapa landing-page-deliverables no GeraLanding e expor consultas das execuções da etapa. */
+/** Responsável por iniciar a etapa landing-page-deliverables no GeraLanding e expor consultas/callbacks da etapa. */
 @RestController
-@RequestMapping("/api/experiments/{experimentId}/geralanding")
+@RequestMapping("/api")
 public class GeraLandingDeliverablesController {
+  private static final Logger LOGGER = LoggerFactory.getLogger(GeraLandingDeliverablesController.class);
   private static final String STAGE_CODE = "landing-page-deliverables";
 
   private final GeraLandingDeliverablesStageService stageService;
   private final GeraLandingDeliverablesStageExecutionService executionService;
 
+  /** Inicializa o controller com os serviços de início e execução da etapa deliverables. */
   public GeraLandingDeliverablesController(GeraLandingDeliverablesStageService stageService, GeraLandingDeliverablesStageExecutionService executionService) {
     this.stageService = stageService;
     this.executionService = executionService;
   }
 
   /** Registra uma execução inicial da etapa landing-page-deliverables. */
-  @PostMapping("/deliverables/start")
+  @PostMapping("/experiments/{experimentId}/geralanding/deliverables/start")
   public ResponseEntity<GeraLandingDeliverablesStartResponse> start(@PathVariable Long experimentId) {
     GeraLandingDeliverablesStartResponse response = stageService.start(experimentId);
     return ResponseEntity.accepted().body(response);
   }
 
   /** Lista as execuções da etapa para o experimento. */
-  @GetMapping("/deliverables/stage-executions")
+  @GetMapping("/experiments/{experimentId}/geralanding/deliverables/stage-executions")
   public ResponseEntity<List<GeraLandingDeliverablesExecutionSummaryResponse>> listStageExecutions(
       @PathVariable Long experimentId,
       @RequestParam(defaultValue = "true") boolean includeCompleted) {
@@ -45,8 +55,107 @@ public class GeraLandingDeliverablesController {
     return ResponseEntity.ok(response);
   }
 
+  /** Lista os jobs pendentes iniciados da etapa deliverables para processamento pelo Worker AI. */
+  @GetMapping("/internal/geralanding/deliverables/stage-executions/pending")
+  public List<RecordDeliverablesPending> pending() {
+    return executionService.listPending(STAGE_CODE);
+  }
+
+  /** Marca uma execução como em processamento para evitar recaptura enquanto o Worker AI chama a OpenAI. */
+  @PostMapping("/internal/geralanding/deliverables/stage-executions/{idJob}/running")
+  public ResponseEntity<Void> running(@PathVariable String idJob, @RequestBody(required = false) RecebeDispatchRequest payload) {
+    LOGGER.info(
+        "[GeraLanding][Deliverables] Marcando execução em processamento idJob={} experimentId={} stageCode={}",
+        idJob,
+        payload != null ? payload.experimentId() : null,
+        payload != null ? payload.stageCode() : null);
+    executionService.markRunning(idJob);
+    return ResponseEntity.accepted().build();
+  }
+
+  /** Recebe prompt, schema e request cru enviados para IA. */
+  @PostMapping("/internal/geralanding/deliverables/stage-executions/{idJob}/receive-prompt")
+  public ResponseEntity<Void> receivePrompt(
+      @PathVariable String idJob, @Valid @RequestBody RecebePromptRequest payload) {
+    LOGGER.info(
+        "[GeraLanding][Deliverables] Recebido request enviado para IA idJob={} experimentId={} stageCode={} openAiJobId={} promptLength={} promptMarkdownLength={} schemaLength={} requestBodyLength={}",
+        idJob,
+        payload.experimentId(),
+        payload.stageCode(),
+        payload.openAiJobId(),
+        payload.prompt().length(),
+        payload.promptMarkdownContent() != null ? payload.promptMarkdownContent().length() : 0,
+        payload.schemaJson().length(),
+        payload.openAiRequestBody().length());
+    executionService.markPromptReceived(
+        idJob,
+        payload.prompt(),
+        payload.promptMarkdownContent(),
+        payload.schemaJson(),
+        payload.openAiRequestBody(),
+        payload.openAiModel(),
+        payload.openAiJobId());
+    return ResponseEntity.accepted().build();
+  }
+
+  /** Recebe prompt, schema e request cru enviados para IA pelo contrato em português. */
+  @PostMapping("/internal/geralanding/deliverables/stage-executions/{idJob}/recebe-prompt")
+  public ResponseEntity<Void> recebePrompt(
+      @PathVariable String idJob, @Valid @RequestBody RecebePromptRequest payload) {
+    return receivePrompt(idJob, payload);
+  }
+
+  /** Recebe o identificador remoto da IA e marca a execução aguardando retorno da OpenAI. */
+  @PostMapping("/internal/geralanding/deliverables/stage-executions/{idJob}/receive-dispatch")
+  public ResponseEntity<Void> receiveDispatch(
+      @PathVariable String idJob, @RequestBody RecebeDispatchRequest payload) {
+    LOGGER.info(
+        "[GeraLanding][Deliverables] Recebido dispatch OpenAI idJob={} experimentId={} stageCode={} openAiJobId={}",
+        idJob,
+        payload.experimentId(),
+        payload.stageCode(),
+        payload.openAiJobId());
+    executionService.markWaitingOpenAiDispatch(idJob, payload.openAiJobId());
+    return ResponseEntity.accepted().build();
+  }
+
+  /** Recebe a resposta da IA para a etapa deliverables e conclui a execução do job. */
+  @PostMapping("/internal/geralanding/deliverables/stage-executions/{idJob}/receive-result")
+  public ResponseEntity<Void> receiveResult(
+      @PathVariable String idJob, @Valid @RequestBody RecebeRespostaRequest payload) {
+    LOGGER.info(
+        "[GeraLanding][Deliverables] Recebida resposta da IA idJob={} experimentId={} stageCode={} openAiJobId={} inputTokens={} outputTokens={} costUsd={} hasError={}",
+        idJob,
+        payload.experimentId(),
+        payload.stageCode(),
+        payload.openAiJobId(),
+        payload.inputTokens(),
+        payload.outputTokens(),
+        payload.costUsd(),
+        payload.errorMessage() != null && !payload.errorMessage().isBlank());
+    executionService.markCompletedFromResponse(
+        idJob,
+        payload.experimentId(),
+        payload.stageCode(),
+        payload.modelResponse(),
+        payload.inputTokens(),
+        payload.outputTokens(),
+        payload.costUsd(),
+        payload.openAiJobId(),
+        payload.errorMessage(),
+        payload.errorDetail());
+    return ResponseEntity.accepted().build();
+  }
+
+  /** Recebe a resposta da IA para a etapa deliverables pelo contrato em português. */
+  @PostMapping("/internal/geralanding/deliverables/stage-executions/{idJob}/recebe-resposta")
+  public ResponseEntity<Void> recebeResposta(
+      @PathVariable String idJob, @Valid @RequestBody RecebeRespostaRequest payload) {
+    return receiveResult(idJob, payload);
+  }
+
   /** Retorna os detalhes de uma execução específica da etapa. */
-  @GetMapping("/deliverables/stage-executions/{idJob}")
+  @GetMapping("/experiments/{experimentId}/geralanding/deliverables/stage-executions/{idJob}")
   public ResponseEntity<GeraLandingDeliverablesStageExecutionDetailResponse> detailStageExecution(
       @PathVariable Long experimentId, @PathVariable String idJob) {
     GeraLandingDeliverablesStageExecutionDetailResponse response =

--- a/backend/ads-service/src/test/java/com/marketinghub/geralanding/deliverables/web/GeraLandingDeliverablesControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/geralanding/deliverables/web/GeraLandingDeliverablesControllerTest.java
@@ -1,0 +1,144 @@
+package com.marketinghub.geralanding.deliverables.web;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marketinghub.geralanding.deliverables.service.GeraLandingDeliverablesStageExecutionService;
+import com.marketinghub.geralanding.deliverables.service.GeraLandingDeliverablesStageService;
+import com.marketinghub.geralanding.deliverables.service.GeraLandingDeliverablesStartResponse;
+import com.marketinghub.geralanding.deliverables.service.pending.RecordDeliverablesExperiment;
+import com.marketinghub.geralanding.deliverables.service.pending.RecordDeliverablesHypothesis;
+import com.marketinghub.geralanding.deliverables.service.pending.RecordDeliverablesPending;
+import com.marketinghub.geralanding.deliverables.service.recebePrompt.RecebeDispatchRequest;
+import com.marketinghub.geralanding.deliverables.service.recebePrompt.RecebePromptRequest;
+import com.marketinghub.geralanding.deliverables.service.recebeResposta.RecebeRespostaRequest;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.junit.jupiter.api.Test;
+
+/** Valida o contrato HTTP da etapa deliverables do GeraLanding. */
+class GeraLandingDeliverablesControllerTest {
+
+    /** Deve delegar início da etapa deliverables para o serviço específico. */
+    @Test
+    void startShouldDelegateToDeliverablesService() {
+        GeraLandingDeliverablesStageService stageService = mock(GeraLandingDeliverablesStageService.class);
+        GeraLandingDeliverablesStageExecutionService executionService = mock(GeraLandingDeliverablesStageExecutionService.class);
+        GeraLandingDeliverablesController controller = new GeraLandingDeliverablesController(stageService, executionService);
+        when(stageService.start(44L)).thenReturn(new GeraLandingDeliverablesStartResponse("job-deliverables", "INICIADO"));
+
+        var response = controller.start(44L);
+
+        assertEquals(202, response.getStatusCode().value());
+        assertEquals("job-deliverables", response.getBody().idJob());
+        verify(stageService).start(44L);
+    }
+
+    /** Deve marcar a execução como em processamento antes da chamada OpenAI. */
+    @Test
+    void runningShouldDelegateToDeliverablesService() {
+        GeraLandingDeliverablesStageService stageService = mock(GeraLandingDeliverablesStageService.class);
+        GeraLandingDeliverablesStageExecutionService executionService = mock(GeraLandingDeliverablesStageExecutionService.class);
+        GeraLandingDeliverablesController controller = new GeraLandingDeliverablesController(stageService, executionService);
+
+        var response = controller.running("job-deliverables", new RecebeDispatchRequest(44L, "landing-page-deliverables", null));
+
+        assertEquals(202, response.getStatusCode().value());
+        verify(executionService).markRunning("job-deliverables");
+    }
+
+    /** Deve receber prompt e delegar o payload bruto para o serviço da etapa deliverables. */
+    @Test
+    void receivePromptShouldDelegateToDeliverablesService() {
+        GeraLandingDeliverablesStageService stageService = mock(GeraLandingDeliverablesStageService.class);
+        GeraLandingDeliverablesStageExecutionService executionService = mock(GeraLandingDeliverablesStageExecutionService.class);
+        GeraLandingDeliverablesController controller = new GeraLandingDeliverablesController(stageService, executionService);
+        RecebePromptRequest payload = new RecebePromptRequest(44L, "landing-page-deliverables", "prompt", "markdown", "{}", "{\"model\":\"gpt\"}", "gpt-5.5", null);
+
+        var response = controller.receivePrompt("job-deliverables", payload);
+
+        assertEquals(202, response.getStatusCode().value());
+        verify(executionService).markPromptReceived("job-deliverables", "prompt", "markdown", "{}", "{\"model\":\"gpt\"}", "gpt-5.5", null);
+    }
+
+    /** Deve receber resposta de sucesso e delegar conclusão para o serviço da etapa deliverables. */
+    @Test
+    void receiveResultShouldDelegateSuccessPayloadToDeliverablesService() {
+        GeraLandingDeliverablesStageService stageService = mock(GeraLandingDeliverablesStageService.class);
+        GeraLandingDeliverablesStageExecutionService executionService = mock(GeraLandingDeliverablesStageExecutionService.class);
+        GeraLandingDeliverablesController controller = new GeraLandingDeliverablesController(stageService, executionService);
+        RecebeRespostaRequest payload = new RecebeRespostaRequest(44L, "landing-page-deliverables", "{\"sampleDeliverables\":[],\"finalProductDeliverables\":[]}", 120, 80, new BigDecimal("0.012300"), "openai-job-1", null, null);
+
+        var response = controller.receiveResult("job-deliverables", payload);
+
+        assertEquals(202, response.getStatusCode().value());
+        verify(executionService).markCompletedFromResponse(
+                "job-deliverables", 44L, "landing-page-deliverables", "{\"sampleDeliverables\":[],\"finalProductDeliverables\":[]}", 120, 80,
+                new BigDecimal("0.012300"), "openai-job-1", null, null);
+    }
+
+    /** Deve serializar pending com os campos exigidos pelo Worker AI de deliverables. */
+    @Test
+    void pendingShouldSerializeListItemsWithExperimentJobidAndIdJob() throws Exception {
+        GeraLandingDeliverablesStageService stageService = mock(GeraLandingDeliverablesStageService.class);
+        GeraLandingDeliverablesStageExecutionService executionService = mock(GeraLandingDeliverablesStageExecutionService.class);
+        GeraLandingDeliverablesController controller = new GeraLandingDeliverablesController(stageService, executionService);
+        when(executionService.listPending("landing-page-deliverables")).thenReturn(List.of(new RecordDeliverablesPending(
+                33L,
+                "job-deliverables",
+                "job-deliverables",
+                "landing-page-deliverables",
+                "INICIADO",
+                Instant.parse("2026-06-08T00:00:00Z"),
+                pendingExperiment(33L, "Experimento 33", "Hipótese 33"),
+                pendingHypothesis())));
+
+        JsonNode json = new ObjectMapper().findAndRegisterModules().valueToTree(controller.pending());
+
+        assertTrue(json.isArray());
+        assertEquals(1, json.size());
+        assertEquals("job-deliverables", json.get(0).get("jobid").asText());
+        assertEquals("job-deliverables", json.get(0).get("idJob").asText());
+        assertEquals("INICIADO", json.get(0).get("status").asText());
+        assertEquals("<html>GeraLanding</html>", json.get(0).get("experiment").get("htmlGeraLanding").asText());
+        assertEquals("Dor superficial", json.get(0).get("hypothesis").get("framework").get("pain").get("surface").asText());
+    }
+
+    /** Cria a hipótese usada pelos testes de contrato pending. */
+    private RecordDeliverablesHypothesis pendingHypothesis() {
+        return new RecordDeliverablesHypothesis(
+                UUID.fromString("11111111-1111-1111-1111-111111111111"),
+                "Hipótese Framework",
+                Map.of("pain", Map.of("surface", "Dor superficial"), "result", Map.of("desiredResult", "Resultado desejado")));
+    }
+
+    /** Cria o resumo de experimento usado pelos testes de contrato pending. */
+    private RecordDeliverablesExperiment pendingExperiment(Long id, String name, String hypothesis) {
+        return new RecordDeliverablesExperiment(
+                id,
+                name,
+                hypothesis,
+                "PLANNED",
+                "LANDING",
+                "Prompt texto",
+                "Prompt imagem",
+                Map.of("campaignAngle", Map.of("singleMindedPromise", "Promessa clara")),
+                Map.of("adCopy", Map.of("headline", "Headline")),
+                "Briefing imagem",
+                "Copy landing",
+                "Wireframe landing",
+                "Planejamento imagem",
+                "Preset design",
+                null,
+                "Quality review",
+                "<html>GeraLanding</html>");
+    }
+}

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -4099,3 +4099,12 @@
 - foi feito: o cliente Responses API agora calcula o custo com `priceInputBatch` e `priceOutputBatch` retornados do banco para o modelo efetivo, mantendo a auditoria de tokens (`inputTokens`/`outputTokens`) e enviando `costUsd` calculado ao backend.
 - validação: adicionados testes unitários para confirmar cálculo via catálogo backend, URL de catálogo configurada e falha explícita quando o modelo não existe na tabela de preços.
 - observação operacional: os jobs já concluídos com `costUsd=0` não são recalculados automaticamente por essa alteração; novas execuções passam a gravar o custo correto a partir dos tokens retornados pela OpenAI.
+
+## 2026-06-08 — Processamento da etapa Gera Entregáveis no Worker AI
+
+- solicitação: criar o processamento do job `landing-page-deliverables` no Worker AI seguindo o padrão de pipeline por etapa descrito em `docs/metodologia/gerado-5-5/arquitetura-pipeline-etapas-archunit.md`.
+- causa-raiz: a etapa de entregáveis registrava execuções como `INICIADO`, mas não tinha fila interna completa no backend nem scheduler efetivo no Worker AI para capturar, processar, concluir e persistir `landing_page_deliverables`.
+- foi feito: o backend passou a expor endpoints internos de pendências, marcação de processamento, recebimento de prompt/request e recebimento de resposta/falha para `landing-page-deliverables`.
+- foi feito: o Worker AI recebeu o núcleo genérico `com.marketinghub.worker.pipeline` e a etapa concreta `pipeline.deliverables`, com scheduler, backend client, processor, validação JSON, artefatos auditáveis e chamada à OpenAI.
+- foi feito: o prompt de deliverables reforça que a saída deve ser JSON com `sampleDeliverables` para a amostra e `finalProductDeliverables` para a entrega do produto final.
+- impacto esperado: jobs de Gera Entregáveis deixam de ficar parados em `INICIADO` e passam a gerar o JSON comercial necessário para amostra gratuita e produto final completo.

--- a/docs/swagger/geralanding-backend-swagger.v1.yaml
+++ b/docs/swagger/geralanding-backend-swagger.v1.yaml
@@ -596,6 +596,109 @@ paths:
         '404':
           description: Experimento ou execução não encontrada.
 
+  /api/internal/geralanding/deliverables/stage-executions/pending:
+    get:
+      tags: [landing-page-deliverables]
+      summary: Lista jobs pendentes da etapa landing-page-deliverables.
+      operationId: pendingGeraLandingDeliverablesExecutions
+      responses:
+        '200':
+          $ref: '#/components/responses/PendingStageExecutionList'
+  /api/internal/geralanding/deliverables/stage-executions/{idJob}/running:
+    post:
+      tags: [landing-page-deliverables]
+      summary: Marca uma execução de deliverables como em processamento.
+      operationId: runningGeraLandingDeliverablesExecution
+      parameters:
+        - $ref: '#/components/parameters/IdJob'
+      requestBody:
+        $ref: '#/components/requestBodies/OpenAiDispatchMarker'
+      responses:
+        '202':
+          description: Execução marcada como em processamento.
+        '404':
+          description: Execução não encontrada.
+  /api/internal/geralanding/deliverables/stage-executions/{idJob}/receive-prompt:
+    post:
+      tags: [landing-page-deliverables]
+      summary: Alias legado que recebe prompt da IA para a etapa deliverables.
+      operationId: receivePromptGeraLandingDeliverablesExecution
+      parameters:
+        - $ref: '#/components/parameters/IdJob'
+      requestBody:
+        $ref: '#/components/requestBodies/PromptReceiveDirect'
+      responses:
+        '202':
+          description: Prompt recebido.
+        '400':
+          description: Payload inválido.
+        '404':
+          description: Execução não encontrada.
+  /api/internal/geralanding/deliverables/stage-executions/{idJob}/recebe-prompt:
+    post:
+      tags: [landing-page-deliverables]
+      summary: Recebe prompt, schema e request bruto enviados para IA na etapa deliverables.
+      operationId: recebePromptGeraLandingDeliverablesExecution
+      parameters:
+        - $ref: '#/components/parameters/IdJob'
+      requestBody:
+        $ref: '#/components/requestBodies/OpenAiPromptDispatchWithExperiment'
+      responses:
+        '202':
+          description: Prompt recebido.
+        '400':
+          description: Payload inválido.
+        '404':
+          description: Execução não encontrada.
+  /api/internal/geralanding/deliverables/stage-executions/{idJob}/receive-dispatch:
+    post:
+      tags: [landing-page-deliverables]
+      summary: Alias legado que marca dispatch OpenAI para a etapa deliverables.
+      operationId: receiveDispatchGeraLandingDeliverablesExecution
+      parameters:
+        - $ref: '#/components/parameters/IdJob'
+      requestBody:
+        $ref: '#/components/requestBodies/OpenAiDispatchMarker'
+      responses:
+        '202':
+          description: Dispatch recebido.
+        '400':
+          description: Payload inválido.
+        '404':
+          description: Execução não encontrada.
+  /api/internal/geralanding/deliverables/stage-executions/{idJob}/receive-result:
+    post:
+      tags: [landing-page-deliverables]
+      summary: Alias legado que recebe resultado da IA para a etapa deliverables.
+      operationId: receiveResultGeraLandingDeliverablesExecution
+      parameters:
+        - $ref: '#/components/parameters/IdJob'
+      requestBody:
+        $ref: '#/components/requestBodies/OpenAiStageResult'
+      responses:
+        '202':
+          description: Resultado recebido.
+        '400':
+          description: Payload inválido.
+        '404':
+          description: Execução não encontrada.
+  /api/internal/geralanding/deliverables/stage-executions/{idJob}/recebe-resposta:
+    post:
+      tags: [landing-page-deliverables]
+      summary: Recebe resposta da IA para a etapa deliverables.
+      operationId: recebeRespostaGeraLandingDeliverablesExecution
+      parameters:
+        - $ref: '#/components/parameters/IdJob'
+      requestBody:
+        $ref: '#/components/requestBodies/OpenAiStageResult'
+      responses:
+        '202':
+          description: Resposta recebida e execução concluída ou marcada como falha.
+        '400':
+          description: Payload inválido.
+        '404':
+          description: Execução não encontrada.
+
   /api/experiments/{experimentId}/geralanding/landing/approve-end-publish:
     post:
       tags: [landing-page-publication]


### PR DESCRIPTION
### Motivation
- Provide a reusable, technology-agnostic pipeline core to orchestrate stage processing and artifact auditing via `PipelineWorker` and related contracts.
- Implement the `landing-page-deliverables` stage end-to-end in the Worker AI so jobs no longer remain stuck in `INICIADO` and can produce validated JSON deliverables.
- Add internal backend endpoints and service logic to expose pending items, receive prompt/dispatch/result callbacks and persist deliverables on experiment records.
- Keep Worker AI isolated from concrete technologies via ports and an in-memory artifact store for audit references during development.

### Description
- Added generic pipeline core under `com.marketinghub.worker.pipeline`: `PipelineWorker`, `StageBackendPort`, `StageProcessor`, `StageContext`, `StageExecution`, `StageResult`, `StageArtifact`, `ArtifactStore` and an in-memory `InMemoryArtifactStore`, plus `ProcessingSummary` and `StageWorkerResult` for operational reporting.
- Implemented deliverables stage under `pipeline.deliverables`: `DeliverablesProcessor` (builds prompt, dispatches to OpenAI, stores artifacts), `DeliverablesBackendClient` (HTTP adapter to backend internal endpoints), `DeliverablesResponseValidator`, `DeliverablesWorkerConfiguration`, `DeliverablesExecutionScheduler`, `DeliverablesInput`/`DeliverablesOutput` and `DeliverablesWorkerProperties` (config + defaults); added prompt resource `landing-page-deliverables.md` and application properties.
- Extended `backend/ads-service` to support the pipeline: expanded `GeraLandingDeliverablesStageExecutionService` with pending listing, `markRunning`, `markPromptReceived`, `markWaitingOpenAiDispatch`, `markCompletedFromResponse` and helpers to normalize JSON artifacts and persist deliverables to `Experiment`; added DTOs for pending/dispatch/prompt/result and controller endpoints under `/api/internal/geralanding/deliverables/stage-executions` for `pending`, `running`, `receive-prompt`/`recebe-prompt`, `receive-dispatch`, `receive-result`/`recebe-resposta` and updated Swagger/docs.
- Tests and architecture checks: added `PipelineWorkerTest`, `DeliverablesResponseValidatorTest`, an ArchUnit `PipelineArchitectureTest` and `GeraLandingDeliverablesControllerTest` to validate contracts and behavior.

### Testing
- Ran unit tests `PipelineWorkerTest`, `DeliverablesResponseValidatorTest` and `GeraLandingDeliverablesControllerTest`, all of which passed.
- Executed the architecture/regression check `PipelineArchitectureTest` (ArchUnit) which passed, ensuring the pipeline root does not depend on concrete stage implementations or technologies.
- Manual/CI notes: integration with the OpenAI client is covered by the deliverables processor wiring but end-to-end OpenAI calls require configured `OpenAiClientPort` and backend endpoints; unit tests cover validation and controller/worker orchestration paths.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a25d09a744c832188936b17fabdd0aa)