### PR TITLE
Define MOIS Market Warmup contracts and Swagger endpoints

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/dto/MoisSalesLibraryDtos.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/dto/MoisSalesLibraryDtos.java
@@ -3,6 +3,7 @@ package com.marketinghub.mois.bibliotecapaginavenda.worker.v1.dto;
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
+import jakarta.validation.constraints.NotNull;
 import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.List;
@@ -457,6 +458,306 @@ public final class MoisSalesLibraryDtos {
     public record HtmlCapturePersistResponse(
             long snapshotId,
             String status
+    ) {
+    }
+
+
+    /**
+     * Define os estados operacionais possíveis de uma pesquisa de aquecimento de mercado.
+     */
+    public enum MarketWarmupJobStatus {
+        PENDING,
+        FETCHING,
+        DONE,
+        FAILED
+    }
+
+    /**
+     * Define a temperatura comercial calculada para o mercado analisado.
+     */
+    public enum MarketWarmupTemperature {
+        HOT,
+        PROMISING,
+        WARM,
+        COLD,
+        SATURATED
+    }
+
+    /**
+     * Define o tipo principal de ecossistema encontrado na pesquisa pública.
+     */
+    public enum MarketWarmupEcosystemType {
+        SPECIALISTS_HEATED,
+        CREATORS_HEATED,
+        RECURRING_PAIN_HEATED,
+        COMPETITORS_HEATED,
+        COLD_OR_UNEDUCATED,
+        SATURATED
+    }
+
+    /**
+     * Define a recomendação comercial objetiva derivada do score e dos sinais.
+     */
+    public enum MarketWarmupRecommendation {
+        PRIORITIZE,
+        OBSERVE,
+        RESEARCH_MORE,
+        DISCARD,
+        SATURATED_REQUIRES_ANGLE
+    }
+
+    /**
+     * Define as plataformas públicas aceitas como origem rastreável de evidência.
+     */
+    public enum MarketWarmupPlatform {
+        WEB,
+        GOOGLE,
+        YOUTUBE,
+        INSTAGRAM,
+        TIKTOK,
+        BLOG,
+        FORUM,
+        COMMUNITY,
+        MARKETPLACE,
+        REVIEW_SITE,
+        OTHER
+    }
+
+    /**
+     * Define o tipo funcional da fonte pública encontrada.
+     */
+    public enum MarketWarmupSourceType {
+        PRODUCT_PRESENCE,
+        CREATOR_CONTENT,
+        SPECIALIST_CONTENT,
+        COMMUNITY_DISCUSSION,
+        REVIEW,
+        COMPLAINT,
+        COMPETITOR_OFFER,
+        AFFILIATE_PROMOTION,
+        SOCIAL_POST,
+        SEARCH_RESULT,
+        OTHER
+    }
+
+    /**
+     * Define os sinais comerciais extraídos das fontes públicas.
+     */
+    public enum MarketWarmupSignalType {
+        PAIN_EXPLICIT,
+        BUYING_INTENT,
+        OBJECTION,
+        SOCIAL_PROOF,
+        CREATOR_AUTHORITY,
+        COMPETITOR_OFFER,
+        COMMUNITY_ACTIVITY,
+        CONTENT_RECENCY,
+        SATURATION_RISK,
+        CHANNEL_FIT
+    }
+
+    /**
+     * Representa a solicitação aceita para criar ou reutilizar uma pesquisa de aquecimento da página.
+     */
+    public record MarketWarmupRequestResponse(
+            long pageId,
+            long jobId,
+            MarketWarmupJobStatus status,
+            Instant createdAt
+    ) {
+    }
+
+    /**
+     * Representa o resumo final rastreável da pesquisa de aquecimento de mercado.
+     */
+    public record MarketWarmupSummaryResponse(
+            long jobId,
+            long pageId,
+            BigDecimal scoreTotal,
+            MarketWarmupTemperature marketTemperature,
+            MarketWarmupEcosystemType ecosystemType,
+            MarketWarmupRecommendation recommendation,
+            List<String> mainPains,
+            List<String> mainObjections,
+            List<String> mainPromises,
+            List<String> mainChannels,
+            List<String> mainCompetitors,
+            String saturationRisk,
+            String opportunityRecommendation,
+            String nextExperimentSuggestion,
+            MarketWarmupJobStatus status,
+            String errorCategory,
+            String errorMessage,
+            Instant createdAt,
+            Instant updatedAt
+    ) {
+    }
+
+    /**
+     * Representa uma fonte pública usada para justificar o aquecimento do mercado.
+     */
+    public record MarketWarmupSourceResponse(
+            long sourceId,
+            long jobId,
+            long pageId,
+            MarketWarmupPlatform platform,
+            MarketWarmupSourceType sourceType,
+            String sourceUrl,
+            String sourceTitle,
+            String authorName,
+            Instant publishedAt,
+            Instant lastActivityAt,
+            Long followersOrSubscribers,
+            Long viewsCount,
+            Long likesCount,
+            Long commentsCount,
+            BigDecimal recencyScore,
+            BigDecimal engagementScore,
+            String evidenceSummary,
+            Instant createdAt,
+            Instant updatedAt
+    ) {
+    }
+
+    /**
+     * Representa a página de fontes públicas retornada para revisão humana.
+     */
+    public record MarketWarmupSourceListResponse(
+            long pageId,
+            long jobId,
+            List<MarketWarmupSourceResponse> items
+    ) {
+    }
+
+    /**
+     * Representa um sinal comercial extraído de uma fonte pública.
+     */
+    public record MarketWarmupSignalResponse(
+            long signalId,
+            long jobId,
+            long sourceId,
+            long pageId,
+            MarketWarmupSignalType signalType,
+            BigDecimal signalStrength,
+            String signalText,
+            String businessInterpretation,
+            Instant createdAt
+    ) {
+    }
+
+    /**
+     * Representa a lista de sinais que explicam a pontuação da pesquisa.
+     */
+    public record MarketWarmupSignalListResponse(
+            long pageId,
+            long jobId,
+            List<MarketWarmupSignalResponse> items
+    ) {
+    }
+
+    /**
+     * Representa o pedido interno do worker para reservar uma pesquisa pendente.
+     */
+    public record MarketWarmupClaimRequest(
+            @NotBlank String workspaceId,
+            @NotBlank String workerId
+    ) {
+    }
+
+    /**
+     * Representa uma pesquisa reservada com os dados comerciais necessários para coleta pública.
+     */
+    public record MarketWarmupClaimedJob(
+            long jobId,
+            long pageId,
+            String workspaceId,
+            String urlCanonical,
+            String title,
+            String offerSummary,
+            String mechanismSummary,
+            String promiseSummary,
+            String proofSummary
+    ) {
+    }
+
+    /**
+     * Representa a resposta da reserva interna de pesquisa de aquecimento.
+     */
+    public record MarketWarmupClaimResponse(
+            boolean claimed,
+            MarketWarmupClaimedJob job
+    ) {
+    }
+
+    /**
+     * Representa uma fonte pública enviada pelo worker ao concluir a pesquisa.
+     */
+    public record MarketWarmupSourceCompleteItem(
+            @NotNull MarketWarmupPlatform platform,
+            @NotNull MarketWarmupSourceType sourceType,
+            @NotBlank String sourceUrl,
+            String sourceTitle,
+            String authorName,
+            Instant publishedAt,
+            Instant lastActivityAt,
+            Long followersOrSubscribers,
+            Long viewsCount,
+            Long likesCount,
+            Long commentsCount,
+            BigDecimal recencyScore,
+            BigDecimal engagementScore,
+            String evidenceSummary
+    ) {
+    }
+
+    /**
+     * Representa um sinal extraído pelo worker e vinculado a uma fonte pelo índice enviado.
+     */
+    public record MarketWarmupSignalCompleteItem(
+            int sourceIndex,
+            @NotNull MarketWarmupSignalType signalType,
+            @NotNull BigDecimal signalStrength,
+            @NotBlank String signalText,
+            String businessInterpretation
+    ) {
+    }
+
+    /**
+     * Representa o resumo calculado pelo worker para persistência final da pesquisa.
+     */
+    public record MarketWarmupSummaryCompleteItem(
+            @NotNull BigDecimal scoreTotal,
+            @NotNull MarketWarmupTemperature marketTemperature,
+            @NotNull MarketWarmupEcosystemType ecosystemType,
+            @NotNull MarketWarmupRecommendation recommendation,
+            List<String> mainPains,
+            List<String> mainObjections,
+            List<String> mainPromises,
+            List<String> mainChannels,
+            List<String> mainCompetitors,
+            String saturationRisk,
+            String opportunityRecommendation,
+            String nextExperimentSuggestion
+    ) {
+    }
+
+    /**
+     * Representa o payload final do worker sem JSON serializado em campos textuais funcionais.
+     */
+    public record MarketWarmupCompleteRequest(
+            @NotEmpty List<@Valid MarketWarmupSourceCompleteItem> sources,
+            @NotEmpty List<@Valid MarketWarmupSignalCompleteItem> signals,
+            @NotNull @Valid MarketWarmupSummaryCompleteItem summary,
+            Instant finishedAt
+    ) {
+    }
+
+    /**
+     * Representa a falha operacional de uma pesquisa de aquecimento pelo worker.
+     */
+    public record MarketWarmupFailRequest(
+            @NotBlank String errorCategory,
+            @NotBlank String errorMessage
     ) {
     }
 

--- a/docs/registros/mois1.md
+++ b/docs/registros/mois1.md
@@ -1207,3 +1207,15 @@ Arquivos alterados:
 - `backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-09-mois-sales-page-market-warmup.yaml`
 - `backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml`
 - `docs/registros/mois1.md`
+
+## 2026-06-09 — Contratos da Etapa 3 de aquecimento de mercado
+
+- Definidos os DTOs e enums HTTP da **Etapa 3 — Pesquisa de Aquecimento e Ecossistema de Mercado** na biblioteca MOIS, cobrindo status de job, temperatura, ecossistema, recomendação, plataforma, tipo de fonte e tipo de sinal.
+- Documentados no Swagger os contratos públicos de solicitação/consulta da pesquisa e os contratos internos do worker para claim, conclusão e falha.
+- O contrato de conclusão usa listas estruturadas de fontes, sinais e resumo, evitando JSON serializado dentro de campos textuais funcionais.
+
+Arquivos alterados:
+
+- `backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/dto/MoisSalesLibraryDtos.java`
+- `docs/swagger/mois-sales-library-swagger.yaml`
+- `docs/registros/mois1.md`

--- a/docs/swagger/mois-sales-library-swagger.yaml
+++ b/docs/swagger/mois-sales-library-swagger.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: Marketing Hub - MOIS Sales Library
-  version: 0.5.0
+  version: 0.6.0
   description: Contratos operacionais da Biblioteca de Páginas de Vendas do MOIS. Na Fase 6, ingestão, captura HTML e análise usam `mois_sales_page` e `mois_sales_page_job_execution` como fonte de verdade operacional atual; tabelas legadas ficam congeladas em somente leitura para auditoria/backfill histórico e não alimentam a UI principal.
 servers:
   - url: /api/mois/sales-library
@@ -376,8 +376,140 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SalesLibrarySnapshotCaptureResponse'
+  /pages/{pageId}/market-warmup:request:
+    post:
+      summary: Solicita pesquisa de aquecimento de mercado para uma página
+      description: Cria ou reutiliza um job pendente da Etapa 3 para uma página de venda já existente. A execução apenas agenda a pesquisa; o worker interno processa posteriormente via endpoints de claim e conclusão.
+      tags: [MOIS Sales Library]
+      parameters:
+        - $ref: '#/components/parameters/PageId'
+      responses:
+        '202':
+          description: Pesquisa de aquecimento solicitada
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MarketWarmupRequestResponse'
+        '404':
+          description: Página não encontrada
+  /pages/{pageId}/market-warmup:
+    get:
+      summary: Consulta o resumo da pesquisa de aquecimento da página
+      description: Retorna o dossiê final da Etapa 3 com score, temperatura, tipo de ecossistema e recomendação objetiva, sem JSON serializado em campos textuais.
+      tags: [MOIS Sales Library]
+      parameters:
+        - $ref: '#/components/parameters/PageId'
+      responses:
+        '200':
+          description: Resumo de aquecimento encontrado
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MarketWarmupSummaryResponse'
+        '404':
+          description: Pesquisa ainda inexistente para a página
+  /pages/{pageId}/market-warmup/sources:
+    get:
+      summary: Lista fontes públicas da pesquisa de aquecimento
+      description: Retorna fontes rastreáveis usadas para sustentar o score e a recomendação da Etapa 3.
+      tags: [MOIS Sales Library]
+      parameters:
+        - $ref: '#/components/parameters/PageId'
+      responses:
+        '200':
+          description: Fontes públicas da pesquisa
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MarketWarmupSourceListResponse'
+  /pages/{pageId}/market-warmup/signals:
+    get:
+      summary: Lista sinais comerciais da pesquisa de aquecimento
+      description: Retorna os sinais extraídos das fontes públicas para explicar o score da Etapa 3.
+      tags: [MOIS Sales Library]
+      parameters:
+        - $ref: '#/components/parameters/PageId'
+      responses:
+        '200':
+          description: Sinais comerciais da pesquisa
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MarketWarmupSignalListResponse'
+  /market-warmup/jobs:claim:
+    post:
+      summary: Reserva internamente uma pesquisa pendente de aquecimento
+      description: Endpoint de uso exclusivo do worker da Etapa 3. O worker conversa somente com o backend principal e não acessa o banco diretamente.
+      tags: [MOIS Sales Library]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MarketWarmupClaimRequest'
+      responses:
+        '200':
+          description: Resultado da reserva interna
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MarketWarmupClaimResponse'
+  /market-warmup/jobs/{jobId}:complete:
+    post:
+      summary: Conclui internamente uma pesquisa de aquecimento
+      description: Recebe fontes, sinais e resumo final em estruturas próprias; é proibido enviar JSON serializado dentro de campos textuais funcionais.
+      tags: [MOIS Sales Library]
+      parameters:
+        - $ref: '#/components/parameters/MarketWarmupJobId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MarketWarmupCompleteRequest'
+      responses:
+        '204':
+          description: Pesquisa concluída
+        '400':
+          description: Payload inválido para o contrato da Etapa 3
+        '404':
+          description: Job não encontrado
+  /market-warmup/jobs/{jobId}:fail:
+    post:
+      summary: Registra falha interna da pesquisa de aquecimento
+      description: Persiste categoria e mensagem operacional para a falha ficar visível por página e por job.
+      tags: [MOIS Sales Library]
+      parameters:
+        - $ref: '#/components/parameters/MarketWarmupJobId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MarketWarmupFailRequest'
+      responses:
+        '204':
+          description: Falha registrada
+        '404':
+          description: Job não encontrado
 components:
   parameters:
+    PageId:
+      in: path
+      name: pageId
+      required: true
+      description: Identificador de `mois_sales_page`.
+      schema:
+        type: integer
+        format: int64
+    MarketWarmupJobId:
+      in: path
+      name: jobId
+      required: true
+      description: Identificador de `mois_sales_page_market_warmup_job`.
+      schema:
+        type: integer
+        format: int64
     JobId:
       in: path
       name: jobId
@@ -402,6 +534,394 @@ components:
         type: integer
         format: int64
   schemas:
+    MarketWarmupJobStatus:
+      type: string
+      enum: [PENDING, FETCHING, DONE, FAILED]
+      description: Estado operacional do job da Etapa 3.
+    MarketWarmupTemperature:
+      type: string
+      enum: [HOT, PROMISING, WARM, COLD, SATURATED]
+      description: Temperatura comercial calculada para o mercado.
+    MarketWarmupEcosystemType:
+      type: string
+      enum: [SPECIALISTS_HEATED, CREATORS_HEATED, RECURRING_PAIN_HEATED, COMPETITORS_HEATED, COLD_OR_UNEDUCATED, SATURATED]
+      description: Tipo principal de ecossistema encontrado.
+    MarketWarmupRecommendation:
+      type: string
+      enum: [PRIORITIZE, OBSERVE, RESEARCH_MORE, DISCARD, SATURATED_REQUIRES_ANGLE]
+      description: Decisão comercial objetiva da Etapa 3.
+    MarketWarmupPlatform:
+      type: string
+      enum: [WEB, GOOGLE, YOUTUBE, INSTAGRAM, TIKTOK, BLOG, FORUM, COMMUNITY, MARKETPLACE, REVIEW_SITE, OTHER]
+      description: Plataforma pública de origem da evidência.
+    MarketWarmupSourceType:
+      type: string
+      enum: [PRODUCT_PRESENCE, CREATOR_CONTENT, SPECIALIST_CONTENT, COMMUNITY_DISCUSSION, REVIEW, COMPLAINT, COMPETITOR_OFFER, AFFILIATE_PROMOTION, SOCIAL_POST, SEARCH_RESULT, OTHER]
+      description: Tipo funcional da fonte pública.
+    MarketWarmupSignalType:
+      type: string
+      enum: [PAIN_EXPLICIT, BUYING_INTENT, OBJECTION, SOCIAL_PROOF, CREATOR_AUTHORITY, COMPETITOR_OFFER, COMMUNITY_ACTIVITY, CONTENT_RECENCY, SATURATION_RISK, CHANNEL_FIT]
+      description: Sinal comercial extraído de fonte pública.
+    MarketWarmupRequestResponse:
+      type: object
+      properties:
+        pageId:
+          type: integer
+          format: int64
+        jobId:
+          type: integer
+          format: int64
+        status:
+          $ref: '#/components/schemas/MarketWarmupJobStatus'
+        createdAt:
+          type: string
+          format: date-time
+    MarketWarmupSummaryResponse:
+      type: object
+      properties:
+        jobId:
+          type: integer
+          format: int64
+        pageId:
+          type: integer
+          format: int64
+        scoreTotal:
+          type: number
+        marketTemperature:
+          $ref: '#/components/schemas/MarketWarmupTemperature'
+        ecosystemType:
+          $ref: '#/components/schemas/MarketWarmupEcosystemType'
+        recommendation:
+          $ref: '#/components/schemas/MarketWarmupRecommendation'
+        mainPains:
+          type: array
+          items: { type: string }
+        mainObjections:
+          type: array
+          items: { type: string }
+        mainPromises:
+          type: array
+          items: { type: string }
+        mainChannels:
+          type: array
+          items: { type: string }
+        mainCompetitors:
+          type: array
+          items: { type: string }
+        saturationRisk:
+          type: string
+          nullable: true
+        opportunityRecommendation:
+          type: string
+          nullable: true
+        nextExperimentSuggestion:
+          type: string
+          nullable: true
+        status:
+          $ref: '#/components/schemas/MarketWarmupJobStatus'
+        errorCategory:
+          type: string
+          nullable: true
+        errorMessage:
+          type: string
+          nullable: true
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+    MarketWarmupSourceResponse:
+      type: object
+      properties:
+        sourceId:
+          type: integer
+          format: int64
+        jobId:
+          type: integer
+          format: int64
+        pageId:
+          type: integer
+          format: int64
+        platform:
+          $ref: '#/components/schemas/MarketWarmupPlatform'
+        sourceType:
+          $ref: '#/components/schemas/MarketWarmupSourceType'
+        sourceUrl:
+          type: string
+          format: uri
+        sourceTitle:
+          type: string
+          nullable: true
+        authorName:
+          type: string
+          nullable: true
+        publishedAt:
+          type: string
+          format: date-time
+          nullable: true
+        lastActivityAt:
+          type: string
+          format: date-time
+          nullable: true
+        followersOrSubscribers:
+          type: integer
+          format: int64
+          nullable: true
+        viewsCount:
+          type: integer
+          format: int64
+          nullable: true
+        likesCount:
+          type: integer
+          format: int64
+          nullable: true
+        commentsCount:
+          type: integer
+          format: int64
+          nullable: true
+        recencyScore:
+          type: number
+          nullable: true
+        engagementScore:
+          type: number
+          nullable: true
+        evidenceSummary:
+          type: string
+          nullable: true
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+    MarketWarmupSourceListResponse:
+      type: object
+      properties:
+        pageId:
+          type: integer
+          format: int64
+        jobId:
+          type: integer
+          format: int64
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/MarketWarmupSourceResponse'
+    MarketWarmupSignalResponse:
+      type: object
+      properties:
+        signalId:
+          type: integer
+          format: int64
+        jobId:
+          type: integer
+          format: int64
+        sourceId:
+          type: integer
+          format: int64
+        pageId:
+          type: integer
+          format: int64
+        signalType:
+          $ref: '#/components/schemas/MarketWarmupSignalType'
+        signalStrength:
+          type: number
+        signalText:
+          type: string
+        businessInterpretation:
+          type: string
+          nullable: true
+        createdAt:
+          type: string
+          format: date-time
+    MarketWarmupSignalListResponse:
+      type: object
+      properties:
+        pageId:
+          type: integer
+          format: int64
+        jobId:
+          type: integer
+          format: int64
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/MarketWarmupSignalResponse'
+    MarketWarmupClaimRequest:
+      type: object
+      required: [workspaceId, workerId]
+      properties:
+        workspaceId:
+          type: string
+        workerId:
+          type: string
+    MarketWarmupClaimedJob:
+      type: object
+      properties:
+        jobId:
+          type: integer
+          format: int64
+        pageId:
+          type: integer
+          format: int64
+        workspaceId:
+          type: string
+        urlCanonical:
+          type: string
+        title:
+          type: string
+          nullable: true
+        offerSummary:
+          type: string
+          nullable: true
+        mechanismSummary:
+          type: string
+          nullable: true
+        promiseSummary:
+          type: string
+          nullable: true
+        proofSummary:
+          type: string
+          nullable: true
+    MarketWarmupClaimResponse:
+      type: object
+      properties:
+        claimed:
+          type: boolean
+        job:
+          $ref: '#/components/schemas/MarketWarmupClaimedJob'
+    MarketWarmupSourceCompleteItem:
+      type: object
+      required: [platform, sourceType, sourceUrl]
+      properties:
+        platform:
+          $ref: '#/components/schemas/MarketWarmupPlatform'
+        sourceType:
+          $ref: '#/components/schemas/MarketWarmupSourceType'
+        sourceUrl:
+          type: string
+          format: uri
+        sourceTitle:
+          type: string
+          nullable: true
+        authorName:
+          type: string
+          nullable: true
+        publishedAt:
+          type: string
+          format: date-time
+          nullable: true
+        lastActivityAt:
+          type: string
+          format: date-time
+          nullable: true
+        followersOrSubscribers:
+          type: integer
+          format: int64
+          nullable: true
+        viewsCount:
+          type: integer
+          format: int64
+          nullable: true
+        likesCount:
+          type: integer
+          format: int64
+          nullable: true
+        commentsCount:
+          type: integer
+          format: int64
+          nullable: true
+        recencyScore:
+          type: number
+          nullable: true
+        engagementScore:
+          type: number
+          nullable: true
+        evidenceSummary:
+          type: string
+          nullable: true
+    MarketWarmupSignalCompleteItem:
+      type: object
+      required: [sourceIndex, signalType, signalStrength, signalText]
+      properties:
+        sourceIndex:
+          type: integer
+          minimum: 0
+          description: Índice da fonte no array `sources` do mesmo payload.
+        signalType:
+          $ref: '#/components/schemas/MarketWarmupSignalType'
+        signalStrength:
+          type: number
+        signalText:
+          type: string
+        businessInterpretation:
+          type: string
+          nullable: true
+    MarketWarmupSummaryCompleteItem:
+      type: object
+      required: [scoreTotal, marketTemperature, ecosystemType, recommendation]
+      properties:
+        scoreTotal:
+          type: number
+          minimum: 0
+          maximum: 100
+        marketTemperature:
+          $ref: '#/components/schemas/MarketWarmupTemperature'
+        ecosystemType:
+          $ref: '#/components/schemas/MarketWarmupEcosystemType'
+        recommendation:
+          $ref: '#/components/schemas/MarketWarmupRecommendation'
+        mainPains:
+          type: array
+          items: { type: string }
+        mainObjections:
+          type: array
+          items: { type: string }
+        mainPromises:
+          type: array
+          items: { type: string }
+        mainChannels:
+          type: array
+          items: { type: string }
+        mainCompetitors:
+          type: array
+          items: { type: string }
+        saturationRisk:
+          type: string
+          nullable: true
+        opportunityRecommendation:
+          type: string
+          nullable: true
+        nextExperimentSuggestion:
+          type: string
+          nullable: true
+    MarketWarmupCompleteRequest:
+      type: object
+      required: [sources, signals, summary]
+      properties:
+        sources:
+          type: array
+          items:
+            $ref: '#/components/schemas/MarketWarmupSourceCompleteItem'
+        signals:
+          type: array
+          items:
+            $ref: '#/components/schemas/MarketWarmupSignalCompleteItem'
+        summary:
+          $ref: '#/components/schemas/MarketWarmupSummaryCompleteItem'
+        finishedAt:
+          type: string
+          format: date-time
+          nullable: true
+    MarketWarmupFailRequest:
+      type: object
+      required: [errorCategory, errorMessage]
+      properties:
+        errorCategory:
+          type: string
+        errorMessage:
+          type: string
     SalesLibraryClaimRequest:
       type: object
       required: [workspaceId, source]


### PR DESCRIPTION
### Motivation
- Canonize Etapa 3 (MARKET_WARMUP_RESEARCH) by introducing the HTTP contracts and DTOs required for the Market Warm-up research phase so workers and UI can request, claim, complete and inspect market-warmup dossiês.
- Ensure the contract follows project rules: no JSON serialized inside text fields, backend-only DB access, traceable sources and explicit enums for status/temperature/ecosystem/recommendation.

### Description
- Added enums, request/response DTOs and worker payload records to `MoisSalesLibraryDtos.java` to model job status, temperature, ecosystem type, recommendation, platforms, source types, signal types and the full worker `complete`/`claim`/`fail` payloads. (`backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/dto/MoisSalesLibraryDtos.java`).
- Documented new public and internal endpoints in the MOIS Swagger file and expanded schemas to include `MarketWarmup` contracts and path/parameter definitions, keeping the final worker payload structured (lists of sources, signals and summary). (`docs/swagger/mois-sales-library-swagger.yaml`).
- Recorded the change in the MOIS operational log to track the implementation step. (`docs/registros/mois1.md`).
- Kept contract constraints explicit (no JSON-in-JSON), added path parameters (`PageId`, `MarketWarmupJobId`) and updated API version in the Swagger spec.

### Testing
- Verified Swagger additions with a YAML sanity check using `ruby -e "require 'yaml'; data=YAML.load_file('docs/swagger/mois-sales-library-swagger.yaml'); raise 'missing path' unless data['paths'].key?('/market-warmup/jobs/{jobId}:complete'); raise 'missing schema' unless data['components']['schemas'].key?('MarketWarmupCompleteRequest')"` which succeeded.
- Attempted `mvn -DskipTests compile` with the environment default JDK (25) which failed due to Lombok/JDK incompatibility, then re-ran compilation with Java 21 via `JAVA_HOME=.../java/21.0.2 PATH=... mvn -DskipTests compile` which succeeded.
- Ran unit tests for the library controller and service with `mvn -Dtest=MoisSalesLibraryControllerTest,MoisSalesLibraryServiceTest test` (total 16 tests) and they passed with no failures.
- Commit created: `ac68999 Define MOIS market warmup contracts` and PR prepared with the changes above.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a284a902b5483269b690a7c8de46e19)