### PR TITLE
Record metaIdUnavailable for targeting elements and stop repeated Meta Ads lookups

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/targeting/TargetingElementRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/targeting/TargetingElementRepository.java
@@ -80,6 +80,7 @@ public interface TargetingElementRepository extends JpaRepository<TargetingEleme
                 com.marketinghub.targeting.TargetingElementType.JOB_TITLE,
                 com.marketinghub.targeting.TargetingElementType.BEHAVIOR
               )
+              and (e.metaIdUnavailable is null or e.metaIdUnavailable = false)
               and (e.metaId is null or e.metaAudienceSizeLowerBound is null or e.metaAudienceSizeUpperBound is null)
             order by e.updatedAt asc, e.id asc
             """)

--- a/backend/ads-service/src/main/java/com/marketinghub/targeting/TargetingElement.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/targeting/TargetingElement.java
@@ -79,6 +79,15 @@ public class TargetingElement {
     @Column(name = "meta_audience_size_upper_bound")
     private Long metaAudienceSizeUpperBound;
 
+    @Column(name = "meta_id_unavailable", nullable = false)
+    @Builder.Default
+    private Boolean metaIdUnavailable = false;
+
+    @Lob
+    @JdbcTypeCode(SqlTypes.LONGVARCHAR)
+    @Column(name = "meta_id_unavailable_reason")
+    private String metaIdUnavailableReason;
+
     @Column(precision = 10, scale = 4)
     private BigDecimal confidence;
 

--- a/backend/ads-service/src/main/java/com/marketinghub/targeting/dto/TargetingElementDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/targeting/dto/TargetingElementDto.java
@@ -32,6 +32,8 @@ public class TargetingElementDto {
     private String metaKey;
     private Long metaAudienceSizeLowerBound;
     private Long metaAudienceSizeUpperBound;
+    private Boolean metaIdUnavailable;
+    private String metaIdUnavailableReason;
     private BigDecimal confidence;
     private Instant createdAt;
     private Instant updatedAt;

--- a/backend/ads-service/src/main/java/com/marketinghub/targeting/dto/UpdateTargetingMetaAdsDataRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/targeting/dto/UpdateTargetingMetaAdsDataRequest.java
@@ -1,8 +1,13 @@
 package com.marketinghub.targeting.dto;
 
+/**
+ * Contrato interno para atualizar o resultado de enriquecimento Meta Ads de um elemento de segmentação.
+ */
 public record UpdateTargetingMetaAdsDataRequest(
         String metaId,
         String metaKey,
         Long metaAudienceSizeLowerBound,
-        Long metaAudienceSizeUpperBound
+        Long metaAudienceSizeUpperBound,
+        Boolean metaIdUnavailable,
+        String metaIdUnavailableReason
 ) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/targeting/service/TargetingElementService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/targeting/service/TargetingElementService.java
@@ -137,6 +137,8 @@ public class TargetingElementService {
         element.setMetaKey(null);
         element.setMetaAudienceSizeLowerBound(null);
         element.setMetaAudienceSizeUpperBound(null);
+        element.setMetaIdUnavailable(false);
+        element.setMetaIdUnavailableReason(null);
         return repository.save(element);
     }
 

--- a/backend/ads-service/src/main/java/com/marketinghub/targeting/service/TargetingMetaAdsSyncService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/targeting/service/TargetingMetaAdsSyncService.java
@@ -36,7 +36,7 @@ public class TargetingMetaAdsSyncService {
     }
 
     /**
-     * Atualiza o elemento com ID oficial, chave exibível e faixa de audiência retornados pela Meta.
+     * Atualiza o elemento com sucesso da Meta ou marca ausência definitiva de ID oficial para sair da fila.
      */
     @Transactional
     public void updateMetaAdsData(Long id, UpdateTargetingMetaAdsDataRequest request) {
@@ -56,6 +56,17 @@ public class TargetingMetaAdsSyncService {
         if (request.metaAudienceSizeUpperBound() != null) {
             element.setMetaAudienceSizeUpperBound(request.metaAudienceSizeUpperBound());
         }
+        if (Boolean.TRUE.equals(request.metaIdUnavailable())) {
+            element.setMetaId(null);
+            element.setMetaKey(null);
+            element.setMetaAudienceSizeLowerBound(null);
+            element.setMetaAudienceSizeUpperBound(null);
+            element.setMetaIdUnavailable(true);
+            element.setMetaIdUnavailableReason(normalizeReason(request.metaIdUnavailableReason()));
+        } else if (Boolean.FALSE.equals(request.metaIdUnavailable()) || StringUtils.hasText(request.metaId())) {
+            element.setMetaIdUnavailable(false);
+            element.setMetaIdUnavailableReason(null);
+        }
     }
 
     /**
@@ -68,5 +79,16 @@ public class TargetingMetaAdsSyncService {
                 element.getType(),
                 element.getTerm()
         );
+    }
+
+    /**
+     * Normaliza a justificativa operacional para impedir payloads excessivos em campos de auditoria.
+     */
+    private String normalizeReason(String reason) {
+        if (!StringUtils.hasText(reason)) {
+            return null;
+        }
+        String normalized = reason.trim();
+        return normalized.length() <= 1000 ? normalized : normalized.substring(0, 1000);
     }
 }

--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-16-targeting-element-meta-id-unavailable.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-16-targeting-element-meta-id-unavailable.yaml
@@ -1,0 +1,21 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-06-16-01-targeting-element-meta-id-unavailable
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - onError: HALT
+        - dbms:
+            type: mysql
+        - not:
+            columnExists:
+              tableName: targeting_element
+              columnName: meta_id_unavailable
+      changes:
+        - sql:
+            splitStatements: true
+            stripComments: true
+            sql: |
+              ALTER TABLE targeting_element
+                ADD COLUMN meta_id_unavailable BOOLEAN NOT NULL DEFAULT 0,
+                ADD COLUMN meta_id_unavailable_reason LONGTEXT NULL;

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -1002,3 +1002,6 @@ databaseChangeLog:
   - include:
       file: changesets/2026-06-16-niche-facebook-pixel-request.yaml
       relativeToChangelogFile: true
+  - include:
+      file: changesets/2026-06-16-targeting-element-meta-id-unavailable.yaml
+      relativeToChangelogFile: true

--- a/backend/ads-service/src/test/java/com/marketinghub/targeting/service/TargetingMetaAdsSyncServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/targeting/service/TargetingMetaAdsSyncServiceTest.java
@@ -1,0 +1,69 @@
+package com.marketinghub.targeting.service;
+
+import com.marketinghub.repository.jpa.targeting.TargetingElementRepository;
+import com.marketinghub.targeting.TargetingElement;
+import com.marketinghub.targeting.dto.UpdateTargetingMetaAdsDataRequest;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+/**
+ * Testes da sincronização de dados oficiais da Meta Ads em elementos de segmentação.
+ */
+@ExtendWith(MockitoExtension.class)
+class TargetingMetaAdsSyncServiceTest {
+    @Mock
+    private TargetingElementRepository repository;
+
+    /**
+     * Deve marcar elemento sem ID oficial da Meta e limpar dados parciais para impedir nova tentativa automática.
+     */
+    @Test
+    void updateMetaAdsDataMarksMetaIdUnavailableAndClearsPartialData() {
+        TargetingElement element = TargetingElement.builder()
+                .metaId("123")
+                .metaKey("Antigo")
+                .metaAudienceSizeLowerBound(10L)
+                .metaAudienceSizeUpperBound(20L)
+                .build();
+        when(repository.findById(7L)).thenReturn(Optional.of(element));
+        TargetingMetaAdsSyncService service = new TargetingMetaAdsSyncService(repository);
+
+        service.updateMetaAdsData(7L, new UpdateTargetingMetaAdsDataRequest(null, null, null, null, true, "sem match"));
+
+        assertThat(element.getMetaId()).isNull();
+        assertThat(element.getMetaKey()).isNull();
+        assertThat(element.getMetaAudienceSizeLowerBound()).isNull();
+        assertThat(element.getMetaAudienceSizeUpperBound()).isNull();
+        assertThat(element.getMetaIdUnavailable()).isTrue();
+        assertThat(element.getMetaIdUnavailableReason()).isEqualTo("sem match");
+    }
+
+    /**
+     * Deve liberar o bloqueio de ausência de ID quando um ID oficial da Meta for persistido.
+     */
+    @Test
+    void updateMetaAdsDataClearsUnavailableFlagWhenMetaIdIsSaved() {
+        TargetingElement element = TargetingElement.builder()
+                .metaIdUnavailable(true)
+                .metaIdUnavailableReason("sem match")
+                .build();
+        when(repository.findById(9L)).thenReturn(Optional.of(element));
+        TargetingMetaAdsSyncService service = new TargetingMetaAdsSyncService(repository);
+
+        service.updateMetaAdsData(9L, new UpdateTargetingMetaAdsDataRequest("456", "Interesse", 100L, 200L, null, null));
+
+        assertThat(element.getMetaId()).isEqualTo("456");
+        assertThat(element.getMetaKey()).isEqualTo("Interesse");
+        assertThat(element.getMetaAudienceSizeLowerBound()).isEqualTo(100L);
+        assertThat(element.getMetaAudienceSizeUpperBound()).isEqualTo(200L);
+        assertThat(element.getMetaIdUnavailable()).isFalse();
+        assertThat(element.getMetaIdUnavailableReason()).isNull();
+    }
+}

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -4606,3 +4606,9 @@
 - causa-raiz: o bloqueio da tela considerava qualquer `facebook_release_requested_at`, mesmo quando o experimento voltava para `FAILED`; além disso, a UI exibia itens aprovados no nicho sem diferenciar os que possuíam `meta_id` oficial dos que ainda não eram publicáveis na Meta.
 - correção aplicada: experimentos em `FAILED` deixam de travar a edição; a aba Público passa a exibir selo “Pronto para Meta” ou “Sem ID Meta”, bloqueando a inclusão de novos itens sem ID oficial e impedindo salvar enquanto houver seleção inválida.
 - prevenção de recorrência: o backend passou a rejeitar salvamento de seleção vinculada a elemento de targeting sem ID oficial da Meta.
+
+## 2026-06-16 — Bloqueio de retentativas infinitas para targeting sem ID Meta
+- solicitação: impedir que o Facebook Ads Worker repita indefinidamente chamadas à Meta para termos de segmentação sem ID oficial.
+- causa-raiz: elementos aprovados sem `meta_id` permaneciam elegíveis em `/api/internal/targeting/elements/metaads-pending` mesmo após a Meta não retornar match, gerando os mesmos erros em ciclos agendados.
+- correção aplicada: o backend passou a registrar `metaIdUnavailable` e motivo operacional no elemento, excluindo esses registros da fila de pendentes; o worker marca essa condição quando não encontra ID após todas as tentativas.
+- impacto esperado: redução do ruído no log do worker e foco operacional na revisão manual de termos que precisam ser corrigidos antes de virar público publicável.

--- a/docs/regra/fluxo-simples-publico-campanha.md
+++ b/docs/regra/fluxo-simples-publico-campanha.md
@@ -26,6 +26,9 @@ Após salvar o nicho, o backend sincroniza os itens em `targeting_element` e o *
    - `metaAudienceSizeLowerBound` (limite mínimo)
    - `metaAudienceSizeUpperBound` (limite máximo)
 4. atualiza o item em `PATCH /api/internal/targeting/elements/{id}/metaads`.
+5. quando não houver ID oficial após todas as tentativas, marca
+   `metaIdUnavailable=true` no mesmo endpoint para o backend retirar o item da
+   fila automática e evitar novas chamadas repetidas à Meta.
 
 > Resultado esperado: cada termo manual de nicho fica com **código oficial + faixa min/max** antes de ser usado no fluxo de campanha.
 

--- a/docs/swagger/facebook-ads-swagger.yaml
+++ b/docs/swagger/facebook-ads-swagger.yaml
@@ -838,8 +838,9 @@ components:
       type: object
       properties:
         metaId: { type: string, nullable: true }
-        metaName: { type: string, nullable: true }
-        metaType: { type: string, nullable: true }
-        status: { type: string, nullable: true }
-        errorMessage: { type: string, nullable: true }
+        metaKey: { type: string, nullable: true }
+        metaAudienceSizeLowerBound: { type: integer, format: int64, nullable: true }
+        metaAudienceSizeUpperBound: { type: integer, format: int64, nullable: true }
+        metaIdUnavailable: { type: boolean, nullable: true }
+        metaIdUnavailableReason: { type: string, nullable: true }
       additionalProperties: true

--- a/facebook-ads-worker/AGENTS.md
+++ b/facebook-ads-worker/AGENTS.md
@@ -29,6 +29,7 @@
 - Não mantenha segredos no repositório; use variáveis de ambiente ou GitHub Secrets.
 - Endpoints do backend devem ser acessados com o prefixo configurado em `backend.api-prefix` (default `/api`).
 - Na sincronização de segmentações salvas manualmente no nicho, o worker deve consultar `GET /{graphVersion}/search` com `type` específico (`adinterest`, `adworkposition`, `adbehavior`) para obter `id`, `audience_size_lower_bound` e `audience_size_upper_bound`, reportando os valores ao backend em `/api/internal/targeting/elements/{id}/metaads`.
+- Na sincronização de segmentações salvas manualmente no nicho, quando a Meta não devolver ID oficial após todas as tentativas, reporte `metaIdUnavailable=true` ao backend em `/api/internal/targeting/elements/{id}/metaads` para retirar o item da fila automática e evitar repetição indefinida.
 - Na sincronização de segmentações manuais via `GET /{graphVersion}/search`, não envie o parâmetro `fields`; mantenha apenas os parâmetros obrigatórios (`type`, `q`, `limit`, `access_token` e opcionais de locale/país).
 - Alinhe a configuração de banco deste módulo com o padrão do `backend/ads-service` (host/usuário/pool Hikari) para evitar divergência entre ambientes.
 - Sempre que chamar o backend registre logs com **URL completa**, parâmetros, payload enviado (quando existir) e a resposta recebida

--- a/facebook-ads-worker/README.md
+++ b/facebook-ads-worker/README.md
@@ -53,6 +53,10 @@ Esses limites são usados pelo Marketing Hub como alcance inicial do sinal antes
 de montar ou escalar campanha. Após encontrar o melhor match, o worker envia os dados para o backend via
 `PATCH /api/internal/targeting/elements/{id}/metaads`, mantendo a base local
 alinhada com os identificadores e faixas de audiência retornados pela Meta.
+Quando a Meta não devolve nenhum identificador oficial após todas as tentativas,
+o worker usa o mesmo endpoint para marcar `metaIdUnavailable=true`; o backend
+remove esse elemento da fila de pendentes para evitar repetir chamadas inválidas
+e reduzir ruído nos logs.
 
 ## Testes com MockWebServer
 

--- a/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebooktargeting/TargetingBackendClient.java
+++ b/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebooktargeting/TargetingBackendClient.java
@@ -131,6 +131,13 @@ public class TargetingBackendClient {
         }
     }
 
+    /**
+     * Reporta ao backend que a Meta não devolveu identificador oficial para o elemento informado.
+     */
+    public void markMetaAdsIdUnavailable(Long id, String reason) {
+        updateMetaAdsData(id, MetaAdsUpdatePayload.unavailable(reason));
+    }
+
     public record MetaAdsPendingElementPayload(
         Long id,
         Long marketNicheId,
@@ -143,8 +150,29 @@ public class TargetingBackendClient {
         @JsonProperty("metaId") String metaId,
         @JsonProperty("metaKey") String metaKey,
         @JsonProperty("metaAudienceSizeLowerBound") Long metaAudienceSizeLowerBound,
-        @JsonProperty("metaAudienceSizeUpperBound") Long metaAudienceSizeUpperBound
-    ) {}
+        @JsonProperty("metaAudienceSizeUpperBound") Long metaAudienceSizeUpperBound,
+        @JsonProperty("metaIdUnavailable") Boolean metaIdUnavailable,
+        @JsonProperty("metaIdUnavailableReason") String metaIdUnavailableReason
+    ) {
+        /**
+         * Cria payload de sucesso mantendo compatibilidade com chamadas existentes.
+         */
+        public MetaAdsUpdatePayload(
+            String metaId,
+            String metaKey,
+            Long metaAudienceSizeLowerBound,
+            Long metaAudienceSizeUpperBound
+        ) {
+            this(metaId, metaKey, metaAudienceSizeLowerBound, metaAudienceSizeUpperBound, null, null);
+        }
+
+        /**
+         * Cria payload para bloquear novas tentativas automáticas quando não há ID oficial da Meta.
+         */
+        public static MetaAdsUpdatePayload unavailable(String reason) {
+            return new MetaAdsUpdatePayload(null, null, null, null, true, reason);
+        }
+    }
 
     @JsonInclude(JsonInclude.Include.NON_NULL)
     public record TargetingCandidateResolutionUpdate(

--- a/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebooktargeting/metaads/MetaAdsTargetingEnrichmentService.java
+++ b/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebooktargeting/metaads/MetaAdsTargetingEnrichmentService.java
@@ -53,7 +53,7 @@ public class MetaAdsTargetingEnrichmentService {
     }
 
     /**
-     * Resolve um elemento individual tentando locales úteis e persistindo o primeiro match com audiência.
+     * Resolve um elemento individual tentando locales úteis e registra sucesso ou ausência definitiva de ID oficial.
      */
     private void enrich(MetaAdsPendingElementPayload element) {
         if (element == null || element.id() == null || !StringUtils.hasText(element.term())) {
@@ -96,7 +96,11 @@ public class MetaAdsTargetingEnrichmentService {
                     selected.audienceSizeUpperBound());
             return;
         }
-        LOGGER.info("No Meta Ads match found for targeting element {} and term {}", element.id(), term);
+        backendClient.markMetaAdsIdUnavailable(
+                element.id(),
+                "Nenhum ID oficial da Meta encontrado para tipo " + searchType.graphType() + " e termo " + term
+        );
+        LOGGER.info("Targeting element {} marked as Meta Ads ID unavailable for term {}", element.id(), term);
     }
 
     /**

--- a/facebook-ads-worker/src/test/java/com/marketinghub/facebookadsworker/facebooktargeting/metaads/MetaAdsTargetingEnrichmentServiceTest.java
+++ b/facebook-ads-worker/src/test/java/com/marketinghub/facebookadsworker/facebooktargeting/metaads/MetaAdsTargetingEnrichmentServiceTest.java
@@ -1,0 +1,43 @@
+package com.marketinghub.facebookadsworker.facebooktargeting.metaads;
+
+import com.marketinghub.facebookadsworker.FacebookAdsService;
+import com.marketinghub.facebookadsworker.facebooktargeting.TargetingBackendClient;
+import org.junit.jupiter.api.Test;
+
+import java.util.Collections;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.contains;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Testes do enriquecimento de elementos de targeting com dados oficiais da Meta Ads.
+ */
+class MetaAdsTargetingEnrichmentServiceTest {
+    /**
+     * Deve reportar ausência de ID oficial ao backend quando a Meta não retorna nenhum resultado útil.
+     */
+    @Test
+    void processPendingElementsMarksUnavailableWhenMetaReturnsNoMatch() {
+        TargetingBackendClient backendClient = mock(TargetingBackendClient.class);
+        FacebookAdsService facebookAdsService = mock(FacebookAdsService.class);
+        when(backendClient.listMetaAdsPendingElements(100)).thenReturn(List.of(
+                new TargetingBackendClient.MetaAdsPendingElementPayload(31L, 8L, "BEHAVIOR", "Small business owners")
+        ));
+        when(facebookAdsService.searchGlobalTargetingOptions(org.mockito.ArgumentMatchers.any()))
+                .thenReturn(Collections.emptyList());
+        MetaAdsTargetingEnrichmentService service = new MetaAdsTargetingEnrichmentService(
+                backendClient,
+                facebookAdsService,
+                "act_123",
+                100
+        );
+
+        service.processPendingElements();
+
+        verify(backendClient).markMetaAdsIdUnavailable(eq(31L), contains("Small business owners"));
+    }
+}


### PR DESCRIPTION
### Motivation
- Prevent endless retries by the Facebook Ads Worker for targeting terms that never receive an official Meta ID. 
- Allow operators to record an operational reason so items can be removed from the automatic enrichment queue and reviewed manually. 
- Keep existing successful enrichment flow unchanged while providing a way to clear the unavailability flag when a valid `metaId` is later stored.

### Description
- Add `metaIdUnavailable` (boolean) and `metaIdUnavailableReason` (longtext) to the `TargetingElement` entity and expose them in `TargetingElementDto` and the internal update contract `UpdateTargetingMetaAdsDataRequest`. 
- Exclude elements marked as unavailable from the pending query in `TargetingElementRepository.findMetaAdsPending`. 
- Implement handling in `TargetingMetaAdsSyncService.updateMetaAdsData` to set/clear the unavailable flag and normalize the reason, and clear the flag in `requestMetaAdsReprocessing`. 
- Update the backend client and payloads in the `facebook-ads-worker` to support `metaIdUnavailable` and `metaIdUnavailableReason`, add `markMetaAdsIdUnavailable` helper, and change enrichment logic to mark elements unavailable when no match is found. 
- Add a Liquibase changeset to alter the `targeting_element` table with the new columns and wire the migration into `db.changelog-master.yaml`. 
- Update documentation and swagger to describe the new field and worker behavior. 
- Add unit tests covering marking unavailable and clearing the flag: `TargetingMetaAdsSyncServiceTest` and `MetaAdsTargetingEnrichmentServiceTest`.

### Testing
- Added `TargetingMetaAdsSyncServiceTest` which verifies that `updateMetaAdsData` marks an element unavailable, clears partial Meta data, and stores the reason; the test passed. 
- Added `MetaAdsTargetingEnrichmentServiceTest` which verifies the worker reports `metaIdUnavailable` when the Graph API returns no match; the test passed. 
- Database migration added as `changesets/2026-06-16-targeting-element-meta-id-unavailable.yaml` and included in `db.changelog-master.yaml` for automated schema updates.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a31bf5ff31483218bb89cd3a921e473)