### PR TITLE
Mostra subnicho identificado durante execução do pipeline NichoCNAE

### DIFF
--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -817,3 +817,7 @@
 - Ajustada a tela de detalhe do CNAE para exibir a coluna Qualidade dos subnichos em português, mantendo o status técnico vindo do backend apenas como contrato interno.
 - Causa-raiz tratada: a interface mostrava códigos técnicos como `MEI_AUDIENCE_READY` e `LIGHTLY_RESEARCHED`, reduzindo clareza operacional para priorização de nichos com potencial de venda.
 - Prevenção de recorrência: a tela passou a reutilizar o mapeamento central de status já existente no módulo OPRM, evitando novas traduções divergentes no mesmo fluxo.
+
+## 2026-06-17 — OPRM NichoCNAE: nome do subnicho na execução
+
+- Ajustada a tela de subnichos do CNAE para destacar, durante a execução do pipeline NichoCNAE, o nome do subnicho identificado pelo backend no ciclo selecionado.

--- a/frontend/src/pages/oprm/OprmCnaeDetailPlaceholderPage.test.tsx
+++ b/frontend/src/pages/oprm/OprmCnaeDetailPlaceholderPage.test.tsx
@@ -202,6 +202,62 @@ describe("OprmCnaeDetailPlaceholderPage", () => {
     expect(screen.queryByText("Em execução")).toBeNull();
   });
 
+  it("mostra o nome do subnicho identificado durante a execução do pipeline", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = input.toString();
+
+        if (url.includes("routine-research-cycle/stage-executions")) {
+          return new Response(
+            JSON.stringify([
+              {
+                researchCycleId: 61,
+                sourceNicheId: 18,
+                cnaeCode: "9602501",
+                nicheName: "Manicure autônoma com agenda recorrente",
+                originalNicheName: "Cabeleireiros, manicure e pedicure",
+                neutralNicheName: "Manicure autônoma com agenda recorrente",
+                researchMode: "ROUTINE_REALITY_RESEARCH",
+                solutionLanguageRiskScore: 10,
+                sourceScore: 90,
+                triggerSource: "MANUAL_CNAE_DETAIL",
+                status: "RUNNING",
+                totalQueries: 12,
+                totalSourceCandidates: 20,
+                totalSourceSnapshots: 4,
+                totalExtractedSignals: 0,
+                executionCostUsd: 0.0377,
+                cnaeTotalCostUsd: 0.0377,
+                startedAt: "2026-06-17T14:03:00Z",
+                finishedAt: null,
+                errorMessage: null,
+              },
+            ]),
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          );
+        }
+
+        return new Response("{}", {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }),
+    );
+
+    renderPage();
+
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Criar novo subnicho" }),
+    );
+
+    expect(
+      await screen.findByText("Subnicho identificado neste pipeline"),
+    ).toBeTruthy();
+    expect(
+      screen.getByText("Manicure autônoma com agenda recorrente"),
+    ).toBeTruthy();
+  });
 
   it("traduz a coluna qualidade dos subnichos gerados para portugues", async () => {
     vi.stubGlobal(

--- a/frontend/src/pages/oprm/OprmCnaeDetailPlaceholderPage.tsx
+++ b/frontend/src/pages/oprm/OprmCnaeDetailPlaceholderPage.tsx
@@ -651,6 +651,9 @@ export default function OprmCnaeDetailPlaceholderPage() {
     qualityGateQuery.data?.qualityNotes,
     "proximoMovimento",
   );
+  const identifiedSubnicheName = latestCycle
+    ? (latestCycle.neutralNicheName ?? latestCycle.nicheName)?.trim()
+    : "";
   const cnaeDescription =
     volumeQuery.data?.cnaeDescription ??
     scoreQuery.data?.cnaeDescription ??
@@ -933,6 +936,14 @@ export default function OprmCnaeDetailPlaceholderPage() {
                   job atual:{" "}
                   <strong>{formatUsd(latestCycle.executionCostUsd)}</strong>
                 </div>
+                {identifiedSubnicheName ? (
+                  <div className="alert alert-light border mt-3 mb-0 py-2 px-3">
+                    <span className="small text-secondary d-block">
+                      Subnicho identificado neste pipeline
+                    </span>
+                    <strong>{identifiedSubnicheName}</strong>
+                  </div>
+                ) : null}
                 {qualityBlockedMessage(latestCycle.status) ? (
                   <div className="mt-2">
                     <p className="mb-2">


### PR DESCRIPTION
### Motivation
- Tornar visível na interface, durante a execução do pipeline NichoCNAE, o nome do subnicho que o backend identificou para facilitar acompanhamento operacional e priorização.
- Preferir o nome operacional neutro enviado pelo backend (`neutralNicheName`) e usar `nicheName` como fallback para garantir informação mesmo quando um campo estiver vazio.

### Description
- Adiciona no componente `frontend/src/pages/oprm/OprmCnaeDetailPlaceholderPage.tsx` a variável `identifiedSubnicheName` que toma `latestCycle.neutralNicheName ?? latestCycle.nicheName` e exibe um bloco de destaque com o nome quando presente.
- Insere um bloco UI (`alert alert-light border`) mostrando o título `Subnicho identificado neste pipeline` seguido do nome identificado, posicionado junto ao resumo do ciclo em execução.
- Adiciona teste de tela em `frontend/src/pages/oprm/OprmCnaeDetailPlaceholderPage.test.tsx` que valida a aparição do bloco e do nome do subnicho enquanto o ciclo está `RUNNING`.
- Atualiza o registro operacional em `docs/registros/oprm1.md` documentando a mudança de interface.

### Testing
- Executado `npm install` para instalar dependências e `npx prettier --write` para formatar os arquivos modificados, ambos concluídos com sucesso.
- Rodado o teste específico com `npm test -- --run src/pages/oprm/OprmCnaeDetailPlaceholderPage.test.tsx` e a suíte reportou `1 file, 5 tests` com todos os testes passando.
- Executado `npm run typecheck` (`tsc --noEmit`) e a checagem de tipos passou sem erros.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a32d45d93b08321bf9385b291a00fd8)