### PR TITLE
Indica nicho OPRM já materializado no pipeline

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/routineresearchorchestrator/service/BackendRoutineResearchOrchestratorService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/routineresearchorchestrator/service/BackendRoutineResearchOrchestratorService.java
@@ -1,5 +1,6 @@
 package com.marketinghub.oprm.nichocnae.routineresearchorchestrator.service;
 
+import com.marketinghub.niche.MarketNicheEnrichmentProfile;
 import com.marketinghub.oprm.cnae.OprmNicheCandidate;
 import com.marketinghub.oprm.nichocnae.OprmNicheRoutineCard;
 import com.marketinghub.oprm.nichocnae.OprmRoutineResearchCycle;
@@ -10,6 +11,7 @@ import com.marketinghub.oprm.nichocnae.routineresearchorchestrator.service.pendi
 import com.marketinghub.oprm.nichocnae.routineresearchorchestrator.service.recent.RecordRoutineResearchOrchestratorRecent;
 import com.marketinghub.oprm.nichocnae.routineresearchorchestrator.service.reprocess.RecordRoutineResearchOrchestratorReprocessResult;
 import com.marketinghub.oprm.nichocnae.routineresearchorchestrator.service.runNext.RecordRoutineResearchOrchestratorResult;
+import com.marketinghub.repository.jpa.niche.MarketNicheEnrichmentProfileRepository;
 import com.marketinghub.repository.jpa.oprm.cnae.OprmNicheCandidateRepository;
 import com.marketinghub.repository.jpa.oprm.nichocnae.OprmNicheRoutineCardRepository;
 import com.marketinghub.repository.jpa.oprm.nichocnae.OprmRoutineResearchCycleRepository;
@@ -46,6 +48,7 @@ public class BackendRoutineResearchOrchestratorService {
     private final OprmRoutineResearchCycleRepository routineResearchCycleRepository;
     private final OprmMeiAudienceProfileRepository meiAudienceProfileRepository;
     private final OprmNicheRoutineCardRepository routineCardRepository;
+    private final MarketNicheEnrichmentProfileRepository enrichmentProfileRepository;
     private final RoutineResearchNicheNameNormalizer nicheNameNormalizer = new RoutineResearchNicheNameNormalizer();
 
     /** Inicializa o serviço com os repositórios canônicos usados pela etapa zero do pipeline. */
@@ -53,11 +56,13 @@ public class BackendRoutineResearchOrchestratorService {
             OprmNicheCandidateRepository nicheCandidateRepository,
             OprmRoutineResearchCycleRepository routineResearchCycleRepository,
             OprmMeiAudienceProfileRepository meiAudienceProfileRepository,
-            OprmNicheRoutineCardRepository routineCardRepository) {
+            OprmNicheRoutineCardRepository routineCardRepository,
+            MarketNicheEnrichmentProfileRepository enrichmentProfileRepository) {
         this.nicheCandidateRepository = nicheCandidateRepository;
         this.routineResearchCycleRepository = routineResearchCycleRepository;
         this.meiAudienceProfileRepository = meiAudienceProfileRepository;
         this.routineCardRepository = routineCardRepository;
+        this.enrichmentProfileRepository = enrichmentProfileRepository;
     }
 
     /** Lista o próximo nicho CNAE pendente que seria selecionado pela etapa zero. */
@@ -281,9 +286,12 @@ public class BackendRoutineResearchOrchestratorService {
         OprmNicheRoutineCard routineCard = routineCardRepository
                 .findFirstByResearchCycleIdOrderByIdDesc(cycle.getId())
                 .orElse(null);
+        Long existingMarketNicheId = resolveExistingMarketNicheId(cycle);
         return new RecordRoutineResearchOrchestratorRecent(
                 cycle.getId(),
                 cycle.getSourceNicheId(),
+                existingMarketNicheId,
+                existingMarketNicheId != null,
                 cycle.getCnaeCode(),
                 cycle.getCnaeDescription(),
                 cycle.getNicheName(),
@@ -303,6 +311,22 @@ public class BackendRoutineResearchOrchestratorService {
                 cycle.getStartedAt(),
                 cycle.getFinishedAt(),
                 cycle.getErrorMessage());
+    }
+
+    /** Identifica o nicho de mercado já associado ao ciclo para evitar linguagem de criação duplicada na UI. */
+    private Long resolveExistingMarketNicheId(OprmRoutineResearchCycle cycle) {
+        Long candidateMarketNicheId = nicheCandidateRepository
+                .findById(cycle.getSourceNicheId())
+                .map(OprmNicheCandidate::getMarketNicheId)
+                .orElse(null);
+        if (candidateMarketNicheId != null) {
+            return candidateMarketNicheId;
+        }
+        return enrichmentProfileRepository
+                .findFirstByResearchCycleIdOrderByIdDesc(cycle.getId())
+                .map(MarketNicheEnrichmentProfile::getMarketNiche)
+                .map(marketNiche -> marketNiche == null ? null : marketNiche.getId())
+                .orElse(null);
     }
 
     /** Converte o candidato selecionável para o contrato de pendência da etapa zero. */

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/routineresearchorchestrator/service/recent/RecordRoutineResearchOrchestratorRecent.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/routineresearchorchestrator/service/recent/RecordRoutineResearchOrchestratorRecent.java
@@ -7,6 +7,8 @@ import java.time.Instant;
 public record RecordRoutineResearchOrchestratorRecent(
         Long researchCycleId,
         Long sourceNicheId,
+        Long existingMarketNicheId,
+        Boolean alreadyMaterialized,
         String cnaeCode,
         String cnaeDescription,
         String nicheName,

--- a/backend/ads-service/src/test/java/com/marketinghub/oprm/nichocnae/routineresearchorchestrator/service/BackendRoutineResearchOrchestratorServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/oprm/nichocnae/routineresearchorchestrator/service/BackendRoutineResearchOrchestratorServiceTest.java
@@ -2,15 +2,18 @@ package com.marketinghub.oprm.nichocnae.routineresearchorchestrator.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.verifyNoInteractions;
 import static org.mockito.Mockito.when;
 
+import com.marketinghub.niche.MarketNiche;
+import com.marketinghub.niche.MarketNicheEnrichmentProfile;
 import com.marketinghub.oprm.cnae.OprmNicheCandidate;
 import com.marketinghub.oprm.nichocnae.OprmRoutineResearchCycle;
 import com.marketinghub.oprm.nichocnae.routineresearchorchestrator.service.pending.RecordRoutineResearchOrchestratorPending;
 import com.marketinghub.oprm.nichocnae.routineresearchorchestrator.service.recent.RecordRoutineResearchOrchestratorRecent;
 import com.marketinghub.oprm.nichocnae.routineresearchorchestrator.service.runNext.RecordRoutineResearchOrchestratorResult;
+import com.marketinghub.repository.jpa.niche.MarketNicheEnrichmentProfileRepository;
 import com.marketinghub.repository.jpa.oprm.cnae.OprmNicheCandidateRepository;
 import com.marketinghub.repository.jpa.oprm.nichocnae.OprmNicheRoutineCardRepository;
 import com.marketinghub.repository.jpa.oprm.nichocnae.OprmRoutineResearchCycleRepository;
@@ -38,6 +41,8 @@ class BackendRoutineResearchOrchestratorServiceTest {
 
     @Mock private OprmNicheRoutineCardRepository routineCardRepository;
 
+    @Mock private MarketNicheEnrichmentProfileRepository enrichmentProfileRepository;
+
     @InjectMocks private BackendRoutineResearchOrchestratorService service;
 
     /** Deve listar o próximo candidato pendente sem usar a consulta com bloqueio pessimista. */
@@ -57,7 +62,8 @@ class BackendRoutineResearchOrchestratorServiceTest {
         ArgumentCaptor<Pageable> pageableCaptor = ArgumentCaptor.forClass(Pageable.class);
         verify(nicheCandidateRepository).findNextPendingRoutineResearchCandidatePreview(pageableCaptor.capture());
         assertThat(pageableCaptor.getValue().getPageSize()).isEqualTo(1);
-        verifyNoInteractions(routineResearchCycleRepository);
+        verify(routineResearchCycleRepository, never())
+                .findAllByOrderByStartedAtDesc(any(Pageable.class));
     }
 
     /** Deve listar os últimos nichos processados pela etapa zero com horário do ciclo criado. */
@@ -73,6 +79,8 @@ class BackendRoutineResearchOrchestratorServiceTest {
         assertThat(result).hasSize(2);
         assertThat(result.getFirst().researchCycleId()).isEqualTo(321L);
         assertThat(result.getFirst().sourceNicheId()).isEqualTo(55L);
+        assertThat(result.getFirst().existingMarketNicheId()).isNull();
+        assertThat(result.getFirst().alreadyMaterialized()).isFalse();
         assertThat(result.getFirst().nicheName()).isEqualTo("Cabeleireiros e manicures");
         assertThat(result.getFirst().originalNicheName()).isEqualTo("Cabeleireiros e manicures");
         assertThat(result.getFirst().neutralNicheName()).isEqualTo("Cabeleireiros e manicures");
@@ -86,7 +94,44 @@ class BackendRoutineResearchOrchestratorServiceTest {
         ArgumentCaptor<Pageable> pageableCaptor = ArgumentCaptor.forClass(Pageable.class);
         verify(routineResearchCycleRepository).findAllByOrderByStartedAtDesc(pageableCaptor.capture());
         assertThat(pageableCaptor.getValue().getPageSize()).isEqualTo(10);
-        verifyNoInteractions(nicheCandidateRepository);
+    }
+
+    /** Deve indicar o nicho existente quando o candidato já foi materializado em MarketNiche. */
+    @Test
+    void listRecentProcessedReturnsExistingMarketNicheAssociation() {
+        OprmRoutineResearchCycle cycle = cycle(321L, 55L, "Cabeleireiros e manicures", "2026-06-03T01:00:00Z");
+        OprmNicheCandidate candidate = candidate();
+        candidate.setMarketNicheId(987L);
+        when(routineResearchCycleRepository.findAllByOrderByStartedAtDesc(any(Pageable.class)))
+                .thenReturn(List.of(cycle));
+        when(nicheCandidateRepository.findById(55L)).thenReturn(Optional.of(candidate));
+
+        List<RecordRoutineResearchOrchestratorRecent> result = service.listRecentProcessed(10);
+
+        assertThat(result).hasSize(1);
+        assertThat(result.getFirst().existingMarketNicheId()).isEqualTo(987L);
+        assertThat(result.getFirst().alreadyMaterialized()).isTrue();
+    }
+
+    /** Deve indicar o nicho existente pelo perfil enriquecido quando o candidato não tem vínculo direto. */
+    @Test
+    void listRecentProcessedReturnsMarketNicheAssociationFromEnrichmentProfile() {
+        OprmRoutineResearchCycle cycle = cycle(321L, 55L, "Cabeleireiros e manicures", "2026-06-03T01:00:00Z");
+        MarketNiche marketNiche = new MarketNiche();
+        marketNiche.setId(654L);
+        MarketNicheEnrichmentProfile profile = new MarketNicheEnrichmentProfile();
+        profile.setMarketNiche(marketNiche);
+        when(routineResearchCycleRepository.findAllByOrderByStartedAtDesc(any(Pageable.class)))
+                .thenReturn(List.of(cycle));
+        when(nicheCandidateRepository.findById(55L)).thenReturn(Optional.empty());
+        when(enrichmentProfileRepository.findFirstByResearchCycleIdOrderByIdDesc(321L))
+                .thenReturn(Optional.of(profile));
+
+        List<RecordRoutineResearchOrchestratorRecent> result = service.listRecentProcessed(10);
+
+        assertThat(result).hasSize(1);
+        assertThat(result.getFirst().existingMarketNicheId()).isEqualTo(654L);
+        assertThat(result.getFirst().alreadyMaterialized()).isTrue();
     }
 
     /** Deve criar novo ciclo imediatamente ao reprocessar um ciclo falho. */

--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -449,3 +449,9 @@
 - Ajustada a instrução inicial da etapa de seed para apresentar a IA como especialista em Marketing e Comportamento do Consumidor no Digital, evitando linguagem interna como construtor/executor de pipeline na requisição exibida ao usuário.
 - Causa-raiz tratada: a tela reconstruía corretamente a requisição, mas o contrato textual da etapa ainda expunha nomenclatura operacional interna, reduzindo clareza de negócio para validação do usuário.
 - Prevenção de recorrência: adicionado teste garantindo presença da persona de marketing/comportamento e ausência das expressões técnicas antigas no prompt da etapa.
+
+## 2026-06-12 — OPRM Pipeline: indicação de nicho já materializado
+
+- A tela `/oprm/pipeline` passou a diferenciar ciclos que já possuem `market_niche` associado, exibindo o badge “Nicho já existe” e priorizando a ação “Abrir nicho existente”.
+- O endpoint de últimos ciclos processados agora informa `existingMarketNicheId` e `alreadyMaterialized`, evitando que a interface induza o usuário a criar um novo nicho quando o ativo comercial já foi materializado.
+- Causa-raiz tratada: a tabela mostrava o ciclo apenas como execução do pipeline e não levava para o nicho operacional já criado, gerando ambiguidade entre atualizar/consultar um nicho existente e criar novamente.

--- a/docs/swagger/oprm-nichocnae-swagger.yaml
+++ b/docs/swagger/oprm-nichocnae-swagger.yaml
@@ -720,6 +720,14 @@ components:
         sourceNicheId:
           type: integer
           format: int64
+        existingMarketNicheId:
+          type: integer
+          format: int64
+          nullable: true
+          description: ID do market_niche já associado ao ciclo/candidato, quando o nicho já foi materializado.
+        alreadyMaterialized:
+          type: boolean
+          description: Indica se o ciclo já possui market_niche associado e não deve ser tratado como criação de novo nicho.
         cnaeCode:
           type: string
           example: '9602501'

--- a/frontend/src/api/oprm/useOprmRoutineResearchOrchestratorRecent.ts
+++ b/frontend/src/api/oprm/useOprmRoutineResearchOrchestratorRecent.ts
@@ -7,6 +7,8 @@ export const oprmRoutineResearchOrchestratorRecentQueryKey = (limit = 10) =>
 export interface OprmRoutineResearchOrchestratorRecent {
   researchCycleId: number;
   sourceNicheId: number;
+  existingMarketNicheId?: number | null;
+  alreadyMaterialized?: boolean | null;
   cnaeCode: string;
   cnaeDescription: string;
   nicheName: string;
@@ -47,6 +49,8 @@ async function fetchRecentProcessed(
 export interface OprmRoutineResearchOrchestratorReprocessResult {
   researchCycleId: number;
   sourceNicheId: number;
+  existingMarketNicheId?: number | null;
+  alreadyMaterialized?: boolean | null;
   cnaeCode: string;
   cnaeDescription: string;
   previousCycleStatus: string;

--- a/frontend/src/pages/oprm/OprmPipelinePage.tsx
+++ b/frontend/src/pages/oprm/OprmPipelinePage.tsx
@@ -225,7 +225,7 @@ const statusLabels: Record<string, string> = {
   COMPLETED: "Concluído",
   ROUTINE_SYNTHESIZED: "Rotina sintetizada",
   MEI_AUDIENCE_SEGMENTED: "Perfil MEI/autônomo criado",
-  ENRICHED_NICHE_CREATED: "Nicho enriquecido criado",
+  ENRICHED_NICHE_CREATED: "Nicho enriquecido disponível",
   ENRICHED_NICHE_FAILED: "Falha no nicho enriquecido",
 };
 
@@ -309,9 +309,9 @@ const cycleStageByStatus: Record<
       "badge text-bg-secondary-subtle border border-secondary-subtle text-secondary",
   },
   ENRICHED_NICHE_CREATED: {
-    label: "Finalizado · Nicho enriquecido criado",
+    label: "Finalizado · Nicho enriquecido disponível",
     description:
-      "A materialização final foi concluída e o nicho já pode alimentar os próximos fluxos de oportunidade e produto.",
+      "A materialização final foi concluída e o nicho existente já pode alimentar os próximos fluxos de oportunidade e produto.",
     badgeClass:
       "badge text-bg-success-subtle border border-success-subtle text-success",
   },
@@ -374,6 +374,13 @@ function getNewResearchCycleButtonLabel(status: string) {
     return "Refazer pelo front-end";
   }
   return "Pesquisar novamente";
+}
+
+function isAlreadyMaterialized(item: {
+  alreadyMaterialized?: boolean | null;
+  existingMarketNicheId?: number | null;
+}) {
+  return Boolean(item.alreadyMaterialized || item.existingMarketNicheId);
 }
 
 function getNewResearchCycleButtonClass(status: string) {
@@ -775,10 +782,15 @@ export default function OprmPipelinePage() {
                           <span className="text-secondary small d-block">
                             Original: {getOriginalName(item)}
                           </span>
-                          <span className="text-secondary small">
+                          <span className="text-secondary small d-block">
                             Ciclo #{item.researchCycleId} ·{" "}
                             {formatResearchMode(item.researchMode)}
                           </span>
+                          {isAlreadyMaterialized(item) ? (
+                            <span className="badge text-bg-success-subtle border border-success-subtle text-success mt-1">
+                              Nicho já existe
+                            </span>
+                          ) : null}
                         </td>
                         <td>
                           <span className="text-nowrap">{item.cnaeCode}</span>
@@ -864,7 +876,14 @@ export default function OprmPipelinePage() {
                           ) : null}
                         </td>
                         <td className="text-end">
-                          {canCreateNewResearchCycle(item.cycleStatus) ? (
+                          {item.existingMarketNicheId ? (
+                            <Link
+                              className="btn btn-outline-success btn-sm text-nowrap"
+                              to={`/niches/${item.existingMarketNicheId}`}
+                            >
+                              Abrir nicho existente
+                            </Link>
+                          ) : canCreateNewResearchCycle(item.cycleStatus) ? (
                             <button
                               type="button"
                               className={getNewResearchCycleButtonClass(
@@ -1067,6 +1086,11 @@ export default function OprmPipelinePage() {
                           >
                             {formatStatusLabel(latestCycle.cycleStatus)}
                           </span>
+                          {isAlreadyMaterialized(latestCycle) ? (
+                            <span className="badge text-bg-success-subtle border border-success-subtle text-success d-block mt-1">
+                              Nicho já existe
+                            </span>
+                          ) : null}
                           {latestCycle.finishedAt ? (
                             <span className="text-secondary d-block mt-1">
                               Finalizado em{" "}


### PR DESCRIPTION
### Motivation
- Evitar que a interface do pipeline trate ciclos já materializados como criação de novo nicho, fornecendo sinal claro quando um `market_niche` já existe para o ciclo/processamento.
- Facilitar a navegação operacional para o nicho existente e reduzir risco de contaminação de artefato com linguagem que sugira criação indevida.

### Description
- Adiciona os campos `existingMarketNicheId` e `alreadyMaterialized` ao contrato de `recent-processed` no backend (`RecordRoutineResearchOrchestratorRecent`) e ao tipo TypeScript usado pelo frontend (`useOprmRoutineResearchOrchestratorRecent`).
- Implementa em `BackendRoutineResearchOrchestratorService` a resolução do vínculo de `market_niche` consultando primeiro o candidato CNAE (`OprmNicheCandidate.marketNicheId`) e, como fallback, o `MarketNicheEnrichmentProfile` mais recente associado ao ciclo; injeta o repositório `MarketNicheEnrichmentProfileRepository` e expõe o ID no DTO.
- Atualiza a UI em `OprmPipelinePage.tsx` para exibir badge "Nicho já existe", alterar o rótulo de status para "Nicho enriquecido disponível" quando aplicável e priorizar a ação principal como "Abrir nicho existente" (link para `/niches/{id}`) em vez de oferecer criação/reprocessamento enganosos.
- Atualiza o Swagger (`docs/swagger/oprm-nichocnae-swagger.yaml`), adiciona entrada no registro operacional (`docs/registros/oprm1.md`) e amplia os testes unitários (`BackendRoutineResearchOrchestratorServiceTest`) para cobrir os casos de associação por candidato e por perfil enriquecido.

### Testing
- Executado o teste unitário Java `BackendRoutineResearchOrchestratorServiceTest` com `mvn -Dtest=BackendRoutineResearchOrchestratorServiceTest test` e a suíte relacionada passou conforme logs gerados; status: sucesso.
- Instaladas dependências do frontend com `npm ci` e executado `npm run typecheck` para validação TypeScript, sem erros após instalação; status: sucesso.
- Verificações estáticas básicas: `git diff --check` foi executado sem problemas; status: sucesso.
- Tentativas de executar `spotless:apply` via Maven falharam no ambiente por ausência do plugin/prefixo disponível no reator, portanto a formatação automática do backend não foi aplicada aqui; status: não aplicável (aviso).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2b68f77d948321ab3937e32273800e)