### PR TITLE
Fix OPRM current stage backfill alias

### DIFF
--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-18-oprm-routine-cycle-current-stage.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-18-oprm-routine-cycle-current-stage.yaml
@@ -50,7 +50,7 @@ databaseChangeLog:
               LEFT JOIN oprm_research_query research_query ON research_query.research_cycle_id = cycle.id
               LEFT JOIN oprm_source_candidate candidate ON candidate.research_cycle_id = cycle.id
               LEFT JOIN oprm_source_snapshot snapshot ON snapshot.research_cycle_id = cycle.id
-              LEFT JOIN oprm_extracted_signal signal ON signal.research_cycle_id = cycle.id
+              LEFT JOIN oprm_extracted_signal extracted_signal ON extracted_signal.research_cycle_id = cycle.id
               LEFT JOIN oprm_niche_routine_card card ON card.research_cycle_id = cycle.id
               LEFT JOIN oprm_mei_audience_profile mei_profile ON mei_profile.research_cycle_id = cycle.id
               LEFT JOIN market_niche_enrichment_profile enrichment ON enrichment.research_cycle_id = cycle.id
@@ -60,8 +60,8 @@ databaseChangeLog:
                 WHEN card.ready_for_hypothesis = 1 AND card.quality_checked_at IS NOT NULL THEN 'enriched-niche-materializer'
                 WHEN mei_profile.id IS NOT NULL AND card.quality_checked_at IS NULL THEN 'routine-quality-gate'
                 WHEN card.id IS NOT NULL AND mei_profile.id IS NULL THEN 'mei-audience-segmenter'
-                WHEN signal.id IS NOT NULL AND card.id IS NULL THEN 'routine-synthesizer'
-                WHEN snapshot.id IS NOT NULL AND signal.id IS NULL THEN 'signal-extractor'
+                WHEN extracted_signal.id IS NOT NULL AND card.id IS NULL THEN 'routine-synthesizer'
+                WHEN snapshot.id IS NOT NULL AND extracted_signal.id IS NULL THEN 'signal-extractor'
                 WHEN candidate.id IS NOT NULL AND snapshot.id IS NULL THEN 'source-fetcher'
                 WHEN research_query.id IS NOT NULL AND candidate.id IS NULL THEN 'source-searcher'
                 WHEN seed.id IS NOT NULL AND research_query.id IS NOT NULL THEN 'source-searcher'

--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -912,3 +912,9 @@
 - Correção aplicada: os testes das filas OPRM NichoCNAE passaram a montar ciclos com `current_stage_code` coerente com a etapa consumida e os testes de service passaram a mockar os métodos `findPendingByStatusAndCycleStage`.
 - Causa-raiz tratada: os testes ainda refletiam a regra antiga baseada apenas em status/artefato, enquanto a implementação atual usa a etapa operacional do ciclo como fonte de verdade para expor pendências.
 - Prevenção de recorrência: as expectativas dos testes agora protegem o contrato de pending por etapa atual, evitando que workers consumam itens fora do ponto correto do pipeline.
+
+## 2026-06-18 — OPRM NichoCNAE: correção do backfill da etapa atual
+
+- Corrigido o changelog de backfill de `current_stage_code` para não usar `signal` como alias SQL, pois `SIGNAL` é palavra reservada no MySQL e bloqueava a migração do backend.
+- Causa-raiz tratada: o SQL do Liquibase estava semanticamente correto, mas não havia validado colisão de alias com palavra reservada do MySQL 5.7.
+- Prevenção de recorrência: aliases de changelogs devem usar nomes funcionais explícitos, evitando termos reservados ou ambíguos em SQL de bootstrap.


### PR DESCRIPTION
### Motivation
- Fix Liquibase migration failure on MySQL caused by using the reserved identifier `signal` as an SQL alias in the `current_stage_code` backfill so the update can run successfully on MySQL 5.7.

### Description
- Replaced the alias `signal` with `extracted_signal` in `backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-18-oprm-routine-cycle-current-stage.yaml` and recorded the change and root cause in `docs/registros/oprm1.md`.

### Testing
- Validated the updated JOIN/UPDATE syntax with the MCP `db_query` tool (`tools/call` -> `db_query`) and confirmed the SELECT with the same joins runs; ran `git diff --check` and validated `relativeToChangelogFile` includes; attempted running the module tests with `./mvnw -pl ads-service test` (could not run from parent reactor) and `../mvnw test` from `backend/ads-service` which executed the test suite (849 tests) and failed with 4 errors unrelated to this Liquibase alias change (notably `CreativeControllerTest` FK cleanup and `MoisSalesLibraryServiceTest` Mockito stubbing issues).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a33743762208321a5b8a3cf7d39b903)