### PR TITLE
Exibe interesses na aba Público do experimento

### DIFF
--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -4551,3 +4551,10 @@
 
 - Corrigida a causa-raiz do erro 500 ao fechar hipótese quando a etapa Prova retornava texto longo da IA: a coluna `hypothesis.success_rule` estava limitada como `TINYTEXT`, incompatível com respostas completas do framework Dor → Resultado → Mecanismo → Prova → Oferta.
 - Adicionado changelog incremental para converter `success_rule` para `LONGTEXT`, mantendo a hipótese completa disponível para criação de experimento sem truncamento.
+
+## 2026-06-16 — Exibição de interesses na aba Público do experimento
+
+- solicitação: explicar por que a aba Público do experimento exibia cargos e comportamentos, mas não exibia interesses aprovados do nicho.
+- causa-raiz: o frontend filtrava explicitamente a lista de elementos aprovados para manter apenas `JOB_TITLE` e `BEHAVIOR`, embora o endpoint do backend já retornasse também `INTEREST` para o nicho do experimento.
+- foi feito: a aba Público passou a listar interesses, cargos e comportamentos aprovados, mantendo o mesmo endpoint e o mesmo salvamento de seleção.
+- prevenção: a mensagem da tela foi atualizada para refletir todas as categorias de público disponíveis.

--- a/frontend/src/pages/experiment/ExperimentAudienceTab.tsx
+++ b/frontend/src/pages/experiment/ExperimentAudienceTab.tsx
@@ -47,8 +47,8 @@ export function ExperimentAudienceTab({
 
   const availableOptions = useMemo(
     () =>
-      (elements ?? []).filter(
-        (item) => item.type === "JOB_TITLE" || item.type === "BEHAVIOR",
+      (elements ?? []).filter((item) =>
+        ["INTEREST", "JOB_TITLE", "BEHAVIOR"].includes(item.type),
       ),
     [elements],
   );
@@ -74,6 +74,7 @@ export function ExperimentAudienceTab({
 
   const grouped = useMemo(() => {
     return {
+      INTEREST: availableOptions.filter((item) => item.type === "INTEREST"),
       JOB_TITLE: availableOptions.filter((item) => item.type === "JOB_TITLE"),
       BEHAVIOR: availableOptions.filter((item) => item.type === "BEHAVIOR"),
     };
@@ -118,7 +119,7 @@ export function ExperimentAudienceTab({
         <div>
           <h5 className="card-title mb-1">Público</h5>
           <p className="text-muted mb-0 small">
-            Marque somente cargos e comportamentos já aprovados para o nicho.
+            Marque somente interesses, cargos e comportamentos já aprovados para o nicho.
           </p>
           {alterationLocked ? (
             <div className="alert alert-secondary mt-3 mb-0" role="status">
@@ -132,12 +133,12 @@ export function ExperimentAudienceTab({
           <div className="text-muted small">Carregando opções do nicho...</div>
         ) : availableOptions.length === 0 ? (
           <div className="text-muted small">
-            Nenhum cargo/comportamento aprovado foi encontrado para este nicho.
+            Nenhum interesse, cargo ou comportamento aprovado foi encontrado para este nicho.
           </div>
         ) : (
           <div className="row g-3">
-            {(["JOB_TITLE", "BEHAVIOR"] as const).map((type) => (
-              <div key={type} className="col-12 col-lg-6">
+            {(["INTEREST", "JOB_TITLE", "BEHAVIOR"] as const).map((type) => (
+              <div key={type} className="col-12 col-lg-4">
                 <div className="border rounded p-3 h-100">
                   <h6 className="mb-2">{TYPE_LABEL[type]}</h6>
                   <div className="d-flex flex-column gap-2">


### PR DESCRIPTION
### Motivation
- Corrigir a discrepância em que a aba "Público" do experimento mostrava apenas cargos e comportamentos mesmo com interesses aprovados disponíveis no backend. 

### Description
- Atualiza o filtro em `frontend/src/pages/experiment/ExperimentAudienceTab.tsx` para incluir `INTEREST` junto com `JOB_TITLE` e `BEHAVIOR`. 
- Adiciona agrupamento e renderização para a categoria `INTEREST`, ajusta a largura das colunas e atualiza textos de UI para mencionar explicitamente "interesses, cargos e comportamentos". 
- Registra causa-raiz e correção em `docs/registros/experimentos.md` para rastreabilidade operacional.

### Testing
- Executado `npm run typecheck` no frontend e o `tsc` completou sem erros após instalação das dependências. 
- Executado `npm run build` e a build do frontend concluiu com sucesso (há aviso não bloqueante sobre chunk grande do Vite).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a30d74183bc8321bb42248915ad186e)