### PR TITLE
Filter pending source candidates to only include RUNNING research cycles

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/sourcefetcher/service/BackendSourceFetcherService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/sourcefetcher/service/BackendSourceFetcherService.java
@@ -27,6 +27,7 @@ import org.springframework.util.StringUtils;
 public class BackendSourceFetcherService {
   private static final Logger LOGGER = LoggerFactory.getLogger(BackendSourceFetcherService.class);
   private static final String CANDIDATE_STATUS_FOUND = "FOUND";
+  private static final String CYCLE_STATUS_RUNNING = "RUNNING";
   private static final String CANDIDATE_STATUS_FETCHED = "FETCHED";
   private static final String CANDIDATE_STATUS_REJECTED = "REJECTED";
   private static final String DEFAULT_FETCH_STATUS = "COMPLETED";
@@ -51,12 +52,12 @@ public class BackendSourceFetcherService {
     this.routineResearchCycleRepository = routineResearchCycleRepository;
   }
 
-  /** Lista fontes candidatas encontradas e ainda não selecionadas para coleta curta. */
+  /** Lista fontes candidatas encontradas apenas de ciclos ativos para coleta curta independente por ciclo. */
   @Transactional(readOnly = true)
   public List<RecordSourceFetcherPending> listPending() {
     return sourceCandidateRepository
-        .findByStatusAndSelectedForFetchFalseOrderByResearchCycleIdAscResearchQueryIdAscSearchPositionAscIdAsc(
-            CANDIDATE_STATUS_FOUND, PageRequest.of(0, MAX_PENDING))
+        .findPendingForFetchFromActiveCycles(
+            CANDIDATE_STATUS_FOUND, CYCLE_STATUS_RUNNING, PageRequest.of(0, MAX_PENDING))
         .stream()
         .map(this::toPending)
         .toList();

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/oprm/nichocnae/OprmSourceCandidateRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/oprm/nichocnae/OprmSourceCandidateRepository.java
@@ -4,6 +4,8 @@ import com.marketinghub.oprm.nichocnae.OprmSourceCandidate;
 import java.util.List;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 /**
  * Repositório responsável por persistir e consultar fontes candidatas do pipeline OPRM nicho CNAE.
@@ -15,7 +17,19 @@ public interface OprmSourceCandidateRepository extends JpaRepository<OprmSourceC
     /** Verifica se uma URL já foi salva para uma query de pesquisa específica. */
     boolean existsByResearchQueryIdAndSourceUrl(Long researchQueryId, String sourceUrl);
 
-    /** Lista fontes candidatas encontradas ainda não selecionadas para fetch na ordem operacional. */
-    List<OprmSourceCandidate> findByStatusAndSelectedForFetchFalseOrderByResearchCycleIdAscResearchQueryIdAscSearchPositionAscIdAsc(
-        String status, Pageable pageable);
+    /** Lista fontes candidatas pendentes apenas de ciclos ativos para manter cada ciclo operacional independente. */
+    @Query("""
+            select candidate
+            from OprmSourceCandidate candidate, OprmRoutineResearchCycle cycle
+            where cycle.id = candidate.researchCycleId
+              and cycle.status = :cycleStatus
+              and cycle.finishedAt is null
+              and candidate.status = :candidateStatus
+              and candidate.selectedForFetch = false
+            order by candidate.researchCycleId asc, candidate.researchQueryId asc, candidate.searchPosition asc, candidate.id asc
+            """)
+    List<OprmSourceCandidate> findPendingForFetchFromActiveCycles(
+            @Param("candidateStatus") String candidateStatus,
+            @Param("cycleStatus") String cycleStatus,
+            Pageable pageable);
 }

--- a/backend/ads-service/src/test/java/com/marketinghub/oprm/nichocnae/OprmSourceCandidateRepositoryTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/oprm/nichocnae/OprmSourceCandidateRepositoryTest.java
@@ -1,0 +1,95 @@
+package com.marketinghub.oprm.nichocnae;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.marketinghub.repository.jpa.oprm.nichocnae.OprmRoutineResearchCycleRepository;
+import com.marketinghub.repository.jpa.oprm.nichocnae.OprmSourceCandidateRepository;
+import java.math.BigDecimal;
+import java.time.Instant;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.test.context.TestPropertySource;
+
+/** Testes responsáveis por validar as filas de fontes candidatas do OPRM NichoCNAE. */
+@DataJpaTest
+@TestPropertySource(properties = "spring.liquibase.enabled=false")
+class OprmSourceCandidateRepositoryTest {
+  @Autowired OprmRoutineResearchCycleRepository cycleRepository;
+  @Autowired OprmSourceCandidateRepository sourceCandidateRepository;
+
+  /** Garante que a coleta ignora pendências residuais de ciclos falhados ou encerrados. */
+  @Test
+  void findPendingForFetchFromActiveCyclesShouldIgnoreClosedCycles() {
+    OprmRoutineResearchCycle failedCycle = saveCycle("FAILED", "2026-06-13T02:04:18Z", true);
+    OprmSourceCandidate failedCandidate = saveCandidate(failedCycle, 1);
+    OprmRoutineResearchCycle cancelledCycle = saveCycle("CANCELLED_BY_MANUAL_RESTART", "2026-06-13T02:10:18Z", true);
+    OprmSourceCandidate cancelledCandidate = saveCandidate(cancelledCycle, 2);
+    OprmRoutineResearchCycle finishedRunningCycle = saveCycle("RUNNING", "2026-06-13T02:12:18Z", true);
+    OprmSourceCandidate finishedRunningCandidate = saveCandidate(finishedRunningCycle, 3);
+    OprmRoutineResearchCycle activeCycle = saveCycle("RUNNING", "2026-06-13T02:15:18Z", false);
+    OprmSourceCandidate activeCandidate = saveCandidate(activeCycle, 4);
+
+    assertThat(sourceCandidateRepository
+            .findPendingForFetchFromActiveCycles("FOUND", "RUNNING", PageRequest.of(0, 10)))
+        .extracting(OprmSourceCandidate::getId)
+        .containsExactly(activeCandidate.getId())
+        .doesNotContain(failedCandidate.getId(), cancelledCandidate.getId(), finishedRunningCandidate.getId());
+  }
+
+  /** Persiste um ciclo com status e finalização controlados para testar independência operacional. */
+  private OprmRoutineResearchCycle saveCycle(String status, String startedAt, boolean finished) {
+    Instant start = Instant.parse(startedAt);
+    OprmRoutineResearchCycle cycle = new OprmRoutineResearchCycle();
+    cycle.setSourceNicheId(77L);
+    cycle.setCnaeCode("9602501");
+    cycle.setCnaeDescription("Cabeleireiros, manicure e pedicure");
+    cycle.setNicheName("manicures autônomas");
+    cycle.setOriginalNicheName("manicures autônomas");
+    cycle.setNeutralNicheName("serviços pessoais de beleza");
+    cycle.setResearchMode("NEUTRAL_ROUTINE_RESEARCH");
+    cycle.setSolutionLanguageRiskScore(BigDecimal.ZERO);
+    cycle.setSourceScore(BigDecimal.valueOf(90));
+    cycle.setTriggerSource("TEST");
+    cycle.setStatus(status);
+    cycle.setTotalQueries(1);
+    cycle.setTotalSourceCandidates(1);
+    cycle.setTotalSourceSnapshots(0);
+    cycle.setTotalExtractedSignals(0);
+    cycle.setStartedAt(start);
+    cycle.setFinishedAt(finished ? start.plusSeconds(60) : null);
+    cycle.setCreatedAt(start);
+    cycle.setUpdatedAt(start);
+    return cycleRepository.saveAndFlush(cycle);
+  }
+
+  /** Persiste uma fonte candidata encontrada para compor a fila de coleta curta. */
+  private OprmSourceCandidate saveCandidate(OprmRoutineResearchCycle cycle, int position) {
+    OprmSourceCandidate candidate = new OprmSourceCandidate();
+    candidate.setResearchCycleId(cycle.getId());
+    candidate.setResearchQueryId(cycle.getId() * 10);
+    candidate.setSourceUrl("https://exemplo.com/fonte-" + position);
+    candidate.setSourceTitle("Fonte " + position);
+    candidate.setSourceSnippet("Rotina real de atendimento autônomo.");
+    candidate.setSourceDomain("exemplo.com");
+    candidate.setSourceGroup("ROUTINE_REPORT");
+    candidate.setSourceIntent("ROUTINE_REPORT");
+    candidate.setRoutineEvidenceScore(88);
+    candidate.setCommercialPageRisk(false);
+    candidate.setSolutionLanguageRisk(false);
+    candidate.setSourceClassificationType("RECENT_SECTOR_CONTENT");
+    candidate.setSourceFreshnessScore(95);
+    candidate.setOutdatedSourceRisk(false);
+    candidate.setBrazilRelevanceScore(90);
+    candidate.setAutonomousProfessionalEvidenceScore(90);
+    candidate.setStructuredBusinessDriftRisk(false);
+    candidate.setSearchProvider("DUCKDUCKGO_HTML");
+    candidate.setSearchPosition(position);
+    candidate.setSelectedForFetch(false);
+    candidate.setStatus("FOUND");
+    candidate.setCreatedAt(cycle.getStartedAt());
+    candidate.setUpdatedAt(cycle.getStartedAt());
+    return sourceCandidateRepository.saveAndFlush(candidate);
+  }
+}

--- a/backend/ads-service/src/test/java/com/marketinghub/oprm/nichocnae/sourcefetcher/service/BackendSourceFetcherServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/oprm/nichocnae/sourcefetcher/service/BackendSourceFetcherServiceTest.java
@@ -38,12 +38,11 @@ class BackendSourceFetcherServiceTest {
 
   @InjectMocks private BackendSourceFetcherService service;
 
-  /** Deve listar fontes encontradas ainda não selecionadas para coleta curta. */
+  /** Deve listar fontes encontradas apenas de ciclos ativos para não misturar falhas antigas com ciclos novos. */
   @Test
-  void listPendingUsesFoundAndNotSelectedFilter() {
+  void listPendingUsesFoundNotSelectedAndRunningCycleFilter() {
     when(sourceCandidateRepository
-            .findByStatusAndSelectedForFetchFalseOrderByResearchCycleIdAscResearchQueryIdAscSearchPositionAscIdAsc(
-                eq("FOUND"), any(Pageable.class)))
+            .findPendingForFetchFromActiveCycles(eq("FOUND"), eq("RUNNING"), any(Pageable.class)))
         .thenReturn(List.of(candidate()));
 
     var result = service.listPending();
@@ -51,6 +50,8 @@ class BackendSourceFetcherServiceTest {
     assertThat(result).hasSize(1);
     assertThat(result.getFirst().sourceCandidateId()).isEqualTo(301L);
     assertThat(result.getFirst().sourceUrl()).isEqualTo("https://exemplo.com/clientes-manicure");
+    verify(sourceCandidateRepository)
+        .findPendingForFetchFromActiveCycles(eq("FOUND"), eq("RUNNING"), any(Pageable.class));
   }
 
   /** Deve gravar snapshot, marcar a candidata como coletada e atualizar o total do ciclo. */

--- a/docs/canonical/oprm-canon.v1.md
+++ b/docs/canonical/oprm-canon.v1.md
@@ -215,6 +215,18 @@ Evitar fechamento prematuro de `import run` que destrói a totalização de mark
 - Testes de arquitetura/ArchUnit devem proteger que o núcleo do pipeline não dependa de etapas concretas e que etapas concretas não dependam entre si.
 - A implementação ou revisão de uma etapa deve validar se o avanço para a próxima etapa ocorre por dados/contratos oficiais, e não por chamada direta entre classes de etapas.
 
+## Regra obrigatória — independência dos ciclos NichoCNAE
+
+- Cada ciclo do pipeline OPRM NichoCNAE deve ser operacionalmente independente dos ciclos anteriores e posteriores do mesmo CNAE.
+- A falha, cancelamento, bloqueio, parada ou pendência residual de um ciclo anterior não pode entrar na fila de execução de um novo ciclo ativo.
+- Filas internas de etapas por candidato, fonte, snapshot, sinal, card ou perfil devem restringir a busca a ciclos `RUNNING` com `finishedAt` vazio, salvo rotinas explícitas de diagnóstico, auditoria ou reprocessamento manual.
+- Ao reiniciar manualmente um CNAE, o novo ciclo deve conseguir avançar mesmo que existam registros `FOUND`, `PENDING` ou parcialmente processados em ciclos antigos já finalizados.
+
+## Critério de efetividade — independência dos ciclos NichoCNAE
+
+- Endpoints internos de fila não devem retornar unidades de trabalho de ciclos `FAILED`, `STALLED`, `CANCELLED_BY_MANUAL_RESTART` ou com `finishedAt` preenchido.
+- Testes de regressão devem cobrir que pendências antigas de ciclo falhado não bloqueiam a etapa equivalente de um ciclo novo em execução.
+
 ## Regra obrigatória — publicação do executor OPRM com acesso à chave OpenAI
 
 - O `oprm-coletor-mei`, quando executar etapas NichoCNAE com IA, deve ser publicado no mesmo host do `ai-worker`: `191.252.120.96`.

--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -552,3 +552,9 @@
 - Desligados por padrão os ciclos agendados de score CNAE (`CNAE_SCORE`) e enriquecimento CNAE (`CNAE_ENRICHMENT`) no `oprm-coletor-mei`, mantendo possibilidade de religar por configuração operacional explícita quando houver atualização real da base.
 - Causa-raiz tratada: a base CNAE/mercado não muda com frequência suficiente para justificar execuções recorrentes, que geravam ciclos vazios e ruído operacional na tela de acompanhamento.
 - Prevenção de recorrência: o cânone OPRM foi atualizado para definir scheduler sob demanda operacional e o teste de contexto garante que os schedulers ficam ausentes por padrão.
+
+## 2026-06-13 — OPRM NichoCNAE: independência da fila de coleta entre ciclos
+
+- Corrigida a fila interna da etapa 4 (`source-fetcher`) para listar apenas fontes `FOUND` de ciclos `RUNNING` ainda sem `finishedAt`, impedindo que pendências residuais de ciclos falhados entrem antes do ciclo atual.
+- Causa-raiz tratada: a etapa de coleta buscava candidatas pendentes globalmente por status da fonte, sem validar o status do ciclo pai, permitindo que o ciclo #26 `FAILED` represasse a coleta do ciclo #27.
+- Prevenção de recorrência: o cânone OPRM passou a exigir independência operacional entre ciclos NichoCNAE e o teste da etapa valida o filtro por ciclo ativo.


### PR DESCRIPTION
### Motivation

- Prevent residual candidates from failed or finished cycles from blocking or contaminating the active cycle's short-excerpt collection.
- Enforce operational independence between NichoCNAE research cycles so each cycle advances without being affected by previous cycles' pendencies.
- Update documentation and operational records to reflect the new rule that internal queues must restrict work to `RUNNING` cycles with `finishedAt` empty.

### Description

- Added `CYCLE_STATUS_RUNNING` constant and changed `BackendSourceFetcherService.listPending` to use a new repository method that filters by cycle status and `finishedAt` null.  
- Introduced `findPendingForFetchFromActiveCycles` in `OprmSourceCandidateRepository` with a JPQL query that joins `OprmRoutineResearchCycle` and restricts results to cycles with `status = :cycleStatus` and `finishedAt is null`.  
- Updated tests: added `OprmSourceCandidateRepositoryTest` (`@DataJpaTest`) to assert old cycles are ignored, and adjusted `BackendSourceFetcherServiceTest` to expect the new repository method invocation.  
- Updated canonical and operational docs (`docs/canonical/oprm-canon.v1.md` and `docs/registros/oprm1.md`) with the rule and changelog describing cycle independence and the fix applied to the `source-fetcher` queue.

### Testing

- Ran unit tests including `BackendSourceFetcherServiceTest` which verifies the service calls `findPendingForFetchFromActiveCycles`, and they passed.  
- Executed repository integration test `OprmSourceCandidateRepositoryTest` as a `@DataJpaTest` which verifies only active `RUNNING` cycles without `finishedAt` return pending candidates, and it passed.  
- Full test suite executed via `./mvnw test` completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2cc400e58083219073b9df182ceb23)