### PR TITLE
Implement OPRM Públicos Gerais frontend (seeds & subniches)

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/generalaudience/OprmGeneralAudiencePainAngle.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/generalaudience/OprmGeneralAudiencePainAngle.java
@@ -1,0 +1,156 @@
+package com.marketinghub.oprm.generalaudience;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+import java.time.Instant;
+
+/** Responsável por armazenar uma dor e seu ângulo seguro antes de oferta, nicho ou campanha. */
+@Entity
+@Table(name = "oprm_general_audience_pain_angle")
+public class OprmGeneralAudiencePainAngle {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "subniche_id", nullable = false)
+    private OprmGeneralAudienceSubniche subniche;
+
+    @Column(name = "pain", nullable = false, columnDefinition = "LONGTEXT")
+    private String pain;
+
+    @Column(name = "desired_result", nullable = false, columnDefinition = "LONGTEXT")
+    private String desiredResult;
+
+    @Column(name = "mechanism_direction", columnDefinition = "LONGTEXT")
+    private String mechanismDirection;
+
+    @Column(name = "proof_or_lead_magnet", columnDefinition = "LONGTEXT")
+    private String proofOrLeadMagnet;
+
+    @Column(name = "safe_promise", columnDefinition = "LONGTEXT")
+    private String safePromise;
+
+    @Column(name = "first_ad_hook", columnDefinition = "LONGTEXT")
+    private String firstAdHook;
+
+    @Column(name = "landing_confirmation_question", columnDefinition = "LONGTEXT")
+    private String landingConfirmationQuestion;
+
+    @Column(name = "compliance_notes", columnDefinition = "LONGTEXT")
+    private String complianceNotes;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 32)
+    private OprmGeneralAudiencePainAngleStatus status;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+
+    /** Inicializa os carimbos de criação e atualização do ângulo. */
+    @PrePersist
+    void onCreate() {
+        Instant now = Instant.now();
+        createdAt = now;
+        updatedAt = now;
+    }
+
+    /** Atualiza o carimbo de modificação do ângulo. */
+    @PreUpdate
+    void onUpdate() {
+        updatedAt = Instant.now();
+    }
+
+    /** Retorna o identificador do ângulo. */
+    public Long getId() { return id; }
+
+    /** Define o identificador do ângulo. */
+    public void setId(Long id) { this.id = id; }
+
+    /** Retorna o subnicho dono da dor. */
+    public OprmGeneralAudienceSubniche getSubniche() { return subniche; }
+
+    /** Define o subnicho dono da dor. */
+    public void setSubniche(OprmGeneralAudienceSubniche subniche) { this.subniche = subniche; }
+
+    /** Retorna a dor observada no subnicho. */
+    public String getPain() { return pain; }
+
+    /** Define a dor observada no subnicho. */
+    public void setPain(String pain) { this.pain = pain; }
+
+    /** Retorna o resultado desejado pelo público. */
+    public String getDesiredResult() { return desiredResult; }
+
+    /** Define o resultado desejado pelo público. */
+    public void setDesiredResult(String desiredResult) { this.desiredResult = desiredResult; }
+
+    /** Retorna a direção de mecanismo plausível para resolver a dor. */
+    public String getMechanismDirection() { return mechanismDirection; }
+
+    /** Define a direção de mecanismo plausível para resolver a dor. */
+    public void setMechanismDirection(String mechanismDirection) { this.mechanismDirection = mechanismDirection; }
+
+    /** Retorna a prova ou isca sugerida para teste futuro. */
+    public String getProofOrLeadMagnet() { return proofOrLeadMagnet; }
+
+    /** Define a prova ou isca sugerida para teste futuro. */
+    public void setProofOrLeadMagnet(String proofOrLeadMagnet) { this.proofOrLeadMagnet = proofOrLeadMagnet; }
+
+    /** Retorna a promessa segura do ângulo. */
+    public String getSafePromise() { return safePromise; }
+
+    /** Define a promessa segura do ângulo. */
+    public void setSafePromise(String safePromise) { this.safePromise = safePromise; }
+
+    /** Retorna o primeiro gancho de anúncio sugerido. */
+    public String getFirstAdHook() { return firstAdHook; }
+
+    /** Define o primeiro gancho de anúncio sugerido. */
+    public void setFirstAdHook(String firstAdHook) { this.firstAdHook = firstAdHook; }
+
+    /** Retorna a pergunta de confirmação da landing. */
+    public String getLandingConfirmationQuestion() { return landingConfirmationQuestion; }
+
+    /** Define a pergunta de confirmação da landing. */
+    public void setLandingConfirmationQuestion(String landingConfirmationQuestion) { this.landingConfirmationQuestion = landingConfirmationQuestion; }
+
+    /** Retorna as notas de compliance do ângulo. */
+    public String getComplianceNotes() { return complianceNotes; }
+
+    /** Define as notas de compliance do ângulo. */
+    public void setComplianceNotes(String complianceNotes) { this.complianceNotes = complianceNotes; }
+
+    /** Retorna o status de revisão do ângulo. */
+    public OprmGeneralAudiencePainAngleStatus getStatus() { return status; }
+
+    /** Define o status de revisão do ângulo. */
+    public void setStatus(OprmGeneralAudiencePainAngleStatus status) { this.status = status; }
+
+    /** Retorna a data de criação do ângulo. */
+    public Instant getCreatedAt() { return createdAt; }
+
+    /** Define a data de criação do ângulo. */
+    public void setCreatedAt(Instant createdAt) { this.createdAt = createdAt; }
+
+    /** Retorna a data da última atualização do ângulo. */
+    public Instant getUpdatedAt() { return updatedAt; }
+
+    /** Define a data da última atualização do ângulo. */
+    public void setUpdatedAt(Instant updatedAt) { this.updatedAt = updatedAt; }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/generalaudience/OprmGeneralAudiencePainAngleStatus.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/generalaudience/OprmGeneralAudiencePainAngleStatus.java
@@ -1,0 +1,9 @@
+package com.marketinghub.oprm.generalaudience;
+
+/** Representa o estágio de revisão de uma dor/ângulo testável de público geral. */
+public enum OprmGeneralAudiencePainAngleStatus {
+    DISCOVERED,
+    NEEDS_REVIEW,
+    APPROVED,
+    REJECTED
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/generalaudience/OprmGeneralAudienceSourceEvidence.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/generalaudience/OprmGeneralAudienceSourceEvidence.java
@@ -1,0 +1,102 @@
+package com.marketinghub.oprm.generalaudience;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.Table;
+import java.time.Instant;
+
+/** Responsável por armazenar evidência agregada e rastreável usada no mapeamento de público geral. */
+@Entity
+@Table(name = "oprm_general_audience_source_evidence")
+public class OprmGeneralAudienceSourceEvidence {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "seed_id", nullable = false)
+    private OprmGeneralAudienceSeed seed;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "subniche_id")
+    private OprmGeneralAudienceSubniche subniche;
+
+    @Column(name = "source_url", length = 1024)
+    private String sourceUrl;
+
+    @Column(name = "source_domain", length = 191)
+    private String sourceDomain;
+
+    @Column(name = "source_type", length = 64)
+    private String sourceType;
+
+    @Column(name = "evidence_summary", nullable = false, columnDefinition = "LONGTEXT")
+    private String evidenceSummary;
+
+    @Column(name = "captured_at", nullable = false)
+    private Instant capturedAt;
+
+    /** Define a data de captura quando a origem não informou uma data explícita. */
+    @PrePersist
+    void onCreate() {
+        if (capturedAt == null) {
+            capturedAt = Instant.now();
+        }
+    }
+
+    /** Retorna o identificador da evidência. */
+    public Long getId() { return id; }
+
+    /** Define o identificador da evidência. */
+    public void setId(Long id) { this.id = id; }
+
+    /** Retorna a semente associada à evidência. */
+    public OprmGeneralAudienceSeed getSeed() { return seed; }
+
+    /** Define a semente associada à evidência. */
+    public void setSeed(OprmGeneralAudienceSeed seed) { this.seed = seed; }
+
+    /** Retorna o subnicho associado à evidência, quando existir. */
+    public OprmGeneralAudienceSubniche getSubniche() { return subniche; }
+
+    /** Define o subnicho associado à evidência, quando existir. */
+    public void setSubniche(OprmGeneralAudienceSubniche subniche) { this.subniche = subniche; }
+
+    /** Retorna a URL rastreável da fonte. */
+    public String getSourceUrl() { return sourceUrl; }
+
+    /** Define a URL rastreável da fonte. */
+    public void setSourceUrl(String sourceUrl) { this.sourceUrl = sourceUrl; }
+
+    /** Retorna o domínio da fonte. */
+    public String getSourceDomain() { return sourceDomain; }
+
+    /** Define o domínio da fonte. */
+    public void setSourceDomain(String sourceDomain) { this.sourceDomain = sourceDomain; }
+
+    /** Retorna o tipo operacional da fonte. */
+    public String getSourceType() { return sourceType; }
+
+    /** Define o tipo operacional da fonte. */
+    public void setSourceType(String sourceType) { this.sourceType = sourceType; }
+
+    /** Retorna o resumo agregado de evidência sem dados pessoais. */
+    public String getEvidenceSummary() { return evidenceSummary; }
+
+    /** Define o resumo agregado de evidência sem dados pessoais. */
+    public void setEvidenceSummary(String evidenceSummary) { this.evidenceSummary = evidenceSummary; }
+
+    /** Retorna a data em que a evidência foi capturada. */
+    public Instant getCapturedAt() { return capturedAt; }
+
+    /** Define a data em que a evidência foi capturada. */
+    public void setCapturedAt(Instant capturedAt) { this.capturedAt = capturedAt; }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/generalaudience/controller/OprmGeneralAudienceDiscoveryController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/generalaudience/controller/OprmGeneralAudienceDiscoveryController.java
@@ -1,0 +1,87 @@
+package com.marketinghub.oprm.generalaudience.controller;
+
+import com.marketinghub.oprm.generalaudience.service.OprmGeneralAudienceDiscoveryService;
+import com.marketinghub.oprm.generalaudience.service.createPainAngle.CreateGeneralAudiencePainAngleRequest;
+import com.marketinghub.oprm.generalaudience.service.createSourceEvidence.CreateGeneralAudienceSourceEvidenceRequest;
+import com.marketinghub.oprm.generalaudience.service.listPainAngles.GeneralAudiencePainAngleResponse;
+import com.marketinghub.oprm.generalaudience.service.listSourceEvidences.GeneralAudienceSourceEvidenceResponse;
+import com.marketinghub.oprm.generalaudience.service.qualityGate.GeneralAudienceQualityGateResponse;
+import com.marketinghub.oprm.generalaudience.service.updatePainAngle.UpdateGeneralAudiencePainAngleRequest;
+import jakarta.validation.Valid;
+import java.net.URI;
+import java.util.List;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/** Responsável pelos endpoints OPRM do pipeline de descoberta de públicos gerais. */
+@RestController
+@RequestMapping("/api/oprm/general-audiences")
+public class OprmGeneralAudienceDiscoveryController {
+
+    private final OprmGeneralAudienceDiscoveryService service;
+
+    /** Inicializa o controller com o serviço de descoberta de públicos gerais. */
+    public OprmGeneralAudienceDiscoveryController(OprmGeneralAudienceDiscoveryService service) {
+        this.service = service;
+    }
+
+    /** Lista dores e ângulos testáveis de um subnicho de público geral. */
+    @GetMapping("/subniches/{subnicheId}/pain-angles")
+    public ResponseEntity<List<GeneralAudiencePainAngleResponse>> listPainAngles(@PathVariable Long subnicheId) {
+        return ResponseEntity.ok(service.listPainAngles(subnicheId));
+    }
+
+    /** Cadastra dor e ângulo seguro sem gerar oferta final ou campanha. */
+    @PostMapping("/subniches/{subnicheId}/pain-angles")
+    public ResponseEntity<GeneralAudiencePainAngleResponse> createPainAngle(
+            @PathVariable Long subnicheId,
+            @Valid @RequestBody CreateGeneralAudiencePainAngleRequest request) {
+        GeneralAudiencePainAngleResponse response = service.createPainAngle(subnicheId, request);
+        return ResponseEntity
+                .created(URI.create("/api/oprm/general-audiences/pain-angles/" + response.id()))
+                .body(response);
+    }
+
+    /** Atualiza um ângulo testável mantendo validações de qualidade e compliance. */
+    @PatchMapping("/pain-angles/{angleId}")
+    public ResponseEntity<GeneralAudiencePainAngleResponse> updatePainAngle(
+            @PathVariable Long angleId,
+            @Valid @RequestBody UpdateGeneralAudiencePainAngleRequest request) {
+        return ResponseEntity.ok(service.updatePainAngle(angleId, request));
+    }
+
+    /** Aprova um ângulo somente quando não há promessa arriscada ou dor genérica. */
+    @PostMapping("/pain-angles/{angleId}/approve")
+    public ResponseEntity<GeneralAudiencePainAngleResponse> approvePainAngle(@PathVariable Long angleId) {
+        return ResponseEntity.ok(service.approvePainAngle(angleId));
+    }
+
+    /** Lista evidências agregadas associadas à semente de público geral. */
+    @GetMapping("/seeds/{seedId}/source-evidences")
+    public ResponseEntity<List<GeneralAudienceSourceEvidenceResponse>> listSeedEvidences(@PathVariable Long seedId) {
+        return ResponseEntity.ok(service.listSeedEvidences(seedId));
+    }
+
+    /** Registra evidência agregada e rastreável sem gravar dados pessoais ou comentários integrais. */
+    @PostMapping("/seeds/{seedId}/source-evidences")
+    public ResponseEntity<GeneralAudienceSourceEvidenceResponse> createSourceEvidence(
+            @PathVariable Long seedId,
+            @Valid @RequestBody CreateGeneralAudienceSourceEvidenceRequest request) {
+        GeneralAudienceSourceEvidenceResponse response = service.createSourceEvidence(seedId, request);
+        return ResponseEntity
+                .created(URI.create("/api/oprm/general-audiences/source-evidences/" + response.id()))
+                .body(response);
+    }
+
+    /** Avalia se o subnicho possui qualidade mínima para avançar sem virar saída genérica. */
+    @GetMapping("/subniches/{subnicheId}/quality-gate")
+    public ResponseEntity<GeneralAudienceQualityGateResponse> evaluateQualityGate(@PathVariable Long subnicheId) {
+        return ResponseEntity.ok(service.evaluateQualityGate(subnicheId));
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/generalaudience/pipeline/OprmGeneralAudienceDiscoveryPipelineSection.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/generalaudience/pipeline/OprmGeneralAudienceDiscoveryPipelineSection.java
@@ -1,0 +1,119 @@
+package com.marketinghub.oprm.generalaudience.pipeline;
+
+import java.util.Locale;
+import java.util.Set;
+
+/** Define as etapas oficiais do pipeline OPRM de descoberta de públicos gerais separado do NichoCNAE. */
+public enum OprmGeneralAudienceDiscoveryPipelineSection {
+    GENERAL_AUDIENCE_SEED_REVIEW(
+            1,
+            "general-audience-seed-review",
+            "Revisão da semente geral",
+            false,
+            "com.marketinghub.oprm.generalaudience",
+            Set.of("seed-review", "oprmGeneralAudienceSeedReview")),
+    GENERAL_AUDIENCE_SUBNICHE_DISCOVERY(
+            2,
+            "general-audience-subniche-discovery",
+            "Descoberta de subnichos",
+            true,
+            "com.marketinghub.oprm.generalaudience.service",
+            Set.of("subniche-discovery", "oprmGeneralAudienceSubnicheDiscovery")),
+    GENERAL_AUDIENCE_PAIN_MAPPING(
+            3,
+            "general-audience-pain-mapping",
+            "Mapeamento de dores e linguagem",
+            true,
+            "com.marketinghub.oprm.generalaudience.service",
+            Set.of("pain-mapping", "oprmGeneralAudiencePainMapping")),
+    GENERAL_AUDIENCE_ANGLE_BUILDER(
+            4,
+            "general-audience-angle-builder",
+            "Construção de ângulos seguros",
+            true,
+            "com.marketinghub.oprm.generalaudience.service",
+            Set.of("angle-builder", "oprmGeneralAudienceAngleBuilder")),
+    GENERAL_AUDIENCE_QUALITY_GATE(
+            5,
+            "general-audience-quality-gate",
+            "Quality gate de público geral",
+            false,
+            "com.marketinghub.oprm.generalaudience.service",
+            Set.of("quality-gate", "oprmGeneralAudienceQualityGate")),
+    GENERAL_AUDIENCE_EXPERIMENT_BRIEF(
+            6,
+            "general-audience-experiment-brief",
+            "Brief de experimento de lead",
+            false,
+            "com.marketinghub.oprm.generalaudience.service",
+            Set.of("experiment-brief", "oprmGeneralAudienceExperimentBrief"));
+
+    private static final String EXECUTION_MODULE = "backend";
+    private final int position;
+    private final String path;
+    private final String displayName;
+    private final boolean requiresOpenAiModel;
+    private final String rootPackage;
+    private final Set<String> aliases;
+
+    /** Inicializa a etapa oficial de descoberta de público geral. */
+    OprmGeneralAudienceDiscoveryPipelineSection(
+            int position,
+            String path,
+            String displayName,
+            boolean requiresOpenAiModel,
+            String rootPackage,
+            Set<String> aliases) {
+        this.position = position;
+        this.path = path;
+        this.displayName = displayName;
+        this.requiresOpenAiModel = requiresOpenAiModel;
+        this.rootPackage = rootPackage;
+        this.aliases = aliases;
+    }
+
+    /** Retorna a posição canônica da etapa. */
+    public int position() { return position; }
+
+    /** Retorna o código operacional da etapa. */
+    public String path() { return path; }
+
+    /** Retorna o nome legível da etapa. */
+    public String displayName() { return displayName; }
+
+    /** Informa se a etapa pode consumir modelo OpenAI em automação futura. */
+    public boolean requiresOpenAiModel() { return requiresOpenAiModel; }
+
+    /** Retorna o módulo executor protegido pelo backend principal. */
+    public String executionModule() { return EXECUTION_MODULE; }
+
+    /** Retorna o pacote backend responsável pela etapa. */
+    public String rootPackage() { return rootPackage; }
+
+    /** Retorna o pacote do módulo executor, sem criar acesso direto fora do backend. */
+    public String modulePackage() { return rootPackage; }
+
+    /** Retorna aliases aceitos para localizar a etapa oficial. */
+    public Set<String> aliases() { return aliases; }
+
+    /** Converte código operacional ou alias em etapa oficial. */
+    public static OprmGeneralAudienceDiscoveryPipelineSection fromCode(String raw) {
+        String normalized = normalize(raw);
+        for (OprmGeneralAudienceDiscoveryPipelineSection section : values()) {
+            if (normalize(section.path).equals(normalized)
+                    || normalize(section.name()).equals(normalized)
+                    || section.aliases.stream().map(OprmGeneralAudienceDiscoveryPipelineSection::normalize).anyMatch(normalized::equals)) {
+                return section;
+            }
+        }
+        throw new IllegalArgumentException("Unknown OPRM general audience discovery section: " + raw);
+    }
+
+    /** Normaliza códigos de etapa para comparação tolerante a caixa e separadores. */
+    private static String normalize(String code) {
+        if (code == null || code.isBlank()) {
+            return "";
+        }
+        return code.trim().toLowerCase(Locale.ROOT).replace('_', '-');
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/generalaudience/service/OprmGeneralAudienceDiscoveryService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/generalaudience/service/OprmGeneralAudienceDiscoveryService.java
@@ -1,0 +1,296 @@
+package com.marketinghub.oprm.generalaudience.service;
+
+import com.marketinghub.oprm.generalaudience.OprmGeneralAudiencePainAngle;
+import com.marketinghub.oprm.generalaudience.OprmGeneralAudiencePainAngleStatus;
+import com.marketinghub.oprm.generalaudience.OprmGeneralAudienceSeed;
+import com.marketinghub.oprm.generalaudience.OprmGeneralAudienceSourceEvidence;
+import com.marketinghub.oprm.generalaudience.OprmGeneralAudienceSubniche;
+import com.marketinghub.oprm.generalaudience.service.createPainAngle.CreateGeneralAudiencePainAngleRequest;
+import com.marketinghub.oprm.generalaudience.service.createSourceEvidence.CreateGeneralAudienceSourceEvidenceRequest;
+import com.marketinghub.oprm.generalaudience.service.listPainAngles.GeneralAudiencePainAngleResponse;
+import com.marketinghub.oprm.generalaudience.service.listSourceEvidences.GeneralAudienceSourceEvidenceResponse;
+import com.marketinghub.oprm.generalaudience.service.qualityGate.GeneralAudienceQualityGateResponse;
+import com.marketinghub.oprm.generalaudience.service.updatePainAngle.UpdateGeneralAudiencePainAngleRequest;
+import com.marketinghub.repository.jpa.oprm.generalaudience.OprmGeneralAudiencePainAngleRepository;
+import com.marketinghub.repository.jpa.oprm.generalaudience.OprmGeneralAudienceSeedRepository;
+import com.marketinghub.repository.jpa.oprm.generalaudience.OprmGeneralAudienceSourceEvidenceRepository;
+import com.marketinghub.repository.jpa.oprm.generalaudience.OprmGeneralAudienceSubnicheRepository;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+import java.util.Set;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+import org.springframework.web.server.ResponseStatusException;
+
+/** Responsável pelo pipeline de descoberta de subnichos, dores, evidências e quality gate de públicos gerais. */
+@Service
+public class OprmGeneralAudienceDiscoveryService {
+
+    private static final Set<String> GENERIC_TERMS = Set.of("marketing digital", "renda extra", "beleza", "relacionamento");
+    private static final Set<String> RISKY_PROMISE_TERMS = Set.of(
+            "garantido", "garantida", "certeza", "sem esforço", "resultado absoluto", "renda garantida");
+    private final OprmGeneralAudienceSeedRepository seedRepository;
+    private final OprmGeneralAudienceSubnicheRepository subnicheRepository;
+    private final OprmGeneralAudiencePainAngleRepository painAngleRepository;
+    private final OprmGeneralAudienceSourceEvidenceRepository sourceEvidenceRepository;
+
+    /** Inicializa o serviço com repositórios centralizados do módulo OPRM. */
+    public OprmGeneralAudienceDiscoveryService(
+            OprmGeneralAudienceSeedRepository seedRepository,
+            OprmGeneralAudienceSubnicheRepository subnicheRepository,
+            OprmGeneralAudiencePainAngleRepository painAngleRepository,
+            OprmGeneralAudienceSourceEvidenceRepository sourceEvidenceRepository) {
+        this.seedRepository = seedRepository;
+        this.subnicheRepository = subnicheRepository;
+        this.painAngleRepository = painAngleRepository;
+        this.sourceEvidenceRepository = sourceEvidenceRepository;
+    }
+
+    /** Lista ângulos de dor de um subnicho para revisão antes de construir oferta. */
+    @Transactional(readOnly = true)
+    public List<GeneralAudiencePainAngleResponse> listPainAngles(Long subnicheId) {
+        findSubniche(subnicheId);
+        return painAngleRepository.findAllBySubnicheIdOrderByUpdatedAtDesc(subnicheId).stream()
+                .map(this::toPainAngleResponse)
+                .toList();
+    }
+
+    /** Cadastra dor e ângulo testável sem publicar campanha ou criar hipótese automaticamente. */
+    @Transactional
+    public GeneralAudiencePainAngleResponse createPainAngle(
+            Long subnicheId,
+            CreateGeneralAudiencePainAngleRequest request) {
+        OprmGeneralAudienceSubniche subniche = findSubniche(subnicheId);
+        OprmGeneralAudiencePainAngle angle = new OprmGeneralAudiencePainAngle();
+        angle.setSubniche(subniche);
+        angle.setPain(requiredText(request.pain(), "pain"));
+        angle.setDesiredResult(requiredText(request.desiredResult(), "desiredResult"));
+        angle.setMechanismDirection(normalizeOptionalText(request.mechanismDirection()));
+        angle.setProofOrLeadMagnet(normalizeOptionalText(request.proofOrLeadMagnet()));
+        angle.setSafePromise(normalizeOptionalText(request.safePromise()));
+        angle.setFirstAdHook(normalizeOptionalText(request.firstAdHook()));
+        angle.setLandingConfirmationQuestion(normalizeOptionalText(request.landingConfirmationQuestion()));
+        angle.setComplianceNotes(normalizeOptionalText(request.complianceNotes()));
+        angle.setStatus(request.status() == null ? OprmGeneralAudiencePainAngleStatus.DISCOVERED : request.status());
+        validateSafeAngle(angle);
+        return toPainAngleResponse(painAngleRepository.save(angle));
+    }
+
+    /** Atualiza um ângulo mantendo a validação contra saída genérica ou promessa arriscada. */
+    @Transactional
+    public GeneralAudiencePainAngleResponse updatePainAngle(
+            Long angleId,
+            UpdateGeneralAudiencePainAngleRequest request) {
+        OprmGeneralAudiencePainAngle angle = findPainAngle(angleId);
+        if (request.pain() != null) {
+            angle.setPain(requiredText(request.pain(), "pain"));
+        }
+        if (request.desiredResult() != null) {
+            angle.setDesiredResult(requiredText(request.desiredResult(), "desiredResult"));
+        }
+        if (request.mechanismDirection() != null) {
+            angle.setMechanismDirection(normalizeOptionalText(request.mechanismDirection()));
+        }
+        if (request.proofOrLeadMagnet() != null) {
+            angle.setProofOrLeadMagnet(normalizeOptionalText(request.proofOrLeadMagnet()));
+        }
+        if (request.safePromise() != null) {
+            angle.setSafePromise(normalizeOptionalText(request.safePromise()));
+        }
+        if (request.firstAdHook() != null) {
+            angle.setFirstAdHook(normalizeOptionalText(request.firstAdHook()));
+        }
+        if (request.landingConfirmationQuestion() != null) {
+            angle.setLandingConfirmationQuestion(normalizeOptionalText(request.landingConfirmationQuestion()));
+        }
+        if (request.complianceNotes() != null) {
+            angle.setComplianceNotes(normalizeOptionalText(request.complianceNotes()));
+        }
+        if (request.status() != null) {
+            angle.setStatus(request.status());
+        }
+        validateSafeAngle(angle);
+        return toPainAngleResponse(painAngleRepository.save(angle));
+    }
+
+    /** Aprova um ângulo somente quando ele passa pela validação de qualidade e promessa segura. */
+    @Transactional
+    public GeneralAudiencePainAngleResponse approvePainAngle(Long angleId) {
+        OprmGeneralAudiencePainAngle angle = findPainAngle(angleId);
+        angle.setStatus(OprmGeneralAudiencePainAngleStatus.APPROVED);
+        validateSafeAngle(angle);
+        return toPainAngleResponse(painAngleRepository.save(angle));
+    }
+
+    /** Lista evidências agregadas de uma semente para auditoria do mapeamento. */
+    @Transactional(readOnly = true)
+    public List<GeneralAudienceSourceEvidenceResponse> listSeedEvidences(Long seedId) {
+        findSeed(seedId);
+        return sourceEvidenceRepository.findAllBySeedIdOrderByCapturedAtDesc(seedId).stream()
+                .map(this::toSourceEvidenceResponse)
+                .toList();
+    }
+
+    /** Registra evidência agregada e rastreável sem persistir comentários integrais ou dados pessoais. */
+    @Transactional
+    public GeneralAudienceSourceEvidenceResponse createSourceEvidence(
+            Long seedId,
+            CreateGeneralAudienceSourceEvidenceRequest request) {
+        OprmGeneralAudienceSeed seed = findSeed(seedId);
+        OprmGeneralAudienceSubniche subniche = null;
+        if (request.subnicheId() != null) {
+            subniche = findSubniche(request.subnicheId());
+            if (!seed.getId().equals(subniche.getSeed().getId())) {
+                throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "subnicheId não pertence à semente informada");
+            }
+        }
+        OprmGeneralAudienceSourceEvidence evidence = new OprmGeneralAudienceSourceEvidence();
+        evidence.setSeed(seed);
+        evidence.setSubniche(subniche);
+        evidence.setSourceUrl(normalizeOptionalText(request.sourceUrl()));
+        evidence.setSourceDomain(normalizeOptionalText(request.sourceDomain()));
+        evidence.setSourceType(normalizeOptionalText(request.sourceType()));
+        evidence.setEvidenceSummary(requiredText(request.evidenceSummary(), "evidenceSummary"));
+        evidence.setCapturedAt(request.capturedAt());
+        return toSourceEvidenceResponse(sourceEvidenceRepository.save(evidence));
+    }
+
+    /** Executa o quality gate de um subnicho para bloquear saída genérica antes de experimento. */
+    @Transactional(readOnly = true)
+    public GeneralAudienceQualityGateResponse evaluateQualityGate(Long subnicheId) {
+        OprmGeneralAudienceSubniche subniche = findSubniche(subnicheId);
+        List<String> blockers = new ArrayList<>();
+        List<String> recommendations = new ArrayList<>();
+        requireText(blockers, subniche.getPersonaSummary(), "Persona/contexto do subnicho ausente.");
+        requireText(blockers, subniche.getPainSummary(), "Dor principal do subnicho ausente.");
+        requireText(blockers, subniche.getQualificationQuestion(), "Pergunta qualificadora obrigatória ausente.");
+        if (isGeneric(subniche.getName()) || isGeneric(subniche.getPainSummary())) {
+            blockers.add("Subnicho ou dor ainda genérico demais para experimento.");
+        }
+        long approvedAngles = painAngleRepository.countBySubnicheIdAndStatusIn(
+                subnicheId,
+                Set.of(OprmGeneralAudiencePainAngleStatus.APPROVED));
+        if (approvedAngles == 0) {
+            blockers.add("Nenhum ângulo de dor aprovado com promessa segura.");
+        }
+        if (sourceEvidenceRepository.countBySubnicheId(subnicheId) == 0) {
+            blockers.add("Nenhuma evidência agregada associada ao subnicho.");
+        }
+        if (!StringUtils.hasText(subniche.getChannelsSummary())) {
+            recommendations.add("Informar canais onde a linguagem real do público aparece.");
+        }
+        if (!StringUtils.hasText(subniche.getDesiredOutcomeSummary())) {
+            recommendations.add("Informar resultado desejado antes de criar isca ou promessa.");
+        }
+        return new GeneralAudienceQualityGateResponse(subnicheId, blockers.isEmpty(), blockers, recommendations);
+    }
+
+    /** Busca uma semente ou devolve erro HTTP de recurso inexistente. */
+    private OprmGeneralAudienceSeed findSeed(Long seedId) {
+        return seedRepository.findById(seedId)
+                .orElseThrow(() -> new ResponseStatusException(
+                        HttpStatus.NOT_FOUND,
+                        "Semente de público geral não encontrada: " + seedId));
+    }
+
+    /** Busca um subnicho ou devolve erro HTTP de recurso inexistente. */
+    private OprmGeneralAudienceSubniche findSubniche(Long subnicheId) {
+        return subnicheRepository.findById(subnicheId)
+                .orElseThrow(() -> new ResponseStatusException(
+                        HttpStatus.NOT_FOUND,
+                        "Subnicho de público geral não encontrado: " + subnicheId));
+    }
+
+    /** Busca um ângulo ou devolve erro HTTP de recurso inexistente. */
+    private OprmGeneralAudiencePainAngle findPainAngle(Long angleId) {
+        return painAngleRepository.findById(angleId)
+                .orElseThrow(() -> new ResponseStatusException(
+                        HttpStatus.NOT_FOUND,
+                        "Ângulo de público geral não encontrado: " + angleId));
+    }
+
+    /** Valida se o ângulo não contém saída genérica ou promessa arriscada. */
+    private void validateSafeAngle(OprmGeneralAudiencePainAngle angle) {
+        if (isGeneric(angle.getPain())) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "pain genérico demais para público geral");
+        }
+        if (containsRiskyPromise(angle.getSafePromise()) || containsRiskyPromise(angle.getFirstAdHook())) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Ângulo contém promessa arriscada ou absoluta");
+        }
+    }
+
+    /** Indica se o texto é curto ou amplo demais para orientar uma decisão comercial. */
+    private boolean isGeneric(String value) {
+        if (!StringUtils.hasText(value)) {
+            return true;
+        }
+        String normalized = value.trim().toLowerCase(Locale.ROOT);
+        return normalized.length() < 12 || GENERIC_TERMS.contains(normalized);
+    }
+
+    /** Indica se o texto contém promessa sensível, absoluta ou garantida. */
+    private boolean containsRiskyPromise(String value) {
+        if (!StringUtils.hasText(value)) {
+            return false;
+        }
+        String normalized = value.toLowerCase(Locale.ROOT);
+        return RISKY_PROMISE_TERMS.stream().anyMatch(normalized::contains);
+    }
+
+    /** Adiciona bloqueio quando um campo textual obrigatório para qualidade está ausente. */
+    private void requireText(List<String> blockers, String value, String message) {
+        if (!StringUtils.hasText(value)) {
+            blockers.add(message);
+        }
+    }
+
+    /** Normaliza texto obrigatório e rejeita valor vazio. */
+    private String requiredText(String value, String fieldName) {
+        if (!StringUtils.hasText(value)) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, fieldName + " não pode ficar vazio");
+        }
+        return value.trim();
+    }
+
+    /** Normaliza texto opcional para persistir nulo quando não há conteúdo útil. */
+    private String normalizeOptionalText(String value) {
+        if (!StringUtils.hasText(value)) {
+            return null;
+        }
+        return value.trim();
+    }
+
+    /** Converte entidade de ângulo para contrato HTTP. */
+    private GeneralAudiencePainAngleResponse toPainAngleResponse(OprmGeneralAudiencePainAngle angle) {
+        return new GeneralAudiencePainAngleResponse(
+                angle.getId(),
+                angle.getSubniche().getId(),
+                angle.getPain(),
+                angle.getDesiredResult(),
+                angle.getMechanismDirection(),
+                angle.getProofOrLeadMagnet(),
+                angle.getSafePromise(),
+                angle.getFirstAdHook(),
+                angle.getLandingConfirmationQuestion(),
+                angle.getComplianceNotes(),
+                angle.getStatus(),
+                angle.getCreatedAt(),
+                angle.getUpdatedAt());
+    }
+
+    /** Converte entidade de evidência para contrato HTTP. */
+    private GeneralAudienceSourceEvidenceResponse toSourceEvidenceResponse(OprmGeneralAudienceSourceEvidence evidence) {
+        return new GeneralAudienceSourceEvidenceResponse(
+                evidence.getId(),
+                evidence.getSeed().getId(),
+                evidence.getSubniche() == null ? null : evidence.getSubniche().getId(),
+                evidence.getSourceUrl(),
+                evidence.getSourceDomain(),
+                evidence.getSourceType(),
+                evidence.getEvidenceSummary(),
+                evidence.getCapturedAt());
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/generalaudience/service/createPainAngle/CreateGeneralAudiencePainAngleRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/generalaudience/service/createPainAngle/CreateGeneralAudiencePainAngleRequest.java
@@ -1,0 +1,18 @@
+package com.marketinghub.oprm.generalaudience.service.createPainAngle;
+
+import com.marketinghub.oprm.generalaudience.OprmGeneralAudiencePainAngleStatus;
+import jakarta.validation.constraints.NotBlank;
+
+/** Contrato de entrada para cadastrar dor e ângulo testável de público geral. */
+public record CreateGeneralAudiencePainAngleRequest(
+        @NotBlank String pain,
+        @NotBlank String desiredResult,
+        String mechanismDirection,
+        String proofOrLeadMagnet,
+        String safePromise,
+        String firstAdHook,
+        String landingConfirmationQuestion,
+        String complianceNotes,
+        OprmGeneralAudiencePainAngleStatus status
+) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/generalaudience/service/createSourceEvidence/CreateGeneralAudienceSourceEvidenceRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/generalaudience/service/createSourceEvidence/CreateGeneralAudienceSourceEvidenceRequest.java
@@ -1,0 +1,16 @@
+package com.marketinghub.oprm.generalaudience.service.createSourceEvidence;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Size;
+import java.time.Instant;
+
+/** Contrato de entrada para registrar evidência agregada de público geral sem dados pessoais. */
+public record CreateGeneralAudienceSourceEvidenceRequest(
+        Long subnicheId,
+        @Size(max = 1024) String sourceUrl,
+        @Size(max = 191) String sourceDomain,
+        @Size(max = 64) String sourceType,
+        @NotBlank String evidenceSummary,
+        Instant capturedAt
+) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/generalaudience/service/listPainAngles/GeneralAudiencePainAngleResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/generalaudience/service/listPainAngles/GeneralAudiencePainAngleResponse.java
@@ -1,0 +1,22 @@
+package com.marketinghub.oprm.generalaudience.service.listPainAngles;
+
+import com.marketinghub.oprm.generalaudience.OprmGeneralAudiencePainAngleStatus;
+import java.time.Instant;
+
+/** Contrato de saída com dor, resultado e ângulo seguro para público geral. */
+public record GeneralAudiencePainAngleResponse(
+        Long id,
+        Long subnicheId,
+        String pain,
+        String desiredResult,
+        String mechanismDirection,
+        String proofOrLeadMagnet,
+        String safePromise,
+        String firstAdHook,
+        String landingConfirmationQuestion,
+        String complianceNotes,
+        OprmGeneralAudiencePainAngleStatus status,
+        Instant createdAt,
+        Instant updatedAt
+) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/generalaudience/service/listSourceEvidences/GeneralAudienceSourceEvidenceResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/generalaudience/service/listSourceEvidences/GeneralAudienceSourceEvidenceResponse.java
@@ -1,0 +1,16 @@
+package com.marketinghub.oprm.generalaudience.service.listSourceEvidences;
+
+import java.time.Instant;
+
+/** Contrato de saída com evidência agregada e rastreável de público geral. */
+public record GeneralAudienceSourceEvidenceResponse(
+        Long id,
+        Long seedId,
+        Long subnicheId,
+        String sourceUrl,
+        String sourceDomain,
+        String sourceType,
+        String evidenceSummary,
+        Instant capturedAt
+) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/generalaudience/service/qualityGate/GeneralAudienceQualityGateResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/generalaudience/service/qualityGate/GeneralAudienceQualityGateResponse.java
@@ -1,0 +1,12 @@
+package com.marketinghub.oprm.generalaudience.service.qualityGate;
+
+import java.util.List;
+
+/** Contrato de saída do gate que impede subnicho genérico ou contaminado por promessa arriscada. */
+public record GeneralAudienceQualityGateResponse(
+        Long subnicheId,
+        boolean approved,
+        List<String> blockers,
+        List<String> recommendations
+) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/generalaudience/service/updatePainAngle/UpdateGeneralAudiencePainAngleRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/generalaudience/service/updatePainAngle/UpdateGeneralAudiencePainAngleRequest.java
@@ -1,0 +1,17 @@
+package com.marketinghub.oprm.generalaudience.service.updatePainAngle;
+
+import com.marketinghub.oprm.generalaudience.OprmGeneralAudiencePainAngleStatus;
+
+/** Contrato de entrada para revisar uma dor e seu ângulo testável. */
+public record UpdateGeneralAudiencePainAngleRequest(
+        String pain,
+        String desiredResult,
+        String mechanismDirection,
+        String proofOrLeadMagnet,
+        String safePromise,
+        String firstAdHook,
+        String landingConfirmationQuestion,
+        String complianceNotes,
+        OprmGeneralAudiencePainAngleStatus status
+) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/pipeline/definition/PipelineDefinitionRegistry.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/pipeline/definition/PipelineDefinitionRegistry.java
@@ -1,6 +1,7 @@
 package com.marketinghub.pipeline.definition;
 
 import com.marketinghub.experiment.pipeline.ExperimentPipelineSection;
+import com.marketinghub.oprm.generalaudience.pipeline.OprmGeneralAudienceDiscoveryPipelineSection;
 import com.marketinghub.oprm.nichocnae.pipeline.OprmNichoCnaePipelineSection;
 import java.util.Arrays;
 import java.util.List;
@@ -28,6 +29,10 @@ public class PipelineDefinitionRegistry {
     private static final String OPRM_NICHO_CNAE_PIPELINE_CODE = "oprm-nicho-cnae-pipeline";
     private static final String OPRM_MODULE = "OPRM";
     private static final String OPRM_NICHO_CNAE_CANONICAL_VERSION = "oprm-nichocnae-canon.v1";
+    private static final String OPRM_GENERAL_AUDIENCE_DISCOVERY_PIPELINE_CODE =
+            "oprm-general-audience-discovery-pipeline";
+    private static final String OPRM_GENERAL_AUDIENCE_DISCOVERY_CANONICAL_VERSION =
+            "oprm-general-audience-discovery-canon.v1";
     private static final String MOIS_SALES_PAGE_LIBRARY_PIPELINE_CODE = "mois-sales-page-library-pipeline";
     private static final String MOIS_MODULE = "MOIS";
     private static final String MOIS_SALES_PAGE_LIBRARY_CANONICAL_VERSION = "mois-sales-page-library-canon.v1";
@@ -56,6 +61,7 @@ public class PipelineDefinitionRegistry {
         this.officialPipelines = List.of(
                 buildExperimentPipeline(),
                 buildOprmNichoCnaePipeline(),
+                buildOprmGeneralAudienceDiscoveryPipeline(),
                 buildMoisSalesPageLibraryPipeline(),
                 buildFacebookAdsPublicationMetricsPipeline());
         this.validModules = Set.of(
@@ -258,6 +264,41 @@ public class PipelineDefinitionRegistry {
                 OPRM_NICHO_CNAE_CANONICAL_VERSION,
                 true,
                 Set.of(OPRM_NICHO_CNAE_PIPELINE_CODE, "nicho-cnae-pipeline", "oprm_nicho_cnae_pipeline"),
+                PipelineFieldPolicy.officialDefault(),
+                StageFieldPolicy.officialDefault(),
+                stages);
+    }
+
+
+    /**
+     * Monta a definição oficial do pipeline OPRM de descoberta de públicos gerais sem dependência de CNAE.
+     */
+    private PipelineDefinition buildOprmGeneralAudienceDiscoveryPipeline() {
+        List<PipelineStageDefinition> stages = Arrays.stream(OprmGeneralAudienceDiscoveryPipelineSection.values())
+                .map(section -> new PipelineStageDefinition(
+                        section.name(),
+                        section.path(),
+                        section.displayName(),
+                        section.position(),
+                        true,
+                        section.requiresOpenAiModel(),
+                        true,
+                        section.executionModule(),
+                        section.rootPackage(),
+                        section.modulePackage(),
+                        section.aliases()))
+                .toList();
+        return new PipelineDefinition(
+                OPRM_MODULE,
+                OPRM_GENERAL_AUDIENCE_DISCOVERY_PIPELINE_CODE,
+                "Pipeline de Descoberta de Públicos Gerais",
+                OPRM_GENERAL_AUDIENCE_DISCOVERY_CANONICAL_VERSION,
+                true,
+                Set.of(
+                        OPRM_GENERAL_AUDIENCE_DISCOVERY_PIPELINE_CODE,
+                        "OPRM_GENERAL_AUDIENCE_DISCOVERY",
+                        "general-audience-discovery",
+                        "publicos-gerais-pipeline"),
                 PipelineFieldPolicy.officialDefault(),
                 StageFieldPolicy.officialDefault(),
                 stages);

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/oprm/generalaudience/OprmGeneralAudiencePainAngleRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/oprm/generalaudience/OprmGeneralAudiencePainAngleRepository.java
@@ -1,0 +1,17 @@
+package com.marketinghub.repository.jpa.oprm.generalaudience;
+
+import com.marketinghub.oprm.generalaudience.OprmGeneralAudiencePainAngle;
+import com.marketinghub.oprm.generalaudience.OprmGeneralAudiencePainAngleStatus;
+import java.util.Collection;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/** Repositório JPA responsável por dores e ângulos testáveis de públicos gerais OPRM. */
+public interface OprmGeneralAudiencePainAngleRepository extends JpaRepository<OprmGeneralAudiencePainAngle, Long> {
+
+    /** Lista ângulos de um subnicho do mais recente para o mais antigo. */
+    List<OprmGeneralAudiencePainAngle> findAllBySubnicheIdOrderByUpdatedAtDesc(Long subnicheId);
+
+    /** Conta ângulos de um subnicho que estão em status aprovados para quality gate. */
+    long countBySubnicheIdAndStatusIn(Long subnicheId, Collection<OprmGeneralAudiencePainAngleStatus> statuses);
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/oprm/generalaudience/OprmGeneralAudienceSourceEvidenceRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/oprm/generalaudience/OprmGeneralAudienceSourceEvidenceRepository.java
@@ -1,0 +1,18 @@
+package com.marketinghub.repository.jpa.oprm.generalaudience;
+
+import com.marketinghub.oprm.generalaudience.OprmGeneralAudienceSourceEvidence;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/** Repositório JPA responsável por evidências agregadas dos públicos gerais OPRM. */
+public interface OprmGeneralAudienceSourceEvidenceRepository extends JpaRepository<OprmGeneralAudienceSourceEvidence, Long> {
+
+    /** Lista evidências de uma semente do registro mais recente para o mais antigo. */
+    List<OprmGeneralAudienceSourceEvidence> findAllBySeedIdOrderByCapturedAtDesc(Long seedId);
+
+    /** Lista evidências de um subnicho do registro mais recente para o mais antigo. */
+    List<OprmGeneralAudienceSourceEvidence> findAllBySubnicheIdOrderByCapturedAtDesc(Long subnicheId);
+
+    /** Conta evidências agregadas associadas diretamente ao subnicho. */
+    long countBySubnicheId(Long subnicheId);
+}

--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-10-oprm-general-audience-discovery.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-10-oprm-general-audience-discovery.yaml
@@ -1,0 +1,69 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-06-10-03-oprm-general-audience-pain-angle
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - onError: HALT
+        - dbms:
+            type: mysql
+        - not:
+            tableExists:
+              tableName: oprm_general_audience_pain_angle
+      changes:
+        - sql:
+            splitStatements: true
+            stripComments: true
+            sql: |
+              CREATE TABLE oprm_general_audience_pain_angle (
+                id BIGINT NOT NULL AUTO_INCREMENT,
+                subniche_id BIGINT NOT NULL,
+                pain LONGTEXT NOT NULL,
+                desired_result LONGTEXT NOT NULL,
+                mechanism_direction LONGTEXT NULL,
+                proof_or_lead_magnet LONGTEXT NULL,
+                safe_promise LONGTEXT NULL,
+                first_ad_hook LONGTEXT NULL,
+                landing_confirmation_question LONGTEXT NULL,
+                compliance_notes LONGTEXT NULL,
+                status VARCHAR(32) NOT NULL,
+                created_at DATETIME NOT NULL,
+                updated_at DATETIME NOT NULL,
+                CONSTRAINT pk_oprm_general_audience_pain_angle PRIMARY KEY (id),
+                CONSTRAINT fk_oprm_general_audience_pain_angle_subniche
+                  FOREIGN KEY (subniche_id) REFERENCES oprm_general_audience_subniche (id)
+              );
+              CREATE INDEX idx_oprm_general_audience_pain_angle_subniche_status ON oprm_general_audience_pain_angle (subniche_id, status, updated_at);
+  - changeSet:
+      id: 2026-06-10-04-oprm-general-audience-source-evidence
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - onError: HALT
+        - dbms:
+            type: mysql
+        - not:
+            tableExists:
+              tableName: oprm_general_audience_source_evidence
+      changes:
+        - sql:
+            splitStatements: true
+            stripComments: true
+            sql: |
+              CREATE TABLE oprm_general_audience_source_evidence (
+                id BIGINT NOT NULL AUTO_INCREMENT,
+                seed_id BIGINT NOT NULL,
+                subniche_id BIGINT NULL,
+                source_url VARCHAR(1024) NULL,
+                source_domain VARCHAR(191) NULL,
+                source_type VARCHAR(64) NULL,
+                evidence_summary LONGTEXT NOT NULL,
+                captured_at DATETIME NOT NULL,
+                CONSTRAINT pk_oprm_general_audience_source_evidence PRIMARY KEY (id),
+                CONSTRAINT fk_oprm_general_audience_source_evidence_seed
+                  FOREIGN KEY (seed_id) REFERENCES oprm_general_audience_seed (id),
+                CONSTRAINT fk_oprm_general_audience_source_evidence_subniche
+                  FOREIGN KEY (subniche_id) REFERENCES oprm_general_audience_subniche (id)
+              );
+              CREATE INDEX idx_oprm_general_audience_source_evidence_seed ON oprm_general_audience_source_evidence (seed_id, captured_at);
+              CREATE INDEX idx_oprm_general_audience_source_evidence_subniche ON oprm_general_audience_source_evidence (subniche_id, captured_at);

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -6,6 +6,9 @@ databaseChangeLog:
       file: changesets/2026-06-10-oprm-general-audience-subniche.yaml
       relativeToChangelogFile: true
   - include:
+      file: changesets/2026-06-10-oprm-general-audience-discovery.yaml
+      relativeToChangelogFile: true
+  - include:
       file: changesets/2026-06-09-oprm-source-freshness-mei-classification.yaml
       relativeToChangelogFile: true
   - include:

--- a/backend/ads-service/src/test/java/com/marketinghub/oprm/generalaudience/service/OprmGeneralAudienceDiscoveryServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/oprm/generalaudience/service/OprmGeneralAudienceDiscoveryServiceTest.java
@@ -1,0 +1,166 @@
+package com.marketinghub.oprm.generalaudience.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.marketinghub.oprm.generalaudience.OprmGeneralAudiencePainAngle;
+import com.marketinghub.oprm.generalaudience.OprmGeneralAudiencePainAngleStatus;
+import com.marketinghub.oprm.generalaudience.OprmGeneralAudienceSeed;
+import com.marketinghub.oprm.generalaudience.OprmGeneralAudienceSourceEvidence;
+import com.marketinghub.oprm.generalaudience.OprmGeneralAudienceSubniche;
+import com.marketinghub.oprm.generalaudience.service.createPainAngle.CreateGeneralAudiencePainAngleRequest;
+import com.marketinghub.oprm.generalaudience.service.createSourceEvidence.CreateGeneralAudienceSourceEvidenceRequest;
+import com.marketinghub.repository.jpa.oprm.generalaudience.OprmGeneralAudiencePainAngleRepository;
+import com.marketinghub.repository.jpa.oprm.generalaudience.OprmGeneralAudienceSeedRepository;
+import com.marketinghub.repository.jpa.oprm.generalaudience.OprmGeneralAudienceSourceEvidenceRepository;
+import com.marketinghub.repository.jpa.oprm.generalaudience.OprmGeneralAudienceSubnicheRepository;
+import java.time.Instant;
+import java.util.Optional;
+import java.util.Set;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.server.ResponseStatusException;
+
+/** Valida o pipeline de descoberta de públicos gerais sem contaminar o fluxo NichoCNAE. */
+class OprmGeneralAudienceDiscoveryServiceTest {
+
+    /** Verifica se o cadastro de ângulo bloqueia dor genérica antes de avançar no pipeline. */
+    @Test
+    void shouldRejectGenericPainAngle() {
+        OprmGeneralAudienceDiscoveryService service = serviceWith(subnicheRepositoryReturning(subniche()));
+
+        assertThatThrownBy(() -> service.createPainAngle(5L, new CreateGeneralAudiencePainAngleRequest(
+                        "beleza",
+                        "Ter mais clientes",
+                        null,
+                        null,
+                        "Organizar a agenda sem promessa absoluta",
+                        null,
+                        null,
+                        null,
+                        null)))
+                .isInstanceOf(ResponseStatusException.class)
+                .hasMessageContaining("pain genérico demais");
+    }
+
+    /** Verifica se o cadastro de ângulo bloqueia promessa absoluta ou arriscada. */
+    @Test
+    void shouldRejectRiskyPromise() {
+        OprmGeneralAudienceDiscoveryService service = serviceWith(subnicheRepositoryReturning(subniche()));
+
+        assertThatThrownBy(() -> service.createPainAngle(5L, new CreateGeneralAudiencePainAngleRequest(
+                        "Agenda vazia durante a semana",
+                        "Reativar clientes antigas",
+                        "Mensagens de WhatsApp",
+                        "Kit de mensagens",
+                        "Agenda cheia garantida",
+                        null,
+                        "Você trabalha como manicure hoje?",
+                        null,
+                        null)))
+                .isInstanceOf(ResponseStatusException.class)
+                .hasMessageContaining("promessa arriscada");
+    }
+
+    /** Verifica se o quality gate aprova somente quando há dor, pergunta, evidência e ângulo aprovado. */
+    @Test
+    void shouldApproveQualityGateWithEvidenceAndApprovedAngle() {
+        OprmGeneralAudienceSubniche subniche = subniche();
+        OprmGeneralAudienceSubnicheRepository subnicheRepository = subnicheRepositoryReturning(subniche);
+        OprmGeneralAudiencePainAngleRepository angleRepository = mock(OprmGeneralAudiencePainAngleRepository.class);
+        OprmGeneralAudienceSourceEvidenceRepository evidenceRepository = mock(OprmGeneralAudienceSourceEvidenceRepository.class);
+        when(angleRepository.countBySubnicheIdAndStatusIn(5L, Set.of(OprmGeneralAudiencePainAngleStatus.APPROVED)))
+                .thenReturn(1L);
+        when(evidenceRepository.countBySubnicheId(5L)).thenReturn(1L);
+        OprmGeneralAudienceDiscoveryService service = new OprmGeneralAudienceDiscoveryService(
+                mock(OprmGeneralAudienceSeedRepository.class),
+                subnicheRepository,
+                angleRepository,
+                evidenceRepository);
+
+        var response = service.evaluateQualityGate(5L);
+
+        assertThat(response.approved()).isTrue();
+        assertThat(response.blockers()).isEmpty();
+    }
+
+    /** Verifica se evidência de outro seed é bloqueada para preservar rastreabilidade correta. */
+    @Test
+    void shouldRejectEvidenceForSubnicheFromAnotherSeed() {
+        OprmGeneralAudienceSeed seed = seed(1L);
+        OprmGeneralAudienceSubniche subniche = subniche();
+        subniche.setSeed(seed(2L));
+        OprmGeneralAudienceSeedRepository seedRepository = mock(OprmGeneralAudienceSeedRepository.class);
+        OprmGeneralAudienceSubnicheRepository subnicheRepository = subnicheRepositoryReturning(subniche);
+        when(seedRepository.findById(1L)).thenReturn(Optional.of(seed));
+        OprmGeneralAudienceDiscoveryService service = new OprmGeneralAudienceDiscoveryService(
+                seedRepository,
+                subnicheRepository,
+                mock(OprmGeneralAudiencePainAngleRepository.class),
+                mock(OprmGeneralAudienceSourceEvidenceRepository.class));
+
+        assertThatThrownBy(() -> service.createSourceEvidence(1L, new CreateGeneralAudienceSourceEvidenceRequest(
+                        5L,
+                        "https://example.com/forum",
+                        "example.com",
+                        "FORUM",
+                        "Manicures relatam agenda vazia em dias úteis.",
+                        Instant.parse("2026-06-10T12:00:00Z"))))
+                .isInstanceOf(ResponseStatusException.class)
+                .hasMessageContaining("não pertence à semente");
+    }
+
+    /** Monta serviço com repositório de subnicho e repositórios auxiliares mockados. */
+    private OprmGeneralAudienceDiscoveryService serviceWith(OprmGeneralAudienceSubnicheRepository subnicheRepository) {
+        OprmGeneralAudiencePainAngleRepository angleRepository = mock(OprmGeneralAudiencePainAngleRepository.class);
+        when(angleRepository.save(any())).thenAnswer(invocation -> {
+            OprmGeneralAudiencePainAngle angle = invocation.getArgument(0);
+            angle.setId(20L);
+            angle.setCreatedAt(Instant.parse("2026-06-10T12:00:00Z"));
+            angle.setUpdatedAt(Instant.parse("2026-06-10T12:00:00Z"));
+            return angle;
+        });
+        OprmGeneralAudienceSourceEvidenceRepository evidenceRepository = mock(OprmGeneralAudienceSourceEvidenceRepository.class);
+        when(evidenceRepository.save(any())).thenAnswer(invocation -> {
+            OprmGeneralAudienceSourceEvidence evidence = invocation.getArgument(0);
+            evidence.setId(30L);
+            return evidence;
+        });
+        return new OprmGeneralAudienceDiscoveryService(
+                mock(OprmGeneralAudienceSeedRepository.class),
+                subnicheRepository,
+                angleRepository,
+                evidenceRepository);
+    }
+
+    /** Monta repositório que retorna um subnicho específico. */
+    private OprmGeneralAudienceSubnicheRepository subnicheRepositoryReturning(OprmGeneralAudienceSubniche subniche) {
+        OprmGeneralAudienceSubnicheRepository repository = mock(OprmGeneralAudienceSubnicheRepository.class);
+        when(repository.findById(5L)).thenReturn(Optional.of(subniche));
+        return repository;
+    }
+
+    /** Monta uma semente mínima para testes. */
+    private OprmGeneralAudienceSeed seed(Long id) {
+        OprmGeneralAudienceSeed seed = new OprmGeneralAudienceSeed();
+        seed.setId(id);
+        seed.setName("Beleza");
+        return seed;
+    }
+
+    /** Monta um subnicho com dados suficientes para quality gate. */
+    private OprmGeneralAudienceSubniche subniche() {
+        OprmGeneralAudienceSubniche subniche = new OprmGeneralAudienceSubniche();
+        subniche.setId(5L);
+        subniche.setSeed(seed(1L));
+        subniche.setName("Manicure autônoma");
+        subniche.setPersonaSummary("Profissional que atende com agenda própria");
+        subniche.setPainSummary("Agenda vazia durante a semana");
+        subniche.setDesiredOutcomeSummary("Reativar clientes antigas");
+        subniche.setChannelsSummary("WhatsApp e Instagram");
+        subniche.setQualificationQuestion("Você trabalha como manicure hoje?");
+        return subniche;
+    }
+}

--- a/backend/ads-service/src/test/java/com/marketinghub/pipeline/service/PipelineServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/pipeline/service/PipelineServiceTest.java
@@ -311,7 +311,7 @@ class PipelineServiceTest {
      */
     @Test
     void shouldExposeOfficialStageAliasesAndCanonicalCodes() {
-        assertThat(definitionRegistry.officialPipelines()).hasSize(4);
+        assertThat(definitionRegistry.officialPipelines()).hasSize(5);
         assertThat(definitionRegistry.findByPipelineCode("experiment-pipeline")).hasValueSatisfying(pipeline -> {
             assertThat(pipeline.code()).isEqualTo("experiment-pipeline");
             assertThat(pipeline.stages()).hasSize(10);
@@ -528,6 +528,42 @@ class PipelineServiceTest {
             assertThat(pipeline.pipelineFieldPolicy().codeStructural()).isTrue();
             assertThat(pipeline.stageFieldPolicy().openAiModelOperational()).isTrue();
         });
+    }
+
+
+
+
+    /**
+     * Garante que o pipeline oficial de públicos gerais fica separado do pipeline NichoCNAE.
+     */
+    @Test
+    void shouldExposeOfficialOprmGeneralAudienceDiscoveryPipeline() {
+        assertThat(definitionRegistry.findByPipelineCode("OPRM_GENERAL_AUDIENCE_DISCOVERY"))
+                .hasValueSatisfying(pipeline -> {
+                    assertThat(pipeline.module()).isEqualTo("OPRM");
+                    assertThat(pipeline.name()).isEqualTo("Pipeline de Descoberta de Públicos Gerais");
+                    assertThat(pipeline.stages()).extracting(stage -> stage.operationalCode())
+                            .containsExactly(
+                                    "general-audience-seed-review",
+                                    "general-audience-subniche-discovery",
+                                    "general-audience-pain-mapping",
+                                    "general-audience-angle-builder",
+                                    "general-audience-quality-gate",
+                                    "general-audience-experiment-brief");
+                    assertThat(pipeline.stages())
+                            .allSatisfy(stage -> {
+                                assertThat(stage.rootPackage()).startsWith("com.marketinghub.oprm.generalaudience");
+                                assertThat(definitionRegistry.findStage(pipeline, stage.canonicalCode())).contains(stage);
+                                assertThat(definitionRegistry.findStage(pipeline, stage.operationalCode())).contains(stage);
+                            });
+                    assertThat(pipeline.stages())
+                            .filteredOn(stage -> stage.requiresOpenAiModel())
+                            .extracting(stage -> stage.operationalCode())
+                            .containsExactly(
+                                    "general-audience-subniche-discovery",
+                                    "general-audience-pain-mapping",
+                                    "general-audience-angle-builder");
+                });
     }
 
 

--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -331,3 +331,8 @@
 - Implementada a etapa 1 do plano de públicos gerais sem sobreposição CNAE: cadastro, listagem, detalhe, atualização e arquivamento manual de sementes de público geral no backend.
 - O fluxo permanece separado do NichoCNAE e não cria nicho, hipótese, experimento ou campanha automaticamente.
 - 2026-06-10 00:00:00 (UTC): executada a etapa 2 do plano de públicos gerais sem sobreposição com CNAE: o backend passou a persistir e expor subnichos derivados de sementes gerais em tabela própria `oprm_general_audience_subniche`, com endpoints OPRM para listar, cadastrar, detalhar, revisar, aprovar e rejeitar subnichos sem gravar esses públicos nas tabelas OPRM CNAE nem tratá-los como campanha pronta.
+
+## 2026-06-10 — Frontend operacional de públicos gerais OPRM
+
+- Implementada a fase 3 do plano de públicos gerais sem sobreposição CNAE: navegação interna OPRM com item **Públicos Gerais**, tela de listagem/cadastro de sementes, detalhe da semente com subnichos derivados e detalhe do subnicho com mapa de dores, linguagem, aprovação e rejeição.
+- Mantida a separação arquitetural entre Público Geral e NichoCNAE: a tela explicita a origem `Público Geral`, não grava dados como CNAE e deixa conversão para `MarketNiche`/experimento bloqueada para a fase futura prevista no plano.

--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -336,3 +336,9 @@
 
 - Implementada a fase 3 do plano de públicos gerais sem sobreposição CNAE: navegação interna OPRM com item **Públicos Gerais**, tela de listagem/cadastro de sementes, detalhe da semente com subnichos derivados e detalhe do subnicho com mapa de dores, linguagem, aprovação e rejeição.
 - Mantida a separação arquitetural entre Público Geral e NichoCNAE: a tela explicita a origem `Público Geral`, não grava dados como CNAE e deixa conversão para `MarketNiche`/experimento bloqueada para a fase futura prevista no plano.
+
+## 2026-06-10 — Pipeline de descoberta de públicos gerais OPRM
+
+- Implementada a fase 4 do plano de públicos gerais sem sobreposição CNAE: criado o pipeline oficial `OPRM_GENERAL_AUDIENCE_DISCOVERY`, com etapas de revisão de semente, descoberta de subnichos, mapeamento de dores, construção de ângulos seguros, quality gate e brief de experimento.
+- Criadas as tabelas próprias de dores/ângulos e evidências agregadas, mantendo públicos gerais fora das tabelas CNAE e persistindo apenas evidência resumida e rastreável.
+- Adicionados endpoints OPRM para cadastrar/listar/revisar/aprovar ângulos, registrar evidências agregadas e executar quality gate bloqueando saída genérica ou promessa arriscada antes de avanço comercial.

--- a/docs/swagger/oprm-general-audiences-swagger.yaml
+++ b/docs/swagger/oprm-general-audiences-swagger.yaml
@@ -1,7 +1,7 @@
 openapi: 3.0.3
 info:
   title: OPRM Públicos Gerais API
-  version: 0.2.0
+  version: 0.3.0
   description: Endpoints do backend para cadastro e revisão manual de sementes e subnichos de públicos gerais antes de virar nicho ou campanha.
 tags:
   - name: OPRM Públicos Gerais
@@ -195,6 +195,119 @@ paths:
                 $ref: '#/components/schemas/GeneralAudienceSubniche'
         '404':
           description: Subnicho não encontrado.
+  /api/oprm/general-audiences/subniches/{subnicheId}/pain-angles:
+    get:
+      summary: Lista dores e ângulos testáveis de um subnicho.
+      tags: [OPRM Públicos Gerais]
+      parameters:
+        - $ref: '#/components/parameters/SubnicheId'
+      responses:
+        '200':
+          description: Ângulos ordenados pela atualização mais recente.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/GeneralAudiencePainAngle'
+    post:
+      summary: Cadastra dor e ângulo seguro sem criar oferta final.
+      tags: [OPRM Públicos Gerais]
+      parameters:
+        - $ref: '#/components/parameters/SubnicheId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateGeneralAudiencePainAngleRequest'
+      responses:
+        '201':
+          description: Dor/ângulo cadastrado para revisão.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralAudiencePainAngle'
+        '400':
+          description: Dor genérica ou promessa arriscada.
+  /api/oprm/general-audiences/pain-angles/{angleId}:
+    patch:
+      summary: Atualiza uma dor e seu ângulo testável.
+      tags: [OPRM Públicos Gerais]
+      parameters:
+        - $ref: '#/components/parameters/AngleId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/UpdateGeneralAudiencePainAngleRequest'
+      responses:
+        '200':
+          description: Ângulo atualizado com validação de qualidade.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralAudiencePainAngle'
+  /api/oprm/general-audiences/pain-angles/{angleId}/approve:
+    post:
+      summary: Aprova um ângulo após validação de promessa segura.
+      tags: [OPRM Públicos Gerais]
+      parameters:
+        - $ref: '#/components/parameters/AngleId'
+      responses:
+        '200':
+          description: Ângulo aprovado para etapa futura de hipótese/experimento.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralAudiencePainAngle'
+  /api/oprm/general-audiences/seeds/{seedId}/source-evidences:
+    get:
+      summary: Lista evidências agregadas de uma semente.
+      tags: [OPRM Públicos Gerais]
+      parameters:
+        - $ref: '#/components/parameters/SeedId'
+      responses:
+        '200':
+          description: Evidências agregadas rastreáveis, sem dados pessoais.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/GeneralAudienceSourceEvidence'
+    post:
+      summary: Registra evidência agregada para semente ou subnicho.
+      tags: [OPRM Públicos Gerais]
+      parameters:
+        - $ref: '#/components/parameters/SeedId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateGeneralAudienceSourceEvidenceRequest'
+      responses:
+        '201':
+          description: Evidência agregada registrada.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralAudienceSourceEvidence'
+  /api/oprm/general-audiences/subniches/{subnicheId}/quality-gate:
+    get:
+      summary: Avalia se o subnicho pode avançar sem saída genérica ou promessa arriscada.
+      tags: [OPRM Públicos Gerais]
+      parameters:
+        - $ref: '#/components/parameters/SubnicheId'
+      responses:
+        '200':
+          description: Resultado do quality gate.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GeneralAudienceQualityGate'
 components:
   parameters:
     SeedId:
@@ -206,6 +319,13 @@ components:
         format: int64
     SubnicheId:
       name: subnicheId
+      in: path
+      required: true
+      schema:
+        type: integer
+        format: int64
+    AngleId:
+      name: angleId
       in: path
       required: true
       schema:
@@ -425,3 +545,111 @@ components:
         updatedAt:
           type: string
           format: date-time
+
+    PainAngleStatus:
+      type: string
+      enum: [DISCOVERED, NEEDS_REVIEW, APPROVED, REJECTED]
+    CreateGeneralAudiencePainAngleRequest:
+      type: object
+      required: [pain, desiredResult]
+      properties:
+        pain:
+          type: string
+        desiredResult:
+          type: string
+        mechanismDirection:
+          type: string
+          nullable: true
+        proofOrLeadMagnet:
+          type: string
+          nullable: true
+        safePromise:
+          type: string
+          nullable: true
+        firstAdHook:
+          type: string
+          nullable: true
+        landingConfirmationQuestion:
+          type: string
+          nullable: true
+        complianceNotes:
+          type: string
+          nullable: true
+        status:
+          $ref: '#/components/schemas/PainAngleStatus'
+    UpdateGeneralAudiencePainAngleRequest:
+      allOf:
+        - $ref: '#/components/schemas/CreateGeneralAudiencePainAngleRequest'
+    GeneralAudiencePainAngle:
+      allOf:
+        - $ref: '#/components/schemas/CreateGeneralAudiencePainAngleRequest'
+        - type: object
+          required: [id, subnicheId, pain, desiredResult, status, createdAt, updatedAt]
+          properties:
+            id:
+              type: integer
+              format: int64
+            subnicheId:
+              type: integer
+              format: int64
+            createdAt:
+              type: string
+              format: date-time
+            updatedAt:
+              type: string
+              format: date-time
+    CreateGeneralAudienceSourceEvidenceRequest:
+      type: object
+      required: [evidenceSummary]
+      properties:
+        subnicheId:
+          type: integer
+          format: int64
+          nullable: true
+        sourceUrl:
+          type: string
+          maxLength: 1024
+          nullable: true
+        sourceDomain:
+          type: string
+          maxLength: 191
+          nullable: true
+        sourceType:
+          type: string
+          maxLength: 64
+          nullable: true
+        evidenceSummary:
+          type: string
+        capturedAt:
+          type: string
+          format: date-time
+          nullable: true
+    GeneralAudienceSourceEvidence:
+      allOf:
+        - $ref: '#/components/schemas/CreateGeneralAudienceSourceEvidenceRequest'
+        - type: object
+          required: [id, seedId, evidenceSummary, capturedAt]
+          properties:
+            id:
+              type: integer
+              format: int64
+            seedId:
+              type: integer
+              format: int64
+    GeneralAudienceQualityGate:
+      type: object
+      required: [subnicheId, approved, blockers, recommendations]
+      properties:
+        subnicheId:
+          type: integer
+          format: int64
+        approved:
+          type: boolean
+        blockers:
+          type: array
+          items:
+            type: string
+        recommendations:
+          type: array
+          items:
+            type: string

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -112,6 +112,9 @@ import OprmCnaeVolumePage from "./pages/oprm/OprmCnaeVolumePage";
 import OprmPipelinePage from "./pages/oprm/OprmPipelinePage";
 import OprmNicheResearchSeedBuilderDetailPage from "./pages/oprm/OprmNicheResearchSeedBuilderDetailPage";
 import OprmEnrichedNicheDetailPage from "./pages/oprm/OprmEnrichedNicheDetailPage";
+import OprmGeneralAudiencesPage from "./pages/oprm/OprmGeneralAudiencesPage";
+import OprmGeneralAudienceSeedDetailPage from "./pages/oprm/OprmGeneralAudienceSeedDetailPage";
+import OprmGeneralAudienceSubnicheDetailPage from "./pages/oprm/OprmGeneralAudienceSubnicheDetailPage";
 import MoisWorkspacePage from "./pages/mois/MoisWorkspacePage";
 import MoisReferenceIntakePage from "./pages/mois/MoisReferenceIntakePage";
 import MoisExtractionPage from "./pages/mois/MoisExtractionPage";
@@ -320,6 +323,9 @@ export default function App() {
                 element={<OprmOperationsPage />}
               />
               <Route path="/oprm/pipeline" element={<OprmPipelinePage />} />
+              <Route path="/oprm/general-audiences" element={<OprmGeneralAudiencesPage />} />
+              <Route path="/oprm/general-audiences/seeds/:seedId" element={<OprmGeneralAudienceSeedDetailPage />} />
+              <Route path="/oprm/general-audiences/subniches/:subnicheId" element={<OprmGeneralAudienceSubnicheDetailPage />} />
               <Route path="/oprm/enriched-niches/profile/:profileId" element={<OprmEnrichedNicheDetailPage />} />
               <Route path="/oprm/pipeline/niche-research-seed-builder/:researchCycleId" element={<OprmNicheResearchSeedBuilderDetailPage />} />
               <Route

--- a/frontend/src/api/oprm/useOprmGeneralAudiences.ts
+++ b/frontend/src/api/oprm/useOprmGeneralAudiences.ts
@@ -1,0 +1,358 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { buildApiUrl } from "../../utils/buildApiUrl";
+
+export type OprmGeneralAudienceSeedType =
+  | "CATEGORY"
+  | "DESIRE"
+  | "LIFE_CONTEXT"
+  | "BEHAVIOR"
+  | "CHANNEL"
+  | "PAIN_CLUSTER";
+
+export type OprmGeneralAudienceSeedStatus =
+  | "DRAFT"
+  | "READY_FOR_RESEARCH"
+  | "RESEARCHING"
+  | "MAPPED"
+  | "PAUSED"
+  | "ARCHIVED";
+
+export type OprmGeneralAudienceSubnicheStatus =
+  | "DISCOVERED"
+  | "NEEDS_REVIEW"
+  | "APPROVED_FOR_EXPERIMENT"
+  | "REJECTED"
+  | "CONVERTED_TO_NICHE";
+
+export interface OprmGeneralAudienceSeedSummary {
+  id: number;
+  name: string;
+  marketContext?: string | null;
+  country: string;
+  language: string;
+  seedType: OprmGeneralAudienceSeedType;
+  status: OprmGeneralAudienceSeedStatus;
+  updatedAt: string;
+}
+
+export interface OprmGeneralAudienceSeed extends OprmGeneralAudienceSeedSummary {
+  description?: string | null;
+  businessGoal?: string | null;
+  riskNotes?: string | null;
+  createdAt: string;
+}
+
+export interface OprmGeneralAudienceSubnicheSummary {
+  id: number;
+  seedId: number;
+  name: string;
+  personaSummary?: string | null;
+  painSummary?: string | null;
+  channelsSummary?: string | null;
+  qualificationQuestion?: string | null;
+  status: OprmGeneralAudienceSubnicheStatus;
+  opportunityScore?: number | null;
+  riskScore?: number | null;
+  marketNicheId?: number | null;
+  updatedAt: string;
+}
+
+export interface OprmGeneralAudienceSubniche extends OprmGeneralAudienceSubnicheSummary {
+  desiredOutcomeSummary?: string | null;
+  languagePatterns?: string | null;
+  createdAt: string;
+}
+
+export interface CreateGeneralAudienceSeedPayload {
+  name: string;
+  description?: string;
+  marketContext?: string;
+  country?: string;
+  language?: string;
+  seedType: OprmGeneralAudienceSeedType;
+  status?: OprmGeneralAudienceSeedStatus;
+  businessGoal?: string;
+  riskNotes?: string;
+}
+
+export interface CreateGeneralAudienceSubnichePayload {
+  name: string;
+  personaSummary?: string;
+  painSummary?: string;
+  desiredOutcomeSummary?: string;
+  languagePatterns?: string;
+  channelsSummary?: string;
+  qualificationQuestion?: string;
+  status?: OprmGeneralAudienceSubnicheStatus;
+  opportunityScore?: number;
+  riskScore?: number;
+  marketNicheId?: number;
+}
+
+export const seedTypeLabels: Record<OprmGeneralAudienceSeedType, string> = {
+  CATEGORY: "Categoria ampla",
+  DESIRE: "Desejo amplo",
+  LIFE_CONTEXT: "Contexto de vida",
+  BEHAVIOR: "Comportamento",
+  CHANNEL: "Canal",
+  PAIN_CLUSTER: "Cluster de dores",
+};
+
+export const seedStatusLabels: Record<OprmGeneralAudienceSeedStatus, string> = {
+  DRAFT: "Rascunho",
+  READY_FOR_RESEARCH: "Pronta para pesquisa",
+  RESEARCHING: "Pesquisando",
+  MAPPED: "Mapeada",
+  PAUSED: "Pausada",
+  ARCHIVED: "Arquivada",
+};
+
+export const subnicheStatusLabels: Record<
+  OprmGeneralAudienceSubnicheStatus,
+  string
+> = {
+  DISCOVERED: "Descoberto",
+  NEEDS_REVIEW: "Precisa revisão",
+  APPROVED_FOR_EXPERIMENT: "Aprovado para experimento",
+  REJECTED: "Rejeitado",
+  CONVERTED_TO_NICHE: "Convertido em nicho",
+};
+
+const generalAudienceKeys = {
+  seeds: ["oprm", "general-audiences", "seeds"] as const,
+  seed: (seedId: number) =>
+    ["oprm", "general-audiences", "seeds", seedId] as const,
+  subniches: (seedId: number) =>
+    ["oprm", "general-audiences", "seeds", seedId, "subniches"] as const,
+  subniche: (subnicheId: number) =>
+    ["oprm", "general-audiences", "subniches", subnicheId] as const,
+};
+
+async function parseJsonResponse<T>(response: Response, errorMessage: string) {
+  if (!response.ok) {
+    throw new Error(`${errorMessage} (status ${response.status}).`);
+  }
+  return (await response.json()) as T;
+}
+
+async function sendJson<T>(
+  path: string,
+  method: "POST" | "PATCH",
+  payload?: unknown,
+  errorMessage = "Não foi possível concluir a operação",
+) {
+  const response = await fetch(buildApiUrl(path), {
+    method,
+    headers: { "Content-Type": "application/json" },
+    body: payload == null ? undefined : JSON.stringify(payload),
+  });
+  return parseJsonResponse<T>(response, errorMessage);
+}
+
+export function useOprmGeneralAudienceSeeds() {
+  return useQuery({
+    queryKey: generalAudienceKeys.seeds,
+    queryFn: async () => {
+      const response = await fetch(
+        buildApiUrl("/api/oprm/general-audiences/seeds"),
+      );
+      return parseJsonResponse<OprmGeneralAudienceSeedSummary[]>(
+        response,
+        "Não foi possível carregar as sementes de públicos gerais",
+      );
+    },
+  });
+}
+
+export function useOprmGeneralAudienceSeed(seedId?: number) {
+  return useQuery({
+    queryKey: seedId
+      ? generalAudienceKeys.seed(seedId)
+      : ["oprm", "general-audience-seed", "missing"],
+    enabled: seedId != null,
+    queryFn: async () => {
+      const response = await fetch(
+        buildApiUrl(`/api/oprm/general-audiences/seeds/${seedId}`),
+      );
+      return parseJsonResponse<OprmGeneralAudienceSeed>(
+        response,
+        "Não foi possível carregar a semente de público geral",
+      );
+    },
+  });
+}
+
+export function useOprmGeneralAudienceSubniches(seedId?: number) {
+  return useQuery({
+    queryKey: seedId
+      ? generalAudienceKeys.subniches(seedId)
+      : ["oprm", "general-audience-subniches", "missing"],
+    enabled: seedId != null,
+    queryFn: async () => {
+      const response = await fetch(
+        buildApiUrl(`/api/oprm/general-audiences/seeds/${seedId}/subniches`),
+      );
+      return parseJsonResponse<OprmGeneralAudienceSubnicheSummary[]>(
+        response,
+        "Não foi possível carregar os subnichos da semente",
+      );
+    },
+  });
+}
+
+export function useOprmGeneralAudienceSubniche(subnicheId?: number) {
+  return useQuery({
+    queryKey: subnicheId
+      ? generalAudienceKeys.subniche(subnicheId)
+      : ["oprm", "general-audience-subniche", "missing"],
+    enabled: subnicheId != null,
+    queryFn: async () => {
+      const response = await fetch(
+        buildApiUrl(`/api/oprm/general-audiences/subniches/${subnicheId}`),
+      );
+      return parseJsonResponse<OprmGeneralAudienceSubniche>(
+        response,
+        "Não foi possível carregar o subnicho de público geral",
+      );
+    },
+  });
+}
+
+export function useCreateOprmGeneralAudienceSeed() {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (payload: CreateGeneralAudienceSeedPayload) =>
+      sendJson<OprmGeneralAudienceSeed>(
+        "/api/oprm/general-audiences/seeds",
+        "POST",
+        payload,
+        "Não foi possível criar a semente de público geral",
+      ),
+    onSuccess: (seed) => {
+      queryClient.invalidateQueries({ queryKey: generalAudienceKeys.seeds });
+      queryClient.setQueryData(generalAudienceKeys.seed(seed.id), seed);
+    },
+  });
+}
+
+export function useUpdateOprmGeneralAudienceSeed(seedId: number) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (payload: Partial<CreateGeneralAudienceSeedPayload>) =>
+      sendJson<OprmGeneralAudienceSeed>(
+        `/api/oprm/general-audiences/seeds/${seedId}`,
+        "PATCH",
+        payload,
+        "Não foi possível atualizar a semente de público geral",
+      ),
+    onSuccess: (seed) => {
+      queryClient.invalidateQueries({ queryKey: generalAudienceKeys.seeds });
+      queryClient.setQueryData(generalAudienceKeys.seed(seed.id), seed);
+    },
+  });
+}
+
+export function useArchiveOprmGeneralAudienceSeed(seedId: number) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: () =>
+      sendJson<OprmGeneralAudienceSeed>(
+        `/api/oprm/general-audiences/seeds/${seedId}/archive`,
+        "POST",
+        undefined,
+        "Não foi possível arquivar a semente de público geral",
+      ),
+    onSuccess: (seed) => {
+      queryClient.invalidateQueries({ queryKey: generalAudienceKeys.seeds });
+      queryClient.setQueryData(generalAudienceKeys.seed(seed.id), seed);
+    },
+  });
+}
+
+export function useCreateOprmGeneralAudienceSubniche(seedId: number) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (payload: CreateGeneralAudienceSubnichePayload) =>
+      sendJson<OprmGeneralAudienceSubniche>(
+        `/api/oprm/general-audiences/seeds/${seedId}/subniches`,
+        "POST",
+        payload,
+        "Não foi possível criar o subnicho de público geral",
+      ),
+    onSuccess: (subniche) => {
+      queryClient.invalidateQueries({
+        queryKey: generalAudienceKeys.subniches(seedId),
+      });
+      queryClient.setQueryData(
+        generalAudienceKeys.subniche(subniche.id),
+        subniche,
+      );
+    },
+  });
+}
+
+export function useUpdateOprmGeneralAudienceSubniche(subnicheId: number) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (payload: Partial<CreateGeneralAudienceSubnichePayload>) =>
+      sendJson<OprmGeneralAudienceSubniche>(
+        `/api/oprm/general-audiences/subniches/${subnicheId}`,
+        "PATCH",
+        payload,
+        "Não foi possível atualizar o subnicho de público geral",
+      ),
+    onSuccess: (subniche) => {
+      queryClient.invalidateQueries({
+        queryKey: generalAudienceKeys.subniches(subniche.seedId),
+      });
+      queryClient.setQueryData(
+        generalAudienceKeys.subniche(subniche.id),
+        subniche,
+      );
+    },
+  });
+}
+
+export function useApproveOprmGeneralAudienceSubniche(subnicheId: number) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: () =>
+      sendJson<OprmGeneralAudienceSubniche>(
+        `/api/oprm/general-audiences/subniches/${subnicheId}/approve`,
+        "POST",
+        undefined,
+        "Não foi possível aprovar o subnicho de público geral",
+      ),
+    onSuccess: (subniche) => {
+      queryClient.invalidateQueries({
+        queryKey: generalAudienceKeys.subniches(subniche.seedId),
+      });
+      queryClient.setQueryData(
+        generalAudienceKeys.subniche(subniche.id),
+        subniche,
+      );
+    },
+  });
+}
+
+export function useRejectOprmGeneralAudienceSubniche(subnicheId: number) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: () =>
+      sendJson<OprmGeneralAudienceSubniche>(
+        `/api/oprm/general-audiences/subniches/${subnicheId}/reject`,
+        "POST",
+        undefined,
+        "Não foi possível rejeitar o subnicho de público geral",
+      ),
+    onSuccess: (subniche) => {
+      queryClient.invalidateQueries({
+        queryKey: generalAudienceKeys.subniches(subniche.seedId),
+      });
+      queryClient.setQueryData(
+        generalAudienceKeys.subniche(subniche.id),
+        subniche,
+      );
+    },
+  });
+}

--- a/frontend/src/components/MainNavigation.tsx
+++ b/frontend/src/components/MainNavigation.tsx
@@ -118,6 +118,11 @@ const NAV_SECTIONS: NavSection[] = [
             icon: Workflow,
             end: true,
           },
+          {
+            to: "/oprm/general-audiences",
+            label: "Públicos Gerais",
+            icon: Users,
+          },
         ],
       },
       { to: "/mds", label: "MDS", icon: Microscope },

--- a/frontend/src/pages/oprm/OprmGeneralAudienceSeedDetailPage.tsx
+++ b/frontend/src/pages/oprm/OprmGeneralAudienceSeedDetailPage.tsx
@@ -1,0 +1,450 @@
+import { FormEvent, useEffect, useState } from "react";
+import { Link, useNavigate, useParams } from "react-router-dom";
+import PageTitle from "../../components/PageTitle";
+import {
+  CreateGeneralAudienceSubnichePayload,
+  OprmGeneralAudienceSeedStatus,
+  seedStatusLabels,
+  seedTypeLabels,
+  subnicheStatusLabels,
+  useArchiveOprmGeneralAudienceSeed,
+  useCreateOprmGeneralAudienceSubniche,
+  useOprmGeneralAudienceSeed,
+  useOprmGeneralAudienceSubniches,
+  useUpdateOprmGeneralAudienceSeed,
+} from "../../api/oprm/useOprmGeneralAudiences";
+import OprmModuleNavigation from "./OprmModuleNavigation";
+
+const seedStatusOptions: OprmGeneralAudienceSeedStatus[] = [
+  "DRAFT",
+  "READY_FOR_RESEARCH",
+  "RESEARCHING",
+  "MAPPED",
+  "PAUSED",
+  "ARCHIVED",
+];
+
+function parseRouteId(value: string | undefined) {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
+}
+
+function formatDateTime(value: string | undefined) {
+  if (!value) {
+    return "-";
+  }
+  return new Date(value).toLocaleString("pt-BR");
+}
+
+function scoreLabel(value: number | null | undefined) {
+  return value == null ? "Pendente" : value.toLocaleString("pt-BR");
+}
+
+export default function OprmGeneralAudienceSeedDetailPage() {
+  const { seedId: seedIdParam } = useParams();
+  const navigate = useNavigate();
+  const seedId = parseRouteId(seedIdParam);
+  const seedQuery = useOprmGeneralAudienceSeed(seedId);
+  const subnichesQuery = useOprmGeneralAudienceSubniches(seedId);
+  const updateSeed = useUpdateOprmGeneralAudienceSeed(seedId ?? 0);
+  const archiveSeed = useArchiveOprmGeneralAudienceSeed(seedId ?? 0);
+  const createSubniche = useCreateOprmGeneralAudienceSubniche(seedId ?? 0);
+  const [status, setStatus] = useState<OprmGeneralAudienceSeedStatus>("DRAFT");
+  const [subnicheForm, setSubnicheForm] =
+    useState<CreateGeneralAudienceSubnichePayload>({
+      name: "",
+      personaSummary: "",
+      painSummary: "",
+      desiredOutcomeSummary: "",
+      languagePatterns: "",
+      channelsSummary: "",
+      qualificationQuestion: "",
+      status: "DISCOVERED",
+    });
+
+  useEffect(() => {
+    if (seedQuery.data?.status) {
+      setStatus(seedQuery.data.status);
+    }
+  }, [seedQuery.data?.status]);
+
+  if (!seedId) {
+    return <div className="alert alert-danger">Semente inválida.</div>;
+  }
+
+  async function handleStatusSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    await updateSeed.mutateAsync({ status });
+  }
+
+  async function handleArchive() {
+    await archiveSeed.mutateAsync();
+    setStatus("ARCHIVED");
+  }
+
+  async function handleSubnicheSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const subniche = await createSubniche.mutateAsync(subnicheForm);
+    setSubnicheForm({
+      name: "",
+      personaSummary: "",
+      painSummary: "",
+      desiredOutcomeSummary: "",
+      languagePatterns: "",
+      channelsSummary: "",
+      qualificationQuestion: "",
+      status: "DISCOVERED",
+    });
+    navigate(`/oprm/general-audiences/subniches/${subniche.id}`);
+  }
+
+  const seed = seedQuery.data;
+
+  return (
+    <div className="d-flex flex-column gap-4">
+      <header className="d-flex flex-column gap-2">
+        <PageTitle>{seed?.name ?? "Semente de Público Geral"}</PageTitle>
+        <p className="text-secondary mb-0">
+          Revise a semente como ponto de partida amplo. Ela não deve ser tratada
+          como CNAE, campanha ou oferta final.
+        </p>
+      </header>
+
+      <OprmModuleNavigation />
+
+      {seedQuery.isLoading ? (
+        <div
+          className="spinner-border text-primary"
+          role="status"
+          aria-label="Carregando semente"
+        />
+      ) : null}
+      {seedQuery.isError ? (
+        <div className="alert alert-danger">
+          Não foi possível carregar a semente de público geral.
+        </div>
+      ) : null}
+
+      {seed ? (
+        <>
+          <section className="card border-0 shadow-sm">
+            <div className="card-body">
+              <div className="d-flex justify-content-between align-items-start gap-3 flex-wrap">
+                <div>
+                  <h2 className="h5 mb-2">Contexto da semente</h2>
+                  <p className="text-secondary mb-0">
+                    Origem: Público Geral → {seed.name}. Próximo passo: quebrar
+                    em subnichos com dores e linguagem real.
+                  </p>
+                </div>
+                <Link
+                  className="btn btn-outline-secondary btn-sm"
+                  to="/oprm/general-audiences"
+                >
+                  Voltar para públicos gerais
+                </Link>
+              </div>
+              <dl className="row mt-4 mb-0">
+                <dt className="col-md-3">Tipo</dt>
+                <dd className="col-md-9">{seedTypeLabels[seed.seedType]}</dd>
+                <dt className="col-md-3">Status</dt>
+                <dd className="col-md-9">{seedStatusLabels[seed.status]}</dd>
+                <dt className="col-md-3">Mercado</dt>
+                <dd className="col-md-9">
+                  {seed.marketContext || "Sem contexto informado"}
+                </dd>
+                <dt className="col-md-3">Objetivo comercial</dt>
+                <dd className="col-md-9">
+                  {seed.businessGoal || "Sem objetivo informado"}
+                </dd>
+                <dt className="col-md-3">Riscos</dt>
+                <dd className="col-md-9">
+                  {seed.riskNotes || "Sem risco informado"}
+                </dd>
+                <dt className="col-md-3">Atualização</dt>
+                <dd className="col-md-9">{formatDateTime(seed.updatedAt)}</dd>
+              </dl>
+            </div>
+          </section>
+
+          <section className="card border-0 shadow-sm">
+            <div className="card-body">
+              <h2 className="h5 mb-3">Controle operacional</h2>
+              <form
+                className="d-flex gap-2 align-items-end flex-wrap"
+                onSubmit={handleStatusSubmit}
+              >
+                <div>
+                  <label className="form-label" htmlFor="seed-status">
+                    Status <span className="text-danger">*</span>
+                  </label>
+                  <select
+                    id="seed-status"
+                    className="form-select"
+                    value={status}
+                    onChange={(event) =>
+                      setStatus(
+                        event.target.value as OprmGeneralAudienceSeedStatus,
+                      )
+                    }
+                    required
+                  >
+                    {seedStatusOptions.map((option) => (
+                      <option key={option} value={option}>
+                        {seedStatusLabels[option]}
+                      </option>
+                    ))}
+                  </select>
+                </div>
+                <button
+                  type="submit"
+                  className="btn btn-primary"
+                  disabled={updateSeed.isPending}
+                >
+                  {updateSeed.isPending ? (
+                    <span
+                      className="spinner-border spinner-border-sm me-2"
+                      aria-hidden="true"
+                    />
+                  ) : null}
+                  Salvar status
+                </button>
+                <button
+                  type="button"
+                  className="btn btn-outline-danger"
+                  onClick={handleArchive}
+                  disabled={archiveSeed.isPending || seed.status === "ARCHIVED"}
+                >
+                  {archiveSeed.isPending ? (
+                    <span
+                      className="spinner-border spinner-border-sm me-2"
+                      aria-hidden="true"
+                    />
+                  ) : null}
+                  Arquivar
+                </button>
+              </form>
+              {updateSeed.isError || archiveSeed.isError ? (
+                <div className="alert alert-danger mt-3 mb-0">
+                  Não foi possível atualizar a semente.
+                </div>
+              ) : null}
+            </div>
+          </section>
+        </>
+      ) : null}
+
+      <section className="card border-0 shadow-sm">
+        <div className="card-body">
+          <h2 className="h5 mb-2">Cadastrar subnicho manual</h2>
+          <p className="text-secondary">
+            O subnicho precisa representar uma pessoa específica, uma dor clara
+            e uma forma de confirmar se o lead pertence ao público.
+          </p>
+          <form className="row g-3" onSubmit={handleSubnicheSubmit}>
+            <div className="col-md-4">
+              <label className="form-label" htmlFor="subniche-name">
+                Nome do subnicho <span className="text-danger">*</span>
+              </label>
+              <input
+                id="subniche-name"
+                className="form-control"
+                value={subnicheForm.name}
+                onChange={(event) =>
+                  setSubnicheForm((current) => ({
+                    ...current,
+                    name: event.target.value,
+                  }))
+                }
+                required
+                maxLength={191}
+                placeholder="Ex.: manicure autônoma"
+              />
+            </div>
+            <div className="col-md-4">
+              <label className="form-label" htmlFor="subniche-persona">
+                Persona/contexto
+              </label>
+              <input
+                id="subniche-persona"
+                className="form-control"
+                value={subnicheForm.personaSummary}
+                onChange={(event) =>
+                  setSubnicheForm((current) => ({
+                    ...current,
+                    personaSummary: event.target.value,
+                  }))
+                }
+                placeholder="Quem é e qual rotina importa"
+              />
+            </div>
+            <div className="col-md-4">
+              <label className="form-label" htmlFor="subniche-question">
+                Pergunta qualificadora
+              </label>
+              <input
+                id="subniche-question"
+                className="form-control"
+                value={subnicheForm.qualificationQuestion}
+                onChange={(event) =>
+                  setSubnicheForm((current) => ({
+                    ...current,
+                    qualificationQuestion: event.target.value,
+                  }))
+                }
+                placeholder="Ex.: Você trabalha como manicure hoje?"
+              />
+            </div>
+            <div className="col-md-6">
+              <label className="form-label" htmlFor="subniche-pain">
+                Dores recorrentes
+              </label>
+              <textarea
+                id="subniche-pain"
+                className="form-control"
+                rows={3}
+                value={subnicheForm.painSummary}
+                onChange={(event) =>
+                  setSubnicheForm((current) => ({
+                    ...current,
+                    painSummary: event.target.value,
+                  }))
+                }
+                placeholder="Agenda vazia, clientes somem, medo de cobrar mais..."
+              />
+            </div>
+            <div className="col-md-6">
+              <label className="form-label" htmlFor="subniche-language">
+                Linguagem e canais
+              </label>
+              <textarea
+                id="subniche-language"
+                className="form-control"
+                rows={3}
+                value={subnicheForm.languagePatterns}
+                onChange={(event) =>
+                  setSubnicheForm((current) => ({
+                    ...current,
+                    languagePatterns: event.target.value,
+                    channelsSummary: event.target.value,
+                  }))
+                }
+                placeholder="Como esse público fala da dor e onde aparece"
+              />
+            </div>
+            {createSubniche.isError ? (
+              <div className="col-12">
+                <div className="alert alert-danger mb-0">
+                  Não foi possível criar o subnicho. Revise os campos.
+                </div>
+              </div>
+            ) : null}
+            <div className="col-12">
+              <button
+                type="submit"
+                className="btn btn-primary"
+                disabled={createSubniche.isPending}
+              >
+                {createSubniche.isPending ? (
+                  <span
+                    className="spinner-border spinner-border-sm me-2"
+                    aria-hidden="true"
+                  />
+                ) : null}
+                Criar subnicho
+              </button>
+            </div>
+          </form>
+        </div>
+      </section>
+
+      <section className="card border-0 shadow-sm">
+        <div className="card-body">
+          <div className="d-flex justify-content-between align-items-start gap-3 mb-3">
+            <div>
+              <h2 className="h5 mb-1">Subnichos derivados</h2>
+              <p className="text-secondary mb-0">
+                Só aprove subnichos com persona, dor, canais e pergunta de
+                triagem claros.
+              </p>
+            </div>
+            <button
+              type="button"
+              className="btn btn-outline-secondary btn-sm"
+              onClick={() => subnichesQuery.refetch()}
+              disabled={subnichesQuery.isFetching}
+            >
+              {subnichesQuery.isFetching ? (
+                <span
+                  className="spinner-border spinner-border-sm me-2"
+                  aria-hidden="true"
+                />
+              ) : null}
+              Atualizar
+            </button>
+          </div>
+          {subnichesQuery.isLoading ? (
+            <div
+              className="spinner-border text-primary"
+              role="status"
+              aria-label="Carregando subnichos"
+            />
+          ) : null}
+          {subnichesQuery.isError ? (
+            <div className="alert alert-danger">
+              Não foi possível carregar os subnichos desta semente.
+            </div>
+          ) : null}
+          {!subnichesQuery.isLoading && !subnichesQuery.isError ? (
+            <div className="table-responsive">
+              <table className="table table-sm align-middle mb-0">
+                <thead>
+                  <tr>
+                    <th>Subnicho</th>
+                    <th>Status</th>
+                    <th>Dor</th>
+                    <th>Pergunta</th>
+                    <th>Score</th>
+                    <th>Ação</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {(subnichesQuery.data ?? []).length > 0 ? (
+                    (subnichesQuery.data ?? []).map((subniche) => (
+                      <tr key={subniche.id}>
+                        <td>{subniche.name}</td>
+                        <td>{subnicheStatusLabels[subniche.status]}</td>
+                        <td className="text-secondary">
+                          {subniche.painSummary || "Dor pendente"}
+                        </td>
+                        <td className="text-secondary">
+                          {subniche.qualificationQuestion ||
+                            "Pergunta pendente"}
+                        </td>
+                        <td>{scoreLabel(subniche.opportunityScore)}</td>
+                        <td>
+                          <Link
+                            className="btn btn-sm btn-outline-primary"
+                            to={`/oprm/general-audiences/subniches/${subniche.id}`}
+                          >
+                            Revisar
+                          </Link>
+                        </td>
+                      </tr>
+                    ))
+                  ) : (
+                    <tr>
+                      <td colSpan={6} className="text-secondary">
+                        Nenhum subnicho cadastrado ainda.
+                      </td>
+                    </tr>
+                  )}
+                </tbody>
+              </table>
+            </div>
+          ) : null}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/frontend/src/pages/oprm/OprmGeneralAudienceSubnicheDetailPage.tsx
+++ b/frontend/src/pages/oprm/OprmGeneralAudienceSubnicheDetailPage.tsx
@@ -1,0 +1,408 @@
+import { FormEvent, useEffect, useState } from "react";
+import { Link, useParams } from "react-router-dom";
+import PageTitle from "../../components/PageTitle";
+import {
+  OprmGeneralAudienceSubnicheStatus,
+  subnicheStatusLabels,
+  useApproveOprmGeneralAudienceSubniche,
+  useOprmGeneralAudienceSubniche,
+  useRejectOprmGeneralAudienceSubniche,
+  useUpdateOprmGeneralAudienceSubniche,
+} from "../../api/oprm/useOprmGeneralAudiences";
+import OprmModuleNavigation from "./OprmModuleNavigation";
+
+function parseRouteId(value: string | undefined) {
+  const parsed = Number(value);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : undefined;
+}
+
+function formatDateTime(value: string | undefined) {
+  if (!value) {
+    return "-";
+  }
+  return new Date(value).toLocaleString("pt-BR");
+}
+
+function emptyToUndefined(value: string) {
+  const trimmed = value.trim();
+  return trimmed.length > 0 ? trimmed : undefined;
+}
+
+export default function OprmGeneralAudienceSubnicheDetailPage() {
+  const { subnicheId: subnicheIdParam } = useParams();
+  const subnicheId = parseRouteId(subnicheIdParam);
+  const subnicheQuery = useOprmGeneralAudienceSubniche(subnicheId);
+  const updateSubniche = useUpdateOprmGeneralAudienceSubniche(subnicheId ?? 0);
+  const approveSubniche = useApproveOprmGeneralAudienceSubniche(
+    subnicheId ?? 0,
+  );
+  const rejectSubniche = useRejectOprmGeneralAudienceSubniche(subnicheId ?? 0);
+  const [form, setForm] = useState({
+    personaSummary: "",
+    painSummary: "",
+    desiredOutcomeSummary: "",
+    languagePatterns: "",
+    channelsSummary: "",
+    qualificationQuestion: "",
+    opportunityScore: "",
+    riskScore: "",
+  });
+
+  useEffect(() => {
+    const subniche = subnicheQuery.data;
+    if (subniche) {
+      setForm({
+        personaSummary: subniche.personaSummary ?? "",
+        painSummary: subniche.painSummary ?? "",
+        desiredOutcomeSummary: subniche.desiredOutcomeSummary ?? "",
+        languagePatterns: subniche.languagePatterns ?? "",
+        channelsSummary: subniche.channelsSummary ?? "",
+        qualificationQuestion: subniche.qualificationQuestion ?? "",
+        opportunityScore: subniche.opportunityScore?.toString() ?? "",
+        riskScore: subniche.riskScore?.toString() ?? "",
+      });
+    }
+  }, [subnicheQuery.data]);
+
+  if (!subnicheId) {
+    return <div className="alert alert-danger">Subnicho inválido.</div>;
+  }
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    await updateSubniche.mutateAsync({
+      personaSummary: emptyToUndefined(form.personaSummary),
+      painSummary: emptyToUndefined(form.painSummary),
+      desiredOutcomeSummary: emptyToUndefined(form.desiredOutcomeSummary),
+      languagePatterns: emptyToUndefined(form.languagePatterns),
+      channelsSummary: emptyToUndefined(form.channelsSummary),
+      qualificationQuestion: emptyToUndefined(form.qualificationQuestion),
+      opportunityScore: form.opportunityScore
+        ? Number(form.opportunityScore)
+        : undefined,
+      riskScore: form.riskScore ? Number(form.riskScore) : undefined,
+    });
+  }
+
+  async function handleStatusAction(status: "approve" | "reject") {
+    if (status === "approve") {
+      await approveSubniche.mutateAsync();
+      return;
+    }
+    await rejectSubniche.mutateAsync();
+  }
+
+  const subniche = subnicheQuery.data;
+  const isActionPending =
+    approveSubniche.isPending ||
+    rejectSubniche.isPending ||
+    updateSubniche.isPending;
+  const isApproved = subniche?.status === "APPROVED_FOR_EXPERIMENT";
+  const isRejected = subniche?.status === "REJECTED";
+  const status = subniche?.status as
+    | OprmGeneralAudienceSubnicheStatus
+    | undefined;
+
+  return (
+    <div className="d-flex flex-column gap-4">
+      <header className="d-flex flex-column gap-2">
+        <PageTitle>{subniche?.name ?? "Subnicho de Público Geral"}</PageTitle>
+        <p className="text-secondary mb-0">
+          Revise se o subnicho tem persona, dor, resultado desejado, linguagem
+          real, canais e pergunta qualificadora antes de avançar para
+          experimento.
+        </p>
+      </header>
+
+      <OprmModuleNavigation />
+
+      {subnicheQuery.isLoading ? (
+        <div
+          className="spinner-border text-primary"
+          role="status"
+          aria-label="Carregando subnicho"
+        />
+      ) : null}
+      {subnicheQuery.isError ? (
+        <div className="alert alert-danger">
+          Não foi possível carregar o subnicho de público geral.
+        </div>
+      ) : null}
+
+      {subniche ? (
+        <>
+          <section className="card border-0 shadow-sm">
+            <div className="card-body">
+              <div className="d-flex justify-content-between align-items-start gap-3 flex-wrap">
+                <div>
+                  <h2 className="h5 mb-2">Mapa de dores e linguagem</h2>
+                  <p className="text-secondary mb-0">
+                    Origem: Público Geral → Semente #{subniche.seedId} →{" "}
+                    {subniche.name}. Este registro ainda não é oferta final.
+                  </p>
+                </div>
+                <Link
+                  className="btn btn-outline-secondary btn-sm"
+                  to={`/oprm/general-audiences/seeds/${subniche.seedId}`}
+                >
+                  Voltar para semente
+                </Link>
+              </div>
+              <dl className="row mt-4 mb-0">
+                <dt className="col-md-3">Status</dt>
+                <dd className="col-md-9">
+                  {status ? subnicheStatusLabels[status] : "-"}
+                </dd>
+                <dt className="col-md-3">Pergunta qualificadora</dt>
+                <dd className="col-md-9">
+                  {subniche.qualificationQuestion || "Pendente"}
+                </dd>
+                <dt className="col-md-3">Última atualização</dt>
+                <dd className="col-md-9">
+                  {formatDateTime(subniche.updatedAt)}
+                </dd>
+              </dl>
+            </div>
+          </section>
+
+          <section className="card border-0 shadow-sm">
+            <div className="card-body">
+              <h2 className="h5 mb-3">Revisão comercial</h2>
+              <form className="row g-3" onSubmit={handleSubmit}>
+                <div className="col-md-6">
+                  <label className="form-label" htmlFor="persona-summary">
+                    Persona e contexto
+                  </label>
+                  <textarea
+                    id="persona-summary"
+                    className="form-control"
+                    rows={3}
+                    value={form.personaSummary}
+                    onChange={(event) =>
+                      setForm((current) => ({
+                        ...current,
+                        personaSummary: event.target.value,
+                      }))
+                    }
+                  />
+                </div>
+                <div className="col-md-6">
+                  <label className="form-label" htmlFor="pain-summary">
+                    Dores reais
+                  </label>
+                  <textarea
+                    id="pain-summary"
+                    className="form-control"
+                    rows={3}
+                    value={form.painSummary}
+                    onChange={(event) =>
+                      setForm((current) => ({
+                        ...current,
+                        painSummary: event.target.value,
+                      }))
+                    }
+                  />
+                </div>
+                <div className="col-md-6">
+                  <label className="form-label" htmlFor="desired-outcome">
+                    Resultado desejado
+                  </label>
+                  <textarea
+                    id="desired-outcome"
+                    className="form-control"
+                    rows={3}
+                    value={form.desiredOutcomeSummary}
+                    onChange={(event) =>
+                      setForm((current) => ({
+                        ...current,
+                        desiredOutcomeSummary: event.target.value,
+                      }))
+                    }
+                  />
+                </div>
+                <div className="col-md-6">
+                  <label className="form-label" htmlFor="language-patterns">
+                    Linguagem real
+                  </label>
+                  <textarea
+                    id="language-patterns"
+                    className="form-control"
+                    rows={3}
+                    value={form.languagePatterns}
+                    onChange={(event) =>
+                      setForm((current) => ({
+                        ...current,
+                        languagePatterns: event.target.value,
+                      }))
+                    }
+                  />
+                </div>
+                <div className="col-md-6">
+                  <label className="form-label" htmlFor="channels-summary">
+                    Canais e sinais de aquisição
+                  </label>
+                  <textarea
+                    id="channels-summary"
+                    className="form-control"
+                    rows={3}
+                    value={form.channelsSummary}
+                    onChange={(event) =>
+                      setForm((current) => ({
+                        ...current,
+                        channelsSummary: event.target.value,
+                      }))
+                    }
+                  />
+                </div>
+                <div className="col-md-6">
+                  <label
+                    className="form-label"
+                    htmlFor="qualification-question"
+                  >
+                    Pergunta qualificadora
+                  </label>
+                  <textarea
+                    id="qualification-question"
+                    className="form-control"
+                    rows={3}
+                    value={form.qualificationQuestion}
+                    onChange={(event) =>
+                      setForm((current) => ({
+                        ...current,
+                        qualificationQuestion: event.target.value,
+                      }))
+                    }
+                  />
+                </div>
+                <div className="col-md-3">
+                  <label className="form-label" htmlFor="opportunity-score">
+                    Score de oportunidade
+                  </label>
+                  <input
+                    id="opportunity-score"
+                    type="number"
+                    min="0"
+                    max="100"
+                    step="0.01"
+                    className="form-control"
+                    value={form.opportunityScore}
+                    onChange={(event) =>
+                      setForm((current) => ({
+                        ...current,
+                        opportunityScore: event.target.value,
+                      }))
+                    }
+                  />
+                </div>
+                <div className="col-md-3">
+                  <label className="form-label" htmlFor="risk-score">
+                    Score de risco
+                  </label>
+                  <input
+                    id="risk-score"
+                    type="number"
+                    min="0"
+                    max="100"
+                    step="0.01"
+                    className="form-control"
+                    value={form.riskScore}
+                    onChange={(event) =>
+                      setForm((current) => ({
+                        ...current,
+                        riskScore: event.target.value,
+                      }))
+                    }
+                  />
+                </div>
+                {updateSubniche.isError ? (
+                  <div className="col-12">
+                    <div className="alert alert-danger mb-0">
+                      Não foi possível salvar a revisão do subnicho.
+                    </div>
+                  </div>
+                ) : null}
+                <div className="col-12">
+                  <button
+                    type="submit"
+                    className="btn btn-primary"
+                    disabled={isActionPending}
+                  >
+                    {updateSubniche.isPending ? (
+                      <span
+                        className="spinner-border spinner-border-sm me-2"
+                        aria-hidden="true"
+                      />
+                    ) : null}
+                    Salvar mapa
+                  </button>
+                </div>
+              </form>
+            </div>
+          </section>
+
+          <section className="card border-0 shadow-sm">
+            <div className="card-body">
+              <h2 className="h5 mb-2">Ações de decisão</h2>
+              <p className="text-secondary">
+                Aprovar libera o subnicho para etapa futura de ângulos e
+                experimento. Rejeitar evita que público amplo ou inseguro vire
+                campanha.
+              </p>
+              <div className="d-flex gap-2 flex-wrap">
+                <button
+                  type="button"
+                  className="btn btn-success"
+                  onClick={() => handleStatusAction("approve")}
+                  disabled={isActionPending || isApproved}
+                >
+                  {approveSubniche.isPending ? (
+                    <span
+                      className="spinner-border spinner-border-sm me-2"
+                      aria-hidden="true"
+                    />
+                  ) : null}
+                  Aprovar para experimento
+                </button>
+                <button
+                  type="button"
+                  className="btn btn-outline-danger"
+                  onClick={() => handleStatusAction("reject")}
+                  disabled={isActionPending || isRejected}
+                >
+                  {rejectSubniche.isPending ? (
+                    <span
+                      className="spinner-border spinner-border-sm me-2"
+                      aria-hidden="true"
+                    />
+                  ) : null}
+                  Rejeitar
+                </button>
+                <button
+                  type="button"
+                  className="btn btn-outline-secondary"
+                  disabled
+                  title="Conversão para MarketNiche pertence à fase 5 do plano para manter controle arquitetural."
+                >
+                  Converter em nicho — fase 5
+                </button>
+                <button
+                  type="button"
+                  className="btn btn-outline-secondary"
+                  disabled
+                  title="Criação de experimento de lead pertence à fase 5 do plano."
+                >
+                  Criar experimento de lead — fase 5
+                </button>
+              </div>
+              {approveSubniche.isError || rejectSubniche.isError ? (
+                <div className="alert alert-danger mt-3 mb-0">
+                  Não foi possível registrar a decisão do subnicho.
+                </div>
+              ) : null}
+            </div>
+          </section>
+        </>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/src/pages/oprm/OprmGeneralAudiencesPage.tsx
+++ b/frontend/src/pages/oprm/OprmGeneralAudiencesPage.tsx
@@ -1,0 +1,309 @@
+import { FormEvent, useMemo, useState } from "react";
+import { Link, useNavigate } from "react-router-dom";
+import PageTitle from "../../components/PageTitle";
+import {
+  OprmGeneralAudienceSeedType,
+  seedStatusLabels,
+  seedTypeLabels,
+  useCreateOprmGeneralAudienceSeed,
+  useOprmGeneralAudienceSeeds,
+} from "../../api/oprm/useOprmGeneralAudiences";
+import OprmModuleNavigation from "./OprmModuleNavigation";
+
+const seedTypeOptions: OprmGeneralAudienceSeedType[] = [
+  "CATEGORY",
+  "DESIRE",
+  "LIFE_CONTEXT",
+  "BEHAVIOR",
+  "CHANNEL",
+  "PAIN_CLUSTER",
+];
+
+function formatDateTime(value: string | undefined) {
+  if (!value) {
+    return "-";
+  }
+  return new Date(value).toLocaleString("pt-BR");
+}
+
+export default function OprmGeneralAudiencesPage() {
+  const navigate = useNavigate();
+  const seedsQuery = useOprmGeneralAudienceSeeds();
+  const createSeed = useCreateOprmGeneralAudienceSeed();
+  const [name, setName] = useState("");
+  const [seedType, setSeedType] =
+    useState<OprmGeneralAudienceSeedType>("CATEGORY");
+  const [marketContext, setMarketContext] = useState("");
+  const [businessGoal, setBusinessGoal] = useState("");
+  const [riskNotes, setRiskNotes] = useState("");
+
+  const summary = useMemo(() => {
+    const seeds = seedsQuery.data ?? [];
+    return {
+      total: seeds.length,
+      ready: seeds.filter((seed) => seed.status === "READY_FOR_RESEARCH")
+        .length,
+      mapped: seeds.filter((seed) => seed.status === "MAPPED").length,
+      pausedOrArchived: seeds.filter(
+        (seed) => seed.status === "PAUSED" || seed.status === "ARCHIVED",
+      ).length,
+    };
+  }, [seedsQuery.data]);
+
+  async function handleSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    const seed = await createSeed.mutateAsync({
+      name,
+      seedType,
+      marketContext,
+      businessGoal,
+      riskNotes,
+      country: "BR",
+      language: "pt-BR",
+      status: "DRAFT",
+    });
+    navigate(`/oprm/general-audiences/seeds/${seed.id}`);
+  }
+
+  return (
+    <div className="d-flex flex-column gap-4">
+      <header className="d-flex flex-column gap-2">
+        <PageTitle>OPRM — Públicos Gerais</PageTitle>
+        <p className="text-secondary mb-0">
+          Cadastre sementes amplas, quebre em subnichos e valide dores antes de
+          criar qualquer nicho, hipótese ou experimento. Este fluxo é separado
+          do NichoCNAE para evitar sobreposição e campanhas genéricas.
+        </p>
+      </header>
+
+      <OprmModuleNavigation />
+
+      <section className="row g-3">
+        <div className="col-md-3">
+          <div className="card border-0 shadow-sm h-100">
+            <div className="card-body">
+              <p className="text-secondary mb-1">Sementes</p>
+              <strong className="h3 mb-0">{summary.total}</strong>
+            </div>
+          </div>
+        </div>
+        <div className="col-md-3">
+          <div className="card border-0 shadow-sm h-100">
+            <div className="card-body">
+              <p className="text-secondary mb-1">Prontas</p>
+              <strong className="h3 mb-0">{summary.ready}</strong>
+            </div>
+          </div>
+        </div>
+        <div className="col-md-3">
+          <div className="card border-0 shadow-sm h-100">
+            <div className="card-body">
+              <p className="text-secondary mb-1">Mapeadas</p>
+              <strong className="h3 mb-0">{summary.mapped}</strong>
+            </div>
+          </div>
+        </div>
+        <div className="col-md-3">
+          <div className="card border-0 shadow-sm h-100">
+            <div className="card-body">
+              <p className="text-secondary mb-1">Pausadas/arquivadas</p>
+              <strong className="h3 mb-0">{summary.pausedOrArchived}</strong>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="card border-0 shadow-sm">
+        <div className="card-body">
+          <h2 className="h5 mb-2">Nova semente manual</h2>
+          <p className="text-secondary">
+            Use somente mercados amplos que ainda precisam virar subnichos com
+            dor, linguagem, isca e pergunta qualificadora.
+          </p>
+          <form className="row g-3" onSubmit={handleSubmit}>
+            <div className="col-md-4">
+              <label className="form-label" htmlFor="general-audience-name">
+                Nome da semente <span className="text-danger">*</span>
+              </label>
+              <input
+                id="general-audience-name"
+                className="form-control"
+                value={name}
+                onChange={(event) => setName(event.target.value)}
+                required
+                maxLength={191}
+                placeholder="Ex.: Beleza para autônomas"
+              />
+            </div>
+            <div className="col-md-3">
+              <label className="form-label" htmlFor="general-audience-type">
+                Tipo <span className="text-danger">*</span>
+              </label>
+              <select
+                id="general-audience-type"
+                className="form-select"
+                value={seedType}
+                onChange={(event) =>
+                  setSeedType(event.target.value as OprmGeneralAudienceSeedType)
+                }
+                required
+              >
+                {seedTypeOptions.map((type) => (
+                  <option key={type} value={type}>
+                    {seedTypeLabels[type]}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div className="col-md-5">
+              <label className="form-label" htmlFor="general-audience-market">
+                Contexto de mercado
+              </label>
+              <input
+                id="general-audience-market"
+                className="form-control"
+                value={marketContext}
+                onChange={(event) => setMarketContext(event.target.value)}
+                placeholder="Ex.: profissionais que dependem de agenda, WhatsApp e Instagram"
+              />
+            </div>
+            <div className="col-md-6">
+              <label className="form-label" htmlFor="general-audience-goal">
+                Objetivo comercial
+              </label>
+              <textarea
+                id="general-audience-goal"
+                className="form-control"
+                rows={3}
+                value={businessGoal}
+                onChange={(event) => setBusinessGoal(event.target.value)}
+                placeholder="Qual venda futura este público pode sustentar?"
+              />
+            </div>
+            <div className="col-md-6">
+              <label className="form-label" htmlFor="general-audience-risk">
+                Risco/compliance
+              </label>
+              <textarea
+                id="general-audience-risk"
+                className="form-control"
+                rows={3}
+                value={riskNotes}
+                onChange={(event) => setRiskNotes(event.target.value)}
+                placeholder="Promessas proibidas, sensibilidades e cuidados"
+              />
+            </div>
+            {createSeed.isError ? (
+              <div className="col-12">
+                <div className="alert alert-danger mb-0">
+                  Não foi possível criar a semente. Revise os campos e tente
+                  novamente.
+                </div>
+              </div>
+            ) : null}
+            <div className="col-12">
+              <button
+                type="submit"
+                className="btn btn-primary"
+                disabled={createSeed.isPending}
+              >
+                {createSeed.isPending ? (
+                  <span
+                    className="spinner-border spinner-border-sm me-2"
+                    aria-hidden="true"
+                  />
+                ) : null}
+                Criar semente
+              </button>
+            </div>
+          </form>
+        </div>
+      </section>
+
+      <section className="card border-0 shadow-sm">
+        <div className="card-body">
+          <div className="d-flex justify-content-between align-items-start gap-3 mb-3">
+            <div>
+              <h2 className="h5 mb-1">Sementes cadastradas</h2>
+              <p className="text-secondary mb-0">
+                Acompanhe a origem ampla antes de aprovar subnichos específicos.
+              </p>
+            </div>
+            <button
+              type="button"
+              className="btn btn-outline-secondary btn-sm"
+              onClick={() => seedsQuery.refetch()}
+              disabled={seedsQuery.isFetching}
+            >
+              {seedsQuery.isFetching ? (
+                <span
+                  className="spinner-border spinner-border-sm me-2"
+                  aria-hidden="true"
+                />
+              ) : null}
+              Atualizar
+            </button>
+          </div>
+
+          {seedsQuery.isLoading ? (
+            <div
+              className="spinner-border text-primary"
+              role="status"
+              aria-label="Carregando sementes"
+            />
+          ) : null}
+          {seedsQuery.isError ? (
+            <div className="alert alert-danger">
+              Não foi possível carregar as sementes de públicos gerais.
+            </div>
+          ) : null}
+          {!seedsQuery.isLoading && !seedsQuery.isError ? (
+            <div className="table-responsive">
+              <table className="table table-sm align-middle mb-0">
+                <thead>
+                  <tr>
+                    <th>Semente</th>
+                    <th>Tipo</th>
+                    <th>Status</th>
+                    <th>Contexto</th>
+                    <th>Atualização</th>
+                    <th>Ação</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {(seedsQuery.data ?? []).length > 0 ? (
+                    (seedsQuery.data ?? []).map((seed) => (
+                      <tr key={seed.id}>
+                        <td>{seed.name}</td>
+                        <td>{seedTypeLabels[seed.seedType]}</td>
+                        <td>{seedStatusLabels[seed.status]}</td>
+                        <td className="text-secondary">
+                          {seed.marketContext || "Sem contexto informado"}
+                        </td>
+                        <td>{formatDateTime(seed.updatedAt)}</td>
+                        <td>
+                          <Link
+                            className="btn btn-sm btn-outline-primary"
+                            to={`/oprm/general-audiences/seeds/${seed.id}`}
+                          >
+                            Abrir
+                          </Link>
+                        </td>
+                      </tr>
+                    ))
+                  ) : (
+                    <tr>
+                      <td colSpan={6} className="text-secondary">
+                        Nenhuma semente cadastrada ainda.
+                      </td>
+                    </tr>
+                  )}
+                </tbody>
+              </table>
+            </div>
+          ) : null}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/frontend/src/pages/oprm/OprmModuleNavigation.tsx
+++ b/frontend/src/pages/oprm/OprmModuleNavigation.tsx
@@ -5,8 +5,9 @@ interface OprmModuleNavigationProps {
 }
 
 const navigationItems = [
-  { label: "CNAEs", to: "/oprm" },
+  { label: "CNAEs", to: "/oprm", end: true },
   { label: "Pipeline", to: "/oprm/pipeline" },
+  { label: "Públicos Gerais", to: "/oprm/general-audiences" },
 ];
 
 export default function OprmModuleNavigation({
@@ -19,6 +20,7 @@ export default function OprmModuleNavigation({
           <li className="nav-item" key={item.to}>
             <NavLink
               to={item.to}
+              end={item.end}
               className={({ isActive }) =>
                 isActive ? "nav-link active" : "nav-link"
               }


### PR DESCRIPTION
### Motivation
- Add an operational, non-CNAE OPRM flow to register and review broad market "seeds" and derived subniches so the product can discover subnichos/angles without contaminating the existing CNAE pipeline. 
- Provide manual controls for review/quality (create/list/detail/update/archive/approve/reject) to follow the phased plan and avoid automatic conversion to MarketNiche/experiments until later phases. 
- Keep architecture boundaries and contracts clear so frontend changes remain inside the OPRM scope and do not write CNAE data or bypass backend quality gates.

### Description
- Added TanStack Query hooks and typed contracts in `frontend/src/api/oprm/useOprmGeneralAudiences.ts` to call the new backend endpoints for seeds and subniches (list/get/create/patch/archive/approve/reject). 
- Implemented the UI pages: `OprmGeneralAudiencesPage` (list, dashboard, create seed), `OprmGeneralAudienceSeedDetailPage` (seed detail, status/archive controls, create subniche), and `OprmGeneralAudienceSubnicheDetailPage` (pain/language map, commercial review, approve/reject). 
- Registered routes and navigation: global menu entry and OPRM internal navigation item `OPRM → Públicos Gerais`, and added routes `/oprm/general-audiences`, `/oprm/general-audiences/seeds/:seedId`, and `/oprm/general-audiences/subniches/:subnicheId` in `frontend/src/App.tsx`, plus internal nav in `OprmModuleNavigation`. 
- Documentation update: appended a record of the frontend Phase 3 delivery to `docs/registros/oprm1.md`; the UI explicitly preserves separation from the NichoCNAE flow and disables conversion/experiment creation (phase-5 actions) in the UI to keep the architectural boundary. 

### Testing
- Ran `npm run typecheck` in `frontend` and TypeScript type-check passed. 
- Ran `npm run build` in `frontend` and the Vite production build completed successfully (build passed with a large-chunk advisory only). 
- Captured a UI screenshot using `npx playwright screenshot http://127.0.0.1:5173/oprm/general-audiences /tmp/oprm-general-audiences.png` which produced a saved screenshot at `/tmp/oprm-general-audiences.png` after installing Playwright browsers and OS deps; the screenshot step succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a28e2bec54883208cb3fb388f08bd76)