### PR TITLE
Ajusta testes OPRM para filas por etapa atual

### DIFF
--- a/backend/ads-service/src/test/java/com/marketinghub/oprm/nichocnae/OprmNicheRoutineCardRepositoryTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/oprm/nichocnae/OprmNicheRoutineCardRepositoryTest.java
@@ -25,15 +25,20 @@ class OprmNicheRoutineCardRepositoryTest {
   /** Garante que a fila MEI/autônomo expõe somente o ciclo ativo sintetizado mais recente. */
   @Test
   void findPendingMeiAudienceSegmentationShouldReturnOnlyLatestEligibleSynthesizedCycle() {
-    OprmRoutineResearchCycle oldSynthesized = saveCycle(100L, "ROUTINE_SYNTHESIZED", "2026-06-01T10:00:00Z");
+    OprmRoutineResearchCycle oldSynthesized =
+        saveCycle(100L, "ROUTINE_SYNTHESIZED", "mei-audience-segmenter", "2026-06-01T10:00:00Z");
     OprmNicheRoutineCard oldCard = saveCard(oldSynthesized, "cartão antigo sintetizado");
-    OprmRoutineResearchCycle latestSynthesized = saveCycle(100L, "ROUTINE_SYNTHESIZED", "2026-06-02T10:00:00Z");
+    OprmRoutineResearchCycle latestSynthesized =
+        saveCycle(100L, "ROUTINE_SYNTHESIZED", "mei-audience-segmenter", "2026-06-02T10:00:00Z");
     OprmNicheRoutineCard latestCard = saveCard(latestSynthesized, "cartão recente sintetizado");
-    OprmRoutineResearchCycle failed = saveCycle(200L, "FAILED", "2026-06-03T10:00:00Z");
+    OprmRoutineResearchCycle failed =
+        saveCycle(200L, "FAILED", "mei-audience-segmenter", "2026-06-03T10:00:00Z");
     OprmNicheRoutineCard failedCard = saveCard(failed, "cartão falho");
-    OprmRoutineResearchCycle cancelled = saveCycle(300L, "CANCELLED_BY_MANUAL_RESTART", "2026-06-04T10:00:00Z");
+    OprmRoutineResearchCycle cancelled =
+        saveCycle(300L, "CANCELLED_BY_MANUAL_RESTART", "mei-audience-segmenter", "2026-06-04T10:00:00Z");
     OprmNicheRoutineCard cancelledCard = saveCard(cancelled, "cartão cancelado");
-    OprmRoutineResearchCycle segmented = saveCycle(400L, "MEI_AUDIENCE_SEGMENTED", "2026-06-05T10:00:00Z");
+    OprmRoutineResearchCycle segmented =
+        saveCycle(400L, "MEI_AUDIENCE_SEGMENTED", "routine-quality-gate", "2026-06-05T10:00:00Z");
     OprmNicheRoutineCard segmentedCard = saveCard(segmented, "cartão já segmentado");
     saveProfile(segmented, segmentedCard);
 
@@ -47,10 +52,16 @@ class OprmNicheRoutineCardRepositoryTest {
   @Test
   void findPendingRoutineQualityGateShouldIgnoreCardsWithoutMeiAudienceProfileBeforeApplyingLimit() {
     for (int index = 0; index < 12; index++) {
-      OprmRoutineResearchCycle oldCycle = saveCycle(500L + index, "ROUTINE_SYNTHESIZED", "2026-06-06T10:0" + (index % 10) + ":00Z");
+      OprmRoutineResearchCycle oldCycle =
+          saveCycle(
+              500L + index,
+              "ROUTINE_SYNTHESIZED",
+              "mei-audience-segmenter",
+              "2026-06-06T10:0" + (index % 10) + ":00Z");
       saveCard(oldCycle, "cartão antigo sem perfil " + index);
     }
-    OprmRoutineResearchCycle eligibleCycle = saveCycle(900L, "MEI_AUDIENCE_SEGMENTED", "2026-06-07T10:00:00Z");
+    OprmRoutineResearchCycle eligibleCycle =
+        saveCycle(900L, "MEI_AUDIENCE_SEGMENTED", "routine-quality-gate", "2026-06-07T10:00:00Z");
     OprmNicheRoutineCard eligibleCard = saveCard(eligibleCycle, "cartão elegível com perfil MEI");
     saveProfile(eligibleCycle, eligibleCard);
 
@@ -60,7 +71,8 @@ class OprmNicheRoutineCardRepositoryTest {
   }
 
   /** Persiste um ciclo com os campos mínimos exigidos pelo contrato JPA do NichoCNAE. */
-  private OprmRoutineResearchCycle saveCycle(Long sourceNicheId, String status, String startedAt) {
+  private OprmRoutineResearchCycle saveCycle(
+      Long sourceNicheId, String status, String currentStageCode, String startedAt) {
     Instant start = Instant.parse(startedAt);
     OprmRoutineResearchCycle cycle = new OprmRoutineResearchCycle();
     cycle.setSourceNicheId(sourceNicheId);
@@ -74,6 +86,7 @@ class OprmNicheRoutineCardRepositoryTest {
     cycle.setSourceScore(BigDecimal.valueOf(85));
     cycle.setTriggerSource("TEST");
     cycle.setStatus(status);
+    cycle.setCurrentStageCode(currentStageCode);
     cycle.setTotalQueries(1);
     cycle.setTotalSourceCandidates(1);
     cycle.setTotalSourceSnapshots(1);

--- a/backend/ads-service/src/test/java/com/marketinghub/oprm/nichocnae/signalextractor/service/BackendSignalExtractorServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/oprm/nichocnae/signalextractor/service/BackendSignalExtractorServiceTest.java
@@ -41,8 +41,8 @@ class BackendSignalExtractorServiceTest {
   /** Deve listar snapshots coletados e ainda pendentes de extração. */
   @Test
   void listPendingUsesCompletedAndPendingFilters() {
-    when(sourceSnapshotRepository.findByFetchStatusAndSignalExtractionStatusOrderByResearchCycleIdAscIdAsc(
-            eq("COMPLETED"), eq("PENDING"), any(Pageable.class)))
+    when(sourceSnapshotRepository.findPendingByStatusAndCycleStage(
+            eq("COMPLETED"), eq("PENDING"), eq("signal-extractor"), any(Pageable.class)))
         .thenReturn(List.of(snapshot()));
     when(extractedSignalRepository.existsBySourceSnapshotId(901L)).thenReturn(false);
 

--- a/backend/ads-service/src/test/java/com/marketinghub/oprm/nichocnae/sourcesearcher/service/BackendSourceSearcherServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/oprm/nichocnae/sourcesearcher/service/BackendSourceSearcherServiceTest.java
@@ -42,7 +42,8 @@ class BackendSourceSearcherServiceTest {
   /** Deve listar queries pendentes em ordem operacional para execução pelo provedor de busca. */
   @Test
   void listPendingUsesResearchQueryPendingFilter() {
-    when(researchQueryRepository.findByStatusOrderByPriorityAscIdAsc(eq("PENDING"), any(Pageable.class)))
+    when(researchQueryRepository
+            .findPendingByStatusAndCycleStage(eq("PENDING"), eq("source-searcher"), any(Pageable.class)))
         .thenReturn(List.of(query()));
 
     var result = service.listPending();

--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -906,3 +906,9 @@
 - Ajustada a tabela “CNAEs por Score OPRM” para manter somente colunas decisórias de volume, remover métricas redundantes e exibir quantidade de subnichos, custo acumulado de pesquisa e indicador visual de processamento ativo.
 - Causa-raiz tratada: a tabela misturava indicadores cadastrais pouco acionáveis com dados operacionais de pesquisa, dificultando a decisão sobre onde criar, acompanhar ou interromper novos subnichos.
 - Prevenção de recorrência: os novos campos vêm do endpoint do backend, preservando a regra de verdade da tela e evitando inferência local no frontend.
+
+## 2026-06-18 — OPRM NichoCNAE: testes alinhados ao current_stage_code
+
+- Correção aplicada: os testes das filas OPRM NichoCNAE passaram a montar ciclos com `current_stage_code` coerente com a etapa consumida e os testes de service passaram a mockar os métodos `findPendingByStatusAndCycleStage`.
+- Causa-raiz tratada: os testes ainda refletiam a regra antiga baseada apenas em status/artefato, enquanto a implementação atual usa a etapa operacional do ciclo como fonte de verdade para expor pendências.
+- Prevenção de recorrência: as expectativas dos testes agora protegem o contrato de pending por etapa atual, evitando que workers consumam itens fora do ponto correto do pipeline.


### PR DESCRIPTION
### Motivation
- Os testes falhavam porque as queries de pending passaram a filtrar também por `current_stage_code` do ciclo e os testes ainda simulavam apenas `status`/contadores; era necessário alinhar os setups e mocks ao novo contrato por etapa.
- Garantir que as filas expostas pelo backend só retornem itens quando o ciclo estiver na etapa operacional esperada evita que workers processem registros fora do ponto correto do pipeline.

### Description
- Atualiza os testes JPA em `OprmNicheRoutineCardRepositoryTest` para criar ciclos com `current_stage_code` coerente com a etapa consumida e altera a assinatura de `saveCycle` para receber e persistir `currentStageCode` (`cycle.setCurrentStageCode(...)`).
- Altera os testes de service para mockar os novos contratos `findPendingByStatusAndCycleStage(...)` usados pela implementação, incluindo `signal-extractor` no `BackendSignalExtractorServiceTest` e `source-searcher` no `BackendSourceSearcherServiceTest`.
- Documenta a correção em `docs/registros/oprm1.md` registrando que os testes agora protegem o contrato de pending por etapa atual.

### Testing
- Executei os unit tests selecionados com `../mvnw -Dtest=OprmNicheRoutineCardRepositoryTest,BackendSignalExtractorServiceTest,BackendSourceSearcherServiceTest test` e os testes passaram com `BUILD SUCCESS`.
- Verifiquei que as alterações dos testes efetivamente exercitam os novos métodos `findPendingByStatusAndCycleStage(...)` e retornam os itens esperados nas assertions. 
- A tentativa de rodar `../mvnw spotless:check -Dspotless.check.skip=false` falhou porque o plugin Spotless não está configurado/resolvido no ambiente Maven, portanto a checagem de formatação não foi executada.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a336e4899c083218e810352ea6e225a)