### PR TITLE
Relax semantic validations for niche seed builder and trust model outputs; update schemas, prompts, docs and tests

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/nicheresearchseedbuilder/service/BackendNicheResearchSeedBuilderService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/nicheresearchseedbuilder/service/BackendNicheResearchSeedBuilderService.java
@@ -14,13 +14,9 @@ import com.marketinghub.repository.jpa.oprm.nichocnae.OprmNicheResearchSeedRepos
 import com.marketinghub.repository.jpa.oprm.nichocnae.OprmResearchQueryRepository;
 import com.marketinghub.repository.jpa.oprm.nichocnae.OprmRoutineResearchCycleRepository;
 import jakarta.persistence.EntityNotFoundException;
-import java.text.Normalizer;
 import java.time.Instant;
 import java.util.Comparator;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Locale;
-import java.util.Set;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.data.domain.PageRequest;
@@ -38,44 +34,6 @@ public class BackendNicheResearchSeedBuilderService {
   private static final String RETRYABLE_LEGACY_CONTRACT_ERROR = "nicheName is required";
   private static final String COMPLETE_STAGE_PATH_FRAGMENT = "niche-research-seed-builder/stage-executions";
   private static final String DEFAULT_CREATED_BY = "AI";
-  private static final int MIN_QUERY_COUNT = 12;
-  private static final int MAX_QUERY_COUNT = 15;
-  private static final Set<String> ALLOWED_QUERY_GOALS = Set.of(
-      "MEI_ROUTINE_DISCOVERY",
-      "AUTONOMOUS_WORK_MODE_DISCOVERY",
-      "CUSTOMER_ACQUISITION_BEHAVIOR_DISCOVERY",
-      "DAILY_OPERATION_PAIN_DISCOVERY",
-      "EMOTIONAL_PAIN_DISCOVERY",
-      "DREAM_DISCOVERY",
-      "FEAR_DISCOVERY",
-      "CHANNEL_BEHAVIOR_DISCOVERY",
-      "LANGUAGE_DISCOVERY",
-      "SOURCE_FRESHNESS_DISCOVERY");
-  private static final Set<String> SOLUTION_TERMS = Set.of(
-      "ia",
-      "inteligencia artificial",
-      "automacao",
-      "software",
-      "sistema",
-      "app",
-      "ferramenta",
-      "curso",
-      "template",
-      "produto",
-      "oferta",
-      "campanha",
-      "landing page");
-  private static final Set<String> GENERIC_QUERIES = Set.of("como vender mais", "aumentar vendas", "vender mais");
-  private static final Set<String> AUDIENCE_MARKERS = Set.of(
-      "mei",
-      "autonomo",
-      "profissional autonomo",
-      "trabalhador por conta propria",
-      "dono operador",
-      "dono-operador");
-  private static final Set<String> BRAZIL_MARKERS = Set.of(
-      "brasil", "brasileiro", "brasileira", "brasileiros", "pt-br");
-
   private final OprmRoutineResearchCycleRepository routineResearchCycleRepository;
   private final OprmNicheResearchSeedRepository nicheResearchSeedRepository;
   private final OprmResearchQueryRepository researchQueryRepository;
@@ -204,86 +162,21 @@ public class BackendNicheResearchSeedBuilderService {
     requiredText(request.commercialObjects(), "commercialObjects");
     requiredText(request.initialAssumptions(), "initialAssumptions");
     requiredText(request.confidenceLevel(), "confidenceLevel");
-    validateQueries(cycle, request.queries());
+    validateQueries(request.queries());
   }
 
-  /** Valida quantidade, objetivos, duplicidade, texto mínimo e ausência de solução nas queries geradas. */
-  private void validateQueries(OprmRoutineResearchCycle cycle, List<NicheResearchQueryRequest> queries) {
-    if (queries == null || queries.size() < MIN_QUERY_COUNT || queries.size() > MAX_QUERY_COUNT) {
-      throw new IllegalArgumentException("queries must contain between 12 and 15 items");
+  /** Valida apenas se a saída do modelo possui queries persistíveis, sem julgar conteúdo semântico. */
+  private void validateQueries(List<NicheResearchQueryRequest> queries) {
+    if (queries == null || queries.isEmpty()) {
+      throw new IllegalArgumentException("queries must contain at least one persistable item");
     }
-    Set<String> uniqueQueryTexts = new HashSet<>();
-    String allowedCnaeText = normalizeForTerms(cycle.getCnaeDescription());
     for (NicheResearchQueryRequest query : queries) {
-      String rawQueryText = requiredText(query == null ? null : query.queryText(), "queryText");
-      String queryText = normalizeForTerms(rawQueryText);
-      if (!uniqueQueryTexts.add(queryText)) {
-        throw new IllegalArgumentException("Duplicate queryText is not allowed: " + query.queryText());
+      if (query == null) {
+        throw new IllegalArgumentException("query item is required");
       }
-      rejectGenericQuery(rawQueryText, queryText);
-      rejectSolutionTerms(rawQueryText, allowedCnaeText);
-      validateAudienceAndBrazilMarkers(rawQueryText);
-      String queryGoal = requiredText(query.queryGoal(), "queryGoal");
-      if (!ALLOWED_QUERY_GOALS.contains(queryGoal)) {
-        throw new IllegalArgumentException("Unsupported queryGoal: " + queryGoal);
-      }
+      requiredText(query.queryText(), "queryText");
+      requiredText(query.queryGoal(), "queryGoal");
     }
-  }
-
-  /** Rejeita queries genéricas que não ajudam a pesquisar a rotina real do MEI/autônomo. */
-  private void rejectGenericQuery(String rawQueryText, String normalizedQueryText) {
-    if (GENERIC_QUERIES.contains(normalizedQueryText)) {
-      throw new IllegalArgumentException("Generic query is not allowed: " + rawQueryText);
-    }
-  }
-
-  /** Exige marcadores claros de público MEI/autônomo e de contexto brasileiro antes da persistência. */
-  private void validateAudienceAndBrazilMarkers(String queryText) {
-    String normalizedQuery = normalizeForTerms(queryText);
-    Set<String> queryTokens = tokenizeNormalizedText(normalizedQuery);
-    boolean hasAudienceMarker = AUDIENCE_MARKERS.stream()
-        .anyMatch(marker -> containsTerm(normalizedQuery, queryTokens, marker));
-    if (!hasAudienceMarker) {
-      throw new IllegalArgumentException("Query must mention MEI/autonomous professional audience: " + queryText);
-    }
-    boolean hasBrazilMarker = BRAZIL_MARKERS.stream()
-        .anyMatch(marker -> containsTerm(normalizedQuery, queryTokens, marker));
-    if (!hasBrazilMarker) {
-      throw new IllegalArgumentException("Query must mention Brazilian or pt-BR context: " + queryText);
-    }
-  }
-
-  /** Rejeita queries que nascem procurando solução sem esse termo existir literalmente na descrição CNAE. */
-  private void rejectSolutionTerms(String queryText, String allowedCnaeText) {
-    String normalizedQuery = normalizeForTerms(queryText);
-    Set<String> queryTokens = tokenizeNormalizedText(normalizedQuery);
-    for (String term : SOLUTION_TERMS) {
-      if (containsTerm(normalizedQuery, queryTokens, term) && !containsAllowedCnaeTerm(allowedCnaeText, term)) {
-        throw new IllegalArgumentException("Query contains forbidden solution language: " + queryText);
-      }
-    }
-  }
-
-  /** Verifica se a descrição CNAE autoriza literalmente o uso de um termo sensível. */
-  private boolean containsAllowedCnaeTerm(String allowedCnaeText, String term) {
-    Set<String> allowedTokens = tokenizeNormalizedText(allowedCnaeText);
-    return containsTerm(allowedCnaeText, allowedTokens, term);
-  }
-
-  /** Tokeniza texto normalizado sem falhar quando palavras comuns aparecem repetidas no payload da IA. */
-  private Set<String> tokenizeNormalizedText(String normalizedText) {
-    Set<String> tokens = new HashSet<>();
-    for (String token : normalizedText.split("[^a-z0-9]+")) {
-      if (StringUtils.hasText(token)) {
-        tokens.add(token);
-      }
-    }
-    return tokens;
-  }
-
-  /** Detecta termos simples por token e expressões compostas por ocorrência textual normalizada. */
-  private boolean containsTerm(String text, Set<String> tokens, String term) {
-    return term.matches(".*[^a-z0-9].*") ? text.contains(term) : tokens.contains(term);
   }
 
   /** Cria a entidade de seed do nicho usando o ciclo canônico como fonte dos dados CNAE. */
@@ -405,12 +298,6 @@ public class BackendNicheResearchSeedBuilderService {
     return value.trim();
   }
 
-
-  /** Normaliza texto removendo acentos para comparar termos de solução de forma determinística. */
-  private String normalizeForTerms(String value) {
-    String normalized = value == null ? "" : value.toLowerCase(Locale.ROOT).trim().replaceAll("\\s+", " ");
-    return Normalizer.normalize(normalized, Normalizer.Form.NFD).replaceAll("\\p{M}+", "");
-  }
 
   /** Converte strings vazias em nulo para campos opcionais persistidos. */
   private String trimToNull(String value) {

--- a/backend/ads-service/src/test/java/com/marketinghub/oprm/nichocnae/nicheresearchseedbuilder/service/BackendNicheResearchSeedBuilderServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/oprm/nichocnae/nicheresearchseedbuilder/service/BackendNicheResearchSeedBuilderServiceTest.java
@@ -117,11 +117,12 @@ class BackendNicheResearchSeedBuilderServiceTest {
     assertThat(cycleCaptor.getValue().getTotalQueries()).isEqualTo(12);
   }
 
-  /** Deve rejeitar objetivos comerciais para impedir pesquisa inicial procurando produto, oferta ou solução. */
+  /** Deve aceitar objetivo retornado pelo modelo sem bloquear semanticamente a etapa preparatória. */
   @Test
-  void completeRejectsCommercialQueryGoal() {
+  void completeAcceptsModelReturnedQueryGoal() {
     OprmRoutineResearchCycle cycle = cycle();
     when(routineResearchCycleRepository.findById(1001L)).thenReturn(Optional.of(cycle));
+    stubSuccessfulPersistence();
     CompleteNicheResearchSeedBuilderRequest request = new CompleteNicheResearchSeedBuilderRequest(
         "Cabeleireiros, manicures e pedicures",
         "serviço local de beleza",
@@ -133,17 +134,18 @@ class BackendNicheResearchSeedBuilderServiceTest {
         "AI",
         validQueryRequestsWithFirst("manicure MEI serviços mais procurados Brasil", "PRODUCT_SERVICE_DISCOVERY"));
 
-    assertThatThrownBy(() -> service.complete(1001L, request))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("Unsupported queryGoal");
-    verify(nicheResearchSeedRepository, never()).save(any());
+    CompleteNicheResearchSeedBuilderResponse response = service.complete(1001L, request);
+
+    assertThat(response.totalQueries()).isEqualTo(12);
+    assertThat(response.queries()).extracting("queryGoal").contains("PRODUCT_SERVICE_DISCOVERY");
   }
 
-  /** Deve rejeitar queries contaminadas por solução quando o termo não faz parte literal do CNAE. */
+  /** Deve aceitar linguagem de solução retornada pelo modelo sem bloquear a criação das queries iniciais. */
   @Test
-  void completeRejectsSolutionLanguageQuery() {
+  void completeAcceptsSolutionLanguageQuery() {
     OprmRoutineResearchCycle cycle = cycle();
     when(routineResearchCycleRepository.findById(1001L)).thenReturn(Optional.of(cycle));
+    stubSuccessfulPersistence();
     CompleteNicheResearchSeedBuilderRequest request = new CompleteNicheResearchSeedBuilderRequest(
         "Cabeleireiros, manicures e pedicures",
         "serviço local de beleza",
@@ -155,17 +157,17 @@ class BackendNicheResearchSeedBuilderServiceTest {
         "AI",
         validQueryRequestsWithFirst("IA para crescimento de manicure MEI Brasil", "MEI_ROUTINE_DISCOVERY"));
 
-    assertThatThrownBy(() -> service.complete(1001L, request))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("forbidden solution language");
-    verify(nicheResearchSeedRepository, never()).save(any());
+    CompleteNicheResearchSeedBuilderResponse response = service.complete(1001L, request);
+
+    assertThat(response.totalQueries()).isEqualTo(12);
   }
 
-  /** Deve rejeitar query sem marcador de MEI/autônomo para impedir retorno ao segmento genérico por CNAE. */
+  /** Deve aceitar query sem marcador literal de MEI/autônomo porque a etapa passa a confiar no modelo. */
   @Test
-  void completeRejectsQueryWithoutAudienceMarker() {
+  void completeAcceptsQueryWithoutAudienceMarker() {
     OprmRoutineResearchCycle cycle = cycle();
     when(routineResearchCycleRepository.findById(1001L)).thenReturn(Optional.of(cycle));
+    stubSuccessfulPersistence();
     CompleteNicheResearchSeedBuilderRequest request = new CompleteNicheResearchSeedBuilderRequest(
         "Cabeleireiros, manicures e pedicures",
         "serviço local de beleza",
@@ -177,17 +179,17 @@ class BackendNicheResearchSeedBuilderServiceTest {
         "AI",
         validQueryRequestsWithFirst("manicure responsabilidades rotina Brasil", "MEI_ROUTINE_DISCOVERY"));
 
-    assertThatThrownBy(() -> service.complete(1001L, request))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("MEI/autonomous professional audience");
-    verify(nicheResearchSeedRepository, never()).save(any());
+    CompleteNicheResearchSeedBuilderResponse response = service.complete(1001L, request);
+
+    assertThat(response.totalQueries()).isEqualTo(12);
   }
 
-  /** Deve rejeitar query sem marcador brasileiro para manter fontes e linguagem do mercado nacional. */
+  /** Deve aceitar query sem marcador literal brasileiro porque a localização será tratada pelas próximas etapas. */
   @Test
-  void completeRejectsQueryWithoutBrazilMarker() {
+  void completeAcceptsQueryWithoutBrazilMarker() {
     OprmRoutineResearchCycle cycle = cycle();
     when(routineResearchCycleRepository.findById(1001L)).thenReturn(Optional.of(cycle));
+    stubSuccessfulPersistence();
     CompleteNicheResearchSeedBuilderRequest request = new CompleteNicheResearchSeedBuilderRequest(
         "Cabeleireiros, manicures e pedicures",
         "serviço local de beleza",
@@ -199,10 +201,9 @@ class BackendNicheResearchSeedBuilderServiceTest {
         "AI",
         validQueryRequestsWithFirst("manicure MEI responsabilidades rotina", "MEI_ROUTINE_DISCOVERY"));
 
-    assertThatThrownBy(() -> service.complete(1001L, request))
-        .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("Brazilian or pt-BR context");
-    verify(nicheResearchSeedRepository, never()).save(any());
+    CompleteNicheResearchSeedBuilderResponse response = service.complete(1001L, request);
+
+    assertThat(response.totalQueries()).isEqualTo(12);
   }
 
   /** Deve aceitar queries com palavras comuns repetidas sem gerar duplicate element na tokenização. */
@@ -210,14 +211,7 @@ class BackendNicheResearchSeedBuilderServiceTest {
   void completeAcceptsRepeatedCommonWordsInQueryText() {
     OprmRoutineResearchCycle cycle = cycle();
     when(routineResearchCycleRepository.findById(1001L)).thenReturn(Optional.of(cycle));
-    when(nicheResearchSeedRepository.existsByResearchCycleId(1001L)).thenReturn(false);
-    when(nicheResearchSeedRepository.save(any(OprmNicheResearchSeed.class)))
-        .thenAnswer(invocation -> {
-          OprmNicheResearchSeed seed = invocation.getArgument(0);
-          seed.setId(44L);
-          return seed;
-        });
-    when(researchQueryRepository.saveAll(any())).thenAnswer(invocation -> invocation.getArgument(0));
+    stubSuccessfulPersistence();
     CompleteNicheResearchSeedBuilderRequest request = new CompleteNicheResearchSeedBuilderRequest(
         "Cabeleireiros, manicures e pedicures",
         "serviço local de beleza",
@@ -236,11 +230,12 @@ class BackendNicheResearchSeedBuilderServiceTest {
     verify(nicheResearchSeedRepository).save(any());
   }
 
-  /** Deve rejeitar payloads com mais de quinze queries para preservar o MVP documentado. */
+  /** Deve aceitar mais de quinze queries quando o modelo decidir ampliar a cobertura da pesquisa inicial. */
   @Test
-  void completeRejectsMoreThanFifteenQueries() {
+  void completeAcceptsMoreThanFifteenQueries() {
     OprmRoutineResearchCycle cycle = cycle();
     when(routineResearchCycleRepository.findById(1001L)).thenReturn(Optional.of(cycle));
+    stubSuccessfulPersistence();
     List<NicheResearchQueryRequest> manyQueries = java.util.stream.IntStream.rangeClosed(1, 16)
         .mapToObj(index -> new NicheResearchQueryRequest(
             "manicure MEI rotina Brasil " + index, "MEI_ROUTINE_DISCOVERY", "web", index))
@@ -256,9 +251,30 @@ class BackendNicheResearchSeedBuilderServiceTest {
         "AI",
         manyQueries);
 
+    CompleteNicheResearchSeedBuilderResponse response = service.complete(1001L, request);
+
+    assertThat(response.totalQueries()).isEqualTo(16);
+  }
+
+  /** Deve rejeitar somente ausência total de queries para evitar concluir etapa sem trabalho executável. */
+  @Test
+  void completeRejectsEmptyQueries() {
+    OprmRoutineResearchCycle cycle = cycle();
+    when(routineResearchCycleRepository.findById(1001L)).thenReturn(Optional.of(cycle));
+    CompleteNicheResearchSeedBuilderRequest request = new CompleteNicheResearchSeedBuilderRequest(
+        "Cabeleireiros, manicures e pedicures",
+        "serviço local de beleza",
+        "agenda e atendimento recorrente",
+        "consumidor final recorrente",
+        "manicure, pedicure, escova",
+        "depende de agenda cheia",
+        "INFERRED_FROM_CNAE",
+        "AI",
+        List.of());
+
     assertThatThrownBy(() -> service.complete(1001L, request))
         .isInstanceOf(IllegalArgumentException.class)
-        .hasMessageContaining("between 12 and 15");
+        .hasMessageContaining("at least one persistable item");
     verify(nicheResearchSeedRepository, never()).save(any());
   }
 
@@ -310,7 +326,7 @@ class BackendNicheResearchSeedBuilderServiceTest {
         validQueryRequests());
   }
 
-  /** Cria a lista mínima válida de queries da etapa dois com marcadores de público e Brasil. */
+  /** Cria a lista padrão de queries da etapa dois usada pelos cenários de persistência. */
   private List<NicheResearchQueryRequest> validQueryRequests() {
     return List.of(
         new NicheResearchQueryRequest("manicure MEI responsabilidades rotina Brasil", "MEI_ROUTINE_DISCOVERY", "web", 1),
@@ -344,6 +360,26 @@ class BackendNicheResearchSeedBuilderServiceTest {
     List<NicheResearchQueryRequest> queries = new java.util.ArrayList<>(validQueryRequests());
     queries.set(0, new NicheResearchQueryRequest(queryText, queryGoal, "web", 1));
     return queries;
+  }
+
+
+  /** Configura os repositórios para simular persistência bem-sucedida da etapa dois. */
+  private void stubSuccessfulPersistence() {
+    when(nicheResearchSeedRepository.existsByResearchCycleId(1001L)).thenReturn(false);
+    when(nicheResearchSeedRepository.save(any(OprmNicheResearchSeed.class)))
+        .thenAnswer(invocation -> {
+          OprmNicheResearchSeed seed = invocation.getArgument(0);
+          seed.setId(44L);
+          return seed;
+        });
+    when(researchQueryRepository.saveAll(any())).thenAnswer(invocation -> {
+      @SuppressWarnings("unchecked")
+      List<OprmResearchQuery> queries = invocation.getArgument(0);
+      for (int i = 0; i < queries.size(); i++) {
+        queries.get(i).setId((long) i + 1);
+      }
+      return queries;
+    });
   }
 
   /** Monta um ciclo falho pelo contrato legado para validar recuperação automática da etapa dois. */

--- a/docs/canonical/oprm-canon.v1.md
+++ b/docs/canonical/oprm-canon.v1.md
@@ -199,6 +199,7 @@ Evitar fechamento prematuro de `import run` que destrói a totalização de mark
 - É proibido acoplar uma etapa concreta a outra etapa concreta para avançar o fluxo; o encadeamento deve ocorrer por contratos persistidos, artefatos auditáveis, endpoints do backend ou outro contrato oficial.
 - O backend principal permanece como fonte de verdade dos dados e contratos; o módulo executor OPRM deve consumir e concluir etapas por endpoints do próprio OPRM/backend, sem acesso direto ao banco.
 - Chamadas ao modelo, prompts, validações e mapeamento de resposta devem ficar encapsulados no pacote da etapa concreta que usa IA, preservando isolamento, rastreabilidade e testabilidade.
+- Na etapa `niche-research-seed-builder`, o sistema deve confiar no modelo para conteúdo semântico das queries; validações determinísticas devem ficar restritas à integridade mínima persistível (estrutura, ciclo correto e campos obrigatórios de banco), sem bloquear por marcador literal de MEI/autônomo, Brasil/pt-BR, quantidade fixa, objetivo fechado, duplicidade textual, linguagem de solução ou genericidade.
 
 ## Critério de efetividade — execução modular das etapas NichoCNAE
 

--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -389,3 +389,9 @@
 - Mantida a validação obrigatória de marcador de público MEI/autônomo, a rejeição de query genérica e o bloqueio de linguagem de solução antes da persistência do seed.
 - Atualizado o teste de regressão para garantir que uma query com nicho e público MEI/autônomo continue válida mesmo sem o marcador literal Brasil/pt-BR.
 - 2026-06-10 22:30:00 (UTC): corrigida a experiência operacional da tela `/oprm/general-audiences/subniches/:id` após aprovação de subnicho: a aprovação já registrada agora fica clara para o usuário, e a próxima ação real disponível passa a ser a conversão controlada do subnicho aprovado em MarketNiche, evitando a percepção de botão travado quando o backend já gravou `APPROVED_FOR_EXPERIMENT`.
+
+## 2026-06-11 — OPRM NichoCNAE: confiança no modelo na etapa de seed e queries
+
+- Decisão operacional registrada: a etapa `niche-research-seed-builder` deve confiar no modelo para o conteúdo semântico das queries e não deve travar o ciclo por marcador literal de MEI/autônomo, Brasil/pt-BR, objetivo fechado, quantidade fixa, duplicidade textual, linguagem de solução ou genericidade.
+- Ajuste técnico: o validador do `oprm-coletor-mei`, o schema da Responses API, o preview do frontend e a validação do backend foram reduzidos ao mínimo persistível: estrutura, ciclo correto, seed obrigatório, lista não vazia de queries e campos de query exigidos pelo banco.
+- Causa-raiz tratada: falsos negativos em português natural estavam bloqueando uma etapa preparatória que deve apenas criar seed e perguntas de pesquisa para as etapas seguintes comprovarem com fontes, sinais, síntese e gate.

--- a/frontend/src/pages/oprm/OprmNicheResearchSeedBuilderDetailPage.tsx
+++ b/frontend/src/pages/oprm/OprmNicheResearchSeedBuilderDetailPage.tsx
@@ -55,22 +55,18 @@ function buildPrompt(detail: {
     `nicheName: ${safe(detail.seed?.nicheName)}`,
     "sourceScore: não disponível no detalhe persistido",
     "",
-    "Regras obrigatórias:",
-    "1. Responda somente JSON válido aderente ao schema solicitado.",
-    "2. Gere um seed que responda quem é o profissional MEI/autônomo pesquisado no Brasil.",
-    "3. Gere de 12 a 15 queries, cada uma em linha lógica própria no array queries.",
-    "4. Cada query deve conter o nicho/CNAE e marcador explícito de pessoa: MEI, autônomo, trabalhador por conta própria, profissional autônomo ou dono-operador.",
-    "5. Cada query deve conter marcador Brasil/brasileiro/pt-BR/estado/cidade ou fonte brasileira recente quando fizer sentido.",
-    "6. Cubra rotina, modo de trabalho, aquisição de clientes, atendimento, cobrança, agenda, materiais, entrega, retrabalho, dores, sonhos, medos, canais e linguagem real.",
-    "7. Não gere query genérica como 'como vender mais' e não direcione pesquisa para solução, produto, oferta, IA, automação, software, curso ou campanha.",
-    "8. Todas as queries devem sair com status PENDING e createdBy AI.",
-    "9. Use queryGoal somente entre MEI_ROUTINE_DISCOVERY, AUTONOMOUS_WORK_MODE_DISCOVERY, CUSTOMER_ACQUISITION_BEHAVIOR_DISCOVERY, DAILY_OPERATION_PAIN_DISCOVERY, EMOTIONAL_PAIN_DISCOVERY, DREAM_DISCOVERY, FEAR_DISCOVERY, CHANNEL_BEHAVIOR_DISCOVERY, LANGUAGE_DISCOVERY e SOURCE_FRESHNESS_DISCOVERY.",
-    "10. Não inclua metadado técnico, comentário operacional, debugInfo ou JSON serializado dentro de texto funcional.",
+    "Orientações operacionais:",
+    "1. Responda JSON válido aderente ao schema estrutural solicitado.",
+    "2. Gere um seed que descreva o profissional pesquisado e o contexto operacional do nicho.",
+    "3. Gere queries suficientes para orientar as próximas etapas de busca, coleta e extração de sinais.",
+    "4. Prefira linguagem natural em pt-BR e termos que ajudem a encontrar rotina, aquisição de clientes, atendimento, cobrança, agenda, materiais, entrega, retrabalho, dores, sonhos, medos, canais e linguagem real.",
+    "5. A etapa confia no modelo: não precisa forçar marcador literal em toda query quando a intenção de pesquisa estiver clara.",
+    "6. Não inclua metadado técnico, comentário operacional, debugInfo ou JSON serializado dentro de texto funcional.",
   ];
   return lines.join("\n");
 }
 
-function buildStrictSchema() {
+function buildStructuralSchema() {
   const string = { type: "string" };
   const integer = { type: "integer" };
   return {
@@ -105,17 +101,12 @@ function buildStrictSchema() {
           customerType: string,
           commercialObjects: string,
           initialAssumptions: string,
-          confidenceLevel: {
-            type: "string",
-            enum: ["INFERRED_FROM_CNAE", "LOW_CONFIDENCE", "NEEDS_RESEARCH"],
-          },
-          createdBy: { type: "string", enum: ["AI"] },
+          confidenceLevel: string,
+          createdBy: string,
         },
       },
       queries: {
         type: "array",
-        minItems: 12,
-        maxItems: 15,
         items: {
           type: "object",
           additionalProperties: false,
@@ -131,25 +122,11 @@ function buildStrictSchema() {
           properties: {
             researchCycleId: integer,
             queryText: string,
-            queryGoal: {
-              type: "string",
-              enum: [
-                "MEI_ROUTINE_DISCOVERY",
-                "AUTONOMOUS_WORK_MODE_DISCOVERY",
-                "CUSTOMER_ACQUISITION_BEHAVIOR_DISCOVERY",
-                "DAILY_OPERATION_PAIN_DISCOVERY",
-                "EMOTIONAL_PAIN_DISCOVERY",
-                "DREAM_DISCOVERY",
-                "FEAR_DISCOVERY",
-                "CHANNEL_BEHAVIOR_DISCOVERY",
-                "LANGUAGE_DISCOVERY",
-                "SOURCE_FRESHNESS_DISCOVERY",
-              ],
-            },
+            queryGoal: string,
             sourceGroup: string,
             priority: integer,
-            status: { type: "string", enum: ["PENDING"] },
-            createdBy: { type: "string", enum: ["AI"] },
+            status: string,
+            createdBy: string,
           },
         },
       },
@@ -179,7 +156,7 @@ function buildAiRequestPreview(detail: {
         format: {
           type: "json_schema",
           name: "oprm_niche_research_seed_builder",
-          schema: buildStrictSchema(),
+          schema: buildStructuralSchema(),
           strict: true,
         },
       },

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnae/nicheresearchseedbuilder/NicheResearchSeedBuilderPromptBuilder.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnae/nicheresearchseedbuilder/NicheResearchSeedBuilderPromptBuilder.java
@@ -7,7 +7,7 @@ import org.springframework.stereotype.Component;
 @Component
 public class NicheResearchSeedBuilderPromptBuilder {
 
-    /** Cria instruções objetivas para a IA transformar CNAE em seed operacional e queries não genéricas. */
+    /** Cria instruções objetivas para a IA transformar CNAE em seed operacional e queries de pesquisa. */
     public String buildPrompt(NicheResearchSeedBuilderPending input) {
         StringJoiner prompt = new StringJoiner("\n");
         prompt.add("Você é o construtor da etapa 2 do pipeline OPRM nichocnae.");
@@ -22,21 +22,13 @@ public class NicheResearchSeedBuilderPromptBuilder {
         prompt.add("nicheName: " + safe(input.nicheName()));
         prompt.add("sourceScore: " + input.sourceScore());
         prompt.add("");
-        prompt.add("Regras obrigatórias:");
-        prompt.add("1. Responda somente JSON válido aderente ao schema solicitado.");
-        prompt.add("2. Gere um seed que responda quem é o profissional MEI/autônomo pesquisado no Brasil sem transformar a pesquisa em oferta.");
-        prompt.add("3. Gere de 12 a 15 queries em português do Brasil, cada uma em linha lógica própria no array queries.");
-        prompt.add("4. Cada query deve conter o nicho ou CNAE e pelo menos um marcador explícito de pessoa pesquisada: MEI, autônomo, trabalhador por conta própria, profissional autônomo ou dono-operador.");
-        prompt.add("5. Cada query deve conter marcador Brasil/brasileiro/pt-BR/estado/cidade ou buscar fonte brasileira recente quando fizer sentido.");
-        prompt.add("6. Pesquise como o profissional consegue clientes, atende, cobra, agenda, compra materiais, entrega serviço e lida com retrabalho.");
-        prompt.add("7. Pesquise sonhos, objetivos pessoais/profissionais, medos, inseguranças, canais usados e linguagem real em pt-BR do MEI/autônomo.");
-        prompt.add("8. Não gere query genérica como 'como vender mais'.");
-        prompt.add("9. Cubra somente rotina, modo de trabalho autônomo, aquisição de clientes, dificuldades, dores operacionais, dores emocionais, sonhos, medos, canais, linguagem orgânica e atualidade de fontes.");
-        prompt.add("10. Não use termos de solução quando eles não fizerem parte literal da descrição CNAE: IA, inteligência artificial, automação, software, sistema, app, ferramenta, curso, template, produto, oferta, campanha ou landing page.");
-        prompt.add("11. Todas as queries devem sair com status PENDING e createdBy AI.");
-        prompt.add("12. Use queryGoal somente entre MEI_ROUTINE_DISCOVERY, AUTONOMOUS_WORK_MODE_DISCOVERY, CUSTOMER_ACQUISITION_BEHAVIOR_DISCOVERY, DAILY_OPERATION_PAIN_DISCOVERY, EMOTIONAL_PAIN_DISCOVERY, DREAM_DISCOVERY, FEAR_DISCOVERY, CHANNEL_BEHAVIOR_DISCOVERY, LANGUAGE_DISCOVERY e SOURCE_FRESHNESS_DISCOVERY.");
-        prompt.add("13. Priorize termos de busca que tragam fontes do Brasil: domínios .br, órgãos brasileiros, entidades setoriais brasileiras, fóruns brasileiros, notícias brasileiras e páginas em pt-BR recentes.");
-        prompt.add("14. Não inclua metadado técnico, comentário operacional, debugInfo ou JSON serializado dentro de texto funcional.");
+        prompt.add("Orientações operacionais:");
+        prompt.add("1. Responda JSON válido aderente ao schema estrutural solicitado.");
+        prompt.add("2. Gere um seed que descreva o profissional pesquisado e o contexto operacional do nicho sem transformar a pesquisa em oferta.");
+        prompt.add("3. Gere queries suficientes em português do Brasil para orientar as próximas etapas de busca, coleta e extração de sinais.");
+        prompt.add("4. Prefira frases de busca sobre clientes, atendimento, cobrança, agenda, materiais, entrega, retrabalho, sonhos, medos, inseguranças, canais usados e linguagem real.");
+        prompt.add("5. A etapa confia no modelo: não force marcador literal em toda query quando a intenção de pesquisa estiver clara.");
+        prompt.add("6. Não inclua metadado técnico, comentário operacional, debugInfo ou JSON serializado dentro de texto funcional.");
         return prompt.toString();
     }
 

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnae/nicheresearchseedbuilder/NicheResearchSeedBuilderSchema.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnae/nicheresearchseedbuilder/NicheResearchSeedBuilderSchema.java
@@ -43,8 +43,8 @@ public class NicheResearchSeedBuilderSchema {
                 Map.entry("customerType", string()),
                 Map.entry("commercialObjects", string()),
                 Map.entry("initialAssumptions", string()),
-                Map.entry("confidenceLevel", enumString("INFERRED_FROM_CNAE", "LOW_CONFIDENCE", "NEEDS_RESEARCH")),
-                Map.entry("createdBy", enumString("AI"))));
+                Map.entry("confidenceLevel", string()),
+                Map.entry("createdBy", string())));
         return schema;
     }
 
@@ -55,21 +55,11 @@ public class NicheResearchSeedBuilderSchema {
         schema.put("properties", Map.of(
                 "researchCycleId", integer(),
                 "queryText", string(),
-                "queryGoal", enumString(
-                        "MEI_ROUTINE_DISCOVERY",
-                        "AUTONOMOUS_WORK_MODE_DISCOVERY",
-                        "CUSTOMER_ACQUISITION_BEHAVIOR_DISCOVERY",
-                        "DAILY_OPERATION_PAIN_DISCOVERY",
-                        "EMOTIONAL_PAIN_DISCOVERY",
-                        "DREAM_DISCOVERY",
-                        "FEAR_DISCOVERY",
-                        "CHANNEL_BEHAVIOR_DISCOVERY",
-                        "LANGUAGE_DISCOVERY",
-                        "SOURCE_FRESHNESS_DISCOVERY"),
+                "queryGoal", string(),
                 "sourceGroup", string(),
                 "priority", integer(),
-                "status", enumString("PENDING"),
-                "createdBy", enumString("AI")));
+                "status", string(),
+                "createdBy", string()));
         return schema;
     }
 
@@ -92,13 +82,8 @@ public class NicheResearchSeedBuilderSchema {
         return Map.of("type", "integer");
     }
 
-    /** Cria um campo textual restrito aos valores permitidos pela regra da etapa dois. */
-    private Map<String, Object> enumString(String... values) {
-        return Map.of("type", "string", "enum", List.of(values));
-    }
-
-    /** Cria um array tipado para a coleção de queries geradas pela IA. */
+    /** Cria um array tipado para a coleção de queries geradas pela IA sem restringir volume. */
     private Map<String, Object> array(Map<String, Object> itemSchema) {
-        return Map.of("type", "array", "minItems", 12, "maxItems", 15, "items", itemSchema);
+        return Map.of("type", "array", "items", itemSchema);
     }
 }

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnae/nicheresearchseedbuilder/NicheResearchSeedBuilderValidator.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnae/nicheresearchseedbuilder/NicheResearchSeedBuilderValidator.java
@@ -1,52 +1,13 @@
 package com.marketinghub.nichocnae.nicheresearchseedbuilder;
 
-import java.text.Normalizer;
-import java.util.HashSet;
 import java.util.List;
-import java.util.Locale;
-import java.util.Set;
 import org.springframework.stereotype.Component;
 
-/** Valida regras determinísticas da etapa dois antes de enviar o seed e as queries ao backend. */
+/** Valida somente a integridade mínima da etapa dois antes de enviar a saída do modelo ao backend. */
 @Component
 public class NicheResearchSeedBuilderValidator {
-    private static final int MIN_QUERIES = 12;
-    private static final int MAX_QUERIES = 15;
-    private static final Set<String> ALLOWED_GOALS = Set.of(
-            "MEI_ROUTINE_DISCOVERY",
-            "AUTONOMOUS_WORK_MODE_DISCOVERY",
-            "CUSTOMER_ACQUISITION_BEHAVIOR_DISCOVERY",
-            "DAILY_OPERATION_PAIN_DISCOVERY",
-            "EMOTIONAL_PAIN_DISCOVERY",
-            "DREAM_DISCOVERY",
-            "FEAR_DISCOVERY",
-            "CHANNEL_BEHAVIOR_DISCOVERY",
-            "LANGUAGE_DISCOVERY",
-            "SOURCE_FRESHNESS_DISCOVERY");
-    private static final Set<String> SOLUTION_TERMS = Set.of(
-            "ia",
-            "inteligencia artificial",
-            "automacao",
-            "software",
-            "sistema",
-            "app",
-            "ferramenta",
-            "curso",
-            "template",
-            "produto",
-            "oferta",
-            "campanha",
-            "landing page");
-    private static final Set<String> GENERIC_QUERIES = Set.of("como vender mais", "aumentar vendas", "vender mais");
-    private static final Set<String> AUDIENCE_MARKERS = Set.of(
-            "mei",
-            "autonomo",
-            "profissional autonomo",
-            "trabalhador por conta propria",
-            "dono operador",
-            "dono-operador");
 
-    /** Garante que o modelo produziu seed completo e queries específicas, pendentes e sem contaminação de solução. */
+    /** Garante que a resposta do modelo pertence ao ciclo processado e possui estrutura persistível. */
     public void validate(NicheResearchSeedBuilderPending input, NicheResearchSeedBuilderOutput output) {
         if (output == null) {
             throw new IllegalArgumentException("Saída da etapa dois não pode ser nula.");
@@ -58,7 +19,7 @@ public class NicheResearchSeedBuilderValidator {
         validateQueries(output.seed(), output.queries());
     }
 
-    /** Valida os campos essenciais do seed que identificam o nicho operacional pesquisado. */
+    /** Confere apenas os campos mínimos do seed necessários para persistir o contrato do backend. */
     private void validateSeed(NicheResearchSeedBuilderPending input, NicheResearchSeed seed) {
         if (seed == null) {
             throw new IllegalArgumentException("Seed da etapa dois não pode ser nulo.");
@@ -72,32 +33,20 @@ public class NicheResearchSeedBuilderValidator {
         requireText(seed.customerType(), "customerType");
         requireText(seed.commercialObjects(), "commercialObjects");
         requireText(seed.initialAssumptions(), "initialAssumptions");
-        if (!"AI".equals(seed.createdBy())) {
-            throw new IllegalArgumentException("createdBy do seed deve ser AI.");
-        }
     }
 
-    /** Valida quantidade, status, objetivo, especificidade e ausência de linguagem de solução nas queries. */
+    /** Confere apenas se as queries existem e possuem campos persistíveis, sem julgar conteúdo semântico. */
     private void validateQueries(NicheResearchSeed seed, List<ResearchQuery> queries) {
-        if (queries == null || queries.size() < MIN_QUERIES || queries.size() > MAX_QUERIES) {
-            throw new IllegalArgumentException("A etapa dois deve gerar entre 12 e 15 queries.");
+        if (queries == null || queries.isEmpty()) {
+            throw new IllegalArgumentException("A etapa dois deve retornar pelo menos uma query persistível.");
         }
-
-        Set<String> uniqueTexts = new HashSet<>();
-        Set<String> anchors = buildAnchors(seed);
-        String allowedCnaeText = normalizeForTerms(seed.cnaeDescription());
         for (ResearchQuery query : queries) {
-            validateQuery(seed, query, uniqueTexts, anchors, allowedCnaeText);
+            validateQuery(seed, query);
         }
     }
 
-    /** Valida uma query individual antes de ela ser persistida como linha própria no backend. */
-    private void validateQuery(
-            NicheResearchSeed seed,
-            ResearchQuery query,
-            Set<String> uniqueTexts,
-            Set<String> anchors,
-            String allowedCnaeText) {
+    /** Valida a associação da query ao ciclo e os textos mínimos exigidos pelo banco. */
+    private void validateQuery(NicheResearchSeed seed, ResearchQuery query) {
         if (query == null) {
             throw new IllegalArgumentException("Query da etapa dois não pode ser nula.");
         }
@@ -105,124 +54,13 @@ public class NicheResearchSeedBuilderValidator {
             throw new IllegalArgumentException("researchCycleId da query não corresponde ao seed.");
         }
         requireText(query.queryText(), "queryText");
-        String normalized = normalize(query.queryText());
-        if (!uniqueTexts.add(normalized)) {
-            throw new IllegalArgumentException("Query duplicada na etapa dois: " + query.queryText());
-        }
-        rejectGenericQuery(query.queryText(), normalized);
-        if (anchors.stream().noneMatch(normalized::contains)) {
-            throw new IllegalArgumentException("Query sem nicho ou contexto operacional específico: " + query.queryText());
-        }
-        rejectSolutionTerms(query.queryText(), allowedCnaeText);
-        validateAudienceMarker(query.queryText());
-        if (!ALLOWED_GOALS.contains(query.queryGoal())) {
-            throw new IllegalArgumentException("queryGoal inválido na etapa dois: " + query.queryGoal());
-        }
-        if (!"PENDING".equals(query.status())) {
-            throw new IllegalArgumentException("Query da etapa dois deve iniciar com status PENDING.");
-        }
-        if (!"AI".equals(query.createdBy())) {
-            throw new IllegalArgumentException("Query da etapa dois deve iniciar com createdBy AI.");
-        }
+        requireText(query.queryGoal(), "queryGoal");
     }
 
-    /** Rejeita consultas genéricas que não revelam rotina, comportamento ou dor concreta do MEI/autônomo. */
-    private void rejectGenericQuery(String queryText, String normalizedQuery) {
-        if (GENERIC_QUERIES.contains(normalizedQuery)) {
-            throw new IllegalArgumentException("Query genérica proibida: " + queryText);
-        }
-    }
-
-    /** Exige marcador explícito de público MEI/autônomo na frase de busca. */
-    private void validateAudienceMarker(String queryText) {
-        String normalizedQuery = normalizeForTerms(queryText);
-        Set<String> queryTokens = tokenizeNormalizedText(normalizedQuery);
-        boolean hasAudienceMarker = AUDIENCE_MARKERS.stream()
-                .anyMatch(marker -> containsTerm(normalizedQuery, queryTokens, marker));
-        if (!hasAudienceMarker) {
-            throw new IllegalArgumentException("Query sem marcador de MEI/autônomo brasileiro: " + queryText);
-        }
-    }
-
-    /** Rejeita linguagem de solução que não aparece literalmente na descrição CNAE do ciclo. */
-    private void rejectSolutionTerms(String queryText, String allowedCnaeText) {
-        String normalizedQuery = normalizeForTerms(queryText);
-        Set<String> queryTokens = tokenizeNormalizedText(normalizedQuery);
-        for (String term : SOLUTION_TERMS) {
-            if (containsTerm(normalizedQuery, queryTokens, term) && !containsAllowedCnaeTerm(allowedCnaeText, term)) {
-                throw new IllegalArgumentException("Query com linguagem de solução proibida na etapa dois: " + queryText);
-            }
-        }
-    }
-
-    /** Verifica se a descrição CNAE contém literalmente o termo sensível e autoriza sua presença na query. */
-    private boolean containsAllowedCnaeTerm(String allowedCnaeText, String term) {
-        Set<String> allowedTokens = tokenizeNormalizedText(allowedCnaeText);
-        return containsTerm(allowedCnaeText, allowedTokens, term);
-    }
-
-    /** Tokeniza texto normalizado tolerando repetição de palavras comuns retornadas pela IA. */
-    private Set<String> tokenizeNormalizedText(String normalizedText) {
-        Set<String> tokens = new HashSet<>();
-        for (String token : normalizedText.split("[^a-z0-9]+")) {
-            if (!token.isBlank()) {
-                tokens.add(token);
-            }
-        }
-        return tokens;
-    }
-
-    /** Detecta termos simples por token e expressões compostas por ocorrência textual normalizada. */
-    private boolean containsTerm(String text, Set<String> tokens, String term) {
-        return term.matches(".*[^a-z0-9].*") ? text.contains(term) : tokens.contains(term);
-    }
-
-    /** Extrai termos âncora do nicho, descrição CNAE e objetos operacionais para bloquear queries genéricas. */
-    private Set<String> buildAnchors(NicheResearchSeed seed) {
-        Set<String> anchors = new HashSet<>();
-        addWords(anchors, seed.nicheName());
-        addWords(anchors, seed.cnaeDescription());
-        addWords(anchors, seed.businessType());
-        addWords(anchors, seed.operationType());
-        addWords(anchors, seed.customerType());
-        addWords(anchors, seed.commercialObjects());
-        return anchors;
-    }
-
-    /** Adiciona palavras relevantes como âncoras de especificidade das queries. */
-    private void addWords(Set<String> anchors, String value) {
-        if (value == null) {
-            return;
-        }
-        String normalized = normalize(value);
-        for (String rawExpression : normalized.split(",")) {
-            String expression = rawExpression.trim();
-            if (!expression.isBlank()) {
-                anchors.add(expression);
-            }
-        }
-        for (String rawWord : normalized.split("[^a-z0-9áàâãéêíóôõúç]+")) {
-            if (rawWord.length() >= 5) {
-                anchors.add(rawWord);
-            }
-        }
-    }
-
-    /** Exige texto funcional preenchido para campos obrigatórios da etapa dois. */
+    /** Exige texto funcional preenchido para campos obrigatórios de persistência da etapa dois. */
     private void requireText(String value, String fieldName) {
         if (value == null || value.isBlank()) {
             throw new IllegalArgumentException("Campo obrigatório vazio na etapa dois: " + fieldName);
         }
-    }
-
-    /** Normaliza texto para comparação simples de duplicidade e especificidade. */
-    private String normalize(String value) {
-        return value == null ? "" : value.toLowerCase(Locale.ROOT).trim().replaceAll("\\s+", " ");
-    }
-
-    /** Normaliza texto removendo acentos para comparar termos de solução com baixa ambiguidade. */
-    private String normalizeForTerms(String value) {
-        String normalized = Normalizer.normalize(normalize(value), Normalizer.Form.NFD);
-        return normalized.replaceAll("\\p{M}+", "");
     }
 }

--- a/oprm-coletor-mei/src/test/java/com/marketinghub/nichocnae/nicheresearchseedbuilder/NicheResearchSeedBuilderValidatorTest.java
+++ b/oprm-coletor-mei/src/test/java/com/marketinghub/nichocnae/nicheresearchseedbuilder/NicheResearchSeedBuilderValidatorTest.java
@@ -9,105 +9,87 @@ import java.util.ArrayList;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 
-/** Responsabilidade: validar as regras determinísticas da etapa dois antes da persistência no backend. */
+/** Responsabilidade: validar apenas a integridade mínima da etapa dois antes da persistência no backend. */
 class NicheResearchSeedBuilderValidatorTest {
     private final NicheResearchSeedBuilderValidator validator = new NicheResearchSeedBuilderValidator();
 
-    /** Deve aceitar seed completo com doze queries específicas vinculadas à rotina operacional do nicho. */
+    /** Deve aceitar seed completo com queries retornadas pelo modelo sem julgar conteúdo semântico. */
     @Test
-    void shouldAcceptSpecificPendingQueries() {
+    void shouldAcceptModelQueriesWithoutSemanticBlocking() {
         NicheResearchSeedBuilderPending pending = pending();
-        NicheResearchSeedBuilderOutput output = outputWithQueries(validQueryTexts());
+        NicheResearchSeedBuilderOutput output = outputWithQueries(modelQueryTexts());
 
         assertThatNoException().isThrownBy(() -> validator.validate(pending, output));
     }
 
-    /** Deve rejeitar query genérica porque ela não ajuda a pesquisar a rotina concreta do nicho. */
+    /** Deve aceitar query genérica porque a etapa passou a confiar no modelo e nas próximas fases do pipeline. */
     @Test
-    void shouldRejectGenericQuery() {
+    void shouldAcceptGenericQueryFromModel() {
         NicheResearchSeedBuilderPending pending = pending();
-        List<String> texts = new ArrayList<>(validQueryTexts());
+        List<String> texts = new ArrayList<>(modelQueryTexts());
         texts.set(0, "como vender mais");
         NicheResearchSeedBuilderOutput output = outputWithQueries(texts);
 
-        assertThatThrownBy(() -> validator.validate(pending, output))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("Query genérica proibida");
+        assertThatNoException().isThrownBy(() -> validator.validate(pending, output));
     }
 
-    /** Deve rejeitar query contaminada por solução quando o termo não faz parte literal do CNAE. */
+    /** Deve aceitar linguagem de solução na query porque o bloqueio semântico foi removido desta etapa. */
     @Test
-    void shouldRejectSolutionLanguageQuery() {
+    void shouldAcceptSolutionLanguageQueryFromModel() {
         NicheResearchSeedBuilderPending pending = pending();
-        List<String> texts = new ArrayList<>(validQueryTexts());
+        List<String> texts = new ArrayList<>(modelQueryTexts());
         texts.set(0, "IA para crescimento de manicure MEI no Brasil");
         NicheResearchSeedBuilderOutput output = outputWithQueries(texts);
 
-        assertThatThrownBy(() -> validator.validate(pending, output))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("linguagem de solução proibida");
+        assertThatNoException().isThrownBy(() -> validator.validate(pending, output));
     }
 
-    /** Deve rejeitar query sem marcador explícito de MEI/autônomo para não voltar a pesquisar apenas o CNAE. */
+    /** Deve aceitar query sem marcador literal de MEI/autônomo porque a etapa não bloqueia mais semântica textual. */
     @Test
-    void shouldRejectQueryWithoutAudienceMarker() {
+    void shouldAcceptQueryWithoutAudienceMarker() {
         NicheResearchSeedBuilderPending pending = pending();
-        List<String> texts = new ArrayList<>(validQueryTexts());
+        List<String> texts = new ArrayList<>(modelQueryTexts());
         texts.set(0, "manicure rotina de atendimento no Brasil");
         NicheResearchSeedBuilderOutput output = outputWithQueries(texts);
 
-        assertThatThrownBy(() -> validator.validate(pending, output))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("marcador de MEI/autônomo");
-    }
-
-    /** Deve aceitar query sem marcador literal Brasil/pt-BR quando ela mantém nicho e público MEI/autônomo. */
-    @Test
-    void shouldAcceptQueryWithoutLiteralBrazilMarker() {
-        NicheResearchSeedBuilderPending pending = pending();
-        List<String> texts = new ArrayList<>(validQueryTexts());
-        texts.set(0, "manicure MEI rotina de atendimento agenda clientes");
-        NicheResearchSeedBuilderOutput output = outputWithQueries(texts);
-
         assertThatNoException().isThrownBy(() -> validator.validate(pending, output));
     }
 
-    /** Deve aceitar palavras repetidas nas queries porque repetição de conectivos não é duplicidade operacional. */
+    /** Deve aceitar qualquer quantidade positiva de queries porque a cobertura passa a ser responsabilidade do modelo. */
     @Test
-    void shouldAcceptRepeatedCommonWordsInQueryText() {
-        NicheResearchSeedBuilderPending pending = pending();
-        List<String> texts = new ArrayList<>(validQueryTexts());
-        NicheResearchSeedBuilderOutput output = outputWithQueries(texts);
-
-        assertThatNoException().isThrownBy(() -> validator.validate(pending, output));
-    }
-
-    /** Deve rejeitar saída com menos de doze queries para manter cobertura mínima do MVP. */
-    @Test
-    void shouldRejectTooFewQueries() {
+    void shouldAcceptPositiveQueryCountFromModel() {
         NicheResearchSeedBuilderPending pending = pending();
         NicheResearchSeedBuilderOutput output = outputWithQueries(List.of("manicure rotina de atendimento"));
 
-        assertThatThrownBy(() -> validator.validate(pending, output))
-                .isInstanceOf(IllegalArgumentException.class)
-                .hasMessageContaining("entre 12 e 15 queries");
+        assertThatNoException().isThrownBy(() -> validator.validate(pending, output));
     }
 
-    /** Cria queries válidas com marcadores de MEI/autônomo e prioridade de contexto brasileiro. */
-    private List<String> validQueryTexts() {
+    /** Deve rejeitar somente ausência total de queries para evitar payload impossível de persistir operacionalmente. */
+    @Test
+    void shouldRejectEmptyQueryList() {
+        NicheResearchSeedBuilderPending pending = pending();
+        NicheResearchSeedBuilderOutput output = outputWithQueries(List.of());
+
+        assertThatThrownBy(() -> validator.validate(pending, output))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("pelo menos uma query");
+    }
+
+    /** Cria queries de exemplo com linguagem natural do modelo. */
+    private List<String> modelQueryTexts() {
         return List.of(
                 "manicure MEI rotina de atendimento no Brasil",
-                "profissional autônomo manicure responsabilidades agenda Brasil",
-                "trabalhador por conta própria unha em gel dúvidas pt-BR",
-                "MEI unha em gel quanto tempo dura Brasil",
-                "profissional autônomo manicure tarefas atendimento semanal brasileiro",
-                "MEI agenda manicure horários vazios Brasil",
-                "dono-operador salão beleza comunicação clientes whatsapp Brasil",
-                "profissional autônomo hidratação cabelo cliente pergunta brasileira",
-                "MEI cabeleireiro rotina salão pequeno Brasil",
-                "profissional autônomo pedicure biossegurança atendimento pt-BR",
-                "MEI manicure preço unha decorada Brasil",
-                "trabalhador por conta própria salão beleza recorrência clientes brasileiros");
+                "profissionais autônomos cabeleireiros enfrentam dificuldades no atendimento",
+                "cidades brasileiras comportamento de aquisição de clientes para salão pequeno",
+                "unha em gel quanto tempo dura na rotina de atendimento",
+                "tarefas semanais de manicure com agenda cheia",
+                "horários vazios na agenda de salão de beleza",
+                "comunicação com clientes pelo whatsapp em salão pequeno",
+                "hidratação cabelo cliente pergunta frequente",
+                "rotina de cabeleireiro em salão pequeno",
+                "biossegurança no atendimento de pedicure",
+                "preço de unha decorada e cobrança recorrente",
+                "recorrência de clientes em salão de bairro");
     }
 
     /** Cria uma pendência padrão equivalente ao ciclo RUNNING retornado pelo backend. */
@@ -118,37 +100,36 @@ class NicheResearchSeedBuilderValidatorTest {
                 "9602501",
                 "Cabeleireiros, manicure e pedicure",
                 "Cabeleireiros, manicure e pedicure",
-                BigDecimal.valueOf(92),
+                BigDecimal.valueOf(90),
                 "AUTO_SCORE_QUEUE",
                 "RUNNING",
-                Instant.now(),
-                Instant.now());
+                Instant.parse("2026-06-06T10:00:00Z"),
+                Instant.parse("2026-06-06T10:00:00Z"));
     }
 
-    /** Cria uma saída com seed de beleza e queries com objetivos alternados para validação. */
+    /** Monta a saída da etapa dois com as queries informadas. */
     private NicheResearchSeedBuilderOutput outputWithQueries(List<String> queryTexts) {
         NicheResearchSeed seed = new NicheResearchSeed(
                 1001L,
                 "9602501",
                 "Cabeleireiros, manicure e pedicure",
-                "Cabeleireiros, manicures e pedicures",
+                "Cabeleireiros, manicure e pedicure",
                 "serviço local de beleza",
-                "atendimento com agenda e recorrência por WhatsApp",
+                "agenda e atendimento recorrente",
                 "consumidor final recorrente",
-                "manicure, unha em gel, salão beleza, hidratação cabelo, pedicure, cabeleireiro, pacote fidelidade, agenda",
-                "O nicho depende de agenda cheia, recorrência e indicação.",
+                "manicure, pedicure, escova",
+                "depende de agenda cheia",
                 "INFERRED_FROM_CNAE",
                 "AI");
         List<ResearchQuery> queries = new ArrayList<>();
-        for (int index = 0; index < queryTexts.size(); index++) {
+        int priority = 1;
+        for (String text : queryTexts) {
             queries.add(new ResearchQuery(
                     1001L,
-                    queryTexts.get(index),
-                    index % 3 == 0
-                            ? "MEI_ROUTINE_DISCOVERY"
-                            : index % 3 == 1 ? "CUSTOMER_ACQUISITION_BEHAVIOR_DISCOVERY" : "DAILY_OPERATION_PAIN_DISCOVERY",
-                    "GENERAL_WEB",
-                    index + 1,
+                    text,
+                    "MEI_ROUTINE_DISCOVERY",
+                    "web",
+                    priority++,
                     "PENDING",
                     "AI"));
         }


### PR DESCRIPTION
### Motivation
- Remove brittle deterministic checks that caused false negatives when the model returned valid semantic content and instead trust the model for query semantics while enforcing only structural and persistence-level integrity. 
- Keep the OPRM pipeline unblockable at the seed/query creation step so downstream steps can validate signals and sources instead of the seed builder stage making content judgments. 

### Description
- Simplified backend validator and service to only enforce minimal persistence constraints (non-null seed, matching `researchCycleId`, non-empty queries and required textual fields) and removed enum/goal/quantity/duplicate/solution/audience/Brazil literal checks and normalization logic. 
- Loosened the JSON Schema and prompt in the collector (`oprm-coletor-mei`) and the frontend to accept structural output only (removed `minItems`/`maxItems`, enums and enum-based `createdBy`/`status`/`queryGoal`/`confidenceLevel` constraints and updated prompt language). 
- Updated prompt builders to instruct the model to produce structural/operational seed and search phrases while explicitly stating the stage now trusts the model for semantic intent. 
- Adjusted unit tests to reflect the relaxed constraints, added `stubSuccessfulPersistence()` helper in service tests, and updated expected behaviors in `BackendNicheResearchSeedBuilderServiceTest` and `NicheResearchSeedBuilderValidatorTest`. 
- Recorded the behavioral change in canonical docs and operational registros to document the decision and rationale. 

### Testing
- Ran unit tests for the niche seed builder backend (`BackendNicheResearchSeedBuilderServiceTest`) and the collector validator (`NicheResearchSeedBuilderValidatorTest`), and all updated tests passed. 
- Executed the module test suites that exercise prompt/schema/validator and persistence paths, and they completed successfully. 
- No automated tests failed as part of this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2a220b8ae08321b4875d76c7cee33a)