### PR TITLE
Add MOIS Market Warmup Liquibase schema

### DIFF
--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-09-mois-sales-page-market-warmup.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-09-mois-sales-page-market-warmup.yaml
@@ -1,0 +1,196 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-06-09-mois-sales-page-market-warmup-job-01
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - onError: HALT
+        - dbms:
+            type: mysql
+        - tableExists:
+            tableName: mois_sales_page
+        - not:
+            tableExists:
+              tableName: mois_sales_page_market_warmup_job
+      changes:
+        - sql:
+            splitStatements: true
+            stripComments: true
+            sql: |
+              CREATE TABLE mois_sales_page_market_warmup_job (
+                id BIGINT NOT NULL AUTO_INCREMENT,
+                sales_page_id BIGINT NOT NULL,
+                workspace_id VARCHAR(120) NOT NULL,
+                status VARCHAR(40) NOT NULL,
+                attempt INT NOT NULL DEFAULT 1,
+                claimed_by VARCHAR(120) NULL,
+                score_total DECIMAL(6,2) NULL,
+                market_temperature VARCHAR(40) NULL,
+                ecosystem_type VARCHAR(60) NULL,
+                recommendation VARCHAR(60) NULL,
+                error_category VARCHAR(120) NULL,
+                error_message VARCHAR(1000) NULL,
+                started_at DATETIME NULL,
+                finished_at DATETIME NULL,
+                created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+                PRIMARY KEY (id),
+                KEY idx_mois_market_warmup_job_workspace_status (workspace_id, status, updated_at),
+                KEY idx_mois_market_warmup_job_page_status (sales_page_id, status, updated_at),
+                KEY idx_mois_market_warmup_job_score (workspace_id, score_total),
+                CONSTRAINT fk_mois_market_warmup_job_sales_page
+                  FOREIGN KEY (sales_page_id) REFERENCES mois_sales_page(id)
+                  ON DELETE CASCADE
+              ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+  - changeSet:
+      id: 2026-06-09-mois-sales-page-market-warmup-source-01
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - onError: HALT
+        - dbms:
+            type: mysql
+        - tableExists:
+            tableName: mois_sales_page_market_warmup_job
+        - tableExists:
+            tableName: mois_sales_page
+        - not:
+            tableExists:
+              tableName: mois_sales_page_market_warmup_source
+      changes:
+        - sql:
+            splitStatements: true
+            stripComments: true
+            sql: |
+              CREATE TABLE mois_sales_page_market_warmup_source (
+                id BIGINT NOT NULL AUTO_INCREMENT,
+                job_id BIGINT NOT NULL,
+                sales_page_id BIGINT NOT NULL,
+                workspace_id VARCHAR(120) NOT NULL,
+                platform VARCHAR(40) NOT NULL,
+                source_type VARCHAR(60) NOT NULL,
+                source_url VARCHAR(1024) NOT NULL,
+                source_title VARCHAR(512) NULL,
+                author_name VARCHAR(255) NULL,
+                published_at DATETIME NULL,
+                last_activity_at DATETIME NULL,
+                followers_or_subscribers BIGINT NULL,
+                views_count BIGINT NULL,
+                likes_count BIGINT NULL,
+                comments_count BIGINT NULL,
+                recency_score DECIMAL(6,2) NULL,
+                engagement_score DECIMAL(6,2) NULL,
+                evidence_summary VARCHAR(2000) NULL,
+                created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+                PRIMARY KEY (id),
+                KEY idx_mois_market_warmup_source_job (job_id),
+                KEY idx_mois_market_warmup_source_page (sales_page_id, created_at),
+                KEY idx_mois_market_warmup_source_platform (workspace_id, platform, last_activity_at),
+                KEY idx_mois_market_warmup_source_url (source_url(191)),
+                CONSTRAINT fk_mois_market_warmup_source_job
+                  FOREIGN KEY (job_id) REFERENCES mois_sales_page_market_warmup_job(id)
+                  ON DELETE CASCADE,
+                CONSTRAINT fk_mois_market_warmup_source_page
+                  FOREIGN KEY (sales_page_id) REFERENCES mois_sales_page(id)
+                  ON DELETE CASCADE
+              ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+  - changeSet:
+      id: 2026-06-09-mois-sales-page-market-warmup-signal-01
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - onError: HALT
+        - dbms:
+            type: mysql
+        - tableExists:
+            tableName: mois_sales_page_market_warmup_job
+        - tableExists:
+            tableName: mois_sales_page_market_warmup_source
+        - tableExists:
+            tableName: mois_sales_page
+        - not:
+            tableExists:
+              tableName: mois_sales_page_market_warmup_signal
+      changes:
+        - sql:
+            splitStatements: true
+            stripComments: true
+            sql: |
+              CREATE TABLE mois_sales_page_market_warmup_signal (
+                id BIGINT NOT NULL AUTO_INCREMENT,
+                job_id BIGINT NOT NULL,
+                source_id BIGINT NOT NULL,
+                sales_page_id BIGINT NOT NULL,
+                workspace_id VARCHAR(120) NOT NULL,
+                signal_type VARCHAR(60) NOT NULL,
+                signal_strength DECIMAL(6,2) NOT NULL DEFAULT 0,
+                signal_text VARCHAR(2000) NOT NULL,
+                business_interpretation VARCHAR(2000) NULL,
+                created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                PRIMARY KEY (id),
+                KEY idx_mois_market_warmup_signal_job (job_id),
+                KEY idx_mois_market_warmup_signal_source (source_id),
+                KEY idx_mois_market_warmup_signal_page (sales_page_id, created_at),
+                KEY idx_mois_market_warmup_signal_type (workspace_id, signal_type, signal_strength),
+                CONSTRAINT fk_mois_market_warmup_signal_job
+                  FOREIGN KEY (job_id) REFERENCES mois_sales_page_market_warmup_job(id)
+                  ON DELETE CASCADE,
+                CONSTRAINT fk_mois_market_warmup_signal_source
+                  FOREIGN KEY (source_id) REFERENCES mois_sales_page_market_warmup_source(id)
+                  ON DELETE CASCADE,
+                CONSTRAINT fk_mois_market_warmup_signal_page
+                  FOREIGN KEY (sales_page_id) REFERENCES mois_sales_page(id)
+                  ON DELETE CASCADE
+              ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+  - changeSet:
+      id: 2026-06-09-mois-sales-page-market-warmup-summary-01
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - onError: HALT
+        - dbms:
+            type: mysql
+        - tableExists:
+            tableName: mois_sales_page_market_warmup_job
+        - tableExists:
+            tableName: mois_sales_page
+        - not:
+            tableExists:
+              tableName: mois_sales_page_market_warmup_summary
+      changes:
+        - sql:
+            splitStatements: true
+            stripComments: true
+            sql: |
+              CREATE TABLE mois_sales_page_market_warmup_summary (
+                job_id BIGINT NOT NULL,
+                sales_page_id BIGINT NOT NULL,
+                workspace_id VARCHAR(120) NOT NULL,
+                score_total DECIMAL(6,2) NOT NULL DEFAULT 0,
+                market_temperature VARCHAR(40) NOT NULL,
+                ecosystem_type VARCHAR(60) NOT NULL,
+                main_pains VARCHAR(2000) NULL,
+                main_objections VARCHAR(2000) NULL,
+                main_promises VARCHAR(2000) NULL,
+                main_channels VARCHAR(1000) NULL,
+                main_competitors VARCHAR(2000) NULL,
+                saturation_risk VARCHAR(1000) NULL,
+                opportunity_recommendation VARCHAR(2000) NULL,
+                next_experiment_suggestion VARCHAR(2000) NULL,
+                created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+                PRIMARY KEY (job_id),
+                KEY idx_mois_market_warmup_summary_page (sales_page_id, updated_at),
+                KEY idx_mois_market_warmup_summary_score (workspace_id, score_total),
+                KEY idx_mois_market_warmup_summary_temperature (workspace_id, market_temperature, updated_at),
+                CONSTRAINT fk_mois_market_warmup_summary_job
+                  FOREIGN KEY (job_id) REFERENCES mois_sales_page_market_warmup_job(id)
+                  ON DELETE CASCADE,
+                CONSTRAINT fk_mois_market_warmup_summary_page
+                  FOREIGN KEY (sales_page_id) REFERENCES mois_sales_page(id)
+                  ON DELETE CASCADE
+              ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -914,3 +914,7 @@ databaseChangeLog:
   - include:
       file: changesets/2026-06-05-oprm-routine-quality-scores.yaml
       relativeToChangelogFile: true
+
+  - include:
+      file: changesets/2026-06-09-mois-sales-page-market-warmup.yaml
+      relativeToChangelogFile: true

--- a/docs/registros/mois1.md
+++ b/docs/registros/mois1.md
@@ -1196,3 +1196,14 @@ Arquivos alterados:
 - `backend/ads-service/src/main/java/com/marketinghub/pipeline/definition/PipelineDefinitionRegistry.java`
 - `backend/ads-service/src/test/java/com/marketinghub/pipeline/service/PipelineServiceTest.java`
 - `docs/registros/mois1.md`
+
+## 2026-06-09 — Schema da Etapa 3 de aquecimento de mercado
+
+- Criado changelog Liquibase MySQL 5.7 para a **Etapa 3 — Pesquisa de Aquecimento e Ecossistema de Mercado** da Biblioteca de Páginas de Vendas do MOIS.
+- Adicionadas as tabelas operacionais de jobs, fontes públicas, sinais comerciais e resumo final do dossiê de aquecimento, com chaves estrangeiras para `mois_sales_page` e relacionamentos internos da etapa.
+- Adicionados índices para operação por workspace, página, status, score e plataforma, preservando o backend como único ponto de acesso ao banco.
+
+Arquivos alterados:
+- `backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-09-mois-sales-page-market-warmup.yaml`
+- `backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml`
+- `docs/registros/mois1.md`


### PR DESCRIPTION
### Motivation
- Provide database support for MOIS Etapa 3 (Market Warmup) so workers and UI can persist jobs, sources, signals and summaries for market aquecimento research.
- Keep Liquibase changes MySQL 5.7-safe and follow project conventions for preConditions, `splitStatements: true` and `stripComments: true`.
- Make the backend the single source of truth for these artifacts and enable traceable evidence-based recommendations in the MOIS pipeline.

### Description
- Added a new changelog `backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-09-mois-sales-page-market-warmup.yaml` that creates tables `mois_sales_page_market_warmup_job`, `mois_sales_page_market_warmup_source`, `mois_sales_page_market_warmup_signal` and `mois_sales_page_market_warmup_summary` with FKs to `mois_sales_page` and internal relationships.
- Included operational indexes for common access patterns (`workspace_id`, `sales_page_id`, `status`, `score_total`, `platform`, `signal_type`) and adjusted `source_url` index prefix to 191 chars to avoid MySQL index length issues.
- Registered the new changelog in the master file `backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml` and recorded the change in `docs/registros/mois1.md`.
- Implemented safe changelog patterns to avoid problematic DML (no `UPDATE`/`DELETE FROM` against the same target table) and used Liquibase `preConditions` to ensure idempotence.

### Testing
- ✅ Validated new YAML files can be parsed with `ruby -e "require 'yaml'; ARGV.each { |p| YAML.load_file(p); puts \"YAML OK: #{p}\" }"` for both the new changeset and the master changelog.
- ✅ Ran a Python check to verify there are no `UPDATE` or `DELETE FROM` DML statements in the new changelog, preventing MySQL 5.7 error 1093 risk.
- ⚠️ Attempted to run `../mvnw -q -DskipTests compile` in the backend to compile the project but compilation was blocked in this environment due to a local JDK 25 vs project Lombok/Javac incompatibility (`com.sun.tools.javac.code.TypeTag :: UNKNOWN`), so full compile/test could not be completed here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a2848ec490483269898fc26a58aa246)