### PR TITLE
Corrige isolamento arquitetural do aquecimento MOIS

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesPageMarketWarmupService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesPageMarketWarmupService.java
@@ -1,11 +1,15 @@
 package com.marketinghub.mois.bibliotecapaginavenda.worker.v1.service;
 
 import com.marketinghub.mois.bibliotecapaginavenda.worker.v1.dto.MoisSalesLibraryDtos;
-import com.marketinghub.repository.jdbc.mois.bibliotecapaginavenda.worker.v1.MoisSalesPageMarketWarmupGateway;
-import com.marketinghub.repository.jdbc.mois.bibliotecapaginavenda.worker.v1.MoisSalesPageMarketWarmupGateway.MarketWarmupClaimData;
-import com.marketinghub.repository.jdbc.mois.bibliotecapaginavenda.worker.v1.MoisSalesPageMarketWarmupGateway.MarketWarmupJobData;
-import com.marketinghub.repository.jdbc.mois.bibliotecapaginavenda.worker.v1.MoisSalesPageMarketWarmupGateway.MarketWarmupSummaryData;
-import com.marketinghub.repository.jdbc.mois.bibliotecapaginavenda.worker.v1.MoisSalesPageMarketWarmupGateway.SalesPageWarmupData;
+import com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1.MoisSalesPageMarketWarmupGateway;
+import com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1.MoisSalesPageMarketWarmupGateway.MarketWarmupClaimData;
+import com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1.MoisSalesPageMarketWarmupGateway.MarketWarmupJobData;
+import com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1.MoisSalesPageMarketWarmupGateway.MarketWarmupSignalData;
+import com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1.MoisSalesPageMarketWarmupGateway.MarketWarmupSignalReadData;
+import com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1.MoisSalesPageMarketWarmupGateway.MarketWarmupSourceData;
+import com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1.MoisSalesPageMarketWarmupGateway.MarketWarmupSummaryData;
+import com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1.MoisSalesPageMarketWarmupGateway.MarketWarmupSummaryWriteData;
+import com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1.MoisSalesPageMarketWarmupGateway.SalesPageWarmupData;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -34,8 +38,8 @@ public class MoisSalesPageMarketWarmupService {
                     .orElseThrow(() -> new IllegalArgumentException("Página MOIS não encontrada para aquecimento: " + pageId));
             MarketWarmupJobData job = gateway.findActiveJobByPage(pageId).orElseGet(() -> gateway.createPendingJob(page));
             log.info("Pesquisa de aquecimento MOIS solicitada. modulo=MOIS, operacao=requestMarketWarmup, pageId={}, jobId={}, status={}",
-                    pageId, job.jobId(), job.status());
-            return new MoisSalesLibraryDtos.MarketWarmupRequestResponse(pageId, job.jobId(), job.status(), job.createdAt());
+                    pageId, job.jobId(), mapJobStatus(job.status()));
+            return new MoisSalesLibraryDtos.MarketWarmupRequestResponse(pageId, job.jobId(), mapJobStatus(job.status()), job.createdAt());
         } catch (RuntimeException ex) {
             log.error("Falha ao solicitar pesquisa de aquecimento MOIS. modulo=MOIS, operacao=requestMarketWarmup, pageId={}, erroClasse={}, erro={}",
                     pageId, ex.getClass().getName(), ex.getMessage(), ex);
@@ -65,7 +69,7 @@ public class MoisSalesPageMarketWarmupService {
         try {
             MarketWarmupJobData job = gateway.findLatestJobByPage(pageId)
                     .orElseThrow(() -> new IllegalArgumentException("Pesquisa de aquecimento não encontrada para página: " + pageId));
-            return new MoisSalesLibraryDtos.MarketWarmupSourceListResponse(pageId, job.jobId(), gateway.listSources(job.jobId()));
+            return new MoisSalesLibraryDtos.MarketWarmupSourceListResponse(pageId, job.jobId(), gateway.listSources(job.jobId()).stream().map(this::mapSource).toList());
         } catch (RuntimeException ex) {
             log.error("Falha ao listar fontes de aquecimento MOIS. modulo=MOIS, operacao=listMarketWarmupSources, pageId={}, erroClasse={}, erro={}",
                     pageId, ex.getClass().getName(), ex.getMessage(), ex);
@@ -80,7 +84,7 @@ public class MoisSalesPageMarketWarmupService {
         try {
             MarketWarmupJobData job = gateway.findLatestJobByPage(pageId)
                     .orElseThrow(() -> new IllegalArgumentException("Pesquisa de aquecimento não encontrada para página: " + pageId));
-            return new MoisSalesLibraryDtos.MarketWarmupSignalListResponse(pageId, job.jobId(), gateway.listSignals(job.jobId()));
+            return new MoisSalesLibraryDtos.MarketWarmupSignalListResponse(pageId, job.jobId(), gateway.listSignals(job.jobId()).stream().map(this::mapSignal).toList());
         } catch (RuntimeException ex) {
             log.error("Falha ao listar sinais de aquecimento MOIS. modulo=MOIS, operacao=listMarketWarmupSignals, pageId={}, erroClasse={}, erro={}",
                     pageId, ex.getClass().getName(), ex.getMessage(), ex);
@@ -124,14 +128,15 @@ public class MoisSalesPageMarketWarmupService {
         try {
             MarketWarmupJobData job = gateway.findJob(jobId)
                     .orElseThrow(() -> new IllegalArgumentException("Job de aquecimento não encontrado: " + jobId));
-            if (job.status() == MoisSalesLibraryDtos.MarketWarmupJobStatus.DONE) {
+            if (mapJobStatus(job.status()) == MoisSalesLibraryDtos.MarketWarmupJobStatus.DONE) {
                 throw new IllegalStateException("Job de aquecimento já concluído: " + jobId);
             }
             gateway.deleteJobDetails(jobId);
             List<Long> sourceIds = persistSources(job, request.sources());
             persistSignals(job, sourceIds, request.signals());
-            gateway.insertSummary(jobId, job.pageId(), job.workspaceId(), request.summary());
-            gateway.markJobDone(jobId, request.summary(), request.finishedAt());
+            MarketWarmupSummaryWriteData summary = mapSummaryWrite(request.summary());
+            gateway.insertSummary(jobId, job.pageId(), job.workspaceId(), summary);
+            gateway.markJobDone(jobId, summary, request.finishedAt());
             log.info("Job de aquecimento MOIS concluído. modulo=MOIS, operacao=completeMarketWarmupJob, workspaceId={}, pageId={}, jobId={}, fontes={}, sinais={}, score={}",
                     job.workspaceId(), job.pageId(), jobId, request.sources().size(), request.signals().size(), request.summary().scoreTotal());
         } catch (RuntimeException ex) {
@@ -166,7 +171,7 @@ public class MoisSalesPageMarketWarmupService {
     private List<Long> persistSources(MarketWarmupJobData job, List<MoisSalesLibraryDtos.MarketWarmupSourceCompleteItem> sources) {
         List<Long> sourceIds = new ArrayList<>();
         for (MoisSalesLibraryDtos.MarketWarmupSourceCompleteItem source : sources) {
-            sourceIds.add(gateway.insertSource(job.jobId(), job.pageId(), job.workspaceId(), source));
+            sourceIds.add(gateway.insertSource(job.jobId(), job.pageId(), job.workspaceId(), mapSourceWrite(source)));
         }
         return sourceIds;
     }
@@ -179,7 +184,7 @@ public class MoisSalesPageMarketWarmupService {
             if (signal.sourceIndex() < 0 || signal.sourceIndex() >= sourceIds.size()) {
                 throw new IllegalArgumentException("Índice de fonte inválido para sinal de aquecimento: " + signal.sourceIndex());
             }
-            gateway.insertSignal(job.jobId(), job.pageId(), job.workspaceId(), sourceIds.get(signal.sourceIndex()), signal);
+            gateway.insertSignal(job.jobId(), job.pageId(), job.workspaceId(), sourceIds.get(signal.sourceIndex()), mapSignalWrite(signal));
         }
     }
 
@@ -188,10 +193,103 @@ public class MoisSalesPageMarketWarmupService {
      */
     private MoisSalesLibraryDtos.MarketWarmupSummaryResponse mapSummary(MarketWarmupSummaryData summary) {
         return new MoisSalesLibraryDtos.MarketWarmupSummaryResponse(
-                summary.jobId(), summary.pageId(), summary.scoreTotal(), summary.marketTemperature(), summary.ecosystemType(), summary.recommendation(),
-                splitLines(summary.mainPains()), splitLines(summary.mainObjections()), splitLines(summary.mainPromises()), splitLines(summary.mainChannels()),
-                splitLines(summary.mainCompetitors()), summary.saturationRisk(), summary.opportunityRecommendation(), summary.nextExperimentSuggestion(),
-                summary.status(), summary.errorCategory(), summary.errorMessage(), summary.createdAt(), summary.updatedAt());
+                summary.jobId(), summary.pageId(), summary.scoreTotal(), mapTemperature(summary.marketTemperature()), mapEcosystem(summary.ecosystemType()),
+                mapRecommendation(summary.recommendation()), splitLines(summary.mainPains()), splitLines(summary.mainObjections()), splitLines(summary.mainPromises()),
+                splitLines(summary.mainChannels()), splitLines(summary.mainCompetitors()), summary.saturationRisk(), summary.opportunityRecommendation(), summary.nextExperimentSuggestion(),
+                mapJobStatus(summary.status()), summary.errorCategory(), summary.errorMessage(), summary.createdAt(), summary.updatedAt());
+    }
+
+    /**
+     * Converte uma fonte persistida em contrato de leitura da API.
+     */
+    private MoisSalesLibraryDtos.MarketWarmupSourceResponse mapSource(MarketWarmupSourceData source) {
+        return new MoisSalesLibraryDtos.MarketWarmupSourceResponse(
+                source.sourceId(), source.jobId(), source.pageId(), mapPlatform(source.platform()), mapSourceType(source.sourceType()), source.sourceUrl(),
+                source.sourceTitle(), source.authorName(), source.publishedAt(), source.lastActivityAt(), source.followersOrSubscribers(), source.viewsCount(),
+                source.likesCount(), source.commentsCount(), source.recencyScore(), source.engagementScore(), source.evidenceSummary(), source.createdAt(), source.updatedAt());
+    }
+
+    /**
+     * Converte um sinal persistido em contrato de leitura da API.
+     */
+    private MoisSalesLibraryDtos.MarketWarmupSignalResponse mapSignal(MarketWarmupSignalReadData signal) {
+        return new MoisSalesLibraryDtos.MarketWarmupSignalResponse(
+                signal.signalId(), signal.jobId(), signal.sourceId(), signal.pageId(), mapSignalType(signal.signalType()), signal.signalStrength(),
+                signal.signalText(), signal.businessInterpretation(), signal.createdAt());
+    }
+
+    /**
+     * Converte uma fonte recebida da API em dados desacoplados de persistência.
+     */
+    private MarketWarmupSourceData mapSourceWrite(MoisSalesLibraryDtos.MarketWarmupSourceCompleteItem source) {
+        return new MarketWarmupSourceData(null, null, null, source.platform().name(), source.sourceType().name(), source.sourceUrl(), source.sourceTitle(),
+                source.authorName(), source.publishedAt(), source.lastActivityAt(), source.followersOrSubscribers(), source.viewsCount(), source.likesCount(),
+                source.commentsCount(), source.recencyScore(), source.engagementScore(), source.evidenceSummary(), null, null);
+    }
+
+    /**
+     * Converte um sinal recebido da API em dados desacoplados de persistência.
+     */
+    private MarketWarmupSignalData mapSignalWrite(MoisSalesLibraryDtos.MarketWarmupSignalCompleteItem signal) {
+        return new MarketWarmupSignalData(signal.signalType().name(), signal.signalStrength(), signal.signalText(), signal.businessInterpretation());
+    }
+
+    /**
+     * Converte o resumo recebido da API em dados desacoplados de persistência.
+     */
+    private MarketWarmupSummaryWriteData mapSummaryWrite(MoisSalesLibraryDtos.MarketWarmupSummaryCompleteItem summary) {
+        return new MarketWarmupSummaryWriteData(summary.scoreTotal(), summary.marketTemperature().name(), summary.ecosystemType().name(), summary.recommendation().name(),
+                summary.mainPains(), summary.mainObjections(), summary.mainPromises(), summary.mainChannels(), summary.mainCompetitors(), summary.saturationRisk(),
+                summary.opportunityRecommendation(), summary.nextExperimentSuggestion());
+    }
+
+    /**
+     * Converte status textual da persistência para o enum público do módulo.
+     */
+    private MoisSalesLibraryDtos.MarketWarmupJobStatus mapJobStatus(String status) {
+        return status == null ? null : MoisSalesLibraryDtos.MarketWarmupJobStatus.valueOf(status);
+    }
+
+    /**
+     * Converte temperatura textual da persistência para o enum público do módulo.
+     */
+    private MoisSalesLibraryDtos.MarketWarmupTemperature mapTemperature(String temperature) {
+        return temperature == null ? null : MoisSalesLibraryDtos.MarketWarmupTemperature.valueOf(temperature);
+    }
+
+    /**
+     * Converte ecossistema textual da persistência para o enum público do módulo.
+     */
+    private MoisSalesLibraryDtos.MarketWarmupEcosystemType mapEcosystem(String ecosystem) {
+        return ecosystem == null ? null : MoisSalesLibraryDtos.MarketWarmupEcosystemType.valueOf(ecosystem);
+    }
+
+    /**
+     * Converte recomendação textual da persistência para o enum público do módulo.
+     */
+    private MoisSalesLibraryDtos.MarketWarmupRecommendation mapRecommendation(String recommendation) {
+        return recommendation == null ? null : MoisSalesLibraryDtos.MarketWarmupRecommendation.valueOf(recommendation);
+    }
+
+    /**
+     * Converte plataforma textual da persistência para o enum público do módulo.
+     */
+    private MoisSalesLibraryDtos.MarketWarmupPlatform mapPlatform(String platform) {
+        return platform == null ? null : MoisSalesLibraryDtos.MarketWarmupPlatform.valueOf(platform);
+    }
+
+    /**
+     * Converte tipo de fonte textual da persistência para o enum público do módulo.
+     */
+    private MoisSalesLibraryDtos.MarketWarmupSourceType mapSourceType(String sourceType) {
+        return sourceType == null ? null : MoisSalesLibraryDtos.MarketWarmupSourceType.valueOf(sourceType);
+    }
+
+    /**
+     * Converte tipo de sinal textual da persistência para o enum público do módulo.
+     */
+    private MoisSalesLibraryDtos.MarketWarmupSignalType mapSignalType(String signalType) {
+        return signalType == null ? null : MoisSalesLibraryDtos.MarketWarmupSignalType.valueOf(signalType);
     }
 
     /**

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/mois/bibliotecapaginavenda/worker/v1/MoisSalesPageMarketWarmupGateway.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/mois/bibliotecapaginavenda/worker/v1/MoisSalesPageMarketWarmupGateway.java
@@ -1,6 +1,6 @@
-package com.marketinghub.repository.jdbc.mois.bibliotecapaginavenda.worker.v1;
+package com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1;
 
-import com.marketinghub.mois.bibliotecapaginavenda.worker.v1.dto.MoisSalesLibraryDtos;
+import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
@@ -53,22 +53,22 @@ public interface MoisSalesPageMarketWarmupGateway {
     /**
      * Insere uma fonte pública rastreável coletada pelo worker.
      */
-    long insertSource(long jobId, long pageId, String workspaceId, MoisSalesLibraryDtos.MarketWarmupSourceCompleteItem source);
+    long insertSource(long jobId, long pageId, String workspaceId, MarketWarmupSourceData source);
 
     /**
      * Insere um sinal comercial vinculado à fonte pública correspondente.
      */
-    void insertSignal(long jobId, long pageId, String workspaceId, long sourceId, MoisSalesLibraryDtos.MarketWarmupSignalCompleteItem signal);
+    void insertSignal(long jobId, long pageId, String workspaceId, long sourceId, MarketWarmupSignalData signal);
 
     /**
      * Insere o resumo final calculado para o job de aquecimento.
      */
-    void insertSummary(long jobId, long pageId, String workspaceId, MoisSalesLibraryDtos.MarketWarmupSummaryCompleteItem summary);
+    void insertSummary(long jobId, long pageId, String workspaceId, MarketWarmupSummaryWriteData summary);
 
     /**
      * Marca o job como concluído e replica os principais classificadores comerciais para busca rápida.
      */
-    void markJobDone(long jobId, MoisSalesLibraryDtos.MarketWarmupSummaryCompleteItem summary, Instant finishedAt);
+    void markJobDone(long jobId, MarketWarmupSummaryWriteData summary, Instant finishedAt);
 
     /**
      * Marca o job como falho com categoria e mensagem operacional.
@@ -83,12 +83,12 @@ public interface MoisSalesPageMarketWarmupGateway {
     /**
      * Lista fontes públicas de um job de aquecimento.
      */
-    List<MoisSalesLibraryDtos.MarketWarmupSourceResponse> listSources(long jobId);
+    List<MarketWarmupSourceData> listSources(long jobId);
 
     /**
      * Lista sinais comerciais extraídos de um job de aquecimento.
      */
-    List<MoisSalesLibraryDtos.MarketWarmupSignalResponse> listSignals(long jobId);
+    List<MarketWarmupSignalReadData> listSignals(long jobId);
 
     /**
      * Representa os dados comerciais da página necessários para iniciar a etapa de aquecimento.
@@ -112,7 +112,7 @@ public interface MoisSalesPageMarketWarmupGateway {
             long jobId,
             long pageId,
             String workspaceId,
-            MoisSalesLibraryDtos.MarketWarmupJobStatus status,
+            String status,
             Instant createdAt,
             String errorCategory,
             String errorMessage
@@ -129,15 +129,87 @@ public interface MoisSalesPageMarketWarmupGateway {
     }
 
     /**
+     * Representa uma fonte pública gravada ou lida pela camada de persistência.
+     */
+    record MarketWarmupSourceData(
+            Long sourceId,
+            Long jobId,
+            Long pageId,
+            String platform,
+            String sourceType,
+            String sourceUrl,
+            String sourceTitle,
+            String authorName,
+            Instant publishedAt,
+            Instant lastActivityAt,
+            Long followersOrSubscribers,
+            Long viewsCount,
+            Long likesCount,
+            Long commentsCount,
+            BigDecimal recencyScore,
+            BigDecimal engagementScore,
+            String evidenceSummary,
+            Instant createdAt,
+            Instant updatedAt
+    ) {
+    }
+
+    /**
+     * Representa um sinal comercial enviado para persistência final.
+     */
+    record MarketWarmupSignalData(
+            String signalType,
+            BigDecimal signalStrength,
+            String signalText,
+            String businessInterpretation
+    ) {
+    }
+
+    /**
+     * Representa um sinal comercial lido da persistência para resposta funcional.
+     */
+    record MarketWarmupSignalReadData(
+            long signalId,
+            long jobId,
+            long sourceId,
+            long pageId,
+            String signalType,
+            BigDecimal signalStrength,
+            String signalText,
+            String businessInterpretation,
+            Instant createdAt
+    ) {
+    }
+
+    /**
+     * Representa o resumo calculado enviado para persistência final.
+     */
+    record MarketWarmupSummaryWriteData(
+            BigDecimal scoreTotal,
+            String marketTemperature,
+            String ecosystemType,
+            String recommendation,
+            List<String> mainPains,
+            List<String> mainObjections,
+            List<String> mainPromises,
+            List<String> mainChannels,
+            List<String> mainCompetitors,
+            String saturationRisk,
+            String opportunityRecommendation,
+            String nextExperimentSuggestion
+    ) {
+    }
+
+    /**
      * Representa o resumo final da pesquisa junto com o estado do job que o produziu.
      */
     record MarketWarmupSummaryData(
             long jobId,
             long pageId,
-            java.math.BigDecimal scoreTotal,
-            MoisSalesLibraryDtos.MarketWarmupTemperature marketTemperature,
-            MoisSalesLibraryDtos.MarketWarmupEcosystemType ecosystemType,
-            MoisSalesLibraryDtos.MarketWarmupRecommendation recommendation,
+            BigDecimal scoreTotal,
+            String marketTemperature,
+            String ecosystemType,
+            String recommendation,
             String mainPains,
             String mainObjections,
             String mainPromises,
@@ -146,7 +218,7 @@ public interface MoisSalesPageMarketWarmupGateway {
             String saturationRisk,
             String opportunityRecommendation,
             String nextExperimentSuggestion,
-            MoisSalesLibraryDtos.MarketWarmupJobStatus status,
+            String status,
             String errorCategory,
             String errorMessage,
             Instant createdAt,

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/mois/bibliotecapaginavenda/worker/v1/MoisSalesPageMarketWarmupRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/mois/bibliotecapaginavenda/worker/v1/MoisSalesPageMarketWarmupRepository.java
@@ -1,6 +1,5 @@
-package com.marketinghub.repository.jdbc.mois.bibliotecapaginavenda.worker.v1;
+package com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1;
 
-import com.marketinghub.mois.bibliotecapaginavenda.worker.v1.dto.MoisSalesLibraryDtos;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;
@@ -72,7 +71,7 @@ public class MoisSalesPageMarketWarmupRepository implements MoisSalesPageMarketW
         Number key = keyHolder.getKey();
         long jobId = key == null ? 0L : key.longValue();
         return findJob(jobId).orElseGet(() -> new MarketWarmupJobData(
-                jobId, page.pageId(), page.workspaceId(), MoisSalesLibraryDtos.MarketWarmupJobStatus.PENDING, Instant.now(), null, null));
+                jobId, page.pageId(), page.workspaceId(), "PENDING", Instant.now(), null, null));
     }
 
     /**
@@ -148,7 +147,7 @@ public class MoisSalesPageMarketWarmupRepository implements MoisSalesPageMarketW
      * Insere uma fonte pública rastreável coletada pelo worker.
      */
     @Override
-    public long insertSource(long jobId, long pageId, String workspaceId, MoisSalesLibraryDtos.MarketWarmupSourceCompleteItem source) {
+    public long insertSource(long jobId, long pageId, String workspaceId, MarketWarmupSourceData source) {
         KeyHolder keyHolder = new GeneratedKeyHolder();
         jdbcTemplate.update(connection -> {
             PreparedStatement statement = connection.prepareStatement("""
@@ -161,8 +160,8 @@ public class MoisSalesPageMarketWarmupRepository implements MoisSalesPageMarketW
             statement.setLong(1, jobId);
             statement.setLong(2, pageId);
             statement.setString(3, workspaceId);
-            statement.setString(4, source.platform().name());
-            statement.setString(5, source.sourceType().name());
+            statement.setString(4, source.platform());
+            statement.setString(5, source.sourceType());
             statement.setString(6, source.sourceUrl());
             statement.setString(7, source.sourceTitle());
             statement.setString(8, source.authorName());
@@ -185,26 +184,26 @@ public class MoisSalesPageMarketWarmupRepository implements MoisSalesPageMarketW
      * Insere um sinal comercial vinculado à fonte pública correspondente.
      */
     @Override
-    public void insertSignal(long jobId, long pageId, String workspaceId, long sourceId, MoisSalesLibraryDtos.MarketWarmupSignalCompleteItem signal) {
+    public void insertSignal(long jobId, long pageId, String workspaceId, long sourceId, MarketWarmupSignalData signal) {
         jdbcTemplate.update("""
                 INSERT INTO mois_sales_page_market_warmup_signal
                 (job_id, source_id, sales_page_id, workspace_id, signal_type, signal_strength, signal_text, business_interpretation, created_at)
                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, UTC_TIMESTAMP())
-                """, jobId, sourceId, pageId, workspaceId, signal.signalType().name(), signal.signalStrength(), signal.signalText(), signal.businessInterpretation());
+                """, jobId, sourceId, pageId, workspaceId, signal.signalType(), signal.signalStrength(), signal.signalText(), signal.businessInterpretation());
     }
 
     /**
      * Insere o resumo final calculado para o job de aquecimento.
      */
     @Override
-    public void insertSummary(long jobId, long pageId, String workspaceId, MoisSalesLibraryDtos.MarketWarmupSummaryCompleteItem summary) {
+    public void insertSummary(long jobId, long pageId, String workspaceId, MarketWarmupSummaryWriteData summary) {
         jdbcTemplate.update("""
                 INSERT INTO mois_sales_page_market_warmup_summary
                 (job_id, sales_page_id, workspace_id, score_total, market_temperature, ecosystem_type, main_pains,
                  main_objections, main_promises, main_channels, main_competitors, saturation_risk,
                  opportunity_recommendation, next_experiment_suggestion, created_at, updated_at)
                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, UTC_TIMESTAMP(), UTC_TIMESTAMP())
-                """, jobId, pageId, workspaceId, summary.scoreTotal(), summary.marketTemperature().name(), summary.ecosystemType().name(),
+                """, jobId, pageId, workspaceId, summary.scoreTotal(), summary.marketTemperature(), summary.ecosystemType(),
                 joinLines(summary.mainPains()), joinLines(summary.mainObjections()), joinLines(summary.mainPromises()), joinLines(summary.mainChannels()),
                 joinLines(summary.mainCompetitors()), summary.saturationRisk(), summary.opportunityRecommendation(), summary.nextExperimentSuggestion());
     }
@@ -213,13 +212,13 @@ public class MoisSalesPageMarketWarmupRepository implements MoisSalesPageMarketW
      * Marca o job como concluído e replica os principais classificadores comerciais para busca rápida.
      */
     @Override
-    public void markJobDone(long jobId, MoisSalesLibraryDtos.MarketWarmupSummaryCompleteItem summary, Instant finishedAt) {
+    public void markJobDone(long jobId, MarketWarmupSummaryWriteData summary, Instant finishedAt) {
         jdbcTemplate.update("""
                 UPDATE mois_sales_page_market_warmup_job
                 SET status = 'DONE', score_total = ?, market_temperature = ?, ecosystem_type = ?, recommendation = ?,
                     finished_at = ?, error_category = NULL, error_message = NULL, updated_at = UTC_TIMESTAMP()
                 WHERE id = ?
-                """, summary.scoreTotal(), summary.marketTemperature().name(), summary.ecosystemType().name(), summary.recommendation().name(),
+                """, summary.scoreTotal(), summary.marketTemperature(), summary.ecosystemType(), summary.recommendation(),
                 toTimestamp(finishedAt == null ? Instant.now() : finishedAt), jobId);
     }
 
@@ -262,7 +261,7 @@ public class MoisSalesPageMarketWarmupRepository implements MoisSalesPageMarketW
      * Lista fontes públicas de um job de aquecimento.
      */
     @Override
-    public List<MoisSalesLibraryDtos.MarketWarmupSourceResponse> listSources(long jobId) {
+    public List<MarketWarmupSourceData> listSources(long jobId) {
         return jdbcTemplate.query("""
                 SELECT id, job_id, sales_page_id, platform, source_type, source_url, source_title, author_name,
                        published_at, last_activity_at, followers_or_subscribers, views_count, likes_count, comments_count,
@@ -277,7 +276,7 @@ public class MoisSalesPageMarketWarmupRepository implements MoisSalesPageMarketW
      * Lista sinais comerciais extraídos de um job de aquecimento.
      */
     @Override
-    public List<MoisSalesLibraryDtos.MarketWarmupSignalResponse> listSignals(long jobId) {
+    public List<MarketWarmupSignalReadData> listSignals(long jobId) {
         return jdbcTemplate.query("""
                 SELECT id, job_id, source_id, sales_page_id, signal_type, signal_strength, signal_text, business_interpretation, created_at
                 FROM mois_sales_page_market_warmup_signal
@@ -299,7 +298,7 @@ public class MoisSalesPageMarketWarmupRepository implements MoisSalesPageMarketW
      */
     private MarketWarmupJobData mapJob(ResultSet rs, int rowNum) throws SQLException {
         return new MarketWarmupJobData(rs.getLong("id"), rs.getLong("sales_page_id"), rs.getString("workspace_id"),
-                MoisSalesLibraryDtos.MarketWarmupJobStatus.valueOf(rs.getString("status")), toInstant(rs.getTimestamp("created_at")),
+                rs.getString("status"), toInstant(rs.getTimestamp("created_at")),
                 rs.getString("error_category"), rs.getString("error_message"));
     }
 
@@ -308,7 +307,7 @@ public class MoisSalesPageMarketWarmupRepository implements MoisSalesPageMarketW
      */
     private MarketWarmupClaimData mapClaim(ResultSet rs, int rowNum) throws SQLException {
         MarketWarmupJobData job = new MarketWarmupJobData(rs.getLong("job_id"), rs.getLong("sales_page_id"), rs.getString("workspace_id"),
-                MoisSalesLibraryDtos.MarketWarmupJobStatus.valueOf(rs.getString("status")), toInstant(rs.getTimestamp("created_at")),
+                rs.getString("status"), toInstant(rs.getTimestamp("created_at")),
                 rs.getString("error_category"), rs.getString("error_message"));
         SalesPageWarmupData page = new SalesPageWarmupData(rs.getLong("sales_page_id"), rs.getString("workspace_id"), rs.getString("url_canonical"),
                 rs.getString("title"), rs.getString("offer_summary"), rs.getString("mechanism_summary"), rs.getString("promise_summary"), rs.getString("proof_summary"));
@@ -324,23 +323,23 @@ public class MoisSalesPageMarketWarmupRepository implements MoisSalesPageMarketW
         String recommendation = rs.getString("recommendation");
         return new MarketWarmupSummaryData(
                 rs.getLong("job_id"), rs.getLong("sales_page_id"), rs.getBigDecimal("score_total"),
-                temperature == null ? null : MoisSalesLibraryDtos.MarketWarmupTemperature.valueOf(temperature),
-                ecosystem == null ? null : MoisSalesLibraryDtos.MarketWarmupEcosystemType.valueOf(ecosystem),
-                recommendation == null ? null : MoisSalesLibraryDtos.MarketWarmupRecommendation.valueOf(recommendation),
+                temperature == null ? null : temperature,
+                ecosystem == null ? null : ecosystem,
+                recommendation == null ? null : recommendation,
                 rs.getString("main_pains"), rs.getString("main_objections"), rs.getString("main_promises"), rs.getString("main_channels"),
                 rs.getString("main_competitors"), rs.getString("saturation_risk"), rs.getString("opportunity_recommendation"),
-                rs.getString("next_experiment_suggestion"), MoisSalesLibraryDtos.MarketWarmupJobStatus.valueOf(rs.getString("status")),
+                rs.getString("next_experiment_suggestion"), rs.getString("status"),
                 rs.getString("error_category"), rs.getString("error_message"), toInstant(rs.getTimestamp("created_at")), toInstant(rs.getTimestamp("updated_at")));
     }
 
     /**
      * Converte uma linha de fonte em contrato de leitura para revisão humana.
      */
-    private MoisSalesLibraryDtos.MarketWarmupSourceResponse mapSource(ResultSet rs, int rowNum) throws SQLException {
-        return new MoisSalesLibraryDtos.MarketWarmupSourceResponse(
+    private MarketWarmupSourceData mapSource(ResultSet rs, int rowNum) throws SQLException {
+        return new MarketWarmupSourceData(
                 rs.getLong("id"), rs.getLong("job_id"), rs.getLong("sales_page_id"),
-                MoisSalesLibraryDtos.MarketWarmupPlatform.valueOf(rs.getString("platform")),
-                MoisSalesLibraryDtos.MarketWarmupSourceType.valueOf(rs.getString("source_type")),
+                rs.getString("platform"),
+                rs.getString("source_type"),
                 rs.getString("source_url"), rs.getString("source_title"), rs.getString("author_name"),
                 toInstant(rs.getTimestamp("published_at")), toInstant(rs.getTimestamp("last_activity_at")),
                 rs.getObject("followers_or_subscribers", Long.class), rs.getObject("views_count", Long.class),
@@ -352,10 +351,10 @@ public class MoisSalesPageMarketWarmupRepository implements MoisSalesPageMarketW
     /**
      * Converte uma linha de sinal em contrato de leitura para explicação do score.
      */
-    private MoisSalesLibraryDtos.MarketWarmupSignalResponse mapSignal(ResultSet rs, int rowNum) throws SQLException {
-        return new MoisSalesLibraryDtos.MarketWarmupSignalResponse(
+    private MarketWarmupSignalReadData mapSignal(ResultSet rs, int rowNum) throws SQLException {
+        return new MarketWarmupSignalReadData(
                 rs.getLong("id"), rs.getLong("job_id"), rs.getLong("source_id"), rs.getLong("sales_page_id"),
-                MoisSalesLibraryDtos.MarketWarmupSignalType.valueOf(rs.getString("signal_type")), rs.getBigDecimal("signal_strength"),
+                rs.getString("signal_type"), rs.getBigDecimal("signal_strength"),
                 rs.getString("signal_text"), rs.getString("business_interpretation"), toInstant(rs.getTimestamp("created_at")));
     }
 

--- a/backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesPageMarketWarmupServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesPageMarketWarmupServiceTest.java
@@ -7,11 +7,14 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
 import com.marketinghub.mois.bibliotecapaginavenda.worker.v1.dto.MoisSalesLibraryDtos;
-import com.marketinghub.repository.jdbc.mois.bibliotecapaginavenda.worker.v1.MoisSalesPageMarketWarmupGateway;
-import com.marketinghub.repository.jdbc.mois.bibliotecapaginavenda.worker.v1.MoisSalesPageMarketWarmupGateway.MarketWarmupClaimData;
-import com.marketinghub.repository.jdbc.mois.bibliotecapaginavenda.worker.v1.MoisSalesPageMarketWarmupGateway.MarketWarmupJobData;
-import com.marketinghub.repository.jdbc.mois.bibliotecapaginavenda.worker.v1.MoisSalesPageMarketWarmupGateway.MarketWarmupSummaryData;
-import com.marketinghub.repository.jdbc.mois.bibliotecapaginavenda.worker.v1.MoisSalesPageMarketWarmupGateway.SalesPageWarmupData;
+import com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1.MoisSalesPageMarketWarmupGateway;
+import com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1.MoisSalesPageMarketWarmupGateway.MarketWarmupClaimData;
+import com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1.MoisSalesPageMarketWarmupGateway.MarketWarmupJobData;
+import com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1.MoisSalesPageMarketWarmupGateway.MarketWarmupSignalData;
+import com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1.MoisSalesPageMarketWarmupGateway.MarketWarmupSourceData;
+import com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1.MoisSalesPageMarketWarmupGateway.MarketWarmupSummaryWriteData;
+import com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1.MoisSalesPageMarketWarmupGateway.MarketWarmupSummaryData;
+import com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1.MoisSalesPageMarketWarmupGateway.SalesPageWarmupData;
 import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.List;
@@ -98,15 +101,15 @@ class MoisSalesPageMarketWarmupServiceTest {
                 0, MoisSalesLibraryDtos.MarketWarmupSignalType.PAIN_EXPLICIT, BigDecimal.valueOf(8.5), "dor explícita", "alta urgência");
         MoisSalesLibraryDtos.MarketWarmupSummaryCompleteItem summary = sampleSummary();
         given(gateway.findJob(99L)).willReturn(Optional.of(job));
-        given(gateway.insertSource(99L, 10L, "workspace-001", source)).willReturn(501L);
+        given(gateway.insertSource(99L, 10L, "workspace-001", sourceData(source))).willReturn(501L);
 
         service.completeJob(99L, new MoisSalesLibraryDtos.MarketWarmupCompleteRequest(
                 List.of(source), List.of(signal), summary, Instant.parse("2026-06-10T10:00:00Z")));
 
         verify(gateway).deleteJobDetails(99L);
-        verify(gateway).insertSignal(99L, 10L, "workspace-001", 501L, signal);
-        verify(gateway).insertSummary(99L, 10L, "workspace-001", summary);
-        verify(gateway).markJobDone(99L, summary, Instant.parse("2026-06-10T10:00:00Z"));
+        verify(gateway).insertSignal(99L, 10L, "workspace-001", 501L, signalData(signal));
+        verify(gateway).insertSummary(99L, 10L, "workspace-001", summaryData(summary));
+        verify(gateway).markJobDone(99L, summaryData(summary), Instant.parse("2026-06-10T10:00:00Z"));
     }
 
     /**
@@ -119,7 +122,7 @@ class MoisSalesPageMarketWarmupServiceTest {
         MoisSalesLibraryDtos.MarketWarmupSignalCompleteItem signal = new MoisSalesLibraryDtos.MarketWarmupSignalCompleteItem(
                 2, MoisSalesLibraryDtos.MarketWarmupSignalType.OBJECTION, BigDecimal.ONE, "objeção", null);
         given(gateway.findJob(99L)).willReturn(Optional.of(job));
-        given(gateway.insertSource(99L, 10L, "workspace-001", source)).willReturn(501L);
+        given(gateway.insertSource(99L, 10L, "workspace-001", sourceData(source))).willReturn(501L);
 
         assertThatThrownBy(() -> service.completeJob(99L, new MoisSalesLibraryDtos.MarketWarmupCompleteRequest(
                 List.of(source), List.of(signal), sampleSummary(), Instant.parse("2026-06-10T10:00:00Z"))))
@@ -138,9 +141,9 @@ class MoisSalesPageMarketWarmupServiceTest {
                 99L,
                 10L,
                 BigDecimal.valueOf(82),
-                MoisSalesLibraryDtos.MarketWarmupTemperature.HOT,
-                MoisSalesLibraryDtos.MarketWarmupEcosystemType.CREATORS_HEATED,
-                MoisSalesLibraryDtos.MarketWarmupRecommendation.PRIORITIZE,
+                "HOT",
+                "CREATORS_HEATED",
+                "PRIORITIZE",
                 "dor 1\ndor 2",
                 "objeção 1",
                 "promessa 1\npromessa 2",
@@ -149,7 +152,7 @@ class MoisSalesPageMarketWarmupServiceTest {
                 "baixo",
                 "priorizar experimento",
                 "ângulo inicial",
-                MoisSalesLibraryDtos.MarketWarmupJobStatus.DONE,
+                "DONE",
                 null,
                 null,
                 Instant.parse("2026-06-10T09:00:00Z"),
@@ -181,7 +184,32 @@ class MoisSalesPageMarketWarmupServiceTest {
      * Monta um job de aquecimento com status controlado pelo cenário de teste.
      */
     private MarketWarmupJobData sampleJob(MoisSalesLibraryDtos.MarketWarmupJobStatus status) {
-        return new MarketWarmupJobData(99L, 10L, "workspace-001", status, Instant.parse("2026-06-10T09:00:00Z"), null, null);
+        return new MarketWarmupJobData(99L, 10L, "workspace-001", status.name(), Instant.parse("2026-06-10T09:00:00Z"), null, null);
+    }
+
+    /**
+     * Monta os dados desacoplados de persistência esperados para uma fonte pública.
+     */
+    private MarketWarmupSourceData sourceData(MoisSalesLibraryDtos.MarketWarmupSourceCompleteItem source) {
+        return new MarketWarmupSourceData(null, null, null, source.platform().name(), source.sourceType().name(), source.sourceUrl(), source.sourceTitle(),
+                source.authorName(), source.publishedAt(), source.lastActivityAt(), source.followersOrSubscribers(), source.viewsCount(), source.likesCount(),
+                source.commentsCount(), source.recencyScore(), source.engagementScore(), source.evidenceSummary(), null, null);
+    }
+
+    /**
+     * Monta os dados desacoplados de persistência esperados para um sinal comercial.
+     */
+    private MarketWarmupSignalData signalData(MoisSalesLibraryDtos.MarketWarmupSignalCompleteItem signal) {
+        return new MarketWarmupSignalData(signal.signalType().name(), signal.signalStrength(), signal.signalText(), signal.businessInterpretation());
+    }
+
+    /**
+     * Monta os dados desacoplados de persistência esperados para o resumo calculado.
+     */
+    private MarketWarmupSummaryWriteData summaryData(MoisSalesLibraryDtos.MarketWarmupSummaryCompleteItem summary) {
+        return new MarketWarmupSummaryWriteData(summary.scoreTotal(), summary.marketTemperature().name(), summary.ecosystemType().name(), summary.recommendation().name(),
+                summary.mainPains(), summary.mainObjections(), summary.mainPromises(), summary.mainChannels(), summary.mainCompetitors(), summary.saturationRisk(),
+                summary.opportunityRecommendation(), summary.nextExperimentSuggestion());
     }
 
     /**

--- a/docs/registros/mois1.md
+++ b/docs/registros/mois1.md
@@ -1253,3 +1253,16 @@ Arquivos alterados:
 - `backend/ads-service/src/main/java/com/marketinghub/repository/jdbc/mois/bibliotecapaginavenda/worker/v1/MoisSalesPageMarketWarmupRepository.java`
 - `backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesPageMarketWarmupServiceTest.java`
 - `docs/registros/mois1.md`
+
+## 2026-06-10 — Correção arquitetural do aquecimento de mercado MOIS
+
+- Corrigida a violação arquitetural da Biblioteca de Páginas de Vendas MOIS removendo dependências do pacote de repository para DTOs internos do módulo MOIS.
+- O gateway de persistência passou a expor dados primitivos/contratos próprios da camada de repository, e o service MOIS assumiu explicitamente os mapeamentos entre contratos HTTP e persistência.
+- Movida a persistência de aquecimento para o pacote canônico `repository.jpa.mois.bibliotecapaginavenda.worker.v1`, alinhado à exceção arquitetural já validada para a biblioteca MOIS.
+
+Arquivos alterados:
+- `backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesPageMarketWarmupService.java`
+- `backend/ads-service/src/main/java/com/marketinghub/repository/jpa/mois/bibliotecapaginavenda/worker/v1/MoisSalesPageMarketWarmupGateway.java`
+- `backend/ads-service/src/main/java/com/marketinghub/repository/jpa/mois/bibliotecapaginavenda/worker/v1/MoisSalesPageMarketWarmupRepository.java`
+- `backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesPageMarketWarmupServiceTest.java`
+- `docs/registros/mois1.md`


### PR DESCRIPTION
### Motivation
- Corrigir violação de arquitetura onde o pacote funcional MOIS dependia diretamente de tipos/DTOs da camada de repository, quebrando a regra de isolamento do módulo MOIS.
- Centralizar a persistência da feature de aquecimento de mercado no pacote canônico de repositories para preservar o contrato do backend como única camada de acesso ao banco.
- Evitar contaminação do domínio/DTO HTTP com tipos de persistência, garantindo manutenção e evolução mais segura das camadas.

### Description
- Move o gateway/repository de `repository.jdbc.mois.bibliotecapaginavenda.worker.v1` para `repository.jpa.mois.bibliotecapaginavenda.worker.v1` e altera suas assinaturas para expor tipos desacoplados (strings, primitivos e records) em vez de `MoisSalesLibraryDtos` internos.
- Atualiza `MoisSalesPageMarketWarmupService` para incluir mapeamentos explícitos entre contratos HTTP (`MoisSalesLibraryDtos`) e os tipos de persistência (`MarketWarmup*Data` / `*WriteData`) e reorganiza chamadas a `gateway` para usar esses mapeamentos.
- Refatora `MoisSalesPageMarketWarmupRepository` para implementar o novo contrato de gateway (rename + ajustes de leitura/gravação) sem expor enums/DTOs do módulo MOIS.
- Atualiza testes unitários (`MoisSalesPageMarketWarmupServiceTest`) e o registro operacional (`docs/registros/mois1.md`) para refletir o desacoplamento e validar o comportamento esperado.

### Testing
- Executado `mvn -Dtest=ArquiteturaTest,MoisSalesPageMarketWarmupServiceTest test` no módulo `ads-service`, com todos os testes relevantes passando (total: 53 tests, Failures: 0). 
- Executado `mvn -DskipTests test-compile` para validar compilação com Java 21 e o código recém-mapeado, que concluiu com sucesso.
- Tentativa de rodar `mvn spotless:apply` falhou porque o plugin `spotless` não está resolvido no ambiente Maven, portanto não foi aplicado (informação de observação).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a28bf0c7bd48320bdea9029f7322ba1)