### PR TITLE
Fix MOIS sales-library worker compilation by removing duplicated helper methods

### DIFF
--- a/docs/registros/mois1.md
+++ b/docs/registros/mois1.md
@@ -1438,3 +1438,12 @@ Arquivos principais:
 
 Arquivo principal:
 - `frontend/src/pages/mois/MoisSalesPageLibraryDetailPage.tsx`
+
+## 2026-06-11 — Correção de compilação do worker de Biblioteca de Páginas MOIS
+
+- Corrigida a causa-raiz do erro de compilação que aparecia como `cannot find symbol: variable log` no worker MOIS.
+- O arquivo de processamento de aquecimento continha métodos duplicados após a evolução da Etapa 3; isso interrompia a compilação e impedia o Lombok de gerar corretamente o logger nas classes anotadas.
+- Removida a duplicidade mantendo a versão mais específica da sugestão de investigação da máquina de venda.
+
+Arquivo principal:
+- `mois-sales-library-worker/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/marketwarmup/MarketWarmupProcessor.java`

--- a/mois-sales-library-worker/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/marketwarmup/MarketWarmupProcessor.java
+++ b/mois-sales-library-worker/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/marketwarmup/MarketWarmupProcessor.java
@@ -269,45 +269,6 @@ public class MarketWarmupProcessor {
         if (socialProofSignals == 0) {
             return "Coletar depoimentos, resultados e provas usadas para converter a audiência em compra.";
         }
-        return "Montar o mapa da máquina de venda: autoridade → canal → captura/aula/live → oferta → prova social → checkout.";
-    }
-
-    /**
-     * Resume alavancas prováveis que explicam a venda do produto observado.
-     */
-    private List<String> buildSuccessLevers(int authoritySignals, int socialProofSignals, int competitorSignals, int channelSignals) {
-        List<String> levers = new ArrayList<>();
-        if (authoritySignals > 0) {
-            levers.add("Autoridade pessoal ou marca especialista aparece como provável motor de confiança.");
-        }
-        if (channelSignals > 0) {
-            levers.add("Canais públicos como Instagram, YouTube, TikTok, WhatsApp ou lives aparecem como ativos de aquisição/aquecimento.");
-        }
-        if (socialProofSignals > 0) {
-            levers.add("Depoimentos, alunas ou resultados aparecem como prova social para conversão.");
-        }
-        if (competitorSignals > 0) {
-            levers.add("Há sinais de distribuição por oferta, afiliados, marketplace ou bônus.");
-        }
-        if (levers.isEmpty()) {
-            levers.add("Alavancas de sucesso ainda não ficaram claras nas fontes públicas V1.");
-        }
-        return levers;
-    }
-
-    /**
-     * Sugere a próxima investigação necessária para explicar como o produtor chegou ao sucesso.
-     */
-    private String buildNextInvestigationSuggestion(int authoritySignals, int socialProofSignals, int channelSignals) {
-        if (authoritySignals == 0) {
-            return "Buscar pessoa pública, fundador, especialista ou marca por trás do produto.";
-        }
-        if (channelSignals == 0) {
-            return "Mapear quais canais levam audiência para a oferta: Instagram, YouTube, TikTok, WhatsApp, lives, afiliados ou anúncios.";
-        }
-        if (socialProofSignals == 0) {
-            return "Coletar depoimentos, resultados e provas usadas para converter a audiência em compra.";
-        }
         return "Conteúdo público de autoridade → audiência em canal forte → cadastro/aula/live/WhatsApp → oferta principal → prova social/comunidade → checkout/marketplace.";
     }
 


### PR DESCRIPTION
### Motivation
- A compilation failure occurred in the MOIS sales-library worker with many `cannot find symbol: variable log` errors and duplicate-method diagnostics in `MarketWarmupProcessor`, blocking the build and Lombok logger generation.

### Description
- Removed duplicated helper methods `buildSuccessLevers` and `buildNextInvestigationSuggestion` from `mois-sales-library-worker/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/marketwarmup/MarketWarmupProcessor.java` to eliminate method duplication and let Lombok generate the logger as expected. 
- Updated `docs/registros/mois1.md` to record the root cause and the fix for the MOIS worker compilation issue.
- Cleaned up the class so only a single canonical implementation of the helper methods remains.

### Testing
- Ran `mvn test -DskipTests=false` in the `mois-sales-library-worker` module and the build completed successfully (`BUILD SUCCESS`).
- Unit tests executed include `MarketWarmupProcessorTest`, `DuckDuckGoPublicWebSearchClientTest`, `MarketWarmupQueryBuilderTest` and the ArchUnit suite, with total tests run = 11 and all passing.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2a965c7ab083219a7161d2d1af2c0d)