### PR TITLE
feat(oprm): add animated pipeline running indicator

### DIFF
--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -1,3 +1,7 @@
+## 2026-06-17 17:06:25 (UTC) — OPRM NichoCNAE: indicador animado de execução
+
+- Ajustada a tela de detalhe do CNAE/subnicho para exibir uma ilustração animada quando o pipeline NichoCNAE estiver em execução, reforçando visualmente que o backend continua processando as etapas automaticamente.
+
 ## 2026-06-14 00:00:00 (UTC) — OPRM NichoCNAE: múltiplos nichos por CNAE
 
 - Alterado o conceito de materialização para permitir mais de um `market_niche` por CNAE quando ciclos aprovados representarem subnichos diferentes.

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -44,7 +44,9 @@
 .funnel-step-card {
   background: linear-gradient(135deg, #f8faff 0%, #eef3ff 100%);
   border: 1px solid rgba(88, 102, 242, 0.18);
-  transition: transform 0.2s ease, box-shadow 0.2s ease;
+  transition:
+    transform 0.2s ease,
+    box-shadow 0.2s ease;
 }
 
 .funnel-step-card:hover,
@@ -95,4 +97,96 @@
   border: 1px solid var(--bs-border-color);
   padding: 0.5rem;
   vertical-align: top;
+}
+
+.pipeline-running-illustration {
+  width: 4rem;
+  height: 4rem;
+  position: relative;
+  flex: 0 0 auto;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.pipeline-running-illustration__orbit {
+  position: absolute;
+  inset: 0.2rem;
+  border: 0.18rem solid rgba(13, 110, 253, 0.18);
+  border-top-color: rgba(13, 110, 253, 0.85);
+  border-radius: 999px;
+  animation: pipeline-running-spin 1.15s linear infinite;
+}
+
+.pipeline-running-illustration__core {
+  width: 2.55rem;
+  height: 2.55rem;
+  border-radius: 999px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  color: #0d6efd;
+  background: #ffffff;
+  box-shadow: 0 0.45rem 1.25rem rgba(13, 110, 253, 0.25);
+  animation: pipeline-running-pulse 1.45s ease-in-out infinite;
+}
+
+.pipeline-running-illustration__dot,
+.pipeline-stage-running-dot {
+  border-radius: 999px;
+  background: #0d6efd;
+}
+
+.pipeline-running-illustration__dot {
+  width: 0.55rem;
+  height: 0.55rem;
+  position: absolute;
+  box-shadow: 0 0 0 0.25rem rgba(13, 110, 253, 0.12);
+}
+
+.pipeline-running-illustration__dot--one {
+  top: 0.1rem;
+  right: 0.65rem;
+  animation: pipeline-running-blink 0.9s ease-in-out infinite;
+}
+
+.pipeline-running-illustration__dot--two {
+  bottom: 0.3rem;
+  left: 0.55rem;
+  animation: pipeline-running-blink 0.9s ease-in-out 0.35s infinite;
+}
+
+.pipeline-stage-running-dot {
+  width: 0.45rem;
+  height: 0.45rem;
+  display: inline-block;
+  animation: pipeline-running-blink 0.85s ease-in-out infinite;
+}
+
+@keyframes pipeline-running-spin {
+  to {
+    transform: rotate(360deg);
+  }
+}
+
+@keyframes pipeline-running-pulse {
+  0%,
+  100% {
+    transform: scale(1);
+  }
+  50% {
+    transform: scale(1.08);
+  }
+}
+
+@keyframes pipeline-running-blink {
+  0%,
+  100% {
+    opacity: 0.35;
+    transform: scale(0.8);
+  }
+  50% {
+    opacity: 1;
+    transform: scale(1.15);
+  }
 }

--- a/frontend/src/pages/oprm/OprmCnaeDetailPlaceholderPage.tsx
+++ b/frontend/src/pages/oprm/OprmCnaeDetailPlaceholderPage.tsx
@@ -1,4 +1,4 @@
-import { Globe2, Sparkles } from "lucide-react";
+import { Activity, Globe2, Sparkles } from "lucide-react";
 import { useState } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
 import {
@@ -213,6 +213,15 @@ function statusLabel(status?: string | null) {
 
 function isQualityBlockedStatus(status?: string | null) {
   return Boolean(status && qualityBlockedStatuses.has(status));
+}
+
+function isCycleRunningStatus(cycle?: OprmRoutineResearchCycleSummary | null) {
+  return Boolean(
+    cycle &&
+    !cycle.finishedAt &&
+    !isCycleStoppedStatus(cycle.status) &&
+    cycle.status !== "ENRICHED_NICHE_CREATED",
+  );
 }
 
 function isCycleStoppedStatus(status?: string | null) {
@@ -925,13 +934,35 @@ export default function OprmCnaeDetailPlaceholderPage() {
 
             {latestCycle ? (
               <div className={pipelineAlertClass(latestCycle.status)}>
-                <div>
-                  Status atual:{" "}
-                  <strong>{statusLabel(latestCycle.status)}</strong> · iniciado
-                  em {formatDateTime(latestCycle.startedAt)} · sinais extraídos:{" "}
-                  {formatNumber(latestCycle.totalExtractedSignals)} · custo do
-                  job atual:{" "}
-                  <strong>{formatUsd(latestCycle.executionCostUsd)}</strong>
+                <div className="d-flex flex-wrap align-items-center gap-3">
+                  {isCycleRunningStatus(latestCycle) ? (
+                    <div
+                      className="pipeline-running-illustration"
+                      aria-label="Pipeline em execução"
+                      role="img"
+                    >
+                      <span className="pipeline-running-illustration__orbit" />
+                      <span className="pipeline-running-illustration__core">
+                        <Activity size={26} aria-hidden="true" />
+                      </span>
+                      <span className="pipeline-running-illustration__dot pipeline-running-illustration__dot--one" />
+                      <span className="pipeline-running-illustration__dot pipeline-running-illustration__dot--two" />
+                    </div>
+                  ) : null}
+                  <div>
+                    Status atual:{" "}
+                    <strong>{statusLabel(latestCycle.status)}</strong> ·
+                    iniciado em {formatDateTime(latestCycle.startedAt)} · sinais
+                    extraídos: {formatNumber(latestCycle.totalExtractedSignals)}{" "}
+                    · custo do job atual:{" "}
+                    <strong>{formatUsd(latestCycle.executionCostUsd)}</strong>
+                    {isCycleRunningStatus(latestCycle) ? (
+                      <span className="d-block small fw-semibold text-primary mt-1">
+                        Processando automaticamente. A tela acompanha o avanço
+                        pelas etapas abaixo.
+                      </span>
+                    ) : null}
+                  </div>
                 </div>
                 {qualityBlockedMessage(latestCycle.status) ? (
                   <div className="mt-2">
@@ -1038,7 +1069,13 @@ export default function OprmCnaeDetailPlaceholderPage() {
                               </span>
                             ) : null}
                           </div>
-                          <span className="badge text-bg-light">
+                          <span className="badge text-bg-light d-inline-flex align-items-center gap-1">
+                            {state.label === "Em execução" ? (
+                              <span
+                                className="pipeline-stage-running-dot"
+                                aria-hidden="true"
+                              />
+                            ) : null}
                             {state.label}
                           </span>
                         </div>


### PR DESCRIPTION
### Motivation
- Improve the UX of the OPRM CNAE detail view by making it explicit when a pipeline cycle is actively executing so users understand the backend is still processing. 

### Description
- Added a running illustration and small status message to the pipeline status area when a cycle is executing by introducing `isCycleRunningStatus` and rendering an animated indicator in `frontend/src/pages/oprm/OprmCnaeDetailPlaceholderPage.tsx`.
- Added a pulsing dot to the active stage badge so the exact stage in progress is visually identifiable in `OprmCnaeDetailPlaceholderPage.tsx`.
- Implemented the required CSS animations and styles in `frontend/src/App.css` for the orbit, core pulse and blinking dots.
- Registered the UI change in the OPRM records document `docs/registros/oprm1.md`.

### Testing
- Ran type checking with `npm run typecheck` in the frontend and it completed without type errors.
- Built the frontend with `npm run build` and the production build completed successfully.
- Attempted a Playwright screenshot to validate the visual result but the container lacked Playwright/browser tooling, so that capture was not performed (this does not affect the successful typecheck/build results).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a32d3c007308321bafd113ce7134c5a)