### PR TITLE
OPRM CNAE: surface quality-gate blocked status, fix stage inference, add test and docs

### DIFF
--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -527,3 +527,9 @@
 - Configurado o ambiente Docker do `oprm-coletor-mei` para expor explicitamente `OPRM_MEI_AUDIENCE_SEGMENTER_OPENAI_API_KEY_FILE` apontando para o segredo OpenAI montado em `/run/secrets/openai_api_key`.
 - Causa-raiz tratada: a etapa `mei-audience-segmenter` já esperava chave própria ou fallback compartilhado no `application.yml`, mas os manifests do serviço só configuravam a chave da etapa seed, deixando a segmentação MEI sem credencial garantida no ambiente de execução.
 - Prevenção de recorrência: o modelo da etapa também ficou parametrizado nos manifests, mantendo paridade operacional entre seed e segmentação MEI/autônomo.
+
+## 2026-06-12 — OPRM NichoCNAE: status visual de bloqueio no detalhe do CNAE
+
+- Ajustada a tela de detalhe do CNAE para não inferir “em execução” quando o ciclo já foi bloqueado pelo gate de qualidade com status como `OUTDATED_SOURCES`, `NEEDS_MORE_RESEARCH`, `NEEDS_MORE_MEI_RESEARCH`, `TOO_CORPORATE`, `SOLUTION_CONTAMINATED` ou `GENERIC`.
+- Causa-raiz tratada: a tela usava apenas contadores do ciclo e `finishedAt` nulo para decidir a próxima etapa visual, então um ciclo já reprovado por qualidade aparecia como “Síntese em execução”.
+- Prevenção de recorrência: adicionada mensagem de negócio explicando o bloqueio e teste de regressão garantindo que “Fontes antigas” aparece no gate de qualidade, a síntese aparece concluída e a materialização fica bloqueada.

--- a/frontend/src/pages/oprm/OprmCnaeDetailPlaceholderPage.test.tsx
+++ b/frontend/src/pages/oprm/OprmCnaeDetailPlaceholderPage.test.tsx
@@ -1,0 +1,137 @@
+import { render, screen, within } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import OprmCnaeDetailPlaceholderPage from "./OprmCnaeDetailPlaceholderPage";
+
+function renderPage() {
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  });
+
+  return render(
+    <QueryClientProvider client={client}>
+      <MemoryRouter initialEntries={["/oprm/cnaes/9602501"]}>
+        <Routes>
+          <Route
+            path="/oprm/cnaes/:cnaeCode"
+            element={<OprmCnaeDetailPlaceholderPage />}
+          />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe("OprmCnaeDetailPlaceholderPage", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("mostra bloqueio de qualidade em vez de síntese em execução para fontes antigas", async () => {
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = input.toString();
+
+      if (url.includes("latest-volume")) {
+        return new Response(
+          JSON.stringify({
+            cnaeCode: "9602501",
+            cnaeDescription: "Cabeleireiros, manicure e pedicure",
+            opportunityScore: 90,
+            totalEstabelecimentos: 100,
+            totalEstabelecimentosAtivos: 80,
+            totalEmpresasMei: 70,
+            totalEmpresas: 100,
+            scoreStatus: "SCORED",
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+
+      if (url.includes("opportunity-score")) {
+        return new Response(
+          JSON.stringify({
+            cnaeCode: "9602501",
+            cnaeDescription: "Cabeleireiros, manicure e pedicure",
+            opportunityScore: 90,
+            marketVolumeScore: 90,
+            meiDensityScore: 90,
+            digitalFitScore: 90,
+            painClarityScore: 90,
+            scoreStatus: "SCORED",
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+
+      if (url.includes("routine-research-cycle/stage-executions")) {
+        return new Response(
+          JSON.stringify([
+            {
+              researchCycleId: 24,
+              sourceNicheId: 1,
+              cnaeCode: "9602501",
+              nicheName: "Cabeleireiros, manicure e pedicure",
+              originalNicheName:
+                "IA para crescimento de Cabeleireiros, manicure e pedicure",
+              neutralNicheName: "Cabeleireiros, manicure e pedicure",
+              researchMode: "ROUTINE_REALITY_RESEARCH",
+              solutionLanguageRiskScore: 100,
+              sourceScore: 90,
+              status: "OUTDATED_SOURCES",
+              totalQueries: 48,
+              totalSourceCandidates: 340,
+              totalSourceSnapshots: 104,
+              totalExtractedSignals: 266,
+              startedAt: "2026-06-12T19:08:26Z",
+              finishedAt: null,
+              errorMessage: null,
+            },
+          ]),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+
+      return new Response("{}", {
+        status: 200,
+        headers: { "Content-Type": "application/json" },
+      });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderPage();
+
+    expect(await screen.findByText(/status atual:/i)).toBeTruthy();
+    expect(
+      screen.getByText(/bloqueada por fontes antigas ou sem atualidade/i),
+    ).toBeTruthy();
+    expect(
+      screen.getByText(/o pipeline não está em execução agora/i),
+    ).toBeTruthy();
+
+    const synthesisCard = screen.getByText("6. Síntese").closest(".card");
+    expect(synthesisCard).toBeTruthy();
+    expect(
+      within(synthesisCard as HTMLElement).getByText("Concluído"),
+    ).toBeTruthy();
+
+    const qualityCard = screen.getByText("8. Qualidade").closest(".card");
+    expect(qualityCard).toBeTruthy();
+    expect(
+      within(qualityCard as HTMLElement).getByText("Fontes antigas"),
+    ).toBeTruthy();
+
+    const materializationCard = screen
+      .getByText("9. Materialização")
+      .closest(".card");
+    expect(materializationCard).toBeTruthy();
+    expect(
+      within(materializationCard as HTMLElement).getByText("Bloqueado"),
+    ).toBeTruthy();
+    expect(screen.queryByText("Em execução")).toBeNull();
+  });
+});

--- a/frontend/src/pages/oprm/OprmCnaeDetailPlaceholderPage.tsx
+++ b/frontend/src/pages/oprm/OprmCnaeDetailPlaceholderPage.tsx
@@ -90,21 +90,87 @@ function formatDateTime(value?: string | null) {
   }).format(new Date(value));
 }
 
+const statusLabels: Record<string, string> = {
+  RUNNING: "Em execução",
+  COMPLETED: "Concluído",
+  READY_FOR_HYPOTHESIS: "Pronto",
+  LIGHTLY_RESEARCHED: "Pesquisa inicial concluída",
+  ROUTINE_SYNTHESIZED: "Rotina sintetizada",
+  MEI_AUDIENCE_SEGMENTED: "Perfil MEI/autônomo criado",
+  MEI_AUDIENCE_READY: "Público MEI/autônomo pronto",
+  ENRICHED_NICHE_CREATED: "Nicho enriquecido disponível",
+  FAILED: "Falhou",
+  STALLED: "Parado sem progresso",
+  CANCELLED_BY_MANUAL_RESTART: "Cancelado por reinício",
+  NEEDS_MORE_RESEARCH: "Precisa aprofundar",
+  NEEDS_MORE_MEI_RESEARCH: "Precisa de mais MEI",
+  OUTDATED_SOURCES: "Fontes antigas",
+  TOO_CORPORATE: "Corporativo demais",
+  SOLUTION_CONTAMINATED: "Contaminado por solução",
+  GENERIC: "Genérico",
+  ENRICHED_NICHE_FAILED: "Falha na materialização",
+};
+
+const qualityBlockedStatuses = new Set([
+  "NEEDS_MORE_RESEARCH",
+  "NEEDS_MORE_MEI_RESEARCH",
+  "OUTDATED_SOURCES",
+  "TOO_CORPORATE",
+  "SOLUTION_CONTAMINATED",
+  "GENERIC",
+]);
+
 function statusLabel(status?: string | null) {
-  const labels: Record<string, string> = {
-    RUNNING: "Em execução",
-    COMPLETED: "Concluído",
-    READY_FOR_HYPOTHESIS: "Pronto",
-    FAILED: "Falhou",
-    NEEDS_MORE_RESEARCH: "Precisa aprofundar",
-    NEEDS_MORE_MEI_RESEARCH: "Precisa de mais MEI",
-    OUTDATED_SOURCES: "Fontes antigas",
-    TOO_CORPORATE: "Corporativo demais",
-    SOLUTION_CONTAMINATED: "Contaminado por solução",
-    GENERIC: "Genérico",
-    ENRICHED_NICHE_FAILED: "Falha na materialização",
+  return status ? (statusLabels[status] ?? status) : "Aguardando";
+}
+
+function isQualityBlockedStatus(status?: string | null) {
+  return Boolean(status && qualityBlockedStatuses.has(status));
+}
+
+function isCycleStoppedStatus(status?: string | null) {
+  return Boolean(
+    status &&
+    (isQualityBlockedStatus(status) ||
+      [
+        "FAILED",
+        "STALLED",
+        "CANCELLED_BY_MANUAL_RESTART",
+        "ENRICHED_NICHE_FAILED",
+      ].includes(status)),
+  );
+}
+
+function qualityBlockedMessage(status?: string | null) {
+  const messages: Record<string, string> = {
+    NEEDS_MORE_RESEARCH:
+      "A pesquisa chegou ao gate de qualidade, mas ainda precisa de mais evidências práticas antes de virar nicho enriquecido.",
+    NEEDS_MORE_MEI_RESEARCH:
+      "A pesquisa chegou ao gate de qualidade, mas faltam sinais mais fortes do público MEI/autônomo dono-operador.",
+    OUTDATED_SOURCES:
+      "A pesquisa chegou ao gate de qualidade, mas foi bloqueada por fontes antigas ou sem atualidade suficiente.",
+    TOO_CORPORATE:
+      "A pesquisa chegou ao gate de qualidade, mas as evidências estão corporativas demais para MEI/autônomo dono-operador.",
+    SOLUTION_CONTAMINATED:
+      "A pesquisa chegou ao gate de qualidade, mas foi contaminada por linguagem de solução/oferta antes da hora.",
+    GENERIC:
+      "A pesquisa chegou ao gate de qualidade, mas ficou genérica demais para sustentar uma oferta vendável.",
   };
-  return status ? (labels[status] ?? status) : "Aguardando";
+  return status ? messages[status] : undefined;
+}
+
+function pipelineAlertClass(status?: string | null) {
+  if (isQualityBlockedStatus(status)) {
+    return "alert alert-warning mb-0";
+  }
+  if (
+    status === "FAILED" ||
+    status === "STALLED" ||
+    status === "ENRICHED_NICHE_FAILED"
+  ) {
+    return "alert alert-danger mb-0";
+  }
+  return "alert alert-info mb-0";
 }
 
 function getCompletedStageIndex(cycle: OprmRoutineResearchCycleSummary) {
@@ -195,6 +261,70 @@ function inferStageState(
     ? inferFailureStageIndex(cycle.errorMessage)
     : undefined;
 
+  if (isQualityBlockedStatus(cycle.status)) {
+    if (stageIndex <= 6) {
+      return { label: "Concluído", className: "border-success text-success" };
+    }
+    if (stageIndex === 7) {
+      return {
+        label: statusLabel(cycle.status),
+        className: "border-warning text-warning",
+      };
+    }
+    return { label: "Bloqueado", className: "border-secondary text-secondary" };
+  }
+
+  if (cycle.status === "ROUTINE_SYNTHESIZED") {
+    if (stageIndex <= 5) {
+      return { label: "Concluído", className: "border-success text-success" };
+    }
+    if (stageIndex === 6) {
+      return { label: "Em execução", className: "border-primary text-primary" };
+    }
+    return { label: "Na fila", className: "border-secondary text-secondary" };
+  }
+
+  if (cycle.status === "MEI_AUDIENCE_SEGMENTED") {
+    if (stageIndex <= 6) {
+      return { label: "Concluído", className: "border-success text-success" };
+    }
+    if (stageIndex === 7) {
+      return { label: "Em execução", className: "border-primary text-primary" };
+    }
+    return { label: "Na fila", className: "border-secondary text-secondary" };
+  }
+
+  if (
+    cycle.status === "MEI_AUDIENCE_READY" ||
+    cycle.status === "LIGHTLY_RESEARCHED"
+  ) {
+    if (stageIndex <= 7) {
+      return { label: "Concluído", className: "border-success text-success" };
+    }
+    return { label: "Em execução", className: "border-primary text-primary" };
+  }
+
+  if (cycle.status === "ENRICHED_NICHE_CREATED") {
+    return { label: "Concluído", className: "border-success text-success" };
+  }
+
+  if (cycle.status === "STALLED") {
+    if (stageIndex <= completedStageIndex) {
+      return { label: "Concluído", className: "border-success text-success" };
+    }
+    if (stageIndex === completedStageIndex + 1) {
+      return { label: "Parado", className: "border-danger text-danger" };
+    }
+    return { label: "Bloqueado", className: "border-secondary text-secondary" };
+  }
+
+  if (cycle.status === "CANCELLED_BY_MANUAL_RESTART") {
+    if (stageIndex <= completedStageIndex) {
+      return { label: "Concluído", className: "border-success text-success" };
+    }
+    return { label: "Cancelado", className: "border-secondary text-secondary" };
+  }
+
   if (failed && stageIndex === failureStageIndex) {
     return { label: "Falhou", className: "border-danger text-danger" };
   }
@@ -207,7 +337,10 @@ function inferStageState(
   if (failed) {
     return { label: "Bloqueado", className: "border-secondary text-secondary" };
   }
-  if (stageIndex === completedStageIndex + 1) {
+  if (
+    !isCycleStoppedStatus(cycle.status) &&
+    stageIndex === completedStageIndex + 1
+  ) {
     return { label: "Em execução", className: "border-primary text-primary" };
   }
   return { label: "Na fila", className: "border-secondary text-secondary" };
@@ -265,9 +398,17 @@ export default function OprmCnaeDetailPlaceholderPage() {
                 disabled={startPipelineMutation.isPending}
                 onClick={() => startPipelineMutation.mutate()}
               >
-                {startPipelineMutation.isPending
-                  ? "Disparando..."
-                  : "Disparar pipeline NichoCNAE"}
+                {startPipelineMutation.isPending ? (
+                  <>
+                    <span
+                      className="spinner-border spinner-border-sm me-2"
+                      aria-hidden="true"
+                    />
+                    Disparando...
+                  </>
+                ) : (
+                  "Disparar pipeline NichoCNAE"
+                )}
               </button>
               <Link className="btn btn-outline-secondary" to="/oprm">
                 Voltar para CNAEs
@@ -375,12 +516,19 @@ export default function OprmCnaeDetailPlaceholderPage() {
           </div>
 
           {latestCycle ? (
-            <div className="alert alert-info mb-0">
+            <div className={pipelineAlertClass(latestCycle.status)}>
               <div>
                 Status atual: <strong>{statusLabel(latestCycle.status)}</strong>{" "}
                 · iniciado em {formatDateTime(latestCycle.startedAt)} · sinais
                 extraídos: {formatNumber(latestCycle.totalExtractedSignals)}
               </div>
+              {qualityBlockedMessage(latestCycle.status) ? (
+                <div className="mt-2">
+                  {qualityBlockedMessage(latestCycle.status)} O pipeline não
+                  está em execução agora; pesquise novamente após corrigir a
+                  causa do bloqueio.
+                </div>
+              ) : null}
               {latestCycle.errorMessage ? (
                 <div className="mt-2 text-danger">
                   Falha registrada: {latestCycle.errorMessage}


### PR DESCRIPTION
### Motivation
- Corrigir exibição incorreta que mostrava ciclos reprovados pelo gate de qualidade como "Em execução" ao inferir o estado só por contadores e `finishedAt` nulo.
- Tornar explícita a razão de bloqueio quando o ciclo estiver em estados como `OUTDATED_SOURCES`, `NEEDS_MORE_RESEARCH`, `NEEDS_MORE_MEI_RESEARCH`, `TOO_CORPORATE`, `SOLUTION_CONTAMINATED` ou `GENERIC` para guiar o usuário a ações corretivas.
- Melhorar a usabilidade do botão de disparo do pipeline ao exibir um spinner durante a operação.

### Description
- Em `frontend/src/pages/oprm/OprmCnaeDetailPlaceholderPage.tsx` adicionadas as tabelas de rótulos `statusLabels`, conjunto `qualityBlockedStatuses` e funções utilitárias `isQualityBlockedStatus`, `isCycleStoppedStatus`, `qualityBlockedMessage` e `pipelineAlertClass` para centralizar tratamento de status do ciclo.
- Alterada a função `inferStageState` para: tratar ciclos bloqueados por qualidade como conclusão das etapas anteriores, exibir o cartão de qualidade com o rótulo de bloqueio e marcar materialização como `Bloqueado`, e evitar inferir "Em execução" quando o ciclo estiver parado por falha/stop/quality.
- Ajustado o alert principal para usar `pipelineAlertClass` e exibir a mensagem de negócio retornada por `qualityBlockedMessage` quando aplicável; também incluído spinner no botão de disparo do pipeline.
- Adicionado teste `frontend/src/pages/oprm/OprmCnaeDetailPlaceholderPage.test.tsx` que mocka `fetch` para um ciclo com `OUTDATED_SOURCES` e valida mensagens, status dos cards e ausência de "Em execução"; e atualizada a documentação em `docs/registros/oprm1.md` descrevendo a mudança visual de bloqueio.

### Testing
- Executado o teste de unidade novo com `vitest` (`OprmCnaeDetailPlaceholderPage.test.tsx`) que valida o fluxo de UI para `OUTDATED_SOURCES` e o teste passou com sucesso.
- Nenhum teste automatizado adicional foi alterado ou falhou como resultado desta mudança.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2c64ab5d3083219d1d55a88a38629c)