### PR TITLE
Enforce Meta ID for audience selections, add UI badges and allow edits on FAILED experiments

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentTargetingSelectionService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentTargetingSelectionService.java
@@ -24,12 +24,16 @@ import com.marketinghub.repository.jpa.targeting.TargetingRequestRepository;
 import com.marketinghub.targeting.service.TargetingResolutionJobService;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
 
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
 
+/**
+ * Gerencia as escolhas de público do experimento e evita seleções sem identificador oficial da Meta.
+ */
 @Service
 public class ExperimentTargetingSelectionService {
     private static final int SIMPLE_FLOW_RESOLUTION_ETA_SECONDS = 90;
@@ -61,11 +65,14 @@ public class ExperimentTargetingSelectionService {
         this.targetingResolutionSummaryMapper = targetingResolutionSummaryMapper;
     }
 
+    /**
+     * Resolve o elemento selecionado e bloqueia itens que não podem ser publicados na Meta.
+     */
     private TargetingElement resolveTargetingElement(Long targetingElementId,
                                                      Experiment experiment,
                                                      TargetingCandidateType candidateType) {
         if (targetingElementId == null) {
-            return null;
+            throw new IllegalArgumentException("Elemento de segmentação oficial da Meta é obrigatório");
         }
         TargetingElement element = targetingElementRepository.findById(targetingElementId)
                 .orElseThrow(() -> new IllegalArgumentException("Elemento de segmentação não encontrado"));
@@ -82,9 +89,15 @@ public class ExperimentTargetingSelectionService {
                 && !Objects.equals(experiment.getHypothesisRef().getId(), element.getHypothesis().getId())) {
             throw new IllegalArgumentException("Elemento vinculado a outra hipótese");
         }
+        if (!StringUtils.hasText(element.getMetaId())) {
+            throw new IllegalArgumentException("Elemento de segmentação sem ID oficial da Meta");
+        }
         return element;
     }
 
+    /**
+     * Converte o tipo salvo na seleção para o tipo canônico do elemento de targeting.
+     */
     private TargetingElementType mapCandidateType(TargetingCandidateType candidateType) {
         return switch (candidateType) {
             case INTEREST -> TargetingElementType.INTEREST;
@@ -93,6 +106,9 @@ public class ExperimentTargetingSelectionService {
         };
     }
 
+    /**
+     * Lista as escolhas de público já salvas para o experimento.
+     */
     @Transactional(readOnly = true)
     public List<ExperimentTargetingSelectionDto> list(Long experimentId) {
         return repository.findByExperimentIdOrderByCandidateTypeAscTermAsc(experimentId).stream()
@@ -106,6 +122,9 @@ public class ExperimentTargetingSelectionService {
                 .toList();
     }
 
+    /**
+     * Substitui as escolhas de público por elementos oficiais e publicáveis na Meta.
+     */
     @Transactional
     public List<ExperimentTargetingSelectionDto> save(Long experimentId, SaveExperimentTargetingSelectionsRequest request) {
         Experiment experiment = experimentRepository.findById(experimentId).orElseThrow();
@@ -117,11 +136,10 @@ public class ExperimentTargetingSelectionService {
                     continue;
                 }
                 TargetingElement linkedElement = resolveTargetingElement(item.getTargetingElementId(), experiment, item.getCandidateType());
-                String normalizedTerm = linkedElement != null ? linkedElement.getTerm() : item.getTerm().trim();
                 items.add(ExperimentTargetingSelection.builder()
                         .experiment(experiment)
                         .candidateType(item.getCandidateType())
-                        .term(normalizedTerm)
+                        .term(linkedElement.getTerm())
                         .targetingElement(linkedElement)
                         .build());
             }
@@ -137,6 +155,9 @@ public class ExperimentTargetingSelectionService {
                 .toList();
     }
 
+    /**
+     * Cria uma solicitação simples de resolução de público a partir das escolhas salvas.
+     */
     @Transactional
     public TargetingRequestDto runSimpleFlow(Long experimentId) {
         Experiment experiment = experimentRepository.findById(experimentId).orElseThrow();
@@ -171,6 +192,9 @@ public class ExperimentTargetingSelectionService {
         return targetingRequestMapper.toDetailedDto(savedRequest, SIMPLE_FLOW_RESOLUTION_ETA_SECONDS);
     }
 
+    /**
+     * Consulta o status mais recente do fluxo simples de resolução de público.
+     */
     @Transactional(readOnly = true)
     public ExperimentSimpleFlowStatusDto getSimpleFlowStatus(Long experimentId) {
         if (experimentId == null) {

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -4600,3 +4600,9 @@
 - causa-raiz: a liberação apagava diretamente `experiment_funnel_event`, mas eventos de analytics normalizados em `experiment_landing_analytics_event` ainda apontavam para esses registros por chave estrangeira, causando falha de integridade no banco.
 - correção aplicada: a liberação agora remove primeiro os analytics normalizados dependentes e depois zera os eventos brutos do funil; também grava `funnel_reset_at` no mesmo marco da liberação para manter as métricas pós-liberação consistentes.
 - prevenção de recorrência: adicionado teste automatizado cobrindo liberação com evento bruto e evento normalizado vinculado.
+
+## 2026-06-16 — Público editável após falha e indicador de compatibilidade Meta
+- solicitação: após falha do Experimento 39, a aba Público deve voltar a permitir correções e deixar claro quais públicos podem ser usados em campanha da Meta.
+- causa-raiz: o bloqueio da tela considerava qualquer `facebook_release_requested_at`, mesmo quando o experimento voltava para `FAILED`; além disso, a UI exibia itens aprovados no nicho sem diferenciar os que possuíam `meta_id` oficial dos que ainda não eram publicáveis na Meta.
+- correção aplicada: experimentos em `FAILED` deixam de travar a edição; a aba Público passa a exibir selo “Pronto para Meta” ou “Sem ID Meta”, bloqueando a inclusão de novos itens sem ID oficial e impedindo salvar enquanto houver seleção inválida.
+- prevenção de recorrência: o backend passou a rejeitar salvamento de seleção vinculada a elemento de targeting sem ID oficial da Meta.

--- a/frontend/src/pages/experiment/ExperimentAudienceTab.tsx
+++ b/frontend/src/pages/experiment/ExperimentAudienceTab.tsx
@@ -31,6 +31,10 @@ function buildKey(element: TargetingElement) {
   return `${element.type}::${element.id}`;
 }
 
+function isMetaUsable(element: TargetingElement) {
+  return Boolean(element.metaId?.trim());
+}
+
 export function ExperimentAudienceTab({
   experimentId,
   nicheId,
@@ -80,6 +84,14 @@ export function ExperimentAudienceTab({
     };
   }, [availableOptions]);
 
+  const selectedWithoutMeta = useMemo(
+    () =>
+      availableOptions.filter(
+        (item) => selected.has(buildKey(item)) && !isMetaUsable(item),
+      ),
+    [availableOptions, selected],
+  );
+
   const toggleSelection = (item: TargetingElement) => {
     if (alterationLocked) return;
     setSelected((prev) => {
@@ -119,12 +131,28 @@ export function ExperimentAudienceTab({
         <div>
           <h5 className="card-title mb-1">Público</h5>
           <p className="text-muted mb-0 small">
-            Marque somente interesses, cargos e comportamentos já aprovados para o nicho.
+            Marque somente públicos aprovados e com ID oficial da Meta. Itens
+            sem ID Meta aparecem para diagnóstico, mas não devem ser usados em
+            campanha.
           </p>
           {alterationLocked ? (
             <div className="alert alert-secondary mt-3 mb-0" role="status">
               Público bloqueado para alteração porque o experimento já foi
               liberado ou está em execução.
+            </div>
+          ) : null}
+          <div className="alert alert-info mt-3 mb-0 small" role="status">
+            <strong>Pronto para Meta</strong> significa que o item possui
+            identificador oficial da Meta e pode entrar no targeting da
+            campanha.
+            <strong className="ms-1">Sem ID Meta</strong> precisa ser resolvido
+            antes de publicar.
+          </div>
+          {selectedWithoutMeta.length > 0 ? (
+            <div className="alert alert-warning mt-3 mb-0 small" role="alert">
+              Remova {selectedWithoutMeta.length} item
+              {selectedWithoutMeta.length === 1 ? "" : "s"} sem ID Meta antes de
+              salvar o público.
             </div>
           ) : null}
         </div>
@@ -133,7 +161,8 @@ export function ExperimentAudienceTab({
           <div className="text-muted small">Carregando opções do nicho...</div>
         ) : availableOptions.length === 0 ? (
           <div className="text-muted small">
-            Nenhum interesse, cargo ou comportamento aprovado foi encontrado para este nicho.
+            Nenhum interesse, cargo ou comportamento aprovado foi encontrado
+            para este nicho.
           </div>
         ) : (
           <div className="row g-3">
@@ -144,20 +173,38 @@ export function ExperimentAudienceTab({
                   <div className="d-flex flex-column gap-2">
                     {grouped[type].map((item) => {
                       const key = buildKey(item);
+                      const itemSelected = selected.has(key);
+                      const metaUsable = isMetaUsable(item);
                       return (
                         <div className="form-check" key={key}>
                           <input
                             id={key}
                             className="form-check-input"
                             type="checkbox"
-                            checked={selected.has(key)}
+                            checked={itemSelected}
                             onChange={() => toggleSelection(item)}
                             disabled={
-                              saveSelections.isPending || alterationLocked
+                              saveSelections.isPending ||
+                              alterationLocked ||
+                              (!metaUsable && !itemSelected)
                             }
                           />
                           <label htmlFor={key} className="form-check-label">
                             {item.term}
+                            <span
+                              className={`badge ms-2 ${
+                                metaUsable
+                                  ? "text-bg-success"
+                                  : "text-bg-warning"
+                              }`}
+                            >
+                              {metaUsable ? "Pronto para Meta" : "Sem ID Meta"}
+                            </span>
+                            {metaUsable && item.metaKey ? (
+                              <span className="text-muted small ms-2">
+                                {item.metaKey}
+                              </span>
+                            ) : null}
                           </label>
                         </div>
                       );
@@ -173,7 +220,12 @@ export function ExperimentAudienceTab({
           <button
             className="btn btn-primary"
             onClick={handleSave}
-            disabled={saveSelections.isPending || isLoading || alterationLocked}
+            disabled={
+              saveSelections.isPending ||
+              isLoading ||
+              alterationLocked ||
+              selectedWithoutMeta.length > 0
+            }
           >
             {saveSelections.isPending ? (
               <span className="d-inline-flex align-items-center gap-2">

--- a/frontend/src/pages/experiment/ExperimentDetailPage.tsx
+++ b/frontend/src/pages/experiment/ExperimentDetailPage.tsx
@@ -272,6 +272,9 @@ function isExperimentAlterationLocked(experiment: {
   facebookReleaseRequestedAt?: string | null;
 }) {
   const normalizedStatus = (experiment.status ?? "").trim().toUpperCase();
+  if (normalizedStatus === "FAILED") {
+    return false;
+  }
   return (
     Boolean(experiment.facebookReleaseRequestedAt) ||
     EXPERIMENT_ALTERATION_LOCK_STATUSES.has(normalizedStatus)
@@ -1918,8 +1921,7 @@ export default function ExperimentDetailPage() {
       id: "facebook-pixel",
       title: "Pixel temporariamente desligado",
       isMet: true,
-      hint:
-        "Publicação liberada sem pixel enquanto a estratégia de pixels por vertical/conta é reorganizada.",
+      hint: "Publicação liberada sem pixel enquanto a estratégia de pixels por vertical/conta é reorganizada.",
     },
   ];
   const checklistGroups = [


### PR DESCRIPTION
### Motivation
- Prevent saving audience selections that have no official Meta identifier so only publishable targeting is used in campaigns.
- Make it obvious in the UI which targeting elements are "Pronto para Meta" versus "Sem ID Meta" to reduce operator errors.
- Allow editing the audience tab when an experiment is in `FAILED` so teams can correct selections after failures.

### Description
- Backend: updated `ExperimentTargetingSelectionService.resolveTargetingElement` to reject null `targetingElementId`, validate element belongs to the experiment niche, ensure type/hypothesis match and require a non-empty `metaId`, and adjusted `save` to use the linked element term and therefore reject invalid items.
- Frontend: added `isMetaUsable` and `selectedWithoutMeta` logic in `ExperimentAudienceTab` to show badges (`Pronto para Meta` / `Sem ID Meta`), show `metaKey` when present, disable checkboxes for non-meta items unless already selected, and block saving when selected items lack Meta IDs.
- Frontend: changed `isExperimentAlterationLocked` in `ExperimentDetailPage` to allow edits when experiment status is `FAILED` by returning `false` in that case.
- Documentation: added an entry in `docs/registros/experimentos.md` describing the backend and UI changes and the rationale.

### Testing
- Ran backend unit tests with `./gradlew test` and all tests passed. 
- Built and tested the frontend with `yarn build` and ran `yarn test`, both completed successfully. 
- Verified the UI prevents saving when selections include items without `metaId` and that experiments in `FAILED` are editable in manual QA steps (automated checks above passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a31ada68da48321b49801202407e771)