### PR TITLE
Fix MOIS sales library build

### DIFF
--- a/backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryServiceTest.java
@@ -469,7 +469,7 @@ class MoisSalesLibraryServiceTest {
                 .thenReturn(List.of(99L));
         lenient().when(jdbcTemplate.query(contains("SELECT p.id, p.workspace_id, p.source"), isA(RowMapper.class), any()))
                 .thenReturn(List.of(new MoisSalesLibraryDtos.SalesLibraryPageResponse(99L, "10", "HOTMART", "https://example.com/pagina", "Title",
-                        "ANALYSIS", "PENDING", null, "PENDING", null, null, null, 0L, BigDecimal.ZERO, null, null, null, null, null, null, null, null, null, Instant.now(), null, null, null, null, null, null)));
+                        "ANALYSIS", "PENDING", null, "PENDING", null, null, null, 0L, BigDecimal.ZERO, null, null, null, null, null, null, null, null, null, null, null, Instant.now(), null, null, null, null, null, null, null, null)));
         lenient().when(jdbcTemplate.update(contains("INSERT INTO mois_sales_page_job_execution"), any(), any(), any())).thenReturn(1);
         lenient().when(jdbcTemplate.queryForObject(contains("SELECT LAST_INSERT_ID()"), eq(Long.class))).thenReturn(123L);
         lenient().when(jdbcTemplate.update(contains("UPDATE mois_sales_page"), any(), any())).thenReturn(1);

--- a/docs/registros/mois1.md
+++ b/docs/registros/mois1.md
@@ -1476,3 +1476,12 @@ Arquivos principais:
 - foi feito: adicionada persistência de `model_name`, `input_tokens`, `output_tokens` e `model_cost_usd` em `mois_sales_page` e `mois_sales_page_job_execution`, cálculo de custo batch pelo catálogo OpenAI do backend e exibição na biblioteca/detalhe da página.
 - foi feito: a criação de nicho passa a iniciar `totalCost` com `totalCost` explícito, ou com `cost` quando o total não for informado, ou zero como fallback.
 - frontend MOIS (`/mois/sales-pages-library`): ajustada a listagem de priorização para exibir temperatura Hotmart e data do dossiê, removendo score de sucesso e fase no diagrama da tabela principal para deixar a decisão comercial mais direta.
+
+## 2026-06-11 — Correção de build da Biblioteca MOIS
+
+- corrigida a compilação do backend após evolução do contrato `SalesLibraryPageResponse`, alinhando o mock de teste aos campos de aquecimento de mercado adicionados ao DTO.
+- corrigida a compilação do frontend restaurando a função de apresentação da fase/status do pipeline na listagem da Biblioteca de Páginas de Vendas.
+
+Arquivos principais:
+- backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryServiceTest.java
+- frontend/src/pages/mois/MoisSalesPagesLibraryPage.tsx

--- a/frontend/src/pages/mois/MoisSalesPagesLibraryPage.tsx
+++ b/frontend/src/pages/mois/MoisSalesPagesLibraryPage.tsx
@@ -77,6 +77,12 @@ function matchesWarmupFilter(item: MoisSalesLibraryPage, filter: string) {
   }
 }
 
+function getPipelinePhase(stage?: string | null, status?: string | null) {
+  const stageLabel = stage?.trim() || "Sem etapa";
+  const statusLabel = status?.trim() || "sem status";
+  return `${stageLabel} · ${statusLabel}`;
+}
+
 function formatDateTime(value?: string | null) {
   if (!value) {
     return "—";


### PR DESCRIPTION
### Motivation
- Restore CI build after a DTO evolution and a missing frontend helper caused compilation/typecheck failures in MOIS sales library flows.
- Ensure the backend test fixture matches the current `SalesLibraryPageResponse` contract and the frontend renders pipeline phase/status correctly.

### Description
- Aligned the backend test mock to the updated `MoisSalesLibraryDtos.SalesLibraryPageResponse` constructor by adding the missing fields in `MoisSalesLibraryServiceTest`. (file: `backend/ads-service/src/test/java/.../MoisSalesLibraryServiceTest.java`)
- Restored the frontend helper `getPipelinePhase(stage?: string | null, status?: string | null)` used by the sales pages library table to present pipeline phase and status. (file: `frontend/src/pages/mois/MoisSalesPagesLibraryPage.tsx`)
- Recorded the fix in the operational log. (file: `docs/registros/mois1.md`)

### Testing
- Ran `mvn -q -Dtest=MoisSalesLibraryServiceTest test` and the MOIS unit test executed successfully.
- Ran `mvn -q test-compile` to validate compilation of tests and it succeeded.
- Ran `npm ci` to install frontend deps and `npm run typecheck` (after `npm ci`) and TypeScript typecheck succeeded.
- Ran `npx prettier --write src/pages/mois/MoisSalesPagesLibraryPage.tsx` to format the frontend file successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2af0ef7fac8321868610d0adadc544)