### PR TITLE
Add hypothesis audit report download and persist raw OpenAI response

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/pipeline/hypothesismechanism/HypothesisMechanismBackendClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/pipeline/hypothesismechanism/HypothesisMechanismBackendClient.java
@@ -81,6 +81,7 @@ public class HypothesisMechanismBackendClient implements StageBackendPort<Hypoth
         body.put("marketNicheId", execution.aggregateId());
         body.put("stageCode", execution.stageCode());
         body.put("modelResponse", openAiResult.modelResponse());
+        body.put("rawResponse", openAiResult.rawResponse());
         body.put("inputTokens", openAiResult.inputTokens());
         body.put("outputTokens", openAiResult.outputTokens());
         body.put("costUsd", openAiResult.costUsd());
@@ -103,6 +104,7 @@ public class HypothesisMechanismBackendClient implements StageBackendPort<Hypoth
         body.put("marketNicheId", execution.aggregateId());
         body.put("stageCode", execution.stageCode());
         body.put("modelResponse", null);
+        body.put("rawResponse", null);
         body.put("inputTokens", null);
         body.put("outputTokens", null);
         body.put("costUsd", null);

--- a/ai-worker/src/main/java/com/marketinghub/worker/pipeline/hypothesisoffer/HypothesisOfferBackendClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/pipeline/hypothesisoffer/HypothesisOfferBackendClient.java
@@ -81,6 +81,7 @@ public class HypothesisOfferBackendClient implements StageBackendPort<Hypothesis
         body.put("marketNicheId", execution.aggregateId());
         body.put("stageCode", execution.stageCode());
         body.put("modelResponse", openAiResult.modelResponse());
+        body.put("rawResponse", openAiResult.rawResponse());
         body.put("inputTokens", openAiResult.inputTokens());
         body.put("outputTokens", openAiResult.outputTokens());
         body.put("costUsd", openAiResult.costUsd());
@@ -103,6 +104,7 @@ public class HypothesisOfferBackendClient implements StageBackendPort<Hypothesis
         body.put("marketNicheId", execution.aggregateId());
         body.put("stageCode", execution.stageCode());
         body.put("modelResponse", null);
+        body.put("rawResponse", null);
         body.put("inputTokens", null);
         body.put("outputTokens", null);
         body.put("costUsd", null);

--- a/ai-worker/src/main/java/com/marketinghub/worker/pipeline/hypothesispain/HypothesisPainBackendClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/pipeline/hypothesispain/HypothesisPainBackendClient.java
@@ -80,6 +80,7 @@ public class HypothesisPainBackendClient implements StageBackendPort<HypothesisP
         body.put("marketNicheId", execution.aggregateId());
         body.put("stageCode", execution.stageCode());
         body.put("modelResponse", openAiResult.modelResponse());
+        body.put("rawResponse", openAiResult.rawResponse());
         body.put("inputTokens", openAiResult.inputTokens());
         body.put("outputTokens", openAiResult.outputTokens());
         body.put("costUsd", openAiResult.costUsd());
@@ -102,6 +103,7 @@ public class HypothesisPainBackendClient implements StageBackendPort<HypothesisP
         body.put("marketNicheId", execution.aggregateId());
         body.put("stageCode", execution.stageCode());
         body.put("modelResponse", null);
+        body.put("rawResponse", null);
         body.put("inputTokens", null);
         body.put("outputTokens", null);
         body.put("costUsd", null);

--- a/ai-worker/src/main/java/com/marketinghub/worker/pipeline/hypothesisproof/HypothesisProofBackendClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/pipeline/hypothesisproof/HypothesisProofBackendClient.java
@@ -81,6 +81,7 @@ public class HypothesisProofBackendClient implements StageBackendPort<Hypothesis
         body.put("marketNicheId", execution.aggregateId());
         body.put("stageCode", execution.stageCode());
         body.put("modelResponse", openAiResult.modelResponse());
+        body.put("rawResponse", openAiResult.rawResponse());
         body.put("inputTokens", openAiResult.inputTokens());
         body.put("outputTokens", openAiResult.outputTokens());
         body.put("costUsd", openAiResult.costUsd());
@@ -103,6 +104,7 @@ public class HypothesisProofBackendClient implements StageBackendPort<Hypothesis
         body.put("marketNicheId", execution.aggregateId());
         body.put("stageCode", execution.stageCode());
         body.put("modelResponse", null);
+        body.put("rawResponse", null);
         body.put("inputTokens", null);
         body.put("outputTokens", null);
         body.put("costUsd", null);

--- a/ai-worker/src/main/java/com/marketinghub/worker/pipeline/hypothesisresult/HypothesisResultBackendClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/pipeline/hypothesisresult/HypothesisResultBackendClient.java
@@ -80,6 +80,7 @@ public class HypothesisResultBackendClient implements StageBackendPort<Hypothesi
         body.put("marketNicheId", execution.aggregateId());
         body.put("stageCode", execution.stageCode());
         body.put("modelResponse", openAiResult.modelResponse());
+        body.put("rawResponse", openAiResult.rawResponse());
         body.put("inputTokens", openAiResult.inputTokens());
         body.put("outputTokens", openAiResult.outputTokens());
         body.put("costUsd", openAiResult.costUsd());
@@ -102,6 +103,7 @@ public class HypothesisResultBackendClient implements StageBackendPort<Hypothesi
         body.put("marketNicheId", execution.aggregateId());
         body.put("stageCode", execution.stageCode());
         body.put("modelResponse", null);
+        body.put("rawResponse", null);
         body.put("inputTokens", null);
         body.put("outputTokens", null);
         body.put("costUsd", null);

--- a/backend/ads-service/src/main/java/com/marketinghub/hypothesis/pain/HypothesisPainStageExecution.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/hypothesis/pain/HypothesisPainStageExecution.java
@@ -96,6 +96,10 @@ public class HypothesisPainStageExecution {
     private String modelResponse;
 
     @Lob
+    @Column(name = "raw_response", columnDefinition = "LONGTEXT")
+    private String rawResponse;
+
+    @Lob
     @Column(name = "provisional_html", columnDefinition = "LONGTEXT")
     private String provisionalHtml;
 

--- a/backend/ads-service/src/main/java/com/marketinghub/hypothesis/pain/service/HypothesisPainStageService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/hypothesis/pain/service/HypothesisPainStageService.java
@@ -510,6 +510,7 @@ public class HypothesisPainStageService {
                 .orElseThrow(() -> new EntityNotFoundException("Hypothesis pain execution not found for idJob: " + idJob));
         try {
             execution.setModelResponse(request.modelResponse());
+            execution.setRawResponse(request.rawResponse());
             if (StringUtils.hasText(request.openAiJobId())) {
                 execution.setOpenAiJobId(request.openAiJobId());
             }
@@ -646,6 +647,7 @@ public class HypothesisPainStageService {
                 execution.getOpenAiRequestBody(),
                 execution.getOpenAiModel(),
                 execution.getOpenAiJobId(),
+                execution.getRawResponse(),
                 execution.getModelResponse(),
                 execution.getErrorMessage(),
                 execution.getErrorDetail(),

--- a/backend/ads-service/src/main/java/com/marketinghub/hypothesis/pain/service/detailStageExecution/HypothesisPainExecutionDetailResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/hypothesis/pain/service/detailStageExecution/HypothesisPainExecutionDetailResponse.java
@@ -21,6 +21,7 @@ public record HypothesisPainExecutionDetailResponse(
         String openAiRequestBody,
         String openAiModel,
         String openAiJobId,
+        String rawResponse,
         String modelResponse,
         String errorMessage,
         String errorDetail,

--- a/backend/ads-service/src/main/java/com/marketinghub/hypothesis/pain/service/recebeResposta/RecebeRespostaRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/hypothesis/pain/service/recebeResposta/RecebeRespostaRequest.java
@@ -7,6 +7,7 @@ public record RecebeRespostaRequest(
         Long marketNicheId,
         String stageCode,
         String modelResponse,
+        String rawResponse,
         Integer inputTokens,
         Integer outputTokens,
         BigDecimal costUsd,

--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-15-hypothesis-pipeline-raw-response.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-15-hypothesis-pipeline-raw-response.yaml
@@ -1,0 +1,19 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-06-15-hypothesis-pipeline-raw-response
+      author: marketinghub
+      preConditions:
+        - onFail: MARK_RAN
+        - onError: HALT
+        - dbms:
+            type: mysql
+        - sqlCheck:
+            expectedResult: "0"
+            sql: SELECT COUNT(*) FROM information_schema.columns WHERE table_schema = DATABASE() AND table_name = 'hypothesis_pain_stage_execution' AND column_name = 'raw_response'
+      changes:
+        - sql:
+            splitStatements: true
+            stripComments: true
+            sql: |
+              ALTER TABLE hypothesis_pain_stage_execution
+                ADD COLUMN raw_response LONGTEXT NULL AFTER model_response;

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -986,3 +986,7 @@ databaseChangeLog:
   - include:
       file: changesets/2026-06-13-mois-hotmart-description-length.yaml
       relativeToChangelogFile: true
+
+  - include:
+      file: changesets/2026-06-15-hypothesis-pipeline-raw-response.yaml
+      relativeToChangelogFile: true

--- a/backend/ads-service/src/test/java/com/marketinghub/hypothesis/pain/service/HypothesisPainStageServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/hypothesis/pain/service/HypothesisPainStageServiceTest.java
@@ -68,6 +68,7 @@ class HypothesisPainStageServiceTest {
                 18L,
                 "hypothesis-pain",
                 "{\"pain\":\"dor validada\"}",
+                "{\"id\":\"resp_1\"}",
                 1200,
                 300,
                 new BigDecimal("999.00000000"),

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -4481,3 +4481,19 @@
 - solicitação: esclarecer no procedimento canônico se `CAMPAIGN_ANGLE`, `AD_COPY`, `AD_IMAGE_BRIEFING` e GeraLanding pertencem ao mesmo pipeline administrativo ou a pipelines separados.
 - foi feito: adicionada seção curta definindo que a tela `/pipelines` deve tratar o fluxo como um único pipeline oficial `experiment-pipeline`, com bloco inicial do experimento e bloco/subpipeline operacional GeraLanding dentro do mesmo contrato.
 - impacto esperado: reduz ambiguidade operacional na administração de pipelines, sincronização canônica e execução das etapas obrigatórias, automáticas e manuais do experimento.
+
+## 2026-06-15 — Relatório auditável da criação de hipótese
+
+- solicitação: permitir baixar, na tela de Nova hipótese, um relatório por etapa com prompt usado, request cru enviado para OpenAI, response cru recebido da OpenAI e informação final guardada no banco.
+- causa-raiz: a tela já exibia status e custo, mas o response cru da OpenAI não era persistido no backend das etapas da hipótese, impedindo auditoria completa sem consultar logs do Worker AI.
+- foi feito: o Worker AI passou a enviar `rawResponse` no callback de conclusão, o backend passou a persistir `raw_response` e expor esse campo no detalhe auditável, e o frontend ganhou o botão de download do relatório em Markdown.
+- validação: testes unitários do backend da etapa de hipótese, testes da tela de hipótese e build do frontend executados.
+- arquivos alterados:
+  - ai-worker/src/main/java/com/marketinghub/worker/pipeline/hypothesispain/HypothesisPainBackendClient.java
+  - ai-worker/src/main/java/com/marketinghub/worker/pipeline/hypothesisresult/HypothesisResultBackendClient.java
+  - ai-worker/src/main/java/com/marketinghub/worker/pipeline/hypothesismechanism/HypothesisMechanismBackendClient.java
+  - ai-worker/src/main/java/com/marketinghub/worker/pipeline/hypothesisproof/HypothesisProofBackendClient.java
+  - ai-worker/src/main/java/com/marketinghub/worker/pipeline/hypothesisoffer/HypothesisOfferBackendClient.java
+  - backend/ads-service/src/main/java/com/marketinghub/hypothesis/pain/HypothesisPainStageExecution.java
+  - backend/ads-service/src/main/java/com/marketinghub/hypothesis/pain/service/HypothesisPainStageService.java
+  - frontend/src/pages/hypothesis/NewHypothesisPage.tsx

--- a/docs/swagger/hypothesis-pain-stage-swagger.yaml
+++ b/docs/swagger/hypothesis-pain-stage-swagger.yaml
@@ -589,6 +589,7 @@ components:
         openAiRequestBody: { type: string, nullable: true }
         openAiModel: { type: string, nullable: true }
         openAiJobId: { type: string, nullable: true }
+        rawResponse: { type: string, nullable: true }
         modelResponse: { type: string, nullable: true }
         errorMessage: { type: string, nullable: true }
         errorDetail: { type: string, nullable: true }
@@ -611,6 +612,7 @@ components:
         marketNicheId: { type: integer, format: int64 }
         stageCode: { type: string }
         modelResponse: { type: string, nullable: true }
+        rawResponse: { type: string, nullable: true }
         inputTokens: { type: integer, nullable: true }
         outputTokens: { type: integer, nullable: true }
         costUsd: { type: number, nullable: true }

--- a/frontend/src/pages/hypothesis/NewHypothesisPage.tsx
+++ b/frontend/src/pages/hypothesis/NewHypothesisPage.tsx
@@ -22,6 +22,15 @@ interface StageExecution {
   errorMessage?: string;
 }
 
+interface StageExecutionDetail extends StageExecution {
+  promptContent?: string | null;
+  prompt?: string | null;
+  promptMarkdownContent?: string | null;
+  openAiRequestBody?: string | null;
+  rawResponse?: string | null;
+  modelResponse?: string | null;
+}
+
 const STAGES = HYPOTHESIS_PIPELINE_STAGES;
 
 const RUNNING_STATUSES = new Set([
@@ -54,6 +63,73 @@ function formatCostUsd(value?: number | string | null) {
 
 function formatModel(value?: string | null) {
   return value && value.trim().length > 0 ? value : "Aguardando IA";
+}
+
+function safeReportValue(value?: string | null) {
+  return value && value.trim().length > 0 ? value : "Não registrado.";
+}
+
+function buildHypothesisAuditReport(
+  nicheId: string,
+  details: Array<{
+    stage: HypothesisPipelineStageConfig;
+    detail: StageExecutionDetail;
+  }>,
+) {
+  const generatedAt = new Date().toLocaleString("pt-BR");
+  const lines = [
+    `# Relatório auditável da criação da hipótese`,
+    ``,
+    `Nicho: #${nicheId}`,
+    `Gerado em: ${generatedAt}`,
+    ``,
+  ];
+
+  details.forEach(({ stage, detail }) => {
+    lines.push(
+      `## Etapa ${stage.number} — ${stage.title}`,
+      ``,
+      `- Job: ${detail.jobid}`,
+      `- Status: ${detail.status}`,
+      `- Modelo usado: ${formatModel(detail.openAiModel)}`,
+      `- Custo: ${formatCostUsd(detail.costUsd)}`,
+      ``,
+      `### Prompt usado`,
+      "```text",
+      safeReportValue(detail.prompt ?? detail.promptContent),
+      "```",
+      ``,
+      `### Request cru enviado para OpenAI`,
+      "```json",
+      safeReportValue(detail.openAiRequestBody),
+      "```",
+      ``,
+      `### Response cru recebido da OpenAI`,
+      "```json",
+      safeReportValue(detail.rawResponse ?? detail.modelResponse),
+      "```",
+      ``,
+      `### Informação final guardada no banco de dados`,
+      "```json",
+      safeReportValue(detail.modelResponse),
+      "```",
+      ``,
+    );
+  });
+
+  return lines.join("\n");
+}
+
+function downloadTextFile(filename: string, content: string) {
+  const blob = new Blob([content], { type: "text/markdown;charset=utf-8" });
+  const url = URL.createObjectURL(blob);
+  const anchor = document.createElement("a");
+  anchor.href = url;
+  anchor.download = filename;
+  document.body.appendChild(anchor);
+  anchor.click();
+  anchor.remove();
+  URL.revokeObjectURL(url);
 }
 
 function StageCard({
@@ -251,6 +327,42 @@ export default function NewHypothesisPage() {
       return cost === null ? total : total + cost;
     }, 0);
 
+  const reportMutation = useMutation({
+    mutationFn: async () => {
+      if (!nicheId) {
+        throw new Error("Nicho não informado.");
+      }
+      const completedStages = STAGES.map((stage, index) => ({
+        stage,
+        latest: stageQueries[index]?.data?.[0],
+      })).filter(({ latest }) => latest?.status === "CONCLUIDO");
+
+      if (completedStages.length === 0) {
+        throw new Error("Nenhuma etapa concluída para gerar relatório.");
+      }
+
+      const details = await Promise.all(
+        completedStages.map(async ({ stage, latest }) => {
+          const { data } = await axios.get<StageExecutionDetail>(
+            `/api/niches/${nicheId}/hypothesis-pipeline/${stage.slug}/stage-executions/${latest?.jobid}`,
+          );
+          return { stage, detail: data };
+        }),
+      );
+
+      return buildHypothesisAuditReport(nicheId, details);
+    },
+    onSuccess: (content) => {
+      downloadTextFile(`relatorio-hipotese-nicho-${nicheId}.md`, content);
+      toast.success("Relatório gerado para download.");
+    },
+    onError: (error) => {
+      const message =
+        error instanceof Error ? error.message : "Falha ao gerar relatório.";
+      toast.error(message);
+    },
+  });
+
   return (
     <div className="hypothesis-new-page">
       <PageTitle icon={hypothesisIcon}>Nova hipótese</PageTitle>
@@ -261,10 +373,30 @@ export default function NewHypothesisPage() {
             <p className="mb-0">
               <strong>Nicho recebido:</strong> #{nicheId}
             </p>
-            <p className="mb-0">
-              <strong>Custo total geral da criação da hipótese:</strong>{" "}
-              {totalCostLoading ? "Calculando..." : formatCostUsd(totalCost)}
-            </p>
+            <div className="d-flex flex-column flex-md-row gap-2 align-items-md-center">
+              <p className="mb-0">
+                <strong>Custo total geral da criação da hipótese:</strong>{" "}
+                {totalCostLoading ? "Calculando..." : formatCostUsd(totalCost)}
+              </p>
+              <button
+                type="button"
+                className="btn btn-outline-primary btn-sm"
+                disabled={!nicheId || reportMutation.isPending}
+                onClick={() => reportMutation.mutate()}
+              >
+                {reportMutation.isPending ? (
+                  <span className="d-inline-flex align-items-center gap-2">
+                    <span
+                      className="spinner-border spinner-border-sm"
+                      aria-hidden="true"
+                    />
+                    Gerando...
+                  </span>
+                ) : (
+                  "Baixar relatório auditável"
+                )}
+              </button>
+            </div>
           </div>
         </section>
       )}


### PR DESCRIPTION
### Motivation
- Provide an auditable, per-stage report on the Nova hipótese screen showing the prompt used, raw OpenAI request, raw OpenAI response and the final content persisted in the DB. 
- The backend previously did not persist the raw OpenAI response for hypothesis pipeline stages, preventing a complete audit without inspecting worker logs. 

### Description
- Frontend: added a `Baixar relatório auditável` button to `NewHypothesisPage` which fetches detailed stage executions and downloads a Markdown report built from `prompt`, `openAiRequestBody`, `rawResponse` and `modelResponse`. (file: `frontend/src/pages/hypothesis/NewHypothesisPage.tsx`)
- Backend: added `raw_response` column to `hypothesis_pain_stage_execution`, persisted `rawResponse` on callback and exposed it in the detail response record `HypothesisPainExecutionDetailResponse`. (files: `backend/ads-service/src/main/java/.../HypothesisPainStageExecution.java`, `HypothesisPainStageService.java`, `detailStageExecution/HypothesisPainExecutionDetailResponse.java`)
- Worker AI: updated hypothesis-stage backend clients to include `rawResponse` in the completion payload for pain/result/mechanism/proof/offer stages. (files: `ai-worker/src/main/java/com/marketinghub/worker/pipeline/*/Hypothesis*BackendClient.java`)
- Database migration and API docs: added a Liquibase changeset to add the `raw_response` column and updated the Swagger contract and experiment registry docs to include the new field. (files: `backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-15-hypothesis-pipeline-raw-response.yaml`, `docs/swagger/hypothesis-pain-stage-swagger.yaml`, `docs/registros/experimentos.md`)

### Testing
- Ran backend unit tests: `cd backend && ./mvnw -f ads-service/pom.xml -Dtest=HypothesisPainStageServiceTest test` — success. 
- Built and installed backend artifact: `cd backend && ./mvnw -f ads-service/pom.xml -DskipTests install` — success. 
- Ran Worker AI client tests: `cd ai-worker && ../backend/mvnw -Dtest='HypothesisPainBackendClientTest,HypothesisResultBackendClientTest,HypothesisMechanismBackendClientTest,HypothesisProofBackendClientTest,HypothesisOfferBackendClientTest' test` — success. 
- Frontend: ran unit tests and production build: `cd frontend && npm test -- --run src/pages/hypothesis/NewHypothesisPage.test.tsx src/pages/hypothesis/HypothesisPipelineSummaryPage.test.tsx` and `cd frontend && npm run build` — tests and build succeeded. 
- Note: attempted `spotless:apply` (`cd backend && ./mvnw -f ads-service/pom.xml spotless:apply`) but the Spotless plugin prefix was not resolved in this environment; this did not block the functional changes or automated tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a300d05ef0c832197cf4fbc8098dcf3)