### PR TITLE
Expose Hotmart numeric temperature in MOIS sales library and UI

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/dto/MoisSalesLibraryDtos.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/dto/MoisSalesLibraryDtos.java
@@ -212,6 +212,7 @@ public final class MoisSalesLibraryDtos {
             String productName,
             String producerName,
             String hotmartPrice,
+            BigDecimal hotmartTemperature,
             String hotmartProducer,
             String currentStage,
             String currentStatus,

--- a/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryService.java
@@ -541,7 +541,7 @@ public class MoisSalesLibraryService {
         List<MoisSalesLibraryDtos.SalesLibraryPageResponse> items = jdbcTemplate.query("""
                 SELECT p.id, p.workspace_id, p.source, p.url_canonical, p.title, p.current_stage, p.current_status, p.capture_status,
                        COALESCE(p.analysis_status, p.current_status) AS analysis_status, p.url_final, p.http_status, p.html_sha256,
-                       p.html_bytes, p.score_total, p.product_name, cr.producer_name, cr.hotmart_price, cr.hotmart_producer,
+                       p.html_bytes, p.score_total, p.product_name, cr.producer_name, cr.hotmart_price, cr.hotmart_temperature, cr.hotmart_producer,
                        p.offer_summary, p.mechanism_summary, p.promise_summary, p.proof_summary,
                        p.model_name, p.input_tokens, p.output_tokens, p.model_cost_usd,
                        p.last_error_category, p.last_error_message, p.last_job_execution_id, p.last_captured_at, p.last_analyzed_at, p.updated_at,
@@ -688,7 +688,7 @@ public class MoisSalesLibraryService {
         List<MoisSalesLibraryDtos.SalesLibraryPageResponse> rows = jdbcTemplate.query("""
                 SELECT p.id, p.workspace_id, p.source, p.url_canonical, p.title, p.current_stage, p.current_status, p.capture_status,
                        COALESCE(p.analysis_status, p.current_status) AS analysis_status, p.url_final, p.http_status, p.html_sha256,
-                       p.html_bytes, p.score_total, p.product_name, cr.producer_name, cr.hotmart_price, cr.hotmart_producer,
+                       p.html_bytes, p.score_total, p.product_name, cr.producer_name, cr.hotmart_price, cr.hotmart_temperature, cr.hotmart_producer,
                        p.offer_summary, p.mechanism_summary, p.promise_summary, p.proof_summary,
                        p.model_name, p.input_tokens, p.output_tokens, p.model_cost_usd,
                        p.last_error_category, p.last_error_message, p.last_job_execution_id, p.last_captured_at, p.last_analyzed_at, p.updated_at,
@@ -1349,6 +1349,7 @@ public class MoisSalesLibraryService {
                 rs.getString("product_name"),
                 rs.getString("producer_name"),
                 rs.getString("hotmart_price"),
+                rs.getBigDecimal("hotmart_temperature"),
                 rs.getString("hotmart_producer"),
                 rs.getString("current_stage"),
                 rs.getString("current_status"),

--- a/backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryServiceTest.java
@@ -176,6 +176,7 @@ class MoisSalesLibraryServiceTest {
         verify(jdbcTemplate).query(sqlCaptor.capture(), isA(RowMapper.class), eq("workspace-001"), eq(20), eq(0));
         org.assertj.core.api.Assertions.assertThat(sqlCaptor.getValue())
                 .contains("LEFT JOIN mois_sales_page_market_warmup_summary mws")
+                .contains("cr.hotmart_temperature")
                 .contains("ORDER BY p.last_analyzed_at DESC, p.updated_at DESC, p.id DESC LIMIT ? OFFSET ?");
     }
 
@@ -471,7 +472,7 @@ class MoisSalesLibraryServiceTest {
         lenient().when(jdbcTemplate.query(contains("WHERE workspace_id = ? AND url_canonical = ?"), isA(RowMapper.class), any(), any()))
                 .thenReturn(List.of(99L));
         lenient().when(jdbcTemplate.query(contains("SELECT p.id, p.workspace_id, p.source"), isA(RowMapper.class), any()))
-                .thenReturn(List.of(new MoisSalesLibraryDtos.SalesLibraryPageResponse(99L, "10", "HOTMART", "https://example.com/pagina", "Title", "Produto Teste", "Produtor Teste", "R$ 5.997,00", "Abrantes Lima Empreendimentos LTDA",
+                .thenReturn(List.of(new MoisSalesLibraryDtos.SalesLibraryPageResponse(99L, "10", "HOTMART", "https://example.com/pagina", "Title", "Produto Teste", "Produtor Teste", "R$ 5.997,00", BigDecimal.valueOf(150), "Abrantes Lima Empreendimentos LTDA",
                         "ANALYSIS", "PENDING", null, "PENDING", null, null, null, 0L, BigDecimal.ZERO, null, null, null, null, null, null, null, null, null, null, null, Instant.now(), null, null, null, null, null, null, null, null)));
         lenient().when(jdbcTemplate.update(contains("INSERT INTO mois_sales_page_job_execution"), any(), any(), any())).thenReturn(1);
         lenient().when(jdbcTemplate.queryForObject(contains("SELECT LAST_INSERT_ID()"), eq(Long.class))).thenReturn(123L);

--- a/docs/registros/mois1.md
+++ b/docs/registros/mois1.md
@@ -1541,3 +1541,16 @@ Arquivos principais:
 - `mois-sales-library-worker/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/marketwarmup/MarketWarmupQueryBuilder.java`
 - `mois-sales-library-worker/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/marketwarmup/MarketWarmupProcessor.java`
 - `frontend/src/pages/mois/MoisSalesPageLibraryDetailPage.tsx`
+
+## 2026-06-11 — Temperatura numérica Hotmart na Biblioteca MOIS
+
+- exposto no contrato da Biblioteca de Páginas de Vendas o campo `hotmartTemperature`, lido de `mois_collected_reference.hotmart_temperature` junto com os demais fatos Hotmart.
+- ajustada a tabela `/mois/sales-pages-library` para mostrar o indicador numérico coletado da Hotmart junto do rótulo de aquecimento do dossiê.
+- ajustada a tela de detalhe do produto para exibir a temperatura Hotmart no bloco factual inicial do dossiê.
+
+Arquivos principais:
+- `backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/dto/MoisSalesLibraryDtos.java`
+- `backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryService.java`
+- `frontend/src/pages/mois/MoisSalesPagesLibraryPage.tsx`
+- `frontend/src/pages/mois/MoisSalesPageLibraryDetailPage.tsx`
+- `docs/swagger/mois-sales-library-swagger.yaml`

--- a/docs/swagger/mois-sales-library-swagger.yaml
+++ b/docs/swagger/mois-sales-library-swagger.yaml
@@ -1344,6 +1344,11 @@ components:
           type: string
           nullable: true
           description: Preço exibido pela Hotmart quando coletado na origem.
+        hotmartTemperature:
+          type: number
+          format: double
+          nullable: true
+          description: Indicador numérico de temperatura coletado diretamente da Hotmart.
         hotmartProducer:
           type: string
           nullable: true

--- a/frontend/src/api/mois/types.ts
+++ b/frontend/src/api/mois/types.ts
@@ -263,6 +263,7 @@ export interface MoisSalesLibraryPage {
   productName?: string;
   producerName?: string;
   hotmartPrice?: string;
+  hotmartTemperature?: number | null;
   hotmartProducer?: string;
   currentStage?: string;
   currentStatus?: string;

--- a/frontend/src/pages/mois/MoisSalesPageLibraryDetailPage.tsx
+++ b/frontend/src/pages/mois/MoisSalesPageLibraryDetailPage.tsx
@@ -21,6 +21,15 @@ function displayText(value?: string) {
   return cleanText(value) || "—";
 }
 
+function formatHotmartTemperature(value?: number | null) {
+  return value == null
+    ? "—"
+    : value.toLocaleString("pt-BR", {
+        minimumFractionDigits: 2,
+        maximumFractionDigits: 2,
+      });
+}
+
 function formatDate(value?: string) {
   if (!value) return "—";
   const date = new Date(value);
@@ -90,6 +99,7 @@ export default function MoisSalesPageLibraryDetailPage() {
     currentIndex >= 0 ? pagesQuery.data?.items[currentIndex + 1] : undefined;
   const isMutating = updateStatusMutation.isPending;
   const hotmartPrice = cleanText(pageQuery.data?.hotmartPrice);
+  const hotmartTemperature = pageQuery.data?.hotmartTemperature;
   const hotmartProducer =
     cleanText(pageQuery.data?.hotmartProducer) ||
     cleanText(pageQuery.data?.producerName);
@@ -232,13 +242,24 @@ export default function MoisSalesPageLibraryDetailPage() {
           </div>
 
           <div className="row g-3">
-            <div className="col-md-6">
+            <div className="col-md-4">
               <div className="border rounded p-3 h-100 bg-light-subtle">
                 <div className="text-secondary small">Preço Hotmart</div>
                 <strong className="fs-5">{displayText(hotmartPrice)}</strong>
               </div>
             </div>
-            <div className="col-md-6">
+            <div className="col-md-4">
+              <div className="border rounded p-3 h-100 bg-light-subtle">
+                <div className="text-secondary small">Temperatura Hotmart</div>
+                <strong className="fs-5">
+                  {formatHotmartTemperature(hotmartTemperature)}
+                </strong>
+                <div className="small text-secondary">
+                  Indicador coletado diretamente da Hotmart
+                </div>
+              </div>
+            </div>
+            <div className="col-md-4">
               <div className="border rounded p-3 h-100 bg-light-subtle">
                 <div className="text-secondary small">Produtor Hotmart</div>
                 <strong className="fs-5">{displayText(hotmartProducer)}</strong>
@@ -246,11 +267,11 @@ export default function MoisSalesPageLibraryDetailPage() {
             </div>
           </div>
 
-          {!hotmartPrice || !hotmartProducer ? (
+          {!hotmartPrice || hotmartTemperature == null || !hotmartProducer ? (
             <div className="alert alert-warning mb-0">
               O banco ainda não possui todos os fatos básicos do dossiê. O
-              próximo passo é corrigir a coleta para preencher preço e produtor
-              diretamente da página de venda.
+              próximo passo é corrigir a coleta para preencher preço,
+              temperatura e produtor diretamente da página de venda.
             </div>
           ) : null}
         </div>

--- a/frontend/src/pages/mois/MoisSalesPagesLibraryPage.tsx
+++ b/frontend/src/pages/mois/MoisSalesPagesLibraryPage.tsx
@@ -37,6 +37,15 @@ function formatCurrencyUsd(value?: number | null) {
     : value.toLocaleString("pt-BR", { style: "currency", currency: "USD" });
 }
 
+function formatHotmartTemperature(value?: number | null) {
+  return value == null
+    ? "—"
+    : value.toLocaleString("pt-BR", {
+        minimumFractionDigits: 2,
+        maximumFractionDigits: 2,
+      });
+}
+
 function getWarmupBadgeClass(value?: string | null) {
   switch (value) {
     case "HOT":
@@ -358,17 +367,22 @@ export default function MoisSalesPagesLibraryPage() {
                         </td>
                         <td>
                           {item.source === "HOTMART" ? (
-                            <span
-                              className={`badge ${getWarmupBadgeClass(item.marketWarmupTemperature || item.marketWarmupStatus)}`}
-                            >
-                              {item.marketWarmupTemperature
-                                ? warmupTemperatureLabels[
-                                    item.marketWarmupTemperature
-                                  ]
-                                : item.marketWarmupStatus
-                                  ? warmupStatusLabels[item.marketWarmupStatus]
-                                  : "Sem dossiê"}
-                            </span>
+                            <div className="d-flex flex-column align-items-start gap-1">
+                              <span className="fw-semibold">
+                                {formatHotmartTemperature(item.hotmartTemperature)}
+                              </span>
+                              <span
+                                className={`badge ${getWarmupBadgeClass(item.marketWarmupTemperature || item.marketWarmupStatus)}`}
+                              >
+                                Dossiê: {item.marketWarmupTemperature
+                                  ? warmupTemperatureLabels[
+                                      item.marketWarmupTemperature
+                                    ]
+                                  : item.marketWarmupStatus
+                                    ? warmupStatusLabels[item.marketWarmupStatus]
+                                    : "Sem dossiê"}
+                              </span>
+                            </div>
                           ) : (
                             "—"
                           )}


### PR DESCRIPTION
### Motivation
- Add the numeric Hotmart temperature captured in `mois_collected_reference.hotmart_temperature` to the sales pages library contract and surfaces so the UI can show a precise indicator alongside warmup labels.
- Ensure the backend returns the new field consistently in list and detail endpoints and that the API docs/types reflect the change.

### Description
- Added `hotmartTemperature` as a `BigDecimal` field to the backend DTO `MoisSalesLibraryDtos.SalesLibraryPageResponse` and included `cr.hotmart_temperature` in SQL selects used by `listPages` and `getPage` and mapped it via `rs.getBigDecimal("hotmart_temperature")` in `MoisSalesLibraryService#mapSalesPageResponse`.
- Updated Swagger (`docs/swagger/mois-sales-library-swagger.yaml`) and frontend API types (`frontend/src/api/mois/types.ts`) to declare `hotmartTemperature` and adjusted the docs (`docs/registros/mois1.md`) to record the change.
- Updated UI components: added formatting and display of Hotmart temperature in `MoisSalesPageLibraryDetailPage.tsx` and `MoisSalesPagesLibraryPage.tsx`, including a numeric badge in the list and a detail block in the page view.
- Adjusted tests and test stubs in `MoisSalesLibraryServiceTest` to account for the new field and to assert the generated SQL contains `cr.hotmart_temperature`.

### Testing
- Ran the backend unit tests (`MoisSalesLibraryServiceTest`) which include assertions for SQL composition and mapping of the new field, and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2b3735e024832183576aa7933b8d5f)