### PR TITLE
Prevent market-warmup before commercial analysis; propagate to worker and UI

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesPageMarketWarmupService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesPageMarketWarmupService.java
@@ -14,6 +14,7 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Locale;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -28,6 +29,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class MoisSalesPageMarketWarmupService {
 
     private static final int DEFAULT_STALE_MINUTES = 120;
+    private static final List<String> ANALYZED_STATUSES = List.of("DONE", "ANALYZED");
 
     private final MoisSalesPageMarketWarmupGateway gateway;
     private final MoisSalesPageMarketWarmupScoreEngine scoreEngine = new MoisSalesPageMarketWarmupScoreEngine();
@@ -40,6 +42,7 @@ public class MoisSalesPageMarketWarmupService {
         try {
             SalesPageWarmupData page = gateway.findSalesPage(pageId)
                     .orElseThrow(() -> new IllegalArgumentException("Página MOIS não encontrada para aquecimento: " + pageId));
+            validatePageAnalyzedForWarmup(page);
             MarketWarmupJobData job = gateway.findActiveJobByPage(pageId).orElseGet(() -> gateway.createPendingJob(page));
             log.info("Pesquisa de aquecimento MOIS solicitada. modulo=MOIS, operacao=requestMarketWarmup, pageId={}, jobId={}, status={}",
                     pageId, job.jobId(), mapJobStatus(job.status()));
@@ -208,6 +211,27 @@ public class MoisSalesPageMarketWarmupService {
                     job.workspaceId(), job.pageId(), job.jobId(), index, sourceId, source.platform(), source.sourceType(), source.sourceUrl());
         }
         return sourceIds;
+    }
+
+    /**
+     * Bloqueia dossiê antes da análise comercial estar concluída para manter a fila consistente.
+     */
+    private void validatePageAnalyzedForWarmup(SalesPageWarmupData page) {
+        String effectiveStatus = page.analysisStatus() == null || page.analysisStatus().isBlank()
+                ? page.currentStatus()
+                : page.analysisStatus();
+        String normalizedStatus = effectiveStatus == null ? "" : effectiveStatus.trim().toUpperCase(Locale.ROOT);
+        if (!ANALYZED_STATUSES.contains(normalizedStatus)) {
+            throw new IllegalStateException("Dossiê MOIS só pode ser iniciado depois da análise comercial da página. pageId="
+                    + page.pageId() + ", statusAtual=" + nullSafe(page.currentStatus()) + ", statusAnalise=" + nullSafe(page.analysisStatus()));
+        }
+    }
+
+    /**
+     * Normaliza valor nulo para mensagem operacional objetiva.
+     */
+    private String nullSafe(String value) {
+        return value == null || value.isBlank() ? "SEM_STATUS" : value;
     }
 
     /**

--- a/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/web/MoisSalesLibraryController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/web/MoisSalesLibraryController.java
@@ -182,6 +182,10 @@ public class MoisSalesLibraryController {
         } catch (IllegalArgumentException ex) {
             log.warn("Biblioteca de páginas de vendas não encontrou página para aquecimento. operacao=requestMarketWarmup, pageId={}, erro={}", pageId, ex.getMessage(), ex);
             throw new ResponseStatusException(HttpStatus.NOT_FOUND, ex.getMessage(), ex);
+        } catch (IllegalStateException ex) {
+            log.warn("Biblioteca de páginas de vendas bloqueou dossiê antes da análise comercial. operacao=requestMarketWarmup, pageId={}, erro={}",
+                    pageId, ex.getMessage(), ex);
+            throw new ResponseStatusException(HttpStatus.CONFLICT, ex.getMessage(), ex);
         }
     }
 

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/mois/bibliotecapaginavenda/worker/v1/MoisSalesPageMarketWarmupGateway.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/mois/bibliotecapaginavenda/worker/v1/MoisSalesPageMarketWarmupGateway.java
@@ -104,6 +104,8 @@ public interface MoisSalesPageMarketWarmupGateway {
             String urlCanonical,
             String title,
             String producerName,
+            String currentStatus,
+            String analysisStatus,
             String offerSummary,
             String mechanismSummary,
             String promiseSummary,

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/mois/bibliotecapaginavenda/worker/v1/MoisSalesPageMarketWarmupRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/mois/bibliotecapaginavenda/worker/v1/MoisSalesPageMarketWarmupRepository.java
@@ -30,6 +30,7 @@ public class MoisSalesPageMarketWarmupRepository implements MoisSalesPageMarketW
     public Optional<SalesPageWarmupData> findSalesPage(long pageId) {
         List<SalesPageWarmupData> rows = jdbcTemplate.query("""
                 SELECT sp.id, sp.workspace_id, sp.url_canonical, sp.title, cr.producer_name,
+                       sp.current_status, sp.analysis_status,
                        sp.offer_summary, sp.mechanism_summary, sp.promise_summary, sp.proof_summary
                 FROM mois_sales_page sp
                 LEFT JOIN mois_collected_reference cr ON cr.id = sp.collected_reference_id
@@ -98,11 +99,13 @@ public class MoisSalesPageMarketWarmupRepository implements MoisSalesPageMarketW
     public Optional<MarketWarmupClaimData> findNextPendingJob(String workspaceId) {
         List<MarketWarmupClaimData> rows = jdbcTemplate.query("""
                 SELECT j.id AS job_id, j.sales_page_id, j.workspace_id, j.status, j.created_at, j.error_category, j.error_message,
-                       sp.url_canonical, sp.title, cr.producer_name, sp.offer_summary, sp.mechanism_summary, sp.promise_summary, sp.proof_summary
+                       sp.url_canonical, sp.title, cr.producer_name, sp.current_status, sp.analysis_status,
+                       sp.offer_summary, sp.mechanism_summary, sp.promise_summary, sp.proof_summary
                 FROM mois_sales_page_market_warmup_job j
                 JOIN mois_sales_page sp ON sp.id = j.sales_page_id
                 LEFT JOIN mois_collected_reference cr ON cr.id = sp.collected_reference_id
                 WHERE j.workspace_id = ? AND j.status = 'PENDING'
+                  AND COALESCE(sp.analysis_status, sp.current_status) IN ('DONE', 'ANALYZED')
                 ORDER BY j.created_at ASC, j.id ASC
                 LIMIT 1
                 """, this::mapClaim, workspaceId);
@@ -311,7 +314,8 @@ public class MoisSalesPageMarketWarmupRepository implements MoisSalesPageMarketW
      */
     private SalesPageWarmupData mapSalesPage(ResultSet rs, int rowNum) throws SQLException {
         return new SalesPageWarmupData(rs.getLong("id"), rs.getString("workspace_id"), rs.getString("url_canonical"), rs.getString("title"),
-                rs.getString("producer_name"), rs.getString("offer_summary"), rs.getString("mechanism_summary"), rs.getString("promise_summary"), rs.getString("proof_summary"));
+                rs.getString("producer_name"), rs.getString("current_status"), rs.getString("analysis_status"),
+                rs.getString("offer_summary"), rs.getString("mechanism_summary"), rs.getString("promise_summary"), rs.getString("proof_summary"));
     }
 
     /**
@@ -331,7 +335,8 @@ public class MoisSalesPageMarketWarmupRepository implements MoisSalesPageMarketW
                 rs.getString("status"), toInstant(rs.getTimestamp("created_at")),
                 rs.getString("error_category"), rs.getString("error_message"));
         SalesPageWarmupData page = new SalesPageWarmupData(rs.getLong("sales_page_id"), rs.getString("workspace_id"), rs.getString("url_canonical"),
-                rs.getString("title"), rs.getString("producer_name"), rs.getString("offer_summary"), rs.getString("mechanism_summary"), rs.getString("promise_summary"), rs.getString("proof_summary"));
+                rs.getString("title"), rs.getString("producer_name"), rs.getString("current_status"), rs.getString("analysis_status"),
+                rs.getString("offer_summary"), rs.getString("mechanism_summary"), rs.getString("promise_summary"), rs.getString("proof_summary"));
         return new MarketWarmupClaimData(job, page);
     }
 

--- a/backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesPageMarketWarmupServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesPageMarketWarmupServiceTest.java
@@ -74,6 +74,33 @@ class MoisSalesPageMarketWarmupServiceTest {
     }
 
     /**
+     * Garante que a pesquisa de aquecimento não nasce antes da análise comercial da página.
+     */
+    @Test
+    void requestResearchRejectsPageWithoutCommercialAnalysis() {
+        SalesPageWarmupData page = new SalesPageWarmupData(
+                10L,
+                "workspace-001",
+                "https://example.test/oferta",
+                "Oferta principal",
+                "Produtor Especialista",
+                "CAPTURED",
+                "PENDING",
+                null,
+                null,
+                null,
+                null);
+        given(gateway.findSalesPage(10L)).willReturn(Optional.of(page));
+
+        assertThatThrownBy(() -> service.requestResearch(10L))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("só pode ser iniciado depois da análise comercial");
+
+        verify(gateway, never()).findActiveJobByPage(10L);
+        verify(gateway, never()).createPendingJob(page);
+    }
+
+    /**
      * Garante que o worker recebe os dados comerciais necessários ao reservar um job pendente.
      */
     @Test
@@ -305,6 +332,8 @@ class MoisSalesPageMarketWarmupServiceTest {
                 "https://example.test/oferta",
                 "Oferta principal",
                 "Produtor Especialista",
+                "ANALYZED",
+                "ANALYZED",
                 "Oferta transforma dor em resultado",
                 "Mecanismo plausível",
                 "Promessa clara",

--- a/backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/web/MoisSalesLibraryControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/web/MoisSalesLibraryControllerTest.java
@@ -260,6 +260,18 @@ class MoisSalesLibraryControllerTest {
     }
 
     /**
+     * Garante que o controller bloqueia dossiê solicitado antes da análise comercial.
+     */
+    @Test
+    void shouldMapMarketWarmupRequestBeforeAnalysisToHttp409() throws Exception {
+        doThrow(new IllegalStateException("Dossiê MOIS só pode ser iniciado depois da análise comercial da página."))
+                .when(marketWarmupService).requestResearch(10L);
+
+        mockMvc.perform(post("/api/mois/sales-library/pages/10/market-warmup:request"))
+                .andExpect(status().isConflict());
+    }
+
+    /**
      * Garante que a consulta pública retorna o resumo comercial rastreável da Etapa 3.
      */
     @Test

--- a/docs/registros/mois1.md
+++ b/docs/registros/mois1.md
@@ -1654,3 +1654,9 @@ Arquivos principais:
 
 - Removida da tela do pipeline da Biblioteca de Sales Pages a área de execução manual da captura da etapa 1, porque essa etapa já acontece de forma automática.
 - Mantidos os indicadores de processamento automático para o usuário acompanhar avanço, última captura, volume pendente e velocidade sem precisar acionar comandos manuais.
+
+## 2026-06-17 — Bloqueio de dossiê antes da análise comercial
+
+- Corrigida a causa-raiz de produtos capturados aparecerem com dossiê pendente antes de terem análise comercial concluída.
+- O backend passa a recusar a criação de job de dossiê quando a página ainda não está em `DONE`/`ANALYZED`, e o worker deixa de reservar jobs pendentes que ainda não estejam elegíveis.
+- A tela de detalhe bloqueia o botão de iniciar dossiê até a análise comercial terminar, e a listagem informa “Dossiê: Aguardando análise” para evitar uma decisão operacional incorreta.

--- a/frontend/src/pages/mois/MoisSalesPageLibraryDetailPage.tsx
+++ b/frontend/src/pages/mois/MoisSalesPageLibraryDetailPage.tsx
@@ -107,8 +107,14 @@ export default function MoisSalesPageLibraryDetailPage() {
       pageQuery.data?.marketWarmupStatus || "",
     ),
   );
+  const isCommercialAnalysisDone = ["DONE", "ANALYZED"].includes(
+    pageQuery.data?.analysisStatus || pageQuery.data?.currentStatus || "",
+  );
   const isWarmupRequestDisabled =
-    !validPageId || requestWarmupMutation.isPending || hasActiveWarmupDossier;
+    !validPageId ||
+    requestWarmupMutation.isPending ||
+    hasActiveWarmupDossier ||
+    !isCommercialAnalysisDone;
   const hotmartPrice = cleanText(pageQuery.data?.hotmartPrice);
   const hotmartTemperature = pageQuery.data?.hotmartTemperature;
   const hotmartProducer =
@@ -262,6 +268,18 @@ export default function MoisSalesPageLibraryDetailPage() {
           Falha ao solicitar dossiê.
         </div>
       ) : null}
+      {!isCommercialAnalysisDone && !hasActiveWarmupDossier ? (
+        <div className="alert alert-warning mb-0">
+          O dossiê fica disponível somente depois que a análise comercial da
+          página estiver concluída. Esta página ainda está em{" "}
+          <strong>
+            {pageQuery.data?.analysisStatus ||
+              pageQuery.data?.currentStatus ||
+              "SEM STATUS"}
+          </strong>
+          .
+        </div>
+      ) : null}
 
       {pageQuery.isLoading ? (
         <p className="text-secondary mb-0">Carregando produto...</p>
@@ -341,9 +359,9 @@ export default function MoisSalesPageLibraryDetailPage() {
           ) : null}
           {!marketWarmupQuery.isLoading && !marketWarmupQuery.data ? (
             <div className="alert alert-warning mb-0">
-              Ainda não há dossiê de aquecimento concluído para este produto.
-              Execute a etapa de pesquisa de aquecimento para validar redes e
-              autoridade do produtor.
+              Ainda não há dossiê de aquecimento concluído para este produto. O
+              comando será liberado quando a análise comercial da página estiver
+              concluída.
             </div>
           ) : null}
 

--- a/frontend/src/pages/mois/MoisSalesPagesLibraryPage.tsx
+++ b/frontend/src/pages/mois/MoisSalesPagesLibraryPage.tsx
@@ -92,6 +92,12 @@ function getPipelinePhase(stage?: string | null, status?: string | null) {
   return `${stageLabel} · ${statusLabel}`;
 }
 
+function isCommercialAnalysisDone(item: MoisSalesLibraryPage) {
+  return ["DONE", "ANALYZED"].includes(
+    item.analysisStatus || item.currentStatus || "",
+  );
+}
+
 function formatDateTime(value?: string | null) {
   if (!value) {
     return "—";
@@ -369,18 +375,25 @@ export default function MoisSalesPagesLibraryPage() {
                           {item.source === "HOTMART" ? (
                             <div className="d-flex flex-column align-items-start gap-1">
                               <span className="fw-semibold">
-                                {formatHotmartTemperature(item.hotmartTemperature)}
+                                {formatHotmartTemperature(
+                                  item.hotmartTemperature,
+                                )}
                               </span>
                               <span
                                 className={`badge ${getWarmupBadgeClass(item.marketWarmupTemperature || item.marketWarmupStatus)}`}
                               >
-                                Dossiê: {item.marketWarmupTemperature
-                                  ? warmupTemperatureLabels[
-                                      item.marketWarmupTemperature
-                                    ]
-                                  : item.marketWarmupStatus
-                                    ? warmupStatusLabels[item.marketWarmupStatus]
-                                    : "Sem dossiê"}
+                                Dossiê:{" "}
+                                {!isCommercialAnalysisDone(item)
+                                  ? "Aguardando análise"
+                                  : item.marketWarmupTemperature
+                                    ? warmupTemperatureLabels[
+                                        item.marketWarmupTemperature
+                                      ]
+                                    : item.marketWarmupStatus
+                                      ? warmupStatusLabels[
+                                          item.marketWarmupStatus
+                                        ]
+                                      : "Sem dossiê"}
                               </span>
                             </div>
                           ) : (


### PR DESCRIPTION
### Motivation
- Prevent creating or processing market-warmup dossiers for sales pages that have not completed commercial analysis (`DONE`/`ANALYZED`).
- Avoid workers claiming jobs and users requesting warmup for pages that are not yet eligible, keeping queue and UI consistent.

### Description
- Added `currentStatus` and `analysisStatus` to `SalesPageWarmupData` and included those columns in page queries in the repository and claim payloads. 
- Enforced eligibility in the service by adding `validatePageAnalyzedForWarmup`, a normalized-status check against `List.of("DONE","ANALYZED")`, and a `nullSafe` helper for messaging. 
- Restrained worker claims at SQL level by adding `AND COALESCE(sp.analysis_status, sp.current_status) IN ('DONE','ANALYZED')` to `findNextPendingJob`. 
- Controller maps the new `IllegalStateException` from `requestResearch` to an `HTTP 409 Conflict` response. 
- Frontend: disabled the warmup request button when commercial analysis is not done, added a warning banner and list/table labels that show "Aguardando análise" until eligibility. 
- Documentation updated to record the behavioral change and rationale. 

### Testing
- Updated and executed unit tests `MoisSalesPageMarketWarmupServiceTest` and `MoisSalesLibraryControllerTest`, including the new `requestResearchRejectsPageWithoutCommercialAnalysis` and controller mapping test, and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a31f2082ec4832186ed455d474c4a2c)