### PR TITLE
fix: desbloqueia criação de pixel solicitado

### DIFF
--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -4581,3 +4581,10 @@
 - causa-raiz: a criação automática baseada apenas na landing pronta deixava ambiguidade operacional; a landing não consegue incluir o código antes de existir `facebook_pixel_id`, então a solicitação explícita torna a fila de criação auditável.
 - correção aplicada: criado endpoint `POST /api/facebook-pixels/niches/{nicheId}/request`, campos `facebook_pixel_requested_at` e `facebook_pixel_request_status` em `market_niche`, listagem de pendências em `/api/facebook-pixels/pending`, botão "Solicitar pixel" na tela do nicho e ajuste do worker para consumir somente pendências solicitadas.
 - impacto esperado: o usuário solicita o pixel no momento certo, o worker cria o pixel em lote, registra o ID/código no nicho e os experimentos posteriores usam o pixel criado sem depender de contorno manual.
+
+## 2026-06-16 — Desbloqueio de execução de pixel solicitado
+- solicitação: corrigir situação em que o pixel do nicho 21 aparecia como solicitado há muito tempo, mas não era executado pelo Facebook Ads Worker.
+- causa-raiz: o worker bloqueava a criação de pixels quando `systemUserAccessToken` ou `pixelOwnerBusinessId` não estavam configurados, mesmo havendo `accessToken` principal válido para operar na Meta; assim a pendência permanecia registrada sem virar pixel criado.
+- correção aplicada: o worker agora usa `systemUserAccessToken` quando existir, usa `accessToken` principal como contingência, e não exige `pixelOwnerBusinessId` para criar o pixel; o owner business passa a ser enviado somente quando configurado.
+- prevenção de recorrência: adicionado teste automatizado garantindo que uma pendência de pixel seja criada mesmo sem token de system user e sem business owner configurado.
+- impacto esperado: solicitações como a do nicho 21 deixam de ficar presas por configuração complementar ausente e passam a ser processadas no próximo ciclo do worker.

--- a/facebook-ads-worker/README.md
+++ b/facebook-ads-worker/README.md
@@ -105,6 +105,9 @@ O agendador `FacebookPixelScheduler` continua condicionado à propriedade
 necessário desligar o recurso em algum ambiente com permissões restritas.
 Quando o job está ativo o worker consulta `/api/facebook-pixels/pending`
 e cria os pixels solicitados como pendência no banco antes de enviar os eventos de conversão.
+Para evitar que uma solicitação fique parada por falta de configuração complementar, a criação de pixel
+usa primeiro `systemUserAccessToken`; se ele não existir, usa o `accessToken` principal já validado.
+O campo `pixelOwnerBusinessId` é enviado apenas quando estiver preenchido, sem bloquear a criação.
 
 O fluxo automatizado cria toda a hierarquia necessária para veiculação:
 

--- a/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookpixel/FacebookPixelService.java
+++ b/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookpixel/FacebookPixelService.java
@@ -23,6 +23,9 @@ import java.time.Instant;
 import java.util.Collections;
 import java.util.List;
 
+/**
+ * Orquestra a criação de pixels solicitados no backend e o envio de conversões para a Meta.
+ */
 @Service
 public class FacebookPixelService {
 
@@ -77,21 +80,25 @@ public class FacebookPixelService {
         sendConversions();
     }
 
+    // Cria pixels pendentes usando o token operacional disponível e sem bloquear quando o Business owner não foi configurado.
     private void createPixelsForPendingRequests(FacebookWorkerConfiguration config) {
         if (!StringUtils.hasText(config.adAccountId())) {
             LOGGER.warn("Facebook ad account id is not configured; skipping pixel creation");
             return;
         }
-        if (!StringUtils.hasText(config.systemUserAccessToken())) {
-            LOGGER.warn("Facebook system user access token is not configured; skipping pixel creation");
+        String pixelAccessToken = resolvePixelAccessToken(config);
+        if (!StringUtils.hasText(pixelAccessToken)) {
+            LOGGER.warn("Facebook access token is not configured; skipping pixel creation");
             return;
         }
-        String systemUserToken = config.systemUserAccessToken().trim();
-        if (!StringUtils.hasText(config.pixelOwnerBusinessId())) {
-            LOGGER.warn("Facebook pixel owner business id is not configured; skipping pixel creation");
-            return;
+        String pixelOwnerBusinessId = StringUtils.hasText(config.pixelOwnerBusinessId())
+            ? config.pixelOwnerBusinessId().trim()
+            : null;
+        if (!StringUtils.hasText(pixelOwnerBusinessId)) {
+            LOGGER.warn(
+                "Facebook pixel owner business id is not configured; creating pixel without owner_business to avoid blocking requested niches"
+            );
         }
-        String pixelOwnerBusinessId = config.pixelOwnerBusinessId().trim();
         List<NichePixel> niches = fetchPendingPixelRequests();
         if (niches.isEmpty()) {
             return;
@@ -103,9 +110,9 @@ public class FacebookPixelService {
                     config.adAccountId(),
                     pixelName,
                     pixelOwnerBusinessId,
-                    systemUserToken
+                    pixelAccessToken
                 );
-                String pixelCode = facebookAdsService.fetchPixelCode(pixelId, systemUserToken);
+                String pixelCode = facebookAdsService.fetchPixelCode(pixelId, pixelAccessToken);
                 registerPixel(niche.nicheId(), pixelId, pixelCode);
             } catch (Exception ex) {
                 LOGGER.error(
@@ -117,6 +124,14 @@ public class FacebookPixelService {
                 );
             }
         }
+    }
+
+    // Resolve o token usado nas operações de pixel priorizando o system user e usando o token principal como contingência.
+    private String resolvePixelAccessToken(FacebookWorkerConfiguration config) {
+        if (StringUtils.hasText(config.systemUserAccessToken())) {
+            return config.systemUserAccessToken().trim();
+        }
+        return StringUtils.hasText(config.accessToken()) ? config.accessToken().trim() : null;
     }
 
     private void sendConversions() {

--- a/facebook-ads-worker/src/test/java/com/marketinghub/facebookadsworker/facebookpixel/FacebookPixelServiceTest.java
+++ b/facebook-ads-worker/src/test/java/com/marketinghub/facebookadsworker/facebookpixel/FacebookPixelServiceTest.java
@@ -1,0 +1,127 @@
+package com.marketinghub.facebookadsworker.facebookpixel;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marketinghub.facebookadsworker.FacebookAdsService;
+import com.marketinghub.facebookadsworker.configuration.FacebookWorkerConfigurationClient;
+import com.marketinghub.facebookadsworker.facebooktargeting.TargetingResolverProperties;
+import com.marketinghub.facebookadsworker.testsupport.FailFastMockWebServer;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.RecordedRequest;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.reactive.function.client.WebClient;
+
+import java.io.IOException;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+/**
+ * Valida o fluxo de criação de pixels solicitados pelo backend.
+ */
+class FacebookPixelServiceTest {
+    private FailFastMockWebServer backend;
+    private FailFastMockWebServer facebook;
+    private ObjectMapper objectMapper;
+    private FacebookPixelService service;
+
+    @BeforeEach
+    // Prepara servidores simulados e o serviço testado.
+    void setUp() throws IOException {
+        backend = new FailFastMockWebServer();
+        facebook = new FailFastMockWebServer();
+        backend.start();
+        facebook.start();
+        objectMapper = new ObjectMapper();
+
+        TargetingResolverProperties resolverProperties = new TargetingResolverProperties();
+        FacebookAdsService facebookAdsService = new FacebookAdsService(
+            WebClient.builder(),
+            facebook.url("/").toString(),
+            "v23.0",
+            objectMapper,
+            resolverProperties
+        );
+        FacebookWorkerConfigurationClient configurationClient = new FacebookWorkerConfigurationClient(
+            WebClient.builder(),
+            backend.url("/").toString(),
+            "/api"
+        );
+        service = new FacebookPixelService(
+            facebookAdsService,
+            WebClient.builder(),
+            configurationClient,
+            backend.url("/").toString(),
+            "/api",
+            objectMapper,
+            true
+        );
+    }
+
+    @AfterEach
+    // Encerra os servidores simulados e verifica requisições inesperadas.
+    void tearDown() throws IOException {
+        backend.assertNoUnmatchedRequests();
+        facebook.assertNoUnmatchedRequests();
+        backend.shutdown();
+        facebook.shutdown();
+    }
+
+    @Test
+    // Garante que a pendência de pixel é executada mesmo sem token de system user e sem business owner.
+    void syncPixelsCreatesPendingPixelWithoutSystemUserTokenOrOwnerBusiness() throws Exception {
+        backend.enqueueResponse(new MockResponse()
+            .setBody("""
+                {
+                  "accountId": 1,
+                  "adAccountId": "1234567890",
+                  "accessToken": "main-token"
+                }
+                """)
+            .addHeader("Content-Type", "application/json"));
+        backend.enqueueResponse(new MockResponse()
+            .setBody("[{\"nicheId\":21,\"nicheName\":\"GerProj 5\"}]")
+            .addHeader("Content-Type", "application/json"));
+        facebook.enqueueResponse(new MockResponse()
+            .setBody("{\"id\":\"pixel-21\"}")
+            .addHeader("Content-Type", "application/json"));
+        facebook.enqueueResponse(new MockResponse()
+            .setBody("{\"code\":\"<script>pixel</script>\"}")
+            .addHeader("Content-Type", "application/json"));
+        backend.enqueueResponse(new MockResponse().setResponseCode(200));
+        backend.enqueueResponse(new MockResponse()
+            .setBody("[]")
+            .addHeader("Content-Type", "application/json"));
+
+        service.syncPixelsAndConversions();
+
+        RecordedRequest configRequest = backend.takeRequest(5, TimeUnit.SECONDS);
+        assertNotNull(configRequest);
+        assertEquals("/api/accounts/facebook/worker-config", configRequest.getPath());
+        RecordedRequest pendingRequest = backend.takeRequest(5, TimeUnit.SECONDS);
+        assertNotNull(pendingRequest);
+        assertEquals("/api/facebook-pixels/pending", pendingRequest.getPath());
+        RecordedRequest createRequest = facebook.takeRequest(5, TimeUnit.SECONDS);
+        assertNotNull(createRequest);
+        assertEquals("/v23.0/act_1234567890/adspixels", createRequest.getPath());
+        String createBody = createRequest.getBody().readUtf8();
+        assertTrue(createBody.contains("\"access_token\":\"main-token\""));
+        assertFalse(createBody.contains("owner_business"));
+        RecordedRequest codeRequest = facebook.takeRequest(5, TimeUnit.SECONDS);
+        assertNotNull(codeRequest);
+        assertTrue(codeRequest.getPath().contains("/v23.0/pixel-21"));
+        RecordedRequest registerRequest = backend.takeRequest(5, TimeUnit.SECONDS);
+        assertNotNull(registerRequest);
+        assertEquals("/api/facebook-pixels", registerRequest.getPath());
+        String registerBody = registerRequest.getBody().readUtf8();
+        assertTrue(registerBody.contains("\"nicheId\":21"));
+        assertTrue(registerBody.contains("\"pixelId\":\"pixel-21\""));
+        RecordedRequest conversionsRequest = backend.takeRequest(5, TimeUnit.SECONDS);
+        assertNotNull(conversionsRequest);
+        assertEquals("/api/facebook-pixels/conversions-ready", conversionsRequest.getPath());
+    }
+}


### PR DESCRIPTION
### Motivation
- Corrigir situação em que pixels solicitados permaneciam pendentes por muito tempo porque o worker bloqueava a criação quando `systemUserAccessToken` ou `pixelOwnerBusinessId` não estavam configurados.
- Permitir que operações essenciais com a Meta sejam realizadas quando houver um `accessToken` principal válido como contingência, evitando dependência de configuração complementar que paralisa o fluxo comercial.
- Tornar o comportamento auditável e previsível, evitando contornos manuais para finalizar experimentos que dependem do pixel.

### Description
- O `FacebookPixelService` agora resolve o token de pixel com `resolvePixelAccessToken(...)`, priorizando `systemUserAccessToken` e caindo para `accessToken` principal quando necessário, e usa esse token em `createPixel`/`fetchPixelCode` em vez de exigir `systemUserAccessToken` obrigatoriamente.
- O `pixelOwnerBusinessId` passou a ser opcional: é enviado à Graph API somente quando preenchido e não bloqueia a criação do pixel quando ausente.
- Adicionado teste de integração unitário `FacebookPixelServiceTest` cobrindo o fluxo de criação de pixel quando não há `systemUserAccessToken` nem `pixelOwnerBusinessId` (mock WebServers para backend e Meta).
- Atualizada documentação operacional em `facebook-ads-worker/README.md` e registrado o incidente e a correção em `docs/registros/experimentos.md`.

### Testing
- Executado o teste automatizado `mvn test -Dtest=FacebookPixelServiceTest`, que passou com sucesso.
- O novo teste valida que o worker cria o pixel pendente, registra o `pixelId` no backend e solicita conversões mesmo sem `systemUserAccessToken` e sem `pixelOwnerBusinessId`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a31775627608321a2a20852759ed821)