### PR TITLE
Use GHCR BuildKit image for Buildx bootstrap in CI workflows

### DIFF
--- a/.github/workflows/ai-worker.yml
+++ b/.github/workflows/ai-worker.yml
@@ -71,6 +71,9 @@ jobs:
       - uses: actions/checkout@v4
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+        with:
+          driver-opts: |
+            image=ghcr.io/moby/buildkit:buildx-stable-1
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/deploy-containers.yml
+++ b/.github/workflows/deploy-containers.yml
@@ -71,6 +71,9 @@ jobs:
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+        with:
+          driver-opts: |
+            image=ghcr.io/moby/buildkit:buildx-stable-1
 
       - name: Build Docker image
         uses: docker/build-push-action@v6

--- a/.github/workflows/email-service-ci.yml
+++ b/.github/workflows/email-service-ci.yml
@@ -46,6 +46,9 @@ jobs:
       - uses: actions/checkout@v4
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+        with:
+          driver-opts: |
+            image=ghcr.io/moby/buildkit:buildx-stable-1
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/facebook-ads-worker.yml
+++ b/.github/workflows/facebook-ads-worker.yml
@@ -51,6 +51,9 @@ jobs:
       - uses: actions/checkout@v4
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+        with:
+          driver-opts: |
+            image=ghcr.io/moby/buildkit:buildx-stable-1
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/image-watermark-ci.yml
+++ b/.github/workflows/image-watermark-ci.yml
@@ -46,6 +46,9 @@ jobs:
       - uses: actions/checkout@v4
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+        with:
+          driver-opts: |
+            image=ghcr.io/moby/buildkit:buildx-stable-1
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/image-zipper-ci.yml
+++ b/.github/workflows/image-zipper-ci.yml
@@ -46,6 +46,9 @@ jobs:
       - uses: actions/checkout@v4
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+        with:
+          driver-opts: |
+            image=ghcr.io/moby/buildkit:buildx-stable-1
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/lead-portal-ci.yml
+++ b/.github/workflows/lead-portal-ci.yml
@@ -67,6 +67,9 @@ jobs:
       - uses: actions/checkout@v4
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+        with:
+          driver-opts: |
+            image=ghcr.io/moby/buildkit:buildx-stable-1
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/lead-portal-payments-ci.yml
+++ b/.github/workflows/lead-portal-payments-ci.yml
@@ -46,6 +46,9 @@ jobs:
       - uses: actions/checkout@v4
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+        with:
+          driver-opts: |
+            image=ghcr.io/moby/buildkit:buildx-stable-1
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/mds-ci.yml
+++ b/.github/workflows/mds-ci.yml
@@ -46,6 +46,9 @@ jobs:
       - uses: actions/checkout@v4
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+        with:
+          driver-opts: |
+            image=ghcr.io/moby/buildkit:buildx-stable-1
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/oprm-ci.yml
+++ b/.github/workflows/oprm-ci.yml
@@ -46,6 +46,9 @@ jobs:
       - uses: actions/checkout@v4
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+        with:
+          driver-opts: |
+            image=ghcr.io/moby/buildkit:buildx-stable-1
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/oprm-coletor-mei-ci.yml
+++ b/.github/workflows/oprm-coletor-mei-ci.yml
@@ -46,6 +46,9 @@ jobs:
       - uses: actions/checkout@v4
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+        with:
+          driver-opts: |
+            image=ghcr.io/moby/buildkit:buildx-stable-1
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
         with:

--- a/.github/workflows/vitrines-ci.yml
+++ b/.github/workflows/vitrines-ci.yml
@@ -67,6 +67,9 @@ jobs:
       - uses: actions/checkout@v4
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
+        with:
+          driver-opts: |
+            image=ghcr.io/moby/buildkit:buildx-stable-1
       - name: Log in to GitHub Container Registry
         uses: docker/login-action@v3
         with:


### PR DESCRIPTION
### Motivation
- Buildx bootstrap was intermittently failing with Docker Hub auth/timeouts when pulling `moby/buildkit:buildx-stable-1`, blocking CI image builds. 
- Pinning the BuildKit bootstrap image source to the GHCR container image reduces reliance on Docker Hub pulls and addresses the timeout failure mode. 

### Description
- Add `with: driver-opts: | image=ghcr.io/moby/buildkit:buildx-stable-1` to every `docker/setup-buildx-action@v3` step so Buildx bootstraps using the GHCR BuildKit image. 
- The change was applied to the CI workflow files: `.github/workflows/ai-worker.yml`, `deploy-containers.yml`, `email-service-ci.yml`, `facebook-ads-worker.yml`, `image-watermark-ci.yml`, `image-zipper-ci.yml`, `lead-portal-ci.yml`, `lead-portal-payments-ci.yml`, `mds-ci.yml`, `oprm-ci.yml`, `oprm-coletor-mei-ci.yml` and `vitrines-ci.yml`. 
- Existing `docker/build-push-action` usage, cache settings and build semantics were preserved so image build and cache behavior remains unchanged. 

### Testing
- `ruby -e 'require "yaml"; Dir[".github/workflows/*.yml"].sort.each { |f| YAML.load_file(f) }; puts "workflow yaml ok"'` was run and returned success, validating workflow YAML syntax. 
- `git diff --check` was run and reported no whitespace/format issues. 
- An attempted Python YAML validation using `PyYAML` was skipped/failed because the runtime lacked the `yaml` module, so that specific check did not run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a2701e2aa6883269ed167a0254e67ee)