### PR TITLE
docs: destacar que a tela deve mostrar a verdade do backend

### DIFF
--- a/frontend/AGENTS.md
+++ b/frontend/AGENTS.md
@@ -3,6 +3,15 @@
 - Qualquer botão que dispare uma requisição assíncrona deve ficar desabilitado e exibir um indicador de carregamento (por exemplo, `spinner-border spinner-border-sm`) enquanto a operação estiver em andamento.
 - Campos de formulário obrigatórios devem exibir um asterisco (`*`) ao lado do rótulo para indicar a obrigatoriedade na interface.
 
+
+## Regra de verdade da tela
+
+> **REGRA OBRIGATÓRIA E EM DESTAQUE:** A tela mostra a verdade do backend, nunca uma inferência local.
+
+- Qualquer status, dado, disponibilidade, contagem, conclusão ou decisão exibida ao usuário deve vir do contrato/endpoint do backend.
+- O frontend pode apenas formatar, organizar e apresentar o dado recebido; não deve deduzir estado de negócio por heurística local quando o backend não enviou essa verdade.
+- Se o backend ainda não expõe a informação necessária, crie ou ajuste o endpoint correto antes de mostrar a informação na tela.
+
 ## Menu lateral
 
 - O menu principal é um drawer lateral fixo à esquerda que controla a navegação global do aplicativo.


### PR DESCRIPTION
### Motivation
- Garantir uma regra explícita no frontend que evite inferências locais e preserve a fonte única de verdade vinda do backend.

### Description
- Adicionada a seção `Regra de verdade da tela` em `frontend/AGENTS.md` com a orientação em destaque "A tela mostra a verdade do backend, nunca uma inferência local" e três pontos curtos orientando que dados/estados devem vir do endpoint do backend e que, se faltar informação, o endpoint deve ser criado ou ajustado.

### Testing
- Rodei `git diff --check` e não foram encontrados problemas.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a323d5168608321818b2c2f68e9908d)