### PR TITLE
OPRM CNAE: highlight AI stages in pipeline UI, add subtle status backgrounds, tests and docs

### DIFF
--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -566,3 +566,9 @@
 - Causa-raiz tratada na observabilidade: a mensagem persistida começava apenas com “Falha ao gerar seed”, escondendo do usuário que a falha veio da OpenAI; agora a exceção operacional começa com “Falha na OpenAI ao gerar seed da etapa dois OPRM nichocnae”.
 - Prevenção de recorrência: adicionado teste de regressão garantindo que o payload enviado contém `service_tier=flex` e que falhas de transporte como `Broken pipe` preservam mensagem explícita de OpenAI.
 - 2026-06-13 02:05:00 (UTC): desligados os ciclos automáticos OPRM CNAE_SCORE e CNAE_ENRICHMENT no `oprm-coletor-mei`; a causa-raiz dos ciclos recorrentes era a presença de `@Scheduled` nos executores de score/enriquecimento e de catch-up por `ApplicationReadyEvent` no enriquecimento. Os métodos de execução foram preservados para acionamento manual/controlado, mas sem disparo automático por cron ou inicialização da aplicação.
+
+## 2026-06-13 — OPRM NichoCNAE: ícone IA nos cards de etapa
+
+- Ajustada a tela de detalhe do CNAE para marcar visualmente os cards das etapas que acessam diretamente IA no pipeline NichoCNAE e aplicar fundos leves por status operacional.
+- Foram sinalizadas as etapas `Seed` e `MEI`, alinhadas ao cânone OPRM que define apenas `niche-research-seed-builder` e `mei-audience-segmenter` como consumidoras diretas de modelo OpenAI configurável.
+- Causa-raiz tratada: a tela operacional mostrava o estado da execução, mas não diferenciava rapidamente as etapas que dependem de IA nem criava hierarquia visual suficiente entre concluído, execução, bloqueio/falha e fila, dificultando o diagnóstico de falhas e decisões operacionais.

--- a/frontend/src/pages/oprm/OprmCnaeDetailPlaceholderPage.test.tsx
+++ b/frontend/src/pages/oprm/OprmCnaeDetailPlaceholderPage.test.tsx
@@ -1,4 +1,4 @@
-import { render, screen, within } from "@testing-library/react";
+import { cleanup, render, screen, within } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -29,6 +29,7 @@ function renderPage() {
 
 describe("OprmCnaeDetailPlaceholderPage", () => {
   afterEach(() => {
+    cleanup();
     vi.restoreAllMocks();
   });
 
@@ -133,5 +134,64 @@ describe("OprmCnaeDetailPlaceholderPage", () => {
       within(materializationCard as HTMLElement).getByText("Bloqueado"),
     ).toBeTruthy();
     expect(screen.queryByText("Em execução")).toBeNull();
+  });
+
+  it("diferencia visualmente os cards por status com fundos leves", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = input.toString();
+
+        if (url.includes("routine-research-cycle/stage-executions")) {
+          return new Response(
+            JSON.stringify([
+              {
+                researchCycleId: 31,
+                sourceNicheId: 1,
+                cnaeCode: "9602501",
+                nicheName: "Cabeleireiros, manicure e pedicure",
+                status: "RUNNING",
+                totalQueries: 48,
+                totalSourceCandidates: 340,
+                totalSourceSnapshots: 104,
+                totalExtractedSignals: 266,
+                startedAt: "2026-06-13T07:31:00Z",
+                finishedAt: null,
+                errorMessage: null,
+              },
+            ]),
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          );
+        }
+
+        return new Response("{}", {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }),
+    );
+
+    renderPage();
+
+    await screen.findByText(/status atual:/i);
+
+    const seedCard = screen.getByText("2. Seed");
+    expect(seedCard.closest(".card")?.className).toContain("bg-success-subtle");
+    expect(
+      within(seedCard.closest(".card") as HTMLElement).getByLabelText(
+        "Etapa com uso direto de IA",
+      ),
+    ).toBeTruthy();
+
+    const synthesisCard = screen.getByText("6. Síntese").closest(".card");
+    expect(synthesisCard?.className).toContain("bg-primary-subtle");
+
+    const meiCard = screen.getByText("7. MEI").closest(".card");
+    expect(meiCard?.className).toContain("bg-body-tertiary");
+    expect(
+      within(meiCard as HTMLElement).getByLabelText(
+        "Etapa com uso direto de IA",
+      ),
+    ).toBeTruthy();
   });
 });

--- a/frontend/src/pages/oprm/OprmCnaeDetailPlaceholderPage.tsx
+++ b/frontend/src/pages/oprm/OprmCnaeDetailPlaceholderPage.tsx
@@ -1,3 +1,4 @@
+import { Sparkles } from "lucide-react";
 import { Link, useParams } from "react-router-dom";
 import {
   useOprmCnaeScore,
@@ -22,6 +23,7 @@ const pipelineStages = [
     code: "seed",
     title: "2. Seed",
     description: "Transforma CNAE em nicho operacional e queries de pesquisa.",
+    usesAiModel: true,
   },
   {
     code: "search",
@@ -48,6 +50,7 @@ const pipelineStages = [
     code: "mei",
     title: "7. MEI",
     description: "Define o público MEI/autônomo dono-operador do nicho.",
+    usesAiModel: true,
   },
   {
     code: "quality",
@@ -242,6 +245,22 @@ function inferFailureStageIndex(errorMessage?: string | null) {
     return 8;
   }
   return undefined;
+}
+
+function stageCardClassName(stateClassName: string) {
+  if (stateClassName.includes("border-success")) {
+    return `${stateClassName} bg-success-subtle`;
+  }
+  if (stateClassName.includes("border-primary")) {
+    return `${stateClassName} bg-primary-subtle`;
+  }
+  if (stateClassName.includes("border-warning")) {
+    return `${stateClassName} bg-warning-subtle`;
+  }
+  if (stateClassName.includes("border-danger")) {
+    return `${stateClassName} bg-danger-subtle`;
+  }
+  return `${stateClassName} bg-body-tertiary`;
 }
 
 function inferStageState(
@@ -547,10 +566,24 @@ export default function OprmCnaeDetailPlaceholderPage() {
               const state = inferStageState(index, latestCycle);
               return (
                 <div className="col-md-4" key={stage.title}>
-                  <div className={`card h-100 ${state.className}`}>
+                  <div
+                    className={`card h-100 ${stageCardClassName(state.className)}`}
+                  >
                     <div className="card-body">
                       <div className="d-flex justify-content-between gap-2 mb-2">
-                        <h3 className="h6 mb-0">{stage.title}</h3>
+                        <div className="d-flex align-items-center gap-2">
+                          <h3 className="h6 mb-0">{stage.title}</h3>
+                          {stage.usesAiModel ? (
+                            <span
+                              className="badge text-bg-primary d-inline-flex align-items-center gap-1"
+                              title="Etapa com uso direto de IA"
+                              aria-label="Etapa com uso direto de IA"
+                            >
+                              <Sparkles size={14} aria-hidden="true" />
+                              IA
+                            </span>
+                          ) : null}
+                        </div>
                         <span className="badge text-bg-light">
                           {state.label}
                         </span>


### PR DESCRIPTION
### Motivation

- Improve operational visibility by visually marking pipeline stages that use AI and by making status differences more immediately readable with soft background colors.
- Prevent ambiguity when diagnosing failures or blocked quality gates by adding hierarchy between completed, running, blocked/failed and queued states in the CNAE pipeline UI.

### Description

- Added `usesAiModel` flags to the `pipelineStages` list and marked `seed` and `mei` as AI-consuming stages. 
- Introduced the `stageCardClassName` helper to map existing `className` status indicators to subtle background variants like `bg-success-subtle`, `bg-primary-subtle`, `bg-warning-subtle` and `bg-danger-subtle` and applied it to each stage card. 
- Rendered an IA badge using the `Sparkles` icon for stages with `usesAiModel` and added `title`/`aria-label` to the badge for accessibility. 
- Updated `OprmCnaeDetailPlaceholderPage.test.tsx` to call `cleanup()`, added a new test asserting background classes and the IA badge presence, and adjusted fetch stubs to exercise the new visuals. 
- Documented the UI change in `docs/registros/oprm1.md` under the 2026-06-13 notes.

### Testing

- Ran the frontend unit test suite with `vitest`, including the updated `OprmCnaeDetailPlaceholderPage` tests, and all tests completed successfully. 
- The new visual-regression-like assertions for class names and `aria-label` passed under the test harness.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2d354f8a4c83219ddb475b89fb548f)