### PR TITLE
Exibe custos da criação de hipótese

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/hypothesis/pain/service/HypothesisPainStageService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/hypothesis/pain/service/HypothesisPainStageService.java
@@ -1,5 +1,6 @@
 package com.marketinghub.hypothesis.pain.service;
 
+import com.marketinghub.cost.CostAttributionService;
 import com.marketinghub.hypothesis.pain.HypothesisPainStageExecution;
 import com.marketinghub.hypothesis.pain.service.detailStageExecution.HypothesisPainExecutionDetailResponse;
 import com.marketinghub.hypothesis.pain.service.listStageExecutions.HypothesisPainExecutionSummaryResponse;
@@ -11,6 +12,7 @@ import com.marketinghub.niche.MarketNiche;
 import com.marketinghub.repository.jpa.hypothesis.HypothesisPainStageExecutionRepository;
 import com.marketinghub.repository.jpa.niche.MarketNicheRepository;
 import jakarta.persistence.EntityNotFoundException;
+import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
 import java.time.Instant;
 import java.util.List;
@@ -34,13 +36,16 @@ public class HypothesisPainStageService {
 
     private final MarketNicheRepository marketNicheRepository;
     private final HypothesisPainStageExecutionRepository executionRepository;
+    private final CostAttributionService costAttributionService;
 
     /** Inicializa o serviço com os repositórios canônicos de nicho e execução de etapa. */
     public HypothesisPainStageService(
             MarketNicheRepository marketNicheRepository,
-            HypothesisPainStageExecutionRepository executionRepository) {
+            HypothesisPainStageExecutionRepository executionRepository,
+            CostAttributionService costAttributionService) {
         this.marketNicheRepository = marketNicheRepository;
         this.executionRepository = executionRepository;
+        this.costAttributionService = costAttributionService;
     }
 
     /** Inicia uma nova execução manual da etapa Dor para o nicho informado. */
@@ -68,7 +73,7 @@ public class HypothesisPainStageService {
     @Transactional(readOnly = true)
     public List<HypothesisPainExecutionSummaryResponse> listStageExecutions(Long marketNicheId, boolean includeCompleted) {
         List<HypothesisPainStageExecution> executions = includeCompleted
-                ? executionRepository.findTop20ByMarketNicheIdAndStageCodeOrderByExecutionRequestedAtDesc(marketNicheId, STAGE_CODE)
+                ? executionRepository.findByMarketNicheIdAndStageCodeOrderByExecutionRequestedAtDesc(marketNicheId, STAGE_CODE)
                 : executionRepository.findTop20ByMarketNicheIdAndStageCodeAndStatusNotOrderByExecutionRequestedAtDesc(
                         marketNicheId,
                         STAGE_CODE,
@@ -155,6 +160,8 @@ public class HypothesisPainStageService {
             }
             execution.setInputTokens(request.inputTokens());
             execution.setOutputTokens(request.outputTokens());
+            BigDecimal previousCostUsd = execution.getCostUsd();
+            BigDecimal costDeltaUsd = calculateCostDeltaUsd(previousCostUsd, request.costUsd());
             execution.setCostUsd(request.costUsd());
             String normalizedErrorDetail = StringUtils.hasText(request.errorDetail()) ? request.errorDetail().trim() : null;
             String normalizedErrorMessage = normalizeErrorMessage(request.errorMessage(), normalizedErrorDetail);
@@ -163,6 +170,7 @@ public class HypothesisPainStageService {
             execution.setCompletedAt(Instant.now());
             execution.setStatus(normalizedErrorMessage != null ? STATUS_FAILED : STATUS_COMPLETED);
             executionRepository.save(execution);
+            costAttributionService.addUsdCostToNiche(execution.getMarketNiche(), costDeltaUsd);
         } catch (RuntimeException ex) {
             log.error(
                     "Erro ao concluir resposta da etapa Dor (idJob={}, marketNicheId={}, stageCode={}, openAiJobId={}, modelResponseLength={}, errorMessage={})",
@@ -175,6 +183,13 @@ public class HypothesisPainStageService {
                     ex);
             throw ex;
         }
+    }
+
+    /** Calcula a diferença de custo em USD para manter o custo do nicho idempotente. */
+    private BigDecimal calculateCostDeltaUsd(BigDecimal previousCostUsd, BigDecimal currentCostUsd) {
+        BigDecimal previous = previousCostUsd != null ? previousCostUsd : BigDecimal.ZERO;
+        BigDecimal current = currentCostUsd != null ? currentCostUsd : BigDecimal.ZERO;
+        return current.subtract(previous);
     }
 
     /** Normaliza a mensagem de erro e garante status de falha quando há detalhe técnico. */

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/hypothesis/HypothesisPainStageExecutionRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/hypothesis/HypothesisPainStageExecutionRepository.java
@@ -18,8 +18,8 @@ public interface HypothesisPainStageExecutionRepository extends JpaRepository<Hy
     @EntityGraph(attributePaths = {"marketNiche", "hypothesis"})
     List<HypothesisPainStageExecution> findTop20ByStageCodeAndStatusOrderByExecutionRequestedAtAsc(String stageCode, String status);
 
-    /** Lista as últimas vinte execuções de uma etapa dentro de um nicho. */
-    List<HypothesisPainStageExecution> findTop20ByMarketNicheIdAndStageCodeOrderByExecutionRequestedAtDesc(Long marketNicheId, String stageCode);
+    /** Lista todas as execuções de uma etapa dentro de um nicho para totalização de custo. */
+    List<HypothesisPainStageExecution> findByMarketNicheIdAndStageCodeOrderByExecutionRequestedAtDesc(Long marketNicheId, String stageCode);
 
     /** Lista as últimas vinte execuções de uma etapa dentro de um nicho excluindo um status operacional. */
     List<HypothesisPainStageExecution> findTop20ByMarketNicheIdAndStageCodeAndStatusNotOrderByExecutionRequestedAtDesc(

--- a/backend/ads-service/src/test/java/com/marketinghub/hypothesis/pain/service/HypothesisPainStageServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/hypothesis/pain/service/HypothesisPainStageServiceTest.java
@@ -1,0 +1,80 @@
+package com.marketinghub.hypothesis.pain.service;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.marketinghub.cost.CostAttributionService;
+import com.marketinghub.hypothesis.pain.HypothesisPainStageExecution;
+import com.marketinghub.hypothesis.pain.service.recebeResposta.RecebeRespostaRequest;
+import com.marketinghub.niche.MarketNiche;
+import com.marketinghub.repository.jpa.hypothesis.HypothesisPainStageExecutionRepository;
+import com.marketinghub.repository.jpa.niche.MarketNicheRepository;
+import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/** Responsabilidade: validar a orquestração de custos da etapa Dor do pipeline de hipótese. */
+@ExtendWith(MockitoExtension.class)
+class HypothesisPainStageServiceTest {
+
+    @Mock
+    private MarketNicheRepository marketNicheRepository;
+
+    @Mock
+    private HypothesisPainStageExecutionRepository executionRepository;
+
+    @Mock
+    private CostAttributionService costAttributionService;
+
+    private HypothesisPainStageService service;
+
+    /** Prepara o serviço com dependências isoladas para cada teste. */
+    @BeforeEach
+    void setup() {
+        service = new HypothesisPainStageService(
+                marketNicheRepository,
+                executionRepository,
+                costAttributionService);
+    }
+
+    /** Deve atribuir ao nicho somente o delta de custo recebido para evitar soma duplicada em reprocessamentos. */
+    @Test
+    void markCompletedFromResponseAttributesOnlyCostDeltaToNiche() {
+        String idJob = "9bb83a22-3894-43bd-9752-374f84eb6a2c";
+        MarketNiche niche = new MarketNiche();
+        niche.setId(18L);
+        HypothesisPainStageExecution execution = HypothesisPainStageExecution.builder()
+                .idJob(idJob.getBytes(StandardCharsets.UTF_8))
+                .marketNicheId(18L)
+                .marketNiche(niche)
+                .stageCode("hypothesis-pain")
+                .status("PROCESSANDO")
+                .costUsd(new BigDecimal("0.010000"))
+                .build();
+        RecebeRespostaRequest request = new RecebeRespostaRequest(
+                18L,
+                "hypothesis-pain",
+                "{\"pain\":\"dor validada\"}",
+                1200,
+                300,
+                new BigDecimal("0.015000"),
+                "openai-job-1",
+                null,
+                null);
+
+        when(executionRepository.findTopByIdJobOrderByExecutionRequestedAtDesc(idJob.getBytes(StandardCharsets.UTF_8)))
+                .thenReturn(Optional.of(execution));
+        when(executionRepository.save(any(HypothesisPainStageExecution.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        service.markCompletedFromResponse(idJob, request);
+
+        verify(costAttributionService).addUsdCostToNiche(niche, new BigDecimal("0.005000"));
+    }
+}

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -4331,3 +4331,10 @@
   - docs/registros/experimentos.md
   - frontend/src/pages/hypothesis/NewHypothesisPage.tsx
   - frontend/src/pages/hypothesis/NewHypothesisPage.test.tsx
+
+## 2026-06-11 — Custos na tela de nova hipótese
+
+- solicitação: exibir o custo de cada execução da etapa Dor, o custo total geral da criação da hipótese e garantir atualização do custo acumulado do nicho.
+- causa-raiz: a tela inicial mostrava apenas status e job atual, apesar de o backend já receber `costUsd` da IA; além disso, a conclusão do job gravava o custo da execução, mas não propagava esse valor para o custo acumulado do nicho.
+- foi feito: a tela passou a mostrar custo total e tabela de execuções com custo individual, e o backend passou a atribuir ao nicho somente o delta de custo em USD convertido pela regra central de custos, evitando duplicidade em reprocessamentos.
+- prevenção: adicionados testes de frontend para a visibilidade dos custos e teste unitário backend para garantir atribuição idempotente do delta ao nicho.

--- a/frontend/src/pages/hypothesis/NewHypothesisPage.test.tsx
+++ b/frontend/src/pages/hypothesis/NewHypothesisPage.test.tsx
@@ -39,23 +39,28 @@ describe("NewHypothesisPage", () => {
           stageCode: "hypothesis-pain",
           status: "INICIADO",
           executionRequestedAt: "2026-06-11T00:16:01Z",
+          completedAt: "2026-06-11T00:20:01Z",
+          costUsd: 0.012345,
         },
       ],
     });
 
     renderPage();
 
-    const link = await screen.findByRole("link", {
+    const links = await screen.findAllByRole("link", {
       name: "9bb83a22-3894-43bd-9752-374f84eb6a2c",
     });
 
-    expect(link).toHaveAttribute(
+    expect(links[0]).toHaveAttribute(
       "href",
       "/niches/18/hypothesis-pipeline/pain/stage-executions/9bb83a22-3894-43bd-9752-374f84eb6a2c",
     );
     expect(screen.queryByText("Dor de superfície")).not.toBeInTheDocument();
     expect(
-      screen.queryByRole("columnheader", { name: "Job" }),
-    ).not.toBeInTheDocument();
+      screen.getByText("Custo total geral da criação da hipótese:", {
+        exact: false,
+      }),
+    ).toBeInTheDocument();
+    expect(screen.getAllByText(/US\$\s*0,012345/)).not.toHaveLength(0);
   });
 });

--- a/frontend/src/pages/hypothesis/NewHypothesisPage.tsx
+++ b/frontend/src/pages/hypothesis/NewHypothesisPage.tsx
@@ -13,6 +13,7 @@ interface PainExecution {
   executionRequestedAt?: string;
   processingStartedAt?: string;
   completedAt?: string;
+  costUsd?: number | string | null;
   errorMessage?: string;
 }
 
@@ -25,6 +26,23 @@ const RUNNING_STATUSES = new Set([
 function formatDate(value?: string) {
   if (!value) return "—";
   return new Date(value).toLocaleString("pt-BR");
+}
+
+function parseCostUsd(value?: number | string | null) {
+  if (value === null || value === undefined || value === "") return null;
+  const numericValue = Number(value);
+  return Number.isFinite(numericValue) ? numericValue : null;
+}
+
+function formatCostUsd(value?: number | string | null) {
+  const numericValue = parseCostUsd(value);
+  if (numericValue === null) return "—";
+  return new Intl.NumberFormat("pt-BR", {
+    style: "currency",
+    currency: "USD",
+    minimumFractionDigits: 4,
+    maximumFractionDigits: 6,
+  }).format(numericValue);
 }
 
 export default function NewHypothesisPage() {
@@ -67,6 +85,10 @@ export default function NewHypothesisPage() {
 
   const executions = executionsQuery.data ?? [];
   const latest = executions[0];
+  const totalCreationCostUsd = executions.reduce((total, item) => {
+    const cost = parseCostUsd(item.costUsd);
+    return cost === null ? total : total + cost;
+  }, 0);
   const hasRunningExecution = executions.some((item) =>
     RUNNING_STATUSES.has(item.status),
   );
@@ -109,9 +131,15 @@ export default function NewHypothesisPage() {
         </div>
         <div className="card-body">
           {nicheId && (
-            <p className="mb-3">
-              <strong>Nicho recebido:</strong> #{nicheId}
-            </p>
+            <div className="d-flex flex-column flex-md-row gap-2 justify-content-between mb-3">
+              <p className="mb-0">
+                <strong>Nicho recebido:</strong> #{nicheId}
+              </p>
+              <p className="mb-0">
+                <strong>Custo total geral da criação da hipótese:</strong>{" "}
+                {formatCostUsd(totalCreationCostUsd)}
+              </p>
+            </div>
           )}
 
           {executionsQuery.isLoading ? (
@@ -135,6 +163,9 @@ export default function NewHypothesisPage() {
                         {latest.jobid}
                       </Link>
                     </div>
+                    <div className="text-muted small">
+                      Custo da última execução: {formatCostUsd(latest.costUsd)}
+                    </div>
                   </div>
                   <div className="text-muted small text-md-end">
                     Solicitado em {formatDate(latest.executionRequestedAt)}
@@ -147,6 +178,39 @@ export default function NewHypothesisPage() {
                     {latest.errorMessage}
                   </div>
                 )}
+              </div>
+
+              <div className="table-responsive">
+                <table className="table table-sm align-middle mb-0">
+                  <thead>
+                    <tr>
+                      <th>Execução</th>
+                      <th>Status</th>
+                      <th>Solicitado em</th>
+                      <th>Concluído em</th>
+                      <th className="text-end">Custo da execução</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {executions.map((execution) => (
+                      <tr key={execution.jobid}>
+                        <td>
+                          <Link
+                            to={`/niches/${nicheId}/hypothesis-pipeline/pain/stage-executions/${execution.jobid}`}
+                          >
+                            {execution.jobid}
+                          </Link>
+                        </td>
+                        <td>{execution.status}</td>
+                        <td>{formatDate(execution.executionRequestedAt)}</td>
+                        <td>{formatDate(execution.completedAt)}</td>
+                        <td className="text-end">
+                          {formatCostUsd(execution.costUsd)}
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
               </div>
             </div>
           )}


### PR DESCRIPTION
### Motivation
- Tornar visível na tela de "Nova hipótese" os custos gerados pela etapa Dor (custo por execução e total da criação da hipótese) para controle financeiro e tomada de decisão.
- Garantir que o custo acumulado do nicho seja atualizado de forma idempotente ao receber respostas da IA, evitando duplicidade quando um job for reprocessado.

### Description
- Frontend: adiciona `parseCostUsd`/`formatCostUsd`, calcula `totalCreationCostUsd`, exibe o `Custo total geral da criação da hipótese`, mostra `Custo da última execução` e adiciona tabela com custo de cada execução em `frontend/src/pages/hypothesis/NewHypothesisPage.tsx`.
- Backend: injeta `CostAttributionService`, calcula `costDeltaUsd = current - previous`, persiste `execution.costUsd` e chama `costAttributionService.addUsdCostToNiche(...)` com o delta, além de adicionar `calculateCostDeltaUsd(...)` em `HypothesisPainStageService`.
- Data: altera a consulta para listar todas as execuções do nicho/etapa (`findByMarketNicheIdAndStageCodeOrderByExecutionRequestedAtDesc`) para totalização correta de custo no repositório `HypothesisPainStageExecutionRepository`.
- Tests & docs: adiciona teste unitário backend `HypothesisPainStageServiceTest` que valida atribuição do delta e ajusta/escreve teste frontend `NewHypothesisPage.test.tsx` para validar exibição dos custos, e atualiza `docs/registros/experimentos.md` com o registro da mudança.

### Testing
- Frontend unit test `vitest` was run with `npm test -- --run src/pages/hypothesis/NewHypothesisPage.test.tsx` and passed.
- Typecheck was run with `npm run typecheck` (`tsc --noEmit`) and passed.
- Backend unit test `HypothesisPainStageServiceTest` was run with `mvn -Dtest=HypothesisPainStageServiceTest test` and passed.
- Repository/format checks (`git diff --check`) were run and reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2a951ce83c832191504b57afe342fa)