### PR TITLE
Agenda ciclo Hotmart para 14h45

### DIFF
--- a/docs/registros/mois1.md
+++ b/docs/registros/mois1.md
@@ -1602,3 +1602,12 @@ Arquivos principais:
 - Causa-raiz investigada: a coleta Hotmart de 14/06/2026 às 22:00 recebeu 400 produtos, mas 119 referências não entraram em `mois_collected_reference` porque `hotmart_description` estava limitada a `VARCHAR(1000)` e as descrições reais da Hotmart excediam esse tamanho.
 - Criado changelog Liquibase para alterar o banco para `hotmart_description LONGTEXT NULL`, preservando a descrição comercial completa e evitando perda de referências relacionais em novas coletas.
 - Atualizado o documento canônico do fluxo Hotmart para refletir que a descrição comercial deve ser persistida completa.
+
+## 2026-06-15 14:24:24 UTC-3
+- ajustado o agendamento pontual do ciclo 1 de coleta Hotmart para executar hoje, 15/06/2026, às 14:45 no timezone `America/Sao_Paulo`.
+- mantido o cron literal diretamente na anotação `@Scheduled`, conforme regra operacional de agendamentos Spring Boot.
+- atualizado o teste unitário do scheduler para prevenir divergência entre código e agendamento esperado.
+- documentos lidos para tratar a situação:
+  - AGENTS.md
+  - mois-hotmart-collector/AGENTS.md
+  - docs/registros/mois1.md

--- a/mois-hotmart-collector/src/main/java/com/marketinghub/moishotmart/service/HotmartCollectorScheduler.java
+++ b/mois-hotmart-collector/src/main/java/com/marketinghub/moishotmart/service/HotmartCollectorScheduler.java
@@ -41,10 +41,10 @@ public class HotmartCollectorScheduler {
     }
 
     /**
-     * Executa o ciclo 1 de listagem de produtos uma única vez às 22:00 em 14 de junho de 2026, no horário de São Paulo.
+     * Executa o ciclo 1 de listagem de produtos uma única vez às 14:45 em 15 de junho de 2026, no horário de São Paulo.
      */
-    @Scheduled(cron = "0 0 22 14 6 *", zone = "America/Sao_Paulo")
-    public void collectFirstCycleAtTwentyTwoHundredOnJuneFourteenth2026() {
+    @Scheduled(cron = "0 45 14 15 6 *", zone = "America/Sao_Paulo")
+    public void collectFirstCycleAtFourteenFortyFiveOnJuneFifteenth2026() {
         if (!enabled) {
             log.info("Hotmart scheduler desabilitado por configuração.");
             return;
@@ -58,7 +58,7 @@ public class HotmartCollectorScheduler {
         }
         HotmartCollectionRequest request = new HotmartCollectionRequest(source, maxProducts);
         HotmartCollectionResponse response = collectorService.collectFirstCycle(request);
-        log.info("Hotmart scheduler executado hora=22:00 dia=14/06 ano=2026 "
+        log.info("Hotmart scheduler executado hora=14:45 dia=15/06 ano=2026 "
                         + "timezone=America/Sao_Paulo ciclo={} status={} produtos={} mensagem={}",
                 "CICLO_1_LISTAGEM",
                 response.status(),

--- a/mois-hotmart-collector/src/test/java/com/marketinghub/moishotmart/service/HotmartCollectorSchedulerTest.java
+++ b/mois-hotmart-collector/src/test/java/com/marketinghub/moishotmart/service/HotmartCollectorSchedulerTest.java
@@ -12,15 +12,15 @@ import org.springframework.scheduling.annotation.Scheduled;
 class HotmartCollectorSchedulerTest {
 
     /**
-     * Garante que o ciclo 1 esteja agendado para 22:00 de 14 de junho de 2026 no fuso de São Paulo.
+     * Garante que o ciclo 1 esteja agendado para 14:45 de 15 de junho de 2026 no fuso de São Paulo.
      */
     @Test
-    void shouldScheduleFirstCycleAtTwentyTwoHundredOnJuneFourteenth() throws NoSuchMethodException {
+    void shouldScheduleFirstCycleAtFourteenFortyFiveOnJuneFifteenth() throws NoSuchMethodException {
         Method method = HotmartCollectorScheduler.class
-                .getDeclaredMethod("collectFirstCycleAtTwentyTwoHundredOnJuneFourteenth2026");
+                .getDeclaredMethod("collectFirstCycleAtFourteenFortyFiveOnJuneFifteenth2026");
         Scheduled scheduled = method.getAnnotation(Scheduled.class);
 
-        assertEquals("0 0 22 14 6 *", scheduled.cron());
+        assertEquals("0 45 14 15 6 *", scheduled.cron());
         assertEquals("America/Sao_Paulo", scheduled.zone());
     }
 


### PR DESCRIPTION
### Motivation
- Ajustar agendamento pontual do coletor Hotmart para executar hoje no horário solicitado de forma explícita no código.
- Garantir que o teste unitário do scheduler valide o cron atualizado para evitar divergência entre código e documentação.
- Registrar a operação no log canônico de alterações do MOIS para rastreabilidade operacional.

### Description
- Atualizado `mois-hotmart-collector/src/main/java/com/marketinghub/moishotmart/service/HotmartCollectorScheduler.java` para alterar o cron do ciclo 1 para `@Scheduled(cron = "0 45 14 15 6 *", zone = "America/Sao_Paulo")` e renomear o método para refletir o novo horário e data. 
- Atualizado `mois-hotmart-collector/src/test/java/com/marketinghub/moishotmart/service/HotmartCollectorSchedulerTest.java` para validar o novo cron `0 45 14 15 6 *` e o nome do método agendado. 
- Adicionado registro operacinal em `docs/registros/mois1.md` com timestamp `2026-06-15 14:24:24 UTC-3` descrevendo a alteração e os documentos consultados.

### Testing
- Executed unit tests in the module with `mvn test` in `mois-hotmart-collector`, and the module's test suite ran without failures.
- Ran repository checks with `git diff --check` and verified there are no whitespace or diff errors.
- Verified changes are staged and committed (commit `6db9606`) and updated registry entry appended to `docs/registros/mois1.md`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3035194a4c8321811885ab6f718581)