### PR TITLE
Corrige fuso horário no resumo da biblioteca MOIS

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryService.java
@@ -11,6 +11,7 @@ import java.sql.SQLException;
 import java.sql.Timestamp;
 import java.time.Instant;
 import java.util.ArrayList;
+import java.util.Calendar;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.HexFormat;
@@ -19,6 +20,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import java.util.TimeZone;
 import java.util.UUID;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -33,6 +35,8 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 @Slf4j
 public class MoisSalesLibraryService {
+
+    private static final TimeZone UTC_TIME_ZONE = TimeZone.getTimeZone("UTC");
 
     private static final String JOB_STATUS_PENDING = "PENDING";
     private static final String ANALYSIS_STATUS_CANCELED = "ANULADO";
@@ -123,7 +127,7 @@ public class MoisSalesLibraryService {
                 rs.getLong("html_bytes"),
                 rs.getString("analysis_status"),
                 rs.getInt("next_attempt"),
-                toInstant(rs.getTimestamp("last_captured_at")),
+                toInstant(rs, "last_captured_at"),
                 rs.getBoolean("raw_html_available")
         ), workspaceId, normalizedSource, normalizedLimit);
         return new MoisSalesLibraryDtos.SalesLibraryPendingAnalysisResponse(
@@ -432,9 +436,9 @@ public class MoisSalesLibraryService {
                         """, (rs, rowNum) -> new MoisSalesLibraryDtos.SalesLibraryJobResponse(
                         rs.getLong("id"), rs.getLong("sales_page_id"), rs.getString("status"),
                         rs.getInt("attempt"), rs.getString("error_category"), rs.getString("error_message"),
-                        null, toInstant(rs.getTimestamp("created_at")),
-                        toInstant(rs.getTimestamp("updated_at")), toInstant(rs.getTimestamp("started_at")),
-                        toInstant(rs.getTimestamp("finished_at"))), jobId);
+                        null, toInstant(rs, "created_at"),
+                        toInstant(rs, "updated_at"), toInstant(rs, "started_at"),
+                        toInstant(rs, "finished_at")), jobId);
         if (rows.isEmpty()) {
             throw new IllegalArgumentException("Job execution not found: " + jobId);
         }
@@ -464,9 +468,9 @@ public class MoisSalesLibraryService {
                         """ + statusClause + " ORDER BY updated_at DESC, id DESC LIMIT ? OFFSET ?",
                 (rs, rowNum) -> new MoisSalesLibraryDtos.SalesLibraryJobResponse(rs.getLong("id"), rs.getLong("sales_page_id"),
                         rs.getString("status"), rs.getInt("attempt"), rs.getString("error_category"), rs.getString("error_message"),
-                        null, toInstant(rs.getTimestamp("created_at")),
-                        toInstant(rs.getTimestamp("updated_at")), toInstant(rs.getTimestamp("started_at")),
-                        toInstant(rs.getTimestamp("finished_at"))),
+                        null, toInstant(rs, "created_at"),
+                        toInstant(rs, "updated_at"), toInstant(rs, "started_at"),
+                        toInstant(rs, "finished_at")),
                 normalizedStatus == null ? new Object[]{workspaceId, normalizedPageSize, offset} : new Object[]{workspaceId, normalizedStatus, normalizedPageSize, offset});
         return new MoisSalesLibraryDtos.SalesLibraryJobPageResponse(normalizedPage, normalizedPageSize, total == null ? 0 : total, items);
     }
@@ -487,8 +491,8 @@ public class MoisSalesLibraryService {
                         """, (rs, rowNum) -> new MoisSalesLibraryDtos.SalesLibraryEntryResponse(
                         rs.getLong("id"), rs.getString("workspace_id"), rs.getString("source"), rs.getString("url_original"),
                         rs.getString("url_canonical"), rs.getString("title"), rs.getInt("ingest_count"),
-                        toInstant(rs.getTimestamp("first_seen_at")), toInstant(rs.getTimestamp("last_captured_at")),
-                        toInstant(rs.getTimestamp("updated_at"))), workspaceId, normalizedPageSize, offset);
+                        toInstant(rs, "first_seen_at"), toInstant(rs, "last_captured_at"),
+                        toInstant(rs, "updated_at")), workspaceId, normalizedPageSize, offset);
         return new MoisSalesLibraryDtos.SalesLibraryEntryPageResponse(normalizedPage, normalizedPageSize, total == null ? 0 : total, items);
     }
 
@@ -782,9 +786,9 @@ public class MoisSalesLibraryService {
                 rs.getLong("market_warmup_cold"), rs.getLong("market_warmup_saturated"),
                 rs.getLong("market_warmup_stuck"),
                 rs.getLong("capturing") > 0 || rs.getLong("captured_last_hour") > 0,
-                toInstant(rs.getTimestamp("last_captured_at")), rs.getLong("captured_last_hour"),
+                toInstant(rs, "last_captured_at"), rs.getLong("captured_last_hour"),
                 rs.getLong("remaining_without_html"), rs.getBigDecimal("average_captures_per_hour"),
-                toInstant(rs.getTimestamp("updated_at"))), workspaceId, workspaceId, workspaceId);
+                toInstant(rs, "updated_at")), workspaceId, workspaceId, workspaceId);
     }
 
     /**
@@ -839,7 +843,7 @@ public class MoisSalesLibraryService {
                 rs.getBigDecimal("score_total"), rs.getString("parser_version"), rs.getString("prompt_version"), rs.getString("model_name"), rs.getString("sections_json"),
                 rs.getString("copy_json"), rs.getString("visual_json"), rs.getString("image_json"),
                 rs.getString("error_message"), rs.getString("request_payload_json"), rs.getString("response_payload_json"),
-                toInstant(rs.getTimestamp("finished_at")), toInstant(rs.getTimestamp("updated_at"))), pageId);
+                toInstant(rs, "finished_at"), toInstant(rs, "updated_at")), pageId);
         if (rows.isEmpty()) throw new IllegalArgumentException("Analysis not found for page: " + pageId);
         return rows.get(0);
     }
@@ -861,9 +865,9 @@ public class MoisSalesLibraryService {
                 rs.getString("status"), rs.getInt("attempt"), rs.getString("input_url"), rs.getString("final_url"),
                 rs.getString("redirect_root_url"), (Integer) rs.getObject("http_status"), rs.getString("content_type"),
                 rs.getLong("raw_html_bytes"), rs.getLong("screenshot_bytes"), rs.getBigDecimal("score_total"),
-                rs.getString("error_category"), rs.getString("error_message"), toInstant(rs.getTimestamp("started_at")),
-                toInstant(rs.getTimestamp("finished_at")), toInstant(rs.getTimestamp("created_at")),
-                toInstant(rs.getTimestamp("updated_at"))), pageId);
+                rs.getString("error_category"), rs.getString("error_message"), toInstant(rs, "started_at"),
+                toInstant(rs, "finished_at"), toInstant(rs, "created_at"),
+                toInstant(rs, "updated_at")), pageId);
     }
 
 
@@ -1410,9 +1414,9 @@ public class MoisSalesLibraryService {
                 mapEnum(MoisSalesLibraryDtos.MarketWarmupEcosystemType.class, rs.getString("ecosystem_type")),
                 recommendation,
                 rs.getString("saturation_risk"),
-                toInstant(rs.getTimestamp("evidence_updated_at")),
+                toInstant(rs, "evidence_updated_at"),
                 resolveSuggestedNextAction(temperature, recommendation, nextSuggestion),
-                buildRankingEvidenceSummary(rs.getBigDecimal("page_score_total"), rs.getBigDecimal("warmup_score_total"), rs.getString("saturation_risk"), toInstant(rs.getTimestamp("evidence_updated_at")))
+                buildRankingEvidenceSummary(rs.getBigDecimal("page_score_total"), rs.getBigDecimal("warmup_score_total"), rs.getString("saturation_risk"), toInstant(rs, "evidence_updated_at"))
         );
     }
 
@@ -1484,15 +1488,15 @@ public class MoisSalesLibraryService {
                 rs.getString("last_error_category"),
                 rs.getString("last_error_message"),
                 rs.getObject("last_job_execution_id", Long.class),
-                toInstant(rs.getTimestamp("last_captured_at")),
-                toInstant(rs.getTimestamp("last_analyzed_at")),
-                toInstant(rs.getTimestamp("updated_at")),
+                toInstant(rs, "last_captured_at"),
+                toInstant(rs, "last_analyzed_at"),
+                toInstant(rs, "updated_at"),
                 rs.getBigDecimal("market_warmup_score_total"),
                 mapEnum(MoisSalesLibraryDtos.MarketWarmupTemperature.class, rs.getString("market_warmup_temperature")),
                 mapEnum(MoisSalesLibraryDtos.MarketWarmupEcosystemType.class, rs.getString("market_warmup_ecosystem_type")),
                 mapEnum(MoisSalesLibraryDtos.MarketWarmupRecommendation.class, rs.getString("market_warmup_recommendation")),
                 mapEnum(MoisSalesLibraryDtos.MarketWarmupJobStatus.class, rs.getString("market_warmup_status")),
-                toInstant(rs.getTimestamp("market_warmup_updated_at"))
+                toInstant(rs, "market_warmup_updated_at")
         );
     }
 
@@ -1534,6 +1538,17 @@ public class MoisSalesLibraryService {
      */
     private String normalizeSource(String source) {
         return source == null || source.isBlank() ? "UNKNOWN" : source.trim().toUpperCase(Locale.ROOT);
+    }
+
+    /**
+     * Lê uma coluna DATETIME gravada em UTC e converte em Instant sem depender do fuso do servidor.
+     */
+    private Instant toInstant(ResultSet rs, String columnName) throws SQLException {
+        Timestamp timestamp = rs.getTimestamp(columnName, Calendar.getInstance(UTC_TIME_ZONE));
+        if (timestamp == null) {
+            timestamp = rs.getTimestamp(columnName);
+        }
+        return toInstant(timestamp);
     }
 
     /**

--- a/backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryServiceTest.java
@@ -15,6 +15,7 @@ import java.sql.ResultSet;
 import java.sql.Timestamp;
 import java.math.BigDecimal;
 import java.time.Instant;
+import java.util.Calendar;
 import java.util.List;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -165,6 +166,31 @@ class MoisSalesLibraryServiceTest {
         org.assertj.core.api.Assertions.assertThat(response.marketWarmupCompleted()).isEqualTo(70L);
         org.assertj.core.api.Assertions.assertThat(response.marketWarmupPromising()).isEqualTo(28L);
         org.assertj.core.api.Assertions.assertThat(response.marketWarmupStuck()).isEqualTo(2L);
+    }
+
+    /**
+     * Garante que horários DATETIME do MySQL são lidos como UTC antes de serem exibidos no fuso de São Paulo.
+     */
+    @Test
+    void shouldReadSummaryTimestampsAsUtcDatetime() throws Exception {
+        given(jdbcTemplate.queryForObject(
+                contains("MAX(CASE WHEN COALESCE(p.html_bytes, 0) > 0 THEN p.last_captured_at END) AS last_captured_at"),
+                isA(RowMapper.class),
+                eq("workspace-001"),
+                eq("workspace-001"),
+                eq("workspace-001")))
+                .willAnswer(invocation -> {
+                    RowMapper<?> mapper = invocation.getArgument(1);
+                    ResultSet row = salesPageSummaryRow();
+                    return mapper.mapRow(row, 0);
+                });
+
+        MoisSalesLibraryDtos.SalesLibraryPageSummaryResponse response = service.summarizePages("workspace-001");
+
+        org.assertj.core.api.Assertions.assertThat(response.lastCapturedAt())
+                .isEqualTo(Instant.parse("2026-06-18T02:50:00Z"));
+        org.assertj.core.api.Assertions.assertThat(response.updatedAt())
+                .isEqualTo(Instant.parse("2026-06-18T03:05:00Z"));
     }
 
     /**
@@ -537,6 +563,45 @@ class MoisSalesLibraryServiceTest {
         given(resultSet.getString("url_canonical")).willReturn(urlCanonical);
         return resultSet;
     }
+
+    /**
+     * Monta uma linha simulada do resumo operacional com datas UTC vindas de DATETIME do MySQL.
+     */
+    private ResultSet salesPageSummaryRow() throws Exception {
+        ResultSet resultSet = org.mockito.Mockito.mock(ResultSet.class);
+        given(resultSet.getLong("total")).willReturn(403L);
+        given(resultSet.getLong("pending")).willReturn(0L);
+        given(resultSet.getLong("capturing")).willReturn(0L);
+        given(resultSet.getLong("captured")).willReturn(355L);
+        given(resultSet.getLong("analyzed")).willReturn(100L);
+        given(resultSet.getLong("analysis_pending")).willReturn(20L);
+        given(resultSet.getLong("analysis_running")).willReturn(1L);
+        given(resultSet.getLong("analysis_failed")).willReturn(2L);
+        given(resultSet.getLong("failed")).willReturn(3L);
+        given(resultSet.getLong("blocked_cooldown")).willReturn(0L);
+        given(resultSet.getLong("hotmart")).willReturn(300L);
+        given(resultSet.getLong("clickbank")).willReturn(103L);
+        given(resultSet.getLong("market_warmup_eligible")).willReturn(10L);
+        given(resultSet.getLong("market_warmup_pending")).willReturn(4L);
+        given(resultSet.getLong("market_warmup_running")).willReturn(1L);
+        given(resultSet.getLong("market_warmup_completed")).willReturn(5L);
+        given(resultSet.getLong("market_warmup_failed")).willReturn(0L);
+        given(resultSet.getLong("market_warmup_hot")).willReturn(1L);
+        given(resultSet.getLong("market_warmup_promising")).willReturn(2L);
+        given(resultSet.getLong("market_warmup_warm")).willReturn(1L);
+        given(resultSet.getLong("market_warmup_cold")).willReturn(1L);
+        given(resultSet.getLong("market_warmup_saturated")).willReturn(0L);
+        given(resultSet.getLong("market_warmup_stuck")).willReturn(0L);
+        given(resultSet.getLong("captured_last_hour")).willReturn(0L);
+        given(resultSet.getLong("remaining_without_html")).willReturn(48L);
+        given(resultSet.getBigDecimal("average_captures_per_hour")).willReturn(BigDecimal.valueOf(0.8));
+        given(resultSet.getTimestamp(eq("last_captured_at"), any(Calendar.class)))
+                .willReturn(Timestamp.from(Instant.parse("2026-06-18T02:50:00Z")));
+        given(resultSet.getTimestamp(eq("updated_at"), any(Calendar.class)))
+                .willReturn(Timestamp.from(Instant.parse("2026-06-18T03:05:00Z")));
+        return resultSet;
+    }
+
     /**
      * Monta uma linha simulada de entrada operacional de página consolidada.
      */

--- a/docs/registros/mois1.md
+++ b/docs/registros/mois1.md
@@ -1698,3 +1698,9 @@ Arquivos principais:
 
 - Ajustada a tela `/mois/sales-pages-library/pipeline` para exibir o horário da última captura no fuso `America/Sao_Paulo`, evitando leitura operacional em UTC ou no fuso local do navegador.
 - Mantido o dado vindo do backend como fonte de verdade; o frontend apenas formata a data para o fuso usado pela operação no Brasil.
+
+## 2026-06-18 — Correção da causa-raiz do fuso na última captura da Biblioteca Sales Pages
+
+- Corrigida a leitura de `DATETIME` do MySQL no backend da Biblioteca de Sales Pages para interpretar os horários operacionais como UTC antes de entregar `Instant` ao frontend.
+- Causa-raiz: o JDBC podia converter `DATETIME` usando o fuso padrão do servidor, fazendo a tela exibir horário futuro em São Paulo mesmo com o Windows do usuário no fuso correto.
+- Adicionado teste de regressão no resumo operacional para impedir que a “última captura feita” volte a depender do fuso do servidor Java/MySQL.


### PR DESCRIPTION
### Motivation
- Corrigir a causa-raiz que fazia a tela do pipeline mostrar horário incorreto (futuro) para “Última captura feita” devido à leitura de `DATETIME` pelo JDBC usando o fuso do servidor em vez de UTC. 
- Garantir que o backend entregue `Instant` coerente ao frontend para que a formatação em `America/Sao_Paulo` produza o horário esperado pelos operadores.

### Description
- Adicionada constante `UTC_TIME_ZONE` e novo helper `toInstant(ResultSet rs, String columnName)` que chama `rs.getTimestamp(columnName, Calendar.getInstance(UTC_TIME_ZONE))` para ler `DATETIME` como UTC. 
- Substituídas leituras diretas de `rs.getTimestamp(...)` por `toInstant(rs, "<coluna>")` em vários mapeamentos do `MoisSalesLibraryService` para preservar a interpretação UTC antes de converter para `Instant`. 
- Adicionado teste de regressão `shouldReadSummaryTimestampsAsUtcDatetime` e helper `salesPageSummaryRow()` em `MoisSalesLibraryServiceTest` para validar a interpretação UTC de `last_captured_at` e `updated_at`. 
- Atualizado registro operacional em `docs/registros/mois1.md` documentando a correção e incluídos os arquivos modificados no commit.

### Testing
- Adicionado teste unitário `shouldReadSummaryTimestampsAsUtcDatetime` (presente em `backend/ads-service/src/test/java/.../MoisSalesLibraryServiceTest.java`) para cobrir a leitura UTC dos `DATETIME`. 
- `git diff --check` passou sem erros após as alterações. 
- Tentativa de rodar os testes com `../mvnw -Dtest=MoisSalesLibraryServiceTest test` não concluiu porque a resolução de dependência falhou no Maven Central com `502 Bad Gateway` ao buscar `io.projectreactor.netty:reactor-netty-http:1.1.18`, portanto a suíte de testes não pôde ser executada integralmente no ambiente atual.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a337269cd9083219a0e5aa0ebe289c9)