### PR TITLE
Expose raw OpenAI request/response in OPRM seed stage and UI

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/OprmNicheResearchSeed.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/OprmNicheResearchSeed.java
@@ -63,6 +63,12 @@ public class OprmNicheResearchSeed {
     @Column(name = "raw_model_response", columnDefinition = "LONGTEXT")
     private String rawModelResponse;
 
+    @Column(name = "raw_openai_request", columnDefinition = "LONGTEXT")
+    private String rawOpenAiRequest;
+
+    @Column(name = "raw_openai_response", columnDefinition = "LONGTEXT")
+    private String rawOpenAiResponse;
+
     @Column(name = "input_tokens")
     private Integer inputTokens;
 

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/nicheresearchseedbuilder/service/BackendNicheResearchSeedBuilderService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/nicheresearchseedbuilder/service/BackendNicheResearchSeedBuilderService.java
@@ -206,6 +206,8 @@ public class BackendNicheResearchSeedBuilderService {
     seed.setCreatedAt(now);
     seed.setModel(trimToNull(request == null ? null : request.model()));
     seed.setRawModelResponse(trimToNull(request == null ? null : request.rawModelResponse()));
+    seed.setRawOpenAiRequest(trimToNull(request == null ? null : request.rawOpenAiRequest()));
+    seed.setRawOpenAiResponse(trimToNull(request == null ? null : request.rawOpenAiResponse()));
     seed.setInputTokens(request == null ? null : request.inputTokens());
     seed.setOutputTokens(request == null ? null : request.outputTokens());
     seed.setCostUsd(estimateCostUsd(request));
@@ -479,6 +481,8 @@ public class BackendNicheResearchSeedBuilderService {
         seed.getCreatedAt(),
         seed.getModel(),
         seed.getRawModelResponse(),
+        seed.getRawOpenAiRequest(),
+        seed.getRawOpenAiResponse(),
         seed.getInputTokens(),
         seed.getOutputTokens(),
         seed.getCostUsd(),

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/nicheresearchseedbuilder/service/completeStageExecution/CompleteNicheResearchSeedBuilderRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/nicheresearchseedbuilder/service/completeStageExecution/CompleteNicheResearchSeedBuilderRequest.java
@@ -14,7 +14,44 @@ public record CompleteNicheResearchSeedBuilderRequest(
     String createdBy,
     String model,
     String rawModelResponse,
+    String rawOpenAiRequest,
+    String rawOpenAiResponse,
     Integer inputTokens,
     Integer outputTokens,
     String openAiResponseId,
-    List<NicheResearchQueryRequest> queries) {}
+    List<NicheResearchQueryRequest> queries) {
+  /** Mantém compatibilidade com chamadas antigas que ainda não enviam payloads crus da OpenAI. */
+  public CompleteNicheResearchSeedBuilderRequest(
+      String nicheName,
+      String businessType,
+      String operationType,
+      String customerType,
+      String commercialObjects,
+      String initialAssumptions,
+      String confidenceLevel,
+      String createdBy,
+      String model,
+      String rawModelResponse,
+      Integer inputTokens,
+      Integer outputTokens,
+      String openAiResponseId,
+      List<NicheResearchQueryRequest> queries) {
+    this(
+        nicheName,
+        businessType,
+        operationType,
+        customerType,
+        commercialObjects,
+        initialAssumptions,
+        confidenceLevel,
+        createdBy,
+        model,
+        rawModelResponse,
+        null,
+        null,
+        inputTokens,
+        outputTokens,
+        openAiResponseId,
+        queries);
+  }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/nicheresearchseedbuilder/service/completeStageExecution/CompleteNicheResearchSeedBuilderResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/nicheresearchseedbuilder/service/completeStageExecution/CompleteNicheResearchSeedBuilderResponse.java
@@ -20,6 +20,8 @@ public record CompleteNicheResearchSeedBuilderResponse(
     Instant createdAt,
     String model,
     String rawModelResponse,
+    String rawOpenAiRequest,
+    String rawOpenAiResponse,
     Integer inputTokens,
     Integer outputTokens,
     java.math.BigDecimal costUsd,

--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-14-oprm-seed-builder-openai-raw-payloads.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-14-oprm-seed-builder-openai-raw-payloads.yaml
@@ -1,0 +1,23 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-06-14-oprm-seed-builder-openai-raw-payloads
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - onError: HALT
+        - dbms:
+            type: mysql
+        - tableExists:
+            tableName: oprm_niche_research_seed
+        - not:
+            columnExists:
+              tableName: oprm_niche_research_seed
+              columnName: raw_openai_request
+      changes:
+        - sql:
+            splitStatements: true
+            stripComments: true
+            sql: |
+              ALTER TABLE oprm_niche_research_seed
+                ADD COLUMN raw_openai_request LONGTEXT NULL AFTER raw_model_response,
+                ADD COLUMN raw_openai_response LONGTEXT NULL AFTER raw_openai_request;

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -1,5 +1,8 @@
 databaseChangeLog:
   - include:
+      file: changesets/2026-06-14-oprm-seed-builder-openai-raw-payloads.yaml
+      relativeToChangelogFile: true
+  - include:
       file: changesets/2026-06-12-facebook-campaign-stop-reason-varchar.yaml
       relativeToChangelogFile: true
   - include:

--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -718,3 +718,9 @@
 
 - A tela `/oprm/cnaes/:cnaeCode` passa a informar quando o ciclo atual foi criado por reprocessamento automático do gate, mostrando o ciclo anterior, a causa de reprovação, o reaproveitamento do aprendizado e o contador de tentativas automáticas.
 - O resumo de ciclos por CNAE passou a expor `triggerSource`, permitindo diferenciar ciclo manual, fila automática e reprocessamento automático sem depender de inferência visual.
+
+## 2026-06-14 — Auditoria crua OpenAI no pipeline NichoCNAE
+
+- A tela de detalhe das etapas OPRM passou a destacar request cru enviado à OpenAI e resposta crua recebida sempre que a etapa usa modelo.
+- A etapa `oprmNicheResearchSeedBuilder` passou a persistir o payload completo enviado à Responses API e o corpo completo retornado pela OpenAI, além da resposta estruturada já existente.
+- As demais etapas foram verificadas: no fluxo NichoCNAE atual, `seed` e `mei` declaram acesso ao modelo; `seed` recebeu persistência completa nesta alteração e a tela mostra alerta objetivo quando uma etapa com IA ainda não tiver payload cru persistido.

--- a/frontend/src/pages/oprm/OprmCnaePipelineStageDetailPage.tsx
+++ b/frontend/src/pages/oprm/OprmCnaePipelineStageDetailPage.tsx
@@ -160,6 +160,13 @@ function asRecord(value: unknown): Record<string, unknown> | null {
     : null;
 }
 
+function rawTextValue(value: unknown) {
+  if (value === null || value === undefined || value === "") {
+    return null;
+  }
+  return typeof value === "string" ? value : formatJson(value);
+}
+
 function textValue(value: unknown) {
   if (value === null || value === undefined || value === "") {
     return "não informado";
@@ -177,11 +184,13 @@ function buildAiTelemetry(metadata: StageMetadata, data: unknown, configuredMode
     modelo: textValue(seed?.model ?? configuredModel ?? metadata.aiModel ?? "modelo configurado na tela de pipeline"),
     request: metadata.aiRequestSummary,
     response: textValue(seed?.openAiResponseId ?? metadata.aiResponseSummary),
+    rawRequest: rawTextValue(seed?.rawOpenAiRequest ?? seed?.rawRequest ?? seed?.requestBodyJson),
+    rawResponse: rawTextValue(seed?.rawOpenAiResponse ?? seed?.rawResponse ?? seed?.rawModelResponse),
     tokensEntrada: textValue(seed?.inputTokens),
     tokensSaida: textValue(seed?.outputTokens),
     custoUsd: seed?.costUsd == null ? "não informado" : `US$ ${seed.costUsd}`,
     hasPersistedTelemetry:
-      seed?.model != null || seed?.inputTokens != null || seed?.outputTokens != null || seed?.costUsd != null,
+      seed?.model != null || seed?.inputTokens != null || seed?.outputTokens != null || seed?.costUsd != null || seed?.rawOpenAiRequest != null || seed?.rawOpenAiResponse != null,
   };
 }
 
@@ -317,6 +326,26 @@ export default function OprmCnaePipelineStageDetailPage() {
                     <dt className="col-md-3 text-secondary fw-normal">Custo</dt>
                     <dd className="col-md-9 mb-0">{aiTelemetry.custoUsd}</dd>
                   </dl>
+                  {aiTelemetry.rawRequest || aiTelemetry.rawResponse ? (
+                    <div className="row g-3">
+                      <div className="col-12 col-xl-6">
+                        <h3 className="h6">Request cru enviado para OpenAI</h3>
+                        <pre className="bg-body-tertiary border rounded p-3 small overflow-auto mb-0" style={{ maxHeight: 420 }}>
+                          {aiTelemetry.rawRequest ?? "não informado"}
+                        </pre>
+                      </div>
+                      <div className="col-12 col-xl-6">
+                        <h3 className="h6">Resposta crua recebida da OpenAI</h3>
+                        <pre className="bg-body-tertiary border rounded p-3 small overflow-auto mb-0" style={{ maxHeight: 420 }}>
+                          {aiTelemetry.rawResponse ?? "não informado"}
+                        </pre>
+                      </div>
+                    </div>
+                  ) : (
+                    <div className="alert alert-warning mb-0 small" role="status">
+                      Esta etapa usa modelo OpenAI, mas ainda não possui request e resposta crus persistidos para esta execução.
+                    </div>
+                  )}
                   {!aiTelemetry.hasPersistedTelemetry ? (
                     <div className="alert alert-info mb-0 small" role="status">
                       Esta execução ainda não possui telemetria persistida para a

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnae/nicheresearchseedbuilder/NicheResearchSeedBuilderBackendClient.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnae/nicheresearchseedbuilder/NicheResearchSeedBuilderBackendClient.java
@@ -111,6 +111,8 @@ public class NicheResearchSeedBuilderBackendClient {
                 seed.createdBy(),
                 result.model(),
                 result.rawModelResponse(),
+                result.rawOpenAiRequest(),
+                result.rawOpenAiResponse(),
                 result.inputTokens(),
                 result.outputTokens(),
                 result.openAiResponseId(),

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnae/nicheresearchseedbuilder/NicheResearchSeedBuilderBackendCompletionRequest.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnae/nicheresearchseedbuilder/NicheResearchSeedBuilderBackendCompletionRequest.java
@@ -14,6 +14,8 @@ public record NicheResearchSeedBuilderBackendCompletionRequest(
         String createdBy,
         String model,
         String rawModelResponse,
+        String rawOpenAiRequest,
+        String rawOpenAiResponse,
         Integer inputTokens,
         Integer outputTokens,
         String openAiResponseId,

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnae/nicheresearchseedbuilder/NicheResearchSeedBuilderBackendCompletionResponse.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnae/nicheresearchseedbuilder/NicheResearchSeedBuilderBackendCompletionResponse.java
@@ -20,6 +20,8 @@ public record NicheResearchSeedBuilderBackendCompletionResponse(
         Instant createdAt,
         String model,
         String rawModelResponse,
+        String rawOpenAiRequest,
+        String rawOpenAiResponse,
         Integer inputTokens,
         Integer outputTokens,
         java.math.BigDecimal costUsd,

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnae/nicheresearchseedbuilder/NicheResearchSeedBuilderCompletionRequest.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnae/nicheresearchseedbuilder/NicheResearchSeedBuilderCompletionRequest.java
@@ -5,6 +5,8 @@ public record NicheResearchSeedBuilderCompletionRequest(
         NicheResearchSeedBuilderOutput output,
         String model,
         String rawModelResponse,
+        String rawOpenAiRequest,
+        String rawOpenAiResponse,
         Integer inputTokens,
         Integer outputTokens,
         String openAiResponseId) {}

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnae/nicheresearchseedbuilder/OpenAiNicheResearchSeedBuilderClient.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnae/nicheresearchseedbuilder/OpenAiNicheResearchSeedBuilderClient.java
@@ -54,16 +54,20 @@ public class OpenAiNicheResearchSeedBuilderClient {
         Map<String, Object> requestBody = buildRequestBody(prompt, model);
         String url = properties.baseUrl() + RESPONSES_PATH;
         try {
+            String rawOpenAiRequest = objectMapper.writeValueAsString(requestBody);
             Map<String, Object> raw = responseBody(url, requestBody, apiKey);
             if (raw == null) {
                 throw new IllegalStateException("OpenAI retornou corpo vazio para a etapa dois OPRM nichocnae.");
             }
+            String rawOpenAiResponse = objectMapper.writeValueAsString(raw);
             String rawModelResponse = extractModelResponse(raw);
             NicheResearchSeedBuilderOutput output =
                     objectMapper.readValue(rawModelResponse, NicheResearchSeedBuilderOutput.class);
             return new OpenAiSeedBuilderResult(
                     output,
                     rawModelResponse,
+                    rawOpenAiRequest,
+                    rawOpenAiResponse,
                     extractInteger(raw, "usage", "input_tokens"),
                     extractInteger(raw, "usage", "output_tokens"),
                     stringValue(raw.get("id")),

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnae/nicheresearchseedbuilder/OpenAiSeedBuilderResult.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnae/nicheresearchseedbuilder/OpenAiSeedBuilderResult.java
@@ -4,6 +4,8 @@ package com.marketinghub.nichocnae.nicheresearchseedbuilder;
 public record OpenAiSeedBuilderResult(
         NicheResearchSeedBuilderOutput output,
         String rawModelResponse,
+        String rawOpenAiRequest,
+        String rawOpenAiResponse,
         Integer inputTokens,
         Integer outputTokens,
         String openAiResponseId,

--- a/oprm-coletor-mei/src/test/java/com/marketinghub/nichocnae/nicheresearchseedbuilder/NicheResearchSeedBuilderBackendClientTest.java
+++ b/oprm-coletor-mei/src/test/java/com/marketinghub/nichocnae/nicheresearchseedbuilder/NicheResearchSeedBuilderBackendClientTest.java
@@ -38,6 +38,8 @@ class NicheResearchSeedBuilderBackendClientTest {
                 new OpenAiSeedBuilderResult(
                         new NicheResearchSeedBuilderOutput(1L, seed, List.of(query)),
                         "{\"seed\":true}",
+                        "{\"input\":true}",
+                        "{\"id\":\"resp_seed\"}",
                         1200,
                         800,
                         "resp_seed",
@@ -52,6 +54,8 @@ class NicheResearchSeedBuilderBackendClientTest {
         assertThat(request.confidenceLevel()).isEqualTo("HIGH");
         assertThat(request.createdBy()).isEqualTo("AI");
         assertThat(request.model()).isEqualTo("gpt-5.4");
+        assertThat(request.rawOpenAiRequest()).isEqualTo("{\"input\":true}");
+        assertThat(request.rawOpenAiResponse()).isEqualTo("{\"id\":\"resp_seed\"}");
         assertThat(request.inputTokens()).isEqualTo(1200);
         assertThat(request.outputTokens()).isEqualTo(800);
         assertThat(request.openAiResponseId()).isEqualTo("resp_seed");
@@ -91,6 +95,8 @@ class NicheResearchSeedBuilderBackendClientTest {
                 null,
                 "gpt-5.4",
                 "{\"seed\":true}",
+                "{\"input\":true}",
+                "{\"id\":\"resp_seed\"}",
                 1200,
                 800,
                 new java.math.BigDecimal("0.0123"),

--- a/oprm-coletor-mei/src/test/java/com/marketinghub/nichocnae/nicheresearchseedbuilder/NicheResearchSeedBuilderProcessorTest.java
+++ b/oprm-coletor-mei/src/test/java/com/marketinghub/nichocnae/nicheresearchseedbuilder/NicheResearchSeedBuilderProcessorTest.java
@@ -24,7 +24,7 @@ class NicheResearchSeedBuilderProcessorTest {
         NicheResearchSeedBuilderProcessor processor = new NicheResearchSeedBuilderProcessor(openAiClient, backendClient);
         NicheResearchSeedBuilderPending pending = pending();
         NicheResearchSeedBuilderOutput output = output();
-        OpenAiSeedBuilderResult generated = new OpenAiSeedBuilderResult(output, "{}", 10, 20, "resp_123", "gpt-test");
+        OpenAiSeedBuilderResult generated = new OpenAiSeedBuilderResult(output, "{}", "{\"input\":true}", "{\"id\":\"resp_123\"}", 10, 20, "resp_123", "gpt-test");
         when(openAiClient.generate(pending)).thenReturn(generated);
         when(backendClient.completeStageExecution(generated)).thenReturn(output);
 


### PR DESCRIPTION
### Motivation

- Provide full auditability of OpenAI calls for OPRM stages that use models by persisting the raw request and raw response payloads alongside the existing structured outputs. 
- Surface those raw payloads in the pipeline UI so operators can inspect exactly what was sent to and returned by the OpenAI Responses API. 
- Keep backwards compatibility with existing callers and avoid contaminating final artifacts with technical metadata by adding explicit fields and a Liquibase changelog.

### Description

- Added Liquibase changelog `2026-06-14-oprm-seed-builder-openai-raw-payloads.yaml` to add `raw_openai_request` and `raw_openai_response` LONGTEXT columns to `oprm_niche_research_seed`. 
- Extended JPA entity `OprmNicheResearchSeed` to include `rawOpenAiRequest` and `rawOpenAiResponse` fields mapped to the new columns. 
- Updated backend DTOs and service code in `backend/ads-service` to accept, persist and return the raw payloads (`CompleteNicheResearchSeedBuilderRequest/Response`, `BackendNicheResearchSeedBuilderService::createSeed` and `toResponse`). A compatibility constructor was added to the request DTO to preserve older callers. 
- Updated the OPRM collector `oprm-coletor-mei` OpenAI client (`OpenAiNicheResearchSeedBuilderClient`) to serialize and keep the request body and the raw response (`rawOpenAiRequest`, `rawOpenAiResponse`) and to propagate them through `OpenAiSeedBuilderResult` and backend completion requests. 
- Frontend: changed `OprmCnaePipelineStageDetailPage.tsx` to compute and render `Request cru enviado para OpenAI` and `Resposta crua recebida da OpenAI` when raw payload telemetry is available, and show a clear alert when an AI stage has no raw payload persisted. 
- Documentation: recorded the change in `docs/registros/oprm1.md` describing the telemetry and UI change.

### Testing

- Backend compile (ads-service) with `mvn -DskipTests compile` completed successfully. 
- Collector module compile and unit tests in `oprm-coletor-mei` were executed (`mvn test` during the rollout) and adjusted tests passed after adding the new fields. 
- Targeted backend unit test `BackendNicheResearchSeedBuilderServiceTest` was exercised and code was updated (compatibility constructor) so the affected tests compile and run in the modified tree. 
- Frontend build succeeded with `npm run build` producing the production `dist` artifacts.

All automated checks run during the rollout finished after small test fixes and code updates; frontend build succeeded and Java modules compiled.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2f1eeb9da48321aba86eccd015819b)