### PR TITLE
Exige pergunta de nicho em briefing de criativos

### DIFF
--- a/ai-worker/src/main/resources/prompts/experiment/ad-image-briefing.md
+++ b/ai-worker/src/main/resources/prompts/experiment/ad-image-briefing.md
@@ -21,8 +21,11 @@ Regras fixas da etapa:
 7. O foco visual deve ser único: uma cena principal, um conflito ou resultado principal e uma hierarquia simples de texto sobreposto.
 8. Não usar dashboard, gráfico, infográfico, múltiplos cards, tela de software genérica ou composição poluída se isso não for essencial ao caso.
 9. O texto sobreposto deve ser curto, legível e coerente com a copy da variação correspondente.
-10. O briefing precisa orientar explicitamente o que incluir e o que evitar para manter a filtragem do público alvo.
-11. Não incluir campos técnicos, comentários internos, instruções de pipeline ou metadados fora do contrato final.
+10. É obrigatório que o texto sobreposto seja uma pergunta clara, completa e objetiva, capaz de filtrar imediatamente quem é verdadeiramente do nicho.
+11. Essa pergunta deve mencionar explicitamente a situação, rotina, cargo, atividade, dor ou resultado específico do nicho; se a pergunta puder servir para qualquer mercado, ela deve ser reescrita.
+12. A pergunta deve funcionar como primeiro filtro visual do anúncio: quem vive aquela realidade precisa responder mentalmente “sim, isso é sobre mim” em até 2 segundos.
+13. O briefing precisa orientar explicitamente o que incluir e o que evitar para manter a filtragem do público alvo.
+14. Não incluir campos técnicos, comentários internos, instruções de pipeline ou metadados fora do contrato final.
 
 OUTPUT_CONTRACT
 Responda em JSON válido e estritamente aderente ao artefato canônico `adImageBriefing`.
@@ -33,14 +36,16 @@ Formato obrigatório do JSON final:
 - adImageBriefing.briefings: array com exatamente 3 objetos.
 - Cada objeto deve conter exatamente: mustMatchAdVariant, visualAngle, assetType, imageTextMaxWords, visualBriefing, hierarchy, formatByPlacement, safeMargins, complianceNotes e messageMatchNotes.
 - visualAngle deve ser um dos valores permitidos pelo contrato: `dor`, `resultado` ou `prova`.
-- visualBriefing deve descrever a cena, o cliente ideal que precisa se reconhecer e os sinais visuais que filtram o público geral.
-- hierarchy deve orientar a ordem visual: foco principal, texto sobreposto curto, CTA e elemento de prova/promessa.
+- visualBriefing deve descrever a cena, o cliente ideal que precisa se reconhecer, os sinais visuais que filtram o público geral e a pergunta obrigatória que aparecerá na imagem.
+- hierarchy deve orientar a ordem visual: foco principal, pergunta sobreposta clara como primeiro filtro do nicho, CTA e elemento de prova/promessa.
 - formatByPlacement deve indicar adaptação para feed ou story vertical mantendo leitura em mobile.
 - experimentMetadata deve repetir os metadados obrigatórios recebidos no prompt base: primary_variable, variant_id, stage, control_or_treatment e asset_role.
 
 Checklist antes de responder:
 1. A imagem fala com o cliente ideal, não com público genérico?
 2. Existem sinais visuais que filtram quem é público alvo de quem não é?
-3. Cada briefing corresponde a uma variação real da copy?
-4. A cena é simples, legível e forte em mobile?
-5. O JSON final contém somente `adImageBriefing` e `experimentMetadata` na raiz?
+3. O texto sobreposto é uma pergunta clara, completa e objetiva que só faz sentido para quem é verdadeiramente do nicho?
+4. A pergunta menciona situação, rotina, cargo, atividade, dor ou resultado específico do nicho e não poderia servir para qualquer mercado?
+5. Cada briefing corresponde a uma variação real da copy?
+6. A cena é simples, legível e forte em mobile?
+7. O JSON final contém somente `adImageBriefing` e `experimentMetadata` na raiz?

--- a/docs/canonical/procedimento-experimento-canon.v1.md
+++ b/docs/canonical/procedimento-experimento-canon.v1.md
@@ -71,6 +71,8 @@ Local canônico vigente:
 - pipeline de experimento (núcleo inicial): `ai-worker/src/main/resources/prompts/experiment`;
 - pipeline de landing no Worker AI: prompts e schemas devem ser resolvidos por configuração tipada da etapa em `openai.core.<etapa>`; o caminho físico em `resources/prompts/<dominio>` é detalhe de recurso versionado e não define namespace Java do Worker AI.
 
+Regra mandatória para `AD_IMAGE_BRIEFING`: cada briefing de imagem de criativo deve orientar texto sobreposto em formato de pergunta clara, completa e objetiva, capaz de filtrar imediatamente pessoas verdadeiramente do nicho. A pergunta precisa mencionar situação, rotina, cargo, atividade, dor ou resultado específico do nicho; se puder servir para qualquer mercado, deve ser reescrita antes da resposta final.
+
 ### 4.2.1 Regra mandatória — oferta low-ticket da hipótese
 
 A etapa `hypothesis-offer` do pipeline de hipótese deve materializar uma oferta low-ticket digital, não uma oferta genérica. O objetivo é entregar um produto de entrada simples, vendável e aplicável rapidamente, que depois possa alimentar página de vendas, isca digital e campanha sem precisar redescobrir a oferta.

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -4712,3 +4712,10 @@
 
 - Ajustado o texto operacional do protocolo jobid para deixar explícito que, se o módulo/pacote já possuir uma tabela de passos compatível, ela deve ser reutilizada.
 - Decisão: evitar duplicação de tabelas e manter uma linha do tempo única por contexto operacional, criando nova tabela apenas quando não existir estrutura compatível ou houver diferença real de domínio, retenção, volume ou contrato.
+
+## 2026-06-17 — Pergunta obrigatória em criativos de anúncio
+
+- Solicitação: reforçar o prompt de imagens de criativos após observar no Experimento 39 que os criativos não comunicavam diretamente com o público desejado.
+- Causa-raiz tratada: o briefing visual exigia sinais de nicho, mas não obrigava uma pergunta textual explícita capaz de filtrar rapidamente quem realmente pertence ao nicho.
+- Correção aplicada: o prompt `ad-image-briefing` agora obriga texto sobreposto em formato de pergunta clara, completa e objetiva, mencionando situação, rotina, cargo, atividade, dor ou resultado específico do nicho.
+- Prevenção de recorrência: o cânone do procedimento de experimento passou a registrar essa regra para manter futuras alterações de prompt alinhadas ao objetivo comercial de segmentação e venda.


### PR DESCRIPTION
### Motivation
- Experimento 39 mostrou que os criativos de imagem não estavam filtrando nem comunicando diretamente com o público do nicho, exigindo reforço do briefing visual para aumentar a relevância comercial e a taxa de reconhecimento imediato.

### Description
- Reforçado o prompt `ad-image-briefing` em `ai-worker/src/main/resources/prompts/experiment/ad-image-briefing.md` para exigir que o texto sobreposto seja uma pergunta clara, completa e objetiva capaz de filtrar quem é verdadeiramente do nicho. 
- Ajustado o contrato/descrição do briefing para exigir que `visualBriefing` contenha a pergunta obrigatória e que a `hierarchy` posicione essa pergunta como primeiro filtro visual do criativo. 
- Ampliada a checklist do prompt para validar que a pergunta mencione situação, rotina, cargo, atividade, dor ou resultado específico do nicho e que não sirva para qualquer mercado.
- Documentada a regra no cânone do procedimento de experimento (`docs/canonical/procedimento-experimento-canon.v1.md`) e registrada a alteração operacional em `docs/registros/experimentos.md` com causa-raiz e prevenção de recorrência.

### Testing
- ✅ Validação por script Python que verifica presença das novas frases-chave no prompt e no cânone (`assert` checks) — passou.
- ✅ Verificação de formato do diff com `git diff --check` — passou.
- ⚠️ Execução de testes Maven dentro de `ai-worker` com `mvn -q test` foi tentada, porém bloqueada por resolução de dependência privada `com.marketinghub:ads-service:0.0.1-SNAPSHOT` retornando `401 Unauthorized` do GitHub Packages, impedindo a execução completa dos testes de Java no momento.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3283f68dd88321ac8b8df6a2c63934)