### PR TITLE
OPRM CNAE detail: show description, scores/volumes and allow manual NichoCNAE pipeline run with per-stage cards

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/cnae/service/OprmCnaeOpportunityPersistenceService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/cnae/service/OprmCnaeOpportunityPersistenceService.java
@@ -85,6 +85,16 @@ public class OprmCnaeOpportunityPersistenceService {
     }
 
     /**
+     * Retorna o score de oportunidade já calculado para um CNAE específico.
+     */
+    @Transactional(readOnly = true)
+    public OprmCnaeOpportunityScoreResponseDto getScore(String cnaeCode) {
+        return scoreRepository.findById(cnaeCode)
+                .map(this::toScoreResponse)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Score OPRM não encontrado para CNAE: " + cnaeCode));
+    }
+
+    /**
      * Lista scores já calculados pelo OPRM, com filtro opcional para retornar somente itens ainda não enriquecidos.
      */
     @Transactional(readOnly = true)

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/cnae/web/OprmCnaeOpportunityController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/cnae/web/OprmCnaeOpportunityController.java
@@ -55,6 +55,14 @@ public class OprmCnaeOpportunityController {
     }
 
     /**
+     * Retorna o score OPRM calculado para o CNAE informado.
+     */
+    @GetMapping("/cnaes/{cnaeCode}/opportunity-score")
+    public OprmCnaeOpportunityScoreResponseDto getScore(@PathVariable String cnaeCode) {
+        return service.getScore(cnaeCode);
+    }
+
+    /**
      * Lista os melhores scores já calculados para enriquecimento automático pelo OPRM.
      */
     @GetMapping("/cnaes/opportunity-scores/top")

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/market/service/OprmMarketImportService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/market/service/OprmMarketImportService.java
@@ -12,11 +12,10 @@ import com.marketinghub.repository.jpa.oprm.market.OprmCnpjImportRunRepository;
 import com.marketinghub.repository.jpa.oprm.market.OprmMarketSizeByCnaeRepository;
 import java.time.Instant;
 import java.util.List;
-import com.marketinghub.oprm.market.dto.OprmTopCnaeMarketVolumeDto;
 import com.marketinghub.oprm.market.exception.SQLException;
-import org.springframework.data.domain.PageRequest;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
@@ -350,5 +349,14 @@ public class OprmMarketImportService {
         int safePage = Math.max(page, 0);
         int safeSize = Math.min(Math.max(size, 1), 100);
         return marketSizeRepository.findTopByLatestSnapshot(PageRequest.of(safePage, safeSize));
+    }
+
+    /**
+     * Retorna os dados de volume e score do CNAE informado no snapshot mais recente.
+     */
+    @Transactional(readOnly = true)
+    public OprmTopCnaeMarketVolumeDto getLatestCnaeMarketVolume(String cnaeCode) {
+        return marketSizeRepository.findLatestSnapshotByCnaeCode(cnaeCode)
+                .orElseThrow(() -> new ResponseStatusException(NOT_FOUND, "CNAE não encontrado no snapshot mais recente: " + cnaeCode));
     }
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/market/web/OprmMarketImportController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/market/web/OprmMarketImportController.java
@@ -103,4 +103,12 @@ public class OprmMarketImportController {
             @RequestParam(defaultValue = "50") int size) {
         return service.listTopCnaesByMarketVolume(page, size);
     }
+
+    /**
+     * Retorna o volume e o score do CNAE informado no snapshot mais recente.
+     */
+    @GetMapping("/cnaes/{cnaeCode}/latest-volume")
+    public OprmTopCnaeMarketVolumeDto getLatestCnaeVolume(@PathVariable String cnaeCode) {
+        return service.getLatestCnaeMarketVolume(cnaeCode);
+    }
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/routineresearchcycle/service/BackendRoutineResearchCycleService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/routineresearchcycle/service/BackendRoutineResearchCycleService.java
@@ -32,6 +32,14 @@ public class BackendRoutineResearchCycleService {
         .toList();
   }
 
+  /** Lista execuções do ciclo de pesquisa de rotina associadas ao CNAE informado. */
+  @Transactional(readOnly = true)
+  public List<RoutineResearchCycleExecutionSummaryResponse> listStageExecutionsByCnae(String cnaeCode) {
+    return routineResearchCycleRepository.findByCnaeCodeOrderByStartedAtDesc(cnaeCode).stream()
+        .map(this::toSummary)
+        .toList();
+  }
+
   /** Lista execuções do ciclo de pesquisa de rotina associadas a um nicho CNAE de origem. */
   @Transactional(readOnly = true)
   public List<RoutineResearchCycleExecutionSummaryResponse> listStageExecutions(Long sourceNicheId) {

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/routineresearchcycle/web/BackendRoutineResearchCycleController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/routineresearchcycle/web/BackendRoutineResearchCycleController.java
@@ -28,6 +28,13 @@ public class BackendRoutineResearchCycleController {
     return executionService.listPending();
   }
 
+  /** Lista execuções do ciclo de pesquisa de rotina vinculadas ao CNAE informado. */
+  @GetMapping("/oprm/nichocnae/cnaes/{cnaeCode}/routine-research-cycle/stage-executions")
+  public ResponseEntity<List<RoutineResearchCycleExecutionSummaryResponse>> listStageExecutionsByCnae(
+      @PathVariable String cnaeCode) {
+    return ResponseEntity.ok(executionService.listStageExecutionsByCnae(cnaeCode));
+  }
+
   /** Lista execuções do ciclo de pesquisa de rotina vinculadas ao nicho CNAE informado. */
   @GetMapping("/oprm/nichocnae/{sourceNicheId}/routine-research-cycle/stage-executions")
   public ResponseEntity<List<RoutineResearchCycleExecutionSummaryResponse>> listStageExecutions(

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/routineresearchorchestrator/service/BackendRoutineResearchOrchestratorService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/routineresearchorchestrator/service/BackendRoutineResearchOrchestratorService.java
@@ -40,6 +40,7 @@ public class BackendRoutineResearchOrchestratorService {
     private static final String CYCLE_STATUS_GENERIC = "GENERIC";
     private static final String TRIGGER_SOURCE_AUTO_SCORE_QUEUE = "AUTO_SCORE_QUEUE";
     private static final String TRIGGER_SOURCE_MANUAL_REPROCESS = "MANUAL_REPROCESS";
+    private static final String TRIGGER_SOURCE_MANUAL_CNAE_DETAIL = "MANUAL_CNAE_DETAIL";
     private static final String RESEARCH_MODE_ROUTINE_REALITY = "ROUTINE_REALITY_RESEARCH";
 
     private final OprmNicheCandidateRepository nicheCandidateRepository;
@@ -174,6 +175,21 @@ public class BackendRoutineResearchOrchestratorService {
         return "Novo ciclo de pesquisa de rotina criado imediatamente para refazer um CNAE genérico ou sem material suficiente.";
     }
 
+    /** Executa a etapa zero para o CNAE escolhido manualmente na tela de detalhe. */
+    @Transactional
+    public RecordRoutineResearchOrchestratorResult runForCnae(String cnaeCode) {
+        LOGGER.info("Iniciando etapa zero OPRM nichocnae por CNAE manual (cnaeCode={})", cnaeCode);
+        List<OprmNicheCandidate> candidates = nicheCandidateRepository.findPendingRoutineResearchCandidateByCnaeCode(
+                cnaeCode, PageRequest.of(0, 1));
+        if (candidates.isEmpty()) {
+            LOGGER.info("Nenhum candidato pendente encontrado para acionamento manual do CNAE (cnaeCode={})", cnaeCode);
+            throw new ResponseStatusException(
+                    HttpStatus.NOT_FOUND,
+                    "Não existe candidato de nicho pendente para iniciar o pipeline deste CNAE: " + cnaeCode);
+        }
+        return startCycleForCandidate(candidates.getFirst(), TRIGGER_SOURCE_MANUAL_CNAE_DETAIL);
+    }
+
     /** Executa a etapa zero, marcando o nicho selecionado como em pesquisa e criando o ciclo pai. */
     @Transactional
     public RecordRoutineResearchOrchestratorResult runNext() {
@@ -188,18 +204,24 @@ public class BackendRoutineResearchOrchestratorService {
                     "Nenhum nicho CNAE pendente com score disponível para pesquisa de rotina.");
         }
 
-        OprmNicheCandidate candidate = candidates.getFirst();
+        return startCycleForCandidate(candidates.getFirst(), TRIGGER_SOURCE_AUTO_SCORE_QUEUE);
+    }
+
+    /** Cria ciclo de pesquisa para um candidato já selecionado e atualiza o status operacional do nicho. */
+    private RecordRoutineResearchOrchestratorResult startCycleForCandidate(OprmNicheCandidate candidate, String triggerSource) {
         LOGGER.info(
-                "Candidato selecionado para etapa zero OPRM nichocnae (sourceNicheId={}, cnaeCode={}, nicheName={}, score={}, routineStatus={}, lastRoutineResearchCycleId={})",
+                "Candidato selecionado para etapa zero OPRM nichocnae (sourceNicheId={}, cnaeCode={}, nicheName={}, score={}, routineStatus={}, lastRoutineResearchCycleId={}, triggerSource={})",
                 candidate.getId(),
                 candidate.getCnaeCode(),
                 candidate.getCandidateNicheName(),
                 candidate.getOpportunityScore(),
                 candidate.getRoutineResearchStatus(),
-                candidate.getLastRoutineResearchCycleId());
+                candidate.getLastRoutineResearchCycleId(),
+                triggerSource);
         Instant now = Instant.now();
         try {
             OprmRoutineResearchCycle cycle = createCycle(candidate, now);
+            cycle.setTriggerSource(triggerSource);
             OprmRoutineResearchCycle savedCycle = routineResearchCycleRepository.save(cycle);
             LOGGER.info(
                     "Ciclo de pesquisa de rotina criado pela etapa zero OPRM nichocnae (researchCycleId={}, sourceNicheId={}, cnaeCode={}, originalNicheName={}, neutralNicheName={}, researchMode={}, solutionLanguageRiskScore={}, cycleStatus={}, triggerSource={}, startedAt={})",
@@ -237,11 +259,12 @@ public class BackendRoutineResearchOrchestratorService {
             return result;
         } catch (RuntimeException ex) {
             LOGGER.error(
-                    "Erro ao executar etapa zero do OPRM nichocnae (sourceNicheId={}, cnaeCode={}, nicheName={}, score={})",
+                    "Erro ao executar etapa zero do OPRM nichocnae (sourceNicheId={}, cnaeCode={}, nicheName={}, score={}, triggerSource={})",
                     candidate.getId(),
                     candidate.getCnaeCode(),
                     candidate.getCandidateNicheName(),
                     candidate.getOpportunityScore(),
+                    triggerSource,
                     ex);
             throw ex;
         }

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/routineresearchorchestrator/web/BackendRoutineResearchOrchestratorController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/routineresearchorchestrator/web/BackendRoutineResearchOrchestratorController.java
@@ -44,6 +44,12 @@ public class BackendRoutineResearchOrchestratorController {
         return executionService.reprocessCycle(researchCycleId);
     }
 
+    /** Executa a etapa zero para iniciar pesquisa de rotina do CNAE escolhido na tela de detalhe. */
+    @PostMapping("/oprm/nichocnae/cnaes/{cnaeCode}/routine-research-orchestrator/run")
+    public ResponseEntity<RecordRoutineResearchOrchestratorResult> runForCnae(@PathVariable String cnaeCode) {
+        return ResponseEntity.accepted().body(executionService.runForCnae(cnaeCode));
+    }
+
     /** Executa a etapa zero para iniciar o próximo ciclo de pesquisa de rotina por score. */
     @PostMapping("/internal/oprm/nichocnae/routine-research-orchestrator/run-next")
     public ResponseEntity<RecordRoutineResearchOrchestratorResult> runNext() {

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/oprm/cnae/OprmNicheCandidateRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/oprm/cnae/OprmNicheCandidateRepository.java
@@ -7,6 +7,7 @@ import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 /**
  * Repositório responsável por persistir e consultar candidatos de nicho gerados pelo OPRM.
@@ -22,6 +23,18 @@ public interface OprmNicheCandidateRepository extends JpaRepository<OprmNicheCan
                     + "and c.opportunityScore is not null "
                     + "order by c.opportunityScore desc, c.createdAt asc")
     List<OprmNicheCandidate> findNextPendingRoutineResearchCandidate(Pageable pageable);
+
+    /**
+     * Seleciona com bloqueio pessimista candidatos pendentes de pesquisa para o CNAE escolhido manualmente.
+     */
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query(
+            "select c from OprmNicheCandidate c "
+                    + "where c.cnaeCode = :cnaeCode "
+                    + "and (c.routineResearchStatus is null or c.routineResearchStatus = 'PENDING') "
+                    + "and c.opportunityScore is not null "
+                    + "order by c.opportunityScore desc, c.createdAt asc")
+    List<OprmNicheCandidate> findPendingRoutineResearchCandidateByCnaeCode(@Param("cnaeCode") String cnaeCode, Pageable pageable);
 
     /**
      * Lista sem bloqueio pessimista os melhores candidatos ainda pendentes de pesquisa de rotina para visualização.

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/oprm/market/OprmMarketSizeByCnaeRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/oprm/market/OprmMarketSizeByCnaeRepository.java
@@ -5,9 +5,11 @@ import com.marketinghub.oprm.market.OprmMarketSizeByCnae;
 import com.marketinghub.oprm.market.OprmMarketSizeByCnaeId;
 import com.marketinghub.oprm.market.dto.OprmTopCnaeMarketVolumeDto;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 /**
  * Repositório responsável por consultar e paginar os agregados de tamanho de mercado por CNAE.
@@ -36,4 +38,28 @@ public interface OprmMarketSizeByCnaeRepository extends JpaRepository<OprmMarket
             order by sc.opportunityScore desc, ms.id.cnaeCode asc
             """)
     List<OprmTopCnaeMarketVolumeDto> findTopByLatestSnapshot(Pageable pageable);
+
+    /**
+     * Retorna o volume do CNAE informado no snapshot mais recente com score OPRM quando existir.
+     */
+    @Query("""
+            select new com.marketinghub.oprm.market.dto.OprmTopCnaeMarketVolumeDto(
+                ms.id.snapshotDate,
+                ms.id.cnaeCode,
+                c.description,
+                ms.totalEstabelecimentos,
+                ms.totalEstabelecimentosAtivos,
+                ms.totalEmpresas,
+                ms.totalEmpresasMei,
+                ms.totalEmpresasSimples,
+                sc.opportunityScore,
+                sc.scoreStatus
+            )
+            from OprmMarketSizeByCnae ms
+            left join OprmCnpjCnaeDim c on c.cnaeCode = ms.id.cnaeCode
+            left join OprmCnaeOpportunityScore sc on sc.cnaeCode = ms.id.cnaeCode
+            where ms.id.snapshotDate = (select max(m2.id.snapshotDate) from OprmMarketSizeByCnae m2)
+              and ms.id.cnaeCode = :cnaeCode
+            """)
+    Optional<OprmTopCnaeMarketVolumeDto> findLatestSnapshotByCnaeCode(@Param("cnaeCode") String cnaeCode);
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/oprm/nichocnae/OprmRoutineResearchCycleRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/oprm/nichocnae/OprmRoutineResearchCycleRepository.java
@@ -14,6 +14,9 @@ public interface OprmRoutineResearchCycleRepository extends JpaRepository<OprmRo
     /** Lista ciclos vinculados ao nicho CNAE de origem em ordem operacional decrescente. */
     List<OprmRoutineResearchCycle> findBySourceNicheIdOrderByStartedAtDesc(Long sourceNicheId);
 
+    /** Lista ciclos vinculados ao CNAE informado em ordem operacional decrescente. */
+    List<OprmRoutineResearchCycle> findByCnaeCodeOrderByStartedAtDesc(String cnaeCode);
+
     /** Lista ciclos por status para filas internas do pipeline de pesquisa de rotina. */
     List<OprmRoutineResearchCycle> findByStatusOrderByStartedAtAsc(String status, Pageable pageable);
 

--- a/backend/ads-service/src/test/java/com/marketinghub/oprm/nichocnae/routineresearchorchestrator/service/BackendRoutineResearchOrchestratorServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/oprm/nichocnae/routineresearchorchestrator/service/BackendRoutineResearchOrchestratorServiceTest.java
@@ -155,7 +155,8 @@ class BackendRoutineResearchOrchestratorServiceTest {
         assertThat(result.lastRoutineResearchCycleId()).isEqualTo(322L);
         assertThat(result.message()).contains("CNAE com falha");
 
-        ArgumentCaptor<OprmRoutineResearchCycle> cycleCaptor = ArgumentCaptor.forClass(OprmRoutineResearchCycle.class);
+        ArgumentCaptor<OprmRoutineResearchCycle> cycleCaptor =
+                ArgumentCaptor.forClass(OprmRoutineResearchCycle.class);
         verify(routineResearchCycleRepository).save(cycleCaptor.capture());
         assertThat(cycleCaptor.getValue().getSourceNicheId()).isEqualTo(55L);
         assertThat(cycleCaptor.getValue().getStatus()).isEqualTo("RUNNING");
@@ -194,7 +195,8 @@ class BackendRoutineResearchOrchestratorServiceTest {
         assertThat(result.previousCycleStatus()).isEqualTo("NEEDS_MORE_RESEARCH");
         assertThat(result.message()).contains("precisava de mais pesquisa");
 
-        ArgumentCaptor<OprmRoutineResearchCycle> cycleCaptor = ArgumentCaptor.forClass(OprmRoutineResearchCycle.class);
+        ArgumentCaptor<OprmRoutineResearchCycle> cycleCaptor =
+                ArgumentCaptor.forClass(OprmRoutineResearchCycle.class);
         verify(routineResearchCycleRepository).save(cycleCaptor.capture());
         assertThat(cycleCaptor.getValue().getStatus()).isEqualTo("RUNNING");
         assertThat(cycleCaptor.getValue().getTriggerSource()).isEqualTo("MANUAL_REPROCESS");
@@ -232,7 +234,8 @@ class BackendRoutineResearchOrchestratorServiceTest {
         assertThat(result.previousCycleStatus()).isEqualTo("ENRICHED_NICHE_FAILED");
         assertThat(result.message()).contains("refazer pelo front-end");
 
-        ArgumentCaptor<OprmRoutineResearchCycle> cycleCaptor = ArgumentCaptor.forClass(OprmRoutineResearchCycle.class);
+        ArgumentCaptor<OprmRoutineResearchCycle> cycleCaptor =
+                ArgumentCaptor.forClass(OprmRoutineResearchCycle.class);
         verify(routineResearchCycleRepository).save(cycleCaptor.capture());
         assertThat(cycleCaptor.getValue().getStatus()).isEqualTo("RUNNING");
         assertThat(cycleCaptor.getValue().getTriggerSource()).isEqualTo("MANUAL_REPROCESS");
@@ -268,7 +271,8 @@ class BackendRoutineResearchOrchestratorServiceTest {
         assertThat(result.neutralNicheName()).isEqualTo("Cabeleireiros e manicures");
         assertThat(result.researchMode()).isEqualTo("ROUTINE_REALITY_RESEARCH");
 
-        ArgumentCaptor<OprmRoutineResearchCycle> cycleCaptor = ArgumentCaptor.forClass(OprmRoutineResearchCycle.class);
+        ArgumentCaptor<OprmRoutineResearchCycle> cycleCaptor =
+                ArgumentCaptor.forClass(OprmRoutineResearchCycle.class);
         verify(routineResearchCycleRepository).save(cycleCaptor.capture());
         OprmRoutineResearchCycle savedCycle = cycleCaptor.getValue();
         assertThat(savedCycle.getSourceNicheId()).isEqualTo(55L);
@@ -313,7 +317,8 @@ class BackendRoutineResearchOrchestratorServiceTest {
         assertThat(result.researchMode()).isEqualTo("ROUTINE_REALITY_RESEARCH");
         assertThat(result.solutionLanguageRiskScore()).isEqualByComparingTo("100.00");
 
-        ArgumentCaptor<OprmRoutineResearchCycle> cycleCaptor = ArgumentCaptor.forClass(OprmRoutineResearchCycle.class);
+        ArgumentCaptor<OprmRoutineResearchCycle> cycleCaptor =
+                ArgumentCaptor.forClass(OprmRoutineResearchCycle.class);
         verify(routineResearchCycleRepository).save(cycleCaptor.capture());
         OprmRoutineResearchCycle savedCycle = cycleCaptor.getValue();
         assertThat(savedCycle.getNicheName()).isEqualTo("Cabeleireiros, manicure e pedicure");
@@ -321,6 +326,38 @@ class BackendRoutineResearchOrchestratorServiceTest {
         assertThat(savedCycle.getNeutralNicheName()).isEqualTo("Cabeleireiros, manicure e pedicure");
         assertThat(savedCycle.getResearchMode()).isEqualTo("ROUTINE_REALITY_RESEARCH");
         assertThat(savedCycle.getSolutionLanguageRiskScore()).isEqualByComparingTo("100.00");
+    }
+
+    /** Deve criar ciclo manual para o CNAE escolhido na tela de detalhe. */
+    @Test
+    void runForCnaeCreatesManualCycleForSelectedCnae() {
+        OprmNicheCandidate candidate = candidate();
+        when(nicheCandidateRepository.findPendingRoutineResearchCandidateByCnaeCode(
+                        any(String.class), any(Pageable.class)))
+                .thenReturn(List.of(candidate));
+        when(routineResearchCycleRepository.save(any(OprmRoutineResearchCycle.class)))
+                .thenAnswer(invocation -> {
+                    OprmRoutineResearchCycle cycle = invocation.getArgument(0);
+                    cycle.setId(323L);
+                    return cycle;
+                });
+
+        RecordRoutineResearchOrchestratorResult result = service.runForCnae("9602501");
+
+        assertThat(result.started()).isTrue();
+        assertThat(result.researchCycleId()).isEqualTo(323L);
+        assertThat(result.cnaeCode()).isEqualTo("9602501");
+        assertThat(result.triggerSource()).isEqualTo("MANUAL_CNAE_DETAIL");
+        assertThat(result.routineResearchStatus()).isEqualTo("RESEARCH_RUNNING");
+
+        ArgumentCaptor<OprmRoutineResearchCycle> cycleCaptor =
+                ArgumentCaptor.forClass(OprmRoutineResearchCycle.class);
+        verify(routineResearchCycleRepository).save(cycleCaptor.capture());
+        assertThat(cycleCaptor.getValue().getTriggerSource()).isEqualTo("MANUAL_CNAE_DETAIL");
+
+        ArgumentCaptor<OprmNicheCandidate> candidateCaptor = ArgumentCaptor.forClass(OprmNicheCandidate.class);
+        verify(nicheCandidateRepository).save(candidateCaptor.capture());
+        assertThat(candidateCaptor.getValue().getLastRoutineResearchCycleId()).isEqualTo(323L);
     }
 
     /** Deve retornar resultado sem início quando não houver nicho pendente com score. */

--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -1,3 +1,10 @@
+## 2026-06-12 — OPRM CNAE: detalhe acionável com pipeline NichoCNAE
+
+- Evoluída a tela `/oprm/cnaes/:cnaeCode` para exibir descrição do CNAE, score OPRM, componentes do score, quantidade de estabelecimentos, empresas e MEIs.
+- Adicionado comando manual para disparar o pipeline NichoCNAE do CNAE selecionado quando houver candidato pendente, sem obrigar o usuário a depender apenas da fila automática por score.
+- Criado acompanhamento por cards das fases do pipeline na tela de detalhe, usando o último ciclo do CNAE para indicar início, status, sinais extraídos e conclusão/falha.
+- Causa-raiz tratada: a tela existia apenas como placeholder, deixando o usuário sem dados de decisão e sem comando direto para transformar CNAE priorizado em pesquisa operacional.
+
 # Registros — OPRM
 
 - 2026-06-11 21:26:05 (UTC-3): atualizado o fluxo OPRM NichoCNAE para tratar aquisição de clientes como realidade operacional obrigatória do MEI/autônomo, reforçando no prompt e no cânone a busca por evidências de captação, canais, indicação, redes sociais, WhatsApp, orçamento, agenda vazia, retorno, fidelização, cancelamento, reativação e recorrência, sem permitir solução, campanha ou oferta.

--- a/docs/swagger/oprm-nichocnae-swagger.yaml
+++ b/docs/swagger/oprm-nichocnae-swagger.yaml
@@ -4,6 +4,28 @@ info:
   version: 0.5.0
   description: Endpoints internos do backend para o pipeline OPRM de pesquisa de rotina por nicho CNAE.
 paths:
+  /api/oprm/cnaes/{cnaeCode}/opportunity-score:
+    get:
+      summary: Retorna o score OPRM calculado para o CNAE exibido na tela de detalhe.
+      tags: [OPRM CNAE]
+      parameters:
+        - $ref: '#/components/parameters/CnaeCode'
+      responses:
+        '200':
+          description: Score de oportunidade do CNAE.
+        '404':
+          description: Score ainda não calculado para o CNAE.
+  /api/oprm/market/import-runs/cnaes/{cnaeCode}/latest-volume:
+    get:
+      summary: Retorna volume de mercado e score agregado do CNAE no snapshot mais recente.
+      tags: [OPRM CNAE]
+      parameters:
+        - $ref: '#/components/parameters/CnaeCode'
+      responses:
+        '200':
+          description: Volume de estabelecimentos, empresas, MEIs e score do CNAE.
+        '404':
+          description: CNAE não encontrado no snapshot mais recente.
   /api/internal/oprm/nichocnae/routine-research-orchestrator/stage-executions/pending:
     get:
       summary: Lista o próximo nicho CNAE pendente para a etapa zero.
@@ -50,6 +72,17 @@ paths:
           description: Ciclo ou nicho CNAE de origem não encontrado.
         '409':
           description: Ciclo não está em status FAILED, NEEDS_MORE_RESEARCH, GENERIC ou ENRICHED_NICHE_FAILED e não pode ser reprocessado.
+  /api/oprm/nichocnae/cnaes/{cnaeCode}/routine-research-orchestrator/run:
+    post:
+      summary: Executa a etapa zero para iniciar o pipeline NichoCNAE do CNAE escolhido manualmente na tela de detalhe.
+      tags: [OPRM Nicho CNAE]
+      parameters:
+        - $ref: '#/components/parameters/CnaeCode'
+      responses:
+        '202':
+          description: Ciclo criado e nicho marcado como em pesquisa para o CNAE informado.
+        '404':
+          description: Não existe candidato de nicho pendente para iniciar o pipeline desse CNAE.
   /api/internal/oprm/nichocnae/routine-research-orchestrator/run-next:
     post:
       summary: Executa a etapa zero e abre o próximo ciclo de pesquisa de rotina.
@@ -66,6 +99,15 @@ paths:
       responses:
         '200':
           description: Ciclos em execução.
+  /api/oprm/nichocnae/cnaes/{cnaeCode}/routine-research-cycle/stage-executions:
+    get:
+      summary: Lista ciclos de pesquisa de rotina por código CNAE para acompanhamento da tela de detalhe.
+      tags: [OPRM Nicho CNAE]
+      parameters:
+        - $ref: '#/components/parameters/CnaeCode'
+      responses:
+        '200':
+          description: Lista de ciclos vinculados ao CNAE.
   /api/oprm/nichocnae/{sourceNicheId}/routine-research-cycle/stage-executions:
     get:
       summary: Lista ciclos de pesquisa de rotina por nicho CNAE de origem.
@@ -674,6 +716,14 @@ paths:
 
 components:
   parameters:
+    CnaeCode:
+      name: cnaeCode
+      in: path
+      required: true
+      schema:
+        type: string
+        minLength: 7
+        maxLength: 7
     ResearchCycleId:
       name: researchCycleId
       in: path

--- a/frontend/src/api/oprm/useOprmCnaeDetail.ts
+++ b/frontend/src/api/oprm/useOprmCnaeDetail.ts
@@ -1,0 +1,53 @@
+import { useQuery } from "@tanstack/react-query";
+import { buildApiUrl } from "../../utils/buildApiUrl";
+import type { OprmCnaeOpportunityScore } from "./useOprmCnaeOpportunityScores";
+import type { OprmTopCnaeMarketVolume } from "./useOprmTopCnaeMarketVolume";
+
+async function fetchCnaeVolume(
+  cnaeCode: string,
+): Promise<OprmTopCnaeMarketVolume> {
+  const response = await fetch(
+    buildApiUrl(
+      `/api/oprm/market/import-runs/cnaes/${encodeURIComponent(cnaeCode)}/latest-volume`,
+    ),
+  );
+  if (!response.ok) {
+    throw new Error(
+      `Não foi possível carregar o volume do CNAE (status ${response.status}).`,
+    );
+  }
+  return (await response.json()) as OprmTopCnaeMarketVolume;
+}
+
+async function fetchCnaeScore(
+  cnaeCode: string,
+): Promise<OprmCnaeOpportunityScore> {
+  const response = await fetch(
+    buildApiUrl(
+      `/api/oprm/cnaes/${encodeURIComponent(cnaeCode)}/opportunity-score`,
+    ),
+  );
+  if (!response.ok) {
+    throw new Error(
+      `Não foi possível carregar o score do CNAE (status ${response.status}).`,
+    );
+  }
+  return (await response.json()) as OprmCnaeOpportunityScore;
+}
+
+export function useOprmCnaeVolume(cnaeCode: string) {
+  return useQuery({
+    queryKey: ["oprm", "cnaes", cnaeCode, "latest-volume"],
+    queryFn: () => fetchCnaeVolume(cnaeCode),
+    enabled: Boolean(cnaeCode),
+  });
+}
+
+export function useOprmCnaeScore(cnaeCode: string) {
+  return useQuery({
+    queryKey: ["oprm", "cnaes", cnaeCode, "opportunity-score"],
+    queryFn: () => fetchCnaeScore(cnaeCode),
+    enabled: Boolean(cnaeCode),
+    retry: false,
+  });
+}

--- a/frontend/src/api/oprm/useOprmCnaePipeline.ts
+++ b/frontend/src/api/oprm/useOprmCnaePipeline.ts
@@ -1,0 +1,93 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { buildApiUrl } from "../../utils/buildApiUrl";
+
+export interface OprmRoutineResearchCycleSummary {
+  researchCycleId: number;
+  sourceNicheId: number;
+  cnaeCode: string;
+  nicheName: string;
+  originalNicheName: string | null;
+  neutralNicheName: string | null;
+  researchMode: string;
+  solutionLanguageRiskScore: number | null;
+  sourceScore: number | null;
+  status: string;
+  totalQueries: number;
+  totalExtractedSignals: number;
+  startedAt: string;
+  finishedAt: string | null;
+}
+
+export interface OprmRoutineResearchStartResult {
+  started: boolean;
+  researchCycleId: number | null;
+  sourceNicheId: number | null;
+  cnaeCode: string | null;
+  cnaeDescription: string | null;
+  nicheName: string | null;
+  sourceScore: number | null;
+  triggerSource: string | null;
+  cycleStatus: string | null;
+  originalNicheName: string | null;
+  neutralNicheName: string | null;
+  researchMode: string | null;
+  solutionLanguageRiskScore: number | null;
+  routineResearchStatus: string | null;
+  message: string | null;
+}
+
+async function fetchCnaeCycles(
+  cnaeCode: string,
+): Promise<OprmRoutineResearchCycleSummary[]> {
+  const response = await fetch(
+    buildApiUrl(
+      `/api/oprm/nichocnae/cnaes/${encodeURIComponent(cnaeCode)}/routine-research-cycle/stage-executions`,
+    ),
+  );
+  if (!response.ok) {
+    throw new Error(
+      `Não foi possível carregar os ciclos NichoCNAE (status ${response.status}).`,
+    );
+  }
+  return (await response.json()) as OprmRoutineResearchCycleSummary[];
+}
+
+async function startCnaePipeline(
+  cnaeCode: string,
+): Promise<OprmRoutineResearchStartResult> {
+  const response = await fetch(
+    buildApiUrl(
+      `/api/oprm/nichocnae/cnaes/${encodeURIComponent(cnaeCode)}/routine-research-orchestrator/run`,
+    ),
+    { method: "POST" },
+  );
+  if (!response.ok) {
+    const message = await response.text();
+    throw new Error(
+      message ||
+        `Não foi possível disparar o pipeline NichoCNAE (status ${response.status}).`,
+    );
+  }
+  return (await response.json()) as OprmRoutineResearchStartResult;
+}
+
+export function useOprmCnaePipelineCycles(cnaeCode: string) {
+  return useQuery({
+    queryKey: ["oprm", "nichocnae", cnaeCode, "routine-cycles"],
+    queryFn: () => fetchCnaeCycles(cnaeCode),
+    enabled: Boolean(cnaeCode),
+    refetchInterval: 15000,
+  });
+}
+
+export function useStartOprmCnaePipeline(cnaeCode: string) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: () => startCnaePipeline(cnaeCode),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({
+        queryKey: ["oprm", "nichocnae", cnaeCode, "routine-cycles"],
+      });
+    },
+  });
+}

--- a/frontend/src/pages/oprm/OprmCnaeDetailPlaceholderPage.tsx
+++ b/frontend/src/pages/oprm/OprmCnaeDetailPlaceholderPage.tsx
@@ -1,11 +1,142 @@
 import { Link, useParams } from "react-router-dom";
+import {
+  useOprmCnaeScore,
+  useOprmCnaeVolume,
+} from "../../api/oprm/useOprmCnaeDetail";
+import {
+  type OprmRoutineResearchCycleSummary,
+  useOprmCnaePipelineCycles,
+  useStartOprmCnaePipeline,
+} from "../../api/oprm/useOprmCnaePipeline";
 import PageTitle from "../../components/PageTitle";
 import OprmModuleNavigation from "./OprmModuleNavigation";
 import { useBreadcrumbs } from "../../app/breadcrumbs";
 
+const pipelineStages = [
+  {
+    title: "1. Ciclo",
+    description: "Ciclo pai criado para pesquisar a rotina real do CNAE.",
+  },
+  {
+    title: "2. Seed",
+    description: "Transforma CNAE em nicho operacional e queries de pesquisa.",
+  },
+  {
+    title: "3. Busca",
+    description: "Procura fontes públicas sobre rotina, tarefas e dificuldades.",
+  },
+  {
+    title: "4. Coleta",
+    description: "Coleta metadados e trechos úteis das fontes selecionadas.",
+  },
+  {
+    title: "5. Sinais",
+    description: "Extrai sinais estruturados sobre dores, rotina e linguagem.",
+  },
+  {
+    title: "6. Síntese",
+    description: "Monta o cartão de rotina do nicho com evidências.",
+  },
+  {
+    title: "7. MEI",
+    description: "Define o público MEI/autônomo dono-operador do nicho.",
+  },
+  {
+    title: "8. Qualidade",
+    description: "Valida se a pesquisa é específica, recente e sem solução pronta.",
+  },
+  {
+    title: "9. Materialização",
+    description: "Grava o nicho enriquecido para alimentar ofertas e experimentos.",
+  },
+];
+
+function formatNumber(value?: number | null) {
+  if (value === null || value === undefined) {
+    return "Sem dado";
+  }
+  return Number(value).toLocaleString("pt-BR");
+}
+
+function formatScore(value?: number | null) {
+  if (value === null || value === undefined || Number.isNaN(Number(value))) {
+    return "Sem score";
+  }
+  return Number(value).toLocaleString("pt-BR", {
+    minimumFractionDigits: 2,
+    maximumFractionDigits: 2,
+  });
+}
+
+function formatDateTime(value?: string | null) {
+  if (!value) {
+    return "Ainda não finalizado";
+  }
+  return new Intl.DateTimeFormat("pt-BR", {
+    dateStyle: "short",
+    timeStyle: "short",
+  }).format(new Date(value));
+}
+
+function statusLabel(status?: string | null) {
+  const labels: Record<string, string> = {
+    RUNNING: "Em execução",
+    COMPLETED: "Concluído",
+    READY_FOR_HYPOTHESIS: "Pronto",
+    FAILED: "Falhou",
+    NEEDS_MORE_RESEARCH: "Precisa aprofundar",
+    NEEDS_MORE_MEI_RESEARCH: "Precisa de mais MEI",
+    OUTDATED_SOURCES: "Fontes antigas",
+    TOO_CORPORATE: "Corporativo demais",
+    SOLUTION_CONTAMINATED: "Contaminado por solução",
+    GENERIC: "Genérico",
+    ENRICHED_NICHE_FAILED: "Falha na materialização",
+  };
+  return status ? (labels[status] ?? status) : "Aguardando";
+}
+
+function inferStageState(
+  stageIndex: number,
+  cycle?: OprmRoutineResearchCycleSummary,
+) {
+  if (!cycle) {
+    return {
+      label: "Aguardando início",
+      className: "border-secondary text-secondary",
+    };
+  }
+  if (cycle.status === "FAILED" || cycle.status?.includes("FAILED")) {
+    return stageIndex === 0
+      ? { label: "Falhou", className: "border-danger text-danger" }
+      : { label: "Bloqueado", className: "border-secondary text-secondary" };
+  }
+  if (cycle.finishedAt) {
+    return { label: "Concluído", className: "border-success text-success" };
+  }
+  if (stageIndex === 0) {
+    return { label: "Em execução", className: "border-primary text-primary" };
+  }
+  if (stageIndex === 1 && cycle.totalQueries > 0) {
+    return { label: "Concluído", className: "border-success text-success" };
+  }
+  if (stageIndex <= 4 && cycle.totalExtractedSignals > 0) {
+    return { label: "Com sinais", className: "border-success text-success" };
+  }
+  return { label: "Na fila", className: "border-secondary text-secondary" };
+}
+
 export default function OprmCnaeDetailPlaceholderPage() {
   const { cnaeCode } = useParams();
   const decodedCnaeCode = cnaeCode ? decodeURIComponent(cnaeCode) : "CNAE";
+  const volumeQuery = useOprmCnaeVolume(decodedCnaeCode);
+  const scoreQuery = useOprmCnaeScore(decodedCnaeCode);
+  const cyclesQuery = useOprmCnaePipelineCycles(decodedCnaeCode);
+  const startPipelineMutation = useStartOprmCnaePipeline(decodedCnaeCode);
+  const latestCycle = cyclesQuery.data?.[0];
+  const cnaeDescription =
+    volumeQuery.data?.cnaeDescription ??
+    scoreQuery.data?.cnaeDescription ??
+    "Descrição ainda não encontrada";
 
   useBreadcrumbs([
     { label: "OPRM", to: "/oprm" },
@@ -17,27 +148,166 @@ export default function OprmCnaeDetailPlaceholderPage() {
       <header className="d-flex flex-column gap-2">
         <PageTitle>Detalhe do nicho CNAE</PageTitle>
         <p className="text-secondary mb-0">
-          Esta tela será construída na próxima etapa para concentrar a visão do
-          nicho, rotina, dores, oportunidades e próximos comandos do fluxo OPRM.
+          Use esta visão para decidir se o CNAE merece pesquisa de rotina,
+          acompanhar a execução do NichoCNAE e avançar apenas com oportunidades
+          sustentadas por sinais reais.
         </p>
       </header>
 
       <OprmModuleNavigation />
 
       <section className="card border-0 shadow-sm">
-        <div className="card-body">
-          <span className="badge text-bg-primary mb-3">
-            CNAE {decodedCnaeCode}
-          </span>
-          <h2 className="h5 mb-2">Detalhe em construção</h2>
-          <p className="text-secondary mb-3">
-            O link do nicho já está preparado para navegação. Quando a tela de
-            detalhe for evoluída, ela deverá mostrar os dados mais importantes
-            para decidir se o nicho merece pesquisa, oferta e experimento.
-          </p>
-          <Link className="btn btn-outline-secondary" to="/oprm">
-            Voltar para CNAEs
-          </Link>
+        <div className="card-body d-flex flex-column gap-3">
+          <div className="d-flex flex-wrap justify-content-between gap-3">
+            <div>
+              <span className="badge text-bg-primary mb-3">
+                CNAE {decodedCnaeCode}
+              </span>
+              <h2 className="h4 mb-2">{cnaeDescription}</h2>
+              <p className="text-secondary mb-0">
+                Score e volume ajudam a priorizar mercados com maior chance de
+                virar produto digital vendável sem perder a visão de rotina real.
+              </p>
+            </div>
+            <div className="d-flex align-items-start gap-2">
+              <button
+                type="button"
+                className="btn btn-primary"
+                disabled={startPipelineMutation.isPending}
+                onClick={() => startPipelineMutation.mutate()}
+              >
+                {startPipelineMutation.isPending
+                  ? "Disparando..."
+                  : "Disparar pipeline NichoCNAE"}
+              </button>
+              <Link className="btn btn-outline-secondary" to="/oprm">
+                Voltar para CNAEs
+              </Link>
+            </div>
+          </div>
+          {startPipelineMutation.isSuccess ? (
+            <div className="alert alert-success mb-0" role="status">
+              Pipeline iniciado para o CNAE {decodedCnaeCode}. Ciclo #
+              {startPipelineMutation.data.researchCycleId} criado para
+              acompanhamento.
+            </div>
+          ) : null}
+          {startPipelineMutation.isError ? (
+            <div className="alert alert-warning mb-0" role="alert">
+              {startPipelineMutation.error.message}
+            </div>
+          ) : null}
+        </div>
+      </section>
+
+      <section className="row g-3">
+        <div className="col-md-3">
+          <div className="card border-0 shadow-sm h-100">
+            <div className="card-body">
+              <span className="text-secondary small">Score OPRM</span>
+              <div className="display-6 fw-semibold">
+                {formatScore(
+                  scoreQuery.data?.opportunityScore ??
+                    volumeQuery.data?.opportunityScore,
+                )}
+              </div>
+              <span className="small text-secondary">
+                {scoreQuery.data?.scoreStatus ??
+                  volumeQuery.data?.scoreStatus ??
+                  "Status não informado"}
+              </span>
+            </div>
+          </div>
+        </div>
+        <div className="col-md-3">
+          <div className="card border-0 shadow-sm h-100">
+            <div className="card-body">
+              <span className="text-secondary small">Estabelecimentos</span>
+              <div className="display-6 fw-semibold">
+                {formatNumber(volumeQuery.data?.totalEstabelecimentos)}
+              </div>
+              <span className="small text-secondary">
+                Ativos: {formatNumber(volumeQuery.data?.totalEstabelecimentosAtivos)}
+              </span>
+            </div>
+          </div>
+        </div>
+        <div className="col-md-3">
+          <div className="card border-0 shadow-sm h-100">
+            <div className="card-body">
+              <span className="text-secondary small">Empresas MEI</span>
+              <div className="display-6 fw-semibold">
+                {formatNumber(volumeQuery.data?.totalEmpresasMei)}
+              </div>
+              <span className="small text-secondary">
+                Empresas: {formatNumber(volumeQuery.data?.totalEmpresas)}
+              </span>
+            </div>
+          </div>
+        </div>
+        <div className="col-md-3">
+          <div className="card border-0 shadow-sm h-100">
+            <div className="card-body">
+              <span className="text-secondary small">Componentes do score</span>
+              <div className="small d-flex flex-column gap-1 mt-2">
+                <span>Volume: {formatScore(scoreQuery.data?.marketVolumeScore)}</span>
+                <span>MEI: {formatScore(scoreQuery.data?.meiDensityScore)}</span>
+                <span>Digital: {formatScore(scoreQuery.data?.digitalFitScore)}</span>
+                <span>Dor: {formatScore(scoreQuery.data?.painClarityScore)}</span>
+              </div>
+            </div>
+          </div>
+        </div>
+      </section>
+
+      <section className="card border-0 shadow-sm">
+        <div className="card-body d-flex flex-column gap-3">
+          <div className="d-flex flex-wrap justify-content-between gap-2">
+            <div>
+              <h2 className="h5 mb-1">Execução do pipeline NichoCNAE</h2>
+              <p className="text-secondary mb-0">
+                Cards por fase para acompanhar onde a pesquisa está antes de
+                transformar o CNAE em nicho enriquecido.
+              </p>
+            </div>
+            <span className="badge text-bg-light align-self-start">
+              Último ciclo: {latestCycle ? `#${latestCycle.researchCycleId}` : "nenhum"}
+            </span>
+          </div>
+
+          {latestCycle ? (
+            <div className="alert alert-info mb-0">
+              Status atual: <strong>{statusLabel(latestCycle.status)}</strong> ·
+              iniciado em {formatDateTime(latestCycle.startedAt)} · sinais extraídos: {" "}
+              {formatNumber(latestCycle.totalExtractedSignals)}
+            </div>
+          ) : (
+            <div className="alert alert-secondary mb-0">
+              Nenhum ciclo encontrado para este CNAE. Use o botão de disparo
+              quando já existir candidato pendente de NichoCNAE para esse CNAE.
+            </div>
+          )}
+
+          <div className="row g-3">
+            {pipelineStages.map((stage, index) => {
+              const state = inferStageState(index, latestCycle);
+              return (
+                <div className="col-md-4" key={stage.title}>
+                  <div className={`card h-100 ${state.className}`}>
+                    <div className="card-body">
+                      <div className="d-flex justify-content-between gap-2 mb-2">
+                        <h3 className="h6 mb-0">{stage.title}</h3>
+                        <span className="badge text-bg-light">{state.label}</span>
+                      </div>
+                      <p className="small text-secondary mb-0">
+                        {stage.description}
+                      </p>
+                    </div>
+                  </div>
+                </div>
+              );
+            })}
+          </div>
         </div>
       </section>
     </div>


### PR DESCRIPTION
### Motivation

- Provide an actionable CNAE detail screen that helps users decide whether to start a NichoCNAE research cycle by showing CNAE description, OPRM score components and market volume metrics. 
- Let operators manually trigger the OPRM NichoCNAE pipeline for a specific CNAE and follow execution progress per pipeline stage instead of relying only on automatic schedulers.

### Description

- Backend: added endpoint to return latest market volume for a CNAE (`GET /api/oprm/market/import-runs/cnaes/{cnaeCode}/latest-volume`) and endpoint to fetch a CNAE's opportunity score (`GET /api/oprm/cnaes/{cnaeCode}/opportunity-score`), plus a controller endpoint to start the NichoCNAE orchestrator for a given CNAE (`POST /api/oprm/nichocnae/cnaes/{cnaeCode}/routine-research-orchestrator/run`).
- Backend: implemented repository/service changes to support the above, including `findLatestSnapshotByCnaeCode`, `findPendingRoutineResearchCandidateByCnaeCode`, `findByCnaeCodeOrderByStartedAtDesc`, and service logic `runForCnae` / `startCycleForCandidate` to create a research cycle triggered from the UI.
- Frontend: added hooks `useOprmCnaeDetail` and `useOprmCnaePipeline` and replaced the placeholder detail page with `OprmCnaeDetailPlaceholderPage.tsx` that displays CNAE description, overall and component scores, counts (estabelecimentos, empresas, MEI) and a button to trigger the pipeline; the page also shows per-stage cards that infer a stage status from the latest research cycle and refreshes cycles periodically.
- Docs: updated `docs/swagger/oprm-nichocnae-swagger.yaml` and `docs/registros/oprm1.md` to document the new routes and the UI evolution.

### Testing

- Frontend unit tests: ran `npm test` for `src/__tests__/OprmNavigation.test.tsx` with `vitest` and all tests passed (7 tests, 1 file). 
- Frontend typecheck: ran `npm run typecheck` (`tsc --noEmit`) with no type errors reported. 
- Backend unit tests: ran `mvn test -DskipITs` for the ads-service module; test execution completed with suites passing (no failures observed in the test run logs). 
- Notes: swagger and docs were updated to keep API contract aligned with the new endpoints.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2b7f3ba7e48321a4ad11af1a91529d)