### PR TITLE
Aplicar protocolo padrão backend na biblioteca de páginas de vendas

### DIFF
--- a/backend/ads-service/src/test/java/com/marketinghub/architecture/ArquiteturaTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/architecture/ArquiteturaTest.java
@@ -62,7 +62,12 @@ class ArquiteturaTest {
             "com.marketinghub.repository.jpa.niche.MarketNicheRepository",
             "com.marketinghub.repository.jpa.niche.MarketNicheEnrichmentProfileRepository");
     private static final Pattern SALES_LIBRARY_LAYER_PATTERN = Pattern.compile(
-            "^com\\.marketinghub\\.mois\\.bibliotecapaginavenda\\.([a-zA-Z0-9_]+)\\.(v\\d+)\\.(web|service|repository)(?:\\..*)?$");
+            "^com\\.marketinghub\\.mois\\.bibliotecapaginavenda\\.([a-zA-Z0-9_]+)\\.(v\\d+)\\.(web|service|dto|repository)(?:\\..*)?$");
+    private static final String MOIS_SALES_LIBRARY_WEB_PACKAGE = MOIS_SALES_LIBRARY_PACKAGE + ".web";
+    private static final String MOIS_SALES_LIBRARY_SERVICE_PACKAGE = MOIS_SALES_LIBRARY_PACKAGE + ".service";
+    private static final String MOIS_SALES_LIBRARY_DTO_PACKAGE = MOIS_SALES_LIBRARY_PACKAGE + ".dto";
+    private static final String MOIS_SALES_LIBRARY_REPOSITORY_PACKAGE =
+            "com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1";
     private static final Pattern BACKEND_STAGE_WEB_PACKAGE_PATTERN =
             Pattern.compile("^com\\.marketinghub\\.geralanding\\.[a-zA-Z0-9_]+\\.web$");
     private static final Pattern BACKEND_STAGE_SERVICE_PACKAGE_PATTERN =
@@ -751,6 +756,101 @@ class ArquiteturaTest {
     static final ArchRule moisSalesLibraryServiceShouldOnlyDependOnRepositoryLayer =
             classes().that(classesBelongingToLayer("service")).should(onlyDependOnLayer("repository"));
 
+
+
+
+    /**
+     * Garante que a Biblioteca de Páginas de Vendas do MOIS tenha controller único e canônico.
+     */
+    @ArchTest
+    static void moisSalesLibraryPackageMustHaveSingleCanonicalController(JavaClasses importedClasses) {
+        List<String> violations = new ArrayList<>();
+        List<JavaClass> webPackageClasses = directPackageClasses(importedClasses, MOIS_SALES_LIBRARY_WEB_PACKAGE);
+        List<JavaClass> controllers = webPackageClasses.stream()
+                .filter(javaClass -> javaClass.getSimpleName().equals("MoisSalesLibraryController"))
+                .toList();
+        if (webPackageClasses.size() != 1) {
+            violations.add("[ARQUITETURA] [BACKEND][MOIS][BibliotecaPaginaVenda] pacote="
+                    + MOIS_SALES_LIBRARY_WEB_PACKAGE
+                    + " deve conter apenas MoisSalesLibraryController; classes=" + simpleNames(webPackageClasses));
+        }
+        if (controllers.size() != 1) {
+            violations.add("[ARQUITETURA] [BACKEND][MOIS][BibliotecaPaginaVenda] pacote="
+                    + MOIS_SALES_LIBRARY_WEB_PACKAGE
+                    + " deve conter exatamente uma classe MoisSalesLibraryController; controllers="
+                    + simpleNames(controllers));
+        } else {
+            JavaClass controller = controllers.get(0);
+            if (!controller.isAnnotatedWith(RestController.class)) {
+                violations.add("[ARQUITETURA] [BACKEND][MOIS][BibliotecaPaginaVenda] classe="
+                        + controller.getName() + " deve possuir @RestController");
+            }
+            if (!hasRequestMapping(controller, "/api/mois/sales-library")) {
+                violations.add("[ARQUITETURA] [BACKEND][MOIS][BibliotecaPaginaVenda] classe="
+                        + controller.getName()
+                        + " deve possuir @RequestMapping(\"/api/mois/sales-library\")");
+            }
+        }
+        failWithArchitectureViolations(violations);
+    }
+
+    /**
+     * Garante que a Biblioteca de Páginas de Vendas do MOIS possua a fachada de service canônica.
+     */
+    @ArchTest
+    static void moisSalesLibraryPackageMustHaveCanonicalServiceFacade(JavaClasses importedClasses) {
+        List<String> violations = new ArrayList<>();
+        List<JavaClass> servicePackageClasses = directPackageClasses(importedClasses, MOIS_SALES_LIBRARY_SERVICE_PACKAGE);
+        List<JavaClass> facades = servicePackageClasses.stream()
+                .filter(javaClass -> javaClass.getSimpleName().equals("MoisSalesLibraryService"))
+                .toList();
+        if (facades.size() != 1) {
+            violations.add("[ARQUITETURA] [BACKEND][MOIS][BibliotecaPaginaVenda] pacote="
+                    + MOIS_SALES_LIBRARY_SERVICE_PACKAGE
+                    + " deve conter exatamente uma fachada MoisSalesLibraryService; facades="
+                    + simpleNames(facades));
+        } else if (!facades.get(0).isAnnotatedWith(Service.class)) {
+            violations.add("[ARQUITETURA] [BACKEND][MOIS][BibliotecaPaginaVenda] classe="
+                    + facades.get(0).getName()
+                    + " deve possuir @Service para marcar a fachada canônica do módulo");
+        }
+        failWithArchitectureViolations(violations);
+    }
+
+    /**
+     * Garante que os contratos da Biblioteca de Páginas de Vendas permaneçam imutáveis.
+     */
+    @ArchTest
+    static void moisSalesLibraryDtosMustBeRecords(JavaClasses importedClasses) {
+        List<String> violations = new ArrayList<>();
+        directPackageClasses(importedClasses, MOIS_SALES_LIBRARY_DTO_PACKAGE).stream()
+                .filter(javaClass -> !javaClass.getSimpleName().equals("MoisSalesLibraryDtos"))
+                .filter(javaClass -> !javaClass.reflect().isRecord())
+                .forEach(javaClass -> violations.add("[ARQUITETURA] [BACKEND][MOIS][BibliotecaPaginaVenda] classe="
+                        + javaClass.getName()
+                        + " deve ser declarada como record quando representar contrato HTTP"));
+        failWithArchitectureViolations(violations);
+    }
+
+    /**
+     * Garante que repositories da Biblioteca de Páginas de Vendas fiquem no pacote canônico externo.
+     */
+    @ArchTest
+    static void moisSalesLibraryRepositoriesMustStayInCanonicalRepositoryPackage(JavaClasses importedClasses) {
+        List<String> violations = new ArrayList<>();
+        List<JavaClass> repositoryClasses = directPackageClasses(importedClasses, MOIS_SALES_LIBRARY_REPOSITORY_PACKAGE);
+        if (repositoryClasses.isEmpty()) {
+            violations.add("[ARQUITETURA] [BACKEND][MOIS][BibliotecaPaginaVenda] pacote="
+                    + MOIS_SALES_LIBRARY_REPOSITORY_PACKAGE
+                    + " deve conter os gateways/repositories canônicos do módulo");
+        }
+        repositoryClasses.stream()
+                .filter(javaClass -> !javaClass.isInterface())
+                .forEach(javaClass -> violations.add("[ARQUITETURA] [BACKEND][MOIS][BibliotecaPaginaVenda] classe="
+                        + javaClass.getName() + " deve permanecer como contrato/interface de persistência no pacote "
+                        + MOIS_SALES_LIBRARY_REPOSITORY_PACKAGE));
+        failWithArchitectureViolations(violations);
+    }
 
 
     @ArchTest

--- a/docs/registros/mois1.md
+++ b/docs/registros/mois1.md
@@ -1,3 +1,7 @@
+## 2026-06-17 — Protocolo padrão backend na Biblioteca de Páginas de Vendas
+- aplicado o protocolo padrão backend no pacote `com.marketinghub.mois.bibliotecapaginavenda.worker.v1` com regras ArchUnit para controller único/canônico, fachada de service canônica, contratos imutáveis e persistência centralizada no pacote `com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1`.
+- objetivo: reduzir risco de dispersão arquitetural na Biblioteca de Páginas de Vendas e preservar a capacidade do MOIS de transformar páginas coletadas em inteligência comercial para vendas.
+
 ## 2026-06-16 — Objetivo comercial da Biblioteca de Páginas de Vendas
 - atualizado o cânone MOIS para deixar claro que a Biblioteca de Páginas de Vendas não tem como objetivo principal encontrar oportunidades de mercado.
 - registrado que o objetivo correto é identificar e reutilizar fórmulas comerciais que já vendem com consistência no digital, copiando a estrutura de venda vencedora sem plagiar conteúdo literal, marca, identidade visual ou ativos de terceiros.


### PR DESCRIPTION
### Motivation
- Garantir que o pacote da Biblioteca de Páginas de Vendas do MOIS siga o protocolo padrão backend de borda HTTP, service, DTOs e persistência para reduzir dispersão arquitetural.
- Evitar acoplamentos indevidos e impor contratos imutáveis e localização centralizada de repositories conforme as diretrizes de arquitetura do backend.

### Description
- Estende a validação ArchUnit em `backend/ads-service/src/test/java/com/marketinghub/architecture/ArquiteturaTest.java` incluindo `dto` no pattern de camada da biblioteca e adicionando constantes canônicas para os pacotes `web`, `service`, `dto` e o pacote de repositories externo. 
- Adiciona quatro regras de validação ArchUnit (`@ArchTest`) que verificam: controller único/canônico (`MoisSalesLibraryController`), fachada de service canônica (`MoisSalesLibraryService`), contratos DTO declarados como `record` no pacote `*.dto`, e presença/contrato dos gateways/repositories no pacote `com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1`.
- Registra a mudança operacional em `docs/registros/mois1.md` com resumo da aplicação do protocolo padrão backend para rastreabilidade.

### Testing
- Executado `../mvnw -Dtest=ArquiteturaTest test`, que não concluiu devido a indisponibilidade temporária do Maven Central ao resolver `org.junit.platform:junit-platform-launcher:1.10.2` (HTTP 502), portanto os testes de integração/execução do ArchUnit não puderam ser validados remotamente. 
- Executado `../mvnw -DskipTests test-compile` no módulo `backend/ads-service` para validar compilação sem executar a suíte de testes; compilação dos sources e testes em modo compile ocorreu com sucesso.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a31f40cb4688321a30329b8b9740aa5)