### PR TITLE
Simplifica tela de nova hipótese

### DIFF
--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -4320,3 +4320,14 @@
 - causa-raiz: o detalhe do nicho ainda abria o formulário manual embutido, enquanto o nicho enriquecido já apontava para o fluxo novo `/niches/:id/hypotheses/new` da construção auditável da hipótese.
 - foi feito: o botão principal do detalhe do nicho passou a ser um link para `/niches/:id/hypotheses/new`, mantendo a criação manual separada na seção própria da página.
 - impacto esperado: o usuário entra no mesmo fluxo de construção da hipótese a partir de qualquer origem, reduzindo desvio operacional e mantendo a etapa Dor como primeiro passo padrão.
+
+## 2026-06-11 02:58:14 UTC-3
+- solicitação: remover da tela de nova hipótese as informações detalhadas marcadas em vermelho, mantendo apenas o acompanhamento essencial do job de dor.
+- raciocínio: a causa do excesso visual era a renderização do resultado estruturado completo e da tabela histórica diretamente na tela inicial; a correção simplifica a tela para reduzir ruído e direcionar o usuário ao fluxo principal.
+- registro do que foi feito: removida a exibição do detalhamento da dor e da tabela de execuções na página de nova hipótese; o teste da tela foi ajustado para garantir que apenas o link do job atual permaneça visível.
+- documentos lidos para pesquisar e resolver o problema:
+  - AGENTS.md
+  - frontend/AGENTS.md
+  - docs/registros/experimentos.md
+  - frontend/src/pages/hypothesis/NewHypothesisPage.tsx
+  - frontend/src/pages/hypothesis/NewHypothesisPage.test.tsx

--- a/frontend/src/pages/hypothesis/NewHypothesisPage.test.tsx
+++ b/frontend/src/pages/hypothesis/NewHypothesisPage.test.tsx
@@ -30,7 +30,7 @@ function renderPage() {
 }
 
 describe("NewHypothesisPage", () => {
-  it("shows the pain job id as links to the job detail page", async () => {
+  it("shows the current pain job id as a link to the job detail page", async () => {
     (axios.get as any).mockResolvedValue({
       data: [
         {
@@ -45,16 +45,17 @@ describe("NewHypothesisPage", () => {
 
     renderPage();
 
-    const links = await screen.findAllByRole("link", {
+    const link = await screen.findByRole("link", {
       name: "9bb83a22-3894-43bd-9752-374f84eb6a2c",
     });
 
-    expect(links).toHaveLength(2);
-    links.forEach((link) => {
-      expect(link).toHaveAttribute(
-        "href",
-        "/niches/18/hypothesis-pipeline/pain/stage-executions/9bb83a22-3894-43bd-9752-374f84eb6a2c",
-      );
-    });
+    expect(link).toHaveAttribute(
+      "href",
+      "/niches/18/hypothesis-pipeline/pain/stage-executions/9bb83a22-3894-43bd-9752-374f84eb6a2c",
+    );
+    expect(screen.queryByText("Dor de superfície")).not.toBeInTheDocument();
+    expect(
+      screen.queryByRole("columnheader", { name: "Job" }),
+    ).not.toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/hypothesis/NewHypothesisPage.tsx
+++ b/frontend/src/pages/hypothesis/NewHypothesisPage.tsx
@@ -1,4 +1,3 @@
-import { useMemo } from "react";
 import { Link, useParams } from "react-router-dom";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import axios from "axios";
@@ -14,34 +13,14 @@ interface PainExecution {
   executionRequestedAt?: string;
   processingStartedAt?: string;
   completedAt?: string;
-  openAiModel?: string;
-  inputTokens?: number;
-  outputTokens?: number;
-  costUsd?: number;
   errorMessage?: string;
-  modelResponse?: string;
 }
 
-interface PainResult {
-  surface?: string;
-  root?: string;
-  emotional?: string;
-  social?: string;
-  cost?: string;
-  summary?: string;
-  evidenceSignals?: string[];
-}
-
-const RUNNING_STATUSES = new Set(["INICIADO", "PROCESSANDO", "AGUARDANDO_RETORNO_OPENAI"]);
-
-function parsePainResult(raw?: string): PainResult | undefined {
-  if (!raw) return undefined;
-  try {
-    return JSON.parse(raw) as PainResult;
-  } catch {
-    return undefined;
-  }
-}
+const RUNNING_STATUSES = new Set([
+  "INICIADO",
+  "PROCESSANDO",
+  "AGUARDANDO_RETORNO_OPENAI",
+]);
 
 function formatDate(value?: string) {
   if (!value) return "—";
@@ -64,7 +43,9 @@ export default function NewHypothesisPage() {
     },
     refetchInterval: (query) => {
       const items = query.state.data ?? [];
-      return items.some((item) => RUNNING_STATUSES.has(item.status)) ? 5000 : false;
+      return items.some((item) => RUNNING_STATUSES.has(item.status))
+        ? 5000
+        : false;
     },
   });
 
@@ -86,11 +67,9 @@ export default function NewHypothesisPage() {
 
   const executions = executionsQuery.data ?? [];
   const latest = executions[0];
-  const latestResult = useMemo(
-    () => parsePainResult(latest?.modelResponse),
-    [latest?.modelResponse],
+  const hasRunningExecution = executions.some((item) =>
+    RUNNING_STATUSES.has(item.status),
   );
-  const hasRunningExecution = executions.some((item) => RUNNING_STATUSES.has(item.status));
 
   return (
     <div className="hypothesis-new-page">
@@ -101,18 +80,24 @@ export default function NewHypothesisPage() {
           <div>
             <h2 className="h5 mb-0">Etapa 1 — Dor do nicho</h2>
             <small className="text-muted">
-              Inicie a construção auditável da dor antes de avançar para resultado, mecanismo, prova e oferta.
+              Inicie a construção auditável da dor antes de avançar para
+              resultado, mecanismo, prova e oferta.
             </small>
           </div>
           <button
             type="button"
             className="btn btn-primary align-self-start align-self-lg-center"
-            disabled={!nicheId || startMutation.isPending || hasRunningExecution}
+            disabled={
+              !nicheId || startMutation.isPending || hasRunningExecution
+            }
             onClick={() => startMutation.mutate()}
           >
             {startMutation.isPending ? (
               <span className="d-inline-flex align-items-center gap-2">
-                <span className="spinner-border spinner-border-sm" aria-hidden="true" />
+                <span
+                  className="spinner-border spinner-border-sm"
+                  aria-hidden="true"
+                />
                 Iniciando...
               </span>
             ) : hasRunningExecution ? (
@@ -133,7 +118,8 @@ export default function NewHypothesisPage() {
             <p className="text-muted mb-0">Carregando execuções...</p>
           ) : executions.length === 0 ? (
             <div className="alert alert-info mb-0">
-              Nenhuma execução de dor iniciada para este nicho. Clique no botão acima para criar o job e acompanhar o resultado.
+              Nenhuma execução de dor iniciada para este nicho. Clique no botão
+              acima para criar o job e acompanhar o resultado.
             </div>
           ) : (
             <div className="d-flex flex-column gap-3">
@@ -143,7 +129,9 @@ export default function NewHypothesisPage() {
                     <strong>Status atual:</strong> {latest.status}
                     <div className="text-muted small">
                       Job:{" "}
-                      <Link to={`/niches/${nicheId}/hypothesis-pipeline/pain/stage-executions/${latest.jobid}`}>
+                      <Link
+                        to={`/niches/${nicheId}/hypothesis-pipeline/pain/stage-executions/${latest.jobid}`}
+                      >
                         {latest.jobid}
                       </Link>
                     </div>
@@ -155,80 +143,10 @@ export default function NewHypothesisPage() {
                   </div>
                 </div>
                 {latest.errorMessage && (
-                  <div className="alert alert-danger mt-3 mb-0">{latest.errorMessage}</div>
+                  <div className="alert alert-danger mt-3 mb-0">
+                    {latest.errorMessage}
+                  </div>
                 )}
-              </div>
-
-              {latestResult ? (
-                <div className="row g-3">
-                  <div className="col-md-6">
-                    <h3 className="h6">Dor de superfície</h3>
-                    <p className="mb-0">{latestResult.surface}</p>
-                  </div>
-                  <div className="col-md-6">
-                    <h3 className="h6">Dor raiz</h3>
-                    <p className="mb-0">{latestResult.root}</p>
-                  </div>
-                  <div className="col-md-4">
-                    <h3 className="h6">Dor emocional</h3>
-                    <p className="mb-0">{latestResult.emotional}</p>
-                  </div>
-                  <div className="col-md-4">
-                    <h3 className="h6">Dor social</h3>
-                    <p className="mb-0">{latestResult.social}</p>
-                  </div>
-                  <div className="col-md-4">
-                    <h3 className="h6">Custo da inação</h3>
-                    <p className="mb-0">{latestResult.cost}</p>
-                  </div>
-                  <div className="col-12">
-                    <h3 className="h6">Resumo operacional</h3>
-                    <p className="mb-0">{latestResult.summary}</p>
-                  </div>
-                  {latestResult.evidenceSignals?.length ? (
-                    <div className="col-12">
-                      <h3 className="h6">Sinais de evidência</h3>
-                      <ul className="mb-0">
-                        {latestResult.evidenceSignals.map((signal, index) => (
-                          <li key={`${signal}-${index}`}>{signal}</li>
-                        ))}
-                      </ul>
-                    </div>
-                  ) : null}
-                </div>
-              ) : (
-                <p className="text-muted mb-0">
-                  O resultado estruturado aparecerá aqui quando o Worker AI concluir a execução.
-                </p>
-              )}
-
-              <div className="table-responsive">
-                <table className="table table-sm align-middle mb-0">
-                  <thead>
-                    <tr>
-                      <th>Job</th>
-                      <th>Status</th>
-                      <th>Modelo</th>
-                      <th>Solicitado</th>
-                      <th>Custo</th>
-                    </tr>
-                  </thead>
-                  <tbody>
-                    {executions.map((execution) => (
-                      <tr key={execution.jobid}>
-                        <td className="small text-break">
-                          <Link to={`/niches/${nicheId}/hypothesis-pipeline/pain/stage-executions/${execution.jobid}`}>
-                            {execution.jobid}
-                          </Link>
-                        </td>
-                        <td>{execution.status}</td>
-                        <td>{execution.openAiModel ?? "—"}</td>
-                        <td>{formatDate(execution.executionRequestedAt)}</td>
-                        <td>{execution.costUsd != null ? `$${execution.costUsd}` : "—"}</td>
-                      </tr>
-                    ))}
-                  </tbody>
-                </table>
               </div>
             </div>
           )}
@@ -238,7 +156,8 @@ export default function NewHypothesisPage() {
       <section className="card">
         <div className="card-body">
           <p className="text-muted mb-3">
-            Depois que a dor estiver clara, avance para construir a hipótese completa seguindo Dor → Resultado → Mecanismo → Prova → Oferta.
+            Depois que a dor estiver clara, avance para construir a hipótese
+            completa seguindo Dor → Resultado → Mecanismo → Prova → Oferta.
           </p>
           <Link className="btn btn-outline-secondary" to="/niches">
             Voltar para nichos


### PR DESCRIPTION
### Motivation
- Remover o conteúdo detalhado e marcado em vermelho da tela "Nova hipótese" para reduzir ruído visual e focar no acompanhamento essencial do job de dor. 
- Evitar exposição prematura de artefatos estruturados e da tabela histórica na tela inicial, direcionando o usuário ao fluxo principal de construção de hipótese.

### Description
- Removeu a renderização do resultado estruturado (tipo `PainResult` e parseamento do `modelResponse`) e a tabela histórica de execuções de `frontend/src/pages/hypothesis/NewHypothesisPage.tsx` para exibir apenas o status atual e o link para o detalhe do job. 
- Simplificou a interface `PainExecution` eliminando campos de telemetry/AI não usados na tela reduzida. 
- Ajustou o teste de regressão `frontend/src/pages/hypothesis/NewHypothesisPage.test.tsx` para validar que apenas o link do job atual aparece e que os blocos removidos não estão presentes. 
- Registrou a alteração no histórico operacional em `docs/registros/experimentos.md` com entrada timestamped.

### Testing
- Executado o teste de unidade com `npm test -- --run src/pages/hypothesis/NewHypothesisPage.test.tsx` e o teste passou (1 test). 
- Verificação de tipagem feita com `npm run typecheck` (`tsc --noEmit`) e foi concluída com sucesso. 
- Formatação verificada com `npx prettier --check` e arquivos formatados com `npx prettier --write`; a checagem final retornou OK.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2a4e07fc2883219d62d4f9c8618488)