### PR TITLE
Finish open routine cycles on manual CNAE restart and add cancellation status

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/routineresearchorchestrator/service/BackendRoutineResearchOrchestratorService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/routineresearchorchestrator/service/BackendRoutineResearchOrchestratorService.java
@@ -38,6 +38,7 @@ public class BackendRoutineResearchOrchestratorService {
     private static final String CYCLE_STATUS_TOO_CORPORATE = "TOO_CORPORATE";
     private static final String CYCLE_STATUS_SOLUTION_CONTAMINATED = "SOLUTION_CONTAMINATED";
     private static final String CYCLE_STATUS_GENERIC = "GENERIC";
+    private static final String CYCLE_STATUS_CANCELLED_BY_MANUAL_RESTART = "CANCELLED_BY_MANUAL_RESTART";
     private static final String TRIGGER_SOURCE_AUTO_SCORE_QUEUE = "AUTO_SCORE_QUEUE";
     private static final String TRIGGER_SOURCE_MANUAL_REPROCESS = "MANUAL_REPROCESS";
     private static final String TRIGGER_SOURCE_MANUAL_CNAE_DETAIL = "MANUAL_CNAE_DETAIL";
@@ -175,19 +176,45 @@ public class BackendRoutineResearchOrchestratorService {
         return "Novo ciclo de pesquisa de rotina criado imediatamente para refazer um CNAE genérico ou sem material suficiente.";
     }
 
-    /** Executa a etapa zero para o CNAE escolhido manualmente na tela de detalhe. */
+    /** Executa a etapa zero para o CNAE escolhido, encerrando ciclos abertos antes de criar uma execução nova. */
     @Transactional
     public RecordRoutineResearchOrchestratorResult runForCnae(String cnaeCode) {
-        LOGGER.info("Iniciando etapa zero OPRM nichocnae por CNAE manual (cnaeCode={})", cnaeCode);
-        List<OprmNicheCandidate> candidates = nicheCandidateRepository.findPendingRoutineResearchCandidateByCnaeCode(
+        LOGGER.info("Iniciando etapa zero OPRM nichocnae por CNAE manual com reinício forçado (cnaeCode={})", cnaeCode);
+        List<OprmNicheCandidate> candidates = nicheCandidateRepository.findManualRoutineResearchCandidateByCnaeCode(
                 cnaeCode, PageRequest.of(0, 1));
         if (candidates.isEmpty()) {
-            LOGGER.info("Nenhum candidato pendente encontrado para acionamento manual do CNAE (cnaeCode={})", cnaeCode);
+            LOGGER.info("Nenhum candidato com score encontrado para acionamento manual do CNAE (cnaeCode={})", cnaeCode);
             throw new ResponseStatusException(
                     HttpStatus.NOT_FOUND,
-                    "Não existe candidato de nicho pendente para iniciar o pipeline deste CNAE: " + cnaeCode);
+                    "Não existe candidato de nicho com score para iniciar um novo pipeline deste CNAE: " + cnaeCode);
         }
+        finishOpenCyclesForManualRestart(cnaeCode);
         return startCycleForCandidate(candidates.getFirst(), TRIGGER_SOURCE_MANUAL_CNAE_DETAIL);
+    }
+
+    /** Encerra ciclos ainda abertos do CNAE para impedir que execuções antigas continuem concorrendo com o novo ciclo manual. */
+    private void finishOpenCyclesForManualRestart(String cnaeCode) {
+        List<OprmRoutineResearchCycle> openCycles =
+                routineResearchCycleRepository.findOpenCyclesByCnaeCodeForUpdate(cnaeCode);
+        if (openCycles == null || openCycles.isEmpty()) {
+            LOGGER.info(
+                    "Nenhum ciclo aberto encontrado para encerramento antes do reinício manual do CNAE (cnaeCode={})",
+                    cnaeCode);
+            return;
+        }
+        Instant now = Instant.now();
+        openCycles.forEach(cycle -> {
+            cycle.setStatus(CYCLE_STATUS_CANCELLED_BY_MANUAL_RESTART);
+            cycle.setFinishedAt(now);
+            cycle.setUpdatedAt(now);
+            cycle.setErrorMessage("Ciclo encerrado automaticamente para reinício manual completo do CNAE " + cnaeCode + ".");
+        });
+        routineResearchCycleRepository.saveAll(openCycles);
+        LOGGER.info(
+                "Ciclos abertos encerrados antes do reinício manual OPRM nichocnae (cnaeCode={}, count={}, status={})",
+                cnaeCode,
+                openCycles.size(),
+                CYCLE_STATUS_CANCELLED_BY_MANUAL_RESTART);
     }
 
     /** Executa a etapa zero, marcando o nicho selecionado como em pesquisa e criando o ciclo pai. */

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/oprm/cnae/OprmNicheCandidateRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/oprm/cnae/OprmNicheCandidateRepository.java
@@ -25,16 +25,15 @@ public interface OprmNicheCandidateRepository extends JpaRepository<OprmNicheCan
     List<OprmNicheCandidate> findNextPendingRoutineResearchCandidate(Pageable pageable);
 
     /**
-     * Seleciona com bloqueio pessimista candidatos pendentes de pesquisa para o CNAE escolhido manualmente.
+     * Seleciona com bloqueio pessimista candidatos com score para reinício manual do CNAE escolhido.
      */
     @Lock(LockModeType.PESSIMISTIC_WRITE)
     @Query(
             "select c from OprmNicheCandidate c "
                     + "where c.cnaeCode = :cnaeCode "
-                    + "and (c.routineResearchStatus is null or c.routineResearchStatus = 'PENDING') "
                     + "and c.opportunityScore is not null "
                     + "order by c.opportunityScore desc, c.createdAt asc")
-    List<OprmNicheCandidate> findPendingRoutineResearchCandidateByCnaeCode(@Param("cnaeCode") String cnaeCode, Pageable pageable);
+    List<OprmNicheCandidate> findManualRoutineResearchCandidateByCnaeCode(@Param("cnaeCode") String cnaeCode, Pageable pageable);
 
     /**
      * Lista sem bloqueio pessimista os melhores candidatos ainda pendentes de pesquisa de rotina para visualização.

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/oprm/nichocnae/OprmRoutineResearchCycleRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/oprm/nichocnae/OprmRoutineResearchCycleRepository.java
@@ -1,9 +1,11 @@
 package com.marketinghub.repository.jpa.oprm.nichocnae;
 
 import com.marketinghub.oprm.nichocnae.OprmRoutineResearchCycle;
+import jakarta.persistence.LockModeType;
 import java.util.List;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -16,6 +18,17 @@ public interface OprmRoutineResearchCycleRepository extends JpaRepository<OprmRo
 
     /** Lista ciclos vinculados ao CNAE informado em ordem operacional decrescente. */
     List<OprmRoutineResearchCycle> findByCnaeCodeOrderByStartedAtDesc(String cnaeCode);
+
+    /** Seleciona com bloqueio pessimista ciclos abertos do CNAE para encerramento antes de reinício manual. */
+    @Lock(LockModeType.PESSIMISTIC_WRITE)
+    @Query("""
+            select cycle
+            from OprmRoutineResearchCycle cycle
+            where cycle.cnaeCode = :cnaeCode
+              and cycle.finishedAt is null
+            order by cycle.startedAt desc
+            """)
+    List<OprmRoutineResearchCycle> findOpenCyclesByCnaeCodeForUpdate(@Param("cnaeCode") String cnaeCode);
 
     /** Lista ciclos por status para filas internas do pipeline de pesquisa de rotina. */
     List<OprmRoutineResearchCycle> findByStatusOrderByStartedAtAsc(String status, Pageable pageable);

--- a/backend/ads-service/src/test/java/com/marketinghub/oprm/nichocnae/routineresearchorchestrator/service/BackendRoutineResearchOrchestratorServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/oprm/nichocnae/routineresearchorchestrator/service/BackendRoutineResearchOrchestratorServiceTest.java
@@ -332,7 +332,7 @@ class BackendRoutineResearchOrchestratorServiceTest {
     @Test
     void runForCnaeCreatesManualCycleForSelectedCnae() {
         OprmNicheCandidate candidate = candidate();
-        when(nicheCandidateRepository.findPendingRoutineResearchCandidateByCnaeCode(
+        when(nicheCandidateRepository.findManualRoutineResearchCandidateByCnaeCode(
                         any(String.class), any(Pageable.class)))
                 .thenReturn(List.of(candidate));
         when(routineResearchCycleRepository.save(any(OprmRoutineResearchCycle.class)))
@@ -354,6 +354,47 @@ class BackendRoutineResearchOrchestratorServiceTest {
                 ArgumentCaptor.forClass(OprmRoutineResearchCycle.class);
         verify(routineResearchCycleRepository).save(cycleCaptor.capture());
         assertThat(cycleCaptor.getValue().getTriggerSource()).isEqualTo("MANUAL_CNAE_DETAIL");
+
+        ArgumentCaptor<OprmNicheCandidate> candidateCaptor = ArgumentCaptor.forClass(OprmNicheCandidate.class);
+        verify(nicheCandidateRepository).save(candidateCaptor.capture());
+        assertThat(candidateCaptor.getValue().getLastRoutineResearchCycleId()).isEqualTo(323L);
+    }
+
+    /** Deve encerrar ciclos abertos do CNAE antes de criar um ciclo manual completamente novo. */
+    @Test
+    void runForCnaeFinishesOpenCyclesBeforeCreatingFreshManualCycle() {
+        OprmNicheCandidate candidate = candidate();
+        candidate.setRoutineResearchStatus("RESEARCH_RUNNING");
+        candidate.setLastRoutineResearchCycleId(321L);
+        OprmRoutineResearchCycle openCycle = cycle(321L, 55L, "Cabeleireiros e manicures", "2026-06-03T01:00:00Z");
+        openCycle.setStatus("ROUTINE_SYNTHESIZED");
+        openCycle.setFinishedAt(null);
+        openCycle.setErrorMessage(null);
+        when(nicheCandidateRepository.findManualRoutineResearchCandidateByCnaeCode(
+                        any(String.class), any(Pageable.class)))
+                .thenReturn(List.of(candidate));
+        when(routineResearchCycleRepository.findOpenCyclesByCnaeCodeForUpdate("9602501"))
+                .thenReturn(List.of(openCycle));
+        when(routineResearchCycleRepository.save(any(OprmRoutineResearchCycle.class)))
+                .thenAnswer(invocation -> {
+                    OprmRoutineResearchCycle cycle = invocation.getArgument(0);
+                    cycle.setId(323L);
+                    return cycle;
+                });
+
+        RecordRoutineResearchOrchestratorResult result = service.runForCnae("9602501");
+
+        assertThat(result.started()).isTrue();
+        assertThat(result.researchCycleId()).isEqualTo(323L);
+        assertThat(result.routineResearchStatus()).isEqualTo("RESEARCH_RUNNING");
+
+        @SuppressWarnings("unchecked")
+        ArgumentCaptor<Iterable<OprmRoutineResearchCycle>> openCyclesCaptor = ArgumentCaptor.forClass(Iterable.class);
+        verify(routineResearchCycleRepository).saveAll(openCyclesCaptor.capture());
+        OprmRoutineResearchCycle cancelledCycle = openCyclesCaptor.getValue().iterator().next();
+        assertThat(cancelledCycle.getStatus()).isEqualTo("CANCELLED_BY_MANUAL_RESTART");
+        assertThat(cancelledCycle.getFinishedAt()).isNotNull();
+        assertThat(cancelledCycle.getErrorMessage()).contains("reinício manual completo do CNAE 9602501");
 
         ArgumentCaptor<OprmNicheCandidate> candidateCaptor = ArgumentCaptor.forClass(OprmNicheCandidate.class);
         verify(nicheCandidateRepository).save(candidateCaptor.capture());

--- a/docs/canonical/oprm-canon.v1.md
+++ b/docs/canonical/oprm-canon.v1.md
@@ -134,6 +134,7 @@ Evitar fechamento prematuro de `import run` que destrói a totalização de mark
 - Todas as etapas do pipeline oficial devem permanecer obrigatórias, ativas e executadas pelo módulo `oprm-coletor-mei`, consumindo exclusivamente endpoints OPRM do backend principal.
 - Somente a etapa `niche-research-seed-builder` deve ser marcada como consumidora direta de modelo OpenAI configurável. As demais etapas são orquestração, consulta, coleta pública, extração/síntese/gate determinísticos ou materialização baseada em dados já coletados, e não devem exibir seleção de modelo OpenAI na tela administrativa quando não houver modelo operacional legado configurado.
 - O pipeline oficial deve preservar a separação canônica: pesquisa de realidade operacional e materialização de nicho enriquecido não podem criar hipótese, experimento, oferta, campanha ou landing page.
+- Quando o usuário solicitar execução manual do pipeline para um CNAE específico, o sistema deve encerrar automaticamente todos os ciclos ainda abertos desse CNAE e iniciar um ciclo completamente novo, mantendo rastreabilidade dos ciclos encerrados e impedindo concorrência entre execuções antigas e a nova solicitação operacional.
 
 ## Critério de efetividade — pipeline oficial OPRM NichoCNAE
 

--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -480,3 +480,9 @@
 
 - Documentado o diagrama de dados do pipeline OPRM NichoCNAE em `docs/relatorios/oprm-nichocnae-diagrama-dados.md`, cobrindo base CNAE/CNPJ, candidatos, ciclo de pesquisa, seed, queries, fontes, snapshots, sinais, cartão de rotina, perfil MEI/autônomo, `market_niche` e `market_niche_enrichment_profile`.
 - A análise foi validada contra o schema real via MCP e registrou que parte dos vínculos OPRM é lógica por `*_id`, com FK física confirmada entre `market_niche_enrichment_profile.market_niche_id` e `market_niche.id`.
+
+## 2026-06-12 — OPRM NichoCNAE: reinício manual completo por CNAE
+
+- Alterada a regra operacional do botão de execução manual por CNAE: quando o usuário solicita novo ciclo para um CNAE específico, o backend encerra automaticamente todos os ciclos ainda abertos desse CNAE e cria uma execução completamente nova.
+- Causa-raiz tratada: o endpoint manual só aceitava candidatos pendentes, então CNAEs já em `RESEARCH_RUNNING` devolviam 404 e impediam nova execução mesmo quando a decisão operacional era recomeçar do zero.
+- Prevenção de recorrência: a regra foi registrada no cânone OPRM, o contrato Swagger foi atualizado e foi criado teste garantindo que ciclos antigos abertos sejam marcados como `CANCELLED_BY_MANUAL_RESTART` antes da criação do novo ciclo.

--- a/docs/swagger/oprm-nichocnae-swagger.yaml
+++ b/docs/swagger/oprm-nichocnae-swagger.yaml
@@ -74,15 +74,15 @@ paths:
           description: Ciclo não está em status FAILED, NEEDS_MORE_RESEARCH, GENERIC ou ENRICHED_NICHE_FAILED e não pode ser reprocessado.
   /api/oprm/nichocnae/cnaes/{cnaeCode}/routine-research-orchestrator/run:
     post:
-      summary: Executa a etapa zero para iniciar o pipeline NichoCNAE do CNAE escolhido manualmente na tela de detalhe.
+      summary: Encerra ciclos abertos e executa a etapa zero para iniciar um novo pipeline NichoCNAE do CNAE escolhido manualmente na tela de detalhe.
       tags: [OPRM Nicho CNAE]
       parameters:
         - $ref: '#/components/parameters/CnaeCode'
       responses:
         '202':
-          description: Ciclo criado e nicho marcado como em pesquisa para o CNAE informado.
+          description: Ciclos abertos anteriores encerrados, ciclo novo criado e nicho marcado como em pesquisa para o CNAE informado.
         '404':
-          description: Não existe candidato de nicho pendente para iniciar o pipeline desse CNAE.
+          description: Não existe candidato de nicho com score para iniciar um novo pipeline desse CNAE.
   /api/internal/oprm/nichocnae/routine-research-orchestrator/run-next:
     post:
       summary: Executa a etapa zero e abre o próximo ciclo de pesquisa de rotina.


### PR DESCRIPTION
### Motivation

- Allow an operator to force a full manual restart for a specific CNAE by ending any still-open routine cycles for that CNAE before creating a fresh cycle.
- Prevent old concurrent executions from competing with a newly requested manual run and keep closed cycles traceable.

### Description

- Added a new cycle status constant `CANCELLED_BY_MANUAL_RESTART` and a helper `finishOpenCyclesForManualRestart(String)` in `BackendRoutineResearchOrchestratorService` that locks, marks open cycles as finished, sets `finishedAt/updatedAt` and an informative `errorMessage`, then saves them with `saveAll`.
- Changed manual-run selection to use `findManualRoutineResearchCandidateByCnaeCode` and call the new finish method before creating a new cycle in `runForCnae`.
- Extended `OprmRoutineResearchCycleRepository` with `findOpenCyclesByCnaeCodeForUpdate` using `PESSIMISTIC_WRITE` to select open cycles for update, and renamed/adjusted the niche candidate repository method to `findManualRoutineResearchCandidateByCnaeCode` with an updated query comment.
- Updated documentation and Swagger (`docs/*` and `docs/swagger/oprm-nichocnae-swagger.yaml`) to describe the behavior of closing open cycles on manual restart and adjusted canonical rules accordingly.

### Testing

- Updated unit tests in `BackendRoutineResearchOrchestratorServiceTest` to call `findManualRoutineResearchCandidateByCnaeCode` and added `runForCnaeFinishesOpenCyclesBeforeCreatingFreshManualCycle` to assert open cycles are marked `CANCELLED_BY_MANUAL_RESTART` and saved before starting a new cycle; existing tests were adapted accordingly.
- Ran the unit test suite (`mvn test`) and the modified/new tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2b862e6b8883219b82611220b21700)