### PR TITLE
OPRM: Persist landing confirmation records and remove Lead Portal/Experiment coupling

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/generalaudience/OprmGeneralAudienceLandingConfirmation.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/generalaudience/OprmGeneralAudienceLandingConfirmation.java
@@ -1,0 +1,181 @@
+package com.marketinghub.oprm.generalaudience;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.PrePersist;
+import jakarta.persistence.PreUpdate;
+import jakarta.persistence.Table;
+import java.time.Instant;
+
+/** Responsável por armazenar a situação de confirmação preparada pelo OPRM para uso posterior por outros módulos. */
+@Entity
+@Table(name = "oprm_general_audience_landing_confirmation")
+public class OprmGeneralAudienceLandingConfirmation {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "pain_angle_id", nullable = false)
+    private OprmGeneralAudiencePainAngle painAngle;
+
+    @Column(name = "experiment_id")
+    private Long experimentId;
+
+    @Column(name = "market_niche_id", nullable = false)
+    private Long marketNicheId;
+
+    @Column(name = "name", nullable = false, length = 255)
+    private String name;
+
+    @Column(name = "slug", nullable = false, length = 255)
+    private String slug;
+
+    @Column(name = "audience_summary", nullable = false, columnDefinition = "LONGTEXT")
+    private String audienceSummary;
+
+    @Column(name = "pain_summary", nullable = false, columnDefinition = "LONGTEXT")
+    private String painSummary;
+
+    @Column(name = "audience_confirmation_question", nullable = false, columnDefinition = "LONGTEXT")
+    private String audienceConfirmationQuestion;
+
+    @Column(name = "qualification_options", nullable = false, columnDefinition = "LONGTEXT")
+    private String qualificationOptions;
+
+    @Column(name = "pain_confirmation_question", nullable = false, columnDefinition = "LONGTEXT")
+    private String painConfirmationQuestion;
+
+    @Column(name = "delivery_description", nullable = false, columnDefinition = "LONGTEXT")
+    private String deliveryDescription;
+
+    @Column(name = "why_it_makes_sense", nullable = false, columnDefinition = "LONGTEXT")
+    private String whyItMakesSense;
+
+    @Column(name = "next_step", nullable = false, columnDefinition = "LONGTEXT")
+    private String nextStep;
+
+    @Column(name = "status", nullable = false, length = 32)
+    private String status;
+
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+
+    /** Inicializa os carimbos de criação e atualização do registro de confirmação. */
+    @PrePersist
+    void onCreate() {
+        Instant now = Instant.now();
+        createdAt = now;
+        updatedAt = now;
+    }
+
+    /** Atualiza o carimbo de modificação do registro de confirmação. */
+    @PreUpdate
+    void onUpdate() {
+        updatedAt = Instant.now();
+    }
+
+    /** Retorna o identificador do registro. */
+    public Long getId() { return id; }
+
+    /** Define o identificador do registro. */
+    public void setId(Long id) { this.id = id; }
+
+    /** Retorna o ângulo de dor relacionado. */
+    public OprmGeneralAudiencePainAngle getPainAngle() { return painAngle; }
+
+    /** Define o ângulo de dor relacionado. */
+    public void setPainAngle(OprmGeneralAudiencePainAngle painAngle) { this.painAngle = painAngle; }
+
+    /** Retorna o identificador externo do experimento informado, sem depender do módulo de experimentos. */
+    public Long getExperimentId() { return experimentId; }
+
+    /** Define o identificador externo do experimento informado. */
+    public void setExperimentId(Long experimentId) { this.experimentId = experimentId; }
+
+    /** Retorna o identificador do MarketNiche convertido. */
+    public Long getMarketNicheId() { return marketNicheId; }
+
+    /** Define o identificador do MarketNiche convertido. */
+    public void setMarketNicheId(Long marketNicheId) { this.marketNicheId = marketNicheId; }
+
+    /** Retorna o nome operacional da confirmação. */
+    public String getName() { return name; }
+
+    /** Define o nome operacional da confirmação. */
+    public void setName(String name) { this.name = name; }
+
+    /** Retorna o slug operacional sugerido. */
+    public String getSlug() { return slug; }
+
+    /** Define o slug operacional sugerido. */
+    public void setSlug(String slug) { this.slug = slug; }
+
+    /** Retorna o resumo do público confirmado. */
+    public String getAudienceSummary() { return audienceSummary; }
+
+    /** Define o resumo do público confirmado. */
+    public void setAudienceSummary(String audienceSummary) { this.audienceSummary = audienceSummary; }
+
+    /** Retorna o resumo da dor confirmada. */
+    public String getPainSummary() { return painSummary; }
+
+    /** Define o resumo da dor confirmada. */
+    public void setPainSummary(String painSummary) { this.painSummary = painSummary; }
+
+    /** Retorna a pergunta que confirma pertencimento ao público. */
+    public String getAudienceConfirmationQuestion() { return audienceConfirmationQuestion; }
+
+    /** Define a pergunta que confirma pertencimento ao público. */
+    public void setAudienceConfirmationQuestion(String audienceConfirmationQuestion) {
+        this.audienceConfirmationQuestion = audienceConfirmationQuestion;
+    }
+
+    /** Retorna as opções de qualificação separadas por quebra de linha. */
+    public String getQualificationOptions() { return qualificationOptions; }
+
+    /** Define as opções de qualificação separadas por quebra de linha. */
+    public void setQualificationOptions(String qualificationOptions) { this.qualificationOptions = qualificationOptions; }
+
+    /** Retorna a pergunta que confirma a dor. */
+    public String getPainConfirmationQuestion() { return painConfirmationQuestion; }
+
+    /** Define a pergunta que confirma a dor. */
+    public void setPainConfirmationQuestion(String painConfirmationQuestion) {
+        this.painConfirmationQuestion = painConfirmationQuestion;
+    }
+
+    /** Retorna a descrição de entrega sugerida. */
+    public String getDeliveryDescription() { return deliveryDescription; }
+
+    /** Define a descrição de entrega sugerida. */
+    public void setDeliveryDescription(String deliveryDescription) { this.deliveryDescription = deliveryDescription; }
+
+    /** Retorna por que a confirmação faz sentido. */
+    public String getWhyItMakesSense() { return whyItMakesSense; }
+
+    /** Define por que a confirmação faz sentido. */
+    public void setWhyItMakesSense(String whyItMakesSense) { this.whyItMakesSense = whyItMakesSense; }
+
+    /** Retorna o próximo passo operacional sugerido. */
+    public String getNextStep() { return nextStep; }
+
+    /** Define o próximo passo operacional sugerido. */
+    public void setNextStep(String nextStep) { this.nextStep = nextStep; }
+
+    /** Retorna o status operacional do registro. */
+    public String getStatus() { return status; }
+
+    /** Define o status operacional do registro. */
+    public void setStatus(String status) { this.status = status; }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/generalaudience/controller/OprmGeneralAudienceDiscoveryController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/generalaudience/controller/OprmGeneralAudienceDiscoveryController.java
@@ -107,7 +107,7 @@ public class OprmGeneralAudienceDiscoveryController {
         return ResponseEntity.ok(service.prepareInitialTargeting(angleId, request));
     }
 
-    /** Cria landing/formulário para confirmar público, dor, entrega e próximo passo. */
+    /** Registra no banco a situação para confirmar público, dor, entrega e próximo passo. */
     @PostMapping("/pain-angles/{angleId}/create-confirmation-flow")
     public ResponseEntity<GeneralAudienceLandingConfirmationResponse> createConfirmationFlow(
             @PathVariable Long angleId,
@@ -116,7 +116,7 @@ public class OprmGeneralAudienceDiscoveryController {
                 angleId,
                 request);
         return ResponseEntity
-                .created(URI.create("/api/lead-portal/flows/" + response.leadPortalFlowId()))
+                .created(URI.create("/api/oprm/general-audiences/landing-confirmations/" + response.confirmationRecordId()))
                 .body(response);
     }
 

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/generalaudience/service/OprmGeneralAudienceLandingConfirmationService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/generalaudience/service/OprmGeneralAudienceLandingConfirmationService.java
@@ -1,12 +1,6 @@
 package com.marketinghub.oprm.generalaudience.service;
 
-import com.marketinghub.experiment.Experiment;
-import com.marketinghub.leadportal.LeadPortalFlow;
-import com.marketinghub.leadportal.LeadPortalFlowQuestion;
-import com.marketinghub.leadportal.LeadPortalQuestionType;
-import com.marketinghub.leadportal.dto.CreateLeadPortalFlowRequest;
-import com.marketinghub.leadportal.dto.LeadPortalFlowQuestionRequest;
-import com.marketinghub.leadportal.service.LeadPortalFlowService;
+import com.marketinghub.oprm.generalaudience.OprmGeneralAudienceLandingConfirmation;
 import com.marketinghub.oprm.generalaudience.OprmGeneralAudiencePainAngle;
 import com.marketinghub.oprm.generalaudience.OprmGeneralAudiencePainAngleStatus;
 import com.marketinghub.oprm.generalaudience.OprmGeneralAudienceSubniche;
@@ -14,39 +8,36 @@ import com.marketinghub.oprm.generalaudience.OprmGeneralAudienceSubnicheStatus;
 import com.marketinghub.oprm.generalaudience.service.landingConfirmation.CreateGeneralAudienceLandingConfirmationRequest;
 import com.marketinghub.oprm.generalaudience.service.landingConfirmation.GeneralAudienceLandingConfirmationQuestionResponse;
 import com.marketinghub.oprm.generalaudience.service.landingConfirmation.GeneralAudienceLandingConfirmationResponse;
-import com.marketinghub.repository.jpa.experiment.ExperimentRepository;
+import com.marketinghub.repository.jpa.oprm.generalaudience.OprmGeneralAudienceLandingConfirmationRepository;
 import com.marketinghub.repository.jpa.oprm.generalaudience.OprmGeneralAudiencePainAngleRepository;
 import java.text.Normalizer;
-import java.util.ArrayList;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
-import java.util.UUID;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 import org.springframework.web.server.ResponseStatusException;
 
-/** Responsável por materializar landing/formulário de confirmação para públicos gerais OPRM. */
+/** Responsável por registrar no banco a situação de confirmação preparada pelo OPRM sem acionar outros módulos. */
 @Service
 public class OprmGeneralAudienceLandingConfirmationService {
 
-    private final OprmGeneralAudiencePainAngleRepository painAngleRepository;
-    private final LeadPortalFlowService leadPortalFlowService;
-    private final ExperimentRepository experimentRepository;
+    private static final String REGISTERED_STATUS = "REGISTERED";
 
-    /** Inicializa o serviço com repositórios OPRM e serviço canônico do Lead Portal. */
+    private final OprmGeneralAudiencePainAngleRepository painAngleRepository;
+    private final OprmGeneralAudienceLandingConfirmationRepository landingConfirmationRepository;
+
+    /** Inicializa o serviço somente com repositórios OPRM permitidos pela arquitetura. */
     public OprmGeneralAudienceLandingConfirmationService(
             OprmGeneralAudiencePainAngleRepository painAngleRepository,
-            LeadPortalFlowService leadPortalFlowService,
-            ExperimentRepository experimentRepository) {
+            OprmGeneralAudienceLandingConfirmationRepository landingConfirmationRepository) {
         this.painAngleRepository = painAngleRepository;
-        this.leadPortalFlowService = leadPortalFlowService;
-        this.experimentRepository = experimentRepository;
+        this.landingConfirmationRepository = landingConfirmationRepository;
     }
 
-    /** Cria um formulário de confirmação sem publicar landing ou campanha automaticamente. */
+    /** Registra a situação de confirmação sem criar fluxo no Lead Portal ou alterar experimento. */
     @Transactional
     public GeneralAudienceLandingConfirmationResponse createConfirmationFlow(
             Long angleId,
@@ -55,53 +46,25 @@ public class OprmGeneralAudienceLandingConfirmationService {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Payload da landing/formulário é obrigatório");
         }
         OprmGeneralAudiencePainAngle angle = findPainAngle(angleId);
-        validateAngleCanCreateConfirmationFlow(angle, request);
+        validateAngleCanCreateConfirmationRecord(angle, request);
         OprmGeneralAudienceSubniche subniche = angle.getSubniche();
         String audienceQuestion = resolveAudienceQuestion(subniche, angle, request);
         List<String> qualificationOptions = normalizeQualificationOptions(request.qualificationOptions());
         String deliveryDescription = resolveDeliveryDescription(angle, request);
         String whyItMakesSense = resolveWhyItMakesSense(angle, request);
         String nextStep = resolveNextStep(request);
-        Experiment experiment = findExperimentForSubniche(request.experimentId(), subniche.getMarketNicheId());
-        LeadPortalFlow flow = leadPortalFlowService.create(buildFlowRequest(
-                subniche,
+        String painQuestion = resolvePainConfirmationQuestion(angle, request);
+        OprmGeneralAudienceLandingConfirmation confirmation = landingConfirmationRepository.save(buildConfirmation(
                 angle,
+                subniche,
                 request,
                 audienceQuestion,
                 qualificationOptions,
+                painQuestion,
                 deliveryDescription,
                 whyItMakesSense,
                 nextStep));
-        attachFlowToExperiment(experiment, flow);
-        return toResponse(
-                angle,
-                subniche,
-                flow,
-                request.experimentId(),
-                deliveryDescription,
-                whyItMakesSense,
-                nextStep);
-    }
-
-    /** Busca e valida o experimento antes de criar o formulário para evitar fluxo órfão. */
-    private Experiment findExperimentForSubniche(Long experimentId, Long marketNicheId) {
-        Experiment experiment = experimentRepository.findById(experimentId)
-                .orElseThrow(() -> new ResponseStatusException(
-                        HttpStatus.NOT_FOUND,
-                        "Experimento não encontrado: " + experimentId));
-        if (experiment.getNiche() == null || !marketNicheId.equals(experiment.getNiche().getId())) {
-            throw new ResponseStatusException(
-                    HttpStatus.BAD_REQUEST,
-                    "Experimento não pertence ao MarketNiche do subnicho geral");
-        }
-        return experiment;
-    }
-
-    /** Vincula o fluxo criado ao experimento para o próximo passo operacional usar a landing correta. */
-    private void attachFlowToExperiment(Experiment experiment, LeadPortalFlow flow) {
-        experiment.setLeadPortalFlow(flow);
-        experiment.setSchemaFirstLeadPortalEnabled(true);
-        experimentRepository.save(experiment);
+        return toResponse(confirmation, qualificationOptions);
     }
 
     /** Busca o ângulo ou devolve erro HTTP de recurso inexistente. */
@@ -112,8 +75,8 @@ public class OprmGeneralAudienceLandingConfirmationService {
                         "Ângulo de público geral não encontrado: " + angleId));
     }
 
-    /** Valida pré-condições para a landing confirmar público real e não virar oferta final. */
-    private void validateAngleCanCreateConfirmationFlow(
+    /** Valida pré-condições para registrar a situação sem materializar outros módulos. */
+    private void validateAngleCanCreateConfirmationRecord(
             OprmGeneralAudiencePainAngle angle,
             CreateGeneralAudienceLandingConfirmationRequest request) {
         if (request.experimentId() == null) {
@@ -136,128 +99,71 @@ public class OprmGeneralAudienceLandingConfirmationService {
         normalizeQualificationOptions(request.qualificationOptions());
     }
 
-    /** Monta o contrato canônico do Lead Portal com as perguntas obrigatórias de confirmação. */
-    private CreateLeadPortalFlowRequest buildFlowRequest(
-            OprmGeneralAudienceSubniche subniche,
+    /** Monta o registro OPRM que descreve a situação a ser consumida por etapa posterior. */
+    private OprmGeneralAudienceLandingConfirmation buildConfirmation(
             OprmGeneralAudiencePainAngle angle,
+            OprmGeneralAudienceSubniche subniche,
             CreateGeneralAudienceLandingConfirmationRequest request,
             String audienceQuestion,
             List<String> qualificationOptions,
+            String painQuestion,
             String deliveryDescription,
             String whyItMakesSense,
             String nextStep) {
-        CreateLeadPortalFlowRequest flowRequest = new CreateLeadPortalFlowRequest();
-        flowRequest.setName(resolveFlowName(subniche, angle, request));
-        flowRequest.setSlug(buildSlug(subniche, angle, request.experimentId()));
-        flowRequest.setDescription(buildFlowDescription(subniche, angle, deliveryDescription, whyItMakesSense, nextStep));
-        flowRequest.setSchemaFirst(true);
-        flowRequest.setMarketNicheId(subniche.getMarketNicheId());
-        flowRequest.setExperimentId(request.experimentId());
-        flowRequest.setQuestions(buildQuestions(angle, request, audienceQuestion, qualificationOptions));
-        return flowRequest;
+        OprmGeneralAudienceLandingConfirmation confirmation = new OprmGeneralAudienceLandingConfirmation();
+        confirmation.setPainAngle(angle);
+        confirmation.setExperimentId(request.experimentId());
+        confirmation.setMarketNicheId(subniche.getMarketNicheId());
+        confirmation.setName(resolveRecordName(subniche, angle, request));
+        confirmation.setSlug(buildSlug(subniche, angle, request.experimentId()));
+        confirmation.setAudienceSummary(subniche.getName().trim());
+        confirmation.setPainSummary(angle.getPain().trim());
+        confirmation.setAudienceConfirmationQuestion(audienceQuestion);
+        confirmation.setQualificationOptions(String.join("\n", qualificationOptions));
+        confirmation.setPainConfirmationQuestion(painQuestion);
+        confirmation.setDeliveryDescription(deliveryDescription);
+        confirmation.setWhyItMakesSense(whyItMakesSense);
+        confirmation.setNextStep(nextStep);
+        confirmation.setStatus(REGISTERED_STATUS);
+        return confirmation;
     }
 
-    /** Monta as perguntas obrigatórias para confirmar pertencimento e dor do lead. */
-    private List<LeadPortalFlowQuestionRequest> buildQuestions(
-            OprmGeneralAudiencePainAngle angle,
-            CreateGeneralAudienceLandingConfirmationRequest request,
-            String audienceQuestion,
-            List<String> qualificationOptions) {
-        List<LeadPortalFlowQuestionRequest> questions = new ArrayList<>();
-        questions.add(singleChoiceQuestion(
-                audienceQuestion,
-                "audience_confirmation",
-                "Confirma se o lead pertence ao público antes de entregar a isca.",
-                qualificationOptions));
-        questions.add(textQuestion(
-                resolvePainQuestion(angle, request),
-                "pain_confirmation",
-                "Confirma a dor principal com linguagem real do lead."));
-        return questions;
-    }
-
-    /** Cria pergunta de escolha única obrigatória para triagem de público. */
-    private LeadPortalFlowQuestionRequest singleChoiceQuestion(
-            String title,
-            String dataKey,
-            String description,
-            List<String> options) {
-        LeadPortalFlowQuestionRequest question = new LeadPortalFlowQuestionRequest();
-        question.setTitle(title);
-        question.setDataKey(dataKey);
-        question.setType(LeadPortalQuestionType.SINGLE_CHOICE);
-        question.setRequired(true);
-        question.setDescription(description);
-        question.setOptions(options);
-        return question;
-    }
-
-    /** Cria pergunta textual obrigatória para capturar sinal de dor real. */
-    private LeadPortalFlowQuestionRequest textQuestion(
-            String title,
-            String dataKey,
-            String description) {
-        LeadPortalFlowQuestionRequest question = new LeadPortalFlowQuestionRequest();
-        question.setTitle(title);
-        question.setDataKey(dataKey);
-        question.setType(LeadPortalQuestionType.TEXT);
-        question.setRequired(true);
-        question.setDescription(description);
-        return question;
-    }
-
-    /** Monta descrição funcional da landing com todos os pontos exigidos pela etapa 9. */
-    private String buildFlowDescription(
-            OprmGeneralAudienceSubniche subniche,
-            OprmGeneralAudiencePainAngle angle,
-            String deliveryDescription,
-            String whyItMakesSense,
-            String nextStep) {
-        return String.join("\n\n",
-                "Para quem é: " + subniche.getName(),
-                "Qual dor resolve: " + angle.getPain(),
-                "O que a pessoa recebe: " + deliveryDescription,
-                "Por que faz sentido: " + whyItMakesSense,
-                "Próximo passo: " + nextStep,
-                "Confirmação obrigatória: o formulário deve verificar se o lead pertence ao público antes de avançar.");
-    }
-
-    /** Converte o fluxo criado para resposta específica do OPRM Público Geral. */
+    /** Converte o registro persistido em resposta sem expor dependência do Lead Portal. */
     private GeneralAudienceLandingConfirmationResponse toResponse(
-            OprmGeneralAudiencePainAngle angle,
-            OprmGeneralAudienceSubniche subniche,
-            LeadPortalFlow flow,
-            Long experimentId,
-            String deliveryDescription,
-            String whyItMakesSense,
-            String nextStep) {
+            OprmGeneralAudienceLandingConfirmation confirmation,
+            List<String> qualificationOptions) {
+        OprmGeneralAudiencePainAngle angle = confirmation.getPainAngle();
+        OprmGeneralAudienceSubniche subniche = angle.getSubniche();
         return new GeneralAudienceLandingConfirmationResponse(
+                confirmation.getId(),
                 angle.getId(),
                 subniche.getId(),
-                subniche.getMarketNicheId(),
-                experimentId,
-                flow.getId(),
-                flow.getSlug(),
-                flow.getName(),
-                subniche.getName(),
-                angle.getPain(),
-                deliveryDescription,
-                whyItMakesSense,
-                nextStep,
-                flow.getQuestions().stream().map(this::toQuestionResponse).toList());
+                confirmation.getMarketNicheId(),
+                confirmation.getExperimentId(),
+                confirmation.getSlug(),
+                confirmation.getName(),
+                confirmation.getAudienceSummary(),
+                confirmation.getPainSummary(),
+                confirmation.getDeliveryDescription(),
+                confirmation.getWhyItMakesSense(),
+                confirmation.getNextStep(),
+                confirmation.getStatus(),
+                List.of(
+                        new GeneralAudienceLandingConfirmationQuestionResponse(
+                                confirmation.getAudienceConfirmationQuestion(),
+                                "audience_confirmation",
+                                "SINGLE_CHOICE",
+                                true,
+                                qualificationOptions),
+                        new GeneralAudienceLandingConfirmationQuestionResponse(
+                                confirmation.getPainConfirmationQuestion(),
+                                "pain_confirmation",
+                                "TEXT",
+                                true,
+                                List.of())));
     }
 
-    /** Converte pergunta do Lead Portal para resumo auditável no contrato OPRM. */
-    private GeneralAudienceLandingConfirmationQuestionResponse toQuestionResponse(LeadPortalFlowQuestion question) {
-        return new GeneralAudienceLandingConfirmationQuestionResponse(
-                question.getTitle(),
-                question.getDataKey(),
-                question.getType().name(),
-                question.isRequired(),
-                List.copyOf(question.getOptions()));
-    }
-
-    /** Resolve a pergunta qualificadora priorizando a pergunta específica da landing. */
+    /** Resolve a pergunta de confirmação de público a partir do pedido ou dos dados já aprovados. */
     private String resolveAudienceQuestion(
             OprmGeneralAudienceSubniche subniche,
             OprmGeneralAudiencePainAngle angle,
@@ -268,120 +174,113 @@ public class OprmGeneralAudienceLandingConfirmationService {
         if (StringUtils.hasText(angle.getLandingConfirmationQuestion())) {
             return angle.getLandingConfirmationQuestion().trim();
         }
-        return subniche.getQualificationQuestion();
+        return subniche.getQualificationQuestion().trim();
     }
 
-    /** Resolve pergunta de dor para validar qualidade do público capturado. */
-    private String resolvePainQuestion(
-            OprmGeneralAudiencePainAngle angle,
-            CreateGeneralAudienceLandingConfirmationRequest request) {
-        if (StringUtils.hasText(request.painConfirmationQuestion())) {
-            return request.painConfirmationQuestion().trim();
-        }
-        return "Qual é hoje sua maior dificuldade com: " + angle.getPain() + "?";
-    }
-
-    /** Resolve o que a pessoa recebe sem permitir formulário vazio. */
+    /** Resolve a descrição de entrega usando primeiro o pedido e depois a isca aprovada. */
     private String resolveDeliveryDescription(
             OprmGeneralAudiencePainAngle angle,
             CreateGeneralAudienceLandingConfirmationRequest request) {
         if (StringUtils.hasText(request.deliveryDescription())) {
             return request.deliveryDescription().trim();
         }
-        return requiredText(resolveLeadMagnet(angle), "proofOrLeadMagnet");
+        return resolveLeadMagnet(angle);
     }
 
-    /** Resolve a razão de pertinência da landing com base no mecanismo da dor. */
+    /** Resolve o motivo operacional para a confirmação antes de outra etapa usar o registro. */
     private String resolveWhyItMakesSense(
             OprmGeneralAudiencePainAngle angle,
             CreateGeneralAudienceLandingConfirmationRequest request) {
         if (StringUtils.hasText(request.whyItMakesSense())) {
             return request.whyItMakesSense().trim();
         }
-        return StringUtils.hasText(angle.getMechanismDirection())
-                ? angle.getMechanismDirection().trim()
-                : "A isca foi criada para a dor informada pelo próprio subnicho.";
+        if (StringUtils.hasText(angle.getMechanismDirection())) {
+            return angle.getMechanismDirection().trim();
+        }
+        return "Confirmar público real e dor antes de avançar para oferta ou escala.";
     }
 
-    /** Resolve próximo passo sem iniciar venda direta automaticamente. */
+    /** Resolve o próximo passo operacional que será registrado para consumo posterior. */
     private String resolveNextStep(CreateGeneralAudienceLandingConfirmationRequest request) {
         if (StringUtils.hasText(request.nextStep())) {
             return request.nextStep().trim();
         }
-        return "Responder o formulário, receber a isca e medir qualidade do lead antes de qualquer oferta.";
+        return "Registrar respostas, medir qualidade do público e decidir se o experimento deve avançar.";
     }
 
-    /** Resolve a isca principal cadastrada no ângulo. */
-    private String resolveLeadMagnet(OprmGeneralAudiencePainAngle angle) {
-        if (StringUtils.hasText(angle.getProofOrLeadMagnet())) {
-            return angle.getProofOrLeadMagnet().trim();
+    /** Resolve a pergunta de confirmação de dor que será persistida. */
+    private String resolvePainConfirmationQuestion(
+            OprmGeneralAudiencePainAngle angle,
+            CreateGeneralAudienceLandingConfirmationRequest request) {
+        if (StringUtils.hasText(request.painConfirmationQuestion())) {
+            return request.painConfirmationQuestion().trim();
         }
-        return angle.getSafePromise();
+        return "Essa dor acontece com você hoje: " + angle.getPain().trim() + "?";
     }
 
-    /** Resolve nome operacional do fluxo criado para o Lead Portal. */
-    private String resolveFlowName(
+    /** Resolve o nome operacional do registro salvo pelo OPRM. */
+    private String resolveRecordName(
             OprmGeneralAudienceSubniche subniche,
             OprmGeneralAudiencePainAngle angle,
             CreateGeneralAudienceLandingConfirmationRequest request) {
         if (StringUtils.hasText(request.name())) {
             return request.name().trim();
         }
-        return shortText("Confirmação Público Geral - " + subniche.getName() + " - " + angle.getPain(), 150);
+        return "Confirmação Público Geral - " + subniche.getName().trim() + " - " + angle.getId();
     }
 
-    /** Cria slug único e rastreável sem depender de CNAE. */
-    private String buildSlug(
-            OprmGeneralAudienceSubniche subniche,
-            OprmGeneralAudiencePainAngle angle,
-            Long experimentId) {
-        String base = "oprm-publico-geral-" + subniche.getId() + "-" + angle.getId() + "-" + experimentId;
-        return slugify(base + "-" + UUID.randomUUID().toString().substring(0, 8));
-    }
-
-    /** Normaliza opções da pergunta qualificadora e exige alternativas suficientes. */
-    private List<String> normalizeQualificationOptions(List<String> values) {
-        if (values == null || values.isEmpty()) {
+    /** Normaliza opções de qualificação removendo vazios e duplicados sem serializar JSON em texto. */
+    private List<String> normalizeQualificationOptions(List<String> options) {
+        if (options == null) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "qualificationOptions é obrigatório");
         }
         LinkedHashSet<String> normalized = new LinkedHashSet<>();
-        for (String value : values) {
-            if (StringUtils.hasText(value)) {
-                normalized.add(value.trim());
+        for (String option : options) {
+            if (StringUtils.hasText(option)) {
+                normalized.add(option.trim());
             }
         }
         if (normalized.size() < 2) {
             throw new ResponseStatusException(
                     HttpStatus.BAD_REQUEST,
-                    "qualificationOptions deve ter ao menos duas opções");
+                    "qualificationOptions precisa ter pelo menos duas opções úteis");
         }
         return List.copyOf(normalized);
     }
 
-    /** Normaliza texto obrigatório e rejeita valor vazio. */
-    private String requiredText(String value, String fieldName) {
+    /** Resolve a isca ou prova aprovada para a situação de confirmação. */
+    private String resolveLeadMagnet(OprmGeneralAudiencePainAngle angle) {
+        if (StringUtils.hasText(angle.getProofOrLeadMagnet())) {
+            return angle.getProofOrLeadMagnet().trim();
+        }
+        if (StringUtils.hasText(angle.getSafePromise())) {
+            return angle.getSafePromise().trim();
+        }
+        return null;
+    }
+
+    /** Exige texto preenchido para impedir registro operacional incompleto. */
+    private void requiredText(String value, String field) {
         if (!StringUtils.hasText(value)) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, fieldName + " não pode ficar vazio");
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, field + " é obrigatório para registrar confirmação");
         }
-        return value.trim();
     }
 
-    /** Encurta texto para respeitar limite operacional do Lead Portal. */
-    private String shortText(String value, int maxLength) {
-        String text = requiredText(value, "text");
-        if (text.length() <= maxLength) {
-            return text;
-        }
-        return text.substring(0, maxLength).trim();
+    /** Monta slug determinístico para o registro OPRM sem publicar rota externa. */
+    private String buildSlug(OprmGeneralAudienceSubniche subniche, OprmGeneralAudiencePainAngle angle, Long experimentId) {
+        String base = "oprm-publico-geral-" + subniche.getId() + "-" + angle.getId() + "-" + experimentId;
+        return normalizeSlug(base);
     }
 
-    /** Converte texto em slug simples para rota pública futura. */
-    private String slugify(String value) {
-        String normalized = Normalizer.normalize(value, Normalizer.Form.NFD)
+    /** Normaliza texto para slug compatível com armazenamento e leitura operacional. */
+    private String normalizeSlug(String value) {
+        String normalized = Normalizer.normalize(value.toLowerCase(Locale.ROOT), Normalizer.Form.NFD)
                 .replaceAll("\\p{M}", "")
-                .toLowerCase(Locale.ROOT)
                 .replaceAll("[^a-z0-9]+", "-")
                 .replaceAll("(^-|-$)", "");
-        return shortText(normalized, 120);
+        if (normalized.isBlank()) {
+            return "oprm-confirmacao";
+        }
+        return normalized;
     }
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/generalaudience/service/landingConfirmation/GeneralAudienceLandingConfirmationResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/generalaudience/service/landingConfirmation/GeneralAudienceLandingConfirmationResponse.java
@@ -2,13 +2,13 @@ package com.marketinghub.oprm.generalaudience.service.landingConfirmation;
 
 import java.util.List;
 
-/** Resposta da criação de landing/formulário de confirmação para público geral. */
+/** Resposta do registro OPRM da situação de confirmação para público geral. */
 public record GeneralAudienceLandingConfirmationResponse(
+        Long confirmationRecordId,
         Long painAngleId,
         Long subnicheId,
         Long marketNicheId,
         Long experimentId,
-        Long leadPortalFlowId,
         String slug,
         String name,
         String audienceSummary,
@@ -16,5 +16,6 @@ public record GeneralAudienceLandingConfirmationResponse(
         String deliveryDescription,
         String whyItMakesSense,
         String nextStep,
+        String status,
         List<GeneralAudienceLandingConfirmationQuestionResponse> questions) {
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/oprm/generalaudience/OprmGeneralAudienceLandingConfirmationRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/oprm/generalaudience/OprmGeneralAudienceLandingConfirmationRepository.java
@@ -1,0 +1,9 @@
+package com.marketinghub.repository.jpa.oprm.generalaudience;
+
+import com.marketinghub.oprm.generalaudience.OprmGeneralAudienceLandingConfirmation;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/** Repositório JPA responsável pelos registros OPRM de situação de confirmação de landing/formulário. */
+public interface OprmGeneralAudienceLandingConfirmationRepository
+        extends JpaRepository<OprmGeneralAudienceLandingConfirmation, Long> {
+}

--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-10-oprm-general-audience-landing-confirmation.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-10-oprm-general-audience-landing-confirmation.yaml
@@ -1,0 +1,42 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-06-10-06-oprm-general-audience-landing-confirmation
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - onError: HALT
+        - dbms:
+            type: mysql
+        - not:
+            tableExists:
+              tableName: oprm_general_audience_landing_confirmation
+      changes:
+        - sql:
+            splitStatements: true
+            stripComments: true
+            sql: |
+              CREATE TABLE oprm_general_audience_landing_confirmation (
+                id BIGINT NOT NULL AUTO_INCREMENT,
+                pain_angle_id BIGINT NOT NULL,
+                experiment_id BIGINT NULL,
+                market_niche_id BIGINT NOT NULL,
+                name VARCHAR(255) NOT NULL,
+                slug VARCHAR(255) NOT NULL,
+                audience_summary LONGTEXT NOT NULL,
+                pain_summary LONGTEXT NOT NULL,
+                audience_confirmation_question LONGTEXT NOT NULL,
+                qualification_options LONGTEXT NOT NULL,
+                pain_confirmation_question LONGTEXT NOT NULL,
+                delivery_description LONGTEXT NOT NULL,
+                why_it_makes_sense LONGTEXT NOT NULL,
+                next_step LONGTEXT NOT NULL,
+                status VARCHAR(32) NOT NULL,
+                created_at DATETIME NOT NULL,
+                updated_at DATETIME NOT NULL,
+                CONSTRAINT pk_oprm_general_audience_landing_confirmation PRIMARY KEY (id),
+                CONSTRAINT fk_oprm_general_audience_confirmation_angle
+                  FOREIGN KEY (pain_angle_id) REFERENCES oprm_general_audience_pain_angle (id)
+              );
+              CREATE INDEX idx_oprm_general_audience_confirmation_angle ON oprm_general_audience_landing_confirmation (pain_angle_id, updated_at);
+              CREATE INDEX idx_oprm_general_audience_confirmation_experiment ON oprm_general_audience_landing_confirmation (experiment_id, updated_at);
+              CREATE INDEX idx_oprm_general_audience_confirmation_market ON oprm_general_audience_landing_confirmation (market_niche_id, updated_at);

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -945,3 +945,6 @@ databaseChangeLog:
   - include:
       file: changesets/2026-06-09-mois-sales-page-market-warmup.yaml
       relativeToChangelogFile: true
+  - include:
+      file: changesets/2026-06-10-oprm-general-audience-landing-confirmation.yaml
+      relativeToChangelogFile: true

--- a/backend/ads-service/src/test/java/com/marketinghub/oprm/generalaudience/controller/OprmGeneralAudienceDiscoveryControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/oprm/generalaudience/controller/OprmGeneralAudienceDiscoveryControllerTest.java
@@ -115,11 +115,11 @@ class OprmGeneralAudienceDiscoveryControllerTest {
     void shouldCreateConfirmationFlowThroughApi() throws Exception {
         when(landingConfirmationService.createConfirmationFlow(any(), any()))
                 .thenReturn(new GeneralAudienceLandingConfirmationResponse(
+                        88L,
                         20L,
                         5L,
                         99L,
                         77L,
-                        88L,
                         "oprm-publico-geral-5-20-77",
                         "Confirmação Público Geral - Manicure autônoma",
                         "Manicure autônoma",
@@ -127,6 +127,7 @@ class OprmGeneralAudienceDiscoveryControllerTest {
                         "kit com 12 mensagens de WhatsApp",
                         "a dor percebida é horário vazio e dinheiro perdido",
                         "Responder o formulário e receber a isca",
+                        "REGISTERED",
                         List.of(new GeneralAudienceLandingConfirmationQuestionResponse(
                                 "Você trabalha como manicure hoje?",
                                 "audience_confirmation",
@@ -147,8 +148,8 @@ class OprmGeneralAudienceDiscoveryControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(objectMapper.writeValueAsString(request)))
                 .andExpect(status().isCreated())
-                .andExpect(header().string(HttpHeaders.LOCATION, "/api/lead-portal/flows/88"))
-                .andExpect(jsonPath("$.leadPortalFlowId").value(88))
+                .andExpect(header().string(HttpHeaders.LOCATION, "/api/oprm/general-audiences/landing-confirmations/88"))
+                .andExpect(jsonPath("$.confirmationRecordId").value(88))
                 .andExpect(jsonPath("$.questions[0].dataKey").value("audience_confirmation"));
     }
 

--- a/backend/ads-service/src/test/java/com/marketinghub/oprm/generalaudience/service/OprmGeneralAudienceLandingConfirmationServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/oprm/generalaudience/service/OprmGeneralAudienceLandingConfirmationServiceTest.java
@@ -6,38 +6,30 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import com.marketinghub.experiment.Experiment;
-import com.marketinghub.leadportal.LeadPortalFlow;
-import com.marketinghub.leadportal.LeadPortalFlowQuestion;
-import com.marketinghub.leadportal.dto.CreateLeadPortalFlowRequest;
-import com.marketinghub.leadportal.service.LeadPortalFlowService;
-import com.marketinghub.niche.MarketNiche;
+import com.marketinghub.oprm.generalaudience.OprmGeneralAudienceLandingConfirmation;
 import com.marketinghub.oprm.generalaudience.OprmGeneralAudiencePainAngle;
 import com.marketinghub.oprm.generalaudience.OprmGeneralAudiencePainAngleStatus;
 import com.marketinghub.oprm.generalaudience.OprmGeneralAudienceSeed;
 import com.marketinghub.oprm.generalaudience.OprmGeneralAudienceSubniche;
 import com.marketinghub.oprm.generalaudience.OprmGeneralAudienceSubnicheStatus;
 import com.marketinghub.oprm.generalaudience.service.landingConfirmation.CreateGeneralAudienceLandingConfirmationRequest;
-import com.marketinghub.repository.jpa.experiment.ExperimentRepository;
+import com.marketinghub.repository.jpa.oprm.generalaudience.OprmGeneralAudienceLandingConfirmationRepository;
 import com.marketinghub.repository.jpa.oprm.generalaudience.OprmGeneralAudiencePainAngleRepository;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.springframework.web.server.ResponseStatusException;
 
-/** Valida a criação de landing/formulário de confirmação para públicos gerais OPRM. */
+/** Valida o registro de situação de confirmação para públicos gerais OPRM. */
 class OprmGeneralAudienceLandingConfirmationServiceTest {
 
-    /** Verifica se o formulário criado confirma público, dor, entrega e próximo passo sem publicar campanha. */
+    /** Verifica se o OPRM salva a situação de confirmação sem acionar outros módulos. */
     @Test
-    void shouldCreateConfirmationFlowWithMandatoryQuestions() {
+    void shouldRegisterConfirmationSituationWithMandatoryQuestions() {
         OprmGeneralAudiencePainAngle angle = approvedAngle(convertedSubniche());
-        OprmGeneralAudiencePainAngleRepository angleRepository = angleRepositoryReturning(angle);
-        LeadPortalFlowService leadPortalFlowService = leadPortalFlowServiceCreatingFlow();
         OprmGeneralAudienceLandingConfirmationService service = new OprmGeneralAudienceLandingConfirmationService(
-                angleRepository,
-                leadPortalFlowService,
-                experimentRepositoryReturning(99L));
+                angleRepositoryReturning(angle),
+                landingConfirmationRepositorySavingRecord());
 
         var response = service.createConfirmationFlow(20L, new CreateGeneralAudienceLandingConfirmationRequest(
                 77L,
@@ -49,10 +41,12 @@ class OprmGeneralAudienceLandingConfirmationServiceTest {
                 null,
                 null));
 
-        assertThat(response.leadPortalFlowId()).isEqualTo(88L);
+        assertThat(response.confirmationRecordId()).isEqualTo(88L);
         assertThat(response.experimentId()).isEqualTo(77L);
+        assertThat(response.marketNicheId()).isEqualTo(99L);
         assertThat(response.deliveryDescription()).isEqualTo("kit com 12 mensagens de WhatsApp");
-        assertThat(response.nextStep()).contains("receber a isca");
+        assertThat(response.nextStep()).contains("Registrar respostas");
+        assertThat(response.status()).isEqualTo("REGISTERED");
         assertThat(response.questions()).hasSize(2);
         assertThat(response.questions().get(0).required()).isTrue();
         assertThat(response.questions().get(0).options()).contains("não sou manicure");
@@ -65,8 +59,7 @@ class OprmGeneralAudienceLandingConfirmationServiceTest {
         OprmGeneralAudiencePainAngle angle = approvedAngle(convertedSubniche());
         OprmGeneralAudienceLandingConfirmationService service = new OprmGeneralAudienceLandingConfirmationService(
                 angleRepositoryReturning(angle),
-                mock(LeadPortalFlowService.class),
-                experimentRepositoryReturning(99L));
+                landingConfirmationRepositorySavingRecord());
 
         assertThatThrownBy(() -> service.createConfirmationFlow(20L, new CreateGeneralAudienceLandingConfirmationRequest(
                 77L,
@@ -87,8 +80,7 @@ class OprmGeneralAudienceLandingConfirmationServiceTest {
         OprmGeneralAudiencePainAngle angle = approvedAngle(subniche());
         OprmGeneralAudienceLandingConfirmationService service = new OprmGeneralAudienceLandingConfirmationService(
                 angleRepositoryReturning(angle),
-                mock(LeadPortalFlowService.class),
-                experimentRepositoryReturning(99L));
+                landingConfirmationRepositorySavingRecord());
 
         assertThatThrownBy(() -> service.createConfirmationFlow(20L, new CreateGeneralAudienceLandingConfirmationRequest(
                 77L,
@@ -103,19 +95,6 @@ class OprmGeneralAudienceLandingConfirmationServiceTest {
                 .hasMessageContaining("convertido em MarketNiche");
     }
 
-    /** Monta repositório de experimento coerente com o MarketNiche convertido. */
-    private ExperimentRepository experimentRepositoryReturning(Long marketNicheId) {
-        ExperimentRepository repository = mock(ExperimentRepository.class);
-        Experiment experiment = new Experiment();
-        experiment.setId(77L);
-        MarketNiche niche = new MarketNiche();
-        niche.setId(marketNicheId);
-        experiment.setNiche(niche);
-        when(repository.findById(77L)).thenReturn(Optional.of(experiment));
-        when(repository.save(any(Experiment.class))).thenAnswer(invocation -> invocation.getArgument(0));
-        return repository;
-    }
-
     /** Monta repositório que retorna o ângulo informado. */
     private OprmGeneralAudiencePainAngleRepository angleRepositoryReturning(OprmGeneralAudiencePainAngle angle) {
         OprmGeneralAudiencePainAngleRepository repository = mock(OprmGeneralAudiencePainAngleRepository.class);
@@ -123,28 +102,15 @@ class OprmGeneralAudienceLandingConfirmationServiceTest {
         return repository;
     }
 
-    /** Monta serviço do Lead Portal que devolve fluxo com perguntas persistidas. */
-    private LeadPortalFlowService leadPortalFlowServiceCreatingFlow() {
-        LeadPortalFlowService service = mock(LeadPortalFlowService.class);
-        when(service.create(any(CreateLeadPortalFlowRequest.class))).thenAnswer(invocation -> {
-            CreateLeadPortalFlowRequest request = invocation.getArgument(0);
-            LeadPortalFlow flow = new LeadPortalFlow();
-            flow.setId(88L);
-            flow.setName(request.getName());
-            flow.setSlug(request.getSlug());
-            flow.setDescription(request.getDescription());
-            flow.setQuestions(request.getQuestions().stream().map(questionRequest -> {
-                LeadPortalFlowQuestion question = new LeadPortalFlowQuestion();
-                question.setTitle(questionRequest.getTitle());
-                question.setDataKey(questionRequest.getDataKey());
-                question.setType(questionRequest.getType());
-                question.setRequired(questionRequest.isRequired());
-                question.setOptions(questionRequest.getOptions() == null ? List.of() : questionRequest.getOptions());
-                return question;
-            }).toList());
-            return flow;
+    /** Monta repositório que simula a persistência do registro OPRM. */
+    private OprmGeneralAudienceLandingConfirmationRepository landingConfirmationRepositorySavingRecord() {
+        OprmGeneralAudienceLandingConfirmationRepository repository = mock(OprmGeneralAudienceLandingConfirmationRepository.class);
+        when(repository.save(any(OprmGeneralAudienceLandingConfirmation.class))).thenAnswer(invocation -> {
+            OprmGeneralAudienceLandingConfirmation confirmation = invocation.getArgument(0);
+            confirmation.setId(88L);
+            return confirmation;
         });
-        return service;
+        return repository;
     }
 
     /** Monta um ângulo aprovado com isca e pergunta de confirmação. */

--- a/docs/canonical/oprm-canon.v1.md
+++ b/docs/canonical/oprm-canon.v1.md
@@ -231,3 +231,16 @@ Evitar fechamento prematuro de `import run` que destrói a totalização de mark
 - Classes em `com.marketinghub.oprm..` não devem importar `com.marketinghub.targeting..` nem `com.marketinghub.repository.jpa.targeting..`.
 - O OPRM pode validar se há dados mínimos para coleta futura pelo Facebook Ads, mas não deve criar elemento de targeting nem liberar publicação.
 - Se o Facebook Ads precisar de novo formato, o contrato deve nascer no backend e ser consumido pelo módulo Facebook Ads, mantendo o OPRM como produtor de dados e não como publicador.
+
+## Regra obrigatória — limite de responsabilidade do OPRM em confirmações e etapas posteriores
+
+- O OPRM deve tratar a situação de oportunidade, dor, público, rotina e confirmação dentro do seu próprio domínio e persistir os dados no banco por contratos/tabelas OPRM.
+- É proibido o pacote `com.marketinghub.oprm..` materializar diretamente fluxos de outros módulos, como Lead Portal, Experimentos, campanhas, ofertas finais ou publicações.
+- Quando o OPRM preparar uma confirmação de público/dor, ele deve registrar a situação em tabela OPRM, com identificadores externos apenas como valores simples quando necessário, sem importar entidades, services, DTOs ou repositories de outros módulos.
+- Módulos posteriores devem consumir os dados persistidos por contrato oficial/API própria, preservando isolamento e evitando que o OPRM ultrapasse seus limites.
+
+## Critério de efetividade — limite de responsabilidade do OPRM
+
+- Testes de arquitetura devem falhar quando classes em `com.marketinghub.oprm..` dependerem diretamente de pacotes internos que não sejam OPRM ou repositories OPRM, salvo exceções nominais já documentadas.
+- Endpoints OPRM de preparação/confirmação devem devolver registros OPRM persistidos, não IDs de entidades criadas em módulos externos.
+- O dado persistido pelo OPRM deve ser suficiente para orientar a próxima etapa do fluxo de vendas sem acoplamento direto entre módulos.

--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -371,3 +371,9 @@
 - O quality gate de públicos gerais agora considera a leitura mais recente, preservando a causa-raiz comercial: público amplo só avança quando os leads demonstram aderência e intenção real, não apenas clique barato.
 - 2026-06-10 17:35:00 (UTC): corrigida a falha de compilação do serviço de sinais Meta Ads do nicho enriquecido OPRM, adicionando o import explícito de `java.util.Locale` usado na normalização pt-BR segura do texto operacional.
 - 2026-06-10 17:46:10 (UTC): corrigida a falha de compilação do teste `OprmGeneralAudienceDiscoveryServiceTest`, alinhando os mocks ao construtor atual do serviço de Públicos Gerais (`OprmGeneralAudienceFacebookAdsDataRepository`) e atualizando a asserção do bloqueio de targeting conservador para a mensagem operacional vigente.
+
+## 2026-06-10 — Correção de limite arquitetural do OPRM em confirmação de landing
+
+- Decisão registrada: o OPRM deve apenas tratar a situação de confirmação e gravar os dados em banco próprio, sem criar fluxo no Lead Portal nem alterar Experimento diretamente.
+- Ajuste técnico: a confirmação de público geral passou a persistir um registro OPRM próprio em `oprm_general_audience_landing_confirmation`.
+- Prevenção de recorrência: o cânone OPRM agora explicita que `com.marketinghub.oprm..` não deve importar services, DTOs, entidades ou repositories de módulos externos para materializar etapas posteriores.

--- a/docs/swagger/oprm-general-audiences-swagger.yaml
+++ b/docs/swagger/oprm-general-audiences-swagger.yaml
@@ -354,6 +354,30 @@ paths:
           description: Payload incompleto ou ângulo ainda sem prontidão mínima.
         "404":
           description: Ângulo não encontrado.
+  /api/oprm/general-audiences/pain-angles/{angleId}/create-confirmation-flow:
+    post:
+      summary: Registra no banco OPRM a situação de confirmação de público e dor.
+      description: O endpoint não cria fluxo no Lead Portal e não altera Experimento; apenas persiste o registro OPRM para etapa posterior consumir por contrato oficial.
+      tags: [OPRM Públicos Gerais]
+      parameters:
+        - $ref: "#/components/parameters/AngleId"
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CreateGeneralAudienceLandingConfirmationRequest"
+      responses:
+        "201":
+          description: Situação de confirmação registrada no banco OPRM.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/GeneralAudienceLandingConfirmation"
+        "400":
+          description: Payload incompleto ou ângulo ainda sem prontidão mínima.
+        "404":
+          description: Ângulo não encontrado.
   /api/oprm/general-audiences/seeds/{seedId}/source-evidences:
     get:
       summary: Lista evidências agregadas de uma semente.
@@ -966,6 +990,92 @@ components:
           type: string
           format: date
 
+    CreateGeneralAudienceLandingConfirmationRequest:
+      type: object
+      required: [experimentId, audienceConfirmationQuestion, qualificationOptions]
+      properties:
+        experimentId:
+          type: integer
+          format: int64
+        name:
+          type: string
+          nullable: true
+        audienceConfirmationQuestion:
+          type: string
+        qualificationOptions:
+          type: array
+          minItems: 2
+          items:
+            type: string
+        deliveryDescription:
+          type: string
+          nullable: true
+        whyItMakesSense:
+          type: string
+          nullable: true
+        nextStep:
+          type: string
+          nullable: true
+        painConfirmationQuestion:
+          type: string
+          nullable: true
+    GeneralAudienceLandingConfirmationQuestion:
+      type: object
+      required: [title, dataKey, type, required, options]
+      properties:
+        title:
+          type: string
+        dataKey:
+          type: string
+        type:
+          type: string
+        required:
+          type: boolean
+        options:
+          type: array
+          items:
+            type: string
+    GeneralAudienceLandingConfirmation:
+      type: object
+      required:
+        [confirmationRecordId, painAngleId, subnicheId, marketNicheId, experimentId, slug, name, audienceSummary, painSummary, deliveryDescription, whyItMakesSense, nextStep, status, questions]
+      properties:
+        confirmationRecordId:
+          type: integer
+          format: int64
+        painAngleId:
+          type: integer
+          format: int64
+        subnicheId:
+          type: integer
+          format: int64
+        marketNicheId:
+          type: integer
+          format: int64
+        experimentId:
+          type: integer
+          format: int64
+        slug:
+          type: string
+        name:
+          type: string
+        audienceSummary:
+          type: string
+        painSummary:
+          type: string
+        deliveryDescription:
+          type: string
+        whyItMakesSense:
+          type: string
+        nextStep:
+          type: string
+        status:
+          type: string
+          enum: [REGISTERED]
+        questions:
+          type: array
+          items:
+            $ref: "#/components/schemas/GeneralAudienceLandingConfirmationQuestion"
     PainAngleStatus:
       type: string
       enum: [DISCOVERED, NEEDS_REVIEW, APPROVED, REJECTED]


### PR DESCRIPTION
### Motivation
- Enforce OPRM architectural boundary by making OPRM only persist confirmation data and not materialize flows in other modules. 
- Avoid direct dependencies from `com.marketinghub.oprm..` to non-OPRM modules (Lead Portal, Experiment) and provide an OPRM-owned record for downstream consumption.

### Description
- Add JPA entity `OprmGeneralAudienceLandingConfirmation` and repository `OprmGeneralAudienceLandingConfirmationRepository` to persist confirmation records. 
- Refactor `OprmGeneralAudienceLandingConfirmationService` to build and save an OPRM record instead of calling `LeadPortalFlowService` or updating `Experiment`, and to return `GeneralAudienceLandingConfirmationResponse` with `confirmationRecordId` and `status`.
- Update controller routing and responses in `OprmGeneralAudienceDiscoveryController` to return the new OPRM record location (`/api/oprm/general-audiences/landing-confirmations/{id}`) and adjust API docs/Swagger accordingly. 
- Add Liquibase changeset to create `oprm_general_audience_landing_confirmation` table and update canonical/docs to reflect the new responsibility and rules for OPRM boundaries. 
- Update unit tests and test fixtures to mock/save the new repository and assert the new response shape in `OprmGeneralAudienceLandingConfirmationServiceTest` and `OprmGeneralAudienceDiscoveryControllerTest`.

### Testing
- Executed updated unit tests for the landing confirmation service in `OprmGeneralAudienceLandingConfirmationServiceTest` which validate saving the confirmation record and input validations; tests passed. 
- Executed controller unit test `OprmGeneralAudienceDiscoveryControllerTest` verifying API response, `Location` header and payload shape for the confirmation endpoint; tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a29a4c044608320aaa552f33b2f631f)