### PR TITLE
Fix hypothesis result stage compilation

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/hypothesis/pain/service/HypothesisPainStageService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/hypothesis/pain/service/HypothesisPainStageService.java
@@ -152,6 +152,25 @@ public class HypothesisPainStageService {
                 .toList();
     }
 
+    /** Garante que a etapa Dor tenha sido concluída com resposta antes de liberar Resultado. */
+    private void requireCompletedPain(Long marketNicheId) {
+        if (!StringUtils.hasText(latestCompletedPainResponse(marketNicheId))) {
+            throw new IllegalStateException(
+                    "A etapa Dor precisa estar concluída antes de iniciar Resultado para o nicho: " + marketNicheId);
+        }
+    }
+
+    /** Retorna a resposta da Dor concluída mais recente para contextualizar etapas seguintes. */
+    private String latestCompletedPainResponse(Long marketNicheId) {
+        return executionRepository.findTopByMarketNicheIdAndStageCodeAndStatusOrderByExecutionRequestedAtDesc(
+                        marketNicheId,
+                        STAGE_CODE,
+                        STATUS_COMPLETED)
+                .map(HypothesisPainStageExecution::getModelResponse)
+                .filter(StringUtils::hasText)
+                .orElse(null);
+    }
+
     /** Marca uma execução como em processamento para evitar recaptura por outro ciclo do worker. */
     @Transactional
     public void markRunning(String idJob) {

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/hypothesis/HypothesisPainStageExecutionRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/hypothesis/HypothesisPainStageExecutionRepository.java
@@ -14,6 +14,12 @@ public interface HypothesisPainStageExecutionRepository extends JpaRepository<Hy
     /** Busca a execução mais recente de uma etapa dentro de um nicho. */
     Optional<HypothesisPainStageExecution> findTopByMarketNicheIdAndStageCodeOrderByExecutionRequestedAtDesc(Long marketNicheId, String stageCode);
 
+    /** Busca a execução concluída mais recente de uma etapa dentro de um nicho. */
+    Optional<HypothesisPainStageExecution> findTopByMarketNicheIdAndStageCodeAndStatusOrderByExecutionRequestedAtDesc(
+            Long marketNicheId,
+            String stageCode,
+            String status);
+
     /** Busca as execuções mais antigas de uma etapa com nicho carregado. */
     @EntityGraph(attributePaths = {"marketNiche", "hypothesis"})
     List<HypothesisPainStageExecution> findTop20ByStageCodeAndStatusOrderByExecutionRequestedAtAsc(String stageCode, String status);

--- a/backend/ads-service/src/test/java/com/marketinghub/hypothesis/pain/service/HypothesisPainStageServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/hypothesis/pain/service/HypothesisPainStageServiceTest.java
@@ -1,7 +1,8 @@
 package com.marketinghub.hypothesis.pain.service;
 
-import static org.mockito.ArgumentMatchers.any;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -13,6 +14,8 @@ import com.marketinghub.repository.jpa.hypothesis.HypothesisPainStageExecutionRe
 import com.marketinghub.repository.jpa.niche.MarketNicheRepository;
 import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
+import java.time.Instant;
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -87,18 +90,52 @@ class HypothesisPainStageServiceTest {
     void startResultRequiresCompletedPain() {
         MarketNiche niche = new MarketNiche();
         niche.setId(18L);
-        HypothesisPainStageExecution painExecution = HypothesisPainStageExecution.builder()
-                .marketNicheId(18L)
-                .marketNiche(niche)
-                .stageCode("hypothesis-pain")
-                .status("INICIADO")
-                .build();
-
         when(marketNicheRepository.findById(18L)).thenReturn(Optional.of(niche));
-        when(executionRepository.findTopByMarketNicheIdAndStageCodeOrderByExecutionRequestedAtDesc(18L, "hypothesis-pain"))
-                .thenReturn(Optional.of(painExecution));
+        when(executionRepository.findTopByMarketNicheIdAndStageCodeAndStatusOrderByExecutionRequestedAtDesc(
+                        18L,
+                        "hypothesis-pain",
+                        "CONCLUIDO"))
+                .thenReturn(Optional.empty());
 
         assertThrows(IllegalStateException.class, () -> service.startResult(18L));
+    }
+
+    /** Deve entregar a resposta da Dor concluída para contextualizar a etapa Resultado no Worker AI. */
+    @Test
+    void listResultPendingIncludesLatestCompletedPainResponse() {
+        MarketNiche niche = new MarketNiche();
+        niche.setId(18L);
+        niche.setName("Produtores digitais");
+        String resultJob = "3bc56a94-45bc-48bf-8e8d-e1f4f8b881df";
+        HypothesisPainStageExecution resultExecution = HypothesisPainStageExecution.builder()
+                .idJob(resultJob.getBytes(StandardCharsets.UTF_8))
+                .marketNicheId(18L)
+                .marketNiche(niche)
+                .stageCode("hypothesis-result")
+                .status("INICIADO")
+                .executionRequestedAt(Instant.parse("2026-06-11T12:00:00Z"))
+                .build();
+        HypothesisPainStageExecution completedPain = HypothesisPainStageExecution.builder()
+                .marketNicheId(18L)
+                .stageCode("hypothesis-pain")
+                .status("CONCLUIDO")
+                .modelResponse("{\"pain\":\"dor validada\"}")
+                .build();
+
+        when(executionRepository.findTop20ByStageCodeAndStatusOrderByExecutionRequestedAtAsc(
+                        "hypothesis-result",
+                        "INICIADO"))
+                .thenReturn(List.of(resultExecution));
+        when(executionRepository.findTopByMarketNicheIdAndStageCodeAndStatusOrderByExecutionRequestedAtDesc(
+                        18L,
+                        "hypothesis-pain",
+                        "CONCLUIDO"))
+                .thenReturn(Optional.of(completedPain));
+
+        var pending = service.listResultPending();
+
+        assertEquals(1, pending.size());
+        assertEquals("{\"pain\":\"dor validada\"}", pending.getFirst().painModelResponse());
     }
 
 }

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -4364,3 +4364,10 @@
 - causa-raiz: a tela e os endpoints estavam presos ao primeiro passo `hypothesis-pain`, impedindo evolução sequencial do framework Dor → Resultado → Mecanismo → Prova → Oferta.
 - foi feito: adicionada a etapa 2 Resultado com card próprio na tela de nova hipótese, endpoints públicos e internos, reaproveitamento da tabela auditável de execuções, bloqueio para iniciar Resultado sem Dor concluída e worker AI isolado com prompt/schema próprios.
 - prevenção: o backend agora diferencia os estágios por `stageCode` e a etapa Resultado recebe a resposta concluída da Dor como contexto obrigatório para reduzir risco de promessa desconectada da dor real.
+
+## 2026-06-11 — Correção de compilação da etapa Resultado da hipótese
+
+- diagnóstico: o backend chamava os métodos internos `requireCompletedPain` e `latestCompletedPainResponse` na orquestração da etapa Resultado, mas esses métodos não tinham sido implementados na classe de serviço.
+- causa-raiz: a evolução da etapa Resultado acoplou a liberação e o contexto ao resultado concluído da etapa Dor sem completar o contrato interno de consulta dessa dependência sequencial.
+- foi feito: implementada a busca da Dor concluída mais recente por nicho, bloqueando Resultado quando não há resposta válida e entregando essa resposta ao Worker AI nos jobs pendentes da etapa Resultado.
+- prevenção: adicionado teste unitário para garantir que a etapa Resultado receba a resposta concluída da Dor como contexto obrigatório.


### PR DESCRIPTION
### Motivation
- The hypothesis Result stage referenced helper methods that were not implemented, causing compilation failures and preventing the Result stage from being blocked when the Pain stage was not completed.
- Result jobs processed by the Worker AI must receive the latest completed Pain response as context to avoid producing disconnected results.

### Description
- Implemented `requireCompletedPain` and `latestCompletedPainResponse` in `HypothesisPainStageService` to validate and fetch the latest completed Pain response for a niche.  
- Added repository query `findTopByMarketNicheIdAndStageCodeAndStatusOrderByExecutionRequestedAtDesc` to `HypothesisPainStageExecutionRepository` to support the lookup.  
- Updated `listPendingByStage` to include the latest completed Pain response in the `HypothesisPainPendingExecution` payload and integrated the validation path used by `startResult`.  
- Extended and adjusted `HypothesisPainStageServiceTest` to cover the blocking behavior (`startResultRequiresCompletedPain`) and to assert that `listResultPending` includes the latest completed Pain response, and updated the experiment log in `docs/registros/experimentos.md`.

### Testing
- Ran `mvn -Dtest=HypothesisPainStageServiceTest test` in `backend/ads-service` and the test class executed successfully with 3 tests passing.  
- Ran `mvn -DskipTests compile` in `backend/ads-service` and compilation completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2ad2de95e48321a01f09ce64b54fb6)