### PR TITLE
feat(oprm): exibir custos de execução do pipeline CNAE

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/routineresearchcycle/service/BackendRoutineResearchCycleService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/routineresearchcycle/service/BackendRoutineResearchCycleService.java
@@ -4,8 +4,10 @@ import com.marketinghub.oprm.nichocnae.OprmRoutineResearchCycle;
 import com.marketinghub.oprm.nichocnae.routineresearchcycle.service.detailStageExecution.RecordBackendRoutineResearchCycleDetalheDto;
 import com.marketinghub.oprm.nichocnae.routineresearchcycle.service.listStageExecutions.RoutineResearchCycleExecutionSummaryResponse;
 import com.marketinghub.oprm.nichocnae.routineresearchcycle.service.pending.RecordRoutineResearchCyclePending;
+import com.marketinghub.repository.jpa.oprm.nichocnae.OprmNicheResearchSeedRepository;
 import com.marketinghub.repository.jpa.oprm.nichocnae.OprmRoutineResearchCycleRepository;
 import jakarta.persistence.EntityNotFoundException;
+import java.math.BigDecimal;
 import java.util.List;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
@@ -17,16 +19,21 @@ public class BackendRoutineResearchCycleService {
   private static final String CYCLE_STATUS_RUNNING = "RUNNING";
 
   private final OprmRoutineResearchCycleRepository routineResearchCycleRepository;
+  private final OprmNicheResearchSeedRepository nicheResearchSeedRepository;
 
   /** Inicializa o serviço com o repositório canônico de ciclos de pesquisa de rotina. */
-  public BackendRoutineResearchCycleService(OprmRoutineResearchCycleRepository routineResearchCycleRepository) {
+  public BackendRoutineResearchCycleService(
+      OprmRoutineResearchCycleRepository routineResearchCycleRepository,
+      OprmNicheResearchSeedRepository nicheResearchSeedRepository) {
     this.routineResearchCycleRepository = routineResearchCycleRepository;
+    this.nicheResearchSeedRepository = nicheResearchSeedRepository;
   }
 
   /** Lista ciclos de pesquisa de rotina pendentes para processamento assíncrono da etapa. */
   @Transactional(readOnly = true)
   public List<RecordRoutineResearchCyclePending> listPending() {
-    return routineResearchCycleRepository.findByStatusOrderByStartedAtAsc(CYCLE_STATUS_RUNNING, PageRequest.of(0, 20))
+    return routineResearchCycleRepository
+        .findByStatusOrderByStartedAtAsc(CYCLE_STATUS_RUNNING, PageRequest.of(0, 20))
         .stream()
         .map(this::toPending)
         .toList();
@@ -35,25 +42,37 @@ public class BackendRoutineResearchCycleService {
   /** Lista execuções do ciclo de pesquisa de rotina associadas ao CNAE informado. */
   @Transactional(readOnly = true)
   public List<RoutineResearchCycleExecutionSummaryResponse> listStageExecutionsByCnae(String cnaeCode) {
-    return routineResearchCycleRepository.findByCnaeCodeOrderByStartedAtDesc(cnaeCode).stream()
-        .map(this::toSummary)
-        .toList();
+    List<OprmRoutineResearchCycle> cycles =
+        routineResearchCycleRepository.findByCnaeCodeOrderByStartedAtDesc(cnaeCode);
+    BigDecimal cnaeTotalCostUsd =
+        cycles.stream()
+            .map(cycle -> executionCostUsd(cycle.getId()))
+            .reduce(BigDecimal.ZERO, BigDecimal::add);
+    return cycles.stream().map(cycle -> toSummary(cycle, cnaeTotalCostUsd)).toList();
   }
 
   /** Lista execuções do ciclo de pesquisa de rotina associadas a um nicho CNAE de origem. */
   @Transactional(readOnly = true)
   public List<RoutineResearchCycleExecutionSummaryResponse> listStageExecutions(Long sourceNicheId) {
-    return routineResearchCycleRepository.findBySourceNicheIdOrderByStartedAtDesc(sourceNicheId).stream()
-        .map(this::toSummary)
-        .toList();
+    List<OprmRoutineResearchCycle> cycles =
+        routineResearchCycleRepository.findBySourceNicheIdOrderByStartedAtDesc(sourceNicheId);
+    BigDecimal totalCostUsd =
+        cycles.stream()
+            .map(cycle -> executionCostUsd(cycle.getId()))
+            .reduce(BigDecimal.ZERO, BigDecimal::add);
+    return cycles.stream().map(cycle -> toSummary(cycle, totalCostUsd)).toList();
   }
 
   /** Retorna os detalhes operacionais de uma execução específica do ciclo de pesquisa de rotina. */
   @Transactional(readOnly = true)
   public RecordBackendRoutineResearchCycleDetalheDto detailStageExecution(Long researchCycleId) {
-    OprmRoutineResearchCycle cycle = routineResearchCycleRepository
-        .findById(researchCycleId)
-        .orElseThrow(() -> new EntityNotFoundException("Routine research cycle not found: " + researchCycleId));
+    OprmRoutineResearchCycle cycle =
+        routineResearchCycleRepository
+            .findById(researchCycleId)
+            .orElseThrow(
+                () ->
+                    new EntityNotFoundException(
+                        "Routine research cycle not found: " + researchCycleId));
     return toDetail(cycle);
   }
 
@@ -77,7 +96,8 @@ public class BackendRoutineResearchCycleService {
   }
 
   /** Converte um ciclo em resumo para listagem operacional. */
-  private RoutineResearchCycleExecutionSummaryResponse toSummary(OprmRoutineResearchCycle cycle) {
+  private RoutineResearchCycleExecutionSummaryResponse toSummary(
+      OprmRoutineResearchCycle cycle, BigDecimal cnaeTotalCostUsd) {
     return new RoutineResearchCycleExecutionSummaryResponse(
         cycle.getId(),
         cycle.getSourceNicheId(),
@@ -93,9 +113,16 @@ public class BackendRoutineResearchCycleService {
         cycle.getTotalSourceCandidates(),
         cycle.getTotalSourceSnapshots(),
         cycle.getTotalExtractedSignals(),
+        executionCostUsd(cycle.getId()),
+        cnaeTotalCostUsd,
         cycle.getStartedAt(),
         cycle.getFinishedAt(),
         cycle.getErrorMessage());
+  }
+
+  /** Soma o custo registrado pelas etapas com telemetria de IA para uma execução do ciclo. */
+  private BigDecimal executionCostUsd(Long researchCycleId) {
+    return nicheResearchSeedRepository.sumCostUsdByResearchCycleId(researchCycleId);
   }
 
   /** Converte um ciclo em detalhe operacional completo. */

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/routineresearchcycle/service/listStageExecutions/RoutineResearchCycleExecutionSummaryResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/routineresearchcycle/service/listStageExecutions/RoutineResearchCycleExecutionSummaryResponse.java
@@ -19,6 +19,8 @@ public record RoutineResearchCycleExecutionSummaryResponse(
     Integer totalSourceCandidates,
     Integer totalSourceSnapshots,
     Integer totalExtractedSignals,
+    BigDecimal executionCostUsd,
+    BigDecimal cnaeTotalCostUsd,
     Instant startedAt,
     Instant finishedAt,
     String errorMessage) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/oprm/nichocnae/OprmNicheResearchSeedRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/oprm/nichocnae/OprmNicheResearchSeedRepository.java
@@ -1,16 +1,22 @@
 package com.marketinghub.repository.jpa.oprm.nichocnae;
 
 import com.marketinghub.oprm.nichocnae.OprmNicheResearchSeed;
+import java.math.BigDecimal;
 import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
-/**
- * Repositório responsável por persistir e consultar seeds de pesquisa de nicho CNAE.
- */
+/** Repositório responsável por persistir e consultar seeds de pesquisa de nicho CNAE. */
 public interface OprmNicheResearchSeedRepository extends JpaRepository<OprmNicheResearchSeed, Long> {
     /** Verifica se um ciclo já possui seed de pesquisa operacional gerado. */
     boolean existsByResearchCycleId(Long researchCycleId);
 
     /** Busca o seed operacional gerado para um ciclo de pesquisa. */
     Optional<OprmNicheResearchSeed> findByResearchCycleId(Long researchCycleId);
+
+    /** Soma o custo de IA registrado para um ciclo de pesquisa. */
+    @Query(
+      "select coalesce(sum(s.costUsd), 0) from OprmNicheResearchSeed s where s.researchCycleId = :researchCycleId")
+    BigDecimal sumCostUsdByResearchCycleId(@Param("researchCycleId") Long researchCycleId);
 }

--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -656,3 +656,9 @@
 - Causa-raiz tratada: o card de bloqueio do detalhe do CNAE informava que o gate rejeitou o ciclo, mas não explicava claramente quais critérios práticos foram reprovados para orientar a ação do usuário.
 - Correção aplicada: o card agora mostra o resultado apurado do gate e lista situações rejeitadas em linguagem operacional, incluindo contaminação por solução, fontes antigas, desvio corporativo, falta de tarefas reais do executor, mix MEI/autônomo incompleto, aquisição/recorrência fraca e ausência de dor prática.
 - Prevenção de recorrência: teste de tela cobre a exibição das rejeições detalhadas no bloqueio por qualidade.
+
+## 2026-06-14 — OPRM NichoCNAE: custos por execução na tela do CNAE
+
+- Solicitação atendida: a tela de detalhe do CNAE passou a mostrar o custo do job atual, o custo total acumulado do CNAE em destaque e uma tabela final com todos os jobs executados e o custo total de cada execução.
+- Causa-raiz tratada: o endpoint de acompanhamento do pipeline já listava os ciclos, mas não carregava a telemetria financeira gravada pela etapa de IA, impedindo decisão operacional sobre gasto antes de escalar o nicho.
+- Correção aplicada: o backend passou a somar o custo registrado nos seeds por ciclo e a devolver também o acumulado do CNAE; o frontend passou a exibir esses valores em USD no resumo e no histórico.

--- a/docs/swagger/oprm-nichocnae-swagger.yaml
+++ b/docs/swagger/oprm-nichocnae-swagger.yaml
@@ -814,6 +814,14 @@ components:
         totalExtractedSignals:
           type: integer
           nullable: true
+        executionCostUsd:
+          type: number
+          nullable: true
+          description: Custo total em USD registrado para esta execução do pipeline.
+        cnaeTotalCostUsd:
+          type: number
+          nullable: true
+          description: Custo total em USD de todas as execuções do CNAE.
         startedAt:
           type: string
           format: date-time

--- a/frontend/src/api/oprm/useOprmCnaePipeline.ts
+++ b/frontend/src/api/oprm/useOprmCnaePipeline.ts
@@ -16,6 +16,8 @@ export interface OprmRoutineResearchCycleSummary {
   totalSourceCandidates: number | null;
   totalSourceSnapshots: number | null;
   totalExtractedSignals: number | null;
+  executionCostUsd: number | string | null;
+  cnaeTotalCostUsd: number | string | null;
   errorMessage: string | null;
   startedAt: string;
   finishedAt: string | null;

--- a/frontend/src/pages/oprm/OprmCnaeDetailPlaceholderPage.test.tsx
+++ b/frontend/src/pages/oprm/OprmCnaeDetailPlaceholderPage.test.tsx
@@ -88,6 +88,8 @@ describe("OprmCnaeDetailPlaceholderPage", () => {
               totalSourceCandidates: 340,
               totalSourceSnapshots: 104,
               totalExtractedSignals: 266,
+              executionCostUsd: 0.0123,
+              cnaeTotalCostUsd: 0.0456,
               startedAt: "2026-06-12T19:08:26Z",
               finishedAt: null,
               errorMessage: null,
@@ -145,6 +147,11 @@ describe("OprmCnaeDetailPlaceholderPage", () => {
     renderPage();
 
     expect(await screen.findByText(/status atual:/i)).toBeTruthy();
+    expect(screen.getByText("Custo total do CNAE")).toBeTruthy();
+    expect(screen.getAllByText("US$ 0,0456").length).toBeGreaterThan(0);
+    expect(screen.getByText(/custo do job atual:/i)).toBeTruthy();
+    expect(screen.getAllByText("US$ 0,0123").length).toBeGreaterThan(0);
+    expect(screen.getByText("Jobs executados para este CNAE")).toBeTruthy();
     expect(
       screen.getByText(/bloqueada por fontes antigas ou sem atualidade/i),
     ).toBeTruthy();

--- a/frontend/src/pages/oprm/OprmCnaeDetailPlaceholderPage.tsx
+++ b/frontend/src/pages/oprm/OprmCnaeDetailPlaceholderPage.tsx
@@ -89,6 +89,22 @@ function formatScore(value?: number | null) {
   });
 }
 
+function formatUsd(value?: number | string | null) {
+  if (value === null || value === undefined || value === "") {
+    return "US$ 0,0000";
+  }
+  const numericValue = Number(value);
+  if (Number.isNaN(numericValue)) {
+    return "US$ 0,0000";
+  }
+  return new Intl.NumberFormat("pt-BR", {
+    style: "currency",
+    currency: "USD",
+    minimumFractionDigits: 4,
+    maximumFractionDigits: 4,
+  }).format(numericValue);
+}
+
 function formatDateTime(value?: string | null) {
   if (!value) {
     return "Ainda não finalizado";
@@ -688,7 +704,7 @@ export default function OprmCnaeDetailPlaceholderPage() {
 
       <section className="card border-0 shadow-sm">
         <div className="card-body d-flex flex-column gap-3">
-          <div className="d-flex flex-wrap justify-content-between gap-2">
+          <div className="d-flex flex-wrap justify-content-between gap-3 align-items-start">
             <div>
               <h2 className="h5 mb-1">Execução do pipeline NichoCNAE</h2>
               <p className="text-secondary mb-0">
@@ -696,10 +712,20 @@ export default function OprmCnaeDetailPlaceholderPage() {
                 transformar o CNAE em nicho enriquecido.
               </p>
             </div>
-            <span className="badge text-bg-light align-self-start">
-              Último ciclo:{" "}
-              {latestCycle ? `#${latestCycle.researchCycleId}` : "nenhum"}
-            </span>
+            <div className="d-flex flex-wrap gap-2 align-items-start justify-content-end">
+              <div className="border rounded-3 bg-light px-3 py-2 text-end">
+                <span className="d-block small text-secondary">
+                  Custo total do CNAE
+                </span>
+                <strong className="fs-5">
+                  {formatUsd(latestCycle?.cnaeTotalCostUsd)}
+                </strong>
+              </div>
+              <span className="badge text-bg-light align-self-start">
+                Último ciclo:{" "}
+                {latestCycle ? `#${latestCycle.researchCycleId}` : "nenhum"}
+              </span>
+            </div>
           </div>
 
           {latestCycle ? (
@@ -707,7 +733,9 @@ export default function OprmCnaeDetailPlaceholderPage() {
               <div>
                 Status atual: <strong>{statusLabel(latestCycle.status)}</strong>{" "}
                 · iniciado em {formatDateTime(latestCycle.startedAt)} · sinais
-                extraídos: {formatNumber(latestCycle.totalExtractedSignals)}
+                extraídos: {formatNumber(latestCycle.totalExtractedSignals)} ·
+                custo do job atual:{" "}
+                <strong>{formatUsd(latestCycle.executionCostUsd)}</strong>
               </div>
               {qualityBlockedMessage(latestCycle.status) ? (
                 <div className="mt-2">
@@ -823,6 +851,62 @@ export default function OprmCnaeDetailPlaceholderPage() {
                 </div>
               );
             })}
+          </div>
+
+          <div className="card border-0 bg-light">
+            <div className="card-body">
+              <div className="d-flex flex-wrap justify-content-between gap-2 mb-3">
+                <div>
+                  <h3 className="h6 mb-1">Jobs executados para este CNAE</h3>
+                  <p className="small text-secondary mb-0">
+                    Histórico por execução para controlar gasto operacional
+                    antes de escalar o nicho.
+                  </p>
+                </div>
+                <strong>
+                  Total: {formatUsd(latestCycle?.cnaeTotalCostUsd)}
+                </strong>
+              </div>
+              <div className="table-responsive">
+                <table className="table table-sm align-middle mb-0">
+                  <thead>
+                    <tr>
+                      <th scope="col">Job</th>
+                      <th scope="col">Status</th>
+                      <th scope="col">Início</th>
+                      <th scope="col">Fim</th>
+                      <th scope="col" className="text-end">
+                        Custo total
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {cyclesQuery.data && cyclesQuery.data.length > 0 ? (
+                      cyclesQuery.data.map((cycle) => (
+                        <tr key={cycle.researchCycleId}>
+                          <td>#{cycle.researchCycleId}</td>
+                          <td>{statusLabel(cycle.status)}</td>
+                          <td>{formatDateTime(cycle.startedAt)}</td>
+                          <td>{formatDateTime(cycle.finishedAt)}</td>
+                          <td className="text-end fw-semibold">
+                            {formatUsd(cycle.executionCostUsd)}
+                          </td>
+                        </tr>
+                      ))
+                    ) : (
+                      <tr>
+                        <td
+                          colSpan={5}
+                          className="text-secondary text-center py-3"
+                        >
+                          Nenhum job executado para este CNAE.
+                        </td>
+                      </tr>
+                    )}
+                  </tbody>
+                </table>
+              </div>
+            </div>
           </div>
         </div>
       </section>


### PR DESCRIPTION
### Motivation
- Dar visibilidade operacional ao gasto de IA por execução do pipeline NichoCNAE para suportar decisões antes de escalar um CNAE. 
- O endpoint que lista ciclos não expunha a telemetria financeira já gravada nas seeds, impedindo totalização e acompanhamento de custos.

### Description
- Backend: adiciona `executionCostUsd` e `cnaeTotalCostUsd` ao resumo de ciclo (`RoutineResearchCycleExecutionSummaryResponse`) e passa a somar `cost_usd` dos seeds por `researchCycleId` usando `OprmNicheResearchSeedRepository#sumCostUsdByResearchCycleId` e a injetar esse repositório em `BackendRoutineResearchCycleService` para calcular custos por execução e total do CNAE (`executionCostUsd(...)`, soma por ciclos). Files-chave: `backend/.../BackendRoutineResearchCycleService.java`, `.../RoutineResearchCycleExecutionSummaryResponse.java`, `.../OprmNicheResearchSeedRepository.java`.
- Frontend: atualiza o tipo em `useOprmCnaePipeline.ts` para incluir `executionCostUsd` e `cnaeTotalCostUsd`, cria `formatUsd` utilitário e altera `OprmCnaeDetailPlaceholderPage.tsx` para exibir em destaque o custo total do CNAE (topo/direita), mostrar o custo do job atual no resumo de status e adicionar uma tabela final com todas as execuções e seus custos. Files-chave: `frontend/src/api/oprm/useOprmCnaePipeline.ts`, `frontend/src/pages/oprm/OprmCnaeDetailPlaceholderPage.tsx`.
- API contract / docs: atualiza `docs/swagger/oprm-nichocnae-swagger.yaml` para documentar `executionCostUsd` e `cnaeTotalCostUsd` no schema retornado pelo endpoint de listagem de ciclos.
- Tests & records: atualiza `OprmCnaeDetailPlaceholderPage.test.tsx` para cobrir exibição de valores financeiros e registra a mudança em `docs/registros/oprm1.md`.

### Testing
- Frontend unit tests: ran `cd frontend && npm test -- --run src/pages/oprm/OprmCnaeDetailPlaceholderPage.test.tsx` and the test file passed (`1 file, 2 tests`), result: ✅ passed.
- Frontend typecheck: ran `cd frontend && npm run typecheck` and TypeScript check completed with no errors: ✅ passed.
- Backend compile: ran `cd backend/ads-service && ../mvnw -q -DskipTests compile` and compilation completed for the `ads-service` module: ✅ passed.
- Formatting task: attempted `cd backend/ads-service && ../mvnw -q spotless:apply` but it did not run because the Spotless plugin was not available in the environment, so formatting was not applied: ⚠️ skipped (Spotless plugin not configured/available).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2e3e6fcb648321946d8c31f78612b5)