### PR TITLE
Remove misleading execution status badges

### DIFF
--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -4697,3 +4697,8 @@
 
 - Ajustado o diagnóstico de falha do experimento para exibir o `jobId` do passo de publicação que originou o erro.
 - Objetivo operacional: permitir consultar diretamente a tabela `facebook_campaign_publication_job_step` e acelerar a investigação da causa-raiz no fluxo de publicação Facebook Ads.
+
+## 2026-06-17 — Remoção de status locais na execução registrada
+
+- Removidos da tela de detalhe do experimento os badges locais de status de campanha, conjunto e anúncio na seção **Execução registrada**.
+- Motivo: esses status refletem o registro interno persistido e podiam sugerir que tudo estava ativo mesmo quando a realidade operacional da Meta Ads era diferente.

--- a/frontend/src/pages/experiment/ExperimentDetailPage.tsx
+++ b/frontend/src/pages/experiment/ExperimentDetailPage.tsx
@@ -2383,11 +2383,6 @@ export default function ExperimentDetailPage() {
                           {formatDateTimeValue(campaign.createdAt)}
                         </div>
                       </div>
-                      <span
-                        className={`badge text-bg-${campaign.status === "PAUSED" ? "secondary" : "success"}`}
-                      >
-                        {campaign.status}
-                      </span>
                     </div>
                     {campaign.issues?.length ? (
                       <div
@@ -2419,11 +2414,6 @@ export default function ExperimentDetailPage() {
                                   {adSet.ads.length === 1 ? "" : "s"}
                                 </div>
                               </div>
-                              <span
-                                className={`badge text-bg-${adSet.experimentAdSetId ? "success" : "warning"}`}
-                              >
-                                {adSet.status}
-                              </span>
                             </div>
                             {adSet.issues?.length ? (
                               <ul className="text-warning small mb-0 mt-2 ps-3">
@@ -2452,11 +2442,6 @@ export default function ExperimentDetailPage() {
                                           {ad.trackingCode ?? "—"}
                                         </div>
                                       </div>
-                                      <span
-                                        className={`badge text-bg-${ad.status === "PAUSED" ? "secondary" : "success"}`}
-                                      >
-                                        {ad.status}
-                                      </span>
                                     </div>
                                     {ad.funnelStages &&
                                     ad.funnelStages.length ? (


### PR DESCRIPTION
### Motivation
- Evitar que badges locais de `ACTIVE/PAUSED` na seção “Execução registrada” do detalhe do experimento induzam à leitura de que o estado persistido corresponde à realidade operacional da Meta Ads.

### Description
- Removidos os badges de status de campanha, conjunto de anúncios e anúncio em `frontend/src/pages/experiment/ExperimentDetailPage.tsx` e adicionada entrada explicando a alteração em `docs/registros/experimentos.md`.

### Testing
- Executados `npm install`, `npm run typecheck`, `npx prettier --check src/pages/experiment/ExperimentDetailPage.tsx` e `npm run build`, com `typecheck` e `build` concluídos com sucesso and the TypeScript file passing Prettier; `npx prettier --check` including `docs/registros/experimentos.md` reported existing formatting warnings for the large records file unrelated to this focused UI change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3215e4692083219713d902d1981520)