### PR TITLE
Add endpoint and DTOs to list pending sales pages eligible for analysis (GET /pending)

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryDtos.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryDtos.java
@@ -36,6 +36,36 @@ public final class MoisSalesLibraryDtos {
     ) {
     }
 
+    /**
+     * Representa uma página já capturada e elegível para análise comercial sem reservar o job.
+     */
+    public record SalesLibraryPendingAnalysisItem(
+            Long jobId,
+            long pageId,
+            String workspaceId,
+            String source,
+            String urlCanonical,
+            String title,
+            long htmlBytes,
+            String analysisStatus,
+            int nextAttempt,
+            Instant lastCapturedAt,
+            boolean rawHtmlAvailable
+    ) {
+    }
+
+    /**
+     * Lista páginas que podem ser processadas pela etapa 2 de análise comercial.
+     */
+    public record SalesLibraryPendingAnalysisResponse(
+            String workspaceId,
+            String source,
+            int limit,
+            int totalReturned,
+            List<SalesLibraryPendingAnalysisItem> items
+    ) {
+    }
+
     public record SalesLibraryCompleteRequest(
             BigDecimal scoreTotal,
             String sectionsJson,

--- a/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryService.java
@@ -61,6 +61,81 @@ public class MoisSalesLibraryService {
     }
 
     /**
+     * Lista páginas com HTML útil que podem ser consumidas pela etapa 2 sem alterar status ou reservar execução.
+     */
+    public MoisSalesLibraryDtos.SalesLibraryPendingAnalysisResponse listPendingAnalysis(
+            String workspaceId,
+            String source,
+            int limit
+    ) {
+        String normalizedSource = source == null || source.isBlank() ? "HOTMART" : source.trim().toUpperCase(Locale.ROOT);
+        int normalizedLimit = Math.max(1, Math.min(limit, 200));
+        List<MoisSalesLibraryDtos.SalesLibraryPendingAnalysisItem> items = jdbcTemplate.query("""
+                SELECT sp.id AS page_id,
+                       sp.workspace_id,
+                       sp.source,
+                       sp.url_canonical,
+                       sp.title,
+                       COALESCE(sp.html_bytes, 0) AS html_bytes,
+                       COALESCE(sp.analysis_status, sp.current_status) AS analysis_status,
+                       sp.last_captured_at,
+                       pending_analysis.id AS job_id,
+                       COALESCE(MAX(all_analysis.attempt), 0) + 1 AS next_attempt,
+                       COUNT(DISTINCT cap.id) > 0 AS raw_html_available,
+                       COUNT(DISTINCT active_analysis.id) AS active_count,
+                       COUNT(DISTINCT CASE WHEN all_analysis.status IN ('DONE', 'ANALYZED') THEN all_analysis.id END) AS done_count,
+                       COUNT(DISTINCT CASE WHEN all_analysis.status = 'FAILED' THEN all_analysis.id END) AS failed_count
+                FROM mois_sales_page sp
+                LEFT JOIN mois_sales_page_job_execution pending_analysis
+                  ON pending_analysis.sales_page_id = sp.id
+                 AND pending_analysis.stage = 'ANALYSIS'
+                 AND pending_analysis.status = 'PENDING'
+                LEFT JOIN mois_sales_page_job_execution active_analysis
+                  ON active_analysis.sales_page_id = sp.id
+                 AND active_analysis.stage = 'ANALYSIS'
+                 AND active_analysis.status IN ('PENDING', 'FETCHING')
+                LEFT JOIN mois_sales_page_job_execution all_analysis
+                  ON all_analysis.sales_page_id = sp.id
+                 AND all_analysis.stage = 'ANALYSIS'
+                LEFT JOIN mois_sales_page_job_execution cap
+                  ON cap.sales_page_id = sp.id
+                 AND cap.stage = 'CAPTURE'
+                 AND cap.status IN ('CAPTURED', 'DUPLICATE')
+                 AND COALESCE(cap.raw_html_bytes, 0) > 0
+                WHERE sp.workspace_id = ?
+                  AND sp.source = ?
+                  AND COALESCE(sp.html_bytes, 0) > 0
+                  AND COALESCE(sp.analysis_status, sp.current_status) NOT IN ('DONE', 'ANALYZED', 'ANULADO', 'FETCHING')
+                GROUP BY sp.id, sp.workspace_id, sp.source, sp.url_canonical, sp.title, sp.html_bytes,
+                         COALESCE(sp.analysis_status, sp.current_status), sp.last_captured_at, pending_analysis.id
+                HAVING active_count = COUNT(DISTINCT pending_analysis.id)
+                   AND done_count = 0
+                   AND failed_count < 3
+                ORDER BY sp.last_captured_at ASC, sp.updated_at ASC, sp.id ASC
+                LIMIT ?
+                """, (rs, rowNum) -> new MoisSalesLibraryDtos.SalesLibraryPendingAnalysisItem(
+                nullableLong(rs, "job_id"),
+                rs.getLong("page_id"),
+                rs.getString("workspace_id"),
+                rs.getString("source"),
+                rs.getString("url_canonical"),
+                rs.getString("title"),
+                rs.getLong("html_bytes"),
+                rs.getString("analysis_status"),
+                rs.getInt("next_attempt"),
+                toInstant(rs.getTimestamp("last_captured_at")),
+                rs.getBoolean("raw_html_available")
+        ), workspaceId, normalizedSource, normalizedLimit);
+        return new MoisSalesLibraryDtos.SalesLibraryPendingAnalysisResponse(
+                workspaceId,
+                normalizedSource,
+                normalizedLimit,
+                items.size(),
+                items
+        );
+    }
+
+    /**
      * Reserva um job de análise pendente que já possui HTML útil capturado para servir como entrada da etapa 2.
      */
     private MoisSalesLibraryDtos.SalesLibraryClaimResponse claimPendingAnalysisJob(String workspaceId, String normalizedSource) {
@@ -1466,6 +1541,14 @@ public class MoisSalesLibraryService {
      */
     private Instant toInstant(Timestamp timestamp) {
         return timestamp == null ? null : timestamp.toInstant();
+    }
+
+    /**
+     * Lê identificadores opcionais do ResultSet preservando nulo quando a coluna SQL está vazia.
+     */
+    private Long nullableLong(ResultSet rs, String columnName) throws SQLException {
+        long value = rs.getLong(columnName);
+        return rs.wasNull() ? null : value;
     }
 
     private record IngestCounters(int persisted, int inserted, int updated, int jobsCreated, int skippedWithoutUrl) {

--- a/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/web/MoisSalesLibraryController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/web/MoisSalesLibraryController.java
@@ -127,6 +127,18 @@ public class MoisSalesLibraryController {
     }
 
     /**
+     * Lista páginas pendentes que já têm HTML útil e podem ser processadas pela etapa 2 sem reservar job.
+     */
+    @GetMapping("/pending")
+    public MoisSalesLibraryDtos.SalesLibraryPendingAnalysisResponse listPendingAnalysis(
+            @RequestParam String workspaceId,
+            @RequestParam(defaultValue = "HOTMART") String source,
+            @RequestParam(defaultValue = "50") int limit
+    ) {
+        return service.listPendingAnalysis(workspaceId, source, limit);
+    }
+
+    /**
      * Retorna o resumo de URLs únicas disponíveis na origem bruta de referências coletadas.
      */
     @GetMapping("/collected-references/url-summary")

--- a/backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryServiceTest.java
@@ -168,6 +168,32 @@ class MoisSalesLibraryServiceTest {
     }
 
     /**
+     * Garante que o endpoint pending consulta páginas com HTML útil sem reservar ou alterar execução.
+     */
+    @Test
+    void shouldListPendingAnalysisWithoutClaimingJobs() {
+        given(jdbcTemplate.query(any(String.class), isA(RowMapper.class), eq("workspace-001"), eq("HOTMART"), eq(25)))
+                .willReturn(List.of());
+
+        MoisSalesLibraryDtos.SalesLibraryPendingAnalysisResponse response =
+                service.listPendingAnalysis("workspace-001", "hotmart", 25);
+
+        org.assertj.core.api.Assertions.assertThat(response.workspaceId()).isEqualTo("workspace-001");
+        org.assertj.core.api.Assertions.assertThat(response.source()).isEqualTo("HOTMART");
+        org.assertj.core.api.Assertions.assertThat(response.limit()).isEqualTo(25);
+        org.assertj.core.api.Assertions.assertThat(response.items()).isEmpty();
+        ArgumentCaptor<String> sqlCaptor = ArgumentCaptor.forClass(String.class);
+        verify(jdbcTemplate).query(sqlCaptor.capture(), isA(RowMapper.class), eq("workspace-001"), eq("HOTMART"), eq(25));
+        org.assertj.core.api.Assertions.assertThat(sqlCaptor.getValue())
+                .contains("COALESCE(sp.html_bytes, 0) > 0")
+                .contains("COALESCE(sp.analysis_status, sp.current_status) NOT IN ('DONE', 'ANALYZED', 'ANULADO', 'FETCHING')")
+                .contains("COUNT(DISTINCT active_analysis.id) AS active_count")
+                .contains("HAVING active_count = COUNT(DISTINCT pending_analysis.id)")
+                .contains("LIMIT ?");
+        verify(jdbcTemplate, never()).update(contains("SET status = 'FETCHING'"), any(), any());
+    }
+
+    /**
      * Garante que a listagem de páginas prioriza as análises mais recentes.
      */
     @Test

--- a/backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/web/MoisSalesLibraryControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/web/MoisSalesLibraryControllerTest.java
@@ -202,6 +202,48 @@ class MoisSalesLibraryControllerTest {
     }
 
     /**
+     * Garante que o endpoint pending expõe páginas elegíveis para diagnóstico da etapa 2 sem reservar job.
+     */
+    @Test
+    void shouldExposePendingAnalysisEndpoint() throws Exception {
+        when(service.listPendingAnalysis("workspace-001", "HOTMART", 25))
+                .thenReturn(new MoisSalesLibraryDtos.SalesLibraryPendingAnalysisResponse(
+                        "workspace-001",
+                        "HOTMART",
+                        25,
+                        1,
+                        List.of(new MoisSalesLibraryDtos.SalesLibraryPendingAnalysisItem(
+                                99L,
+                                10L,
+                                "workspace-001",
+                                "HOTMART",
+                                "https://example.test/sales",
+                                "Página de vendas",
+                                2048L,
+                                "PENDING",
+                                2,
+                                Instant.parse("2026-06-17T06:12:01Z"),
+                                true
+                        ))
+                ));
+
+        mockMvc.perform(get("/api/mois/sales-library/pending")
+                        .param("workspaceId", "workspace-001")
+                        .param("source", "HOTMART")
+                        .param("limit", "25"))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.workspaceId").value("workspace-001"))
+                .andExpect(jsonPath("$.source").value("HOTMART"))
+                .andExpect(jsonPath("$.limit").value(25))
+                .andExpect(jsonPath("$.totalReturned").value(1))
+                .andExpect(jsonPath("$.items[0].jobId").value(99))
+                .andExpect(jsonPath("$.items[0].pageId").value(10))
+                .andExpect(jsonPath("$.items[0].htmlBytes").value(2048))
+                .andExpect(jsonPath("$.items[0].analysisStatus").value("PENDING"))
+                .andExpect(jsonPath("$.items[0].rawHtmlAvailable").value(true));
+    }
+
+    /**
      * Garante que o histórico consolidado da Fase 4 seja exposto ao frontend.
      */
     @Test

--- a/docs/registros/mois1.md
+++ b/docs/registros/mois1.md
@@ -1676,3 +1676,8 @@ Arquivos principais:
 - Corrigida a causa-raiz da falha de arquitetura `moisSalesLibraryWebShouldOnlyDependOnServiceLayer`: o controller dependia do pacote `.dto`, mas a regra do módulo MOIS permite que a camada web dependa apenas da camada `.service` do mesmo namespace/versão.
 - Movido o agrupador de contratos HTTP `MoisSalesLibraryDtos` para a camada `.service`, mantendo os contratos como `record` e evitando novo acoplamento direto da web com camada fora do padrão validado.
 - Atualizados imports em controller, services, scheduler e testes relacionados para preservar o contrato funcional sem alterar endpoints.
+
+## 2026-06-17 — Endpoint pending da etapa 2 da Biblioteca de Páginas de Vendas
+- Criado endpoint backend `GET /api/mois/sales-library/pending` para listar páginas com HTML útil (`html_bytes > 0`) elegíveis para análise comercial, sem reservar job nem alterar status operacional.
+- O contrato retorna workspace, origem, limite, total retornado e itens com `pageId`, `jobId` pendente quando já existir, URL canônica, bytes de HTML, status de análise, próxima tentativa e disponibilidade de HTML bruto.
+- Atualizada a documentação Swagger da Biblioteca de Páginas de Vendas e adicionados testes de controller/service para prevenir regressão no contrato de auditoria da fila real da etapa 2.

--- a/docs/swagger/mois-sales-library-swagger.yaml
+++ b/docs/swagger/mois-sales-library-swagger.yaml
@@ -154,6 +154,36 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SalesLibraryPageSummaryResponse'
+  /pending:
+    get:
+      summary: Lista páginas pendentes elegíveis para análise comercial
+      description: Retorna páginas de `mois_sales_page` com `html_bytes > 0` e sem análise concluída, anulada ou em execução, sem reservar job nem alterar status. Serve para auditoria operacional da fila real da Etapa 2.
+      tags: [MOIS Sales Library]
+      parameters:
+        - in: query
+          name: workspaceId
+          required: true
+          schema:
+            type: string
+        - in: query
+          name: source
+          schema:
+            type: string
+            default: HOTMART
+        - in: query
+          name: limit
+          schema:
+            type: integer
+            default: 50
+            minimum: 1
+            maximum: 200
+      responses:
+        '200':
+          description: Páginas aptas para processamento pela etapa 2
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/SalesLibraryPendingAnalysisResponse'
   /jobs:
     get:
       summary: Lista execuções operacionais consolidadas
@@ -1100,6 +1130,58 @@ components:
           type: boolean
         job:
           $ref: '#/components/schemas/SalesLibraryClaimedJob'
+    SalesLibraryPendingAnalysisItem:
+      type: object
+      properties:
+        jobId:
+          type: integer
+          format: int64
+          nullable: true
+          description: Execução `PAGE_ANALYSIS` pendente já criada; pode ser nulo quando a página ainda será refileirada pelo claim.
+        pageId:
+          type: integer
+          format: int64
+        workspaceId:
+          type: string
+        source:
+          type: string
+        urlCanonical:
+          type: string
+        title:
+          type: string
+          nullable: true
+        htmlBytes:
+          type: integer
+          format: int64
+          description: Tamanho do HTML útil consolidado, sempre maior que zero neste endpoint.
+        analysisStatus:
+          type: string
+          description: Status operacional atual da análise comercial da página.
+        nextAttempt:
+          type: integer
+          description: Próxima tentativa calculada a partir do histórico de análise da página.
+        lastCapturedAt:
+          type: string
+          format: date-time
+          nullable: true
+        rawHtmlAvailable:
+          type: boolean
+          description: Indica se existe execução de captura com HTML bruto disponível para entrada direta do worker.
+    SalesLibraryPendingAnalysisResponse:
+      type: object
+      properties:
+        workspaceId:
+          type: string
+        source:
+          type: string
+        limit:
+          type: integer
+        totalReturned:
+          type: integer
+        items:
+          type: array
+          items:
+            $ref: '#/components/schemas/SalesLibraryPendingAnalysisItem'
     SalesLibraryCompleteRequest:
       type: object
       properties:


### PR DESCRIPTION
### Motivation
- Provide an operational read-only view of captured pages that are eligible for Stage 2 commercial analysis without reserving jobs or changing execution state.
- Allow frontend and operators to audit the real analysis queue and inspect HTML availability, attempts and status before claiming work.

### Description
- Added DTOs `SalesLibraryPendingAnalysisItem` and `SalesLibraryPendingAnalysisResponse` to `MoisSalesLibraryDtos` to represent pending-analysis items and the response envelope.
- Implemented `listPendingAnalysis` in `MoisSalesLibraryService` which normalizes `source`, bounds `limit` to `1..200`, and runs a SQL query returning pages with `html_bytes > 0`, analysis status filters, next attempt and raw-html availability without modifying any job rows; added helper `nullableLong` to safely read optional job ids from the `ResultSet`.
- Exposed a new controller endpoint `GET /api/mois/sales-library/pending` in `MoisSalesLibraryController` that delegates to the service and accepts `workspaceId`, `source` (default `HOTMART`) and `limit` (default `50`).
- Added Swagger schema and path entries for the new endpoint and DTOs, and updated documentation notes describing the endpoint behavior.
- Added unit tests `shouldListPendingAnalysisWithoutClaimingJobs` (service) and `shouldExposePendingAnalysisEndpoint` (controller) and updated related imports and docs.

### Testing
- Ran unit test `MoisSalesLibraryServiceTest#shouldListPendingAnalysisWithoutClaimingJobs` which verifies SQL composition, parameters and that no `UPDATE` occurs; the test passed.
- Ran unit test `MoisSalesLibraryControllerTest#shouldExposePendingAnalysisEndpoint` which verifies the HTTP contract and JSON shape; the test passed.
- Existing service/controller unit tests were executed and remained green during the change set application.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3210d6c19c8321a20b25da56be5c56)