### PR TITLE
Corrige temperatura Hotmart na biblioteca MOIS

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryService.java
@@ -534,14 +534,21 @@ public class MoisSalesLibraryService {
                 ) mwj_latest ON mwj_latest.sales_page_id = p.id
                 LEFT JOIN mois_sales_page_market_warmup_job mwj ON mwj.id = mwj_latest.latest_warmup_job_id
                 LEFT JOIN mois_sales_page_market_warmup_summary mws ON mws.job_id = mwj.id
-                LEFT JOIN mois_collected_reference cr ON cr.id = p.collected_reference_id
+                LEFT JOIN mois_collected_reference cr_direct ON cr_direct.id = p.collected_reference_id
+                LEFT JOIN (
+                    SELECT workspace_id, COALESCE(sales_page_url, product_url) AS reference_url, MAX(id) AS latest_reference_id
+                    FROM mois_collected_reference
+                    WHERE source = 'HOTMART' AND COALESCE(sales_page_url, product_url) IS NOT NULL
+                    GROUP BY workspace_id, COALESCE(sales_page_url, product_url)
+                ) cr_latest ON cr_latest.workspace_id = p.workspace_id AND cr_latest.reference_url = p.url_canonical
+                LEFT JOIN mois_collected_reference cr_url ON cr_url.id = cr_latest.latest_reference_id
                 WHERE p.workspace_id = ?
                 """ + warmupCondition;
         Long total = jdbcTemplate.queryForObject("SELECT COUNT(*) " + joins, Long.class, workspaceId);
         List<MoisSalesLibraryDtos.SalesLibraryPageResponse> items = jdbcTemplate.query("""
                 SELECT p.id, p.workspace_id, p.source, p.url_canonical, p.title, p.current_stage, p.current_status, p.capture_status,
                        COALESCE(p.analysis_status, p.current_status) AS analysis_status, p.url_final, p.http_status, p.html_sha256,
-                       p.html_bytes, p.score_total, p.product_name, cr.producer_name, cr.hotmart_price, cr.hotmart_temperature, cr.hotmart_producer,
+                       p.html_bytes, p.score_total, p.product_name, COALESCE(cr_direct.producer_name, cr_url.producer_name) AS producer_name, COALESCE(cr_direct.hotmart_price, cr_url.hotmart_price) AS hotmart_price, COALESCE(cr_direct.hotmart_temperature, cr_url.hotmart_temperature) AS hotmart_temperature, COALESCE(cr_direct.hotmart_producer, cr_url.hotmart_producer) AS hotmart_producer,
                        p.offer_summary, p.mechanism_summary, p.promise_summary, p.proof_summary,
                        p.model_name, p.input_tokens, p.output_tokens, p.model_cost_usd,
                        p.last_error_category, p.last_error_message, p.last_job_execution_id, p.last_captured_at, p.last_analyzed_at, p.updated_at,
@@ -688,7 +695,7 @@ public class MoisSalesLibraryService {
         List<MoisSalesLibraryDtos.SalesLibraryPageResponse> rows = jdbcTemplate.query("""
                 SELECT p.id, p.workspace_id, p.source, p.url_canonical, p.title, p.current_stage, p.current_status, p.capture_status,
                        COALESCE(p.analysis_status, p.current_status) AS analysis_status, p.url_final, p.http_status, p.html_sha256,
-                       p.html_bytes, p.score_total, p.product_name, cr.producer_name, cr.hotmart_price, cr.hotmart_temperature, cr.hotmart_producer,
+                       p.html_bytes, p.score_total, p.product_name, COALESCE(cr_direct.producer_name, cr_url.producer_name) AS producer_name, COALESCE(cr_direct.hotmart_price, cr_url.hotmart_price) AS hotmart_price, COALESCE(cr_direct.hotmart_temperature, cr_url.hotmart_temperature) AS hotmart_temperature, COALESCE(cr_direct.hotmart_producer, cr_url.hotmart_producer) AS hotmart_producer,
                        p.offer_summary, p.mechanism_summary, p.promise_summary, p.proof_summary,
                        p.model_name, p.input_tokens, p.output_tokens, p.model_cost_usd,
                        p.last_error_category, p.last_error_message, p.last_job_execution_id, p.last_captured_at, p.last_analyzed_at, p.updated_at,
@@ -703,7 +710,14 @@ public class MoisSalesLibraryService {
                 ) mwj_latest ON mwj_latest.sales_page_id = p.id
                 LEFT JOIN mois_sales_page_market_warmup_job mwj ON mwj.id = mwj_latest.latest_warmup_job_id
                 LEFT JOIN mois_sales_page_market_warmup_summary mws ON mws.job_id = mwj.id
-                LEFT JOIN mois_collected_reference cr ON cr.id = p.collected_reference_id
+                LEFT JOIN mois_collected_reference cr_direct ON cr_direct.id = p.collected_reference_id
+                LEFT JOIN (
+                    SELECT workspace_id, COALESCE(sales_page_url, product_url) AS reference_url, MAX(id) AS latest_reference_id
+                    FROM mois_collected_reference
+                    WHERE source = 'HOTMART' AND COALESCE(sales_page_url, product_url) IS NOT NULL
+                    GROUP BY workspace_id, COALESCE(sales_page_url, product_url)
+                ) cr_latest ON cr_latest.workspace_id = p.workspace_id AND cr_latest.reference_url = p.url_canonical
+                LEFT JOIN mois_collected_reference cr_url ON cr_url.id = cr_latest.latest_reference_id
                 WHERE p.id = ? LIMIT 1
                 """, this::mapSalesPageResponse, pageId);
         if (rows.isEmpty()) throw new IllegalArgumentException("Page not found: " + pageId);

--- a/backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryServiceTest.java
@@ -176,7 +176,8 @@ class MoisSalesLibraryServiceTest {
         verify(jdbcTemplate).query(sqlCaptor.capture(), isA(RowMapper.class), eq("workspace-001"), eq(20), eq(0));
         org.assertj.core.api.Assertions.assertThat(sqlCaptor.getValue())
                 .contains("LEFT JOIN mois_sales_page_market_warmup_summary mws")
-                .contains("cr.hotmart_temperature")
+                .contains("cr_latest.workspace_id = p.workspace_id AND cr_latest.reference_url = p.url_canonical")
+                .contains("COALESCE(cr_direct.hotmart_temperature, cr_url.hotmart_temperature) AS hotmart_temperature")
                 .contains("ORDER BY p.last_analyzed_at DESC, p.updated_at DESC, p.id DESC LIMIT ? OFFSET ?");
     }
 

--- a/docs/registros/mois1.md
+++ b/docs/registros/mois1.md
@@ -1638,3 +1638,9 @@ Arquivos principais:
   - docs/canonical/mois-hotmart-mapeamento-ciclos-campos-banco.md
   - mois-hotmart-collector/AGENTS.md
   - docs/registros/mois1.md
+
+## 2026-06-16 — Temperatura Hotmart na biblioteca de sales pages
+
+- Corrigida a causa-raiz da tela `/mois/sales-pages-library` exibir `—` na temperatura Hotmart: páginas consolidadas novas estavam sem `collected_reference_id`, embora a referência Hotmart existisse em `mois_collected_reference` com a mesma URL canônica.
+- Ajustada a consulta da biblioteca para usar a referência direta quando existir e, caso contrário, recuperar a última referência Hotmart pela URL da página/produto, preservando preço, produtor e temperatura na listagem e no detalhe.
+- Adicionado teste de regressão para garantir que a consulta mantenha o fallback por URL e não volte a depender apenas do vínculo direto.


### PR DESCRIPTION
### Motivation
- Corrigir a causa-raiz que fazia a tela `/mois/sales-pages-library` exibir `—` na temperatura Hotmart quando a página consolidada não tinha `collected_reference_id` mesmo havendo referência em `mois_collected_reference` com a mesma URL canônica.
- Garantir que a listagem e o detalhe preservem `hotmart_price`, `hotmart_temperature`, `hotmart_producer` e `producer_name` mesmo para produtos consolidados sem vínculo direto à referência coletada.

### Description
- Atualiza a consulta em `MoisSalesLibraryService` para usar `LEFT JOIN` adicional que encontra a última `mois_collected_reference` por `workspace_id` + `COALESCE(sales_page_url, product_url)` e faz `COALESCE(cr_direct.*, cr_url.*)` no `SELECT` para retornar preço, produtor e temperatura Hotmart quando `collected_reference_id` estiver ausente.
- Aplica o mesmo fallback por URL na query de detalhe (`getPage`) para manter consistência entre listagem e detalhe. 
- Ajusta o teste unitário `MoisSalesLibraryServiceTest` para validar que a SQL gerada contém a nova junção/fallback e a seleção `COALESCE(... hotmart_temperature ...)` como regressão contra a quebra anterior. 
- Registra a correção no histórico operacional em `docs/registros/mois1.md` explicando a causa-raiz e a mitigação.

### Testing
- Executado o teste unitário específico com `MoisSalesLibraryServiceTest` (módulo `ads-service`) e a suíte relacionada ao serviço, que passou localmente durante a verificação (testes verdes).
- Validada a query contra o banco via MCP com `tools/db_query` confirmando que a nova consulta retorna `hotmart_temperature=150.00` para produtos recentes usando o fallback por URL; a verificação foi bem-sucedida.
- Executado `git diff --check` para checar formatação e não foram encontrados problemas.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a31b77531ac83219881cc442c6aff18)