### PR TITLE
Materialize validated Meta options as approved TargetingElement and make enqueue transactional

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/targeting/TargetingElementRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/targeting/TargetingElementRepository.java
@@ -8,6 +8,7 @@ import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 /**
@@ -19,6 +20,11 @@ public interface TargetingElementRepository extends JpaRepository<TargetingEleme
      * Lista todos os elementos vinculados a um nicho para sincronização e revisão.
      */
     List<TargetingElement> findByNicheId(Long nicheId);
+
+    /**
+     * Busca elemento já materializado pela Meta para manter idempotência da resolução.
+     */
+    Optional<TargetingElement> findFirstByNicheIdAndTypeAndMetaId(Long nicheId, TargetingElementType type, String metaId);
 
     /**
      * Lista elementos filtrados para telas administrativas de segmentação.

--- a/backend/ads-service/src/main/java/com/marketinghub/targeting/service/TargetingRequestService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/targeting/service/TargetingRequestService.java
@@ -6,6 +6,10 @@ import com.marketinghub.targeting.TargetingCandidateStatus;
 import com.marketinghub.targeting.TargetingCandidateType;
 import com.marketinghub.targeting.TargetingOption;
 import com.marketinghub.targeting.TargetingOptionSource;
+import com.marketinghub.targeting.TargetingElement;
+import com.marketinghub.targeting.TargetingElementSource;
+import com.marketinghub.targeting.TargetingElementStatus;
+import com.marketinghub.targeting.TargetingElementType;
 import com.marketinghub.targeting.TargetingResolutionJob;
 import com.marketinghub.targeting.TargetingResolutionJobStatus;
 import com.marketinghub.targeting.TargetingRequest;
@@ -25,6 +29,7 @@ import com.marketinghub.targeting.dto.TargetingResolutionSummaryDto;
 import com.marketinghub.targeting.mapper.TargetingResolutionSummaryMapper;
 import com.marketinghub.targeting.service.TargetingResolutionJobService.TargetingResolutionSummary;
 import com.marketinghub.repository.jpa.targeting.TargetingCandidateRepository;
+import com.marketinghub.repository.jpa.targeting.TargetingElementRepository;
 import com.marketinghub.repository.jpa.targeting.TargetingResolutionJobRepository;
 import com.marketinghub.repository.jpa.targeting.TargetingRequestRepository;
 import jakarta.persistence.EntityNotFoundException;
@@ -49,6 +54,9 @@ import java.util.Locale;
 import java.util.UUID;
 import java.util.regex.Pattern;
 
+/**
+ * Coordena solicitações de público, candidatos gerados por IA e materialização de opções Meta aprovadas.
+ */
 @Service
 public class TargetingRequestService {
     private static final Logger log = LoggerFactory.getLogger(TargetingRequestService.class);
@@ -64,14 +72,19 @@ public class TargetingRequestService {
 
     private final TargetingRequestRepository requestRepository;
     private final TargetingCandidateRepository candidateRepository;
+    private final TargetingElementRepository targetingElementRepository;
     private final TargetingResolutionJobRepository resolutionJobRepository;
     private final TargetingResolutionJobService resolutionJobService;
     private final TargetingResolutionSummaryMapper resolutionSummaryMapper;
     private final MarketNicheRepository nicheRepository;
     private final HypothesisRepository hypothesisRepository;
 
+    /**
+     * Inicializa o serviço com repositórios de solicitações, candidatos, elementos aprovados e jobs de resolução.
+     */
     public TargetingRequestService(TargetingRequestRepository requestRepository,
                                    TargetingCandidateRepository candidateRepository,
+                                   TargetingElementRepository targetingElementRepository,
                                    TargetingResolutionJobRepository resolutionJobRepository,
                                    TargetingResolutionJobService resolutionJobService,
                                    TargetingResolutionSummaryMapper resolutionSummaryMapper,
@@ -79,6 +92,7 @@ public class TargetingRequestService {
                                    HypothesisRepository hypothesisRepository) {
         this.requestRepository = requestRepository;
         this.candidateRepository = candidateRepository;
+        this.targetingElementRepository = targetingElementRepository;
         this.resolutionJobRepository = resolutionJobRepository;
         this.resolutionJobService = resolutionJobService;
         this.resolutionSummaryMapper = resolutionSummaryMapper;
@@ -246,6 +260,9 @@ public class TargetingRequestService {
         return saved;
     }
 
+    /**
+     * Aplica o retorno do Facebook Ads Worker e transforma opções validadas em públicos aprovados para experimentos.
+     */
     @Transactional
     public void applyResolution(Long candidateId, TargetingCandidateResolutionUpdateRequest payload) {
         if (payload == null || payload.getStatus() == null) {
@@ -258,8 +275,8 @@ public class TargetingRequestService {
         if (!CollectionUtils.isEmpty(candidate.getOptions())) {
             candidate.getOptions().clear();
         }
+        List<OptionPayload> optionPayloads = payload.getOptions();
         if (payload.getStatus() == TargetingCandidateStatus.VALIDATED) {
-            List<OptionPayload> optionPayloads = payload.getOptions();
             if (!CollectionUtils.isEmpty(optionPayloads)) {
                 for (OptionPayload optionPayload : optionPayloads) {
                     TargetingOption option = toOptionEntity(candidate, optionPayload);
@@ -270,10 +287,85 @@ public class TargetingRequestService {
             }
         }
         TargetingCandidate savedCandidate = candidateRepository.save(candidate);
+        materializeApprovedTargetingElements(savedCandidate, optionPayloads);
         updateResolutionJob(candidateId, payload, savedCandidate);
         log.info("Updated candidate {} with status {}", candidateId, candidate.getStatus());
     }
 
+    /**
+     * Materializa cada opção validada pela Meta como elemento aprovado disponível na aba Público do experimento.
+     */
+    private void materializeApprovedTargetingElements(TargetingCandidate candidate, List<OptionPayload> optionPayloads) {
+        if (candidate == null
+                || candidate.getStatus() != TargetingCandidateStatus.VALIDATED
+                || candidate.getRequest() == null
+                || candidate.getRequest().getNiche() == null
+                || CollectionUtils.isEmpty(optionPayloads)) {
+            return;
+        }
+        for (OptionPayload optionPayload : optionPayloads) {
+            TargetingElement element = toApprovedTargetingElement(candidate, optionPayload);
+            if (element != null) {
+                targetingElementRepository.save(element);
+            }
+        }
+    }
+
+    /**
+     * Converte uma opção Meta validada em elemento de segmentação aprovado e idempotente por nicho/tipo/metaId.
+     */
+    private TargetingElement toApprovedTargetingElement(TargetingCandidate candidate, OptionPayload payload) {
+        if (payload == null || !StringUtils.hasText(payload.getFacebookId()) || !StringUtils.hasText(payload.getName())) {
+            return null;
+        }
+        TargetingElementType elementType = toElementType(payload.getType() != null ? payload.getType() : candidate.getType());
+        if (elementType == null) {
+            return null;
+        }
+        String metaId = payload.getFacebookId().trim();
+        TargetingElement element = targetingElementRepository
+                .findFirstByNicheIdAndTypeAndMetaId(candidate.getRequest().getNiche().getId(), elementType, metaId)
+                .orElseGet(() -> TargetingElement.builder()
+                        .niche(candidate.getRequest().getNiche())
+                        .hypothesis(candidate.getRequest().getHypothesis())
+                        .type(elementType)
+                        .source(TargetingElementSource.AI)
+                        .build());
+        element.setTerm(payload.getName().trim());
+        element.setDescription(firstNonBlank(candidate.getRationale(), payload.getSearchTerm(), candidate.getSeed()));
+        element.setStatus(TargetingElementStatus.APPROVED);
+        element.setMetaId(metaId);
+        element.setMetaKey(payload.getName().trim());
+        element.setMetaIdUnavailable(false);
+        element.setMetaIdUnavailableReason(null);
+        element.setConfidence(payload.getFinalScore() != null ? payload.getFinalScore() : candidate.getScore());
+        if (payload.getAudienceSize() != null) {
+            element.setMetaAudienceSizeLowerBound(payload.getAudienceSize());
+            element.setMetaAudienceSizeUpperBound(payload.getAudienceSize());
+        }
+        if (element.getNiche() == null) {
+            element.setNiche(candidate.getRequest().getNiche());
+        }
+        return element;
+    }
+
+    /**
+     * Converte o tipo de candidato vindo do worker para o tipo canônico de elemento de público.
+     */
+    private TargetingElementType toElementType(TargetingCandidateType candidateType) {
+        if (candidateType == null) {
+            return null;
+        }
+        return switch (candidateType) {
+            case INTEREST -> TargetingElementType.INTEREST;
+            case BEHAVIOR -> TargetingElementType.BEHAVIOR;
+            case WORK_POSITION -> TargetingElementType.JOB_TITLE;
+        };
+    }
+
+    /**
+     * Atualiza o job de resolução com o resultado operacional recebido do worker.
+     */
     private void updateResolutionJob(Long candidateId,
                                      TargetingCandidateResolutionUpdateRequest payload,
                                      TargetingCandidate candidate) {

--- a/backend/ads-service/src/main/java/com/marketinghub/targeting/service/TargetingResolutionJobService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/targeting/service/TargetingResolutionJobService.java
@@ -7,12 +7,13 @@ import com.marketinghub.targeting.TargetingRequest;
 import com.marketinghub.repository.jpa.targeting.TargetingResolutionJobRepository;
 import jakarta.persistence.EntityManager;
 import jakarta.persistence.EntityNotFoundException;
-import jakarta.transaction.Transactional;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.PlatformTransactionManager;
 import org.springframework.transaction.support.TransactionSynchronization;
 import org.springframework.transaction.support.TransactionSynchronizationManager;
+import org.springframework.transaction.support.TransactionTemplate;
 import org.springframework.util.CollectionUtils;
 
 import java.time.Instant;
@@ -25,19 +26,31 @@ import java.util.Objects;
 import java.util.UUID;
 import java.util.stream.Collectors;
 
+/**
+ * Gerencia a fila persistida de resolução de candidatos de público pelo Facebook Ads Worker.
+ */
 @Service
 public class TargetingResolutionJobService {
     private static final Logger log = LoggerFactory.getLogger(TargetingResolutionJobService.class);
 
     private final TargetingResolutionJobRepository repository;
     private final EntityManager entityManager;
+    private final TransactionTemplate transactionTemplate;
 
+    /**
+     * Inicializa o serviço com persistência JPA e transação explícita para enfileiramento pós-commit.
+     */
     public TargetingResolutionJobService(TargetingResolutionJobRepository repository,
-                                         EntityManager entityManager) {
+                                         EntityManager entityManager,
+                                         PlatformTransactionManager transactionManager) {
         this.repository = repository;
         this.entityManager = entityManager;
+        this.transactionTemplate = new TransactionTemplate(transactionManager);
     }
 
+    /**
+     * Agenda a criação dos jobs de resolução Meta somente depois que os candidatos forem gravados.
+     */
     public void enqueueAfterCommit(TargetingRequest request, Collection<TargetingCandidate> candidates) {
         if (request == null || request.getId() == null || CollectionUtils.isEmpty(candidates)) {
             return;
@@ -50,7 +63,7 @@ public class TargetingResolutionJobService {
         if (CollectionUtils.isEmpty(candidateIds)) {
             return;
         }
-        Runnable action = () -> enqueueInternal(requestId, candidateIds);
+        Runnable action = () -> runEnqueueInNewTransaction(requestId, candidateIds);
         if (TransactionSynchronizationManager.isSynchronizationActive()) {
             TransactionSynchronizationManager.registerSynchronization(new TransactionSynchronization() {
                 @Override
@@ -63,8 +76,22 @@ public class TargetingResolutionJobService {
         }
     }
 
-    @Transactional
-    protected void enqueueInternal(UUID requestId, Collection<Long> candidateIds) {
+    /**
+     * Executa o enfileiramento em transação própria para não depender da transação que acabou de commitar.
+     */
+    private void runEnqueueInNewTransaction(UUID requestId, Collection<Long> candidateIds) {
+        try {
+            transactionTemplate.executeWithoutResult(status -> enqueueInternal(requestId, candidateIds));
+        } catch (RuntimeException ex) {
+            log.error("Failed to enqueue targeting candidates for Meta resolution: requestId={}, candidateIds={}", requestId, candidateIds, ex);
+            throw ex;
+        }
+    }
+
+    /**
+     * Persiste ou reinicia os jobs pendentes consumidos pelo Facebook Ads Worker.
+     */
+    private void enqueueInternal(UUID requestId, Collection<Long> candidateIds) {
         if (requestId == null || CollectionUtils.isEmpty(candidateIds)) {
             return;
         }
@@ -103,6 +130,9 @@ public class TargetingResolutionJobService {
         }
     }
 
+    /**
+     * Resume a situação operacional dos jobs por solicitação de targeting.
+     */
     public Map<UUID, TargetingResolutionSummary> summarizeByRequestIds(List<UUID> requestIds) {
         if (CollectionUtils.isEmpty(requestIds)) {
             return Collections.emptyMap();
@@ -119,6 +149,9 @@ public class TargetingResolutionJobService {
         return summaries;
     }
 
+    /**
+     * Consolida contadores, última tentativa, última conclusão e último erro de uma lista de jobs.
+     */
     private TargetingResolutionSummary summarize(List<TargetingResolutionJob> jobs) {
         if (CollectionUtils.isEmpty(jobs)) {
             return TargetingResolutionSummary.empty();
@@ -160,6 +193,9 @@ public class TargetingResolutionJobService {
         return new TargetingResolutionSummary(pending, processing, succeeded, failed, lastAttempt, lastCompleted, lastError);
     }
 
+    /**
+     * Representa o resumo operacional da fila de resolução Meta para uma solicitação.
+     */
     public record TargetingResolutionSummary(
             int pending,
             int processing,

--- a/backend/ads-service/src/test/java/com/marketinghub/targeting/service/TargetingRequestServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/targeting/service/TargetingRequestServiceTest.java
@@ -2,9 +2,13 @@ package com.marketinghub.targeting.service;
 
 import com.marketinghub.repository.jpa.hypothesis.HypothesisRepository;
 import com.marketinghub.repository.jpa.niche.MarketNicheRepository;
+import com.marketinghub.niche.MarketNiche;
 import com.marketinghub.targeting.TargetingCandidate;
 import com.marketinghub.targeting.TargetingCandidateStatus;
 import com.marketinghub.targeting.TargetingCandidateType;
+import com.marketinghub.targeting.TargetingElement;
+import com.marketinghub.targeting.TargetingElementStatus;
+import com.marketinghub.targeting.TargetingElementType;
 import com.marketinghub.targeting.TargetingOption;
 import com.marketinghub.targeting.TargetingRequest;
 import com.marketinghub.targeting.TargetingResolutionJob;
@@ -12,6 +16,7 @@ import com.marketinghub.targeting.TargetingResolutionJobStatus;
 import com.marketinghub.targeting.dto.TargetingCandidateResolutionUpdateRequest;
 import com.marketinghub.targeting.mapper.TargetingResolutionSummaryMapper;
 import com.marketinghub.repository.jpa.targeting.TargetingCandidateRepository;
+import com.marketinghub.repository.jpa.targeting.TargetingElementRepository;
 import com.marketinghub.repository.jpa.targeting.TargetingRequestRepository;
 import com.marketinghub.repository.jpa.targeting.TargetingResolutionJobRepository;
 import org.junit.jupiter.api.BeforeEach;
@@ -33,6 +38,9 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+/**
+ * Testa o fluxo de solicitações de targeting e materialização de públicos Meta aprovados.
+ */
 @ExtendWith(MockitoExtension.class)
 class TargetingRequestServiceTest {
 
@@ -40,6 +48,8 @@ class TargetingRequestServiceTest {
     private TargetingRequestRepository requestRepository;
     @Mock
     private TargetingCandidateRepository candidateRepository;
+    @Mock
+    private TargetingElementRepository targetingElementRepository;
     @Mock
     private TargetingResolutionJobRepository resolutionJobRepository;
     @Mock
@@ -53,11 +63,13 @@ class TargetingRequestServiceTest {
 
     private TargetingRequestService service;
 
+    /** Prepara o serviço com dependências simuladas para cada teste. */
     @BeforeEach
     void setUp() {
         service = new TargetingRequestService(
                 requestRepository,
                 candidateRepository,
+                targetingElementRepository,
                 resolutionJobRepository,
                 resolutionJobService,
                 resolutionSummaryMapper,
@@ -66,6 +78,7 @@ class TargetingRequestServiceTest {
         );
     }
 
+    /** Verifica que resolução validada conclui o job com sucesso e limpa erro anterior. */
     @Test
     void applyResolutionShouldUpdateJobAsSucceededAndClearLastError() {
         Long candidateId = 10L;
@@ -107,6 +120,61 @@ class TargetingRequestServiceTest {
         assertThat(savedJob.getFinishedAt()).isAfterOrEqualTo(savedJob.getStartedAt());
     }
 
+
+    /** Verifica que opções Meta validadas viram elementos aprovados disponíveis para experimentos. */
+    @Test
+    void applyResolutionShouldMaterializeValidatedMetaOptionsAsApprovedTargetingElements() {
+        Long candidateId = 12L;
+        MarketNiche niche = MarketNiche.builder().id(22L).name("Nicho unhas").build();
+        TargetingRequest request = TargetingRequest.builder()
+                .id(UUID.randomUUID())
+                .descricao("desc")
+                .niche(niche)
+                .build();
+        TargetingCandidate candidate = TargetingCandidate.builder()
+                .id(candidateId)
+                .request(request)
+                .seed("manicure")
+                .type(TargetingCandidateType.WORK_POSITION)
+                .status(TargetingCandidateStatus.PENDING_FACEBOOK_MATCH)
+                .rationale("Profissional do nicho")
+                .build();
+        TargetingResolutionJob job = TargetingResolutionJob.builder()
+                .candidate(candidate)
+                .request(request)
+                .status(TargetingResolutionJobStatus.PROCESSING)
+                .build();
+        TargetingCandidateResolutionUpdateRequest.OptionPayload option = option("meta-1", "Manicure");
+        option.setType(TargetingCandidateType.WORK_POSITION);
+        option.setAudienceSize(12345L);
+
+        TargetingCandidateResolutionUpdateRequest payload = new TargetingCandidateResolutionUpdateRequest();
+        payload.setStatus(TargetingCandidateStatus.VALIDATED);
+        payload.setOptions(List.of(option));
+
+        when(candidateRepository.findDetailedById(candidateId)).thenReturn(Optional.of(candidate));
+        when(candidateRepository.save(any(TargetingCandidate.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        when(targetingElementRepository.findFirstByNicheIdAndTypeAndMetaId(22L, TargetingElementType.JOB_TITLE, "meta-1"))
+                .thenReturn(Optional.empty());
+        when(resolutionJobRepository.findByCandidateId(candidateId)).thenReturn(Optional.of(job));
+
+        service.applyResolution(candidateId, payload);
+
+        ArgumentCaptor<TargetingElement> elementCaptor = ArgumentCaptor.forClass(TargetingElement.class);
+        verify(targetingElementRepository).save(elementCaptor.capture());
+        TargetingElement savedElement = elementCaptor.getValue();
+
+        assertThat(savedElement.getNiche()).isEqualTo(niche);
+        assertThat(savedElement.getType()).isEqualTo(TargetingElementType.JOB_TITLE);
+        assertThat(savedElement.getStatus()).isEqualTo(TargetingElementStatus.APPROVED);
+        assertThat(savedElement.getTerm()).isEqualTo("Manicure");
+        assertThat(savedElement.getMetaId()).isEqualTo("meta-1");
+        assertThat(savedElement.getMetaKey()).isEqualTo("Manicure");
+        assertThat(savedElement.getMetaAudienceSizeLowerBound()).isEqualTo(12345L);
+        assertThat(savedElement.getMetaAudienceSizeUpperBound()).isEqualTo(12345L);
+    }
+
+    /** Verifica que falha técnica mantém o candidato pendente e marca o job como falho. */
     @Test
     void applyResolutionShouldMarkJobFailedForTechnicalFailureStatus() {
         Long candidateId = 11L;
@@ -147,6 +215,7 @@ class TargetingRequestServiceTest {
         assertThat(savedJob.getStartedAt()).isEqualTo(startedAt);
     }
 
+    /** Monta uma opção Meta mínima para os testes de resolução. */
     private TargetingCandidateResolutionUpdateRequest.OptionPayload option(String facebookId, String name) {
         TargetingCandidateResolutionUpdateRequest.OptionPayload payload = new TargetingCandidateResolutionUpdateRequest.OptionPayload();
         payload.setFacebookId(facebookId);

--- a/backend/ads-service/src/test/java/com/marketinghub/targeting/service/TargetingResolutionJobServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/targeting/service/TargetingResolutionJobServiceTest.java
@@ -9,6 +9,7 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.transaction.PlatformTransactionManager;
 
 import java.time.Instant;
 import java.util.List;
@@ -18,6 +19,9 @@ import java.util.UUID;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
+/**
+ * Testa os resumos operacionais da fila de resolução de públicos Meta.
+ */
 @ExtendWith(MockitoExtension.class)
 class TargetingResolutionJobServiceTest {
 
@@ -27,9 +31,13 @@ class TargetingResolutionJobServiceTest {
     @Mock
     private EntityManager entityManager;
 
+    @Mock
+    private PlatformTransactionManager transactionManager;
+
+    /** Verifica que o resumo usa a conclusão mais recente entre jobs da mesma solicitação. */
     @Test
     void summarizeByRequestIdsShouldReturnLatestFinishedAtAsLastCompletedAt() {
-        TargetingResolutionJobService service = new TargetingResolutionJobService(repository, entityManager);
+        TargetingResolutionJobService service = new TargetingResolutionJobService(repository, entityManager, transactionManager);
         UUID requestId = UUID.randomUUID();
         Instant firstFinish = Instant.parse("2026-01-01T10:00:00Z");
         Instant latestFinish = Instant.parse("2026-01-01T12:00:00Z");

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -1,4 +1,19 @@
 
+## 2026-06-18 — Pipeline de públicos de nicho até seleção no experimento
+
+- solicitação: garantir que a criação de públicos na tela de nicho siga o fluxo IA → Facebook Ads Worker → públicos Meta disponíveis para seleção no experimento.
+- causa-raiz: a resolução Meta de candidatos ficava registrada apenas em `targeting_candidate`/`targeting_option`, sem materializar automaticamente os resultados validados como `targeting_element` aprovado; além disso, o enfileiramento pós-commit dos jobs de resolução dependia de chamada interna sem transação explícita.
+- foi feito: opções validadas pelo Facebook Ads Worker agora viram `TargetingElement` aprovado com `metaId`, `metaKey` e volume Meta, disponíveis para a aba Público do experimento; o enfileiramento de resolução Meta passou a abrir transação própria após commit para garantir jobs consumíveis pelo worker.
+- validação: testes unitários de targeting atualizados para cobrir materialização do público aprovado e resumo de jobs.
+- arquivos alterados:
+  - backend/ads-service/src/main/java/com/marketinghub/targeting/service/TargetingRequestService.java
+  - backend/ads-service/src/main/java/com/marketinghub/targeting/service/TargetingResolutionJobService.java
+  - backend/ads-service/src/main/java/com/marketinghub/repository/jpa/targeting/TargetingElementRepository.java
+  - backend/ads-service/src/test/java/com/marketinghub/targeting/service/TargetingRequestServiceTest.java
+  - backend/ads-service/src/test/java/com/marketinghub/targeting/service/TargetingResolutionJobServiceTest.java
+  - docs/registros/experimentos.md
+
+
 ## 2026-06-17 — Protocolo padrão backend: localização obrigatória dos testes
 
 - Atualizada a definição do protocolo padrão backend para explicitar que as regras/testes ArchUnit devem ficar no arquivo `backend/ads-service/src/test/java/com/marketinghub/architecture/ArquiteturaTest.java`.


### PR DESCRIPTION
### Motivation

- Ensure validated options returned by the Facebook Ads Worker are persisted as approved, idempotent `TargetingElement` records so they become selectable in experiment audiences.
- Prevent post-commit enqueue of resolution jobs from depending on the original transaction by running the enqueue in its own transaction.

### Description

- Added `findFirstByNicheIdAndTypeAndMetaId` to `TargetingElementRepository` to support idempotent lookup by `nicheId`, `type` and `metaId`.
- Extended `TargetingRequestService` to convert validated `TargetingCandidate` options into `TargetingElement` records via `materializeApprovedTargetingElements`, including mapping of type, `metaId`, `metaKey`, audience size and confidence, and reusing existing elements when present.
- Reworked `TargetingResolutionJobService` to schedule enqueue logic after commit in a new transaction using `TransactionTemplate` and `PlatformTransactionManager` and moved enqueue internals into `enqueueInternal` called via `transactionTemplate.executeWithoutResult`.
- Updated unit tests and documentation: added coverage for materialization in `TargetingRequestServiceTest`, adapted `TargetingResolutionJobServiceTest` to the new constructor signature, and recorded the change in `docs/registros/experimentos.md`.

### Testing

- Ran unit tests covering the modified behavior: `TargetingRequestServiceTest` (includes materialization assertions) and `TargetingResolutionJobServiceTest` (summarization and enqueue-related constructor); all assertions passed.
- Verified that the new repository lookup is exercised by the tests and that job summary logic returns the expected `lastCompletedAt` value during test runs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a344654d2b48321800e3ca8b786d39e)