### PR TITLE
Add guideline for user responses to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,6 +20,7 @@ O Marketing Hub é uma fábrica automatizada de produtos digitais: descobre dore
 - **Regra Número 1** : O objetivo principal do sistema é gerar VENDAS de produtos que ofereçam valor através do uso da Inteligencia Artificial.
 - **Regra Número 2** : Sempre que tiver algum problema não tentar resolver consequencias. Buscar SEMPRE resolver a causa-raiz.
 - **Regra Número 3** : Seja SIMPLES, OBJETIVO e EFICAZ.
+- **Respostas ao usuário nesta interação**: ao responder o usuário, priorize um nível mais alto, conceitual, objetivo e orientado ao negócio; baseie as respostas principalmente na análise do código, do banco de dados e dos logs, e só depois complemente com a documentação quando necessário; reduza detalhes técnicos, comandos e implementação interna ao mínimo necessário para sustentar a decisão ou o próximo passo.
 - invesgtigação da causa raiz
 - Se for um erro na tela:
 - 1. Pesquisar o dado da tela de qual endpoint ele vem


### PR DESCRIPTION
### Motivation
- Introduce an explicit instruction in `AGENTS.md` to standardize how responses to users should be framed, prioritizing high-level, business-oriented guidance based on code, database and logs while minimizing low-level technical details.

### Description
- Insert a new bullet under "Convenções de engenharia" in `AGENTS.md` named "Respostas ao usuário nesta interação" that instructs responders to favor conceptual, objective and business-focused answers and to reduce internal implementation details and commands.

### Testing
- This is a documentation-only change so no unit tests were required; `markdownlint` was run against `AGENTS.md` and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a2701221288832697dbf264128e91b9)