### PR TITLE
Corrige acompanhamento de subnichos OPRM

### DIFF
--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -850,3 +850,9 @@
 - Ajustada a tela de subnichos do CNAE para exibir os ciclos iniciados que ainda não foram materializados como subnicho final.
 - Causa-raiz tratada: o usuário conseguia iniciar um novo subnicho, sair da tela e, ao voltar, enxergava apenas subnichos já materializados, perdendo o acesso operacional a ciclos ainda em processamento.
 - Prevenção de recorrência: a tela agora cruza a verdade dos ciclos do backend com a lista de subnichos materializados e mantém uma seção fixa “Em processamento antes de virar subnicho” com ação de acompanhamento.
+
+## 2026-06-17 — OPRM CNAE: botões Acompanhar abrem cards do pipeline
+
+- Corrigida a navegação dos botões “Acompanhar” na tela de subnichos do CNAE para exibir automaticamente a visão dedicada com cards das etapas do pipeline quando a URL contém o ciclo selecionado.
+- Causa-raiz tratada: o componente era reutilizado pelo React Router entre a lista de subnichos e a rota `/subnichos/:researchCycleId`, mas o estado local que mostra o pipeline só era inicializado na primeira montagem; ao clicar em “Acompanhar”, a URL mudava e a tela permanecia na lista.
+- Prevenção de recorrência: adicionado teste de regressão cobrindo acesso direto à rota de subnicho e validando a exibição dos cards do pipeline para consulta do usuário.

--- a/frontend/src/pages/oprm/OprmCnaeDetailPlaceholderPage.test.tsx
+++ b/frontend/src/pages/oprm/OprmCnaeDetailPlaceholderPage.test.tsx
@@ -5,7 +5,7 @@ import { MemoryRouter, Route, Routes } from "react-router-dom";
 import { afterEach, describe, expect, it, vi } from "vitest";
 import OprmCnaeDetailPlaceholderPage from "./OprmCnaeDetailPlaceholderPage";
 
-function renderPage() {
+function renderPage(initialEntry = "/oprm/cnaes/9602501") {
   const client = new QueryClient({
     defaultOptions: {
       queries: {
@@ -16,10 +16,14 @@ function renderPage() {
 
   return render(
     <QueryClientProvider client={client}>
-      <MemoryRouter initialEntries={["/oprm/cnaes/9602501"]}>
+      <MemoryRouter initialEntries={[initialEntry]}>
         <Routes>
           <Route
             path="/oprm/cnaes/:cnaeCode"
+            element={<OprmCnaeDetailPlaceholderPage />}
+          />
+          <Route
+            path="/oprm/cnaes/:cnaeCode/subnichos/:researchCycleId"
             element={<OprmCnaeDetailPlaceholderPage />}
           />
         </Routes>
@@ -365,6 +369,80 @@ describe("OprmCnaeDetailPlaceholderPage", () => {
       screen.getByText("Ainda não virou subnicho materializado"),
     ).toBeTruthy();
     expect(screen.getByText("#62")).toBeTruthy();
+  });
+
+  it("abre os cards do pipeline ao acessar um subnicho pelo botao acompanhar", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(async (input: RequestInfo | URL) => {
+        const url = input.toString();
+
+        if (url.includes("routine-research-cycle/stage-executions")) {
+          return new Response(
+            JSON.stringify([
+              {
+                researchCycleId: 60,
+                sourceNicheId: 18,
+                cnaeCode: "9602501",
+                nicheName: "Manicure autônoma com agenda recorrente",
+                neutralNicheName: "Manicure autônoma com agenda recorrente",
+                triggerSource: "MANUAL_CNAE_DETAIL",
+                status: "ENRICHED_NICHE_CREATED",
+                totalQueries: 12,
+                totalSourceCandidates: 20,
+                totalSourceSnapshots: 4,
+                totalExtractedSignals: 30,
+                executionCostUsd: 0.0227,
+                cnaeTotalCostUsd: 0.0377,
+                startedAt: "2026-06-15T17:03:00Z",
+                finishedAt: "2026-06-15T17:39:00Z",
+                errorMessage: null,
+              },
+            ]),
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          );
+        }
+
+        if (url.includes("enriched-niches")) {
+          return new Response(
+            JSON.stringify([
+              {
+                enrichedNicheProfileId: 60,
+                marketNicheId: 21,
+                researchCycleId: 60,
+                cnaeCode: "9602501",
+                cnaeDescription: "Cabeleireiros, manicure e pedicure",
+                nicheName: "Manicure autônoma com agenda recorrente",
+                qualityStatus: "MEI_AUDIENCE_READY",
+                routineEvidenceScore: 84,
+                difficultyEvidenceScore: 82,
+                sourceDiversityScore: 100,
+                materializedAt: "2026-06-15T17:39:00Z",
+              },
+            ]),
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          );
+        }
+
+        return new Response("{}", {
+          status: 200,
+          headers: { "Content-Type": "application/json" },
+        });
+      }),
+    );
+
+    renderPage("/oprm/cnaes/9602501/subnichos/60");
+
+    expect(
+      await screen.findByText("Execução do pipeline NichoCNAE"),
+    ).toBeTruthy();
+    expect(
+      await screen.findByText((_, element) =>
+        Boolean(element?.textContent?.trim() === "Ciclo selecionado: #60"),
+      ),
+    ).toBeTruthy();
+    expect(screen.getByText("1. Ciclo")).toBeTruthy();
+    expect(screen.getByText("9. Materialização")).toBeTruthy();
   });
 
   it("traduz a coluna qualidade dos subnichos gerados para portugues", async () => {

--- a/frontend/src/pages/oprm/OprmCnaeDetailPlaceholderPage.tsx
+++ b/frontend/src/pages/oprm/OprmCnaeDetailPlaceholderPage.tsx
@@ -1,5 +1,5 @@
 import { Activity, Globe2, Sparkles } from "lucide-react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { Link, useNavigate, useParams } from "react-router-dom";
 import {
   useOprmCnaeScore,
@@ -635,6 +635,11 @@ export default function OprmCnaeDetailPlaceholderPage() {
   const [showPipeline, setShowPipeline] = useState(
     Boolean(selectedResearchCycleId),
   );
+  useEffect(() => {
+    if (selectedResearchCycleId) {
+      setShowPipeline(true);
+    }
+  }, [selectedResearchCycleId]);
   const volumeQuery = useOprmCnaeVolume(decodedCnaeCode);
   const scoreQuery = useOprmCnaeScore(decodedCnaeCode);
   const cyclesQuery = useOprmCnaePipelineCycles(decodedCnaeCode);


### PR DESCRIPTION
### Motivation
- Usuários clicavam em “Acompanhar” nos subnichos e a tela não abria os cards do pipeline porque o componente era reutilizado pelo React Router e o estado local `showPipeline` não reagia à mudança de rota com `researchCycleId`.
- É necessário que a visão dedicada do ciclo (cards das etapas, jobs e custo) abra automaticamente quando a URL contém `subnichos/:researchCycleId` para permitir acompanhamento imediato.

### Description
- Ajusta o componente `OprmCnaeDetailPlaceholderPage` para sincronizar `showPipeline` com `selectedResearchCycleId` usando `useEffect`, garantindo que a visão do pipeline abra quando a rota contém um `researchCycleId` (`frontend/src/pages/oprm/OprmCnaeDetailPlaceholderPage.tsx`).
- Expande os testes de front-end adicionando rota de detalhe de subnicho ao `MemoryRouter` e inclui um teste de regressão que simula acesso a `/oprm/cnaes/:cnaeCode/subnichos/:researchCycleId` e valida a exibição dos cards do pipeline (`frontend/src/pages/oprm/OprmCnaeDetailPlaceholderPage.test.tsx`).
- Registra a correção, causa-raiz e prevenção no histórico operacional OPRM (`docs/registros/oprm1.md`).

### Testing
- Rodei os testes unitários focados: `npm test -- --run src/pages/oprm/OprmCnaeDetailPlaceholderPage.test.tsx`, todos os casos passaram (`7 passed`).
- Rodei verificação de tipos TypeScript: `npm run typecheck`, sem erros de tipagem (OK).
- Os testes adicionados cobrem navegação direta para `/subnichos/:researchCycleId` e verificam a presença da seção "Execução do pipeline NichoCNAE" e dos cards de etapa.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a32f65ecfbc8321b037216b46b19579)