### PR TITLE
Move MOIS Sales Pages JDBC repositories into jdbc subpackage and update tests/docs

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/mois/bibliotecapaginavenda/worker/v1/jdbc/MoisSalesLibraryPricingRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/mois/bibliotecapaginavenda/worker/v1/jdbc/MoisSalesLibraryPricingRepository.java
@@ -1,5 +1,7 @@
-package com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1;
+package com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1.jdbc;
 
+import com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1.MoisSalesLibraryPricingGateway;
+import com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1.MoisSalesLibraryPricingGateway.ModelPricing;
 import java.util.List;
 import java.util.Locale;
 import java.util.Optional;

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/mois/bibliotecapaginavenda/worker/v1/jdbc/MoisSalesPageBackfillRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/mois/bibliotecapaginavenda/worker/v1/jdbc/MoisSalesPageBackfillRepository.java
@@ -1,5 +1,6 @@
-package com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1;
+package com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1.jdbc;
 
+import com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1.MoisSalesPageBackfillGateway;
 import java.sql.DatabaseMetaData;
 import java.sql.ResultSet;
 import java.sql.SQLException;

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/mois/bibliotecapaginavenda/worker/v1/jdbc/MoisSalesPageMarketWarmupRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/mois/bibliotecapaginavenda/worker/v1/jdbc/MoisSalesPageMarketWarmupRepository.java
@@ -1,5 +1,14 @@
-package com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1;
+package com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1.jdbc;
 
+import com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1.MoisSalesPageMarketWarmupGateway;
+import com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1.MoisSalesPageMarketWarmupGateway.MarketWarmupClaimData;
+import com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1.MoisSalesPageMarketWarmupGateway.MarketWarmupJobData;
+import com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1.MoisSalesPageMarketWarmupGateway.MarketWarmupSignalData;
+import com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1.MoisSalesPageMarketWarmupGateway.MarketWarmupSignalReadData;
+import com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1.MoisSalesPageMarketWarmupGateway.MarketWarmupSourceData;
+import com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1.MoisSalesPageMarketWarmupGateway.MarketWarmupSummaryData;
+import com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1.MoisSalesPageMarketWarmupGateway.MarketWarmupSummaryWriteData;
+import com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1.MoisSalesPageMarketWarmupGateway.SalesPageWarmupData;
 import java.sql.PreparedStatement;
 import java.sql.ResultSet;
 import java.sql.SQLException;

--- a/backend/ads-service/src/test/java/com/marketinghub/repository/jpa/mois/bibliotecapaginavenda/worker/v1/MoisSalesLibraryPricingRepositoryTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/repository/jpa/mois/bibliotecapaginavenda/worker/v1/MoisSalesLibraryPricingRepositoryTest.java
@@ -5,6 +5,7 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.BDDMockito.given;
 
+import com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1.jdbc.MoisSalesLibraryPricingRepository;
 import java.math.BigDecimal;
 import java.sql.ResultSet;
 import java.util.List;

--- a/docs/registros/mois1.md
+++ b/docs/registros/mois1.md
@@ -1664,3 +1664,9 @@ Arquivos principais:
 - Corrigida a causa-raiz de produtos capturados aparecerem com dossiê pendente antes de terem análise comercial concluída.
 - O backend passa a recusar a criação de job de dossiê quando a página ainda não está em `DONE`/`ANALYZED`, e o worker deixa de reservar jobs pendentes que ainda não estejam elegíveis.
 - A tela de detalhe bloqueia o botão de iniciar dossiê até a análise comercial terminar, e a listagem informa “Dossiê: Aguardando análise” para evitar uma decisão operacional incorreta.
+
+## 2026-06-17 — Ajuste arquitetural dos repositories da Biblioteca de Sales Pages
+
+- Corrigida a causa-raiz da falha de arquitetura em `moisSalesLibraryRepositoriesMustStayInCanonicalRepositoryPackage`: implementações JDBC concretas estavam no pacote canônico reservado a contratos/interfaces de persistência.
+- Movidas as implementações JDBC para subpacote de implementação, mantendo no pacote canônico apenas os gateways/interfaces esperados pela regra arquitetural.
+- Atualizado o teste unitário do repository de pricing para apontar para a nova localização da implementação sem alterar o contrato consumido pelos services.


### PR DESCRIPTION
### Motivation

- Enforce the architectural rule that repository contracts/interfaces remain in the canonical package while concrete JDBC implementations live in an implementation subpackage to avoid package-level contract violations.
- Keep code organization explicit so the `moisSalesLibraryRepositoriesMustStayInCanonicalRepositoryPackage` architectural check is respected.

### Description

- Moved concrete JDBC repository implementations into `com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1.jdbc` (renamed files include `MoisSalesLibraryPricingRepository`, `MoisSalesPageBackfillRepository`, and `MoisSalesPageMarketWarmupRepository`).
- Updated class imports to reference the gateway interfaces in the canonical package and added explicit model/DTO imports where needed (e.g. `MoisSalesLibraryPricingGateway` and several `MoisSalesPageMarketWarmupGateway` nested types).
- Updated the unit test import to use the relocated implementation class (`MoisSalesLibraryPricingRepository`) and adjusted code references accordingly.
- Documented the architectural change in `docs/registros/mois1.md` describing the package move and the rationale.

### Testing

- Ran the updated unit test `MoisSalesLibraryPricingRepositoryTest`, which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a31f6fd6bac8321994fb834466898fb)