### PR TITLE
Inject Brazil geo_locations into /reachestimate validation

### DIFF
--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -4606,3 +4606,9 @@
 - causa-raiz: o bloqueio da tela considerava qualquer `facebook_release_requested_at`, mesmo quando o experimento voltava para `FAILED`; além disso, a UI exibia itens aprovados no nicho sem diferenciar os que possuíam `meta_id` oficial dos que ainda não eram publicáveis na Meta.
 - correção aplicada: experimentos em `FAILED` deixam de travar a edição; a aba Público passa a exibir selo “Pronto para Meta” ou “Sem ID Meta”, bloqueando a inclusão de novos itens sem ID oficial e impedindo salvar enquanto houver seleção inválida.
 - prevenção de recorrência: o backend passou a rejeitar salvamento de seleção vinculada a elemento de targeting sem ID oficial da Meta.
+
+## 2026-06-16 — Correção da validação de alcance do Experimento 39
+- solicitação: verificar novo retry do Experimento 39 após retorno para PLANNED.
+- causa-raiz: o Facebook Ads Worker montava corretamente o ad set final com `geo_locations.countries=["BR"]`, mas a validação prévia de alcance em `/reachestimate` usava apenas interesses/cargos/comportamentos do pacote aprovado, sem localização; a Meta rejeitou a estimativa com “Falta uma localização” e o worker marcou o experimento como `FAILED` antes de criar a campanha.
+- correção aplicada: a validação prévia de alcance agora injeta Brasil como localização quando o pacote de targeting aprovado não traz `geo_locations`, alinhando a estimativa ao ad set que será publicado.
+- prevenção de recorrência: adicionado teste automatizado garantindo que o `targeting_spec` enviado para `/reachestimate` inclui `geo_locations.countries=["BR"]`.

--- a/facebook-ads-worker/AGENTS.md
+++ b/facebook-ads-worker/AGENTS.md
@@ -10,6 +10,7 @@
 - A versão da Graph API é configurável via propriedade `facebook.graph-api.version` (default `v23.0`) e deve estar alinhada com a recomendação oficial.
 - Nas chamadas de validação de público (`/targetingvalidation`) e estimativa de alcance (`/reachestimate`), serializar `targeting_spec` com URL encoding completo para evitar erro de expansão (`Not enough variable values available to expand`) quando o JSON inclui chaves entre `{}`.
 - Ao serializar `targeting_spec`, use codificação estrita (UTF-8) e preserve espaços como `%20` (não `+`) para manter compatibilidade com a Graph API.
+- Em estimativas de alcance (`/reachestimate`) feitas antes da publicação, garanta `geo_locations.countries = ["BR"]` quando o pacote de segmentação aprovado não trouxer localização explícita, mantendo a validação alinhada ao ad set que será criado.
 - Na fila de resolução de targeting (`targeting_resolution_job`), sempre priorize o `ad_account_id` da conta de Facebook associada ao experimento (`ad_set -> experiment -> fb_page -> fb_account`) antes de qualquer fallback global.
 - Sugestões de interesses baseadas em seed devem usar o endpoint `/act_<AD_ACCOUNT_ID>/targetingsuggestions` com o parâmetro `targeting_list=[{"type":"interests","id":"..."}]` guardando os seeds escolhidos.
 - No discovery de público do playbook (`FACEBOOK_SEED_LOOKUP`), execute chamadas separadas em `/act_<AD_ACCOUNT_ID>/targetingsearch` para `adinterest`, `adbehavior` e `adworkposition`; não use payload misto sem `type` nem fallback por `/search` para essa etapa.

--- a/facebook-ads-worker/README.md
+++ b/facebook-ads-worker/README.md
@@ -138,6 +138,10 @@ O fluxo automatizado cria toda a hierarquia necessária para veiculação:
    códigos não numéricos (por exemplo, `"SP"`) são descartados com aviso em log
    para evitar a rejeição `(#100) Invalid parameter` devolvida pela Meta. Chaves
    não textuais em `geo_locations` também são ignoradas antes do envio para a
+   API. A validação prévia de alcance (`/reachestimate`) usa a mesma regra de
+   país inteiro e injeta `geo_locations.countries = ["BR"]` quando o pacote de
+   público aprovado contém apenas interesses, cargos ou comportamentos, evitando
+   rejeição da Meta por falta de localização antes da criação da campanha.
    Graph API, garantindo que o payload use apenas campos com nomes válidos.
    Se a Meta rejeitar o `POST /adsets` com erro no formato
    `targeting[<campo>][<índice>][id]` (por exemplo, `interests` ou

--- a/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java
+++ b/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java
@@ -62,7 +62,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Supplier;
 
 /**
- * Orchestrates Facebook campaign publication for released Marketing Hub experiments.
+ * Orquestra a publicação de campanhas Facebook para experimentos liberados no Marketing Hub.
  */
 @Service
 public class FacebookCampaignService {
@@ -391,7 +391,12 @@ public class FacebookCampaignService {
             } else {
                 resolvedTargeting = resolveApprovedManualTargeting(exp.id());
             }
-            validateReachBeforeCampaignCreation(exp.id(), config.adAccountId(), resolvedTargeting.targetingJson());
+            validateReachBeforeCampaignCreation(
+                exp.id(),
+                config.adAccountId(),
+                resolvedTargeting.targetingJson(),
+                FacebookAdsService.BRAZIL_COUNTRY_CODE
+            );
             creativePayloads = preloadCreativeImagesForExperiment(exp.id(), config.adAccountId(), creativePayloads);
             try {
                 campaignId = executeFacebookCallWithLogging(
@@ -867,8 +872,12 @@ public class FacebookCampaignService {
     /**
      * Valida o alcance do público na Meta antes de criar qualquer campanha do experimento.
      */
-    private void validateReachBeforeCampaignCreation(long experimentId, String adAccountId, String targetingJson) {
-        JsonNode targetingSpec = parseTargetingSpecForReachValidation(experimentId, targetingJson);
+    private void validateReachBeforeCampaignCreation(long experimentId,
+                                                     String adAccountId,
+                                                     String targetingJson,
+                                                     String targetCountry) {
+        ObjectNode targetingSpec = parseTargetingSpecForReachValidation(experimentId, targetingJson);
+        ensureGeoLocationForReachValidation(targetingSpec, targetCountry);
         JsonNode response = executeFacebookCallWithLogging(
             experimentId,
             ExperimentFacebookApiLogContext.CAMPAIGN_REACH_VALIDATION,
@@ -903,18 +912,35 @@ public class FacebookCampaignService {
     /**
      * Converte o targeting JSON aprovado em objeto validável pela Graph API.
      */
-    private JsonNode parseTargetingSpecForReachValidation(long experimentId, String targetingJson) {
+    private ObjectNode parseTargetingSpecForReachValidation(long experimentId, String targetingJson) {
         if (!StringUtils.hasText(targetingJson)) {
             throw new IllegalStateException("Targeting vazio para validação de alcance do experimento " + experimentId);
         }
         try {
-            return objectMapper.readTree(targetingJson);
+            JsonNode parsed = objectMapper.readTree(targetingJson);
+            if (!parsed.isObject()) {
+                throw new IllegalStateException("Targeting precisa ser um objeto JSON");
+            }
+            return (ObjectNode) parsed;
         } catch (Exception ex) {
             throw new IllegalStateException(
                 "Targeting inválido para validação de alcance do experimento " + experimentId + ": " + ex.getMessage(),
                 ex
             );
         }
+    }
+
+    /**
+     * Garante localização no payload de estimativa para manter o contrato mínimo exigido pela Meta.
+     */
+    private void ensureGeoLocationForReachValidation(ObjectNode targetingSpec, String targetCountry) {
+        JsonNode existingGeoLocations = targetingSpec.path("geo_locations");
+        if (existingGeoLocations.isObject() && existingGeoLocations.size() > 0) {
+            return;
+        }
+        ObjectNode geoLocations = targetingSpec.putObject("geo_locations");
+        ArrayNode countries = geoLocations.putArray("countries");
+        countries.add(StringUtils.hasText(targetCountry) ? targetCountry : FacebookAdsService.BRAZIL_COUNTRY_CODE);
     }
 
     /**

--- a/facebook-ads-worker/src/test/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignServiceTest.java
+++ b/facebook-ads-worker/src/test/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignServiceTest.java
@@ -28,6 +28,8 @@ import org.springframework.web.reactive.function.client.WebClient;
 import reactor.netty.http.client.HttpClient;
 
 import java.io.IOException;
+import java.net.URLDecoder;
+import java.nio.charset.StandardCharsets;
 import java.time.Duration;
 import java.util.ArrayDeque;
 import java.util.List;
@@ -42,7 +44,7 @@ import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 /**
- * Verifies Facebook campaign publication orchestration against backend and Meta API stubs.
+ * Valida a orquestração de publicação de campanhas Facebook contra stubs de backend e Meta API.
  */
 @Timeout(value = 15, unit = TimeUnit.SECONDS)
 class FacebookCampaignServiceTest {
@@ -420,6 +422,8 @@ class FacebookCampaignServiceTest {
         );
         RecordedRequest reachRequest = takeFacebookRequest("reach validation");
         assertTrue(reachRequest.getPath().contains("/reachestimate?"));
+        JsonNode reachTargetingSpec = targetingSpecFromReachEstimateRequest(reachRequest);
+        assertEquals("BR", reachTargetingSpec.get("geo_locations").get("countries").get(0).asText());
         RecordedRequest failedStatusRequest = takeBackendRequestMatching(
             "failed status update",
             request -> request.getPath() != null
@@ -1398,6 +1402,21 @@ class FacebookCampaignServiceTest {
         assertEquals(1, workPositions.size());
         assertEquals("1419795191647433", workPositions.get(0).get("id").asText());
         assertEquals("Certified Personal Trainer", workPositions.get(0).get("name").asText());
+    }
+
+    /**
+     * Extrai o targeting_spec enviado para a estimativa de alcance da Meta.
+     */
+    private JsonNode targetingSpecFromReachEstimateRequest(RecordedRequest request) throws IOException {
+        String path = request.getPath();
+        assertNotNull(path);
+        String prefix = "targeting_spec=";
+        int start = path.indexOf(prefix);
+        assertTrue(start >= 0);
+        int valueStart = start + prefix.length();
+        int valueEnd = path.indexOf('&', valueStart);
+        String encoded = valueEnd >= 0 ? path.substring(valueStart, valueEnd) : path.substring(valueStart);
+        return objectMapper.readTree(URLDecoder.decode(encoded, StandardCharsets.UTF_8));
     }
 
     @Test


### PR DESCRIPTION
### Motivation
- The Facebook Ads Worker validated audience reach via `/reachestimate` without a location when the approved targeting package lacked `geo_locations`, causing Meta to reject the estimate with “missing location” and failing the experiment before campaign creation.
- Documentation and runbooks needed to reflect the requirement to align reach estimation payloads with the ad set that will be created for Brazil.

### Description
- Adjusted `validateReachBeforeCampaignCreation` to accept a `targetCountry` parameter and ensure the reach estimation payload includes `geo_locations.countries = ["BR"]` when no geo is present. 
- Changed `parseTargetingSpecForReachValidation` to return an `ObjectNode` and added `ensureGeoLocationForReachValidation` to inject the country into the targeting spec. 
- Updated `AGENTS.md` and `README.md` to document the rule that `/reachestimate` requests must include `geo_locations.countries = ["BR"]` when the approved targeting package lacks explicit location. 
- Updated `FacebookCampaignServiceTest` to assert the `targeting_spec` sent to `/reachestimate` includes Brazil and added `targetingSpecFromReachEstimateRequest` helper to decode the URL-encoded payload. 

### Testing
- Ran unit tests in `facebook-ads-worker/src/test/java/.../FacebookCampaignServiceTest` which include the new assertion validating `geo_locations.countries = ["BR"]`, and they passed. 
- Executed the module test suite (`mvn test`) to verify integration of the reach validation change with existing campaign publication flows, and the tests completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a31bd4f57a48321b2d5c025b56bf44e)