### PR TITLE
Melhora visualização JSON no detalhe de execução de 'dor'

### DIFF
--- a/frontend/src/pages/hypothesis/HypothesisPainStageExecutionDetailPage.tsx
+++ b/frontend/src/pages/hypothesis/HypothesisPainStageExecutionDetailPage.tsx
@@ -2,6 +2,7 @@ import { Link, useParams } from "react-router-dom";
 import PageTitle from "../../components/PageTitle";
 import hypothesisIcon from "../../assets/icons/hypothesis-icon.svg";
 import { useHypothesisPainStageExecutionDetail } from "../../api/hypothesis/useHypothesisPainStageExecutionDetail";
+import CollapsibleJsonViewer from "../../components/CollapsibleJsonViewer";
 
 function formatDate(value?: string) {
   if (!value) return "—";
@@ -18,12 +19,7 @@ function AuditBlock({ title, value }: { title: string; value?: string }) {
     <section className="card mb-3">
       <div className="card-header fw-semibold">{title}</div>
       <div className="card-body">
-        <pre
-          className="bg-light border rounded p-3 mb-0 small text-break"
-          style={{ whiteSpace: "pre-wrap" }}
-        >
-          {value}
-        </pre>
+        <CollapsibleJsonViewer content={value} />
       </div>
     </section>
   );


### PR DESCRIPTION
### Motivation
- Reutilizar o mesmo visualizador colapsável de JSON usado no detalhe de `geralanding` para facilitar a inspeção interativa de campos que podem conter JSON no detalhe do job da dor.

### Description
- Substitui o bloco `<pre>` pelo componente `CollapsibleJsonViewer` em `frontend/src/pages/hypothesis/HypothesisPainStageExecutionDetailPage.tsx` para exibir conteúdos como prompt, schema, request e resposta do modelo com suporte a expansão/colapso e fallback legível.

### Testing
- Rodei `npm run typecheck` e não foram reportados erros de compilação TypeScript; o comando retornou com sucesso.
- Levantei o frontend (`npm run dev`) e capturei uma página com Playwright usando um mock da API para validar visualmente a renderização interativa; a captura foi gravada em `/tmp/hypothesis-json-viewer-mocked.png` com sucesso.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2a327f39ac83218ff69be7b4c03359)