### PR TITLE
Add hypothesis finalization (UI + backend) to close pipeline into BACKLOG

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/hypothesis/pain/controller/HypothesisPainStageController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/hypothesis/pain/controller/HypothesisPainStageController.java
@@ -1,5 +1,8 @@
 package com.marketinghub.hypothesis.pain.controller;
 
+import com.marketinghub.hypothesis.dto.HypothesisDto;
+import com.marketinghub.hypothesis.mapper.HypothesisMapper;
+import com.marketinghub.hypothesis.pain.service.FinalizeHypothesisRequest;
 import com.marketinghub.hypothesis.pain.service.HypothesisPainStageService;
 import com.marketinghub.hypothesis.pain.service.detailStageExecution.HypothesisPainExecutionDetailResponse;
 import com.marketinghub.hypothesis.pain.service.listStageExecutions.HypothesisPainExecutionSummaryResponse;
@@ -27,10 +30,12 @@ import org.springframework.web.bind.annotation.RestController;
 public class HypothesisPainStageController {
     private static final Logger log = LoggerFactory.getLogger(HypothesisPainStageController.class);
     private final HypothesisPainStageService service;
+    private final HypothesisMapper hypothesisMapper;
 
     /** Inicializa o controller com o serviço das etapas do pipeline de hipótese. */
-    public HypothesisPainStageController(HypothesisPainStageService service) {
+    public HypothesisPainStageController(HypothesisPainStageService service, HypothesisMapper hypothesisMapper) {
         this.service = service;
+        this.hypothesisMapper = hypothesisMapper;
     }
 
     /** Registra uma execução inicial da etapa Dor para um nicho. */
@@ -113,6 +118,14 @@ public class HypothesisPainStageController {
     @GetMapping("/niches/{nicheId}/hypothesis-pipeline/summary")
     public ResponseEntity<List<HypothesisStageFinalSummaryResponse>> finalSummary(@PathVariable Long nicheId) {
         return ResponseEntity.ok(service.listFinalSummary(nicheId));
+    }
+
+    /** Fecha o pipeline concluído como hipótese disponível no backlog para gerar experimento. */
+    @PostMapping("/niches/{nicheId}/hypothesis-pipeline/finalize")
+    public ResponseEntity<HypothesisDto> finalizeHypothesis(
+            @PathVariable Long nicheId,
+            @Valid @RequestBody FinalizeHypothesisRequest request) {
+        return ResponseEntity.status(201).body(hypothesisMapper.toDto(service.finalizeHypothesis(nicheId, request)));
     }
 
     /** Consulta detalhe auditável de uma execução da etapa Dor vinculada ao nicho. */

--- a/backend/ads-service/src/main/java/com/marketinghub/hypothesis/pain/service/FinalizeHypothesisRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/hypothesis/pain/service/FinalizeHypothesisRequest.java
@@ -1,0 +1,9 @@
+package com.marketinghub.hypothesis.pain.service;
+
+import jakarta.validation.constraints.NotBlank;
+
+/** Contrato de entrada para fechar o pipeline auditável como hipótese disponível para experimento. */
+public record FinalizeHypothesisRequest(
+        @NotBlank(message = "O nome da hipótese é obrigatório")
+        String name) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/hypothesis/pain/service/HypothesisPainStageService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/hypothesis/pain/service/HypothesisPainStageService.java
@@ -1,5 +1,9 @@
 package com.marketinghub.hypothesis.pain.service;
 
+import com.marketinghub.hypothesis.Hypothesis;
+import com.marketinghub.hypothesis.HypothesisStatus;
+import com.marketinghub.hypothesis.dto.HypothesisFrameworkDto;
+import com.marketinghub.hypothesis.framework.HypothesisFrameworkMapperSupport;
 import com.marketinghub.hypothesis.pain.HypothesisPainCostCalculator;
 import com.marketinghub.hypothesis.pain.HypothesisPainStageExecution;
 import com.marketinghub.hypothesis.pain.provisorio.HypothesisPainEnrichmentProfileReader;
@@ -14,6 +18,7 @@ import com.marketinghub.hypothesis.pain.service.start.HypothesisPainStartRespons
 import com.marketinghub.hypothesis.pain.service.summary.HypothesisStageFinalSummaryResponse;
 import com.marketinghub.niche.MarketNiche;
 import com.marketinghub.repository.jpa.hypothesis.HypothesisPainStageExecutionRepository;
+import com.marketinghub.repository.jpa.hypothesis.HypothesisRepository;
 import com.marketinghub.repository.jpa.niche.MarketNicheRepository;
 import jakarta.persistence.EntityNotFoundException;
 import java.math.BigDecimal;
@@ -64,17 +69,23 @@ public class HypothesisPainStageService {
     private final HypothesisPainEnrichmentProfileReader enrichmentProfileReader;
     private final HypothesisPainStageExecutionRepository executionRepository;
     private final HypothesisPainCostCalculator costCalculator;
+    private final HypothesisRepository hypothesisRepository;
+    private final HypothesisFrameworkMapperSupport frameworkMapperSupport;
 
     /** Inicializa o serviço com os repositórios canônicos e o calculador interno de custo da etapa. */
     public HypothesisPainStageService(
             MarketNicheRepository marketNicheRepository,
             HypothesisPainEnrichmentProfileReader enrichmentProfileReader,
             HypothesisPainStageExecutionRepository executionRepository,
-            HypothesisPainCostCalculator costCalculator) {
+            HypothesisPainCostCalculator costCalculator,
+            HypothesisRepository hypothesisRepository,
+            HypothesisFrameworkMapperSupport frameworkMapperSupport) {
         this.marketNicheRepository = marketNicheRepository;
         this.enrichmentProfileReader = enrichmentProfileReader;
         this.executionRepository = executionRepository;
         this.costCalculator = costCalculator;
+        this.hypothesisRepository = hypothesisRepository;
+        this.frameworkMapperSupport = frameworkMapperSupport;
     }
 
     /** Inicia uma nova execução manual da etapa Dor para o nicho informado. */
@@ -183,6 +194,113 @@ public class HypothesisPainStageService {
                 .status(STATUS_STARTED)
                 .idJob(toDatabaseIdJob(UUID.randomUUID().toString()))
                 .build();
+    }
+
+    /** Fecha o framework concluído em uma hipótese BACKLOG pronta para gerar experimento. */
+    @Transactional
+    public Hypothesis finalizeHypothesis(Long marketNicheId, FinalizeHypothesisRequest request) {
+        String title = normalizeHypothesisName(request.name());
+        MarketNiche niche = marketNicheRepository.findById(marketNicheId)
+                .orElseThrow(() -> new EntityNotFoundException("Market niche not found: " + marketNicheId));
+        String pain = requireCompletedStageResponse(marketNicheId, STAGE_CODE, "Dor");
+        String result = requireCompletedStageResponse(marketNicheId, RESULT_STAGE_CODE, "Resultado");
+        String mechanism = requireCompletedStageResponse(marketNicheId, MECHANISM_STAGE_CODE, "Mecanismo");
+        String proof = requireCompletedStageResponse(marketNicheId, PROOF_STAGE_CODE, "Prova");
+        String offer = requireCompletedStageResponse(marketNicheId, OFFER_STAGE_CODE, "Oferta");
+        Hypothesis hypothesis = Hypothesis.builder()
+                .marketNiche(niche)
+                .title(title)
+                .persona(niche.getName())
+                .problem(pain)
+                .promise(result)
+                .mechanism(mechanism)
+                .uniqueMechanism(mechanism)
+                .entrega(offer)
+                .successRule(proof)
+                .model(latestCompletedStageModel(marketNicheId, OFFER_STAGE_CODE))
+                .costUsd(totalCompletedCostUsd(marketNicheId))
+                .status(HypothesisStatus.BACKLOG)
+                .generatedAt(Instant.now())
+                .build();
+        frameworkMapperSupport.storeSnapshot(
+                hypothesis,
+                finalizedFramework(title, pain, result, mechanism, proof, offer),
+                null);
+        return hypothesisRepository.save(hypothesis);
+    }
+
+    /** Normaliza e valida o nome informado pelo usuário para a hipótese final. */
+    private String normalizeHypothesisName(String rawName) {
+        if (!StringUtils.hasText(rawName)) {
+            throw new IllegalStateException("Informe um nome para fechar a hipótese.");
+        }
+        return rawName.trim();
+    }
+
+    /** Exige uma resposta concluída de etapa antes de permitir fechar a hipótese. */
+    private String requireCompletedStageResponse(Long marketNicheId, String stageCode, String stageLabel) {
+        String response = latestCompletedStageResponse(marketNicheId, stageCode);
+        if (!StringUtils.hasText(response)) {
+            throw new IllegalStateException(
+                    "A etapa " + stageLabel + " precisa estar concluída antes de fechar a hipótese.");
+        }
+        return response;
+    }
+
+    /** Retorna o modelo da etapa concluída mais recente para rastreabilidade da hipótese final. */
+    private String latestCompletedStageModel(Long marketNicheId, String stageCode) {
+        return executionRepository.findTopByMarketNicheIdAndStageCodeAndStatusOrderByExecutionRequestedAtDesc(
+                        marketNicheId,
+                        stageCode,
+                        STATUS_COMPLETED)
+                .map(HypothesisPainStageExecution::getOpenAiModel)
+                .filter(StringUtils::hasText)
+                .orElse(null);
+    }
+
+    /** Soma o custo das execuções concluídas usadas para formar a hipótese final. */
+    private BigDecimal totalCompletedCostUsd(Long marketNicheId) {
+        return STAGE_SEQUENCE.stream()
+                .map(stageCode -> executionRepository
+                        .findTopByMarketNicheIdAndStageCodeAndStatusOrderByExecutionRequestedAtDesc(
+                                marketNicheId,
+                                stageCode,
+                                STATUS_COMPLETED))
+                .flatMap(Optional::stream)
+                .map(HypothesisPainStageExecution::getCostUsd)
+                .filter(cost -> cost != null)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+    }
+
+    /** Monta o snapshot canônico Dor → Resultado → Mecanismo → Prova → Oferta aprovado para experimento. */
+    private HypothesisFrameworkDto finalizedFramework(
+            String title,
+            String pain,
+            String result,
+            String mechanism,
+            String proof,
+            String offer) {
+        HypothesisFrameworkDto dto = new HypothesisFrameworkDto();
+        dto.getPain().setRoot(pain);
+        dto.getPain().setSummary(pain);
+        dto.getResult().setDesiredResult(result);
+        dto.getResult().setSummary(result);
+        dto.getMechanism().setCore(mechanism);
+        dto.getMechanism().setUnique(mechanism);
+        dto.getMechanism().setSummary(mechanism);
+        dto.getProof().setMessage(proof);
+        dto.getProof().setSummary(proof);
+        dto.getOffer().setName(title);
+        dto.getOffer().setCorePromise(result);
+        dto.getOffer().setDeliverables(offer);
+        dto.getOffer().setSummary(offer);
+        dto.getChecklist().setPainReady(Boolean.TRUE);
+        dto.getChecklist().setResultReady(Boolean.TRUE);
+        dto.getChecklist().setMechanismReady(Boolean.TRUE);
+        dto.getChecklist().setProofReady(Boolean.TRUE);
+        dto.getChecklist().setOfferReady(Boolean.TRUE);
+        dto.getChecklist().setApprovedForExperiment(Boolean.TRUE);
+        return dto;
     }
 
     /** Lista execuções da etapa Dor para o nicho informado. */

--- a/backend/ads-service/src/test/java/com/marketinghub/hypothesis/pain/service/HypothesisPainStageServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/hypothesis/pain/service/HypothesisPainStageServiceTest.java
@@ -7,6 +7,8 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marketinghub.hypothesis.framework.HypothesisFrameworkMapperSupport;
 import com.marketinghub.hypothesis.pain.HypothesisPainCostCalculator;
 import com.marketinghub.hypothesis.pain.HypothesisPainStageExecution;
 import com.marketinghub.hypothesis.pain.provisorio.HypothesisPainEnrichmentProfileReader;
@@ -14,6 +16,7 @@ import com.marketinghub.hypothesis.pain.provisorio.HypothesisPainEnrichmentProfi
 import com.marketinghub.hypothesis.pain.service.recebeResposta.RecebeRespostaRequest;
 import com.marketinghub.niche.MarketNiche;
 import com.marketinghub.repository.jpa.hypothesis.HypothesisPainStageExecutionRepository;
+import com.marketinghub.repository.jpa.hypothesis.HypothesisRepository;
 import com.marketinghub.repository.jpa.niche.MarketNicheRepository;
 import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
@@ -43,6 +46,9 @@ class HypothesisPainStageServiceTest {
     @Mock
     private HypothesisPainCostCalculator costCalculator;
 
+    @Mock
+    private HypothesisRepository hypothesisRepository;
+
     private HypothesisPainStageService service;
 
     /** Prepara o serviço com dependências isoladas para cada teste. */
@@ -52,7 +58,9 @@ class HypothesisPainStageServiceTest {
                 marketNicheRepository,
                 enrichmentProfileReader,
                 executionRepository,
-                costCalculator);
+                costCalculator,
+                hypothesisRepository,
+                new HypothesisFrameworkMapperSupport(new ObjectMapper()));
     }
 
     /** Deve atribuir ao nicho somente o delta de custo calculado para evitar soma duplicada em reprocessamentos. */

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -4538,3 +4538,4 @@
 - causa-raiz tratada: o cliente comum da OpenAI já forçava `service_tier=flex` no envio final, mas o request montado pela etapa de hipótese e persistido para auditoria ainda não carregava explicitamente esse campo, deixando a execução auditável diferente do contrato operacional esperado.
 - foi feito: o `HypothesisPainProcessor` passou a montar o payload da Responses API com `service_tier=flex` desde a origem, antes da persistência no backend e antes do envio final.
 - validação: adicionado teste unitário garantindo que o request auditável da etapa Dor da hipótese contém `service_tier=flex`.
+- 2026-06-16 02:27:20 (UTC): tela de nova hipótese passou a exigir nome para fechar o framework Dor → Resultado → Mecanismo → Prova → Oferta como hipótese BACKLOG; backend criou o endpoint /api/niches/{nicheId}/hypothesis-pipeline/finalize para consolidar as cinco etapas concluídas e disponibilizar a hipótese na criação de experimento.

--- a/docs/swagger/hypothesis-pain-stage-swagger.yaml
+++ b/docs/swagger/hypothesis-pain-stage-swagger.yaml
@@ -21,6 +21,27 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/HypothesisStageFinalSummaryResponse'
+  /api/niches/{nicheId}/hypothesis-pipeline/finalize:
+    post:
+      summary: Fecha o framework concluído como hipótese disponível para gerar experimento.
+      parameters:
+        - in: path
+          name: nicheId
+          required: true
+          schema: { type: integer, format: int64 }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/FinalizeHypothesisRequest'
+      responses:
+        '201':
+          description: Hipótese criada em BACKLOG.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/HypothesisDto'
   /api/niches/{nicheId}/hypothesis-pipeline/pain/start:
     post:
       summary: Inicia a construção auditável da dor do nicho.
@@ -582,6 +603,24 @@ components:
         finalContent: { type: string, nullable: true }
         sourceTable: { type: string }
         sourceField: { type: string }
+    FinalizeHypothesisRequest:
+      type: object
+      required: [name]
+      properties:
+        name:
+          type: string
+          description: Nome final da hipótese que aparecerá na criação de experimento.
+    HypothesisDto:
+      type: object
+      properties:
+        id: { type: string, format: uuid }
+        marketNicheId: { type: integer, format: int64, nullable: true }
+        title: { type: string }
+        problem: { type: string, nullable: true }
+        promise: { type: string, nullable: true }
+        mechanism: { type: string, nullable: true }
+        entrega: { type: string, nullable: true }
+        status: { type: string, example: BACKLOG }
     HypothesisPainPendingExecution:
       type: object
       properties:

--- a/frontend/src/pages/hypothesis/NewHypothesisPage.test.tsx
+++ b/frontend/src/pages/hypothesis/NewHypothesisPage.test.tsx
@@ -1,4 +1,10 @@
-import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+import {
+  cleanup,
+  fireEvent,
+  render,
+  screen,
+  waitFor,
+} from "@testing-library/react";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
@@ -144,6 +150,10 @@ describe("NewHypothesisPage", () => {
     expect(screen.getByText("Etapa 4 — Prova")).toBeInTheDocument();
     expect(screen.getByText("Etapa 5 — Oferta")).toBeInTheDocument();
     expect(screen.getByText(/US\$\s*0,026345/)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Nome da hipótese/)).toBeInTheDocument();
+    expect(
+      screen.getByRole("button", { name: "Fechar hipótese" }),
+    ).toBeDisabled();
     expect(
       screen.getByRole("link", { name: "Resumo do framework" }),
     ).toHaveAttribute("href", "/niches/18/hypothesis-pipeline/summary");
@@ -204,6 +214,39 @@ describe("NewHypothesisPage", () => {
     expect(
       screen.getByRole("button", { name: "Iniciar construção da oferta" }),
     ).toBeDisabled();
+  });
+
+  it("closes the completed pipeline as a backlog hypothesis", async () => {
+    (axios.get as any).mockResolvedValue({
+      data: [
+        {
+          jobid: "completed-job",
+          marketNicheId: 18,
+          status: "CONCLUIDO",
+          costUsd: 0.001,
+        },
+      ],
+    });
+    (axios.post as any).mockResolvedValue({
+      data: {
+        id: "hypothesis-id",
+        title: "Agenda recorrente",
+        status: "BACKLOG",
+      },
+    });
+
+    renderPage();
+
+    const input = await screen.findByLabelText(/Nome da hipótese/);
+    fireEvent.change(input, { target: { value: "Agenda recorrente" } });
+    fireEvent.click(screen.getByRole("button", { name: "Fechar hipótese" }));
+
+    await waitFor(() => {
+      expect(axios.post).toHaveBeenCalledWith(
+        "/api/niches/18/hypothesis-pipeline/finalize",
+        { name: "Agenda recorrente" },
+      );
+    });
   });
 
   it("starts the full hypothesis flow from the page action", async () => {

--- a/frontend/src/pages/hypothesis/NewHypothesisPage.tsx
+++ b/frontend/src/pages/hypothesis/NewHypothesisPage.tsx
@@ -1,3 +1,4 @@
+import { FormEvent, useState } from "react";
 import { Link, useParams } from "react-router-dom";
 import { useMutation, useQueries, useQueryClient } from "@tanstack/react-query";
 import axios from "axios";
@@ -325,6 +326,7 @@ export default function NewHypothesisPage() {
   const hasRunningExecution = stageQueries.some((query) =>
     (query.data ?? []).some((item) => RUNNING_STATUSES.has(item.status)),
   );
+  const [hypothesisName, setHypothesisName] = useState("");
   const allStagesCompleted = STAGES.every((_, index) =>
     stageIsCompleted(stageQueries[index]?.data),
   );
@@ -351,6 +353,34 @@ export default function NewHypothesisPage() {
       toast.error("Não foi possível iniciar o fluxo completo da hipótese");
     },
   });
+
+  const finalizeMutation = useMutation({
+    mutationFn: async () => {
+      const { data } = await axios.post(
+        `/api/niches/${nicheId}/hypothesis-pipeline/finalize`,
+        { name: hypothesisName.trim() },
+      );
+      return data;
+    },
+    onSuccess: () => {
+      toast.success("Hipótese fechada e disponível para gerar experimento.");
+      queryClient.invalidateQueries({
+        queryKey: ["niche-hypotheses", nicheId, "BACKLOG"],
+      });
+    },
+    onError: () => {
+      toast.error("Não foi possível fechar a hipótese.");
+    },
+  });
+
+  function handleFinalizeSubmit(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!hypothesisName.trim()) {
+      toast.error("Informe um nome para a hipótese.");
+      return;
+    }
+    finalizeMutation.mutate();
+  }
 
   const reportMutation = useMutation({
     mutationFn: async () => {
@@ -477,9 +507,59 @@ export default function NewHypothesisPage() {
         <div className="card-body">
           <p className="text-muted mb-3">
             Depois que dor, resultado, mecanismo, prova e oferta estiverem
-            claros, use a hipótese completa para avançar nos experimentos
-            seguindo Dor → Resultado → Mecanismo → Prova → Oferta.
+            claros, dê um nome para fechar a hipótese. Ela entrará no backlog e
+            ficará disponível na tela de criação de experimento.
           </p>
+          <form
+            className="row g-2 align-items-end mb-3"
+            onSubmit={handleFinalizeSubmit}
+          >
+            <div className="col-12 col-lg-8">
+              <label className="form-label" htmlFor="final-hypothesis-name">
+                Nome da hipótese <span className="text-danger">*</span>
+              </label>
+              <input
+                id="final-hypothesis-name"
+                className="form-control"
+                type="text"
+                value={hypothesisName}
+                onChange={(event) => setHypothesisName(event.target.value)}
+                placeholder="Ex.: Agenda recorrente sem retrabalho para manicure autônoma"
+                disabled={!allStagesCompleted || finalizeMutation.isPending}
+              />
+            </div>
+            <div className="col-12 col-lg-4">
+              <button
+                type="submit"
+                className="btn btn-success w-100"
+                disabled={
+                  !allStagesCompleted ||
+                  finalizeMutation.isPending ||
+                  !hypothesisName.trim()
+                }
+              >
+                {finalizeMutation.isPending ? (
+                  <span className="d-inline-flex align-items-center gap-2">
+                    <span
+                      className="spinner-border spinner-border-sm"
+                      aria-hidden="true"
+                    />
+                    Fechando...
+                  </span>
+                ) : (
+                  "Fechar hipótese"
+                )}
+              </button>
+            </div>
+            {!allStagesCompleted && (
+              <div className="col-12">
+                <small className="text-muted">
+                  Conclua todas as cinco etapas para liberar o fechamento da
+                  hipótese.
+                </small>
+              </div>
+            )}
+          </form>
           <div className="d-flex flex-wrap gap-2">
             <Link
               className="btn btn-primary"


### PR DESCRIPTION
### Motivation
- Allow users to close a completed Dor → Resultado → Mecanismo → Prova → Oferta pipeline by providing a final name so the result becomes a `BACKLOG` hypothesis available when creating experiments.

### Description
- Add backend endpoint `POST /api/niches/{nicheId}/hypothesis-pipeline/finalize` with request contract `FinalizeHypothesisRequest` to finalize a pipeline and persist a `Hypothesis` in `BACKLOG` status, implemented in `HypothesisPainStageService.finalizeHypothesis` and exposed in `HypothesisPainStageController`.
- Compose a canonical `HypothesisFrameworkDto` snapshot for the finalized hypothesis using `HypothesisFrameworkMapperSupport` and attribute aggregated cost/model metadata from completed stage executions; persist via `HypothesisRepository`.
- Update frontend `NewHypothesisPage` to show a required name input and `Fechar hipótese` action that calls the new endpoint, with UI blocking while stages are incomplete or request is pending and toast feedback on success/error.
- Update Swagger (`docs/swagger/hypothesis-pain-stage-swagger.yaml`), add request DTO file, adjust unit tests, and record the change in `docs/registros/experimentos.md`.

### Testing
- Ran backend targeted unit tests: `mvn -q -DskipTests compile && mvn -q -Dtest=HypothesisPainStageServiceTest test` and the focused tests passed.  
- Ran frontend tests and typecheck: `npm test -- --run src/pages/hypothesis/NewHypothesisPage.test.tsx` (Vitest) and `npm run typecheck` (`tsc --noEmit`) — Vitest tests passed and typecheck succeeded.  
- Attempted `mvn -q spotless:apply` but the Spotless plugin was not configured in the current Maven execution (observed and noted).  
- Full `mvn -q test` run was not completed due to long execution; targeted backend compile/tests and frontend test/typecheck completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a30b3c9f2bc832191b96f3891a6a50f)