### PR TITLE
Reorienta Etapa 3 para "Investigação de Sucesso do Produto" — adiciona producerName, novas queries, heurísticas e UI/docs

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/dto/MoisSalesLibraryDtos.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/dto/MoisSalesLibraryDtos.java
@@ -723,6 +723,7 @@ public final class MoisSalesLibraryDtos {
             String workspaceId,
             String urlCanonical,
             String title,
+            String producerName,
             String offerSummary,
             String mechanismSummary,
             String promiseSummary,

--- a/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesPageMarketWarmupScoreEngine.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesPageMarketWarmupScoreEngine.java
@@ -292,11 +292,11 @@ class MoisSalesPageMarketWarmupScoreEngine {
      */
     private String recommendationText(MarketWarmupRecommendation recommendation) {
         return switch (recommendation) {
-            case PRIORITIZE -> "Priorizar experimento comercial com este mercado.";
-            case OBSERVE -> "Observar e refinar o ângulo antes de escalar.";
-            case RESEARCH_MORE -> "Pesquisar mais fontes antes de criar oferta.";
-            case DISCARD -> "Descartar ou deixar em baixa prioridade.";
-            case SATURATED_REQUIRES_ANGLE -> "Avançar somente com ângulo claramente diferenciado.";
+            case PRIORITIZE -> "Produto com máquina de venda forte para estudar e usar como referência.";
+            case OBSERVE -> "Estudar com refinamento a autoridade, os canais e a prova antes de usar como referência.";
+            case RESEARCH_MORE -> "Pesquisar mais fontes para explicar canal, autoridade, funil e prova social.";
+            case DISCARD -> "Pouca evidência pública para explicar o sucesso; deixar em baixa prioridade até achar o canal real.";
+            case SATURATED_REQUIRES_ANGLE -> "Estudar com cautela: máquina possivelmente saturada ou dependente de ângulo muito específico.";
         };
     }
 
@@ -306,11 +306,11 @@ class MoisSalesPageMarketWarmupScoreEngine {
     private String experimentSuggestion(MarketWarmupRecommendation recommendation, MarketWarmupEcosystemType ecosystemType) {
         String ecosystem = ecosystemType.name().toLowerCase(Locale.ROOT).replace('_', ' ');
         return switch (recommendation) {
-            case PRIORITIZE -> "Criar experimento inicial apoiado no ecossistema " + ecosystem + ".";
-            case OBSERVE -> "Validar novo ângulo com mais sinais do ecossistema " + ecosystem + ".";
-            case RESEARCH_MORE -> "Coletar fontes adicionais antes do experimento.";
-            case DISCARD -> "Não criar experimento neste momento.";
-            case SATURATED_REQUIRES_ANGLE -> "Buscar promessa e mecanismo menos comoditizados antes de vender.";
+            case PRIORITIZE -> "Mapear detalhadamente a máquina de venda apoiada no ecossistema " + ecosystem + ".";
+            case OBSERVE -> "Confirmar autoridade, canal e prova social com mais sinais do ecossistema " + ecosystem + ".";
+            case RESEARCH_MORE -> "Coletar fontes adicionais antes de concluir como o produto vende.";
+            case DISCARD -> "Não concluir engenharia de sucesso neste momento; faltam evidências públicas.";
+            case SATURATED_REQUIRES_ANGLE -> "Buscar diferencial claro antes de usar este produto como referência.";
         };
     }
 

--- a/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesPageMarketWarmupService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesPageMarketWarmupService.java
@@ -119,7 +119,7 @@ public class MoisSalesPageMarketWarmupService {
             log.info("Job de aquecimento MOIS reservado. modulo=MOIS, operacao=claimMarketWarmupJob, workspaceId={}, workerId={}, pageId={}, jobId={}",
                     request.workspaceId(), request.workerId(), page.pageId(), pending.job().jobId());
             return new MoisSalesLibraryDtos.MarketWarmupClaimResponse(true, new MoisSalesLibraryDtos.MarketWarmupClaimedJob(
-                    pending.job().jobId(), page.pageId(), page.workspaceId(), page.urlCanonical(), page.title(), page.offerSummary(),
+                    pending.job().jobId(), page.pageId(), page.workspaceId(), page.urlCanonical(), page.title(), page.producerName(), page.offerSummary(),
                     page.mechanismSummary(), page.promiseSummary(), page.proofSummary()));
         } catch (RuntimeException ex) {
             log.error("Falha ao reservar job de aquecimento MOIS. modulo=MOIS, operacao=claimMarketWarmupJob, workspaceId={}, workerId={}, erroClasse={}, erro={}",

--- a/backend/ads-service/src/main/java/com/marketinghub/pipeline/definition/PipelineDefinitionRegistry.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/pipeline/definition/PipelineDefinitionRegistry.java
@@ -332,7 +332,7 @@ public class PipelineDefinitionRegistry {
                 moisSalesPageLibraryStage(
                         "MARKET_WARMUP_RESEARCH",
                         "market-warmup-research",
-                        "Pesquisa de Aquecimento e Ecossistema de Mercado",
+                        "Investigação de Sucesso do Produto",
                         3,
                         true,
                         MOIS_MARKET_WARMUP_WORKER_MODULE,
@@ -343,7 +343,9 @@ public class PipelineDefinitionRegistry {
                                 "warmup-research",
                                 "ecosystem-research",
                                 "aquecimento-mercado",
-                                "pesquisa-aquecimento")));
+                                "pesquisa-aquecimento",
+                                "product-success-research",
+                                "investigacao-sucesso-produto")));
         return new PipelineDefinition(
                 MOIS_MODULE,
                 MOIS_SALES_PAGE_LIBRARY_PIPELINE_CODE,

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/mois/bibliotecapaginavenda/worker/v1/MoisSalesPageMarketWarmupGateway.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/mois/bibliotecapaginavenda/worker/v1/MoisSalesPageMarketWarmupGateway.java
@@ -103,6 +103,7 @@ public interface MoisSalesPageMarketWarmupGateway {
             String workspaceId,
             String urlCanonical,
             String title,
+            String producerName,
             String offerSummary,
             String mechanismSummary,
             String promiseSummary,

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/mois/bibliotecapaginavenda/worker/v1/MoisSalesPageMarketWarmupRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/mois/bibliotecapaginavenda/worker/v1/MoisSalesPageMarketWarmupRepository.java
@@ -29,9 +29,11 @@ public class MoisSalesPageMarketWarmupRepository implements MoisSalesPageMarketW
     @Override
     public Optional<SalesPageWarmupData> findSalesPage(long pageId) {
         List<SalesPageWarmupData> rows = jdbcTemplate.query("""
-                SELECT id, workspace_id, url_canonical, title, offer_summary, mechanism_summary, promise_summary, proof_summary
-                FROM mois_sales_page
-                WHERE id = ?
+                SELECT sp.id, sp.workspace_id, sp.url_canonical, sp.title, cr.producer_name,
+                       sp.offer_summary, sp.mechanism_summary, sp.promise_summary, sp.proof_summary
+                FROM mois_sales_page sp
+                LEFT JOIN mois_collected_reference cr ON cr.id = sp.collected_reference_id
+                WHERE sp.id = ?
                 LIMIT 1
                 """, this::mapSalesPage, pageId);
         return rows.stream().findFirst();
@@ -96,9 +98,10 @@ public class MoisSalesPageMarketWarmupRepository implements MoisSalesPageMarketW
     public Optional<MarketWarmupClaimData> findNextPendingJob(String workspaceId) {
         List<MarketWarmupClaimData> rows = jdbcTemplate.query("""
                 SELECT j.id AS job_id, j.sales_page_id, j.workspace_id, j.status, j.created_at, j.error_category, j.error_message,
-                       sp.url_canonical, sp.title, sp.offer_summary, sp.mechanism_summary, sp.promise_summary, sp.proof_summary
+                       sp.url_canonical, sp.title, cr.producer_name, sp.offer_summary, sp.mechanism_summary, sp.promise_summary, sp.proof_summary
                 FROM mois_sales_page_market_warmup_job j
                 JOIN mois_sales_page sp ON sp.id = j.sales_page_id
+                LEFT JOIN mois_collected_reference cr ON cr.id = sp.collected_reference_id
                 WHERE j.workspace_id = ? AND j.status = 'PENDING'
                 ORDER BY j.created_at ASC, j.id ASC
                 LIMIT 1
@@ -308,7 +311,7 @@ public class MoisSalesPageMarketWarmupRepository implements MoisSalesPageMarketW
      */
     private SalesPageWarmupData mapSalesPage(ResultSet rs, int rowNum) throws SQLException {
         return new SalesPageWarmupData(rs.getLong("id"), rs.getString("workspace_id"), rs.getString("url_canonical"), rs.getString("title"),
-                rs.getString("offer_summary"), rs.getString("mechanism_summary"), rs.getString("promise_summary"), rs.getString("proof_summary"));
+                rs.getString("producer_name"), rs.getString("offer_summary"), rs.getString("mechanism_summary"), rs.getString("promise_summary"), rs.getString("proof_summary"));
     }
 
     /**
@@ -328,7 +331,7 @@ public class MoisSalesPageMarketWarmupRepository implements MoisSalesPageMarketW
                 rs.getString("status"), toInstant(rs.getTimestamp("created_at")),
                 rs.getString("error_category"), rs.getString("error_message"));
         SalesPageWarmupData page = new SalesPageWarmupData(rs.getLong("sales_page_id"), rs.getString("workspace_id"), rs.getString("url_canonical"),
-                rs.getString("title"), rs.getString("offer_summary"), rs.getString("mechanism_summary"), rs.getString("promise_summary"), rs.getString("proof_summary"));
+                rs.getString("title"), rs.getString("producer_name"), rs.getString("offer_summary"), rs.getString("mechanism_summary"), rs.getString("promise_summary"), rs.getString("proof_summary"));
         return new MarketWarmupClaimData(job, page);
     }
 

--- a/backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesPageMarketWarmupServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesPageMarketWarmupServiceTest.java
@@ -304,6 +304,7 @@ class MoisSalesPageMarketWarmupServiceTest {
                 "workspace-001",
                 "https://example.test/oferta",
                 "Oferta principal",
+                "Produtor Especialista",
                 "Oferta transforma dor em resultado",
                 "Mecanismo plausível",
                 "Promessa clara",

--- a/backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/web/MoisSalesLibraryControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/web/MoisSalesLibraryControllerTest.java
@@ -387,6 +387,7 @@ class MoisSalesLibraryControllerTest {
                                 "workspace-001",
                                 "https://example.test/oferta",
                                 "Oferta principal",
+                                "Produtor Especialista",
                                 "Oferta transforma dor em resultado",
                                 "Mecanismo plausível",
                                 "Promessa clara",

--- a/docs/canonical/mois-worker-canon.v1.md
+++ b/docs/canonical/mois-worker-canon.v1.md
@@ -587,13 +587,14 @@ A definição oficial do pipeline `mois-sales-page-library-pipeline` passa a ter
 |---:|---|---|---|---|---|---|---|
 | 1 | `HTML_ACQUISITION` | `html-acquisition` | Obtenção de HTML | Capturar HTML bruto útil da página de venda e preservar evidência operacional para análise posterior. | `mois-sales-library-worker` | Não | `html-capture`, `page-snapshot`, `capture`, `obtencao-html` |
 | 2 | `COMMERCIAL_PAGE_ANALYSIS` | `commercial-page-analysis` | Análise Comercial da Página | Usar o HTML capturado para extrair diagnóstico comercial da página, incluindo dor, promessa, mecanismo, prova, público, categoria e score. | `mois-sales-library-worker` | Sim | `page-analysis`, `analysis`, `commercial-analysis`, `analise-comercial` |
-| 3 | `MARKET_WARMUP_RESEARCH` | `market-warmup-research` | Pesquisa de Aquecimento e Ecossistema de Mercado | Pesquisar fontes públicas rastreáveis para medir se existe ecossistema ativo preparando o mercado para comprar solução parecida, separando presença do produto específico de sinais do mercado/dor. | `mois-market-warmup-worker` | Sim | `market-warmup`, `warmup-research`, `ecosystem-research`, `aquecimento-mercado`, `pesquisa-aquecimento` |
+| 3 | `MARKET_WARMUP_RESEARCH` | `market-warmup-research` | Investigação de Sucesso do Produto | Pesquisar fontes públicas rastreáveis para explicar como um produto aparentemente vencedor vende: autoridade por trás, canais de aquisição, funil, prova social, distribuição por afiliados/marketplace e riscos comerciais. | `mois-market-warmup-worker` | Sim | `market-warmup`, `warmup-research`, `ecosystem-research`, `aquecimento-mercado`, `pesquisa-aquecimento`, `product-success-research`, `investigacao-sucesso-produto` |
 
 Regras canônicas da Etapa 3:
 
 1. A Etapa 3 só pode iniciar para página com a Etapa 2 concluída, pois deve usar dor, promessa, mecanismo, prova, público e categoria já identificados na análise comercial.
-2. O backend principal continua sendo o único módulo com acesso ao banco; o worker de aquecimento deve conversar somente com endpoints do backend MOIS.
+2. O backend principal continua sendo o único módulo com acesso ao banco; o worker de investigação deve conversar somente com endpoints do backend MOIS.
 3. Toda conclusão da Etapa 3 deve ser explicável por fontes públicas rastreáveis e sinais persistidos, evitando opinião sem evidência.
-4. O score da Etapa 3 é o `Market Warm-up Score` de 0 a 100, classificado inicialmente como `Quente`, `Promissor`, `Morno`, `Frio` ou `Saturado` quando houver risco alto de saturação.
-5. A etapa deve preservar o eixo comercial `Dor → Resultado → Mecanismo → Prova → Oferta` e apoiar a decisão de priorizar, pesquisar mais, observar, descartar ou avançar apenas com ângulo diferenciado.
-6. O artefato final exibido ao usuário não pode conter marcador técnico, campo de debug ou JSON serializado dentro de texto funcional.
+4. O score da Etapa 3 passa a representar a força da **engenharia pública de sucesso do produto** em escala de 0 a 100, classificada como `Quente`, `Promissor`, `Morno`, `Frio` ou `Saturado` quando houver risco alto de saturação/desconfiança.
+5. A etapa deve preservar o eixo comercial `Dor → Resultado → Mecanismo → Prova → Oferta`, mas a decisão principal passa a ser explicar **como o produtor chegou ao sucesso**: marca pessoal, influenciador, canal de conteúdo, comunidade, aula/live, WhatsApp, afiliados, marketplace, prova social e checkout.
+6. As buscas públicas da Etapa 3 devem priorizar título do produto combinado com produtor/marca/autoridade para evitar resultados genéricos por palavras isoladas do nome do produto.
+7. O artefato final exibido ao usuário não pode conter marcador técnico, campo de debug ou JSON serializado dentro de texto funcional.

--- a/docs/registros/mois1.md
+++ b/docs/registros/mois1.md
@@ -1400,3 +1400,22 @@ Arquivos principais:
 Arquivos principais:
 - `mois-sales-library-worker/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/marketwarmup/DuckDuckGoPublicWebSearchClient.java`
 - `mois-sales-library-worker/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/marketwarmup/DuckDuckGoPublicWebSearchClientTest.java`
+
+## 2026-06-11 — Reorientação da Etapa 3 para engenharia de sucesso do produto
+
+- Atualizada a regra canônica da **Etapa 3** da Biblioteca de Páginas de Vendas: o objetivo deixa de ser apenas medir aquecimento genérico de mercado e passa a ser explicar **como um produto aparentemente vencedor conseguiu vender**.
+- A investigação agora deve buscar evidências de autoridade, produtor/marca, influenciador, canais de aquisição, aula/live, WhatsApp, comunidade, afiliados, marketplace, prova social e riscos comerciais.
+- Ajustados os textos da UI para apresentar o bloco como **Engenharia de Sucesso do Produto**, com foco em hipótese de venda, canais encontrados, alavancas de sucesso e próxima investigação.
+- Ajustado o worker para incluir o produtor/marca no payload de claim e montar buscas públicas mais específicas, reduzindo resultados genéricos por palavras isoladas do nome do produto.
+
+Arquivos principais:
+- `docs/canonical/mois-worker-canon.v1.md`
+- `docs/swagger/mois-sales-library-swagger.yaml`
+- `frontend/src/pages/mois/MoisSalesPageLibraryDetailPage.tsx`
+- `frontend/src/pages/mois/MoisSalesPagesLibraryPage.tsx`
+- `frontend/src/pages/mois/MoisSalesPagesPipelinePage.tsx`
+- `backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/dto/MoisSalesLibraryDtos.java`
+- `backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesPageMarketWarmupService.java`
+- `backend/ads-service/src/main/java/com/marketinghub/repository/jpa/mois/bibliotecapaginavenda/worker/v1/MoisSalesPageMarketWarmupRepository.java`
+- `mois-sales-library-worker/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/marketwarmup/MarketWarmupQueryBuilder.java`
+- `mois-sales-library-worker/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/marketwarmup/MarketWarmupProcessor.java`

--- a/docs/swagger/mois-sales-library-swagger.yaml
+++ b/docs/swagger/mois-sales-library-swagger.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.3
 info:
   title: Marketing Hub - MOIS Sales Library
   version: 0.7.0
-  description: Contratos operacionais da Biblioteca de Páginas de Vendas do MOIS. Na Fase 6, ingestão, captura HTML e análise usam `mois_sales_page` e `mois_sales_page_job_execution` como fonte de verdade operacional atual; tabelas legadas ficam congeladas em somente leitura para auditoria/backfill histórico e não alimentam a UI principal. A Etapa 3 (`MARKET_WARMUP_RESEARCH`) possui contrato HTTP completo para solicitação, consulta, auditoria de fontes/sinais e integração interna do worker, incluindo respostas de erro padronizadas.
+  description: Contratos operacionais da Biblioteca de Páginas de Vendas do MOIS. Na Fase 6, ingestão, captura HTML e análise usam `mois_sales_page` e `mois_sales_page_job_execution` como fonte de verdade operacional atual; tabelas legadas ficam congeladas em somente leitura para auditoria/backfill histórico e não alimentam a UI principal. A Etapa 3 (`MARKET_WARMUP_RESEARCH`) possui contrato HTTP completo para investigação de sucesso do produto, consulta, auditoria de fontes/sinais e integração interna do worker, incluindo respostas de erro padronizadas.
 servers:
   - url: /api/mois/sales-library
 paths:
@@ -392,14 +392,14 @@ paths:
                 $ref: '#/components/schemas/SalesLibrarySnapshotCaptureResponse'
   /pages/{pageId}/market-warmup:request:
     post:
-      summary: Solicita pesquisa de aquecimento de mercado para uma página
-      description: Cria ou reutiliza um job pendente da Etapa 3 para uma página de venda já existente. A execução apenas agenda a pesquisa; o worker interno processa posteriormente via endpoints de claim e conclusão.
+      summary: Solicita investigação de sucesso do produto para uma página
+      description: Cria ou reutiliza um job pendente da Etapa 3 para uma página de venda já existente. A execução agenda a investigação de autoridade, canais, funil, prova social e distribuição que podem explicar o sucesso do produto.
       tags: [MOIS Sales Library]
       parameters:
         - $ref: '#/components/parameters/PageId'
       responses:
         '202':
-          description: Pesquisa de aquecimento solicitada
+          description: Investigação de sucesso solicitada
           content:
             application/json:
               schema:
@@ -412,14 +412,14 @@ paths:
           $ref: '#/components/responses/MarketWarmupConflict'
   /pages/{pageId}/market-warmup:
     get:
-      summary: Consulta o resumo da pesquisa de aquecimento da página
-      description: Retorna o dossiê final da Etapa 3 com score, temperatura, tipo de ecossistema e recomendação objetiva, sem JSON serializado em campos textuais.
+      summary: Consulta o dossiê de sucesso do produto da página
+      description: Retorna o dossiê final da Etapa 3 com score, força da máquina de venda, motor provável, hipótese de sucesso e próxima investigação, sem JSON serializado em campos textuais.
       tags: [MOIS Sales Library]
       parameters:
         - $ref: '#/components/parameters/PageId'
       responses:
         '200':
-          description: Resumo de aquecimento encontrado
+          description: Dossiê de sucesso encontrado
           content:
             application/json:
               schema:
@@ -428,14 +428,14 @@ paths:
           $ref: '#/components/responses/MarketWarmupNotFound'
   /pages/{pageId}/market-warmup/sources:
     get:
-      summary: Lista fontes públicas da pesquisa de aquecimento
-      description: Retorna fontes rastreáveis usadas para sustentar o score e a recomendação da Etapa 3.
+      summary: Lista fontes públicas da investigação de sucesso
+      description: Retorna fontes rastreáveis usadas para explicar autoridade, canais, funil, prova social, distribuição e score da Etapa 3.
       tags: [MOIS Sales Library]
       parameters:
         - $ref: '#/components/parameters/PageId'
       responses:
         '200':
-          description: Fontes públicas da pesquisa
+          description: Fontes públicas da investigação
           content:
             application/json:
               schema:
@@ -444,14 +444,14 @@ paths:
           $ref: '#/components/responses/MarketWarmupNotFound'
   /pages/{pageId}/market-warmup/signals:
     get:
-      summary: Lista sinais comerciais da pesquisa de aquecimento
-      description: Retorna os sinais extraídos das fontes públicas para explicar o score da Etapa 3.
+      summary: Lista sinais que explicam a venda do produto
+      description: Retorna os sinais extraídos das fontes públicas para explicar como o produto vendeu ou ganhou tração.
       tags: [MOIS Sales Library]
       parameters:
         - $ref: '#/components/parameters/PageId'
       responses:
         '200':
-          description: Sinais comerciais da pesquisa
+          description: Sinais da investigação de sucesso
           content:
             application/json:
               schema:
@@ -887,6 +887,10 @@ components:
         title:
           type: string
           nullable: true
+        producerName:
+          type: string
+          nullable: true
+          description: Nome do produtor, marca ou autoridade coletada na origem, usado para evitar buscas genéricas e mapear a máquina de venda.
         offerSummary:
           type: string
           nullable: true
@@ -1340,6 +1344,10 @@ components:
         scoreTotal:
           type: number
           nullable: true
+        producerName:
+          type: string
+          nullable: true
+          description: Nome do produtor, marca ou autoridade coletada na origem, usado para evitar buscas genéricas e mapear a máquina de venda.
         offerSummary:
           type: string
           nullable: true

--- a/frontend/src/pages/mois/MoisSalesPageLibraryDetailPage.tsx
+++ b/frontend/src/pages/mois/MoisSalesPageLibraryDetailPage.tsx
@@ -41,11 +41,11 @@ const ecosystemLabels: Record<MoisMarketWarmupEcosystemType, string> = {
 };
 
 const recommendationLabels: Record<MoisMarketWarmupRecommendation, string> = {
-  PRIORITIZE: "Priorizar experimento",
-  OBSERVE: "Observar com refinamento",
-  RESEARCH_MORE: "Pesquisar mais",
-  DISCARD: "Descartar por baixa prioridade",
-  SATURATED_REQUIRES_ANGLE: "Avançar só com ângulo diferenciado",
+  PRIORITIZE: "Máquina forte para estudar",
+  OBSERVE: "Estudar com refinamento",
+  RESEARCH_MORE: "Pesquisar mais evidências",
+  DISCARD: "Pouca evidência pública",
+  SATURATED_REQUIRES_ANGLE: "Sucesso exige ângulo diferenciado",
 };
 
 const statusLabels: Record<MoisMarketWarmupJobStatus, string> = {
@@ -394,10 +394,11 @@ export default function MoisSalesPageLibraryDetailPage() {
         <div className="card-body d-flex flex-column gap-3">
           <div className="d-flex flex-wrap justify-content-between align-items-start gap-3">
             <div>
-              <h2 className="h5 mb-1">Aquecimento do Mercado</h2>
+              <h2 className="h5 mb-1">Engenharia de Sucesso do Produto</h2>
               <p className="text-secondary mb-0">
-                Dossiê da Etapa 3 para decidir se existe conversa ativa, dor
-                clara e evidência suficiente para priorizar este mercado.
+                Dossiê da Etapa 3 para descobrir como este produto aparentemente
+                vencedor vende: autoridade, canais, funil, prova social e
+                distribuição.
               </p>
             </div>
             {!warmupQuery.data && !requestedWarmupJob ? (
@@ -418,24 +419,24 @@ export default function MoisSalesPageLibraryDetailPage() {
                     aria-hidden="true"
                   />
                 ) : null}
-                Executar pesquisa de aquecimento
+                Investigar sucesso do produto
               </button>
             ) : null}
           </div>
 
           {warmupQuery.isLoading ? (
             <p className="text-secondary mb-0">
-              Carregando aquecimento do mercado...
+              Carregando engenharia de sucesso...
             </p>
           ) : null}
           {warmupQuery.isError ? (
             <div className="alert alert-danger mb-0">
-              Falha ao carregar o dossiê de aquecimento.
+              Falha ao carregar o dossiê de sucesso.
             </div>
           ) : null}
           {requestWarmupMutation.isError ? (
             <div className="alert alert-danger mb-0">
-              Falha ao solicitar nova pesquisa de aquecimento.
+              Falha ao solicitar nova investigação de sucesso.
             </div>
           ) : null}
           {requestedWarmupJob ? (
@@ -449,9 +450,9 @@ export default function MoisSalesPageLibraryDetailPage() {
           !warmupQuery.data &&
           !requestedWarmupJob ? (
             <div className="alert alert-info mb-0">
-              Ainda não existe dossiê de aquecimento para esta página. Solicite
-              a pesquisa para medir temperatura, canais, dores e sinais de
-              compra do mercado.
+              Ainda não existe dossiê de sucesso para esta página. Solicite a
+              investigação para mapear autoridade, canais, funil, prova social e
+              distribuição que podem explicar as vendas do produto.
             </div>
           ) : null}
 
@@ -468,7 +469,7 @@ export default function MoisSalesPageLibraryDetailPage() {
                 </div>
                 <div className="col-md-3">
                   <div className="border rounded p-3 h-100 bg-light-subtle">
-                    <div className="text-secondary small">Temperatura</div>
+                    <div className="text-secondary small">Força da máquina</div>
                     <span
                       className={`badge ${getTemperatureBadgeClass(warmupQuery.data.marketTemperature)}`}
                     >
@@ -478,7 +479,7 @@ export default function MoisSalesPageLibraryDetailPage() {
                 </div>
                 <div className="col-md-3">
                   <div className="border rounded p-3 h-100 bg-light-subtle">
-                    <div className="text-secondary small">Ecossistema</div>
+                    <div className="text-secondary small">Motor provável</div>
                     <strong>
                       {ecosystemLabels[warmupQuery.data.ecosystemType]}
                     </strong>
@@ -494,7 +495,7 @@ export default function MoisSalesPageLibraryDetailPage() {
 
               <div className="border rounded p-3">
                 <div className="text-secondary small">
-                  Recomendação comercial
+                  Hipótese de como vende
                 </div>
                 <p className="mb-1 fw-semibold">
                   {recommendationLabels[warmupQuery.data.recommendation]}
@@ -505,7 +506,7 @@ export default function MoisSalesPageLibraryDetailPage() {
                 </p>
                 {warmupQuery.data.nextExperimentSuggestion ? (
                   <p className="mb-0 mt-2 small text-secondary">
-                    Próximo experimento sugerido:{" "}
+                    Próxima investigação sugerida:{" "}
                     {warmupQuery.data.nextExperimentSuggestion}
                   </p>
                 ) : null}
@@ -523,32 +524,34 @@ export default function MoisSalesPageLibraryDetailPage() {
 
               <div className="row g-3 small">
                 <div className="col-md-6">
-                  <strong>Dores principais</strong>
+                  <strong>Dor/promessa central</strong>
                   <TextList items={warmupQuery.data.mainPains} />
                 </div>
                 <div className="col-md-6">
-                  <strong>Objeções principais</strong>
+                  <strong>Objeções/riscos</strong>
                   <TextList items={warmupQuery.data.mainObjections} />
                 </div>
                 <div className="col-md-6">
-                  <strong>Canais principais</strong>
+                  <strong>Canais encontrados</strong>
                   <TextList items={warmupQuery.data.mainChannels} />
                 </div>
                 <div className="col-md-6">
-                  <strong>Concorrentes principais</strong>
+                  <strong>Alavancas de sucesso</strong>
                   <TextList items={warmupQuery.data.mainCompetitors} />
                 </div>
               </div>
 
               {warmupQuery.data.saturationRisk ? (
                 <div className="alert alert-warning mb-0">
-                  <strong>Risco de saturação:</strong>{" "}
+                  <strong>Risco comercial:</strong>{" "}
                   {warmupQuery.data.saturationRisk}
                 </div>
               ) : null}
 
               <div>
-                <h3 className="h6 mb-2">Fontes públicas rastreáveis</h3>
+                <h3 className="h6 mb-2">
+                  Fontes públicas para explicar o sucesso
+                </h3>
                 {warmupSourcesQuery.isLoading ? (
                   <p className="text-secondary mb-0">Carregando fontes...</p>
                 ) : null}
@@ -599,7 +602,7 @@ export default function MoisSalesPageLibraryDetailPage() {
               </div>
 
               <div>
-                <h3 className="h6 mb-2">Sinais que justificam a pontuação</h3>
+                <h3 className="h6 mb-2">Sinais que explicam a venda</h3>
                 {warmupSignalsQuery.isLoading ? (
                   <p className="text-secondary mb-0">Carregando sinais...</p>
                 ) : null}
@@ -611,7 +614,7 @@ export default function MoisSalesPageLibraryDetailPage() {
                 {!warmupSignalsQuery.isLoading &&
                 (warmupSignalsQuery.data?.items.length ?? 0) === 0 ? (
                   <p className="text-secondary mb-0">
-                    Nenhum sinal comercial registrado para este dossiê.
+                    Nenhum sinal de venda registrado para este dossiê.
                   </p>
                 ) : null}
                 <div className="row g-2">

--- a/frontend/src/pages/mois/MoisSalesPagesLibraryPage.tsx
+++ b/frontend/src/pages/mois/MoisSalesPagesLibraryPage.tsx
@@ -162,7 +162,7 @@ export default function MoisSalesPagesLibraryPage() {
             <div className="card border-0 shadow-sm h-100">
               <div className="card-body">
                 <p className="text-secondary mb-1">
-                  Elegíveis para aquecimento
+                  Elegíveis para dossiê de sucesso
                 </p>
                 <h3 className="mb-0">{summary.marketWarmupEligible}</h3>
               </div>
@@ -196,8 +196,8 @@ export default function MoisSalesPagesLibraryPage() {
               <div>
                 <h2 className="h5 mb-1">Ranking de oportunidades comerciais</h2>
                 <p className="text-secondary mb-0">
-                  Prioriza mercados combinando score da página, aquecimento,
-                  risco de saturação e recência das evidências.
+                  Prioriza produtos combinando score da página, engenharia de
+                  sucesso, risco de saturação e recência das evidências.
                 </p>
               </div>
             </div>
@@ -217,7 +217,7 @@ export default function MoisSalesPagesLibraryPage() {
                       <th>Prioridade</th>
                       <th>Mercado/produto</th>
                       <th>Score combinado</th>
-                      <th>Aquecimento</th>
+                      <th>Sucesso do produto</th>
                       <th>Próxima ação</th>
                       <th>Evidência</th>
                     </tr>
@@ -269,16 +269,17 @@ export default function MoisSalesPagesLibraryPage() {
         <div className="card-body d-flex flex-column gap-3">
           <div className="d-flex flex-wrap align-items-end justify-content-between gap-3">
             <div>
-              <h2 className="h5 mb-1">Priorização por aquecimento</h2>
+              <h2 className="h5 mb-1">Priorização por engenharia de sucesso</h2>
               <p className="text-secondary mb-0">
                 Ordene a listagem diretamente no backend pelo score de
-                aquecimento para decidir quais mercados merecem ação primeiro.
+                engenharia de sucesso para entender quais produtos vencedores
+                merecem estudo primeiro.
               </p>
             </div>
             <div className="d-flex flex-wrap gap-3">
               <div>
                 <label className="form-label small" htmlFor="warmupFilter">
-                  Filtro de aquecimento
+                  Filtro de sucesso
                 </label>
                 <select
                   id="warmupFilter"
@@ -307,7 +308,7 @@ export default function MoisSalesPagesLibraryPage() {
                   onChange={(event) => setSort(event.target.value)}
                 >
                   <option value="MARKET_WARMUP_SCORE">
-                    Maior score de aquecimento
+                    Maior score de sucesso
                   </option>
                   <option value="RECENT_ANALYSIS">Análise mais recente</option>
                 </select>
@@ -332,8 +333,8 @@ export default function MoisSalesPagesLibraryPage() {
                     <th>Produto</th>
                     <th>Origem</th>
                     <th>Status</th>
-                    <th>Aquecimento</th>
-                    <th>Score aquecimento</th>
+                    <th>Sucesso do produto</th>
+                    <th>Score sucesso</th>
                     <th>Data da análise</th>
                     <th>Fase no diagrama</th>
                     <th>Ações</th>

--- a/frontend/src/pages/mois/MoisSalesPagesPipelinePage.tsx
+++ b/frontend/src/pages/mois/MoisSalesPagesPipelinePage.tsx
@@ -29,7 +29,7 @@ const htmlAcquisitionChecklist = [
 const marketWarmupChecklist = [
   "Páginas com análise comercial concluída",
   "Sinais públicos de demanda, conversa e concorrência",
-  "Score de aquecimento do mercado e risco de saturação",
+  "Score de engenharia de sucesso e riscos comerciais",
   "Recomendação comercial para priorizar, observar ou diferenciar o ângulo",
 ];
 
@@ -118,7 +118,7 @@ export default function MoisSalesPagesPipelinePage() {
           <p className="text-secondary mb-0">
             Execute e acompanhe o pipeline operacional: obter HTML bruto
             versionado, analisar comercialmente as páginas capturadas e preparar
-            a pesquisa de aquecimento do mercado.
+            a investigação de sucesso do produto.
           </p>
         </div>
         <Link
@@ -417,8 +417,9 @@ export default function MoisSalesPagesPipelinePage() {
                     {summaryQuery.isLoading ? "..." : analysisBacklog}
                   </h3>
                   <p className="text-secondary small mb-0 mt-2">
-                    Fila real: {analysisPending} pendentes · {analysisRunning}{" "}
-                    em execução · {analysisFailed} falhas registradas
+                    Fila real da investigação: {analysisPending} pendentes ·{" "}
+                    {analysisRunning} em execução · {analysisFailed} falhas
+                    registradas
                   </p>
                 </div>
               </div>
@@ -456,12 +457,12 @@ export default function MoisSalesPagesPipelinePage() {
           <div className="d-flex flex-wrap align-items-start justify-content-between gap-3">
             <div>
               <span className="badge text-bg-primary mb-2">Etapa 3</span>
-              <h2 className="h4 mb-2">Pesquisa de aquecimento e ecossistema</h2>
+              <h2 className="h4 mb-2">Investigação de sucesso do produto</h2>
               <p className="text-secondary mb-0">
                 Próximo bloco do pipeline: usar a análise comercial da etapa 2
-                para medir se o mercado já está sendo aquecido por conversas,
-                conteúdos, provas públicas e ofertas parecidas antes de criar
-                novos produtos ou ângulos de venda.
+                para descobrir como o produto aparentemente vencedor vende:
+                autoridade por trás, canais de audiência, funil, prova social e
+                distribuição.
               </p>
             </div>
             <span className="badge text-bg-warning align-self-start">
@@ -488,11 +489,11 @@ export default function MoisSalesPagesPipelinePage() {
                 <p className="text-uppercase text-secondary small fw-semibold mb-1">
                   Saída esperada
                 </p>
-                <h3 className="h6 mb-2">Score de aquecimento do mercado</h3>
+                <h3 className="h6 mb-2">Score da engenharia de sucesso</h3>
                 <p className="text-secondary small mb-0">
-                  O resultado esperado classifica o mercado como quente,
-                  promissor, morno, frio ou saturado com base em fontes públicas
-                  rastreáveis.
+                  O resultado esperado classifica a força da máquina de venda
+                  como quente, promissora, morna, fria ou saturada com base em
+                  fontes públicas rastreáveis.
                 </p>
               </div>
             </div>
@@ -503,8 +504,8 @@ export default function MoisSalesPagesPipelinePage() {
                 </p>
                 <h3 className="h6 mb-2">Decisão comercial explicável</h3>
                 <p className="text-secondary small mb-0">
-                  A recomendação deve preservar o eixo dor, resultado,
-                  mecanismo, prova e oferta, evitando opinião sem evidência.
+                  A recomendação deve explicar autoridade, canal, captura,
+                  oferta, prova e checkout, evitando opinião sem evidência.
                 </p>
               </div>
             </div>
@@ -515,8 +516,8 @@ export default function MoisSalesPagesPipelinePage() {
               <div>
                 <h3 className="h6 mb-1">Resumo da etapa 3</h3>
                 <p className="text-secondary small mb-0">
-                  Mostra cobertura real da Etapa 3 para priorizar mercados com
-                  dossiê concluído, fila visível e temperatura comercial.
+                  Mostra cobertura real da Etapa 3 para priorizar produtos com
+                  dossiê concluído, fila visível e força comercial.
                 </p>
               </div>
               {summaryQuery.isLoading ? (
@@ -528,7 +529,7 @@ export default function MoisSalesPagesPipelinePage() {
               <div className="col-sm-6 col-lg-4">
                 <div className="bg-light rounded-3 p-3 h-100">
                   <p className="text-secondary mb-1">
-                    Elegíveis para aquecimento
+                    Elegíveis para dossiê de sucesso
                   </p>
                   <h3 className="mb-0">
                     {summaryQuery.isLoading ? "..." : marketWarmupEligiblePages}
@@ -542,7 +543,8 @@ export default function MoisSalesPagesPipelinePage() {
                     {summaryQuery.isLoading ? "..." : marketWarmupCompleted}
                   </h3>
                   <p className="text-secondary small mb-0 mt-2">
-                    Pesquisa pronta para decisão comercial e revisão humana.
+                    Dossiê pronto para explicar a máquina de venda e revisão
+                    humana.
                   </p>
                 </div>
               </div>
@@ -555,16 +557,17 @@ export default function MoisSalesPagesPipelinePage() {
                       : marketWarmupHot + marketWarmupPromising}
                   </h3>
                   <p className="text-secondary small mb-0 mt-2">
-                    Mercados com maior prioridade inicial para experimentos.
+                    Produtos com maior prioridade para estudo de engenharia de
+                    venda.
                   </p>
                 </div>
               </div>
             </div>
             <p className="text-secondary small mb-0 mt-3">
-              Fila real: {marketWarmupPending} pendentes · {marketWarmupRunning}{" "}
-              em pesquisa · {marketWarmupStuck} presos há mais de 120 min ·{" "}
-              {marketWarmupFailed} falhas · {marketWarmupCold} frios ·{" "}
-              {marketWarmupSaturated} saturados.
+              Fila real da investigação: {marketWarmupPending} pendentes ·{" "}
+              {marketWarmupRunning} em pesquisa · {marketWarmupStuck} presos há
+              mais de 120 min · {marketWarmupFailed} falhas · {marketWarmupCold}{" "}
+              fracos · {marketWarmupSaturated} saturados.
             </p>
           </div>
 

--- a/mois-sales-library-worker/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/marketwarmup/MarketWarmupProcessor.java
+++ b/mois-sales-library-worker/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/marketwarmup/MarketWarmupProcessor.java
@@ -112,11 +112,17 @@ public class MarketWarmupProcessor {
             if (containsAny(text, "reclama", "golpe", "não funciona", "risco", "contraindica", "procon")) {
                 addSignal(signals, index, MarketWarmupSignalType.OBJECTION, buildSignalText(result), "Existe objeção ou risco de confiança que precisa ser tratado na oferta.", 7);
             }
-            if (containsAny(text, "youtube", "instagram", "tiktok", "canal", "influencer")) {
-                addSignal(signals, index, MarketWarmupSignalType.CHANNEL_FIT, buildSignalText(result), "A fonte sugere canal público adequado para aquecer ou vender.", 5);
+            if (containsAny(text, "youtube", "instagram", "tiktok", "canal", "influencer", "whatsapp", "live")) {
+                addSignal(signals, index, MarketWarmupSignalType.CHANNEL_FIT, buildSignalText(result), "A fonte sugere canal público usado para aquecer, capturar ou vender.", 6);
             }
-            if (containsAny(text, "afiliado", "concorrente", "hotmart", "clickbank", "produto")) {
-                addSignal(signals, index, MarketWarmupSignalType.COMPETITOR_OFFER, buildSignalText(result), "Há sinal de maturidade de oferta ou concorrência no mercado.", 5);
+            if (containsAny(text, "fundador", "fundadora", "especialista", "professora", "mentor", "seguidores", "autoridade", "criadora", "criador")) {
+                addSignal(signals, index, MarketWarmupSignalType.CREATOR_AUTHORITY, buildSignalText(result), "Há sinal de autoridade pessoal ou marca especialista por trás do produto.", 8);
+            }
+            if (containsAny(text, "depoimento", "alunas", "alunos", "resultado", "transformação", "antes e depois", "casos de sucesso")) {
+                addSignal(signals, index, MarketWarmupSignalType.SOCIAL_PROOF, buildSignalText(result), "Há prova social pública que ajuda a explicar a confiança na oferta.", 7);
+            }
+            if (containsAny(text, "afiliado", "concorrente", "hotmart", "clickbank", "produto", "oferta", "bônus", "checkout")) {
+                addSignal(signals, index, MarketWarmupSignalType.COMPETITOR_OFFER, buildSignalText(result), "Há sinal de maturidade de oferta, distribuição ou venda do produto.", 5);
             }
         }
         return signals;
@@ -136,8 +142,11 @@ public class MarketWarmupProcessor {
         int painSignals = countSignals(signals, MarketWarmupSignalType.PAIN_EXPLICIT);
         int intentSignals = countSignals(signals, MarketWarmupSignalType.BUYING_INTENT);
         int competitorSignals = countSignals(signals, MarketWarmupSignalType.COMPETITOR_OFFER);
+        int authoritySignals = countSignals(signals, MarketWarmupSignalType.CREATOR_AUTHORITY);
+        int socialProofSignals = countSignals(signals, MarketWarmupSignalType.SOCIAL_PROOF);
+        int channelSignals = countSignals(signals, MarketWarmupSignalType.CHANNEL_FIT);
         int objectionSignals = countSignals(signals, MarketWarmupSignalType.OBJECTION);
-        int score = Math.min(100, 20 + Math.min(20, sources.size() * 3) + Math.min(20, painSignals * 5) + Math.min(20, intentSignals * 5) + Math.min(10, competitorSignals * 3) - Math.min(10, objectionSignals * 2));
+        int score = Math.min(100, 20 + Math.min(20, sources.size() * 3) + Math.min(20, painSignals * 5) + Math.min(20, intentSignals * 5) + Math.min(15, authoritySignals * 5) + Math.min(15, socialProofSignals * 5) + Math.min(10, channelSignals * 3) + Math.min(10, competitorSignals * 3) - Math.min(10, objectionSignals * 2));
         MarketWarmupTemperature temperature = classifyTemperature(score, objectionSignals);
         MarketWarmupRecommendation recommendation = classifyRecommendation(temperature);
         return new MarketWarmupSummaryCompleteItem(
@@ -145,14 +154,14 @@ public class MarketWarmupProcessor {
                 temperature,
                 classifyEcosystem(sources, competitorSignals, objectionSignals),
                 recommendation,
-                List.of(firstUseful(job.promiseSummary(), "Dor principal inferida das fontes públicas e da promessa analisada.")),
+                List.of(firstUseful(job.promiseSummary(), "Dor central inferida da promessa usada pelo produto vencedor.")),
                 objectionSignals > 0 ? List.of("Confiança no método e prova de resultado precisam ser reforçadas.") : List.of("Objeções explícitas ainda não apareceram com força na busca V1."),
                 List.of(firstUseful(job.promiseSummary(), "Promessa principal ainda precisa de refinamento pela análise comercial.")),
                 collectChannels(sources),
-                competitorSignals > 0 ? List.of("Há sinais de produtos, afiliados ou ofertas concorrentes nas fontes públicas.") : List.of("Concorrentes diretos não foram fortes no dossiê V1."),
+                buildSuccessLevers(authoritySignals, socialProofSignals, competitorSignals, channelSignals),
                 objectionSignals >= 3 ? "Risco moderado de desconfiança ou saturação; exigir ângulo e prova mais específicos." : "Risco de saturação baixo ou não conclusivo na coleta V1.",
-                buildOpportunityRecommendation(temperature),
-                "Validar experimento usando a dor e a promessa com maior presença nas fontes rastreáveis.");
+                buildOpportunityRecommendation(temperature, authoritySignals, socialProofSignals, channelSignals),
+                buildNextInvestigationSuggestion(authoritySignals, socialProofSignals, channelSignals));
     }
 
     /**
@@ -210,14 +219,57 @@ public class MarketWarmupProcessor {
     /**
      * Monta recomendação de negócio direta para orientar o próximo experimento.
      */
-    private String buildOpportunityRecommendation(MarketWarmupTemperature temperature) {
+    private String buildOpportunityRecommendation(MarketWarmupTemperature temperature, int authoritySignals, int socialProofSignals, int channelSignals) {
+        if (authoritySignals > 0 || socialProofSignals > 0 || channelSignals > 0) {
+            return "Investigar como o produto vende: há sinais de autoridade, canal de audiência, prova social ou funil público que podem explicar o sucesso.";
+        }
         return switch (temperature) {
-            case HOT -> "Priorizar experimento: há evidência pública suficiente para testar oferta rapidamente.";
-            case PROMISING -> "Priorizar com refinamento de ângulo: há sinais de demanda, mas a promessa deve ser diferenciada.";
-            case WARM -> "Pesquisar mais antes de criar oferta: o mercado tem sinais, mas ainda não sustenta prioridade máxima.";
-            case SATURATED -> "Avançar somente com ângulo diferenciado e prova forte para reduzir desconfiança.";
-            case COLD -> "Baixa prioridade comercial no momento; buscar outro mercado com dor mais explícita.";
+            case HOT -> "Produto com sinais fortes de engenharia de venda pública; mapear canal principal e prova social antes de replicar.";
+            case PROMISING -> "Produto promissor para estudo; aprofundar autoridade, audiência e funil antes de criar referência.";
+            case WARM -> "Pesquisar mais fontes para confirmar canal de aquisição, influência e prova social.";
+            case SATURATED -> "Avançar somente se houver ângulo de diferenciação claro frente à saturação percebida.";
+            case COLD -> "Baixa evidência pública sobre a máquina de venda; buscar produtor, influenciador ou canal antes de concluir.";
         };
+    }
+
+
+    /**
+     * Resume alavancas prováveis que explicam a venda do produto observado.
+     */
+    private List<String> buildSuccessLevers(int authoritySignals, int socialProofSignals, int competitorSignals, int channelSignals) {
+        List<String> levers = new ArrayList<>();
+        if (authoritySignals > 0) {
+            levers.add("Autoridade pessoal ou marca especialista aparece como provável motor de confiança.");
+        }
+        if (channelSignals > 0) {
+            levers.add("Canais públicos como Instagram, YouTube, TikTok, WhatsApp ou lives aparecem como ativos de aquisição/aquecimento.");
+        }
+        if (socialProofSignals > 0) {
+            levers.add("Depoimentos, alunas ou resultados aparecem como prova social para conversão.");
+        }
+        if (competitorSignals > 0) {
+            levers.add("Há sinais de distribuição por oferta, afiliados, marketplace ou bônus.");
+        }
+        if (levers.isEmpty()) {
+            levers.add("Alavancas de sucesso ainda não ficaram claras nas fontes públicas V1.");
+        }
+        return levers;
+    }
+
+    /**
+     * Sugere a próxima investigação necessária para explicar como o produtor chegou ao sucesso.
+     */
+    private String buildNextInvestigationSuggestion(int authoritySignals, int socialProofSignals, int channelSignals) {
+        if (authoritySignals == 0) {
+            return "Buscar pessoa pública, fundador, especialista ou marca por trás do produto.";
+        }
+        if (channelSignals == 0) {
+            return "Mapear quais canais levam audiência para a oferta: Instagram, YouTube, TikTok, WhatsApp, lives, afiliados ou anúncios.";
+        }
+        if (socialProofSignals == 0) {
+            return "Coletar depoimentos, resultados e provas usadas para converter a audiência em compra.";
+        }
+        return "Montar o mapa da máquina de venda: autoridade → canal → captura/aula/live → oferta → prova social → checkout.";
     }
 
     /**
@@ -254,8 +306,14 @@ public class MarketWarmupProcessor {
         if (containsAny(text, "reclama", "golpe", "procon")) {
             return MarketWarmupSourceType.COMPLAINT;
         }
-        if (containsAny(text, "youtube", "instagram", "tiktok", "canal")) {
+        if (containsAny(text, "instagram", "tiktok", "post", "perfil")) {
+            return MarketWarmupSourceType.SOCIAL_POST;
+        }
+        if (containsAny(text, "youtube", "canal", "live", "aula gratuita", "webinar")) {
             return MarketWarmupSourceType.CREATOR_CONTENT;
+        }
+        if (containsAny(text, "fundador", "fundadora", "especialista", "professora", "mentor", "autoridade")) {
+            return MarketWarmupSourceType.SPECIALIST_CONTENT;
         }
         if (containsAny(text, "afiliado", "hotmart", "clickbank")) {
             return MarketWarmupSourceType.AFFILIATE_PROMOTION;
@@ -275,7 +333,7 @@ public class MarketWarmupProcessor {
      */
     private BigDecimal scoreEngagement(PublicSearchResult result) {
         String text = normalizeText(result.title() + " " + result.snippet());
-        return containsAny(text, "coment", "pergunta", "review", "depoimento", "preço") ? BigDecimal.valueOf(6) : BigDecimal.valueOf(3);
+        return containsAny(text, "coment", "pergunta", "review", "depoimento", "preço", "seguidores", "alunas", "whatsapp", "live") ? BigDecimal.valueOf(7) : BigDecimal.valueOf(3);
     }
 
     /**

--- a/mois-sales-library-worker/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/marketwarmup/MarketWarmupQueryBuilder.java
+++ b/mois-sales-library-worker/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/marketwarmup/MarketWarmupQueryBuilder.java
@@ -12,21 +12,32 @@ import org.springframework.stereotype.Component;
 @Component
 public class MarketWarmupQueryBuilder {
     /**
-     * Monta queries focadas em produto, dor, promessa, prova e concorrentes para a Etapa 3.
+     * Monta queries focadas em descobrir canais, autoridade, funil e provas que explicam o sucesso do produto.
      */
     public List<String> buildQueries(MarketWarmupClaimedJob job) {
         String title = clean(job.title());
+        String producer = clean(job.producerName());
         String promise = clean(job.promiseSummary());
         String mechanism = clean(job.mechanismSummary());
         String offer = clean(job.offerSummary());
         String proof = clean(job.proofSummary());
+        String productAndProducer = clean(title + " " + producer);
         Set<String> queries = new LinkedHashSet<>();
-        addIfUseful(queries, title + " review depoimento reclamação");
-        addIfUseful(queries, title + " YouTube Instagram TikTok");
-        addIfUseful(queries, promise + " como resolver");
-        addIfUseful(queries, mechanism + " método resultados");
-        addIfUseful(queries, offer + " concorrentes afiliados");
-        addIfUseful(queries, proof + " antes depois depoimentos");
+        if (!productAndProducer.isBlank()) {
+            addIfUseful(queries, exact(title) + " " + producer + " Instagram YouTube TikTok influenciador fundador");
+            addIfUseful(queries, productAndProducer + " depoimento review funciona vale a pena reclamação");
+            addIfUseful(queries, productAndProducer + " aula gratuita live whatsapp comunidade lançamento");
+            addIfUseful(queries, productAndProducer + " afiliado hotmart produtor oferta bônus");
+        }
+        if (!producer.isBlank()) {
+            addIfUseful(queries, producer + " autoridade seguidores alunas método");
+        }
+        if (!clean(promise + " " + mechanism).isBlank()) {
+            addIfUseful(queries, promise + " " + mechanism + " canal influencer especialista");
+        }
+        if (!clean(offer + " " + proof).isBlank()) {
+            addIfUseful(queries, offer + " " + proof + " prova social depoimentos resultados");
+        }
         return queries.stream().limit(6).toList();
     }
 
@@ -35,9 +46,31 @@ public class MarketWarmupQueryBuilder {
      */
     private void addIfUseful(Set<String> queries, String query) {
         String normalized = clean(query);
-        if (normalized.length() >= 12) {
+        if (normalized.length() >= 18 && hasSpecificSignal(normalized)) {
             queries.add(normalized);
         }
+    }
+
+    /**
+     * Exige termos de produto, produtor ou ativos de venda para reduzir resultados genéricos por palavras soltas.
+     */
+    private boolean hasSpecificSignal(String query) {
+        return query.contains("\"")
+                || query.toLowerCase().contains("instagram")
+                || query.toLowerCase().contains("youtube")
+                || query.toLowerCase().contains("hotmart")
+                || query.toLowerCase().contains("whatsapp")
+                || query.toLowerCase().contains("depoimento")
+                || query.toLowerCase().contains("alunas")
+                || query.toLowerCase().contains("seguidores");
+    }
+
+    /**
+     * Protege nomes de produtos para que a busca trate o título como uma expressão e não como termos genéricos isolados.
+     */
+    private String exact(String value) {
+        String normalized = clean(value);
+        return normalized.isBlank() ? "" : "\"" + normalized.replace("\"", "") + "\"";
     }
 
     /**

--- a/mois-sales-library-worker/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/model/WorkerDtos.java
+++ b/mois-sales-library-worker/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/model/WorkerDtos.java
@@ -39,7 +39,7 @@ public final class WorkerDtos {
     public enum MarketWarmupRecommendation { PRIORITIZE, OBSERVE, RESEARCH_MORE, DISCARD, SATURATED_REQUIRES_ANGLE }
 
     public record MarketWarmupClaimRequest(String workspaceId, String workerId) {}
-    public record MarketWarmupClaimedJob(Long jobId, Long pageId, String workspaceId, String urlCanonical, String title, String offerSummary, String mechanismSummary, String promiseSummary, String proofSummary) {}
+    public record MarketWarmupClaimedJob(Long jobId, Long pageId, String workspaceId, String urlCanonical, String title, String producerName, String offerSummary, String mechanismSummary, String promiseSummary, String proofSummary) {}
     public record MarketWarmupClaimResponse(boolean claimed, MarketWarmupClaimedJob job) {}
     public record MarketWarmupSourceCompleteItem(MarketWarmupPlatform platform, MarketWarmupSourceType sourceType, String sourceUrl, String sourceTitle, String authorName, Instant publishedAt, Instant lastActivityAt, Long followersOrSubscribers, Long viewsCount, Long likesCount, Long commentsCount, BigDecimal recencyScore, BigDecimal engagementScore, String evidenceSummary) {}
     public record MarketWarmupSignalCompleteItem(int sourceIndex, MarketWarmupSignalType signalType, BigDecimal signalStrength, String signalText, String businessInterpretation) {}

--- a/mois-sales-library-worker/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/marketwarmup/MarketWarmupProcessorTest.java
+++ b/mois-sales-library-worker/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/marketwarmup/MarketWarmupProcessorTest.java
@@ -25,6 +25,7 @@ class MarketWarmupProcessorTest {
                 "workspace-001",
                 "https://example.com/oferta",
                 "Sono Profundo",
+                "Especialista do Sono",
                 "Oferta contra insônia",
                 "método respiratório",
                 "dormir melhor em 7 dias",
@@ -33,7 +34,7 @@ class MarketWarmupProcessorTest {
         var result = processor.process(job, 3);
 
         assertThat(result.sources()).isNotEmpty();
-        assertThat(result.signals()).extracting(signal -> signal.signalType()).contains(MarketWarmupSignalType.PAIN_EXPLICIT, MarketWarmupSignalType.BUYING_INTENT);
+        assertThat(result.signals()).extracting(signal -> signal.signalType()).contains(MarketWarmupSignalType.PAIN_EXPLICIT, MarketWarmupSignalType.BUYING_INTENT, MarketWarmupSignalType.CREATOR_AUTHORITY, MarketWarmupSignalType.SOCIAL_PROOF);
         assertThat(result.sources()).extracting(source -> source.platform()).contains(MarketWarmupPlatform.YOUTUBE);
         assertThat(result.summary().recommendation()).isNotNull();
         assertThat(result.summary().scoreTotal()).isPositive();
@@ -49,8 +50,8 @@ class MarketWarmupProcessorTest {
         @Override
         public List<PublicSearchResult> search(String query, int limit) throws IOException {
             return List.of(
-                    new PublicSearchResult("Insônia: dor e dificuldade para dormir", "https://www.youtube.com/watch?v=abc", "Comentários perguntam se funciona e preço do método.", "<div>raw</div>"),
-                    new PublicSearchResult("Review Sono Profundo vale a pena", "https://blog.example.com/review", "Depoimento e objeção sobre confiança no produto.", "<div>raw</div>"));
+                    new PublicSearchResult("Insônia: dor e dificuldade para dormir", "https://www.youtube.com/watch?v=abc", "Professora especialista faz live e comentários perguntam se funciona e preço do método.", "<div>raw</div>"),
+                    new PublicSearchResult("Review Sono Profundo vale a pena", "https://blog.example.com/review", "Depoimento de alunos mostra resultado e objeção sobre confiança no produto.", "<div>raw</div>"));
         }
     }
 }

--- a/mois-sales-library-worker/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/marketwarmup/MarketWarmupQueryBuilderTest.java
+++ b/mois-sales-library-worker/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/marketwarmup/MarketWarmupQueryBuilderTest.java
@@ -21,6 +21,7 @@ class MarketWarmupQueryBuilderTest {
                 "workspace-001",
                 "https://example.com/oferta",
                 "Produto Sono Profundo",
+                "Especialista do Sono",
                 "Curso para dormir melhor",
                 "rotina de respiração guiada",
                 "acabar com insônia sem remédios",
@@ -28,7 +29,8 @@ class MarketWarmupQueryBuilderTest {
 
         assertThat(builder.buildQueries(job))
                 .hasSize(6)
-                .anySatisfy(query -> assertThat(query).contains("acabar com insônia"))
-                .anySatisfy(query -> assertThat(query).contains("rotina de respiração guiada"));
+                .anySatisfy(query -> assertThat(query).contains("Especialista do Sono"))
+                .anySatisfy(query -> assertThat(query).contains("Instagram YouTube TikTok"))
+                .anySatisfy(query -> assertThat(query).contains("aula gratuita"));
     }
 }


### PR DESCRIPTION
### Motivation

- Reorientar a Etapa 3 da Biblioteca de Páginas de Vendas para explicar como um produto aparentemente vencedor conseguiu vender, priorizando autoridade/produtor, canais, funil e prova social em vez de medir apenas "aquecimento" genérico do mercado. 
- Evitar buscas genéricas por título isolado acrescentando o produtor/marca ao payload e às queries públicas para melhorar qualidade das fontes rastreáveis.

### Description

- Adiciona o campo `producerName` ao contrato de claim/claim response e aos DTOs (`MoisSalesLibraryDtos`, worker `WorkerDtos`) e propaga o valor desde a leitura SQL até o payload retornado ao worker. 
- Atualiza o repositório JDBC para fazer `LEFT JOIN mois_collected_reference` e mapear `producer_name` em `SalesPageWarmupData` e `MarketWarmupClaim` result set mapping. 
- Refatora o worker de pesquisa pública: `MarketWarmupQueryBuilder` passa a construir queries combinando título+produtor, exige sinais específicos antes de adicionar queries genéricas, e protege nomes de produto com busca exata; `MarketWarmupProcessor` adiciona detecção de autoridade, prova social e canais, ajusta sinais/tipos, recalibra o cálculo de score e inclui helpers (`buildSuccessLevers`, `buildNextInvestigationSuggestion`). 
- Atualiza textos de UI e API: front-end pages (`MoisSalesPageLibraryDetailPage`, `MoisSalesPagesLibraryPage`, `MoisSalesPagesPipelinePage`), OpenAPI spec (`docs/swagger/mois-sales-library-swagger.yaml`) e documentação canônica (`docs/canonical/mois-worker-canon.v1.md`, registros) para refletir a nova nomenclatura "Investigação de Sucesso do Produto" e novos campos/descrições. 

### Testing

- Executed unit tests touching the changed modules: `MoisSalesPageMarketWarmupServiceTest`, `MoisSalesLibraryControllerTest`, `MarketWarmupProcessorTest`, and `MarketWarmupQueryBuilderTest`; all updated tests passed. 
- Ran the worker module unit suite for `mois-sales-library-worker` covering signal extraction and query generation; tests succeeded. 
- Ran repository/DAO unit tests that exercise `findSalesPage` and `findNextPendingJob` mappings; they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2a317aa66883219430febf010059b1)