### PR TITLE
Exibe modelo OpenAI usado em cada etapa da hipótese

### DIFF
--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -4407,3 +4407,10 @@
   - a liberação da Oferta passou a exigir Mecanismo concluído, preservando a causa-raiz do fluxo sequencial;
   - atualizada a documentação Swagger do pipeline de hipótese para incluir Oferta.
 - impacto esperado: o usuário passa a acompanhar e iniciar a construção da Oferta no mesmo lugar onde já acompanha as etapas anteriores, reduzindo dispersão operacional e mantendo foco em venda.
+
+## 2026-06-11 — Modelo OpenAI por etapa na tela de nova hipótese
+
+- solicitação: exibir na tela `/niches/:nicheId/hypotheses/new` qual modelo foi usado em cada etapa do pipeline de criação de hipótese.
+- causa-raiz: o backend já expunha `openAiModel` nas execuções auditáveis, mas a interface ocultava esse dado; isso dificultava comparar custo, qualidade e rastreabilidade por etapa.
+- foi feito: a tela passou a mostrar o modelo usado no resumo da execução atual e em cada linha da tabela de execuções de Dor, Resultado, Mecanismo e Oferta.
+- impacto esperado: o usuário passa a auditar rapidamente qual modelo gerou cada etapa, conectando qualidade do output, custo de IA e decisão comercial.

--- a/frontend/src/pages/hypothesis/NewHypothesisPage.test.tsx
+++ b/frontend/src/pages/hypothesis/NewHypothesisPage.test.tsx
@@ -42,6 +42,7 @@ describe("NewHypothesisPage", () => {
               status: "INICIADO",
               executionRequestedAt: "2026-06-11T00:16:01Z",
               completedAt: "2026-06-11T00:20:01Z",
+              openAiModel: "gpt-4.1-mini",
               costUsd: 0.012345,
             },
           ],
@@ -57,6 +58,7 @@ describe("NewHypothesisPage", () => {
               status: "CONCLUIDO",
               executionRequestedAt: "2026-06-11T00:21:01Z",
               completedAt: "2026-06-11T00:25:01Z",
+              openAiModel: "gpt-4.1",
               costUsd: 0.002,
             },
           ],
@@ -109,6 +111,9 @@ describe("NewHypothesisPage", () => {
       }),
     ).toBeInTheDocument();
     expect(screen.getAllByText(/US\$\s*0,012345/)).not.toHaveLength(0);
+    expect(screen.getAllByText("gpt-4.1-mini")).not.toHaveLength(0);
+    expect(screen.getAllByText("gpt-4.1")).not.toHaveLength(0);
+    expect(screen.getAllByText("Aguardando IA")).not.toHaveLength(0);
     expect(
       screen.getByText("Etapa 2 — Resultado desejado"),
     ).toBeInTheDocument();

--- a/frontend/src/pages/hypothesis/NewHypothesisPage.tsx
+++ b/frontend/src/pages/hypothesis/NewHypothesisPage.tsx
@@ -13,6 +13,7 @@ interface StageExecution {
   executionRequestedAt?: string;
   processingStartedAt?: string;
   completedAt?: string;
+  openAiModel?: string | null;
   costUsd?: number | string | null;
   errorMessage?: string;
 }
@@ -113,6 +114,10 @@ function formatCostUsd(value?: number | string | null) {
     minimumFractionDigits: 4,
     maximumFractionDigits: 6,
   }).format(numericValue);
+}
+
+function formatModel(value?: string | null) {
+  return value && value.trim().length > 0 ? value : "Aguardando IA";
 }
 
 function StageCard({
@@ -217,6 +222,9 @@ function StageCard({
                     </Link>
                   </div>
                   <div className="text-muted small">
+                    Modelo usado: {formatModel(latest.openAiModel)}
+                  </div>
+                  <div className="text-muted small">
                     Custo da última execução: {formatCostUsd(latest.costUsd)}
                   </div>
                 </div>
@@ -241,6 +249,7 @@ function StageCard({
                     <th>Status</th>
                     <th>Solicitado em</th>
                     <th>Concluído em</th>
+                    <th>Modelo usado</th>
                     <th className="text-end">Custo da execução</th>
                   </tr>
                 </thead>
@@ -257,6 +266,7 @@ function StageCard({
                       <td>{execution.status}</td>
                       <td>{formatDate(execution.executionRequestedAt)}</td>
                       <td>{formatDate(execution.completedAt)}</td>
+                      <td>{formatModel(execution.openAiModel)}</td>
                       <td className="text-end">
                         {formatCostUsd(execution.costUsd)}
                       </td>


### PR DESCRIPTION
### Motivation
- Tornar audível qual modelo OpenAI gerou cada etapa do pipeline Dor → Resultado → Mecanismo → Oferta para facilitar correlação entre custo, qualidade e decisão comercial.
- O backend já persiste `openAiModel` nas execuções; a interface precisava exibir esse campo e um fallback quando ainda não houver modelo definido.

### Description
- Adiciona o campo `openAiModel?: string | null` ao `StageExecution` e implementa o helper `formatModel` com fallback `"Aguardando IA"` em `frontend/src/pages/hypothesis/NewHypothesisPage.tsx`.
- Exibe `Modelo usado` no resumo da execução atual de cada etapa e adiciona a coluna `Modelo usado` na tabela de execuções por etapa na mesma tela.
- Atualiza o teste `frontend/src/pages/hypothesis/NewHypothesisPage.test.tsx` para validar modelos reais e o fallback, e registra a mudança no histórico em `docs/registros/experimentos.md`.

### Testing
- Executado o teste de UI com `npm test -- --run src/pages/hypothesis/NewHypothesisPage.test.tsx` e passou com 1 teste OK.
- Rodado o `TypeScript` typecheck com `npm run typecheck` sem erros.
- Build de produção gerada com `npm run build` sem falhas.
- Verificação de formatação feita com `npx prettier --check src/pages/hypothesis/NewHypothesisPage.tsx src/pages/hypothesis/NewHypothesisPage.test.tsx` e sem divergências.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2b392997b083219fffb92eb2de3359)