### PR TITLE
OPRM: reuse existing MarketNiche by CNAE + neutral name and record updates

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/enrichednichematerializer/service/BackendEnrichedNicheMaterializerService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/enrichednichematerializer/service/BackendEnrichedNicheMaterializerService.java
@@ -32,8 +32,10 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.springframework.data.domain.PageRequest;
@@ -47,6 +49,7 @@ public class BackendEnrichedNicheMaterializerService {
   private static final int MAX_PENDING = 10;
   private static final String SOURCE_MODULE = "OPRM_NICHO_CNAE";
   private static final String ENRICHED_STATUS = "ENRICHED_NICHE_CREATED";
+  private static final String ENRICHED_UPDATED_STATUS = "ENRICHED_NICHE_UPDATED";
   private static final String FAILED_STATUS = "ENRICHED_NICHE_FAILED";
   private static final String HISTORICAL_RESEARCH_RECOMMENDATION = "Preferir novo ciclo neutro em vez de editar manualmente o texto antigo.";
   private static final List<String> SOLUTION_LANGUAGE_TERMS = List.of(
@@ -116,17 +119,33 @@ public class BackendEnrichedNicheMaterializerService {
           .orElseThrow(() -> new IllegalStateException("routine card already materialized without retrievable profile"));
       publishMetaSignalsForExistingProfile(cycle, card, existing);
       return new CompleteEnrichedNicheMaterializerResponse(
-          researchCycleId, card.getId(), existing.getMarketNiche().getId(), existing.getId(), cycle.getStatus(), existing.getCreatedAt());
+          researchCycleId,
+          card.getId(),
+          existing.getMarketNiche().getId(),
+          existing.getId(),
+          cycle.getStatus(),
+          existing.getCreatedAt(),
+          "Cartão já materializado anteriormente; sinais do nicho existente foram revisados sem criar novo market_niche.");
     }
 
     OprmNicheCandidate candidate = nicheCandidateRepository.findById(cycle.getSourceNicheId()).orElse(null);
     OprmEnrichedNicheMetaSignalService.MetaSignalPackage metaSignalPackage = metaSignalService.buildSignalPackage(cycle, card);
-    MarketNiche marketNiche = resolveMarketNiche(card, cycle, candidate, metaSignalPackage);
-    MarketNicheEnrichmentProfile profile = buildProfile(card, cycle, candidate, marketNiche, request);
+    ResolvedMarketNiche resolvedMarketNiche = resolveMarketNiche(card, cycle, candidate, metaSignalPackage);
+    MarketNicheEnrichmentProfile profile = buildProfile(card, cycle, candidate, resolvedMarketNiche.marketNiche(), request);
     MarketNicheEnrichmentProfile savedProfile = enrichmentProfileRepository.save(profile);
-    updateCycleAndCandidate(cycle, candidate, marketNiche.getId());
+    updateCycleAndCandidate(
+        cycle,
+        candidate,
+        resolvedMarketNiche.marketNiche().getId(),
+        resolvedMarketNiche.existingMatchedByCnaeAndNeutralName());
     return new CompleteEnrichedNicheMaterializerResponse(
-        researchCycleId, card.getId(), marketNiche.getId(), savedProfile.getId(), cycle.getStatus(), savedProfile.getCreatedAt());
+        researchCycleId,
+        card.getId(),
+        resolvedMarketNiche.marketNiche().getId(),
+        savedProfile.getId(),
+        cycle.getStatus(),
+        savedProfile.getCreatedAt(),
+        buildCompletionMessage(resolvedMarketNiche.existingMatchedByCnaeAndNeutralName()));
   }
 
   /** Registra falha da etapa final no ciclo para manter rastreabilidade operacional. */
@@ -268,15 +287,28 @@ public class BackendEnrichedNicheMaterializerService {
         card.getQualityCheckedAt());
   }
 
-  /** Reaproveita nicho existente do candidato ou cria um nicho base com dados enriquecidos do card. */
-  private MarketNiche resolveMarketNiche(
+  /** Reaproveita primeiro nicho já materializado pelo mesmo CNAE/nome neutro, depois candidato, ou cria novo nicho base. */
+  private ResolvedMarketNiche resolveMarketNiche(
       OprmNicheRoutineCard card,
       OprmRoutineResearchCycle cycle,
       OprmNicheCandidate candidate,
       OprmEnrichedNicheMetaSignalService.MetaSignalPackage metaSignalPackage) {
-    MarketNiche marketNiche = candidate != null && candidate.getMarketNicheId() != null
-        ? marketNicheRepository.findById(candidate.getMarketNicheId()).orElseGet(MarketNiche::new)
-        : new MarketNiche();
+    Optional<MarketNiche> existingByCnaeAndNeutralName = findExistingMarketNicheByCnaeAndNeutralName(cycle);
+    MarketNiche marketNiche = existingByCnaeAndNeutralName
+        .map(existing -> updateMarketNicheFields(existing, card, cycle, metaSignalPackage))
+        .orElseGet(() -> resolveCandidateMarketNiche(candidate)
+            .map(existing -> updateMarketNicheFields(existing, card, cycle, metaSignalPackage))
+            .orElseGet(() -> updateMarketNicheFields(new MarketNiche(), card, cycle, metaSignalPackage)));
+    MarketNiche savedMarketNiche = marketNicheRepository.save(marketNiche);
+    return new ResolvedMarketNiche(savedMarketNiche, existingByCnaeAndNeutralName.isPresent());
+  }
+
+  /** Atualiza os campos publicáveis do nicho base com os dados mais recentes do cartão aprovado. */
+  private MarketNiche updateMarketNicheFields(
+      MarketNiche marketNiche,
+      OprmNicheRoutineCard card,
+      OprmRoutineResearchCycle cycle,
+      OprmEnrichedNicheMetaSignalService.MetaSignalPackage metaSignalPackage) {
     marketNiche.setName(requiredText(neutralNicheName(cycle), "neutralNicheName"));
     marketNiche.setDescription(buildMarketNicheDescription(card, cycle));
     marketNiche.setDemandVolume("CNAE " + cycle.getCnaeCode() + " · Score OPRM " + cycle.getSourceScore());
@@ -286,7 +318,34 @@ public class BackendEnrichedNicheMaterializerService {
     marketNiche.setDemographicFilters("Público profissional/empreendedor ligado a " + cycle.getCnaeDescription());
     applyMetaSignalsToNiche(marketNiche, metaSignalPackage);
     marketNiche.setExtraTips(buildExtraTips(card));
-    return marketNicheRepository.save(marketNiche);
+    return marketNiche;
+  }
+
+  /** Localiza nicho já vinculado ao mesmo CNAE e ao mesmo nome neutro normalizado por perfil OPRM anterior. */
+  private Optional<MarketNiche> findExistingMarketNicheByCnaeAndNeutralName(OprmRoutineResearchCycle cycle) {
+    String normalizedNeutralName = normalizeLookupText(neutralNicheName(cycle));
+    if (!StringUtils.hasText(cycle.getCnaeCode()) || !StringUtils.hasText(normalizedNeutralName)) {
+      return Optional.empty();
+    }
+    List<MarketNicheEnrichmentProfile> existingProfiles = enrichmentProfileRepository.findMaterializedByCnaeAndNormalizedNeutralName(
+        cycle.getCnaeCode().trim(), normalizedNeutralName, PageRequest.of(0, 1));
+    if (existingProfiles == null || existingProfiles.isEmpty()) {
+      return Optional.empty();
+    }
+    return Optional.ofNullable(existingProfiles.getFirst().getMarketNiche());
+  }
+
+  /** Localiza o nicho já apontado pelo candidato quando não há match canônico por CNAE/nome neutro. */
+  private Optional<MarketNiche> resolveCandidateMarketNiche(OprmNicheCandidate candidate) {
+    if (candidate == null || candidate.getMarketNicheId() == null) {
+      return Optional.empty();
+    }
+    return marketNicheRepository.findById(candidate.getMarketNicheId());
+  }
+
+  /** Normaliza texto para comparação canônica simples com a consulta do banco. */
+  private String normalizeLookupText(String value) {
+    return StringUtils.hasText(value) ? value.trim().toLowerCase(Locale.ROOT) : null;
   }
 
   /** Aplica sinais Meta Ads apenas nos campos do backend que serão consultados pelo Facebook Ads. */
@@ -609,22 +668,34 @@ public class BackendEnrichedNicheMaterializerService {
     return value == null ? 0 : Math.max(0, Math.min(100, value));
   }
 
-  /** Atualiza ciclo e candidato para indicar que o nicho enriquecido foi materializado. */
-  private void updateCycleAndCandidate(OprmRoutineResearchCycle cycle, OprmNicheCandidate candidate, Long marketNicheId) {
+  /** Atualiza ciclo e candidato para indicar criação ou revisão de nicho enriquecido. */
+  private void updateCycleAndCandidate(
+      OprmRoutineResearchCycle cycle, OprmNicheCandidate candidate, Long marketNicheId, boolean existingMatchedByCnaeAndNeutralName) {
     Instant now = Instant.now();
-    cycle.setStatus(ENRICHED_STATUS);
+    cycle.setStatus(existingMatchedByCnaeAndNeutralName ? ENRICHED_UPDATED_STATUS : ENRICHED_STATUS);
     cycle.setFinishedAt(now);
     cycle.setUpdatedAt(now);
     cycleRepository.save(cycle);
     if (candidate != null) {
       candidate.setMarketNicheId(marketNicheId);
-      candidate.setStatus(ENRICHED_STATUS);
-      candidate.setRoutineResearchStatus(ENRICHED_STATUS);
+      candidate.setStatus(cycle.getStatus());
+      candidate.setRoutineResearchStatus(cycle.getStatus());
       candidate.setLastRoutineResearchCycleId(cycle.getId());
       candidate.setUpdatedAt(now);
       nicheCandidateRepository.save(candidate);
     }
   }
+
+  /** Monta mensagem operacional deixando claro se houve criação ou revisão de nicho existente. */
+  private String buildCompletionMessage(boolean existingMatchedByCnaeAndNeutralName) {
+    if (existingMatchedByCnaeAndNeutralName) {
+      return "Ciclo materializado como atualização/revisão de market_niche existente para o mesmo CNAE e nome neutro; nenhum novo nicho foi criado.";
+    }
+    return "Ciclo materializado com criação de novo market_niche porque não havia nicho anterior para o mesmo CNAE e nome neutro.";
+  }
+
+  /** Representa o nicho resolvido e se ele veio do match canônico CNAE/nome neutro. */
+  private record ResolvedMarketNiche(MarketNiche marketNiche, boolean existingMatchedByCnaeAndNeutralName) {}
 
   /** Converte um ciclo contaminado em item de diagnóstico operacional. */
   private ContaminatedNicheDiagnosticItem toCycleDiagnosticItem(OprmRoutineResearchCycle cycle, String matchedTerm) {

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/enrichednichematerializer/service/completeStageExecution/CompleteEnrichedNicheMaterializerResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/enrichednichematerializer/service/completeStageExecution/CompleteEnrichedNicheMaterializerResponse.java
@@ -9,4 +9,5 @@ public record CompleteEnrichedNicheMaterializerResponse(
     Long marketNicheId,
     Long enrichedNicheProfileId,
     String cycleStatus,
-    Instant materializedAt) {}
+    Instant materializedAt,
+    String operationalMessage) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/niche/MarketNicheEnrichmentProfileRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/niche/MarketNicheEnrichmentProfileRepository.java
@@ -3,6 +3,7 @@ package com.marketinghub.repository.jpa.niche;
 import com.marketinghub.niche.MarketNicheEnrichmentProfile;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
@@ -14,6 +15,19 @@ public interface MarketNicheEnrichmentProfileRepository extends JpaRepository<Ma
 
   /** Busca o perfil enriquecido materializado para um ciclo de pesquisa de rotina. */
   Optional<MarketNicheEnrichmentProfile> findFirstByResearchCycleIdOrderByIdDesc(Long researchCycleId);
+
+  /** Busca perfis que já materializaram o mesmo CNAE com o mesmo nome neutro normalizado. */
+  @Query("""
+      select p from MarketNicheEnrichmentProfile p
+      join fetch p.marketNiche n
+      where p.cnaeCode = :cnaeCode
+        and lower(trim(p.neutralNicheName)) = :normalizedNeutralNicheName
+      order by p.updatedAt desc, p.id desc
+      """)
+  List<MarketNicheEnrichmentProfile> findMaterializedByCnaeAndNormalizedNeutralName(
+      @Param("cnaeCode") String cnaeCode,
+      @Param("normalizedNeutralNicheName") String normalizedNeutralNicheName,
+      Pageable pageable);
 
   /** Lista o perfil enriquecido mais recente de cada nicho informado. */
   @Query("""

--- a/backend/ads-service/src/test/java/com/marketinghub/oprm/nichocnae/enrichednichematerializer/service/BackendEnrichedNicheMaterializerServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/oprm/nichocnae/enrichednichematerializer/service/BackendEnrichedNicheMaterializerServiceTest.java
@@ -133,6 +133,45 @@ class BackendEnrichedNicheMaterializerServiceTest {
             && "Objeções".equals(profile.getObjections())));
   }
 
+  /** Deve revisar nicho existente quando outro ciclo tiver mesmo CNAE e nome neutro normalizado. */
+  @Test
+  void shouldReuseExistingNicheForSameCnaeAndNeutralName() {
+    OprmRoutineResearchCycle cycle = cycle();
+    OprmNicheRoutineCard card = card();
+    OprmNicheCandidate candidate = candidate();
+    MarketNiche existingNiche = new MarketNiche();
+    existingNiche.setId(200L);
+    existingNiche.setName("salões pequenos");
+    MarketNicheEnrichmentProfile existingProfile = profile(existingNiche);
+    when(cycleRepository.findById(1001L)).thenReturn(Optional.of(cycle));
+    when(cardRepository.findById(10L)).thenReturn(Optional.of(card));
+    when(candidateRepository.findById(77L)).thenReturn(Optional.of(candidate));
+    when(profileRepository.existsBySourceRoutineCardId(10L)).thenReturn(false);
+    when(profileRepository.findMaterializedByCnaeAndNormalizedNeutralName("9602501", "salões pequenos", Pageable.ofSize(1)))
+        .thenReturn(List.of(existingProfile));
+    when(metaSignalService.buildSignalPackage(cycle, card)).thenReturn(metaSignalPackage);
+    when(marketNicheRepository.save(any(MarketNiche.class))).thenAnswer(invocation -> invocation.getArgument(0));
+    when(profileRepository.save(any(MarketNicheEnrichmentProfile.class))).thenAnswer(invocation -> {
+      MarketNicheEnrichmentProfile profile = invocation.getArgument(0);
+      profile.setId(301L);
+      return profile;
+    });
+
+    CompleteEnrichedNicheMaterializerResponse response = service.complete(1001L, new CompleteEnrichedNicheMaterializerRequest(
+        1001L, 10L, "Persona", "Linguagem", "Gatilhos", "Objeções", "test"));
+
+    assertThat(response.marketNicheId()).isEqualTo(200L);
+    assertThat(response.enrichedNicheProfileId()).isEqualTo(301L);
+    assertThat(response.cycleStatus()).isEqualTo("ENRICHED_NICHE_UPDATED");
+    assertThat(response.operationalMessage()).contains("atualização/revisão");
+    assertThat(candidate.getMarketNicheId()).isEqualTo(200L);
+    assertThat(cycle.getStatus()).isEqualTo("ENRICHED_NICHE_UPDATED");
+    verify(profileRepository).save(org.mockito.ArgumentMatchers.argThat(profile ->
+        Long.valueOf(200L).equals(profile.getMarketNiche().getId())
+            && "9602501".equals(profile.getCnaeCode())
+            && "Salões pequenos".equals(profile.getNeutralNicheName())));
+  }
+
   /** Deve localizar registros históricos contaminados para orientar novo ciclo neutro. */
   @Test
   void shouldDiagnoseHistoricalContamination() {

--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -449,3 +449,9 @@
 - Ajustada a instrução inicial da etapa de seed para apresentar a IA como especialista em Marketing e Comportamento do Consumidor no Digital, evitando linguagem interna como construtor/executor de pipeline na requisição exibida ao usuário.
 - Causa-raiz tratada: a tela reconstruía corretamente a requisição, mas o contrato textual da etapa ainda expunha nomenclatura operacional interna, reduzindo clareza de negócio para validação do usuário.
 - Prevenção de recorrência: adicionado teste garantindo presença da persona de marketing/comportamento e ausência das expressões técnicas antigas no prompt da etapa.
+
+## 2026-06-12 — OPRM NichoCNAE: materialização idempotente por CNAE e nome neutro
+
+- Corrigida a causa-raiz de duplicação de `market_niche` quando um novo ciclo OPRM materializava o mesmo CNAE e o mesmo nome neutro já materializados anteriormente.
+- O materializador agora consulta primeiro perfis enriquecidos existentes pelo par CNAE/nome neutro normalizado, atualiza o `market_niche` encontrado e vincula o novo ciclo/perfil a esse nicho, registrando status operacional de atualização/revisão em vez de criação.
+- Prevenção de recorrência: adicionado teste cobrindo duplicidade para o CNAE `9602501` com nome neutro `Salões pequenos`, garantindo reaproveitamento do nicho existente.


### PR DESCRIPTION
### Motivation
- Prevent duplicate `market_niche` records when the OPRM NichoCNAE pipeline materializes the same CNAE and the same neutral niche name across different cycles.  
- Preserve auditability by linking new enrichment profiles/cycles to an existing `market_niche` and marking the operation as an update instead of blindly creating a new niche.  
- Make the materialization outcome explicit to operators via an operational message and distinct cycle status for updates vs creations.

### Description
- Add a canonical lookup in `MarketNicheEnrichmentProfileRepository` (`findMaterializedByCnaeAndNormalizedNeutralName`) to find prior materializations by `cnaeCode` + normalized `neutralNicheName`.  
- Change `BackendEnrichedNicheMaterializerService` materialization flow to: (1) search for an existing `market_niche` by CNAE + normalized neutral name, (2) if none found fall back to candidate-linked niche, (3) otherwise create a new `market_niche`; and update the found/created entity with the card data.  
- Introduce `ENRICHED_NICHE_UPDATED` status and return an `operationalMessage` in `CompleteEnrichedNicheMaterializerResponse` to indicate whether the materialization created a new niche or updated an existing one.  
- Add a regression test `shouldReuseExistingNicheForSameCnaeAndNeutralName` in `BackendEnrichedNicheMaterializerServiceTest` covering CNAE `9602501` / neutral name `Salões pequenos`, and record the operational decision in `docs/registros/oprm1.md`.

### Testing
- Ran the module unit tests with `../mvnw -Dtest=BackendEnrichedNicheMaterializerServiceTest test` and the test suite for `BackendEnrichedNicheMaterializerServiceTest` passed (`Tests run: 5, Failures: 0`).  
- Verified code formatting/checks with `git diff --check` (no check failures).  
- Attempted to run `../mvnw spotless:apply -DskipTests` but the module environment did not resolve a `spotless` plugin prefix, so automatic formatting was not executed in this run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2b68f1b54883219938289c81b4d08a)