### PR TITLE
Mostrar Custo total do nicho na lista de Testes de Nicho (substitui coluna Valor)

### DIFF
--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -4724,3 +4724,8 @@
 
 - Ajustada a tela de solicitações recentes de targeting para mostrar o motivo da decisão operacional diretamente no card do candidato, usando a verdade já exposta pelo backend (`rationale` ou `rejection_reason`) e evitando que o operador interprete score/status sem causa-raiz visível.
 - O ajuste reduz ambiguidade entre candidato ranqueado, candidato pendente, candidato validado e candidato bloqueado, deixando a próxima ação mais clara para operação de campanhas.
+
+## 2026-06-17 — Coluna de custo total do nicho em Testes de Nicho
+
+- Ajustada a lista de Testes de Nicho para substituir a coluna **Valor** por **Custo**.
+- A coluna agora mostra o custo total acumulado do nicho, calculado a partir dos custos dos experimentos retornados pelo backend, mantendo a tela orientada ao controle financeiro do nicho.

--- a/frontend/src/pages/experiment/ExperimentListPage.test.tsx
+++ b/frontend/src/pages/experiment/ExperimentListPage.test.tsx
@@ -47,7 +47,7 @@ describe("ExperimentListPage", () => {
         hypothesisId: `hypothesis-${id}`,
         name: `Experimento ${id}`,
         hypothesis: `Hipótese ${id}`,
-        unitPrice: id,
+        cost: id,
         startDate: `2026-06-${String(id).padStart(2, "0")}`,
         endDate: null,
         creativeApproved: false,
@@ -96,7 +96,7 @@ describe("ExperimentListPage", () => {
     ).toBeTruthy();
     expect(screen.getByRole("columnheader", { name: "Nicho" })).toBeTruthy();
     expect(screen.getByRole("columnheader", { name: "Hipótese" })).toBeTruthy();
-    expect(screen.getByRole("columnheader", { name: "Valor" })).toBeTruthy();
+    expect(screen.getByRole("columnheader", { name: "Custo" })).toBeTruthy();
     expect(screen.getByRole("columnheader", { name: "Status" })).toBeTruthy();
     expect(
       screen.getByRole("columnheader", { name: "Botões/Ações" }),
@@ -125,7 +125,7 @@ describe("ExperimentListPage", () => {
       within(row as HTMLTableRowElement).getByText("Nicho Principal"),
     ).toBeTruthy();
     expect(
-      within(row as HTMLTableRowElement).getByText("R$ 1,00"),
+      within(row as HTMLTableRowElement).getByText("R$ 351,00"),
     ).toBeTruthy();
   });
 });

--- a/frontend/src/pages/experiment/ExperimentListPage.tsx
+++ b/frontend/src/pages/experiment/ExperimentListPage.tsx
@@ -261,7 +261,7 @@ export default function ExperimentListPage() {
               <th>Data de criação</th>
               <th>Nicho</th>
               <th>Hipótese</th>
-              <th>Valor</th>
+              <th>Custo</th>
               <th>Status</th>
               <th>Botões/Ações</th>
             </tr>
@@ -281,7 +281,7 @@ export default function ExperimentListPage() {
                   </td>
                   <td>{e.hypothesis || "—"}</td>
                   <td>
-                    {formatCurrency(e.unitPrice ?? resolveExperimentCost(e))}
+                    {formatCurrency(nicheTotalCostMap[e.nicheId] ?? 0)}
                   </td>
                   <td>{e.status}</td>
                   <td>


### PR DESCRIPTION
### Motivation
- A lista de Testes de Nicho deve evidenciar o custo financeiro agregado do nicho em vez de mostrar apenas um valor unitário por experimento para facilitar controle financeiro por nicho.

### Description
- Substitui o cabeçalho da coluna `Valor` por `Custo` em `frontend/src/pages/experiment/ExperimentListPage.tsx` e altera a célula para exibir `nicheTotalCostMap[e.nicheId]` (soma dos custos por `nicheId`).
- Reutiliza o `nicheTotalCostMap` já calculado a partir dos experimentos para apresentar o custo total acumulado do nicho na linha do experimento. 
- Atualiza o teste `frontend/src/pages/experiment/ExperimentListPage.test.tsx` para fornecer `cost` nos dados fictícios e validar o novo cabeçalho `Custo` e o valor agregado esperado. 
- Registra a mudança operacional em `docs/registros/experimentos.md` para manter o histórico canônico do projeto.

### Testing
- Ran the focused unit test file with `npm test -- --run src/pages/experiment/ExperimentListPage.test.tsx` and the test suite passed (2 tests). 
- Ran TypeScript checks with `npm run typecheck` and `tsc --noEmit` completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a32ee71d868832186653aa38b2e4497)