### PR TITLE
Traduz a coluna "Qualidade" dos subnichos OPRM para português

### DIFF
--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -811,3 +811,9 @@
 - Causa-raiz tratada: o fluxo CNAE de oportunidade tinha contratos e serviços úteis, mas não possuía fronteira arquitetural explícita entre núcleo genérico, etapas concretas e tecnologia/infraestrutura, permitindo recorrência de acoplamento futuro entre score e enriquecimento.
 - Prevenção de recorrência: adicionadas regras ArchUnit específicas para bloquear dependência do núcleo em etapas concretas, acoplamento direto entre etapas, processors fora do contrato `StageProcessor` e tecnologia concreta no núcleo `opportunity.pipeline`.
 - Não houve alteração no backend principal; o backend permanece como API/persistência do fluxo OPRM.
+
+## 2026-06-17 — OPRM CNAE: tradução da coluna Qualidade
+
+- Ajustada a tela de detalhe do CNAE para exibir a coluna Qualidade dos subnichos em português, mantendo o status técnico vindo do backend apenas como contrato interno.
+- Causa-raiz tratada: a interface mostrava códigos técnicos como `MEI_AUDIENCE_READY` e `LIGHTLY_RESEARCHED`, reduzindo clareza operacional para priorização de nichos com potencial de venda.
+- Prevenção de recorrência: a tela passou a reutilizar o mapeamento central de status já existente no módulo OPRM, evitando novas traduções divergentes no mesmo fluxo.

--- a/frontend/src/pages/oprm/OprmCnaeDetailPlaceholderPage.test.tsx
+++ b/frontend/src/pages/oprm/OprmCnaeDetailPlaceholderPage.test.tsx
@@ -202,6 +202,69 @@ describe("OprmCnaeDetailPlaceholderPage", () => {
     expect(screen.queryByText("Em execução")).toBeNull();
   });
 
+
+  it("traduz a coluna qualidade dos subnichos gerados para portugues", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = input.toString();
+
+        if (url.includes("routine-research-cycle/stage-executions")) {
+          return new Response(JSON.stringify([]), {
+            status: 200,
+            headers: { "Content-Type": "application/json" },
+          });
+        }
+
+        if (url.includes("enriched-niches")) {
+          return new Response(
+            JSON.stringify([
+              {
+                enrichedNicheProfileId: 60,
+                marketNicheId: 21,
+                researchCycleId: 60,
+                cnaeCode: "9602501",
+                cnaeDescription: "Cabeleireiros, manicure e pedicure",
+                nicheName: "Manicure autônoma com agenda recorrente",
+                qualityStatus: "MEI_AUDIENCE_READY",
+                routineEvidenceScore: 84,
+                difficultyEvidenceScore: 82,
+                sourceDiversityScore: 100,
+                materializedAt: "2026-06-15T17:39:00Z",
+              },
+              {
+                enrichedNicheProfileId: 11,
+                marketNicheId: 18,
+                researchCycleId: 11,
+                cnaeCode: "9602501",
+                cnaeDescription: "Cabeleireiros, manicure e pedicure",
+                nicheName: "Cabeleireiros, manicure e pedicure",
+                qualityStatus: "LIGHTLY_RESEARCHED",
+                routineEvidenceScore: 82,
+                difficultyEvidenceScore: 84,
+                sourceDiversityScore: 100,
+                materializedAt: "2026-06-09T00:40:00Z",
+              },
+            ]),
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          );
+        }
+
+        return new Response("{}", {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }),
+    );
+
+    renderPage();
+
+    expect(await screen.findByText("Público MEI/autônomo pronto")).toBeTruthy();
+    expect(screen.getByText("Pesquisa inicial concluída")).toBeTruthy();
+    expect(screen.queryByText("MEI_AUDIENCE_READY")).toBeNull();
+    expect(screen.queryByText("LIGHTLY_RESEARCHED")).toBeNull();
+  });
+
   it("informa quando o ciclo atual foi reprocessado automaticamente com aprendizado", async () => {
     vi.stubGlobal(
       "fetch",

--- a/frontend/src/pages/oprm/OprmCnaeDetailPlaceholderPage.tsx
+++ b/frontend/src/pages/oprm/OprmCnaeDetailPlaceholderPage.tsx
@@ -863,7 +863,7 @@ export default function OprmCnaeDetailPlaceholderPage() {
                           {niche.enrichedNicheProfileId}
                         </span>
                       </td>
-                      <td>{niche.qualityStatus}</td>
+                      <td>{statusLabel(niche.qualityStatus)}</td>
                       <td>#{niche.researchCycleId}</td>
                       <td>
                         Rotina {niche.routineEvidenceScore} · Dor{" "}


### PR DESCRIPTION
### Motivation
- Tornar a coluna `Qualidade` da lista de subnichos mais legível para operadores, evitando exibir códigos técnicos (ex.: `MEI_AUDIENCE_READY`, `LIGHTLY_RESEARCHED`) diretamente para o usuário. 
- Manter o contrato do backend inalterado e aplicar a tradução apenas na camada de apresentação para preservar integridade dos dados.

### Description
- Substitui a exibição direta de `niche.qualityStatus` por `statusLabel(niche.qualityStatus)` em `frontend/src/pages/oprm/OprmCnaeDetailPlaceholderPage.tsx` para mostrar rótulos em português. 
- Adiciona um teste em `frontend/src/pages/oprm/OprmCnaeDetailPlaceholderPage.test.tsx` que valida a tradução de `MEI_AUDIENCE_READY` e `LIGHTLY_RESEARCHED` e garante que os códigos técnicos não apareçam na UI. 
- Registra a alteração no histórico operacional em `docs/registros/oprm1.md` com causa-raiz e prevenção de recorrência. 
- Não há mudanças no backend nem no contrato da API; a alteração é puramente de UI e testes.

### Testing
- Executado o teste específico com `npm test -- --run src/pages/oprm/OprmCnaeDetailPlaceholderPage.test.tsx`, que retornou sucesso com todas as especificações passando (4 tests). 
- Executado o `typecheck` com `npm run typecheck` / `tsc --noEmit`, que concluiu sem erros.
- Não foram necessárias alterações em testes do backend ou no contrato API, pois o mapeamento é local ao frontend.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3287ba6aec8321af1712faf0bc5145)