### PR TITLE
Expose list of enriched niches by CNAE and show them on CNAE detail page

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/enrichednichematerializer/service/BackendEnrichedNicheMaterializerService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/enrichednichematerializer/service/BackendEnrichedNicheMaterializerService.java
@@ -16,6 +16,7 @@ import com.marketinghub.oprm.nichocnae.enrichednichematerializer.service.detailS
 import com.marketinghub.oprm.nichocnae.enrichednichematerializer.service.diagnoseContamination.ContaminatedNicheDiagnosticItem;
 import com.marketinghub.oprm.nichocnae.enrichednichematerializer.service.diagnoseContamination.ContaminatedNicheDiagnosticResponse;
 import com.marketinghub.oprm.nichocnae.enrichednichematerializer.service.failStageExecution.FailEnrichedNicheMaterializerRequest;
+import com.marketinghub.oprm.nichocnae.enrichednichematerializer.service.generatedByCnae.GeneratedEnrichedNicheByCnaeResponse;
 import com.marketinghub.oprm.nichocnae.enrichednichematerializer.service.pending.RecordEnrichedNicheMaterializerPending;
 import com.marketinghub.oprm.nichocnae.meiaudienceprofile.OprmMeiAudienceProfile;
 import com.marketinghub.repository.jpa.niche.MarketNicheEnrichmentProfileRepository;
@@ -176,6 +177,15 @@ public class BackendEnrichedNicheMaterializerService {
     return buildDetailResponse(cycle, card, profile);
   }
 
+  /** Lista os nichos enriquecidos já gerados para o CNAE informado. */
+  @Transactional(readOnly = true)
+  public List<GeneratedEnrichedNicheByCnaeResponse> listGeneratedByCnae(String cnaeCode, int limit) {
+    int boundedLimit = Math.max(1, Math.min(limit, 100));
+    return enrichmentProfileRepository.findGeneratedByCnaeCode(cnaeCode, PageRequest.of(0, boundedLimit)).stream()
+        .map(this::toGeneratedByCnaeResponse)
+        .toList();
+  }
+
   /** Gera o documento Markdown de auditoria do pipeline completo a partir do perfil enriquecido final. */
   @Transactional(readOnly = true)
   public String buildPipelineMarkdownByProfileId(Long profileId) {
@@ -238,6 +248,22 @@ public class BackendEnrichedNicheMaterializerService {
         profile == null ? scoreOrZero(card == null ? null : card.getSourceDiversityScore()) : profile.getSourceDiversityScore(),
         profile == null ? scoreOrZero(card == null ? null : card.getSolutionLanguageRiskScore()) : profile.getSolutionLanguageRiskScore(),
         profile == null ? null : profile.getCreatedAt());
+  }
+
+  /** Converte o perfil enriquecido em resumo para a lista de nichos do CNAE. */
+  private GeneratedEnrichedNicheByCnaeResponse toGeneratedByCnaeResponse(MarketNicheEnrichmentProfile profile) {
+    return new GeneratedEnrichedNicheByCnaeResponse(
+        profile.getId(),
+        profile.getMarketNiche().getId(),
+        profile.getResearchCycleId(),
+        profile.getCnaeCode(),
+        profile.getCnaeDescription(),
+        profile.getNeutralNicheName(),
+        profile.getQualityStatus(),
+        profile.getRoutineEvidenceScore(),
+        profile.getDifficultyEvidenceScore(),
+        profile.getSourceDiversityScore(),
+        profile.getCreatedAt());
   }
 
   /** Confirma se a pendência final tem perfil MEI/autônomo do próprio ciclo antes de expor ao coletor. */

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/enrichednichematerializer/service/generatedByCnae/GeneratedEnrichedNicheByCnaeResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/enrichednichematerializer/service/generatedByCnae/GeneratedEnrichedNicheByCnaeResponse.java
@@ -1,0 +1,17 @@
+package com.marketinghub.oprm.nichocnae.enrichednichematerializer.service.generatedByCnae;
+
+import java.time.Instant;
+
+/** Resumo público de um nicho enriquecido já gerado para um CNAE. */
+public record GeneratedEnrichedNicheByCnaeResponse(
+    Long enrichedNicheProfileId,
+    Long marketNicheId,
+    Long researchCycleId,
+    String cnaeCode,
+    String cnaeDescription,
+    String nicheName,
+    String qualityStatus,
+    Integer routineEvidenceScore,
+    Integer difficultyEvidenceScore,
+    Integer sourceDiversityScore,
+    Instant materializedAt) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/enrichednichematerializer/web/BackendEnrichedNicheMaterializerController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/enrichednichematerializer/web/BackendEnrichedNicheMaterializerController.java
@@ -6,6 +6,7 @@ import com.marketinghub.oprm.nichocnae.enrichednichematerializer.service.complet
 import com.marketinghub.oprm.nichocnae.enrichednichematerializer.service.detailStageExecution.EnrichedNicheMaterializerDetailResponse;
 import com.marketinghub.oprm.nichocnae.enrichednichematerializer.service.diagnoseContamination.ContaminatedNicheDiagnosticResponse;
 import com.marketinghub.oprm.nichocnae.enrichednichematerializer.service.failStageExecution.FailEnrichedNicheMaterializerRequest;
+import com.marketinghub.oprm.nichocnae.enrichednichematerializer.service.generatedByCnae.GeneratedEnrichedNicheByCnaeResponse;
 import com.marketinghub.oprm.nichocnae.enrichednichematerializer.service.pending.RecordEnrichedNicheMaterializerPending;
 import java.util.List;
 import org.springframework.http.HttpHeaders;
@@ -60,6 +61,14 @@ public class BackendEnrichedNicheMaterializerController {
   @GetMapping("/api/oprm/nichocnae/enriched-niche-materializer/profiles/{profileId}")
   public ResponseEntity<EnrichedNicheMaterializerDetailResponse> detailByProfileId(@PathVariable Long profileId) {
     return ResponseEntity.ok(executionService.detailByProfileId(profileId));
+  }
+
+  /** Lista os nichos enriquecidos já materializados para um CNAE. */
+  @GetMapping("/api/oprm/nichocnae/cnaes/{cnaeCode}/enriched-niches")
+  public List<GeneratedEnrichedNicheByCnaeResponse> listGeneratedByCnae(
+      @PathVariable String cnaeCode,
+      @RequestParam(defaultValue = "50") int limit) {
+    return executionService.listGeneratedByCnae(cnaeCode, limit);
   }
 
   /** Entrega um documento Markdown baixável com auditoria de todo o pipeline processado para o perfil. */

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/niche/MarketNicheEnrichmentProfileRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/niche/MarketNicheEnrichmentProfileRepository.java
@@ -26,6 +26,17 @@ public interface MarketNicheEnrichmentProfileRepository extends JpaRepository<Ma
       @Param("normalizedNeutralNicheName") String normalizedNeutralNicheName,
       Pageable pageable);
 
+  /** Lista os nichos enriquecidos já materializados para um CNAE. */
+  @Query("""
+      select p from MarketNicheEnrichmentProfile p
+      join fetch p.marketNiche n
+      where p.cnaeCode = :cnaeCode
+      order by p.createdAt desc, p.id desc
+      """)
+  List<MarketNicheEnrichmentProfile> findGeneratedByCnaeCode(
+      @Param("cnaeCode") String cnaeCode,
+      Pageable pageable);
+
   /** Lista o perfil enriquecido mais recente de cada nicho informado. */
   @Query("""
       select p from MarketNicheEnrichmentProfile p

--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -748,3 +748,9 @@
 - Causa-raiz tratada: o gate exigia dor prática apenas pelos contadores estruturados; quando a síntese textual trazia falta, remarcação, agenda instável, retrabalho e cobrança, mas os contadores vinham zerados, o mix MEI/autônomo ficava falso e o nicho bom era descartado.
 - Correção aplicada: o gate agora reconhece dor prática também no texto do card, relaxa bloqueios automáticos quando o risco de solução/fonte antiga é residual e existem evidências recentes suficientes, mantendo bloqueio forte para contaminação textual ou perfil realmente dominado por solução.
 - Prevenção de recorrência: adicionado teste de regressão simulando o caso do ciclo 53, garantindo aprovação quando há rotina executora, dor vendável textual, aquisição/canais e fontes brasileiras recentes mesmo com contadores de dor prática zerados.
+
+## 2026-06-15 — OPRM NichoCNAE: lista de nichos antes do pipeline
+
+- Alterado o fluxo da tela de detalhe do CNAE para priorizar a lista de nichos enriquecidos já gerados pelo CNAE antes de exibir as etapas do pipeline.
+- Causa-raiz tratada: o clique no CNAE entrava direto na visão operacional do pipeline, dificultando perceber se o CNAE já tinha nichos gerados e aumentando risco de duplicidade, confusão entre CNAE e nicho e gasto desnecessário.
+- Correção aplicada: criado endpoint backend para listar nichos enriquecidos por CNAE; o frontend passou a exibir essa lista com ação de abertura do nicho e botão único para gerar um novo nicho, mostrando as etapas do pipeline apenas após esse comando.

--- a/frontend/src/api/oprm/useOprmGeneratedEnrichedNichesByCnae.ts
+++ b/frontend/src/api/oprm/useOprmGeneratedEnrichedNichesByCnae.ts
@@ -1,0 +1,40 @@
+import { useQuery } from "@tanstack/react-query";
+import { buildApiUrl } from "../../utils/buildApiUrl";
+
+export interface OprmGeneratedEnrichedNicheByCnae {
+  enrichedNicheProfileId: number;
+  marketNicheId: number;
+  researchCycleId: number;
+  cnaeCode: string;
+  cnaeDescription: string;
+  nicheName: string;
+  qualityStatus: string;
+  routineEvidenceScore: number;
+  difficultyEvidenceScore: number;
+  sourceDiversityScore: number;
+  materializedAt: string;
+}
+
+async function fetchGeneratedEnrichedNichesByCnae(
+  cnaeCode: string,
+): Promise<OprmGeneratedEnrichedNicheByCnae[]> {
+  const response = await fetch(
+    buildApiUrl(
+      `/api/oprm/nichocnae/cnaes/${encodeURIComponent(cnaeCode)}/enriched-niches`,
+    ),
+  );
+  if (!response.ok) {
+    throw new Error(
+      `Não foi possível carregar os nichos gerados para este CNAE (status ${response.status}).`,
+    );
+  }
+  return (await response.json()) as OprmGeneratedEnrichedNicheByCnae[];
+}
+
+export function useOprmGeneratedEnrichedNichesByCnae(cnaeCode: string) {
+  return useQuery({
+    queryKey: ["oprm", "nichocnae", cnaeCode, "generated-enriched-niches"],
+    queryFn: () => fetchGeneratedEnrichedNichesByCnae(cnaeCode),
+    enabled: Boolean(cnaeCode),
+  });
+}

--- a/frontend/src/pages/oprm/OprmCnaeDetailPlaceholderPage.test.tsx
+++ b/frontend/src/pages/oprm/OprmCnaeDetailPlaceholderPage.test.tsx
@@ -1,4 +1,5 @@
 import { cleanup, render, screen, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { afterEach, describe, expect, it, vi } from "vitest";
@@ -118,7 +119,8 @@ describe("OprmCnaeDetailPlaceholderPage", () => {
             qualityNotes: {
               status: "OUTDATED_SOURCES",
               proximoMovimentoCodigo: "BUSCAR_FONTES_BRASILEIRAS_RECENTES",
-              proximoMovimento: "Abrir nova pesquisa priorizando fontes brasileiras recentes dos ultimos 24 meses",
+              proximoMovimento:
+                "Abrir nova pesquisa priorizando fontes brasileiras recentes dos ultimos 24 meses",
               fontes: 54,
               sinais: 85,
               tarefasConcretasDistintas: 0,
@@ -149,6 +151,9 @@ describe("OprmCnaeDetailPlaceholderPage", () => {
 
     renderPage();
 
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Gerar novo nicho" }),
+    );
     expect(await screen.findByText(/status atual:/i)).toBeTruthy();
     expect(screen.getByText("Custo total do CNAE")).toBeTruthy();
     expect(screen.getAllByText("US$ 0,0456").length).toBeGreaterThan(0);
@@ -168,7 +173,9 @@ describe("OprmCnaeDetailPlaceholderPage", () => {
     expect(screen.getByText(/54 fontes · 85 sinais/i)).toBeTruthy();
     expect(screen.getByText("Próximo movimento automático")).toBeTruthy();
     expect(
-      screen.getByText(/Abrir nova pesquisa priorizando fontes brasileiras recentes/i),
+      screen.getByText(
+        /Abrir nova pesquisa priorizando fontes brasileiras recentes/i,
+      ),
     ).toBeTruthy();
     expect(screen.getByText(/Atualidade das fontes: risco 85%/i)).toBeTruthy();
     expect(screen.getByText(/Rotina do executor insuficiente/i)).toBeTruthy();
@@ -195,7 +202,6 @@ describe("OprmCnaeDetailPlaceholderPage", () => {
     ).toBeTruthy();
     expect(screen.queryByText("Em execução")).toBeNull();
   });
-
 
   it("informa quando o ciclo atual foi reprocessado automaticamente com aprendizado", async () => {
     vi.stubGlobal(
@@ -264,17 +270,21 @@ describe("OprmCnaeDetailPlaceholderPage", () => {
 
     renderPage();
 
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Gerar novo nicho" }),
+    );
     expect(
       await screen.findByText("Reprocessamento automático em andamento"),
     ).toBeTruthy();
     expect(
-      screen.getByText(/ciclo #48 foi criado automaticamente depois que o ciclo #47 terminou como corporativo demais/i),
+      screen.getByText(
+        /ciclo #48 foi criado automaticamente depois que o ciclo #47 terminou como corporativo demais/i,
+      ),
     ).toBeTruthy();
     expect(
       screen.getByText(/tentativas automáticas usadas: 1\/3/i),
     ).toBeTruthy();
   });
-
 
   it("diferencia visualmente os cards concluídos e em execução por contraste forte", async () => {
     vi.stubGlobal(
@@ -314,6 +324,9 @@ describe("OprmCnaeDetailPlaceholderPage", () => {
 
     renderPage();
 
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Gerar novo nicho" }),
+    );
     await screen.findByText(/status atual:/i);
 
     const seedCard = screen.getByText("2. Seed");

--- a/frontend/src/pages/oprm/OprmCnaeDetailPlaceholderPage.tsx
+++ b/frontend/src/pages/oprm/OprmCnaeDetailPlaceholderPage.tsx
@@ -1,4 +1,5 @@
 import { Globe2, Sparkles } from "lucide-react";
+import { useState } from "react";
 import { Link, useParams } from "react-router-dom";
 import {
   useOprmCnaeScore,
@@ -13,6 +14,7 @@ import {
   type OprmQualityNotes,
   useOprmRoutineQualityGateDetail,
 } from "../../api/oprm/useOprmRoutineQualityGateDetail";
+import { useOprmGeneratedEnrichedNichesByCnae } from "../../api/oprm/useOprmGeneratedEnrichedNichesByCnae";
 import PageTitle from "../../components/PageTitle";
 import OprmModuleNavigation from "./OprmModuleNavigation";
 import { useBreadcrumbs } from "../../app/breadcrumbs";
@@ -136,7 +138,6 @@ const statusLabels: Record<string, string> = {
   GENERIC: "Genérico",
   ENRICHED_NICHE_FAILED: "Falha na materialização",
 };
-
 
 const AUTO_QUALITY_REPROCESS_TRIGGER = "AUTO_QUALITY_REPROCESS";
 const MAX_AUTO_REPROCESS_PER_CANDIDATE = 3;
@@ -263,7 +264,10 @@ function buildBusinessRecommendation(params: {
   return null;
 }
 
-function getQualityNoteText(notes: OprmQualityNotes | null | undefined, key: string) {
+function getQualityNoteText(
+  notes: OprmQualityNotes | null | undefined,
+  key: string,
+) {
   const value = notes?.[key];
   return typeof value === "string" && value.trim() ? value.trim() : null;
 }
@@ -599,9 +603,12 @@ function inferStageState(
 export default function OprmCnaeDetailPlaceholderPage() {
   const { cnaeCode } = useParams();
   const decodedCnaeCode = cnaeCode ? decodeURIComponent(cnaeCode) : "CNAE";
+  const [showPipeline, setShowPipeline] = useState(false);
   const volumeQuery = useOprmCnaeVolume(decodedCnaeCode);
   const scoreQuery = useOprmCnaeScore(decodedCnaeCode);
   const cyclesQuery = useOprmCnaePipelineCycles(decodedCnaeCode);
+  const generatedNichesQuery =
+    useOprmGeneratedEnrichedNichesByCnae(decodedCnaeCode);
   const startPipelineMutation = useStartOprmCnaePipeline(decodedCnaeCode);
   const latestCycle = cyclesQuery.data?.[0];
   const previousCycle = findPreviousCycle(cyclesQuery.data, latestCycle);
@@ -672,26 +679,6 @@ export default function OprmCnaeDetailPlaceholderPage() {
               </p>
             </div>
             <div className="d-flex align-items-start gap-2">
-              <button
-                type="button"
-                className="btn btn-primary"
-                disabled={startPipelineMutation.isPending}
-                onClick={() => startPipelineMutation.mutate()}
-              >
-                {startPipelineMutation.isPending ? (
-                  <>
-                    <span
-                      className="spinner-border spinner-border-sm me-2"
-                      aria-hidden="true"
-                    />
-                    Disparando...
-                  </>
-                ) : latestCycle && businessRecommendation ? (
-                  "Reprocessar com subnicho operacional"
-                ) : (
-                  "Disparar pipeline NichoCNAE"
-                )}
-              </button>
               <Link className="btn btn-outline-secondary" to="/oprm">
                 Voltar para CNAEs
               </Link>
@@ -785,230 +772,339 @@ export default function OprmCnaeDetailPlaceholderPage() {
         <div className="card-body d-flex flex-column gap-3">
           <div className="d-flex flex-wrap justify-content-between gap-3 align-items-start">
             <div>
-              <h2 className="h5 mb-1">Execução do pipeline NichoCNAE</h2>
+              <h2 className="h5 mb-1">Nichos gerados com este CNAE</h2>
               <p className="text-secondary mb-0">
-                Cards por fase para acompanhar onde a pesquisa está antes de
-                transformar o CNAE em nicho enriquecido.
+                Primeiro confira se já existe um nicho utilizável para evitar
+                duplicidade e gasto desnecessário; gere um novo apenas quando o
+                histórico não atender ao objetivo comercial.
               </p>
             </div>
-            <div className="d-flex flex-wrap gap-2 align-items-start justify-content-end">
-              <div className="border rounded-3 bg-light px-3 py-2 text-end">
-                <span className="d-block small text-secondary">
-                  Custo total do CNAE
-                </span>
-                <strong className="fs-5">
-                  {formatUsd(latestCycle?.cnaeTotalCostUsd)}
-                </strong>
-              </div>
-              <span className="badge text-bg-light align-self-start">
-                Último ciclo:{" "}
-                {latestCycle ? `#${latestCycle.researchCycleId}` : "nenhum"}
-              </span>
-            </div>
+            <button
+              type="button"
+              className="btn btn-primary"
+              disabled={startPipelineMutation.isPending}
+              onClick={() =>
+                startPipelineMutation.mutate(undefined, {
+                  onSuccess: () => setShowPipeline(true),
+                })
+              }
+            >
+              {startPipelineMutation.isPending ? (
+                <>
+                  <span
+                    className="spinner-border spinner-border-sm me-2"
+                    aria-hidden="true"
+                  />
+                  Gerando...
+                </>
+              ) : (
+                "Gerar novo nicho"
+              )}
+            </button>
           </div>
 
-          {latestCycle ? (
-            <div className={pipelineAlertClass(latestCycle.status)}>
-              <div>
-                Status atual: <strong>{statusLabel(latestCycle.status)}</strong>{" "}
-                · iniciado em {formatDateTime(latestCycle.startedAt)} · sinais
-                extraídos: {formatNumber(latestCycle.totalExtractedSignals)} ·
-                custo do job atual:{" "}
-                <strong>{formatUsd(latestCycle.executionCostUsd)}</strong>
-              </div>
-              {qualityBlockedMessage(latestCycle.status) ? (
-                <div className="mt-2">
-                  <p className="mb-2">
-                    {qualityBlockedMessage(latestCycle.status)} O pipeline não
-                    está em execução agora; pesquise novamente após corrigir a
-                    causa do bloqueio.
-                  </p>
-                  {qualityResultSummary ? (
-                    <p className="mb-2 small">
-                      <span className="fw-semibold">Resultado apurado:</span>{" "}
-                      {qualityResultSummary}.
-                    </p>
-                  ) : null}
-                  {qualityNextMove ? (
-                    <div className="alert alert-info border mb-2 py-2 px-3">
-                      <span className="fw-semibold d-block mb-1">
-                        Próximo movimento automático
-                      </span>
-                      <span>{qualityNextMove}.</span>
-                    </div>
-                  ) : null}
-                  {qualityRejectedSituations.length > 0 ? (
-                    <div className="alert alert-light border mb-0 py-2 px-3">
-                      <span className="fw-semibold d-block mb-1">
-                        Situações rejeitadas pelo gate
-                      </span>
-                      <ul className="mb-0 ps-3">
-                        {qualityRejectedSituations.map((situation) => (
-                          <li key={situation}>{situation}</li>
-                        ))}
-                      </ul>
-                    </div>
-                  ) : null}
-                </div>
-              ) : null}
-              {automaticProcess ? (
-                <div className={automaticProcess.className} role="status">
-                  <span className="fw-semibold d-block mb-1">
-                    {automaticProcess.title}
-                  </span>
-                  <span>{automaticProcess.text}</span>
-                  <span className="d-block small text-secondary mt-1">
-                    Tentativas automáticas usadas: {automaticAttempts}/
-                    {MAX_AUTO_REPROCESS_PER_CANDIDATE}.
-                  </span>
-                </div>
-              ) : null}
-              {businessRecommendation ? (
-                <div className="alert alert-light border mt-3 mb-0">
-                  <span className="fw-semibold d-block">
-                    Recomendação de negócio
-                  </span>
-                  {businessRecommendation}
-                  <span className="d-block small text-secondary mt-1">
-                    Comando recomendado: Reprocessar com subnicho operacional.
-                  </span>
-                </div>
-              ) : null}
-              {latestCycle.errorMessage ? (
-                <div className="mt-2 text-danger">
-                  Falha registrada: {latestCycle.errorMessage}
-                </div>
-              ) : null}
+          {generatedNichesQuery.isLoading ? (
+            <div className="alert alert-light border mb-0" role="status">
+              Carregando nichos gerados para o CNAE...
             </div>
-          ) : (
-            <div className="alert alert-secondary mb-0">
-              Nenhum ciclo encontrado para este CNAE. Use o botão de disparo
-              quando já existir candidato pendente de NichoCNAE para esse CNAE.
+          ) : null}
+          {generatedNichesQuery.isError ? (
+            <div className="alert alert-warning mb-0" role="alert">
+              Não foi possível carregar os nichos gerados para este CNAE.
             </div>
-          )}
-
-          <div className="row g-3">
-            {pipelineStages.map((stage, index) => {
-              const state = inferStageState(index, latestCycle);
-              return (
-                <div className="col-md-4" key={stage.title}>
-                  <div
-                    className={`card h-100 ${stageCardClassName(state.className)}`}
-                  >
-                    <div className="card-body">
-                      <div className="d-flex justify-content-between gap-2 mb-2">
-                        <div className="d-flex align-items-center gap-2">
-                          <h3 className="h6 mb-0">{stage.title}</h3>
-                          {stage.usesAiModel ? (
-                            <span
-                              className="badge text-bg-primary d-inline-flex align-items-center gap-1"
-                              title="Etapa com uso direto de IA"
-                              aria-label="Etapa com uso direto de IA"
-                            >
-                              <Sparkles size={14} aria-hidden="true" />
-                              IA
-                            </span>
-                          ) : null}
-                          {stage.usesInternetResearch ? (
-                            <span
-                              className="badge text-bg-info d-inline-flex align-items-center gap-1"
-                              title="Etapa que acessa a internet para pesquisar fontes"
-                              aria-label="Etapa que acessa a internet para pesquisar fontes"
-                            >
-                              <Globe2 size={14} aria-hidden="true" />
-                              Web
-                            </span>
-                          ) : null}
-                        </div>
-                        <span className="badge text-bg-light">
-                          {state.label}
+          ) : null}
+          {generatedNichesQuery.data?.length ? (
+            <div className="table-responsive">
+              <table className="table table-sm align-middle mb-0">
+                <thead>
+                  <tr>
+                    <th scope="col">Nicho gerado</th>
+                    <th scope="col">Qualidade</th>
+                    <th scope="col">Ciclo</th>
+                    <th scope="col">Evidências</th>
+                    <th scope="col">Gerado em</th>
+                    <th scope="col" className="text-end">
+                      Ação
+                    </th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {generatedNichesQuery.data.map((niche) => (
+                    <tr key={niche.enrichedNicheProfileId}>
+                      <td>
+                        <div className="fw-semibold">{niche.nicheName}</div>
+                        <span className="small text-secondary">
+                          Nicho #{niche.marketNicheId} · Perfil #
+                          {niche.enrichedNicheProfileId}
                         </span>
-                      </div>
-                      <p className={stageDescriptionClassName(state.className)}>
-                        {stage.description}
-                      </p>
-                      {latestCycle ? (
+                      </td>
+                      <td>{niche.qualityStatus}</td>
+                      <td>#{niche.researchCycleId}</td>
+                      <td>
+                        Rotina {niche.routineEvidenceScore} · Dor{" "}
+                        {niche.difficultyEvidenceScore} · Fontes{" "}
+                        {niche.sourceDiversityScore}
+                      </td>
+                      <td>{formatDateTime(niche.materializedAt)}</td>
+                      <td className="text-end">
                         <Link
-                          className={stageDetailButtonClassName(
-                            state.className,
-                          )}
-                          to={`/oprm/cnaes/${encodeURIComponent(decodedCnaeCode)}/pipeline/${latestCycle.researchCycleId}/stages/${stage.code}`}
+                          className="btn btn-outline-primary btn-sm"
+                          to={`/oprm/enriched-niches/profile/${niche.enrichedNicheProfileId}`}
                         >
-                          Ver detalhes
+                          Abrir
                         </Link>
-                      ) : (
-                        <button
-                          type="button"
-                          className="btn btn-outline-secondary btn-sm"
-                          disabled
-                        >
-                          Ver detalhes
-                        </button>
-                      )}
-                    </div>
-                  </div>
-                </div>
-              );
-            })}
-          </div>
-
-          <div className="card border-0 bg-light">
-            <div className="card-body">
-              <div className="d-flex flex-wrap justify-content-between gap-2 mb-3">
-                <div>
-                  <h3 className="h6 mb-1">Jobs executados para este CNAE</h3>
-                  <p className="small text-secondary mb-0">
-                    Histórico por execução para controlar gasto operacional
-                    antes de escalar o nicho.
-                  </p>
-                </div>
-                <strong>
-                  Total: {formatUsd(latestCycle?.cnaeTotalCostUsd)}
-                </strong>
-              </div>
-              <div className="table-responsive">
-                <table className="table table-sm align-middle mb-0">
-                  <thead>
-                    <tr>
-                      <th scope="col">Job</th>
-                      <th scope="col">Status</th>
-                      <th scope="col">Início</th>
-                      <th scope="col">Fim</th>
-                      <th scope="col" className="text-end">
-                        Custo total
-                      </th>
+                      </td>
                     </tr>
-                  </thead>
-                  <tbody>
-                    {cyclesQuery.data && cyclesQuery.data.length > 0 ? (
-                      cyclesQuery.data.map((cycle) => (
-                        <tr key={cycle.researchCycleId}>
-                          <td>#{cycle.researchCycleId}</td>
-                          <td>{statusLabel(cycle.status)}</td>
-                          <td>{formatDateTime(cycle.startedAt)}</td>
-                          <td>{formatDateTime(cycle.finishedAt)}</td>
-                          <td className="text-end fw-semibold">
-                            {formatUsd(cycle.executionCostUsd)}
-                          </td>
-                        </tr>
-                      ))
-                    ) : (
-                      <tr>
-                        <td
-                          colSpan={5}
-                          className="text-secondary text-center py-3"
-                        >
-                          Nenhum job executado para este CNAE.
-                        </td>
-                      </tr>
-                    )}
-                  </tbody>
-                </table>
-              </div>
+                  ))}
+                </tbody>
+              </table>
             </div>
-          </div>
+          ) : null}
+          {!generatedNichesQuery.isLoading &&
+          !generatedNichesQuery.isError &&
+          !generatedNichesQuery.data?.length ? (
+            <div className="alert alert-secondary mb-0">
+              Ainda não existe nicho enriquecido gerado para este CNAE. Use
+              “Gerar novo nicho” para iniciar o pipeline.
+            </div>
+          ) : null}
         </div>
       </section>
+
+      {showPipeline ? (
+        <section className="card border-0 shadow-sm">
+          <div className="card-body d-flex flex-column gap-3">
+            <div className="d-flex flex-wrap justify-content-between gap-3 align-items-start">
+              <div>
+                <h2 className="h5 mb-1">Execução do pipeline NichoCNAE</h2>
+                <p className="text-secondary mb-0">
+                  Cards por fase para acompanhar onde a pesquisa está antes de
+                  transformar o CNAE em nicho enriquecido.
+                </p>
+              </div>
+              <div className="d-flex flex-wrap gap-2 align-items-start justify-content-end">
+                <div className="border rounded-3 bg-light px-3 py-2 text-end">
+                  <span className="d-block small text-secondary">
+                    Custo total do CNAE
+                  </span>
+                  <strong className="fs-5">
+                    {formatUsd(latestCycle?.cnaeTotalCostUsd)}
+                  </strong>
+                </div>
+                <span className="badge text-bg-light align-self-start">
+                  Último ciclo:{" "}
+                  {latestCycle ? `#${latestCycle.researchCycleId}` : "nenhum"}
+                </span>
+              </div>
+            </div>
+
+            {latestCycle ? (
+              <div className={pipelineAlertClass(latestCycle.status)}>
+                <div>
+                  Status atual:{" "}
+                  <strong>{statusLabel(latestCycle.status)}</strong> · iniciado
+                  em {formatDateTime(latestCycle.startedAt)} · sinais extraídos:{" "}
+                  {formatNumber(latestCycle.totalExtractedSignals)} · custo do
+                  job atual:{" "}
+                  <strong>{formatUsd(latestCycle.executionCostUsd)}</strong>
+                </div>
+                {qualityBlockedMessage(latestCycle.status) ? (
+                  <div className="mt-2">
+                    <p className="mb-2">
+                      {qualityBlockedMessage(latestCycle.status)} O pipeline não
+                      está em execução agora; pesquise novamente após corrigir a
+                      causa do bloqueio.
+                    </p>
+                    {qualityResultSummary ? (
+                      <p className="mb-2 small">
+                        <span className="fw-semibold">Resultado apurado:</span>{" "}
+                        {qualityResultSummary}.
+                      </p>
+                    ) : null}
+                    {qualityNextMove ? (
+                      <div className="alert alert-info border mb-2 py-2 px-3">
+                        <span className="fw-semibold d-block mb-1">
+                          Próximo movimento automático
+                        </span>
+                        <span>{qualityNextMove}.</span>
+                      </div>
+                    ) : null}
+                    {qualityRejectedSituations.length > 0 ? (
+                      <div className="alert alert-light border mb-0 py-2 px-3">
+                        <span className="fw-semibold d-block mb-1">
+                          Situações rejeitadas pelo gate
+                        </span>
+                        <ul className="mb-0 ps-3">
+                          {qualityRejectedSituations.map((situation) => (
+                            <li key={situation}>{situation}</li>
+                          ))}
+                        </ul>
+                      </div>
+                    ) : null}
+                  </div>
+                ) : null}
+                {automaticProcess ? (
+                  <div className={automaticProcess.className} role="status">
+                    <span className="fw-semibold d-block mb-1">
+                      {automaticProcess.title}
+                    </span>
+                    <span>{automaticProcess.text}</span>
+                    <span className="d-block small text-secondary mt-1">
+                      Tentativas automáticas usadas: {automaticAttempts}/
+                      {MAX_AUTO_REPROCESS_PER_CANDIDATE}.
+                    </span>
+                  </div>
+                ) : null}
+                {businessRecommendation ? (
+                  <div className="alert alert-light border mt-3 mb-0">
+                    <span className="fw-semibold d-block">
+                      Recomendação de negócio
+                    </span>
+                    {businessRecommendation}
+                    <span className="d-block small text-secondary mt-1">
+                      Comando recomendado: Reprocessar com subnicho operacional.
+                    </span>
+                  </div>
+                ) : null}
+                {latestCycle.errorMessage ? (
+                  <div className="mt-2 text-danger">
+                    Falha registrada: {latestCycle.errorMessage}
+                  </div>
+                ) : null}
+              </div>
+            ) : (
+              <div className="alert alert-secondary mb-0">
+                Nenhum ciclo encontrado para este CNAE. Use o botão de disparo
+                quando já existir candidato pendente de NichoCNAE para esse
+                CNAE.
+              </div>
+            )}
+
+            <div className="row g-3">
+              {pipelineStages.map((stage, index) => {
+                const state = inferStageState(index, latestCycle);
+                return (
+                  <div className="col-md-4" key={stage.title}>
+                    <div
+                      className={`card h-100 ${stageCardClassName(state.className)}`}
+                    >
+                      <div className="card-body">
+                        <div className="d-flex justify-content-between gap-2 mb-2">
+                          <div className="d-flex align-items-center gap-2">
+                            <h3 className="h6 mb-0">{stage.title}</h3>
+                            {stage.usesAiModel ? (
+                              <span
+                                className="badge text-bg-primary d-inline-flex align-items-center gap-1"
+                                title="Etapa com uso direto de IA"
+                                aria-label="Etapa com uso direto de IA"
+                              >
+                                <Sparkles size={14} aria-hidden="true" />
+                                IA
+                              </span>
+                            ) : null}
+                            {stage.usesInternetResearch ? (
+                              <span
+                                className="badge text-bg-info d-inline-flex align-items-center gap-1"
+                                title="Etapa que acessa a internet para pesquisar fontes"
+                                aria-label="Etapa que acessa a internet para pesquisar fontes"
+                              >
+                                <Globe2 size={14} aria-hidden="true" />
+                                Web
+                              </span>
+                            ) : null}
+                          </div>
+                          <span className="badge text-bg-light">
+                            {state.label}
+                          </span>
+                        </div>
+                        <p
+                          className={stageDescriptionClassName(state.className)}
+                        >
+                          {stage.description}
+                        </p>
+                        {latestCycle ? (
+                          <Link
+                            className={stageDetailButtonClassName(
+                              state.className,
+                            )}
+                            to={`/oprm/cnaes/${encodeURIComponent(decodedCnaeCode)}/pipeline/${latestCycle.researchCycleId}/stages/${stage.code}`}
+                          >
+                            Ver detalhes
+                          </Link>
+                        ) : (
+                          <button
+                            type="button"
+                            className="btn btn-outline-secondary btn-sm"
+                            disabled
+                          >
+                            Ver detalhes
+                          </button>
+                        )}
+                      </div>
+                    </div>
+                  </div>
+                );
+              })}
+            </div>
+
+            <div className="card border-0 bg-light">
+              <div className="card-body">
+                <div className="d-flex flex-wrap justify-content-between gap-2 mb-3">
+                  <div>
+                    <h3 className="h6 mb-1">Jobs executados para este CNAE</h3>
+                    <p className="small text-secondary mb-0">
+                      Histórico por execução para controlar gasto operacional
+                      antes de escalar o nicho.
+                    </p>
+                  </div>
+                  <strong>
+                    Total: {formatUsd(latestCycle?.cnaeTotalCostUsd)}
+                  </strong>
+                </div>
+                <div className="table-responsive">
+                  <table className="table table-sm align-middle mb-0">
+                    <thead>
+                      <tr>
+                        <th scope="col">Job</th>
+                        <th scope="col">Status</th>
+                        <th scope="col">Início</th>
+                        <th scope="col">Fim</th>
+                        <th scope="col" className="text-end">
+                          Custo total
+                        </th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {cyclesQuery.data && cyclesQuery.data.length > 0 ? (
+                        cyclesQuery.data.map((cycle) => (
+                          <tr key={cycle.researchCycleId}>
+                            <td>#{cycle.researchCycleId}</td>
+                            <td>{statusLabel(cycle.status)}</td>
+                            <td>{formatDateTime(cycle.startedAt)}</td>
+                            <td>{formatDateTime(cycle.finishedAt)}</td>
+                            <td className="text-end fw-semibold">
+                              {formatUsd(cycle.executionCostUsd)}
+                            </td>
+                          </tr>
+                        ))
+                      ) : (
+                        <tr>
+                          <td
+                            colSpan={5}
+                            className="text-secondary text-center py-3"
+                          >
+                            Nenhum job executado para este CNAE.
+                          </td>
+                        </tr>
+                      )}
+                    </tbody>
+                  </table>
+                </div>
+              </div>
+            </div>
+          </div>
+        </section>
+      ) : null}
     </div>
   );
 }


### PR DESCRIPTION
### Motivation

- Prevent duplicate work and surface already-materialized niches by CNAE before running the pipeline. 
- Provide a lightweight backend endpoint to fetch enriched-niche summaries for a CNAE for the frontend to display. 
- Improve UX of the CNAE detail page to prefer opening an existing enriched niche and make generation explicit.

### Description

- Added `GET /api/oprm/nichocnae/cnaes/{cnaeCode}/enriched-niches` with service method `listGeneratedByCnae` and mapping helper `toGeneratedByCnaeResponse`. 
- Introduced `GeneratedEnrichedNicheByCnaeResponse` record and new repository query `findGeneratedByCnaeCode` in `MarketNicheEnrichmentProfileRepository`. 
- Frontend: added `useOprmGeneratedEnrichedNichesByCnae` hook and updated `OprmCnaeDetailPlaceholderPage` to list generated niches, add a single `Gerar novo nicho` button that shows the pipeline UI after starting a job, and reworked layout/flow accordingly. 
- Updated tests and docs: modified `OprmCnaeDetailPlaceholderPage.test.tsx` to interact with the new button and added changelog entry in `docs/registros/oprm1.md`.

### Testing

- Ran frontend unit tests with `vitest`, including the updated `OprmCnaeDetailPlaceholderPage.test.tsx`, and they passed. 
- Performed local builds/type-checks for the frontend and backend after the changes and they completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2f701f24988321940ffd530214ed2f)