### PR TITLE
Implement MOIS opportunity ranking (Phase 11)

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/dto/MoisSalesLibraryDtos.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/dto/MoisSalesLibraryDtos.java
@@ -574,6 +574,38 @@ public final class MoisSalesLibraryDtos {
         CHANNEL_FIT
     }
 
+
+    /**
+     * Representa uma página priorizada por score comercial combinado da Etapa 3.
+     */
+    public record MarketWarmupOpportunityRankingItem(
+            long pageId,
+            String title,
+            String urlCanonical,
+            String source,
+            BigDecimal pageScoreTotal,
+            BigDecimal warmupScoreTotal,
+            BigDecimal combinedCommercialScore,
+            MarketWarmupTemperature marketTemperature,
+            MarketWarmupEcosystemType ecosystemType,
+            MarketWarmupRecommendation recommendation,
+            String saturationRisk,
+            Instant evidenceUpdatedAt,
+            String suggestedNextAction,
+            String evidenceSummary
+    ) {
+    }
+
+    /**
+     * Representa o ranking comercial de oportunidades para escolher próximo experimento ou pesquisa.
+     */
+    public record MarketWarmupOpportunityRankingResponse(
+            String workspaceId,
+            int limit,
+            List<MarketWarmupOpportunityRankingItem> items
+    ) {
+    }
+
     /**
      * Representa a solicitação aceita para criar ou reutilizar uma pesquisa de aquecimento da página.
      */

--- a/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryService.java
@@ -540,6 +540,55 @@ public class MoisSalesLibraryService {
     }
 
     /**
+     * Lista oportunidades com decisão comercial combinando score da página, aquecimento, saturação e recência da evidência.
+     */
+    public MoisSalesLibraryDtos.MarketWarmupOpportunityRankingResponse rankMarketWarmupOpportunities(String workspaceId, int limit) {
+        int normalizedLimit = Math.max(1, Math.min(limit, 50));
+        List<MoisSalesLibraryDtos.MarketWarmupOpportunityRankingItem> items = jdbcTemplate.query("""
+                SELECT ranked.page_id, ranked.title, ranked.url_canonical, ranked.source, ranked.page_score_total,
+                       ranked.warmup_score_total, ranked.combined_commercial_score, ranked.market_temperature,
+                       ranked.ecosystem_type, ranked.recommendation, ranked.saturation_risk, ranked.evidence_updated_at,
+                       ranked.opportunity_recommendation, ranked.next_experiment_suggestion
+                FROM (
+                    SELECT p.id AS page_id, p.title, p.url_canonical, p.source,
+                           COALESCE(p.score_total, 0) AS page_score_total,
+                           COALESCE(mws.score_total, 0) AS warmup_score_total,
+                           mws.market_temperature, mws.ecosystem_type, mws.recommendation, mws.saturation_risk,
+                           COALESCE(src.evidence_updated_at, mws.updated_at, mwj.updated_at) AS evidence_updated_at,
+                           mws.opportunity_recommendation, mws.next_experiment_suggestion,
+                           ROUND(
+                               (COALESCE(p.score_total, 0) * 0.45) +
+                               (COALESCE(mws.score_total, 0) * 0.35) +
+                               (GREATEST(0, 100 - LEAST(100, TIMESTAMPDIFF(DAY, COALESCE(src.evidence_updated_at, mws.updated_at, mwj.updated_at), UTC_TIMESTAMP()) * 5)) * 0.20) -
+                               (CASE
+                                   WHEN mws.market_temperature = 'SATURATED' OR mws.recommendation = 'SATURATED_REQUIRES_ANGLE'
+                                        OR COALESCE(mws.saturation_risk, '') <> '' THEN 20
+                                   ELSE 0
+                                END)
+                           , 2) AS combined_commercial_score
+                    FROM mois_sales_page p
+                    JOIN (
+                        SELECT sales_page_id, MAX(id) AS latest_warmup_job_id
+                        FROM mois_sales_page_market_warmup_job
+                        WHERE status = 'DONE'
+                        GROUP BY sales_page_id
+                    ) mwj_latest ON mwj_latest.sales_page_id = p.id
+                    JOIN mois_sales_page_market_warmup_job mwj ON mwj.id = mwj_latest.latest_warmup_job_id
+                    JOIN mois_sales_page_market_warmup_summary mws ON mws.job_id = mwj.id
+                    LEFT JOIN (
+                        SELECT job_id, MAX(COALESCE(last_activity_at, published_at, updated_at, created_at)) AS evidence_updated_at
+                        FROM mois_sales_page_market_warmup_source
+                        GROUP BY job_id
+                    ) src ON src.job_id = mwj.id
+                    WHERE p.workspace_id = ?
+                ) ranked
+                ORDER BY ranked.combined_commercial_score DESC, ranked.warmup_score_total DESC, ranked.evidence_updated_at DESC, ranked.page_id DESC
+                LIMIT ?
+                """, this::mapMarketWarmupOpportunityRankingItem, workspaceId, normalizedLimit);
+        return new MoisSalesLibraryDtos.MarketWarmupOpportunityRankingResponse(workspaceId, normalizedLimit, items);
+    }
+
+    /**
      * Calcula os contadores globais da biblioteca usando html_bytes > 0 como critério canônico de página capturada.
      */
     public MoisSalesLibraryDtos.SalesLibraryPageSummaryResponse summarizePages(String workspaceId) {
@@ -1182,6 +1231,64 @@ public class MoisSalesLibraryService {
             }
         }
         return null;
+    }
+
+    /**
+     * Converte uma linha ranqueada em oportunidade comercial objetiva para a biblioteca MOIS.
+     */
+    private MoisSalesLibraryDtos.MarketWarmupOpportunityRankingItem mapMarketWarmupOpportunityRankingItem(ResultSet rs, int rowNum) throws SQLException {
+        MoisSalesLibraryDtos.MarketWarmupTemperature temperature = mapEnum(MoisSalesLibraryDtos.MarketWarmupTemperature.class, rs.getString("market_temperature"));
+        MoisSalesLibraryDtos.MarketWarmupRecommendation recommendation = mapEnum(MoisSalesLibraryDtos.MarketWarmupRecommendation.class, rs.getString("recommendation"));
+        String nextSuggestion = coalesceNotBlank(rs.getString("next_experiment_suggestion"), rs.getString("opportunity_recommendation"));
+        return new MoisSalesLibraryDtos.MarketWarmupOpportunityRankingItem(
+                rs.getLong("page_id"),
+                rs.getString("title"),
+                rs.getString("url_canonical"),
+                rs.getString("source"),
+                rs.getBigDecimal("page_score_total"),
+                rs.getBigDecimal("warmup_score_total"),
+                rs.getBigDecimal("combined_commercial_score"),
+                temperature,
+                mapEnum(MoisSalesLibraryDtos.MarketWarmupEcosystemType.class, rs.getString("ecosystem_type")),
+                recommendation,
+                rs.getString("saturation_risk"),
+                toInstant(rs.getTimestamp("evidence_updated_at")),
+                resolveSuggestedNextAction(temperature, recommendation, nextSuggestion),
+                buildRankingEvidenceSummary(rs.getBigDecimal("page_score_total"), rs.getBigDecimal("warmup_score_total"), rs.getString("saturation_risk"), toInstant(rs.getTimestamp("evidence_updated_at")))
+        );
+    }
+
+    /**
+     * Define a próxima ação comercial a partir da recomendação de aquecimento e da sugestão persistida.
+     */
+    private String resolveSuggestedNextAction(
+            MoisSalesLibraryDtos.MarketWarmupTemperature temperature,
+            MoisSalesLibraryDtos.MarketWarmupRecommendation recommendation,
+            String persistedSuggestion
+    ) {
+        if (recommendation == MoisSalesLibraryDtos.MarketWarmupRecommendation.SATURATED_REQUIRES_ANGLE
+                || temperature == MoisSalesLibraryDtos.MarketWarmupTemperature.SATURATED) {
+            return "Pesquisar ângulo diferenciado com OPRM/MDS antes de criar experimento.";
+        }
+        if (recommendation == MoisSalesLibraryDtos.MarketWarmupRecommendation.PRIORITIZE) {
+            return persistedSuggestion == null ? "Criar próximo experimento comercial para este mercado." : persistedSuggestion;
+        }
+        if (recommendation == MoisSalesLibraryDtos.MarketWarmupRecommendation.OBSERVE) {
+            return persistedSuggestion == null ? "Refinar promessa e validar mais evidências antes do experimento." : persistedSuggestion;
+        }
+        if (recommendation == MoisSalesLibraryDtos.MarketWarmupRecommendation.RESEARCH_MORE) {
+            return "Solicitar próxima pesquisa OPRM/MDS para aprofundar dor, rotina e mecanismo.";
+        }
+        return "Não priorizar agora; manter apenas como referência de mercado.";
+    }
+
+    /**
+     * Monta explicação curta e rastreável do score combinado exibido no ranking.
+     */
+    private String buildRankingEvidenceSummary(BigDecimal pageScore, BigDecimal warmupScore, String saturationRisk, Instant evidenceUpdatedAt) {
+        String saturation = saturationRisk == null || saturationRisk.isBlank() ? "sem penalidade explícita de saturação" : "com risco de saturação descontado";
+        String evidenceDate = evidenceUpdatedAt == null ? "sem data de evidência" : "evidência até " + evidenceUpdatedAt;
+        return "Combina score da página " + pageScore + ", aquecimento " + warmupScore + ", " + saturation + " e " + evidenceDate + ".";
     }
 
     /**

--- a/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/web/MoisSalesLibraryController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/web/MoisSalesLibraryController.java
@@ -161,6 +161,17 @@ public class MoisSalesLibraryController {
     }
 
     /**
+     * Lista oportunidades priorizadas pela combinação de análise comercial e aquecimento de mercado.
+     */
+    @GetMapping("/market-warmup/opportunity-ranking")
+    public MoisSalesLibraryDtos.MarketWarmupOpportunityRankingResponse rankMarketWarmupOpportunities(
+            @RequestParam String workspaceId,
+            @RequestParam(defaultValue = "10") int limit
+    ) {
+        return service.rankMarketWarmupOpportunities(workspaceId, limit);
+    }
+
+    /**
      * Solicita a pesquisa de aquecimento de mercado da Etapa 3 para uma página de vendas.
      */
     @PostMapping("/pages/{pageId}/market-warmup:request")

--- a/backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryServiceTest.java
@@ -7,6 +7,7 @@ import static org.mockito.ArgumentMatchers.isA;
 import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
 import com.marketinghub.mois.bibliotecapaginavenda.worker.v1.dto.MoisSalesLibraryDtos;
@@ -197,6 +198,46 @@ class MoisSalesLibraryServiceTest {
         org.assertj.core.api.Assertions.assertThat(sqlCaptor.getValue())
                 .contains("mws.market_temperature IN ('HOT', 'PROMISING')")
                 .contains("ORDER BY mws.score_total IS NULL ASC, mws.score_total DESC");
+    }
+
+    /**
+     * Garante que o ranking de oportunidades combina página, aquecimento, saturação e recência no backend.
+     */
+    @Test
+    void shouldRankMarketWarmupOpportunitiesByCombinedCommercialScore() throws Exception {
+        given(jdbcTemplate.query(contains("combined_commercial_score"), isA(RowMapper.class), eq("workspace-001"), eq(5)))
+                .willAnswer(invocation -> {
+                    RowMapper<?> mapper = invocation.getArgument(1);
+                    ResultSet row = mock(ResultSet.class);
+                    given(row.getLong("page_id")).willReturn(77L);
+                    given(row.getString("title")).willReturn("Produto promissor");
+                    given(row.getString("url_canonical")).willReturn("https://example.com/oferta");
+                    given(row.getString("source")).willReturn("HOTMART");
+                    given(row.getBigDecimal("page_score_total")).willReturn(BigDecimal.valueOf(82));
+                    given(row.getBigDecimal("warmup_score_total")).willReturn(BigDecimal.valueOf(76));
+                    given(row.getBigDecimal("combined_commercial_score")).willReturn(BigDecimal.valueOf(79.5));
+                    given(row.getString("market_temperature")).willReturn("PROMISING");
+                    given(row.getString("ecosystem_type")).willReturn("CREATORS_HEATED");
+                    given(row.getString("recommendation")).willReturn("PRIORITIZE");
+                    given(row.getString("saturation_risk")).willReturn(null);
+                    given(row.getTimestamp("evidence_updated_at")).willReturn(Timestamp.from(Instant.parse("2026-06-09T12:00:00Z")));
+                    given(row.getString("next_experiment_suggestion")).willReturn("Criar experimento com promessa direta.");
+                    given(row.getString("opportunity_recommendation")).willReturn("Priorizar mercado.");
+                    return List.of(mapper.mapRow(row, 0));
+                });
+
+        MoisSalesLibraryDtos.MarketWarmupOpportunityRankingResponse response =
+                service.rankMarketWarmupOpportunities("workspace-001", 5);
+
+        org.assertj.core.api.Assertions.assertThat(response.items()).hasSize(1);
+        org.assertj.core.api.Assertions.assertThat(response.items().get(0).combinedCommercialScore()).isEqualByComparingTo("79.5");
+        org.assertj.core.api.Assertions.assertThat(response.items().get(0).suggestedNextAction()).isEqualTo("Criar experimento com promessa direta.");
+        ArgumentCaptor<String> sqlCaptor = ArgumentCaptor.forClass(String.class);
+        verify(jdbcTemplate).query(sqlCaptor.capture(), isA(RowMapper.class), eq("workspace-001"), eq(5));
+        org.assertj.core.api.Assertions.assertThat(sqlCaptor.getValue())
+                .contains("COALESCE(p.score_total, 0) * 0.45")
+                .contains("mws.market_temperature = 'SATURATED'")
+                .contains("ORDER BY ranked.combined_commercial_score DESC");
     }
 
     /**

--- a/docs/registros/mois1.md
+++ b/docs/registros/mois1.md
@@ -1365,3 +1365,19 @@ Arquivos principais:
 - `backend/ads-service/src/main/java/com/marketinghub/repository/jpa/mois/bibliotecapaginavenda/worker/v1/MoisSalesPageMarketWarmupRepository.java`
 - `frontend/src/pages/mois/MoisSalesPagesPipelinePage.tsx`
 - `docs/swagger/mois-sales-library-swagger.yaml`
+
+## 2026-06-10 — Fase 11 da Etapa 3: ranking de oportunidades MOIS
+
+- implementado endpoint backend `GET /api/mois/sales-library/market-warmup/opportunity-ranking` para priorizar páginas por score comercial combinado, usando score da página, score de aquecimento, risco de saturação e recência das evidências.
+- adicionados contratos de resposta para ranking de oportunidades da Etapa 3, com próxima ação objetiva para experimento ou pesquisa OPRM/MDS.
+- adicionada visualização na Biblioteca de Páginas de Vendas com ranking de oportunidades comerciais e evidências resumidas.
+- adicionados tipos e hook frontend para consumir o ranking pelo backend principal, mantendo o frontend sem acesso direto ao banco.
+
+Arquivos principais:
+- backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/dto/MoisSalesLibraryDtos.java
+- backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryService.java
+- backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/web/MoisSalesLibraryController.java
+- backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryServiceTest.java
+- frontend/src/api/mois/types.ts
+- frontend/src/api/mois/useMoisSalesLibrary.ts
+- frontend/src/pages/mois/MoisSalesPagesLibraryPage.tsx

--- a/frontend/src/api/mois/types.ts
+++ b/frontend/src/api/mois/types.ts
@@ -404,6 +404,29 @@ export type MoisMarketWarmupSignalType =
   | "SATURATION_RISK"
   | "CHANNEL_FIT";
 
+export interface MoisMarketWarmupOpportunityRankingItem {
+  pageId: number;
+  title?: string;
+  urlCanonical: string;
+  source?: string;
+  pageScoreTotal?: number;
+  warmupScoreTotal?: number;
+  combinedCommercialScore?: number;
+  marketTemperature: MoisMarketWarmupTemperature;
+  ecosystemType: MoisMarketWarmupEcosystemType;
+  recommendation: MoisMarketWarmupRecommendation;
+  saturationRisk?: string;
+  evidenceUpdatedAt?: string;
+  suggestedNextAction: string;
+  evidenceSummary: string;
+}
+
+export interface MoisMarketWarmupOpportunityRankingResponse {
+  workspaceId: string;
+  limit: number;
+  items: MoisMarketWarmupOpportunityRankingItem[];
+}
+
 export interface MoisMarketWarmupRequestResponse {
   pageId: number;
   jobId: number;

--- a/frontend/src/api/mois/useMoisSalesLibrary.ts
+++ b/frontend/src/api/mois/useMoisSalesLibrary.ts
@@ -2,6 +2,7 @@ import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import axios from "axios";
 import type {
   MoisCollectedReferenceUrlSummary,
+  MoisMarketWarmupOpportunityRankingResponse,
   MoisMarketWarmupReprocessStaleResponse,
   MoisMarketWarmupRequestResponse,
   MoisMarketWarmupSignalListResponse,
@@ -105,6 +106,30 @@ export function useMoisSalesLibraryPages(
           },
         },
       );
+      return data;
+    },
+  });
+}
+
+export function useMoisSalesLibraryOpportunityRanking(
+  workspaceId: string,
+  limit = 5,
+) {
+  return useQuery({
+    queryKey: [
+      "mois",
+      "sales-library",
+      "market-warmup",
+      "opportunity-ranking",
+      workspaceId,
+      limit,
+    ],
+    queryFn: async () => {
+      const { data } =
+        await axios.get<MoisMarketWarmupOpportunityRankingResponse>(
+          "/api/mois/sales-library/market-warmup/opportunity-ranking",
+          { params: { workspaceId, limit } },
+        );
       return data;
     },
   });

--- a/frontend/src/pages/mois/MoisSalesPagesLibraryPage.tsx
+++ b/frontend/src/pages/mois/MoisSalesPagesLibraryPage.tsx
@@ -3,6 +3,7 @@ import { Link, useSearchParams } from "react-router-dom";
 import PageTitle from "../../components/PageTitle";
 import {
   getSalesLibraryJobBadgeClass,
+  useMoisSalesLibraryOpportunityRanking,
   useMoisSalesLibraryPages,
   useMoisSalesLibraryPageSummary,
 } from "../../api/mois/useMoisSalesLibrary";
@@ -113,6 +114,10 @@ export default function MoisSalesPagesLibraryPage() {
     sort,
   );
   const summaryQuery = useMoisSalesLibraryPageSummary(WORKSPACE_ID);
+  const opportunityRankingQuery = useMoisSalesLibraryOpportunityRanking(
+    WORKSPACE_ID,
+    5,
+  );
   const summary = summaryQuery.data;
   const visiblePages = useMemo(() => {
     return (pagesQuery.data?.items ?? []).filter((item) =>
@@ -183,6 +188,82 @@ export default function MoisSalesPagesLibraryPage() {
           </div>
         </section>
       ) : null}
+
+      <section>
+        <div className="card border-0 shadow-sm">
+          <div className="card-body">
+            <div className="d-flex flex-wrap justify-content-between gap-3 mb-3">
+              <div>
+                <h2 className="h5 mb-1">Ranking de oportunidades comerciais</h2>
+                <p className="text-secondary mb-0">
+                  Prioriza mercados combinando score da página, aquecimento,
+                  risco de saturação e recência das evidências.
+                </p>
+              </div>
+            </div>
+            {opportunityRankingQuery.isLoading ? (
+              <p className="text-secondary mb-0">Carregando ranking...</p>
+            ) : null}
+            {opportunityRankingQuery.isError ? (
+              <div className="alert alert-danger mb-0">
+                Falha ao carregar ranking de oportunidades.
+              </div>
+            ) : null}
+            {opportunityRankingQuery.data ? (
+              <div className="table-responsive">
+                <table className="table table-sm align-middle mb-0">
+                  <thead>
+                    <tr>
+                      <th>Prioridade</th>
+                      <th>Mercado/produto</th>
+                      <th>Score combinado</th>
+                      <th>Aquecimento</th>
+                      <th>Próxima ação</th>
+                      <th>Evidência</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {opportunityRankingQuery.data.items.length === 0 ? (
+                      <tr>
+                        <td colSpan={6} className="text-secondary">
+                          Nenhum dossiê concluído para priorização ainda.
+                        </td>
+                      </tr>
+                    ) : (
+                      opportunityRankingQuery.data.items.map((item, index) => (
+                        <tr key={item.pageId}>
+                          <td className="fw-semibold">#{index + 1}</td>
+                          <td className="text-break">
+                            <Link
+                              to={`/mois/sales-pages-library/${item.pageId}`}
+                            >
+                              {item.title || item.urlCanonical}
+                            </Link>
+                          </td>
+                          <td className="fw-semibold text-nowrap">
+                            {formatWarmupScore(item.combinedCommercialScore)}
+                          </td>
+                          <td>
+                            <span
+                              className={`badge ${getWarmupBadgeClass(item.marketTemperature)}`}
+                            >
+                              {warmupTemperatureLabels[item.marketTemperature]}
+                            </span>
+                          </td>
+                          <td>{item.suggestedNextAction}</td>
+                          <td className="small text-secondary">
+                            {item.evidenceSummary}
+                          </td>
+                        </tr>
+                      ))
+                    )}
+                  </tbody>
+                </table>
+              </div>
+            ) : null}
+          </div>
+        </div>
+      </section>
 
       <section className="card border-0 shadow-sm">
         <div className="card-body d-flex flex-column gap-3">


### PR DESCRIPTION
### Motivation
- Add a commercial prioritization layer (Fase 11) to Etapa 3 so the Library can recommend which markets/pages to experiment on using combined signals from page analysis and market warm-up research. 
- Provide an objective, explainable ranking that combines page score, market-warmup score, evidence recency and saturation risk to guide next actions. 
- Keep the backend as the single source of truth and expose the ranking through the MOIS API so workers and frontend consume only validated contracts.

### Description
- Added DTOs for ranking results: `MarketWarmupOpportunityRankingItem` and `MarketWarmupOpportunityRankingResponse` in `MoisSalesLibraryDtos`. 
- Implemented `GET /api/mois/sales-library/market-warmup/opportunity-ranking` in `MoisSalesLibraryController` that delegates to `MoisSalesLibraryService#rankMarketWarmupOpportunities`. 
- Implemented ranking logic in `MoisSalesLibraryService#rankMarketWarmupOpportunities` that computes a `combined_commercial_score` combining page score, warmup score, evidence recency and a saturation penalty, plus mappers `mapMarketWarmupOpportunityRankingItem`, helper `resolveSuggestedNextAction` and explanation builder `buildRankingEvidenceSummary`. 
- Added frontend types, hook and UI: `MoisMarketWarmupOpportunityRanking*` types, `useMoisSalesLibraryOpportunityRanking` hook, and a new ranking table in `MoisSalesPagesLibraryPage.tsx` to display priority, combined score, temperature, suggested next action and evidence. 
- Added a unit test `shouldRankMarketWarmupOpportunitiesByCombinedCommercialScore` to validate SQL composition and mapping of the ranking response, and updated `docs/registros/mois1.md` with the Fase 11 entry.

### Testing
- Ran TypeScript typecheck with `npm run typecheck` which completed successfully. 
- Built the frontend with `npm run build` which completed and produced the UI bundle. 
- Attempted to run backend unit tests with `../mvnw -Dtest=MoisSalesLibraryServiceTest test` but compilation failed in this environment due to local Java/Lombok toolchain incompatibility (Lombok/Javac `TypeTag :: UNKNOWN`), so JVM-based tests could not be executed here. 
- Attempted to run `spotless:apply` via Maven but it failed in this environment because the `spotless` plugin prefix was not resolvable in the current Maven configuration; `git diff --check` returned no problems.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a299a00957c8320ae99d76e86982776)