### PR TITLE
Hotmart collector: reschedule cycle 1 to 13/06/2026 01:35 and update docs/tests

### DIFF
--- a/docs/canonical/mois-hotmart-mapeamento-ciclos-campos-banco.md
+++ b/docs/canonical/mois-hotmart-mapeamento-ciclos-campos-banco.md
@@ -192,7 +192,7 @@ Em resumo: o erro normalmente não está na UI; ele nasce na qualidade do campo 
 
 Agendamento operacional vigente no `mois-hotmart-collector`:
 
-- **Ciclo 1 (listagem):** execução pontual única em **13 de junho de 2026 às 00:05**, no fuso `America/Sao_Paulo`.
+- **Ciclo 1 (listagem):** execução pontual única em **13 de junho de 2026 às 01:35**, no fuso `America/Sao_Paulo`.
 - **Ciclo 2 (detalhes):** execução diária às **17:00**, conforme scheduler vigente do coletor.
 - O cron do ciclo 1 fica hardcoded no `HotmartCollectorScheduler` para manter rastreabilidade operacional do horário combinado e possui guarda de ano para não repetir após 2026.
 

--- a/docs/registros/mois1.md
+++ b/docs/registros/mois1.md
@@ -1569,3 +1569,7 @@ Arquivos principais:
 ## 2026-06-13 — Hotmart ciclo 1 agendado para execução única às 00:05
 - Ajustado o `HotmartCollectorScheduler` para executar o ciclo 1 de listagem uma única vez em **13/06/2026 às 00:05** no timezone `America/Sao_Paulo`.
 - Atualizados teste do scheduler e cânone Hotmart para refletir o novo cron `0 5 0 13 6 *` e preservar a guarda operacional de execução somente no ano de 2026.
+
+## 2026-06-13 — Reexecução Hotmart ciclo 1 às 01:35
+- Após falha operacional às 00:05 causada por JWT Hotmart expirado, o ciclo 1 de listagem do `mois-hotmart-collector` foi reagendado para execução pontual única em **13/06/2026 às 01:35** no timezone `America/Sao_Paulo`.
+- Atualizados scheduler, teste unitário e cânone Hotmart para usar o cron `0 35 1 13 6 *`, mantendo o alvo operacional de 400 produtos e a guarda de execução apenas em 2026.

--- a/mois-hotmart-collector/src/main/java/com/marketinghub/moishotmart/service/HotmartCollectorScheduler.java
+++ b/mois-hotmart-collector/src/main/java/com/marketinghub/moishotmart/service/HotmartCollectorScheduler.java
@@ -41,10 +41,10 @@ public class HotmartCollectorScheduler {
     }
 
     /**
-     * Executa o ciclo 1 de listagem de produtos uma única vez às 00:05 em 13 de junho de 2026, no horário de São Paulo.
+     * Executa o ciclo 1 de listagem de produtos uma única vez às 01:35 em 13 de junho de 2026, no horário de São Paulo.
      */
-    @Scheduled(cron = "0 5 0 13 6 *", zone = "America/Sao_Paulo")
-    public void collectFirstCycleAtZeroZeroFiveOnJuneThirteenth2026() {
+    @Scheduled(cron = "0 35 1 13 6 *", zone = "America/Sao_Paulo")
+    public void collectFirstCycleAtOneThirtyFiveOnJuneThirteenth2026() {
         if (!enabled) {
             log.info("Hotmart scheduler desabilitado por configuração.");
             return;
@@ -58,7 +58,7 @@ public class HotmartCollectorScheduler {
         }
         HotmartCollectionRequest request = new HotmartCollectionRequest(source, maxProducts);
         HotmartCollectionResponse response = collectorService.collectFirstCycle(request);
-        log.info("Hotmart scheduler executado hora=00:05 dia=13/06 ano=2026 "
+        log.info("Hotmart scheduler executado hora=01:35 dia=13/06 ano=2026 "
                         + "timezone=America/Sao_Paulo ciclo={} status={} produtos={} mensagem={}",
                 "CICLO_1_LISTAGEM",
                 response.status(),

--- a/mois-hotmart-collector/src/test/java/com/marketinghub/moishotmart/service/HotmartCollectorSchedulerTest.java
+++ b/mois-hotmart-collector/src/test/java/com/marketinghub/moishotmart/service/HotmartCollectorSchedulerTest.java
@@ -12,15 +12,15 @@ import org.springframework.scheduling.annotation.Scheduled;
 class HotmartCollectorSchedulerTest {
 
     /**
-     * Garante que o ciclo 1 esteja agendado para 00:05 de 13 de junho de 2026 no fuso de São Paulo.
+     * Garante que o ciclo 1 esteja agendado para 01:35 de 13 de junho de 2026 no fuso de São Paulo.
      */
     @Test
-    void shouldScheduleFirstCycleAtZeroZeroFiveOnJuneThirteenth() throws NoSuchMethodException {
+    void shouldScheduleFirstCycleAtOneThirtyFiveOnJuneThirteenth() throws NoSuchMethodException {
         Method method = HotmartCollectorScheduler.class
-                .getDeclaredMethod("collectFirstCycleAtZeroZeroFiveOnJuneThirteenth2026");
+                .getDeclaredMethod("collectFirstCycleAtOneThirtyFiveOnJuneThirteenth2026");
         Scheduled scheduled = method.getAnnotation(Scheduled.class);
 
-        assertEquals("0 5 0 13 6 *", scheduled.cron());
+        assertEquals("0 35 1 13 6 *", scheduled.cron());
         assertEquals("America/Sao_Paulo", scheduled.zone());
     }
 }


### PR DESCRIPTION
### Motivation

- The first Hotmart collection cycle needed to be reexecuted after an operational failure at 00:05, so the scheduled one-off run was moved to 01:35 on 13/06/2026 to reflect the actual retry time. 
- Documentation and tests must match the new operational cron and keep the existing timezone and 2026-only guard for traceability.

### Description

- Updated the scheduler cron in `HotmartCollectorScheduler` from `0 5 0 13 6 *` to `0 35 1 13 6 *`, renamed the method and adjusted the log message and javadoc to reflect `01:35` São Paulo time. 
- Preserved the `America/Sao_Paulo` zone and the year guard logic for 2026. 
- Updated the unit test `HotmartCollectorSchedulerTest` to assert the new cron and method name. 
- Synchronized documentation files in `docs/canonical/mois-hotmart-mapeamento-ciclos-campos-banco.md` and `docs/registros/mois1.md` to describe the rescheduled execution at `01:35` and the reason for reexecution.

### Testing

- Updated and ran the unit test `HotmartCollectorSchedulerTest`, which verifies the cron expression and timezone, and it passed. 
- Ran the module test suite for the `mois-hotmart-collector` module (`mvn test`), and all tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2cd2b6d38483219024b5bcf429363f)