### PR TITLE
Add hypothesis framework summary view

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/hypothesis/pain/controller/HypothesisPainStageController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/hypothesis/pain/controller/HypothesisPainStageController.java
@@ -7,6 +7,7 @@ import com.marketinghub.hypothesis.pain.service.pending.HypothesisPainPendingExe
 import com.marketinghub.hypothesis.pain.service.recebePrompt.RecebePromptRequest;
 import com.marketinghub.hypothesis.pain.service.recebeResposta.RecebeRespostaRequest;
 import com.marketinghub.hypothesis.pain.service.start.HypothesisPainStartResponse;
+import com.marketinghub.hypothesis.pain.service.summary.HypothesisStageFinalSummaryResponse;
 import jakarta.validation.Valid;
 import java.util.List;
 import org.slf4j.Logger;
@@ -86,6 +87,12 @@ public class HypothesisPainStageController {
             @PathVariable Long nicheId,
             @RequestParam(defaultValue = "true") boolean includeCompleted) {
         return ResponseEntity.ok(service.listOfferStageExecutions(nicheId, includeCompleted));
+    }
+
+    /** Lista o conteúdo final de cada etapa concluída do framework para resumo executivo. */
+    @GetMapping("/niches/{nicheId}/hypothesis-pipeline/summary")
+    public ResponseEntity<List<HypothesisStageFinalSummaryResponse>> finalSummary(@PathVariable Long nicheId) {
+        return ResponseEntity.ok(service.listFinalSummary(nicheId));
     }
 
     /** Consulta detalhe auditável de uma execução da etapa Dor vinculada ao nicho. */

--- a/backend/ads-service/src/main/java/com/marketinghub/hypothesis/pain/service/HypothesisPainStageService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/hypothesis/pain/service/HypothesisPainStageService.java
@@ -8,6 +8,7 @@ import com.marketinghub.hypothesis.pain.service.pending.HypothesisPainPendingExe
 import com.marketinghub.hypothesis.pain.service.pending.HypothesisPainPendingNiche;
 import com.marketinghub.hypothesis.pain.service.recebeResposta.RecebeRespostaRequest;
 import com.marketinghub.hypothesis.pain.service.start.HypothesisPainStartResponse;
+import com.marketinghub.hypothesis.pain.service.summary.HypothesisStageFinalSummaryResponse;
 import com.marketinghub.niche.MarketNiche;
 import com.marketinghub.repository.jpa.hypothesis.HypothesisPainStageExecutionRepository;
 import com.marketinghub.repository.jpa.niche.MarketNicheRepository;
@@ -166,6 +167,51 @@ public class HypothesisPainStageService {
         return executionRepository.findTopByIdJobOrderByExecutionRequestedAtDesc(toDatabaseIdJob(idJob))
                 .map(this::toDetailResponse)
                 .orElseThrow(() -> new EntityNotFoundException("Hypothesis pain execution not found for idJob: " + idJob));
+    }
+
+    /** Lista o conteúdo final concluído de cada etapa do framework para uso como insumo em próximos pipelines. */
+    @Transactional(readOnly = true)
+    public List<HypothesisStageFinalSummaryResponse> listFinalSummary(Long marketNicheId) {
+        return List.of(
+                toFinalSummary(marketNicheId, "pain", 1, "Dor do nicho", STAGE_CODE),
+                toFinalSummary(marketNicheId, "result", 2, "Resultado desejado", RESULT_STAGE_CODE),
+                toFinalSummary(marketNicheId, "mechanism", 3, "Mecanismo", MECHANISM_STAGE_CODE),
+                toFinalSummary(marketNicheId, "offer", 5, "Oferta", OFFER_STAGE_CODE));
+    }
+
+    /** Monta o resumo de uma etapa com a origem exata do conteúdo final no banco de dados. */
+    private HypothesisStageFinalSummaryResponse toFinalSummary(
+            Long marketNicheId,
+            String slug,
+            int stageNumber,
+            String stageTitle,
+            String stageCode) {
+        return executionRepository.findTopByMarketNicheIdAndStageCodeAndStatusOrderByExecutionRequestedAtDesc(
+                        marketNicheId,
+                        stageCode,
+                        STATUS_COMPLETED)
+                .map(execution -> new HypothesisStageFinalSummaryResponse(
+                        slug,
+                        stageNumber,
+                        stageTitle,
+                        stageCode,
+                        fromDatabaseIdJob(execution.getIdJob()),
+                        execution.getStatus(),
+                        execution.getCompletedAt(),
+                        execution.getModelResponse(),
+                        "hypothesis_pain_stage_execution",
+                        "model_response"))
+                .orElseGet(() -> new HypothesisStageFinalSummaryResponse(
+                        slug,
+                        stageNumber,
+                        stageTitle,
+                        stageCode,
+                        null,
+                        null,
+                        null,
+                        null,
+                        "hypothesis_pain_stage_execution",
+                        "model_response"));
     }
 
     /** Lista os jobs iniciados da etapa Dor para processamento pelo Worker AI. */

--- a/backend/ads-service/src/main/java/com/marketinghub/hypothesis/pain/service/summary/HypothesisStageFinalSummaryResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/hypothesis/pain/service/summary/HypothesisStageFinalSummaryResponse.java
@@ -1,0 +1,17 @@
+package com.marketinghub.hypothesis.pain.service.summary;
+
+import java.time.Instant;
+
+/** Resumo do conteúdo final persistido de uma etapa do framework de hipótese. */
+public record HypothesisStageFinalSummaryResponse(
+        String slug,
+        int stageNumber,
+        String stageTitle,
+        String stageCode,
+        String jobid,
+        String status,
+        Instant completedAt,
+        String finalContent,
+        String sourceTable,
+        String sourceField) {
+}

--- a/backend/ads-service/src/test/java/com/marketinghub/hypothesis/pain/service/HypothesisPainStageServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/hypothesis/pain/service/HypothesisPainStageServiceTest.java
@@ -310,4 +310,52 @@ class HypothesisPainStageServiceTest {
         assertEquals("{\"mechanism\":\"mecanismo validado\"}", pending.getFirst().mechanismModelResponse());
     }
 
+    /** Deve listar somente o conteúdo final persistido e a origem no banco para cada etapa do framework. */
+    @Test
+    void listFinalSummaryReturnsFinalContentAndDatabaseSource() {
+        String painJob = "9bb83a22-3894-43bd-9752-374f84eb6a2c";
+        HypothesisPainStageExecution completedPain = HypothesisPainStageExecution.builder()
+                .idJob(painJob.getBytes(StandardCharsets.UTF_8))
+                .marketNicheId(18L)
+                .stageCode("hypothesis-pain")
+                .status("CONCLUIDO")
+                .completedAt(Instant.parse("2026-06-11T01:36:19Z"))
+                .modelResponse("{\"pain\":\"dor final\"}")
+                .build();
+
+        when(executionRepository.findTopByMarketNicheIdAndStageCodeAndStatusOrderByExecutionRequestedAtDesc(
+                        18L,
+                        "hypothesis-pain",
+                        "CONCLUIDO"))
+                .thenReturn(Optional.of(completedPain));
+        when(executionRepository.findTopByMarketNicheIdAndStageCodeAndStatusOrderByExecutionRequestedAtDesc(
+                        18L,
+                        "hypothesis-result",
+                        "CONCLUIDO"))
+                .thenReturn(Optional.empty());
+        when(executionRepository.findTopByMarketNicheIdAndStageCodeAndStatusOrderByExecutionRequestedAtDesc(
+                        18L,
+                        "hypothesis-mechanism",
+                        "CONCLUIDO"))
+                .thenReturn(Optional.empty());
+        when(executionRepository.findTopByMarketNicheIdAndStageCodeAndStatusOrderByExecutionRequestedAtDesc(
+                        18L,
+                        "hypothesis-offer",
+                        "CONCLUIDO"))
+                .thenReturn(Optional.empty());
+
+        var summary = service.listFinalSummary(18L);
+
+        assertEquals(4, summary.size());
+        assertEquals("pain", summary.getFirst().slug());
+        assertEquals(painJob, summary.getFirst().jobid());
+        assertEquals("{\"pain\":\"dor final\"}", summary.getFirst().finalContent());
+        assertEquals("hypothesis_pain_stage_execution", summary.getFirst().sourceTable());
+        assertEquals("model_response", summary.getFirst().sourceField());
+        assertEquals("result", summary.get(1).slug());
+        assertEquals(null, summary.get(1).finalContent());
+        assertEquals("hypothesis_pain_stage_execution", summary.get(1).sourceTable());
+        assertEquals("model_response", summary.get(1).sourceField());
+    }
+
 }

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -4407,3 +4407,10 @@
   - a liberação da Oferta passou a exigir Mecanismo concluído, preservando a causa-raiz do fluxo sequencial;
   - atualizada a documentação Swagger do pipeline de hipótese para incluir Oferta.
 - impacto esperado: o usuário passa a acompanhar e iniciar a construção da Oferta no mesmo lugar onde já acompanha as etapas anteriores, reduzindo dispersão operacional e mantendo foco em venda.
+
+## 2026-06-11 — Resumo final do framework da hipótese
+
+- solicitação: adicionar na tela de nova hipótese um botão de resumo que leve a uma tela com a descrição final gerada em cada etapa do framework.
+- causa-raiz/objetivo: os conteúdos finais usados como insumo dos próximos pipelines estavam disponíveis apenas misturados ao histórico técnico dos jobs, dificultando leitura executiva e reaproveitamento comercial.
+- foi feito: criado endpoint de resumo final por nicho, botão “Resumo do framework” e tela dedicada exibindo somente o conteúdo persistido em `model_response` para cada etapa concluída, com observação de tabela e campo de origem.
+- impacto esperado: o usuário passa a enxergar rapidamente Dor, Resultado, Mecanismo e Oferta finais, sem ruído de prompt/request/log técnico, acelerando a decisão de avançar para experimentos e vendas.

--- a/docs/swagger/hypothesis-pain-stage-swagger.yaml
+++ b/docs/swagger/hypothesis-pain-stage-swagger.yaml
@@ -4,6 +4,23 @@ info:
   version: 1.0.0
   description: Contratos das etapas Dor, Resultado, Mecanismo e Oferta do pipeline de hipótese.
 paths:
+  /api/niches/{nicheId}/hypothesis-pipeline/summary:
+    get:
+      summary: Lista o conteúdo final concluído de cada etapa do framework de hipótese.
+      parameters:
+        - in: path
+          name: nicheId
+          required: true
+          schema: { type: integer, format: int64 }
+      responses:
+        '200':
+          description: Conteúdos finais retornados com origem no banco de dados.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/HypothesisStageFinalSummaryResponse'
   /api/niches/{nicheId}/hypothesis-pipeline/pain/start:
     post:
       summary: Inicia a construção auditável da dor do nicho.
@@ -420,6 +437,19 @@ components:
       properties:
         jobid: { type: string }
         status: { type: string }
+    HypothesisStageFinalSummaryResponse:
+      type: object
+      properties:
+        slug: { type: string }
+        stageNumber: { type: integer }
+        stageTitle: { type: string }
+        stageCode: { type: string }
+        jobid: { type: string, nullable: true }
+        status: { type: string, nullable: true }
+        completedAt: { type: string, format: date-time, nullable: true }
+        finalContent: { type: string, nullable: true }
+        sourceTable: { type: string }
+        sourceField: { type: string }
     HypothesisPainExecutionSummaryResponse:
       type: object
       properties:

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -55,6 +55,7 @@ import HypothesesPage from "./pages/hypothesis/HypothesesPage";
 import HypothesisListPage from "./pages/hypothesis/HypothesisListPage";
 import NewHypothesisPage from "./pages/hypothesis/NewHypothesisPage";
 import HypothesisPainStageExecutionDetailPage from "./pages/hypothesis/HypothesisPainStageExecutionDetailPage";
+import HypothesisPipelineSummaryPage from "./pages/hypothesis/HypothesisPipelineSummaryPage";
 import EditHypothesisPage from "./pages/hypothesis/EditHypothesisPage";
 import AppLayout from "./app/AppLayout";
 import AnglesPage from "./pages/AnglesPage";
@@ -199,6 +200,10 @@ export default function App() {
                 <Route
                   path=":nicheId/hypotheses/new"
                   element={<NewHypothesisPage />}
+                />
+                <Route
+                  path=":nicheId/hypothesis-pipeline/summary"
+                  element={<HypothesisPipelineSummaryPage />}
                 />
                 <Route
                   path=":nicheId/hypothesis-pipeline/:stageSlug/stage-executions/:jobId"

--- a/frontend/src/api/hypothesis/useHypothesisPipelineSummary.ts
+++ b/frontend/src/api/hypothesis/useHypothesisPipelineSummary.ts
@@ -1,0 +1,28 @@
+import { useQuery } from "@tanstack/react-query";
+import axios from "axios";
+
+export interface HypothesisStageFinalSummary {
+  slug: string;
+  stageNumber: number;
+  stageTitle: string;
+  stageCode: string;
+  jobid?: string | null;
+  status?: string | null;
+  completedAt?: string | null;
+  finalContent?: string | null;
+  sourceTable: string;
+  sourceField: string;
+}
+
+export function useHypothesisPipelineSummary(nicheId?: string) {
+  return useQuery({
+    queryKey: ["hypothesis-pipeline-summary", nicheId],
+    enabled: Boolean(nicheId),
+    queryFn: async () => {
+      const { data } = await axios.get<HypothesisStageFinalSummary[]>(
+        `/api/niches/${nicheId}/hypothesis-pipeline/summary`,
+      );
+      return data;
+    },
+  });
+}

--- a/frontend/src/pages/hypothesis/HypothesisPipelineSummaryPage.test.tsx
+++ b/frontend/src/pages/hypothesis/HypothesisPipelineSummaryPage.test.tsx
@@ -1,0 +1,75 @@
+import { render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { describe, expect, it, vi } from "vitest";
+import axios from "axios";
+import HypothesisPipelineSummaryPage from "./HypothesisPipelineSummaryPage";
+
+vi.mock("axios");
+
+function renderPage() {
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: { retry: false },
+      mutations: { retry: false },
+    },
+  });
+
+  return render(
+    <QueryClientProvider client={client}>
+      <MemoryRouter initialEntries={["/niches/18/hypothesis-pipeline/summary"]}>
+        <Routes>
+          <Route
+            path="/niches/:nicheId/hypothesis-pipeline/summary"
+            element={<HypothesisPipelineSummaryPage />}
+          />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe("HypothesisPipelineSummaryPage", () => {
+  it("shows only final stage content with database source notes", async () => {
+    (axios.get as any).mockResolvedValue({
+      data: [
+        {
+          slug: "pain",
+          stageNumber: 1,
+          stageTitle: "Dor do nicho",
+          stageCode: "hypothesis-pain",
+          jobid: "9bb83a22-3894-43bd-9752-374f84eb6a2c",
+          status: "CONCLUIDO",
+          completedAt: "2026-06-11T01:36:19Z",
+          finalContent: '{"pain":"dor final"}',
+          sourceTable: "hypothesis_pain_stage_execution",
+          sourceField: "model_response",
+        },
+        {
+          slug: "offer",
+          stageNumber: 5,
+          stageTitle: "Oferta",
+          stageCode: "hypothesis-offer",
+          finalContent: null,
+          sourceTable: "hypothesis_pain_stage_execution",
+          sourceField: "model_response",
+        },
+      ],
+    });
+
+    renderPage();
+
+    expect(
+      await screen.findByText("Etapa 1 — Dor do nicho"),
+    ).toBeInTheDocument();
+    expect(screen.getByText("dor final")).toBeInTheDocument();
+    expect(
+      screen.getAllByText("hypothesis_pain_stage_execution")[0],
+    ).toBeInTheDocument();
+    expect(screen.getAllByText("model_response")[0]).toBeInTheDocument();
+    expect(
+      screen.getByText(/ainda não possui conteúdo final concluído/i),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("prompt usado")).not.toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/hypothesis/HypothesisPipelineSummaryPage.tsx
+++ b/frontend/src/pages/hypothesis/HypothesisPipelineSummaryPage.tsx
@@ -1,0 +1,99 @@
+import { Link, useParams } from "react-router-dom";
+import PageTitle from "../../components/PageTitle";
+import CollapsibleJsonViewer from "../../components/CollapsibleJsonViewer";
+import hypothesisIcon from "../../assets/icons/hypothesis-icon.svg";
+import { useHypothesisPipelineSummary } from "../../api/hypothesis/useHypothesisPipelineSummary";
+
+function formatDate(value?: string | null) {
+  if (!value) return "—";
+  return new Date(value).toLocaleString("pt-BR");
+}
+
+export default function HypothesisPipelineSummaryPage() {
+  const { nicheId } = useParams();
+  const summaryQuery = useHypothesisPipelineSummary(nicheId);
+  const summaries = summaryQuery.data ?? [];
+
+  return (
+    <div className="hypothesis-pipeline-summary-page">
+      <PageTitle icon={hypothesisIcon}>Resumo do framework</PageTitle>
+
+      <div className="mb-3">
+        <Link
+          className="btn btn-outline-secondary"
+          to={`/niches/${nicheId}/hypotheses/new`}
+        >
+          Voltar para nova hipótese
+        </Link>
+      </div>
+
+      <section className="card mb-4">
+        <div className="card-body">
+          <p className="mb-2">
+            <strong>Nicho:</strong> #{nicheId}
+          </p>
+          <p className="text-muted mb-0">
+            Esta tela mostra somente o conteúdo final gravado no banco de dados
+            para cada etapa concluída do framework. Esse conteúdo é o insumo
+            reaproveitado pelos próximos pipelines.
+          </p>
+        </div>
+      </section>
+
+      {summaryQuery.isLoading ? (
+        <p className="text-muted">Carregando resumo do framework...</p>
+      ) : null}
+      {summaryQuery.isError ? (
+        <div className="alert alert-danger">
+          Não foi possível carregar o resumo do framework.
+        </div>
+      ) : null}
+
+      {!summaryQuery.isLoading && !summaryQuery.isError ? (
+        <div className="d-flex flex-column gap-3">
+          {summaries.map((stage) => (
+            <section className="card" key={stage.stageCode}>
+              <div className="card-header d-flex flex-column flex-lg-row gap-2 justify-content-lg-between">
+                <div>
+                  <h2 className="h5 mb-1">
+                    Etapa {stage.stageNumber} — {stage.stageTitle}
+                  </h2>
+                  <div className="text-muted small">
+                    Observação: origem em tabela{" "}
+                    <code>{stage.sourceTable}</code>, campo{" "}
+                    <code>{stage.sourceField}</code>.
+                  </div>
+                </div>
+                <div className="text-muted small text-lg-end">
+                  Status: {stage.status ?? "sem conteúdo final"}
+                  <br />
+                  Concluído em: {formatDate(stage.completedAt)}
+                </div>
+              </div>
+              <div className="card-body">
+                {stage.jobid ? (
+                  <p className="small text-muted mb-3">
+                    Job final usado como origem:{" "}
+                    <Link
+                      to={`/niches/${nicheId}/hypothesis-pipeline/${stage.slug}/stage-executions/${stage.jobid}`}
+                    >
+                      {stage.jobid}
+                    </Link>
+                  </p>
+                ) : null}
+                {stage.finalContent ? (
+                  <CollapsibleJsonViewer content={stage.finalContent} />
+                ) : (
+                  <div className="alert alert-warning mb-0">
+                    Esta etapa ainda não possui conteúdo final concluído para
+                    reaproveitamento em outros pipelines.
+                  </div>
+                )}
+              </div>
+            </section>
+          ))}
+        </div>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/src/pages/hypothesis/NewHypothesisPage.test.tsx
+++ b/frontend/src/pages/hypothesis/NewHypothesisPage.test.tsx
@@ -115,5 +115,8 @@ describe("NewHypothesisPage", () => {
     expect(screen.getByText("Etapa 3 — Mecanismo")).toBeInTheDocument();
     expect(screen.getByText("Etapa 5 — Oferta")).toBeInTheDocument();
     expect(screen.getByText(/US\$\s*0,021345/)).toBeInTheDocument();
+    expect(
+      screen.getByRole("link", { name: "Resumo do framework" }),
+    ).toHaveAttribute("href", "/niches/18/hypothesis-pipeline/summary");
   });
 });

--- a/frontend/src/pages/hypothesis/NewHypothesisPage.tsx
+++ b/frontend/src/pages/hypothesis/NewHypothesisPage.tsx
@@ -4,6 +4,10 @@ import axios from "axios";
 import { toast } from "react-toastify";
 import PageTitle from "../../components/PageTitle";
 import hypothesisIcon from "../../assets/icons/hypothesis-icon.svg";
+import {
+  HYPOTHESIS_PIPELINE_STAGES,
+  type HypothesisPipelineStageConfig,
+} from "./hypothesisPipelineStages";
 
 interface StageExecution {
   jobid: string;
@@ -17,75 +21,7 @@ interface StageExecution {
   errorMessage?: string;
 }
 
-interface StageConfig {
-  slug: "pain" | "result" | "mechanism" | "offer";
-  number: number;
-  title: string;
-  startLabel: string;
-  startedToast: string;
-  startErrorToast: string;
-  loadingLabel: string;
-  emptyMessage: string;
-  description: string;
-}
-
-const STAGES: StageConfig[] = [
-  {
-    slug: "pain",
-    number: 1,
-    title: "Dor do nicho",
-    startLabel: "Iniciar construção da dor",
-    startedToast: "Etapa Dor iniciada",
-    startErrorToast: "Não foi possível iniciar a etapa Dor",
-    loadingLabel: "Carregando execuções de dor...",
-    emptyMessage:
-      "Nenhuma execução de dor iniciada para este nicho. Clique no botão acima para criar o job e acompanhar o resultado.",
-    description:
-      "Inicie a construção auditável da dor antes de avançar para resultado, mecanismo, prova e oferta.",
-  },
-  {
-    slug: "result",
-    number: 2,
-    title: "Resultado desejado",
-    startLabel: "Iniciar construção do resultado",
-    startedToast: "Etapa Resultado iniciada",
-    startErrorToast:
-      "Não foi possível iniciar a etapa Resultado. Conclua a dor antes de avançar.",
-    loadingLabel: "Carregando execuções de resultado...",
-    emptyMessage:
-      "Nenhuma execução de resultado iniciada para este nicho. Depois de concluir a dor, clique no botão acima para criar o job e acompanhar o resultado.",
-    description:
-      "Transforme a dor validada em um resultado claro, desejável e plausível antes de avançar para mecanismo, prova e oferta.",
-  },
-  {
-    slug: "mechanism",
-    number: 3,
-    title: "Mecanismo",
-    startLabel: "Iniciar construção do mecanismo",
-    startedToast: "Etapa Mecanismo iniciada",
-    startErrorToast:
-      "Não foi possível iniciar a etapa Mecanismo. Conclua o resultado antes de avançar.",
-    loadingLabel: "Carregando execuções de mecanismo...",
-    emptyMessage:
-      "Nenhuma execução de mecanismo iniciada para este nicho. Depois de concluir o resultado, clique no botão acima para criar o job e acompanhar o mecanismo.",
-    description:
-      "Converta o resultado desejado em um mecanismo plausível antes de avançar para prova e oferta.",
-  },
-  {
-    slug: "offer",
-    number: 5,
-    title: "Oferta",
-    startLabel: "Iniciar construção da oferta",
-    startedToast: "Etapa Oferta iniciada",
-    startErrorToast:
-      "Não foi possível iniciar a etapa Oferta. Conclua o mecanismo antes de avançar.",
-    loadingLabel: "Carregando execuções de oferta...",
-    emptyMessage:
-      "Nenhuma execução de oferta iniciada para este nicho. Depois de concluir o mecanismo, clique no botão acima para criar o job e acompanhar a oferta.",
-    description:
-      "Empacote mecanismo, prova prometida e promessa central em uma oferta clara para venda.",
-  },
-];
+const STAGES = HYPOTHESIS_PIPELINE_STAGES;
 
 const RUNNING_STATUSES = new Set([
   "INICIADO",
@@ -119,7 +55,7 @@ function StageCard({
   stage,
   nicheId,
 }: {
-  stage: StageConfig;
+  stage: HypothesisPipelineStageConfig;
   nicheId?: string;
 }) {
   const queryClient = useQueryClient();
@@ -325,9 +261,17 @@ export default function NewHypothesisPage() {
             a hipótese completa para avançar nos experimentos seguindo Dor →
             Resultado → Mecanismo → Prova → Oferta.
           </p>
-          <Link className="btn btn-outline-secondary" to="/niches">
-            Voltar para nichos
-          </Link>
+          <div className="d-flex flex-wrap gap-2">
+            <Link
+              className="btn btn-primary"
+              to={`/niches/${nicheId}/hypothesis-pipeline/summary`}
+            >
+              Resumo do framework
+            </Link>
+            <Link className="btn btn-outline-secondary" to="/niches">
+              Voltar para nichos
+            </Link>
+          </div>
         </div>
       </section>
     </div>

--- a/frontend/src/pages/hypothesis/hypothesisPipelineStages.ts
+++ b/frontend/src/pages/hypothesis/hypothesisPipelineStages.ts
@@ -1,0 +1,74 @@
+export interface HypothesisPipelineStageConfig {
+  slug: "pain" | "result" | "mechanism" | "offer";
+  number: number;
+  stageCode: string;
+  title: string;
+  startLabel: string;
+  startedToast: string;
+  startErrorToast: string;
+  loadingLabel: string;
+  emptyMessage: string;
+  description: string;
+}
+
+export const HYPOTHESIS_PIPELINE_STAGES: HypothesisPipelineStageConfig[] = [
+  {
+    slug: "pain",
+    number: 1,
+    stageCode: "hypothesis-pain",
+    title: "Dor do nicho",
+    startLabel: "Iniciar construção da dor",
+    startedToast: "Etapa Dor iniciada",
+    startErrorToast: "Não foi possível iniciar a etapa Dor",
+    loadingLabel: "Carregando execuções de dor...",
+    emptyMessage:
+      "Nenhuma execução de dor iniciada para este nicho. Clique no botão acima para criar o job e acompanhar o resultado.",
+    description:
+      "Inicie a construção auditável da dor antes de avançar para resultado, mecanismo, prova e oferta.",
+  },
+  {
+    slug: "result",
+    number: 2,
+    stageCode: "hypothesis-result",
+    title: "Resultado desejado",
+    startLabel: "Iniciar construção do resultado",
+    startedToast: "Etapa Resultado iniciada",
+    startErrorToast:
+      "Não foi possível iniciar a etapa Resultado. Conclua a dor antes de avançar.",
+    loadingLabel: "Carregando execuções de resultado...",
+    emptyMessage:
+      "Nenhuma execução de resultado iniciada para este nicho. Depois de concluir a dor, clique no botão acima para criar o job e acompanhar o resultado.",
+    description:
+      "Transforme a dor validada em um resultado claro, desejável e plausível antes de avançar para mecanismo, prova e oferta.",
+  },
+  {
+    slug: "mechanism",
+    number: 3,
+    stageCode: "hypothesis-mechanism",
+    title: "Mecanismo",
+    startLabel: "Iniciar construção do mecanismo",
+    startedToast: "Etapa Mecanismo iniciada",
+    startErrorToast:
+      "Não foi possível iniciar a etapa Mecanismo. Conclua o resultado antes de avançar.",
+    loadingLabel: "Carregando execuções de mecanismo...",
+    emptyMessage:
+      "Nenhuma execução de mecanismo iniciada para este nicho. Depois de concluir o resultado, clique no botão acima para criar o job e acompanhar o mecanismo.",
+    description:
+      "Converta o resultado desejado em um mecanismo plausível antes de avançar para prova e oferta.",
+  },
+  {
+    slug: "offer",
+    number: 5,
+    stageCode: "hypothesis-offer",
+    title: "Oferta",
+    startLabel: "Iniciar construção da oferta",
+    startedToast: "Etapa Oferta iniciada",
+    startErrorToast:
+      "Não foi possível iniciar a etapa Oferta. Conclua o mecanismo antes de avançar.",
+    loadingLabel: "Carregando execuções de oferta...",
+    emptyMessage:
+      "Nenhuma execução de oferta iniciada para este nicho. Depois de concluir o mecanismo, clique no botão acima para criar o job e acompanhar a oferta.",
+    description:
+      "Empacote mecanismo, prova prometida e promessa central em uma oferta clara para venda.",
+  },
+];


### PR DESCRIPTION
### Motivation
- Provide a clean, executive view of the final content produced by each step of the hypothesis framework so downstream pipelines can consume only the persisted final output without audit/log noise. 
- Make explicit the database origin of the final content to avoid accidental reuse of transient/prompt artifacts and to speed decision-making to advance to experiments and sales.

### Description
- Added a backend endpoint `GET /api/niches/{nicheId}/hypothesis-pipeline/summary` and service method `listFinalSummary` that returns the most recent `CONCLUIDO` `model_response` for each stage and includes `sourceTable`/`sourceField` metadata (`hypothesis_pain_stage_execution.model_response`).
- Introduced DTO `HypothesisStageFinalSummaryResponse` to encapsulate `slug`, `stageNumber`, `stageTitle`, `stageCode`, `jobid`, `status`, `completedAt`, `finalContent`, `sourceTable`, and `sourceField`.
- Updated Swagger contract `docs/swagger/hypothesis-pain-stage-swagger.yaml` with the new summary path and schema and recorded the task in `docs/registros/experimentos.md`.
- Frontend: added route and page `HypothesisPipelineSummaryPage` at `/niches/:nicheId/hypothesis-pipeline/summary`, a hook `useHypothesisPipelineSummary`, a button `Resumo do framework` on the new-hypothesis screen, and a small refactor to extract stage config to `hypothesisPipelineStages.ts`; the summary page shows only the persisted `finalContent` and the origin table/field.
- Added unit tests for the backend service (`HypothesisPainStageServiceTest`) and frontend UI tests (`HypothesisPipelineSummaryPage.test.tsx`) and updated the existing `NewHypothesisPage` test to assert the new button link.

### Testing
- Ran backend unit tests with `cd backend/ads-service && ../mvnw test -Dtest=HypothesisPainStageServiceTest`, which completed successfully (8 tests, 0 failures). 
- Ran frontend typecheck with `cd frontend && npm run typecheck` after installing dependencies, which completed without blocking errors.
- Ran frontend tests with `cd frontend && npm test -- --run src/pages/hypothesis/NewHypothesisPage.test.tsx src/pages/hypothesis/HypothesisPipelineSummaryPage.test.tsx`, and both test files passed (2 tests total).
- Applied formatting on frontend files with `npx prettier --write` (files updated); attempted `../mvnw spotless:apply` for backend but Spotless plugin was not available in the module (warning, non-blocking).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2b3892c4b4832186eb46eb0aae2e4f)