### PR TITLE
Add toast notifications for saving niche segmentation and invalidate niche-targeting-elements cache

### DIFF
--- a/frontend/src/api/niche/useUpdateNiche.ts
+++ b/frontend/src/api/niche/useUpdateNiche.ts
@@ -15,6 +15,12 @@ export function useUpdateNiche() {
     onSuccess: (niche) => {
       queryClient.setQueryData(["niche", niche.id], niche);
       queryClient.invalidateQueries({ queryKey: ["niches"] });
+      queryClient.invalidateQueries({
+        queryKey: ["niche-targeting-elements", String(niche.id)],
+      });
+      queryClient.invalidateQueries({
+        queryKey: ["niche-targeting-elements", niche.id],
+      });
     },
   });
 }

--- a/frontend/src/pages/niche/NicheDetailPage.tsx
+++ b/frontend/src/pages/niche/NicheDetailPage.tsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { Link, useParams } from "react-router-dom";
+import { toast } from "react-toastify";
 import { useNiche } from "../../api/niche/useNiche";
 import { useUpdateNiche } from "../../api/niche/useUpdateNiche";
 import { useHypothesesByNiche } from "../../api/hypothesis/useHypothesesByNiche";
@@ -774,29 +775,31 @@ export default function NicheDetailPage() {
       setBehaviorInput("");
     }
   };
+  const saveSegmentationLists = (label: string) => {
+    void toast
+      .promise(
+        updateNiche.mutateAsync({
+          ...data,
+          interestList: interestItems,
+          roleList: roleItems,
+          behaviorList: behaviorItems,
+        }),
+        {
+          pending: `Salvando ${label}...`,
+          success: `${label} salvos com sucesso.`,
+          error: `Não foi possível salvar ${label}.`,
+        },
+      )
+      .catch(() => undefined);
+  };
   const onSaveInterests = () => {
-    updateNiche.mutate({
-      ...data,
-      interestList: interestItems,
-      roleList: roleItems,
-      behaviorList: behaviorItems,
-    });
+    saveSegmentationLists("interesses");
   };
   const onSaveRoles = () => {
-    updateNiche.mutate({
-      ...data,
-      interestList: interestItems,
-      roleList: roleItems,
-      behaviorList: behaviorItems,
-    });
+    saveSegmentationLists("cargos");
   };
   const onSaveBehaviors = () => {
-    updateNiche.mutate({
-      ...data,
-      interestList: interestItems,
-      roleList: roleItems,
-      behaviorList: behaviorItems,
-    });
+    saveSegmentationLists("comportamentos");
   };
   const onRequestHypotheses = handleSubmitHypothesisRequest(
     async ({


### PR DESCRIPTION
### Motivation
- Improve UX by showing confirmation and error toasts when saving niche segmentation lists.
- Ensure related targeting-elements cache is refreshed after a niche update to keep UI data consistent.

### Description
- Added `react-toastify` `toast.promise` wrapper in `NicheDetailPage` to show pending/success/error messages when saving segmentation lists and extracted a `saveSegmentationLists` helper that calls `updateNiche.mutateAsync` and handles the toast lifecycle.
- Replaced inline `updateNiche.mutate` calls in `onSaveInterests`, `onSaveRoles`, and `onSaveBehaviors` with calls to `saveSegmentationLists` using Portuguese labels `interesses`, `cargos`, and `comportamentos`.
- Updated `useUpdateNiche` to invalidate `['niche-targeting-elements', String(niche.id)]` and `['niche-targeting-elements', niche.id]` queries in `onSuccess` so both string and numeric keyed cache entries are refreshed.

### Testing
- Ran TypeScript type check and the project build with `yarn build`, which completed successfully.
- Ran the frontend test suite with `yarn test`, and unit tests passed.
- Ran `yarn lint` to ensure formatting and lint rules are satisfied and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a30cd19ac1483219e810487f6be12fe)