### PR TITLE
Support tokenized OpenAI pricing parsing and sync; broaden model pricing resolution

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/modelos/openai/catalogo/v1/service/OpenAiModelCatalogV1Service.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/modelos/openai/catalogo/v1/service/OpenAiModelCatalogV1Service.java
@@ -65,10 +65,10 @@ public class OpenAiModelCatalogV1Service {
         }
     }
 
-    /** Busca preços oficiais de texto e indexa por código do modelo para enriquecer a lista de seleção. */
+    /** Busca preços oficiais tokenizados e indexa por código do modelo para enriquecer a lista de seleção. */
     private Map<String, OpenAiModelCatalogPriceResponse> fetchPricingByModel() {
         try {
-            List<OpenAiModelPricing> pricingRows = pricingPageClient.fetchTextModelPricing();
+            List<OpenAiModelPricing> pricingRows = pricingPageClient.fetchAllModelPricing();
             Map<String, OpenAiModelCatalogPriceResponse> pricingByModel = new LinkedHashMap<>();
             for (OpenAiModelPricing pricing : pricingRows) {
                 pricingByModel.put(pricing.code(), toPriceResponse(pricing));
@@ -76,7 +76,7 @@ public class OpenAiModelCatalogV1Service {
             List<OpenAiCatalogModelV1> catalogModels = repository.findAll();
             for (OpenAiCatalogModelV1 catalogModel : catalogModels) {
                 pricingPageClient
-                        .findBestTextModelPricing(pricingRows, catalogModel.getCode())
+                        .findBestModelPricing(pricingRows, catalogModel.getCode())
                         .ifPresent(pricing -> pricingByModel.putIfAbsent(
                                 catalogModel.getCode(), toPriceResponse(pricing)));
             }

--- a/backend/ads-service/src/main/java/com/marketinghub/openai/OpenAiPricingPageClient.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/openai/OpenAiPricingPageClient.java
@@ -18,7 +18,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
-/** Responsabilidade: consultar a página oficial de preços da OpenAI e extrair preços de modelos de texto. */
+/** Responsabilidade: consultar a página oficial de preços da OpenAI e extrair preços tokenizados de modelos suportados. */
 @Component
 public class OpenAiPricingPageClient {
     private static final Logger log = LoggerFactory.getLogger(OpenAiPricingPageClient.class);
@@ -31,8 +31,8 @@ public class OpenAiPricingPageClient {
         this.properties = properties;
     }
 
-    /** Busca a página oficial de preços e retorna os modelos com preços standard e batch consolidados. */
-    public List<OpenAiModelPricing> fetchTextModelPricing() {
+    /** Busca a página oficial de preços e retorna modelos tokenizados com preços standard e batch consolidados. */
+    public List<OpenAiModelPricing> fetchAllModelPricing() {
         try {
             String html = Jsoup.connect(properties.getPricingUrl())
                     .userAgent("MarketingHub/1.0 (+https://oportunidadebrasil.shop)")
@@ -41,7 +41,7 @@ public class OpenAiPricingPageClient {
                     .followRedirects(true)
                     .execute()
                     .body();
-            return parseTextModelPricing(html);
+            return parseAllModelPricing(html);
         } catch (IOException ex) {
             log.error(
                     "Falha de IO ao buscar página oficial de preços OpenAI; operation=openai-pricing-fetch source={}",
@@ -57,8 +57,13 @@ public class OpenAiPricingPageClient {
         }
     }
 
+    /** Busca preços tokenizados preservando compatibilidade com chamadas antigas focadas em texto. */
+    public List<OpenAiModelPricing> fetchTextModelPricing() {
+        return fetchAllModelPricing();
+    }
+
     /** Seleciona preço exato ou preço-base mais específico para variantes datadas retornadas por /models. */
-    public Optional<OpenAiModelPricing> findBestTextModelPricing(List<OpenAiModelPricing> prices, String modelCode) {
+    public Optional<OpenAiModelPricing> findBestModelPricing(List<OpenAiModelPricing> prices, String modelCode) {
         if (prices == null || modelCode == null || modelCode.isBlank()) {
             return Optional.empty();
         }
@@ -74,24 +79,45 @@ public class OpenAiPricingPageClient {
                 .max((left, right) -> Integer.compare(left.code().length(), right.code().length()));
     }
 
+    /** Seleciona preço mantendo compatibilidade com chamadas antigas focadas em texto. */
+    public Optional<OpenAiModelPricing> findBestTextModelPricing(List<OpenAiModelPricing> prices, String modelCode) {
+        return findBestModelPricing(prices, modelCode);
+    }
+
     /** Converte o timeout configurado para milissegundos aceitos pelo cliente HTTP de preços. */
     private int toRequestTimeoutMillis() {
         long millis = properties.getRequestTimeout().toMillis();
         return millis > Integer.MAX_VALUE ? Integer.MAX_VALUE : Math.max(1, (int) millis);
     }
 
-    /** Extrai os preços oficiais textuais, aceitando tabela legada standard/batch ou tabela atual short/long context. */
-    public List<OpenAiModelPricing> parseTextModelPricing(String html) {
+    /** Extrai os preços oficiais tokenizados, aceitando múltiplas seções standard/batch da página atual. */
+    public List<OpenAiModelPricing> parseAllModelPricing(String html) {
         if (html == null || html.isBlank()) {
             return List.of();
         }
-        List<Map<String, PriceTriple>> tables = parseTextPricingTables(html);
+        List<PricingTable> tables = parsePricingTables(html);
         if (tables.isEmpty()) {
-            log.warn("Nenhuma tabela de preço de texto OpenAI encontrada; operation=openai-pricing-parse source={}", properties.getPricingUrl());
+            log.warn(
+                    "Nenhuma tabela tokenizada de preço OpenAI encontrada; operation=openai-pricing-parse source={}",
+                    properties.getPricingUrl());
             return List.of();
         }
-        Map<String, PriceTriple> standard = tables.get(0);
-        Map<String, PriceTriple> batch = tables.size() > 1 ? tables.get(1) : Map.of();
+        Map<String, PriceTriple> standard = new LinkedHashMap<>();
+        Map<String, PriceTriple> batch = new LinkedHashMap<>();
+        for (PricingTable table : tables) {
+            if (table.mode() == PricingMode.SKIP) {
+                continue;
+            }
+            for (Map.Entry<String, PriceTriple> entry : table.rows().entrySet()) {
+                if (table.mode() == PricingMode.BATCH) {
+                    batch.putIfAbsent(entry.getKey(), entry.getValue());
+                } else if (table.mode() == PricingMode.STANDARD || !standard.containsKey(entry.getKey())) {
+                    standard.putIfAbsent(entry.getKey(), entry.getValue());
+                } else {
+                    batch.putIfAbsent(entry.getKey(), entry.getValue());
+                }
+            }
+        }
         List<OpenAiModelPricing> result = new ArrayList<>();
         for (Map.Entry<String, PriceTriple> entry : standard.entrySet()) {
             PriceTriple standardPrice = entry.getValue();
@@ -109,10 +135,15 @@ public class OpenAiPricingPageClient {
         return result;
     }
 
+    /** Extrai preços mantendo compatibilidade com chamadas antigas focadas em texto. */
+    public List<OpenAiModelPricing> parseTextModelPricing(String html) {
+        return parseAllModelPricing(html);
+    }
+
     /** Localiza tabelas com colunas de modelo, input, cached input e output e converte suas linhas em preços. */
-    private List<Map<String, PriceTriple>> parseTextPricingTables(String html) {
+    private List<PricingTable> parsePricingTables(String html) {
         Document document = Jsoup.parse(html);
-        List<Map<String, PriceTriple>> parsedTables = new ArrayList<>();
+        List<PricingTable> parsedTables = new ArrayList<>();
         for (Element table : document.select("table")) {
             String headerText = table.select("thead").text().toLowerCase(Locale.ROOT);
             if (!headerText.contains("model") || !headerText.contains("input") || !headerText.contains("output")) {
@@ -120,31 +151,54 @@ public class OpenAiPricingPageClient {
             }
             Map<String, PriceTriple> rows = parseRows(table.select("tbody tr"));
             if (!rows.isEmpty()) {
-                parsedTables.add(rows);
+                parsedTables.add(new PricingTable(resolveTableMode(table), rows));
             }
         }
         return parsedTables;
     }
 
-    /** Converte linhas HTML de preço em mapa por código canônico do modelo. */
+    /** Converte linhas HTML de preço em mapa por código canônico do modelo e escolhe a modalidade operacional. */
     private Map<String, PriceTriple> parseRows(Elements rows) {
         Map<String, PriceTriple> tablePrices = new LinkedHashMap<>();
+        Map<String, Integer> scores = new LinkedHashMap<>();
+        String currentCode = null;
         for (Element row : rows) {
             Elements cells = row.select("td");
             if (cells.size() < 4) {
                 continue;
             }
-            String displayName = cells.get(0).text().trim();
-            String code = normalizeModelCode(displayName);
-            if (!isTextModelCode(code)) {
+            RowPricing rowPricing = parseRowPricing(cells, currentCode);
+            if (rowPricing == null || !isSupportedTokenModelCode(rowPricing.code())) {
                 continue;
             }
-            PriceTriple price = parsePriceTriple(cells, 1, code);
-            if (price != null) {
-                tablePrices.put(code, price);
+            currentCode = rowPricing.code();
+            PriceTriple price = parsePriceTriple(cells, rowPricing.firstPriceCell(), rowPricing.code());
+            if (price == null) {
+                continue;
+            }
+            int score = modalityScore(rowPricing.code(), rowPricing.modality());
+            if (score > scores.getOrDefault(rowPricing.code(), -1)) {
+                tablePrices.put(rowPricing.code(), price);
+                scores.put(rowPricing.code(), score);
             }
         }
         return tablePrices;
+    }
+
+    /** Identifica código, modalidade opcional e posição inicial dos preços dentro de uma linha de tabela. */
+    private RowPricing parseRowPricing(Elements cells, String currentCode) {
+        String first = cells.get(0).text().trim();
+        String normalizedFirst = normalizeModelCode(first);
+        if (isSupportedTokenModelCode(normalizedFirst)) {
+            if (cells.size() >= 5 && isKnownModality(cells.get(1).text())) {
+                return new RowPricing(normalizedFirst, cells.get(1).text().trim(), 2);
+            }
+            return new RowPricing(normalizedFirst, null, 1);
+        }
+        if (currentCode != null && isKnownModality(first)) {
+            return new RowPricing(currentCode, first, 1);
+        }
+        return null;
     }
 
     /** Extrai um trio input/cache/output a partir da posição inicial informada na linha da tabela. */
@@ -161,14 +215,74 @@ public class OpenAiPricingPageClient {
         return new PriceTriple(code, input, zeroIfNull(cachedInput), output);
     }
 
+    /** Classifica a tabela para separar preços standard, batch e modos que não cabem no contrato financeiro atual. */
+    private PricingMode resolveTableMode(Element table) {
+        String context = previousContext(table).toLowerCase(Locale.ROOT);
+        int batch = context.lastIndexOf("batch");
+        int standard = context.lastIndexOf("standard");
+        int flex = context.lastIndexOf("flex");
+        int priority = context.lastIndexOf("priority");
+        if ((flex > batch && flex > standard) || (priority > batch && priority > standard)) {
+            return PricingMode.SKIP;
+        }
+        if (batch > standard) {
+            return PricingMode.BATCH;
+        }
+        if (standard >= 0) {
+            return PricingMode.STANDARD;
+        }
+        return PricingMode.UNKNOWN;
+    }
+
+    /** Coleta contexto textual próximo antes da tabela para inferir se ela representa standard ou batch. */
+    private String previousContext(Element table) {
+        StringBuilder context = new StringBuilder();
+        Element previous = table.previousElementSibling();
+        for (int i = 0; previous != null && i < 8; i++) {
+            String text = previous.text();
+            if (!text.isBlank()) {
+                context.insert(0, text + " ");
+            }
+            previous = previous.previousElementSibling();
+        }
+        return context.toString();
+    }
+
     /** Remove observações de contexto e normaliza o código do modelo para comparação e persistência. */
     private String normalizeModelCode(String value) {
         return value.replaceAll("\\s*\\(.*$", "").trim().toLowerCase(Locale.ROOT);
     }
 
-    /** Indica se o código extraído representa modelo de texto/reasoning suportado no catálogo financeiro. */
-    private boolean isTextModelCode(String code) {
-        return code.startsWith("gpt-") || code.startsWith("o1") || code.startsWith("o3") || code.startsWith("o4");
+    /** Indica se o código extraído representa modelo tokenizado suportado no catálogo financeiro. */
+    private boolean isSupportedTokenModelCode(String code) {
+        return code.startsWith("gpt-")
+                || code.startsWith("o1")
+                || code.startsWith("o3")
+                || code.startsWith("o4")
+                || code.startsWith("text-")
+                || code.startsWith("chatgpt-")
+                || code.startsWith("computer-use-");
+    }
+
+    /** Verifica se a célula representa uma modalidade de preço tokenizado na tabela oficial. */
+    private boolean isKnownModality(String value) {
+        String normalized = value == null ? "" : value.trim().toLowerCase(Locale.ROOT);
+        return normalized.equals("text") || normalized.equals("image") || normalized.equals("audio");
+    }
+
+    /** Prioriza a modalidade que melhor representa o uso operacional do modelo no contrato atual de preços. */
+    private int modalityScore(String code, String modality) {
+        if (modality == null || modality.isBlank()) {
+            return 2;
+        }
+        String normalized = modality.trim().toLowerCase(Locale.ROOT);
+        if (code.startsWith("gpt-image")) {
+            return normalized.equals("image") ? 4 : 1;
+        }
+        if (code.startsWith("gpt-realtime") || code.startsWith("gpt-audio")) {
+            return normalized.equals("audio") ? 4 : 2;
+        }
+        return normalized.equals("text") ? 4 : 1;
     }
 
     /** Verifica se o código de /models é uma variante datada do código-base publicado na página de preços. */
@@ -193,6 +307,20 @@ public class OpenAiPricingPageClient {
     private BigDecimal zeroIfNull(BigDecimal value) {
         return value == null ? BigDecimal.ZERO : value;
     }
+
+    /** Responsabilidade: indicar o papel operacional de uma tabela de preços parseada. */
+    private enum PricingMode {
+        STANDARD,
+        BATCH,
+        UNKNOWN,
+        SKIP
+    }
+
+    /** Responsabilidade: transportar uma tabela de preços parseada com seu modo financeiro. */
+    private record PricingTable(PricingMode mode, Map<String, PriceTriple> rows) {}
+
+    /** Responsabilidade: transportar a interpretação de uma linha de preço da tabela oficial. */
+    private record RowPricing(String code, String modality, int firstPriceCell) {}
 
     /** Responsabilidade: manter um trio de preços input/cache/output por modo de processamento. */
     private record PriceTriple(String name, BigDecimal input, BigDecimal cachedInput, BigDecimal output) {

--- a/backend/ads-service/src/main/java/com/marketinghub/openai/service/OpenAiModelPricingSyncService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/openai/service/OpenAiModelPricingSyncService.java
@@ -29,7 +29,7 @@ public class OpenAiModelPricingSyncService {
     /** Consulta a fonte oficial e persiste preços atuais, inclusive para variantes datadas já cadastradas. */
     @Transactional
     public int syncOfficialPricing() {
-        List<OpenAiModelPricing> prices = pricingPageClient.fetchTextModelPricing();
+        List<OpenAiModelPricing> prices = pricingPageClient.fetchAllModelPricing();
         Instant syncedAt = Instant.now();
         int updated = upsertOfficialBaseModels(prices, syncedAt);
         updated += refreshExistingModelVariants(prices, syncedAt);
@@ -59,7 +59,7 @@ public class OpenAiModelPricingSyncService {
             if (prices.stream().anyMatch(price -> price.code().equals(model.getCode()))) {
                 continue;
             }
-            var pricing = pricingPageClient.findBestTextModelPricing(prices, model.getCode());
+            var pricing = pricingPageClient.findBestModelPricing(prices, model.getCode());
             if (pricing.isPresent()) {
                 applyPrice(model, pricing.get(), syncedAt, false);
                 repository.save(model);

--- a/backend/ads-service/src/main/java/com/marketinghub/openai/service/OpenAiModelService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/openai/service/OpenAiModelService.java
@@ -119,8 +119,8 @@ public class OpenAiModelService {
 
     /** Aplica na entidade persistida os dados oficiais resolvidos a partir da API e da página de preços da OpenAI. */
     private void applyOfficialData(OpenAiModel model, String requestedName, String code, boolean imageModel) {
-        List<OpenAiModelPricing> prices = pricingPageClient.fetchTextModelPricing();
-        Optional<OpenAiModelPricing> pricing = pricingPageClient.findBestTextModelPricing(prices, code);
+        List<OpenAiModelPricing> prices = pricingPageClient.fetchAllModelPricing();
+        Optional<OpenAiModelPricing> pricing = pricingPageClient.findBestModelPricing(prices, code);
         model.setName(toDisplayName(requestedName, code));
         model.setCode(code);
         if (pricing.isPresent()) {
@@ -133,7 +133,7 @@ public class OpenAiModelService {
         model.setLastPricingSyncAt(Instant.now());
     }
 
-    /** Aplica os preços oficiais de texto na entidade usada para cálculo financeiro. */
+    /** Aplica os preços oficiais tokenizados na entidade usada para cálculo financeiro. */
     private void applyPricing(OpenAiModel model, OpenAiModelPricing pricing) {
         model.setPriceInputStandard(pricing.priceInputStandard());
         model.setPriceInputCachedStandard(pricing.priceInputCachedStandard());

--- a/backend/ads-service/src/test/java/com/marketinghub/openai/OpenAiModelPricingSyncServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/openai/OpenAiModelPricingSyncServiceTest.java
@@ -48,8 +48,8 @@ class OpenAiModelPricingSyncServiceTest {
                 .priceInputCachedBatch(BigDecimal.ZERO)
                 .priceOutputBatch(BigDecimal.ZERO)
                 .build();
-        when(pricingPageClient.fetchTextModelPricing()).thenReturn(List.of(basePrice));
-        when(pricingPageClient.findBestTextModelPricing(List.of(basePrice), datedVariant.getCode()))
+        when(pricingPageClient.fetchAllModelPricing()).thenReturn(List.of(basePrice));
+        when(pricingPageClient.findBestModelPricing(List.of(basePrice), datedVariant.getCode()))
                 .thenReturn(Optional.of(basePrice));
         when(repository.findByCode("gpt-5.5")).thenReturn(Optional.empty());
         when(repository.findAll()).thenReturn(List.of(datedVariant));
@@ -83,7 +83,7 @@ class OpenAiModelPricingSyncServiceTest {
                 new BigDecimal("2.50"),
                 new BigDecimal("0.25"),
                 new BigDecimal("15.00"));
-        when(pricingPageClient.fetchTextModelPricing()).thenReturn(List.of(basePrice));
+        when(pricingPageClient.fetchAllModelPricing()).thenReturn(List.of(basePrice));
         when(repository.findByCode("gpt-5.5")).thenReturn(Optional.empty());
         when(repository.findAll()).thenReturn(List.of());
 

--- a/backend/ads-service/src/test/java/com/marketinghub/openai/OpenAiPricingPageClientTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/openai/OpenAiPricingPageClientTest.java
@@ -6,8 +6,10 @@ import java.math.BigDecimal;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
+/** Responsabilidade: validar parsing e resolução de preços oficiais OpenAI para modelos tokenizados. */
 class OpenAiPricingPageClientTest {
 
+    /** Garante compatibilidade com tabelas legadas de preços standard e batch por modelo textual. */
     @Test
     void shouldParseStandardAndBatchPricesFromOfficialPricingTables() {
         OpenAiProperties properties = new OpenAiProperties();
@@ -42,6 +44,7 @@ class OpenAiPricingPageClientTest {
         assertThat(pricing.priceOutputBatch()).isEqualByComparingTo(new BigDecimal("15.00"));
     }
 
+    /** Garante fallback de batch como metade do standard quando a fonte não publica uma tabela batch. */
     @Test
     void shouldUseHalfStandardAsBatchFallbackWhenBatchTableIsMissing() {
         OpenAiProperties properties = new OpenAiProperties();
@@ -62,6 +65,7 @@ class OpenAiPricingPageClientTest {
         assertThat(pricing.priceOutputBatch()).isEqualByComparingTo(new BigDecimal("2.20"));
     }
 
+    /** Garante que tabelas com contexto curto e longo usem o preço operacional de contexto curto. */
     @Test
     void shouldParsePricesFromCurrentShortAndLongContextTable() {
         OpenAiProperties properties = new OpenAiProperties();
@@ -91,6 +95,94 @@ class OpenAiPricingPageClientTest {
         assertThat(pricing.priceOutputBatch()).isEqualByComparingTo(new BigDecimal("7.50"));
     }
 
+
+    /** Garante que modelos de imagem sejam sincronizados pela modalidade Image nas tabelas oficiais. */
+    @Test
+    void shouldParseImageModelPricesFromOfficialPricingTablesWithModalityColumn() {
+        OpenAiProperties properties = new OpenAiProperties();
+        OpenAiPricingPageClient client = new OpenAiPricingPageClient(properties);
+
+        List<OpenAiModelPricing> prices = client.parseAllModelPricing("""
+                <html><body>
+                  <section>
+                    <h3>Image generation models</h3>
+                    <p>Standard</p>
+                    <table>
+                      <thead><tr><th>Model</th><th>Modality</th><th>Input</th><th>Cached input</th><th>Output</th></tr></thead>
+                      <tbody>
+                        <tr><td>gpt-image-2</td><td>Image</td><td>$8.00</td><td>$2.00</td><td>$30.00</td></tr>
+                        <tr><td></td><td>Text</td><td>$5.00</td><td>$1.25</td><td>-</td></tr>
+                        <tr><td>gpt-image-1.5</td><td>Image</td><td>$8.00</td><td>$2.00</td><td>$32.00</td></tr>
+                        <tr><td></td><td>Text</td><td>$5.00</td><td>$1.25</td><td>$10.00</td></tr>
+                      </tbody>
+                    </table>
+                    <p>Batch</p>
+                    <table>
+                      <thead><tr><th>Model</th><th>Modality</th><th>Input</th><th>Cached input</th><th>Output</th></tr></thead>
+                      <tbody>
+                        <tr><td>gpt-image-2</td><td>Image</td><td>$4.00</td><td>$1.00</td><td>$15.00</td></tr>
+                        <tr><td></td><td>Text</td><td>$2.50</td><td>$0.625</td><td>-</td></tr>
+                        <tr><td>gpt-image-1.5</td><td>Image</td><td>$4.00</td><td>$1.00</td><td>$16.00</td></tr>
+                        <tr><td></td><td>Text</td><td>$2.50</td><td>$0.63</td><td>$5.00</td></tr>
+                      </tbody>
+                    </table>
+                  </section>
+                </body></html>
+                """);
+
+        assertThat(prices).extracting(OpenAiModelPricing::code).contains("gpt-image-2", "gpt-image-1.5");
+        OpenAiModelPricing gptImage2 = prices.stream()
+                .filter(pricing -> pricing.code().equals("gpt-image-2"))
+                .findFirst()
+                .orElseThrow();
+        assertThat(gptImage2.priceInputStandard()).isEqualByComparingTo(new BigDecimal("8.00"));
+        assertThat(gptImage2.priceInputCachedStandard()).isEqualByComparingTo(new BigDecimal("2.00"));
+        assertThat(gptImage2.priceOutputStandard()).isEqualByComparingTo(new BigDecimal("30.00"));
+        assertThat(gptImage2.priceInputBatch()).isEqualByComparingTo(new BigDecimal("4.00"));
+        assertThat(gptImage2.priceInputCachedBatch()).isEqualByComparingTo(new BigDecimal("1.00"));
+        assertThat(gptImage2.priceOutputBatch()).isEqualByComparingTo(new BigDecimal("15.00"));
+    }
+
+    /** Garante que o parser percorra todas as seções de preço e não apenas o primeiro par de tabelas. */
+    @Test
+    void shouldParseMultiplePricingSectionsInsteadOfOnlyFirstPairOfTables() {
+        OpenAiProperties properties = new OpenAiProperties();
+        OpenAiPricingPageClient client = new OpenAiPricingPageClient(properties);
+
+        List<OpenAiModelPricing> prices = client.parseAllModelPricing("""
+                <html><body>
+                  <h3>Flagship chat models</h3>
+                  <p>Standard</p>
+                  <table>
+                    <thead><tr><th>Model</th><th>Input</th><th>Cached input</th><th>Output</th></tr></thead>
+                    <tbody><tr><td>gpt-5.5</td><td>$5.00</td><td>$0.50</td><td>$30.00</td></tr></tbody>
+                  </table>
+                  <p>Batch</p>
+                  <table>
+                    <thead><tr><th>Model</th><th>Input</th><th>Cached input</th><th>Output</th></tr></thead>
+                    <tbody><tr><td>gpt-5.5</td><td>$2.50</td><td>$0.25</td><td>$15.00</td></tr></tbody>
+                  </table>
+                  <h3>Image generation models</h3>
+                  <p>Standard</p>
+                  <table>
+                    <thead><tr><th>Model</th><th>Modality</th><th>Input</th><th>Cached input</th><th>Output</th></tr></thead>
+                    <tbody><tr><td>gpt-image-1.5</td><td>Image</td><td>$8.00</td><td>$2.00</td><td>$32.00</td></tr></tbody>
+                  </table>
+                  <p>Batch</p>
+                  <table>
+                    <thead><tr><th>Model</th><th>Modality</th><th>Input</th><th>Cached input</th><th>Output</th></tr></thead>
+                    <tbody><tr><td>gpt-image-1.5</td><td>Image</td><td>$4.00</td><td>$1.00</td><td>$16.00</td></tr></tbody>
+                  </table>
+                </body></html>
+                """);
+
+        assertThat(prices).extracting(OpenAiModelPricing::code).containsExactly("gpt-5.5", "gpt-image-1.5");
+        OpenAiModelPricing image = prices.get(1);
+        assertThat(image.priceOutputStandard()).isEqualByComparingTo(new BigDecimal("32.00"));
+        assertThat(image.priceOutputBatch()).isEqualByComparingTo(new BigDecimal("16.00"));
+    }
+
+    /** Garante que variantes datadas usem o preço-base oficial mais específico. */
     @Test
     void shouldResolvePricingForDatedModelVariantUsingMostSpecificBaseCode() {
         OpenAiProperties properties = new OpenAiProperties();

--- a/backend/ads-service/src/test/java/com/marketinghub/openai/service/OpenAiModelPricingSyncServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/openai/service/OpenAiModelPricingSyncServiceTest.java
@@ -14,14 +14,16 @@ import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 
+/** Responsabilidade: validar a sincronização transacional de preços oficiais OpenAI. */
 class OpenAiModelPricingSyncServiceTest {
 
+    /** Garante que a sincronização atualize modelos pelo código canônico retornado pela fonte oficial. */
     @Test
     void shouldUpsertOfficialPricingByModelCode() {
         OpenAiPricingPageClient client = mock(OpenAiPricingPageClient.class);
         OpenAiModelRepository repository = mock(OpenAiModelRepository.class);
         OpenAiModel existing = new OpenAiModel();
-        when(client.fetchTextModelPricing()).thenReturn(List.of(new OpenAiModelPricing(
+        when(client.fetchAllModelPricing()).thenReturn(List.of(new OpenAiModelPricing(
                 "gpt-5.5",
                 "gpt-5.5",
                 new BigDecimal("5.00"),
@@ -42,4 +44,35 @@ class OpenAiModelPricingSyncServiceTest {
         assertThat(existing.getLastPricingSyncAt()).isNotNull();
         verify(repository).save(existing);
     }
+
+    /** Garante que a sincronização persista preços de modelos de imagem quando publicados pela fonte oficial. */
+    @Test
+    void shouldUpsertImageModelPricingByModelCode() {
+        OpenAiPricingPageClient client = mock(OpenAiPricingPageClient.class);
+        OpenAiModelRepository repository = mock(OpenAiModelRepository.class);
+        OpenAiModel existing = new OpenAiModel();
+        when(client.fetchAllModelPricing()).thenReturn(List.of(new OpenAiModelPricing(
+                "gpt-image-2",
+                "gpt-image-2",
+                new BigDecimal("8.00"),
+                new BigDecimal("2.00"),
+                new BigDecimal("30.00"),
+                new BigDecimal("4.00"),
+                new BigDecimal("1.00"),
+                new BigDecimal("15.00"))));
+        when(repository.findByCode("gpt-image-2")).thenReturn(Optional.of(existing));
+
+        int updated = new OpenAiModelPricingSyncService(client, repository).syncOfficialPricing();
+
+        assertThat(updated).isEqualTo(1);
+        assertThat(existing.getCode()).isEqualTo("gpt-image-2");
+        assertThat(existing.getPriceInputStandard()).isEqualByComparingTo(new BigDecimal("8.00"));
+        assertThat(existing.getPriceInputCachedStandard()).isEqualByComparingTo(new BigDecimal("2.00"));
+        assertThat(existing.getPriceOutputStandard()).isEqualByComparingTo(new BigDecimal("30.00"));
+        assertThat(existing.getPriceInputBatch()).isEqualByComparingTo(new BigDecimal("4.00"));
+        assertThat(existing.getPriceInputCachedBatch()).isEqualByComparingTo(new BigDecimal("1.00"));
+        assertThat(existing.getPriceOutputBatch()).isEqualByComparingTo(new BigDecimal("15.00"));
+        verify(repository).save(existing);
+    }
+
 }

--- a/backend/ads-service/src/test/java/com/marketinghub/openai/service/OpenAiModelServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/openai/service/OpenAiModelServiceTest.java
@@ -47,8 +47,8 @@ class OpenAiModelServiceTest {
                 new BigDecimal("0.25"),
                 new BigDecimal("15.00"));
         List<OpenAiModelPricing> prices = List.of(pricing);
-        when(pricingPageClient.fetchTextModelPricing()).thenReturn(prices);
-        when(pricingPageClient.findBestTextModelPricing(prices, "gpt-5.5")).thenReturn(Optional.of(pricing));
+        when(pricingPageClient.fetchAllModelPricing()).thenReturn(prices);
+        when(pricingPageClient.findBestModelPricing(prices, "gpt-5.5")).thenReturn(Optional.of(pricing));
         when(repository.findByCode("gpt-5.5")).thenReturn(Optional.empty());
         when(repository.save(org.mockito.ArgumentMatchers.any(OpenAiModel.class)))
                 .thenAnswer(invocation -> invocation.getArgument(0));
@@ -90,8 +90,8 @@ class OpenAiModelServiceTest {
                 BigDecimal.ZERO,
                 new BigDecimal("90.00"));
         List<OpenAiModelPricing> prices = List.of(pricing);
-        when(pricingPageClient.fetchTextModelPricing()).thenReturn(prices);
-        when(pricingPageClient.findBestTextModelPricing(prices, "gpt-5.4-pro-2026-03-05"))
+        when(pricingPageClient.fetchAllModelPricing()).thenReturn(prices);
+        when(pricingPageClient.findBestModelPricing(prices, "gpt-5.4-pro-2026-03-05"))
                 .thenReturn(Optional.of(pricing));
         when(repository.findByCode("gpt-5.4-pro-2026-03-05")).thenReturn(Optional.empty());
         when(repository.save(org.mockito.ArgumentMatchers.any(OpenAiModel.class)))


### PR DESCRIPTION
### Motivation
- Expand pricing support from legacy "text" tables to the tokenized pricing layout used by OpenAI, including multiple sections and modalities (text/image/audio). 
- Ensure pricing lookup and synchronization pick the most specific base price for dated model variants and remain backward compatible with existing calls.
- Improve robustness of HTML parsing to handle modality columns, multiple table sections, and table context (standard vs batch).

### Description
- Reworked `OpenAiPricingPageClient` to parse tokenized pricing: added `fetchAllModelPricing`, `parseAllModelPricing`, `parsePricingTables`, `PricingTable`, `RowPricing`, `PricingMode`, and modality handling methods, while keeping compatibility wrappers `fetchTextModelPricing` and `parseTextModelPricing` that forward to the new implementations. 
- Enhanced parsing logic to detect modality columns, infer table mode (standard/batch/skip) from surrounding context, merge multiple sections, and score modality-specific rows so the most relevant price is chosen for each model. 
- Replaced usages of text-focused methods with the new tokenized APIs: callers updated include `OpenAiModelCatalogV1Service.fetchPricingByModel`, `OpenAiModelPricingSyncService.syncOfficialPricing`, and `OpenAiModelService.applyOfficialData` to use `fetchAllModelPricing` and `findBestModelPricing`. 
- Broadened model-code recognition to accept additional tokenized prefixes (e.g. `text-`, `chatgpt-`, `computer-use-`) and added helpers `isKnownModality`, `modalityScore`, and improved normalization. 
- Updated and extended unit tests to reflect the new behavior and to validate parsing for short/long context tables, image modality tables, multiple pricing sections, and sync behavior for image models.

### Testing
- Ran unit tests in `OpenAiPricingPageClientTest`, `OpenAiModelPricingSyncServiceTest`, `OpenAiModelServiceTest`, and `OpenAiModelPricingSyncServiceTest`, with new cases added for modality parsing and multi-section parsing; all tests passed.
- Verified updated sync and service tests that call `fetchAllModelPricing` / `findBestModelPricing` succeed and assert correct price application for base and dated variant models.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a26d59240f8832093e86c93bdc66cf7)