### PR TITLE
Remover controles manuais de captura na pipeline MOIS

### DIFF
--- a/docs/registros/mois1.md
+++ b/docs/registros/mois1.md
@@ -1649,3 +1649,8 @@ Arquivos principais:
 - Corrigida a causa-raiz da tela `/mois/sales-pages-library` exibir `—` na temperatura Hotmart: páginas consolidadas novas estavam sem `collected_reference_id`, embora a referência Hotmart existisse em `mois_collected_reference` com a mesma URL canônica.
 - Ajustada a consulta da biblioteca para usar a referência direta quando existir e, caso contrário, recuperar a última referência Hotmart pela URL da página/produto, preservando preço, produtor e temperatura na listagem e no detalhe.
 - Adicionado teste de regressão para garantir que a consulta mantenha o fallback por URL e não volte a depender apenas do vínculo direto.
+
+## 2026-06-16 — Remoção do acionamento manual da etapa 1
+
+- Removida da tela do pipeline da Biblioteca de Sales Pages a área de execução manual da captura da etapa 1, porque essa etapa já acontece de forma automática.
+- Mantidos os indicadores de processamento automático para o usuário acompanhar avanço, última captura, volume pendente e velocidade sem precisar acionar comandos manuais.

--- a/frontend/src/pages/mois/MoisSalesPagesPipelinePage.tsx
+++ b/frontend/src/pages/mois/MoisSalesPagesPipelinePage.tsx
@@ -1,29 +1,17 @@
-import { useState } from "react";
 import { Link } from "react-router-dom";
 import PageTitle from "../../components/PageTitle";
 import {
-  useCaptureMoisSalesLibrarySnapshots,
   useMoisCollectedReferenceUrlSummary,
   useMoisSalesLibraryPageSummary,
   useReprocessStaleMoisSalesLibraryMarketWarmup,
 } from "../../api/mois/useMoisSalesLibrary";
-import type { MoisSalesLibrarySnapshotCaptureItem } from "../../api/mois/types";
 
 const WORKSPACE_ID = "workspace-001";
-const DEFAULT_CAPTURE_LIMIT = 5;
-
 const analysisChecklist = [
   "Jobs pendentes para análise por IA",
   "Páginas com HTML útil disponíveis como entrada",
   "Score comercial e blocos de oferta, promessa, mecanismo e prova",
   "Falhas de análise registradas no histórico operacional",
-];
-
-const htmlAcquisitionChecklist = [
-  "URLs pendentes para captura",
-  "Snapshots com HTML bruto salvo",
-  "Falhas de acesso, bloqueio ou timeout",
-  "Hash, tamanho e data da última captura",
 ];
 
 const marketWarmupChecklist = [
@@ -32,19 +20,6 @@ const marketWarmupChecklist = [
   "Score de engenharia de sucesso e riscos comerciais",
   "Recomendação comercial para priorizar, observar ou diferenciar o ângulo",
 ];
-
-function formatBytes(value: number) {
-  if (!value) {
-    return "0 B";
-  }
-  if (value < 1024) {
-    return `${value} B`;
-  }
-  if (value < 1024 * 1024) {
-    return `${(value / 1024).toFixed(1)} KB`;
-  }
-  return `${(value / (1024 * 1024)).toFixed(1)} MB`;
-}
 
 function formatDateTime(value?: string) {
   if (!value) {
@@ -66,50 +41,15 @@ function formatAverage(value?: number) {
   })}/h`;
 }
 
-function getSnapshotStatusBadgeClass(status: string) {
-  switch (status) {
-    case "CAPTURED":
-    case "DUPLICATE":
-      return "bg-success-subtle text-success-emphasis";
-    case "FAILED":
-      return "bg-danger-subtle text-danger-emphasis";
-    case "FETCHING":
-      return "bg-primary-subtle text-primary-emphasis";
-    default:
-      return "bg-secondary-subtle text-secondary-emphasis";
-  }
-}
-
-function getResultMessage(item: MoisSalesLibrarySnapshotCaptureItem) {
-  const redirectInfo = item.redirectDestinationUrl
-    ? `Destino: ${item.redirectDestinationUrl}${
-        item.redirectRootUrl ? ` · Raiz: ${item.redirectRootUrl}` : ""
-      }`
-    : "";
-  if (item.errorMessage) {
-    return [item.errorMessage, redirectInfo].filter(Boolean).join(" · ");
-  }
-  if (item.snapshotHash) {
-    return [`hash ${item.snapshotHash.slice(0, 12)}...`, redirectInfo]
-      .filter(Boolean)
-      .join(" · ");
-  }
-  return redirectInfo || "Sem detalhe adicional";
-}
-
 export default function MoisSalesPagesPipelinePage() {
-  const [forceCapture, setForceCapture] = useState(false);
   const summaryQuery = useMoisSalesLibraryPageSummary(WORKSPACE_ID);
   const collectedUrlSummaryQuery =
     useMoisCollectedReferenceUrlSummary(WORKSPACE_ID);
-  const captureMutation = useCaptureMoisSalesLibrarySnapshots(WORKSPACE_ID);
   const reprocessStaleWarmupMutation =
     useReprocessStaleMoisSalesLibraryMarketWarmup(WORKSPACE_ID);
   const summary = summaryQuery.data;
   const collectedUrlSummary = collectedUrlSummaryQuery.data;
 
-  const lastRun = captureMutation.data;
-  const isRunning = captureMutation.isPending;
   const capturedPages = summary?.captured ?? 0;
   const analyzedPages = summary?.analyzed ?? 0;
   const analysisBacklog = Math.max(capturedPages - analyzedPages, 0);
@@ -327,83 +267,6 @@ export default function MoisSalesPagesPipelinePage() {
                 </div>
               </div>
             </div>
-          </div>
-
-          <div className="border rounded-3 p-3">
-            <div className="d-flex flex-wrap align-items-center justify-content-between gap-3">
-              <div>
-                <h3 className="h6 mb-1">Executar captura agora</h3>
-                <p className="text-secondary small mb-0">
-                  O acionamento usa o backend existente e processa até{" "}
-                  {DEFAULT_CAPTURE_LIMIT} URLs sem HTML útil por execução para
-                  evitar bloqueios e timeouts longos.
-                </p>
-              </div>
-              <div className="d-flex flex-wrap align-items-center gap-3">
-                <div className="form-check form-switch mb-0">
-                  <input
-                    className="form-check-input"
-                    id="forceCapture"
-                    type="checkbox"
-                    checked={forceCapture}
-                    onChange={(event) => setForceCapture(event.target.checked)}
-                    disabled={isRunning}
-                  />
-                  <label
-                    className="form-check-label small"
-                    htmlFor="forceCapture"
-                  >
-                    Forçar URLs sem HTML (ignorar cooldown)
-                  </label>
-                </div>
-                <button
-                  className="btn btn-primary"
-                  type="button"
-                  disabled={isRunning}
-                  onClick={() =>
-                    captureMutation.mutate({
-                      limit: DEFAULT_CAPTURE_LIMIT,
-                      force: forceCapture,
-                    })
-                  }
-                >
-                  {isRunning ? (
-                    <>
-                      <span
-                        className="spinner-border spinner-border-sm me-2"
-                        aria-hidden="true"
-                      />
-                      Executando...
-                    </>
-                  ) : (
-                    "Executar etapa 1"
-                  )}
-                </button>
-              </div>
-            </div>
-            {captureMutation.isError ? (
-              <div className="alert alert-danger mt-3 mb-0">
-                Falha ao executar a captura. Verifique se o backend está
-                acessível e tente novamente.
-              </div>
-            ) : null}
-            {lastRun ? (
-              <div className="alert alert-success mt-3 mb-0">
-                Execução concluída em{" "}
-                {new Date(lastRun.capturedAt).toLocaleString()}:{" "}
-                {lastRun.processed} URL(s) processada(s), {lastRun.captured}{" "}
-                captura(s) útil(is) e {lastRun.failed} falha(s).
-              </div>
-            ) : null}
-          </div>
-
-          <div>
-            <h3 className="h6 mb-2">Informações que este card acompanha</h3>
-            <ul className="mb-0 text-secondary">
-              {htmlAcquisitionChecklist.map((item) => (
-                <li key={item}>{item}</li>
-              ))}
-            </ul>
           </div>
         </div>
       </section>
@@ -704,58 +567,6 @@ export default function MoisSalesPagesPipelinePage() {
           </div>
         </div>
       </section>
-
-      {lastRun ? (
-        <section className="card border-0 shadow-sm">
-          <div className="card-body table-responsive">
-            <h2 className="h5 mb-3">Resultado da última execução</h2>
-            <table className="table table-sm align-middle mb-0">
-              <thead>
-                <tr>
-                  <th>Página</th>
-                  <th>Status</th>
-                  <th>HTTP</th>
-                  <th>HTML</th>
-                  <th>Detalhe</th>
-                </tr>
-              </thead>
-              <tbody>
-                {lastRun.items.length === 0 ? (
-                  <tr>
-                    <td colSpan={5} className="text-secondary">
-                      Nenhuma URL elegível encontrada para esta execução.
-                    </td>
-                  </tr>
-                ) : (
-                  lastRun.items.map((item) => (
-                    <tr
-                      key={`${item.pageId}-${item.snapshotId ?? "sem-snapshot"}`}
-                    >
-                      <td className="text-break">
-                        <Link to={`/mois/sales-pages-library/${item.pageId}`}>
-                          {item.urlCanonical}
-                        </Link>
-                      </td>
-                      <td>
-                        <span
-                          className={`badge ${getSnapshotStatusBadgeClass(item.status)}`}
-                        >
-                          {item.status}
-                        </span>
-                      </td>
-                      <td>{item.httpStatus ?? "—"}</td>
-                      <td>{formatBytes(item.rawHtmlBytes)}</td>
-                      <td className="text-secondary small text-break">
-                        {getResultMessage(item)}
-                      </td>
-                    </tr>
-                  ))
-                )}
-              </tbody>
-            </table>
-          </div>
-        </section>
-      ) : null}
     </div>
   );
 }


### PR DESCRIPTION
### Motivation
- A etapa 1 de captura passou a rodar automaticamente e o controle manual na UI criava confusão e comandos redundantes para o usuário.
- Simplificar a tela reduz superfície de manutenção e evita ações manuais que podem duplicar ou conflitar com o processamento automático.

### Description
- Removido o bloco de UI responsável por acionar a captura manual (botão `Executar etapa 1`, switch `Forçar URLs sem HTML` e mensagens relacionadas) em `frontend/src/pages/mois/MoisSalesPagesPipelinePage.tsx`.
- Eliminados imports, estado e helpers usados apenas para a execução manual, incluindo `useState`, `useCaptureMoisSalesLibrarySnapshots`, `DEFAULT_CAPTURE_LIMIT`, `htmlAcquisitionChecklist`, `formatBytes`, `getSnapshotStatusBadgeClass`, `getResultMessage` e referências a `lastRun`/`captureMutation`.
- Mantidos e preservados os indicadores de processamento automático (última captura, velocidade, volume pendente) e a transição direta para a etapa 2 (análise comercial via worker).
- Registrado no histórico do módulo MOIS em `docs/registros/mois1.md` a remoção do acionamento manual para manter rastreabilidade documental.

### Testing
- Executado `npm install` no diretório `frontend` para garantir dependências; instalação concluída com sucesso.
- Executado `npm run typecheck` em `frontend` e o TypeScript check completou sem erros.
- Verificada a aplicação do `prettier` no arquivo modificado para manter formatação consistente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a31ca384d888321a46323b54a4687a2)