### PR TITLE
Add Facebook Ads publication & metrics pipeline (code, DB changelog, docs, tests)

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/pipeline/definition/PipelineDefinitionRegistry.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/pipeline/definition/PipelineDefinitionRegistry.java
@@ -36,6 +36,12 @@ public class PipelineDefinitionRegistry {
     private static final String MOIS_SALES_PAGE_LIBRARY_WORKER_ROOT_PACKAGE =
             "com.marketinghub.mois.bibliotecapaginavenda.worker.v1";
     private static final String MOIS_SALES_PAGE_LIBRARY_WORKER_MODULE = "mois-sales-library-worker";
+    private static final String FACEBOOK_ADS_PUBLICATION_METRICS_PIPELINE_CODE =
+            "facebook-ads-publication-metrics-pipeline";
+    private static final String FACEBOOK_ADS_MODULE = "FACEBOOK_ADS";
+    private static final String FACEBOOK_ADS_CANONICAL_VERSION = "facebook-campaign-publication-canon.v1";
+    private static final String FACEBOOK_ADS_WORKER_ROOT_PACKAGE = "com.marketinghub.facebookadsworker.facebookcampaign";
+    private static final String FACEBOOK_ADS_WORKER_MODULE = "facebook-ads-worker";
 
     private final List<PipelineDefinition> officialPipelines;
     private final Set<String> validModules;
@@ -47,8 +53,10 @@ public class PipelineDefinitionRegistry {
         this.officialPipelines = List.of(
                 buildExperimentPipeline(),
                 buildOprmNichoCnaePipeline(),
-                buildMoisSalesPageLibraryPipeline());
-        this.validModules = Set.of(EXPERIMENT_MODULE, "GERALANDING", "MDS", MOIS_MODULE, OPRM_MODULE);
+                buildMoisSalesPageLibraryPipeline(),
+                buildFacebookAdsPublicationMetricsPipeline());
+        this.validModules = Set.of(
+                EXPERIMENT_MODULE, "GERALANDING", "MDS", MOIS_MODULE, OPRM_MODULE, FACEBOOK_ADS_MODULE);
     }
 
     /**
@@ -314,6 +322,110 @@ public class PipelineDefinitionRegistry {
                 MOIS_SALES_PAGE_LIBRARY_WORKER_MODULE,
                 MOIS_SALES_PAGE_LIBRARY_BACKEND_ROOT_PACKAGE + "." + backendPackage,
                 MOIS_SALES_PAGE_LIBRARY_WORKER_ROOT_PACKAGE + "." + workerPackage,
+                aliases);
+    }
+
+
+    /**
+     * Monta a definição oficial do pipeline de publicação e medição de campanhas Facebook Ads.
+     */
+    private PipelineDefinition buildFacebookAdsPublicationMetricsPipeline() {
+        List<PipelineStageDefinition> stages = List.of(
+                facebookAdsStage(
+                        "WORKER_CONFIGURATION",
+                        "worker-configuration",
+                        "Configuração da conta Facebook",
+                        1,
+                        "configuration",
+                        Set.of("facebook-worker-config", "accounts-facebook-worker-config", "configuracao-facebook")),
+                facebookAdsStage(
+                        "EXPERIMENT_READINESS",
+                        "experiment-readiness",
+                        "Prontidão do experimento",
+                        2,
+                        "readiness",
+                        Set.of("experiments-ready", "facebook-readiness", "prontidao-experimento")),
+                facebookAdsStage(
+                        "CREATIVE_CONSUMPTION",
+                        "creative-consumption",
+                        "Criativos aprovados",
+                        3,
+                        "creative",
+                        Set.of("creatives-ready", "approved-creatives", "criativos-aprovados")),
+                facebookAdsStage(
+                        "CAMPAIGN_HIERARCHY_PUBLICATION",
+                        "campaign-hierarchy-publication",
+                        "Publicação da hierarquia de campanha",
+                        4,
+                        "publication",
+                        Set.of("campaign-publication", "meta-campaign-creation", "publicacao-campanha")),
+                facebookAdsStage(
+                        "PUBLICATION_REGISTRATION",
+                        "publication-registration",
+                        "Registro da publicação no backend",
+                        5,
+                        "publication",
+                        Set.of("campaign-registration", "facebook-campaigns-post", "registro-publicacao")),
+                facebookAdsStage(
+                        "METRICS_SYNC_TARGET_SELECTION",
+                        "metrics-sync-target-selection",
+                        "Seleção de campanhas para métricas",
+                        6,
+                        "metrics",
+                        Set.of("metrics-sync-targets", "campaign-metrics-targets", "alvos-metricas")),
+                facebookAdsStage(
+                        "META_INSIGHTS_COLLECTION",
+                        "meta-insights-collection",
+                        "Coleta de insights na Meta",
+                        7,
+                        "metrics",
+                        Set.of("campaign-insights", "meta-insights", "coleta-insights")),
+                facebookAdsStage(
+                        "METRICS_PERSISTENCE",
+                        "metrics-persistence",
+                        "Persistência das métricas",
+                        8,
+                        "metrics",
+                        Set.of("experiment-campaign-metric", "campaign-metrics-post", "persistencia-metricas")),
+                facebookAdsStage(
+                        "METRICS_ERROR_HANDLING",
+                        "metrics-error-handling",
+                        "Tratamento de falhas de métricas",
+                        9,
+                        "metrics",
+                        Set.of("metrics-error", "campaign-metrics-error", "falhas-metricas")));
+        return new PipelineDefinition(
+                FACEBOOK_ADS_MODULE,
+                FACEBOOK_ADS_PUBLICATION_METRICS_PIPELINE_CODE,
+                "Pipeline Facebook Ads: Publicação e Métricas",
+                FACEBOOK_ADS_CANONICAL_VERSION,
+                true,
+                Set.of(
+                        FACEBOOK_ADS_PUBLICATION_METRICS_PIPELINE_CODE,
+                        "facebook_ads_publication_metrics_pipeline",
+                        "facebook-ads-pipeline",
+                        "facebook-campaign-publication-pipeline"),
+                PipelineFieldPolicy.officialDefault(),
+                StageFieldPolicy.officialDefault(),
+                stages);
+    }
+
+    /**
+     * Converte uma tarefa do Facebook Ads Worker para definição canônica exibida na tela de pipelines.
+     */
+    private PipelineStageDefinition facebookAdsStage(
+            String canonicalCode, String operationalCode, String name, int position, String workerPackage, Set<String> aliases) {
+        return new PipelineStageDefinition(
+                canonicalCode,
+                operationalCode,
+                name,
+                position,
+                true,
+                false,
+                true,
+                FACEBOOK_ADS_WORKER_MODULE,
+                FACEBOOK_ADS_WORKER_ROOT_PACKAGE,
+                FACEBOOK_ADS_WORKER_ROOT_PACKAGE + "." + workerPackage,
                 aliases);
     }
 

--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-09-facebook-ads-publication-metrics-pipeline.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-09-facebook-ads-publication-metrics-pipeline.yaml
@@ -1,0 +1,193 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-06-09-facebook-ads-publication-metrics-pipeline-operational
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - onError: MARK_RAN
+        - dbms:
+            type: mysql
+        - tableExists:
+            tableName: pipeline
+        - tableExists:
+            tableName: pipeline_stage
+      changes:
+        - sql:
+            splitStatements: true
+            stripComments: true
+            sql: |
+              INSERT INTO pipeline (name, code, module, description, active, created_at, updated_at)
+              SELECT 'Pipeline Facebook Ads: Publicação e Métricas', 'facebook-ads-publication-metrics-pipeline', 'FACEBOOK_ADS', 'Fluxo operacional do Facebook Ads Worker para publicar campanhas, registrar IDs da Meta, sincronizar métricas e expor falhas de medição para decisão de escala ou correção.', 1, NOW(), NOW()
+              FROM dual
+              WHERE NOT EXISTS (SELECT 1 FROM pipeline WHERE code = 'facebook-ads-publication-metrics-pipeline');
+
+              INSERT INTO pipeline_stage (pipeline_id, position, name, code, description, required, active, created_at, updated_at)
+              SELECT p.id, 1, 'Configuração da conta Facebook', 'worker-configuration', 'Carrega token, conta de anúncios, defaults de orçamento, CTA e credenciais necessárias para operar a campanha com segurança.', 1, 1, NOW(), NOW()
+              FROM pipeline p
+              WHERE p.code = 'facebook-ads-publication-metrics-pipeline'
+                AND NOT EXISTS (SELECT 1 FROM pipeline_stage ps WHERE ps.pipeline_id = p.id AND ps.code = 'worker-configuration');
+
+              INSERT INTO pipeline_stage (pipeline_id, position, name, code, description, required, active, created_at, updated_at)
+              SELECT p.id, 2, 'Prontidão do experimento', 'experiment-readiness', 'Busca experimentos liberados e prontos para Facebook, impedindo duplicidade de campanha e bloqueando publicação sem requisitos mínimos.', 1, 1, NOW(), NOW()
+              FROM pipeline p
+              WHERE p.code = 'facebook-ads-publication-metrics-pipeline'
+                AND NOT EXISTS (SELECT 1 FROM pipeline_stage ps WHERE ps.pipeline_id = p.id AND ps.code = 'experiment-readiness');
+
+              INSERT INTO pipeline_stage (pipeline_id, position, name, code, description, required, active, created_at, updated_at)
+              SELECT p.id, 3, 'Criativos aprovados', 'creative-consumption', 'Consome somente criativos aprovados pelo contrato exclusivo do módulo Facebook antes de montar a campanha na Meta.', 1, 1, NOW(), NOW()
+              FROM pipeline p
+              WHERE p.code = 'facebook-ads-publication-metrics-pipeline'
+                AND NOT EXISTS (SELECT 1 FROM pipeline_stage ps WHERE ps.pipeline_id = p.id AND ps.code = 'creative-consumption');
+
+              INSERT INTO pipeline_stage (pipeline_id, position, name, code, description, required, active, created_at, updated_at)
+              SELECT p.id, 4, 'Publicação da hierarquia de campanha', 'campaign-hierarchy-publication', 'Cria campanha, conjunto, imagem, criativo e anúncio na Graph API, mantendo status seguro para revisão operacional.', 1, 1, NOW(), NOW()
+              FROM pipeline p
+              WHERE p.code = 'facebook-ads-publication-metrics-pipeline'
+                AND NOT EXISTS (SELECT 1 FROM pipeline_stage ps WHERE ps.pipeline_id = p.id AND ps.code = 'campaign-hierarchy-publication');
+
+              INSERT INTO pipeline_stage (pipeline_id, position, name, code, description, required, active, created_at, updated_at)
+              SELECT p.id, 5, 'Registro da publicação no backend', 'publication-registration', 'Persiste campanha, ad set, criativo, anúncio e IDs externos para rastrear o experimento e impedir publicação duplicada.', 1, 1, NOW(), NOW()
+              FROM pipeline p
+              WHERE p.code = 'facebook-ads-publication-metrics-pipeline'
+                AND NOT EXISTS (SELECT 1 FROM pipeline_stage ps WHERE ps.pipeline_id = p.id AND ps.code = 'publication-registration');
+
+              INSERT INTO pipeline_stage (pipeline_id, position, name, code, description, required, active, created_at, updated_at)
+              SELECT p.id, 6, 'Seleção de campanhas para métricas', 'metrics-sync-target-selection', 'Lista campanhas em execução que precisam de sincronização de métricas para transformar tráfego pago em decisão mensurável.', 1, 1, NOW(), NOW()
+              FROM pipeline p
+              WHERE p.code = 'facebook-ads-publication-metrics-pipeline'
+                AND NOT EXISTS (SELECT 1 FROM pipeline_stage ps WHERE ps.pipeline_id = p.id AND ps.code = 'metrics-sync-target-selection');
+
+              INSERT INTO pipeline_stage (pipeline_id, position, name, code, description, required, active, created_at, updated_at)
+              SELECT p.id, 7, 'Coleta de insights na Meta', 'meta-insights-collection', 'Consulta insights da campanha na Graph API e transforma impressões, cliques, leads e gasto em payload operacional.', 1, 1, NOW(), NOW()
+              FROM pipeline p
+              WHERE p.code = 'facebook-ads-publication-metrics-pipeline'
+                AND NOT EXISTS (SELECT 1 FROM pipeline_stage ps WHERE ps.pipeline_id = p.id AND ps.code = 'meta-insights-collection');
+
+              INSERT INTO pipeline_stage (pipeline_id, position, name, code, description, required, active, created_at, updated_at)
+              SELECT p.id, 8, 'Persistência das métricas', 'metrics-persistence', 'Atualiza experiment_campaign_metric e limpa erro anterior para que o funil mostre custo, clique, lead, CPC e CPL atualizados.', 1, 1, NOW(), NOW()
+              FROM pipeline p
+              WHERE p.code = 'facebook-ads-publication-metrics-pipeline'
+                AND NOT EXISTS (SELECT 1 FROM pipeline_stage ps WHERE ps.pipeline_id = p.id AND ps.code = 'metrics-persistence');
+
+              INSERT INTO pipeline_stage (pipeline_id, position, name, code, description, required, active, created_at, updated_at)
+              SELECT p.id, 9, 'Tratamento de falhas de métricas', 'metrics-error-handling', 'Registra falhas de permissão, payload ou integração para reduzir incerteza operacional e orientar correção de causa-raiz.', 1, 1, NOW(), NOW()
+              FROM pipeline p
+              WHERE p.code = 'facebook-ads-publication-metrics-pipeline'
+                AND NOT EXISTS (SELECT 1 FROM pipeline_stage ps WHERE ps.pipeline_id = p.id AND ps.code = 'metrics-error-handling');
+  - changeSet:
+      id: 2026-06-09-facebook-ads-publication-metrics-pipeline-location
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - onError: MARK_RAN
+        - dbms:
+            type: mysql
+        - tableExists:
+            tableName: pipeline_stage
+        - columnExists:
+            tableName: pipeline_stage
+            columnName: execution_module
+        - columnExists:
+            tableName: pipeline_stage
+            columnName: root_package
+      changes:
+        - sql:
+            splitStatements: true
+            stripComments: true
+            sql: |
+              UPDATE pipeline_stage ps
+              INNER JOIN pipeline p ON p.id = ps.pipeline_id
+              SET ps.execution_module = 'facebook-ads-worker',
+                  ps.root_package = 'com.marketinghub.facebookadsworker.facebookcampaign'
+              WHERE p.code = 'facebook-ads-publication-metrics-pipeline';
+  - changeSet:
+      id: 2026-06-09-facebook-ads-publication-metrics-pipeline-persistent-contract
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - onError: MARK_RAN
+        - dbms:
+            type: mysql
+        - tableExists:
+            tableName: pipeline_definition
+        - tableExists:
+            tableName: pipeline_stage_definition
+        - tableExists:
+            tableName: pipeline_stage_config
+        - columnExists:
+            tableName: pipeline_stage_definition
+            columnName: execution_module
+        - columnExists:
+            tableName: pipeline_stage_definition
+            columnName: root_package
+      changes:
+        - sql:
+            splitStatements: true
+            stripComments: true
+            sql: |
+              INSERT INTO pipeline_definition (module, code, name, canonical_version, active, created_at, updated_at)
+              SELECT 'FACEBOOK_ADS', 'facebook-ads-publication-metrics-pipeline', 'Pipeline Facebook Ads: Publicação e Métricas', 'facebook-campaign-publication-canon.v1', 1, NOW(), NOW()
+              FROM dual
+              WHERE NOT EXISTS (SELECT 1 FROM pipeline_definition WHERE code = 'facebook-ads-publication-metrics-pipeline' AND canonical_version = 'facebook-campaign-publication-canon.v1');
+
+              INSERT INTO pipeline_stage_definition (pipeline_definition_id, canonical_code, display_name, position, required, implemented_stage_enum, requires_openai_model, configurable, execution_module, root_package, created_at, updated_at)
+              SELECT pd.id, 'WORKER_CONFIGURATION', 'Configuração da conta Facebook', 1, 1, 'WORKER_CONFIGURATION', 0, 1, 'facebook-ads-worker', 'com.marketinghub.facebookadsworker.facebookcampaign', NOW(), NOW()
+              FROM pipeline_definition pd
+              WHERE pd.code = 'facebook-ads-publication-metrics-pipeline' AND pd.canonical_version = 'facebook-campaign-publication-canon.v1'
+                AND NOT EXISTS (SELECT 1 FROM pipeline_stage_definition psd WHERE psd.pipeline_definition_id = pd.id AND psd.canonical_code = 'WORKER_CONFIGURATION');
+
+              INSERT INTO pipeline_stage_definition (pipeline_definition_id, canonical_code, display_name, position, required, implemented_stage_enum, requires_openai_model, configurable, execution_module, root_package, created_at, updated_at)
+              SELECT pd.id, 'EXPERIMENT_READINESS', 'Prontidão do experimento', 2, 1, 'EXPERIMENT_READINESS', 0, 1, 'facebook-ads-worker', 'com.marketinghub.facebookadsworker.facebookcampaign', NOW(), NOW()
+              FROM pipeline_definition pd
+              WHERE pd.code = 'facebook-ads-publication-metrics-pipeline' AND pd.canonical_version = 'facebook-campaign-publication-canon.v1'
+                AND NOT EXISTS (SELECT 1 FROM pipeline_stage_definition psd WHERE psd.pipeline_definition_id = pd.id AND psd.canonical_code = 'EXPERIMENT_READINESS');
+
+              INSERT INTO pipeline_stage_definition (pipeline_definition_id, canonical_code, display_name, position, required, implemented_stage_enum, requires_openai_model, configurable, execution_module, root_package, created_at, updated_at)
+              SELECT pd.id, 'CREATIVE_CONSUMPTION', 'Criativos aprovados', 3, 1, 'CREATIVE_CONSUMPTION', 0, 1, 'facebook-ads-worker', 'com.marketinghub.facebookadsworker.facebookcampaign', NOW(), NOW()
+              FROM pipeline_definition pd
+              WHERE pd.code = 'facebook-ads-publication-metrics-pipeline' AND pd.canonical_version = 'facebook-campaign-publication-canon.v1'
+                AND NOT EXISTS (SELECT 1 FROM pipeline_stage_definition psd WHERE psd.pipeline_definition_id = pd.id AND psd.canonical_code = 'CREATIVE_CONSUMPTION');
+
+              INSERT INTO pipeline_stage_definition (pipeline_definition_id, canonical_code, display_name, position, required, implemented_stage_enum, requires_openai_model, configurable, execution_module, root_package, created_at, updated_at)
+              SELECT pd.id, 'CAMPAIGN_HIERARCHY_PUBLICATION', 'Publicação da hierarquia de campanha', 4, 1, 'CAMPAIGN_HIERARCHY_PUBLICATION', 0, 1, 'facebook-ads-worker', 'com.marketinghub.facebookadsworker.facebookcampaign', NOW(), NOW()
+              FROM pipeline_definition pd
+              WHERE pd.code = 'facebook-ads-publication-metrics-pipeline' AND pd.canonical_version = 'facebook-campaign-publication-canon.v1'
+                AND NOT EXISTS (SELECT 1 FROM pipeline_stage_definition psd WHERE psd.pipeline_definition_id = pd.id AND psd.canonical_code = 'CAMPAIGN_HIERARCHY_PUBLICATION');
+
+              INSERT INTO pipeline_stage_definition (pipeline_definition_id, canonical_code, display_name, position, required, implemented_stage_enum, requires_openai_model, configurable, execution_module, root_package, created_at, updated_at)
+              SELECT pd.id, 'PUBLICATION_REGISTRATION', 'Registro da publicação no backend', 5, 1, 'PUBLICATION_REGISTRATION', 0, 1, 'facebook-ads-worker', 'com.marketinghub.facebookadsworker.facebookcampaign', NOW(), NOW()
+              FROM pipeline_definition pd
+              WHERE pd.code = 'facebook-ads-publication-metrics-pipeline' AND pd.canonical_version = 'facebook-campaign-publication-canon.v1'
+                AND NOT EXISTS (SELECT 1 FROM pipeline_stage_definition psd WHERE psd.pipeline_definition_id = pd.id AND psd.canonical_code = 'PUBLICATION_REGISTRATION');
+
+              INSERT INTO pipeline_stage_definition (pipeline_definition_id, canonical_code, display_name, position, required, implemented_stage_enum, requires_openai_model, configurable, execution_module, root_package, created_at, updated_at)
+              SELECT pd.id, 'METRICS_SYNC_TARGET_SELECTION', 'Seleção de campanhas para métricas', 6, 1, 'METRICS_SYNC_TARGET_SELECTION', 0, 1, 'facebook-ads-worker', 'com.marketinghub.facebookadsworker.facebookcampaign', NOW(), NOW()
+              FROM pipeline_definition pd
+              WHERE pd.code = 'facebook-ads-publication-metrics-pipeline' AND pd.canonical_version = 'facebook-campaign-publication-canon.v1'
+                AND NOT EXISTS (SELECT 1 FROM pipeline_stage_definition psd WHERE psd.pipeline_definition_id = pd.id AND psd.canonical_code = 'METRICS_SYNC_TARGET_SELECTION');
+
+              INSERT INTO pipeline_stage_definition (pipeline_definition_id, canonical_code, display_name, position, required, implemented_stage_enum, requires_openai_model, configurable, execution_module, root_package, created_at, updated_at)
+              SELECT pd.id, 'META_INSIGHTS_COLLECTION', 'Coleta de insights na Meta', 7, 1, 'META_INSIGHTS_COLLECTION', 0, 1, 'facebook-ads-worker', 'com.marketinghub.facebookadsworker.facebookcampaign', NOW(), NOW()
+              FROM pipeline_definition pd
+              WHERE pd.code = 'facebook-ads-publication-metrics-pipeline' AND pd.canonical_version = 'facebook-campaign-publication-canon.v1'
+                AND NOT EXISTS (SELECT 1 FROM pipeline_stage_definition psd WHERE psd.pipeline_definition_id = pd.id AND psd.canonical_code = 'META_INSIGHTS_COLLECTION');
+
+              INSERT INTO pipeline_stage_definition (pipeline_definition_id, canonical_code, display_name, position, required, implemented_stage_enum, requires_openai_model, configurable, execution_module, root_package, created_at, updated_at)
+              SELECT pd.id, 'METRICS_PERSISTENCE', 'Persistência das métricas', 8, 1, 'METRICS_PERSISTENCE', 0, 1, 'facebook-ads-worker', 'com.marketinghub.facebookadsworker.facebookcampaign', NOW(), NOW()
+              FROM pipeline_definition pd
+              WHERE pd.code = 'facebook-ads-publication-metrics-pipeline' AND pd.canonical_version = 'facebook-campaign-publication-canon.v1'
+                AND NOT EXISTS (SELECT 1 FROM pipeline_stage_definition psd WHERE psd.pipeline_definition_id = pd.id AND psd.canonical_code = 'METRICS_PERSISTENCE');
+
+              INSERT INTO pipeline_stage_definition (pipeline_definition_id, canonical_code, display_name, position, required, implemented_stage_enum, requires_openai_model, configurable, execution_module, root_package, created_at, updated_at)
+              SELECT pd.id, 'METRICS_ERROR_HANDLING', 'Tratamento de falhas de métricas', 9, 1, 'METRICS_ERROR_HANDLING', 0, 1, 'facebook-ads-worker', 'com.marketinghub.facebookadsworker.facebookcampaign', NOW(), NOW()
+              FROM pipeline_definition pd
+              WHERE pd.code = 'facebook-ads-publication-metrics-pipeline' AND pd.canonical_version = 'facebook-campaign-publication-canon.v1'
+                AND NOT EXISTS (SELECT 1 FROM pipeline_stage_definition psd WHERE psd.pipeline_definition_id = pd.id AND psd.canonical_code = 'METRICS_ERROR_HANDLING');
+
+              INSERT INTO pipeline_stage_config (pipeline_stage_definition_id, active, openai_model_id, description_override, updated_by, created_at, updated_at)
+              SELECT psd.id, 1, NULL, NULL, 'liquibase-facebook-ads-publication-metrics-pipeline', NOW(), NOW()
+              FROM pipeline_stage_definition psd
+              INNER JOIN pipeline_definition pd ON pd.id = psd.pipeline_definition_id
+              WHERE pd.code = 'facebook-ads-publication-metrics-pipeline'
+                AND pd.canonical_version = 'facebook-campaign-publication-canon.v1'
+                AND NOT EXISTS (SELECT 1 FROM pipeline_stage_config psc WHERE psc.pipeline_stage_definition_id = psd.id);

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -642,6 +642,9 @@ databaseChangeLog:
       file: changesets/2026-06-04-pipeline-persistent-contract.yaml
       relativeToChangelogFile: true
   - include:
+      file: changesets/2026-06-09-facebook-ads-publication-metrics-pipeline.yaml
+      relativeToChangelogFile: true
+  - include:
       file: changesets/2026-06-04-openai-model-accepts-image-input.yaml
       relativeToChangelogFile: true
   - include:

--- a/backend/ads-service/src/test/java/com/marketinghub/pipeline/service/PipelineServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/pipeline/service/PipelineServiceTest.java
@@ -311,7 +311,7 @@ class PipelineServiceTest {
      */
     @Test
     void shouldExposeOfficialStageAliasesAndCanonicalCodes() {
-        assertThat(definitionRegistry.officialPipelines()).hasSize(3);
+        assertThat(definitionRegistry.officialPipelines()).hasSize(4);
         assertThat(definitionRegistry.findByPipelineCode("experiment-pipeline")).hasValueSatisfying(pipeline -> {
             assertThat(pipeline.code()).isEqualTo("experiment-pipeline");
             assertThat(pipeline.stages()).hasSize(10);
@@ -596,6 +596,45 @@ class PipelineServiceTest {
             assertThat(definitionRegistry.findStage(pipeline, "page-analysis"))
                     .hasValueSatisfying(stage -> assertThat(stage.operationalCode()).isEqualTo("commercial-page-analysis"));
         });
+    }
+
+
+    /**
+     * Garante que o pipeline oficial Facebook Ads reflete publicação e métricas operadas pelo worker.
+     */
+    @Test
+    void shouldExposeOfficialFacebookAdsPublicationMetricsPipeline() {
+        assertThat(definitionRegistry.findByPipelineCode("facebook-ads-publication-metrics-pipeline"))
+                .hasValueSatisfying(pipeline -> {
+                    assertThat(pipeline.module()).isEqualTo("FACEBOOK_ADS");
+                    assertThat(pipeline.name()).isEqualTo("Pipeline Facebook Ads: Publicação e Métricas");
+                    assertThat(pipeline.canonicalVersion()).isEqualTo("facebook-campaign-publication-canon.v1");
+                    assertThat(pipeline.stages()).hasSize(9);
+                    assertThat(pipeline.stages()).extracting(stage -> stage.operationalCode())
+                            .containsExactly(
+                                    "worker-configuration",
+                                    "experiment-readiness",
+                                    "creative-consumption",
+                                    "campaign-hierarchy-publication",
+                                    "publication-registration",
+                                    "metrics-sync-target-selection",
+                                    "meta-insights-collection",
+                                    "metrics-persistence",
+                                    "metrics-error-handling");
+                    assertThat(pipeline.stages())
+                            .allSatisfy(stage -> {
+                                assertThat(stage.executionModule()).isEqualTo("facebook-ads-worker");
+                                assertThat(stage.rootPackage()).isEqualTo("com.marketinghub.facebookadsworker.facebookcampaign");
+                                assertThat(stage.modulePackage())
+                                        .startsWith("com.marketinghub.facebookadsworker.facebookcampaign.");
+                                assertThat(stage.requiresOpenAiModel()).isFalse();
+                                assertThat(definitionRegistry.findStage(pipeline, stage.canonicalCode())).contains(stage);
+                                assertThat(definitionRegistry.findStage(pipeline, stage.operationalCode())).contains(stage);
+                            });
+                    assertThat(definitionRegistry.findStage(pipeline, "meta-insights"))
+                            .hasValueSatisfying(stage -> assertThat(stage.operationalCode())
+                                    .isEqualTo("meta-insights-collection"));
+                });
     }
 
     /**

--- a/docs/canonical/facebook-campaign-publication-canon.v1.md
+++ b/docs/canonical/facebook-campaign-publication-canon.v1.md
@@ -29,6 +29,24 @@ Este documento complementa o `system-governance-canon.v2.md` e passa a ser a fon
 | Fontes de verdade das flags usadas pela UI (cartão Campanha de Facebook Ads) e pelos serviços (`ExperimentReadinessService`, `/api/facebook-campaigns/experiments-ready`, `/api/facebook-pixels`). | Contratos de outros canais pagos ou fluxos do Lead Portal que já possuem cânone próprio. |
 | Padrão arquitetural da publicação de campanhas como etapa plugável dentro do `facebook-ads-worker`. | Migração genérica de todos os workers para pipeline; este cânone cobre somente publicação de campanha Facebook. |
 
+## 2.1 Pipeline oficial na tela de Pipelines
+
+O fluxo do Facebook Ads Worker deve aparecer na tela administrativa `/pipelines` como o pipeline oficial `facebook-ads-publication-metrics-pipeline`, com módulo `FACEBOOK_ADS` e nome operacional **Pipeline Facebook Ads: Publicação e Métricas**.
+
+As etapas oficiais expostas para operação são:
+
+1. `worker-configuration` — carregar configuração, token, conta de anúncios e defaults.
+2. `experiment-readiness` — selecionar experimentos liberados, prontos e sem campanha duplicada.
+3. `creative-consumption` — consumir somente criativos aprovados pelo contrato do módulo Facebook.
+4. `campaign-hierarchy-publication` — criar campanha, conjunto, imagem, criativo e anúncio na Meta.
+5. `publication-registration` — persistir IDs externos no backend e marcar rastreabilidade da publicação.
+6. `metrics-sync-target-selection` — selecionar campanhas em execução para sincronização de métricas.
+7. `meta-insights-collection` — coletar insights da Graph API.
+8. `metrics-persistence` — atualizar `experiment_campaign_metric` e dados de última sincronização.
+9. `metrics-error-handling` — registrar falhas de coleta para correção de causa-raiz.
+
+Esse pipeline é administrativo e operacional: ele torna visível o fluxo do worker, mas não transfere ownership de banco para o worker. O backend continua sendo o único responsável por persistência, e o Facebook Ads Worker continua consumindo contratos HTTP do módulo Facebook.
+
 ## 3. Ownership e módulos
 
 | Regra | Dono | Consumidores |

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -4163,3 +4163,8 @@
 - foi feito: o endpoint de pacotes prontos para ad sets passou a aceitar filtro opcional `experimentId` e o service passou a priorizar os elementos de segmentação selecionados no experimento, enviando apenas itens aprovados e com `metaId` oficial.
 - foi feito: quando não houver seleção manual salva, o comportamento antigo de fallback por elementos aprovados do nicho continua disponível, também filtrando itens sem `metaId` para evitar público amplo ou inválido.
 - impacto esperado: ao reenfileirar a publicação, o worker deve montar o targeting a partir do público escolhido no Marketing Hub e avançar até as chamadas de criação de campanha/ad set/criativo/anúncio, cujas respostas da Meta já são registradas em `experiment_facebook_api_log`.
+
+## 2026-06-09 — Pipeline oficial de publicação e métricas Facebook Ads
+
+- Registrado o pipeline `facebook-ads-publication-metrics-pipeline` para tornar visíveis, na tela `/pipelines`, as tarefas do Facebook Ads Worker ligadas à publicação de campanhas e sincronização de métricas.
+- Etapas cobrem configuração, prontidão do experimento, consumo de criativos, publicação na Meta, registro no backend, seleção de alvos de métricas, coleta de insights, persistência de métricas e tratamento de falhas.


### PR DESCRIPTION
### Motivation
- Introduce a formal, visible pipeline for the Facebook Ads worker so the backend and UI share a canonical contract for publication and metrics collection. 
- Persist the new pipeline and its stages into the database so the administrative `/pipelines` view and runtime checks can rely on a single source of truth.

### Description
- Added constants, a `buildFacebookAdsPublicationMetricsPipeline()` and `facebookAdsStage()` helper to `PipelineDefinitionRegistry` and registered the pipeline in `officialPipelines` and `validModules` so the service exposes the new pipeline in-memory. 
- Created a Liquibase changelog `changesets/2026-06-09-facebook-ads-publication-metrics-pipeline.yaml` that inserts the `pipeline`, its `pipeline_stage` rows, updates `execution_module`/`root_package`, and persists `pipeline_definition`, `pipeline_stage_definition` and `pipeline_stage_config` entries for the canonical contract. 
- Included the new changelog in `db.changelog-master.yaml` and added the canonical document `docs/canonical/facebook-campaign-publication-canon.v1.md` and a release note in `docs/registros/experimentos.md` describing the pipeline and its 9-stage flow. 
- Updated unit tests in `PipelineServiceTest` to expect the registry size increase and added `shouldExposeOfficialFacebookAdsPublicationMetricsPipeline` to verify pipeline metadata, stage ordering, `executionModule`, `rootPackage` and alias lookups.

### Testing
- Ran unit tests in `backend/ads-service`, including the updated `PipelineServiceTest`, and the suite passed after updating expected registry size and adding assertions for the Facebook Ads pipeline. 
- Validated Liquibase changelog inclusion by adding the file to `db.changelog-master.yaml` and ensuring changelog syntax is consistent with existing changesets.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a278038479883269e59b59c1aa3598b)