### PR TITLE
Fix Liquibase include: declare relativeToChangelogFile for hypothesis changeset

### DIFF
--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -989,6 +989,7 @@ databaseChangeLog:
 
   - include:
       file: changesets/2026-06-15-hypothesis-pipeline-raw-response.yaml
+      relativeToChangelogFile: true
   - include:
       file: changesets/2026-06-15-mois-hotmart-description-longtext.yaml
       relativeToChangelogFile: true


### PR DESCRIPTION
### Motivation
- Liquibase failed to locate the `changesets/2026-06-15-hypothesis-pipeline-raw-response.yaml` file because the master changelog include did not declare it as relative to the master changelog directory.

### Description
- Added `relativeToChangelogFile: true` to the include entry for `changesets/2026-06-15-hypothesis-pipeline-raw-response.yaml` in `backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml` so Liquibase resolves the changeset path correctly.

### Testing
- Passed: ran a `python` validation script that verifies every `file: changesets/...` include in the master changelog declares `relativeToChangelogFile: true` and it reported success.
- Passed: repository consistency checks (`git diff --check`) showed no whitespace/conflict issues after the change.
- Warning: attempted `./backend/mvnw -f backend/ads-service/pom.xml -DskipTests liquibase:validate`, Liquibase was reached but the run failed because no database URL/properties are available in this environment, so full runtime validation could not complete.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a30146b24a08321baa015733c567a01)