### PR TITLE
Corrige camada dos DTOs da Biblioteca MOIS

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryDtos.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryDtos.java
@@ -1,4 +1,4 @@
-package com.marketinghub.mois.bibliotecapaginavenda.worker.v1.dto;
+package com.marketinghub.mois.bibliotecapaginavenda.worker.v1.service;
 
 import jakarta.validation.Valid;
 import jakarta.validation.constraints.NotBlank;

--- a/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryService.java
@@ -1,6 +1,6 @@
 package com.marketinghub.mois.bibliotecapaginavenda.worker.v1.service;
 
-import com.marketinghub.mois.bibliotecapaginavenda.worker.v1.dto.MoisSalesLibraryDtos;
+import com.marketinghub.mois.bibliotecapaginavenda.worker.v1.service.MoisSalesLibraryDtos;
 import java.math.BigDecimal;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;

--- a/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibrarySnapshotScheduler.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibrarySnapshotScheduler.java
@@ -1,6 +1,6 @@
 package com.marketinghub.mois.bibliotecapaginavenda.worker.v1.service;
 
-import com.marketinghub.mois.bibliotecapaginavenda.worker.v1.dto.MoisSalesLibraryDtos;
+import com.marketinghub.mois.bibliotecapaginavenda.worker.v1.service.MoisSalesLibraryDtos;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.scheduling.annotation.Scheduled;

--- a/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibrarySnapshotService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibrarySnapshotService.java
@@ -1,6 +1,6 @@
 package com.marketinghub.mois.bibliotecapaginavenda.worker.v1.service;
 
-import com.marketinghub.mois.bibliotecapaginavenda.worker.v1.dto.MoisSalesLibraryDtos;
+import com.marketinghub.mois.bibliotecapaginavenda.worker.v1.service.MoisSalesLibraryDtos;
 import java.awt.Color;
 import java.awt.Dimension;
 import java.awt.Graphics2D;

--- a/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesPageMarketWarmupScoreEngine.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesPageMarketWarmupScoreEngine.java
@@ -1,14 +1,14 @@
 package com.marketinghub.mois.bibliotecapaginavenda.worker.v1.service;
 
-import com.marketinghub.mois.bibliotecapaginavenda.worker.v1.dto.MoisSalesLibraryDtos.MarketWarmupCompleteRequest;
-import com.marketinghub.mois.bibliotecapaginavenda.worker.v1.dto.MoisSalesLibraryDtos.MarketWarmupEcosystemType;
-import com.marketinghub.mois.bibliotecapaginavenda.worker.v1.dto.MoisSalesLibraryDtos.MarketWarmupRecommendation;
-import com.marketinghub.mois.bibliotecapaginavenda.worker.v1.dto.MoisSalesLibraryDtos.MarketWarmupSignalCompleteItem;
-import com.marketinghub.mois.bibliotecapaginavenda.worker.v1.dto.MoisSalesLibraryDtos.MarketWarmupSignalType;
-import com.marketinghub.mois.bibliotecapaginavenda.worker.v1.dto.MoisSalesLibraryDtos.MarketWarmupSourceCompleteItem;
-import com.marketinghub.mois.bibliotecapaginavenda.worker.v1.dto.MoisSalesLibraryDtos.MarketWarmupSourceType;
-import com.marketinghub.mois.bibliotecapaginavenda.worker.v1.dto.MoisSalesLibraryDtos.MarketWarmupSummaryCompleteItem;
-import com.marketinghub.mois.bibliotecapaginavenda.worker.v1.dto.MoisSalesLibraryDtos.MarketWarmupTemperature;
+import com.marketinghub.mois.bibliotecapaginavenda.worker.v1.service.MoisSalesLibraryDtos.MarketWarmupCompleteRequest;
+import com.marketinghub.mois.bibliotecapaginavenda.worker.v1.service.MoisSalesLibraryDtos.MarketWarmupEcosystemType;
+import com.marketinghub.mois.bibliotecapaginavenda.worker.v1.service.MoisSalesLibraryDtos.MarketWarmupRecommendation;
+import com.marketinghub.mois.bibliotecapaginavenda.worker.v1.service.MoisSalesLibraryDtos.MarketWarmupSignalCompleteItem;
+import com.marketinghub.mois.bibliotecapaginavenda.worker.v1.service.MoisSalesLibraryDtos.MarketWarmupSignalType;
+import com.marketinghub.mois.bibliotecapaginavenda.worker.v1.service.MoisSalesLibraryDtos.MarketWarmupSourceCompleteItem;
+import com.marketinghub.mois.bibliotecapaginavenda.worker.v1.service.MoisSalesLibraryDtos.MarketWarmupSourceType;
+import com.marketinghub.mois.bibliotecapaginavenda.worker.v1.service.MoisSalesLibraryDtos.MarketWarmupSummaryCompleteItem;
+import com.marketinghub.mois.bibliotecapaginavenda.worker.v1.service.MoisSalesLibraryDtos.MarketWarmupTemperature;
 import java.math.BigDecimal;
 import java.math.RoundingMode;
 import java.util.Collection;

--- a/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesPageMarketWarmupService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesPageMarketWarmupService.java
@@ -1,6 +1,6 @@
 package com.marketinghub.mois.bibliotecapaginavenda.worker.v1.service;
 
-import com.marketinghub.mois.bibliotecapaginavenda.worker.v1.dto.MoisSalesLibraryDtos;
+import com.marketinghub.mois.bibliotecapaginavenda.worker.v1.service.MoisSalesLibraryDtos;
 import com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1.MoisSalesPageMarketWarmupGateway;
 import com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1.MoisSalesPageMarketWarmupGateway.MarketWarmupClaimData;
 import com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1.MoisSalesPageMarketWarmupGateway.MarketWarmupJobData;

--- a/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/web/MoisSalesLibraryController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/web/MoisSalesLibraryController.java
@@ -1,6 +1,6 @@
 package com.marketinghub.mois.bibliotecapaginavenda.worker.v1.web;
 
-import com.marketinghub.mois.bibliotecapaginavenda.worker.v1.dto.MoisSalesLibraryDtos;
+import com.marketinghub.mois.bibliotecapaginavenda.worker.v1.service.MoisSalesLibraryDtos;
 import com.marketinghub.mois.bibliotecapaginavenda.worker.v1.service.MoisSalesLibraryService;
 import com.marketinghub.mois.bibliotecapaginavenda.worker.v1.service.MoisSalesLibrarySnapshotService;
 import com.marketinghub.mois.bibliotecapaginavenda.worker.v1.service.MoisSalesPageMarketWarmupService;

--- a/backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryServiceTest.java
@@ -10,7 +10,7 @@ import static org.mockito.Mockito.lenient;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
 
-import com.marketinghub.mois.bibliotecapaginavenda.worker.v1.dto.MoisSalesLibraryDtos;
+import com.marketinghub.mois.bibliotecapaginavenda.worker.v1.service.MoisSalesLibraryDtos;
 import java.sql.ResultSet;
 import java.sql.Timestamp;
 import java.math.BigDecimal;

--- a/backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibrarySnapshotServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibrarySnapshotServiceTest.java
@@ -2,7 +2,7 @@ package com.marketinghub.mois.bibliotecapaginavenda.worker.v1.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.marketinghub.mois.bibliotecapaginavenda.worker.v1.dto.MoisSalesLibraryDtos;
+import com.marketinghub.mois.bibliotecapaginavenda.worker.v1.service.MoisSalesLibraryDtos;
 import com.sun.net.httpserver.HttpServer;
 import java.io.IOException;
 import java.net.InetSocketAddress;

--- a/backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesPageMarketWarmupServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesPageMarketWarmupServiceTest.java
@@ -6,7 +6,7 @@ import static org.mockito.BDDMockito.given;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 
-import com.marketinghub.mois.bibliotecapaginavenda.worker.v1.dto.MoisSalesLibraryDtos;
+import com.marketinghub.mois.bibliotecapaginavenda.worker.v1.service.MoisSalesLibraryDtos;
 import com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1.MoisSalesPageMarketWarmupGateway;
 import com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1.MoisSalesPageMarketWarmupGateway.MarketWarmupClaimData;
 import com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1.MoisSalesPageMarketWarmupGateway.MarketWarmupJobData;

--- a/backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/web/MoisSalesLibraryControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/web/MoisSalesLibraryControllerTest.java
@@ -10,7 +10,7 @@ import static org.springframework.test.web.servlet.request.MockMvcRequestBuilder
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
-import com.marketinghub.mois.bibliotecapaginavenda.worker.v1.dto.MoisSalesLibraryDtos;
+import com.marketinghub.mois.bibliotecapaginavenda.worker.v1.service.MoisSalesLibraryDtos;
 import com.marketinghub.mois.bibliotecapaginavenda.worker.v1.service.MoisSalesLibraryService;
 import com.marketinghub.mois.bibliotecapaginavenda.worker.v1.service.MoisSalesLibrarySnapshotService;
 import com.marketinghub.mois.bibliotecapaginavenda.worker.v1.service.MoisSalesPageMarketWarmupService;

--- a/docs/registros/mois1.md
+++ b/docs/registros/mois1.md
@@ -1670,3 +1670,9 @@ Arquivos principais:
 - Corrigida a causa-raiz da falha de arquitetura em `moisSalesLibraryRepositoriesMustStayInCanonicalRepositoryPackage`: implementações JDBC concretas estavam no pacote canônico reservado a contratos/interfaces de persistência.
 - Movidas as implementações JDBC para subpacote de implementação, mantendo no pacote canônico apenas os gateways/interfaces esperados pela regra arquitetural.
 - Atualizado o teste unitário do repository de pricing para apontar para a nova localização da implementação sem alterar o contrato consumido pelos services.
+
+## 2026-06-17 — Ajuste arquitetural dos DTOs da Biblioteca de Sales Pages
+
+- Corrigida a causa-raiz da falha de arquitetura `moisSalesLibraryWebShouldOnlyDependOnServiceLayer`: o controller dependia do pacote `.dto`, mas a regra do módulo MOIS permite que a camada web dependa apenas da camada `.service` do mesmo namespace/versão.
+- Movido o agrupador de contratos HTTP `MoisSalesLibraryDtos` para a camada `.service`, mantendo os contratos como `record` e evitando novo acoplamento direto da web com camada fora do padrão validado.
+- Atualizados imports em controller, services, scheduler e testes relacionados para preservar o contrato funcional sem alterar endpoints.


### PR DESCRIPTION
### Motivation
- Resolver falha do teste de arquitetura `moisSalesLibraryWebShouldOnlyDependOnServiceLayer` eliminando dependência do controller para o pacote `.dto` fora do layer permitido.
- Garantir que os contratos HTTP do módulo MOIS sejam expostos via camada `service` (mesmo namespace/versão) para manter isolamento arquitetural e evitar regressões futuras.

### Description
- Movido o agrupador de contratos `MoisSalesLibraryDtos` do pacote `.dto` para `com.marketinghub.mois.bibliotecapaginavenda.worker.v1.service` preservando todos os `record` existentes.
- Atualizados imports e referências em `MoisSalesLibraryController`, serviços (`MoisSalesLibraryService`, `MoisSalesLibrarySnapshotService`, `MoisSalesPageMarketWarmupService`, `MoisSalesPageMarketWarmupScoreEngine`), scheduler e testes correspondentes para referenciar o novo pacote sem alterar endpoints nem contratos HTTP.
- Atualizado registro operacional em `docs/registros/mois1.md` documentando a causa-raiz e a ação tomada para prevenção de recorrência.

### Testing
- Executado `../../backend/mvnw -Dtest=com.marketinghub.architecture.ArquiteturaTest test` e o teste de arquitetura passou com `Tests run: 59, Failures: 0, Errors: 0, Skipped: 0`.
- Executado o conjunto de testes do módulo MOIS (incluindo `MoisSalesLibraryControllerTest`, `MoisSalesLibraryServiceTest`, `MoisSalesLibrarySnapshotServiceTest`, `MoisSalesPageMarketWarmupServiceTest`) via Maven e todos os testes automatizados mencionados passaram com `Failures: 0`.
- Verificações estáticas finais `git diff --check` não retornaram problemas de formatação/merge.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a31fb3461fc8321be709d1a3709c958)