### PR TITLE
feat: add Offer (Etapa 5) to hypothesis new-screen and backend pipeline

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/hypothesis/pain/controller/HypothesisPainStageController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/hypothesis/pain/controller/HypothesisPainStageController.java
@@ -20,14 +20,14 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
-/** Responsável por expor os endpoints das etapas iniciais do pipeline de hipótese. */
+/** Responsável por expor os endpoints das etapas do pipeline de hipótese por nicho. */
 @RestController
 @RequestMapping("/api")
 public class HypothesisPainStageController {
     private static final Logger log = LoggerFactory.getLogger(HypothesisPainStageController.class);
     private final HypothesisPainStageService service;
 
-    /** Inicializa o controller com o serviço das etapas iniciais. */
+    /** Inicializa o controller com o serviço das etapas do pipeline de hipótese. */
     public HypothesisPainStageController(HypothesisPainStageService service) {
         this.service = service;
     }
@@ -48,6 +48,12 @@ public class HypothesisPainStageController {
     @PostMapping("/niches/{nicheId}/hypothesis-pipeline/mechanism/start")
     public ResponseEntity<HypothesisPainStartResponse> startMechanism(@PathVariable Long nicheId) {
         return ResponseEntity.accepted().body(service.startMechanism(nicheId));
+    }
+
+    /** Registra uma execução inicial da etapa Oferta para um nicho. */
+    @PostMapping("/niches/{nicheId}/hypothesis-pipeline/offer/start")
+    public ResponseEntity<HypothesisPainStartResponse> startOffer(@PathVariable Long nicheId) {
+        return ResponseEntity.accepted().body(service.startOffer(nicheId));
     }
 
     /** Lista execuções da etapa Dor para acompanhamento na tela de nova hipótese. */
@@ -74,6 +80,14 @@ public class HypothesisPainStageController {
         return ResponseEntity.ok(service.listMechanismStageExecutions(nicheId, includeCompleted));
     }
 
+    /** Lista execuções da etapa Oferta para acompanhamento na tela de nova hipótese. */
+    @GetMapping("/niches/{nicheId}/hypothesis-pipeline/offer/stage-executions")
+    public ResponseEntity<List<HypothesisPainExecutionSummaryResponse>> listOfferStageExecutions(
+            @PathVariable Long nicheId,
+            @RequestParam(defaultValue = "true") boolean includeCompleted) {
+        return ResponseEntity.ok(service.listOfferStageExecutions(nicheId, includeCompleted));
+    }
+
     /** Consulta detalhe auditável de uma execução da etapa Dor vinculada ao nicho. */
     @GetMapping("/niches/{nicheId}/hypothesis-pipeline/pain/stage-executions/{idJob}")
     public ResponseEntity<HypothesisPainExecutionDetailResponse> detailForNiche(
@@ -93,6 +107,14 @@ public class HypothesisPainStageController {
     /** Consulta detalhe auditável de uma execução da etapa Mecanismo vinculada ao nicho. */
     @GetMapping("/niches/{nicheId}/hypothesis-pipeline/mechanism/stage-executions/{idJob}")
     public ResponseEntity<HypothesisPainExecutionDetailResponse> detailMechanismForNiche(
+            @PathVariable Long nicheId,
+            @PathVariable String idJob) {
+        return ResponseEntity.ok(service.detailForNiche(nicheId, idJob));
+    }
+
+    /** Consulta detalhe auditável de uma execução da etapa Oferta vinculada ao nicho. */
+    @GetMapping("/niches/{nicheId}/hypothesis-pipeline/offer/stage-executions/{idJob}")
+    public ResponseEntity<HypothesisPainExecutionDetailResponse> detailOfferForNiche(
             @PathVariable Long nicheId,
             @PathVariable String idJob) {
         return ResponseEntity.ok(service.detailForNiche(nicheId, idJob));
@@ -122,11 +144,18 @@ public class HypothesisPainStageController {
         return service.listMechanismPending();
     }
 
+    /** Lista jobs pendentes da etapa Oferta para processamento pelo Worker AI. */
+    @GetMapping("/internal/hypothesis-pipeline/offer/stage-executions/pending")
+    public List<HypothesisPainPendingExecution> offerPending() {
+        return service.listOfferPending();
+    }
+
     /** Marca uma execução de etapa como em processamento. */
     @PostMapping({
             "/internal/hypothesis-pipeline/pain/stage-executions/{idJob}/running",
             "/internal/hypothesis-pipeline/result/stage-executions/{idJob}/running",
-            "/internal/hypothesis-pipeline/mechanism/stage-executions/{idJob}/running"
+            "/internal/hypothesis-pipeline/mechanism/stage-executions/{idJob}/running",
+            "/internal/hypothesis-pipeline/offer/stage-executions/{idJob}/running"
     })
     public ResponseEntity<Void> running(@PathVariable String idJob) {
         service.markRunning(idJob);
@@ -137,7 +166,8 @@ public class HypothesisPainStageController {
     @PostMapping({
             "/internal/hypothesis-pipeline/pain/stage-executions/{idJob}/recebe-prompt",
             "/internal/hypothesis-pipeline/result/stage-executions/{idJob}/recebe-prompt",
-            "/internal/hypothesis-pipeline/mechanism/stage-executions/{idJob}/recebe-prompt"
+            "/internal/hypothesis-pipeline/mechanism/stage-executions/{idJob}/recebe-prompt",
+            "/internal/hypothesis-pipeline/offer/stage-executions/{idJob}/recebe-prompt"
     })
     public ResponseEntity<Void> recebePrompt(
             @PathVariable String idJob,
@@ -165,7 +195,8 @@ public class HypothesisPainStageController {
     @PostMapping({
             "/internal/hypothesis-pipeline/pain/stage-executions/{idJob}/recebe-resposta",
             "/internal/hypothesis-pipeline/result/stage-executions/{idJob}/recebe-resposta",
-            "/internal/hypothesis-pipeline/mechanism/stage-executions/{idJob}/recebe-resposta"
+            "/internal/hypothesis-pipeline/mechanism/stage-executions/{idJob}/recebe-resposta",
+            "/internal/hypothesis-pipeline/offer/stage-executions/{idJob}/recebe-resposta"
     })
     public ResponseEntity<Void> recebeResposta(
             @PathVariable String idJob,

--- a/backend/ads-service/src/main/java/com/marketinghub/hypothesis/pain/service/HypothesisPainStageService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/hypothesis/pain/service/HypothesisPainStageService.java
@@ -23,13 +23,14 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 
-/** Responsabilidade: orquestrar execuções auditáveis das etapas iniciais do pipeline de hipótese. */
+/** Responsabilidade: orquestrar execuções auditáveis das etapas do pipeline de hipótese por nicho. */
 @Service
 public class HypothesisPainStageService {
     private static final Logger log = LoggerFactory.getLogger(HypothesisPainStageService.class);
     private static final String STAGE_CODE = "hypothesis-pain";
     private static final String RESULT_STAGE_CODE = "hypothesis-result";
     private static final String MECHANISM_STAGE_CODE = "hypothesis-mechanism";
+    private static final String OFFER_STAGE_CODE = "hypothesis-offer";
     private static final String STATUS_STARTED = "INICIADO";
     private static final String STATUS_WAITING_OPENAI_DISPATCH = "AGUARDANDO_RETORNO_OPENAI";
     private static final String STATUS_PROCESSING = "PROCESSANDO";
@@ -53,19 +54,25 @@ public class HypothesisPainStageService {
     /** Inicia uma nova execução manual da etapa Dor para o nicho informado. */
     @Transactional
     public HypothesisPainStartResponse start(Long marketNicheId) {
-        return startStage(marketNicheId, STAGE_CODE, "Dor", false, false);
+        return startStage(marketNicheId, STAGE_CODE, "Dor", false, false, false);
     }
 
     /** Inicia uma nova execução manual da etapa Resultado para o nicho informado. */
     @Transactional
     public HypothesisPainStartResponse startResult(Long marketNicheId) {
-        return startStage(marketNicheId, RESULT_STAGE_CODE, "Resultado", true, false);
+        return startStage(marketNicheId, RESULT_STAGE_CODE, "Resultado", true, false, false);
     }
 
     /** Inicia uma nova execução manual da etapa Mecanismo para o nicho informado. */
     @Transactional
     public HypothesisPainStartResponse startMechanism(Long marketNicheId) {
-        return startStage(marketNicheId, MECHANISM_STAGE_CODE, "Mecanismo", true, true);
+        return startStage(marketNicheId, MECHANISM_STAGE_CODE, "Mecanismo", true, true, false);
+    }
+
+    /** Inicia uma nova execução manual da etapa Oferta para o nicho informado. */
+    @Transactional
+    public HypothesisPainStartResponse startOffer(Long marketNicheId) {
+        return startStage(marketNicheId, OFFER_STAGE_CODE, "Oferta", true, true, true);
     }
 
     /** Inicia uma nova execução manual de uma etapa do pipeline para o nicho informado. */
@@ -74,7 +81,8 @@ public class HypothesisPainStageService {
             String stageCode,
             String stageLabel,
             boolean requiresCompletedPain,
-            boolean requiresCompletedResult) {
+            boolean requiresCompletedResult,
+            boolean requiresCompletedMechanism) {
         Instant now = Instant.now();
         MarketNiche niche = marketNicheRepository.findById(marketNicheId)
                 .orElseThrow(() -> new EntityNotFoundException("Market niche not found: " + marketNicheId));
@@ -83,6 +91,9 @@ public class HypothesisPainStageService {
         }
         if (requiresCompletedResult) {
             requireCompletedResult(marketNicheId);
+        }
+        if (requiresCompletedMechanism) {
+            requireCompletedMechanism(marketNicheId);
         }
         HypothesisPainStageExecution execution = HypothesisPainStageExecution.builder()
                 .marketNicheId(niche.getId())
@@ -117,6 +128,14 @@ public class HypothesisPainStageService {
             Long marketNicheId,
             boolean includeCompleted) {
         return listStageExecutions(marketNicheId, MECHANISM_STAGE_CODE, includeCompleted);
+    }
+
+    /** Lista execuções da etapa Oferta para o nicho informado. */
+    @Transactional(readOnly = true)
+    public List<HypothesisPainExecutionSummaryResponse> listOfferStageExecutions(
+            Long marketNicheId,
+            boolean includeCompleted) {
+        return listStageExecutions(marketNicheId, OFFER_STAGE_CODE, includeCompleted);
     }
 
     /** Lista execuções de uma etapa específica para o nicho informado. */
@@ -167,6 +186,12 @@ public class HypothesisPainStageService {
         return listPendingByStage(MECHANISM_STAGE_CODE);
     }
 
+    /** Lista os jobs iniciados da etapa Oferta para processamento pelo Worker AI. */
+    @Transactional(readOnly = true)
+    public List<HypothesisPainPendingExecution> listOfferPending() {
+        return listPendingByStage(OFFER_STAGE_CODE);
+    }
+
     /** Lista os jobs iniciados de uma etapa para processamento pelo Worker AI. */
     private List<HypothesisPainPendingExecution> listPendingByStage(String stageCode) {
         return executionRepository.findTop20ByStageCodeAndStatusOrderByExecutionRequestedAtAsc(stageCode, STATUS_STARTED)
@@ -177,9 +202,34 @@ public class HypothesisPainStageService {
                         execution.getStageCode(),
                         execution.getExecutionRequestedAt(),
                         toPendingNiche(execution.getMarketNiche()),
-                        latestCompletedPainResponse(execution.getMarketNicheId()),
-                        latestCompletedResultResponse(execution.getMarketNicheId())))
+                        pendingPainResponse(execution),
+                        pendingResultResponse(execution),
+                        pendingMechanismResponse(execution)))
                 .toList();
+    }
+
+    /** Retorna a Dor concluída quando a etapa pendente precisa desse contexto. */
+    private String pendingPainResponse(HypothesisPainStageExecution execution) {
+        return RESULT_STAGE_CODE.equals(execution.getStageCode())
+                || MECHANISM_STAGE_CODE.equals(execution.getStageCode())
+                || OFFER_STAGE_CODE.equals(execution.getStageCode())
+                ? latestCompletedPainResponse(execution.getMarketNicheId())
+                : null;
+    }
+
+    /** Retorna o Resultado concluído quando a etapa pendente precisa desse contexto. */
+    private String pendingResultResponse(HypothesisPainStageExecution execution) {
+        return MECHANISM_STAGE_CODE.equals(execution.getStageCode())
+                        || OFFER_STAGE_CODE.equals(execution.getStageCode())
+                ? latestCompletedResultResponse(execution.getMarketNicheId())
+                : null;
+    }
+
+    /** Retorna o Mecanismo concluído quando a etapa pendente precisa desse contexto. */
+    private String pendingMechanismResponse(HypothesisPainStageExecution execution) {
+        return OFFER_STAGE_CODE.equals(execution.getStageCode())
+                ? latestCompletedMechanismResponse(execution.getMarketNicheId())
+                : null;
     }
 
     /** Garante que a etapa Dor tenha sido concluída com resposta antes de liberar Resultado. */
@@ -198,6 +248,14 @@ public class HypothesisPainStageService {
         }
     }
 
+    /** Garante que a etapa Mecanismo tenha sido concluída com resposta antes de liberar Oferta. */
+    private void requireCompletedMechanism(Long marketNicheId) {
+        if (!StringUtils.hasText(latestCompletedMechanismResponse(marketNicheId))) {
+            throw new IllegalStateException(
+                    "A etapa Mecanismo precisa estar concluída antes de iniciar Oferta para o nicho: " + marketNicheId);
+        }
+    }
+
     /** Retorna a resposta da Dor concluída mais recente para contextualizar etapas seguintes. */
     private String latestCompletedPainResponse(Long marketNicheId) {
         return latestCompletedStageResponse(marketNicheId, STAGE_CODE);
@@ -206,6 +264,11 @@ public class HypothesisPainStageService {
     /** Retorna a resposta do Resultado concluído mais recente para contextualizar Mecanismo. */
     private String latestCompletedResultResponse(Long marketNicheId) {
         return latestCompletedStageResponse(marketNicheId, RESULT_STAGE_CODE);
+    }
+
+    /** Retorna a resposta do Mecanismo concluído mais recente para contextualizar Oferta. */
+    private String latestCompletedMechanismResponse(Long marketNicheId) {
+        return latestCompletedStageResponse(marketNicheId, MECHANISM_STAGE_CODE);
     }
 
     /** Retorna a resposta concluída mais recente de uma etapa para contextualizar próximas etapas. */

--- a/backend/ads-service/src/main/java/com/marketinghub/hypothesis/pain/service/pending/HypothesisPainPendingExecution.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/hypothesis/pain/service/pending/HypothesisPainPendingExecution.java
@@ -2,7 +2,7 @@ package com.marketinghub.hypothesis.pain.service.pending;
 
 import java.time.Instant;
 
-/** Execução pendente da etapa Dor entregue ao Worker AI. */
+/** Execução pendente de etapa do pipeline de hipótese entregue ao Worker AI. */
 public record HypothesisPainPendingExecution(
         Long marketNicheId,
         String jobid,
@@ -10,6 +10,7 @@ public record HypothesisPainPendingExecution(
         Instant executionRequestedAt,
         HypothesisPainPendingNiche niche,
         String painModelResponse,
-        String resultModelResponse
+        String resultModelResponse,
+        String mechanismModelResponse
 ) {
 }

--- a/backend/ads-service/src/test/java/com/marketinghub/hypothesis/pain/service/HypothesisPainStageServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/hypothesis/pain/service/HypothesisPainStageServiceTest.java
@@ -23,7 +23,7 @@ import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-/** Responsabilidade: validar a orquestração de custos da etapa Dor do pipeline de hipótese. */
+/** Responsabilidade: validar a orquestração das etapas do pipeline de hipótese por nicho. */
 @ExtendWith(MockitoExtension.class)
 class HypothesisPainStageServiceTest {
 
@@ -211,6 +211,103 @@ class HypothesisPainStageServiceTest {
         assertEquals(1, pending.size());
         assertEquals("{\"pain\":\"dor validada\"}", pending.getFirst().painModelResponse());
         assertEquals("{\"result\":\"resultado validado\"}", pending.getFirst().resultModelResponse());
+    }
+
+    /** Deve bloquear a etapa Oferta quando o mecanismo ainda não está concluído. */
+    @Test
+    void startOfferRequiresCompletedMechanism() {
+        MarketNiche niche = new MarketNiche();
+        niche.setId(18L);
+        when(marketNicheRepository.findById(18L)).thenReturn(Optional.of(niche));
+        when(executionRepository.findTopByMarketNicheIdAndStageCodeAndStatusOrderByExecutionRequestedAtDesc(
+                        18L,
+                        "hypothesis-pain",
+                        "CONCLUIDO"))
+                .thenReturn(Optional.of(HypothesisPainStageExecution.builder()
+                        .marketNicheId(18L)
+                        .stageCode("hypothesis-pain")
+                        .status("CONCLUIDO")
+                        .modelResponse("{\"pain\":\"dor validada\"}")
+                        .build()));
+        when(executionRepository.findTopByMarketNicheIdAndStageCodeAndStatusOrderByExecutionRequestedAtDesc(
+                        18L,
+                        "hypothesis-result",
+                        "CONCLUIDO"))
+                .thenReturn(Optional.of(HypothesisPainStageExecution.builder()
+                        .marketNicheId(18L)
+                        .stageCode("hypothesis-result")
+                        .status("CONCLUIDO")
+                        .modelResponse("{\"result\":\"resultado validado\"}")
+                        .build()));
+        when(executionRepository.findTopByMarketNicheIdAndStageCodeAndStatusOrderByExecutionRequestedAtDesc(
+                        18L,
+                        "hypothesis-mechanism",
+                        "CONCLUIDO"))
+                .thenReturn(Optional.empty());
+
+        assertThrows(IllegalStateException.class, () -> service.startOffer(18L));
+    }
+
+    /** Deve entregar Dor, Resultado e Mecanismo concluídos para contextualizar a etapa Oferta no Worker AI. */
+    @Test
+    void listOfferPendingIncludesLatestCompletedPainResultAndMechanismResponses() {
+        MarketNiche niche = new MarketNiche();
+        niche.setId(18L);
+        niche.setName("Produtores digitais");
+        String offerJob = "5cc56a94-45bc-48bf-8e8d-e1f4f8b881df";
+        HypothesisPainStageExecution offerExecution = HypothesisPainStageExecution.builder()
+                .idJob(offerJob.getBytes(StandardCharsets.UTF_8))
+                .marketNicheId(18L)
+                .marketNiche(niche)
+                .stageCode("hypothesis-offer")
+                .status("INICIADO")
+                .executionRequestedAt(Instant.parse("2026-06-11T14:00:00Z"))
+                .build();
+        HypothesisPainStageExecution completedPain = HypothesisPainStageExecution.builder()
+                .marketNicheId(18L)
+                .stageCode("hypothesis-pain")
+                .status("CONCLUIDO")
+                .modelResponse("{\"pain\":\"dor validada\"}")
+                .build();
+        HypothesisPainStageExecution completedResult = HypothesisPainStageExecution.builder()
+                .marketNicheId(18L)
+                .stageCode("hypothesis-result")
+                .status("CONCLUIDO")
+                .modelResponse("{\"result\":\"resultado validado\"}")
+                .build();
+        HypothesisPainStageExecution completedMechanism = HypothesisPainStageExecution.builder()
+                .marketNicheId(18L)
+                .stageCode("hypothesis-mechanism")
+                .status("CONCLUIDO")
+                .modelResponse("{\"mechanism\":\"mecanismo validado\"}")
+                .build();
+
+        when(executionRepository.findTop20ByStageCodeAndStatusOrderByExecutionRequestedAtAsc(
+                        "hypothesis-offer",
+                        "INICIADO"))
+                .thenReturn(List.of(offerExecution));
+        when(executionRepository.findTopByMarketNicheIdAndStageCodeAndStatusOrderByExecutionRequestedAtDesc(
+                        18L,
+                        "hypothesis-pain",
+                        "CONCLUIDO"))
+                .thenReturn(Optional.of(completedPain));
+        when(executionRepository.findTopByMarketNicheIdAndStageCodeAndStatusOrderByExecutionRequestedAtDesc(
+                        18L,
+                        "hypothesis-result",
+                        "CONCLUIDO"))
+                .thenReturn(Optional.of(completedResult));
+        when(executionRepository.findTopByMarketNicheIdAndStageCodeAndStatusOrderByExecutionRequestedAtDesc(
+                        18L,
+                        "hypothesis-mechanism",
+                        "CONCLUIDO"))
+                .thenReturn(Optional.of(completedMechanism));
+
+        var pending = service.listOfferPending();
+
+        assertEquals(1, pending.size());
+        assertEquals("{\"pain\":\"dor validada\"}", pending.getFirst().painModelResponse());
+        assertEquals("{\"result\":\"resultado validado\"}", pending.getFirst().resultModelResponse());
+        assertEquals("{\"mechanism\":\"mecanismo validado\"}", pending.getFirst().mechanismModelResponse());
     }
 
 }

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -4396,3 +4396,14 @@
 - causa-raiz: o backend já criava e expunha jobs `hypothesis-mechanism`, mas o `ai-worker` não tinha configuração, backend client, processor, scheduler, prompt e schema próprios para consumir essa fila.
 - foi feito: adicionada a etapa `hypothesis-mechanism` no Worker AI, com consumo do endpoint interno de Mecanismo, uso de Dor e Resultado concluídos como contexto, resposta estruturada de mecanismo plausível e testes de contrato.
 - impacto esperado: jobs de Mecanismo deixam de ficar parados em `INICIADO` e passam a avançar para processamento OpenAI, completando o terceiro passo do eixo Dor → Resultado → Mecanismo.
+
+## 2026-06-11 — Etapa 5 Oferta na tela de nova hipótese
+
+- solicitação: transferir a etapa 5 para a tela `/niches/:nicheId/hypotheses/new`.
+- causa-raiz/objetivo: a tela de nova hipótese mostrava apenas Dor, Resultado e Mecanismo, deixando a etapa Oferta fora do acompanhamento operacional do fluxo Dor → Resultado → Mecanismo → Prova → Oferta.
+- foi feito:
+  - adicionada a Etapa 5 — Oferta na tela de nova hipótese, com listagem de execuções, botão assíncrono de início e inclusão do custo no total geral;
+  - criados endpoints backend públicos e internos para iniciar, listar, detalhar e acompanhar jobs da etapa `hypothesis-offer` usando a mesma tabela auditável do pipeline de hipótese;
+  - a liberação da Oferta passou a exigir Mecanismo concluído, preservando a causa-raiz do fluxo sequencial;
+  - atualizada a documentação Swagger do pipeline de hipótese para incluir Oferta.
+- impacto esperado: o usuário passa a acompanhar e iniciar a construção da Oferta no mesmo lugar onde já acompanha as etapas anteriores, reduzindo dispersão operacional e mantendo foco em venda.

--- a/docs/swagger/hypothesis-pain-stage-swagger.yaml
+++ b/docs/swagger/hypothesis-pain-stage-swagger.yaml
@@ -1,8 +1,8 @@
 openapi: 3.0.3
 info:
-  title: Hypothesis Pipeline Initial Stages API
+  title: Hypothesis Pipeline Stages API
   version: 1.0.0
-  description: Contratos das etapas Dor, Resultado e Mecanismo do pipeline de hipótese.
+  description: Contratos das etapas Dor, Resultado, Mecanismo e Oferta do pipeline de hipótese.
 paths:
   /api/niches/{nicheId}/hypothesis-pipeline/pain/start:
     post:
@@ -297,6 +297,108 @@ paths:
   /api/internal/hypothesis-pipeline/mechanism/stage-executions/{idJob}/recebe-resposta:
     post:
       summary: Recebe resposta ou erro da OpenAI para concluir a etapa Mecanismo.
+      parameters:
+        - in: path
+          name: idJob
+          required: true
+          schema: { type: string }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RecebeRespostaRequest'
+      responses:
+        '202': { description: Resposta registrada. }
+  /api/niches/{nicheId}/hypothesis-pipeline/offer/start:
+    post:
+      summary: Inicia a construção auditável da oferta do nicho.
+      parameters:
+        - in: path
+          name: nicheId
+          required: true
+          schema: { type: integer, format: int64 }
+      responses:
+        '202':
+          description: Execução iniciada.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HypothesisPainStartResponse'
+  /api/niches/{nicheId}/hypothesis-pipeline/offer/stage-executions:
+    get:
+      summary: Lista execuções da etapa Oferta para acompanhamento na tela de nova hipótese.
+      parameters:
+        - in: path
+          name: nicheId
+          required: true
+          schema: { type: integer, format: int64 }
+        - in: query
+          name: includeCompleted
+          schema: { type: boolean, default: true }
+      responses:
+        '200':
+          description: Execuções retornadas.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/HypothesisPainExecutionSummaryResponse'
+  /api/niches/{nicheId}/hypothesis-pipeline/offer/stage-executions/{idJob}:
+    get:
+      summary: Consulta detalhe auditável de uma execução da etapa Oferta para a tela de detalhe do job.
+      parameters:
+        - in: path
+          name: nicheId
+          required: true
+          schema: { type: integer, format: int64 }
+        - in: path
+          name: idJob
+          required: true
+          schema: { type: string }
+      responses:
+        '200':
+          description: Detalhe da execução retornado.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HypothesisPainExecutionDetailResponse'
+  /api/internal/hypothesis-pipeline/offer/stage-executions/pending:
+    get:
+      summary: Lista jobs pendentes da etapa Oferta para o Worker AI.
+      responses:
+        '200':
+          description: Jobs pendentes.
+  /api/internal/hypothesis-pipeline/offer/stage-executions/{idJob}/running:
+    post:
+      summary: Marca uma execução de oferta como em processamento.
+      parameters:
+        - in: path
+          name: idJob
+          required: true
+          schema: { type: string }
+      responses:
+        '202': { description: Execução marcada. }
+  /api/internal/hypothesis-pipeline/offer/stage-executions/{idJob}/recebe-prompt:
+    post:
+      summary: Recebe prompt, schema e request cru da etapa Oferta enviados para a OpenAI.
+      parameters:
+        - in: path
+          name: idJob
+          required: true
+          schema: { type: string }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RecebePromptRequest'
+      responses:
+        '202': { description: Prompt registrado. }
+  /api/internal/hypothesis-pipeline/offer/stage-executions/{idJob}/recebe-resposta:
+    post:
+      summary: Recebe resposta ou erro da OpenAI para concluir a etapa Oferta.
       parameters:
         - in: path
           name: idJob

--- a/frontend/src/pages/hypothesis/NewHypothesisPage.test.tsx
+++ b/frontend/src/pages/hypothesis/NewHypothesisPage.test.tsx
@@ -62,16 +62,31 @@ describe("NewHypothesisPage", () => {
           ],
         });
       }
+      if (url.includes("/hypothesis-pipeline/mechanism/")) {
+        return Promise.resolve({
+          data: [
+            {
+              jobid: "bbbbbbbb-3894-43bd-9752-374f84eb6a2c",
+              marketNicheId: 18,
+              stageCode: "hypothesis-mechanism",
+              status: "CONCLUIDO",
+              executionRequestedAt: "2026-06-11T00:31:01Z",
+              completedAt: "2026-06-11T00:35:01Z",
+              costUsd: 0.003,
+            },
+          ],
+        });
+      }
       return Promise.resolve({
         data: [
           {
-            jobid: "bbbbbbbb-3894-43bd-9752-374f84eb6a2c",
+            jobid: "cccccccc-3894-43bd-9752-374f84eb6a2c",
             marketNicheId: 18,
-            stageCode: "hypothesis-mechanism",
+            stageCode: "hypothesis-offer",
             status: "CONCLUIDO",
-            executionRequestedAt: "2026-06-11T00:31:01Z",
-            completedAt: "2026-06-11T00:35:01Z",
-            costUsd: 0.003,
+            executionRequestedAt: "2026-06-11T00:41:01Z",
+            completedAt: "2026-06-11T00:45:01Z",
+            costUsd: 0.004,
           },
         ],
       });
@@ -98,6 +113,7 @@ describe("NewHypothesisPage", () => {
       screen.getByText("Etapa 2 — Resultado desejado"),
     ).toBeInTheDocument();
     expect(screen.getByText("Etapa 3 — Mecanismo")).toBeInTheDocument();
-    expect(screen.getByText(/US\$\s*0,017345/)).toBeInTheDocument();
+    expect(screen.getByText("Etapa 5 — Oferta")).toBeInTheDocument();
+    expect(screen.getByText(/US\$\s*0,021345/)).toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/hypothesis/NewHypothesisPage.tsx
+++ b/frontend/src/pages/hypothesis/NewHypothesisPage.tsx
@@ -18,7 +18,7 @@ interface StageExecution {
 }
 
 interface StageConfig {
-  slug: "pain" | "result" | "mechanism";
+  slug: "pain" | "result" | "mechanism" | "offer";
   number: number;
   title: string;
   startLabel: string;
@@ -70,6 +70,20 @@ const STAGES: StageConfig[] = [
       "Nenhuma execução de mecanismo iniciada para este nicho. Depois de concluir o resultado, clique no botão acima para criar o job e acompanhar o mecanismo.",
     description:
       "Converta o resultado desejado em um mecanismo plausível antes de avançar para prova e oferta.",
+  },
+  {
+    slug: "offer",
+    number: 5,
+    title: "Oferta",
+    startLabel: "Iniciar construção da oferta",
+    startedToast: "Etapa Oferta iniciada",
+    startErrorToast:
+      "Não foi possível iniciar a etapa Oferta. Conclua o mecanismo antes de avançar.",
+    loadingLabel: "Carregando execuções de oferta...",
+    emptyMessage:
+      "Nenhuma execução de oferta iniciada para este nicho. Depois de concluir o mecanismo, clique no botão acima para criar o job e acompanhar a oferta.",
+    description:
+      "Empacote mecanismo, prova prometida e promessa central em uma oferta clara para venda.",
   },
 ];
 
@@ -307,9 +321,9 @@ export default function NewHypothesisPage() {
       <section className="card">
         <div className="card-body">
           <p className="text-muted mb-3">
-            Depois que dor, resultado e mecanismo estiverem claros, avance para
-            construir a hipótese completa seguindo Dor → Resultado → Mecanismo
-            → Prova → Oferta.
+            Depois que dor, resultado, mecanismo e oferta estiverem claros, use
+            a hipótese completa para avançar nos experimentos seguindo Dor →
+            Resultado → Mecanismo → Prova → Oferta.
           </p>
           <Link className="btn btn-outline-secondary" to="/niches">
             Voltar para nichos


### PR DESCRIPTION
### Motivation
- Consolidate the full Dor → Resultado → Mecanismo → Prova → Oferta flow on the New Hypothesis screen by bringing Etapa 5 (Oferta) into the same UI where early stages are managed. 
- Ensure the Offer stage is processed in the same audit-able pipeline with the same operational guarantees (context, sequencing and worker integration). 

### Description
- Frontend: added `offer` to the stages list in `frontend/src/pages/hypothesis/NewHypothesisPage.tsx`, rendering the Offer card, including its start button and including Offer executions in the total cost aggregation, and updated copy to mention the complete flow. 
- Backend controller/service: introduced `hypothesis-offer` stage constants and methods (`startOffer`, `listOfferStageExecutions`, `listOfferPending`) and exposed public and internal endpoints for start/list/detail/pending/running/recebe-prompt/recebe-resposta in `HypothesisPainStageController` and `HypothesisPainStageService`. 
- Sequencing and context: added `requireCompletedMechanism` to block Offer until Mechanism is completed, and enhanced pending payloads to include `mechanismModelResponse` so workers receive pain/result/mechanism context (`HypothesisPainPendingExecution` record updated). 
- Docs & contract: updated `docs/swagger/hypothesis-pain-stage-swagger.yaml` to include Offer endpoints and recorded the change in `docs/registros/experimentos.md`. 
- Tests: updated and added unit tests covering UI rendering and total cost, backend sequencing rules and pending payload composition (`HypothesisPainStageServiceTest` and `NewHypothesisPage.test.tsx`).

### Testing
- Ran backend unit test `HypothesisPainStageServiceTest` and it completed successfully (no failures). 
- Ran frontend unit test `src/pages/hypothesis/NewHypothesisPage.test.tsx` with `vitest` and it passed (`1 test` passed). 
- Ran frontend typecheck with `tsc --noEmit` and it completed with no type errors. 
- Ran `git diff --check` to ensure no whitespace/patch issues (no blocking issues found).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2b32127b9c83219e0941f9244b2bfa)