### PR TITLE
Add internal endpoint to list routine research jobs by status for executor reprocessing

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/routineresearchorchestrator/service/BackendRoutineResearchOrchestratorService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/routineresearchorchestrator/service/BackendRoutineResearchOrchestratorService.java
@@ -22,6 +22,7 @@ import com.marketinghub.repository.jpa.oprm.nichocnae.OprmRoutineResearchCycleRe
 import com.marketinghub.repository.jpa.oprm.nichocnae.meiaudienceprofile.OprmMeiAudienceProfileRepository;
 import java.time.Instant;
 import java.util.List;
+import java.util.Locale;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.data.domain.PageRequest;
@@ -111,6 +112,25 @@ public class BackendRoutineResearchOrchestratorService {
                 .toList();
         LOGGER.info("Ciclos recentes da etapa zero OPRM nichocnae retornados (count={})", recentCycles.size());
         return recentCycles;
+    }
+
+    /** Lista jobs por status para o executor decidir reprocessamentos com aprendizado da tentativa anterior. */
+    @Transactional(readOnly = true)
+    public List<RecordRoutineResearchOrchestratorRecent> listJobsByStatus(List<String> statuses, int limit) {
+        List<String> normalizedStatuses = normalizeStatusFilter(statuses);
+        int safeLimit = Math.max(1, Math.min(limit, 50));
+        LOGGER.info(
+                "Listando jobs OPRM nichocnae por status para executor (statuses={}, requestedLimit={}, safeLimit={})",
+                normalizedStatuses,
+                limit,
+                safeLimit);
+        List<RecordRoutineResearchOrchestratorRecent> jobs = routineResearchCycleRepository
+                .findByStatusInOrderByStartedAtAsc(normalizedStatuses, PageRequest.of(0, safeLimit))
+                .stream()
+                .map(this::toRecentProcessed)
+                .toList();
+        LOGGER.info("Jobs OPRM nichocnae por status retornados para executor (count={})", jobs.size());
+        return jobs;
     }
 
     /** Reabre o mesmo job e limpa os artefatos das etapas que serão executadas novamente com novo input. */
@@ -237,6 +257,22 @@ public class BackendRoutineResearchOrchestratorService {
                 || CYCLE_STATUS_GENERIC.equals(status)
                 || CYCLE_STATUS_NEEDS_EXECUTOR_ROUTINE_EVIDENCE.equals(status)
                 || "ENRICHED_NICHE_FAILED".equals(status);
+    }
+
+    /** Normaliza o filtro de status e bloqueia consultas amplas sem status explícito. */
+    private List<String> normalizeStatusFilter(List<String> statuses) {
+        if (statuses == null || statuses.isEmpty()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "At least one status is required");
+        }
+        List<String> normalizedStatuses = statuses.stream()
+                .filter(status -> status != null && !status.isBlank())
+                .map(status -> status.trim().toUpperCase(Locale.ROOT))
+                .distinct()
+                .toList();
+        if (normalizedStatuses.isEmpty()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "At least one status is required");
+        }
+        return normalizedStatuses;
     }
 
     /** Monta mensagem operacional para explicar ao usuário por que o mesmo job foi reaberto. */

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/routineresearchorchestrator/web/BackendRoutineResearchOrchestratorController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/routineresearchorchestrator/web/BackendRoutineResearchOrchestratorController.java
@@ -40,6 +40,14 @@ public class BackendRoutineResearchOrchestratorController {
         return executionService.listRecentProcessed(limit);
     }
 
+    /** Lista jobs por status para o executor decidir nova tentativa usando aprendizado da tentativa anterior. */
+    @GetMapping("/internal/oprm/nichocnae/routine-research-orchestrator/jobs")
+    public List<RecordRoutineResearchOrchestratorRecent> jobsByStatus(
+            @RequestParam("status") List<String> statuses,
+            @RequestParam(defaultValue = "20") int limit) {
+        return executionService.listJobsByStatus(statuses, limit);
+    }
+
     /** Reabre o mesmo job para falhas, pesquisas insuficientes ou resultados genéricos. */
     @PostMapping("/oprm/nichocnae/routine-research-orchestrator/recent-processed/{researchCycleId}/reprocess")
     public RecordRoutineResearchOrchestratorReprocessResult reprocess(

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/oprm/nichocnae/OprmRoutineResearchCycleRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/oprm/nichocnae/OprmRoutineResearchCycleRepository.java
@@ -40,6 +40,9 @@ public interface OprmRoutineResearchCycleRepository extends JpaRepository<OprmRo
     /** Lista os ciclos de pesquisa de rotina mais recentes para acompanhamento operacional. */
     List<OprmRoutineResearchCycle> findAllByOrderByStartedAtDesc(Pageable pageable);
 
+    /** Lista ciclos de pesquisa por status para filas de diagnóstico e reprocessamento do executor. */
+    List<OprmRoutineResearchCycle> findByStatusInOrderByStartedAtAsc(List<String> statuses, Pageable pageable);
+
     /** Lista ciclos aptos à etapa de seed, incluindo falhas retryáveis sem artefatos persistidos. */
     @Query("""
             select cycle

--- a/backend/ads-service/src/test/java/com/marketinghub/oprm/nichocnae/routineresearchorchestrator/service/BackendRoutineResearchOrchestratorServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/oprm/nichocnae/routineresearchorchestrator/service/BackendRoutineResearchOrchestratorServiceTest.java
@@ -108,6 +108,31 @@ class BackendRoutineResearchOrchestratorServiceTest {
         assertThat(pageableCaptor.getValue().getPageSize()).isEqualTo(10);
     }
 
+    /** Deve listar jobs filtrados por status para o executor decidir nova tentativa com aprendizado anterior. */
+    @Test
+    void listJobsByStatusReturnsFilteredCyclesForExecutorRetry() {
+        OprmRoutineResearchCycle cycle = cycle(321L, 55L, "Cabeleireiros e manicures", "2026-06-03T01:00:00Z");
+        cycle.setStatus("NEEDS_MORE_RESEARCH");
+        when(routineResearchCycleRepository.findByStatusInOrderByStartedAtAsc(
+                        org.mockito.ArgumentMatchers.eq(List.of("NEEDS_MORE_RESEARCH", "GENERIC")), any(Pageable.class)))
+                .thenReturn(List.of(cycle));
+
+        List<RecordRoutineResearchOrchestratorRecent> result =
+                service.listJobsByStatus(List.of(" needs_more_research ", "GENERIC", "generic"), 99);
+
+        assertThat(result).hasSize(1);
+        assertThat(result.getFirst().researchCycleId()).isEqualTo(321L);
+        assertThat(result.getFirst().cycleStatus()).isEqualTo("NEEDS_MORE_RESEARCH");
+        assertThat(result.getFirst().errorMessage()).isEqualTo("nicheName is required");
+
+        ArgumentCaptor<Pageable> pageableCaptor = ArgumentCaptor.forClass(Pageable.class);
+        verify(routineResearchCycleRepository)
+                .findByStatusInOrderByStartedAtAsc(
+                        org.mockito.ArgumentMatchers.eq(List.of("NEEDS_MORE_RESEARCH", "GENERIC")),
+                        pageableCaptor.capture());
+        assertThat(pageableCaptor.getValue().getPageSize()).isEqualTo(50);
+    }
+
     /** Deve indicar o nicho existente quando o candidato já foi materializado em MarketNiche. */
     @Test
     void listRecentProcessedReturnsExistingMarketNicheAssociation() {

--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -1,3 +1,9 @@
+## 2026-06-18 02:23:30 (UTC) — OPRM NichoCNAE: endpoint de jobs por status para reprocessamento pelo executor
+
+- Causa-raiz identificada no ciclo #68: o backend marcava `NEEDS_MORE_RESEARCH` durante a triagem pré-segmentação MEI/autônomo, antes de o job chegar ao gate de qualidade que já aciona o reprocessamento automático no executor.
+- Correção aplicada: criado endpoint interno `GET /api/internal/oprm/nichocnae/routine-research-orchestrator/jobs?status=...&limit=...` para o executor OPRM buscar jobs por status recuperável, obter os dados da tentativa anterior e decidir nova tentativa com aprendizado nos prompts, mantendo o backend como leitura/escrita e o controle operacional no executor.
+- Prevenção de recorrência: adicionado teste unitário garantindo normalização de status, limite seguro e consulta filtrada por status no backend.
+
 ## 2026-06-17 00:00:00 (UTC) — OPRM NichoCNAE: evitar repetição de subnichos por CNAE
 
 - Causa-raiz tratada: a etapa `oprmNicheResearchSeedBuilder` já quebrava o CNAE em subnichos vendáveis, mas não recebia explicitamente os subnichos já materializados para o mesmo CNAE, permitindo repetir ou aproximar semanticamente um recorte já existente.

--- a/docs/swagger/oprm-nichocnae-swagger.yaml
+++ b/docs/swagger/oprm-nichocnae-swagger.yaml
@@ -55,6 +55,50 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/RoutineResearchOrchestratorRecent'
+  /api/internal/oprm/nichocnae/routine-research-orchestrator/jobs:
+    get:
+      summary: Lista jobs do pipeline NichoCNAE filtrados por status para reprocessamento pelo executor.
+      description: Endpoint interno de leitura para o executor OPRM localizar jobs recuperáveis, obter dados da tentativa anterior e decidir nova tentativa com aprendizado nos prompts.
+      tags: [OPRM Nicho CNAE]
+      parameters:
+        - name: status
+          in: query
+          required: true
+          description: Um ou mais status de ciclo. Pode ser enviado repetido ou separado por vírgula conforme conversão padrão do Spring.
+          schema:
+            type: array
+            items:
+              type: string
+              enum:
+                - FAILED
+                - STALLED
+                - NEEDS_MORE_RESEARCH
+                - NEEDS_MORE_MEI_RESEARCH
+                - OUTDATED_SOURCES
+                - TOO_CORPORATE
+                - SOLUTION_CONTAMINATED
+                - NEEDS_EXECUTOR_ROUTINE_EVIDENCE
+                - GENERIC
+                - ENRICHED_NICHE_FAILED
+        - name: limit
+          in: query
+          required: false
+          schema:
+            type: integer
+            minimum: 1
+            maximum: 50
+            default: 20
+      responses:
+        '200':
+          description: Jobs encontrados em ordem operacional ascendente para o executor decidir reprocessamento.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/RoutineResearchOrchestratorRecent'
+        '400':
+          description: Nenhum status informado.
   /api/oprm/nichocnae/routine-research-orchestrator/recent-processed/{researchCycleId}/reprocess:
     post:
       summary: Reabre o mesmo job para reexecutar etapas do CNAE falho, fraco, genérico ou com falha na materialização final.


### PR DESCRIPTION
### Motivation

- Provide the executor with a read-only way to find recoverable pipeline jobs and learn from the previous attempt to decide reprocessing strategies.
- Prevent broad or accidental queries by requiring an explicit status filter and enforcing a safe maximum page size.
- Record the change in operational docs and the API spec so the executor and operators can consume the new flow.

### Description

- Added `BackendRoutineResearchOrchestratorService.listJobsByStatus(List<String>, int)` which normalizes status input, enforces a safe `limit` (max 50), logs the query and returns recent cycles mapped to `RecordRoutineResearchOrchestratorRecent`.
- Implemented `normalizeStatusFilter` to trim, uppercase and deduplicate statuses and to reject empty input with `ResponseStatusException` (`400`).
- Exposed a new internal controller endpoint `GET /api/internal/oprm/nichocnae/routine-research-orchestrator/jobs` in `BackendRoutineResearchOrchestratorController` that accepts `status` (repeatable) and `limit` parameters and delegates to the service.
- Added repository method `OprmRoutineResearchCycleRepository.findByStatusInOrderByStartedAtAsc(List<String>, Pageable)` and updated Swagger and `docs/registros/oprm1.md` to document the new internal API and rationale.

### Testing

- Added unit test `listJobsByStatusReturnsFilteredCyclesForExecutorRetry` in `BackendRoutineResearchOrchestratorServiceTest` that verifies status normalization, safe pagination size, repository invocation and returned payload; the test passed.
- Ran the module unit test suite with `mvn test` and all tests (including the new test and existing `listRecentProcessed` tests) succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a335438a1048321866ecde3d1d3a289)