### PR TITLE
Make hypothesis pain job IDs clickable and add job detail view

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/hypothesis/pain/controller/HypothesisPainStageController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/hypothesis/pain/controller/HypothesisPainStageController.java
@@ -46,7 +46,15 @@ public class HypothesisPainStageController {
         return ResponseEntity.ok(service.listStageExecutions(nicheId, includeCompleted));
     }
 
-    /** Consulta detalhe auditável de uma execução da etapa Dor. */
+    /** Consulta detalhe auditável de uma execução da etapa Dor vinculada ao nicho. */
+    @GetMapping("/niches/{nicheId}/hypothesis-pipeline/pain/stage-executions/{idJob}")
+    public ResponseEntity<HypothesisPainExecutionDetailResponse> detailForNiche(
+            @PathVariable Long nicheId,
+            @PathVariable String idJob) {
+        return ResponseEntity.ok(service.detailForNiche(nicheId, idJob));
+    }
+
+    /** Consulta detalhe auditável de uma execução da etapa Dor para integrações internas. */
     @GetMapping("/internal/hypothesis-pipeline/pain/stage-executions/{idJob}")
     public ResponseEntity<HypothesisPainExecutionDetailResponse> detail(@PathVariable String idJob) {
         return ResponseEntity.ok(service.detail(idJob));

--- a/backend/ads-service/src/main/java/com/marketinghub/hypothesis/pain/service/HypothesisPainStageService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/hypothesis/pain/service/HypothesisPainStageService.java
@@ -76,6 +76,17 @@ public class HypothesisPainStageService {
         return executions.stream().map(this::toSummaryResponse).toList();
     }
 
+    /** Retorna o detalhe completo de auditoria de uma execução pelo jobid dentro do nicho informado. */
+    @Transactional(readOnly = true)
+    public HypothesisPainExecutionDetailResponse detailForNiche(Long marketNicheId, String idJob) {
+        HypothesisPainStageExecution execution = findExecution(idJob);
+        if (!marketNicheId.equals(execution.getMarketNicheId())) {
+            throw new EntityNotFoundException(
+                    "Hypothesis pain execution not found for marketNicheId: " + marketNicheId + " and idJob: " + idJob);
+        }
+        return toDetailResponse(execution);
+    }
+
     /** Retorna o detalhe completo de auditoria de uma execução pelo jobid. */
     @Transactional(readOnly = true)
     public HypothesisPainExecutionDetailResponse detail(String idJob) {

--- a/docs/swagger/hypothesis-pain-stage-swagger.yaml
+++ b/docs/swagger/hypothesis-pain-stage-swagger.yaml
@@ -39,6 +39,25 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/HypothesisPainExecutionSummaryResponse'
+  /api/niches/{nicheId}/hypothesis-pipeline/pain/stage-executions/{idJob}:
+    get:
+      summary: Consulta detalhe auditável de uma execução da etapa Dor para a tela de detalhe do job.
+      parameters:
+        - in: path
+          name: nicheId
+          required: true
+          schema: { type: integer, format: int64 }
+        - in: path
+          name: idJob
+          required: true
+          schema: { type: string }
+      responses:
+        '200':
+          description: Detalhe da execução retornado.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HypothesisPainExecutionDetailResponse'
   /api/internal/hypothesis-pipeline/pain/stage-executions/pending:
     get:
       summary: Lista jobs pendentes da etapa Dor para o Worker AI.
@@ -113,6 +132,31 @@ components:
         costUsd: { type: number, nullable: true }
         errorMessage: { type: string, nullable: true }
         modelResponse: { type: string, nullable: true }
+    HypothesisPainExecutionDetailResponse:
+      type: object
+      properties:
+        jobid: { type: string }
+        marketNicheId: { type: integer, format: int64 }
+        hypothesisId: { type: string, nullable: true }
+        stageCode: { type: string }
+        status: { type: string }
+        executionRequestedAt: { type: string, format: date-time }
+        processingStartedAt: { type: string, format: date-time, nullable: true }
+        completedAt: { type: string, format: date-time, nullable: true }
+        promptTemplateId: { type: string, nullable: true }
+        promptContent: { type: string, nullable: true }
+        prompt: { type: string, nullable: true }
+        promptMarkdownContent: { type: string, nullable: true }
+        schemaJson: { type: string, nullable: true }
+        openAiRequestBody: { type: string, nullable: true }
+        openAiModel: { type: string, nullable: true }
+        openAiJobId: { type: string, nullable: true }
+        modelResponse: { type: string, nullable: true }
+        errorMessage: { type: string, nullable: true }
+        errorDetail: { type: string, nullable: true }
+        inputTokens: { type: integer, nullable: true }
+        outputTokens: { type: integer, nullable: true }
+        costUsd: { type: number, nullable: true }
     RecebePromptRequest:
       type: object
       required: [prompt, schemaJson, requestBodyJson]

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -54,6 +54,7 @@ import HypothesisDetailPage from "./pages/hypothesis/HypothesisDetailPage";
 import HypothesesPage from "./pages/hypothesis/HypothesesPage";
 import HypothesisListPage from "./pages/hypothesis/HypothesisListPage";
 import NewHypothesisPage from "./pages/hypothesis/NewHypothesisPage";
+import HypothesisPainStageExecutionDetailPage from "./pages/hypothesis/HypothesisPainStageExecutionDetailPage";
 import EditHypothesisPage from "./pages/hypothesis/EditHypothesisPage";
 import AppLayout from "./app/AppLayout";
 import AnglesPage from "./pages/AnglesPage";
@@ -198,6 +199,10 @@ export default function App() {
                 <Route
                   path=":nicheId/hypotheses/new"
                   element={<NewHypothesisPage />}
+                />
+                <Route
+                  path=":nicheId/hypothesis-pipeline/pain/stage-executions/:jobId"
+                  element={<HypothesisPainStageExecutionDetailPage />}
                 />
                 <Route
                   path=":nicheId/hypotheses/:hypothesisId"

--- a/frontend/src/api/hypothesis/useHypothesisPainStageExecutionDetail.ts
+++ b/frontend/src/api/hypothesis/useHypothesisPainStageExecutionDetail.ts
@@ -1,0 +1,43 @@
+import { useQuery } from "@tanstack/react-query";
+import axios from "axios";
+
+export interface HypothesisPainStageExecutionDetail {
+  jobid: string;
+  marketNicheId: number;
+  hypothesisId?: string | null;
+  stageCode: string;
+  status: string;
+  executionRequestedAt?: string;
+  processingStartedAt?: string;
+  completedAt?: string;
+  promptTemplateId?: string;
+  promptContent?: string;
+  prompt?: string;
+  promptMarkdownContent?: string;
+  schemaJson?: string;
+  openAiRequestBody?: string;
+  openAiModel?: string;
+  openAiJobId?: string;
+  modelResponse?: string;
+  errorMessage?: string;
+  errorDetail?: string;
+  inputTokens?: number;
+  outputTokens?: number;
+  costUsd?: number;
+}
+
+export function useHypothesisPainStageExecutionDetail(
+  nicheId?: string,
+  jobId?: string,
+) {
+  return useQuery({
+    queryKey: ["hypothesis-pain-stage-execution-detail", nicheId, jobId],
+    enabled: Boolean(nicheId && jobId),
+    queryFn: async () => {
+      const { data } = await axios.get<HypothesisPainStageExecutionDetail>(
+        `/api/niches/${nicheId}/hypothesis-pipeline/pain/stage-executions/${jobId}`,
+      );
+      return data;
+    },
+  });
+}

--- a/frontend/src/pages/hypothesis/HypothesisPainStageExecutionDetailPage.tsx
+++ b/frontend/src/pages/hypothesis/HypothesisPainStageExecutionDetailPage.tsx
@@ -1,0 +1,139 @@
+import { Link, useParams } from "react-router-dom";
+import PageTitle from "../../components/PageTitle";
+import hypothesisIcon from "../../assets/icons/hypothesis-icon.svg";
+import { useHypothesisPainStageExecutionDetail } from "../../api/hypothesis/useHypothesisPainStageExecutionDetail";
+
+function formatDate(value?: string) {
+  if (!value) return "—";
+  return new Date(value).toLocaleString("pt-BR");
+}
+
+function formatCost(value?: number) {
+  return value != null ? `$${value}` : "—";
+}
+
+function AuditBlock({ title, value }: { title: string; value?: string }) {
+  if (!value) return null;
+  return (
+    <section className="card mb-3">
+      <div className="card-header fw-semibold">{title}</div>
+      <div className="card-body">
+        <pre
+          className="bg-light border rounded p-3 mb-0 small text-break"
+          style={{ whiteSpace: "pre-wrap" }}
+        >
+          {value}
+        </pre>
+      </div>
+    </section>
+  );
+}
+
+export default function HypothesisPainStageExecutionDetailPage() {
+  const { nicheId, jobId } = useParams();
+  const detailQuery = useHypothesisPainStageExecutionDetail(nicheId, jobId);
+  const detail = detailQuery.data;
+
+  return (
+    <div className="hypothesis-pain-stage-execution-detail-page">
+      <PageTitle icon={hypothesisIcon}>Detalhe do job da dor</PageTitle>
+
+      <div className="mb-3">
+        <Link
+          className="btn btn-outline-secondary"
+          to={`/niches/${nicheId}/hypotheses/new`}
+        >
+          Voltar para nova hipótese
+        </Link>
+      </div>
+
+      {detailQuery.isLoading ? (
+        <p className="text-muted">Carregando detalhe do job...</p>
+      ) : null}
+      {detailQuery.isError ? (
+        <div className="alert alert-danger">
+          Não foi possível carregar o detalhe do job.
+        </div>
+      ) : null}
+
+      {detail ? (
+        <>
+          <section className="card mb-3">
+            <div className="card-header d-flex flex-column flex-lg-row gap-2 justify-content-lg-between">
+              <div>
+                <h2 className="h5 mb-1">Job {detail.jobid}</h2>
+                <span className="badge text-bg-light">{detail.status}</span>
+              </div>
+              <div className="text-muted small text-lg-end">
+                Nicho #{detail.marketNicheId}
+                <br />
+                Etapa {detail.stageCode}
+              </div>
+            </div>
+            <div className="card-body">
+              <div className="row g-3">
+                <div className="col-md-4">
+                  <strong>Solicitado</strong>
+                  <div>{formatDate(detail.executionRequestedAt)}</div>
+                </div>
+                <div className="col-md-4">
+                  <strong>Processamento iniciado</strong>
+                  <div>{formatDate(detail.processingStartedAt)}</div>
+                </div>
+                <div className="col-md-4">
+                  <strong>Concluído</strong>
+                  <div>{formatDate(detail.completedAt)}</div>
+                </div>
+                <div className="col-md-4">
+                  <strong>Modelo</strong>
+                  <div>{detail.openAiModel ?? "—"}</div>
+                </div>
+                <div className="col-md-4">
+                  <strong>Job OpenAI</strong>
+                  <div className="text-break">{detail.openAiJobId ?? "—"}</div>
+                </div>
+                <div className="col-md-4">
+                  <strong>Custo</strong>
+                  <div>{formatCost(detail.costUsd)}</div>
+                </div>
+                <div className="col-md-4">
+                  <strong>Tokens de entrada</strong>
+                  <div>{detail.inputTokens ?? "—"}</div>
+                </div>
+                <div className="col-md-4">
+                  <strong>Tokens de saída</strong>
+                  <div>{detail.outputTokens ?? "—"}</div>
+                </div>
+                <div className="col-md-4">
+                  <strong>Template do prompt</strong>
+                  <div>{detail.promptTemplateId ?? "—"}</div>
+                </div>
+              </div>
+              {detail.errorMessage ? (
+                <div className="alert alert-danger mt-3 mb-0">
+                  {detail.errorMessage}
+                </div>
+              ) : null}
+            </div>
+          </section>
+
+          <AuditBlock
+            title="Prompt usado"
+            value={
+              detail.promptMarkdownContent ??
+              detail.prompt ??
+              detail.promptContent
+            }
+          />
+          <AuditBlock title="Schema enviado" value={detail.schemaJson} />
+          <AuditBlock title="Request OpenAI" value={detail.openAiRequestBody} />
+          <AuditBlock title="Resposta do modelo" value={detail.modelResponse} />
+          <AuditBlock
+            title="Detalhe técnico do erro"
+            value={detail.errorDetail}
+          />
+        </>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/src/pages/hypothesis/NewHypothesisPage.test.tsx
+++ b/frontend/src/pages/hypothesis/NewHypothesisPage.test.tsx
@@ -1,0 +1,60 @@
+import { render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { describe, expect, it, vi } from "vitest";
+import axios from "axios";
+import NewHypothesisPage from "./NewHypothesisPage";
+
+vi.mock("axios");
+
+function renderPage() {
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+
+  return render(
+    <QueryClientProvider client={client}>
+      <MemoryRouter initialEntries={["/niches/18/hypotheses/new"]}>
+        <Routes>
+          <Route
+            path="/niches/:nicheId/hypotheses/new"
+            element={<NewHypothesisPage />}
+          />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe("NewHypothesisPage", () => {
+  it("shows the pain job id as links to the job detail page", async () => {
+    (axios.get as any).mockResolvedValue({
+      data: [
+        {
+          jobid: "9bb83a22-3894-43bd-9752-374f84eb6a2c",
+          marketNicheId: 18,
+          stageCode: "hypothesis-pain",
+          status: "INICIADO",
+          executionRequestedAt: "2026-06-11T00:16:01Z",
+        },
+      ],
+    });
+
+    renderPage();
+
+    const links = await screen.findAllByRole("link", {
+      name: "9bb83a22-3894-43bd-9752-374f84eb6a2c",
+    });
+
+    expect(links).toHaveLength(2);
+    links.forEach((link) => {
+      expect(link).toHaveAttribute(
+        "href",
+        "/niches/18/hypothesis-pipeline/pain/stage-executions/9bb83a22-3894-43bd-9752-374f84eb6a2c",
+      );
+    });
+  });
+});

--- a/frontend/src/pages/hypothesis/NewHypothesisPage.tsx
+++ b/frontend/src/pages/hypothesis/NewHypothesisPage.tsx
@@ -141,7 +141,12 @@ export default function NewHypothesisPage() {
                 <div className="d-flex flex-column flex-md-row justify-content-between gap-2">
                   <div>
                     <strong>Status atual:</strong> {latest.status}
-                    <div className="text-muted small">Job: {latest.jobid}</div>
+                    <div className="text-muted small">
+                      Job:{" "}
+                      <Link to={`/niches/${nicheId}/hypothesis-pipeline/pain/stage-executions/${latest.jobid}`}>
+                        {latest.jobid}
+                      </Link>
+                    </div>
                   </div>
                   <div className="text-muted small text-md-end">
                     Solicitado em {formatDate(latest.executionRequestedAt)}
@@ -211,7 +216,11 @@ export default function NewHypothesisPage() {
                   <tbody>
                     {executions.map((execution) => (
                       <tr key={execution.jobid}>
-                        <td className="small text-break">{execution.jobid}</td>
+                        <td className="small text-break">
+                          <Link to={`/niches/${nicheId}/hypothesis-pipeline/pain/stage-executions/${execution.jobid}`}>
+                            {execution.jobid}
+                          </Link>
+                        </td>
                         <td>{execution.status}</td>
                         <td>{execution.openAiModel ?? "—"}</td>
                         <td>{formatDate(execution.executionRequestedAt)}</td>


### PR DESCRIPTION
### Motivation

- Improve UX by making the job identifier on the New Hypothesis screen a clickable link that opens a dedicated audit/detail view for the hypothesis "pain" job, matching behavior already present for GeraLanding jobs.

### Description

- Frontend: render the job id as a `Link` in `frontend/src/pages/hypothesis/NewHypothesisPage.tsx` for both the summary block and the executions table. 
- Frontend: add a new route and page component `HypothesisPainStageExecutionDetailPage` with API hook `useHypothesisPainStageExecutionDetail` to fetch and show prompt, schema, request and model response details. 
- Frontend: register the new route in `frontend/src/App.tsx` at `/niches/:nicheId/hypothesis-pipeline/pain/stage-executions/:jobId`. 
- Backend: expose a niche-scoped detail endpoint `GET /api/niches/{nicheId}/hypothesis-pipeline/pain/stage-executions/{idJob}` in `HypothesisPainStageController` and implement `detailForNiche` in `HypothesisPainStageService` that validates the execution belongs to the requested niche before returning the audit detail. 
- Docs: update `docs/swagger/hypothesis-pain-stage-swagger.yaml` to include the new niche-scoped detail endpoint and the detail schema. 
- Tests & formatting: add `NewHypothesisPage` unit test that asserts job ids render as links; run Prettier on changed files.

### Testing

- Frontend unit test: ran `vitest` for the new `NewHypothesisPage` test and it passed (1 test). 
- Typecheck: ran `tsc --noEmit` in the frontend and it completed with no type errors. 
- Formatting: ran `prettier --write` on modified frontend files. 
- Backend: compiled with `mvn -DskipTests compile` and executed the test suite via `mvn test`; the test run executed but the overall run produced unrelated test errors during the local run (observed failures/exceptions in lead-portal related tests and scheduler errors referencing missing test table), which appear to be infra or unrelated integration test issues rather than regressions in the new endpoints.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2a28c7891c8321a2884489510833d6)