### PR TITLE
Corrige liberação do experimento para Facebook Ads Worker

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentService.java
@@ -16,6 +16,7 @@ import com.marketinghub.experiment.pipeline.ads.ExperimentPipelineAdExtractor;
 import com.marketinghub.experiment.pipeline.ads.PipelineAdCreativePlan;
 import com.marketinghub.repository.jpa.experiment.ExperimentRepository;
 import com.marketinghub.repository.jpa.experiment.funnel.ExperimentFunnelEventRepository;
+import com.marketinghub.repository.jpa.experiment.funnel.ExperimentLandingAnalyticsEventRepository;
 import com.marketinghub.journey.model.JourneyTemplate;
 import com.marketinghub.repository.jpa.journey.JourneyTemplateRepository;
 import com.marketinghub.leadportal.LeadPortalFlow;
@@ -60,6 +61,7 @@ public class ExperimentService {
     private final ImageGenerationQualityRepository imageGenerationQualityRepository;
     private final com.marketinghub.repository.jpa.sampleemail.SampleEmailRepository sampleEmailRepository;
     private final ExperimentFunnelEventRepository experimentFunnelEventRepository;
+    private final ExperimentLandingAnalyticsEventRepository experimentLandingAnalyticsEventRepository;
     private final ObjectMapper objectMapper;
 
     public ExperimentService(ExperimentRepository repository, MarketNicheRepository nicheRepository,
@@ -75,7 +77,9 @@ public class ExperimentService {
                              ImageGenerationModelRepository imageGenerationModelRepository,
                              ImageGenerationQualityRepository imageGenerationQualityRepository,
                              com.marketinghub.repository.jpa.sampleemail.SampleEmailRepository sampleEmailRepository,
-                             ExperimentFunnelEventRepository experimentFunnelEventRepository, ObjectMapper objectMapper) {
+                             ExperimentFunnelEventRepository experimentFunnelEventRepository,
+                             ExperimentLandingAnalyticsEventRepository experimentLandingAnalyticsEventRepository,
+                             ObjectMapper objectMapper) {
         this.repository = repository;
         this.nicheRepository = nicheRepository;
         this.hypothesisRepository = hypothesisRepository;
@@ -91,6 +95,7 @@ public class ExperimentService {
         this.imageGenerationQualityRepository = imageGenerationQualityRepository;
         this.sampleEmailRepository = sampleEmailRepository;
         this.experimentFunnelEventRepository = experimentFunnelEventRepository;
+        this.experimentLandingAnalyticsEventRepository = experimentLandingAnalyticsEventRepository;
         this.objectMapper = objectMapper;
     }
 
@@ -700,7 +705,7 @@ public class ExperimentService {
     }
 
     /**
-     * Marks the experiment as released to the Facebook Ads Worker and resets the funnel.
+     * Libera o experimento para o Facebook Ads Worker e remove eventos dependentes antes de zerar o funil.
      */
     @Transactional
     public Experiment releaseForFacebook(Long id) {
@@ -710,6 +715,8 @@ public class ExperimentService {
         }
         experiment.setStatus(ExperimentStatus.PLANNED);
         experiment.setFacebookReleaseRequestedAt(Instant.now());
+        experiment.setFunnelResetAt(experiment.getFacebookReleaseRequestedAt());
+        experimentLandingAnalyticsEventRepository.deleteByExperimentId(id);
         experimentFunnelEventRepository.deleteByExperimentId(id);
         return experiment;
     }

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/ExperimentServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/ExperimentServiceTest.java
@@ -13,7 +13,9 @@ import com.marketinghub.experiment.service.ExperimentService;
 import com.marketinghub.journey.model.JourneyTemplate;
 import com.marketinghub.repository.jpa.journey.JourneyTemplateRepository;
 import com.marketinghub.experiment.funnel.ExperimentFunnelEvent;
+import com.marketinghub.experiment.funnel.ExperimentLandingAnalyticsEvent;
 import com.marketinghub.repository.jpa.experiment.funnel.ExperimentFunnelEventRepository;
+import com.marketinghub.repository.jpa.experiment.funnel.ExperimentLandingAnalyticsEventRepository;
 import com.marketinghub.experiment.funnel.ExperimentFunnelStage;
 import com.marketinghub.niche.MarketNiche;
 import com.marketinghub.repository.jpa.niche.MarketNicheRepository;
@@ -62,6 +64,8 @@ class ExperimentServiceTest {
     com.marketinghub.repository.jpa.leadportal.LeadPortalFlowRepository leadPortalFlowRepository;
     @Autowired
     ExperimentFunnelEventRepository experimentFunnelEventRepository;
+    @Autowired
+    ExperimentLandingAnalyticsEventRepository experimentLandingAnalyticsEventRepository;
 
     private InstagramAccount createInstagramAccount() {
         return instagramAccountRepository.save(
@@ -562,11 +566,25 @@ class ExperimentServiceTest {
                 .source("manual")
                 .occurredAt(Instant.now().minusSeconds(60))
                 .build());
+        ExperimentFunnelEvent landingEvent = experimentFunnelEventRepository.save(ExperimentFunnelEvent.builder()
+                .experiment(experiment)
+                .stage(ExperimentFunnelStage.VISUALIZACAO_FORM)
+                .source(ExperimentFunnelEventRepository.LANDING_PAGE_ANALYTICS_SOURCE)
+                .occurredAt(Instant.now().minusSeconds(30))
+                .build());
+        experimentLandingAnalyticsEventRepository.save(ExperimentLandingAnalyticsEvent.builder()
+                .experiment(experiment)
+                .funnelEvent(landingEvent)
+                .eventType("page_view")
+                .occurredAt(landingEvent.getOccurredAt())
+                .build());
 
         Experiment released = service.releaseForFacebook(experiment.getId());
 
         assertThat(released.getStatus()).isEqualTo(ExperimentStatus.PLANNED);
         assertThat(released.getFacebookReleaseRequestedAt()).isNotNull();
+        assertThat(released.getFunnelResetAt()).isNotNull();
+        assertThat(experimentLandingAnalyticsEventRepository.count()).isZero();
         assertThat(experimentFunnelEventRepository.count()).isZero();
     }
 

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -4594,3 +4594,9 @@
 - causa-raiz: a Meta bloqueia a criação de novo pixel quando a conta de anúncios já possui pixel, deixando nichos pendentes e atrasando a validação comercial.
 - correção aplicada: o Facebook Ads Worker passou a manter `FACEBOOKPIXEL_ENABLED=false` por padrão, preservando a campanha sem bloquear por pixel, e a checklist do experimento passou a sinalizar o pixel como recurso temporariamente desligado.
 - impacto esperado: campanhas podem ser liberadas para vendas usando a landing aprovada, enquanto a estratégia futura de pixels por vertical/conta é definida.
+
+## 2026-06-16 — Correção da liberação do Experimento 39
+- solicitação: corrigir erro ao clicar em “Liberar para Facebook Ads Worker” no Experimento 39.
+- causa-raiz: a liberação apagava diretamente `experiment_funnel_event`, mas eventos de analytics normalizados em `experiment_landing_analytics_event` ainda apontavam para esses registros por chave estrangeira, causando falha de integridade no banco.
+- correção aplicada: a liberação agora remove primeiro os analytics normalizados dependentes e depois zera os eventos brutos do funil; também grava `funnel_reset_at` no mesmo marco da liberação para manter as métricas pós-liberação consistentes.
+- prevenção de recorrência: adicionado teste automatizado cobrindo liberação com evento bruto e evento normalizado vinculado.


### PR DESCRIPTION
### Motivation
- O Experimento 39 não podia ser liberado porque a ação de reset do funil apagava os eventos brutos em `experiment_funnel_event` enquanto registros normalizados em `experiment_landing_analytics_event` ainda referenciavam esses eventos, provocando violação de integridade referencial. 
- É necessário garantir que a limpeza de analytics normalizados e a atualização do marco temporal do funil ocorram de forma consistente ao marcar o experimento como `PLANNED` para o Facebook Ads Worker.

### Description
- Injeta `ExperimentLandingAnalyticsEventRepository` em `ExperimentService` e passa a usá-lo durante a liberação do experimento. 
- Em `releaseForFacebook(Long id)` a rotina agora grava `funnelResetAt` com o mesmo carimbo de `facebookReleaseRequestedAt` e apaga primeiro os eventos normalizados com `experimentLandingAnalyticsEventRepository.deleteByExperimentId(id)` antes de apagar os eventos brutos com `experimentFunnelEventRepository.deleteByExperimentId(id)`.
- Adiciona um teste de regressão em `ExperimentServiceTest` que cria um evento bruto e um evento normalizado vinculado, chama `releaseForFacebook` e verifica que ambos os conjuntos de eventos foram removidos e que `funnelResetAt` foi preenchido. 
- Documenta a correção em `docs/registros/experimentos.md` explicando solicitação, causa-raiz, correção e prevenção de recorrência.

### Testing
- Executado o teste unitário `ExperimentServiceTest#releaseForFacebookResetsFunnelAndTimestamp` no módulo `ads-service` via Maven, que passou com sucesso (`Tests run: 1, Failures: 0`).
- A execução do teste e a compilação do módulo retornaram `BUILD SUCCESS`, validando a correção automatizada.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a318dde60788321ad570e0f11a86ba3)