### PR TITLE
fix(oprm): use configured model in MEI segmenter

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/meiaudiencesegmenter/service/BackendMeiAudienceSegmenterService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/meiaudiencesegmenter/service/BackendMeiAudienceSegmenterService.java
@@ -49,6 +49,7 @@ public class BackendMeiAudienceSegmenterService {
   private final OprmExtractedSignalRepository extractedSignalRepository;
   private final OprmSourceSnapshotRepository sourceSnapshotRepository;
   private final BackendMeiAudienceProfileService profileService;
+  private final MeiAudienceSegmenterConfigurationGateway configurationGateway;
 
   /** Inicializa o serviço com repositórios e serviço de perfil canônico usados pela etapa de segmentação. */
   public BackendMeiAudienceSegmenterService(
@@ -56,12 +57,14 @@ public class BackendMeiAudienceSegmenterService {
       OprmNicheRoutineCardRepository routineCardRepository,
       OprmExtractedSignalRepository extractedSignalRepository,
       OprmSourceSnapshotRepository sourceSnapshotRepository,
-      BackendMeiAudienceProfileService profileService) {
+      BackendMeiAudienceProfileService profileService,
+      MeiAudienceSegmenterConfigurationGateway configurationGateway) {
     this.routineResearchCycleRepository = routineResearchCycleRepository;
     this.routineCardRepository = routineCardRepository;
     this.extractedSignalRepository = extractedSignalRepository;
     this.sourceSnapshotRepository = sourceSnapshotRepository;
     this.profileService = profileService;
+    this.configurationGateway = configurationGateway;
   }
 
   /** Lista somente cartões de ciclos ativos e elegíveis para segmentação comportamental antes do gate e materialização. */
@@ -133,6 +136,7 @@ public class BackendMeiAudienceSegmenterService {
   private RecordMeiAudienceSegmenterPending toPending(OprmNicheRoutineCard card, OprmRoutineResearchCycle cycle) {
     List<OprmSourceSnapshot> snapshots = sourceSnapshotRepository.findByResearchCycleIdOrderByIdAsc(card.getResearchCycleId());
     List<OprmExtractedSignal> signals = extractedSignalRepository.findByResearchCycleIdOrderByIdAsc(card.getResearchCycleId());
+    Optional<MeiAudienceSegmenterModel> configuredModel = resolveConfiguredOpenAiModel();
     return new RecordMeiAudienceSegmenterPending(
         cycle.getId(),
         card.getId(),
@@ -141,6 +145,8 @@ public class BackendMeiAudienceSegmenterService {
         cycle.getCnaeDescription(),
         cycle.getNeutralNicheName(),
         card.getNicheName(),
+        configuredModel.map(MeiAudienceSegmenterModel::code).orElse(null),
+        configuredModel.map(MeiAudienceSegmenterModel::name).orElse(null),
         card.getRoutineSummary(),
         card.getCustomerBehaviorSummary(),
         card.getChannelsSummary(),
@@ -160,6 +166,12 @@ public class BackendMeiAudienceSegmenterService {
         card.getCreatedAt(),
         snapshots.stream().sorted(Comparator.comparing(OprmSourceSnapshot::getId)).limit(MAX_SOURCES).map(this::toSource).toList(),
         signals.stream().sorted(Comparator.comparing(OprmExtractedSignal::getId)).limit(MAX_SIGNALS).map(this::toSignal).toList());
+  }
+
+
+  /** Recupera o modelo configurado para a etapa MEI/autônomo sem bloquear a fila quando ausente. */
+  private Optional<MeiAudienceSegmenterModel> resolveConfiguredOpenAiModel() {
+    return configurationGateway.findConfiguredModel();
   }
 
   /** Converte snapshot persistido em fonte curta com indicadores de atualidade e aderência. */

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/meiaudiencesegmenter/service/MeiAudienceSegmenterConfigurationGateway.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/meiaudiencesegmenter/service/MeiAudienceSegmenterConfigurationGateway.java
@@ -1,0 +1,10 @@
+package com.marketinghub.oprm.nichocnae.meiaudiencesegmenter.service;
+
+import java.util.Optional;
+
+/** Define o contrato OPRM para consultar a configuração de IA da etapa de segmentação MEI/autônomo. */
+public interface MeiAudienceSegmenterConfigurationGateway {
+
+  /** Recupera o modelo de IA configurado para a etapa de segmentação MEI/autônomo do pipeline OPRM nicho CNAE. */
+  Optional<MeiAudienceSegmenterModel> findConfiguredModel();
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/meiaudiencesegmenter/service/MeiAudienceSegmenterModel.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/meiaudiencesegmenter/service/MeiAudienceSegmenterModel.java
@@ -1,0 +1,4 @@
+package com.marketinghub.oprm.nichocnae.meiaudiencesegmenter.service;
+
+/** Representa o modelo de IA configurado para a etapa de segmentação MEI/autônomo do OPRM. */
+public record MeiAudienceSegmenterModel(String code, String name) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/meiaudiencesegmenter/service/pending/RecordMeiAudienceSegmenterPending.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/meiaudiencesegmenter/service/pending/RecordMeiAudienceSegmenterPending.java
@@ -12,6 +12,8 @@ public record RecordMeiAudienceSegmenterPending(
     String cnaeDescription,
     String neutralNicheName,
     String nicheName,
+    String openAiModelCode,
+    String openAiModelName,
     String routineSummary,
     String customerBehaviorSummary,
     String channelsSummary,

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/oprm/nichocnae/meiaudiencesegmenter/JpaMeiAudienceSegmenterConfigurationGateway.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/oprm/nichocnae/meiaudiencesegmenter/JpaMeiAudienceSegmenterConfigurationGateway.java
@@ -1,0 +1,52 @@
+package com.marketinghub.repository.jpa.oprm.nichocnae.meiaudiencesegmenter;
+
+import com.marketinghub.openai.OpenAiModel;
+import com.marketinghub.oprm.nichocnae.meiaudiencesegmenter.service.MeiAudienceSegmenterConfigurationGateway;
+import com.marketinghub.oprm.nichocnae.meiaudiencesegmenter.service.MeiAudienceSegmenterModel;
+import com.marketinghub.repository.jpa.pipeline.PipelineStageConfigRepository;
+import com.marketinghub.repository.jpa.pipeline.PipelineStageRepository;
+import java.util.Optional;
+import org.springframework.stereotype.Component;
+
+/** Implementa a leitura do modelo configurado para a etapa MEI usando o contrato canônico de pipeline. */
+@Component
+public class JpaMeiAudienceSegmenterConfigurationGateway implements MeiAudienceSegmenterConfigurationGateway {
+  private static final String OPRM_NICHO_CNAE_PIPELINE_CODE = "oprm-nicho-cnae-pipeline";
+  private static final String OPRM_NICHO_CNAE_CANONICAL_VERSION = "oprm-nichocnae-canon.v1";
+  private static final String MEI_AUDIENCE_CANONICAL_CODE = "MEI_AUDIENCE_SEGMENTER";
+  private static final String MEI_AUDIENCE_STAGE_CODE = "mei-audience-segmenter";
+  private final PipelineStageConfigRepository pipelineStageConfigRepository;
+  private final PipelineStageRepository pipelineStageRepository;
+
+  /** Inicializa o gateway com os repositórios canônicos de configuração de pipeline. */
+  public JpaMeiAudienceSegmenterConfigurationGateway(
+      PipelineStageConfigRepository pipelineStageConfigRepository, PipelineStageRepository pipelineStageRepository) {
+    this.pipelineStageConfigRepository = pipelineStageConfigRepository;
+    this.pipelineStageRepository = pipelineStageRepository;
+  }
+
+  /** Recupera o modelo configurado priorizando a configuração oficial versionada e mantendo fallback operacional legado. */
+  @Override
+  public Optional<MeiAudienceSegmenterModel> findConfiguredModel() {
+    return findPersistentConfiguredModel().or(this::findLegacyConfiguredModel).map(this::toOprmModel);
+  }
+
+  /** Busca o modelo na configuração oficial versionada do pipeline OPRM nicho CNAE. */
+  private Optional<OpenAiModel> findPersistentConfiguredModel() {
+    return pipelineStageConfigRepository
+        .findOfficialStageConfig(OPRM_NICHO_CNAE_PIPELINE_CODE, OPRM_NICHO_CNAE_CANONICAL_VERSION, MEI_AUDIENCE_CANONICAL_CODE)
+        .map(config -> config.getOpenAiModel());
+  }
+
+  /** Busca o modelo na configuração operacional legada da etapa para preservar compatibilidade. */
+  private Optional<OpenAiModel> findLegacyConfiguredModel() {
+    return pipelineStageRepository
+        .findByPipelineCodeAndStageCode(OPRM_NICHO_CNAE_PIPELINE_CODE, MEI_AUDIENCE_STAGE_CODE)
+        .map(stage -> stage.getOpenAiModel());
+  }
+
+  /** Converte o modelo canônico OpenAI para o contrato interno permitido no OPRM. */
+  private MeiAudienceSegmenterModel toOprmModel(OpenAiModel model) {
+    return new MeiAudienceSegmenterModel(model.getCode(), model.getName());
+  }
+}

--- a/backend/ads-service/src/test/java/com/marketinghub/oprm/nichocnae/meiaudiencesegmenter/service/BackendMeiAudienceSegmenterServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/oprm/nichocnae/meiaudiencesegmenter/service/BackendMeiAudienceSegmenterServiceTest.java
@@ -25,12 +25,14 @@ class BackendMeiAudienceSegmenterServiceTest {
   private final OprmExtractedSignalRepository extractedSignalRepository = mock(OprmExtractedSignalRepository.class);
   private final OprmSourceSnapshotRepository sourceSnapshotRepository = mock(OprmSourceSnapshotRepository.class);
   private final BackendMeiAudienceProfileService profileService = mock(BackendMeiAudienceProfileService.class);
+  private final MeiAudienceSegmenterConfigurationGateway configurationGateway = mock(MeiAudienceSegmenterConfigurationGateway.class);
   private final BackendMeiAudienceSegmenterService service = new BackendMeiAudienceSegmenterService(
       cycleRepository,
       routineCardRepository,
       extractedSignalRepository,
       sourceSnapshotRepository,
-      profileService);
+      profileService,
+      configurationGateway);
 
   /** Garante que o serviço não exponha cartões caso a consulta retorne ciclo fora do status elegível. */
   @Test
@@ -43,10 +45,12 @@ class BackendMeiAudienceSegmenterServiceTest {
     when(cycleRepository.findById(20L)).thenReturn(Optional.of(cycle(20L, "ROUTINE_SYNTHESIZED")));
     when(sourceSnapshotRepository.findByResearchCycleIdOrderByIdAsc(20L)).thenReturn(List.of());
     when(extractedSignalRepository.findByResearchCycleIdOrderByIdAsc(20L)).thenReturn(List.of());
+    when(configurationGateway.findConfiguredModel()).thenReturn(Optional.of(new MeiAudienceSegmenterModel("gpt-5.4", "GPT-5.4")));
 
     assertThat(service.listPending())
         .extracting(pending -> pending.researchCycleId())
         .containsExactly(20L);
+    assertThat(service.listPending().get(0).openAiModelCode()).isEqualTo("gpt-5.4");
   }
 
   /** Monta um ciclo mínimo usado pela revalidação da fila MEI/autônomo. */

--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -587,3 +587,9 @@
 - Ajustada a tela de detalhe do CNAE para marcar visualmente os cards das etapas que acessam diretamente IA no pipeline NichoCNAE e aplicar fundos leves por status operacional.
 - Foram sinalizadas as etapas `Seed` e `MEI`, alinhadas ao cânone OPRM que define apenas `niche-research-seed-builder` e `mei-audience-segmenter` como consumidoras diretas de modelo OpenAI configurável.
 - Causa-raiz tratada: a tela operacional mostrava o estado da execução, mas não diferenciava rapidamente as etapas que dependem de IA nem criava hierarquia visual suficiente entre concluído, execução, bloqueio/falha e fila, dificultando o diagnóstico de falhas e decisões operacionais.
+
+## 2026-06-13 — OPRM MEI: uso do modelo configurado no pipeline
+
+- Causa-raiz corrigida: a etapa `mei-audience-segmenter` era marcada como IA configurável na tela de pipeline, mas o backend não enviava o modelo configurado na pendência da etapa e o coletor usava o fallback local `gpt-4.1-mini`.
+- Correção aplicada: o backend agora lê o modelo configurado na configuração oficial/legada do pipeline OPRM NichoCNAE e envia `openAiModelCode/openAiModelName` para o coletor; o coletor passa a priorizar esse modelo ao montar a chamada para a OpenAI.
+- Prevenção de recorrência: adicionados testes cobrindo a fila backend da segmentação MEI e a resolução de modelo no cliente OpenAI do coletor, além de remover da tela de detalhe o fallback visual fixo que sugeria `gpt-4.1-mini` quando não havia telemetria persistida.

--- a/frontend/src/pages/oprm/OprmCnaePipelineStageDetailPage.tsx
+++ b/frontend/src/pages/oprm/OprmCnaePipelineStageDetailPage.tsx
@@ -4,6 +4,7 @@ import {
   type OprmCnaePipelineStageCode,
   useOprmCnaePipelineStageDetail,
 } from "../../api/oprm/useOprmCnaePipelineStageDetail";
+import { usePipelines } from "../../api/pipeline/usePipelines";
 import { useBreadcrumbs } from "../../app/breadcrumbs";
 import PageTitle from "../../components/PageTitle";
 import OprmModuleNavigation from "./OprmModuleNavigation";
@@ -47,7 +48,6 @@ const stageMetadataByCode: Record<OprmCnaePipelineStageCode, StageMetadata> = {
       "Queries priorizadas com objetivo, grupo de fonte, status e contador de resultados.",
     ],
     usesAiModel: true,
-    aiModel: "gpt-4.1-mini",
     aiRequestSummary:
       "Request para OpenAI Responses API com prompt de pesquisa de rotina real e schema JSON estruturado para seed e queries.",
     aiResponseSummary:
@@ -117,7 +117,6 @@ const stageMetadataByCode: Record<OprmCnaePipelineStageCode, StageMetadata> = {
       "Scores de aderência autônoma, evidência comportamental, frescor da fonte e riscos de desvio corporativo/solução.",
     ],
     usesAiModel: true,
-    aiModel: "gpt-4.1-mini",
     aiRequestSummary:
       "Request para OpenAI Responses API com cartão de rotina, fontes e sinais para segmentar o público MEI/autônomo real.",
     aiResponseSummary:
@@ -168,14 +167,14 @@ function textValue(value: unknown) {
   return String(value);
 }
 
-function buildAiTelemetry(metadata: StageMetadata, data: unknown) {
+function buildAiTelemetry(metadata: StageMetadata, data: unknown, configuredModel?: string | null) {
   if (!metadata.usesAiModel) {
     return null;
   }
   const payload = asRecord(data);
   const seed = asRecord(payload?.seed) ?? payload;
   return {
-    modelo: textValue(seed?.model ?? metadata.aiModel),
+    modelo: textValue(seed?.model ?? configuredModel ?? metadata.aiModel ?? "modelo configurado na tela de pipeline"),
     request: metadata.aiRequestSummary,
     response: textValue(seed?.openAiResponseId ?? metadata.aiResponseSummary),
     tokensEntrada: textValue(seed?.inputTokens),
@@ -201,7 +200,21 @@ export default function OprmCnaePipelineStageDetailPage() {
     validStageCode,
     isValidCycleId ? cycleId : undefined,
   );
-  const aiTelemetry = metadata ? buildAiTelemetry(metadata, data) : null;
+  const { data: pipelines } = usePipelines();
+  const configuredPipelineModel = metadata
+    ? pipelines
+        ?.find((pipeline) => pipeline.code === "oprm-nicho-cnae-pipeline")
+        ?.stages.find(
+          (stage) =>
+            stage.code === metadata.technicalName ||
+            stage.code === metadata.code ||
+            (stage.code === "mei-audience-segmenter" && metadata.code === "mei") ||
+            (stage.code === "niche-research-seed-builder" && metadata.code === "seed"),
+        )?.openAiModelCode
+    : null;
+  const aiTelemetry = metadata
+    ? buildAiTelemetry(metadata, data, configuredPipelineModel)
+    : null;
 
   useBreadcrumbs([
     { label: "OPRM", to: "/oprm" },

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnae/meiaudiencesegmenter/MeiAudienceSegmenterPending.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnae/meiaudiencesegmenter/MeiAudienceSegmenterPending.java
@@ -12,6 +12,8 @@ public record MeiAudienceSegmenterPending(
         String cnaeDescription,
         String neutralNicheName,
         String nicheName,
+        String openAiModelCode,
+        String openAiModelName,
         String routineSummary,
         String customerBehaviorSummary,
         String channelsSummary,

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnae/meiaudiencesegmenter/OpenAiMeiAudienceSegmenterClient.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnae/meiaudiencesegmenter/OpenAiMeiAudienceSegmenterClient.java
@@ -75,7 +75,8 @@ public class OpenAiMeiAudienceSegmenterClient {
                             + ".");
         }
         String prompt = promptBuilder.buildPrompt(input);
-        Map<String, Object> requestBody = buildRequestBody(prompt);
+        String model = resolveModel(input);
+        Map<String, Object> requestBody = buildRequestBody(prompt, model);
         String url = properties.baseUrl() + RESPONSES_PATH;
         try {
             Map<String, Object> raw = responseBody(url, requestBody, apiKey);
@@ -133,8 +134,16 @@ public class OpenAiMeiAudienceSegmenterClient {
         return response == null ? null : (Map<String, Object>) response;
     }
 
+    /** Resolve o modelo efetivo priorizando a configuração operacional recebida do backend. */
+    String resolveModel(MeiAudienceSegmenterPending input) {
+        if (input != null && input.openAiModelCode() != null && !input.openAiModelCode().isBlank()) {
+            return input.openAiModelCode().trim();
+        }
+        return properties.model();
+    }
+
     /** Monta corpo da Responses API com schema JSON estrito. */
-    private Map<String, Object> buildRequestBody(String prompt) {
+    private Map<String, Object> buildRequestBody(String prompt, String model) {
         Map<String, Object> format = new LinkedHashMap<>();
         format.put("type", "json_schema");
         format.put("name", SCHEMA_NAME);
@@ -145,7 +154,7 @@ public class OpenAiMeiAudienceSegmenterClient {
         text.put("format", format);
 
         Map<String, Object> body = new LinkedHashMap<>();
-        body.put("model", properties.model());
+        body.put("model", model);
         body.put("input", prompt);
         body.put("text", text);
         return body;

--- a/oprm-coletor-mei/src/test/java/com/marketinghub/nichocnae/meiaudiencesegmenter/MeiAudienceSegmenterOperationalGuardTest.java
+++ b/oprm-coletor-mei/src/test/java/com/marketinghub/nichocnae/meiaudiencesegmenter/MeiAudienceSegmenterOperationalGuardTest.java
@@ -99,6 +99,8 @@ class MeiAudienceSegmenterOperationalGuardTest {
                 "Cabeleireiros, manicure e pedicure",
                 "Serviços de beleza",
                 "Beleza MEI",
+                null,
+                null,
                 "Rotina operacional",
                 "Captação por indicação",
                 "Instagram e WhatsApp",

--- a/oprm-coletor-mei/src/test/java/com/marketinghub/nichocnae/meiaudiencesegmenter/MeiAudienceSegmenterValidatorTest.java
+++ b/oprm-coletor-mei/src/test/java/com/marketinghub/nichocnae/meiaudiencesegmenter/MeiAudienceSegmenterValidatorTest.java
@@ -35,6 +35,8 @@ class MeiAudienceSegmenterValidatorTest {
                 "Cabeleireiros, manicure e pedicure",
                 "serviços de beleza",
                 "serviços de beleza",
+                null,
+                null,
                 "rotina com atendimento por agenda e deslocamento",
                 "clientes chegam por indicação e retorno",
                 "WhatsApp e Instagram",

--- a/oprm-coletor-mei/src/test/java/com/marketinghub/nichocnae/meiaudiencesegmenter/OpenAiMeiAudienceSegmenterClientTest.java
+++ b/oprm-coletor-mei/src/test/java/com/marketinghub/nichocnae/meiaudiencesegmenter/OpenAiMeiAudienceSegmenterClientTest.java
@@ -1,0 +1,51 @@
+package com.marketinghub.nichocnae.meiaudiencesegmenter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.client.RestClient;
+
+/** Responsabilidade: validar a montagem operacional da chamada OpenAI da segmentação MEI/autônomo. */
+class OpenAiMeiAudienceSegmenterClientTest {
+
+    /** Garante que o modelo configurado no pipeline e enviado pelo backend tem prioridade sobre o fallback local. */
+    @Test
+    void shouldUsePipelineConfiguredModelBeforeLocalFallback() {
+        OpenAiMeiAudienceSegmenterClient client = client("gpt-4.1-mini");
+
+        assertThat(client.resolveModel(pending("gpt-5.4"))).isEqualTo("gpt-5.4");
+    }
+
+    /** Garante que a etapa continua operável com fallback local quando o backend ainda não enviar modelo. */
+    @Test
+    void shouldUseLocalFallbackWhenPendingHasNoConfiguredModel() {
+        OpenAiMeiAudienceSegmenterClient client = client("gpt-4.1-mini");
+
+        assertThat(client.resolveModel(pending(null))).isEqualTo("gpt-4.1-mini");
+    }
+
+    /** Cria cliente com dependências simuladas para validar apenas resolução de modelo. */
+    private OpenAiMeiAudienceSegmenterClient client(String fallbackModel) {
+        return new OpenAiMeiAudienceSegmenterClient(
+                mock(RestClient.class),
+                new ObjectMapper(),
+                new MeiAudienceSegmenterOpenAiProperties("https://api.openai.com/v1", "key", "", fallbackModel,
+                        "OPRM_MEI_AUDIENCE_SEGMENTER_OPENAI_API_KEY", "OPENAI_API_KEY"),
+                mock(MeiAudienceSegmenterPromptBuilder.class),
+                mock(MeiAudienceSegmenterSchema.class),
+                mock(MeiAudienceSegmenterValidator.class));
+    }
+
+    /** Cria uma pendência mínima com modelo configurável para teste da chamada OpenAI. */
+    private MeiAudienceSegmenterPending pending(String openAiModelCode) {
+        return new MeiAudienceSegmenterPending(
+                1001L, 2002L, 3003L, "9602501", "Cabeleireiros", "Serviços de beleza", "Beleza MEI",
+                openAiModelCode, "Modelo configurado", "Rotina", "Comportamento", "Canais", "Dores operacionais",
+                "Dores emocionais", "Sonhos", "Medos", "Linguagem", "Dores", "Resultados", "Evidências",
+                "example.com", 80, 75, 70, 10, Instant.parse("2026-06-12T00:00:00Z"), List.of(), List.of());
+    }
+}


### PR DESCRIPTION
### Motivation
- Corrigir divergência entre o modelo exibido na tela de pipeline e o modelo efetivamente usado pelo coletor OPRM na etapa MEI, que vinha usando um fallback local em vez do modelo configurado no pipeline. 
- Preservar rastreabilidade operacional e telemetria do modelo (modelo, tokens, custo, openAiResponseId) para auditoria e cálculo de custos. 
- Evitar recorrência adicionando testes de regressão e registrando a causa-raiz no registro OPRM. 

### Description
- Backend: incluiu `openAiModelCode`/`openAiModelName` no contrato interno `RecordMeiAudienceSegmenterPending` e passou a popular esses campos lendo o modelo configurado via um novo gateway `MeiAudienceSegmenterConfigurationGateway` com implementação `JpaMeiAudienceSegmenterConfigurationGateway`. 
- Coletor OPRM: `OpenAiMeiAudienceSegmenterClient` agora prioriza o `openAiModelCode` recebido no `pending` ao montar a chamada à OpenAI e transmite esse modelo no payload da Responses API (substitui o uso direto do fallback local). 
- Frontend: a página de detalhe da etapa (`OprmCnaePipelineStageDetailPage.tsx`) deixou de exibir `gpt-4.1-mini` como fallback fixo quando não há telemetria; ela passa a consultar o pipeline persistido (`usePipelines`) e mostrar o modelo efetivamente configurado na tela de pipeline quando disponível. 
- Testes e documentação: adicionados testes de unidade para garantir que o backend envie o modelo na pendência e que o coletor priorize o modelo do backend (`OpenAiMeiAudienceSegmenterClientTest`), atualizados testes de fila backend (`BackendMeiAudienceSegmenterServiceTest`) e ajustados testes do coletor (`MeiAudienceSegmenterValidatorTest`, `MeiAudienceSegmenterOperationalGuardTest`), e registrado a correção em `docs/registros/oprm1.md`. 

### Testing
- Executado `mvn -Dtest=BackendMeiAudienceSegmenterServiceTest test` no módulo backend e o teste passou com sucesso. 
- Executado `mvn -Dtest=OpenAiMeiAudienceSegmenterClientTest,MeiAudienceSegmenterValidatorTest,MeiAudienceSegmenterOperationalGuardTest test` no módulo `oprm-coletor-mei` e todos os testes passaram com sucesso. 
- Executado `npm run typecheck` no frontend para validar as mudanças de tipagem e integrações com `usePipelines` e o comando completou sem erros (typecheck OK).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2d422932bc83218c39da16e05f79d8)