### PR TITLE
Support Meta behavior category in targeting enrichment and treat elements with `metaId` as Ready

### DIFF
--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -4617,3 +4617,9 @@
 - causa-raiz: o Facebook Ads Worker montava corretamente o ad set final com `geo_locations.countries=["BR"]`, mas a validação prévia de alcance em `/reachestimate` usava apenas interesses/cargos/comportamentos do pacote aprovado, sem localização; a Meta rejeitou a estimativa com “Falta uma localização” e o worker marcou o experimento como `FAILED` antes de criar a campanha.
 - correção aplicada: a validação prévia de alcance agora injeta Brasil como localização quando o pacote de targeting aprovado não traz `geo_locations`, alinhando a estimativa ao ad set que será publicado.
 - prevenção de recorrência: adicionado teste automatizado garantindo que o `targeting_spec` enviado para `/reachestimate` inclui `geo_locations.countries=["BR"]`.
+
+## 2026-06-16 — Correção de sincronização Meta Ads para comportamentos de nicho
+
+- Corrigida a causa-raiz que fazia comportamentos válidos da Meta, como `Small business owners`, ficarem marcados como pendentes/indisponíveis na tela de nicho.
+- O `facebook-ads-worker` passa a consultar comportamentos pelo contrato correto da Graph API: `type=adTargetingCategory&class=behaviors`.
+- A tela de nicho passa a considerar um elemento pronto quando há `metaId`, mesmo quando a Meta não retorna faixa de alcance para cargos.

--- a/facebook-ads-worker/AGENTS.md
+++ b/facebook-ads-worker/AGENTS.md
@@ -29,7 +29,7 @@
 - Identificadores de instant form no formato `ai_form_*` devem ser normalizados para `form_*` antes de chamar a Graph API.
 - Não mantenha segredos no repositório; use variáveis de ambiente ou GitHub Secrets.
 - Endpoints do backend devem ser acessados com o prefixo configurado em `backend.api-prefix` (default `/api`).
-- Na sincronização de segmentações salvas manualmente no nicho, o worker deve consultar `GET /{graphVersion}/search` com `type` específico (`adinterest`, `adworkposition`, `adbehavior`) para obter `id`, `audience_size_lower_bound` e `audience_size_upper_bound`, reportando os valores ao backend em `/api/internal/targeting/elements/{id}/metaads`.
+- Na sincronização de segmentações salvas manualmente no nicho, o worker deve consultar `GET /{graphVersion}/search` com `type` específico (`adinterest`, `adworkposition`) para interesses/cargos e `type=adTargetingCategory&class=behaviors` para comportamentos, obtendo `id`, `audience_size_lower_bound` e `audience_size_upper_bound` quando disponíveis e reportando os valores ao backend em `/api/internal/targeting/elements/{id}/metaads`.
 - Na sincronização de segmentações salvas manualmente no nicho, quando a Meta não devolver ID oficial após todas as tentativas, reporte `metaIdUnavailable=true` ao backend em `/api/internal/targeting/elements/{id}/metaads` para retirar o item da fila automática e evitar repetição indefinida.
 - Na sincronização de segmentações manuais via `GET /{graphVersion}/search`, não envie o parâmetro `fields`; mantenha apenas os parâmetros obrigatórios (`type`, `q`, `limit`, `access_token` e opcionais de locale/país).
 - Alinhe a configuração de banco deste módulo com o padrão do `backend/ads-service` (host/usuário/pool Hikari) para evitar divergência entre ambientes.

--- a/facebook-ads-worker/README.md
+++ b/facebook-ads-worker/README.md
@@ -42,8 +42,9 @@ cadastrados manualmente na tela de nicho e os sinais iniciais gerados pelo OPRM
 NichoCNAE para nichos enriquecidos (interesses, cargos e comportamentos).
 O scheduler `MetaAdsTargetingEnrichmentScheduler` busca itens pendentes no backend
 (`GET /api/internal/targeting/elements/metaads-pending`) e consulta a Graph API
-no endpoint global `/search` com o `type` correspondente (`adinterest`,
-`adworkposition` ou `adbehavior`) para capturar:
+no endpoint global `/search` com o `type` correspondente (`adinterest` para
+interesses, `adworkposition` para cargos e `adTargetingCategory` com
+`class=behaviors` para comportamentos) para capturar:
 
 - código oficial da Meta (`id`),
 - limite mínimo estimado (`audience_size_lower_bound`),

--- a/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/FacebookAdsService.java
+++ b/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/FacebookAdsService.java
@@ -606,6 +606,9 @@ public class FacebookAdsService {
         return immutableResults;
     }
 
+    /**
+     * Consulta opções globais de targeting na Graph API, incluindo a classe exigida para categorias de comportamento.
+     */
     public List<FacebookTargetingSearchResult> searchGlobalTargetingOptions(TargetingSearchRequest request) {
         if (request == null || request.type() == null || request.type().graphType() == null || !hasText(request.query())) {
             return Collections.emptyList();
@@ -621,6 +624,9 @@ public class FacebookAdsService {
             .queryParam("q", normalizedQuery)
             .queryParam("limit", limit)
             .queryParam("access_token", requireAccessToken());
+        if (hasText(request.type().categoryClass())) {
+            builder.queryParam("class", request.type().categoryClass());
+        }
         if (hasText(request.locale())) {
             builder.queryParam("locale", request.locale());
         }
@@ -1524,18 +1530,35 @@ private FacebookInterest searchInterest(String interestName, String locale) {
         ANY(null),
         AD_INTEREST("adinterest"),
         AD_BEHAVIOR("adbehavior"),
+        AD_TARGETING_CATEGORY_BEHAVIOR("adTargetingCategory", "behaviors"),
         AD_WORK_POSITION("adworkposition"),
         AD_INDUSTRY("adindustry"),
         AD_WORK_EMPLOYER("adworkemployer");
 
         private final String graphType;
+        private final String categoryClass;
 
         TargetingSearchType(String graphType) {
-            this.graphType = graphType;
+            this(graphType, null);
         }
 
+        TargetingSearchType(String graphType, String categoryClass) {
+            this.graphType = graphType;
+            this.categoryClass = categoryClass;
+        }
+
+        /**
+         * Retorna o valor aceito pela Meta no parâmetro type.
+         */
         public String graphType() {
             return graphType;
+        }
+
+        /**
+         * Retorna a classe complementar exigida por categorias de targeting, quando existir.
+         */
+        public String categoryClass() {
+            return categoryClass;
         }
     }
 

--- a/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebooktargeting/metaads/MetaAdsTargetingEnrichmentService.java
+++ b/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebooktargeting/metaads/MetaAdsTargetingEnrichmentService.java
@@ -126,7 +126,7 @@ public class MetaAdsTargetingEnrichmentService {
         return switch (backendType.trim().toUpperCase(Locale.ROOT)) {
             case "INTEREST" -> FacebookAdsService.TargetingSearchType.AD_INTEREST;
             case "JOB_TITLE" -> FacebookAdsService.TargetingSearchType.AD_WORK_POSITION;
-            case "BEHAVIOR" -> FacebookAdsService.TargetingSearchType.AD_BEHAVIOR;
+            case "BEHAVIOR" -> FacebookAdsService.TargetingSearchType.AD_TARGETING_CATEGORY_BEHAVIOR;
             default -> null;
         };
     }

--- a/facebook-ads-worker/src/test/java/com/marketinghub/facebookadsworker/FacebookAdsServiceTest.java
+++ b/facebook-ads-worker/src/test/java/com/marketinghub/facebookadsworker/FacebookAdsServiceTest.java
@@ -382,6 +382,34 @@ class FacebookAdsServiceTest {
         assertEquals("Certified Personal Trainer", results.get(0).name());
     }
 
+
+    @Test
+    void searchGlobalTargetingOptionsSendsBehaviorCategoryClass() throws Exception {
+        server.enqueueResponse(new MockResponse().setBody("{\"data\":[{\"id\":\"6002714898572\",\"name\":\"Small business owners\"}]}" )
+            .addHeader("Content-Type", "application/json"));
+
+        List<FacebookAdsService.FacebookTargetingSearchResult> results = service.searchGlobalTargetingOptions(
+            new FacebookAdsService.TargetingSearchRequest(
+                FacebookAdsService.TargetingSearchType.AD_TARGETING_CATEGORY_BEHAVIOR,
+                "Small business owners",
+                null,
+                "pt_BR",
+                "BR",
+                200
+            )
+        );
+
+        RecordedRequest request = takeRequest("global behavior category search request");
+        HttpUrl requestUrl = request.getRequestUrl();
+        assertNotNull(requestUrl);
+        assertEquals("/v23.0/search", requestUrl.encodedPath());
+        assertEquals("adTargetingCategory", requestUrl.queryParameter("type"));
+        assertEquals("behaviors", requestUrl.queryParameter("class"));
+        assertEquals("Small business owners", requestUrl.queryParameter("q"));
+        assertEquals(1, results.size());
+        assertEquals("6002714898572", results.get(0).id());
+    }
+
     @Test
     void createAdSetResolvesInterestNamesToIds() throws Exception {
         server.enqueueResponse(new MockResponse().setBody("{\"data\":[{\"id\":\"6003139266461\",\"name\":\"Pilates\"}]}" )

--- a/facebook-ads-worker/src/test/java/com/marketinghub/facebookadsworker/facebooktargeting/metaads/MetaAdsTargetingEnrichmentServiceTest.java
+++ b/facebook-ads-worker/src/test/java/com/marketinghub/facebookadsworker/facebooktargeting/metaads/MetaAdsTargetingEnrichmentServiceTest.java
@@ -7,11 +7,13 @@ import org.junit.jupiter.api.Test;
 import java.util.Collections;
 import java.util.List;
 
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.contains;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
+import static org.assertj.core.api.Assertions.assertThat;
 
 /**
  * Testes do enriquecimento de elementos de targeting com dados oficiais da Meta Ads.
@@ -27,7 +29,7 @@ class MetaAdsTargetingEnrichmentServiceTest {
         when(backendClient.listMetaAdsPendingElements(100)).thenReturn(List.of(
                 new TargetingBackendClient.MetaAdsPendingElementPayload(31L, 8L, "BEHAVIOR", "Small business owners")
         ));
-        when(facebookAdsService.searchGlobalTargetingOptions(org.mockito.ArgumentMatchers.any()))
+        when(facebookAdsService.searchGlobalTargetingOptions(any()))
                 .thenReturn(Collections.emptyList());
         MetaAdsTargetingEnrichmentService service = new MetaAdsTargetingEnrichmentService(
                 backendClient,
@@ -39,5 +41,47 @@ class MetaAdsTargetingEnrichmentServiceTest {
         service.processPendingElements();
 
         verify(backendClient).markMetaAdsIdUnavailable(eq(31L), contains("Small business owners"));
+    }
+
+    /**
+     * Deve consultar comportamentos pela categoria oficial de targeting para localizar Small business owners.
+     */
+    @Test
+    void processPendingElementsSearchesBehaviorsAsTargetingCategory() {
+        TargetingBackendClient backendClient = mock(TargetingBackendClient.class);
+        FacebookAdsService facebookAdsService = mock(FacebookAdsService.class);
+        when(backendClient.listMetaAdsPendingElements(100)).thenReturn(List.of(
+                new TargetingBackendClient.MetaAdsPendingElementPayload(31L, 8L, "BEHAVIOR", "Small business owners")
+        ));
+        when(facebookAdsService.searchGlobalTargetingOptions(any()))
+                .thenReturn(List.of(new FacebookAdsService.FacebookTargetingSearchResult(
+                        "6002714898572",
+                        "Small business owners",
+                        "behaviors",
+                        "People who list themselves as small business owners",
+                        48708955L,
+                        57281732L,
+                        List.of("Digital activities", "Small business owners"))));
+        MetaAdsTargetingEnrichmentService service = new MetaAdsTargetingEnrichmentService(
+                backendClient,
+                facebookAdsService,
+                "act_123",
+                100
+        );
+
+        service.processPendingElements();
+
+        org.mockito.ArgumentCaptor<FacebookAdsService.TargetingSearchRequest> requestCaptor =
+                org.mockito.ArgumentCaptor.forClass(FacebookAdsService.TargetingSearchRequest.class);
+        verify(facebookAdsService).searchGlobalTargetingOptions(requestCaptor.capture());
+        assertThat(requestCaptor.getValue().type())
+                .isEqualTo(FacebookAdsService.TargetingSearchType.AD_TARGETING_CATEGORY_BEHAVIOR);
+        verify(backendClient).updateMetaAdsData(
+                eq(31L),
+                eq(new TargetingBackendClient.MetaAdsUpdatePayload(
+                        "6002714898572",
+                        "Small business owners",
+                        48708955L,
+                        57281732L)));
     }
 }

--- a/frontend/src/pages/niche/NicheDetailPage.tsx
+++ b/frontend/src/pages/niche/NicheDetailPage.tsx
@@ -69,10 +69,7 @@ function resolveMetaAdsStatus(
   if (!element) return "PENDING";
   const hasMetaId =
     typeof element.metaId === "string" && element.metaId.trim() !== "";
-  const hasAudienceData =
-    typeof element.metaAudienceSizeLowerBound === "number" ||
-    typeof element.metaAudienceSizeUpperBound === "number";
-  if (hasMetaId && hasAudienceData) {
+  if (hasMetaId) {
     return "READY";
   }
   return "PENDING";


### PR DESCRIPTION
### Motivation
- Corrigir casos em que comportamentos válidos da Meta (ex.: `Small business owners`) eram marcados como pendentes por uso incorreto do endpoint `/search` sem a `class` exigida pela Graph API. 
- Evitar que a ausência de estimativa de alcance impeça a interface de marcar um elemento como publicável quando já existe um `metaId` oficial.

### Description
- Adicionada a função `searchGlobalTargetingOptions` que envia `class` quando o `TargetingSearchType` requer (ex.: `adTargetingCategory&class=behaviors`) e reusa a lógica de busca global. 
- Incluído o novo enum `TargetingSearchType.AD_TARGETING_CATEGORY_BEHAVIOR` com `graphType = "adTargetingCategory"` e `categoryClass = "behaviors"`, e mapeado `BEHAVIOR` do backend para esse tipo no `MetaAdsTargetingEnrichmentService`. 
- Atualizados `AGENTS.md` e `README.md` para documentar a consulta a comportamentos via `type=adTargetingCategory&class=behaviors` e outras orientações de sincronização. 
- Ajustada a UI em `NicheDetailPage.tsx` para considerar um elemento `READY` quando há `metaId`, independentemente da presença de faixas de audiência. 
- Adicionados testes unitários cobrindo o envio do `class=behaviors` em `FacebookAdsServiceTest` e o fluxo de enriquecimento que atualiza o backend quando a Meta retorna um comportamento em `MetaAdsTargetingEnrichmentServiceTest`.

### Testing
- Executados testes unitários `FacebookAdsServiceTest` (incluindo `searchGlobalTargetingOptionsSendsBehaviorCategoryClass`) e `MetaAdsTargetingEnrichmentServiceTest` (incluindo `processPendingElementsSearchesBehaviorsAsTargetingCategory`) e ambos passaram. 
- Suite de testes existente relacionada a buscas globais e criação de adsets foi executada e não apresentou regressões nos casos verificados.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a31c7de8a1c8321babe6930cc4e48ce)