### PR TITLE
Ajusta largura dos cards de segmentação

### DIFF
--- a/frontend/src/pages/niche/NicheDetailPage.css
+++ b/frontend/src/pages/niche/NicheDetailPage.css
@@ -426,7 +426,7 @@
 }
 
 .niche-list-cards {
-  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  grid-template-columns: 1fr;
 }
 
 .niche-list-form {
@@ -489,11 +489,13 @@
 }
 
 .niche-list__item {
-  display: inline-flex;
+  display: flex;
   align-items: center;
-  gap: 0.35rem;
-  padding: 0.5rem 0.85rem;
-  border-radius: 999px;
+  justify-content: space-between;
+  gap: 0.75rem;
+  width: 100%;
+  padding: 0.65rem 0.9rem;
+  border-radius: 1rem;
   border: 1px solid var(--bs-border-color, rgba(33, 37, 41, 0.12));
   background: var(--bs-tertiary-bg, #f8f9fa);
   color: var(--bs-emphasis-color, #212529);
@@ -517,8 +519,13 @@
   border-radius: 0.75rem;
 }
 
+.niche-list__item > span:first-child {
+  flex: 1 1 auto;
+  min-width: 180px;
+}
+
 .niche-list__item span {
-  white-space: nowrap;
+  overflow-wrap: anywhere;
 }
 
 .niche-list-card__empty {


### PR DESCRIPTION
### Motivation
- Os cards da seção "Segmentações sugeridas" estavam visualmente comprimidos em colunas e o layout dos itens não aproveitava a largura disponível, prejudicando a leitura; o objetivo foi tornar os cards em largura completa para melhorar a usabilidade visual.

### Description
- Altera o comportamento da grid de segmentações para ocupar toda a largura disponível definindo `.niche-list-cards { grid-template-columns: 1fr; }` no arquivo `frontend/src/pages/niche/NicheDetailPage.css`.
- Converte cada item da lista em uma linha de largura total ajustando `.niche-list__item` para `display: flex`, `justify-content: space-between`, largura `100%`, padding e borda arredondada para melhor separação entre texto, status e ações.
- Adiciona uma regra `.niche-list__item > span:first-child { flex: 1 1 auto; min-width: 180px; }` e muda `white-space` para `overflow-wrap: anywhere` para permitir quebra de termos longos e evitar estouro visual.
- Essas alterações mantêm o estilo visual (bordas, cores e sombras) enquanto tornam a listagem mais legível em telas largas.

### Testing
- Executado `npm ci` para instalar dependências e a instalação concluiu com sucesso.
- Executado `npm run typecheck` e a checagem de tipos (`tsc --noEmit`) passou sem erros após instalar dependências.
- Executado `npm run build` (Vite) e o build de produção completou com sucesso.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a316234d9488321ac29b562261bea84)