### PR TITLE
Limit backfill of OPRM current_stage to active (RUNNING) cycles to avoid lock timeouts

### DIFF
--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-18-oprm-routine-cycle-current-stage.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-18-oprm-routine-cycle-current-stage.yaml
@@ -48,6 +48,7 @@ databaseChangeLog:
               UPDATE oprm_routine_research_cycle cycle
               SET cycle.current_stage_code = 'enriched-niche-materializer'
               WHERE cycle.current_stage_code IS NULL
+                AND cycle.status = 'RUNNING'
                 AND EXISTS (
                   SELECT 1
                   FROM oprm_niche_routine_card card
@@ -59,6 +60,7 @@ databaseChangeLog:
               UPDATE oprm_routine_research_cycle cycle
               SET cycle.current_stage_code = 'routine-quality-gate'
               WHERE cycle.current_stage_code IS NULL
+                AND cycle.status = 'RUNNING'
                 AND EXISTS (
                   SELECT 1
                   FROM oprm_mei_audience_profile mei_profile
@@ -74,6 +76,7 @@ databaseChangeLog:
               UPDATE oprm_routine_research_cycle cycle
               SET cycle.current_stage_code = 'mei-audience-segmenter'
               WHERE cycle.current_stage_code IS NULL
+                AND cycle.status = 'RUNNING'
                 AND EXISTS (
                   SELECT 1
                   FROM oprm_niche_routine_card card
@@ -88,6 +91,7 @@ databaseChangeLog:
               UPDATE oprm_routine_research_cycle cycle
               SET cycle.current_stage_code = 'routine-synthesizer'
               WHERE cycle.current_stage_code IS NULL
+                AND cycle.status = 'RUNNING'
                 AND EXISTS (
                   SELECT 1
                   FROM oprm_extracted_signal extracted_signal
@@ -102,6 +106,7 @@ databaseChangeLog:
               UPDATE oprm_routine_research_cycle cycle
               SET cycle.current_stage_code = 'signal-extractor'
               WHERE cycle.current_stage_code IS NULL
+                AND cycle.status = 'RUNNING'
                 AND EXISTS (
                   SELECT 1
                   FROM oprm_source_snapshot snapshot
@@ -116,6 +121,7 @@ databaseChangeLog:
               UPDATE oprm_routine_research_cycle cycle
               SET cycle.current_stage_code = 'source-fetcher'
               WHERE cycle.current_stage_code IS NULL
+                AND cycle.status = 'RUNNING'
                 AND EXISTS (
                   SELECT 1
                   FROM oprm_source_candidate candidate
@@ -130,6 +136,7 @@ databaseChangeLog:
               UPDATE oprm_routine_research_cycle cycle
               SET cycle.current_stage_code = 'source-searcher'
               WHERE cycle.current_stage_code IS NULL
+                AND cycle.status = 'RUNNING'
                 AND EXISTS (
                   SELECT 1
                   FROM oprm_research_query research_query

--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -924,3 +924,9 @@
 - Corrigido o backfill Liquibase de `current_stage_code` para substituir o `UPDATE` único com múltiplos `LEFT JOINs` por atualizações segmentadas por etapa usando `EXISTS`/`NOT EXISTS` nas tabelas de artefatos.
 - Causa-raiz tratada: o SQL anterior fazia uma junção ampla entre várias tabelas do pipeline OPRM, multiplicando linhas por ciclo e mantendo locks por tempo suficiente para estourar `Lock wait timeout` na inicialização do backend.
 - Prevenção de recorrência: backfills de bootstrap devem evitar joins amplos entre tabelas operacionais de alta cardinalidade e preferir atualizações pequenas, indexáveis e ordenadas pela etapa funcional.
+
+## 2026-06-18 — OPRM NichoCNAE: backfill de etapa atual limitado a ciclos ativos
+
+- Corrigido o backfill Liquibase de `current_stage_code` para atualizar somente ciclos `RUNNING`, que são os únicos necessários para reabrir as filas `pending` após a migração.
+- Causa-raiz tratada: o backfill ainda varria ciclos históricos sem necessidade operacional imediata, ampliando o conjunto de linhas candidatas e aumentando a chance de conflito com locks em tabelas operacionais durante o bootstrap do backend.
+- Prevenção de recorrência: backfills executados na inicialização devem limitar o escopo ao dado necessário para manter a operação ativa, evitando reclassificação massiva de histórico quando a aplicação precisa apenas publicar pendências executáveis.


### PR DESCRIPTION
### Motivation

- The Liquibase backfill updated a large set of historical OPRM cycles during application bootstrap, causing `Lock wait timeout exceeded` errors on MySQL when the DB attempted to acquire long locks on high-cardinality tables. 
- The intent is to restrict the bootstrap backfill to only the cycles that matter for runtime (those in `RUNNING`), reducing lock contention and startup failures.

### Description

- Updated the changeset `backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-18-oprm-routine-cycle-current-stage.yaml` to add `AND cycle.status = 'RUNNING'` to each `UPDATE` clause in the backfill SQL so only active cycles are modified.
- Recorded the change and root-cause analysis in `docs/registros/oprm1.md` explaining why backfills executed on startup must limit scope to active data.

### Testing

- Validated YAML parsing of the modified changelog files using Ruby (`YAML.load_file(...)`) and the master changelog check, and both parsed successfully. 
- Verified the master changelog includes are correct (no missing `relativeToChangelogFile`) with a local script, and the check passed. 
- Compiled the backend module with `../mvnw -DskipTests compile` from `backend/ads-service` and the build completed with `BUILD SUCCESS`. 
- Ran `git diff --check` and basic repository checks to ensure no trailing whitespace or obvious diff errors; those checks passed, while a Python `PyYAML` validation attempt failed due to `PyYAML` not being available in the environment but was replaced by the Ruby validation which succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3403f0d0ec83219f4b364873686766)