### PR TITLE
Bloqueia segmentação MEI sem chave OpenAI

### DIFF
--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -515,3 +515,9 @@
 - Criado contrato próprio da etapa seed para consultar modelo configurado e estimar custo, com implementação fora do pacote funcional OPRM para preservar o limite arquitetural validado pelo ArchUnit.
 - Causa-raiz tratada: a etapa OPRM consumia diretamente serviços e repositórios compartilhados para dados auxiliares de IA, rompendo a regra de isolamento do módulo.
 - Prevenção de recorrência: os testes da etapa passaram a mockar a abstração OPRM, mantendo o serviço de negócio sem imports proibidos.
+
+## 2026-06-12 — OPRM MEI: barreira operacional para chave OpenAI da segmentação
+
+- Adicionada verificação operacional da etapa `mei-audience-segmenter` no `oprm-coletor-mei` para bloquear busca/processamento de pendências quando não houver chave OpenAI dedicada nem fallback global.
+- Causa-raiz tratada: a etapa podia chegar até a execução da IA sem evidência operacional clara da variável ausente, mascarando a falha de configuração e consumindo o fluxo de pendências sem uma mensagem acionável.
+- Prevenção de recorrência: logs padronizados passaram a registrar `module=oprm-coletor-mei`, `operation=mei-audience-segmenter`, variável esperada, fallback e `researchCycleId` quando aplicável; os testes cobrem ausência de `OPRM_MEI_AUDIENCE_SEGMENTER_OPENAI_API_KEY`, fallback por `OPENAI_API_KEY` já resolvido pelo `application.yml` e notificação do erro operacional ao backend quando houver ciclo conhecido.

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnae/meiaudiencesegmenter/MeiAudienceSegmenterOpenAiProperties.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnae/meiaudiencesegmenter/MeiAudienceSegmenterOpenAiProperties.java
@@ -8,7 +8,9 @@ public record MeiAudienceSegmenterOpenAiProperties(
         String baseUrl,
         String apiKey,
         String apiKeyFile,
-        String model) {
+        String model,
+        String expectedApiKeyVariable,
+        String fallbackApiKeyVariable) {
 
     /** Normaliza valores padrão seguros para chamada síncrona da Responses API. */
     public MeiAudienceSegmenterOpenAiProperties {
@@ -16,5 +18,11 @@ public record MeiAudienceSegmenterOpenAiProperties(
         apiKey = apiKey == null ? "" : apiKey;
         apiKeyFile = apiKeyFile == null ? "" : apiKeyFile;
         model = model == null || model.isBlank() ? "gpt-4.1-mini" : model;
+        expectedApiKeyVariable = expectedApiKeyVariable == null || expectedApiKeyVariable.isBlank()
+                ? "OPRM_MEI_AUDIENCE_SEGMENTER_OPENAI_API_KEY"
+                : expectedApiKeyVariable;
+        fallbackApiKeyVariable = fallbackApiKeyVariable == null || fallbackApiKeyVariable.isBlank()
+                ? "OPENAI_API_KEY"
+                : fallbackApiKeyVariable;
     }
 }

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnae/meiaudiencesegmenter/MeiAudienceSegmenterOperationalException.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnae/meiaudiencesegmenter/MeiAudienceSegmenterOperationalException.java
@@ -1,0 +1,15 @@
+package com.marketinghub.nichocnae.meiaudiencesegmenter;
+
+/** Representa uma falha operacional de configuração que impede a segmentação MEI/autônomo. */
+public class MeiAudienceSegmenterOperationalException extends RuntimeException {
+
+    /** Cria a exceção com mensagem clara para operador e backend. */
+    public MeiAudienceSegmenterOperationalException(String message) {
+        super(message);
+    }
+
+    /** Cria a exceção preservando a causa-raiz técnica original. */
+    public MeiAudienceSegmenterOperationalException(String message, Throwable cause) {
+        super(message, cause);
+    }
+}

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnae/meiaudiencesegmenter/MeiAudienceSegmenterOperationalGuard.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnae/meiaudiencesegmenter/MeiAudienceSegmenterOperationalGuard.java
@@ -1,0 +1,122 @@
+package com.marketinghub.nichocnae.meiaudiencesegmenter;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.boot.ApplicationArguments;
+import org.springframework.boot.ApplicationRunner;
+import org.springframework.stereotype.Component;
+
+/** Valida a prontidão operacional da chave OpenAI antes da segmentação comportamental MEI/autônomo. */
+@Component
+public class MeiAudienceSegmenterOperationalGuard implements ApplicationRunner {
+    static final String MODULE = "oprm-coletor-mei";
+    static final String OPERATION = "mei-audience-segmenter";
+    static final String DEFAULT_EXPECTED_VARIABLE = "OPRM_MEI_AUDIENCE_SEGMENTER_OPENAI_API_KEY";
+    static final String DEFAULT_FALLBACK_VARIABLE = "OPENAI_API_KEY";
+
+    private static final Logger log = LoggerFactory.getLogger(MeiAudienceSegmenterOperationalGuard.class);
+
+    private final MeiAudienceSegmenterOpenAiProperties properties;
+
+    /** Inicializa a validação operacional com as propriedades OpenAI da etapa MEI. */
+    public MeiAudienceSegmenterOperationalGuard(MeiAudienceSegmenterOpenAiProperties properties) {
+        this.properties = properties;
+    }
+
+    /** Registra no startup se a etapa MEI possui chave configurada para execução com OpenAI. */
+    @Override
+    public void run(ApplicationArguments args) {
+        if (isReadyForExecution()) {
+            log.info(
+                    "Configuração operacional presente (module={}, operation={}, expectedVariable={}, fallbackVariable={}, researchCycleId={})",
+                    MODULE,
+                    OPERATION,
+                    expectedVariable(),
+                    fallbackVariable(),
+                    "n/a");
+            return;
+        }
+        log.warn(
+                "Configuração operacional ausente; pendências MEI não serão processadas (module={}, operation={}, expectedVariable={}, fallbackVariable={}, researchCycleId={})",
+                MODULE,
+                OPERATION,
+                expectedVariable(),
+                fallbackVariable(),
+                "n/a");
+    }
+
+    /** Bloqueia a busca ou execução de pendências quando a chave OpenAI operacional não estiver configurada. */
+    public void assertReadyForExecution(Long researchCycleId) {
+        if (isReadyForExecution()) {
+            return;
+        }
+        log.error(
+                "Configuração operacional ausente; bloqueando pendências MEI (module={}, operation={}, expectedVariable={}, fallbackVariable={}, researchCycleId={})",
+                MODULE,
+                OPERATION,
+                expectedVariable(),
+                fallbackVariable(),
+                researchCycleId == null ? "n/a" : researchCycleId);
+        throw new MeiAudienceSegmenterOperationalException(missingApiKeyMessage(researchCycleId));
+    }
+
+    /** Informa se existe chave direta, fallback via OPENAI_API_KEY ou arquivo montado configurado. */
+    public boolean isReadyForExecution() {
+        return !resolveApiKeyForOperationalCheck().isBlank();
+    }
+
+    /** Resolve a chave apenas para verificação operacional, sem expor o valor em logs ou respostas. */
+    String resolveApiKeyForOperationalCheck() {
+        if (!properties.apiKey().isBlank()) {
+            return properties.apiKey().trim();
+        }
+        if (properties.apiKeyFile().isBlank()) {
+            return "";
+        }
+        try {
+            return Files.readString(Path.of(properties.apiKeyFile())).trim();
+        } catch (IOException ex) {
+            log.error(
+                    "Erro ao ler arquivo de chave OpenAI; etapa MEI ficará bloqueada (module={}, operation={}, expectedVariable={}, fallbackVariable={}, apiKeyFile={})",
+                    MODULE,
+                    OPERATION,
+                    expectedVariable(),
+                    fallbackVariable(),
+                    properties.apiKeyFile(),
+                    ex);
+            throw new MeiAudienceSegmenterOperationalException(
+                    "Falha operacional na etapa mei-audience-segmenter: arquivo de chave OpenAI configurado em "
+                            + properties.apiKeyFile() + " não pôde ser lido.",
+                    ex);
+        }
+    }
+
+    /** Retorna a variável operacional esperada para a chave dedicada da etapa. */
+    String expectedVariable() {
+        return properties.expectedApiKeyVariable().isBlank()
+                ? DEFAULT_EXPECTED_VARIABLE
+                : properties.expectedApiKeyVariable();
+    }
+
+    /** Retorna a variável de fallback aceita quando a chave dedicada não estiver definida. */
+    String fallbackVariable() {
+        return properties.fallbackApiKeyVariable().isBlank()
+                ? DEFAULT_FALLBACK_VARIABLE
+                : properties.fallbackApiKeyVariable();
+    }
+
+    /** Monta uma mensagem operacional clara sem revelar segredos. */
+    private String missingApiKeyMessage(Long researchCycleId) {
+        String cycle = researchCycleId == null ? "n/a" : researchCycleId.toString();
+        return "Falha operacional na etapa mei-audience-segmenter: variável " + expectedVariable()
+                + " ausente e fallback " + fallbackVariable()
+                + " indisponível. module=" + MODULE
+                + ", operation=" + OPERATION
+                + ", expectedVariable=" + expectedVariable()
+                + ", fallbackVariable=" + fallbackVariable()
+                + ", researchCycleId=" + cycle + ".";
+    }
+}

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnae/meiaudiencesegmenter/MeiAudienceSegmenterService.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnae/meiaudiencesegmenter/MeiAudienceSegmenterService.java
@@ -18,22 +18,29 @@ public class MeiAudienceSegmenterService {
     private final MeiAudienceSegmenterBackendClient backendClient;
     private final MeiAudienceSegmenterProcessor processor;
     private final ArtifactStore artifactStore;
+    private final MeiAudienceSegmenterOperationalGuard operationalGuard;
 
     /** Inicializa o serviço com borda backend, processor concreto e armazenamento genérico de artefatos. */
     public MeiAudienceSegmenterService(
-            MeiAudienceSegmenterBackendClient backendClient, MeiAudienceSegmenterProcessor processor, ArtifactStore artifactStore) {
+            MeiAudienceSegmenterBackendClient backendClient,
+            MeiAudienceSegmenterProcessor processor,
+            ArtifactStore artifactStore,
+            MeiAudienceSegmenterOperationalGuard operationalGuard) {
         this.backendClient = backendClient;
         this.processor = processor;
         this.artifactStore = artifactStore;
+        this.operationalGuard = operationalGuard;
     }
 
     /** Lista ciclos pendentes que ainda precisam de segmentação comportamental. */
     public List<MeiAudienceSegmenterPending> listPendingCycles() {
+        operationalGuard.assertReadyForExecution(null);
         return backendClient.listPendingCycles();
     }
 
     /** Processa ciclos pendentes pela etapa de segmentação e retorna perfis gravados no backend. */
     public List<MeiAudienceSegmenterOutput> processPending(String requestedBy) {
+        operationalGuard.assertReadyForExecution(null);
         List<MeiAudienceSegmenterPending> pendingCycles = backendClient.listPendingCycles();
         return pendingCycles.stream()
                 .map(pending -> processOne(pending, requestedBy))
@@ -47,6 +54,7 @@ public class MeiAudienceSegmenterService {
                 pending,
                 Map.of("stage", "oprmMeiAudienceSegmenter", "requestedBy", requestedBy));
         try {
+            operationalGuard.assertReadyForExecution(pending.researchCycleId());
             PipelineWorker<MeiAudienceSegmenterPending, MeiAudienceSegmenterOutput> worker = new PipelineWorker<>(processor, artifactStore);
             StageResult<MeiAudienceSegmenterOutput> result = worker.processResult(execution);
             return result.output();

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnae/meiaudiencesegmenter/OpenAiMeiAudienceSegmenterClient.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnae/meiaudiencesegmenter/OpenAiMeiAudienceSegmenterClient.java
@@ -49,7 +49,30 @@ public class OpenAiMeiAudienceSegmenterClient {
     public MeiAudienceSegmentDraft segment(MeiAudienceSegmenterPending input) {
         String apiKey = resolveApiKey(input);
         if (apiKey.isBlank()) {
-            throw new IllegalStateException("OPRM mei-audience-segmenter OpenAI API key não configurada.");
+            log.error(
+                    "Configuração operacional ausente antes de chamar OpenAI (module={}, operation={}, expectedVariable={}, fallbackVariable={}, researchCycleId={}, cnaeCode={})",
+                    MeiAudienceSegmenterOperationalGuard.MODULE,
+                    MeiAudienceSegmenterOperationalGuard.OPERATION,
+                    properties.expectedApiKeyVariable(),
+                    properties.fallbackApiKeyVariable(),
+                    input.researchCycleId(),
+                    input.cnaeCode());
+            throw new MeiAudienceSegmenterOperationalException(
+                    "Falha operacional na etapa mei-audience-segmenter: variável "
+                            + properties.expectedApiKeyVariable()
+                            + " ausente e fallback "
+                            + properties.fallbackApiKeyVariable()
+                            + " indisponível. module="
+                            + MeiAudienceSegmenterOperationalGuard.MODULE
+                            + ", operation="
+                            + MeiAudienceSegmenterOperationalGuard.OPERATION
+                            + ", expectedVariable="
+                            + properties.expectedApiKeyVariable()
+                            + ", fallbackVariable="
+                            + properties.fallbackApiKeyVariable()
+                            + ", researchCycleId="
+                            + input.researchCycleId()
+                            + ".");
         }
         String prompt = promptBuilder.buildPrompt(input);
         Map<String, Object> requestBody = buildRequestBody(prompt);
@@ -63,6 +86,8 @@ public class OpenAiMeiAudienceSegmenterClient {
             MeiAudienceSegmentDraft draft = objectMapper.readValue(rawModelResponse, MeiAudienceSegmentDraft.class);
             validator.validate(input, draft);
             return draft;
+        } catch (MeiAudienceSegmenterOperationalException ex) {
+            throw ex;
         } catch (RestClientException | JsonProcessingException | IllegalStateException | IllegalArgumentException ex) {
             log.error(
                     "Erro ao segmentar público MEI/autônomo com OpenAI (endpoint={}, researchCycleId={}, cnaeCode={})",

--- a/oprm-coletor-mei/src/main/resources/application.yml
+++ b/oprm-coletor-mei/src/main/resources/application.yml
@@ -29,6 +29,8 @@ oprm:
         api-key: ${OPRM_MEI_AUDIENCE_SEGMENTER_OPENAI_API_KEY:${OPENAI_API_KEY:}}
         api-key-file: ${OPRM_MEI_AUDIENCE_SEGMENTER_OPENAI_API_KEY_FILE:${OPENAI_API_KEY_FILE:}}
         model: ${OPRM_MEI_AUDIENCE_SEGMENTER_OPENAI_MODEL:gpt-4.1-mini}
+        expected-api-key-variable: OPRM_MEI_AUDIENCE_SEGMENTER_OPENAI_API_KEY
+        fallback-api-key-variable: OPENAI_API_KEY
   market-import:
     collector:
       backend-base-url: ${OPRM_COLLECTOR_BACKEND_BASE_URL:http://191.252.181.168}

--- a/oprm-coletor-mei/src/test/java/com/marketinghub/nichocnae/meiaudiencesegmenter/MeiAudienceSegmenterOperationalGuardTest.java
+++ b/oprm-coletor-mei/src/test/java/com/marketinghub/nichocnae/meiaudiencesegmenter/MeiAudienceSegmenterOperationalGuardTest.java
@@ -1,0 +1,122 @@
+package com.marketinghub.nichocnae.meiaudiencesegmenter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.marketinghub.nichocnae.pipeline.ArtifactStore;
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/** Responsabilidade: validar a barreira operacional da etapa MEI antes de buscar ou processar pendências. */
+@ExtendWith(MockitoExtension.class)
+class MeiAudienceSegmenterOperationalGuardTest {
+    @Mock MeiAudienceSegmenterBackendClient backendClient;
+    @Mock MeiAudienceSegmenterProcessor processor;
+    @Mock ArtifactStore artifactStore;
+
+    /** Confirma que a ausência da chave dedicada e do fallback bloqueia a etapa antes de buscar pendências. */
+    @Test
+    void shouldBlockPendingLookupWhenDedicatedAndFallbackOpenAiKeysAreMissing() {
+        MeiAudienceSegmenterOperationalGuard guard = new MeiAudienceSegmenterOperationalGuard(propertiesWithApiKey(""));
+        MeiAudienceSegmenterService service = new MeiAudienceSegmenterService(backendClient, processor, artifactStore, guard);
+
+        assertThatThrownBy(service::listPendingCycles)
+                .isInstanceOf(MeiAudienceSegmenterOperationalException.class)
+                .hasMessageContaining("OPRM_MEI_AUDIENCE_SEGMENTER_OPENAI_API_KEY")
+                .hasMessageContaining("OPENAI_API_KEY")
+                .hasMessageContaining("module=oprm-coletor-mei")
+                .hasMessageContaining("operation=mei-audience-segmenter")
+                .hasMessageContaining("researchCycleId=n/a");
+        verify(backendClient, never()).listPendingCycles();
+    }
+
+    /** Confirma que o valor já resolvido pelo fallback OPENAI_API_KEY libera a busca de pendências. */
+    @Test
+    void shouldAllowPendingLookupWhenOpenAiFallbackApiKeyIsConfigured() {
+        MeiAudienceSegmenterOperationalGuard guard = new MeiAudienceSegmenterOperationalGuard(propertiesWithApiKey("fallback-openai-key"));
+        MeiAudienceSegmenterService service = new MeiAudienceSegmenterService(backendClient, processor, artifactStore, guard);
+        when(backendClient.listPendingCycles()).thenReturn(List.of(pending()));
+
+        List<MeiAudienceSegmenterPending> pendingCycles = service.listPendingCycles();
+
+        assertThat(pendingCycles).hasSize(1);
+        verify(backendClient).listPendingCycles();
+    }
+
+    /** Confirma que a falha operacional com ciclo conhecido é reportada ao backend sem mascarar a causa-raiz. */
+    @Test
+    void shouldNotifyBackendWithOperationalErrorWhenKeyIsMissingAfterPendingWasLoaded() {
+        MeiAudienceSegmenterOperationalGuard guard = mock(MeiAudienceSegmenterOperationalGuard.class);
+        MeiAudienceSegmenterService service = new MeiAudienceSegmenterService(backendClient, processor, artifactStore, guard);
+        MeiAudienceSegmenterPending pending = pending();
+        MeiAudienceSegmenterOperationalException error = new MeiAudienceSegmenterOperationalException(
+                "Falha operacional na etapa mei-audience-segmenter: variável OPRM_MEI_AUDIENCE_SEGMENTER_OPENAI_API_KEY ausente e fallback OPENAI_API_KEY indisponível. module=oprm-coletor-mei, operation=mei-audience-segmenter, researchCycleId=1001.");
+        when(backendClient.listPendingCycles()).thenReturn(List.of(pending));
+        doAnswer(invocation -> {
+                    Long researchCycleId = invocation.getArgument(0);
+                    if (Long.valueOf(1001L).equals(researchCycleId)) {
+                        throw error;
+                    }
+                    return null;
+                })
+                .when(guard)
+                .assertReadyForExecution(any());
+
+        assertThatThrownBy(() -> service.processPending("test"))
+                .isSameAs(error)
+                .hasMessageContaining("researchCycleId=1001");
+        verify(backendClient).failStageExecution(pending, error);
+    }
+
+    /** Cria propriedades simulando o valor final já resolvido pelo application.yml. */
+    private MeiAudienceSegmenterOpenAiProperties propertiesWithApiKey(String apiKey) {
+        return new MeiAudienceSegmenterOpenAiProperties(
+                "https://api.openai.com/v1",
+                apiKey,
+                "",
+                "gpt-test",
+                "OPRM_MEI_AUDIENCE_SEGMENTER_OPENAI_API_KEY",
+                "OPENAI_API_KEY");
+    }
+
+    /** Cria uma pendência mínima para testar a barreira operacional. */
+    private MeiAudienceSegmenterPending pending() {
+        return new MeiAudienceSegmenterPending(
+                1001L,
+                2002L,
+                3003L,
+                "9602501",
+                "Cabeleireiros, manicure e pedicure",
+                "Serviços de beleza",
+                "Beleza MEI",
+                "Rotina operacional",
+                "Captação por indicação",
+                "Instagram e WhatsApp",
+                "Agenda cheia e retrabalho",
+                "Medo de perder clientes",
+                "Ter agenda previsível",
+                "Ficar sem faturamento",
+                "Linguagem direta",
+                "Dores comprovadas",
+                "Resultados desejados",
+                "Evidências recentes",
+                "example.com",
+                80,
+                75,
+                70,
+                10,
+                Instant.parse("2026-06-12T00:00:00Z"),
+                List.of(),
+                List.of());
+    }
+}


### PR DESCRIPTION
### Motivation
- Garantir que a etapa `mei-audience-segmenter` não consuma pendências ou invoque a OpenAI sem uma chave operacional configurada (dedicada ou fallback). 
- Produzir logs operacionais claros contendo `module=oprm-coletor-mei`, `operation=mei-audience-segmenter`, variável esperada, fallback e `researchCycleId` para facilitar diagnóstico e auditoria. 
- Evitar mascaramento da causa-raiz ao falhar: retornar erro operacional explícito que preserve a causa original quando a configuração estiver ausente.

### Description
- Adiciona `MeiAudienceSegmenterOperationalGuard` (implementa `ApplicationRunner`) e `MeiAudienceSegmenterOperationalException` para checagem de prontidão da chave OpenAI no startup e antes de listar/processar pendências. 
- Atualiza `MeiAudienceSegmenterService` para invocar a guarda antes de `listPendingCycles`, `processPending` e por ciclo individual; e atualiza `OpenAiMeiAudienceSegmenterClient` para logar e lançar `MeiAudienceSegmenterOperationalException` quando não houver chave resolvida. 
- Expande `MeiAudienceSegmenterOpenAiProperties` e `application.yml` para expor `expected-api-key-variable` e `fallback-api-key-variable`, mantendo fallback por `OPENAI_API_KEY` e centralizando nomes; adiciona testes unitários em `MeiAudienceSegmenterOperationalGuardTest` cobrindo ausência da chave, fallback resolvido e notificação de falha ao backend quando houver `researchCycleId`. 
- Documenta a mudança em `docs/registros/oprm1.md`.

### Testing
- Executado `mvn test -Dtest=MeiAudienceSegmenterOperationalGuardTest` e o teste específico passou com sucesso. 
- Executado `mvn test` no módulo `oprm-coletor-mei` e a suíte completa do módulo passou (todas as suítes executadas concluídas sem falhas). 
- Os testes cobrem os cenários de chave ausente, leitura de fallback e confirmação de que a falha operacional é reportada ao backend sem mascarar a causa-raiz.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2c3c8223d08321bca7287f1893ddc1)