### PR TITLE
Add complete experiment Markdown report and download button

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/report/dto/ExperimentCompleteMarkdownReportDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/report/dto/ExperimentCompleteMarkdownReportDto.java
@@ -1,0 +1,7 @@
+package com.marketinghub.experiment.report.dto;
+
+/**
+ * Resposta com o relatório completo do experimento em Markdown.
+ */
+public record ExperimentCompleteMarkdownReportDto(String filename, String markdown) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/report/service/ExperimentCompleteMarkdownReportService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/report/service/ExperimentCompleteMarkdownReportService.java
@@ -1,0 +1,489 @@
+package com.marketinghub.experiment.report.service;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marketinghub.experiment.Experiment;
+import com.marketinghub.experiment.ExperimentCampaignMetric;
+import com.marketinghub.experiment.ExperimentStatus;
+import com.marketinghub.facebookads.FacebookAdsAd;
+import com.marketinghub.facebookads.FacebookAdsAdCreative;
+import com.marketinghub.facebookads.FacebookAdsAdSet;
+import com.marketinghub.facebookads.FacebookAdsCampaign;
+import com.marketinghub.geralanding.GeraLandingStageExecution;
+import com.marketinghub.hypothesis.Hypothesis;
+import com.marketinghub.niche.MarketNiche;
+import com.marketinghub.repository.jpa.experiment.ExperimentRepository;
+import com.marketinghub.repository.jpa.facebookads.FacebookAdsCampaignRepository;
+import com.marketinghub.repository.jpa.geralanding.GeraLandingStageExecutionRepository;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Responsável por montar o relatório completo em Markdown para experimentos encerrados.
+ */
+@Service
+public class ExperimentCompleteMarkdownReportService {
+
+    private static final Set<ExperimentStatus> ALLOWED_STATUSES = Set.of(
+            ExperimentStatus.VALIDATED,
+            ExperimentStatus.INVALIDATED
+    );
+
+    private final ExperimentRepository experimentRepository;
+    private final GeraLandingStageExecutionRepository geraLandingStageExecutionRepository;
+    private final FacebookAdsCampaignRepository facebookAdsCampaignRepository;
+    private final ExperimentReportMaterialService materialService;
+    private final ObjectMapper objectMapper;
+
+    /** Inicializa o serviço com os repositórios e consolidadores necessários para o relatório. */
+    public ExperimentCompleteMarkdownReportService(ExperimentRepository experimentRepository,
+                                                   GeraLandingStageExecutionRepository geraLandingStageExecutionRepository,
+                                                   FacebookAdsCampaignRepository facebookAdsCampaignRepository,
+                                                   ExperimentReportMaterialService materialService,
+                                                   ObjectMapper objectMapper) {
+        this.experimentRepository = experimentRepository;
+        this.geraLandingStageExecutionRepository = geraLandingStageExecutionRepository;
+        this.facebookAdsCampaignRepository = facebookAdsCampaignRepository;
+        this.materialService = materialService;
+        this.objectMapper = objectMapper;
+    }
+
+    /**
+     * Gera o relatório completo em Markdown para um experimento validado ou invalidado.
+     */
+    @Transactional(readOnly = true)
+    public String buildMarkdown(Long experimentId) {
+        Experiment experiment = experimentRepository.findById(experimentId)
+                .orElseThrow(() -> new IllegalArgumentException("Experimento não encontrado: " + experimentId));
+        validateReportAvailability(experiment);
+
+        var material = materialService.build(experimentId);
+        List<GeraLandingStageExecution> geraLandingExecutions = geraLandingStageExecutionRepository
+                .findByExperimentIdOrderByExecutionRequestedAtAsc(experimentId);
+        List<FacebookAdsCampaign> facebookCampaigns = facebookAdsCampaignRepository
+                .findDetailedByExperimentId(experimentId);
+
+        StringBuilder markdown = new StringBuilder();
+        appendHeader(markdown, experiment);
+        appendStrategicContext(markdown, experiment);
+        appendHypothesisFramework(markdown, experiment.getHypothesisRef());
+        appendRawExperimentArtifacts(markdown, experiment);
+        appendCampaignMetrics(markdown, experiment.getCampaignMetric());
+        appendGeraLandingExecutions(markdown, geraLandingExecutions);
+        appendFacebookCampaigns(markdown, facebookCampaigns);
+        appendMaterialSnapshot(markdown, material);
+        return markdown.toString();
+    }
+
+    /**
+     * Monta um nome de arquivo seguro para download do relatório em Markdown.
+     */
+    public String buildFilename(Long experimentId) {
+        return "experimento-" + experimentId + "-relatorio-completo.md";
+    }
+
+    /**
+     * Bloqueia a geração quando o experimento ainda não foi concluído pelo pipeline.
+     */
+    private void validateReportAvailability(Experiment experiment) {
+        if (!ALLOWED_STATUSES.contains(experiment.getStatus())) {
+            throw new IllegalStateException(
+                    "O relatório completo só fica disponível para experimentos validados ou invalidados."
+            );
+        }
+    }
+
+    /**
+     * Adiciona o cabeçalho executivo do relatório.
+     */
+    private void appendHeader(StringBuilder markdown, Experiment experiment) {
+        markdown.append("# Relatório completo do experimento #")
+                .append(experiment.getId())
+                .append(" — ")
+                .append(safe(experiment.getName()))
+                .append("\n\n");
+        markdown.append("- Gerado em: ").append(Instant.now()).append("\n");
+        markdown.append("- Status final: ").append(value(experiment.getStatus())).append("\n");
+        markdown.append("- Plataforma: ").append(value(experiment.getPlatform())).append("\n");
+        markdown.append("- Etapa: ").append(value(experiment.getStage())).append("\n\n");
+    }
+
+    /**
+     * Adiciona nicho, hipótese e parâmetros principais do experimento.
+     */
+    private void appendStrategicContext(StringBuilder markdown, Experiment experiment) {
+        MarketNiche niche = experiment.getNiche();
+        Hypothesis hypothesis = experiment.getHypothesisRef();
+        markdown.append("## 1. Contexto estratégico\n\n");
+        markdown.append("### Nicho\n\n");
+        markdown.append("- ID: ").append(niche != null ? niche.getId() : "—").append("\n");
+        markdown.append("- Nome: ").append(niche != null ? safe(niche.getName()) : "—").append("\n");
+        markdown.append("- Descrição: ").append(niche != null ? safe(niche.getDescription()) : "—").append("\n");
+        markdown.append("- Interesses: ").append(niche != null ? value(niche.getInterestList()) : "—").append("\n");
+        markdown.append("- Funções: ").append(niche != null ? value(niche.getRoleList()) : "—").append("\n");
+        markdown.append("- Comportamentos: ").append(niche != null ? value(niche.getBehaviorList()) : "—").append("\n\n");
+
+        markdown.append("### Hipótese\n\n");
+        markdown.append("- ID: ").append(hypothesis != null ? hypothesis.getId() : "—").append("\n");
+        markdown.append("- Título: ").append(hypothesis != null ? safe(hypothesis.getTitle()) : "—").append("\n");
+        markdown.append("- Dor/problema: ").append(hypothesis != null ? safe(hypothesis.getProblem()) : "—").append("\n");
+        markdown.append("- Promessa: ").append(hypothesis != null ? safe(hypothesis.getPromise()) : "—").append("\n");
+        markdown.append("- Persona: ").append(hypothesis != null ? safe(hypothesis.getPersona()) : "—").append("\n");
+        markdown.append("- Mecanismo: ").append(hypothesis != null ? safe(hypothesis.getMechanism()) : "—").append("\n");
+        markdown.append("- Mecanismo único: ").append(hypothesis != null ? safe(hypothesis.getUniqueMechanism()) : "—").append("\n");
+        markdown.append("- Entrega/oferta: ").append(hypothesis != null ? safe(hypothesis.getEntrega()) : "—").append("\n\n");
+
+        markdown.append("### Parâmetros do experimento\n\n");
+        appendJsonBlock(markdown, "experiment_parameters", mapOf(
+                "primaryVariable", experiment.getPrimaryVariable(),
+                "primaryMetric", experiment.getPrimaryMetric(),
+                "startDate", experiment.getStartDate(),
+                "endDate", experiment.getEndDate(),
+                "dailyBudget", experiment.getDailyBudget(),
+                "kpiTargetCpl", experiment.getKpiTargetCpl(),
+                "stopLossCpl", experiment.getStopLossCpl(),
+                "sampleSize", experiment.getSampleSize(),
+                "baselineCvr", experiment.getBaselineCvr(),
+                "targetCvr", experiment.getTargetCvr(),
+                "mdePercent", experiment.getMdePercent(),
+                "unitPrice", experiment.getUnitPrice(),
+                "totalCost", experiment.getTotalCost(),
+                "expense", experiment.getExpense()
+        ));
+    }
+
+    /**
+     * Adiciona o framework canônico da hipótese em formato JSON bruto.
+     */
+    private void appendHypothesisFramework(StringBuilder markdown, Hypothesis hypothesis) {
+        markdown.append("## 2. Framework da hipótese\n\n");
+        appendCodeBlock(markdown, "json", prettyJson(hypothesis != null ? hypothesis.getFrameworkJson() : null));
+    }
+
+    /**
+     * Adiciona os JSONs e artefatos principais gerados antes do GeraLanding.
+     */
+    private void appendRawExperimentArtifacts(StringBuilder markdown, Experiment experiment) {
+        markdown.append("## 3. Artefatos brutos do experimento\n\n");
+        appendNamedRawBlock(markdown, "Ângulo de campanha", experiment.getCampaignAngle());
+        appendNamedRawBlock(markdown, "Ad copy", experiment.getAdCopy());
+        appendNamedRawBlock(markdown, "Prompt de imagem do anúncio", experiment.getCreativeImagePrompt());
+        appendNamedRawBlock(markdown, "Briefing de imagem do anúncio", experiment.getAdImageBriefing());
+        appendNamedRawBlock(markdown, "Prompt de texto criativo", experiment.getCreativeTextPrompt());
+        appendNamedRawBlock(markdown, "Copy da landing", experiment.getLandingPageCopy());
+        appendNamedRawBlock(markdown, "Wireframe da landing", experiment.getLandingPageWireframe());
+        appendNamedRawBlock(markdown, "Planejamento de imagem da landing", experiment.getLandingPageImagePlanning());
+        appendNamedRawBlock(markdown, "Assets de imagem da landing", experiment.getLandingPageImageAssets());
+        appendNamedRawBlock(markdown, "Preset visual da landing", experiment.getLandingPageDesignPreset());
+        appendNamedRawBlock(markdown, "HTML GeraLanding", experiment.getHtmlGeraLanding());
+        appendNamedRawBlock(markdown, "Revisão de qualidade da landing", experiment.getLandingPageQualityReview());
+        appendNamedRawBlock(markdown, "Entregáveis da landing", experiment.getLandingPageDeliverables());
+        appendNamedRawBlock(markdown, "HTML final da landing", experiment.getLandingPageHtml());
+    }
+
+    /**
+     * Adiciona as métricas agregadas sincronizadas para a campanha do experimento.
+     */
+    private void appendCampaignMetrics(StringBuilder markdown, ExperimentCampaignMetric metric) {
+        markdown.append("## 4. Métricas agregadas da campanha\n\n");
+        if (metric == null) {
+            markdown.append("Nenhuma métrica agregada sincronizada para este experimento.\n\n");
+            return;
+        }
+        appendJsonBlock(markdown, "campaign_metric", mapOf(
+                "dateStart", metric.getDateStart(),
+                "dateStop", metric.getDateStop(),
+                "impressions", metric.getImpressions(),
+                "clicks", metric.getClicks(),
+                "leads", metric.getLeads(),
+                "spend", metric.getSpend(),
+                "cpc", metric.getCpc(),
+                "cpl", metric.getCpl(),
+                "metricsLastSyncedAt", metric.getCampaign() != null ? metric.getCampaign().getMetricsLastSyncedAt() : null,
+                "metricsLastError", metric.getCampaign() != null ? metric.getCampaign().getMetricsLastError() : null
+        ));
+    }
+
+    /**
+     * Adiciona todas as execuções e payloads auditáveis do GeraLanding.
+     */
+    private void appendGeraLandingExecutions(StringBuilder markdown, List<GeraLandingStageExecution> executions) {
+        markdown.append("## 5. GeraLanding — todas as execuções e JSONs\n\n");
+        if (executions == null || executions.isEmpty()) {
+            markdown.append("Nenhuma execução de GeraLanding encontrada para este experimento.\n\n");
+            return;
+        }
+        for (GeraLandingStageExecution execution : executions) {
+            markdown.append("### Etapa ")
+                    .append(safe(execution.getStageCode()))
+                    .append(" — job ")
+                    .append(fromDatabaseIdJob(execution.getIdJob()))
+                    .append("\n\n");
+            appendJsonBlock(markdown, "geralanding_execution_metadata", mapOf(
+                    "idJob", fromDatabaseIdJob(execution.getIdJob()),
+                    "stageCode", execution.getStageCode(),
+                    "status", execution.getStatus(),
+                    "promptTemplateId", execution.getPromptTemplateId(),
+                    "openAiModel", execution.getOpenAiModel(),
+                    "openAiJobId", execution.getOpenAiJobId(),
+                    "executionRequestedAt", execution.getExecutionRequestedAt(),
+                    "processingStartedAt", execution.getProcessingStartedAt(),
+                    "completedAt", execution.getCompletedAt(),
+                    "inputTokens", execution.getInputTokens(),
+                    "outputTokens", execution.getOutputTokens(),
+                    "costUsd", execution.getCostUsd(),
+                    "errorMessage", execution.getErrorMessage(),
+                    "errorDetail", execution.getErrorDetail()
+            ));
+            appendNamedRawBlock(markdown, "Prompt content", execution.getPromptContent());
+            appendNamedRawBlock(markdown, "Prompt final", execution.getPrompt());
+            appendNamedRawBlock(markdown, "OpenAI request body", execution.getOpenAiRequestBody());
+            appendNamedRawBlock(markdown, "Schema JSON", execution.getSchemaJson());
+            appendNamedRawBlock(markdown, "Prompt markdown", execution.getPromptMarkdownContent());
+            appendNamedRawBlock(markdown, "Resposta do modelo", execution.getModelResponse());
+            appendNamedRawBlock(markdown, "HTML provisório", execution.getProvisionalHtml());
+            appendNamedRawBlock(markdown, "Auditoria da revisão de qualidade", execution.getQualityReviewAudit());
+        }
+    }
+
+    /**
+     * Adiciona campanhas, conjuntos de anúncios, anúncios, criativos e métricas do Facebook Ads.
+     */
+    private void appendFacebookCampaigns(StringBuilder markdown, List<FacebookAdsCampaign> campaigns) {
+        markdown.append("## 6. Facebook Ads — campanhas e métricas\n\n");
+        if (campaigns == null || campaigns.isEmpty()) {
+            markdown.append("Nenhuma campanha do Facebook Ads encontrada para este experimento.\n\n");
+            return;
+        }
+        for (FacebookAdsCampaign campaign : campaigns) {
+            markdown.append("### Campanha ").append(safe(campaign.getName())).append("\n\n");
+            appendJsonBlock(markdown, "facebook_campaign", mapOf(
+                    "id", campaign.getId(),
+                    "externalId", campaign.getExternalId(),
+                    "adAccountId", campaign.getAdAccountId(),
+                    "name", campaign.getName(),
+                    "objective", campaign.getObjective(),
+                    "status", campaign.getStatus(),
+                    "budgetMode", campaign.getBudgetMode(),
+                    "dailyBudgetMinor", campaign.getDailyBudgetMinor(),
+                    "lifetimeBudgetMinor", campaign.getLifetimeBudgetMinor(),
+                    "apiVersion", campaign.getApiVersion(),
+                    "specialAdCategories", campaign.getSpecialAdCategories(),
+                    "specialAdCountries", campaign.getSpecialAdCountries(),
+                    "metricsLastSyncedAt", campaign.getMetricsLastSyncedAt(),
+                    "metricsLastError", campaign.getMetricsLastError(),
+                    "stopReason", campaign.getStopReason(),
+                    "stopRequestedAt", campaign.getStopRequestedAt(),
+                    "stopCompletedAt", campaign.getStopCompletedAt(),
+                    "stopLastError", campaign.getStopLastError(),
+                    "createdAt", campaign.getCreatedAt(),
+                    "updatedAt", campaign.getUpdatedAt()
+            ));
+            appendAdSets(markdown, campaign.getAdSets());
+        }
+    }
+
+    /**
+     * Adiciona o detalhamento dos conjuntos de anúncios de uma campanha.
+     */
+    private void appendAdSets(StringBuilder markdown, List<FacebookAdsAdSet> adSets) {
+        if (adSets == null || adSets.isEmpty()) {
+            markdown.append("Nenhum conjunto de anúncios persistido nesta campanha.\n\n");
+            return;
+        }
+        for (FacebookAdsAdSet adSet : adSets) {
+            markdown.append("#### Conjunto de anúncios ").append(safe(adSet.getName())).append("\n\n");
+            appendJsonBlock(markdown, "facebook_ad_set", mapOf(
+                    "id", adSet.getId(),
+                    "externalId", adSet.getExternalId(),
+                    "name", adSet.getName(),
+                    "status", adSet.getStatus(),
+                    "dailyBudgetMinor", adSet.getDailyBudgetMinor(),
+                    "lifetimeBudgetMinor", adSet.getLifetimeBudgetMinor(),
+                    "startTime", adSet.getStartTime(),
+                    "endTime", adSet.getEndTime(),
+                    "billingEvent", adSet.getBillingEvent(),
+                    "optimizationGoal", adSet.getOptimizationGoal(),
+                    "bidStrategy", adSet.getBidStrategy(),
+                    "bidAmountMinor", adSet.getBidAmountMinor(),
+                    "promotedObjectJson", parseMaybeJson(adSet.getPromotedObjectJson()),
+                    "targetingJson", parseMaybeJson(adSet.getTargetingJson()),
+                    "createdAt", adSet.getCreatedAt(),
+                    "updatedAt", adSet.getUpdatedAt()
+            ));
+            appendAds(markdown, adSet.getAds());
+        }
+    }
+
+    /**
+     * Adiciona anúncios e seus criativos publicados no Facebook Ads.
+     */
+    private void appendAds(StringBuilder markdown, List<FacebookAdsAd> ads) {
+        if (ads == null || ads.isEmpty()) {
+            markdown.append("Nenhum anúncio persistido neste conjunto.\n\n");
+            return;
+        }
+        for (FacebookAdsAd ad : ads) {
+            FacebookAdsAdCreative creative = ad.getCreative();
+            markdown.append("##### Anúncio ").append(safe(ad.getName())).append("\n\n");
+            appendJsonBlock(markdown, "facebook_ad", mapOf(
+                    "id", ad.getId(),
+                    "externalId", ad.getExternalId(),
+                    "name", ad.getName(),
+                    "status", ad.getStatus(),
+                    "creativeId", creative != null ? creative.getId() : null,
+                    "trackingUtm", ad.getTrackingUtm() != null ? mapOf(
+                            "utmSource", ad.getTrackingUtm().getUtmSource(),
+                            "utmMedium", ad.getTrackingUtm().getUtmMedium(),
+                            "utmCampaign", ad.getTrackingUtm().getUtmCampaign(),
+                            "utmContent", ad.getTrackingUtm().getUtmContent(),
+                            "utmTerm", ad.getTrackingUtm().getUtmTerm()
+                    ) : null,
+                    "createdAt", ad.getCreatedAt(),
+                    "updatedAt", ad.getUpdatedAt()
+            ));
+            if (creative != null) {
+                appendJsonBlock(markdown, "facebook_ad_creative", mapOf(
+                        "id", creative.getId(),
+                        "externalId", creative.getExternalId(),
+                        "pageId", creative.getPageId(),
+                        "instagramUserId", creative.getInstagramUserId(),
+                        "kind", creative.getKind(),
+                        "linkDataJson", parseMaybeJson(creative.getLinkDataJson()),
+                        "videoDataJson", parseMaybeJson(creative.getVideoDataJson()),
+                        "carouselDataJson", parseMaybeJson(creative.getCarouselDataJson()),
+                        "lastPreviewUrl", creative.getLastPreviewUrl(),
+                        "createdAt", creative.getCreatedAt(),
+                        "updatedAt", creative.getUpdatedAt()
+                ));
+            }
+        }
+    }
+
+    /**
+     * Adiciona um snapshot JSON consolidado usado para auditoria completa do relatório.
+     */
+    private void appendMaterialSnapshot(StringBuilder markdown, Object material) {
+        markdown.append("## 7. Snapshot consolidado do backend\n\n");
+        appendJsonBlock(markdown, "experiment_report_material", material);
+    }
+
+    /**
+     * Adiciona um bloco bruto nomeado, formatando JSON quando possível.
+     */
+    private void appendNamedRawBlock(StringBuilder markdown, String title, String rawValue) {
+        markdown.append("### ").append(title).append("\n\n");
+        appendCodeBlock(markdown, detectLanguage(rawValue), prettyJson(rawValue));
+    }
+
+    /**
+     * Adiciona um objeto serializado como JSON em bloco Markdown.
+     */
+    private void appendJsonBlock(StringBuilder markdown, String title, Object value) {
+        markdown.append("#### ").append(title).append("\n\n");
+        appendCodeBlock(markdown, "json", toPrettyJson(value));
+    }
+
+    /**
+     * Adiciona um bloco de código Markdown.
+     */
+    private void appendCodeBlock(StringBuilder markdown, String language, String value) {
+        markdown.append("```").append(language == null ? "" : language).append("\n")
+                .append(value == null || value.isBlank() ? "—" : value.trim())
+                .append("\n```\n\n");
+    }
+
+    /**
+     * Detecta se um texto bruto deve ser exibido como JSON ou texto simples.
+     */
+    private String detectLanguage(String rawValue) {
+        if (rawValue == null) {
+            return "";
+        }
+        String trimmed = rawValue.trim();
+        return (trimmed.startsWith("{") && trimmed.endsWith("}"))
+                || (trimmed.startsWith("[") && trimmed.endsWith("]")) ? "json" : "";
+    }
+
+    /**
+     * Formata JSON textual quando o conteúdo for válido.
+     */
+    private String prettyJson(String rawValue) {
+        if (rawValue == null || rawValue.isBlank()) {
+            return "—";
+        }
+        try {
+            Object parsed = objectMapper.readValue(rawValue, Object.class);
+            return objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(parsed);
+        } catch (JsonProcessingException ex) {
+            return rawValue;
+        }
+    }
+
+    /**
+     * Serializa qualquer objeto como JSON identado.
+     */
+    private String toPrettyJson(Object value) {
+        if (value == null) {
+            return "—";
+        }
+        try {
+            return objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(value);
+        } catch (JsonProcessingException ex) {
+            throw new IllegalStateException("Não foi possível serializar seção do relatório completo", ex);
+        }
+    }
+
+    /**
+     * Tenta converter texto JSON em estrutura para evitar JSON escapado dentro de JSON.
+     */
+    private Object parseMaybeJson(String rawValue) {
+        if (rawValue == null || rawValue.isBlank()) {
+            return null;
+        }
+        try {
+            return objectMapper.readValue(rawValue, Object.class);
+        } catch (JsonProcessingException ex) {
+            return rawValue;
+        }
+    }
+
+    /**
+     * Cria um mapa ordenado ignorando pares com quantidade inválida.
+     */
+    private Map<String, Object> mapOf(Object... entries) {
+        Map<String, Object> map = new LinkedHashMap<>();
+        for (int i = 0; i + 1 < entries.length; i += 2) {
+            map.put(String.valueOf(entries[i]), entries[i + 1]);
+        }
+        return map;
+    }
+
+    /**
+     * Converte o identificador do job gravado como bytes para texto.
+     */
+    private String fromDatabaseIdJob(byte[] idJob) {
+        return idJob == null ? "—" : new String(idJob, StandardCharsets.UTF_8);
+    }
+
+    /**
+     * Retorna texto seguro para campos livres.
+     */
+    private String safe(String value) {
+        return value == null || value.isBlank() ? "—" : value.trim();
+    }
+
+    /**
+     * Retorna a representação textual de valores possivelmente nulos.
+     */
+    private String value(Object value) {
+        return Objects.toString(value, "—");
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/report/web/ExperimentReportMaterialController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/report/web/ExperimentReportMaterialController.java
@@ -1,6 +1,8 @@
 package com.marketinghub.experiment.report.web;
 
+import com.marketinghub.experiment.report.dto.ExperimentCompleteMarkdownReportDto;
 import com.marketinghub.experiment.report.dto.ExperimentReportMaterialDto;
+import com.marketinghub.experiment.report.service.ExperimentCompleteMarkdownReportService;
 import com.marketinghub.experiment.report.service.ExperimentReportMaterialService;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -15,13 +17,27 @@ import org.springframework.web.bind.annotation.RestController;
 public class ExperimentReportMaterialController {
 
     private final ExperimentReportMaterialService service;
+    private final ExperimentCompleteMarkdownReportService completeMarkdownReportService;
 
-    public ExperimentReportMaterialController(ExperimentReportMaterialService service) {
+    /** Inicializa o controller com serviços de material estruturado e relatório Markdown. */
+    public ExperimentReportMaterialController(ExperimentReportMaterialService service,
+                                              ExperimentCompleteMarkdownReportService completeMarkdownReportService) {
         this.service = service;
+        this.completeMarkdownReportService = completeMarkdownReportService;
     }
 
+    /** Retorna o pacote estruturado de dados usado por prévias e workers de relatório. */
     @GetMapping
     public ExperimentReportMaterialDto getMaterial(@PathVariable Long experimentId) {
         return service.build(experimentId);
+    }
+
+    /** Retorna o relatório completo do experimento em Markdown para download pelo usuário. */
+    @GetMapping("/complete-markdown")
+    public ExperimentCompleteMarkdownReportDto getCompleteMarkdown(@PathVariable Long experimentId) {
+        return new ExperimentCompleteMarkdownReportDto(
+                completeMarkdownReportService.buildFilename(experimentId),
+                completeMarkdownReportService.buildMarkdown(experimentId)
+        );
     }
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/geralanding/GeraLandingStageExecutionRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/geralanding/GeraLandingStageExecutionRepository.java
@@ -9,26 +9,36 @@ import java.util.Optional;
 
 /** Repositório responsável por consultar e persistir execuções das etapas do GeraLanding. */
 public interface GeraLandingStageExecutionRepository extends JpaRepository<GeraLandingStageExecution, byte[]> {
+    /** Busca a execução mais recente pelo identificador técnico do job. */
     Optional<GeraLandingStageExecution> findTopByIdJobOrderByExecutionRequestedAtDesc(byte[] idJob);
 
+    /** Busca a execução mais recente de um job dentro de um experimento. */
     Optional<GeraLandingStageExecution> findTopByExperimentIdAndIdJobOrderByExecutionRequestedAtDesc(Long experimentId,
                                                                                                        byte[] idJob);
 
+    /** Busca a execução mais recente de uma etapa dentro de um experimento. */
     Optional<GeraLandingStageExecution> findTopByExperimentIdAndStageCodeOrderByExecutionRequestedAtDesc(Long experimentId,
                                                                                                            String stageCode);
 
+    /** Lista as próximas vinte execuções de um status em ordem de solicitação. */
     List<GeraLandingStageExecution> findTop20ByStatusOrderByExecutionRequestedAtAsc(String status);
 
+    /** Lista as próximas vinte execuções que estejam em qualquer um dos status informados. */
     List<GeraLandingStageExecution> findTop20ByStatusInOrderByExecutionRequestedAtAsc(List<String> statuses);
+
+    /** Busca todas as execuções de um experimento em ordem cronológica para auditoria completa. */
+    List<GeraLandingStageExecution> findByExperimentIdOrderByExecutionRequestedAtAsc(Long experimentId);
 
     /** Busca as execuções mais antigas de uma etapa com experimento e hipótese carregados. */
     @EntityGraph(attributePaths = {"experiment", "experiment.hypothesisRef"})
     List<GeraLandingStageExecution> findTop20ByStageCodeAndStatusOrderByExecutionRequestedAtAsc(String stageCode,
                                                                                                 String status);
 
+    /** Lista as últimas vinte execuções de uma etapa dentro de um experimento. */
     List<GeraLandingStageExecution>
     findTop20ByExperimentIdAndStageCodeOrderByExecutionRequestedAtDesc(Long experimentId, String stageCode);
 
+    /** Lista as últimas vinte execuções de uma etapa excluindo um status operacional. */
     List<GeraLandingStageExecution>
     findTop20ByExperimentIdAndStageCodeAndStatusNotOrderByExecutionRequestedAtDesc(
             Long experimentId,

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -4244,3 +4244,10 @@
 - tarefa: retirar instruções de prompt de AdCopy hardcoded em Java/React, reforçar que a copy fala diretamente com o cliente ideal e verificar a mesma diretriz no prompt de imagem do anúncio.
 - foi feito: removido o template hardcoded de AdCopy do frontend, removido o marcador textual hardcoded de AdCopy no Java, reforçado o prompt `ad-copy.md` com filtragem explícita de público e criado o prompt versionado `ad-image-briefing.md` com a mesma comunicação direta/filtragem visual.
 - impacto esperado: a etapa `AD_COPY` passa a depender apenas do prompt versionado no `ai-worker`, e a etapa de briefing de imagem de anúncio passa a orientar visualmente a separação entre cliente ideal e público geral.
+
+## 2026-06-09 — Relatório completo em Markdown para experimento concluído
+
+- solicitação: permitir que o usuário obtenha um relatório geral bem detalhado para experimentos com pipeline concluído, tanto validados quanto invalidados.
+- causa-raiz: a tela já expunha partes do material do experimento, mas não havia uma ação única que consolidasse nicho, framework da hipótese, JSONs de campanha/anúncio/imagem, JSONs do GeraLanding e detalhamento de Facebook Ads em um artefato auditável.
+- foi feito: criado endpoint de relatório completo em Markdown e botão na tela do experimento, exibido somente para status `VALIDATED` ou `INVALIDATED`, com download direto do arquivo `.md`.
+- impacto esperado: o usuário consegue revisar e reaproveitar todo o aprendizado comercial do experimento encerrado sem buscar dados em múltiplas abas, acelerando análise de vencedores e perdedores.

--- a/frontend/src/api/experiment/useExperimentCompleteMarkdownReport.ts
+++ b/frontend/src/api/experiment/useExperimentCompleteMarkdownReport.ts
@@ -1,0 +1,46 @@
+import { useMutation } from "@tanstack/react-query";
+import axios from "axios";
+import { toast } from "react-toastify";
+
+export interface ExperimentCompleteMarkdownReport {
+  filename: string;
+  markdown: string;
+}
+
+export function useExperimentCompleteMarkdownReport(experimentId?: string) {
+  return useMutation({
+    mutationFn: async () => {
+      if (!experimentId) {
+        throw new Error("Experiment id is required");
+      }
+      const { data } = await axios.get<ExperimentCompleteMarkdownReport>(
+        `/api/experiments/${experimentId}/report-material/complete-markdown`,
+      );
+      return data;
+    },
+    onSuccess: (data) => {
+      downloadMarkdown(data.markdown, data.filename);
+      toast.success("Relatório completo em Markdown gerado");
+    },
+    onError: (error: unknown) => {
+      const message = axios.isAxiosError(error)
+        ? (error.response?.data?.message ?? error.message)
+        : (error as Error)?.message;
+      toast.error(
+        message ?? "Não foi possível gerar o relatório completo agora",
+      );
+    },
+  });
+}
+
+function downloadMarkdown(markdown: string, filename: string) {
+  const blob = new Blob([markdown], { type: "text/markdown;charset=utf-8" });
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = filename || "relatorio-completo-experimento.md";
+  document.body.appendChild(link);
+  link.click();
+  document.body.removeChild(link);
+  URL.revokeObjectURL(url);
+}

--- a/frontend/src/pages/experiment/ExperimentDetailPage.tsx
+++ b/frontend/src/pages/experiment/ExperimentDetailPage.tsx
@@ -42,6 +42,7 @@ import {
   useGeraLandingStageModels,
   type GeraLandingStageModel,
 } from "../../api/pipeline/useGeraLandingStageModels";
+import { useExperimentCompleteMarkdownReport } from "../../api/experiment/useExperimentCompleteMarkdownReport";
 
 function formatPipelineStageModel(stageModel?: GeraLandingStageModel) {
   const name = stageModel?.openAiModelName?.trim();
@@ -440,6 +441,7 @@ export default function ExperimentDetailPage() {
   } = useExperimentCampaignResetPreview(expId);
   const resetCampaigns = useExperimentCampaignReset(expId);
   const releaseExperiment = useExperimentFacebookRelease(expId);
+  const completeMarkdownReport = useExperimentCompleteMarkdownReport(expId);
   const frameworkImagePendingCount = useMemo(
     () =>
       (frameworkImageStatuses ?? []).filter((item) => {
@@ -448,6 +450,15 @@ export default function ExperimentDetailPage() {
       }).length,
     [frameworkImageStatuses],
   );
+  const canDownloadCompleteReport =
+    data?.status === "VALIDATED" || data?.status === "INVALIDATED";
+
+  const handleDownloadCompleteReport = () => {
+    if (!completeMarkdownReport.isPending) {
+      completeMarkdownReport.mutate();
+    }
+  };
+
   const pipelineContentCards = useMemo<PipelineContentCard[]>(
     () => [
       {
@@ -2093,6 +2104,27 @@ export default function ExperimentDetailPage() {
           <Link to="pipeline-jobs" className="btn btn-outline-dark me-2">
             Jobs do pipeline
           </Link>
+          {canDownloadCompleteReport ? (
+            <button
+              type="button"
+              className="btn btn-success me-2"
+              onClick={handleDownloadCompleteReport}
+              disabled={completeMarkdownReport.isPending}
+            >
+              {completeMarkdownReport.isPending ? (
+                <>
+                  <span
+                    className="spinner-border spinner-border-sm me-2"
+                    role="status"
+                    aria-hidden="true"
+                  />
+                  Gerando...
+                </>
+              ) : (
+                "Relatório completo (.md)"
+              )}
+            </button>
+          ) : null}
           <button
             type="button"
             className="btn btn-outline-danger me-2"


### PR DESCRIPTION
### Motivation

- Provide a single, auditable artifact that consolidates all experiment data for experiments with pipeline concluded (validated or invalidated). 
- Make it easy for users to export niche, hypothesis framework, all pipeline JSONs (campaign angle, ad copy, image prompts, geraLanding payloads, landing artifacts) and Facebook Ads details/metrics in a human-readable Markdown file. 
- Expose the report from the backend and make it available in the frontend only when the experiment is finished to avoid exposing incomplete data.

### Description

- Added a backend Markdown report generator `ExperimentCompleteMarkdownReportService` that builds a complete `.md` document including strategic context, hypothesis framework, raw experiment artifacts, campaign metrics, all GeraLanding executions (prompts, request bodies, model responses, provisional HTML, audits) and Facebook Ads campaigns/adsets/ads/creatives; filename helper `buildFilename` included. 
- Introduced DTO `ExperimentCompleteMarkdownReportDto` and new endpoint `GET /api/experiments/{experimentId}/report-material/complete-markdown` in `ExperimentReportMaterialController` that returns `{ filename, markdown }`. 
- Extended `GeraLandingStageExecutionRepository` with `findByExperimentIdOrderByExecutionRequestedAtAsc` to retrieve all executions chronologically for audit inclusion. 
- Added frontend mutation `useExperimentCompleteMarkdownReport` which downloads the returned Markdown as a `.md` file, and added a guarded button `Relatório completo (.md)` to `ExperimentDetailPage.tsx` that is visible only when `data.status` is `VALIDATED` or `INVALIDATED` and shows a loading state while generating. 
- Updated project records in `docs/registros/experimentos.md` documenting the change.

### Testing

- Ran frontend typecheck with `npm run typecheck` and it passed. 
- Ran Prettier checks with `npx prettier --check` for the new files and formatting checks passed after fixing style issues. 
- Ran local lint/format checks and `git diff --check` with no issues before committing. 
- Backend `mvnw -DskipTests compile` could not be completed in this environment due to a Maven/Lombok/JDK compatibility error (`com.sun.tools.javac.code.TypeTag :: UNKNOWN`) on the runner (the change is pure Java service/controller additions and should compile in CI with the repository JDK configuration). 
- `spotless:check` was not executed here because the Maven `spotless` plugin prefix was not resolvable in this environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a2891f8fba483269d3b3793a5360ff2)