### PR TITLE
Disable MOIS sales page backfill by default

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesPageBackfillService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesPageBackfillService.java
@@ -19,7 +19,7 @@ public class MoisSalesPageBackfillService implements ApplicationRunner {
 
     private final MoisSalesPageBackfillGateway gateway;
 
-    @Value("${mois.sales-page.backfill.enabled:true}")
+    @Value("${mois.sales-page.backfill.enabled:false}")
     private boolean enabled;
 
     /**

--- a/backend/ads-service/src/main/resources/application.properties
+++ b/backend/ads-service/src/main/resources/application.properties
@@ -183,4 +183,4 @@ integrations.mois.hotmart-collection.country=${MOIS_HOTMART_COLLECTION_COUNTRY:B
 integrations.mois.hotmart-collection.min-success-score=${MOIS_HOTMART_COLLECTION_MIN_SUCCESS_SCORE:80}
 
 # MOIS sales page two-table migration
-mois.sales-page.backfill.enabled=${MOIS_SALES_PAGE_BACKFILL_ENABLED:true}
+mois.sales-page.backfill.enabled=${MOIS_SALES_PAGE_BACKFILL_ENABLED:false}

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -10,6 +10,7 @@ services:
       OPENAI_API_KEY: ${OPENAI_API_KEY:-}
       OPENAI_API_KEY_FILE: ${OPENAI_API_KEY_FILE:-/run/secrets/openai_api_key}
       OPENAI_BASE_URL: ${OPENAI_BASE_URL:-https://api.openai.com/v1}
+      MOIS_SALES_PAGE_BACKFILL_ENABLED: ${MOIS_SALES_PAGE_BACKFILL_ENABLED:-false}
     ports:
       - "80:8000"
       - "8000:8000"

--- a/docs/canonical/mois-worker-canon.v1.md
+++ b/docs/canonical/mois-worker-canon.v1.md
@@ -516,6 +516,7 @@ Regras obrigatórias da Fase 5:
 - a conclusão ou falha de análise deve atualizar primeiro `mois_sales_page_job_execution` e depois o estado consolidado em `mois_sales_page`;
 - reanálise e atualização manual de status devem criar execuções novas no histórico consolidado sem depender de tabelas legadas;
 - tabelas legadas de URL, job e análise não podem receber a escrita operacional principal nem ser fonte de verdade da UI operacional;
+- o backfill de páginas de venda (`MOIS_SALES_PAGE_BACKFILL_ENABLED`) deve permanecer desabilitado por padrão em produção (`false`) e só pode ser ligado temporariamente para migração controlada/manual, com reinício explícito do backend e confirmação em logs por `operacao=salesPageBackfill`;
 - logs de transição devem informar `pageId`, `executionId`, operação executada e resultado para rastrear cada mudança de etapa;
 - contratos Swagger da Biblioteca devem explicitar que `jobId` de claim/complete/fail representa `mois_sales_page_job_execution.id` nesta fase;
 - o endpoint de listagem de entradas (`GET /api/mois/sales-library/entries`) deve ler `mois_sales_page`; o campo compatível `firstCapturedAt` passa a representar `first_seen_at` enquanto o contrato externo não for renomeado.

--- a/docs/registros/mois1.md
+++ b/docs/registros/mois1.md
@@ -1573,3 +1573,10 @@ Arquivos principais:
 ## 2026-06-13 — Reexecução Hotmart ciclo 1 às 01:35
 - Após falha operacional às 00:05 causada por JWT Hotmart expirado, o ciclo 1 de listagem do `mois-hotmart-collector` foi reagendado para execução pontual única em **13/06/2026 às 01:35** no timezone `America/Sao_Paulo`.
 - Atualizados scheduler, teste unitário e cânone Hotmart para usar o cron `0 35 1 13 6 *`, mantendo o alvo operacional de 400 produtos e a guarda de execução apenas em 2026.
+
+### 2026-06-13 — Backfill de páginas de venda MOIS desabilitado por padrão
+
+- Decidido que o backfill `MOIS_SALES_PAGE_BACKFILL_ENABLED` não é rotina automática de produção; ele deve permanecer `false` e ser usado apenas em migração controlada/manual.
+- Atualizado o deploy do backend para injetar `MOIS_SALES_PAGE_BACKFILL_ENABLED=false` por padrão e alinhado o default interno do backend para evitar execução acidental em novos ambientes.
+- Registrada a regra na Fase 5 do cânone MOIS, exigindo confirmação operacional em logs com `operacao=salesPageBackfill` quando houver reinício/execução.
+


### PR DESCRIPTION
### Motivation
- Prevent accidental or automatic execution of the MOIS sales-page backfill in production by making it opt-in and requiring an explicit operational decision. 
- Keep the backfill routine available for controlled/manual migrations only and require an explicit backend restart and log confirmation when it runs. 
- Record the operational rule in the MOIS canon so the deployment default, code default and runbooks remain consistent.

### Description
- Set the deployment environment variable default `MOIS_SALES_PAGE_BACKFILL_ENABLED=false` in `deploy/docker-compose.yml`. 
- Change the application default to `mois.sales-page.backfill.enabled=${MOIS_SALES_PAGE_BACKFILL_ENABLED:false}` in `backend/ads-service/src/main/resources/application.properties`. 
- Align the service internal default to `@Value("${mois.sales-page.backfill.enabled:false}")` in `MoisSalesPageBackfillService.java` so startup will skip the backfill unless explicitly enabled. 
- Document the rule in `docs/canonical/mois-worker-canon.v1.md` (Fase 5) and add the operational record in `docs/registros/mois1.md` describing the decision and required log confirmation string `operacao=salesPageBackfill`.

### Testing
- Ran the unit tests for the backfill orchestration with `../mvnw -Dtest=MoisSalesPageBackfillServiceTest test` in the `backend/ads-service` module and the tests passed (`Tests run: 2, Failures: 0, Errors: 0`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2d37343eb08321a5dad7319c301c6d)