### PR TITLE
Fix OPRM quality gate pending queue

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/routinequalitygate/service/BackendRoutineQualityGateService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/routinequalitygate/service/BackendRoutineQualityGateService.java
@@ -67,8 +67,7 @@ public class BackendRoutineQualityGateService {
   /** Lista cartões sintetizados ainda não avaliados com contadores concretos de fontes e sinais. */
   @Transactional(readOnly = true)
   public List<RecordRoutineQualityGatePending> listPending() {
-    return routineCardRepository.findByQualityCheckedAtIsNullOrderByCreatedAtAscIdAsc(PageRequest.of(0, MAX_PENDING)).stream()
-        .filter(card -> meiAudienceProfileRepository.existsByResearchCycleId(card.getResearchCycleId()))
+    return routineCardRepository.findPendingRoutineQualityGate(PageRequest.of(0, MAX_PENDING)).stream()
         .map(this::toPending)
         .toList();
   }

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/oprm/nichocnae/OprmNicheRoutineCardRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/oprm/nichocnae/OprmNicheRoutineCardRepository.java
@@ -16,8 +16,17 @@ public interface OprmNicheRoutineCardRepository extends JpaRepository<OprmNicheR
   /** Busca o cartão de rotina mais recente de um ciclo. */
   Optional<OprmNicheRoutineCard> findFirstByResearchCycleIdOrderByIdDesc(Long researchCycleId);
 
-  /** Lista cartões sintetizados ainda não avaliados pelo gate de qualidade. */
-  List<OprmNicheRoutineCard> findByQualityCheckedAtIsNullOrderByCreatedAtAscIdAsc(Pageable pageable);
+  /** Lista cartões sintetizados, segmentados como MEI/autônomo e ainda não avaliados pelo gate de qualidade. */
+  @Query("""
+      select c from OprmNicheRoutineCard c
+      where c.qualityCheckedAt is null
+        and exists (
+          select 1 from OprmMeiAudienceProfile p
+          where p.researchCycleId = c.researchCycleId
+        )
+      order by c.createdAt asc, c.id asc
+      """)
+  List<OprmNicheRoutineCard> findPendingRoutineQualityGate(Pageable pageable);
 
   /** Lista cartões do ciclo ativo sintetizado mais recente que ainda não possuem segmentação MEI/autônomo. */
   @Query("""

--- a/backend/ads-service/src/test/java/com/marketinghub/oprm/nichocnae/OprmNicheRoutineCardRepositoryTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/oprm/nichocnae/OprmNicheRoutineCardRepositoryTest.java
@@ -43,6 +43,22 @@ class OprmNicheRoutineCardRepositoryTest {
         .doesNotContain(oldCard.getId(), failedCard.getId(), cancelledCard.getId(), segmentedCard.getId());
   }
 
+  /** Garante que a fila do gate de qualidade não fica presa por cartões antigos sem perfil MEI/autônomo. */
+  @Test
+  void findPendingRoutineQualityGateShouldIgnoreCardsWithoutMeiAudienceProfileBeforeApplyingLimit() {
+    for (int index = 0; index < 12; index++) {
+      OprmRoutineResearchCycle oldCycle = saveCycle(500L + index, "ROUTINE_SYNTHESIZED", "2026-06-06T10:0" + (index % 10) + ":00Z");
+      saveCard(oldCycle, "cartão antigo sem perfil " + index);
+    }
+    OprmRoutineResearchCycle eligibleCycle = saveCycle(900L, "MEI_AUDIENCE_SEGMENTED", "2026-06-07T10:00:00Z");
+    OprmNicheRoutineCard eligibleCard = saveCard(eligibleCycle, "cartão elegível com perfil MEI");
+    saveProfile(eligibleCycle, eligibleCard);
+
+    assertThat(routineCardRepository.findPendingRoutineQualityGate(PageRequest.of(0, 10)))
+        .extracting(OprmNicheRoutineCard::getId)
+        .containsExactly(eligibleCard.getId());
+  }
+
   /** Persiste um ciclo com os campos mínimos exigidos pelo contrato JPA do NichoCNAE. */
   private OprmRoutineResearchCycle saveCycle(Long sourceNicheId, String status, String startedAt) {
     Instant start = Instant.parse(startedAt);

--- a/backend/ads-service/src/test/java/com/marketinghub/oprm/nichocnae/routinequalitygate/service/BackendRoutineQualityGateServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/oprm/nichocnae/routinequalitygate/service/BackendRoutineQualityGateServiceTest.java
@@ -41,8 +41,7 @@ class BackendRoutineQualityGateServiceTest {
   @Test
   void shouldListPendingWithSignalTypeAliases() {
     OprmNicheRoutineCard card = card();
-    when(cardRepository.findByQualityCheckedAtIsNullOrderByCreatedAtAscIdAsc(any(Pageable.class))).thenReturn(List.of(card));
-    when(meiAudienceProfileRepository.existsByResearchCycleId(1001L)).thenReturn(true);
+    when(cardRepository.findPendingRoutineQualityGate(any(Pageable.class))).thenReturn(List.of(card));
     when(snapshotRepository.findByResearchCycleIdOrderByIdAsc(1001L)).thenReturn(List.of(new OprmSourceSnapshot(), new OprmSourceSnapshot()));
     OprmSourceSnapshot riskSnapshot = snapshot(true, 80, 70, false, false, "a.com.br");
     OprmSourceSnapshot routineSnapshot = snapshot(false, 75, 65, false, false, "b.com.br");
@@ -82,8 +81,7 @@ class BackendRoutineQualityGateServiceTest {
     OprmMeiAudienceProfile profile = profile();
     profile.setCustomerAcquisitionBehavior("Sem evidência suficiente sobre comportamento de clientes.");
     profile.setChannelsUsed("Sem evidência suficiente sobre canais usados.");
-    when(cardRepository.findByQualityCheckedAtIsNullOrderByCreatedAtAscIdAsc(any(Pageable.class))).thenReturn(List.of(card));
-    when(meiAudienceProfileRepository.existsByResearchCycleId(1001L)).thenReturn(true);
+    when(cardRepository.findPendingRoutineQualityGate(any(Pageable.class))).thenReturn(List.of(card));
     when(snapshotRepository.findByResearchCycleIdOrderByIdAsc(1001L)).thenReturn(List.of(snapshot(false, 80, 70, false, false, "a.com.br")));
     when(meiAudienceProfileRepository.findFirstByResearchCycleIdOrderByIdDesc(1001L)).thenReturn(Optional.of(profile));
     when(signalRepository.findByResearchCycleIdOrderByIdAsc(1001L)).thenReturn(List.of(signal("ROUTINE_TASK")));

--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -637,3 +637,9 @@
 - Causa-raiz corrigida: o gate de evidência mínima da etapa `mei-audience-segmenter` passou a usar `Locale.ROOT` para normalizar textos de ausência de evidência, mas a classe não importava `java.util.Locale`, quebrando a compilação do `ads-service`.
 - Correção aplicada: adicionado o import explícito de `java.util.Locale` no serviço backend da segmentação MEI/autônomo.
 - Prevenção de recorrência: executada compilação Maven direcionada ao módulo `ads-service` para validar que o erro `cannot find symbol Locale` não retorna.
+
+## 2026-06-14 — OPRM NichoCNAE: desbloqueio do gate de qualidade após segmentação MEI/autônomo
+
+- Diagnosticado que o ciclo #39 do CNAE 9602501 estava com status `MEI_AUDIENCE_SEGMENTED`, cartão de rotina e perfil MEI/autônomo criados, mas sem pendência retornada para a etapa de qualidade.
+- Causa-raiz corrigida no backend: a fila do gate de qualidade aplicava limite antes de filtrar cartões com perfil MEI/autônomo, permitindo que cartões antigos sem perfil ocupassem a página e escondessem o ciclo elegível atual.
+- Ajustada a consulta do repositório para filtrar no banco apenas cartões não avaliados que já possuem perfil MEI/autônomo, prevenindo nova parada silenciosa do pipeline na etapa de qualidade.


### PR DESCRIPTION
### Motivation

- The OPRM pipeline could get stuck when the quality-gate pending page was filled by older routine cards that did not have a MEI audience profile, hiding eligible cycles that already completed segmentation.

### Description

- Move the MEI/profile existence filter into the JPA repository by adding `findPendingRoutineQualityGate(Pageable)` with a `@Query` that returns only `OprmNicheRoutineCard` rows where `qualityCheckedAt is null` and a corresponding `OprmMeiAudienceProfile` exists. 
- Update `BackendRoutineQualityGateService.listPending()` to call `routineCardRepository.findPendingRoutineQualityGate(...)` and remove the in-memory `existsByResearchCycleId` filter. 
- Add a JPA integration regression test `findPendingRoutineQualityGateShouldIgnoreCardsWithoutMeiAudienceProfileBeforeApplyingLimit()` in `OprmNicheRoutineCardRepositoryTest` to ensure pagination cannot hide eligible cards. 
- Record the operational diagnosis and fix in `docs/registros/oprm1.md`.

### Testing

- Ran unit/integration tests: `BackendRoutineQualityGateServiceTest` and `OprmNicheRoutineCardRepositoryTest` via Maven; test suite completed successfully (`BUILD SUCCESS`).
- Verified `git diff --check` returned clean; changes committed.
- Attempted `spotless:check` but it did not run because the Spotless plugin prefix is not configured in this Maven project (warning only).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2df3a907948321b6c62f50181ae337)