### PR TITLE
Qualificar redes sociais do produtor no dossiê MOIS

### DIFF
--- a/docs/registros/mois1.md
+++ b/docs/registros/mois1.md
@@ -1530,3 +1530,14 @@ Arquivos principais:
 - `backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/dto/MoisSalesLibraryDtos.java`
 - `backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryService.java`
 - `frontend/src/pages/mois/MoisSalesPageLibraryDetailPage.tsx`
+
+## 2026-06-11 — Pesquisa social qualificada do produtor no dossiê MOIS
+
+- implementada a próxima parte do dossiê: quando o nome do produtor Hotmart existe, a Etapa 3 passa a gerar buscas específicas em Instagram, YouTube e TikTok usando o produtor como âncora.
+- causa-raiz tratada: a pesquisa pública podia considerar resultados sociais genéricos, homônimos ou perfis do produtor falando de outro assunto; agora fontes sociais só entram quando contêm o mesmo nome do produtor e tokens comerciais semelhantes ao produto/promessa/mecanismo/oferta.
+- o detalhe da Biblioteca MOIS passa a mostrar a seção “redes do produtor”, destacando temperatura, recomendação, score e fontes sociais qualificadas, sem misturar perfis não confirmados ao dossiê.
+
+Arquivos principais:
+- `mois-sales-library-worker/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/marketwarmup/MarketWarmupQueryBuilder.java`
+- `mois-sales-library-worker/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/marketwarmup/MarketWarmupProcessor.java`
+- `frontend/src/pages/mois/MoisSalesPageLibraryDetailPage.tsx`

--- a/frontend/src/pages/mois/MoisSalesPageLibraryDetailPage.tsx
+++ b/frontend/src/pages/mois/MoisSalesPageLibraryDetailPage.tsx
@@ -1,6 +1,8 @@
 import { Link, useParams } from "react-router-dom";
 import PageTitle from "../../components/PageTitle";
 import {
+  useMoisSalesLibraryMarketWarmup,
+  useMoisSalesLibraryMarketWarmupSources,
   useMoisSalesLibraryPage,
   useMoisSalesLibraryPageExecutions,
   useMoisSalesLibraryPages,
@@ -34,6 +36,36 @@ type HistoryItem = {
   detail: string;
 };
 
+const SOCIAL_PLATFORMS = new Set(["YOUTUBE", "INSTAGRAM", "TIKTOK"]);
+const PRODUCER_SOCIAL_SOURCE_TYPES = new Set([
+  "CREATOR_CONTENT",
+  "SPECIALIST_CONTENT",
+  "SOCIAL_POST",
+]);
+
+function labelPlatform(value: string) {
+  const labels: Record<string, string> = {
+    YOUTUBE: "YouTube",
+    INSTAGRAM: "Instagram",
+    TIKTOK: "TikTok",
+    WEB: "Web",
+    MARKETPLACE: "Marketplace",
+    REVIEW_SITE: "Reviews",
+  };
+  return labels[value] || value;
+}
+
+function labelRecommendation(value?: string) {
+  const labels: Record<string, string> = {
+    PRIORITIZE: "priorizar",
+    OBSERVE: "observar",
+    RESEARCH_MORE: "pesquisar mais",
+    DISCARD: "descartar",
+    SATURATED_REQUIRES_ANGLE: "exige novo ângulo",
+  };
+  return value ? labels[value] || value : "—";
+}
+
 export default function MoisSalesPageLibraryDetailPage() {
   const { pageId } = useParams();
   const numericPageId = Number(pageId);
@@ -42,6 +74,11 @@ export default function MoisSalesPageLibraryDetailPage() {
     : undefined;
   const pageQuery = useMoisSalesLibraryPage(validPageId);
   const executionsQuery = useMoisSalesLibraryPageExecutions(validPageId);
+  const marketWarmupQuery = useMoisSalesLibraryMarketWarmup(validPageId);
+  const marketWarmupSourcesQuery = useMoisSalesLibraryMarketWarmupSources(
+    validPageId,
+    Boolean(marketWarmupQuery.data),
+  );
   const pagesQuery = useMoisSalesLibraryPages(WORKSPACE_ID, 1, PAGE_SIZE);
   const updateStatusMutation =
     useUpdateMoisSalesLibraryPageStatus(WORKSPACE_ID);
@@ -56,6 +93,14 @@ export default function MoisSalesPageLibraryDetailPage() {
   const hotmartProducer =
     cleanText(pageQuery.data?.hotmartProducer) ||
     cleanText(pageQuery.data?.producerName);
+
+  const producerSocialSources = (marketWarmupSourcesQuery.data?.items ?? [])
+    .filter(
+      (source) =>
+        SOCIAL_PLATFORMS.has(source.platform) &&
+        PRODUCER_SOCIAL_SOURCE_TYPES.has(source.sourceType),
+    )
+    .slice(0, 6);
 
   const history: HistoryItem[] = (executionsQuery.data ?? []).map((item) => ({
     key: String(item.executionId),
@@ -207,6 +252,118 @@ export default function MoisSalesPageLibraryDetailPage() {
               próximo passo é corrigir a coleta para preencher preço e produtor
               diretamente da página de venda.
             </div>
+          ) : null}
+        </div>
+      </section>
+
+      <section className="card border-0 shadow-sm">
+        <div className="card-body d-flex flex-column gap-3">
+          <div>
+            <h2 className="h5 mb-1">Dossiê do produto — redes do produtor</h2>
+            <p className="text-secondary mb-0">
+              Quando o produtor Hotmart está disponível, a pesquisa pública
+              busca perfis sociais do mesmo nome e só aproveita fontes que
+              também falam de conteúdo semelhante ao produto.
+            </p>
+          </div>
+
+          {marketWarmupQuery.isLoading ? (
+            <p className="text-secondary mb-0">
+              Carregando pesquisa pública do dossiê...
+            </p>
+          ) : null}
+          {marketWarmupQuery.isError || marketWarmupSourcesQuery.isError ? (
+            <div className="alert alert-danger mb-0">
+              Falha ao carregar a pesquisa pública do produtor.
+            </div>
+          ) : null}
+          {!marketWarmupQuery.isLoading && !marketWarmupQuery.data ? (
+            <div className="alert alert-warning mb-0">
+              Ainda não há dossiê de aquecimento concluído para este produto.
+              Execute a etapa de pesquisa de aquecimento para validar redes e
+              autoridade do produtor.
+            </div>
+          ) : null}
+
+          {marketWarmupQuery.data ? (
+            <>
+              <div className="row g-3">
+                <div className="col-md-4">
+                  <div className="border rounded p-3 h-100 bg-light-subtle">
+                    <div className="text-secondary small">Temperatura</div>
+                    <strong>{marketWarmupQuery.data.marketTemperature}</strong>
+                  </div>
+                </div>
+                <div className="col-md-4">
+                  <div className="border rounded p-3 h-100 bg-light-subtle">
+                    <div className="text-secondary small">Recomendação</div>
+                    <strong>
+                      {labelRecommendation(
+                        marketWarmupQuery.data.recommendation,
+                      )}
+                    </strong>
+                  </div>
+                </div>
+                <div className="col-md-4">
+                  <div className="border rounded p-3 h-100 bg-light-subtle">
+                    <div className="text-secondary small">Score do dossiê</div>
+                    <strong>{marketWarmupQuery.data.scoreTotal ?? "—"}</strong>
+                  </div>
+                </div>
+              </div>
+
+              {marketWarmupQuery.data.opportunityRecommendation ? (
+                <div className="alert alert-info mb-0">
+                  {marketWarmupQuery.data.opportunityRecommendation}
+                </div>
+              ) : null}
+
+              <div>
+                <h3 className="h6 mb-2">Fontes sociais qualificadas</h3>
+                {marketWarmupSourcesQuery.isLoading ? (
+                  <p className="text-secondary mb-0">
+                    Carregando fontes sociais qualificadas...
+                  </p>
+                ) : null}
+                {!marketWarmupSourcesQuery.isLoading &&
+                producerSocialSources.length === 0 ? (
+                  <p className="text-secondary mb-0">
+                    Nenhuma rede social do produtor foi qualificada ainda. Isso
+                    evita usar homônimos ou perfis com assunto diferente do
+                    produto.
+                  </p>
+                ) : (
+                  <div className="d-flex flex-column gap-2">
+                    {producerSocialSources.map((source) => (
+                      <div
+                        key={source.sourceId}
+                        className="border rounded p-3 bg-light-subtle"
+                      >
+                        <div className="d-flex flex-wrap justify-content-between gap-2">
+                          <strong>
+                            {source.sourceTitle || source.sourceUrl}
+                          </strong>
+                          <span className="badge text-bg-primary">
+                            {labelPlatform(source.platform)}
+                          </span>
+                        </div>
+                        <p className="small text-secondary mb-2 mt-2">
+                          {source.evidenceSummary ||
+                            "Fonte social qualificada pela pesquisa pública."}
+                        </p>
+                        <a
+                          href={source.sourceUrl}
+                          target="_blank"
+                          rel="noreferrer"
+                        >
+                          Abrir fonte
+                        </a>
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </div>
+            </>
           ) : null}
         </div>
       </section>

--- a/mois-sales-library-worker/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/marketwarmup/MarketWarmupProcessor.java
+++ b/mois-sales-library-worker/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/marketwarmup/MarketWarmupProcessor.java
@@ -13,12 +13,15 @@ import com.marketinghub.mois.bibliotecapaginavenda.worker.v1.model.WorkerDtos.Ma
 import com.marketinghub.mois.bibliotecapaginavenda.worker.v1.model.WorkerDtos.MarketWarmupTemperature;
 import java.io.IOException;
 import java.math.BigDecimal;
+import java.text.Normalizer;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Set;
+import java.util.regex.Pattern;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
@@ -30,6 +33,24 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 @Slf4j
 public class MarketWarmupProcessor {
+    private static final Pattern NON_ALPHANUMERIC = Pattern.compile("[^\\p{L}\\p{N}]+");
+    private static final Set<String> PRODUCT_STOPWORDS = Set.of(
+            "para",
+            "com",
+            "sem",
+            "dos",
+            "das",
+            "uma",
+            "por",
+            "que",
+            "curso",
+            "produto",
+            "oferta",
+            "metodo",
+            "hotmart",
+            "certificacao",
+            "avancada");
+
     private final MarketWarmupQueryBuilder queryBuilder;
     private final PublicWebSearchClient searchClient;
 
@@ -43,15 +64,95 @@ public class MarketWarmupProcessor {
             rawResults.addAll(searchClient.search(query, searchLimit));
         }
         List<PublicSearchResult> deduplicatedResults = deduplicate(rawResults).stream().limit(searchLimit * 2L).toList();
-        if (deduplicatedResults.isEmpty()) {
+        List<PublicSearchResult> qualifiedResults = keepOnlyQualifiedProducerSocialResults(job, deduplicatedResults);
+        if (qualifiedResults.isEmpty()) {
             throw new IllegalStateException("Busca pública não retornou fontes rastreáveis para montar o dossiê");
         }
-        List<MarketWarmupSourceCompleteItem> sources = buildSources(deduplicatedResults);
-        List<MarketWarmupSignalCompleteItem> signals = buildSignals(deduplicatedResults);
+        List<MarketWarmupSourceCompleteItem> sources = buildSources(qualifiedResults);
+        List<MarketWarmupSignalCompleteItem> signals = buildSignals(qualifiedResults);
         MarketWarmupSummaryCompleteItem summary = buildSummary(job, sources, signals);
         log.info("MOIS market-warmup dossier built. jobId={}, pageId={}, queries={}, sources={}, signals={}, score={}",
                 job.jobId(), job.pageId(), queries.size(), sources.size(), signals.size(), summary.scoreTotal());
         return new MarketWarmupCompleteRequest(sources, signals, summary, Instant.now());
+    }
+
+    /**
+     * Mantém fontes sociais do produtor somente quando o mesmo nome aparece junto de conteúdo semelhante ao produto.
+     */
+    private List<PublicSearchResult> keepOnlyQualifiedProducerSocialResults(MarketWarmupClaimedJob job, List<PublicSearchResult> results) {
+        List<String> producerTokens = meaningfulTokens(job.producerName());
+        Set<String> productTokens = new LinkedHashSet<>();
+        productTokens.addAll(meaningfulTokens(job.title()));
+        productTokens.addAll(meaningfulTokens(job.promiseSummary()));
+        productTokens.addAll(meaningfulTokens(job.mechanismSummary()));
+        productTokens.addAll(meaningfulTokens(job.offerSummary()));
+        List<PublicSearchResult> qualified = new ArrayList<>();
+        for (PublicSearchResult result : results) {
+            MarketWarmupPlatform platform = detectPlatform(result.url());
+            if (!isProducerSocialPlatform(platform)) {
+                qualified.add(result);
+                continue;
+            }
+            String text = normalizedComparableText(result.title() + " " + result.snippet() + " " + result.url());
+            if (containsAllTokens(text, producerTokens) && containsEnoughProductSimilarity(text, productTokens)) {
+                qualified.add(result);
+            } else {
+                log.info("MOIS market-warmup producer social source ignored. jobId={}, pageId={}, platform={}, url={}",
+                        job.jobId(), job.pageId(), platform, result.url());
+            }
+        }
+        return qualified;
+    }
+
+    /**
+     * Identifica plataformas sociais onde homônimos do produtor precisam ser bloqueados.
+     */
+    private boolean isProducerSocialPlatform(MarketWarmupPlatform platform) {
+        return platform == MarketWarmupPlatform.YOUTUBE || platform == MarketWarmupPlatform.INSTAGRAM || platform == MarketWarmupPlatform.TIKTOK;
+    }
+
+    /**
+     * Verifica se todos os tokens relevantes do nome do produtor aparecem na fonte social.
+     */
+    private boolean containsAllTokens(String text, List<String> tokens) {
+        return !tokens.isEmpty() && tokens.stream().allMatch(text::contains);
+    }
+
+    /**
+     * Exige semelhança mínima com o produto para evitar perfis corretos tratando de outro assunto.
+     */
+    private boolean containsEnoughProductSimilarity(String text, Set<String> productTokens) {
+        if (productTokens.isEmpty()) {
+            return false;
+        }
+        long matches = productTokens.stream().filter(text::contains).count();
+        return matches >= Math.min(2, productTokens.size());
+    }
+
+    /**
+     * Extrai tokens comparáveis de nomes e temas comerciais removendo ruído comum.
+     */
+    private List<String> meaningfulTokens(String value) {
+        String normalized = normalizedComparableText(value);
+        if (normalized.isBlank()) {
+            return List.of();
+        }
+        return Arrays.stream(normalized.split(" "))
+                .filter(token -> token.length() >= 3)
+                .filter(token -> !PRODUCT_STOPWORDS.contains(token))
+                .distinct()
+                .toList();
+    }
+
+    /**
+     * Normaliza acentos, caixa e pontuação para comparação robusta entre produtor e conteúdo.
+     */
+    private String normalizedComparableText(String value) {
+        if (value == null) {
+            return "";
+        }
+        String withoutAccents = Normalizer.normalize(value, Normalizer.Form.NFD).replaceAll("\\p{M}+", "");
+        return NON_ALPHANUMERIC.matcher(withoutAccents.toLowerCase(Locale.ROOT)).replaceAll(" ").replaceAll("\\s+", " ").trim();
     }
 
     /**

--- a/mois-sales-library-worker/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/marketwarmup/MarketWarmupQueryBuilder.java
+++ b/mois-sales-library-worker/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/marketwarmup/MarketWarmupQueryBuilder.java
@@ -23,6 +23,10 @@ public class MarketWarmupQueryBuilder {
         String proof = clean(job.proofSummary());
         String productAndProducer = clean(title + " " + producer);
         Set<String> queries = new LinkedHashSet<>();
+        if (!producer.isBlank() && !clean(title + " " + promise + " " + mechanism).isBlank()) {
+            addIfUseful(queries, exact(producer) + " " + exact(title) + " Instagram YouTube TikTok");
+            addIfUseful(queries, exact(producer) + " " + promise + " " + mechanism + " canal perfil especialista");
+        }
         if (!productAndProducer.isBlank()) {
             addIfUseful(queries, exact(title) + " " + producer + " Instagram YouTube TikTok influenciador fundador");
             addIfUseful(queries, productAndProducer + " depoimento review funciona vale a pena reclamação");
@@ -30,7 +34,7 @@ public class MarketWarmupQueryBuilder {
             addIfUseful(queries, productAndProducer + " afiliado hotmart produtor oferta bônus");
         }
         if (!producer.isBlank()) {
-            addIfUseful(queries, producer + " autoridade seguidores alunas método");
+            addIfUseful(queries, exact(producer) + " autoridade seguidores alunas método " + firstUseful(title, promise));
         }
         if (!clean(promise + " " + mechanism).isBlank()) {
             addIfUseful(queries, promise + " " + mechanism + " canal influencer especialista");
@@ -38,7 +42,15 @@ public class MarketWarmupQueryBuilder {
         if (!clean(offer + " " + proof).isBlank()) {
             addIfUseful(queries, offer + " " + proof + " prova social depoimentos resultados");
         }
-        return queries.stream().limit(6).toList();
+        return queries.stream().limit(8).toList();
+    }
+
+    /**
+     * Escolhe o primeiro texto comercial útil para ancorar a busca do produtor.
+     */
+    private String firstUseful(String first, String second) {
+        String primary = clean(first);
+        return primary.isBlank() ? clean(second) : primary;
     }
 
     /**

--- a/mois-sales-library-worker/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/marketwarmup/MarketWarmupProcessorTest.java
+++ b/mois-sales-library-worker/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/marketwarmup/MarketWarmupProcessorTest.java
@@ -44,6 +44,32 @@ class MarketWarmupProcessorTest {
     }
 
     /**
+     * Garante que uma rede social do produtor só entre no dossiê quando falar de conteúdo semelhante ao produto.
+     */
+    @Test
+    void shouldKeepOnlyProducerSocialProfileWithSimilarProductContent() throws Exception {
+        MarketWarmupProcessor processor = new MarketWarmupProcessor(new MarketWarmupQueryBuilder(), new ProducerSocialSearchClient());
+        MarketWarmupClaimedJob job = new MarketWarmupClaimedJob(
+                8L,
+                80L,
+                "workspace-001",
+                "https://example.com/peptideos",
+                "CAP - Certificação Avançada em Peptídeos",
+                "Thiago Bechara dos Santos",
+                "certificação para prescrição segura de peptídeos",
+                "protocolo avançado de peptídeos",
+                "dominar peptídeos com segurança clínica",
+                "depoimentos de profissionais");
+
+        var result = processor.process(job, 4);
+
+        assertThat(result.sources())
+                .extracting(source -> source.sourceUrl())
+                .contains("https://www.instagram.com/thiagobechara.peptideos")
+                .doesNotContain("https://www.instagram.com/thiagobechara.musica", "https://www.youtube.com/@outrothiagopeptideos");
+    }
+
+    /**
      * Simula uma fonte pública sem dependência de rede para manter o teste determinístico.
      */
     private static class FakeSearchClient implements PublicWebSearchClient {
@@ -53,8 +79,24 @@ class MarketWarmupProcessorTest {
         @Override
         public List<PublicSearchResult> search(String query, int limit) throws IOException {
             return List.of(
-                    new PublicSearchResult("Insônia: dor e dificuldade para dormir", "https://www.youtube.com/watch?v=abc", "Professora especialista faz live e comentários perguntam se funciona e preço do método.", "<div>raw</div>"),
+                    new PublicSearchResult("Especialista do Sono ensina Sono Profundo", "https://www.youtube.com/watch?v=abc", "Especialista do Sono é professora especialista e faz live sobre método respiratório para dormir melhor; comentários perguntam se funciona e preço.", "<div>raw</div>"),
                     new PublicSearchResult("Review Sono Profundo vale a pena", "https://blog.example.com/review", "Depoimento de alunos mostra resultado e objeção sobre confiança no produto.", "<div>raw</div>"));
+        }
+    }
+
+    /**
+     * Simula resultados sociais com homônimo e perfil do mesmo produtor em outro assunto.
+     */
+    private static class ProducerSocialSearchClient implements PublicWebSearchClient {
+        /**
+         * Retorna fontes sociais para validar o filtro de mesmo produtor e conteúdo semelhante.
+         */
+        @Override
+        public List<PublicSearchResult> search(String query, int limit) throws IOException {
+            return List.of(
+                    new PublicSearchResult("Thiago Bechara dos Santos | Peptídeos", "https://www.instagram.com/thiagobechara.peptideos", "Conteúdo sobre certificação avançada em peptídeos, protocolo seguro, prescrição clínica e depoimentos de profissionais.", "<div>raw</div>"),
+                    new PublicSearchResult("Thiago Bechara dos Santos músico", "https://www.instagram.com/thiagobechara.musica", "Agenda de shows, violão e bastidores de música autoral.", "<div>raw</div>"),
+                    new PublicSearchResult("Thiago Peptídeos", "https://www.youtube.com/@outrothiagopeptideos", "Canal sobre peptídeos sem relação com Thiago Bechara dos Santos.", "<div>raw</div>"));
         }
     }
 }

--- a/mois-sales-library-worker/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/marketwarmup/MarketWarmupQueryBuilderTest.java
+++ b/mois-sales-library-worker/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/marketwarmup/MarketWarmupQueryBuilderTest.java
@@ -28,9 +28,9 @@ class MarketWarmupQueryBuilderTest {
                 "depoimentos de alunos");
 
         assertThat(builder.buildQueries(job))
-                .hasSize(6)
-                .anySatisfy(query -> assertThat(query).contains("Especialista do Sono"))
-                .anySatisfy(query -> assertThat(query).contains("Instagram YouTube TikTok"))
+                .hasSize(8)
+                .anySatisfy(query -> assertThat(query).contains("\"Especialista do Sono\"").contains("Instagram YouTube TikTok"))
+                .anySatisfy(query -> assertThat(query).contains("Produto Sono Profundo"))
                 .anySatisfy(query -> assertThat(query).contains("aula gratuita"));
     }
 }


### PR DESCRIPTION
### Motivation
- Evitar que homônimos ou perfis do mesmo nome, mas sobre outro assunto, contaminem o dossiê de aquecimento da Biblioteca MOIS; a pesquisa social deve identificar apenas perfis do produtor que tratem de conteúdo similar ao produto.
- Expor no front-end uma visão clara das `redes do produtor` (temperatura, recomendação, score e fontes sociais qualificadas) para suporte à decisão comercial sem misturar perfis não verificados.

### Description
- Atualiza `MarketWarmupQueryBuilder` para gerar queries adicionais ancoradas no `producer` e no `title/promise/mechanism` para buscas em Instagram/YouTube/TikTok. (`mois-sales-library-worker/src/main/java/.../MarketWarmupQueryBuilder.java`).
- Implementa filtragem no worker com `keepOnlyQualifiedProducerSocialResults`, tokenização/normalização e heurística de similaridade que permite incluir fontes sociais do produtor apenas quando o nome do produtor aparece e há semelhança com tokens comerciais do produto; preserva demais fontes web. (`MarketWarmupProcessor.java`).
- Adiciona seção UI `Dossiê do produto — redes do produtor` exibindo temperatura, recomendação, score e as `Fontes sociais qualificadas`, com links abertos em nova aba e mensagens claras quando não houver fontes qualificadas. (`frontend/src/pages/mois/MoisSalesPageLibraryDetailPage.tsx`).
- Inclui testes unitários para cobrir a geração de queries e o filtro de redes do produtor: `MarketWarmupQueryBuilderTest` e `MarketWarmupProcessorTest` (adicionada verificação de homônimo vs perfil relevante).
- Documenta a mudança no registro operacional `docs/registros/mois1.md`.

### Testing
- Executado `mvn -q test` no módulo `mois-sales-library-worker`, incluindo `MarketWarmupProcessorTest` e `MarketWarmupQueryBuilderTest`, ambos concluídos com sucesso (tests passed).
- Executado `npm ci` seguido de `npm run typecheck` no frontend, sem erros (typecheck passed).
- Executado `npm run build` (Vite) no frontend com sucesso; artefato gerado (`dist/`) e bundle produzido (build passed).
- Formatação aplicada com `prettier` no arquivo de UI modificado e logs de execução do worker mostram filtragem de homônimos durante testes unitários (logs informativos emitidos pelo `MarketWarmupProcessor`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2b32b7bf288321bcecf0c92ccda570)