### PR TITLE
Use mwj.recommendation for market-warmup queries and update registro note

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryService.java
@@ -505,7 +505,7 @@ public class MoisSalesLibraryService {
                        p.html_bytes, p.score_total, p.offer_summary, p.mechanism_summary, p.promise_summary, p.proof_summary,
                        p.last_error_category, p.last_error_message, p.last_job_execution_id, p.last_captured_at, p.last_analyzed_at, p.updated_at,
                        mws.score_total AS market_warmup_score_total, mws.market_temperature AS market_warmup_temperature,
-                       mws.ecosystem_type AS market_warmup_ecosystem_type, mws.recommendation AS market_warmup_recommendation,
+                       mws.ecosystem_type AS market_warmup_ecosystem_type, mwj.recommendation AS market_warmup_recommendation,
                        mwj.status AS market_warmup_status, COALESCE(mws.updated_at, mwj.updated_at) AS market_warmup_updated_at
                 """ + joins + " ORDER BY " + orderBy + " LIMIT ? OFFSET ?",
                 this::mapSalesPageResponse, workspaceId, normalizedPageSize, offset);
@@ -553,7 +553,7 @@ public class MoisSalesLibraryService {
                     SELECT p.id AS page_id, p.title, p.url_canonical, p.source,
                            COALESCE(p.score_total, 0) AS page_score_total,
                            COALESCE(mws.score_total, 0) AS warmup_score_total,
-                           mws.market_temperature, mws.ecosystem_type, mws.recommendation, mws.saturation_risk,
+                           mws.market_temperature, mws.ecosystem_type, mwj.recommendation, mws.saturation_risk,
                            COALESCE(src.evidence_updated_at, mws.updated_at, mwj.updated_at) AS evidence_updated_at,
                            mws.opportunity_recommendation, mws.next_experiment_suggestion,
                            ROUND(
@@ -561,7 +561,7 @@ public class MoisSalesLibraryService {
                                (COALESCE(mws.score_total, 0) * 0.35) +
                                (GREATEST(0, 100 - LEAST(100, TIMESTAMPDIFF(DAY, COALESCE(src.evidence_updated_at, mws.updated_at, mwj.updated_at), UTC_TIMESTAMP()) * 5)) * 0.20) -
                                (CASE
-                                   WHEN mws.market_temperature = 'SATURATED' OR mws.recommendation = 'SATURATED_REQUIRES_ANGLE'
+                                   WHEN mws.market_temperature = 'SATURATED' OR mwj.recommendation = 'SATURATED_REQUIRES_ANGLE'
                                         OR COALESCE(mws.saturation_risk, '') <> '' THEN 20
                                    ELSE 0
                                 END)
@@ -650,7 +650,7 @@ public class MoisSalesLibraryService {
                        p.html_bytes, p.score_total, p.offer_summary, p.mechanism_summary, p.promise_summary, p.proof_summary,
                        p.last_error_category, p.last_error_message, p.last_job_execution_id, p.last_captured_at, p.last_analyzed_at, p.updated_at,
                        mws.score_total AS market_warmup_score_total, mws.market_temperature AS market_warmup_temperature,
-                       mws.ecosystem_type AS market_warmup_ecosystem_type, mws.recommendation AS market_warmup_recommendation,
+                       mws.ecosystem_type AS market_warmup_ecosystem_type, mwj.recommendation AS market_warmup_recommendation,
                        mwj.status AS market_warmup_status, COALESCE(mws.updated_at, mwj.updated_at) AS market_warmup_updated_at
                 FROM mois_sales_page p
                 LEFT JOIN (

--- a/docs/registros/mois1.md
+++ b/docs/registros/mois1.md
@@ -1381,3 +1381,12 @@ Arquivos principais:
 - frontend/src/api/mois/types.ts
 - frontend/src/api/mois/useMoisSalesLibrary.ts
 - frontend/src/pages/mois/MoisSalesPagesLibraryPage.tsx
+
+## 2026-06-10 — Correção da listagem da Etapa 3 MOIS
+
+- Corrigida a causa-raiz da falha ao carregar a Biblioteca de Páginas de Vendas com filtros de aquecimento e o ranking de oportunidades comerciais.
+- A consulta de leitura usava `mws.recommendation`, mas o schema real persiste a recomendação comercial em `mois_sales_page_market_warmup_job.recommendation`; a tabela de resumo não possui essa coluna.
+- A listagem, o detalhe da página e o ranking passam a ler `mwj.recommendation`, mantendo a tela apta a listar páginas sem dossiê para iniciar a Etapa 3.
+
+Arquivos principais:
+- `backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryService.java`


### PR DESCRIPTION
### Motivation

- Fix a runtime failure when listing pages and computing opportunity rankings caused by selecting a non-existent `recommendation` column from the summary table. 
- The recommendation is persisted on the job row, not on the summary row, so queries must read `mwj.recommendation` instead of `mws.recommendation`.

### Description

- Replaced `mws.recommendation` with `mwj.recommendation` in the sales library listing query to avoid querying a column that does not exist on the summary table. 
- Replaced `mws.recommendation` with `mwj.recommendation` in the market-warmup opportunity ranking query and adjusted the saturation logic to reference the job recommendation. 
- Replaced `mws.recommendation` with `mwj.recommendation` in the single-page `getPage` query to ensure page detail loads correctly without a dossier. 
- Updated `docs/registros/mois1.md` with a note describing the fix and the affected file.

### Testing

- Ran `MoisSalesLibraryServiceTest` and related unit tests in the ads-service module, and they passed. 
- Executed the backend module test suite via `./gradlew :backend:ads-service:test` and the tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a29c3ca08348320a045f1ddbc67bf61)