### PR TITLE
Fix Facebook recommendation test budget mode

### DIFF
--- a/backend/ads-service/src/test/java/com/marketinghub/facebookads/FacebookCampaignRecommendationServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/facebookads/FacebookCampaignRecommendationServiceTest.java
@@ -92,7 +92,7 @@ class FacebookCampaignRecommendationServiceTest {
         campaign.setName("Campanha");
         campaign.setObjective("OUTCOME_TRAFFIC");
         campaign.setStatus(FacebookAdStatus.ACTIVE);
-        campaign.setBudgetMode(BudgetMode.DAILY);
+        campaign.setBudgetMode(BudgetMode.CAMPAIGN);
         campaign.setExperiment(experiment);
         campaign.setFacebookAccount(account);
         return campaign;


### PR DESCRIPTION
### Motivation
- The unit test referenced a removed enum value `BudgetMode.DAILY`, causing compilation failures during `testCompile`; update the fixture to a valid enum to restore tests.

### Description
- Changed `backend/ads-service/src/test/java/com/marketinghub/facebookads/FacebookCampaignRecommendationServiceTest.java` to replace `campaign.setBudgetMode(BudgetMode.DAILY);` with `campaign.setBudgetMode(BudgetMode.CAMPAIGN);`.

### Testing
- Running `mvn test -Dtest=FacebookCampaignRecommendationServiceTest` under the default Java 25 environment fails due to Lombok/JDK incompatibility; re-ran with `mise exec java@21 -- mvn test -Dtest=FacebookCampaignRecommendationServiceTest` and the test suite passed (`2 tests, 0 failures`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a29bf9a2dbc8320aa7532870127ba88)