### PR TITLE
Estrutura `qualityNotes` como objeto e destacar scores reprovados na UI

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/routinequalitygate/service/BackendRoutineQualityGateService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/routinequalitygate/service/BackendRoutineQualityGateService.java
@@ -17,8 +17,10 @@ import com.marketinghub.repository.jpa.oprm.nichocnae.OprmSourceSnapshotReposito
 import com.marketinghub.repository.jpa.oprm.nichocnae.meiaudienceprofile.OprmMeiAudienceProfileRepository;
 import jakarta.persistence.EntityNotFoundException;
 import java.time.Instant;
+import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.data.domain.PageRequest;
@@ -149,9 +151,46 @@ public class BackendRoutineQualityGateService {
         card == null ? null : card.getDifficultyEvidenceScore(),
         card == null ? null : card.getSourceDiversityScore(),
         card == null ? null : card.getSolutionLanguageRiskScore(),
-        card == null ? null : card.getQualityNotes(),
+        card == null ? null : parseQualityNotes(card.getQualityNotes()),
         card == null ? null : card.getQualityCheckedBy(),
         card == null ? null : card.getQualityCheckedAt());
+  }
+
+  /** Converte as notas legadas em chave/valor para um objeto JSON estável na consulta de detalhe. */
+  private Map<String, Object> parseQualityNotes(String qualityNotes) {
+    String notes = trimOptional(qualityNotes);
+    if (notes == null) {
+      return null;
+    }
+    Map<String, Object> parsed = new LinkedHashMap<>();
+    for (String part : notes.split(";")) {
+      String item = part.trim();
+      if (!StringUtils.hasText(item)) {
+        continue;
+      }
+      int separatorIndex = item.indexOf('=');
+      if (separatorIndex <= 0) {
+        parsed.put("texto", item);
+        continue;
+      }
+      String key = item.substring(0, separatorIndex).trim();
+      String value = item.substring(separatorIndex + 1).trim();
+      if (StringUtils.hasText(key)) {
+        parsed.put(key, parseQualityNoteValue(value));
+      }
+    }
+    return parsed.isEmpty() ? Map.of("texto", notes) : parsed;
+  }
+
+  /** Converte valores textuais das notas para booleano ou número quando possível. */
+  private Object parseQualityNoteValue(String value) {
+    if ("true".equalsIgnoreCase(value) || "false".equalsIgnoreCase(value)) {
+      return Boolean.valueOf(value);
+    }
+    if (value.matches("-?\\d+") && value.replace("-", "").length() <= 9) {
+      return Integer.valueOf(value);
+    }
+    return value;
   }
 
   /** Converte um cartão persistido na unidade de trabalho usada pelo coletor da etapa sete. */

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/routinequalitygate/service/detailStageExecution/RoutineQualityGateDetailResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/routinequalitygate/service/detailStageExecution/RoutineQualityGateDetailResponse.java
@@ -1,6 +1,7 @@
 package com.marketinghub.oprm.nichocnae.routinequalitygate.service.detailStageExecution;
 
 import java.time.Instant;
+import java.util.Map;
 
 /** Detalhe público da avaliação de qualidade de um cartão de rotina OPRM NichoCNAE. */
 public record RoutineQualityGateDetailResponse(
@@ -16,6 +17,6 @@ public record RoutineQualityGateDetailResponse(
     Integer difficultyEvidenceScore,
     Integer sourceDiversityScore,
     Integer solutionLanguageRiskScore,
-    String qualityNotes,
+    Map<String, Object> qualityNotes,
     String checkedBy,
     Instant checkedAt) {}

--- a/backend/ads-service/src/test/java/com/marketinghub/oprm/nichocnae/routinequalitygate/service/BackendRoutineQualityGateServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/oprm/nichocnae/routinequalitygate/service/BackendRoutineQualityGateServiceTest.java
@@ -14,6 +14,7 @@ import com.marketinghub.oprm.nichocnae.OprmSourceSnapshot;
 import com.marketinghub.oprm.nichocnae.meiaudienceprofile.OprmMeiAudienceProfile;
 import com.marketinghub.oprm.nichocnae.routinequalitygate.service.completeStageExecution.CompleteRoutineQualityGateRequest;
 import com.marketinghub.oprm.nichocnae.routinequalitygate.service.completeStageExecution.CompleteRoutineQualityGateResponse;
+import com.marketinghub.oprm.nichocnae.routinequalitygate.service.detailStageExecution.RoutineQualityGateDetailResponse;
 import com.marketinghub.oprm.nichocnae.routinequalitygate.service.pending.RecordRoutineQualityGatePending;
 import com.marketinghub.repository.jpa.oprm.nichocnae.OprmExtractedSignalRepository;
 import com.marketinghub.repository.jpa.oprm.nichocnae.OprmNicheRoutineCardRepository;
@@ -116,6 +117,31 @@ class BackendRoutineQualityGateServiceTest {
     assertThat(card.getQualityCheckedAt()).isNotNull();
     verify(cardRepository).save(card);
     verify(cycleRepository).save(cycle);
+  }
+
+  /** Deve expor notas de qualidade como objeto JSON tipado para a tela de detalhe. */
+  @Test
+  void shouldDetailQualityNotesAsStructuredObject() {
+    OprmRoutineResearchCycle cycle = new OprmRoutineResearchCycle();
+    cycle.setId(1001L);
+    cycle.setStatus("SOLUTION_CONTAMINATED");
+    OprmNicheRoutineCard card = card();
+    card.setQualityStatus("SOLUTION_CONTAMINATED");
+    card.setReadyForHypothesis(false);
+    card.setSpecificityScore(72);
+    card.setConfidenceScore(32);
+    card.setDuplicationScore(10);
+    card.setQualityNotes("status=SOLUTION_CONTAMINATED; fontes=46; mixMinimoMeiAutonomo=false; riscoLinguagemSolucao=70");
+    when(cycleRepository.findById(1001L)).thenReturn(Optional.of(cycle));
+    when(cardRepository.findFirstByResearchCycleIdOrderByIdDesc(1001L)).thenReturn(Optional.of(card));
+
+    RoutineQualityGateDetailResponse response = service.detail(1001L);
+
+    assertThat(response.qualityNotes())
+        .containsEntry("status", "SOLUTION_CONTAMINATED")
+        .containsEntry("fontes", 46)
+        .containsEntry("mixMinimoMeiAutonomo", false)
+        .containsEntry("riscoLinguagemSolucao", 70);
   }
 
   /** Deve bloquear liberação para hipótese quando o status final ainda exige mais pesquisa MEI/autônomo. */

--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -540,3 +540,9 @@
 - Causa-raiz tratada: a etapa MEI foi criada no fluxo operacional e no detalhe do CNAE, mas não foi incorporada ao contrato administrativo `oprm-nicho-cnae-pipeline`, deixando a tela `/pipelines` com apenas uma etapa IA e com nove etapas em vez das dez executadas no fluxo real.
 - Correção aplicada: o cânone, enum oficial, teste de contrato e changelog incremental foram ajustados para incluir `mei-audience-segmenter` entre a síntese e o gate, marcada com `requires_openai_model = true`.
 - Ajuste visual complementar: a mensagem de telemetria do detalhe da etapa deixou de citar apenas a etapa seed quando a tela está exibindo a segmentação MEI.
+
+## 2026-06-13 — OPRM NichoCNAE: notas estruturadas do gate de qualidade
+
+- Alterado o detalhe do gate de qualidade para expor `qualityNotes` como objeto JSON chave/valor, mantendo a gravação legada em texto auditável no banco e estruturando o contrato apenas na resposta de detalhe.
+- Ajustada a tela de detalhe do pipeline para exibir os scores completos do gate e destacar em vermelho os indicadores que não atenderam aos limites de aprovação.
+- Causa-raiz tratada: a nota do gate era uma string única com pares `chave=valor`, dificultando leitura pela tela e impedindo sinalização visual objetiva dos critérios reprovados.

--- a/docs/swagger/oprm-nichocnae-swagger.yaml
+++ b/docs/swagger/oprm-nichocnae-swagger.yaml
@@ -2800,8 +2800,18 @@ components:
           type: integer
           nullable: true
         qualityNotes:
-          type: string
+          type: object
           nullable: true
+          additionalProperties:
+            oneOf:
+              - type: string
+              - type: integer
+              - type: boolean
+          example:
+            status: SOLUTION_CONTAMINATED
+            fontes: 46
+            mixMinimoMeiAutonomo: false
+            riscoLinguagemSolucao: 70
         checkedBy:
           type: string
           nullable: true

--- a/frontend/src/api/oprm/useOprmRoutineQualityGateDetail.ts
+++ b/frontend/src/api/oprm/useOprmRoutineQualityGateDetail.ts
@@ -1,6 +1,8 @@
 import { useQuery } from "@tanstack/react-query";
 import { buildApiUrl } from "../../utils/buildApiUrl";
 
+export type OprmQualityNotes = Record<string, string | number | boolean>;
+
 export interface OprmRoutineQualityGateDetail {
   researchCycleId: number;
   cycleStatus: string;
@@ -14,7 +16,7 @@ export interface OprmRoutineQualityGateDetail {
   difficultyEvidenceScore?: number | null;
   sourceDiversityScore?: number | null;
   solutionLanguageRiskScore?: number | null;
-  qualityNotes: string | null;
+  qualityNotes: OprmQualityNotes | null;
   checkedBy: string | null;
   checkedAt: string | null;
 }

--- a/frontend/src/pages/oprm/OprmPipelinePage.tsx
+++ b/frontend/src/pages/oprm/OprmPipelinePage.tsx
@@ -7,7 +7,10 @@ import {
   useReprocessOprmRoutineResearchCycle,
 } from "../../api/oprm/useOprmRoutineResearchOrchestratorRecent";
 import { useOprmRoutineSynthesizerDetail } from "../../api/oprm/useOprmRoutineSynthesizerDetail";
-import { useOprmRoutineQualityGateDetail } from "../../api/oprm/useOprmRoutineQualityGateDetail";
+import {
+  type OprmQualityNotes,
+  useOprmRoutineQualityGateDetail,
+} from "../../api/oprm/useOprmRoutineQualityGateDetail";
 import { useOprmSourceFetcherDetail } from "../../api/oprm/useOprmSourceFetcherDetail";
 import { useOprmSignalExtractorDetail } from "../../api/oprm/useOprmSignalExtractorDetail";
 import { useOprmSourceSearcherDetail } from "../../api/oprm/useOprmSourceSearcherDetail";
@@ -376,11 +379,146 @@ function getCycleStage(status: string) {
   );
 }
 
-function formatQualityNotes(value: string) {
-  return Object.entries(statusLabels).reduce(
-    (formatted, [status, label]) => formatted.split(status).join(label),
-    value,
-  );
+const qualityNoteLabels: Record<string, string> = {
+  status: "Status",
+  fontes: "Fontes",
+  fontesBrasileiras: "Fontes brasileiras",
+  fontesRecentes: "Fontes recentes",
+  sinais: "Sinais",
+  tarefasRotina: "Tarefas de rotina",
+  tarefasConcretasDistintas: "Tarefas concretas distintas",
+  rotinaGenericaRepetida: "Rotina genérica repetida",
+  rotinaApenasGestaoAgendaAtendimentoOrganizacao:
+    "Rotina apenas gestão/agenda/organização",
+  rotinaRevelaTarefasReaisExecutor: "Revela tarefas reais do executor",
+  aquisicaoOuCanal: "Aquisição ou canal",
+  resumoComportamentoClienteUtil: "Resumo de comportamento útil",
+  resumoCanaisUtil: "Resumo de canais útil",
+  faltaEvidenciaAquisicaoCanaisRecorrenciaOuComportamentoClientes:
+    "Falta evidência comercial",
+  dorPratica: "Dor prática",
+  dorEmocionalSonhoOuMedo: "Dor emocional/sonho/medo",
+  mixMinimoMeiAutonomo: "Mix mínimo MEI/autônomo",
+  evidenciaAuditavelBrasil: "Evidência auditável Brasil",
+  fontesRecentesSuficientes: "Fontes recentes suficientes",
+  riscoFonteAntiga: "Risco de fonte antiga",
+  riscoEmpresaEstruturada: "Risco empresa estruturada",
+  riscoLinguagemSolucao: "Risco linguagem de solução",
+  riscoTextualSolucao: "Risco textual de solução",
+  dominadoPorSolucao: "Dominado por solução",
+  fitMeiAutonomo: "Fit MEI/autônomo",
+  evidenciaComportamental: "Evidência comportamental",
+  fontesDistintas: "Fontes distintas",
+};
+
+function formatQualityNoteValue(value: string | number | boolean) {
+  if (typeof value === "boolean") {
+    return value ? "Sim" : "Não";
+  }
+  if (typeof value === "string") {
+    return formatStatusLabel(value);
+  }
+  return String(value);
+}
+
+function isQualityNoteAccepted(key: string, value: string | number | boolean) {
+  if (key === "status") {
+    return value === "MEI_AUDIENCE_READY";
+  }
+  if (typeof value === "boolean") {
+    const expectedTrue = new Set([
+      "rotinaRevelaTarefasReaisExecutor",
+      "resumoComportamentoClienteUtil",
+      "resumoCanaisUtil",
+      "mixMinimoMeiAutonomo",
+      "evidenciaAuditavelBrasil",
+      "fontesRecentesSuficientes",
+    ]);
+    const expectedFalse = new Set([
+      "rotinaGenericaRepetida",
+      "rotinaApenasGestaoAgendaAtendimentoOrganizacao",
+      "faltaEvidenciaAquisicaoCanaisRecorrenciaOuComportamentoClientes",
+      "dominadoPorSolucao",
+    ]);
+    if (expectedTrue.has(key)) {
+      return value;
+    }
+    if (expectedFalse.has(key)) {
+      return !value;
+    }
+  }
+  if (typeof value === "number") {
+    const minimums: Record<string, number> = {
+      fontes: 3,
+      fontesBrasileiras: 3,
+      fontesRecentes: 2,
+      sinais: 6,
+      tarefasRotina: 1,
+      tarefasConcretasDistintas: 2,
+      aquisicaoOuCanal: 1,
+      dorPratica: 1,
+      dorEmocionalSonhoOuMedo: 1,
+      fitMeiAutonomo: 50,
+      evidenciaComportamental: 55,
+      fontesDistintas: 2,
+    };
+    const maximums: Record<string, number> = {
+      riscoFonteAntiga: 45,
+      riscoEmpresaEstruturada: 45,
+      riscoLinguagemSolucao: 35,
+      riscoTextualSolucao: 35,
+    };
+    if (minimums[key] !== undefined) {
+      return value >= minimums[key];
+    }
+    if (maximums[key] !== undefined) {
+      return value <= maximums[key];
+    }
+  }
+  return true;
+}
+
+function getQualityScoreClass(
+  scoreName:
+    | "specificity"
+    | "confidence"
+    | "duplication"
+    | "routineEvidence"
+    | "difficultyEvidence"
+    | "sourceDiversity"
+    | "solutionRisk",
+  value?: number | null,
+) {
+  if (value === null || value === undefined) {
+    return "col-6 mb-0 fw-semibold";
+  }
+  const accepted =
+    scoreName === "duplication"
+      ? value < 70
+      : scoreName === "solutionRisk"
+        ? value <= 35
+        : scoreName === "confidence"
+          ? value >= 50
+          : value >= 60;
+  return `col-6 mb-0 fw-semibold ${accepted ? "" : "text-danger"}`;
+}
+
+function renderQualityNotes(notes: OprmQualityNotes) {
+  return Object.entries(notes).map(([key, value]) => {
+    const accepted = isQualityNoteAccepted(key, value);
+    return (
+      <span
+        className={`badge border me-1 mb-1 ${
+          accepted
+            ? "text-bg-light text-secondary"
+            : "text-bg-danger border-danger"
+        }`}
+        key={key}
+      >
+        {qualityNoteLabels[key] ?? key}: {formatQualityNoteValue(value)}
+      </span>
+    );
+  });
 }
 
 function canCreateNewResearchCycle(status: string) {
@@ -1878,7 +2016,13 @@ export default function OprmPipelinePage() {
                             <dt className="col-6 text-secondary fw-normal">
                               Pronto para hipótese
                             </dt>
-                            <dd className="col-6 mb-0 fw-semibold">
+                            <dd
+                              className={`col-6 mb-0 fw-semibold ${
+                                routineQualityGateDetail.readyForHypothesis
+                                  ? ""
+                                  : "text-danger"
+                              }`}
+                            >
                               {routineQualityGateDetail.readyForHypothesis
                                 ? "Sim"
                                 : "Não"}
@@ -1886,7 +2030,12 @@ export default function OprmPipelinePage() {
                             <dt className="col-6 text-secondary fw-normal">
                               Especificidade
                             </dt>
-                            <dd className="col-6 mb-0 fw-semibold">
+                            <dd
+                              className={getQualityScoreClass(
+                                "specificity",
+                                routineQualityGateDetail.specificityScore,
+                              )}
+                            >
                               {formatStageCount(
                                 routineQualityGateDetail.specificityScore ??
                                   undefined,
@@ -1896,7 +2045,12 @@ export default function OprmPipelinePage() {
                             <dt className="col-6 text-secondary fw-normal">
                               Confiança
                             </dt>
-                            <dd className="col-6 mb-0 fw-semibold">
+                            <dd
+                              className={getQualityScoreClass(
+                                "confidence",
+                                routineQualityGateDetail.confidenceScore,
+                              )}
+                            >
                               {formatStageCount(
                                 routineQualityGateDetail.confidenceScore ??
                                   undefined,
@@ -1906,7 +2060,12 @@ export default function OprmPipelinePage() {
                             <dt className="col-6 text-secondary fw-normal">
                               Duplicação
                             </dt>
-                            <dd className="col-6 mb-0 fw-semibold">
+                            <dd
+                              className={getQualityScoreClass(
+                                "duplication",
+                                routineQualityGateDetail.duplicationScore,
+                              )}
+                            >
                               {formatStageCount(
                                 routineQualityGateDetail.duplicationScore ??
                                   undefined,
@@ -1916,7 +2075,12 @@ export default function OprmPipelinePage() {
                             <dt className="col-6 text-secondary fw-normal">
                               Evidência rotina
                             </dt>
-                            <dd className="col-6 mb-0 fw-semibold">
+                            <dd
+                              className={getQualityScoreClass(
+                                "routineEvidence",
+                                routineQualityGateDetail.routineEvidenceScore,
+                              )}
+                            >
                               {formatStageCount(
                                 routineQualityGateDetail.routineEvidenceScore ??
                                   undefined,
@@ -1924,9 +2088,44 @@ export default function OprmPipelinePage() {
                               %
                             </dd>
                             <dt className="col-6 text-secondary fw-normal">
+                              Evidência dificuldade
+                            </dt>
+                            <dd
+                              className={getQualityScoreClass(
+                                "difficultyEvidence",
+                                routineQualityGateDetail.difficultyEvidenceScore,
+                              )}
+                            >
+                              {formatStageCount(
+                                routineQualityGateDetail.difficultyEvidenceScore ??
+                                  undefined,
+                              )}
+                              %
+                            </dd>
+                            <dt className="col-6 text-secondary fw-normal">
+                              Diversidade fontes
+                            </dt>
+                            <dd
+                              className={getQualityScoreClass(
+                                "sourceDiversity",
+                                routineQualityGateDetail.sourceDiversityScore,
+                              )}
+                            >
+                              {formatStageCount(
+                                routineQualityGateDetail.sourceDiversityScore ??
+                                  undefined,
+                              )}
+                              %
+                            </dd>
+                            <dt className="col-6 text-secondary fw-normal">
                               Risco solução
                             </dt>
-                            <dd className="col-6 mb-0 fw-semibold">
+                            <dd
+                              className={getQualityScoreClass(
+                                "solutionRisk",
+                                routineQualityGateDetail.solutionLanguageRiskScore,
+                              )}
+                            >
                               {formatStageCount(
                                 routineQualityGateDetail.solutionLanguageRiskScore ??
                                   undefined,
@@ -1951,8 +2150,8 @@ export default function OprmPipelinePage() {
                               <span className="fw-semibold d-block">
                                 Justificativa do gate
                               </span>
-                              <span>
-                                {formatQualityNotes(
+                              <span className="d-block">
+                                {renderQualityNotes(
                                   routineQualityGateDetail.qualityNotes,
                                 )}
                               </span>


### PR DESCRIPTION
### Motivation
- O campo `qualityNotes` era armazenado como uma única string `chave=valor` que dificulta leitura e sinalização visual na tela de detalhe do Gate de Qualidade. 
- A tela precisa mostrar todos os scores relevantes e destacar em vermelho os critérios que não atenderam aos limites comerciais para facilitar decisão de reprocessamento. 
- É necessário preservar a gravação legada em texto para auditoria e ao mesmo tempo entregar um contrato estruturado para a UI.

### Description
- Backend: o `RoutineQualityGateDetailResponse` passou a expor `qualityNotes` como `Map<String,Object>` e foi adicionada a função `parseQualityNotes` para converter o texto legado em tipos `boolean`/`integer`/`string` quando aplicável, mantendo a string legada no banco. (`BackendRoutineQualityGateService.java`, `RoutineQualityGateDetailResponse.java`).
- Swagger: o `docs/swagger/oprm-nichocnae-swagger.yaml` foi atualizado para documentar `qualityNotes` como `object` com `additionalProperties` tipadas e exemplo de payload. 
- Frontend: a tipagem foi alterada para `OprmQualityNotes`, a tela `/pipelines` foi atualizada para renderizar `qualityNotes` como badges legíveis e para aplicar classes que pintam em vermelho os scores/indicadores reprovados, além de exibir `difficultyEvidence` e `sourceDiversity` no bloco de scores. (`useOprmRoutineQualityGateDetail.ts`, `OprmPipelinePage.tsx`).
- Tests & docs: adicionado teste de regressão que valida a estruturação de `qualityNotes` em `BackendRoutineQualityGateServiceTest`, e registrado o ajuste em `docs/registros/oprm1.md`.

### Testing
- Executed backend unit tests with `../mvnw -Dtest=BackendRoutineQualityGateServiceTest test` and they passed (6 tests, 0 failures). 
- Executed frontend typecheck with `npm run typecheck` and it completed successfully. 
- Verified formatting with `npx prettier --check src/pages/oprm/OprmPipelinePage.tsx src/api/oprm/useOprmRoutineQualityGateDetail.ts` which passed, and built the frontend with `npm run build` which completed successfully. 
- Note: `../mvnw spotless:check -DskipTests` did not run successfully in this environment due to the Spotless plugin resolution in the current Maven setup and therefore was not enforced here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2cb7819aec83219ba286a375b3c6a8)