### PR TITLE
docs: consolidate and redirect obsolete experiment/pipeline canonical references

### DIFF
--- a/docs/canonical/avatar-sales-video-canonical-rules.md
+++ b/docs/canonical/avatar-sales-video-canonical-rules.md
@@ -184,6 +184,6 @@ Mudanças que flexibilizem ética/evidência exigem revisão humana explícita.
 Este documento complementa e deve ser usado junto com:
 
 - `docs/canonical/system-governance-canon.v2.md`
-- `docs/canonical/modelo-canonico-artefatos-pipeline-experimento.md`
+- `docs/canonical/pipeline-operacional-canon.v1.md`
 
 Em caso de conflito operacional geral, prevalece o `system-governance-canon.v2.md`; em caso de conteúdo específico de avatar de venda, prevalece este documento no escopo do módulo.

--- a/docs/canonical/lhm-evolution-guide.v1.md
+++ b/docs/canonical/lhm-evolution-guide.v1.md
@@ -19,7 +19,7 @@ Leitura obrigatória antes de qualquer alteração em:
 ## 3. Checklist obrigatório de evolução do LHM
 
 1. **Revalidar contrato canônico vigente**
-   - Ler `docs/canonical/modelo-canonico-artefatos-pipeline-experimento.md` (seção `landingPageHtml`).
+   - Ler `docs/canonical/procedimento-experimento-canon.v1.md` (seção do contrato operacional de `landingPageHtml`).
    - Confirmar requisitos obrigatórios do runtime (`submit` assíncrono, validação, loading, feedback inline).
 
 2. **Aplicar evolução orientada a contrato (não por heurística local)**

--- a/docs/canonical/mois-worker-canon.v1.md
+++ b/docs/canonical/mois-worker-canon.v1.md
@@ -116,8 +116,9 @@ Este documento é o único cânone ativo para o worker do MOIS.
 
 ## 11. Referências normativas
 - `docs/canonical/system-governance-canon.v2.md`
-- `docs/canonical/modelo-canonico-artefatos-pipeline-experimento.md`
-- `docs/canonical/experiments-automation-flow-canon.v1.md`
+- `docs/canonical/pipeline-operacional-canon.v1.md`
+
+O MOIS Worker segue as regras gerais de governança e operação de pipelines, mas não depende dos cânones legados específicos do pipeline de experimento. Regras específicas de experimento só se aplicam ao MOIS quando forem explicitamente incorporadas neste documento.
 
 ## 12. Fluxo canônico de alimentação da biblioteca de páginas de vendas
 

--- a/docs/canonical/procedimento-experimento-canon.v1.md
+++ b/docs/canonical/procedimento-experimento-canon.v1.md
@@ -167,7 +167,23 @@ A etapa `landing-page-quality-review` deve avaliar o artefato final publicável 
 
 O prompt textual do Quality Review não deve receber `experiment.landing_page_html` como fallback legado, nem JSONs intermediários de wireframe, copy, image planning, image generation ou design preset. A causa-raiz apontada pelo Quality Review deve ser inferida apenas a partir do HTML final e da evidência visual renderizada, preservando o foco no artefato que será publicado e evitando falhas quando `landing_page_html` ainda estiver nulo antes da aprovação/publicação.
 
-### 5.7 Worker AI — divisão equivalente por etapa (obrigatória)
+### 5.7 Contrato operacional de `landingPageHtml`
+
+A etapa `LANDING_PAGE_HTML` / `landingPageHtml` deve gerar um documento HTML final completo, publicável e livre de metadados técnicos internos. A resposta do gerador deve ser HTML puro; envelopes como `{ "landingPageHtml": { "htmlDocument": "..." } }` são quebra de contrato da etapa.
+
+O HTML final da landing deve implementar, no mínimo:
+- listener de `submit` no formulário alvo;
+- `event.preventDefault()`;
+- gate de validação com `checkValidity()` e `reportValidity()`;
+- envio assíncrono com `fetch(form.action, ...)`;
+- payload usando `new FormData(form)`;
+- controle de loading no botão de submit, desabilitando durante a requisição e restaurando depois;
+- feedback inline de sucesso/erro ao usuário;
+- acabamento visual do feedback como banner/card coerente com `landingPageDesignPreset`, incluindo fundo semântico, borda sutil, espaçamento, contraste AA e leitura clara no mobile.
+
+A geração deve preservar a paridade entre variantes públicas quando houver geração dupla de landing: a mesma entrada canônica e as mesmas validações críticas devem ser aplicadas às variantes `deterministic` e `ai`, mantendo comparabilidade comercial entre os outputs.
+
+### 5.8 Worker AI — divisão equivalente por etapa (obrigatória)
 
 No `ai-worker`, a mesma divisão por etapa deve ser mantida para evitar acoplamento entre execução,
 prompt e schema. A arquitetura canônica vigente para qualquer etapa de landing no Worker AI é o núcleo

--- a/docs/canonical/system-governance-canon.v2.md
+++ b/docs/canonical/system-governance-canon.v2.md
@@ -151,8 +151,8 @@ Regra prática:
 ```text
 docs/canonical/
 ├─ system-governance-canon.v2.md              # documento-mãe
-├─ experiments-canon.v1.md                    # estados e contratos do pipeline de experimentos
-├─ experiments-automation-flow-canon.v1.md    # ordem e estados da fila automática do pipeline
+├─ procedimento-experimento-canon.v1.md        # procedimento ponta a ponta dos experimentos
+├─ pipeline-operacional-canon.v1.md            # padrão operacional de pipelines, etapas e filas
 ├─ experiments-decision-schema.v1.json        # schema machine-readable para validações automáticas
 ├─ lead-capture-canon.v1.md                   # fluxos do Lead Portal, packages e payments
 ├─ media-packages-canon.v1.md                 # lifecycle watermark → zip → email → entrega

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -4471,3 +4471,8 @@
 
 - Criado o documento canônico `docs/canonical/pipeline-operacional-canon.v1.md` para definir o padrão de implementação de pipelines usando o GeraLanding como referência.
 - O documento consolida regras de etapas, arquitetura backend/worker, encadeamento, estados, formato de telas, cards, validações, diagnóstico de causa-raiz e checklist de PR.
+
+## 2026-06-13 — Consolidação de referências canônicas ativas
+- Revisadas referências ativas aos cânones obsoletos `modelo-canonico-artefatos-pipeline-experimento.md` e `experiments-automation-flow-canon.v1.md`.
+- Regras válidas de `landingPageHtml` foram consolidadas em `docs/canonical/procedimento-experimento-canon.v1.md`.
+- Referências operacionais gerais foram redirecionadas para `docs/canonical/pipeline-operacional-canon.v1.md` e referências não aplicáveis ao MOIS foram removidas.


### PR DESCRIPTION
### Motivation
- Remove active document dependencies on obsolete canon files under `docs/canonical/obsoletos` and prevent future drift between code and documentation. 
- Consolidate the still-valid `landingPageHtml` contract in a single active canonical (`procedimento-experimento-canon.v1.md`) so runtimes and reviewers have one source of truth. 
- Redirect normative pointers to the new/active pipeline canon (`pipeline-operacional-canon.v1.md`) and remove inappropriate normative coupling from the MOIS worker to legacy experiment artifacts.

### Description
- Updated `docs/canonical/procedimento-experimento-canon.v1.md` to include a clear, active `landingPageHtml` contract (HTML-pure response requirement, submit behavior, validation, async submit, loading control, inline feedback and parity between `deterministic`/`ai` variants). 
- Replaced obsolete references in `docs/canonical/lhm-evolution-guide.v1.md` to point at the active `procedimento-experimento-canon.v1.md` section for `landingPageHtml`. 
- Redirected `docs/canonical/avatar-sales-video-canonical-rules.md` to reference `docs/canonical/pipeline-operacional-canon.v1.md` instead of the obsoleted artefacts document. 
- Removed legacy experiment-specific normative references from `docs/canonical/mois-worker-canon.v1.md` and added an explicit note that MOIS follows general governance/pipeline canons unless experiment rules are incorporated into the MOIS canon. 
- Updated `docs/canonical/system-governance-canon.v2.md` structure to list the active `procedimento-experimento-canon.v1.md` and `pipeline-operacional-canon.v1.md` entries instead of obsolete experiment automations. 
- Appended an entry to `docs/registros/experimentos.md` recording the consolidation activity and rationale. 
- Ensured no active document points into `docs/canonical/obsoletos` for the two problematic canon files by updating the documents listed above. 

### Testing
- Ran a repository-wide search to confirm removal of active references: `rg -n "modelo-canonico-artefatos-pipeline-experimento|experiments-automation-flow-canon\.v1|docs/canonical/obsoletos" docs/canonical --glob '!obsoletos/**' --glob '!**/obsoletos/**'`, which returned no active-document matches after edits. (Succeeded)
- Reviewed diffs with `git diff` for `docs/canonical/*` changes to validate the exact replacements and inserted `landingPageHtml` contract text. (Succeeded)
- Verified repository status with `git status --short` to confirm the intended files were updated. (Succeeded)

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2d3fd512b483218cbd7957eca7b18f)