### PR TITLE
Add Etapa 3 (Mecanismo) to hypothesis new-page and backend pipeline

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/hypothesis/pain/controller/HypothesisPainStageController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/hypothesis/pain/controller/HypothesisPainStageController.java
@@ -44,6 +44,12 @@ public class HypothesisPainStageController {
         return ResponseEntity.accepted().body(service.startResult(nicheId));
     }
 
+    /** Registra uma execução inicial da etapa Mecanismo para um nicho. */
+    @PostMapping("/niches/{nicheId}/hypothesis-pipeline/mechanism/start")
+    public ResponseEntity<HypothesisPainStartResponse> startMechanism(@PathVariable Long nicheId) {
+        return ResponseEntity.accepted().body(service.startMechanism(nicheId));
+    }
+
     /** Lista execuções da etapa Dor para acompanhamento na tela de nova hipótese. */
     @GetMapping("/niches/{nicheId}/hypothesis-pipeline/pain/stage-executions")
     public ResponseEntity<List<HypothesisPainExecutionSummaryResponse>> listStageExecutions(
@@ -60,6 +66,14 @@ public class HypothesisPainStageController {
         return ResponseEntity.ok(service.listResultStageExecutions(nicheId, includeCompleted));
     }
 
+    /** Lista execuções da etapa Mecanismo para acompanhamento na tela de nova hipótese. */
+    @GetMapping("/niches/{nicheId}/hypothesis-pipeline/mechanism/stage-executions")
+    public ResponseEntity<List<HypothesisPainExecutionSummaryResponse>> listMechanismStageExecutions(
+            @PathVariable Long nicheId,
+            @RequestParam(defaultValue = "true") boolean includeCompleted) {
+        return ResponseEntity.ok(service.listMechanismStageExecutions(nicheId, includeCompleted));
+    }
+
     /** Consulta detalhe auditável de uma execução da etapa Dor vinculada ao nicho. */
     @GetMapping("/niches/{nicheId}/hypothesis-pipeline/pain/stage-executions/{idJob}")
     public ResponseEntity<HypothesisPainExecutionDetailResponse> detailForNiche(
@@ -71,6 +85,14 @@ public class HypothesisPainStageController {
     /** Consulta detalhe auditável de uma execução da etapa Resultado vinculada ao nicho. */
     @GetMapping("/niches/{nicheId}/hypothesis-pipeline/result/stage-executions/{idJob}")
     public ResponseEntity<HypothesisPainExecutionDetailResponse> detailResultForNiche(
+            @PathVariable Long nicheId,
+            @PathVariable String idJob) {
+        return ResponseEntity.ok(service.detailForNiche(nicheId, idJob));
+    }
+
+    /** Consulta detalhe auditável de uma execução da etapa Mecanismo vinculada ao nicho. */
+    @GetMapping("/niches/{nicheId}/hypothesis-pipeline/mechanism/stage-executions/{idJob}")
+    public ResponseEntity<HypothesisPainExecutionDetailResponse> detailMechanismForNiche(
             @PathVariable Long nicheId,
             @PathVariable String idJob) {
         return ResponseEntity.ok(service.detailForNiche(nicheId, idJob));
@@ -94,15 +116,29 @@ public class HypothesisPainStageController {
         return service.listResultPending();
     }
 
+    /** Lista jobs pendentes da etapa Mecanismo para processamento pelo Worker AI. */
+    @GetMapping("/internal/hypothesis-pipeline/mechanism/stage-executions/pending")
+    public List<HypothesisPainPendingExecution> mechanismPending() {
+        return service.listMechanismPending();
+    }
+
     /** Marca uma execução de etapa como em processamento. */
-    @PostMapping({"/internal/hypothesis-pipeline/pain/stage-executions/{idJob}/running", "/internal/hypothesis-pipeline/result/stage-executions/{idJob}/running"})
+    @PostMapping({
+            "/internal/hypothesis-pipeline/pain/stage-executions/{idJob}/running",
+            "/internal/hypothesis-pipeline/result/stage-executions/{idJob}/running",
+            "/internal/hypothesis-pipeline/mechanism/stage-executions/{idJob}/running"
+    })
     public ResponseEntity<Void> running(@PathVariable String idJob) {
         service.markRunning(idJob);
         return ResponseEntity.accepted().build();
     }
 
     /** Recebe prompt, schema e request cru enviados para IA e marca a execução aguardando retorno. */
-    @PostMapping({"/internal/hypothesis-pipeline/pain/stage-executions/{idJob}/recebe-prompt", "/internal/hypothesis-pipeline/result/stage-executions/{idJob}/recebe-prompt"})
+    @PostMapping({
+            "/internal/hypothesis-pipeline/pain/stage-executions/{idJob}/recebe-prompt",
+            "/internal/hypothesis-pipeline/result/stage-executions/{idJob}/recebe-prompt",
+            "/internal/hypothesis-pipeline/mechanism/stage-executions/{idJob}/recebe-prompt"
+    })
     public ResponseEntity<Void> recebePrompt(
             @PathVariable String idJob,
             @Valid @RequestBody RecebePromptRequest payload) {
@@ -126,7 +162,11 @@ public class HypothesisPainStageController {
     }
 
     /** Recebe a resposta da IA para uma etapa e conclui a execução do job. */
-    @PostMapping({"/internal/hypothesis-pipeline/pain/stage-executions/{idJob}/recebe-resposta", "/internal/hypothesis-pipeline/result/stage-executions/{idJob}/recebe-resposta"})
+    @PostMapping({
+            "/internal/hypothesis-pipeline/pain/stage-executions/{idJob}/recebe-resposta",
+            "/internal/hypothesis-pipeline/result/stage-executions/{idJob}/recebe-resposta",
+            "/internal/hypothesis-pipeline/mechanism/stage-executions/{idJob}/recebe-resposta"
+    })
     public ResponseEntity<Void> recebeResposta(
             @PathVariable String idJob,
             @Valid @RequestBody RecebeRespostaRequest payload) {

--- a/backend/ads-service/src/main/java/com/marketinghub/hypothesis/pain/service/HypothesisPainStageService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/hypothesis/pain/service/HypothesisPainStageService.java
@@ -29,6 +29,7 @@ public class HypothesisPainStageService {
     private static final Logger log = LoggerFactory.getLogger(HypothesisPainStageService.class);
     private static final String STAGE_CODE = "hypothesis-pain";
     private static final String RESULT_STAGE_CODE = "hypothesis-result";
+    private static final String MECHANISM_STAGE_CODE = "hypothesis-mechanism";
     private static final String STATUS_STARTED = "INICIADO";
     private static final String STATUS_WAITING_OPENAI_DISPATCH = "AGUARDANDO_RETORNO_OPENAI";
     private static final String STATUS_PROCESSING = "PROCESSANDO";
@@ -52,22 +53,36 @@ public class HypothesisPainStageService {
     /** Inicia uma nova execução manual da etapa Dor para o nicho informado. */
     @Transactional
     public HypothesisPainStartResponse start(Long marketNicheId) {
-        return startStage(marketNicheId, STAGE_CODE, "Dor", false);
+        return startStage(marketNicheId, STAGE_CODE, "Dor", false, false);
     }
 
     /** Inicia uma nova execução manual da etapa Resultado para o nicho informado. */
     @Transactional
     public HypothesisPainStartResponse startResult(Long marketNicheId) {
-        return startStage(marketNicheId, RESULT_STAGE_CODE, "Resultado", true);
+        return startStage(marketNicheId, RESULT_STAGE_CODE, "Resultado", true, false);
+    }
+
+    /** Inicia uma nova execução manual da etapa Mecanismo para o nicho informado. */
+    @Transactional
+    public HypothesisPainStartResponse startMechanism(Long marketNicheId) {
+        return startStage(marketNicheId, MECHANISM_STAGE_CODE, "Mecanismo", true, true);
     }
 
     /** Inicia uma nova execução manual de uma etapa do pipeline para o nicho informado. */
-    private HypothesisPainStartResponse startStage(Long marketNicheId, String stageCode, String stageLabel, boolean requiresCompletedPain) {
+    private HypothesisPainStartResponse startStage(
+            Long marketNicheId,
+            String stageCode,
+            String stageLabel,
+            boolean requiresCompletedPain,
+            boolean requiresCompletedResult) {
         Instant now = Instant.now();
         MarketNiche niche = marketNicheRepository.findById(marketNicheId)
                 .orElseThrow(() -> new EntityNotFoundException("Market niche not found: " + marketNicheId));
         if (requiresCompletedPain) {
             requireCompletedPain(marketNicheId);
+        }
+        if (requiresCompletedResult) {
+            requireCompletedResult(marketNicheId);
         }
         HypothesisPainStageExecution execution = HypothesisPainStageExecution.builder()
                 .marketNicheId(niche.getId())
@@ -94,6 +109,14 @@ public class HypothesisPainStageService {
     @Transactional(readOnly = true)
     public List<HypothesisPainExecutionSummaryResponse> listResultStageExecutions(Long marketNicheId, boolean includeCompleted) {
         return listStageExecutions(marketNicheId, RESULT_STAGE_CODE, includeCompleted);
+    }
+
+    /** Lista execuções da etapa Mecanismo para o nicho informado. */
+    @Transactional(readOnly = true)
+    public List<HypothesisPainExecutionSummaryResponse> listMechanismStageExecutions(
+            Long marketNicheId,
+            boolean includeCompleted) {
+        return listStageExecutions(marketNicheId, MECHANISM_STAGE_CODE, includeCompleted);
     }
 
     /** Lista execuções de uma etapa específica para o nicho informado. */
@@ -138,6 +161,12 @@ public class HypothesisPainStageService {
         return listPendingByStage(RESULT_STAGE_CODE);
     }
 
+    /** Lista os jobs iniciados da etapa Mecanismo para processamento pelo Worker AI. */
+    @Transactional(readOnly = true)
+    public List<HypothesisPainPendingExecution> listMechanismPending() {
+        return listPendingByStage(MECHANISM_STAGE_CODE);
+    }
+
     /** Lista os jobs iniciados de uma etapa para processamento pelo Worker AI. */
     private List<HypothesisPainPendingExecution> listPendingByStage(String stageCode) {
         return executionRepository.findTop20ByStageCodeAndStatusOrderByExecutionRequestedAtAsc(stageCode, STATUS_STARTED)
@@ -148,7 +177,8 @@ public class HypothesisPainStageService {
                         execution.getStageCode(),
                         execution.getExecutionRequestedAt(),
                         toPendingNiche(execution.getMarketNiche()),
-                        latestCompletedPainResponse(execution.getMarketNicheId())))
+                        latestCompletedPainResponse(execution.getMarketNicheId()),
+                        latestCompletedResultResponse(execution.getMarketNicheId())))
                 .toList();
     }
 
@@ -160,11 +190,29 @@ public class HypothesisPainStageService {
         }
     }
 
+    /** Garante que a etapa Resultado tenha sido concluída com resposta antes de liberar Mecanismo. */
+    private void requireCompletedResult(Long marketNicheId) {
+        if (!StringUtils.hasText(latestCompletedResultResponse(marketNicheId))) {
+            throw new IllegalStateException(
+                    "A etapa Resultado precisa estar concluída antes de iniciar Mecanismo para o nicho: " + marketNicheId);
+        }
+    }
+
     /** Retorna a resposta da Dor concluída mais recente para contextualizar etapas seguintes. */
     private String latestCompletedPainResponse(Long marketNicheId) {
+        return latestCompletedStageResponse(marketNicheId, STAGE_CODE);
+    }
+
+    /** Retorna a resposta do Resultado concluído mais recente para contextualizar Mecanismo. */
+    private String latestCompletedResultResponse(Long marketNicheId) {
+        return latestCompletedStageResponse(marketNicheId, RESULT_STAGE_CODE);
+    }
+
+    /** Retorna a resposta concluída mais recente de uma etapa para contextualizar próximas etapas. */
+    private String latestCompletedStageResponse(Long marketNicheId, String stageCode) {
         return executionRepository.findTopByMarketNicheIdAndStageCodeAndStatusOrderByExecutionRequestedAtDesc(
                         marketNicheId,
-                        STAGE_CODE,
+                        stageCode,
                         STATUS_COMPLETED)
                 .map(HypothesisPainStageExecution::getModelResponse)
                 .filter(StringUtils::hasText)

--- a/backend/ads-service/src/main/java/com/marketinghub/hypothesis/pain/service/pending/HypothesisPainPendingExecution.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/hypothesis/pain/service/pending/HypothesisPainPendingExecution.java
@@ -9,6 +9,7 @@ public record HypothesisPainPendingExecution(
         String stageCode,
         Instant executionRequestedAt,
         HypothesisPainPendingNiche niche,
-        String painModelResponse
+        String painModelResponse,
+        String resultModelResponse
 ) {
 }

--- a/backend/ads-service/src/test/java/com/marketinghub/hypothesis/pain/service/HypothesisPainStageServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/hypothesis/pain/service/HypothesisPainStageServiceTest.java
@@ -138,4 +138,79 @@ class HypothesisPainStageServiceTest {
         assertEquals("{\"pain\":\"dor validada\"}", pending.getFirst().painModelResponse());
     }
 
+    /** Deve bloquear a etapa Mecanismo quando o resultado ainda não está concluído. */
+    @Test
+    void startMechanismRequiresCompletedResult() {
+        MarketNiche niche = new MarketNiche();
+        niche.setId(18L);
+        when(marketNicheRepository.findById(18L)).thenReturn(Optional.of(niche));
+        when(executionRepository.findTopByMarketNicheIdAndStageCodeAndStatusOrderByExecutionRequestedAtDesc(
+                        18L,
+                        "hypothesis-pain",
+                        "CONCLUIDO"))
+                .thenReturn(Optional.of(HypothesisPainStageExecution.builder()
+                        .marketNicheId(18L)
+                        .stageCode("hypothesis-pain")
+                        .status("CONCLUIDO")
+                        .modelResponse("{\"pain\":\"dor validada\"}")
+                        .build()));
+        when(executionRepository.findTopByMarketNicheIdAndStageCodeAndStatusOrderByExecutionRequestedAtDesc(
+                        18L,
+                        "hypothesis-result",
+                        "CONCLUIDO"))
+                .thenReturn(Optional.empty());
+
+        assertThrows(IllegalStateException.class, () -> service.startMechanism(18L));
+    }
+
+    /** Deve entregar Dor e Resultado concluídos para contextualizar a etapa Mecanismo no Worker AI. */
+    @Test
+    void listMechanismPendingIncludesLatestCompletedPainAndResultResponses() {
+        MarketNiche niche = new MarketNiche();
+        niche.setId(18L);
+        niche.setName("Produtores digitais");
+        String mechanismJob = "4cc56a94-45bc-48bf-8e8d-e1f4f8b881df";
+        HypothesisPainStageExecution mechanismExecution = HypothesisPainStageExecution.builder()
+                .idJob(mechanismJob.getBytes(StandardCharsets.UTF_8))
+                .marketNicheId(18L)
+                .marketNiche(niche)
+                .stageCode("hypothesis-mechanism")
+                .status("INICIADO")
+                .executionRequestedAt(Instant.parse("2026-06-11T13:00:00Z"))
+                .build();
+        HypothesisPainStageExecution completedPain = HypothesisPainStageExecution.builder()
+                .marketNicheId(18L)
+                .stageCode("hypothesis-pain")
+                .status("CONCLUIDO")
+                .modelResponse("{\"pain\":\"dor validada\"}")
+                .build();
+        HypothesisPainStageExecution completedResult = HypothesisPainStageExecution.builder()
+                .marketNicheId(18L)
+                .stageCode("hypothesis-result")
+                .status("CONCLUIDO")
+                .modelResponse("{\"result\":\"resultado validado\"}")
+                .build();
+
+        when(executionRepository.findTop20ByStageCodeAndStatusOrderByExecutionRequestedAtAsc(
+                        "hypothesis-mechanism",
+                        "INICIADO"))
+                .thenReturn(List.of(mechanismExecution));
+        when(executionRepository.findTopByMarketNicheIdAndStageCodeAndStatusOrderByExecutionRequestedAtDesc(
+                        18L,
+                        "hypothesis-pain",
+                        "CONCLUIDO"))
+                .thenReturn(Optional.of(completedPain));
+        when(executionRepository.findTopByMarketNicheIdAndStageCodeAndStatusOrderByExecutionRequestedAtDesc(
+                        18L,
+                        "hypothesis-result",
+                        "CONCLUIDO"))
+                .thenReturn(Optional.of(completedResult));
+
+        var pending = service.listMechanismPending();
+
+        assertEquals(1, pending.size());
+        assertEquals("{\"pain\":\"dor validada\"}", pending.getFirst().painModelResponse());
+        assertEquals("{\"result\":\"resultado validado\"}", pending.getFirst().resultModelResponse());
+    }
+
 }

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -4371,3 +4371,9 @@
 - causa-raiz: a evolução da etapa Resultado acoplou a liberação e o contexto ao resultado concluído da etapa Dor sem completar o contrato interno de consulta dessa dependência sequencial.
 - foi feito: implementada a busca da Dor concluída mais recente por nicho, bloqueando Resultado quando não há resposta válida e entregando essa resposta ao Worker AI nos jobs pendentes da etapa Resultado.
 - prevenção: adicionado teste unitário para garantir que a etapa Resultado receba a resposta concluída da Dor como contexto obrigatório.
+
+## 2026-06-11 — Etapa 3 do pipeline na tela de nova hipótese
+
+- A tela de nova hipótese passou a exibir a Etapa 3 — Mecanismo junto das etapas Dor e Resultado.
+- O backend expôs os contratos de início, listagem, detalhe e integrações internas da etapa `hypothesis-mechanism`, mantendo a exigência de Resultado concluído antes da execução.
+- A documentação Swagger do pipeline inicial de hipótese foi atualizada para incluir Dor, Resultado e Mecanismo.

--- a/docs/swagger/hypothesis-pain-stage-swagger.yaml
+++ b/docs/swagger/hypothesis-pain-stage-swagger.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.3
 info:
   title: Hypothesis Pipeline Initial Stages API
   version: 1.0.0
-  description: Contratos das etapas Dor e Resultado do pipeline de hipótese.
+  description: Contratos das etapas Dor, Resultado e Mecanismo do pipeline de hipótese.
 paths:
   /api/niches/{nicheId}/hypothesis-pipeline/pain/start:
     post:
@@ -195,6 +195,108 @@ paths:
   /api/internal/hypothesis-pipeline/result/stage-executions/{idJob}/recebe-resposta:
     post:
       summary: Recebe resposta ou erro da OpenAI para concluir a etapa Resultado.
+      parameters:
+        - in: path
+          name: idJob
+          required: true
+          schema: { type: string }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RecebeRespostaRequest'
+      responses:
+        '202': { description: Resposta registrada. }
+  /api/niches/{nicheId}/hypothesis-pipeline/mechanism/start:
+    post:
+      summary: Inicia a construção auditável do mecanismo do nicho.
+      parameters:
+        - in: path
+          name: nicheId
+          required: true
+          schema: { type: integer, format: int64 }
+      responses:
+        '202':
+          description: Execução iniciada.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HypothesisPainStartResponse'
+  /api/niches/{nicheId}/hypothesis-pipeline/mechanism/stage-executions:
+    get:
+      summary: Lista execuções da etapa Mecanismo para acompanhamento na tela de nova hipótese.
+      parameters:
+        - in: path
+          name: nicheId
+          required: true
+          schema: { type: integer, format: int64 }
+        - in: query
+          name: includeCompleted
+          schema: { type: boolean, default: true }
+      responses:
+        '200':
+          description: Execuções retornadas.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/HypothesisPainExecutionSummaryResponse'
+  /api/niches/{nicheId}/hypothesis-pipeline/mechanism/stage-executions/{idJob}:
+    get:
+      summary: Consulta detalhe auditável de uma execução da etapa Mecanismo para a tela de detalhe do job.
+      parameters:
+        - in: path
+          name: nicheId
+          required: true
+          schema: { type: integer, format: int64 }
+        - in: path
+          name: idJob
+          required: true
+          schema: { type: string }
+      responses:
+        '200':
+          description: Detalhe da execução retornado.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HypothesisPainExecutionDetailResponse'
+  /api/internal/hypothesis-pipeline/mechanism/stage-executions/pending:
+    get:
+      summary: Lista jobs pendentes da etapa Mecanismo para o Worker AI.
+      responses:
+        '200':
+          description: Jobs pendentes.
+  /api/internal/hypothesis-pipeline/mechanism/stage-executions/{idJob}/running:
+    post:
+      summary: Marca uma execução de mecanismo como em processamento.
+      parameters:
+        - in: path
+          name: idJob
+          required: true
+          schema: { type: string }
+      responses:
+        '202': { description: Execução marcada. }
+  /api/internal/hypothesis-pipeline/mechanism/stage-executions/{idJob}/recebe-prompt:
+    post:
+      summary: Recebe prompt, schema e request cru da etapa Mecanismo enviados para a OpenAI.
+      parameters:
+        - in: path
+          name: idJob
+          required: true
+          schema: { type: string }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RecebePromptRequest'
+      responses:
+        '202': { description: Prompt registrado. }
+  /api/internal/hypothesis-pipeline/mechanism/stage-executions/{idJob}/recebe-resposta:
+    post:
+      summary: Recebe resposta ou erro da OpenAI para concluir a etapa Mecanismo.
       parameters:
         - in: path
           name: idJob

--- a/frontend/src/pages/hypothesis/NewHypothesisPage.test.tsx
+++ b/frontend/src/pages/hypothesis/NewHypothesisPage.test.tsx
@@ -47,16 +47,31 @@ describe("NewHypothesisPage", () => {
           ],
         });
       }
+      if (url.includes("/hypothesis-pipeline/result/")) {
+        return Promise.resolve({
+          data: [
+            {
+              jobid: "aaaaaaaa-3894-43bd-9752-374f84eb6a2c",
+              marketNicheId: 18,
+              stageCode: "hypothesis-result",
+              status: "CONCLUIDO",
+              executionRequestedAt: "2026-06-11T00:21:01Z",
+              completedAt: "2026-06-11T00:25:01Z",
+              costUsd: 0.002,
+            },
+          ],
+        });
+      }
       return Promise.resolve({
         data: [
           {
-            jobid: "aaaaaaaa-3894-43bd-9752-374f84eb6a2c",
+            jobid: "bbbbbbbb-3894-43bd-9752-374f84eb6a2c",
             marketNicheId: 18,
-            stageCode: "hypothesis-result",
+            stageCode: "hypothesis-mechanism",
             status: "CONCLUIDO",
-            executionRequestedAt: "2026-06-11T00:21:01Z",
-            completedAt: "2026-06-11T00:25:01Z",
-            costUsd: 0.002,
+            executionRequestedAt: "2026-06-11T00:31:01Z",
+            completedAt: "2026-06-11T00:35:01Z",
+            costUsd: 0.003,
           },
         ],
       });
@@ -82,6 +97,7 @@ describe("NewHypothesisPage", () => {
     expect(
       screen.getByText("Etapa 2 — Resultado desejado"),
     ).toBeInTheDocument();
-    expect(screen.getByText(/US\$\s*0,014345/)).toBeInTheDocument();
+    expect(screen.getByText("Etapa 3 — Mecanismo")).toBeInTheDocument();
+    expect(screen.getByText(/US\$\s*0,017345/)).toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/hypothesis/NewHypothesisPage.tsx
+++ b/frontend/src/pages/hypothesis/NewHypothesisPage.tsx
@@ -18,7 +18,7 @@ interface StageExecution {
 }
 
 interface StageConfig {
-  slug: "pain" | "result";
+  slug: "pain" | "result" | "mechanism";
   number: number;
   title: string;
   startLabel: string;
@@ -56,6 +56,20 @@ const STAGES: StageConfig[] = [
       "Nenhuma execução de resultado iniciada para este nicho. Depois de concluir a dor, clique no botão acima para criar o job e acompanhar o resultado.",
     description:
       "Transforme a dor validada em um resultado claro, desejável e plausível antes de avançar para mecanismo, prova e oferta.",
+  },
+  {
+    slug: "mechanism",
+    number: 3,
+    title: "Mecanismo",
+    startLabel: "Iniciar construção do mecanismo",
+    startedToast: "Etapa Mecanismo iniciada",
+    startErrorToast:
+      "Não foi possível iniciar a etapa Mecanismo. Conclua o resultado antes de avançar.",
+    loadingLabel: "Carregando execuções de mecanismo...",
+    emptyMessage:
+      "Nenhuma execução de mecanismo iniciada para este nicho. Depois de concluir o resultado, clique no botão acima para criar o job e acompanhar o mecanismo.",
+    description:
+      "Converta o resultado desejado em um mecanismo plausível antes de avançar para prova e oferta.",
   },
 ];
 
@@ -293,9 +307,9 @@ export default function NewHypothesisPage() {
       <section className="card">
         <div className="card-body">
           <p className="text-muted mb-3">
-            Depois que dor e resultado estiverem claros, avance para construir a
-            hipótese completa seguindo Dor → Resultado → Mecanismo → Prova →
-            Oferta.
+            Depois que dor, resultado e mecanismo estiverem claros, avance para
+            construir a hipótese completa seguindo Dor → Resultado → Mecanismo
+            → Prova → Oferta.
           </p>
           <Link className="btn btn-outline-secondary" to="/niches">
             Voltar para nichos


### PR DESCRIPTION
### Motivation
- Add the third pipeline stage (Etapa 3 — Mecanismo) to the New Hypothesis flow so the UI and backend support the full Dor → Resultado → Mecanismo → Prova → Oferta sequence. 
- Ensure the mechanism stage only runs after a completed Resultado and provide the worker with both Dor and Resultado context to produce valid mechanism output.

### Description
- Frontend: added a `mechanism` stage to `STAGES` and to `NewHypothesisPage` so the page shows Etapa 3, includes it in the total-cost aggregation and updates copy to reference the full pipeline (`frontend/src/pages/hypothesis/NewHypothesisPage.tsx`).
- Backend controller: exposed public and internal endpoints for mechanism start/list/detail and internal worker hooks (`/api/niches/{nicheId}/hypothesis-pipeline/mechanism/*` and `/api/internal/hypothesis-pipeline/mechanism/*`) in `HypothesisPainStageController`.
- Backend service: added `MECHANISM_STAGE_CODE`, `startMechanism`, `listMechanismStageExecutions`, `listMechanismPending`, `requireCompletedResult` and helpers to return latest completed stage responses so mechanism jobs include both `pain` and `result` context (`HypothesisPainStageService`).
- Contracts & tests: extended the pending payload record to include `resultModelResponse`, updated Swagger (`docs/swagger/hypothesis-pain-stage-swagger.yaml`), appended experiment records (`docs/registros/experimentos.md`) and added unit tests covering mechanism prerequisites and pending payload (`HypothesisPainStageServiceTest`).

### Testing
- Ran backend unit tests: `mvn -Dtest=HypothesisPainStageServiceTest test`, which executed the new/updated service tests and passed (no failures observed during the run). 
- Ran frontend unit test attempt: `npm test -- --run src/pages/hypothesis/NewHypothesisPage.test.tsx` was blocked because frontend dependencies are not installed in the environment (`vitest: not found`), so the updated UI test was added but not executed here.
- Performed static diffs and basic sanity checks (`git diff --check`) with no trailing whitespace or diff-check issues reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2ada5dabf483219ff882a221152a93)