### PR TITLE
Ajusta ranking OPRM de CNAEs — adiciona subnichos, custo e indicador de pesquisa

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/market/dto/OprmTopCnaeMarketVolumeDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/market/dto/OprmTopCnaeMarketVolumeDto.java
@@ -4,7 +4,7 @@ import java.math.BigDecimal;
 import java.time.LocalDate;
 
 /**
- * DTO responsável por expor o ranking operacional de CNAEs com volume de mercado e score OPRM.
+ * DTO responsável por expor o ranking operacional de CNAEs com volume, score e indicadores de pesquisa de nicho.
  */
 public record OprmTopCnaeMarketVolumeDto(
         LocalDate snapshotDate,
@@ -16,4 +16,7 @@ public record OprmTopCnaeMarketVolumeDto(
         long totalEmpresasMei,
         long totalEmpresasSimples,
         BigDecimal opportunityScore,
-        String scoreStatus) {}
+        String scoreStatus,
+        long subnicheCount,
+        BigDecimal researchCostUsd,
+        boolean nicheResearchRunning) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/oprm/market/OprmMarketSizeByCnaeRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/oprm/market/OprmMarketSizeByCnaeRepository.java
@@ -29,7 +29,17 @@ public interface OprmMarketSizeByCnaeRepository extends JpaRepository<OprmMarket
                 ms.totalEmpresasMei,
                 ms.totalEmpresasSimples,
                 sc.opportunityScore,
-                sc.scoreStatus
+                sc.scoreStatus,
+                (select count(distinct c2.neutralNicheName)
+                    from OprmRoutineResearchCycle c2
+                    where c2.cnaeCode = ms.id.cnaeCode),
+                (select coalesce(sum(seed.costUsd), 0)
+                    from OprmNicheResearchSeed seed
+                    where seed.cnaeCode = ms.id.cnaeCode),
+                case when (select count(c3.id)
+                    from OprmRoutineResearchCycle c3
+                    where c3.cnaeCode = ms.id.cnaeCode
+                      and c3.status = 'RUNNING') > 0 then true else false end
             )
             from OprmMarketSizeByCnae ms
             left join OprmCnpjCnaeDim c on c.cnaeCode = ms.id.cnaeCode
@@ -53,7 +63,17 @@ public interface OprmMarketSizeByCnaeRepository extends JpaRepository<OprmMarket
                 ms.totalEmpresasMei,
                 ms.totalEmpresasSimples,
                 sc.opportunityScore,
-                sc.scoreStatus
+                sc.scoreStatus,
+                (select count(distinct c2.neutralNicheName)
+                    from OprmRoutineResearchCycle c2
+                    where c2.cnaeCode = ms.id.cnaeCode),
+                (select coalesce(sum(seed.costUsd), 0)
+                    from OprmNicheResearchSeed seed
+                    where seed.cnaeCode = ms.id.cnaeCode),
+                case when (select count(c3.id)
+                    from OprmRoutineResearchCycle c3
+                    where c3.cnaeCode = ms.id.cnaeCode
+                      and c3.status = 'RUNNING') > 0 then true else false end
             )
             from OprmMarketSizeByCnae ms
             left join OprmCnpjCnaeDim c on c.cnaeCode = ms.id.cnaeCode

--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -893,3 +893,9 @@
 - Adicionado botão “Relatório” para cada execução do NichoCNAE, permitindo baixar um arquivo `nicho-cnae<id>.md` com detalhamento etapa por etapa.
 - Causa-raiz tratada: a tela permitia acompanhar o estado do pipeline, mas não entregava uma auditoria consolidada para o usuário analisar request/response de IA, URLs pesquisadas, retornos coletados, sinais, síntese e qualidade sem navegar por várias telas.
 - Prevenção de recorrência: o relatório é gerado pelo backend a partir das tabelas canônicas da execução, mantendo a tela como consumidora da verdade do backend e evitando inferência local no frontend.
+
+## 2026-06-18 — OPRM CNAE: ranking com subnichos, custo e pesquisa em execução
+
+- Ajustada a tabela “CNAEs por Score OPRM” para manter somente colunas decisórias de volume, remover métricas redundantes e exibir quantidade de subnichos, custo acumulado de pesquisa e indicador visual de processamento ativo.
+- Causa-raiz tratada: a tabela misturava indicadores cadastrais pouco acionáveis com dados operacionais de pesquisa, dificultando a decisão sobre onde criar, acompanhar ou interromper novos subnichos.
+- Prevenção de recorrência: os novos campos vêm do endpoint do backend, preservando a regra de verdade da tela e evitando inferência local no frontend.

--- a/frontend/src/api/oprm/useOprmTopCnaeMarketVolume.ts
+++ b/frontend/src/api/oprm/useOprmTopCnaeMarketVolume.ts
@@ -12,6 +12,9 @@ export interface OprmTopCnaeMarketVolume {
   totalEmpresasSimples: number;
   opportunityScore: number | null;
   scoreStatus: string | null;
+  subnicheCount: number;
+  researchCostUsd: number | null;
+  nicheResearchRunning: boolean;
 }
 
 async function fetchTopCnaes(

--- a/frontend/src/pages/oprm/OprmCnaeVolumePage.tsx
+++ b/frontend/src/pages/oprm/OprmCnaeVolumePage.tsx
@@ -17,6 +17,15 @@ function formatScore(value: number | undefined) {
     : value.toLocaleString("pt-BR", { maximumFractionDigits: 2 });
 }
 
+function formatCurrencyUsd(value: number | null | undefined) {
+  return (value ?? 0).toLocaleString("pt-BR", {
+    style: "currency",
+    currency: "USD",
+    minimumFractionDigits: 4,
+    maximumFractionDigits: 4,
+  });
+}
+
 function formatDateTime(value: string | null | undefined) {
   if (!value) {
     return "-";
@@ -271,11 +280,11 @@ export default function OprmCnaeVolumePage() {
                     <>
                       <th>Score OPRM ↓</th>
                       <th>Estab. total</th>
-                      <th>Empresas</th>
-                      <th>Empresas Simples</th>
-                      <th>Estab. ativos</th>
-                      <th>Empresas MEI</th>
-                      <th>Status score</th>
+                      <th>Simples</th>
+                      <th>MEI</th>
+                      <th>Subnichos</th>
+                      <th>Custo</th>
+                      <th>Pesquisa</th>
                     </>
                   ) : (
                     <th>Status</th>
@@ -301,13 +310,28 @@ export default function OprmCnaeVolumePage() {
                           {formatScore(item.opportunityScore ?? undefined)}
                         </td>
                         <td>{formatNumber(item.totalEstabelecimentos)}</td>
-                        <td>{formatNumber(item.totalEmpresas)}</td>
                         <td>{formatNumber(item.totalEmpresasSimples)}</td>
-                        <td>
-                          {formatNumber(item.totalEstabelecimentosAtivos)}
-                        </td>
                         <td>{formatNumber(item.totalEmpresasMei)}</td>
-                        <td>{item.scoreStatus ?? "Aguardando scheduler"}</td>
+                        <td>{formatNumber(item.subnicheCount)}</td>
+                        <td>{formatCurrencyUsd(item.researchCostUsd)}</td>
+                        <td>
+                          {item.nicheResearchRunning ? (
+                            <span
+                              className="text-primary"
+                              title="Pesquisa de nicho em execução neste CNAE"
+                              aria-label="Pesquisa de nicho em execução"
+                            >
+                              🔎
+                            </span>
+                          ) : (
+                            <span
+                              className="text-secondary"
+                              aria-label="Sem pesquisa em execução"
+                            >
+                              -
+                            </span>
+                          )}
+                        </td>
                       </tr>
                     ))
                   : (cnaeCatalogQuery.data ?? [])


### PR DESCRIPTION
### Motivation
- Tornar a tabela “CNAEs por Score OPRM” mais acionável removendo colunas redundantes e mostrando indicadores operacionais relevantes para decisão (subnichos, custo e execução de pesquisa).
- Fornecer a verdade do backend para a UI em vez de inferências locais, incluindo custo agregado de pesquisa e contagem de subnichos por CNAE.
- Expor visualmente no frontend quando existe pesquisa de nicho em execução para facilitar acompanhamento e operação imediata.

### Description
- Atualiza o contrato de saída `OprmTopCnaeMarketVolumeDto` para incluir `subnicheCount`, `researchCostUsd` e `nicheResearchRunning` e ajusta a Javadoc do DTO. 
- Altera a query em `OprmMarketSizeByCnaeRepository` para calcular por CNAE a contagem de subnichos, a soma `costUsd` das seeds e se existe ciclo `RUNNING` entregando os novos campos no DTO. 
- Atualiza o tipo TypeScript `OprmTopCnaeMarketVolume` e o hook `useOprmTopCnaeMarketVolume` para consumir os novos campos do endpoint. 
- Ajusta a tela `OprmCnaeVolumePage.tsx` para remover colunas solicitadas, incluir colunas `Subnichos` e `Custo`, formatar `researchCostUsd` em USD via `formatCurrencyUsd` e exibir o ícone `🔎` quando `nicheResearchRunning` for true. 
- Registra a alteração operacional no histórico `docs/registros/oprm1.md` explicando causa-raiz e prevenção de recorrência. 

### Testing
- Executado `./mvnw -f ads-service/pom.xml -DskipTests compile` no backend e a compilação foi bem-sucedida. 
- Executado o teste de unidade `BackendNicheResearchSeedBuilderServiceTest` com `./mvnw -f ads-service/pom.xml -Dtest=BackendNicheResearchSeedBuilderServiceTest test` e os testes passaram. 
- Rodado `npx prettier --write` sobre os arquivos frontend modificados para formatar o código com sucesso. 
- `npm run typecheck` e `npm test` no frontend não foram concluídos no ambiente por falta de `node_modules` (tipos e `vitest` ausentes), portanto a verificação/execução dos testes frontend não pôde ser finalizada.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a335cc825f48321856b0539a5528df7)