### PR TITLE
Ajusta horário da última captura MOIS para São Paulo

### DIFF
--- a/docs/registros/mois1.md
+++ b/docs/registros/mois1.md
@@ -1688,3 +1688,8 @@ Arquivos principais:
 - A etapa 2 de análise comercial foi isolada como etapa plugável em `pipeline.pageanalysis`, usando o núcleo genérico `PipelineWorker`, `StageProcessor`, `StageContext`, `StageResult` e `StageArtifact`.
 - As integrações OpenAI da análise comercial foram movidas para o pacote concreto da própria etapa, evitando vazamento de tecnologia para o núcleo do pipeline.
 - Ajustadas as regras ArchUnit do worker para validar núcleo sem dependência de etapas concretas, independência entre etapas, ausência de ciclos, processors por contrato e núcleo sem tecnologias concretas.
+
+## 2026-06-17 — Fuso horário São Paulo no pipeline de sales pages
+
+- Ajustada a tela `/mois/sales-pages-library/pipeline` para exibir o horário da última captura no fuso `America/Sao_Paulo`, evitando leitura operacional em UTC ou no fuso local do navegador.
+- Mantido o dado vindo do backend como fonte de verdade; o frontend apenas formata a data para o fuso usado pela operação no Brasil.

--- a/frontend/src/pages/mois/MoisSalesPagesPipelinePage.tsx
+++ b/frontend/src/pages/mois/MoisSalesPagesPipelinePage.tsx
@@ -28,6 +28,7 @@ function formatDateTime(value?: string) {
   return new Intl.DateTimeFormat("pt-BR", {
     dateStyle: "short",
     timeStyle: "short",
+    timeZone: "America/Sao_Paulo",
   }).format(new Date(value));
 }
 


### PR DESCRIPTION
### Motivation
- Operadores no Brasil precisam ver o horário da última captura no fuso de São Paulo para evitar confusão entre UTC e horário local operacional. 
- Manter o backend como fonte de verdade e aplicar apenas formatação de apresentação no frontend para consistência operacional.

### Description
- Atualizada a função `formatDateTime` em `frontend/src/pages/mois/MoisSalesPagesPipelinePage.tsx` para usar explicitamente o fuso `America/Sao_Paulo` na formatação de datas. 
- Registrada a alteração no histórico do módulo MOIS em `docs/registros/mois1.md` com a nota sobre o ajuste de fuso.

### Testing
- Executado `npm ci` na pasta `frontend` para instalar dependências, que concluiu com sucesso. 
- Executado `npm run typecheck` (`tsc --noEmit`) e não foram reportados erros após a instalação, validando a alteração de tipagem/compilação.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a328816c5148321a0de04605dd16e77)