### PR TITLE
Report `budgetMode=ADSET` and set `is_adset_budget_sharing_enabled=false` for experiment campaigns

### DIFF
--- a/docs/canonical/facebook-campaign-publication-canon.v1.md
+++ b/docs/canonical/facebook-campaign-publication-canon.v1.md
@@ -15,6 +15,7 @@
 > - adiciona validação obrigatória de alcance por `reachestimate` antes de criar a hierarquia da campanha na Meta
 > - ajusta a regra de negócio para tratar ausência de limites da Meta como alerta controlado, não como falha automática
 > - formaliza a coleta periódica de sugestões oficiais da Meta para campanhas ativas, com persistência exclusiva via backend
+- formaliza que campanhas de experimento usam orçamento diário no nível do ad set (`budgetMode=ADSET`) e que orçamento de campanha é reservado para etapa futura de escala
 
 Este documento complementa o `system-governance-canon.v2.md` e passa a ser a fonte de verdade para prontidão, liberação e telemetria de campanhas de experimento no Facebook Ads Worker.
 
@@ -128,7 +129,7 @@ O cartão também lista itens operacionais que não travam o worker, mas devem s
 
 - **Conta do Facebook Ads conectada** – exposta pelo hook `useFacebookConfigurationStatus` e validada no backend.
 - **Página do Facebook** e **Conta do Instagram** – precisam existir no hub e permanecer válidas para evitar erros de publicação.
-- **Orçamento diário** – `experiment.daily_budget` deve estar preenchido para refletir a automação de mídia.
+- **Orçamento diário** – `experiment.daily_budget` deve estar preenchido para refletir a automação de mídia. Em campanhas de experimento, esse valor é orçamento controlado por ad set: o `facebook-ads-worker` deve reportar `budgetMode=ADSET`, enviar `daily_budget` no conjunto de anúncios e criar a campanha sem orçamento próprio com `is_adset_budget_sharing_enabled=false`. Orçamento no nível da campanha é reservado para uma etapa futura de escala de vencedores, não para a validação inicial.
 - **Formulário de captação** – quando existir link válido de formulário no fluxo do experimento, ele é tratado como publicado para operação do Marketing Hub.
 - **Importante**: o formulário usado neste checklist é o formulário interno publicado pelo **Gera Landing** no Marketing Hub, **não** o Instant Form nativo do Facebook Ads.
 

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -1,3 +1,31 @@
+## 2026-06-17 — Alinhamento da estratégia de orçamento Facebook Ads por Ad Set
+
+- solicitação: ajustar o fluxo conforme a conclusão estratégica de marketing digital para campanhas do Marketing Hub.
+- causa-raiz: o sistema já operava orçamento real no Ad Set, mas reportava `budgetMode=CAMPAIGN`, criando divergência entre estratégia de validação e registro operacional.
+- foi feito: o Facebook Ads Worker passou a reportar `budgetMode=ADSET`, preservando `dailyBudget` no conjunto de anúncios e mantendo campanha sem orçamento próprio com `is_adset_budget_sharing_enabled=false`.
+- decisão canônica: experimentos usam orçamento por Ad Set para comparação controlada; orçamento de campanha fica reservado para etapa futura de escala de vencedores.
+- validação: teste de publicação de hierarquia de campanha passou a verificar `budgetMode=ADSET` e o orçamento diário no Ad Set.
+- arquivos alterados:
+  - facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java
+  - facebook-ads-worker/src/test/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignServiceTest.java
+  - facebook-ads-worker/README.md
+  - facebook-ads-worker/AGENTS.md
+  - docs/canonical/facebook-campaign-publication-canon.v1.md
+  - docs/registros/experimentos.md
+
+## 2026-06-17 — Correção de criação de campanha Meta Ads sem orçamento de campanha
+
+- solicitação: investigar novo erro 400 ao liberar o experimento 39 para o Facebook Ads Worker.
+- causa-raiz: a Graph API passou a exigir o campo `is_adset_budget_sharing_enabled` em campanhas sem orçamento no nível da campanha; o worker criava a campanha apenas com orçamento posterior no ad set.
+- foi feito: o payload de criação de campanha agora declara `is_adset_budget_sharing_enabled=false`, preservando o orçamento no conjunto de anúncios e removendo o bloqueio antes da criação dos ad sets.
+- validação: testes unitários do Facebook Ads Worker atualizados para garantir o envio do campo nas campanhas de tráfego e leads.
+- arquivos alterados:
+  - facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/FacebookAdsService.java
+  - facebook-ads-worker/src/test/java/com/marketinghub/facebookadsworker/FacebookAdsServiceTest.java
+  - facebook-ads-worker/README.md
+  - facebook-ads-worker/AGENTS.md
+  - docs/registros/experimentos.md
+
 ## 2026-06-16 — Bloqueio de geração automática de imagem de anúncio após AD_IMAGE_BRIEFING
 
 - solicitação: impedir que o sistema gere imagem de anúncio automaticamente ao concluir a etapa `AD_IMAGE_BRIEFING`.

--- a/facebook-ads-worker/AGENTS.md
+++ b/facebook-ads-worker/AGENTS.md
@@ -45,6 +45,7 @@
   foi removido da publicação canônica e não deve ser reintroduzido.
 - Na criação de campanhas, não delegue materialização de targeting ao `ai-worker`; o `facebook-ads-worker` monta o targeting
   da Meta localmente a partir do playbook ou do pacote manual aprovado.
+- Campanhas de experimento devem registrar `budgetMode=ADSET`, enviar o orçamento diário apenas no ad set e criar a campanha sem orçamento próprio com `is_adset_budget_sharing_enabled=false`; orçamento de campanha fica reservado para etapa futura de escala de vencedores.
 - Em caso de erro de permissão do Facebook, o worker bloqueia o experimento em memória até que o serviço seja reiniciado.
 - Ao publicar instant forms aprove os rascunhos com `facebookFormId` nulo e reporte o identificador definitivo recebido da Meta
   através de `PATCH /api/instant-forms/{id}/publication`. A criação automática foi descontinuada; os formulários devem ser

--- a/facebook-ads-worker/README.md
+++ b/facebook-ads-worker/README.md
@@ -475,6 +475,18 @@ em memória e ignora execuções seguintes até que o serviço seja reiniciado. 
 ajustar as permissões, atualize manualmente o status do experimento para que ele
 volte a ser elegível e reinicie o worker para que o novo token seja utilizado.
 
+
+### Estratégia de orçamento para campanhas de experimento
+
+Campanhas de experimento usam orçamento diário no nível do ad set (`budgetMode=ADSET`)
+para preservar comparação controlada entre públicos, criativos e ofertas. A
+campanha é criada sem orçamento próprio e o worker envia
+`is_adset_budget_sharing_enabled=false` em `POST /{ad_account_id}/campaigns`,
+mantendo o controle de gasto no conjunto de anúncios e evitando falha `(#100)
+Invalid parameter` antes da criação dos ad sets. Orçamento no nível da campanha
+deve ser reservado para uma etapa futura de escala, depois que o experimento
+identificar vencedor comercial.
+
 ### Erro `(#100) Invalid parameter` ao criar o criativo
 
 O endpoint [`POST /{ad_account_id}/adcreatives`](https://developers.facebook.com/docs/marketing-api/reference/ad-creative#Creating)

--- a/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/FacebookAdsService.java
+++ b/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/FacebookAdsService.java
@@ -163,29 +163,41 @@ public class FacebookAdsService {
         );
     }
 
+    /**
+     * Cria uma campanha pausada de Instagram usando objetivo de tráfego quando nenhum objetivo específico é informado.
+     */
     public String createInstagramCampaign(String adAccountId, String name) {
         return createInstagramCampaign(adAccountId, name, "OUTCOME_TRAFFIC");
     }
 
+    /**
+     * Cria uma campanha pausada na Meta sem orçamento de campanha, declarando explicitamente o compartilhamento de orçamento dos ad sets.
+     */
     public String createInstagramCampaign(String adAccountId, String name, String objective) {
         String path = buildVersionedPath("/act_" + adAccountId + "/campaigns");
         String resolvedObjective = hasText(objective) ? objective : "OUTCOME_TRAFFIC";
-        Map<String, Object> body = Map.of(
-            "name", name,
-            "objective", resolvedObjective,
-            "status", "PAUSED",
-            "special_ad_categories", List.of(),
-            "access_token", requireAccessToken()
-        );
+        Map<String, Object> body = new HashMap<>();
+        body.put("name", name);
+        body.put("objective", resolvedObjective);
+        body.put("status", "PAUSED");
+        body.put("special_ad_categories", List.of());
+        body.put("is_adset_budget_sharing_enabled", false);
+        body.put("access_token", requireAccessToken());
 
         JsonNode response = executePost(path, body);
         return response.path("id").asText();
     }
 
+    /**
+     * Cria uma campanha Meta com objetivo de tráfego quando nenhum objetivo específico é informado.
+     */
     public String createCampaign(String adAccountId, String name) {
         return createCampaign(adAccountId, name, "OUTCOME_TRAFFIC");
     }
 
+    /**
+     * Cria uma campanha Meta reaproveitando o fluxo de campanha de Instagram do worker.
+     */
     public String createCampaign(String adAccountId, String name, String objective) {
         return createInstagramCampaign(adAccountId, name, objective);
     }

--- a/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java
+++ b/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignService.java
@@ -252,7 +252,7 @@ public class FacebookCampaignService {
     }
 
     /**
-     * Publishes one released experiment to Facebook Ads using the best available targeting source.
+     * Publica um experimento liberado no Facebook Ads usando orçamento no ad set para validação controlada e a melhor fonte de targeting disponível.
      */
     private void processExperiment(Experiment exp, FacebookWorkerConfiguration config) {
         String campaignId = null;
@@ -495,7 +495,7 @@ public class FacebookCampaignService {
                 exp.name(),
                 resolvedCampaignObjective,
                 "ACTIVE",
-                "CAMPAIGN",
+                "ADSET",
                 exp.id(),
                 config.accountId(),
                 new CreateCampaignRequest.AdSet(

--- a/facebook-ads-worker/src/test/java/com/marketinghub/facebookadsworker/FacebookAdsServiceTest.java
+++ b/facebook-ads-worker/src/test/java/com/marketinghub/facebookadsworker/FacebookAdsServiceTest.java
@@ -70,6 +70,7 @@ class FacebookAdsServiceTest {
         assertEquals("OUTCOME_TRAFFIC", body.get("objective").asText());
         assertEquals("PAUSED", body.get("status").asText());
         assertEquals(0, body.get("special_ad_categories").size());
+        assertFalse(body.get("is_adset_budget_sharing_enabled").asBoolean());
         assertEquals("123", id);
     }
 
@@ -83,6 +84,7 @@ class FacebookAdsServiceTest {
         JsonNode body = objectMapper.readTree(request.getBody().inputStream());
         assertEquals("Camp", body.get("name").asText());
         assertEquals("OUTCOME_LEADS", body.get("objective").asText());
+        assertFalse(body.get("is_adset_budget_sharing_enabled").asBoolean());
         assertEquals("456", id);
     }
 

--- a/facebook-ads-worker/src/test/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignServiceTest.java
+++ b/facebook-ads-worker/src/test/java/com/marketinghub/facebookadsworker/facebookcampaign/FacebookCampaignServiceTest.java
@@ -399,6 +399,8 @@ class FacebookCampaignServiceTest {
         );
         JsonNode backendPayload = objectMapper.readTree(postBackend.getBody().inputStream());
         assertEquals("ACTIVE", backendPayload.get("status").asText());
+        assertEquals("ADSET", backendPayload.get("budgetMode").asText());
+        assertEquals("2500", backendPayload.get("adSet").get("dailyBudget").asText());
         assertTrue(backend.getRequestCount() >= 4);
     }
 


### PR DESCRIPTION
### Motivation

- Align the publication flow with the marketing decision to control daily budget at the ad set level for experiments and reserve campaign-level budget for later scaling.
- Fix Graph API 400 errors caused by omitting the `is_adset_budget_sharing_enabled` flag when creating campaigns without a campaign-level budget.
- Keep documentation, operational guidance and worker behavior consistent so the backend, worker and operators share the same canonical contract for experiment publication.

### Description

- The campaign creation payload now includes `is_adset_budget_sharing_enabled=false` in `FacebookAdsService.createInstagramCampaign` and `createCampaign` to create campaigns without campaign-level budget and explicitly declare ad set budget sharing behavior.
- The worker reports `budgetMode` as `ADSET` and moves the daily budget into the reported ad set payload when calling the backend in `FacebookCampaignService`. The creation flow continues to place spending control at the ad set level for experiments.
- Updated documentation and operational files: `docs/canonical/facebook-campaign-publication-canon.v1.md`, `docs/registros/experimentos.md`, `facebook-ads-worker/AGENTS.md`, and `facebook-ads-worker/README.md` to reflect the new budget strategy and the Graph API requirement.
- Tests and helpers were adjusted to validate the new fields and reporting: `facebook-ads-worker/src/test/java/.../FacebookAdsServiceTest.java` and `facebook-ads-worker/src/test/java/.../facebookcampaign/FacebookCampaignServiceTest.java` were updated accordingly.

### Testing

- Ran unit tests under the `facebook-ads-worker` module including `FacebookAdsServiceTest` and `FacebookCampaignServiceTest`, which assert the `is_adset_budget_sharing_enabled` flag on campaign creation and `budgetMode=ADSET` + ad set `dailyBudget` in backend reporting; all updated tests passed.
- Verified mock server request assertions for campaign and ad set creation to ensure the outgoing Facebook payload and backend reporting match the new contract; checks succeeded.
- No integration test failures were observed in the updated test suite after these changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3206b5a68883219be1eae64db8c342)