### PR TITLE
Alinha botão 'Criar hipótese' no detalhe do nicho

### DIFF
--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -4313,3 +4313,10 @@
 - causa-raiz: o Worker AI já recebia `OPENAI_API_KEY_FILE` no compose, porém a configuração central do core OpenAI lia apenas `OPENAI_API_KEY`; quando esse valor vinha como placeholder, ele era enviado para a OpenAI em vez de buscar o arquivo seguro.
 - foi feito: o core OpenAI do Worker AI passou a resolver a chave por arquivo seguro quando a variável estiver vazia ou com placeholder e a bloquear inicialização real com `test-key` caso não exista token válido.
 - prevenção: adicionada regressão unitária para garantir fallback por arquivo seguro e bloqueio de placeholder antes de qualquer requisição real à OpenAI.
+
+## 2026-06-11 — Alinhamento do botão Criar hipótese no detalhe do nicho
+
+- solicitação: fazer o botão `Criar hipótese` da tela de detalhe do nicho desviar para a mesma tela usada pelo botão `Criar hipótese` da tela de nicho enriquecido.
+- causa-raiz: o detalhe do nicho ainda abria o formulário manual embutido, enquanto o nicho enriquecido já apontava para o fluxo novo `/niches/:id/hypotheses/new` da construção auditável da hipótese.
+- foi feito: o botão principal do detalhe do nicho passou a ser um link para `/niches/:id/hypotheses/new`, mantendo a criação manual separada na seção própria da página.
+- impacto esperado: o usuário entra no mesmo fluxo de construção da hipótese a partir de qualquer origem, reduzindo desvio operacional e mantendo a etapa Dor como primeiro passo padrão.

--- a/frontend/src/__tests__/NicheFlow.test.tsx
+++ b/frontend/src/__tests__/NicheFlow.test.tsx
@@ -86,16 +86,19 @@ describe("niche navigation", () => {
       </QueryClientProvider>,
     );
 
+    const user = userEvent.setup();
     await screen.findByText("Fitness");
-    userEvent.click(screen.getByText("Fitness"));
+    await user.click(screen.getByText("Fitness"));
     await screen.findByText("Ver detalhes");
     await screen.findByText(/Entrega:/);
-    await screen.findByRole("button", { name: /^criar hipótese$/i });
+    expect(
+      await screen.findByRole("link", { name: /^criar hipótese$/i }),
+    ).toHaveAttribute("href", "/niches/1/hypotheses/new");
     await screen.findByRole("button", { name: /salvar em markdown/i });
-    userEvent.click(screen.getByText("Ver detalhes"));
+    await user.click(screen.getByText("Ver detalhes"));
     await screen.findByText("Criar Experimento");
-    userEvent.click(screen.getByText("Abrir"));
-    expect(await screen.findByText("Exp 1")).toBeTruthy();
+    await user.click(screen.getByText("Abrir"));
+    expect(await screen.findAllByText("Exp 1")).not.toHaveLength(0);
     const bc = screen.getByRole("navigation", { name: /breadcrumb/i });
     expect(bc).toBeTruthy();
     expect(within(bc).getByText("Fitness")).toBeTruthy();

--- a/frontend/src/pages/niche/NicheDetailPage.tsx
+++ b/frontend/src/pages/niche/NicheDetailPage.tsx
@@ -959,14 +959,13 @@ export default function NicheDetailPage() {
           </div>
         </div>
         <div className="niche-detail__actions">
-          <button
-            type="button"
+          <Link
             className="btn btn-primary niche-detail__action-btn"
-            onClick={handleOpenManualHypothesisForm}
+            to={`/niches/${normalizedNicheId}/hypotheses/new`}
           >
             <Plus size={18} />
             <span>Criar hipótese</span>
-          </button>
+          </Link>
           <button
             type="button"
             className="btn btn-outline-secondary niche-detail__action-btn"


### PR DESCRIPTION
### Motivation
- Unificar a navegação para criação de hipóteses para que o botão principal do detalhe do nicho leve ao mesmo fluxo auditável usado pelo nicho enriquecido, reduzindo desvios operacionais e fricção do usuário.

### Description
- Substituído o botão que abria o formulário manual embutido por um `Link` apontando para `
/niches/${normalizedNicheId}/hypotheses/new` em `frontend/src/pages/niche/NicheDetailPage.tsx`.
- Atualizado o teste de fluxo `frontend/src/__tests__/NicheFlow.test.tsx` para validar que `Criar hipótese` é um `link` com `href` igual a `/niches/1/hypotheses/new` e para usar `userEvent.setup()` nas interações de usuário.
- Ajustada a asserção que valida abertura do experimento para usar `findAllByText("Exp 1")` (evita falso-positivo quando o texto aparece em mais de um lugar na página).
- Registrada a tarefa e a justificativa no log `docs/registros/experimentos.md` sob entrada `2026-06-11 — Alinhamento do botão Criar hipótese no detalhe do nicho`.

### Testing
- Executado `npm test -- --run --testTimeout 30000 src/__tests__/NicheFlow.test.tsx src/pages/oprm/OprmEnrichedNicheDetailPage.test.tsx` e ambos os testes passaram.
- Executado `npm run typecheck` (`tsc --noEmit`) sem erros.
- As mudanças foram validadas localmente com asserções automatizadas atualizadas e não alteram a existência do formulário manual que permanece disponível na seção apropriada da página.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2a276333248321bc6b3fffa510ab81)