### PR TITLE
feat(oprm): adiciona relatório Markdown por execução CNAE

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/routineresearchcycle/service/BackendRoutineResearchCycleService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/routineresearchcycle/service/BackendRoutineResearchCycleService.java
@@ -1,14 +1,29 @@
 package com.marketinghub.oprm.nichocnae.routineresearchcycle.service;
 
+import com.marketinghub.oprm.nichocnae.OprmExtractedSignal;
+import com.marketinghub.oprm.nichocnae.OprmNicheResearchSeed;
+import com.marketinghub.oprm.nichocnae.OprmNicheRoutineCard;
+import com.marketinghub.oprm.nichocnae.OprmResearchQuery;
 import com.marketinghub.oprm.nichocnae.OprmRoutineResearchCycle;
+import com.marketinghub.oprm.nichocnae.OprmSourceCandidate;
+import com.marketinghub.oprm.nichocnae.OprmSourceSnapshot;
+import com.marketinghub.oprm.nichocnae.meiaudienceprofile.OprmMeiAudienceProfile;
 import com.marketinghub.oprm.nichocnae.routineresearchcycle.service.detailStageExecution.RecordBackendRoutineResearchCycleDetalheDto;
 import com.marketinghub.oprm.nichocnae.routineresearchcycle.service.listStageExecutions.RoutineResearchCycleExecutionSummaryResponse;
 import com.marketinghub.oprm.nichocnae.routineresearchcycle.service.pending.RecordRoutineResearchCyclePending;
+import com.marketinghub.repository.jpa.oprm.nichocnae.OprmExtractedSignalRepository;
 import com.marketinghub.repository.jpa.oprm.nichocnae.OprmNicheResearchSeedRepository;
+import com.marketinghub.repository.jpa.oprm.nichocnae.OprmNicheRoutineCardRepository;
+import com.marketinghub.repository.jpa.oprm.nichocnae.OprmResearchQueryRepository;
+import com.marketinghub.repository.jpa.oprm.nichocnae.OprmSourceCandidateRepository;
+import com.marketinghub.repository.jpa.oprm.nichocnae.OprmSourceSnapshotRepository;
+import com.marketinghub.repository.jpa.oprm.nichocnae.meiaudienceprofile.OprmMeiAudienceProfileRepository;
 import com.marketinghub.repository.jpa.oprm.nichocnae.OprmRoutineResearchCycleRepository;
 import jakarta.persistence.EntityNotFoundException;
 import java.math.BigDecimal;
+import java.time.Instant;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -20,13 +35,31 @@ public class BackendRoutineResearchCycleService {
 
   private final OprmRoutineResearchCycleRepository routineResearchCycleRepository;
   private final OprmNicheResearchSeedRepository nicheResearchSeedRepository;
+  private final OprmResearchQueryRepository researchQueryRepository;
+  private final OprmSourceCandidateRepository sourceCandidateRepository;
+  private final OprmSourceSnapshotRepository sourceSnapshotRepository;
+  private final OprmExtractedSignalRepository extractedSignalRepository;
+  private final OprmNicheRoutineCardRepository routineCardRepository;
+  private final OprmMeiAudienceProfileRepository meiAudienceProfileRepository;
 
   /** Inicializa o serviço com o repositório canônico de ciclos de pesquisa de rotina. */
   public BackendRoutineResearchCycleService(
       OprmRoutineResearchCycleRepository routineResearchCycleRepository,
-      OprmNicheResearchSeedRepository nicheResearchSeedRepository) {
+      OprmNicheResearchSeedRepository nicheResearchSeedRepository,
+      OprmResearchQueryRepository researchQueryRepository,
+      OprmSourceCandidateRepository sourceCandidateRepository,
+      OprmSourceSnapshotRepository sourceSnapshotRepository,
+      OprmExtractedSignalRepository extractedSignalRepository,
+      OprmNicheRoutineCardRepository routineCardRepository,
+      OprmMeiAudienceProfileRepository meiAudienceProfileRepository) {
     this.routineResearchCycleRepository = routineResearchCycleRepository;
     this.nicheResearchSeedRepository = nicheResearchSeedRepository;
+    this.researchQueryRepository = researchQueryRepository;
+    this.sourceCandidateRepository = sourceCandidateRepository;
+    this.sourceSnapshotRepository = sourceSnapshotRepository;
+    this.extractedSignalRepository = extractedSignalRepository;
+    this.routineCardRepository = routineCardRepository;
+    this.meiAudienceProfileRepository = meiAudienceProfileRepository;
   }
 
   /** Lista ciclos de pesquisa de rotina pendentes para processamento assíncrono da etapa. */
@@ -76,6 +109,50 @@ public class BackendRoutineResearchCycleService {
     return toDetail(cycle);
   }
 
+  /** Monta um relatório Markdown baixável com os dados auditáveis da execução. */
+  @Transactional(readOnly = true)
+  public String buildMarkdownReport(Long researchCycleId) {
+    OprmRoutineResearchCycle cycle = findCycle(researchCycleId);
+    Optional<OprmNicheResearchSeed> seed =
+        nicheResearchSeedRepository.findByResearchCycleId(researchCycleId);
+    List<OprmResearchQuery> queries =
+        researchQueryRepository.findByResearchCycleIdOrderByPriorityAscIdAsc(researchCycleId);
+    List<OprmSourceCandidate> candidates =
+        sourceCandidateRepository.findByResearchCycleIdOrderByResearchQueryIdAscSearchPositionAscIdAsc(
+            researchCycleId);
+    List<OprmSourceSnapshot> snapshots =
+        sourceSnapshotRepository.findByResearchCycleIdOrderByIdAsc(researchCycleId);
+    List<OprmExtractedSignal> signals =
+        extractedSignalRepository.findByResearchCycleIdOrderByIdAsc(researchCycleId);
+    Optional<OprmNicheRoutineCard> card =
+        routineCardRepository.findFirstByResearchCycleIdOrderByIdDesc(researchCycleId);
+    Optional<OprmMeiAudienceProfile> meiProfile =
+        meiAudienceProfileRepository.findFirstByResearchCycleIdOrderByIdDesc(researchCycleId);
+
+    StringBuilder report = new StringBuilder();
+    appendTitle(report, cycle);
+    appendCycleSection(report, cycle);
+    appendSeedSection(report, seed);
+    appendSearchSection(report, queries, candidates);
+    appendFetchSection(report, snapshots);
+    appendSignalsSection(report, signals);
+    appendSynthesisSection(report, card);
+    appendMeiSection(report, meiProfile);
+    appendQualitySection(report, card);
+    appendFooter(report);
+    return report.toString();
+  }
+
+  /** Busca uma execução de ciclo ou falha com erro de entidade inexistente. */
+  private OprmRoutineResearchCycle findCycle(Long researchCycleId) {
+    return routineResearchCycleRepository
+        .findById(researchCycleId)
+        .orElseThrow(
+            () ->
+                new EntityNotFoundException(
+                    "Routine research cycle not found: " + researchCycleId));
+  }
+
   /** Converte um ciclo em unidade de trabalho fechada para processamento interno da etapa. */
   private RecordRoutineResearchCyclePending toPending(OprmRoutineResearchCycle cycle) {
     return new RecordRoutineResearchCyclePending(
@@ -119,6 +196,194 @@ public class BackendRoutineResearchCycleService {
         cycle.getStartedAt(),
         cycle.getFinishedAt(),
         cycle.getErrorMessage());
+  }
+
+  /** Adiciona o título principal do relatório Markdown. */
+  private void appendTitle(StringBuilder report, OprmRoutineResearchCycle cycle) {
+    report.append("# Relatório da execução NichoCNAE #").append(cycle.getId()).append("\n\n");
+    report.append("**Arquivo sugerido:** nicho-cnae").append(cycle.getId()).append(".md\n\n");
+  }
+
+  /** Adiciona os metadados gerais do ciclo de pesquisa. */
+  private void appendCycleSection(StringBuilder report, OprmRoutineResearchCycle cycle) {
+    report.append("## 1. Ciclo\n\n");
+    appendField(report, "CNAE", cycle.getCnaeCode());
+    appendField(report, "Descrição CNAE", cycle.getCnaeDescription());
+    appendField(report, "Nicho", cycle.getNicheName());
+    appendField(report, "Subnicho operacional", cycle.getNeutralNicheName());
+    appendField(report, "Status", cycle.getStatus());
+    appendField(report, "Início", cycle.getStartedAt());
+    appendField(report, "Fim", cycle.getFinishedAt());
+    appendField(report, "Custo IA registrado", executionCostUsd(cycle.getId()));
+    appendField(report, "Erro", cycle.getErrorMessage());
+    report.append("\n");
+  }
+
+  /** Adiciona a etapa de seed com request e response da IA quando existirem. */
+  private void appendSeedSection(StringBuilder report, Optional<OprmNicheResearchSeed> seed) {
+    report.append("## 2. Seed de pesquisa (IA)\n\n");
+    if (seed.isEmpty()) {
+      appendMissing(report);
+      return;
+    }
+    OprmNicheResearchSeed value = seed.get();
+    appendField(report, "Modelo", value.getModel());
+    appendField(report, "Input tokens", value.getInputTokens());
+    appendField(report, "Output tokens", value.getOutputTokens());
+    appendField(report, "Custo", value.getCostUsd());
+    appendCodeBlock(report, "Request OpenAI", value.getRawOpenAiRequest());
+    appendCodeBlock(report, "Response OpenAI", value.getRawOpenAiResponse());
+    appendCodeBlock(report, "Resposta modelada", value.getRawModelResponse());
+  }
+
+  /** Adiciona a etapa de busca com queries e URLs retornadas. */
+  private void appendSearchSection(
+      StringBuilder report, List<OprmResearchQuery> queries, List<OprmSourceCandidate> candidates) {
+    report.append("## 3. Busca de fontes (Web)\n\n");
+    if (queries.isEmpty() && candidates.isEmpty()) {
+      appendMissing(report);
+      return;
+    }
+    report.append("### Queries executadas\n\n");
+    queries.forEach(
+        query ->
+            report
+                .append("- #")
+                .append(query.getId())
+                .append(" — ")
+                .append(safe(query.getQueryText()))
+                .append(" | status: ")
+                .append(safe(query.getStatus()))
+                .append(" | resultados: ")
+                .append(query.getResultCount())
+                .append("\n"));
+    report.append("\n### URLs retornadas\n\n");
+    candidates.forEach(
+        candidate ->
+            report
+                .append("- ")
+                .append(safe(candidate.getSourceUrl()))
+                .append(" — ")
+                .append(safe(candidate.getSourceTitle()))
+                .append(" | status: ")
+                .append(safe(candidate.getStatus()))
+                .append(" | posição: ")
+                .append(candidate.getSearchPosition())
+                .append("\n  - Snippet: ")
+                .append(safe(candidate.getSourceSnippet()))
+                .append("\n"));
+    report.append("\n");
+  }
+
+  /** Adiciona a etapa de coleta com retorno resumido de cada URL acessada. */
+  private void appendFetchSection(StringBuilder report, List<OprmSourceSnapshot> snapshots) {
+    report.append("## 4. Coleta de URLs (Web)\n\n");
+    if (snapshots.isEmpty()) {
+      appendMissing(report);
+      return;
+    }
+    snapshots.forEach(
+        snapshot -> {
+          report.append("### ").append(safe(snapshot.getSourceTitle())).append("\n\n");
+          appendField(report, "URL pesquisada", snapshot.getSourceUrl());
+          appendField(report, "HTTP", snapshot.getHttpStatus());
+          appendField(report, "Status da coleta", snapshot.getFetchStatus());
+          appendCodeBlock(report, "Retorno/trecho coletado", snapshot.getShortExcerpt());
+          appendCodeBlock(report, "Snippet", snapshot.getSnippet());
+        });
+  }
+
+  /** Adiciona a etapa de extração de sinais estruturados. */
+  private void appendSignalsSection(StringBuilder report, List<OprmExtractedSignal> signals) {
+    report.append("## 5. Sinais extraídos\n\n");
+    if (signals.isEmpty()) {
+      appendMissing(report);
+      return;
+    }
+    signals.forEach(
+        signal ->
+            report
+                .append("- ")
+                .append(safe(signal.getSignalType()))
+                .append(" — ")
+                .append(safe(signal.getSignalText()))
+                .append(" | confiança: ")
+                .append(signal.getConfidenceScore())
+                .append(" | fonte: ")
+                .append(safe(signal.getSourceDomain()))
+                .append("\n  - Evidência: ")
+                .append(safe(signal.getEvidenceExcerpt()))
+                .append("\n"));
+    report.append("\n");
+  }
+
+  /** Adiciona a etapa de síntese de rotina. */
+  private void appendSynthesisSection(StringBuilder report, Optional<OprmNicheRoutineCard> card) {
+    report.append("## 6. Síntese de rotina\n\n");
+    if (card.isEmpty()) {
+      appendMissing(report);
+      return;
+    }
+    OprmNicheRoutineCard value = card.get();
+    appendCodeBlock(report, "Rotina", value.getRoutineSummary());
+    appendCodeBlock(report, "Dores", value.getPainsSummary());
+    appendCodeBlock(report, "Resultados", value.getResultsSummary());
+    appendCodeBlock(report, "Mecanismos possíveis", value.getMechanismOpportunitiesSummary());
+    appendCodeBlock(report, "Evidências", value.getEvidenceSummary());
+  }
+
+  /** Adiciona a etapa de perfil MEI/autônomo. */
+  private void appendMeiSection(StringBuilder report, Optional<OprmMeiAudienceProfile> profile) {
+    report.append("## 7. Perfil MEI/autônomo\n\n");
+    if (profile.isEmpty()) {
+      appendMissing(report);
+      return;
+    }
+    OprmMeiAudienceProfile value = profile.get();
+    appendField(report, "Público", value.getAudienceName());
+    appendCodeBlock(report, "Rotina diária", value.getDailyRoutineSummary());
+    appendCodeBlock(report, "Tarefas recorrentes", value.getRecurringTasksSummary());
+    appendCodeBlock(report, "Dores operacionais", value.getOperationalPainsSummary());
+    appendCodeBlock(report, "Linguagem", value.getLanguagePatterns());
+  }
+
+  /** Adiciona a etapa de qualidade e materialização quando houver cartão avaliado. */
+  private void appendQualitySection(StringBuilder report, Optional<OprmNicheRoutineCard> card) {
+    report.append("## 8. Qualidade e materialização\n\n");
+    if (card.isEmpty()) {
+      appendMissing(report);
+      return;
+    }
+    OprmNicheRoutineCard value = card.get();
+    appendField(report, "Status de qualidade", value.getQualityStatus());
+    appendField(report, "Pronto para hipótese", value.getReadyForHypothesis());
+    appendField(report, "Checado em", value.getQualityCheckedAt());
+    appendCodeBlock(report, "Notas de qualidade", value.getQualityNotes());
+  }
+
+  /** Adiciona rodapé de rastreabilidade do relatório. */
+  private void appendFooter(StringBuilder report) {
+    report.append("---\nRelatório gerado pelo backend em ").append(Instant.now()).append(".\n");
+  }
+
+  /** Adiciona um campo simples ao Markdown quando existir valor. */
+  private void appendField(StringBuilder report, String label, Object value) {
+    report.append("- **").append(label).append(":** ").append(safe(value)).append("\n");
+  }
+
+  /** Adiciona bloco de código para payloads longos, request e response. */
+  private void appendCodeBlock(StringBuilder report, String label, String value) {
+    report.append("### ").append(label).append("\n\n```\n").append(safe(value)).append("\n```\n\n");
+  }
+
+  /** Registra ausência explícita de dados para uma etapa ainda não executada. */
+  private void appendMissing(StringBuilder report) {
+    report.append("Dados ainda não registrados para esta etapa.\n\n");
+  }
+
+  /** Normaliza valores nulos para texto seguro no relatório. */
+  private String safe(Object value) {
+    return value == null || value.toString().isBlank() ? "Não registrado" : value.toString();
   }
 
   /** Soma o custo registrado pelas etapas com telemetria de IA para uma execução do ciclo. */

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/routineresearchcycle/web/BackendRoutineResearchCycleController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/routineresearchcycle/web/BackendRoutineResearchCycleController.java
@@ -4,7 +4,11 @@ import com.marketinghub.oprm.nichocnae.routineresearchcycle.service.BackendRouti
 import com.marketinghub.oprm.nichocnae.routineresearchcycle.service.detailStageExecution.RecordBackendRoutineResearchCycleDetalheDto;
 import com.marketinghub.oprm.nichocnae.routineresearchcycle.service.listStageExecutions.RoutineResearchCycleExecutionSummaryResponse;
 import com.marketinghub.oprm.nichocnae.routineresearchcycle.service.pending.RecordRoutineResearchCyclePending;
+import java.nio.charset.StandardCharsets;
 import java.util.List;
+import org.springframework.http.ContentDisposition;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.MediaType;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -47,5 +51,18 @@ public class BackendRoutineResearchCycleController {
   public ResponseEntity<RecordBackendRoutineResearchCycleDetalheDto> detailStageExecution(
       @PathVariable Long researchCycleId) {
     return ResponseEntity.ok(executionService.detailStageExecution(researchCycleId));
+  }
+
+  /** Baixa um relatório Markdown com a auditoria completa da execução informada. */
+  @GetMapping(
+      value = "/oprm/nichocnae/routine-research-cycle/stage-executions/{researchCycleId}/report",
+      produces = "text/markdown")
+  public ResponseEntity<String> downloadMarkdownReport(@PathVariable Long researchCycleId) {
+    String filename = "nicho-cnae" + researchCycleId + ".md";
+    HttpHeaders headers = new HttpHeaders();
+    headers.setContentDisposition(
+        ContentDisposition.attachment().filename(filename, StandardCharsets.UTF_8).build());
+    headers.setContentType(MediaType.parseMediaType("text/markdown; charset=UTF-8"));
+    return ResponseEntity.ok().headers(headers).body(executionService.buildMarkdownReport(researchCycleId));
   }
 }

--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -861,3 +861,9 @@
 - Ajustada a seção “Em processamento antes de virar subnicho” para exibir 10 ciclos por página, custo individual por ciclo e custo total no cabeçalho do card.
 - Causa-raiz tratada: a lista podia crescer sem controle visual e não mostrava o impacto financeiro dos ciclos que ainda não viraram subnicho, dificultando decisão operacional sobre continuidade ou reprocessamento.
 - Prevenção de recorrência: a tela passou a calcular a visualização paginada e o total financeiro diretamente a partir da verdade enviada pelo backend para os ciclos OPRM.
+
+## 2026-06-17 — OPRM CNAE: relatório Markdown por execução
+
+- Adicionado botão “Relatório” para cada execução do NichoCNAE, permitindo baixar um arquivo `nicho-cnae<id>.md` com detalhamento etapa por etapa.
+- Causa-raiz tratada: a tela permitia acompanhar o estado do pipeline, mas não entregava uma auditoria consolidada para o usuário analisar request/response de IA, URLs pesquisadas, retornos coletados, sinais, síntese e qualidade sem navegar por várias telas.
+- Prevenção de recorrência: o relatório é gerado pelo backend a partir das tabelas canônicas da execução, mantendo a tela como consumidora da verdade do backend e evitando inferência local no frontend.

--- a/frontend/src/api/oprm/useOprmCnaePipeline.ts
+++ b/frontend/src/api/oprm/useOprmCnaePipeline.ts
@@ -77,6 +77,28 @@ async function startCnaePipeline(
   return (await response.json()) as OprmRoutineResearchStartResult;
 }
 
+export async function downloadOprmCnaeCycleReport(researchCycleId: number) {
+  const response = await fetch(
+    buildApiUrl(
+      `/api/oprm/nichocnae/routine-research-cycle/stage-executions/${researchCycleId}/report`,
+    ),
+  );
+  if (!response.ok) {
+    throw new Error(
+      `Não foi possível baixar o relatório da execução (status ${response.status}).`,
+    );
+  }
+  const blob = await response.blob();
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = `nicho-cnae${researchCycleId}.md`;
+  document.body.appendChild(link);
+  link.click();
+  link.remove();
+  URL.revokeObjectURL(url);
+}
+
 export function useOprmCnaePipelineCycles(cnaeCode: string) {
   return useQuery({
     queryKey: ["oprm", "nichocnae", cnaeCode, "routine-cycles"],

--- a/frontend/src/pages/oprm/OprmCnaeDetailPlaceholderPage.tsx
+++ b/frontend/src/pages/oprm/OprmCnaeDetailPlaceholderPage.tsx
@@ -6,6 +6,7 @@ import {
   useOprmCnaeVolume,
 } from "../../api/oprm/useOprmCnaeDetail";
 import {
+  downloadOprmCnaeCycleReport,
   type OprmRoutineResearchCycleSummary,
   useOprmCnaePipelineCycles,
   useStartOprmCnaePipeline,
@@ -657,6 +658,12 @@ export default function OprmCnaeDetailPlaceholderPage() {
     }
   }, [selectedResearchCycleId]);
   const [pendingCyclesPage, setPendingCyclesPage] = useState(1);
+  const [reportDownloadCycleId, setReportDownloadCycleId] = useState<
+    number | null
+  >(null);
+  const [reportDownloadError, setReportDownloadError] = useState<string | null>(
+    null,
+  );
   const volumeQuery = useOprmCnaeVolume(decodedCnaeCode);
   const scoreQuery = useOprmCnaeScore(decodedCnaeCode);
   const cyclesQuery = useOprmCnaePipelineCycles(decodedCnaeCode);
@@ -667,7 +674,9 @@ export default function OprmCnaeDetailPlaceholderPage() {
     cyclesQuery.data,
     generatedNichesQuery.data,
   );
-  const pendingCyclesTotalCost = sumCycleCosts(pendingCyclesBeforeEnrichedNiche);
+  const pendingCyclesTotalCost = sumCycleCosts(
+    pendingCyclesBeforeEnrichedNiche,
+  );
   const pendingCyclesTotalPages = Math.max(
     1,
     Math.ceil(
@@ -716,6 +725,22 @@ export default function OprmCnaeDetailPlaceholderPage() {
   const identifiedSubnicheName = latestCycle
     ? (latestCycle.neutralNicheName ?? latestCycle.nicheName)?.trim()
     : "";
+  const handleDownloadReport = async (cycleId: number) => {
+    setReportDownloadCycleId(cycleId);
+    setReportDownloadError(null);
+    try {
+      await downloadOprmCnaeCycleReport(cycleId);
+    } catch (error) {
+      setReportDownloadError(
+        error instanceof Error
+          ? error.message
+          : "Não foi possível baixar o relatório da execução.",
+      );
+    } finally {
+      setReportDownloadCycleId(null);
+    }
+  };
+
   const cnaeDescription =
     volumeQuery.data?.cnaeDescription ??
     scoreQuery.data?.cnaeDescription ??
@@ -783,6 +808,11 @@ export default function OprmCnaeDetailPlaceholderPage() {
           {startPipelineMutation.isError ? (
             <div className="alert alert-warning mb-0" role="alert">
               {startPipelineMutation.error.message}
+            </div>
+          ) : null}
+          {reportDownloadError ? (
+            <div className="alert alert-warning mb-0" role="alert">
+              {reportDownloadError}
             </div>
           ) : null}
         </div>
@@ -943,12 +973,36 @@ export default function OprmCnaeDetailPlaceholderPage() {
                       </td>
                       <td>{formatDateTime(niche.materializedAt)}</td>
                       <td className="text-end">
-                        <Link
-                          className="btn btn-outline-primary btn-sm"
-                          to={`/oprm/cnaes/${encodeURIComponent(decodedCnaeCode)}/subnichos/${niche.researchCycleId}`}
-                        >
-                          Acompanhar
-                        </Link>
+                        <div className="d-inline-flex flex-wrap gap-2 justify-content-end">
+                          <button
+                            type="button"
+                            className="btn btn-outline-secondary btn-sm"
+                            disabled={
+                              reportDownloadCycleId === niche.researchCycleId
+                            }
+                            onClick={() =>
+                              void handleDownloadReport(niche.researchCycleId)
+                            }
+                          >
+                            {reportDownloadCycleId === niche.researchCycleId ? (
+                              <>
+                                <span
+                                  className="spinner-border spinner-border-sm me-1"
+                                  aria-hidden="true"
+                                />
+                                Relatório
+                              </>
+                            ) : (
+                              "Relatório"
+                            )}
+                          </button>
+                          <Link
+                            className="btn btn-outline-primary btn-sm"
+                            to={`/oprm/cnaes/${encodeURIComponent(decodedCnaeCode)}/subnichos/${niche.researchCycleId}`}
+                          >
+                            Acompanhar
+                          </Link>
+                        </div>
                       </td>
                     </tr>
                   ))}
@@ -1031,12 +1085,37 @@ export default function OprmCnaeDetailPlaceholderPage() {
                         <td>{formatUsd(cycle.executionCostUsd)}</td>
                         <td>{formatDateTime(cycle.startedAt)}</td>
                         <td className="text-end">
-                          <Link
-                            className="btn btn-outline-primary btn-sm"
-                            to={`/oprm/cnaes/${encodeURIComponent(decodedCnaeCode)}/subnichos/${cycle.researchCycleId}`}
-                          >
-                            Acompanhar
-                          </Link>
+                          <div className="d-inline-flex flex-wrap gap-2 justify-content-end">
+                            <button
+                              type="button"
+                              className="btn btn-outline-secondary btn-sm"
+                              disabled={
+                                reportDownloadCycleId === cycle.researchCycleId
+                              }
+                              onClick={() =>
+                                void handleDownloadReport(cycle.researchCycleId)
+                              }
+                            >
+                              {reportDownloadCycleId ===
+                              cycle.researchCycleId ? (
+                                <>
+                                  <span
+                                    className="spinner-border spinner-border-sm me-1"
+                                    aria-hidden="true"
+                                  />
+                                  Relatório
+                                </>
+                              ) : (
+                                "Relatório"
+                              )}
+                            </button>
+                            <Link
+                              className="btn btn-outline-primary btn-sm"
+                              to={`/oprm/cnaes/${encodeURIComponent(decodedCnaeCode)}/subnichos/${cycle.researchCycleId}`}
+                            >
+                              Acompanhar
+                            </Link>
+                          </div>
                         </td>
                       </tr>
                     ))}
@@ -1047,7 +1126,8 @@ export default function OprmCnaeDetailPlaceholderPage() {
             {!cyclesQuery.isLoading &&
             !generatedNichesQuery.isLoading &&
             !cyclesQuery.isError &&
-            pendingCyclesBeforeEnrichedNiche.length > PENDING_CYCLES_PAGE_SIZE ? (
+            pendingCyclesBeforeEnrichedNiche.length >
+              PENDING_CYCLES_PAGE_SIZE ? (
               <div className="d-flex flex-wrap justify-content-between align-items-center gap-2 mt-3">
                 <span className="small text-secondary">
                   Página {pendingCyclesPage} de {pendingCyclesTotalPages} · 10


### PR DESCRIPTION
### Motivation
- Fornecer ao usuário uma auditoria por execução do pipeline NichoCNAE para análise operacional e auditoria, reunindo request/response de IA, URLs pesquisadas, retornos coletados, sinais, síntese e qualidade num único arquivo Markdown nomeado `nicho-cnae<id>.md`.
- Evitar que o usuário precise navegar por várias telas para levantar evidência técnica da execução e permitir exportação para investigação e compliance.

### Description
- Backend: adiciona endpoint `GET /api/oprm/nichocnae/routine-research-cycle/stage-executions/{researchCycleId}/report` que retorna um Markdown auditável com filename `nicho-cnae<id>.md` e headers de `Content-Disposition`/`Content-Type` (file: `backend/ads-service/src/main/java/.../BackendRoutineResearchCycleController.java`).
- Backend: implementa `buildMarkdownReport` que compila dados canônicos por execução (seed, OpenAI request/response, queries, source candidates, snapshots, extracted signals, routine card, MEI profile, quality notes) em seções Markdown; inclui helpers de formatação e bloco de código para payloads (file: `backend/ads-service/src/main/java/.../BackendRoutineResearchCycleService.java`).
- Frontend: adiciona `downloadOprmCnaeCycleReport` helper que baixa o blob e salva como `nicho-cnae<id>.md` e integra o botão “Relatório” com estado de loading e mensagem de erro nas listas de subnichos materializados e em processamento (files: `frontend/src/api/oprm/useOprmCnaePipeline.ts`, `frontend/src/pages/oprm/OprmCnaeDetailPlaceholderPage.tsx`).
- Docs: registra a mudança operacional em `docs/registros/oprm1.md` e faz pequenas formatações e prettier no frontend.

### Testing
- Executado `../../backend/mvnw -DskipTests compile` e a compilação do módulo `ads-service` concluiu com sucesso.
- Executado `../../backend/mvnw test -DskipITs` e os testes do backend foram executados com sucesso (build/tests concluídos com `BUILD SUCCESS`).
- Executado `npm install`, `npm run typecheck` e `npm run build` no frontend, com instalação de dependências, typecheck e build produzindo saída aguardada e artefatos `dist` sem erros críticos.
- Rodado `npx prettier --write` sobre os arquivos frontend modificados e `git diff --check` para verificar problemas de estilo; ambos concluíram sem bloqueios; tentativa de `../../backend/mvnw spotless:apply` falhou por ausência do plugin Spotless no contexto do prefixo Maven (informativo, não bloqueante).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a330aa4f3b483219475c78720114c31)