### PR TITLE
Match ResultSet#getTimestamp overload in test and disable processing guard in test config

### DIFF
--- a/backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryServiceTest.java
@@ -288,7 +288,8 @@ class MoisSalesLibraryServiceTest {
                     given(row.getString("ecosystem_type")).willReturn("CREATORS_HEATED");
                     given(row.getString("recommendation")).willReturn("PRIORITIZE");
                     given(row.getString("saturation_risk")).willReturn(null);
-                    given(row.getTimestamp("evidence_updated_at")).willReturn(Timestamp.from(Instant.parse("2026-06-09T12:00:00Z")));
+                    given(row.getTimestamp(eq("evidence_updated_at"), any(Calendar.class)))
+                            .willReturn(Timestamp.from(Instant.parse("2026-06-09T12:00:00Z")));
                     given(row.getString("next_experiment_suggestion")).willReturn("Criar experimento com promessa direta.");
                     given(row.getString("opportunity_recommendation")).willReturn("Priorizar mercado.");
                     return List.of(mapper.mapRow(row, 0));

--- a/backend/ads-service/src/test/resources/application-test.yml
+++ b/backend/ads-service/src/test/resources/application-test.yml
@@ -9,3 +9,8 @@ spring:
       ddl-auto: create-drop
   liquibase:
     enabled: false
+
+lead-portal:
+  worker:
+    processing-guard:
+      enabled: false


### PR DESCRIPTION
### Motivation
- Fix a failing unit test caused by the `ResultSet#getTimestamp` overload that accepts a `Calendar` parameter and prevent the processing guard from interfering with test execution.

### Description
- Update `MoisSalesLibraryServiceTest` to mock `row.getTimestamp(eq("evidence_updated_at"), any(Calendar.class))` instead of the no-arg overload, and add `lead-portal.worker.processing-guard.enabled: false` to `application-test.yml` to disable the guard during tests.

### Testing
- Ran the unit tests for the `backend/ads-service` module, including `MoisSalesLibraryServiceTest`, and the tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a33ca5cbf208321a341167f07dce166)