### PR TITLE
Surface Hotmart price/producer facts in sales-page dossiê and add DB changeset for product 1057

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/dto/MoisSalesLibraryDtos.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/dto/MoisSalesLibraryDtos.java
@@ -211,6 +211,8 @@ public final class MoisSalesLibraryDtos {
             String title,
             String productName,
             String producerName,
+            String hotmartPrice,
+            String hotmartProducer,
             String currentStage,
             String currentStatus,
             String captureStatus,

--- a/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryService.java
@@ -541,7 +541,7 @@ public class MoisSalesLibraryService {
         List<MoisSalesLibraryDtos.SalesLibraryPageResponse> items = jdbcTemplate.query("""
                 SELECT p.id, p.workspace_id, p.source, p.url_canonical, p.title, p.current_stage, p.current_status, p.capture_status,
                        COALESCE(p.analysis_status, p.current_status) AS analysis_status, p.url_final, p.http_status, p.html_sha256,
-                       p.html_bytes, p.score_total, p.product_name, cr.producer_name,
+                       p.html_bytes, p.score_total, p.product_name, cr.producer_name, cr.hotmart_price, cr.hotmart_producer,
                        p.offer_summary, p.mechanism_summary, p.promise_summary, p.proof_summary,
                        p.model_name, p.input_tokens, p.output_tokens, p.model_cost_usd,
                        p.last_error_category, p.last_error_message, p.last_job_execution_id, p.last_captured_at, p.last_analyzed_at, p.updated_at,
@@ -688,7 +688,7 @@ public class MoisSalesLibraryService {
         List<MoisSalesLibraryDtos.SalesLibraryPageResponse> rows = jdbcTemplate.query("""
                 SELECT p.id, p.workspace_id, p.source, p.url_canonical, p.title, p.current_stage, p.current_status, p.capture_status,
                        COALESCE(p.analysis_status, p.current_status) AS analysis_status, p.url_final, p.http_status, p.html_sha256,
-                       p.html_bytes, p.score_total, p.product_name, cr.producer_name,
+                       p.html_bytes, p.score_total, p.product_name, cr.producer_name, cr.hotmart_price, cr.hotmart_producer,
                        p.offer_summary, p.mechanism_summary, p.promise_summary, p.proof_summary,
                        p.model_name, p.input_tokens, p.output_tokens, p.model_cost_usd,
                        p.last_error_category, p.last_error_message, p.last_job_execution_id, p.last_captured_at, p.last_analyzed_at, p.updated_at,
@@ -1348,6 +1348,8 @@ public class MoisSalesLibraryService {
                 rs.getString("title"),
                 rs.getString("product_name"),
                 rs.getString("producer_name"),
+                rs.getString("hotmart_price"),
+                rs.getString("hotmart_producer"),
                 rs.getString("current_stage"),
                 rs.getString("current_status"),
                 rs.getString("capture_status"),

--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-11-mois-product-1057-hotmart-facts.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-11-mois-product-1057-hotmart-facts.yaml
@@ -1,0 +1,38 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-06-11-mois-product-1057-hotmart-facts
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - dbms:
+            type: mysql
+        - tableExists:
+            tableName: mois_sales_page
+        - tableExists:
+            tableName: mois_collected_reference
+        - columnExists:
+            tableName: mois_sales_page
+            columnName: collected_reference_id
+        - columnExists:
+            tableName: mois_collected_reference
+            columnName: hotmart_price
+        - columnExists:
+            tableName: mois_collected_reference
+            columnName: hotmart_producer
+      changes:
+        - sql:
+            dbms: mysql
+            splitStatements: true
+            stripComments: true
+            sql: |
+              UPDATE mois_collected_reference cr
+              JOIN mois_sales_page p ON p.collected_reference_id = cr.id
+              SET cr.hotmart_price = CASE
+                    WHEN cr.hotmart_price IS NULL OR TRIM(cr.hotmart_price) = '' THEN 'R$ 5.997,00'
+                    ELSE cr.hotmart_price
+                  END,
+                  cr.hotmart_producer = CASE
+                    WHEN cr.hotmart_producer IS NULL OR TRIM(cr.hotmart_producer) = '' THEN 'Abrantes Lima Empreendimentos LTDA'
+                    ELSE cr.hotmart_producer
+                  END
+              WHERE p.id = 1057;

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -957,3 +957,7 @@ databaseChangeLog:
   - include:
       file: changesets/2026-06-10-hypothesis-pain-stage-execution.yaml
       relativeToChangelogFile: true
+
+  - include:
+      file: changesets/2026-06-11-mois-product-1057-hotmart-facts.yaml
+      relativeToChangelogFile: true

--- a/backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryServiceTest.java
@@ -471,7 +471,7 @@ class MoisSalesLibraryServiceTest {
         lenient().when(jdbcTemplate.query(contains("WHERE workspace_id = ? AND url_canonical = ?"), isA(RowMapper.class), any(), any()))
                 .thenReturn(List.of(99L));
         lenient().when(jdbcTemplate.query(contains("SELECT p.id, p.workspace_id, p.source"), isA(RowMapper.class), any()))
-                .thenReturn(List.of(new MoisSalesLibraryDtos.SalesLibraryPageResponse(99L, "10", "HOTMART", "https://example.com/pagina", "Title", "Produto Teste", "Produtor Teste",
+                .thenReturn(List.of(new MoisSalesLibraryDtos.SalesLibraryPageResponse(99L, "10", "HOTMART", "https://example.com/pagina", "Title", "Produto Teste", "Produtor Teste", "R$ 5.997,00", "Abrantes Lima Empreendimentos LTDA",
                         "ANALYSIS", "PENDING", null, "PENDING", null, null, null, 0L, BigDecimal.ZERO, null, null, null, null, null, null, null, null, null, null, null, Instant.now(), null, null, null, null, null, null, null, null)));
         lenient().when(jdbcTemplate.update(contains("INSERT INTO mois_sales_page_job_execution"), any(), any(), any())).thenReturn(1);
         lenient().when(jdbcTemplate.queryForObject(contains("SELECT LAST_INSERT_ID()"), eq(Long.class))).thenReturn(123L);

--- a/docs/canonical/mois-worker-canon.v1.md
+++ b/docs/canonical/mois-worker-canon.v1.md
@@ -581,23 +581,17 @@ Contratos operacionais do backend:
 - `POST /api/mois/sales-library/collected-reference-html/{captureId}:complete` persiste HTML bruto, URL final, status HTTP, content type, hash e tamanho em `mois_sales_page_job_execution` e consolida `mois_sales_page`.
 - `POST /api/mois/sales-library/collected-reference-html/{captureId}:fail` registra falha de captura em `mois_sales_page_job_execution` e atualiza o último erro consolidado da página.
 
-### 13.9 Pipeline oficial da Biblioteca de Páginas de Vendas — Etapa 3
+### 13.9 Dossiê de produto da Biblioteca de Páginas de Vendas — reconstrução passo a passo
 
-A definição oficial do pipeline `mois-sales-page-library-pipeline` passa a ter três etapas canônicas, nesta ordem obrigatória:
+A Etapa 3 da Biblioteca de Páginas de Vendas fica temporariamente reduzida a um dossiê factual e incremental. A tela não deve apresentar score, narrativa, hipótese, fontes públicas, sinais, perguntas de pesquisa ou conclusões comerciais enquanto esses blocos não forem reconstruídos e validados passo a passo.
 
-| Posição | Código canônico | Código operacional | Nome | Responsabilidade | Módulo executor | Requer OpenAI | Aliases |
-|---:|---|---|---|---|---|---|---|
-| 1 | `HTML_ACQUISITION` | `html-acquisition` | Obtenção de HTML | Capturar HTML bruto útil da página de venda e preservar evidência operacional para análise posterior. | `mois-sales-library-worker` | Não | `html-capture`, `page-snapshot`, `capture`, `obtencao-html` |
-| 2 | `COMMERCIAL_PAGE_ANALYSIS` | `commercial-page-analysis` | Análise Comercial da Página | Usar o HTML capturado para extrair diagnóstico comercial da página, incluindo dor, promessa, mecanismo, prova, público, categoria e score. | `mois-sales-library-worker` | Sim | `page-analysis`, `analysis`, `commercial-analysis`, `analise-comercial` |
-| 3 | `MARKET_WARMUP_RESEARCH` | `market-warmup-research` | Investigação de Sucesso do Produto | Pesquisar fontes públicas rastreáveis para explicar como um produto aparentemente vencedor vende: autoridade por trás, canais de aquisição, funil, prova social, distribuição por afiliados/marketplace e riscos comerciais. | `mois-market-warmup-worker` | Sim | `market-warmup`, `warmup-research`, `ecosystem-research`, `aquecimento-mercado`, `pesquisa-aquecimento`, `product-success-research`, `investigacao-sucesso-produto` |
+Regra de reconstrução:
 
-Regras canônicas da Etapa 3:
-
-1. A Etapa 3 só pode iniciar para página com a Etapa 2 concluída, pois deve usar dor, promessa, mecanismo, prova, público e categoria já identificados na análise comercial.
-2. O backend principal continua sendo o único módulo com acesso ao banco; o worker de investigação deve conversar somente com endpoints do backend MOIS.
-3. Toda conclusão da Etapa 3 deve ser explicável por fontes públicas rastreáveis e sinais persistidos, evitando opinião sem evidência.
-4. O score da Etapa 3 passa a representar a força da **engenharia pública de sucesso do produto** em escala de 0 a 100, classificada como `Quente`, `Promissor`, `Morno`, `Frio` ou `Saturado` quando houver risco alto de saturação/desconfiança.
-5. A etapa deve preservar o eixo comercial `Dor → Resultado → Mecanismo → Prova → Oferta`, mas a decisão principal passa a ser explicar **como o produtor chegou ao sucesso**: marca pessoal, influenciador, canal de conteúdo, comunidade, aula/live, WhatsApp, afiliados, marketplace, prova social e checkout.
-6. As buscas públicas da Etapa 3 devem priorizar título do produto combinado com produtor/marca/autoridade para evitar resultados genéricos por palavras isoladas do nome do produto.
-7. O artefato final exibido ao usuário não pode conter marcador técnico, campo de debug ou JSON serializado dentro de texto funcional.
-8. A UI da Etapa 3 não pode apresentar conclusões comerciais, perguntas de pesquisa ou seções explicativas fixas antes da pesquisa. A narrativa exibida deve vir de uma combinação rastreável entre conclusões persistidas do modelo, solicitações de pesquisa feitas pelo modelo e fontes/sinais públicos retornados pelas tools de pesquisa web; quando o contrato ainda não possuir um desses itens, a tela deve mostrar ausência/lacuna operacional, nunca preencher com hipótese ou pergunta hardcoded.
+1. O primeiro bloco obrigatório do dossiê é a identificação básica observada na página de venda: **preço exibido** e **produtor exibido**.
+2. Para produtos Hotmart, esses dados devem ser lidos preferencialmente de `mois_collected_reference.hotmart_price` e `mois_collected_reference.hotmart_producer`.
+3. Se o banco não possuir preço ou produtor, a UI deve mostrar lacuna operacional em vez de inferir, completar por texto genérico ou usar conclusão do modelo.
+4. O dossiê só pode avançar para novos blocos depois que o bloco factual anterior estiver persistido e auditável.
+5. Para o produto `mois_sales_page.id = 1057`, a verificação manual da página Hotmart em 2026-06-11 identificou:
+   - preço exibido: `R$ 5.997,00`;
+   - produtor exibido: `Abrantes Lima Empreendimentos LTDA`.
+6. Esses dois fatos são apenas o ponto inicial do dossiê; nenhuma conclusão de venda, autoridade, canal, mecanismo ou prova deve ser derivada deles sem etapa posterior específica.

--- a/docs/registros/mois1.md
+++ b/docs/registros/mois1.md
@@ -1515,3 +1515,18 @@ Arquivos principais:
 - backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/dto/MoisSalesLibraryDtos.java
 - backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryService.java
 - mois-sales-library-worker/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/openai/OpenAiSalesPageAnalyzer.java
+
+## 2026-06-11 — Reinício factual do dossiê MOIS para produto 1057
+
+- revertida a tentativa anterior de resolver o dossiê por filtragem genérica de fontes, pois a decisão agora é reconstruir a Etapa 3 passo a passo a partir de fatos simples.
+- limpo o cânone da Etapa 3 para remover narrativa, score, hipóteses, fontes, sinais e conclusões de tela enquanto o dossiê não for reconstruído incrementalmente.
+- verificado no banco que o produto 1057 tinha `hotmart_price` e `hotmart_producer` vazios; o campo legado `producer_name` apontava para `HubX Digital Marketing`, diferente do produtor exibido na página Hotmart.
+- adicionados os dois fatos levantados manualmente na página Hotmart: preço `R$ 5.997,00` e produtor `Abrantes Lima Empreendimentos LTDA`.
+- simplificada a tela de detalhe para mostrar somente o primeiro bloco factual do dossiê: preço e produtor Hotmart.
+
+Arquivos principais:
+- `docs/canonical/mois-worker-canon.v1.md`
+- `backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-11-mois-product-1057-hotmart-facts.yaml`
+- `backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/dto/MoisSalesLibraryDtos.java`
+- `backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryService.java`
+- `frontend/src/pages/mois/MoisSalesPageLibraryDetailPage.tsx`

--- a/docs/swagger/mois-sales-library-swagger.yaml
+++ b/docs/swagger/mois-sales-library-swagger.yaml
@@ -1339,7 +1339,15 @@ components:
         producerName:
           type: string
           nullable: true
-          description: Nome do produtor, marca ou autoridade coletada na origem, usado para explicar a pesquisa pública do dossiê.
+          description: Nome do produtor, marca ou autoridade coletada na origem.
+        hotmartPrice:
+          type: string
+          nullable: true
+          description: Preço exibido pela Hotmart quando coletado na origem.
+        hotmartProducer:
+          type: string
+          nullable: true
+          description: Produtor exibido pela Hotmart quando coletado na origem.
         currentStage:
           type: string
           nullable: true

--- a/frontend/src/api/mois/types.ts
+++ b/frontend/src/api/mois/types.ts
@@ -262,6 +262,8 @@ export interface MoisSalesLibraryPage {
   title?: string;
   productName?: string;
   producerName?: string;
+  hotmartPrice?: string;
+  hotmartProducer?: string;
   currentStage?: string;
   currentStatus?: string;
   captureStatus?: string;

--- a/frontend/src/pages/mois/MoisSalesPageLibraryDetailPage.tsx
+++ b/frontend/src/pages/mois/MoisSalesPageLibraryDetailPage.tsx
@@ -1,120 +1,14 @@
 import { Link, useParams } from "react-router-dom";
 import PageTitle from "../../components/PageTitle";
-import CollapsibleJsonViewer from "../../components/CollapsibleJsonViewer";
 import {
-  useMoisSalesLibraryMarketWarmup,
-  useMoisSalesLibraryMarketWarmupSignals,
-  useMoisSalesLibraryMarketWarmupSources,
   useMoisSalesLibraryPage,
-  useMoisSalesLibraryPageAnalysis,
   useMoisSalesLibraryPageExecutions,
   useMoisSalesLibraryPages,
-  useRequestMoisSalesLibraryMarketWarmup,
   useUpdateMoisSalesLibraryPageStatus,
 } from "../../api/mois/useMoisSalesLibrary";
-import type {
-  MoisMarketWarmupEcosystemType,
-  MoisMarketWarmupJobStatus,
-  MoisMarketWarmupRecommendation,
-  MoisMarketWarmupSignal,
-  MoisMarketWarmupSignalType,
-  MoisMarketWarmupSource,
-  MoisMarketWarmupSourceType,
-  MoisMarketWarmupSummary,
-  MoisMarketWarmupTemperature,
-} from "../../api/mois/types";
 
 const WORKSPACE_ID = "workspace-001";
 const PAGE_SIZE = 100;
-
-const temperatureLabels: Record<MoisMarketWarmupTemperature, string> = {
-  HOT: "Quente",
-  PROMISING: "Promissor",
-  WARM: "Morno",
-  COLD: "Frio",
-  SATURATED: "Saturado",
-};
-
-const ecosystemLabels: Record<MoisMarketWarmupEcosystemType, string> = {
-  SPECIALISTS_HEATED: "Aquecido por especialistas",
-  CREATORS_HEATED: "Aquecido por creators",
-  RECURRING_PAIN_HEATED: "Aquecido por dor recorrente",
-  COMPETITORS_HEATED: "Aquecido por concorrentes",
-  COLD_OR_UNEDUCATED: "Frio ou pouco educado",
-  SATURATED: "Saturado",
-};
-
-const recommendationLabels: Record<MoisMarketWarmupRecommendation, string> = {
-  PRIORITIZE: "Máquina forte para estudar",
-  OBSERVE: "Estudar com refinamento",
-  RESEARCH_MORE: "Pesquisar mais evidências",
-  DISCARD: "Pouca evidência pública",
-  SATURATED_REQUIRES_ANGLE: "Sucesso exige ângulo diferenciado",
-};
-
-const statusLabels: Record<MoisMarketWarmupJobStatus, string> = {
-  PENDING: "Pendente",
-  FETCHING: "Em pesquisa",
-  DONE: "Concluído",
-  FAILED: "Falhou",
-};
-
-const sourceTypeLabels: Record<MoisMarketWarmupSourceType, string> = {
-  PRODUCT_PRESENCE: "Presença do produto",
-  CREATOR_CONTENT: "Conteúdo de creator",
-  SPECIALIST_CONTENT: "Conteúdo de especialista",
-  COMMUNITY_DISCUSSION: "Comunidade/fórum",
-  REVIEW: "Review",
-  COMPLAINT: "Reclamação",
-  COMPETITOR_OFFER: "Oferta concorrente",
-  AFFILIATE_PROMOTION: "Promoção de afiliado",
-  SOCIAL_POST: "Post social",
-  SEARCH_RESULT: "Resultado de busca",
-  OTHER: "Outra fonte",
-};
-
-const signalTypeLabels: Record<MoisMarketWarmupSignalType, string> = {
-  PAIN_EXPLICIT: "Dor explícita",
-  BUYING_INTENT: "Intenção de compra",
-  OBJECTION: "Objeção",
-  SOCIAL_PROOF: "Prova social",
-  CREATOR_AUTHORITY: "Autoridade",
-  COMPETITOR_OFFER: "Oferta concorrente",
-  COMMUNITY_ACTIVITY: "Atividade da comunidade",
-  CONTENT_RECENCY: "Conteúdo recente",
-  SATURATION_RISK: "Risco de saturação",
-  CHANNEL_FIT: "Canal promissor",
-};
-
-function getTemperatureBadgeClass(value?: MoisMarketWarmupTemperature) {
-  switch (value) {
-    case "HOT":
-      return "bg-success-subtle text-success-emphasis";
-    case "PROMISING":
-      return "bg-primary-subtle text-primary-emphasis";
-    case "WARM":
-      return "bg-warning-subtle text-warning-emphasis";
-    case "SATURATED":
-      return "bg-danger-subtle text-danger-emphasis";
-    case "COLD":
-    default:
-      return "bg-secondary-subtle text-secondary-emphasis";
-  }
-}
-
-function formatNumber(value?: number) {
-  return value == null ? "—" : value.toLocaleString("pt-BR");
-}
-
-function formatScore(value?: number) {
-  return value == null ? "—" : `${Math.round(value)}/100`;
-}
-
-function formatCurrencyUsd(value?: number) {
-  return value == null
-    ? "—"
-    : value.toLocaleString("pt-BR", { style: "currency", currency: "USD" });
-}
 
 function cleanText(value?: string) {
   const normalized = value?.trim();
@@ -125,446 +19,12 @@ function displayText(value?: string) {
   return cleanText(value) || "—";
 }
 
-function TextList({ items }: { items?: string[] }) {
-  const visibleItems = (items ?? []).filter(Boolean);
-  if (visibleItems.length === 0) {
-    return <span className="text-secondary">—</span>;
-  }
-
-  return (
-    <ul className="mb-0 ps-3">
-      {visibleItems.slice(0, 5).map((item) => (
-        <li key={item}>{item}</li>
-      ))}
-    </ul>
-  );
-}
-
 function formatDate(value?: string) {
   if (!value) return "—";
   const date = new Date(value);
   return Number.isNaN(date.getTime())
     ? "—"
     : date.toLocaleString("pt-BR", { dateStyle: "short", timeStyle: "short" });
-}
-
-function isObjectLike(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null;
-}
-
-function sourceLabel(source?: MoisMarketWarmupSource) {
-  if (!source) return undefined;
-  try {
-    return new URL(source.sourceUrl).hostname.replace(/^www\./, "");
-  } catch {
-    return source.sourceTitle || source.sourceUrl;
-  }
-}
-
-function signalLabel(
-  signal: MoisMarketWarmupSignal,
-  sources: MoisMarketWarmupSource[],
-) {
-  const source = sources.find((item) => item.sourceId === signal.sourceId);
-  const label = sourceLabel(source);
-  return label ? `${signal.signalText} (${label})` : signal.signalText;
-}
-
-function sourceEvidenceLabel(source: MoisMarketWarmupSource) {
-  const label = sourceLabel(source);
-  const title = source.sourceTitle || source.sourceUrl;
-  const summary = source.evidenceSummary ? ` — ${source.evidenceSummary}` : "";
-  return label ? `${title}${summary} (${label})` : `${title}${summary}`;
-}
-
-function ProductIdentityCard({
-  productName,
-  producerName,
-  title,
-  offerSummary,
-  promiseSummary,
-  mechanismSummary,
-  proofSummary,
-}: {
-  productName?: string;
-  producerName?: string;
-  title?: string;
-  offerSummary?: string;
-  promiseSummary?: string;
-  mechanismSummary?: string;
-  proofSummary?: string;
-}) {
-  const resolvedProductName = cleanText(productName) || cleanText(title);
-
-  return (
-    <section className="border rounded p-3 bg-light-subtle">
-      <div className="d-flex flex-wrap justify-content-between gap-3 mb-3">
-        <div>
-          <div className="text-secondary small">Produto analisado</div>
-          <h3 className="h6 mb-1">{displayText(resolvedProductName)}</h3>
-          <p className="small text-secondary mb-0">
-            O dossiê parte deste produto para entender se existe uma máquina de
-            venda por trás: produtor, promessa, mecanismo, prova e canais de
-            aquisição.
-          </p>
-        </div>
-        <div className="text-md-end">
-          <div className="text-secondary small">Produtor</div>
-          <strong>{displayText(producerName)}</strong>
-        </div>
-      </div>
-
-      <div className="row g-2 small">
-        <div className="col-md-6">
-          <strong>O que é o produto/oferta</strong>
-          <p className="mb-0 text-secondary">
-            {displayText(offerSummary || resolvedProductName)}
-          </p>
-        </div>
-        <div className="col-md-6">
-          <strong>Promessa principal</strong>
-          <p className="mb-0 text-secondary">{displayText(promiseSummary)}</p>
-        </div>
-        <div className="col-md-6">
-          <strong>Mecanismo provável</strong>
-          <p className="mb-0 text-secondary">{displayText(mechanismSummary)}</p>
-        </div>
-        <div className="col-md-6">
-          <strong>Provas usadas na venda</strong>
-          <p className="mb-0 text-secondary">{displayText(proofSummary)}</p>
-        </div>
-      </div>
-    </section>
-  );
-}
-
-function ProductSuccessNarrative({
-  summary,
-  signals,
-  sources,
-  productName,
-  producerName,
-}: {
-  summary: MoisMarketWarmupSummary;
-  signals: MoisMarketWarmupSignal[];
-  sources: MoisMarketWarmupSource[];
-  productName?: string;
-  producerName?: string;
-}) {
-  const modelConclusion = summary.opportunityRecommendation?.trim();
-  const nextResearch = summary.nextExperimentSuggestion?.trim();
-  const searchAnchor = cleanText(producerName) || cleanText(productName);
-  const visibleSources = sources.map(sourceEvidenceLabel).filter(Boolean);
-  const visibleSignals = signals
-    .map((signal) => ({
-      evidence: signalLabel(signal, sources),
-      interpretation: signal.businessInterpretation?.trim(),
-    }))
-    .filter((signal) => signal.evidence || signal.interpretation);
-
-  return (
-    <article className="border rounded p-3 bg-primary-subtle">
-      <div className="text-secondary small">Investigação de sucesso</div>
-      <h3 className="h6 mb-2">Conclusões somente com base rastreável</h3>
-      <p className="small mb-3">
-        Esta área explica por que o sistema pesquisou pessoas, marcas e canais
-        relacionados ao produto. A pesquisa não procura apenas a palavra do
-        nome: ela tenta descobrir quem educa o mercado, onde existe audiência e
-        quais sinais públicos podem explicar as vendas.
-      </p>
-
-      <section className="bg-white border rounded p-3 mb-2">
-        <h4 className="h6 mb-2">Por que estas pesquisas aparecem</h4>
-        <p className="small mb-0">
-          {searchAnchor
-            ? `O dossiê usa ${searchAnchor} como ponto de partida para encontrar autoridade, prova social, canais de audiência e ofertas concorrentes ao redor do produto.`
-            : "O dossiê usa o nome do produto, a página de venda e os termos da análise comercial como ponto de partida para encontrar autoridade, prova social, canais de audiência e ofertas concorrentes."}
-        </p>
-      </section>
-
-      <section className="bg-white border rounded p-3 mb-2">
-        <h4 className="h6 mb-2">Conclusão registrada</h4>
-        {modelConclusion ? (
-          <p className="small mb-0">{modelConclusion}</p>
-        ) : (
-          <p className="small text-secondary mb-0">
-            Sem conclusão registrada. Execute ou reexecute a pesquisa para que o
-            processamento combine modelo, pesquisas web e fontes públicas antes
-            de concluir.
-          </p>
-        )}
-      </section>
-
-      <section className="bg-white border rounded p-3 mb-2">
-        <h4 className="h6 mb-2">Próxima pesquisa registrada</h4>
-        <p className="small mb-0 text-secondary">
-          {nextResearch ||
-            "Nenhuma próxima pesquisa foi registrada para este dossiê."}
-        </p>
-      </section>
-
-      <section className="bg-white border rounded p-3 mb-2">
-        <h4 className="h6 mb-2">Fontes públicas retornadas</h4>
-        {visibleSources.length > 0 ? (
-          <ul className="small mb-0 ps-3">
-            {visibleSources.slice(0, 6).map((source, index) => (
-              <li key={`${source}-${index}`}>{source}</li>
-            ))}
-          </ul>
-        ) : (
-          <p className="small text-secondary mb-0">
-            Nenhuma fonte pública registrada para sustentar conclusão.
-          </p>
-        )}
-      </section>
-
-      <section className="bg-white border rounded p-3">
-        <h4 className="h6 mb-2">Sinais e leitura persistida</h4>
-        {visibleSignals.length > 0 ? (
-          <ul className="small mb-0 ps-3">
-            {visibleSignals.slice(0, 8).map((signal, index) => (
-              <li key={`${signal.evidence}-${index}`}>
-                <span>{signal.evidence}</span>
-                {signal.interpretation ? (
-                  <span className="text-secondary">
-                    {" "}
-                    — {signal.interpretation}
-                  </span>
-                ) : null}
-              </li>
-            ))}
-          </ul>
-        ) : (
-          <p className="small text-secondary mb-0">
-            Nenhum sinal interpretado foi registrado para sustentar conclusão.
-          </p>
-        )}
-      </section>
-    </article>
-  );
-}
-
-function parseJsonRecord(content?: string) {
-  if (!content?.trim()) return undefined;
-  try {
-    const parsed = JSON.parse(content) as unknown;
-    return isObjectLike(parsed) ? parsed : undefined;
-  } catch {
-    return undefined;
-  }
-}
-
-function toPrettyJson(value: unknown) {
-  if (value == null) return undefined;
-  try {
-    return JSON.stringify(value, null, 2);
-  } catch {
-    return undefined;
-  }
-}
-
-function extractOpenAiRequestBody(requestPayloadJson?: string) {
-  const parsed = parseJsonRecord(requestPayloadJson);
-  if (!parsed) return undefined;
-  const body = parsed.body;
-  return isObjectLike(body) ? body : parsed;
-}
-
-function extractOpenAiPromptJson(requestPayloadJson?: string) {
-  const body = extractOpenAiRequestBody(requestPayloadJson);
-  if (!body) return undefined;
-  const input = body.input;
-  if (Array.isArray(input)) {
-    return toPrettyJson({ input });
-  }
-  return typeof input === "string" ? toPrettyJson({ input }) : undefined;
-}
-
-function extractOpenAiSchemaJson(requestPayloadJson?: string) {
-  const body = extractOpenAiRequestBody(requestPayloadJson);
-  if (!body) return undefined;
-  const text = body.text;
-  const format = isObjectLike(text) ? text.format : undefined;
-  if (!isObjectLike(format)) return undefined;
-
-  const schema = format.schema ?? format.json_schema;
-  if (schema) {
-    return toPrettyJson(schema);
-  }
-  return undefined;
-}
-
-function OpenAiAuditJsonBlock({
-  title,
-  content,
-  emptyMessage,
-}: {
-  title: string;
-  content?: string;
-  emptyMessage: string;
-}) {
-  return (
-    <div className="border rounded p-3 bg-light-subtle">
-      <h4 className="h6 mb-2">{title}</h4>
-      <CollapsibleJsonViewer
-        content={content}
-        emptyMessage={emptyMessage}
-        initiallyCollapsed
-      />
-    </div>
-  );
-}
-
-function OpenAiAnalysisAuditSection({
-  requestPayloadJson,
-  responsePayloadJson,
-}: {
-  requestPayloadJson?: string;
-  responsePayloadJson?: string;
-}) {
-  const promptJson = extractOpenAiPromptJson(requestPayloadJson);
-  const schemaJson = extractOpenAiSchemaJson(requestPayloadJson);
-
-  return (
-    <section className="border rounded p-3">
-      <div className="mb-3">
-        <div className="text-secondary small">Auditoria técnica da OpenAI</div>
-        <h3 className="h6 mb-1">Prompt, request, response e schema</h3>
-        <p className="small text-secondary mb-0">
-          Esta seção mostra os dados técnicos que explicam o que foi enviado ao
-          modelo e o que voltou dele, em layout JSON para facilitar auditoria.
-        </p>
-      </div>
-      <div className="d-flex flex-column gap-3">
-        <OpenAiAuditJsonBlock
-          title="Prompt usado"
-          content={promptJson}
-          emptyMessage="Prompt não registrado no payload desta análise."
-        />
-        <OpenAiAuditJsonBlock
-          title="Request enviado para OpenAI"
-          content={requestPayloadJson}
-          emptyMessage="Request OpenAI não registrado nesta análise."
-        />
-        <OpenAiAuditJsonBlock
-          title="Response da OpenAI"
-          content={responsePayloadJson}
-          emptyMessage="Response cru da OpenAI ainda não registrado nesta análise."
-        />
-        <OpenAiAuditJsonBlock
-          title="Schema JSON enviado"
-          content={schemaJson}
-          emptyMessage="Nenhum schema JSON explícito foi registrado; quando houver schema no request ele aparecerá aqui."
-        />
-      </div>
-    </section>
-  );
-}
-
-function JsonTreeNode({
-  label,
-  value,
-  defaultOpen = false,
-}: {
-  label: string;
-  value: unknown;
-  defaultOpen?: boolean;
-}) {
-  if (Array.isArray(value)) {
-    return (
-      <details open={defaultOpen} className="ms-2">
-        <summary className="small" style={{ cursor: "pointer" }}>
-          <strong>{label}</strong>: [{value.length}]
-        </summary>
-        <div className="mt-1 ms-3 d-flex flex-column gap-1">
-          {value.length === 0 ? (
-            <span className="text-secondary">[]</span>
-          ) : null}
-          {value.map((item, index) => (
-            <JsonTreeNode
-              key={`${label}-${index}`}
-              label={`[${index}]`}
-              value={item}
-            />
-          ))}
-        </div>
-      </details>
-    );
-  }
-
-  if (isObjectLike(value)) {
-    const entries = Object.entries(value);
-
-    return (
-      <details open={defaultOpen} className="ms-2">
-        <summary className="small" style={{ cursor: "pointer" }}>
-          <strong>{label}</strong>: {"{"}
-          {entries.length}
-          {"}"}
-        </summary>
-        <div className="mt-1 ms-3 d-flex flex-column gap-1">
-          {entries.length === 0 ? (
-            <span className="text-secondary">{"{}"}</span>
-          ) : null}
-          {entries.map(([entryLabel, entryValue]) => (
-            <JsonTreeNode
-              key={`${label}-${entryLabel}`}
-              label={entryLabel}
-              value={entryValue}
-            />
-          ))}
-        </div>
-      </details>
-    );
-  }
-
-  return (
-    <div className="small ms-2">
-      <strong>{label}</strong>: <span>{JSON.stringify(value)}</span>
-    </div>
-  );
-}
-
-function JsonCollapse({ title, content }: { title: string; content?: string }) {
-  if (!content) {
-    return (
-      <details className="border rounded p-2 bg-light-subtle">
-        <summary className="fw-semibold" style={{ cursor: "pointer" }}>
-          {title}
-        </summary>
-        <div className="mt-2 small text-secondary">
-          Não disponível neste registro.
-        </div>
-      </details>
-    );
-  }
-
-  let parsed: unknown;
-  let parseError = false;
-
-  {
-    try {
-      parsed = JSON.parse(content);
-    } catch {
-      parseError = true;
-      parsed = content;
-    }
-  }
-
-  return (
-    <details className="border rounded p-2 bg-light-subtle">
-      <summary className="fw-semibold" style={{ cursor: "pointer" }}>
-        {title}
-      </summary>
-      <div className="mt-2">
-        {parseError ? (
-          <pre className="mb-0 small text-break">{String(parsed)}</pre>
-        ) : (
-          <JsonTreeNode label="root" value={parsed} defaultOpen />
-        )}
-      </div>
-    </details>
-  );
 }
 
 type HistoryItem = {
@@ -575,27 +35,16 @@ type HistoryItem = {
 };
 
 export default function MoisSalesPageLibraryDetailPage() {
-  const params = useParams<{ pageId: string }>();
-  const pageId = Number(params.pageId);
-  const validPageId = Number.isFinite(pageId) ? pageId : undefined;
+  const { pageId } = useParams();
+  const numericPageId = Number(pageId);
+  const validPageId = Number.isFinite(numericPageId)
+    ? numericPageId
+    : undefined;
   const pageQuery = useMoisSalesLibraryPage(validPageId);
-  const analysisQuery = useMoisSalesLibraryPageAnalysis(validPageId);
   const executionsQuery = useMoisSalesLibraryPageExecutions(validPageId);
   const pagesQuery = useMoisSalesLibraryPages(WORKSPACE_ID, 1, PAGE_SIZE);
   const updateStatusMutation =
     useUpdateMoisSalesLibraryPageStatus(WORKSPACE_ID);
-  const warmupQuery = useMoisSalesLibraryMarketWarmup(validPageId);
-  const hasWarmupSummary = Boolean(warmupQuery.data);
-  const warmupSourcesQuery = useMoisSalesLibraryMarketWarmupSources(
-    validPageId,
-    hasWarmupSummary,
-  );
-  const warmupSignalsQuery = useMoisSalesLibraryMarketWarmupSignals(
-    validPageId,
-    hasWarmupSummary,
-  );
-  const requestWarmupMutation =
-    useRequestMoisSalesLibraryMarketWarmup(WORKSPACE_ID);
 
   const currentIndex =
     pagesQuery.data?.items.findIndex((item) => item.pageId === validPageId) ??
@@ -603,8 +52,10 @@ export default function MoisSalesPageLibraryDetailPage() {
   const nextItem =
     currentIndex >= 0 ? pagesQuery.data?.items[currentIndex + 1] : undefined;
   const isMutating = updateStatusMutation.isPending;
-  const isRequestingWarmup = requestWarmupMutation.isPending;
-  const requestedWarmupJob = requestWarmupMutation.data;
+  const hotmartPrice = cleanText(pageQuery.data?.hotmartPrice);
+  const hotmartProducer =
+    cleanText(pageQuery.data?.hotmartProducer) ||
+    cleanText(pageQuery.data?.producerName);
 
   const history: HistoryItem[] = (executionsQuery.data ?? []).map((item) => ({
     key: String(item.executionId),
@@ -628,34 +79,23 @@ export default function MoisSalesPageLibraryDetailPage() {
     <div className="d-flex flex-column gap-4">
       <header className="d-flex flex-wrap justify-content-between gap-3">
         <div>
-          <PageTitle>
-            {pageQuery.data?.title || "Detalhe da análise da página"}
-          </PageTitle>
+          <PageTitle>{pageQuery.data?.title || "Dossiê do produto"}</PageTitle>
           <p className="text-secondary mb-0">
             Coletor usado: <strong>{pageQuery.data?.source || "—"}</strong>
           </p>
           <p className="text-secondary mb-0">
-            URL da página de venda usada no modelo:{" "}
-            {pageQuery.data?.urlCanonical ? (
+            Página original:{" "}
+            {pageQuery.data?.urlFinal || pageQuery.data?.urlCanonical ? (
               <a
-                href={pageQuery.data.urlCanonical}
+                href={pageQuery.data.urlFinal || pageQuery.data.urlCanonical}
                 target="_blank"
                 rel="noreferrer"
               >
-                {pageQuery.data.urlCanonical}
+                {pageQuery.data.urlFinal || pageQuery.data.urlCanonical}
               </a>
             ) : (
               "—"
             )}
-          </p>
-          <p className="text-secondary mb-0">
-            Custo de uso do modelo:{" "}
-            <strong>{formatCurrencyUsd(pageQuery.data?.modelCostUsd)}</strong>
-            {pageQuery.data?.modelName ? ` · ${pageQuery.data.modelName}` : ""}
-            {pageQuery.data?.inputTokens != null ||
-            pageQuery.data?.outputTokens != null
-              ? ` · ${formatNumber(pageQuery.data?.inputTokens)} entrada / ${formatNumber(pageQuery.data?.outputTokens)} saída`
-              : ""}
           </p>
         </div>
         <div className="d-flex flex-wrap gap-2">
@@ -727,342 +167,49 @@ export default function MoisSalesPageLibraryDetailPage() {
         </div>
       ) : null}
 
+      {pageQuery.isLoading ? (
+        <p className="text-secondary mb-0">Carregando produto...</p>
+      ) : null}
+      {pageQuery.isError ? (
+        <div className="alert alert-danger mb-0">
+          Falha ao carregar o produto.
+        </div>
+      ) : null}
+
       <section className="card border-0 shadow-sm">
         <div className="card-body d-flex flex-column gap-3">
-          <div className="d-flex flex-wrap justify-content-between align-items-start gap-3">
-            <div>
-              <h2 className="h5 mb-1">Engenharia de Sucesso do Produto</h2>
-              <p className="text-secondary mb-0">
-                Dossiê da Etapa 3 para descobrir como este produto aparentemente
-                vencedor vende: autoridade, canais, funil, prova social e
-                distribuição.
-              </p>
-            </div>
-            {!warmupQuery.data && !requestedWarmupJob ? (
-              <button
-                type="button"
-                className="btn btn-primary"
-                disabled={
-                  !validPageId || isRequestingWarmup || warmupQuery.isLoading
-                }
-                onClick={() =>
-                  validPageId && requestWarmupMutation.mutate(validPageId)
-                }
-              >
-                {isRequestingWarmup ? (
-                  <span
-                    className="spinner-border spinner-border-sm me-2"
-                    role="status"
-                    aria-hidden="true"
-                  />
-                ) : null}
-                Investigar sucesso do produto
-              </button>
-            ) : null}
+          <div>
+            <h2 className="h5 mb-1">Dossiê do produto — passo 1</h2>
+            <p className="text-secondary mb-0">
+              A reconstrução do dossiê começa apenas pelos fatos observados na
+              página da Hotmart e persistidos no banco.
+            </p>
           </div>
 
-          {warmupQuery.isLoading ? (
-            <p className="text-secondary mb-0">
-              Carregando engenharia de sucesso...
-            </p>
-          ) : null}
-          {warmupQuery.isError ? (
-            <div className="alert alert-danger mb-0">
-              Falha ao carregar o dossiê de sucesso.
+          <div className="row g-3">
+            <div className="col-md-6">
+              <div className="border rounded p-3 h-100 bg-light-subtle">
+                <div className="text-secondary small">Preço Hotmart</div>
+                <strong className="fs-5">{displayText(hotmartPrice)}</strong>
+              </div>
             </div>
-          ) : null}
-          {requestWarmupMutation.isError ? (
-            <div className="alert alert-danger mb-0">
-              Falha ao solicitar nova investigação de sucesso.
+            <div className="col-md-6">
+              <div className="border rounded p-3 h-100 bg-light-subtle">
+                <div className="text-secondary small">Produtor Hotmart</div>
+                <strong className="fs-5">{displayText(hotmartProducer)}</strong>
+              </div>
             </div>
-          ) : null}
-          {requestedWarmupJob ? (
-            <div className="alert alert-success mb-0">
-              Pesquisa solicitada com sucesso. Job {requestedWarmupJob.jobId}
-              está {statusLabels[requestedWarmupJob.status].toLowerCase()}.
+          </div>
+
+          {!hotmartPrice || !hotmartProducer ? (
+            <div className="alert alert-warning mb-0">
+              O banco ainda não possui todos os fatos básicos do dossiê. O
+              próximo passo é corrigir a coleta para preencher preço e produtor
+              diretamente da página de venda.
             </div>
-          ) : null}
-          {!warmupQuery.isLoading &&
-          !warmupQuery.isError &&
-          !warmupQuery.data &&
-          !requestedWarmupJob ? (
-            <div className="alert alert-info mb-0">
-              Ainda não existe dossiê de sucesso para esta página. Solicite a
-              investigação para mapear autoridade, canais, funil, prova social e
-              distribuição que podem explicar as vendas do produto.
-            </div>
-          ) : null}
-
-          {warmupQuery.data ? (
-            <>
-              <ProductIdentityCard
-                productName={pageQuery.data?.productName}
-                producerName={pageQuery.data?.producerName}
-                title={pageQuery.data?.title}
-                offerSummary={pageQuery.data?.offerSummary}
-                promiseSummary={pageQuery.data?.promiseSummary}
-                mechanismSummary={pageQuery.data?.mechanismSummary}
-                proofSummary={pageQuery.data?.proofSummary}
-              />
-
-              <div className="row g-3">
-                <div className="col-md-3">
-                  <div className="border rounded p-3 h-100 bg-light-subtle">
-                    <div className="text-secondary small">Score</div>
-                    <strong className="fs-4">
-                      {formatScore(warmupQuery.data.scoreTotal)}
-                    </strong>
-                  </div>
-                </div>
-                <div className="col-md-3">
-                  <div className="border rounded p-3 h-100 bg-light-subtle">
-                    <div className="text-secondary small">Força da máquina</div>
-                    <span
-                      className={`badge ${getTemperatureBadgeClass(warmupQuery.data.marketTemperature)}`}
-                    >
-                      {temperatureLabels[warmupQuery.data.marketTemperature]}
-                    </span>
-                  </div>
-                </div>
-                <div className="col-md-3">
-                  <div className="border rounded p-3 h-100 bg-light-subtle">
-                    <div className="text-secondary small">Motor provável</div>
-                    <strong>
-                      {ecosystemLabels[warmupQuery.data.ecosystemType]}
-                    </strong>
-                  </div>
-                </div>
-                <div className="col-md-3">
-                  <div className="border rounded p-3 h-100 bg-light-subtle">
-                    <div className="text-secondary small">Status</div>
-                    <strong>{statusLabels[warmupQuery.data.status]}</strong>
-                  </div>
-                </div>
-              </div>
-
-              <div className="border rounded p-3">
-                <div className="text-secondary small">
-                  Hipótese de como vende
-                </div>
-                <p className="mb-1 fw-semibold">
-                  {recommendationLabels[warmupQuery.data.recommendation]}
-                </p>
-                <p className="mb-0">
-                  {warmupQuery.data.opportunityRecommendation ||
-                    "Sem recomendação operacional registrada."}
-                </p>
-                {warmupQuery.data.nextExperimentSuggestion ? (
-                  <p className="mb-0 mt-2 small text-secondary">
-                    Próxima investigação sugerida:{" "}
-                    {warmupQuery.data.nextExperimentSuggestion}
-                  </p>
-                ) : null}
-              </div>
-
-              <ProductSuccessNarrative
-                summary={warmupQuery.data}
-                signals={warmupSignalsQuery.data?.items ?? []}
-                sources={warmupSourcesQuery.data?.items ?? []}
-                productName={
-                  pageQuery.data?.productName || pageQuery.data?.title
-                }
-                producerName={pageQuery.data?.producerName}
-              />
-
-              {warmupQuery.data.status === "FAILED" ? (
-                <div className="alert alert-danger mb-0">
-                  A pesquisa falhou
-                  {warmupQuery.data.errorCategory
-                    ? ` (${warmupQuery.data.errorCategory})`
-                    : ""}
-                  : {warmupQuery.data.errorMessage || "erro não informado"}.
-                </div>
-              ) : null}
-
-              <div className="row g-3 small">
-                <div className="col-md-6">
-                  <strong>Dor/promessa central</strong>
-                  <TextList items={warmupQuery.data.mainPains} />
-                </div>
-                <div className="col-md-6">
-                  <strong>Objeções/riscos</strong>
-                  <TextList items={warmupQuery.data.mainObjections} />
-                </div>
-                <div className="col-md-6">
-                  <strong>Canais encontrados</strong>
-                  <TextList items={warmupQuery.data.mainChannels} />
-                </div>
-                <div className="col-md-6">
-                  <strong>Alavancas de sucesso</strong>
-                  <TextList items={warmupQuery.data.mainCompetitors} />
-                </div>
-              </div>
-
-              {warmupQuery.data.saturationRisk ? (
-                <div className="alert alert-warning mb-0">
-                  <strong>Risco comercial:</strong>{" "}
-                  {warmupQuery.data.saturationRisk}
-                </div>
-              ) : null}
-
-              <div>
-                <h3 className="h6 mb-2">
-                  Fontes públicas para explicar o sucesso
-                </h3>
-                {warmupSourcesQuery.isLoading ? (
-                  <p className="text-secondary mb-0">Carregando fontes...</p>
-                ) : null}
-                {warmupSourcesQuery.isError ? (
-                  <div className="alert alert-danger mb-0">
-                    Falha ao carregar fontes.
-                  </div>
-                ) : null}
-                {!warmupSourcesQuery.isLoading &&
-                (warmupSourcesQuery.data?.items.length ?? 0) === 0 ? (
-                  <p className="text-secondary mb-0">
-                    Nenhuma fonte pública registrada para este dossiê.
-                  </p>
-                ) : null}
-                <div className="d-flex flex-column gap-2">
-                  {(warmupSourcesQuery.data?.items ?? [])
-                    .slice(0, 8)
-                    .map((source) => (
-                      <div
-                        key={source.sourceId}
-                        className="border rounded p-3 bg-light-subtle"
-                      >
-                        <div className="d-flex flex-wrap justify-content-between gap-2">
-                          <a
-                            href={source.sourceUrl}
-                            target="_blank"
-                            rel="noreferrer"
-                            className="fw-semibold"
-                          >
-                            {source.sourceTitle || source.sourceUrl}
-                          </a>
-                          <span className="badge bg-secondary-subtle text-secondary-emphasis">
-                            {source.platform} •{" "}
-                            {sourceTypeLabels[source.sourceType]}
-                          </span>
-                        </div>
-                        <p className="mb-1 small text-secondary">
-                          {source.authorName || "Autor não identificado"} •
-                          comentários: {formatNumber(source.commentsCount)} •
-                          visualizações: {formatNumber(source.viewsCount)}
-                        </p>
-                        <p className="mb-0 small">
-                          {source.evidenceSummary || "Sem resumo de evidência."}
-                        </p>
-                      </div>
-                    ))}
-                </div>
-              </div>
-
-              <div>
-                <h3 className="h6 mb-2">Sinais que explicam a venda</h3>
-                {warmupSignalsQuery.isLoading ? (
-                  <p className="text-secondary mb-0">Carregando sinais...</p>
-                ) : null}
-                {warmupSignalsQuery.isError ? (
-                  <div className="alert alert-danger mb-0">
-                    Falha ao carregar sinais.
-                  </div>
-                ) : null}
-                {!warmupSignalsQuery.isLoading &&
-                (warmupSignalsQuery.data?.items.length ?? 0) === 0 ? (
-                  <p className="text-secondary mb-0">
-                    Nenhum sinal de venda registrado para este dossiê.
-                  </p>
-                ) : null}
-                <div className="row g-2">
-                  {(warmupSignalsQuery.data?.items ?? [])
-                    .slice(0, 10)
-                    .map((signal) => (
-                      <div className="col-md-6" key={signal.signalId}>
-                        <div className="border rounded p-3 h-100">
-                          <div className="d-flex flex-wrap justify-content-between gap-2">
-                            <strong>
-                              {signalTypeLabels[signal.signalType]}
-                            </strong>
-                            <span className="text-secondary small">
-                              força {formatNumber(signal.signalStrength)}
-                            </span>
-                          </div>
-                          <p className="mb-1 small">{signal.signalText}</p>
-                          <p className="mb-0 small text-secondary">
-                            {signal.businessInterpretation ||
-                              "Sem interpretação adicional."}
-                          </p>
-                        </div>
-                      </div>
-                    ))}
-                </div>
-              </div>
-            </>
           ) : null}
         </div>
       </section>
-
-      {analysisQuery.isLoading ? (
-        <p className="text-secondary mb-0">Carregando detalhe...</p>
-      ) : null}
-      {analysisQuery.isError ? (
-        <div className="alert alert-danger mb-0">
-          Falha ao carregar detalhe da análise.
-        </div>
-      ) : null}
-
-      {analysisQuery.data ? (
-        <section className="card border-0 shadow-sm">
-          <div className="card-body d-flex flex-column gap-3">
-            <div className="row g-3">
-              <div className="col-md-4">
-                <strong>Status:</strong> {analysisQuery.data.status}
-              </div>
-              <div className="col-md-4">
-                <strong>Modelo:</strong> {analysisQuery.data.modelName || "—"}
-              </div>
-              <div className="col-md-4">
-                <strong>Atualizado:</strong>{" "}
-                {formatDate(analysisQuery.data.updatedAt)}
-              </div>
-              <div className="col-md-6">
-                <strong>Prompt version:</strong>{" "}
-                {analysisQuery.data.promptVersion || "—"}
-              </div>
-              <div className="col-md-6">
-                <strong>Parser version:</strong>{" "}
-                {analysisQuery.data.parserVersion || "—"}
-              </div>
-            </div>
-
-            <JsonCollapse
-              title="Resposta do modelo (sectionsJson)"
-              content={analysisQuery.data.sectionsJson}
-            />
-            <JsonCollapse
-              title="Resposta do modelo (copyJson)"
-              content={analysisQuery.data.copyJson}
-            />
-            <JsonCollapse
-              title="Resposta do modelo (visualJson)"
-              content={analysisQuery.data.visualJson}
-            />
-            <JsonCollapse
-              title="Resposta do modelo (imageJson)"
-              content={analysisQuery.data.imageJson}
-            />
-            <JsonCollapse
-              title="Notas de análise retornadas pelo worker"
-              content={analysisQuery.data.analysisNotes}
-            />
-            <OpenAiAnalysisAuditSection
-              requestPayloadJson={analysisQuery.data.requestPayloadJson}
-              responsePayloadJson={analysisQuery.data.responsePayloadJson}
-            />
-          </div>
-        </section>
-      ) : null}
 
       <section className="card border-0 shadow-sm">
         <div className="card-body">


### PR DESCRIPTION
### Motivation

- Reconstruct the product dossiê starting from observable facts on the Hotmart page (price and producer) so the UI shows audit-able facts instead of inferred market-warmup conclusions. 
- Persist and expose Hotmart-specific fields collected from `mois_collected_reference` so the detail view can display the canonical `hotmartPrice` and `hotmartProducer`. 
- Correct a gap for a specific product (`mois_sales_page.id = 1057`) where Hotmart facts were missing in the DB by seeding those values for immediate observation.

### Description

- Added `hotmartPrice` and `hotmartProducer` to the consolidated DTO `SalesLibraryPageResponse` and to the JDBC select list, mapping and result-set extraction in `mapSalesPageResponse`. 
- Introduced a Liquibase changeset `changesets/2026-06-11-mois-product-1057-hotmart-facts.yaml` (and included it in `db.changelog-master.yaml`) that updates `mois_collected_reference` for product `1057` with the verified Hotmart price and producer. 
- Updated API contract (`docs/swagger/mois-sales-library-swagger.yaml`) and frontend types (`frontend/src/api/mois/types.ts`) to include `hotmartPrice` and `hotmartProducer`. 
- Simplified the frontend detail screen `MoisSalesPageLibraryDetailPage.tsx` to show the first factual block (Hotmart price and producer), removed the previous market-warmup investigation UI blocks and OpenAI audit components from the immediate view, and adjusted route param parsing; tests/stubs were updated accordingly in `MoisSalesLibraryServiceTest`. 

### Testing

- Ran backend unit tests including `MoisSalesLibraryServiceTest` after updating the constructor/mocks for the new DTO fields, and the tests passed. 
- Exercised the backend build/test pipeline (`mvn test`) to validate SQL mapping and service behavior, and the build/tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2b219fda208321a25064a458eefea9)