### PR TITLE
Add Facebook campaign recommendations: backend persistence, API and worker sync

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/facebookads/FacebookAdsCampaign.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/facebookads/FacebookAdsCampaign.java
@@ -15,6 +15,9 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
+/**
+ * Representa a campanha publicada na Meta para um experimento do Marketing Hub.
+ */
 @Entity
 @Table(name = "facebook_ads_campaign")
 @Getter
@@ -100,6 +103,12 @@ public class FacebookAdsCampaign {
 
     @Column(name = "metrics_last_error", columnDefinition = "TEXT")
     private String metricsLastError;
+
+    @Column(name = "recommendations_last_synced_at")
+    private Instant recommendationsLastSyncedAt;
+
+    @Column(name = "recommendations_last_error", columnDefinition = "TEXT")
+    private String recommendationsLastError;
 
     @CreationTimestamp
     @Column(name = "created_at", nullable = false, updatable = false)

--- a/backend/ads-service/src/main/java/com/marketinghub/facebookads/FacebookAdsRecommendation.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/facebookads/FacebookAdsRecommendation.java
@@ -1,0 +1,70 @@
+package com.marketinghub.facebookads;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+/**
+ * Representa uma sugestão oficial retornada pela Meta para uma campanha ativa.
+ */
+@Entity
+@Table(name = "facebook_ads_recommendation")
+@Getter
+@Setter
+@NoArgsConstructor
+public class FacebookAdsRecommendation {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "campaign_id", nullable = false, columnDefinition = "CHAR(36)")
+    private FacebookAdsCampaign campaign;
+
+    @Column(name = "recommendation_code")
+    private String recommendationCode;
+
+    @Column(name = "title", columnDefinition = "TEXT")
+    private String title;
+
+    @Column(name = "message", columnDefinition = "TEXT")
+    private String message;
+
+    @Column(name = "importance", length = 50)
+    private String importance;
+
+    @Column(name = "confidence", length = 50)
+    private String confidence;
+
+    @Column(name = "blame_field", length = 255)
+    private String blameField;
+
+    @Column(name = "recommendation_data_json", columnDefinition = "LONGTEXT")
+    private String recommendationDataJson;
+
+    @Column(name = "raw_json", nullable = false, columnDefinition = "LONGTEXT")
+    private String rawJson;
+
+    @Column(name = "collected_at", nullable = false)
+    private Instant collectedAt;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at")
+    private Instant updatedAt;
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/facebookads/controller/FacebookAdsCampaignController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/facebookads/controller/FacebookAdsCampaignController.java
@@ -31,6 +31,10 @@ import com.marketinghub.facebookads.FacebookAdsAdSet;
 import com.marketinghub.repository.jpa.facebookads.FacebookAdsAdSetRepository;
 import com.marketinghub.facebookads.FacebookAdsCampaign;
 import com.marketinghub.facebookads.FacebookAdStatus;
+import com.marketinghub.facebookads.service.recommendation.FacebookCampaignRecommendationDto;
+import com.marketinghub.facebookads.service.recommendation.FacebookCampaignRecommendationIngestionRequest;
+import com.marketinghub.facebookads.service.recommendation.FacebookCampaignRecommendationService;
+import com.marketinghub.facebookads.service.recommendation.FacebookCampaignRecommendationSyncTarget;
 import com.marketinghub.repository.jpa.facebookads.FacebookAdsCampaignRepository;
 import com.marketinghub.repository.jpa.creative.CreativeRepository;
 import com.marketinghub.experiment.AdSet;
@@ -75,6 +79,7 @@ public class FacebookAdsCampaignController {
     private final LeadPortalPublicUrlResolver leadPortalPublicUrlResolver;
 
     private final LeadPortalMetricsService leadPortalMetricsService;
+    private final FacebookCampaignRecommendationService recommendationService;
 
     /**
      * Cria o controller com os repositórios e serviços usados pelos contratos de campanhas Facebook.
@@ -92,7 +97,8 @@ public class FacebookAdsCampaignController {
                                          ExperimentFunnelAutoStopService funnelAutoStopService,
                                          com.marketinghub.experiment.service.ExperimentReadinessService experimentReadinessService,
                                          LeadPortalPublicUrlResolver leadPortalPublicUrlResolver,
-                                         LeadPortalMetricsService leadPortalMetricsService) {
+                                         LeadPortalMetricsService leadPortalMetricsService,
+                                         FacebookCampaignRecommendationService recommendationService) {
         this.experimentService = experimentService;
         this.campaignRepository = campaignRepository;
         this.accountRepository = accountRepository;
@@ -107,6 +113,7 @@ public class FacebookAdsCampaignController {
         this.experimentReadinessService = experimentReadinessService;
         this.leadPortalPublicUrlResolver = leadPortalPublicUrlResolver;
         this.leadPortalMetricsService = leadPortalMetricsService;
+        this.recommendationService = recommendationService;
     }
 
     @GetMapping("/experiments-ready")
@@ -147,6 +154,35 @@ public class FacebookAdsCampaignController {
                         dto -> dto,
                         (first, second) -> first,
                         LinkedHashMap::new));
+    }
+
+
+    @GetMapping("/recommendations/sync-targets")
+    // Lista campanhas ativas que precisam de coleta de sugestões oficiais da Meta.
+    public List<FacebookCampaignRecommendationSyncTarget> recommendationSyncTargets() {
+        return recommendationService.listSyncTargets();
+    }
+
+    @PostMapping("/{campaignId}/recommendations")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    // Recebe do worker o retrato mais recente de sugestões oficiais da Meta para a campanha.
+    public void ingestRecommendations(@PathVariable String campaignId,
+                                      @RequestBody FacebookCampaignRecommendationIngestionRequest request) {
+        recommendationService.ingest(campaignId, request);
+    }
+
+    @PostMapping("/{campaignId}/recommendations-error")
+    @ResponseStatus(HttpStatus.NO_CONTENT)
+    // Registra falha de coleta de sugestões da Meta sem apagar o último retrato válido.
+    public void recommendationSyncError(@PathVariable String campaignId,
+                                        @RequestBody CampaignMetricsErrorRequest request) {
+        recommendationService.registerError(campaignId, request != null ? request.message() : null);
+    }
+
+    @GetMapping("/{campaignId}/recommendations")
+    // Lista as sugestões oficiais da Meta salvas para uma campanha.
+    public List<FacebookCampaignRecommendationDto> listRecommendations(@PathVariable String campaignId) {
+        return recommendationService.listByCampaign(campaignId);
     }
 
     @GetMapping("/metrics/sync-targets")

--- a/backend/ads-service/src/main/java/com/marketinghub/facebookads/service/recommendation/FacebookCampaignRecommendationDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/facebookads/service/recommendation/FacebookCampaignRecommendationDto.java
@@ -1,0 +1,19 @@
+package com.marketinghub.facebookads.service.recommendation;
+
+import java.time.Instant;
+
+/**
+ * Contrato de saída das sugestões Meta salvas para uma campanha Facebook Ads.
+ */
+public record FacebookCampaignRecommendationDto(
+        Long id,
+        String campaignId,
+        String recommendationCode,
+        String title,
+        String message,
+        String importance,
+        String confidence,
+        String blameField,
+        String recommendationDataJson,
+        String rawJson,
+        Instant collectedAt) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/facebookads/service/recommendation/FacebookCampaignRecommendationIngestionRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/facebookads/service/recommendation/FacebookCampaignRecommendationIngestionRequest.java
@@ -1,0 +1,11 @@
+package com.marketinghub.facebookads.service.recommendation;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import java.time.Instant;
+
+/**
+ * Contrato de entrada usado pelo worker para reportar sugestões coletadas na Meta.
+ */
+public record FacebookCampaignRecommendationIngestionRequest(
+        Instant collectedAt,
+        JsonNode recommendations) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/facebookads/service/recommendation/FacebookCampaignRecommendationService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/facebookads/service/recommendation/FacebookCampaignRecommendationService.java
@@ -1,0 +1,181 @@
+package com.marketinghub.facebookads.service.recommendation;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marketinghub.experiment.ExperimentStatus;
+import com.marketinghub.facebookads.FacebookAdStatus;
+import com.marketinghub.facebookads.FacebookAdsCampaign;
+import com.marketinghub.facebookads.FacebookAdsRecommendation;
+import com.marketinghub.repository.jpa.facebookads.FacebookAdsCampaignRepository;
+import com.marketinghub.repository.jpa.facebookads.FacebookAdsRecommendationRepository;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.NoSuchElementException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+/**
+ * Orquestra a seleção e persistência das sugestões oficiais da Meta para campanhas ativas.
+ */
+@Service
+public class FacebookCampaignRecommendationService {
+    private final FacebookAdsCampaignRepository campaignRepository;
+    private final FacebookAdsRecommendationRepository recommendationRepository;
+    private final ObjectMapper objectMapper;
+
+    /**
+     * Cria o serviço com os repositórios necessários para sincronizar sugestões da Meta.
+     */
+    public FacebookCampaignRecommendationService(FacebookAdsCampaignRepository campaignRepository,
+                                                 FacebookAdsRecommendationRepository recommendationRepository,
+                                                 ObjectMapper objectMapper) {
+        this.campaignRepository = campaignRepository;
+        this.recommendationRepository = recommendationRepository;
+        this.objectMapper = objectMapper;
+    }
+
+    /**
+     * Lista campanhas ativas e em execução que devem ter sugestões coletadas pelo worker.
+     */
+    @Transactional(readOnly = true)
+    public List<FacebookCampaignRecommendationSyncTarget> listSyncTargets() {
+        return campaignRepository
+                .findAllByExperimentStatusAndStatus(ExperimentStatus.RUNNING, FacebookAdStatus.ACTIVE)
+                .stream()
+                .map(campaign -> new FacebookCampaignRecommendationSyncTarget(
+                        campaign.getId(),
+                        StringUtils.hasText(campaign.getExternalId()) ? campaign.getExternalId() : campaign.getId(),
+                        campaign.getExperiment().getId(),
+                        campaign.getAdAccountId(),
+                        campaign.getRecommendationsLastSyncedAt()))
+                .toList();
+    }
+
+    /**
+     * Substitui o retrato de sugestões de uma campanha pelo payload mais recente coletado na Meta.
+     */
+    @Transactional
+    public void ingest(String campaignId, FacebookCampaignRecommendationIngestionRequest request) {
+        FacebookAdsCampaign campaign = campaignRepository.findById(campaignId)
+                .orElseThrow(() -> new NoSuchElementException("Facebook campaign not found: " + campaignId));
+        Instant collectedAt = request != null && request.collectedAt() != null ? request.collectedAt() : Instant.now();
+        recommendationRepository.deleteByCampaignId(campaignId);
+        for (JsonNode recommendationNode : normalizeRecommendations(request != null ? request.recommendations() : null)) {
+            recommendationRepository.save(toEntity(campaign, recommendationNode, collectedAt));
+        }
+        campaign.setRecommendationsLastSyncedAt(collectedAt);
+        campaign.setRecommendationsLastError(null);
+    }
+
+    /**
+     * Registra falha de coleta para a campanha sem apagar o último retrato válido.
+     */
+    @Transactional
+    public void registerError(String campaignId, String message) {
+        FacebookAdsCampaign campaign = campaignRepository.findById(campaignId)
+                .orElseThrow(() -> new NoSuchElementException("Facebook campaign not found: " + campaignId));
+        campaign.setRecommendationsLastError(sanitizeMessage(message));
+    }
+
+    /**
+     * Lista as sugestões atualmente salvas para uma campanha.
+     */
+    @Transactional(readOnly = true)
+    public List<FacebookCampaignRecommendationDto> listByCampaign(String campaignId) {
+        return recommendationRepository.findByCampaignIdOrderByCollectedAtDescIdAsc(campaignId)
+                .stream()
+                .map(this::toDto)
+                .toList();
+    }
+
+    /**
+     * Normaliza o payload recebido da Meta para uma lista de itens de recomendação.
+     */
+    private List<JsonNode> normalizeRecommendations(JsonNode recommendations) {
+        if (recommendations == null || recommendations.isNull() || recommendations.isMissingNode()) {
+            return List.of();
+        }
+        JsonNode candidates = recommendations.has("data") ? recommendations.path("data") : recommendations;
+        if (!candidates.isArray()) {
+            return List.of(candidates);
+        }
+        List<JsonNode> result = new ArrayList<>();
+        candidates.forEach(result::add);
+        return result;
+    }
+
+    /**
+     * Converte uma recomendação bruta da Meta na entidade persistida pelo backend.
+     */
+    private FacebookAdsRecommendation toEntity(FacebookAdsCampaign campaign, JsonNode node, Instant collectedAt) {
+        FacebookAdsRecommendation recommendation = new FacebookAdsRecommendation();
+        recommendation.setCampaign(campaign);
+        recommendation.setRecommendationCode(text(node, "code"));
+        recommendation.setTitle(text(node, "title"));
+        recommendation.setMessage(text(node, "message"));
+        recommendation.setImportance(text(node, "importance"));
+        recommendation.setConfidence(text(node, "confidence"));
+        recommendation.setBlameField(text(node, "blame_field"));
+        recommendation.setRecommendationDataJson(writeJson(node.path("recommendation_data")));
+        recommendation.setRawJson(writeJson(node));
+        recommendation.setCollectedAt(collectedAt);
+        return recommendation;
+    }
+
+    /**
+     * Converte a entidade persistida no contrato de leitura da API.
+     */
+    private FacebookCampaignRecommendationDto toDto(FacebookAdsRecommendation recommendation) {
+        return new FacebookCampaignRecommendationDto(
+                recommendation.getId(),
+                recommendation.getCampaign().getId(),
+                recommendation.getRecommendationCode(),
+                recommendation.getTitle(),
+                recommendation.getMessage(),
+                recommendation.getImportance(),
+                recommendation.getConfidence(),
+                recommendation.getBlameField(),
+                recommendation.getRecommendationDataJson(),
+                recommendation.getRawJson(),
+                recommendation.getCollectedAt());
+    }
+
+    /**
+     * Lê um campo textual simples preservando nulo quando a Meta não envia valor útil.
+     */
+    private String text(JsonNode node, String fieldName) {
+        if (node == null || !node.hasNonNull(fieldName)) {
+            return null;
+        }
+        String value = node.path(fieldName).asText(null);
+        return StringUtils.hasText(value) ? value : null;
+    }
+
+    /**
+     * Serializa um nó JSON para armazenamento bruto e auditável.
+     */
+    private String writeJson(JsonNode node) {
+        if (node == null || node.isMissingNode() || node.isNull()) {
+            return null;
+        }
+        try {
+            return objectMapper.writeValueAsString(node);
+        } catch (JsonProcessingException ex) {
+            throw new IllegalArgumentException("Could not serialize Facebook recommendation payload", ex);
+        }
+    }
+
+    /**
+     * Limita a mensagem de erro para armazenamento operacional no cadastro da campanha.
+     */
+    private String sanitizeMessage(String message) {
+        if (!StringUtils.hasText(message)) {
+            return "Unknown recommendation sync error";
+        }
+        String trimmed = message.trim();
+        return trimmed.length() > 500 ? trimmed.substring(0, 500) : trimmed;
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/facebookads/service/recommendation/FacebookCampaignRecommendationSyncTarget.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/facebookads/service/recommendation/FacebookCampaignRecommendationSyncTarget.java
@@ -1,0 +1,13 @@
+package com.marketinghub.facebookads.service.recommendation;
+
+import java.time.Instant;
+
+/**
+ * Contrato de leitura de campanha ativa que precisa de coleta de sugestões na Meta.
+ */
+public record FacebookCampaignRecommendationSyncTarget(
+        String campaignId,
+        String externalCampaignId,
+        Long experimentId,
+        String adAccountId,
+        Instant lastSyncedAt) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/facebookads/FacebookAdsCampaignRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/facebookads/FacebookAdsCampaignRepository.java
@@ -2,6 +2,7 @@ package com.marketinghub.repository.jpa.facebookads;
 
 import com.marketinghub.facebookads.FacebookAdsCampaign;
 import com.marketinghub.experiment.ExperimentStatus;
+import com.marketinghub.facebookads.FacebookAdStatus;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -14,7 +15,7 @@ import java.util.List;
 public interface FacebookAdsCampaignRepository extends JpaRepository<FacebookAdsCampaign, String> {
 
     /**
-     * Lists campaigns whose owning experiment currently has the requested status.
+     * Lista campanhas cujo experimento proprietário está no status informado.
      */
     @Query("""
             select c from FacebookAdsCampaign c
@@ -24,7 +25,20 @@ public interface FacebookAdsCampaignRepository extends JpaRepository<FacebookAds
     List<FacebookAdsCampaign> findAllByExperimentStatus(@Param("status") ExperimentStatus status);
 
     /**
-     * Lists campaigns with their ad sets for one experiment in creation order.
+     * Lista campanhas ativas cujo experimento proprietário está no status informado.
+     */
+    @Query("""
+            select c from FacebookAdsCampaign c
+            join fetch c.experiment e
+            where e.status = :experimentStatus
+              and c.status = :campaignStatus
+            """)
+    List<FacebookAdsCampaign> findAllByExperimentStatusAndStatus(
+            @Param("experimentStatus") ExperimentStatus experimentStatus,
+            @Param("campaignStatus") FacebookAdStatus campaignStatus);
+
+    /**
+     * Lista campanhas com seus conjuntos de anúncios para um experimento em ordem de criação.
      */
     @Query("""
             select distinct c from FacebookAdsCampaign c
@@ -36,17 +50,17 @@ public interface FacebookAdsCampaignRepository extends JpaRepository<FacebookAds
     List<FacebookAdsCampaign> findDetailedByExperimentId(@Param("experimentId") Long experimentId);
 
     /**
-     * Checks whether an experiment already has a campaign persisted in the backend.
+     * Verifica se um experimento já possui campanha persistida no backend.
      */
     boolean existsByExperimentId(Long experimentId);
 
     /**
-     * Lists campaigns persisted for one experiment without forcing fetch joins.
+     * Lista campanhas persistidas para um experimento sem forçar joins de leitura.
      */
     List<FacebookAdsCampaign> findByExperimentId(Long experimentId);
 
     /**
-     * Lists campaigns with pending stop requests for the Facebook worker.
+     * Lista campanhas com solicitações de parada pendentes para o worker Facebook.
      */
     @Query("""
             select distinct c from FacebookAdsCampaign c

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/facebookads/FacebookAdsRecommendationRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/facebookads/FacebookAdsRecommendationRepository.java
@@ -1,0 +1,27 @@
+package com.marketinghub.repository.jpa.facebookads;
+
+import com.marketinghub.facebookads.FacebookAdsRecommendation;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+/**
+ * Repositório JPA responsável pela persistência das sugestões de campanhas Facebook Ads.
+ */
+public interface FacebookAdsRecommendationRepository extends JpaRepository<FacebookAdsRecommendation, Long> {
+
+    /**
+     * Remove as sugestões antigas de uma campanha antes de gravar o novo retrato da Meta.
+     */
+    @Modifying
+    @Query("delete from FacebookAdsRecommendation r where r.campaign.id = :campaignId")
+    void deleteByCampaignId(@Param("campaignId") String campaignId);
+
+    /**
+     * Lista as sugestões persistidas para uma campanha.
+     */
+    @Query("select r from FacebookAdsRecommendation r where r.campaign.id = :campaignId order by r.collectedAt desc, r.id asc")
+    List<FacebookAdsRecommendation> findByCampaignIdOrderByCollectedAtDescIdAsc(@Param("campaignId") String campaignId);
+}

--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-10-facebook-campaign-recommendations.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-10-facebook-campaign-recommendations.yaml
@@ -1,0 +1,110 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-06-10-facebook-campaign-recommendations-columns
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - onError: MARK_RAN
+        - dbms:
+            type: mysql
+        - tableExists:
+            tableName: facebook_ads_campaign
+        - not:
+            - columnExists:
+                tableName: facebook_ads_campaign
+                columnName: recommendations_last_synced_at
+      changes:
+        - addColumn:
+            tableName: facebook_ads_campaign
+            columns:
+              - column:
+                  name: recommendations_last_synced_at
+                  type: datetime
+              - column:
+                  name: recommendations_last_error
+                  type: text
+  - changeSet:
+      id: 2026-06-10-facebook-campaign-recommendations-table
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - onError: MARK_RAN
+        - dbms:
+            type: mysql
+        - not:
+            - tableExists:
+                tableName: facebook_ads_recommendation
+      changes:
+        - createTable:
+            tableName: facebook_ads_recommendation
+            columns:
+              - column:
+                  name: id
+                  type: bigint
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: campaign_id
+                  type: char(36)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: recommendation_code
+                  type: varchar(255)
+              - column:
+                  name: title
+                  type: text
+              - column:
+                  name: message
+                  type: text
+              - column:
+                  name: importance
+                  type: varchar(50)
+              - column:
+                  name: confidence
+                  type: varchar(50)
+              - column:
+                  name: blame_field
+                  type: varchar(255)
+              - column:
+                  name: recommendation_data_json
+                  type: longtext
+              - column:
+                  name: raw_json
+                  type: longtext
+                  constraints:
+                    nullable: false
+              - column:
+                  name: collected_at
+                  type: datetime
+                  constraints:
+                    nullable: false
+              - column:
+                  name: created_at
+                  type: datetime
+                  constraints:
+                    nullable: false
+              - column:
+                  name: updated_at
+                  type: datetime
+        - addForeignKeyConstraint:
+            baseTableName: facebook_ads_recommendation
+            baseColumnNames: campaign_id
+            constraintName: fk_fb_ads_recommendation_campaign
+            referencedTableName: facebook_ads_campaign
+            referencedColumnNames: id
+            onDelete: CASCADE
+        - createIndex:
+            tableName: facebook_ads_recommendation
+            indexName: idx_fb_ads_recommendation_campaign
+            columns:
+              - column:
+                  name: campaign_id
+        - createIndex:
+            tableName: facebook_ads_recommendation
+            indexName: idx_fb_ads_recommendation_collected
+            columns:
+              - column:
+                  name: collected_at

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -1,5 +1,8 @@
 databaseChangeLog:
   - include:
+      file: changesets/2026-06-10-facebook-campaign-recommendations.yaml
+      relativeToChangelogFile: true
+  - include:
       file: changesets/2026-06-10-oprm-general-audience-quality-reading.yaml
       relativeToChangelogFile: true
   - include:

--- a/backend/ads-service/src/test/java/com/marketinghub/facebookads/FacebookCampaignRecommendationServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/facebookads/FacebookCampaignRecommendationServiceTest.java
@@ -1,0 +1,100 @@
+package com.marketinghub.facebookads;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marketinghub.ads.FacebookAccount;
+import com.marketinghub.experiment.Experiment;
+import com.marketinghub.experiment.ExperimentStatus;
+import com.marketinghub.facebookads.service.recommendation.FacebookCampaignRecommendationIngestionRequest;
+import com.marketinghub.facebookads.service.recommendation.FacebookCampaignRecommendationService;
+import com.marketinghub.repository.jpa.facebookads.FacebookAdsCampaignRepository;
+import com.marketinghub.repository.jpa.facebookads.FacebookAdsRecommendationRepository;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * Valida a seleção e a persistência das sugestões oficiais da Meta no backend.
+ */
+@ExtendWith(MockitoExtension.class)
+class FacebookCampaignRecommendationServiceTest {
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    @Mock
+    private FacebookAdsCampaignRepository campaignRepository;
+
+    @Mock
+    private FacebookAdsRecommendationRepository recommendationRepository;
+
+    private FacebookCampaignRecommendationService service;
+
+    @org.junit.jupiter.api.BeforeEach
+    // Prepara o serviço com repositórios simulados para cada teste.
+    void setUp() {
+        service = new FacebookCampaignRecommendationService(campaignRepository, recommendationRepository, objectMapper);
+    }
+
+    @Test
+    // Garante que somente campanhas ativas em experimentos em execução viram alvo de coleta.
+    void shouldListOnlyActiveCampaignTargets() {
+        FacebookAdsCampaign campaign = campaign();
+        campaign.setRecommendationsLastSyncedAt(Instant.parse("2026-06-10T10:00:00Z"));
+        when(campaignRepository.findAllByExperimentStatusAndStatus(ExperimentStatus.RUNNING, FacebookAdStatus.ACTIVE))
+                .thenReturn(List.of(campaign));
+
+        var targets = service.listSyncTargets();
+
+        assertThat(targets).hasSize(1);
+        assertThat(targets.get(0).campaignId()).isEqualTo("camp-1");
+        assertThat(targets.get(0).externalCampaignId()).isEqualTo("meta-camp-1");
+        assertThat(targets.get(0).experimentId()).isEqualTo(42L);
+        assertThat(targets.get(0).adAccountId()).isEqualTo("12345");
+    }
+
+    @Test
+    // Garante que a ingestão substitui o retrato anterior e limpa erro antigo.
+    void shouldReplaceRecommendationSnapshotAndClearPreviousError() throws Exception {
+        FacebookAdsCampaign campaign = campaign();
+        campaign.setRecommendationsLastError("erro antigo");
+        when(campaignRepository.findById("camp-1")).thenReturn(Optional.of(campaign));
+        var payload = objectMapper.readTree("{\"data\":[{\"code\":\"1\",\"title\":\"Ajuste orçamento\",\"message\":\"Teste\",\"importance\":\"HIGH\",\"confidence\":\"MEDIUM\",\"blame_field\":\"daily_budget\",\"recommendation_data\":{\"value\":10}}]}");
+        Instant collectedAt = Instant.parse("2026-06-10T11:00:00Z");
+
+        service.ingest("camp-1", new FacebookCampaignRecommendationIngestionRequest(collectedAt, payload));
+
+        verify(recommendationRepository).deleteByCampaignId("camp-1");
+        ArgumentCaptor<FacebookAdsRecommendation> captor = ArgumentCaptor.forClass(FacebookAdsRecommendation.class);
+        verify(recommendationRepository).save(captor.capture());
+        assertThat(captor.getValue().getRecommendationCode()).isEqualTo("1");
+        assertThat(captor.getValue().getTitle()).isEqualTo("Ajuste orçamento");
+        assertThat(captor.getValue().getRecommendationDataJson()).contains("value");
+        assertThat(campaign.getRecommendationsLastSyncedAt()).isEqualTo(collectedAt);
+        assertThat(campaign.getRecommendationsLastError()).isNull();
+    }
+
+    // Monta uma campanha válida para os cenários de sugestão.
+    private FacebookAdsCampaign campaign() {
+        Experiment experiment = new Experiment();
+        experiment.setId(42L);
+        FacebookAccount account = FacebookAccount.builder().id(7L).name("Conta").build();
+        FacebookAdsCampaign campaign = new FacebookAdsCampaign();
+        campaign.setId("camp-1");
+        campaign.setExternalId("meta-camp-1");
+        campaign.setAdAccountId("12345");
+        campaign.setName("Campanha");
+        campaign.setObjective("OUTCOME_TRAFFIC");
+        campaign.setStatus(FacebookAdStatus.ACTIVE);
+        campaign.setBudgetMode(BudgetMode.DAILY);
+        campaign.setExperiment(experiment);
+        campaign.setFacebookAccount(account);
+        return campaign;
+    }
+}

--- a/docs/canonical/facebook-campaign-publication-canon.v1.md
+++ b/docs/canonical/facebook-campaign-publication-canon.v1.md
@@ -13,6 +13,7 @@
 > - formaliza a separação de ownership dos criativos: criação/edição/aprovação é do módulo Experimentos; consumo operacional é por endpoint exclusivo do módulo Facebook
 > - torna obrigatório o upload de imagens de criativo por bytes/multipart para a Meta, proibindo fallback por URL externa em campanhas
 > - adiciona validação obrigatória de alcance por `reachestimate` antes de criar a hierarquia da campanha na Meta
+> - formaliza a coleta periódica de sugestões oficiais da Meta para campanhas ativas, com persistência exclusiva via backend
 
 Este documento complementa o `system-governance-canon.v2.md` e passa a ser a fonte de verdade para prontidão, liberação e telemetria de campanhas de experimento no Facebook Ads Worker.
 
@@ -151,6 +152,19 @@ O cartão também lista itens operacionais que não travam o worker, mas devem s
    - **invariante operacional obrigatório**: é proibido usar fallback de publicação por `url` externa em `/adimages` ou por `picture` no criativo para contornar falhas de upload. Se o worker não conseguir baixar a imagem, enviar bytes ou obter `image_hash`, a publicação deve falhar de forma explícita para correção da causa-raiz.
    - **invariante de eficiência**: deduplicação por conteúdo de imagem é obrigatória para reduzir custo, latência e risco de variação acidental entre anúncios com o mesmo asset.
 
+
+## 7.2 Coleta de sugestões oficiais da Meta
+
+Após a publicação completa, campanhas com `facebook_ads_campaign.status='ACTIVE'` e experimento `RUNNING` devem entrar na rotina operacional de coleta de sugestões oficiais da Meta. O objetivo dessa rotina é transformar sinais da plataforma em decisões de otimização orientadas a vendas, sem aplicar mudanças automaticamente.
+
+Regras obrigatórias:
+
+1. O backend é a fonte de verdade dos alvos de coleta e expõe somente campanhas elegíveis em `GET /api/facebook-campaigns/recommendations/sync-targets`.
+2. O `facebook-ads-worker` consulta a Graph API usando o identificador externo da campanha e lê o campo `recommendations`.
+3. O worker não acessa diretamente o banco para persistir sugestões; ele reporta o retrato coletado ao backend em `POST /api/facebook-campaigns/{campaignId}/recommendations`.
+4. Cada nova coleta substitui o retrato anterior da mesma campanha e atualiza `recommendations_last_synced_at`.
+5. Quando a coleta falhar, o worker deve registrar `POST /api/facebook-campaigns/{campaignId}/recommendations-error` e preservar o último retrato válido para não perder contexto operacional.
+6. Sugestões da Meta são diagnóstico de plataforma, não decisão automática de negócio; aplicação de orçamento, público ou criativo deve continuar condicionada à análise de CPA, CPL, ROAS, lucro estimado e estágio do experimento.
 
 ## 7.1 Publicação como etapa plugável do pipeline
 

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -4291,3 +4291,9 @@
   - docs/canonical/facebook-campaign-publication-canon.v1.md
   - docs/canonical/geralanding-arquitetura-canon.v1.md
   - docs/registros/experimentos.md
+
+## 2026-06-10 — Coleta de sugestões Meta para campanhas ativas
+
+- Criada rotina no `facebook-ads-worker` para buscar sugestões oficiais da Meta em campanhas ativas e reportar o retrato ao backend.
+- Criada persistência no backend para armazenar recomendações por campanha, preservando o último retrato válido quando houver falha de coleta.
+- Atualizado contrato Swagger de Facebook Ads com endpoints de alvos, ingestão, erro e leitura das sugestões.

--- a/docs/swagger/facebook-ads-swagger.yaml
+++ b/docs/swagger/facebook-ads-swagger.yaml
@@ -274,6 +274,57 @@ paths:
       summary: Lista campanhas que precisam sincronizar métricas da Meta.
       responses:
         '200': { description: Alvos de sincronização retornados. }
+  /api/facebook-campaigns/recommendations/sync-targets:
+    get:
+      tags: [Facebook Campaigns]
+      summary: Lista campanhas ativas que precisam sincronizar sugestões oficiais da Meta.
+      responses:
+        '200':
+          description: Alvos de sincronização retornados.
+          content:
+            application/json:
+              schema:
+                type: array
+                items: { $ref: '#/components/schemas/FacebookCampaignRecommendationSyncTarget' }
+  /api/facebook-campaigns/{campaignId}/recommendations:
+    get:
+      tags: [Facebook Campaigns]
+      summary: Lista sugestões oficiais da Meta salvas para a campanha.
+      parameters:
+        - $ref: '#/components/parameters/CampaignId'
+      responses:
+        '200':
+          description: Sugestões retornadas.
+          content:
+            application/json:
+              schema:
+                type: array
+                items: { $ref: '#/components/schemas/FacebookCampaignRecommendation' }
+    post:
+      tags: [Facebook Campaigns]
+      summary: Substitui o retrato de sugestões oficiais da Meta para a campanha.
+      parameters:
+        - $ref: '#/components/parameters/CampaignId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/FacebookCampaignRecommendationIngestionRequest' }
+      responses:
+        '204': { description: Sugestões persistidas. }
+  /api/facebook-campaigns/{campaignId}/recommendations-error:
+    post:
+      tags: [Facebook Campaigns]
+      summary: Registra falha de sincronização de sugestões oficiais da Meta.
+      parameters:
+        - $ref: '#/components/parameters/CampaignId'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema: { $ref: '#/components/schemas/CampaignMetricsErrorRequest' }
+      responses:
+        '204': { description: Erro registrado. }
   /api/facebook-campaigns/experiments/{experimentId}/creatives-ready:
     get:
       tags: [Facebook Creatives]
@@ -683,6 +734,42 @@ components:
           enum: [READY]
           description: O endpoint filtra e retorna apenas criativos aprovados para publicação.
       required: [id, experimentId, status]
+    FacebookCampaignRecommendationSyncTarget:
+      type: object
+      properties:
+        campaignId: { type: string }
+        externalCampaignId: { type: string, nullable: true }
+        experimentId: { type: integer, format: int64 }
+        adAccountId: { type: string }
+        lastSyncedAt: { type: string, format: date-time, nullable: true }
+      required: [campaignId, experimentId, adAccountId]
+    FacebookCampaignRecommendationIngestionRequest:
+      type: object
+      additionalProperties: true
+      properties:
+        collectedAt: { type: string, format: date-time, nullable: true }
+        recommendations:
+          description: Payload estruturado retornado pelo campo recommendations da Graph API.
+          oneOf:
+            - type: array
+              items: { type: object, additionalProperties: true }
+            - type: object
+              additionalProperties: true
+    FacebookCampaignRecommendation:
+      type: object
+      properties:
+        id: { type: integer, format: int64 }
+        campaignId: { type: string }
+        recommendationCode: { type: string, nullable: true }
+        title: { type: string, nullable: true }
+        message: { type: string, nullable: true }
+        importance: { type: string, nullable: true }
+        confidence: { type: string, nullable: true }
+        blameField: { type: string, nullable: true }
+        recommendationDataJson: { type: string, nullable: true }
+        rawJson: { type: string }
+        collectedAt: { type: string, format: date-time }
+      required: [id, campaignId, rawJson, collectedAt]
     CreateCampaignRequest:
       type: object
       additionalProperties: true

--- a/facebook-ads-worker/AGENTS.md
+++ b/facebook-ads-worker/AGENTS.md
@@ -74,6 +74,7 @@
   em vez de tratar como erro para evitar itens presos como pendentes.
 - Chamadas de Insights (`/{campaignId}/insights`) devem evitar logs de sucesso em `INFO`
   para reduzir poluição; mantenha logs de erro/aviso para troubleshooting.
+- A coleta de sugestões oficiais da Meta para campanhas ativas deve consultar `GET /api/facebook-campaigns/recommendations/sync-targets`, ler o campo `recommendations` da campanha na Graph API e persistir exclusivamente via backend em `POST /api/facebook-campaigns/{campaignId}/recommendations`; em falhas, registrar `/recommendations-error` sem apagar o último retrato válido.
 
 - Perguntas personalizadas geradas pelo ChatGPT agora são persistidas no backend
   e devolvidas em JSON para o worker; mantenha compatível qualquer mudança que

--- a/facebook-ads-worker/README.md
+++ b/facebook-ads-worker/README.md
@@ -21,6 +21,20 @@ vez de persistir anchor genérico.
 
 
 
+
+## Sugestões oficiais da Meta
+
+O worker executa uma rotina agendada a cada trinta minutos para consultar o campo
+`recommendations` das campanhas Facebook ativas retornadas pelo backend em
+`GET /api/facebook-campaigns/recommendations/sync-targets`. Cada retrato coletado
+é enviado de volta para `POST /api/facebook-campaigns/{campaignId}/recommendations`,
+permitindo que o backend mantenha no banco as recomendações atuais da Meta sem
+dar acesso direto do worker ao modelo JPA do sistema.
+
+Quando a Graph API ou o backend falham, o worker registra o erro em
+`POST /api/facebook-campaigns/{campaignId}/recommendations-error` e preserva o
+último retrato válido de sugestões para apoiar decisões de otimização e vendas.
+
 ## Enriquecimento de segmentações de nicho
 
 Além da fila de candidatos de targeting, o worker também processa os termos

--- a/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/FacebookAdsService.java
+++ b/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/FacebookAdsService.java
@@ -56,6 +56,9 @@ import java.util.UUID;
 
 import static org.springframework.util.StringUtils.hasText;
 
+/**
+ * Centraliza as chamadas do worker para a Graph API da Meta.
+ */
 @Service
 public class FacebookAdsService {
     private static final Logger LOGGER = LoggerFactory.getLogger(FacebookAdsService.class);
@@ -2157,6 +2160,19 @@ private FacebookInterest searchInterest(String interestName, String locale) {
                 objectLabel, objectId, ex.getMessage()
             );
         }
+    }
+
+
+    /**
+     * Busca as sugestões oficiais da Meta para uma campanha publicada.
+     */
+    public JsonNode getCampaignRecommendations(String campaignId) {
+        UriComponentsBuilder builder = UriComponentsBuilder.fromPath("/" + campaignId)
+            .queryParam("fields", "recommendations")
+            .queryParam("access_token", requireAccessToken());
+        String path = buildVersionedPath(builder.toUriString());
+        FacebookApiResponse response = executeGet(path);
+        return response.body() != null ? response.body().path("recommendations") : objectMapper.createArrayNode();
     }
 
     public JsonNode getCampaignInsights(String campaignId, Map<String, String> queryParams) {

--- a/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookrecommendation/FacebookCampaignRecommendationScheduler.java
+++ b/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookrecommendation/FacebookCampaignRecommendationScheduler.java
@@ -1,0 +1,27 @@
+package com.marketinghub.facebookadsworker.facebookrecommendation;
+
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/**
+ * Agenda a coleta periódica de sugestões oficiais da Meta para campanhas ativas.
+ */
+@Component
+public class FacebookCampaignRecommendationScheduler {
+    private final FacebookCampaignRecommendationService service;
+
+    /**
+     * Cria o agendador com o serviço de coleta de sugestões.
+     */
+    public FacebookCampaignRecommendationScheduler(FacebookCampaignRecommendationService service) {
+        this.service = service;
+    }
+
+    /**
+     * Executa a coleta a cada trinta minutos com cron explícito.
+     */
+    @Scheduled(cron = "0 */30 * * * *")
+    public void scheduleRecommendationSync() {
+        service.syncActiveCampaignRecommendations();
+    }
+}

--- a/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookrecommendation/FacebookCampaignRecommendationService.java
+++ b/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookrecommendation/FacebookCampaignRecommendationService.java
@@ -1,0 +1,219 @@
+package com.marketinghub.facebookadsworker.facebookrecommendation;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.marketinghub.facebookadsworker.FacebookAccessTokenExpiredException;
+import com.marketinghub.facebookadsworker.FacebookAccessTokenManager;
+import com.marketinghub.facebookadsworker.FacebookAdsService;
+import com.marketinghub.facebookadsworker.FacebookPermissionException;
+import com.marketinghub.facebookadsworker.configuration.FacebookWorkerConfigurationClient;
+import com.marketinghub.facebookadsworker.configuration.FacebookWorkerConfigurationClient.FacebookWorkerConfiguration;
+import com.marketinghub.facebookadsworker.util.UrlUtils;
+import java.time.Instant;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+import org.springframework.web.reactive.function.client.WebClient;
+import org.springframework.web.reactive.function.client.WebClientRequestException;
+import reactor.core.publisher.Mono;
+
+/**
+ * Coleta sugestões oficiais da Meta para campanhas ativas e reporta o retrato ao backend.
+ */
+@Service
+public class FacebookCampaignRecommendationService {
+    private static final Logger LOGGER = LoggerFactory.getLogger(FacebookCampaignRecommendationService.class);
+
+    private final FacebookAdsService facebookAdsService;
+    private final FacebookAccessTokenManager accessTokenManager;
+    private final FacebookWorkerConfigurationClient configurationClient;
+    private final WebClient backendClient;
+    private final String backendBaseUrl;
+    private final String apiPrefix;
+    private final boolean enabled;
+    private final AtomicBoolean configurationUnavailableWarningLogged = new AtomicBoolean(false);
+
+    /**
+     * Cria o serviço com clientes necessários para consultar a Meta e persistir o resultado via backend.
+     */
+    public FacebookCampaignRecommendationService(FacebookAdsService facebookAdsService,
+                                                 FacebookAccessTokenManager accessTokenManager,
+                                                 FacebookWorkerConfigurationClient configurationClient,
+                                                 WebClient.Builder builder,
+                                                 @Value("${backend.base-url:http://localhost:8000}") String backendBaseUrl,
+                                                 @Value("${backend.api-prefix:/api}") String apiPrefix,
+                                                 @Value("${facebookcampaign.recommendations.enabled:true}") boolean enabled) {
+        this.facebookAdsService = facebookAdsService;
+        this.accessTokenManager = accessTokenManager;
+        this.configurationClient = configurationClient;
+        this.backendClient = builder.build();
+        this.backendBaseUrl = backendBaseUrl;
+        this.apiPrefix = apiPrefix;
+        this.enabled = enabled;
+    }
+
+    /**
+     * Executa um ciclo completo de coleta de sugestões para campanhas ativas.
+     */
+    public void syncActiveCampaignRecommendations() {
+        if (!enabled) {
+            return;
+        }
+        Optional<FacebookWorkerConfiguration> configuration = configurationClient.fetchConfiguration();
+        if (configuration.isEmpty()) {
+            if (configurationUnavailableWarningLogged.compareAndSet(false, true)) {
+                LOGGER.warn("Facebook worker configuration is unavailable; skipping campaign recommendation sync");
+            }
+            return;
+        }
+        configurationUnavailableWarningLogged.set(false);
+        FacebookWorkerConfiguration config = configuration.get();
+        if (!StringUtils.hasText(config.accessToken())) {
+            LOGGER.warn("Facebook worker configuration does not include an access token; skipping campaign recommendation sync");
+            return;
+        }
+        ensureAccessToken(config.accessToken());
+        for (FacebookCampaignRecommendationSyncTarget target : fetchSyncTargets()) {
+            processTarget(target);
+        }
+    }
+
+    /**
+     * Coleta e reporta sugestões de uma campanha individual, renovando token quando necessário.
+     */
+    private void processTarget(FacebookCampaignRecommendationSyncTarget target) {
+        String metaCampaignId = StringUtils.hasText(target.externalCampaignId())
+                ? target.externalCampaignId()
+                : target.campaignId();
+        try {
+            JsonNode recommendations = facebookAdsService.getCampaignRecommendations(metaCampaignId);
+            sendRecommendations(target.campaignId(), new FacebookCampaignRecommendationIngestionRequest(Instant.now(), recommendations));
+        } catch (FacebookAccessTokenExpiredException ex) {
+            LOGGER.warn("Facebook access token expired while fetching recommendations for campaign {}", target.campaignId(), ex);
+            if (tryRenewAccessToken()) {
+                processTarget(target);
+            }
+        } catch (FacebookPermissionException ex) {
+            LOGGER.warn("Facebook permission error while fetching recommendations for campaign {}: {}", target.campaignId(), ex.getMessage(), ex);
+            reportRecommendationError(target.campaignId(), "Permission error: " + ex.getMessage());
+        } catch (WebClientRequestException ex) {
+            LOGGER.warn("Backend connectivity error while syncing recommendations for campaign {}", target.campaignId(), ex);
+        } catch (Exception ex) {
+            LOGGER.warn("Unexpected error while syncing recommendations for campaign {}: {}", target.campaignId(), ex.getMessage(), ex);
+            reportRecommendationError(target.campaignId(), "Unexpected error: " + ex.getMessage());
+        }
+    }
+
+    /**
+     * Busca no backend as campanhas ativas elegíveis para coleta de sugestões.
+     */
+    private List<FacebookCampaignRecommendationSyncTarget> fetchSyncTargets() {
+        String url = UrlUtils.joinPath(backendBaseUrl, apiPrefix, "/facebook-campaigns/recommendations/sync-targets");
+        try {
+            List<FacebookCampaignRecommendationSyncTarget> targets = backendClient.get()
+                    .uri(url)
+                    .retrieve()
+                    .bodyToFlux(FacebookCampaignRecommendationSyncTarget.class)
+                    .collectList()
+                    .block();
+            return targets != null ? targets : Collections.emptyList();
+        } catch (WebClientRequestException ex) {
+            LOGGER.warn("Could not fetch campaign recommendation sync targets from backend: url==>{}", url, ex);
+            return Collections.emptyList();
+        }
+    }
+
+    /**
+     * Envia ao backend o retrato mais recente de sugestões da campanha.
+     */
+    private void sendRecommendations(String campaignId, FacebookCampaignRecommendationIngestionRequest payload) {
+        String url = UrlUtils.joinPath(backendBaseUrl, apiPrefix, "/facebook-campaigns/" + campaignId + "/recommendations");
+        backendClient.post()
+                .uri(url)
+                .bodyValue(payload)
+                .retrieve()
+                .onStatus(HttpStatusCode::isError, response -> response.createException().flatMap(e -> {
+                    LOGGER.warn("Backend rejected recommendations for campaign {}: status={} message={}", campaignId, response.statusCode(), e.getMessage());
+                    return Mono.error(e);
+                }))
+                .toBodilessEntity()
+                .block();
+    }
+
+    /**
+     * Registra no backend uma falha de coleta sem apagar sugestões válidas anteriores.
+     */
+    private void reportRecommendationError(String campaignId, String message) {
+        String url = UrlUtils.joinPath(backendBaseUrl, apiPrefix, "/facebook-campaigns/" + campaignId + "/recommendations-error");
+        try {
+            backendClient.post()
+                    .uri(url)
+                    .bodyValue(new FacebookCampaignRecommendationErrorRequest(sanitizeMessage(message)))
+                    .retrieve()
+                    .toBodilessEntity()
+                    .block();
+        } catch (Exception ex) {
+            LOGGER.warn("Could not report recommendation sync error for campaign {}: {}", campaignId, ex.getMessage(), ex);
+        }
+    }
+
+    /**
+     * Aplica no cliente da Graph API o token operacional configurado no backend.
+     */
+    private void ensureAccessToken(String configuredToken) {
+        String currentToken = facebookAdsService.getCurrentAccessToken();
+        if (!StringUtils.hasText(currentToken) || !currentToken.equals(configuredToken)) {
+            facebookAdsService.updateAccessToken(configuredToken);
+        }
+    }
+
+    /**
+     * Tenta renovar o token quando a Meta indica expiração durante a coleta.
+     */
+    private boolean tryRenewAccessToken() {
+        FacebookAccessTokenManager.RenewalAttemptResult renewalResult = accessTokenManager.tryRenewAccessTokenIfPossible();
+        if (renewalResult.outcome() == FacebookAccessTokenManager.RenewalOutcome.SUCCESS) {
+            LOGGER.info("Facebook access token renewed automatically during recommendation sync");
+            return true;
+        }
+        LOGGER.warn("Could not renew Facebook access token during recommendation sync: outcome={} message={}",
+                renewalResult.outcome(), renewalResult.errorMessage());
+        return false;
+    }
+
+    /**
+     * Limita a mensagem de erro enviada ao backend.
+     */
+    private String sanitizeMessage(String message) {
+        if (!StringUtils.hasText(message)) {
+            return "Unknown recommendation sync error";
+        }
+        return message.length() > 500 ? message.substring(0, 500) : message;
+    }
+
+    /**
+     * Contrato da campanha ativa que o backend entrega ao worker para coleta de sugestões.
+     */
+    public record FacebookCampaignRecommendationSyncTarget(
+            String campaignId,
+            String externalCampaignId,
+            Long experimentId,
+            String adAccountId,
+            Instant lastSyncedAt) {}
+
+    /**
+     * Contrato enviado ao backend com as sugestões retornadas pela Meta.
+     */
+    public record FacebookCampaignRecommendationIngestionRequest(Instant collectedAt, JsonNode recommendations) {}
+
+    /**
+     * Contrato enviado ao backend quando a coleta da Meta falha.
+     */
+    public record FacebookCampaignRecommendationErrorRequest(String message) {}
+}

--- a/facebook-ads-worker/src/test/java/com/marketinghub/facebookadsworker/facebookrecommendation/FacebookCampaignRecommendationServiceTest.java
+++ b/facebook-ads-worker/src/test/java/com/marketinghub/facebookadsworker/facebookrecommendation/FacebookCampaignRecommendationServiceTest.java
@@ -1,0 +1,124 @@
+package com.marketinghub.facebookadsworker.facebookrecommendation;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marketinghub.facebookadsworker.FacebookAdsService;
+import com.marketinghub.facebookadsworker.configuration.FacebookWorkerConfigurationClient;
+import com.marketinghub.facebookadsworker.configuration.FacebookWorkerConfigurationClient.FacebookWorkerConfiguration;
+import com.marketinghub.facebookadsworker.facebooktargeting.TargetingResolverProperties;
+import java.util.Optional;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.reactive.function.client.WebClient;
+
+/**
+ * Valida a coleta agendada de sugestões oficiais da Meta pelo worker.
+ */
+class FacebookCampaignRecommendationServiceTest {
+    private MockWebServer backend;
+    private MockWebServer graph;
+    private FacebookCampaignRecommendationService service;
+
+    @BeforeEach
+    // Prepara servidores HTTP locais para simular backend e Graph API.
+    void setUp() throws Exception {
+        backend = new MockWebServer();
+        backend.start();
+        graph = new MockWebServer();
+        graph.start();
+        FacebookAdsService facebookAdsService = new FacebookAdsService(
+                WebClient.builder(),
+                graph.url("/").toString(),
+                "v23.0",
+                new ObjectMapper(),
+                new TargetingResolverProperties());
+        service = new FacebookCampaignRecommendationService(
+                facebookAdsService,
+                null,
+                new StaticConfigurationClient(configuration()),
+                WebClient.builder(),
+                backend.url("/").toString(),
+                "/api",
+                true);
+    }
+
+    @AfterEach
+    // Encerra os servidores HTTP locais usados no teste.
+    void tearDown() throws Exception {
+        backend.shutdown();
+        graph.shutdown();
+    }
+
+    @Test
+    // Garante que o worker busca alvos ativos, consulta a Meta e reporta sugestões ao backend.
+    void shouldFetchActiveTargetsAndSendRecommendationsToBackend() throws Exception {
+        backend.enqueue(new MockResponse()
+                .setHeader("Content-Type", "application/json")
+                .setBody("[{\"campaignId\":\"camp-1\",\"externalCampaignId\":\"meta-camp-1\",\"experimentId\":42,\"adAccountId\":\"12345\",\"lastSyncedAt\":\"2026-06-10T10:00:00Z\"}]"));
+        graph.enqueue(new MockResponse()
+                .setHeader("Content-Type", "application/json")
+                .setBody("{\"recommendations\":{\"data\":[{\"code\":\"1\",\"title\":\"Ajuste orçamento\"}]}}"));
+        backend.enqueue(new MockResponse().setResponseCode(204));
+
+        service.syncActiveCampaignRecommendations();
+
+        var targetRequest = backend.takeRequest();
+        assertThat(targetRequest.getMethod()).isEqualTo("GET");
+        assertThat(targetRequest.getPath()).isEqualTo("/api/facebook-campaigns/recommendations/sync-targets");
+        var graphRequest = graph.takeRequest();
+        assertThat(graphRequest.getPath()).contains("/v23.0/meta-camp-1");
+        assertThat(graphRequest.getPath()).contains("fields=recommendations");
+        var ingestionRequest = backend.takeRequest();
+        assertThat(ingestionRequest.getMethod()).isEqualTo("POST");
+        assertThat(ingestionRequest.getPath()).isEqualTo("/api/facebook-campaigns/camp-1/recommendations");
+        assertThat(ingestionRequest.getBody().readUtf8()).contains("Ajuste orçamento");
+    }
+
+    // Cria a configuração operacional mínima do worker para a coleta.
+    private FacebookWorkerConfiguration configuration() {
+        return new FacebookWorkerConfiguration(
+                7L,
+                "act_12345",
+                "token-123",
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                null);
+    }
+
+    /**
+     * Cliente de configuração fixo para evitar chamadas externas durante o teste.
+     */
+    private static class StaticConfigurationClient extends FacebookWorkerConfigurationClient {
+        private final FacebookWorkerConfiguration configuration;
+
+        // Inicializa o cliente fixo com a configuração informada.
+        StaticConfigurationClient(FacebookWorkerConfiguration configuration) {
+            super(WebClient.builder(), "http://localhost", "/api");
+            this.configuration = configuration;
+        }
+
+        @Override
+        // Retorna sempre a configuração fixa do cenário.
+        public Optional<FacebookWorkerConfiguration> fetchConfiguration() {
+            return Optional.of(configuration);
+        }
+    }
+}


### PR DESCRIPTION
### Motivation

- Persist official Meta `recommendations` for active campaigns so the platform can surface diagnostic suggestions without giving the worker direct DB access. 
- Provide an API contract to list sync targets, ingest a collected snapshot, record sync errors and read stored recommendations. 
- Implement a worker-side routine to periodically fetch `recommendations` from the Graph API and report them to the backend, preserving the last valid snapshot on failure.

### Description

- Added a new JPA entity `FacebookAdsRecommendation` and repository `FacebookAdsRecommendationRepository`, and extended `FacebookAdsCampaign` with `recommendations_last_synced_at` and `recommendations_last_error` columns. 
- Exposed new endpoints in `FacebookAdsCampaignController`: `GET /recommendations/sync-targets`, `POST /{campaignId}/recommendations`, `POST /{campaignId}/recommendations-error` and `GET /{campaignId}/recommendations`, and wired `FacebookCampaignRecommendationService` to handle them. 
- Implemented backend service `FacebookCampaignRecommendationService` with normalization, ingestion (replace snapshot), error registration and listing logic, plus DTOs `FacebookCampaignRecommendationDto` and ingestion request contract. 
- Added DB changelog `2026-06-10-facebook-campaign-recommendations.yaml` and included it in `db.changelog-master.yaml`. 
- Implemented worker-side support: `FacebookAdsService#getCampaignRecommendations`, a worker `FacebookCampaignRecommendationService` to fetch targets, call the Graph API and POST snapshots to the backend, and a scheduler `FacebookCampaignRecommendationScheduler` to run every 30 minutes. 
- Added OpenAPI/Swagger contract updates and documentation changes in `docs/` plus worker guidance in `AGENTS.md` and `README.md` to describe the new flow. 

### Testing

- Ran backend unit test `FacebookCampaignRecommendationServiceTest`, which verifies target selection and ingestion behavior, and it passed. 
- Ran worker unit test `facebookrecommendation.FacebookCampaignRecommendationServiceTest`, which uses `MockWebServer` to validate the fetch-from-Graph and POST-to-backend flow, and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a29a1d1b2e083208af67e0ac8e02213)