### PR TITLE
OPRM: implementar fluxo de Públicos Gerais (sementes, subnichos, ângulos, quality-gate e endpoints)

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/generalaudience/OprmGeneralAudienceQualityReading.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/generalaudience/OprmGeneralAudienceQualityReading.java
@@ -1,0 +1,248 @@
+package com.marketinghub.oprm.generalaudience;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+import java.math.BigDecimal;
+import java.time.Instant;
+
+/** Responsável por registrar a leitura de qualidade real dos leads de um subnicho de público geral. */
+@Entity
+@Table(name = "oprm_general_audience_quality_reading")
+public class OprmGeneralAudienceQualityReading {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "subniche_id", nullable = false)
+    private OprmGeneralAudienceSubniche subniche;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "pain_angle_id")
+    private OprmGeneralAudiencePainAngle painAngle;
+
+    @Column(name = "experiment_id")
+    private Long experimentId;
+
+    @Column(name = "total_leads", nullable = false)
+    private Integer totalLeads;
+
+    @Column(name = "correct_profession_leads", nullable = false)
+    private Integer correctProfessionLeads;
+
+    @Column(name = "real_pain_responses", nullable = false)
+    private Integer realPainResponses;
+
+    @Column(name = "material_requests", nullable = false)
+    private Integer materialRequests;
+
+    @Column(name = "whatsapp_replies", nullable = false)
+    private Integer whatsappReplies;
+
+    @Column(name = "price_or_next_step_questions", nullable = false)
+    private Integer priceOrNextStepQuestions;
+
+    @Column(name = "out_of_profile_leads", nullable = false)
+    private Integer outOfProfileLeads;
+
+    @Column(name = "curious_without_profession", nullable = false)
+    private Integer curiousWithoutProfession;
+
+    @Column(name = "low_completion_events", nullable = false)
+    private Integer lowCompletionEvents;
+
+    @Column(name = "confusing_promise_reports", nullable = false)
+    private Integer confusingPromiseReports;
+
+    @Column(name = "lead_magnet_no_response", nullable = false)
+    private Integer leadMagnetNoResponse;
+
+    @Column(name = "quality_score", nullable = false, precision = 5, scale = 2)
+    private BigDecimal qualityScore;
+
+    @Column(name = "approved", nullable = false)
+    private boolean approved;
+
+    @Column(name = "blockers", columnDefinition = "LONGTEXT")
+    private String blockers;
+
+    @Column(name = "recommendations", columnDefinition = "LONGTEXT")
+    private String recommendations;
+
+    @Column(name = "notes", columnDefinition = "LONGTEXT")
+    private String notes;
+
+    @Column(name = "captured_at", nullable = false)
+    private Instant capturedAt;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+
+    /** Inicializa datas e contadores antes da primeira gravação. */
+    @PrePersist
+    void onCreate() {
+        Instant now = Instant.now();
+        createdAt = now;
+        updatedAt = now;
+        if (capturedAt == null) {
+            capturedAt = now;
+        }
+    }
+
+    /** Atualiza a data de modificação antes de salvar alterações. */
+    @PreUpdate
+    void onUpdate() {
+        updatedAt = Instant.now();
+    }
+
+    /** Retorna o identificador da leitura. */
+    public Long getId() { return id; }
+
+    /** Define o identificador da leitura. */
+    public void setId(Long id) { this.id = id; }
+
+    /** Retorna o subnicho avaliado. */
+    public OprmGeneralAudienceSubniche getSubniche() { return subniche; }
+
+    /** Define o subnicho avaliado. */
+    public void setSubniche(OprmGeneralAudienceSubniche subniche) { this.subniche = subniche; }
+
+    /** Retorna o ângulo relacionado à leitura. */
+    public OprmGeneralAudiencePainAngle getPainAngle() { return painAngle; }
+
+    /** Define o ângulo relacionado à leitura. */
+    public void setPainAngle(OprmGeneralAudiencePainAngle painAngle) { this.painAngle = painAngle; }
+
+    /** Retorna o experimento relacionado à leitura. */
+    public Long getExperimentId() { return experimentId; }
+
+    /** Define o experimento relacionado à leitura. */
+    public void setExperimentId(Long experimentId) { this.experimentId = experimentId; }
+
+    /** Retorna a quantidade total de leads observados. */
+    public Integer getTotalLeads() { return totalLeads; }
+
+    /** Define a quantidade total de leads observados. */
+    public void setTotalLeads(Integer totalLeads) { this.totalLeads = totalLeads; }
+
+    /** Retorna quantos leads informaram a profissão correta. */
+    public Integer getCorrectProfessionLeads() { return correctProfessionLeads; }
+
+    /** Define quantos leads informaram a profissão correta. */
+    public void setCorrectProfessionLeads(Integer correctProfessionLeads) { this.correctProfessionLeads = correctProfessionLeads; }
+
+    /** Retorna quantas respostas trouxeram dor real. */
+    public Integer getRealPainResponses() { return realPainResponses; }
+
+    /** Define quantas respostas trouxeram dor real. */
+    public void setRealPainResponses(Integer realPainResponses) { this.realPainResponses = realPainResponses; }
+
+    /** Retorna quantas pessoas pediram o material. */
+    public Integer getMaterialRequests() { return materialRequests; }
+
+    /** Define quantas pessoas pediram o material. */
+    public void setMaterialRequests(Integer materialRequests) { this.materialRequests = materialRequests; }
+
+    /** Retorna quantas pessoas responderam no WhatsApp. */
+    public Integer getWhatsappReplies() { return whatsappReplies; }
+
+    /** Define quantas pessoas responderam no WhatsApp. */
+    public void setWhatsappReplies(Integer whatsappReplies) { this.whatsappReplies = whatsappReplies; }
+
+    /** Retorna quantas pessoas perguntaram preço ou próximo passo. */
+    public Integer getPriceOrNextStepQuestions() { return priceOrNextStepQuestions; }
+
+    /** Define quantas pessoas perguntaram preço ou próximo passo. */
+    public void setPriceOrNextStepQuestions(Integer priceOrNextStepQuestions) { this.priceOrNextStepQuestions = priceOrNextStepQuestions; }
+
+    /** Retorna quantos leads vieram fora do perfil. */
+    public Integer getOutOfProfileLeads() { return outOfProfileLeads; }
+
+    /** Define quantos leads vieram fora do perfil. */
+    public void setOutOfProfileLeads(Integer outOfProfileLeads) { this.outOfProfileLeads = outOfProfileLeads; }
+
+    /** Retorna quantos curiosos vieram sem profissão aderente. */
+    public Integer getCuriousWithoutProfession() { return curiousWithoutProfession; }
+
+    /** Define quantos curiosos vieram sem profissão aderente. */
+    public void setCuriousWithoutProfession(Integer curiousWithoutProfession) { this.curiousWithoutProfession = curiousWithoutProfession; }
+
+    /** Retorna quantos eventos indicaram baixo preenchimento. */
+    public Integer getLowCompletionEvents() { return lowCompletionEvents; }
+
+    /** Define quantos eventos indicaram baixo preenchimento. */
+    public void setLowCompletionEvents(Integer lowCompletionEvents) { this.lowCompletionEvents = lowCompletionEvents; }
+
+    /** Retorna quantos relatos apontaram promessa confusa. */
+    public Integer getConfusingPromiseReports() { return confusingPromiseReports; }
+
+    /** Define quantos relatos apontaram promessa confusa. */
+    public void setConfusingPromiseReports(Integer confusingPromiseReports) { this.confusingPromiseReports = confusingPromiseReports; }
+
+    /** Retorna quantos leads baixaram a isca sem responder depois. */
+    public Integer getLeadMagnetNoResponse() { return leadMagnetNoResponse; }
+
+    /** Define quantos leads baixaram a isca sem responder depois. */
+    public void setLeadMagnetNoResponse(Integer leadMagnetNoResponse) { this.leadMagnetNoResponse = leadMagnetNoResponse; }
+
+    /** Retorna o score de qualidade calculado. */
+    public BigDecimal getQualityScore() { return qualityScore; }
+
+    /** Define o score de qualidade calculado. */
+    public void setQualityScore(BigDecimal qualityScore) { this.qualityScore = qualityScore; }
+
+    /** Indica se a leitura aprovou a qualidade do público. */
+    public boolean isApproved() { return approved; }
+
+    /** Define se a leitura aprovou a qualidade do público. */
+    public void setApproved(boolean approved) { this.approved = approved; }
+
+    /** Retorna bloqueios calculados para a leitura. */
+    public String getBlockers() { return blockers; }
+
+    /** Define bloqueios calculados para a leitura. */
+    public void setBlockers(String blockers) { this.blockers = blockers; }
+
+    /** Retorna recomendações calculadas para a leitura. */
+    public String getRecommendations() { return recommendations; }
+
+    /** Define recomendações calculadas para a leitura. */
+    public void setRecommendations(String recommendations) { this.recommendations = recommendations; }
+
+    /** Retorna observações operacionais da leitura. */
+    public String getNotes() { return notes; }
+
+    /** Define observações operacionais da leitura. */
+    public void setNotes(String notes) { this.notes = notes; }
+
+    /** Retorna a data em que os sinais foram capturados. */
+    public Instant getCapturedAt() { return capturedAt; }
+
+    /** Define a data em que os sinais foram capturados. */
+    public void setCapturedAt(Instant capturedAt) { this.capturedAt = capturedAt; }
+
+    /** Retorna a data de criação da leitura. */
+    public Instant getCreatedAt() { return createdAt; }
+
+    /** Define a data de criação da leitura. */
+    public void setCreatedAt(Instant createdAt) { this.createdAt = createdAt; }
+
+    /** Retorna a data de atualização da leitura. */
+    public Instant getUpdatedAt() { return updatedAt; }
+
+    /** Define a data de atualização da leitura. */
+    public void setUpdatedAt(Instant updatedAt) { this.updatedAt = updatedAt; }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/generalaudience/controller/OprmGeneralAudienceDiscoveryController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/generalaudience/controller/OprmGeneralAudienceDiscoveryController.java
@@ -6,9 +6,11 @@ import com.marketinghub.oprm.generalaudience.service.createHypothesis.CreateGene
 import com.marketinghub.oprm.generalaudience.service.createHypothesis.GeneralAudienceHypothesisResponse;
 import com.marketinghub.oprm.generalaudience.service.createLeadExperiment.CreateGeneralAudienceLeadExperimentRequest;
 import com.marketinghub.oprm.generalaudience.service.createLeadExperiment.GeneralAudienceLeadExperimentResponse;
+import com.marketinghub.oprm.generalaudience.service.createQualityReading.CreateGeneralAudienceQualityReadingRequest;
 import com.marketinghub.oprm.generalaudience.service.createPainAngle.CreateGeneralAudiencePainAngleRequest;
 import com.marketinghub.oprm.generalaudience.service.createSourceEvidence.CreateGeneralAudienceSourceEvidenceRequest;
 import com.marketinghub.oprm.generalaudience.service.listPainAngles.GeneralAudiencePainAngleResponse;
+import com.marketinghub.oprm.generalaudience.service.listQualityReadings.GeneralAudienceQualityReadingResponse;
 import com.marketinghub.oprm.generalaudience.service.listSourceEvidences.GeneralAudienceSourceEvidenceResponse;
 import com.marketinghub.oprm.generalaudience.service.landingConfirmation.CreateGeneralAudienceLandingConfirmationRequest;
 import com.marketinghub.oprm.generalaudience.service.landingConfirmation.GeneralAudienceLandingConfirmationResponse;
@@ -132,6 +134,24 @@ public class OprmGeneralAudienceDiscoveryController {
         GeneralAudienceSourceEvidenceResponse response = service.createSourceEvidence(seedId, request);
         return ResponseEntity
                 .created(URI.create("/api/oprm/general-audiences/source-evidences/" + response.id()))
+                .body(response);
+    }
+
+    /** Lista leituras de qualidade real para decidir se o público merece escala. */
+    @GetMapping("/subniches/{subnicheId}/quality-readings")
+    public ResponseEntity<List<GeneralAudienceQualityReadingResponse>> listQualityReadings(
+            @PathVariable Long subnicheId) {
+        return ResponseEntity.ok(service.listQualityReadings(subnicheId));
+    }
+
+    /** Registra leitura de qualidade real com sinais bons e ruins além de CTR e CPL. */
+    @PostMapping("/subniches/{subnicheId}/quality-readings")
+    public ResponseEntity<GeneralAudienceQualityReadingResponse> createQualityReading(
+            @PathVariable Long subnicheId,
+            @Valid @RequestBody CreateGeneralAudienceQualityReadingRequest request) {
+        GeneralAudienceQualityReadingResponse response = service.createQualityReading(subnicheId, request);
+        return ResponseEntity
+                .created(URI.create("/api/oprm/general-audiences/quality-readings/" + response.id()))
                 .body(response);
     }
 

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/generalaudience/service/OprmGeneralAudienceDiscoveryService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/generalaudience/service/OprmGeneralAudienceDiscoveryService.java
@@ -2,26 +2,30 @@ package com.marketinghub.oprm.generalaudience.service;
 
 import com.marketinghub.oprm.generalaudience.OprmGeneralAudiencePainAngle;
 import com.marketinghub.oprm.generalaudience.OprmGeneralAudiencePainAngleStatus;
+import com.marketinghub.oprm.generalaudience.OprmGeneralAudienceQualityReading;
 import com.marketinghub.oprm.generalaudience.OprmGeneralAudienceSeed;
 import com.marketinghub.oprm.generalaudience.OprmGeneralAudienceSourceEvidence;
 import com.marketinghub.oprm.generalaudience.OprmGeneralAudienceSubniche;
 import com.marketinghub.oprm.generalaudience.OprmGeneralAudienceSubnicheStatus;
 import com.marketinghub.oprm.generalaudience.service.createHypothesis.CreateGeneralAudienceHypothesisRequest;
+import com.marketinghub.oprm.generalaudience.service.createHypothesis.GeneralAudienceHypothesisResponse;
 import com.marketinghub.oprm.generalaudience.service.createLeadExperiment.CreateGeneralAudienceLeadExperimentRequest;
 import com.marketinghub.oprm.generalaudience.service.createLeadExperiment.GeneralAudienceLeadExperimentResponse;
-import com.marketinghub.oprm.generalaudience.service.createHypothesis.GeneralAudienceHypothesisResponse;
+import com.marketinghub.oprm.generalaudience.service.createQualityReading.CreateGeneralAudienceQualityReadingRequest;
+import com.marketinghub.oprm.generalaudience.service.createPainAngle.CreateGeneralAudiencePainAngleRequest;
+import com.marketinghub.oprm.generalaudience.service.createSourceEvidence.CreateGeneralAudienceSourceEvidenceRequest;
 import com.marketinghub.oprm.generalaudience.service.prepareTargeting.GeneralAudienceTargetingElementResponse;
 import com.marketinghub.oprm.generalaudience.service.prepareTargeting.GeneralAudienceTargetingPreparationRequest;
 import com.marketinghub.oprm.generalaudience.service.prepareTargeting.GeneralAudienceTargetingPreparationResponse;
-import com.marketinghub.oprm.generalaudience.service.createPainAngle.CreateGeneralAudiencePainAngleRequest;
-import com.marketinghub.oprm.generalaudience.service.createSourceEvidence.CreateGeneralAudienceSourceEvidenceRequest;
 import com.marketinghub.oprm.generalaudience.service.listPainAngles.GeneralAudiencePainAngleResponse;
+import com.marketinghub.oprm.generalaudience.service.listQualityReadings.GeneralAudienceQualityReadingResponse;
 import com.marketinghub.oprm.generalaudience.service.listSourceEvidences.GeneralAudienceSourceEvidenceResponse;
 import com.marketinghub.oprm.generalaudience.service.qualityGate.GeneralAudienceQualityGateResponse;
 import com.marketinghub.oprm.generalaudience.service.updatePainAngle.UpdateGeneralAudiencePainAngleRequest;
 import com.marketinghub.repository.jpa.oprm.generalaudience.OprmGeneralAudienceHypothesisMaterializationRepository;
 import com.marketinghub.repository.jpa.oprm.generalaudience.OprmGeneralAudienceLeadExperimentMaterializationRepository;
 import com.marketinghub.repository.jpa.oprm.generalaudience.OprmGeneralAudiencePainAngleRepository;
+import com.marketinghub.repository.jpa.oprm.generalaudience.OprmGeneralAudienceQualityReadingRepository;
 import com.marketinghub.repository.jpa.oprm.generalaudience.OprmGeneralAudienceSeedRepository;
 import com.marketinghub.repository.jpa.oprm.generalaudience.OprmGeneralAudienceSourceEvidenceRepository;
 import com.marketinghub.repository.jpa.oprm.generalaudience.OprmGeneralAudienceSubnicheRepository;
@@ -32,6 +36,8 @@ import com.marketinghub.targeting.TargetingElementType;
 import com.marketinghub.targeting.dto.CreateTargetingElementRequest;
 import com.marketinghub.targeting.service.TargetingElementService;
 import java.math.BigDecimal;
+import java.math.RoundingMode;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
@@ -53,6 +59,7 @@ public class OprmGeneralAudienceDiscoveryService {
     private final OprmGeneralAudienceSubnicheRepository subnicheRepository;
     private final OprmGeneralAudiencePainAngleRepository painAngleRepository;
     private final OprmGeneralAudienceSourceEvidenceRepository sourceEvidenceRepository;
+    private final OprmGeneralAudienceQualityReadingRepository qualityReadingRepository;
     private static final BigDecimal MAX_GENERAL_AUDIENCE_DAILY_BUDGET = new BigDecimal("100.00");
     private final OprmGeneralAudienceHypothesisMaterializationRepository hypothesisMaterializationRepository;
     private final OprmGeneralAudienceLeadExperimentMaterializationRepository leadExperimentMaterializationRepository;
@@ -64,6 +71,7 @@ public class OprmGeneralAudienceDiscoveryService {
             OprmGeneralAudienceSubnicheRepository subnicheRepository,
             OprmGeneralAudiencePainAngleRepository painAngleRepository,
             OprmGeneralAudienceSourceEvidenceRepository sourceEvidenceRepository,
+            OprmGeneralAudienceQualityReadingRepository qualityReadingRepository,
             OprmGeneralAudienceHypothesisMaterializationRepository hypothesisMaterializationRepository,
             OprmGeneralAudienceLeadExperimentMaterializationRepository leadExperimentMaterializationRepository,
             TargetingElementService targetingElementService) {
@@ -71,6 +79,7 @@ public class OprmGeneralAudienceDiscoveryService {
         this.subnicheRepository = subnicheRepository;
         this.painAngleRepository = painAngleRepository;
         this.sourceEvidenceRepository = sourceEvidenceRepository;
+        this.qualityReadingRepository = qualityReadingRepository;
         this.hypothesisMaterializationRepository = hypothesisMaterializationRepository;
         this.leadExperimentMaterializationRepository = leadExperimentMaterializationRepository;
         this.targetingElementService = targetingElementService;
@@ -185,6 +194,61 @@ public class OprmGeneralAudienceDiscoveryService {
         return toSourceEvidenceResponse(sourceEvidenceRepository.save(evidence));
     }
 
+    /** Lista leituras de qualidade real de leads de um subnicho. */
+    @Transactional(readOnly = true)
+    public List<GeneralAudienceQualityReadingResponse> listQualityReadings(Long subnicheId) {
+        findSubniche(subnicheId);
+        return qualityReadingRepository.findAllBySubnicheIdOrderByCapturedAtDesc(subnicheId).stream()
+                .map(this::toQualityReadingResponse)
+                .toList();
+    }
+
+    /** Registra sinais bons e ruins para medir qualidade real além de CTR e CPL. */
+    @Transactional
+    public GeneralAudienceQualityReadingResponse createQualityReading(
+            Long subnicheId,
+            CreateGeneralAudienceQualityReadingRequest request) {
+        if (request == null) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Payload de leitura de qualidade é obrigatório");
+        }
+        OprmGeneralAudienceSubniche subniche = findSubniche(subnicheId);
+        OprmGeneralAudiencePainAngle painAngle = null;
+        if (request.painAngleId() != null) {
+            painAngle = findPainAngle(request.painAngleId());
+            if (!subnicheId.equals(painAngle.getSubniche().getId())) {
+                throw new ResponseStatusException(
+                        HttpStatus.BAD_REQUEST, "painAngleId não pertence ao subnicho informado");
+            }
+        }
+        OprmGeneralAudienceQualityReading reading = new OprmGeneralAudienceQualityReading();
+        reading.setSubniche(subniche);
+        reading.setPainAngle(painAngle);
+        reading.setExperimentId(request.experimentId());
+        reading.setTotalLeads(nonNegativeOrZero(request.totalLeads(), "totalLeads"));
+        reading.setCorrectProfessionLeads(nonNegativeOrZero(request.correctProfessionLeads(), "correctProfessionLeads"));
+        reading.setRealPainResponses(nonNegativeOrZero(request.realPainResponses(), "realPainResponses"));
+        reading.setMaterialRequests(nonNegativeOrZero(request.materialRequests(), "materialRequests"));
+        reading.setWhatsappReplies(nonNegativeOrZero(request.whatsappReplies(), "whatsappReplies"));
+        reading.setPriceOrNextStepQuestions(
+                nonNegativeOrZero(request.priceOrNextStepQuestions(), "priceOrNextStepQuestions"));
+        reading.setOutOfProfileLeads(nonNegativeOrZero(request.outOfProfileLeads(), "outOfProfileLeads"));
+        reading.setCuriousWithoutProfession(
+                nonNegativeOrZero(request.curiousWithoutProfession(), "curiousWithoutProfession"));
+        reading.setLowCompletionEvents(nonNegativeOrZero(request.lowCompletionEvents(), "lowCompletionEvents"));
+        reading.setConfusingPromiseReports(
+                nonNegativeOrZero(request.confusingPromiseReports(), "confusingPromiseReports"));
+        reading.setLeadMagnetNoResponse(nonNegativeOrZero(request.leadMagnetNoResponse(), "leadMagnetNoResponse"));
+        reading.setNotes(normalizeOptionalText(request.notes()));
+        reading.setCapturedAt(request.capturedAt() == null ? Instant.now() : request.capturedAt());
+        List<String> blockers = qualityReadingBlockers(reading);
+        List<String> recommendations = qualityReadingRecommendations(reading);
+        reading.setQualityScore(calculateQualityScore(reading));
+        reading.setApproved(blockers.isEmpty() && reading.getQualityScore().compareTo(new BigDecimal("60.00")) >= 0);
+        reading.setBlockers(joinLines(blockers));
+        reading.setRecommendations(joinLines(recommendations));
+        return toQualityReadingResponse(qualityReadingRepository.save(reading));
+    }
+
     /** Executa o quality gate de um subnicho para bloquear saída genérica antes de experimento. */
     @Transactional(readOnly = true)
     public GeneralAudienceQualityGateResponse evaluateQualityGate(Long subnicheId) {
@@ -212,6 +276,18 @@ public class OprmGeneralAudienceDiscoveryService {
         if (!StringUtils.hasText(subniche.getDesiredOutcomeSummary())) {
             recommendations.add("Informar resultado desejado antes de criar isca ou promessa.");
         }
+        qualityReadingRepository.findTopBySubnicheIdOrderByCapturedAtDesc(subnicheId).ifPresentOrElse(reading -> {
+            if (!reading.isApproved()) {
+                blockers.add("Leitura de qualidade mais recente não aprovou o público.");
+            }
+            if (reading.getWhatsappReplies() == 0) {
+                recommendations.add("Medir resposta no WhatsApp antes de escalar o público.");
+            }
+            if (reading.getPriceOrNextStepQuestions() == 0) {
+                recommendations.add(
+                        "Validar pergunta de preço ou próximo passo antes de tratar como público comprador.");
+            }
+        }, () -> recommendations.add("Registrar leitura de qualidade real após a primeira captação de leads."));
         return new GeneralAudienceQualityGateResponse(subnicheId, blockers.isEmpty(), blockers, recommendations);
     }
 
@@ -614,6 +690,112 @@ public class OprmGeneralAudienceDiscoveryService {
         return text.substring(0, maxLength).trim();
     }
 
+    /** Calcula bloqueios objetivos da leitura de qualidade de público. */
+    private List<String> qualityReadingBlockers(OprmGeneralAudienceQualityReading reading) {
+        List<String> blockers = new ArrayList<>();
+        if (reading.getTotalLeads() == 0) {
+            blockers.add("Sem leads observados para medir qualidade do público.");
+        }
+        if (reading.getTotalLeads() > 0 && reading.getCorrectProfessionLeads() * 2 < reading.getTotalLeads()) {
+            blockers.add("Menos da metade dos leads informou profissão correta.");
+        }
+        if (reading.getRealPainResponses() == 0) {
+            blockers.add("Nenhuma resposta trouxe dor real do público.");
+        }
+        if (badSignalCount(reading) > goodSignalCount(reading)) {
+            blockers.add("Sinais ruins superam sinais bons na leitura do público.");
+        }
+        if (reading.getOutOfProfileLeads() > reading.getCorrectProfessionLeads()) {
+            blockers.add("Há mais leads fora do perfil do que leads com profissão correta.");
+        }
+        if (reading.getConfusingPromiseReports() > 0) {
+            blockers.add("Existem relatos de promessa confusa que precisam ajustar criativo ou landing.");
+        }
+        return blockers;
+    }
+
+    /** Calcula recomendações para melhorar a qualidade antes de escalar o público. */
+    private List<String> qualityReadingRecommendations(OprmGeneralAudienceQualityReading reading) {
+        List<String> recommendations = new ArrayList<>();
+        if (reading.getMaterialRequests() == 0) {
+            recommendations.add("Revisar isca: ninguém pediu claramente o material.");
+        }
+        if (reading.getWhatsappReplies() == 0) {
+            recommendations.add("Acompanhar ou reforçar convite de WhatsApp antes de escalar.");
+        }
+        if (reading.getPriceOrNextStepQuestions() == 0) {
+            recommendations.add("Validar próximo passo comercial, pois ainda não houve pergunta de preço ou avanço.");
+        }
+        if (reading.getLowCompletionEvents() > 0) {
+            recommendations.add("Simplificar formulário ou pergunta qualificadora para reduzir baixo preenchimento.");
+        }
+        if (reading.getLeadMagnetNoResponse() > 0) {
+            recommendations.add("Revisar entrega e follow-up: há lead que baixa a isca, mas não responde.");
+        }
+        return recommendations;
+    }
+
+    /** Calcula score percentual ponderando sinais bons contra sinais ruins. */
+    private BigDecimal calculateQualityScore(OprmGeneralAudienceQualityReading reading) {
+        int goodSignals = goodSignalCount(reading);
+        int badSignals = badSignalCount(reading);
+        int totalSignals = goodSignals + badSignals;
+        if (totalSignals == 0) {
+            return BigDecimal.ZERO.setScale(2);
+        }
+        return BigDecimal.valueOf(goodSignals)
+                .multiply(new BigDecimal("100.00"))
+                .divide(BigDecimal.valueOf(totalSignals), 2, RoundingMode.HALF_UP);
+    }
+
+    /** Soma sinais bons definidos na etapa dez do plano de públicos gerais. */
+    private int goodSignalCount(OprmGeneralAudienceQualityReading reading) {
+        return reading.getCorrectProfessionLeads()
+                + reading.getRealPainResponses()
+                + reading.getMaterialRequests()
+                + reading.getWhatsappReplies()
+                + reading.getPriceOrNextStepQuestions();
+    }
+
+    /** Soma sinais ruins definidos na etapa dez do plano de públicos gerais. */
+    private int badSignalCount(OprmGeneralAudienceQualityReading reading) {
+        return reading.getOutOfProfileLeads()
+                + reading.getCuriousWithoutProfession()
+                + reading.getLowCompletionEvents()
+                + reading.getConfusingPromiseReports()
+                + reading.getLeadMagnetNoResponse();
+    }
+
+    /** Normaliza número opcional para zero e rejeita valores negativos. */
+    private int nonNegativeOrZero(Integer value, String fieldName) {
+        if (value == null) {
+            return 0;
+        }
+        if (value < 0) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, fieldName + " não pode ser negativo");
+        }
+        return value;
+    }
+
+    /** Junta mensagens em linhas para persistir sem serializar JSON dentro de texto. */
+    private String joinLines(List<String> lines) {
+        if (lines == null || lines.isEmpty()) {
+            return null;
+        }
+        return String.join("\n", lines);
+    }
+
+    /** Separa mensagens persistidas em linhas simples. */
+    private List<String> splitLines(String value) {
+        if (!StringUtils.hasText(value)) {
+            return List.of();
+        }
+        return value.lines()
+                .map(String::trim)
+                .filter(StringUtils::hasText)
+                .toList();
+    }
+
     /** Valida que o ângulo e o subnicho estão prontos para criar uma hipótese específica. */
     private void validateAngleCanCreateHypothesis(OprmGeneralAudiencePainAngle angle) {
         if (angle.getStatus() != OprmGeneralAudiencePainAngleStatus.APPROVED) {
@@ -735,6 +917,34 @@ public class OprmGeneralAudienceDiscoveryService {
             return null;
         }
         return value.trim();
+    }
+
+    /** Converte entidade de leitura de qualidade para contrato HTTP. */
+    private GeneralAudienceQualityReadingResponse toQualityReadingResponse(OprmGeneralAudienceQualityReading reading) {
+        return new GeneralAudienceQualityReadingResponse(
+                reading.getId(),
+                reading.getSubniche().getId(),
+                reading.getPainAngle() == null ? null : reading.getPainAngle().getId(),
+                reading.getExperimentId(),
+                reading.getTotalLeads(),
+                reading.getCorrectProfessionLeads(),
+                reading.getRealPainResponses(),
+                reading.getMaterialRequests(),
+                reading.getWhatsappReplies(),
+                reading.getPriceOrNextStepQuestions(),
+                reading.getOutOfProfileLeads(),
+                reading.getCuriousWithoutProfession(),
+                reading.getLowCompletionEvents(),
+                reading.getConfusingPromiseReports(),
+                reading.getLeadMagnetNoResponse(),
+                reading.getQualityScore(),
+                reading.isApproved(),
+                splitLines(reading.getBlockers()),
+                splitLines(reading.getRecommendations()),
+                reading.getNotes(),
+                reading.getCapturedAt(),
+                reading.getCreatedAt(),
+                reading.getUpdatedAt());
     }
 
     /** Converte entidade de ângulo para contrato HTTP. */

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/generalaudience/service/createQualityReading/CreateGeneralAudienceQualityReadingRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/generalaudience/service/createQualityReading/CreateGeneralAudienceQualityReadingRequest.java
@@ -1,0 +1,24 @@
+package com.marketinghub.oprm.generalaudience.service.createQualityReading;
+
+import jakarta.validation.constraints.PositiveOrZero;
+import java.time.Instant;
+
+/** Contrato de entrada para registrar sinais de qualidade real dos leads de um público geral. */
+public record CreateGeneralAudienceQualityReadingRequest(
+        Long painAngleId,
+        Long experimentId,
+        @PositiveOrZero Integer totalLeads,
+        @PositiveOrZero Integer correctProfessionLeads,
+        @PositiveOrZero Integer realPainResponses,
+        @PositiveOrZero Integer materialRequests,
+        @PositiveOrZero Integer whatsappReplies,
+        @PositiveOrZero Integer priceOrNextStepQuestions,
+        @PositiveOrZero Integer outOfProfileLeads,
+        @PositiveOrZero Integer curiousWithoutProfession,
+        @PositiveOrZero Integer lowCompletionEvents,
+        @PositiveOrZero Integer confusingPromiseReports,
+        @PositiveOrZero Integer leadMagnetNoResponse,
+        String notes,
+        Instant capturedAt
+) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/generalaudience/service/listQualityReadings/GeneralAudienceQualityReadingResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/generalaudience/service/listQualityReadings/GeneralAudienceQualityReadingResponse.java
@@ -1,0 +1,33 @@
+package com.marketinghub.oprm.generalaudience.service.listQualityReadings;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+
+/** Contrato de saída da leitura de qualidade real de um público geral. */
+public record GeneralAudienceQualityReadingResponse(
+        Long id,
+        Long subnicheId,
+        Long painAngleId,
+        Long experimentId,
+        Integer totalLeads,
+        Integer correctProfessionLeads,
+        Integer realPainResponses,
+        Integer materialRequests,
+        Integer whatsappReplies,
+        Integer priceOrNextStepQuestions,
+        Integer outOfProfileLeads,
+        Integer curiousWithoutProfession,
+        Integer lowCompletionEvents,
+        Integer confusingPromiseReports,
+        Integer leadMagnetNoResponse,
+        BigDecimal qualityScore,
+        boolean approved,
+        List<String> blockers,
+        List<String> recommendations,
+        String notes,
+        Instant capturedAt,
+        Instant createdAt,
+        Instant updatedAt
+) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/oprm/generalaudience/OprmGeneralAudienceQualityReadingRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/oprm/generalaudience/OprmGeneralAudienceQualityReadingRepository.java
@@ -1,0 +1,16 @@
+package com.marketinghub.repository.jpa.oprm.generalaudience;
+
+import com.marketinghub.oprm.generalaudience.OprmGeneralAudienceQualityReading;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/** Repositório responsável pelas leituras de qualidade de públicos gerais do OPRM. */
+public interface OprmGeneralAudienceQualityReadingRepository extends JpaRepository<OprmGeneralAudienceQualityReading, Long> {
+
+    /** Lista leituras de qualidade de um subnicho, da mais recente para a mais antiga. */
+    List<OprmGeneralAudienceQualityReading> findAllBySubnicheIdOrderByCapturedAtDesc(Long subnicheId);
+
+    /** Busca a leitura de qualidade mais recente de um subnicho. */
+    Optional<OprmGeneralAudienceQualityReading> findTopBySubnicheIdOrderByCapturedAtDesc(Long subnicheId);
+}

--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-10-oprm-general-audience-quality-reading.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-10-oprm-general-audience-quality-reading.yaml
@@ -1,0 +1,55 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-06-10-oprm-general-audience-quality-reading
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - onError: HALT
+        - dbms:
+            type: mysql
+        - not:
+            tableExists:
+              tableName: oprm_general_audience_quality_reading
+      changes:
+        - sql:
+            splitStatements: true
+            stripComments: true
+            sql: |
+              CREATE TABLE oprm_general_audience_quality_reading (
+                id BIGINT AUTO_INCREMENT NOT NULL,
+                subniche_id BIGINT NOT NULL,
+                pain_angle_id BIGINT NULL,
+                experiment_id BIGINT NULL,
+                total_leads INT NOT NULL DEFAULT 0,
+                correct_profession_leads INT NOT NULL DEFAULT 0,
+                real_pain_responses INT NOT NULL DEFAULT 0,
+                material_requests INT NOT NULL DEFAULT 0,
+                whatsapp_replies INT NOT NULL DEFAULT 0,
+                price_or_next_step_questions INT NOT NULL DEFAULT 0,
+                out_of_profile_leads INT NOT NULL DEFAULT 0,
+                curious_without_profession INT NOT NULL DEFAULT 0,
+                low_completion_events INT NOT NULL DEFAULT 0,
+                confusing_promise_reports INT NOT NULL DEFAULT 0,
+                lead_magnet_no_response INT NOT NULL DEFAULT 0,
+                quality_score DECIMAL(5,2) NOT NULL DEFAULT 0.00,
+                approved TINYINT(1) NOT NULL DEFAULT 0,
+                blockers LONGTEXT NULL,
+                recommendations LONGTEXT NULL,
+                notes LONGTEXT NULL,
+                captured_at DATETIME NOT NULL,
+                created_at DATETIME NOT NULL,
+                updated_at DATETIME NOT NULL,
+                CONSTRAINT pk_oprm_general_audience_quality_reading PRIMARY KEY (id),
+                CONSTRAINT fk_oprm_general_audience_quality_subniche FOREIGN KEY (subniche_id) REFERENCES oprm_general_audience_subniche(id),
+                CONSTRAINT fk_oprm_general_audience_quality_angle FOREIGN KEY (pain_angle_id) REFERENCES oprm_general_audience_pain_angle(id),
+                CONSTRAINT fk_oprm_general_audience_quality_experiment FOREIGN KEY (experiment_id) REFERENCES experiment(id)
+              );
+
+              CREATE INDEX idx_oprm_general_audience_quality_subniche_captured
+                ON oprm_general_audience_quality_reading (subniche_id, captured_at);
+
+              CREATE INDEX idx_oprm_general_audience_quality_angle_captured
+                ON oprm_general_audience_quality_reading (pain_angle_id, captured_at);
+
+              CREATE INDEX idx_oprm_general_audience_quality_experiment
+                ON oprm_general_audience_quality_reading (experiment_id);

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -1,5 +1,8 @@
 databaseChangeLog:
   - include:
+      file: changesets/2026-06-10-oprm-general-audience-quality-reading.yaml
+      relativeToChangelogFile: true
+  - include:
       file: changesets/2026-06-10-oprm-general-audience-seed.yaml
       relativeToChangelogFile: true
   - include:

--- a/backend/ads-service/src/test/java/com/marketinghub/oprm/generalaudience/controller/OprmGeneralAudienceDiscoveryControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/oprm/generalaudience/controller/OprmGeneralAudienceDiscoveryControllerTest.java
@@ -2,6 +2,7 @@ package com.marketinghub.oprm.generalaudience.controller;
 
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.header;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -14,6 +15,8 @@ import com.marketinghub.oprm.generalaudience.service.createHypothesis.CreateGene
 import com.marketinghub.oprm.generalaudience.service.createHypothesis.GeneralAudienceHypothesisResponse;
 import com.marketinghub.oprm.generalaudience.service.createLeadExperiment.CreateGeneralAudienceLeadExperimentRequest;
 import com.marketinghub.oprm.generalaudience.service.createLeadExperiment.GeneralAudienceLeadExperimentResponse;
+import com.marketinghub.oprm.generalaudience.service.createQualityReading.CreateGeneralAudienceQualityReadingRequest;
+import com.marketinghub.oprm.generalaudience.service.listQualityReadings.GeneralAudienceQualityReadingResponse;
 import com.marketinghub.oprm.generalaudience.service.landingConfirmation.CreateGeneralAudienceLandingConfirmationRequest;
 import com.marketinghub.oprm.generalaudience.service.landingConfirmation.GeneralAudienceLandingConfirmationQuestionResponse;
 import com.marketinghub.oprm.generalaudience.service.landingConfirmation.GeneralAudienceLandingConfirmationResponse;
@@ -148,5 +151,60 @@ class OprmGeneralAudienceDiscoveryControllerTest {
                 .andExpect(jsonPath("$.leadPortalFlowId").value(88))
                 .andExpect(jsonPath("$.questions[0].dataKey").value("audience_confirmation"));
     }
+
+    /** Verifica se a API registra uma leitura de qualidade real de público geral. */
+    @Test
+    void shouldCreateQualityReadingThroughApi() throws Exception {
+        when(service.createQualityReading(any(), any())).thenReturn(new GeneralAudienceQualityReadingResponse(
+                40L,
+                5L,
+                20L,
+                77L,
+                10,
+                7,
+                6,
+                5,
+                3,
+                2,
+                1,
+                0,
+                0,
+                0,
+                1,
+                new BigDecimal("92.00"),
+                true,
+                List.of(),
+                List.of("Revisar follow-up"),
+                "Primeira leitura",
+                Instant.parse("2026-06-10T13:30:00Z"),
+                Instant.parse("2026-06-10T14:00:00Z"),
+                Instant.parse("2026-06-10T14:00:00Z")));
+        CreateGeneralAudienceQualityReadingRequest request = new CreateGeneralAudienceQualityReadingRequest(
+                20L, 77L, 10, 7, 6, 5, 3, 2, 1, 0, 0, 0, 1, "Primeira leitura", null);
+
+        mockMvc.perform(post("/api/oprm/general-audiences/subniches/5/quality-readings")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isCreated())
+                .andExpect(header().string(HttpHeaders.LOCATION, "/api/oprm/general-audiences/quality-readings/40"))
+                .andExpect(jsonPath("$.qualityScore").value(92.00))
+                .andExpect(jsonPath("$.approved").value(true));
+    }
+
+    /** Verifica se a API lista leituras de qualidade real do subnicho. */
+    @Test
+    void shouldListQualityReadingsThroughApi() throws Exception {
+        when(service.listQualityReadings(any())).thenReturn(List.of(new GeneralAudienceQualityReadingResponse(
+                40L, 5L, null, null, 3, 1, 0, 1, 0, 0, 2, 1, 1, 0, 2,
+                new BigDecimal("25.00"), false, List.of("Nenhuma resposta trouxe dor real."), List.of(), null,
+                Instant.parse("2026-06-10T13:30:00Z"), null, null)));
+
+        mockMvc.perform(get("/api/oprm/general-audiences/subniches/5/quality-readings"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].id").value(40))
+                .andExpect(jsonPath("$[0].approved").value(false))
+                .andExpect(jsonPath("$[0].blockers[0]").value("Nenhuma resposta trouxe dor real."));
+    }
+
 
 }

--- a/backend/ads-service/src/test/java/com/marketinghub/oprm/generalaudience/service/OprmGeneralAudienceDiscoveryServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/oprm/generalaudience/service/OprmGeneralAudienceDiscoveryServiceTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.when;
 
 import com.marketinghub.oprm.generalaudience.OprmGeneralAudiencePainAngle;
 import com.marketinghub.oprm.generalaudience.OprmGeneralAudiencePainAngleStatus;
+import com.marketinghub.oprm.generalaudience.OprmGeneralAudienceQualityReading;
 import com.marketinghub.oprm.generalaudience.OprmGeneralAudienceSeed;
 import com.marketinghub.oprm.generalaudience.OprmGeneralAudienceSourceEvidence;
 import com.marketinghub.oprm.generalaudience.OprmGeneralAudienceSubniche;
@@ -15,6 +16,7 @@ import com.marketinghub.oprm.generalaudience.OprmGeneralAudienceSubnicheStatus;
 import com.marketinghub.oprm.generalaudience.service.createHypothesis.CreateGeneralAudienceHypothesisRequest;
 import com.marketinghub.oprm.generalaudience.service.createLeadExperiment.CreateGeneralAudienceLeadExperimentRequest;
 import com.marketinghub.oprm.generalaudience.service.createPainAngle.CreateGeneralAudiencePainAngleRequest;
+import com.marketinghub.oprm.generalaudience.service.createQualityReading.CreateGeneralAudienceQualityReadingRequest;
 import com.marketinghub.oprm.generalaudience.service.prepareTargeting.GeneralAudienceTargetingPreparationRequest;
 import com.marketinghub.oprm.generalaudience.service.createSourceEvidence.CreateGeneralAudienceSourceEvidenceRequest;
 import com.marketinghub.repository.jpa.oprm.generalaudience.OprmGeneralAudienceHypothesisMaterializationRepository;
@@ -22,6 +24,7 @@ import com.marketinghub.repository.jpa.oprm.generalaudience.OprmGeneralAudienceL
 import com.marketinghub.repository.jpa.oprm.generalaudience.OprmGeneralAudienceMaterializedLeadExperiment;
 import com.marketinghub.repository.jpa.oprm.generalaudience.OprmGeneralAudienceMaterializedHypothesis;
 import com.marketinghub.repository.jpa.oprm.generalaudience.OprmGeneralAudiencePainAngleRepository;
+import com.marketinghub.repository.jpa.oprm.generalaudience.OprmGeneralAudienceQualityReadingRepository;
 import com.marketinghub.repository.jpa.oprm.generalaudience.OprmGeneralAudienceSeedRepository;
 import com.marketinghub.repository.jpa.oprm.generalaudience.OprmGeneralAudienceSourceEvidenceRepository;
 import com.marketinghub.repository.jpa.oprm.generalaudience.OprmGeneralAudienceSubnicheRepository;
@@ -96,6 +99,7 @@ class OprmGeneralAudienceDiscoveryServiceTest {
                 subnicheRepository,
                 angleRepository,
                 evidenceRepository,
+                mock(OprmGeneralAudienceQualityReadingRepository.class),
                 mock(OprmGeneralAudienceHypothesisMaterializationRepository.class),
                 mock(OprmGeneralAudienceLeadExperimentMaterializationRepository.class),
                 mock(TargetingElementService.class));
@@ -120,6 +124,7 @@ class OprmGeneralAudienceDiscoveryServiceTest {
                 subnicheRepository,
                 mock(OprmGeneralAudiencePainAngleRepository.class),
                 mock(OprmGeneralAudienceSourceEvidenceRepository.class),
+                mock(OprmGeneralAudienceQualityReadingRepository.class),
                 mock(OprmGeneralAudienceHypothesisMaterializationRepository.class),
                 mock(OprmGeneralAudienceLeadExperimentMaterializationRepository.class),
                 mock(TargetingElementService.class));
@@ -157,6 +162,7 @@ class OprmGeneralAudienceDiscoveryServiceTest {
                 subnicheRepositoryReturning(subniche),
                 angleRepository,
                 mock(OprmGeneralAudienceSourceEvidenceRepository.class),
+                mock(OprmGeneralAudienceQualityReadingRepository.class),
                 hypothesisRepository,
                 mock(OprmGeneralAudienceLeadExperimentMaterializationRepository.class),
                 mock(TargetingElementService.class));
@@ -181,6 +187,7 @@ class OprmGeneralAudienceDiscoveryServiceTest {
                 subnicheRepositoryReturning(subniche),
                 angleRepository,
                 mock(OprmGeneralAudienceSourceEvidenceRepository.class),
+                mock(OprmGeneralAudienceQualityReadingRepository.class),
                 mock(OprmGeneralAudienceHypothesisMaterializationRepository.class),
                 mock(OprmGeneralAudienceLeadExperimentMaterializationRepository.class),
                 mock(TargetingElementService.class));
@@ -219,6 +226,7 @@ class OprmGeneralAudienceDiscoveryServiceTest {
                 subnicheRepositoryReturning(subniche),
                 angleRepository,
                 mock(OprmGeneralAudienceSourceEvidenceRepository.class),
+                mock(OprmGeneralAudienceQualityReadingRepository.class),
                 mock(OprmGeneralAudienceHypothesisMaterializationRepository.class),
                 experimentRepository,
                 mock(TargetingElementService.class));
@@ -253,6 +261,7 @@ class OprmGeneralAudienceDiscoveryServiceTest {
                 subnicheRepositoryReturning(subniche),
                 angleRepository,
                 mock(OprmGeneralAudienceSourceEvidenceRepository.class),
+                mock(OprmGeneralAudienceQualityReadingRepository.class),
                 mock(OprmGeneralAudienceHypothesisMaterializationRepository.class),
                 mock(OprmGeneralAudienceLeadExperimentMaterializationRepository.class),
                 mock(TargetingElementService.class));
@@ -285,6 +294,7 @@ class OprmGeneralAudienceDiscoveryServiceTest {
                 subnicheRepositoryReturning(subniche),
                 angleRepository,
                 mock(OprmGeneralAudienceSourceEvidenceRepository.class),
+                mock(OprmGeneralAudienceQualityReadingRepository.class),
                 mock(OprmGeneralAudienceHypothesisMaterializationRepository.class),
                 mock(OprmGeneralAudienceLeadExperimentMaterializationRepository.class),
                 targetingElementService);
@@ -322,6 +332,7 @@ class OprmGeneralAudienceDiscoveryServiceTest {
                 subnicheRepositoryReturning(subniche),
                 angleRepository,
                 mock(OprmGeneralAudienceSourceEvidenceRepository.class),
+                mock(OprmGeneralAudienceQualityReadingRepository.class),
                 mock(OprmGeneralAudienceHypothesisMaterializationRepository.class),
                 mock(OprmGeneralAudienceLeadExperimentMaterializationRepository.class),
                 targetingElementService);
@@ -342,6 +353,84 @@ class OprmGeneralAudienceDiscoveryServiceTest {
         assertThat(response.blockers()).isEmpty();
         assertThat(response.elements()).anyMatch(element -> element.type() == TargetingElementType.JOB_TITLE
                 && element.publishableForCurrentPublisher());
+    }
+
+
+    /** Verifica se a leitura de qualidade aprova público com profissão correta, dor real e resposta comercial. */
+    @Test
+    void shouldRegisterApprovedQualityReading() {
+        OprmGeneralAudienceSubniche subniche = subniche();
+        OprmGeneralAudiencePainAngle angle = approvedAngle(subniche);
+        OprmGeneralAudiencePainAngleRepository angleRepository = mock(OprmGeneralAudiencePainAngleRepository.class);
+        OprmGeneralAudienceQualityReadingRepository qualityRepository = mock(OprmGeneralAudienceQualityReadingRepository.class);
+        when(angleRepository.findById(20L)).thenReturn(Optional.of(angle));
+        when(qualityRepository.save(any())).thenAnswer(invocation -> {
+            OprmGeneralAudienceQualityReading reading = invocation.getArgument(0);
+            reading.setId(40L);
+            reading.setCreatedAt(Instant.parse("2026-06-10T14:00:00Z"));
+            reading.setUpdatedAt(Instant.parse("2026-06-10T14:00:00Z"));
+            return reading;
+        });
+        OprmGeneralAudienceDiscoveryService service = new OprmGeneralAudienceDiscoveryService(
+                mock(OprmGeneralAudienceSeedRepository.class),
+                subnicheRepositoryReturning(subniche),
+                angleRepository,
+                mock(OprmGeneralAudienceSourceEvidenceRepository.class),
+                qualityRepository,
+                mock(OprmGeneralAudienceHypothesisMaterializationRepository.class),
+                mock(OprmGeneralAudienceLeadExperimentMaterializationRepository.class),
+                mock(TargetingElementService.class));
+
+        var response = service.createQualityReading(5L, new CreateGeneralAudienceQualityReadingRequest(
+                20L,
+                77L,
+                10,
+                7,
+                6,
+                5,
+                3,
+                2,
+                1,
+                0,
+                0,
+                0,
+                1,
+                "Primeira leitura pós-formulário",
+                Instant.parse("2026-06-10T13:30:00Z")));
+
+        assertThat(response.id()).isEqualTo(40L);
+        assertThat(response.approved()).isTrue();
+        assertThat(response.qualityScore()).isEqualByComparingTo("92.00");
+        assertThat(response.blockers()).isEmpty();
+        assertThat(response.recommendations()).anyMatch(item -> item.contains("follow-up"));
+    }
+
+    /** Verifica se a leitura de qualidade bloqueia público fora do perfil e sem dor real. */
+    @Test
+    void shouldBlockLowQualityAudienceReading() {
+        OprmGeneralAudienceSubniche subniche = subniche();
+        OprmGeneralAudienceQualityReadingRepository qualityRepository = mock(OprmGeneralAudienceQualityReadingRepository.class);
+        when(qualityRepository.save(any())).thenAnswer(invocation -> {
+            OprmGeneralAudienceQualityReading reading = invocation.getArgument(0);
+            reading.setId(41L);
+            return reading;
+        });
+        OprmGeneralAudienceDiscoveryService service = new OprmGeneralAudienceDiscoveryService(
+                mock(OprmGeneralAudienceSeedRepository.class),
+                subnicheRepositoryReturning(subniche),
+                mock(OprmGeneralAudiencePainAngleRepository.class),
+                mock(OprmGeneralAudienceSourceEvidenceRepository.class),
+                qualityRepository,
+                mock(OprmGeneralAudienceHypothesisMaterializationRepository.class),
+                mock(OprmGeneralAudienceLeadExperimentMaterializationRepository.class),
+                mock(TargetingElementService.class));
+
+        var response = service.createQualityReading(5L, new CreateGeneralAudienceQualityReadingRequest(
+                null, null, 10, 2, 0, 1, 0, 0, 6, 2, 1, 1, 3, null, null));
+
+        assertThat(response.approved()).isFalse();
+        assertThat(response.blockers()).anyMatch(item -> item.contains("profissão correta"));
+        assertThat(response.blockers()).anyMatch(item -> item.contains("dor real"));
     }
 
     /** Monta serviço com repositório de subnicho e repositórios auxiliares mockados. */
@@ -365,6 +454,7 @@ class OprmGeneralAudienceDiscoveryServiceTest {
                 subnicheRepository,
                 angleRepository,
                 evidenceRepository,
+                mock(OprmGeneralAudienceQualityReadingRepository.class),
                 mock(OprmGeneralAudienceHypothesisMaterializationRepository.class),
                 mock(OprmGeneralAudienceLeadExperimentMaterializationRepository.class),
                 mock(TargetingElementService.class));

--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -361,3 +361,9 @@
 - Executada a etapa 9 do plano de públicos gerais sem sobreposição CNAE: criado endpoint OPRM para materializar fluxo de Lead Portal como landing/formulário de confirmação a partir de ângulo aprovado, exigindo subnicho convertido, experimento, pergunta qualificadora e opções de triagem.
 - A landing/formulário passa a explicitar para quem é, qual dor resolve, o que a pessoa recebe, por que faz sentido, próximo passo e duas perguntas obrigatórias: pertencimento ao público e confirmação textual da dor, sem publicar campanha ou oferta final automaticamente.
 - 2026-06-10 15:05:00 (UTC): implementada a etapa de sinais iniciais Meta Ads para nichos enriquecidos OPRM NichoCNAE. Ao concluir a materialização final, o backend agora gera interesses, cargos e comportamentos por CNAE, grava esses sinais nas listas do `market_niche` e publica `targeting_element` aprovado com origem `OPRM_NICHE`; o Facebook Ads Worker passa a consumir esses elementos pendentes e devolver ID oficial e faixa de alcance da Meta (`audience_size_lower_bound`/`audience_size_upper_bound`) para decisão de campanha.
+
+## 2026-06-10 — OPRM Públicos Gerais: leitura de qualidade do público
+
+- Executada a etapa 10 do plano de públicos gerais sem sobreposição CNAE: o backend passou a registrar leituras de qualidade real por subnicho, medindo sinais bons além de CTR/CPL — profissão correta, dor real, pedido de material, resposta no WhatsApp e pergunta de preço/próximo passo.
+- A leitura também registra sinais ruins — público fora do perfil, curiosos sem profissão, baixo preenchimento, promessa confusa e lead que baixa a isca sem responder — calculando score, bloqueios e recomendações antes de qualquer escala comercial.
+- O quality gate de públicos gerais agora considera a leitura mais recente, preservando a causa-raiz comercial: público amplo só avança quando os leads demonstram aderência e intenção real, não apenas clique barato.

--- a/docs/swagger/oprm-general-audiences-swagger.yaml
+++ b/docs/swagger/oprm-general-audiences-swagger.yaml
@@ -364,6 +364,39 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/GeneralAudienceSourceEvidence"
+  /api/oprm/general-audiences/subniches/{subnicheId}/quality-readings:
+    get:
+      summary: Lista leituras de qualidade real do público geral além de CTR e CPL.
+      tags: [OPRM Públicos Gerais]
+      parameters:
+        - $ref: "#/components/parameters/SubnicheId"
+      responses:
+        "200":
+          description: Leituras de qualidade do público.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: "#/components/schemas/GeneralAudienceQualityReading"
+    post:
+      summary: Registra sinais bons e ruins para medir qualidade do público.
+      tags: [OPRM Públicos Gerais]
+      parameters:
+        - $ref: "#/components/parameters/SubnicheId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateGeneralAudienceQualityReadingRequest"
+      responses:
+        "201":
+          description: Leitura de qualidade registrada.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralAudienceQualityReading"
   /api/oprm/general-audiences/subniches/{subnicheId}/quality-gate:
     get:
       summary: Avalia se o subnicho pode avançar sem saída genérica ou promessa arriscada.
@@ -910,6 +943,89 @@ components:
             seedId:
               type: integer
               format: int64
+    CreateGeneralAudienceQualityReadingRequest:
+      type: object
+      properties:
+        painAngleId:
+          type: integer
+          format: int64
+          nullable: true
+        experimentId:
+          type: integer
+          format: int64
+          nullable: true
+        totalLeads:
+          type: integer
+          minimum: 0
+        correctProfessionLeads:
+          type: integer
+          minimum: 0
+        realPainResponses:
+          type: integer
+          minimum: 0
+        materialRequests:
+          type: integer
+          minimum: 0
+        whatsappReplies:
+          type: integer
+          minimum: 0
+        priceOrNextStepQuestions:
+          type: integer
+          minimum: 0
+        outOfProfileLeads:
+          type: integer
+          minimum: 0
+        curiousWithoutProfession:
+          type: integer
+          minimum: 0
+        lowCompletionEvents:
+          type: integer
+          minimum: 0
+        confusingPromiseReports:
+          type: integer
+          minimum: 0
+        leadMagnetNoResponse:
+          type: integer
+          minimum: 0
+        notes:
+          type: string
+          nullable: true
+        capturedAt:
+          type: string
+          format: date-time
+          nullable: true
+    GeneralAudienceQualityReading:
+      allOf:
+        - $ref: "#/components/schemas/CreateGeneralAudienceQualityReadingRequest"
+        - type: object
+          required:
+            [id, subnicheId, totalLeads, qualityScore, approved, blockers, recommendations, capturedAt, createdAt, updatedAt]
+          properties:
+            id:
+              type: integer
+              format: int64
+            subnicheId:
+              type: integer
+              format: int64
+            qualityScore:
+              type: number
+              format: decimal
+            approved:
+              type: boolean
+            blockers:
+              type: array
+              items:
+                type: string
+            recommendations:
+              type: array
+              items:
+                type: string
+            createdAt:
+              type: string
+              format: date-time
+            updatedAt:
+              type: string
+              format: date-time
     GeneralAudienceQualityGate:
       type: object
       required: [subnicheId, approved, blockers, recommendations]


### PR DESCRIPTION
### Motivation
- Implementar um fluxo paralelo para "Públicos Gerais" que permita descobrir subnichos, mapear dores e validar qualidade sem sobrepor ou falsificar o pipeline CNAE existente. 
- Garantir gates de qualidade e artefatos auditáveis (evidências, perguntas de triagem, targeting conservador) antes de converter subnichos em nichos comerciais ou criar experimentos. 
- Fornecer APIs operacionais e integração com Lead Portal para confirmação do público/landing, preservando rastreabilidade e segregação entre origens. 
- Evitar promessas arriscadas e publicação de ad sets amplos sem validação manual/Meta, seguindo padrões de arquitetura do backend. 

### Description
- Adicionados modelos persistidos e changelogs Liquibase para as tabelas novas `oprm_general_audience_seed`, `oprm_general_audience_subniche`, `oprm_general_audience_pain_angle` e `oprm_general_audience_source_evidence` em `backend/ads-service/src/main/resources/db/changelog/changesets/`.
- Implementados controllers e serviços OPRM para CRUD e pipeline de descoberta: `OprmGeneralAudienceController`, `OprmGeneralAudienceDiscoveryController`, `OprmGeneralAudienceService`, `OprmGeneralAudienceDiscoveryService` e `OprmGeneralAudienceLandingConfirmationService`, com DTOs como `record` e rotas em `/api/oprm/general-audiences`.
- Implementada a lógica do Quality Gate (Etapa 10 — leitura de qualidade do público) em `evaluateQualityGate(...)`, validações de segurança de ângulo (`validateSafeAngle`), critérios de avanço e recomendações; também criado pipeline `OPRM_GENERAL_AUDIENCE_DISCOVERY` e stages correspondentes.
- Integração operacional: repositories centralizados em `com.marketinghub.repository.jpa.oprm.generalaudience`, materializadores para hipótese/experimento (`*MaterializationRepository`), Swagger (`docs/swagger/oprm-general-audiences-swagger.yaml`) e geração de targeting conservador que cria `TargetingElement` (origem auditável) sem liberar ad set amplo puro. 

### Testing
- Foram adicionados testes unitários e de controller em `backend/ads-service/src/test/java/com/marketinghub/oprm/generalaudience/` cobrindo controller, service, discovery, landing confirmation e materializers. 
- Também foram incluídos testes auxiliares que exercitam a criação de lead/experiments e a preparação de targeting (mocks de `TargetingElementService` e `LeadPortalFlowService`). 
- Nenhuma suíte de testes automatizada foi executada durante este rollout; recomenda-se executar os testes do módulo `ads-service` localmente ou no CI (`:backend:ads-service:test`) antes de abrir o PR final. 
- Revisões manuais focadas em arquitetura foram aplicadas para garantir que todos os repositories fiquem sob `com.marketinghub.repository` e que contratos Swagger/DTOs sejam atualizados com o novo fluxo.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a299a45db848320a225d82f58e8d49c)