### PR TITLE
Prioritize experiment-selected targeting for Facebook AdSets and add `experimentId` filter

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/facebookads/controller/FacebookAdSetController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/facebookads/controller/FacebookAdSetController.java
@@ -5,6 +5,7 @@ import com.marketinghub.facebookads.service.FacebookAdSetExperimentService;
 import java.util.List;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 /**
@@ -23,10 +24,13 @@ public class FacebookAdSetController {
         this.experimentService = experimentService;
     }
 
+    /**
+     * Lista os experimentos prontos para materializar conjuntos de anúncios, com filtro opcional por experimento.
+     */
     @GetMapping("/experiments-ready")
-    // Executa a operação experimentsReady da integração Facebook Ads.
-    public List<ExperimentReadyForAdSetDto> experimentsReady() {
-        return experimentService.listExperimentsReadyForAdSets();
+    public List<ExperimentReadyForAdSetDto> experimentsReady(
+            @RequestParam(name = "experimentId", required = false) Long experimentId) {
+        return experimentService.listExperimentsReadyForAdSets(experimentId);
     }
 }
 

--- a/backend/ads-service/src/main/java/com/marketinghub/facebookads/service/FacebookAdSetExperimentService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/facebookads/service/FacebookAdSetExperimentService.java
@@ -3,13 +3,16 @@ package com.marketinghub.facebookads.service;
 import com.marketinghub.experiment.Experiment;
 import com.marketinghub.experiment.ExperimentPlatform;
 import com.marketinghub.experiment.ExperimentStatus;
+import com.marketinghub.experiment.ExperimentTargetingSelection;
 import com.marketinghub.experiment.mapper.ExperimentMapper;
 import com.marketinghub.repository.jpa.experiment.ExperimentRepository;
+import com.marketinghub.repository.jpa.experiment.ExperimentTargetingSelectionRepository;
 import com.marketinghub.facebookads.dto.ExperimentReadyForAdSetDto;
 import com.marketinghub.facebookads.dto.TargetingPackageDto;
 import com.marketinghub.hypothesis.mapper.HypothesisMapper;
 import com.marketinghub.niche.mapper.MarketNicheMapper;
 import com.marketinghub.targeting.TargetingElement;
+import com.marketinghub.targeting.TargetingElementStatus;
 import com.marketinghub.targeting.TargetingElementType;
 import com.marketinghub.targeting.dto.TargetingElementDto;
 import com.marketinghub.targeting.mapper.TargetingElementMapper;
@@ -20,6 +23,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
 
 /**
  * Builds the payload consumed by workers to generate Facebook ad sets.
@@ -30,19 +34,25 @@ public class FacebookAdSetExperimentService {
             ExperimentStatus.PLANNED, ExperimentStatus.RUNNING, ExperimentStatus.PAUSED);
 
     private final ExperimentRepository experimentRepository;
+    private final ExperimentTargetingSelectionRepository targetingSelectionRepository;
     private final TargetingElementRepository targetingElementRepository;
     private final ExperimentMapper experimentMapper;
     private final MarketNicheMapper marketNicheMapper;
     private final HypothesisMapper hypothesisMapper;
     private final TargetingElementMapper targetingElementMapper;
 
+    /**
+     * Inicializa o serviço com repositórios e mapeadores usados para montar o contrato do worker.
+     */
     public FacebookAdSetExperimentService(ExperimentRepository experimentRepository,
+                                          ExperimentTargetingSelectionRepository targetingSelectionRepository,
                                           TargetingElementRepository targetingElementRepository,
                                           ExperimentMapper experimentMapper,
                                           MarketNicheMapper marketNicheMapper,
                                           HypothesisMapper hypothesisMapper,
                                           TargetingElementMapper targetingElementMapper) {
         this.experimentRepository = experimentRepository;
+        this.targetingSelectionRepository = targetingSelectionRepository;
         this.targetingElementRepository = targetingElementRepository;
         this.experimentMapper = experimentMapper;
         this.marketNicheMapper = marketNicheMapper;
@@ -51,10 +61,16 @@ public class FacebookAdSetExperimentService {
     }
 
     /**
-     * Lists experiments that are ready to have ad sets generated alongside their
-     * approved targeting elements.
+     * Lista todos os experimentos prontos para conjuntos de anúncios.
      */
     public List<ExperimentReadyForAdSetDto> listExperimentsReadyForAdSets() {
+        return listExperimentsReadyForAdSets(null);
+    }
+
+    /**
+     * Lista experimentos prontos para conjuntos de anúncios, priorizando o público selecionado no experimento.
+     */
+    public List<ExperimentReadyForAdSetDto> listExperimentsReadyForAdSets(Long experimentId) {
         List<Experiment> experiments = experimentRepository.findAllReadyForAdSets(
                 ExperimentPlatform.FACEBOOK, STATUSES);
         if (experiments.isEmpty()) {
@@ -62,6 +78,9 @@ public class FacebookAdSetExperimentService {
         }
         List<ExperimentReadyForAdSetDto> result = new ArrayList<>();
         for (Experiment experiment : experiments) {
+            if (experimentId != null && !experimentId.equals(experiment.getId())) {
+                continue;
+            }
             TargetingPackageDto targeting = buildTargetingPackage(experiment);
             if (targeting == null) {
                 continue;
@@ -76,13 +95,50 @@ public class FacebookAdSetExperimentService {
         return result;
     }
 
+    /**
+     * Monta o pacote de público usando as seleções do experimento e, se não existirem, o pacote aprovado do nicho.
+     */
     private TargetingPackageDto buildTargetingPackage(Experiment experiment) {
         if (experiment.getNiche() == null) {
             return null;
         }
+        TargetingPackageDto selectedTargeting = buildSelectedTargetingPackage(experiment);
+        if (selectedTargeting != null) {
+            return selectedTargeting;
+        }
+        return buildApprovedNicheTargetingPackage(experiment);
+    }
+
+    /**
+     * Monta o público salvo na tela do experimento com elementos aprovados e identificáveis pela Meta.
+     */
+    private TargetingPackageDto buildSelectedTargetingPackage(Experiment experiment) {
+        List<ExperimentTargetingSelection> selections = targetingSelectionRepository
+                .findByExperimentIdWithTargetingElement(experiment.getId());
+        if (selections.isEmpty()) {
+            return null;
+        }
+        Map<TargetingElementType, List<TargetingElementDto>> mapped = emptyTargetingMap();
+        for (ExperimentTargetingSelection selection : selections) {
+            TargetingElement element = selection.getTargetingElement();
+            if (!isPublishableTargetingElement(element)) {
+                continue;
+            }
+            mapped.get(element.getType()).add(targetingElementMapper.toDto(element));
+        }
+        if (mapped.get(TargetingElementType.JOB_TITLE).isEmpty()) {
+            return null;
+        }
+        return toTargetingPackage(mapped);
+    }
+
+    /**
+     * Monta o pacote aprovado por nicho quando o experimento ainda não tem seleção manual salva.
+     */
+    private TargetingPackageDto buildApprovedNicheTargetingPackage(Experiment experiment) {
         Long nicheId = experiment.getNiche().getId();
         UUID hypothesisId = experiment.getHypothesisRef() != null ? experiment.getHypothesisRef().getId() : null;
-        Map<TargetingElementType, List<TargetingElementDto>> mapped = new EnumMap<>(TargetingElementType.class);
+        Map<TargetingElementType, List<TargetingElementDto>> mapped = emptyTargetingMap();
         for (TargetingElementType type : TargetingElementType.values()) {
             List<TargetingElementDto> dtos = mapElements(nicheId, hypothesisId, type);
             if (type == TargetingElementType.JOB_TITLE && dtos.isEmpty()) {
@@ -90,17 +146,51 @@ public class FacebookAdSetExperimentService {
             }
             mapped.put(type, dtos);
         }
-        return new TargetingPackageDto(
-                mapped.get(TargetingElementType.INTEREST),
-                mapped.get(TargetingElementType.JOB_TITLE),
-                mapped.get(TargetingElementType.BEHAVIOR));
+        return toTargetingPackage(mapped);
     }
 
+    /**
+     * Cria o mapa base com as categorias de público suportadas pela Meta.
+     */
+    private Map<TargetingElementType, List<TargetingElementDto>> emptyTargetingMap() {
+        Map<TargetingElementType, List<TargetingElementDto>> mapped = new EnumMap<>(TargetingElementType.class);
+        mapped.put(TargetingElementType.INTEREST, new ArrayList<>());
+        mapped.put(TargetingElementType.JOB_TITLE, new ArrayList<>());
+        mapped.put(TargetingElementType.BEHAVIOR, new ArrayList<>());
+        return mapped;
+    }
+
+    /**
+     * Converte o mapa de elementos no DTO consumido pelo worker de Facebook Ads.
+     */
+    private TargetingPackageDto toTargetingPackage(Map<TargetingElementType, List<TargetingElementDto>> mapped) {
+        return new TargetingPackageDto(
+                List.copyOf(mapped.get(TargetingElementType.INTEREST)),
+                List.copyOf(mapped.get(TargetingElementType.JOB_TITLE)),
+                List.copyOf(mapped.get(TargetingElementType.BEHAVIOR)));
+    }
+
+    /**
+     * Indica se o elemento selecionado pode ser enviado para a Meta com identificador oficial.
+     */
+    private boolean isPublishableTargetingElement(TargetingElement element) {
+        return element != null
+                && element.getStatus() == TargetingElementStatus.APPROVED
+                && element.getType() != null
+                && StringUtils.hasText(element.getMetaId());
+    }
+
+    /**
+     * Busca elementos aprovados por nicho e hipótese para o fallback sem seleção manual.
+     */
     private List<TargetingElementDto> mapElements(Long nicheId, UUID hypothesisId, TargetingElementType type) {
         List<TargetingElement> elements = targetingElementRepository.findApprovedForExperiment(nicheId, type, hypothesisId);
         if (elements.isEmpty()) {
             return List.of();
         }
-        return elements.stream().map(targetingElementMapper::toDto).toList();
+        return elements.stream()
+                .filter(this::isPublishableTargetingElement)
+                .map(targetingElementMapper::toDto)
+                .toList();
     }
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/experiment/ExperimentTargetingSelectionRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/experiment/ExperimentTargetingSelectionRepository.java
@@ -3,6 +3,8 @@ package com.marketinghub.repository.jpa.experiment;
 import com.marketinghub.experiment.ExperimentTargetingSelection;
 import com.marketinghub.targeting.TargetingCandidateType;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 import java.util.List;
 
@@ -11,6 +13,19 @@ import java.util.List;
  */
 public interface ExperimentTargetingSelectionRepository extends JpaRepository<ExperimentTargetingSelection, Long> {
     List<ExperimentTargetingSelection> findByExperimentIdOrderByCandidateTypeAscTermAsc(Long experimentId);
+
+    /**
+     * Busca seleções de público do experimento com o elemento de segmentação materializado.
+     */
+    @Query("""
+            select selection from ExperimentTargetingSelection selection
+            left join fetch selection.targetingElement element
+            left join fetch element.niche
+            left join fetch element.hypothesis
+            where selection.experiment.id = :experimentId
+            order by selection.candidateType asc, selection.term asc
+            """)
+    List<ExperimentTargetingSelection> findByExperimentIdWithTargetingElement(@Param("experimentId") Long experimentId);
 
     long countByExperimentId(Long experimentId);
     long countByExperimentIdAndCandidateType(Long experimentId, TargetingCandidateType candidateType);

--- a/backend/ads-service/src/test/java/com/marketinghub/facebookads/controller/FacebookAdSetControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/facebookads/controller/FacebookAdSetControllerTest.java
@@ -1,5 +1,6 @@
 package com.marketinghub.facebookads.controller;
 
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -84,7 +85,7 @@ class FacebookAdSetControllerTest {
                 hypothesis,
                 new TargetingPackageDto(List.of(interest), List.of(jobTitle), List.of(behavior)));
 
-        when(experimentService.listExperimentsReadyForAdSets()).thenReturn(List.of(dto));
+        when(experimentService.listExperimentsReadyForAdSets(null)).thenReturn(List.of(dto));
 
         mockMvc.perform(get("/api/facebook-adsets/experiments-ready"))
                 .andExpect(status().isOk())
@@ -123,7 +124,7 @@ class FacebookAdSetControllerTest {
                 hypothesis,
                 new TargetingPackageDto(List.of(), List.of(jobTitle), List.of()));
 
-        when(experimentService.listExperimentsReadyForAdSets()).thenReturn(List.of(dto));
+        when(experimentService.listExperimentsReadyForAdSets(null)).thenReturn(List.of(dto));
 
         mockMvc.perform(get("/api/facebook-adsets/experiments-ready"))
                 .andExpect(status().isOk())
@@ -132,4 +133,23 @@ class FacebookAdSetControllerTest {
                 .andExpect(jsonPath("$[0].targeting.jobTitles[0].term").value("CMO"))
                 .andExpect(jsonPath("$[0].targeting.behaviors").isEmpty());
     }
+    @Test
+    void experimentsReadyAcceptsExperimentFilter() throws Exception {
+        ExperimentDto experiment = new ExperimentDto();
+        experiment.setId(38L);
+        experiment.setName("Filtered experiment");
+
+        ExperimentReadyForAdSetDto dto = new ExperimentReadyForAdSetDto(
+                experiment,
+                new MarketNicheDto(),
+                null,
+                new TargetingPackageDto(List.of(), List.of(), List.of()));
+
+        when(experimentService.listExperimentsReadyForAdSets(eq(38L))).thenReturn(List.of(dto));
+
+        mockMvc.perform(get("/api/facebook-adsets/experiments-ready").param("experimentId", "38"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].experiment.id").value(38));
+    }
+
 }

--- a/backend/ads-service/src/test/java/com/marketinghub/facebookads/service/FacebookAdSetExperimentServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/facebookads/service/FacebookAdSetExperimentServiceTest.java
@@ -9,8 +9,10 @@ import com.marketinghub.ads.mapper.FacebookInstantFormMapper;
 import com.marketinghub.experiment.Experiment;
 import com.marketinghub.experiment.ExperimentPlatform;
 import com.marketinghub.experiment.ExperimentStatus;
+import com.marketinghub.experiment.ExperimentTargetingSelection;
 import com.marketinghub.experiment.mapper.ExperimentMapper;
 import com.marketinghub.repository.jpa.experiment.ExperimentRepository;
+import com.marketinghub.repository.jpa.experiment.ExperimentTargetingSelectionRepository;
 import com.marketinghub.facebookads.dto.ExperimentReadyForAdSetDto;
 import com.marketinghub.hypothesis.Hypothesis;
 import com.marketinghub.hypothesis.mapper.HypothesisMapper;
@@ -18,7 +20,9 @@ import com.marketinghub.hypothesis.framework.HypothesisFrameworkMapperSupport;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marketinghub.niche.MarketNiche;
 import com.marketinghub.niche.mapper.MarketNicheMapper;
+import com.marketinghub.targeting.TargetingCandidateType;
 import com.marketinghub.targeting.TargetingElement;
+import com.marketinghub.targeting.TargetingElementStatus;
 import com.marketinghub.targeting.TargetingElementType;
 import com.marketinghub.targeting.dto.TargetingElementDto;
 import com.marketinghub.targeting.mapper.TargetingElementMapper;
@@ -37,6 +41,8 @@ class FacebookAdSetExperimentServiceTest {
     @Mock
     private ExperimentRepository experimentRepository;
     @Mock
+    private ExperimentTargetingSelectionRepository targetingSelectionRepository;
+    @Mock
     private TargetingElementRepository targetingElementRepository;
 
     private FacebookAdSetExperimentService service;
@@ -51,6 +57,7 @@ class FacebookAdSetExperimentServiceTest {
         TargetingElementMapper targetingElementMapper = Mappers.getMapper(TargetingElementMapper.class);
         service = new FacebookAdSetExperimentService(
                 experimentRepository,
+                targetingSelectionRepository,
                 targetingElementRepository,
                 experimentMapper,
                 marketNicheMapper,
@@ -132,6 +139,8 @@ class FacebookAdSetExperimentServiceTest {
                 .hypothesis(hypothesis)
                 .type(TargetingElementType.INTEREST)
                 .term("Remarketing")
+                .status(TargetingElementStatus.APPROVED)
+                .metaId("interest-1")
                 .build();
         TargetingElement jobTitle = TargetingElement.builder()
                 .id(2L)
@@ -139,6 +148,8 @@ class FacebookAdSetExperimentServiceTest {
                 .hypothesis(hypothesis)
                 .type(TargetingElementType.JOB_TITLE)
                 .term("CMO")
+                .status(TargetingElementStatus.APPROVED)
+                .metaId("job-2")
                 .build();
         TargetingElement behavior = TargetingElement.builder()
                 .id(3L)
@@ -146,6 +157,8 @@ class FacebookAdSetExperimentServiceTest {
                 .hypothesis(hypothesis)
                 .type(TargetingElementType.BEHAVIOR)
                 .term("Engaged Shoppers")
+                .status(TargetingElementStatus.APPROVED)
+                .metaId("behavior-3")
                 .build();
 
         when(targetingElementRepository.findApprovedForExperiment(5L, TargetingElementType.INTEREST, hypothesisId))
@@ -200,6 +213,8 @@ class FacebookAdSetExperimentServiceTest {
                 .hypothesis(hypothesis)
                 .type(TargetingElementType.JOB_TITLE)
                 .term("CMO")
+                .status(TargetingElementStatus.APPROVED)
+                .metaId("job-2")
                 .build();
         when(targetingElementRepository.findApprovedForExperiment(5L, TargetingElementType.JOB_TITLE, hypothesisId))
                 .thenReturn(List.of(jobTitle));
@@ -215,6 +230,69 @@ class FacebookAdSetExperimentServiceTest {
         assertThat(dto.getTargeting().getJobTitles()).extracting(TargetingElementDto::getTerm)
                 .containsExactly("CMO");
         assertThat(dto.getTargeting().getBehaviors()).isEmpty();
+    }
+
+    @Test
+    void listExperimentsReadyPrioritizesSelectedExperimentTargeting() {
+        MarketNiche niche = new MarketNiche();
+        niche.setId(5L);
+
+        Hypothesis hypothesis = new Hypothesis();
+        hypothesis.setId(UUID.randomUUID());
+        hypothesis.setMarketNiche(niche);
+
+        Experiment experiment = new Experiment();
+        experiment.setId(13L);
+        experiment.setName("Selected targeting");
+        experiment.setNiche(niche);
+        experiment.setHypothesisRef(hypothesis);
+        experiment.setStatus(ExperimentStatus.PLANNED);
+        experiment.setPlatform(ExperimentPlatform.FACEBOOK);
+        experiment.setCreativeApproved(true);
+
+        TargetingElement selectedJobTitle = TargetingElement.builder()
+                .id(21L)
+                .niche(niche)
+                .type(TargetingElementType.JOB_TITLE)
+                .term("Personal Trainer")
+                .status(TargetingElementStatus.APPROVED)
+                .metaId("1419795191647433")
+                .metaKey("Certified Personal Trainer")
+                .build();
+        TargetingElement ignoredMissingMetaId = TargetingElement.builder()
+                .id(22L)
+                .niche(niche)
+                .type(TargetingElementType.JOB_TITLE)
+                .term("Profissionais de Educação Física")
+                .status(TargetingElementStatus.APPROVED)
+                .build();
+
+        when(experimentRepository.findAllReadyForAdSets(eq(ExperimentPlatform.FACEBOOK), any()))
+                .thenReturn(List.of(experiment));
+        when(targetingSelectionRepository.findByExperimentIdWithTargetingElement(13L))
+                .thenReturn(List.of(
+                        ExperimentTargetingSelection.builder()
+                                .experiment(experiment)
+                                .candidateType(TargetingCandidateType.WORK_POSITION)
+                                .term("Personal Trainer")
+                                .targetingElement(selectedJobTitle)
+                                .build(),
+                        ExperimentTargetingSelection.builder()
+                                .experiment(experiment)
+                                .candidateType(TargetingCandidateType.WORK_POSITION)
+                                .term("Profissionais de Educação Física")
+                                .targetingElement(ignoredMissingMetaId)
+                                .build()));
+
+        List<ExperimentReadyForAdSetDto> result = service.listExperimentsReadyForAdSets(13L);
+
+        assertThat(result).hasSize(1);
+        assertThat(result.getFirst().getTargeting().getJobTitles())
+                .extracting(TargetingElementDto::getMetaId)
+                .containsExactly("1419795191647433");
+        assertThat(result.getFirst().getTargeting().getJobTitles())
+                .extracting(TargetingElementDto::getTerm)
+                .containsExactly("Personal Trainer");
     }
 
     @Test

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -4155,3 +4155,11 @@
 - foi feito: o schema backend passou a descrever o papel comercial de cada campo estratégico e removeu `funnelStage`; o backend também rejeita respostas de `campaignAngle` com campos vazios ou com `funnelStage` antes de persistir no experimento.
 - ajuste posterior: por decisão de produto, o prompt `campaign-angle` passou para `v3` e a etapa de ângulo deixou de solicitar detalhes de dor, resultado, prova e oferta no contrato final, pois esses blocos já são cobertos nos demais prompts do pipeline. O contrato do ângulo ficou focado em framing visual, hook, mecanismo narrativo, CTA, continuidade, filtro de público, objeções, message match e diferenciação.
 - impacto esperado: a etapa não deve mais avançar com ângulo vazio, preservando a qualidade comercial do pipeline antes de gerar anúncios, imagens e landing.
+
+## 2026-06-09 — Publicação de campanha com público selecionado no Marketing Hub
+
+- solicitação: garantir que a criação da campanha do experimento use o público definido no Marketing Hub e mantenha logs das respostas da Meta/Facebook.
+- causa-raiz: o fallback manual do Facebook Ads Worker buscava o pacote aprovado por nicho via `/api/facebook-adsets/experiments-ready`, mas o backend montava esse pacote a partir dos elementos aprovados do nicho, não priorizando as seleções salvas em `experiment_targeting_selection` para o experimento específico.
+- foi feito: o endpoint de pacotes prontos para ad sets passou a aceitar filtro opcional `experimentId` e o service passou a priorizar os elementos de segmentação selecionados no experimento, enviando apenas itens aprovados e com `metaId` oficial.
+- foi feito: quando não houver seleção manual salva, o comportamento antigo de fallback por elementos aprovados do nicho continua disponível, também filtrando itens sem `metaId` para evitar público amplo ou inválido.
+- impacto esperado: ao reenfileirar a publicação, o worker deve montar o targeting a partir do público escolhido no Marketing Hub e avançar até as chamadas de criação de campanha/ad set/criativo/anúncio, cujas respostas da Meta já são registradas em `experiment_facebook_api_log`.

--- a/docs/swagger/facebook-ads-swagger.yaml
+++ b/docs/swagger/facebook-ads-swagger.yaml
@@ -376,8 +376,14 @@ paths:
     get:
       tags: [Facebook Ad Sets]
       summary: Lista experimentos prontos para criação de conjuntos de anúncios.
+      parameters:
+        - name: experimentId
+          in: query
+          required: false
+          schema: { type: integer, format: int64 }
+          description: Filtra o pacote de público pelo experimento selecionado.
       responses:
-        '200': { description: Experimentos retornados. }
+        '200': { description: Experimentos retornados com o público definido no Marketing Hub. }
   /api/adsets:
     get:
       tags: [Facebook Ad Sets]


### PR DESCRIPTION
### Motivation
- Ensure the ad set generation worker uses the audience explicitly selected in the Marketing Hub for an experiment instead of always falling back to niche-approved elements. 
- Prevent invalid/too-broad targeting from being sent to Meta by requiring approved elements to have an official `metaId`.
- Expose an API filter so callers can request the targeting package for a specific experiment via `experimentId`.

### Description
- Added an optional query parameter `experimentId` to the endpoint `GET /api/facebook-adsets/experiments-ready` in `FacebookAdSetController` and routed it to the service call `listExperimentsReadyForAdSets(experimentId)`.
- Extended `FacebookAdSetExperimentService` to accept `ExperimentTargetingSelectionRepository`, to prefer experiment-saved targeting selections (`findByExperimentIdWithTargetingElement`) and fall back to niche-approved elements when no manual selection exists, while filtering elements to only those `APPROVED` and with a non-empty `metaId`.
- Introduced helper methods `buildSelectedTargetingPackage`, `buildApprovedNicheTargetingPackage`, `emptyTargetingMap`, `toTargetingPackage`, and `isPublishableTargetingElement` to centralize mapping and validation logic, and updated `mapElements` to filter by publishable elements.
- Added `findByExperimentIdWithTargetingElement` JPA query to `ExperimentTargetingSelectionRepository` to eager-fetch associated `TargetingElement` data used by the prioritization logic.
- Updated API documentation in `docs/swagger/facebook-ads-swagger.yaml` and release notes in `docs/registros/experimentos.md` to describe the new `experimentId` parameter and behavior.
- Adjusted unit tests to account for the new service signature and added tests exercising the experiment filter and prioritization of selected targeting.

### Testing
- Ran `FacebookAdSetControllerTest` which was updated to call `listExperimentsReadyForAdSets(null)` and to verify the `experimentId` query parameter is accepted, and all assertions passed.
- Ran `FacebookAdSetExperimentServiceTest` which now mocks `ExperimentTargetingSelectionRepository`, verifies fallback behavior, and includes a new test `listExperimentsReadyPrioritizesSelectedExperimentTargeting`, and all assertions passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a277212698c832686e80fa47c432f49)