### PR TITLE
Clarify commercial objective of Sales Pages Library and update related docs

### DIFF
--- a/docs/canonical/mois-worker-canon.v1.md
+++ b/docs/canonical/mois-worker-canon.v1.md
@@ -124,6 +124,20 @@ O MOIS Worker segue as regras gerais de governança e operação de pipelines, m
 
 Esta seção consolida o fluxo ponta a ponta de **alimentação da biblioteca** (coleta de URLs de produtos vencedores, análise com OpenAI e persistência dos resultados) para remover ambiguidades operacionais entre coletores, backend e worker.
 
+### 12.0 Objetivo comercial da Biblioteca de Páginas de Vendas
+
+A Biblioteca de Páginas de Vendas **não tem como objetivo principal encontrar oportunidades de mercado**. O objetivo é identificar, registrar e reutilizar as **fórmulas comerciais que já demonstram vender com consistência no digital**, para acelerar a criação de novas ofertas e páginas com maior probabilidade de conversão.
+
+Neste contexto, “copiar” significa **replicar a fórmula estrutural vencedora**, não plagiar conteúdo literal, marca, identidade visual, promessa proprietária ou ativos de terceiros. A análise deve transformar páginas vencedoras em padrões reutilizáveis do tipo:
+
+- sequência de argumento da oferta;
+- estrutura de headline, promessa, prova, objeção e chamada para ação;
+- mecanismo de persuasão usado para afastar dor/esforço e aproximar facilidade/prazer;
+- organização visual que sustenta a leitura e a decisão de compra;
+- combinação de Dor → Resultado → Mecanismo → Prova → Oferta que parece explicar a venda consistente.
+
+Portanto, rankings, scores e pesquisas complementares da biblioteca devem responder principalmente: **“qual fórmula de venda está funcionando aqui e como podemos adaptar essa fórmula para produtos próprios do Marketing Hub?”**. Eles não devem reposicionar a biblioteca como ferramenta primária de descoberta de oportunidade de mercado; essa responsabilidade pertence aos fluxos de pesquisa de mercado, rotina, dores e validação de nicho.
+
 ### 12.1 Etapas macro (visão executiva)
 1. **Ingestão de produtos de sucesso (fontes de mercado)**
    - **Hotmart collector** seleciona produtos elegíveis, prioriza `salesPageUrl` com fallback em `detailsUrl` e envia para `POST /api/mois/sales-library/urls:ingest`.

--- a/docs/novos-modulos/mois-biblioteca-pagina-venda/especificacao-biblioteca-sales-pages.md
+++ b/docs/novos-modulos/mois-biblioteca-pagina-venda/especificacao-biblioteca-sales-pages.md
@@ -5,9 +5,11 @@
 Este módulo tem como objetivo criar uma biblioteca contínua de páginas de vendas coletadas pelo **mois-hotmart-collector**, com processamento em background para:
 
 1. armazenar snapshots rastreáveis das URLs;
-2. extrair padrões de copy, estilo visual e imagens;
-3. transformar os dados em análises estruturadas reutilizáveis pelo Marketing Hub;
+2. extrair fórmulas comerciais que estão vendendo com consistência no digital;
+3. transformar padrões de copy, estilo visual, prova, objeção, mecanismo e chamada para ação em análises estruturadas reutilizáveis pelo Marketing Hub;
 4. acelerar a criação de produtos e páginas com maior potencial de conversão.
+
+A biblioteca **não é uma ferramenta primária de descoberta de oportunidades de mercado**. Sua função é estudar páginas vencedoras para “copiar” a fórmula estrutural de venda — sequência de argumento, promessa, prova, mecanismo, CTA e organização visual — sem copiar literalmente conteúdo, marca, identidade visual ou ativos de terceiros.
 
 A definição funcional segue o eixo canônico do sistema:
 

--- a/docs/novos-modulos/mois-biblioteca-pagina-venda/uso-paginas-vendas-sucesso-pequenos-passos.md
+++ b/docs/novos-modulos/mois-biblioteca-pagina-venda/uso-paginas-vendas-sucesso-pequenos-passos.md
@@ -14,7 +14,7 @@ Em vez disso, o sistema deve evoluir em pequenos passos, aprendendo gradualmente
 4. transformar esses padrões em insumos úteis;
 5. usar esses insumos nas etapas de geração de novas páginas.
 
-O objetivo não é copiar páginas existentes, mas sim transformar referências em inteligência estruturada para apoiar a geração de:
+O objetivo é copiar **fórmulas comerciais vencedoras**, não páginas existentes de forma literal. Na prática, o sistema deve transformar referências em inteligência estruturada para apoiar a geração de:
 
 - wireframes;
 - copy;
@@ -25,9 +25,11 @@ O objetivo não é copiar páginas existentes, mas sim transformar referências 
 
 ## Princípio central
 
-> Referências devem ser usadas como inspiração estruturada, não como cópia.
+> Referências devem ser usadas para copiar a fórmula estrutural que vende, não para plagiar conteúdo, marca, identidade visual ou ativos.
 
-O sistema não deve reproduzir headlines, layouts ou visuais de páginas existentes.  
+O sistema não deve reproduzir literalmente headlines, layouts proprietários ou visuais de páginas existentes.
+
+A leitura correta da biblioteca é: identificar qual sequência de Dor → Resultado → Mecanismo → Prova → Oferta está funcionando, entender como ela reduz dor/esforço e aumenta facilidade/prazer, e adaptar essa fórmula para produtos próprios do Marketing Hub.
 Ele deve extrair padrões, estratégias e orientações reutilizáveis.
 
 A lógica recomendada é:

--- a/docs/registros/mois1.md
+++ b/docs/registros/mois1.md
@@ -1,3 +1,8 @@
+## 2026-06-16 — Objetivo comercial da Biblioteca de Páginas de Vendas
+- atualizado o cânone MOIS para deixar claro que a Biblioteca de Páginas de Vendas não tem como objetivo principal encontrar oportunidades de mercado.
+- registrado que o objetivo correto é identificar e reutilizar fórmulas comerciais que já vendem com consistência no digital, copiando a estrutura de venda vencedora sem plagiar conteúdo literal, marca, identidade visual ou ativos de terceiros.
+- alinhadas especificações complementares da biblioteca para reforçar que rankings, scores e análises devem responder qual fórmula de venda funciona e como adaptá-la para produtos próprios do Marketing Hub.
+
 ## 2026-06-11 18:20:00 UTC
 - corrigido o cálculo de custo da análise da Biblioteca de Páginas de Vendas do MOIS para não depender diretamente do pacote `com.marketinghub.openai`, preservando o isolamento arquitetural validado por ArchUnit.
 - criado serviço local no pacote `com.marketinghub.mois.bibliotecapaginavenda.worker.v1.service` para calcular preço batch a partir dos tokens do worker.


### PR DESCRIPTION
### Motivation
- Clarify that the Biblioteca de Páginas de Vendas is intended to extract and reuse winning commercial formulas rather than to serve as a primary market-discovery tool. 
- Emphasize structural copying of sales formulas while prohibiting literal plagiarism of content, brand, identity or third-party assets. 
- Align canonical guidance and module specifications so rankings, scores and analyses focus on which sales formula is working and how to adapt it for the Marketing Hub.

### Description
- Added a new section `12.0 Objetivo comercial da Biblioteca de Páginas de Vendas` to `docs/canonical/mois-worker-canon.v1.md` describing the commercial intent and permitted scope of copying. 
- Updated `docs/novos-modulos/mois-biblioteca-pagina-venda/especificacao-biblioteca-sales-pages.md` to reframe extraction goals as capturing "fórmulas comerciais" and to reinforce reuse constraints. 
- Revised `docs/novos-modulos/mois-biblioteca-pagina-venda/uso-paginas-vendas-sucesso-pequenos-passos.md` to clarify the principle of structural copying and added a registry entry in `docs/registros/mois1.md` documenting the change. 

### Testing
- No automated tests were executed because this is a documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3180b25a308321ae2357ddc5af9412)