### PR TITLE
Desbloqueia criação de pixel antes da liberação final

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/niche/service/MarketNicheService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/niche/service/MarketNicheService.java
@@ -317,7 +317,7 @@ public class MarketNicheService {
                 .collect(Collectors.toMap(profile -> profile.getMarketNiche().getId(), Function.identity()));
     }
 
-    /** Lista nichos prontos para criação de pixel do Facebook. */
+    /** Lista nichos com experimento comercialmente pronto para criação de pixel do Facebook. */
     public List<MarketNiche> listReadyForPixel() {
         List<ExperimentStatus> statuses = List.of(
                 ExperimentStatus.PLANNED,

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/niche/MarketNicheRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/niche/MarketNicheRepository.java
@@ -97,7 +97,7 @@ public interface MarketNicheRepository extends JpaRepository<MarketNiche, Long> 
     List<MarketNiche> findAllToGenerateDetailedDescriptions();
 
     /**
-     * Lista nichos que possuem ao menos um experimento pronto para criação de pixel.
+     * Lista nichos que possuem ao menos um experimento comercialmente pronto para criação de pixel.
      */
     @Query("""
             select distinct n from MarketNiche n
@@ -108,7 +108,7 @@ public interface MarketNicheRepository extends JpaRepository<MarketNiche, Long> 
                       and e.status in :statuses
                       and e.platform = :platform
                       and e.creativeApproved = true
-                      and e.facebookReleaseRequestedAt is not null
+                      and e.followUpActionUrl is not null
               )
             """)
     List<MarketNiche> findReadyForPixel(@Param("statuses") List<ExperimentStatus> statuses,

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/ExperimentRepositoryTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/ExperimentRepositoryTest.java
@@ -69,14 +69,14 @@ class ExperimentRepositoryTest {
     }
 
     @Test
-    void findReadyForPixelIncludesReleasedExperimentsWithoutPixel() {
+    void findReadyForPixelIncludesCommerciallyReadyExperimentsWithoutPixel() {
         MarketNiche niche = nicheRepository.save(MarketNiche.builder().name("Pixel niche").build());
         Hypothesis hyp = hypothesisRepository.save(Hypothesis.builder()
                 .marketNiche(niche)
                 .title("Hypothesis")
                 .build());
         JourneyTemplate template = journeyTemplateRepository.save(JourneyTemplate.builder().name("Lifecycle").build());
-        java.time.Instant releaseTime = java.time.Instant.now();
+        MarketNiche nicheWithoutLanding = nicheRepository.save(MarketNiche.builder().name("Sem landing").build());
 
         repository.save(Experiment.builder()
                 .niche(niche)
@@ -86,7 +86,7 @@ class ExperimentRepositoryTest {
                 .platform(ExperimentPlatform.FACEBOOK)
                 .status(ExperimentStatus.PLANNED)
                 .creativeApproved(true)
-                .facebookReleaseRequestedAt(releaseTime)
+                .followUpActionUrl("https://example.test/landing-planned")
                 .build());
 
         repository.save(Experiment.builder()
@@ -97,13 +97,13 @@ class ExperimentRepositoryTest {
                 .platform(ExperimentPlatform.FACEBOOK)
                 .status(ExperimentStatus.RUNNING)
                 .creativeApproved(true)
-                .facebookReleaseRequestedAt(releaseTime)
+                .followUpActionUrl("https://example.test/landing-running")
                 .build());
 
         repository.save(Experiment.builder()
-                .niche(niche)
+                .niche(nicheWithoutLanding)
                 .hypothesisRef(hyp)
-                .name("Without release")
+                .name("Without landing")
                 .journeyTemplate(template)
                 .platform(ExperimentPlatform.FACEBOOK)
                 .status(ExperimentStatus.PAUSED)
@@ -120,7 +120,8 @@ class ExperimentRepositoryTest {
 
         assertThat(result)
                 .extracting(MarketNiche::getId)
-                .containsExactly(niche.getId());
+                .containsExactly(niche.getId())
+                .doesNotContain(nicheWithoutLanding.getId());
     }
 
     @Test

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -4569,3 +4569,9 @@
 - causa-raiz: o frontend filtrava explicitamente a lista de elementos aprovados para manter apenas `JOB_TITLE` e `BEHAVIOR`, embora o endpoint do backend já retornasse também `INTEREST` para o nicho do experimento.
 - foi feito: a aba Público passou a listar interesses, cargos e comportamentos aprovados, mantendo o mesmo endpoint e o mesmo salvamento de seleção.
 - prevenção: a mensagem da tela foi atualizada para refletir todas as categorias de público disponíveis.
+
+## 2026-06-16 — Desbloqueio de criação de pixel antes da liberação final do Experimento 39
+- solicitação: corrigir ciclo em que o Experimento 39 não podia ser liberado para o Facebook por falta de pixel, mas o nicho também não aparecia para criação de pixel por ainda não ter liberação registrada.
+- causa-raiz: a consulta de nichos prontos para pixel exigia `facebook_release_requested_at`, que é gravado justamente na liberação final; isso criava dependência circular entre criação de pixel e liberação do experimento.
+- correção aplicada: a elegibilidade para criação de pixel passou a considerar experimento Facebook com criativo aprovado e landing de destino publicada (`follow_up_action_url`), sem exigir a liberação final já registrada.
+- impacto esperado: o nicho do Experimento 39 passa a ficar disponível para criação de pixel assim que a oferta/landing estiver pronta, permitindo concluir o fluxo comercial sem contorno manual.


### PR DESCRIPTION
### Motivation
- O Experimento 39 ficava bloqueado por dependência circular: não era possível finalizar por falta de pixel e o nicho não aparecia para criação de pixel porque a query exigia `facebook_release_requested_at`; é necessário permitir criação de pixel assim que a landing publicável (`follow_up_action_url`) estiver pronta e o criativo aprovado.

### Description
- Altera a query `findReadyForPixel` em `MarketNicheRepository` para checar `e.followUpActionUrl is not null` em vez de `facebookReleaseRequestedAt is not null`.
- Atualiza o comentário do método `MarketNicheService.listReadyForPixel()` para explicar a regra comercial correta.
- Ajusta o teste `ExperimentRepositoryTest` para garantir que experimento comercialmente pronto (creativo aprovado + landing publicada) aparece para criação de pixel e que experimento sem landing não aparece.
- Registra a correção no histórico em `docs/registros/experimentos.md`.

### Testing
- Executei `mvn -q -f backend/ads-service/pom.xml -Dtest=ExperimentRepositoryTest test` e os testes relevantes passaram.
- Rodei `git diff --check` e não foram encontrados problemas de whitespace/merge.
- Tentei `mvn -q -f backend/ads-service/pom.xml spotless:check`, mas o plugin `spotless` não está disponível no ambiente de execução, portanto esse check não foi executado.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a315cbb7ae08321b62db05b93136740)