### PR TITLE
Add 'Iniciar dossiê' action to MOIS sales page detail

### DIFF
--- a/frontend/src/pages/mois/MoisSalesPageLibraryDetailPage.tsx
+++ b/frontend/src/pages/mois/MoisSalesPageLibraryDetailPage.tsx
@@ -4,6 +4,7 @@ import {
   useMoisSalesLibraryMarketWarmup,
   useMoisSalesLibraryMarketWarmupSources,
   useMoisSalesLibraryPage,
+  useRequestMoisSalesLibraryMarketWarmup,
   useMoisSalesLibraryPageExecutions,
   useMoisSalesLibraryPages,
   useUpdateMoisSalesLibraryPageStatus,
@@ -91,6 +92,8 @@ export default function MoisSalesPageLibraryDetailPage() {
   const pagesQuery = useMoisSalesLibraryPages(WORKSPACE_ID, 1, PAGE_SIZE);
   const updateStatusMutation =
     useUpdateMoisSalesLibraryPageStatus(WORKSPACE_ID);
+  const requestWarmupMutation =
+    useRequestMoisSalesLibraryMarketWarmup(WORKSPACE_ID);
 
   const currentIndex =
     pagesQuery.data?.items.findIndex((item) => item.pageId === validPageId) ??
@@ -98,6 +101,14 @@ export default function MoisSalesPageLibraryDetailPage() {
   const nextItem =
     currentIndex >= 0 ? pagesQuery.data?.items[currentIndex + 1] : undefined;
   const isMutating = updateStatusMutation.isPending;
+  const hasActiveWarmupDossier = Boolean(
+    marketWarmupQuery.data ||
+    ["PENDING", "FETCHING", "DONE"].includes(
+      pageQuery.data?.marketWarmupStatus || "",
+    ),
+  );
+  const isWarmupRequestDisabled =
+    !validPageId || requestWarmupMutation.isPending || hasActiveWarmupDossier;
   const hotmartPrice = cleanText(pageQuery.data?.hotmartPrice);
   const hotmartTemperature = pageQuery.data?.hotmartTemperature;
   const hotmartProducer =
@@ -195,6 +206,25 @@ export default function MoisSalesPageLibraryDetailPage() {
         </button>
         <button
           type="button"
+          className="btn btn-outline-primary"
+          disabled={isWarmupRequestDisabled}
+          onClick={() =>
+            validPageId && requestWarmupMutation.mutate(validPageId)
+          }
+        >
+          {requestWarmupMutation.isPending ? (
+            <span
+              className="spinner-border spinner-border-sm me-2"
+              role="status"
+              aria-hidden="true"
+            />
+          ) : null}
+          {requestWarmupMutation.isPending
+            ? "Solicitando dossiê..."
+            : "Iniciar dossiê"}
+        </button>
+        <button
+          type="button"
           className="btn btn-outline-danger"
           disabled={!validPageId || isMutating}
           onClick={() =>
@@ -219,6 +249,17 @@ export default function MoisSalesPageLibraryDetailPage() {
       {updateStatusMutation.isError ? (
         <div className="alert alert-danger mb-0">
           Falha ao atualizar status da página.
+        </div>
+      ) : null}
+
+      {requestWarmupMutation.isSuccess ? (
+        <div className="alert alert-success mb-0">
+          Dossiê enviado para fila.
+        </div>
+      ) : null}
+      {requestWarmupMutation.isError ? (
+        <div className="alert alert-danger mb-0">
+          Falha ao solicitar dossiê.
         </div>
       ) : null}
 


### PR DESCRIPTION
### Motivation
- Provide a direct action in the page detail to request the market-warmup dossier for a product so operators can trigger the public-research step from the UI. 
- Prevent duplicate/irrelevant requests by disabling the action when the page id is invalid, a request is pending, or an active/finished dossier exists. 
- Surface immediate, simple feedback for pending / success / error states to improve operator UX.

### Description
- Imported and instantiated the existing hook `useRequestMoisSalesLibraryMarketWarmup` with `WORKSPACE_ID` in `MoisSalesPageLibraryDetailPage.tsx`. 
- Added a visible action button labeled `Iniciar dossiê` beside the existing `Voltar para pendente` and `Marcar como anulado` buttons that calls `requestWarmupMutation.mutate(validPageId)` on click. 
- Disabled the button when there is no `validPageId`, when `requestWarmupMutation.isPending` is true, or when an active/existing dossier/status is present (checked via `marketWarmupQuery.data` or `pageQuery.data?.marketWarmupStatus`). 
- Added simple feedback text: pending shows `Solicitando dossiê...`, success shows `Dossiê enviado para fila.`, and error shows `Falha ao solicitar dossiê.`. 
- The button uses the existing hook which calls `POST /api/mois/sales-library/pages/{pageId}/market-warmup:request` and relies on the hook's `onSuccess` to invalidate queries for `market-warmup`, `sources`, `signals`, `pages` and `pages-summary` so the UI refreshes automatically.

### Testing
- Ran `npm run typecheck` to validate TypeScript types; the command completed successfully. 
- Built the frontend with `npm run build`; the production build completed successfully. 
- Captured a UI screenshot using `npx playwright screenshot --full-page http://127.0.0.1:5173/mois/sales-pages-library/1 /tmp/mois-sales-library-detail-warmup-button.png` to verify the button renders; the screenshot step completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2b5d028604832188385ed6c5d2ab97)