### PR TITLE
OPRM: add per-stage detail page and links from CNAE pipeline cards

### DIFF
--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -486,3 +486,9 @@
 - Alterada a regra operacional do botão de execução manual por CNAE: quando o usuário solicita novo ciclo para um CNAE específico, o backend encerra automaticamente todos os ciclos ainda abertos desse CNAE e cria uma execução completamente nova.
 - Causa-raiz tratada: o endpoint manual só aceitava candidatos pendentes, então CNAEs já em `RESEARCH_RUNNING` devolviam 404 e impediam nova execução mesmo quando a decisão operacional era recomeçar do zero.
 - Prevenção de recorrência: a regra foi registrada no cânone OPRM, o contrato Swagger foi atualizado e foi criado teste garantindo que ciclos antigos abertos sejam marcados como `CANCELLED_BY_MANUAL_RESTART` antes da criação do novo ciclo.
+
+## 2026-06-12 — OPRM NichoCNAE: detalhe por card do CNAE
+
+- A tela de detalhe do CNAE ganhou botão “Ver detalhes” em cada card do pipeline, abrindo uma página separada para não poluir a visão principal.
+- A nova página informa as tabelas populadas por etapa, o tipo de conteúdo gravado, os dados retornados pelo backend e se a etapa acessa modelo de IA.
+- Para etapas com IA, a página exibe request/response conceitual, modelo configurado e deixa explícito quando tokens e custo ainda não estão persistidos no detalhe operacional.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -112,6 +112,7 @@ import OprmOperationsPage from "./pages/oprm/OprmOperationsPage";
 import OprmOccupationCatalogPage from "./pages/oprm/OprmOccupationCatalogPage";
 import OprmCnaeVolumePage from "./pages/oprm/OprmCnaeVolumePage";
 import OprmCnaeDetailPlaceholderPage from "./pages/oprm/OprmCnaeDetailPlaceholderPage";
+import OprmCnaePipelineStageDetailPage from "./pages/oprm/OprmCnaePipelineStageDetailPage";
 import OprmPipelinePage from "./pages/oprm/OprmPipelinePage";
 import OprmNicheResearchSeedBuilderDetailPage from "./pages/oprm/OprmNicheResearchSeedBuilderDetailPage";
 import OprmEnrichedNicheDetailPage from "./pages/oprm/OprmEnrichedNicheDetailPage";
@@ -297,6 +298,10 @@ export default function App() {
               <Route
                 path="/oprm/cnaes/:cnaeCode"
                 element={<OprmCnaeDetailPlaceholderPage />}
+              />
+              <Route
+                path="/oprm/cnaes/:cnaeCode/pipeline/:researchCycleId/stages/:stageCode"
+                element={<OprmCnaePipelineStageDetailPage />}
               />
               <Route path="/mois" element={<MoisWorkspacePage />} />
               <Route path="/mois/references/new" element={<MoisReferenceIntakePage />} />

--- a/frontend/src/api/oprm/useOprmCnaePipelineStageDetail.ts
+++ b/frontend/src/api/oprm/useOprmCnaePipelineStageDetail.ts
@@ -1,0 +1,79 @@
+import { useQuery } from "@tanstack/react-query";
+import { buildApiUrl } from "../../utils/buildApiUrl";
+
+export type OprmCnaePipelineStageCode =
+  | "cycle"
+  | "seed"
+  | "search"
+  | "fetch"
+  | "signals"
+  | "synthesis"
+  | "mei"
+  | "quality"
+  | "materialization";
+
+const stageEndpointByCode: Record<OprmCnaePipelineStageCode, string> = {
+  cycle: "routine-research-cycle",
+  seed: "niche-research-seed-builder",
+  search: "source-searcher",
+  fetch: "source-fetcher",
+  signals: "signal-extractor",
+  synthesis: "routine-synthesizer",
+  mei: "mei-audience-profiles/research-cycles",
+  quality: "routine-quality-gate",
+  materialization: "enriched-niche-materializer",
+};
+
+function buildStageDetailPath(
+  stageCode: OprmCnaePipelineStageCode,
+  researchCycleId: number,
+) {
+  if (stageCode === "mei") {
+    return `/api/oprm/nichocnae/${stageEndpointByCode[stageCode]}/${researchCycleId}`;
+  }
+  return `/api/oprm/nichocnae/${stageEndpointByCode[stageCode]}/stage-executions/${researchCycleId}`;
+}
+
+async function fetchStageDetail(
+  stageCode: OprmCnaePipelineStageCode,
+  researchCycleId: number,
+): Promise<unknown | null> {
+  const response = await fetch(
+    buildApiUrl(buildStageDetailPath(stageCode, researchCycleId)),
+  );
+  if (response.status === 404 || response.status === 409) {
+    return null;
+  }
+  if (!response.ok) {
+    throw new Error(
+      `Não foi possível carregar o detalhe da etapa (status ${response.status}).`,
+    );
+  }
+  return (await response.json()) as unknown;
+}
+
+export function isOprmCnaePipelineStageCode(
+  value: string | undefined,
+): value is OprmCnaePipelineStageCode {
+  return Boolean(
+    value && Object.prototype.hasOwnProperty.call(stageEndpointByCode, value),
+  );
+}
+
+export function useOprmCnaePipelineStageDetail(
+  stageCode: OprmCnaePipelineStageCode | undefined,
+  researchCycleId: number | undefined,
+) {
+  return useQuery({
+    queryKey: [
+      "oprm",
+      "nichocnae",
+      "pipeline-stage-detail",
+      stageCode,
+      researchCycleId,
+    ],
+    queryFn: () => fetchStageDetail(stageCode as OprmCnaePipelineStageCode, researchCycleId as number),
+    enabled: Boolean(stageCode && researchCycleId),
+    retry: false,
+  });
+}

--- a/frontend/src/pages/oprm/OprmCnaeDetailPlaceholderPage.tsx
+++ b/frontend/src/pages/oprm/OprmCnaeDetailPlaceholderPage.tsx
@@ -14,38 +14,47 @@ import { useBreadcrumbs } from "../../app/breadcrumbs";
 
 const pipelineStages = [
   {
+    code: "cycle",
     title: "1. Ciclo",
     description: "Ciclo pai criado para pesquisar a rotina real do CNAE.",
   },
   {
+    code: "seed",
     title: "2. Seed",
     description: "Transforma CNAE em nicho operacional e queries de pesquisa.",
   },
   {
+    code: "search",
     title: "3. Busca",
     description: "Procura fontes públicas sobre rotina, tarefas e dificuldades.",
   },
   {
+    code: "fetch",
     title: "4. Coleta",
     description: "Coleta metadados e trechos úteis das fontes selecionadas.",
   },
   {
+    code: "signals",
     title: "5. Sinais",
     description: "Extrai sinais estruturados sobre dores, rotina e linguagem.",
   },
   {
+    code: "synthesis",
     title: "6. Síntese",
     description: "Monta o cartão de rotina do nicho com evidências.",
   },
   {
+    code: "mei",
     title: "7. MEI",
     description: "Define o público MEI/autônomo dono-operador do nicho.",
   },
   {
+    code: "quality",
     title: "8. Qualidade",
     description: "Valida se a pesquisa é específica, recente e sem solução pronta.",
   },
   {
+    code: "materialization",
     title: "9. Materialização",
     description: "Grava o nicho enriquecido para alimentar ofertas e experimentos.",
   },
@@ -299,9 +308,25 @@ export default function OprmCnaeDetailPlaceholderPage() {
                         <h3 className="h6 mb-0">{stage.title}</h3>
                         <span className="badge text-bg-light">{state.label}</span>
                       </div>
-                      <p className="small text-secondary mb-0">
+                      <p className="small text-secondary mb-3">
                         {stage.description}
                       </p>
+                      {latestCycle ? (
+                        <Link
+                          className="btn btn-outline-primary btn-sm"
+                          to={`/oprm/cnaes/${encodeURIComponent(decodedCnaeCode)}/pipeline/${latestCycle.researchCycleId}/stages/${stage.code}`}
+                        >
+                          Ver detalhes
+                        </Link>
+                      ) : (
+                        <button
+                          type="button"
+                          className="btn btn-outline-secondary btn-sm"
+                          disabled
+                        >
+                          Ver detalhes
+                        </button>
+                      )}
                     </div>
                   </div>
                 </div>

--- a/frontend/src/pages/oprm/OprmCnaePipelineStageDetailPage.tsx
+++ b/frontend/src/pages/oprm/OprmCnaePipelineStageDetailPage.tsx
@@ -1,0 +1,332 @@
+import { Link, useParams } from "react-router-dom";
+import {
+  isOprmCnaePipelineStageCode,
+  type OprmCnaePipelineStageCode,
+  useOprmCnaePipelineStageDetail,
+} from "../../api/oprm/useOprmCnaePipelineStageDetail";
+import { useBreadcrumbs } from "../../app/breadcrumbs";
+import PageTitle from "../../components/PageTitle";
+import OprmModuleNavigation from "./OprmModuleNavigation";
+
+interface StageMetadata {
+  code: OprmCnaePipelineStageCode;
+  title: string;
+  technicalName: string;
+  description: string;
+  populatedTables: string[];
+  dataContent: string[];
+  usesAiModel: boolean;
+  aiModel?: string;
+  aiRequestSummary?: string;
+  aiResponseSummary?: string;
+}
+
+const stageMetadataByCode: Record<OprmCnaePipelineStageCode, StageMetadata> = {
+  cycle: {
+    code: "cycle",
+    title: "1. Ciclo",
+    technicalName: "oprmRoutineResearchCycle",
+    description:
+      "Controla o ciclo pai da pesquisa, mantendo o CNAE, o nicho operacional e os contadores das próximas etapas.",
+    populatedTables: ["oprm_routine_research_cycle"],
+    dataContent: [
+      "CNAE, descrição, nome do nicho, modo de pesquisa e score de origem.",
+      "Status do ciclo, totais de queries, fontes, snapshots, sinais, início, fim e erro operacional.",
+    ],
+    usesAiModel: false,
+  },
+  seed: {
+    code: "seed",
+    title: "2. Seed",
+    technicalName: "oprmNicheResearchSeedBuilder",
+    description:
+      "Transforma o CNAE em seed operacional e frases de pesquisa para buscar sinais reais do nicho.",
+    populatedTables: ["oprm_niche_research_seed", "oprm_niche_research_query"],
+    dataContent: [
+      "Seed com tipo de negócio, operação, cliente, objetos comerciais e suposições iniciais.",
+      "Queries priorizadas com objetivo, grupo de fonte, status e contador de resultados.",
+    ],
+    usesAiModel: true,
+    aiModel: "gpt-4.1-mini",
+    aiRequestSummary:
+      "Request para OpenAI Responses API com prompt de pesquisa de rotina real e schema JSON estruturado para seed e queries.",
+    aiResponseSummary:
+      "Resposta JSON validada e persistida como seed do nicho e lista de queries operacionais.",
+  },
+  search: {
+    code: "search",
+    title: "3. Busca",
+    technicalName: "oprmSourceSearcher",
+    description:
+      "Executa as queries em fontes públicas e grava candidatos de páginas para análise posterior.",
+    populatedTables: ["oprm_source_candidate", "oprm_niche_research_query"],
+    dataContent: [
+      "URLs candidatas, domínio, título, snippet, posição, provedor de busca, tipo de fonte e scores iniciais.",
+      "Status das queries, quantidade de resultados e último erro de busca quando houver.",
+    ],
+    usesAiModel: false,
+  },
+  fetch: {
+    code: "fetch",
+    title: "4. Coleta",
+    technicalName: "oprmSourceFetcher",
+    description:
+      "Coleta metadados e trecho curto das fontes candidatas selecionadas.",
+    populatedTables: ["oprm_source_snapshot", "oprm_source_candidate"],
+    dataContent: [
+      "Título, domínio, tipo de fonte, data de publicação, snippet, trecho curto e metadados de aderência.",
+      "Status da fonte candidata após coleta ou rejeição operacional.",
+    ],
+    usesAiModel: false,
+  },
+  signals: {
+    code: "signals",
+    title: "5. Sinais",
+    technicalName: "oprmSignalExtractor",
+    description:
+      "Extrai sinais estruturados de rotina, dores, linguagem, tarefas e evidências a partir dos snapshots.",
+    populatedTables: ["oprm_extracted_signal", "oprm_source_snapshot"],
+    dataContent: [
+      "Tipo do sinal, texto do sinal, trecho de evidência, domínio de origem e score de confiança.",
+      "Contadores de sinais no ciclo e status dos snapshots processados.",
+    ],
+    usesAiModel: false,
+  },
+  synthesis: {
+    code: "synthesis",
+    title: "6. Síntese",
+    technicalName: "oprmRoutineSynthesizer",
+    description:
+      "Monta o cartão de rotina que resume o que o público vive, sofre, deseja e fala.",
+    populatedTables: ["oprm_niche_routine_card"],
+    dataContent: [
+      "Resumo de rotina, comportamento, canais, dores operacionais/emocionais, sonhos, medos e linguagem.",
+      "Resumo de evidências, domínios usados e scores de confiança, rotina, dificuldade, diversidade e risco de solução.",
+    ],
+    usesAiModel: false,
+  },
+  mei: {
+    code: "mei",
+    title: "7. MEI",
+    technicalName: "oprmMeiAudienceSegmenter",
+    description:
+      "Define o perfil comportamental MEI/autônomo dono-operador do nicho sem criar produto ou campanha.",
+    populatedTables: ["oprm_mei_audience_profile", "oprm_niche_routine_card"],
+    dataContent: [
+      "Nome do público, termos de ocupação, modo de trabalho, rotina, tarefas, canais, dores, sonhos, medos e linguagem.",
+      "Scores de aderência autônoma, evidência comportamental, frescor da fonte e riscos de desvio corporativo/solução.",
+    ],
+    usesAiModel: true,
+    aiModel: "gpt-4.1-mini",
+    aiRequestSummary:
+      "Request para OpenAI Responses API com cartão de rotina, fontes e sinais para segmentar o público MEI/autônomo real.",
+    aiResponseSummary:
+      "Resposta JSON validada e persistida como perfil comportamental aprovado ou bloqueado pelo gate de qualidade.",
+  },
+  quality: {
+    code: "quality",
+    title: "8. Qualidade",
+    technicalName: "oprmRoutineQualityGate",
+    description:
+      "Valida se a pesquisa ficou específica, recente, diversa e sem contaminação por solução pronta.",
+    populatedTables: ["oprm_niche_routine_card", "oprm_routine_research_cycle"],
+    dataContent: [
+      "Status de qualidade, pronto para hipótese, notas do gate, avaliador e data da checagem.",
+      "Scores de especificidade, confiança, duplicação, evidência de rotina, evidência de dificuldade e diversidade.",
+    ],
+    usesAiModel: false,
+  },
+  materialization: {
+    code: "materialization",
+    title: "9. Materialização",
+    technicalName: "oprmEnrichedNicheMaterializer",
+    description:
+      "Grava o nicho enriquecido aprovado para alimentar hipóteses, ofertas e experimentos comerciais.",
+    populatedTables: ["market_niche", "market_niche_enrichment_profile"],
+    dataContent: [
+      "Nicho final, CNAE, resumo de rotina, dores, resultados, oportunidades de mecanismo, evidências e fontes.",
+      "IDs do nicho e perfil enriquecido, qualidade final, scores de evidência/diversidade e data de materialização.",
+    ],
+    usesAiModel: false,
+  },
+};
+
+function formatJson(value: unknown) {
+  return JSON.stringify(value, null, 2);
+}
+
+function buildAiTelemetry(metadata: StageMetadata) {
+  if (!metadata.usesAiModel) {
+    return null;
+  }
+  return {
+    modelo: metadata.aiModel ?? "não informado",
+    request: metadata.aiRequestSummary,
+    response: metadata.aiResponseSummary,
+    tokensEntrada: "não persistido no detalhe atual",
+    tokensSaida: "não persistido no detalhe atual",
+    custoUsd: "não persistido no detalhe atual",
+  };
+}
+
+export default function OprmCnaePipelineStageDetailPage() {
+  const { cnaeCode, researchCycleId, stageCode } = useParams();
+  const decodedCnaeCode = cnaeCode ? decodeURIComponent(cnaeCode) : "CNAE";
+  const cycleId = Number(researchCycleId);
+  const validStageCode = isOprmCnaePipelineStageCode(stageCode)
+    ? stageCode
+    : undefined;
+  const metadata = validStageCode
+    ? stageMetadataByCode[validStageCode]
+    : undefined;
+  const isValidCycleId = Number.isInteger(cycleId) && cycleId > 0;
+  const { data, isLoading, isError, error } = useOprmCnaePipelineStageDetail(
+    validStageCode,
+    isValidCycleId ? cycleId : undefined,
+  );
+  const aiTelemetry = metadata ? buildAiTelemetry(metadata) : null;
+
+  useBreadcrumbs([
+    { label: "OPRM", to: "/oprm" },
+    { label: "Detalhe do nicho", to: `/oprm/cnaes/${encodeURIComponent(decodedCnaeCode)}` },
+    { label: "Detalhe da etapa" },
+  ]);
+
+  return (
+    <div className="d-flex flex-column gap-4">
+      <header className="d-flex flex-column gap-2">
+        <PageTitle>Detalhe da etapa NichoCNAE</PageTitle>
+        <p className="text-secondary mb-0">
+          Esta página concentra a tabela populada, o conteúdo gravado e a
+          auditoria de IA da etapa, sem poluir a tela principal do CNAE.
+        </p>
+      </header>
+
+      <OprmModuleNavigation />
+
+      <div className="d-flex flex-wrap gap-2">
+        <Link
+          className="btn btn-outline-secondary btn-sm"
+          to={`/oprm/cnaes/${encodeURIComponent(decodedCnaeCode)}`}
+        >
+          Voltar ao CNAE
+        </Link>
+        <Link className="btn btn-outline-secondary btn-sm" to="/oprm/pipeline">
+          Ver pipeline geral
+        </Link>
+      </div>
+
+      {!metadata || !validStageCode || !isValidCycleId ? (
+        <div className="alert alert-warning" role="alert">
+          Etapa ou ciclo inválido na URL. Volte ao detalhe do CNAE e abra os
+          detalhes por um card válido.
+        </div>
+      ) : (
+        <>
+          <section className="card border-0 shadow-sm">
+            <div className="card-body d-flex flex-column gap-3">
+              <div className="d-flex flex-wrap justify-content-between gap-3">
+                <div>
+                  <span className="badge text-bg-primary mb-2">
+                    {metadata.technicalName}
+                  </span>
+                  <h2 className="h5 mb-2">{metadata.title}</h2>
+                  <p className="text-secondary mb-0">{metadata.description}</p>
+                </div>
+                <div className="text-secondary small text-lg-end">
+                  <span className="d-block">CNAE {decodedCnaeCode}</span>
+                  <span className="d-block">Ciclo #{cycleId}</span>
+                </div>
+              </div>
+            </div>
+          </section>
+
+          <section className="card border-0 shadow-sm">
+            <div className="card-body">
+              <h2 className="h5 mb-3">Tabelas e conteúdo populado</h2>
+              <div className="table-responsive">
+                <table className="table table-sm align-middle mb-0">
+                  <thead>
+                    <tr>
+                      <th scope="col">Tabela</th>
+                      <th scope="col">Conteúdo dos dados</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {metadata.populatedTables.map((tableName, index) => (
+                      <tr key={tableName}>
+                        <td className="fw-semibold text-nowrap">{tableName}</td>
+                        <td>{metadata.dataContent[index] ?? metadata.dataContent[0]}</td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            </div>
+          </section>
+
+          <section className="card border-0 shadow-sm">
+            <div className="card-body">
+              <h2 className="h5 mb-3">Acesso a modelo de IA</h2>
+              {aiTelemetry ? (
+                <div className="d-flex flex-column gap-3">
+                  <dl className="row g-2 mb-0">
+                    <dt className="col-md-3 text-secondary fw-normal">Modelo</dt>
+                    <dd className="col-md-9 mb-0 fw-semibold">
+                      {aiTelemetry.modelo}
+                    </dd>
+                    <dt className="col-md-3 text-secondary fw-normal">Request</dt>
+                    <dd className="col-md-9 mb-0">{aiTelemetry.request}</dd>
+                    <dt className="col-md-3 text-secondary fw-normal">Response</dt>
+                    <dd className="col-md-9 mb-0">{aiTelemetry.response}</dd>
+                    <dt className="col-md-3 text-secondary fw-normal">Tokens</dt>
+                    <dd className="col-md-9 mb-0">
+                      Entrada: {aiTelemetry.tokensEntrada} · Saída:{" "}
+                      {aiTelemetry.tokensSaida}
+                    </dd>
+                    <dt className="col-md-3 text-secondary fw-normal">Custo</dt>
+                    <dd className="col-md-9 mb-0">{aiTelemetry.custoUsd}</dd>
+                  </dl>
+                  <div className="alert alert-info mb-0 small" role="status">
+                    Para exibir tokens e custo reais, o backend precisa receber
+                    e persistir telemetria de uso da chamada OpenAI desta etapa.
+                  </div>
+                </div>
+              ) : (
+                <div className="alert alert-secondary mb-0" role="status">
+                  Esta etapa não acessa modelo de IA diretamente; ela usa dados
+                  já gravados por etapas anteriores ou coleta determinística.
+                </div>
+              )}
+            </div>
+          </section>
+
+          <section className="card border-0 shadow-sm">
+            <div className="card-body">
+              <h2 className="h5 mb-3">Dados retornados pelo backend</h2>
+              {isLoading ? (
+                <div className="text-secondary">Carregando dados da etapa...</div>
+              ) : isError ? (
+                <div className="alert alert-warning mb-0" role="alert">
+                  {error instanceof Error
+                    ? error.message
+                    : "Não foi possível carregar os dados."}
+                </div>
+              ) : data ? (
+                <pre className="bg-body-tertiary border rounded p-3 small overflow-auto mb-0">
+                  {formatJson(data)}
+                </pre>
+              ) : (
+                <div className="alert alert-info mb-0" role="status">
+                  Ainda não há dados públicos gravados para esta etapa neste
+                  ciclo, ou o registro existe mas ainda não foi aprovado para
+                  consumo.
+                </div>
+              )}
+            </div>
+          </section>
+        </>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
### Motivation

- Give users a way to inspect each pipeline card without cluttering the CNAE overview by opening a dedicated detail page per stage. 

### Description

- Add a new route `/oprm/cnaes/:cnaeCode/pipeline/:researchCycleId/stages/:stageCode` and page `OprmCnaePipelineStageDetailPage` that shows populated tables, stored content descriptions, backend JSON and AI telemetry for the selected stage. 
- Add `useOprmCnaePipelineStageDetail` hook to fetch existing backend stage detail endpoints and gracefully handle missing/unapproved records. 
- Update CNAE detail cards to include a `code` per stage and a `Ver detalhes` button that opens the new page when a cycle exists. 
- Document the UI change in `docs/registros/oprm1.md` and include per-stage metadata (including which stages use AI and conceptual request/response notes). 

### Testing

- Ran TypeScript checks with `npm run typecheck` which completed without errors. 
- Built the frontend with `npm run build` which succeeded and produced the `dist/` artifacts. 
- Exercised the new page visually using Playwright to capture a screenshot with `npx playwright screenshot ...` which produced a non-empty image file, validating the page renders and the new route is reachable.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2b8c7462408321942767093e024174)