### PR TITLE
Implementa cadastro de sementes de públicos gerais OPRM

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/generalaudience/OprmGeneralAudienceSeed.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/generalaudience/OprmGeneralAudienceSeed.java
@@ -1,0 +1,192 @@
+package com.marketinghub.oprm.generalaudience;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+import java.time.Instant;
+
+/** Responsável por armazenar a semente ampla de público geral que ainda não é nicho nem campanha. */
+@Entity
+@Table(name = "oprm_general_audience_seed")
+public class OprmGeneralAudienceSeed {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "name", nullable = false, length = 191)
+    private String name;
+
+    @Column(name = "description", columnDefinition = "LONGTEXT")
+    private String description;
+
+    @Column(name = "market_context", columnDefinition = "LONGTEXT")
+    private String marketContext;
+
+    @Column(name = "country", nullable = false, length = 64)
+    private String country;
+
+    @Column(name = "language", nullable = false, length = 32)
+    private String language;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "seed_type", nullable = false, length = 32)
+    private OprmGeneralAudienceSeedType seedType;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 32)
+    private OprmGeneralAudienceSeedStatus status;
+
+    @Column(name = "business_goal", columnDefinition = "LONGTEXT")
+    private String businessGoal;
+
+    @Column(name = "risk_notes", columnDefinition = "LONGTEXT")
+    private String riskNotes;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+
+    /** Inicializa os carimbos de data antes da primeira persistência. */
+    @PrePersist
+    void onCreate() {
+        Instant now = Instant.now();
+        createdAt = now;
+        updatedAt = now;
+    }
+
+    /** Atualiza o carimbo de modificação antes de salvar alterações. */
+    @PreUpdate
+    void onUpdate() {
+        updatedAt = Instant.now();
+    }
+
+    /** Retorna o identificador da semente. */
+    public Long getId() {
+        return id;
+    }
+
+    /** Define o identificador da semente. */
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    /** Retorna o nome de negócio da semente. */
+    public String getName() {
+        return name;
+    }
+
+    /** Define o nome de negócio da semente. */
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /** Retorna a descrição da semente ampla. */
+    public String getDescription() {
+        return description;
+    }
+
+    /** Define a descrição da semente ampla. */
+    public void setDescription(String description) {
+        this.description = description;
+    }
+
+    /** Retorna o contexto de mercado usado para orientar a revisão da semente. */
+    public String getMarketContext() {
+        return marketContext;
+    }
+
+    /** Define o contexto de mercado usado para orientar a revisão da semente. */
+    public void setMarketContext(String marketContext) {
+        this.marketContext = marketContext;
+    }
+
+    /** Retorna o país alvo da semente. */
+    public String getCountry() {
+        return country;
+    }
+
+    /** Define o país alvo da semente. */
+    public void setCountry(String country) {
+        this.country = country;
+    }
+
+    /** Retorna o idioma alvo da semente. */
+    public String getLanguage() {
+        return language;
+    }
+
+    /** Define o idioma alvo da semente. */
+    public void setLanguage(String language) {
+        this.language = language;
+    }
+
+    /** Retorna o tipo comercial da semente. */
+    public OprmGeneralAudienceSeedType getSeedType() {
+        return seedType;
+    }
+
+    /** Define o tipo comercial da semente. */
+    public void setSeedType(OprmGeneralAudienceSeedType seedType) {
+        this.seedType = seedType;
+    }
+
+    /** Retorna o status operacional da semente. */
+    public OprmGeneralAudienceSeedStatus getStatus() {
+        return status;
+    }
+
+    /** Define o status operacional da semente. */
+    public void setStatus(OprmGeneralAudienceSeedStatus status) {
+        this.status = status;
+    }
+
+    /** Retorna o objetivo comercial esperado para a semente. */
+    public String getBusinessGoal() {
+        return businessGoal;
+    }
+
+    /** Define o objetivo comercial esperado para a semente. */
+    public void setBusinessGoal(String businessGoal) {
+        this.businessGoal = businessGoal;
+    }
+
+    /** Retorna as observações de risco e compliance da semente. */
+    public String getRiskNotes() {
+        return riskNotes;
+    }
+
+    /** Define as observações de risco e compliance da semente. */
+    public void setRiskNotes(String riskNotes) {
+        this.riskNotes = riskNotes;
+    }
+
+    /** Retorna a data de criação da semente. */
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    /** Define a data de criação da semente. */
+    public void setCreatedAt(Instant createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    /** Retorna a data da última alteração da semente. */
+    public Instant getUpdatedAt() {
+        return updatedAt;
+    }
+
+    /** Define a data da última alteração da semente. */
+    public void setUpdatedAt(Instant updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/generalaudience/OprmGeneralAudienceSeedStatus.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/generalaudience/OprmGeneralAudienceSeedStatus.java
@@ -1,0 +1,11 @@
+package com.marketinghub.oprm.generalaudience;
+
+/** Representa o estágio operacional da semente de público geral antes de virar nicho testável. */
+public enum OprmGeneralAudienceSeedStatus {
+    DRAFT,
+    READY_FOR_RESEARCH,
+    RESEARCHING,
+    MAPPED,
+    PAUSED,
+    ARCHIVED
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/generalaudience/OprmGeneralAudienceSeedType.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/generalaudience/OprmGeneralAudienceSeedType.java
@@ -1,0 +1,11 @@
+package com.marketinghub.oprm.generalaudience;
+
+/** Representa o tipo comercial da semente ampla de público geral no OPRM. */
+public enum OprmGeneralAudienceSeedType {
+    CATEGORY,
+    DESIRE,
+    LIFE_CONTEXT,
+    BEHAVIOR,
+    CHANNEL,
+    PAIN_CLUSTER
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/generalaudience/controller/OprmGeneralAudienceController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/generalaudience/controller/OprmGeneralAudienceController.java
@@ -1,0 +1,67 @@
+package com.marketinghub.oprm.generalaudience.controller;
+
+import com.marketinghub.oprm.generalaudience.service.OprmGeneralAudienceService;
+import com.marketinghub.oprm.generalaudience.service.createSeed.CreateGeneralAudienceSeedRequest;
+import com.marketinghub.oprm.generalaudience.service.getSeed.GeneralAudienceSeedResponse;
+import com.marketinghub.oprm.generalaudience.service.listSeeds.GeneralAudienceSeedSummaryResponse;
+import com.marketinghub.oprm.generalaudience.service.updateSeed.UpdateGeneralAudienceSeedRequest;
+import jakarta.validation.Valid;
+import java.net.URI;
+import java.util.List;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/** Responsável pelos endpoints OPRM de cadastro e revisão manual de sementes de público geral. */
+@RestController
+@RequestMapping("/api/oprm/general-audiences")
+public class OprmGeneralAudienceController {
+
+    private final OprmGeneralAudienceService service;
+
+    /** Inicializa o controller com o serviço único do módulo de públicos gerais. */
+    public OprmGeneralAudienceController(OprmGeneralAudienceService service) {
+        this.service = service;
+    }
+
+    /** Lista sementes de público geral para seleção operacional. */
+    @GetMapping("/seeds")
+    public ResponseEntity<List<GeneralAudienceSeedSummaryResponse>> listSeeds() {
+        return ResponseEntity.ok(service.listSeeds());
+    }
+
+    /** Cadastra uma semente de público geral sem iniciar campanha ou descoberta automática. */
+    @PostMapping("/seeds")
+    public ResponseEntity<GeneralAudienceSeedResponse> createSeed(
+            @Valid @RequestBody CreateGeneralAudienceSeedRequest request) {
+        GeneralAudienceSeedResponse response = service.createSeed(request);
+        return ResponseEntity
+                .created(URI.create("/api/oprm/general-audiences/seeds/" + response.id()))
+                .body(response);
+    }
+
+    /** Detalha uma semente de público geral para revisão manual. */
+    @GetMapping("/seeds/{seedId}")
+    public ResponseEntity<GeneralAudienceSeedResponse> getSeed(@PathVariable Long seedId) {
+        return ResponseEntity.ok(service.getSeed(seedId));
+    }
+
+    /** Atualiza os campos manuais da semente de público geral. */
+    @PatchMapping("/seeds/{seedId}")
+    public ResponseEntity<GeneralAudienceSeedResponse> updateSeed(
+            @PathVariable Long seedId,
+            @Valid @RequestBody UpdateGeneralAudienceSeedRequest request) {
+        return ResponseEntity.ok(service.updateSeed(seedId, request));
+    }
+
+    /** Arquiva uma semente de público geral sem remover seu histórico. */
+    @PostMapping("/seeds/{seedId}/archive")
+    public ResponseEntity<GeneralAudienceSeedResponse> archiveSeed(@PathVariable Long seedId) {
+        return ResponseEntity.ok(service.archiveSeed(seedId));
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/generalaudience/service/OprmGeneralAudienceService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/generalaudience/service/OprmGeneralAudienceService.java
@@ -1,0 +1,163 @@
+package com.marketinghub.oprm.generalaudience.service;
+
+import com.marketinghub.oprm.generalaudience.OprmGeneralAudienceSeed;
+import com.marketinghub.oprm.generalaudience.OprmGeneralAudienceSeedStatus;
+import com.marketinghub.oprm.generalaudience.service.createSeed.CreateGeneralAudienceSeedRequest;
+import com.marketinghub.oprm.generalaudience.service.getSeed.GeneralAudienceSeedResponse;
+import com.marketinghub.oprm.generalaudience.service.listSeeds.GeneralAudienceSeedSummaryResponse;
+import com.marketinghub.oprm.generalaudience.service.updateSeed.UpdateGeneralAudienceSeedRequest;
+import com.marketinghub.repository.jpa.oprm.generalaudience.OprmGeneralAudienceSeedRepository;
+import java.util.List;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+import org.springframework.web.server.ResponseStatusException;
+
+/** Responsável por orquestrar o cadastro e a revisão manual de sementes de público geral no OPRM. */
+@Service
+public class OprmGeneralAudienceService {
+
+    private static final String DEFAULT_COUNTRY = "BR";
+    private static final String DEFAULT_LANGUAGE = "pt-BR";
+    private final OprmGeneralAudienceSeedRepository seedRepository;
+
+    /** Inicializa o serviço com a persistência centralizada de sementes de público geral. */
+    public OprmGeneralAudienceService(OprmGeneralAudienceSeedRepository seedRepository) {
+        this.seedRepository = seedRepository;
+    }
+
+    /** Lista sementes cadastradas para seleção e revisão manual pelo usuário. */
+    @Transactional(readOnly = true)
+    public List<GeneralAudienceSeedSummaryResponse> listSeeds() {
+        return seedRepository.findAllByOrderByUpdatedAtDesc().stream()
+                .map(this::toSummaryResponse)
+                .toList();
+    }
+
+    /** Cadastra uma nova semente ampla sem tratá-la como nicho ou campanha pronta. */
+    @Transactional
+    public GeneralAudienceSeedResponse createSeed(CreateGeneralAudienceSeedRequest request) {
+        OprmGeneralAudienceSeed seed = new OprmGeneralAudienceSeed();
+        seed.setName(requiredText(request.name(), "name"));
+        seed.setDescription(normalizeOptionalText(request.description()));
+        seed.setMarketContext(normalizeOptionalText(request.marketContext()));
+        seed.setCountry(resolveDefaultText(request.country(), DEFAULT_COUNTRY));
+        seed.setLanguage(resolveDefaultText(request.language(), DEFAULT_LANGUAGE));
+        seed.setSeedType(request.seedType());
+        seed.setStatus(request.status() == null ? OprmGeneralAudienceSeedStatus.DRAFT : request.status());
+        seed.setBusinessGoal(normalizeOptionalText(request.businessGoal()));
+        seed.setRiskNotes(normalizeOptionalText(request.riskNotes()));
+        return toResponse(seedRepository.save(seed));
+    }
+
+    /** Detalha uma semente para deixar claro que ela ainda precisa ser quebrada em subnichos e dores. */
+    @Transactional(readOnly = true)
+    public GeneralAudienceSeedResponse getSeed(Long seedId) {
+        return toResponse(findSeed(seedId));
+    }
+
+    /** Atualiza campos manuais da semente sem acionar descoberta automática ou publicação de campanha. */
+    @Transactional
+    public GeneralAudienceSeedResponse updateSeed(Long seedId, UpdateGeneralAudienceSeedRequest request) {
+        OprmGeneralAudienceSeed seed = findSeed(seedId);
+        if (request.name() != null) {
+            seed.setName(requiredText(request.name(), "name"));
+        }
+        if (request.description() != null) {
+            seed.setDescription(normalizeOptionalText(request.description()));
+        }
+        if (request.marketContext() != null) {
+            seed.setMarketContext(normalizeOptionalText(request.marketContext()));
+        }
+        if (request.country() != null) {
+            seed.setCountry(requiredText(request.country(), "country"));
+        }
+        if (request.language() != null) {
+            seed.setLanguage(requiredText(request.language(), "language"));
+        }
+        if (request.seedType() != null) {
+            seed.setSeedType(request.seedType());
+        }
+        if (request.status() != null) {
+            seed.setStatus(request.status());
+        }
+        if (request.businessGoal() != null) {
+            seed.setBusinessGoal(normalizeOptionalText(request.businessGoal()));
+        }
+        if (request.riskNotes() != null) {
+            seed.setRiskNotes(normalizeOptionalText(request.riskNotes()));
+        }
+        return toResponse(seedRepository.save(seed));
+    }
+
+    /** Arquiva a semente para removê-la do fluxo ativo sem apagar histórico de decisão. */
+    @Transactional
+    public GeneralAudienceSeedResponse archiveSeed(Long seedId) {
+        OprmGeneralAudienceSeed seed = findSeed(seedId);
+        seed.setStatus(OprmGeneralAudienceSeedStatus.ARCHIVED);
+        return toResponse(seedRepository.save(seed));
+    }
+
+    /** Busca a semente ou devolve erro HTTP de recurso inexistente. */
+    private OprmGeneralAudienceSeed findSeed(Long seedId) {
+        return seedRepository.findById(seedId)
+                .orElseThrow(() -> new ResponseStatusException(
+                        HttpStatus.NOT_FOUND,
+                        "Semente de público geral não encontrada: " + seedId));
+    }
+
+    /** Converte a entidade de semente para o contrato detalhado. */
+    private GeneralAudienceSeedResponse toResponse(OprmGeneralAudienceSeed seed) {
+        return new GeneralAudienceSeedResponse(
+                seed.getId(),
+                seed.getName(),
+                seed.getDescription(),
+                seed.getMarketContext(),
+                seed.getCountry(),
+                seed.getLanguage(),
+                seed.getSeedType(),
+                seed.getStatus(),
+                seed.getBusinessGoal(),
+                seed.getRiskNotes(),
+                seed.getCreatedAt(),
+                seed.getUpdatedAt());
+    }
+
+    /** Converte a entidade de semente para o contrato resumido de listagem. */
+    private GeneralAudienceSeedSummaryResponse toSummaryResponse(OprmGeneralAudienceSeed seed) {
+        return new GeneralAudienceSeedSummaryResponse(
+                seed.getId(),
+                seed.getName(),
+                seed.getMarketContext(),
+                seed.getCountry(),
+                seed.getLanguage(),
+                seed.getSeedType(),
+                seed.getStatus(),
+                seed.getUpdatedAt());
+    }
+
+    /** Normaliza texto obrigatório e rejeita valor vazio para evitar semente sem decisão comercial. */
+    private String requiredText(String value, String fieldName) {
+        if (!StringUtils.hasText(value)) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, fieldName + " não pode ficar vazio");
+        }
+        return value.trim();
+    }
+
+    /** Aplica valor padrão quando o campo opcional não foi informado. */
+    private String resolveDefaultText(String value, String defaultValue) {
+        if (!StringUtils.hasText(value)) {
+            return defaultValue;
+        }
+        return value.trim();
+    }
+
+    /** Normaliza textos opcionais para persistir nulo em vez de conteúdo vazio. */
+    private String normalizeOptionalText(String value) {
+        if (!StringUtils.hasText(value)) {
+            return null;
+        }
+        return value.trim();
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/generalaudience/service/createSeed/CreateGeneralAudienceSeedRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/generalaudience/service/createSeed/CreateGeneralAudienceSeedRequest.java
@@ -1,0 +1,21 @@
+package com.marketinghub.oprm.generalaudience.service.createSeed;
+
+import com.marketinghub.oprm.generalaudience.OprmGeneralAudienceSeedStatus;
+import com.marketinghub.oprm.generalaudience.OprmGeneralAudienceSeedType;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Size;
+
+/** Contrato de entrada para cadastrar uma semente manual de público geral. */
+public record CreateGeneralAudienceSeedRequest(
+        @NotBlank @Size(max = 191) String name,
+        String description,
+        String marketContext,
+        @Size(max = 64) String country,
+        @Size(max = 32) String language,
+        @NotNull OprmGeneralAudienceSeedType seedType,
+        OprmGeneralAudienceSeedStatus status,
+        String businessGoal,
+        String riskNotes
+) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/generalaudience/service/getSeed/GeneralAudienceSeedResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/generalaudience/service/getSeed/GeneralAudienceSeedResponse.java
@@ -1,0 +1,22 @@
+package com.marketinghub.oprm.generalaudience.service.getSeed;
+
+import com.marketinghub.oprm.generalaudience.OprmGeneralAudienceSeedStatus;
+import com.marketinghub.oprm.generalaudience.OprmGeneralAudienceSeedType;
+import java.time.Instant;
+
+/** Contrato de saída com todos os campos editáveis da semente de público geral. */
+public record GeneralAudienceSeedResponse(
+        Long id,
+        String name,
+        String description,
+        String marketContext,
+        String country,
+        String language,
+        OprmGeneralAudienceSeedType seedType,
+        OprmGeneralAudienceSeedStatus status,
+        String businessGoal,
+        String riskNotes,
+        Instant createdAt,
+        Instant updatedAt
+) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/generalaudience/service/listSeeds/GeneralAudienceSeedSummaryResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/generalaudience/service/listSeeds/GeneralAudienceSeedSummaryResponse.java
@@ -1,0 +1,18 @@
+package com.marketinghub.oprm.generalaudience.service.listSeeds;
+
+import com.marketinghub.oprm.generalaudience.OprmGeneralAudienceSeedStatus;
+import com.marketinghub.oprm.generalaudience.OprmGeneralAudienceSeedType;
+import java.time.Instant;
+
+/** Contrato de saída resumido para seleção e listagem de sementes de público geral. */
+public record GeneralAudienceSeedSummaryResponse(
+        Long id,
+        String name,
+        String marketContext,
+        String country,
+        String language,
+        OprmGeneralAudienceSeedType seedType,
+        OprmGeneralAudienceSeedStatus status,
+        Instant updatedAt
+) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/generalaudience/service/updateSeed/UpdateGeneralAudienceSeedRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/generalaudience/service/updateSeed/UpdateGeneralAudienceSeedRequest.java
@@ -1,0 +1,19 @@
+package com.marketinghub.oprm.generalaudience.service.updateSeed;
+
+import com.marketinghub.oprm.generalaudience.OprmGeneralAudienceSeedStatus;
+import com.marketinghub.oprm.generalaudience.OprmGeneralAudienceSeedType;
+import jakarta.validation.constraints.Size;
+
+/** Contrato de entrada para revisar manualmente uma semente de público geral. */
+public record UpdateGeneralAudienceSeedRequest(
+        @Size(max = 191) String name,
+        String description,
+        String marketContext,
+        @Size(max = 64) String country,
+        @Size(max = 32) String language,
+        OprmGeneralAudienceSeedType seedType,
+        OprmGeneralAudienceSeedStatus status,
+        String businessGoal,
+        String riskNotes
+) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/oprm/generalaudience/OprmGeneralAudienceSeedRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/oprm/generalaudience/OprmGeneralAudienceSeedRepository.java
@@ -1,0 +1,11 @@
+package com.marketinghub.repository.jpa.oprm.generalaudience;
+
+import com.marketinghub.oprm.generalaudience.OprmGeneralAudienceSeed;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/** Repositório JPA responsável pela persistência das sementes de público geral do OPRM. */
+public interface OprmGeneralAudienceSeedRepository extends JpaRepository<OprmGeneralAudienceSeed, Long> {
+    /** Lista as sementes mais recentes para revisão manual do usuário. */
+    List<OprmGeneralAudienceSeed> findAllByOrderByUpdatedAtDesc();
+}

--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-10-oprm-general-audience-seed.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-10-oprm-general-audience-seed.yaml
@@ -1,0 +1,35 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-06-10-01-oprm-general-audience-seed
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - onError: HALT
+        - dbms:
+            type: mysql
+        - not:
+            tableExists:
+              tableName: oprm_general_audience_seed
+      changes:
+        - sql:
+            splitStatements: true
+            stripComments: true
+            sql: |
+              CREATE TABLE oprm_general_audience_seed (
+                id BIGINT NOT NULL AUTO_INCREMENT,
+                name VARCHAR(191) NOT NULL,
+                description LONGTEXT NULL,
+                market_context LONGTEXT NULL,
+                country VARCHAR(64) NOT NULL DEFAULT 'BR',
+                language VARCHAR(32) NOT NULL DEFAULT 'pt-BR',
+                seed_type VARCHAR(32) NOT NULL,
+                status VARCHAR(32) NOT NULL,
+                business_goal LONGTEXT NULL,
+                risk_notes LONGTEXT NULL,
+                created_at DATETIME NOT NULL,
+                updated_at DATETIME NOT NULL,
+                CONSTRAINT pk_oprm_general_audience_seed PRIMARY KEY (id)
+              );
+              CREATE INDEX idx_oprm_general_audience_seed_status ON oprm_general_audience_seed (status, updated_at);
+              CREATE INDEX idx_oprm_general_audience_seed_type ON oprm_general_audience_seed (seed_type, updated_at);
+              CREATE INDEX idx_oprm_general_audience_seed_locale ON oprm_general_audience_seed (country, language, updated_at);

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -1,5 +1,8 @@
 databaseChangeLog:
   - include:
+      file: changesets/2026-06-10-oprm-general-audience-seed.yaml
+      relativeToChangelogFile: true
+  - include:
       file: changesets/2026-06-09-oprm-source-freshness-mei-classification.yaml
       relativeToChangelogFile: true
   - include:

--- a/backend/ads-service/src/test/java/com/marketinghub/oprm/generalaudience/controller/OprmGeneralAudienceControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/oprm/generalaudience/controller/OprmGeneralAudienceControllerTest.java
@@ -1,0 +1,97 @@
+package com.marketinghub.oprm.generalaudience.controller;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marketinghub.oprm.generalaudience.OprmGeneralAudienceSeedStatus;
+import com.marketinghub.oprm.generalaudience.OprmGeneralAudienceSeedType;
+import com.marketinghub.oprm.generalaudience.service.OprmGeneralAudienceService;
+import com.marketinghub.oprm.generalaudience.service.createSeed.CreateGeneralAudienceSeedRequest;
+import com.marketinghub.oprm.generalaudience.service.getSeed.GeneralAudienceSeedResponse;
+import com.marketinghub.oprm.generalaudience.service.listSeeds.GeneralAudienceSeedSummaryResponse;
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+/** Valida o contrato HTTP da etapa de cadastro manual de sementes de público geral do OPRM. */
+@WebMvcTest(OprmGeneralAudienceController.class)
+class OprmGeneralAudienceControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @Autowired
+    ObjectMapper objectMapper;
+
+    @MockBean
+    OprmGeneralAudienceService service;
+
+    /** Verifica se a API lista sementes para seleção operacional. */
+    @Test
+    void shouldListSeedsThroughApi() throws Exception {
+        when(service.listSeeds()).thenReturn(List.of(new GeneralAudienceSeedSummaryResponse(
+                1L,
+                "Beleza",
+                "Agenda, WhatsApp e Instagram",
+                "BR",
+                "pt-BR",
+                OprmGeneralAudienceSeedType.CATEGORY,
+                OprmGeneralAudienceSeedStatus.DRAFT,
+                Instant.parse("2026-06-10T10:00:00Z"))));
+
+        mockMvc.perform(get("/api/oprm/general-audiences/seeds"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].id").value(1))
+                .andExpect(jsonPath("$[0].name").value("Beleza"))
+                .andExpect(jsonPath("$[0].status").value("DRAFT"));
+    }
+
+    /** Verifica se a API cadastra semente sem acionar campanha ou descoberta automática. */
+    @Test
+    void shouldCreateSeedThroughApi() throws Exception {
+        when(service.createSeed(any())).thenReturn(new GeneralAudienceSeedResponse(
+                2L,
+                "Beleza",
+                "Profissionais autônomas",
+                "Agenda, WhatsApp e Instagram",
+                "BR",
+                "pt-BR",
+                OprmGeneralAudienceSeedType.CATEGORY,
+                OprmGeneralAudienceSeedStatus.DRAFT,
+                "Gerar leads qualificados",
+                "Evitar promessa absoluta",
+                Instant.parse("2026-06-10T10:00:00Z"),
+                Instant.parse("2026-06-10T10:00:00Z")));
+        CreateGeneralAudienceSeedRequest request = new CreateGeneralAudienceSeedRequest(
+                "Beleza",
+                "Profissionais autônomas",
+                "Agenda, WhatsApp e Instagram",
+                null,
+                null,
+                OprmGeneralAudienceSeedType.CATEGORY,
+                null,
+                "Gerar leads qualificados",
+                "Evitar promessa absoluta");
+
+        mockMvc.perform(post("/api/oprm/general-audiences/seeds")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isCreated())
+                .andExpect(header().string(HttpHeaders.LOCATION, "/api/oprm/general-audiences/seeds/2"))
+                .andExpect(jsonPath("$.id").value(2))
+                .andExpect(jsonPath("$.name").value("Beleza"))
+                .andExpect(jsonPath("$.seedType").value("CATEGORY"));
+    }
+}

--- a/backend/ads-service/src/test/java/com/marketinghub/oprm/generalaudience/service/OprmGeneralAudienceServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/oprm/generalaudience/service/OprmGeneralAudienceServiceTest.java
@@ -1,0 +1,143 @@
+package com.marketinghub.oprm.generalaudience.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.marketinghub.oprm.generalaudience.OprmGeneralAudienceSeed;
+import com.marketinghub.oprm.generalaudience.OprmGeneralAudienceSeedStatus;
+import com.marketinghub.oprm.generalaudience.OprmGeneralAudienceSeedType;
+import com.marketinghub.oprm.generalaudience.service.createSeed.CreateGeneralAudienceSeedRequest;
+import com.marketinghub.oprm.generalaudience.service.updateSeed.UpdateGeneralAudienceSeedRequest;
+import com.marketinghub.repository.jpa.oprm.generalaudience.OprmGeneralAudienceSeedRepository;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.server.ResponseStatusException;
+
+/** Valida o cadastro manual de sementes amplas de público geral sem acionar o fluxo NichoCNAE. */
+class OprmGeneralAudienceServiceTest {
+
+    /** Verifica se a criação normaliza campos e aplica padrões comerciais seguros. */
+    @Test
+    void shouldCreateSeedWithDefaults() {
+        OprmGeneralAudienceSeedRepository repository = mock(OprmGeneralAudienceSeedRepository.class);
+        OprmGeneralAudienceService service = new OprmGeneralAudienceService(repository);
+        when(repository.save(any())).thenAnswer(invocation -> {
+            OprmGeneralAudienceSeed seed = invocation.getArgument(0);
+            seed.setId(10L);
+            seed.setCreatedAt(Instant.parse("2026-06-10T10:00:00Z"));
+            seed.setUpdatedAt(Instant.parse("2026-06-10T10:00:00Z"));
+            return seed;
+        });
+
+        var response = service.createSeed(new CreateGeneralAudienceSeedRequest(
+                " Beleza ",
+                " Profissionais autônomas ",
+                " WhatsApp e Instagram ",
+                null,
+                null,
+                OprmGeneralAudienceSeedType.CATEGORY,
+                null,
+                " Gerar leads qualificados ",
+                " Evitar promessa de resultado garantido "));
+
+        assertThat(response.id()).isEqualTo(10L);
+        assertThat(response.name()).isEqualTo("Beleza");
+        assertThat(response.country()).isEqualTo("BR");
+        assertThat(response.language()).isEqualTo("pt-BR");
+        assertThat(response.status()).isEqualTo(OprmGeneralAudienceSeedStatus.DRAFT);
+        assertThat(response.seedType()).isEqualTo(OprmGeneralAudienceSeedType.CATEGORY);
+    }
+
+    /** Verifica se a listagem retorna sementes em contrato resumido para seleção operacional. */
+    @Test
+    void shouldListSeedSummaries() {
+        OprmGeneralAudienceSeedRepository repository = mock(OprmGeneralAudienceSeedRepository.class);
+        OprmGeneralAudienceService service = new OprmGeneralAudienceService(repository);
+        OprmGeneralAudienceSeed seed = seed(7L, OprmGeneralAudienceSeedStatus.READY_FOR_RESEARCH);
+        when(repository.findAllByOrderByUpdatedAtDesc()).thenReturn(List.of(seed));
+
+        var response = service.listSeeds();
+
+        assertThat(response).hasSize(1);
+        assertThat(response.get(0).id()).isEqualTo(7L);
+        assertThat(response.get(0).name()).isEqualTo("Beleza");
+        assertThat(response.get(0).status()).isEqualTo(OprmGeneralAudienceSeedStatus.READY_FOR_RESEARCH);
+    }
+
+    /** Verifica se a atualização mantém campos ausentes e altera apenas decisões enviadas. */
+    @Test
+    void shouldUpdateOnlyProvidedFields() {
+        OprmGeneralAudienceSeedRepository repository = mock(OprmGeneralAudienceSeedRepository.class);
+        OprmGeneralAudienceService service = new OprmGeneralAudienceService(repository);
+        OprmGeneralAudienceSeed seed = seed(8L, OprmGeneralAudienceSeedStatus.DRAFT);
+        when(repository.findById(8L)).thenReturn(Optional.of(seed));
+        when(repository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        var response = service.updateSeed(8L, new UpdateGeneralAudienceSeedRequest(
+                " Beleza profissional ",
+                null,
+                null,
+                null,
+                null,
+                null,
+                OprmGeneralAudienceSeedStatus.READY_FOR_RESEARCH,
+                null,
+                " Revisado para evitar promessa absoluta "));
+
+        assertThat(response.name()).isEqualTo("Beleza profissional");
+        assertThat(response.description()).isEqualTo("Profissionais autônomas de beleza");
+        assertThat(response.status()).isEqualTo(OprmGeneralAudienceSeedStatus.READY_FOR_RESEARCH);
+        assertThat(response.riskNotes()).isEqualTo("Revisado para evitar promessa absoluta");
+    }
+
+    /** Verifica se o arquivamento preserva a semente e altera somente o status operacional. */
+    @Test
+    void shouldArchiveSeed() {
+        OprmGeneralAudienceSeedRepository repository = mock(OprmGeneralAudienceSeedRepository.class);
+        OprmGeneralAudienceService service = new OprmGeneralAudienceService(repository);
+        OprmGeneralAudienceSeed seed = seed(9L, OprmGeneralAudienceSeedStatus.PAUSED);
+        when(repository.findById(9L)).thenReturn(Optional.of(seed));
+        when(repository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        var response = service.archiveSeed(9L);
+
+        assertThat(response.status()).isEqualTo(OprmGeneralAudienceSeedStatus.ARCHIVED);
+        verify(repository).save(seed);
+    }
+
+    /** Verifica se a busca de semente inexistente devolve erro claro de recurso não encontrado. */
+    @Test
+    void shouldRejectMissingSeed() {
+        OprmGeneralAudienceSeedRepository repository = mock(OprmGeneralAudienceSeedRepository.class);
+        OprmGeneralAudienceService service = new OprmGeneralAudienceService(repository);
+        when(repository.findById(404L)).thenReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.getSeed(404L))
+                .isInstanceOf(ResponseStatusException.class)
+                .hasMessageContaining("Semente de público geral não encontrada");
+    }
+
+    /** Monta uma semente completa para os cenários de revisão manual. */
+    private OprmGeneralAudienceSeed seed(Long id, OprmGeneralAudienceSeedStatus status) {
+        OprmGeneralAudienceSeed seed = new OprmGeneralAudienceSeed();
+        seed.setId(id);
+        seed.setName("Beleza");
+        seed.setDescription("Profissionais autônomas de beleza");
+        seed.setMarketContext("Agenda, WhatsApp e Instagram");
+        seed.setCountry("BR");
+        seed.setLanguage("pt-BR");
+        seed.setSeedType(OprmGeneralAudienceSeedType.CATEGORY);
+        seed.setStatus(status);
+        seed.setBusinessGoal("Gerar leads qualificados");
+        seed.setRiskNotes("Evitar promessa absoluta");
+        seed.setCreatedAt(Instant.parse("2026-06-10T09:00:00Z"));
+        seed.setUpdatedAt(Instant.parse("2026-06-10T10:00:00Z"));
+        return seed;
+    }
+}

--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -324,3 +324,8 @@
 - 2026-06-10 00:00:00 (UTC): executada a etapa 7 do plano de redirecionamento OPRM NichoCNAE para MEI/autônomo: criada a etapa `oprmMeiAudienceSegmenter` após a síntese de rotina para transformar sinais, fontes recentes, indicadores e cartão de rotina em perfil comportamental MEI/autônomo persistido em `oprm_mei_audience_profile`; o backend expõe pendência/conclusão/falha, o coletor processa e valida o perfil sem produto/oferta/campanha/solução, e o gate de qualidade passa a aguardar a segmentação antes de avaliar o cartão.
 - 2026-06-10 00:00:00 (UTC): criado plano de implementação para inserir públicos gerais no Marketing Hub como fluxo OPRM separado do NichoCNAE, usando sementes, subnichos, ângulos, quality gate e conversão controlada para nicho/hipótese/experimento sem criar CNAEs artificiais nem sobrepor o pipeline atual.
 - 2026-06-10 00:00:00 (UTC): executada a etapa 8 do plano de redirecionamento NichoCNAE para público MEI/autônomo. A extração de sinais do coletor OPRM passou a classificar modo de trabalho autônomo, aquisição de clientes, canais, dores práticas/emocionais, sonhos, medos, status, pressão de tempo, instabilidade de renda, reputação, preço e cancelamentos com evidência curta; a síntese de rotina passou a persistir e expor blocos comportamentais separados no backend, mantendo compatibilidade com os campos legados e bloqueando promoção de linguagem de solução/oferta.
+
+## 2026-06-10 — OPRM Públicos Gerais: cadastro de sementes
+
+- Implementada a etapa 1 do plano de públicos gerais sem sobreposição CNAE: cadastro, listagem, detalhe, atualização e arquivamento manual de sementes de público geral no backend.
+- O fluxo permanece separado do NichoCNAE e não cria nicho, hipótese, experimento ou campanha automaticamente.

--- a/docs/swagger/oprm-general-audiences-swagger.yaml
+++ b/docs/swagger/oprm-general-audiences-swagger.yaml
@@ -1,0 +1,206 @@
+openapi: 3.0.3
+info:
+  title: OPRM Públicos Gerais API
+  version: 0.1.0
+  description: Endpoints do backend para cadastro e revisão manual de sementes de públicos gerais antes de virar subnicho, nicho ou campanha.
+tags:
+  - name: OPRM Públicos Gerais
+paths:
+  /api/oprm/general-audiences/seeds:
+    get:
+      summary: Lista sementes de público geral cadastradas.
+      tags: [OPRM Públicos Gerais]
+      responses:
+        '200':
+          description: Sementes ordenadas pela atualização mais recente.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/GeneralAudienceSeedSummary'
+    post:
+      summary: Cadastra uma semente de público geral.
+      tags: [OPRM Públicos Gerais]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateGeneralAudienceSeedRequest'
+      responses:
+        '201':
+          description: Semente cadastrada para revisão manual, ainda sem status de nicho ou campanha.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralAudienceSeed'
+        '400':
+          description: Payload inválido.
+  /api/oprm/general-audiences/seeds/{seedId}:
+    get:
+      summary: Detalha uma semente de público geral.
+      tags: [OPRM Públicos Gerais]
+      parameters:
+        - $ref: '#/components/parameters/SeedId'
+      responses:
+        '200':
+          description: Detalhe da semente para revisão operacional.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralAudienceSeed'
+        '404':
+          description: Semente não encontrada.
+    patch:
+      summary: Atualiza campos manuais de uma semente de público geral.
+      tags: [OPRM Públicos Gerais]
+      parameters:
+        - $ref: '#/components/parameters/SeedId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateGeneralAudienceSeedRequest'
+      responses:
+        '200':
+          description: Semente atualizada sem acionar descoberta automática ou publicação.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralAudienceSeed'
+        '400':
+          description: Payload inválido.
+        '404':
+          description: Semente não encontrada.
+  /api/oprm/general-audiences/seeds/{seedId}/archive:
+    post:
+      summary: Arquiva uma semente de público geral.
+      tags: [OPRM Públicos Gerais]
+      parameters:
+        - $ref: '#/components/parameters/SeedId'
+      responses:
+        '200':
+          description: Semente arquivada sem perda de histórico.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralAudienceSeed'
+        '404':
+          description: Semente não encontrada.
+components:
+  parameters:
+    SeedId:
+      name: seedId
+      in: path
+      required: true
+      schema:
+        type: integer
+        format: int64
+  schemas:
+    SeedType:
+      type: string
+      enum: [CATEGORY, DESIRE, LIFE_CONTEXT, BEHAVIOR, CHANNEL, PAIN_CLUSTER]
+    SeedStatus:
+      type: string
+      enum: [DRAFT, READY_FOR_RESEARCH, RESEARCHING, MAPPED, PAUSED, ARCHIVED]
+    CreateGeneralAudienceSeedRequest:
+      type: object
+      required: [name, seedType]
+      properties:
+        name:
+          type: string
+          maxLength: 191
+          example: Beleza
+        description:
+          type: string
+          nullable: true
+          example: Profissionais autônomas que dependem de agenda, WhatsApp e Instagram para vender serviços.
+        marketContext:
+          type: string
+          nullable: true
+        country:
+          type: string
+          maxLength: 64
+          default: BR
+        language:
+          type: string
+          maxLength: 32
+          default: pt-BR
+        seedType:
+          $ref: '#/components/schemas/SeedType'
+        status:
+          $ref: '#/components/schemas/SeedStatus'
+        businessGoal:
+          type: string
+          nullable: true
+        riskNotes:
+          type: string
+          nullable: true
+    UpdateGeneralAudienceSeedRequest:
+      type: object
+      properties:
+        name:
+          type: string
+          maxLength: 191
+        description:
+          type: string
+          nullable: true
+        marketContext:
+          type: string
+          nullable: true
+        country:
+          type: string
+          maxLength: 64
+        language:
+          type: string
+          maxLength: 32
+        seedType:
+          $ref: '#/components/schemas/SeedType'
+        status:
+          $ref: '#/components/schemas/SeedStatus'
+        businessGoal:
+          type: string
+          nullable: true
+        riskNotes:
+          type: string
+          nullable: true
+    GeneralAudienceSeed:
+      allOf:
+        - $ref: '#/components/schemas/CreateGeneralAudienceSeedRequest'
+        - type: object
+          required: [id, name, country, language, seedType, status, createdAt, updatedAt]
+          properties:
+            id:
+              type: integer
+              format: int64
+            createdAt:
+              type: string
+              format: date-time
+            updatedAt:
+              type: string
+              format: date-time
+    GeneralAudienceSeedSummary:
+      type: object
+      required: [id, name, country, language, seedType, status, updatedAt]
+      properties:
+        id:
+          type: integer
+          format: int64
+        name:
+          type: string
+        marketContext:
+          type: string
+          nullable: true
+        country:
+          type: string
+        language:
+          type: string
+        seedType:
+          $ref: '#/components/schemas/SeedType'
+        status:
+          $ref: '#/components/schemas/SeedStatus'
+        updatedAt:
+          type: string
+          format: date-time


### PR DESCRIPTION
### Motivation
- Implementar a Etapa 1 do plano de Públicos Gerais para permitir cadastro e revisão manual de sementes (origem separada do fluxo CNAE) sem gerar nicho/hipótese/experimento/campanha automaticamente.
- Evitar sobreposição com o pipeline NichoCNAE garantindo rastreabilidade e contrato persistente próprio para públicos amplos.

### Description
- Adiciona entidade JPA `OprmGeneralAudienceSeed`, enums `OprmGeneralAudienceSeedType` e `OprmGeneralAudienceSeedStatus`, e repositório central `OprmGeneralAudienceSeedRepository` em `com.marketinghub.repository.jpa.oprm.generalaudience` para persistência consistente com o padrão do backend.
- Implementa serviço único `OprmGeneralAudienceService` e controller único `OprmGeneralAudienceController` com endpoints `GET/POST /api/oprm/general-audiences/seeds`, `GET/PATCH /api/oprm/general-audiences/seeds/{seedId}` e `POST /api/oprm/general-audiences/seeds/{seedId}/archive` e contratos DTOs/records organizados por operação em `service.*`.
- Cria changelog Liquibase `2026-06-10-oprm-general-audience-seed.yaml` e o inclui no `db.changelog-master.yaml` para criar a tabela `oprm_general_audience_seed` com índices de status/tipo/locale.
- Adiciona documentação OpenAPI em `docs/swagger/oprm-general-audiences-swagger.yaml` e registra a atividade em `docs/registros/oprm1.md`.
- Inclui testes unitários para o service (`OprmGeneralAudienceServiceTest`) e testes de contrato HTTP do controller (`OprmGeneralAudienceControllerTest`).

### Testing
- Executados os testes unitários do módulo ads-service com: `../mvnw -Dtest=OprmGeneralAudienceServiceTest,OprmGeneralAudienceControllerTest test`, que retornaram `BUILD SUCCESS` e `Tests run: 7, Failures: 0, Errors: 0`.
- Executado `../mvnw -Dtest=ArquiteturaTest test` para validar regras de arquitetura, que retornou `BUILD SUCCESS` e `Tests run: 47, Failures: 0, Errors: 0`.
- Verificações estáticas: `git diff --cached --check` não apresentou problemas.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a28dad89538832080e8ff7a3928c757)