### PR TITLE
Block OPRM materialization unless approved MEI audience profile exists

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/enrichednichematerializer/service/BackendEnrichedNicheMaterializerService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/enrichednichematerializer/service/BackendEnrichedNicheMaterializerService.java
@@ -17,6 +17,7 @@ import com.marketinghub.oprm.nichocnae.enrichednichematerializer.service.diagnos
 import com.marketinghub.oprm.nichocnae.enrichednichematerializer.service.diagnoseContamination.ContaminatedNicheDiagnosticResponse;
 import com.marketinghub.oprm.nichocnae.enrichednichematerializer.service.failStageExecution.FailEnrichedNicheMaterializerRequest;
 import com.marketinghub.oprm.nichocnae.enrichednichematerializer.service.pending.RecordEnrichedNicheMaterializerPending;
+import com.marketinghub.oprm.nichocnae.meiaudienceprofile.OprmMeiAudienceProfile;
 import com.marketinghub.repository.jpa.niche.MarketNicheEnrichmentProfileRepository;
 import com.marketinghub.repository.jpa.niche.MarketNicheRepository;
 import com.marketinghub.repository.jpa.oprm.cnae.OprmNicheCandidateRepository;
@@ -27,6 +28,7 @@ import com.marketinghub.repository.jpa.oprm.nichocnae.OprmResearchQueryRepositor
 import com.marketinghub.repository.jpa.oprm.nichocnae.OprmRoutineResearchCycleRepository;
 import com.marketinghub.repository.jpa.oprm.nichocnae.OprmSourceCandidateRepository;
 import com.marketinghub.repository.jpa.oprm.nichocnae.OprmSourceSnapshotRepository;
+import com.marketinghub.repository.jpa.oprm.nichocnae.meiaudienceprofile.OprmMeiAudienceProfileRepository;
 import jakarta.persistence.EntityNotFoundException;
 import java.time.Instant;
 import java.util.ArrayList;
@@ -34,6 +36,7 @@ import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 import org.springframework.data.domain.PageRequest;
@@ -62,6 +65,7 @@ public class BackendEnrichedNicheMaterializerService {
   private final OprmExtractedSignalRepository extractedSignalRepository;
   private final MarketNicheRepository marketNicheRepository;
   private final MarketNicheEnrichmentProfileRepository enrichmentProfileRepository;
+  private final OprmMeiAudienceProfileRepository meiAudienceProfileRepository;
   private final OprmEnrichedNicheMetaSignalService metaSignalService;
 
   /** Inicializa o serviço com os repositórios oficiais do backend usados pela etapa final. */
@@ -76,6 +80,7 @@ public class BackendEnrichedNicheMaterializerService {
       OprmExtractedSignalRepository extractedSignalRepository,
       MarketNicheRepository marketNicheRepository,
       MarketNicheEnrichmentProfileRepository enrichmentProfileRepository,
+      OprmMeiAudienceProfileRepository meiAudienceProfileRepository,
       OprmEnrichedNicheMetaSignalService metaSignalService) {
     this.cycleRepository = cycleRepository;
     this.routineCardRepository = routineCardRepository;
@@ -87,6 +92,7 @@ public class BackendEnrichedNicheMaterializerService {
     this.extractedSignalRepository = extractedSignalRepository;
     this.marketNicheRepository = marketNicheRepository;
     this.enrichmentProfileRepository = enrichmentProfileRepository;
+    this.meiAudienceProfileRepository = meiAudienceProfileRepository;
     this.metaSignalService = metaSignalService;
   }
 
@@ -94,6 +100,7 @@ public class BackendEnrichedNicheMaterializerService {
   @Transactional(readOnly = true)
   public List<RecordEnrichedNicheMaterializerPending> listPending() {
     return routineCardRepository.findPendingEnrichedNicheMaterialization(PageRequest.of(0, MAX_PENDING)).stream()
+        .filter(this::hasMeiAudienceProfileForPending)
         .map(this::toPending)
         .toList();
   }
@@ -111,6 +118,8 @@ public class BackendEnrichedNicheMaterializerService {
     if (!Boolean.TRUE.equals(card.getReadyForHypothesis())) {
       throw new IllegalArgumentException("routine card is not approved by quality gate");
     }
+    OprmNicheCandidate candidate = nicheCandidateRepository.findById(cycle.getSourceNicheId()).orElse(null);
+    OprmMeiAudienceProfile meiAudienceProfile = requireApprovedMeiAudienceProfile(cycle, candidate);
     if (enrichmentProfileRepository.existsBySourceRoutineCardId(card.getId())) {
       MarketNicheEnrichmentProfile existing = enrichmentProfileRepository.findFirstByResearchCycleIdOrderByIdDesc(researchCycleId)
           .orElseThrow(() -> new IllegalStateException("routine card already materialized without retrievable profile"));
@@ -119,9 +128,8 @@ public class BackendEnrichedNicheMaterializerService {
           researchCycleId, card.getId(), existing.getMarketNiche().getId(), existing.getId(), cycle.getStatus(), existing.getCreatedAt());
     }
 
-    OprmNicheCandidate candidate = nicheCandidateRepository.findById(cycle.getSourceNicheId()).orElse(null);
     OprmEnrichedNicheMetaSignalService.MetaSignalPackage metaSignalPackage = metaSignalService.buildSignalPackage(cycle, card);
-    MarketNiche marketNiche = resolveMarketNiche(card, cycle, candidate, metaSignalPackage);
+    MarketNiche marketNiche = resolveMarketNiche(card, cycle, candidate, meiAudienceProfile, metaSignalPackage);
     MarketNicheEnrichmentProfile profile = buildProfile(card, cycle, candidate, marketNiche, request);
     MarketNicheEnrichmentProfile savedProfile = enrichmentProfileRepository.save(profile);
     updateCycleAndCandidate(cycle, candidate, marketNiche.getId());
@@ -234,6 +242,16 @@ public class BackendEnrichedNicheMaterializerService {
     marketNicheRepository.save(marketNiche);
   }
 
+  /** Confirma se a pendência final tem perfil MEI/autônomo rastreável antes de expor ao coletor. */
+  private boolean hasMeiAudienceProfileForPending(OprmNicheRoutineCard card) {
+    if (meiAudienceProfileRepository.existsByResearchCycleId(card.getResearchCycleId())) {
+      return true;
+    }
+    OprmRoutineResearchCycle cycle = findCycle(card.getResearchCycleId());
+    OprmNicheCandidate candidate = nicheCandidateRepository.findById(cycle.getSourceNicheId()).orElse(null);
+    return findProfileByMaterializedNiche(candidate).isPresent();
+  }
+
   /** Converte cartão aprovado em unidade de trabalho completa para o coletor OPRM. */
   private RecordEnrichedNicheMaterializerPending toPending(OprmNicheRoutineCard card) {
     OprmRoutineResearchCycle cycle = findCycle(card.getResearchCycleId());
@@ -268,14 +286,34 @@ public class BackendEnrichedNicheMaterializerService {
         card.getQualityCheckedAt());
   }
 
-  /** Reaproveita nicho existente do candidato ou cria um nicho base com dados enriquecidos do card. */
+  /** Exige perfil MEI/autônomo aprovado para impedir avanço estratégico sem público humano validado. */
+  private OprmMeiAudienceProfile requireApprovedMeiAudienceProfile(OprmRoutineResearchCycle cycle, OprmNicheCandidate candidate) {
+    return meiAudienceProfileRepository.findFirstByResearchCycleIdOrderByIdDesc(cycle.getId())
+        .or(() -> findProfileByMaterializedNiche(candidate))
+        .orElseThrow(() -> new IllegalStateException(
+            "Ciclo OPRM aguardando perfil MEI/autônomo aprovado antes da materialização final"));
+  }
+
+  /** Busca perfil MEI/autônomo por nicho já materializado quando o ciclo atual é retentativa controlada. */
+  private Optional<OprmMeiAudienceProfile> findProfileByMaterializedNiche(OprmNicheCandidate candidate) {
+    if (candidate == null || candidate.getMarketNicheId() == null) {
+      return Optional.empty();
+    }
+    return meiAudienceProfileRepository.findFirstByMarketNicheIdOrderByIdDesc(candidate.getMarketNicheId());
+  }
+
+  /** Reaproveita nicho existente do candidato/perfil MEI ou cria um nicho base com dados enriquecidos do card. */
   private MarketNiche resolveMarketNiche(
       OprmNicheRoutineCard card,
       OprmRoutineResearchCycle cycle,
       OprmNicheCandidate candidate,
+      OprmMeiAudienceProfile meiAudienceProfile,
       OprmEnrichedNicheMetaSignalService.MetaSignalPackage metaSignalPackage) {
-    MarketNiche marketNiche = candidate != null && candidate.getMarketNicheId() != null
-        ? marketNicheRepository.findById(candidate.getMarketNicheId()).orElseGet(MarketNiche::new)
+    Long existingMarketNicheId = candidate != null && candidate.getMarketNicheId() != null
+        ? candidate.getMarketNicheId()
+        : meiAudienceProfile.getMarketNicheId();
+    MarketNiche marketNiche = existingMarketNicheId != null
+        ? marketNicheRepository.findById(existingMarketNicheId).orElseGet(MarketNiche::new)
         : new MarketNiche();
     marketNiche.setName(requiredText(neutralNicheName(cycle), "neutralNicheName"));
     marketNiche.setDescription(buildMarketNicheDescription(card, cycle));

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/oprm/nichocnae/meiaudienceprofile/OprmMeiAudienceProfileRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/oprm/nichocnae/meiaudienceprofile/OprmMeiAudienceProfileRepository.java
@@ -13,6 +13,9 @@ public interface OprmMeiAudienceProfileRepository extends JpaRepository<OprmMeiA
   /** Busca o perfil de público-alvo MEI/autônomo mais recente de um ciclo de pesquisa. */
   Optional<OprmMeiAudienceProfile> findFirstByResearchCycleIdOrderByIdDesc(Long researchCycleId);
 
+  /** Busca o perfil de público-alvo MEI/autônomo mais recente vinculado a um nicho já materializado. */
+  Optional<OprmMeiAudienceProfile> findFirstByMarketNicheIdOrderByIdDesc(Long marketNicheId);
+
   /** Lista perfis de público-alvo MEI/autônomo vinculados a um CNAE. */
   List<OprmMeiAudienceProfile> findByCnaeCodeOrderByCreatedAtDesc(String cnaeCode);
 }

--- a/backend/ads-service/src/test/java/com/marketinghub/oprm/nichocnae/enrichednichematerializer/service/BackendEnrichedNicheMaterializerServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/oprm/nichocnae/enrichednichematerializer/service/BackendEnrichedNicheMaterializerServiceTest.java
@@ -1,8 +1,10 @@
 package com.marketinghub.oprm.nichocnae.enrichednichematerializer.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -19,6 +21,7 @@ import com.marketinghub.oprm.nichocnae.OprmSourceSnapshot;
 import com.marketinghub.oprm.nichocnae.enrichednichematerializer.service.completeStageExecution.CompleteEnrichedNicheMaterializerRequest;
 import com.marketinghub.oprm.nichocnae.enrichednichematerializer.service.completeStageExecution.CompleteEnrichedNicheMaterializerResponse;
 import com.marketinghub.oprm.nichocnae.enrichednichematerializer.service.pending.RecordEnrichedNicheMaterializerPending;
+import com.marketinghub.oprm.nichocnae.meiaudienceprofile.OprmMeiAudienceProfile;
 import com.marketinghub.repository.jpa.niche.MarketNicheEnrichmentProfileRepository;
 import com.marketinghub.repository.jpa.niche.MarketNicheRepository;
 import com.marketinghub.repository.jpa.oprm.cnae.OprmNicheCandidateRepository;
@@ -29,6 +32,7 @@ import com.marketinghub.repository.jpa.oprm.nichocnae.OprmResearchQueryRepositor
 import com.marketinghub.repository.jpa.oprm.nichocnae.OprmRoutineResearchCycleRepository;
 import com.marketinghub.repository.jpa.oprm.nichocnae.OprmSourceCandidateRepository;
 import com.marketinghub.repository.jpa.oprm.nichocnae.OprmSourceSnapshotRepository;
+import com.marketinghub.repository.jpa.oprm.nichocnae.meiaudienceprofile.OprmMeiAudienceProfileRepository;
 import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.List;
@@ -48,12 +52,13 @@ class BackendEnrichedNicheMaterializerServiceTest {
   private final OprmExtractedSignalRepository extractedSignalRepository = mock(OprmExtractedSignalRepository.class);
   private final MarketNicheRepository marketNicheRepository = mock(MarketNicheRepository.class);
   private final MarketNicheEnrichmentProfileRepository profileRepository = mock(MarketNicheEnrichmentProfileRepository.class);
+  private final OprmMeiAudienceProfileRepository meiAudienceProfileRepository = mock(OprmMeiAudienceProfileRepository.class);
   private final OprmEnrichedNicheMetaSignalService metaSignalService = mock(OprmEnrichedNicheMetaSignalService.class);
   private final OprmEnrichedNicheMetaSignalService.MetaSignalPackage metaSignalPackage = new OprmEnrichedNicheMetaSignalService.MetaSignalPackage(
       List.of("Salão de beleza"), List.of("Cabeleireiro"), List.of("Small business owners"));
   private final BackendEnrichedNicheMaterializerService service = new BackendEnrichedNicheMaterializerService(
       cycleRepository, cardRepository, candidateRepository, seedRepository, researchQueryRepository, sourceCandidateRepository,
-      sourceSnapshotRepository, extractedSignalRepository, marketNicheRepository, profileRepository, metaSignalService);
+      sourceSnapshotRepository, extractedSignalRepository, marketNicheRepository, profileRepository, meiAudienceProfileRepository, metaSignalService);
 
   /** Deve publicar uma unidade de trabalho completa para o coletor materializar o nicho enriquecido. */
   @Test
@@ -62,6 +67,7 @@ class BackendEnrichedNicheMaterializerServiceTest {
     OprmRoutineResearchCycle cycle = cycle();
     OprmNicheCandidate candidate = candidate();
     when(cardRepository.findPendingEnrichedNicheMaterialization(any(Pageable.class))).thenReturn(List.of(card));
+    when(meiAudienceProfileRepository.existsByResearchCycleId(1001L)).thenReturn(true);
     when(cycleRepository.findById(1001L)).thenReturn(Optional.of(cycle));
     when(candidateRepository.findById(77L)).thenReturn(Optional.of(candidate));
 
@@ -91,6 +97,7 @@ class BackendEnrichedNicheMaterializerServiceTest {
     when(cardRepository.findById(10L)).thenReturn(Optional.of(card));
     when(candidateRepository.findById(77L)).thenReturn(Optional.of(candidate));
     when(profileRepository.existsBySourceRoutineCardId(10L)).thenReturn(false);
+    when(meiAudienceProfileRepository.findFirstByResearchCycleIdOrderByIdDesc(1001L)).thenReturn(Optional.of(meiProfile()));
     when(metaSignalService.buildSignalPackage(cycle, card)).thenReturn(metaSignalPackage);
     when(marketNicheRepository.save(any(MarketNiche.class))).thenAnswer(invocation -> {
       MarketNiche niche = invocation.getArgument(0);
@@ -131,6 +138,29 @@ class BackendEnrichedNicheMaterializerServiceTest {
             && !profile.getMechanismOpportunitiesSummary().contains("Mecanismo de agenda")
             && "Gatilhos".equals(profile.getCommercialTriggers())
             && "Objeções".equals(profile.getObjections())));
+  }
+
+  /** Deve bloquear materialização quando o ciclo sintetizado não tem perfil MEI/autônomo aprovado. */
+  @Test
+  void shouldNotReleaseMaterializationWithoutMeiAudienceProfile() {
+    OprmRoutineResearchCycle cycle = cycle();
+    cycle.setStatus("ROUTINE_SYNTHESIZED");
+    OprmNicheRoutineCard card = card();
+    OprmNicheCandidate candidate = candidate();
+    when(cycleRepository.findById(1001L)).thenReturn(Optional.of(cycle));
+    when(cardRepository.findById(10L)).thenReturn(Optional.of(card));
+    when(candidateRepository.findById(77L)).thenReturn(Optional.of(candidate));
+    when(profileRepository.existsBySourceRoutineCardId(10L)).thenReturn(false);
+    when(meiAudienceProfileRepository.findFirstByResearchCycleIdOrderByIdDesc(1001L)).thenReturn(Optional.empty());
+
+    assertThatThrownBy(() -> service.complete(1001L, new CompleteEnrichedNicheMaterializerRequest(
+        1001L, 10L, "Persona", "Linguagem", "Gatilhos", "Objeções", "test")))
+        .isInstanceOf(IllegalStateException.class)
+        .hasMessageContaining("aguardando perfil MEI/autônomo");
+
+    assertThat(cycle.getStatus()).isEqualTo("ROUTINE_SYNTHESIZED");
+    verify(marketNicheRepository, never()).save(any(MarketNiche.class));
+    verify(profileRepository, never()).save(any(MarketNicheEnrichmentProfile.class));
   }
 
   /** Deve localizar registros históricos contaminados para orientar novo ciclo neutro. */
@@ -234,6 +264,22 @@ class BackendEnrichedNicheMaterializerServiceTest {
     candidate.setStatus("LIGHTLY_RESEARCHED");
     candidate.setRoutineResearchStatus("LIGHTLY_RESEARCHED");
     return candidate;
+  }
+
+  /** Cria o perfil MEI/autônomo aprovado usado como trava de liberação comercial. */
+  private OprmMeiAudienceProfile meiProfile() {
+    OprmMeiAudienceProfile profile = new OprmMeiAudienceProfile();
+    profile.setId(400L);
+    profile.setResearchCycleId(1001L);
+    profile.setRoutineCardId(10L);
+    profile.setSourceNicheCandidateId(77L);
+    profile.setCnaeCode("9602501");
+    profile.setCnaeDescription("Cabeleireiros, manicure e pedicure");
+    profile.setNeutralNicheName("Salões pequenos");
+    profile.setAudienceName("MEI dono-operador de salão pequeno");
+    profile.setCreatedAt(Instant.parse("2026-06-05T00:00:00Z"));
+    profile.setUpdatedAt(Instant.parse("2026-06-05T00:00:00Z"));
+    return profile;
   }
 
   /** Cria o perfil enriquecido final usado pelo download Markdown. */

--- a/docs/canonical/oprm-canon.v1.md
+++ b/docs/canonical/oprm-canon.v1.md
@@ -108,6 +108,7 @@ Evitar fechamento prematuro de `import run` que destrói a totalização de mark
 ## Regra obrigatória — materialização final do NichoCNAE em nicho enriquecido
 
 - Após o `oprmRoutineQualityGate` aprovar um cartão com `readyForHypothesis=true`, o pipeline OPRM NichoCNAE deve executar uma etapa final chamada `oprmEnrichedNicheMaterializer`.
+- A etapa final só pode liberar materialização, estratégia ou próximos fluxos comerciais quando existir `oprm_mei_audience_profile` rastreável para o `research_cycle_id` ou, em retentativas controladas, para o `market_niche_id` já materializado; sem esse perfil, o ciclo deve permanecer operacionalmente como “Aguardando perfil MEI/autônomo”.
 - Essa etapa final deve alimentar obrigatoriamente duas estruturas persistidas: a tabela principal de nichos (`market_niche`) e a tabela de nicho enriquecido (`market_niche_enrichment_profile`).
 - A materialização final não deve criar hipótese, experimento, oferta, campanha ou landing page; hipótese será tratada em fluxo próprio posterior.
 - O `market_niche` deve receber o cadastro operacional do nicho com nome neutro, descrição enriquecida, segmentação base e contexto de uso, sem inventar uma oferta; o nome original contaminado deve ficar apenas como auditoria.
@@ -120,6 +121,7 @@ Evitar fechamento prematuro de `import run` que destrói a totalização de mark
 
 - Um cartão aprovado pelo gate só pode ser considerado finalizado quando existir um registro correspondente em `market_niche_enrichment_profile` e um `market_niche_id` persistido.
 - A etapa deve ser idempotente por `routine_card_id` e `research_cycle_id`, evitando duplicar nichos enriquecidos quando houver retentativa do coletor.
+- Quando já existir `market_niche_id` associado ao candidato ou ao perfil MEI/autônomo, a etapa final deve atualizar esse nicho de forma controlada em vez de criar duplicata.
 - A tela `/oprm/pipeline` deve exibir a etapa final e informar o `marketNicheId`, o `enrichedNicheProfileId` e o status de materialização.
 - Ciclos em `ENRICHED_NICHE_FAILED` devem oferecer ação operacional pelo próprio front-end para abrir novo ciclo rastreável; o usuário não deve ser orientado a corrigir esse caso por acesso direto ao banco de dados.
 - O contrato da etapa final deve seguir o padrão de unidade de trabalho fechada: o endpoint `pending` precisa entregar todos os dados necessários para o coletor concluir a materialização sem buscar detalhes adicionais.

--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -449,3 +449,9 @@
 - Ajustada a instrução inicial da etapa de seed para apresentar a IA como especialista em Marketing e Comportamento do Consumidor no Digital, evitando linguagem interna como construtor/executor de pipeline na requisição exibida ao usuário.
 - Causa-raiz tratada: a tela reconstruía corretamente a requisição, mas o contrato textual da etapa ainda expunha nomenclatura operacional interna, reduzindo clareza de negócio para validação do usuário.
 - Prevenção de recorrência: adicionado teste garantindo presença da persona de marketing/comportamento e ausência das expressões técnicas antigas no prompt da etapa.
+
+## 2026-06-12 — OPRM NichoCNAE: trava por perfil MEI/autônomo aprovado
+
+- Corrigida a liberação final do OPRM para exigir `oprm_mei_audience_profile` antes de materializar `market_niche` e `market_niche_enrichment_profile`, mantendo ciclos sem perfil na etapa visual “Aguardando perfil MEI/autônomo”.
+- Causa-raiz tratada: a etapa final confiava apenas no `readyForHypothesis` do cartão e podia ser chamada diretamente sem comprovar o perfil humano MEI/autônomo que sustenta os fluxos comerciais seguintes.
+- Prevenção de recorrência: adicionado teste de regressão bloqueando ciclo `ROUTINE_SYNTHESIZED` sem perfil MEI/autônomo e regra canônica para atualizar nicho existente de forma controlada, sem duplicar `market_niche`.

--- a/frontend/src/pages/oprm/OprmPipelinePage.tsx
+++ b/frontend/src/pages/oprm/OprmPipelinePage.tsx
@@ -331,6 +331,28 @@ const cycleStageByStatus: Record<
   },
 };
 
+function hasMeiAudienceProfile(item: { audienceName?: string | null }) {
+  return Boolean(item.audienceName?.trim());
+}
+
+function getEffectiveCycleStatus(item: {
+  cycleStatus: string;
+  audienceName?: string | null;
+}) {
+  if (
+    !hasMeiAudienceProfile(item) &&
+    [
+      "MEI_AUDIENCE_SEGMENTED",
+      "LIGHTLY_RESEARCHED",
+      "MEI_AUDIENCE_READY",
+      "ENRICHED_NICHE_CREATED",
+    ].includes(item.cycleStatus)
+  ) {
+    return "ROUTINE_SYNTHESIZED";
+  }
+  return item.cycleStatus;
+}
+
 function formatStatusLabel(status: string) {
   return statusLabels[status] ?? status;
 }
@@ -564,8 +586,14 @@ export default function OprmPipelinePage() {
   } = useOprmRoutineResearchOrchestratorRecent(10);
   const reprocessCycleMutation = useReprocessOprmRoutineResearchCycle(10);
   const latestCycle = recentProcessed[0];
+  const latestEffectiveCycleStatus = latestCycle
+    ? getEffectiveCycleStatus(latestCycle)
+    : undefined;
   const latestProblemPoint = latestCycle
-    ? buildProblemPoint(latestCycle.cycleStatus, latestCycle.errorMessage)
+    ? buildProblemPoint(
+        latestEffectiveCycleStatus ?? latestCycle.cycleStatus,
+        latestCycle.errorMessage,
+      )
     : null;
   const latestRunningCycle = recentProcessed.find(
     (item) => item.cycleStatus === "RUNNING",
@@ -758,9 +786,10 @@ export default function OprmPipelinePage() {
                 </thead>
                 <tbody>
                   {recentProcessed.map((item) => {
-                    const cycleStage = getCycleStage(item.cycleStatus);
+                    const effectiveCycleStatus = getEffectiveCycleStatus(item);
+                    const cycleStage = getCycleStage(effectiveCycleStatus);
                     const problemPoint = buildProblemPoint(
-                      item.cycleStatus,
+                      effectiveCycleStatus,
                       item.errorMessage,
                     );
                     return (
@@ -825,12 +854,14 @@ export default function OprmPipelinePage() {
                         </td>
                         <td>
                           <span
-                            className={buildStatusBadgeClass(item.cycleStatus)}
+                            className={buildStatusBadgeClass(
+                              effectiveCycleStatus,
+                            )}
                           >
-                            {formatStatusLabel(item.cycleStatus)}
+                            {formatStatusLabel(effectiveCycleStatus)}
                           </span>
-                          {item.cycleStatus === "FAILED" ||
-                          item.cycleStatus === "ENRICHED_NICHE_FAILED" ? (
+                          {effectiveCycleStatus === "FAILED" ||
+                          effectiveCycleStatus === "ENRICHED_NICHE_FAILED" ? (
                             <div className="text-danger small mt-1">
                               <span className="fw-semibold">Detalhe:</span>{" "}
                               {buildFailureMessage(item.errorMessage)}
@@ -2010,6 +2041,13 @@ export default function OprmPipelinePage() {
                             </p>
                           ) : null}
                         </div>
+                      ) : latestEffectiveCycleStatus ===
+                        "ROUTINE_SYNTHESIZED" ? (
+                        <p className="text-secondary small mb-0">
+                          Ciclo #{latestCycle.researchCycleId} está aguardando
+                          perfil MEI/autônomo aprovado antes de liberar nicho,
+                          materialização ou estratégia final.
+                        </p>
                       ) : routineQualityGateDetail?.readyForHypothesis ? (
                         <p className="text-primary mb-0 small">
                           O card aprovado está pronto para alimentar nicho e


### PR DESCRIPTION
### Motivation
- Prevent the OPRM pipeline from advancing to commercial materialization/strategy when there is no approved `oprm_mei_audience_profile` for the `research_cycle_id` or for an already materialized `market_niche_id`.
- Avoid duplicating `market_niche` records by reusing and updating an existing niche when a valid MEI profile or materialized niche exists.
- Reflect the gating rule in the UI so cycles without a validated MEI audience remain visually as “Aguardando perfil MEI/autônomo” and cannot be mistaken for ready-for-materialization states.

### Description
- Backend: `BackendEnrichedNicheMaterializerService` now requires an approved `OprmMeiAudienceProfile` before completing materialization and will throw `IllegalStateException` when the cycle lacks a profile; the `complete` flow now resolves the market niche using either the candidate's `marketNicheId` or the `marketNicheId` present on the approved MEI profile to avoid duplicates.
- Backend: `listPending()` now filters pending materialization payloads to include only cards that have an associated MEI audience profile by `research_cycle_id` or by `market_niche_id` via a lookup helper.
- Repository: added `findFirstByMarketNicheIdOrderByIdDesc` to `OprmMeiAudienceProfileRepository` to allow finding profiles associated with an already materialized niche.
- Frontend: `OprmPipelinePage.tsx` computes an `effectiveCycleStatus` that maps cycles lacking `audienceName` to `ROUTINE_SYNTHESIZED` for statuses that would otherwise appear as ready, and shows a clear message: the cycle is awaiting an approved MEI/autônomo profile before materialization or commercial steps are allowed.
- Tests and docs: added a unit test `shouldNotReleaseMaterializationWithoutMeiAudienceProfile` in `BackendEnrichedNicheMaterializerServiceTest` that asserts materialization is blocked when no MEI profile exists, and updated `docs/canonical/oprm-canon.v1.md` and `docs/registros/oprm1.md` with the new rule and rationale.

### Testing
- Ran the backend unit test suite for the materializer: `../mvnw -Dtest=BackendEnrichedNicheMaterializerServiceTest test` and the targeted tests passed (5 tests, 0 failures). 
- Installed frontend deps and checked TypeScript: `npm ci` then `npm run typecheck` succeeded with no reported type errors after installing packages.
- Verified repository and UI behavior via automated unit test and local typecheck; both checks succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2b690062c883219fdada49bff7121a)