### PR TITLE
OPRM NichoCNAE: alinhar teste do prompt da etapa 2 e atualizar documentação

### DIFF
--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -401,3 +401,8 @@
 - Corrigida a causa-raiz do erro recorrente `Query sem marcador de MEI/autônomo brasileiro` no ciclo de rotina: a etapa `niche-research-seed-builder` deixou de executar o validador bloqueante no coletor e o backend passou a gravar seed/queries com defaults quando algum campo estrutural vier ausente.
 - A tela `/oprm/pipeline` agora identifica a etapa exata da falha a partir da mensagem técnica do ciclo, mostrando `Etapa 2 · Seed de Pesquisa do Nicho` quando o erro vem da geração de seed.
 - Prevenção de recorrência: falhas por formato incompleto do modelo não travam mais a criação da pesquisa; as etapas seguintes continuam responsáveis por buscar fontes, extrair sinais e filtrar qualidade.
+
+## 2026-06-11 — OPRM NichoCNAE: alinhamento do teste do prompt da etapa 2
+
+- Corrigida a causa-raiz da falha do teste `NicheResearchSeedBuilderPromptBuilderTest`: o teste ainda exigia marcadores literais de fonte Brasil/domínio `.br` e objetivos antigos, enquanto a regra operacional atual da etapa 2 passou a confiar no modelo e não bloquear por marcador literal.
+- O teste agora valida o comportamento correto do prompt: pesquisa de rotina real, proibição de solução/oferta/produto/ferramenta, ausência de exigência de marcadores literais e prevenção de metadado técnico no texto funcional.

--- a/oprm-coletor-mei/src/test/java/com/marketinghub/nichocnae/nicheresearchseedbuilder/NicheResearchSeedBuilderPromptBuilderTest.java
+++ b/oprm-coletor-mei/src/test/java/com/marketinghub/nichocnae/nicheresearchseedbuilder/NicheResearchSeedBuilderPromptBuilderTest.java
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.Test;
 class NicheResearchSeedBuilderPromptBuilderTest {
     private final NicheResearchSeedBuilderPromptBuilder promptBuilder = new NicheResearchSeedBuilderPromptBuilder();
 
-    /** Deve declarar explicitamente rotina/dificuldades e proibir produto, oferta, ferramenta e solução. */
+    /** Deve declarar rotina real, confiar no modelo para marcadores literais e proibir solução comercial. */
     @Test
     void shouldBuildRoutineRealityPromptWithoutSolutionSearch() {
         String prompt = promptBuilder.buildPrompt(pending());
@@ -18,16 +18,15 @@ class NicheResearchSeedBuilderPromptBuilderTest {
         assertThat(prompt)
                 .contains("profissional brasileiro MEI/autônomo")
                 .contains("português do Brasil")
-                .contains("fontes do Brasil")
-                .contains("domínios .br")
                 .contains("tarefas")
-                .contains("dificuldades")
+                .contains("não force marcador literal")
+                .contains("Não inclua metadado técnico")
                 .contains("Não proponha solução")
                 .contains("Não procure produto")
                 .contains("Não procure oferta")
                 .contains("Não procure ferramenta")
-                .contains("DAILY_OPERATION_PAIN_DISCOVERY")
-                .contains("MEI_ROUTINE_DISCOVERY")
+                .doesNotContain("fontes do Brasil")
+                .doesNotContain("domínios .br")
                 .doesNotContain("PRODUCT_SERVICE_DISCOVERY")
                 .doesNotContain("OFFER_PATTERN_DISCOVERY")
                 .doesNotContain("SALES_PAIN_DISCOVERY");


### PR DESCRIPTION
### Motivation
- Remover bloqueios por marcadores literais e evitar falsos negativos na etapa `niche-research-seed-builder`, passando a confiar no modelo para conteúdo semântico. 
- Atualizar o teste que ainda exigia marcadores literais `Brasil`/`.br` e objetivos antigos para refletir a nova regra operacional da etapa 2. 
- Documentar o alinhamento do teste no registro histórico dos OPRM para rastreabilidade operacional.

### Description
- Atualiza `docs/registros/oprm1.md` adicionando a seção "2026-06-11 — OPRM NichoCNAE: alinhamento do teste do prompt da etapa 2" que descreve a correção e o comportamento esperado do prompt. 
- Modifica `oprm-coletor-mei/src/test/java/.../NicheResearchSeedBuilderPromptBuilderTest.java` para remover asserções que exigiam `fontes do Brasil` e `domínios .br`, para exigir que o prompt não force marcadores literais e não inclua metadado técnico, e para proibir busca por solução/oferta/produto/ferramenta. 
- Ajusta asserções para eliminar checagens de tokens de objetivos antigos e preservar as validações de atividades/rotina esperadas no prompt.

### Testing
- Executed unit tests for the `oprm-coletor-mei` module via `mvn test`, including `NicheResearchSeedBuilderPromptBuilderTest`. 
- All tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2a95f7cb88832190a4b0571d28be6f)