### PR TITLE
Fix hypothesis finalization: widen `success_rule` to LONGTEXT and add migration

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/hypothesis/Hypothesis.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/hypothesis/Hypothesis.java
@@ -17,6 +17,7 @@ import java.util.HashSet;
 import java.util.Set;
 import java.util.UUID;
 
+/** Responsabilidade: representar uma hipótese comercial usada para gerar, validar e escalar experimentos de venda. */
 @Entity
 @Data
 @Builder
@@ -113,6 +114,7 @@ public class Hypothesis {
 
     /** Regra de sucesso que define se a hipótese será validada. */
     @Lob
+    @Column(name = "success_rule", columnDefinition = "LONGTEXT")
     private String successRule;
 
     @Enumerated(EnumType.STRING)

--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-16-hypothesis-success-rule-longtext.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-16-hypothesis-success-rule-longtext.yaml
@@ -1,0 +1,17 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-06-16-hypothesis-success-rule-longtext
+      author: marketinghub
+      preConditions:
+        - onFail: MARK_RAN
+        - dbms:
+            type: mysql
+        - columnExists:
+            tableName: hypothesis
+            columnName: success_rule
+      changes:
+        - sql:
+            splitStatements: true
+            stripComments: true
+            sql: |
+              ALTER TABLE hypothesis MODIFY COLUMN success_rule LONGTEXT NULL;

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -996,3 +996,6 @@ databaseChangeLog:
   - include:
       file: changesets/2026-06-15-mois-hotmart-description-longtext.yaml
       relativeToChangelogFile: true
+  - include:
+      file: changesets/2026-06-16-hypothesis-success-rule-longtext.yaml
+      relativeToChangelogFile: true

--- a/backend/ads-service/src/test/java/com/marketinghub/hypothesis/service/finalizeHypothesis/HypothesisPipelineFinalizationServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/hypothesis/service/finalizeHypothesis/HypothesisPipelineFinalizationServiceTest.java
@@ -15,6 +15,7 @@ import com.marketinghub.niche.MarketNiche;
 import com.marketinghub.repository.jpa.hypothesis.HypothesisPainStageExecutionRepository;
 import com.marketinghub.repository.jpa.hypothesis.HypothesisRepository;
 import com.marketinghub.repository.jpa.niche.MarketNicheRepository;
+import jakarta.persistence.Column;
 import java.math.BigDecimal;
 import java.util.Optional;
 import org.junit.jupiter.api.BeforeEach;
@@ -79,6 +80,15 @@ class HypothesisPipelineFinalizationServiceTest {
         org.assertj.core.api.Assertions.assertThat(captor.getValue().getFrameworkJson())
                 .contains("dor validada")
                 .contains("oferta low-ticket");
+    }
+
+    /** Deve manter a prova final compatível com respostas longas geradas pela IA. */
+    @Test
+    void successRuleColumnSupportsLongAiProofResponses() throws NoSuchFieldException {
+        Column column = Hypothesis.class.getDeclaredField("successRule").getAnnotation(Column.class);
+
+        assertEquals("success_rule", column.name());
+        assertEquals("LONGTEXT", column.columnDefinition());
     }
 
     /** Deve bloquear o fechamento quando alguma etapa obrigatória ainda não tem resposta concluída. */

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -4546,3 +4546,8 @@
 - causa-raiz: `HypothesisPainStageService` estava acumulando a orquestração da etapa Dor com a materialização/persistência da hipótese final, violando o isolamento arquitetural protegido por ArchUnit.
 - foi feito: extraído o fechamento para `HypothesisPipelineFinalizationService`, mantendo o endpoint público existente e removendo de `HypothesisPainStageService` as dependências diretas de `HypothesisRepository` e `HypothesisFrameworkMapperSupport`.
 - prevenção: o cânone de arquitetura por etapa passou a declarar que o fechamento da hipótese deve ficar fora do pacote específico da etapa Dor/Pain.
+
+## 2026-06-16 — Correção do fechamento de hipótese
+
+- Corrigida a causa-raiz do erro 500 ao fechar hipótese quando a etapa Prova retornava texto longo da IA: a coluna `hypothesis.success_rule` estava limitada como `TINYTEXT`, incompatível com respostas completas do framework Dor → Resultado → Mecanismo → Prova → Oferta.
+- Adicionado changelog incremental para converter `success_rule` para `LONGTEXT`, mantendo a hipótese completa disponível para criação de experimento sem truncamento.


### PR DESCRIPTION
### Motivation
- Corrigir erro 500 ao finalizar hipótese causado por truncamento ao inserir `success_rule` (a coluna estava como `TINYTEXT`), o que impedia persistir respostas longas geradas pela IA.
- Alinhar a entidade JPA ao schema canônico para evitar divergências entre Hibernate e Liquibase no campo `success_rule`.
- Fornecer uma migração segura via Liquibase para aplicar a alteração no banco sem quebrar deploys existentes.

### Description
- Atualizada a entidade `Hypothesis` para declarar explicitamente `@Column(name = "success_rule", columnDefinition = "LONGTEXT")` e adicionado comentário de responsabilidade da classe em `backend/ads-service/src/main/java/com/marketinghub/hypothesis/Hypothesis.java`.
- Adicionado changelog Liquibase `backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-16-hypothesis-success-rule-longtext.yaml` que executa `ALTER TABLE hypothesis MODIFY COLUMN success_rule LONGTEXT NULL;` e incluído no `db.changelog-master.yaml` com `relativeToChangelogFile: true`.
- Incluído teste de regressão `successRuleColumnSupportsLongAiProofResponses` em `HypothesisPipelineFinalizationServiceTest` para garantir que o mapeamento JPA use a coluna `success_rule` com `LONGTEXT`.
- Atualizado registro operacional em `docs/registros/experimentos.md` descrevendo a causa‑raiz e a correção.

### Testing
- Executado o teste unitário `HypothesisPipelineFinalizationServiceTest` com `mvn -Dtest=HypothesisPipelineFinalizationServiceTest test` no módulo `backend/ads-service`, que rodou 3 testes com 0 falhas e finalizou com `BUILD SUCCESS`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a30c74b27348321bd28fe2215961c08)