### PR TITLE
Quality Review: send only canonical `htmlGeraLanding` in prompt payload and update prompt/tests

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/openai/core/qualityreview/QualityReviewBackendClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/openai/core/qualityreview/QualityReviewBackendClient.java
@@ -85,14 +85,10 @@ public class QualityReviewBackendClient implements StageBackendPort<QualityRevie
         return new StageExecution<>(idJob, experimentId, stageCode, STATUS_STARTED, asInstant(item.get("executionRequestedAt")), input);
     }
 
-    /** Monta o contexto textual enviado ao modelo com os insumos mínimos necessários para avaliação visual e causa-raiz. */
+    /** Monta o contexto textual enxuto com somente o HTML final canônico necessário ao Quality Review. */
     private Map<String, Object> buildPromptDataFromPending(Map<String, Object> pending) {
         Map<String, Object> experiment = asMap(pending.get("experiment"));
         Map<String, Object> payload = new LinkedHashMap<>();
-        putIfPresent(payload, "experimentName", firstPresent(pending.get("experimentName"), experiment.get("name")));
-        putIfPresent(payload, "hypothesisTitle", firstPresent(pending.get("hypothesisTitle"), asMap(pending.get("hypothesis")).get("title")));
-        putIfPresent(payload, "landingPageWireframe", firstPresent(pending.get("landingPageWireframe"), experiment.get("landingPageWireframe")));
-        putIfPresent(payload, "landingPageDesignPreset", firstPresent(pending.get("landingPageDesignPreset"), experiment.get("landingPageDesignPreset")));
         putIfPresent(payload, "htmlGeraLanding", resolveHtmlGeraLanding(pending, experiment));
         return payload;
     }
@@ -106,11 +102,6 @@ public class QualityReviewBackendClient implements StageBackendPort<QualityRevie
     private String resolveHtmlGeraLanding(Map<String, Object> pending, Map<String, Object> experiment) {
         String html = asString(pending.get("htmlGeraLanding"));
         return html != null ? html : asString(experiment.get("htmlGeraLanding"));
-    }
-
-    /** Retorna o primeiro valor não nulo entre o contrato novo enxuto e o contrato legado aninhado. */
-    private Object firstPresent(Object primary, Object fallback) {
-        return primary != null ? primary : fallback;
     }
 
     /** Adiciona ao payload somente campos com valor real para preservar compatibilidade com Map.copyOf. */

--- a/ai-worker/src/main/resources/prompts/geralanding/landing-page-quality-review.md
+++ b/ai-worker/src/main/resources/prompts/geralanding/landing-page-quality-review.md
@@ -17,7 +17,7 @@ A landing do GeraLanding não deve apenas parecer bonita. Ela precisa cumprir um
 
 Use as imagens como evidência principal. Avalie o que aparece na tela, não o que provavelmente estava no briefing. Não recompense intenção invisível.
 
-Além dos screenshots, você receberá o HTML final consolidado `htmlGeraLanding` e dois artefatos de causa-raiz: `landingPageWireframe` e `landingPageDesignPreset`. Use os screenshots como evidência principal do que o visitante vê, use o HTML para confirmar problemas técnicos/textuais e use wireframe/preset apenas para separar se a causa provável veio da estrutura/copy upstream ou da composição visual.
+Além dos screenshots, você receberá somente o HTML final consolidado `htmlGeraLanding`. Use os screenshots como evidência principal do que o visitante vê e use o HTML apenas para confirmar problemas técnicos/textuais observáveis no artefato final.
 
 ## Arquivo enviado para avaliação de causa-raiz
 
@@ -27,31 +27,19 @@ Além dos screenshots, você receberá o HTML final consolidado `htmlGeraLanding
 {{htmlGeraLanding}}
 ```
 
-### Wireframe usado como referência estrutural (`landingPageWireframe`)
-
-```json
-{{landingPageWireframe}}
-```
-
-### Preset de design usado como referência visual (`landingPageDesignPreset`)
-
-```json
-{{landingPageDesignPreset}}
-```
-
 ### Screenshots renderizados enviados como imagens
 
 ```json
 {{renderedLandingScreenshots}}
 ```
 
-Ao preencher `blockingIssues` e `recommendedRegeneration`, cite problemas observáveis no `htmlGeraLanding` e nos screenshots renderizados. Quando recomendar regeneração, diferencie:
+Ao preencher `blockingIssues` e `recommendedRegeneration`, cite apenas problemas observáveis no `htmlGeraLanding` e nos screenshots renderizados. Quando recomendar regeneração, diferencie pela evidência final observada:
 
 - `LANDING_PAGE_WIREFRAME`: quando a falha principal estiver na ordem, estrutura, promessa, prova, CTA ou conteúdo planejado;
 - `LANDING_PAGE_DESIGN_PRESET`: quando a estrutura estiver correta, mas a percepção visual, contraste, hierarquia, espaçamento, responsividade ou acabamento estiver ruim;
 - `LANDING_PAGE_HTML`: quando o problema for montagem/renderização final, HTML/CSS, overflow, corte, conteúdo visível indevido ou aplicação incorreta do preset.
 
-Não use o wireframe ou o preset para perdoar uma falha visível na landing. Se a evidência visual estiver ruim, a nota deve refletir a experiência final do visitante.
+Não use intenção interna de etapas anteriores para perdoar uma falha visível na landing. Se a evidência visual estiver ruim, a nota deve refletir a experiência final do visitante.
 
 ## O que a landing precisa provar
 

--- a/ai-worker/src/test/java/com/marketinghub/worker/openai/core/qualityreview/QualityReviewBackendClientTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/openai/core/qualityreview/QualityReviewBackendClientTest.java
@@ -32,7 +32,7 @@ class QualityReviewBackendClientTest {
         server.shutdown();
     }
 
-    /** Deve expor HTML, wireframe e preset para renderização visual e diagnóstico de causa-raiz. */
+    /** Deve expor somente o HTML final canônico para renderização visual e prompt enxuto. */
     @Test
     void listPendingShouldExposeLeanQualityReviewInputsForScreenshotRendering() {
         server.enqueue(new MockResponse()
@@ -63,11 +63,19 @@ class QualityReviewBackendClientTest {
         assertThat(pending.getFirst().input().landingHtml())
                 .isEqualTo("<!doctype html><html><body><h1>Landing final</h1></body></html>");
         assertThat(pending.getFirst().input().promptData())
-                .containsOnlyKeys("experimentName", "hypothesisTitle", "landingPageWireframe", "landingPageDesignPreset", "htmlGeraLanding")
-                .containsEntry("experimentName", "Experimento visual")
-                .containsEntry("hypothesisTitle", "Hipótese visual")
+                .containsOnlyKeys("htmlGeraLanding")
                 .containsEntry("htmlGeraLanding", "<!doctype html><html><body><h1>Landing final</h1></body></html>")
-                .doesNotContainKeys("experimentId", "landingPageHtml", "CASE_DATA_BLOCK", "landingPageImageAssets", "adCopy", "adImageBriefing");
+                .doesNotContainKeys(
+                        "experimentName",
+                        "hypothesisTitle",
+                        "experimentId",
+                        "landingPageHtml",
+                        "landingPageWireframe",
+                        "landingPageDesignPreset",
+                        "CASE_DATA_BLOCK",
+                        "landingPageImageAssets",
+                        "adCopy",
+                        "adImageBriefing");
     }
 
     /** Deve manter compatibilidade com o contrato legado aninhado quando o backend ainda enviar experiment. */

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -4729,3 +4729,10 @@
 
 - Ajustada a lista de Testes de Nicho para substituir a coluna **Valor** por **Custo**.
 - A coluna agora mostra o custo total acumulado do nicho, calculado a partir dos custos dos experimentos retornados pelo backend, mantendo a tela orientada ao controle financeiro do nicho.
+
+## 2026-06-18 — Correção do contrato enxuto do Quality Review
+
+- solicitação: investigar a falha recente do teste `QualityReviewPromptBuilderTest` considerando o histórico de request grande na etapa `landing-page-quality-review`.
+- causa-raiz: o registro e o cânone já definiam que o Quality Review deve usar somente `htmlGeraLanding` e screenshots renderizados, mas o prompt markdown e o `QualityReviewBackendClient` voltaram a incluir artefatos intermediários (`landingPageWireframe` e `landingPageDesignPreset`), aumentando o payload e quebrando o teste de contrato que protege o request enxuto.
+- correção aplicada: o Worker AI voltou a montar `promptData` apenas com `htmlGeraLanding`; o prompt foi ajustado para não solicitar nem renderizar JSONs intermediários; o teste do client passou a bloquear explicitamente wireframe/preset no payload textual.
+- resultado esperado: o AI Worker recebe do backend apenas o insumo necessário para renderizar a landing e enviar screenshots ao modelo de visão, reduzindo risco de estouro de tamanho do request e mantendo a revisão focada no artefato final que o usuário verá.


### PR DESCRIPTION
### Motivation
- Reduce request payload size and enforce the canonical input for the Quality Review stage by sending only the final HTML (`htmlGeraLanding`) and screenshots to the vision prompt. 
- Fix a failing contract test caused by reintroduction of intermediate artifacts (`landingPageWireframe` and `landingPageDesignPreset`) that expanded the request and violated the lean payload requirement. 

### Description
- Simplified `QualityReviewBackendClient.buildPromptDataFromPending` to populate `promptData` with only `htmlGeraLanding` and removed inclusion of `experimentName`, `hypothesisTitle`, `landingPageWireframe`, and `landingPageDesignPreset`. 
- Adjusted HTML resolution helpers to prefer `htmlGeraLanding` from the pending item or nested `experiment` and removed the legacy `firstPresent` helper. 
- Updated the quality-review prompt markdown `landing-page-quality-review.md` to reference only `htmlGeraLanding` and removed sections that rendered `landingPageWireframe` and `landingPageDesignPreset`. 
- Updated unit tests in `QualityReviewBackendClientTest` to assert the lean contract (only `htmlGeraLanding` present) and to continue supporting legacy nested `experiment` payloads. 
- Added a docs entry describing the contract correction for the Quality Review stage. 

### Testing
- Ran unit tests including `QualityReviewBackendClientTest` which now contains `listPendingShouldExposeLeanQualityReviewInputsForScreenshotRendering` and `listPendingShouldReadLegacyNestedExperimentWhenLeanFieldsAreAbsent`, and they passed. 
- Executed the project test suite via `./gradlew test` and observed no test failures related to the Quality Review changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a33d0b937f08321a8894af8d768c707)