### PR TITLE
OPRM: strengthen pipeline card contrast and add Web badges for search/fetch stages

### DIFF
--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -1,3 +1,18 @@
+## 2026-06-13 — OPRM NichoCNAE: registro de efeito perceptivo das cores antigas
+
+- Registrado ponto de pesquisa futura sobre as cores antigas dos cards do pipeline: `bg-success-subtle` (`#d1e7dd`) para concluído e `bg-primary-subtle` (`#cfe2ff`) para em execução criavam um efeito visual interessante; de perto pareciam muito semelhantes, mas de longe a diferença entre verde claro e azul claro ficava mais perceptível.
+- Hipótese para investigar depois: esse comportamento pode estar ligado a contraste cromático de baixa saturação, distância de observação, mistura óptica e percepção periférica, podendo ser útil para interfaces que precisam indicar estados sem gerar poluição visual.
+
+## 2026-06-13 — OPRM NichoCNAE: ícones para etapas com pesquisa na internet
+
+- Adicionados ícones/selo `Web` nas etapas `Busca` e `Coleta` da tela `/oprm/cnaes/:cnaeCode`, deixando claro quais fases acessam a internet para pesquisar e coletar fontes públicas.
+- Causa-raiz tratada: a tela diferenciava uso de IA, mas não indicava visualmente as etapas que dependem de pesquisa externa na internet, reduzindo clareza operacional durante acompanhamento do pipeline.
+
+## 2026-06-13 — OPRM NichoCNAE: contraste visual dos cards de execução
+
+- Ajustada a tela `/oprm/cnaes/:cnaeCode` para diferenciar claramente cards concluídos e em execução: concluído passou a usar fundo verde sólido com texto claro, enquanto etapa em execução permanece em azul claro com borda reforçada.
+- Causa-raiz tratada: os dois estados usavam fundos leves muito próximos, reduzindo a leitura operacional rápida do andamento do pipeline.
+
 ## 2026-06-12 — OPRM CNAE: detalhe acionável com pipeline NichoCNAE
 
 - Evoluída a tela `/oprm/cnaes/:cnaeCode` para exibir descrição do CNAE, score OPRM, componentes do score, quantidade de estabelecimentos, empresas e MEIs.

--- a/frontend/src/pages/oprm/OprmCnaeDetailPlaceholderPage.test.tsx
+++ b/frontend/src/pages/oprm/OprmCnaeDetailPlaceholderPage.test.tsx
@@ -136,7 +136,7 @@ describe("OprmCnaeDetailPlaceholderPage", () => {
     expect(screen.queryByText("Em execução")).toBeNull();
   });
 
-  it("diferencia visualmente os cards por status com fundos leves", async () => {
+  it("diferencia visualmente os cards concluídos e em execução por contraste forte", async () => {
     vi.stubGlobal(
       "fetch",
       vi.fn(async (input: RequestInfo | URL) => {
@@ -176,15 +176,31 @@ describe("OprmCnaeDetailPlaceholderPage", () => {
     await screen.findByText(/status atual:/i);
 
     const seedCard = screen.getByText("2. Seed");
-    expect(seedCard.closest(".card")?.className).toContain("bg-success-subtle");
+    expect(seedCard.closest(".card")?.className).toContain("bg-success");
+    expect(seedCard.closest(".card")?.className).toContain("text-white");
     expect(
       within(seedCard.closest(".card") as HTMLElement).getByLabelText(
         "Etapa com uso direto de IA",
       ),
     ).toBeTruthy();
 
+    const searchCard = screen.getByText("3. Busca").closest(".card");
+    expect(
+      within(searchCard as HTMLElement).getByLabelText(
+        "Etapa que acessa a internet para pesquisar fontes",
+      ),
+    ).toBeTruthy();
+
+    const fetchCard = screen.getByText("4. Coleta").closest(".card");
+    expect(
+      within(fetchCard as HTMLElement).getByLabelText(
+        "Etapa que acessa a internet para pesquisar fontes",
+      ),
+    ).toBeTruthy();
+
     const synthesisCard = screen.getByText("6. Síntese").closest(".card");
     expect(synthesisCard?.className).toContain("bg-primary-subtle");
+    expect(synthesisCard?.className).toContain("border-2");
 
     const meiCard = screen.getByText("7. MEI").closest(".card");
     expect(meiCard?.className).toContain("bg-body-tertiary");

--- a/frontend/src/pages/oprm/OprmCnaeDetailPlaceholderPage.tsx
+++ b/frontend/src/pages/oprm/OprmCnaeDetailPlaceholderPage.tsx
@@ -1,4 +1,4 @@
-import { Sparkles } from "lucide-react";
+import { Globe2, Sparkles } from "lucide-react";
 import { Link, useParams } from "react-router-dom";
 import {
   useOprmCnaeScore,
@@ -30,11 +30,13 @@ const pipelineStages = [
     title: "3. Busca",
     description:
       "Procura fontes públicas sobre rotina, tarefas e dificuldades.",
+    usesInternetResearch: true,
   },
   {
     code: "fetch",
     title: "4. Coleta",
     description: "Coleta metadados e trechos úteis das fontes selecionadas.",
+    usesInternetResearch: true,
   },
   {
     code: "signals",
@@ -249,18 +251,32 @@ function inferFailureStageIndex(errorMessage?: string | null) {
 
 function stageCardClassName(stateClassName: string) {
   if (stateClassName.includes("border-success")) {
-    return `${stateClassName} bg-success-subtle`;
+    return "border-success bg-success text-white shadow-sm";
   }
   if (stateClassName.includes("border-primary")) {
-    return `${stateClassName} bg-primary-subtle`;
+    return `${stateClassName} bg-primary-subtle border-2`;
   }
   if (stateClassName.includes("border-warning")) {
-    return `${stateClassName} bg-warning-subtle`;
+    return `${stateClassName} bg-warning-subtle border-2`;
   }
   if (stateClassName.includes("border-danger")) {
-    return `${stateClassName} bg-danger-subtle`;
+    return `${stateClassName} bg-danger-subtle border-2`;
   }
   return `${stateClassName} bg-body-tertiary`;
+}
+
+function stageDescriptionClassName(stateClassName: string) {
+  if (stateClassName.includes("border-success")) {
+    return "small text-white-50 mb-3";
+  }
+  return "small text-secondary mb-3";
+}
+
+function stageDetailButtonClassName(stateClassName: string) {
+  if (stateClassName.includes("border-success")) {
+    return "btn btn-light btn-sm";
+  }
+  return "btn btn-outline-primary btn-sm";
 }
 
 function inferStageState(
@@ -583,17 +599,27 @@ export default function OprmCnaeDetailPlaceholderPage() {
                               IA
                             </span>
                           ) : null}
+                          {stage.usesInternetResearch ? (
+                            <span
+                              className="badge text-bg-info d-inline-flex align-items-center gap-1"
+                              title="Etapa que acessa a internet para pesquisar fontes"
+                              aria-label="Etapa que acessa a internet para pesquisar fontes"
+                            >
+                              <Globe2 size={14} aria-hidden="true" />
+                              Web
+                            </span>
+                          ) : null}
                         </div>
                         <span className="badge text-bg-light">
                           {state.label}
                         </span>
                       </div>
-                      <p className="small text-secondary mb-3">
+                      <p className={stageDescriptionClassName(state.className)}>
                         {stage.description}
                       </p>
                       {latestCycle ? (
                         <Link
-                          className="btn btn-outline-primary btn-sm"
+                          className={stageDetailButtonClassName(state.className)}
                           to={`/oprm/cnaes/${encodeURIComponent(decodedCnaeCode)}/pipeline/${latestCycle.researchCycleId}/stages/${stage.code}`}
                         >
                           Ver detalhes


### PR DESCRIPTION
### Motivation

- The pipeline detail UI used very similar subtle backgrounds for completed and running stages, which reduced quick readability and introduced a perceptual ambiguity with low-saturation colors.  
- The UI did not visually indicate which stages perform external internet research, reducing operational clarity when following the pipeline.  
- A docs note was added to record observations about the perceptual behavior of the old subtle color backgrounds for future investigation.  

### Description

- Updated documentation `docs/registros/oprm1.md` with entries about color-perception observations, the addition of Web icons for research stages, and the decision to increase visual contrast for completed vs running cards.  
- In `OprmCnaeDetailPlaceholderPage.tsx` imported `Globe2`, added `usesInternetResearch` flags to the `pipelineStages` for `search` and `fetch`, and rendered a `Web` badge (with `Globe2` icon and `aria-label`) when the flag is present.  
- Reworked `stageCardClassName` to use a solid green (`bg-success` + `text-white`) for completed states and to add stronger borders (`border-2`) for primary/warning/danger states, and added `stageDescriptionClassName` and `stageDetailButtonClassName` helpers to adapt text and button styles according to state.  
- Updated `OprmCnaeDetailPlaceholderPage.test.tsx` to reflect the new class names, badges and labels, renaming the test and adjusting assertions to expect `bg-success`, `text-white`, `border-2`, and the `Web` badge on search/fetch stages.  

### Testing

- Ran the frontend component unit tests (Vitest) including `OprmCnaeDetailPlaceholderPage.test.tsx`, and the updated tests passed.  
- No backend behavior was changed and no other automated test suites were affected by these UI-only changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2d3caa25cc83219e9494aedd82d4f2)