### PR TITLE
Introduce OPRM currency converter and wire seed cost into niche materialization

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/enrichednichematerializer/service/BackendEnrichedNicheMaterializerService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/enrichednichematerializer/service/BackendEnrichedNicheMaterializerService.java
@@ -1,6 +1,5 @@
 package com.marketinghub.oprm.nichocnae.enrichednichematerializer.service;
 
-import com.marketinghub.finance.CurrencyConversionService;
 import com.marketinghub.niche.MarketNiche;
 import com.marketinghub.niche.MarketNicheEnrichmentProfile;
 import com.marketinghub.oprm.cnae.OprmNicheCandidate;
@@ -72,7 +71,7 @@ public class BackendEnrichedNicheMaterializerService {
   private final MarketNicheEnrichmentProfileRepository enrichmentProfileRepository;
   private final OprmMeiAudienceProfileRepository meiAudienceProfileRepository;
   private final OprmEnrichedNicheMetaSignalService metaSignalService;
-  private final CurrencyConversionService currencyConversionService;
+  private final OprmCurrencyConversionService currencyConversionService;
 
   /** Inicializa o serviço com os repositórios oficiais do backend usados pela etapa final. */
   public BackendEnrichedNicheMaterializerService(
@@ -88,7 +87,7 @@ public class BackendEnrichedNicheMaterializerService {
       MarketNicheEnrichmentProfileRepository enrichmentProfileRepository,
       OprmMeiAudienceProfileRepository meiAudienceProfileRepository,
       OprmEnrichedNicheMetaSignalService metaSignalService,
-      CurrencyConversionService currencyConversionService) {
+      OprmCurrencyConversionService currencyConversionService) {
     this.cycleRepository = cycleRepository;
     this.routineCardRepository = routineCardRepository;
     this.nicheCandidateRepository = nicheCandidateRepository;

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/enrichednichematerializer/service/OprmCurrencyConversionService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/enrichednichematerializer/service/OprmCurrencyConversionService.java
@@ -1,0 +1,41 @@
+package com.marketinghub.oprm.nichocnae.enrichednichematerializer.service;
+
+import java.math.BigDecimal;
+import java.math.RoundingMode;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+
+/** Serviço OPRM responsável por converter custos operacionais em dólar para real sem acoplar o módulo financeiro. */
+@Service
+public class OprmCurrencyConversionService {
+  private final BigDecimal usdToBrlRate;
+
+  /** Inicializa o conversor com a cotação configurada para custos de identificação do OPRM. */
+  public OprmCurrencyConversionService(@Value("${app.currency.usd-to-brl:5.0}") BigDecimal usdToBrlRate) {
+    this.usdToBrlRate = usdToBrlRate;
+  }
+
+  /** Converte um valor em dólar para real mantendo o arredondamento financeiro usado pelo backend. */
+  public BigDecimal usdToBrl(BigDecimal usdAmount) {
+    if (usdAmount == null) {
+      return null;
+    }
+    if (usdAmount.compareTo(BigDecimal.ZERO) == 0) {
+      return BigDecimal.ZERO.setScale(2, RoundingMode.HALF_UP);
+    }
+    BigDecimal effectiveRate = effectiveUsdToBrlRate();
+    BigDecimal converted = usdAmount.multiply(effectiveRate).setScale(2, RoundingMode.HALF_UP);
+    if (converted.compareTo(BigDecimal.ZERO) == 0 && usdAmount.compareTo(BigDecimal.ZERO) > 0) {
+      return new BigDecimal("0.01");
+    }
+    return converted;
+  }
+
+  /** Retorna a cotação configurada ou uma cotação neutra quando a configuração estiver inválida. */
+  private BigDecimal effectiveUsdToBrlRate() {
+    if (usdToBrlRate == null || usdToBrlRate.compareTo(BigDecimal.ZERO) <= 0) {
+      return BigDecimal.ONE;
+    }
+    return usdToBrlRate;
+  }
+}

--- a/backend/ads-service/src/test/java/com/marketinghub/oprm/nichocnae/enrichednichematerializer/service/BackendEnrichedNicheMaterializerServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/oprm/nichocnae/enrichednichematerializer/service/BackendEnrichedNicheMaterializerServiceTest.java
@@ -8,7 +8,6 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.marketinghub.finance.CurrencyConversionService;
 import com.marketinghub.niche.MarketNiche;
 import com.marketinghub.niche.MarketNicheEnrichmentProfile;
 import com.marketinghub.oprm.cnae.OprmNicheCandidate;
@@ -55,7 +54,7 @@ class BackendEnrichedNicheMaterializerServiceTest {
   private final MarketNicheEnrichmentProfileRepository profileRepository = mock(MarketNicheEnrichmentProfileRepository.class);
   private final OprmMeiAudienceProfileRepository meiAudienceProfileRepository = mock(OprmMeiAudienceProfileRepository.class);
   private final OprmEnrichedNicheMetaSignalService metaSignalService = mock(OprmEnrichedNicheMetaSignalService.class);
-  private final CurrencyConversionService currencyConversionService = mock(CurrencyConversionService.class);
+  private final OprmCurrencyConversionService currencyConversionService = mock(OprmCurrencyConversionService.class);
   private final OprmEnrichedNicheMetaSignalService.MetaSignalPackage metaSignalPackage = new OprmEnrichedNicheMetaSignalService.MetaSignalPackage(
       List.of("Salão de beleza"), List.of("Cabeleireiro"), List.of("Small business owners"));
   private final BackendEnrichedNicheMaterializerService service = new BackendEnrichedNicheMaterializerService(

--- a/backend/ads-service/src/test/java/com/marketinghub/oprm/nichocnae/enrichednichematerializer/service/OprmCurrencyConversionServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/oprm/nichocnae/enrichednichematerializer/service/OprmCurrencyConversionServiceTest.java
@@ -1,0 +1,40 @@
+package com.marketinghub.oprm.nichocnae.enrichednichematerializer.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.math.BigDecimal;
+import org.junit.jupiter.api.Test;
+
+/** Responsabilidade: validar a conversão monetária local do OPRM sem dependência do módulo financeiro. */
+class OprmCurrencyConversionServiceTest {
+
+  /** Deve converter dólares para reais usando a cotação configurada e arredondamento financeiro. */
+  @Test
+  void shouldConvertUsdToBrlUsingConfiguredRate() {
+    OprmCurrencyConversionService service = new OprmCurrencyConversionService(new BigDecimal("5.0"));
+
+    BigDecimal converted = service.usdToBrl(new BigDecimal("0.0473"));
+
+    assertThat(converted).isEqualByComparingTo(new BigDecimal("0.24"));
+  }
+
+  /** Deve preservar um centavo mínimo quando custo positivo arredondaria para zero. */
+  @Test
+  void shouldPreserveMinimumCentForPositiveCost() {
+    OprmCurrencyConversionService service = new OprmCurrencyConversionService(new BigDecimal("5.0"));
+
+    BigDecimal converted = service.usdToBrl(new BigDecimal("0.0001"));
+
+    assertThat(converted).isEqualByComparingTo(new BigDecimal("0.01"));
+  }
+
+  /** Deve usar cotação neutra quando a configuração recebida for inválida. */
+  @Test
+  void shouldUseNeutralRateWhenConfiguredRateIsInvalid() {
+    OprmCurrencyConversionService service = new OprmCurrencyConversionService(BigDecimal.ZERO);
+
+    BigDecimal converted = service.usdToBrl(new BigDecimal("2.345"));
+
+    assertThat(converted).isEqualByComparingTo(new BigDecimal("2.35"));
+  }
+}

--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -767,3 +767,9 @@
 - Causa-raiz tratada: a etapa final `oprmEnrichedNicheMaterializer` copiava rotina, segmentação e evidências para `market_niche`, mas não transferia o custo de identificação registrado em `oprm_niche_research_seed.cost_usd`; por isso o nicho materializado ficava com custo inicial zerado/nulo mesmo após gastar IA para identificar o subnicho.
 - Correção aplicada: a materialização final agora soma o custo USD do seed do ciclo, converte para BRL pelo serviço canônico de moeda e preenche `market_niche.cost` e `market_niche.totalCost` quando ainda estiverem vazios/zerados, sem duplicar custo em reprocessamentos.
 - Prevenção de recorrência: adicionado teste de regressão na etapa final e changelog de backfill para corrigir nichos OPRM já materializados sem custo de identificação.
+
+## 2026-06-15 — OPRM NichoCNAE: isolamento arquitetural da conversão de moeda
+
+- Causa-raiz tratada: o materializador enriquecido do OPRM dependia diretamente de `com.marketinghub.finance.CurrencyConversionService`, quebrando a regra ArchUnit de isolamento do módulo OPRM.
+- Correção aplicada: criado conversor próprio dentro do pacote OPRM para custos de identificação, preservando a mesma configuração `app.currency.usd-to-brl` e o mesmo arredondamento financeiro sem acoplar o materializador ao pacote financeiro.
+- Prevenção de recorrência: a suíte ArchUnit foi executada junto com o teste do materializador para garantir que o OPRM permaneça dependente apenas dos pacotes autorizados.


### PR DESCRIPTION
### Motivation
- Ensure the final materialization step copies the seed identification cost into `market_niche.cost`/`market_niche.totalCost` so materialized niches do not lose identification expenses.
- Remove the direct dependency on `com.marketinghub.finance.CurrencyConversionService` to respect OPRM module isolation rules enforced by ArchUnit.
- Preserve existing configuration and financial rounding behaviour for USD→BRL conversion while avoiding coupling to the finance package.

### Description
- Added `OprmCurrencyConversionService` with `usdToBrl(BigDecimal)` using a configurable `app.currency.usd-to-brl` rate, `RoundingMode.HALF_UP` to 2 decimals, a neutral fallback rate, and a minimum positive cent guard returning `0.01` when rounding would produce `0.00` for a positive USD amount.
- Replaced the injected `CurrencyConversionService` with `OprmCurrencyConversionService` in `BackendEnrichedNicheMaterializerService` and updated the constructor and test mocks accordingly.
- Added `OprmCurrencyConversionServiceTest` to cover normal conversion, minimum-cent preservation, and neutral-rate behaviour.
- Updated `docs/registros/oprm1.md` with changelog entries describing the cost transfer fix and the architectural isolation of the currency converter.

### Testing
- Ran `BackendEnrichedNicheMaterializerServiceTest` and it passed.
- Ran `OprmCurrencyConversionServiceTest` and it passed.
- Executed the ArchUnit checks together with the module test suite to confirm the OPRM package no longer depends on the finance package, and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a30681369248321acae61d3235d7acd)