### PR TITLE
Fix pipeline stage position collision in reach-validation changelog

### DIFF
--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-09-facebook-ads-reach-validation-stage.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-09-facebook-ads-reach-validation-stage.yaml
@@ -22,16 +22,29 @@ databaseChangeLog:
               LEFT JOIN pipeline_stage existing_stage
                 ON existing_stage.pipeline_id = p.id
                AND existing_stage.code = 'reach-validation'
-              SET ps.position = ps.position + 1
+              SET ps.position = ps.position + 1000
               WHERE p.code = 'facebook-ads-publication-metrics-pipeline'
                 AND existing_stage.id IS NULL
-                AND ps.position >= 4;
+                AND ps.position >= 4
+                AND ps.position < 1000;
+
+              UPDATE pipeline_stage ps
+              INNER JOIN pipeline p ON p.id = ps.pipeline_id
+              LEFT JOIN pipeline_stage existing_stage
+                ON existing_stage.pipeline_id = p.id
+               AND existing_stage.code = 'reach-validation'
+              SET ps.position = ps.position - 999
+              WHERE p.code = 'facebook-ads-publication-metrics-pipeline'
+                AND existing_stage.id IS NULL
+                AND ps.position >= 1004
+                AND ps.position < 2000;
 
               INSERT INTO pipeline_stage (pipeline_id, position, name, code, description, required, active, created_at, updated_at)
               SELECT p.id, 4, 'Validação de alcance', 'reach-validation', 'Consulta reachestimate na Graph API antes da criação da campanha e bloqueia públicos fora da faixa operacional de 200.000 a 20.000.000 pessoas estimadas.', 1, 1, NOW(), NOW()
               FROM pipeline p
+              LEFT JOIN pipeline_stage ps ON ps.pipeline_id = p.id AND ps.code = 'reach-validation'
               WHERE p.code = 'facebook-ads-publication-metrics-pipeline'
-                AND NOT EXISTS (SELECT 1 FROM pipeline_stage ps WHERE ps.pipeline_id = p.id AND ps.code = 'reach-validation');
+                AND ps.id IS NULL;
 
 
   - changeSet:
@@ -94,24 +107,39 @@ databaseChangeLog:
               LEFT JOIN pipeline_stage_definition existing_stage
                 ON existing_stage.pipeline_definition_id = pd.id
                AND existing_stage.canonical_code = 'REACH_VALIDATION'
-              SET psd.position = psd.position + 1
+              SET psd.position = psd.position + 1000
               WHERE pd.code = 'facebook-ads-publication-metrics-pipeline'
                 AND pd.canonical_version = 'facebook-campaign-publication-canon.v1'
                 AND existing_stage.id IS NULL
-                AND psd.position >= 4;
+                AND psd.position >= 4
+                AND psd.position < 1000;
+
+              UPDATE pipeline_stage_definition psd
+              INNER JOIN pipeline_definition pd ON pd.id = psd.pipeline_definition_id
+              LEFT JOIN pipeline_stage_definition existing_stage
+                ON existing_stage.pipeline_definition_id = pd.id
+               AND existing_stage.canonical_code = 'REACH_VALIDATION'
+              SET psd.position = psd.position - 999
+              WHERE pd.code = 'facebook-ads-publication-metrics-pipeline'
+                AND pd.canonical_version = 'facebook-campaign-publication-canon.v1'
+                AND existing_stage.id IS NULL
+                AND psd.position >= 1004
+                AND psd.position < 2000;
 
               INSERT INTO pipeline_stage_definition (pipeline_definition_id, canonical_code, display_name, position, required, implemented_stage_enum, requires_openai_model, configurable, execution_module, root_package, created_at, updated_at)
               SELECT pd.id, 'REACH_VALIDATION', 'Validação de alcance', 4, 1, 'REACH_VALIDATION', 0, 1, 'facebook-ads-worker', 'com.marketinghub.facebookadsworker.facebookcampaign', NOW(), NOW()
               FROM pipeline_definition pd
+              LEFT JOIN pipeline_stage_definition psd ON psd.pipeline_definition_id = pd.id AND psd.canonical_code = 'REACH_VALIDATION'
               WHERE pd.code = 'facebook-ads-publication-metrics-pipeline'
                 AND pd.canonical_version = 'facebook-campaign-publication-canon.v1'
-                AND NOT EXISTS (SELECT 1 FROM pipeline_stage_definition psd WHERE psd.pipeline_definition_id = pd.id AND psd.canonical_code = 'REACH_VALIDATION');
+                AND psd.id IS NULL;
 
               INSERT INTO pipeline_stage_config (pipeline_stage_definition_id, active, openai_model_id, description_override, updated_by, created_at, updated_at)
               SELECT psd.id, 1, NULL, NULL, 'liquibase-facebook-ads-reach-validation-stage', NOW(), NOW()
               FROM pipeline_stage_definition psd
               INNER JOIN pipeline_definition pd ON pd.id = psd.pipeline_definition_id
+              LEFT JOIN pipeline_stage_config psc ON psc.pipeline_stage_definition_id = psd.id
               WHERE pd.code = 'facebook-ads-publication-metrics-pipeline'
                 AND pd.canonical_version = 'facebook-campaign-publication-canon.v1'
                 AND psd.canonical_code = 'REACH_VALIDATION'
-                AND NOT EXISTS (SELECT 1 FROM pipeline_stage_config psc WHERE psc.pipeline_stage_definition_id = psd.id);
+                AND psc.id IS NULL;

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -4225,3 +4225,10 @@
 - impacto esperado: o módulo passa a ter entrada HTTP única e service de orquestração único, reduzindo risco de contratos duplicados e facilitando a próxima etapa de migração dos DTOs para subpacotes por operação.
 - 2026-06-09 00:00:00 (UTC): adicionada etapa obrigatória `reach-validation` ao pipeline oficial Facebook Ads: antes de criar campanha/ad set/imagem/criativo/anúncio na Meta, o worker consulta `reachestimate` com o targeting final e bloqueia públicos fora da faixa canônica de 200.000 a 20.000.000 usuários estimados, evitando campanhas ativas com entrega inviável.
 - 2026-06-09 17:31:00 (UTC): ajustado o teste `PipelineServiceTest.shouldExposeOfficialFacebookAdsPublicationMetricsPipeline` para refletir as 10 etapas oficiais do pipeline Facebook Ads, incluindo `reach-validation`, mantendo a validação automatizada alinhada ao cânone de publicação e métricas.
+
+## 2026-06-09 — Correção da migração da etapa de validação de alcance
+
+- solicitação: corrigir a falha de Liquibase `Duplicate entry '3-5' for key 'uk_pipeline_stage_position'` ao inserir a etapa `reach-validation` no pipeline oficial de publicação e métricas Facebook Ads.
+- causa-raiz: a migração deslocava posições do pipeline com `position = position + 1` em uma única atualização, fazendo o MySQL validar temporariamente uma posição já ocupada dentro da mesma chave única `(pipeline_id, position)`.
+- foi feito: o deslocamento passou a usar uma faixa temporária alta antes de normalizar as posições finais, preservando a chave única durante toda a migração e mantendo a etapa `reach-validation` na posição 4.
+- prevenção: os inserts idempotentes do mesmo changelog passaram a usar `LEFT JOIN ... IS NULL`, mantendo o padrão seguro para MySQL 5.7 e reduzindo risco de recorrência em reexecuções.


### PR DESCRIPTION
### Motivation
- The Liquibase changeset inserting the `reach-validation` stage failed with `Duplicate entry '3-5' for key 'uk_pipeline_stage_position'` because a single-step `UPDATE ... SET position = position + 1` temporarily produced duplicate `(pipeline_id, position)` values under MySQL unique constraints.

### Description
- Update `backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-09-facebook-ads-reach-validation-stage.yaml` to perform a two-step position shift using a high temporary offset (`+1000`) followed by a normalization step (`-999`) to preserve the unique key during migration for both `pipeline_stage` and `pipeline_stage_definition`.
- Change idempotency checks to use `LEFT JOIN ... IS NULL` for the `INSERT` statements and add `LEFT JOIN` guards for `pipeline_stage_config` to follow the safe MySQL 5.7 pattern.
- Document the root cause and the corrective action in `docs/registros/experimentos.md` and commit the adjusted changelog.

### Testing
- Parsed the modified YAML with `ruby -e "require 'yaml'; YAML.load_file('<path>')"` which succeeded for the changed changelog.
- Ran a Python script to assert there are no `UPDATE` statements that read the same target table in a subquery, and the check passed.
- Queried the MCP DB via the `db_query` tool to inspect current `pipeline`/`pipeline_stage` and `pipeline_definition`/`pipeline_stage_definition` rows and verified the existing ordering; the queries returned successfully.
- Attempted a local compile with `cd backend/ads-service && ../mvnw -DskipTests compile`, which failed in this environment due to a Lombok/JDK incompatibility (`com.sun.tools.javac.code.TypeTag :: UNKNOWN`) unrelated to the SQL changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a28698a8c4883268f447d51d60fac87)