### PR TITLE
Agendar ciclo 2 do Hotmart para 04:10 em 16/06/2026 e atualizar testes e documentação

### DIFF
--- a/docs/canonical/mois-hotmart-mapeamento-ciclos-campos-banco.md
+++ b/docs/canonical/mois-hotmart-mapeamento-ciclos-campos-banco.md
@@ -193,7 +193,7 @@ Em resumo: o erro normalmente não está na UI; ele nasce na qualidade do campo 
 Agendamento operacional vigente no `mois-hotmart-collector`:
 
 - **Ciclo 1 (listagem):** próxima execução pontual única em **14 de junho de 2026 às 22:00**, no fuso `America/Sao_Paulo`, após a falha anterior por JWT expirado/inválido.
-- **Ciclo 2 (detalhes):** próxima execução pontual única em **13 de junho de 2026 às 12:20**, no fuso `America/Sao_Paulo`, conforme scheduler vigente do coletor.
+- **Ciclo 2 (detalhes):** próxima execução pontual única em **16 de junho de 2026 às 04:10**, no fuso `America/Sao_Paulo`, conforme scheduler vigente do coletor.
 - O cron do ciclo 1 fica hardcoded no `HotmartCollectorScheduler` para manter rastreabilidade operacional do horário combinado e possui guarda de ano para não repetir após 2026.
 
 Sequência operacional consolidada:

--- a/docs/registros/mois1.md
+++ b/docs/registros/mois1.md
@@ -1611,3 +1611,10 @@ Arquivos principais:
   - AGENTS.md
   - mois-hotmart-collector/AGENTS.md
   - docs/registros/mois1.md
+
+
+## 2026-06-16 — Reagendamento pontual do ciclo 2 Hotmart
+
+- Solicitação: agendar o ciclo 2 do Hotmart para execução hoje, 16/06/2026, às 04:10 no fuso `America/Sao_Paulo`.
+- Foi feito: atualizado o scheduler do `mois-hotmart-collector` para cron literal `0 10 4 16 6 *`, mantendo execução pontual restrita ao ano de 2026.
+- Também foi atualizado o documento canônico de mapeamento dos ciclos Hotmart para refletir o novo horário operacional.

--- a/mois-hotmart-collector/src/main/java/com/marketinghub/moishotmart/service/HotmartCollectorScheduler.java
+++ b/mois-hotmart-collector/src/main/java/com/marketinghub/moishotmart/service/HotmartCollectorScheduler.java
@@ -67,10 +67,10 @@ public class HotmartCollectorScheduler {
     }
 
     /**
-     * Executa o ciclo 2 de enriquecimento de detalhes uma única vez às 12:20 em 13 de junho de 2026, no horário de São Paulo.
+     * Executa o ciclo 2 de enriquecimento de detalhes uma única vez às 04:10 em 16 de junho de 2026, no horário de São Paulo.
      */
-    @Scheduled(cron = "0 20 12 13 6 *", zone = "America/Sao_Paulo")
-    public void collectSecondCycleAtTwelveTwentyOnJuneThirteenth2026() {
+    @Scheduled(cron = "0 10 4 16 6 *", zone = "America/Sao_Paulo")
+    public void collectSecondCycleAtFourTenOnJuneSixteenth2026() {
         if (!enabled) {
             log.info("Hotmart scheduler desabilitado por configuração.");
             return;
@@ -84,7 +84,7 @@ public class HotmartCollectorScheduler {
         }
         HotmartCollectionRequest request = new HotmartCollectionRequest(source, maxProducts);
         HotmartCollectionResponse response = collectorService.collectSecondCycleFromBackend(request);
-        log.info("Hotmart scheduler executado hora=12:20 dia=13/06 ano=2026 "
+        log.info("Hotmart scheduler executado hora=04:10 dia=16/06 ano=2026 "
                         + "timezone=America/Sao_Paulo ciclo={} status={} produtos={} mensagem={}",
                 "CICLO_2_DETALHES",
                 response.status(),

--- a/mois-hotmart-collector/src/test/java/com/marketinghub/moishotmart/service/HotmartCollectorSchedulerTest.java
+++ b/mois-hotmart-collector/src/test/java/com/marketinghub/moishotmart/service/HotmartCollectorSchedulerTest.java
@@ -25,15 +25,15 @@ class HotmartCollectorSchedulerTest {
     }
 
     /**
-     * Garante que o ciclo 2 esteja agendado para 12:20 de 13 de junho de 2026 no fuso de São Paulo.
+     * Garante que o ciclo 2 esteja agendado para 04:10 de 16 de junho de 2026 no fuso de São Paulo.
      */
     @Test
-    void shouldScheduleSecondCycleAtTwelveTwentyOnJuneThirteenth() throws NoSuchMethodException {
+    void shouldScheduleSecondCycleAtFourTenOnJuneSixteenth() throws NoSuchMethodException {
         Method method = HotmartCollectorScheduler.class
-                .getDeclaredMethod("collectSecondCycleAtTwelveTwentyOnJuneThirteenth2026");
+                .getDeclaredMethod("collectSecondCycleAtFourTenOnJuneSixteenth2026");
         Scheduled scheduled = method.getAnnotation(Scheduled.class);
 
-        assertEquals("0 20 12 13 6 *", scheduled.cron());
+        assertEquals("0 10 4 16 6 *", scheduled.cron());
         assertEquals("America/Sao_Paulo", scheduled.zone());
     }
 }


### PR DESCRIPTION
### Motivation

- Ajustar o agendamento operacional do ciclo 2 do coletor Hotmart para atender solicitação de execução pontual em 16/06/2026 às 04:10 (fuso `America/Sao_Paulo`).
- Manter rastreabilidade e proteção de execução exclusiva para o ano de 2026 conforme regra já aplicada ao ciclo 1.

### Description

- Altera o cron do ciclo 2 em `HotmartCollectorScheduler` de `"0 20 12 13 6 *"` para `"0 10 4 16 6 *"` e atualiza a `@Scheduled` e a JavaDoc para refletir `04:10` em `16/06/2026`.
- Renomeia o método para `collectSecondCycleAtFourTenOnJuneSixteenth2026` e atualiza a mensagem de log para indicar o novo horário e data.
- Atualiza o teste unitário `HotmartCollectorSchedulerTest` para buscar o novo método e verificar o `cron` `"0 10 4 16 6 *"` e a `zone` `"America/Sao_Paulo"`.
- Atualiza a documentação canônica `docs/canonical/mois-hotmart-mapeamento-ciclos-campos-banco.md` e o registro operacional `docs/registros/mois1.md` para refletir o novo agendamento do ciclo 2.

### Testing

- Executado o teste unitário `HotmartCollectorSchedulerTest` que valida os agendamentos, e ele passou com sucesso.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a30bbf95f208321a5556ab4deee8dd6)