### PR TITLE
OPRM NichoCNAE: add Google Custom Search recent-first provider with DuckDuckGo fallback

### DIFF
--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -695,3 +695,9 @@
 - Causa-raiz tratada: a reprovação já protegia o pipeline contra nichos fracos, contaminados ou sem dor vendável, mas ainda exigia interpretação manual para decidir se a próxima ação era refazer busca sem solução, buscar fontes recentes, trocar foco para dono-operador, validar aquisição/canais, validar dor vendável ou completar o mix MEI/autônomo.
 - Correção aplicada: o gate agora grava `proximoMovimentoCodigo` e `proximoMovimento` nas notas de qualidade, com decisão determinística por causa dominante; a tela de detalhe do CNAE exibe o próximo movimento automático no bloqueio de qualidade.
 - Prevenção de recorrência: testes unitários validam os movimentos automáticos para aprovação e para reprovações por solução, fontes antigas, desvio corporativo, aquisição/canais fracos e dor vendável fraca.
+
+## 2026-06-14 — OPRM NichoCNAE: busca Google para fontes recentes
+
+- Adicionado provedor `GOOGLE_CUSTOM_SEARCH_RECENT` na etapa `oprmSourceSearcher`, configurável por variáveis `OPRM_NICHO_CNAE_SOURCE_SEARCHER_GOOGLE_*`, para priorizar fontes brasileiras recentes com `dateRestrict` padrão de 24 meses antes do fallback DuckDuckGo.
+- Causa-raiz tratada: ciclos do CNAE 9602501 estavam chegando ao gate com sinais suficientes, mas bloqueados por `OUTDATED_SOURCES`; a busca anterior dependia somente do DuckDuckGo HTML e frequentemente retornava resultados sem data clara, aumentando risco de fonte antiga.
+- Prevenção de recorrência: criado provedor composto recent-first com fallback auditável, preservando o provider persistido no backend e evitando travar o pipeline caso Google não esteja configurado ou falhe.

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnae/sourcesearcher/GoogleCustomSearchProperties.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnae/sourcesearcher/GoogleCustomSearchProperties.java
@@ -1,0 +1,40 @@
+package com.marketinghub.nichocnae.sourcesearcher;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+import org.springframework.util.StringUtils;
+
+/** Configura o provedor Google Custom Search para reforçar buscas recentes do NichoCNAE. */
+@ConfigurationProperties(prefix = "oprm.nichocnae.source-searcher.google")
+public record GoogleCustomSearchProperties(
+        boolean enabled,
+        String apiKey,
+        String searchEngineId,
+        String baseUrl,
+        String dateRestrict,
+        String countryRestrict,
+        String languageRestrict) {
+    /** Indica se o provedor Google tem credenciais e pode ser usado como fonte primária. */
+    public boolean configured() {
+        return enabled && StringUtils.hasText(apiKey) && StringUtils.hasText(searchEngineId);
+    }
+
+    /** Retorna a URL base efetiva da API de busca customizada do Google. */
+    public String effectiveBaseUrl() {
+        return StringUtils.hasText(baseUrl) ? baseUrl : "https://www.googleapis.com/customsearch/v1";
+    }
+
+    /** Retorna o recorte temporal efetivo para privilegiar fontes recentes. */
+    public String effectiveDateRestrict() {
+        return StringUtils.hasText(dateRestrict) ? dateRestrict : "m24";
+    }
+
+    /** Retorna o filtro de país efetivo para preservar o foco Brasil-first. */
+    public String effectiveCountryRestrict() {
+        return StringUtils.hasText(countryRestrict) ? countryRestrict : "countryBR";
+    }
+
+    /** Retorna o filtro de idioma efetivo para preservar português do Brasil. */
+    public String effectiveLanguageRestrict() {
+        return StringUtils.hasText(languageRestrict) ? languageRestrict : "lang_pt";
+    }
+}

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnae/sourcesearcher/GoogleCustomSearchSourceSearchProvider.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnae/sourcesearcher/GoogleCustomSearchSourceSearchProvider.java
@@ -1,0 +1,202 @@
+package com.marketinghub.nichocnae.sourcesearcher;
+
+import java.net.URI;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.time.ZoneOffset;
+import java.time.format.DateTimeParseException;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+import org.springframework.web.client.RestClient;
+import org.springframework.web.client.RestClientException;
+import org.springframework.web.util.UriComponentsBuilder;
+
+/** Consulta Google Custom Search para priorizar fontes brasileiras recentes na etapa três do NichoCNAE. */
+@Component
+public class GoogleCustomSearchSourceSearchProvider implements PublicSourceSearchProvider {
+    private static final Logger log = LoggerFactory.getLogger(GoogleCustomSearchSourceSearchProvider.class);
+    private static final String PROVIDER_CODE = "GOOGLE_CUSTOM_SEARCH_RECENT";
+    private static final int GOOGLE_MAX_RESULTS_PER_REQUEST = 10;
+
+    private final GoogleCustomSearchProperties properties;
+    private final RestClient restClient;
+
+    /** Inicializa o provedor com configurações de Google Custom Search e cliente HTTP compartilhado. */
+    public GoogleCustomSearchSourceSearchProvider(GoogleCustomSearchProperties properties, RestClient restClient) {
+        this.properties = properties;
+        this.restClient = restClient;
+    }
+
+    /** Executa busca recente no Google Custom Search quando o provedor estiver configurado. */
+    @Override
+    public List<SourceSearchResult> search(String queryText, int maxResults) {
+        if (!properties.configured()) {
+            return List.of();
+        }
+        String localizedQuery = buildRecentBrazilianQuery(queryText);
+        try {
+            GoogleSearchResponse response = restClient.get()
+                    .uri(buildSearchUri(localizedQuery, maxResults))
+                    .retrieve()
+                    .body(GoogleSearchResponse.class);
+            if (response == null || response.items() == null) {
+                return List.of();
+            }
+            return response.items().stream()
+                    .limit(Math.max(0, maxResults))
+                    .map(this::toSearchResult)
+                    .filter(result -> result != null)
+                    .toList();
+        } catch (RestClientException ex) {
+            log.error("Erro de integração ao buscar fontes recentes no Google Custom Search (queryText={}, localizedQuery={})", queryText, localizedQuery, ex);
+            throw ex;
+        } catch (RuntimeException ex) {
+            log.error("Erro runtime ao buscar fontes recentes no Google Custom Search (queryText={}, localizedQuery={})", queryText, localizedQuery, ex);
+            throw ex;
+        }
+    }
+
+    /** Informa o código operacional do provedor Google Custom Search recente. */
+    @Override
+    public String providerCode() {
+        return PROVIDER_CODE;
+    }
+
+    /** Indica se o provedor está habilitado e possui credenciais para execução. */
+    boolean configured() {
+        return properties.configured();
+    }
+
+    /** Monta query Brasil-first com termos explícitos de recência para reforçar a intenção comercial atual. */
+    String buildRecentBrazilianQuery(String queryText) {
+        String baseQuery = StringUtils.hasText(queryText) ? queryText.trim() : "rotina profissional autônomo Brasil";
+        String normalized = baseQuery.toLowerCase();
+        String withBrazil = normalized.contains("brasil") || normalized.contains("brasileir") || normalized.contains("site:.br")
+                ? baseQuery
+                : baseQuery + " Brasil";
+        return withBrazil + " 2025 OR 2026";
+    }
+
+    /** Monta a URI da API oficial do Google com restrição de data, país e idioma. */
+    private String buildSearchUri(String localizedQuery, int maxResults) {
+        int boundedResults = Math.max(1, Math.min(maxResults, GOOGLE_MAX_RESULTS_PER_REQUEST));
+        return UriComponentsBuilder.fromUriString(properties.effectiveBaseUrl())
+                .queryParam("key", properties.apiKey())
+                .queryParam("cx", properties.searchEngineId())
+                .queryParam("q", localizedQuery)
+                .queryParam("num", boundedResults)
+                .queryParam("dateRestrict", properties.effectiveDateRestrict())
+                .queryParam("cr", properties.effectiveCountryRestrict())
+                .queryParam("lr", properties.effectiveLanguageRestrict())
+                .queryParam("gl", "br")
+                .build()
+                .toUriString();
+    }
+
+    /** Converte um item orgânico do Google em resultado normalizado para o contrato da etapa três. */
+    private SourceSearchResult toSearchResult(GoogleSearchItem item) {
+        if (item == null || !StringUtils.hasText(item.link()) || !StringUtils.hasText(item.title())) {
+            return null;
+        }
+        String domain = extractDomain(item.link());
+        if (!StringUtils.hasText(domain)) {
+            return null;
+        }
+        return new SourceSearchResult(
+                item.link().trim(),
+                item.title().trim(),
+                StringUtils.hasText(item.snippet()) ? item.snippet().trim() : null,
+                domain,
+                null,
+                null,
+                null,
+                false,
+                false,
+                null,
+                null,
+                false,
+                null,
+                null,
+                false,
+                extractPublishedAt(item));
+    }
+
+    /** Extrai domínio da URL final retornada pelo Google para rastreabilidade. */
+    private String extractDomain(String sourceUrl) {
+        try {
+            URI uri = URI.create(sourceUrl);
+            String host = uri.getHost();
+            if (!StringUtils.hasText(host)) {
+                return null;
+            }
+            return host.startsWith("www.") ? host.substring(4) : host;
+        } catch (RuntimeException ex) {
+            log.warn("Domínio de fonte ignorado por URL inválida no Google Custom Search (sourceUrl={})", sourceUrl, ex);
+            return null;
+        }
+    }
+
+    /** Extrai data de publicação exposta em metatags do Google Custom Search quando disponível. */
+    private Instant extractPublishedAt(GoogleSearchItem item) {
+        if (item.pagemap() == null || item.pagemap().metatags() == null) {
+            return null;
+        }
+        for (GoogleSearchMetatag metatag : item.pagemap().metatags()) {
+            Instant date = firstValidDate(
+                    metatag.articlePublishedTime(),
+                    metatag.datePublished(),
+                    metatag.dateModified(),
+                    metatag.ogUpdatedTime());
+            if (date != null) {
+                return date;
+            }
+        }
+        return null;
+    }
+
+    /** Retorna a primeira data válida encontrada em campos comuns de metadados públicos. */
+    private Instant firstValidDate(String... values) {
+        for (String value : values) {
+            Instant parsed = parseDate(value);
+            if (parsed != null) {
+                return parsed;
+            }
+        }
+        return null;
+    }
+
+    /** Converte data ISO completa ou data simples em instante UTC para cálculo de frescor. */
+    private Instant parseDate(String value) {
+        if (!StringUtils.hasText(value)) {
+            return null;
+        }
+        try {
+            return Instant.parse(value.trim());
+        } catch (DateTimeParseException ignored) {
+            try {
+                return LocalDate.parse(value.trim()).atStartOfDay().toInstant(ZoneOffset.UTC);
+            } catch (DateTimeParseException ex) {
+                return null;
+            }
+        }
+    }
+
+    /** Representa a resposta mínima da API Google Custom Search usada pelo coletor. */
+    record GoogleSearchResponse(List<GoogleSearchItem> items) {}
+
+    /** Representa um resultado orgânico mínimo retornado pelo Google Custom Search. */
+    record GoogleSearchItem(String title, String link, String snippet, GoogleSearchPagemap pagemap) {}
+
+    /** Representa o mapa de metadados públicos retornado pelo Google Custom Search. */
+    record GoogleSearchPagemap(List<GoogleSearchMetatag> metatags) {}
+
+    /** Representa metatags comuns de data retornadas pelo Google Custom Search. */
+    record GoogleSearchMetatag(
+            @com.fasterxml.jackson.annotation.JsonProperty("article:published_time") String articlePublishedTime,
+            @com.fasterxml.jackson.annotation.JsonProperty("datePublished") String datePublished,
+            @com.fasterxml.jackson.annotation.JsonProperty("dateModified") String dateModified,
+            @com.fasterxml.jackson.annotation.JsonProperty("og:updated_time") String ogUpdatedTime) {}
+}

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnae/sourcesearcher/RecentFirstSourceSearchProvider.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnae/sourcesearcher/RecentFirstSourceSearchProvider.java
@@ -1,0 +1,53 @@
+package com.marketinghub.nichocnae.sourcesearcher;
+
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.context.annotation.Primary;
+import org.springframework.stereotype.Component;
+
+/** Escolhe Google recente quando configurado e usa DuckDuckGo HTML como fallback operacional. */
+@Primary
+@Component
+public class RecentFirstSourceSearchProvider implements PublicSourceSearchProvider {
+    private static final Logger log = LoggerFactory.getLogger(RecentFirstSourceSearchProvider.class);
+    private static final String COMPOSITE_PROVIDER_CODE = "RECENT_FIRST_SEARCH";
+
+    private final GoogleCustomSearchSourceSearchProvider googleProvider;
+    private final DuckDuckGoHtmlSourceSearchProvider duckDuckGoProvider;
+    private final ThreadLocal<String> lastProviderCode = ThreadLocal.withInitial(() -> COMPOSITE_PROVIDER_CODE);
+
+    /** Inicializa o provedor composto com Google recente e fallback DuckDuckGo. */
+    public RecentFirstSourceSearchProvider(
+            GoogleCustomSearchSourceSearchProvider googleProvider,
+            DuckDuckGoHtmlSourceSearchProvider duckDuckGoProvider) {
+        this.googleProvider = googleProvider;
+        this.duckDuckGoProvider = duckDuckGoProvider;
+    }
+
+    /** Executa busca priorizando fontes recentes do Google e preservando fallback sem travar o pipeline. */
+    @Override
+    public List<SourceSearchResult> search(String queryText, int maxResults) {
+        if (googleProvider.configured()) {
+            try {
+                List<SourceSearchResult> googleResults = googleProvider.search(queryText, maxResults);
+                if (!googleResults.isEmpty()) {
+                    lastProviderCode.set(googleProvider.providerCode());
+                    return googleResults;
+                }
+                log.warn("Google Custom Search não retornou fontes recentes; usando fallback DuckDuckGo HTML (queryText={})", queryText);
+            } catch (RuntimeException ex) {
+                log.error("Falha no Google Custom Search; usando fallback DuckDuckGo HTML (queryText={})", queryText, ex);
+            }
+        }
+        List<SourceSearchResult> fallbackResults = duckDuckGoProvider.search(queryText, maxResults);
+        lastProviderCode.set(duckDuckGoProvider.providerCode());
+        return fallbackResults;
+    }
+
+    /** Informa o provedor que gerou a última busca da thread atual para persistência auditável. */
+    @Override
+    public String providerCode() {
+        return lastProviderCode.get();
+    }
+}

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/oprmcoletormei/marketimport/config/OprmMarketImportConfig.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/oprmcoletormei/marketimport/config/OprmMarketImportConfig.java
@@ -2,20 +2,24 @@ package com.marketinghub.oprmcoletormei.marketimport.config;
 
 import com.marketinghub.nichocnae.meiaudiencesegmenter.MeiAudienceSegmenterOpenAiProperties;
 import com.marketinghub.nichocnae.nicheresearchseedbuilder.NicheResearchSeedBuilderOpenAiProperties;
+import com.marketinghub.nichocnae.sourcesearcher.GoogleCustomSearchProperties;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.web.client.RestClient;
 
+/** Centraliza beans e propriedades operacionais usados pelo coletor OPRM. */
 @Configuration
 @EnableConfigurationProperties({
         OprmMarketImportScheduleProperties.class,
         OprmMarketImportCollectorProperties.class,
         NicheResearchSeedBuilderOpenAiProperties.class,
-        MeiAudienceSegmenterOpenAiProperties.class
+        MeiAudienceSegmenterOpenAiProperties.class,
+        GoogleCustomSearchProperties.class
 })
 public class OprmMarketImportConfig {
 
+    /** Cria o cliente HTTP compartilhado para integrações externas do coletor. */
     @Bean
     RestClient restClient() {
         return RestClient.builder().build();

--- a/oprm-coletor-mei/src/main/resources/application.yml
+++ b/oprm-coletor-mei/src/main/resources/application.yml
@@ -17,6 +17,15 @@ management:
 
 oprm:
   nichocnae:
+    source-searcher:
+      google:
+        enabled: ${OPRM_NICHO_CNAE_SOURCE_SEARCHER_GOOGLE_ENABLED:false}
+        api-key: ${OPRM_NICHO_CNAE_SOURCE_SEARCHER_GOOGLE_API_KEY:}
+        search-engine-id: ${OPRM_NICHO_CNAE_SOURCE_SEARCHER_GOOGLE_SEARCH_ENGINE_ID:}
+        base-url: ${OPRM_NICHO_CNAE_SOURCE_SEARCHER_GOOGLE_BASE_URL:https://www.googleapis.com/customsearch/v1}
+        date-restrict: ${OPRM_NICHO_CNAE_SOURCE_SEARCHER_GOOGLE_DATE_RESTRICT:m24}
+        country-restrict: ${OPRM_NICHO_CNAE_SOURCE_SEARCHER_GOOGLE_COUNTRY_RESTRICT:countryBR}
+        language-restrict: ${OPRM_NICHO_CNAE_SOURCE_SEARCHER_GOOGLE_LANGUAGE_RESTRICT:lang_pt}
     seed-builder:
       openai:
         base-url: ${OPRM_NICHO_CNAE_SEED_BUILDER_OPENAI_BASE_URL:https://api.openai.com/v1}

--- a/oprm-coletor-mei/src/test/java/com/marketinghub/nichocnae/sourcesearcher/GoogleCustomSearchSourceSearchProviderTest.java
+++ b/oprm-coletor-mei/src/test/java/com/marketinghub/nichocnae/sourcesearcher/GoogleCustomSearchSourceSearchProviderTest.java
@@ -1,0 +1,35 @@
+package com.marketinghub.nichocnae.sourcesearcher;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.web.client.RestClient;
+
+/** Responsabilidade: validar a configuração e a query recente Brasil-first do provedor Google. */
+class GoogleCustomSearchSourceSearchProviderTest {
+
+    /** Deve considerar Google configurado somente quando habilitado com chave e motor de busca. */
+    @Test
+    void shouldRequireEnabledApiKeyAndSearchEngineId() {
+        GoogleCustomSearchProperties disabled = new GoogleCustomSearchProperties(false, "key", "cx", null, null, null, null);
+        GoogleCustomSearchProperties missingKey = new GoogleCustomSearchProperties(true, "", "cx", null, null, null, null);
+        GoogleCustomSearchProperties configured = new GoogleCustomSearchProperties(true, "key", "cx", null, null, null, null);
+
+        assertThat(disabled.configured()).isFalse();
+        assertThat(missingKey.configured()).isFalse();
+        assertThat(configured.configured()).isTrue();
+    }
+
+    /** Deve reforçar Brasil e anos recentes na query enviada ao Google. */
+    @Test
+    void shouldBuildRecentBrazilianQuery() {
+        GoogleCustomSearchSourceSearchProvider provider = new GoogleCustomSearchSourceSearchProvider(
+                new GoogleCustomSearchProperties(true, "key", "cx", null, null, null, null),
+                RestClient.builder().build());
+
+        assertThat(provider.buildRecentBrazilianQuery("manicure faltas clientes"))
+                .isEqualTo("manicure faltas clientes Brasil 2025 OR 2026");
+        assertThat(provider.buildRecentBrazilianQuery("manicure faltas clientes Brasil"))
+                .isEqualTo("manicure faltas clientes Brasil 2025 OR 2026");
+    }
+}

--- a/oprm-coletor-mei/src/test/java/com/marketinghub/nichocnae/sourcesearcher/RecentFirstSourceSearchProviderTest.java
+++ b/oprm-coletor-mei/src/test/java/com/marketinghub/nichocnae/sourcesearcher/RecentFirstSourceSearchProviderTest.java
@@ -1,0 +1,55 @@
+package com.marketinghub.nichocnae.sourcesearcher;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+/** Responsabilidade: validar a escolha recent-first entre Google configurado e fallback DuckDuckGo. */
+class RecentFirstSourceSearchProviderTest {
+
+    /** Deve usar Google quando configurado e houver fontes recentes retornadas. */
+    @Test
+    void shouldUseGoogleWhenConfiguredAndResultsExist() {
+        GoogleCustomSearchSourceSearchProvider google = mock(GoogleCustomSearchSourceSearchProvider.class);
+        DuckDuckGoHtmlSourceSearchProvider duckDuckGo = mock(DuckDuckGoHtmlSourceSearchProvider.class);
+        SourceSearchResult result = result("https://exemplo.com.br/recente");
+        when(google.configured()).thenReturn(true);
+        when(google.search("manicure agenda", 20)).thenReturn(List.of(result));
+        when(google.providerCode()).thenReturn("GOOGLE_CUSTOM_SEARCH_RECENT");
+        RecentFirstSourceSearchProvider provider = new RecentFirstSourceSearchProvider(google, duckDuckGo);
+
+        List<SourceSearchResult> results = provider.search("manicure agenda", 20);
+
+        assertThat(results).containsExactly(result);
+        assertThat(provider.providerCode()).isEqualTo("GOOGLE_CUSTOM_SEARCH_RECENT");
+        verifyNoInteractions(duckDuckGo);
+    }
+
+    /** Deve usar DuckDuckGo quando Google não estiver configurado para não interromper o pipeline. */
+    @Test
+    void shouldUseDuckDuckGoWhenGoogleIsNotConfigured() {
+        GoogleCustomSearchSourceSearchProvider google = mock(GoogleCustomSearchSourceSearchProvider.class);
+        DuckDuckGoHtmlSourceSearchProvider duckDuckGo = mock(DuckDuckGoHtmlSourceSearchProvider.class);
+        SourceSearchResult result = result("https://fallback.com.br/fonte");
+        when(google.configured()).thenReturn(false);
+        when(duckDuckGo.search("manicure agenda", 20)).thenReturn(List.of(result));
+        when(duckDuckGo.providerCode()).thenReturn("DUCKDUCKGO_HTML");
+        RecentFirstSourceSearchProvider provider = new RecentFirstSourceSearchProvider(google, duckDuckGo);
+
+        List<SourceSearchResult> results = provider.search("manicure agenda", 20);
+
+        assertThat(results).containsExactly(result);
+        assertThat(provider.providerCode()).isEqualTo("DUCKDUCKGO_HTML");
+        verify(duckDuckGo).search("manicure agenda", 20);
+    }
+
+    /** Cria resultado mínimo para validar roteamento entre provedores. */
+    private SourceSearchResult result(String url) {
+        return new SourceSearchResult(url, "Fonte recente", "Resumo", "exemplo.com.br", 1, null, null, false, false);
+    }
+}


### PR DESCRIPTION
### Motivation

- Ciclos do NichoCNAE vinham sendo bloqueados por `OUTDATED_SOURCES` devido a buscas que retornavam fontes sem data clara; é necessário priorizar fontes brasileiras recentes. 
- Reforçar buscas recentes com Google Custom Search ajuda a melhorar qualidade do gate e reduzir falso-negativos por fontes antigas. 
- A integração deve ser defensiva e não travar o pipeline quando o Google não estiver configurado ou falhar. 

### Description

- Adicionadas propriedades de configuração `GoogleCustomSearchProperties` sob o prefixo `oprm.nichocnae.source-searcher.google` e entradas em `application.yml` para controlar `enabled`, `api-key`, `search-engine-id`, `date-restrict`, `country-restrict` e `language-restrict`. 
- Implementado o provedor `GoogleCustomSearchSourceSearchProvider` que consulta a API do Google Custom Search e extrai metadados de data para priorizar fontes recentes. 
- Criado o provedor composto `RecentFirstSourceSearchProvider` (marcado como `@Primary`) que usa Google quando configurado e tem resultados recentes, e faz fallback ao `DuckDuckGoHtmlSourceSearchProvider` em caso de falta de configuração ou falha. 
- Registrado `GoogleCustomSearchProperties` e um bean `RestClient` em `OprmMarketImportConfig`, e atualizada a documentação interna `docs/registros/oprm1.md` explicando o novo provedor. 

### Testing

- Adicionados testes unitários `GoogleCustomSearchSourceSearchProviderTest` para validação de configuração e construção de query recente, e `RecentFirstSourceSearchProviderTest` para comportamento recent-first e fallback. 
- Executados os novos testes de unidade no módulo `oprm-coletor-mei` e ambos os testes passaram com sucesso. 
- A integração do provedor é defensiva e não altera comportamento quando `OPRM_NICHO_CNAE_SOURCE_SEARCHER_GOOGLE_ENABLED` está `false` (coberto pelos testes de fallback).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2ed3d52abc832189d513739a607f52)