### PR TITLE
Exibe jobId no diagnóstico de falha do experimento

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/dto/ExperimentFailureDetailsDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/dto/ExperimentFailureDetailsDto.java
@@ -2,11 +2,15 @@ package com.marketinghub.experiment.dto;
 
 import java.time.Instant;
 
+/**
+ * Representa os detalhes operacionais da última falha visível no diagnóstico do experimento.
+ */
 public record ExperimentFailureDetailsDto(
         String message,
         String endpoint,
         Integer statusCode,
         Instant occurredAt,
-        String source
+        String source,
+        String jobId
 ) {
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentDiagnosticsService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentDiagnosticsService.java
@@ -133,7 +133,8 @@ public class ExperimentDiagnosticsService {
                 step.getEndpoint(),
                 step.getStatusCode(),
                 step.getOccurredAt(),
-                StringUtils.hasText(step.getProvider()) ? step.getProvider() : "PUBLICATION_JOB_STEP"
+                StringUtils.hasText(step.getProvider()) ? step.getProvider() : "PUBLICATION_JOB_STEP",
+                step.getJobId()
         );
     }
 
@@ -149,7 +150,8 @@ public class ExperimentDiagnosticsService {
                         log.endpoint(),
                         log.statusCode(),
                         resolveOccurrence(log),
-                        resolveFailureSource(log)
+                        resolveFailureSource(log),
+                        log.jobId() == null ? null : log.jobId().toString()
                 ))
                 .orElse(null);
     }

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/service/ExperimentDiagnosticsServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/service/ExperimentDiagnosticsServiceTest.java
@@ -142,6 +142,7 @@ class ExperimentDiagnosticsServiceTest {
         FacebookCampaignPublicationJobStep step = new FacebookCampaignPublicationJobStep();
         step.setErrorMessage("Público pequeno demais para publicar: a Meta estimou 1.000 a 1.000 pessoas.");
         step.setProvider("FACEBOOK_WORKER");
+        step.setJobId("fbpub-39-20260617005448");
         step.setStepName("CAMPAIGN_REACH_VALIDATION_BLOCKED");
         step.setOccurredAt(Instant.parse("2026-06-17T00:54:48Z"));
 
@@ -155,6 +156,7 @@ class ExperimentDiagnosticsServiceTest {
         assertThat(diagnostics.failureDetails()).isNotNull();
         assertThat(diagnostics.failureDetails().message()).contains("Público pequeno demais");
         assertThat(diagnostics.failureDetails().source()).isEqualTo("FACEBOOK_WORKER");
+        assertThat(diagnostics.failureDetails().jobId()).isEqualTo("fbpub-39-20260617005448");
         assertThat(diagnostics.failureDetails().occurredAt()).isEqualTo(Instant.parse("2026-06-17T00:54:48Z"));
     }
 

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -4655,3 +4655,8 @@
 
 - Ajustada a aba Público do experimento para destacar os elementos que já possuem alcance quantificado pela Meta.
 - A tela agora mostra os valores de alcance disponíveis ao lado de cada público e em um resumo específico, ajudando a escolher públicos com evidência objetiva antes da publicação.
+
+## 2026-06-17 — Job ID no diagnóstico de falha de publicação
+
+- Ajustado o diagnóstico de falha do experimento para exibir o `jobId` do passo de publicação que originou o erro.
+- Objetivo operacional: permitir consultar diretamente a tabela `facebook_campaign_publication_job_step` e acelerar a investigação da causa-raiz no fluxo de publicação Facebook Ads.

--- a/frontend/src/api/experiment/useExperimentDiagnostics.ts
+++ b/frontend/src/api/experiment/useExperimentDiagnostics.ts
@@ -23,6 +23,7 @@ export interface ExperimentDiagnostics {
     statusCode: number | null;
     occurredAt: string | null;
     source: string | null;
+    jobId: string | null;
   } | null;
 }
 

--- a/frontend/src/pages/experiment/ExperimentDetailPage.tsx
+++ b/frontend/src/pages/experiment/ExperimentDetailPage.tsx
@@ -2193,6 +2193,14 @@ export default function ExperimentDetailPage() {
                       {diagnostics.failureDetails.source ?? "—"}
                     </li>
                     <li>
+                      <strong>Job ID:</strong>{" "}
+                      {diagnostics.failureDetails.jobId ? (
+                        <code>{diagnostics.failureDetails.jobId}</code>
+                      ) : (
+                        "—"
+                      )}
+                    </li>
+                    <li>
                       <strong>Horário do erro:</strong>{" "}
                       {diagnostics.failureDetails.occurredAt
                         ? formatDateTimeValue(


### PR DESCRIPTION
### Motivation
- Quando ocorrer erro na publicação para Meta/Facebook, é necessário expor o `jobId` na interface para permitir investigação direta na tabela `facebook_campaign_publication_job_step` e acelerar a causa-raiz.

### Description
- Adiciona o campo `jobId` ao DTO de falha `ExperimentFailureDetailsDto` para transportar o identificador do job de publicação.\n
- Preenche `jobId` a partir do registro de passos de publicação (`FacebookCampaignPublicationJobStep.jobId`) ou a partir do log da integração Meta (`ExperimentFacebookApiLogDto.jobId`) quando disponível, no serviço `ExperimentDiagnosticsService`.\n
- Atualiza o tipo TypeScript em `frontend/src/api/experiment/useExperimentDiagnostics.ts` e altera a tela em `frontend/src/pages/experiment/ExperimentDetailPage.tsx` para exibir o `Job ID` no bloco “Último erro retornado pelo worker / Meta Ads”.\n
- Ajusta o teste unitário `ExperimentDiagnosticsServiceTest` para verificar que `jobId` é apresentado quando o passo de publicação contém erro.\n
- Registra a alteração no histórico operacional em `docs/registros/experimentos.md`.

### Testing
- Executado `../mvnw -Dtest=ExperimentDiagnosticsServiceTest test` no módulo `ads-service`, onde a suíte `ExperimentDiagnosticsServiceTest` rodou com sucesso (4 tests, 0 failures).\n
- Executado `npm run typecheck` no `frontend`, que não concluiu no ambiente de CI local por falta de dependências (`node_modules` ausente) e tipos (`@testing-library/jest-dom`, `vite/client`, `vitest/globals`), portanto o tipo-check do frontend não pôde ser validado aqui.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a32078fbdbc8321b5a60c90d661ac66)