### PR TITLE
Incluir analytics da landing no relatório completo do experimento e pré‑vista UI

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/report/dto/ExperimentReportMaterialDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/report/dto/ExperimentReportMaterialDto.java
@@ -2,6 +2,7 @@ package com.marketinghub.experiment.report.dto;
 
 import com.marketinghub.experiment.dto.ExperimentCampaignMetricDto;
 import com.marketinghub.experiment.funnel.dto.ExperimentFunnelStageDto;
+import com.marketinghub.experiment.funnel.service.analytics.ExperimentLandingAnalyticsDto;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
 import lombok.Data;
@@ -35,6 +36,7 @@ public class ExperimentReportMaterialDto {
     private List<LeadPortalFlowSnapshot> leadPortalFlows = Collections.emptyList();
     private InstantFormSnapshot instantForm;
     private ExperimentCampaignMetricDto campaignMetric;
+    private ExperimentLandingAnalyticsDto landingAnalytics;
     @Builder.Default
     private List<ExperimentFunnelStageDto> funnelStages = Collections.emptyList();
 

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/report/service/ExperimentCompleteMarkdownReportService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/report/service/ExperimentCompleteMarkdownReportService.java
@@ -5,6 +5,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marketinghub.experiment.Experiment;
 import com.marketinghub.experiment.ExperimentCampaignMetric;
 import com.marketinghub.experiment.ExperimentStatus;
+import com.marketinghub.experiment.funnel.service.analytics.ExperimentLandingAnalyticsDto;
+import com.marketinghub.experiment.funnel.service.analytics.ExperimentLandingAnalyticsSectionDto;
+import com.marketinghub.experiment.funnel.service.analytics.ExperimentLandingAnalyticsSessionDto;
 import com.marketinghub.facebookads.FacebookAdsAd;
 import com.marketinghub.facebookads.FacebookAdsAdCreative;
 import com.marketinghub.facebookads.FacebookAdsAdSet;
@@ -78,6 +81,7 @@ public class ExperimentCompleteMarkdownReportService {
         appendCampaignMetrics(markdown, experiment.getCampaignMetric());
         appendGeraLandingExecutions(markdown, geraLandingExecutions);
         appendFacebookCampaigns(markdown, facebookCampaigns);
+        appendLandingAnalytics(markdown, material.getLandingAnalytics());
         appendMaterialSnapshot(markdown, material);
         return markdown.toString();
     }
@@ -367,11 +371,65 @@ public class ExperimentCompleteMarkdownReportService {
         }
     }
 
+
+    /**
+     * Adiciona os dados de analytics da landing com tempos de página, sessões e trechos mais vistos.
+     */
+    private void appendLandingAnalytics(StringBuilder markdown, ExperimentLandingAnalyticsDto analytics) {
+        markdown.append("## 7. Analytics da landing — tempos em página e trechos\n\n");
+        if (analytics == null || analytics.totalEvents() == 0) {
+            markdown.append("Nenhum evento de analytics da landing encontrado para este experimento.\n\n");
+            return;
+        }
+        appendJsonBlock(markdown, "landing_analytics_summary", mapOf(
+                "totalEvents", analytics.totalEvents(),
+                "totalSessions", analytics.totalSessions(),
+                "pageViews", analytics.pageViews(),
+                "sectionViewEvents", analytics.sectionViewEvents(),
+                "totalVisibleMs", analytics.totalVisibleMs(),
+                "averageVisibleMsPerSession", analytics.averageVisibleMsPerSession(),
+                "lastEventAt", analytics.lastEventAt(),
+                "deviceBreakdown", analytics.deviceBreakdown(),
+                "mobileOperatingSystemBreakdown", analytics.mobileOperatingSystemBreakdown(),
+                "screenSizeBreakdown", analytics.screenSizeBreakdown(),
+                "visitors", analytics.visitors()
+        ));
+        appendJsonBlock(markdown, "landing_analytics_top_sections", aggregateLandingAnalyticsSections(analytics.sessions()));
+        appendJsonBlock(markdown, "landing_analytics_sessions", analytics.sessions());
+    }
+
+    /**
+     * Consolida os trechos da landing por tempo visível acumulado em todas as sessões do relatório.
+     */
+    private List<Map<String, Object>> aggregateLandingAnalyticsSections(List<ExperimentLandingAnalyticsSessionDto> sessions) {
+        Map<String, LandingAnalyticsSectionAccumulator> sections = new LinkedHashMap<>();
+        if (sessions == null) {
+            return List.of();
+        }
+        for (ExperimentLandingAnalyticsSessionDto session : sessions) {
+            if (session.topSections() == null) {
+                continue;
+            }
+            for (ExperimentLandingAnalyticsSectionDto section : session.topSections()) {
+                sections.computeIfAbsent(section.sectionId(), LandingAnalyticsSectionAccumulator::new)
+                        .record(section.visibleMs(), section.events());
+            }
+        }
+        return sections.values().stream()
+                .sorted((left, right) -> Long.compare(right.visibleMs(), left.visibleMs()))
+                .map(section -> mapOf(
+                        "sectionId", section.sectionId(),
+                        "visibleMs", section.visibleMs(),
+                        "events", section.events()
+                ))
+                .toList();
+    }
+
     /**
      * Adiciona um snapshot JSON consolidado usado para auditoria completa do relatório.
      */
     private void appendMaterialSnapshot(StringBuilder markdown, Object material) {
-        markdown.append("## 7. Snapshot consolidado do backend\n\n");
+        markdown.append("## 8. Snapshot consolidado do backend\n\n");
         appendJsonBlock(markdown, "experiment_report_material", material);
     }
 
@@ -486,4 +544,40 @@ public class ExperimentCompleteMarkdownReportService {
     private String value(Object value) {
         return Objects.toString(value, "—");
     }
+
+    /**
+     * Acumula o tempo visível e eventos de um trecho da landing para o relatório completo.
+     */
+    private static final class LandingAnalyticsSectionAccumulator {
+        private final String sectionId;
+        private long visibleMs;
+        private long events;
+
+        /** Cria o acumulador para um trecho identificado da landing. */
+        private LandingAnalyticsSectionAccumulator(String sectionId) {
+            this.sectionId = sectionId;
+        }
+
+        /** Soma tempo visível e eventos ao trecho agregado. */
+        private void record(long visibleMs, long events) {
+            this.visibleMs += visibleMs;
+            this.events += events;
+        }
+
+        /** Retorna o identificador do trecho da landing. */
+        private String sectionId() {
+            return sectionId;
+        }
+
+        /** Retorna o tempo visível acumulado do trecho. */
+        private long visibleMs() {
+            return visibleMs;
+        }
+
+        /** Retorna a quantidade de eventos registrados no trecho. */
+        private long events() {
+            return events;
+        }
+    }
+
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/report/service/ExperimentReportMaterialService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/report/service/ExperimentReportMaterialService.java
@@ -47,6 +47,7 @@ public class ExperimentReportMaterialService {
     private final ExperimentFunnelService experimentFunnelService;
     private final ObjectMapper objectMapper;
 
+    /** Inicializa o serviço com repositórios e consolidadores do relatório do experimento. */
     public ExperimentReportMaterialService(ExperimentRepository experimentRepository,
                                            CreativeRepository creativeRepository,
                                            CreativeVariantRepository creativeVariantRepository,
@@ -65,6 +66,7 @@ public class ExperimentReportMaterialService {
         this.objectMapper = objectMapper;
     }
 
+    /** Consolida o material completo do relatório, incluindo funil e analytics da landing. */
     @Transactional(readOnly = true)
     public ExperimentReportMaterialDto build(Long experimentId) {
         Experiment experiment = experimentRepository.findById(experimentId)
@@ -82,6 +84,7 @@ public class ExperimentReportMaterialService {
                 .hypothesis(toHypothesisSnapshot(experiment.getHypothesisRef()))
                 .instantForm(toInstantFormSnapshot(experiment.getFacebookInstantForm()))
                 .campaignMetric(toCampaignMetricDto(experiment.getCampaignMetric()))
+                .landingAnalytics(experimentFunnelService.summarizeLandingAnalytics(experimentId))
                 .build();
 
         dto.setCreatives(mapCreatives(creatives));

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -4251,3 +4251,7 @@
 - causa-raiz: a tela já expunha partes do material do experimento, mas não havia uma ação única que consolidasse nicho, framework da hipótese, JSONs de campanha/anúncio/imagem, JSONs do GeraLanding e detalhamento de Facebook Ads em um artefato auditável.
 - foi feito: criado endpoint de relatório completo em Markdown e botão na tela do experimento, exibido somente para status `VALIDATED` ou `INVALIDATED`, com download direto do arquivo `.md`.
 - impacto esperado: o usuário consegue revisar e reaproveitar todo o aprendizado comercial do experimento encerrado sem buscar dados em múltiplas abas, acelerando análise de vencedores e perdedores.
+
+## 2026-06-10 — Relatório de experimento com analytics da landing
+- foi feito: incluídos no material e no relatório completo do experimento os dados de analytics da landing, com sessões, page views, tempo visível total/médio e trechos/seções com maior tempo de visualização.
+- impacto: o relatório passa a apoiar decisão comercial com evidências de atenção real na página, não apenas métricas de campanha e funil.

--- a/frontend/src/api/experiment/useExperimentLandingAnalytics.ts
+++ b/frontend/src/api/experiment/useExperimentLandingAnalytics.ts
@@ -50,6 +50,27 @@ export interface ExperimentLandingAnalyticsSession {
   topSections: ExperimentLandingAnalyticsSection[];
 }
 
+export interface ExperimentLandingAnalyticsVisitor {
+  visitorId: string;
+  totalSessions: number;
+  validPageViews: number;
+  firstAccessAt?: string | null;
+  lastAccessAt?: string | null;
+  intervalSeconds: number;
+  distinctPages: number;
+  lastUserAgent?: string | null;
+  deviceType?: string | null;
+  deviceLabel?: string | null;
+  recurrent: boolean;
+}
+
+export interface ExperimentLandingAnalyticsVisitors {
+  probableVisitors: number;
+  recurrentVisitors: number;
+  singleVisitVisitors: number;
+  visitors: ExperimentLandingAnalyticsVisitor[];
+}
+
 export interface ExperimentLandingAnalytics {
   totalEvents: number;
   totalSessions: number;
@@ -61,6 +82,7 @@ export interface ExperimentLandingAnalytics {
   deviceBreakdown: ExperimentLandingAnalyticsDevice[];
   mobileOperatingSystemBreakdown: ExperimentLandingAnalyticsOperatingSystem[];
   screenSizeBreakdown: ExperimentLandingAnalyticsScreenSize[];
+  visitors?: ExperimentLandingAnalyticsVisitors | null;
   sessions: ExperimentLandingAnalyticsSession[];
 }
 

--- a/frontend/src/api/experiment/useExperimentReportMaterial.ts
+++ b/frontend/src/api/experiment/useExperimentReportMaterial.ts
@@ -2,6 +2,7 @@ import { useQuery } from "@tanstack/react-query";
 import axios from "axios";
 import type { ExperimentCampaignMetric } from "./useExperiments";
 import type { ExperimentFunnelStageSummary } from "./useExperimentFunnel";
+import type { ExperimentLandingAnalytics } from "./useExperimentLandingAnalytics";
 
 export interface ExperimentReportMaterial {
   experiment?: ExperimentReportExperimentSnapshot | null;
@@ -13,6 +14,7 @@ export interface ExperimentReportMaterial {
   leadPortalFlows: ExperimentReportLeadPortalFlowSnapshot[];
   instantForm?: ExperimentReportInstantFormSnapshot | null;
   campaignMetric?: ExperimentCampaignMetric | null;
+  landingAnalytics?: ExperimentLandingAnalytics | null;
   funnelStages: ExperimentFunnelStageSummary[];
 }
 

--- a/frontend/src/pages/experiment/ExperimentReportPanel.tsx
+++ b/frontend/src/pages/experiment/ExperimentReportPanel.tsx
@@ -33,8 +33,11 @@ export default function ExperimentReportPanel({
   const { data: requests, isLoading: isLoadingRequests } =
     useExperimentReportRequests(experimentId);
   const createRequest = useCreateExperimentReportRequest(experimentId);
-  const { data: material, isLoading: isLoadingMaterial, isFetching } =
-    useExperimentReportMaterial(experimentId);
+  const {
+    data: material,
+    isLoading: isLoadingMaterial,
+    isFetching,
+  } = useExperimentReportMaterial(experimentId);
 
   const hasActiveRequest = useMemo(
     () =>
@@ -55,7 +58,9 @@ export default function ExperimentReportPanel({
       <div className="card-body d-flex flex-column gap-3">
         <div className="d-flex flex-column flex-md-row justify-content-between gap-2">
           <div>
-            <h5 className="card-title mb-1">Relatório objetivo do experimento</h5>
+            <h5 className="card-title mb-1">
+              Relatório objetivo do experimento
+            </h5>
             <p className="text-muted mb-0">
               Consolida nicho, hipótese, artefatos e métricas (campanha e funil)
               em um único material pronto para revisão.
@@ -115,7 +120,8 @@ export default function ExperimentReportPanel({
                             por {request.requestedBy}
                           </span>
                         ) : null}
-                        {request.status === "FAILED" && request.failureReason ? (
+                        {request.status === "FAILED" &&
+                        request.failureReason ? (
                           <div className="text-danger small mt-1">
                             {request.failureReason}
                           </div>
@@ -219,7 +225,7 @@ function ReportMaterialPreview({
               ) : null}
               {material.experiment?.dailyBudget ? (
                 <li>
-                  <strong>Orçamento diário:</strong> {" "}
+                  <strong>Orçamento diário:</strong>{" "}
                   {formatCurrency(material.experiment.dailyBudget)}
                 </li>
               ) : null}
@@ -237,15 +243,16 @@ function ReportMaterialPreview({
             <h6 className="fw-semibold">Artefatos mapeados</h6>
             <ul className="list-unstyled mb-2 text-muted small">
               <li>
-                {(material.creatives ?? []).length} criativo(s) aprovados com headline e
-                imagem.
+                {(material.creatives ?? []).length} criativo(s) aprovados com
+                headline e imagem.
               </li>
               <li>
-                {(material.landingPages ?? []).length} landing page(s) monitoradas.
+                {(material.landingPages ?? []).length} landing page(s)
+                monitoradas.
               </li>
               <li>
-                {(material.leadPortalFlows ?? []).length} fluxo(s) do portal do lead com
-                perguntas e estilo visual.
+                {(material.leadPortalFlows ?? []).length} fluxo(s) do portal do
+                lead com perguntas e estilo visual.
               </li>
             </ul>
             {material.instantForm ? (
@@ -284,14 +291,59 @@ function ReportMaterialPreview({
         <div className="border rounded p-3">
           <h6 className="fw-semibold mb-2">Métricas da campanha</h6>
           <div className="row row-cols-2 row-cols-md-4 g-3 text-center">
-            <MetricItem label="Impressões" value={material.campaignMetric.impressions} />
-            <MetricItem label="Cliques" value={material.campaignMetric.clicks} />
+            <MetricItem
+              label="Impressões"
+              value={material.campaignMetric.impressions}
+            />
+            <MetricItem
+              label="Cliques"
+              value={material.campaignMetric.clicks}
+            />
             <MetricItem label="Leads" value={material.campaignMetric.leads} />
             <MetricItem
               label="CPL"
               value={formatCurrency(material.campaignMetric.cpl ?? null)}
             />
           </div>
+        </div>
+      ) : null}
+      {material.landingAnalytics ? (
+        <div className="border rounded p-3">
+          <h6 className="fw-semibold mb-2">Analytics da landing</h6>
+          <div className="row row-cols-2 row-cols-md-4 g-3 text-center mb-3">
+            <MetricItem
+              label="Sessões"
+              value={material.landingAnalytics.totalSessions}
+            />
+            <MetricItem
+              label="Page views"
+              value={material.landingAnalytics.pageViews}
+            />
+            <MetricItem
+              label="Tempo médio"
+              value={formatDuration(
+                material.landingAnalytics.averageVisibleMsPerSession,
+              )}
+            />
+            <MetricItem
+              label="Tempo total"
+              value={formatDuration(material.landingAnalytics.totalVisibleMs)}
+            />
+          </div>
+          {material.landingAnalytics.sessions?.length ? (
+            <div className="text-muted small">
+              Trechos com maior atenção por sessão:{" "}
+              {material.landingAnalytics.sessions
+                .flatMap((session) => session.topSections ?? [])
+                .sort((left, right) => right.visibleMs - left.visibleMs)
+                .slice(0, 3)
+                .map(
+                  (section) =>
+                    `${section.sectionId} (${formatDuration(section.visibleMs)})`,
+                )
+                .join(", ") || "sem trechos registrados"}
+            </div>
+          ) : null}
         </div>
       ) : null}
       {material.funnelStages?.length ? (
@@ -341,6 +393,20 @@ function formatValue(value?: number | string | null) {
     return value.toLocaleString("pt-BR");
   }
   return value;
+}
+
+function formatDuration(ms?: number | null) {
+  const safeMs = Math.max(0, ms ?? 0);
+  if (safeMs < 1000) {
+    return `${safeMs} ms`;
+  }
+  const seconds = Math.round(safeMs / 1000);
+  if (seconds < 60) {
+    return `${seconds}s`;
+  }
+  const minutes = Math.floor(seconds / 60);
+  const remainingSeconds = seconds % 60;
+  return `${minutes}min ${remainingSeconds}s`;
 }
 
 function formatCurrency(value?: number | null) {


### PR DESCRIPTION
### Motivation
- Enriquecer o relatório completo do experimento com evidências de atenção na landing (sessões, page views, tempos visíveis e trechos/seções mais vistos) para suportar decisões comerciais além das métricas de campanha e funil.
- Expor esses dados também na pré‑vista do painel do experimento para revisão rápida sem precisar baixar o Markdown completo.

### Description
- Adiciona `landingAnalytics` ao DTO do relatório com `ExperimentLandingAnalyticsDto` em `ExperimentReportMaterialDto` e popula este campo em `ExperimentReportMaterialService.build(Long)` chamando `experimentFunnelService.summarizeLandingAnalytics(experimentId)`.
- Estende `ExperimentCompleteMarkdownReportService` para incluir `appendLandingAnalytics(...)`, `aggregateLandingAnalyticsSections(...)` e o acumulador `LandingAnalyticsSectionAccumulator` e insere a seção "Analytics da landing" antes do snapshot consolidado no Markdown gerado.
- Atualiza o front-end: estende tipos em `useExperimentLandingAnalytics.ts` e `useExperimentReportMaterial.ts` e adiciona uma seção de pré‑vista de `landingAnalytics` em `ExperimentReportPanel.tsx` exibindo sessões, page views, tempos e top‑sections (com `formatDuration`).
- Atualiza `docs/registros/experimentos.md` com registro da mudança operacional.

### Testing
- Executado `npm run typecheck` no frontend para validação de tipos TypeScript e a verificação passou sem erros.
- Executado o build/testes unitários do backend (`mvn test` via wrapper no módulo `ads-service`); houve um problema inicial de compilador/Lombok relacionado à versão do JDK que foi resolvido instalando OpenJDK 21 e re‑executando os testes, após o qual os testes unitários do módulo foram executados e não apresentaram falhas automatizadas.
- Formatação/linters aplicados (`prettier`) nos arquivos TypeScript modificados antes dos testes de frontend.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a28c08bfeec8320b0c47a870211125e)