### PR TITLE
Track publication job steps and broaden targeting (OR) for reach validation

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentDiagnosticsService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentDiagnosticsService.java
@@ -9,11 +9,13 @@ import com.marketinghub.experiment.dto.ExperimentPublishingArtifactDto;
 import com.marketinghub.facebookads.FacebookAdsAd;
 import com.marketinghub.facebookads.FacebookAdsAdSet;
 import com.marketinghub.facebookads.FacebookAdsCampaign;
+import com.marketinghub.facebookads.FacebookCampaignPublicationJobStep;
 import com.marketinghub.facebookads.playbook.dto.ExperimentFacebookApiLogDto;
 import com.marketinghub.facebookads.playbook.service.ExperimentFacebookApiLogService;
 import com.marketinghub.repository.jpa.facebookads.FacebookAdsAdRepository;
 import com.marketinghub.repository.jpa.facebookads.FacebookAdsAdSetRepository;
 import com.marketinghub.repository.jpa.facebookads.FacebookAdsCampaignRepository;
+import com.marketinghub.repository.jpa.facebookads.FacebookCampaignPublicationJobStepRepository;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -34,6 +36,7 @@ public class ExperimentDiagnosticsService {
     private final FacebookAdsAdSetRepository adSetRepository;
     private final FacebookAdsAdRepository adRepository;
     private final ExperimentFacebookApiLogService facebookApiLogService;
+    private final FacebookCampaignPublicationJobStepRepository publicationJobStepRepository;
 
     /**
      * Inicializa o serviço com consultas de experimento, artefatos locais e logs da integração Meta.
@@ -42,12 +45,14 @@ public class ExperimentDiagnosticsService {
                                         FacebookAdsCampaignRepository campaignRepository,
                                         FacebookAdsAdSetRepository adSetRepository,
                                         FacebookAdsAdRepository adRepository,
-                                        ExperimentFacebookApiLogService facebookApiLogService) {
+                                        ExperimentFacebookApiLogService facebookApiLogService,
+                                        FacebookCampaignPublicationJobStepRepository publicationJobStepRepository) {
         this.experimentService = experimentService;
         this.campaignRepository = campaignRepository;
         this.adSetRepository = adSetRepository;
         this.adRepository = adRepository;
         this.facebookApiLogService = facebookApiLogService;
+        this.publicationJobStepRepository = publicationJobStepRepository;
     }
 
     /**
@@ -108,12 +113,34 @@ public class ExperimentDiagnosticsService {
     }
 
     /**
-     * Retorna detalhes de falha somente quando a chamada mais recente da Meta também falhou.
+     * Retorna detalhes da falha operacional mais recente registrada pelo job ou pela Meta.
      */
     private ExperimentFailureDetailsDto resolveFailureDetails(Long experimentId, boolean statusFailed) {
         if (!statusFailed) {
             return null;
         }
+        return publicationJobStepRepository.findTopByExperimentIdAndErrorMessageIsNotNullOrderByOccurredAtDescIdDesc(experimentId)
+                .map(this::toFailureDetails)
+                .orElseGet(() -> resolveFacebookApiFailureDetails(experimentId));
+    }
+
+    /**
+     * Converte o passo do job em detalhes legíveis para a tela do experimento.
+     */
+    private ExperimentFailureDetailsDto toFailureDetails(FacebookCampaignPublicationJobStep step) {
+        return new ExperimentFailureDetailsDto(
+                step.getErrorMessage(),
+                step.getEndpoint(),
+                step.getStatusCode(),
+                step.getOccurredAt(),
+                StringUtils.hasText(step.getProvider()) ? step.getProvider() : "PUBLICATION_JOB_STEP"
+        );
+    }
+
+    /**
+     * Busca falha HTTP ou textual mais recente registrada na integração com a Meta.
+     */
+    private ExperimentFailureDetailsDto resolveFacebookApiFailureDetails(Long experimentId) {
         return facebookApiLogService.findLogs(experimentId, 200).stream()
                 .max(Comparator.comparing(this::resolveOccurrence, Comparator.nullsLast(Comparator.naturalOrder())))
                 .filter(this::isFailureLog)

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/facebookads/FacebookCampaignPublicationJobStepRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/facebookads/FacebookCampaignPublicationJobStepRepository.java
@@ -12,4 +12,7 @@ public interface FacebookCampaignPublicationJobStepRepository extends JpaReposit
 
     /** Lista os passos registrados para um job em ordem cronológica. */
     List<FacebookCampaignPublicationJobStep> findByJobIdOrderByOccurredAtAscIdAsc(String jobId);
+
+    /** Busca o último passo com erro registrado para o experimento. */
+    java.util.Optional<FacebookCampaignPublicationJobStep> findTopByExperimentIdAndErrorMessageIsNotNullOrderByOccurredAtDescIdDesc(Long experimentId);
 }

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/service/ExperimentDiagnosticsServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/service/ExperimentDiagnosticsServiceTest.java
@@ -4,13 +4,16 @@ import com.marketinghub.experiment.Experiment;
 import com.marketinghub.experiment.ExperimentStatus;
 import com.marketinghub.experiment.dto.ExperimentDiagnosticsDto;
 import com.marketinghub.facebookads.FacebookAdsCampaign;
+import com.marketinghub.facebookads.FacebookCampaignPublicationJobStep;
 import com.marketinghub.facebookads.playbook.dto.ExperimentFacebookApiLogDto;
 import com.marketinghub.facebookads.playbook.service.ExperimentFacebookApiLogService;
 import com.marketinghub.repository.jpa.facebookads.FacebookAdsAdRepository;
 import com.marketinghub.repository.jpa.facebookads.FacebookAdsAdSetRepository;
 import com.marketinghub.repository.jpa.facebookads.FacebookAdsCampaignRepository;
+import com.marketinghub.repository.jpa.facebookads.FacebookCampaignPublicationJobStepRepository;
 import java.time.Instant;
 import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -36,6 +39,8 @@ class ExperimentDiagnosticsServiceTest {
     private FacebookAdsAdRepository adRepository;
     @Mock
     private ExperimentFacebookApiLogService facebookApiLogService;
+    @Mock
+    private FacebookCampaignPublicationJobStepRepository publicationJobStepRepository;
 
     @InjectMocks
     private ExperimentDiagnosticsService service;
@@ -59,6 +64,8 @@ class ExperimentDiagnosticsServiceTest {
         when(experimentService.get(experimentId)).thenReturn(experiment);
         when(campaignRepository.findByExperimentId(experimentId)).thenReturn(List.of(campaign));
         when(adSetRepository.findByCampaignIdIn(List.of(campaign.getId()))).thenReturn(List.of());
+        when(publicationJobStepRepository.findTopByExperimentIdAndErrorMessageIsNotNullOrderByOccurredAtDescIdDesc(experimentId))
+                .thenReturn(Optional.empty());
         when(facebookApiLogService.findLogs(experimentId, 200)).thenReturn(List.of());
 
         ExperimentDiagnosticsDto diagnostics = service.diagnose(experimentId);
@@ -80,6 +87,8 @@ class ExperimentDiagnosticsServiceTest {
 
         when(experimentService.get(experimentId)).thenReturn(experiment);
         when(campaignRepository.findByExperimentId(experimentId)).thenReturn(List.of());
+        when(publicationJobStepRepository.findTopByExperimentIdAndErrorMessageIsNotNullOrderByOccurredAtDescIdDesc(experimentId))
+                .thenReturn(Optional.empty());
         when(facebookApiLogService.findLogs(experimentId, 200)).thenReturn(List.of(
                 apiLog(1L, 400, "400 Bad Request", Instant.parse("2026-06-08T20:31:25Z")),
                 apiLog(2L, 200, null, Instant.parse("2026-06-09T03:24:53Z"))
@@ -104,6 +113,8 @@ class ExperimentDiagnosticsServiceTest {
 
         when(experimentService.get(experimentId)).thenReturn(experiment);
         when(campaignRepository.findByExperimentId(experimentId)).thenReturn(List.of());
+        when(publicationJobStepRepository.findTopByExperimentIdAndErrorMessageIsNotNullOrderByOccurredAtDescIdDesc(experimentId))
+                .thenReturn(Optional.empty());
         when(facebookApiLogService.findLogs(experimentId, 200)).thenReturn(List.of(
                 apiLog(1L, 200, null, Instant.parse("2026-06-09T03:20:00Z")),
                 apiLog(2L, 400, "400 Bad Request", Instant.parse("2026-06-09T03:24:53Z"))
@@ -114,6 +125,37 @@ class ExperimentDiagnosticsServiceTest {
         assertThat(diagnostics.failureDetails()).isNotNull();
         assertThat(diagnostics.failureDetails().message()).isEqualTo("400 Bad Request");
         assertThat(diagnostics.failureDetails().occurredAt()).isEqualTo(Instant.parse("2026-06-09T03:24:53Z"));
+    }
+
+
+    /**
+     * Mostra a falha operacional do job quando a Meta respondeu 200, mas o worker bloqueou por regra de alcance.
+     */
+    @Test
+    void shouldShowPublicationJobFailureWhenReachValidationBlockedAfterSuccessfulMetaCall() {
+        Long experimentId = 39L;
+
+        Experiment experiment = new Experiment();
+        experiment.setId(experimentId);
+        experiment.setStatus(ExperimentStatus.FAILED);
+
+        FacebookCampaignPublicationJobStep step = new FacebookCampaignPublicationJobStep();
+        step.setErrorMessage("Público pequeno demais para publicar: a Meta estimou 1.000 a 1.000 pessoas.");
+        step.setProvider("FACEBOOK_WORKER");
+        step.setStepName("CAMPAIGN_REACH_VALIDATION_BLOCKED");
+        step.setOccurredAt(Instant.parse("2026-06-17T00:54:48Z"));
+
+        when(experimentService.get(experimentId)).thenReturn(experiment);
+        when(campaignRepository.findByExperimentId(experimentId)).thenReturn(List.of());
+        when(publicationJobStepRepository.findTopByExperimentIdAndErrorMessageIsNotNullOrderByOccurredAtDescIdDesc(experimentId))
+                .thenReturn(Optional.of(step));
+
+        ExperimentDiagnosticsDto diagnostics = service.diagnose(experimentId);
+
+        assertThat(diagnostics.failureDetails()).isNotNull();
+        assertThat(diagnostics.failureDetails().message()).contains("Público pequeno demais");
+        assertThat(diagnostics.failureDetails().source()).isEqualTo("FACEBOOK_WORKER");
+        assertThat(diagnostics.failureDetails().occurredAt()).isEqualTo(Instant.parse("2026-06-17T00:54:48Z"));
     }
 
     /**

--- a/docs/canonical/facebook-campaign-publication-canon.v1.md
+++ b/docs/canonical/facebook-campaign-publication-canon.v1.md
@@ -40,7 +40,7 @@ As etapas oficiais expostas para operação são:
 1. `worker-configuration` — carregar configuração, token, conta de anúncios e defaults.
 2. `experiment-readiness` — selecionar experimentos liberados, prontos e sem campanha duplicada.
 3. `creative-consumption` — consumir somente criativos aprovados pelo contrato do módulo Facebook.
-4. `reach-validation` — consultar `reachestimate` da Meta com o targeting final e bloquear publicação quando o público estimado estiver fora da faixa operacional.
+4. `reach-validation` — consultar `reachestimate` da Meta com o targeting final ampliado em lógica **OU** entre interesses, cargos e comportamentos, bloqueando publicação quando o público estimado estiver fora da faixa operacional.
 5. `campaign-hierarchy-publication` — criar campanha, conjunto, imagem, criativo e anúncio na Meta.
 6. `publication-registration` — persistir IDs externos no backend e marcar rastreabilidade da publicação.
 7. `metrics-sync-target-selection` — selecionar campanhas em execução para sincronização de métricas.
@@ -52,12 +52,12 @@ Esse pipeline é administrativo e operacional: ele torna visível o fluxo do wor
 
 ### 2.2 Gate obrigatório de alcance
 
-Antes de qualquer criação de campanha, conjunto, imagem, criativo ou anúncio na Meta, o `facebook-ads-worker` deve validar o targeting final no endpoint `reachestimate` da Graph API. A publicação só pode avançar quando a resposta trouxer `users_lower_bound` e `users_upper_bound` e ambos estiverem dentro da faixa operacional canônica:
+Antes de qualquer criação de campanha, conjunto, imagem, criativo ou anúncio na Meta, o `facebook-ads-worker` deve validar o targeting final no endpoint `reachestimate` da Graph API. Para evitar públicos pequenos demais por interseção, interesses, cargos e comportamentos aprovados devem ser agrupados em um único grupo de segmentação ampla com lógica **OU** (`flexible_spec` único), mantendo localização e demais restrições estruturais no topo do `targeting_spec`. A publicação só pode avançar quando a resposta trouxer `users_lower_bound` e `users_upper_bound` e ambos estiverem dentro da faixa operacional canônica:
 
 - mínimo: `users_lower_bound >= 200000`;
 - máximo: `users_upper_bound <= 20000000`.
 
-Quando a Meta não retornar os limites ou o público ficar fora dessa faixa, o experimento deve ser bloqueado antes da criação da campanha e registrado como falha operacional para correção de causa-raiz do público.
+Quando a Meta não retornar os limites ou o público ficar fora dessa faixa, o experimento deve ser bloqueado antes da criação da campanha e registrado como falha operacional para correção de causa-raiz do público. A mensagem exibida ao usuário deve informar objetivamente o alcance estimado retornado pela Meta, o mínimo/máximo operacional e a ação recomendada: ampliar ou revisar o público antes de liberar nova tentativa.
 
 ## 3. Ownership e módulos
 

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -4644,3 +4644,8 @@
 
 - Decisão registrada: o padrão de rastreabilidade por `jobId`, tabela de passos e endpoint de registro do executor passa a se chamar **protocolo jobid**.
 - Quando solicitado em novos fluxos, o protocolo deve replicar o padrão aplicado na publicação de experimentos como campanhas Facebook.
+
+## 2026-06-17 — Publicação Facebook: público amplo e mensagem de alcance
+
+- Ajustada a regra canônica de publicação para usar lógica OU entre interesses, cargos e comportamentos antes da validação de alcance da Meta.
+- Melhorada a rastreabilidade de falhas de alcance para exibir ao usuário o motivo operacional quando a Meta estima público abaixo da faixa mínima.

--- a/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookapi/ExperimentFacebookApiLogClient.java
+++ b/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookapi/ExperimentFacebookApiLogClient.java
@@ -108,6 +108,42 @@ public class ExperimentFacebookApiLogClient {
         }
     }
 
+
+    /**
+     * Registra um bloqueio operacional do worker que acontece após uma chamada válida da Meta.
+     */
+    public void logPublicationJobFailureStep(String jobId, Long experimentId, String stepName, String errorMessage) {
+        if (jobId == null || jobId.isBlank() || stepName == null || stepName.isBlank()) {
+            return;
+        }
+        PublicationJobStepRequest body = new PublicationJobStepRequest(
+            jobId,
+            experimentId,
+            stepName,
+            "FACEBOOK_WORKER",
+            null,
+            null,
+            null,
+            null,
+            null,
+            errorMessage,
+            java.time.Instant.now()
+        );
+        String url = UrlUtils.joinPath(backendBaseUrl, apiPrefix, "/facebook-campaigns/publication-job-steps");
+        try {
+            backendClient
+                .post()
+                .uri(url)
+                .bodyValue(body)
+                .retrieve()
+                .toBodilessEntity()
+                .block();
+        } catch (Exception ex) {
+            LOGGER.debug("Failed to register publication job failure step: jobId={}, experimentId={}, stepName={}, message={}",
+                jobId, experimentId, stepName, ex.getMessage());
+        }
+    }
+
     private JsonNode toJsonNode(String raw) {
         if (raw == null || raw.isBlank()) {
             return null;

--- a/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java
+++ b/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java
@@ -378,7 +378,7 @@ public class FacebookCampaignService {
             selectedSpec = selectPrimarySpec(readySpecs);
             if (selectedSpec != null) {
                 resolvedTargeting = new ResolvedTargeting(
-                    normalizeTargetingSpec(selectedSpec.targetingSpec()),
+                    normalizeAndBroadenTargetingSpec(selectedSpec.targetingSpec()),
                     Collections.emptyList()
                 );
                 adSetName = buildAdSetName(exp.name(), selectedSpec);
@@ -741,12 +741,13 @@ public class FacebookCampaignService {
                 "Experimento " + experimentId + " sem cargos aprovados no targeting manual; publicação bloqueada para evitar público amplo"
             );
         }
+        ObjectNode broadenedTargetingSpec = broadenTargetingSpecToOrAudience(targetingSpec);
         LOGGER.info(
             "Using backend-approved manual targeting package for experiment {}: {}",
             experimentId,
-            JsonLogFormatter.wrap(objectMapper, targetingSpec)
+            JsonLogFormatter.wrap(objectMapper, broadenedTargetingSpec)
         );
-        return new ResolvedTargeting(targetingSpec.toString(), Collections.emptyList());
+        return new ResolvedTargeting(broadenedTargetingSpec.toString(), Collections.emptyList());
     }
 
     /**
@@ -891,21 +892,25 @@ public class FacebookCampaignService {
         );
         ReachEstimateBounds bounds = extractReachEstimateBounds(response);
         if (!bounds.complete()) {
-            throw new IllegalStateException(
-                "Validação de alcance sem limites retornados pela Meta para o experimento " + experimentId
+            String message = "A Meta não retornou os limites de alcance do público. Amplie ou revise a segmentação antes de liberar a campanha novamente.";
+            experimentFacebookApiLogClient.logPublicationJobFailureStep(
+                publicationJobId,
+                experimentId,
+                "CAMPAIGN_REACH_VALIDATION_BLOCKED",
+                message
             );
+            throw new IllegalStateException(message + " Experimento=" + experimentId);
         }
         if (bounds.lowerBound() < MIN_REACH_LOWER_BOUND || bounds.upperBound() > MAX_REACH_UPPER_BOUND) {
-            throw new IllegalStateException(
-                "Público fora da faixa de alcance para publicação: experimento=%d, lower=%d, upper=%d, mínimo=%d, máximo=%d"
-                    .formatted(
-                        experimentId,
-                        bounds.lowerBound(),
-                        bounds.upperBound(),
-                        MIN_REACH_LOWER_BOUND,
-                        MAX_REACH_UPPER_BOUND
-                    )
+            String message = "Público pequeno demais para publicar: a Meta estimou %d a %d pessoas, mas o mínimo operacional é %d. Revise o público usando critérios mais amplos em OU e libere novamente."
+                .formatted(bounds.lowerBound(), bounds.upperBound(), MIN_REACH_LOWER_BOUND);
+            experimentFacebookApiLogClient.logPublicationJobFailureStep(
+                publicationJobId,
+                experimentId,
+                "CAMPAIGN_REACH_VALIDATION_BLOCKED",
+                message
             );
+            throw new IllegalStateException(message);
         }
         LOGGER.info(
             "Reach validation approved before campaign creation: experimentId={}, lowerBound={}, upperBound={}",
@@ -1219,18 +1224,91 @@ public class FacebookCampaignService {
         return experimentName + " - Ad Set";
     }
 
-    private String normalizeTargetingSpec(String raw) {
+    /**
+     * Normaliza o targeting aprovado e amplia o público colocando interesses, cargos e comportamentos em condição OU.
+     */
+    private String normalizeAndBroadenTargetingSpec(String raw) {
         if (!StringUtils.hasText(raw)) {
             return raw;
         }
         try {
             JsonNode node = objectMapper.readTree(raw);
+            if (node instanceof ObjectNode objectNode) {
+                return objectMapper.writeValueAsString(broadenTargetingSpecToOrAudience(objectNode));
+            }
             return objectMapper.writeValueAsString(node);
         } catch (Exception ex) {
             LOGGER.warn("Failed to normalize targeting spec JSON: {}", ex.getMessage());
             LOGGER.debug("Stacktrace while normalizing targeting spec JSON", ex);
             return raw;
         }
+    }
+
+    /**
+     * Move critérios detalhados para um único flexible_spec para a Meta tratar o público como OU, não como E entre campos.
+     */
+    private ObjectNode broadenTargetingSpecToOrAudience(ObjectNode source) {
+        ObjectNode broadened = source.deepCopy();
+        ObjectNode orGroup = objectMapper.createObjectNode();
+        moveArrayFieldToOrGroup(broadened, orGroup, "interests");
+        moveArrayFieldToOrGroup(broadened, orGroup, "work_positions");
+        moveArrayFieldToOrGroup(broadened, orGroup, "behaviors");
+        mergeExistingFlexibleSpecIntoOrGroup(broadened, orGroup);
+        if (orGroup.size() > 0) {
+            ArrayNode flexibleSpec = objectMapper.createArrayNode();
+            flexibleSpec.add(orGroup);
+            broadened.set("flexible_spec", flexibleSpec);
+        }
+        return broadened;
+    }
+
+    /**
+     * Move um array de segmentação do topo para o grupo OU quando houver itens úteis.
+     */
+    private void moveArrayFieldToOrGroup(ObjectNode targetingSpec, ObjectNode orGroup, String fieldName) {
+        JsonNode value = targetingSpec.get(fieldName);
+        targetingSpec.remove(fieldName);
+        if (value != null && value.isArray() && !value.isEmpty()) {
+            orGroup.set(fieldName, value);
+        }
+    }
+
+    /**
+     * Consolida flexible_spec existente em um único grupo OU para evitar estreitamento por múltiplos grupos.
+     */
+    private void mergeExistingFlexibleSpecIntoOrGroup(ObjectNode targetingSpec, ObjectNode orGroup) {
+        JsonNode existingFlexibleSpec = targetingSpec.get("flexible_spec");
+        targetingSpec.remove("flexible_spec");
+        if (existingFlexibleSpec == null || !existingFlexibleSpec.isArray()) {
+            return;
+        }
+        for (JsonNode group : existingFlexibleSpec) {
+            if (!group.isObject()) {
+                continue;
+            }
+            mergeArrayField(orGroup, group, "interests");
+            mergeArrayField(orGroup, group, "work_positions");
+            mergeArrayField(orGroup, group, "behaviors");
+        }
+    }
+
+    /**
+     * Junta arrays de uma mesma categoria preservando os objetos oficiais retornados pela Meta.
+     */
+    private void mergeArrayField(ObjectNode target, JsonNode source, String fieldName) {
+        JsonNode sourceArray = source.get(fieldName);
+        if (sourceArray == null || !sourceArray.isArray() || sourceArray.isEmpty()) {
+            return;
+        }
+        ArrayNode targetArray;
+        JsonNode existing = target.get(fieldName);
+        if (existing instanceof ArrayNode existingArray) {
+            targetArray = existingArray;
+        } else {
+            targetArray = objectMapper.createArrayNode();
+            target.set(fieldName, targetArray);
+        }
+        sourceArray.forEach(targetArray::add);
     }
 
     private <T> T executeFacebookCallWithLogging(String publicationJobId,

--- a/facebook-ads-worker/src/test/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignServiceTest.java
+++ b/facebook-ads-worker/src/test/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignServiceTest.java
@@ -133,6 +133,11 @@ class FacebookCampaignServiceTest {
             () -> new MockResponse().setBody("{}").addHeader("Content-Type", "application/json")
         );
         backend.enqueuePriorityConditionalResponse(
+            request -> "/api/facebook-campaigns/publication-job-steps".equals(request.getPath())
+                && "POST".equals(request.getMethod()),
+            () -> new MockResponse().setBody("{}").addHeader("Content-Type", "application/json")
+        );
+        backend.enqueuePriorityConditionalResponse(
             request -> request.getPath() != null
                 && request.getPath().contains("/api/instant-forms/")
                 && request.getPath().endsWith("/publication")
@@ -361,6 +366,9 @@ class FacebookCampaignServiceTest {
         assertEquals("42", adSetPayload.get("promoted_object").get("page_id").asText());
         JsonNode targeting = adSetPayload.get("targeting");
         assertEquals("BR", targeting.get("geo_locations").get("countries").get(0).asText());
+        assertFalse(targeting.has("work_positions"));
+        assertEquals(1, targeting.get("flexible_spec").size());
+        assertEquals("1419795191647433", targeting.get("flexible_spec").get(0).get("work_positions").get(0).get("id").asText());
         assertEquals(0, targeting.get("targeting_automation").get("advantage_audience").asInt());
 
         RecordedRequest postCreative = takeFacebookRequest("facebook request");
@@ -398,7 +406,7 @@ class FacebookCampaignServiceTest {
     // Garante que a campanha não é criada quando o público fica abaixo do alcance mínimo.
     void skipsCampaignCreationWhenReachValidationIsBelowMinimum() throws Exception {
         reachEstimateResponseBody = "{\"data\":[{\"users_lower_bound\":1000,\"users_upper_bound\":50000}]}";
-        backend.enqueueResponse(new MockResponse().setBody("[{\"id\":1,\"name\":\"Exp\",\"dailyBudget\":25.0,\"facebookPage\":{\"id\":9,\"pageId\":\"84\",\"name\":\"Estúdio\"},\"instagramAccount\":{\"id\":55,\"handle\":\"@estudio\",\"code\":\"IG-EST\",\"name\":\"Estúdio\"}}]")
+        backend.enqueueResponse(new MockResponse().setBody("[{\"id\":1,\"name\":\"Exp\",\"dailyBudget\":25.0,\"facebookPage\":{\"id\":9,\"pageId\":\"84\",\"name\":\"Estúdio\"},\"instagramAccount\":{\"id\":55,\"handle\":\"@estudio\",\"code\":\"IG-EST\",\"name\":\"Estúdio\"},\"publicationJobId\":\"job-reach-low\"}]")
             .addHeader("Content-Type", "application/json"));
         backend.enqueueResponse(new MockResponse().setBody("[{\"id\":101,\"experimentId\":1,\"headline\":\"HL\",\"primaryText\":\"Texto Criativo\",\"imageUrl\":\"" + imageUrl + "\",\"description\":\"Desc\",\"cta\":\"SHOP_NOW\",\"destinationUrl\":\"https://exp.example/landing\",\"instagramUserId\":\"21\",\"status\":\"READY\"}]")
             .addHeader("Content-Type", "application/json"));
@@ -424,6 +432,21 @@ class FacebookCampaignServiceTest {
         assertTrue(reachRequest.getPath().contains("/reachestimate?"));
         JsonNode reachTargetingSpec = targetingSpecFromReachEstimateRequest(reachRequest);
         assertEquals("BR", reachTargetingSpec.get("geo_locations").get("countries").get(0).asText());
+        assertFalse(reachTargetingSpec.has("work_positions"));
+        assertEquals(1, reachTargetingSpec.get("flexible_spec").size());
+        takeBackendRequestMatching(
+            "publication job reach step",
+            request -> "/api/facebook-campaigns/publication-job-steps".equals(request.getPath())
+                && "POST".equals(request.getMethod())
+        );
+        RecordedRequest failureStepRequest = takeBackendRequestMatching(
+            "publication job failure step",
+            request -> "/api/facebook-campaigns/publication-job-steps".equals(request.getPath())
+                && "POST".equals(request.getMethod())
+        );
+        JsonNode failureStepPayload = objectMapper.readTree(failureStepRequest.getBody().inputStream());
+        assertEquals("CAMPAIGN_REACH_VALIDATION_BLOCKED", failureStepPayload.get("stepName").asText());
+        assertTrue(failureStepPayload.get("errorMessage").asText().contains("Público pequeno demais"));
         RecordedRequest failedStatusRequest = takeBackendRequestMatching(
             "failed status update",
             request -> request.getPath() != null
@@ -1450,7 +1473,9 @@ class FacebookCampaignServiceTest {
         takeFacebookRequest("facebook request"); // campaign
         RecordedRequest adSetRequest = takeFacebookRequest("facebook request");
         JsonNode adSetPayload = objectMapper.readTree(adSetRequest.getBody().inputStream());
-        JsonNode workPositions = adSetPayload.get("targeting").get("work_positions");
+        JsonNode targeting = adSetPayload.get("targeting");
+        assertFalse(targeting.has("work_positions"));
+        JsonNode workPositions = targeting.get("flexible_spec").get(0).get("work_positions");
         assertEquals(1, workPositions.size());
         assertEquals("1419795191647433", workPositions.get(0).get("id").asText());
         assertEquals("Certified Personal Trainer", workPositions.get(0).get("name").asText());


### PR DESCRIPTION
### Motivation

- Improve operational observability by recording and surfacing worker-side publication job failures alongside Meta API logs. 
- Prevent overly-narrow audiences caused by implicit AND between interests/careers/behaviors by converting them to a single OR flexible spec before reach estimation. 

### Description

- Add repository method `findTopByExperimentIdAndErrorMessageIsNotNullOrderByOccurredAtDescIdDesc` to `FacebookCampaignPublicationJobStepRepository` and wire it into `ExperimentDiagnosticsService`. 
- Enhance `ExperimentDiagnosticsService` to prefer recent job-step failure details via `publicationJobStepRepository` and convert steps to `ExperimentFailureDetailsDto` with `toFailureDetails`. 
- Add `ExperimentFacebookApiLogClient#logPublicationJobFailureStep` and make the worker post job steps to the backend at `POST /api/facebook-campaigns/publication-job-steps`. 
- In the worker `FacebookCampaignService`, broaden approved targeting by moving `interests`, `work_positions` and `behaviors` into a single `flexible_spec` (OR audience) using `normalizeAndBroadenTargetingSpec` / `broadenTargetingSpecToOrAudience`, and log+register a publication job failure step when reach validation is missing or out-of-range via `logPublicationJobFailureStep`. 
- Update tests and HTTP test stubs to expect publication-job-step posts and to assert the broadened `flexible_spec` payload and failure-step details. 
- Document canonical changes about reach-validation and job-id publication tracing in docs. 

### Testing

- Ran `ExperimentDiagnosticsServiceTest` which was updated to mock `FacebookCampaignPublicationJobStepRepository` and includes `shouldShowPublicationJobFailureWhenReachValidationBlockedAfterSuccessfulMetaCall`; tests passed. 
- Ran `FacebookCampaignServiceTest` updates (including `skipsCampaignCreationWhenReachValidationIsBelowMinimum`) which assert `flexible_spec` usage and published job-step payloads; tests passed. 
- Existing worker integration-style tests exercised the new backend POST to `/facebook-campaigns/publication-job-steps` and succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a31f0565b308321a3e225370464ee5f)