### PR TITLE
fix(oprm): preserve qualified niche in quality gate

### DIFF
--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -741,3 +741,10 @@
 - A tela de detalhe das etapas OPRM passou a destacar request cru enviado à OpenAI e resposta crua recebida sempre que a etapa usa modelo.
 - A etapa `oprmNicheResearchSeedBuilder` passou a persistir o payload completo enviado à Responses API e o corpo completo retornado pela OpenAI, além da resposta estruturada já existente.
 - As demais etapas foram verificadas: no fluxo NichoCNAE atual, `seed` e `mei` declaram acesso ao modelo; `seed` recebeu persistência completa nesta alteração e a tela mostra alerta objetivo quando uma etapa com IA ainda não tiver payload cru persistido.
+
+## 2026-06-15 — OPRM NichoCNAE: correção do gate para não descartar nicho bom por contador incompleto
+
+- Investigado o CNAE 9602501 após reprovações sucessivas no gate de qualidade, incluindo ciclos recentes com muitos sinais, fontes brasileiras e subnicho comercialmente claro de manicure autônoma em domicílio.
+- Causa-raiz tratada: o gate exigia dor prática apenas pelos contadores estruturados; quando a síntese textual trazia falta, remarcação, agenda instável, retrabalho e cobrança, mas os contadores vinham zerados, o mix MEI/autônomo ficava falso e o nicho bom era descartado.
+- Correção aplicada: o gate agora reconhece dor prática também no texto do card, relaxa bloqueios automáticos quando o risco de solução/fonte antiga é residual e existem evidências recentes suficientes, mantendo bloqueio forte para contaminação textual ou perfil realmente dominado por solução.
+- Prevenção de recorrência: adicionado teste de regressão simulando o caso do ciclo 53, garantindo aprovação quando há rotina executora, dor vendável textual, aquisição/canais e fontes brasileiras recentes mesmo com contadores de dor prática zerados.

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnae/routinequalitygate/RoutineQualityGateEngine.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnae/routinequalitygate/RoutineQualityGateEngine.java
@@ -48,14 +48,20 @@ public class RoutineQualityGateEngine {
         boolean hasCommercialAcquisitionEvidence = hasAcquisitionOrChannelCounter
                 && hasUsefulCustomerBehaviorSummary
                 && hasUsefulChannelsSummary;
-        boolean hasPracticalPain = value(pending.operationalDifficultyCount()) > 0 || value(pending.painSignalCount()) > 0;
+        boolean hasPracticalPain = value(pending.operationalDifficultyCount()) > 0
+                || value(pending.painSignalCount()) > 0
+                || hasTextualPracticalPain(pending);
         boolean hasHumanOutcome = value(pending.emotionalOutcomeEvidenceCount()) > 0;
         boolean hasMinimumSignalMix = hasRoutineTask && hasCommercialAcquisitionEvidence && hasPracticalPain && hasHumanOutcome;
         boolean weakAcquisitionOrChannels = !hasCommercialAcquisitionEvidence;
         boolean weakSellablePain = sellablePainScore < MIN_SELLABLE_PAIN_SCORE;
-        boolean dominatedBySolution = effectiveSolutionRiskScore > MAX_ACCEPTABLE_SOLUTION_RISK
+        boolean dominatedBySolution = (effectiveSolutionRiskScore > MAX_ACCEPTABLE_SOLUTION_RISK
+                        && (textualSolutionRiskScore > MAX_ACCEPTABLE_SOLUTION_RISK
+                                || value(pending.solutionLanguageRiskCount()) > signalCount / 2
+                                || value(pending.profileSolutionLanguageRiskScore()) >= 70))
                 || value(pending.solutionLanguageRiskCount()) > signalCount / 2;
-        boolean outdated = outdatedRiskScore > MAX_ACCEPTABLE_OUTDATED_RISK || !hasRecentSources;
+        boolean outdated = !hasRecentSources
+                || (outdatedRiskScore > MAX_ACCEPTABLE_OUTDATED_RISK && value(pending.recentSourceCount()) < 3);
         boolean tooCorporate = corporateRiskScore > MAX_ACCEPTABLE_CORPORATE_RISK || value(pending.autonomousProfessionalFitScore()) < 50;
         boolean commerciallyPromisingNeedsExecutorRoutine = !routineRevealsExecutorTasks
                 && hasRequiredSummaries
@@ -269,6 +275,30 @@ public class RoutineQualityGateEngine {
         return clamp(matches * 12);
     }
 
+
+    /** Identifica dor prática no texto quando a extração trouxe a dor no resumo, mas não preencheu contadores estruturados. */
+    private boolean hasTextualPracticalPain(RoutineQualityGatePending pending) {
+        String text = normalize(String.join(
+                " ",
+                nullToEmpty(pending.painsSummary()),
+                nullToEmpty(pending.customerBehaviorSummary())));
+        return containsAnyTerm(text, List.of(
+                "falta",
+                "faltas",
+                "atraso",
+                "remarcacao",
+                "desmarc",
+                "retrabalho",
+                "perda de agenda",
+                "agenda instavel",
+                "agenda vazia",
+                "horario vazio",
+                "cobranca",
+                "falha no atendimento",
+                "material",
+                "no show"));
+    }
+
     /** Mede se a dor é vendável, exigindo urgência, recorrência, impacto financeiro e resultado desejado. */
     private int calculateSellablePainScore(RoutineQualityGatePending pending) {
         String text = normalize(String.join(
@@ -339,6 +369,7 @@ public class RoutineQualityGateEngine {
         notes.add("resumoCanaisUtil=" + hasUsefulChannelsSummary);
         notes.add("faltaEvidenciaAquisicaoCanaisRecorrenciaOuComportamentoClientes=" + weakAcquisitionOrChannels);
         notes.add("dorPratica=" + (value(pending.operationalDifficultyCount()) + value(pending.painSignalCount())));
+        notes.add("dorPraticaTextual=" + hasTextualPracticalPain(pending));
         notes.add("dorEmocionalSonhoOuMedo=" + value(pending.emotionalOutcomeEvidenceCount()));
         notes.add("dorVendavelScore=" + sellablePainScore);
         notes.add("dorVendavelSuficiente=" + !weakSellablePain);

--- a/oprm-coletor-mei/src/test/java/com/marketinghub/nichocnae/routinequalitygate/RoutineQualityGateEngineTest.java
+++ b/oprm-coletor-mei/src/test/java/com/marketinghub/nichocnae/routinequalitygate/RoutineQualityGateEngineTest.java
@@ -536,6 +536,60 @@ class RoutineQualityGateEngineTest {
         assertThat(decision.qualityNotes()).contains("proximoMovimentoCodigo=TROCAR_PARA_DONO_OPERADOR");
     }
 
+    /** Deve aprovar nicho com dor prática textual quando os contadores estruturados vierem zerados. */
+    @Test
+    void shouldApproveWhenPracticalPainIsPresentInTextButCountersAreMissing() {
+        RoutineQualityGatePending pending = new RoutineQualityGatePending(
+                41L,
+                53L,
+                "Manicure e pedicure autônoma que atende em domicílio",
+                text("Rotina concreta: lixar unhas, retirar cutícula, esmaltar unhas, aplicar gel e higienizar materiais", 8),
+                text("Dores práticas de falta, remarcação, agenda instável, retrabalho na esmaltação e cobrança", 8),
+                text("Resultados desejados com agenda cheia, retorno quinzenal, recorrência e previsibilidade", 8),
+                text("Dores emocionais de insegurança, pressão, reputação e medo de perder clientes", 8),
+                "Clientes chegam por WhatsApp, Instagram e indicação, pedem orçamento, remarcam e retornam por agenda recorrente.",
+                "Canais usados: WhatsApp, Instagram, indicação de clientes do bairro e mensagens para confirmação de horário.",
+                "Evidências em fontes públicas brasileiras",
+                "unhadecoradasimples.com.br,gauchazh.clicrbs.com.br,instagram.com,sebraepr.com.br,blog.organizabot.com",
+                80,
+                17,
+                53,
+                6,
+                0,
+                0,
+                4,
+                15,
+                12,
+                6,
+                0,
+                86,
+                84,
+                72,
+                44,
+                13,
+                6,
+                11,
+                0,
+                12,
+                6,
+                95,
+                79,
+                80,
+                65,
+                27,
+                44,
+                Instant.parse("2026-06-15T00:10:00Z"));
+
+        RoutineQualityDecision decision = engine.evaluate(pending);
+
+        assertThat(decision.qualityStatus()).isEqualTo("MEI_AUDIENCE_READY");
+        assertThat(decision.readyForHypothesis()).isTrue();
+        assertThat(decision.qualityNotes())
+                .contains("dorPraticaTextual=true")
+                .contains("dominadoPorSolucao=false")
+                .contains("proximoMovimentoCodigo=MATERIALIZAR_NICHO");
+    }
+
     /** Cria uma pendência mínima da etapa sete para validar as regras do engine. */
     private RoutineQualityGatePending pending(
             String routineSummary,


### PR DESCRIPTION
### Motivation
- The gate was discarding commercially-valid niches (example CNAE 9602501) when practical pain appeared only in the synthesized text while the structured pain counters were zero.  
- That caused repeated false negatives (good niches marked GENERIC/REJECTED) and wasted collection/processing budget; the gate needed to consider textual evidence as fallback and avoid rejecting when contamination risk is residual.

### Description
- Add a textual pain detector `hasTextualPracticalPain(...)` and include it in the `hasPracticalPain` predicate so the engine recognizes practical pain coming from card text.  
- Relax the `dominatedBySolution` and `outdated` heuristics to require stronger textual/aggregate signals before hard-failing a card, while keeping strong blocking when contamination is real.  
- Expose `dorPraticaTextual` in the gate `qualityNotes` for traceability and debugging.  
- Add a regression unit test (`RoutineQualityGateEngineTest`) that reproduces the CNAE 9602501/cycle-53 case and asserts approval as `MEI_AUDIENCE_READY`, and update `docs/registros/oprm1.md` with the investigation and fix rationale.

### Testing
- Ran targeted unit tests: `mvn -q -Dtest=RoutineQualityGateEngineTest test`, and the modified engine tests passed.  
- Ran module test suite: `mvn -q test`; the full test run encountered unrelated failures caused by external integrations (OpenAI / network `Broken pipe`), so the unrelated tests failed while the focused regression for the gate succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2f4cb6c7108321a62e1fd8956e4b86)