### PR TITLE
Implementa subnichos de públicos gerais no OPRM (etapa 2)

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/generalaudience/OprmGeneralAudienceSubniche.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/generalaudience/OprmGeneralAudienceSubniche.java
@@ -1,0 +1,235 @@
+package com.marketinghub.oprm.generalaudience;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+import java.math.BigDecimal;
+import java.time.Instant;
+
+/** Responsável por armazenar um subnicho descoberto a partir de uma semente de público geral. */
+@Entity
+@Table(name = "oprm_general_audience_subniche")
+public class OprmGeneralAudienceSubniche {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "seed_id", nullable = false)
+    private OprmGeneralAudienceSeed seed;
+
+    @Column(name = "name", nullable = false, length = 191)
+    private String name;
+
+    @Column(name = "persona_summary", columnDefinition = "LONGTEXT")
+    private String personaSummary;
+
+    @Column(name = "pain_summary", columnDefinition = "LONGTEXT")
+    private String painSummary;
+
+    @Column(name = "desired_outcome_summary", columnDefinition = "LONGTEXT")
+    private String desiredOutcomeSummary;
+
+    @Column(name = "language_patterns", columnDefinition = "LONGTEXT")
+    private String languagePatterns;
+
+    @Column(name = "channels_summary", columnDefinition = "LONGTEXT")
+    private String channelsSummary;
+
+    @Column(name = "qualification_question", columnDefinition = "LONGTEXT")
+    private String qualificationQuestion;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 32)
+    private OprmGeneralAudienceSubnicheStatus status;
+
+    @Column(name = "opportunity_score", precision = 5, scale = 2)
+    private BigDecimal opportunityScore;
+
+    @Column(name = "risk_score", precision = 5, scale = 2)
+    private BigDecimal riskScore;
+
+    @Column(name = "market_niche_id")
+    private Long marketNicheId;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+
+    /** Inicializa os carimbos de data antes da primeira persistência. */
+    @PrePersist
+    void onCreate() {
+        Instant now = Instant.now();
+        createdAt = now;
+        updatedAt = now;
+    }
+
+    /** Atualiza o carimbo de modificação antes de salvar alterações. */
+    @PreUpdate
+    void onUpdate() {
+        updatedAt = Instant.now();
+    }
+
+    /** Retorna o identificador do subnicho. */
+    public Long getId() {
+        return id;
+    }
+
+    /** Define o identificador do subnicho. */
+    public void setId(Long id) {
+        this.id = id;
+    }
+
+    /** Retorna a semente que originou o subnicho. */
+    public OprmGeneralAudienceSeed getSeed() {
+        return seed;
+    }
+
+    /** Define a semente que originou o subnicho. */
+    public void setSeed(OprmGeneralAudienceSeed seed) {
+        this.seed = seed;
+    }
+
+    /** Retorna o nome específico do subnicho. */
+    public String getName() {
+        return name;
+    }
+
+    /** Define o nome específico do subnicho. */
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    /** Retorna quem é a pessoa representada pelo subnicho. */
+    public String getPersonaSummary() {
+        return personaSummary;
+    }
+
+    /** Define quem é a pessoa representada pelo subnicho. */
+    public void setPersonaSummary(String personaSummary) {
+        this.personaSummary = personaSummary;
+    }
+
+    /** Retorna o resumo das dores relevantes do subnicho. */
+    public String getPainSummary() {
+        return painSummary;
+    }
+
+    /** Define o resumo das dores relevantes do subnicho. */
+    public void setPainSummary(String painSummary) {
+        this.painSummary = painSummary;
+    }
+
+    /** Retorna o resultado desejado pelo subnicho. */
+    public String getDesiredOutcomeSummary() {
+        return desiredOutcomeSummary;
+    }
+
+    /** Define o resultado desejado pelo subnicho. */
+    public void setDesiredOutcomeSummary(String desiredOutcomeSummary) {
+        this.desiredOutcomeSummary = desiredOutcomeSummary;
+    }
+
+    /** Retorna padrões de linguagem úteis para confirmar o público. */
+    public String getLanguagePatterns() {
+        return languagePatterns;
+    }
+
+    /** Define padrões de linguagem úteis para confirmar o público. */
+    public void setLanguagePatterns(String languagePatterns) {
+        this.languagePatterns = languagePatterns;
+    }
+
+    /** Retorna os canais usados pelo subnicho. */
+    public String getChannelsSummary() {
+        return channelsSummary;
+    }
+
+    /** Define os canais usados pelo subnicho. */
+    public void setChannelsSummary(String channelsSummary) {
+        this.channelsSummary = channelsSummary;
+    }
+
+    /** Retorna a pergunta qualificadora para separar o lead certo do público errado. */
+    public String getQualificationQuestion() {
+        return qualificationQuestion;
+    }
+
+    /** Define a pergunta qualificadora para separar o lead certo do público errado. */
+    public void setQualificationQuestion(String qualificationQuestion) {
+        this.qualificationQuestion = qualificationQuestion;
+    }
+
+    /** Retorna o status operacional do subnicho. */
+    public OprmGeneralAudienceSubnicheStatus getStatus() {
+        return status;
+    }
+
+    /** Define o status operacional do subnicho. */
+    public void setStatus(OprmGeneralAudienceSubnicheStatus status) {
+        this.status = status;
+    }
+
+    /** Retorna o score de oportunidade do subnicho. */
+    public BigDecimal getOpportunityScore() {
+        return opportunityScore;
+    }
+
+    /** Define o score de oportunidade do subnicho. */
+    public void setOpportunityScore(BigDecimal opportunityScore) {
+        this.opportunityScore = opportunityScore;
+    }
+
+    /** Retorna o score de risco do subnicho. */
+    public BigDecimal getRiskScore() {
+        return riskScore;
+    }
+
+    /** Define o score de risco do subnicho. */
+    public void setRiskScore(BigDecimal riskScore) {
+        this.riskScore = riskScore;
+    }
+
+    /** Retorna o nicho de mercado gerado, quando houver conversão controlada. */
+    public Long getMarketNicheId() {
+        return marketNicheId;
+    }
+
+    /** Define o nicho de mercado gerado, quando houver conversão controlada. */
+    public void setMarketNicheId(Long marketNicheId) {
+        this.marketNicheId = marketNicheId;
+    }
+
+    /** Retorna a data de criação do subnicho. */
+    public Instant getCreatedAt() {
+        return createdAt;
+    }
+
+    /** Define a data de criação do subnicho. */
+    public void setCreatedAt(Instant createdAt) {
+        this.createdAt = createdAt;
+    }
+
+    /** Retorna a data da última alteração do subnicho. */
+    public Instant getUpdatedAt() {
+        return updatedAt;
+    }
+
+    /** Define a data da última alteração do subnicho. */
+    public void setUpdatedAt(Instant updatedAt) {
+        this.updatedAt = updatedAt;
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/generalaudience/OprmGeneralAudienceSubnicheStatus.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/generalaudience/OprmGeneralAudienceSubnicheStatus.java
@@ -1,0 +1,10 @@
+package com.marketinghub.oprm.generalaudience;
+
+/** Representa o estágio operacional do subnicho derivado de uma semente de público geral. */
+public enum OprmGeneralAudienceSubnicheStatus {
+    DISCOVERED,
+    NEEDS_REVIEW,
+    APPROVED_FOR_EXPERIMENT,
+    REJECTED,
+    CONVERTED_TO_NICHE
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/generalaudience/controller/OprmGeneralAudienceController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/generalaudience/controller/OprmGeneralAudienceController.java
@@ -2,9 +2,13 @@ package com.marketinghub.oprm.generalaudience.controller;
 
 import com.marketinghub.oprm.generalaudience.service.OprmGeneralAudienceService;
 import com.marketinghub.oprm.generalaudience.service.createSeed.CreateGeneralAudienceSeedRequest;
+import com.marketinghub.oprm.generalaudience.service.createSubniche.CreateGeneralAudienceSubnicheRequest;
 import com.marketinghub.oprm.generalaudience.service.getSeed.GeneralAudienceSeedResponse;
+import com.marketinghub.oprm.generalaudience.service.getSubniche.GeneralAudienceSubnicheResponse;
 import com.marketinghub.oprm.generalaudience.service.listSeeds.GeneralAudienceSeedSummaryResponse;
+import com.marketinghub.oprm.generalaudience.service.listSubniches.GeneralAudienceSubnicheSummaryResponse;
 import com.marketinghub.oprm.generalaudience.service.updateSeed.UpdateGeneralAudienceSeedRequest;
+import com.marketinghub.oprm.generalaudience.service.updateSubniche.UpdateGeneralAudienceSubnicheRequest;
 import jakarta.validation.Valid;
 import java.net.URI;
 import java.util.List;
@@ -17,7 +21,7 @@ import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
-/** Responsável pelos endpoints OPRM de cadastro e revisão manual de sementes de público geral. */
+/** Responsável pelos endpoints OPRM de cadastro e revisão manual de sementes e subnichos gerais. */
 @RestController
 @RequestMapping("/api/oprm/general-audiences")
 public class OprmGeneralAudienceController {
@@ -63,5 +67,48 @@ public class OprmGeneralAudienceController {
     @PostMapping("/seeds/{seedId}/archive")
     public ResponseEntity<GeneralAudienceSeedResponse> archiveSeed(@PathVariable Long seedId) {
         return ResponseEntity.ok(service.archiveSeed(seedId));
+    }
+
+    /** Lista subnichos descobertos a partir de uma semente de público geral. */
+    @GetMapping("/seeds/{seedId}/subniches")
+    public ResponseEntity<List<GeneralAudienceSubnicheSummaryResponse>> listSubniches(@PathVariable Long seedId) {
+        return ResponseEntity.ok(service.listSubniches(seedId));
+    }
+
+    /** Cadastra manualmente um subnicho derivado da semente sem tratá-lo como CNAE. */
+    @PostMapping("/seeds/{seedId}/subniches")
+    public ResponseEntity<GeneralAudienceSubnicheResponse> createSubniche(
+            @PathVariable Long seedId,
+            @Valid @RequestBody CreateGeneralAudienceSubnicheRequest request) {
+        GeneralAudienceSubnicheResponse response = service.createSubniche(seedId, request);
+        return ResponseEntity
+                .created(URI.create("/api/oprm/general-audiences/subniches/" + response.id()))
+                .body(response);
+    }
+
+    /** Detalha um subnicho de público geral para revisão de persona, dor, canais e triagem. */
+    @GetMapping("/subniches/{subnicheId}")
+    public ResponseEntity<GeneralAudienceSubnicheResponse> getSubniche(@PathVariable Long subnicheId) {
+        return ResponseEntity.ok(service.getSubniche(subnicheId));
+    }
+
+    /** Atualiza os campos manuais de um subnicho de público geral. */
+    @PatchMapping("/subniches/{subnicheId}")
+    public ResponseEntity<GeneralAudienceSubnicheResponse> updateSubniche(
+            @PathVariable Long subnicheId,
+            @Valid @RequestBody UpdateGeneralAudienceSubnicheRequest request) {
+        return ResponseEntity.ok(service.updateSubniche(subnicheId, request));
+    }
+
+    /** Aprova um subnicho específico para avançar para experimentos futuros. */
+    @PostMapping("/subniches/{subnicheId}/approve")
+    public ResponseEntity<GeneralAudienceSubnicheResponse> approveSubniche(@PathVariable Long subnicheId) {
+        return ResponseEntity.ok(service.approveSubniche(subnicheId));
+    }
+
+    /** Rejeita um subnicho amplo ou inseguro sem apagar histórico de descoberta. */
+    @PostMapping("/subniches/{subnicheId}/reject")
+    public ResponseEntity<GeneralAudienceSubnicheResponse> rejectSubniche(@PathVariable Long subnicheId) {
+        return ResponseEntity.ok(service.rejectSubniche(subnicheId));
     }
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/generalaudience/service/OprmGeneralAudienceService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/generalaudience/service/OprmGeneralAudienceService.java
@@ -2,11 +2,18 @@ package com.marketinghub.oprm.generalaudience.service;
 
 import com.marketinghub.oprm.generalaudience.OprmGeneralAudienceSeed;
 import com.marketinghub.oprm.generalaudience.OprmGeneralAudienceSeedStatus;
+import com.marketinghub.oprm.generalaudience.OprmGeneralAudienceSubniche;
+import com.marketinghub.oprm.generalaudience.OprmGeneralAudienceSubnicheStatus;
 import com.marketinghub.oprm.generalaudience.service.createSeed.CreateGeneralAudienceSeedRequest;
+import com.marketinghub.oprm.generalaudience.service.createSubniche.CreateGeneralAudienceSubnicheRequest;
 import com.marketinghub.oprm.generalaudience.service.getSeed.GeneralAudienceSeedResponse;
+import com.marketinghub.oprm.generalaudience.service.getSubniche.GeneralAudienceSubnicheResponse;
 import com.marketinghub.oprm.generalaudience.service.listSeeds.GeneralAudienceSeedSummaryResponse;
+import com.marketinghub.oprm.generalaudience.service.listSubniches.GeneralAudienceSubnicheSummaryResponse;
 import com.marketinghub.oprm.generalaudience.service.updateSeed.UpdateGeneralAudienceSeedRequest;
+import com.marketinghub.oprm.generalaudience.service.updateSubniche.UpdateGeneralAudienceSubnicheRequest;
 import com.marketinghub.repository.jpa.oprm.generalaudience.OprmGeneralAudienceSeedRepository;
+import com.marketinghub.repository.jpa.oprm.generalaudience.OprmGeneralAudienceSubnicheRepository;
 import java.util.List;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
@@ -14,17 +21,21 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 import org.springframework.web.server.ResponseStatusException;
 
-/** Responsável por orquestrar o cadastro e a revisão manual de sementes de público geral no OPRM. */
+/** Responsável por orquestrar o cadastro e a revisão manual de sementes e subnichos gerais no OPRM. */
 @Service
 public class OprmGeneralAudienceService {
 
     private static final String DEFAULT_COUNTRY = "BR";
     private static final String DEFAULT_LANGUAGE = "pt-BR";
     private final OprmGeneralAudienceSeedRepository seedRepository;
+    private final OprmGeneralAudienceSubnicheRepository subnicheRepository;
 
-    /** Inicializa o serviço com a persistência centralizada de sementes de público geral. */
-    public OprmGeneralAudienceService(OprmGeneralAudienceSeedRepository seedRepository) {
+    /** Inicializa o serviço com a persistência centralizada de públicos gerais. */
+    public OprmGeneralAudienceService(
+            OprmGeneralAudienceSeedRepository seedRepository,
+            OprmGeneralAudienceSubnicheRepository subnicheRepository) {
         this.seedRepository = seedRepository;
+        this.subnicheRepository = subnicheRepository;
     }
 
     /** Lista sementes cadastradas para seleção e revisão manual pelo usuário. */
@@ -99,12 +110,117 @@ public class OprmGeneralAudienceService {
         return toResponse(seedRepository.save(seed));
     }
 
+    /** Lista subnichos descobertos para uma semente sem consultar ou alterar o fluxo NichoCNAE. */
+    @Transactional(readOnly = true)
+    public List<GeneralAudienceSubnicheSummaryResponse> listSubniches(Long seedId) {
+        findSeed(seedId);
+        return subnicheRepository.findAllBySeedIdOrderByUpdatedAtDesc(seedId).stream()
+                .map(this::toSubnicheSummaryResponse)
+                .toList();
+    }
+
+    /** Cadastra um subnicho derivado de uma semente com dados suficientes para revisão comercial. */
+    @Transactional
+    public GeneralAudienceSubnicheResponse createSubniche(
+            Long seedId,
+            CreateGeneralAudienceSubnicheRequest request) {
+        OprmGeneralAudienceSeed seed = findSeed(seedId);
+        OprmGeneralAudienceSubniche subniche = new OprmGeneralAudienceSubniche();
+        subniche.setSeed(seed);
+        subniche.setName(requiredText(request.name(), "name"));
+        subniche.setPersonaSummary(normalizeOptionalText(request.personaSummary()));
+        subniche.setPainSummary(normalizeOptionalText(request.painSummary()));
+        subniche.setDesiredOutcomeSummary(normalizeOptionalText(request.desiredOutcomeSummary()));
+        subniche.setLanguagePatterns(normalizeOptionalText(request.languagePatterns()));
+        subniche.setChannelsSummary(normalizeOptionalText(request.channelsSummary()));
+        subniche.setQualificationQuestion(normalizeOptionalText(request.qualificationQuestion()));
+        subniche.setStatus(request.status() == null
+                ? OprmGeneralAudienceSubnicheStatus.DISCOVERED
+                : request.status());
+        subniche.setOpportunityScore(request.opportunityScore());
+        subniche.setRiskScore(request.riskScore());
+        subniche.setMarketNicheId(request.marketNicheId());
+        return toSubnicheResponse(subnicheRepository.save(subniche));
+    }
+
+    /** Detalha um subnicho para revisão de persona, dores, canais e pergunta qualificadora. */
+    @Transactional(readOnly = true)
+    public GeneralAudienceSubnicheResponse getSubniche(Long subnicheId) {
+        return toSubnicheResponse(findSubniche(subnicheId));
+    }
+
+    /** Atualiza campos manuais do subnicho sem convertê-lo automaticamente em nicho ou campanha. */
+    @Transactional
+    public GeneralAudienceSubnicheResponse updateSubniche(
+            Long subnicheId,
+            UpdateGeneralAudienceSubnicheRequest request) {
+        OprmGeneralAudienceSubniche subniche = findSubniche(subnicheId);
+        if (request.name() != null) {
+            subniche.setName(requiredText(request.name(), "name"));
+        }
+        if (request.personaSummary() != null) {
+            subniche.setPersonaSummary(normalizeOptionalText(request.personaSummary()));
+        }
+        if (request.painSummary() != null) {
+            subniche.setPainSummary(normalizeOptionalText(request.painSummary()));
+        }
+        if (request.desiredOutcomeSummary() != null) {
+            subniche.setDesiredOutcomeSummary(normalizeOptionalText(request.desiredOutcomeSummary()));
+        }
+        if (request.languagePatterns() != null) {
+            subniche.setLanguagePatterns(normalizeOptionalText(request.languagePatterns()));
+        }
+        if (request.channelsSummary() != null) {
+            subniche.setChannelsSummary(normalizeOptionalText(request.channelsSummary()));
+        }
+        if (request.qualificationQuestion() != null) {
+            subniche.setQualificationQuestion(normalizeOptionalText(request.qualificationQuestion()));
+        }
+        if (request.status() != null) {
+            subniche.setStatus(request.status());
+        }
+        if (request.opportunityScore() != null) {
+            subniche.setOpportunityScore(request.opportunityScore());
+        }
+        if (request.riskScore() != null) {
+            subniche.setRiskScore(request.riskScore());
+        }
+        if (request.marketNicheId() != null) {
+            subniche.setMarketNicheId(request.marketNicheId());
+        }
+        return toSubnicheResponse(subnicheRepository.save(subniche));
+    }
+
+    /** Aprova um subnicho para experimento quando ele já tem definição comercial suficiente. */
+    @Transactional
+    public GeneralAudienceSubnicheResponse approveSubniche(Long subnicheId) {
+        OprmGeneralAudienceSubniche subniche = findSubniche(subnicheId);
+        subniche.setStatus(OprmGeneralAudienceSubnicheStatus.APPROVED_FOR_EXPERIMENT);
+        return toSubnicheResponse(subnicheRepository.save(subniche));
+    }
+
+    /** Rejeita um subnicho para evitar avanço de público amplo, genérico ou sem confirmação de lead. */
+    @Transactional
+    public GeneralAudienceSubnicheResponse rejectSubniche(Long subnicheId) {
+        OprmGeneralAudienceSubniche subniche = findSubniche(subnicheId);
+        subniche.setStatus(OprmGeneralAudienceSubnicheStatus.REJECTED);
+        return toSubnicheResponse(subnicheRepository.save(subniche));
+    }
+
     /** Busca a semente ou devolve erro HTTP de recurso inexistente. */
     private OprmGeneralAudienceSeed findSeed(Long seedId) {
         return seedRepository.findById(seedId)
                 .orElseThrow(() -> new ResponseStatusException(
                         HttpStatus.NOT_FOUND,
                         "Semente de público geral não encontrada: " + seedId));
+    }
+
+    /** Busca o subnicho ou devolve erro HTTP de recurso inexistente. */
+    private OprmGeneralAudienceSubniche findSubniche(Long subnicheId) {
+        return subnicheRepository.findById(subnicheId)
+                .orElseThrow(() -> new ResponseStatusException(
+                        HttpStatus.NOT_FOUND,
+                        "Subnicho de público geral não encontrado: " + subnicheId));
     }
 
     /** Converte a entidade de semente para o contrato detalhado. */
@@ -135,6 +251,43 @@ public class OprmGeneralAudienceService {
                 seed.getSeedType(),
                 seed.getStatus(),
                 seed.getUpdatedAt());
+    }
+
+    /** Converte a entidade de subnicho para o contrato detalhado. */
+    private GeneralAudienceSubnicheResponse toSubnicheResponse(OprmGeneralAudienceSubniche subniche) {
+        return new GeneralAudienceSubnicheResponse(
+                subniche.getId(),
+                subniche.getSeed().getId(),
+                subniche.getName(),
+                subniche.getPersonaSummary(),
+                subniche.getPainSummary(),
+                subniche.getDesiredOutcomeSummary(),
+                subniche.getLanguagePatterns(),
+                subniche.getChannelsSummary(),
+                subniche.getQualificationQuestion(),
+                subniche.getStatus(),
+                subniche.getOpportunityScore(),
+                subniche.getRiskScore(),
+                subniche.getMarketNicheId(),
+                subniche.getCreatedAt(),
+                subniche.getUpdatedAt());
+    }
+
+    /** Converte a entidade de subnicho para o contrato resumido de listagem. */
+    private GeneralAudienceSubnicheSummaryResponse toSubnicheSummaryResponse(OprmGeneralAudienceSubniche subniche) {
+        return new GeneralAudienceSubnicheSummaryResponse(
+                subniche.getId(),
+                subniche.getSeed().getId(),
+                subniche.getName(),
+                subniche.getPersonaSummary(),
+                subniche.getPainSummary(),
+                subniche.getChannelsSummary(),
+                subniche.getQualificationQuestion(),
+                subniche.getStatus(),
+                subniche.getOpportunityScore(),
+                subniche.getRiskScore(),
+                subniche.getMarketNicheId(),
+                subniche.getUpdatedAt());
     }
 
     /** Normaliza texto obrigatório e rejeita valor vazio para evitar semente sem decisão comercial. */

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/generalaudience/service/createSubniche/CreateGeneralAudienceSubnicheRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/generalaudience/service/createSubniche/CreateGeneralAudienceSubnicheRequest.java
@@ -1,0 +1,24 @@
+package com.marketinghub.oprm.generalaudience.service.createSubniche;
+
+import com.marketinghub.oprm.generalaudience.OprmGeneralAudienceSubnicheStatus;
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import java.math.BigDecimal;
+
+/** Contrato de entrada para cadastrar manualmente um subnicho derivado de uma semente geral. */
+public record CreateGeneralAudienceSubnicheRequest(
+        @NotBlank @Size(max = 191) String name,
+        String personaSummary,
+        String painSummary,
+        String desiredOutcomeSummary,
+        String languagePatterns,
+        String channelsSummary,
+        String qualificationQuestion,
+        OprmGeneralAudienceSubnicheStatus status,
+        @DecimalMin("0.00") @DecimalMax("100.00") BigDecimal opportunityScore,
+        @DecimalMin("0.00") @DecimalMax("100.00") BigDecimal riskScore,
+        Long marketNicheId
+) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/generalaudience/service/getSubniche/GeneralAudienceSubnicheResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/generalaudience/service/getSubniche/GeneralAudienceSubnicheResponse.java
@@ -1,0 +1,25 @@
+package com.marketinghub.oprm.generalaudience.service.getSubniche;
+
+import com.marketinghub.oprm.generalaudience.OprmGeneralAudienceSubnicheStatus;
+import java.math.BigDecimal;
+import java.time.Instant;
+
+/** Contrato de saída com todos os campos decisórios do subnicho de público geral. */
+public record GeneralAudienceSubnicheResponse(
+        Long id,
+        Long seedId,
+        String name,
+        String personaSummary,
+        String painSummary,
+        String desiredOutcomeSummary,
+        String languagePatterns,
+        String channelsSummary,
+        String qualificationQuestion,
+        OprmGeneralAudienceSubnicheStatus status,
+        BigDecimal opportunityScore,
+        BigDecimal riskScore,
+        Long marketNicheId,
+        Instant createdAt,
+        Instant updatedAt
+) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/generalaudience/service/listSubniches/GeneralAudienceSubnicheSummaryResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/generalaudience/service/listSubniches/GeneralAudienceSubnicheSummaryResponse.java
@@ -1,0 +1,22 @@
+package com.marketinghub.oprm.generalaudience.service.listSubniches;
+
+import com.marketinghub.oprm.generalaudience.OprmGeneralAudienceSubnicheStatus;
+import java.math.BigDecimal;
+import java.time.Instant;
+
+/** Contrato de saída resumido para revisão operacional de subnichos de uma semente. */
+public record GeneralAudienceSubnicheSummaryResponse(
+        Long id,
+        Long seedId,
+        String name,
+        String personaSummary,
+        String painSummary,
+        String channelsSummary,
+        String qualificationQuestion,
+        OprmGeneralAudienceSubnicheStatus status,
+        BigDecimal opportunityScore,
+        BigDecimal riskScore,
+        Long marketNicheId,
+        Instant updatedAt
+) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/generalaudience/service/updateSubniche/UpdateGeneralAudienceSubnicheRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/generalaudience/service/updateSubniche/UpdateGeneralAudienceSubnicheRequest.java
@@ -1,0 +1,23 @@
+package com.marketinghub.oprm.generalaudience.service.updateSubniche;
+
+import com.marketinghub.oprm.generalaudience.OprmGeneralAudienceSubnicheStatus;
+import jakarta.validation.constraints.DecimalMax;
+import jakarta.validation.constraints.DecimalMin;
+import jakarta.validation.constraints.Size;
+import java.math.BigDecimal;
+
+/** Contrato de entrada para revisar manualmente um subnicho de público geral. */
+public record UpdateGeneralAudienceSubnicheRequest(
+        @Size(max = 191) String name,
+        String personaSummary,
+        String painSummary,
+        String desiredOutcomeSummary,
+        String languagePatterns,
+        String channelsSummary,
+        String qualificationQuestion,
+        OprmGeneralAudienceSubnicheStatus status,
+        @DecimalMin("0.00") @DecimalMax("100.00") BigDecimal opportunityScore,
+        @DecimalMin("0.00") @DecimalMax("100.00") BigDecimal riskScore,
+        Long marketNicheId
+) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/oprm/generalaudience/OprmGeneralAudienceSubnicheRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/oprm/generalaudience/OprmGeneralAudienceSubnicheRepository.java
@@ -1,0 +1,11 @@
+package com.marketinghub.repository.jpa.oprm.generalaudience;
+
+import com.marketinghub.oprm.generalaudience.OprmGeneralAudienceSubniche;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/** Repositório JPA responsável pela persistência dos subnichos de públicos gerais do OPRM. */
+public interface OprmGeneralAudienceSubnicheRepository extends JpaRepository<OprmGeneralAudienceSubniche, Long> {
+    /** Lista subnichos de uma semente com os itens mais recentes primeiro. */
+    List<OprmGeneralAudienceSubniche> findAllBySeedIdOrderByUpdatedAtDesc(Long seedId);
+}

--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-10-oprm-general-audience-subniche.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-10-oprm-general-audience-subniche.yaml
@@ -1,0 +1,40 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-06-10-02-oprm-general-audience-subniche
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - onError: HALT
+        - dbms:
+            type: mysql
+        - not:
+            tableExists:
+              tableName: oprm_general_audience_subniche
+      changes:
+        - sql:
+            splitStatements: true
+            stripComments: true
+            sql: |
+              CREATE TABLE oprm_general_audience_subniche (
+                id BIGINT NOT NULL AUTO_INCREMENT,
+                seed_id BIGINT NOT NULL,
+                name VARCHAR(191) NOT NULL,
+                persona_summary LONGTEXT NULL,
+                pain_summary LONGTEXT NULL,
+                desired_outcome_summary LONGTEXT NULL,
+                language_patterns LONGTEXT NULL,
+                channels_summary LONGTEXT NULL,
+                qualification_question LONGTEXT NULL,
+                status VARCHAR(32) NOT NULL,
+                opportunity_score DECIMAL(5,2) NULL,
+                risk_score DECIMAL(5,2) NULL,
+                market_niche_id BIGINT NULL,
+                created_at DATETIME NOT NULL,
+                updated_at DATETIME NOT NULL,
+                CONSTRAINT pk_oprm_general_audience_subniche PRIMARY KEY (id),
+                CONSTRAINT fk_oprm_general_audience_subniche_seed
+                  FOREIGN KEY (seed_id) REFERENCES oprm_general_audience_seed (id)
+              );
+              CREATE INDEX idx_oprm_general_audience_subniche_seed_status ON oprm_general_audience_subniche (seed_id, status, updated_at);
+              CREATE INDEX idx_oprm_general_audience_subniche_status ON oprm_general_audience_subniche (status, updated_at);
+              CREATE INDEX idx_oprm_general_audience_subniche_market_niche ON oprm_general_audience_subniche (market_niche_id);

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -3,6 +3,9 @@ databaseChangeLog:
       file: changesets/2026-06-10-oprm-general-audience-seed.yaml
       relativeToChangelogFile: true
   - include:
+      file: changesets/2026-06-10-oprm-general-audience-subniche.yaml
+      relativeToChangelogFile: true
+  - include:
       file: changesets/2026-06-09-oprm-source-freshness-mei-classification.yaml
       relativeToChangelogFile: true
   - include:

--- a/backend/ads-service/src/test/java/com/marketinghub/oprm/generalaudience/controller/OprmGeneralAudienceControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/oprm/generalaudience/controller/OprmGeneralAudienceControllerTest.java
@@ -3,6 +3,7 @@ package com.marketinghub.oprm.generalaudience.controller;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -11,10 +12,15 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marketinghub.oprm.generalaudience.OprmGeneralAudienceSeedStatus;
 import com.marketinghub.oprm.generalaudience.OprmGeneralAudienceSeedType;
+import com.marketinghub.oprm.generalaudience.OprmGeneralAudienceSubnicheStatus;
 import com.marketinghub.oprm.generalaudience.service.OprmGeneralAudienceService;
 import com.marketinghub.oprm.generalaudience.service.createSeed.CreateGeneralAudienceSeedRequest;
+import com.marketinghub.oprm.generalaudience.service.createSubniche.CreateGeneralAudienceSubnicheRequest;
 import com.marketinghub.oprm.generalaudience.service.getSeed.GeneralAudienceSeedResponse;
+import com.marketinghub.oprm.generalaudience.service.getSubniche.GeneralAudienceSubnicheResponse;
 import com.marketinghub.oprm.generalaudience.service.listSeeds.GeneralAudienceSeedSummaryResponse;
+import com.marketinghub.oprm.generalaudience.service.listSubniches.GeneralAudienceSubnicheSummaryResponse;
+import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.List;
 import org.junit.jupiter.api.Test;
@@ -25,7 +31,7 @@ import org.springframework.http.HttpHeaders;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 
-/** Valida o contrato HTTP da etapa de cadastro manual de sementes de público geral do OPRM. */
+/** Valida o contrato HTTP da etapa manual de sementes e subnichos de público geral do OPRM. */
 @WebMvcTest(OprmGeneralAudienceController.class)
 class OprmGeneralAudienceControllerTest {
 
@@ -94,4 +100,115 @@ class OprmGeneralAudienceControllerTest {
                 .andExpect(jsonPath("$.name").value("Beleza"))
                 .andExpect(jsonPath("$.seedType").value("CATEGORY"));
     }
+
+    /** Verifica se a API lista subnichos de uma semente para revisão operacional. */
+    @Test
+    void shouldListSubnichesThroughApi() throws Exception {
+        when(service.listSubniches(2L)).thenReturn(List.of(subnicheSummaryResponse()));
+
+        mockMvc.perform(get("/api/oprm/general-audiences/seeds/2/subniches"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].id").value(5))
+                .andExpect(jsonPath("$[0].seedId").value(2))
+                .andExpect(jsonPath("$[0].name").value("Manicure autônoma"))
+                .andExpect(jsonPath("$[0].status").value("DISCOVERED"));
+    }
+
+    /** Verifica se a API cadastra subnicho sem misturar dados de público geral com CNAE. */
+    @Test
+    void shouldCreateSubnicheThroughApi() throws Exception {
+        when(service.createSubniche(any(), any())).thenReturn(subnicheResponse(OprmGeneralAudienceSubnicheStatus.DISCOVERED));
+        CreateGeneralAudienceSubnicheRequest request = new CreateGeneralAudienceSubnicheRequest(
+                "Manicure autônoma",
+                "Profissional que atende com agenda própria",
+                "Agenda vazia durante a semana",
+                "Preencher horários ociosos",
+                "Clientes somem",
+                "WhatsApp e Instagram",
+                "Você trabalha como manicure hoje?",
+                null,
+                new BigDecimal("82.50"),
+                new BigDecimal("18.00"),
+                null);
+
+        mockMvc.perform(post("/api/oprm/general-audiences/seeds/2/subniches")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isCreated())
+                .andExpect(header().string(HttpHeaders.LOCATION, "/api/oprm/general-audiences/subniches/5"))
+                .andExpect(jsonPath("$.id").value(5))
+                .andExpect(jsonPath("$.seedId").value(2))
+                .andExpect(jsonPath("$.qualificationQuestion").value("Você trabalha como manicure hoje?"));
+    }
+
+    /** Verifica se a API atualiza um subnicho manualmente. */
+    @Test
+    void shouldUpdateSubnicheThroughApi() throws Exception {
+        when(service.updateSubniche(any(), any())).thenReturn(subnicheResponse(OprmGeneralAudienceSubnicheStatus.NEEDS_REVIEW));
+
+        mockMvc.perform(patch("/api/oprm/general-audiences/subniches/5")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("{\"status\":\"NEEDS_REVIEW\"}"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(5))
+                .andExpect(jsonPath("$.status").value("NEEDS_REVIEW"));
+    }
+
+    /** Verifica se a API aprova um subnicho para experimento futuro. */
+    @Test
+    void shouldApproveSubnicheThroughApi() throws Exception {
+        when(service.approveSubniche(5L)).thenReturn(subnicheResponse(OprmGeneralAudienceSubnicheStatus.APPROVED_FOR_EXPERIMENT));
+
+        mockMvc.perform(post("/api/oprm/general-audiences/subniches/5/approve"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("APPROVED_FOR_EXPERIMENT"));
+    }
+
+    /** Verifica se a API rejeita um subnicho amplo ou inseguro. */
+    @Test
+    void shouldRejectSubnicheThroughApi() throws Exception {
+        when(service.rejectSubniche(5L)).thenReturn(subnicheResponse(OprmGeneralAudienceSubnicheStatus.REJECTED));
+
+        mockMvc.perform(post("/api/oprm/general-audiences/subniches/5/reject"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.status").value("REJECTED"));
+    }
+
+    /** Monta resposta detalhada de subnicho para os testes HTTP. */
+    private GeneralAudienceSubnicheResponse subnicheResponse(OprmGeneralAudienceSubnicheStatus status) {
+        return new GeneralAudienceSubnicheResponse(
+                5L,
+                2L,
+                "Manicure autônoma",
+                "Profissional que atende com agenda própria",
+                "Agenda vazia durante a semana",
+                "Preencher horários ociosos",
+                "Clientes somem",
+                "WhatsApp e Instagram",
+                "Você trabalha como manicure hoje?",
+                status,
+                new BigDecimal("82.50"),
+                new BigDecimal("18.00"),
+                null,
+                Instant.parse("2026-06-10T11:00:00Z"),
+                Instant.parse("2026-06-10T11:00:00Z"));
+    }
+
+    /** Monta resposta resumida de subnicho para os testes HTTP. */
+    private GeneralAudienceSubnicheSummaryResponse subnicheSummaryResponse() {
+        return new GeneralAudienceSubnicheSummaryResponse(
+                5L,
+                2L,
+                "Manicure autônoma",
+                "Profissional que atende com agenda própria",
+                "Agenda vazia durante a semana",
+                "WhatsApp e Instagram",
+                "Você trabalha como manicure hoje?",
+                OprmGeneralAudienceSubnicheStatus.DISCOVERED,
+                new BigDecimal("82.50"),
+                new BigDecimal("18.00"),
+                null,
+                Instant.parse("2026-06-10T11:00:00Z"));
+    }
+
 }

--- a/backend/ads-service/src/test/java/com/marketinghub/oprm/generalaudience/service/OprmGeneralAudienceServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/oprm/generalaudience/service/OprmGeneralAudienceServiceTest.java
@@ -10,23 +10,30 @@ import static org.mockito.Mockito.when;
 import com.marketinghub.oprm.generalaudience.OprmGeneralAudienceSeed;
 import com.marketinghub.oprm.generalaudience.OprmGeneralAudienceSeedStatus;
 import com.marketinghub.oprm.generalaudience.OprmGeneralAudienceSeedType;
+import com.marketinghub.oprm.generalaudience.OprmGeneralAudienceSubniche;
+import com.marketinghub.oprm.generalaudience.OprmGeneralAudienceSubnicheStatus;
 import com.marketinghub.oprm.generalaudience.service.createSeed.CreateGeneralAudienceSeedRequest;
+import com.marketinghub.oprm.generalaudience.service.createSubniche.CreateGeneralAudienceSubnicheRequest;
 import com.marketinghub.oprm.generalaudience.service.updateSeed.UpdateGeneralAudienceSeedRequest;
+import com.marketinghub.oprm.generalaudience.service.updateSubniche.UpdateGeneralAudienceSubnicheRequest;
 import com.marketinghub.repository.jpa.oprm.generalaudience.OprmGeneralAudienceSeedRepository;
+import com.marketinghub.repository.jpa.oprm.generalaudience.OprmGeneralAudienceSubnicheRepository;
+import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.springframework.web.server.ResponseStatusException;
 
-/** Valida o cadastro manual de sementes amplas de público geral sem acionar o fluxo NichoCNAE. */
+/** Valida o cadastro manual de sementes e subnichos de público geral sem acionar o fluxo NichoCNAE. */
 class OprmGeneralAudienceServiceTest {
 
     /** Verifica se a criação normaliza campos e aplica padrões comerciais seguros. */
     @Test
     void shouldCreateSeedWithDefaults() {
         OprmGeneralAudienceSeedRepository repository = mock(OprmGeneralAudienceSeedRepository.class);
-        OprmGeneralAudienceService service = new OprmGeneralAudienceService(repository);
+        OprmGeneralAudienceService service = new OprmGeneralAudienceService(
+                repository, mock(OprmGeneralAudienceSubnicheRepository.class));
         when(repository.save(any())).thenAnswer(invocation -> {
             OprmGeneralAudienceSeed seed = invocation.getArgument(0);
             seed.setId(10L);
@@ -58,7 +65,8 @@ class OprmGeneralAudienceServiceTest {
     @Test
     void shouldListSeedSummaries() {
         OprmGeneralAudienceSeedRepository repository = mock(OprmGeneralAudienceSeedRepository.class);
-        OprmGeneralAudienceService service = new OprmGeneralAudienceService(repository);
+        OprmGeneralAudienceService service = new OprmGeneralAudienceService(
+                repository, mock(OprmGeneralAudienceSubnicheRepository.class));
         OprmGeneralAudienceSeed seed = seed(7L, OprmGeneralAudienceSeedStatus.READY_FOR_RESEARCH);
         when(repository.findAllByOrderByUpdatedAtDesc()).thenReturn(List.of(seed));
 
@@ -74,7 +82,8 @@ class OprmGeneralAudienceServiceTest {
     @Test
     void shouldUpdateOnlyProvidedFields() {
         OprmGeneralAudienceSeedRepository repository = mock(OprmGeneralAudienceSeedRepository.class);
-        OprmGeneralAudienceService service = new OprmGeneralAudienceService(repository);
+        OprmGeneralAudienceService service = new OprmGeneralAudienceService(
+                repository, mock(OprmGeneralAudienceSubnicheRepository.class));
         OprmGeneralAudienceSeed seed = seed(8L, OprmGeneralAudienceSeedStatus.DRAFT);
         when(repository.findById(8L)).thenReturn(Optional.of(seed));
         when(repository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
@@ -100,7 +109,8 @@ class OprmGeneralAudienceServiceTest {
     @Test
     void shouldArchiveSeed() {
         OprmGeneralAudienceSeedRepository repository = mock(OprmGeneralAudienceSeedRepository.class);
-        OprmGeneralAudienceService service = new OprmGeneralAudienceService(repository);
+        OprmGeneralAudienceService service = new OprmGeneralAudienceService(
+                repository, mock(OprmGeneralAudienceSubnicheRepository.class));
         OprmGeneralAudienceSeed seed = seed(9L, OprmGeneralAudienceSeedStatus.PAUSED);
         when(repository.findById(9L)).thenReturn(Optional.of(seed));
         when(repository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
@@ -115,12 +125,131 @@ class OprmGeneralAudienceServiceTest {
     @Test
     void shouldRejectMissingSeed() {
         OprmGeneralAudienceSeedRepository repository = mock(OprmGeneralAudienceSeedRepository.class);
-        OprmGeneralAudienceService service = new OprmGeneralAudienceService(repository);
+        OprmGeneralAudienceService service = new OprmGeneralAudienceService(
+                repository, mock(OprmGeneralAudienceSubnicheRepository.class));
         when(repository.findById(404L)).thenReturn(Optional.empty());
 
         assertThatThrownBy(() -> service.getSeed(404L))
                 .isInstanceOf(ResponseStatusException.class)
                 .hasMessageContaining("Semente de público geral não encontrada");
+    }
+
+
+    /** Verifica se a criação de subnicho preserva vínculo com a semente e aplica status inicial seguro. */
+    @Test
+    void shouldCreateSubnicheWithSeedLink() {
+        OprmGeneralAudienceSeedRepository seedRepository = mock(OprmGeneralAudienceSeedRepository.class);
+        OprmGeneralAudienceSubnicheRepository subnicheRepository = mock(OprmGeneralAudienceSubnicheRepository.class);
+        OprmGeneralAudienceService service = new OprmGeneralAudienceService(seedRepository, subnicheRepository);
+        OprmGeneralAudienceSeed seed = seed(10L, OprmGeneralAudienceSeedStatus.READY_FOR_RESEARCH);
+        when(seedRepository.findById(10L)).thenReturn(Optional.of(seed));
+        when(subnicheRepository.save(any())).thenAnswer(invocation -> {
+            OprmGeneralAudienceSubniche subniche = invocation.getArgument(0);
+            subniche.setId(20L);
+            subniche.setCreatedAt(Instant.parse("2026-06-10T11:00:00Z"));
+            subniche.setUpdatedAt(Instant.parse("2026-06-10T11:00:00Z"));
+            return subniche;
+        });
+
+        var response = service.createSubniche(10L, new CreateGeneralAudienceSubnicheRequest(
+                " Manicure autônoma ",
+                "Profissional que atende com agenda própria",
+                "Agenda vazia durante a semana",
+                "Preencher horários ociosos",
+                "Fala em clientes que somem",
+                "WhatsApp e Instagram",
+                "Você trabalha como manicure hoje?",
+                null,
+                new BigDecimal("82.50"),
+                new BigDecimal("18.00"),
+                null));
+
+        assertThat(response.id()).isEqualTo(20L);
+        assertThat(response.seedId()).isEqualTo(10L);
+        assertThat(response.name()).isEqualTo("Manicure autônoma");
+        assertThat(response.status()).isEqualTo(OprmGeneralAudienceSubnicheStatus.DISCOVERED);
+        assertThat(response.qualificationQuestion()).isEqualTo("Você trabalha como manicure hoje?");
+    }
+
+    /** Verifica se a atualização de subnicho altera somente campos enviados pela revisão manual. */
+    @Test
+    void shouldUpdateSubnicheOnlyProvidedFields() {
+        OprmGeneralAudienceSeedRepository seedRepository = mock(OprmGeneralAudienceSeedRepository.class);
+        OprmGeneralAudienceSubnicheRepository subnicheRepository = mock(OprmGeneralAudienceSubnicheRepository.class);
+        OprmGeneralAudienceService service = new OprmGeneralAudienceService(seedRepository, subnicheRepository);
+        OprmGeneralAudienceSubniche subniche = subniche(21L, seed(10L, OprmGeneralAudienceSeedStatus.READY_FOR_RESEARCH));
+        when(subnicheRepository.findById(21L)).thenReturn(Optional.of(subniche));
+        when(subnicheRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        var response = service.updateSubniche(21L, new UpdateGeneralAudienceSubnicheRequest(
+                null,
+                null,
+                "Clientes somem depois do primeiro atendimento",
+                null,
+                null,
+                null,
+                "Você atende clientes de manicure hoje?",
+                OprmGeneralAudienceSubnicheStatus.NEEDS_REVIEW,
+                null,
+                new BigDecimal("22.00"),
+                null));
+
+        assertThat(response.name()).isEqualTo("Manicure autônoma");
+        assertThat(response.painSummary()).isEqualTo("Clientes somem depois do primeiro atendimento");
+        assertThat(response.qualificationQuestion()).isEqualTo("Você atende clientes de manicure hoje?");
+        assertThat(response.status()).isEqualTo(OprmGeneralAudienceSubnicheStatus.NEEDS_REVIEW);
+        assertThat(response.riskScore()).isEqualByComparingTo("22.00");
+    }
+
+    /** Verifica se a aprovação de subnicho marca a preparação para experimento sem criar campanha. */
+    @Test
+    void shouldApproveSubnicheForExperiment() {
+        OprmGeneralAudienceSeedRepository seedRepository = mock(OprmGeneralAudienceSeedRepository.class);
+        OprmGeneralAudienceSubnicheRepository subnicheRepository = mock(OprmGeneralAudienceSubnicheRepository.class);
+        OprmGeneralAudienceService service = new OprmGeneralAudienceService(seedRepository, subnicheRepository);
+        OprmGeneralAudienceSubniche subniche = subniche(22L, seed(10L, OprmGeneralAudienceSeedStatus.READY_FOR_RESEARCH));
+        when(subnicheRepository.findById(22L)).thenReturn(Optional.of(subniche));
+        when(subnicheRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        var response = service.approveSubniche(22L);
+
+        assertThat(response.status()).isEqualTo(OprmGeneralAudienceSubnicheStatus.APPROVED_FOR_EXPERIMENT);
+        verify(subnicheRepository).save(subniche);
+    }
+
+    /** Verifica se a rejeição de subnicho bloqueia avanço de público amplo demais. */
+    @Test
+    void shouldRejectSubniche() {
+        OprmGeneralAudienceSeedRepository seedRepository = mock(OprmGeneralAudienceSeedRepository.class);
+        OprmGeneralAudienceSubnicheRepository subnicheRepository = mock(OprmGeneralAudienceSubnicheRepository.class);
+        OprmGeneralAudienceService service = new OprmGeneralAudienceService(seedRepository, subnicheRepository);
+        OprmGeneralAudienceSubniche subniche = subniche(23L, seed(10L, OprmGeneralAudienceSeedStatus.READY_FOR_RESEARCH));
+        when(subnicheRepository.findById(23L)).thenReturn(Optional.of(subniche));
+        when(subnicheRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+
+        var response = service.rejectSubniche(23L);
+
+        assertThat(response.status()).isEqualTo(OprmGeneralAudienceSubnicheStatus.REJECTED);
+    }
+
+    /** Monta um subnicho completo para os cenários de revisão manual. */
+    private OprmGeneralAudienceSubniche subniche(Long id, OprmGeneralAudienceSeed seed) {
+        OprmGeneralAudienceSubniche subniche = new OprmGeneralAudienceSubniche();
+        subniche.setId(id);
+        subniche.setSeed(seed);
+        subniche.setName("Manicure autônoma");
+        subniche.setPersonaSummary("Profissional que atende com agenda própria");
+        subniche.setPainSummary("Agenda vazia durante a semana");
+        subniche.setDesiredOutcomeSummary("Preencher horários ociosos");
+        subniche.setLanguagePatterns("Clientes que somem");
+        subniche.setChannelsSummary("WhatsApp e Instagram");
+        subniche.setQualificationQuestion("Você trabalha como manicure hoje?");
+        subniche.setStatus(OprmGeneralAudienceSubnicheStatus.DISCOVERED);
+        subniche.setOpportunityScore(new BigDecimal("82.50"));
+        subniche.setRiskScore(new BigDecimal("18.00"));
+        subniche.setCreatedAt(Instant.parse("2026-06-10T11:00:00Z"));
+        subniche.setUpdatedAt(Instant.parse("2026-06-10T11:00:00Z"));
+        return subniche;
     }
 
     /** Monta uma semente completa para os cenários de revisão manual. */

--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -329,3 +329,4 @@
 
 - Implementada a etapa 1 do plano de públicos gerais sem sobreposição CNAE: cadastro, listagem, detalhe, atualização e arquivamento manual de sementes de público geral no backend.
 - O fluxo permanece separado do NichoCNAE e não cria nicho, hipótese, experimento ou campanha automaticamente.
+- 2026-06-10 00:00:00 (UTC): executada a etapa 2 do plano de públicos gerais sem sobreposição com CNAE: o backend passou a persistir e expor subnichos derivados de sementes gerais em tabela própria `oprm_general_audience_subniche`, com endpoints OPRM para listar, cadastrar, detalhar, revisar, aprovar e rejeitar subnichos sem gravar esses públicos nas tabelas OPRM CNAE nem tratá-los como campanha pronta.

--- a/docs/swagger/oprm-general-audiences-swagger.yaml
+++ b/docs/swagger/oprm-general-audiences-swagger.yaml
@@ -1,8 +1,8 @@
 openapi: 3.0.3
 info:
   title: OPRM Públicos Gerais API
-  version: 0.1.0
-  description: Endpoints do backend para cadastro e revisão manual de sementes de públicos gerais antes de virar subnicho, nicho ou campanha.
+  version: 0.2.0
+  description: Endpoints do backend para cadastro e revisão manual de sementes e subnichos de públicos gerais antes de virar nicho ou campanha.
 tags:
   - name: OPRM Públicos Gerais
 paths:
@@ -89,10 +89,123 @@ paths:
                 $ref: '#/components/schemas/GeneralAudienceSeed'
         '404':
           description: Semente não encontrada.
+  /api/oprm/general-audiences/seeds/{seedId}/subniches:
+    get:
+      summary: Lista subnichos derivados de uma semente de público geral.
+      tags: [OPRM Públicos Gerais]
+      parameters:
+        - $ref: '#/components/parameters/SeedId'
+      responses:
+        '200':
+          description: Subnichos da semente ordenados pela atualização mais recente.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/GeneralAudienceSubnicheSummary'
+        '404':
+          description: Semente não encontrada.
+    post:
+      summary: Cadastra manualmente um subnicho derivado da semente.
+      tags: [OPRM Públicos Gerais]
+      parameters:
+        - $ref: '#/components/parameters/SeedId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateGeneralAudienceSubnicheRequest'
+      responses:
+        '201':
+          description: Subnicho cadastrado para descoberta/revisão, sem ser tratado como CNAE.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralAudienceSubniche'
+        '400':
+          description: Payload inválido.
+        '404':
+          description: Semente não encontrada.
+  /api/oprm/general-audiences/subniches/{subnicheId}:
+    get:
+      summary: Detalha um subnicho de público geral.
+      tags: [OPRM Públicos Gerais]
+      parameters:
+        - $ref: '#/components/parameters/SubnicheId'
+      responses:
+        '200':
+          description: Detalhe do subnicho para revisão de persona, dor, canais e triagem.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralAudienceSubniche'
+        '404':
+          description: Subnicho não encontrado.
+    patch:
+      summary: Atualiza campos manuais de um subnicho de público geral.
+      tags: [OPRM Públicos Gerais]
+      parameters:
+        - $ref: '#/components/parameters/SubnicheId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateGeneralAudienceSubnicheRequest'
+      responses:
+        '200':
+          description: Subnicho atualizado sem conversão automática para nicho ou campanha.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralAudienceSubniche'
+        '400':
+          description: Payload inválido.
+        '404':
+          description: Subnicho não encontrado.
+  /api/oprm/general-audiences/subniches/{subnicheId}/approve:
+    post:
+      summary: Aprova um subnicho para experimento futuro.
+      tags: [OPRM Públicos Gerais]
+      parameters:
+        - $ref: '#/components/parameters/SubnicheId'
+      responses:
+        '200':
+          description: Subnicho marcado como aprovado para experimento.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralAudienceSubniche'
+        '404':
+          description: Subnicho não encontrado.
+  /api/oprm/general-audiences/subniches/{subnicheId}/reject:
+    post:
+      summary: Rejeita um subnicho amplo ou inseguro.
+      tags: [OPRM Públicos Gerais]
+      parameters:
+        - $ref: '#/components/parameters/SubnicheId'
+      responses:
+        '200':
+          description: Subnicho rejeitado sem apagar o histórico de descoberta.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralAudienceSubniche'
+        '404':
+          description: Subnicho não encontrado.
 components:
   parameters:
     SeedId:
       name: seedId
+      in: path
+      required: true
+      schema:
+        type: integer
+        format: int64
+    SubnicheId:
+      name: subnicheId
       in: path
       required: true
       schema:
@@ -105,6 +218,15 @@ components:
     SeedStatus:
       type: string
       enum: [DRAFT, READY_FOR_RESEARCH, RESEARCHING, MAPPED, PAUSED, ARCHIVED]
+    SubnicheStatus:
+      type: string
+      enum: [DISCOVERED, NEEDS_REVIEW, APPROVED_FOR_EXPERIMENT, REJECTED, CONVERTED_TO_NICHE]
+    Score:
+      type: number
+      format: decimal
+      minimum: 0
+      maximum: 100
+      nullable: true
     CreateGeneralAudienceSeedRequest:
       type: object
       required: [name, seedType]
@@ -166,6 +288,50 @@ components:
         riskNotes:
           type: string
           nullable: true
+    CreateGeneralAudienceSubnicheRequest:
+      type: object
+      required: [name]
+      properties:
+        name:
+          type: string
+          maxLength: 191
+          example: Manicure autônoma
+        personaSummary:
+          type: string
+          nullable: true
+          example: Profissional autônoma que atende clientes com agenda própria.
+        painSummary:
+          type: string
+          nullable: true
+          example: Agenda vazia durante a semana e clientes que somem.
+        desiredOutcomeSummary:
+          type: string
+          nullable: true
+          example: Preencher horários ociosos com clientes antigas e recorrentes.
+        languagePatterns:
+          type: string
+          nullable: true
+        channelsSummary:
+          type: string
+          nullable: true
+          example: WhatsApp e Instagram.
+        qualificationQuestion:
+          type: string
+          nullable: true
+          example: Você trabalha como manicure hoje?
+        status:
+          $ref: '#/components/schemas/SubnicheStatus'
+        opportunityScore:
+          $ref: '#/components/schemas/Score'
+        riskScore:
+          $ref: '#/components/schemas/Score'
+        marketNicheId:
+          type: integer
+          format: int64
+          nullable: true
+    UpdateGeneralAudienceSubnicheRequest:
+      allOf:
+        - $ref: '#/components/schemas/CreateGeneralAudienceSubnicheRequest'
     GeneralAudienceSeed:
       allOf:
         - $ref: '#/components/schemas/CreateGeneralAudienceSeedRequest'
@@ -201,6 +367,61 @@ components:
           $ref: '#/components/schemas/SeedType'
         status:
           $ref: '#/components/schemas/SeedStatus'
+        updatedAt:
+          type: string
+          format: date-time
+    GeneralAudienceSubniche:
+      allOf:
+        - $ref: '#/components/schemas/CreateGeneralAudienceSubnicheRequest'
+        - type: object
+          required: [id, seedId, name, status, createdAt, updatedAt]
+          properties:
+            id:
+              type: integer
+              format: int64
+            seedId:
+              type: integer
+              format: int64
+            createdAt:
+              type: string
+              format: date-time
+            updatedAt:
+              type: string
+              format: date-time
+    GeneralAudienceSubnicheSummary:
+      type: object
+      required: [id, seedId, name, status, updatedAt]
+      properties:
+        id:
+          type: integer
+          format: int64
+        seedId:
+          type: integer
+          format: int64
+        name:
+          type: string
+        personaSummary:
+          type: string
+          nullable: true
+        painSummary:
+          type: string
+          nullable: true
+        channelsSummary:
+          type: string
+          nullable: true
+        qualificationQuestion:
+          type: string
+          nullable: true
+        status:
+          $ref: '#/components/schemas/SubnicheStatus'
+        opportunityScore:
+          $ref: '#/components/schemas/Score'
+        riskScore:
+          $ref: '#/components/schemas/Score'
+        marketNicheId:
+          type: integer
+          format: int64
+          nullable: true
         updatedAt:
           type: string
           format: date-time


### PR DESCRIPTION
### Motivation
- Implementar a Etapa 2 do plano `Públicos Gerais` para permitir descoberta e revisão de subnichos derivados de sementes gerais sem sobrepor ou falsificar dados CNAE.
- Garantir separação arquitetural entre o fluxo NichoCNAE e o novo fluxo de públicos gerais, preservando rastreabilidade e governança de persistência.

### Description
- Adiciona tabela Liquibase `oprm_general_audience_subniche` e inclui o changelog `2026-06-10-oprm-general-audience-subniche.yaml` para persistência segura do subnicho sem contaminar tabelas CNAE; o master `db.changelog-master.yaml` foi atualizado para incluir o changeset. (files: `backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-10-oprm-general-audience-subniche.yaml`, `db.changelog-master.yaml`)
- Cria entidade JPA `OprmGeneralAudienceSubniche`, enum `OprmGeneralAudienceSubnicheStatus` e repositório `OprmGeneralAudienceSubnicheRepository` em `com.marketinghub.oprm.generalaudience` e `com.marketinghub.repository.jpa.oprm.generalaudience` para leitura/gravação centralizada. (files: `OprmGeneralAudienceSubniche.java`, `OprmGeneralAudienceSubnicheStatus.java`, repository)
- Estende o serviço `OprmGeneralAudienceService` com operações de `list/create/get/update/approve/reject` para subnichos e adiciona endpoints HTTP correspondentes no controller único `OprmGeneralAudienceController` sob a rota base `/api/oprm/general-audiences` (novas rotas: `/seeds/{seedId}/subniches`, `/subniches/{subnicheId}`, `/subniches/{subnicheId}/approve|reject`).
- Adiciona DTO/record de contrato para criação/atualização/listagem/detalhe de subnicho e atualiza o Swagger `docs/swagger/oprm-general-audiences-swagger.yaml` para documentar os novos endpoints e schemas.
- Inclui testes unitários e de controller cobrindo criação, listagem, atualização, aprovação e rejeição de subnichos, além de atualizar os testes existentes de sementes para injetar o novo repository (files: tests under `backend/ads-service/src/test/java/com/marketinghub/oprm/generalaudience`).
- Atualiza o registro operacional `docs/registros/oprm1.md` com a execução da Etapa 2 e preserva a regra de não converter automaticamente subnichos em CNAE/nicho/campanha.

### Testing
- Executado `../mvnw -Dtest=OprmGeneralAudienceServiceTest,OprmGeneralAudienceControllerTest test` no módulo `ads-service` com `JAVA_HOME` apontando para Java 21; os testes selecionados completaram com sucesso (total de 16 testes, 0 falhas). 
- Executado build/test do módulo `ads-service` durante verificação local; compilação e suíte de testes do módulo completaram com `BUILD SUCCESS` durante validação local.
- Verificações de estilo/formatação: `spotless:apply` não pôde ser executado automaticamente neste ambiente porque o prefixo/plugin `spotless` não foi resolvido no runtime Maven deste job (informação operacional apenas).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a28de4b231c832095ba6c37623f3a49)