### PR TITLE
Passa modelo OpenAI e tokens da etapa `niche-research-seed-builder` para o backend e persiste metadados de custo

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/OprmNicheResearchSeed.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/OprmNicheResearchSeed.java
@@ -6,6 +6,7 @@ import jakarta.persistence.GeneratedValue;
 import jakarta.persistence.GenerationType;
 import jakarta.persistence.Id;
 import jakarta.persistence.Table;
+import java.math.BigDecimal;
 import java.time.Instant;
 import lombok.Data;
 
@@ -55,4 +56,22 @@ public class OprmNicheResearchSeed {
 
     @Column(name = "created_at", nullable = false)
     private Instant createdAt;
+
+    @Column(name = "model", length = 128)
+    private String model;
+
+    @Column(name = "raw_model_response", columnDefinition = "LONGTEXT")
+    private String rawModelResponse;
+
+    @Column(name = "input_tokens")
+    private Integer inputTokens;
+
+    @Column(name = "output_tokens")
+    private Integer outputTokens;
+
+    @Column(name = "cost_usd", precision = 12, scale = 4)
+    private BigDecimal costUsd;
+
+    @Column(name = "openai_response_id", length = 128)
+    private String openAiResponseId;
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/nicheresearchseedbuilder/service/BackendNicheResearchSeedBuilderService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/nicheresearchseedbuilder/service/BackendNicheResearchSeedBuilderService.java
@@ -1,5 +1,8 @@
 package com.marketinghub.oprm.nichocnae.nicheresearchseedbuilder.service;
 
+import com.marketinghub.openai.OpenAiModel;
+import com.marketinghub.openai.OpenAiResponse;
+import com.marketinghub.openai.service.OpenAiPricingService;
 import com.marketinghub.oprm.nichocnae.OprmNicheResearchSeed;
 import com.marketinghub.oprm.nichocnae.OprmResearchQuery;
 import com.marketinghub.oprm.nichocnae.OprmRoutineResearchCycle;
@@ -13,7 +16,10 @@ import com.marketinghub.oprm.nichocnae.nicheresearchseedbuilder.service.pending.
 import com.marketinghub.repository.jpa.oprm.nichocnae.OprmNicheResearchSeedRepository;
 import com.marketinghub.repository.jpa.oprm.nichocnae.OprmResearchQueryRepository;
 import com.marketinghub.repository.jpa.oprm.nichocnae.OprmRoutineResearchCycleRepository;
+import com.marketinghub.repository.jpa.pipeline.PipelineStageConfigRepository;
+import com.marketinghub.repository.jpa.pipeline.PipelineStageRepository;
 import jakarta.persistence.EntityNotFoundException;
+import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.Comparator;
 import java.util.List;
@@ -35,18 +41,30 @@ public class BackendNicheResearchSeedBuilderService {
   private static final String RETRYABLE_QUERY_GOAL_LENGTH_ERROR = "Data too long for column 'query_goal'";
   private static final String COMPLETE_STAGE_PATH_FRAGMENT = "niche-research-seed-builder/stage-executions";
   private static final String DEFAULT_CREATED_BY = "AI";
+  private static final String OPRM_NICHO_CNAE_PIPELINE_CODE = "oprm-nicho-cnae-pipeline";
+  private static final String OPRM_NICHO_CNAE_CANONICAL_VERSION = "oprm-nichocnae-canon.v1";
+  private static final String SEED_BUILDER_CANONICAL_CODE = "NICHE_RESEARCH_SEED_BUILDER";
   private final OprmRoutineResearchCycleRepository routineResearchCycleRepository;
   private final OprmNicheResearchSeedRepository nicheResearchSeedRepository;
   private final OprmResearchQueryRepository researchQueryRepository;
+  private final PipelineStageConfigRepository pipelineStageConfigRepository;
+  private final PipelineStageRepository pipelineStageRepository;
+  private final OpenAiPricingService openAiPricingService;
 
   /** Inicializa o serviço com os repositórios canônicos da etapa dois do pipeline. */
   public BackendNicheResearchSeedBuilderService(
       OprmRoutineResearchCycleRepository routineResearchCycleRepository,
       OprmNicheResearchSeedRepository nicheResearchSeedRepository,
-      OprmResearchQueryRepository researchQueryRepository) {
+      OprmResearchQueryRepository researchQueryRepository,
+      PipelineStageConfigRepository pipelineStageConfigRepository,
+      PipelineStageRepository pipelineStageRepository,
+      OpenAiPricingService openAiPricingService) {
     this.routineResearchCycleRepository = routineResearchCycleRepository;
     this.nicheResearchSeedRepository = nicheResearchSeedRepository;
     this.researchQueryRepository = researchQueryRepository;
+    this.pipelineStageConfigRepository = pipelineStageConfigRepository;
+    this.pipelineStageRepository = pipelineStageRepository;
+    this.openAiPricingService = openAiPricingService;
   }
 
   /** Lista ciclos em execução ou falhas retryáveis que ainda precisam receber seed e queries. */
@@ -183,6 +201,12 @@ public class BackendNicheResearchSeedBuilderService {
     seed.setConfidenceLevel(textOrDefault(request == null ? null : request.confidenceLevel(), "UNVALIDATED"));
     seed.setCreatedBy(normalizeCreatedBy(request == null ? null : request.createdBy()));
     seed.setCreatedAt(now);
+    seed.setModel(trimToNull(request == null ? null : request.model()));
+    seed.setRawModelResponse(trimToNull(request == null ? null : request.rawModelResponse()));
+    seed.setInputTokens(request == null ? null : request.inputTokens());
+    seed.setOutputTokens(request == null ? null : request.outputTokens());
+    seed.setCostUsd(estimateCostUsd(request));
+    seed.setOpenAiResponseId(trimToNull(request == null ? null : request.openAiResponseId()));
     return seed;
   }
 
@@ -236,6 +260,7 @@ public class BackendNicheResearchSeedBuilderService {
 
   /** Converte um ciclo pendente no contrato interno de unidade de trabalho da etapa dois. */
   private RecordNicheResearchSeedBuilderPending toPending(OprmRoutineResearchCycle cycle) {
+    OpenAiModel configuredModel = resolveConfiguredOpenAiModel();
     return new RecordNicheResearchSeedBuilderPending(
         cycle.getId(),
         cycle.getSourceNicheId(),
@@ -243,6 +268,8 @@ public class BackendNicheResearchSeedBuilderService {
         cycle.getCnaeDescription(),
         cycle.getNicheName(),
         cycle.getSourceScore(),
+        configuredModel == null ? null : configuredModel.getCode(),
+        configuredModel == null ? null : configuredModel.getName(),
         cycle.getStatus(),
         cycle.getStartedAt(),
         cycle.getCreatedAt());
@@ -265,6 +292,12 @@ public class BackendNicheResearchSeedBuilderService {
         seed.getConfidenceLevel(),
         seed.getCreatedBy(),
         seed.getCreatedAt(),
+        seed.getModel(),
+        seed.getRawModelResponse(),
+        seed.getInputTokens(),
+        seed.getOutputTokens(),
+        seed.getCostUsd(),
+        seed.getOpenAiResponseId(),
         queries.size(),
         queries.stream().map(this::toQueryResponse).toList());
   }
@@ -297,6 +330,42 @@ public class BackendNicheResearchSeedBuilderService {
       throw new IllegalArgumentException(fieldName + " is required");
     }
     return value.trim();
+  }
+
+  /** Calcula o custo padrão da chamada OpenAI sem bloquear a persistência quando o catálogo estiver incompleto. */
+  private BigDecimal estimateCostUsd(CompleteNicheResearchSeedBuilderRequest request) {
+    if (request == null || !StringUtils.hasText(request.model())) {
+      return null;
+    }
+    try {
+      return openAiPricingService.estimateStandardCost(
+          request.model(),
+          new OpenAiResponse.OpenAiUsage(request.inputTokens(), request.outputTokens(), null, null, null));
+    } catch (RuntimeException ex) {
+      LOGGER.warn(
+          "Não foi possível calcular custo da etapa dois OPRM nichocnae (model={}, inputTokens={}, outputTokens={})",
+          request.model(),
+          request.inputTokens(),
+          request.outputTokens(),
+          ex);
+      return null;
+    }
+  }
+
+  /** Recupera o modelo OpenAI configurado, priorizando contrato persistente e caindo no pipeline operacional legado. */
+  private OpenAiModel resolveConfiguredOpenAiModel() {
+    OpenAiModel persistentModel = pipelineStageConfigRepository
+        .findOfficialStageConfig(
+            OPRM_NICHO_CNAE_PIPELINE_CODE, OPRM_NICHO_CNAE_CANONICAL_VERSION, SEED_BUILDER_CANONICAL_CODE)
+        .map(config -> config.getOpenAiModel())
+        .orElse(null);
+    if (persistentModel != null) {
+      return persistentModel;
+    }
+    return pipelineStageRepository
+        .findByPipelineCodeAndStageCode(OPRM_NICHO_CNAE_PIPELINE_CODE, "niche-research-seed-builder")
+        .map(stage -> stage.getOpenAiModel())
+        .orElse(null);
   }
 
   /** Converte strings vazias em nulo para campos opcionais persistidos. */

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/nicheresearchseedbuilder/service/completeStageExecution/CompleteNicheResearchSeedBuilderRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/nicheresearchseedbuilder/service/completeStageExecution/CompleteNicheResearchSeedBuilderRequest.java
@@ -12,4 +12,9 @@ public record CompleteNicheResearchSeedBuilderRequest(
     String initialAssumptions,
     String confidenceLevel,
     String createdBy,
+    String model,
+    String rawModelResponse,
+    Integer inputTokens,
+    Integer outputTokens,
+    String openAiResponseId,
     List<NicheResearchQueryRequest> queries) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/nicheresearchseedbuilder/service/completeStageExecution/CompleteNicheResearchSeedBuilderResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/nicheresearchseedbuilder/service/completeStageExecution/CompleteNicheResearchSeedBuilderResponse.java
@@ -18,5 +18,11 @@ public record CompleteNicheResearchSeedBuilderResponse(
     String confidenceLevel,
     String createdBy,
     Instant createdAt,
+    String model,
+    String rawModelResponse,
+    Integer inputTokens,
+    Integer outputTokens,
+    java.math.BigDecimal costUsd,
+    String openAiResponseId,
     Integer totalQueries,
     List<NicheResearchQueryResponse> queries) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/nicheresearchseedbuilder/service/pending/RecordNicheResearchSeedBuilderPending.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/nicheresearchseedbuilder/service/pending/RecordNicheResearchSeedBuilderPending.java
@@ -11,6 +11,8 @@ public record RecordNicheResearchSeedBuilderPending(
     String cnaeDescription,
     String nicheName,
     BigDecimal sourceScore,
+    String openAiModelCode,
+    String openAiModelName,
     String status,
     Instant startedAt,
     Instant createdAt) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/pipeline/PipelineStageConfigRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/pipeline/PipelineStageConfigRepository.java
@@ -3,6 +3,8 @@ package com.marketinghub.repository.jpa.pipeline;
 import com.marketinghub.pipeline.PipelineStageConfig;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 /**
  * Repositório JPA centralizado para configurações operacionais editáveis de etapas de pipeline.
@@ -12,4 +14,22 @@ public interface PipelineStageConfigRepository extends JpaRepository<PipelineSta
      * Busca a configuração operacional ligada a uma definição persistente de etapa.
      */
     Optional<PipelineStageConfig> findByPipelineStageDefinitionId(Long pipelineStageDefinitionId);
+
+    /**
+     * Busca a configuração operacional de uma etapa oficial pelo código do pipeline, versão canônica e etapa.
+     */
+    @Query("""
+            select config
+            from PipelineStageConfig config
+            join fetch config.pipelineStageDefinition stageDefinition
+            join fetch stageDefinition.pipelineDefinition pipelineDefinition
+            left join fetch config.openAiModel
+            where pipelineDefinition.code = :pipelineCode
+              and pipelineDefinition.canonicalVersion = :canonicalVersion
+              and stageDefinition.canonicalCode = :canonicalCode
+            """)
+    Optional<PipelineStageConfig> findOfficialStageConfig(
+            @Param("pipelineCode") String pipelineCode,
+            @Param("canonicalVersion") String canonicalVersion,
+            @Param("canonicalCode") String canonicalCode);
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/pipeline/PipelineStageRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/pipeline/PipelineStageRepository.java
@@ -2,7 +2,10 @@ package com.marketinghub.repository.jpa.pipeline;
 
 import com.marketinghub.pipeline.PipelineStage;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 /**
  * Repositório JPA centralizado para persistir etapas de pipelines operacionais.
@@ -12,4 +15,18 @@ public interface PipelineStageRepository extends JpaRepository<PipelineStage, Lo
      * Lista as etapas de um pipeline na ordem operacional configurada.
      */
     List<PipelineStage> findByPipelineIdOrderByPositionAscIdAsc(Long pipelineId);
+
+    /**
+     * Busca uma etapa operacional pelo código do pipeline legado e pelo código da etapa.
+     */
+    @Query("""
+            select stage
+            from PipelineStage stage
+            join fetch stage.pipeline pipeline
+            left join fetch stage.openAiModel
+            where pipeline.code = :pipelineCode
+              and stage.code = :stageCode
+            """)
+    Optional<PipelineStage> findByPipelineCodeAndStageCode(
+            @Param("pipelineCode") String pipelineCode, @Param("stageCode") String stageCode);
 }

--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-12-oprm-seed-builder-openai-telemetry.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-12-oprm-seed-builder-openai-telemetry.yaml
@@ -1,0 +1,27 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-06-12-oprm-seed-builder-openai-telemetry
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - onError: HALT
+        - dbms:
+            type: mysql
+        - tableExists:
+            tableName: oprm_niche_research_seed
+        - not:
+            columnExists:
+              tableName: oprm_niche_research_seed
+              columnName: model
+      changes:
+        - sql:
+            splitStatements: true
+            stripComments: true
+            sql: |
+              ALTER TABLE oprm_niche_research_seed
+                ADD COLUMN model VARCHAR(128) NULL AFTER created_at,
+                ADD COLUMN raw_model_response LONGTEXT NULL AFTER model,
+                ADD COLUMN input_tokens INT NULL AFTER raw_model_response,
+                ADD COLUMN output_tokens INT NULL AFTER input_tokens,
+                ADD COLUMN cost_usd DECIMAL(12,4) NULL AFTER output_tokens,
+                ADD COLUMN openai_response_id VARCHAR(128) NULL AFTER cost_usd;

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -87,6 +87,9 @@ databaseChangeLog:
       file: changesets/2026-06-02-oprm-nichocnae-seed-builder.yaml
       relativeToChangelogFile: true
   - include:
+      file: changesets/2026-06-12-oprm-seed-builder-openai-telemetry.yaml
+      relativeToChangelogFile: true
+  - include:
       file: changesets/2026-06-01-pipeline-crud.yaml
       relativeToChangelogFile: true
   - include:

--- a/backend/ads-service/src/test/java/com/marketinghub/oprm/nichocnae/nicheresearchseedbuilder/service/BackendNicheResearchSeedBuilderServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/oprm/nichocnae/nicheresearchseedbuilder/service/BackendNicheResearchSeedBuilderServiceTest.java
@@ -3,9 +3,12 @@ package com.marketinghub.oprm.nichocnae.nicheresearchseedbuilder.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.marketinghub.openai.OpenAiResponse;
+import com.marketinghub.openai.service.OpenAiPricingService;
 import com.marketinghub.oprm.nichocnae.OprmNicheResearchSeed;
 import com.marketinghub.oprm.nichocnae.OprmResearchQuery;
 import com.marketinghub.oprm.nichocnae.OprmRoutineResearchCycle;
@@ -16,6 +19,8 @@ import com.marketinghub.oprm.nichocnae.nicheresearchseedbuilder.service.failStag
 import com.marketinghub.repository.jpa.oprm.nichocnae.OprmNicheResearchSeedRepository;
 import com.marketinghub.repository.jpa.oprm.nichocnae.OprmResearchQueryRepository;
 import com.marketinghub.repository.jpa.oprm.nichocnae.OprmRoutineResearchCycleRepository;
+import com.marketinghub.repository.jpa.pipeline.PipelineStageConfigRepository;
+import com.marketinghub.repository.jpa.pipeline.PipelineStageRepository;
 import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.List;
@@ -34,8 +39,25 @@ class BackendNicheResearchSeedBuilderServiceTest {
   @Mock private OprmRoutineResearchCycleRepository routineResearchCycleRepository;
   @Mock private OprmNicheResearchSeedRepository nicheResearchSeedRepository;
   @Mock private OprmResearchQueryRepository researchQueryRepository;
+  @Mock private PipelineStageConfigRepository pipelineStageConfigRepository;
+  @Mock private PipelineStageRepository pipelineStageRepository;
+  @Mock private OpenAiPricingService openAiPricingService;
 
   @InjectMocks private BackendNicheResearchSeedBuilderService service;
+
+  /** Configura preço padrão para os testes que enviam telemetria de OpenAI. */
+  @org.junit.jupiter.api.BeforeEach
+  void setUpPricing() {
+    lenient()
+        .when(openAiPricingService.estimateStandardCost(eq("gpt-5.4"), any(OpenAiResponse.OpenAiUsage.class)))
+        .thenReturn(new BigDecimal("0.0123"));
+    lenient()
+        .when(pipelineStageConfigRepository.findOfficialStageConfig(any(), any(), any()))
+        .thenReturn(Optional.empty());
+    lenient()
+        .when(pipelineStageRepository.findByPipelineCodeAndStageCode(any(), any()))
+        .thenReturn(Optional.empty());
+  }
 
   /** Deve listar ciclos em execução e falhas retryáveis sem seed para a etapa dois. */
   @Test
@@ -85,6 +107,10 @@ class BackendNicheResearchSeedBuilderServiceTest {
     assertThat(response.totalQueries()).isEqualTo(12);
     assertThat(response.queries()).extracting("status").containsOnly("PENDING");
     assertThat(response.queries()).extracting("resultCount").containsOnly(0);
+    assertThat(response.model()).isEqualTo("gpt-5.4");
+    assertThat(response.inputTokens()).isEqualTo(1200);
+    assertThat(response.outputTokens()).isEqualTo(800);
+    assertThat(response.costUsd()).isEqualByComparingTo("0.0123");
 
     ArgumentCaptor<OprmRoutineResearchCycle> cycleCaptor = ArgumentCaptor.forClass(OprmRoutineResearchCycle.class);
     verify(routineResearchCycleRepository).save(cycleCaptor.capture());
@@ -131,6 +157,11 @@ class BackendNicheResearchSeedBuilderServiceTest {
         "depende de agenda cheia",
         "INFERRED_FROM_CNAE",
         "AI",
+        "gpt-5.4",
+        "{\"seed\":true}",
+        1200,
+        800,
+        "resp_seed",
         validQueryRequestsWithFirst("manicure MEI serviços mais procurados Brasil", "PRODUCT_SERVICE_DISCOVERY"));
 
     CompleteNicheResearchSeedBuilderResponse response = service.complete(1001L, request);
@@ -154,6 +185,11 @@ class BackendNicheResearchSeedBuilderServiceTest {
         "depende de agenda cheia",
         "INFERRED_FROM_CNAE",
         "AI",
+        "gpt-5.4",
+        "{\"seed\":true}",
+        1200,
+        800,
+        "resp_seed",
         validQueryRequestsWithFirst("IA para crescimento de manicure MEI Brasil", "MEI_ROUTINE_DISCOVERY"));
 
     CompleteNicheResearchSeedBuilderResponse response = service.complete(1001L, request);
@@ -176,6 +212,11 @@ class BackendNicheResearchSeedBuilderServiceTest {
         "depende de agenda cheia",
         "INFERRED_FROM_CNAE",
         "AI",
+        "gpt-5.4",
+        "{\"seed\":true}",
+        1200,
+        800,
+        "resp_seed",
         validQueryRequestsWithFirst("manicure responsabilidades rotina Brasil", "MEI_ROUTINE_DISCOVERY"));
 
     CompleteNicheResearchSeedBuilderResponse response = service.complete(1001L, request);
@@ -198,6 +239,11 @@ class BackendNicheResearchSeedBuilderServiceTest {
         "depende de agenda cheia",
         "INFERRED_FROM_CNAE",
         "AI",
+        "gpt-5.4",
+        "{\"seed\":true}",
+        1200,
+        800,
+        "resp_seed",
         validQueryRequestsWithFirst("manicure MEI responsabilidades rotina", "MEI_ROUTINE_DISCOVERY"));
 
     CompleteNicheResearchSeedBuilderResponse response = service.complete(1001L, request);
@@ -220,6 +266,11 @@ class BackendNicheResearchSeedBuilderServiceTest {
         "depende de agenda cheia",
         "INFERRED_FROM_CNAE",
         "AI",
+        "gpt-5.4",
+        "{\"seed\":true}",
+        1200,
+        800,
+        "resp_seed",
         validQueryRequestsWithFirst(
             "rotina de manicure MEI e atendimento e organização diária Brasil", "MEI_ROUTINE_DISCOVERY"));
 
@@ -248,6 +299,11 @@ class BackendNicheResearchSeedBuilderServiceTest {
         "depende de agenda cheia",
         "INFERRED_FROM_CNAE",
         "AI",
+        "gpt-5.4",
+        "{\"seed\":true}",
+        1200,
+        800,
+        "resp_seed",
         manyQueries);
 
     CompleteNicheResearchSeedBuilderResponse response = service.complete(1001L, request);
@@ -278,6 +334,11 @@ class BackendNicheResearchSeedBuilderServiceTest {
         "depende de agenda cheia",
         "INFERRED_FROM_CNAE",
         "AI",
+        "gpt-5.4",
+        "{\"seed\":true}",
+        1200,
+        800,
+        "resp_seed",
         List.of());
 
     CompleteNicheResearchSeedBuilderResponse response = service.complete(1001L, request);
@@ -332,6 +393,11 @@ class BackendNicheResearchSeedBuilderServiceTest {
         "depende de agenda cheia",
         "INFERRED_FROM_CNAE",
         null,
+        "gpt-5.4",
+        "{\"seed\":true}",
+        1200,
+        800,
+        "resp_seed",
         validQueryRequests());
   }
 

--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -493,3 +493,13 @@
 - A nova página informa as tabelas populadas por etapa, o tipo de conteúdo gravado, os dados retornados pelo backend e se a etapa acessa modelo de IA.
 - Para etapas com IA, a página exibe request/response conceitual, modelo configurado e deixa explícito quando tokens e custo ainda não estão persistidos no detalhe operacional.
 - 2026-06-12 00:00:00 (UTC): diagnosticada parada do ciclo OPRM NichoCNAE #20 na etapa `oprmNicheResearchSeedBuilder`: endpoint backend operacional em `http://191.252.181.168/api/internal/oprm/nichocnae/niche-research-seed-builder/stage-executions/pending` retorna o ciclo, enquanto a porta `:8000` responde indisponível para o coletor e os logs publicados não exibem o boot do scheduler `Scheduler da etapa dois OPRM NichoCNAE carregado`. Corrigido o default do `oprm-coletor-mei` para usar a URL operacional sem porta, adicionado teste de carregamento do pacote `com.marketinghub.nichocnae` e criada proteção backend para marcar ciclos `RUNNING` sem progresso como `STALLED`, evitando tela com execução aparentemente saudável quando o pipeline estiver parado.
+
+## 2026-06-12 — Correção do modelo e telemetria OpenAI da etapa seed NichoCNAE
+
+- causa-raiz: a tela `/pipelines` gravava o modelo da etapa `niche-research-seed-builder` no pipeline operacional, mas o coletor OPRM usava apenas a propriedade local `gpt-4.1-mini`; além disso, o contrato de conclusão da etapa descartava `usage` da OpenAI, impedindo cálculo e exibição de tokens/custo.
+- correção aplicada:
+  - o backend passou a enviar na pendência da etapa seed o modelo configurado no pipeline oficial/pipeline operacional;
+  - o coletor OPRM passou a priorizar esse modelo recebido do backend na chamada à OpenAI Responses API;
+  - a conclusão da etapa passou a enviar e persistir modelo, resposta bruta, tokens de entrada/saída, `openAiResponseId` e custo estimado;
+  - a tela de detalhe da etapa passou a exibir a telemetria real quando persistida.
+- verificação operacional: consulta via MCP confirmou que a etapa operacional `niche-research-seed-builder` está configurada com `gpt-5.4` no banco.

--- a/frontend/src/api/oprm/useOprmNicheResearchSeedBuilderDetail.ts
+++ b/frontend/src/api/oprm/useOprmNicheResearchSeedBuilderDetail.ts
@@ -30,6 +30,12 @@ export interface OprmNicheResearchSeedDetail {
   confidenceLevel: string;
   createdBy: string;
   createdAt: string;
+  model?: string | null;
+  rawModelResponse?: string | null;
+  inputTokens?: number | null;
+  outputTokens?: number | null;
+  costUsd?: number | string | null;
+  openAiResponseId?: string | null;
   totalQueries: number;
   queries: OprmNicheResearchQueryDetail[];
 }

--- a/frontend/src/pages/oprm/OprmCnaePipelineStageDetailPage.tsx
+++ b/frontend/src/pages/oprm/OprmCnaePipelineStageDetailPage.tsx
@@ -155,17 +155,34 @@ function formatJson(value: unknown) {
   return JSON.stringify(value, null, 2);
 }
 
-function buildAiTelemetry(metadata: StageMetadata) {
+function asRecord(value: unknown): Record<string, unknown> | null {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function textValue(value: unknown) {
+  if (value === null || value === undefined || value === "") {
+    return "não informado";
+  }
+  return String(value);
+}
+
+function buildAiTelemetry(metadata: StageMetadata, data: unknown) {
   if (!metadata.usesAiModel) {
     return null;
   }
+  const payload = asRecord(data);
+  const seed = asRecord(payload?.seed) ?? payload;
   return {
-    modelo: metadata.aiModel ?? "não informado",
+    modelo: textValue(seed?.model ?? metadata.aiModel),
     request: metadata.aiRequestSummary,
-    response: metadata.aiResponseSummary,
-    tokensEntrada: "não persistido no detalhe atual",
-    tokensSaida: "não persistido no detalhe atual",
-    custoUsd: "não persistido no detalhe atual",
+    response: textValue(seed?.openAiResponseId ?? metadata.aiResponseSummary),
+    tokensEntrada: textValue(seed?.inputTokens),
+    tokensSaida: textValue(seed?.outputTokens),
+    custoUsd: seed?.costUsd == null ? "não informado" : `US$ ${seed.costUsd}`,
+    hasPersistedTelemetry:
+      seed?.model != null || seed?.inputTokens != null || seed?.outputTokens != null || seed?.costUsd != null,
   };
 }
 
@@ -184,7 +201,7 @@ export default function OprmCnaePipelineStageDetailPage() {
     validStageCode,
     isValidCycleId ? cycleId : undefined,
   );
-  const aiTelemetry = metadata ? buildAiTelemetry(metadata) : null;
+  const aiTelemetry = metadata ? buildAiTelemetry(metadata, data) : null;
 
   useBreadcrumbs([
     { label: "OPRM", to: "/oprm" },
@@ -287,10 +304,11 @@ export default function OprmCnaePipelineStageDetailPage() {
                     <dt className="col-md-3 text-secondary fw-normal">Custo</dt>
                     <dd className="col-md-9 mb-0">{aiTelemetry.custoUsd}</dd>
                   </dl>
-                  <div className="alert alert-info mb-0 small" role="status">
-                    Para exibir tokens e custo reais, o backend precisa receber
-                    e persistir telemetria de uso da chamada OpenAI desta etapa.
-                  </div>
+                  {!aiTelemetry.hasPersistedTelemetry ? (
+                    <div className="alert alert-info mb-0 small" role="status">
+                      Esta execução ainda não possui telemetria persistida; novas execuções da etapa seed passam a gravar modelo, tokens e custo.
+                    </div>
+                  ) : null}
                 </div>
               ) : (
                 <div className="alert alert-secondary mb-0" role="status">

--- a/frontend/src/pages/oprm/OprmNicheResearchSeedBuilderDetailPage.tsx
+++ b/frontend/src/pages/oprm/OprmNicheResearchSeedBuilderDetailPage.tsx
@@ -7,7 +7,6 @@ import PageTitle from "../../components/PageTitle";
 import OprmModuleNavigation from "./OprmModuleNavigation";
 
 const OPENAI_RESPONSES_ENDPOINT = "https://api.openai.com/v1/responses";
-const OPENAI_MODEL = "gpt-4.1-mini";
 
 function formatProcessedAt(value?: string | null) {
   if (!value) {
@@ -134,13 +133,13 @@ function buildStructuralSchema() {
   };
 }
 
+function resolveOpenAiModel(seed?: OprmNicheResearchSeedDetail | null) {
+  return safe(seed?.model);
+}
+
 function buildAiRequestPreview(detail: {
   researchCycleId: number;
-  seed?: {
-    cnaeCode: string;
-    cnaeDescription: string;
-    nicheName: string;
-  } | null;
+  seed?: OprmNicheResearchSeedDetail | null;
 }) {
   return {
     method: "POST",
@@ -150,7 +149,7 @@ function buildAiRequestPreview(detail: {
       "Content-Type": "application/json",
     },
     body: {
-      model: OPENAI_MODEL,
+      model: resolveOpenAiModel(detail.seed),
       input: buildPrompt(detail),
       text: {
         format: {
@@ -209,6 +208,10 @@ export default function OprmNicheResearchSeedBuilderDetailPage() {
     useOprmNicheResearchSeedBuilderDetail(isValidCycleId ? cycleId : undefined);
   const generatedPayload = buildGeneratedPayload(data?.seed ?? null);
   const aiRequestPreview = data ? buildAiRequestPreview(data) : null;
+  const tokenSummary = data?.seed
+    ? `${data.seed.inputTokens ?? "não informado"} entrada / ${data.seed.outputTokens ?? "não informado"} saída`
+    : "não informado";
+  const costSummary = data?.seed?.costUsd == null ? "não informado" : `US$ ${data.seed.costUsd}`;
 
   return (
     <div className="d-flex flex-column gap-4">
@@ -270,6 +273,11 @@ export default function OprmNicheResearchSeedBuilderDetailPage() {
                     <span className="d-block">
                       Criado por {data.seed.createdBy}
                     </span>
+                    <span className="d-block">
+                      Modelo {resolveOpenAiModel(data.seed)}
+                    </span>
+                    <span className="d-block">Tokens {tokenSummary}</span>
+                    <span className="d-block">Custo {costSummary}</span>
                   </div>
                 ) : null}
               </div>
@@ -294,6 +302,22 @@ export default function OprmNicheResearchSeedBuilderDetailPage() {
                   {JSON.stringify(aiRequestPreview, null, 2)}
                 </pre>
               ) : null}
+            </div>
+          </section>
+
+          <section className="card border-0 shadow-sm">
+            <div className="card-body">
+              <h2 className="h5 mb-3">Telemetria OpenAI persistida</h2>
+              <dl className="row g-3 mb-0">
+                <dt className="col-md-3 text-secondary fw-normal">Modelo usado</dt>
+                <dd className="col-md-9 mb-0 fw-semibold">{resolveOpenAiModel(data.seed)}</dd>
+                <dt className="col-md-3 text-secondary fw-normal">Tokens</dt>
+                <dd className="col-md-9 mb-0">{tokenSummary}</dd>
+                <dt className="col-md-3 text-secondary fw-normal">Custo</dt>
+                <dd className="col-md-9 mb-0">{costSummary}</dd>
+                <dt className="col-md-3 text-secondary fw-normal">Resposta OpenAI</dt>
+                <dd className="col-md-9 mb-0">{safe(data.seed?.openAiResponseId)}</dd>
+              </dl>
             </div>
           </section>
 

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnae/nicheresearchseedbuilder/NicheResearchSeedBuilderBackendClient.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnae/nicheresearchseedbuilder/NicheResearchSeedBuilderBackendClient.java
@@ -71,7 +71,7 @@ public class NicheResearchSeedBuilderBackendClient {
     public NicheResearchSeedBuilderOutput completeStageExecution(OpenAiSeedBuilderResult result) {
         Long researchCycleId = result.output().researchCycleId();
         String url = collectorProperties.backendBaseUrl() + COMPLETE_PATH_PREFIX + researchCycleId + COMPLETE_PATH_SUFFIX;
-        NicheResearchSeedBuilderBackendCompletionRequest request = toBackendCompletionRequest(result.output());
+        NicheResearchSeedBuilderBackendCompletionRequest request = toBackendCompletionRequest(result);
         try {
             NicheResearchSeedBuilderBackendCompletionResponse response = restClient.post()
                     .uri(url)
@@ -93,8 +93,9 @@ public class NicheResearchSeedBuilderBackendClient {
         }
     }
 
-    /** Converte a saída validada da IA para o DTO achatado esperado pelo backend. */
-    NicheResearchSeedBuilderBackendCompletionRequest toBackendCompletionRequest(NicheResearchSeedBuilderOutput output) {
+    /** Converte a saída validada da IA e telemetria para o DTO achatado esperado pelo backend. */
+    NicheResearchSeedBuilderBackendCompletionRequest toBackendCompletionRequest(OpenAiSeedBuilderResult result) {
+        NicheResearchSeedBuilderOutput output = result == null ? null : result.output();
         if (output == null || output.seed() == null) {
             throw new IllegalArgumentException("Seed builder output is required to complete stage two.");
         }
@@ -108,6 +109,11 @@ public class NicheResearchSeedBuilderBackendClient {
                 seed.initialAssumptions(),
                 seed.confidenceLevel(),
                 seed.createdBy(),
+                result.model(),
+                result.rawModelResponse(),
+                result.inputTokens(),
+                result.outputTokens(),
+                result.openAiResponseId(),
                 output.queries());
     }
 

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnae/nicheresearchseedbuilder/NicheResearchSeedBuilderBackendCompletionRequest.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnae/nicheresearchseedbuilder/NicheResearchSeedBuilderBackendCompletionRequest.java
@@ -12,4 +12,9 @@ public record NicheResearchSeedBuilderBackendCompletionRequest(
         String initialAssumptions,
         String confidenceLevel,
         String createdBy,
+        String model,
+        String rawModelResponse,
+        Integer inputTokens,
+        Integer outputTokens,
+        String openAiResponseId,
         List<ResearchQuery> queries) {}

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnae/nicheresearchseedbuilder/NicheResearchSeedBuilderBackendCompletionResponse.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnae/nicheresearchseedbuilder/NicheResearchSeedBuilderBackendCompletionResponse.java
@@ -18,5 +18,11 @@ public record NicheResearchSeedBuilderBackendCompletionResponse(
         String confidenceLevel,
         String createdBy,
         Instant createdAt,
+        String model,
+        String rawModelResponse,
+        Integer inputTokens,
+        Integer outputTokens,
+        java.math.BigDecimal costUsd,
+        String openAiResponseId,
         Integer totalQueries,
         List<NicheResearchSeedBuilderBackendQueryResponse> queries) {}

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnae/nicheresearchseedbuilder/NicheResearchSeedBuilderPending.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnae/nicheresearchseedbuilder/NicheResearchSeedBuilderPending.java
@@ -11,6 +11,8 @@ public record NicheResearchSeedBuilderPending(
         String cnaeDescription,
         String nicheName,
         BigDecimal sourceScore,
+        String openAiModelCode,
+        String openAiModelName,
         String triggerSource,
         String status,
         Instant startedAt,

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnae/nicheresearchseedbuilder/OpenAiNicheResearchSeedBuilderClient.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnae/nicheresearchseedbuilder/OpenAiNicheResearchSeedBuilderClient.java
@@ -49,8 +49,9 @@ public class OpenAiNicheResearchSeedBuilderClient {
             throw new IllegalStateException("OPRM nichocnae seed builder OpenAI API key não configurada.");
         }
 
+        String model = resolveModel(input);
         String prompt = promptBuilder.buildPrompt(input);
-        Map<String, Object> requestBody = buildRequestBody(prompt);
+        Map<String, Object> requestBody = buildRequestBody(prompt, model);
         String url = properties.baseUrl() + RESPONSES_PATH;
         try {
             Map<String, Object> raw = responseBody(url, requestBody, apiKey);
@@ -66,7 +67,7 @@ public class OpenAiNicheResearchSeedBuilderClient {
                     extractInteger(raw, "usage", "input_tokens"),
                     extractInteger(raw, "usage", "output_tokens"),
                     stringValue(raw.get("id")),
-                    properties.model());
+                    model);
         } catch (RestClientException | JsonProcessingException | IllegalStateException | IllegalArgumentException ex) {
             log.error(
                     "Erro ao gerar seed da etapa dois OPRM nichocnae com OpenAI (endpoint={}, researchCycleId={}, cnaeCode={})",
@@ -112,8 +113,16 @@ public class OpenAiNicheResearchSeedBuilderClient {
         return response == null ? null : (Map<String, Object>) response;
     }
 
+    /** Resolve o modelo efetivo da etapa priorizando a configuração operacional recebida do backend. */
+    String resolveModel(NicheResearchSeedBuilderPending input) {
+        if (input != null && input.openAiModelCode() != null && !input.openAiModelCode().isBlank()) {
+            return input.openAiModelCode().trim();
+        }
+        return properties.model();
+    }
+
     /** Monta o corpo da Responses API com schema JSON estrito para evitar saída ambígua ou fora do contrato. */
-    private Map<String, Object> buildRequestBody(String prompt) {
+    private Map<String, Object> buildRequestBody(String prompt, String model) {
         Map<String, Object> format = new LinkedHashMap<>();
         format.put("type", "json_schema");
         format.put("name", SCHEMA_NAME);
@@ -124,7 +133,7 @@ public class OpenAiNicheResearchSeedBuilderClient {
         text.put("format", format);
 
         Map<String, Object> body = new LinkedHashMap<>();
-        body.put("model", properties.model());
+        body.put("model", model);
         body.put("input", prompt);
         body.put("text", text);
         return body;

--- a/oprm-coletor-mei/src/test/java/com/marketinghub/nichocnae/nicheresearchseedbuilder/NicheResearchSeedBuilderBackendClientTest.java
+++ b/oprm-coletor-mei/src/test/java/com/marketinghub/nichocnae/nicheresearchseedbuilder/NicheResearchSeedBuilderBackendClientTest.java
@@ -35,7 +35,13 @@ class NicheResearchSeedBuilderBackendClientTest {
                 "AI");
 
         NicheResearchSeedBuilderBackendCompletionRequest request = client.toBackendCompletionRequest(
-                new NicheResearchSeedBuilderOutput(1L, seed, List.of(query)));
+                new OpenAiSeedBuilderResult(
+                        new NicheResearchSeedBuilderOutput(1L, seed, List.of(query)),
+                        "{\"seed\":true}",
+                        1200,
+                        800,
+                        "resp_seed",
+                        "gpt-5.4"));
 
         assertThat(request.nicheName()).isEqualTo("Cabeleireiros MEI e profissionais autônomos");
         assertThat(request.businessType()).isEqualTo("Serviços de beleza");
@@ -45,6 +51,10 @@ class NicheResearchSeedBuilderBackendClientTest {
         assertThat(request.initialAssumptions()).isEqualTo("clientes sofrem com agenda vazia");
         assertThat(request.confidenceLevel()).isEqualTo("HIGH");
         assertThat(request.createdBy()).isEqualTo("AI");
+        assertThat(request.model()).isEqualTo("gpt-5.4");
+        assertThat(request.inputTokens()).isEqualTo(1200);
+        assertThat(request.outputTokens()).isEqualTo(800);
+        assertThat(request.openAiResponseId()).isEqualTo("resp_seed");
         assertThat(request.queries()).containsExactly(query);
     }
 
@@ -79,6 +89,12 @@ class NicheResearchSeedBuilderBackendClientTest {
                 "HIGH",
                 "AI",
                 null,
+                "gpt-5.4",
+                "{\"seed\":true}",
+                1200,
+                800,
+                new java.math.BigDecimal("0.0123"),
+                "resp_seed",
                 1,
                 List.of(query));
 

--- a/oprm-coletor-mei/src/test/java/com/marketinghub/nichocnae/nicheresearchseedbuilder/NicheResearchSeedBuilderProcessorTest.java
+++ b/oprm-coletor-mei/src/test/java/com/marketinghub/nichocnae/nicheresearchseedbuilder/NicheResearchSeedBuilderProcessorTest.java
@@ -48,6 +48,8 @@ class NicheResearchSeedBuilderProcessorTest {
                 "Cabeleireiros, manicure e pedicure",
                 "Cabeleireiros, manicure e pedicure",
                 BigDecimal.valueOf(92),
+                "gpt-5.4",
+                "gpt-5.4 (gpt-5.4)",
                 "AUTO_SCORE_QUEUE",
                 "RUNNING",
                 Instant.now(),

--- a/oprm-coletor-mei/src/test/java/com/marketinghub/nichocnae/nicheresearchseedbuilder/NicheResearchSeedBuilderPromptBuilderTest.java
+++ b/oprm-coletor-mei/src/test/java/com/marketinghub/nichocnae/nicheresearchseedbuilder/NicheResearchSeedBuilderPromptBuilderTest.java
@@ -71,6 +71,8 @@ class NicheResearchSeedBuilderPromptBuilderTest {
                 "Cabeleireiros, manicure e pedicure",
                 "Cabeleireiros, manicure e pedicure",
                 BigDecimal.valueOf(92),
+                "gpt-5.4",
+                "gpt-5.4 (gpt-5.4)",
                 "AUTO_SCORE_QUEUE",
                 "RUNNING",
                 Instant.now(),

--- a/oprm-coletor-mei/src/test/java/com/marketinghub/nichocnae/nicheresearchseedbuilder/OpenAiNicheResearchSeedBuilderClientTest.java
+++ b/oprm-coletor-mei/src/test/java/com/marketinghub/nichocnae/nicheresearchseedbuilder/OpenAiNicheResearchSeedBuilderClientTest.java
@@ -39,7 +39,18 @@ class OpenAiNicheResearchSeedBuilderClientTest {
         assertThat(apiKey).isEqualTo("file-key");
     }
 
-    /** Cria o client com dependências nulas porque o teste cobre apenas resolução de chave. */
+    /** Confirma que a configuração operacional recebida do backend define o modelo enviado à OpenAI. */
+    @Test
+    void shouldResolveModelFromPendingStageConfiguration() {
+        OpenAiNicheResearchSeedBuilderClient client = clientWithProperties(
+                new NicheResearchSeedBuilderOpenAiProperties("https://api.openai.com/v1", "direct-key", "", "gpt-4.1-mini"));
+
+        String model = client.resolveModel(pending());
+
+        assertThat(model).isEqualTo("gpt-5.4");
+    }
+
+    /** Cria o client com dependências nulas porque o teste cobre apenas resolução de chave e modelo. */
     private OpenAiNicheResearchSeedBuilderClient clientWithProperties(NicheResearchSeedBuilderOpenAiProperties properties) {
         return new OpenAiNicheResearchSeedBuilderClient(null, null, properties, null, null);
     }
@@ -53,6 +64,8 @@ class OpenAiNicheResearchSeedBuilderClientTest {
                 "Cabeleireiros, manicure e pedicure",
                 "Cabeleireiros, manicure e pedicure",
                 BigDecimal.valueOf(92),
+                "gpt-5.4",
+                "gpt-5.4 (gpt-5.4)",
                 "AUTO_SCORE_QUEUE",
                 "RUNNING",
                 Instant.now(),


### PR DESCRIPTION
### Motivation
- A etapa de seed (`niche-research-seed-builder`) foi configurada na tela para usar um modelo OpenAI específico, porém o coletor estava usando um modelo hardcoded/default e não repassava contagem de tokens/metadados, impedindo o cálculo de custo e a rastreabilidade da execução.

### Description
- O coletor `oprm-coletor-mei` agora envia os metadados da chamada OpenAI (`model`, `inputTokens`, `outputTokens`, `openAiResponseId`, `rawModelResponse`) ao backend ao completar a etapa, usando o `OpenAiSeedBuilderResult` como fonte de verdade. 
- O contrato do backend para conclusão da etapa foi estendido (`CompleteNicheResearchSeedBuilderRequest`) para aceitar `model`, `rawModelResponse`, `inputTokens`, `outputTokens` e `openAiResponseId` e as camadas de controller/service foram atualizadas para receber esses campos. 
- Foi adicionada migração Liquibase para estender a tabela `oprm_niche_research_seed` com colunas opcionais para persistir `model`, `input_tokens`, `output_tokens`, `openai_response_id` e `raw_response` para auditoria e cálculo de custo futuro. 
- Ajustes foram aplicados aos clientes HTTP internos e aos mappers relacionados (coletor → backend DTOs, testes unitários afetados atualizados) para propagar os novos campos sem quebrar o fluxo existente.

### Testing
- Executado o conjunto de testes unitários do backend com `mvn -DskipTests=false test` e as suítes relacionadas a pipeline/oprm/openai passaram (status: sucesso). 
- Executados os testes frontend relevantes (componentes e hooks de OPRM) com a suíte de testes do projeto e os testes de página `OprmNicheResearchSeedBuilderDetailPage` e chamadas de API local passaram (status: sucesso). 
- Testes de integração manual verificados na tela `/oprm/pipeline` e detalhe do seed confirmaram que o modelo selecionado é refletido na prévia de requisição à OpenAI e que os tokens/metadados são enviados ao backend (status: verificado).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2bf689388083219aea5b2bee9d336d)