### PR TITLE
OPRM: restrict MEI audience segmentation queue to eligible ROUTINE_SYNTHESIZED cycles

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/meiaudiencesegmenter/service/BackendMeiAudienceSegmenterService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/meiaudiencesegmenter/service/BackendMeiAudienceSegmenterService.java
@@ -22,6 +22,7 @@ import java.time.Instant;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
+import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.data.domain.PageRequest;
@@ -33,6 +34,7 @@ import org.springframework.util.StringUtils;
 @Service
 public class BackendMeiAudienceSegmenterService {
   private static final Logger LOGGER = LoggerFactory.getLogger(BackendMeiAudienceSegmenterService.class);
+  private static final String ROUTINE_SYNTHESIZED_STATUS = "ROUTINE_SYNTHESIZED";
   private static final String SEGMENTED_STATUS = "MEI_AUDIENCE_SEGMENTED";
   private static final String FAILED_STATUS = "FAILED";
   private static final int MAX_PENDING = 10;
@@ -62,11 +64,12 @@ public class BackendMeiAudienceSegmenterService {
     this.profileService = profileService;
   }
 
-  /** Lista cartões sintetizados que ainda precisam de segmentação comportamental antes do gate e materialização. */
+  /** Lista somente cartões de ciclos ativos e elegíveis para segmentação comportamental antes do gate e materialização. */
   @Transactional(readOnly = true)
   public List<RecordMeiAudienceSegmenterPending> listPending() {
     return routineCardRepository.findPendingMeiAudienceSegmentation(PageRequest.of(0, MAX_PENDING)).stream()
-        .map(this::toPending)
+        .map(this::toPendingIfEligible)
+        .flatMap(Optional::stream)
         .toList();
   }
 
@@ -117,9 +120,17 @@ public class BackendMeiAudienceSegmenterService {
     }
   }
 
-  /** Converte cartão, ciclo, fontes e sinais na unidade de trabalho enviada ao coletor de IA. */
-  private RecordMeiAudienceSegmenterPending toPending(OprmNicheRoutineCard card) {
+  /** Revalida a elegibilidade do ciclo antes de expor o cartão na fila MEI/autônomo. */
+  private Optional<RecordMeiAudienceSegmenterPending> toPendingIfEligible(OprmNicheRoutineCard card) {
     OprmRoutineResearchCycle cycle = findCycle(card.getResearchCycleId());
+    if (!ROUTINE_SYNTHESIZED_STATUS.equals(cycle.getStatus())) {
+      return Optional.empty();
+    }
+    return Optional.of(toPending(card, cycle));
+  }
+
+  /** Converte cartão, ciclo, fontes e sinais na unidade de trabalho enviada ao coletor de IA. */
+  private RecordMeiAudienceSegmenterPending toPending(OprmNicheRoutineCard card, OprmRoutineResearchCycle cycle) {
     List<OprmSourceSnapshot> snapshots = sourceSnapshotRepository.findByResearchCycleIdOrderByIdAsc(card.getResearchCycleId());
     List<OprmExtractedSignal> signals = extractedSignalRepository.findByResearchCycleIdOrderByIdAsc(card.getResearchCycleId());
     return new RecordMeiAudienceSegmenterPending(

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/oprm/nichocnae/OprmNicheRoutineCardRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/oprm/nichocnae/OprmNicheRoutineCardRepository.java
@@ -19,16 +19,32 @@ public interface OprmNicheRoutineCardRepository extends JpaRepository<OprmNicheR
   /** Lista cartões sintetizados ainda não avaliados pelo gate de qualidade. */
   List<OprmNicheRoutineCard> findByQualityCheckedAtIsNullOrderByCreatedAtAscIdAsc(Pageable pageable);
 
-  /** Lista cartões sintetizados que ainda não possuem segmentação comportamental MEI/autônomo persistida. */
+  /** Lista cartões do ciclo ativo sintetizado mais recente que ainda não possuem segmentação MEI/autônomo. */
   @Query("""
       select c from OprmNicheRoutineCard c
-      where not exists (
-        select 1 from OprmMeiAudienceProfile p
-        where p.researchCycleId = c.researchCycleId
-      )
-      order by c.createdAt asc, c.id asc
+      join OprmRoutineResearchCycle cycle on cycle.id = c.researchCycleId
+      where cycle.status = 'ROUTINE_SYNTHESIZED'
+        and not exists (
+          select 1 from OprmMeiAudienceProfile p
+          where p.researchCycleId = c.researchCycleId
+        )
+        and not exists (
+          select 1 from MarketNicheEnrichmentProfile enrichment
+          where enrichment.sourceRoutineCardId = c.id
+             or enrichment.researchCycleId = c.researchCycleId
+        )
+        and not exists (
+          select 1 from OprmRoutineResearchCycle newerCycle
+          where newerCycle.sourceNicheId = cycle.sourceNicheId
+            and (
+              newerCycle.startedAt > cycle.startedAt
+              or (newerCycle.startedAt = cycle.startedAt and newerCycle.id > cycle.id)
+            )
+        )
+      order by cycle.startedAt desc, c.createdAt asc, c.id asc
       """)
   List<OprmNicheRoutineCard> findPendingMeiAudienceSegmentation(Pageable pageable);
+
   /** Lista cartões aprovados no gate de qualidade que ainda não alimentaram nicho e nicho enriquecido. */
   @Query("""
       select c from OprmNicheRoutineCard c

--- a/backend/ads-service/src/test/java/com/marketinghub/oprm/nichocnae/OprmNicheRoutineCardRepositoryTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/oprm/nichocnae/OprmNicheRoutineCardRepositoryTest.java
@@ -1,0 +1,125 @@
+package com.marketinghub.oprm.nichocnae;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.marketinghub.oprm.nichocnae.meiaudienceprofile.OprmMeiAudienceProfile;
+import com.marketinghub.repository.jpa.oprm.nichocnae.OprmNicheRoutineCardRepository;
+import com.marketinghub.repository.jpa.oprm.nichocnae.OprmRoutineResearchCycleRepository;
+import com.marketinghub.repository.jpa.oprm.nichocnae.meiaudienceprofile.OprmMeiAudienceProfileRepository;
+import java.math.BigDecimal;
+import java.time.Instant;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.test.context.TestPropertySource;
+
+/** Testes responsáveis por validar as filas derivadas dos cartões de rotina do OPRM NichoCNAE. */
+@DataJpaTest
+@TestPropertySource(properties = "spring.liquibase.enabled=false")
+class OprmNicheRoutineCardRepositoryTest {
+  @Autowired OprmRoutineResearchCycleRepository cycleRepository;
+  @Autowired OprmNicheRoutineCardRepository routineCardRepository;
+  @Autowired OprmMeiAudienceProfileRepository meiAudienceProfileRepository;
+
+  /** Garante que a fila MEI/autônomo expõe somente o ciclo ativo sintetizado mais recente. */
+  @Test
+  void findPendingMeiAudienceSegmentationShouldReturnOnlyLatestEligibleSynthesizedCycle() {
+    OprmRoutineResearchCycle oldSynthesized = saveCycle(100L, "ROUTINE_SYNTHESIZED", "2026-06-01T10:00:00Z");
+    OprmNicheRoutineCard oldCard = saveCard(oldSynthesized, "cartão antigo sintetizado");
+    OprmRoutineResearchCycle latestSynthesized = saveCycle(100L, "ROUTINE_SYNTHESIZED", "2026-06-02T10:00:00Z");
+    OprmNicheRoutineCard latestCard = saveCard(latestSynthesized, "cartão recente sintetizado");
+    OprmRoutineResearchCycle failed = saveCycle(200L, "FAILED", "2026-06-03T10:00:00Z");
+    OprmNicheRoutineCard failedCard = saveCard(failed, "cartão falho");
+    OprmRoutineResearchCycle cancelled = saveCycle(300L, "CANCELLED_BY_MANUAL_RESTART", "2026-06-04T10:00:00Z");
+    OprmNicheRoutineCard cancelledCard = saveCard(cancelled, "cartão cancelado");
+    OprmRoutineResearchCycle segmented = saveCycle(400L, "MEI_AUDIENCE_SEGMENTED", "2026-06-05T10:00:00Z");
+    OprmNicheRoutineCard segmentedCard = saveCard(segmented, "cartão já segmentado");
+    saveProfile(segmented, segmentedCard);
+
+    assertThat(routineCardRepository.findPendingMeiAudienceSegmentation(PageRequest.of(0, 10)))
+        .extracting(OprmNicheRoutineCard::getId)
+        .containsExactly(latestCard.getId())
+        .doesNotContain(oldCard.getId(), failedCard.getId(), cancelledCard.getId(), segmentedCard.getId());
+  }
+
+  /** Persiste um ciclo com os campos mínimos exigidos pelo contrato JPA do NichoCNAE. */
+  private OprmRoutineResearchCycle saveCycle(Long sourceNicheId, String status, String startedAt) {
+    Instant start = Instant.parse(startedAt);
+    OprmRoutineResearchCycle cycle = new OprmRoutineResearchCycle();
+    cycle.setSourceNicheId(sourceNicheId);
+    cycle.setCnaeCode("9602501");
+    cycle.setCnaeDescription("Cabeleireiros, manicure e pedicure");
+    cycle.setNicheName("manicures autônomas");
+    cycle.setOriginalNicheName("manicures autônomas");
+    cycle.setNeutralNicheName("serviços pessoais de beleza");
+    cycle.setResearchMode("NEUTRAL_ROUTINE_RESEARCH");
+    cycle.setSolutionLanguageRiskScore(BigDecimal.ZERO);
+    cycle.setSourceScore(BigDecimal.valueOf(85));
+    cycle.setTriggerSource("TEST");
+    cycle.setStatus(status);
+    cycle.setTotalQueries(1);
+    cycle.setTotalSourceCandidates(1);
+    cycle.setTotalSourceSnapshots(1);
+    cycle.setTotalExtractedSignals(1);
+    cycle.setStartedAt(start);
+    cycle.setFinishedAt(start.plusSeconds(60));
+    cycle.setCreatedAt(start);
+    cycle.setUpdatedAt(start);
+    return cycleRepository.saveAndFlush(cycle);
+  }
+
+  /** Persiste um cartão de rotina vinculado ao ciclo informado para alimentar a fila MEI/autônomo. */
+  private OprmNicheRoutineCard saveCard(OprmRoutineResearchCycle cycle, String routineSummary) {
+    OprmNicheRoutineCard card = new OprmNicheRoutineCard();
+    card.setResearchCycleId(cycle.getId());
+    card.setNicheName(cycle.getNicheName());
+    card.setRoutineSummary(routineSummary);
+    card.setPainsSummary("Dores operacionais recorrentes da rotina.");
+    card.setCustomerBehaviorSummary("Capta clientes por indicação e canais próprios.");
+    card.setChannelsSummary("WhatsApp e Instagram.");
+    card.setOperationalPainsSummary("Agenda instável e retrabalho.");
+    card.setEmotionalPainsSummary("Insegurança de renda.");
+    card.setDreamsSummary("Agenda previsível.");
+    card.setFearsSummary("Ficar sem clientes.");
+    card.setLanguageSummary("agenda cheia, cliente fixa, preço justo");
+    card.setResultsSummary("Rotina mais previsível e organizada.");
+    card.setMechanismOpportunitiesSummary("Organização operacional e priorização de tarefas.");
+    card.setEvidenceSummary("Evidências brasileiras recentes sobre rotina autônoma.");
+    card.setSourceDomains("example.com");
+    card.setConfidenceScore(90);
+    card.setRoutineEvidenceScore(88);
+    card.setDifficultyEvidenceScore(82);
+    card.setSourceDiversityScore(75);
+    card.setSolutionLanguageRiskScore(0);
+    card.setReadyForHypothesis(false);
+    card.setSynthesizedBy("test");
+    card.setCreatedAt(cycle.getStartedAt().plusSeconds(30));
+    return routineCardRepository.saveAndFlush(card);
+  }
+
+  /** Persiste um perfil MEI/autônomo para simular ciclo que já saiu da fila de segmentação. */
+  private void saveProfile(OprmRoutineResearchCycle cycle, OprmNicheRoutineCard card) {
+    OprmMeiAudienceProfile profile = new OprmMeiAudienceProfile();
+    profile.setResearchCycleId(cycle.getId());
+    profile.setRoutineCardId(card.getId());
+    profile.setSourceNicheCandidateId(cycle.getSourceNicheId());
+    profile.setCnaeCode(cycle.getCnaeCode());
+    profile.setCnaeDescription(cycle.getCnaeDescription());
+    profile.setNeutralNicheName(cycle.getNeutralNicheName());
+    profile.setAudienceName("manicures MEI que atendem por agenda própria");
+    profile.setWorkMode("Atendimento autônomo com agenda própria.");
+    profile.setDailyRoutineSummary("Agenda, atende, cobra e reorganiza horários.");
+    profile.setOperationalPainsSummary("Cancelamentos e retrabalho.");
+    profile.setRecentSourceSummary("Fontes recentes sobre rotina de manicures autônomas.");
+    profile.setAutonomousProfessionalFitScore(92);
+    profile.setBehavioralEvidenceScore(88);
+    profile.setSourceFreshnessScore(81);
+    profile.setOutdatedSourceRiskScore(12);
+    profile.setStructuredBusinessDriftRiskScore(9);
+    profile.setSolutionLanguageRiskScore(0);
+    profile.setCreatedAt(cycle.getUpdatedAt());
+    profile.setUpdatedAt(cycle.getUpdatedAt());
+    meiAudienceProfileRepository.saveAndFlush(profile);
+  }
+}

--- a/backend/ads-service/src/test/java/com/marketinghub/oprm/nichocnae/meiaudiencesegmenter/service/BackendMeiAudienceSegmenterServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/oprm/nichocnae/meiaudiencesegmenter/service/BackendMeiAudienceSegmenterServiceTest.java
@@ -1,0 +1,89 @@
+package com.marketinghub.oprm.nichocnae.meiaudiencesegmenter.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import com.marketinghub.oprm.nichocnae.OprmNicheRoutineCard;
+import com.marketinghub.oprm.nichocnae.OprmRoutineResearchCycle;
+import com.marketinghub.oprm.nichocnae.meiaudienceprofile.service.BackendMeiAudienceProfileService;
+import com.marketinghub.repository.jpa.oprm.nichocnae.OprmExtractedSignalRepository;
+import com.marketinghub.repository.jpa.oprm.nichocnae.OprmNicheRoutineCardRepository;
+import com.marketinghub.repository.jpa.oprm.nichocnae.OprmRoutineResearchCycleRepository;
+import com.marketinghub.repository.jpa.oprm.nichocnae.OprmSourceSnapshotRepository;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.springframework.data.domain.Pageable;
+
+/** Testes responsáveis por validar a fila backend da etapa de segmentação MEI/autônomo. */
+class BackendMeiAudienceSegmenterServiceTest {
+  private final OprmRoutineResearchCycleRepository cycleRepository = mock(OprmRoutineResearchCycleRepository.class);
+  private final OprmNicheRoutineCardRepository routineCardRepository = mock(OprmNicheRoutineCardRepository.class);
+  private final OprmExtractedSignalRepository extractedSignalRepository = mock(OprmExtractedSignalRepository.class);
+  private final OprmSourceSnapshotRepository sourceSnapshotRepository = mock(OprmSourceSnapshotRepository.class);
+  private final BackendMeiAudienceProfileService profileService = mock(BackendMeiAudienceProfileService.class);
+  private final BackendMeiAudienceSegmenterService service = new BackendMeiAudienceSegmenterService(
+      cycleRepository,
+      routineCardRepository,
+      extractedSignalRepository,
+      sourceSnapshotRepository,
+      profileService);
+
+  /** Garante que o serviço não exponha cartões caso a consulta retorne ciclo fora do status elegível. */
+  @Test
+  void listPendingShouldRevalidateEligibleCycleBeforeExposingQueue() {
+    OprmNicheRoutineCard failedCard = card(10L, 1L);
+    OprmNicheRoutineCard synthesizedCard = card(20L, 2L);
+    when(routineCardRepository.findPendingMeiAudienceSegmentation(any(Pageable.class)))
+        .thenReturn(List.of(failedCard, synthesizedCard));
+    when(cycleRepository.findById(10L)).thenReturn(Optional.of(cycle(10L, "FAILED")));
+    when(cycleRepository.findById(20L)).thenReturn(Optional.of(cycle(20L, "ROUTINE_SYNTHESIZED")));
+    when(sourceSnapshotRepository.findByResearchCycleIdOrderByIdAsc(20L)).thenReturn(List.of());
+    when(extractedSignalRepository.findByResearchCycleIdOrderByIdAsc(20L)).thenReturn(List.of());
+
+    assertThat(service.listPending())
+        .extracting(pending -> pending.researchCycleId())
+        .containsExactly(20L);
+  }
+
+  /** Monta um ciclo mínimo usado pela revalidação da fila MEI/autônomo. */
+  private OprmRoutineResearchCycle cycle(Long id, String status) {
+    OprmRoutineResearchCycle cycle = new OprmRoutineResearchCycle();
+    cycle.setId(id);
+    cycle.setSourceNicheId(100L);
+    cycle.setCnaeCode("9602501");
+    cycle.setCnaeDescription("Cabeleireiros, manicure e pedicure");
+    cycle.setNeutralNicheName("serviços pessoais de beleza");
+    cycle.setStatus(status);
+    return cycle;
+  }
+
+  /** Monta um cartão mínimo para conversão em item pendente da fila MEI/autônomo. */
+  private OprmNicheRoutineCard card(Long researchCycleId, Long cardId) {
+    OprmNicheRoutineCard card = new OprmNicheRoutineCard();
+    card.setId(cardId);
+    card.setResearchCycleId(researchCycleId);
+    card.setNicheName("manicures autônomas");
+    card.setRoutineSummary("Rotina operacional concreta.");
+    card.setCustomerBehaviorSummary("Clientes chegam por indicação.");
+    card.setChannelsSummary("WhatsApp e Instagram.");
+    card.setOperationalPainsSummary("Agenda instável.");
+    card.setEmotionalPainsSummary("Insegurança de renda.");
+    card.setDreamsSummary("Agenda cheia.");
+    card.setFearsSummary("Ficar sem clientes.");
+    card.setLanguageSummary("agenda cheia, cliente fixa");
+    card.setPainsSummary("Cancelamentos e retrabalho.");
+    card.setResultsSummary("Rotina mais previsível.");
+    card.setEvidenceSummary("Evidências brasileiras recentes.");
+    card.setSourceDomains("example.com");
+    card.setRoutineEvidenceScore(80);
+    card.setDifficultyEvidenceScore(80);
+    card.setSourceDiversityScore(70);
+    card.setSolutionLanguageRiskScore(0);
+    card.setCreatedAt(Instant.parse("2026-06-12T00:00:00Z"));
+    return card;
+  }
+}

--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -493,3 +493,9 @@
 - A nova página informa as tabelas populadas por etapa, o tipo de conteúdo gravado, os dados retornados pelo backend e se a etapa acessa modelo de IA.
 - Para etapas com IA, a página exibe request/response conceitual, modelo configurado e deixa explícito quando tokens e custo ainda não estão persistidos no detalhe operacional.
 - 2026-06-12 00:00:00 (UTC): diagnosticada parada do ciclo OPRM NichoCNAE #20 na etapa `oprmNicheResearchSeedBuilder`: endpoint backend operacional em `http://191.252.181.168/api/internal/oprm/nichocnae/niche-research-seed-builder/stage-executions/pending` retorna o ciclo, enquanto a porta `:8000` responde indisponível para o coletor e os logs publicados não exibem o boot do scheduler `Scheduler da etapa dois OPRM NichoCNAE carregado`. Corrigido o default do `oprm-coletor-mei` para usar a URL operacional sem porta, adicionado teste de carregamento do pacote `com.marketinghub.nichocnae` e criada proteção backend para marcar ciclos `RUNNING` sem progresso como `STALLED`, evitando tela com execução aparentemente saudável quando o pipeline estiver parado.
+
+## 2026-06-12 — OPRM NichoCNAE: fila MEI/autônomo por ciclo elegível
+
+- Ajustada a fila da etapa MEI/autônomo para expor somente cartões do ciclo mais recente realmente elegível em `ROUTINE_SYNTHESIZED`, sem puxar ciclos falhos, cancelados por reinício manual, já segmentados ou antigos substituídos por execução mais nova.
+- Causa-raiz tratada: a consulta anterior olhava apenas a ausência de perfil MEI/autônomo e podia reenfileirar cartões históricos ou descartados, consumindo IA em ciclos que não faziam mais parte do fluxo ativo de venda.
+- Prevenção de recorrência: adicionada revalidação no serviço da fila e teste de regressão garantindo que somente o ciclo `ROUTINE_SYNTHESIZED` mais recente aparece para processamento.


### PR DESCRIPTION
### Motivation
- Prevent the MEI/autônomo queue from returning cards that belong to final/discarded or older cycles and avoid wasting IA resources on ineligible cycles.
- Prioritize processing of cards from the active `ROUTINE_SYNTHESIZED` cycle so the pipeline only handles cycles that are part of the active flow. 

### Description
- Tightened `findPendingMeiAudienceSegmentation(Pageable)` in `OprmNicheRoutineCardRepository.java` to join the cycle, require `cycle.status = 'ROUTINE_SYNTHESIZED'`, exclude cards/cycles already materialized or with existing MEI profiles, and ignore cycles superseded by a newer cycle for the same `sourceNicheId`.
- Updated `BackendMeiAudienceSegmenterService` so `listPending()` revalidates each card's cycle before exposing it, adding `toPendingIfEligible(...)` which returns empty when the cycle is not `ROUTINE_SYNTHESIZED`, and refactored `toPending(...)` to accept the cycle object.
- Added an integration-style JPA test `OprmNicheRoutineCardRepositoryTest` that asserts repository query excludes failed, cancelled, already-segmented and older cycles while keeping the most recent synthesized cycle.
- Added a unit test `BackendMeiAudienceSegmenterServiceTest` that verifies the service revalidates cycles and only exposes cards whose cycle is `ROUTINE_SYNTHESIZED`.
- Documented the change in `docs/registros/oprm1.md` describing the cause and prevention of the recurrence.

### Testing
- Ran `OprmNicheRoutineCardRepositoryTest` (Data JPA) which passed and confirmed the repository query returns only the expected latest `ROUTINE_SYNTHESIZED` card.
- Ran `BackendMeiAudienceSegmenterServiceTest` (unit test with Mockito) which passed and confirmed the service revalidation filters out non-eligible cycles.
- Executed the two tests together via Maven (`-Dtest=OprmNicheRoutineCardRepositoryTest,BackendMeiAudienceSegmenterServiceTest`) and the test run completed successfully with zero failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2bf6a365fc8321a055891c16b42391)