### PR TITLE
Add automatic-processing metrics to Sales Library summary and show them in UI

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/dto/MoisSalesLibraryDtos.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/dto/MoisSalesLibraryDtos.java
@@ -274,6 +274,11 @@ public final class MoisSalesLibraryDtos {
             long marketWarmupCold,
             long marketWarmupSaturated,
             long marketWarmupStuck,
+            boolean automaticProcessingActive,
+            Instant lastCapturedAt,
+            long capturedLastHour,
+            long remainingWithoutHtml,
+            BigDecimal averageCapturesPerHour,
             Instant updatedAt
     ) {
     }

--- a/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryService.java
@@ -658,6 +658,26 @@ public class MoisSalesLibraryService {
                        SUM(mws.market_temperature = 'SATURATED') AS market_warmup_saturated,
                        SUM(mwj.status = 'FETCHING'
                            AND COALESCE(mwj.started_at, mwj.updated_at, mwj.created_at) < DATE_SUB(UTC_TIMESTAMP(), INTERVAL 120 MINUTE)) AS market_warmup_stuck,
+                       SUM(COALESCE(p.html_bytes, 0) = 0) AS remaining_without_html,
+                       MAX(CASE WHEN COALESCE(p.html_bytes, 0) > 0 THEN p.last_captured_at END) AS last_captured_at,
+                       (
+                           SELECT COUNT(DISTINCT e.sales_page_id)
+                           FROM mois_sales_page_job_execution e
+                           JOIN mois_sales_page ep ON ep.id = e.sales_page_id
+                           WHERE ep.workspace_id = ?
+                             AND e.stage = 'CAPTURE'
+                             AND e.status = 'CAPTURED'
+                             AND e.finished_at >= DATE_SUB(UTC_TIMESTAMP(), INTERVAL 1 HOUR)
+                       ) AS captured_last_hour,
+                       (
+                           SELECT COUNT(DISTINCT e.sales_page_id)
+                           FROM mois_sales_page_job_execution e
+                           JOIN mois_sales_page ep ON ep.id = e.sales_page_id
+                           WHERE ep.workspace_id = ?
+                             AND e.stage = 'CAPTURE'
+                             AND e.status = 'CAPTURED'
+                             AND e.finished_at >= DATE_SUB(UTC_TIMESTAMP(), INTERVAL 6 HOUR)
+                       ) / 6.0 AS average_captures_per_hour,
                        MAX(p.updated_at) AS updated_at
                 FROM mois_sales_page p
                 LEFT JOIN (
@@ -678,7 +698,11 @@ public class MoisSalesLibraryService {
                 rs.getLong("market_warmup_failed"), rs.getLong("market_warmup_hot"),
                 rs.getLong("market_warmup_promising"), rs.getLong("market_warmup_warm"),
                 rs.getLong("market_warmup_cold"), rs.getLong("market_warmup_saturated"),
-                rs.getLong("market_warmup_stuck"), toInstant(rs.getTimestamp("updated_at"))), workspaceId);
+                rs.getLong("market_warmup_stuck"),
+                rs.getLong("capturing") > 0 || rs.getLong("captured_last_hour") > 0,
+                toInstant(rs.getTimestamp("last_captured_at")), rs.getLong("captured_last_hour"),
+                rs.getLong("remaining_without_html"), rs.getBigDecimal("average_captures_per_hour"),
+                toInstant(rs.getTimestamp("updated_at"))), workspaceId, workspaceId, workspaceId);
     }
 
     /**

--- a/backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryServiceTest.java
@@ -117,6 +117,8 @@ class MoisSalesLibraryServiceTest {
         given(jdbcTemplate.queryForObject(
                 contains("SUM(COALESCE(p.html_bytes, 0) > 0) AS captured"),
                 isA(RowMapper.class),
+                eq("workspace-001"),
+                eq("workspace-001"),
                 eq("workspace-001")))
                 .willReturn(new MoisSalesLibraryDtos.SalesLibraryPageSummaryResponse(
                         "workspace-001",
@@ -143,6 +145,11 @@ class MoisSalesLibraryServiceTest {
                         5L,
                         7L,
                         2L,
+                        true,
+                        Instant.parse("2026-06-07T05:20:13Z"),
+                        9L,
+                        94L,
+                        BigDecimal.valueOf(6.5),
                         Instant.parse("2026-06-07T05:38:13Z")
                 ));
 
@@ -151,6 +158,10 @@ class MoisSalesLibraryServiceTest {
         org.assertj.core.api.Assertions.assertThat(response.captured()).isEqualTo(327L);
         org.assertj.core.api.Assertions.assertThat(response.analysisPending()).isEqualTo(190L);
         org.assertj.core.api.Assertions.assertThat(response.marketWarmupEligible()).isEqualTo(106L);
+        org.assertj.core.api.Assertions.assertThat(response.automaticProcessingActive()).isTrue();
+        org.assertj.core.api.Assertions.assertThat(response.capturedLastHour()).isEqualTo(9L);
+        org.assertj.core.api.Assertions.assertThat(response.remainingWithoutHtml()).isEqualTo(94L);
+        org.assertj.core.api.Assertions.assertThat(response.averageCapturesPerHour()).isEqualByComparingTo("6.5");
         org.assertj.core.api.Assertions.assertThat(response.marketWarmupCompleted()).isEqualTo(70L);
         org.assertj.core.api.Assertions.assertThat(response.marketWarmupPromising()).isEqualTo(28L);
         org.assertj.core.api.Assertions.assertThat(response.marketWarmupStuck()).isEqualTo(2L);

--- a/backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/web/MoisSalesLibraryControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/web/MoisSalesLibraryControllerTest.java
@@ -166,6 +166,11 @@ class MoisSalesLibraryControllerTest {
                         5L,
                         18L,
                         3L,
+                        true,
+                        Instant.parse("2026-06-04T15:50:09Z"),
+                        5L,
+                        125L,
+                        BigDecimal.valueOf(4.5),
                         Instant.parse("2026-06-04T16:00:09Z")
                 ));
 
@@ -175,6 +180,10 @@ class MoisSalesLibraryControllerTest {
                 .andExpect(jsonPath("$.total").value(145))
                 .andExpect(jsonPath("$.pending").value(4))
                 .andExpect(jsonPath("$.captured").value(20))
+                .andExpect(jsonPath("$.automaticProcessingActive").value(true))
+                .andExpect(jsonPath("$.capturedLastHour").value(5))
+                .andExpect(jsonPath("$.remainingWithoutHtml").value(125))
+                .andExpect(jsonPath("$.averageCapturesPerHour").value(4.5))
                 .andExpect(jsonPath("$.analyzed").value(105))
                 .andExpect(jsonPath("$.analysisPending").value(12))
                 .andExpect(jsonPath("$.analysisRunning").value(2))

--- a/docs/registros/mois1.md
+++ b/docs/registros/mois1.md
@@ -1638,3 +1638,9 @@ Arquivos principais:
   - docs/canonical/mois-hotmart-mapeamento-ciclos-campos-banco.md
   - mois-hotmart-collector/AGENTS.md
   - docs/registros/mois1.md
+
+## 2026-06-16 — Visibilidade do processamento automático da Biblioteca Sales Pages
+
+- Adicionados indicadores operacionais na tela do pipeline de páginas de vendas para mostrar se o processamento automático está ativo, a última captura feita, páginas capturadas na última hora, páginas ainda sem HTML útil e velocidade média de avanço.
+- Expandido o resumo do backend da biblioteca MOIS com métricas de acompanhamento da etapa 1 baseadas em `mois_sales_page` e `mois_sales_page_job_execution`.
+- Atualizado o contrato Swagger e o tipo TypeScript do resumo para manter frontend, backend e documentação sincronizados.

--- a/docs/swagger/mois-sales-library-swagger.yaml
+++ b/docs/swagger/mois-sales-library-swagger.yaml
@@ -1550,6 +1550,26 @@ components:
           type: integer
           format: int64
           description: Jobs da Etapa 3 em `FETCHING` há mais de 120 minutos, considerados presos para saneamento operacional.
+        automaticProcessingActive:
+          type: boolean
+          description: Indica avanço automático recente quando há captura em execução ou páginas capturadas na última hora.
+        lastCapturedAt:
+          type: string
+          format: date-time
+          nullable: true
+          description: Data/hora da última página com HTML útil capturado.
+        capturedLastHour:
+          type: integer
+          format: int64
+          description: Total de páginas capturadas pela etapa 1 na última hora.
+        remainingWithoutHtml:
+          type: integer
+          format: int64
+          description: Total de páginas ainda sem HTML útil (`html_bytes = 0`).
+        averageCapturesPerHour:
+          type: number
+          format: double
+          description: Média de páginas capturadas por hora nas últimas 6 horas.
         updatedAt:
           type: string
           format: date-time

--- a/frontend/src/api/mois/types.ts
+++ b/frontend/src/api/mois/types.ts
@@ -321,6 +321,11 @@ export interface MoisSalesLibraryPageSummary {
   marketWarmupCold: number;
   marketWarmupSaturated: number;
   marketWarmupStuck: number;
+  automaticProcessingActive: boolean;
+  lastCapturedAt?: string;
+  capturedLastHour: number;
+  remainingWithoutHtml: number;
+  averageCapturesPerHour: number;
   updatedAt?: string;
 }
 

--- a/frontend/src/api/mois/useMoisSalesLibrary.ts
+++ b/frontend/src/api/mois/useMoisSalesLibrary.ts
@@ -138,6 +138,7 @@ export function useMoisSalesLibraryOpportunityRanking(
 export function useMoisSalesLibraryPageSummary(workspaceId: string) {
   return useQuery({
     queryKey: ["mois", "sales-library", "pages-summary", workspaceId],
+    refetchInterval: 30000,
     queryFn: async () => {
       const { data } = await axios.get<MoisSalesLibraryPageSummary>(
         "/api/mois/sales-library/pages/summary",

--- a/frontend/src/pages/mois/MoisSalesPagesPipelinePage.tsx
+++ b/frontend/src/pages/mois/MoisSalesPagesPipelinePage.tsx
@@ -46,6 +46,26 @@ function formatBytes(value: number) {
   return `${(value / (1024 * 1024)).toFixed(1)} MB`;
 }
 
+function formatDateTime(value?: string) {
+  if (!value) {
+    return "Sem captura registrada";
+  }
+  return new Intl.DateTimeFormat("pt-BR", {
+    dateStyle: "short",
+    timeStyle: "short",
+  }).format(new Date(value));
+}
+
+function formatAverage(value?: number) {
+  if (!value) {
+    return "0,0/h";
+  }
+  return `${value.toLocaleString("pt-BR", {
+    maximumFractionDigits: 1,
+    minimumFractionDigits: 1,
+  })}/h`;
+}
+
 function getSnapshotStatusBadgeClass(status: string) {
   switch (status) {
     case "CAPTURED":
@@ -97,6 +117,11 @@ export default function MoisSalesPagesPipelinePage() {
   const analysisRunning = summary?.analysisRunning ?? 0;
   const analysisFailed = summary?.analysisFailed ?? 0;
   const pendingPages = summary?.pending ?? 0;
+  const automaticProcessingActive = summary?.automaticProcessingActive ?? false;
+  const lastCapturedAt = summary?.lastCapturedAt;
+  const capturedLastHour = summary?.capturedLastHour ?? 0;
+  const remainingWithoutHtml = summary?.remainingWithoutHtml ?? 0;
+  const averageCapturesPerHour = summary?.averageCapturesPerHour ?? 0;
   const marketWarmupEligiblePages = summary?.marketWarmupEligible ?? 0;
   const marketWarmupPending = summary?.marketWarmupPending ?? 0;
   const marketWarmupRunning = summary?.marketWarmupRunning ?? 0;
@@ -236,6 +261,69 @@ export default function MoisSalesPagesPipelinePage() {
                   <h3 className="mb-0">
                     {summaryQuery.isLoading ? "..." : (summary?.captured ?? 0)}
                   </h3>
+                </div>
+              </div>
+            </div>
+
+            <div className="border rounded-3 p-3 mt-3">
+              <div className="d-flex flex-wrap align-items-start justify-content-between gap-3 mb-3">
+                <div>
+                  <h4 className="h6 mb-1">Processamento automático</h4>
+                  <p className="text-secondary small mb-0">
+                    Indicadores atualizados automaticamente para confirmar se a
+                    biblioteca continua tratando páginas sem ação manual.
+                  </p>
+                </div>
+                <span
+                  className={`badge ${
+                    automaticProcessingActive
+                      ? "text-bg-success"
+                      : "text-bg-secondary"
+                  }`}
+                >
+                  {automaticProcessingActive
+                    ? "Processamento automático ativo"
+                    : "Sem avanço recente"}
+                </span>
+              </div>
+              <div className="row g-3">
+                <div className="col-sm-6 col-xl-3">
+                  <div className="bg-light rounded-3 p-3 h-100">
+                    <p className="text-secondary mb-1">Última captura feita</p>
+                    <h5 className="mb-0">
+                      {summaryQuery.isLoading
+                        ? "..."
+                        : formatDateTime(lastCapturedAt)}
+                    </h5>
+                  </div>
+                </div>
+                <div className="col-sm-6 col-xl-3">
+                  <div className="bg-light rounded-3 p-3 h-100">
+                    <p className="text-secondary mb-1">
+                      Capturadas na última hora
+                    </p>
+                    <h5 className="mb-0">
+                      {summaryQuery.isLoading ? "..." : capturedLastHour}
+                    </h5>
+                  </div>
+                </div>
+                <div className="col-sm-6 col-xl-3">
+                  <div className="bg-light rounded-3 p-3 h-100">
+                    <p className="text-secondary mb-1">Ainda faltam</p>
+                    <h5 className="mb-0">
+                      {summaryQuery.isLoading ? "..." : remainingWithoutHtml}
+                    </h5>
+                  </div>
+                </div>
+                <div className="col-sm-6 col-xl-3">
+                  <div className="bg-light rounded-3 p-3 h-100">
+                    <p className="text-secondary mb-1">Velocidade média</p>
+                    <h5 className="mb-0">
+                      {summaryQuery.isLoading
+                        ? "..."
+                        : formatAverage(averageCapturesPerHour)}
+                    </h5>
+                  </div>
                 </div>
               </div>
             </div>


### PR DESCRIPTION
### Motivation

- Provide operational visibility into the automatic capture pipeline by exposing recent capture activity and backlog metrics in the Sales Library summary.

### Description

- Added SQL aggregations to compute `remaining_without_html`, `last_captured_at`, `captured_last_hour` and `average_captures_per_hour` and exposed a derived `automaticProcessingActive` boolean in `MoisSalesLibraryService` and the `SalesLibraryPageSummaryResponse` DTO.
- Updated the Swagger contract (`docs/swagger/mois-sales-library-swagger.yaml`), frontend TypeScript types (`frontend/src/api/mois/types.ts`), and documentation (`docs/registros/mois1.md`) to include the new fields `automaticProcessingActive`, `lastCapturedAt`, `capturedLastHour`, `remainingWithoutHtml` and `averageCapturesPerHour`.
- Frontend changes include a 30s polling interval for the summary query (`useMoisSalesLibraryPageSummary`), new formatting helpers, and a UI block in `MoisSalesPagesPipelinePage.tsx` that displays the automatic processing badge and the new metrics.
- Updated unit tests and controller tests to account for the new fields and adjusted the service call parameters accordingly.

### Testing

- Updated `MoisSalesLibraryServiceTest` to assert the new summary fields and `MoisSalesLibraryControllerTest` to verify the controller JSON includes the added properties.
- Ran the Java unit test suite covering the modified tests (`MoisSalesLibraryServiceTest`, `MoisSalesLibraryControllerTest`); the tests passed locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a31b725f7a083218750e00eff47fc15)