### PR TITLE
Orienta IA como especialista em Marketing/Comportamento no OPRM (prompt, UI, testes e docs)

### DIFF
--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -443,3 +443,9 @@
 
 - Corrigida a causa-raiz da falha do teste `NicheResearchSeedBuilderPromptBuilderTest`: o prompt da etapa 2 já restringia aquisição a comportamento operacional, mas não trazia a instrução explícita esperada para impedir que as queries virassem aconselhamento de marketing.
 - Prevenção de recorrência: a frase de bloqueio ficou diretamente no prompt enviado ao modelo, mantendo a etapa focada em rotina real do MEI/autônomo e não em campanha, funil, anúncio, oferta ou estratégia de venda.
+
+## 2026-06-12 — OPRM NichoCNAE: persona da IA orientada a marketing
+
+- Ajustada a instrução inicial da etapa de seed para apresentar a IA como especialista em Marketing e Comportamento do Consumidor no Digital, evitando linguagem interna como construtor/executor de pipeline na requisição exibida ao usuário.
+- Causa-raiz tratada: a tela reconstruía corretamente a requisição, mas o contrato textual da etapa ainda expunha nomenclatura operacional interna, reduzindo clareza de negócio para validação do usuário.
+- Prevenção de recorrência: adicionado teste garantindo presença da persona de marketing/comportamento e ausência das expressões técnicas antigas no prompt da etapa.

--- a/frontend/src/pages/oprm/OprmNicheResearchSeedBuilderDetailPage.test.tsx
+++ b/frontend/src/pages/oprm/OprmNicheResearchSeedBuilderDetailPage.test.tsx
@@ -100,6 +100,12 @@ describe("OprmNicheResearchSeedBuilderDetailPage", () => {
       screen.getAllByText(/oprm_niche_research_seed_builder/).length,
     ).toBeGreaterThan(0);
     expect(
+      screen.getAllByText(
+        /especialista em Marketing e Comportamento do Consumidor no Digital/,
+      ).length,
+    ).toBeGreaterThan(0);
+    expect(screen.queryByText(/construtor da etapa 2/)).toBeNull();
+    expect(
       screen.getAllByText(/Quais são as etapas diárias na rotina de trabalho\?/)
         .length,
     ).toBeGreaterThan(0);

--- a/frontend/src/pages/oprm/OprmNicheResearchSeedBuilderDetailPage.tsx
+++ b/frontend/src/pages/oprm/OprmNicheResearchSeedBuilderDetailPage.tsx
@@ -44,7 +44,7 @@ function buildPrompt(detail: {
   } | null;
 }) {
   const lines = [
-    "Você é o construtor da etapa 2 do pipeline OPRM nichocnae.",
+    "Você é um especialista em Marketing e Comportamento do Consumidor no Digital, focado em entender a rotina real do profissional brasileiro MEI/autônomo antes de qualquer oferta.",
     "Objetivo: conhecer como o nicho funciona na rotina, sem criar oferta, produto, campanha ou landing page.",
     "Use o eixo Dor → Resultado → Mecanismo → Prova → Oferta apenas como referência distante; nesta etapa gere apenas seed e frases de pesquisa.",
     "",

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnae/nicheresearchseedbuilder/NicheResearchSeedBuilderPromptBuilder.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnae/nicheresearchseedbuilder/NicheResearchSeedBuilderPromptBuilder.java
@@ -10,7 +10,7 @@ public class NicheResearchSeedBuilderPromptBuilder {
     /** Cria instruções para transformar CNAE em seed e queries de rotina com aquisição como eixo operacional. */
     public String buildPrompt(NicheResearchSeedBuilderPending input) {
         StringJoiner prompt = new StringJoiner("\n");
-        prompt.add("Você é o construtor da etapa 2 do pipeline OPRM nichocnae.");
+        prompt.add("Você é um especialista em Marketing e Comportamento do Consumidor no Digital, focado em entender a rotina real do profissional brasileiro MEI/autônomo antes de qualquer oferta.");
         prompt.add("Objetivo: transformar o CNAE em pesquisas sobre o profissional brasileiro MEI/autônomo que executa o trabalho, sem assumir solução, IA, automação, produto, curso, ferramenta ou oferta.");
         prompt.add("Gere apenas seed operacional e frases de pesquisa sobre comportamento, rotina executada, tarefas do dia a dia, procedimentos práticos, decisões, atendimento, agenda, materiais, clientes, cobrança, entrega, retrabalho, sonhos, medos, inseguranças, canais usados e linguagem real em pt-BR.");
         prompt.add("Gere apenas seed operacional e frases de pesquisa sobre comportamento, rotina, tarefas, decisões, atendimento, agenda, materiais, clientes, cobrança, entrega, retrabalho, sonhos, medos, inseguranças, canais usados e linguagem real em pt-BR.");

--- a/oprm-coletor-mei/src/test/java/com/marketinghub/nichocnae/nicheresearchseedbuilder/NicheResearchSeedBuilderPromptBuilderTest.java
+++ b/oprm-coletor-mei/src/test/java/com/marketinghub/nichocnae/nicheresearchseedbuilder/NicheResearchSeedBuilderPromptBuilderTest.java
@@ -16,6 +16,7 @@ class NicheResearchSeedBuilderPromptBuilderTest {
         String prompt = promptBuilder.buildPrompt(pending());
 
         assertThat(prompt)
+                .contains("especialista em Marketing e Comportamento do Consumidor no Digital")
                 .contains("profissional brasileiro MEI/autônomo")
                 .contains("português do Brasil")
                 .contains("tarefas")
@@ -52,6 +53,8 @@ class NicheResearchSeedBuilderPromptBuilderTest {
                 .contains("criação de campanha")
                 .contains("funil")
                 .contains("anúncio")
+                .doesNotContain("construtor da etapa 2")
+                .doesNotContain("executor de pipeline")
                 .doesNotContain("fontes do Brasil")
                 .doesNotContain("domínios .br")
                 .doesNotContain("PRODUCT_SERVICE_DISCOVERY")


### PR DESCRIPTION
### Motivation
- Melhorar a clareza de negócio na interface e no prompt da etapa 2 do OPRM removendo linguagem operacional interna e apresentando a IA como especialista em Marketing e Comportamento do Consumidor no Digital.
- Evitar que a requisição exibida ao usuário mostre termos técnicos como "construtor da etapa" que reduzem a legibilidade para analistas/comercio.
- Preservar a fronteira OPRM (pesquisa de rotina, sem criação de oferta) enquanto tornamos a persona mais alinhada ao público de validação comercial.

### Description
- Substitui a instrução inicial do prompt no coletor por: `"Você é um especialista em Marketing e Comportamento do Consumidor no Digital, focado em entender a rotina real do profissional brasileiro MEI/autônomo antes de qualquer oferta."` em `oprm-coletor-mei/src/main/.../NicheResearchSeedBuilderPromptBuilder.java`.
- Atualiza a prévia exibida no frontend para usar a mesma frase de persona em `frontend/src/pages/oprm/OprmNicheResearchSeedBuilderDetailPage.tsx` para evitar exposição de terminologia operacional.
- Adiciona asserções de regressão no frontend e no coletor para garantir presença da nova persona e ausência das expressões técnicas antigas em `frontend/src/pages/oprm/OprmNicheResearchSeedBuilderDetailPage.test.tsx` e `oprm-coletor-mei/src/test/.../NicheResearchSeedBuilderPromptBuilderTest.java`.
- Registra a mudança operacional em `docs/registros/oprm1.md` descrevendo causa-raiz e prevenção de recorrência.

### Testing
- Executed `npm test -- --run src/pages/oprm/OprmNicheResearchSeedBuilderDetailPage.test.tsx` and the frontend test passed (1 test passed).
- Executed `npm run typecheck` and TypeScript typecheck completed successfully with no errors.
- Executed `mvn -Dtest=NicheResearchSeedBuilderPromptBuilderTest test` and the Java unit test passed (`BUILD SUCCESS`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2b5f825c4c8321ba105417fcff69f7)