### PR TITLE
Implementa service da etapa de aquecimento MOIS

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesPageMarketWarmupService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesPageMarketWarmupService.java
@@ -1,0 +1,209 @@
+package com.marketinghub.mois.bibliotecapaginavenda.worker.v1.service;
+
+import com.marketinghub.mois.bibliotecapaginavenda.worker.v1.dto.MoisSalesLibraryDtos;
+import com.marketinghub.repository.jdbc.mois.bibliotecapaginavenda.worker.v1.MoisSalesPageMarketWarmupGateway;
+import com.marketinghub.repository.jdbc.mois.bibliotecapaginavenda.worker.v1.MoisSalesPageMarketWarmupGateway.MarketWarmupClaimData;
+import com.marketinghub.repository.jdbc.mois.bibliotecapaginavenda.worker.v1.MoisSalesPageMarketWarmupGateway.MarketWarmupJobData;
+import com.marketinghub.repository.jdbc.mois.bibliotecapaginavenda.worker.v1.MoisSalesPageMarketWarmupGateway.MarketWarmupSummaryData;
+import com.marketinghub.repository.jdbc.mois.bibliotecapaginavenda.worker.v1.MoisSalesPageMarketWarmupGateway.SalesPageWarmupData;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * Orquestra a solicitação, reserva e persistência da pesquisa de aquecimento de mercado da Biblioteca MOIS.
+ */
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class MoisSalesPageMarketWarmupService {
+
+    private final MoisSalesPageMarketWarmupGateway gateway;
+
+    /**
+     * Solicita uma pesquisa de aquecimento para a página, reutilizando jobs pendentes ou em execução.
+     */
+    @Transactional
+    public MoisSalesLibraryDtos.MarketWarmupRequestResponse requestResearch(long pageId) {
+        try {
+            SalesPageWarmupData page = gateway.findSalesPage(pageId)
+                    .orElseThrow(() -> new IllegalArgumentException("Página MOIS não encontrada para aquecimento: " + pageId));
+            MarketWarmupJobData job = gateway.findActiveJobByPage(pageId).orElseGet(() -> gateway.createPendingJob(page));
+            log.info("Pesquisa de aquecimento MOIS solicitada. modulo=MOIS, operacao=requestMarketWarmup, pageId={}, jobId={}, status={}",
+                    pageId, job.jobId(), job.status());
+            return new MoisSalesLibraryDtos.MarketWarmupRequestResponse(pageId, job.jobId(), job.status(), job.createdAt());
+        } catch (RuntimeException ex) {
+            log.error("Falha ao solicitar pesquisa de aquecimento MOIS. modulo=MOIS, operacao=requestMarketWarmup, pageId={}, erroClasse={}, erro={}",
+                    pageId, ex.getClass().getName(), ex.getMessage(), ex);
+            throw ex;
+        }
+    }
+
+    /**
+     * Lista o resumo mais recente de aquecimento de uma página de venda.
+     */
+    public MoisSalesLibraryDtos.MarketWarmupSummaryResponse getSummary(long pageId) {
+        try {
+            MarketWarmupSummaryData summary = gateway.findLatestSummaryByPage(pageId)
+                    .orElseThrow(() -> new IllegalArgumentException("Pesquisa de aquecimento não encontrada para página: " + pageId));
+            return mapSummary(summary);
+        } catch (RuntimeException ex) {
+            log.error("Falha ao consultar resumo de aquecimento MOIS. modulo=MOIS, operacao=getMarketWarmupSummary, pageId={}, erroClasse={}, erro={}",
+                    pageId, ex.getClass().getName(), ex.getMessage(), ex);
+            throw ex;
+        }
+    }
+
+    /**
+     * Lista as fontes rastreáveis do job de aquecimento mais recente da página.
+     */
+    public MoisSalesLibraryDtos.MarketWarmupSourceListResponse listSources(long pageId) {
+        try {
+            MarketWarmupJobData job = gateway.findLatestJobByPage(pageId)
+                    .orElseThrow(() -> new IllegalArgumentException("Pesquisa de aquecimento não encontrada para página: " + pageId));
+            return new MoisSalesLibraryDtos.MarketWarmupSourceListResponse(pageId, job.jobId(), gateway.listSources(job.jobId()));
+        } catch (RuntimeException ex) {
+            log.error("Falha ao listar fontes de aquecimento MOIS. modulo=MOIS, operacao=listMarketWarmupSources, pageId={}, erroClasse={}, erro={}",
+                    pageId, ex.getClass().getName(), ex.getMessage(), ex);
+            throw ex;
+        }
+    }
+
+    /**
+     * Lista os sinais comerciais do job de aquecimento mais recente da página.
+     */
+    public MoisSalesLibraryDtos.MarketWarmupSignalListResponse listSignals(long pageId) {
+        try {
+            MarketWarmupJobData job = gateway.findLatestJobByPage(pageId)
+                    .orElseThrow(() -> new IllegalArgumentException("Pesquisa de aquecimento não encontrada para página: " + pageId));
+            return new MoisSalesLibraryDtos.MarketWarmupSignalListResponse(pageId, job.jobId(), gateway.listSignals(job.jobId()));
+        } catch (RuntimeException ex) {
+            log.error("Falha ao listar sinais de aquecimento MOIS. modulo=MOIS, operacao=listMarketWarmupSignals, pageId={}, erroClasse={}, erro={}",
+                    pageId, ex.getClass().getName(), ex.getMessage(), ex);
+            throw ex;
+        }
+    }
+
+    /**
+     * Reserva o próximo job pendente para processamento pelo worker de aquecimento.
+     */
+    @Transactional
+    public MoisSalesLibraryDtos.MarketWarmupClaimResponse claimJob(MoisSalesLibraryDtos.MarketWarmupClaimRequest request) {
+        try {
+            MarketWarmupClaimData pending = gateway.findNextPendingJob(request.workspaceId())
+                    .orElse(null);
+            if (pending == null) {
+                return new MoisSalesLibraryDtos.MarketWarmupClaimResponse(false, null);
+            }
+            boolean claimed = gateway.claimPendingJob(pending.job().jobId(), request.workerId());
+            if (!claimed) {
+                return new MoisSalesLibraryDtos.MarketWarmupClaimResponse(false, null);
+            }
+            SalesPageWarmupData page = pending.page();
+            log.info("Job de aquecimento MOIS reservado. modulo=MOIS, operacao=claimMarketWarmupJob, workspaceId={}, workerId={}, pageId={}, jobId={}",
+                    request.workspaceId(), request.workerId(), page.pageId(), pending.job().jobId());
+            return new MoisSalesLibraryDtos.MarketWarmupClaimResponse(true, new MoisSalesLibraryDtos.MarketWarmupClaimedJob(
+                    pending.job().jobId(), page.pageId(), page.workspaceId(), page.urlCanonical(), page.title(), page.offerSummary(),
+                    page.mechanismSummary(), page.promiseSummary(), page.proofSummary()));
+        } catch (RuntimeException ex) {
+            log.error("Falha ao reservar job de aquecimento MOIS. modulo=MOIS, operacao=claimMarketWarmupJob, workspaceId={}, workerId={}, erroClasse={}, erro={}",
+                    request.workspaceId(), request.workerId(), ex.getClass().getName(), ex.getMessage(), ex);
+            throw ex;
+        }
+    }
+
+    /**
+     * Conclui o job com fontes, sinais e resumo final enviados pelo worker.
+     */
+    @Transactional
+    public void completeJob(long jobId, MoisSalesLibraryDtos.MarketWarmupCompleteRequest request) {
+        try {
+            MarketWarmupJobData job = gateway.findJob(jobId)
+                    .orElseThrow(() -> new IllegalArgumentException("Job de aquecimento não encontrado: " + jobId));
+            if (job.status() == MoisSalesLibraryDtos.MarketWarmupJobStatus.DONE) {
+                throw new IllegalStateException("Job de aquecimento já concluído: " + jobId);
+            }
+            gateway.deleteJobDetails(jobId);
+            List<Long> sourceIds = persistSources(job, request.sources());
+            persistSignals(job, sourceIds, request.signals());
+            gateway.insertSummary(jobId, job.pageId(), job.workspaceId(), request.summary());
+            gateway.markJobDone(jobId, request.summary(), request.finishedAt());
+            log.info("Job de aquecimento MOIS concluído. modulo=MOIS, operacao=completeMarketWarmupJob, workspaceId={}, pageId={}, jobId={}, fontes={}, sinais={}, score={}",
+                    job.workspaceId(), job.pageId(), jobId, request.sources().size(), request.signals().size(), request.summary().scoreTotal());
+        } catch (RuntimeException ex) {
+            log.error("Falha ao concluir job de aquecimento MOIS. modulo=MOIS, operacao=completeMarketWarmupJob, jobId={}, erroClasse={}, erro={}",
+                    jobId, ex.getClass().getName(), ex.getMessage(), ex);
+            throw ex;
+        }
+    }
+
+    /**
+     * Registra falha operacional em um job de aquecimento pendente ou em execução.
+     */
+    @Transactional
+    public void failJob(long jobId, MoisSalesLibraryDtos.MarketWarmupFailRequest request) {
+        try {
+            boolean failed = gateway.markJobFailed(jobId, request.errorCategory(), request.errorMessage());
+            if (!failed) {
+                throw new IllegalStateException("Job de aquecimento não encontrado ou não pode falhar: " + jobId);
+            }
+            log.info("Job de aquecimento MOIS marcado como falho. modulo=MOIS, operacao=failMarketWarmupJob, jobId={}, errorCategory={}",
+                    jobId, request.errorCategory());
+        } catch (RuntimeException ex) {
+            log.error("Falha ao registrar erro de job de aquecimento MOIS. modulo=MOIS, operacao=failMarketWarmupJob, jobId={}, erroClasse={}, erro={}",
+                    jobId, ex.getClass().getName(), ex.getMessage(), ex);
+            throw ex;
+        }
+    }
+
+    /**
+     * Persiste as fontes enviadas pelo worker mantendo a posição de entrada para vincular sinais.
+     */
+    private List<Long> persistSources(MarketWarmupJobData job, List<MoisSalesLibraryDtos.MarketWarmupSourceCompleteItem> sources) {
+        List<Long> sourceIds = new ArrayList<>();
+        for (MoisSalesLibraryDtos.MarketWarmupSourceCompleteItem source : sources) {
+            sourceIds.add(gateway.insertSource(job.jobId(), job.pageId(), job.workspaceId(), source));
+        }
+        return sourceIds;
+    }
+
+    /**
+     * Persiste os sinais enviados pelo worker validando o índice da fonte declarada.
+     */
+    private void persistSignals(MarketWarmupJobData job, List<Long> sourceIds, List<MoisSalesLibraryDtos.MarketWarmupSignalCompleteItem> signals) {
+        for (MoisSalesLibraryDtos.MarketWarmupSignalCompleteItem signal : signals) {
+            if (signal.sourceIndex() < 0 || signal.sourceIndex() >= sourceIds.size()) {
+                throw new IllegalArgumentException("Índice de fonte inválido para sinal de aquecimento: " + signal.sourceIndex());
+            }
+            gateway.insertSignal(job.jobId(), job.pageId(), job.workspaceId(), sourceIds.get(signal.sourceIndex()), signal);
+        }
+    }
+
+    /**
+     * Converte o resumo persistido em contrato de leitura da API.
+     */
+    private MoisSalesLibraryDtos.MarketWarmupSummaryResponse mapSummary(MarketWarmupSummaryData summary) {
+        return new MoisSalesLibraryDtos.MarketWarmupSummaryResponse(
+                summary.jobId(), summary.pageId(), summary.scoreTotal(), summary.marketTemperature(), summary.ecosystemType(), summary.recommendation(),
+                splitLines(summary.mainPains()), splitLines(summary.mainObjections()), splitLines(summary.mainPromises()), splitLines(summary.mainChannels()),
+                splitLines(summary.mainCompetitors()), summary.saturationRisk(), summary.opportunityRecommendation(), summary.nextExperimentSuggestion(),
+                summary.status(), summary.errorCategory(), summary.errorMessage(), summary.createdAt(), summary.updatedAt());
+    }
+
+    /**
+     * Converte texto funcional separado por linhas em lista sem interpretar JSON serializado.
+     */
+    private List<String> splitLines(String value) {
+        if (value == null || value.isBlank()) {
+            return List.of();
+        }
+        return Arrays.stream(value.split("\\R"))
+                .map(String::trim)
+                .filter(line -> !line.isBlank())
+                .toList();
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jdbc/mois/bibliotecapaginavenda/worker/v1/MoisSalesPageMarketWarmupGateway.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jdbc/mois/bibliotecapaginavenda/worker/v1/MoisSalesPageMarketWarmupGateway.java
@@ -1,0 +1,156 @@
+package com.marketinghub.repository.jdbc.mois.bibliotecapaginavenda.worker.v1;
+
+import com.marketinghub.mois.bibliotecapaginavenda.worker.v1.dto.MoisSalesLibraryDtos;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * Define o contrato de persistência da pesquisa de aquecimento de mercado da Biblioteca MOIS.
+ */
+public interface MoisSalesPageMarketWarmupGateway {
+
+    /**
+     * Busca os dados mínimos da página consolidada que receberá a pesquisa de aquecimento.
+     */
+    Optional<SalesPageWarmupData> findSalesPage(long pageId);
+
+    /**
+     * Busca o job pendente ou em execução mais recente da página para evitar duplicidade operacional.
+     */
+    Optional<MarketWarmupJobData> findActiveJobByPage(long pageId);
+
+    /**
+     * Cria um job pendente de aquecimento para uma página elegível.
+     */
+    MarketWarmupJobData createPendingJob(SalesPageWarmupData page);
+
+    /**
+     * Busca o job mais recente da página, independentemente do status.
+     */
+    Optional<MarketWarmupJobData> findLatestJobByPage(long pageId);
+
+    /**
+     * Busca o próximo job pendente no workspace para reserva pelo worker.
+     */
+    Optional<MarketWarmupClaimData> findNextPendingJob(String workspaceId);
+
+    /**
+     * Marca um job pendente como reservado pelo worker informado.
+     */
+    boolean claimPendingJob(long jobId, String workerId);
+
+    /**
+     * Busca um job pelo identificador operacional.
+     */
+    Optional<MarketWarmupJobData> findJob(long jobId);
+
+    /**
+     * Remove fontes, sinais e resumo anteriores do job antes da gravação final idempotente.
+     */
+    void deleteJobDetails(long jobId);
+
+    /**
+     * Insere uma fonte pública rastreável coletada pelo worker.
+     */
+    long insertSource(long jobId, long pageId, String workspaceId, MoisSalesLibraryDtos.MarketWarmupSourceCompleteItem source);
+
+    /**
+     * Insere um sinal comercial vinculado à fonte pública correspondente.
+     */
+    void insertSignal(long jobId, long pageId, String workspaceId, long sourceId, MoisSalesLibraryDtos.MarketWarmupSignalCompleteItem signal);
+
+    /**
+     * Insere o resumo final calculado para o job de aquecimento.
+     */
+    void insertSummary(long jobId, long pageId, String workspaceId, MoisSalesLibraryDtos.MarketWarmupSummaryCompleteItem summary);
+
+    /**
+     * Marca o job como concluído e replica os principais classificadores comerciais para busca rápida.
+     */
+    void markJobDone(long jobId, MoisSalesLibraryDtos.MarketWarmupSummaryCompleteItem summary, Instant finishedAt);
+
+    /**
+     * Marca o job como falho com categoria e mensagem operacional.
+     */
+    boolean markJobFailed(long jobId, String errorCategory, String errorMessage);
+
+    /**
+     * Busca o resumo mais recente da página com os dados do job associado.
+     */
+    Optional<MarketWarmupSummaryData> findLatestSummaryByPage(long pageId);
+
+    /**
+     * Lista fontes públicas de um job de aquecimento.
+     */
+    List<MoisSalesLibraryDtos.MarketWarmupSourceResponse> listSources(long jobId);
+
+    /**
+     * Lista sinais comerciais extraídos de um job de aquecimento.
+     */
+    List<MoisSalesLibraryDtos.MarketWarmupSignalResponse> listSignals(long jobId);
+
+    /**
+     * Representa os dados comerciais da página necessários para iniciar a etapa de aquecimento.
+     */
+    record SalesPageWarmupData(
+            long pageId,
+            String workspaceId,
+            String urlCanonical,
+            String title,
+            String offerSummary,
+            String mechanismSummary,
+            String promiseSummary,
+            String proofSummary
+    ) {
+    }
+
+    /**
+     * Representa o estado operacional de um job de aquecimento persistido.
+     */
+    record MarketWarmupJobData(
+            long jobId,
+            long pageId,
+            String workspaceId,
+            MoisSalesLibraryDtos.MarketWarmupJobStatus status,
+            Instant createdAt,
+            String errorCategory,
+            String errorMessage
+    ) {
+    }
+
+    /**
+     * Representa o job pendente enriquecido com a página de venda para reserva interna do worker.
+     */
+    record MarketWarmupClaimData(
+            MarketWarmupJobData job,
+            SalesPageWarmupData page
+    ) {
+    }
+
+    /**
+     * Representa o resumo final da pesquisa junto com o estado do job que o produziu.
+     */
+    record MarketWarmupSummaryData(
+            long jobId,
+            long pageId,
+            java.math.BigDecimal scoreTotal,
+            MoisSalesLibraryDtos.MarketWarmupTemperature marketTemperature,
+            MoisSalesLibraryDtos.MarketWarmupEcosystemType ecosystemType,
+            MoisSalesLibraryDtos.MarketWarmupRecommendation recommendation,
+            String mainPains,
+            String mainObjections,
+            String mainPromises,
+            String mainChannels,
+            String mainCompetitors,
+            String saturationRisk,
+            String opportunityRecommendation,
+            String nextExperimentSuggestion,
+            MoisSalesLibraryDtos.MarketWarmupJobStatus status,
+            String errorCategory,
+            String errorMessage,
+            Instant createdAt,
+            Instant updatedAt
+    ) {
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jdbc/mois/bibliotecapaginavenda/worker/v1/MoisSalesPageMarketWarmupRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jdbc/mois/bibliotecapaginavenda/worker/v1/MoisSalesPageMarketWarmupRepository.java
@@ -1,0 +1,385 @@
+package com.marketinghub.repository.jdbc.mois.bibliotecapaginavenda.worker.v1;
+
+import com.marketinghub.mois.bibliotecapaginavenda.worker.v1.dto.MoisSalesLibraryDtos;
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.sql.Timestamp;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.support.GeneratedKeyHolder;
+import org.springframework.jdbc.support.KeyHolder;
+import org.springframework.stereotype.Repository;
+
+/**
+ * Executa as operações JDBC da pesquisa de aquecimento de mercado da Biblioteca MOIS.
+ */
+@Repository
+@RequiredArgsConstructor
+public class MoisSalesPageMarketWarmupRepository implements MoisSalesPageMarketWarmupGateway {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    /**
+     * Busca os dados mínimos da página consolidada que receberá a pesquisa de aquecimento.
+     */
+    @Override
+    public Optional<SalesPageWarmupData> findSalesPage(long pageId) {
+        List<SalesPageWarmupData> rows = jdbcTemplate.query("""
+                SELECT id, workspace_id, url_canonical, title, offer_summary, mechanism_summary, promise_summary, proof_summary
+                FROM mois_sales_page
+                WHERE id = ?
+                LIMIT 1
+                """, this::mapSalesPage, pageId);
+        return rows.stream().findFirst();
+    }
+
+    /**
+     * Busca o job pendente ou reservado mais recente da página para reaproveitar solicitações duplicadas.
+     */
+    @Override
+    public Optional<MarketWarmupJobData> findActiveJobByPage(long pageId) {
+        List<MarketWarmupJobData> rows = jdbcTemplate.query("""
+                SELECT id, sales_page_id, workspace_id, status, created_at, error_category, error_message
+                FROM mois_sales_page_market_warmup_job
+                WHERE sales_page_id = ? AND status IN ('PENDING', 'FETCHING')
+                ORDER BY created_at DESC, id DESC
+                LIMIT 1
+                """, this::mapJob, pageId);
+        return rows.stream().findFirst();
+    }
+
+    /**
+     * Cria um job pendente de aquecimento para uma página elegível.
+     */
+    @Override
+    public MarketWarmupJobData createPendingJob(SalesPageWarmupData page) {
+        KeyHolder keyHolder = new GeneratedKeyHolder();
+        jdbcTemplate.update(connection -> {
+            PreparedStatement statement = connection.prepareStatement("""
+                    INSERT INTO mois_sales_page_market_warmup_job
+                    (sales_page_id, workspace_id, status, attempt, created_at, updated_at)
+                    VALUES (?, ?, 'PENDING', 1, UTC_TIMESTAMP(), UTC_TIMESTAMP())
+                    """, Statement.RETURN_GENERATED_KEYS);
+            statement.setLong(1, page.pageId());
+            statement.setString(2, page.workspaceId());
+            return statement;
+        }, keyHolder);
+        Number key = keyHolder.getKey();
+        long jobId = key == null ? 0L : key.longValue();
+        return findJob(jobId).orElseGet(() -> new MarketWarmupJobData(
+                jobId, page.pageId(), page.workspaceId(), MoisSalesLibraryDtos.MarketWarmupJobStatus.PENDING, Instant.now(), null, null));
+    }
+
+    /**
+     * Busca o job mais recente da página, independentemente do status.
+     */
+    @Override
+    public Optional<MarketWarmupJobData> findLatestJobByPage(long pageId) {
+        List<MarketWarmupJobData> rows = jdbcTemplate.query("""
+                SELECT id, sales_page_id, workspace_id, status, created_at, error_category, error_message
+                FROM mois_sales_page_market_warmup_job
+                WHERE sales_page_id = ?
+                ORDER BY created_at DESC, id DESC
+                LIMIT 1
+                """, this::mapJob, pageId);
+        return rows.stream().findFirst();
+    }
+
+    /**
+     * Busca o próximo job pendente no workspace para reserva pelo worker.
+     */
+    @Override
+    public Optional<MarketWarmupClaimData> findNextPendingJob(String workspaceId) {
+        List<MarketWarmupClaimData> rows = jdbcTemplate.query("""
+                SELECT j.id AS job_id, j.sales_page_id, j.workspace_id, j.status, j.created_at, j.error_category, j.error_message,
+                       sp.url_canonical, sp.title, sp.offer_summary, sp.mechanism_summary, sp.promise_summary, sp.proof_summary
+                FROM mois_sales_page_market_warmup_job j
+                JOIN mois_sales_page sp ON sp.id = j.sales_page_id
+                WHERE j.workspace_id = ? AND j.status = 'PENDING'
+                ORDER BY j.created_at ASC, j.id ASC
+                LIMIT 1
+                """, this::mapClaim, workspaceId);
+        return rows.stream().findFirst();
+    }
+
+    /**
+     * Marca um job pendente como reservado pelo worker informado.
+     */
+    @Override
+    public boolean claimPendingJob(long jobId, String workerId) {
+        int updated = jdbcTemplate.update("""
+                UPDATE mois_sales_page_market_warmup_job
+                SET status = 'FETCHING', claimed_by = ?, started_at = UTC_TIMESTAMP(), updated_at = UTC_TIMESTAMP()
+                WHERE id = ? AND status = 'PENDING'
+                """, workerId, jobId);
+        return updated > 0;
+    }
+
+    /**
+     * Busca um job pelo identificador operacional.
+     */
+    @Override
+    public Optional<MarketWarmupJobData> findJob(long jobId) {
+        List<MarketWarmupJobData> rows = jdbcTemplate.query("""
+                SELECT id, sales_page_id, workspace_id, status, created_at, error_category, error_message
+                FROM mois_sales_page_market_warmup_job
+                WHERE id = ?
+                LIMIT 1
+                """, this::mapJob, jobId);
+        return rows.stream().findFirst();
+    }
+
+    /**
+     * Remove fontes, sinais e resumo anteriores do job antes da gravação final idempotente.
+     */
+    @Override
+    public void deleteJobDetails(long jobId) {
+        jdbcTemplate.update("DELETE FROM mois_sales_page_market_warmup_signal WHERE job_id = ?", jobId);
+        jdbcTemplate.update("DELETE FROM mois_sales_page_market_warmup_source WHERE job_id = ?", jobId);
+        jdbcTemplate.update("DELETE FROM mois_sales_page_market_warmup_summary WHERE job_id = ?", jobId);
+    }
+
+    /**
+     * Insere uma fonte pública rastreável coletada pelo worker.
+     */
+    @Override
+    public long insertSource(long jobId, long pageId, String workspaceId, MoisSalesLibraryDtos.MarketWarmupSourceCompleteItem source) {
+        KeyHolder keyHolder = new GeneratedKeyHolder();
+        jdbcTemplate.update(connection -> {
+            PreparedStatement statement = connection.prepareStatement("""
+                    INSERT INTO mois_sales_page_market_warmup_source
+                    (job_id, sales_page_id, workspace_id, platform, source_type, source_url, source_title, author_name,
+                     published_at, last_activity_at, followers_or_subscribers, views_count, likes_count, comments_count,
+                     recency_score, engagement_score, evidence_summary, created_at, updated_at)
+                    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, UTC_TIMESTAMP(), UTC_TIMESTAMP())
+                    """, Statement.RETURN_GENERATED_KEYS);
+            statement.setLong(1, jobId);
+            statement.setLong(2, pageId);
+            statement.setString(3, workspaceId);
+            statement.setString(4, source.platform().name());
+            statement.setString(5, source.sourceType().name());
+            statement.setString(6, source.sourceUrl());
+            statement.setString(7, source.sourceTitle());
+            statement.setString(8, source.authorName());
+            statement.setTimestamp(9, toTimestamp(source.publishedAt()));
+            statement.setTimestamp(10, toTimestamp(source.lastActivityAt()));
+            statement.setObject(11, source.followersOrSubscribers());
+            statement.setObject(12, source.viewsCount());
+            statement.setObject(13, source.likesCount());
+            statement.setObject(14, source.commentsCount());
+            statement.setBigDecimal(15, source.recencyScore());
+            statement.setBigDecimal(16, source.engagementScore());
+            statement.setString(17, source.evidenceSummary());
+            return statement;
+        }, keyHolder);
+        Number key = keyHolder.getKey();
+        return key == null ? 0L : key.longValue();
+    }
+
+    /**
+     * Insere um sinal comercial vinculado à fonte pública correspondente.
+     */
+    @Override
+    public void insertSignal(long jobId, long pageId, String workspaceId, long sourceId, MoisSalesLibraryDtos.MarketWarmupSignalCompleteItem signal) {
+        jdbcTemplate.update("""
+                INSERT INTO mois_sales_page_market_warmup_signal
+                (job_id, source_id, sales_page_id, workspace_id, signal_type, signal_strength, signal_text, business_interpretation, created_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, UTC_TIMESTAMP())
+                """, jobId, sourceId, pageId, workspaceId, signal.signalType().name(), signal.signalStrength(), signal.signalText(), signal.businessInterpretation());
+    }
+
+    /**
+     * Insere o resumo final calculado para o job de aquecimento.
+     */
+    @Override
+    public void insertSummary(long jobId, long pageId, String workspaceId, MoisSalesLibraryDtos.MarketWarmupSummaryCompleteItem summary) {
+        jdbcTemplate.update("""
+                INSERT INTO mois_sales_page_market_warmup_summary
+                (job_id, sales_page_id, workspace_id, score_total, market_temperature, ecosystem_type, main_pains,
+                 main_objections, main_promises, main_channels, main_competitors, saturation_risk,
+                 opportunity_recommendation, next_experiment_suggestion, created_at, updated_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, UTC_TIMESTAMP(), UTC_TIMESTAMP())
+                """, jobId, pageId, workspaceId, summary.scoreTotal(), summary.marketTemperature().name(), summary.ecosystemType().name(),
+                joinLines(summary.mainPains()), joinLines(summary.mainObjections()), joinLines(summary.mainPromises()), joinLines(summary.mainChannels()),
+                joinLines(summary.mainCompetitors()), summary.saturationRisk(), summary.opportunityRecommendation(), summary.nextExperimentSuggestion());
+    }
+
+    /**
+     * Marca o job como concluído e replica os principais classificadores comerciais para busca rápida.
+     */
+    @Override
+    public void markJobDone(long jobId, MoisSalesLibraryDtos.MarketWarmupSummaryCompleteItem summary, Instant finishedAt) {
+        jdbcTemplate.update("""
+                UPDATE mois_sales_page_market_warmup_job
+                SET status = 'DONE', score_total = ?, market_temperature = ?, ecosystem_type = ?, recommendation = ?,
+                    finished_at = ?, error_category = NULL, error_message = NULL, updated_at = UTC_TIMESTAMP()
+                WHERE id = ?
+                """, summary.scoreTotal(), summary.marketTemperature().name(), summary.ecosystemType().name(), summary.recommendation().name(),
+                toTimestamp(finishedAt == null ? Instant.now() : finishedAt), jobId);
+    }
+
+    /**
+     * Marca o job como falho com categoria e mensagem operacional.
+     */
+    @Override
+    public boolean markJobFailed(long jobId, String errorCategory, String errorMessage) {
+        int updated = jdbcTemplate.update("""
+                UPDATE mois_sales_page_market_warmup_job
+                SET status = 'FAILED', error_category = ?, error_message = ?, finished_at = UTC_TIMESTAMP(), updated_at = UTC_TIMESTAMP()
+                WHERE id = ? AND status IN ('PENDING', 'FETCHING')
+                """, errorCategory, errorMessage, jobId);
+        return updated > 0;
+    }
+
+    /**
+     * Busca o resumo mais recente da página com os dados do job associado.
+     */
+    @Override
+    public Optional<MarketWarmupSummaryData> findLatestSummaryByPage(long pageId) {
+        List<MarketWarmupSummaryData> rows = jdbcTemplate.query("""
+                SELECT j.id AS job_id, j.sales_page_id, COALESCE(s.score_total, j.score_total) AS score_total,
+                       COALESCE(s.market_temperature, j.market_temperature) AS market_temperature,
+                       COALESCE(s.ecosystem_type, j.ecosystem_type) AS ecosystem_type,
+                       j.recommendation, s.main_pains, s.main_objections, s.main_promises, s.main_channels, s.main_competitors,
+                       s.saturation_risk, s.opportunity_recommendation, s.next_experiment_suggestion,
+                       j.status, j.error_category, j.error_message, COALESCE(s.created_at, j.created_at) AS created_at,
+                       COALESCE(s.updated_at, j.updated_at) AS updated_at
+                FROM mois_sales_page_market_warmup_job j
+                LEFT JOIN mois_sales_page_market_warmup_summary s ON s.job_id = j.id
+                WHERE j.sales_page_id = ?
+                ORDER BY j.created_at DESC, j.id DESC
+                LIMIT 1
+                """, this::mapSummary, pageId);
+        return rows.stream().findFirst();
+    }
+
+    /**
+     * Lista fontes públicas de um job de aquecimento.
+     */
+    @Override
+    public List<MoisSalesLibraryDtos.MarketWarmupSourceResponse> listSources(long jobId) {
+        return jdbcTemplate.query("""
+                SELECT id, job_id, sales_page_id, platform, source_type, source_url, source_title, author_name,
+                       published_at, last_activity_at, followers_or_subscribers, views_count, likes_count, comments_count,
+                       recency_score, engagement_score, evidence_summary, created_at, updated_at
+                FROM mois_sales_page_market_warmup_source
+                WHERE job_id = ?
+                ORDER BY last_activity_at DESC, created_at DESC, id DESC
+                """, this::mapSource, jobId);
+    }
+
+    /**
+     * Lista sinais comerciais extraídos de um job de aquecimento.
+     */
+    @Override
+    public List<MoisSalesLibraryDtos.MarketWarmupSignalResponse> listSignals(long jobId) {
+        return jdbcTemplate.query("""
+                SELECT id, job_id, source_id, sales_page_id, signal_type, signal_strength, signal_text, business_interpretation, created_at
+                FROM mois_sales_page_market_warmup_signal
+                WHERE job_id = ?
+                ORDER BY signal_strength DESC, created_at DESC, id DESC
+                """, this::mapSignal, jobId);
+    }
+
+    /**
+     * Converte uma linha de página consolidada em dados de entrada do aquecimento.
+     */
+    private SalesPageWarmupData mapSalesPage(ResultSet rs, int rowNum) throws SQLException {
+        return new SalesPageWarmupData(rs.getLong("id"), rs.getString("workspace_id"), rs.getString("url_canonical"), rs.getString("title"),
+                rs.getString("offer_summary"), rs.getString("mechanism_summary"), rs.getString("promise_summary"), rs.getString("proof_summary"));
+    }
+
+    /**
+     * Converte uma linha de job em estado operacional do aquecimento.
+     */
+    private MarketWarmupJobData mapJob(ResultSet rs, int rowNum) throws SQLException {
+        return new MarketWarmupJobData(rs.getLong("id"), rs.getLong("sales_page_id"), rs.getString("workspace_id"),
+                MoisSalesLibraryDtos.MarketWarmupJobStatus.valueOf(rs.getString("status")), toInstant(rs.getTimestamp("created_at")),
+                rs.getString("error_category"), rs.getString("error_message"));
+    }
+
+    /**
+     * Converte uma linha pendente em payload de claim do worker.
+     */
+    private MarketWarmupClaimData mapClaim(ResultSet rs, int rowNum) throws SQLException {
+        MarketWarmupJobData job = new MarketWarmupJobData(rs.getLong("job_id"), rs.getLong("sales_page_id"), rs.getString("workspace_id"),
+                MoisSalesLibraryDtos.MarketWarmupJobStatus.valueOf(rs.getString("status")), toInstant(rs.getTimestamp("created_at")),
+                rs.getString("error_category"), rs.getString("error_message"));
+        SalesPageWarmupData page = new SalesPageWarmupData(rs.getLong("sales_page_id"), rs.getString("workspace_id"), rs.getString("url_canonical"),
+                rs.getString("title"), rs.getString("offer_summary"), rs.getString("mechanism_summary"), rs.getString("promise_summary"), rs.getString("proof_summary"));
+        return new MarketWarmupClaimData(job, page);
+    }
+
+    /**
+     * Converte uma linha de resumo em resposta interna de persistência.
+     */
+    private MarketWarmupSummaryData mapSummary(ResultSet rs, int rowNum) throws SQLException {
+        String temperature = rs.getString("market_temperature");
+        String ecosystem = rs.getString("ecosystem_type");
+        String recommendation = rs.getString("recommendation");
+        return new MarketWarmupSummaryData(
+                rs.getLong("job_id"), rs.getLong("sales_page_id"), rs.getBigDecimal("score_total"),
+                temperature == null ? null : MoisSalesLibraryDtos.MarketWarmupTemperature.valueOf(temperature),
+                ecosystem == null ? null : MoisSalesLibraryDtos.MarketWarmupEcosystemType.valueOf(ecosystem),
+                recommendation == null ? null : MoisSalesLibraryDtos.MarketWarmupRecommendation.valueOf(recommendation),
+                rs.getString("main_pains"), rs.getString("main_objections"), rs.getString("main_promises"), rs.getString("main_channels"),
+                rs.getString("main_competitors"), rs.getString("saturation_risk"), rs.getString("opportunity_recommendation"),
+                rs.getString("next_experiment_suggestion"), MoisSalesLibraryDtos.MarketWarmupJobStatus.valueOf(rs.getString("status")),
+                rs.getString("error_category"), rs.getString("error_message"), toInstant(rs.getTimestamp("created_at")), toInstant(rs.getTimestamp("updated_at")));
+    }
+
+    /**
+     * Converte uma linha de fonte em contrato de leitura para revisão humana.
+     */
+    private MoisSalesLibraryDtos.MarketWarmupSourceResponse mapSource(ResultSet rs, int rowNum) throws SQLException {
+        return new MoisSalesLibraryDtos.MarketWarmupSourceResponse(
+                rs.getLong("id"), rs.getLong("job_id"), rs.getLong("sales_page_id"),
+                MoisSalesLibraryDtos.MarketWarmupPlatform.valueOf(rs.getString("platform")),
+                MoisSalesLibraryDtos.MarketWarmupSourceType.valueOf(rs.getString("source_type")),
+                rs.getString("source_url"), rs.getString("source_title"), rs.getString("author_name"),
+                toInstant(rs.getTimestamp("published_at")), toInstant(rs.getTimestamp("last_activity_at")),
+                rs.getObject("followers_or_subscribers", Long.class), rs.getObject("views_count", Long.class),
+                rs.getObject("likes_count", Long.class), rs.getObject("comments_count", Long.class),
+                rs.getBigDecimal("recency_score"), rs.getBigDecimal("engagement_score"), rs.getString("evidence_summary"),
+                toInstant(rs.getTimestamp("created_at")), toInstant(rs.getTimestamp("updated_at")));
+    }
+
+    /**
+     * Converte uma linha de sinal em contrato de leitura para explicação do score.
+     */
+    private MoisSalesLibraryDtos.MarketWarmupSignalResponse mapSignal(ResultSet rs, int rowNum) throws SQLException {
+        return new MoisSalesLibraryDtos.MarketWarmupSignalResponse(
+                rs.getLong("id"), rs.getLong("job_id"), rs.getLong("source_id"), rs.getLong("sales_page_id"),
+                MoisSalesLibraryDtos.MarketWarmupSignalType.valueOf(rs.getString("signal_type")), rs.getBigDecimal("signal_strength"),
+                rs.getString("signal_text"), rs.getString("business_interpretation"), toInstant(rs.getTimestamp("created_at")));
+    }
+
+    /**
+     * Converte listas funcionais em linhas de texto simples sem serializar JSON dentro de campos textuais.
+     */
+    private String joinLines(List<String> values) {
+        if (values == null || values.isEmpty()) {
+            return null;
+        }
+        return values.stream().filter(value -> value != null && !value.isBlank()).map(String::trim).reduce((left, right) -> left + "\n" + right).orElse(null);
+    }
+
+    /**
+     * Converte timestamp JDBC em Instant preservando nulo.
+     */
+    private Instant toInstant(Timestamp timestamp) {
+        return timestamp == null ? null : timestamp.toInstant();
+    }
+
+    /**
+     * Converte Instant em timestamp JDBC preservando nulo.
+     */
+    private Timestamp toTimestamp(Instant instant) {
+        return instant == null ? null : Timestamp.from(instant);
+    }
+}

--- a/backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesPageMarketWarmupServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesPageMarketWarmupServiceTest.java
@@ -1,0 +1,226 @@
+package com.marketinghub.mois.bibliotecapaginavenda.worker.v1.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+
+import com.marketinghub.mois.bibliotecapaginavenda.worker.v1.dto.MoisSalesLibraryDtos;
+import com.marketinghub.repository.jdbc.mois.bibliotecapaginavenda.worker.v1.MoisSalesPageMarketWarmupGateway;
+import com.marketinghub.repository.jdbc.mois.bibliotecapaginavenda.worker.v1.MoisSalesPageMarketWarmupGateway.MarketWarmupClaimData;
+import com.marketinghub.repository.jdbc.mois.bibliotecapaginavenda.worker.v1.MoisSalesPageMarketWarmupGateway.MarketWarmupJobData;
+import com.marketinghub.repository.jdbc.mois.bibliotecapaginavenda.worker.v1.MoisSalesPageMarketWarmupGateway.MarketWarmupSummaryData;
+import com.marketinghub.repository.jdbc.mois.bibliotecapaginavenda.worker.v1.MoisSalesPageMarketWarmupGateway.SalesPageWarmupData;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * Valida as regras de serviço da pesquisa de aquecimento de mercado da Biblioteca MOIS.
+ */
+@ExtendWith(MockitoExtension.class)
+class MoisSalesPageMarketWarmupServiceTest {
+
+    @Mock
+    private MoisSalesPageMarketWarmupGateway gateway;
+
+    @InjectMocks
+    private MoisSalesPageMarketWarmupService service;
+
+    /**
+     * Garante que solicitação duplicada reutiliza job pendente em vez de criar outro processamento.
+     */
+    @Test
+    void requestResearchReusesActiveJob() {
+        SalesPageWarmupData page = samplePage();
+        MarketWarmupJobData job = sampleJob(MoisSalesLibraryDtos.MarketWarmupJobStatus.PENDING);
+        given(gateway.findSalesPage(10L)).willReturn(Optional.of(page));
+        given(gateway.findActiveJobByPage(10L)).willReturn(Optional.of(job));
+
+        MoisSalesLibraryDtos.MarketWarmupRequestResponse response = service.requestResearch(10L);
+
+        assertThat(response.jobId()).isEqualTo(99L);
+        assertThat(response.status()).isEqualTo(MoisSalesLibraryDtos.MarketWarmupJobStatus.PENDING);
+        verify(gateway, never()).createPendingJob(page);
+    }
+
+    /**
+     * Garante que uma página sem job ativo recebe nova pesquisa pendente.
+     */
+    @Test
+    void requestResearchCreatesPendingJobWhenNoActiveJobExists() {
+        SalesPageWarmupData page = samplePage();
+        MarketWarmupJobData job = sampleJob(MoisSalesLibraryDtos.MarketWarmupJobStatus.PENDING);
+        given(gateway.findSalesPage(10L)).willReturn(Optional.of(page));
+        given(gateway.findActiveJobByPage(10L)).willReturn(Optional.empty());
+        given(gateway.createPendingJob(page)).willReturn(job);
+
+        MoisSalesLibraryDtos.MarketWarmupRequestResponse response = service.requestResearch(10L);
+
+        assertThat(response.pageId()).isEqualTo(10L);
+        assertThat(response.jobId()).isEqualTo(99L);
+        verify(gateway).createPendingJob(page);
+    }
+
+    /**
+     * Garante que o worker recebe os dados comerciais necessários ao reservar um job pendente.
+     */
+    @Test
+    void claimJobReturnsCommercialContextWhenPendingJobIsClaimed() {
+        SalesPageWarmupData page = samplePage();
+        MarketWarmupJobData job = sampleJob(MoisSalesLibraryDtos.MarketWarmupJobStatus.PENDING);
+        given(gateway.findNextPendingJob("workspace-001")).willReturn(Optional.of(new MarketWarmupClaimData(job, page)));
+        given(gateway.claimPendingJob(99L, "worker-1")).willReturn(true);
+
+        MoisSalesLibraryDtos.MarketWarmupClaimResponse response = service.claimJob(
+                new MoisSalesLibraryDtos.MarketWarmupClaimRequest("workspace-001", "worker-1"));
+
+        assertThat(response.claimed()).isTrue();
+        assertThat(response.job().pageId()).isEqualTo(10L);
+        assertThat(response.job().offerSummary()).isEqualTo("Oferta transforma dor em resultado");
+    }
+
+    /**
+     * Garante que conclusão grava fontes, sinais, resumo e estado final em uma única orquestração.
+     */
+    @Test
+    void completeJobPersistsSourcesSignalsSummaryAndDoneStatus() {
+        MarketWarmupJobData job = sampleJob(MoisSalesLibraryDtos.MarketWarmupJobStatus.FETCHING);
+        MoisSalesLibraryDtos.MarketWarmupSourceCompleteItem source = sampleSource();
+        MoisSalesLibraryDtos.MarketWarmupSignalCompleteItem signal = new MoisSalesLibraryDtos.MarketWarmupSignalCompleteItem(
+                0, MoisSalesLibraryDtos.MarketWarmupSignalType.PAIN_EXPLICIT, BigDecimal.valueOf(8.5), "dor explícita", "alta urgência");
+        MoisSalesLibraryDtos.MarketWarmupSummaryCompleteItem summary = sampleSummary();
+        given(gateway.findJob(99L)).willReturn(Optional.of(job));
+        given(gateway.insertSource(99L, 10L, "workspace-001", source)).willReturn(501L);
+
+        service.completeJob(99L, new MoisSalesLibraryDtos.MarketWarmupCompleteRequest(
+                List.of(source), List.of(signal), summary, Instant.parse("2026-06-10T10:00:00Z")));
+
+        verify(gateway).deleteJobDetails(99L);
+        verify(gateway).insertSignal(99L, 10L, "workspace-001", 501L, signal);
+        verify(gateway).insertSummary(99L, 10L, "workspace-001", summary);
+        verify(gateway).markJobDone(99L, summary, Instant.parse("2026-06-10T10:00:00Z"));
+    }
+
+    /**
+     * Garante que sinais com índice de fonte inválido não contaminam a conclusão do job.
+     */
+    @Test
+    void completeJobRejectsSignalWithInvalidSourceIndex() {
+        MarketWarmupJobData job = sampleJob(MoisSalesLibraryDtos.MarketWarmupJobStatus.FETCHING);
+        MoisSalesLibraryDtos.MarketWarmupSourceCompleteItem source = sampleSource();
+        MoisSalesLibraryDtos.MarketWarmupSignalCompleteItem signal = new MoisSalesLibraryDtos.MarketWarmupSignalCompleteItem(
+                2, MoisSalesLibraryDtos.MarketWarmupSignalType.OBJECTION, BigDecimal.ONE, "objeção", null);
+        given(gateway.findJob(99L)).willReturn(Optional.of(job));
+        given(gateway.insertSource(99L, 10L, "workspace-001", source)).willReturn(501L);
+
+        assertThatThrownBy(() -> service.completeJob(99L, new MoisSalesLibraryDtos.MarketWarmupCompleteRequest(
+                List.of(source), List.of(signal), sampleSummary(), Instant.parse("2026-06-10T10:00:00Z"))))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Índice de fonte inválido");
+
+        verify(gateway, never()).markJobDone(org.mockito.ArgumentMatchers.anyLong(), org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any());
+    }
+
+    /**
+     * Garante que o resumo lido converte listas em linhas funcionais sem depender de JSON em texto.
+     */
+    @Test
+    void getSummarySplitsFunctionalTextLinesIntoLists() {
+        given(gateway.findLatestSummaryByPage(10L)).willReturn(Optional.of(new MarketWarmupSummaryData(
+                99L,
+                10L,
+                BigDecimal.valueOf(82),
+                MoisSalesLibraryDtos.MarketWarmupTemperature.HOT,
+                MoisSalesLibraryDtos.MarketWarmupEcosystemType.CREATORS_HEATED,
+                MoisSalesLibraryDtos.MarketWarmupRecommendation.PRIORITIZE,
+                "dor 1\ndor 2",
+                "objeção 1",
+                "promessa 1\npromessa 2",
+                "YouTube\nBlog",
+                "Concorrente A",
+                "baixo",
+                "priorizar experimento",
+                "ângulo inicial",
+                MoisSalesLibraryDtos.MarketWarmupJobStatus.DONE,
+                null,
+                null,
+                Instant.parse("2026-06-10T09:00:00Z"),
+                Instant.parse("2026-06-10T10:00:00Z"))));
+
+        MoisSalesLibraryDtos.MarketWarmupSummaryResponse response = service.getSummary(10L);
+
+        assertThat(response.mainPains()).containsExactly("dor 1", "dor 2");
+        assertThat(response.mainChannels()).containsExactly("YouTube", "Blog");
+        assertThat(response.recommendation()).isEqualTo(MoisSalesLibraryDtos.MarketWarmupRecommendation.PRIORITIZE);
+    }
+
+    /**
+     * Monta uma página consolidada com os campos comerciais necessários ao aquecimento.
+     */
+    private SalesPageWarmupData samplePage() {
+        return new SalesPageWarmupData(
+                10L,
+                "workspace-001",
+                "https://example.test/oferta",
+                "Oferta principal",
+                "Oferta transforma dor em resultado",
+                "Mecanismo plausível",
+                "Promessa clara",
+                "Prova social");
+    }
+
+    /**
+     * Monta um job de aquecimento com status controlado pelo cenário de teste.
+     */
+    private MarketWarmupJobData sampleJob(MoisSalesLibraryDtos.MarketWarmupJobStatus status) {
+        return new MarketWarmupJobData(99L, 10L, "workspace-001", status, Instant.parse("2026-06-10T09:00:00Z"), null, null);
+    }
+
+    /**
+     * Monta uma fonte pública mínima válida para conclusão do aquecimento.
+     */
+    private MoisSalesLibraryDtos.MarketWarmupSourceCompleteItem sampleSource() {
+        return new MoisSalesLibraryDtos.MarketWarmupSourceCompleteItem(
+                MoisSalesLibraryDtos.MarketWarmupPlatform.YOUTUBE,
+                MoisSalesLibraryDtos.MarketWarmupSourceType.CREATOR_CONTENT,
+                "https://youtube.com/watch?v=abc",
+                "Vídeo sobre a dor",
+                "Creator",
+                Instant.parse("2026-06-01T00:00:00Z"),
+                Instant.parse("2026-06-09T00:00:00Z"),
+                10_000L,
+                5_000L,
+                300L,
+                80L,
+                BigDecimal.valueOf(9),
+                BigDecimal.valueOf(8),
+                "Comentários recentes mostram dor explícita");
+    }
+
+    /**
+     * Monta o resumo final mínimo calculado pelo worker.
+     */
+    private MoisSalesLibraryDtos.MarketWarmupSummaryCompleteItem sampleSummary() {
+        return new MoisSalesLibraryDtos.MarketWarmupSummaryCompleteItem(
+                BigDecimal.valueOf(82),
+                MoisSalesLibraryDtos.MarketWarmupTemperature.HOT,
+                MoisSalesLibraryDtos.MarketWarmupEcosystemType.CREATORS_HEATED,
+                MoisSalesLibraryDtos.MarketWarmupRecommendation.PRIORITIZE,
+                List.of("dor explícita"),
+                List.of("preço"),
+                List.of("resultado rápido"),
+                List.of("YouTube"),
+                List.of("Concorrente A"),
+                "baixo",
+                "priorizar experimento",
+                "testar criativo com dor explícita");
+    }
+}

--- a/docs/registros/mois1.md
+++ b/docs/registros/mois1.md
@@ -1240,3 +1240,16 @@ Arquivos alterados:
 
 - `docs/swagger/mois-sales-library-swagger.yaml`
 - `docs/registros/mois1.md`
+
+## 2026-06-10 — Fase 4 da Etapa 3 de aquecimento de mercado
+
+- Implementado o service de responsabilidade única para orquestrar a pesquisa de aquecimento da Biblioteca de Páginas de Vendas MOIS, cobrindo solicitação, consulta de resumo, fontes, sinais, claim interno, conclusão e falha de jobs.
+- Centralizada a persistência JDBC da etapa no pacote permitido `com.marketinghub.repository`, mantendo o backend como único ponto de acesso ao banco.
+- Adicionados testes unitários do service para proteger reutilização de job ativo, claim do worker, persistência de fontes/sinais/resumo, validação de índice de fonte e leitura de listas funcionais sem JSON serializado em texto.
+
+Arquivos alterados:
+- `backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesPageMarketWarmupService.java`
+- `backend/ads-service/src/main/java/com/marketinghub/repository/jdbc/mois/bibliotecapaginavenda/worker/v1/MoisSalesPageMarketWarmupGateway.java`
+- `backend/ads-service/src/main/java/com/marketinghub/repository/jdbc/mois/bibliotecapaginavenda/worker/v1/MoisSalesPageMarketWarmupRepository.java`
+- `backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesPageMarketWarmupServiceTest.java`
+- `docs/registros/mois1.md`


### PR DESCRIPTION
### Motivation
- Add the Phase 4 backend orchestration for the MOIS "Pesquisa de Aquecimento e Ecossistema de Mercado" to turn page analyses into explainable market warm-up dossiers. 
- Keep database access centralized in the backend repository layer and avoid JSON-in-text payloads in final contract fields.

### Description
- New service `MoisSalesPageMarketWarmupService` implements request/reuse of jobs, summary lookup, sources/signals listing, worker `claim`, `complete` and `fail` flows with contextual logging and input validation. 
- Introduced gateway contract `MoisSalesPageMarketWarmupGateway` under `com.marketinghub.repository.jdbc...` and a JDBC implementation `MoisSalesPageMarketWarmupRepository` that performs all SQL persistence for jobs, sources, signals and summaries; list fields are stored as line-separated text (no JSON-in-text). 
- Added DTO usage (existing `MoisSalesLibraryDtos`) for API contracts and adapter mapping between DB rows and API records. 
- Added unit tests `MoisSalesPageMarketWarmupServiceTest` covering job reuse, pending job creation, worker claim, complete flow (sources/signals/summary persistence), invalid source-index validation and summary line-splitting. 
- Documented the work in `docs/registros/mois1.md` (Fase 4 entry) and kept package organization aligned with backend conventions.

### Testing
- Ran the service unit tests with Maven: `mvn -Dtest=MoisSalesPageMarketWarmupServiceTest test` using Java 21 after resolving a local compiler/annotation-processor issue; the targeted tests passed. 
- Ran an expanded test set: `mvn -Dtest='MoisSalesPageMarketWarmupServiceTest,MoisSalesLibraryServiceTest,MoisSalesPageSchemaChangelogTest' test`; these tests executed successfully. 
- Verified compilation with `mvn -DskipTests compile` under Java 21 to ensure build correctness; compilation succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a28ae832438832081f6bca9aed6c2ce)