### PR TITLE
feat(frontend): adicionar botão "Criar hipótese" no cabeçalho do nicho

### DIFF
--- a/frontend/src/__tests__/NicheFlow.test.tsx
+++ b/frontend/src/__tests__/NicheFlow.test.tsx
@@ -90,6 +90,7 @@ describe("niche navigation", () => {
     userEvent.click(screen.getByText("Fitness"));
     await screen.findByText("Ver detalhes");
     await screen.findByText(/Entrega:/);
+    await screen.findByRole("button", { name: /^criar hipótese$/i });
     await screen.findByRole("button", { name: /salvar em markdown/i });
     userEvent.click(screen.getByText("Ver detalhes"));
     await screen.findByText("Criar Experimento");

--- a/frontend/src/pages/niche/NicheDetailPage.css
+++ b/frontend/src/pages/niche/NicheDetailPage.css
@@ -91,7 +91,7 @@
   gap: 0.75rem;
 }
 
-.niche-detail__export-btn {
+.niche-detail__action-btn {
   display: inline-flex;
   align-items: center;
   gap: 0.5rem;
@@ -101,7 +101,7 @@
   box-shadow: 0 16px 30px -20px rgba(var(--bs-primary-rgb, 13, 110, 253), 0.45);
 }
 
-.niche-detail__export-btn:focus-visible {
+.niche-detail__action-btn:focus-visible {
   outline: 3px solid rgba(var(--bs-primary-rgb, 13, 110, 253), 0.35);
   outline-offset: 2px;
 }
@@ -127,7 +127,9 @@
 
 .niche-detail__stat--interactive {
   cursor: pointer;
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  transition:
+    transform 0.2s ease,
+    box-shadow 0.2s ease;
 }
 
 .niche-detail__stat--interactive:hover {
@@ -714,6 +716,16 @@
 @media (max-width: 576px) {
   .niche-detail__header {
     padding: 1.25rem;
+  }
+
+  .niche-detail__actions {
+    align-items: stretch;
+    flex-direction: column;
+    width: 100%;
+  }
+
+  .niche-detail__action-btn {
+    justify-content: center;
   }
 
   .niche-detail__stats {

--- a/frontend/src/pages/niche/NicheDetailPage.tsx
+++ b/frontend/src/pages/niche/NicheDetailPage.tsx
@@ -218,7 +218,9 @@ export default function NicheDetailPage() {
   const leadPortalFlowList = Array.isArray(nicheLeadPortalFlows)
     ? nicheLeadPortalFlows
     : [];
-  const [flowBeingEdited, setFlowBeingEdited] = useState<LeadPortalFlow | null>(null);
+  const [flowBeingEdited, setFlowBeingEdited] = useState<LeadPortalFlow | null>(
+    null,
+  );
   const { data: detailedDescriptions } = useNicheDetailedDescriptions(nicheId);
   const requestHypotheses = useRequestHypotheses(id);
   const requestDetailedDescriptions = useRequestDetailedDescriptions(id);
@@ -359,6 +361,16 @@ export default function NicheDetailPage() {
   const handleManualHypothesisSuccess = useCallback(() => {
     setManualHypothesisFormVisible(false);
   }, []);
+
+  const handleOpenManualHypothesisForm = useCallback(() => {
+    setManualHypothesisFormVisible(true);
+    const scrollToForm = () => scrollToSection("niche-manual-hypothesis-form");
+    if (typeof window.requestAnimationFrame === "function") {
+      window.requestAnimationFrame(scrollToForm);
+      return;
+    }
+    window.setTimeout(scrollToForm, 0);
+  }, [scrollToSection]);
 
   const list = Array.isArray(hypotheses)
     ? [...hypotheses].sort((a, b) => {
@@ -642,7 +654,9 @@ export default function NicheDetailPage() {
       icon: Sparkles,
       label: "Pixel do Facebook",
       value: facebookPixelId ? "Ativo" : "Pendente",
-      helper: facebookPixelId ?? "Gerado automaticamente quando um experimento é liberado",
+      helper:
+        facebookPixelId ??
+        "Gerado automaticamente quando um experimento é liberado",
       targetId: "niche-facebook-pixel",
     },
     {
@@ -947,7 +961,15 @@ export default function NicheDetailPage() {
         <div className="niche-detail__actions">
           <button
             type="button"
-            className="btn btn-outline-secondary niche-detail__export-btn"
+            className="btn btn-primary niche-detail__action-btn"
+            onClick={handleOpenManualHypothesisForm}
+          >
+            <Plus size={18} />
+            <span>Criar hipótese</span>
+          </button>
+          <button
+            type="button"
+            className="btn btn-outline-secondary niche-detail__action-btn"
             onClick={handleSaveMarkdown}
           >
             <FileDown size={18} />
@@ -1028,7 +1050,10 @@ export default function NicheDetailPage() {
       >
         <div className="niche-section__header">
           <div>
-            <h2 className="niche-section__title" id="niche-facebook-pixel-title">
+            <h2
+              className="niche-section__title"
+              id="niche-facebook-pixel-title"
+            >
               Pixel do Facebook
             </h2>
             <p className="niche-section__subtitle">
@@ -1060,13 +1085,15 @@ export default function NicheDetailPage() {
               />
             ) : (
               <div className="alert alert-info mb-0">
-                Pixel registrado. Aguarde o retorno do código completo pela Meta.
+                Pixel registrado. Aguarde o retorno do código completo pela
+                Meta.
               </div>
             )}
           </div>
         ) : (
           <div className="alert alert-warning mb-0">
-            Libere um experimento pronto para que o worker gere o pixel automaticamente.
+            Libere um experimento pronto para que o worker gere o pixel
+            automaticamente.
           </div>
         )}
       </section>
@@ -2063,10 +2090,14 @@ export default function NicheDetailPage() {
                             {flow.approved ? "Aprovado" : "Pendente"}
                           </span>
                           {flow.customFormHtml ? (
-                            <span className="badge text-bg-info">HTML personalizado</span>
+                            <span className="badge text-bg-info">
+                              HTML personalizado
+                            </span>
                           ) : null}
                           {flowBeingEdited?.id === flow.id ? (
-                            <span className="badge text-bg-warning">Em edição</span>
+                            <span className="badge text-bg-warning">
+                              Em edição
+                            </span>
                           ) : null}
                         </div>
                         <p className="text-muted small mb-1">
@@ -2093,7 +2124,9 @@ export default function NicheDetailPage() {
                         {flow.customFormHtml ? (
                           <details className="mt-2">
                             <summary>Ver HTML personalizado</summary>
-                            <pre className="bg-body-tertiary rounded-3 p-3 small overflow-auto">{flow.customFormHtml}</pre>
+                            <pre className="bg-body-tertiary rounded-3 p-3 small overflow-auto">
+                              {flow.customFormHtml}
+                            </pre>
                           </details>
                         ) : null}
 


### PR DESCRIPTION
### Motivation
- Melhorar a usabilidade da página de detalhe do nicho simples oferecendo acesso rápido ao formulário de criação de hipótese sem precisar rolar a página.
- Reutilizar o formulário manual já existente para manter consistência e evitar duplicação de código.

### Description
- Adiciona botão `Criar hipótese` no cabeçalho da página de nicho em `frontend/src/pages/niche/NicheDetailPage.tsx` que abre o formulário manual e realiza scroll até `#niche-manual-hypothesis-form` via `handleOpenManualHypothesisForm`.
- Atualiza estilos em `frontend/src/pages/niche/NicheDetailPage.css`, renomeando a classe do botão de ação para `.niche-detail__action-btn` e ajustando a responsividade/flex do grupo de ações para telas pequenas.
- Reaproveita `HypothesisManualForm` sem alterações funcionais e mantém comportamento já existente de salvar hipótese via `useCreateHypothesis`.
- Ajusta teste de integração `frontend/src/__tests__/NicheFlow.test.tsx` para checar a presença do novo botão no fluxo de navegação.

### Testing
- Executado `npm test -- --run src/__tests__/NicheFlow.test.tsx` dentro de `frontend` e o teste passou com sucesso.
- Executado `npm run typecheck` (via `tsc --noEmit`) e não foram encontrados erros de tipagem.
- Executado `npm run build` em `frontend` e o build completou com sucesso.
- Gerada captura de tela do fluxo com `npx playwright screenshot` para validação visual da adição do botão e do comportamento de abrir/scroll, e o screenshot foi produzido com sucesso.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_b_6a2a1449c8e08320bd7daf93b73c3581)