### PR TITLE
Fix frontend default backend URL (remove :8000); update tests and docs

### DIFF
--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -377,3 +377,8 @@
 - Decisão registrada: o OPRM deve apenas tratar a situação de confirmação e gravar os dados em banco próprio, sem criar fluxo no Lead Portal nem alterar Experimento diretamente.
 - Ajuste técnico: a confirmação de público geral passou a persistir um registro OPRM próprio em `oprm_general_audience_landing_confirmation`.
 - Prevenção de recorrência: o cânone OPRM agora explicita que `com.marketinghub.oprm..` não deve importar services, DTOs, entidades ou repositories de módulos externos para materializar etapas posteriores.
+
+## 2026-06-10 — OPRM Públicos Gerais: correção da URL padrão do backend no frontend
+
+- Corrigida a causa-raiz de ações do fluxo de Públicos Gerais parecerem travadas quando o frontend era acessado em `:5173`: a URL padrão do backend no frontend apontava para `:8000`, porta que pode recusar conexão nesse ambiente, enquanto o backend público responde pelo mesmo host na porta 80.
+- Mantido suporte a `VITE_API_URL` para ambientes que precisem sobrescrever a URL do backend.

--- a/frontend/src/config/api.ts
+++ b/frontend/src/config/api.ts
@@ -1,4 +1,4 @@
-const defaultApiBaseUrl = `${window.location.protocol}//${window.location.hostname}:8000`;
+const defaultApiBaseUrl = `${window.location.protocol}//${window.location.hostname}`;
 const envApiUrl = import.meta.env.VITE_API_URL?.trim();
 
 export const apiBaseUrl = envApiUrl && envApiUrl.length > 0 ? envApiUrl : defaultApiBaseUrl;

--- a/frontend/src/pages/oprm/OprmEnrichedNicheDetailPage.test.tsx
+++ b/frontend/src/pages/oprm/OprmEnrichedNicheDetailPage.test.tsx
@@ -70,11 +70,11 @@ describe("OprmEnrichedNicheDetailPage", () => {
       screen.getByRole("link", { name: "Baixar pesquisa Markdown" }),
     ).toHaveAttribute(
       "href",
-      "http://localhost:8000/api/oprm/nichocnae/enriched-niche-materializer/profiles/1/pipeline-markdown",
+      "http://localhost/api/oprm/nichocnae/enriched-niche-materializer/profiles/1/pipeline-markdown",
     );
     await waitFor(() => {
       expect(fetchMock).toHaveBeenCalledWith(
-        "http://localhost:8000/api/oprm/nichocnae/enriched-niche-materializer/profiles/1",
+        "http://localhost/api/oprm/nichocnae/enriched-niche-materializer/profiles/1",
       );
     });
   });

--- a/frontend/src/utils/resolveAssetUrl.test.ts
+++ b/frontend/src/utils/resolveAssetUrl.test.ts
@@ -5,13 +5,13 @@ import { resolveAssetUrl } from "./resolveAssetUrl";
 describe("resolveAssetUrl", () => {
   it("normaliza caminhos salvos com prefixo /api/uploads para o endpoint estático do backend", () => {
     expect(resolveAssetUrl("/api/uploads/imagem.png")).toBe(
-      "http://localhost:8000/uploads/imagem.png",
+      "http://localhost/uploads/imagem.png",
     );
   });
 
   it("mantém caminhos relativos funcionando como antes", () => {
     expect(resolveAssetUrl("uploads/imagem.png")).toBe(
-      "http://localhost:8000/uploads/imagem.png",
+      "http://localhost/uploads/imagem.png",
     );
   });
 


### PR DESCRIPTION
### Motivation

- Prevent frontend running on `:5173` from failing network calls due to a hardcoded `:8000` backend port that may refuse connections.
- Preserve the ability to override the backend URL via environment by keeping support for `VITE_API_URL`.
- Document the behavioral change for OPRM Públicos Gerais so the team understands the root cause and fix.

### Description

- Changed the frontend default backend base URL in `frontend/src/config/api.ts` from `${window.location.protocol}//${window.location.hostname}:8000` to `${window.location.protocol}//${window.location.hostname}` to use the same host default port (80) when no env override is provided.
- Updated unit tests in `OprmEnrichedNicheDetailPage.test.tsx` and `resolveAssetUrl.test.ts` to expect URLs without the `:8000` port in assertions for API and asset endpoints.
- Added documentation entry in `docs/registros/oprm1.md` noting the backend URL fix and that `VITE_API_URL` remains supported.

### Testing

- Ran the frontend unit tests with `vitest` covering `OprmEnrichedNicheDetailPage.test.tsx` and `resolveAssetUrl.test.ts`, and the updated assertions passed. 
- Ran the full frontend test suite locally and observed all tests passing after the changes. 
- No backend integration tests were modified as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a29c37232cc83209dd6b9ac2e1692b1)