### PR TITLE
fix: prevent OPRM Liquibase index timeout

### DIFF
--- a/backend/ads-service/src/main/resources/application.properties
+++ b/backend/ads-service/src/main/resources/application.properties
@@ -13,7 +13,7 @@ db.pool.keepalive-time=${DB_KEEPALIVE_TIME:300000}
 app.currency.usd-to-brl=${APP_USD_TO_BRL:5.0}
 
 
-spring.datasource.url=jdbc:mysql://${db.host}:${db.port}/${db.name}?connectTimeout=10000&socketTimeout=60000&tcpKeepAlive=true
+spring.datasource.url=jdbc:mysql://${db.host}:${db.port}/${db.name}?connectTimeout=10000&socketTimeout=600000&tcpKeepAlive=true
 spring.datasource.username=${db.username}
 spring.datasource.password=${db.password}
 spring.datasource.driver-class-name=com.mysql.cj.jdbc.Driver

--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-18-oprm-nichocnae-lock-indexes.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-18-oprm-nichocnae-lock-indexes.yaml
@@ -1,12 +1,16 @@
 databaseChangeLog:
   - changeSet:
-      id: 2026-06-18-01-oprm-nichocnae-lock-indexes
+      id: 2026-06-18-01-oprm-routine-cycle-cnae-finished-started-index
       author: codex
       preConditions:
         - onFail: MARK_RAN
         - onError: HALT
         - dbms:
             type: mysql
+        - not:
+            - indexExists:
+                tableName: oprm_routine_research_cycle
+                indexName: idx_oprm_routine_cycle_cnae_finished_started
       changes:
         - createIndex:
             tableName: oprm_routine_research_cycle
@@ -18,6 +22,20 @@ databaseChangeLog:
                   name: finished_at
               - column:
                   name: started_at
+
+  - changeSet:
+      id: 2026-06-18-02-oprm-niche-candidate-cnae-score-created-index
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - onError: HALT
+        - dbms:
+            type: mysql
+        - not:
+            - indexExists:
+                tableName: oprm_niche_candidate
+                indexName: idx_oprm_niche_candidate_cnae_score_created
+      changes:
         - createIndex:
             tableName: oprm_niche_candidate
             indexName: idx_oprm_niche_candidate_cnae_score_created

--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -936,3 +936,10 @@
 - Adicionados índices compostos para as consultas de reinício manual do NichoCNAE por CNAE: ciclos por `cnae_code`/`finished_at`/`started_at` e candidatos por `cnae_code`/`opportunity_score`/`created_at`.
 - Causa-raiz tratada: o reinício manual precisava localizar ciclos abertos do CNAE e o melhor candidato com bloqueio pessimista sem índice alinhado ao filtro principal, aumentando varredura, tempo de transação e chance de `Lock wait timeout`.
 - Prevenção de recorrência: consultas operacionais com `FOR UPDATE` devem ter índice pelo filtro seletivo do comando para reduzir locks de faixa e tempo de espera no MySQL 5.7.
+
+## 2026-06-18 — OPRM NichoCNAE: prevenção de timeout no Liquibase de índices
+
+- Corrigido o changelog de índices do reinício manual NichoCNAE para separar cada índice em um changeset próprio e validar `indexExists` antes da criação.
+- Aumentado o `socketTimeout` JDBC do backend para 10 minutos, evitando que operações DDL legítimas de inicialização sejam interrompidas no limite anterior de 60 segundos.
+- Causa-raiz tratada: o índice em tabela operacional podia demorar mais que o timeout de leitura do conector MySQL durante o bootstrap, fechando a conexão antes do fim da DDL e impedindo a aplicação de subir.
+- Prevenção de recorrência: DDLs potencialmente longas devem ser idempotentes por índice e o timeout JDBC precisa ser compatível com migrações estruturais de banco em produção.


### PR DESCRIPTION
### Motivation
- Liquibase index creation on operational OPRM tables can take longer than the JDBC `socketTimeout` causing the MySQL connector to close the connection and abort application bootstrap.  
- The index changelog previously used a single changeset and lacked idempotency guards, which can leave bootstrap in an inconsistent/failing state when a previous run partially executed.

### Description
- Increased JDBC `socketTimeout` in `backend/ads-service/src/main/resources/application.properties` from `60000` to `600000` (10 minutes) to allow legitimate DDL to complete during startup.  
- Split the single index changelog into two idempotent `changeSet`s in `backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-18-oprm-nichocnae-lock-indexes.yaml`, each guarded with `not -> indexExists` so creation is safe if a prior run already created the index.  
- Added an entry to `docs/registros/oprm1.md` documenting the root cause and the recurrence prevention measures applied.

### Testing
- Ran `cd backend/ads-service && ../mvnw -q -DskipTests compile` to ensure the module builds with the changes and it completed successfully.  
- Validated YAML syntax of the modified changelog and master include with `ruby -e "require 'yaml'; ARGV.each { |f| YAML.load_file(f) }; puts 'yaml-ok'"` and it returned `yaml-ok`.  
- Executed a relative-include validation script (Python) to confirm all `include` entries in `db.changelog-master.yaml` declare `relativeToChangelogFile: true` and it reported no violations.  
- Queried the database via MCP (`db_query`) to confirm target indexes did not exist prior to the fix and the check returned zero rows, and ran `git diff --check` which reported no whitespace/errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3415cacb908321810fbe1f975a2220)