### PR TITLE
Fix MEI audience segmenter Locale compile error

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/meiaudiencesegmenter/service/BackendMeiAudienceSegmenterService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/meiaudiencesegmenter/service/BackendMeiAudienceSegmenterService.java
@@ -18,10 +18,11 @@ import com.marketinghub.repository.jpa.oprm.nichocnae.OprmNicheRoutineCardReposi
 import com.marketinghub.repository.jpa.oprm.nichocnae.OprmRoutineResearchCycleRepository;
 import com.marketinghub.repository.jpa.oprm.nichocnae.OprmSourceSnapshotRepository;
 import jakarta.persistence.EntityNotFoundException;
+import java.text.Normalizer;
 import java.time.Instant;
 import java.util.Comparator;
 import java.util.List;
-import java.text.Normalizer;
+import java.util.Locale;
 import java.util.Optional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -310,7 +311,7 @@ public class BackendMeiAudienceSegmenterService {
 
   /** Normaliza texto para comparação consistente de termos proibidos. */
   private String normalize(String value) {
-    String normalized = Normalizer.normalize(value == null ? "" : value.toLowerCase(java.util.Locale.ROOT), Normalizer.Form.NFD);
+    String normalized = Normalizer.normalize(value == null ? "" : value.toLowerCase(Locale.ROOT), Normalizer.Form.NFD);
     return normalized.replaceAll("\\p{M}+", "").replaceAll("\\s+", " ").trim();
   }
 

--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -631,3 +631,9 @@
 - Causa-raiz tratada: a etapa `mei-audience-segmenter` já bloqueava parte da linguagem de solução, mas o prompt e a pré-validação não reforçavam explicitamente todos os termos de contaminação indireta, como software, IA, automação e ferramenta, antes do envio ao backend.
 - Correção aplicada: o prompt passou a limitar a saída a perfil comportamental (quem é, como trabalha, como consegue clientes, dores, medos, linguagem, canais e evidências), sem criar produto, sugerir solução ou mencionar oferta, software, IA, automação ou ferramenta.
 - Prevenção de recorrência: o coletor agora pré-valida a resposta com a mesma lista de termos proibidos, regenera uma única vez com instrução corretiva quando detectar contaminação e só registra falha se a resposta corrigida continuar inválida.
+
+## 2026-06-13 — OPRM MEI: correção de compilação no gate de dor prática
+
+- Causa-raiz corrigida: o gate de evidência mínima da etapa `mei-audience-segmenter` passou a usar `Locale.ROOT` para normalizar textos de ausência de evidência, mas a classe não importava `java.util.Locale`, quebrando a compilação do `ads-service`.
+- Correção aplicada: adicionado o import explícito de `java.util.Locale` no serviço backend da segmentação MEI/autônomo.
+- Prevenção de recorrência: executada compilação Maven direcionada ao módulo `ads-service` para validar que o erro `cannot find symbol Locale` não retorna.


### PR DESCRIPTION
### Motivation
- Fix a compilation failure in the MEI audience segmenter where `Locale.ROOT` was used without importing `java.util.Locale`, restoring correct text normalization and the evidence gate behavior.

### Description
- Add `import java.util.Locale` and replace the fully-qualified `java.util.Locale.ROOT` usage with `Locale.ROOT` in `backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/meiaudiencesegmenter/service/BackendMeiAudienceSegmenterService.java`, and record the change in `docs/registros/oprm1.md`.

### Testing
- Ran `mvn compile -DskipTests` and `mvn test -DskipITs` in `backend/ads-service`; compilation and the test suite completed successfully (`BUILD SUCCESS`, tests run: 800, failures: 0, skipped: 1).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2dc07efe1c8321b796aa0446d23f04)