### PR TITLE
Add OPRM NichoCNAE cycle-feedback class diagram and registro entry

### DIFF
--- a/docs/oprm-nichocnae-cycle-feedback-class-diagram.md
+++ b/docs/oprm-nichocnae-cycle-feedback-class-diagram.md
@@ -1,0 +1,211 @@
+# Diagrama de classes — OPRM NichoCNAE com feedback entre ciclos
+
+Este desenho propõe o pipeline NichoCNAE como um fluxo iterativo por ciclos encadeados. A etapa de qualidade não chama diretamente etapas anteriores: ela produz um feedback estruturado e um plano de correção. O orquestrador cria o próximo ciclo usando esse plano como contexto obrigatório.
+
+## Visão de classes
+
+```mermaid
+classDiagram
+    direction LR
+
+    class NicheCnaePipelineOrchestrator {
+      +startCycle(command) ResearchCycle
+      +continueCycle(cycleId) void
+      +handleQualityDecision(cycleId, review) ResearchCycle?
+    }
+
+    class ResearchCycle {
+      +String cycleId
+      +String rootCycleId
+      +String parentCycleId
+      +String cnaeCode
+      +Long cycleNumber
+      +CycleStatus status
+      +ReprocessPolicy reprocessPolicy
+      +Instant startedAt
+      +Instant finishedAt
+    }
+
+    class StageExecution {
+      +Long id
+      +String cycleId
+      +StageCode stageCode
+      +StageStatus status
+      +Long inputArtifactId
+      +Long outputArtifactId
+      +Instant startedAt
+      +Instant finishedAt
+      +String errorMessage
+    }
+
+    class StageProcessor {
+      <<interface>>
+      +supports(stageCode) boolean
+      +process(context) StageResult
+    }
+
+    class StageContext {
+      +String cycleId
+      +String cnaeCode
+      +List~StageArtifact~ previousArtifacts
+      +QualityFeedback previousFeedback
+      +CorrectionPlan correctionPlan
+    }
+
+    class StageResult {
+      +StageStatus status
+      +StageArtifact outputArtifact
+      +String summary
+      +String errorMessage
+    }
+
+    class StageArtifact {
+      +Long id
+      +String cycleId
+      +StageCode stageCode
+      +ArtifactType type
+      +String contentRef
+      +String checksum
+      +Instant createdAt
+    }
+
+    class QualityGateProcessor {
+      +process(context) StageResult
+      -evaluate(card, artifacts) QualityReview
+    }
+
+    class QualityReview {
+      +Integer score
+      +QualityDecision decision
+      +List~QualityProblem~ problems
+      +CorrectionPlan correctionPlan
+    }
+
+    class QualityProblem {
+      +String code
+      +Severity severity
+      +StageCode affectedStage
+      +String evidence
+      +String recommendation
+    }
+
+    class CorrectionPlan {
+      +ReprocessPolicy policy
+      +List~StageCode~ rerunStages
+      +List~StageCode~ reuseStages
+      +List~String~ instructions
+    }
+
+    class QualityFeedback {
+      +String sourceCycleId
+      +Integer previousScore
+      +QualityDecision previousDecision
+      +List~QualityProblem~ openProblems
+      +CorrectionPlan correctionPlan
+    }
+
+    class CycleRepository {
+      +save(cycle) ResearchCycle
+      +findById(cycleId) ResearchCycle
+      +findLastByRootCycle(rootCycleId) ResearchCycle
+    }
+
+    class StageExecutionRepository {
+      +save(execution) StageExecution
+      +findByCycle(cycleId) List~StageExecution~
+    }
+
+    class ArtifactStore {
+      +save(artifact) StageArtifact
+      +findByCycle(cycleId) List~StageArtifact~
+      +findReusableArtifacts(parentCycleId, plan) List~StageArtifact~
+    }
+
+    NicheCnaePipelineOrchestrator --> CycleRepository
+    NicheCnaePipelineOrchestrator --> StageExecutionRepository
+    NicheCnaePipelineOrchestrator --> ArtifactStore
+    NicheCnaePipelineOrchestrator --> StageProcessor
+    NicheCnaePipelineOrchestrator --> ResearchCycle
+
+    ResearchCycle "1" --> "0..1" ResearchCycle : parentCycle
+    ResearchCycle "1" --> "0..*" StageExecution
+    StageExecution "1" --> "0..1" StageArtifact : input
+    StageExecution "1" --> "0..1" StageArtifact : output
+
+    StageProcessor <|.. QualityGateProcessor
+    StageProcessor --> StageContext
+    StageProcessor --> StageResult
+    StageContext --> QualityFeedback
+    StageContext --> CorrectionPlan
+    StageContext --> StageArtifact
+    StageResult --> StageArtifact
+
+    QualityGateProcessor --> QualityReview
+    QualityReview --> QualityProblem
+    QualityReview --> CorrectionPlan
+    QualityFeedback --> QualityProblem
+    QualityFeedback --> CorrectionPlan
+    ArtifactStore --> StageArtifact
+```
+
+## Leitura arquitetural
+
+- `ResearchCycle` é o agregado principal: cada tentativa de qualificação do CNAE/subnicho é um ciclo versionado.
+- `parentCycleId` liga um reprocessamento ao ciclo anterior; `rootCycleId` agrupa todas as tentativas da mesma investigação.
+- `QualityGateProcessor` não reprocessa nada diretamente; ele apenas emite `QualityReview` com decisão, problemas e plano de correção.
+- `NicheCnaePipelineOrchestrator` é o único responsável por criar o próximo ciclo quando a decisão for `REPROCESS_REQUIRED`.
+- `StageContext` carrega o conhecimento do ciclo anterior por contrato, usando `QualityFeedback`, `CorrectionPlan` e artefatos reutilizáveis.
+- `StageProcessor` mantém as etapas plugáveis e coesas; uma etapa não importa nem chama diretamente outra etapa concreta.
+- `ArtifactStore` preserva entradas e saídas auditáveis, permitindo reprocessamento parcial ou complementar sem perder rastreabilidade.
+
+## Decisões de reprocessamento
+
+```mermaid
+classDiagram
+    class QualityDecision {
+      <<enumeration>>
+      APPROVED
+      REPROCESS_REQUIRED
+      MANUAL_REVIEW
+      REJECTED
+    }
+
+    class ReprocessPolicy {
+      <<enumeration>>
+      NONE
+      FULL_REPROCESS
+      PARTIAL_REPROCESS
+      COMPLEMENTARY_REPROCESS
+      MANUAL_REVIEW
+    }
+
+    class CycleStatus {
+      <<enumeration>>
+      CREATED
+      RUNNING
+      QUALITY_REVIEW
+      APPROVED
+      REPROCESS_REQUIRED
+      REPROCESSING
+      MATERIALIZED
+      FAILED
+    }
+
+    class StageCode {
+      <<enumeration>>
+      ROUTINE_RESEARCH_ORCHESTRATOR
+      ROUTINE_RESEARCH_CYCLE
+      NICHE_RESEARCH_SEED_BUILDER
+      SOURCE_SEARCHER
+      SOURCE_FETCHER
+      SIGNAL_EXTRACTOR
+      ROUTINE_SYNTHESIZER
+      MEI_AUDIENCE_SEGMENTER
+      ROUTINE_QUALITY_GATE
+      ENRICHED_NICHE_MATERIALIZER
+    }
+```
+
+## Regra central
+
+O próximo ciclo só pode nascer a partir de uma decisão explícita do `QualityReview`. Assim, o sistema deixa de “rodar de novo” e passa a executar uma nova tentativa orientada por causa: problema identificado, etapa afetada, artefato reutilizável e plano de correção.

--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -786,3 +786,9 @@
 - Causa-raiz tratada: manter um caminho separado de pipeline competia com o fluxo atual de criação de novo nicho pelo CNAE, aumentando risco de confusão operacional, comandos duplicados e gasto sem direcionamento comercial.
 - Correção aplicada: o menu interno OPRM remove o item Pipeline, as rotas antigas de pipeline redirecionam para `/oprm` e o cânone passou a orientar que o pipeline NichoCNAE seja usado somente pelo caminho de criação de novo nicho/subnicho.
 - Prevenção de recorrência: o teste de navegação OPRM valida que o link Pipeline não aparece e que a rota obsoleta não renderiza mais a tela antiga.
+
+## 2026-06-17 — OPRM NichoCNAE: diagrama de ciclos com feedback
+
+- Documentado o desenho arquitetural proposto para o pipeline NichoCNAE com ciclos encadeados, feedback estruturado e reprocessamento orientado por plano de correção.
+- Decisão técnica sugerida: tratar o Quality Gate como produtor de diagnóstico e plano, mantendo o orquestrador como único responsável por abrir novo ciclo e evitando acoplamento direto entre etapas concretas.
+- Prevenção de recorrência: o diagrama explicita `parentCycleId`, `rootCycleId`, artefatos versionados e contratos de feedback para impedir reprocessamento cego sem aprendizado do ciclo anterior.


### PR DESCRIPTION
### Motivation

- Document the proposed iterative pipeline design for NichoCNAE that uses explicit quality feedback and correction plans to avoid blind reprocessing.
- Provide a canonical class model and decision rules (cycles, artifacts, quality gate, reprocess policies) to guide implementation and architectural reviews.

### Description

- Add `docs/oprm-nichocnae-cycle-feedback-class-diagram.md` with a Mermaid class diagram and architectural notes covering `ResearchCycle`, `StageProcessor`, `QualityGateProcessor`, `ArtifactStore`, `QualityReview`, `CorrectionPlan`, enums and relationships. 
- Update `docs/registros/oprm1.md` to record the new diagram, the technical decision to treat the quality gate as a diagnostic producer, and prevention notes about `parentCycleId`/`rootCycleId` and artifact versioning. 
- This is a documentation-only change and does not modify production code.

### Testing

- No automated tests were executed for this documentation-only change.
- The registro documents prior automated runs (for example the `ArchUnit` checks and the materializer regression test) that were executed as part of earlier fixes but are not part of this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a324061a6808321902689d55d051a62)