### PR TITLE
Desativa tela obsoleta do pipeline OPRM

### DIFF
--- a/docs/canonical/oprm-canon.v1.md
+++ b/docs/canonical/oprm-canon.v1.md
@@ -119,7 +119,7 @@ Evitar fechamento prematuro de `import run` que destrói a totalização de mark
 - Seeds, queries, fontes, sinais, sínteses e gates da fase inicial devem ser aceitos somente quando servirem à compreensão da rotina real e das dificuldades do nicho no Brasil.
 - Snapshots da etapa quatro devem persistir indicadores próprios de intenção da fonte, evidência de rotina, risco comercial e risco de linguagem de solução, mantendo política de armazenamento curto.
 - Qualquer conteúdo de solução, produto, campanha, oferta ou hipótese comercial deve pertencer a fluxo posterior, separado e rastreável, depois da conclusão da pesquisa de realidade operacional.
-- A tela `/oprm/pipeline` deve orientar o usuário de que o NichoCNAE está levantando realidade operacional no Brasil e não montando solução ou campanha nessa etapa; ciclos em `FAILED`, `NEEDS_MORE_RESEARCH` ou `GENERIC` devem oferecer ação de novo ciclo manual/reprocessamento.
+- A tela administrativa `/oprm/pipeline` está obsoleta e deve permanecer desativada no frontend; o acompanhamento e o disparo do pipeline NichoCNAE devem acontecer somente pelo caminho de criação de novo nicho/subnicho a partir do CNAE (`/oprm` e detalhe do CNAE), para evitar operação paralela sem decisão comercial clara.
 
 ## Regra obrigatória — materialização final do NichoCNAE em nicho enriquecido
 
@@ -139,7 +139,7 @@ Evitar fechamento prematuro de `import run` que destrói a totalização de mark
 - É permitido gerar múltiplos registros em `market_niche_enrichment_profile` para o mesmo `market_niche_id`, inclusive para o mesmo `routine_card_id` ou `research_cycle_id`, quando houver reprocessamento operacional; cada registro deve preservar a auditoria histórica da execução que o criou.
 - Reprocessamentos devem reaproveitar e atualizar o `market_niche` existente de forma controlada, criando novo perfil enriquecido rastreável em vez de bloquear a execução por idempotência rígida.
 - O mesmo CNAE pode gerar mais de um `market_niche` quando os ciclos aprovados representarem subnichos diferentes; a etapa final só deve atualizar um nicho existente quando encontrar materialização anterior do mesmo `cnae_code` com o mesmo `neutral_niche_name` normalizado. `market_niche_id` associado ao candidato ou ao perfil MEI/autônomo não pode, sozinho, forçar atualização de um nicho diferente.
-- A tela `/oprm/pipeline` deve exibir a etapa final e informar o `marketNicheId`, o `enrichedNicheProfileId` e o status de materialização.
+- A etapa final, o `marketNicheId`, o `enrichedNicheProfileId` e o status de materialização devem ser exibidos no fluxo de detalhe/criação de novo nicho do CNAE; a tela administrativa `/oprm/pipeline` não deve ser usada para esse acompanhamento.
 - Ciclos em `ENRICHED_NICHE_FAILED` devem oferecer ação operacional pelo próprio front-end para abrir novo ciclo rastreável; o usuário não deve ser orientado a corrigir esse caso por acesso direto ao banco de dados.
 - O contrato da etapa final deve seguir o padrão de unidade de trabalho fechada: o endpoint `pending` precisa entregar todos os dados necessários para o coletor concluir a materialização sem buscar detalhes adicionais.
 

--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -779,3 +779,10 @@
 - Aplicado o protocolo padrão backend no pacote `com.marketinghub.oprm.nichocnae` por meio de regras ArchUnit específicas para as etapas do NichoCNAE.
 - Causa-raiz tratada: o pacote já possuía várias etapas operacionais, mas não havia uma trava arquitetural dedicada garantindo controller canônico, service backend canônico e contratos imutáveis em subpacotes de service.
 - Prevenção de recorrência: a suíte de arquitetura agora valida que cada etapa tenha um único `Backend<Etapa>Controller`, um service backend canônico e DTOs/contratos como `record`, reduzindo risco de espalhamento de contratos e endpoints no fluxo que qualifica nichos para vendas.
+
+## 2026-06-17 — OPRM NichoCNAE: desativação da tela administrativa de pipeline
+
+- Decisão registrada: a tela `/oprm/pipeline` ficou obsoleta e foi desativada no frontend.
+- Causa-raiz tratada: manter um caminho separado de pipeline competia com o fluxo atual de criação de novo nicho pelo CNAE, aumentando risco de confusão operacional, comandos duplicados e gasto sem direcionamento comercial.
+- Correção aplicada: o menu interno OPRM remove o item Pipeline, as rotas antigas de pipeline redirecionam para `/oprm` e o cânone passou a orientar que o pipeline NichoCNAE seja usado somente pelo caminho de criação de novo nicho/subnicho.
+- Prevenção de recorrência: o teste de navegação OPRM valida que o link Pipeline não aparece e que a rota obsoleta não renderiza mais a tela antiga.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,4 +1,4 @@
-import { Route, Routes } from "react-router-dom";
+import { Navigate, Route, Routes } from "react-router-dom";
 
 import FacebookAccountsPage from "./pages/FacebookAccountsPage";
 import InstagramAccountsPage from "./pages/InstagramAccountsPage";
@@ -113,8 +113,6 @@ import OprmOccupationCatalogPage from "./pages/oprm/OprmOccupationCatalogPage";
 import OprmCnaeVolumePage from "./pages/oprm/OprmCnaeVolumePage";
 import OprmCnaeDetailPlaceholderPage from "./pages/oprm/OprmCnaeDetailPlaceholderPage";
 import OprmCnaePipelineStageDetailPage from "./pages/oprm/OprmCnaePipelineStageDetailPage";
-import OprmPipelinePage from "./pages/oprm/OprmPipelinePage";
-import OprmNicheResearchSeedBuilderDetailPage from "./pages/oprm/OprmNicheResearchSeedBuilderDetailPage";
 import OprmEnrichedNicheDetailPage from "./pages/oprm/OprmEnrichedNicheDetailPage";
 import OprmGeneralAudiencesPage from "./pages/oprm/OprmGeneralAudiencesPage";
 import OprmGeneralAudienceSeedDetailPage from "./pages/oprm/OprmGeneralAudienceSeedDetailPage";
@@ -225,15 +223,42 @@ export default function App() {
               <Route path="/experiments/:id" element={<AppLayout />}>
                 <Route index element={<ExperimentDetailPage />} />
                 <Route path="edit" element={<EditExperimentPage />} />
-                <Route path="instant-forms/:instantFormId" element={<InstantFormDetailPage />} />
-                <Route path="emails/:emailStepId" element={<ExperimentEmailDetailPage />} />
-                <Route path="adset-workflow" element={<ExperimentAdSetWorkflowPage />} />
-                <Route path="facebook-api-logs" element={<ExperimentFacebookApiLogsPage />} />
-                <Route path="pipeline-jobs" element={<ExperimentPipelineJobsPage />} />
-                <Route path="geralanding/stage-executions/:jobId" element={<ExperimentGeraLandingExecutionDetailPage />} />
-                <Route path="geralanding/stage-executions/:jobId/provisional-html" element={<ExperimentGeraLandingProvisionalHtmlPage />} />
-                <Route path="adset-workflow/jobs/:jobId" element={<ExperimentAdSetJobDetailPage />} />
-                <Route path="framework-images" element={<ExperimentFrameworkImageDetailsPage />} />
+                <Route
+                  path="instant-forms/:instantFormId"
+                  element={<InstantFormDetailPage />}
+                />
+                <Route
+                  path="emails/:emailStepId"
+                  element={<ExperimentEmailDetailPage />}
+                />
+                <Route
+                  path="adset-workflow"
+                  element={<ExperimentAdSetWorkflowPage />}
+                />
+                <Route
+                  path="facebook-api-logs"
+                  element={<ExperimentFacebookApiLogsPage />}
+                />
+                <Route
+                  path="pipeline-jobs"
+                  element={<ExperimentPipelineJobsPage />}
+                />
+                <Route
+                  path="geralanding/stage-executions/:jobId"
+                  element={<ExperimentGeraLandingExecutionDetailPage />}
+                />
+                <Route
+                  path="geralanding/stage-executions/:jobId/provisional-html"
+                  element={<ExperimentGeraLandingProvisionalHtmlPage />}
+                />
+                <Route
+                  path="adset-workflow/jobs/:jobId"
+                  element={<ExperimentAdSetJobDetailPage />}
+                />
+                <Route
+                  path="framework-images"
+                  element={<ExperimentFrameworkImageDetailsPage />}
+                />
               </Route>
               <Route path="/hypotheses" element={<HypothesisListPage />} />
               <Route path="/hypotheses/board" element={<HypothesesPage />} />
@@ -244,7 +269,10 @@ export default function App() {
                 element={<EditAiServicePage />}
               />
               <Route path="/openai-models" element={<OpenAiModelListPage />} />
-              <Route path="/openai-models/new" element={<NewOpenAiModelPage />} />
+              <Route
+                path="/openai-models/new"
+                element={<NewOpenAiModelPage />}
+              />
               <Route
                 path="/openai-models/:id/edit"
                 element={<EditOpenAiModelPage />}
@@ -253,10 +281,7 @@ export default function App() {
               <Route path="/agents/new" element={<NewAgentPage />} />
               <Route path="/agents/:id/edit" element={<EditAgentPage />} />
               <Route path="/agent-themes" element={<AgentThemePage />} />
-              <Route
-                path="/microservices"
-                element={<MicroserviceListPage />}
-              />
+              <Route path="/microservices" element={<MicroserviceListPage />} />
               <Route
                 path="/microservices/errors"
                 element={<MicroserviceExceptionListPage />}
@@ -308,22 +333,55 @@ export default function App() {
                 element={<OprmCnaePipelineStageDetailPage />}
               />
               <Route path="/mois" element={<MoisWorkspacePage />} />
-              <Route path="/mois/references/new" element={<MoisReferenceIntakePage />} />
-              <Route path="/mois/research-sources" element={<MoisResearchSourcesPage />} />
-              <Route path="/mois/auto-collection" element={<MoisAutoCollectionPage />} />
-              <Route path="/mois/automatic-collections" element={<MoisAutomaticCollectionsPage />} />
-              <Route path="/mois/automatic-collections/:jobId" element={<MoisCollectionJobDetailPage />} />
+              <Route
+                path="/mois/references/new"
+                element={<MoisReferenceIntakePage />}
+              />
+              <Route
+                path="/mois/research-sources"
+                element={<MoisResearchSourcesPage />}
+              />
+              <Route
+                path="/mois/auto-collection"
+                element={<MoisAutoCollectionPage />}
+              />
+              <Route
+                path="/mois/automatic-collections"
+                element={<MoisAutomaticCollectionsPage />}
+              />
+              <Route
+                path="/mois/automatic-collections/:jobId"
+                element={<MoisCollectionJobDetailPage />}
+              />
               <Route path="/mois/extraction" element={<MoisExtractionPage />} />
               <Route path="/mois/library" element={<MoisLibraryPage />} />
-              <Route path="/mois/sales-pages-library" element={<MoisSalesPagesLibraryPage />} />
-              <Route path="/mois/sales-pages-library/pipeline" element={<MoisSalesPagesPipelinePage />} />
-              <Route path="/mois/sales-pages-library/:pageId" element={<MoisSalesPageLibraryDetailPage />} />
+              <Route
+                path="/mois/sales-pages-library"
+                element={<MoisSalesPagesLibraryPage />}
+              />
+              <Route
+                path="/mois/sales-pages-library/pipeline"
+                element={<MoisSalesPagesPipelinePage />}
+              />
+              <Route
+                path="/mois/sales-pages-library/:pageId"
+                element={<MoisSalesPageLibraryDetailPage />}
+              />
               <Route path="/mois/comparison" element={<MoisComparisonPage />} />
               <Route path="/mois/builder" element={<MoisOfferBuilderPage />} />
               <Route path="/mds" element={<MdsWorkspacePage />} />
-              <Route path="/mds/requests/:requestId" element={<MdsRequestDetailPage />} />
-              <Route path="/mds/requests/:requestId/artifacts" element={<MdsArtifactsPage />} />
-              <Route path="/mds/reports/:requestId" element={<MdsReportPage />} />
+              <Route
+                path="/mds/requests/:requestId"
+                element={<MdsRequestDetailPage />}
+              />
+              <Route
+                path="/mds/requests/:requestId/artifacts"
+                element={<MdsArtifactsPage />}
+              />
+              <Route
+                path="/mds/reports/:requestId"
+                element={<MdsReportPage />}
+              />
               <Route path="/hotmart" element={<HotmartPage />} />
               <Route path="/clickbase" element={<ClickbasePage />} />
               <Route
@@ -342,16 +400,31 @@ export default function App() {
                 path="/oprm/feedback/:occupationSeedRef"
                 element={<OprmFeedbackPage />}
               />
+              <Route path="/oprm/operations" element={<OprmOperationsPage />} />
               <Route
-                path="/oprm/operations"
-                element={<OprmOperationsPage />}
+                path="/oprm/pipeline"
+                element={<Navigate to="/oprm" replace />}
               />
-              <Route path="/oprm/pipeline" element={<OprmPipelinePage />} />
-              <Route path="/oprm/general-audiences" element={<OprmGeneralAudiencesPage />} />
-              <Route path="/oprm/general-audiences/seeds/:seedId" element={<OprmGeneralAudienceSeedDetailPage />} />
-              <Route path="/oprm/general-audiences/subniches/:subnicheId" element={<OprmGeneralAudienceSubnicheDetailPage />} />
-              <Route path="/oprm/enriched-niches/profile/:profileId" element={<OprmEnrichedNicheDetailPage />} />
-              <Route path="/oprm/pipeline/niche-research-seed-builder/:researchCycleId" element={<OprmNicheResearchSeedBuilderDetailPage />} />
+              <Route
+                path="/oprm/general-audiences"
+                element={<OprmGeneralAudiencesPage />}
+              />
+              <Route
+                path="/oprm/general-audiences/seeds/:seedId"
+                element={<OprmGeneralAudienceSeedDetailPage />}
+              />
+              <Route
+                path="/oprm/general-audiences/subniches/:subnicheId"
+                element={<OprmGeneralAudienceSubnicheDetailPage />}
+              />
+              <Route
+                path="/oprm/enriched-niches/profile/:profileId"
+                element={<OprmEnrichedNicheDetailPage />}
+              />
+              <Route
+                path="/oprm/pipeline/niche-research-seed-builder/:researchCycleId"
+                element={<Navigate to="/oprm" replace />}
+              />
               <Route
                 path="/oprm/occupations"
                 element={<OprmOccupationCatalogPage />}
@@ -370,10 +443,7 @@ export default function App() {
               <Route path="/analytics" element={<AnalyticsDashboard />} />
               <Route path="/funnels" element={<FunnelListPage />} />
               <Route path="/funnels/new" element={<NewFunnelPage />} />
-              <Route
-                path="/funnels/:id/edit"
-                element={<EditFunnelPage />}
-              />
+              <Route path="/funnels/:id/edit" element={<EditFunnelPage />} />
               <Route
                 path="/lead-portal/metrics"
                 element={<LeadPortalExperimentMetricsPage />}
@@ -407,9 +477,18 @@ export default function App() {
               <Route path="/chat-dialogs" element={<ChatDialogListPage />} />
               <Route path="/chat-dialogs/new" element={<NewChatDialogPage />} />
               <Route path="/prompt-entities" element={<PromptEntitiesPage />} />
-              <Route path="/prompt-domains" element={<PromptDomainListPage />} />
-              <Route path="/prompt-domains/new" element={<NewPromptDomainPage />} />
-              <Route path="/prompt-domains/:id/edit" element={<EditPromptDomainPage />} />
+              <Route
+                path="/prompt-domains"
+                element={<PromptDomainListPage />}
+              />
+              <Route
+                path="/prompt-domains/new"
+                element={<NewPromptDomainPage />}
+              />
+              <Route
+                path="/prompt-domains/:id/edit"
+                element={<EditPromptDomainPage />}
+              />
               <Route
                 path="/prompt-entities/new"
                 element={<NewPromptEntityPage />}

--- a/frontend/src/__tests__/OprmNavigation.test.tsx
+++ b/frontend/src/__tests__/OprmNavigation.test.tsx
@@ -25,7 +25,7 @@ describe("OPRM navigation", () => {
     expect(
       screen.getByRole("button", { name: /ver nichos enriquecidos/i }),
     ).toBeTruthy();
-    expect(screen.getByRole("link", { name: /^pipeline$/i })).toBeTruthy();
+    expect(screen.queryByRole("link", { name: /^pipeline$/i })).toBeNull();
   });
 
   it("has menu link to /oprm", () => {
@@ -51,13 +51,11 @@ describe("OPRM navigation", () => {
     ).toBeTruthy();
   });
 
-  it("renders Pipeline page on /oprm/pipeline route", () => {
+  it("redirects obsolete /oprm/pipeline route to CNAE niche creation flow", () => {
     setup(<App />, ["/oprm/pipeline"]);
-    expect(screen.getByText(/^Pipeline NichoCNAE$/)).toBeTruthy();
-    expect(screen.getByText(/^Últimos 10 nichos processados$/)).toBeTruthy();
-    expect(screen.getByText(/^Ciclo de Pesquisa de Rotina$/)).toBeTruthy();
-    expect(screen.getByText(/^Seed de Pesquisa do Nicho$/)).toBeTruthy();
-    expect(screen.getByText(/^Gate de Qualidade$/)).toBeTruthy();
+    expect(screen.getByText(/^CNAEs por Score OPRM$/)).toBeTruthy();
+    expect(screen.queryByText(/^Pipeline NichoCNAE$/)).toBeNull();
+    expect(screen.queryByRole("link", { name: /^pipeline$/i })).toBeNull();
   });
 
   it("renders loading state on /oprm/operations route", async () => {

--- a/frontend/src/pages/oprm/OprmModuleNavigation.tsx
+++ b/frontend/src/pages/oprm/OprmModuleNavigation.tsx
@@ -6,7 +6,6 @@ interface OprmModuleNavigationProps {
 
 const navigationItems = [
   { label: "CNAEs", to: "/oprm", end: true },
-  { label: "Pipeline", to: "/oprm/pipeline" },
   { label: "Públicos Gerais", to: "/oprm/general-audiences" },
 ];
 


### PR DESCRIPTION
### Motivation
- A tela administrativa `/oprm/pipeline` está obsoleta e pode causar operação paralela e confusão com o fluxo oficial de criação de nicho a partir do CNAE, então deve ser desativada e o acompanhamento centralizado no caminho de criação de novo nicho (`/oprm`).

### Description
- Redireciona as rotas obsoletas para o fluxo CNAE: `/oprm/pipeline` e `/oprm/pipeline/niche-research-seed-builder/:researchCycleId` passam a retornar `Navigate` para `/oprm` em `frontend/src/App.tsx` e as importações da página de pipeline foram removidas.
- Remove o item `Pipeline` da navegação interna OPRM em `frontend/src/pages/oprm/OprmModuleNavigation.tsx` para evitar exposição do caminho obsoleto.
- Atualiza o teste de navegação em `frontend/src/__tests__/OprmNavigation.test.tsx` para validar que o link `Pipeline` não aparece e que a rota antiga redireciona ao fluxo CNAE; também ajusta a mensagem do teste correspondente.
- Registra a decisão nos documentos canônicos e de registro ajustando `docs/canonical/oprm-canon.v1.md` e `docs/registros/oprm1.md` com a justificativa, causa-raiz e prevenção de recorrência.

### Testing
- Executado `npm ci` na pasta `frontend` com sucesso para instalar dependências. 
- Executado `npm run typecheck` (TS `tsc --noEmit`) com sucesso sem erros de tipagem. 
- Executado `npm test -- --run src/__tests__/OprmNavigation.test.tsx -t "redirects obsolete /oprm/pipeline route"` que passou e validou o comportamento de redirecionamento.
- Uma execução mais ampla de `npm test -- --run src/__tests__/OprmNavigation.test.tsx` inicialmente mostrou uma falha preexistente não relacionada na verificação do placeholder `/oprm/cnaes/:cnaeCode`, que não foi introduzida por esta mudança; o teste de redirecionamento específico passou conforme esperado.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3215904d4c8321acd8c2a05267d9db)