### PR TITLE
Fix ResultSet timestamp mocking in operational listing test and update changelog

### DIFF
--- a/backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryServiceTest.java
@@ -614,9 +614,12 @@ class MoisSalesLibraryServiceTest {
         given(resultSet.getString("url_canonical")).willReturn("https://example.com/pagina");
         given(resultSet.getString("title")).willReturn("Página de oferta");
         given(resultSet.getInt("ingest_count")).willReturn(2);
-        given(resultSet.getTimestamp("first_seen_at")).willReturn(Timestamp.from(Instant.parse("2026-06-01T10:00:00Z")));
-        given(resultSet.getTimestamp("last_captured_at")).willReturn(Timestamp.from(Instant.parse("2026-06-02T10:00:00Z")));
-        given(resultSet.getTimestamp("updated_at")).willReturn(Timestamp.from(Instant.parse("2026-06-03T10:00:00Z")));
+        given(resultSet.getTimestamp(eq("first_seen_at"), any(Calendar.class)))
+                .willReturn(Timestamp.from(Instant.parse("2026-06-01T10:00:00Z")));
+        given(resultSet.getTimestamp(eq("last_captured_at"), any(Calendar.class)))
+                .willReturn(Timestamp.from(Instant.parse("2026-06-02T10:00:00Z")));
+        given(resultSet.getTimestamp(eq("updated_at"), any(Calendar.class)))
+                .willReturn(Timestamp.from(Instant.parse("2026-06-03T10:00:00Z")));
         return resultSet;
     }
 

--- a/docs/registros/mois1.md
+++ b/docs/registros/mois1.md
@@ -1704,3 +1704,9 @@ Arquivos principais:
 - Corrigida a leitura de `DATETIME` do MySQL no backend da Biblioteca de Sales Pages para interpretar os horários operacionais como UTC antes de entregar `Instant` ao frontend.
 - Causa-raiz: o JDBC podia converter `DATETIME` usando o fuso padrão do servidor, fazendo a tela exibir horário futuro em São Paulo mesmo com o Windows do usuário no fuso correto.
 - Adicionado teste de regressão no resumo operacional para impedir que a “última captura feita” volte a depender do fuso do servidor Java/MySQL.
+
+## 2026-06-18 — Correção do teste de listagem operacional da Biblioteca Sales Pages
+
+- Corrigido o mock do teste `shouldListEntriesFromOperationalSalesPageTable` para usar a mesma assinatura UTC do backend ao ler `DATETIME` de `mois_sales_page`.
+- Causa-raiz: o service passou a chamar `ResultSet#getTimestamp(String, Calendar)` para evitar dependência do fuso do servidor, mas o teste ainda simulava `ResultSet#getTimestamp(String)`.
+- A correção mantém a proteção contra regressão de fuso horário sem alterar o contrato funcional da listagem operacional.


### PR DESCRIPTION
### Motivation
- Prevent timezone-related test flakiness introduced when the service started calling `ResultSet#getTimestamp(String, Calendar)` to read `DATETIME` as UTC. 
- Keep the operational listing test aligned with the service behavior and document the change in the project changelog.

### Description
- Updated the mock in `MoisSalesLibraryServiceTest.salesPageEntryRow()` to use `getTimestamp(..., Calendar)` for `first_seen_at`, `last_captured_at` and `updated_at` instead of the old `getTimestamp(String)` signature. 
- This change matches the service's protected UTC-reading behavior and avoids server timezone leakage in tests. 
- Added an entry to `docs/registros/mois1.md` describing the timezone fix and the test correction to prevent regression.

### Testing
- Ran the unit test `MoisSalesLibraryServiceTest`, including `shouldListEntriesFromOperationalSalesPageTable`, and the test passed. 
- Ran the module unit test suite for the ads-service and all tests completed green.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3375f55fc08321ab86c66cd6efb8c2)