### PR TITLE
Ajusta fluxo OPRM CNAE para subnichos

### DIFF
--- a/docs/canonical/oprm-canon.v1.md
+++ b/docs/canonical/oprm-canon.v1.md
@@ -191,6 +191,18 @@ Evitar fechamento prematuro de `import run` que destrói a totalização de mark
 - Ao navegar entre páginas, a ordenação deve permanecer estável por `Score OPRM` decrescente.
 - O texto de apoio na tela deve deixar explícito para o usuário que o ranking está ordenado por Score OPRM e paginado.
 
+## Regra obrigatória — fluxo operacional CNAE → subnicho
+
+- A experiência administrativa do OPRM deve começar pela lista paginada de CNAEs priorizados por Score OPRM.
+- Ao selecionar um CNAE, a tela deve exibir todos os subnichos/nichos enriquecidos já criados para esse CNAE antes de oferecer nova execução, reduzindo duplicidade e gasto sem aprendizado.
+- O comando manual principal dessa tela deve ser “Criar novo subnicho” e deve disparar a análise do CNAE considerando os nichos já criados para buscar uma oportunidade diferente com potencial de venda.
+- Após a criação do ciclo, a UI deve levar o usuário para uma visão dedicada ao subnicho/ciclo recém-criado, exibindo etapas, histórico de jobs apenas desse novo nicho, custo total do subnicho, custo por execução e evolução do pipeline.
+
+## Critério de efetividade — fluxo operacional CNAE → subnicho
+
+- A tela do CNAE não deve misturar histórico de custos de ciclos antigos quando o usuário estiver acompanhando um subnicho específico.
+- A visão dedicada do subnicho deve manter rastreabilidade por `researchCycleId` e permitir abrir detalhes das etapas do pipeline.
+
 ## Regra obrigatória — lista de nichos enriquecidos por score
 
 - A lista de nichos enriquecidos exibida na tela de CNAEs por Score OPRM deve priorizar os candidatos com maior `opportunityScore` no começo.

--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -754,3 +754,5 @@
 - Alterado o fluxo da tela de detalhe do CNAE para priorizar a lista de nichos enriquecidos já gerados pelo CNAE antes de exibir as etapas do pipeline.
 - Causa-raiz tratada: o clique no CNAE entrava direto na visão operacional do pipeline, dificultando perceber se o CNAE já tinha nichos gerados e aumentando risco de duplicidade, confusão entre CNAE e nicho e gasto desnecessário.
 - Correção aplicada: criado endpoint backend para listar nichos enriquecidos por CNAE; o frontend passou a exibir essa lista com ação de abertura do nicho e botão único para gerar um novo nicho, mostrando as etapas do pipeline apenas após esse comando.
+
+- 2026-06-15 00:00:00 (UTC-3): ajustado o fluxo administrativo CNAE → subnicho no frontend: a lista de CNAEs leva para uma tela com todos os subnichos do CNAE, o comando principal passou a criar novo subnicho com potencial de venda e, após o disparo, a navegação abre uma visão dedicada ao ciclo criado com etapas, custo e jobs restritos ao novo subnicho.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -300,6 +300,10 @@ export default function App() {
                 element={<OprmCnaeDetailPlaceholderPage />}
               />
               <Route
+                path="/oprm/cnaes/:cnaeCode/subnichos/:researchCycleId"
+                element={<OprmCnaeDetailPlaceholderPage />}
+              />
+              <Route
                 path="/oprm/cnaes/:cnaeCode/pipeline/:researchCycleId/stages/:stageCode"
                 element={<OprmCnaePipelineStageDetailPage />}
               />

--- a/frontend/src/pages/oprm/OprmCnaeDetailPlaceholderPage.test.tsx
+++ b/frontend/src/pages/oprm/OprmCnaeDetailPlaceholderPage.test.tsx
@@ -152,14 +152,13 @@ describe("OprmCnaeDetailPlaceholderPage", () => {
     renderPage();
 
     await userEvent.click(
-      await screen.findByRole("button", { name: "Gerar novo nicho" }),
+      await screen.findByRole("button", { name: "Criar novo subnicho" }),
     );
     expect(await screen.findByText(/status atual:/i)).toBeTruthy();
-    expect(screen.getByText("Custo total do CNAE")).toBeTruthy();
-    expect(screen.getAllByText("US$ 0,0456").length).toBeGreaterThan(0);
+    expect(screen.getByText("Custo total do subnicho")).toBeTruthy();
     expect(screen.getByText(/custo do job atual:/i)).toBeTruthy();
     expect(screen.getAllByText("US$ 0,0123").length).toBeGreaterThan(0);
-    expect(screen.getByText("Jobs executados para este CNAE")).toBeTruthy();
+    expect(screen.getByText("Jobs deste subnicho")).toBeTruthy();
     expect(
       screen.getByText(/bloqueada por fontes antigas ou sem atualidade/i),
     ).toBeTruthy();
@@ -271,7 +270,7 @@ describe("OprmCnaeDetailPlaceholderPage", () => {
     renderPage();
 
     await userEvent.click(
-      await screen.findByRole("button", { name: "Gerar novo nicho" }),
+      await screen.findByRole("button", { name: "Criar novo subnicho" }),
     );
     expect(
       await screen.findByText("Reprocessamento automático em andamento"),
@@ -325,7 +324,7 @@ describe("OprmCnaeDetailPlaceholderPage", () => {
     renderPage();
 
     await userEvent.click(
-      await screen.findByRole("button", { name: "Gerar novo nicho" }),
+      await screen.findByRole("button", { name: "Criar novo subnicho" }),
     );
     await screen.findByText(/status atual:/i);
 

--- a/frontend/src/pages/oprm/OprmCnaeDetailPlaceholderPage.tsx
+++ b/frontend/src/pages/oprm/OprmCnaeDetailPlaceholderPage.tsx
@@ -1,6 +1,6 @@
 import { Globe2, Sparkles } from "lucide-react";
 import { useState } from "react";
-import { Link, useParams } from "react-router-dom";
+import { Link, useNavigate, useParams } from "react-router-dom";
 import {
   useOprmCnaeScore,
   useOprmCnaeVolume,
@@ -601,16 +601,26 @@ function inferStageState(
 }
 
 export default function OprmCnaeDetailPlaceholderPage() {
-  const { cnaeCode } = useParams();
+  const { cnaeCode, researchCycleId } = useParams();
+  const navigate = useNavigate();
   const decodedCnaeCode = cnaeCode ? decodeURIComponent(cnaeCode) : "CNAE";
-  const [showPipeline, setShowPipeline] = useState(false);
+  const selectedResearchCycleId = researchCycleId
+    ? Number(researchCycleId)
+    : null;
+  const [showPipeline, setShowPipeline] = useState(
+    Boolean(selectedResearchCycleId),
+  );
   const volumeQuery = useOprmCnaeVolume(decodedCnaeCode);
   const scoreQuery = useOprmCnaeScore(decodedCnaeCode);
   const cyclesQuery = useOprmCnaePipelineCycles(decodedCnaeCode);
   const generatedNichesQuery =
     useOprmGeneratedEnrichedNichesByCnae(decodedCnaeCode);
   const startPipelineMutation = useStartOprmCnaePipeline(decodedCnaeCode);
-  const latestCycle = cyclesQuery.data?.[0];
+  const latestCycle = selectedResearchCycleId
+    ? cyclesQuery.data?.find(
+        (cycle) => cycle.researchCycleId === selectedResearchCycleId,
+      )
+    : cyclesQuery.data?.[0];
   const previousCycle = findPreviousCycle(cyclesQuery.data, latestCycle);
   const automaticAttempts = countAutomaticReprocessCycles(cyclesQuery.data);
   const automaticProcess = automaticProcessMessage(
@@ -648,17 +658,25 @@ export default function OprmCnaeDetailPlaceholderPage() {
 
   useBreadcrumbs([
     { label: "OPRM", to: "/oprm" },
-    { label: "Detalhe do nicho" },
+    {
+      label: selectedResearchCycleId
+        ? "Pipeline do subnicho"
+        : "Subnichos do CNAE",
+    },
   ]);
 
   return (
     <div className="d-flex flex-column gap-4">
       <header className="d-flex flex-column gap-2">
-        <PageTitle>Detalhe do nicho CNAE</PageTitle>
+        <PageTitle>
+          {selectedResearchCycleId
+            ? "Pipeline do subnicho"
+            : "Subnichos do CNAE"}
+        </PageTitle>
         <p className="text-secondary mb-0">
-          Use esta visão para decidir se o CNAE merece pesquisa de rotina,
-          acompanhar a execução do NichoCNAE e avançar apenas com oportunidades
-          sustentadas por sinais reais.
+          {selectedResearchCycleId
+            ? "Acompanhe somente os jobs, custos e etapas do subnicho recém-criado, sem misturar com execuções antigas do mesmo CNAE."
+            : "Confira todos os subnichos já criados para este CNAE e gere um novo apenas quando houver espaço comercial para uma oportunidade diferente."}
         </p>
       </header>
 
@@ -686,9 +704,9 @@ export default function OprmCnaeDetailPlaceholderPage() {
           </div>
           {startPipelineMutation.isSuccess ? (
             <div className="alert alert-success mb-0" role="status">
-              Pipeline iniciado para o CNAE {decodedCnaeCode}. Ciclo #
+              Novo subnicho iniciado para o CNAE {decodedCnaeCode}. Ciclo #
               {startPipelineMutation.data.researchCycleId} criado para
-              acompanhamento.
+              acompanhamento dedicado.
             </div>
           ) : null}
           {startPipelineMutation.isError ? (
@@ -772,11 +790,11 @@ export default function OprmCnaeDetailPlaceholderPage() {
         <div className="card-body d-flex flex-column gap-3">
           <div className="d-flex flex-wrap justify-content-between gap-3 align-items-start">
             <div>
-              <h2 className="h5 mb-1">Nichos gerados com este CNAE</h2>
+              <h2 className="h5 mb-1">Subnichos deste CNAE</h2>
               <p className="text-secondary mb-0">
-                Primeiro confira se já existe um nicho utilizável para evitar
-                duplicidade e gasto desnecessário; gere um novo apenas quando o
-                histórico não atender ao objetivo comercial.
+                Esta é a segunda etapa do fluxo: o usuário escolhe um subnicho
+                existente ou solicita a criação de um novo subnicho com
+                potencial de venda.
               </p>
             </div>
             <button
@@ -785,7 +803,14 @@ export default function OprmCnaeDetailPlaceholderPage() {
               disabled={startPipelineMutation.isPending}
               onClick={() =>
                 startPipelineMutation.mutate(undefined, {
-                  onSuccess: () => setShowPipeline(true),
+                  onSuccess: (result) => {
+                    setShowPipeline(true);
+                    if (result.researchCycleId) {
+                      navigate(
+                        `/oprm/cnaes/${encodeURIComponent(decodedCnaeCode)}/subnichos/${result.researchCycleId}`,
+                      );
+                    }
+                  },
                 })
               }
             >
@@ -798,19 +823,19 @@ export default function OprmCnaeDetailPlaceholderPage() {
                   Gerando...
                 </>
               ) : (
-                "Gerar novo nicho"
+                "Criar novo subnicho"
               )}
             </button>
           </div>
 
           {generatedNichesQuery.isLoading ? (
             <div className="alert alert-light border mb-0" role="status">
-              Carregando nichos gerados para o CNAE...
+              Carregando subnichos do CNAE...
             </div>
           ) : null}
           {generatedNichesQuery.isError ? (
             <div className="alert alert-warning mb-0" role="alert">
-              Não foi possível carregar os nichos gerados para este CNAE.
+              Não foi possível carregar os subnichos deste CNAE.
             </div>
           ) : null}
           {generatedNichesQuery.data?.length ? (
@@ -818,7 +843,7 @@ export default function OprmCnaeDetailPlaceholderPage() {
               <table className="table table-sm align-middle mb-0">
                 <thead>
                   <tr>
-                    <th scope="col">Nicho gerado</th>
+                    <th scope="col">Subnicho</th>
                     <th scope="col">Qualidade</th>
                     <th scope="col">Ciclo</th>
                     <th scope="col">Evidências</th>
@@ -849,9 +874,9 @@ export default function OprmCnaeDetailPlaceholderPage() {
                       <td className="text-end">
                         <Link
                           className="btn btn-outline-primary btn-sm"
-                          to={`/oprm/enriched-niches/profile/${niche.enrichedNicheProfileId}`}
+                          to={`/oprm/cnaes/${encodeURIComponent(decodedCnaeCode)}/subnichos/${niche.researchCycleId}`}
                         >
-                          Abrir
+                          Acompanhar
                         </Link>
                       </td>
                     </tr>
@@ -864,8 +889,8 @@ export default function OprmCnaeDetailPlaceholderPage() {
           !generatedNichesQuery.isError &&
           !generatedNichesQuery.data?.length ? (
             <div className="alert alert-secondary mb-0">
-              Ainda não existe nicho enriquecido gerado para este CNAE. Use
-              “Gerar novo nicho” para iniciar o pipeline.
+              Ainda não existe subnicho criado para este CNAE. Use “Criar novo
+              subnicho” para iniciar a análise.
             </div>
           ) : null}
         </div>
@@ -885,14 +910,14 @@ export default function OprmCnaeDetailPlaceholderPage() {
               <div className="d-flex flex-wrap gap-2 align-items-start justify-content-end">
                 <div className="border rounded-3 bg-light px-3 py-2 text-end">
                   <span className="d-block small text-secondary">
-                    Custo total do CNAE
+                    Custo total do subnicho
                   </span>
                   <strong className="fs-5">
-                    {formatUsd(latestCycle?.cnaeTotalCostUsd)}
+                    {formatUsd(latestCycle?.executionCostUsd)}
                   </strong>
                 </div>
                 <span className="badge text-bg-light align-self-start">
-                  Último ciclo:{" "}
+                  Ciclo selecionado:{" "}
                   {latestCycle ? `#${latestCycle.researchCycleId}` : "nenhum"}
                 </span>
               </div>
@@ -1051,14 +1076,15 @@ export default function OprmCnaeDetailPlaceholderPage() {
               <div className="card-body">
                 <div className="d-flex flex-wrap justify-content-between gap-2 mb-3">
                   <div>
-                    <h3 className="h6 mb-1">Jobs executados para este CNAE</h3>
+                    <h3 className="h6 mb-1">Jobs deste subnicho</h3>
                     <p className="small text-secondary mb-0">
-                      Histórico por execução para controlar gasto operacional
-                      antes de escalar o nicho.
+                      Histórico restrito ao ciclo do subnicho selecionado para
+                      controlar gasto operacional sem misturar execuções antigas
+                      do CNAE.
                     </p>
                   </div>
                   <strong>
-                    Total: {formatUsd(latestCycle?.cnaeTotalCostUsd)}
+                    Total: {formatUsd(latestCycle?.executionCostUsd)}
                   </strong>
                 </div>
                 <div className="table-responsive">
@@ -1075,8 +1101,8 @@ export default function OprmCnaeDetailPlaceholderPage() {
                       </tr>
                     </thead>
                     <tbody>
-                      {cyclesQuery.data && cyclesQuery.data.length > 0 ? (
-                        cyclesQuery.data.map((cycle) => (
+                      {latestCycle ? (
+                        [latestCycle].map((cycle) => (
                           <tr key={cycle.researchCycleId}>
                             <td>#{cycle.researchCycleId}</td>
                             <td>{statusLabel(cycle.status)}</td>
@@ -1093,7 +1119,7 @@ export default function OprmCnaeDetailPlaceholderPage() {
                             colSpan={5}
                             className="text-secondary text-center py-3"
                           >
-                            Nenhum job executado para este CNAE.
+                            Nenhum job executado para este subnicho.
                           </td>
                         </tr>
                       )}


### PR DESCRIPTION
### Motivation
- Evitar duplicidade e mistura de histórico ao abrir um CNAE, apresentando primeiro os subnichos já gerados e permitindo criar/acompanhar um subnicho isolado para análise comercial dedicada.
- Dar rastreabilidade e acompanhamento por `researchCycleId` para que jobs, custos e etapas sejam restritos ao subnicho/ciclo selecionado, não ao histórico agregado do CNAE.
- Registrar a nova regra operacional no cânone OPRM para manter a documentação alinhada ao comportamento da UI.

### Description
- Frontend: altera `OprmCnaeDetailPlaceholderPage` para exibir a lista de subnichos do CNAE, renomeia textos e botão de ação para `Criar novo subnicho`, e passa a navegar para uma rota dedicada ao ciclo criado (`/oprm/cnaes/:cnaeCode/subnichos/:researchCycleId`).
- Frontend: quando uma `researchCycleId` está presente a tela abre a visão do pipeline limitada ao `latestCycle` selecionado (jobs, custo total e custo por execução são calculados por ciclo), e os links de lista de subnichos apontam para a visão de acompanhamento do ciclo em vez do perfil enriquecido.
- Routes: adicionada rota em `frontend/src/App.tsx` para `/oprm/cnaes/:cnaeCode/subnichos/:researchCycleId` que reutiliza a página de detalhe atualizada.
- Tests: atualizado `OprmCnaeDetailPlaceholderPage.test.tsx` para usar o novo botão `Criar novo subnicho` e verificar textos/valores de custo e jobs do subnicho.
- Docs: inserida seção canônica em `docs/canonical/oprm-canon.v1.md` descrevendo o fluxo CNAE → subnicho e critérios de efetividade, e registrada a alteração em `docs/registros/oprm1.md`.

### Testing
- Executed unit tests: `npm --prefix frontend run test -- OprmCnaeDetailPlaceholderPage.test.tsx --run` and all tests in that file passed (3/3) after updates.
- Type checking: `npm --prefix frontend run typecheck` (i.e. `tsc --noEmit`) completed successfully with no type errors.
- UI screenshot attempt with Playwright failed due to missing native library in the environment (`libatk-1.0.so.0`), so no end-to-end screenshot was produced (Playwright browser install/launch error).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a303aabdba88321b5313e49ebf5aa45)