### PR TITLE
Disable OPRM CNAE automatic score/enrichment cycles by default

### DIFF
--- a/docs/canonical/oprm-canon.v1.md
+++ b/docs/canonical/oprm-canon.v1.md
@@ -186,10 +186,10 @@ Evitar fechamento prematuro de `import run` que destrói a totalização de mark
 ## Regra obrigatória — responsabilidade do OPRM no fluxo CNAE → oportunidade
 
 - No fluxo CNAE → score → enriquecimento → candidatos de nicho, o **módulo OPRM** é o único responsável por cálculo de score de oportunidade, seleção de CNAEs prioritários para enriquecimento, pesquisa externa, acionamento de MDS/Worker AI e geração de candidatos de nicho.
-- O usuário não deve precisar solicitar manualmente a geração de score de oportunidade; o OPRM deve processar CNAEs sem score ou com score vencido por execução agendada.
-- O enriquecimento de CNAEs com melhor score deve ocorrer em execução agendada separada do cálculo de score, para permitir controle operacional, retentativa e auditoria independentes.
+- O usuário não deve precisar solicitar manualmente a geração de score de oportunidade quando houver necessidade real de atualização; porém, como a base CNAE muda pouco, os ciclos agendados de score e enriquecimento devem ficar desligados por padrão e só devem ser religados por configuração operacional explícita.
+- O enriquecimento de CNAEs com melhor score deve ocorrer em execução agendada separada do cálculo de score quando habilitado, para permitir controle operacional, retentativa e auditoria independentes.
 - O backend deve atuar somente como camada de API e persistência para esse fluxo: leitura, gravação, paginação, filtros e validação técnica de contrato. É proibido colocar no backend cálculo de score, enriquecimento, chamada a integrações externas ou regra de negócio de priorização CNAE.
-- Cada execução agendada desse fluxo deve registrar identificadores de ciclo, no mínimo `cycleId`, `cycleType` e `cycleNumber`, e os logs devem incluir esses identificadores junto com o `cnaeCode` quando aplicável.
+- Cada execução agendada desse fluxo, quando habilitada, deve registrar identificadores de ciclo, no mínimo `cycleId`, `cycleType` e `cycleNumber`, e os logs devem incluir esses identificadores junto com o `cnaeCode` quando aplicável.
 
 ## Critério de efetividade — ciclos CNAE de oportunidade
 

--- a/docs/novos-modulos/OPRM/oprm-cnae-para-nichos-arquitetura.md
+++ b/docs/novos-modulos/OPRM/oprm-cnae-para-nichos-arquitetura.md
@@ -4,15 +4,15 @@
 
 Este documento descreve como a lista de CNAEs deve ser usada para descobrir, priorizar e transformar oportunidades de mercado em candidatos de nicho, preservando o eixo **Dor → Resultado → Mecanismo → Prova → Oferta**.
 
-A proposta evita criar nichos automaticamente apenas pelo nome do CNAE. O CNAE entra como evidência de tamanho e concentração de mercado; o score, o enriquecimento, as pesquisas externas e a geração de candidatos são responsabilidades do **módulo OPRM**, executadas por ciclos agendados. O backend atua somente como camada de API e persistência: lê dados, valida contrato técnico e grava dados, sem cálculo, enriquecimento ou regra de negócio.
+A proposta evita criar nichos automaticamente apenas pelo nome do CNAE. O CNAE entra como evidência de tamanho e concentração de mercado; o score, o enriquecimento, as pesquisas externas e a geração de candidatos são responsabilidades do **módulo OPRM**, executadas por ciclos agendados habilitáveis sob demanda operacional. O backend atua somente como camada de API e persistência: lê dados, valida contrato técnico e grava dados, sem cálculo, enriquecimento ou regra de negócio.
 
 ## Princípios operacionais
 
 1. **CNAE não é nicho final**: CNAE é fonte estruturada para encontrar mercados com volume e densidade.
 2. **Backend é somente API e persistência**: o backend lê e grava dados, aplica validações técnicas de contrato e integridade, mas não calcula score, não enriquece dados e não decide prioridade de negócio.
 3. **OPRM é dono da regra de negócio CNAE → oportunidade**: todo cálculo de score, seleção de CNAEs para enriquecimento, pesquisa externa, geração de sinais e criação de candidatos fica no módulo OPRM.
-4. **Processamento é automático por scheduler**: o usuário não solicita geração de score; o OPRM periodicamente busca CNAEs sem score e grava o resultado. Outro scheduler seleciona CNAEs com melhor score para enriquecimento e pesquisa externa.
-5. **Ciclos precisam ser rastreáveis**: cada execução agendada deve ter `cycleId`, `cycleType`, `cycleNumber` e logs com início, critérios, quantidade lida, quantidade processada, falhas e resumo final.
+4. **Processamento por scheduler sob demanda operacional**: a base CNAE muda pouco; por isso os schedulers de score e enriquecimento ficam desligados por padrão e só rodam quando a operação habilitar explicitamente a atualização.
+5. **Ciclos precisam ser rastreáveis**: cada execução agendada habilitada deve ter `cycleId`, `cycleType`, `cycleNumber` e logs com início, critérios, quantidade lida, quantidade processada, falhas e resumo final.
 6. **Frontend orienta decisão humana**: a UI mostra ranking, score, candidatos, ciclos e próximos passos, mas a criação oficial do nicho depende de aprovação humana.
 7. **Integrações externas são insumos, não fonte única de verdade**: dados públicos, fontes web, MDS e Worker AI complementam o banco interno e os documentos canônicos.
 
@@ -22,7 +22,7 @@ A proposta evita criar nichos automaticamente apenas pelo nome do CNAE. O CNAE e
 | --------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------ |
 | Frontend Marketing Hub            | Exibir CNAEs, scores, ciclos, enriquecimentos e candidatos; permitir aprovação/rejeição humana.                                               | Calcular score, enriquecer dados, chamar integrações externas diretamente ou gravar no banco.                                        |
 | Backend Marketing Hub             | Expor endpoints do pacote OPRM; consultar e persistir dados; validar contrato técnico; aplicar paginação e filtros de leitura.                | Calcular score, escolher CNAEs prioritários, chamar MDS/AI/fontes externas para enriquecimento ou executar regra de negócio do OPRM. |
-| Módulo OPRM                       | Executar schedulers; calcular score; selecionar melhores CNAEs; pesquisar fontes externas; acionar MDS/AI; gerar candidatos e justificativas. | Escrever direto no banco ou consumir controllers de outro módulo fora do escopo OPRM.                                                |
+| Módulo OPRM                       | Executar schedulers quando habilitados; calcular score; selecionar melhores CNAEs; pesquisar fontes externas; acionar MDS/AI; gerar candidatos e justificativas. | Escrever direto no banco ou consumir controllers de outro módulo fora do escopo OPRM.                                                |
 | MySQL 5.7                         | Guardar catálogo CNAE, market size, scores, ciclos, artefatos e candidatos.                                                                   | Executar regra de negócio fora de consultas/filtros necessários.                                                                     |
 | MDS / Worker AI / fontes externas | Fornecer evidências, mecanismos, conteúdo bruto e apoio de estruturação.                                                                      | Ser fonte única de verdade ou publicar nicho automaticamente.                                                                        |
 
@@ -44,13 +44,13 @@ Para facilitar logs, comunicação e auditoria, cada execução do OPRM deve reg
 Tipos iniciais sugeridos:
 
 1. **Ciclo de score — `CNAE_SCORE`**
-   - Scheduler do OPRM roda de tempos em tempos.
+   - Scheduler do OPRM roda somente quando habilitado por configuração operacional explícita.
    - OPRM chama o backend para buscar CNAEs sem score ou com score vencido.
    - OPRM calcula `opportunityScore` e componentes do score.
    - OPRM grava score e justificativa por endpoint do backend.
 
 2. **Ciclo de enriquecimento — `CNAE_ENRICHMENT`**
-   - Scheduler separado do OPRM roda de tempos em tempos.
+   - Scheduler separado do OPRM roda somente quando habilitado por configuração operacional explícita.
    - OPRM chama o backend para buscar CNAEs com melhor score e ainda não enriquecidos.
    - OPRM pesquisa fontes externas, aciona MDS/AI quando necessário e gera sinais de rotina, dor, resultado, mecanismo, prova e oferta.
    - OPRM grava artefatos, candidatos e vínculos por endpoint do backend.

--- a/docs/novos-modulos/OPRM/oprm-telas-acompanhamento-operacional.md
+++ b/docs/novos-modulos/OPRM/oprm-telas-acompanhamento-operacional.md
@@ -209,7 +209,7 @@ A tela é considerada pronta quando o usuário consegue saber se a base de merca
 
 ### Objetivo
 
-Acompanhar os ciclos automáticos de Score OPRM e enriquecimento sem confundir o usuário com execução manual.
+Acompanhar os últimos ciclos de Score OPRM e enriquecimento, que ficam desligados por padrão e só rodam quando habilitados operacionalmente.
 
 ### Perguntas que responde
 

--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -546,3 +546,9 @@
 - Alterado o detalhe do gate de qualidade para expor `qualityNotes` como objeto JSON chave/valor, mantendo a gravação legada em texto auditável no banco e estruturando o contrato apenas na resposta de detalhe.
 - Ajustada a tela de detalhe do pipeline para exibir os scores completos do gate e destacar em vermelho os indicadores que não atenderam aos limites de aprovação.
 - Causa-raiz tratada: a nota do gate era uma string única com pares `chave=valor`, dificultando leitura pela tela e impedindo sinalização visual objetiva dos critérios reprovados.
+
+## 2026-06-13 — OPRM CNAE: desligamento padrão dos ciclos automáticos
+
+- Desligados por padrão os ciclos agendados de score CNAE (`CNAE_SCORE`) e enriquecimento CNAE (`CNAE_ENRICHMENT`) no `oprm-coletor-mei`, mantendo possibilidade de religar por configuração operacional explícita quando houver atualização real da base.
+- Causa-raiz tratada: a base CNAE/mercado não muda com frequência suficiente para justificar execuções recorrentes, que geravam ciclos vazios e ruído operacional na tela de acompanhamento.
+- Prevenção de recorrência: o cânone OPRM foi atualizado para definir scheduler sob demanda operacional e o teste de contexto garante que os schedulers ficam ausentes por padrão.

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/oprmcoletormei/opportunity/service/OprmCnaeEnrichmentScheduler.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/oprmcoletormei/opportunity/service/OprmCnaeEnrichmentScheduler.java
@@ -8,16 +8,18 @@ import java.time.format.DateTimeFormatter;
 import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.event.EventListener;
-import org.springframework.beans.factory.annotation.Value;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 /**
- * Scheduler responsável por enriquecer automaticamente CNAEs com melhor score e publicar candidatos de nicho.
+ * Scheduler responsável por enriquecer CNAEs com melhor score e publicar candidatos de nicho quando habilitado operacionalmente.
  */
 @Component
+@ConditionalOnProperty(name = "oprm.cnae-enrichment.scheduler.enabled", havingValue = "true")
 public class OprmCnaeEnrichmentScheduler {
     private static final Logger log = LoggerFactory.getLogger(OprmCnaeEnrichmentScheduler.class);
     private static final String CYCLE_TYPE = "CNAE_ENRICHMENT";
@@ -31,7 +33,7 @@ public class OprmCnaeEnrichmentScheduler {
     public OprmCnaeEnrichmentScheduler(
             OprmCnaeOpportunityBackendClient backendClient,
             OprmCnaeRoutineSignalBuilder routineSignalBuilder,
-            @Value("${oprm.cnae-enrichment.startup-catch-up.enabled:true}") boolean startupCatchUpEnabled) {
+            @Value("${oprm.cnae-enrichment.startup-catch-up.enabled:false}") boolean startupCatchUpEnabled) {
         this.backendClient = backendClient;
         this.routineSignalBuilder = routineSignalBuilder;
         this.startupCatchUpEnabled = startupCatchUpEnabled;
@@ -48,7 +50,7 @@ public class OprmCnaeEnrichmentScheduler {
         runEnrichmentCycle();
     }
 
-    /** Executa periodicamente o ciclo de enriquecimento para CNAEs priorizados por score já calculado. */
+    /** Executa o ciclo agendado de enriquecimento para CNAEs priorizados por score quando o scheduler estiver habilitado. */
     @Scheduled(cron = "0 15 * * * *", zone = "America/Sao_Paulo")
     public void runEnrichmentCycle() {
         Long cycleNumber = null;

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/oprmcoletormei/opportunity/service/OprmCnaeOpportunityScheduler.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/oprmcoletormei/opportunity/service/OprmCnaeOpportunityScheduler.java
@@ -11,13 +11,15 @@ import java.time.format.DateTimeFormatter;
 import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 /**
- * Scheduler responsável por calcular automaticamente scores de oportunidade para CNAEs ainda não pontuados.
+ * Scheduler responsável por calcular scores de oportunidade para CNAEs ainda não pontuados quando habilitado operacionalmente.
  */
 @Component
+@ConditionalOnProperty(name = "oprm.cnae-opportunity.scheduler.enabled", havingValue = "true")
 public class OprmCnaeOpportunityScheduler {
     private static final Logger log = LoggerFactory.getLogger(OprmCnaeOpportunityScheduler.class);
     private static final String CYCLE_TYPE = "CNAE_SCORE";
@@ -31,7 +33,7 @@ public class OprmCnaeOpportunityScheduler {
         this.backendClient = backendClient;
     }
 
-    /** Executa periodicamente o ciclo de score automático para CNAEs sem score. */
+    /** Executa o ciclo agendado de score para CNAEs sem score quando o scheduler estiver habilitado. */
     @Scheduled(cron = "0 */30 * * * *", zone = "America/Sao_Paulo")
     public void runScoreCycle() {
         Long cycleNumber = backendClient.nextCycleNumber(CYCLE_TYPE);

--- a/oprm-coletor-mei/src/main/resources/application.yml
+++ b/oprm-coletor-mei/src/main/resources/application.yml
@@ -31,6 +31,15 @@ oprm:
         model: ${OPRM_MEI_AUDIENCE_SEGMENTER_OPENAI_MODEL:gpt-4.1-mini}
         expected-api-key-variable: OPRM_MEI_AUDIENCE_SEGMENTER_OPENAI_API_KEY
         fallback-api-key-variable: OPENAI_API_KEY
+
+  cnae-opportunity:
+    scheduler:
+      enabled: ${OPRM_CNAE_OPPORTUNITY_SCHEDULER_ENABLED:false}
+  cnae-enrichment:
+    scheduler:
+      enabled: ${OPRM_CNAE_ENRICHMENT_SCHEDULER_ENABLED:false}
+    startup-catch-up:
+      enabled: ${OPRM_CNAE_ENRICHMENT_STARTUP_CATCH_UP_ENABLED:false}
   market-import:
     collector:
       backend-base-url: ${OPRM_COLLECTOR_BACKEND_BASE_URL:http://191.252.181.168}

--- a/oprm-coletor-mei/src/test/java/com/marketinghub/oprmcoletormei/OprmColetorMeiApplicationTests.java
+++ b/oprm-coletor-mei/src/test/java/com/marketinghub/oprmcoletormei/OprmColetorMeiApplicationTests.java
@@ -4,6 +4,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 import com.marketinghub.nichocnae.nicheresearchseedbuilder.NicheResearchSeedBuilderScheduler;
 import com.marketinghub.nichocnae.nicheresearchseedbuilder.web.NicheResearchSeedBuilderController;
+import com.marketinghub.oprmcoletormei.opportunity.service.OprmCnaeEnrichmentScheduler;
+import com.marketinghub.oprmcoletormei.opportunity.service.OprmCnaeOpportunityScheduler;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -13,7 +15,7 @@ import org.springframework.core.env.Environment;
 /**
  * Valida que o contexto Spring do coletor OPRM sobe sem disparar integrações externas durante testes.
  */
-@SpringBootTest(properties = "oprm.cnae-enrichment.startup-catch-up.enabled=false")
+@SpringBootTest
 class OprmColetorMeiApplicationTests {
     @Autowired private ApplicationContext applicationContext;
     @Autowired private Environment environment;
@@ -36,5 +38,15 @@ class OprmColetorMeiApplicationTests {
     void backendBaseUrlDefaultsToOperationalHttpPort() {
         assertThat(environment.getProperty("oprm.market-import.collector.backend-base-url"))
                 .isEqualTo("http://191.252.181.168");
+    }
+
+    /** Confirma que os ciclos CNAE automáticos ficam desligados por padrão para evitar execuções sem necessidade operacional. */
+    @Test
+    void cnaeAutomaticCyclesAreDisabledByDefault() {
+        assertThat(applicationContext.getBeanNamesForType(OprmCnaeOpportunityScheduler.class)).isEmpty();
+        assertThat(applicationContext.getBeanNamesForType(OprmCnaeEnrichmentScheduler.class)).isEmpty();
+        assertThat(environment.getProperty("oprm.cnae-opportunity.scheduler.enabled")).isEqualTo("false");
+        assertThat(environment.getProperty("oprm.cnae-enrichment.scheduler.enabled")).isEqualTo("false");
+        assertThat(environment.getProperty("oprm.cnae-enrichment.startup-catch-up.enabled")).isEqualTo("false");
     }
 }


### PR DESCRIPTION
### Motivation
- Reduce noise and wasted runs by turning off automatic CNAE score/enrichment cycles when the CNAE market data changes infrequently.  
- Give operators explicit control to enable cycles only when an operational update is required.  
- Keep the module behavior and documentation aligned with the canonical OPRM responsibility model (OPRM executes cycles, backend remains API/persistence).  

### Description
- Guarded the automatic schedulers by adding `@ConditionalOnProperty` to `OprmCnaeOpportunityScheduler` and `OprmCnaeEnrichmentScheduler` so they only start when `oprm.cnae-opportunity.scheduler.enabled` / `oprm.cnae-enrichment.scheduler.enabled` are `true`.  
- Added configuration defaults to `oprm-coletor-mei/src/main/resources/application.yml` with the new properties set to `false` and made the enrichment startup catch-up default `false`.  
- Updated documentation and canonical rules in `docs/canonical/oprm-canon.v1.md`, architecture doc `docs/novos-modulos/OPRM/oprm-cnae-para-nichos-arquitetura.md`, UI guidance `docs/novos-modulos/OPRM/oprm-telas-acompanhamento-operacional.md` and operational register `docs/registros/oprm1.md` to reflect that CNAE cycles are disabled by default and run only when enabled operationally.  
- Added a Spring context test `OprmColetorMeiApplicationTests.cnaeAutomaticCyclesAreDisabledByDefault()` to assert the schedulers are absent by default and the properties evaluate to `false`.  

### Testing
- Ran `mvn test` in `oprm-coletor-mei` and all module tests passed (`BUILD SUCCESS`).  
- Existing unit/architecture tests in the collector were executed as part of the module test run and showed no regressions.  
- The new context test confirms schedulers are not present in the default test profile and property defaults are `false`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2cc12b12248321bee2225b717ed2d1)