### PR TITLE
Implementa motor de score do aquecimento MOIS

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesPageMarketWarmupScoreEngine.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesPageMarketWarmupScoreEngine.java
@@ -1,0 +1,330 @@
+package com.marketinghub.mois.bibliotecapaginavenda.worker.v1.service;
+
+import com.marketinghub.mois.bibliotecapaginavenda.worker.v1.dto.MoisSalesLibraryDtos.MarketWarmupCompleteRequest;
+import com.marketinghub.mois.bibliotecapaginavenda.worker.v1.dto.MoisSalesLibraryDtos.MarketWarmupEcosystemType;
+import com.marketinghub.mois.bibliotecapaginavenda.worker.v1.dto.MoisSalesLibraryDtos.MarketWarmupRecommendation;
+import com.marketinghub.mois.bibliotecapaginavenda.worker.v1.dto.MoisSalesLibraryDtos.MarketWarmupSignalCompleteItem;
+import com.marketinghub.mois.bibliotecapaginavenda.worker.v1.dto.MoisSalesLibraryDtos.MarketWarmupSignalType;
+import com.marketinghub.mois.bibliotecapaginavenda.worker.v1.dto.MoisSalesLibraryDtos.MarketWarmupSourceCompleteItem;
+import com.marketinghub.mois.bibliotecapaginavenda.worker.v1.dto.MoisSalesLibraryDtos.MarketWarmupSourceType;
+import com.marketinghub.mois.bibliotecapaginavenda.worker.v1.dto.MoisSalesLibraryDtos.MarketWarmupSummaryCompleteItem;
+import com.marketinghub.mois.bibliotecapaginavenda.worker.v1.dto.MoisSalesLibraryDtos.MarketWarmupTemperature;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.EnumMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * Calcula score, temperatura, ecossistema e recomendação da pesquisa de aquecimento de mercado MOIS.
+ */
+class MoisSalesPageMarketWarmupScoreEngine {
+
+    private static final BigDecimal ZERO = BigDecimal.ZERO;
+    private static final BigDecimal TEN = BigDecimal.TEN;
+    private static final BigDecimal SATURATION_THRESHOLD = BigDecimal.valueOf(8);
+
+    /**
+     * Recalcula o resumo final usando fontes e sinais rastreáveis como base explicável do score.
+     */
+    MarketWarmupSummaryCompleteItem calculate(MarketWarmupCompleteRequest request) {
+        DimensionScores dimensions = calculateDimensions(request.sources(), request.signals());
+        BigDecimal score = clamp(dimensions.totalBeforeClamp(), ZERO, BigDecimal.valueOf(100)).setScale(0, RoundingMode.HALF_UP);
+        MarketWarmupTemperature temperature = classifyTemperature(score, dimensions.saturationPenalty());
+        MarketWarmupRecommendation recommendation = classifyRecommendation(score, dimensions.saturationPenalty());
+        MarketWarmupEcosystemType ecosystemType = classifyEcosystem(request.sources(), request.signals(), dimensions.saturationPenalty());
+        MarketWarmupSummaryCompleteItem base = request.summary();
+        return new MarketWarmupSummaryCompleteItem(
+                score,
+                temperature,
+                ecosystemType,
+                recommendation,
+                base.mainPains(),
+                base.mainObjections(),
+                base.mainPromises(),
+                base.mainChannels(),
+                base.mainCompetitors(),
+                chooseText(base.saturationRisk(), saturationText(dimensions.saturationPenalty())),
+                chooseText(base.opportunityRecommendation(), recommendationText(recommendation)),
+                chooseText(base.nextExperimentSuggestion(), experimentSuggestion(recommendation, ecosystemType)));
+    }
+
+    /**
+     * Soma as dimensões comerciais canônicas do Market Warm-up Score.
+     */
+    private DimensionScores calculateDimensions(
+            List<MarketWarmupSourceCompleteItem> sources, List<MarketWarmupSignalCompleteItem> signals) {
+        BigDecimal activity = averageSourceScore(sources, SourceScoreKind.RECENCY).multiply(BigDecimal.valueOf(2));
+        BigDecimal creatorDensity = calculateCreatorDensity(sources, signals);
+        BigDecimal engagement = max(
+                averageSourceScore(sources, SourceScoreKind.ENGAGEMENT).multiply(BigDecimal.valueOf(2)),
+                averageSignalStrength(
+                                signals,
+                                Set.of(
+                                        MarketWarmupSignalType.BUYING_INTENT,
+                                        MarketWarmupSignalType.COMMUNITY_ACTIVITY,
+                                        MarketWarmupSignalType.CHANNEL_FIT))
+                        .multiply(BigDecimal.valueOf(2)));
+        BigDecimal explicitPain = averageSignalStrength(
+                        signals, Set.of(MarketWarmupSignalType.PAIN_EXPLICIT, MarketWarmupSignalType.OBJECTION))
+                .multiply(BigDecimal.valueOf(1.5));
+        BigDecimal offerMaturity = calculateOfferMaturity(sources, signals);
+        BigDecimal socialProof = averageSignalStrength(
+                signals, Set.of(MarketWarmupSignalType.SOCIAL_PROOF, MarketWarmupSignalType.CREATOR_AUTHORITY));
+        BigDecimal saturationPenalty = calculateSaturationPenalty(sources, signals);
+        BigDecimal total = clamp(activity, ZERO, BigDecimal.valueOf(20))
+                .add(clamp(creatorDensity, ZERO, BigDecimal.valueOf(15)))
+                .add(clamp(engagement, ZERO, BigDecimal.valueOf(20)))
+                .add(clamp(explicitPain, ZERO, BigDecimal.valueOf(15)))
+                .add(clamp(offerMaturity, ZERO, BigDecimal.valueOf(10)))
+                .add(clamp(socialProof, ZERO, BigDecimal.valueOf(10)))
+                .subtract(clamp(saturationPenalty, ZERO, TEN));
+        return new DimensionScores(total, clamp(saturationPenalty, ZERO, TEN));
+    }
+
+    /**
+     * Calcula densidade de criadores e especialistas pelo volume de fontes e sinais de autoridade.
+     */
+    private BigDecimal calculateCreatorDensity(
+            List<MarketWarmupSourceCompleteItem> sources, List<MarketWarmupSignalCompleteItem> signals) {
+        long creatorSources = sources.stream()
+                .filter(source -> Set.of(
+                                MarketWarmupSourceType.CREATOR_CONTENT,
+                                MarketWarmupSourceType.SPECIALIST_CONTENT,
+                                MarketWarmupSourceType.SOCIAL_POST,
+                                MarketWarmupSourceType.AFFILIATE_PROMOTION)
+                        .contains(source.sourceType()))
+                .count();
+        BigDecimal authority = averageSignalStrength(signals, Set.of(MarketWarmupSignalType.CREATOR_AUTHORITY)).multiply(BigDecimal.valueOf(0.5));
+        return BigDecimal.valueOf(creatorSources).multiply(BigDecimal.valueOf(3)).add(authority);
+    }
+
+    /**
+     * Calcula maturidade de oferta por presença de concorrentes, afiliados, reviews e prova social.
+     */
+    private BigDecimal calculateOfferMaturity(
+            List<MarketWarmupSourceCompleteItem> sources, List<MarketWarmupSignalCompleteItem> signals) {
+        long offerSources = sources.stream()
+                .filter(source -> Set.of(
+                                MarketWarmupSourceType.PRODUCT_PRESENCE,
+                                MarketWarmupSourceType.COMPETITOR_OFFER,
+                                MarketWarmupSourceType.AFFILIATE_PROMOTION,
+                                MarketWarmupSourceType.REVIEW)
+                        .contains(source.sourceType()))
+                .count();
+        BigDecimal signalStrength = averageSignalStrength(signals, Set.of(MarketWarmupSignalType.COMPETITOR_OFFER, MarketWarmupSignalType.SOCIAL_PROOF));
+        return BigDecimal.valueOf(offerSources).multiply(BigDecimal.valueOf(2)).add(signalStrength.multiply(BigDecimal.valueOf(0.6)));
+    }
+
+    /**
+     * Calcula penalidade de saturação por sinais explícitos e excesso de fontes de concorrência.
+     */
+    private BigDecimal calculateSaturationPenalty(
+            List<MarketWarmupSourceCompleteItem> sources, List<MarketWarmupSignalCompleteItem> signals) {
+        BigDecimal explicitSaturation = averageSignalStrength(signals, Set.of(MarketWarmupSignalType.SATURATION_RISK));
+        long competitorSources = sources.stream()
+                .filter(source -> Set.of(MarketWarmupSourceType.COMPETITOR_OFFER, MarketWarmupSourceType.AFFILIATE_PROMOTION).contains(source.sourceType()))
+                .count();
+        BigDecimal competitionPressure = BigDecimal.valueOf(Math.max(0, competitorSources - 2)).multiply(BigDecimal.valueOf(1.5));
+        return max(explicitSaturation, competitionPressure);
+    }
+
+    /**
+     * Classifica a temperatura comercial seguindo faixas canônicas e bloqueio de saturação alta.
+     */
+    private MarketWarmupTemperature classifyTemperature(BigDecimal score, BigDecimal saturationPenalty) {
+        if (saturationPenalty.compareTo(SATURATION_THRESHOLD) >= 0) {
+            return MarketWarmupTemperature.SATURATED;
+        }
+        if (score.compareTo(BigDecimal.valueOf(80)) >= 0) {
+            return MarketWarmupTemperature.HOT;
+        }
+        if (score.compareTo(BigDecimal.valueOf(60)) >= 0) {
+            return MarketWarmupTemperature.PROMISING;
+        }
+        if (score.compareTo(BigDecimal.valueOf(40)) >= 0) {
+            return MarketWarmupTemperature.WARM;
+        }
+        return MarketWarmupTemperature.COLD;
+    }
+
+    /**
+     * Classifica a recomendação objetiva para decisão comercial da página analisada.
+     */
+    private MarketWarmupRecommendation classifyRecommendation(BigDecimal score, BigDecimal saturationPenalty) {
+        if (saturationPenalty.compareTo(SATURATION_THRESHOLD) >= 0) {
+            return MarketWarmupRecommendation.SATURATED_REQUIRES_ANGLE;
+        }
+        if (score.compareTo(BigDecimal.valueOf(80)) >= 0) {
+            return MarketWarmupRecommendation.PRIORITIZE;
+        }
+        if (score.compareTo(BigDecimal.valueOf(60)) >= 0) {
+            return MarketWarmupRecommendation.OBSERVE;
+        }
+        if (score.compareTo(BigDecimal.valueOf(40)) >= 0) {
+            return MarketWarmupRecommendation.RESEARCH_MORE;
+        }
+        return MarketWarmupRecommendation.DISCARD;
+    }
+
+    /**
+     * Classifica o ecossistema dominante pela força média dos sinais e tipos das fontes encontradas.
+     */
+    private MarketWarmupEcosystemType classifyEcosystem(
+            List<MarketWarmupSourceCompleteItem> sources,
+            List<MarketWarmupSignalCompleteItem> signals,
+            BigDecimal saturationPenalty) {
+        if (saturationPenalty.compareTo(SATURATION_THRESHOLD) >= 0) {
+            return MarketWarmupEcosystemType.SATURATED;
+        }
+        Map<MarketWarmupEcosystemType, BigDecimal> strengths = new EnumMap<>(MarketWarmupEcosystemType.class);
+        strengths.put(MarketWarmupEcosystemType.SPECIALISTS_HEATED, sourceTypeCount(sources, MarketWarmupSourceType.SPECIALIST_CONTENT).multiply(BigDecimal.valueOf(2))
+                .add(averageSignalStrength(signals, Set.of(MarketWarmupSignalType.CREATOR_AUTHORITY))));
+        strengths.put(MarketWarmupEcosystemType.CREATORS_HEATED, sourceTypeCount(sources, MarketWarmupSourceType.CREATOR_CONTENT, MarketWarmupSourceType.SOCIAL_POST).multiply(BigDecimal.valueOf(2))
+                .add(averageSignalStrength(signals, Set.of(MarketWarmupSignalType.CHANNEL_FIT))));
+        strengths.put(MarketWarmupEcosystemType.RECURRING_PAIN_HEATED, sourceTypeCount(sources, MarketWarmupSourceType.COMMUNITY_DISCUSSION, MarketWarmupSourceType.COMPLAINT).multiply(BigDecimal.valueOf(2))
+                .add(averageSignalStrength(signals, Set.of(MarketWarmupSignalType.PAIN_EXPLICIT, MarketWarmupSignalType.COMMUNITY_ACTIVITY))));
+        strengths.put(MarketWarmupEcosystemType.COMPETITORS_HEATED, sourceTypeCount(sources, MarketWarmupSourceType.COMPETITOR_OFFER, MarketWarmupSourceType.AFFILIATE_PROMOTION).multiply(BigDecimal.valueOf(2))
+                .add(averageSignalStrength(signals, Set.of(MarketWarmupSignalType.COMPETITOR_OFFER))));
+        return strengths.entrySet().stream()
+                .max(Comparator.comparing(Map.Entry::getValue))
+                .filter(entry -> entry.getValue().compareTo(BigDecimal.valueOf(3)) >= 0)
+                .map(Map.Entry::getKey)
+                .orElse(MarketWarmupEcosystemType.COLD_OR_UNEDUCATED);
+    }
+
+    /**
+     * Calcula a média de recência ou engajamento das fontes em escala de zero a dez.
+     */
+    private BigDecimal averageSourceScore(List<MarketWarmupSourceCompleteItem> sources, SourceScoreKind kind) {
+        List<BigDecimal> values = sources.stream()
+                .map(source -> kind == SourceScoreKind.RECENCY ? source.recencyScore() : source.engagementScore())
+                .filter(value -> value != null)
+                .map(value -> clamp(value, ZERO, TEN))
+                .toList();
+        return average(values);
+    }
+
+    /**
+     * Calcula a força média dos sinais de tipos comerciais selecionados em escala de zero a dez.
+     */
+    private BigDecimal averageSignalStrength(
+            List<MarketWarmupSignalCompleteItem> signals, Set<MarketWarmupSignalType> signalTypes) {
+        List<BigDecimal> values = signals.stream()
+                .filter(signal -> signalTypes.contains(signal.signalType()))
+                .map(MarketWarmupSignalCompleteItem::signalStrength)
+                .filter(value -> value != null)
+                .map(value -> clamp(value, ZERO, TEN))
+                .toList();
+        return average(values);
+    }
+
+    /**
+     * Conta fontes de tipos selecionados para inferir predominância de ecossistema.
+     */
+    private BigDecimal sourceTypeCount(
+            List<MarketWarmupSourceCompleteItem> sources, MarketWarmupSourceType... sourceTypes) {
+        Set<MarketWarmupSourceType> acceptedTypes = Set.of(sourceTypes);
+        return BigDecimal.valueOf(sources.stream().filter(source -> acceptedTypes.contains(source.sourceType())).count());
+    }
+
+    /**
+     * Calcula média decimal segura para coleções vazias.
+     */
+    private BigDecimal average(Collection<BigDecimal> values) {
+        if (values.isEmpty()) {
+            return ZERO;
+        }
+        BigDecimal total = values.stream().reduce(ZERO, BigDecimal::add);
+        return total.divide(BigDecimal.valueOf(values.size()), 4, RoundingMode.HALF_UP);
+    }
+
+    /**
+     * Mantém valores numéricos dentro dos limites da dimensão comercial.
+     */
+    private BigDecimal clamp(BigDecimal value, BigDecimal min, BigDecimal max) {
+        if (value == null || value.compareTo(min) < 0) {
+            return min;
+        }
+        if (value.compareTo(max) > 0) {
+            return max;
+        }
+        return value;
+    }
+
+    /**
+     * Retorna o maior valor entre duas dimensões calculadas.
+     */
+    private BigDecimal max(BigDecimal first, BigDecimal second) {
+        return first.compareTo(second) >= 0 ? first : second;
+    }
+
+    /**
+     * Usa texto recebido pelo worker quando existe, ou texto padrão do motor quando está vazio.
+     */
+    private String chooseText(String received, String fallback) {
+        return Optional.ofNullable(received)
+                .map(String::trim)
+                .filter(value -> !value.isBlank())
+                .orElse(fallback);
+    }
+
+    /**
+     * Descreve a saturação de forma simples para a UI comercial.
+     */
+    private String saturationText(BigDecimal saturationPenalty) {
+        if (saturationPenalty.compareTo(SATURATION_THRESHOLD) >= 0) {
+            return "alto";
+        }
+        if (saturationPenalty.compareTo(BigDecimal.valueOf(4)) >= 0) {
+            return "moderado";
+        }
+        return "baixo";
+    }
+
+    /**
+     * Gera recomendação objetiva quando o worker não trouxe texto funcional próprio.
+     */
+    private String recommendationText(MarketWarmupRecommendation recommendation) {
+        return switch (recommendation) {
+            case PRIORITIZE -> "Priorizar experimento comercial com este mercado.";
+            case OBSERVE -> "Observar e refinar o ângulo antes de escalar.";
+            case RESEARCH_MORE -> "Pesquisar mais fontes antes de criar oferta.";
+            case DISCARD -> "Descartar ou deixar em baixa prioridade.";
+            case SATURATED_REQUIRES_ANGLE -> "Avançar somente com ângulo claramente diferenciado.";
+        };
+    }
+
+    /**
+     * Gera próximo passo comercial quando o worker não trouxe sugestão específica.
+     */
+    private String experimentSuggestion(MarketWarmupRecommendation recommendation, MarketWarmupEcosystemType ecosystemType) {
+        String ecosystem = ecosystemType.name().toLowerCase(Locale.ROOT).replace('_', ' ');
+        return switch (recommendation) {
+            case PRIORITIZE -> "Criar experimento inicial apoiado no ecossistema " + ecosystem + ".";
+            case OBSERVE -> "Validar novo ângulo com mais sinais do ecossistema " + ecosystem + ".";
+            case RESEARCH_MORE -> "Coletar fontes adicionais antes do experimento.";
+            case DISCARD -> "Não criar experimento neste momento.";
+            case SATURATED_REQUIRES_ANGLE -> "Buscar promessa e mecanismo menos comoditizados antes de vender.";
+        };
+    }
+
+    /**
+     * Guarda dimensões intermediárias necessárias para decisão de temperatura e saturação.
+     */
+    private record DimensionScores(BigDecimal totalBeforeClamp, BigDecimal saturationPenalty) {
+    }
+
+    /**
+     * Diferencia qual nota operacional da fonte deve entrar na dimensão calculada.
+     */
+    private enum SourceScoreKind {
+        RECENCY,
+        ENGAGEMENT
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesPageMarketWarmupService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesPageMarketWarmupService.java
@@ -27,6 +27,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class MoisSalesPageMarketWarmupService {
 
     private final MoisSalesPageMarketWarmupGateway gateway;
+    private final MoisSalesPageMarketWarmupScoreEngine scoreEngine = new MoisSalesPageMarketWarmupScoreEngine();
 
     /**
      * Solicita uma pesquisa de aquecimento para a página, reutilizando jobs pendentes ou em execução.
@@ -134,11 +135,11 @@ public class MoisSalesPageMarketWarmupService {
             gateway.deleteJobDetails(jobId);
             List<Long> sourceIds = persistSources(job, request.sources());
             persistSignals(job, sourceIds, request.signals());
-            MarketWarmupSummaryWriteData summary = mapSummaryWrite(request.summary());
+            MarketWarmupSummaryWriteData summary = mapSummaryWrite(scoreEngine.calculate(request));
             gateway.insertSummary(jobId, job.pageId(), job.workspaceId(), summary);
             gateway.markJobDone(jobId, summary, request.finishedAt());
             log.info("Job de aquecimento MOIS concluído. modulo=MOIS, operacao=completeMarketWarmupJob, workspaceId={}, pageId={}, jobId={}, fontes={}, sinais={}, score={}",
-                    job.workspaceId(), job.pageId(), jobId, request.sources().size(), request.signals().size(), request.summary().scoreTotal());
+                    job.workspaceId(), job.pageId(), jobId, request.sources().size(), request.signals().size(), summary.scoreTotal());
         } catch (RuntimeException ex) {
             log.error("Falha ao concluir job de aquecimento MOIS. modulo=MOIS, operacao=completeMarketWarmupJob, jobId={}, erroClasse={}, erro={}",
                     jobId, ex.getClass().getName(), ex.getMessage(), ex);

--- a/backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesPageMarketWarmupServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesPageMarketWarmupServiceTest.java
@@ -21,6 +21,7 @@ import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
@@ -108,8 +109,22 @@ class MoisSalesPageMarketWarmupServiceTest {
 
         verify(gateway).deleteJobDetails(99L);
         verify(gateway).insertSignal(99L, 10L, "workspace-001", 501L, signalData(signal));
-        verify(gateway).insertSummary(99L, 10L, "workspace-001", summaryData(summary));
-        verify(gateway).markJobDone(99L, summaryData(summary), Instant.parse("2026-06-10T10:00:00Z"));
+        ArgumentCaptor<MarketWarmupSummaryWriteData> summaryCaptor = ArgumentCaptor.forClass(MarketWarmupSummaryWriteData.class);
+        verify(gateway).insertSummary(
+                org.mockito.ArgumentMatchers.eq(99L),
+                org.mockito.ArgumentMatchers.eq(10L),
+                org.mockito.ArgumentMatchers.eq("workspace-001"),
+                summaryCaptor.capture());
+        verify(gateway).markJobDone(
+                org.mockito.ArgumentMatchers.eq(99L),
+                summaryCaptor.capture(),
+                org.mockito.ArgumentMatchers.eq(Instant.parse("2026-06-10T10:00:00Z")));
+        assertThat(summaryCaptor.getAllValues()).allSatisfy(calculatedSummary -> {
+            assertThat(calculatedSummary.scoreTotal()).isEqualByComparingTo(BigDecimal.valueOf(50));
+            assertThat(calculatedSummary.marketTemperature()).isEqualTo("WARM");
+            assertThat(calculatedSummary.ecosystemType()).isEqualTo("RECURRING_PAIN_HEATED");
+            assertThat(calculatedSummary.recommendation()).isEqualTo("RESEARCH_MORE");
+        });
     }
 
     /**
@@ -166,6 +181,104 @@ class MoisSalesPageMarketWarmupServiceTest {
     }
 
     /**
+     * Garante que o motor classifica mercado quente quando todas as dimensões comerciais estão fortes.
+     */
+    @Test
+    void scoreEngineClassifiesHotMarket() {
+        MoisSalesPageMarketWarmupScoreEngine engine = new MoisSalesPageMarketWarmupScoreEngine();
+
+        MoisSalesLibraryDtos.MarketWarmupSummaryCompleteItem summary = engine.calculate(new MoisSalesLibraryDtos.MarketWarmupCompleteRequest(
+                List.of(
+                        warmupSource(MoisSalesLibraryDtos.MarketWarmupSourceType.CREATOR_CONTENT, BigDecimal.TEN, BigDecimal.TEN),
+                        warmupSource(MoisSalesLibraryDtos.MarketWarmupSourceType.SPECIALIST_CONTENT, BigDecimal.valueOf(9), BigDecimal.valueOf(9)),
+                        warmupSource(MoisSalesLibraryDtos.MarketWarmupSourceType.COMPETITOR_OFFER, BigDecimal.valueOf(8), BigDecimal.valueOf(8)),
+                        warmupSource(MoisSalesLibraryDtos.MarketWarmupSourceType.REVIEW, BigDecimal.valueOf(8), BigDecimal.valueOf(8)),
+                        warmupSource(MoisSalesLibraryDtos.MarketWarmupSourceType.SOCIAL_POST, BigDecimal.valueOf(9), BigDecimal.valueOf(9))),
+                List.of(
+                        warmupSignal(MoisSalesLibraryDtos.MarketWarmupSignalType.PAIN_EXPLICIT, BigDecimal.TEN),
+                        warmupSignal(MoisSalesLibraryDtos.MarketWarmupSignalType.BUYING_INTENT, BigDecimal.TEN),
+                        warmupSignal(MoisSalesLibraryDtos.MarketWarmupSignalType.SOCIAL_PROOF, BigDecimal.valueOf(9)),
+                        warmupSignal(MoisSalesLibraryDtos.MarketWarmupSignalType.CREATOR_AUTHORITY, BigDecimal.valueOf(9)),
+                        warmupSignal(MoisSalesLibraryDtos.MarketWarmupSignalType.COMPETITOR_OFFER, BigDecimal.valueOf(8))),
+                sampleSummary(),
+                Instant.parse("2026-06-10T10:00:00Z")));
+
+        assertThat(summary.scoreTotal()).isEqualByComparingTo(BigDecimal.valueOf(84));
+        assertThat(summary.marketTemperature()).isEqualTo(MoisSalesLibraryDtos.MarketWarmupTemperature.HOT);
+        assertThat(summary.recommendation()).isEqualTo(MoisSalesLibraryDtos.MarketWarmupRecommendation.PRIORITIZE);
+    }
+
+    /**
+     * Garante que o motor classifica mercado promissor quando há bons sinais sem força máxima.
+     */
+    @Test
+    void scoreEngineClassifiesPromisingMarket() {
+        MoisSalesPageMarketWarmupScoreEngine engine = new MoisSalesPageMarketWarmupScoreEngine();
+
+        MoisSalesLibraryDtos.MarketWarmupSummaryCompleteItem summary = engine.calculate(new MoisSalesLibraryDtos.MarketWarmupCompleteRequest(
+                List.of(
+                        warmupSource(MoisSalesLibraryDtos.MarketWarmupSourceType.CREATOR_CONTENT, BigDecimal.valueOf(8), BigDecimal.valueOf(7)),
+                        warmupSource(MoisSalesLibraryDtos.MarketWarmupSourceType.SPECIALIST_CONTENT, BigDecimal.valueOf(8), BigDecimal.valueOf(7)),
+                        warmupSource(MoisSalesLibraryDtos.MarketWarmupSourceType.COMMUNITY_DISCUSSION, BigDecimal.valueOf(7), BigDecimal.valueOf(7)),
+                        warmupSource(MoisSalesLibraryDtos.MarketWarmupSourceType.REVIEW, BigDecimal.valueOf(7), BigDecimal.valueOf(6))),
+                List.of(
+                        warmupSignal(MoisSalesLibraryDtos.MarketWarmupSignalType.PAIN_EXPLICIT, BigDecimal.valueOf(7)),
+                        warmupSignal(MoisSalesLibraryDtos.MarketWarmupSignalType.BUYING_INTENT, BigDecimal.valueOf(7)),
+                        warmupSignal(MoisSalesLibraryDtos.MarketWarmupSignalType.SOCIAL_PROOF, BigDecimal.valueOf(6)),
+                        warmupSignal(MoisSalesLibraryDtos.MarketWarmupSignalType.CREATOR_AUTHORITY, BigDecimal.valueOf(7)),
+                        warmupSignal(MoisSalesLibraryDtos.MarketWarmupSignalType.CHANNEL_FIT, BigDecimal.valueOf(7))),
+                sampleSummary(),
+                Instant.parse("2026-06-10T10:00:00Z")));
+
+        assertThat(summary.scoreTotal()).isEqualByComparingTo(BigDecimal.valueOf(61));
+        assertThat(summary.marketTemperature()).isEqualTo(MoisSalesLibraryDtos.MarketWarmupTemperature.PROMISING);
+        assertThat(summary.recommendation()).isEqualTo(MoisSalesLibraryDtos.MarketWarmupRecommendation.OBSERVE);
+    }
+
+    /**
+     * Garante que o motor descarta mercado frio quando faltam fontes e sinais de intenção.
+     */
+    @Test
+    void scoreEngineClassifiesColdMarket() {
+        MoisSalesPageMarketWarmupScoreEngine engine = new MoisSalesPageMarketWarmupScoreEngine();
+
+        MoisSalesLibraryDtos.MarketWarmupSummaryCompleteItem summary = engine.calculate(new MoisSalesLibraryDtos.MarketWarmupCompleteRequest(
+                List.of(warmupSource(MoisSalesLibraryDtos.MarketWarmupSourceType.SEARCH_RESULT, BigDecimal.valueOf(2), BigDecimal.valueOf(1))),
+                List.of(warmupSignal(MoisSalesLibraryDtos.MarketWarmupSignalType.CONTENT_RECENCY, BigDecimal.valueOf(2))),
+                sampleSummary(),
+                Instant.parse("2026-06-10T10:00:00Z")));
+
+        assertThat(summary.scoreTotal()).isEqualByComparingTo(BigDecimal.valueOf(6));
+        assertThat(summary.marketTemperature()).isEqualTo(MoisSalesLibraryDtos.MarketWarmupTemperature.COLD);
+        assertThat(summary.recommendation()).isEqualTo(MoisSalesLibraryDtos.MarketWarmupRecommendation.DISCARD);
+        assertThat(summary.ecosystemType()).isEqualTo(MoisSalesLibraryDtos.MarketWarmupEcosystemType.COLD_OR_UNEDUCATED);
+    }
+
+    /**
+     * Garante que saturação alta prevalece sobre score comercial positivo.
+     */
+    @Test
+    void scoreEngineClassifiesSaturatedMarket() {
+        MoisSalesPageMarketWarmupScoreEngine engine = new MoisSalesPageMarketWarmupScoreEngine();
+
+        MoisSalesLibraryDtos.MarketWarmupSummaryCompleteItem summary = engine.calculate(new MoisSalesLibraryDtos.MarketWarmupCompleteRequest(
+                List.of(
+                        warmupSource(MoisSalesLibraryDtos.MarketWarmupSourceType.COMPETITOR_OFFER, BigDecimal.TEN, BigDecimal.TEN),
+                        warmupSource(MoisSalesLibraryDtos.MarketWarmupSourceType.AFFILIATE_PROMOTION, BigDecimal.TEN, BigDecimal.TEN),
+                        warmupSource(MoisSalesLibraryDtos.MarketWarmupSourceType.COMPETITOR_OFFER, BigDecimal.TEN, BigDecimal.TEN)),
+                List.of(
+                        warmupSignal(MoisSalesLibraryDtos.MarketWarmupSignalType.PAIN_EXPLICIT, BigDecimal.TEN),
+                        warmupSignal(MoisSalesLibraryDtos.MarketWarmupSignalType.BUYING_INTENT, BigDecimal.TEN),
+                        warmupSignal(MoisSalesLibraryDtos.MarketWarmupSignalType.SATURATION_RISK, BigDecimal.valueOf(9))),
+                sampleSummary(),
+                Instant.parse("2026-06-10T10:00:00Z")));
+
+        assertThat(summary.marketTemperature()).isEqualTo(MoisSalesLibraryDtos.MarketWarmupTemperature.SATURATED);
+        assertThat(summary.ecosystemType()).isEqualTo(MoisSalesLibraryDtos.MarketWarmupEcosystemType.SATURATED);
+        assertThat(summary.recommendation()).isEqualTo(MoisSalesLibraryDtos.MarketWarmupRecommendation.SATURATED_REQUIRES_ANGLE);
+    }
+
+    /**
      * Monta uma página consolidada com os campos comerciais necessários ao aquecimento.
      */
     private SalesPageWarmupData samplePage() {
@@ -210,6 +323,40 @@ class MoisSalesPageMarketWarmupServiceTest {
         return new MarketWarmupSummaryWriteData(summary.scoreTotal(), summary.marketTemperature().name(), summary.ecosystemType().name(), summary.recommendation().name(),
                 summary.mainPains(), summary.mainObjections(), summary.mainPromises(), summary.mainChannels(), summary.mainCompetitors(), summary.saturationRisk(),
                 summary.opportunityRecommendation(), summary.nextExperimentSuggestion());
+    }
+
+    /**
+     * Monta uma fonte com notas controladas para cenários do motor de score.
+     */
+    private MoisSalesLibraryDtos.MarketWarmupSourceCompleteItem warmupSource(
+            MoisSalesLibraryDtos.MarketWarmupSourceType sourceType,
+            BigDecimal recencyScore,
+            BigDecimal engagementScore) {
+        return new MoisSalesLibraryDtos.MarketWarmupSourceCompleteItem(
+                MoisSalesLibraryDtos.MarketWarmupPlatform.WEB,
+                sourceType,
+                "https://example.test/" + sourceType.name().toLowerCase(),
+                sourceType.name(),
+                "Autor",
+                Instant.parse("2026-06-01T00:00:00Z"),
+                Instant.parse("2026-06-09T00:00:00Z"),
+                null,
+                null,
+                null,
+                null,
+                recencyScore,
+                engagementScore,
+                "evidência rastreável");
+    }
+
+    /**
+     * Monta um sinal com força controlada para cenários do motor de score.
+     */
+    private MoisSalesLibraryDtos.MarketWarmupSignalCompleteItem warmupSignal(
+            MoisSalesLibraryDtos.MarketWarmupSignalType signalType,
+            BigDecimal signalStrength) {
+        return new MoisSalesLibraryDtos.MarketWarmupSignalCompleteItem(
+                0, signalType, signalStrength, signalType.name(), "interpretação comercial");
     }
 
     /**

--- a/docs/registros/mois1.md
+++ b/docs/registros/mois1.md
@@ -1294,3 +1294,14 @@ Arquivos alterados:
 - `mois-sales-library-worker/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/marketwarmup/`
 - `mois-sales-library-worker/pom.xml`
 - `docs/registros/mois1.md`
+
+## 2026-06-10 — Etapa 3 MOIS / Fase 7 — Motor de score e recomendação
+
+- Implementado motor backend do Market Warm-up Score para calcular score, temperatura, tipo de ecossistema e recomendação objetiva a partir das fontes e sinais rastreáveis salvos na pesquisa de aquecimento.
+- A conclusão do job passa a persistir o resumo calculado pelo backend, reduzindo dependência de classificação enviada pelo worker e mantendo a explicação do score vinculada aos sinais.
+- Adicionados testes unitários para cenários quente, promissor, frio e saturado.
+
+Arquivos principais:
+- `backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesPageMarketWarmupScoreEngine.java`
+- `backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesPageMarketWarmupService.java`
+- `backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesPageMarketWarmupServiceTest.java`


### PR DESCRIPTION
### Motivation
- Tornar a Etapa 3 (Market Warm-up) determinística e explicável no backend, calculando um score reproduzível a partir de fontes e sinais rastreáveis em vez de confiar apenas na classificação enviada pelo worker. 
- Produzir recomendações objetivas (temperatura, ecossistema, recomendação) que possam ser auditadas e exibidas na UI com ligação direta aos sinais persistidos.

### Description
- Adiciona o motor de score `MoisSalesPageMarketWarmupScoreEngine` que calcula `scoreTotal`, `marketTemperature`, `ecosystemType` e `recommendation` a partir das fontes e sinais (`backend/ads-service/src/main/java/.../MoisSalesPageMarketWarmupScoreEngine.java`).
- Integra o motor na finalização do job no service `MoisSalesPageMarketWarmupService`, substituindo a persistência do resumo enviado pelo worker pelo resumo calculado pelo backend (`mapSummaryWrite(scoreEngine.calculate(request))`).
- Atualiza os testes unitários do serviço para capturar e validar o resumo calculado persistido e adiciona cenários unitários do motor para mercados `HOT`, `PROMISING`, `COLD` e `SATURATED` (`MoisSalesPageMarketWarmupServiceTest`).
- Registra a alteração operacional no log de registros do projeto (`docs/registros/mois1.md`).

### Testing
- Executei `JAVA_HOME=/usr/lib/jvm/java-21-openjdk-amd64 PATH=/usr/lib/jvm/java-21-openjdk-amd64/bin:$PATH ./mvnw -f ads-service/pom.xml -Dtest=MoisSalesPageMarketWarmupServiceTest test` e os testes do módulo `ads-service` passaram com sucesso (10 tests, 0 failures). 
- Verifiquei que as chamadas de persistência do resumo agora recebem o resumo calculado e que os asserts do novo motor cobrem os cenários quente/promissor/frio/saturado, todos aprovados. 
- Tentativa de rodar `spotless:apply` no módulo falhou porque o plugin/prefixo `spotless` não está disponível no contexto do POM deste módulo, sem impacto nas alterações funcionais.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a28de5f600483208827dcb9b2590057)