### PR TITLE
Remove MCP endpoint authentication

### DIFF
--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -40,8 +40,8 @@ mvn -s settings.xml spring-boot:run
 
 ## Segurança
 
-- Se `MCP_API_KEY` estiver definido, o endpoint `/mcp` exige `Authorization: Bearer <MCP_API_KEY>`.
-- Se `MCP_API_KEY` estiver vazio, o endpoint permanece aberto (apenas para ambientes internos/controlados).
+- O endpoint `/mcp` não solicita nem valida autenticação de entrada (sem token, API key ou header `Authorization`).
+- Mantenha a exposição controlada por rede/proxy/firewall quando necessário, sem exigir credencial no contrato HTTP do MCP.
 
 ## Logs de Spring Boot dos módulos Java
 
@@ -117,7 +117,6 @@ docker run --rm -p 8096:8096 \
   -e SPRING_DATASOURCE_URL=jdbc:mysql://<host>:3306/<db> \
   -e SPRING_DATASOURCE_USERNAME=<user> \
   -e SPRING_DATASOURCE_PASSWORD=<pass> \
-  -e MCP_API_KEY=<token-forte> \
   marketinghub/mcp-server
 ```
 
@@ -144,7 +143,6 @@ Depois, valide:
 ```bash
 curl -i http://mcpserverdigi.shop/mcp \
   -H 'Content-Type: application/json' \
-  -H 'Authorization: Bearer <MCP_API_KEY>' \
   -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}'
 ```
 
@@ -261,16 +259,14 @@ Se nada for encontrado, reemita o certificado e valide novamente o caminho `live
 > Esta etapa corresponde ao item 3 (instalar/publicar o servidor MCP no Codex Cloud).
 
 1. Publique o `mcp-server` em uma URL HTTPS pública, por exemplo `https://mcp.seudominio.com/mcp`.
-2. Defina `MCP_API_KEY` no servidor para proteger o endpoint.
-3. No Codex Cloud, crie/instale um plugin MCP apontando para a URL publicada e passando o header de autenticação.
-4. Use o arquivo `codex-cloud/mcp-server-config.example.json` como base para preencher os dados do ambiente.
+2. No Codex Cloud, crie/instale um plugin MCP apontando para a URL publicada sem headers de autenticação.
+3. Use o arquivo `codex-cloud/mcp-server-config.example.json` como base para preencher os dados do ambiente.
 
 ### Teste rápido antes de conectar ao Codex
 
 ```bash
 curl -sS https://mcp.seudominio.com/mcp \
   -H 'Content-Type: application/json' \
-  -H 'Authorization: Bearer <MCP_API_KEY>' \
   -d '{"jsonrpc":"2.0","id":1,"method":"initialize","params":{}}'
 ```
 

--- a/mcp-server/codex-cloud/mcp-server-config.example.json
+++ b/mcp-server/codex-cloud/mcp-server-config.example.json
@@ -3,9 +3,6 @@
   "description": "MCP do Marketing Hub para diagnóstico de banco (db_health)",
   "transport": {
     "type": "http",
-    "url": "https://mcp.seudominio.com/mcp",
-    "headers": {
-      "Authorization": "Bearer ${MCP_API_KEY}"
-    }
+    "url": "https://mcp.seudominio.com/mcp"
   }
 }

--- a/mcp-server/src/main/java/com/marketinghub/mcpserver/config/McpProperties.java
+++ b/mcp-server/src/main/java/com/marketinghub/mcpserver/config/McpProperties.java
@@ -18,7 +18,6 @@ import java.util.List;
 public record McpProperties(
         @NotBlank String serverName,
         @NotBlank String serverVersion,
-        String apiKey,
         @NotNull @Valid Logs logs,
         @NotNull @Valid Meta meta,
         @NotNull @Valid Github github

--- a/mcp-server/src/main/java/com/marketinghub/mcpserver/controller/McpController.java
+++ b/mcp-server/src/main/java/com/marketinghub/mcpserver/controller/McpController.java
@@ -10,7 +10,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
-import org.springframework.util.StringUtils;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -31,8 +30,6 @@ public class McpController {
 
     private static final Logger logger = LoggerFactory.getLogger(McpController.class);
 
-    private static final String AUTHORIZATION_HEADER = "Authorization";
-    private static final String BEARER_PREFIX = "Bearer ";
     private static final int DEFAULT_LIMIT = 50;
     private static final int MAX_LIMIT = 200;
     private static final int MAX_QUERY_LIMIT = 500;
@@ -85,10 +82,6 @@ public class McpController {
         String method = String.valueOf(request.getOrDefault("method", ""));
         logger.info("Nova requisição MCP recebida: requestId={} method={} remoteAddr={} userAgent={}",
                 id, method, httpServletRequest.getRemoteAddr(), httpServletRequest.getHeader("User-Agent"));
-        if (!isAuthorized(httpServletRequest)) {
-            return ResponseEntity.status(401).body(error(id, -32001, "Unauthorized"));
-        }
-
         return switch (method) {
             case "initialize" -> ResponseEntity.ok(success(id, Map.of(
                     "protocolVersion", "2024-11-05",
@@ -243,20 +236,6 @@ public class McpController {
             case "tools/call" -> ResponseEntity.ok(callTool(id, request));
             default -> ResponseEntity.ok(error(id, -32601, "Method not found: " + method));
         };
-    }
-
-    /**
-     * Valida o bearer token quando a chave MCP está configurada.
-     */
-    private boolean isAuthorized(HttpServletRequest request) {
-        if (!StringUtils.hasText(properties.apiKey())) {
-            return true;
-        }
-
-        String authHeader = request.getHeader(AUTHORIZATION_HEADER);
-        return StringUtils.hasText(authHeader)
-                && authHeader.startsWith(BEARER_PREFIX)
-                && properties.apiKey().equals(authHeader.substring(BEARER_PREFIX.length()));
     }
 
     /**

--- a/mcp-server/src/main/resources/application.yml
+++ b/mcp-server/src/main/resources/application.yml
@@ -40,7 +40,6 @@ logging:
 mcp:
   server-name: ${MCP_SERVER_NAME:marketing-hub-mcp}
   server-version: ${MCP_SERVER_VERSION:1.0.0}
-  api-key: ${MCP_API_KEY:}
   logs:
     backend-path: ${MCP_LOG_BACKEND_PATH:http://191.252.120.96:4567/worker-observability/logfile}
     ai-worker-path: ${MCP_LOG_AI_WORKER_PATH:http://191.252.120.96:4567/worker-observability/logfile}

--- a/mcp-server/src/test/java/com/marketinghub/mcpserver/controller/McpControllerTest.java
+++ b/mcp-server/src/test/java/com/marketinghub/mcpserver/controller/McpControllerTest.java
@@ -20,6 +20,9 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
+/**
+ * Valida o contrato HTTP/JSON-RPC público do controller MCP.
+ */
 @SpringBootTest
 @AutoConfigureMockMvc
 class McpControllerTest {
@@ -32,6 +35,9 @@ class McpControllerTest {
     @Autowired
     private JdbcTemplate jdbcTemplate;
 
+    /**
+     * Configura datasource e paths de logs isolados para os testes do controller MCP.
+     */
     @DynamicPropertySource
     static void setDatasource(DynamicPropertyRegistry registry) {
         registry.add("spring.datasource.url", () -> "jdbc:h2:mem:mcpdb;MODE=MySQL;DB_CLOSE_DELAY=-1");
@@ -62,6 +68,9 @@ class McpControllerTest {
         registry.add("mcp.github.repo", () -> "marketing-hub");
     }
 
+    /**
+     * Prepara dados e arquivos de log usados pelas tools testadas.
+     */
     @BeforeEach
     void setupDatabase() throws Exception {
         jdbcTemplate.execute("DROP TABLE IF EXISTS leads");
@@ -78,6 +87,9 @@ class McpControllerTest {
                 StandardCharsets.UTF_8);
     }
 
+    /**
+     * Garante que o método initialize responde sem autenticação.
+     */
     @Test
     void shouldInitializeMcpServer() throws Exception {
         mockMvc.perform(post("/mcp")
@@ -89,6 +101,9 @@ class McpControllerTest {
                 .andExpect(jsonPath("$.result.serverInfo.name").value("marketing-hub-mcp"));
     }
 
+    /**
+     * Garante que o GET de reachability expõe metadados básicos do MCP.
+     */
     @Test
     void shouldExposeGetEndpointForReachabilityChecks() throws Exception {
         mockMvc.perform(get("/mcp"))
@@ -97,6 +112,9 @@ class McpControllerTest {
                 .andExpect(jsonPath("$.protocol").value("json-rpc-2.0"));
     }
 
+    /**
+     * Garante que a tool db_health retorna status operacional do banco.
+     */
     @Test
     void shouldCallDbHealthTool() throws Exception {
         mockMvc.perform(post("/mcp")
@@ -108,6 +126,9 @@ class McpControllerTest {
                 .andExpect(jsonPath("$.result.structuredContent.status").value("ok"));
     }
 
+    /**
+     * Garante que a tool db_list_tables lista as tabelas do schema de teste.
+     */
     @Test
     void shouldListDatabaseTables() throws Exception {
         mockMvc.perform(post("/mcp")
@@ -120,6 +141,9 @@ class McpControllerTest {
                 .andExpect(jsonPath("$.result.structuredContent.tables[0]").value("LEADS"));
     }
 
+    /**
+     * Garante que a tool db_read_table retorna linhas paginadas da tabela solicitada.
+     */
     @Test
     void shouldReadTableRows() throws Exception {
         mockMvc.perform(post("/mcp")
@@ -134,6 +158,9 @@ class McpControllerTest {
                 .andExpect(jsonPath("$.result.structuredContent.rows[0].EMAIL").value("ana@example.com"));
     }
 
+    /**
+     * Garante que a tool db_read_table rejeita nomes de tabela inválidos.
+     */
     @Test
     void shouldRejectInvalidTableName() throws Exception {
         mockMvc.perform(post("/mcp")
@@ -145,6 +172,9 @@ class McpControllerTest {
                 .andExpect(jsonPath("$.error.code").value(-32602));
     }
 
+    /**
+     * Garante que a tool db_query executa apenas leitura e retorna dados.
+     */
     @Test
     void shouldExecuteReadOnlyQueryTool() throws Exception {
         mockMvc.perform(post("/mcp")
@@ -157,6 +187,9 @@ class McpControllerTest {
                 .andExpect(jsonPath("$.result.structuredContent.rows[0].NAME").value("Ana"));
     }
 
+    /**
+     * Garante que a tool db_query rejeita comandos que alteram dados.
+     */
     @Test
     void shouldRejectNonSelectQuery() throws Exception {
         mockMvc.perform(post("/mcp")
@@ -169,6 +202,9 @@ class McpControllerTest {
                 .andExpect(jsonPath("$.error.message").value("only SELECT queries are allowed"));
     }
 
+    /**
+     * Garante que a tool java_module_logs lê logs de módulo Java configurado.
+     */
     @Test
     void shouldReadJavaModuleLogs() throws Exception {
         mockMvc.perform(post("/mcp")
@@ -184,6 +220,9 @@ class McpControllerTest {
                 .andExpect(jsonPath("$.result.structuredContent.lines[1]").value("line-3"));
     }
 
+    /**
+     * Garante que o alias mois-sales-library-worker usa o path de log esperado.
+     */
     @Test
     void shouldReadMoisSalesLibraryWorkerLogs() throws Exception {
         mockMvc.perform(post("/mcp")
@@ -199,6 +238,9 @@ class McpControllerTest {
                         .value("mois-sales-library-worker-line-2"));
     }
 
+    /**
+     * Garante que a tool java_module_logs rejeita módulos fora da lista permitida.
+     */
     @Test
     void shouldRejectInvalidJavaModuleName() throws Exception {
         mockMvc.perform(post("/mcp")
@@ -214,6 +256,9 @@ class McpControllerTest {
 
 
 
+    /**
+     * Garante que a tool java_module_logs aplica filtro textual e paginação.
+     */
     @Test
     void shouldFilterAndPaginateJavaModuleLogs() throws Exception {
         mockMvc.perform(post("/mcp")
@@ -225,6 +270,9 @@ class McpControllerTest {
                 .andExpect(jsonPath("$.result.structuredContent.returnedLines").value(1))
                 .andExpect(jsonPath("$.result.structuredContent.lines[0]").value("line-2"));
     }
+    /**
+     * Garante que erros JSON-RPC preservam id nulo quando a requisição não informou id.
+     */
     @Test
     void shouldHandleErrorResponseWhenRequestIdIsNull() throws Exception {
         mockMvc.perform(post("/mcp")
@@ -238,6 +286,9 @@ class McpControllerTest {
                 .andExpect(jsonPath("$.error.code").value(-32601));
     }
 
+    /**
+     * Garante que tools Meta e GitHub continuam anunciadas em tools/list.
+     */
     @Test
     void shouldListMetaTools() throws Exception {
         mockMvc.perform(post("/mcp")
@@ -254,6 +305,25 @@ class McpControllerTest {
     }
 
 
+
+    /**
+     * Garante que headers Authorization enviados por clientes legados são ignorados.
+     */
+    @Test
+    void shouldIgnoreAuthorizationHeaderWhenClientStillSendsBearerToken() throws Exception {
+        mockMvc.perform(post("/mcp")
+                        .header("Authorization", "Bearer legacy-token")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"jsonrpc":"2.0","id":17,"method":"initialize","params":{}}
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result.serverInfo.name").value("marketing-hub-mcp"));
+    }
+
+    /**
+     * Garante que tools GitHub desabilitadas retornam erro explícito.
+     */
     @Test
     void shouldRejectGithubToolWhenDisabled() throws Exception {
         mockMvc.perform(post("/mcp")
@@ -266,6 +336,9 @@ class McpControllerTest {
                 .andExpect(jsonPath("$.error.message").value("github tools are disabled (set mcp.github.enabled=true)"));
     }
 
+    /**
+     * Garante que tools Meta desabilitadas retornam erro explícito.
+     */
     @Test
     void shouldRejectMetaToolWhenDisabled() throws Exception {
         mockMvc.perform(post("/mcp")
@@ -276,67 +349,5 @@ class McpControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.error.code").value(-32602))
                 .andExpect(jsonPath("$.error.message").value("meta tools are disabled (set mcp.meta.enabled=true)"));
-    }
-}
-
-@SpringBootTest(properties = "mcp.api-key=super-secret")
-@AutoConfigureMockMvc
-class McpControllerApiKeyEnabledTest {
-
-    private static final Path TEST_LOG_DIR = Path.of("target/test-logs-api-key");
-
-    @Autowired
-    private MockMvc mockMvc;
-
-    @DynamicPropertySource
-    static void setDatasource(DynamicPropertyRegistry registry) {
-        registry.add("spring.datasource.url", () -> "jdbc:h2:mem:mcpdb2;MODE=MySQL;DB_CLOSE_DELAY=-1");
-        registry.add("spring.datasource.driver-class-name", () -> "org.h2.Driver");
-        registry.add("spring.datasource.username", () -> "sa");
-        registry.add("spring.datasource.password", () -> "");
-        registry.add("mcp.logs.backend-path", () -> TEST_LOG_DIR.resolve("backend.log").toString());
-        registry.add("mcp.logs.ai-worker-path", () -> TEST_LOG_DIR.resolve("ai-worker.log").toString());
-        registry.add("mcp.logs.lead-portal-path", () -> TEST_LOG_DIR.resolve("lead-portal.log").toString());
-        registry.add("mcp.logs.facebook-ads-path", () -> TEST_LOG_DIR.resolve("facebook-ads.log").toString());
-        registry.add("mcp.logs.email-service-path", () -> TEST_LOG_DIR.resolve("email-service.log").toString());
-        registry.add("mcp.logs.lead-portal-payment-path",
-                () -> TEST_LOG_DIR.resolve("lead-portal-payment.log").toString());
-        registry.add("mcp.logs.mds-path", () -> TEST_LOG_DIR.resolve("mds.log").toString());
-        registry.add("mcp.logs.mois-path", () -> TEST_LOG_DIR.resolve("mois.log").toString());
-        registry.add("mcp.logs.mois-sales-library-worker-path",
-                () -> TEST_LOG_DIR.resolve("mois-sales-library-worker.log").toString());
-        registry.add("mcp.logs.mois-hotmart-path", () -> TEST_LOG_DIR.resolve("mois-hotmart.log").toString());
-        registry.add("mcp.logs.oprm-coletor-receita-path", () -> TEST_LOG_DIR.resolve("oprm-coletor-receita.log").toString());
-        registry.add("mcp.logs.max-lines", () -> "500");
-        registry.add("mcp.meta.enabled", () -> "false");
-        registry.add("mcp.meta.graph-base-url", () -> "https://graph.facebook.com");
-        registry.add("mcp.meta.graph-version", () -> "v23.0");
-        registry.add("mcp.meta.docs-allowed-hosts", () -> "developers.facebook.com,business.facebook.com");
-        registry.add("mcp.github.enabled", () -> "false");
-        registry.add("mcp.github.api-base-url", () -> "https://api.github.com");
-        registry.add("mcp.github.owner", () -> "marketinghub");
-        registry.add("mcp.github.repo", () -> "marketing-hub");
-    }
-
-    @Test
-    void shouldRejectWhenAuthorizationHeaderIsMissing() throws Exception {
-        mockMvc.perform(post("/mcp")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("""
-                                {"jsonrpc":"2.0","id":3,"method":"initialize","params":{}}
-                                """))
-                .andExpect(status().isUnauthorized());
-    }
-
-    @Test
-    void shouldAuthorizeWhenBearerTokenMatches() throws Exception {
-        mockMvc.perform(post("/mcp")
-                        .header("Authorization", "Bearer super-secret")
-                        .contentType(MediaType.APPLICATION_JSON)
-                        .content("""
-                                {"jsonrpc":"2.0","id":4,"method":"initialize","params":{}}
-                                """))
-                .andExpect(status().isOk())
-                .andExpect(jsonPath("$.result.serverInfo.name").value("marketing-hub-mcp"));
     }
 }


### PR DESCRIPTION
### Motivation

- Make the MCP HTTP/JSON-RPC contract unauthenticated so the `/mcp` endpoint does not require tokens/Authorization headers and can be used from internal tooling/plugins without a bearer key.

### Description

- Removed inbound bearer/API-key validation from the MCP controller by deleting the `isAuthorized` check and related constants/imports in `mcp-server/src/main/java/com/marketinghub/mcpserver/controller/McpController.java` so `handleRequest` accepts `initialize`, `tools/list` and `tools/call` without auth.
- Removed the `apiKey` binding from `McpProperties` and the `mcp.api-key` entry in `mcp-server/src/main/resources/application.yml` to eliminate the configuration surface for endpoint authentication.
- Updated documentation and integration sample to reflect the unauthenticated contract by editing `mcp-server/README.md` and `mcp-server/codex-cloud/mcp-server-config.example.json` to remove `Authorization` examples and instruct clients to call the endpoint without headers.
- Adjusted controller tests in `mcp-server/src/test/java/com/marketinghub/mcpserver/controller/McpControllerTest.java` to assert the unauthenticated behavior, to ensure legacy `Authorization` headers are ignored, and added clarifying test comments and small test reorganizations.

### Testing

- Ran static checks `git diff --check` and `rg -n "MCP_API_KEY|mcp\.api-key|api-key:|apiKey|isAuthorized|Unauthorized|Authorization: Bearer|headers" mcp-server` which showed the updated references (success).
- Attempted to run the full test suite with `mvn -s settings.xml test`, but execution was blocked by environment/network: Maven failed to resolve the Spring Boot parent POM due to DNS/name resolution errors (`repo.maven.apache.org: Temporary failure in name resolution`).
- Attempted offline build with `mvn -o -s settings.xml test` which also failed because the Spring Boot parent POM is not present in the local cache, so unit tests could not be executed in this environment.
- Unit tests were adapted to the new unauthenticated behavior and are expected to pass locally or in CI when Maven can resolve dependencies.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a26e74054f4832684f1113d20efab8b)