### PR TITLE
Allow reprocessing of enriched niche materializations and relax DB uniqueness constraints

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/enrichednichematerializer/service/BackendEnrichedNicheMaterializerService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/enrichednichematerializer/service/BackendEnrichedNicheMaterializerService.java
@@ -122,20 +122,6 @@ public class BackendEnrichedNicheMaterializerService {
     }
     OprmNicheCandidate candidate = nicheCandidateRepository.findById(cycle.getSourceNicheId()).orElse(null);
     OprmMeiAudienceProfile meiAudienceProfile = requireApprovedMeiAudienceProfile(cycle, candidate);
-    if (enrichmentProfileRepository.existsBySourceRoutineCardId(card.getId())) {
-      MarketNicheEnrichmentProfile existing = enrichmentProfileRepository.findFirstByResearchCycleIdOrderByIdDesc(researchCycleId)
-          .orElseThrow(() -> new IllegalStateException("routine card already materialized without retrievable profile"));
-      publishMetaSignalsForExistingProfile(cycle, card, existing);
-      return new CompleteEnrichedNicheMaterializerResponse(
-          researchCycleId,
-          card.getId(),
-          existing.getMarketNiche().getId(),
-          existing.getId(),
-          cycle.getStatus(),
-          existing.getCreatedAt(),
-          "Cartão já materializado anteriormente; sinais do nicho existente foram revisados sem criar novo market_niche.");
-    }
-
     OprmEnrichedNicheMetaSignalService.MetaSignalPackage metaSignalPackage = metaSignalService.buildSignalPackage(cycle, card);
     Optional<MarketNiche> existingMarketNicheByCnaeAndNeutralName = findExistingMarketNicheByCnaeAndNeutralName(cycle);
     boolean existingMatchedByCnaeAndNeutralName = existingMarketNicheByCnaeAndNeutralName.isPresent();
@@ -252,17 +238,6 @@ public class BackendEnrichedNicheMaterializerService {
         profile == null ? scoreOrZero(card == null ? null : card.getSourceDiversityScore()) : profile.getSourceDiversityScore(),
         profile == null ? scoreOrZero(card == null ? null : card.getSolutionLanguageRiskScore()) : profile.getSolutionLanguageRiskScore(),
         profile == null ? null : profile.getCreatedAt());
-  }
-
-  /** Atualiza sinais Meta Ads quando uma materialização idempotente já possui perfil final. */
-  private void publishMetaSignalsForExistingProfile(
-      OprmRoutineResearchCycle cycle,
-      OprmNicheRoutineCard card,
-      MarketNicheEnrichmentProfile existing) {
-    OprmEnrichedNicheMetaSignalService.MetaSignalPackage metaSignalPackage = metaSignalService.buildSignalPackage(cycle, card);
-    MarketNiche marketNiche = existing.getMarketNiche();
-    applyMetaSignalsToNiche(marketNiche, metaSignalPackage);
-    marketNicheRepository.save(marketNiche);
   }
 
   /** Confirma se a pendência final tem perfil MEI/autônomo rastreável antes de expor ao coletor. */

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/niche/MarketNicheEnrichmentProfileRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/niche/MarketNicheEnrichmentProfileRepository.java
@@ -10,9 +10,6 @@ import org.springframework.data.repository.query.Param;
 
 /** Repositório responsável por persistir e consultar perfis enriquecidos de nichos. */
 public interface MarketNicheEnrichmentProfileRepository extends JpaRepository<MarketNicheEnrichmentProfile, Long> {
-  /** Verifica se um cartão de rotina já foi materializado como nicho enriquecido. */
-  boolean existsBySourceRoutineCardId(Long sourceRoutineCardId);
-
   /** Busca o perfil enriquecido materializado para um ciclo de pesquisa de rotina. */
   Optional<MarketNicheEnrichmentProfile> findFirstByResearchCycleIdOrderByIdDesc(Long researchCycleId);
 

--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-12-oprm-enriched-niche-reprocessing.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-12-oprm-enriched-niche-reprocessing.yaml
@@ -1,0 +1,75 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-06-12-01-oprm-enriched-niche-drop-unique-card-index
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - onError: HALT
+        - dbms:
+            type: mysql
+        - indexExists:
+            tableName: market_niche_enrichment_profile
+            indexName: uk_market_niche_enrichment_profile_card
+      changes:
+        - sql:
+            splitStatements: true
+            stripComments: true
+            sql: |
+              DROP INDEX uk_market_niche_enrichment_profile_card ON market_niche_enrichment_profile;
+  - changeSet:
+      id: 2026-06-12-02-oprm-enriched-niche-drop-unique-cycle-index
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - onError: HALT
+        - dbms:
+            type: mysql
+        - indexExists:
+            tableName: market_niche_enrichment_profile
+            indexName: uk_market_niche_enrichment_profile_cycle
+      changes:
+        - sql:
+            splitStatements: true
+            stripComments: true
+            sql: |
+              DROP INDEX uk_market_niche_enrichment_profile_cycle ON market_niche_enrichment_profile;
+  - changeSet:
+      id: 2026-06-12-03-oprm-enriched-niche-reprocess-card-index
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - onError: HALT
+        - dbms:
+            type: mysql
+        - tableExists:
+            tableName: market_niche_enrichment_profile
+        - not:
+            indexExists:
+              tableName: market_niche_enrichment_profile
+              indexName: idx_market_niche_enrichment_profile_card
+      changes:
+        - sql:
+            splitStatements: true
+            stripComments: true
+            sql: |
+              CREATE INDEX idx_market_niche_enrichment_profile_card ON market_niche_enrichment_profile (routine_card_id);
+  - changeSet:
+      id: 2026-06-12-04-oprm-enriched-niche-reprocess-cycle-index
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - onError: HALT
+        - dbms:
+            type: mysql
+        - tableExists:
+            tableName: market_niche_enrichment_profile
+        - not:
+            indexExists:
+              tableName: market_niche_enrichment_profile
+              indexName: idx_market_niche_enrichment_profile_cycle
+      changes:
+        - sql:
+            splitStatements: true
+            stripComments: true
+            sql: |
+              CREATE INDEX idx_market_niche_enrichment_profile_cycle ON market_niche_enrichment_profile (research_cycle_id);

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -51,6 +51,9 @@ databaseChangeLog:
       file: changesets/2026-06-06-oprm-enriched-niche-materializer-routine-fields.yaml
       relativeToChangelogFile: true
   - include:
+      file: changesets/2026-06-12-oprm-enriched-niche-reprocessing.yaml
+      relativeToChangelogFile: true
+  - include:
       file: changesets/2026-06-07-oprm-nichocnae-openai-stage-flags.yaml
       relativeToChangelogFile: true
   - include:

--- a/backend/ads-service/src/test/java/com/marketinghub/oprm/nichocnae/enrichednichematerializer/service/BackendEnrichedNicheMaterializerServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/oprm/nichocnae/enrichednichematerializer/service/BackendEnrichedNicheMaterializerServiceTest.java
@@ -96,7 +96,6 @@ class BackendEnrichedNicheMaterializerServiceTest {
     when(cycleRepository.findById(1001L)).thenReturn(Optional.of(cycle));
     when(cardRepository.findById(10L)).thenReturn(Optional.of(card));
     when(candidateRepository.findById(77L)).thenReturn(Optional.of(candidate));
-    when(profileRepository.existsBySourceRoutineCardId(10L)).thenReturn(false);
     when(meiAudienceProfileRepository.findFirstByResearchCycleIdOrderByIdDesc(1001L)).thenReturn(Optional.of(meiProfile()));
     when(metaSignalService.buildSignalPackage(cycle, card)).thenReturn(metaSignalPackage);
     when(marketNicheRepository.save(any(MarketNiche.class))).thenAnswer(invocation -> {
@@ -140,6 +139,45 @@ class BackendEnrichedNicheMaterializerServiceTest {
             && "Objeções".equals(profile.getObjections())));
   }
 
+  /** Deve permitir reprocessar o mesmo cartão criando novo perfil para o mesmo nicho existente. */
+  @Test
+  void shouldCreateNewProfileWhenReprocessingAlreadyMaterializedCard() {
+    OprmRoutineResearchCycle cycle = cycle();
+    OprmNicheRoutineCard card = card();
+    OprmNicheCandidate candidate = candidate();
+    MarketNiche existingNiche = new MarketNiche();
+    existingNiche.setId(200L);
+    MarketNicheEnrichmentProfile previousProfile = profile(existingNiche);
+    when(cycleRepository.findById(1001L)).thenReturn(Optional.of(cycle));
+    when(cardRepository.findById(10L)).thenReturn(Optional.of(card));
+    when(candidateRepository.findById(77L)).thenReturn(Optional.of(candidate));
+    when(meiAudienceProfileRepository.findFirstByResearchCycleIdOrderByIdDesc(1001L)).thenReturn(Optional.of(meiProfile()));
+    when(profileRepository.findMaterializedByCnaeAndNormalizedNeutralName(
+        org.mockito.ArgumentMatchers.eq("9602501"),
+        org.mockito.ArgumentMatchers.eq("salões pequenos"),
+        any(Pageable.class)))
+        .thenReturn(List.of(previousProfile));
+    when(metaSignalService.buildSignalPackage(cycle, card)).thenReturn(metaSignalPackage);
+    when(marketNicheRepository.save(any(MarketNiche.class))).thenAnswer(invocation -> invocation.getArgument(0));
+    when(profileRepository.save(any(MarketNicheEnrichmentProfile.class))).thenAnswer(invocation -> {
+      MarketNicheEnrichmentProfile profile = invocation.getArgument(0);
+      profile.setId(301L);
+      return profile;
+    });
+
+    CompleteEnrichedNicheMaterializerResponse response = service.complete(1001L, new CompleteEnrichedNicheMaterializerRequest(
+        1001L, 10L, "Persona reprocessada", "Linguagem reprocessada", "Gatilhos", "Objeções", "test"));
+
+    assertThat(response.marketNicheId()).isEqualTo(200L);
+    assertThat(response.enrichedNicheProfileId()).isEqualTo(301L);
+    assertThat(response.cycleStatus()).isEqualTo("ENRICHED_NICHE_UPDATED");
+    verify(profileRepository).save(org.mockito.ArgumentMatchers.argThat(profile ->
+        Long.valueOf(200L).equals(profile.getMarketNiche().getId())
+            && Long.valueOf(1001L).equals(profile.getResearchCycleId())
+            && Long.valueOf(10L).equals(profile.getSourceRoutineCardId())
+            && "Persona reprocessada".equals(profile.getPersonaSummary())));
+  }
+
   /** Deve bloquear materialização quando o ciclo sintetizado não tem perfil MEI/autônomo aprovado. */
   @Test
   void shouldNotReleaseMaterializationWithoutMeiAudienceProfile() {
@@ -150,7 +188,6 @@ class BackendEnrichedNicheMaterializerServiceTest {
     when(cycleRepository.findById(1001L)).thenReturn(Optional.of(cycle));
     when(cardRepository.findById(10L)).thenReturn(Optional.of(card));
     when(candidateRepository.findById(77L)).thenReturn(Optional.of(candidate));
-    when(profileRepository.existsBySourceRoutineCardId(10L)).thenReturn(false);
     when(meiAudienceProfileRepository.findFirstByResearchCycleIdOrderByIdDesc(1001L)).thenReturn(Optional.empty());
 
     assertThatThrownBy(() -> service.complete(1001L, new CompleteEnrichedNicheMaterializerRequest(

--- a/docs/canonical/oprm-canon.v1.md
+++ b/docs/canonical/oprm-canon.v1.md
@@ -119,9 +119,10 @@ Evitar fechamento prematuro de `import run` que destrói a totalização de mark
 
 ## Critério de efetividade — nicho enriquecido materializado
 
-- Um cartão aprovado pelo gate só pode ser considerado finalizado quando existir um registro correspondente em `market_niche_enrichment_profile` e um `market_niche_id` persistido.
-- A etapa deve ser idempotente por `routine_card_id` e `research_cycle_id`, evitando duplicar nichos enriquecidos quando houver retentativa do coletor.
-- Quando já existir `market_niche_id` associado ao candidato ou ao perfil MEI/autônomo, a etapa final deve atualizar esse nicho de forma controlada em vez de criar duplicata.
+- Um cartão aprovado pelo gate só pode ser considerado finalizado quando existir pelo menos um registro correspondente em `market_niche_enrichment_profile` e um `market_niche_id` persistido.
+- É permitido gerar múltiplos registros em `market_niche_enrichment_profile` para o mesmo `market_niche_id`, inclusive para o mesmo `routine_card_id` ou `research_cycle_id`, quando houver reprocessamento operacional; cada registro deve preservar a auditoria histórica da execução que o criou.
+- Reprocessamentos devem reaproveitar e atualizar o `market_niche` existente de forma controlada, criando novo perfil enriquecido rastreável em vez de bloquear a execução por idempotência rígida.
+- Quando já existir `market_niche_id` associado ao candidato, ao perfil MEI/autônomo ou a materialização anterior do mesmo CNAE/nome neutro, a etapa final deve atualizar esse nicho de forma controlada em vez de criar duplicata.
 - A tela `/oprm/pipeline` deve exibir a etapa final e informar o `marketNicheId`, o `enrichedNicheProfileId` e o status de materialização.
 - Ciclos em `ENRICHED_NICHE_FAILED` devem oferecer ação operacional pelo próprio front-end para abrir novo ciclo rastreável; o usuário não deve ser orientado a corrigir esse caso por acesso direto ao banco de dados.
 - O contrato da etapa final deve seguir o padrão de unidade de trabalho fechada: o endpoint `pending` precisa entregar todos os dados necessários para o coletor concluir a materialização sem buscar detalhes adicionais.

--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -461,3 +461,9 @@
 - Corrigida a causa-raiz da falha ArchUnit no OPRM sem afrouxar a regra de arquitetura: removido o `record` interno que fazia o materializador final parecer uma nova classe dependente de `MarketNiche` fora da exceção nominal.
 - A etapa final de materialização agora resolve o nicho existente por CNAE/nome neutro com variáveis locais e salva explicitamente o `market_niche` antes de criar o perfil enriquecido, mantendo a indicação correta de criação versus atualização.
 - A consulta usada pela etapa zero para indicar nicho já materializado foi movida para o repositório OPRM, evitando dependência direta do serviço OPRM em repositórios/classes do pacote de nicho e mantendo a UI informando “nicho já existe” sem violar o isolamento modular.
+
+## 2026-06-12 — Reprocessamento de perfil enriquecido OPRM
+
+- Ajustada a regra canônica do NichoCNAE para permitir múltiplos registros em `market_niche_enrichment_profile` para o mesmo nicho quando houver reprocessamento operacional.
+- A materialização final passa a reaproveitar o `market_niche` existente e criar um novo perfil enriquecido rastreável, preservando histórico em vez de bloquear pela materialização anterior.
+- Criado changelog incremental para remover unicidade rígida por `routine_card_id` e `research_cycle_id` e manter índices não únicos de consulta.


### PR DESCRIPTION
### Motivation

- Permit controlled reprocessing of an already-materialized routine card so the system can create a new `market_niche_enrichment_profile` while reusing/updating the existing `market_niche` instead of blocking execution by rigid idempotency.
- Preserve historical auditability for multiple enrichment runs by allowing multiple profiles for the same `market_niche_id` and keeping the materialization traceable to `research_cycle_id` and `routine_card_id`.
- Adjust database constraints and indexes to support repeatable reprocessing without uniqueness conflicts on `routine_card_id`/`research_cycle_id`.

### Description

- Removed the early-return idempotency check that used `existsBySourceRoutineCardId` in `BackendEnrichedNicheMaterializerService.complete` and deleted the now-unused helper `publishMetaSignalsForExistingProfile`. 
- Deleted `existsBySourceRoutineCardId` from `MarketNicheEnrichmentProfileRepository` and rely on existing lookup by CNAE + normalized neutral name to detect or reuse `market_niche` while always creating a new enrichment profile. 
- Added a Liquibase changeset `changesets/2026-06-12-oprm-enriched-niche-reprocessing.yaml` and included it in `db.changelog-master.yaml` to drop the unique indexes and create non-unique lookup indexes `idx_market_niche_enrichment_profile_card` and `idx_market_niche_enrichment_profile_cycle`. 
- Updated tests in `BackendEnrichedNicheMaterializerServiceTest` to remove obsolete mocks and to add `shouldCreateNewProfileWhenReprocessingAlreadyMaterializedCard` which asserts a new profile is created and linked to the existing `market_niche`; also adjusted other tests accordingly. 
- Updated canonical/docs (`oprm-canon.v1.md`, `oprm1.md`) to record the changed canonical rule allowing multiple enrichment profiles per niche and describing the reprocessing behavior.

### Testing

- Ran unit tests including `BackendEnrichedNicheMaterializerServiceTest`, and the new test `shouldCreateNewProfileWhenReprocessingAlreadyMaterializedCard` passed. 
- Executed the test suite via the build (unit tests) and all modified tests succeeded. 
- Database changelog was added and validated in CI migration checks (Liquibase include added to `db.changelog-master.yaml`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2b762f9fc883219a736fdb2cdec716)