### PR TITLE
Force flex tier for hypothesis OpenAI requests

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/pipeline/hypothesispain/HypothesisPainProcessor.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/pipeline/hypothesispain/HypothesisPainProcessor.java
@@ -105,7 +105,7 @@ public class HypothesisPainProcessor implements StageProcessor<HypothesisPainInp
                         "marketNicheId", context.execution().aggregateId()));
     }
 
-    /** Serializa o corpo compatível com Responses API usando schema JSON estrito. */
+    /** Serializa o corpo compatível com Responses API usando schema JSON estrito e modo flex auditável. */
     private String buildResponsesApiRequest(String prompt, String schemaJson) {
         try {
             Object schema = objectMapper.readValue(schemaJson, Object.class);
@@ -120,6 +120,7 @@ public class HypothesisPainProcessor implements StageProcessor<HypothesisPainInp
             body.put("model", properties.model());
             body.put("input", prompt);
             body.put("text", text);
+            body.put("service_tier", "flex");
             return objectMapper.writeValueAsString(body);
         } catch (JsonProcessingException ex) {
             log.error("Could not build OpenAI Responses API request for hypothesis pain. schemaName={}", properties.schemaName(), ex);

--- a/ai-worker/src/test/java/com/marketinghub/worker/pipeline/hypothesispain/HypothesisPainProcessorTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/pipeline/hypothesispain/HypothesisPainProcessorTest.java
@@ -1,0 +1,52 @@
+package com.marketinghub.worker.pipeline.hypothesispain;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marketinghub.worker.openai.core.port.OpenAiClientPort;
+import java.lang.reflect.Method;
+import java.time.Duration;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/** Responsabilidade: validar a montagem do request OpenAI da etapa Dor da hipótese. */
+class HypothesisPainProcessorTest {
+
+    /** Deve incluir modo flex no request persistido e enviado para a Responses API. */
+    @Test
+    void shouldBuildAuditableResponsesApiRequestWithFlexServiceTier() throws Exception {
+        ObjectMapper objectMapper = new ObjectMapper();
+        HypothesisPainProcessor processor = new HypothesisPainProcessor(
+                objectMapper,
+                properties(),
+                org.mockito.Mockito.mock(OpenAiClientPort.class),
+                new HypothesisPainResponseValidator(objectMapper),
+                org.mockito.Mockito.mock(HypothesisPainBackendClient.class));
+        Method method = HypothesisPainProcessor.class.getDeclaredMethod("buildResponsesApiRequest", String.class, String.class);
+        method.setAccessible(true);
+
+        String requestJson = (String) method.invoke(processor, "Prompt", "{\"type\":\"object\"}");
+
+        Map<String, Object> request = objectMapper.readValue(requestJson, new TypeReference<>() {});
+        assertThat(request)
+                .containsEntry("model", "gpt-5.5")
+                .containsEntry("input", "Prompt")
+                .containsEntry("service_tier", "flex")
+                .containsKey("text");
+    }
+
+    /** Cria propriedades mínimas para montar o request OpenAI em teste unitário. */
+    private HypothesisPainWorkerProperties properties() {
+        return new HypothesisPainWorkerProperties(
+                true,
+                5,
+                "http://backend",
+                "/api",
+                "prompts/hypothesis-pipeline/hypothesis-pain.md",
+                "prompts/hypothesis-pipeline/hypothesis-pain-schema.json",
+                "hypothesis_pipeline_pain",
+                "gpt-5.5",
+                Duration.ofMinutes(30));
+    }
+}

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -4532,3 +4532,9 @@
 - Criado leitor provisório da etapa Dor para isolar a consulta ao perfil enriquecido e entregar ao service apenas um snapshot desacoplado.
 - Atualizado o teste unitário da etapa para mockar o leitor provisório e preservar a entrega dos sinais OPRM ao Worker AI.
 - Validação executada: `../mvnw -Dtest=HypothesisPainStageServiceTest,ArquiteturaTest test` no módulo `backend/ads-service`.
+
+## 2026-06-16 — Modo flex auditável no pipeline de hipótese
+- solicitação: garantir que os acessos ao modelo na tela de nova hipótese usem o modo flex.
+- causa-raiz tratada: o cliente comum da OpenAI já forçava `service_tier=flex` no envio final, mas o request montado pela etapa de hipótese e persistido para auditoria ainda não carregava explicitamente esse campo, deixando a execução auditável diferente do contrato operacional esperado.
+- foi feito: o `HypothesisPainProcessor` passou a montar o payload da Responses API com `service_tier=flex` desde a origem, antes da persistência no backend e antes do envio final.
+- validação: adicionado teste unitário garantindo que o request auditável da etapa Dor da hipótese contém `service_tier=flex`.


### PR DESCRIPTION
### Motivation
- Guarantee that the hypothesis pipeline (Dor) persists and exposes an auditable OpenAI `Responses` API request that matches the canonical Flex processing mode used at send-time. 
- Prevent a mismatch between the request shown in backend audits and the final call (which is required to run with `service_tier=flex`) to ensure accurate billing, observability and contract compliance.

### Description
- Modified `HypothesisPainProcessor.buildResponsesApiRequest` to inject `"service_tier": "flex"` into the serialized Responses API payload and updated the method comment to reflect the change. 
- Added a unit test `HypothesisPainProcessorTest` that reflects the expected payload contract and asserts the presence of `service_tier = flex`. 
- Recorded the change in `docs/registros/experimentos.md` describing the rationale and validation expected.

### Testing
- Added the unit test `HypothesisPainProcessorTest` to cover the new request-building behavior. 
- Attempted to run `mvn -Dtest=HypothesisPainProcessorTest,ResponsesApiOpenAiClientTest test`, but the run was blocked because Maven could not resolve `com.marketinghub:ads-service:0.0.1-SNAPSHOT` from GitHub Packages (HTTP 401). 
- Ran static checks (`git diff --check`) which completed without reporting issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a30a70cafcc8321b804219055d549ac)