### PR TITLE
Isola configuração da etapa seed OPRM

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/nicheresearchseedbuilder/service/BackendNicheResearchSeedBuilderService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/nicheresearchseedbuilder/service/BackendNicheResearchSeedBuilderService.java
@@ -1,8 +1,5 @@
 package com.marketinghub.oprm.nichocnae.nicheresearchseedbuilder.service;
 
-import com.marketinghub.openai.OpenAiModel;
-import com.marketinghub.openai.OpenAiResponse;
-import com.marketinghub.openai.service.OpenAiPricingService;
 import com.marketinghub.oprm.nichocnae.OprmNicheResearchSeed;
 import com.marketinghub.oprm.nichocnae.OprmResearchQuery;
 import com.marketinghub.oprm.nichocnae.OprmRoutineResearchCycle;
@@ -16,8 +13,6 @@ import com.marketinghub.oprm.nichocnae.nicheresearchseedbuilder.service.pending.
 import com.marketinghub.repository.jpa.oprm.nichocnae.OprmNicheResearchSeedRepository;
 import com.marketinghub.repository.jpa.oprm.nichocnae.OprmResearchQueryRepository;
 import com.marketinghub.repository.jpa.oprm.nichocnae.OprmRoutineResearchCycleRepository;
-import com.marketinghub.repository.jpa.pipeline.PipelineStageConfigRepository;
-import com.marketinghub.repository.jpa.pipeline.PipelineStageRepository;
 import jakarta.persistence.EntityNotFoundException;
 import java.math.BigDecimal;
 import java.time.Instant;
@@ -41,30 +36,21 @@ public class BackendNicheResearchSeedBuilderService {
   private static final String RETRYABLE_QUERY_GOAL_LENGTH_ERROR = "Data too long for column 'query_goal'";
   private static final String COMPLETE_STAGE_PATH_FRAGMENT = "niche-research-seed-builder/stage-executions";
   private static final String DEFAULT_CREATED_BY = "AI";
-  private static final String OPRM_NICHO_CNAE_PIPELINE_CODE = "oprm-nicho-cnae-pipeline";
-  private static final String OPRM_NICHO_CNAE_CANONICAL_VERSION = "oprm-nichocnae-canon.v1";
-  private static final String SEED_BUILDER_CANONICAL_CODE = "NICHE_RESEARCH_SEED_BUILDER";
   private final OprmRoutineResearchCycleRepository routineResearchCycleRepository;
   private final OprmNicheResearchSeedRepository nicheResearchSeedRepository;
   private final OprmResearchQueryRepository researchQueryRepository;
-  private final PipelineStageConfigRepository pipelineStageConfigRepository;
-  private final PipelineStageRepository pipelineStageRepository;
-  private final OpenAiPricingService openAiPricingService;
+  private final OprmNicheResearchSeedBuilderConfigurationGateway configurationGateway;
 
   /** Inicializa o serviço com os repositórios canônicos da etapa dois do pipeline. */
   public BackendNicheResearchSeedBuilderService(
       OprmRoutineResearchCycleRepository routineResearchCycleRepository,
       OprmNicheResearchSeedRepository nicheResearchSeedRepository,
       OprmResearchQueryRepository researchQueryRepository,
-      PipelineStageConfigRepository pipelineStageConfigRepository,
-      PipelineStageRepository pipelineStageRepository,
-      OpenAiPricingService openAiPricingService) {
+      OprmNicheResearchSeedBuilderConfigurationGateway configurationGateway) {
     this.routineResearchCycleRepository = routineResearchCycleRepository;
     this.nicheResearchSeedRepository = nicheResearchSeedRepository;
     this.researchQueryRepository = researchQueryRepository;
-    this.pipelineStageConfigRepository = pipelineStageConfigRepository;
-    this.pipelineStageRepository = pipelineStageRepository;
-    this.openAiPricingService = openAiPricingService;
+    this.configurationGateway = configurationGateway;
   }
 
   /** Lista ciclos em execução ou falhas retryáveis que ainda precisam receber seed e queries. */
@@ -260,7 +246,7 @@ public class BackendNicheResearchSeedBuilderService {
 
   /** Converte um ciclo pendente no contrato interno de unidade de trabalho da etapa dois. */
   private RecordNicheResearchSeedBuilderPending toPending(OprmRoutineResearchCycle cycle) {
-    OpenAiModel configuredModel = resolveConfiguredOpenAiModel();
+    OprmNicheResearchSeedBuilderModel configuredModel = resolveConfiguredOpenAiModel();
     return new RecordNicheResearchSeedBuilderPending(
         cycle.getId(),
         cycle.getSourceNicheId(),
@@ -268,8 +254,8 @@ public class BackendNicheResearchSeedBuilderService {
         cycle.getCnaeDescription(),
         cycle.getNicheName(),
         cycle.getSourceScore(),
-        configuredModel == null ? null : configuredModel.getCode(),
-        configuredModel == null ? null : configuredModel.getName(),
+        configuredModel == null ? null : configuredModel.code(),
+        configuredModel == null ? null : configuredModel.name(),
         cycle.getStatus(),
         cycle.getStartedAt(),
         cycle.getCreatedAt());
@@ -338,9 +324,7 @@ public class BackendNicheResearchSeedBuilderService {
       return null;
     }
     try {
-      return openAiPricingService.estimateStandardCost(
-          request.model(),
-          new OpenAiResponse.OpenAiUsage(request.inputTokens(), request.outputTokens(), null, null, null));
+      return configurationGateway.estimateCostUsd(request.model(), request.inputTokens(), request.outputTokens());
     } catch (RuntimeException ex) {
       LOGGER.warn(
           "Não foi possível calcular custo da etapa dois OPRM nichocnae (model={}, inputTokens={}, outputTokens={})",
@@ -352,20 +336,9 @@ public class BackendNicheResearchSeedBuilderService {
     }
   }
 
-  /** Recupera o modelo OpenAI configurado, priorizando contrato persistente e caindo no pipeline operacional legado. */
-  private OpenAiModel resolveConfiguredOpenAiModel() {
-    OpenAiModel persistentModel = pipelineStageConfigRepository
-        .findOfficialStageConfig(
-            OPRM_NICHO_CNAE_PIPELINE_CODE, OPRM_NICHO_CNAE_CANONICAL_VERSION, SEED_BUILDER_CANONICAL_CODE)
-        .map(config -> config.getOpenAiModel())
-        .orElse(null);
-    if (persistentModel != null) {
-      return persistentModel;
-    }
-    return pipelineStageRepository
-        .findByPipelineCodeAndStageCode(OPRM_NICHO_CNAE_PIPELINE_CODE, "niche-research-seed-builder")
-        .map(stage -> stage.getOpenAiModel())
-        .orElse(null);
+  /** Recupera o modelo de IA configurado pela abstração canônica permitida para o OPRM. */
+  private OprmNicheResearchSeedBuilderModel resolveConfiguredOpenAiModel() {
+    return configurationGateway.findConfiguredModel().orElse(null);
   }
 
   /** Converte strings vazias em nulo para campos opcionais persistidos. */

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/nicheresearchseedbuilder/service/OprmNicheResearchSeedBuilderConfigurationGateway.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/nicheresearchseedbuilder/service/OprmNicheResearchSeedBuilderConfigurationGateway.java
@@ -1,0 +1,14 @@
+package com.marketinghub.oprm.nichocnae.nicheresearchseedbuilder.service;
+
+import java.math.BigDecimal;
+import java.util.Optional;
+
+/** Define o contrato OPRM para consultar configuração de IA e custo da etapa dois sem depender de pacotes externos. */
+public interface OprmNicheResearchSeedBuilderConfigurationGateway {
+
+  /** Recupera o modelo de IA configurado para a etapa dois do pipeline OPRM nicho CNAE. */
+  Optional<OprmNicheResearchSeedBuilderModel> findConfiguredModel();
+
+  /** Estima o custo da chamada de IA usada pela etapa dois a partir do modelo e dos tokens informados. */
+  BigDecimal estimateCostUsd(String model, Integer inputTokens, Integer outputTokens);
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/nicheresearchseedbuilder/service/OprmNicheResearchSeedBuilderModel.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/nicheresearchseedbuilder/service/OprmNicheResearchSeedBuilderModel.java
@@ -1,0 +1,4 @@
+package com.marketinghub.oprm.nichocnae.nicheresearchseedbuilder.service;
+
+/** Representa o modelo de IA configurado para a etapa dois do pipeline OPRM nicho CNAE. */
+public record OprmNicheResearchSeedBuilderModel(String code, String name) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/oprm/nichocnae/nicheresearchseedbuilder/JpaOprmNicheResearchSeedBuilderConfigurationGateway.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/oprm/nichocnae/nicheresearchseedbuilder/JpaOprmNicheResearchSeedBuilderConfigurationGateway.java
@@ -1,0 +1,70 @@
+package com.marketinghub.repository.jpa.oprm.nichocnae.nicheresearchseedbuilder;
+
+import com.marketinghub.openai.OpenAiModel;
+import com.marketinghub.openai.OpenAiResponse;
+import com.marketinghub.openai.service.OpenAiPricingService;
+import com.marketinghub.oprm.nichocnae.nicheresearchseedbuilder.service.OprmNicheResearchSeedBuilderConfigurationGateway;
+import com.marketinghub.oprm.nichocnae.nicheresearchseedbuilder.service.OprmNicheResearchSeedBuilderModel;
+import com.marketinghub.repository.jpa.pipeline.PipelineStageConfigRepository;
+import com.marketinghub.repository.jpa.pipeline.PipelineStageRepository;
+import java.math.BigDecimal;
+import java.util.Optional;
+import org.springframework.stereotype.Component;
+
+/**
+ * Implementa o contrato OPRM de configuração da etapa dois usando os repositórios canônicos de pipeline e preços.
+ */
+@Component
+public class JpaOprmNicheResearchSeedBuilderConfigurationGateway
+    implements OprmNicheResearchSeedBuilderConfigurationGateway {
+  private static final String OPRM_NICHO_CNAE_PIPELINE_CODE = "oprm-nicho-cnae-pipeline";
+  private static final String OPRM_NICHO_CNAE_CANONICAL_VERSION = "oprm-nichocnae-canon.v1";
+  private static final String SEED_BUILDER_CANONICAL_CODE = "NICHE_RESEARCH_SEED_BUILDER";
+  private static final String SEED_BUILDER_STAGE_CODE = "niche-research-seed-builder";
+  private final PipelineStageConfigRepository pipelineStageConfigRepository;
+  private final PipelineStageRepository pipelineStageRepository;
+  private final OpenAiPricingService openAiPricingService;
+
+  /** Inicializa o gateway com os componentes canônicos que ficam fora do limite arquitetural direto do OPRM. */
+  public JpaOprmNicheResearchSeedBuilderConfigurationGateway(
+      PipelineStageConfigRepository pipelineStageConfigRepository,
+      PipelineStageRepository pipelineStageRepository,
+      OpenAiPricingService openAiPricingService) {
+    this.pipelineStageConfigRepository = pipelineStageConfigRepository;
+    this.pipelineStageRepository = pipelineStageRepository;
+    this.openAiPricingService = openAiPricingService;
+  }
+
+  /** Recupera o modelo configurado priorizando o contrato persistente oficial e mantendo fallback legado. */
+  @Override
+  public Optional<OprmNicheResearchSeedBuilderModel> findConfiguredModel() {
+    return findPersistentConfiguredModel().or(this::findLegacyConfiguredModel).map(this::toOprmModel);
+  }
+
+  /** Estima o custo padrão da chamada OpenAI para a etapa OPRM usando o serviço canônico de preços. */
+  @Override
+  public BigDecimal estimateCostUsd(String model, Integer inputTokens, Integer outputTokens) {
+    return openAiPricingService.estimateStandardCost(
+        model, new OpenAiResponse.OpenAiUsage(inputTokens, outputTokens, null, null, null));
+  }
+
+  /** Busca o modelo na configuração oficial versionada do pipeline OPRM nicho CNAE. */
+  private Optional<OpenAiModel> findPersistentConfiguredModel() {
+    return pipelineStageConfigRepository
+        .findOfficialStageConfig(
+            OPRM_NICHO_CNAE_PIPELINE_CODE, OPRM_NICHO_CNAE_CANONICAL_VERSION, SEED_BUILDER_CANONICAL_CODE)
+        .map(config -> config.getOpenAiModel());
+  }
+
+  /** Busca o modelo na configuração operacional legada da etapa para preservar compatibilidade. */
+  private Optional<OpenAiModel> findLegacyConfiguredModel() {
+    return pipelineStageRepository
+        .findByPipelineCodeAndStageCode(OPRM_NICHO_CNAE_PIPELINE_CODE, SEED_BUILDER_STAGE_CODE)
+        .map(stage -> stage.getOpenAiModel());
+  }
+
+  /** Converte o modelo canônico OpenAI para o contrato interno permitido no OPRM. */
+  private OprmNicheResearchSeedBuilderModel toOprmModel(OpenAiModel model) {
+    return new OprmNicheResearchSeedBuilderModel(model.getCode(), model.getName());
+  }
+}

--- a/backend/ads-service/src/test/java/com/marketinghub/oprm/nichocnae/nicheresearchseedbuilder/service/BackendNicheResearchSeedBuilderServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/oprm/nichocnae/nicheresearchseedbuilder/service/BackendNicheResearchSeedBuilderServiceTest.java
@@ -7,8 +7,6 @@ import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.marketinghub.openai.OpenAiResponse;
-import com.marketinghub.openai.service.OpenAiPricingService;
 import com.marketinghub.oprm.nichocnae.OprmNicheResearchSeed;
 import com.marketinghub.oprm.nichocnae.OprmResearchQuery;
 import com.marketinghub.oprm.nichocnae.OprmRoutineResearchCycle;
@@ -19,8 +17,6 @@ import com.marketinghub.oprm.nichocnae.nicheresearchseedbuilder.service.failStag
 import com.marketinghub.repository.jpa.oprm.nichocnae.OprmNicheResearchSeedRepository;
 import com.marketinghub.repository.jpa.oprm.nichocnae.OprmResearchQueryRepository;
 import com.marketinghub.repository.jpa.oprm.nichocnae.OprmRoutineResearchCycleRepository;
-import com.marketinghub.repository.jpa.pipeline.PipelineStageConfigRepository;
-import com.marketinghub.repository.jpa.pipeline.PipelineStageRepository;
 import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.List;
@@ -39,9 +35,7 @@ class BackendNicheResearchSeedBuilderServiceTest {
   @Mock private OprmRoutineResearchCycleRepository routineResearchCycleRepository;
   @Mock private OprmNicheResearchSeedRepository nicheResearchSeedRepository;
   @Mock private OprmResearchQueryRepository researchQueryRepository;
-  @Mock private PipelineStageConfigRepository pipelineStageConfigRepository;
-  @Mock private PipelineStageRepository pipelineStageRepository;
-  @Mock private OpenAiPricingService openAiPricingService;
+  @Mock private OprmNicheResearchSeedBuilderConfigurationGateway configurationGateway;
 
   @InjectMocks private BackendNicheResearchSeedBuilderService service;
 
@@ -49,14 +43,9 @@ class BackendNicheResearchSeedBuilderServiceTest {
   @org.junit.jupiter.api.BeforeEach
   void setUpPricing() {
     lenient()
-        .when(openAiPricingService.estimateStandardCost(eq("gpt-5.4"), any(OpenAiResponse.OpenAiUsage.class)))
+        .when(configurationGateway.estimateCostUsd(eq("gpt-5.4"), any(), any()))
         .thenReturn(new BigDecimal("0.0123"));
-    lenient()
-        .when(pipelineStageConfigRepository.findOfficialStageConfig(any(), any(), any()))
-        .thenReturn(Optional.empty());
-    lenient()
-        .when(pipelineStageRepository.findByPipelineCodeAndStageCode(any(), any()))
-        .thenReturn(Optional.empty());
+    lenient().when(configurationGateway.findConfiguredModel()).thenReturn(Optional.empty());
   }
 
   /** Deve listar ciclos em execução e falhas retryáveis sem seed para a etapa dois. */

--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -508,3 +508,10 @@
   - a conclusão da etapa passou a enviar e persistir modelo, resposta bruta, tokens de entrada/saída, `openAiResponseId` e custo estimado;
   - a tela de detalhe da etapa passou a exibir a telemetria real quando persistida.
 - verificação operacional: consulta via MCP confirmou que a etapa operacional `niche-research-seed-builder` está configurada com `gpt-5.4` no banco.
+
+## 2026-06-12 — OPRM NichoCNAE: isolamento arquitetural da etapa seed
+
+- Removida a dependência direta do serviço OPRM `BackendNicheResearchSeedBuilderService` em pacotes `openai` e `pipeline`.
+- Criado contrato próprio da etapa seed para consultar modelo configurado e estimar custo, com implementação fora do pacote funcional OPRM para preservar o limite arquitetural validado pelo ArchUnit.
+- Causa-raiz tratada: a etapa OPRM consumia diretamente serviços e repositórios compartilhados para dados auxiliares de IA, rompendo a regra de isolamento do módulo.
+- Prevenção de recorrência: os testes da etapa passaram a mockar a abstração OPRM, mantendo o serviço de negócio sem imports proibidos.


### PR DESCRIPTION
### Motivation
- Preserve o isolamento arquitetural do módulo OPRM removendo dependências diretas em pacotes `openai` e `pipeline` do serviço de etapa `niche-research-seed-builder`. 
- Evitar violações detectadas pelo teste de arquitetura `ArquiteturaTest` e prevenir contaminação do domínio OPRM com contratos/serviços transversais.

### Description
- Substitui as dependências diretas por uma nova abstração `OprmNicheResearchSeedBuilderConfigurationGateway` consumida por `BackendNicheResearchSeedBuilderService`. 
- Adiciona o record `OprmNicheResearchSeedBuilderModel` como contrato de modelo e implementa um `JpaOprmNicheResearchSeedBuilderConfigurationGateway` em `com.marketinghub.repository.jpa.oprm.nichocnae.nicheresearchseedbuilder` que encapsula o acesso a `PipelineStageConfigRepository`, `PipelineStageRepository` e `OpenAiPricingService`. 
- Altera `BackendNicheResearchSeedBuilderService` para usar a nova abstração para recuperar o modelo configurado e estimar custo (substituindo chamadas diretas a `OpenAiPricingService` e repositórios de pipeline). 
- Atualiza o teste `BackendNicheResearchSeedBuilderServiceTest` para mockar a nova `configurationGateway` e registra a mudança no histórico em `docs/registros/oprm1.md`.

### Testing
- Executei o teste unitário específico com `../mvnw -Dtest=BackendNicheResearchSeedBuilderServiceTest test` e ele passou com sucesso. 
- Rodei a verificação de arquitetura com `../mvnw -Dtest=ArquiteturaTest test` e as regras do ArchUnit foram satisfeitas. 
- Tentei `../mvnw spotless:check` e essa verificação falhou devido à ausência do plugin Spotless configurado no ambiente, não relacionado às alterações de código.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2c2c05d5d483218b7501b1464e500b)