### PR TITLE
Add composite indexes to support OPRM NichoCNAE manual restart and include changelog

### DIFF
--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-18-oprm-nichocnae-lock-indexes.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-18-oprm-nichocnae-lock-indexes.yaml
@@ -1,0 +1,30 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-06-18-01-oprm-nichocnae-lock-indexes
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - onError: HALT
+        - dbms:
+            type: mysql
+      changes:
+        - createIndex:
+            tableName: oprm_routine_research_cycle
+            indexName: idx_oprm_routine_cycle_cnae_finished_started
+            columns:
+              - column:
+                  name: cnae_code
+              - column:
+                  name: finished_at
+              - column:
+                  name: started_at
+        - createIndex:
+            tableName: oprm_niche_candidate
+            indexName: idx_oprm_niche_candidate_cnae_score_created
+            columns:
+              - column:
+                  name: cnae_code
+              - column:
+                  name: opportunity_score
+              - column:
+                  name: created_at

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -1,5 +1,8 @@
 databaseChangeLog:
   - include:
+      file: changesets/2026-06-18-oprm-nichocnae-lock-indexes.yaml
+      relativeToChangelogFile: true
+  - include:
       file: changesets/2026-06-18-oprm-routine-cycle-current-stage.yaml
       relativeToChangelogFile: true
   - include:

--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -930,3 +930,9 @@
 - Corrigido o backfill Liquibase de `current_stage_code` para atualizar somente ciclos `RUNNING`, que são os únicos necessários para reabrir as filas `pending` após a migração.
 - Causa-raiz tratada: o backfill ainda varria ciclos históricos sem necessidade operacional imediata, ampliando o conjunto de linhas candidatas e aumentando a chance de conflito com locks em tabelas operacionais durante o bootstrap do backend.
 - Prevenção de recorrência: backfills executados na inicialização devem limitar o escopo ao dado necessário para manter a operação ativa, evitando reclassificação massiva de histórico quando a aplicação precisa apenas publicar pendências executáveis.
+
+## 2026-06-18 — OPRM NichoCNAE: índices para reinício manual por CNAE
+
+- Adicionados índices compostos para as consultas de reinício manual do NichoCNAE por CNAE: ciclos por `cnae_code`/`finished_at`/`started_at` e candidatos por `cnae_code`/`opportunity_score`/`created_at`.
+- Causa-raiz tratada: o reinício manual precisava localizar ciclos abertos do CNAE e o melhor candidato com bloqueio pessimista sem índice alinhado ao filtro principal, aumentando varredura, tempo de transação e chance de `Lock wait timeout`.
+- Prevenção de recorrência: consultas operacionais com `FOR UPDATE` devem ter índice pelo filtro seletivo do comando para reduzir locks de faixa e tempo de espera no MySQL 5.7.


### PR DESCRIPTION
### Motivation

- Reduce `Lock wait timeout` and large table scans for manual restart operations by adding targeted indexes for CNAE-based queries that use `FOR UPDATE` and pessimistic locking.
- Ensure the new index changes are applied during deployment by adding the changeset to the master Liquibase changelog. 
- Document the rationale and migration details in the OPRM registro to record the operational impact and prevention measures.

### Description

- Add a new Liquibase changeset `changesets/2026-06-18-oprm-nichocnae-lock-indexes.yaml` that creates composite indexes `idx_oprm_routine_cycle_cnae_finished_started` on `oprm_routine_research_cycle(cnae_code, finished_at, started_at)` and `idx_oprm_niche_candidate_cnae_score_created` on `oprm_niche_candidate(cnae_code, opportunity_score, created_at)`.
- Include the new changeset in `backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml` so it runs as part of the database migration sequence.
- Update `docs/registros/oprm1.md` with a note explaining the added indexes, the root cause, and the prevention rationale.

### Testing

- Ran Liquibase changelog validation (`liquibase validate`) and generated the migration plan against a MySQL 5.7 target without errors. 
- Applied the changeset on a local MySQL 5.7 instance to verify index creation succeeded. 
- Executed the backend unit test suite in CI (`./gradlew test`) and observed no test failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a340cc1bd788321a3093d2734acf9dc)