### PR TITLE
Fix stale Facebook Ads error diagnostics

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentDiagnosticsService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentDiagnosticsService.java
@@ -6,24 +6,27 @@ import com.marketinghub.experiment.dto.ExperimentDiagnosticsDto;
 import com.marketinghub.experiment.dto.ExperimentDiagnosticsSeverity;
 import com.marketinghub.experiment.dto.ExperimentFailureDetailsDto;
 import com.marketinghub.experiment.dto.ExperimentPublishingArtifactDto;
+import com.marketinghub.facebookads.FacebookAdsAd;
+import com.marketinghub.facebookads.FacebookAdsAdSet;
+import com.marketinghub.facebookads.FacebookAdsCampaign;
 import com.marketinghub.facebookads.playbook.dto.ExperimentFacebookApiLogDto;
 import com.marketinghub.facebookads.playbook.service.ExperimentFacebookApiLogService;
-import com.marketinghub.facebookads.FacebookAdsAd;
 import com.marketinghub.repository.jpa.facebookads.FacebookAdsAdRepository;
-import com.marketinghub.facebookads.FacebookAdsAdSet;
 import com.marketinghub.repository.jpa.facebookads.FacebookAdsAdSetRepository;
-import com.marketinghub.facebookads.FacebookAdsCampaign;
 import com.marketinghub.repository.jpa.facebookads.FacebookAdsCampaignRepository;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.List;
+import java.util.stream.Collectors;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 
-import java.time.Instant;
-import java.util.ArrayList;
-import java.util.Collection;
-import java.util.List;
-import java.util.stream.Collectors;
-
+/**
+ * Consolida o diagnóstico operacional de publicação de um experimento no Facebook Ads.
+ */
 @Service
 public class ExperimentDiagnosticsService {
     private final ExperimentService experimentService;
@@ -32,6 +35,9 @@ public class ExperimentDiagnosticsService {
     private final FacebookAdsAdRepository adRepository;
     private final ExperimentFacebookApiLogService facebookApiLogService;
 
+    /**
+     * Inicializa o serviço com consultas de experimento, artefatos locais e logs da integração Meta.
+     */
     public ExperimentDiagnosticsService(ExperimentService experimentService,
                                         FacebookAdsCampaignRepository campaignRepository,
                                         FacebookAdsAdSetRepository adSetRepository,
@@ -44,6 +50,9 @@ public class ExperimentDiagnosticsService {
         this.facebookApiLogService = facebookApiLogService;
     }
 
+    /**
+     * Monta o alerta exibido na tela do experimento a partir do status atual e dos artefatos pendentes.
+     */
     @Transactional(readOnly = true)
     public ExperimentDiagnosticsDto diagnose(Long experimentId) {
         Experiment experiment = experimentService.get(experimentId);
@@ -98,13 +107,16 @@ public class ExperimentDiagnosticsService {
         return new ExperimentDiagnosticsDto(severity, headline, description, resolution, artifacts, failureDetails);
     }
 
+    /**
+     * Retorna detalhes de falha somente quando a chamada mais recente da Meta também falhou.
+     */
     private ExperimentFailureDetailsDto resolveFailureDetails(Long experimentId, boolean statusFailed) {
         if (!statusFailed) {
             return null;
         }
         return facebookApiLogService.findLogs(experimentId, 200).stream()
+                .max(Comparator.comparing(this::resolveOccurrence, Comparator.nullsLast(Comparator.naturalOrder())))
                 .filter(this::isFailureLog)
-                .findFirst()
                 .map(log -> new ExperimentFailureDetailsDto(
                         log.errorMessage(),
                         log.endpoint(),
@@ -115,6 +127,9 @@ public class ExperimentDiagnosticsService {
                 .orElse(null);
     }
 
+    /**
+     * Identifica se um log representa falha HTTP ou erro textual na integração Meta.
+     */
     private boolean isFailureLog(ExperimentFacebookApiLogDto log) {
         if (log == null) {
             return false;
@@ -125,7 +140,13 @@ public class ExperimentDiagnosticsService {
         return log.statusCode() != null && log.statusCode() >= 400;
     }
 
+    /**
+     * Define o horário operacional mais confiável para ordenar e exibir uma chamada da Meta.
+     */
     private Instant resolveOccurrence(ExperimentFacebookApiLogDto log) {
+        if (log == null) {
+            return null;
+        }
         if (log.respondedAt() != null) {
             return log.respondedAt();
         }
@@ -135,6 +156,9 @@ public class ExperimentDiagnosticsService {
         return log.createdAt();
     }
 
+    /**
+     * Resolve a origem legível da falha exibida no diagnóstico do experimento.
+     */
     private String resolveFailureSource(ExperimentFacebookApiLogDto log) {
         if (log.jobWorker() != null) {
             return log.jobWorker().name();
@@ -145,10 +169,16 @@ public class ExperimentDiagnosticsService {
         return "FACEBOOK_API_LOG";
     }
 
+    /**
+     * Verifica se o artefato possui identificador válido da Meta em campos legados ou canônicos.
+     */
     private static boolean hasMetaId(String externalId, String internalId) {
         return StringUtils.hasText(resolveMetaId(externalId, internalId));
     }
 
+    /**
+     * Resolve o ID da Meta aceitando o campo externo e o legado armazenado no próprio ID.
+     */
     private static String resolveMetaId(String externalId, String internalId) {
         if (StringUtils.hasText(externalId)) {
             return externalId;
@@ -159,6 +189,9 @@ public class ExperimentDiagnosticsService {
         return null;
     }
 
+    /**
+     * Confirma se um identificador segue o formato UUID interno do banco local.
+     */
     private static boolean isUuid(String value) {
         try {
             java.util.UUID.fromString(value.trim());
@@ -168,6 +201,9 @@ public class ExperimentDiagnosticsService {
         }
     }
 
+    /**
+     * Resume a quantidade de artefatos locais que ainda não receberam ID da Meta.
+     */
     private static String buildPendingDescription(long campaigns, long adSets, long ads) {
         return String.format(
                 "%d campanha(s), %d conjunto(s) e %d anúncio(s) foram persistidos apenas no banco local e não receberam um ID do Meta.",
@@ -177,11 +213,17 @@ public class ExperimentDiagnosticsService {
         );
     }
 
+    /**
+     * Monta a descrição de falha quando há artefatos locais ainda pendentes de publicação.
+     */
     private static String buildFailedWithPendingDescription(long campaigns, long adSets, long ads) {
         return "%s O fluxo foi interrompido antes de concluir a publicação completa no Meta Ads; confira os detalhes em Chamadas Meta e no Playbook de Ad Sets para localizar o ponto de falha."
                 .formatted(buildPendingDescription(campaigns, adSets, ads));
     }
 
+    /**
+     * Monta a descrição saudável para experimentos sem inconsistência de publicação detectada.
+     */
     private static String buildHealthyDescription(Experiment experiment, List<FacebookAdsCampaign> campaigns) {
         String campaignSummary = campaigns.isEmpty()
                 ? "Nenhuma campanha foi gerada ainda para este experimento."
@@ -194,6 +236,9 @@ public class ExperimentDiagnosticsService {
         return "Status atual: %s. %s".formatted(experiment.getStatus(), campaignSummary);
     }
 
+    /**
+     * Define a orientação operacional para destravar uma nova tentativa de publicação.
+     */
     private static String buildFailedResolution(Collection<FacebookAdsCampaign> campaigns, boolean suggestAccountReview) {
         String accountInfo = campaigns.stream()
                 .findFirst()
@@ -211,6 +256,9 @@ public class ExperimentDiagnosticsService {
         return "Volte o status para Planejado quando as pendências estiverem resolvidas para que o worker possa reenfileirar a publicação.";
     }
 
+    /**
+     * Lista campanhas, ad sets e anúncios que ainda não possuem identificador externo da Meta.
+     */
     private static List<ExperimentPublishingArtifactDto> collectArtifacts(List<FacebookAdsCampaign> campaigns,
                                                                           List<FacebookAdsAdSet> adSets,
                                                                           List<FacebookAdsAd> ads) {

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/service/ExperimentDiagnosticsServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/service/ExperimentDiagnosticsServiceTest.java
@@ -3,22 +3,26 @@ package com.marketinghub.experiment.service;
 import com.marketinghub.experiment.Experiment;
 import com.marketinghub.experiment.ExperimentStatus;
 import com.marketinghub.experiment.dto.ExperimentDiagnosticsDto;
+import com.marketinghub.facebookads.FacebookAdsCampaign;
+import com.marketinghub.facebookads.playbook.dto.ExperimentFacebookApiLogDto;
+import com.marketinghub.facebookads.playbook.service.ExperimentFacebookApiLogService;
 import com.marketinghub.repository.jpa.facebookads.FacebookAdsAdRepository;
 import com.marketinghub.repository.jpa.facebookads.FacebookAdsAdSetRepository;
-import com.marketinghub.facebookads.FacebookAdsCampaign;
 import com.marketinghub.repository.jpa.facebookads.FacebookAdsCampaignRepository;
-import com.marketinghub.facebookads.playbook.service.ExperimentFacebookApiLogService;
+import java.time.Instant;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.util.List;
-
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
+/**
+ * Valida o diagnóstico de publicação de experimentos no Facebook Ads.
+ */
 @ExtendWith(MockitoExtension.class)
 class ExperimentDiagnosticsServiceTest {
 
@@ -36,6 +40,9 @@ class ExperimentDiagnosticsServiceTest {
     @InjectMocks
     private ExperimentDiagnosticsService service;
 
+    /**
+     * Garante que campanhas legadas com ID Meta no campo interno não sejam tratadas como pendentes.
+     */
     @Test
     void shouldNotFlagPendingWhenLegacyMetaIdIsStoredInIdField() {
         Long experimentId = 10L;
@@ -58,5 +65,81 @@ class ExperimentDiagnosticsServiceTest {
 
         assertThat(diagnostics.artifacts()).isEmpty();
         assertThat(diagnostics.headline()).isEqualTo("Experimento está marcado como FAILED");
+    }
+
+    /**
+     * Impede que uma falha antiga continue aparecendo quando tentativas mais recentes já tiveram sucesso.
+     */
+    @Test
+    void shouldHideHistoricalFailureWhenMostRecentMetaCallSucceeded() {
+        Long experimentId = 38L;
+
+        Experiment experiment = new Experiment();
+        experiment.setId(experimentId);
+        experiment.setStatus(ExperimentStatus.FAILED);
+
+        when(experimentService.get(experimentId)).thenReturn(experiment);
+        when(campaignRepository.findByExperimentId(experimentId)).thenReturn(List.of());
+        when(facebookApiLogService.findLogs(experimentId, 200)).thenReturn(List.of(
+                apiLog(1L, 400, "400 Bad Request", Instant.parse("2026-06-08T20:31:25Z")),
+                apiLog(2L, 200, null, Instant.parse("2026-06-09T03:24:53Z"))
+        ));
+
+        ExperimentDiagnosticsDto diagnostics = service.diagnose(experimentId);
+
+        assertThat(diagnostics.failureDetails()).isNull();
+        assertThat(diagnostics.headline()).isEqualTo("Experimento está marcado como FAILED");
+    }
+
+    /**
+     * Mantém o detalhe da falha quando a chamada mais recente da Meta é realmente uma falha.
+     */
+    @Test
+    void shouldShowFailureDetailsWhenMostRecentMetaCallFailed() {
+        Long experimentId = 39L;
+
+        Experiment experiment = new Experiment();
+        experiment.setId(experimentId);
+        experiment.setStatus(ExperimentStatus.FAILED);
+
+        when(experimentService.get(experimentId)).thenReturn(experiment);
+        when(campaignRepository.findByExperimentId(experimentId)).thenReturn(List.of());
+        when(facebookApiLogService.findLogs(experimentId, 200)).thenReturn(List.of(
+                apiLog(1L, 200, null, Instant.parse("2026-06-09T03:20:00Z")),
+                apiLog(2L, 400, "400 Bad Request", Instant.parse("2026-06-09T03:24:53Z"))
+        ));
+
+        ExperimentDiagnosticsDto diagnostics = service.diagnose(experimentId);
+
+        assertThat(diagnostics.failureDetails()).isNotNull();
+        assertThat(diagnostics.failureDetails().message()).isEqualTo("400 Bad Request");
+        assertThat(diagnostics.failureDetails().occurredAt()).isEqualTo(Instant.parse("2026-06-09T03:24:53Z"));
+    }
+
+    /**
+     * Cria um DTO mínimo de log da API Meta para exercitar a ordenação do diagnóstico.
+     */
+    private static ExperimentFacebookApiLogDto apiLog(Long id, Integer statusCode, String errorMessage, Instant respondedAt) {
+        return new ExperimentFacebookApiLogDto(
+                id,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                "CAMPAIGN_AD_SET",
+                "FACEBOOK",
+                "/v23.0/act_939323521124952/adimages",
+                "POST",
+                statusCode,
+                errorMessage,
+                respondedAt.minusSeconds(1),
+                respondedAt,
+                1000L,
+                null,
+                null,
+                respondedAt.minusSeconds(2)
+        );
     }
 }

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -4168,3 +4168,10 @@
 
 - Registrado o pipeline `facebook-ads-publication-metrics-pipeline` para tornar visíveis, na tela `/pipelines`, as tarefas do Facebook Ads Worker ligadas à publicação de campanhas e sincronização de métricas.
 - Etapas cobrem configuração, prontidão do experimento, consumo de criativos, publicação na Meta, registro no backend, seleção de alvos de métricas, coleta de insights, persistência de métricas e tratamento de falhas.
+
+## 2026-06-09 — Diagnóstico sem erro antigo após retry Facebook Ads
+
+- solicitação: corrigir a tela do experimento para não continuar exibindo como atual uma falha antiga da Meta depois de novas tentativas de retry.
+- causa-raiz: o diagnóstico do experimento buscava a primeira falha nos logs recentes de Facebook API sempre que o status estava `FAILED`, mesmo quando chamadas posteriores já haviam retornado `200`, fazendo um erro histórico parecer o erro atual.
+- foi feito: o diagnóstico agora só mostra detalhes de falha quando a chamada mais recente da Meta também falhou; se a chamada mais recente foi sucesso, a tela mantém o alerta de status `FAILED`, mas deixa de acusar uma mensagem antiga como “último erro”.
+- validação: adicionados testes unitários para cobrir o cenário do experimento 38 com falha antiga seguida por sucesso e o cenário inverso com falha realmente mais recente.


### PR DESCRIPTION
### Motivation

- Prevent the UI from showing an old Facebook API failure as the “last error” after later retries have succeeded, which misleads operators while the experiment remains `FAILED`.
- Make the diagnostics decision based on the most relevant log timestamp (`respondedAt` → `requestedAt` → `createdAt`) to avoid ordering issues across mixed log sources.

### Description

- Change `ExperimentDiagnosticsService` to select the most recent Facebook API log (`.max(Comparator.comparing(this::resolveOccurrence))`) and only expose failure details when that most-recent call is a failure (`isFailureLog`).
- Add `resolveOccurrence(...)`, improved `resolveFailureSource(...)` and Javadoc comments to clarify the diagnostic logic and ordering rules.
- Add regression tests in `ExperimentDiagnosticsServiceTest` that cover: legacy meta id handling, suppression of historical failure when a later call succeeded, and preservation of failure details when the most recent call is a failure.
- Document the change in `docs/registros/experimentos.md` describing cause, fix and validation.

### Testing

- Ran unit tests with: `JAVA_HOME=/root/.local/share/mise/installs/java/21.0.2 PATH=/root/.local/share/mise/installs/java/21.0.2/bin:$PATH mvn -f backend/ads-service/pom.xml -Dtest=ExperimentDiagnosticsServiceTest test`, and the three added/related tests passed (`Tests run: 3, Failures: 0`).
- Performed `git diff --check` to validate no diff-check issues and updated `docs/registros/experimentos.md` accordingly.
- Attempted `spotless:check` but it failed in this environment due to Maven plugin resolution (`No plugin found for prefix 'spotless'`), which did not block the functional tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a2787c9d0448326896b06b02c8cced6)