### PR TITLE
Exibe alcance Meta na aba de público

### DIFF
--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -4649,3 +4649,8 @@
 
 - Ajustada a regra canônica de publicação para usar lógica OU entre interesses, cargos e comportamentos antes da validação de alcance da Meta.
 - Melhorada a rastreabilidade de falhas de alcance para exibir ao usuário o motivo operacional quando a Meta estima público abaixo da faixa mínima.
+
+## 2026-06-17 — Exibição de público quantificado pela Meta
+
+- Ajustada a aba Público do experimento para destacar os elementos que já possuem alcance quantificado pela Meta.
+- A tela agora mostra os valores de alcance disponíveis ao lado de cada público e em um resumo específico, ajudando a escolher públicos com evidência objetiva antes da publicação.

--- a/frontend/src/pages/experiment/ExperimentAudienceTab.tsx
+++ b/frontend/src/pages/experiment/ExperimentAudienceTab.tsx
@@ -35,6 +35,32 @@ function isMetaUsable(element: TargetingElement) {
   return Boolean(element.metaId?.trim());
 }
 
+function formatAudienceSize(value: number) {
+  return new Intl.NumberFormat("pt-BR").format(value);
+}
+
+function formatMetaAudienceRange(element: TargetingElement) {
+  const lower = element.metaAudienceSizeLowerBound;
+  const upper = element.metaAudienceSizeUpperBound;
+
+  if (typeof lower === "number" && typeof upper === "number") {
+    if (lower === upper) {
+      return `${formatAudienceSize(lower)} pessoas`;
+    }
+    return `${formatAudienceSize(lower)} a ${formatAudienceSize(upper)} pessoas`;
+  }
+
+  if (typeof lower === "number") {
+    return `a partir de ${formatAudienceSize(lower)} pessoas`;
+  }
+
+  if (typeof upper === "number") {
+    return `até ${formatAudienceSize(upper)} pessoas`;
+  }
+
+  return null;
+}
+
 export function ExperimentAudienceTab({
   experimentId,
   nicheId,
@@ -75,6 +101,11 @@ export function ExperimentAudienceTab({
     });
     setSelected(next);
   }, [savedSelections, availableOptions]);
+
+  const quantifiedMetaOptions = useMemo(
+    () => availableOptions.filter((item) => formatMetaAudienceRange(item)),
+    [availableOptions],
+  );
 
   const grouped = useMemo(() => {
     return {
@@ -155,6 +186,23 @@ export function ExperimentAudienceTab({
               salvar o público.
             </div>
           ) : null}
+          {quantifiedMetaOptions.length > 0 ? (
+            <div className="alert alert-success mt-3 mb-0 small" role="status">
+              <div className="fw-semibold mb-2">
+                Públicos com alcance quantificado pela Meta
+              </div>
+              <div className="d-flex flex-wrap gap-2">
+                {quantifiedMetaOptions.map((item) => (
+                  <span
+                    className="badge text-bg-light border"
+                    key={buildKey(item)}
+                  >
+                    {item.term}: {formatMetaAudienceRange(item)}
+                  </span>
+                ))}
+              </div>
+            </div>
+          ) : null}
         </div>
 
         {isLoading ? (
@@ -203,6 +251,11 @@ export function ExperimentAudienceTab({
                             {metaUsable && item.metaKey ? (
                               <span className="text-muted small ms-2">
                                 {item.metaKey}
+                              </span>
+                            ) : null}
+                            {formatMetaAudienceRange(item) ? (
+                              <span className="badge text-bg-light border ms-2">
+                                Meta: {formatMetaAudienceRange(item)}
                               </span>
                             ) : null}
                           </label>


### PR DESCRIPTION
### Motivation

- Facilitar a escolha de públicos no experimento exibindo claramente quais elementos já têm alcance quantificado pela Meta.
- Ajudar a priorizar públicos com evidência objetiva de tamanho antes de publicar campanhas na Meta.

### Description

- Adiciona as funções `formatAudienceSize` e `formatMetaAudienceRange` e calcula `quantifiedMetaOptions` para identificar elementos com alcance retornado pela Meta in `frontend/src/pages/experiment/ExperimentAudienceTab.tsx`.
- Exibe um resumo `Públicos com alcance quantificado pela Meta` com badges contendo os valores formatados em `pt-BR` e adiciona um badge `Meta: ... pessoas` ao lado de cada item quando disponível. 
- Mantém a lógica anterior de bloqueio/validação (itens sem `metaId` continuam sinalizados e impedem salvar) sem alterar contratos de backend. 
- Registra a mudança operacional em `docs/registros/experimentos.md` para rastreabilidade e histórico de decisões.

### Testing

- Executado `npm ci` na pasta `frontend` para instalar dependências e a execução foi bem-sucedida. 
- Rodado `npx prettier --check src/pages/experiment/ExperimentAudienceTab.tsx` e `npx prettier --write` para ajustar formatação; a verificação final passou com sucesso. 
- Rodado `npm run typecheck` (`tsc --noEmit`) e a verificação de tipos passou após a instalação das dependências. 
- Rodado `npm run build` (Vite) e o build de produção foi concluído com sucesso.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a32006412d08321a7f9806b13a2ba40)