### PR TITLE
feat(oprm): show pending CNAE subniche cycles

### DIFF
--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -844,3 +844,9 @@
 - Causa-raiz tratada: serviços do OPRM importavam `MarketNiche`, `MarketNicheEnrichmentProfile` e repositories de `niche`, violando a fronteira arquitetural validada pelo ArchUnit.
 - Correção aplicada: o OPRM passou a depender apenas de uma porta canônica própria (`OprmEnrichedNicheGateway`), enquanto o adaptador JPA que conhece o domínio `niche` ficou fora do pacote OPRM.
 - Prevenção de recorrência: a regra ArchUnit `oprmMustNotDependOnOtherMarketingHubPackages` foi validada junto com os testes de serviço afetados.
+
+## 2026-06-17 — OPRM CNAE: visibilidade de subnichos em processamento
+
+- Ajustada a tela de subnichos do CNAE para exibir os ciclos iniciados que ainda não foram materializados como subnicho final.
+- Causa-raiz tratada: o usuário conseguia iniciar um novo subnicho, sair da tela e, ao voltar, enxergava apenas subnichos já materializados, perdendo o acesso operacional a ciclos ainda em processamento.
+- Prevenção de recorrência: a tela agora cruza a verdade dos ciclos do backend com a lista de subnichos materializados e mantém uma seção fixa “Em processamento antes de virar subnicho” com ação de acompanhamento.

--- a/frontend/src/pages/oprm/OprmCnaeDetailPlaceholderPage.test.tsx
+++ b/frontend/src/pages/oprm/OprmCnaeDetailPlaceholderPage.test.tsx
@@ -255,8 +255,116 @@ describe("OprmCnaeDetailPlaceholderPage", () => {
       await screen.findByText("Subnicho identificado neste pipeline"),
     ).toBeTruthy();
     expect(
-      screen.getByText("Manicure autônoma com agenda recorrente"),
+      screen.getAllByText("Manicure autônoma com agenda recorrente").length,
+    ).toBeGreaterThan(0);
+  });
+
+  it("lista ciclos em processamento que ainda nao viraram subnicho", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = input.toString();
+
+        if (url.includes("routine-research-cycle/stage-executions")) {
+          return new Response(
+            JSON.stringify([
+              {
+                researchCycleId: 62,
+                sourceNicheId: 18,
+                cnaeCode: "9602501",
+                nicheName: "Manicure autônoma para atendimento em domicílio",
+                originalNicheName: "Cabeleireiros, manicure e pedicure",
+                neutralNicheName:
+                  "Manicure autônoma para atendimento em domicílio",
+                researchMode: "ROUTINE_REALITY_RESEARCH",
+                solutionLanguageRiskScore: 10,
+                sourceScore: 90,
+                triggerSource: "MANUAL_CNAE_DETAIL",
+                status: "RUNNING",
+                totalQueries: 4,
+                totalSourceCandidates: 8,
+                totalSourceSnapshots: 0,
+                totalExtractedSignals: 0,
+                executionCostUsd: 0.015,
+                cnaeTotalCostUsd: 0.0377,
+                startedAt: "2026-06-17T14:03:00Z",
+                finishedAt: null,
+                errorMessage: null,
+              },
+              {
+                researchCycleId: 60,
+                sourceNicheId: 18,
+                cnaeCode: "9602501",
+                nicheName: "Manicure autônoma com agenda recorrente",
+                originalNicheName: "Cabeleireiros, manicure e pedicure",
+                neutralNicheName: "Manicure autônoma com agenda recorrente",
+                researchMode: "ROUTINE_REALITY_RESEARCH",
+                solutionLanguageRiskScore: 10,
+                sourceScore: 90,
+                triggerSource: "MANUAL_CNAE_DETAIL",
+                status: "ENRICHED_NICHE_CREATED",
+                totalQueries: 12,
+                totalSourceCandidates: 20,
+                totalSourceSnapshots: 4,
+                totalExtractedSignals: 0,
+                executionCostUsd: 0.0227,
+                cnaeTotalCostUsd: 0.0377,
+                startedAt: "2026-06-15T17:03:00Z",
+                finishedAt: "2026-06-15T17:39:00Z",
+                errorMessage: null,
+              },
+            ]),
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          );
+        }
+
+        if (url.includes("enriched-niches")) {
+          return new Response(
+            JSON.stringify([
+              {
+                enrichedNicheProfileId: 60,
+                marketNicheId: 21,
+                researchCycleId: 60,
+                cnaeCode: "9602501",
+                cnaeDescription: "Cabeleireiros, manicure e pedicure",
+                nicheName: "Manicure autônoma com agenda recorrente",
+                qualityStatus: "MEI_AUDIENCE_READY",
+                routineEvidenceScore: 84,
+                difficultyEvidenceScore: 82,
+                sourceDiversityScore: 100,
+                materializedAt: "2026-06-15T17:39:00Z",
+              },
+            ]),
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          );
+        }
+
+        return new Response("{}", {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }),
+    );
+
+    renderPage();
+
+    expect(
+      await screen.findByText("Em processamento antes de virar subnicho"),
     ).toBeTruthy();
+    expect(
+      await screen.findByText((_, element) =>
+        Boolean(element?.textContent?.trim() === "1 em aberto"),
+      ),
+    ).toBeTruthy();
+    expect(
+      await screen.findByText(
+        "Manicure autônoma para atendimento em domicílio",
+      ),
+    ).toBeTruthy();
+    expect(
+      screen.getByText("Ainda não virou subnicho materializado"),
+    ).toBeTruthy();
+    expect(screen.getByText("#62")).toBeTruthy();
   });
 
   it("traduz a coluna qualidade dos subnichos gerados para portugues", async () => {

--- a/frontend/src/pages/oprm/OprmCnaeDetailPlaceholderPage.tsx
+++ b/frontend/src/pages/oprm/OprmCnaeDetailPlaceholderPage.tsx
@@ -163,6 +163,22 @@ function findPreviousCycle(
   );
 }
 
+function findPendingCyclesBeforeEnrichedNiche(
+  cycles?: OprmRoutineResearchCycleSummary[],
+  enrichedNiches?: { researchCycleId: number }[],
+) {
+  const safeEnrichedNiches = Array.isArray(enrichedNiches)
+    ? enrichedNiches
+    : [];
+  const safeCycles = Array.isArray(cycles) ? cycles : [];
+  const materializedCycleIds = new Set(
+    safeEnrichedNiches.map((niche) => niche.researchCycleId),
+  );
+  return safeCycles.filter(
+    (cycle) => !materializedCycleIds.has(cycle.researchCycleId),
+  );
+}
+
 function automaticProcessMessage(
   latestCycle?: OprmRoutineResearchCycleSummary | null,
   previousCycle?: OprmRoutineResearchCycleSummary | null,
@@ -625,6 +641,10 @@ export default function OprmCnaeDetailPlaceholderPage() {
   const generatedNichesQuery =
     useOprmGeneratedEnrichedNichesByCnae(decodedCnaeCode);
   const startPipelineMutation = useStartOprmCnaePipeline(decodedCnaeCode);
+  const pendingCyclesBeforeEnrichedNiche = findPendingCyclesBeforeEnrichedNiche(
+    cyclesQuery.data,
+    generatedNichesQuery.data,
+  );
   const latestCycle = selectedResearchCycleId
     ? cyclesQuery.data?.find(
         (cycle) => cycle.researchCycleId === selectedResearchCycleId,
@@ -905,6 +925,88 @@ export default function OprmCnaeDetailPlaceholderPage() {
               subnicho” para iniciar a análise.
             </div>
           ) : null}
+
+          <div className="border rounded-3 p-3 bg-light">
+            <div className="d-flex flex-wrap justify-content-between gap-2 align-items-start mb-3">
+              <div>
+                <h3 className="h6 mb-1">
+                  Em processamento antes de virar subnicho
+                </h3>
+                <p className="small text-secondary mb-0">
+                  Ciclos iniciados para este CNAE que ainda não materializaram
+                  um subnicho final. Use “Acompanhar” para voltar ao ponto exato
+                  da execução mesmo depois de sair da tela.
+                </p>
+              </div>
+              <span className="badge text-bg-primary">
+                {pendingCyclesBeforeEnrichedNiche.length} em aberto
+              </span>
+            </div>
+            {cyclesQuery.isLoading || generatedNichesQuery.isLoading ? (
+              <div className="alert alert-light border mb-0" role="status">
+                Carregando processamentos em aberto...
+              </div>
+            ) : null}
+            {cyclesQuery.isError ? (
+              <div className="alert alert-warning mb-0" role="alert">
+                Não foi possível carregar os processamentos em aberto deste
+                CNAE.
+              </div>
+            ) : null}
+            {!cyclesQuery.isLoading &&
+            !generatedNichesQuery.isLoading &&
+            !cyclesQuery.isError &&
+            pendingCyclesBeforeEnrichedNiche.length ? (
+              <div className="table-responsive">
+                <table className="table table-sm align-middle mb-0">
+                  <thead>
+                    <tr>
+                      <th scope="col">Subnicho em análise</th>
+                      <th scope="col">Status</th>
+                      <th scope="col">Ciclo</th>
+                      <th scope="col">Início</th>
+                      <th scope="col" className="text-end">
+                        Ação
+                      </th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    {pendingCyclesBeforeEnrichedNiche.map((cycle) => (
+                      <tr key={cycle.researchCycleId}>
+                        <td>
+                          <div className="fw-semibold">
+                            {cycle.neutralNicheName ?? cycle.nicheName}
+                          </div>
+                          <span className="small text-secondary">
+                            Ainda não virou subnicho materializado
+                          </span>
+                        </td>
+                        <td>{statusLabel(cycle.status)}</td>
+                        <td>#{cycle.researchCycleId}</td>
+                        <td>{formatDateTime(cycle.startedAt)}</td>
+                        <td className="text-end">
+                          <Link
+                            className="btn btn-outline-primary btn-sm"
+                            to={`/oprm/cnaes/${encodeURIComponent(decodedCnaeCode)}/subnichos/${cycle.researchCycleId}`}
+                          >
+                            Acompanhar
+                          </Link>
+                        </td>
+                      </tr>
+                    ))}
+                  </tbody>
+                </table>
+              </div>
+            ) : null}
+            {!cyclesQuery.isLoading &&
+            !generatedNichesQuery.isLoading &&
+            !cyclesQuery.isError &&
+            !pendingCyclesBeforeEnrichedNiche.length ? (
+              <div className="alert alert-secondary mb-0">
+                Nenhum processamento em aberto para este CNAE agora.
+              </div>
+            ) : null}
+          </div>
         </div>
       </section>
 


### PR DESCRIPTION
### Motivation
- Users could start a subnicho pipeline, leave the CNAE detail screen and, on return, only see materialized subnichos while in-progress cycles disappeared. 
- The UI must reflect backend truth and surface cycles that were started but not yet materialized so the user can resume/inspect them. 
- Avoid local inference of final state on the client and keep an explicit path to `Acompanhar` each running cycle.

### Description
- Added `findPendingCyclesBeforeEnrichedNiche` to compute cycles that have not been materialized by cross-referencing `routine-research-cycle/stage-executions` with `enriched-niches`. 
- Integrated the helper into `OprmCnaeDetailPlaceholderPage.tsx` and rendered a new fixed section "Em processamento antes de virar subnicho" with a table of pending cycles and an `Acompanhar` link for each cycle. 
- Added a regression test `lista ciclos em processamento que ainda nao viraram subnicho` and adjusted related assertions in `OprmCnaeDetailPlaceholderPage.test.tsx`, and recorded the change in `docs/registros/oprm1.md`.

### Testing
- Ran the focused test suite with `npm --prefix frontend test -- OprmCnaeDetailPlaceholderPage.test.tsx --run` and all tests passed (6/6). 
- Ran the TypeScript check with `npm --prefix frontend run typecheck` (`tsc --noEmit`) with no type errors. 
- Attempted an end-to-end screenshot via Playwright but the container lacks Playwright/Chromium tooling, so this step was not executed; unit tests and typecheck succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a32f09fc8908321bf4c6719b761e1e2)