### PR TITLE
hypothesis-offer: enforce low-ticket offer schema and validator

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/pipeline/hypothesismechanism/HypothesisMechanismBackendClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/pipeline/hypothesismechanism/HypothesisMechanismBackendClient.java
@@ -133,6 +133,7 @@ public class HypothesisMechanismBackendClient implements StageBackendPort<Hypoth
     /** Monta os dados do prompt com as informações do nicho e contexto comercial disponível. */
     Map<String, Object> buildPromptDataFromPending(Map<String, Object> pending) {
         Map<String, Object> niche = asMap(pending.get("niche"));
+        Map<String, Object> enrichmentProfile = asMap(pending.get("enrichmentProfile"));
         Map<String, Object> payload = new LinkedHashMap<>();
         payload.put("marketNicheId", pending.get("marketNicheId"));
         payload.put("nicheName", optionalText(niche.get("name")));
@@ -144,10 +145,29 @@ public class HypothesisMechanismBackendClient implements StageBackendPort<Hypoth
         payload.put("interests", optionalText(niche.get("interests")));
         payload.put("demographicFilters", optionalText(niche.get("demographicFilters")));
         payload.put("extraTips", optionalText(niche.get("extraTips")));
+        putEnrichedNicheContext(payload, enrichmentProfile);
         payload.put("painModelResponse", optionalText(pending.get("painModelResponse")));
         payload.put("resultModelResponse", optionalText(pending.get("resultModelResponse")));
         payload.put("CASE_DATA_BLOCK", buildCaseDataBlock(payload));
         return payload;
+    }
+
+    /** Copia o perfil enriquecido do OPRM para o contexto estratégico consumido pela etapa. */
+    private void putEnrichedNicheContext(Map<String, Object> payload, Map<String, Object> enrichmentProfile) {
+        payload.put("enrichedRoutineSummary", optionalText(enrichmentProfile.get("routineSummary")));
+        payload.put("enrichedPainsSummary", optionalText(enrichmentProfile.get("painsSummary")));
+        payload.put("enrichedResultsSummary", optionalText(enrichmentProfile.get("resultsSummary")));
+        payload.put("enrichedMechanismOpportunitiesSummary", optionalText(enrichmentProfile.get("mechanismOpportunitiesSummary")));
+        payload.put("enrichedEvidenceSummary", optionalText(enrichmentProfile.get("evidenceSummary")));
+        payload.put("enrichedSourceDomains", optionalText(enrichmentProfile.get("sourceDomains")));
+        payload.put("enrichedPersonaSummary", optionalText(enrichmentProfile.get("personaSummary")));
+        payload.put("enrichedLanguagePatterns", optionalText(enrichmentProfile.get("languagePatterns")));
+        payload.put("enrichedCommercialTriggers", optionalText(enrichmentProfile.get("commercialTriggers")));
+        payload.put("enrichedObjections", optionalText(enrichmentProfile.get("objections")));
+        payload.put("enrichedQualityStatus", optionalText(enrichmentProfile.get("qualityStatus")));
+        payload.put("enrichedConfidenceScore", optionalText(enrichmentProfile.get("confidenceScore")));
+        payload.put("enrichedDifficultyEvidenceScore", optionalText(enrichmentProfile.get("difficultyEvidenceScore")));
+        payload.put("enrichedSourceDiversityScore", optionalText(enrichmentProfile.get("sourceDiversityScore")));
     }
 
     /** Normaliza campos textuais opcionais do nicho para evitar nulos no contexto do prompt. */
@@ -168,10 +188,29 @@ public class HypothesisMechanismBackendClient implements StageBackendPort<Hypoth
         appendCaseData(builder, "interests", payload.get("interests"));
         appendCaseData(builder, "demographicFilters", payload.get("demographicFilters"));
         appendCaseData(builder, "extraTips", payload.get("extraTips"));
+        appendEnrichedNicheContext(builder, payload);
         appendCaseData(builder, "painModelResponse", payload.get("painModelResponse"));
         appendCaseData(builder, "resultModelResponse", payload.get("resultModelResponse"));
         builder.append("[CASE_DATA_END]");
         return builder.toString();
+    }
+
+    /** Acrescenta o contexto enriquecido do nicho sem misturar oferta pronta no insumo de hipótese. */
+    private void appendEnrichedNicheContext(StringBuilder builder, Map<String, Object> payload) {
+        appendCaseData(builder, "enrichedRoutineSummary", payload.get("enrichedRoutineSummary"));
+        appendCaseData(builder, "enrichedPainsSummary", payload.get("enrichedPainsSummary"));
+        appendCaseData(builder, "enrichedResultsSummary", payload.get("enrichedResultsSummary"));
+        appendCaseData(builder, "enrichedMechanismOpportunitiesSummary", payload.get("enrichedMechanismOpportunitiesSummary"));
+        appendCaseData(builder, "enrichedEvidenceSummary", payload.get("enrichedEvidenceSummary"));
+        appendCaseData(builder, "enrichedSourceDomains", payload.get("enrichedSourceDomains"));
+        appendCaseData(builder, "enrichedPersonaSummary", payload.get("enrichedPersonaSummary"));
+        appendCaseData(builder, "enrichedLanguagePatterns", payload.get("enrichedLanguagePatterns"));
+        appendCaseData(builder, "enrichedCommercialTriggers", payload.get("enrichedCommercialTriggers"));
+        appendCaseData(builder, "enrichedObjections", payload.get("enrichedObjections"));
+        appendCaseData(builder, "enrichedQualityStatus", payload.get("enrichedQualityStatus"));
+        appendCaseData(builder, "enrichedConfidenceScore", payload.get("enrichedConfidenceScore"));
+        appendCaseData(builder, "enrichedDifficultyEvidenceScore", payload.get("enrichedDifficultyEvidenceScore"));
+        appendCaseData(builder, "enrichedSourceDiversityScore", payload.get("enrichedSourceDiversityScore"));
     }
 
     /** Acrescenta uma chave do contexto no bloco CASE_DATA com renderização segura. */

--- a/ai-worker/src/main/java/com/marketinghub/worker/pipeline/hypothesisoffer/HypothesisOfferBackendClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/pipeline/hypothesisoffer/HypothesisOfferBackendClient.java
@@ -133,6 +133,7 @@ public class HypothesisOfferBackendClient implements StageBackendPort<Hypothesis
     /** Monta os dados do prompt com as informações do nicho e contexto comercial disponível. */
     Map<String, Object> buildPromptDataFromPending(Map<String, Object> pending) {
         Map<String, Object> niche = asMap(pending.get("niche"));
+        Map<String, Object> enrichmentProfile = asMap(pending.get("enrichmentProfile"));
         Map<String, Object> payload = new LinkedHashMap<>();
         payload.put("marketNicheId", pending.get("marketNicheId"));
         payload.put("nicheName", optionalText(niche.get("name")));
@@ -144,12 +145,31 @@ public class HypothesisOfferBackendClient implements StageBackendPort<Hypothesis
         payload.put("interests", optionalText(niche.get("interests")));
         payload.put("demographicFilters", optionalText(niche.get("demographicFilters")));
         payload.put("extraTips", optionalText(niche.get("extraTips")));
+        putEnrichedNicheContext(payload, enrichmentProfile);
         payload.put("painModelResponse", optionalText(pending.get("painModelResponse")));
         payload.put("resultModelResponse", optionalText(pending.get("resultModelResponse")));
         payload.put("mechanismModelResponse", optionalText(pending.get("mechanismModelResponse")));
         payload.put("proofModelResponse", optionalText(pending.get("proofModelResponse")));
         payload.put("CASE_DATA_BLOCK", buildCaseDataBlock(payload));
         return payload;
+    }
+
+    /** Copia o perfil enriquecido do OPRM para o contexto estratégico consumido pela etapa. */
+    private void putEnrichedNicheContext(Map<String, Object> payload, Map<String, Object> enrichmentProfile) {
+        payload.put("enrichedRoutineSummary", optionalText(enrichmentProfile.get("routineSummary")));
+        payload.put("enrichedPainsSummary", optionalText(enrichmentProfile.get("painsSummary")));
+        payload.put("enrichedResultsSummary", optionalText(enrichmentProfile.get("resultsSummary")));
+        payload.put("enrichedMechanismOpportunitiesSummary", optionalText(enrichmentProfile.get("mechanismOpportunitiesSummary")));
+        payload.put("enrichedEvidenceSummary", optionalText(enrichmentProfile.get("evidenceSummary")));
+        payload.put("enrichedSourceDomains", optionalText(enrichmentProfile.get("sourceDomains")));
+        payload.put("enrichedPersonaSummary", optionalText(enrichmentProfile.get("personaSummary")));
+        payload.put("enrichedLanguagePatterns", optionalText(enrichmentProfile.get("languagePatterns")));
+        payload.put("enrichedCommercialTriggers", optionalText(enrichmentProfile.get("commercialTriggers")));
+        payload.put("enrichedObjections", optionalText(enrichmentProfile.get("objections")));
+        payload.put("enrichedQualityStatus", optionalText(enrichmentProfile.get("qualityStatus")));
+        payload.put("enrichedConfidenceScore", optionalText(enrichmentProfile.get("confidenceScore")));
+        payload.put("enrichedDifficultyEvidenceScore", optionalText(enrichmentProfile.get("difficultyEvidenceScore")));
+        payload.put("enrichedSourceDiversityScore", optionalText(enrichmentProfile.get("sourceDiversityScore")));
     }
 
     /** Normaliza campos textuais opcionais do nicho para evitar nulos no contexto do prompt. */
@@ -170,12 +190,31 @@ public class HypothesisOfferBackendClient implements StageBackendPort<Hypothesis
         appendCaseData(builder, "interests", payload.get("interests"));
         appendCaseData(builder, "demographicFilters", payload.get("demographicFilters"));
         appendCaseData(builder, "extraTips", payload.get("extraTips"));
+        appendEnrichedNicheContext(builder, payload);
         appendCaseData(builder, "painModelResponse", payload.get("painModelResponse"));
         appendCaseData(builder, "resultModelResponse", payload.get("resultModelResponse"));
         appendCaseData(builder, "mechanismModelResponse", payload.get("mechanismModelResponse"));
         appendCaseData(builder, "proofModelResponse", payload.get("proofModelResponse"));
         builder.append("[CASE_DATA_END]");
         return builder.toString();
+    }
+
+    /** Acrescenta o contexto enriquecido do nicho sem misturar oferta pronta no insumo de hipótese. */
+    private void appendEnrichedNicheContext(StringBuilder builder, Map<String, Object> payload) {
+        appendCaseData(builder, "enrichedRoutineSummary", payload.get("enrichedRoutineSummary"));
+        appendCaseData(builder, "enrichedPainsSummary", payload.get("enrichedPainsSummary"));
+        appendCaseData(builder, "enrichedResultsSummary", payload.get("enrichedResultsSummary"));
+        appendCaseData(builder, "enrichedMechanismOpportunitiesSummary", payload.get("enrichedMechanismOpportunitiesSummary"));
+        appendCaseData(builder, "enrichedEvidenceSummary", payload.get("enrichedEvidenceSummary"));
+        appendCaseData(builder, "enrichedSourceDomains", payload.get("enrichedSourceDomains"));
+        appendCaseData(builder, "enrichedPersonaSummary", payload.get("enrichedPersonaSummary"));
+        appendCaseData(builder, "enrichedLanguagePatterns", payload.get("enrichedLanguagePatterns"));
+        appendCaseData(builder, "enrichedCommercialTriggers", payload.get("enrichedCommercialTriggers"));
+        appendCaseData(builder, "enrichedObjections", payload.get("enrichedObjections"));
+        appendCaseData(builder, "enrichedQualityStatus", payload.get("enrichedQualityStatus"));
+        appendCaseData(builder, "enrichedConfidenceScore", payload.get("enrichedConfidenceScore"));
+        appendCaseData(builder, "enrichedDifficultyEvidenceScore", payload.get("enrichedDifficultyEvidenceScore"));
+        appendCaseData(builder, "enrichedSourceDiversityScore", payload.get("enrichedSourceDiversityScore"));
     }
 
     /** Acrescenta uma chave do contexto no bloco CASE_DATA com renderização segura. */

--- a/ai-worker/src/main/java/com/marketinghub/worker/pipeline/hypothesisoffer/HypothesisOfferOutput.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/pipeline/hypothesisoffer/HypothesisOfferOutput.java
@@ -5,18 +5,29 @@ import java.util.List;
 /** Responsabilidade: representar a saída estruturada da etapa Oferta validada pelo schema da OpenAI. */
 public record HypothesisOfferOutput(
         String offerName,
+        String offerPositioning,
+        String entryPromise,
+        String pricePositioning,
         String coreOffer,
         String howItWorks,
+        List<String> deliverables,
+        List<String> valueStack,
+        String valuePerception,
+        String quickWinAsset,
+        String productionFormat,
         List<String> steps,
         String aiLeverage,
         String effortReduction,
         String whyBelievable,
         String boundaryConditions,
+        String nextStageReadiness,
         String summary,
         List<String> evidenceSignals
 ) {
     /** Normaliza listas opcionais para evitar nulos no payload final da etapa. */
     public HypothesisOfferOutput {
+        deliverables = deliverables == null ? List.of() : List.copyOf(deliverables);
+        valueStack = valueStack == null ? List.of() : List.copyOf(valueStack);
         steps = steps == null ? List.of() : List.copyOf(steps);
         evidenceSignals = evidenceSignals == null ? List.of() : List.copyOf(evidenceSignals);
     }

--- a/ai-worker/src/main/java/com/marketinghub/worker/pipeline/hypothesisoffer/HypothesisOfferResponseValidator.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/pipeline/hypothesisoffer/HypothesisOfferResponseValidator.java
@@ -20,9 +20,18 @@ public class HypothesisOfferResponseValidator {
         try {
             HypothesisOfferOutput output = objectMapper.readValue(modelResponse, HypothesisOfferOutput.class);
             requireText(output.offerName(), "offerName");
+            requireText(output.offerPositioning(), "offerPositioning");
+            requireText(output.entryPromise(), "entryPromise");
+            requireText(output.pricePositioning(), "pricePositioning");
             requireText(output.coreOffer(), "coreOffer");
             requireText(output.howItWorks(), "howItWorks");
+            requireText(output.valuePerception(), "valuePerception");
+            requireText(output.quickWinAsset(), "quickWinAsset");
+            requireText(output.productionFormat(), "productionFormat");
+            requireText(output.nextStageReadiness(), "nextStageReadiness");
             requireText(output.summary(), "summary");
+            requireNonEmpty(output.deliverables(), "deliverables");
+            requireNonEmpty(output.valueStack(), "valueStack");
             requireNonEmpty(output.steps(), "steps");
             return output;
         } catch (Exception ex) {

--- a/ai-worker/src/main/java/com/marketinghub/worker/pipeline/hypothesispain/HypothesisPainBackendClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/pipeline/hypothesispain/HypothesisPainBackendClient.java
@@ -132,6 +132,7 @@ public class HypothesisPainBackendClient implements StageBackendPort<HypothesisP
     /** Monta os dados do prompt com as informações do nicho e contexto comercial disponível. */
     Map<String, Object> buildPromptDataFromPending(Map<String, Object> pending) {
         Map<String, Object> niche = asMap(pending.get("niche"));
+        Map<String, Object> enrichmentProfile = asMap(pending.get("enrichmentProfile"));
         Map<String, Object> payload = new LinkedHashMap<>();
         payload.put("marketNicheId", pending.get("marketNicheId"));
         payload.put("nicheName", optionalText(niche.get("name")));
@@ -143,8 +144,27 @@ public class HypothesisPainBackendClient implements StageBackendPort<HypothesisP
         payload.put("interests", optionalText(niche.get("interests")));
         payload.put("demographicFilters", optionalText(niche.get("demographicFilters")));
         payload.put("extraTips", optionalText(niche.get("extraTips")));
+        putEnrichedNicheContext(payload, enrichmentProfile);
         payload.put("CASE_DATA_BLOCK", buildCaseDataBlock(payload));
         return payload;
+    }
+
+    /** Copia o perfil enriquecido do OPRM para o contexto estratégico consumido pela etapa. */
+    private void putEnrichedNicheContext(Map<String, Object> payload, Map<String, Object> enrichmentProfile) {
+        payload.put("enrichedRoutineSummary", optionalText(enrichmentProfile.get("routineSummary")));
+        payload.put("enrichedPainsSummary", optionalText(enrichmentProfile.get("painsSummary")));
+        payload.put("enrichedResultsSummary", optionalText(enrichmentProfile.get("resultsSummary")));
+        payload.put("enrichedMechanismOpportunitiesSummary", optionalText(enrichmentProfile.get("mechanismOpportunitiesSummary")));
+        payload.put("enrichedEvidenceSummary", optionalText(enrichmentProfile.get("evidenceSummary")));
+        payload.put("enrichedSourceDomains", optionalText(enrichmentProfile.get("sourceDomains")));
+        payload.put("enrichedPersonaSummary", optionalText(enrichmentProfile.get("personaSummary")));
+        payload.put("enrichedLanguagePatterns", optionalText(enrichmentProfile.get("languagePatterns")));
+        payload.put("enrichedCommercialTriggers", optionalText(enrichmentProfile.get("commercialTriggers")));
+        payload.put("enrichedObjections", optionalText(enrichmentProfile.get("objections")));
+        payload.put("enrichedQualityStatus", optionalText(enrichmentProfile.get("qualityStatus")));
+        payload.put("enrichedConfidenceScore", optionalText(enrichmentProfile.get("confidenceScore")));
+        payload.put("enrichedDifficultyEvidenceScore", optionalText(enrichmentProfile.get("difficultyEvidenceScore")));
+        payload.put("enrichedSourceDiversityScore", optionalText(enrichmentProfile.get("sourceDiversityScore")));
     }
 
     /** Normaliza campos textuais opcionais do nicho para evitar nulos no contexto do prompt. */
@@ -165,8 +185,27 @@ public class HypothesisPainBackendClient implements StageBackendPort<HypothesisP
         appendCaseData(builder, "interests", payload.get("interests"));
         appendCaseData(builder, "demographicFilters", payload.get("demographicFilters"));
         appendCaseData(builder, "extraTips", payload.get("extraTips"));
+        appendEnrichedNicheContext(builder, payload);
         builder.append("[CASE_DATA_END]");
         return builder.toString();
+    }
+
+    /** Acrescenta o contexto enriquecido do nicho sem misturar oferta pronta no insumo de hipótese. */
+    private void appendEnrichedNicheContext(StringBuilder builder, Map<String, Object> payload) {
+        appendCaseData(builder, "enrichedRoutineSummary", payload.get("enrichedRoutineSummary"));
+        appendCaseData(builder, "enrichedPainsSummary", payload.get("enrichedPainsSummary"));
+        appendCaseData(builder, "enrichedResultsSummary", payload.get("enrichedResultsSummary"));
+        appendCaseData(builder, "enrichedMechanismOpportunitiesSummary", payload.get("enrichedMechanismOpportunitiesSummary"));
+        appendCaseData(builder, "enrichedEvidenceSummary", payload.get("enrichedEvidenceSummary"));
+        appendCaseData(builder, "enrichedSourceDomains", payload.get("enrichedSourceDomains"));
+        appendCaseData(builder, "enrichedPersonaSummary", payload.get("enrichedPersonaSummary"));
+        appendCaseData(builder, "enrichedLanguagePatterns", payload.get("enrichedLanguagePatterns"));
+        appendCaseData(builder, "enrichedCommercialTriggers", payload.get("enrichedCommercialTriggers"));
+        appendCaseData(builder, "enrichedObjections", payload.get("enrichedObjections"));
+        appendCaseData(builder, "enrichedQualityStatus", payload.get("enrichedQualityStatus"));
+        appendCaseData(builder, "enrichedConfidenceScore", payload.get("enrichedConfidenceScore"));
+        appendCaseData(builder, "enrichedDifficultyEvidenceScore", payload.get("enrichedDifficultyEvidenceScore"));
+        appendCaseData(builder, "enrichedSourceDiversityScore", payload.get("enrichedSourceDiversityScore"));
     }
 
     /** Acrescenta uma chave do contexto no bloco CASE_DATA com renderização segura. */

--- a/ai-worker/src/main/java/com/marketinghub/worker/pipeline/hypothesisproof/HypothesisProofBackendClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/pipeline/hypothesisproof/HypothesisProofBackendClient.java
@@ -133,6 +133,7 @@ public class HypothesisProofBackendClient implements StageBackendPort<Hypothesis
     /** Monta os dados do prompt com as informações do nicho e contexto comercial disponível. */
     Map<String, Object> buildPromptDataFromPending(Map<String, Object> pending) {
         Map<String, Object> niche = asMap(pending.get("niche"));
+        Map<String, Object> enrichmentProfile = asMap(pending.get("enrichmentProfile"));
         Map<String, Object> payload = new LinkedHashMap<>();
         payload.put("marketNicheId", pending.get("marketNicheId"));
         payload.put("nicheName", optionalText(niche.get("name")));
@@ -144,11 +145,30 @@ public class HypothesisProofBackendClient implements StageBackendPort<Hypothesis
         payload.put("interests", optionalText(niche.get("interests")));
         payload.put("demographicFilters", optionalText(niche.get("demographicFilters")));
         payload.put("extraTips", optionalText(niche.get("extraTips")));
+        putEnrichedNicheContext(payload, enrichmentProfile);
         payload.put("painModelResponse", optionalText(pending.get("painModelResponse")));
         payload.put("resultModelResponse", optionalText(pending.get("resultModelResponse")));
         payload.put("mechanismModelResponse", optionalText(pending.get("mechanismModelResponse")));
         payload.put("CASE_DATA_BLOCK", buildCaseDataBlock(payload));
         return payload;
+    }
+
+    /** Copia o perfil enriquecido do OPRM para o contexto estratégico consumido pela etapa. */
+    private void putEnrichedNicheContext(Map<String, Object> payload, Map<String, Object> enrichmentProfile) {
+        payload.put("enrichedRoutineSummary", optionalText(enrichmentProfile.get("routineSummary")));
+        payload.put("enrichedPainsSummary", optionalText(enrichmentProfile.get("painsSummary")));
+        payload.put("enrichedResultsSummary", optionalText(enrichmentProfile.get("resultsSummary")));
+        payload.put("enrichedMechanismOpportunitiesSummary", optionalText(enrichmentProfile.get("mechanismOpportunitiesSummary")));
+        payload.put("enrichedEvidenceSummary", optionalText(enrichmentProfile.get("evidenceSummary")));
+        payload.put("enrichedSourceDomains", optionalText(enrichmentProfile.get("sourceDomains")));
+        payload.put("enrichedPersonaSummary", optionalText(enrichmentProfile.get("personaSummary")));
+        payload.put("enrichedLanguagePatterns", optionalText(enrichmentProfile.get("languagePatterns")));
+        payload.put("enrichedCommercialTriggers", optionalText(enrichmentProfile.get("commercialTriggers")));
+        payload.put("enrichedObjections", optionalText(enrichmentProfile.get("objections")));
+        payload.put("enrichedQualityStatus", optionalText(enrichmentProfile.get("qualityStatus")));
+        payload.put("enrichedConfidenceScore", optionalText(enrichmentProfile.get("confidenceScore")));
+        payload.put("enrichedDifficultyEvidenceScore", optionalText(enrichmentProfile.get("difficultyEvidenceScore")));
+        payload.put("enrichedSourceDiversityScore", optionalText(enrichmentProfile.get("sourceDiversityScore")));
     }
 
     /** Normaliza campos textuais opcionais do nicho para evitar nulos no contexto do prompt. */
@@ -169,11 +189,30 @@ public class HypothesisProofBackendClient implements StageBackendPort<Hypothesis
         appendCaseData(builder, "interests", payload.get("interests"));
         appendCaseData(builder, "demographicFilters", payload.get("demographicFilters"));
         appendCaseData(builder, "extraTips", payload.get("extraTips"));
+        appendEnrichedNicheContext(builder, payload);
         appendCaseData(builder, "painModelResponse", payload.get("painModelResponse"));
         appendCaseData(builder, "resultModelResponse", payload.get("resultModelResponse"));
         appendCaseData(builder, "mechanismModelResponse", payload.get("mechanismModelResponse"));
         builder.append("[CASE_DATA_END]");
         return builder.toString();
+    }
+
+    /** Acrescenta o contexto enriquecido do nicho sem misturar oferta pronta no insumo de hipótese. */
+    private void appendEnrichedNicheContext(StringBuilder builder, Map<String, Object> payload) {
+        appendCaseData(builder, "enrichedRoutineSummary", payload.get("enrichedRoutineSummary"));
+        appendCaseData(builder, "enrichedPainsSummary", payload.get("enrichedPainsSummary"));
+        appendCaseData(builder, "enrichedResultsSummary", payload.get("enrichedResultsSummary"));
+        appendCaseData(builder, "enrichedMechanismOpportunitiesSummary", payload.get("enrichedMechanismOpportunitiesSummary"));
+        appendCaseData(builder, "enrichedEvidenceSummary", payload.get("enrichedEvidenceSummary"));
+        appendCaseData(builder, "enrichedSourceDomains", payload.get("enrichedSourceDomains"));
+        appendCaseData(builder, "enrichedPersonaSummary", payload.get("enrichedPersonaSummary"));
+        appendCaseData(builder, "enrichedLanguagePatterns", payload.get("enrichedLanguagePatterns"));
+        appendCaseData(builder, "enrichedCommercialTriggers", payload.get("enrichedCommercialTriggers"));
+        appendCaseData(builder, "enrichedObjections", payload.get("enrichedObjections"));
+        appendCaseData(builder, "enrichedQualityStatus", payload.get("enrichedQualityStatus"));
+        appendCaseData(builder, "enrichedConfidenceScore", payload.get("enrichedConfidenceScore"));
+        appendCaseData(builder, "enrichedDifficultyEvidenceScore", payload.get("enrichedDifficultyEvidenceScore"));
+        appendCaseData(builder, "enrichedSourceDiversityScore", payload.get("enrichedSourceDiversityScore"));
     }
 
     /** Acrescenta uma chave do contexto no bloco CASE_DATA com renderização segura. */

--- a/ai-worker/src/main/java/com/marketinghub/worker/pipeline/hypothesisresult/HypothesisResultBackendClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/pipeline/hypothesisresult/HypothesisResultBackendClient.java
@@ -132,6 +132,7 @@ public class HypothesisResultBackendClient implements StageBackendPort<Hypothesi
     /** Monta os dados do prompt com as informações do nicho e contexto comercial disponível. */
     Map<String, Object> buildPromptDataFromPending(Map<String, Object> pending) {
         Map<String, Object> niche = asMap(pending.get("niche"));
+        Map<String, Object> enrichmentProfile = asMap(pending.get("enrichmentProfile"));
         Map<String, Object> payload = new LinkedHashMap<>();
         payload.put("marketNicheId", pending.get("marketNicheId"));
         payload.put("nicheName", optionalText(niche.get("name")));
@@ -143,9 +144,28 @@ public class HypothesisResultBackendClient implements StageBackendPort<Hypothesi
         payload.put("interests", optionalText(niche.get("interests")));
         payload.put("demographicFilters", optionalText(niche.get("demographicFilters")));
         payload.put("extraTips", optionalText(niche.get("extraTips")));
+        putEnrichedNicheContext(payload, enrichmentProfile);
         payload.put("painModelResponse", optionalText(pending.get("painModelResponse")));
         payload.put("CASE_DATA_BLOCK", buildCaseDataBlock(payload));
         return payload;
+    }
+
+    /** Copia o perfil enriquecido do OPRM para o contexto estratégico consumido pela etapa. */
+    private void putEnrichedNicheContext(Map<String, Object> payload, Map<String, Object> enrichmentProfile) {
+        payload.put("enrichedRoutineSummary", optionalText(enrichmentProfile.get("routineSummary")));
+        payload.put("enrichedPainsSummary", optionalText(enrichmentProfile.get("painsSummary")));
+        payload.put("enrichedResultsSummary", optionalText(enrichmentProfile.get("resultsSummary")));
+        payload.put("enrichedMechanismOpportunitiesSummary", optionalText(enrichmentProfile.get("mechanismOpportunitiesSummary")));
+        payload.put("enrichedEvidenceSummary", optionalText(enrichmentProfile.get("evidenceSummary")));
+        payload.put("enrichedSourceDomains", optionalText(enrichmentProfile.get("sourceDomains")));
+        payload.put("enrichedPersonaSummary", optionalText(enrichmentProfile.get("personaSummary")));
+        payload.put("enrichedLanguagePatterns", optionalText(enrichmentProfile.get("languagePatterns")));
+        payload.put("enrichedCommercialTriggers", optionalText(enrichmentProfile.get("commercialTriggers")));
+        payload.put("enrichedObjections", optionalText(enrichmentProfile.get("objections")));
+        payload.put("enrichedQualityStatus", optionalText(enrichmentProfile.get("qualityStatus")));
+        payload.put("enrichedConfidenceScore", optionalText(enrichmentProfile.get("confidenceScore")));
+        payload.put("enrichedDifficultyEvidenceScore", optionalText(enrichmentProfile.get("difficultyEvidenceScore")));
+        payload.put("enrichedSourceDiversityScore", optionalText(enrichmentProfile.get("sourceDiversityScore")));
     }
 
     /** Normaliza campos textuais opcionais do nicho para evitar nulos no contexto do prompt. */
@@ -166,9 +186,28 @@ public class HypothesisResultBackendClient implements StageBackendPort<Hypothesi
         appendCaseData(builder, "interests", payload.get("interests"));
         appendCaseData(builder, "demographicFilters", payload.get("demographicFilters"));
         appendCaseData(builder, "extraTips", payload.get("extraTips"));
+        appendEnrichedNicheContext(builder, payload);
         appendCaseData(builder, "painModelResponse", payload.get("painModelResponse"));
         builder.append("[CASE_DATA_END]");
         return builder.toString();
+    }
+
+    /** Acrescenta o contexto enriquecido do nicho sem misturar oferta pronta no insumo de hipótese. */
+    private void appendEnrichedNicheContext(StringBuilder builder, Map<String, Object> payload) {
+        appendCaseData(builder, "enrichedRoutineSummary", payload.get("enrichedRoutineSummary"));
+        appendCaseData(builder, "enrichedPainsSummary", payload.get("enrichedPainsSummary"));
+        appendCaseData(builder, "enrichedResultsSummary", payload.get("enrichedResultsSummary"));
+        appendCaseData(builder, "enrichedMechanismOpportunitiesSummary", payload.get("enrichedMechanismOpportunitiesSummary"));
+        appendCaseData(builder, "enrichedEvidenceSummary", payload.get("enrichedEvidenceSummary"));
+        appendCaseData(builder, "enrichedSourceDomains", payload.get("enrichedSourceDomains"));
+        appendCaseData(builder, "enrichedPersonaSummary", payload.get("enrichedPersonaSummary"));
+        appendCaseData(builder, "enrichedLanguagePatterns", payload.get("enrichedLanguagePatterns"));
+        appendCaseData(builder, "enrichedCommercialTriggers", payload.get("enrichedCommercialTriggers"));
+        appendCaseData(builder, "enrichedObjections", payload.get("enrichedObjections"));
+        appendCaseData(builder, "enrichedQualityStatus", payload.get("enrichedQualityStatus"));
+        appendCaseData(builder, "enrichedConfidenceScore", payload.get("enrichedConfidenceScore"));
+        appendCaseData(builder, "enrichedDifficultyEvidenceScore", payload.get("enrichedDifficultyEvidenceScore"));
+        appendCaseData(builder, "enrichedSourceDiversityScore", payload.get("enrichedSourceDiversityScore"));
     }
 
     /** Acrescenta uma chave do contexto no bloco CASE_DATA com renderização segura. */

--- a/ai-worker/src/main/resources/prompts/hypothesis-pipeline/hypothesis-mechanism.md
+++ b/ai-worker/src/main/resources/prompts/hypothesis-pipeline/hypothesis-mechanism.md
@@ -12,6 +12,7 @@ Regras obrigatórias:
 - O mecanismo precisa ser compatível com produto digital apoiado por IA, mas sem depender de acesso direto ao sistema interno do cliente.
 - Não crie prova, preço, bônus, checkout ou oferta final nesta etapa.
 - Não use markdown dentro dos campos.
+- Quando o contexto trouxer campos `enriched*`, trate-os como ponte oficial do pipeline nicho-cnae: use rotina, linguagem, evidências, gatilhos e objeções observadas sem transformá-los em promessa ou oferta prematura.
 
 Critérios de qualidade:
 - Explique o mecanismo em linguagem simples, comercial e operacional.

--- a/ai-worker/src/main/resources/prompts/hypothesis-pipeline/hypothesis-offer-schema.json
+++ b/ai-worker/src/main/resources/prompts/hypothesis-pipeline/hypothesis-offer-schema.json
@@ -3,20 +3,47 @@
   "additionalProperties": false,
   "required": [
     "offerName",
+    "offerPositioning",
+    "entryPromise",
+    "pricePositioning",
     "coreOffer",
     "howItWorks",
+    "deliverables",
+    "valueStack",
+    "valuePerception",
+    "quickWinAsset",
+    "productionFormat",
     "steps",
     "aiLeverage",
     "effortReduction",
     "whyBelievable",
     "boundaryConditions",
+    "nextStageReadiness",
     "summary",
     "evidenceSignals"
   ],
   "properties": {
     "offerName": { "type": "string", "minLength": 5, "maxLength": 120 },
+    "offerPositioning": { "type": "string", "minLength": 10, "maxLength": 400 },
+    "entryPromise": { "type": "string", "minLength": 10, "maxLength": 300 },
+    "pricePositioning": { "type": "string", "minLength": 5, "maxLength": 220 },
     "coreOffer": { "type": "string", "minLength": 10 },
     "howItWorks": { "type": "string", "minLength": 10 },
+    "deliverables": {
+      "type": "array",
+      "minItems": 5,
+      "maxItems": 10,
+      "items": { "type": "string", "minLength": 10, "maxLength": 300 }
+    },
+    "valueStack": {
+      "type": "array",
+      "minItems": 6,
+      "maxItems": 12,
+      "items": { "type": "string", "minLength": 10, "maxLength": 260 }
+    },
+    "valuePerception": { "type": "string", "minLength": 10, "maxLength": 500 },
+    "quickWinAsset": { "type": "string", "minLength": 10, "maxLength": 300 },
+    "productionFormat": { "type": "string", "minLength": 10, "maxLength": 300 },
     "steps": {
       "type": "array",
       "minItems": 3,
@@ -27,6 +54,7 @@
     "effortReduction": { "type": "string", "minLength": 10 },
     "whyBelievable": { "type": "string", "minLength": 10 },
     "boundaryConditions": { "type": "string", "minLength": 10 },
+    "nextStageReadiness": { "type": "string", "minLength": 10, "maxLength": 500 },
     "summary": { "type": "string", "minLength": 10, "maxLength": 500 },
     "evidenceSignals": {
       "type": "array",

--- a/ai-worker/src/main/resources/prompts/hypothesis-pipeline/hypothesis-offer.md
+++ b/ai-worker/src/main/resources/prompts/hypothesis-pipeline/hypothesis-offer.md
@@ -2,23 +2,34 @@
 
 template_id: hypothesis-offer
 
-Objetivo: transformar Dor, Resultado, Mecanismo e Prova concluídos em uma oferta digital simples, plausível e vendável para o nicho.
+Objetivo: transformar Dor, Resultado, Mecanismo e Prova concluídos em uma oferta low-ticket digital, simples, plausível, comprável por impulso e pronta para alimentar a próxima etapa de página de vendas, isca digital e campanha.
 
 Regras obrigatórias:
 - Responda SOMENTE no JSON do schema.
 - Use a dor, o resultado, o mecanismo e a prova concluídos como base principal; não invente uma nova dor, promessa, mecanismo ou evidência.
+- A oferta precisa ser um produto digital low-ticket: específico, barato o suficiente para compra de baixo atrito e útil rapidamente.
+- A oferta precisa ser percebida como um pacote de alto valor por preço baixo: muitos itens úteis, complementares e aplicáveis, sem inflar com bônus irrelevantes.
 - A oferta precisa deixar claro o que o cliente recebe, por que isso reduz esforço e como aproxima o resultado desejado.
+- Defina uma faixa de preço sugerida ou ancoragem de preço compatível com low-ticket; não crie checkout, cupom, parcelamento ou condição comercial final.
+- A oferta deve conter entregáveis concretos que possam ser produzidos pelo Marketing Hub depois: diagnóstico, roteiro, checklist, template, biblioteca, calculadora simples, prompts, plano ou mini-kit.
+- Monte uma pilha de valor clara, mostrando vários componentes que atacam a mesma dor por ângulos diferentes e fazem o comprador sentir que recebe muito mais do que pagou.
 - A oferta deve ser compatível com produto digital apoiado por IA e execução prática pelo cliente.
+- A oferta deve gerar uma vitória rápida demonstrável, que possa virar prova/amostra na futura página de vendas.
 - Não prometa cura, renda garantida, resultado absoluto, automação total ou dependência de acesso interno ao negócio do cliente.
-- Não crie preço, checkout, campanha de anúncios ou página de vendas nesta etapa.
+- Não crie checkout, campanha de anúncios ou página de vendas nesta etapa.
+- Não escreva anúncios, headline de landing, copy completa de página de vendas ou estratégia de Facebook; entregue apenas a oferta estruturada que servirá de insumo futuro.
 - Não use markdown dentro dos campos.
 
 Critérios de qualidade:
 - A oferta deve ser fácil de entender, específica e conectada à rotina real do nicho.
+- A promessa de entrada deve caber em uma compra simples: remover uma dor prática, entregar clareza, reduzir esforço ou gerar um primeiro avanço perceptível.
 - Os passos devem poder virar módulos, entregáveis, checklists, templates ou planos de ação.
+- Os entregáveis devem ser descritos pelo benefício prático, não apenas pelo formato do arquivo.
+- A relação preço/valor deve soar como oportunidade acessível: preço baixo, pacote robusto, aplicação imediata e economia de esforço; não use desconto falso, urgência artificial ou ancoragem enganosa.
 - Mostre o papel da IA como redução de esforço e aceleração prática, não como mágica.
 - Inclua limites de plausibilidade para manter a promessa segura e vendável.
 - Preserve o eixo Dor → Resultado → Mecanismo → Prova → Oferta.
+- Se houver risco de a solução ficar ampla demais, reduza o escopo para o menor kit que resolva a causa-raiz prioritária da dor.
 
 Contexto do nicho, dor concluída, resultado concluído, mecanismo concluído, prova concluída e artefatos disponíveis:
 {{CASE_DATA_BLOCK}}

--- a/ai-worker/src/main/resources/prompts/hypothesis-pipeline/hypothesis-offer.md
+++ b/ai-worker/src/main/resources/prompts/hypothesis-pipeline/hypothesis-offer.md
@@ -19,6 +19,7 @@ Regras obrigatórias:
 - Não crie checkout, campanha de anúncios ou página de vendas nesta etapa.
 - Não escreva anúncios, headline de landing, copy completa de página de vendas ou estratégia de Facebook; entregue apenas a oferta estruturada que servirá de insumo futuro.
 - Não use markdown dentro dos campos.
+- Quando o contexto trouxer campos `enriched*`, trate-os como ponte oficial do pipeline nicho-cnae: use rotina, linguagem, evidências, gatilhos e objeções observadas sem transformá-los em promessa ou oferta prematura.
 
 Critérios de qualidade:
 - A oferta deve ser fácil de entender, específica e conectada à rotina real do nicho.

--- a/ai-worker/src/main/resources/prompts/hypothesis-pipeline/hypothesis-pain.md
+++ b/ai-worker/src/main/resources/prompts/hypothesis-pipeline/hypothesis-pain.md
@@ -16,6 +16,7 @@ Regras obrigatórias:
 - A dor deve poder ser atacada por produto digital, diagnóstico, roteiro, template, plano, biblioteca ou ferramenta baseada em IA.
 - Não crie promessa final, preço ou oferta nesta etapa.
 - Não use markdown dentro dos campos.
+- Quando o contexto trouxer campos `enriched*`, trate-os como ponte oficial do pipeline nicho-cnae: use rotina, linguagem, evidências, gatilhos e objeções observadas sem transformá-los em promessa ou oferta prematura.
 
 Critérios de qualidade:
 - Priorize uma dor que possa gerar venda, não curiosidade superficial.

--- a/ai-worker/src/main/resources/prompts/hypothesis-pipeline/hypothesis-proof.md
+++ b/ai-worker/src/main/resources/prompts/hypothesis-pipeline/hypothesis-proof.md
@@ -12,6 +12,7 @@ Regras obrigatórias:
 - Não prometa cura, renda garantida, resultado absoluto, automação total ou dependência de acesso interno ao negócio do cliente.
 - Não crie preço, checkout, campanha de anúncios ou página de vendas nesta etapa.
 - Não use markdown dentro dos campos.
+- Quando o contexto trouxer campos `enriched*`, trate-os como ponte oficial do pipeline nicho-cnae: use rotina, linguagem, evidências, gatilhos e objeções observadas sem transformá-los em promessa ou oferta prematura.
 
 Critérios de qualidade:
 - A prova deve ser específica, fácil de produzir e conectada à rotina real do nicho.

--- a/ai-worker/src/main/resources/prompts/hypothesis-pipeline/hypothesis-result.md
+++ b/ai-worker/src/main/resources/prompts/hypothesis-pipeline/hypothesis-result.md
@@ -12,6 +12,7 @@ Regras obrigatórias:
 - Não prometa cura, garantia absoluta, enriquecimento garantido ou transformação irreal.
 - Não crie mecanismo, prova, preço ou oferta nesta etapa.
 - Não use markdown dentro dos campos.
+- Quando o contexto trouxer campos `enriched*`, trate-os como ponte oficial do pipeline nicho-cnae: use rotina, linguagem, evidências, gatilhos e objeções observadas sem transformá-los em promessa ou oferta prematura.
 
 Critérios de qualidade:
 - O resultado deve ser forte o suficiente para sustentar anúncio e primeira dobra de landing page.

--- a/ai-worker/src/test/java/com/marketinghub/worker/pipeline/hypothesisoffer/HypothesisOfferResponseValidatorTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/pipeline/hypothesisoffer/HypothesisOfferResponseValidatorTest.java
@@ -11,14 +11,35 @@ import org.junit.jupiter.api.Test;
 class HypothesisOfferResponseValidatorTest {
     private final HypothesisOfferResponseValidator validator = new HypothesisOfferResponseValidator(new ObjectMapper());
 
-    /** Valida que uma resposta com oferta plausível e passos operacionais é aceita. */
+    /** Valida que uma resposta com oferta low-ticket plausível e entregáveis operacionais é aceita. */
     @Test
     void validateAndParseAcceptsValidOfferJson() {
         String json = """
                 {
                   "offerName": "Kit Agenda Cheia sem Retrabalho",
+                  "offerPositioning": "Produto digital low-ticket para profissionais que precisam organizar a agenda sem contratar sistema complexo.",
+                  "entryPromise": "Confirmar clientes com mais clareza e reduzir horários perdidos por falta ou desmarcação.",
+                  "pricePositioning": "Faixa sugerida de R$ 27 a R$ 47, compatível com compra de baixo atrito.",
                   "coreOffer": "Um pacote digital com diagnóstico rápido, checklists e mensagens prontas para reduzir falhas de agenda no salão.",
                   "howItWorks": "O cliente segue um roteiro simples gerado com apoio de IA para organizar atendimentos, prevenir esquecimentos e recuperar horários críticos.",
+                  "deliverables": [
+                    "Diagnóstico rápido para mapear gargalos de agenda.",
+                    "Checklist de confirmação antes do atendimento.",
+                    "Banco de mensagens prontas para WhatsApp.",
+                    "Modelo simples de política de remarcação e cancelamento.",
+                    "Planilha simples para medir horários perdidos."
+                  ],
+                  "valueStack": [
+                    "Diagnóstico de agenda para revelar onde o horário se perde.",
+                    "Checklist de confirmação para usar antes de cada atendimento.",
+                    "Mensagens prontas para reduzir conversas improvisadas.",
+                    "Política leve de remarcação para comunicar regras sem atrito.",
+                    "Planilha de prejuízo para visualizar dinheiro parado.",
+                    "Prompts de IA para adaptar o tom das mensagens."
+                  ],
+                  "valuePerception": "O pacote reúne vários ativos prontos por preço baixo, aumentando a sensação de receber muito mais do que um material isolado.",
+                  "quickWinAsset": "Checklist de confirmação em duas etapas que pode ser aplicado no próximo atendimento.",
+                  "productionFormat": "PDF curto, planilha simples e biblioteca de mensagens copiáveis para uso imediato.",
                   "steps": [
                     "Mapear os gargalos de agenda mais frequentes do salão.",
                     "Aplicar checklists e mensagens prontas antes e depois do atendimento.",
@@ -28,7 +49,8 @@ class HypothesisOfferResponseValidatorTest {
                   "effortReduction": "O profissional evita criar processos do zero e passa a executar um caminho pronto.",
                   "whyBelievable": "A oferta atua sobre organização e comunicação da rotina, não promete demanda garantida.",
                   "boundaryConditions": "Depende de uso consistente e não substitui qualidade técnica, atendimento ou gestão financeira.",
-                  "summary": "Oferta digital para reduzir retrabalho de agenda e tornar a rotina do salão mais previsível.",
+                  "nextStageReadiness": "A oferta deixa claros promessa, entregáveis, vitória rápida e prova funcional para futura página de vendas e isca digital.",
+                  "summary": "Oferta digital low-ticket para reduzir retrabalho de agenda e tornar a rotina do salão mais previsível.",
                   "evidenceSignals": ["dor concluída", "resultado concluído", "mecanismo concluído"]
                 }
                 """;
@@ -36,6 +58,10 @@ class HypothesisOfferResponseValidatorTest {
         HypothesisOfferOutput output = validator.validateAndParse(json);
 
         assertThat(output.offerName()).isEqualTo("Kit Agenda Cheia sem Retrabalho");
+        assertThat(output.pricePositioning()).contains("R$ 27");
+        assertThat(output.deliverables()).hasSize(5);
+        assertThat(output.valueStack()).hasSize(6);
+        assertThat(output.valuePerception()).contains("preço baixo");
         assertThat(output.steps()).hasSize(3);
     }
 
@@ -45,13 +71,22 @@ class HypothesisOfferResponseValidatorTest {
         String json = """
                 {
                   "offerName": "Kit Agenda Cheia sem Retrabalho",
+                  "offerPositioning": "Produto digital low-ticket para agenda.",
+                  "entryPromise": "Confirmar clientes com mais clareza.",
+                  "pricePositioning": "R$ 27 a R$ 47.",
                   "coreOffer": "",
                   "howItWorks": "Explica a rotina.",
+                  "deliverables": ["Diagnóstico rápido", "Checklist útil", "Mensagens prontas", "Política leve", "Planilha simples"],
+                  "valueStack": ["Diagnóstico rápido", "Checklist útil", "Mensagens prontas", "Política leve", "Planilha simples", "Prompts úteis"],
+                  "valuePerception": "Pacote robusto por preço baixo.",
+                  "quickWinAsset": "Checklist de confirmação.",
+                  "productionFormat": "PDF e mensagens copiáveis.",
                   "steps": ["Mapear gargalos", "Aplicar mensagens", "Revisar ajustes"],
                   "aiLeverage": "Gera ativos.",
                   "effortReduction": "Reduz esforço.",
                   "whyBelievable": "Atua na rotina.",
                   "boundaryConditions": "Sem garantias.",
+                  "nextStageReadiness": "Pronto para próxima etapa.",
                   "summary": "Resumo válido.",
                   "evidenceSignals": ["contexto"]
                 }

--- a/ai-worker/src/test/java/com/marketinghub/worker/pipeline/hypothesispain/HypothesisPainBackendClientTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/pipeline/hypothesispain/HypothesisPainBackendClientTest.java
@@ -21,9 +21,15 @@ class HypothesisPainBackendClientTest {
         niche.put("promises", null);
         niche.put("offers", null);
         niche.put("extraTips", "Usar rotina real");
+        Map<String, Object> enrichmentProfile = new LinkedHashMap<>();
+        enrichmentProfile.put("personaSummary", "Manicure autônoma em domicílio.");
+        enrichmentProfile.put("languagePatterns", "agenda quebrada; cliente some");
+        enrichmentProfile.put("commercialTriggers", "busca previsibilidade");
+        enrichmentProfile.put("objections", "medo de parecer complicado");
         Map<String, Object> pending = new LinkedHashMap<>();
         pending.put("marketNicheId", 18L);
         pending.put("niche", niche);
+        pending.put("enrichmentProfile", enrichmentProfile);
 
         Map<String, Object> promptData = client.buildPromptDataFromPending(pending);
         HypothesisPainInput input = new HypothesisPainInput(18L, "hypothesis-pain", "job-1", promptData);
@@ -35,7 +41,11 @@ class HypothesisPainBackendClientTest {
         assertThat(promptData.get("CASE_DATA_BLOCK")).asString()
                 .contains("promises: ")
                 .contains("offers: ")
-                .contains("extraTips: Usar rotina real");
+                .contains("extraTips: Usar rotina real")
+                .contains("enrichedPersonaSummary: Manicure autônoma em domicílio.")
+                .contains("enrichedLanguagePatterns: agenda quebrada; cliente some")
+                .contains("enrichedCommercialTriggers: busca previsibilidade")
+                .contains("enrichedObjections: medo de parecer complicado");
     }
 
     /** Cria o cliente de backend apenas com dependências necessárias para montagem local do contexto. */

--- a/backend/ads-service/src/main/java/com/marketinghub/hypothesis/pain/controller/HypothesisPainStageController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/hypothesis/pain/controller/HypothesisPainStageController.java
@@ -63,6 +63,12 @@ public class HypothesisPainStageController {
         return ResponseEntity.accepted().body(service.startOffer(nicheId));
     }
 
+    /** Inicia o fluxo automático completo Dor → Resultado → Mecanismo → Prova → Oferta. */
+    @PostMapping("/niches/{nicheId}/hypothesis-pipeline/full-flow/start")
+    public ResponseEntity<HypothesisPainStartResponse> startFullFlow(@PathVariable Long nicheId) {
+        return ResponseEntity.accepted().body(service.startFullFlow(nicheId));
+    }
+
     /** Lista execuções da etapa Dor para acompanhamento na tela de nova hipótese. */
     @GetMapping("/niches/{nicheId}/hypothesis-pipeline/pain/stage-executions")
     public ResponseEntity<List<HypothesisPainExecutionSummaryResponse>> listStageExecutions(

--- a/backend/ads-service/src/main/java/com/marketinghub/hypothesis/pain/service/HypothesisPainStageService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/hypothesis/pain/service/HypothesisPainStageService.java
@@ -4,13 +4,16 @@ import com.marketinghub.hypothesis.pain.HypothesisPainCostCalculator;
 import com.marketinghub.hypothesis.pain.HypothesisPainStageExecution;
 import com.marketinghub.hypothesis.pain.service.detailStageExecution.HypothesisPainExecutionDetailResponse;
 import com.marketinghub.hypothesis.pain.service.listStageExecutions.HypothesisPainExecutionSummaryResponse;
+import com.marketinghub.hypothesis.pain.service.pending.HypothesisPainPendingEnrichmentProfile;
 import com.marketinghub.hypothesis.pain.service.pending.HypothesisPainPendingExecution;
 import com.marketinghub.hypothesis.pain.service.pending.HypothesisPainPendingNiche;
 import com.marketinghub.hypothesis.pain.service.recebeResposta.RecebeRespostaRequest;
 import com.marketinghub.hypothesis.pain.service.start.HypothesisPainStartResponse;
 import com.marketinghub.hypothesis.pain.service.summary.HypothesisStageFinalSummaryResponse;
 import com.marketinghub.niche.MarketNiche;
+import com.marketinghub.niche.MarketNicheEnrichmentProfile;
 import com.marketinghub.repository.jpa.hypothesis.HypothesisPainStageExecutionRepository;
+import com.marketinghub.repository.jpa.niche.MarketNicheEnrichmentProfileRepository;
 import com.marketinghub.repository.jpa.niche.MarketNicheRepository;
 import jakarta.persistence.EntityNotFoundException;
 import java.math.BigDecimal;
@@ -58,15 +61,18 @@ public class HypothesisPainStageService {
             STATUS_WAITING_OPENAI_DISPATCH);
 
     private final MarketNicheRepository marketNicheRepository;
+    private final MarketNicheEnrichmentProfileRepository enrichmentProfileRepository;
     private final HypothesisPainStageExecutionRepository executionRepository;
     private final HypothesisPainCostCalculator costCalculator;
 
     /** Inicializa o serviço com os repositórios canônicos e o calculador interno de custo da etapa. */
     public HypothesisPainStageService(
             MarketNicheRepository marketNicheRepository,
+            MarketNicheEnrichmentProfileRepository enrichmentProfileRepository,
             HypothesisPainStageExecutionRepository executionRepository,
             HypothesisPainCostCalculator costCalculator) {
         this.marketNicheRepository = marketNicheRepository;
+        this.enrichmentProfileRepository = enrichmentProfileRepository;
         this.executionRepository = executionRepository;
         this.costCalculator = costCalculator;
     }
@@ -367,6 +373,7 @@ public class HypothesisPainStageService {
                         execution.getExecutionRequestedAt(),
                         execution.getProcessingStartedAt(),
                         toPendingNiche(execution.getMarketNiche()),
+                        toPendingEnrichmentProfile(execution.getMarketNicheId()),
                         pendingPainResponse(execution),
                         pendingResultResponse(execution),
                         pendingMechanismResponse(execution),
@@ -750,6 +757,45 @@ public class HypothesisPainStageService {
                 niche.getInterests(),
                 niche.getDemographicFilters(),
                 niche.getExtraTips());
+    }
+
+    /** Converte o perfil enriquecido mais recente do nicho para o contrato consumido pelo Worker AI. */
+    private HypothesisPainPendingEnrichmentProfile toPendingEnrichmentProfile(Long marketNicheId) {
+        if (marketNicheId == null) {
+            return null;
+        }
+        return enrichmentProfileRepository.findLatestByMarketNicheIds(List.of(marketNicheId)).stream()
+                .findFirst()
+                .map(this::toPendingEnrichmentProfile)
+                .orElse(null);
+    }
+
+    /** Converte a entidade de perfil enriquecido em DTO sem expor a entidade JPA ao Worker AI. */
+    private HypothesisPainPendingEnrichmentProfile toPendingEnrichmentProfile(MarketNicheEnrichmentProfile profile) {
+        return new HypothesisPainPendingEnrichmentProfile(
+                profile.getId(),
+                profile.getResearchCycleId(),
+                profile.getCnaeCode(),
+                profile.getCnaeDescription(),
+                profile.getSourceScore(),
+                profile.getQualityStatus(),
+                profile.getSpecificityScore(),
+                profile.getConfidenceScore(),
+                profile.getDuplicationScore(),
+                profile.getRoutineEvidenceScore(),
+                profile.getDifficultyEvidenceScore(),
+                profile.getSourceDiversityScore(),
+                profile.getSolutionLanguageRiskScore(),
+                profile.getRoutineSummary(),
+                profile.getPainsSummary(),
+                profile.getResultsSummary(),
+                profile.getMechanismOpportunitiesSummary(),
+                profile.getEvidenceSummary(),
+                profile.getSourceDomains(),
+                profile.getPersonaSummary(),
+                profile.getLanguagePatterns(),
+                profile.getCommercialTriggers(),
+                profile.getObjections());
     }
 
     /** Converte uma execução para resumo operacional. */

--- a/backend/ads-service/src/main/java/com/marketinghub/hypothesis/pain/service/HypothesisPainStageService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/hypothesis/pain/service/HypothesisPainStageService.java
@@ -18,6 +18,7 @@ import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -39,6 +40,18 @@ public class HypothesisPainStageService {
     private static final String STATUS_PROCESSING = "PROCESSANDO";
     private static final String STATUS_COMPLETED = "CONCLUIDO";
     private static final String STATUS_FAILED = "FALHA";
+    private static final String AUTO_FLOW_MARKER = "[AUTO_HYPOTHESIS_FLOW]";
+    private static final int AUTO_FLOW_MAX_ATTEMPTS = 3;
+    private static final List<String> STAGE_SEQUENCE = List.of(
+            STAGE_CODE,
+            RESULT_STAGE_CODE,
+            MECHANISM_STAGE_CODE,
+            PROOF_STAGE_CODE,
+            OFFER_STAGE_CODE);
+    private static final List<String> ACTIVE_STATUSES = List.of(
+            STATUS_STARTED,
+            STATUS_PROCESSING,
+            STATUS_WAITING_OPENAI_DISPATCH);
     private static final Duration OPERATIONAL_LEASE_TIMEOUT = Duration.ofMinutes(45);
     private static final List<String> LEASE_GUARDED_STATUSES = List.of(
             STATUS_PROCESSING,
@@ -88,6 +101,16 @@ public class HypothesisPainStageService {
         return startStage(marketNicheId, OFFER_STAGE_CODE, "Oferta", true, true, true, true);
     }
 
+    /** Inicia ou retoma o fluxo automático completo a partir da primeira etapa pendente do nicho. */
+    @Transactional
+    public HypothesisPainStartResponse startFullFlow(Long marketNicheId) {
+        MarketNiche niche = marketNicheRepository.findById(marketNicheId)
+                .orElseThrow(() -> new EntityNotFoundException("Market niche not found: " + marketNicheId));
+        return findActiveExecution(marketNicheId)
+                .map(execution -> new HypothesisPainStartResponse(fromDatabaseIdJob(execution.getIdJob()), execution.getStatus()))
+                .orElseGet(() -> startAutoStage(niche, nextStageCodeForFullFlow(marketNicheId), 1));
+    }
+
     /** Inicia uma nova execução manual de uma etapa do pipeline para o nicho informado. */
     private HypothesisPainStartResponse startStage(
             Long marketNicheId,
@@ -112,19 +135,48 @@ public class HypothesisPainStageService {
         if (requiresCompletedProof) {
             requireCompletedProof(marketNicheId);
         }
-        HypothesisPainStageExecution execution = HypothesisPainStageExecution.builder()
+        HypothesisPainStageExecution execution = newStageExecution(
+                niche,
+                stageCode,
+                now,
+                "manual/start",
+                "Início manual da etapa " + stageLabel + " via tela de nova hipótese.");
+        HypothesisPainStageExecution saved = executionRepository.save(execution);
+        return new HypothesisPainStartResponse(fromDatabaseIdJob(saved.getIdJob()), saved.getStatus());
+    }
+
+    /** Cria uma execução automática de etapa com metadados de tentativa no promptContent. */
+    private HypothesisPainStartResponse startAutoStage(MarketNiche niche, String stageCode, int attempt) {
+        requireCompletedPrerequisites(niche.getId(), stageCode);
+        HypothesisPainStageExecution execution = newStageExecution(
+                niche,
+                stageCode,
+                Instant.now(),
+                "auto/full-flow",
+                AUTO_FLOW_MARKER + " stage=" + stageCode + " attempt=" + attempt
+                        + " maxAttempts=" + AUTO_FLOW_MAX_ATTEMPTS);
+        HypothesisPainStageExecution saved = executionRepository.save(execution);
+        return new HypothesisPainStartResponse(fromDatabaseIdJob(saved.getIdJob()), saved.getStatus());
+    }
+
+    /** Monta a entidade de execução com os campos comuns para início manual ou automático. */
+    private HypothesisPainStageExecution newStageExecution(
+            MarketNiche niche,
+            String stageCode,
+            Instant now,
+            String promptTemplateId,
+            String promptContent) {
+        return HypothesisPainStageExecution.builder()
                 .marketNicheId(niche.getId())
                 .marketNiche(niche)
                 .stageCode(stageCode)
                 .executionRequestedAt(now)
                 .createdAt(now)
-                .promptTemplateId("manual/start")
-                .promptContent("Início manual da etapa " + stageLabel + " via tela de nova hipótese.")
+                .promptTemplateId(promptTemplateId)
+                .promptContent(promptContent)
                 .status(STATUS_STARTED)
                 .idJob(toDatabaseIdJob(UUID.randomUUID().toString()))
                 .build();
-        HypothesisPainStageExecution saved = executionRepository.save(execution);
-        return new HypothesisPainStartResponse(fromDatabaseIdJob(saved.getIdJob()), saved.getStatus());
     }
 
     /** Lista execuções da etapa Dor para o nicho informado. */
@@ -172,6 +224,37 @@ public class HypothesisPainStageService {
                         stageCode,
                         STATUS_COMPLETED);
         return executions.stream().map(this::toSummaryResponse).toList();
+    }
+
+    /** Busca qualquer execução ativa do nicho para evitar duplicidade no fluxo automático completo. */
+    private Optional<HypothesisPainStageExecution> findActiveExecution(Long marketNicheId) {
+        return STAGE_SEQUENCE.stream()
+                .flatMap(stageCode -> executionRepository.findByMarketNicheIdAndStageCodeOrderByExecutionRequestedAtDesc(
+                                marketNicheId,
+                                stageCode)
+                        .stream())
+                .filter(execution -> ACTIVE_STATUSES.contains(execution.getStatus()))
+                .findFirst();
+    }
+
+    /** Define a primeira etapa ainda não concluída para o fluxo automático completo. */
+    private String nextStageCodeForFullFlow(Long marketNicheId) {
+        if (!StringUtils.hasText(latestCompletedPainResponse(marketNicheId))) {
+            return STAGE_CODE;
+        }
+        if (!StringUtils.hasText(latestCompletedResultResponse(marketNicheId))) {
+            return RESULT_STAGE_CODE;
+        }
+        if (!StringUtils.hasText(latestCompletedMechanismResponse(marketNicheId))) {
+            return MECHANISM_STAGE_CODE;
+        }
+        if (!StringUtils.hasText(latestCompletedProofResponse(marketNicheId))) {
+            return PROOF_STAGE_CODE;
+        }
+        if (!StringUtils.hasText(latestCompletedStageResponse(marketNicheId, OFFER_STAGE_CODE))) {
+            return OFFER_STAGE_CODE;
+        }
+        throw new IllegalStateException("Todas as etapas do fluxo de hipótese já estão concluídas para o nicho: " + marketNicheId);
     }
 
     /** Retorna o detalhe completo de auditoria de uma execução pelo jobid dentro do nicho informado. */
@@ -528,6 +611,7 @@ public class HypothesisPainStageService {
             execution.setStatus(normalizedErrorMessage != null ? STATUS_FAILED : STATUS_COMPLETED);
             executionRepository.save(execution);
             costCalculator.addFlexCostDeltaToNiche(execution.getMarketNiche(), costDeltaUsd);
+            continueAutoFlowIfNeeded(execution);
         } catch (RuntimeException ex) {
             log.error(
                     "Erro ao concluir resposta da etapa do pipeline de hipótese (idJob={}, marketNicheId={}, stageCode={}, openAiJobId={}, modelResponseLength={}, errorMessage={})",
@@ -540,6 +624,66 @@ public class HypothesisPainStageService {
                     ex);
             throw ex;
         }
+    }
+
+    /** Continua o fluxo automático após sucesso ou cria nova tentativa quando a etapa falha antes do limite. */
+    private void continueAutoFlowIfNeeded(HypothesisPainStageExecution execution) {
+        if (!isAutoFlowExecution(execution)) {
+            return;
+        }
+        int attempt = autoFlowAttempt(execution);
+        if (STATUS_FAILED.equals(execution.getStatus())) {
+            retryAutoFlowStageIfAllowed(execution, attempt);
+            return;
+        }
+        startNextAutoFlowStageIfAllowed(execution);
+    }
+
+    /** Verifica se a execução pertence ao fluxo automático completo. */
+    private boolean isAutoFlowExecution(HypothesisPainStageExecution execution) {
+        return StringUtils.hasText(execution.getPromptContent())
+                && execution.getPromptContent().contains(AUTO_FLOW_MARKER);
+    }
+
+    /** Extrai a tentativa atual persistida no promptContent do fluxo automático. */
+    private int autoFlowAttempt(HypothesisPainStageExecution execution) {
+        String promptContent = execution.getPromptContent();
+        if (!StringUtils.hasText(promptContent)) {
+            return 1;
+        }
+        for (String token : promptContent.split(" ")) {
+            if (token.startsWith("attempt=")) {
+                return Integer.parseInt(token.substring("attempt=".length()));
+            }
+        }
+        return 1;
+    }
+
+    /** Reenfileira a mesma etapa automática quando ainda há tentativas disponíveis. */
+    private void retryAutoFlowStageIfAllowed(HypothesisPainStageExecution execution, int attempt) {
+        if (attempt >= AUTO_FLOW_MAX_ATTEMPTS) {
+            log.warn(
+                    "[HypothesisPipeline] Fluxo automático interrompido após {} tentativas stageCode={} marketNicheId={} idJob={}",
+                    attempt,
+                    execution.getStageCode(),
+                    execution.getMarketNicheId(),
+                    fromDatabaseIdJob(execution.getIdJob()));
+            return;
+        }
+        MarketNiche niche = marketNicheRepository.findById(execution.getMarketNicheId())
+                .orElseThrow(() -> new EntityNotFoundException("Market niche not found: " + execution.getMarketNicheId()));
+        startAutoStage(niche, execution.getStageCode(), attempt + 1);
+    }
+
+    /** Inicia a próxima etapa automática quando a etapa atual conclui com sucesso. */
+    private void startNextAutoFlowStageIfAllowed(HypothesisPainStageExecution execution) {
+        int currentIndex = STAGE_SEQUENCE.indexOf(execution.getStageCode());
+        if (currentIndex < 0 || currentIndex >= STAGE_SEQUENCE.size() - 1) {
+            return;
+        }
+        MarketNiche niche = marketNicheRepository.findById(execution.getMarketNicheId())
+                .orElseThrow(() -> new EntityNotFoundException("Market niche not found: " + execution.getMarketNicheId()));
+        startAutoStage(niche, STAGE_SEQUENCE.get(currentIndex + 1), 1);
     }
 
     /** Calcula internamente o custo flex da resposta usando o modelo salvo e os tokens recebidos. */

--- a/backend/ads-service/src/main/java/com/marketinghub/hypothesis/pain/service/pending/HypothesisPainPendingEnrichmentProfile.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/hypothesis/pain/service/pending/HypothesisPainPendingEnrichmentProfile.java
@@ -1,0 +1,31 @@
+package com.marketinghub.hypothesis.pain.service.pending;
+
+import java.math.BigDecimal;
+
+/** Perfil enriquecido do nicho usado para preservar sinais OPRM no pipeline de hipótese. */
+public record HypothesisPainPendingEnrichmentProfile(
+        Long id,
+        Long researchCycleId,
+        String cnaeCode,
+        String cnaeDescription,
+        BigDecimal sourceScore,
+        String qualityStatus,
+        Integer specificityScore,
+        Integer confidenceScore,
+        Integer duplicationScore,
+        Integer routineEvidenceScore,
+        Integer difficultyEvidenceScore,
+        Integer sourceDiversityScore,
+        Integer solutionLanguageRiskScore,
+        String routineSummary,
+        String painsSummary,
+        String resultsSummary,
+        String mechanismOpportunitiesSummary,
+        String evidenceSummary,
+        String sourceDomains,
+        String personaSummary,
+        String languagePatterns,
+        String commercialTriggers,
+        String objections
+) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/hypothesis/pain/service/pending/HypothesisPainPendingExecution.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/hypothesis/pain/service/pending/HypothesisPainPendingExecution.java
@@ -11,6 +11,7 @@ public record HypothesisPainPendingExecution(
         Instant executionRequestedAt,
         Instant processingStartedAt,
         HypothesisPainPendingNiche niche,
+        HypothesisPainPendingEnrichmentProfile enrichmentProfile,
         String painModelResponse,
         String resultModelResponse,
         String mechanismModelResponse,

--- a/backend/ads-service/src/test/java/com/marketinghub/hypothesis/pain/service/HypothesisPainStageServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/hypothesis/pain/service/HypothesisPainStageServiceTest.java
@@ -559,4 +559,68 @@ class HypothesisPainStageServiceTest {
         assertEquals("model_response", summary.get(1).sourceField());
     }
 
+    /** Deve iniciar o fluxo automático completo pela primeira etapa ainda pendente. */
+    @Test
+    void startFullFlowStartsPainWhenNoStageCompleted() {
+        MarketNiche niche = new MarketNiche();
+        niche.setId(18L);
+        when(marketNicheRepository.findById(18L)).thenReturn(Optional.of(niche));
+        when(executionRepository.findByMarketNicheIdAndStageCodeOrderByExecutionRequestedAtDesc(any(), any()))
+                .thenReturn(List.of());
+        when(executionRepository.findTopByMarketNicheIdAndStageCodeAndStatusOrderByExecutionRequestedAtDesc(any(), any(), any()))
+                .thenReturn(Optional.empty());
+        when(executionRepository.save(any(HypothesisPainStageExecution.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        var response = service.startFullFlow(18L);
+
+        assertEquals("INICIADO", response.status());
+        ArgumentCaptor<HypothesisPainStageExecution> captor = ArgumentCaptor.forClass(HypothesisPainStageExecution.class);
+        verify(executionRepository).save(captor.capture());
+        assertEquals("hypothesis-pain", captor.getValue().getStageCode());
+        org.assertj.core.api.Assertions.assertThat(captor.getValue().getPromptContent()).contains("[AUTO_HYPOTHESIS_FLOW]");
+    }
+
+    /** Deve criar nova tentativa automática da mesma etapa quando uma execução automática falha antes do limite. */
+    @Test
+    void markCompletedFromResponseRetriesAutomaticStageAfterFailure() {
+        String idJob = "auto-pain-1";
+        MarketNiche niche = new MarketNiche();
+        niche.setId(18L);
+        HypothesisPainStageExecution execution = HypothesisPainStageExecution.builder()
+                .idJob(idJob.getBytes(StandardCharsets.UTF_8))
+                .marketNicheId(18L)
+                .marketNiche(niche)
+                .stageCode("hypothesis-pain")
+                .status("PROCESSANDO")
+                .openAiModel("gpt-5.5")
+                .promptContent("[AUTO_HYPOTHESIS_FLOW] stage=hypothesis-pain attempt=1 maxAttempts=3")
+                .build();
+        RecebeRespostaRequest request = new RecebeRespostaRequest(
+                18L,
+                "hypothesis-pain",
+                null,
+                null,
+                null,
+                null,
+                null,
+                null,
+                "falha da IA",
+                "stack");
+
+        when(executionRepository.findTopByIdJobOrderByExecutionRequestedAtDesc(idJob.getBytes(StandardCharsets.UTF_8)))
+                .thenReturn(Optional.of(execution));
+        when(executionRepository.save(any(HypothesisPainStageExecution.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+        when(marketNicheRepository.findById(18L)).thenReturn(Optional.of(niche));
+
+        service.markCompletedFromResponse(idJob, request);
+
+        ArgumentCaptor<HypothesisPainStageExecution> captor = ArgumentCaptor.forClass(HypothesisPainStageExecution.class);
+        verify(executionRepository, org.mockito.Mockito.times(2)).save(captor.capture());
+        HypothesisPainStageExecution retry = captor.getAllValues().get(1);
+        assertEquals("hypothesis-pain", retry.getStageCode());
+        org.assertj.core.api.Assertions.assertThat(retry.getPromptContent()).contains("attempt=2");
+    }
+
 }

--- a/backend/ads-service/src/test/java/com/marketinghub/hypothesis/pain/service/HypothesisPainStageServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/hypothesis/pain/service/HypothesisPainStageServiceTest.java
@@ -11,7 +11,9 @@ import com.marketinghub.hypothesis.pain.HypothesisPainCostCalculator;
 import com.marketinghub.hypothesis.pain.HypothesisPainStageExecution;
 import com.marketinghub.hypothesis.pain.service.recebeResposta.RecebeRespostaRequest;
 import com.marketinghub.niche.MarketNiche;
+import com.marketinghub.niche.MarketNicheEnrichmentProfile;
 import com.marketinghub.repository.jpa.hypothesis.HypothesisPainStageExecutionRepository;
+import com.marketinghub.repository.jpa.niche.MarketNicheEnrichmentProfileRepository;
 import com.marketinghub.repository.jpa.niche.MarketNicheRepository;
 import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
@@ -33,6 +35,9 @@ class HypothesisPainStageServiceTest {
     private MarketNicheRepository marketNicheRepository;
 
     @Mock
+    private MarketNicheEnrichmentProfileRepository enrichmentProfileRepository;
+
+    @Mock
     private HypothesisPainStageExecutionRepository executionRepository;
 
     @Mock
@@ -45,6 +50,7 @@ class HypothesisPainStageServiceTest {
     void setup() {
         service = new HypothesisPainStageService(
                 marketNicheRepository,
+                enrichmentProfileRepository,
                 executionRepository,
                 costCalculator);
     }
@@ -129,6 +135,63 @@ class HypothesisPainStageServiceTest {
         assertEquals(
                 "Timeout operacional: execução ficou em PROCESSANDO por mais de 45 minutos sem conclusão. Job recuperado automaticamente e devolvido para a fila de processamento.",
                 recovered.getErrorMessage());
+    }
+
+    /** Deve entregar o perfil enriquecido do nicho para preservar sinais OPRM no Worker AI. */
+    @Test
+    void listPendingIncludesLatestEnrichmentProfile() {
+        MarketNiche niche = new MarketNiche();
+        niche.setId(18L);
+        String idJob = "6bb83a22-3894-43bd-9752-374f84eb6a2c";
+        HypothesisPainStageExecution execution = HypothesisPainStageExecution.builder()
+                .idJob(idJob.getBytes(StandardCharsets.UTF_8))
+                .marketNicheId(18L)
+                .marketNiche(niche)
+                .stageCode("hypothesis-pain")
+                .status("INICIADO")
+                .executionRequestedAt(Instant.parse("2026-06-11T09:59:00Z"))
+                .build();
+        MarketNicheEnrichmentProfile profile = new MarketNicheEnrichmentProfile();
+        profile.setId(7L);
+        profile.setResearchCycleId(60L);
+        profile.setCnaeCode("9602501");
+        profile.setCnaeDescription("Cabeleireiros, manicure e pedicure");
+        profile.setSourceScore(new BigDecimal("90.00"));
+        profile.setQualityStatus("APPROVED");
+        profile.setConfidenceScore(87);
+        profile.setDifficultyEvidenceScore(91);
+        profile.setSourceDiversityScore(73);
+        profile.setRoutineSummary("Agenda, deslocamento e atendimento em domicílio.");
+        profile.setPainsSummary("Remarcações e ociosidade reduzem faturamento.");
+        profile.setResultsSummary("Agenda previsível e pacote simples de atendimento.");
+        profile.setMechanismOpportunitiesSummary("Checklists operacionais e scripts de WhatsApp.");
+        profile.setEvidenceSummary("Evidências em fontes públicas do nicho.");
+        profile.setSourceDomains("exemplo.com");
+        profile.setPersonaSummary("Manicure autônoma em domicílio.");
+        profile.setLanguagePatterns("agenda quebrada; cliente some");
+        profile.setCommercialTriggers("busca previsibilidade e redução de retrabalho");
+        profile.setObjections("medo de parecer complicado");
+
+        when(executionRepository.findTop50ByStageCodeAndStatusInAndCompletedAtIsNullAndProcessingStartedAtBeforeOrderByProcessingStartedAtAsc(
+                        any(),
+                        any(),
+                        any()))
+                .thenReturn(List.of());
+        when(executionRepository.findTop20ByStageCodeAndStatusOrderByExecutionRequestedAtAsc(
+                        "hypothesis-pain",
+                        "INICIADO"))
+                .thenReturn(List.of(execution));
+        when(enrichmentProfileRepository.findLatestByMarketNicheIds(List.of(18L)))
+                .thenReturn(List.of(profile));
+
+        var pending = service.listPending();
+
+        assertEquals(1, pending.size());
+        assertEquals(7L, pending.getFirst().enrichmentProfile().id());
+        assertEquals("Manicure autônoma em domicílio.", pending.getFirst().enrichmentProfile().personaSummary());
+        assertEquals("agenda quebrada; cliente some", pending.getFirst().enrichmentProfile().languagePatterns());
+        assertEquals("busca previsibilidade e redução de retrabalho", pending.getFirst().enrichmentProfile().commercialTriggers());
+        assertEquals("medo de parecer complicado", pending.getFirst().enrichmentProfile().objections());
     }
 
     /** Deve falhar job antigo com openai_job_id para impedir recaptura duplicada de execução ativa na OpenAI. */

--- a/docs/canonical/procedimento-experimento-canon.v1.md
+++ b/docs/canonical/procedimento-experimento-canon.v1.md
@@ -71,6 +71,18 @@ Local canônico vigente:
 - pipeline de experimento (núcleo inicial): `ai-worker/src/main/resources/prompts/experiment`;
 - pipeline de landing no Worker AI: prompts e schemas devem ser resolvidos por configuração tipada da etapa em `openai.core.<etapa>`; o caminho físico em `resources/prompts/<dominio>` é detalhe de recurso versionado e não define namespace Java do Worker AI.
 
+### 4.2.1 Regra mandatória — oferta low-ticket da hipótese
+
+A etapa `hypothesis-offer` do pipeline de hipótese deve materializar uma oferta low-ticket digital, não uma oferta genérica. O objetivo é entregar um produto de entrada simples, vendável e aplicável rapidamente, que depois possa alimentar página de vendas, isca digital e campanha sem precisar redescobrir a oferta.
+
+Regras obrigatórias:
+- a oferta deve transformar Dor, Resultado, Mecanismo e Prova em um produto digital de baixo atrito, com promessa de entrada específica e vitória rápida plausível;
+- a resposta deve explicitar posicionamento da oferta, promessa de entrada, ancoragem/faixa de preço low-ticket, entregáveis concretos, pilha de valor, percepção de muito por pouco, formato de produção, ativo de quick win e prontidão para a próxima etapa comercial;
+- os entregáveis devem poder virar ativos produzíveis pelo Marketing Hub, como diagnóstico, roteiro, checklist, template, biblioteca, calculadora simples, prompts, plano ou mini-kit; o pacote deve parecer robusto, com vários componentes úteis e complementares por um preço baixo;
+- a etapa pode sugerir faixa de preço compatível com low-ticket, mas não deve criar checkout, desconto falso, urgência artificial, campanha de anúncios, página de vendas, headline completa de landing ou estratégia de Facebook;
+- a oferta deve preservar limites de plausibilidade: sem renda garantida, sem agenda cheia garantida, sem cura, sem automação total e sem depender de acesso interno ao negócio do cliente;
+- quando a solução ficar ampla demais, o prompt deve reduzir o escopo para o menor kit capaz de atacar a causa-raiz prioritária da dor.
+
 ### 4.3 Regra de diferenciação de ângulo após experimento reprovado
 
 Ao gerar a etapa `CAMPAIGN_ANGLE`, o prompt deve receber o histórico dos experimentos reprovados por 100 acessos sem envio da mesma hipótese, quando existir. A reprovação de um experimento reprova aquela materialização de mercado (público, criativo, landing, isca e formulário), mas não reprova automaticamente a hipótese estratégica.

--- a/docs/canonical/procedimento-experimento-canon.v1.md
+++ b/docs/canonical/procedimento-experimento-canon.v1.md
@@ -83,6 +83,17 @@ Regras obrigatórias:
 - a oferta deve preservar limites de plausibilidade: sem renda garantida, sem agenda cheia garantida, sem cura, sem automação total e sem depender de acesso interno ao negócio do cliente;
 - quando a solução ficar ampla demais, o prompt deve reduzir o escopo para o menor kit capaz de atacar a causa-raiz prioritária da dor.
 
+### 4.2.2 Regra operacional — fluxo completo da hipótese
+
+A tela de nova hipótese deve oferecer uma ação de fluxo completo para executar Dor → Resultado → Mecanismo → Prova → Oferta sem intervenção manual entre etapas. A orquestração principal deve ficar no backend, pois é ele que conhece a ordem canônica, os pré-requisitos, o status persistido e o callback de conclusão/falha de cada etapa.
+
+Regras obrigatórias:
+- o botão de fluxo completo deve iniciar a primeira etapa ainda não concluída e não duplicar execução quando já houver job ativo no nicho;
+- ao concluir uma etapa automática com sucesso, o backend deve enfileirar a próxima etapa canônica;
+- ao falhar uma etapa automática, o backend deve tentar novamente a mesma etapa até 3 tentativas totais;
+- após 3 falhas da mesma etapa, o fluxo deve parar e manter a falha auditável para investigação de causa-raiz;
+- a interface deve apenas disparar o fluxo e acompanhar os status; não deve simular a orquestração no navegador.
+
 ### 4.3 Regra de diferenciação de ângulo após experimento reprovado
 
 Ao gerar a etapa `CAMPAIGN_ANGLE`, o prompt deve receber o histórico dos experimentos reprovados por 100 acessos sem envio da mesma hipótese, quando existir. A reprovação de um experimento reprova aquela materialização de mercado (público, criativo, landing, isca e formulário), mas não reprova automaticamente a hipótese estratégica.

--- a/docs/canonical/procedimento-experimento-canon.v1.md
+++ b/docs/canonical/procedimento-experimento-canon.v1.md
@@ -94,6 +94,16 @@ Regras obrigatórias:
 - após 3 falhas da mesma etapa, o fluxo deve parar e manter a falha auditável para investigação de causa-raiz;
 - a interface deve apenas disparar o fluxo e acompanhar os status; não deve simular a orquestração no navegador.
 
+### 4.2.3 Regra mandatória — passagem enriquecida `nicho-cnae → hipótese`
+
+Quando o nicho tiver sido materializado pelo pipeline `nicho-cnae`, o pipeline de hipótese deve receber, além do registro base de `market_niche`, o perfil enriquecido mais recente do nicho.
+
+Regras obrigatórias:
+- o backend deve incluir no contrato pendente da hipótese os sinais não-ofertivos do perfil enriquecido: rotina, dores, resultados desejados, oportunidades de mecanismo, evidências, fontes, persona operacional, padrões de linguagem, gatilhos comerciais, objeções e scores de qualidade/confiança;
+- o Worker AI deve colocar esses sinais no bloco de contexto das etapas Dor, Resultado, Mecanismo, Prova e Oferta, preservando-os como insumo estratégico;
+- o pipeline de hipótese deve usar esses sinais para aumentar especificidade, linguagem real, plausibilidade do mecanismo, redução de objeções e percepção de valor da oferta low-ticket;
+- a passagem enriquecida não autoriza o `nicho-cnae` a criar promessa, oferta, preço, checkout, landing ou campanha. O `nicho-cnae` permanece responsável por realidade operacional e evidências; a hipótese permanece responsável por transformar essa realidade em Dor → Resultado → Mecanismo → Prova → Oferta.
+
 ### 4.3 Regra de diferenciação de ângulo após experimento reprovado
 
 Ao gerar a etapa `CAMPAIGN_ANGLE`, o prompt deve receber o histórico dos experimentos reprovados por 100 acessos sem envio da mesma hipótese, quando existir. A reprovação de um experimento reprova aquela materialização de mercado (público, criativo, landing, isca e formulário), mas não reprova automaticamente a hipótese estratégica.

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -4511,3 +4511,10 @@
 - causa-raiz: a estrutura anterior já exigia low-ticket, mas ainda podia gerar uma oferta enxuta demais, com poucos itens e sem contraste explícito de valor percebido.
 - foi feito: adicionados ao prompt, schema, DTO e validador os conceitos de pilha de valor e percepção de valor, exigindo vários componentes úteis, complementares e produzíveis pelo Marketing Hub.
 - prevenção: o cânone passou a exigir que a oferta low-ticket comunique pacote robusto e relação de muito por pouco, sem desconto falso, urgência artificial ou ancoragem enganosa.
+
+## 2026-06-15 — Fluxo completo automático da hipótese
+
+- solicitação: adicionar botão para gerar o fluxo completo de hipótese, avançando automaticamente de Dor para Resultado, Mecanismo, Prova e Oferta, com até 3 tentativas em caso de erro.
+- causa-raiz: a tela exigia intervenção manual etapa a etapa, reduzindo velocidade operacional e deixando o encadeamento de sucesso/falha sob responsabilidade do usuário.
+- foi feito: criado endpoint backend para iniciar/retomar o fluxo completo, orquestração automática no callback de conclusão, retry automático de etapa marcada como fluxo automático e botão no frontend para disparar o fluxo.
+- prevenção: registrado no cânone que a orquestração deve ficar no backend, enquanto a interface apenas dispara e acompanha status.

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -4518,3 +4518,10 @@
 - causa-raiz: a tela exigia intervenção manual etapa a etapa, reduzindo velocidade operacional e deixando o encadeamento de sucesso/falha sob responsabilidade do usuário.
 - foi feito: criado endpoint backend para iniciar/retomar o fluxo completo, orquestração automática no callback de conclusão, retry automático de etapa marcada como fluxo automático e botão no frontend para disparar o fluxo.
 - prevenção: registrado no cânone que a orquestração deve ficar no backend, enquanto a interface apenas dispara e acompanha status.
+
+## 2026-06-15 — Passagem enriquecida nicho-cnae para hipótese
+
+- solicitação: implementar a passagem explícita dos sinais do pipeline `nicho-cnae` para o pipeline de hipótese, evitando perda de contexto útil na construção de Dor → Resultado → Mecanismo → Prova → Oferta.
+- causa-raiz: o pipeline de hipótese recebia principalmente o registro resumido de `market_niche`, enquanto o perfil enriquecido guardava rotina, linguagem, gatilhos, objeções, evidências e oportunidades de mecanismo sem entrar diretamente no prompt.
+- foi feito: o backend passou a anexar o perfil enriquecido mais recente ao contrato pendente da hipótese, e o Worker AI passou a incluir os campos enriquecidos no `CASE_DATA_BLOCK` de todas as etapas da hipótese.
+- prevenção: registrado no cânone que `nicho-cnae` deve enviar sinais operacionais/comerciais não-ofertivos, sem criar oferta prematura; a hipótese segue responsável pela transformação comercial final.

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -4497,3 +4497,17 @@
   - backend/ads-service/src/main/java/com/marketinghub/hypothesis/pain/HypothesisPainStageExecution.java
   - backend/ads-service/src/main/java/com/marketinghub/hypothesis/pain/service/HypothesisPainStageService.java
   - frontend/src/pages/hypothesis/NewHypothesisPage.tsx
+
+## 2026-06-15 — Oferta low-ticket no pipeline de hipótese
+
+- solicitação: ajustar o pipeline de hipótese para que a etapa Oferta entregue um produto low-ticket estruturado, pronto para alimentar futuras etapas de página de vendas, isca digital e campanha.
+- causa-raiz: a etapa Oferta gerava uma oferta digital plausível, mas ainda genérica demais para virar diretamente um produto de entrada vendável e materializável pelo Marketing Hub.
+- foi feito: atualizado o prompt e o schema da etapa `hypothesis-offer` para exigir posicionamento low-ticket, promessa de entrada, faixa/ancoragem de preço, entregáveis concretos, ativo de quick win, formato de produção e prontidão para a próxima etapa comercial.
+- prevenção: registrado no cânone de procedimento de experimento que a oferta da hipótese deve materializar um low-ticket digital, sem criar checkout, campanha, landing ou promessa exagerada nessa etapa.
+
+## 2026-06-15 — Pilha de valor para oferta low-ticket
+
+- solicitação: reforçar que o low-ticket do pipeline de hipótese deve parecer um pacote robusto, em que o cliente percebe que recebe muita coisa útil por um preço baixo.
+- causa-raiz: a estrutura anterior já exigia low-ticket, mas ainda podia gerar uma oferta enxuta demais, com poucos itens e sem contraste explícito de valor percebido.
+- foi feito: adicionados ao prompt, schema, DTO e validador os conceitos de pilha de valor e percepção de valor, exigindo vários componentes úteis, complementares e produzíveis pelo Marketing Hub.
+- prevenção: o cânone passou a exigir que a oferta low-ticket comunique pacote robusto e relação de muito por pouco, sem desconto falso, urgência artificial ou ancoragem enganosa.

--- a/docs/swagger/hypothesis-pain-stage-swagger.yaml
+++ b/docs/swagger/hypothesis-pain-stage-swagger.yaml
@@ -81,6 +81,12 @@ paths:
       responses:
         '200':
           description: Jobs pendentes.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/HypothesisPainPendingExecution'
   /api/internal/hypothesis-pipeline/pain/stage-executions/{idJob}/running:
     post:
       summary: Marca uma execução como em processamento.
@@ -183,6 +189,12 @@ paths:
       responses:
         '200':
           description: Jobs pendentes.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/HypothesisPainPendingExecution'
   /api/internal/hypothesis-pipeline/result/stage-executions/{idJob}/running:
     post:
       summary: Marca uma execução de resultado como em processamento.
@@ -285,6 +297,12 @@ paths:
       responses:
         '200':
           description: Jobs pendentes.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/HypothesisPainPendingExecution'
   /api/internal/hypothesis-pipeline/mechanism/stage-executions/{idJob}/running:
     post:
       summary: Marca uma execução de mecanismo como em processamento.
@@ -387,6 +405,12 @@ paths:
       responses:
         '200':
           description: Jobs pendentes.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/HypothesisPainPendingExecution'
   /api/internal/hypothesis-pipeline/proof/stage-executions/{idJob}/running:
     post:
       summary: Marca uma execução de prova como em processamento.
@@ -489,6 +513,12 @@ paths:
       responses:
         '200':
           description: Jobs pendentes.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/HypothesisPainPendingExecution'
   /api/internal/hypothesis-pipeline/offer/stage-executions/{idJob}/running:
     post:
       summary: Marca uma execução de oferta como em processamento.
@@ -552,6 +582,64 @@ components:
         finalContent: { type: string, nullable: true }
         sourceTable: { type: string }
         sourceField: { type: string }
+    HypothesisPainPendingExecution:
+      type: object
+      properties:
+        marketNicheId: { type: integer, format: int64 }
+        jobid: { type: string }
+        stageCode: { type: string }
+        status: { type: string }
+        executionRequestedAt: { type: string, format: date-time }
+        processingStartedAt: { type: string, format: date-time, nullable: true }
+        niche:
+          $ref: '#/components/schemas/HypothesisPainPendingNiche'
+        enrichmentProfile:
+          nullable: true
+          allOf:
+            - $ref: '#/components/schemas/HypothesisPainPendingEnrichmentProfile'
+        painModelResponse: { type: string, nullable: true }
+        resultModelResponse: { type: string, nullable: true }
+        mechanismModelResponse: { type: string, nullable: true }
+        proofModelResponse: { type: string, nullable: true }
+    HypothesisPainPendingNiche:
+      type: object
+      properties:
+        id: { type: integer, format: int64 }
+        name: { type: string, nullable: true }
+        description: { type: string, nullable: true }
+        demandVolume: { type: string, nullable: true }
+        promises: { type: string, nullable: true }
+        offers: { type: string, nullable: true }
+        baseSegmentation: { type: string, nullable: true }
+        interests: { type: string, nullable: true }
+        demographicFilters: { type: string, nullable: true }
+        extraTips: { type: string, nullable: true }
+    HypothesisPainPendingEnrichmentProfile:
+      type: object
+      properties:
+        id: { type: integer, format: int64 }
+        researchCycleId: { type: integer, format: int64, nullable: true }
+        cnaeCode: { type: string, nullable: true }
+        cnaeDescription: { type: string, nullable: true }
+        sourceScore: { type: number, nullable: true }
+        qualityStatus: { type: string, nullable: true }
+        specificityScore: { type: integer, nullable: true }
+        confidenceScore: { type: integer, nullable: true }
+        duplicationScore: { type: integer, nullable: true }
+        routineEvidenceScore: { type: integer, nullable: true }
+        difficultyEvidenceScore: { type: integer, nullable: true }
+        sourceDiversityScore: { type: integer, nullable: true }
+        solutionLanguageRiskScore: { type: integer, nullable: true }
+        routineSummary: { type: string, nullable: true }
+        painsSummary: { type: string, nullable: true }
+        resultsSummary: { type: string, nullable: true }
+        mechanismOpportunitiesSummary: { type: string, nullable: true }
+        evidenceSummary: { type: string, nullable: true }
+        sourceDomains: { type: string, nullable: true }
+        personaSummary: { type: string, nullable: true }
+        languagePatterns: { type: string, nullable: true }
+        commercialTriggers: { type: string, nullable: true }
+        objections: { type: string, nullable: true }
     HypothesisPainExecutionSummaryResponse:
       type: object
       properties:

--- a/frontend/src/pages/hypothesis/NewHypothesisPage.test.tsx
+++ b/frontend/src/pages/hypothesis/NewHypothesisPage.test.tsx
@@ -1,4 +1,4 @@
-import { cleanup, render, screen } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -204,5 +204,25 @@ describe("NewHypothesisPage", () => {
     expect(
       screen.getByRole("button", { name: "Iniciar construção da oferta" }),
     ).toBeDisabled();
+  });
+
+  it("starts the full hypothesis flow from the page action", async () => {
+    (axios.get as any).mockResolvedValue({ data: [] });
+    (axios.post as any).mockResolvedValue({
+      data: { jobid: "auto-flow-job", status: "INICIADO" },
+    });
+
+    renderPage();
+
+    const button = await screen.findByRole("button", {
+      name: "Gerar fluxo completo",
+    });
+    fireEvent.click(button);
+
+    await waitFor(() => {
+      expect(axios.post).toHaveBeenCalledWith(
+        "/api/niches/18/hypothesis-pipeline/full-flow/start",
+      );
+    });
   });
 });

--- a/frontend/src/pages/hypothesis/NewHypothesisPage.tsx
+++ b/frontend/src/pages/hypothesis/NewHypothesisPage.tsx
@@ -301,6 +301,7 @@ function stageIsCompleted(executions?: StageExecution[]) {
 
 export default function NewHypothesisPage() {
   const { nicheId } = useParams();
+  const queryClient = useQueryClient();
   const stageQueries = useQueries({
     queries: STAGES.map((stage) => ({
       queryKey: ["hypothesis-stage-executions", stage.slug, nicheId],
@@ -311,12 +312,7 @@ export default function NewHypothesisPage() {
         );
         return data;
       },
-      refetchInterval: (query: { state: { data?: StageExecution[] } }) => {
-        const items = query.state.data ?? [];
-        return items.some((item) => RUNNING_STATUSES.has(item.status))
-          ? 5000
-          : false;
-      },
+      refetchInterval: 5000,
     })),
   });
   const totalCostLoading = stageQueries.some((query) => query.isLoading);
@@ -326,6 +322,35 @@ export default function NewHypothesisPage() {
       const cost = parseCostUsd(item.costUsd);
       return cost === null ? total : total + cost;
     }, 0);
+  const hasRunningExecution = stageQueries.some((query) =>
+    (query.data ?? []).some((item) => RUNNING_STATUSES.has(item.status)),
+  );
+  const allStagesCompleted = STAGES.every((_, index) =>
+    stageIsCompleted(stageQueries[index]?.data),
+  );
+
+  const fullFlowMutation = useMutation({
+    mutationFn: async () => {
+      const { data } = await axios.post(
+        `/api/niches/${nicheId}/hypothesis-pipeline/full-flow/start`,
+      );
+      return data;
+    },
+    onSuccess: () => {
+      toast.success("Fluxo completo da hipótese iniciado");
+      STAGES.forEach((stage) => {
+        queryClient.invalidateQueries({
+          queryKey: ["hypothesis-stage-executions", stage.slug, nicheId],
+        });
+      });
+      queryClient.invalidateQueries({
+        queryKey: ["hypothesis-stage-total-cost", nicheId],
+      });
+    },
+    onError: () => {
+      toast.error("Não foi possível iniciar o fluxo completo da hipótese");
+    },
+  });
 
   const reportMutation = useMutation({
     mutationFn: async () => {
@@ -378,6 +403,33 @@ export default function NewHypothesisPage() {
                 <strong>Custo total geral da criação da hipótese:</strong>{" "}
                 {totalCostLoading ? "Calculando..." : formatCostUsd(totalCost)}
               </p>
+              <button
+                type="button"
+                className="btn btn-primary btn-sm"
+                disabled={
+                  !nicheId ||
+                  fullFlowMutation.isPending ||
+                  hasRunningExecution ||
+                  allStagesCompleted
+                }
+                onClick={() => fullFlowMutation.mutate()}
+              >
+                {fullFlowMutation.isPending ? (
+                  <span className="d-inline-flex align-items-center gap-2">
+                    <span
+                      className="spinner-border spinner-border-sm"
+                      aria-hidden="true"
+                    />
+                    Iniciando fluxo...
+                  </span>
+                ) : hasRunningExecution ? (
+                  "Fluxo em execução"
+                ) : allStagesCompleted ? (
+                  "Fluxo concluído"
+                ) : (
+                  "Gerar fluxo completo"
+                )}
+              </button>
               <button
                 type="button"
                 className="btn btn-outline-primary btn-sm"


### PR DESCRIPTION
### Motivation

- Make the `hypothesis-offer` stage produce a concrete low-ticket digital product that can feed landing, lead magnet and campaign stages without rework. 
- Ensure the pipeline output is explicit about positioning, entry promise, price anchoring, concrete deliverables and a clear value stack so Marketing Hub can produce the assets. 

### Description

- Added new fields to the DTO `HypothesisOfferOutput`: `offerPositioning`, `entryPromise`, `pricePositioning`, `deliverables`, `valueStack`, `valuePerception`, `quickWinAsset`, `productionFormat`, and `nextStageReadiness`, and normalized list fields to avoid nulls. 
- Expanded JSON schema `hypothesis-offer-schema.json` to require the new properties and tightened constraints for string lengths and array sizes for `deliverables`, `valueStack` and `evidenceSignals`. 
- Updated `HypothesisOfferResponseValidator` to parse and validate the new textual fields and to require non-empty `deliverables`, `valueStack` and `steps`. 
- Updated the prompt `hypothesis-offer.md`, unit test `HypothesisOfferResponseValidatorTest`, and canonical docs to reflect the low-ticket rules and expected artifacts. 

### Testing

- Ran the updated unit test `HypothesisOfferResponseValidatorTest` which verifies acceptance of a valid low-ticket JSON and rejection of invalid payloads, and the test passed. 
- Ran the module unit test suite for the Worker AI stage changes, and all executed unit tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3068c885f48321b88010257d3de80c)