### PR TITLE
Support market-warmup prioritization, stuck-job metric and reprocess action

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/dto/MoisSalesLibraryDtos.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/dto/MoisSalesLibraryDtos.java
@@ -4,6 +4,7 @@ import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotEmpty;
 import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
 import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.List;
@@ -259,6 +260,7 @@ public final class MoisSalesLibraryDtos {
             long marketWarmupWarm,
             long marketWarmupCold,
             long marketWarmupSaturated,
+            long marketWarmupStuck,
             Instant updatedAt
     ) {
     }
@@ -702,6 +704,26 @@ public final class MoisSalesLibraryDtos {
     public record MarketWarmupClaimResponse(
             boolean claimed,
             MarketWarmupClaimedJob job
+    ) {
+    }
+
+    /**
+     * Representa a solicitação operacional para reprocessar jobs de aquecimento presos em execução antiga.
+     */
+    public record MarketWarmupReprocessStaleRequest(
+            @NotBlank String workspaceId,
+            @Positive Integer staleMinutes
+    ) {
+    }
+
+    /**
+     * Representa o resultado da ação de saneamento que refileira jobs presos sem acesso direto ao banco.
+     */
+    public record MarketWarmupReprocessStaleResponse(
+            String workspaceId,
+            int staleMinutes,
+            long requeuedJobs,
+            Instant updatedAt
     ) {
     }
 

--- a/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryService.java
@@ -469,18 +469,25 @@ public class MoisSalesLibraryService {
      * Lista páginas canônicas consolidadas priorizando as análises mais recentes para a UI operacional.
      */
     public MoisSalesLibraryDtos.SalesLibraryPageListResponse listPages(String workspaceId, int page, int pageSize) {
+        return listPages(workspaceId, page, pageSize, null, "RECENT_ANALYSIS");
+    }
+
+    /**
+     * Lista páginas canônicas com filtro e ordenação de aquecimento para priorização comercial da Etapa 3.
+     */
+    public MoisSalesLibraryDtos.SalesLibraryPageListResponse listPages(
+            String workspaceId,
+            int page,
+            int pageSize,
+            String marketWarmupFilter,
+            String sort
+    ) {
         int normalizedPage = Math.max(1, page);
         int normalizedPageSize = Math.max(1, Math.min(pageSize, 100));
         int offset = (normalizedPage - 1) * normalizedPageSize;
-        Long total = jdbcTemplate.queryForObject("SELECT COUNT(*) FROM mois_sales_page WHERE workspace_id = ?", Long.class, workspaceId);
-        List<MoisSalesLibraryDtos.SalesLibraryPageResponse> items = jdbcTemplate.query("""
-                SELECT p.id, p.workspace_id, p.source, p.url_canonical, p.title, p.current_stage, p.current_status, p.capture_status,
-                       COALESCE(p.analysis_status, p.current_status) AS analysis_status, p.url_final, p.http_status, p.html_sha256,
-                       p.html_bytes, p.score_total, p.offer_summary, p.mechanism_summary, p.promise_summary, p.proof_summary,
-                       p.last_error_category, p.last_error_message, p.last_job_execution_id, p.last_captured_at, p.last_analyzed_at, p.updated_at,
-                       mws.score_total AS market_warmup_score_total, mws.market_temperature AS market_warmup_temperature,
-                       mws.ecosystem_type AS market_warmup_ecosystem_type, mws.recommendation AS market_warmup_recommendation,
-                       mwj.status AS market_warmup_status, COALESCE(mws.updated_at, mwj.updated_at) AS market_warmup_updated_at
+        String warmupCondition = resolveMarketWarmupFilterCondition(marketWarmupFilter);
+        String orderBy = resolveSalesPageOrderBy(sort);
+        String joins = """
                 FROM mois_sales_page p
                 LEFT JOIN (
                     SELECT sales_page_id, MAX(id) AS latest_warmup_job_id
@@ -490,9 +497,46 @@ public class MoisSalesLibraryService {
                 LEFT JOIN mois_sales_page_market_warmup_job mwj ON mwj.id = mwj_latest.latest_warmup_job_id
                 LEFT JOIN mois_sales_page_market_warmup_summary mws ON mws.job_id = mwj.id
                 WHERE p.workspace_id = ?
-                ORDER BY p.last_analyzed_at DESC, p.updated_at DESC, p.id DESC LIMIT ? OFFSET ?
-                """, this::mapSalesPageResponse, workspaceId, normalizedPageSize, offset);
+                """ + warmupCondition;
+        Long total = jdbcTemplate.queryForObject("SELECT COUNT(*) " + joins, Long.class, workspaceId);
+        List<MoisSalesLibraryDtos.SalesLibraryPageResponse> items = jdbcTemplate.query("""
+                SELECT p.id, p.workspace_id, p.source, p.url_canonical, p.title, p.current_stage, p.current_status, p.capture_status,
+                       COALESCE(p.analysis_status, p.current_status) AS analysis_status, p.url_final, p.http_status, p.html_sha256,
+                       p.html_bytes, p.score_total, p.offer_summary, p.mechanism_summary, p.promise_summary, p.proof_summary,
+                       p.last_error_category, p.last_error_message, p.last_job_execution_id, p.last_captured_at, p.last_analyzed_at, p.updated_at,
+                       mws.score_total AS market_warmup_score_total, mws.market_temperature AS market_warmup_temperature,
+                       mws.ecosystem_type AS market_warmup_ecosystem_type, mws.recommendation AS market_warmup_recommendation,
+                       mwj.status AS market_warmup_status, COALESCE(mws.updated_at, mwj.updated_at) AS market_warmup_updated_at
+                """ + joins + " ORDER BY " + orderBy + " LIMIT ? OFFSET ?",
+                this::mapSalesPageResponse, workspaceId, normalizedPageSize, offset);
         return new MoisSalesLibraryDtos.SalesLibraryPageListResponse(normalizedPage, normalizedPageSize, total == null ? 0 : total, items);
+    }
+
+    /**
+     * Converte o filtro público de aquecimento em condição SQL fixa para evitar concatenação de entrada do usuário.
+     */
+    private String resolveMarketWarmupFilterCondition(String marketWarmupFilter) {
+        if (marketWarmupFilter == null || marketWarmupFilter.isBlank()) {
+            return "";
+        }
+        return switch (marketWarmupFilter) {
+            case "WITH_DOSSIER" -> " AND mwj.status = 'DONE' AND mws.job_id IS NOT NULL\n";
+            case "PENDING_OR_RUNNING" -> " AND mwj.status IN ('PENDING', 'FETCHING')\n";
+            case "FAILED" -> " AND mwj.status = 'FAILED'\n";
+            case "HOT_OR_PROMISING" -> " AND mws.market_temperature IN ('HOT', 'PROMISING')\n";
+            case "WITHOUT_DOSSIER" -> " AND mwj.id IS NULL\n";
+            default -> "";
+        };
+    }
+
+    /**
+     * Converte a ordenação pública em cláusula SQL fixa para a listagem operacional da biblioteca.
+     */
+    private String resolveSalesPageOrderBy(String sort) {
+        if ("MARKET_WARMUP_SCORE".equals(sort)) {
+            return "mws.score_total IS NULL ASC, mws.score_total DESC, COALESCE(mws.updated_at, mwj.updated_at) DESC, p.last_analyzed_at DESC, p.id DESC";
+        }
+        return "p.last_analyzed_at DESC, p.updated_at DESC, p.id DESC";
     }
 
     /**
@@ -522,6 +566,8 @@ public class MoisSalesLibraryService {
                        SUM(mws.market_temperature = 'WARM') AS market_warmup_warm,
                        SUM(mws.market_temperature = 'COLD') AS market_warmup_cold,
                        SUM(mws.market_temperature = 'SATURATED') AS market_warmup_saturated,
+                       SUM(mwj.status = 'FETCHING'
+                           AND COALESCE(mwj.started_at, mwj.updated_at, mwj.created_at) < DATE_SUB(UTC_TIMESTAMP(), INTERVAL 120 MINUTE)) AS market_warmup_stuck,
                        MAX(p.updated_at) AS updated_at
                 FROM mois_sales_page p
                 LEFT JOIN (
@@ -542,7 +588,7 @@ public class MoisSalesLibraryService {
                 rs.getLong("market_warmup_failed"), rs.getLong("market_warmup_hot"),
                 rs.getLong("market_warmup_promising"), rs.getLong("market_warmup_warm"),
                 rs.getLong("market_warmup_cold"), rs.getLong("market_warmup_saturated"),
-                toInstant(rs.getTimestamp("updated_at"))), workspaceId);
+                rs.getLong("market_warmup_stuck"), toInstant(rs.getTimestamp("updated_at"))), workspaceId);
     }
 
     /**

--- a/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesPageMarketWarmupService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesPageMarketWarmupService.java
@@ -10,6 +10,7 @@ import com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1.Mois
 import com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1.MoisSalesPageMarketWarmupGateway.MarketWarmupSummaryData;
 import com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1.MoisSalesPageMarketWarmupGateway.MarketWarmupSummaryWriteData;
 import com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1.MoisSalesPageMarketWarmupGateway.SalesPageWarmupData;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
@@ -25,6 +26,8 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 @Slf4j
 public class MoisSalesPageMarketWarmupService {
+
+    private static final int DEFAULT_STALE_MINUTES = 120;
 
     private final MoisSalesPageMarketWarmupGateway gateway;
     private final MoisSalesPageMarketWarmupScoreEngine scoreEngine = new MoisSalesPageMarketWarmupScoreEngine();
@@ -102,10 +105,14 @@ public class MoisSalesPageMarketWarmupService {
             MarketWarmupClaimData pending = gateway.findNextPendingJob(request.workspaceId())
                     .orElse(null);
             if (pending == null) {
+                log.info("Nenhum job de aquecimento MOIS pendente para reserva. modulo=MOIS, operacao=claimMarketWarmupJob, workspaceId={}, workerId={}",
+                        request.workspaceId(), request.workerId());
                 return new MoisSalesLibraryDtos.MarketWarmupClaimResponse(false, null);
             }
             boolean claimed = gateway.claimPendingJob(pending.job().jobId(), request.workerId());
             if (!claimed) {
+                log.warn("Job de aquecimento MOIS não foi reservado por concorrência operacional. modulo=MOIS, operacao=claimMarketWarmupJob, workspaceId={}, workerId={}, jobId={}",
+                        request.workspaceId(), request.workerId(), pending.job().jobId());
                 return new MoisSalesLibraryDtos.MarketWarmupClaimResponse(false, null);
             }
             SalesPageWarmupData page = pending.page();
@@ -132,6 +139,8 @@ public class MoisSalesPageMarketWarmupService {
             if (mapJobStatus(job.status()) == MoisSalesLibraryDtos.MarketWarmupJobStatus.DONE) {
                 throw new IllegalStateException("Job de aquecimento já concluído: " + jobId);
             }
+            log.info("Iniciando conclusão do job de aquecimento MOIS. modulo=MOIS, operacao=completeMarketWarmupJob, workspaceId={}, pageId={}, jobId={}, fontesRecebidas={}, sinaisRecebidos={}",
+                    job.workspaceId(), job.pageId(), jobId, request.sources().size(), request.signals().size());
             gateway.deleteJobDetails(jobId);
             List<Long> sourceIds = persistSources(job, request.sources());
             persistSignals(job, sourceIds, request.signals());
@@ -157,11 +166,31 @@ public class MoisSalesPageMarketWarmupService {
             if (!failed) {
                 throw new IllegalStateException("Job de aquecimento não encontrado ou não pode falhar: " + jobId);
             }
-            log.info("Job de aquecimento MOIS marcado como falho. modulo=MOIS, operacao=failMarketWarmupJob, jobId={}, errorCategory={}",
-                    jobId, request.errorCategory());
+            log.info("Job de aquecimento MOIS marcado como falho. modulo=MOIS, operacao=failMarketWarmupJob, jobId={}, errorCategory={}, errorMessage={}",
+                    jobId, request.errorCategory(), request.errorMessage());
         } catch (RuntimeException ex) {
             log.error("Falha ao registrar erro de job de aquecimento MOIS. modulo=MOIS, operacao=failMarketWarmupJob, jobId={}, erroClasse={}, erro={}",
                     jobId, ex.getClass().getName(), ex.getMessage(), ex);
+            throw ex;
+        }
+    }
+
+    /**
+     * Refileira jobs antigos presos em FETCHING para permitir nova execução sem intervenção direta no banco.
+     */
+    @Transactional
+    public MoisSalesLibraryDtos.MarketWarmupReprocessStaleResponse reprocessStaleJobs(
+            MoisSalesLibraryDtos.MarketWarmupReprocessStaleRequest request
+    ) {
+        int staleMinutes = request.staleMinutes() == null ? DEFAULT_STALE_MINUTES : request.staleMinutes();
+        try {
+            long requeued = gateway.requeueStaleFetchingJobs(request.workspaceId(), staleMinutes);
+            log.info("Jobs de aquecimento MOIS presos refileirados. modulo=MOIS, operacao=reprocessStaleMarketWarmupJobs, workspaceId={}, staleMinutes={}, requeuedJobs={}",
+                    request.workspaceId(), staleMinutes, requeued);
+            return new MoisSalesLibraryDtos.MarketWarmupReprocessStaleResponse(request.workspaceId(), staleMinutes, requeued, Instant.now());
+        } catch (RuntimeException ex) {
+            log.error("Falha ao reprocessar jobs de aquecimento MOIS presos. modulo=MOIS, operacao=reprocessStaleMarketWarmupJobs, workspaceId={}, staleMinutes={}, erroClasse={}, erro={}",
+                    request.workspaceId(), staleMinutes, ex.getClass().getName(), ex.getMessage(), ex);
             throw ex;
         }
     }
@@ -171,8 +200,12 @@ public class MoisSalesPageMarketWarmupService {
      */
     private List<Long> persistSources(MarketWarmupJobData job, List<MoisSalesLibraryDtos.MarketWarmupSourceCompleteItem> sources) {
         List<Long> sourceIds = new ArrayList<>();
-        for (MoisSalesLibraryDtos.MarketWarmupSourceCompleteItem source : sources) {
-            sourceIds.add(gateway.insertSource(job.jobId(), job.pageId(), job.workspaceId(), mapSourceWrite(source)));
+        for (int index = 0; index < sources.size(); index++) {
+            MoisSalesLibraryDtos.MarketWarmupSourceCompleteItem source = sources.get(index);
+            long sourceId = gateway.insertSource(job.jobId(), job.pageId(), job.workspaceId(), mapSourceWrite(source));
+            sourceIds.add(sourceId);
+            log.info("Fonte pública de aquecimento MOIS persistida. modulo=MOIS, operacao=completeMarketWarmupJob, workspaceId={}, pageId={}, jobId={}, sourceIndex={}, sourceId={}, platform={}, sourceType={}, sourceUrl={}",
+                    job.workspaceId(), job.pageId(), job.jobId(), index, sourceId, source.platform(), source.sourceType(), source.sourceUrl());
         }
         return sourceIds;
     }

--- a/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/web/MoisSalesLibraryController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/web/MoisSalesLibraryController.java
@@ -105,15 +105,17 @@ public class MoisSalesLibraryController {
     }
 
     /**
-     * Lista páginas canônicas registradas no modelo consolidado da biblioteca.
+     * Lista páginas canônicas registradas no modelo consolidado da biblioteca com filtros opcionais de aquecimento.
      */
     @GetMapping("/pages")
     public MoisSalesLibraryDtos.SalesLibraryPageListResponse listPages(
             @RequestParam String workspaceId,
             @RequestParam(defaultValue = "1") int page,
-            @RequestParam(defaultValue = "20") int pageSize
+            @RequestParam(defaultValue = "20") int pageSize,
+            @RequestParam(required = false) String marketWarmupFilter,
+            @RequestParam(defaultValue = "RECENT_ANALYSIS") String sort
     ) {
-        return service.listPages(workspaceId, page, pageSize);
+        return service.listPages(workspaceId, page, pageSize, marketWarmupFilter, sort);
     }
 
     /**
@@ -243,6 +245,16 @@ public class MoisSalesLibraryController {
                     jobId, ex.getMessage(), ex);
             throw new ResponseStatusException(HttpStatus.CONFLICT, ex.getMessage(), ex);
         }
+    }
+
+    /**
+     * Refileira jobs antigos presos em execução para saneamento operacional sem acesso direto ao banco.
+     */
+    @PostMapping("/market-warmup/jobs:reprocess-stale")
+    public MoisSalesLibraryDtos.MarketWarmupReprocessStaleResponse reprocessStaleMarketWarmupJobs(
+            @Valid @RequestBody MoisSalesLibraryDtos.MarketWarmupReprocessStaleRequest request
+    ) {
+        return marketWarmupService.reprocessStaleJobs(request);
     }
 
     /**

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/mois/bibliotecapaginavenda/worker/v1/MoisSalesPageMarketWarmupGateway.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/mois/bibliotecapaginavenda/worker/v1/MoisSalesPageMarketWarmupGateway.java
@@ -76,6 +76,11 @@ public interface MoisSalesPageMarketWarmupGateway {
     boolean markJobFailed(long jobId, String errorCategory, String errorMessage);
 
     /**
+     * Recoloca jobs presos em FETCHING antigo na fila pendente para reprocessamento operacional.
+     */
+    long requeueStaleFetchingJobs(String workspaceId, int staleMinutes);
+
+    /**
      * Busca o resumo mais recente da página com os dados do job associado.
      */
     Optional<MarketWarmupSummaryData> findLatestSummaryByPage(long pageId);

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/mois/bibliotecapaginavenda/worker/v1/MoisSalesPageMarketWarmupRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/mois/bibliotecapaginavenda/worker/v1/MoisSalesPageMarketWarmupRepository.java
@@ -236,6 +236,24 @@ public class MoisSalesPageMarketWarmupRepository implements MoisSalesPageMarketW
     }
 
     /**
+     * Recoloca jobs presos em FETCHING antigo na fila pendente para reprocessamento operacional.
+     */
+    @Override
+    public long requeueStaleFetchingJobs(String workspaceId, int staleMinutes) {
+        int updated = jdbcTemplate.update("""
+                UPDATE mois_sales_page_market_warmup_job
+                SET status = 'PENDING', attempt = attempt + 1, claimed_by = NULL, started_at = NULL, finished_at = NULL,
+                    error_category = 'STALE_FETCHING_REQUEUED',
+                    error_message = 'Job FETCHING antigo recolocado na fila pela ação operacional da Fase 10',
+                    updated_at = UTC_TIMESTAMP()
+                WHERE workspace_id = ?
+                  AND status = 'FETCHING'
+                  AND COALESCE(started_at, updated_at, created_at) < DATE_SUB(UTC_TIMESTAMP(), INTERVAL ? MINUTE)
+                """, workspaceId, staleMinutes);
+        return updated;
+    }
+
+    /**
      * Busca o resumo mais recente da página com os dados do job associado.
      */
     @Override

--- a/backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryServiceTest.java
@@ -138,6 +138,7 @@ class MoisSalesLibraryServiceTest {
                         12L,
                         5L,
                         7L,
+                        2L,
                         Instant.parse("2026-06-07T05:38:13Z")
                 ));
 
@@ -148,6 +149,7 @@ class MoisSalesLibraryServiceTest {
         org.assertj.core.api.Assertions.assertThat(response.marketWarmupEligible()).isEqualTo(106L);
         org.assertj.core.api.Assertions.assertThat(response.marketWarmupCompleted()).isEqualTo(70L);
         org.assertj.core.api.Assertions.assertThat(response.marketWarmupPromising()).isEqualTo(28L);
+        org.assertj.core.api.Assertions.assertThat(response.marketWarmupStuck()).isEqualTo(2L);
     }
 
     /**
@@ -156,7 +158,7 @@ class MoisSalesLibraryServiceTest {
     @Test
     void shouldListPagesOrderedByMostRecentAnalysisDate() {
         given(jdbcTemplate.queryForObject(
-                eq("SELECT COUNT(*) FROM mois_sales_page WHERE workspace_id = ?"),
+                contains("SELECT COUNT(*)"),
                 eq(Long.class),
                 eq("workspace-001")))
                 .willReturn(42L);
@@ -171,6 +173,30 @@ class MoisSalesLibraryServiceTest {
         org.assertj.core.api.Assertions.assertThat(sqlCaptor.getValue())
                 .contains("LEFT JOIN mois_sales_page_market_warmup_summary mws")
                 .contains("ORDER BY p.last_analyzed_at DESC, p.updated_at DESC, p.id DESC LIMIT ? OFFSET ?");
+    }
+
+    /**
+     * Garante que a listagem de páginas permite priorização global pelo score de aquecimento.
+     */
+    @Test
+    void shouldListPagesOrderedByMarketWarmupScoreWhenRequested() {
+        given(jdbcTemplate.queryForObject(
+                contains("mws.market_temperature IN ('HOT', 'PROMISING')"),
+                eq(Long.class),
+                eq("workspace-001")))
+                .willReturn(8L);
+        given(jdbcTemplate.query(any(String.class), isA(RowMapper.class), eq("workspace-001"), eq(20), eq(0)))
+                .willReturn(List.of());
+
+        MoisSalesLibraryDtos.SalesLibraryPageListResponse response =
+                service.listPages("workspace-001", 1, 20, "HOT_OR_PROMISING", "MARKET_WARMUP_SCORE");
+
+        org.assertj.core.api.Assertions.assertThat(response.total()).isEqualTo(8L);
+        ArgumentCaptor<String> sqlCaptor = ArgumentCaptor.forClass(String.class);
+        verify(jdbcTemplate).query(sqlCaptor.capture(), isA(RowMapper.class), eq("workspace-001"), eq(20), eq(0));
+        org.assertj.core.api.Assertions.assertThat(sqlCaptor.getValue())
+                .contains("mws.market_temperature IN ('HOT', 'PROMISING')")
+                .contains("ORDER BY mws.score_total IS NULL ASC, mws.score_total DESC");
     }
 
     /**

--- a/backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesPageMarketWarmupServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesPageMarketWarmupServiceTest.java
@@ -147,6 +147,23 @@ class MoisSalesPageMarketWarmupServiceTest {
         verify(gateway, never()).markJobDone(org.mockito.ArgumentMatchers.anyLong(), org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any());
     }
 
+
+    /**
+     * Garante que jobs presos em FETCHING antigo podem ser refileirados sem mexer diretamente no banco.
+     */
+    @Test
+    void reprocessStaleJobsReturnsOperationalCount() {
+        given(gateway.requeueStaleFetchingJobs("workspace-001", 120)).willReturn(3L);
+
+        MoisSalesLibraryDtos.MarketWarmupReprocessStaleResponse response = service.reprocessStaleJobs(
+                new MoisSalesLibraryDtos.MarketWarmupReprocessStaleRequest("workspace-001", null));
+
+        assertThat(response.workspaceId()).isEqualTo("workspace-001");
+        assertThat(response.staleMinutes()).isEqualTo(120);
+        assertThat(response.requeuedJobs()).isEqualTo(3L);
+        verify(gateway).requeueStaleFetchingJobs("workspace-001", 120);
+    }
+
     /**
      * Garante que o resumo lido converte listas em linhas funcionais sem depender de JSON em texto.
      */

--- a/backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/web/MoisSalesLibraryControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/web/MoisSalesLibraryControllerTest.java
@@ -118,6 +118,23 @@ class MoisSalesLibraryControllerTest {
                 .andExpect(jsonPath("$[0].screenshotBytes").value(1024));
     }
 
+
+    /**
+     * Garante que a listagem encaminha filtro e ordenação de aquecimento para priorização comercial.
+     */
+    @Test
+    void shouldExposeMarketWarmupPrioritizationParamsOnPagesEndpoint() throws Exception {
+        when(service.listPages("workspace-001", 1, 20, "HOT_OR_PROMISING", "MARKET_WARMUP_SCORE"))
+                .thenReturn(new MoisSalesLibraryDtos.SalesLibraryPageListResponse(1, 20, 0L, List.of()));
+
+        mockMvc.perform(get("/api/mois/sales-library/pages")
+                        .param("workspaceId", "workspace-001")
+                        .param("marketWarmupFilter", "HOT_OR_PROMISING")
+                        .param("sort", "MARKET_WARMUP_SCORE"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.total").value(0));
+    }
+
     /**
      * Garante que o resumo global consolidado da Fase 4 seja exposto ao frontend.
      */
@@ -148,6 +165,7 @@ class MoisSalesLibraryControllerTest {
                         9L,
                         5L,
                         18L,
+                        3L,
                         Instant.parse("2026-06-04T16:00:09Z")
                 ));
 
@@ -170,7 +188,8 @@ class MoisSalesLibraryControllerTest {
                 .andExpect(jsonPath("$.marketWarmupFailed").value(4))
                 .andExpect(jsonPath("$.marketWarmupHot").value(16))
                 .andExpect(jsonPath("$.marketWarmupPromising").value(22))
-                .andExpect(jsonPath("$.marketWarmupSaturated").value(18));
+                .andExpect(jsonPath("$.marketWarmupSaturated").value(18))
+                .andExpect(jsonPath("$.marketWarmupStuck").value(3));
     }
 
     /**
@@ -415,6 +434,34 @@ class MoisSalesLibraryControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(marketWarmupCompletePayload()))
                 .andExpect(status().isConflict());
+    }
+
+
+    /**
+     * Garante que o operador consegue refileirar jobs presos sem acessar o banco.
+     */
+    @Test
+    void shouldExposeMarketWarmupReprocessStaleEndpoint() throws Exception {
+        when(marketWarmupService.reprocessStaleJobs(any(MoisSalesLibraryDtos.MarketWarmupReprocessStaleRequest.class)))
+                .thenReturn(new MoisSalesLibraryDtos.MarketWarmupReprocessStaleResponse(
+                        "workspace-001",
+                        120,
+                        2L,
+                        Instant.parse("2026-06-10T14:00:00Z")
+                ));
+
+        mockMvc.perform(post("/api/mois/sales-library/market-warmup/jobs:reprocess-stale")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "workspaceId": "workspace-001",
+                                  "staleMinutes": 120
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.workspaceId").value("workspace-001"))
+                .andExpect(jsonPath("$.staleMinutes").value(120))
+                .andExpect(jsonPath("$.requeuedJobs").value(2));
     }
 
     /**

--- a/docs/registros/mois1.md
+++ b/docs/registros/mois1.md
@@ -1334,3 +1334,34 @@ Arquivos principais:
 - `frontend/src/pages/mois/MoisSalesPagesLibraryPage.tsx`
 - `frontend/src/pages/mois/MoisSalesPagesPipelinePage.tsx`
 - `docs/swagger/mois-sales-library-swagger.yaml`
+
+## 2026-06-10 — MOIS Etapa 3 fase 9: priorização na biblioteca e pipeline
+
+- Executada a fase 9 do plano de aquecimento do ecossistema de mercado, conectando a biblioteca e o pipeline aos campos consolidados da Etapa 3.
+- A listagem da Biblioteca de Páginas de Vendas agora aceita filtro operacional de aquecimento e ordenação backend por maior score, permitindo priorização global das páginas quentes/promissoras sem depender apenas da ordenação local da primeira página.
+- O card de pipeline da Etapa 3 direciona o operador diretamente para a biblioteca filtrada por mercados quentes/promissores e ordenada pelo score de aquecimento.
+
+Arquivos principais:
+
+- `backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryService.java`
+- `backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/web/MoisSalesLibraryController.java`
+- `frontend/src/api/mois/useMoisSalesLibrary.ts`
+- `frontend/src/pages/mois/MoisSalesPagesLibraryPage.tsx`
+- `frontend/src/pages/mois/MoisSalesPagesPipelinePage.tsx`
+- `docs/swagger/mois-sales-library-swagger.yaml`
+
+## 2026-06-10 — MOIS Etapa 3 fase 10: observabilidade e saneamento operacional
+
+- Executada a fase 10 do plano de aquecimento do ecossistema de mercado para impedir que jobs da Etapa 3 fiquem parados silenciosamente.
+- Adicionados logs operacionais mais explícitos para claim sem fila, concorrência de claim, início de complete, fontes públicas persistidas e fail com categoria/mensagem.
+- Criada ação backend para refileirar jobs `FETCHING` antigos, permitindo reprocessamento sem intervenção direta no banco.
+- Adicionada métrica de jobs presos ao resumo da biblioteca e ao card de pipeline da Etapa 3, com botão operacional para reprocessar presos.
+
+Arquivos principais:
+
+- `backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/dto/MoisSalesLibraryDtos.java`
+- `backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesPageMarketWarmupService.java`
+- `backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/web/MoisSalesLibraryController.java`
+- `backend/ads-service/src/main/java/com/marketinghub/repository/jpa/mois/bibliotecapaginavenda/worker/v1/MoisSalesPageMarketWarmupRepository.java`
+- `frontend/src/pages/mois/MoisSalesPagesPipelinePage.tsx`
+- `docs/swagger/mois-sales-library-swagger.yaml`

--- a/docs/swagger/mois-sales-library-swagger.yaml
+++ b/docs/swagger/mois-sales-library-swagger.yaml
@@ -94,7 +94,7 @@ paths:
   /pages:
     get:
       summary: Lista páginas operacionais consolidadas
-      description: Retorna páginas de `mois_sales_page` ordenadas por `last_analyzed_at` decrescente, com `updated_at` e `id` como desempate; a UI principal consome as 20 análises mais recentes usando `pageSize=20`.
+      description: Retorna páginas de `mois_sales_page`; aceita filtro e ordenação de aquecimento para a biblioteca priorizar globalmente páginas com maior score da Etapa 3.
       tags: [MOIS Sales Library]
       parameters:
         - in: query
@@ -115,9 +115,23 @@ paths:
             default: 20
             minimum: 1
             maximum: 100
+        - in: query
+          name: marketWarmupFilter
+          description: Filtro operacional da Etapa 3 usado pela biblioteca para priorização comercial.
+          schema:
+            type: string
+            enum: [ALL, WITH_DOSSIER, HOT_OR_PROMISING, PENDING_OR_RUNNING, FAILED, WITHOUT_DOSSIER]
+            default: ALL
+        - in: query
+          name: sort
+          description: Ordenação da listagem consolidada; `MARKET_WARMUP_SCORE` prioriza os maiores scores salvos da Etapa 3.
+          schema:
+            type: string
+            enum: [RECENT_ANALYSIS, MARKET_WARMUP_SCORE]
+            default: RECENT_ANALYSIS
       responses:
         '200':
-          description: Páginas consolidadas ordenadas da análise mais recente para a mais antiga
+          description: Páginas consolidadas conforme filtro e ordenação solicitados
           content:
             application/json:
               schema:
@@ -462,6 +476,28 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/MarketWarmupClaimResponse'
+        '400':
+          $ref: '#/components/responses/MarketWarmupBadRequest'
+        '403':
+          $ref: '#/components/responses/MarketWarmupForbidden'
+  /market-warmup/jobs:reprocess-stale:
+    post:
+      summary: Reprocessa jobs antigos presos em execução
+      description: Ação operacional da Fase 10 para refileirar jobs `FETCHING` antigos sem acesso direto ao banco.
+      tags: [MOIS Sales Library]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MarketWarmupReprocessStaleRequest'
+      responses:
+        '200':
+          description: Quantidade de jobs refileirados
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MarketWarmupReprocessStaleResponse'
         '400':
           $ref: '#/components/responses/MarketWarmupBadRequest'
         '403':
@@ -870,6 +906,30 @@ components:
           type: boolean
         job:
           $ref: '#/components/schemas/MarketWarmupClaimedJob'
+    MarketWarmupReprocessStaleRequest:
+      type: object
+      required: [workspaceId]
+      properties:
+        workspaceId:
+          type: string
+        staleMinutes:
+          type: integer
+          minimum: 1
+          default: 120
+          description: Idade mínima em minutos para considerar um job `FETCHING` preso.
+    MarketWarmupReprocessStaleResponse:
+      type: object
+      properties:
+        workspaceId:
+          type: string
+        staleMinutes:
+          type: integer
+        requeuedJobs:
+          type: integer
+          format: int64
+        updatedAt:
+          type: string
+          format: date-time
     MarketWarmupSourceCompleteItem:
       type: object
       required: [platform, sourceType, sourceUrl]
@@ -1430,6 +1490,10 @@ components:
         marketWarmupSaturated:
           type: integer
           format: int64
+        marketWarmupStuck:
+          type: integer
+          format: int64
+          description: Jobs da Etapa 3 em `FETCHING` há mais de 120 minutos, considerados presos para saneamento operacional.
         updatedAt:
           type: string
           format: date-time

--- a/frontend/src/api/mois/types.ts
+++ b/frontend/src/api/mois/types.ts
@@ -311,6 +311,7 @@ export interface MoisSalesLibraryPageSummary {
   marketWarmupWarm: number;
   marketWarmupCold: number;
   marketWarmupSaturated: number;
+  marketWarmupStuck: number;
   updatedAt?: string;
 }
 
@@ -408,6 +409,13 @@ export interface MoisMarketWarmupRequestResponse {
   jobId: number;
   status: MoisMarketWarmupJobStatus;
   createdAt: string;
+}
+
+export interface MoisMarketWarmupReprocessStaleResponse {
+  workspaceId: string;
+  staleMinutes: number;
+  requeuedJobs: number;
+  updatedAt: string;
 }
 
 export interface MoisMarketWarmupSummary {

--- a/frontend/src/api/mois/useMoisSalesLibrary.ts
+++ b/frontend/src/api/mois/useMoisSalesLibrary.ts
@@ -2,6 +2,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import axios from "axios";
 import type {
   MoisCollectedReferenceUrlSummary,
+  MoisMarketWarmupReprocessStaleResponse,
   MoisMarketWarmupRequestResponse,
   MoisMarketWarmupSignalListResponse,
   MoisMarketWarmupSourceListResponse,
@@ -74,14 +75,34 @@ export function useMoisSalesLibraryPages(
   workspaceId: string,
   page: number,
   pageSize: number,
+  marketWarmupFilter?: string,
+  sort?: string,
 ) {
   return useQuery({
-    queryKey: ["mois", "sales-library", "pages", workspaceId, page, pageSize],
+    queryKey: [
+      "mois",
+      "sales-library",
+      "pages",
+      workspaceId,
+      page,
+      pageSize,
+      marketWarmupFilter || "ALL",
+      sort || "RECENT_ANALYSIS",
+    ],
     queryFn: async () => {
       const { data } = await axios.get<MoisSalesLibraryPageListResponse>(
         "/api/mois/sales-library/pages",
         {
-          params: { workspaceId, page, pageSize },
+          params: {
+            workspaceId,
+            page,
+            pageSize,
+            marketWarmupFilter:
+              marketWarmupFilter && marketWarmupFilter !== "ALL"
+                ? marketWarmupFilter
+                : undefined,
+            sort,
+          },
         },
       );
       return data;
@@ -325,6 +346,29 @@ export function useMoisSalesLibraryMarketWarmupSignals(
         `/api/mois/sales-library/pages/${pageId}/market-warmup/signals`,
       );
       return data;
+    },
+  });
+}
+
+export function useReprocessStaleMoisSalesLibraryMarketWarmup(
+  workspaceId: string,
+) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (staleMinutes?: number) => {
+      const { data } = await axios.post<MoisMarketWarmupReprocessStaleResponse>(
+        "/api/mois/sales-library/market-warmup/jobs:reprocess-stale",
+        { workspaceId, staleMinutes: staleMinutes ?? 120 },
+      );
+      return data;
+    },
+    onSuccess: () => {
+      void queryClient.invalidateQueries({
+        queryKey: ["mois", "sales-library", "pages", workspaceId],
+      });
+      void queryClient.invalidateQueries({
+        queryKey: ["mois", "sales-library", "pages-summary", workspaceId],
+      });
     },
   });
 }

--- a/frontend/src/pages/mois/MoisSalesPagesLibraryPage.tsx
+++ b/frontend/src/pages/mois/MoisSalesPagesLibraryPage.tsx
@@ -1,5 +1,5 @@
 import { useMemo, useState } from "react";
-import { Link } from "react-router-dom";
+import { Link, useSearchParams } from "react-router-dom";
 import PageTitle from "../../components/PageTitle";
 import {
   getSalesLibraryJobBadgeClass,
@@ -100,18 +100,24 @@ function formatAnalysisDate(value?: string | null) {
 }
 
 export default function MoisSalesPagesLibraryPage() {
-  const [warmupFilter, setWarmupFilter] = useState("ALL");
-  const pagesQuery = useMoisSalesLibraryPages(WORKSPACE_ID, 1, PAGE_SIZE);
+  const [searchParams] = useSearchParams();
+  const initialWarmupFilter = searchParams.get("warmupFilter") || "ALL";
+  const initialSort = searchParams.get("sort") || "MARKET_WARMUP_SCORE";
+  const [warmupFilter, setWarmupFilter] = useState(initialWarmupFilter);
+  const [sort, setSort] = useState(initialSort);
+  const pagesQuery = useMoisSalesLibraryPages(
+    WORKSPACE_ID,
+    1,
+    PAGE_SIZE,
+    warmupFilter,
+    sort,
+  );
   const summaryQuery = useMoisSalesLibraryPageSummary(WORKSPACE_ID);
   const summary = summaryQuery.data;
   const visiblePages = useMemo(() => {
-    return [...(pagesQuery.data?.items ?? [])]
-      .filter((item) => matchesWarmupFilter(item, warmupFilter))
-      .sort(
-        (first, second) =>
-          (second.marketWarmupScoreTotal ?? -1) -
-          (first.marketWarmupScoreTotal ?? -1),
-      );
+    return (pagesQuery.data?.items ?? []).filter((item) =>
+      matchesWarmupFilter(item, warmupFilter),
+    );
   }, [pagesQuery.data?.items, warmupFilter]);
 
   return (
@@ -184,29 +190,47 @@ export default function MoisSalesPagesLibraryPage() {
             <div>
               <h2 className="h5 mb-1">Priorização por aquecimento</h2>
               <p className="text-secondary mb-0">
-                Ordene a página atual pelo score de aquecimento para decidir
-                quais mercados merecem ação primeiro.
+                Ordene a listagem diretamente no backend pelo score de
+                aquecimento para decidir quais mercados merecem ação primeiro.
               </p>
             </div>
-            <div>
-              <label className="form-label small" htmlFor="warmupFilter">
-                Filtro de aquecimento
-              </label>
-              <select
-                id="warmupFilter"
-                className="form-select form-select-sm"
-                value={warmupFilter}
-                onChange={(event) => setWarmupFilter(event.target.value)}
-              >
-                <option value="ALL">Todos</option>
-                <option value="WITH_DOSSIER">Com dossiê</option>
-                <option value="HOT_OR_PROMISING">Quentes/promissores</option>
-                <option value="PENDING_OR_RUNNING">
-                  Pendentes/em pesquisa
-                </option>
-                <option value="FAILED">Falharam</option>
-                <option value="WITHOUT_DOSSIER">Sem dossiê</option>
-              </select>
+            <div className="d-flex flex-wrap gap-3">
+              <div>
+                <label className="form-label small" htmlFor="warmupFilter">
+                  Filtro de aquecimento
+                </label>
+                <select
+                  id="warmupFilter"
+                  className="form-select form-select-sm"
+                  value={warmupFilter}
+                  onChange={(event) => setWarmupFilter(event.target.value)}
+                >
+                  <option value="ALL">Todos</option>
+                  <option value="WITH_DOSSIER">Com dossiê</option>
+                  <option value="HOT_OR_PROMISING">Quentes/promissores</option>
+                  <option value="PENDING_OR_RUNNING">
+                    Pendentes/em pesquisa
+                  </option>
+                  <option value="FAILED">Falharam</option>
+                  <option value="WITHOUT_DOSSIER">Sem dossiê</option>
+                </select>
+              </div>
+              <div>
+                <label className="form-label small" htmlFor="warmupSort">
+                  Ordenação
+                </label>
+                <select
+                  id="warmupSort"
+                  className="form-select form-select-sm"
+                  value={sort}
+                  onChange={(event) => setSort(event.target.value)}
+                >
+                  <option value="MARKET_WARMUP_SCORE">
+                    Maior score de aquecimento
+                  </option>
+                  <option value="RECENT_ANALYSIS">Análise mais recente</option>
+                </select>
+              </div>
             </div>
           </div>
           <div className="table-responsive">

--- a/frontend/src/pages/mois/MoisSalesPagesPipelinePage.tsx
+++ b/frontend/src/pages/mois/MoisSalesPagesPipelinePage.tsx
@@ -5,6 +5,7 @@ import {
   useCaptureMoisSalesLibrarySnapshots,
   useMoisCollectedReferenceUrlSummary,
   useMoisSalesLibraryPageSummary,
+  useReprocessStaleMoisSalesLibraryMarketWarmup,
 } from "../../api/mois/useMoisSalesLibrary";
 import type { MoisSalesLibrarySnapshotCaptureItem } from "../../api/mois/types";
 
@@ -82,6 +83,8 @@ export default function MoisSalesPagesPipelinePage() {
   const collectedUrlSummaryQuery =
     useMoisCollectedReferenceUrlSummary(WORKSPACE_ID);
   const captureMutation = useCaptureMoisSalesLibrarySnapshots(WORKSPACE_ID);
+  const reprocessStaleWarmupMutation =
+    useReprocessStaleMoisSalesLibraryMarketWarmup(WORKSPACE_ID);
   const summary = summaryQuery.data;
   const collectedUrlSummary = collectedUrlSummaryQuery.data;
 
@@ -103,6 +106,9 @@ export default function MoisSalesPagesPipelinePage() {
   const marketWarmupPromising = summary?.marketWarmupPromising ?? 0;
   const marketWarmupCold = summary?.marketWarmupCold ?? 0;
   const marketWarmupSaturated = summary?.marketWarmupSaturated ?? 0;
+  const marketWarmupStuck = summary?.marketWarmupStuck ?? 0;
+  const requeuedWarmupJobs = reprocessStaleWarmupMutation.data?.requeuedJobs;
+  const isReprocessingWarmup = reprocessStaleWarmupMutation.isPending;
 
   return (
     <div className="d-flex flex-column gap-4">
@@ -556,8 +562,9 @@ export default function MoisSalesPagesPipelinePage() {
             </div>
             <p className="text-secondary small mb-0 mt-3">
               Fila real: {marketWarmupPending} pendentes · {marketWarmupRunning}{" "}
-              em pesquisa · {marketWarmupFailed} falhas · {marketWarmupCold}{" "}
-              frios · {marketWarmupSaturated} saturados.
+              em pesquisa · {marketWarmupStuck} presos há mais de 120 min ·{" "}
+              {marketWarmupFailed} falhas · {marketWarmupCold} frios ·{" "}
+              {marketWarmupSaturated} saturados.
             </p>
           </div>
 
@@ -569,13 +576,40 @@ export default function MoisSalesPagesPipelinePage() {
                   <li key={item}>{item}</li>
                 ))}
               </ul>
+              {requeuedWarmupJobs != null ? (
+                <p className="text-success small mb-0 mt-2">
+                  {requeuedWarmupJobs} job(s) preso(s) refileirado(s) para nova
+                  execução.
+                </p>
+              ) : null}
+              {reprocessStaleWarmupMutation.isError ? (
+                <p className="text-danger small mb-0 mt-2">
+                  Não foi possível refileirar os jobs presos agora.
+                </p>
+              ) : null}
             </div>
-            <Link
-              className="btn btn-outline-primary align-self-start"
-              to="/mois/sales-pages-library"
-            >
-              Priorizar na biblioteca
-            </Link>
+            <div className="d-flex flex-wrap gap-2 align-self-start">
+              <button
+                className="btn btn-outline-warning"
+                type="button"
+                disabled={isReprocessingWarmup || marketWarmupStuck === 0}
+                onClick={() => reprocessStaleWarmupMutation.mutate(120)}
+              >
+                {isReprocessingWarmup ? (
+                  <span
+                    className="spinner-border spinner-border-sm me-2"
+                    aria-hidden="true"
+                  />
+                ) : null}
+                Reprocessar presos
+              </button>
+              <Link
+                className="btn btn-outline-primary"
+                to="/mois/sales-pages-library?warmupFilter=HOT_OR_PROMISING&sort=MARKET_WARMUP_SCORE"
+              >
+                Priorizar quentes/promissores
+              </Link>
+            </div>
           </div>
         </div>
       </section>


### PR DESCRIPTION
### Motivation
- Allow operators to prioritize library pages by consolidated market-warmup score and filter by warmup dossier/temperature/queue state to drive commercial prioritization. 
- Surface an operational metric for jobs stuck in `FETCHING` to improve observability and enable safe remediation. 
- Provide an operational action to requeue stale `FETCHING` jobs without direct DB access and add more explicit logs for warmup worker lifecycle events.

### Description
- Added market-warmup filtering and ordering to the pages listing by extending `MoisSalesLibraryService.listPages` with `marketWarmupFilter` and `sort` parameters and helper methods `resolveMarketWarmupFilterCondition` and `resolveSalesPageOrderBy`.
- Introduced `marketWarmupStuck` counter in `MoisSalesLibraryDtos.SalesLibraryPageSummaryResponse` and SQL to count `FETCHING` jobs older than 120 minutes, and exposed it through the summary and Swagger spec.
- Implemented a safe reprocess action: new DTOs `MarketWarmupReprocessStaleRequest`/`Response`, controller endpoint `POST /market-warmup/jobs:reprocess-stale`, service `reprocessStaleJobs`, and gateway/repository method `requeueStaleFetchingJobs` which updates stale `FETCHING` jobs to `PENDING` and increments `attempt`.
- Improved operational logging (claim no-job, claim race, complete start, persisted sources, fail with message) and added frontend support: types, hooks (`useReprocessStaleMoisSalesLibraryMarketWarmup`), pages updates for passing `marketWarmupFilter`/`sort`, UI controls for ordering/filtering, pipeline card showing `marketWarmupStuck` and a "Reprocessar presos" button and link that sets the filter+sort.

### Testing
- Unit tests updated/added in backend: `MoisSalesLibraryServiceTest`, `MoisSalesPageMarketWarmupServiceTest`, and controller tests `MoisSalesLibraryControllerTest` to assert SQL contains warmup joins/ordering, summary includes `marketWarmupStuck`, and reprocess action behavior; these tests were executed and passed. 
- Frontend behavior covered by type and hook changes and exercised via existing UI unit/integration test suite where applicable; TypeScript compilation and React hooks usage were validated locally and succeeded. 
- End-to-end/manual regression was not part of this automated run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a2974108b088320a9bf87795f44d05e)