### PR TITLE
Fix MCP test McpProperties constructors

### DIFF
--- a/mcp-server/src/test/java/com/marketinghub/mcpserver/service/MetaToolsServiceTest.java
+++ b/mcp-server/src/test/java/com/marketinghub/mcpserver/service/MetaToolsServiceTest.java
@@ -37,7 +37,6 @@ class MetaToolsServiceTest {
         McpProperties properties = new McpProperties(
                 "marketing-hub-mcp",
                 "1.0.0",
-                null,
                 new McpProperties.Logs("a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", 45, 3, 400, 500, 262144),
                 new McpProperties.Meta(
                         true,

--- a/mcp-server/src/test/java/com/marketinghub/mcpserver/service/ModuleLogServiceTest.java
+++ b/mcp-server/src/test/java/com/marketinghub/mcpserver/service/ModuleLogServiceTest.java
@@ -104,6 +104,6 @@ class ModuleLogServiceTest {
                 ""
         );
 
-        return new McpProperties("marketing-hub-mcp", "1.0.0", "", logs, meta, github);
+        return new McpProperties("marketing-hub-mcp", "1.0.0", logs, meta, github);
     }
 }


### PR DESCRIPTION
### Motivation
- Fix compilation failures in MCP server tests caused by constructing the `McpProperties` record with an incorrect/obsolete argument list. 

### Description
- Update `mcp-server/src/test/java/com/marketinghub/mcpserver/service/MetaToolsServiceTest.java` to instantiate `McpProperties` using the current five-argument record constructor (removed the obsolete `null` third argument). 
- Update `mcp-server/src/test/java/com/marketinghub/mcpserver/service/ModuleLogServiceTest.java` to build `McpProperties` with the current constructor signature (removed the extra empty-string argument). 

### Testing
- Attempted to run `mvn test` in `mcp-server`, but Maven could not resolve the Spring Boot parent POM from Maven Central due to an HTTP 403, so the test run could not complete. 
- Verified the root cause was the constructor argument mismatch in tests and updated test sources to match the `McpProperties` record signature so the prior compilation errors should be resolved once dependencies are reachable.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a26f2c6d1688326a0db4907efefd2e8)