### PR TITLE
OPRM: copy identification cost to materialized MarketNiche and add DB backfill

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/enrichednichematerializer/service/BackendEnrichedNicheMaterializerService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/enrichednichematerializer/service/BackendEnrichedNicheMaterializerService.java
@@ -1,5 +1,6 @@
 package com.marketinghub.oprm.nichocnae.enrichednichematerializer.service;
 
+import com.marketinghub.finance.CurrencyConversionService;
 import com.marketinghub.niche.MarketNiche;
 import com.marketinghub.niche.MarketNicheEnrichmentProfile;
 import com.marketinghub.oprm.cnae.OprmNicheCandidate;
@@ -31,6 +32,7 @@ import com.marketinghub.repository.jpa.oprm.nichocnae.OprmSourceCandidateReposit
 import com.marketinghub.repository.jpa.oprm.nichocnae.OprmSourceSnapshotRepository;
 import com.marketinghub.repository.jpa.oprm.nichocnae.meiaudienceprofile.OprmMeiAudienceProfileRepository;
 import jakarta.persistence.EntityNotFoundException;
+import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.LinkedHashMap;
@@ -70,6 +72,7 @@ public class BackendEnrichedNicheMaterializerService {
   private final MarketNicheEnrichmentProfileRepository enrichmentProfileRepository;
   private final OprmMeiAudienceProfileRepository meiAudienceProfileRepository;
   private final OprmEnrichedNicheMetaSignalService metaSignalService;
+  private final CurrencyConversionService currencyConversionService;
 
   /** Inicializa o serviço com os repositórios oficiais do backend usados pela etapa final. */
   public BackendEnrichedNicheMaterializerService(
@@ -84,7 +87,8 @@ public class BackendEnrichedNicheMaterializerService {
       MarketNicheRepository marketNicheRepository,
       MarketNicheEnrichmentProfileRepository enrichmentProfileRepository,
       OprmMeiAudienceProfileRepository meiAudienceProfileRepository,
-      OprmEnrichedNicheMetaSignalService metaSignalService) {
+      OprmEnrichedNicheMetaSignalService metaSignalService,
+      CurrencyConversionService currencyConversionService) {
     this.cycleRepository = cycleRepository;
     this.routineCardRepository = routineCardRepository;
     this.nicheCandidateRepository = nicheCandidateRepository;
@@ -97,6 +101,7 @@ public class BackendEnrichedNicheMaterializerService {
     this.enrichmentProfileRepository = enrichmentProfileRepository;
     this.meiAudienceProfileRepository = meiAudienceProfileRepository;
     this.metaSignalService = metaSignalService;
+    this.currencyConversionService = currencyConversionService;
   }
 
   /** Lista cartões aprovados pelo gate que ainda precisam materializar nicho e nicho enriquecido. */
@@ -129,6 +134,7 @@ public class BackendEnrichedNicheMaterializerService {
     MarketNiche marketNiche = existingMarketNicheByCnaeAndNeutralName
         .orElseGet(MarketNiche::new);
     applyRoutineCardToMarketNiche(marketNiche, card, cycle, metaSignalPackage);
+    applyIdentificationCostToMarketNiche(marketNiche, cycle);
     MarketNiche savedMarketNiche = marketNicheRepository.save(marketNiche);
     MarketNicheEnrichmentProfile profile = buildProfile(card, cycle, candidate, savedMarketNiche, request);
     MarketNicheEnrichmentProfile savedProfile = enrichmentProfileRepository.save(profile);
@@ -327,6 +333,24 @@ public class BackendEnrichedNicheMaterializerService {
     marketNiche.setDemographicFilters("Público profissional/empreendedor ligado a " + cycle.getCnaeDescription());
     applyMetaSignalsToNiche(marketNiche, metaSignalPackage);
     marketNiche.setExtraTips(buildExtraTips(card));
+  }
+
+  /** Aplica o custo de identificação do NichoCNAE ao nicho base sem duplicar reprocessamentos. */
+  private void applyIdentificationCostToMarketNiche(MarketNiche marketNiche, OprmRoutineResearchCycle cycle) {
+    BigDecimal identificationCostUsd = seedRepository.sumCostUsdByResearchCycleId(cycle.getId());
+    if (identificationCostUsd == null || identificationCostUsd.compareTo(BigDecimal.ZERO) <= 0) {
+      return;
+    }
+    BigDecimal identificationCostBrl = currencyConversionService.usdToBrl(identificationCostUsd);
+    if (identificationCostBrl == null || identificationCostBrl.compareTo(BigDecimal.ZERO) <= 0) {
+      return;
+    }
+    if (marketNiche.getCost() == null || marketNiche.getCost().compareTo(BigDecimal.ZERO) == 0) {
+      marketNiche.setCost(identificationCostBrl);
+    }
+    if (marketNiche.getTotalCost() == null || marketNiche.getTotalCost().compareTo(BigDecimal.ZERO) == 0) {
+      marketNiche.setTotalCost(identificationCostBrl);
+    }
   }
 
   /** Localiza nicho já vinculado ao mesmo CNAE e ao mesmo nome neutro, permitindo vários nichos diferentes no mesmo CNAE. */

--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-15-oprm-enriched-niche-identification-cost.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-15-oprm-enriched-niche-identification-cost.yaml
@@ -1,0 +1,36 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-06-15-oprm-enriched-niche-identification-cost
+      author: marketinghub
+      preConditions:
+        - onFail: MARK_RAN
+        - onError: HALT
+        - dbms:
+            type: mysql
+      changes:
+        - sql:
+            splitStatements: true
+            stripComments: true
+            dbms: mysql
+            sql: |-
+              SET @usd_to_brl := 5.00;
+              UPDATE market_niche n
+                   INNER JOIN market_niche_enrichment_profile p
+                           ON p.market_niche_id = n.id
+                   INNER JOIN (
+                       SELECT research_cycle_id,
+                              ROUND(SUM(COALESCE(cost_usd, 0)) * @usd_to_brl, 2) AS identification_cost_brl
+                         FROM oprm_niche_research_seed
+                        GROUP BY research_cycle_id
+                   ) s ON s.research_cycle_id = p.research_cycle_id
+                 SET n.cost = CASE
+                                WHEN n.cost IS NULL OR n.cost = 0 THEN s.identification_cost_brl
+                                ELSE n.cost
+                              END,
+                     n.total_cost = CASE
+                                      WHEN n.total_cost IS NULL OR n.total_cost = 0 THEN s.identification_cost_brl
+                                      ELSE n.total_cost
+                                    END
+               WHERE s.identification_cost_brl > 0
+                 AND ((n.cost IS NULL OR n.cost = 0)
+                   OR (n.total_cost IS NULL OR n.total_cost = 0));

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -1,5 +1,8 @@
 databaseChangeLog:
   - include:
+      file: changesets/2026-06-15-oprm-enriched-niche-identification-cost.yaml
+      relativeToChangelogFile: true
+  - include:
       file: changesets/2026-06-14-oprm-seed-builder-openai-raw-payloads.yaml
       relativeToChangelogFile: true
   - include:

--- a/backend/ads-service/src/test/java/com/marketinghub/oprm/nichocnae/enrichednichematerializer/service/BackendEnrichedNicheMaterializerServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/oprm/nichocnae/enrichednichematerializer/service/BackendEnrichedNicheMaterializerServiceTest.java
@@ -8,6 +8,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.marketinghub.finance.CurrencyConversionService;
 import com.marketinghub.niche.MarketNiche;
 import com.marketinghub.niche.MarketNicheEnrichmentProfile;
 import com.marketinghub.oprm.cnae.OprmNicheCandidate;
@@ -54,11 +55,13 @@ class BackendEnrichedNicheMaterializerServiceTest {
   private final MarketNicheEnrichmentProfileRepository profileRepository = mock(MarketNicheEnrichmentProfileRepository.class);
   private final OprmMeiAudienceProfileRepository meiAudienceProfileRepository = mock(OprmMeiAudienceProfileRepository.class);
   private final OprmEnrichedNicheMetaSignalService metaSignalService = mock(OprmEnrichedNicheMetaSignalService.class);
+  private final CurrencyConversionService currencyConversionService = mock(CurrencyConversionService.class);
   private final OprmEnrichedNicheMetaSignalService.MetaSignalPackage metaSignalPackage = new OprmEnrichedNicheMetaSignalService.MetaSignalPackage(
       List.of("Salão de beleza"), List.of("Cabeleireiro"), List.of("Small business owners"));
   private final BackendEnrichedNicheMaterializerService service = new BackendEnrichedNicheMaterializerService(
       cycleRepository, cardRepository, candidateRepository, seedRepository, researchQueryRepository, sourceCandidateRepository,
-      sourceSnapshotRepository, extractedSignalRepository, marketNicheRepository, profileRepository, meiAudienceProfileRepository, metaSignalService);
+      sourceSnapshotRepository, extractedSignalRepository, marketNicheRepository, profileRepository, meiAudienceProfileRepository, metaSignalService,
+      currencyConversionService);
 
   /** Deve publicar uma unidade de trabalho completa para o coletor materializar o nicho enriquecido. */
   @Test
@@ -98,6 +101,8 @@ class BackendEnrichedNicheMaterializerServiceTest {
     when(candidateRepository.findById(77L)).thenReturn(Optional.of(candidate));
     when(meiAudienceProfileRepository.findFirstByResearchCycleIdOrderByIdDesc(1001L)).thenReturn(Optional.of(meiProfile()));
     when(metaSignalService.buildSignalPackage(cycle, card)).thenReturn(metaSignalPackage);
+    when(seedRepository.sumCostUsdByResearchCycleId(1001L)).thenReturn(new BigDecimal("0.0473"));
+    when(currencyConversionService.usdToBrl(new BigDecimal("0.0473"))).thenReturn(new BigDecimal("0.24"));
     when(marketNicheRepository.save(any(MarketNiche.class))).thenAnswer(invocation -> {
       MarketNiche niche = invocation.getArgument(0);
       niche.setId(200L);
@@ -120,6 +125,8 @@ class BackendEnrichedNicheMaterializerServiceTest {
         "Salões pequenos".equals(niche.getName())
             && niche.getPromises() == null
             && niche.getOffers() == null
+            && new BigDecimal("0.24").compareTo(niche.getCost()) == 0
+            && new BigDecimal("0.24").compareTo(niche.getTotalCost()) == 0
             && niche.getDescription().contains("Nome original recebido para auditoria: IA para salões pequenos")
             && niche.getDescription().contains("Nome neutro pesquisado: Salões pequenos")
             && niche.getDescription().contains("Contexto operacional e linguagem pública:")

--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -756,3 +756,9 @@
 - Correção aplicada: criado endpoint backend para listar nichos enriquecidos por CNAE; o frontend passou a exibir essa lista com ação de abertura do nicho e botão único para gerar um novo nicho, mostrando as etapas do pipeline apenas após esse comando.
 
 - 2026-06-15 00:00:00 (UTC-3): ajustado o fluxo administrativo CNAE → subnicho no frontend: a lista de CNAEs leva para uma tela com todos os subnichos do CNAE, o comando principal passou a criar novo subnicho com potencial de venda e, após o disparo, a navegação abre uma visão dedicada ao ciclo criado com etapas, custo e jobs restritos ao novo subnicho.
+
+## 2026-06-15 — OPRM NichoCNAE: custo de identificação no nicho materializado
+
+- Causa-raiz tratada: a etapa final `oprmEnrichedNicheMaterializer` copiava rotina, segmentação e evidências para `market_niche`, mas não transferia o custo de identificação registrado em `oprm_niche_research_seed.cost_usd`; por isso o nicho materializado ficava com custo inicial zerado/nulo mesmo após gastar IA para identificar o subnicho.
+- Correção aplicada: a materialização final agora soma o custo USD do seed do ciclo, converte para BRL pelo serviço canônico de moeda e preenche `market_niche.cost` e `market_niche.totalCost` quando ainda estiverem vazios/zerados, sem duplicar custo em reprocessamentos.
+- Prevenção de recorrência: adicionado teste de regressão na etapa final e changelog de backfill para corrigir nichos OPRM já materializados sem custo de identificação.


### PR DESCRIPTION
### Motivation
- The final materialization stage did not propagate the identification cost recorded in `oprm_niche_research_seed.cost_usd` to `market_niche`, leaving newly created niches with zero/null initial cost.
- Existing materialized niches therefore lacked the identification expense and reprocessings could duplicate or lose cost information.

### Description
- Injected `CurrencyConversionService` into `BackendEnrichedNicheMaterializerService` and added `applyIdentificationCostToMarketNiche` to convert seed USD sum to BRL and set `marketNiche.cost` and `marketNiche.totalCost` when those fields are empty or zero, and invoked it from `complete`.
- Added `BigDecimal` usage and defensive null/zero checks to avoid overwriting existing costs or duplicating on reprocess.
- Added a Liquibase changeset `2026-06-15-oprm-enriched-niche-identification-cost.yaml` and included it in `db.changelog-master.yaml` to backfill `market_niche.cost` and `market_niche.total_cost` from summed `oprm_niche_research_seed.cost_usd` converted to BRL.
- Updated documentation `docs/registros/oprm1.md` to record the change and rationale.

### Testing
- Updated and ran `BackendEnrichedNicheMaterializerServiceTest`, including `shouldCompleteMaterializationCreatingNicheAndProfile` which now mocks `seedRepository.sumCostUsdByResearchCycleId` and `CurrencyConversionService.usdToBrl`, and the test passed.
- Ran `shouldListPendingMaterializationWithClosedPayload` and related unit tests in `BackendEnrichedNicheMaterializerServiceTest`, and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a30618be8308321bed6ebc25bc325c6)