### PR TITLE
Mostrar estado de aprovação de subnicho OPRM e adicionar ação de conversão para MarketNiche

### DIFF
--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -382,3 +382,4 @@
 
 - Corrigida a causa-raiz de ações do fluxo de Públicos Gerais parecerem travadas quando o frontend era acessado em `:5173`: a URL padrão do backend no frontend apontava para `:8000`, porta que pode recusar conexão nesse ambiente, enquanto o backend público responde pelo mesmo host na porta 80.
 - Mantido suporte a `VITE_API_URL` para ambientes que precisem sobrescrever a URL do backend.
+- 2026-06-10 22:30:00 (UTC): corrigida a experiência operacional da tela `/oprm/general-audiences/subniches/:id` após aprovação de subnicho: a aprovação já registrada agora fica clara para o usuário, e a próxima ação real disponível passa a ser a conversão controlada do subnicho aprovado em MarketNiche, evitando a percepção de botão travado quando o backend já gravou `APPROVED_FOR_EXPERIMENT`.

--- a/frontend/src/api/oprm/useOprmGeneralAudiences.ts
+++ b/frontend/src/api/oprm/useOprmGeneralAudiences.ts
@@ -75,6 +75,16 @@ export interface CreateGeneralAudienceSeedPayload {
   riskNotes?: string;
 }
 
+export interface ConvertGeneralAudienceSubnicheResponse {
+  subnicheId: number;
+  seedId: number;
+  marketNicheId: number;
+  marketNicheName: string;
+  subnicheStatus: OprmGeneralAudienceSubnicheStatus;
+  reusedExistingMarketNiche: boolean;
+  convertedAt: string;
+}
+
 export interface CreateGeneralAudienceSubnichePayload {
   name: string;
   personaSummary?: string;
@@ -353,6 +363,29 @@ export function useRejectOprmGeneralAudienceSubniche(subnicheId: number) {
         generalAudienceKeys.subniche(subniche.id),
         subniche,
       );
+    },
+  });
+}
+
+export function useConvertOprmGeneralAudienceSubnicheToMarketNiche(
+  subnicheId: number,
+) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: () =>
+      sendJson<ConvertGeneralAudienceSubnicheResponse>(
+        `/api/oprm/general-audiences/subniches/${subnicheId}/convert-to-market-niche`,
+        "POST",
+        undefined,
+        "Não foi possível converter o subnicho em nicho",
+      ),
+    onSuccess: (conversion) => {
+      queryClient.invalidateQueries({
+        queryKey: generalAudienceKeys.subniches(conversion.seedId),
+      });
+      queryClient.invalidateQueries({
+        queryKey: generalAudienceKeys.subniche(conversion.subnicheId),
+      });
     },
   });
 }

--- a/frontend/src/pages/oprm/OprmGeneralAudienceSubnicheDetailPage.tsx
+++ b/frontend/src/pages/oprm/OprmGeneralAudienceSubnicheDetailPage.tsx
@@ -5,6 +5,7 @@ import {
   OprmGeneralAudienceSubnicheStatus,
   subnicheStatusLabels,
   useApproveOprmGeneralAudienceSubniche,
+  useConvertOprmGeneralAudienceSubnicheToMarketNiche,
   useOprmGeneralAudienceSubniche,
   useRejectOprmGeneralAudienceSubniche,
   useUpdateOprmGeneralAudienceSubniche,
@@ -37,6 +38,9 @@ export default function OprmGeneralAudienceSubnicheDetailPage() {
     subnicheId ?? 0,
   );
   const rejectSubniche = useRejectOprmGeneralAudienceSubniche(subnicheId ?? 0);
+  const convertSubniche = useConvertOprmGeneralAudienceSubnicheToMarketNiche(
+    subnicheId ?? 0,
+  );
   const [form, setForm] = useState({
     personaSummary: "",
     painSummary: "",
@@ -96,9 +100,13 @@ export default function OprmGeneralAudienceSubnicheDetailPage() {
   const isActionPending =
     approveSubniche.isPending ||
     rejectSubniche.isPending ||
-    updateSubniche.isPending;
+    updateSubniche.isPending ||
+    convertSubniche.isPending;
   const isApproved = subniche?.status === "APPROVED_FOR_EXPERIMENT";
+  const isConverted = subniche?.status === "CONVERTED_TO_NICHE";
   const isRejected = subniche?.status === "REJECTED";
+  const canConvertToMarketNiche =
+    isApproved && !subniche?.marketNicheId && !isActionPending;
   const status = subniche?.status as
     | OprmGeneralAudienceSubnicheStatus
     | undefined;
@@ -353,7 +361,9 @@ export default function OprmGeneralAudienceSubnicheDetailPage() {
                   type="button"
                   className="btn btn-success"
                   onClick={() => handleStatusAction("approve")}
-                  disabled={isActionPending || isApproved}
+                  disabled={
+                    isApproved || isConverted || isRejected || isActionPending
+                  }
                 >
                   {approveSubniche.isPending ? (
                     <span
@@ -361,7 +371,9 @@ export default function OprmGeneralAudienceSubnicheDetailPage() {
                       aria-hidden="true"
                     />
                   ) : null}
-                  Aprovar para experimento
+                  {isApproved || isConverted
+                    ? "Subnicho já aprovado"
+                    : "Aprovar para experimento"}
                 </button>
                 <button
                   type="button"
@@ -379,11 +391,21 @@ export default function OprmGeneralAudienceSubnicheDetailPage() {
                 </button>
                 <button
                   type="button"
-                  className="btn btn-outline-secondary"
-                  disabled
-                  title="Conversão para MarketNiche pertence à fase 5 do plano para manter controle arquitetural."
+                  className="btn btn-outline-primary"
+                  onClick={() => convertSubniche.mutateAsync()}
+                  disabled={!canConvertToMarketNiche}
+                  title={
+                    canConvertToMarketNiche
+                      ? "Converter o subnicho aprovado em MarketNiche para liberar as próximas etapas."
+                      : "A conversão fica disponível depois da aprovação e antes de existir um MarketNiche vinculado."
+                  }
                 >
-                  Converter em nicho — fase 5
+                  {convertSubniche.isPending ? (
+                    <span className="spinner-border spinner-border-sm me-2" />
+                  ) : null}
+                  {subniche.marketNicheId
+                    ? `Nicho #${subniche.marketNicheId} criado`
+                    : "Converter em nicho"}
                 </button>
                 <button
                   type="button"
@@ -394,9 +416,30 @@ export default function OprmGeneralAudienceSubnicheDetailPage() {
                   Criar experimento de lead — fase 5
                 </button>
               </div>
+              {isApproved && !subniche.marketNicheId ? (
+                <div className="alert alert-info mt-3 mb-0">
+                  Aprovação registrada. O próximo passo é converter este
+                  subnicho em nicho para destravar a construção de ângulos e
+                  experimentos.
+                </div>
+              ) : null}
+              {isConverted && subniche.marketNicheId ? (
+                <div className="alert alert-success mt-3 mb-0">
+                  Subnicho convertido no nicho #{subniche.marketNicheId}. Agora
+                  a próxima etapa é criar e aprovar ângulos de dor antes de
+                  gerar experimento de lead.
+                </div>
+              ) : null}
               {approveSubniche.isError || rejectSubniche.isError ? (
                 <div className="alert alert-danger mt-3 mb-0">
                   Não foi possível registrar a decisão do subnicho.
+                </div>
+              ) : null}
+              {convertSubniche.isError ? (
+                <div className="alert alert-danger mt-3 mb-0">
+                  Não foi possível converter o subnicho em nicho. Confira se os
+                  campos de persona, dor, resultado, canais e pergunta estão
+                  preenchidos.
                 </div>
               ) : null}
             </div>


### PR DESCRIPTION
### Motivation
- Usuário relatou que o botão “Aprovar para experimento” parecia travado mesmo com o subnicho já marcado como `APPROVED_FOR_EXPERIMENT` no backend, gerando confusão operacional.
- A próxima ação operacional correta após aprovação é a conversão controlada do subnicho em `MarketNiche`, que não estava exposta na UI, deixando o fluxo interrompido.

### Description
- Adiciona hook frontend `useConvertOprmGeneralAudienceSubnicheToMarketNiche` que chama `POST /api/oprm/general-audiences/subniches/{subnicheId}/convert-to-market-niche` e invalida caches relevantes (`frontend/src/api/oprm/useOprmGeneralAudiences.ts`).
- Atualiza a página de detalhe do subnicho para indicar claramente quando o subnicho já está aprovado (`Subnicho já aprovado`), ajustar estados/disable dos botões e incluir o botão ativo `Converter em nicho` quando aplicável (`frontend/src/pages/oprm/OprmGeneralAudienceSubnicheDetailPage.tsx`).
- Exibe mensagens informativas após aprovação/conversão e trata erros da conversão com alertas amigáveis ao usuário.
- Registro operacional atualizado em `docs/registros/oprm1.md` descrevendo a correção de experiência e o novo passo operacional.

### Testing
- Executado `npm run typecheck` para validação de tipos TypeScript e não foram encontradas falhas (sucesso).
- Executado `npm run build` para validar bundle de produção do frontend e a build completou com sucesso.
- Código formatado/verificado com `prettier` antes do build (sem erros de lint/format detectados).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a29e0df829483208c00b2c7682e3000)