### PR TITLE
Persist OpenAI response, add product/producer fields and audit UI for MOIS sales library

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/dto/MoisSalesLibraryDtos.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/dto/MoisSalesLibraryDtos.java
@@ -44,6 +44,7 @@ public final class MoisSalesLibraryDtos {
             String imageJson,
             String analysisNotes,
             String requestPayloadJson,
+            String responsePayloadJson,
             String parserVersion,
             String promptVersion,
             String modelName,
@@ -208,6 +209,8 @@ public final class MoisSalesLibraryDtos {
             String source,
             String urlCanonical,
             String title,
+            String productName,
+            String producerName,
             String currentStage,
             String currentStatus,
             String captureStatus,
@@ -358,6 +361,7 @@ public final class MoisSalesLibraryDtos {
             String imageJson,
             String analysisNotes,
             String requestPayloadJson,
+            String responsePayloadJson,
             Instant analyzedAt,
             Instant updatedAt
     ) {

--- a/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryService.java
@@ -130,12 +130,13 @@ public class MoisSalesLibraryService {
                 UPDATE mois_sales_page_job_execution
                 SET job_type = 'PAGE_ANALYSIS', stage = 'ANALYSIS', status = 'DONE', score_total = ?,
                     sections_json = ?, copy_json = ?, visual_json = ?, image_json = ?,
-                    request_payload_json = ?, response_payload_json = ?, model_name = ?, input_tokens = ?, output_tokens = ?, model_cost_usd = ?,
+                    request_payload_json = ?, response_payload_json = ?, parser_version = ?, prompt_version = ?,
+                    model_name = ?, input_tokens = ?, output_tokens = ?, model_cost_usd = ?,
                     error_category = NULL, error_message = ?, finished_at = ?, updated_at = UTC_TIMESTAMP()
                 WHERE id = ?
                 """, request.scoreTotal(), request.sectionsJson(), request.copyJson(), request.visualJson(), request.imageJson(),
-                request.requestPayloadJson(), request.analysisNotes(), request.modelName(), request.inputTokens(), request.outputTokens(), modelCostUsd,
-                null, Timestamp.from(analyzedAt), jobId);
+                request.requestPayloadJson(), request.responsePayloadJson(), request.parserVersion(), request.promptVersion(),
+                request.modelName(), request.inputTokens(), request.outputTokens(), modelCostUsd, null, Timestamp.from(analyzedAt), jobId);
         jdbcTemplate.update("""
                 UPDATE mois_sales_page
                 SET current_stage = 'ANALYSIS', current_status = 'DONE', analysis_status = 'DONE', score_total = ?,
@@ -537,13 +538,15 @@ public class MoisSalesLibraryService {
                 ) mwj_latest ON mwj_latest.sales_page_id = p.id
                 LEFT JOIN mois_sales_page_market_warmup_job mwj ON mwj.id = mwj_latest.latest_warmup_job_id
                 LEFT JOIN mois_sales_page_market_warmup_summary mws ON mws.job_id = mwj.id
+                LEFT JOIN mois_collected_reference cr ON cr.id = p.collected_reference_id
                 WHERE p.workspace_id = ?
                 """ + warmupCondition;
         Long total = jdbcTemplate.queryForObject("SELECT COUNT(*) " + joins, Long.class, workspaceId);
         List<MoisSalesLibraryDtos.SalesLibraryPageResponse> items = jdbcTemplate.query("""
                 SELECT p.id, p.workspace_id, p.source, p.url_canonical, p.title, p.current_stage, p.current_status, p.capture_status,
                        COALESCE(p.analysis_status, p.current_status) AS analysis_status, p.url_final, p.http_status, p.html_sha256,
-                       p.html_bytes, p.score_total, p.offer_summary, p.mechanism_summary, p.promise_summary, p.proof_summary,
+                       p.html_bytes, p.score_total, p.product_name, cr.producer_name,
+                       p.offer_summary, p.mechanism_summary, p.promise_summary, p.proof_summary,
                        p.model_name, p.input_tokens, p.output_tokens, p.model_cost_usd,
                        p.last_error_category, p.last_error_message, p.last_job_execution_id, p.last_captured_at, p.last_analyzed_at, p.updated_at,
                        mws.score_total AS market_warmup_score_total, mws.market_temperature AS market_warmup_temperature,
@@ -689,7 +692,8 @@ public class MoisSalesLibraryService {
         List<MoisSalesLibraryDtos.SalesLibraryPageResponse> rows = jdbcTemplate.query("""
                 SELECT p.id, p.workspace_id, p.source, p.url_canonical, p.title, p.current_stage, p.current_status, p.capture_status,
                        COALESCE(p.analysis_status, p.current_status) AS analysis_status, p.url_final, p.http_status, p.html_sha256,
-                       p.html_bytes, p.score_total, p.offer_summary, p.mechanism_summary, p.promise_summary, p.proof_summary,
+                       p.html_bytes, p.score_total, p.product_name, cr.producer_name,
+                       p.offer_summary, p.mechanism_summary, p.promise_summary, p.proof_summary,
                        p.model_name, p.input_tokens, p.output_tokens, p.model_cost_usd,
                        p.last_error_category, p.last_error_message, p.last_job_execution_id, p.last_captured_at, p.last_analyzed_at, p.updated_at,
                        mws.score_total AS market_warmup_score_total, mws.market_temperature AS market_warmup_temperature,
@@ -703,6 +707,7 @@ public class MoisSalesLibraryService {
                 ) mwj_latest ON mwj_latest.sales_page_id = p.id
                 LEFT JOIN mois_sales_page_market_warmup_job mwj ON mwj.id = mwj_latest.latest_warmup_job_id
                 LEFT JOIN mois_sales_page_market_warmup_summary mws ON mws.job_id = mwj.id
+                LEFT JOIN mois_collected_reference cr ON cr.id = p.collected_reference_id
                 WHERE p.id = ? LIMIT 1
                 """, this::mapSalesPageResponse, pageId);
         if (rows.isEmpty()) throw new IllegalArgumentException("Page not found: " + pageId);
@@ -715,15 +720,16 @@ public class MoisSalesLibraryService {
     public MoisSalesLibraryDtos.SalesLibraryPageAnalysisResponse getPageAnalysis(long pageId) {
         List<MoisSalesLibraryDtos.SalesLibraryPageAnalysisResponse> rows = jdbcTemplate.query("""
                 SELECT e.id, e.sales_page_id, e.status, e.score_total, e.sections_json, e.copy_json, e.visual_json,
-                       e.image_json, e.request_payload_json, e.error_message, e.finished_at, e.updated_at
+                       e.image_json, e.request_payload_json, e.response_payload_json, e.error_message, e.parser_version, e.prompt_version,
+                       e.model_name, e.finished_at, e.updated_at
                 FROM mois_sales_page_job_execution e
                 WHERE e.sales_page_id = ? AND e.job_type = 'PAGE_ANALYSIS'
                 ORDER BY e.updated_at DESC, e.id DESC LIMIT 1
                 """, (rs, rn) -> new MoisSalesLibraryDtos.SalesLibraryPageAnalysisResponse(
                 rs.getLong("id"), rs.getLong("sales_page_id"), null, rs.getString("status"),
-                rs.getBigDecimal("score_total"), null, null, null, rs.getString("sections_json"),
+                rs.getBigDecimal("score_total"), rs.getString("parser_version"), rs.getString("prompt_version"), rs.getString("model_name"), rs.getString("sections_json"),
                 rs.getString("copy_json"), rs.getString("visual_json"), rs.getString("image_json"),
-                rs.getString("error_message"), rs.getString("request_payload_json"),
+                rs.getString("error_message"), rs.getString("request_payload_json"), rs.getString("response_payload_json"),
                 toInstant(rs.getTimestamp("finished_at")), toInstant(rs.getTimestamp("updated_at"))), pageId);
         if (rows.isEmpty()) throw new IllegalArgumentException("Analysis not found for page: " + pageId);
         return rows.get(0);
@@ -1344,6 +1350,8 @@ public class MoisSalesLibraryService {
                 rs.getString("source"),
                 rs.getString("url_canonical"),
                 rs.getString("title"),
+                rs.getString("product_name"),
+                rs.getString("producer_name"),
                 rs.getString("current_stage"),
                 rs.getString("current_status"),
                 rs.getString("capture_status"),

--- a/backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryServiceTest.java
@@ -468,7 +468,7 @@ class MoisSalesLibraryServiceTest {
         lenient().when(jdbcTemplate.query(contains("WHERE workspace_id = ? AND url_canonical = ?"), isA(RowMapper.class), any(), any()))
                 .thenReturn(List.of(99L));
         lenient().when(jdbcTemplate.query(contains("SELECT p.id, p.workspace_id, p.source"), isA(RowMapper.class), any()))
-                .thenReturn(List.of(new MoisSalesLibraryDtos.SalesLibraryPageResponse(99L, "10", "HOTMART", "https://example.com/pagina", "Title",
+                .thenReturn(List.of(new MoisSalesLibraryDtos.SalesLibraryPageResponse(99L, "10", "HOTMART", "https://example.com/pagina", "Title", "Produto Teste", "Produtor Teste",
                         "ANALYSIS", "PENDING", null, "PENDING", null, null, null, 0L, BigDecimal.ZERO, null, null, null, null, null, null, null, null, null, null, null, Instant.now(), null, null, null, null, null, null, null, null)));
         lenient().when(jdbcTemplate.update(contains("INSERT INTO mois_sales_page_job_execution"), any(), any(), any())).thenReturn(1);
         lenient().when(jdbcTemplate.queryForObject(contains("SELECT LAST_INSERT_ID()"), eq(Long.class))).thenReturn(123L);

--- a/docs/registros/mois1.md
+++ b/docs/registros/mois1.md
@@ -1485,3 +1485,27 @@ Arquivos principais:
 Arquivos principais:
 - backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryServiceTest.java
 - frontend/src/pages/mois/MoisSalesPagesLibraryPage.tsx
+
+## 2026-06-11 — Clareza do dossiê de sucesso MOIS
+
+- corrigida a causa-raiz da confusão na tela de dossiê: a UI mostrava pesquisas públicas sem explicar que elas servem para encontrar autoridade, audiência, prova social e canais que podem justificar as vendas do produto.
+- o detalhe da Biblioteca MOIS passa a destacar produto analisado, produtor, oferta, promessa, mecanismo e provas antes das fontes públicas.
+- o backend passa a expor `productName` e `producerName` no contrato de página consolidada, usando `mois_sales_page` como estado operacional e `mois_collected_reference` apenas como origem bruta vinculada.
+
+Arquivos principais:
+- backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/dto/MoisSalesLibraryDtos.java
+- backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryService.java
+- frontend/src/pages/mois/MoisSalesPageLibraryDetailPage.tsx
+- docs/swagger/mois-sales-library-swagger.yaml
+
+## 2026-06-11 — Auditoria OpenAI no dossiê MOIS
+
+- adicionada seção visual separada no detalhe da Biblioteca MOIS para exibir prompt usado, request enviado para OpenAI, response cru da OpenAI e schema JSON quando houver.
+- a visualização usa layout JSON colapsável, seguindo o padrão usado nas telas de GeraLanding para facilitar auditoria pelo usuário.
+- corrigida a persistência da resposta crua da OpenAI na análise de página, separando `analysisNotes` de `responsePayloadJson`.
+
+Arquivos principais:
+- frontend/src/pages/mois/MoisSalesPageLibraryDetailPage.tsx
+- backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/dto/MoisSalesLibraryDtos.java
+- backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryService.java
+- mois-sales-library-worker/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/openai/OpenAiSalesPageAnalyzer.java

--- a/docs/swagger/mois-sales-library-swagger.yaml
+++ b/docs/swagger/mois-sales-library-swagger.yaml
@@ -890,7 +890,6 @@ components:
         producerName:
           type: string
           nullable: true
-          description: Nome do produtor, marca ou autoridade coletada na origem, usado para evitar buscas genéricas e mapear a máquina de venda.
         offerSummary:
           type: string
           nullable: true
@@ -1118,6 +1117,10 @@ components:
           type: string
         requestPayloadJson:
           type: string
+        responsePayloadJson:
+          type: string
+          nullable: true
+          description: Resposta crua retornada pela OpenAI para auditoria da análise.
         parserVersion:
           type: string
         promptVersion:
@@ -1329,6 +1332,14 @@ components:
         title:
           type: string
           nullable: true
+        productName:
+          type: string
+          nullable: true
+          description: Nome comercial do produto coletado na origem, quando disponível.
+        producerName:
+          type: string
+          nullable: true
+          description: Nome do produtor, marca ou autoridade coletada na origem, usado para explicar a pesquisa pública do dossiê.
         currentStage:
           type: string
           nullable: true
@@ -1356,10 +1367,6 @@ components:
         scoreTotal:
           type: number
           nullable: true
-        producerName:
-          type: string
-          nullable: true
-          description: Nome do produtor, marca ou autoridade coletada na origem, usado para evitar buscas genéricas e mapear a máquina de venda.
         offerSummary:
           type: string
           nullable: true

--- a/frontend/src/api/mois/types.ts
+++ b/frontend/src/api/mois/types.ts
@@ -260,6 +260,8 @@ export interface MoisSalesLibraryPage {
   source: string;
   urlCanonical: string;
   title?: string;
+  productName?: string;
+  producerName?: string;
   currentStage?: string;
   currentStatus?: string;
   captureStatus?: string;
@@ -558,6 +560,7 @@ export interface MoisSalesLibraryPageAnalysis {
   imageJson?: string;
   analysisNotes?: string;
   requestPayloadJson?: string;
+  responsePayloadJson?: string;
   analyzedAt?: string;
   updatedAt: string;
 }

--- a/frontend/src/pages/mois/MoisSalesPageLibraryDetailPage.tsx
+++ b/frontend/src/pages/mois/MoisSalesPageLibraryDetailPage.tsx
@@ -1,5 +1,6 @@
 import { Link, useParams } from "react-router-dom";
 import PageTitle from "../../components/PageTitle";
+import CollapsibleJsonViewer from "../../components/CollapsibleJsonViewer";
 import {
   useMoisSalesLibraryMarketWarmup,
   useMoisSalesLibraryMarketWarmupSignals,
@@ -115,6 +116,15 @@ function formatCurrencyUsd(value?: number) {
     : value.toLocaleString("pt-BR", { style: "currency", currency: "USD" });
 }
 
+function cleanText(value?: string) {
+  const normalized = value?.trim();
+  return normalized ? normalized : undefined;
+}
+
+function displayText(value?: string) {
+  return cleanText(value) || "—";
+}
+
 function TextList({ items }: { items?: string[] }) {
   const visibleItems = (items ?? []).filter(Boolean);
   if (visibleItems.length === 0) {
@@ -167,17 +177,83 @@ function sourceEvidenceLabel(source: MoisMarketWarmupSource) {
   return label ? `${title}${summary} (${label})` : `${title}${summary}`;
 }
 
+function ProductIdentityCard({
+  productName,
+  producerName,
+  title,
+  offerSummary,
+  promiseSummary,
+  mechanismSummary,
+  proofSummary,
+}: {
+  productName?: string;
+  producerName?: string;
+  title?: string;
+  offerSummary?: string;
+  promiseSummary?: string;
+  mechanismSummary?: string;
+  proofSummary?: string;
+}) {
+  const resolvedProductName = cleanText(productName) || cleanText(title);
+
+  return (
+    <section className="border rounded p-3 bg-light-subtle">
+      <div className="d-flex flex-wrap justify-content-between gap-3 mb-3">
+        <div>
+          <div className="text-secondary small">Produto analisado</div>
+          <h3 className="h6 mb-1">{displayText(resolvedProductName)}</h3>
+          <p className="small text-secondary mb-0">
+            O dossiê parte deste produto para entender se existe uma máquina de
+            venda por trás: produtor, promessa, mecanismo, prova e canais de
+            aquisição.
+          </p>
+        </div>
+        <div className="text-md-end">
+          <div className="text-secondary small">Produtor</div>
+          <strong>{displayText(producerName)}</strong>
+        </div>
+      </div>
+
+      <div className="row g-2 small">
+        <div className="col-md-6">
+          <strong>O que é o produto/oferta</strong>
+          <p className="mb-0 text-secondary">
+            {displayText(offerSummary || resolvedProductName)}
+          </p>
+        </div>
+        <div className="col-md-6">
+          <strong>Promessa principal</strong>
+          <p className="mb-0 text-secondary">{displayText(promiseSummary)}</p>
+        </div>
+        <div className="col-md-6">
+          <strong>Mecanismo provável</strong>
+          <p className="mb-0 text-secondary">{displayText(mechanismSummary)}</p>
+        </div>
+        <div className="col-md-6">
+          <strong>Provas usadas na venda</strong>
+          <p className="mb-0 text-secondary">{displayText(proofSummary)}</p>
+        </div>
+      </div>
+    </section>
+  );
+}
+
 function ProductSuccessNarrative({
   summary,
   signals,
   sources,
+  productName,
+  producerName,
 }: {
   summary: MoisMarketWarmupSummary;
   signals: MoisMarketWarmupSignal[];
   sources: MoisMarketWarmupSource[];
+  productName?: string;
+  producerName?: string;
 }) {
   const modelConclusion = summary.opportunityRecommendation?.trim();
   const nextResearch = summary.nextExperimentSuggestion?.trim();
+  const searchAnchor = cleanText(producerName) || cleanText(productName);
   const visibleSources = sources.map(sourceEvidenceLabel).filter(Boolean);
   const visibleSignals = signals
     .map((signal) => ({
@@ -191,10 +267,20 @@ function ProductSuccessNarrative({
       <div className="text-secondary small">Investigação de sucesso</div>
       <h3 className="h6 mb-2">Conclusões somente com base rastreável</h3>
       <p className="small mb-3">
-        Esta área não cria narrativa própria na tela. Ela mostra apenas a
-        conclusão persistida pelo processamento, a próxima pesquisa registrada e
-        as fontes/sinais públicos retornados para auditoria.
+        Esta área explica por que o sistema pesquisou pessoas, marcas e canais
+        relacionados ao produto. A pesquisa não procura apenas a palavra do
+        nome: ela tenta descobrir quem educa o mercado, onde existe audiência e
+        quais sinais públicos podem explicar as vendas.
       </p>
+
+      <section className="bg-white border rounded p-3 mb-2">
+        <h4 className="h6 mb-2">Por que estas pesquisas aparecem</h4>
+        <p className="small mb-0">
+          {searchAnchor
+            ? `O dossiê usa ${searchAnchor} como ponto de partida para encontrar autoridade, prova social, canais de audiência e ofertas concorrentes ao redor do produto.`
+            : "O dossiê usa o nome do produto, a página de venda e os termos da análise comercial como ponto de partida para encontrar autoridade, prova social, canais de audiência e ofertas concorrentes."}
+        </p>
+      </section>
 
       <section className="bg-white border rounded p-3 mb-2">
         <h4 className="h6 mb-2">Conclusão registrada</h4>
@@ -255,6 +341,123 @@ function ProductSuccessNarrative({
         )}
       </section>
     </article>
+  );
+}
+
+function parseJsonRecord(content?: string) {
+  if (!content?.trim()) return undefined;
+  try {
+    const parsed = JSON.parse(content) as unknown;
+    return isObjectLike(parsed) ? parsed : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+function toPrettyJson(value: unknown) {
+  if (value == null) return undefined;
+  try {
+    return JSON.stringify(value, null, 2);
+  } catch {
+    return undefined;
+  }
+}
+
+function extractOpenAiRequestBody(requestPayloadJson?: string) {
+  const parsed = parseJsonRecord(requestPayloadJson);
+  if (!parsed) return undefined;
+  const body = parsed.body;
+  return isObjectLike(body) ? body : parsed;
+}
+
+function extractOpenAiPromptJson(requestPayloadJson?: string) {
+  const body = extractOpenAiRequestBody(requestPayloadJson);
+  if (!body) return undefined;
+  const input = body.input;
+  if (Array.isArray(input)) {
+    return toPrettyJson({ input });
+  }
+  return typeof input === "string" ? toPrettyJson({ input }) : undefined;
+}
+
+function extractOpenAiSchemaJson(requestPayloadJson?: string) {
+  const body = extractOpenAiRequestBody(requestPayloadJson);
+  if (!body) return undefined;
+  const text = body.text;
+  const format = isObjectLike(text) ? text.format : undefined;
+  if (!isObjectLike(format)) return undefined;
+
+  const schema = format.schema ?? format.json_schema;
+  if (schema) {
+    return toPrettyJson(schema);
+  }
+  return undefined;
+}
+
+function OpenAiAuditJsonBlock({
+  title,
+  content,
+  emptyMessage,
+}: {
+  title: string;
+  content?: string;
+  emptyMessage: string;
+}) {
+  return (
+    <div className="border rounded p-3 bg-light-subtle">
+      <h4 className="h6 mb-2">{title}</h4>
+      <CollapsibleJsonViewer
+        content={content}
+        emptyMessage={emptyMessage}
+        initiallyCollapsed
+      />
+    </div>
+  );
+}
+
+function OpenAiAnalysisAuditSection({
+  requestPayloadJson,
+  responsePayloadJson,
+}: {
+  requestPayloadJson?: string;
+  responsePayloadJson?: string;
+}) {
+  const promptJson = extractOpenAiPromptJson(requestPayloadJson);
+  const schemaJson = extractOpenAiSchemaJson(requestPayloadJson);
+
+  return (
+    <section className="border rounded p-3">
+      <div className="mb-3">
+        <div className="text-secondary small">Auditoria técnica da OpenAI</div>
+        <h3 className="h6 mb-1">Prompt, request, response e schema</h3>
+        <p className="small text-secondary mb-0">
+          Esta seção mostra os dados técnicos que explicam o que foi enviado ao
+          modelo e o que voltou dele, em layout JSON para facilitar auditoria.
+        </p>
+      </div>
+      <div className="d-flex flex-column gap-3">
+        <OpenAiAuditJsonBlock
+          title="Prompt usado"
+          content={promptJson}
+          emptyMessage="Prompt não registrado no payload desta análise."
+        />
+        <OpenAiAuditJsonBlock
+          title="Request enviado para OpenAI"
+          content={requestPayloadJson}
+          emptyMessage="Request OpenAI não registrado nesta análise."
+        />
+        <OpenAiAuditJsonBlock
+          title="Response da OpenAI"
+          content={responsePayloadJson}
+          emptyMessage="Response cru da OpenAI ainda não registrado nesta análise."
+        />
+        <OpenAiAuditJsonBlock
+          title="Schema JSON enviado"
+          content={schemaJson}
+          emptyMessage="Nenhum schema JSON explícito foi registrado; quando houver schema no request ele aparecerá aqui."
+        />
+      </div>
+    </section>
   );
 }
 
@@ -592,6 +795,16 @@ export default function MoisSalesPageLibraryDetailPage() {
 
           {warmupQuery.data ? (
             <>
+              <ProductIdentityCard
+                productName={pageQuery.data?.productName}
+                producerName={pageQuery.data?.producerName}
+                title={pageQuery.data?.title}
+                offerSummary={pageQuery.data?.offerSummary}
+                promiseSummary={pageQuery.data?.promiseSummary}
+                mechanismSummary={pageQuery.data?.mechanismSummary}
+                proofSummary={pageQuery.data?.proofSummary}
+              />
+
               <div className="row g-3">
                 <div className="col-md-3">
                   <div className="border rounded p-3 h-100 bg-light-subtle">
@@ -650,6 +863,10 @@ export default function MoisSalesPageLibraryDetailPage() {
                 summary={warmupQuery.data}
                 signals={warmupSignalsQuery.data?.items ?? []}
                 sources={warmupSourcesQuery.data?.items ?? []}
+                productName={
+                  pageQuery.data?.productName || pageQuery.data?.title
+                }
+                producerName={pageQuery.data?.producerName}
               />
 
               {warmupQuery.data.status === "FAILED" ? (
@@ -839,13 +1056,9 @@ export default function MoisSalesPageLibraryDetailPage() {
               title="Notas de análise retornadas pelo worker"
               content={analysisQuery.data.analysisNotes}
             />
-            <JsonCollapse
-              title="Request enviado ao modelo"
-              content={analysisQuery.data.requestPayloadJson}
-            />
-            <JsonCollapse
-              title="Prompt usado no modelo"
-              content={analysisQuery.data.promptVersion}
+            <OpenAiAnalysisAuditSection
+              requestPayloadJson={analysisQuery.data.requestPayloadJson}
+              responsePayloadJson={analysisQuery.data.responsePayloadJson}
             />
           </div>
         </section>

--- a/mois-sales-library-worker/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/model/WorkerDtos.java
+++ b/mois-sales-library-worker/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/model/WorkerDtos.java
@@ -15,7 +15,7 @@ public final class WorkerDtos {
     public record ClaimRequest(String workspaceId, String source) {}
     public record ClaimedJob(Long jobId, Long pageId, String urlCanonical, String title, String rawHtml) {}
     public record ClaimResponse(boolean claimed, ClaimedJob job) {}
-    public record CompleteRequest(BigDecimal scoreTotal, String sectionsJson, String copyJson, String visualJson, String imageJson, String analysisNotes, String requestPayloadJson, String parserVersion, String promptVersion, String modelName, Integer inputTokens, Integer outputTokens, BigDecimal modelCostUsd, Instant analyzedAt) {}
+    public record CompleteRequest(BigDecimal scoreTotal, String sectionsJson, String copyJson, String visualJson, String imageJson, String analysisNotes, String requestPayloadJson, String responsePayloadJson, String parserVersion, String promptVersion, String modelName, Integer inputTokens, Integer outputTokens, BigDecimal modelCostUsd, Instant analyzedAt) {}
     public record FailRequest(String errorCategory, String errorMessage) {}
 
     public record CollectedReferenceHtmlClaimRequest(String workspaceId, String source) {}

--- a/mois-sales-library-worker/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/openai/OpenAiSalesPageAnalyzer.java
+++ b/mois-sales-library-worker/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/openai/OpenAiSalesPageAnalyzer.java
@@ -206,6 +206,7 @@ public class OpenAiSalesPageAnalyzer {
                     objectMapper.writeValueAsString(parsed.path("image_json")),
                     parsed.path("analysis_notes").asText("Análise gerada via OpenAI batch"),
                     requestPayloadJson,
+                    outputJsonl,
                     "html-v1",
                     "openai-batch-v1",
                     properties.normalizedModel(),

--- a/mois-sales-library-worker/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/openai/SalesPageAnalysisResult.java
+++ b/mois-sales-library-worker/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/openai/SalesPageAnalysisResult.java
@@ -13,6 +13,7 @@ public record SalesPageAnalysisResult(
         String imageJson,
         String analysisNotes,
         String requestPayloadJson,
+        String responsePayloadJson,
         String parserVersion,
         String promptVersion,
         String modelName,

--- a/mois-sales-library-worker/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/PipelineRunner.java
+++ b/mois-sales-library-worker/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/PipelineRunner.java
@@ -112,7 +112,7 @@ public class PipelineRunner {
             String text = extractAnalysisText(claim.job());
             SalesPageAnalysisResult analysis =
                     openAiSalesPageAnalyzer.analyze(jobId, claim.job().pageId(), claim.job().urlCanonical(), text);
-            backendClient.complete(jobId, new CompleteRequest(
+            CompleteRequest completeRequest = new CompleteRequest(
                     analysis.scoreTotal(),
                     analysis.sectionsJson(),
                     analysis.copyJson(),
@@ -120,13 +120,17 @@ public class PipelineRunner {
                     analysis.imageJson(),
                     analysis.analysisNotes(),
                     analysis.requestPayloadJson(),
+                    analysis.responsePayloadJson(),
                     analysis.parserVersion(),
                     analysis.promptVersion(),
                     analysis.modelName(),
                     analysis.inputTokens(),
                     analysis.outputTokens(),
                     analysis.modelCostUsd(),
-                    Instant.now()));
+                    Instant.now());
+            log.info("MOIS sales-library enviando payload de conclusão ao backend. jobId={}, payload={}",
+                    jobId, completeRequest);
+            backendClient.complete(jobId, completeRequest);
             log.info("MOIS library job {} completed for page {}", jobId, claim.job().pageId());
         } catch (Exception ex) {
             backendClient.fail(jobId, new FailRequest("PIPELINE_ERROR", ex.getMessage()));


### PR DESCRIPTION
### Motivation

- Persist the raw OpenAI response and expose product identity to enable technical auditability and clearer dossiê narratives for MOIS sales pages.
- Surface model usage metadata (tokens/cost) and product/producer information in the consolidated page contract so the UI can explain why public research was performed.

### Description

- Backend DTOs were extended to carry `responsePayloadJson`, and `SalesLibraryPageResponse` now includes `productName` and `producerName` with SQL joins to `mois_collected_reference` and updated mapping in `mapSalesPageResponse`.
- `completeJob` SQL and job execution columns were adjusted to persist `response_payload_json`, `parser_version` and `prompt_version` correctly and to include model usage fields when updating consolidated page state.
- Worker changes propagate the OpenAI raw response: `SalesPageAnalysisResult` and `WorkerDtos.CompleteRequest` now include `responsePayloadJson`, `OpenAiSalesPageAnalyzer` returns the output JSONL as response payload, and `PipelineRunner` forwards it to the backend with logging.
- Frontend updates add `productName`/`producerName` and `responsePayloadJson` to API types, introduce `ProductIdentityCard`, an improved success narrative explaining the search anchor, and an `OpenAiAnalysisAuditSection` with JSON viewers for prompt/request/response/schema using `CollapsibleJsonViewer`.
- Swagger and documentation were updated to document the new fields and clarify UX changes; unit test mocks were updated to reflect the evolved DTO shape.

### Testing

- Updated and ran the backend unit test `MoisSalesLibraryServiceTest` which was adjusted to the new DTO fields and passed.
- Performed frontend type-check/build (TypeScript) to validate the added fields and new components and the build/type-check succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2afb80fde88321a5294fb935e56d86)