### PR TITLE
Add manual Facebook Pixel request flow (DB, API, worker, UI)

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/facebookads/controller/FacebookPixelController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/facebookads/controller/FacebookPixelController.java
@@ -30,12 +30,18 @@ public class FacebookPixelController {
         this.conversionService = conversionService;
     }
 
-    @GetMapping("/niches-ready")
-    // Executa a operação listNichesReadyForPixel da integração Facebook Ads.
-    public List<NichePixelDto> listNichesReadyForPixel() {
-        return marketNicheService.listReadyForPixel().stream()
+    @GetMapping("/pending")
+    // Lista as pendências de criação de pixel solicitadas pelo usuário e prontas para o worker.
+    public List<NichePixelDto> listPendingPixelRequests() {
+        return marketNicheService.listPendingPixelRequests().stream()
                 .map(niche -> new NichePixelDto(niche.getId(), niche.getName()))
                 .toList();
+    }
+
+    @PostMapping("/niches/{nicheId}/request")
+    // Registra a solicitação manual de criação de pixel para o nicho informado.
+    public MarketNicheDto requestPixel(@PathVariable("nicheId") Long nicheId) {
+        return marketNicheMapper.toDto(marketNicheService.requestFacebookPixel(nicheId));
     }
 
     @PostMapping

--- a/backend/ads-service/src/main/java/com/marketinghub/niche/MarketNiche.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/niche/MarketNiche.java
@@ -20,7 +20,7 @@ import java.time.Instant;
 import java.util.List;
 
 /**
- * Entity representing a market niche that can be tested manually or via AI.
+ * Representa um nicho de mercado usado para descoberta, experimentos e mensuração comercial.
  */
 @Entity
 @Data
@@ -51,6 +51,12 @@ public class MarketNiche {
 
     @Column(name = "facebook_pixel_created_at")
     private Instant facebookPixelCreatedAt;
+
+    @Column(name = "facebook_pixel_requested_at")
+    private Instant facebookPixelRequestedAt;
+
+    @Column(name = "facebook_pixel_request_status", length = 32)
+    private String facebookPixelRequestStatus;
 
     /** Categoria principal de interesse associada ao nicho. */
     private String interestCategory;

--- a/backend/ads-service/src/main/java/com/marketinghub/niche/dto/MarketNicheDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/niche/dto/MarketNicheDto.java
@@ -15,6 +15,8 @@ public class MarketNicheDto {
     private String facebookPixelId;
     private String facebookPixelCode;
     private Instant facebookPixelCreatedAt;
+    private Instant facebookPixelRequestedAt;
+    private String facebookPixelRequestStatus;
     private String interestCategory;
     private String roleCategory;
     private String demandVolume;

--- a/backend/ads-service/src/main/java/com/marketinghub/niche/service/MarketNicheService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/niche/service/MarketNicheService.java
@@ -33,6 +33,9 @@ import org.springframework.web.server.ResponseStatusException;
  */
 @Service
 public class MarketNicheService {
+    private static final String FACEBOOK_PIXEL_REQUEST_PENDING = "PENDING";
+    private static final String FACEBOOK_PIXEL_REQUEST_COMPLETED = "COMPLETED";
+
     private final MarketNicheRepository repository;
     private final MarketNicheEnrichmentProfileRepository enrichmentProfileRepository;
     private final ChatDialogRepository chatDialogRepository;
@@ -317,14 +320,29 @@ public class MarketNicheService {
                 .collect(Collectors.toMap(profile -> profile.getMarketNiche().getId(), Function.identity()));
     }
 
-    /** Lista nichos com experimento comercialmente pronto para criação de pixel do Facebook. */
-    public List<MarketNiche> listReadyForPixel() {
+    /** Lista nichos com solicitação pendente e experimento comercialmente pronto para criação de pixel do Facebook. */
+    public List<MarketNiche> listPendingPixelRequests() {
         List<ExperimentStatus> statuses = List.of(
                 ExperimentStatus.PLANNED,
                 ExperimentStatus.RUNNING,
                 ExperimentStatus.PAUSED
         );
-        return repository.findReadyForPixel(statuses, ExperimentPlatform.FACEBOOK);
+        return repository.findPendingPixelRequests(statuses, ExperimentPlatform.FACEBOOK);
+    }
+
+    /** Registra uma pendência para o worker criar o pixel do Facebook do nicho. */
+    @Transactional
+    public MarketNiche requestFacebookPixel(Long nicheId) {
+        MarketNiche niche = repository.findById(nicheId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Market niche not found: " + nicheId));
+        if (niche.getFacebookPixelId() != null && !niche.getFacebookPixelId().isBlank()) {
+            return niche;
+        }
+        if (niche.getFacebookPixelRequestedAt() == null) {
+            niche.setFacebookPixelRequestedAt(Instant.now());
+        }
+        niche.setFacebookPixelRequestStatus(FACEBOOK_PIXEL_REQUEST_PENDING);
+        return niche;
     }
 
     /** Vincula dados do pixel do Facebook ao nicho informado. */
@@ -338,6 +356,7 @@ public class MarketNicheService {
         niche.setFacebookPixelId(pixelId.trim());
         niche.setFacebookPixelCode(pixelCode);
         niche.setFacebookPixelCreatedAt(createdAt != null ? createdAt : Instant.now());
+        niche.setFacebookPixelRequestStatus(FACEBOOK_PIXEL_REQUEST_COMPLETED);
         return niche;
     }
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/niche/MarketNicheRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/niche/MarketNicheRepository.java
@@ -97,11 +97,13 @@ public interface MarketNicheRepository extends JpaRepository<MarketNiche, Long> 
     List<MarketNiche> findAllToGenerateDetailedDescriptions();
 
     /**
-     * Lista nichos que possuem ao menos um experimento comercialmente pronto para criação de pixel.
+     * Lista nichos que possuem solicitação pendente e ao menos um experimento comercialmente pronto para criação de pixel.
      */
     @Query("""
             select distinct n from MarketNiche n
             where n.facebookPixelId is null
+              and n.facebookPixelRequestStatus = 'PENDING'
+              and n.facebookPixelRequestedAt is not null
               and exists (
                     select 1 from Experiment e
                     where e.niche = n
@@ -111,8 +113,8 @@ public interface MarketNicheRepository extends JpaRepository<MarketNiche, Long> 
                       and e.followUpActionUrl is not null
               )
             """)
-    List<MarketNiche> findReadyForPixel(@Param("statuses") List<ExperimentStatus> statuses,
-                                       @Param("platform") ExperimentPlatform platform);
+    List<MarketNiche> findPendingPixelRequests(@Param("statuses") List<ExperimentStatus> statuses,
+                                               @Param("platform") ExperimentPlatform platform);
 
     /**
      * Incrementa o custo total acumulado de um nicho.

--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-16-niche-facebook-pixel-request.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-16-niche-facebook-pixel-request.yaml
@@ -1,0 +1,39 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-06-16-01-niche-facebook-pixel-requested-at
+      author: marketinghub
+      preConditions:
+        - onFail: MARK_RAN
+        - onError: HALT
+        - dbms:
+            type: mysql
+        - not:
+            - columnExists:
+                tableName: market_niche
+                columnName: facebook_pixel_requested_at
+      changes:
+        - addColumn:
+            tableName: market_niche
+            columns:
+              - column:
+                  name: facebook_pixel_requested_at
+                  type: TIMESTAMP
+  - changeSet:
+      id: 2026-06-16-02-niche-facebook-pixel-request-status
+      author: marketinghub
+      preConditions:
+        - onFail: MARK_RAN
+        - onError: HALT
+        - dbms:
+            type: mysql
+        - not:
+            - columnExists:
+                tableName: market_niche
+                columnName: facebook_pixel_request_status
+      changes:
+        - addColumn:
+            tableName: market_niche
+            columns:
+              - column:
+                  name: facebook_pixel_request_status
+                  type: VARCHAR(32)

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -999,3 +999,6 @@ databaseChangeLog:
   - include:
       file: changesets/2026-06-16-hypothesis-success-rule-longtext.yaml
       relativeToChangelogFile: true
+  - include:
+      file: changesets/2026-06-16-niche-facebook-pixel-request.yaml
+      relativeToChangelogFile: true

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/ExperimentRepositoryTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/ExperimentRepositoryTest.java
@@ -69,14 +69,22 @@ class ExperimentRepositoryTest {
     }
 
     @Test
-    void findReadyForPixelIncludesCommerciallyReadyExperimentsWithoutPixel() {
-        MarketNiche niche = nicheRepository.save(MarketNiche.builder().name("Pixel niche").build());
+    void findPendingPixelRequestsIncludesCommerciallyReadyExperimentsWithoutPixel() {
+        MarketNiche niche = nicheRepository.save(MarketNiche.builder()
+                .name("Pixel niche")
+                .facebookPixelRequestedAt(java.time.Instant.now())
+                .facebookPixelRequestStatus("PENDING")
+                .build());
         Hypothesis hyp = hypothesisRepository.save(Hypothesis.builder()
                 .marketNiche(niche)
                 .title("Hypothesis")
                 .build());
         JourneyTemplate template = journeyTemplateRepository.save(JourneyTemplate.builder().name("Lifecycle").build());
-        MarketNiche nicheWithoutLanding = nicheRepository.save(MarketNiche.builder().name("Sem landing").build());
+        MarketNiche nicheWithoutLanding = nicheRepository.save(MarketNiche.builder()
+                .name("Sem landing")
+                .facebookPixelRequestedAt(java.time.Instant.now())
+                .facebookPixelRequestStatus("PENDING")
+                .build());
 
         repository.save(Experiment.builder()
                 .niche(niche)
@@ -113,7 +121,7 @@ class ExperimentRepositoryTest {
         entityManager.flush();
         entityManager.clear();
 
-        java.util.List<MarketNiche> result = nicheRepository.findReadyForPixel(
+        java.util.List<MarketNiche> result = nicheRepository.findPendingPixelRequests(
                 java.util.List.of(ExperimentStatus.PLANNED, ExperimentStatus.RUNNING, ExperimentStatus.PAUSED),
                 ExperimentPlatform.FACEBOOK
         );

--- a/docs/canonical/facebook-campaign-publication-canon.v1.md
+++ b/docs/canonical/facebook-campaign-publication-canon.v1.md
@@ -67,7 +67,7 @@ Quando a Meta não retornar os limites ou o público ficar fora dessa faixa, o e
 | Criação, edição, aprovação e exclusão de registros `creative` | Módulo Experimentos | Frontend Experimentos, Worker AI |
 | Consumo de criativos aprovados para publicação Facebook | Módulo Facebook (`/api/facebook-campaigns/experiments/{experimentId}/creatives-ready`) | `facebook-ads-worker` |
 | Publicação de campanha, criação de campanha/ad set/criativos/anúncios e fallback de segmentação manual | `facebook-ads-worker` | Backend `ads-service`, Meta Marketing API |
-| Fluxo de liberação (`facebook_release_requested_at`, `status`, `market_niche.facebook_pixel_id`) | Backend `ads-service` | UI Experimentos, `facebook-ads-worker`, pixel worker |
+| Fluxo de liberação (`facebook_release_requested_at`, `status`, `market_niche.facebook_pixel_id`, `market_niche.facebook_pixel_request_status`) | Backend `ads-service` | UI Experimentos, `facebook-ads-worker`, pixel worker |
 | Geração por IA de ativos prévios (ex.: texto/imagem criativa antes da aprovação) | `ai-worker` | Backend `ads-service`, Frontend |
 | Funil de 9 etapas (`experiment_campaign_metric`, eventos do Lead Portal e checkout) | Backend `ads-service` + `lead-portal` | Frontend (aba Funil), operadores, times de mídia |
 
@@ -78,7 +78,7 @@ Quando a Meta não retornar os limites ou o público ficar fora dessa faixa, o e
 | `experiment.creative_approved`, `creative.status` | Tabelas do schema `marketinghubdb` | Ao menos um `creative` do experimento precisa estar em `READY` ou `IN_PRODUCTION` após aprovação. |
 | `experiment.follow_up_action_url` | `marketinghubdb.experiment` | Representa a landing aprovada na aba Landing; com valor preenchido, a página está publicada para uso como destino da campanha. |
 | `targeting_element` (job_title) | `marketinghubdb.targeting_element` | Para publicação manual, pelo menos **1** elemento `JOB_TITLE` com `status='APPROVED'`; quando existirem `meta_id`/`meta_key`, o `facebook-ads-worker` deve preferi-los no payload de targeting. |
-| `experiment.daily_budget`, `facebook_release_requested_at`, `funnel_reset_at`, `market_niche.facebook_pixel_id`, `status` | `marketinghubdb.experiment` | Controlam orçamento, liberação, resets e sincronismo de pixel. |
+| `experiment.daily_budget`, `facebook_release_requested_at`, `funnel_reset_at`, `market_niche.facebook_pixel_id`, `market_niche.facebook_pixel_requested_at`, `market_niche.facebook_pixel_request_status`, `status` | `marketinghubdb.experiment` | Controlam orçamento, liberação, resets e sincronismo de pixel. |
 | `experiment_campaign_metric` + eventos do Lead Portal + checkout/pagamentos | bancos do domínio de experimentos e `lead-portal` | Usados para preencher alcance, impressões, funil e custo por etapa. |
 
 ## 5. Bloqueios canônicos de publicação (diagnóstico do worker)
@@ -139,8 +139,9 @@ O cartão também lista itens operacionais que não travam o worker, mas devem s
 4. **Reprocessamentos controlados** – um novo disparo de publicação só é permitido após evidência explícita de encerramento da campanha anterior (arquivada/finalizada/erro terminal com limpeza operacional). O reprocessamento mantém o mesmo vínculo canônico de campanha do experimento e não pode duplicar campanha.
 5. **Persistência do carimbo** – `facebook_release_requested_at` permanece preenchido quando o status muda para `RUNNING` ou `PAUSED`, preservando o filtro do funil. Só muda no próximo clique autorizado de reprocessamento.
 6. **Confirmação de publicação completa** – depois que a Meta retornar sucesso para campanha, conjunto, criativo e anúncio, o `facebook-ads-worker` deve confirmar a publicação no backend por `POST /api/facebook-campaigns` enviando `status='ACTIVE'`. O backend deve persistir `facebook_ads_campaign.status='ACTIVE'` e `experiment.status='RUNNING'`; retries do mesmo `campaignId` devem apenas atualizar essa confirmação, sem recriar hierarquia.
-7. **Pixel worker** – a mesma liberação coloca o nicho na fila de criação de pixel enquanto `market_niche.facebook_pixel_id` estiver vazio. O worker consulta `/api/facebook-pixels/niches-ready` e só considera nichos com experimentos liberados (`facebook_release_requested_at` definido, `creative_approved=true`, `status IN ('PLANNED','RUNNING','PAUSED')` e plataforma Facebook). Ao registrar o pixel do nicho, todos os experimentos herdam o mesmo ID/HTML.
-8. **Execução registrada** – cada anúncio publicado referencia o valor de rastreamento (`utm_campaign`) exibido na UI junto com as conversões atribuídas.
+7. **Solicitação de pixel** – a tela do nicho registra uma pendência explícita em `market_niche.facebook_pixel_requested_at` e `market_niche.facebook_pixel_request_status='PENDING'`. O pixel deve ser criado antes da campanha usar mensuração Meta; enquanto não houver `market_niche.facebook_pixel_id`, a landing não injeta Meta Pixel.
+8. **Pixel worker** – o worker consulta `/api/facebook-pixels/pending` periodicamente e só processa pendências de nichos com experimento Facebook comercialmente pronto (`creative_approved=true`, `follow_up_action_url` preenchida, `status IN ('PLANNED','RUNNING','PAUSED')` e plataforma Facebook). Ao registrar o pixel do nicho, a pendência muda para `COMPLETED` e os experimentos passam a usar o mesmo ID/HTML.
+9. **Execução registrada** – cada anúncio publicado referencia o valor de rastreamento (`utm_campaign`) exibido na UI junto com as conversões atribuídas.
 9. **Parada manual do operador** – a UI de Experimentos pode registrar `status='USER_STOPPED'` quando a campanha for interrompida por decisão humana. Esse status encerra o ciclo operacional no Hub e **não** recoloca o experimento na fila `/api/facebook-campaigns/experiments-ready` até uma nova liberação explícita.
 10. **Upload de imagem por bytes com reuso canônico (Meta `image_hash`)** – para criativos de anúncio, o worker **não** deve fazer upload cego da mesma imagem em toda execução e **não pode depender de URL externa como caminho de publicação**. O fluxo obrigatório é:
    - baixar a imagem aprovada no próprio `facebook-ads-worker` antes de chamar a Meta;
@@ -214,6 +215,6 @@ Consequência arquitetural: a publicação de campanha passa a ser substituível
 
 - `system-governance-canon.v2.md` – precedência canônica e critérios de criação de novos cânones.
 - `ExperimentReadinessService` (backend) – cálculo dos bloqueios.
-- Endpoints: `/api/facebook-campaigns/experiments-ready`, `/api/facebook-campaigns/experiments/{experimentId}/creatives-ready`, `/api/facebook-adsets/experiments-ready`, `/api/facebook-pixels/niches-ready`, `/api/experiments/{experimentId}/funnel/diagnostics`.
+- Endpoints: `/api/facebook-campaigns/experiments-ready`, `/api/facebook-campaigns/experiments/{experimentId}/creatives-ready`, `/api/facebook-adsets/experiments-ready`, `/api/facebook-pixels/pending`, `/api/facebook-pixels/niches/{nicheId}/request`, `/api/experiments/{experimentId}/funnel/diagnostics`.
 - Metodologia de arquitetura por etapa: `docs/metodologia/gerado-5-5/arquitetura-pipeline-etapas-archunit.md`.
 - Tabelas do schema `marketinghubdb`: `experiment`, `creative`, `lead_portal_flow`, `targeting_element`, `experiment_campaign_metric`.

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -4575,3 +4575,9 @@
 - causa-raiz: a consulta de nichos prontos para pixel exigia `facebook_release_requested_at`, que é gravado justamente na liberação final; isso criava dependência circular entre criação de pixel e liberação do experimento.
 - correção aplicada: a elegibilidade para criação de pixel passou a considerar experimento Facebook com criativo aprovado e landing de destino publicada (`follow_up_action_url`), sem exigir a liberação final já registrada.
 - impacto esperado: o nicho do Experimento 39 passa a ficar disponível para criação de pixel assim que a oferta/landing estiver pronta, permitindo concluir o fluxo comercial sem contorno manual.
+
+## 2026-06-16 — Solicitação manual de pixel por nicho
+- solicitação: adicionar na tela do nicho um botão para solicitar pixel, gravando uma pendência no banco para o Facebook Ads Worker criar periodicamente os pixels pendentes.
+- causa-raiz: a criação automática baseada apenas na landing pronta deixava ambiguidade operacional; a landing não consegue incluir o código antes de existir `facebook_pixel_id`, então a solicitação explícita torna a fila de criação auditável.
+- correção aplicada: criado endpoint `POST /api/facebook-pixels/niches/{nicheId}/request`, campos `facebook_pixel_requested_at` e `facebook_pixel_request_status` em `market_niche`, listagem de pendências em `/api/facebook-pixels/pending`, botão "Solicitar pixel" na tela do nicho e ajuste do worker para consumir somente pendências solicitadas.
+- impacto esperado: o usuário solicita o pixel no momento certo, o worker cria o pixel em lote, registra o ID/código no nicho e os experimentos posteriores usam o pixel criado sem depender de contorno manual.

--- a/docs/swagger/facebook-ads-swagger.yaml
+++ b/docs/swagger/facebook-ads-swagger.yaml
@@ -479,12 +479,23 @@ paths:
             schema: { $ref: '#/components/schemas/CreateAdSetRequest' }
       responses:
         '200': { description: Ad set criado. }
-  /api/facebook-pixels/niches-ready:
+  /api/facebook-pixels/pending:
     get:
       tags: [Facebook Pixels]
-      summary: Lista nichos prontos para criação de pixel.
+      summary: Lista pendências de criação de pixel prontas para o worker.
       responses:
-        '200': { description: Nichos retornados. }
+        '200': { description: Pendências retornadas. }
+  /api/facebook-pixels/niches/{nicheId}/request:
+    post:
+      tags: [Facebook Pixels]
+      summary: Solicita criação de pixel para um nicho.
+      parameters:
+        - name: nicheId
+          in: path
+          required: true
+          schema: { type: integer, format: int64 }
+      responses:
+        '200': { description: Solicitação registrada no nicho. }
   /api/facebook-pixels:
     post:
       tags: [Facebook Pixels]

--- a/facebook-ads-worker/README.md
+++ b/facebook-ads-worker/README.md
@@ -103,8 +103,8 @@ A sincronização de pixels e o envio de eventos agora ficam **habilitados por p
 O agendador `FacebookPixelScheduler` continua condicionado à propriedade
 `facebookpixel.enabled`, portanto basta definir o valor como `false` se for
 necessário desligar o recurso em algum ambiente com permissões restritas.
-Quando o job está ativo o worker consulta `/api/facebook-pixels/experiments-ready`
-e cria o pixel antes de enviar os eventos de conversão.
+Quando o job está ativo o worker consulta `/api/facebook-pixels/pending`
+e cria os pixels solicitados como pendência no banco antes de enviar os eventos de conversão.
 
 O fluxo automatizado cria toda a hierarquia necessária para veiculação:
 

--- a/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookpixel/FacebookPixelService.java
+++ b/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookpixel/FacebookPixelService.java
@@ -73,11 +73,11 @@ public class FacebookPixelService {
             return;
         }
 
-        createPixelsForReadyNiches(config);
+        createPixelsForPendingRequests(config);
         sendConversions();
     }
 
-    private void createPixelsForReadyNiches(FacebookWorkerConfiguration config) {
+    private void createPixelsForPendingRequests(FacebookWorkerConfiguration config) {
         if (!StringUtils.hasText(config.adAccountId())) {
             LOGGER.warn("Facebook ad account id is not configured; skipping pixel creation");
             return;
@@ -92,7 +92,7 @@ public class FacebookPixelService {
             return;
         }
         String pixelOwnerBusinessId = config.pixelOwnerBusinessId().trim();
-        List<NichePixel> niches = fetchNichesReadyForPixel();
+        List<NichePixel> niches = fetchPendingPixelRequests();
         if (niches.isEmpty()) {
             return;
         }
@@ -149,10 +149,10 @@ public class FacebookPixelService {
         }
     }
 
-    private List<NichePixel> fetchNichesReadyForPixel() {
-        String url = UrlUtils.joinPath(backendBaseUrl, apiPrefix, "/facebook-pixels/niches-ready");
+    private List<NichePixel> fetchPendingPixelRequests() {
+        String url = UrlUtils.joinPath(backendBaseUrl, apiPrefix, "/facebook-pixels/pending");
         LOGGER.info(
-            "Requesting niches ready for pixel creation: url==>{}, params={}",
+            "Requesting pending pixel creation requests: url==>{}, params={}",
             url,
             JsonLogFormatter.wrap(Collections.emptyMap())
         );
@@ -165,16 +165,16 @@ public class FacebookPixelService {
                 .collectList()
                 .block();
             LOGGER.info(
-                "Received niches for pixel creation: url<=={}, response={}",
+                "Received pending pixel creation requests: url<=={}, response={}",
                 url,
                 JsonLogFormatter.wrap(objectMapper, niches)
             );
             return niches != null ? niches : List.of();
         } catch (WebClientRequestException ex) {
-            LOGGER.warn("Failed to fetch niches ready for pixel creation: url==>{}", url, ex);
+            LOGGER.warn("Failed to fetch pending pixel creation requests: url==>{}", url, ex);
         } catch (WebClientResponseException ex) {
             LOGGER.error(
-                "Backend responded with error when fetching niches ready for pixel creation: status={}, body={}",
+                "Backend responded with error when fetching pending pixel creation requests: status={}, body={}",
                 ex.getRawStatusCode(),
                 ex.getResponseBodyAsString(),
                 ex

--- a/frontend/src/api/niche/useNiches.ts
+++ b/frontend/src/api/niche/useNiches.ts
@@ -10,6 +10,8 @@ export interface MarketNiche {
   facebookPixelId?: string | null;
   facebookPixelCode?: string | null;
   facebookPixelCreatedAt?: string | null;
+  facebookPixelRequestedAt?: string | null;
+  facebookPixelRequestStatus?: string | null;
   interestList?: string[];
   roleList?: string[];
   behaviorList?: string[];

--- a/frontend/src/api/niche/useRequestFacebookPixel.ts
+++ b/frontend/src/api/niche/useRequestFacebookPixel.ts
@@ -1,0 +1,22 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import axios from "axios";
+import { MarketNiche } from "./useNiches";
+
+export function useRequestFacebookPixel(id?: number) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async () => {
+      if (!id) {
+        throw new Error("Nicho inválido para solicitação de pixel.");
+      }
+      const { data } = await axios.post<MarketNiche>(
+        `/api/facebook-pixels/niches/${id}/request`,
+      );
+      return data;
+    },
+    onSuccess: (data) => {
+      queryClient.setQueryData(["niche", id], data);
+      queryClient.invalidateQueries({ queryKey: ["niches"] });
+    },
+  });
+}

--- a/frontend/src/pages/niche/NicheDetailPage.tsx
+++ b/frontend/src/pages/niche/NicheDetailPage.tsx
@@ -35,6 +35,7 @@ import { useOpenAiModels } from "../../api/openAiModel/useOpenAiModels";
 import { useDifferentiatedTechnologies } from "../../api/differentiatedTechnology/useDifferentiatedTechnologies";
 import { useInformationSourcesByNiche } from "../../api/informationSource/useInformationSourcesByNiche";
 import { useRequestMetaAdsReprocess } from "../../api/targeting/useRequestMetaAdsReprocess";
+import { useRequestFacebookPixel } from "../../api/niche/useRequestFacebookPixel";
 import { useCreateInformationSource } from "../../api/informationSource/useCreateInformationSource";
 import {
   ArrowUpRight,
@@ -201,6 +202,10 @@ export default function NicheDetailPage() {
   const facebookPixelCreatedAtLabel = data?.facebookPixelCreatedAt
     ? formatDateTime(data.facebookPixelCreatedAt)
     : null;
+  const facebookPixelRequestedAtLabel = data?.facebookPixelRequestedAt
+    ? formatDateTime(data.facebookPixelRequestedAt)
+    : null;
+  const isFacebookPixelPending = data?.facebookPixelRequestStatus === "PENDING";
   const { data: chatDialog } = useChatDialog(data?.chatDialogId);
   const { data: hypotheses } = useHypothesesByNiche(nicheId, "ALL");
   const { data: targetingElements, isFetching: isFetchingTargeting } =
@@ -315,6 +320,7 @@ export default function NicheDetailPage() {
   const createInformationSource = useCreateInformationSource(id);
   const updateNiche = useUpdateNiche();
   const requestMetaAdsReprocess = useRequestMetaAdsReprocess();
+  const requestFacebookPixel = useRequestFacebookPixel(normalizedNicheId);
   useBreadcrumbs([{ label: data?.name || "...", icon: nicheIcon }]);
 
   useEffect(() => {
@@ -372,6 +378,17 @@ export default function NicheDetailPage() {
     }
     window.setTimeout(scrollToForm, 0);
   }, [scrollToSection]);
+
+  const handleRequestFacebookPixel = useCallback(async () => {
+    try {
+      await requestFacebookPixel.mutateAsync();
+      toast.success(
+        "Solicitação de pixel registrada. O worker vai criar o pixel automaticamente.",
+      );
+    } catch (error) {
+      toast.error("Não foi possível solicitar o pixel agora.");
+    }
+  }, [requestFacebookPixel]);
 
   const list = Array.isArray(hypotheses)
     ? [...hypotheses].sort((a, b) => {
@@ -1094,8 +1111,37 @@ export default function NicheDetailPage() {
           </div>
         ) : (
           <div className="alert alert-warning mb-0">
-            Libere um experimento pronto para que o worker gere o pixel
-            automaticamente.
+            <div className="d-flex flex-column flex-md-row align-items-md-center justify-content-between gap-3">
+              <div>
+                <strong>Pixel ainda não solicitado.</strong> Solicite a criação
+                para o worker gerar o pixel e liberar o uso nos experimentos.
+                {facebookPixelRequestedAtLabel ? (
+                  <span className="d-block small mt-1">
+                    Solicitação registrada em {facebookPixelRequestedAtLabel}.
+                  </span>
+                ) : null}
+              </div>
+              <button
+                type="button"
+                className="btn btn-warning"
+                onClick={handleRequestFacebookPixel}
+                disabled={
+                  requestFacebookPixel.isPending ||
+                  isFacebookPixelPending ||
+                  !normalizedNicheId
+                }
+              >
+                {requestFacebookPixel.isPending ? (
+                  <span
+                    className="spinner-border spinner-border-sm me-2"
+                    aria-hidden="true"
+                  />
+                ) : null}
+                {isFacebookPixelPending
+                  ? "Pixel solicitado"
+                  : "Solicitar pixel"}
+              </button>
+            </div>
           </div>
         )}
       </section>


### PR DESCRIPTION
### Motivation
- Introduce an explicit, auditable flow to request Facebook Pixel creation for a niche to avoid circular dependency between experiment release and pixel creation and to let operators trigger pixel creation when landing and creative are ready.

### Description
- Add `facebook_pixel_requested_at` and `facebook_pixel_request_status` columns with a Liquibase changeset and expose them in `MarketNiche` and `MarketNicheDto`.
- Replace the previous "ready for pixel" query with a pending-request query: `findPendingPixelRequests(...)` and update `MarketNicheService` to provide `listPendingPixelRequests()` and `requestFacebookPixel(Long)` which mark a niche as `PENDING` and set timestamps; attaching a pixel marks the request `COMPLETED`.
- Update backend API surface: rename `/api/facebook-pixels/niches-ready` to `/api/facebook-pixels/pending` and add `POST /api/facebook-pixels/niches/{nicheId}/request` in `FacebookPixelController`; update Swagger and docs accordingly.
- Change the Facebook Ads Worker to fetch `/facebook-pixels/pending`, create pixels and register them via existing `/facebook-pixels` endpoint, and adjust logging/variable names.
- Frontend changes include adding `facebookPixelRequestedAt`/`facebookPixelRequestStatus` to the niche model, a `useRequestFacebookPixel` hook, and a button/UI on the Niche detail page to request a pixel with pending/disabled states and toast feedback.
- Update tests and repository spec: rename and adapt `ExperimentRepositoryTest` to validate the new pending-request query semantics.

### Testing
- Ran backend unit tests for the `ads-service` module including the updated `ExperimentRepositoryTest` which verifies `findPendingPixelRequests`; tests completed successfully.
- Built and typechecked the frontend and ran its basic unit checks (`yarn build` / typecheck), and the UI hook and niche detail changes passed local smoke tests.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a316281ba34832180c93da42de121cc)