### PR TITLE
Add 'Prova' (hypothesis-proof) stage: backend checks and AI-worker pipeline support

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/pipeline/hypothesisproof/HypothesisProofBackendClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/pipeline/hypothesisproof/HypothesisProofBackendClient.java
@@ -1,4 +1,4 @@
-package com.marketinghub.worker.pipeline.hypothesisoffer;
+package com.marketinghub.worker.pipeline.hypothesisproof;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marketinghub.worker.openai.core.model.OpenAiRequest;
@@ -13,25 +13,25 @@ import java.util.Map;
 import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.web.reactive.function.client.WebClient;
 
-/** Responsabilidade: integrar a etapa Oferta do pipeline de hipótese aos endpoints internos do backend. */
-public class HypothesisOfferBackendClient implements StageBackendPort<HypothesisOfferInput, HypothesisOfferOutput> {
+/** Responsabilidade: integrar a etapa Prova do pipeline de hipótese aos endpoints internos do backend. */
+public class HypothesisProofBackendClient implements StageBackendPort<HypothesisProofInput, HypothesisProofOutput> {
     private static final String STATUS_STARTED = "INICIADO";
     private final WebClient webClient;
-    private final HypothesisOfferWorkerProperties properties;
+    private final HypothesisProofWorkerProperties properties;
     private final ObjectMapper objectMapper;
 
-    /** Inicializa o cliente com WebClient, propriedades da etapa Oferta e ObjectMapper para normalizar contexto. */
-    public HypothesisOfferBackendClient(WebClient.Builder builder, HypothesisOfferWorkerProperties properties, ObjectMapper objectMapper) {
+    /** Inicializa o cliente com WebClient, propriedades da etapa Prova e ObjectMapper para normalizar contexto. */
+    public HypothesisProofBackendClient(WebClient.Builder builder, HypothesisProofWorkerProperties properties, ObjectMapper objectMapper) {
         this.webClient = builder.build();
         this.properties = properties;
         this.objectMapper = objectMapper;
     }
 
-    /** Busca no backend os jobs da etapa Oferta iniciados e aptos para processamento. */
+    /** Busca no backend os jobs da etapa Prova iniciados e aptos para processamento. */
     @Override
-    public List<StageExecution<HypothesisOfferInput>> listPending(int limit) {
+    public List<StageExecution<HypothesisProofInput>> listPending(int limit) {
         int effectiveLimit = Math.max(1, limit);
-        String uri = joinPath(properties.backendBaseUrl(), properties.apiPrefix(), "/internal/hypothesis-pipeline/offer/stage-executions/pending");
+        String uri = joinPath(properties.backendBaseUrl(), properties.apiPrefix(), "/internal/hypothesis-pipeline/proof/stage-executions/pending");
         List<Map<String, Object>> payload = webClient.get()
                 .uri(uri)
                 .retrieve()
@@ -49,7 +49,7 @@ public class HypothesisOfferBackendClient implements StageBackendPort<Hypothesis
 
     /** Marca a execução como em processamento para impedir recaptura em ciclos concorrentes. */
     @Override
-    public void markRunning(StageExecution<HypothesisOfferInput> execution) {
+    public void markRunning(StageExecution<HypothesisProofInput> execution) {
         webClient.post()
                 .uri(stageExecutionBaseUrl() + "/{idJob}/running", execution.idJob())
                 .retrieve()
@@ -58,7 +58,7 @@ public class HypothesisOfferBackendClient implements StageBackendPort<Hypothesis
     }
 
     /** Persiste no backend o prompt renderizado, schema e request bruto enviados para OpenAI. */
-    public void saveOpenAiRequest(StageExecution<HypothesisOfferInput> execution, OpenAiRequest request) {
+    public void saveOpenAiRequest(StageExecution<HypothesisProofInput> execution, OpenAiRequest request) {
         Map<String, Object> body = new LinkedHashMap<>();
         body.put("prompt", request.prompt());
         body.put("promptMarkdownContent", request.promptMarkdownContent());
@@ -74,9 +74,9 @@ public class HypothesisOfferBackendClient implements StageBackendPort<Hypothesis
                 .block(properties.timeout());
     }
 
-    /** Envia ao backend a resposta validada da OpenAI para concluir a etapa Oferta. */
+    /** Envia ao backend a resposta validada da OpenAI para concluir a etapa Prova. */
     @Override
-    public void markCompleted(StageExecution<HypothesisOfferInput> execution, StageResult<HypothesisOfferOutput> result) {
+    public void markCompleted(StageExecution<HypothesisProofInput> execution, StageResult<HypothesisProofOutput> result) {
         OpenAiResult<String> openAiResult = openAiResult(result);
         Map<String, Object> body = new LinkedHashMap<>();
         body.put("marketNicheId", execution.aggregateId());
@@ -97,9 +97,9 @@ public class HypothesisOfferBackendClient implements StageBackendPort<Hypothesis
                 .block(properties.timeout());
     }
 
-    /** Envia ao backend os dados de falha quando a etapa Oferta não é concluída. */
+    /** Envia ao backend os dados de falha quando a etapa Prova não é concluída. */
     @Override
-    public void markFailed(StageExecution<HypothesisOfferInput> execution, Throwable error) {
+    public void markFailed(StageExecution<HypothesisProofInput> execution, Throwable error) {
         Map<String, Object> body = new LinkedHashMap<>();
         body.put("marketNicheId", execution.aggregateId());
         body.put("stageCode", execution.stageCode());
@@ -120,11 +120,11 @@ public class HypothesisOfferBackendClient implements StageBackendPort<Hypothesis
     }
 
     /** Converte o payload pendente do backend para o modelo interno de execução da etapa. */
-    private StageExecution<HypothesisOfferInput> toStageExecution(Map<String, Object> item) {
+    private StageExecution<HypothesisProofInput> toStageExecution(Map<String, Object> item) {
         Long marketNicheId = asLong(item.get("marketNicheId"));
         String stageCode = asString(item.get("stageCode"));
         String idJob = asString(firstPresent(item.get("jobid"), item.get("idJob")));
-        HypothesisOfferInput input = new HypothesisOfferInput(marketNicheId, stageCode, idJob, buildPromptDataFromPending(item));
+        HypothesisProofInput input = new HypothesisProofInput(marketNicheId, stageCode, idJob, buildPromptDataFromPending(item));
         return new StageExecution<>(idJob, marketNicheId, stageCode, STATUS_STARTED, asInstant(item.get("executionRequestedAt")), input, Map.of());
     }
 
@@ -145,7 +145,6 @@ public class HypothesisOfferBackendClient implements StageBackendPort<Hypothesis
         payload.put("painModelResponse", optionalText(pending.get("painModelResponse")));
         payload.put("resultModelResponse", optionalText(pending.get("resultModelResponse")));
         payload.put("mechanismModelResponse", optionalText(pending.get("mechanismModelResponse")));
-        payload.put("proofModelResponse", optionalText(pending.get("proofModelResponse")));
         payload.put("CASE_DATA_BLOCK", buildCaseDataBlock(payload));
         return payload;
     }
@@ -155,7 +154,7 @@ public class HypothesisOfferBackendClient implements StageBackendPort<Hypothesis
         return value != null ? value.toString() : "";
     }
 
-    /** Monta o bloco textual de contexto estratégico exigido pelo prompt da etapa Oferta. */
+    /** Monta o bloco textual de contexto estratégico exigido pelo prompt da etapa Prova. */
     private String buildCaseDataBlock(Map<String, Object> payload) {
         StringBuilder builder = new StringBuilder("[CASE_DATA_BEGIN]\n");
         appendCaseData(builder, "marketNicheId", payload.get("marketNicheId"));
@@ -171,7 +170,6 @@ public class HypothesisOfferBackendClient implements StageBackendPort<Hypothesis
         appendCaseData(builder, "painModelResponse", payload.get("painModelResponse"));
         appendCaseData(builder, "resultModelResponse", payload.get("resultModelResponse"));
         appendCaseData(builder, "mechanismModelResponse", payload.get("mechanismModelResponse"));
-        appendCaseData(builder, "proofModelResponse", payload.get("proofModelResponse"));
         builder.append("[CASE_DATA_END]");
         return builder.toString();
     }
@@ -181,13 +179,13 @@ public class HypothesisOfferBackendClient implements StageBackendPort<Hypothesis
         builder.append(key).append(": ").append(toJsonOrText(value).trim()).append('\n');
     }
 
-    /** Extrai a oferta OpenAI bruto armazenado nas métricas da oferta da etapa. */
-    private OpenAiResult<String> openAiResult(StageResult<HypothesisOfferOutput> result) {
+    /** Extrai a prova OpenAI bruto armazenado nas métricas da prova da etapa. */
+    private OpenAiResult<String> openAiResult(StageResult<HypothesisProofOutput> result) {
         Object value = result.metrics().get("openAiResult");
         if (value instanceof OpenAiResult<?> raw) {
             return new OpenAiResult<>(raw.openAiJobId(), raw.rawResponse(), raw.modelResponse(), raw.modelResponse(), raw.inputTokens(), raw.outputTokens(), raw.costUsd());
         }
-        throw new IllegalStateException("Resultado da etapa Oferta sem métrica openAiResult");
+        throw new IllegalStateException("Resultado da etapa Prova sem métrica openAiResult");
     }
 
     /** Renderiza objetos estruturados como JSON formatado e preserva textos simples. */
@@ -201,8 +199,8 @@ public class HypothesisOfferBackendClient implements StageBackendPort<Hypothesis
         try {
             return objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(value);
         } catch (Exception error) {
-            org.slf4j.LoggerFactory.getLogger(HypothesisOfferBackendClient.class).warn(
-                    "Falha ao serializar valor do prompt da etapa Oferta; usando fallback textual. valueType={}",
+            org.slf4j.LoggerFactory.getLogger(HypothesisProofBackendClient.class).warn(
+                    "Falha ao serializar valor do prompt da etapa Prova; usando fallback textual. valueType={}",
                     value.getClass().getName(),
                     error);
             return value.toString();
@@ -255,21 +253,21 @@ public class HypothesisOfferBackendClient implements StageBackendPort<Hypothesis
         return null;
     }
 
-    /** Monta a URL base dos endpoints internos de execução da etapa Oferta. */
+    /** Monta a URL base dos endpoints internos de execução da etapa Prova. */
     private String stageExecutionBaseUrl() {
-        return joinPath(properties.backendBaseUrl(), properties.apiPrefix(), "/internal/hypothesis-pipeline/offer/stage-executions");
+        return joinPath(properties.backendBaseUrl(), properties.apiPrefix(), "/internal/hypothesis-pipeline/proof/stage-executions");
     }
 
     /** Registra o payload enviado de volta para o backend com o jobId operacional. */
     private void logBackendPayload(String idJob, Map<String, Object> body) {
         try {
-            org.slf4j.LoggerFactory.getLogger(HypothesisOfferBackendClient.class).info(
-                    "Enviando payload para backend na etapa Oferta. jobId={} payload={}",
+            org.slf4j.LoggerFactory.getLogger(HypothesisProofBackendClient.class).info(
+                    "Enviando payload para backend na etapa Prova. jobId={} payload={}",
                     idJob,
                     objectMapper.writeValueAsString(body));
         } catch (Exception error) {
-            org.slf4j.LoggerFactory.getLogger(HypothesisOfferBackendClient.class).warn(
-                    "Falha ao serializar payload de log da etapa Oferta. jobId={}",
+            org.slf4j.LoggerFactory.getLogger(HypothesisProofBackendClient.class).warn(
+                    "Falha ao serializar payload de log da etapa Prova. jobId={}",
                     idJob,
                     error);
         }

--- a/ai-worker/src/main/java/com/marketinghub/worker/pipeline/hypothesisproof/HypothesisProofExecutionScheduler.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/pipeline/hypothesisproof/HypothesisProofExecutionScheduler.java
@@ -1,0 +1,35 @@
+package com.marketinghub.worker.pipeline.hypothesisproof;
+
+import com.marketinghub.worker.pipeline.PipelineWorker;
+import com.marketinghub.worker.pipeline.ProcessingSummary;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Scheduled;
+
+/** Responsabilidade: agendar o processamento periódico dos jobs pendentes da etapa Prova. */
+public class HypothesisProofExecutionScheduler {
+    private static final Logger log = LoggerFactory.getLogger(HypothesisProofExecutionScheduler.class);
+    private final PipelineWorker<HypothesisProofInput, HypothesisProofOutput> worker;
+    private final HypothesisProofWorkerProperties properties;
+
+    /** Recebe o worker e as propriedades usadas pelo ciclo agendado da etapa Prova. */
+    public HypothesisProofExecutionScheduler(
+            PipelineWorker<HypothesisProofInput, HypothesisProofOutput> worker,
+            HypothesisProofWorkerProperties properties) {
+        this.worker = worker;
+        this.properties = properties;
+    }
+
+    /** Executa a cada um minuto o ciclo de processamento dos jobs pendentes da etapa Prova. */
+    @Scheduled(cron = "0 */1 * * * *")
+    public void run() {
+        ProcessingSummary summary = worker.processPending(properties.pendingLimit());
+        if (summary.total() > 0) {
+            log.info(
+                    "Hypothesis proof worker processed pending jobs. total={} success={} failure={}",
+                    summary.total(),
+                    summary.succeeded(),
+                    summary.failed());
+        }
+    }
+}

--- a/ai-worker/src/main/java/com/marketinghub/worker/pipeline/hypothesisproof/HypothesisProofInput.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/pipeline/hypothesisproof/HypothesisProofInput.java
@@ -1,0 +1,16 @@
+package com.marketinghub.worker.pipeline.hypothesisproof;
+
+import java.util.Map;
+
+/** Responsabilidade: transportar o payload de entrada da etapa Prova do pipeline de hipótese. */
+public record HypothesisProofInput(
+        Long marketNicheId,
+        String stageCode,
+        String idJob,
+        Map<String, Object> promptData
+) {
+    /** Normaliza os dados de prompt para evitar mapas nulos durante o processamento da etapa. */
+    public HypothesisProofInput {
+        promptData = promptData == null ? Map.of() : Map.copyOf(promptData);
+    }
+}

--- a/ai-worker/src/main/java/com/marketinghub/worker/pipeline/hypothesisproof/HypothesisProofOutput.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/pipeline/hypothesisproof/HypothesisProofOutput.java
@@ -1,0 +1,21 @@
+package com.marketinghub.worker.pipeline.hypothesisproof;
+
+import java.util.List;
+
+/** Responsabilidade: representar a saída estruturada da etapa Prova validada pelo schema da OpenAI. */
+public record HypothesisProofOutput(
+        String proofType,
+        String proofAsset,
+        String proofMessage,
+        List<String> evidenceSignals,
+        String collectionMethod,
+        String credibilityRationale,
+        String objectionReduced,
+        String boundaryConditions,
+        String summary
+) {
+    /** Normaliza listas opcionais para evitar nulos no payload final da etapa. */
+    public HypothesisProofOutput {
+        evidenceSignals = evidenceSignals == null ? List.of() : List.copyOf(evidenceSignals);
+    }
+}

--- a/ai-worker/src/main/java/com/marketinghub/worker/pipeline/hypothesisproof/HypothesisProofProcessor.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/pipeline/hypothesisproof/HypothesisProofProcessor.java
@@ -1,0 +1,155 @@
+package com.marketinghub.worker.pipeline.hypothesisproof;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marketinghub.worker.openai.core.exception.StageWorkerException;
+import com.marketinghub.worker.openai.core.model.OpenAiDispatch;
+import com.marketinghub.worker.openai.core.model.OpenAiRequest;
+import com.marketinghub.worker.openai.core.model.OpenAiResult;
+import com.marketinghub.worker.openai.core.port.OpenAiClientPort;
+import com.marketinghub.worker.openai.core.prompt.PromptTemplateResolver;
+import com.marketinghub.worker.pipeline.StageArtifact;
+import com.marketinghub.worker.pipeline.StageContext;
+import com.marketinghub.worker.pipeline.StageProcessor;
+import com.marketinghub.worker.pipeline.StageResult;
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.core.io.ClassPathResource;
+
+/** Responsabilidade: construir a prova do nicho usando uma etapa OpenAI isolada no pipeline genérico. */
+public class HypothesisProofProcessor implements StageProcessor<HypothesisProofInput, HypothesisProofOutput> {
+    private static final Logger log = LoggerFactory.getLogger(HypothesisProofProcessor.class);
+    private final ObjectMapper objectMapper;
+    private final HypothesisProofWorkerProperties properties;
+    private final OpenAiClientPort openAiClient;
+    private final HypothesisProofResponseValidator responseValidator;
+    private final HypothesisProofBackendClient backendClient;
+    private final PromptTemplateResolver promptTemplateResolver;
+
+    /** Inicializa o processor com dependências específicas da etapa Prova. */
+    public HypothesisProofProcessor(
+            ObjectMapper objectMapper,
+            HypothesisProofWorkerProperties properties,
+            OpenAiClientPort openAiClient,
+            HypothesisProofResponseValidator responseValidator,
+            HypothesisProofBackendClient backendClient) {
+        this.objectMapper = objectMapper;
+        this.properties = properties;
+        this.openAiClient = openAiClient;
+        this.responseValidator = responseValidator;
+        this.backendClient = backendClient;
+        this.promptTemplateResolver = new PromptTemplateResolver(this::loadResource, this::toJsonOrText);
+    }
+
+    /** Processa a etapa criando prompt, enviando para OpenAI, validando JSON e registrando artefatos. */
+    @Override
+    public StageResult<HypothesisProofOutput> process(StageContext<HypothesisProofInput> context) {
+        OpenAiRequest request = buildOpenAiRequest(context);
+        backendClient.saveOpenAiRequest(context.execution(), request);
+        log.info("Enviando request cru para OpenAI na etapa Prova. jobId={} requestBodyJson={}", context.execution().idJob(), request.requestBodyJson());
+        OpenAiDispatch dispatch = openAiClient.dispatch(request);
+        OpenAiResult<String> rawResult = openAiClient.awaitResult(dispatch);
+        log.info("Resposta crua da OpenAI recebida na etapa Prova. jobId={} rawResponse={}", context.execution().idJob(), rawResult.rawResponse());
+        HypothesisProofOutput output = responseValidator.validateAndParse(rawResult.modelResponse());
+        StageArtifact requestArtifact = context.artifactStore().save(
+                "OPENAI_REQUEST",
+                "hypothesis-proof-request.json",
+                "application/json",
+                request.requestBodyJson(),
+                Map.of("idJob", context.execution().idJob(), "stageCode", context.execution().stageCode()));
+        StageArtifact responseArtifact = context.artifactStore().save(
+                "OPENAI_RESPONSE",
+                "hypothesis-proof-response.json",
+                "application/json",
+                rawResult.rawResponse(),
+                Map.of("idJob", context.execution().idJob(), "stageCode", context.execution().stageCode()));
+        StageArtifact outputArtifact = context.artifactStore().save(
+                "NORMALIZED_JSON",
+                "hypothesis-proof-output.json",
+                "application/json",
+                rawResult.modelResponse(),
+                Map.of("idJob", context.execution().idJob(), "stageCode", context.execution().stageCode()));
+        return new StageResult<>(
+                output,
+                List.of(requestArtifact, responseArtifact, outputArtifact),
+                Map.of(
+                        "openAiResult", rawResult,
+                        "openAiJobId", rawResult.openAiJobId() == null ? "" : rawResult.openAiJobId(),
+                        "inputTokens", rawResult.inputTokens() == null ? 0 : rawResult.inputTokens(),
+                        "outputTokens", rawResult.outputTokens() == null ? 0 : rawResult.outputTokens()));
+    }
+
+    /** Monta o request completo da OpenAI mantendo prompt markdown, schema e metadados de auditoria. */
+    private OpenAiRequest buildOpenAiRequest(StageContext<HypothesisProofInput> context) {
+        Map<String, Object> data = context.input().promptData();
+        String promptResource = properties.promptResource();
+        String promptMarkdownContent = loadResource(promptResource);
+        String prompt = promptTemplateResolver.resolve(promptMarkdownContent, data, promptResource);
+        String schemaJson = loadResource(properties.schemaResource());
+        String requestBodyJson = buildResponsesApiRequest(prompt, schemaJson);
+        return new OpenAiRequest(
+                properties.model(),
+                prompt,
+                requestBodyJson,
+                properties.schemaName(),
+                schemaJson,
+                promptMarkdownContent,
+                Map.of(
+                        "stageCode", context.execution().stageCode(),
+                        "idJob", context.execution().idJob(),
+                        "marketNicheId", context.execution().aggregateId()));
+    }
+
+    /** Serializa o corpo compatível com Responses API usando schema JSON estrito. */
+    private String buildResponsesApiRequest(String prompt, String schemaJson) {
+        try {
+            Object schema = objectMapper.readValue(schemaJson, Object.class);
+            Map<String, Object> format = new LinkedHashMap<>();
+            format.put("type", "json_schema");
+            format.put("name", properties.schemaName());
+            format.put("schema", schema);
+            format.put("strict", true);
+            Map<String, Object> text = new LinkedHashMap<>();
+            text.put("format", format);
+            Map<String, Object> body = new LinkedHashMap<>();
+            body.put("model", properties.model());
+            body.put("input", prompt);
+            body.put("text", text);
+            return objectMapper.writeValueAsString(body);
+        } catch (JsonProcessingException ex) {
+            log.error("Could not build OpenAI Responses API request for hypothesis proof. schemaName={}", properties.schemaName(), ex);
+            throw new StageWorkerException("Could not build OpenAI Responses API request for hypothesis proof", ex);
+        }
+    }
+
+    /** Converte valores de placeholder para texto ou JSON formatado antes da substituição. */
+    private String toJsonOrText(Object value) {
+        if (value == null) {
+            return "";
+        }
+        if (value instanceof String text) {
+            return text;
+        }
+        try {
+            return objectMapper.writerWithDefaultPrettyPrinter().writeValueAsString(value);
+        } catch (JsonProcessingException ex) {
+            log.warn("Could not serialize hypothesis proof prompt value; using toString fallback. valueType={}", value.getClass().getName(), ex);
+            return value.toString();
+        }
+    }
+
+    /** Lê recursos do classpath usados como prompt markdown ou schema da etapa. */
+    private String loadResource(String path) {
+        try {
+            return new ClassPathResource(path).getContentAsString(StandardCharsets.UTF_8);
+        } catch (IOException ex) {
+            log.error("Could not load resource for hypothesis proof. path={}", path, ex);
+            throw new StageWorkerException("Could not load resource " + path, ex);
+        }
+    }
+}

--- a/ai-worker/src/main/java/com/marketinghub/worker/pipeline/hypothesisproof/HypothesisProofResponseValidator.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/pipeline/hypothesisproof/HypothesisProofResponseValidator.java
@@ -1,0 +1,47 @@
+package com.marketinghub.worker.pipeline.hypothesisproof;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marketinghub.worker.openai.core.exception.StageWorkerException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Responsabilidade: validar e converter a resposta JSON da OpenAI para a etapa Prova. */
+public class HypothesisProofResponseValidator {
+    private static final Logger log = LoggerFactory.getLogger(HypothesisProofResponseValidator.class);
+    private final ObjectMapper objectMapper;
+
+    /** Inicializa o validador com o ObjectMapper usado para conversão JSON. */
+    public HypothesisProofResponseValidator(ObjectMapper objectMapper) {
+        this.objectMapper = objectMapper;
+    }
+
+    /** Valida campos essenciais da prova e retorna o objeto normalizado da etapa. */
+    public HypothesisProofOutput validateAndParse(String modelResponse) {
+        try {
+            HypothesisProofOutput output = objectMapper.readValue(modelResponse, HypothesisProofOutput.class);
+            requireText(output.proofType(), "proofType");
+            requireText(output.proofAsset(), "proofAsset");
+            requireText(output.proofMessage(), "proofMessage");
+            requireText(output.summary(), "summary");
+            requireNonEmpty(output.evidenceSignals(), "evidenceSignals");
+            return output;
+        } catch (Exception ex) {
+            log.error("Resposta inválida recebida da OpenAI na etapa Prova", ex);
+            throw new StageWorkerException("Resposta inválida da etapa Prova", ex);
+        }
+    }
+
+    /** Garante que um campo textual obrigatório veio preenchido. */
+    private void requireText(String value, String field) {
+        if (value == null || value.isBlank()) {
+            throw new StageWorkerException("Campo obrigatório ausente na etapa Prova: " + field);
+        }
+    }
+
+    /** Garante que uma lista obrigatória veio preenchida. */
+    private void requireNonEmpty(java.util.List<String> value, String field) {
+        if (value == null || value.isEmpty()) {
+            throw new StageWorkerException("Lista obrigatória ausente na etapa Prova: " + field);
+        }
+    }
+}

--- a/ai-worker/src/main/java/com/marketinghub/worker/pipeline/hypothesisproof/HypothesisProofWorkerConfiguration.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/pipeline/hypothesisproof/HypothesisProofWorkerConfiguration.java
@@ -1,0 +1,81 @@
+package com.marketinghub.worker.pipeline.hypothesisproof;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marketinghub.worker.openai.core.openai.OpenAiClientProperties;
+import com.marketinghub.worker.openai.core.openai.ResponsesApiOpenAiClient;
+import com.marketinghub.worker.openai.core.port.OpenAiClientPort;
+import com.marketinghub.worker.pipeline.ArtifactStore;
+import com.marketinghub.worker.pipeline.InMemoryArtifactStore;
+import com.marketinghub.worker.pipeline.PipelineWorker;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
+
+/** Responsabilidade: declarar os beans Spring necessários para executar a etapa Prova no pipeline genérico. */
+@Configuration
+@EnableConfigurationProperties({HypothesisProofWorkerProperties.class, OpenAiClientProperties.class})
+@ConditionalOnProperty(prefix = "hypothesis-proof.worker", name = "enabled", havingValue = "true", matchIfMissing = false)
+public class HypothesisProofWorkerConfiguration {
+    /** Cria o adapter HTTP da etapa Prova para consultar e atualizar execuções no backend. */
+    @Bean
+    public HypothesisProofBackendClient hypothesisProofBackendClient(
+            WebClient.Builder webClientBuilder,
+            HypothesisProofWorkerProperties properties,
+            ObjectMapper objectMapper) {
+        return new HypothesisProofBackendClient(webClientBuilder, properties, objectMapper);
+    }
+
+    /** Cria o validador da resposta JSON retornada pela OpenAI para a etapa Prova. */
+    @Bean
+    public HypothesisProofResponseValidator hypothesisProofResponseValidator(ObjectMapper objectMapper) {
+        return new HypothesisProofResponseValidator(objectMapper);
+    }
+
+    /** Cria o cliente OpenAI compartilhado quando nenhuma outra etapa já o registrou. */
+    @Bean
+    @ConditionalOnMissingBean(OpenAiClientPort.class)
+    public OpenAiClientPort hypothesisProofOpenAiClientPort(
+            WebClient.Builder webClientBuilder,
+            ObjectMapper objectMapper,
+            OpenAiClientProperties properties) {
+        return new ResponsesApiOpenAiClient(webClientBuilder, objectMapper, properties);
+    }
+
+    /** Cria o ArtifactStore genérico usado para referenciar request, response e JSON normalizado da etapa. */
+    @Bean
+    @ConditionalOnMissingBean(ArtifactStore.class)
+    public ArtifactStore artifactStore() {
+        return new InMemoryArtifactStore();
+    }
+
+    /** Cria o processor específico responsável por construir a prova via OpenAI. */
+    @Bean
+    public HypothesisProofProcessor hypothesisProofProcessor(
+            ObjectMapper objectMapper,
+            HypothesisProofWorkerProperties properties,
+            OpenAiClientPort openAiClient,
+            HypothesisProofResponseValidator responseValidator,
+            HypothesisProofBackendClient backendClient) {
+        return new HypothesisProofProcessor(objectMapper, properties, openAiClient, responseValidator, backendClient);
+    }
+
+    /** Compõe o worker genérico com o port e processor específicos da etapa Prova. */
+    @Bean
+    public PipelineWorker<HypothesisProofInput, HypothesisProofOutput> hypothesisProofPipelineWorker(
+            HypothesisProofBackendClient backendClient,
+            HypothesisProofProcessor processor,
+            ArtifactStore artifactStore) {
+        return new PipelineWorker<>(backendClient, processor, artifactStore);
+    }
+
+    /** Cria o agendador periódico que aciona o worker da etapa Prova. */
+    @Bean
+    public HypothesisProofExecutionScheduler hypothesisProofExecutionScheduler(
+            PipelineWorker<HypothesisProofInput, HypothesisProofOutput> worker,
+            HypothesisProofWorkerProperties properties) {
+        return new HypothesisProofExecutionScheduler(worker, properties);
+    }
+}

--- a/ai-worker/src/main/java/com/marketinghub/worker/pipeline/hypothesisproof/HypothesisProofWorkerProperties.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/pipeline/hypothesisproof/HypothesisProofWorkerProperties.java
@@ -1,0 +1,36 @@
+package com.marketinghub.worker.pipeline.hypothesisproof;
+
+import jakarta.validation.constraints.Min;
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import java.time.Duration;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.validation.annotation.Validated;
+
+/** Responsabilidade: concentrar as propriedades operacionais da etapa Prova do pipeline de hipótese. */
+@Validated
+@ConfigurationProperties(prefix = "hypothesis-proof.worker")
+public record HypothesisProofWorkerProperties(
+        boolean enabled,
+        @Min(1) int pendingLimit,
+        @NotBlank String backendBaseUrl,
+        String apiPrefix,
+        @NotBlank String promptResource,
+        @NotBlank String schemaResource,
+        @NotBlank String schemaName,
+        @NotBlank String model,
+        @NotNull Duration timeout
+) {
+    /** Normaliza valores opcionais usados pelo worker quando a configuração externa omite o campo. */
+    public HypothesisProofWorkerProperties {
+        if (apiPrefix == null || apiPrefix.isBlank()) {
+            apiPrefix = "/api";
+        }
+        if (model == null || model.isBlank()) {
+            model = "gpt-5.5";
+        }
+        if (timeout == null) {
+            timeout = Duration.ofMinutes(30);
+        }
+    }
+}

--- a/ai-worker/src/main/resources/application.properties
+++ b/ai-worker/src/main/resources/application.properties
@@ -165,6 +165,16 @@ hypothesis-mechanism.worker.schema-name=${HYPOTHESIS_MECHANISM_WORKER_SCHEMA_NAM
 hypothesis-mechanism.worker.model=${HYPOTHESIS_MECHANISM_WORKER_MODEL:gpt-5.5}
 hypothesis-mechanism.worker.timeout=${HYPOTHESIS_MECHANISM_WORKER_TIMEOUT:PT30M}
 
+hypothesis-proof.worker.enabled=${HYPOTHESIS_PROOF_WORKER_ENABLED:true}
+hypothesis-proof.worker.pending-limit=${HYPOTHESIS_PROOF_WORKER_PENDING_LIMIT:5}
+hypothesis-proof.worker.backend-base-url=${HYPOTHESIS_PROOF_WORKER_BACKEND_BASE_URL:${backend.base-url}}
+hypothesis-proof.worker.api-prefix=${HYPOTHESIS_PROOF_WORKER_API_PREFIX:${backend.api-prefix}}
+hypothesis-proof.worker.prompt-resource=${HYPOTHESIS_PROOF_WORKER_PROMPT_RESOURCE:prompts/hypothesis-pipeline/hypothesis-proof.md}
+hypothesis-proof.worker.schema-resource=${HYPOTHESIS_PROOF_WORKER_SCHEMA_RESOURCE:prompts/hypothesis-pipeline/hypothesis-proof-schema.json}
+hypothesis-proof.worker.schema-name=${HYPOTHESIS_PROOF_WORKER_SCHEMA_NAME:hypothesis_pipeline_proof}
+hypothesis-proof.worker.model=${HYPOTHESIS_PROOF_WORKER_MODEL:gpt-5.5}
+hypothesis-proof.worker.timeout=${HYPOTHESIS_PROOF_WORKER_TIMEOUT:PT30M}
+
 hypothesis-offer.worker.enabled=${HYPOTHESIS_OFFER_WORKER_ENABLED:true}
 hypothesis-offer.worker.pending-limit=${HYPOTHESIS_OFFER_WORKER_PENDING_LIMIT:5}
 hypothesis-offer.worker.backend-base-url=${HYPOTHESIS_OFFER_WORKER_BACKEND_BASE_URL:${backend.base-url}}

--- a/ai-worker/src/main/resources/prompts/hypothesis-pipeline/hypothesis-offer.md
+++ b/ai-worker/src/main/resources/prompts/hypothesis-pipeline/hypothesis-offer.md
@@ -2,11 +2,11 @@
 
 template_id: hypothesis-offer
 
-Objetivo: transformar Dor, Resultado e Mecanismo concluídos em uma oferta digital simples, plausível e vendável para o nicho.
+Objetivo: transformar Dor, Resultado, Mecanismo e Prova concluídos em uma oferta digital simples, plausível e vendável para o nicho.
 
 Regras obrigatórias:
 - Responda SOMENTE no JSON do schema.
-- Use a dor, o resultado e o mecanismo concluídos como base principal; não invente uma nova dor, promessa ou mecanismo.
+- Use a dor, o resultado, o mecanismo e a prova concluídos como base principal; não invente uma nova dor, promessa, mecanismo ou evidência.
 - A oferta precisa deixar claro o que o cliente recebe, por que isso reduz esforço e como aproxima o resultado desejado.
 - A oferta deve ser compatível com produto digital apoiado por IA e execução prática pelo cliente.
 - Não prometa cura, renda garantida, resultado absoluto, automação total ou dependência de acesso interno ao negócio do cliente.
@@ -20,5 +20,5 @@ Critérios de qualidade:
 - Inclua limites de plausibilidade para manter a promessa segura e vendável.
 - Preserve o eixo Dor → Resultado → Mecanismo → Prova → Oferta.
 
-Contexto do nicho, dor concluída, resultado concluído, mecanismo concluído e artefatos disponíveis:
+Contexto do nicho, dor concluída, resultado concluído, mecanismo concluído, prova concluída e artefatos disponíveis:
 {{CASE_DATA_BLOCK}}

--- a/ai-worker/src/main/resources/prompts/hypothesis-pipeline/hypothesis-proof-schema.json
+++ b/ai-worker/src/main/resources/prompts/hypothesis-pipeline/hypothesis-proof-schema.json
@@ -1,0 +1,31 @@
+{
+  "type": "object",
+  "additionalProperties": false,
+  "required": [
+    "proofType",
+    "proofAsset",
+    "proofMessage",
+    "evidenceSignals",
+    "collectionMethod",
+    "credibilityRationale",
+    "objectionReduced",
+    "boundaryConditions",
+    "summary"
+  ],
+  "properties": {
+    "proofType": { "type": "string", "minLength": 5, "maxLength": 120 },
+    "proofAsset": { "type": "string", "minLength": 10, "maxLength": 200 },
+    "proofMessage": { "type": "string", "minLength": 10 },
+    "evidenceSignals": {
+      "type": "array",
+      "minItems": 2,
+      "maxItems": 5,
+      "items": { "type": "string", "minLength": 5 }
+    },
+    "collectionMethod": { "type": "string", "minLength": 10 },
+    "credibilityRationale": { "type": "string", "minLength": 10 },
+    "objectionReduced": { "type": "string", "minLength": 10 },
+    "boundaryConditions": { "type": "string", "minLength": 10 },
+    "summary": { "type": "string", "minLength": 10, "maxLength": 500 }
+  }
+}

--- a/ai-worker/src/main/resources/prompts/hypothesis-pipeline/hypothesis-proof.md
+++ b/ai-worker/src/main/resources/prompts/hypothesis-pipeline/hypothesis-proof.md
@@ -1,0 +1,22 @@
+# Etapa: hypothesis-proof
+
+template_id: hypothesis-proof
+
+Objetivo: transformar Dor, Resultado e Mecanismo concluídos em uma prova simples, crível e aplicável antes de empacotar a oferta.
+
+Regras obrigatórias:
+- Responda SOMENTE no JSON do schema.
+- Use a dor, o resultado e o mecanismo concluídos como base principal; não invente uma nova dor, promessa ou mecanismo.
+- A prova deve reduzir ceticismo e mostrar por que o mecanismo é plausível para o nicho.
+- A prova precisa ser viável para produto digital apoiado por IA: diagnóstico, checklist, amostra, simulação, mini-plano, antes/depois demonstrável ou evidência operacional.
+- Não prometa cura, renda garantida, resultado absoluto, automação total ou dependência de acesso interno ao negócio do cliente.
+- Não crie preço, checkout, campanha de anúncios ou página de vendas nesta etapa.
+- Não use markdown dentro dos campos.
+
+Critérios de qualidade:
+- A prova deve ser específica, fácil de produzir e conectada à rotina real do nicho.
+- Explique qual objeção a prova reduz e como ela será coletada ou demonstrada.
+- Preserve o eixo Dor → Resultado → Mecanismo → Prova → Oferta.
+
+Contexto do nicho, dor concluída, resultado concluído e mecanismo concluído:
+{{CASE_DATA_BLOCK}}

--- a/ai-worker/src/test/java/com/marketinghub/worker/pipeline/hypothesisproof/HypothesisProofBackendClientTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/pipeline/hypothesisproof/HypothesisProofBackendClientTest.java
@@ -1,4 +1,4 @@
-package com.marketinghub.worker.pipeline.hypothesisoffer;
+package com.marketinghub.worker.pipeline.hypothesisproof;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -9,13 +9,13 @@ import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.springframework.web.reactive.function.client.WebClient;
 
-/** Responsabilidade: validar a montagem do contexto de prompt da etapa Oferta da hipótese. */
-class HypothesisOfferBackendClientTest {
+/** Responsabilidade: validar a montagem do contexto de prompt da etapa Prova da hipótese. */
+class HypothesisProofBackendClientTest {
 
-    /** Garante que o contexto da etapa Oferta carregue Dor, Resultado, Mecanismo e Prova concluídos. */
+    /** Garante que o contexto da etapa Prova carregue Dor, Resultado e Mecanismo concluídos. */
     @Test
-    void shouldIncludePainResultMechanismAndProofResponsesInPromptData() {
-        HypothesisOfferBackendClient client = newClient();
+    void shouldIncludePainResultAndMechanismResponsesInPromptData() {
+        HypothesisProofBackendClient client = newClient();
         Map<String, Object> niche = new LinkedHashMap<>();
         niche.put("name", "Cabeleireiros, manicure e pedicure");
         niche.put("description", "Rotina com agenda, atendimento e retrabalho.");
@@ -25,33 +25,30 @@ class HypothesisOfferBackendClientTest {
         pending.put("painModelResponse", "Dor: perda de agenda por falhas operacionais.");
         pending.put("resultModelResponse", "Resultado: agenda previsível com menos retrabalho.");
         pending.put("mechanismModelResponse", "Mecanismo: agenda guiada por IA com checklists simples.");
-        pending.put("proofModelResponse", "Prova: mini diagnóstico demonstrando gargalos da agenda.");
 
         Map<String, Object> promptData = client.buildPromptDataFromPending(pending);
 
         assertThat(promptData).containsEntry("painModelResponse", "Dor: perda de agenda por falhas operacionais.");
         assertThat(promptData).containsEntry("resultModelResponse", "Resultado: agenda previsível com menos retrabalho.");
         assertThat(promptData).containsEntry("mechanismModelResponse", "Mecanismo: agenda guiada por IA com checklists simples.");
-        assertThat(promptData).containsEntry("proofModelResponse", "Prova: mini diagnóstico demonstrando gargalos da agenda.");
         assertThat(promptData.get("CASE_DATA_BLOCK")).asString()
                 .contains("painModelResponse: Dor: perda de agenda por falhas operacionais.")
                 .contains("resultModelResponse: Resultado: agenda previsível com menos retrabalho.")
-                .contains("mechanismModelResponse: Mecanismo: agenda guiada por IA com checklists simples.")
-                .contains("proofModelResponse: Prova: mini diagnóstico demonstrando gargalos da agenda.");
+                .contains("mechanismModelResponse: Mecanismo: agenda guiada por IA com checklists simples.");
     }
 
     /** Cria o cliente de backend apenas com dependências necessárias para montagem local do contexto. */
-    private HypothesisOfferBackendClient newClient() {
-        HypothesisOfferWorkerProperties properties = new HypothesisOfferWorkerProperties(
+    private HypothesisProofBackendClient newClient() {
+        HypothesisProofWorkerProperties properties = new HypothesisProofWorkerProperties(
                 true,
                 5,
                 "http://backend",
                 "/api",
-                "prompts/hypothesis-pipeline/hypothesis-offer.md",
-                "prompts/hypothesis-pipeline/hypothesis-offer-schema.json",
-                "hypothesis_pipeline_offer",
+                "prompts/hypothesis-pipeline/hypothesis-proof.md",
+                "prompts/hypothesis-pipeline/hypothesis-proof-schema.json",
+                "hypothesis_pipeline_proof",
                 "gpt-5.5",
                 Duration.ofMinutes(30));
-        return new HypothesisOfferBackendClient(WebClient.builder(), properties, new ObjectMapper());
+        return new HypothesisProofBackendClient(WebClient.builder(), properties, new ObjectMapper());
     }
 }

--- a/ai-worker/src/test/java/com/marketinghub/worker/pipeline/hypothesisproof/HypothesisProofResponseValidatorTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/pipeline/hypothesisproof/HypothesisProofResponseValidatorTest.java
@@ -1,0 +1,58 @@
+package com.marketinghub.worker.pipeline.hypothesisproof;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marketinghub.worker.openai.core.exception.StageWorkerException;
+import org.junit.jupiter.api.Test;
+
+/** Responsabilidade: validar a resposta estruturada da etapa Prova da hipótese. */
+class HypothesisProofResponseValidatorTest {
+    private final HypothesisProofResponseValidator validator = new HypothesisProofResponseValidator(new ObjectMapper());
+
+    /** Deve aceitar JSON válido com os campos essenciais da etapa Prova. */
+    @Test
+    void shouldParseValidProofResponse() {
+        String json = """
+                {
+                  "proofType":"Mini diagnóstico operacional",
+                  "proofAsset":"Checklist de gargalos da agenda",
+                  "proofMessage":"Mostra onde a rotina perde tempo antes da compra.",
+                  "evidenceSignals":["gargalo identificado", "tempo recuperável"],
+                  "collectionMethod":"Aplicar perguntas simples sobre agenda e retrabalho.",
+                  "credibilityRationale":"A prova usa dados da própria rotina do cliente.",
+                  "objectionReduced":"Reduz a dúvida de que o método serve para a rotina real.",
+                  "boundaryConditions":"Não promete agenda cheia nem resultado automático.",
+                  "summary":"Prova prática para tangibilizar o mecanismo antes da oferta."
+                }
+                """;
+
+        HypothesisProofOutput output = validator.validateAndParse(json);
+
+        assertThat(output.proofType()).isEqualTo("Mini diagnóstico operacional");
+        assertThat(output.evidenceSignals()).contains("gargalo identificado");
+    }
+
+    /** Deve rejeitar JSON sem campos obrigatórios para evitar prova fraca ou vazia. */
+    @Test
+    void shouldRejectMissingProofMessage() {
+        String json = """
+                {
+                  "proofType":"Mini diagnóstico operacional",
+                  "proofAsset":"Checklist de gargalos da agenda",
+                  "proofMessage":"",
+                  "evidenceSignals":["gargalo identificado"],
+                  "collectionMethod":"Aplicar perguntas simples.",
+                  "credibilityRationale":"Usa dados da rotina.",
+                  "objectionReduced":"Reduz dúvida.",
+                  "boundaryConditions":"Sem promessa absoluta.",
+                  "summary":"Prova prática."
+                }
+                """;
+
+        assertThatThrownBy(() -> validator.validateAndParse(json))
+                .isInstanceOf(StageWorkerException.class)
+                .hasMessageContaining("Resposta inválida da etapa Prova");
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/hypothesis/pain/controller/HypothesisPainStageController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/hypothesis/pain/controller/HypothesisPainStageController.java
@@ -51,6 +51,12 @@ public class HypothesisPainStageController {
         return ResponseEntity.accepted().body(service.startMechanism(nicheId));
     }
 
+    /** Registra uma execução inicial da etapa Prova para um nicho. */
+    @PostMapping("/niches/{nicheId}/hypothesis-pipeline/proof/start")
+    public ResponseEntity<HypothesisPainStartResponse> startProof(@PathVariable Long nicheId) {
+        return ResponseEntity.accepted().body(service.startProof(nicheId));
+    }
+
     /** Registra uma execução inicial da etapa Oferta para um nicho. */
     @PostMapping("/niches/{nicheId}/hypothesis-pipeline/offer/start")
     public ResponseEntity<HypothesisPainStartResponse> startOffer(@PathVariable Long nicheId) {
@@ -79,6 +85,14 @@ public class HypothesisPainStageController {
             @PathVariable Long nicheId,
             @RequestParam(defaultValue = "true") boolean includeCompleted) {
         return ResponseEntity.ok(service.listMechanismStageExecutions(nicheId, includeCompleted));
+    }
+
+    /** Lista execuções da etapa Prova para acompanhamento na tela de nova hipótese. */
+    @GetMapping("/niches/{nicheId}/hypothesis-pipeline/proof/stage-executions")
+    public ResponseEntity<List<HypothesisPainExecutionSummaryResponse>> listProofStageExecutions(
+            @PathVariable Long nicheId,
+            @RequestParam(defaultValue = "true") boolean includeCompleted) {
+        return ResponseEntity.ok(service.listProofStageExecutions(nicheId, includeCompleted));
     }
 
     /** Lista execuções da etapa Oferta para acompanhamento na tela de nova hipótese. */
@@ -119,6 +133,14 @@ public class HypothesisPainStageController {
         return ResponseEntity.ok(service.detailForNiche(nicheId, idJob));
     }
 
+    /** Consulta detalhe auditável de uma execução da etapa Prova vinculada ao nicho. */
+    @GetMapping("/niches/{nicheId}/hypothesis-pipeline/proof/stage-executions/{idJob}")
+    public ResponseEntity<HypothesisPainExecutionDetailResponse> detailProofForNiche(
+            @PathVariable Long nicheId,
+            @PathVariable String idJob) {
+        return ResponseEntity.ok(service.detailForNiche(nicheId, idJob));
+    }
+
     /** Consulta detalhe auditável de uma execução da etapa Oferta vinculada ao nicho. */
     @GetMapping("/niches/{nicheId}/hypothesis-pipeline/offer/stage-executions/{idJob}")
     public ResponseEntity<HypothesisPainExecutionDetailResponse> detailOfferForNiche(
@@ -151,6 +173,12 @@ public class HypothesisPainStageController {
         return service.listMechanismPending();
     }
 
+    /** Lista jobs pendentes da etapa Prova para processamento pelo Worker AI. */
+    @GetMapping("/internal/hypothesis-pipeline/proof/stage-executions/pending")
+    public List<HypothesisPainPendingExecution> proofPending() {
+        return service.listProofPending();
+    }
+
     /** Lista jobs pendentes da etapa Oferta para processamento pelo Worker AI. */
     @GetMapping("/internal/hypothesis-pipeline/offer/stage-executions/pending")
     public List<HypothesisPainPendingExecution> offerPending() {
@@ -162,6 +190,7 @@ public class HypothesisPainStageController {
             "/internal/hypothesis-pipeline/pain/stage-executions/{idJob}/running",
             "/internal/hypothesis-pipeline/result/stage-executions/{idJob}/running",
             "/internal/hypothesis-pipeline/mechanism/stage-executions/{idJob}/running",
+            "/internal/hypothesis-pipeline/proof/stage-executions/{idJob}/running",
             "/internal/hypothesis-pipeline/offer/stage-executions/{idJob}/running"
     })
     public ResponseEntity<Void> running(@PathVariable String idJob) {
@@ -174,6 +203,7 @@ public class HypothesisPainStageController {
             "/internal/hypothesis-pipeline/pain/stage-executions/{idJob}/recebe-prompt",
             "/internal/hypothesis-pipeline/result/stage-executions/{idJob}/recebe-prompt",
             "/internal/hypothesis-pipeline/mechanism/stage-executions/{idJob}/recebe-prompt",
+            "/internal/hypothesis-pipeline/proof/stage-executions/{idJob}/recebe-prompt",
             "/internal/hypothesis-pipeline/offer/stage-executions/{idJob}/recebe-prompt"
     })
     public ResponseEntity<Void> recebePrompt(
@@ -203,6 +233,7 @@ public class HypothesisPainStageController {
             "/internal/hypothesis-pipeline/pain/stage-executions/{idJob}/recebe-resposta",
             "/internal/hypothesis-pipeline/result/stage-executions/{idJob}/recebe-resposta",
             "/internal/hypothesis-pipeline/mechanism/stage-executions/{idJob}/recebe-resposta",
+            "/internal/hypothesis-pipeline/proof/stage-executions/{idJob}/recebe-resposta",
             "/internal/hypothesis-pipeline/offer/stage-executions/{idJob}/recebe-resposta"
     })
     public ResponseEntity<Void> recebeResposta(

--- a/backend/ads-service/src/main/java/com/marketinghub/hypothesis/pain/service/HypothesisPainStageService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/hypothesis/pain/service/HypothesisPainStageService.java
@@ -31,6 +31,7 @@ public class HypothesisPainStageService {
     private static final String STAGE_CODE = "hypothesis-pain";
     private static final String RESULT_STAGE_CODE = "hypothesis-result";
     private static final String MECHANISM_STAGE_CODE = "hypothesis-mechanism";
+    private static final String PROOF_STAGE_CODE = "hypothesis-proof";
     private static final String OFFER_STAGE_CODE = "hypothesis-offer";
     private static final String STATUS_STARTED = "INICIADO";
     private static final String STATUS_WAITING_OPENAI_DISPATCH = "AGUARDANDO_RETORNO_OPENAI";
@@ -55,25 +56,31 @@ public class HypothesisPainStageService {
     /** Inicia uma nova execução manual da etapa Dor para o nicho informado. */
     @Transactional
     public HypothesisPainStartResponse start(Long marketNicheId) {
-        return startStage(marketNicheId, STAGE_CODE, "Dor", false, false, false);
+        return startStage(marketNicheId, STAGE_CODE, "Dor", false, false, false, false);
     }
 
     /** Inicia uma nova execução manual da etapa Resultado para o nicho informado. */
     @Transactional
     public HypothesisPainStartResponse startResult(Long marketNicheId) {
-        return startStage(marketNicheId, RESULT_STAGE_CODE, "Resultado", true, false, false);
+        return startStage(marketNicheId, RESULT_STAGE_CODE, "Resultado", true, false, false, false);
     }
 
     /** Inicia uma nova execução manual da etapa Mecanismo para o nicho informado. */
     @Transactional
     public HypothesisPainStartResponse startMechanism(Long marketNicheId) {
-        return startStage(marketNicheId, MECHANISM_STAGE_CODE, "Mecanismo", true, true, false);
+        return startStage(marketNicheId, MECHANISM_STAGE_CODE, "Mecanismo", true, true, false, false);
+    }
+
+    /** Inicia uma nova execução manual da etapa Prova para o nicho informado. */
+    @Transactional
+    public HypothesisPainStartResponse startProof(Long marketNicheId) {
+        return startStage(marketNicheId, PROOF_STAGE_CODE, "Prova", true, true, true, false);
     }
 
     /** Inicia uma nova execução manual da etapa Oferta para o nicho informado. */
     @Transactional
     public HypothesisPainStartResponse startOffer(Long marketNicheId) {
-        return startStage(marketNicheId, OFFER_STAGE_CODE, "Oferta", true, true, true);
+        return startStage(marketNicheId, OFFER_STAGE_CODE, "Oferta", true, true, true, true);
     }
 
     /** Inicia uma nova execução manual de uma etapa do pipeline para o nicho informado. */
@@ -83,7 +90,8 @@ public class HypothesisPainStageService {
             String stageLabel,
             boolean requiresCompletedPain,
             boolean requiresCompletedResult,
-            boolean requiresCompletedMechanism) {
+            boolean requiresCompletedMechanism,
+            boolean requiresCompletedProof) {
         Instant now = Instant.now();
         MarketNiche niche = marketNicheRepository.findById(marketNicheId)
                 .orElseThrow(() -> new EntityNotFoundException("Market niche not found: " + marketNicheId));
@@ -95,6 +103,9 @@ public class HypothesisPainStageService {
         }
         if (requiresCompletedMechanism) {
             requireCompletedMechanism(marketNicheId);
+        }
+        if (requiresCompletedProof) {
+            requireCompletedProof(marketNicheId);
         }
         HypothesisPainStageExecution execution = HypothesisPainStageExecution.builder()
                 .marketNicheId(niche.getId())
@@ -129,6 +140,14 @@ public class HypothesisPainStageService {
             Long marketNicheId,
             boolean includeCompleted) {
         return listStageExecutions(marketNicheId, MECHANISM_STAGE_CODE, includeCompleted);
+    }
+
+    /** Lista execuções da etapa Prova para o nicho informado. */
+    @Transactional(readOnly = true)
+    public List<HypothesisPainExecutionSummaryResponse> listProofStageExecutions(
+            Long marketNicheId,
+            boolean includeCompleted) {
+        return listStageExecutions(marketNicheId, PROOF_STAGE_CODE, includeCompleted);
     }
 
     /** Lista execuções da etapa Oferta para o nicho informado. */
@@ -176,6 +195,7 @@ public class HypothesisPainStageService {
                 toFinalSummary(marketNicheId, "pain", 1, "Dor do nicho", STAGE_CODE),
                 toFinalSummary(marketNicheId, "result", 2, "Resultado desejado", RESULT_STAGE_CODE),
                 toFinalSummary(marketNicheId, "mechanism", 3, "Mecanismo", MECHANISM_STAGE_CODE),
+                toFinalSummary(marketNicheId, "proof", 4, "Prova", PROOF_STAGE_CODE),
                 toFinalSummary(marketNicheId, "offer", 5, "Oferta", OFFER_STAGE_CODE));
     }
 
@@ -232,6 +252,12 @@ public class HypothesisPainStageService {
         return listPendingByStage(MECHANISM_STAGE_CODE);
     }
 
+    /** Lista os jobs iniciados da etapa Prova para processamento pelo Worker AI. */
+    @Transactional(readOnly = true)
+    public List<HypothesisPainPendingExecution> listProofPending() {
+        return listPendingByStage(PROOF_STAGE_CODE);
+    }
+
     /** Lista os jobs iniciados da etapa Oferta para processamento pelo Worker AI. */
     @Transactional(readOnly = true)
     public List<HypothesisPainPendingExecution> listOfferPending() {
@@ -250,7 +276,8 @@ public class HypothesisPainStageService {
                         toPendingNiche(execution.getMarketNiche()),
                         pendingPainResponse(execution),
                         pendingResultResponse(execution),
-                        pendingMechanismResponse(execution)))
+                        pendingMechanismResponse(execution),
+                        pendingProofResponse(execution)))
                 .toList();
     }
 
@@ -258,6 +285,7 @@ public class HypothesisPainStageService {
     private String pendingPainResponse(HypothesisPainStageExecution execution) {
         return RESULT_STAGE_CODE.equals(execution.getStageCode())
                 || MECHANISM_STAGE_CODE.equals(execution.getStageCode())
+                || PROOF_STAGE_CODE.equals(execution.getStageCode())
                 || OFFER_STAGE_CODE.equals(execution.getStageCode())
                 ? latestCompletedPainResponse(execution.getMarketNicheId())
                 : null;
@@ -266,6 +294,7 @@ public class HypothesisPainStageService {
     /** Retorna o Resultado concluído quando a etapa pendente precisa desse contexto. */
     private String pendingResultResponse(HypothesisPainStageExecution execution) {
         return MECHANISM_STAGE_CODE.equals(execution.getStageCode())
+                        || PROOF_STAGE_CODE.equals(execution.getStageCode())
                         || OFFER_STAGE_CODE.equals(execution.getStageCode())
                 ? latestCompletedResultResponse(execution.getMarketNicheId())
                 : null;
@@ -273,8 +302,16 @@ public class HypothesisPainStageService {
 
     /** Retorna o Mecanismo concluído quando a etapa pendente precisa desse contexto. */
     private String pendingMechanismResponse(HypothesisPainStageExecution execution) {
-        return OFFER_STAGE_CODE.equals(execution.getStageCode())
+        return PROOF_STAGE_CODE.equals(execution.getStageCode())
+                || OFFER_STAGE_CODE.equals(execution.getStageCode())
                 ? latestCompletedMechanismResponse(execution.getMarketNicheId())
+                : null;
+    }
+
+    /** Retorna a Prova concluída quando a etapa pendente precisa desse contexto. */
+    private String pendingProofResponse(HypothesisPainStageExecution execution) {
+        return OFFER_STAGE_CODE.equals(execution.getStageCode())
+                ? latestCompletedProofResponse(execution.getMarketNicheId())
                 : null;
     }
 
@@ -302,6 +339,14 @@ public class HypothesisPainStageService {
         }
     }
 
+    /** Garante que a etapa Prova tenha sido concluída com resposta antes de liberar Oferta. */
+    private void requireCompletedProof(Long marketNicheId) {
+        if (!StringUtils.hasText(latestCompletedProofResponse(marketNicheId))) {
+            throw new IllegalStateException(
+                    "A etapa Prova precisa estar concluída antes de iniciar Oferta para o nicho: " + marketNicheId);
+        }
+    }
+
     /** Retorna a resposta da Dor concluída mais recente para contextualizar etapas seguintes. */
     private String latestCompletedPainResponse(Long marketNicheId) {
         return latestCompletedStageResponse(marketNicheId, STAGE_CODE);
@@ -315,6 +360,11 @@ public class HypothesisPainStageService {
     /** Retorna a resposta do Mecanismo concluído mais recente para contextualizar Oferta. */
     private String latestCompletedMechanismResponse(Long marketNicheId) {
         return latestCompletedStageResponse(marketNicheId, MECHANISM_STAGE_CODE);
+    }
+
+    /** Retorna a resposta da Prova concluída mais recente para contextualizar Oferta. */
+    private String latestCompletedProofResponse(Long marketNicheId) {
+        return latestCompletedStageResponse(marketNicheId, PROOF_STAGE_CODE);
     }
 
     /** Retorna a resposta concluída mais recente de uma etapa para contextualizar próximas etapas. */

--- a/backend/ads-service/src/main/java/com/marketinghub/hypothesis/pain/service/pending/HypothesisPainPendingExecution.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/hypothesis/pain/service/pending/HypothesisPainPendingExecution.java
@@ -11,6 +11,7 @@ public record HypothesisPainPendingExecution(
         HypothesisPainPendingNiche niche,
         String painModelResponse,
         String resultModelResponse,
-        String mechanismModelResponse
+        String mechanismModelResponse,
+        String proofModelResponse
 ) {
 }

--- a/backend/ads-service/src/test/java/com/marketinghub/hypothesis/pain/service/HypothesisPainStageServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/hypothesis/pain/service/HypothesisPainStageServiceTest.java
@@ -248,9 +248,55 @@ class HypothesisPainStageServiceTest {
         assertThrows(IllegalStateException.class, () -> service.startOffer(18L));
     }
 
-    /** Deve entregar Dor, Resultado e Mecanismo concluídos para contextualizar a etapa Oferta no Worker AI. */
+
+    /** Deve bloquear a etapa Oferta quando a prova ainda não está concluída. */
     @Test
-    void listOfferPendingIncludesLatestCompletedPainResultAndMechanismResponses() {
+    void startOfferRequiresCompletedProof() {
+        MarketNiche niche = new MarketNiche();
+        niche.setId(18L);
+        when(marketNicheRepository.findById(18L)).thenReturn(Optional.of(niche));
+        when(executionRepository.findTopByMarketNicheIdAndStageCodeAndStatusOrderByExecutionRequestedAtDesc(
+                        18L,
+                        "hypothesis-pain",
+                        "CONCLUIDO"))
+                .thenReturn(Optional.of(HypothesisPainStageExecution.builder()
+                        .marketNicheId(18L)
+                        .stageCode("hypothesis-pain")
+                        .status("CONCLUIDO")
+                        .modelResponse("{\"pain\":\"dor validada\"}")
+                        .build()));
+        when(executionRepository.findTopByMarketNicheIdAndStageCodeAndStatusOrderByExecutionRequestedAtDesc(
+                        18L,
+                        "hypothesis-result",
+                        "CONCLUIDO"))
+                .thenReturn(Optional.of(HypothesisPainStageExecution.builder()
+                        .marketNicheId(18L)
+                        .stageCode("hypothesis-result")
+                        .status("CONCLUIDO")
+                        .modelResponse("{\"result\":\"resultado validado\"}")
+                        .build()));
+        when(executionRepository.findTopByMarketNicheIdAndStageCodeAndStatusOrderByExecutionRequestedAtDesc(
+                        18L,
+                        "hypothesis-mechanism",
+                        "CONCLUIDO"))
+                .thenReturn(Optional.of(HypothesisPainStageExecution.builder()
+                        .marketNicheId(18L)
+                        .stageCode("hypothesis-mechanism")
+                        .status("CONCLUIDO")
+                        .modelResponse("{\"mechanism\":\"mecanismo validado\"}")
+                        .build()));
+        when(executionRepository.findTopByMarketNicheIdAndStageCodeAndStatusOrderByExecutionRequestedAtDesc(
+                        18L,
+                        "hypothesis-proof",
+                        "CONCLUIDO"))
+                .thenReturn(Optional.empty());
+
+        assertThrows(IllegalStateException.class, () -> service.startOffer(18L));
+    }
+
+    /** Deve entregar Dor, Resultado, Mecanismo e Prova concluídos para contextualizar a etapa Oferta no Worker AI. */
+    @Test
+    void listOfferPendingIncludesLatestCompletedPainResultMechanismAndProofResponses() {
         MarketNiche niche = new MarketNiche();
         niche.setId(18L);
         niche.setName("Produtores digitais");
@@ -281,6 +327,12 @@ class HypothesisPainStageServiceTest {
                 .status("CONCLUIDO")
                 .modelResponse("{\"mechanism\":\"mecanismo validado\"}")
                 .build();
+        HypothesisPainStageExecution completedProof = HypothesisPainStageExecution.builder()
+                .marketNicheId(18L)
+                .stageCode("hypothesis-proof")
+                .status("CONCLUIDO")
+                .modelResponse("{\"proof\":\"prova validada\"}")
+                .build();
 
         when(executionRepository.findTop20ByStageCodeAndStatusOrderByExecutionRequestedAtAsc(
                         "hypothesis-offer",
@@ -301,6 +353,11 @@ class HypothesisPainStageServiceTest {
                         "hypothesis-mechanism",
                         "CONCLUIDO"))
                 .thenReturn(Optional.of(completedMechanism));
+        when(executionRepository.findTopByMarketNicheIdAndStageCodeAndStatusOrderByExecutionRequestedAtDesc(
+                        18L,
+                        "hypothesis-proof",
+                        "CONCLUIDO"))
+                .thenReturn(Optional.of(completedProof));
 
         var pending = service.listOfferPending();
 
@@ -308,6 +365,7 @@ class HypothesisPainStageServiceTest {
         assertEquals("{\"pain\":\"dor validada\"}", pending.getFirst().painModelResponse());
         assertEquals("{\"result\":\"resultado validado\"}", pending.getFirst().resultModelResponse());
         assertEquals("{\"mechanism\":\"mecanismo validado\"}", pending.getFirst().mechanismModelResponse());
+        assertEquals("{\"proof\":\"prova validada\"}", pending.getFirst().proofModelResponse());
     }
 
     /** Deve listar somente o conteúdo final persistido e a origem no banco para cada etapa do framework. */
@@ -340,13 +398,18 @@ class HypothesisPainStageServiceTest {
                 .thenReturn(Optional.empty());
         when(executionRepository.findTopByMarketNicheIdAndStageCodeAndStatusOrderByExecutionRequestedAtDesc(
                         18L,
+                        "hypothesis-proof",
+                        "CONCLUIDO"))
+                .thenReturn(Optional.empty());
+        when(executionRepository.findTopByMarketNicheIdAndStageCodeAndStatusOrderByExecutionRequestedAtDesc(
+                        18L,
                         "hypothesis-offer",
                         "CONCLUIDO"))
                 .thenReturn(Optional.empty());
 
         var summary = service.listFinalSummary(18L);
 
-        assertEquals(4, summary.size());
+        assertEquals(5, summary.size());
         assertEquals("pain", summary.getFirst().slug());
         assertEquals(painJob, summary.getFirst().jobid());
         assertEquals("{\"pain\":\"dor final\"}", summary.getFirst().finalContent());

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -4433,3 +4433,10 @@
 - foi feito: criado o documento `docs/relatorios/experimentos/plano-de-melhoria-marketing-hub-experimento-37.md` consolidando aprendizados estratégicos e recomendações de produto, marketing e operação.
 - diagnóstico: o experimento 37 teve atenção e clique, mas falhou na conversão pós-clique; a causa-raiz provável é sistêmica, combinando captura não validada ponta a ponta, persona genérica, segmentação ampla, landing abaixo do padrão e isca ampla demais para a dor quente do WhatsApp.
 - recomendação principal: implementar gates de pré-publicação para formulário, qualidade da landing e persona mínima antes de liberar mídia paga; depois rodar o experimento derivado 37B com foco em roteiro anti-preço para personal trainer.
+
+## 2026-06-11 — Correção da Etapa 4 Prova no pipeline de hipótese
+
+- solicitação: investigar por que a tela mostrava Etapa 3 e Etapa 5, pulando a Etapa 4.
+- causa-raiz: o fluxo de hipótese havia recebido Mecanismo e Oferta, mas a etapa Prova não existia no contrato da tela, nos endpoints do backend nem no Worker AI; além disso, Oferta era liberada após Mecanismo, permitindo avançar sem prova.
+- foi feito: adicionada a Etapa 4 — Prova na tela, nos endpoints públicos/internos, no resumo final, no contexto pendente do backend e no Worker AI com prompt/schema próprios; a Oferta agora exige Prova concluída e recebe `proofModelResponse` como contexto.
+- impacto esperado: o eixo Dor → Resultado → Mecanismo → Prova → Oferta volta a ficar completo, sequencial e auditável, reduzindo risco de criar oferta sem elemento de credibilidade para venda.

--- a/docs/swagger/hypothesis-pain-stage-swagger.yaml
+++ b/docs/swagger/hypothesis-pain-stage-swagger.yaml
@@ -2,7 +2,7 @@ openapi: 3.0.3
 info:
   title: Hypothesis Pipeline Stages API
   version: 1.0.0
-  description: Contratos das etapas Dor, Resultado, Mecanismo e Oferta do pipeline de hipótese.
+  description: Contratos das etapas Dor, Resultado, Mecanismo, Prova e Oferta do pipeline de hipótese.
 paths:
   /api/niches/{nicheId}/hypothesis-pipeline/summary:
     get:
@@ -314,6 +314,108 @@ paths:
   /api/internal/hypothesis-pipeline/mechanism/stage-executions/{idJob}/recebe-resposta:
     post:
       summary: Recebe resposta ou erro da OpenAI para concluir a etapa Mecanismo.
+      parameters:
+        - in: path
+          name: idJob
+          required: true
+          schema: { type: string }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RecebeRespostaRequest'
+      responses:
+        '202': { description: Resposta registrada. }
+  /api/niches/{nicheId}/hypothesis-pipeline/proof/start:
+    post:
+      summary: Inicia a construção auditável da prova do nicho.
+      parameters:
+        - in: path
+          name: nicheId
+          required: true
+          schema: { type: integer, format: int64 }
+      responses:
+        '202':
+          description: Execução iniciada.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HypothesisPainStartResponse'
+  /api/niches/{nicheId}/hypothesis-pipeline/proof/stage-executions:
+    get:
+      summary: Lista execuções da etapa Prova para acompanhamento na tela de nova hipótese.
+      parameters:
+        - in: path
+          name: nicheId
+          required: true
+          schema: { type: integer, format: int64 }
+        - in: query
+          name: includeCompleted
+          schema: { type: boolean, default: true }
+      responses:
+        '200':
+          description: Execuções retornadas.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/HypothesisPainExecutionSummaryResponse'
+  /api/niches/{nicheId}/hypothesis-pipeline/proof/stage-executions/{idJob}:
+    get:
+      summary: Consulta detalhe auditável de uma execução da etapa Prova para a tela de detalhe do job.
+      parameters:
+        - in: path
+          name: nicheId
+          required: true
+          schema: { type: integer, format: int64 }
+        - in: path
+          name: idJob
+          required: true
+          schema: { type: string }
+      responses:
+        '200':
+          description: Detalhe da execução retornado.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HypothesisPainExecutionDetailResponse'
+  /api/internal/hypothesis-pipeline/proof/stage-executions/pending:
+    get:
+      summary: Lista jobs pendentes da etapa Prova para o Worker AI.
+      responses:
+        '200':
+          description: Jobs pendentes.
+  /api/internal/hypothesis-pipeline/proof/stage-executions/{idJob}/running:
+    post:
+      summary: Marca uma execução de prova como em processamento.
+      parameters:
+        - in: path
+          name: idJob
+          required: true
+          schema: { type: string }
+      responses:
+        '202': { description: Execução marcada. }
+  /api/internal/hypothesis-pipeline/proof/stage-executions/{idJob}/recebe-prompt:
+    post:
+      summary: Recebe prompt, schema e request cru da etapa Prova enviados para a OpenAI.
+      parameters:
+        - in: path
+          name: idJob
+          required: true
+          schema: { type: string }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RecebePromptRequest'
+      responses:
+        '202': { description: Prompt registrado. }
+  /api/internal/hypothesis-pipeline/proof/stage-executions/{idJob}/recebe-resposta:
+    post:
+      summary: Recebe resposta ou erro da OpenAI para concluir a etapa Prova.
       parameters:
         - in: path
           name: idJob

--- a/frontend/src/pages/hypothesis/HypothesisPainStageExecutionDetailPage.tsx
+++ b/frontend/src/pages/hypothesis/HypothesisPainStageExecutionDetailPage.tsx
@@ -113,7 +113,14 @@ function AuditBlock({
 
 export default function HypothesisPainStageExecutionDetailPage() {
   const { nicheId, jobId, stageSlug = "pain" } = useParams();
-  const stageLabel = stageSlug === "result" ? "resultado" : "dor";
+  const stageLabelBySlug: Record<string, string> = {
+    pain: "dor",
+    result: "resultado",
+    mechanism: "mecanismo",
+    proof: "prova",
+    offer: "oferta",
+  };
+  const stageLabel = stageLabelBySlug[stageSlug] ?? "etapa";
   const detailQuery = useHypothesisPainStageExecutionDetail(
     nicheId,
     jobId,

--- a/frontend/src/pages/hypothesis/NewHypothesisPage.test.tsx
+++ b/frontend/src/pages/hypothesis/NewHypothesisPage.test.tsx
@@ -79,6 +79,21 @@ describe("NewHypothesisPage", () => {
           ],
         });
       }
+      if (url.includes("/hypothesis-pipeline/proof/")) {
+        return Promise.resolve({
+          data: [
+            {
+              jobid: "dddddddd-3894-43bd-9752-374f84eb6a2c",
+              marketNicheId: 18,
+              stageCode: "hypothesis-proof",
+              status: "CONCLUIDO",
+              executionRequestedAt: "2026-06-11T00:36:01Z",
+              completedAt: "2026-06-11T00:40:01Z",
+              costUsd: 0.005,
+            },
+          ],
+        });
+      }
       return Promise.resolve({
         data: [
           {
@@ -118,8 +133,9 @@ describe("NewHypothesisPage", () => {
       screen.getByText("Etapa 2 — Resultado desejado"),
     ).toBeInTheDocument();
     expect(screen.getByText("Etapa 3 — Mecanismo")).toBeInTheDocument();
+    expect(screen.getByText("Etapa 4 — Prova")).toBeInTheDocument();
     expect(screen.getByText("Etapa 5 — Oferta")).toBeInTheDocument();
-    expect(screen.getByText(/US\$\s*0,021345/)).toBeInTheDocument();
+    expect(screen.getByText(/US\$\s*0,026345/)).toBeInTheDocument();
     expect(
       screen.getByRole("link", { name: "Resumo do framework" }),
     ).toHaveAttribute("href", "/niches/18/hypothesis-pipeline/summary");

--- a/frontend/src/pages/hypothesis/NewHypothesisPage.tsx
+++ b/frontend/src/pages/hypothesis/NewHypothesisPage.tsx
@@ -267,9 +267,9 @@ export default function NewHypothesisPage() {
       <section className="card">
         <div className="card-body">
           <p className="text-muted mb-3">
-            Depois que dor, resultado, mecanismo e oferta estiverem claros, use
-            a hipótese completa para avançar nos experimentos seguindo Dor →
-            Resultado → Mecanismo → Prova → Oferta.
+            Depois que dor, resultado, mecanismo, prova e oferta estiverem
+            claros, use a hipótese completa para avançar nos experimentos
+            seguindo Dor → Resultado → Mecanismo → Prova → Oferta.
           </p>
           <div className="d-flex flex-wrap gap-2">
             <Link

--- a/frontend/src/pages/hypothesis/hypothesisPipelineStages.ts
+++ b/frontend/src/pages/hypothesis/hypothesisPipelineStages.ts
@@ -1,5 +1,5 @@
 export interface HypothesisPipelineStageConfig {
-  slug: "pain" | "result" | "mechanism" | "offer";
+  slug: "pain" | "result" | "mechanism" | "proof" | "offer";
   number: number;
   stageCode: string;
   title: string;
@@ -57,6 +57,21 @@ export const HYPOTHESIS_PIPELINE_STAGES: HypothesisPipelineStageConfig[] = [
       "Converta o resultado desejado em um mecanismo plausível antes de avançar para prova e oferta.",
   },
   {
+    slug: "proof",
+    number: 4,
+    stageCode: "hypothesis-proof",
+    title: "Prova",
+    startLabel: "Iniciar construção da prova",
+    startedToast: "Etapa Prova iniciada",
+    startErrorToast:
+      "Não foi possível iniciar a etapa Prova. Conclua o mecanismo antes de avançar.",
+    loadingLabel: "Carregando execuções de prova...",
+    emptyMessage:
+      "Nenhuma execução de prova iniciada para este nicho. Depois de concluir o mecanismo, clique no botão acima para criar o job e acompanhar a prova.",
+    description:
+      "Transforme o mecanismo em prova clara e crível antes de empacotar a oferta.",
+  },
+  {
     slug: "offer",
     number: 5,
     stageCode: "hypothesis-offer",
@@ -64,10 +79,10 @@ export const HYPOTHESIS_PIPELINE_STAGES: HypothesisPipelineStageConfig[] = [
     startLabel: "Iniciar construção da oferta",
     startedToast: "Etapa Oferta iniciada",
     startErrorToast:
-      "Não foi possível iniciar a etapa Oferta. Conclua o mecanismo antes de avançar.",
+      "Não foi possível iniciar a etapa Oferta. Conclua a prova antes de avançar.",
     loadingLabel: "Carregando execuções de oferta...",
     emptyMessage:
-      "Nenhuma execução de oferta iniciada para este nicho. Depois de concluir o mecanismo, clique no botão acima para criar o job e acompanhar a oferta.",
+      "Nenhuma execução de oferta iniciada para este nicho. Depois de concluir a prova, clique no botão acima para criar o job e acompanhar a oferta.",
     description:
       "Empacote mecanismo, prova prometida e promessa central em uma oferta clara para venda.",
   },


### PR DESCRIPTION
### Motivation
- The hypothesis pipeline skipped step 4 (Prova), allowing step 5 (Oferta) to advance without a completed proof, so the pipeline must enforce the sequence Dor → Resultado → Mecanismo → Prova → Oferta. 
- Worker integration for the Hypothesis pipeline needs a dedicated stage handler so the async OpenAI flow can produce and persist proof artifacts for downstream reuse.

### Description
- Backend: extended `HypothesisPainStageService` to add a new stage constant `PROOF_STAGE_CODE = "hypothesis-proof"`, a `startProof(...)` entry, and updated `startStage(...)` signature to accept `requiresCompletedProof`; added `requireCompletedProof(...)`, `latestCompletedProofResponse(...)`, `pendingProofResponse(...)`, `listProofStageExecutions(...)`, and included the proof stage in `listFinalSummary(...)` so Offer now requires Proof to be completed before starting. 
- AI Worker: added a new pipeline module `hypothesisproof` under `ai-worker/src/main/java/com/marketinghub/worker/pipeline/hypothesisproof` by adapting the existing `hypothesisoffer` implementation; new classes include `HypothesisProofBackendClient`, `HypothesisProofProcessor`, `HypothesisProofResponseValidator`, `HypothesisProofWorkerConfiguration`, `HypothesisProofExecutionScheduler`, `HypothesisProofInput`, `HypothesisProofOutput`, and `HypothesisProofWorkerProperties` to handle prompt building, OpenAI dispatch, validation and backend callbacks for the proof stage. 
- Artifacts & prompts: generated validator and `Proof` output shape aligned to a proof-oriented schema; prompt/schema resources for the new stage should be wired via worker properties (properties use `prompts/hypothesis-pipeline/...` by convention). 
- Misc: added/created files and wiring in `ai-worker` and updated backend service logic to preserve auditability and cost accounting paths already used by other hypothesis stages.

### Testing
- No automated unit or integration tests were executed in this rollout; only repository inspections and file edits were performed (`rg`, `sed`, creation of `ai-worker` files and modifications to `HypothesisPainStageService`).
- Recommend running the Java backend unit tests (`mvn -pl backend/ads-service test`) and the ai-worker test suite (e.g., `./mvn -pl ai-worker test` or the project CI pipeline) before merging to validate compilation and stage behavior.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2b4add73bc832180f72cfc776151b0)