### PR TITLE
oprm-nichocnae: automatic reprocess for recoverable quality-gate rejections (limit 3)

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/routinequalitygate/service/BackendRoutineQualityGateService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/routinequalitygate/service/BackendRoutineQualityGateService.java
@@ -1,5 +1,6 @@
 package com.marketinghub.oprm.nichocnae.routinequalitygate.service;
 
+import com.marketinghub.oprm.cnae.OprmNicheCandidate;
 import com.marketinghub.oprm.nichocnae.OprmExtractedSignal;
 import com.marketinghub.oprm.nichocnae.OprmNicheRoutineCard;
 import com.marketinghub.oprm.nichocnae.OprmRoutineResearchCycle;
@@ -10,6 +11,7 @@ import com.marketinghub.oprm.nichocnae.routinequalitygate.service.completeStageE
 import com.marketinghub.oprm.nichocnae.routinequalitygate.service.detailStageExecution.RoutineQualityGateDetailResponse;
 import com.marketinghub.oprm.nichocnae.routinequalitygate.service.failStageExecution.FailRoutineQualityGateRequest;
 import com.marketinghub.oprm.nichocnae.routinequalitygate.service.pending.RecordRoutineQualityGatePending;
+import com.marketinghub.repository.jpa.oprm.cnae.OprmNicheCandidateRepository;
 import com.marketinghub.repository.jpa.oprm.nichocnae.OprmExtractedSignalRepository;
 import com.marketinghub.repository.jpa.oprm.nichocnae.OprmNicheRoutineCardRepository;
 import com.marketinghub.repository.jpa.oprm.nichocnae.OprmRoutineResearchCycleRepository;
@@ -33,6 +35,7 @@ import org.springframework.util.StringUtils;
 public class BackendRoutineQualityGateService {
   private static final Logger LOGGER = LoggerFactory.getLogger(BackendRoutineQualityGateService.class);
   private static final String FAILED_STATUS = "FAILED";
+  private static final String CYCLE_STATUS_RUNNING = "RUNNING";
   private static final String LIGHTLY_RESEARCHED_STATUS = "LIGHTLY_RESEARCHED";
   private static final String MEI_AUDIENCE_READY_STATUS = "MEI_AUDIENCE_READY";
   private static final String NEEDS_MORE_RESEARCH_STATUS = "NEEDS_MORE_RESEARCH";
@@ -41,7 +44,10 @@ public class BackendRoutineQualityGateService {
   private static final String TOO_CORPORATE_STATUS = "TOO_CORPORATE";
   private static final String SOLUTION_CONTAMINATED_STATUS = "SOLUTION_CONTAMINATED";
   private static final String GENERIC_STATUS = "GENERIC";
+  private static final String AUTO_QUALITY_REPROCESS_TRIGGER = "AUTO_QUALITY_REPROCESS";
+  private static final String ROUTINE_RESEARCH_RUNNING_STATUS = "RESEARCH_RUNNING";
   private static final int MAX_PENDING = 10;
+  private static final int MAX_AUTO_REPROCESS_PER_CANDIDATE = 3;
   private static final int MAX_NOTES_LENGTH = 4000;
 
   private final OprmRoutineResearchCycleRepository routineResearchCycleRepository;
@@ -49,6 +55,7 @@ public class BackendRoutineQualityGateService {
   private final OprmExtractedSignalRepository extractedSignalRepository;
   private final OprmSourceSnapshotRepository sourceSnapshotRepository;
   private final OprmMeiAudienceProfileRepository meiAudienceProfileRepository;
+  private final OprmNicheCandidateRepository nicheCandidateRepository;
 
   /** Inicializa o serviço com os repositórios canônicos necessários para calcular o contexto da qualidade. */
   public BackendRoutineQualityGateService(
@@ -56,12 +63,14 @@ public class BackendRoutineQualityGateService {
       OprmNicheRoutineCardRepository routineCardRepository,
       OprmExtractedSignalRepository extractedSignalRepository,
       OprmSourceSnapshotRepository sourceSnapshotRepository,
-      OprmMeiAudienceProfileRepository meiAudienceProfileRepository) {
+      OprmMeiAudienceProfileRepository meiAudienceProfileRepository,
+      OprmNicheCandidateRepository nicheCandidateRepository) {
     this.routineResearchCycleRepository = routineResearchCycleRepository;
     this.routineCardRepository = routineCardRepository;
     this.extractedSignalRepository = extractedSignalRepository;
     this.sourceSnapshotRepository = sourceSnapshotRepository;
     this.meiAudienceProfileRepository = meiAudienceProfileRepository;
+    this.nicheCandidateRepository = nicheCandidateRepository;
   }
 
   /** Lista cartões sintetizados ainda não avaliados com contadores concretos de fontes e sinais. */
@@ -96,11 +105,12 @@ public class BackendRoutineQualityGateService {
       routineCardRepository.save(card);
       cycle.setStatus(qualityStatus);
       cycle.setUpdatedAt(now);
+      cycle.setFinishedAt(now);
       if (isApprovedQualityStatus(qualityStatus)) {
-        cycle.setFinishedAt(now);
         cycle.setErrorMessage(null);
       }
       routineResearchCycleRepository.save(cycle);
+      maybeStartAutomaticReprocess(cycle, card, qualityStatus, now);
       return new CompleteRoutineQualityGateResponse(
           card.getId(), cycle.getId(), cycle.getStatus(), qualityStatus, card.getReadyForHypothesis(),
           card.getSpecificityScore(), card.getConfidenceScore(), card.getDuplicationScore(), card.getQualityCheckedAt());
@@ -113,6 +123,84 @@ public class BackendRoutineQualityGateService {
           ex);
       throw ex;
     }
+  }
+
+  /** Cria automaticamente um novo ciclo quando o gate reprova por causa corrigível e ainda há tentativas disponíveis. */
+  private void maybeStartAutomaticReprocess(
+      OprmRoutineResearchCycle rejectedCycle, OprmNicheRoutineCard rejectedCard, String qualityStatus, Instant now) {
+    if (!isAutomaticReprocessStatus(qualityStatus)) {
+      return;
+    }
+    long automaticAttempts = routineResearchCycleRepository.countBySourceNicheIdAndTriggerSource(
+        rejectedCycle.getSourceNicheId(), AUTO_QUALITY_REPROCESS_TRIGGER);
+    if (automaticAttempts >= MAX_AUTO_REPROCESS_PER_CANDIDATE) {
+      LOGGER.info(
+          "Limite de reprocessamento automático OPRM nichocnae atingido (sourceNicheId={}, rejectedResearchCycleId={}, qualityStatus={}, automaticAttempts={}, limit={})",
+          rejectedCycle.getSourceNicheId(),
+          rejectedCycle.getId(),
+          qualityStatus,
+          automaticAttempts,
+          MAX_AUTO_REPROCESS_PER_CANDIDATE);
+      return;
+    }
+    OprmNicheCandidate candidate = nicheCandidateRepository.findById(rejectedCycle.getSourceNicheId()).orElse(null);
+    if (candidate == null) {
+      LOGGER.warn(
+          "Reprocessamento automático OPRM nichocnae ignorado porque o candidato não foi encontrado (sourceNicheId={}, rejectedResearchCycleId={})",
+          rejectedCycle.getSourceNicheId(),
+          rejectedCycle.getId());
+      return;
+    }
+    OprmRoutineResearchCycle newCycle = createLearningCycle(rejectedCycle, now);
+    OprmRoutineResearchCycle savedCycle = routineResearchCycleRepository.save(newCycle);
+    candidate.setRoutineResearchStatus(ROUTINE_RESEARCH_RUNNING_STATUS);
+    candidate.setLastRoutineResearchCycleId(savedCycle.getId());
+    candidate.setUpdatedAt(now);
+    nicheCandidateRepository.save(candidate);
+    LOGGER.info(
+        "Reprocessamento automático OPRM nichocnae criado preservando aprendizado do gate (previousResearchCycleId={}, newResearchCycleId={}, sourceNicheId={}, cnaeCode={}, qualityStatus={}, qualityNotes={}, automaticAttempt={}/{})",
+        rejectedCycle.getId(),
+        savedCycle.getId(),
+        rejectedCycle.getSourceNicheId(),
+        rejectedCycle.getCnaeCode(),
+        qualityStatus,
+        rejectedCard == null ? null : rejectedCard.getQualityNotes(),
+        automaticAttempts + 1,
+        MAX_AUTO_REPROCESS_PER_CANDIDATE);
+  }
+
+  /** Informa se o status reprovado deve abrir novo ciclo sem clique humano. */
+  private boolean isAutomaticReprocessStatus(String qualityStatus) {
+    return NEEDS_MORE_RESEARCH_STATUS.equals(qualityStatus)
+        || NEEDS_MORE_MEI_RESEARCH_STATUS.equals(qualityStatus)
+        || OUTDATED_SOURCES_STATUS.equals(qualityStatus)
+        || TOO_CORPORATE_STATUS.equals(qualityStatus)
+        || SOLUTION_CONTAMINATED_STATUS.equals(qualityStatus)
+        || GENERIC_STATUS.equals(qualityStatus);
+  }
+
+  /** Cria novo ciclo usando o subnicho já aprendido no ciclo anterior como ponto de partida auditável. */
+  private OprmRoutineResearchCycle createLearningCycle(OprmRoutineResearchCycle previousCycle, Instant now) {
+    OprmRoutineResearchCycle newCycle = new OprmRoutineResearchCycle();
+    newCycle.setSourceNicheId(previousCycle.getSourceNicheId());
+    newCycle.setCnaeCode(previousCycle.getCnaeCode());
+    newCycle.setCnaeDescription(previousCycle.getCnaeDescription());
+    newCycle.setNicheName(previousCycle.getNicheName());
+    newCycle.setOriginalNicheName(previousCycle.getOriginalNicheName());
+    newCycle.setNeutralNicheName(previousCycle.getNeutralNicheName());
+    newCycle.setResearchMode(previousCycle.getResearchMode());
+    newCycle.setSolutionLanguageRiskScore(previousCycle.getSolutionLanguageRiskScore());
+    newCycle.setSourceScore(previousCycle.getSourceScore());
+    newCycle.setTriggerSource(AUTO_QUALITY_REPROCESS_TRIGGER);
+    newCycle.setStatus(CYCLE_STATUS_RUNNING);
+    newCycle.setTotalQueries(0);
+    newCycle.setTotalSourceCandidates(0);
+    newCycle.setTotalSourceSnapshots(0);
+    newCycle.setTotalExtractedSignals(0);
+    newCycle.setStartedAt(now);
+    newCycle.setCreatedAt(now);
+    newCycle.setUpdatedAt(now);
+    return newCycle;
   }
 
   /** Registra falha operacional da avaliação de qualidade no ciclo para investigação posterior. */

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/routineresearchcycle/service/BackendRoutineResearchCycleService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/routineresearchcycle/service/BackendRoutineResearchCycleService.java
@@ -108,6 +108,7 @@ public class BackendRoutineResearchCycleService {
         cycle.getResearchMode(),
         cycle.getSolutionLanguageRiskScore(),
         cycle.getSourceScore(),
+        cycle.getTriggerSource(),
         cycle.getStatus(),
         cycle.getTotalQueries(),
         cycle.getTotalSourceCandidates(),

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/routineresearchcycle/service/listStageExecutions/RoutineResearchCycleExecutionSummaryResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/routineresearchcycle/service/listStageExecutions/RoutineResearchCycleExecutionSummaryResponse.java
@@ -14,6 +14,7 @@ public record RoutineResearchCycleExecutionSummaryResponse(
     String researchMode,
     BigDecimal solutionLanguageRiskScore,
     BigDecimal sourceScore,
+    String triggerSource,
     String status,
     Integer totalQueries,
     Integer totalSourceCandidates,

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/oprm/nichocnae/OprmRoutineResearchCycleRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/oprm/nichocnae/OprmRoutineResearchCycleRepository.java
@@ -34,6 +34,9 @@ public interface OprmRoutineResearchCycleRepository extends JpaRepository<OprmRo
     /** Lista ciclos por status para filas internas do pipeline de pesquisa de rotina. */
     List<OprmRoutineResearchCycle> findByStatusOrderByStartedAtAsc(String status, Pageable pageable);
 
+    /** Conta reprocessamentos automáticos já abertos para o mesmo candidato e fonte de gatilho. */
+    long countBySourceNicheIdAndTriggerSource(Long sourceNicheId, String triggerSource);
+
     /** Lista os ciclos de pesquisa de rotina mais recentes para acompanhamento operacional. */
     List<OprmRoutineResearchCycle> findAllByOrderByStartedAtDesc(Pageable pageable);
 

--- a/backend/ads-service/src/test/java/com/marketinghub/oprm/nichocnae/routinequalitygate/service/BackendRoutineQualityGateServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/oprm/nichocnae/routinequalitygate/service/BackendRoutineQualityGateServiceTest.java
@@ -4,9 +4,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.marketinghub.oprm.cnae.OprmNicheCandidate;
 import com.marketinghub.oprm.nichocnae.OprmExtractedSignal;
 import com.marketinghub.oprm.nichocnae.OprmNicheRoutineCard;
 import com.marketinghub.oprm.nichocnae.OprmRoutineResearchCycle;
@@ -16,11 +18,13 @@ import com.marketinghub.oprm.nichocnae.routinequalitygate.service.completeStageE
 import com.marketinghub.oprm.nichocnae.routinequalitygate.service.completeStageExecution.CompleteRoutineQualityGateResponse;
 import com.marketinghub.oprm.nichocnae.routinequalitygate.service.detailStageExecution.RoutineQualityGateDetailResponse;
 import com.marketinghub.oprm.nichocnae.routinequalitygate.service.pending.RecordRoutineQualityGatePending;
+import com.marketinghub.repository.jpa.oprm.cnae.OprmNicheCandidateRepository;
 import com.marketinghub.repository.jpa.oprm.nichocnae.OprmExtractedSignalRepository;
 import com.marketinghub.repository.jpa.oprm.nichocnae.OprmNicheRoutineCardRepository;
 import com.marketinghub.repository.jpa.oprm.nichocnae.OprmRoutineResearchCycleRepository;
 import com.marketinghub.repository.jpa.oprm.nichocnae.OprmSourceSnapshotRepository;
 import com.marketinghub.repository.jpa.oprm.nichocnae.meiaudienceprofile.OprmMeiAudienceProfileRepository;
+import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
@@ -34,8 +38,15 @@ class BackendRoutineQualityGateServiceTest {
   private final OprmExtractedSignalRepository signalRepository = mock(OprmExtractedSignalRepository.class);
   private final OprmSourceSnapshotRepository snapshotRepository = mock(OprmSourceSnapshotRepository.class);
   private final OprmMeiAudienceProfileRepository meiAudienceProfileRepository = mock(OprmMeiAudienceProfileRepository.class);
+  private final OprmNicheCandidateRepository nicheCandidateRepository = mock(OprmNicheCandidateRepository.class);
   private final BackendRoutineQualityGateService service =
-      new BackendRoutineQualityGateService(cycleRepository, cardRepository, signalRepository, snapshotRepository, meiAudienceProfileRepository);
+      new BackendRoutineQualityGateService(
+          cycleRepository,
+          cardRepository,
+          signalRepository,
+          snapshotRepository,
+          meiAudienceProfileRepository,
+          nicheCandidateRepository);
 
   /** Deve montar pendência com aliases de tipos de sinais já gerados pela etapa cinco. */
   @Test
@@ -115,6 +126,72 @@ class BackendRoutineQualityGateServiceTest {
     assertThat(card.getQualityCheckedAt()).isNotNull();
     verify(cardRepository).save(card);
     verify(cycleRepository).save(cycle);
+  }
+
+
+  /** Deve abrir automaticamente novo ciclo reprovado preservando subnicho e aprendizado para a etapa de seed. */
+  @Test
+  void shouldAutomaticallyReprocessRejectedQualityGateWithinLimit() {
+    OprmRoutineResearchCycle cycle = new OprmRoutineResearchCycle();
+    cycle.setId(1001L);
+    cycle.setSourceNicheId(55L);
+    cycle.setCnaeCode("9602501");
+    cycle.setCnaeDescription("Cabeleireiros, manicure e pedicure");
+    cycle.setNicheName("Manicure autônoma com agenda instável");
+    cycle.setOriginalNicheName("Cabeleireiros, manicure e pedicure");
+    cycle.setNeutralNicheName("Manicure autônoma com agenda instável");
+    cycle.setResearchMode("ROUTINE_REALITY_RESEARCH");
+    cycle.setSolutionLanguageRiskScore(BigDecimal.ZERO);
+    cycle.setSourceScore(BigDecimal.valueOf(91));
+    cycle.setStatus("ROUTINE_SYNTHESIZED");
+    OprmNicheRoutineCard card = card();
+    card.setQualityNotes(
+        "status=TOO_CORPORATE; proximoMovimentoCodigo=TROCAR_PARA_DONO_OPERADOR; proximoMovimento=Focar dono-operador");
+    OprmNicheCandidate candidate = new OprmNicheCandidate();
+    candidate.setId(55L);
+    when(cycleRepository.findById(1001L)).thenReturn(Optional.of(cycle));
+    when(cardRepository.findById(10L)).thenReturn(Optional.of(card));
+    when(cardRepository.save(any(OprmNicheRoutineCard.class))).thenAnswer(invocation -> invocation.getArgument(0));
+    when(cycleRepository.save(any(OprmRoutineResearchCycle.class))).thenAnswer(invocation -> {
+      OprmRoutineResearchCycle saved = invocation.getArgument(0);
+      if (saved.getId() == null) {
+        saved.setId(1002L);
+      }
+      return saved;
+    });
+    when(cycleRepository.countBySourceNicheIdAndTriggerSource(55L, "AUTO_QUALITY_REPROCESS")).thenReturn(2L);
+    when(nicheCandidateRepository.findById(55L)).thenReturn(Optional.of(candidate));
+    when(nicheCandidateRepository.save(any(OprmNicheCandidate.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+    CompleteRoutineQualityGateResponse response = service.complete(1001L, new CompleteRoutineQualityGateRequest(
+        1001L, 10L, "TOO_CORPORATE", false, 75, 80, 10, card.getQualityNotes(), "test"));
+
+    assertThat(response.qualityStatus()).isEqualTo("TOO_CORPORATE");
+    assertThat(cycle.getFinishedAt()).isNotNull();
+    assertThat(candidate.getRoutineResearchStatus()).isEqualTo("RESEARCH_RUNNING");
+    assertThat(candidate.getLastRoutineResearchCycleId()).isEqualTo(1002L);
+    verify(cycleRepository).countBySourceNicheIdAndTriggerSource(55L, "AUTO_QUALITY_REPROCESS");
+    verify(nicheCandidateRepository).save(candidate);
+  }
+
+  /** Deve parar o reprocessamento automático no limite para evitar gasto infinito. */
+  @Test
+  void shouldNotAutomaticallyReprocessWhenLimitWasReached() {
+    OprmRoutineResearchCycle cycle = new OprmRoutineResearchCycle();
+    cycle.setId(1001L);
+    cycle.setSourceNicheId(55L);
+    cycle.setStatus("ROUTINE_SYNTHESIZED");
+    OprmNicheRoutineCard card = card();
+    when(cycleRepository.findById(1001L)).thenReturn(Optional.of(cycle));
+    when(cardRepository.findById(10L)).thenReturn(Optional.of(card));
+    when(cardRepository.save(any(OprmNicheRoutineCard.class))).thenAnswer(invocation -> invocation.getArgument(0));
+    when(cycleRepository.save(any(OprmRoutineResearchCycle.class))).thenAnswer(invocation -> invocation.getArgument(0));
+    when(cycleRepository.countBySourceNicheIdAndTriggerSource(55L, "AUTO_QUALITY_REPROCESS")).thenReturn(3L);
+
+    service.complete(1001L, new CompleteRoutineQualityGateRequest(
+        1001L, 10L, "GENERIC", false, 75, 80, 10, "status=GENERIC", "test"));
+
+    verify(nicheCandidateRepository, never()).save(any(OprmNicheCandidate.class));
   }
 
   /** Deve expor notas de qualidade como objeto JSON tipado para a tela de detalhe. */

--- a/docs/canonical/oprm-canon.v1.md
+++ b/docs/canonical/oprm-canon.v1.md
@@ -303,6 +303,8 @@ Evitar fechamento prematuro de `import run` que destrói a totalização de mark
 - Toda reprovação da etapa `routine-quality-gate` deve produzir um próximo movimento operacional explícito, persistido nas notas estruturadas de qualidade, para evitar que o pipeline apenas pare sem direcionamento.
 - O próximo movimento deve ser escolhido pela causa dominante da reprovação: contaminação de solução, desvio corporativo, fonte antiga, aquisição/canais fracos, dor vendável fraca, rotina genérica ou mix MEI/autônomo incompleto.
 - Quando o gate aprovar o ciclo, o próximo movimento deve apontar para materialização do nicho enriquecido; quando reprovar, deve apontar para a nova pesquisa direcionada ou correção objetiva antes de gastar nova execução profunda.
+- Quando a reprovação do gate for recuperável (`NEEDS_MORE_RESEARCH`, `NEEDS_MORE_MEI_RESEARCH`, `OUTDATED_SOURCES`, `TOO_CORPORATE`, `SOLUTION_CONTAMINATED` ou `GENERIC`), o backend deve iniciar automaticamente novo ciclo de pesquisa até o limite de 3 tentativas automáticas por candidato, sem exigir clique humano a cada reprovação.
+- Cada novo ciclo automático deve preservar o subnicho aprendido e disponibilizar ao seed o status, o próximo movimento e as notas compactadas do gate anterior, para que a próxima execução não perca aprendizado e não repita a mesma causa dominante de reprovação.
 - A tela operacional deve expor esse próximo movimento em linguagem de negócio, mantendo os detalhes técnicos como apoio e não como principal orientação ao usuário.
 
 ## Critério de efetividade — próximo movimento automático no gate NichoCNAE

--- a/docs/canonical/oprm-canon.v1.md
+++ b/docs/canonical/oprm-canon.v1.md
@@ -306,6 +306,7 @@ Evitar fechamento prematuro de `import run` que destrói a totalização de mark
 - Quando a reprovação do gate for recuperável (`NEEDS_MORE_RESEARCH`, `NEEDS_MORE_MEI_RESEARCH`, `OUTDATED_SOURCES`, `TOO_CORPORATE`, `SOLUTION_CONTAMINATED` ou `GENERIC`), o backend deve iniciar automaticamente novo ciclo de pesquisa até o limite de 3 tentativas automáticas por candidato, sem exigir clique humano a cada reprovação.
 - Cada novo ciclo automático deve preservar o subnicho aprendido e disponibilizar ao seed o status, o próximo movimento e as notas compactadas do gate anterior, para que a próxima execução não perca aprendizado e não repita a mesma causa dominante de reprovação.
 - A tela operacional deve expor esse próximo movimento em linguagem de negócio, mantendo os detalhes técnicos como apoio e não como principal orientação ao usuário.
+- Quando houver reprocessamento automático, a tela do fluxo deve informar claramente ao usuário que o novo ciclo foi criado sem clique manual, qual ciclo anterior gerou o aprendizado, qual causa do gate orientou a nova tentativa e quantas tentativas automáticas já foram usadas.
 
 ## Critério de efetividade — próximo movimento automático no gate NichoCNAE
 

--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -707,3 +707,9 @@
 - Adicionado provedor `GOOGLE_CUSTOM_SEARCH_RECENT` na etapa `oprmSourceSearcher`, configurável por variáveis `OPRM_NICHO_CNAE_SOURCE_SEARCHER_GOOGLE_*`, para priorizar fontes brasileiras recentes com `dateRestrict` padrão de 24 meses antes do fallback DuckDuckGo.
 - Causa-raiz tratada: ciclos do CNAE 9602501 estavam chegando ao gate com sinais suficientes, mas bloqueados por `OUTDATED_SOURCES`; a busca anterior dependia somente do DuckDuckGo HTML e frequentemente retornava resultados sem data clara, aumentando risco de fonte antiga.
 - Prevenção de recorrência: criado provedor composto recent-first com fallback auditável, preservando o provider persistido no backend e evitando travar o pipeline caso Google não esteja configurado ou falhe.
+
+## 2026-06-14 — OPRM NichoCNAE: reprocessamento automático com aprendizado entre ciclos
+
+- O gate de qualidade do NichoCNAE passa a abrir automaticamente novo ciclo quando reprovar por causa corrigível (`NEEDS_MORE_RESEARCH`, `NEEDS_MORE_MEI_RESEARCH`, `OUTDATED_SOURCES`, `TOO_CORPORATE`, `SOLUTION_CONTAMINATED` ou `GENERIC`), limitado a 3 reprocessamentos automáticos por candidato para controlar custo.
+- O ciclo reprocessado preserva o subnicho vencedor e as notas estruturadas do gate anterior; a etapa de seed já recebe `previousQualityStatus`, `previousNextMoveCode`, `previousNextMove` e `previousLearningNotes`, evitando perder aprendizado e reduzindo repetição da mesma causa de reprovação.
+- Causa-raiz: o fluxo dependia de clique humano após reprovações recuperáveis, e ciclos reprovados ficavam como decisão terminal sem disparar automaticamente a próxima tentativa orientada pelo aprendizado.

--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -713,3 +713,8 @@
 - O gate de qualidade do NichoCNAE passa a abrir automaticamente novo ciclo quando reprovar por causa corrigível (`NEEDS_MORE_RESEARCH`, `NEEDS_MORE_MEI_RESEARCH`, `OUTDATED_SOURCES`, `TOO_CORPORATE`, `SOLUTION_CONTAMINATED` ou `GENERIC`), limitado a 3 reprocessamentos automáticos por candidato para controlar custo.
 - O ciclo reprocessado preserva o subnicho vencedor e as notas estruturadas do gate anterior; a etapa de seed já recebe `previousQualityStatus`, `previousNextMoveCode`, `previousNextMove` e `previousLearningNotes`, evitando perder aprendizado e reduzindo repetição da mesma causa de reprovação.
 - Causa-raiz: o fluxo dependia de clique humano após reprovações recuperáveis, e ciclos reprovados ficavam como decisão terminal sem disparar automaticamente a próxima tentativa orientada pelo aprendizado.
+
+## 2026-06-14 — OPRM NichoCNAE: transparência do reprocessamento automático na tela do fluxo
+
+- A tela `/oprm/cnaes/:cnaeCode` passa a informar quando o ciclo atual foi criado por reprocessamento automático do gate, mostrando o ciclo anterior, a causa de reprovação, o reaproveitamento do aprendizado e o contador de tentativas automáticas.
+- O resumo de ciclos por CNAE passou a expor `triggerSource`, permitindo diferenciar ciclo manual, fila automática e reprocessamento automático sem depender de inferência visual.

--- a/docs/swagger/oprm-nichocnae-swagger.yaml
+++ b/docs/swagger/oprm-nichocnae-swagger.yaml
@@ -800,6 +800,10 @@ components:
         sourceScore:
           type: number
           nullable: true
+        triggerSource:
+          type: string
+          nullable: true
+          description: Origem do ciclo, incluindo AUTO_QUALITY_REPROCESS quando criado automaticamente pelo gate.
         status:
           type: string
         totalQueries:

--- a/frontend/src/api/oprm/useOprmCnaePipeline.ts
+++ b/frontend/src/api/oprm/useOprmCnaePipeline.ts
@@ -11,6 +11,7 @@ export interface OprmRoutineResearchCycleSummary {
   researchMode: string;
   solutionLanguageRiskScore: number | null;
   sourceScore: number | null;
+  triggerSource: string | null;
   status: string;
   totalQueries: number | null;
   totalSourceCandidates: number | null;

--- a/frontend/src/pages/oprm/OprmCnaeDetailPlaceholderPage.test.tsx
+++ b/frontend/src/pages/oprm/OprmCnaeDetailPlaceholderPage.test.tsx
@@ -83,6 +83,7 @@ describe("OprmCnaeDetailPlaceholderPage", () => {
               researchMode: "ROUTINE_REALITY_RESEARCH",
               solutionLanguageRiskScore: 100,
               sourceScore: 90,
+              triggerSource: "MANUAL_CNAE_DETAIL",
               status: "OUTDATED_SOURCES",
               totalQueries: 48,
               totalSourceCandidates: 340,
@@ -195,6 +196,86 @@ describe("OprmCnaeDetailPlaceholderPage", () => {
     expect(screen.queryByText("Em execução")).toBeNull();
   });
 
+
+  it("informa quando o ciclo atual foi reprocessado automaticamente com aprendizado", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = input.toString();
+
+        if (url.includes("routine-research-cycle/stage-executions")) {
+          return new Response(
+            JSON.stringify([
+              {
+                researchCycleId: 48,
+                sourceNicheId: 1,
+                cnaeCode: "9602501",
+                nicheName: "Manicure autônoma com agenda instável",
+                originalNicheName: "Cabeleireiros, manicure e pedicure",
+                neutralNicheName: "Manicure autônoma com agenda instável",
+                researchMode: "ROUTINE_REALITY_RESEARCH",
+                solutionLanguageRiskScore: 10,
+                sourceScore: 90,
+                triggerSource: "AUTO_QUALITY_REPROCESS",
+                status: "RUNNING",
+                totalQueries: 8,
+                totalSourceCandidates: 20,
+                totalSourceSnapshots: 4,
+                totalExtractedSignals: 12,
+                executionCostUsd: 0.01,
+                cnaeTotalCostUsd: 0.05,
+                startedAt: "2026-06-14T19:07:28Z",
+                finishedAt: null,
+                errorMessage: null,
+              },
+              {
+                researchCycleId: 47,
+                sourceNicheId: 1,
+                cnaeCode: "9602501",
+                nicheName: "Manicure autônoma com agenda instável",
+                originalNicheName: "Cabeleireiros, manicure e pedicure",
+                neutralNicheName: "Manicure autônoma com agenda instável",
+                researchMode: "ROUTINE_REALITY_RESEARCH",
+                solutionLanguageRiskScore: 10,
+                sourceScore: 90,
+                triggerSource: "MANUAL_CNAE_DETAIL",
+                status: "TOO_CORPORATE",
+                totalQueries: 29,
+                totalSourceCandidates: 160,
+                totalSourceSnapshots: 17,
+                totalExtractedSignals: 59,
+                executionCostUsd: 0.0373,
+                cnaeTotalCostUsd: 0.05,
+                startedAt: "2026-06-14T18:33:52Z",
+                finishedAt: "2026-06-14T18:59:59Z",
+                errorMessage: null,
+              },
+            ]),
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          );
+        }
+
+        return new Response("{}", {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }),
+    );
+
+    renderPage();
+
+    expect(
+      await screen.findByText("Reprocessamento automático em andamento"),
+    ).toBeTruthy();
+    expect(
+      screen.getByText(/ciclo #48 foi criado automaticamente depois que o ciclo #47 terminou como corporativo demais/i),
+    ).toBeTruthy();
+    expect(
+      screen.getByText(/tentativas automáticas usadas: 1\/3/i),
+    ).toBeTruthy();
+  });
+
+
   it("diferencia visualmente os cards concluídos e em execução por contraste forte", async () => {
     vi.stubGlobal(
       "fetch",
@@ -209,6 +290,7 @@ describe("OprmCnaeDetailPlaceholderPage", () => {
                 sourceNicheId: 1,
                 cnaeCode: "9602501",
                 nicheName: "Cabeleireiros, manicure e pedicure",
+                triggerSource: "MANUAL_CNAE_DETAIL",
                 status: "RUNNING",
                 totalQueries: 48,
                 totalSourceCandidates: 340,

--- a/frontend/src/pages/oprm/OprmCnaeDetailPlaceholderPage.tsx
+++ b/frontend/src/pages/oprm/OprmCnaeDetailPlaceholderPage.tsx
@@ -136,6 +136,65 @@ const statusLabels: Record<string, string> = {
   ENRICHED_NICHE_FAILED: "Falha na materialização",
 };
 
+
+const AUTO_QUALITY_REPROCESS_TRIGGER = "AUTO_QUALITY_REPROCESS";
+const MAX_AUTO_REPROCESS_PER_CANDIDATE = 3;
+
+function isAutomaticReprocessCycle(
+  cycle?: OprmRoutineResearchCycleSummary | null,
+) {
+  return cycle?.triggerSource === AUTO_QUALITY_REPROCESS_TRIGGER;
+}
+
+function countAutomaticReprocessCycles(
+  cycles?: OprmRoutineResearchCycleSummary[],
+) {
+  return (cycles ?? []).filter(isAutomaticReprocessCycle).length;
+}
+
+function findPreviousCycle(
+  cycles: OprmRoutineResearchCycleSummary[] | undefined,
+  latestCycle?: OprmRoutineResearchCycleSummary | null,
+) {
+  return (cycles ?? []).find(
+    (cycle) => cycle.researchCycleId !== latestCycle?.researchCycleId,
+  );
+}
+
+function automaticProcessMessage(
+  latestCycle?: OprmRoutineResearchCycleSummary | null,
+  previousCycle?: OprmRoutineResearchCycleSummary | null,
+  automaticAttempts = 0,
+) {
+  if (!latestCycle) {
+    return null;
+  }
+  if (isAutomaticReprocessCycle(latestCycle)) {
+    return {
+      title: "Reprocessamento automático em andamento",
+      text: previousCycle
+        ? `O ciclo #${latestCycle.researchCycleId} foi criado automaticamente depois que o ciclo #${previousCycle.researchCycleId} terminou como ${statusLabel(previousCycle.status)}. O sistema reaproveitou o subnicho aprendido e as notas do gate anterior para tentar corrigir a causa sem novo clique.`
+        : `O ciclo #${latestCycle.researchCycleId} foi criado automaticamente. O sistema está reaproveitando o aprendizado do gate anterior para continuar sem novo clique.`,
+      className: "alert alert-primary border mt-3 mb-0",
+    };
+  }
+  if (isQualityBlockedStatus(latestCycle.status)) {
+    const reachedLimit = automaticAttempts >= MAX_AUTO_REPROCESS_PER_CANDIDATE;
+    return {
+      title: reachedLimit
+        ? "Limite automático atingido"
+        : "Aguardando reprocessamento automático",
+      text: reachedLimit
+        ? `O sistema já usou ${automaticAttempts}/${MAX_AUTO_REPROCESS_PER_CANDIDATE} tentativas automáticas para este candidato. Revise o detalhe da etapa de qualidade antes de gastar novo ciclo manual.`
+        : `O gate indicou ${statusLabel(latestCycle.status)}. O backend deve abrir a próxima tentativa automaticamente e carregar este aprendizado para o seed do novo ciclo.`,
+      className: reachedLimit
+        ? "alert alert-warning border mt-3 mb-0"
+        : "alert alert-info border mt-3 mb-0",
+    };
+  }
+  return null;
+}
+
 const qualityBlockedStatuses = new Set([
   "NEEDS_MORE_RESEARCH",
   "NEEDS_MORE_MEI_RESEARCH",
@@ -541,6 +600,13 @@ export default function OprmCnaeDetailPlaceholderPage() {
   const cyclesQuery = useOprmCnaePipelineCycles(decodedCnaeCode);
   const startPipelineMutation = useStartOprmCnaePipeline(decodedCnaeCode);
   const latestCycle = cyclesQuery.data?.[0];
+  const previousCycle = findPreviousCycle(cyclesQuery.data, latestCycle);
+  const automaticAttempts = countAutomaticReprocessCycles(cyclesQuery.data);
+  const automaticProcess = automaticProcessMessage(
+    latestCycle,
+    previousCycle,
+    automaticAttempts,
+  );
   const qualityGateQuery = useOprmRoutineQualityGateDetail(
     latestCycle?.researchCycleId,
   );
@@ -779,6 +845,18 @@ export default function OprmCnaeDetailPlaceholderPage() {
                       </ul>
                     </div>
                   ) : null}
+                </div>
+              ) : null}
+              {automaticProcess ? (
+                <div className={automaticProcess.className} role="status">
+                  <span className="fw-semibold d-block mb-1">
+                    {automaticProcess.title}
+                  </span>
+                  <span>{automaticProcess.text}</span>
+                  <span className="d-block small text-secondary mt-1">
+                    Tentativas automáticas usadas: {automaticAttempts}/
+                    {MAX_AUTO_REPROCESS_PER_CANDIDATE}.
+                  </span>
                 </div>
               ) : null}
               {businessRecommendation ? (


### PR DESCRIPTION
### Motivation
- Introduce automated reprocessing when the `routine-quality-gate` reproves a cycle for recoverable causes so the pipeline can continue without human click for simple corrections. 
- Preserve learning from the rejected cycle (subniche and structured notes) and avoid repeating the same error across retries.

### Description
- Add automatic reprocess flow in `BackendRoutineQualityGateService.complete` that calls `maybeStartAutomaticReprocess` after saving a rejected cycle and card. 
- Implement `maybeStartAutomaticReprocess` and `createLearningCycle` to create a new `OprmRoutineResearchCycle` preserving learned fields and set `triggerSource` to `AUTO_QUALITY_REPROCESS`, with a cap of `MAX_AUTO_REPROCESS_PER_CANDIDATE = 3` attempts. 
- Inject `OprmNicheCandidateRepository` and update `OprmRoutineResearchCycleRepository` with `countBySourceNicheIdAndTriggerSource` to enforce the automatic-attempt limit and update the candidate (`routineResearchStatus` and `lastRoutineResearchCycleId`). 
- Add constants for new statuses/flags and update tests and docs to reflect the new automatic reprocess behavior.

### Testing
- Added and ran unit tests in `BackendRoutineQualityGateServiceTest`, including `shouldAutomaticallyReprocessRejectedQualityGateWithinLimit` and `shouldNotAutomaticallyReprocessWhenLimitWasReached`, which passed. 
- Existing unit tests in the same test class (such as `shouldCompleteQualityGateAndUpdateCycleStatus`, `shouldListPendingWithSignalTypeAliases`, and `shouldDetailQualityNotesAsStructuredObject`) were executed and remained passing. 
- No automated test failures were observed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2efab7630483218798b97f94dd2ddb)