### PR TITLE
Resolve ad set targeting lookup for experiment-specific retry (experiment 38)

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/facebookads/service/FacebookAdSetExperimentService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/facebookads/service/FacebookAdSetExperimentService.java
@@ -71,6 +71,12 @@ public class FacebookAdSetExperimentService {
      * Lista experimentos prontos para conjuntos de anúncios, priorizando o público selecionado no experimento.
      */
     public List<ExperimentReadyForAdSetDto> listExperimentsReadyForAdSets(Long experimentId) {
+        if (experimentId != null) {
+            return experimentRepository.findForAdSetTargetingById(experimentId, ExperimentPlatform.FACEBOOK)
+                    .map(this::toReadyForAdSetDto)
+                    .map(List::of)
+                    .orElseGet(List::of);
+        }
         List<Experiment> experiments = experimentRepository.findAllReadyForAdSets(
                 ExperimentPlatform.FACEBOOK, STATUSES);
         if (experiments.isEmpty()) {
@@ -78,21 +84,27 @@ public class FacebookAdSetExperimentService {
         }
         List<ExperimentReadyForAdSetDto> result = new ArrayList<>();
         for (Experiment experiment : experiments) {
-            if (experimentId != null && !experimentId.equals(experiment.getId())) {
-                continue;
+            ExperimentReadyForAdSetDto dto = toReadyForAdSetDto(experiment);
+            if (dto != null) {
+                result.add(dto);
             }
-            TargetingPackageDto targeting = buildTargetingPackage(experiment);
-            if (targeting == null) {
-                continue;
-            }
-            ExperimentReadyForAdSetDto dto = new ExperimentReadyForAdSetDto(
-                    experimentMapper.toDto(experiment),
-                    marketNicheMapper.toDto(experiment.getNiche()),
-                    experiment.getHypothesisRef() != null ? hypothesisMapper.toDto(experiment.getHypothesisRef()) : null,
-                    targeting);
-            result.add(dto);
         }
         return result;
+    }
+
+    /**
+     * Converte um experimento em contrato de ad set quando existe pacote de segmentação publicável.
+     */
+    private ExperimentReadyForAdSetDto toReadyForAdSetDto(Experiment experiment) {
+        TargetingPackageDto targeting = buildTargetingPackage(experiment);
+        if (targeting == null) {
+            return null;
+        }
+        return new ExperimentReadyForAdSetDto(
+                experimentMapper.toDto(experiment),
+                marketNicheMapper.toDto(experiment.getNiche()),
+                experiment.getHypothesisRef() != null ? hypothesisMapper.toDto(experiment.getHypothesisRef()) : null,
+                targeting);
     }
 
     /**

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/experiment/ExperimentRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/experiment/ExperimentRepository.java
@@ -154,6 +154,27 @@ public interface ExperimentRepository extends JpaRepository<Experiment, Long> {
     List<Experiment> findAllReadyForAdSets(@Param("platform") ExperimentPlatform platform,
                                            @Param("statuses") List<ExperimentStatus> statuses);
 
+    /**
+     * Busca um experimento específico para resolver targeting de ad set sem depender do status operacional atual.
+     */
+    @Query("""
+            select distinct e from Experiment e
+            join fetch e.niche n
+            join fetch e.hypothesisRef h
+            where e.id = :experimentId
+              and e.platform = :platform
+              and e.creativeApproved = true
+              and exists (
+                    select 1 from TargetingElement te
+                    where te.niche = e.niche
+                      and te.type = com.marketinghub.targeting.TargetingElementType.JOB_TITLE
+                      and te.status = com.marketinghub.targeting.TargetingElementStatus.APPROVED
+                      and (te.hypothesis is null or te.hypothesis = e.hypothesisRef)
+              )
+            """)
+    Optional<Experiment> findForAdSetTargetingById(@Param("experimentId") Long experimentId,
+                                                   @Param("platform") ExperimentPlatform platform);
+
     @Modifying(clearAutomatically = true, flushAutomatically = true)
     @Query("update Experiment e set e.facebookPage = null where e.facebookPage.id = :facebookPageId")
     int clearFacebookPageById(@Param("facebookPageId") Long facebookPageId);

--- a/backend/ads-service/src/test/java/com/marketinghub/facebookads/service/FacebookAdSetExperimentServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/facebookads/service/FacebookAdSetExperimentServiceTest.java
@@ -28,6 +28,7 @@ import com.marketinghub.targeting.dto.TargetingElementDto;
 import com.marketinghub.targeting.mapper.TargetingElementMapper;
 import com.marketinghub.repository.jpa.targeting.TargetingElementRepository;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -36,6 +37,9 @@ import org.mapstruct.factory.Mappers;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+/**
+ * Valida a montagem dos pacotes de targeting expostos ao Facebook Ads Worker.
+ */
 @ExtendWith(MockitoExtension.class)
 class FacebookAdSetExperimentServiceTest {
     @Mock
@@ -47,6 +51,9 @@ class FacebookAdSetExperimentServiceTest {
 
     private FacebookAdSetExperimentService service;
 
+    /**
+     * Configura o serviço com mocks e mapeadores reais usados nas respostas do contrato.
+     */
     @BeforeEach
     void setUp() {
         ExperimentMapper experimentMapper = Mappers.getMapper(ExperimentMapper.class);
@@ -65,6 +72,9 @@ class FacebookAdSetExperimentServiceTest {
                 targetingElementMapper);
     }
 
+    /**
+     * Injeta o suporte de framework no mapper de hipótese gerado pelo MapStruct.
+     */
     private void injectFrameworkMapper(HypothesisMapper hypothesisMapper) {
         HypothesisFrameworkMapperSupport support = new HypothesisFrameworkMapperSupport(new ObjectMapper());
         try {
@@ -87,6 +97,9 @@ class FacebookAdSetExperimentServiceTest {
         }
     }
 
+    /**
+     * Injeta o mapper de formulário instantâneo no mapper de experimento gerado pelo MapStruct.
+     */
     private void injectFacebookInstantFormMapper(ExperimentMapper experimentMapper) {
         FacebookInstantFormMapper formMapper = Mappers.getMapper(FacebookInstantFormMapper.class);
         try {
@@ -109,6 +122,9 @@ class FacebookAdSetExperimentServiceTest {
         }
     }
 
+    /**
+     * Garante que experimentos prontos recebem pacote completo de interesses, cargos e comportamentos.
+     */
     @Test
     void listExperimentsReadyIncludesTargetingPackage() {
         MarketNiche niche = new MarketNiche();
@@ -183,6 +199,9 @@ class FacebookAdSetExperimentServiceTest {
                 .containsExactly("Engaged Shoppers");
     }
 
+    /**
+     * Garante que um cargo aprovado e identificável pela Meta basta para expor o pacote publicável.
+     */
     @Test
     void listExperimentsReadyAcceptsOnlyApprovedJobTitle() {
         MarketNiche niche = new MarketNiche();
@@ -232,6 +251,9 @@ class FacebookAdSetExperimentServiceTest {
         assertThat(dto.getTargeting().getBehaviors()).isEmpty();
     }
 
+    /**
+     * Garante que o filtro por experimento prioriza a seleção manual e ignora itens sem metaId.
+     */
     @Test
     void listExperimentsReadyPrioritizesSelectedExperimentTargeting() {
         MarketNiche niche = new MarketNiche();
@@ -267,8 +289,8 @@ class FacebookAdSetExperimentServiceTest {
                 .status(TargetingElementStatus.APPROVED)
                 .build();
 
-        when(experimentRepository.findAllReadyForAdSets(eq(ExperimentPlatform.FACEBOOK), any()))
-                .thenReturn(List.of(experiment));
+        when(experimentRepository.findForAdSetTargetingById(13L, ExperimentPlatform.FACEBOOK))
+                .thenReturn(Optional.of(experiment));
         when(targetingSelectionRepository.findByExperimentIdWithTargetingElement(13L))
                 .thenReturn(List.of(
                         ExperimentTargetingSelection.builder()
@@ -295,6 +317,60 @@ class FacebookAdSetExperimentServiceTest {
                 .containsExactly("Personal Trainer");
     }
 
+    /**
+     * Garante que o filtro direto por experimento ainda resolve targeting após falha operacional anterior.
+     */
+    @Test
+    void listExperimentsReadyByExperimentIdIgnoresOperationalStatus() {
+        MarketNiche niche = new MarketNiche();
+        niche.setId(16L);
+
+        Hypothesis hypothesis = new Hypothesis();
+        hypothesis.setId(UUID.randomUUID());
+        hypothesis.setMarketNiche(niche);
+
+        Experiment experiment = new Experiment();
+        experiment.setId(38L);
+        experiment.setName("Experimento 38");
+        experiment.setNiche(niche);
+        experiment.setHypothesisRef(hypothesis);
+        experiment.setStatus(ExperimentStatus.FAILED);
+        experiment.setPlatform(ExperimentPlatform.FACEBOOK);
+        experiment.setCreativeApproved(true);
+
+        TargetingElement selectedJobTitle = TargetingElement.builder()
+                .id(10L)
+                .niche(niche)
+                .type(TargetingElementType.JOB_TITLE)
+                .term("Personal Trainer")
+                .status(TargetingElementStatus.APPROVED)
+                .metaId("1419795191647433")
+                .metaKey("Certified Personal Trainer")
+                .build();
+
+        when(experimentRepository.findForAdSetTargetingById(38L, ExperimentPlatform.FACEBOOK))
+                .thenReturn(Optional.of(experiment));
+        when(targetingSelectionRepository.findByExperimentIdWithTargetingElement(38L))
+                .thenReturn(List.of(
+                        ExperimentTargetingSelection.builder()
+                                .experiment(experiment)
+                                .candidateType(TargetingCandidateType.WORK_POSITION)
+                                .term("Personal Trainer")
+                                .targetingElement(selectedJobTitle)
+                                .build()));
+
+        List<ExperimentReadyForAdSetDto> result = service.listExperimentsReadyForAdSets(38L);
+
+        assertThat(result).hasSize(1);
+        assertThat(result.getFirst().getExperiment().getId()).isEqualTo(38L);
+        assertThat(result.getFirst().getTargeting().getJobTitles())
+                .extracting(TargetingElementDto::getMetaId)
+                .containsExactly("1419795191647433");
+    }
+
+    /**
+     * Garante que o pacote não é exposto quando não há cargo aprovado para evitar público amplo.
+     */
     @Test
     void listExperimentsReadySkipsWhenApprovedJobTitleIsMissing() {
         MarketNiche niche = new MarketNiche();

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -4184,3 +4184,12 @@
 - causa-raiz: o diagnóstico do experimento buscava a primeira falha nos logs recentes de Facebook API sempre que o status estava `FAILED`, mesmo quando chamadas posteriores já haviam retornado `200`, fazendo um erro histórico parecer o erro atual.
 - foi feito: o diagnóstico agora só mostra detalhes de falha quando a chamada mais recente da Meta também falhou; se a chamada mais recente foi sucesso, a tela mantém o alerta de status `FAILED`, mas deixa de acusar uma mensagem antiga como “último erro”.
 - validação: adicionados testes unitários para cobrir o cenário do experimento 38 com falha antiga seguida por sucesso e o cenário inverso com falha realmente mais recente.
+
+## 2026-06-09 — Correção da resolução de público do experimento 38 após falha operacional
+
+- solicitação: acompanhar nova tentativa de publicação do experimento 38 como campanha.
+- diagnóstico: a tentativa chegou a reenviar as imagens aprovadas para a Meta com sucesso, mas o worker bloqueou a campanha antes de criar campanha/ad set porque a consulta filtrada de pacote de segmentação retornou vazia; o experimento já estava em `FAILED`, e o endpoint de ad sets filtrava apenas status operacionais prontos.
+- causa-raiz: o mesmo endpoint era usado para duas finalidades diferentes: listar experimentos prontos e resolver o pacote de targeting de um experimento específico já selecionado pelo fluxo de publicação. Ao aplicar o filtro de status também no segundo caso, uma falha operacional anterior escondia o público aprovado e impedia o retry.
+- correção: quando `experimentId` é informado, o backend agora busca diretamente o experimento para resolução de targeting, sem depender do status operacional atual, mantendo os bloqueios de segurança de plataforma Facebook, criativo aprovado e cargo aprovado com `metaId` oficial.
+- validação: teste unitário cobre o caso do experimento em `FAILED` ainda retornando o pacote manual aprovado para permitir novo retry sem cair em público amplo.
+- próximo passo: reenfileirar a publicação do experimento 38 após deploy desta correção e confirmar criação de campanha, ad set, criativo e anúncio na Meta.


### PR DESCRIPTION
### Motivation
- The Facebook Ads publication flow was blocking retries for a specific experiment when the experiment status was `FAILED` because the ad-set readiness endpoint applied status filters and hid the experiment's approved manual targeting.
- The change ensures the worker can resolve the experiment-specific targeting package for a retry without exposing broad audiences.

### Description
- Add `findForAdSetTargetingById(...)` to `ExperimentRepository` to load a single experiment (with niche and hypothesis) for targeting resolution without requiring an operational-ready status. 
- Modify `FacebookAdSetExperimentService.listExperimentsReadyForAdSets(...)` to use the new repository query when `experimentId` is provided and factor out `toReadyForAdSetDto(...)` to centralize conversion and reuse targeting checks. 
- Add a unit test `listExperimentsReadyByExperimentIdIgnoresOperationalStatus` to `FacebookAdSetExperimentServiceTest` that asserts an experiment in `FAILED` still returns its manual targeting package when requested by ID. 
- Document the diagnosis and fix in `docs/registros/experimentos.md` so the operational context and next steps for requeueing experiment 38 are recorded.

### Testing
- Ran the unit tests in the ads-service module with the focused test class using Java 21: `JAVA_HOME=/root/.local/share/mise/installs/java/21.0.2 PATH=/root/.local/share/mise/installs/java/21.0.2/bin:$PATH ../mvnw -Dtest=FacebookAdSetExperimentServiceTest test`, and the suite completed with `Tests run: 5, Failures: 0, Errors: 0, Skipped: 0` (build success). 
- An initial `../mvnw -Dtest=FacebookAdSetExperimentServiceTest test` attempt failed in the environment using Java 25 due to a Lombok/javac incompatibility (`TypeTag :: UNKNOWN`), so the tests were re-run under Java 21 and passed. 
- Static checks `git diff --check` returned no issues after the changes and the modified tests exercise the new code path for `experimentId` lookups.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a278d59935c832692dd24e9e35cbb01)