### PR TITLE
Extract hypothesis finalization into dedicated service and controller

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/hypothesis/pain/controller/HypothesisPainStageController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/hypothesis/pain/controller/HypothesisPainStageController.java
@@ -1,8 +1,5 @@
 package com.marketinghub.hypothesis.pain.controller;
 
-import com.marketinghub.hypothesis.dto.HypothesisDto;
-import com.marketinghub.hypothesis.mapper.HypothesisMapper;
-import com.marketinghub.hypothesis.pain.service.FinalizeHypothesisRequest;
 import com.marketinghub.hypothesis.pain.service.HypothesisPainStageService;
 import com.marketinghub.hypothesis.pain.service.detailStageExecution.HypothesisPainExecutionDetailResponse;
 import com.marketinghub.hypothesis.pain.service.listStageExecutions.HypothesisPainExecutionSummaryResponse;
@@ -30,12 +27,10 @@ import org.springframework.web.bind.annotation.RestController;
 public class HypothesisPainStageController {
     private static final Logger log = LoggerFactory.getLogger(HypothesisPainStageController.class);
     private final HypothesisPainStageService service;
-    private final HypothesisMapper hypothesisMapper;
 
     /** Inicializa o controller com o serviço das etapas do pipeline de hipótese. */
-    public HypothesisPainStageController(HypothesisPainStageService service, HypothesisMapper hypothesisMapper) {
+    public HypothesisPainStageController(HypothesisPainStageService service) {
         this.service = service;
-        this.hypothesisMapper = hypothesisMapper;
     }
 
     /** Registra uma execução inicial da etapa Dor para um nicho. */
@@ -118,14 +113,6 @@ public class HypothesisPainStageController {
     @GetMapping("/niches/{nicheId}/hypothesis-pipeline/summary")
     public ResponseEntity<List<HypothesisStageFinalSummaryResponse>> finalSummary(@PathVariable Long nicheId) {
         return ResponseEntity.ok(service.listFinalSummary(nicheId));
-    }
-
-    /** Fecha o pipeline concluído como hipótese disponível no backlog para gerar experimento. */
-    @PostMapping("/niches/{nicheId}/hypothesis-pipeline/finalize")
-    public ResponseEntity<HypothesisDto> finalizeHypothesis(
-            @PathVariable Long nicheId,
-            @Valid @RequestBody FinalizeHypothesisRequest request) {
-        return ResponseEntity.status(201).body(hypothesisMapper.toDto(service.finalizeHypothesis(nicheId, request)));
     }
 
     /** Consulta detalhe auditável de uma execução da etapa Dor vinculada ao nicho. */

--- a/backend/ads-service/src/main/java/com/marketinghub/hypothesis/pain/service/HypothesisPainStageService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/hypothesis/pain/service/HypothesisPainStageService.java
@@ -1,9 +1,5 @@
 package com.marketinghub.hypothesis.pain.service;
 
-import com.marketinghub.hypothesis.Hypothesis;
-import com.marketinghub.hypothesis.HypothesisStatus;
-import com.marketinghub.hypothesis.dto.HypothesisFrameworkDto;
-import com.marketinghub.hypothesis.framework.HypothesisFrameworkMapperSupport;
 import com.marketinghub.hypothesis.pain.HypothesisPainCostCalculator;
 import com.marketinghub.hypothesis.pain.HypothesisPainStageExecution;
 import com.marketinghub.hypothesis.pain.provisorio.HypothesisPainEnrichmentProfileReader;
@@ -18,7 +14,6 @@ import com.marketinghub.hypothesis.pain.service.start.HypothesisPainStartRespons
 import com.marketinghub.hypothesis.pain.service.summary.HypothesisStageFinalSummaryResponse;
 import com.marketinghub.niche.MarketNiche;
 import com.marketinghub.repository.jpa.hypothesis.HypothesisPainStageExecutionRepository;
-import com.marketinghub.repository.jpa.hypothesis.HypothesisRepository;
 import com.marketinghub.repository.jpa.niche.MarketNicheRepository;
 import jakarta.persistence.EntityNotFoundException;
 import java.math.BigDecimal;
@@ -69,23 +64,17 @@ public class HypothesisPainStageService {
     private final HypothesisPainEnrichmentProfileReader enrichmentProfileReader;
     private final HypothesisPainStageExecutionRepository executionRepository;
     private final HypothesisPainCostCalculator costCalculator;
-    private final HypothesisRepository hypothesisRepository;
-    private final HypothesisFrameworkMapperSupport frameworkMapperSupport;
 
     /** Inicializa o serviço com os repositórios canônicos e o calculador interno de custo da etapa. */
     public HypothesisPainStageService(
             MarketNicheRepository marketNicheRepository,
             HypothesisPainEnrichmentProfileReader enrichmentProfileReader,
             HypothesisPainStageExecutionRepository executionRepository,
-            HypothesisPainCostCalculator costCalculator,
-            HypothesisRepository hypothesisRepository,
-            HypothesisFrameworkMapperSupport frameworkMapperSupport) {
+            HypothesisPainCostCalculator costCalculator) {
         this.marketNicheRepository = marketNicheRepository;
         this.enrichmentProfileReader = enrichmentProfileReader;
         this.executionRepository = executionRepository;
         this.costCalculator = costCalculator;
-        this.hypothesisRepository = hypothesisRepository;
-        this.frameworkMapperSupport = frameworkMapperSupport;
     }
 
     /** Inicia uma nova execução manual da etapa Dor para o nicho informado. */
@@ -194,113 +183,6 @@ public class HypothesisPainStageService {
                 .status(STATUS_STARTED)
                 .idJob(toDatabaseIdJob(UUID.randomUUID().toString()))
                 .build();
-    }
-
-    /** Fecha o framework concluído em uma hipótese BACKLOG pronta para gerar experimento. */
-    @Transactional
-    public Hypothesis finalizeHypothesis(Long marketNicheId, FinalizeHypothesisRequest request) {
-        String title = normalizeHypothesisName(request.name());
-        MarketNiche niche = marketNicheRepository.findById(marketNicheId)
-                .orElseThrow(() -> new EntityNotFoundException("Market niche not found: " + marketNicheId));
-        String pain = requireCompletedStageResponse(marketNicheId, STAGE_CODE, "Dor");
-        String result = requireCompletedStageResponse(marketNicheId, RESULT_STAGE_CODE, "Resultado");
-        String mechanism = requireCompletedStageResponse(marketNicheId, MECHANISM_STAGE_CODE, "Mecanismo");
-        String proof = requireCompletedStageResponse(marketNicheId, PROOF_STAGE_CODE, "Prova");
-        String offer = requireCompletedStageResponse(marketNicheId, OFFER_STAGE_CODE, "Oferta");
-        Hypothesis hypothesis = Hypothesis.builder()
-                .marketNiche(niche)
-                .title(title)
-                .persona(niche.getName())
-                .problem(pain)
-                .promise(result)
-                .mechanism(mechanism)
-                .uniqueMechanism(mechanism)
-                .entrega(offer)
-                .successRule(proof)
-                .model(latestCompletedStageModel(marketNicheId, OFFER_STAGE_CODE))
-                .costUsd(totalCompletedCostUsd(marketNicheId))
-                .status(HypothesisStatus.BACKLOG)
-                .generatedAt(Instant.now())
-                .build();
-        frameworkMapperSupport.storeSnapshot(
-                hypothesis,
-                finalizedFramework(title, pain, result, mechanism, proof, offer),
-                null);
-        return hypothesisRepository.save(hypothesis);
-    }
-
-    /** Normaliza e valida o nome informado pelo usuário para a hipótese final. */
-    private String normalizeHypothesisName(String rawName) {
-        if (!StringUtils.hasText(rawName)) {
-            throw new IllegalStateException("Informe um nome para fechar a hipótese.");
-        }
-        return rawName.trim();
-    }
-
-    /** Exige uma resposta concluída de etapa antes de permitir fechar a hipótese. */
-    private String requireCompletedStageResponse(Long marketNicheId, String stageCode, String stageLabel) {
-        String response = latestCompletedStageResponse(marketNicheId, stageCode);
-        if (!StringUtils.hasText(response)) {
-            throw new IllegalStateException(
-                    "A etapa " + stageLabel + " precisa estar concluída antes de fechar a hipótese.");
-        }
-        return response;
-    }
-
-    /** Retorna o modelo da etapa concluída mais recente para rastreabilidade da hipótese final. */
-    private String latestCompletedStageModel(Long marketNicheId, String stageCode) {
-        return executionRepository.findTopByMarketNicheIdAndStageCodeAndStatusOrderByExecutionRequestedAtDesc(
-                        marketNicheId,
-                        stageCode,
-                        STATUS_COMPLETED)
-                .map(HypothesisPainStageExecution::getOpenAiModel)
-                .filter(StringUtils::hasText)
-                .orElse(null);
-    }
-
-    /** Soma o custo das execuções concluídas usadas para formar a hipótese final. */
-    private BigDecimal totalCompletedCostUsd(Long marketNicheId) {
-        return STAGE_SEQUENCE.stream()
-                .map(stageCode -> executionRepository
-                        .findTopByMarketNicheIdAndStageCodeAndStatusOrderByExecutionRequestedAtDesc(
-                                marketNicheId,
-                                stageCode,
-                                STATUS_COMPLETED))
-                .flatMap(Optional::stream)
-                .map(HypothesisPainStageExecution::getCostUsd)
-                .filter(cost -> cost != null)
-                .reduce(BigDecimal.ZERO, BigDecimal::add);
-    }
-
-    /** Monta o snapshot canônico Dor → Resultado → Mecanismo → Prova → Oferta aprovado para experimento. */
-    private HypothesisFrameworkDto finalizedFramework(
-            String title,
-            String pain,
-            String result,
-            String mechanism,
-            String proof,
-            String offer) {
-        HypothesisFrameworkDto dto = new HypothesisFrameworkDto();
-        dto.getPain().setRoot(pain);
-        dto.getPain().setSummary(pain);
-        dto.getResult().setDesiredResult(result);
-        dto.getResult().setSummary(result);
-        dto.getMechanism().setCore(mechanism);
-        dto.getMechanism().setUnique(mechanism);
-        dto.getMechanism().setSummary(mechanism);
-        dto.getProof().setMessage(proof);
-        dto.getProof().setSummary(proof);
-        dto.getOffer().setName(title);
-        dto.getOffer().setCorePromise(result);
-        dto.getOffer().setDeliverables(offer);
-        dto.getOffer().setSummary(offer);
-        dto.getChecklist().setPainReady(Boolean.TRUE);
-        dto.getChecklist().setResultReady(Boolean.TRUE);
-        dto.getChecklist().setMechanismReady(Boolean.TRUE);
-        dto.getChecklist().setProofReady(Boolean.TRUE);
-        dto.getChecklist().setOfferReady(Boolean.TRUE);
-        dto.getChecklist().setApprovedForExperiment(Boolean.TRUE);
-        return dto;
     }
 
     /** Lista execuções da etapa Dor para o nicho informado. */

--- a/backend/ads-service/src/main/java/com/marketinghub/hypothesis/service/finalizeHypothesis/FinalizeHypothesisRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/hypothesis/service/finalizeHypothesis/FinalizeHypothesisRequest.java
@@ -1,8 +1,8 @@
-package com.marketinghub.hypothesis.pain.service;
+package com.marketinghub.hypothesis.service.finalizeHypothesis;
 
 import jakarta.validation.constraints.NotBlank;
 
-/** Contrato de entrada para fechar o pipeline auditável como hipótese disponível para experimento. */
+/** Contrato de entrada da etapa de fechamento que materializa o framework validado como hipótese. */
 public record FinalizeHypothesisRequest(
         @NotBlank(message = "O nome da hipótese é obrigatório")
         String name) {

--- a/backend/ads-service/src/main/java/com/marketinghub/hypothesis/service/finalizeHypothesis/HypothesisPipelineFinalizationService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/hypothesis/service/finalizeHypothesis/HypothesisPipelineFinalizationService.java
@@ -1,0 +1,171 @@
+package com.marketinghub.hypothesis.service.finalizeHypothesis;
+
+import com.marketinghub.hypothesis.Hypothesis;
+import com.marketinghub.hypothesis.HypothesisStatus;
+import com.marketinghub.hypothesis.dto.HypothesisFrameworkDto;
+import com.marketinghub.hypothesis.framework.HypothesisFrameworkMapperSupport;
+import com.marketinghub.hypothesis.pain.HypothesisPainStageExecution;
+import com.marketinghub.niche.MarketNiche;
+import com.marketinghub.repository.jpa.hypothesis.HypothesisPainStageExecutionRepository;
+import com.marketinghub.repository.jpa.hypothesis.HypothesisRepository;
+import com.marketinghub.repository.jpa.niche.MarketNicheRepository;
+import jakarta.persistence.EntityNotFoundException;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+/** Responsabilidade: executar a etapa de fechamento que transforma o framework concluído em hipótese de backlog. */
+@Service
+public class HypothesisPipelineFinalizationService {
+    private static final String STAGE_CODE = "hypothesis-pain";
+    private static final String RESULT_STAGE_CODE = "hypothesis-result";
+    private static final String MECHANISM_STAGE_CODE = "hypothesis-mechanism";
+    private static final String PROOF_STAGE_CODE = "hypothesis-proof";
+    private static final String OFFER_STAGE_CODE = "hypothesis-offer";
+    private static final String STATUS_COMPLETED = "CONCLUIDO";
+    private static final List<String> STAGE_SEQUENCE = List.of(
+            STAGE_CODE,
+            RESULT_STAGE_CODE,
+            MECHANISM_STAGE_CODE,
+            PROOF_STAGE_CODE,
+            OFFER_STAGE_CODE);
+
+    private final MarketNicheRepository marketNicheRepository;
+    private final HypothesisPainStageExecutionRepository executionRepository;
+    private final HypothesisRepository hypothesisRepository;
+    private final HypothesisFrameworkMapperSupport frameworkMapperSupport;
+
+    /** Inicializa a etapa de fechamento com os repositórios e o normalizador canônico do framework. */
+    public HypothesisPipelineFinalizationService(
+            MarketNicheRepository marketNicheRepository,
+            HypothesisPainStageExecutionRepository executionRepository,
+            HypothesisRepository hypothesisRepository,
+            HypothesisFrameworkMapperSupport frameworkMapperSupport) {
+        this.marketNicheRepository = marketNicheRepository;
+        this.executionRepository = executionRepository;
+        this.hypothesisRepository = hypothesisRepository;
+        this.frameworkMapperSupport = frameworkMapperSupport;
+    }
+
+    /** Fecha o framework concluído em uma hipótese BACKLOG pronta para gerar experimento. */
+    @Transactional
+    public Hypothesis finalizeHypothesis(Long marketNicheId, FinalizeHypothesisRequest request) {
+        String title = normalizeHypothesisName(request.name());
+        MarketNiche niche = marketNicheRepository.findById(marketNicheId)
+                .orElseThrow(() -> new EntityNotFoundException("Market niche not found: " + marketNicheId));
+        String pain = requireCompletedStageResponse(marketNicheId, STAGE_CODE, "Dor");
+        String result = requireCompletedStageResponse(marketNicheId, RESULT_STAGE_CODE, "Resultado");
+        String mechanism = requireCompletedStageResponse(marketNicheId, MECHANISM_STAGE_CODE, "Mecanismo");
+        String proof = requireCompletedStageResponse(marketNicheId, PROOF_STAGE_CODE, "Prova");
+        String offer = requireCompletedStageResponse(marketNicheId, OFFER_STAGE_CODE, "Oferta");
+        Hypothesis hypothesis = Hypothesis.builder()
+                .marketNiche(niche)
+                .title(title)
+                .persona(niche.getName())
+                .problem(pain)
+                .promise(result)
+                .mechanism(mechanism)
+                .uniqueMechanism(mechanism)
+                .entrega(offer)
+                .successRule(proof)
+                .model(latestCompletedStageModel(marketNicheId, OFFER_STAGE_CODE))
+                .costUsd(totalCompletedCostUsd(marketNicheId))
+                .status(HypothesisStatus.BACKLOG)
+                .generatedAt(Instant.now())
+                .build();
+        frameworkMapperSupport.storeSnapshot(
+                hypothesis,
+                finalizedFramework(title, pain, result, mechanism, proof, offer),
+                null);
+        return hypothesisRepository.save(hypothesis);
+    }
+
+    /** Normaliza e valida o nome informado pelo usuário para a hipótese final. */
+    private String normalizeHypothesisName(String rawName) {
+        if (!StringUtils.hasText(rawName)) {
+            throw new IllegalStateException("Informe um nome para fechar a hipótese.");
+        }
+        return rawName.trim();
+    }
+
+    /** Exige uma resposta concluída de etapa antes de permitir fechar a hipótese. */
+    private String requireCompletedStageResponse(Long marketNicheId, String stageCode, String stageLabel) {
+        String response = latestCompletedStageResponse(marketNicheId, stageCode);
+        if (!StringUtils.hasText(response)) {
+            throw new IllegalStateException(
+                    "A etapa " + stageLabel + " precisa estar concluída antes de fechar a hipótese.");
+        }
+        return response;
+    }
+
+    /** Retorna a resposta concluída mais recente de uma etapa do framework. */
+    private String latestCompletedStageResponse(Long marketNicheId, String stageCode) {
+        return executionRepository.findTopByMarketNicheIdAndStageCodeAndStatusOrderByExecutionRequestedAtDesc(
+                        marketNicheId,
+                        stageCode,
+                        STATUS_COMPLETED)
+                .map(HypothesisPainStageExecution::getModelResponse)
+                .filter(StringUtils::hasText)
+                .orElse(null);
+    }
+
+    /** Retorna o modelo da etapa concluída mais recente para rastreabilidade da hipótese final. */
+    private String latestCompletedStageModel(Long marketNicheId, String stageCode) {
+        return executionRepository.findTopByMarketNicheIdAndStageCodeAndStatusOrderByExecutionRequestedAtDesc(
+                        marketNicheId,
+                        stageCode,
+                        STATUS_COMPLETED)
+                .map(HypothesisPainStageExecution::getOpenAiModel)
+                .filter(StringUtils::hasText)
+                .orElse(null);
+    }
+
+    /** Soma o custo das execuções concluídas usadas para formar a hipótese final. */
+    private BigDecimal totalCompletedCostUsd(Long marketNicheId) {
+        return STAGE_SEQUENCE.stream()
+                .map(stageCode -> executionRepository
+                        .findTopByMarketNicheIdAndStageCodeAndStatusOrderByExecutionRequestedAtDesc(
+                                marketNicheId,
+                                stageCode,
+                                STATUS_COMPLETED))
+                .flatMap(Optional::stream)
+                .map(HypothesisPainStageExecution::getCostUsd)
+                .filter(cost -> cost != null)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+    }
+
+    /** Monta o snapshot canônico Dor → Resultado → Mecanismo → Prova → Oferta aprovado para experimento. */
+    private HypothesisFrameworkDto finalizedFramework(
+            String title,
+            String pain,
+            String result,
+            String mechanism,
+            String proof,
+            String offer) {
+        HypothesisFrameworkDto dto = new HypothesisFrameworkDto();
+        dto.getPain().setRoot(pain);
+        dto.getPain().setSummary(pain);
+        dto.getResult().setDesiredResult(result);
+        dto.getResult().setSummary(result);
+        dto.getMechanism().setCore(mechanism);
+        dto.getMechanism().setUnique(mechanism);
+        dto.getMechanism().setSummary(mechanism);
+        dto.getProof().setMessage(proof);
+        dto.getProof().setSummary(proof);
+        dto.getOffer().setName(title);
+        dto.getOffer().setCorePromise(result);
+        dto.getOffer().setDeliverables(offer);
+        dto.getOffer().setSummary(offer);
+        dto.getChecklist().setPainReady(Boolean.TRUE);
+        dto.getChecklist().setResultReady(Boolean.TRUE);
+        dto.getChecklist().setMechanismReady(Boolean.TRUE);
+        dto.getChecklist().setProofReady(Boolean.TRUE);
+        dto.getChecklist().setOfferReady(Boolean.TRUE);
+        dto.getChecklist().setApprovedForExperiment(Boolean.TRUE);
+        return dto;
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/hypothesis/web/HypothesisPipelineFinalizationController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/hypothesis/web/HypothesisPipelineFinalizationController.java
@@ -1,0 +1,38 @@
+package com.marketinghub.hypothesis.web;
+
+import com.marketinghub.hypothesis.dto.HypothesisDto;
+import com.marketinghub.hypothesis.mapper.HypothesisMapper;
+import com.marketinghub.hypothesis.service.finalizeHypothesis.FinalizeHypothesisRequest;
+import com.marketinghub.hypothesis.service.finalizeHypothesis.HypothesisPipelineFinalizationService;
+import jakarta.validation.Valid;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/** Responsabilidade: expor a etapa de fechamento do pipeline de hipótese fora da etapa Dor/Pain. */
+@RestController
+@RequestMapping("/api")
+public class HypothesisPipelineFinalizationController {
+    private final HypothesisPipelineFinalizationService finalizationService;
+    private final HypothesisMapper hypothesisMapper;
+
+    /** Inicializa o controller da etapa de fechamento com o serviço dedicado e o mapper de hipótese. */
+    public HypothesisPipelineFinalizationController(
+            HypothesisPipelineFinalizationService finalizationService,
+            HypothesisMapper hypothesisMapper) {
+        this.finalizationService = finalizationService;
+        this.hypothesisMapper = hypothesisMapper;
+    }
+
+    /** Fecha o pipeline concluído como hipótese disponível no backlog para gerar experimento. */
+    @PostMapping("/niches/{nicheId}/hypothesis-pipeline/finalize")
+    public ResponseEntity<HypothesisDto> finalizeHypothesis(
+            @PathVariable Long nicheId,
+            @Valid @RequestBody FinalizeHypothesisRequest request) {
+        return ResponseEntity.status(201)
+                .body(hypothesisMapper.toDto(finalizationService.finalizeHypothesis(nicheId, request)));
+    }
+}

--- a/backend/ads-service/src/test/java/com/marketinghub/hypothesis/pain/service/HypothesisPainStageServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/hypothesis/pain/service/HypothesisPainStageServiceTest.java
@@ -7,8 +7,6 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import com.fasterxml.jackson.databind.ObjectMapper;
-import com.marketinghub.hypothesis.framework.HypothesisFrameworkMapperSupport;
 import com.marketinghub.hypothesis.pain.HypothesisPainCostCalculator;
 import com.marketinghub.hypothesis.pain.HypothesisPainStageExecution;
 import com.marketinghub.hypothesis.pain.provisorio.HypothesisPainEnrichmentProfileReader;
@@ -16,7 +14,6 @@ import com.marketinghub.hypothesis.pain.provisorio.HypothesisPainEnrichmentProfi
 import com.marketinghub.hypothesis.pain.service.recebeResposta.RecebeRespostaRequest;
 import com.marketinghub.niche.MarketNiche;
 import com.marketinghub.repository.jpa.hypothesis.HypothesisPainStageExecutionRepository;
-import com.marketinghub.repository.jpa.hypothesis.HypothesisRepository;
 import com.marketinghub.repository.jpa.niche.MarketNicheRepository;
 import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
@@ -46,9 +43,6 @@ class HypothesisPainStageServiceTest {
     @Mock
     private HypothesisPainCostCalculator costCalculator;
 
-    @Mock
-    private HypothesisRepository hypothesisRepository;
-
     private HypothesisPainStageService service;
 
     /** Prepara o serviço com dependências isoladas para cada teste. */
@@ -58,9 +52,7 @@ class HypothesisPainStageServiceTest {
                 marketNicheRepository,
                 enrichmentProfileReader,
                 executionRepository,
-                costCalculator,
-                hypothesisRepository,
-                new HypothesisFrameworkMapperSupport(new ObjectMapper()));
+                costCalculator);
     }
 
     /** Deve atribuir ao nicho somente o delta de custo calculado para evitar soma duplicada em reprocessamentos. */

--- a/backend/ads-service/src/test/java/com/marketinghub/hypothesis/service/finalizeHypothesis/HypothesisPipelineFinalizationServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/hypothesis/service/finalizeHypothesis/HypothesisPipelineFinalizationServiceTest.java
@@ -1,0 +1,118 @@
+package com.marketinghub.hypothesis.service.finalizeHypothesis;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marketinghub.hypothesis.Hypothesis;
+import com.marketinghub.hypothesis.HypothesisStatus;
+import com.marketinghub.hypothesis.framework.HypothesisFrameworkMapperSupport;
+import com.marketinghub.hypothesis.pain.HypothesisPainStageExecution;
+import com.marketinghub.niche.MarketNiche;
+import com.marketinghub.repository.jpa.hypothesis.HypothesisPainStageExecutionRepository;
+import com.marketinghub.repository.jpa.hypothesis.HypothesisRepository;
+import com.marketinghub.repository.jpa.niche.MarketNicheRepository;
+import java.math.BigDecimal;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/** Responsabilidade: validar a etapa de fechamento do pipeline de hipótese. */
+@ExtendWith(MockitoExtension.class)
+class HypothesisPipelineFinalizationServiceTest {
+    @Mock
+    private MarketNicheRepository marketNicheRepository;
+
+    @Mock
+    private HypothesisPainStageExecutionRepository executionRepository;
+
+    @Mock
+    private HypothesisRepository hypothesisRepository;
+
+    private HypothesisPipelineFinalizationService service;
+
+    /** Prepara a etapa de fechamento com dependências isoladas para cada teste. */
+    @BeforeEach
+    void setup() {
+        service = new HypothesisPipelineFinalizationService(
+                marketNicheRepository,
+                executionRepository,
+                hypothesisRepository,
+                new HypothesisFrameworkMapperSupport(new ObjectMapper()));
+    }
+
+    /** Deve materializar o framework concluído como hipótese BACKLOG fora da etapa Dor. */
+    @Test
+    void finalizeHypothesisCreatesBacklogHypothesisFromCompletedStages() {
+        MarketNiche niche = new MarketNiche();
+        niche.setId(18L);
+        niche.setName("Salões de beleza");
+        when(marketNicheRepository.findById(18L)).thenReturn(Optional.of(niche));
+        mockCompletedStage("hypothesis-pain", "dor validada", "gpt-5.2", new BigDecimal("0.01000000"));
+        mockCompletedStage("hypothesis-result", "resultado claro", "gpt-5.2", new BigDecimal("0.02000000"));
+        mockCompletedStage("hypothesis-mechanism", "mecanismo plausível", "gpt-5.2", new BigDecimal("0.03000000"));
+        mockCompletedStage("hypothesis-proof", "prova segura", "gpt-5.2", new BigDecimal("0.04000000"));
+        mockCompletedStage("hypothesis-offer", "oferta low-ticket", "gpt-5.2", new BigDecimal("0.05000000"));
+        when(hypothesisRepository.save(any(Hypothesis.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        Hypothesis hypothesis = service.finalizeHypothesis(18L, new FinalizeHypothesisRequest(" Hipótese final "));
+
+        assertEquals("Hipótese final", hypothesis.getTitle());
+        assertEquals("Salões de beleza", hypothesis.getPersona());
+        assertEquals("dor validada", hypothesis.getProblem());
+        assertEquals("resultado claro", hypothesis.getPromise());
+        assertEquals("mecanismo plausível", hypothesis.getMechanism());
+        assertEquals("oferta low-ticket", hypothesis.getEntrega());
+        assertEquals("prova segura", hypothesis.getSuccessRule());
+        assertEquals("gpt-5.2", hypothesis.getModel());
+        assertEquals(new BigDecimal("0.15000000"), hypothesis.getCostUsd());
+        assertEquals(HypothesisStatus.BACKLOG, hypothesis.getStatus());
+        ArgumentCaptor<Hypothesis> captor = ArgumentCaptor.forClass(Hypothesis.class);
+        verify(hypothesisRepository).save(captor.capture());
+        org.assertj.core.api.Assertions.assertThat(captor.getValue().getFrameworkJson())
+                .contains("dor validada")
+                .contains("oferta low-ticket");
+    }
+
+    /** Deve bloquear o fechamento quando alguma etapa obrigatória ainda não tem resposta concluída. */
+    @Test
+    void finalizeHypothesisRequiresCompletedPainStage() {
+        MarketNiche niche = new MarketNiche();
+        niche.setId(18L);
+        when(marketNicheRepository.findById(18L)).thenReturn(Optional.of(niche));
+        when(executionRepository.findTopByMarketNicheIdAndStageCodeAndStatusOrderByExecutionRequestedAtDesc(
+                        18L,
+                        "hypothesis-pain",
+                        "CONCLUIDO"))
+                .thenReturn(Optional.empty());
+
+        IllegalStateException error = assertThrows(
+                IllegalStateException.class,
+                () -> service.finalizeHypothesis(18L, new FinalizeHypothesisRequest("Hipótese")));
+
+        assertEquals("A etapa Dor precisa estar concluída antes de fechar a hipótese.", error.getMessage());
+    }
+
+    /** Cria uma execução concluída simulada para a etapa informada. */
+    private void mockCompletedStage(String stageCode, String response, String model, BigDecimal cost) {
+        when(executionRepository.findTopByMarketNicheIdAndStageCodeAndStatusOrderByExecutionRequestedAtDesc(
+                        18L,
+                        stageCode,
+                        "CONCLUIDO"))
+                .thenReturn(Optional.of(HypothesisPainStageExecution.builder()
+                        .marketNicheId(18L)
+                        .stageCode(stageCode)
+                        .status("CONCLUIDO")
+                        .modelResponse(response)
+                        .openAiModel(model)
+                        .costUsd(cost)
+                        .build()));
+    }
+}

--- a/docs/canonical/arquitetura-etapas.md
+++ b/docs/canonical/arquitetura-etapas.md
@@ -238,3 +238,14 @@ pois isso quebra o contrato semântico do consumidor, dificulta validação por 
 de estrutura em campos como `campaignAngle`. O padrão obrigatório é: detectar conteúdo JSON válido,
 converter com `ObjectMapper`/parser equivalente, manter campos textuais como texto e registrar log com
 contexto operacional quando um campo aparentemente JSON não puder ser convertido.
+
+## Pipeline de hipótese — etapa de fechamento
+
+O fechamento do pipeline de hipótese é uma etapa própria posterior a Dor → Resultado → Mecanismo → Prova → Oferta.
+Essa etapa materializa o framework validado como uma `Hypothesis` em backlog para experimento, mas não pertence à etapa
+Dor/Pain. Portanto, services de `com.marketinghub.hypothesis.pain.service` não devem criar, normalizar ou persistir a
+hipótese final; eles devem apenas orquestrar execuções auditáveis das etapas e expor os conteúdos concluídos.
+
+A responsabilidade de fechamento deve ficar em um serviço dedicado de hipótese fora do pacote específico da etapa Dor,
+com validação explícita de que todas as etapas obrigatórias foram concluídas antes de criar a hipótese. Esse limite evita
+acoplamento indevido entre uma etapa operacional e a materialização comercial final do framework.

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -4539,3 +4539,10 @@
 - foi feito: o `HypothesisPainProcessor` passou a montar o payload da Responses API com `service_tier=flex` desde a origem, antes da persistência no backend e antes do envio final.
 - validação: adicionado teste unitário garantindo que o request auditável da etapa Dor da hipótese contém `service_tier=flex`.
 - 2026-06-16 02:27:20 (UTC): tela de nova hipótese passou a exigir nome para fechar o framework Dor → Resultado → Mecanismo → Prova → Oferta como hipótese BACKLOG; backend criou o endpoint /api/niches/{nicheId}/hypothesis-pipeline/finalize para consolidar as cinco etapas concluídas e disponibilizar a hipótese na criação de experimento.
+
+## 2026-06-16 — Fechamento como etapa própria do pipeline de hipótese
+
+- decisão: o fechamento do framework Dor → Resultado → Mecanismo → Prova → Oferta não pertence à etapa Dor/Pain; ele é uma etapa própria posterior às cinco etapas de construção da hipótese.
+- causa-raiz: `HypothesisPainStageService` estava acumulando a orquestração da etapa Dor com a materialização/persistência da hipótese final, violando o isolamento arquitetural protegido por ArchUnit.
+- foi feito: extraído o fechamento para `HypothesisPipelineFinalizationService`, mantendo o endpoint público existente e removendo de `HypothesisPainStageService` as dependências diretas de `HypothesisRepository` e `HypothesisFrameworkMapperSupport`.
+- prevenção: o cânone de arquitetura por etapa passou a declarar que o fechamento da hipótese deve ficar fora do pacote específico da etapa Dor/Pain.


### PR DESCRIPTION
### Motivation

- Separate responsibilities so the Pain stage service only orchestrates audit-able stage executions and does not materialize or persist final `Hypothesis` entities.
- Preserve architectural boundaries and avoid coupling between the Dor/Pain pipeline and the commercial hypothesis persistence logic.
- Make the finalization step a distinct, testable service that validates all required stages before creating a backlog hypothesis.

### Description

- Removed finalization responsibilities and direct dependencies on `HypothesisRepository` and `HypothesisFrameworkMapperSupport` from `HypothesisPainStageService` and removed `FinalizeHypothesisRequest` usage from the pain controller.
- Added `HypothesisPipelineFinalizationService` to perform the normalization, validation of completed stages, snapshot mapping and persistence of `Hypothesis` entities.
- Added `HypothesisPipelineFinalizationController` to expose the existing `POST /niches/{nicheId}/hypothesis-pipeline/finalize` endpoint using the new service and `HypothesisMapper` to return `HypothesisDto`.
- Moved `FinalizeHypothesisRequest` to `com.marketinghub.hypothesis.service.finalizeHypothesis` and updated tests accordingly, plus documentation updates explaining the architectural decision and the new pipeline boundary.

### Testing

- Updated `HypothesisPainStageServiceTest` to match the new constructor signature and assertions, and the test passed under unit test execution.
- Added `HypothesisPipelineFinalizationServiceTest` covering successful finalization and failure when required stages are missing, and the test passed under unit test execution.
- Ran the module unit tests for the modified classes with `mvn -Dtest=HypothesisPainStageServiceTest,HypothesisPipelineFinalizationServiceTest test` and both tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a30b9c9b6748321abbc6ad441db7554)