### PR TITLE
Add MOIS-local OpenAI pricing gateway and service and use it for model cost calculation

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryPricingService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryPricingService.java
@@ -1,0 +1,42 @@
+package com.marketinghub.mois.bibliotecapaginavenda.worker.v1.service;
+
+import com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1.MoisSalesLibraryPricingGateway;
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+/**
+ * Calcula custos de modelos OpenAI usados pela Biblioteca de Páginas de Vendas do MOIS.
+ */
+@Service
+@RequiredArgsConstructor
+public class MoisSalesLibraryPricingService {
+
+    private static final BigDecimal ONE_MILLION = BigDecimal.valueOf(1_000_000);
+
+    private final MoisSalesLibraryPricingGateway pricingGateway;
+
+    /**
+     * Estima o custo batch do modelo usado na análise da página de venda MOIS.
+     */
+    public BigDecimal estimateBatchCost(String modelCode, Integer inputTokens, Integer outputTokens) {
+        MoisSalesLibraryPricingGateway.ModelPricing pricing = pricingGateway.findPricingByModelCode(modelCode)
+                .orElseThrow(() -> new IllegalStateException(
+                        "Modelo OpenAI não encontrado no catálogo para cálculo de custo MOIS: " + modelCode));
+        BigDecimal inputCost = multiplyTokens(pricing.priceInputBatch(), inputTokens);
+        BigDecimal outputCost = multiplyTokens(pricing.priceOutputBatch(), outputTokens);
+        return inputCost.add(outputCost).setScale(4, RoundingMode.HALF_UP);
+    }
+
+    /**
+     * Multiplica o preço por milhão pela quantidade de tokens informada.
+     */
+    private BigDecimal multiplyTokens(BigDecimal pricePerMillion, Integer tokens) {
+        if (pricePerMillion == null || tokens == null || tokens <= 0) {
+            return BigDecimal.ZERO;
+        }
+        return pricePerMillion.multiply(BigDecimal.valueOf(tokens))
+                .divide(ONE_MILLION, 6, RoundingMode.HALF_UP);
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryService.java
@@ -1,8 +1,6 @@
 package com.marketinghub.mois.bibliotecapaginavenda.worker.v1.service;
 
 import com.marketinghub.mois.bibliotecapaginavenda.worker.v1.dto.MoisSalesLibraryDtos;
-import com.marketinghub.openai.OpenAiResponse;
-import com.marketinghub.openai.service.OpenAiPricingService;
 import java.math.BigDecimal;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
@@ -41,7 +39,7 @@ public class MoisSalesLibraryService {
     private static final int COLLECTED_REFERENCE_HTML_CANDIDATE_SCAN_LIMIT = 2000;
 
     private final JdbcTemplate jdbcTemplate;
-    private final OpenAiPricingService openAiPricingService;
+    private final MoisSalesLibraryPricingService pricingService;
 
     /**
      * Reserva o próximo job pendente da biblioteca para processamento pelo worker.
@@ -167,10 +165,8 @@ public class MoisSalesLibraryService {
         if ((request.inputTokens() == null && request.outputTokens() == null) || request.modelName() == null || request.modelName().isBlank()) {
             return null;
         }
-        OpenAiResponse.OpenAiUsage usage = new OpenAiResponse.OpenAiUsage(
-                request.inputTokens(), request.outputTokens(), null, null, null);
         try {
-            return openAiPricingService.estimateBatchCost(request.modelName(), usage);
+            return pricingService.estimateBatchCost(request.modelName(), request.inputTokens(), request.outputTokens());
         } catch (RuntimeException ex) {
             log.error(
                     "Falha ao calcular custo OpenAI da análise MOIS. modulo=MOIS, operacao=resolveModelCostUsd, "

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/mois/bibliotecapaginavenda/worker/v1/MoisSalesLibraryPricingGateway.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/mois/bibliotecapaginavenda/worker/v1/MoisSalesLibraryPricingGateway.java
@@ -1,0 +1,21 @@
+package com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1;
+
+import java.math.BigDecimal;
+import java.util.Optional;
+
+/**
+ * Define a leitura dos preços de modelos usados no cálculo de custo da Biblioteca MOIS.
+ */
+public interface MoisSalesLibraryPricingGateway {
+
+    /**
+     * Busca os preços batch do modelo pelo código informado pelo worker.
+     */
+    Optional<ModelPricing> findPricingByModelCode(String modelCode);
+
+    /**
+     * Representa os preços por milhão necessários para calcular custo batch.
+     */
+    record ModelPricing(BigDecimal priceInputBatch, BigDecimal priceOutputBatch) {
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/mois/bibliotecapaginavenda/worker/v1/MoisSalesLibraryPricingRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/mois/bibliotecapaginavenda/worker/v1/MoisSalesLibraryPricingRepository.java
@@ -1,0 +1,41 @@
+package com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1;
+
+import java.util.List;
+import java.util.Locale;
+import java.util.Optional;
+import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.stereotype.Repository;
+import org.springframework.util.StringUtils;
+
+/**
+ * Executa a leitura JDBC dos preços de modelos OpenAI usados pela Biblioteca MOIS.
+ */
+@Repository
+@RequiredArgsConstructor
+public class MoisSalesLibraryPricingRepository implements MoisSalesLibraryPricingGateway {
+
+    private final JdbcTemplate jdbcTemplate;
+
+    /**
+     * Busca o preço batch por código normalizado e pelo código original para preservar compatibilidade operacional.
+     */
+    @Override
+    public Optional<ModelPricing> findPricingByModelCode(String modelCode) {
+        if (!StringUtils.hasText(modelCode)) {
+            return Optional.empty();
+        }
+        String originalCode = modelCode.trim();
+        String normalizedCode = originalCode.toLowerCase(Locale.ROOT);
+        List<ModelPricing> rows = jdbcTemplate.query("""
+                SELECT price_input_batch, price_output_batch
+                FROM openai_model
+                WHERE code = ? OR code = ?
+                ORDER BY CASE WHEN code = ? THEN 0 ELSE 1 END
+                LIMIT 1
+                """, (rs, rowNum) -> new ModelPricing(
+                rs.getBigDecimal("price_input_batch"),
+                rs.getBigDecimal("price_output_batch")), normalizedCode, originalCode, normalizedCode);
+        return rows.stream().findFirst();
+    }
+}

--- a/backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryPricingServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryPricingServiceTest.java
@@ -1,0 +1,53 @@
+package com.marketinghub.mois.bibliotecapaginavenda.worker.v1.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+import com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1.MoisSalesLibraryPricingGateway;
+import java.math.BigDecimal;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * Valida o cálculo de custos OpenAI mantido dentro do pacote da Biblioteca MOIS.
+ */
+@ExtendWith(MockitoExtension.class)
+class MoisSalesLibraryPricingServiceTest {
+
+    @Mock
+    private MoisSalesLibraryPricingGateway pricingGateway;
+
+    @InjectMocks
+    private MoisSalesLibraryPricingService service;
+
+    /**
+     * Garante cálculo batch usando os preços obtidos do banco pelo gateway permitido do MOIS.
+     */
+    @Test
+    void shouldEstimateBatchCostFromMoisPricingGateway() {
+        given(pricingGateway.findPricingByModelCode("gpt-5.2"))
+                .willReturn(Optional.of(new MoisSalesLibraryPricingGateway.ModelPricing(
+                        new BigDecimal("1.25000"), new BigDecimal("10.00000"))));
+
+        BigDecimal cost = service.estimateBatchCost("gpt-5.2", 250_000, 125_000);
+
+        assertThat(cost).isEqualByComparingTo("1.5625");
+    }
+
+    /**
+     * Garante erro controlado quando o modelo ainda não existe no catálogo de preços.
+     */
+    @Test
+    void shouldFailWhenModelPricingIsMissing() {
+        given(pricingGateway.findPricingByModelCode("modelo-ausente")).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> service.estimateBatchCost("modelo-ausente", 1000, 1000))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Modelo OpenAI não encontrado");
+    }
+}

--- a/backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryServiceTest.java
@@ -34,6 +34,9 @@ class MoisSalesLibraryServiceTest {
     @Mock
     private JdbcTemplate jdbcTemplate;
 
+    @Mock
+    private MoisSalesLibraryPricingService pricingService;
+
     @InjectMocks
     private MoisSalesLibraryService service;
 

--- a/backend/ads-service/src/test/java/com/marketinghub/repository/jpa/mois/bibliotecapaginavenda/worker/v1/MoisSalesLibraryPricingRepositoryTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/repository/jpa/mois/bibliotecapaginavenda/worker/v1/MoisSalesLibraryPricingRepositoryTest.java
@@ -1,0 +1,67 @@
+package com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.BDDMockito.given;
+
+import java.math.BigDecimal;
+import java.sql.ResultSet;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowMapper;
+
+/**
+ * Valida a leitura JDBC dos preços usados pela Biblioteca MOIS.
+ */
+@ExtendWith(MockitoExtension.class)
+class MoisSalesLibraryPricingRepositoryTest {
+
+    @Mock
+    private JdbcTemplate jdbcTemplate;
+
+    @InjectMocks
+    private MoisSalesLibraryPricingRepository repository;
+
+    /**
+     * Garante que o repositório consulta a tabela canônica openai_model com código normalizado e original.
+     */
+    @Test
+    void shouldReadBatchPricesFromOpenAiModelTable() throws Exception {
+        given(jdbcTemplate.query(
+                any(String.class),
+                any(RowMapper.class),
+                eq("gpt-5.2"),
+                eq("GPT-5.2"),
+                eq("gpt-5.2")))
+                .willAnswer(invocation -> {
+                    RowMapper<?> mapper = invocation.getArgument(1);
+                    ResultSet row = org.mockito.Mockito.mock(ResultSet.class);
+                    given(row.getBigDecimal("price_input_batch")).willReturn(new BigDecimal("1.25000"));
+                    given(row.getBigDecimal("price_output_batch")).willReturn(new BigDecimal("10.00000"));
+                    return List.of(mapper.mapRow(row, 0));
+                });
+
+        Optional<MoisSalesLibraryPricingGateway.ModelPricing> pricing = repository.findPricingByModelCode(" GPT-5.2 ");
+
+        assertThat(pricing).isPresent();
+        assertThat(pricing.get().priceInputBatch()).isEqualByComparingTo("1.25000");
+        assertThat(pricing.get().priceOutputBatch()).isEqualByComparingTo("10.00000");
+    }
+
+    /**
+     * Garante que código vazio não gera consulta desnecessária ao banco.
+     */
+    @Test
+    void shouldReturnEmptyWhenModelCodeIsBlank() {
+        Optional<MoisSalesLibraryPricingGateway.ModelPricing> pricing = repository.findPricingByModelCode(" ");
+
+        assertThat(pricing).isEmpty();
+    }
+}

--- a/docs/registros/mois1.md
+++ b/docs/registros/mois1.md
@@ -1,3 +1,9 @@
+## 2026-06-11 18:20:00 UTC
+- corrigido o cálculo de custo da análise da Biblioteca de Páginas de Vendas do MOIS para não depender diretamente do pacote `com.marketinghub.openai`, preservando o isolamento arquitetural validado por ArchUnit.
+- criado serviço local no pacote `com.marketinghub.mois.bibliotecapaginavenda.worker.v1.service` para calcular preço batch a partir dos tokens do worker.
+- criada leitura JDBC no gateway/repositório permitido `com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1` para obter `price_input_batch` e `price_output_batch` da tabela canônica `openai_model`.
+- adicionados testes unitários do cálculo e da leitura de preços, além da validação de arquitetura para prevenir recorrência do acoplamento com OpenAI central.
+
 ## 2026-06-07 — Timeout de captura HTML ampliado para 5 minutos
 
 - aumentado o timeout de captura HTTP/HTML da Biblioteca de Páginas de Vendas do MOIS para 5 minutos (`300000 ms`) no backend e no worker.


### PR DESCRIPTION
### Motivation
- Prevent direct dependency on the central `com.marketinghub.openai` package and keep pricing logic isolated within the MOIS sales-library module for architectural isolation validated by ArchUnit.
- Provide a local, testable way to compute batch model costs from token counts using the canonical `openai_model` table prices.
- Make the cost resolution resilient when `modelCostUsd` is not provided by the worker payload.

### Description
- Added `MoisSalesLibraryPricingGateway` interface to define reading of `price_input_batch` and `price_output_batch` and a `ModelPricing` record.
- Implemented `MoisSalesLibraryPricingRepository` that queries the `openai_model` table by normalized and original `code` to return batch prices.
- Introduced `MoisSalesLibraryPricingService` that computes batch cost from per-million prices and token counts and replaced usage of the central OpenAI pricing service in `MoisSalesLibraryService` with the new local `pricingService`.
- Updated unit tests and docs: added `MoisSalesLibraryPricingServiceTest`, `MoisSalesLibraryPricingRepositoryTest`, adjusted `MoisSalesLibraryServiceTest` to mock the new service, and recorded the change in `docs/registros/mois1.md`.

### Testing
- Ran `MoisSalesLibraryPricingServiceTest` which verifies batch cost calculation and missing-pricing error handling, and it passed.
- Ran `MoisSalesLibraryPricingRepositoryTest` which validates JDBC read of `openai_model` using normalized and original codes, and it passed.
- Ran `MoisSalesLibraryServiceTest` (updated to mock `MoisSalesLibraryPricingService`) and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2af98cdf0c8321b3d0bb56eff56839)