### PR TITLE
Fix hypothesis pain architecture dependency

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/hypothesis/pain/provisorio/HypothesisPainEnrichmentProfileReader.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/hypothesis/pain/provisorio/HypothesisPainEnrichmentProfileReader.java
@@ -1,0 +1,56 @@
+package com.marketinghub.hypothesis.pain.provisorio;
+
+import com.marketinghub.niche.MarketNicheEnrichmentProfile;
+import com.marketinghub.repository.jpa.niche.MarketNicheEnrichmentProfileRepository;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.stereotype.Component;
+
+/** Responsabilidade: isolar a leitura provisória do perfil enriquecido usado como contexto da hipótese de dor. */
+@Component
+public class HypothesisPainEnrichmentProfileReader {
+    private final MarketNicheEnrichmentProfileRepository enrichmentProfileRepository;
+
+    /** Inicializa o leitor com o repositório de perfis enriquecidos do nicho. */
+    public HypothesisPainEnrichmentProfileReader(MarketNicheEnrichmentProfileRepository enrichmentProfileRepository) {
+        this.enrichmentProfileRepository = enrichmentProfileRepository;
+    }
+
+    /** Busca o perfil enriquecido mais recente do nicho e devolve um snapshot desacoplado. */
+    public Optional<HypothesisPainEnrichmentProfileSnapshot> findLatestByMarketNicheId(Long marketNicheId) {
+        if (marketNicheId == null) {
+            return Optional.empty();
+        }
+        return enrichmentProfileRepository.findLatestByMarketNicheIds(List.of(marketNicheId)).stream()
+                .findFirst()
+                .map(this::toSnapshot);
+    }
+
+    /** Converte a entidade persistida em snapshot de leitura para o pipeline de hipótese. */
+    private HypothesisPainEnrichmentProfileSnapshot toSnapshot(MarketNicheEnrichmentProfile profile) {
+        return new HypothesisPainEnrichmentProfileSnapshot(
+                profile.getId(),
+                profile.getResearchCycleId(),
+                profile.getCnaeCode(),
+                profile.getCnaeDescription(),
+                profile.getSourceScore(),
+                profile.getQualityStatus(),
+                profile.getSpecificityScore(),
+                profile.getConfidenceScore(),
+                profile.getDuplicationScore(),
+                profile.getRoutineEvidenceScore(),
+                profile.getDifficultyEvidenceScore(),
+                profile.getSourceDiversityScore(),
+                profile.getSolutionLanguageRiskScore(),
+                profile.getRoutineSummary(),
+                profile.getPainsSummary(),
+                profile.getResultsSummary(),
+                profile.getMechanismOpportunitiesSummary(),
+                profile.getEvidenceSummary(),
+                profile.getSourceDomains(),
+                profile.getPersonaSummary(),
+                profile.getLanguagePatterns(),
+                profile.getCommercialTriggers(),
+                profile.getObjections());
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/hypothesis/pain/provisorio/HypothesisPainEnrichmentProfileSnapshot.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/hypothesis/pain/provisorio/HypothesisPainEnrichmentProfileSnapshot.java
@@ -1,0 +1,29 @@
+package com.marketinghub.hypothesis.pain.provisorio;
+
+import java.math.BigDecimal;
+
+/** Responsabilidade: transportar os sinais enriquecidos do nicho sem expor entidade externa ao service de hipótese. */
+public record HypothesisPainEnrichmentProfileSnapshot(
+        Long id,
+        Long researchCycleId,
+        String cnaeCode,
+        String cnaeDescription,
+        BigDecimal sourceScore,
+        String qualityStatus,
+        Integer specificityScore,
+        Integer confidenceScore,
+        Integer duplicationScore,
+        Integer routineEvidenceScore,
+        Integer difficultyEvidenceScore,
+        Integer sourceDiversityScore,
+        Integer solutionLanguageRiskScore,
+        String routineSummary,
+        String painsSummary,
+        String resultsSummary,
+        String mechanismOpportunitiesSummary,
+        String evidenceSummary,
+        String sourceDomains,
+        String personaSummary,
+        String languagePatterns,
+        String commercialTriggers,
+        String objections) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/hypothesis/pain/service/HypothesisPainStageService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/hypothesis/pain/service/HypothesisPainStageService.java
@@ -2,6 +2,8 @@ package com.marketinghub.hypothesis.pain.service;
 
 import com.marketinghub.hypothesis.pain.HypothesisPainCostCalculator;
 import com.marketinghub.hypothesis.pain.HypothesisPainStageExecution;
+import com.marketinghub.hypothesis.pain.provisorio.HypothesisPainEnrichmentProfileReader;
+import com.marketinghub.hypothesis.pain.provisorio.HypothesisPainEnrichmentProfileSnapshot;
 import com.marketinghub.hypothesis.pain.service.detailStageExecution.HypothesisPainExecutionDetailResponse;
 import com.marketinghub.hypothesis.pain.service.listStageExecutions.HypothesisPainExecutionSummaryResponse;
 import com.marketinghub.hypothesis.pain.service.pending.HypothesisPainPendingEnrichmentProfile;
@@ -11,9 +13,7 @@ import com.marketinghub.hypothesis.pain.service.recebeResposta.RecebeRespostaReq
 import com.marketinghub.hypothesis.pain.service.start.HypothesisPainStartResponse;
 import com.marketinghub.hypothesis.pain.service.summary.HypothesisStageFinalSummaryResponse;
 import com.marketinghub.niche.MarketNiche;
-import com.marketinghub.niche.MarketNicheEnrichmentProfile;
 import com.marketinghub.repository.jpa.hypothesis.HypothesisPainStageExecutionRepository;
-import com.marketinghub.repository.jpa.niche.MarketNicheEnrichmentProfileRepository;
 import com.marketinghub.repository.jpa.niche.MarketNicheRepository;
 import jakarta.persistence.EntityNotFoundException;
 import java.math.BigDecimal;
@@ -61,18 +61,18 @@ public class HypothesisPainStageService {
             STATUS_WAITING_OPENAI_DISPATCH);
 
     private final MarketNicheRepository marketNicheRepository;
-    private final MarketNicheEnrichmentProfileRepository enrichmentProfileRepository;
+    private final HypothesisPainEnrichmentProfileReader enrichmentProfileReader;
     private final HypothesisPainStageExecutionRepository executionRepository;
     private final HypothesisPainCostCalculator costCalculator;
 
     /** Inicializa o serviço com os repositórios canônicos e o calculador interno de custo da etapa. */
     public HypothesisPainStageService(
             MarketNicheRepository marketNicheRepository,
-            MarketNicheEnrichmentProfileRepository enrichmentProfileRepository,
+            HypothesisPainEnrichmentProfileReader enrichmentProfileReader,
             HypothesisPainStageExecutionRepository executionRepository,
             HypothesisPainCostCalculator costCalculator) {
         this.marketNicheRepository = marketNicheRepository;
-        this.enrichmentProfileRepository = enrichmentProfileRepository;
+        this.enrichmentProfileReader = enrichmentProfileReader;
         this.executionRepository = executionRepository;
         this.costCalculator = costCalculator;
     }
@@ -764,38 +764,37 @@ public class HypothesisPainStageService {
         if (marketNicheId == null) {
             return null;
         }
-        return enrichmentProfileRepository.findLatestByMarketNicheIds(List.of(marketNicheId)).stream()
-                .findFirst()
+        return enrichmentProfileReader.findLatestByMarketNicheId(marketNicheId)
                 .map(this::toPendingEnrichmentProfile)
                 .orElse(null);
     }
 
-    /** Converte a entidade de perfil enriquecido em DTO sem expor a entidade JPA ao Worker AI. */
-    private HypothesisPainPendingEnrichmentProfile toPendingEnrichmentProfile(MarketNicheEnrichmentProfile profile) {
+    /** Converte o snapshot de perfil enriquecido em DTO sem expor entidade JPA ao Worker AI. */
+    private HypothesisPainPendingEnrichmentProfile toPendingEnrichmentProfile(HypothesisPainEnrichmentProfileSnapshot profile) {
         return new HypothesisPainPendingEnrichmentProfile(
-                profile.getId(),
-                profile.getResearchCycleId(),
-                profile.getCnaeCode(),
-                profile.getCnaeDescription(),
-                profile.getSourceScore(),
-                profile.getQualityStatus(),
-                profile.getSpecificityScore(),
-                profile.getConfidenceScore(),
-                profile.getDuplicationScore(),
-                profile.getRoutineEvidenceScore(),
-                profile.getDifficultyEvidenceScore(),
-                profile.getSourceDiversityScore(),
-                profile.getSolutionLanguageRiskScore(),
-                profile.getRoutineSummary(),
-                profile.getPainsSummary(),
-                profile.getResultsSummary(),
-                profile.getMechanismOpportunitiesSummary(),
-                profile.getEvidenceSummary(),
-                profile.getSourceDomains(),
-                profile.getPersonaSummary(),
-                profile.getLanguagePatterns(),
-                profile.getCommercialTriggers(),
-                profile.getObjections());
+                profile.id(),
+                profile.researchCycleId(),
+                profile.cnaeCode(),
+                profile.cnaeDescription(),
+                profile.sourceScore(),
+                profile.qualityStatus(),
+                profile.specificityScore(),
+                profile.confidenceScore(),
+                profile.duplicationScore(),
+                profile.routineEvidenceScore(),
+                profile.difficultyEvidenceScore(),
+                profile.sourceDiversityScore(),
+                profile.solutionLanguageRiskScore(),
+                profile.routineSummary(),
+                profile.painsSummary(),
+                profile.resultsSummary(),
+                profile.mechanismOpportunitiesSummary(),
+                profile.evidenceSummary(),
+                profile.sourceDomains(),
+                profile.personaSummary(),
+                profile.languagePatterns(),
+                profile.commercialTriggers(),
+                profile.objections());
     }
 
     /** Converte uma execução para resumo operacional. */

--- a/backend/ads-service/src/test/java/com/marketinghub/hypothesis/pain/service/HypothesisPainStageServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/hypothesis/pain/service/HypothesisPainStageServiceTest.java
@@ -9,11 +9,11 @@ import static org.mockito.Mockito.when;
 
 import com.marketinghub.hypothesis.pain.HypothesisPainCostCalculator;
 import com.marketinghub.hypothesis.pain.HypothesisPainStageExecution;
+import com.marketinghub.hypothesis.pain.provisorio.HypothesisPainEnrichmentProfileReader;
+import com.marketinghub.hypothesis.pain.provisorio.HypothesisPainEnrichmentProfileSnapshot;
 import com.marketinghub.hypothesis.pain.service.recebeResposta.RecebeRespostaRequest;
 import com.marketinghub.niche.MarketNiche;
-import com.marketinghub.niche.MarketNicheEnrichmentProfile;
 import com.marketinghub.repository.jpa.hypothesis.HypothesisPainStageExecutionRepository;
-import com.marketinghub.repository.jpa.niche.MarketNicheEnrichmentProfileRepository;
 import com.marketinghub.repository.jpa.niche.MarketNicheRepository;
 import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
@@ -35,7 +35,7 @@ class HypothesisPainStageServiceTest {
     private MarketNicheRepository marketNicheRepository;
 
     @Mock
-    private MarketNicheEnrichmentProfileRepository enrichmentProfileRepository;
+    private HypothesisPainEnrichmentProfileReader enrichmentProfileReader;
 
     @Mock
     private HypothesisPainStageExecutionRepository executionRepository;
@@ -50,7 +50,7 @@ class HypothesisPainStageServiceTest {
     void setup() {
         service = new HypothesisPainStageService(
                 marketNicheRepository,
-                enrichmentProfileRepository,
+                enrichmentProfileReader,
                 executionRepository,
                 costCalculator);
     }
@@ -151,26 +151,30 @@ class HypothesisPainStageServiceTest {
                 .status("INICIADO")
                 .executionRequestedAt(Instant.parse("2026-06-11T09:59:00Z"))
                 .build();
-        MarketNicheEnrichmentProfile profile = new MarketNicheEnrichmentProfile();
-        profile.setId(7L);
-        profile.setResearchCycleId(60L);
-        profile.setCnaeCode("9602501");
-        profile.setCnaeDescription("Cabeleireiros, manicure e pedicure");
-        profile.setSourceScore(new BigDecimal("90.00"));
-        profile.setQualityStatus("APPROVED");
-        profile.setConfidenceScore(87);
-        profile.setDifficultyEvidenceScore(91);
-        profile.setSourceDiversityScore(73);
-        profile.setRoutineSummary("Agenda, deslocamento e atendimento em domicílio.");
-        profile.setPainsSummary("Remarcações e ociosidade reduzem faturamento.");
-        profile.setResultsSummary("Agenda previsível e pacote simples de atendimento.");
-        profile.setMechanismOpportunitiesSummary("Checklists operacionais e scripts de WhatsApp.");
-        profile.setEvidenceSummary("Evidências em fontes públicas do nicho.");
-        profile.setSourceDomains("exemplo.com");
-        profile.setPersonaSummary("Manicure autônoma em domicílio.");
-        profile.setLanguagePatterns("agenda quebrada; cliente some");
-        profile.setCommercialTriggers("busca previsibilidade e redução de retrabalho");
-        profile.setObjections("medo de parecer complicado");
+        HypothesisPainEnrichmentProfileSnapshot profile = new HypothesisPainEnrichmentProfileSnapshot(
+                7L,
+                60L,
+                "9602501",
+                "Cabeleireiros, manicure e pedicure",
+                new BigDecimal("90.00"),
+                "APPROVED",
+                null,
+                87,
+                null,
+                null,
+                91,
+                73,
+                null,
+                "Agenda, deslocamento e atendimento em domicílio.",
+                "Remarcações e ociosidade reduzem faturamento.",
+                "Agenda previsível e pacote simples de atendimento.",
+                "Checklists operacionais e scripts de WhatsApp.",
+                "Evidências em fontes públicas do nicho.",
+                "exemplo.com",
+                "Manicure autônoma em domicílio.",
+                "agenda quebrada; cliente some",
+                "busca previsibilidade e redução de retrabalho",
+                "medo de parecer complicado");
 
         when(executionRepository.findTop50ByStageCodeAndStatusInAndCompletedAtIsNullAndProcessingStartedAtBeforeOrderByProcessingStartedAtAsc(
                         any(),
@@ -181,8 +185,8 @@ class HypothesisPainStageServiceTest {
                         "hypothesis-pain",
                         "INICIADO"))
                 .thenReturn(List.of(execution));
-        when(enrichmentProfileRepository.findLatestByMarketNicheIds(List.of(18L)))
-                .thenReturn(List.of(profile));
+        when(enrichmentProfileReader.findLatestByMarketNicheId(18L))
+                .thenReturn(Optional.of(profile));
 
         var pending = service.listPending();
 

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -4525,3 +4525,10 @@
 - causa-raiz: o pipeline de hipótese recebia principalmente o registro resumido de `market_niche`, enquanto o perfil enriquecido guardava rotina, linguagem, gatilhos, objeções, evidências e oportunidades de mecanismo sem entrar diretamente no prompt.
 - foi feito: o backend passou a anexar o perfil enriquecido mais recente ao contrato pendente da hipótese, e o Worker AI passou a incluir os campos enriquecidos no `CASE_DATA_BLOCK` de todas as etapas da hipótese.
 - prevenção: registrado no cânone que `nicho-cnae` deve enviar sinais operacionais/comerciais não-ofertivos, sem criar oferta prematura; a hipótese segue responsável pela transformação comercial final.
+
+## 2026-06-15 — Correção de arquitetura no pipeline Hypothesis Pain
+
+- Corrigida a violação de arquitetura em `HypothesisPainStageService`, removendo a dependência direta do service de hipótese para o repository e a entidade de perfil enriquecido de nicho.
+- Criado leitor provisório da etapa Dor para isolar a consulta ao perfil enriquecido e entregar ao service apenas um snapshot desacoplado.
+- Atualizado o teste unitário da etapa para mockar o leitor provisório e preservar a entrega dos sinais OPRM ao Worker AI.
+- Validação executada: `../mvnw -Dtest=HypothesisPainStageServiceTest,ArquiteturaTest test` no módulo `backend/ads-service`.


### PR DESCRIPTION
### Motivation
- Resolve ArchUnit violation where `HypothesisPainStageService` depended directly on `MarketNicheEnrichmentProfile` and its repository, breaking the same-stage dependency rule for hypothesis services. 
- Preserve the need to deliver OPRM enrichment signals to the Worker AI while keeping hypothesis services limited to allowed same-stage packages. 

### Description
- Replace direct repository/entity dependency in `HypothesisPainStageService` with a same-stage provisional reader by injecting `HypothesisPainEnrichmentProfileReader` instead of `MarketNicheEnrichmentProfileRepository`. 
- Add `HypothesisPainEnrichmentProfileReader` (`hypothesis.pain.provisorio`) which reads the latest enrichment profile and returns a detached `HypothesisPainEnrichmentProfileSnapshot` record. 
- Convert the snapshot to the existing pending DTO (`HypothesisPainPendingEnrichmentProfile`) inside the service and update method signatures and imports accordingly. 
- Update `HypothesisPainStageServiceTest` to mock the new reader and adjust fixtures, and add an entry to `docs/registros/experimentos.md` documenting the change. 

### Testing
- Ran `../mvnw -Dtest=HypothesisPainStageServiceTest,ArquiteturaTest test` for the `backend/ads-service` module and the test suites passed (build success). 
- Attempted `../mvnw spotless:apply` but the Spotless plugin prefix could not be resolved in this module (`No plugin found for prefix 'spotless'`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3088f6f83883218788c8f8b6356c14)