### PR TITLE
Reagenda ciclo 2 Hotmart para 13h15

### DIFF
--- a/docs/registros/mois1.md
+++ b/docs/registros/mois1.md
@@ -1624,3 +1624,12 @@ Arquivos principais:
 - Alterado o fluxo do ciclo 2 Hotmart para buscar candidatos em endpoint próprio, separado da tela administrativa.
 - O novo endpoint retorna produtos do ciclo 1 mais recente ainda não processados por ciclos 2 anteriores, evitando repetir os mesmos registros em reexecuções.
 - A comparação considera `reference_id`, `product_url`, `sales_page_url` e combinação título + produtor para cobrir produtos sem `ucode` estável.
+
+## 2026-06-16 12:11:47 UTC-3
+- solicitação operacional: montar a próxima execução do ciclo 2 da ingestão Hotmart para hoje às 13:15.
+- raciocínio aplicado: manter a execução pontual no scheduler existente do `mois-hotmart-collector`, usando cron literal direto e timezone `America/Sao_Paulo`, sem alterar o contrato de ingestão nem o fluxo de persistência.
+- registro do que foi feito: reagendado o método do Ciclo 2 Hotmart para `16/06/2026 13:15 UTC-3`, atualizado o teste unitário que valida o cron e preservado o ciclo 1 sem mudança.
+- documentos lidos para tratar a situação:
+  - docs/canonical/mois-hotmart-mapeamento-ciclos-campos-banco.md
+  - mois-hotmart-collector/AGENTS.md
+  - docs/registros/mois1.md

--- a/mois-hotmart-collector/src/main/java/com/marketinghub/moishotmart/service/HotmartCollectorScheduler.java
+++ b/mois-hotmart-collector/src/main/java/com/marketinghub/moishotmart/service/HotmartCollectorScheduler.java
@@ -67,10 +67,10 @@ public class HotmartCollectorScheduler {
     }
 
     /**
-     * Executa o ciclo 2 de enriquecimento de detalhes uma única vez às 04:10 em 16 de junho de 2026, no horário de São Paulo.
+     * Executa o ciclo 2 de enriquecimento de detalhes uma única vez às 13:15 em 16 de junho de 2026, no horário de São Paulo.
      */
-    @Scheduled(cron = "0 10 4 16 6 *", zone = "America/Sao_Paulo")
-    public void collectSecondCycleAtFourTenOnJuneSixteenth2026() {
+    @Scheduled(cron = "0 15 13 16 6 *", zone = "America/Sao_Paulo")
+    public void collectSecondCycleAtThirteenFifteenOnJuneSixteenth2026() {
         if (!enabled) {
             log.info("Hotmart scheduler desabilitado por configuração.");
             return;
@@ -84,7 +84,7 @@ public class HotmartCollectorScheduler {
         }
         HotmartCollectionRequest request = new HotmartCollectionRequest(source, maxProducts);
         HotmartCollectionResponse response = collectorService.collectSecondCycleFromBackend(request);
-        log.info("Hotmart scheduler executado hora=04:10 dia=16/06 ano=2026 "
+        log.info("Hotmart scheduler executado hora=13:15 dia=16/06 ano=2026 "
                         + "timezone=America/Sao_Paulo ciclo={} status={} produtos={} mensagem={}",
                 "CICLO_2_DETALHES",
                 response.status(),

--- a/mois-hotmart-collector/src/test/java/com/marketinghub/moishotmart/service/HotmartCollectorSchedulerTest.java
+++ b/mois-hotmart-collector/src/test/java/com/marketinghub/moishotmart/service/HotmartCollectorSchedulerTest.java
@@ -25,15 +25,15 @@ class HotmartCollectorSchedulerTest {
     }
 
     /**
-     * Garante que o ciclo 2 esteja agendado para 04:10 de 16 de junho de 2026 no fuso de São Paulo.
+     * Garante que o ciclo 2 esteja agendado para 13:15 de 16 de junho de 2026 no fuso de São Paulo.
      */
     @Test
-    void shouldScheduleSecondCycleAtFourTenOnJuneSixteenth() throws NoSuchMethodException {
+    void shouldScheduleSecondCycleAtThirteenFifteenOnJuneSixteenth() throws NoSuchMethodException {
         Method method = HotmartCollectorScheduler.class
-                .getDeclaredMethod("collectSecondCycleAtFourTenOnJuneSixteenth2026");
+                .getDeclaredMethod("collectSecondCycleAtThirteenFifteenOnJuneSixteenth2026");
         Scheduled scheduled = method.getAnnotation(Scheduled.class);
 
-        assertEquals("0 10 4 16 6 *", scheduled.cron());
+        assertEquals("0 15 13 16 6 *", scheduled.cron());
         assertEquals("America/Sao_Paulo", scheduled.zone());
     }
 }


### PR DESCRIPTION
### Motivation
- Agendar pontualmente a próxima execução do Ciclo 2 da ingestão Hotmart para hoje (16/06/2026) às 13:15 no timezone `America/Sao_Paulo` para atender solicitação operacional.

### Description
- Atualiza o agendador `HotmartCollectorScheduler` trocando o cron do ciclo 2 para `0 15 13 16 6 *`, renomeando o método e ajustando comentário e log para refletir `13:15`.
- Ajusta o teste unitário `HotmartCollectorSchedulerTest` para validar o novo cron literal e o novo nome do método agendado.
- Adiciona um registro operacional no arquivo canônico `docs/registros/mois1.md` detalhando a ação e as fontes consultadas.

### Testing
- Executado `mvn -pl mois-hotmart-collector test` a partir da raiz, que falhou por não localizar o módulo no reactor (erro esperado ao invocar o módulo por projeto a partir da raiz). 
- Executado `mvn test` dentro de `mois-hotmart-collector`, com `BUILD SUCCESS` e `Tests run: 11, Failures: 0, Errors: 0, Skipped: 0`, validando a alteração do scheduler.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a31677e65b08321be7aa714b16d4eb8)