### PR TITLE
Use OpenAI authenticated /models API for pricing instead of scraping pricing page

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/modelos/openai/catalogo/v1/service/OpenAiModelCatalogV1Service.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/modelos/openai/catalogo/v1/service/OpenAiModelCatalogV1Service.java
@@ -57,7 +57,7 @@ public class OpenAiModelCatalogV1Service {
                     new ArrayList<>(text),
                     new ArrayList<>(image),
                     fetchPricingByModel(),
-                    "openai:/models + openai:pricing",
+                    "openai:/models",
                     now.toString());
         } catch (RuntimeException ex) {
             log.error("Falha ao consultar catálogo oficial OpenAI; operation=openai-model-catalog-fetch endpoint=/models", ex);
@@ -83,9 +83,9 @@ public class OpenAiModelCatalogV1Service {
             return pricingByModel;
         } catch (RuntimeException ex) {
             log.error(
-                    "Falha ao consultar preços oficiais OpenAI para catálogo; operation=openai-model-catalog-pricing source=pricing-page",
+                    "Falha ao consultar preços oficiais OpenAI para catálogo; operation=openai-model-catalog-pricing source=openai-models-api",
                     ex);
-            return Map.of();
+            throw ex;
         }
     }
 

--- a/backend/ads-service/src/main/java/com/marketinghub/openai/OpenAiPricingPageClient.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/openai/OpenAiPricingPageClient.java
@@ -1,58 +1,56 @@
 package com.marketinghub.openai;
 
-import java.io.IOException;
+import com.fasterxml.jackson.databind.JsonNode;
 import java.math.BigDecimal;
 import java.util.ArrayList;
-import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
-import java.util.Map;
 import java.util.Optional;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
-import org.jsoup.Jsoup;
-import org.jsoup.nodes.Document;
-import org.jsoup.nodes.Element;
-import org.jsoup.select.Elements;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
+import org.springframework.web.reactive.function.client.WebClient;
 
-/** Responsabilidade: consultar a página oficial de preços da OpenAI e extrair preços tokenizados de modelos suportados. */
+/** Responsabilidade: consultar a API autenticada da OpenAI e extrair preços tokenizados de modelos suportados. */
 @Component
 public class OpenAiPricingPageClient {
     private static final Logger log = LoggerFactory.getLogger(OpenAiPricingPageClient.class);
     private static final Pattern MONEY_PATTERN = Pattern.compile("[0-9]+(?:\\.[0-9]+)?");
 
-    private final OpenAiProperties properties;
+    private final WebClient openAiWebClient;
 
-    /** Inicializa o cliente com as propriedades de URL/timeout da integração OpenAI. */
-    public OpenAiPricingPageClient(OpenAiProperties properties) {
-        this.properties = properties;
+    /** Inicializa o cliente com o WebClient autenticado da API OpenAI. */
+    @Autowired
+    public OpenAiPricingPageClient(@Qualifier("openAiWebClient") WebClient openAiWebClient) {
+        this.openAiWebClient = openAiWebClient;
     }
 
-    /** Busca a página oficial de preços e retorna modelos tokenizados com preços standard e batch consolidados. */
+    /** Inicializa o cliente em testes focados no parser da resposta autenticada. */
+    OpenAiPricingPageClient() {
+        this.openAiWebClient = null;
+    }
+
+    /** Busca preços exclusivamente na API autenticada da OpenAI e falha quando a API não entregar preços. */
     public List<OpenAiModelPricing> fetchAllModelPricing() {
+        if (openAiWebClient == null) {
+            throw new IllegalStateException("Cliente autenticado da OpenAI não configurado para buscar preços.");
+        }
         try {
-            String html = Jsoup.connect(properties.getPricingUrl())
-                    .userAgent("MarketingHub/1.0 (+https://oportunidadebrasil.shop)")
-                    .timeout(toRequestTimeoutMillis())
-                    .ignoreContentType(true)
-                    .followRedirects(true)
-                    .execute()
-                    .body();
-            return parseAllModelPricing(html);
-        } catch (IOException ex) {
-            log.error(
-                    "Falha de IO ao buscar página oficial de preços OpenAI; operation=openai-pricing-fetch source={}",
-                    properties.getPricingUrl(),
-                    ex);
-            throw new IllegalStateException("Não foi possível consultar a página oficial de preços da OpenAI.", ex);
+            JsonNode response = openAiWebClient.get().uri("/models").retrieve().bodyToMono(JsonNode.class).block();
+            List<OpenAiModelPricing> prices = parseAuthenticatedApiPricing(response);
+            if (prices.isEmpty()) {
+                throw new IllegalStateException("API OpenAI /models não retornou metadados de preço para sincronização.");
+            }
+            log.info(
+                    "Preços OpenAI obtidos pela API autenticada; operation=openai-pricing-api-fetch models={}",
+                    prices.size());
+            return prices;
         } catch (RuntimeException ex) {
-            log.error(
-                    "Falha inesperada ao buscar página oficial de preços OpenAI; operation=openai-pricing-fetch source={}",
-                    properties.getPricingUrl(),
-                    ex);
+            log.error("Falha ao buscar preços pela API autenticada OpenAI; operation=openai-pricing-api-fetch endpoint=/models", ex);
             throw ex;
         }
     }
@@ -60,6 +58,38 @@ public class OpenAiPricingPageClient {
     /** Busca preços tokenizados preservando compatibilidade com chamadas antigas focadas em texto. */
     public List<OpenAiModelPricing> fetchTextModelPricing() {
         return fetchAllModelPricing();
+    }
+
+    /** Converte uma resposta autenticada de /models em preços a partir dos metadados financeiros do payload. */
+    List<OpenAiModelPricing> parseAuthenticatedApiPricing(JsonNode response) {
+        if (response == null || !response.path("data").isArray()) {
+            return List.of();
+        }
+        List<OpenAiModelPricing> prices = new ArrayList<>();
+        for (JsonNode model : response.path("data")) {
+            String code = model.path("id").asText("").trim().toLowerCase(Locale.ROOT);
+            if (!isSupportedTokenModelCode(code)) {
+                continue;
+            }
+            Optional<PriceTriple> standard = findApiPriceTriple(model, code, PricingMode.STANDARD);
+            if (standard.isEmpty()) {
+                continue;
+            }
+            Optional<PriceTriple> batch = findApiPriceTriple(model, code, PricingMode.BATCH);
+            if (batch.isEmpty()) {
+                continue;
+            }
+            prices.add(new OpenAiModelPricing(
+                    code,
+                    code,
+                    standard.get().input(),
+                    standard.get().cachedInput(),
+                    standard.get().output(),
+                    batch.get().input(),
+                    batch.get().cachedInput(),
+                    batch.get().output()));
+        }
+        return prices;
     }
 
     /** Seleciona preço exato ou preço-base mais específico para variantes datadas retornadas por /models. */
@@ -84,173 +114,68 @@ public class OpenAiPricingPageClient {
         return findBestModelPricing(prices, modelCode);
     }
 
-    /** Converte o timeout configurado para milissegundos aceitos pelo cliente HTTP de preços. */
-    private int toRequestTimeoutMillis() {
-        long millis = properties.getRequestTimeout().toMillis();
-        return millis > Integer.MAX_VALUE ? Integer.MAX_VALUE : Math.max(1, (int) millis);
+    /** Localiza no JSON da API o bloco financeiro standard ou batch, priorizando modalidade operacional correta. */
+    private Optional<PriceTriple> findApiPriceTriple(JsonNode model, String code, PricingMode mode) {
+        JsonNode pricing = model.path("pricing");
+        if (pricing.isMissingNode() || pricing.isNull()) {
+            return Optional.empty();
+        }
+        List<JsonNode> candidates = new ArrayList<>();
+        JsonNode modeNode = pricing.path(mode.name().toLowerCase(Locale.ROOT));
+        addApiPricingCandidates(candidates, modeNode, code);
+        addApiPricingCandidates(candidates, pricing.path(code.startsWith("gpt-image") ? "image" : "text"), code);
+        addApiPricingCandidates(candidates, pricing, code);
+        for (JsonNode candidate : candidates) {
+            PriceTriple price = parseApiPriceTriple(code, candidate);
+            if (price != null) {
+                return Optional.of(price);
+            }
+        }
+        return Optional.empty();
     }
 
-    /** Extrai os preços oficiais tokenizados, aceitando múltiplas seções standard/batch da página atual. */
-    public List<OpenAiModelPricing> parseAllModelPricing(String html) {
-        if (html == null || html.isBlank()) {
-            return List.of();
+    /** Adiciona candidatos de preço da API considerando objetos diretos e subobjetos por modalidade. */
+    private void addApiPricingCandidates(List<JsonNode> candidates, JsonNode node, String code) {
+        if (node == null || node.isMissingNode() || node.isNull()) {
+            return;
         }
-        List<PricingTable> tables = parsePricingTables(html);
-        if (tables.isEmpty()) {
-            log.warn(
-                    "Nenhuma tabela tokenizada de preço OpenAI encontrada; operation=openai-pricing-parse source={}",
-                    properties.getPricingUrl());
-            return List.of();
+        if (code.startsWith("gpt-image")) {
+            candidates.add(node.path("image"));
+        } else {
+            candidates.add(node.path("text"));
         }
-        Map<String, PriceTriple> standard = new LinkedHashMap<>();
-        Map<String, PriceTriple> batch = new LinkedHashMap<>();
-        for (PricingTable table : tables) {
-            if (table.mode() == PricingMode.SKIP) {
-                continue;
-            }
-            for (Map.Entry<String, PriceTriple> entry : table.rows().entrySet()) {
-                if (table.mode() == PricingMode.BATCH) {
-                    batch.putIfAbsent(entry.getKey(), entry.getValue());
-                } else if (table.mode() == PricingMode.STANDARD || !standard.containsKey(entry.getKey())) {
-                    standard.putIfAbsent(entry.getKey(), entry.getValue());
-                } else {
-                    batch.putIfAbsent(entry.getKey(), entry.getValue());
-                }
-            }
-        }
-        List<OpenAiModelPricing> result = new ArrayList<>();
-        for (Map.Entry<String, PriceTriple> entry : standard.entrySet()) {
-            PriceTriple standardPrice = entry.getValue();
-            PriceTriple batchPrice = batch.getOrDefault(entry.getKey(), standardPrice.half());
-            result.add(new OpenAiModelPricing(
-                    entry.getKey(),
-                    standardPrice.name(),
-                    standardPrice.input(),
-                    standardPrice.cachedInput(),
-                    standardPrice.output(),
-                    batchPrice.input(),
-                    batchPrice.cachedInput(),
-                    batchPrice.output()));
-        }
-        return result;
+        candidates.add(node);
     }
 
-    /** Extrai preços mantendo compatibilidade com chamadas antigas focadas em texto. */
-    public List<OpenAiModelPricing> parseTextModelPricing(String html) {
-        return parseAllModelPricing(html);
-    }
-
-    /** Localiza tabelas com colunas de modelo, input, cached input e output e converte suas linhas em preços. */
-    private List<PricingTable> parsePricingTables(String html) {
-        Document document = Jsoup.parse(html);
-        List<PricingTable> parsedTables = new ArrayList<>();
-        for (Element table : document.select("table")) {
-            String headerText = table.select("thead").text().toLowerCase(Locale.ROOT);
-            if (!headerText.contains("model") || !headerText.contains("input") || !headerText.contains("output")) {
-                continue;
-            }
-            Map<String, PriceTriple> rows = parseRows(table.select("tbody tr"));
-            if (!rows.isEmpty()) {
-                parsedTables.add(new PricingTable(resolveTableMode(table), rows));
-            }
-        }
-        return parsedTables;
-    }
-
-    /** Converte linhas HTML de preço em mapa por código canônico do modelo e escolhe a modalidade operacional. */
-    private Map<String, PriceTriple> parseRows(Elements rows) {
-        Map<String, PriceTriple> tablePrices = new LinkedHashMap<>();
-        Map<String, Integer> scores = new LinkedHashMap<>();
-        String currentCode = null;
-        for (Element row : rows) {
-            Elements cells = row.select("td");
-            if (cells.size() < 4) {
-                continue;
-            }
-            RowPricing rowPricing = parseRowPricing(cells, currentCode);
-            if (rowPricing == null || !isSupportedTokenModelCode(rowPricing.code())) {
-                continue;
-            }
-            currentCode = rowPricing.code();
-            PriceTriple price = parsePriceTriple(cells, rowPricing.firstPriceCell(), rowPricing.code());
-            if (price == null) {
-                continue;
-            }
-            int score = modalityScore(rowPricing.code(), rowPricing.modality());
-            if (score > scores.getOrDefault(rowPricing.code(), -1)) {
-                tablePrices.put(rowPricing.code(), price);
-                scores.put(rowPricing.code(), score);
-            }
-        }
-        return tablePrices;
-    }
-
-    /** Identifica código, modalidade opcional e posição inicial dos preços dentro de uma linha de tabela. */
-    private RowPricing parseRowPricing(Elements cells, String currentCode) {
-        String first = cells.get(0).text().trim();
-        String normalizedFirst = normalizeModelCode(first);
-        if (isSupportedTokenModelCode(normalizedFirst)) {
-            if (cells.size() >= 5 && isKnownModality(cells.get(1).text())) {
-                return new RowPricing(normalizedFirst, cells.get(1).text().trim(), 2);
-            }
-            return new RowPricing(normalizedFirst, null, 1);
-        }
-        if (currentCode != null && isKnownModality(first)) {
-            return new RowPricing(currentCode, first, 1);
-        }
-        return null;
-    }
-
-    /** Extrai um trio input/cache/output a partir da posição inicial informada na linha da tabela. */
-    private PriceTriple parsePriceTriple(Elements cells, int firstPriceCell, String code) {
-        if (cells.size() <= firstPriceCell + 2) {
-            return null;
-        }
-        BigDecimal input = parseMoney(cells.get(firstPriceCell).text());
-        BigDecimal cachedInput = parseMoney(cells.get(firstPriceCell + 1).text());
-        BigDecimal output = parseMoney(cells.get(firstPriceCell + 2).text());
+    /** Converte um bloco financeiro da API em trio input/cache/output por 1 milhão de tokens. */
+    private PriceTriple parseApiPriceTriple(String code, JsonNode node) {
+        BigDecimal input = readMoney(node, "input", "input_price", "inputPrice");
+        BigDecimal cachedInput = readMoney(node, "cached_input", "input_cached", "cachedInput", "inputCached");
+        BigDecimal output = readMoney(node, "output", "output_price", "outputPrice");
         if (input == null || output == null) {
             return null;
         }
         return new PriceTriple(code, input, zeroIfNull(cachedInput), output);
     }
 
-    /** Classifica a tabela para separar preços standard, batch e modos que não cabem no contrato financeiro atual. */
-    private PricingMode resolveTableMode(Element table) {
-        String context = previousContext(table).toLowerCase(Locale.ROOT);
-        int batch = context.lastIndexOf("batch");
-        int standard = context.lastIndexOf("standard");
-        int flex = context.lastIndexOf("flex");
-        int priority = context.lastIndexOf("priority");
-        if ((flex > batch && flex > standard) || (priority > batch && priority > standard)) {
-            return PricingMode.SKIP;
+    /** Lê campos monetários flexíveis publicados pela API como número ou texto. */
+    private BigDecimal readMoney(JsonNode node, String... fieldNames) {
+        if (node == null || node.isMissingNode() || node.isNull()) {
+            return null;
         }
-        if (batch > standard) {
-            return PricingMode.BATCH;
-        }
-        if (standard >= 0) {
-            return PricingMode.STANDARD;
-        }
-        return PricingMode.UNKNOWN;
-    }
-
-    /** Coleta contexto textual próximo antes da tabela para inferir se ela representa standard ou batch. */
-    private String previousContext(Element table) {
-        StringBuilder context = new StringBuilder();
-        Element previous = table.previousElementSibling();
-        for (int i = 0; previous != null && i < 8; i++) {
-            String text = previous.text();
-            if (!text.isBlank()) {
-                context.insert(0, text + " ");
+        for (String fieldName : fieldNames) {
+            JsonNode value = node.path(fieldName);
+            if (value.isNumber()) {
+                return value.decimalValue();
             }
-            previous = previous.previousElementSibling();
+            if (value.isTextual()) {
+                BigDecimal parsed = parseMoney(value.asText());
+                if (parsed != null) {
+                    return parsed;
+                }
+            }
         }
-        return context.toString();
-    }
-
-    /** Remove observações de contexto e normaliza o código do modelo para comparação e persistência. */
-    private String normalizeModelCode(String value) {
-        return value.replaceAll("\\s*\\(.*$", "").trim().toLowerCase(Locale.ROOT);
+        return null;
     }
 
     /** Indica se o código extraído representa modelo tokenizado suportado no catálogo financeiro. */
@@ -264,28 +189,7 @@ public class OpenAiPricingPageClient {
                 || code.startsWith("computer-use-");
     }
 
-    /** Verifica se a célula representa uma modalidade de preço tokenizado na tabela oficial. */
-    private boolean isKnownModality(String value) {
-        String normalized = value == null ? "" : value.trim().toLowerCase(Locale.ROOT);
-        return normalized.equals("text") || normalized.equals("image") || normalized.equals("audio");
-    }
-
-    /** Prioriza a modalidade que melhor representa o uso operacional do modelo no contrato atual de preços. */
-    private int modalityScore(String code, String modality) {
-        if (modality == null || modality.isBlank()) {
-            return 2;
-        }
-        String normalized = modality.trim().toLowerCase(Locale.ROOT);
-        if (code.startsWith("gpt-image")) {
-            return normalized.equals("image") ? 4 : 1;
-        }
-        if (code.startsWith("gpt-realtime") || code.startsWith("gpt-audio")) {
-            return normalized.equals("audio") ? 4 : 2;
-        }
-        return normalized.equals("text") ? 4 : 1;
-    }
-
-    /** Verifica se o código de /models é uma variante datada do código-base publicado na página de preços. */
+    /** Verifica se o código de /models é uma variante datada do código-base publicado na API. */
     private boolean isVersionVariantOf(String requestedCode, String pricedCode) {
         if (requestedCode == null || pricedCode == null || requestedCode.equals(pricedCode)) {
             return false;
@@ -293,7 +197,7 @@ public class OpenAiPricingPageClient {
         return requestedCode.startsWith(pricedCode + "-");
     }
 
-    /** Converte valores monetários da tabela oficial para decimal por 1 milhão de tokens. */
+    /** Converte valores monetários da API para decimal por 1 milhão de tokens. */
     private BigDecimal parseMoney(String value) {
         String normalized = value == null ? "" : value.replace(",", "").trim();
         Matcher matcher = MONEY_PATTERN.matcher(normalized);
@@ -308,29 +212,12 @@ public class OpenAiPricingPageClient {
         return value == null ? BigDecimal.ZERO : value;
     }
 
-    /** Responsabilidade: indicar o papel operacional de uma tabela de preços parseada. */
+    /** Responsabilidade: indicar o modo financeiro publicado pela API de preços. */
     private enum PricingMode {
         STANDARD,
-        BATCH,
-        UNKNOWN,
-        SKIP
+        BATCH
     }
-
-    /** Responsabilidade: transportar uma tabela de preços parseada com seu modo financeiro. */
-    private record PricingTable(PricingMode mode, Map<String, PriceTriple> rows) {}
-
-    /** Responsabilidade: transportar a interpretação de uma linha de preço da tabela oficial. */
-    private record RowPricing(String code, String modality, int firstPriceCell) {}
 
     /** Responsabilidade: manter um trio de preços input/cache/output por modo de processamento. */
-    private record PriceTriple(String name, BigDecimal input, BigDecimal cachedInput, BigDecimal output) {
-        /** Calcula fallback batch como metade do preço standard quando a página não expõe tabela batch separada. */
-        private PriceTriple half() {
-            return new PriceTriple(
-                    name,
-                    input.divide(BigDecimal.valueOf(2)),
-                    cachedInput.divide(BigDecimal.valueOf(2)),
-                    output.divide(BigDecimal.valueOf(2)));
-        }
-    }
+    private record PriceTriple(String name, BigDecimal input, BigDecimal cachedInput, BigDecimal output) {}
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/openai/OpenAiProperties.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/openai/OpenAiProperties.java
@@ -12,7 +12,6 @@ public class OpenAiProperties {
 
     private String apiKey;
     private String apiKeyFile = "/root/infra/openai-token/openai_api_key";
-    private String pricingUrl = "https://developers.openai.com/api/docs/pricing";
     private String baseUrl = "https://api.openai.com/v1";
     private Duration connectTimeout = Duration.ofSeconds(10);
     private Duration requestTimeout = Duration.ofSeconds(90);
@@ -38,16 +37,6 @@ public class OpenAiProperties {
     /** Define o caminho do arquivo seguro usado como fallback para carregar o token OpenAI. */
     public void setApiKeyFile(String apiKeyFile) {
         this.apiKeyFile = apiKeyFile;
-    }
-
-    /** Retorna a URL oficial consultada para sincronizar preços dos modelos OpenAI. */
-    public String getPricingUrl() {
-        return pricingUrl;
-    }
-
-    /** Define a URL oficial consultada para sincronizar preços dos modelos OpenAI. */
-    public void setPricingUrl(String pricingUrl) {
-        this.pricingUrl = pricingUrl;
     }
 
     /** Retorna a URL base da API OpenAI usada nas chamadas autenticadas. */

--- a/backend/ads-service/src/main/java/com/marketinghub/openai/service/OpenAiModelPricingSyncService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/openai/service/OpenAiModelPricingSyncService.java
@@ -15,7 +15,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 public class OpenAiModelPricingSyncService {
     private static final Logger log = LoggerFactory.getLogger(OpenAiModelPricingSyncService.class);
-    private static final String PRICING_SOURCE = "https://developers.openai.com/api/docs/pricing";
+    private static final String PRICING_SOURCE = "openai:/models";
 
     private final OpenAiPricingPageClient pricingPageClient;
     private final OpenAiModelRepository repository;

--- a/backend/ads-service/src/main/java/com/marketinghub/openai/service/OpenAiModelService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/openai/service/OpenAiModelService.java
@@ -26,7 +26,7 @@ import org.springframework.util.StringUtils;
 @Service
 public class OpenAiModelService {
     private static final Logger log = LoggerFactory.getLogger(OpenAiModelService.class);
-    private static final String PRICING_SOURCE = "https://developers.openai.com/api/docs/pricing";
+    private static final String PRICING_SOURCE = "openai:/models";
     private static final BigDecimal ZERO_PRICE = BigDecimal.ZERO.setScale(5);
 
     private final OpenAiModelRepository repository;

--- a/backend/ads-service/src/main/resources/application.properties
+++ b/backend/ads-service/src/main/resources/application.properties
@@ -128,7 +128,6 @@ lead-portal.worker.processing-guard.initial-delay=${LEAD_PORTAL_PROCESSING_GUARD
 # OpenAI batch generation
 openai.api-key=${OPENAI_API_KEY:}
 openai.api-key-file=${OPENAI_API_KEY_FILE:/root/infra/openai-token/openai_api_key}
-openai.pricing-url=${OPENAI_PRICING_URL:https://developers.openai.com/api/docs/pricing}
 openai.base-url=${OPENAI_BASE_URL:https://api.openai.com/v1}
 openai.connect-timeout=${OPENAI_CONNECT_TIMEOUT:PT10S}
 openai.request-timeout=${OPENAI_REQUEST_TIMEOUT:PT90S}

--- a/backend/ads-service/src/test/java/com/marketinghub/openai/OpenAiModelPricingSyncServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/openai/OpenAiModelPricingSyncServiceTest.java
@@ -66,7 +66,7 @@ class OpenAiModelPricingSyncServiceTest {
         assertThat(datedVariant.getPriceInputBatch()).isEqualByComparingTo(new BigDecimal("2.50"));
         assertThat(datedVariant.getPriceInputCachedBatch()).isEqualByComparingTo(new BigDecimal("0.25"));
         assertThat(datedVariant.getPriceOutputBatch()).isEqualByComparingTo(new BigDecimal("15.00"));
-        assertThat(datedVariant.getPricingSource()).isEqualTo("https://developers.openai.com/api/docs/pricing");
+        assertThat(datedVariant.getPricingSource()).isEqualTo("openai:/models");
         assertThat(datedVariant.getLastPricingSyncAt()).isNotNull();
         verify(repository).save(datedVariant);
     }

--- a/backend/ads-service/src/test/java/com/marketinghub/openai/OpenAiPricingPageClientTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/openai/OpenAiPricingPageClientTest.java
@@ -1,192 +1,87 @@
 package com.marketinghub.openai;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import java.math.BigDecimal;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
-/** Responsabilidade: validar parsing e resolução de preços oficiais OpenAI para modelos tokenizados. */
+/** Responsabilidade: validar parsing e resolução de preços retornados pela API autenticada OpenAI. */
 class OpenAiPricingPageClientTest {
 
-    /** Garante compatibilidade com tabelas legadas de preços standard e batch por modelo textual. */
+    /** Garante que a rotina aproveite preços quando a API autenticada da OpenAI publicar metadados financeiros. */
     @Test
-    void shouldParseStandardAndBatchPricesFromOfficialPricingTables() {
-        OpenAiProperties properties = new OpenAiProperties();
-        OpenAiPricingPageClient client = new OpenAiPricingPageClient(properties);
+    void shouldParsePricingMetadataFromAuthenticatedModelsApi() throws Exception {
+        OpenAiPricingPageClient client = new OpenAiPricingPageClient();
 
-        List<OpenAiModelPricing> prices = client.parseTextModelPricing("""
-                <html><body>
-                  <table>
-                    <thead><tr><th>Model</th><th>Input</th><th>Cached input</th><th>Output</th></tr></thead>
-                    <tbody>
-                      <tr><td>gpt-5.5 (&lt;272K context length)</td><td>$5.00</td><td>$0.50</td><td>$30.00</td></tr>
-                      <tr><td>gpt-image-1</td><td>$5.00</td><td>$1.25</td><td>-</td></tr>
-                    </tbody>
-                  </table>
-                  <table>
-                    <thead><tr><th>Model</th><th>Input</th><th>Cached input</th><th>Output</th></tr></thead>
-                    <tbody>
-                      <tr><td>gpt-5.5 (&lt;272K context length)</td><td>$2.50</td><td>$0.25</td><td>$15.00</td></tr>
-                    </tbody>
-                  </table>
-                </body></html>
-                """);
+        List<OpenAiModelPricing> prices = client.parseAuthenticatedApiPricing(new ObjectMapper().readTree("""
+                {
+                  "data": [
+                    {
+                      "id": "gpt-image-2",
+                      "pricing": {
+                        "standard": {
+                          "image": {"input": 8, "cached_input": 2, "output": 30}
+                        },
+                        "batch": {
+                          "image": {"input": 4, "cached_input": 1, "output": 15}
+                        }
+                      }
+                    }
+                  ]
+                }
+                """));
 
         assertThat(prices).hasSize(1);
         OpenAiModelPricing pricing = prices.get(0);
-        assertThat(pricing.code()).isEqualTo("gpt-5.5");
-        assertThat(pricing.priceInputStandard()).isEqualByComparingTo(new BigDecimal("5.00"));
-        assertThat(pricing.priceInputCachedStandard()).isEqualByComparingTo(new BigDecimal("0.50"));
-        assertThat(pricing.priceOutputStandard()).isEqualByComparingTo(new BigDecimal("30.00"));
-        assertThat(pricing.priceInputBatch()).isEqualByComparingTo(new BigDecimal("2.50"));
-        assertThat(pricing.priceInputCachedBatch()).isEqualByComparingTo(new BigDecimal("0.25"));
-        assertThat(pricing.priceOutputBatch()).isEqualByComparingTo(new BigDecimal("15.00"));
+        assertThat(pricing.code()).isEqualTo("gpt-image-2");
+        assertThat(pricing.priceInputStandard()).isEqualByComparingTo(new BigDecimal("8"));
+        assertThat(pricing.priceInputCachedStandard()).isEqualByComparingTo(new BigDecimal("2"));
+        assertThat(pricing.priceOutputStandard()).isEqualByComparingTo(new BigDecimal("30"));
+        assertThat(pricing.priceInputBatch()).isEqualByComparingTo(new BigDecimal("4"));
+        assertThat(pricing.priceInputCachedBatch()).isEqualByComparingTo(new BigDecimal("1"));
+        assertThat(pricing.priceOutputBatch()).isEqualByComparingTo(new BigDecimal("15"));
     }
 
-    /** Garante fallback de batch como metade do standard quando a fonte não publica uma tabela batch. */
+    /** Garante que ausência de batch não seja substituída por cálculo local. */
     @Test
-    void shouldUseHalfStandardAsBatchFallbackWhenBatchTableIsMissing() {
-        OpenAiProperties properties = new OpenAiProperties();
-        OpenAiPricingPageClient client = new OpenAiPricingPageClient(properties);
+    void shouldNotInventBatchPricingWhenApiDoesNotReturnBatch() throws Exception {
+        OpenAiPricingPageClient client = new OpenAiPricingPageClient();
 
-        List<OpenAiModelPricing> prices = client.parseTextModelPricing("""
-                <table>
-                  <thead><tr><th>Model</th><th>Input</th><th>Cached input</th><th>Output</th></tr></thead>
-                  <tbody><tr><td>o4-mini</td><td>$1.10</td><td>$0.275</td><td>$4.40</td></tr></tbody>
-                </table>
-                """);
+        List<OpenAiModelPricing> prices = client.parseAuthenticatedApiPricing(new ObjectMapper().readTree("""
+                {
+                  "data": [
+                    {
+                      "id": "gpt-image-2",
+                      "pricing": {
+                        "standard": {
+                          "image": {"input": 8, "cached_input": 2, "output": 30}
+                        }
+                      }
+                    }
+                  ]
+                }
+                """));
 
-        assertThat(prices).hasSize(1);
-        OpenAiModelPricing pricing = prices.get(0);
-        assertThat(pricing.code()).isEqualTo("o4-mini");
-        assertThat(pricing.priceInputBatch()).isEqualByComparingTo(new BigDecimal("0.55"));
-        assertThat(pricing.priceInputCachedBatch()).isEqualByComparingTo(new BigDecimal("0.1375"));
-        assertThat(pricing.priceOutputBatch()).isEqualByComparingTo(new BigDecimal("2.20"));
+        assertThat(prices).isEmpty();
     }
 
-    /** Garante que tabelas com contexto curto e longo usem o preço operacional de contexto curto. */
+    /** Garante que uma execução sem cliente autenticado falhe em vez de usar qualquer fallback. */
     @Test
-    void shouldParsePricesFromCurrentShortAndLongContextTable() {
-        OpenAiProperties properties = new OpenAiProperties();
-        OpenAiPricingPageClient client = new OpenAiPricingPageClient(properties);
+    void shouldFailWhenAuthenticatedClientIsMissing() {
+        OpenAiPricingPageClient client = new OpenAiPricingPageClient();
 
-        List<OpenAiModelPricing> prices = client.parseTextModelPricing("""
-                <table>
-                  <thead>
-                    <tr><th></th><th colspan="3">Short context</th><th colspan="3">Long context</th></tr>
-                    <tr><th>Model</th><th>Input</th><th>Cached input</th><th>Output</th><th>Input</th><th>Cached input</th><th>Output</th></tr>
-                  </thead>
-                  <tbody>
-                    <tr><td>gpt-5.4</td><td>$2.50</td><td>$0.25</td><td>$15.00</td><td>$5.00</td><td>$0.50</td><td>$22.50</td></tr>
-                    <tr><td>gpt-5.4-mini</td><td>$0.75</td><td>$0.075</td><td>$4.50</td><td>-</td><td>-</td><td>-</td></tr>
-                  </tbody>
-                </table>
-                """);
-
-        assertThat(prices).hasSize(2);
-        OpenAiModelPricing pricing = prices.get(0);
-        assertThat(pricing.code()).isEqualTo("gpt-5.4");
-        assertThat(pricing.priceInputStandard()).isEqualByComparingTo(new BigDecimal("2.50"));
-        assertThat(pricing.priceInputCachedStandard()).isEqualByComparingTo(new BigDecimal("0.25"));
-        assertThat(pricing.priceOutputStandard()).isEqualByComparingTo(new BigDecimal("15.00"));
-        assertThat(pricing.priceInputBatch()).isEqualByComparingTo(new BigDecimal("1.25"));
-        assertThat(pricing.priceInputCachedBatch()).isEqualByComparingTo(new BigDecimal("0.125"));
-        assertThat(pricing.priceOutputBatch()).isEqualByComparingTo(new BigDecimal("7.50"));
-    }
-
-
-    /** Garante que modelos de imagem sejam sincronizados pela modalidade Image nas tabelas oficiais. */
-    @Test
-    void shouldParseImageModelPricesFromOfficialPricingTablesWithModalityColumn() {
-        OpenAiProperties properties = new OpenAiProperties();
-        OpenAiPricingPageClient client = new OpenAiPricingPageClient(properties);
-
-        List<OpenAiModelPricing> prices = client.parseAllModelPricing("""
-                <html><body>
-                  <section>
-                    <h3>Image generation models</h3>
-                    <p>Standard</p>
-                    <table>
-                      <thead><tr><th>Model</th><th>Modality</th><th>Input</th><th>Cached input</th><th>Output</th></tr></thead>
-                      <tbody>
-                        <tr><td>gpt-image-2</td><td>Image</td><td>$8.00</td><td>$2.00</td><td>$30.00</td></tr>
-                        <tr><td></td><td>Text</td><td>$5.00</td><td>$1.25</td><td>-</td></tr>
-                        <tr><td>gpt-image-1.5</td><td>Image</td><td>$8.00</td><td>$2.00</td><td>$32.00</td></tr>
-                        <tr><td></td><td>Text</td><td>$5.00</td><td>$1.25</td><td>$10.00</td></tr>
-                      </tbody>
-                    </table>
-                    <p>Batch</p>
-                    <table>
-                      <thead><tr><th>Model</th><th>Modality</th><th>Input</th><th>Cached input</th><th>Output</th></tr></thead>
-                      <tbody>
-                        <tr><td>gpt-image-2</td><td>Image</td><td>$4.00</td><td>$1.00</td><td>$15.00</td></tr>
-                        <tr><td></td><td>Text</td><td>$2.50</td><td>$0.625</td><td>-</td></tr>
-                        <tr><td>gpt-image-1.5</td><td>Image</td><td>$4.00</td><td>$1.00</td><td>$16.00</td></tr>
-                        <tr><td></td><td>Text</td><td>$2.50</td><td>$0.63</td><td>$5.00</td></tr>
-                      </tbody>
-                    </table>
-                  </section>
-                </body></html>
-                """);
-
-        assertThat(prices).extracting(OpenAiModelPricing::code).contains("gpt-image-2", "gpt-image-1.5");
-        OpenAiModelPricing gptImage2 = prices.stream()
-                .filter(pricing -> pricing.code().equals("gpt-image-2"))
-                .findFirst()
-                .orElseThrow();
-        assertThat(gptImage2.priceInputStandard()).isEqualByComparingTo(new BigDecimal("8.00"));
-        assertThat(gptImage2.priceInputCachedStandard()).isEqualByComparingTo(new BigDecimal("2.00"));
-        assertThat(gptImage2.priceOutputStandard()).isEqualByComparingTo(new BigDecimal("30.00"));
-        assertThat(gptImage2.priceInputBatch()).isEqualByComparingTo(new BigDecimal("4.00"));
-        assertThat(gptImage2.priceInputCachedBatch()).isEqualByComparingTo(new BigDecimal("1.00"));
-        assertThat(gptImage2.priceOutputBatch()).isEqualByComparingTo(new BigDecimal("15.00"));
-    }
-
-    /** Garante que o parser percorra todas as seções de preço e não apenas o primeiro par de tabelas. */
-    @Test
-    void shouldParseMultiplePricingSectionsInsteadOfOnlyFirstPairOfTables() {
-        OpenAiProperties properties = new OpenAiProperties();
-        OpenAiPricingPageClient client = new OpenAiPricingPageClient(properties);
-
-        List<OpenAiModelPricing> prices = client.parseAllModelPricing("""
-                <html><body>
-                  <h3>Flagship chat models</h3>
-                  <p>Standard</p>
-                  <table>
-                    <thead><tr><th>Model</th><th>Input</th><th>Cached input</th><th>Output</th></tr></thead>
-                    <tbody><tr><td>gpt-5.5</td><td>$5.00</td><td>$0.50</td><td>$30.00</td></tr></tbody>
-                  </table>
-                  <p>Batch</p>
-                  <table>
-                    <thead><tr><th>Model</th><th>Input</th><th>Cached input</th><th>Output</th></tr></thead>
-                    <tbody><tr><td>gpt-5.5</td><td>$2.50</td><td>$0.25</td><td>$15.00</td></tr></tbody>
-                  </table>
-                  <h3>Image generation models</h3>
-                  <p>Standard</p>
-                  <table>
-                    <thead><tr><th>Model</th><th>Modality</th><th>Input</th><th>Cached input</th><th>Output</th></tr></thead>
-                    <tbody><tr><td>gpt-image-1.5</td><td>Image</td><td>$8.00</td><td>$2.00</td><td>$32.00</td></tr></tbody>
-                  </table>
-                  <p>Batch</p>
-                  <table>
-                    <thead><tr><th>Model</th><th>Modality</th><th>Input</th><th>Cached input</th><th>Output</th></tr></thead>
-                    <tbody><tr><td>gpt-image-1.5</td><td>Image</td><td>$4.00</td><td>$1.00</td><td>$16.00</td></tr></tbody>
-                  </table>
-                </body></html>
-                """);
-
-        assertThat(prices).extracting(OpenAiModelPricing::code).containsExactly("gpt-5.5", "gpt-image-1.5");
-        OpenAiModelPricing image = prices.get(1);
-        assertThat(image.priceOutputStandard()).isEqualByComparingTo(new BigDecimal("32.00"));
-        assertThat(image.priceOutputBatch()).isEqualByComparingTo(new BigDecimal("16.00"));
+        assertThatThrownBy(client::fetchAllModelPricing)
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Cliente autenticado da OpenAI não configurado");
     }
 
     /** Garante que variantes datadas usem o preço-base oficial mais específico. */
     @Test
     void shouldResolvePricingForDatedModelVariantUsingMostSpecificBaseCode() {
-        OpenAiProperties properties = new OpenAiProperties();
-        OpenAiPricingPageClient client = new OpenAiPricingPageClient(properties);
+        OpenAiPricingPageClient client = new OpenAiPricingPageClient();
         List<OpenAiModelPricing> prices = List.of(
                 new OpenAiModelPricing(
                         "gpt-5.4",
@@ -214,5 +109,4 @@ class OpenAiPricingPageClientTest {
         assertThat(pricing.code()).isEqualTo("gpt-5.4-pro");
         assertThat(pricing.priceInputStandard()).isEqualByComparingTo(new BigDecimal("30.00"));
     }
-
 }

--- a/backend/ads-service/src/test/java/com/marketinghub/openai/service/OpenAiModelPricingSyncServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/openai/service/OpenAiModelPricingSyncServiceTest.java
@@ -40,7 +40,7 @@ class OpenAiModelPricingSyncServiceTest {
         assertThat(existing.getCode()).isEqualTo("gpt-5.5");
         assertThat(existing.getPriceInputStandard()).isEqualByComparingTo(new BigDecimal("5.00"));
         assertThat(existing.getPriceOutputBatch()).isEqualByComparingTo(new BigDecimal("15.00"));
-        assertThat(existing.getPricingSource()).isEqualTo("https://developers.openai.com/api/docs/pricing");
+        assertThat(existing.getPricingSource()).isEqualTo("openai:/models");
         assertThat(existing.getLastPricingSyncAt()).isNotNull();
         verify(repository).save(existing);
     }

--- a/backend/ads-service/src/test/java/com/marketinghub/openai/service/OpenAiModelServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/openai/service/OpenAiModelServiceTest.java
@@ -60,7 +60,7 @@ class OpenAiModelServiceTest {
         assertThat(created.getPriceInputStandard()).isEqualByComparingTo("5.00");
         assertThat(created.getPriceOutputBatch()).isEqualByComparingTo("15.00");
         assertThat(created.isAcceptsImageInput()).isFalse();
-        assertThat(created.getPricingSource()).isEqualTo("https://developers.openai.com/api/docs/pricing");
+        assertThat(created.getPricingSource()).isEqualTo("openai:/models");
         assertThat(created.getLastPricingSyncAt()).isNotNull();
         verify(catalogService).fetchAndPersistCatalog();
     }


### PR DESCRIPTION
### Motivation

- Replace fragile HTML scraping of the OpenAI pricing page with the authenticated OpenAI `/models` API to obtain model pricing metadata. 
- Centralize pricing source identification as `openai:/models` and remove the dependency on an external pricing page URL.
- Ensure pricing lookups are consistent with the same `/models` payload used for catalog synchronization.

### Description

- Reworked `OpenAiPricingPageClient` to use an injected `WebClient` (`openAiWebClient`) and to fetch pricing from the authenticated `/models` API via `fetchAllModelPricing` instead of downloading and parsing HTML pages. 
- Added JSON parsing helpers: `parseAuthenticatedApiPricing`, `findApiPriceTriple`, `parseApiPriceTriple`, `addApiPricingCandidates`, and `readMoney`, and removed the old Jsoup-based HTML parsing code and related helpers. 
- Adjusted error handling to throw on pricing API failures and added informative logs referencing `endpoint=/models` and `source=openai-models-api`. 
- Removed the `pricingUrl` property from `OpenAiProperties` and deleted its entry from `application.properties`. 
- Updated services and constants to use `openai:/models` as the `PRICING_SOURCE` and changed catalog response source string accordingly. 
- Updated unit tests to reflect the new JSON-based parser and behavior, including tests for successful parsing, missing batch behavior, and missing authenticated client errors.

### Testing

- Ran updated unit tests in `OpenAiPricingPageClientTest` which exercise `parseAuthenticatedApiPricing` scenarios and they passed. 
- Ran updated service tests in `OpenAiModelPricingSyncServiceTest` and `OpenAiModelServiceTest` which assert `PRICING_SOURCE` and synchronization behavior, and they passed. 
- Verified other modified unit tests that mock `OpenAiPricingPageClient` behavior (dated-variant and image model flows) executed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a27727347f883269b1800b2428882c7)