### PR TITLE
Frontend: adicionar UI e hooks de "Aquecimento do Mercado" (MOIS Fase 8)

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/dto/MoisSalesLibraryDtos.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/dto/MoisSalesLibraryDtos.java
@@ -222,7 +222,13 @@ public final class MoisSalesLibraryDtos {
             Long lastJobExecutionId,
             Instant lastCapturedAt,
             Instant analyzedAt,
-            Instant updatedAt
+            Instant updatedAt,
+            BigDecimal marketWarmupScoreTotal,
+            MarketWarmupTemperature marketWarmupTemperature,
+            MarketWarmupEcosystemType marketWarmupEcosystemType,
+            MarketWarmupRecommendation marketWarmupRecommendation,
+            MarketWarmupJobStatus marketWarmupStatus,
+            Instant marketWarmupUpdatedAt
     ) {
     }
 
@@ -243,6 +249,16 @@ public final class MoisSalesLibraryDtos {
             long blockedCooldown,
             long hotmart,
             long clickbank,
+            long marketWarmupEligible,
+            long marketWarmupPending,
+            long marketWarmupRunning,
+            long marketWarmupCompleted,
+            long marketWarmupFailed,
+            long marketWarmupHot,
+            long marketWarmupPromising,
+            long marketWarmupWarm,
+            long marketWarmupCold,
+            long marketWarmupSaturated,
             Instant updatedAt
     ) {
     }

--- a/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryService.java
@@ -474,13 +474,23 @@ public class MoisSalesLibraryService {
         int offset = (normalizedPage - 1) * normalizedPageSize;
         Long total = jdbcTemplate.queryForObject("SELECT COUNT(*) FROM mois_sales_page WHERE workspace_id = ?", Long.class, workspaceId);
         List<MoisSalesLibraryDtos.SalesLibraryPageResponse> items = jdbcTemplate.query("""
-                SELECT id, workspace_id, source, url_canonical, title, current_stage, current_status, capture_status,
-                       COALESCE(analysis_status, current_status) AS analysis_status, url_final, http_status, html_sha256,
-                       html_bytes, score_total, offer_summary, mechanism_summary, promise_summary, proof_summary,
-                       last_error_category, last_error_message, last_job_execution_id, last_captured_at, last_analyzed_at, updated_at
-                FROM mois_sales_page
-                WHERE workspace_id = ?
-                ORDER BY last_analyzed_at DESC, updated_at DESC, id DESC LIMIT ? OFFSET ?
+                SELECT p.id, p.workspace_id, p.source, p.url_canonical, p.title, p.current_stage, p.current_status, p.capture_status,
+                       COALESCE(p.analysis_status, p.current_status) AS analysis_status, p.url_final, p.http_status, p.html_sha256,
+                       p.html_bytes, p.score_total, p.offer_summary, p.mechanism_summary, p.promise_summary, p.proof_summary,
+                       p.last_error_category, p.last_error_message, p.last_job_execution_id, p.last_captured_at, p.last_analyzed_at, p.updated_at,
+                       mws.score_total AS market_warmup_score_total, mws.market_temperature AS market_warmup_temperature,
+                       mws.ecosystem_type AS market_warmup_ecosystem_type, mws.recommendation AS market_warmup_recommendation,
+                       mwj.status AS market_warmup_status, COALESCE(mws.updated_at, mwj.updated_at) AS market_warmup_updated_at
+                FROM mois_sales_page p
+                LEFT JOIN (
+                    SELECT sales_page_id, MAX(id) AS latest_warmup_job_id
+                    FROM mois_sales_page_market_warmup_job
+                    GROUP BY sales_page_id
+                ) mwj_latest ON mwj_latest.sales_page_id = p.id
+                LEFT JOIN mois_sales_page_market_warmup_job mwj ON mwj.id = mwj_latest.latest_warmup_job_id
+                LEFT JOIN mois_sales_page_market_warmup_summary mws ON mws.job_id = mwj.id
+                WHERE p.workspace_id = ?
+                ORDER BY p.last_analyzed_at DESC, p.updated_at DESC, p.id DESC LIMIT ? OFFSET ?
                 """, this::mapSalesPageResponse, workspaceId, normalizedPageSize, offset);
         return new MoisSalesLibraryDtos.SalesLibraryPageListResponse(normalizedPage, normalizedPageSize, total == null ? 0 : total, items);
     }
@@ -491,25 +501,47 @@ public class MoisSalesLibraryService {
     public MoisSalesLibraryDtos.SalesLibraryPageSummaryResponse summarizePages(String workspaceId) {
         return jdbcTemplate.queryForObject("""
                 SELECT COUNT(*) AS total,
-                       SUM(current_status = 'PENDING') AS pending,
-                       SUM(current_status IN ('FETCHING', 'CAPTURING')) AS capturing,
-                       SUM(COALESCE(html_bytes, 0) > 0) AS captured,
-                       SUM(current_status IN ('DONE', 'ANALYZED')) AS analyzed,
-                       SUM(COALESCE(html_bytes, 0) > 0 AND COALESCE(analysis_status, current_status) = 'PENDING') AS analysis_pending,
-                       SUM(COALESCE(html_bytes, 0) > 0 AND COALESCE(analysis_status, current_status) = 'FETCHING') AS analysis_running,
-                       SUM(COALESCE(html_bytes, 0) > 0 AND COALESCE(analysis_status, current_status) = 'FAILED') AS analysis_failed,
-                       SUM(current_status = 'FAILED') AS failed,
-                       SUM(current_status = 'BLOCKED_COOLDOWN') AS blocked_cooldown,
-                       SUM(source = 'HOTMART') AS hotmart,
-                       SUM(source = 'CLICKBANK') AS clickbank,
-                       MAX(updated_at) AS updated_at
-                FROM mois_sales_page
-                WHERE workspace_id = ?
+                       SUM(p.current_status = 'PENDING') AS pending,
+                       SUM(p.current_status IN ('FETCHING', 'CAPTURING')) AS capturing,
+                       SUM(COALESCE(p.html_bytes, 0) > 0) AS captured,
+                       SUM(p.current_status IN ('DONE', 'ANALYZED')) AS analyzed,
+                       SUM(COALESCE(p.html_bytes, 0) > 0 AND COALESCE(p.analysis_status, p.current_status) = 'PENDING') AS analysis_pending,
+                       SUM(COALESCE(p.html_bytes, 0) > 0 AND COALESCE(p.analysis_status, p.current_status) = 'FETCHING') AS analysis_running,
+                       SUM(COALESCE(p.html_bytes, 0) > 0 AND COALESCE(p.analysis_status, p.current_status) = 'FAILED') AS analysis_failed,
+                       SUM(p.current_status = 'FAILED') AS failed,
+                       SUM(p.current_status = 'BLOCKED_COOLDOWN') AS blocked_cooldown,
+                       SUM(p.source = 'HOTMART') AS hotmart,
+                       SUM(p.source = 'CLICKBANK') AS clickbank,
+                       SUM(p.current_status IN ('DONE', 'ANALYZED')) AS market_warmup_eligible,
+                       SUM(mwj.status = 'PENDING') AS market_warmup_pending,
+                       SUM(mwj.status = 'FETCHING') AS market_warmup_running,
+                       SUM(mwj.status = 'DONE' AND mws.job_id IS NOT NULL) AS market_warmup_completed,
+                       SUM(mwj.status = 'FAILED') AS market_warmup_failed,
+                       SUM(mws.market_temperature = 'HOT') AS market_warmup_hot,
+                       SUM(mws.market_temperature = 'PROMISING') AS market_warmup_promising,
+                       SUM(mws.market_temperature = 'WARM') AS market_warmup_warm,
+                       SUM(mws.market_temperature = 'COLD') AS market_warmup_cold,
+                       SUM(mws.market_temperature = 'SATURATED') AS market_warmup_saturated,
+                       MAX(p.updated_at) AS updated_at
+                FROM mois_sales_page p
+                LEFT JOIN (
+                    SELECT sales_page_id, MAX(id) AS latest_warmup_job_id
+                    FROM mois_sales_page_market_warmup_job
+                    GROUP BY sales_page_id
+                ) mwj_latest ON mwj_latest.sales_page_id = p.id
+                LEFT JOIN mois_sales_page_market_warmup_job mwj ON mwj.id = mwj_latest.latest_warmup_job_id
+                LEFT JOIN mois_sales_page_market_warmup_summary mws ON mws.job_id = mwj.id
+                WHERE p.workspace_id = ?
                 """, (rs, rn) -> new MoisSalesLibraryDtos.SalesLibraryPageSummaryResponse(
                 workspaceId, rs.getLong("total"), rs.getLong("pending"), rs.getLong("capturing"),
                 rs.getLong("captured"), rs.getLong("analyzed"), rs.getLong("analysis_pending"),
                 rs.getLong("analysis_running"), rs.getLong("analysis_failed"), rs.getLong("failed"),
                 rs.getLong("blocked_cooldown"), rs.getLong("hotmart"), rs.getLong("clickbank"),
+                rs.getLong("market_warmup_eligible"), rs.getLong("market_warmup_pending"),
+                rs.getLong("market_warmup_running"), rs.getLong("market_warmup_completed"),
+                rs.getLong("market_warmup_failed"), rs.getLong("market_warmup_hot"),
+                rs.getLong("market_warmup_promising"), rs.getLong("market_warmup_warm"),
+                rs.getLong("market_warmup_cold"), rs.getLong("market_warmup_saturated"),
                 toInstant(rs.getTimestamp("updated_at"))), workspaceId);
     }
 
@@ -518,12 +550,22 @@ public class MoisSalesLibraryService {
      */
     public MoisSalesLibraryDtos.SalesLibraryPageResponse getPage(long pageId) {
         List<MoisSalesLibraryDtos.SalesLibraryPageResponse> rows = jdbcTemplate.query("""
-                SELECT id, workspace_id, source, url_canonical, title, current_stage, current_status, capture_status,
-                       COALESCE(analysis_status, current_status) AS analysis_status, url_final, http_status, html_sha256,
-                       html_bytes, score_total, offer_summary, mechanism_summary, promise_summary, proof_summary,
-                       last_error_category, last_error_message, last_job_execution_id, last_captured_at, last_analyzed_at, updated_at
-                FROM mois_sales_page
-                WHERE id = ? LIMIT 1
+                SELECT p.id, p.workspace_id, p.source, p.url_canonical, p.title, p.current_stage, p.current_status, p.capture_status,
+                       COALESCE(p.analysis_status, p.current_status) AS analysis_status, p.url_final, p.http_status, p.html_sha256,
+                       p.html_bytes, p.score_total, p.offer_summary, p.mechanism_summary, p.promise_summary, p.proof_summary,
+                       p.last_error_category, p.last_error_message, p.last_job_execution_id, p.last_captured_at, p.last_analyzed_at, p.updated_at,
+                       mws.score_total AS market_warmup_score_total, mws.market_temperature AS market_warmup_temperature,
+                       mws.ecosystem_type AS market_warmup_ecosystem_type, mws.recommendation AS market_warmup_recommendation,
+                       mwj.status AS market_warmup_status, COALESCE(mws.updated_at, mwj.updated_at) AS market_warmup_updated_at
+                FROM mois_sales_page p
+                LEFT JOIN (
+                    SELECT sales_page_id, MAX(id) AS latest_warmup_job_id
+                    FROM mois_sales_page_market_warmup_job
+                    GROUP BY sales_page_id
+                ) mwj_latest ON mwj_latest.sales_page_id = p.id
+                LEFT JOIN mois_sales_page_market_warmup_job mwj ON mwj.id = mwj_latest.latest_warmup_job_id
+                LEFT JOIN mois_sales_page_market_warmup_summary mws ON mws.job_id = mwj.id
+                WHERE p.id = ? LIMIT 1
                 """, this::mapSalesPageResponse, pageId);
         if (rows.isEmpty()) throw new IllegalArgumentException("Page not found: " + pageId);
         return rows.get(0);
@@ -1124,8 +1166,25 @@ public class MoisSalesLibraryService {
                 rs.getObject("last_job_execution_id", Long.class),
                 toInstant(rs.getTimestamp("last_captured_at")),
                 toInstant(rs.getTimestamp("last_analyzed_at")),
-                toInstant(rs.getTimestamp("updated_at"))
+                toInstant(rs.getTimestamp("updated_at")),
+                rs.getBigDecimal("market_warmup_score_total"),
+                mapEnum(MoisSalesLibraryDtos.MarketWarmupTemperature.class, rs.getString("market_warmup_temperature")),
+                mapEnum(MoisSalesLibraryDtos.MarketWarmupEcosystemType.class, rs.getString("market_warmup_ecosystem_type")),
+                mapEnum(MoisSalesLibraryDtos.MarketWarmupRecommendation.class, rs.getString("market_warmup_recommendation")),
+                mapEnum(MoisSalesLibraryDtos.MarketWarmupJobStatus.class, rs.getString("market_warmup_status")),
+                toInstant(rs.getTimestamp("market_warmup_updated_at"))
         );
+    }
+
+
+    /**
+     * Converte texto persistido em enum sem quebrar a UI quando o campo ainda não existe.
+     */
+    private <E extends Enum<E>> E mapEnum(Class<E> enumType, String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+        return Enum.valueOf(enumType, value);
     }
 
     /**

--- a/backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryServiceTest.java
@@ -111,7 +111,7 @@ class MoisSalesLibraryServiceTest {
     @Test
     void shouldSummarizeCapturedPagesByUsefulHtmlBytes() {
         given(jdbcTemplate.queryForObject(
-                contains("SUM(COALESCE(html_bytes, 0) > 0) AS captured"),
+                contains("SUM(COALESCE(p.html_bytes, 0) > 0) AS captured"),
                 isA(RowMapper.class),
                 eq("workspace-001")))
                 .willReturn(new MoisSalesLibraryDtos.SalesLibraryPageSummaryResponse(
@@ -128,6 +128,16 @@ class MoisSalesLibraryServiceTest {
                         0L,
                         402L,
                         19L,
+                        106L,
+                        8L,
+                        3L,
+                        70L,
+                        2L,
+                        18L,
+                        28L,
+                        12L,
+                        5L,
+                        7L,
                         Instant.parse("2026-06-07T05:38:13Z")
                 ));
 
@@ -135,6 +145,9 @@ class MoisSalesLibraryServiceTest {
 
         org.assertj.core.api.Assertions.assertThat(response.captured()).isEqualTo(327L);
         org.assertj.core.api.Assertions.assertThat(response.analysisPending()).isEqualTo(190L);
+        org.assertj.core.api.Assertions.assertThat(response.marketWarmupEligible()).isEqualTo(106L);
+        org.assertj.core.api.Assertions.assertThat(response.marketWarmupCompleted()).isEqualTo(70L);
+        org.assertj.core.api.Assertions.assertThat(response.marketWarmupPromising()).isEqualTo(28L);
     }
 
     /**
@@ -156,7 +169,8 @@ class MoisSalesLibraryServiceTest {
         ArgumentCaptor<String> sqlCaptor = ArgumentCaptor.forClass(String.class);
         verify(jdbcTemplate).query(sqlCaptor.capture(), isA(RowMapper.class), eq("workspace-001"), eq(20), eq(0));
         org.assertj.core.api.Assertions.assertThat(sqlCaptor.getValue())
-                .contains("ORDER BY last_analyzed_at DESC, updated_at DESC, id DESC LIMIT ? OFFSET ?");
+                .contains("LEFT JOIN mois_sales_page_market_warmup_summary mws")
+                .contains("ORDER BY p.last_analyzed_at DESC, p.updated_at DESC, p.id DESC LIMIT ? OFFSET ?");
     }
 
     /**
@@ -386,9 +400,9 @@ class MoisSalesLibraryServiceTest {
                 .thenReturn(upsertResults.length == 0 ? 1 : upsertResults[0], java.util.Arrays.stream(upsertResults).skip(1).boxed().toArray(Integer[]::new));
         lenient().when(jdbcTemplate.query(contains("WHERE workspace_id = ? AND url_canonical = ?"), isA(RowMapper.class), any(), any()))
                 .thenReturn(List.of(99L));
-        lenient().when(jdbcTemplate.query(contains("SELECT id, workspace_id, source"), isA(RowMapper.class), any()))
+        lenient().when(jdbcTemplate.query(contains("SELECT p.id, p.workspace_id, p.source"), isA(RowMapper.class), any()))
                 .thenReturn(List.of(new MoisSalesLibraryDtos.SalesLibraryPageResponse(99L, "10", "HOTMART", "https://example.com/pagina", "Title",
-                        "ANALYSIS", "PENDING", null, "PENDING", null, null, null, 0L, BigDecimal.ZERO, null, null, null, null, null, null, null, null, null, Instant.now())));
+                        "ANALYSIS", "PENDING", null, "PENDING", null, null, null, 0L, BigDecimal.ZERO, null, null, null, null, null, null, null, null, null, Instant.now(), null, null, null, null, null, null)));
         lenient().when(jdbcTemplate.update(contains("INSERT INTO mois_sales_page_job_execution"), any(), any(), any())).thenReturn(1);
         lenient().when(jdbcTemplate.queryForObject(contains("SELECT LAST_INSERT_ID()"), eq(Long.class))).thenReturn(123L);
         lenient().when(jdbcTemplate.update(contains("UPDATE mois_sales_page"), any(), any())).thenReturn(1);

--- a/backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/web/MoisSalesLibraryControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/web/MoisSalesLibraryControllerTest.java
@@ -138,6 +138,16 @@ class MoisSalesLibraryControllerTest {
                         0L,
                         126L,
                         19L,
+                        105L,
+                        6L,
+                        2L,
+                        70L,
+                        4L,
+                        16L,
+                        22L,
+                        9L,
+                        5L,
+                        18L,
                         Instant.parse("2026-06-04T16:00:09Z")
                 ));
 
@@ -152,7 +162,15 @@ class MoisSalesLibraryControllerTest {
                 .andExpect(jsonPath("$.analysisRunning").value(2))
                 .andExpect(jsonPath("$.analysisFailed").value(16))
                 .andExpect(jsonPath("$.failed").value(16))
-                .andExpect(jsonPath("$.blockedCooldown").value(0));
+                .andExpect(jsonPath("$.blockedCooldown").value(0))
+                .andExpect(jsonPath("$.marketWarmupEligible").value(105))
+                .andExpect(jsonPath("$.marketWarmupPending").value(6))
+                .andExpect(jsonPath("$.marketWarmupRunning").value(2))
+                .andExpect(jsonPath("$.marketWarmupCompleted").value(70))
+                .andExpect(jsonPath("$.marketWarmupFailed").value(4))
+                .andExpect(jsonPath("$.marketWarmupHot").value(16))
+                .andExpect(jsonPath("$.marketWarmupPromising").value(22))
+                .andExpect(jsonPath("$.marketWarmupSaturated").value(18));
     }
 
     /**

--- a/docs/registros/mois1.md
+++ b/docs/registros/mois1.md
@@ -1318,3 +1318,19 @@ Arquivos principais:
 - `frontend/src/api/mois/types.ts`
 - `frontend/src/api/mois/useMoisSalesLibrary.ts`
 - `frontend/src/pages/mois/MoisSalesPageLibraryDetailPage.tsx`
+
+## 2026-06-10 — MOIS Etapa 3 — Fase 9: biblioteca e pipeline de aquecimento
+
+- Executada a Fase 9 do plano `docs/implementacao/mois/plano-etapa-3-aquecimento-ecossistema-mercado.md`.
+- O backend passou a expor contadores globais da Etapa 3 no resumo da biblioteca e os campos de aquecimento mais recentes na listagem de páginas.
+- A tela de pipeline passou a mostrar cobertura real da Etapa 3: elegíveis, concluídos, fila, falhas e temperaturas de mercado.
+- A biblioteca passou a permitir priorização por score de aquecimento, com filtro simples por dossiê, temperatura quente/promissora, fila, falha ou ausência de dossiê.
+
+Arquivos principais:
+
+- `backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/dto/MoisSalesLibraryDtos.java`
+- `backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryService.java`
+- `frontend/src/api/mois/types.ts`
+- `frontend/src/pages/mois/MoisSalesPagesLibraryPage.tsx`
+- `frontend/src/pages/mois/MoisSalesPagesPipelinePage.tsx`
+- `docs/swagger/mois-sales-library-swagger.yaml`

--- a/docs/registros/mois1.md
+++ b/docs/registros/mois1.md
@@ -1305,3 +1305,16 @@ Arquivos principais:
 - `backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesPageMarketWarmupScoreEngine.java`
 - `backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesPageMarketWarmupService.java`
 - `backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesPageMarketWarmupServiceTest.java`
+
+## 2026-06-10 — MOIS Etapa 3 — Fase 8: UI de aquecimento no detalhe da página
+
+- Executada a Fase 8 do plano `docs/implementacao/mois/plano-etapa-3-aquecimento-ecossistema-mercado.md`.
+- Criados hooks frontend para consultar resumo, fontes e sinais da pesquisa de aquecimento e para solicitar uma nova pesquisa via backend MOIS.
+- Adicionado bloco **Aquecimento do Mercado** na tela de detalhe da página da biblioteca de páginas de venda, com score, temperatura, ecossistema, recomendação, fontes rastreáveis, sinais comerciais, estados de carregamento, erro e vazio.
+- Mantido o padrão arquitetural: o frontend consome somente endpoints do backend MOIS já existentes e os links externos das fontes abrem em nova aba.
+
+Arquivos principais:
+
+- `frontend/src/api/mois/types.ts`
+- `frontend/src/api/mois/useMoisSalesLibrary.ts`
+- `frontend/src/pages/mois/MoisSalesPageLibraryDetailPage.tsx`

--- a/docs/swagger/mois-sales-library-swagger.yaml
+++ b/docs/swagger/mois-sales-library-swagger.yaml
@@ -1314,6 +1314,30 @@ components:
         updatedAt:
           type: string
           format: date-time
+        marketWarmupScoreTotal:
+          type: number
+          nullable: true
+          description: Score do dossiê mais recente de aquecimento da Etapa 3.
+        marketWarmupTemperature:
+          nullable: true
+          allOf:
+            - $ref: '#/components/schemas/MarketWarmupTemperature'
+        marketWarmupEcosystemType:
+          nullable: true
+          allOf:
+            - $ref: '#/components/schemas/MarketWarmupEcosystemType'
+        marketWarmupRecommendation:
+          nullable: true
+          allOf:
+            - $ref: '#/components/schemas/MarketWarmupRecommendation'
+        marketWarmupStatus:
+          nullable: true
+          allOf:
+            - $ref: '#/components/schemas/MarketWarmupJobStatus'
+        marketWarmupUpdatedAt:
+          type: string
+          format: date-time
+          nullable: true
     SalesLibraryPageListResponse:
       type: object
       properties:
@@ -1372,6 +1396,38 @@ components:
           type: integer
           format: int64
         clickbank:
+          type: integer
+          format: int64
+        marketWarmupEligible:
+          type: integer
+          format: int64
+          description: Páginas analisadas elegíveis para pesquisa de aquecimento da Etapa 3.
+        marketWarmupPending:
+          type: integer
+          format: int64
+        marketWarmupRunning:
+          type: integer
+          format: int64
+        marketWarmupCompleted:
+          type: integer
+          format: int64
+          description: Páginas com dossiê de aquecimento concluído e resumo salvo.
+        marketWarmupFailed:
+          type: integer
+          format: int64
+        marketWarmupHot:
+          type: integer
+          format: int64
+        marketWarmupPromising:
+          type: integer
+          format: int64
+        marketWarmupWarm:
+          type: integer
+          format: int64
+        marketWarmupCold:
+          type: integer
+          format: int64
+        marketWarmupSaturated:
           type: integer
           format: int64
         updatedAt:

--- a/frontend/src/api/mois/types.ts
+++ b/frontend/src/api/mois/types.ts
@@ -279,6 +279,12 @@ export interface MoisSalesLibraryPage {
   lastCapturedAt?: string;
   analyzedAt?: string;
   updatedAt: string;
+  marketWarmupScoreTotal?: number;
+  marketWarmupTemperature?: MoisMarketWarmupTemperature;
+  marketWarmupEcosystemType?: MoisMarketWarmupEcosystemType;
+  marketWarmupRecommendation?: MoisMarketWarmupRecommendation;
+  marketWarmupStatus?: MoisMarketWarmupJobStatus;
+  marketWarmupUpdatedAt?: string;
 }
 
 export interface MoisSalesLibraryPageSummary {
@@ -295,6 +301,16 @@ export interface MoisSalesLibraryPageSummary {
   blockedCooldown: number;
   hotmart: number;
   clickbank: number;
+  marketWarmupEligible: number;
+  marketWarmupPending: number;
+  marketWarmupRunning: number;
+  marketWarmupCompleted: number;
+  marketWarmupFailed: number;
+  marketWarmupHot: number;
+  marketWarmupPromising: number;
+  marketWarmupWarm: number;
+  marketWarmupCold: number;
+  marketWarmupSaturated: number;
   updatedAt?: string;
 }
 

--- a/frontend/src/api/mois/types.ts
+++ b/frontend/src/api/mois/types.ts
@@ -298,7 +298,6 @@ export interface MoisSalesLibraryPageSummary {
   updatedAt?: string;
 }
 
-
 export interface MoisCollectedReferenceUrlSourceBreakdown {
   source: string;
   uniqueEffectiveUrls: number;
@@ -320,6 +319,147 @@ export interface MoisCollectedReferenceUrlSummary {
   missingFromOperationalLibrary: number;
   bySource: MoisCollectedReferenceUrlSourceBreakdown[];
   byUrlType: MoisCollectedReferenceUrlTypeBreakdown[];
+}
+
+export type MoisMarketWarmupJobStatus =
+  | "PENDING"
+  | "FETCHING"
+  | "DONE"
+  | "FAILED";
+
+export type MoisMarketWarmupTemperature =
+  | "HOT"
+  | "PROMISING"
+  | "WARM"
+  | "COLD"
+  | "SATURATED";
+
+export type MoisMarketWarmupEcosystemType =
+  | "SPECIALISTS_HEATED"
+  | "CREATORS_HEATED"
+  | "RECURRING_PAIN_HEATED"
+  | "COMPETITORS_HEATED"
+  | "COLD_OR_UNEDUCATED"
+  | "SATURATED";
+
+export type MoisMarketWarmupRecommendation =
+  | "PRIORITIZE"
+  | "OBSERVE"
+  | "RESEARCH_MORE"
+  | "DISCARD"
+  | "SATURATED_REQUIRES_ANGLE";
+
+export type MoisMarketWarmupPlatform =
+  | "WEB"
+  | "GOOGLE"
+  | "YOUTUBE"
+  | "INSTAGRAM"
+  | "TIKTOK"
+  | "BLOG"
+  | "FORUM"
+  | "COMMUNITY"
+  | "MARKETPLACE"
+  | "REVIEW_SITE"
+  | "OTHER";
+
+export type MoisMarketWarmupSourceType =
+  | "PRODUCT_PRESENCE"
+  | "CREATOR_CONTENT"
+  | "SPECIALIST_CONTENT"
+  | "COMMUNITY_DISCUSSION"
+  | "REVIEW"
+  | "COMPLAINT"
+  | "COMPETITOR_OFFER"
+  | "AFFILIATE_PROMOTION"
+  | "SOCIAL_POST"
+  | "SEARCH_RESULT"
+  | "OTHER";
+
+export type MoisMarketWarmupSignalType =
+  | "PAIN_EXPLICIT"
+  | "BUYING_INTENT"
+  | "OBJECTION"
+  | "SOCIAL_PROOF"
+  | "CREATOR_AUTHORITY"
+  | "COMPETITOR_OFFER"
+  | "COMMUNITY_ACTIVITY"
+  | "CONTENT_RECENCY"
+  | "SATURATION_RISK"
+  | "CHANNEL_FIT";
+
+export interface MoisMarketWarmupRequestResponse {
+  pageId: number;
+  jobId: number;
+  status: MoisMarketWarmupJobStatus;
+  createdAt: string;
+}
+
+export interface MoisMarketWarmupSummary {
+  jobId: number;
+  pageId: number;
+  scoreTotal?: number;
+  marketTemperature: MoisMarketWarmupTemperature;
+  ecosystemType: MoisMarketWarmupEcosystemType;
+  recommendation: MoisMarketWarmupRecommendation;
+  mainPains: string[];
+  mainObjections: string[];
+  mainPromises: string[];
+  mainChannels: string[];
+  mainCompetitors: string[];
+  saturationRisk?: string;
+  opportunityRecommendation?: string;
+  nextExperimentSuggestion?: string;
+  status: MoisMarketWarmupJobStatus;
+  errorCategory?: string;
+  errorMessage?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface MoisMarketWarmupSource {
+  sourceId: number;
+  jobId: number;
+  pageId: number;
+  platform: MoisMarketWarmupPlatform;
+  sourceType: MoisMarketWarmupSourceType;
+  sourceUrl: string;
+  sourceTitle?: string;
+  authorName?: string;
+  publishedAt?: string;
+  lastActivityAt?: string;
+  followersOrSubscribers?: number;
+  viewsCount?: number;
+  likesCount?: number;
+  commentsCount?: number;
+  recencyScore?: number;
+  engagementScore?: number;
+  evidenceSummary?: string;
+  createdAt: string;
+  updatedAt: string;
+}
+
+export interface MoisMarketWarmupSourceListResponse {
+  pageId: number;
+  jobId: number;
+  items: MoisMarketWarmupSource[];
+}
+
+export interface MoisMarketWarmupSignal {
+  signalId: number;
+  jobId: number;
+  sourceId: number;
+  pageId: number;
+  signalType: MoisMarketWarmupSignalType;
+  signalStrength?: number;
+  signalText: string;
+  businessInterpretation?: string;
+  createdAt: string;
+}
+
+export interface MoisMarketWarmupSignalListResponse {
+  pageId: number;
+  jobId: number;
+  items: MoisMarketWarmupSignal[];
 }
 
 export interface MoisSalesLibraryPageExecution {

--- a/frontend/src/api/mois/useMoisSalesLibrary.ts
+++ b/frontend/src/api/mois/useMoisSalesLibrary.ts
@@ -2,6 +2,10 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import axios from "axios";
 import type {
   MoisCollectedReferenceUrlSummary,
+  MoisMarketWarmupRequestResponse,
+  MoisMarketWarmupSignalListResponse,
+  MoisMarketWarmupSourceListResponse,
+  MoisMarketWarmupSummary,
   MoisSalesLibraryEntryPageResponse,
   MoisSalesLibraryJobPageResponse,
   MoisSalesLibraryPage,
@@ -14,6 +18,10 @@ import type {
   MoisSalesLibrarySnapshotCaptureResponse,
   MoisSalesLibraryStatusUpdateResponse,
 } from "./types";
+
+function isHttpNotFound(error: unknown) {
+  return axios.isAxiosError(error) && error.response?.status === 404;
+}
 
 export function useMoisSalesLibraryEntries(
   workspaceId: string,
@@ -96,7 +104,12 @@ export function useMoisSalesLibraryPageSummary(workspaceId: string) {
 
 export function useMoisCollectedReferenceUrlSummary(workspaceId: string) {
   return useQuery({
-    queryKey: ["mois", "sales-library", "collected-reference-url-summary", workspaceId],
+    queryKey: [
+      "mois",
+      "sales-library",
+      "collected-reference-url-summary",
+      workspaceId,
+    ],
     queryFn: async () => {
       const { data } = await axios.get<MoisCollectedReferenceUrlSummary>(
         "/api/mois/sales-library/collected-references/url-summary",
@@ -260,6 +273,87 @@ export function useMoisSalesLibraryPageExecutions(pageId?: number) {
         `/api/mois/sales-library/pages/${pageId}/executions`,
       );
       return data;
+    },
+  });
+}
+
+export function useMoisSalesLibraryMarketWarmup(pageId?: number) {
+  return useQuery({
+    queryKey: ["mois", "sales-library", "market-warmup", pageId],
+    enabled: Boolean(pageId),
+    queryFn: async () => {
+      try {
+        const { data } = await axios.get<MoisMarketWarmupSummary>(
+          `/api/mois/sales-library/pages/${pageId}/market-warmup`,
+        );
+        return data;
+      } catch (error) {
+        if (isHttpNotFound(error)) {
+          return null;
+        }
+        throw error;
+      }
+    },
+  });
+}
+
+export function useMoisSalesLibraryMarketWarmupSources(
+  pageId?: number,
+  enabled = true,
+) {
+  return useQuery({
+    queryKey: ["mois", "sales-library", "market-warmup", pageId, "sources"],
+    enabled: Boolean(pageId) && enabled,
+    queryFn: async () => {
+      const { data } = await axios.get<MoisMarketWarmupSourceListResponse>(
+        `/api/mois/sales-library/pages/${pageId}/market-warmup/sources`,
+      );
+      return data;
+    },
+  });
+}
+
+export function useMoisSalesLibraryMarketWarmupSignals(
+  pageId?: number,
+  enabled = true,
+) {
+  return useQuery({
+    queryKey: ["mois", "sales-library", "market-warmup", pageId, "signals"],
+    enabled: Boolean(pageId) && enabled,
+    queryFn: async () => {
+      const { data } = await axios.get<MoisMarketWarmupSignalListResponse>(
+        `/api/mois/sales-library/pages/${pageId}/market-warmup/signals`,
+      );
+      return data;
+    },
+  });
+}
+
+export function useRequestMoisSalesLibraryMarketWarmup(workspaceId: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (pageId: number) => {
+      const { data } = await axios.post<MoisMarketWarmupRequestResponse>(
+        `/api/mois/sales-library/pages/${pageId}/market-warmup:request`,
+      );
+      return data;
+    },
+    onSuccess: (_, pageId) => {
+      void queryClient.invalidateQueries({
+        queryKey: ["mois", "sales-library", "market-warmup", pageId],
+      });
+      void queryClient.invalidateQueries({
+        queryKey: ["mois", "sales-library", "market-warmup", pageId, "sources"],
+      });
+      void queryClient.invalidateQueries({
+        queryKey: ["mois", "sales-library", "market-warmup", pageId, "signals"],
+      });
+      void queryClient.invalidateQueries({
+        queryKey: ["mois", "sales-library", "pages", workspaceId],
+      });
+      void queryClient.invalidateQueries({
+        queryKey: ["mois", "sales-library", "pages-summary", workspaceId],
+      });
     },
   });
 }

--- a/frontend/src/pages/mois/MoisSalesPageLibraryDetailPage.tsx
+++ b/frontend/src/pages/mois/MoisSalesPageLibraryDetailPage.tsx
@@ -1,15 +1,125 @@
 import { Link, useParams } from "react-router-dom";
 import PageTitle from "../../components/PageTitle";
 import {
+  useMoisSalesLibraryMarketWarmup,
+  useMoisSalesLibraryMarketWarmupSignals,
+  useMoisSalesLibraryMarketWarmupSources,
   useMoisSalesLibraryPage,
   useMoisSalesLibraryPageAnalysis,
   useMoisSalesLibraryPageExecutions,
   useMoisSalesLibraryPages,
+  useRequestMoisSalesLibraryMarketWarmup,
   useUpdateMoisSalesLibraryPageStatus,
 } from "../../api/mois/useMoisSalesLibrary";
+import type {
+  MoisMarketWarmupEcosystemType,
+  MoisMarketWarmupJobStatus,
+  MoisMarketWarmupRecommendation,
+  MoisMarketWarmupSignalType,
+  MoisMarketWarmupSourceType,
+  MoisMarketWarmupTemperature,
+} from "../../api/mois/types";
 
 const WORKSPACE_ID = "workspace-001";
 const PAGE_SIZE = 100;
+
+const temperatureLabels: Record<MoisMarketWarmupTemperature, string> = {
+  HOT: "Quente",
+  PROMISING: "Promissor",
+  WARM: "Morno",
+  COLD: "Frio",
+  SATURATED: "Saturado",
+};
+
+const ecosystemLabels: Record<MoisMarketWarmupEcosystemType, string> = {
+  SPECIALISTS_HEATED: "Aquecido por especialistas",
+  CREATORS_HEATED: "Aquecido por creators",
+  RECURRING_PAIN_HEATED: "Aquecido por dor recorrente",
+  COMPETITORS_HEATED: "Aquecido por concorrentes",
+  COLD_OR_UNEDUCATED: "Frio ou pouco educado",
+  SATURATED: "Saturado",
+};
+
+const recommendationLabels: Record<MoisMarketWarmupRecommendation, string> = {
+  PRIORITIZE: "Priorizar experimento",
+  OBSERVE: "Observar com refinamento",
+  RESEARCH_MORE: "Pesquisar mais",
+  DISCARD: "Descartar por baixa prioridade",
+  SATURATED_REQUIRES_ANGLE: "Avançar só com ângulo diferenciado",
+};
+
+const statusLabels: Record<MoisMarketWarmupJobStatus, string> = {
+  PENDING: "Pendente",
+  FETCHING: "Em pesquisa",
+  DONE: "Concluído",
+  FAILED: "Falhou",
+};
+
+const sourceTypeLabels: Record<MoisMarketWarmupSourceType, string> = {
+  PRODUCT_PRESENCE: "Presença do produto",
+  CREATOR_CONTENT: "Conteúdo de creator",
+  SPECIALIST_CONTENT: "Conteúdo de especialista",
+  COMMUNITY_DISCUSSION: "Comunidade/fórum",
+  REVIEW: "Review",
+  COMPLAINT: "Reclamação",
+  COMPETITOR_OFFER: "Oferta concorrente",
+  AFFILIATE_PROMOTION: "Promoção de afiliado",
+  SOCIAL_POST: "Post social",
+  SEARCH_RESULT: "Resultado de busca",
+  OTHER: "Outra fonte",
+};
+
+const signalTypeLabels: Record<MoisMarketWarmupSignalType, string> = {
+  PAIN_EXPLICIT: "Dor explícita",
+  BUYING_INTENT: "Intenção de compra",
+  OBJECTION: "Objeção",
+  SOCIAL_PROOF: "Prova social",
+  CREATOR_AUTHORITY: "Autoridade",
+  COMPETITOR_OFFER: "Oferta concorrente",
+  COMMUNITY_ACTIVITY: "Atividade da comunidade",
+  CONTENT_RECENCY: "Conteúdo recente",
+  SATURATION_RISK: "Risco de saturação",
+  CHANNEL_FIT: "Canal promissor",
+};
+
+function getTemperatureBadgeClass(value?: MoisMarketWarmupTemperature) {
+  switch (value) {
+    case "HOT":
+      return "bg-success-subtle text-success-emphasis";
+    case "PROMISING":
+      return "bg-primary-subtle text-primary-emphasis";
+    case "WARM":
+      return "bg-warning-subtle text-warning-emphasis";
+    case "SATURATED":
+      return "bg-danger-subtle text-danger-emphasis";
+    case "COLD":
+    default:
+      return "bg-secondary-subtle text-secondary-emphasis";
+  }
+}
+
+function formatNumber(value?: number) {
+  return value == null ? "—" : value.toLocaleString("pt-BR");
+}
+
+function formatScore(value?: number) {
+  return value == null ? "—" : `${Math.round(value)}/100`;
+}
+
+function TextList({ items }: { items?: string[] }) {
+  const visibleItems = (items ?? []).filter(Boolean);
+  if (visibleItems.length === 0) {
+    return <span className="text-secondary">—</span>;
+  }
+
+  return (
+    <ul className="mb-0 ps-3">
+      {visibleItems.slice(0, 5).map((item) => (
+        <li key={item}>{item}</li>
+      ))}
+    </ul>
+  );
+}
 
 function formatDate(value?: string) {
   if (!value) return "—";
@@ -146,6 +256,18 @@ export default function MoisSalesPageLibraryDetailPage() {
   const pagesQuery = useMoisSalesLibraryPages(WORKSPACE_ID, 1, PAGE_SIZE);
   const updateStatusMutation =
     useUpdateMoisSalesLibraryPageStatus(WORKSPACE_ID);
+  const warmupQuery = useMoisSalesLibraryMarketWarmup(validPageId);
+  const hasWarmupSummary = Boolean(warmupQuery.data);
+  const warmupSourcesQuery = useMoisSalesLibraryMarketWarmupSources(
+    validPageId,
+    hasWarmupSummary,
+  );
+  const warmupSignalsQuery = useMoisSalesLibraryMarketWarmupSignals(
+    validPageId,
+    hasWarmupSummary,
+  );
+  const requestWarmupMutation =
+    useRequestMoisSalesLibraryMarketWarmup(WORKSPACE_ID);
 
   const currentIndex =
     pagesQuery.data?.items.findIndex((item) => item.pageId === validPageId) ??
@@ -153,6 +275,8 @@ export default function MoisSalesPageLibraryDetailPage() {
   const nextItem =
     currentIndex >= 0 ? pagesQuery.data?.items[currentIndex + 1] : undefined;
   const isMutating = updateStatusMutation.isPending;
+  const isRequestingWarmup = requestWarmupMutation.isPending;
+  const requestedWarmupJob = requestWarmupMutation.data;
 
   const history: HistoryItem[] = (executionsQuery.data ?? []).map((item) => ({
     key: String(item.executionId),
@@ -265,6 +389,259 @@ export default function MoisSalesPageLibraryDetailPage() {
           Falha ao atualizar status da página.
         </div>
       ) : null}
+
+      <section className="card border-0 shadow-sm">
+        <div className="card-body d-flex flex-column gap-3">
+          <div className="d-flex flex-wrap justify-content-between align-items-start gap-3">
+            <div>
+              <h2 className="h5 mb-1">Aquecimento do Mercado</h2>
+              <p className="text-secondary mb-0">
+                Dossiê da Etapa 3 para decidir se existe conversa ativa, dor
+                clara e evidência suficiente para priorizar este mercado.
+              </p>
+            </div>
+            {!warmupQuery.data && !requestedWarmupJob ? (
+              <button
+                type="button"
+                className="btn btn-primary"
+                disabled={
+                  !validPageId || isRequestingWarmup || warmupQuery.isLoading
+                }
+                onClick={() =>
+                  validPageId && requestWarmupMutation.mutate(validPageId)
+                }
+              >
+                {isRequestingWarmup ? (
+                  <span
+                    className="spinner-border spinner-border-sm me-2"
+                    role="status"
+                    aria-hidden="true"
+                  />
+                ) : null}
+                Executar pesquisa de aquecimento
+              </button>
+            ) : null}
+          </div>
+
+          {warmupQuery.isLoading ? (
+            <p className="text-secondary mb-0">
+              Carregando aquecimento do mercado...
+            </p>
+          ) : null}
+          {warmupQuery.isError ? (
+            <div className="alert alert-danger mb-0">
+              Falha ao carregar o dossiê de aquecimento.
+            </div>
+          ) : null}
+          {requestWarmupMutation.isError ? (
+            <div className="alert alert-danger mb-0">
+              Falha ao solicitar nova pesquisa de aquecimento.
+            </div>
+          ) : null}
+          {requestedWarmupJob ? (
+            <div className="alert alert-success mb-0">
+              Pesquisa solicitada com sucesso. Job {requestedWarmupJob.jobId}
+              está {statusLabels[requestedWarmupJob.status].toLowerCase()}.
+            </div>
+          ) : null}
+          {!warmupQuery.isLoading &&
+          !warmupQuery.isError &&
+          !warmupQuery.data &&
+          !requestedWarmupJob ? (
+            <div className="alert alert-info mb-0">
+              Ainda não existe dossiê de aquecimento para esta página. Solicite
+              a pesquisa para medir temperatura, canais, dores e sinais de
+              compra do mercado.
+            </div>
+          ) : null}
+
+          {warmupQuery.data ? (
+            <>
+              <div className="row g-3">
+                <div className="col-md-3">
+                  <div className="border rounded p-3 h-100 bg-light-subtle">
+                    <div className="text-secondary small">Score</div>
+                    <strong className="fs-4">
+                      {formatScore(warmupQuery.data.scoreTotal)}
+                    </strong>
+                  </div>
+                </div>
+                <div className="col-md-3">
+                  <div className="border rounded p-3 h-100 bg-light-subtle">
+                    <div className="text-secondary small">Temperatura</div>
+                    <span
+                      className={`badge ${getTemperatureBadgeClass(warmupQuery.data.marketTemperature)}`}
+                    >
+                      {temperatureLabels[warmupQuery.data.marketTemperature]}
+                    </span>
+                  </div>
+                </div>
+                <div className="col-md-3">
+                  <div className="border rounded p-3 h-100 bg-light-subtle">
+                    <div className="text-secondary small">Ecossistema</div>
+                    <strong>
+                      {ecosystemLabels[warmupQuery.data.ecosystemType]}
+                    </strong>
+                  </div>
+                </div>
+                <div className="col-md-3">
+                  <div className="border rounded p-3 h-100 bg-light-subtle">
+                    <div className="text-secondary small">Status</div>
+                    <strong>{statusLabels[warmupQuery.data.status]}</strong>
+                  </div>
+                </div>
+              </div>
+
+              <div className="border rounded p-3">
+                <div className="text-secondary small">
+                  Recomendação comercial
+                </div>
+                <p className="mb-1 fw-semibold">
+                  {recommendationLabels[warmupQuery.data.recommendation]}
+                </p>
+                <p className="mb-0">
+                  {warmupQuery.data.opportunityRecommendation ||
+                    "Sem recomendação operacional registrada."}
+                </p>
+                {warmupQuery.data.nextExperimentSuggestion ? (
+                  <p className="mb-0 mt-2 small text-secondary">
+                    Próximo experimento sugerido:{" "}
+                    {warmupQuery.data.nextExperimentSuggestion}
+                  </p>
+                ) : null}
+              </div>
+
+              {warmupQuery.data.status === "FAILED" ? (
+                <div className="alert alert-danger mb-0">
+                  A pesquisa falhou
+                  {warmupQuery.data.errorCategory
+                    ? ` (${warmupQuery.data.errorCategory})`
+                    : ""}
+                  : {warmupQuery.data.errorMessage || "erro não informado"}.
+                </div>
+              ) : null}
+
+              <div className="row g-3 small">
+                <div className="col-md-6">
+                  <strong>Dores principais</strong>
+                  <TextList items={warmupQuery.data.mainPains} />
+                </div>
+                <div className="col-md-6">
+                  <strong>Objeções principais</strong>
+                  <TextList items={warmupQuery.data.mainObjections} />
+                </div>
+                <div className="col-md-6">
+                  <strong>Canais principais</strong>
+                  <TextList items={warmupQuery.data.mainChannels} />
+                </div>
+                <div className="col-md-6">
+                  <strong>Concorrentes principais</strong>
+                  <TextList items={warmupQuery.data.mainCompetitors} />
+                </div>
+              </div>
+
+              {warmupQuery.data.saturationRisk ? (
+                <div className="alert alert-warning mb-0">
+                  <strong>Risco de saturação:</strong>{" "}
+                  {warmupQuery.data.saturationRisk}
+                </div>
+              ) : null}
+
+              <div>
+                <h3 className="h6 mb-2">Fontes públicas rastreáveis</h3>
+                {warmupSourcesQuery.isLoading ? (
+                  <p className="text-secondary mb-0">Carregando fontes...</p>
+                ) : null}
+                {warmupSourcesQuery.isError ? (
+                  <div className="alert alert-danger mb-0">
+                    Falha ao carregar fontes.
+                  </div>
+                ) : null}
+                {!warmupSourcesQuery.isLoading &&
+                (warmupSourcesQuery.data?.items.length ?? 0) === 0 ? (
+                  <p className="text-secondary mb-0">
+                    Nenhuma fonte pública registrada para este dossiê.
+                  </p>
+                ) : null}
+                <div className="d-flex flex-column gap-2">
+                  {(warmupSourcesQuery.data?.items ?? [])
+                    .slice(0, 8)
+                    .map((source) => (
+                      <div
+                        key={source.sourceId}
+                        className="border rounded p-3 bg-light-subtle"
+                      >
+                        <div className="d-flex flex-wrap justify-content-between gap-2">
+                          <a
+                            href={source.sourceUrl}
+                            target="_blank"
+                            rel="noreferrer"
+                            className="fw-semibold"
+                          >
+                            {source.sourceTitle || source.sourceUrl}
+                          </a>
+                          <span className="badge bg-secondary-subtle text-secondary-emphasis">
+                            {source.platform} •{" "}
+                            {sourceTypeLabels[source.sourceType]}
+                          </span>
+                        </div>
+                        <p className="mb-1 small text-secondary">
+                          {source.authorName || "Autor não identificado"} •
+                          comentários: {formatNumber(source.commentsCount)} •
+                          visualizações: {formatNumber(source.viewsCount)}
+                        </p>
+                        <p className="mb-0 small">
+                          {source.evidenceSummary || "Sem resumo de evidência."}
+                        </p>
+                      </div>
+                    ))}
+                </div>
+              </div>
+
+              <div>
+                <h3 className="h6 mb-2">Sinais que justificam a pontuação</h3>
+                {warmupSignalsQuery.isLoading ? (
+                  <p className="text-secondary mb-0">Carregando sinais...</p>
+                ) : null}
+                {warmupSignalsQuery.isError ? (
+                  <div className="alert alert-danger mb-0">
+                    Falha ao carregar sinais.
+                  </div>
+                ) : null}
+                {!warmupSignalsQuery.isLoading &&
+                (warmupSignalsQuery.data?.items.length ?? 0) === 0 ? (
+                  <p className="text-secondary mb-0">
+                    Nenhum sinal comercial registrado para este dossiê.
+                  </p>
+                ) : null}
+                <div className="row g-2">
+                  {(warmupSignalsQuery.data?.items ?? [])
+                    .slice(0, 10)
+                    .map((signal) => (
+                      <div className="col-md-6" key={signal.signalId}>
+                        <div className="border rounded p-3 h-100">
+                          <div className="d-flex flex-wrap justify-content-between gap-2">
+                            <strong>
+                              {signalTypeLabels[signal.signalType]}
+                            </strong>
+                            <span className="text-secondary small">
+                              força {formatNumber(signal.signalStrength)}
+                            </span>
+                          </div>
+                          <p className="mb-1 small">{signal.signalText}</p>
+                          <p className="mb-0 small text-secondary">
+                            {signal.businessInterpretation ||
+                              "Sem interpretação adicional."}
+                          </p>
+                        </div>
+                      </div>
+                    ))}
+                </div>
+              </div>
+            </>
+          ) : null}
+        </div>
+      </section>
 
       {analysisQuery.isLoading ? (
         <p className="text-secondary mb-0">Carregando detalhe...</p>

--- a/frontend/src/pages/mois/MoisSalesPagesLibraryPage.tsx
+++ b/frontend/src/pages/mois/MoisSalesPagesLibraryPage.tsx
@@ -1,3 +1,4 @@
+import { useMemo, useState } from "react";
 import { Link } from "react-router-dom";
 import PageTitle from "../../components/PageTitle";
 import {
@@ -5,9 +6,69 @@ import {
   useMoisSalesLibraryPages,
   useMoisSalesLibraryPageSummary,
 } from "../../api/mois/useMoisSalesLibrary";
+import type { MoisSalesLibraryPage } from "../../api/mois/types";
 
 const WORKSPACE_ID = "workspace-001";
 const PAGE_SIZE = 20;
+
+const warmupTemperatureLabels: Record<string, string> = {
+  HOT: "Quente",
+  PROMISING: "Promissor",
+  WARM: "Morno",
+  COLD: "Frio",
+  SATURATED: "Saturado",
+};
+
+const warmupStatusLabels: Record<string, string> = {
+  PENDING: "Pendente",
+  FETCHING: "Em pesquisa",
+  DONE: "Com dossiê",
+  FAILED: "Falhou",
+};
+
+function formatWarmupScore(value?: number | null) {
+  return value == null ? "—" : `${Math.round(value)}/100`;
+}
+
+function getWarmupBadgeClass(value?: string | null) {
+  switch (value) {
+    case "HOT":
+      return "bg-success-subtle text-success-emphasis";
+    case "PROMISING":
+      return "bg-primary-subtle text-primary-emphasis";
+    case "WARM":
+      return "bg-warning-subtle text-warning-emphasis";
+    case "SATURATED":
+    case "FAILED":
+      return "bg-danger-subtle text-danger-emphasis";
+    case "FETCHING":
+      return "bg-info-subtle text-info-emphasis";
+    case "PENDING":
+      return "bg-warning-subtle text-warning-emphasis";
+    case "DONE":
+      return "bg-success-subtle text-success-emphasis";
+    case "COLD":
+    default:
+      return "bg-secondary-subtle text-secondary-emphasis";
+  }
+}
+
+function matchesWarmupFilter(item: MoisSalesLibraryPage, filter: string) {
+  switch (filter) {
+    case "WITH_DOSSIER":
+      return item.marketWarmupStatus === "DONE";
+    case "PENDING_OR_RUNNING":
+      return ["PENDING", "FETCHING"].includes(item.marketWarmupStatus || "");
+    case "FAILED":
+      return item.marketWarmupStatus === "FAILED";
+    case "HOT_OR_PROMISING":
+      return ["HOT", "PROMISING"].includes(item.marketWarmupTemperature || "");
+    case "WITHOUT_DOSSIER":
+      return !item.marketWarmupStatus;
+    default:
+      return true;
+  }
+}
 
 function getPipelinePhase(stage?: string | null, status?: string | null) {
   if (stage === "CAPTURE" && status === "FAILED") {
@@ -39,9 +100,19 @@ function formatAnalysisDate(value?: string | null) {
 }
 
 export default function MoisSalesPagesLibraryPage() {
+  const [warmupFilter, setWarmupFilter] = useState("ALL");
   const pagesQuery = useMoisSalesLibraryPages(WORKSPACE_ID, 1, PAGE_SIZE);
   const summaryQuery = useMoisSalesLibraryPageSummary(WORKSPACE_ID);
   const summary = summaryQuery.data;
+  const visiblePages = useMemo(() => {
+    return [...(pagesQuery.data?.items ?? [])]
+      .filter((item) => matchesWarmupFilter(item, warmupFilter))
+      .sort(
+        (first, second) =>
+          (second.marketWarmupScoreTotal ?? -1) -
+          (first.marketWarmupScoreTotal ?? -1),
+      );
+  }, [pagesQuery.data?.items, warmupFilter]);
 
   return (
     <div className="d-flex flex-column gap-4">
@@ -79,24 +150,28 @@ export default function MoisSalesPagesLibraryPage() {
           <div className="col-sm-6 col-lg-3">
             <div className="card border-0 shadow-sm h-100">
               <div className="card-body">
-                <p className="text-secondary mb-1">Produtos Hotmart</p>
-                <h3 className="mb-0">{summary.hotmart}</h3>
+                <p className="text-secondary mb-1">
+                  Elegíveis para aquecimento
+                </p>
+                <h3 className="mb-0">{summary.marketWarmupEligible}</h3>
               </div>
             </div>
           </div>
           <div className="col-sm-6 col-lg-3">
             <div className="card border-0 shadow-sm h-100">
               <div className="card-body">
-                <p className="text-secondary mb-1">Produtos Clickbank</p>
-                <h3 className="mb-0">{summary.clickbank}</h3>
+                <p className="text-secondary mb-1">Com dossiê concluído</p>
+                <h3 className="mb-0">{summary.marketWarmupCompleted}</h3>
               </div>
             </div>
           </div>
           <div className="col-sm-6 col-lg-3">
             <div className="card border-0 shadow-sm h-100">
               <div className="card-body">
-                <p className="text-secondary mb-1">Analisadas</p>
-                <h3 className="mb-0">{summary.analyzed}</h3>
+                <p className="text-secondary mb-1">Quentes/promissores</p>
+                <h3 className="mb-0">
+                  {summary.marketWarmupHot + summary.marketWarmupPromising}
+                </h3>
               </div>
             </div>
           </div>
@@ -104,85 +179,134 @@ export default function MoisSalesPagesLibraryPage() {
       ) : null}
 
       <section className="card border-0 shadow-sm">
-        <div className="card-body table-responsive">
-          {pagesQuery.isLoading ? (
-            <p className="text-secondary mb-0">
-              Carregando produtos coletados...
-            </p>
-          ) : null}
-          {pagesQuery.isError ? (
-            <div className="alert alert-danger mb-0">
-              Falha ao carregar produtos da biblioteca.
+        <div className="card-body d-flex flex-column gap-3">
+          <div className="d-flex flex-wrap align-items-end justify-content-between gap-3">
+            <div>
+              <h2 className="h5 mb-1">Priorização por aquecimento</h2>
+              <p className="text-secondary mb-0">
+                Ordene a página atual pelo score de aquecimento para decidir
+                quais mercados merecem ação primeiro.
+              </p>
             </div>
-          ) : null}
-          {pagesQuery.data ? (
-            <table className="table table-sm align-middle mb-0">
-              <thead>
-                <tr>
-                  <th>Produto</th>
-                  <th>Origem</th>
-                  <th>Status</th>
-                  <th>Data da análise</th>
-                  <th>Fase no diagrama</th>
-                  <th>Ações</th>
-                </tr>
-              </thead>
-              <tbody>
-                {pagesQuery.data.items.length === 0 ? (
+            <div>
+              <label className="form-label small" htmlFor="warmupFilter">
+                Filtro de aquecimento
+              </label>
+              <select
+                id="warmupFilter"
+                className="form-select form-select-sm"
+                value={warmupFilter}
+                onChange={(event) => setWarmupFilter(event.target.value)}
+              >
+                <option value="ALL">Todos</option>
+                <option value="WITH_DOSSIER">Com dossiê</option>
+                <option value="HOT_OR_PROMISING">Quentes/promissores</option>
+                <option value="PENDING_OR_RUNNING">
+                  Pendentes/em pesquisa
+                </option>
+                <option value="FAILED">Falharam</option>
+                <option value="WITHOUT_DOSSIER">Sem dossiê</option>
+              </select>
+            </div>
+          </div>
+          <div className="table-responsive">
+            {pagesQuery.isLoading ? (
+              <p className="text-secondary mb-0">
+                Carregando produtos coletados...
+              </p>
+            ) : null}
+            {pagesQuery.isError ? (
+              <div className="alert alert-danger mb-0">
+                Falha ao carregar produtos da biblioteca.
+              </div>
+            ) : null}
+            {pagesQuery.data ? (
+              <table className="table table-sm align-middle mb-0">
+                <thead>
                   <tr>
-                    <td colSpan={6} className="text-secondary">
-                      Nenhum produto coletado encontrado.
-                    </td>
+                    <th>Produto</th>
+                    <th>Origem</th>
+                    <th>Status</th>
+                    <th>Aquecimento</th>
+                    <th>Score aquecimento</th>
+                    <th>Data da análise</th>
+                    <th>Fase no diagrama</th>
+                    <th>Ações</th>
                   </tr>
-                ) : (
-                  pagesQuery.data.items.map((item) => (
-                    <tr key={item.pageId}>
-                      <td className="text-break">
-                        {item.title || item.urlCanonical}
-                      </td>
-                      <td>{item.source || "—"}</td>
-                      <td>
-                        <span
-                          className={`badge ${getSalesLibraryJobBadgeClass({ status: item.currentStatus })}`}
-                        >
-                          {item.currentStatus ||
-                            item.analysisStatus ||
-                            "SEM STATUS"}
-                        </span>
-                      </td>
-                      <td className="text-nowrap">
-                        {formatAnalysisDate(item.analyzedAt)}
-                      </td>
-                      <td>
-                        {getPipelinePhase(
-                          item.currentStage,
-                          item.currentStatus,
-                        )}
-                      </td>
-                      <td>
-                        <div className="d-flex flex-wrap gap-2">
-                          <Link
-                            className="btn btn-outline-primary btn-sm"
-                            to={`/mois/sales-pages-library/${item.pageId}`}
-                          >
-                            Ver detalhe
-                          </Link>
-                          <a
-                            className="btn btn-outline-secondary btn-sm"
-                            href={item.urlCanonical}
-                            target="_blank"
-                            rel="noreferrer"
-                          >
-                            Abrir página
-                          </a>
-                        </div>
+                </thead>
+                <tbody>
+                  {visiblePages.length === 0 ? (
+                    <tr>
+                      <td colSpan={8} className="text-secondary">
+                        Nenhum produto coletado encontrado para o filtro atual.
                       </td>
                     </tr>
-                  ))
-                )}
-              </tbody>
-            </table>
-          ) : null}
+                  ) : (
+                    visiblePages.map((item) => (
+                      <tr key={item.pageId}>
+                        <td className="text-break">
+                          {item.title || item.urlCanonical}
+                        </td>
+                        <td>{item.source || "—"}</td>
+                        <td>
+                          <span
+                            className={`badge ${getSalesLibraryJobBadgeClass({ status: item.currentStatus })}`}
+                          >
+                            {item.currentStatus ||
+                              item.analysisStatus ||
+                              "SEM STATUS"}
+                          </span>
+                        </td>
+                        <td>
+                          <span
+                            className={`badge ${getWarmupBadgeClass(item.marketWarmupTemperature || item.marketWarmupStatus)}`}
+                          >
+                            {item.marketWarmupTemperature
+                              ? warmupTemperatureLabels[
+                                  item.marketWarmupTemperature
+                                ]
+                              : item.marketWarmupStatus
+                                ? warmupStatusLabels[item.marketWarmupStatus]
+                                : "Sem dossiê"}
+                          </span>
+                        </td>
+                        <td className="text-nowrap fw-semibold">
+                          {formatWarmupScore(item.marketWarmupScoreTotal)}
+                        </td>
+                        <td className="text-nowrap">
+                          {formatAnalysisDate(item.analyzedAt)}
+                        </td>
+                        <td>
+                          {getPipelinePhase(
+                            item.currentStage,
+                            item.currentStatus,
+                          )}
+                        </td>
+                        <td>
+                          <div className="d-flex flex-wrap gap-2">
+                            <Link
+                              className="btn btn-outline-primary btn-sm"
+                              to={`/mois/sales-pages-library/${item.pageId}`}
+                            >
+                              Ver detalhe
+                            </Link>
+                            <a
+                              className="btn btn-outline-secondary btn-sm"
+                              href={item.urlCanonical}
+                              target="_blank"
+                              rel="noreferrer"
+                            >
+                              Abrir página
+                            </a>
+                          </div>
+                        </td>
+                      </tr>
+                    ))
+                  )}
+                </tbody>
+              </table>
+            ) : null}
+          </div>
         </div>
       </section>
     </div>

--- a/frontend/src/pages/mois/MoisSalesPagesPipelinePage.tsx
+++ b/frontend/src/pages/mois/MoisSalesPagesPipelinePage.tsx
@@ -94,7 +94,15 @@ export default function MoisSalesPagesPipelinePage() {
   const analysisRunning = summary?.analysisRunning ?? 0;
   const analysisFailed = summary?.analysisFailed ?? 0;
   const pendingPages = summary?.pending ?? 0;
-  const marketWarmupEligiblePages = analyzedPages;
+  const marketWarmupEligiblePages = summary?.marketWarmupEligible ?? 0;
+  const marketWarmupPending = summary?.marketWarmupPending ?? 0;
+  const marketWarmupRunning = summary?.marketWarmupRunning ?? 0;
+  const marketWarmupCompleted = summary?.marketWarmupCompleted ?? 0;
+  const marketWarmupFailed = summary?.marketWarmupFailed ?? 0;
+  const marketWarmupHot = summary?.marketWarmupHot ?? 0;
+  const marketWarmupPromising = summary?.marketWarmupPromising ?? 0;
+  const marketWarmupCold = summary?.marketWarmupCold ?? 0;
+  const marketWarmupSaturated = summary?.marketWarmupSaturated ?? 0;
 
   return (
     <div className="d-flex flex-column gap-4">
@@ -501,8 +509,8 @@ export default function MoisSalesPagesPipelinePage() {
               <div>
                 <h3 className="h6 mb-1">Resumo da etapa 3</h3>
                 <p className="text-secondary small mb-0">
-                  Indica o volume já pronto para pesquisa de aquecimento assim
-                  que o worker dedicado for ativado.
+                  Mostra cobertura real da Etapa 3 para priorizar mercados com
+                  dossiê concluído, fila visível e temperatura comercial.
                 </p>
               </div>
               {summaryQuery.isLoading ? (
@@ -523,23 +531,34 @@ export default function MoisSalesPagesPipelinePage() {
               </div>
               <div className="col-sm-6 col-lg-4">
                 <div className="bg-light rounded-3 p-3 h-100">
-                  <p className="text-secondary mb-1">Contrato oficial</p>
-                  <h3 className="h6 mb-0">MARKET_WARMUP_RESEARCH</h3>
+                  <p className="text-secondary mb-1">Dossiês concluídos</p>
+                  <h3 className="mb-0">
+                    {summaryQuery.isLoading ? "..." : marketWarmupCompleted}
+                  </h3>
                   <p className="text-secondary small mb-0 mt-2">
-                    Etapa canônica na posição 3 do pipeline MOIS.
+                    Pesquisa pronta para decisão comercial e revisão humana.
                   </p>
                 </div>
               </div>
               <div className="col-sm-6 col-lg-4">
                 <div className="bg-light rounded-3 p-3 h-100">
-                  <p className="text-secondary mb-1">Decisão apoiada</p>
-                  <h3 className="h6 mb-0">Priorizar ou diferenciar</h3>
+                  <p className="text-secondary mb-1">Quentes/promissores</p>
+                  <h3 className="mb-0">
+                    {summaryQuery.isLoading
+                      ? "..."
+                      : marketWarmupHot + marketWarmupPromising}
+                  </h3>
                   <p className="text-secondary small mb-0 mt-2">
-                    Foco em escolher mercados com sinais reais de compra.
+                    Mercados com maior prioridade inicial para experimentos.
                   </p>
                 </div>
               </div>
             </div>
+            <p className="text-secondary small mb-0 mt-3">
+              Fila real: {marketWarmupPending} pendentes · {marketWarmupRunning}{" "}
+              em pesquisa · {marketWarmupFailed} falhas · {marketWarmupCold}{" "}
+              frios · {marketWarmupSaturated} saturados.
+            </p>
           </div>
 
           <div className="d-flex flex-wrap align-items-start justify-content-between gap-3">
@@ -555,7 +574,7 @@ export default function MoisSalesPagesPipelinePage() {
               className="btn btn-outline-primary align-self-start"
               to="/mois/sales-pages-library"
             >
-              Ver páginas elegíveis
+              Priorizar na biblioteca
             </Link>
           </div>
         </div>


### PR DESCRIPTION
### Motivation
- Entregar a Fase 8 do plano da Etapa 3 para que o usuário consiga consultar e solicitar a pesquisa de aquecimento do mercado a partir da tela de detalhe da página; a decisão comercial deve ser baseada em evidências públicas rastreáveis. 
- Manter o padrão arquitetural do projeto garantindo que o frontend consuma apenas endpoints do backend MOIS e que o payload final não contenha JSON serializado em campos textuais funcionais.

### Description
- Adiciona contratos TypeScript para a Etapa 3 em `frontend/src/api/mois/types.ts` (status, temperatura, ecossistema, recomendação, fontes, sinais e respostas). 
- Cria hooks TanStack Query para a Etapa 3 em `frontend/src/api/mois/useMoisSalesLibrary.ts`: `useMoisSalesLibraryMarketWarmup`, `useMoisSalesLibraryMarketWarmupSources`, `useMoisSalesLibraryMarketWarmupSignals` e `useRequestMoisSalesLibraryMarketWarmup`, com tratamento de `404` e invalidação de cache adequada. 
- Implementa o bloco de UI `Aquecimento do Mercado` na página de detalhe em `frontend/src/pages/mois/MoisSalesPageLibraryDetailPage.tsx`, incluindo: score, temperatura, ecossistema, status, recomendação, principais dores/objeções/canais/concorrentes, lista de fontes públicas com `target="_blank"`, listagem de sinais, CTA para executar pesquisa e estados de loading/erro/vazio/sucesso. 
- Atualiza o registro operacional em `docs/registros/mois1.md` para documentar a execução da Fase 8 e arquivos principais alterados.

### Testing
- `npm run typecheck` (TypeScript `tsc --noEmit`) — passou com sucesso. 
- `npm run build` (Vite production build) — passou com sucesso; observação de aviso de chunk grande apenas. 
- Captura visual da página com Playwright (`npx playwright screenshot --full-page http://127.0.0.1:5173/mois/sales-pages-library/1 /tmp/mois-market-warmup-detail.png`) — execução concluída com sucesso e screenshot gerado para verificação visual.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a28e2eb40fc83208adf9e6bd8981d53)