### PR TITLE
Corrige NPE no teste do orquestrador OPRM ao injetar mocks faltantes

### DIFF
--- a/backend/ads-service/src/test/java/com/marketinghub/oprm/nichocnae/routineresearchorchestrator/service/BackendRoutineResearchOrchestratorServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/oprm/nichocnae/routineresearchorchestrator/service/BackendRoutineResearchOrchestratorServiceTest.java
@@ -12,7 +12,9 @@ import com.marketinghub.oprm.nichocnae.routineresearchorchestrator.service.pendi
 import com.marketinghub.oprm.nichocnae.routineresearchorchestrator.service.recent.RecordRoutineResearchOrchestratorRecent;
 import com.marketinghub.oprm.nichocnae.routineresearchorchestrator.service.runNext.RecordRoutineResearchOrchestratorResult;
 import com.marketinghub.repository.jpa.oprm.cnae.OprmNicheCandidateRepository;
+import com.marketinghub.repository.jpa.oprm.nichocnae.OprmNicheRoutineCardRepository;
 import com.marketinghub.repository.jpa.oprm.nichocnae.OprmRoutineResearchCycleRepository;
+import com.marketinghub.repository.jpa.oprm.nichocnae.meiaudienceprofile.OprmMeiAudienceProfileRepository;
 import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.List;
@@ -31,6 +33,10 @@ class BackendRoutineResearchOrchestratorServiceTest {
     @Mock private OprmNicheCandidateRepository nicheCandidateRepository;
 
     @Mock private OprmRoutineResearchCycleRepository routineResearchCycleRepository;
+
+    @Mock private OprmMeiAudienceProfileRepository meiAudienceProfileRepository;
+
+    @Mock private OprmNicheRoutineCardRepository routineCardRepository;
 
     @InjectMocks private BackendRoutineResearchOrchestratorService service;
 

--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -344,3 +344,5 @@
 - Implementada a fase 4 do plano de públicos gerais sem sobreposição CNAE: criado o pipeline oficial `OPRM_GENERAL_AUDIENCE_DISCOVERY`, com etapas de revisão de semente, descoberta de subnichos, mapeamento de dores, construção de ângulos seguros, quality gate e brief de experimento.
 - Criadas as tabelas próprias de dores/ângulos e evidências agregadas, mantendo públicos gerais fora das tabelas CNAE e persistindo apenas evidência resumida e rastreável.
 - Adicionados endpoints OPRM para cadastrar/listar/revisar/aprovar ângulos, registrar evidências agregadas e executar quality gate bloqueando saída genérica ou promessa arriscada antes de avanço comercial.
+
+- 2026-06-10 14:03:12 (UTC): corrigida a causa-raiz do erro de teste em `BackendRoutineResearchOrchestratorServiceTest`: o serviço passou a depender dos repositórios de perfil MEI e card de rotina para montar o histórico recente, mas o teste ainda não injetava mocks dessas dependências, gerando `NullPointerException` antes da validação do contrato.


### PR DESCRIPTION
### Motivation
- O serviço `BackendRoutineResearchOrchestratorService` passou a depender dos repositórios de perfil MEI e do card de rotina para montar o histórico recente, e o teste não criava mocks dessas dependências causando `NullPointerException` ao chamar `findFirstByResearchCycleIdOrderByIdDesc(...)`.

### Description
- Adiciona mocks `@Mock private OprmMeiAudienceProfileRepository meiAudienceProfileRepository` e `@Mock private OprmNicheRoutineCardRepository routineCardRepository` no teste `backend/ads-service/src/test/java/com/marketinghub/oprm/nichocnae/routineresearchorchestrator/service/BackendRoutineResearchOrchestratorServiceTest.java` para satisfazer o construtor do serviço.
- Atualiza o registro operacional em `docs/registros/oprm1.md` documentando a causa-raiz e a correção.

### Testing
- Executado o teste específico com `JAVA_HOME=/root/.local/share/mise/installs/java/21.0.2 PATH=/root/.local/share/mise/installs/java/21.0.2/bin:$PATH ../mvnw -q -Dtest=BackendRoutineResearchOrchestratorServiceTest test` e os testes relevantes foram executados com sucesso.
- Observação: uma execução inicial do `../mvnw -Dtest=BackendRoutineResearchOrchestratorServiceTest test` com o Java padrão do ambiente (`openjdk 25`) falhou por incompatibilidade na fase de compilação (Lombok/javac); a execução de verificação foi repetida com Java 21 conforme o padrão do backend e passou.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a296e2601308320acc5d3e7aee04825)