### PR TITLE
Aplica protocolo padrão backend no OPRM NichoCNAE

### DIFF
--- a/backend/ads-service/src/test/java/com/marketinghub/architecture/ArquiteturaTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/architecture/ArquiteturaTest.java
@@ -97,6 +97,11 @@ class ArquiteturaTest {
     private static final Pattern FACEBOOK_ADS_STAGE_SERVICE_PACKAGE_PATTERN =
             Pattern.compile("^com\\.marketinghub\\.facebookads\\.stage\\.([a-zA-Z0-9_]+)\\.service$");
     private static final String FACEBOOK_ADS_STAGE_PACKAGE_PREFIX = "com.marketinghub.facebookads.stage.";
+    private static final Pattern OPRM_NICHO_CNAE_STAGE_CONTROLLER_PACKAGE_PATTERN = Pattern.compile(
+            "^com\\.marketinghub\\.oprm\\.nichocnae\\.([a-zA-Z0-9_]+)\\.(web|controller)$");
+    private static final Pattern OPRM_NICHO_CNAE_STAGE_SERVICE_PACKAGE_PATTERN = Pattern.compile(
+            "^com\\.marketinghub\\.oprm\\.nichocnae\\.([a-zA-Z0-9_]+)\\.service$");
+    private static final String OPRM_NICHO_CNAE_STAGE_PACKAGE_PREFIX = "com.marketinghub.oprm.nichocnae.";
     private static final List<String> REQUIRED_BACKEND_SERVICE_SUBPACKAGES = List.of(
             "detailStageExecution", "listStageExecutions", "pending", "recebePrompt", "recebeResposta");
     private static final List<String> REQUIRED_EPM_SERVICE_SUBPACKAGES = List.of(
@@ -523,6 +528,76 @@ class ArquiteturaTest {
                                             + " está no subpacote obrigatório " + requiredSubpackage
                                             + " e deve ser declarada como record"));
                 }));
+        failWithArchitectureViolations(violations);
+    }
+
+    /**
+     * Garante que cada etapa do OPRM nicho CNAE tenha um único controller canônico anotado.
+     */
+    @ArchTest
+    static void oprmNichoCnaeStageControllerPackagesMustHaveSingleCanonicalController(JavaClasses importedClasses) {
+        List<String> violations = new ArrayList<>();
+        oprmNichoCnaeStageControllerPackages(importedClasses).forEach((packageName, packageClasses) -> {
+            List<JavaClass> controllers = packageClasses.stream()
+                    .filter(ArquiteturaTest::isBackendControllerClass)
+                    .toList();
+            if (packageClasses.size() != 1) {
+                violations.add("[ARQUITETURA] [BACKEND][OPRM][NichoCNAE] pacote=" + packageName
+                        + " deve conter apenas uma classe Backend<Etapa>Controller; classes="
+                        + simpleNames(packageClasses));
+            }
+            if (controllers.size() != 1) {
+                violations.add("[ARQUITETURA] [BACKEND][OPRM][NichoCNAE] pacote=" + packageName
+                        + " deve conter exatamente uma classe canônica Backend<Etapa>Controller; controllers="
+                        + simpleNames(controllers));
+                return;
+            }
+            JavaClass controller = controllers.get(0);
+            if (!controller.isAnnotatedWith(RestController.class)) {
+                violations.add("[ARQUITETURA] [BACKEND][OPRM][NichoCNAE] classe=" + controller.getName()
+                        + " deve possuir @RestController");
+            }
+        });
+        failWithArchitectureViolations(violations);
+    }
+
+    /**
+     * Garante que cada etapa do OPRM nicho CNAE tenha um service backend canônico anotado.
+     */
+    @ArchTest
+    static void oprmNichoCnaeStageServicePackagesMustHaveCanonicalBackendService(JavaClasses importedClasses) {
+        List<String> violations = new ArrayList<>();
+        oprmNichoCnaeStageServicePackages(importedClasses).forEach((packageName, packageClasses) -> {
+            List<JavaClass> services = packageClasses.stream()
+                    .filter(ArquiteturaTest::isCanonicalOprmNichoCnaeBackendServiceClass)
+                    .toList();
+            if (services.size() != 1) {
+                violations.add("[ARQUITETURA] [BACKEND][OPRM][NichoCNAE] pacote=" + packageName
+                        + " deve conter exatamente uma classe canônica Backend<Etapa>Service; services="
+                        + simpleNames(services));
+                return;
+            }
+            if (!services.get(0).isAnnotatedWith(Service.class)) {
+                violations.add("[ARQUITETURA] [BACKEND][OPRM][NichoCNAE] classe=" + services.get(0).getName()
+                        + " deve possuir @Service");
+            }
+        });
+        failWithArchitectureViolations(violations);
+    }
+
+    /**
+     * Garante que contratos de etapas OPRM nicho CNAE em subpacotes de service sejam records.
+     */
+    @ArchTest
+    static void oprmNichoCnaeStageServiceSubpackagesMustContainOnlyRecords(JavaClasses importedClasses) {
+        List<String> violations = new ArrayList<>();
+        importedClasses.stream()
+                .filter(ArquiteturaTest::isProductionTopLevelClass)
+                .filter(ArquiteturaTest::isOprmNichoCnaeStageServiceSubpackageClass)
+                .filter(candidate -> !candidate.reflect().isRecord())
+                .forEach(candidate -> violations.add("[ARQUITETURA] [BACKEND][OPRM][NichoCNAE] classe="
+                        + candidate.getName()
+                        + " está em subpacote de service de etapa OPRM nicho CNAE e deve ser declarada como record"));
         failWithArchitectureViolations(violations);
     }
 
@@ -981,6 +1056,60 @@ class ArquiteturaTest {
                         .computeIfAbsent(javaClass.getPackageName(), ignored -> new ArrayList<>())
                         .add(javaClass));
         return packages;
+    }
+
+    /**
+     * Agrupa classes diretas de controller/web das etapas OPRM nicho CNAE.
+     */
+    private static Map<String, List<JavaClass>> oprmNichoCnaeStageControllerPackages(JavaClasses importedClasses) {
+        Map<String, List<JavaClass>> packages = new LinkedHashMap<>();
+        importedClasses.stream()
+                .filter(ArquiteturaTest::isProductionTopLevelClass)
+                .filter(javaClass -> OPRM_NICHO_CNAE_STAGE_CONTROLLER_PACKAGE_PATTERN
+                        .matcher(javaClass.getPackageName())
+                        .matches())
+                .sorted(Comparator.comparing(JavaClass::getName))
+                .forEach(javaClass -> packages
+                        .computeIfAbsent(javaClass.getPackageName(), ignored -> new ArrayList<>())
+                        .add(javaClass));
+        return packages;
+    }
+
+    /**
+     * Agrupa classes diretas de service das etapas OPRM nicho CNAE.
+     */
+    private static Map<String, List<JavaClass>> oprmNichoCnaeStageServicePackages(JavaClasses importedClasses) {
+        Map<String, List<JavaClass>> packages = new LinkedHashMap<>();
+        importedClasses.stream()
+                .filter(ArquiteturaTest::isProductionTopLevelClass)
+                .filter(javaClass -> OPRM_NICHO_CNAE_STAGE_SERVICE_PACKAGE_PATTERN
+                        .matcher(javaClass.getPackageName())
+                        .matches())
+                .sorted(Comparator.comparing(JavaClass::getName))
+                .forEach(javaClass -> packages
+                        .computeIfAbsent(javaClass.getPackageName(), ignored -> new ArrayList<>())
+                        .add(javaClass));
+        return packages;
+    }
+
+    /**
+     * Verifica se a classe é service backend canônico da etapa OPRM nicho CNAE.
+     */
+    private static boolean isCanonicalOprmNichoCnaeBackendServiceClass(JavaClass javaClass) {
+        return isBackendServiceClass(javaClass) && !javaClass.getSimpleName().contains("StallGuard");
+    }
+
+    /**
+     * Verifica se a classe está em subpacote de service de etapa OPRM nicho CNAE.
+     */
+    private static boolean isOprmNichoCnaeStageServiceSubpackageClass(JavaClass javaClass) {
+        String packageName = javaClass.getPackageName();
+        if (!packageName.startsWith(OPRM_NICHO_CNAE_STAGE_PACKAGE_PREFIX)) {
+            return false;
+        }
+        String remainder = packageName.substring(OPRM_NICHO_CNAE_STAGE_PACKAGE_PREFIX.length());
+        String[] parts = remainder.split("\\.");
+        return parts.length >= 3 && "service".equals(parts[1]);
     }
 
     /**

--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -773,3 +773,9 @@
 - Causa-raiz tratada: o materializador enriquecido do OPRM dependia diretamente de `com.marketinghub.finance.CurrencyConversionService`, quebrando a regra ArchUnit de isolamento do módulo OPRM.
 - Correção aplicada: criado conversor próprio dentro do pacote OPRM para custos de identificação, preservando a mesma configuração `app.currency.usd-to-brl` e o mesmo arredondamento financeiro sem acoplar o materializador ao pacote financeiro.
 - Prevenção de recorrência: a suíte ArchUnit foi executada junto com o teste do materializador para garantir que o OPRM permaneça dependente apenas dos pacotes autorizados.
+
+## 2026-06-17 — OPRM NichoCNAE: protocolo padrão backend
+
+- Aplicado o protocolo padrão backend no pacote `com.marketinghub.oprm.nichocnae` por meio de regras ArchUnit específicas para as etapas do NichoCNAE.
+- Causa-raiz tratada: o pacote já possuía várias etapas operacionais, mas não havia uma trava arquitetural dedicada garantindo controller canônico, service backend canônico e contratos imutáveis em subpacotes de service.
+- Prevenção de recorrência: a suíte de arquitetura agora valida que cada etapa tenha um único `Backend<Etapa>Controller`, um service backend canônico e DTOs/contratos como `record`, reduzindo risco de espalhamento de contratos e endpoints no fluxo que qualifica nichos para vendas.


### PR DESCRIPTION
### Motivation
- Garantir isolamento arquitetural e consistência do padrão backend no pacote `com.marketinghub.oprm.nichocnae` para evitar espalhamento de controllers, services e contratos por etapa.
- Forçar convenções canônicas (um `Backend<Etapa>Controller` por etapa, um service backend canônico e DTOs como `record`) para reduzir risco de endpoints/contratos duplicados e facilitar auditoria.

### Description
- Adicionadas regras ArchUnit ao arquivo `backend/ads-service/src/test/java/com/marketinghub/architecture/ArquiteturaTest.java` para detectar pacotes de etapa do OPRM NichoCNAE (`OPRM_NICHO_CNAE_STAGE_*`), exigindo controller único canônico e service backend canônico por etapa.
- Incluídos helpers para agrupar pacotes de controller/service do NichoCNAE, utilitários `isCanonicalOprmNichoCnaeBackendServiceClass` e validação que subpacotes de `service` contenham apenas `record` para contratos.
- Atualizado o documento operacional `docs/registros/oprm1.md` com registro da aplicação do protocolo padrão backend e notas de causa-raiz e prevenção de recorrência.

### Testing
- Executado `./backend/mvnw -f backend/ads-service/pom.xml -Dtest=ArquiteturaTest test` e a suíte `ArquiteturaTest` passou com sucesso (62 tests, 0 failures).
- Verificações estáticas/diff (`git diff --check`) não reportaram problemas e a alteração de cobertura ArchUnit não introduziu falhas nos testes existentes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3211ab6e3c8321aaa92be0f658052a)