### PR TITLE
Add Etapa 3 (Market Warmup Research) card to MOIS pipeline page and update docs

### DIFF
--- a/docs/registros/mois1.md
+++ b/docs/registros/mois1.md
@@ -1219,3 +1219,13 @@ Arquivos alterados:
 - `backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/dto/MoisSalesLibraryDtos.java`
 - `docs/swagger/mois-sales-library-swagger.yaml`
 - `docs/registros/mois1.md`
+
+## 2026-06-09 — Card da Etapa 3 no pipeline de páginas de vendas
+
+- Adicionado na tela `/mois/sales-pages-library/pipeline` o card visual da **Etapa 3 — Pesquisa de aquecimento e ecossistema**, deixando claro o objetivo comercial da etapa antes da execução operacional completa.
+- O card apresenta entrada, saída esperada, critério de qualidade, volume elegível a partir das páginas já analisadas e checklist dos sinais que a etapa deve acompanhar.
+- A mudança mantém a tela alinhada ao contrato canônico `MARKET_WARMUP_RESEARCH` e evita sugerir execução ativa enquanto o worker dedicado ainda está em ativação operacional.
+
+Arquivos alterados:
+- `frontend/src/pages/mois/MoisSalesPagesPipelinePage.tsx`
+- `docs/registros/mois1.md`

--- a/frontend/src/pages/mois/MoisSalesPagesPipelinePage.tsx
+++ b/frontend/src/pages/mois/MoisSalesPagesPipelinePage.tsx
@@ -25,6 +25,13 @@ const htmlAcquisitionChecklist = [
   "Hash, tamanho e data da última captura",
 ];
 
+const marketWarmupChecklist = [
+  "Páginas com análise comercial concluída",
+  "Sinais públicos de demanda, conversa e concorrência",
+  "Score de aquecimento do mercado e risco de saturação",
+  "Recomendação comercial para priorizar, observar ou diferenciar o ângulo",
+];
+
 function formatBytes(value: number) {
   if (!value) {
     return "0 B";
@@ -87,6 +94,7 @@ export default function MoisSalesPagesPipelinePage() {
   const analysisRunning = summary?.analysisRunning ?? 0;
   const analysisFailed = summary?.analysisFailed ?? 0;
   const pendingPages = summary?.pending ?? 0;
+  const marketWarmupEligiblePages = analyzedPages;
 
   return (
     <div className="d-flex flex-column gap-4">
@@ -95,7 +103,8 @@ export default function MoisSalesPagesPipelinePage() {
           <PageTitle>Pipeline de Páginas de Vendas</PageTitle>
           <p className="text-secondary mb-0">
             Execute e acompanhe o pipeline operacional: obter HTML bruto
-            versionado e analisar comercialmente as páginas capturadas.
+            versionado, analisar comercialmente as páginas capturadas e preparar
+            a pesquisa de aquecimento do mercado.
           </p>
         </div>
         <Link
@@ -305,9 +314,9 @@ export default function MoisSalesPagesPipelinePage() {
               <h2 className="h4 mb-2">Análise comercial da página</h2>
               <p className="text-secondary mb-0">
                 Etapa já implementada no backend: o worker reserva jobs de
-                análise pendentes, usa o HTML bruto capturado na etapa 1 e grava score,
-                promessa, mecanismo, prova, oferta e histórico auditável da
-                execução.
+                análise pendentes, usa o HTML bruto capturado na etapa 1 e grava
+                score, promessa, mecanismo, prova, oferta e histórico auditável
+                da execução.
               </p>
             </div>
             <span className="badge text-bg-success align-self-start">
@@ -423,6 +432,130 @@ export default function MoisSalesPagesPipelinePage() {
               to="/mois/sales-pages-library"
             >
               Ver páginas analisadas
+            </Link>
+          </div>
+        </div>
+      </section>
+
+      <section className="card border-0 shadow-sm">
+        <div className="card-body d-flex flex-column gap-4">
+          <div className="d-flex flex-wrap align-items-start justify-content-between gap-3">
+            <div>
+              <span className="badge text-bg-primary mb-2">Etapa 3</span>
+              <h2 className="h4 mb-2">Pesquisa de aquecimento e ecossistema</h2>
+              <p className="text-secondary mb-0">
+                Próximo bloco do pipeline: usar a análise comercial da etapa 2
+                para medir se o mercado já está sendo aquecido por conversas,
+                conteúdos, provas públicas e ofertas parecidas antes de criar
+                novos produtos ou ângulos de venda.
+              </p>
+            </div>
+            <span className="badge text-bg-warning align-self-start">
+              Preparada para ativação
+            </span>
+          </div>
+
+          <div className="row g-3">
+            <div className="col-12 col-lg-4">
+              <div className="border rounded-3 p-3 h-100 bg-light">
+                <p className="text-uppercase text-secondary small fw-semibold mb-1">
+                  Entrada
+                </p>
+                <h3 className="h6 mb-2">Diagnóstico comercial concluído</h3>
+                <p className="text-secondary small mb-0">
+                  A etapa 3 só deve iniciar quando dor, promessa, mecanismo,
+                  prova, público e categoria já estiverem identificados na
+                  análise comercial.
+                </p>
+              </div>
+            </div>
+            <div className="col-12 col-lg-4">
+              <div className="border rounded-3 p-3 h-100 bg-light">
+                <p className="text-uppercase text-secondary small fw-semibold mb-1">
+                  Saída esperada
+                </p>
+                <h3 className="h6 mb-2">Score de aquecimento do mercado</h3>
+                <p className="text-secondary small mb-0">
+                  O resultado esperado classifica o mercado como quente,
+                  promissor, morno, frio ou saturado com base em fontes públicas
+                  rastreáveis.
+                </p>
+              </div>
+            </div>
+            <div className="col-12 col-lg-4">
+              <div className="border rounded-3 p-3 h-100 bg-light">
+                <p className="text-uppercase text-secondary small fw-semibold mb-1">
+                  Critério de qualidade
+                </p>
+                <h3 className="h6 mb-2">Decisão comercial explicável</h3>
+                <p className="text-secondary small mb-0">
+                  A recomendação deve preservar o eixo dor, resultado,
+                  mecanismo, prova e oferta, evitando opinião sem evidência.
+                </p>
+              </div>
+            </div>
+          </div>
+
+          <div className="border rounded-3 p-3">
+            <div className="d-flex flex-wrap align-items-start justify-content-between gap-3 mb-3">
+              <div>
+                <h3 className="h6 mb-1">Resumo da etapa 3</h3>
+                <p className="text-secondary small mb-0">
+                  Indica o volume já pronto para pesquisa de aquecimento assim
+                  que o worker dedicado for ativado.
+                </p>
+              </div>
+              {summaryQuery.isLoading ? (
+                <span className="badge text-bg-secondary">Carregando...</span>
+              ) : null}
+            </div>
+
+            <div className="row g-3">
+              <div className="col-sm-6 col-lg-4">
+                <div className="bg-light rounded-3 p-3 h-100">
+                  <p className="text-secondary mb-1">
+                    Elegíveis para aquecimento
+                  </p>
+                  <h3 className="mb-0">
+                    {summaryQuery.isLoading ? "..." : marketWarmupEligiblePages}
+                  </h3>
+                </div>
+              </div>
+              <div className="col-sm-6 col-lg-4">
+                <div className="bg-light rounded-3 p-3 h-100">
+                  <p className="text-secondary mb-1">Contrato oficial</p>
+                  <h3 className="h6 mb-0">MARKET_WARMUP_RESEARCH</h3>
+                  <p className="text-secondary small mb-0 mt-2">
+                    Etapa canônica na posição 3 do pipeline MOIS.
+                  </p>
+                </div>
+              </div>
+              <div className="col-sm-6 col-lg-4">
+                <div className="bg-light rounded-3 p-3 h-100">
+                  <p className="text-secondary mb-1">Decisão apoiada</p>
+                  <h3 className="h6 mb-0">Priorizar ou diferenciar</h3>
+                  <p className="text-secondary small mb-0 mt-2">
+                    Foco em escolher mercados com sinais reais de compra.
+                  </p>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div className="d-flex flex-wrap align-items-start justify-content-between gap-3">
+            <div>
+              <h3 className="h6 mb-2">Informações que este card acompanha</h3>
+              <ul className="mb-0 text-secondary">
+                {marketWarmupChecklist.map((item) => (
+                  <li key={item}>{item}</li>
+                ))}
+              </ul>
+            </div>
+            <Link
+              className="btn btn-outline-primary align-self-start"
+              to="/mois/sales-pages-library"
+            >
+              Ver páginas elegíveis
             </Link>
           </div>
         </div>


### PR DESCRIPTION
### Motivation
- Expose the upcoming Etapa 3 (Pesquisa de aquecimento e ecossistema) in the pipeline UI so product and ops can see its purpose and readiness before the worker is fully activated.
- Surface a checklist and eligibility counts so teams understand when pages are ready to be processed by the market warmup worker.
- Keep the docs changelog in sync with the frontend change to document the new card and the canonical contract `MARKET_WARMUP_RESEARCH`.

### Description
- Added a new Etapa 3 card to `frontend/src/pages/mois/MoisSalesPagesPipelinePage.tsx` that describes input, expected output, quality criteria, a summary panel and a checklist for market warmup research. 
- Introduced `marketWarmupChecklist` and `marketWarmupEligiblePages` derived from existing summary data, and updated the page intro to include the market warmup step. 
- Updated `docs/registros/mois1.md` to record the UI addition alongside existing backend schema and contract changes.

### Testing
- Ran the frontend typecheck/build with `yarn build` which completed successfully. 
- Executed the frontend test suite with `yarn test` and existing tests passed. 
- Verified the pipeline page renders the new Etapa 3 card and checklist in a development environment (visual smoke check succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a288b668a888326a713c3b6def12049)