### PR TITLE
docs: registrar melhorias sistêmicas do experimento 37

### DIFF
--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -4278,3 +4278,16 @@
 - impacto esperado: o sistema dá mais tempo para a Meta estabilizar a entrega antes de concluir que o experimento não teve distribuição mínima útil.
 - foi feito: definida a regra canônica de 24 horas com menos de 100 impressões, registrando `LOW_IMPRESSIONS_AFTER_RUNNING_TIME` em `facebook_ads_campaign.stop_reason`, invalidando o experimento e solicitando pausa ao Facebook Ads Worker.
 - impacto esperado: experimentos com distribuição inviável deixam de ficar rodando indefinidamente e o time ganha motivo claro no banco para decidir ajuste de público, criativo ou nova liberação.
+
+## 2026-06-10 00:42:23 UTC-3
+- solicitação para analisar a conclusão do experimento 37 e extrair melhorias aplicáveis ao sistema como um todo, não apenas ao experimento citado.
+- raciocínio aplicado: preservar a hipótese comercial quando houver sinal de atenção no topo do funil, mas transformar a falha de captura em melhoria sistêmica para evitar desperdício de mídia e invalidação indevida de hipóteses.
+- foi feito: adição de uma seção de melhorias sistêmicas no relatório de conclusão do experimento 37, cobrindo gates de publicação, distinção entre falha técnica e falha comercial, persona mínima, isca ligada ao momento de dor, criativos por rotas comerciais, segmentação, reaproveitamento do relatório no próximo ciclo e painel geral de gargalos.
+- documentos/arquivos lidos para tratar a situação:
+  - AGENTS.md
+  - docs/relatorios/experimentos/conclusao-do-experimento-37.md
+  - docs/relatorios/experimentos/experimento-37-relatorio-completo.md
+  - docs/canonical/procedimento-experimento-canon.v1.md
+  - docs/canonical/facebook-campaign-publication-canon.v1.md
+  - docs/canonical/geralanding-arquitetura-canon.v1.md
+  - docs/registros/experimentos.md

--- a/docs/relatorios/experimentos/conclusao-do-experimento-37.md
+++ b/docs/relatorios/experimentos/conclusao-do-experimento-37.md
@@ -270,6 +270,7 @@ Validar se a dor de preço no WhatsApp converte melhor do que a promessa mais am
 - [ ] Prova visual legível antes do formulário.
 - [ ] Métrica primária definida antes da publicação.
 
+
 ## 10. Conclusão final
 
 O experimento 37 mostrou que existe atenção inicial para a dor, mas não provou rejeição do mercado ao produto. O aprendizado principal é que a próxima rodada precisa ser mais simples e mais próxima da venda real do personal: **WhatsApp, objeção de preço e próximo passo**.
@@ -279,3 +280,133 @@ A melhor melhoria é sair de uma oferta ampla (“prévia de ciclo de 8 semanas�
 > “Personal trainer, receba um roteiro pronto para responder ‘quanto custa?’ sem dar desconto.”
 
 Essa rota reduz esforço mental, aumenta clareza do benefício e conversa diretamente com o momento em que o personal sente a dor e perde dinheiro.
+
+## 11. Melhorias sistêmicas para o Marketing Hub
+
+A leitura do experimento 37 expõe melhorias que devem virar capacidade geral do sistema, não apenas correção de um único teste. O objetivo é proteger a verba de mídia, aumentar a qualidade do aprendizado e acelerar a criação de ofertas que realmente vendem.
+
+### 11.1 Bloqueio de publicação por qualidade funcional da captura
+
+O sistema não deve permitir publicação paga quando a captura ainda não foi validada ponta a ponta.
+
+**Melhoria geral recomendada:** criar um gate obrigatório de pré-publicação que só libera mídia quando houver:
+
+1. envio real de teste do formulário;
+2. criação do lead no backend;
+3. registro do evento de envio no funil;
+4. confirmação de entrega da amostra, e-mail ou próximo passo;
+5. ausência de recomendação `REGENERATE_BEFORE_PUBLICATION` na revisão de landing.
+
+**Impacto esperado:** evita que o sistema invalide hipóteses promissoras por falha técnica de landing/formulário.
+
+### 11.2 Diagnóstico separado entre falha comercial e falha técnica
+
+O funil atual consegue indicar zero envio após volume mínimo, mas a decisão operacional precisa separar melhor duas situações diferentes:
+
+- **falha comercial:** a promessa, público ou oferta não gerou desejo suficiente;
+- **falha técnica:** o usuário tentou ou chegou ao ponto de conversão, mas a captura não funcionou ou gerou fricção indevida.
+
+**Melhoria geral recomendada:** todo relatório de conclusão deve classificar a invalidação em uma dessas categorias antes de recomendar abandono, repetição ou derivação da hipótese.
+
+**Impacto esperado:** melhora a qualidade da decisão e reduz descarte indevido de nichos, dores e mecanismos.
+
+### 11.3 Persona mínima obrigatória antes de gerar ativos
+
+Uma persona preenchida como “teste” enfraquece todos os ativos gerados: anúncio, landing, isca, promessa, CTA e segmentação.
+
+**Melhoria geral recomendada:** bloquear a geração/publicação quando a persona não tiver pelo menos:
+
+1. papel profissional claro;
+2. maturidade do negócio;
+3. canal principal de venda;
+4. objeção dominante;
+5. situação de dor concreta;
+6. resultado financeiro desejado.
+
+**Impacto esperado:** melhora a especificidade da oferta e aumenta a chance de o criativo falar com uma dor real de compra.
+
+### 11.4 Isca alinhada ao momento de dor mais próximo da venda
+
+O experimento indicou que uma oferta ampla pode gerar curiosidade, mas não necessariamente ação. Para o sistema como um todo, a isca deve nascer do momento em que o cliente sente a dor com mais urgência.
+
+**Melhoria geral recomendada:** adicionar uma validação de “momento de dor” antes de publicar a landing:
+
+- onde a dor acontece?
+- o que a pessoa está tentando fazer nesse momento?
+- qual frase ela diria se estivesse pedindo ajuda?
+- qual ativo resolve uma parte do problema em menos de 5 minutos?
+
+**Impacto esperado:** mais leads qualificados, menos curiosos e maior ligação entre clique, landing e formulário.
+
+### 11.5 Criativos com rotas comerciais realmente diferentes
+
+Criativos muito parecidos reduzem o aprendizado. O sistema precisa testar ângulos diferentes, não apenas variações superficiais de texto.
+
+**Melhoria geral recomendada:** exigir pelo menos três rotas comerciais antes de publicar campanhas exploratórias:
+
+1. rota da dor imediata;
+2. rota do resultado desejado;
+3. rota do mecanismo/prova.
+
+Cada rota deve ter headline, promessa, imagem e CTA coerentes com uma única dor principal.
+
+**Impacto esperado:** o experimento passa a descobrir qual argumento vende melhor, e não apenas se uma peça isolada performa.
+
+### 11.6 Segmentação mínima por maturidade e contexto
+
+Campanhas amplas podem ser úteis em escala, mas são ruins para aprender quando a persona ainda está pouco definida.
+
+**Melhoria geral recomendada:** exigir uma segmentação mínima de contexto para testes iniciais, com separação por maturidade quando fizer sentido:
+
+- iniciante versus profissional estabelecido;
+- presencial versus online/híbrido;
+- autônomo versus equipe/empresa;
+- venda por WhatsApp versus checkout direto.
+
+**Impacto esperado:** leitura mais limpa dos resultados e menor risco de clique barato sem intenção real.
+
+### 11.7 Relatório de conclusão como entrada automática do próximo experimento
+
+O relatório não deve ficar apenas como documento pós-morte. Ele deve alimentar automaticamente o próximo ciclo.
+
+**Melhoria geral recomendada:** transformar conclusões recorrentes em campos reaproveitáveis no próximo experimento derivado:
+
+1. causa-raiz provável;
+2. hipótese preservada ou descartada;
+3. nova dor de entrada;
+4. nova isca;
+5. bloqueios técnicos obrigatórios;
+6. métrica primária;
+7. regra de parada ajustada.
+
+**Impacto esperado:** reduz repetição de erros e acelera a evolução de Dor → Resultado → Mecanismo → Prova → Oferta.
+
+### 11.8 Painel geral de gargalos por etapa
+
+O aprendizado do experimento 37 é valioso porque mostrou que o topo do funil não era o gargalo principal. Esse tipo de leitura deve ser visível em nível de portfólio.
+
+**Melhoria geral recomendada:** criar uma visão consolidada que mostre, por nicho e por hipótese:
+
+- gargalo mais frequente;
+- taxa de passagem por etapa;
+- custo por etapa;
+- motivos de invalidação;
+- suspeitas técnicas versus falhas comerciais;
+- hipóteses que merecem derivação em vez de descarte.
+
+**Impacto esperado:** o Marketing Hub deixa de olhar experimentos isolados e passa a aprender como fábrica de vendas.
+
+### 11.9 Prevenção de recorrência
+
+A causa-raiz sistêmica é a ausência de uma trava operacional que impeça tráfego pago antes de comprovar que a promessa, a página e a captura estão tecnicamente prontas e comercialmente específicas.
+
+**Correção preventiva recomendada:** tratar o próximo desenvolvimento como melhoria de plataforma:
+
+1. gate funcional de formulário;
+2. gate de qualidade da landing;
+3. gate de persona mínima;
+4. gate de coerência anúncio → landing → CTA;
+5. relatório de conclusão categorizando falha técnica ou comercial;
+6. reaproveitamento obrigatório do aprendizado no experimento derivado.
+
+Essa melhoria protege o objetivo principal do sistema: gerar vendas com menos desperdício de mídia e com aprendizado acumulado a cada ciclo.


### PR DESCRIPTION
### Motivation
- The Experiment 37 conclusion showed a technical capture failure (100 form views → 0 submissions) that risks wasting media spend and invalidating valid hypotheses. 
- The change consolidates platform-level protections so similar failures are detected and blocked before paid traffic is released. 
- The intent is to convert tactical learnings from a single experiment into repeatable system capabilities (gates, persona checks, creative/segmentation rules and reuse of conclusions).

### Description
- Added a new section `## 11. Melhorias sistêmicas para o Marketing Hub` to `docs/relatorios/experimentos/conclusao-do-experimento-37.md` with recommended platform improvements including a pre-publication gate for functional form validation, separation of commercial vs technical failures, persona minimums, moment-of-pain aligned lead magnets, required creative routes, segmentation minima, automated reuse of conclusions and a portfolio-level bottleneck panel. 
- Appended a timestamped record to `docs/registros/experimentos.md` documenting the analysis and the change, following the repository's append-only registration policy. 
- Changes were committed and a PR titled `docs: registrar melhorias sistemicas do experimento 37` was created to capture the documentation updates.

### Testing
- Ran `git diff --check` to validate whitespace/diff sanity, which passed without errors. 
- Verified presence of the new content with `rg -n "Melhorias sistêmicas|gate obrigatório|falha comercial|falha técnica|Persona mínima|Relatório de conclusão como entrada" docs/relatorios/experimentos/conclusao-do-experimento-37.md`, which returned the expected matches. 
- Confirmed working tree and staged commit with `git status --short`, and the commit was created successfully (2 files changed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a28dcaf20f48320a30d01004a7e63ca)