### PR TITLE
Programar coleta Hotmart de página de vendas para 12:20

### DIFF
--- a/docs/canonical/mois-hotmart-mapeamento-ciclos-campos-banco.md
+++ b/docs/canonical/mois-hotmart-mapeamento-ciclos-campos-banco.md
@@ -193,7 +193,7 @@ Em resumo: o erro normalmente não está na UI; ele nasce na qualidade do campo 
 Agendamento operacional vigente no `mois-hotmart-collector`:
 
 - **Ciclo 1 (listagem):** execução pontual única em **13 de junho de 2026 às 01:35**, no fuso `America/Sao_Paulo`.
-- **Ciclo 2 (detalhes):** execução diária às **17:00**, conforme scheduler vigente do coletor.
+- **Ciclo 2 (detalhes):** próxima execução pontual única em **13 de junho de 2026 às 12:20**, no fuso `America/Sao_Paulo`, conforme scheduler vigente do coletor.
 - O cron do ciclo 1 fica hardcoded no `HotmartCollectorScheduler` para manter rastreabilidade operacional do horário combinado e possui guarda de ano para não repetir após 2026.
 
 Sequência operacional consolidada:

--- a/docs/registros/mois1.md
+++ b/docs/registros/mois1.md
@@ -1580,3 +1580,12 @@ Arquivos principais:
 - Atualizado o deploy do backend para injetar `MOIS_SALES_PAGE_BACKFILL_ENABLED=false` por padrão e alinhado o default interno do backend para evitar execução acidental em novos ambientes.
 - Registrada a regra na Fase 5 do cânone MOIS, exigindo confirmação operacional em logs com `operacao=salesPageBackfill` quando houver reinício/execução.
 
+
+## 2026-06-13 11:58:40 UTC-3
+- solicitada programação da próxima coleta de página de vendas Hotmart para 12:20.
+- a causa operacional é que o ciclo 2 é o responsável por enriquecer os produtos com URL/página de vendas, então o agendamento correto deve ficar no scheduler do ciclo 2.
+- ajustado o ciclo 2 do `mois-hotmart-collector` para execução pontual em 13/06/2026 às 12:20 no timezone `America/Sao_Paulo`, com guarda de ano para evitar repetição futura indevida.
+- atualizado o teste do scheduler e o cânone de mapeamento dos ciclos Hotmart para manter a documentação aderente ao comportamento operacional.
+- documentos lidos para tratar a situação:
+  - docs/canonical/mois-hotmart-mapeamento-ciclos-campos-banco.md
+  - mois-hotmart-collector/AGENTS.md

--- a/mois-hotmart-collector/src/main/java/com/marketinghub/moishotmart/service/HotmartCollectorScheduler.java
+++ b/mois-hotmart-collector/src/main/java/com/marketinghub/moishotmart/service/HotmartCollectorScheduler.java
@@ -67,17 +67,25 @@ public class HotmartCollectorScheduler {
     }
 
     /**
-     * Executa o ciclo 2 de enriquecimento de detalhes diariamente às 17:00.
+     * Executa o ciclo 2 de enriquecimento de detalhes uma única vez às 12:20 em 13 de junho de 2026, no horário de São Paulo.
      */
-    @Scheduled(cron = "0 0 17 * * *")
-    public void collectSecondCycleAtSeventeen() {
+    @Scheduled(cron = "0 20 12 13 6 *", zone = "America/Sao_Paulo")
+    public void collectSecondCycleAtTwelveTwentyOnJuneThirteenth2026() {
         if (!enabled) {
             log.info("Hotmart scheduler desabilitado por configuração.");
             return;
         }
+        int currentYear = ZonedDateTime.now(SAO_PAULO_ZONE).getYear();
+        if (currentYear != 2026) {
+            log.info(
+                    "Hotmart scheduler ciclo 2 ignorado porque o agendamento solicitado é exclusivo de 2026. anoAtual={}",
+                    currentYear);
+            return;
+        }
         HotmartCollectionRequest request = new HotmartCollectionRequest(source, maxProducts);
         HotmartCollectionResponse response = collectorService.collectSecondCycleFromBackend(request);
-        log.info("Hotmart scheduler executado hora=17 ciclo={} status={} produtos={} mensagem={}",
+        log.info("Hotmart scheduler executado hora=12:20 dia=13/06 ano=2026 "
+                        + "timezone=America/Sao_Paulo ciclo={} status={} produtos={} mensagem={}",
                 "CICLO_2_DETALHES",
                 response.status(),
                 response.products().size(),

--- a/mois-hotmart-collector/src/test/java/com/marketinghub/moishotmart/service/HotmartCollectorSchedulerTest.java
+++ b/mois-hotmart-collector/src/test/java/com/marketinghub/moishotmart/service/HotmartCollectorSchedulerTest.java
@@ -23,4 +23,17 @@ class HotmartCollectorSchedulerTest {
         assertEquals("0 35 1 13 6 *", scheduled.cron());
         assertEquals("America/Sao_Paulo", scheduled.zone());
     }
+
+    /**
+     * Garante que o ciclo 2 esteja agendado para 12:20 de 13 de junho de 2026 no fuso de São Paulo.
+     */
+    @Test
+    void shouldScheduleSecondCycleAtTwelveTwentyOnJuneThirteenth() throws NoSuchMethodException {
+        Method method = HotmartCollectorScheduler.class
+                .getDeclaredMethod("collectSecondCycleAtTwelveTwentyOnJuneThirteenth2026");
+        Scheduled scheduled = method.getAnnotation(Scheduled.class);
+
+        assertEquals("0 20 12 13 6 *", scheduled.cron());
+        assertEquals("America/Sao_Paulo", scheduled.zone());
+    }
 }


### PR DESCRIPTION
### Motivation
- Agendar a próxima execução do ciclo 2 (enriquecimento de detalhes) do coletor Hotmart para capturar/atualizar páginas de vendas em horário operacional específico. 
- Garantir rastreabilidade operacional evitando reexecução fora do ano de 2026 usando guarda de ano.
- Manter documentação e registro operacional alinhados ao comportamento do scheduler.

### Description
- Altera o scheduler `HotmartCollectorScheduler` para executar o ciclo 2 uma única vez em `13/06/2026` às `12:20` com cron `"0 20 12 13 6 *"` e fuso `America/Sao_Paulo`, adicionando verificação de ano. (file: `mois-hotmart-collector/src/main/java/com/marketinghub/moishotmart/service/HotmartCollectorScheduler.java`)
- Atualiza o teste `HotmartCollectorSchedulerTest` para validar o novo cron e `zone` do método do ciclo 2. (file: `mois-hotmart-collector/src/test/java/com/marketinghub/moishotmart/service/HotmartCollectorSchedulerTest.java`)
- Atualiza a documentação canônica para indicar a próxima execução pontual do ciclo 2 às `12:20`. (file: `docs/canonical/mois-hotmart-mapeamento-ciclos-campos-banco.md`)
- Adiciona registro operacional resumindo a mudança e a causa no histórico MOIS. (file: `docs/registros/mois1.md`)

### Testing
- Executed `mvn test -Dtest=HotmartCollectorSchedulerTest` which passed and validated the scheduler annotation for the second cycle. 
- Executed full module tests with `mvn test` in `mois-hotmart-collector` which completed successfully (`Tests run: 11, Failures: 0`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2d6fec29408321bf911982c0553e64)