### PR TITLE
Add Facebook campaign reach (alcance) to experiment reports

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/ExperimentCampaignMetric.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/ExperimentCampaignMetric.java
@@ -11,7 +11,7 @@ import java.time.Instant;
 import java.time.LocalDate;
 
 /**
- * Stores aggregated performance metrics for an experiment's Facebook campaign.
+ * Guarda as métricas agregadas de desempenho da campanha Facebook vinculada ao experimento.
  */
 @Entity
 @Table(name = "experiment_campaign_metric")
@@ -35,6 +35,8 @@ public class ExperimentCampaignMetric {
 
     private LocalDate dateStart;
     private LocalDate dateStop;
+    @Column(name = "reach")
+    private Long reach;
     private Long impressions;
     private Long clicks;
     private Long leads;

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/dto/ExperimentCampaignMetricDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/dto/ExperimentCampaignMetricDto.java
@@ -5,10 +5,14 @@ import java.time.Instant;
 import java.time.LocalDate;
 import lombok.Data;
 
+/**
+ * Transporta as métricas agregadas da campanha Facebook para relatórios e telas do experimento.
+ */
 @Data
 public class ExperimentCampaignMetricDto {
     private LocalDate dateStart;
     private LocalDate dateStop;
+    private Long reach;
     private Long impressions;
     private Long clicks;
     private Long leads;

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/report/service/ExperimentCompleteMarkdownReportService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/report/service/ExperimentCompleteMarkdownReportService.java
@@ -204,6 +204,7 @@ public class ExperimentCompleteMarkdownReportService {
         appendJsonBlock(markdown, "campaign_metric", mapOf(
                 "dateStart", metric.getDateStart(),
                 "dateStop", metric.getDateStop(),
+                "reach", metric.getReach(),
                 "impressions", metric.getImpressions(),
                 "clicks", metric.getClicks(),
                 "leads", metric.getLeads(),

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/report/service/ExperimentReportMaterialService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/report/service/ExperimentReportMaterialService.java
@@ -268,6 +268,9 @@ public class ExperimentReportMaterialService {
                 .collect(Collectors.toList());
     }
 
+    /**
+     * Converte as métricas de campanha para o DTO usado pelo material de relatório.
+     */
     private ExperimentCampaignMetricDto toCampaignMetricDto(ExperimentCampaignMetric metric) {
         if (metric == null) {
             return null;
@@ -275,6 +278,7 @@ public class ExperimentReportMaterialService {
         ExperimentCampaignMetricDto dto = new ExperimentCampaignMetricDto();
         dto.setDateStart(metric.getDateStart());
         dto.setDateStop(metric.getDateStop());
+        dto.setReach(metric.getReach());
         dto.setImpressions(metric.getImpressions());
         dto.setClicks(metric.getClicks());
         dto.setLeads(metric.getLeads());

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentCampaignMetricService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentCampaignMetricService.java
@@ -13,12 +13,18 @@ import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.time.LocalDate;
 
+/**
+ * Mantém as métricas agregadas de campanha e propaga o custo de mídia para o experimento.
+ */
 @Service
 public class ExperimentCampaignMetricService {
     private final ExperimentCampaignMetricRepository repository;
     private final FacebookAdsCampaignRepository campaignRepository;
     private final CostAttributionService costAttributionService;
 
+    /**
+     * Inicializa o serviço com repositórios de campanha, métricas e atribuição de custo.
+     */
     public ExperimentCampaignMetricService(ExperimentCampaignMetricRepository repository,
                                            FacebookAdsCampaignRepository campaignRepository,
                                            CostAttributionService costAttributionService) {
@@ -27,13 +33,17 @@ public class ExperimentCampaignMetricService {
         this.costAttributionService = costAttributionService;
     }
 
+    /**
+     * Cria ou atualiza as métricas sincronizadas da campanha Facebook de um experimento.
+     */
     @Transactional
     public ExperimentCampaignMetric upsert(String campaignId,
                                            LocalDate dateStart,
                                            LocalDate dateStop,
+                                           Long reach,
                                            Long impressions,
-                                            Long clicks,
-                                            Long leads,
+                                           Long clicks,
+                                           Long leads,
                                            BigDecimal spend) {
         FacebookAdsCampaign campaign = campaignRepository.findById(campaignId)
                 .orElseThrow(() -> new IllegalArgumentException("Facebook campaign not found: " + campaignId));
@@ -47,6 +57,7 @@ public class ExperimentCampaignMetricService {
         metric.setCampaign(campaign);
         metric.setDateStart(dateStart);
         metric.setDateStop(dateStop);
+        metric.setReach(reach);
         metric.setImpressions(impressions);
         metric.setClicks(clicks);
         metric.setLeads(leads);
@@ -58,6 +69,9 @@ public class ExperimentCampaignMetricService {
         return saved;
     }
 
+    /**
+     * Calcula o custo por clique a partir do gasto e dos cliques sincronizados.
+     */
     private BigDecimal calculateCpc(BigDecimal spend, Long clicks) {
         if (spend == null || clicks == null || clicks == 0) {
             return BigDecimal.ZERO;
@@ -65,6 +79,9 @@ public class ExperimentCampaignMetricService {
         return spend.divide(BigDecimal.valueOf(clicks), 2, RoundingMode.HALF_UP);
     }
 
+    /**
+     * Calcula o custo por lead a partir do gasto e dos leads sincronizados.
+     */
     private BigDecimal calculateCpl(BigDecimal spend, Long leads) {
         if (spend == null || leads == null || leads == 0) {
             return BigDecimal.ZERO;
@@ -72,6 +89,9 @@ public class ExperimentCampaignMetricService {
         return spend.divide(BigDecimal.valueOf(leads), 2, RoundingMode.HALF_UP);
     }
 
+    /**
+     * Aplica ao experimento apenas a diferença entre o gasto novo e o gasto anterior.
+     */
     private void applySpendDelta(Experiment experiment, BigDecimal newSpend, BigDecimal previousSpend) {
         if (experiment == null) {
             return;

--- a/backend/ads-service/src/main/java/com/marketinghub/facebookads/controller/FacebookAdsCampaignController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/facebookads/controller/FacebookAdsCampaignController.java
@@ -298,6 +298,7 @@ public class FacebookAdsCampaignController {
                 campaignId,
                 request.dateStart(),
                 request.dateStop(),
+                request.reach(),
                 request.impressions(),
                 request.clicks(),
                 request.leads(),
@@ -648,6 +649,7 @@ public class FacebookAdsCampaignController {
         return new CampaignMetricSummary(
                 metric.getDateStart(),
                 metric.getDateStop(),
+                metric.getReach(),
                 metric.getImpressions(),
                 metric.getClicks(),
                 metric.getLeads(),
@@ -720,6 +722,7 @@ public class FacebookAdsCampaignController {
     public record CampaignMetricSummary(
             LocalDate dateStart,
             LocalDate dateStop,
+            Long reach,
             Long impressions,
             Long clicks,
             Long leads,
@@ -734,6 +737,7 @@ public class FacebookAdsCampaignController {
     public record CampaignMetricsUpdateRequest(
             LocalDate dateStart,
             LocalDate dateStop,
+            Long reach,
             Long impressions,
             Long clicks,
             Long leads,

--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-12-experiment-campaign-metric-reach.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-12-experiment-campaign-metric-reach.yaml
@@ -1,0 +1,22 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-06-12-experiment-campaign-metric-reach
+      author: marketinghub
+      preConditions:
+        - onFail: MARK_RAN
+        - dbms:
+            type: mysql
+        - tableExists:
+            tableName: experiment_campaign_metric
+        - not:
+            columnExists:
+              tableName: experiment_campaign_metric
+              columnName: reach
+      changes:
+        - sql:
+            dbms: mysql
+            splitStatements: true
+            stripComments: true
+            sql: |
+              ALTER TABLE experiment_campaign_metric
+                  ADD COLUMN reach BIGINT NULL AFTER date_stop;

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -970,3 +970,7 @@ databaseChangeLog:
   - include:
       file: changesets/2026-06-11-mois-product-1057-hotmart-facts.yaml
       relativeToChangelogFile: true
+
+  - include:
+      file: changesets/2026-06-12-experiment-campaign-metric-reach.yaml
+      relativeToChangelogFile: true

--- a/backend/ads-service/src/test/java/com/marketinghub/facebookads/controller/FacebookAdsCampaignMetricsAutoStopControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/facebookads/controller/FacebookAdsCampaignMetricsAutoStopControllerTest.java
@@ -164,6 +164,7 @@ class FacebookAdsCampaignMetricsAutoStopControllerTest {
                 .experiment(experiment)
                 .dateStart(LocalDate.parse("2026-06-12"))
                 .dateStop(LocalDate.parse("2026-06-12"))
+                .reach(1300L)
                 .impressions(1500L)
                 .clicks(120L)
                 .leads(6L)
@@ -176,6 +177,7 @@ class FacebookAdsCampaignMetricsAutoStopControllerTest {
                 eq(CAMPAIGN_ID),
                 eq(LocalDate.parse("2026-06-12")),
                 eq(LocalDate.parse("2026-06-12")),
+                eq(1300L),
                 eq(1500L),
                 eq(120L),
                 eq(6L),
@@ -190,6 +192,7 @@ class FacebookAdsCampaignMetricsAutoStopControllerTest {
                 {
                   "dateStart": "2026-06-12",
                   "dateStop": "2026-06-12",
+                  "reach": 1300,
                   "impressions": 1500,
                   "clicks": 120,
                   "leads": 6,
@@ -201,6 +204,7 @@ class FacebookAdsCampaignMetricsAutoStopControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content(payload))
                 .andExpect(status().isOk())
+                .andExpect(jsonPath("$.reach").value(1300))
                 .andExpect(jsonPath("$.impressions").value(1500))
                 .andExpect(jsonPath("$.spend").value(25.0));
 

--- a/docs/canonical/facebook-campaign-publication-canon.v1.md
+++ b/docs/canonical/facebook-campaign-publication-canon.v1.md
@@ -44,8 +44,8 @@ As etapas oficiais expostas para operação são:
 5. `campaign-hierarchy-publication` — criar campanha, conjunto, imagem, criativo e anúncio na Meta.
 6. `publication-registration` — persistir IDs externos no backend e marcar rastreabilidade da publicação.
 7. `metrics-sync-target-selection` — selecionar campanhas em execução para sincronização de métricas.
-8. `meta-insights-collection` — coletar insights da Graph API.
-9. `metrics-persistence` — atualizar `experiment_campaign_metric` e dados de última sincronização.
+8. `meta-insights-collection` — coletar insights da Graph API, incluindo `reach`/alcance, impressões, cliques, gasto e ações de lead.
+9. `metrics-persistence` — atualizar `experiment_campaign_metric` e dados de última sincronização, preservando alcance para relatórios gerais do experimento.
 10. `metrics-error-handling` — registrar falhas de coleta para correção de causa-raiz.
 
 Esse pipeline é administrativo e operacional: ele torna visível o fluxo do worker, mas não transfere ownership de banco para o worker. O backend continua sendo o único responsável por persistência, e o Facebook Ads Worker continua consumindo contratos HTTP do módulo Facebook.
@@ -79,7 +79,7 @@ Quando a Meta não retornar os limites ou o público ficar fora dessa faixa, o e
 | `experiment.follow_up_action_url` | `marketinghubdb.experiment` | Representa a landing aprovada na aba Landing; com valor preenchido, a página está publicada para uso como destino da campanha. |
 | `targeting_element` (job_title) | `marketinghubdb.targeting_element` | Para publicação manual, pelo menos **1** elemento `JOB_TITLE` com `status='APPROVED'`; quando existirem `meta_id`/`meta_key`, o `facebook-ads-worker` deve preferi-los no payload de targeting. |
 | `experiment.daily_budget`, `facebook_release_requested_at`, `funnel_reset_at`, `market_niche.facebook_pixel_id`, `status` | `marketinghubdb.experiment` | Controlam orçamento, liberação, resets e sincronismo de pixel. |
-| `experiment_campaign_metric` + eventos do Lead Portal + checkout/pagamentos | bancos do domínio de experimentos e `lead-portal` | Usados para preencher o funil e o custo por etapa. |
+| `experiment_campaign_metric` + eventos do Lead Portal + checkout/pagamentos | bancos do domínio de experimentos e `lead-portal` | Usados para preencher alcance, impressões, funil e custo por etapa. |
 
 ## 5. Bloqueios canônicos de publicação (diagnóstico do worker)
 
@@ -188,7 +188,7 @@ Consequência arquitetural: a publicação de campanha passa a ser substituível
 
 1. **Invalidação por baixa distribuição** – quando uma campanha vinculada a experimento `RUNNING` completar **48 horas** desde o registro em `facebook_ads_campaign.created_at` e ainda tiver **menos de 100 impressões** sincronizadas em `experiment_campaign_metric.impressions`, o backend deve invalidar o experimento (`experiment.status='INVALIDATED'`), registrar o motivo operacional em `facebook_ads_campaign.stop_reason='LOW_IMPRESSIONS_AFTER_RUNNING_TIME'` e criar uma solicitação de pausa para o Facebook Ads Worker (`stop_requested_at`). Essa regra evita consumo de tempo em campanhas sem entrega mínima suficiente para validar demanda.
 2. **Invalidação por baixo interesse do público-alvo** – quando a transição `Visualização do anúncio → Acesso ao formulário de lead` ficar abaixo de **1,5%** e o limite superior estatístico de 95% também ficar abaixo desse mínimo, o backend deve manter o experimento em execução até o gasto de mídia sincronizado em `experiment_campaign_metric.spend` atingir **R$ 25,00**. A partir desse piso financeiro, o backend deve invalidar o experimento (`experiment.status='INVALIDATED'`), registrar `facebook_ads_campaign.stop_reason='TARGET_AUDIENCE_LOW_INTEREST_STATISTICAL'` e solicitar pausa ao Facebook Ads Worker. Essa regra diferencia falta de interesse real do público-alvo de amostra pequena e também evita parar antes de um gasto mínimo operacional: não basta CTR baixo observado; a margem estatística precisa confirmar que o anúncio/ângulo não está gerando intenção suficiente para avançar ao formulário e a campanha precisa ter consumido ao menos R$ 25,00.
-3. **Aba Funil de vendas** – expõe nove etapas da jornada (impressão → download/compra) usando `experiment_campaign_metric` para mídia, eventos do `lead-portal` para engajamentos e eventos de checkout/pagamento para conversões finais.
+3. **Aba Funil de vendas e relatórios gerais** – expõem alcance, impressões e nove etapas da jornada (impressão → download/compra) usando `experiment_campaign_metric` para mídia, eventos do `lead-portal` para engajamentos e eventos de checkout/pagamento para conversões finais.
 4. **Custo por etapa** – o cartão mostra o gasto total sincronizado pela Marketing API do Meta Ads e divide o valor por conversão em cada etapa, permitindo encontrar gargalos sem sair do experimento. (Fonte externa: [Meta Marketing API](https://developers.facebook.com/docs/marketing-api/)).
 5. **Composição canônica do custo total do experimento** – para qualquer visão consolidada de custo (cards, listagens, relatórios e APIs de resumo), o valor de `custo_total_experimento_brl` deve ser calculado pela soma:
    - `custo_campanha_brl` (gasto de mídia sincronizado da Meta Ads API);

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -4460,3 +4460,9 @@
 - causa-raiz: jobs que perdiam o ciclo do Worker AI ficavam fora da fila porque a listagem consumia apenas `INICIADO`, criando travamento operacional sem decisão de recuperação ou falha.
 - foi feito: definido lease operacional de 45 minutos; jobs antigos em `PROCESSANDO` sem `openai_job_id` voltam para `INICIADO` com mensagem clara; jobs antigos com possível execução OpenAI ativa viram `FALHA` para evitar duplicidade.
 - prevenção: adicionados testes unitários cobrindo recuperação segura e bloqueio de recaptura quando existe `openai_job_id` associado.
+
+## 2026-06-12 — Alcance nos relatórios gerais do experimento
+
+- Confirmado que a sincronização de métricas do Facebook Ads não coletava nem persistia `reach`/alcance: o worker consultava apenas `impressions`, `clicks`, `spend`, `actions`, `date_start` e `date_stop`.
+- Adicionada a métrica `reach` ao contrato de insights, persistência em `experiment_campaign_metric`, DTOs, material de relatório e Markdown completo baixado pelo botão **Relatório completo (.md)**.
+- Atualizado o painel de material do relatório para exibir Alcance junto das demais métricas de campanha.

--- a/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignMetricsService.java
+++ b/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignMetricsService.java
@@ -29,6 +29,9 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+/**
+ * Sincroniza métricas de campanhas Facebook na Graph API e envia o agregado ao backend.
+ */
 @Service
 public class FacebookCampaignMetricsService {
     private static final Logger LOGGER = LoggerFactory.getLogger(FacebookCampaignMetricsService.class);
@@ -41,6 +44,9 @@ public class FacebookCampaignMetricsService {
     private final String apiPrefix;
     private final AtomicBoolean configurationUnavailableWarningLogged = new AtomicBoolean(false);
 
+    /**
+     * Inicializa o sincronizador com clientes da Meta, backend e configuração operacional.
+     */
     public FacebookCampaignMetricsService(FacebookAdsService facebookAdsService,
                                           FacebookAccessTokenManager accessTokenManager,
                                           FacebookWorkerConfigurationClient configurationClient,
@@ -55,6 +61,9 @@ public class FacebookCampaignMetricsService {
         this.apiPrefix = apiPrefix;
     }
 
+    /**
+     * Busca a configuração ativa e sincroniza métricas de todas as campanhas elegíveis.
+     */
     public void syncCampaignMetrics() {
         Optional<FacebookWorkerConfiguration> configuration = configurationClient.fetchConfiguration();
         if (configuration.isEmpty()) {
@@ -82,6 +91,9 @@ public class FacebookCampaignMetricsService {
         }
     }
 
+    /**
+     * Processa uma campanha elegível consultando insights e reportando sucesso ou erro ao backend.
+     */
     private void processTarget(CampaignMetricsSyncTarget target) {
         try {
             JsonNode insights = facebookAdsService.getCampaignInsights(target.campaignId(), buildInsightsQuery());
@@ -103,7 +115,7 @@ public class FacebookCampaignMetricsService {
                 processTarget(target);
             }
         } catch (FacebookPermissionException ex) {
-            LOGGER.warn("Facebook permission error while fetching metrics for campaign {}: {}", target.campaignId(), ex.getMessage());
+            LOGGER.warn("Facebook permission error while fetching metrics for campaign {}: {}", target.campaignId(), ex.getMessage(), ex);
             reportMetricsError(target.campaignId(), "Permission error: " + ex.getMessage());
         } catch (WebClientRequestException ex) {
             LOGGER.warn("Backend connectivity error while syncing metrics for campaign {}", target.campaignId(), ex);
@@ -113,53 +125,74 @@ public class FacebookCampaignMetricsService {
         }
     }
 
+    /**
+     * Monta os parâmetros canônicos de consulta de insights de campanha na Meta.
+     */
     private Map<String, String> buildInsightsQuery() {
         Map<String, String> params = new HashMap<>();
-        params.put("fields", "campaign_name,impressions,clicks,spend,actions,date_start,date_stop");
+        params.put("fields", "campaign_name,reach,impressions,clicks,spend,actions,date_start,date_stop");
         params.put("date_preset", "maximum");
         params.put("time_increment", "all_days");
         return params;
     }
 
+    /**
+     * Converte a linha de insights da Meta no payload aceito pelo backend.
+     */
     private CampaignMetricsUpdateRequest mapToPayload(JsonNode row) {
         if (row == null || row.isNull()) {
             return null;
         }
         LocalDate dateStart = parseDate(row.path("date_start").asText(null));
         LocalDate dateStop = parseDate(row.path("date_stop").asText(null));
+        Long reach = parseLong(row.path("reach"));
         Long impressions = parseLong(row.path("impressions"));
         Long clicks = parseLong(row.path("clicks"));
         BigDecimal spend = parseBigDecimal(row.path("spend"));
         Long leads = extractLeadCount(row.path("actions"));
-        return new CampaignMetricsUpdateRequest(dateStart, dateStop, impressions, clicks, leads, spend);
+        return new CampaignMetricsUpdateRequest(dateStart, dateStop, reach, impressions, clicks, leads, spend);
     }
 
+    /**
+     * Cria payload zerado quando a Meta não retorna linha de insights para a campanha.
+     */
     private CampaignMetricsUpdateRequest buildEmptyMetricsPayload() {
-        return new CampaignMetricsUpdateRequest(null, null, 0L, 0L, 0L, BigDecimal.ZERO);
+        return new CampaignMetricsUpdateRequest(null, null, 0L, 0L, 0L, 0L, BigDecimal.ZERO);
     }
 
+    /**
+     * Lê um número inteiro longo de um nó JSON, retornando zero quando ausente ou inválido.
+     */
     private Long parseLong(JsonNode node) {
         if (node == null || node.isNull()) {
             return 0L;
         }
         try {
             return node.asLong();
-        } catch (Exception ex) {
+        } catch (RuntimeException ex) {
+            LOGGER.debug("Could not parse Long from metrics payload: {}", node, ex);
             return 0L;
         }
     }
 
+    /**
+     * Converte uma data textual ISO-8601 da Meta para LocalDate.
+     */
     private LocalDate parseDate(String value) {
         if (!StringUtils.hasText(value)) {
             return null;
         }
         try {
             return LocalDate.parse(value);
-        } catch (Exception ex) {
+        } catch (RuntimeException ex) {
+            LOGGER.debug("Could not parse LocalDate from metrics payload value {}", value, ex);
             return null;
         }
     }
 
+    /**
+     * Lê valor decimal de um nó JSON, retornando zero quando ausente ou inválido.
+     */
     private BigDecimal parseBigDecimal(JsonNode node) {
         if (node == null || node.isNull()) {
             return BigDecimal.ZERO;
@@ -171,11 +204,14 @@ public class FacebookCampaignMetricsService {
         try {
             return new BigDecimal(text);
         } catch (NumberFormatException ex) {
-            LOGGER.debug("Could not parse BigDecimal from value {}: {}", text, ex.getMessage());
+            LOGGER.debug("Could not parse BigDecimal from metrics payload value {}", text, ex);
             return BigDecimal.ZERO;
         }
     }
 
+    /**
+     * Soma ações de lead retornadas pela Meta no payload de insights.
+     */
     private long extractLeadCount(JsonNode actionsNode) {
         if (actionsNode == null || !actionsNode.isArray()) {
             return 0L;
@@ -193,6 +229,9 @@ public class FacebookCampaignMetricsService {
         return total;
     }
 
+    /**
+     * Envia ao backend as métricas sincronizadas de uma campanha.
+     */
     private void sendMetrics(String campaignId, CampaignMetricsUpdateRequest payload) {
         String url = UrlUtils.joinPath(backendBaseUrl, apiPrefix, "/facebook-campaigns/" + campaignId + "/metrics");
         backendClient.post()
@@ -207,6 +246,9 @@ public class FacebookCampaignMetricsService {
             .block();
     }
 
+    /**
+     * Registra no backend uma falha de sincronização de métricas da campanha.
+     */
     private void reportMetricsError(String campaignId, String message) {
         String sanitized = sanitizeMessage(message);
         String url = UrlUtils.joinPath(backendBaseUrl, apiPrefix, "/facebook-campaigns/" + campaignId + "/metrics-error");
@@ -223,6 +265,9 @@ public class FacebookCampaignMetricsService {
         }
     }
 
+    /**
+     * Limita mensagens de erro para persistência segura no backend.
+     */
     private String sanitizeMessage(String message) {
         if (!StringUtils.hasText(message)) {
             return "Unknown error";
@@ -230,6 +275,9 @@ public class FacebookCampaignMetricsService {
         return message.length() > 500 ? message.substring(0, 500) : message;
     }
 
+    /**
+     * Busca no backend as campanhas que precisam de sincronização de métricas.
+     */
     private List<CampaignMetricsSyncTarget> fetchSyncTargets() {
         String url = UrlUtils.joinPath(backendBaseUrl, apiPrefix, "/facebook-campaigns/metrics/sync-targets");
         try {
@@ -247,6 +295,9 @@ public class FacebookCampaignMetricsService {
         }
     }
 
+    /**
+     * Atualiza o token usado nas chamadas da Meta quando a configuração mudou.
+     */
     private void ensureAccessToken(String configuredToken) {
         String currentToken = facebookAdsService.getCurrentAccessToken();
         if (!StringUtils.hasText(currentToken) || !currentToken.equals(configuredToken)) {
@@ -254,6 +305,9 @@ public class FacebookCampaignMetricsService {
         }
     }
 
+    /**
+     * Tenta renovar o token e informa se a sincronização pode ser repetida.
+     */
     private boolean tryRenewAccessToken() {
         FacebookAccessTokenManager.RenewalAttemptResult renewalResult = accessTokenManager.tryRenewAccessTokenIfPossible();
         if (renewalResult.outcome() == FacebookAccessTokenManager.RenewalOutcome.SUCCESS) {
@@ -273,6 +327,7 @@ public class FacebookCampaignMetricsService {
     public record CampaignMetricsUpdateRequest(
             LocalDate dateStart,
             LocalDate dateStop,
+            Long reach,
             Long impressions,
             Long clicks,
             Long leads,

--- a/facebook-ads-worker/src/test/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignMetricsServiceTest.java
+++ b/facebook-ads-worker/src/test/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignMetricsServiceTest.java
@@ -1,0 +1,78 @@
+package com.marketinghub.facebookadsworker.facebookcampaign;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marketinghub.facebookadsworker.FacebookAccessTokenManager;
+import com.marketinghub.facebookadsworker.FacebookAdsService;
+import com.marketinghub.facebookadsworker.configuration.FacebookWorkerConfigurationClient;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.lang.reflect.Method;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+/** Testa o mapeamento das métricas de campanha coletadas na Meta. */
+class FacebookCampaignMetricsServiceTest {
+
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    /** Garante que a consulta de insights pede o campo de alcance da Meta. */
+    @Test
+    void buildInsightsQueryIncludesReach() throws Exception {
+        FacebookCampaignMetricsService service = service();
+
+        Method method = FacebookCampaignMetricsService.class.getDeclaredMethod("buildInsightsQuery");
+        method.setAccessible(true);
+        @SuppressWarnings("unchecked")
+        Map<String, String> query = (Map<String, String>) method.invoke(service);
+
+        assertThat(query.get("fields")).contains("reach");
+    }
+
+    /** Garante que o alcance retornado pela Meta entra no payload enviado ao backend. */
+    @Test
+    void mapToPayloadCopiesReachFromInsights() throws Exception {
+        FacebookCampaignMetricsService service = service();
+        JsonNode row = objectMapper.readTree("""
+                {
+                  "date_start": "2026-06-12",
+                  "date_stop": "2026-06-12",
+                  "reach": "1300",
+                  "impressions": "1500",
+                  "clicks": "120",
+                  "spend": "25.00",
+                  "actions": [{"action_type": "lead", "value": "6"}]
+                }
+                """);
+
+        Method method = FacebookCampaignMetricsService.class.getDeclaredMethod("mapToPayload", JsonNode.class);
+        method.setAccessible(true);
+        FacebookCampaignMetricsService.CampaignMetricsUpdateRequest payload =
+                (FacebookCampaignMetricsService.CampaignMetricsUpdateRequest) method.invoke(service, row);
+
+        assertThat(payload.dateStart()).isEqualTo(LocalDate.parse("2026-06-12"));
+        assertThat(payload.dateStop()).isEqualTo(LocalDate.parse("2026-06-12"));
+        assertThat(payload.reach()).isEqualTo(1300L);
+        assertThat(payload.impressions()).isEqualTo(1500L);
+        assertThat(payload.clicks()).isEqualTo(120L);
+        assertThat(payload.leads()).isEqualTo(6L);
+        assertThat(payload.spend()).isEqualByComparingTo(new BigDecimal("25.00"));
+    }
+
+    /** Cria o serviço com dependências simuladas para testar apenas o mapeamento local. */
+    private FacebookCampaignMetricsService service() {
+        return new FacebookCampaignMetricsService(
+                mock(FacebookAdsService.class),
+                mock(FacebookAccessTokenManager.class),
+                mock(FacebookWorkerConfigurationClient.class),
+                WebClient.builder(),
+                "http://backend.test",
+                "/api"
+        );
+    }
+}

--- a/frontend/src/api/experiment/useExperiments.ts
+++ b/frontend/src/api/experiment/useExperiments.ts
@@ -43,6 +43,7 @@ export interface FacebookInstantFormSummary {
 export interface ExperimentCampaignMetric {
   dateStart?: string | null;
   dateStop?: string | null;
+  reach?: number | null;
   impressions?: number | null;
   clicks?: number | null;
   leads?: number | null;

--- a/frontend/src/pages/experiment/ExperimentReportPanel.tsx
+++ b/frontend/src/pages/experiment/ExperimentReportPanel.tsx
@@ -290,7 +290,8 @@ function ReportMaterialPreview({
       {material.campaignMetric ? (
         <div className="border rounded p-3">
           <h6 className="fw-semibold mb-2">Métricas da campanha</h6>
-          <div className="row row-cols-2 row-cols-md-4 g-3 text-center">
+          <div className="row row-cols-2 row-cols-md-5 g-3 text-center">
+            <MetricItem label="Alcance" value={material.campaignMetric.reach} />
             <MetricItem
               label="Impressões"
               value={material.campaignMetric.impressions}
@@ -310,7 +311,7 @@ function ReportMaterialPreview({
       {material.landingAnalytics ? (
         <div className="border rounded p-3">
           <h6 className="fw-semibold mb-2">Analytics da landing</h6>
-          <div className="row row-cols-2 row-cols-md-4 g-3 text-center mb-3">
+          <div className="row row-cols-2 row-cols-md-5 g-3 text-center mb-3">
             <MetricItem
               label="Sessões"
               value={material.landingAnalytics.totalSessions}


### PR DESCRIPTION
### Motivation
- Ensure the experiment reports include the Facebook metric `reach` (alcance) because the worker previously collected only impressions/clicks/spend and reports must reflect audience size for decisions. 
- Make the metric available end-to-end: Graph API → worker → backend persistence → DTOs → report material → UI and downloadable Markdown.

### Description
- Facebook worker now requests `reach` in the Insights fields and maps it into the metrics payload sent to the backend (`facebook-ads-worker/src/main/java/.../FacebookCampaignMetricsService.java`).
- Persist `reach` in `experiment_campaign_metric` with a new Liquibase changeset and an entity column (`backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-12-experiment-campaign-metric-reach.yaml` and `ExperimentCampaignMetric.java`).
- Extend backend contracts and flows: update controller request/response records and service `upsert` to accept/store `reach`, update DTOs and report builders to include `reach` in the complete Markdown report and report material (`ExperimentCampaignMetricDto`, `ExperimentReportMaterialService`, `ExperimentCompleteMarkdownReportService`, `FacebookAdsCampaignController`).
- Frontend changes to display Alcance in the experiment report material panel and to include `reach` in the typed API shape (`frontend/src/.../useExperiments.ts` and `ExperimentReportPanel.tsx`).
- Add unit tests to validate mapping and query behavior in the worker (`FacebookCampaignMetricsServiceTest`) and adjust an existing backend controller test to include `reach` (`FacebookAdsCampaignMetricsAutoStopControllerTest`).
- Update canonical doc and experiment records to document the contract change and operational rationale (`docs/canonical/...`, `docs/registros/experimentos.md`).

### Testing
- Ran backend unit test `FacebookAdsCampaignMetricsAutoStopControllerTest` with Maven and it passed (tests run: 2, failures: 0). 
- Ran facebook-ads-worker unit test `FacebookCampaignMetricsServiceTest` with Maven and it passed (tests run: 2, failures: 0).
- Performed frontend typecheck with `npm run typecheck` after installing dependencies and it completed successfully.
- Attempted `spotless:apply` in `ads-service` but the plugin invocation was not available in this environment (non-blocking for the functional change).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2c5997053c83219b5a0581194508d2)