### PR TITLE
Disable automatic ad creative image generation after AD_IMAGE_BRIEFING

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationService.java
@@ -6,7 +6,6 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marketinghub.ai.generation.dto.AiWorkerGenerationRequest;
 import com.marketinghub.ai.generation.service.AiWorkerGenerationService;
 import com.marketinghub.cost.CostAttributionService;
-import com.marketinghub.experiment.CreativeGenerationMode;
 import com.marketinghub.experiment.Experiment;
 import com.marketinghub.experiment.ExperimentStatus;
 import com.marketinghub.experiment.dto.ExperimentDto;
@@ -15,8 +14,6 @@ import com.marketinghub.experiment.pipeline.ExperimentPipelineGenerationJob;
 import com.marketinghub.experiment.pipeline.ExperimentPipelineGenerationJobStage;
 import com.marketinghub.experiment.pipeline.ExperimentPipelineGenerationJobStatus;
 import com.marketinghub.experiment.pipeline.ExperimentPipelineSection;
-import com.marketinghub.experiment.pipeline.ads.ExperimentPipelineAdExtractor;
-import com.marketinghub.experiment.pipeline.ads.PipelineAdCreativePlan;
 import com.marketinghub.experiment.pipeline.dto.ExperimentPipelineGenerationJobDetailDto;
 import com.marketinghub.experiment.pipeline.dto.ExperimentPipelineGenerationJobSummaryDto;
 import com.marketinghub.experiment.pipeline.dto.ExperimentPipelineGenerationRequest;
@@ -918,6 +915,7 @@ public class ExperimentPipelineGenerationService {
         }
     }
 
+    /** Encadeia apenas as próximas etapas automáticas permitidas, sem disparar imagens de anúncio sem comando explícito. */
     private void enqueueNextAutomaticStep(ExperimentPipelineGenerationJob job,
                                           ExperimentPipelineGenerationJobCompletionRequest request) {
         if (job == null || job.getExperiment() == null || job.getExperiment().getId() == null) {
@@ -934,10 +932,9 @@ public class ExperimentPipelineGenerationService {
             return;
         }
         if (section == ExperimentPipelineSection.AD_IMAGE_BRIEFING) {
-            enqueuePipelineAdCreativeImages(job.getExperiment());
             log.info("Fila automática finalizada após AD_IMAGE_BRIEFING para experimento {}. "
-                            + "Criativos de anúncio foram encaminhados para geração de imagem; "
-                            + "as etapas de Gera Landing devem ser iniciadas manualmente.",
+                            + "Criativos de anúncio não serão gerados automaticamente; "
+                            + "o usuário deve acionar a geração de imagens de anúncio explicitamente.",
                     experimentId);
             return;
         }
@@ -955,31 +952,6 @@ public class ExperimentPipelineGenerationService {
         enqueueJob(job.getExperiment(), successor, deriveFollowUpRequest(request));
     }
 
-
-    /** Encaminha a geração de imagens dos criativos usando texto e briefing já concluídos no pipeline. */
-    private void enqueuePipelineAdCreativeImages(Experiment experiment) {
-        if (experiment == null || experiment.getId() == null) {
-            return;
-        }
-        Integer pendingCreatives = experiment.getCreativesToGenerate();
-        if (pendingCreatives != null && pendingCreatives > 0) {
-            log.info("Geração de criativos já estava pendente para experimento {} (quantidade={}); não será duplicada",
-                    experiment.getId(), pendingCreatives);
-            return;
-        }
-        ExperimentPipelineAdExtractor extractor = new ExperimentPipelineAdExtractor(objectMapper);
-        List<PipelineAdCreativePlan> plans = extractor.extract(experiment);
-        if (plans.isEmpty()) {
-            log.warn("AD_IMAGE_BRIEFING concluído, mas nenhum par texto/briefing válido foi encontrado para gerar criativos do experimento {}",
-                    experiment.getId());
-            return;
-        }
-        int quantity = Math.min(3, plans.size());
-        experiment.setCreativesToGenerate(quantity);
-        experiment.setCreativeGenerationMode(CreativeGenerationMode.PIPELINE_ADS);
-        log.info("Geração de imagem dos criativos enfileirada para experimento {} a partir das etapas AD_COPY e AD_IMAGE_BRIEFING (quantidade={})",
-                experiment.getId(), quantity);
-    }
 
     private ExperimentPipelineGenerationRequest deriveFollowUpRequest(ExperimentPipelineGenerationJobCompletionRequest request) {
         ExperimentPipelineGenerationRequest followUp = new ExperimentPipelineGenerationRequest();

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationServiceTest.java
@@ -47,6 +47,7 @@ import java.math.BigDecimal;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -1275,8 +1276,9 @@ class ExperimentPipelineGenerationServiceTest {
                         && saved.getStatus() == ExperimentPipelineGenerationJobStatus.PENDING));
     }
 
+    /** Garante que concluir AD_IMAGE_BRIEFING não gera imagens de anúncio automaticamente. */
     @Test
-    void completeJobQueuesPipelineCreativeImageGenerationAfterAdImageBriefing() {
+    void completeJobDoesNotQueuePipelineCreativeImageGenerationAfterAdImageBriefing() {
         Experiment experiment = new Experiment();
         experiment.setId(316L);
         experiment.setAdCopy("""
@@ -1305,8 +1307,8 @@ class ExperimentPipelineGenerationServiceTest {
                 20,
                 null));
 
-        assertEquals(1, experiment.getCreativesToGenerate());
-        assertEquals(CreativeGenerationMode.PIPELINE_ADS, experiment.getCreativeGenerationMode());
+        assertNull(experiment.getCreativesToGenerate());
+        assertEquals(CreativeGenerationMode.DEFAULT, experiment.getCreativeGenerationMode());
     }
 
     @Test

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -1,3 +1,14 @@
+## 2026-06-16 — Bloqueio de geração automática de imagem de anúncio após AD_IMAGE_BRIEFING
+
+- solicitação: impedir que o sistema gere imagem de anúncio automaticamente ao concluir a etapa `AD_IMAGE_BRIEFING`.
+- causa-raiz: o backend enfileirava criativos `PIPELINE_ADS` imediatamente ao finalizar o briefing de imagem do anúncio, mesmo quando o usuário estava operando outro fluxo, como Gera Landing.
+- foi feito: a conclusão de `AD_IMAGE_BRIEFING` agora apenas encerra a fila automática e registra que a geração de imagens de anúncio precisa de comando explícito do usuário.
+- validação: teste unitário atualizado para garantir que `creativesToGenerate` não é preenchido e `creativeGenerationMode` não muda para `PIPELINE_ADS` ao concluir `AD_IMAGE_BRIEFING`.
+- arquivos alterados:
+  - backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationService.java
+  - backend/ads-service/src/test/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationServiceTest.java
+  - docs/registros/experimentos.md
+
 ## 2026-06-07 — Coluna de data de criação na lista de Testes de Nicho
 
 - solicitação: adicionar a coluna Data de criação na lista paginada de Testes de Nicho.


### PR DESCRIPTION
### Motivation
- Prevent the backend from automatically enqueuing ad creative image generation when the pipeline completes `AD_IMAGE_BRIEFING`, so users operating other flows (e.g. Gera Landing) are not surprised by unsolicited creative generation.  

### Description
- Remove the automatic hand-off that enqueued pipeline ad creative image generation after `AD_IMAGE_BRIEFING` by deleting `enqueuePipelineAdCreativeImages` and its invocation.  
- Update `enqueueNextAutomaticStep` to stop triggering creative image generation and to log that ad image generation requires an explicit user action.  
- Adjust unit test `ExperimentPipelineGenerationServiceTest` to reflect the new behavior by asserting that `creativesToGenerate` remains null and `creativeGenerationMode` stays at the default after `AD_IMAGE_BRIEFING`.  
- Add an entry to `docs/registros/experimentos.md` documenting the behavioral change and rationale.  

### Testing
- Updated unit test `ExperimentPipelineGenerationServiceTest` was run and passed, including `completeJobDoesNotQueuePipelineCreativeImageGenerationAfterAdImageBriefing`.  
- Project unit test suite was exercised locally with `./mvnw test` and completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a30d14e1c4483218437079caca19838)