### PR TITLE
Canoniza Etapa 3 do pipeline MOIS — MARKET_WARMUP_RESEARCH

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/pipeline/definition/PipelineDefinitionRegistry.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/pipeline/definition/PipelineDefinitionRegistry.java
@@ -36,6 +36,9 @@ public class PipelineDefinitionRegistry {
     private static final String MOIS_SALES_PAGE_LIBRARY_WORKER_ROOT_PACKAGE =
             "com.marketinghub.mois.bibliotecapaginavenda.worker.v1";
     private static final String MOIS_SALES_PAGE_LIBRARY_WORKER_MODULE = "mois-sales-library-worker";
+    private static final String MOIS_MARKET_WARMUP_WORKER_MODULE = "mois-market-warmup-worker";
+    private static final String MOIS_MARKET_WARMUP_WORKER_ROOT_PACKAGE =
+            "com.marketinghub.mois.marketwarmup.worker.v1";
     private static final String FACEBOOK_ADS_PUBLICATION_METRICS_PIPELINE_CODE =
             "facebook-ads-publication-metrics-pipeline";
     private static final String FACEBOOK_ADS_MODULE = "FACEBOOK_ADS";
@@ -271,8 +274,9 @@ public class PipelineDefinitionRegistry {
                         "Obtenção de HTML",
                         1,
                         false,
+                        MOIS_SALES_PAGE_LIBRARY_WORKER_MODULE,
                         "service",
-                        "pipeline.htmlcapture",
+                        MOIS_SALES_PAGE_LIBRARY_WORKER_ROOT_PACKAGE + ".pipeline.htmlcapture",
                         Set.of("html-capture", "page-snapshot", "capture", "obtencao-html")),
                 moisSalesPageLibraryStage(
                         "COMMERCIAL_PAGE_ANALYSIS",
@@ -280,9 +284,25 @@ public class PipelineDefinitionRegistry {
                         "Análise Comercial da Página",
                         2,
                         true,
+                        MOIS_SALES_PAGE_LIBRARY_WORKER_MODULE,
                         "service",
-                        "openai",
-                        Set.of("page-analysis", "analysis", "commercial-analysis", "analise-comercial")));
+                        MOIS_SALES_PAGE_LIBRARY_WORKER_ROOT_PACKAGE + ".openai",
+                        Set.of("page-analysis", "analysis", "commercial-analysis", "analise-comercial")),
+                moisSalesPageLibraryStage(
+                        "MARKET_WARMUP_RESEARCH",
+                        "market-warmup-research",
+                        "Pesquisa de Aquecimento e Ecossistema de Mercado",
+                        3,
+                        true,
+                        MOIS_MARKET_WARMUP_WORKER_MODULE,
+                        "service.marketwarmup",
+                        MOIS_MARKET_WARMUP_WORKER_ROOT_PACKAGE,
+                        Set.of(
+                                "market-warmup",
+                                "warmup-research",
+                                "ecosystem-research",
+                                "aquecimento-mercado",
+                                "pesquisa-aquecimento")));
         return new PipelineDefinition(
                 MOIS_MODULE,
                 MOIS_SALES_PAGE_LIBRARY_PIPELINE_CODE,
@@ -308,8 +328,9 @@ public class PipelineDefinitionRegistry {
             String name,
             int position,
             boolean requiresOpenAiModel,
+            String executionModule,
             String backendPackage,
-            String workerPackage,
+            String modulePackage,
             Set<String> aliases) {
         return new PipelineStageDefinition(
                 canonicalCode,
@@ -319,12 +340,11 @@ public class PipelineDefinitionRegistry {
                 true,
                 requiresOpenAiModel,
                 true,
-                MOIS_SALES_PAGE_LIBRARY_WORKER_MODULE,
+                executionModule,
                 MOIS_SALES_PAGE_LIBRARY_BACKEND_ROOT_PACKAGE + "." + backendPackage,
-                MOIS_SALES_PAGE_LIBRARY_WORKER_ROOT_PACKAGE + "." + workerPackage,
+                modulePackage,
                 aliases);
     }
-
 
     /**
      * Monta a definição oficial do pipeline de publicação e medição de campanhas Facebook Ads.
@@ -515,7 +535,7 @@ public class PipelineDefinitionRegistry {
     }
 
     /**
-     * Definição oficial de uma etapa implementada no código para um pipeline protegido.
+     * Definição oficial de uma etapa canônica para um pipeline protegido.
      */
     public record PipelineStageDefinition(
             String canonicalCode,

--- a/backend/ads-service/src/test/java/com/marketinghub/pipeline/service/PipelineServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/pipeline/service/PipelineServiceTest.java
@@ -569,32 +569,40 @@ class PipelineServiceTest {
 
 
     /**
-     * Garante que o pipeline oficial da Biblioteca de Páginas de Vendas MOIS reflete o fluxo operacional atual.
+     * Garante que o pipeline oficial da Biblioteca de Páginas de Vendas MOIS reflete o contrato canonizado.
      */
     @Test
-    void shouldExposeOfficialMoisSalesPageLibraryPipelineFromImplementedStages() {
+    void shouldExposeOfficialMoisSalesPageLibraryPipelineFromCanonicalContract() {
         assertThat(definitionRegistry.findByPipelineCode("mois-sales-page-library-pipeline")).hasValueSatisfying(pipeline -> {
             assertThat(pipeline.module()).isEqualTo("MOIS");
             assertThat(pipeline.name()).isEqualTo("Pipeline Biblioteca de Páginas de Vendas");
-            assertThat(pipeline.stages()).hasSize(2);
+            assertThat(pipeline.stages()).hasSize(3);
             assertThat(pipeline.stages()).extracting(stage -> stage.operationalCode())
-                    .containsExactly("html-acquisition", "commercial-page-analysis");
+                    .containsExactly("html-acquisition", "commercial-page-analysis", "market-warmup-research");
             assertThat(pipeline.stages())
                     .allSatisfy(stage -> {
-                        assertThat(stage.executionModule()).isEqualTo("mois-sales-library-worker");
                         assertThat(stage.rootPackage())
                                 .startsWith("com.marketinghub.mois.bibliotecapaginavenda.worker.v1.service");
-                        assertThat(stage.modulePackage())
-                                .startsWith("com.marketinghub.mois.bibliotecapaginavenda.worker.v1.");
                         assertThat(definitionRegistry.findStage(pipeline, stage.canonicalCode())).contains(stage);
                         assertThat(definitionRegistry.findStage(pipeline, stage.operationalCode())).contains(stage);
                     });
+            assertThat(pipeline.stages().get(0).executionModule()).isEqualTo("mois-sales-library-worker");
+            assertThat(pipeline.stages().get(1).executionModule()).isEqualTo("mois-sales-library-worker");
+            assertThat(pipeline.stages().get(2).executionModule()).isEqualTo("mois-market-warmup-worker");
+            assertThat(pipeline.stages().get(0).modulePackage())
+                    .isEqualTo("com.marketinghub.mois.bibliotecapaginavenda.worker.v1.pipeline.htmlcapture");
+            assertThat(pipeline.stages().get(1).modulePackage())
+                    .isEqualTo("com.marketinghub.mois.bibliotecapaginavenda.worker.v1.openai");
+            assertThat(pipeline.stages().get(2).modulePackage())
+                    .isEqualTo("com.marketinghub.mois.marketwarmup.worker.v1");
             assertThat(pipeline.stages())
                     .filteredOn(stage -> stage.requiresOpenAiModel())
                     .extracting(stage -> stage.operationalCode())
-                    .containsExactly("commercial-page-analysis");
+                    .containsExactly("commercial-page-analysis", "market-warmup-research");
             assertThat(definitionRegistry.findStage(pipeline, "page-analysis"))
                     .hasValueSatisfying(stage -> assertThat(stage.operationalCode()).isEqualTo("commercial-page-analysis"));
+            assertThat(definitionRegistry.findStage(pipeline, "aquecimento-mercado"))
+                    .hasValueSatisfying(stage -> assertThat(stage.operationalCode()).isEqualTo("market-warmup-research"));
         });
     }
 
@@ -664,7 +672,7 @@ class PipelineServiceTest {
 
         PipelineSyncResultDto result = synchronizer.syncOfficialByCode("mois-sales-page-library-pipeline");
 
-        assertThat(result.appliedActions()).hasSize(2);
+        assertThat(result.appliedActions()).hasSize(3);
         assertThat(result.canonicalPipelineCode()).isEqualTo("mois-sales-page-library-pipeline");
     }
 

--- a/docs/canonical/mois-worker-canon.v1.md
+++ b/docs/canonical/mois-worker-canon.v1.md
@@ -578,3 +578,22 @@ Contratos operacionais do backend:
 - `POST /api/mois/sales-library/collected-reference-html:claim` reserva uma referência coletada para captura e retorna `captureId` como identificador de execução em `mois_sales_page_job_execution`.
 - `POST /api/mois/sales-library/collected-reference-html/{captureId}:complete` persiste HTML bruto, URL final, status HTTP, content type, hash e tamanho em `mois_sales_page_job_execution` e consolida `mois_sales_page`.
 - `POST /api/mois/sales-library/collected-reference-html/{captureId}:fail` registra falha de captura em `mois_sales_page_job_execution` e atualiza o último erro consolidado da página.
+
+### 13.9 Pipeline oficial da Biblioteca de Páginas de Vendas — Etapa 3
+
+A definição oficial do pipeline `mois-sales-page-library-pipeline` passa a ter três etapas canônicas, nesta ordem obrigatória:
+
+| Posição | Código canônico | Código operacional | Nome | Responsabilidade | Módulo executor | Requer OpenAI | Aliases |
+|---:|---|---|---|---|---|---|---|
+| 1 | `HTML_ACQUISITION` | `html-acquisition` | Obtenção de HTML | Capturar HTML bruto útil da página de venda e preservar evidência operacional para análise posterior. | `mois-sales-library-worker` | Não | `html-capture`, `page-snapshot`, `capture`, `obtencao-html` |
+| 2 | `COMMERCIAL_PAGE_ANALYSIS` | `commercial-page-analysis` | Análise Comercial da Página | Usar o HTML capturado para extrair diagnóstico comercial da página, incluindo dor, promessa, mecanismo, prova, público, categoria e score. | `mois-sales-library-worker` | Sim | `page-analysis`, `analysis`, `commercial-analysis`, `analise-comercial` |
+| 3 | `MARKET_WARMUP_RESEARCH` | `market-warmup-research` | Pesquisa de Aquecimento e Ecossistema de Mercado | Pesquisar fontes públicas rastreáveis para medir se existe ecossistema ativo preparando o mercado para comprar solução parecida, separando presença do produto específico de sinais do mercado/dor. | `mois-market-warmup-worker` | Sim | `market-warmup`, `warmup-research`, `ecosystem-research`, `aquecimento-mercado`, `pesquisa-aquecimento` |
+
+Regras canônicas da Etapa 3:
+
+1. A Etapa 3 só pode iniciar para página com a Etapa 2 concluída, pois deve usar dor, promessa, mecanismo, prova, público e categoria já identificados na análise comercial.
+2. O backend principal continua sendo o único módulo com acesso ao banco; o worker de aquecimento deve conversar somente com endpoints do backend MOIS.
+3. Toda conclusão da Etapa 3 deve ser explicável por fontes públicas rastreáveis e sinais persistidos, evitando opinião sem evidência.
+4. O score da Etapa 3 é o `Market Warm-up Score` de 0 a 100, classificado inicialmente como `Quente`, `Promissor`, `Morno`, `Frio` ou `Saturado` quando houver risco alto de saturação.
+5. A etapa deve preservar o eixo comercial `Dor → Resultado → Mecanismo → Prova → Oferta` e apoiar a decisão de priorizar, pesquisar mais, observar, descartar ou avançar apenas com ângulo diferenciado.
+6. O artefato final exibido ao usuário não pode conter marcador técnico, campo de debug ou JSON serializado dentro de texto funcional.

--- a/docs/registros/mois1.md
+++ b/docs/registros/mois1.md
@@ -1184,3 +1184,15 @@ Arquivos alterados:
 Arquivos alterados:
 - `docs/implementacao/mois/plano-etapa-3-aquecimento-ecossistema-mercado.md`
 - `docs/registros/mois1.md`
+
+## 2026-06-09 — Canonização da Etapa 3 de aquecimento no pipeline MOIS
+
+- Canonizada a **Etapa 3 — Pesquisa de Aquecimento e Ecossistema de Mercado** no documento oficial do MOIS, com código `MARKET_WARMUP_RESEARCH`, slug `market-warmup-research`, posição 3, responsabilidade, módulo executor e aliases operacionais.
+- Atualizado o registry oficial do backend para expor o pipeline `mois-sales-page-library-pipeline` com três etapas: obtenção de HTML, análise comercial e pesquisa de aquecimento de mercado.
+- Atualizados os testes de contrato do pipeline oficial para proteger a nova etapa e a sincronização segura do pipeline ausente.
+
+Arquivos alterados:
+- `docs/canonical/mois-worker-canon.v1.md`
+- `backend/ads-service/src/main/java/com/marketinghub/pipeline/definition/PipelineDefinitionRegistry.java`
+- `backend/ads-service/src/test/java/com/marketinghub/pipeline/service/PipelineServiceTest.java`
+- `docs/registros/mois1.md`


### PR DESCRIPTION
### Motivation
- Incluir a etapa de pesquisa de aquecimento/ ecossistema de mercado na pipeline da Biblioteca de Páginas de Vendas (MOIS) para priorizar mercados com evidência pública de demanda e orientar decisões comerciais. 
- Formalizar no registry e na documentação canônica a existência da etapa 3 (`MARKET_WARMUP_RESEARCH`) para que a orquestração e a sincronização de pipelines reflitam o novo fluxo canônico. 

### Description
- Atualiza `PipelineDefinitionRegistry` para expor o pipeline `mois-sales-page-library-pipeline` com três etapas: `HTML_ACQUISITION`, `COMMERCIAL_PAGE_ANALYSIS` e a nova `MARKET_WARMUP_RESEARCH`, e adiciona constantes para o worker executor e pacote root do worker de aquecimento (`mois-market-warmup-worker`). 
- Ajusta a assinatura auxiliar `moisSalesPageLibraryStage(...)` para permitir especificar o `executionModule` e `modulePackage` por etapa, permitindo que a terceira etapa seja executada por worker distinto. 
- Atualiza `PipelineServiceTest` para validar a nova etapa no contrato canônico (passando a esperar 3 etapas, verificar `executionModule` e `modulePackage`, aliases e flags OpenAI). 
- Documenta a canonização no `docs/canonical/mois-worker-canon.v1.md` adicionando a seção `13.9` com regras e requisitos da Etapa 3 e registra a mudança em `docs/registros/mois1.md`.

### Testing
- Executed unit test target with `../mvnw -Dtest=PipelineServiceTest test` under `backend/ads-service`, but the build did not complete due to a compile-time error caused by the environment Java 25 + project Lombok incompatibility (`com.sun.tools.javac.code.TypeTag :: UNKNOWN`).
- Attempted to run Spotless via `../mvnw spotless:apply -Dspotless.check.skip=false` but it failed because the `spotless` plugin could not be resolved in this execution environment.
- Verified code quality with `git diff --check`, which returned clean results.
- Files changed: `backend/ads-service/src/main/java/com/marketinghub/pipeline/definition/PipelineDefinitionRegistry.java`, `backend/ads-service/src/test/java/com/marketinghub/pipeline/service/PipelineServiceTest.java`, `docs/canonical/mois-worker-canon.v1.md`, and `docs/registros/mois1.md`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a2846403ad48326919327c5ef28aa67)