### PR TITLE
Fix MCP Meta service constructor injection

### DIFF
--- a/mcp-server/src/main/java/com/marketinghub/mcpserver/service/MetaDiagnosticsService.java
+++ b/mcp-server/src/main/java/com/marketinghub/mcpserver/service/MetaDiagnosticsService.java
@@ -5,8 +5,9 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marketinghub.mcpserver.config.McpProperties;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.http.ResponseEntity;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.dao.DataAccessException;
+import org.springframework.http.ResponseEntity;
 import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Service;
 import org.springframework.util.StringUtils;
@@ -44,6 +45,7 @@ public class MetaDiagnosticsService {
     /**
      * Inicializa o serviço usando um cliente HTTP padrão para documentação e Graph API.
      */
+    @Autowired
     public MetaDiagnosticsService(McpProperties properties, ObjectMapper objectMapper, JdbcTemplate jdbcTemplate) {
         this(properties, objectMapper, jdbcTemplate, new RestTemplate());
     }


### PR DESCRIPTION
### Motivation
- Spring failed to instantiate the application context for `McpControllerTest` because `MetaDiagnosticsService` exposed two constructors and the container could not pick the production one, causing `NoSuchMethodException`/`No default constructor found` errors during bean creation. 

### Description
- Annotated the production constructor of `MetaDiagnosticsService` with `@Autowired` so Spring will select it when creating the bean. 
- Preserved the package-private constructor that accepts a `RestTemplate` to allow isolated unit tests to inject a mock HTTP client. 
- Changed file: `mcp-server/src/main/java/com/marketinghub/mcpserver/service/MetaDiagnosticsService.java`.

### Testing
- Ran `mvn -Dtest=McpControllerTest test` in `mcp-server` and observed the previously failing context load errors disappear with the controller tests passing. 
- Ran full `mvn test` in `mcp-server` and all tests passed (`Tests run: 25, Failures: 0, Errors: 0`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a31c103f6a883219262fa17f6bb165c)