### PR TITLE
OPRM NichoCNAE: enviar `service_tier=flex` na etapa seed e mensagem de erro explícita da OpenAI

### DIFF
--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -558,3 +558,10 @@
 - Corrigida a fila interna da etapa 4 (`source-fetcher`) para listar apenas fontes `FOUND` de ciclos `RUNNING` ainda sem `finishedAt`, impedindo que pendências residuais de ciclos falhados entrem antes do ciclo atual.
 - Causa-raiz tratada: a etapa de coleta buscava candidatas pendentes globalmente por status da fonte, sem validar o status do ciclo pai, permitindo que o ciclo #26 `FAILED` represasse a coleta do ciclo #27.
 - Prevenção de recorrência: o cânone OPRM passou a exigir independência operacional entre ciclos NichoCNAE e o teste da etapa valida o filtro por ciclo ativo.
+
+## 2026-06-13 — OPRM NichoCNAE: Flex Processing e erro claro na OpenAI da etapa seed
+
+- Verificado que a etapa `niche-research-seed-builder` chamava a OpenAI Responses API sem `service_tier`, portanto não estava forçando o modo Flex no payload da requisição.
+- Ajustado o coletor OPRM para enviar `service_tier=flex` por padrão na etapa seed, com configuração operacional `OPRM_NICHO_CNAE_SEED_BUILDER_OPENAI_SERVICE_TIER` para manter rastreabilidade e flexibilidade futura.
+- Causa-raiz tratada na observabilidade: a mensagem persistida começava apenas com “Falha ao gerar seed”, escondendo do usuário que a falha veio da OpenAI; agora a exceção operacional começa com “Falha na OpenAI ao gerar seed da etapa dois OPRM nichocnae”.
+- Prevenção de recorrência: adicionado teste de regressão garantindo que o payload enviado contém `service_tier=flex` e que falhas de transporte como `Broken pipe` preservam mensagem explícita de OpenAI.

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnae/nicheresearchseedbuilder/NicheResearchSeedBuilderOpenAiProperties.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnae/nicheresearchseedbuilder/NicheResearchSeedBuilderOpenAiProperties.java
@@ -8,7 +8,8 @@ public record NicheResearchSeedBuilderOpenAiProperties(
         String baseUrl,
         String apiKey,
         String apiKeyFile,
-        String model) {
+        String model,
+        String serviceTier) {
 
     /** Normaliza valores padrão seguros para a chamada síncrona da Responses API. */
     public NicheResearchSeedBuilderOpenAiProperties {
@@ -16,5 +17,6 @@ public record NicheResearchSeedBuilderOpenAiProperties(
         apiKey = apiKey == null ? "" : apiKey;
         apiKeyFile = apiKeyFile == null ? "" : apiKeyFile;
         model = model == null || model.isBlank() ? "gpt-4.1-mini" : model;
+        serviceTier = serviceTier == null || serviceTier.isBlank() ? "flex" : serviceTier;
     }
 }

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnae/nicheresearchseedbuilder/OpenAiNicheResearchSeedBuilderClient.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnae/nicheresearchseedbuilder/OpenAiNicheResearchSeedBuilderClient.java
@@ -70,12 +70,13 @@ public class OpenAiNicheResearchSeedBuilderClient {
                     model);
         } catch (RestClientException | JsonProcessingException | IllegalStateException | IllegalArgumentException ex) {
             log.error(
-                    "Erro ao gerar seed da etapa dois OPRM nichocnae com OpenAI (endpoint={}, researchCycleId={}, cnaeCode={})",
+                    "Erro ao gerar seed da etapa dois OPRM nichocnae com OpenAI (endpoint={}, researchCycleId={}, cnaeCode={}, serviceTier={})",
                     url,
                     input.researchCycleId(),
                     input.cnaeCode(),
+                    properties.serviceTier(),
                     ex);
-            throw new IllegalStateException("Falha ao gerar seed da etapa dois OPRM nichocnae.", ex);
+            throw new IllegalStateException("Falha na OpenAI ao gerar seed da etapa dois OPRM nichocnae.", ex);
         }
     }
 
@@ -122,7 +123,7 @@ public class OpenAiNicheResearchSeedBuilderClient {
     }
 
     /** Monta o corpo da Responses API com schema JSON estrito para evitar saída ambígua ou fora do contrato. */
-    private Map<String, Object> buildRequestBody(String prompt, String model) {
+    Map<String, Object> buildRequestBody(String prompt, String model) {
         Map<String, Object> format = new LinkedHashMap<>();
         format.put("type", "json_schema");
         format.put("name", SCHEMA_NAME);
@@ -136,6 +137,7 @@ public class OpenAiNicheResearchSeedBuilderClient {
         body.put("model", model);
         body.put("input", prompt);
         body.put("text", text);
+        body.put("service_tier", properties.serviceTier());
         return body;
     }
 

--- a/oprm-coletor-mei/src/main/resources/application.yml
+++ b/oprm-coletor-mei/src/main/resources/application.yml
@@ -23,6 +23,7 @@ oprm:
         api-key: ${OPRM_NICHO_CNAE_SEED_BUILDER_OPENAI_API_KEY:${OPENAI_API_KEY:}}
         api-key-file: ${OPRM_NICHO_CNAE_SEED_BUILDER_OPENAI_API_KEY_FILE:${OPENAI_API_KEY_FILE:}}
         model: ${OPRM_NICHO_CNAE_SEED_BUILDER_OPENAI_MODEL:gpt-4.1-mini}
+        service-tier: ${OPRM_NICHO_CNAE_SEED_BUILDER_OPENAI_SERVICE_TIER:flex}
     mei-audience-segmenter:
       openai:
         base-url: ${OPRM_MEI_AUDIENCE_SEGMENTER_OPENAI_BASE_URL:https://api.openai.com/v1}

--- a/oprm-coletor-mei/src/test/java/com/marketinghub/nichocnae/nicheresearchseedbuilder/OpenAiNicheResearchSeedBuilderClientTest.java
+++ b/oprm-coletor-mei/src/test/java/com/marketinghub/nichocnae/nicheresearchseedbuilder/OpenAiNicheResearchSeedBuilderClientTest.java
@@ -1,13 +1,24 @@
 package com.marketinghub.nichocnae.nicheresearchseedbuilder;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.springframework.test.web.client.ExpectedCount.once;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.jsonPath;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withException;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.IOException;
 import java.math.BigDecimal;
+import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.time.Instant;
+import java.util.Map;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestClient;
 
 /** Responsabilidade: validar a resolução segura da chave OpenAI no módulo OPRM. */
 class OpenAiNicheResearchSeedBuilderClientTest {
@@ -18,8 +29,8 @@ class OpenAiNicheResearchSeedBuilderClientTest {
     void shouldPreferDirectApiKeyWhenConfigured() throws Exception {
         Path keyFile = tempDir.resolve("openai_api_key");
         Files.writeString(keyFile, "file-key");
-        OpenAiNicheResearchSeedBuilderClient client = clientWithProperties(
-                new NicheResearchSeedBuilderOpenAiProperties("https://api.openai.com/v1", "direct-key", keyFile.toString(), "gpt-test"));
+        OpenAiNicheResearchSeedBuilderClient client = clientWithProperties(new NicheResearchSeedBuilderOpenAiProperties(
+                "https://api.openai.com/v1", "direct-key", keyFile.toString(), "gpt-test", "flex"));
 
         String apiKey = client.resolveApiKey(pending());
 
@@ -31,8 +42,8 @@ class OpenAiNicheResearchSeedBuilderClientTest {
     void shouldReadApiKeyFromMountedFileWhenDirectKeyIsBlank() throws Exception {
         Path keyFile = tempDir.resolve("openai_api_key");
         Files.writeString(keyFile, " file-key \n");
-        OpenAiNicheResearchSeedBuilderClient client = clientWithProperties(
-                new NicheResearchSeedBuilderOpenAiProperties("https://api.openai.com/v1", "", keyFile.toString(), "gpt-test"));
+        OpenAiNicheResearchSeedBuilderClient client = clientWithProperties(new NicheResearchSeedBuilderOpenAiProperties(
+                "https://api.openai.com/v1", "", keyFile.toString(), "gpt-test", "flex"));
 
         String apiKey = client.resolveApiKey(pending());
 
@@ -42,17 +53,57 @@ class OpenAiNicheResearchSeedBuilderClientTest {
     /** Confirma que a configuração operacional recebida do backend define o modelo enviado à OpenAI. */
     @Test
     void shouldResolveModelFromPendingStageConfiguration() {
-        OpenAiNicheResearchSeedBuilderClient client = clientWithProperties(
-                new NicheResearchSeedBuilderOpenAiProperties("https://api.openai.com/v1", "direct-key", "", "gpt-4.1-mini"));
+        OpenAiNicheResearchSeedBuilderClient client = clientWithProperties(new NicheResearchSeedBuilderOpenAiProperties(
+                "https://api.openai.com/v1", "direct-key", "", "gpt-4.1-mini", "flex"));
 
         String model = client.resolveModel(pending());
 
         assertThat(model).isEqualTo("gpt-5.4");
     }
 
-    /** Cria o client com dependências nulas porque o teste cobre apenas resolução de chave e modelo. */
-    private OpenAiNicheResearchSeedBuilderClient clientWithProperties(NicheResearchSeedBuilderOpenAiProperties properties) {
-        return new OpenAiNicheResearchSeedBuilderClient(null, null, properties, null, null);
+    /** Confirma que a requisição da etapa dois usa Flex Processing por padrão para reduzir custo operacional. */
+    @Test
+    void shouldUseFlexServiceTierInRequestBodyByDefault() {
+        OpenAiNicheResearchSeedBuilderClient client = clientWithProperties(new NicheResearchSeedBuilderOpenAiProperties(
+                "https://api.openai.com/v1", "direct-key", "", "gpt-test", null));
+
+        Map<String, Object> requestBody = client.buildRequestBody("prompt", "gpt-test");
+
+        assertThat(requestBody).containsEntry("service_tier", "flex");
+    }
+
+    /** Confirma que falhas de transporte na OpenAI geram mensagem operacional clara para a tela. */
+    @Test
+    void shouldReportOpenAiWhenTransportFails() throws Exception {
+        RestClient.Builder builder = RestClient.builder();
+        MockRestServiceServer server = MockRestServiceServer.bindTo(builder).build();
+        server.expect(once(), requestTo(URI.create("https://api.openai.com/v1/responses")))
+                .andExpect(jsonPath("$.service_tier").value("flex"))
+                .andRespond(withException(new IOException("Broken pipe")));
+        OpenAiNicheResearchSeedBuilderClient client = new OpenAiNicheResearchSeedBuilderClient(
+                builder.build(),
+                new ObjectMapper(),
+                new NicheResearchSeedBuilderOpenAiProperties(
+                        "https://api.openai.com/v1", "direct-key", "", "gpt-test", null),
+                new NicheResearchSeedBuilderPromptBuilder(),
+                new NicheResearchSeedBuilderSchema());
+
+        assertThatThrownBy(() -> client.generate(pending()))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Falha na OpenAI ao gerar seed da etapa dois OPRM nichocnae")
+                .hasRootCauseMessage("Broken pipe");
+        server.verify();
+    }
+
+    /** Cria o client com dependências mínimas porque o teste cobre resolução de chave, modelo e corpo de requisição. */
+    private OpenAiNicheResearchSeedBuilderClient clientWithProperties(
+            NicheResearchSeedBuilderOpenAiProperties properties) {
+        return new OpenAiNicheResearchSeedBuilderClient(
+                null,
+                new ObjectMapper(),
+                properties,
+                new NicheResearchSeedBuilderPromptBuilder(),
+                new NicheResearchSeedBuilderSchema());
     }
 
     /** Cria uma pendência mínima para contexto de logs de resolução de chave. */


### PR DESCRIPTION
### Motivation
- Garantir que a etapa seed do fluxo NichoCNAE force o modo Flex nas chamadas à OpenAI para controle de custo e comportamento previsível. 
- Tornar a observabilidade e mensagens de erro mais explícitas ao usuário, explicitando quando a falha veio da OpenAI. 

### Description
- Adicionada a propriedade `serviceTier` no record `NicheResearchSeedBuilderOpenAiProperties` com valor padrão `"flex"` e mapeamento em `application.yml` via `oprm.nichocnae.seed-builder.openai.service-tier`.
- Incluído `service_tier` no payload enviado à Responses API em `OpenAiNicheResearchSeedBuilderClient.buildRequestBody` e incluso no log de erro como `serviceTier` para rastreabilidade.
- Alterada a mensagem lançada em falhas para começar com `"Falha na OpenAI ao gerar seed da etapa dois OPRM nichocnae"` para destacar origem da falha, e reduzido escopo de método `buildRequestBody` para permitir testes.
- Atualizados e adicionados testes em `OpenAiNicheResearchSeedBuilderClientTest` para validar o `service_tier=flex` por padrão e para verificar que falhas de transporte preservam mensagem explícita da OpenAI.

### Testing
- Executados os testes unitários do módulo `oprm-coletor-mei`, incluindo `OpenAiNicheResearchSeedBuilderClientTest`, que cobrem resolução de chave, resolução de modelo, presença de `service_tier` no corpo e tratamento de exceções; todos os testes passaram com sucesso.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2cd298851483218b3a1e304e5076ce)