### PR TITLE
Make hotmart_description LONGTEXT (Liquibase) and update docs

### DIFF
--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-15-mois-hotmart-description-longtext.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-15-mois-hotmart-description-longtext.yaml
@@ -1,0 +1,20 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-06-15-mois-hotmart-description-longtext
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - onError: HALT
+        - dbms:
+            type: mysql
+        - columnExists:
+            tableName: mois_collected_reference
+            columnName: hotmart_description
+      changes:
+        - sql:
+            dbms: mysql
+            splitStatements: true
+            stripComments: true
+            sql: |
+              ALTER TABLE mois_collected_reference
+                MODIFY COLUMN hotmart_description LONGTEXT NULL;

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -986,3 +986,6 @@ databaseChangeLog:
   - include:
       file: changesets/2026-06-13-mois-hotmart-description-length.yaml
       relativeToChangelogFile: true
+  - include:
+      file: changesets/2026-06-15-mois-hotmart-description-longtext.yaml
+      relativeToChangelogFile: true

--- a/docs/canonical/mois-hotmart-mapeamento-ciclos-campos-banco.md
+++ b/docs/canonical/mois-hotmart-mapeamento-ciclos-campos-banco.md
@@ -81,7 +81,7 @@ A persistência acontece via payload `references` + `rawMetadata`. O backend gra
 | `product_name` | `reference.title`, `rawMetadata.productName`, `rawMetadata.hotmartProductName` | primeiro não-vazio |
 | `product_url` | `reference.url`, `rawMetadata.productUrl` | primeiro não-vazio |
 | `producer_name` | `rawMetadata.hotmartProducer`, `rawMetadata.producerName`, `rawMetadata.producer` | primeiro não-vazio |
-| `hotmart_description` | `rawMetadata.hotmartDescription`, `rawMetadata.description` | descrição comercial da coleta; coluna ampliada para até 1000 caracteres |
+| `hotmart_description` | `rawMetadata.hotmartDescription`, `rawMetadata.description` | descrição comercial da coleta; coluna LONGTEXT para preservar descrições completas vindas da Hotmart |
 | `collected_at` | `reference.collectedAt`, `rawMetadata.collectedAt` | data/hora da coleta específica, preservando novas coletas do mesmo produto em jobs futuros |
 | `reference_id` | `productUcode` normalizado quando disponível | estável por produto dentro de cada job para comparar o mesmo produto entre coletas |
 | `sales_page_url` | `rawMetadata.salesPageUrl`, `rawMetadata.pageSalesLink`, `rawMetadata.checkoutUrl`, `reference.url` | primeiro não-vazio |
@@ -95,7 +95,7 @@ A persistência acontece via payload `references` + `rawMetadata`. O backend gra
 ## 4) Pontos de atenção operacionais
 
 1. A coluna **`sales_page_url`** é a coluna canônica para “página de vendas” no banco.
-2. Temperatura, descrição, produtor e `collected_at` devem ser persistidos em toda coleta para permitir comparar o mesmo produto em execuções futuras.
+2. Temperatura, descrição completa, produtor e `collected_at` devem ser persistidos em toda coleta para permitir comparar o mesmo produto em execuções futuras.
 3. O `reference_id` Hotmart deve ser estável por produto quando houver `ucode`, evitando perder rastreabilidade histórica entre jobs.
 4. O ciclo 2 existe para reduzir ambiguidade de URL e melhorar qualidade comercial do link final.
 5. Se `salesPageUrl` vier vazio mesmo no ciclo 2, a persistência ainda pode usar fallback (`checkoutUrl`/`reference.url`) para não quebrar o fluxo.

--- a/docs/registros/mois1.md
+++ b/docs/registros/mois1.md
@@ -1597,3 +1597,8 @@ Arquivos principais:
 ## 2026-06-14 — Reagendamento Hotmart ciclo 1 para 22:00
 - Por solicitação operacional, o ciclo 1 de listagem do `mois-hotmart-collector` foi reagendado de 13:00 para execução pontual única em **14/06/2026 às 22:00** no timezone `America/Sao_Paulo`.
 - Atualizados scheduler, teste unitário e cânone Hotmart para usar o cron `0 0 22 14 6 *`, mantendo o alvo operacional de 400 produtos e a guarda de execução apenas em 2026.
+
+## 2026-06-15 — Hotmart: descrição completa em LONGTEXT
+- Causa-raiz investigada: a coleta Hotmart de 14/06/2026 às 22:00 recebeu 400 produtos, mas 119 referências não entraram em `mois_collected_reference` porque `hotmart_description` estava limitada a `VARCHAR(1000)` e as descrições reais da Hotmart excediam esse tamanho.
+- Criado changelog Liquibase para alterar o banco para `hotmart_description LONGTEXT NULL`, preservando a descrição comercial completa e evitando perda de referências relacionais em novas coletas.
+- Atualizado o documento canônico do fluxo Hotmart para refletir que a descrição comercial deve ser persistida completa.


### PR DESCRIPTION
### Motivation

- Prevent loss of Hotmart commercial descriptions that exceed the previous `VARCHAR(1000)` limit and caused collected references to be dropped. 
- Ensure the `mois_collected_reference.hotmart_description` column can store full descriptions produced by the Hotmart collector. 
- Keep the canonical documentation and change history aligned with the database schema change.

### Description

- Added a Liquibase changeset `changesets/2026-06-15-mois-hotmart-description-longtext.yaml` that alters `mois_collected_reference.hotmart_description` to `LONGTEXT NULL` for MySQL. 
- Included the new changeset in `db.changelog-master.yaml` so it is applied during migrations. 
- Updated canonical documentation `docs/canonical/mois-hotmart-mapeamento-ciclos-campos-banco.md` and the rollout record `docs/registros/mois1.md` to reflect that `hotmart_description` is persisted as `LONGTEXT` and that full descriptions should be preserved.

### Testing

- No application logic changes were made; the change is a DB migration and docs update. 
- The Liquibase changeset was added to the changelog and validated in the repository structure. 
- Ran the project automated test suite with `./gradlew test` and the tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a2f70a6f5448321adb672379b7843b4)