### PR TITLE
fix(ai-worker): avoid direct import of CreativeGenerationStatus to fix compilation

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/creative/ExperimentCreativeService.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/creative/ExperimentCreativeService.java
@@ -6,7 +6,6 @@ import com.marketinghub.creative.dto.CreateCreativeRequest;
 import com.marketinghub.creative.service.CreativeService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marketinghub.experiment.Experiment;
-import com.marketinghub.experiment.CreativeGenerationStatus;
 import com.marketinghub.repository.jpa.experiment.ExperimentRepository;
 import com.marketinghub.hypothesis.Hypothesis;
 import com.marketinghub.worker.creative.pipeline.ExperimentPipelineAdExtractor;
@@ -29,8 +28,7 @@ import java.util.Map;
 import java.lang.reflect.Method;
 
 /**
- * Service that loops through experiments with {@code creativesToGenerate > 0}
- * and asks ChatGPT to generate creatives for each one.
+ * Serviço que processa experimentos com criativos pendentes e gera anúncios via IA.
  */
 @Service
 public class ExperimentCreativeService {
@@ -58,9 +56,7 @@ public class ExperimentCreativeService {
     }
 
     /**
-     * Generates creatives for all configured experiments.
-     *
-     * @return map keyed by experiment id containing the generated creatives
+     * Gera criativos para os experimentos configurados e retorna os itens por experimento.
      */
     @Transactional
     public Map<Long, List<Creative>> generate() {
@@ -84,7 +80,7 @@ public class ExperimentCreativeService {
                         ? generateFromPipeline(exp, qty)
                         : generateWithChatGpt(exp, qty);
                 exp.setCreativesToGenerate(0);
-                exp.setCreativeGenerationStatus(CreativeGenerationStatus.COMPLETED);
+                setCreativeGenerationStatus(exp, "COMPLETED");
                 exp.setCreativeGenerationFinishedAt(Instant.now());
                 exp.setCreativeGenerationError(null);
                 if (pipelineMode) {
@@ -104,7 +100,7 @@ public class ExperimentCreativeService {
      * Marca a solicitação como assumida pelo Worker AI antes de iniciar chamadas externas.
      */
     private void markProcessing(Experiment experiment) {
-        experiment.setCreativeGenerationStatus(CreativeGenerationStatus.PROCESSING);
+        setCreativeGenerationStatus(experiment, "PROCESSING");
         experiment.setCreativeGenerationStartedAt(Instant.now());
         experiment.setCreativeGenerationError(null);
         experimentRepository.save(experiment);
@@ -128,9 +124,9 @@ public class ExperimentCreativeService {
     private void markTimedOut(Experiment experiment) {
         log.warn("Creative generation timed out for experiment {}. pendingCreatives={} requestedAt={} status={}",
                 experiment.getId(), experiment.getCreativesToGenerate(), experiment.getCreativeGenerationRequestedAt(),
-                experiment.getCreativeGenerationStatus());
+                getCreativeGenerationStatusName(experiment));
         experiment.setCreativesToGenerate(0);
-        experiment.setCreativeGenerationStatus(CreativeGenerationStatus.TIMEOUT);
+        setCreativeGenerationStatus(experiment, "TIMEOUT");
         experiment.setCreativeGenerationFinishedAt(Instant.now());
         experiment.setCreativeGenerationError("Geração excedeu o tempo operacional de 30 minutos; solicite nova tentativa.");
         if (isPipelineAdsMode(experiment)) {
@@ -141,14 +137,14 @@ public class ExperimentCreativeService {
 
 
     /**
-     * Clears a failed creative generation request so the UI does not stay indefinitely blocked after logging the root cause.
+     * Limpa uma solicitação com falha para liberar nova tentativa após registrar a causa-raiz.
      */
     private void handleGenerationFailure(Experiment experiment, boolean pipelineMode, Exception exception) {
         log.error("Failed to generate creatives for experiment {}. pendingCreatives={} generationMode={} rootCauseCategory={} rootCauseMessage={}",
                 experiment.getId(), experiment.getCreativesToGenerate(), pipelineMode ? "PIPELINE_ADS" : "DEFAULT",
                 classifyRootCause(exception), rootCauseMessage(exception), exception);
         experiment.setCreativesToGenerate(0);
-        experiment.setCreativeGenerationStatus(CreativeGenerationStatus.FAILED);
+        setCreativeGenerationStatus(experiment, "FAILED");
         experiment.setCreativeGenerationFinishedAt(Instant.now());
         experiment.setCreativeGenerationError(truncate(rootCauseMessage(exception), 1024));
         if (pipelineMode) {
@@ -158,6 +154,35 @@ public class ExperimentCreativeService {
         log.warn("Cleared failed creative generation request for experiment {} to avoid an indefinite UI lock; user can request generation again after fixing the root cause",
                 experiment.getId());
     }
+
+    /**
+     * Atualiza o status da geração usando o enum fornecido pelo modelo canônico do backend.
+     */
+    @SuppressWarnings({"unchecked", "rawtypes"})
+    private void setCreativeGenerationStatus(Experiment experiment, String statusName) {
+        try {
+            Method setter = Experiment.class.getMethod("setCreativeGenerationStatus", Class.forName("com.marketinghub.experiment.CreativeGenerationStatus"));
+            Class<? extends Enum> statusType = (Class<? extends Enum>) setter.getParameterTypes()[0];
+            setter.invoke(experiment, Enum.valueOf(statusType, statusName));
+        } catch (ReflectiveOperationException exception) {
+            throw new IllegalStateException("Modelo canônico do backend não expõe CreativeGenerationStatus."
+                    + " Atualize a dependência ads-service usada pelo Worker AI.", exception);
+        }
+    }
+
+    /**
+     * Lê o status da geração sem acoplar o Worker AI à versão publicada do enum do backend.
+     */
+    private String getCreativeGenerationStatusName(Experiment experiment) {
+        try {
+            Method getter = Experiment.class.getMethod("getCreativeGenerationStatus");
+            Object status = getter.invoke(experiment);
+            return status == null ? null : status.toString();
+        } catch (ReflectiveOperationException exception) {
+            return null;
+        }
+    }
+
 
     /**
      * Generates default creatives and persists the batch only when every image URL is available.

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -1,3 +1,14 @@
+## 2026-06-18 — Correção de compilação do Worker AI na geração de criativos
+
+- solicitação: corrigir falha de compilação por import direto de `CreativeGenerationStatus` no Worker AI.
+- causa-raiz: o Worker AI compila contra a biblioteca canônica `ads-service` publicada/instalada; quando essa biblioteca ainda não expõe o enum esperado, o import direto quebra a compilação antes da atualização coordenada do pacote.
+- foi feito: o Worker AI deixou de importar diretamente o enum e passou a resolver o status pelo modelo canônico do backend em tempo de execução, mantendo a escrita dos estados operacionais sem duplicar modelo local.
+- validação: compilação do backend instalada localmente e empacotamento do Worker AI executado com sucesso; a suíte completa do Worker AI ainda apresenta falhas preexistentes de expectativa de número de salvamentos em `ExperimentCreativeServiceTest`.
+- arquivos alterados:
+  - ai-worker/src/main/java/com/marketinghub/worker/creative/ExperimentCreativeService.java
+  - docs/registros/experimentos.md
+
+
 ## 2026-06-18 — Estado operacional da geração de criativos do pipeline
 
 - solicitação: destravar a geração de anúncios do pipeline quando o item fica preso em “Gerando anúncios...”.


### PR DESCRIPTION
### Motivation
- Fix a compilation error in the AI worker caused by a direct import of `com.marketinghub.experiment.CreativeGenerationStatus` when the canonical `ads-service` artifact may not expose that enum at build time.

### Description
- Removed the direct import of `CreativeGenerationStatus` from `ai-worker/src/main/java/com/marketinghub/worker/creative/ExperimentCreativeService.java` and replaced direct enum usage with reflective setters/getters. 
- Added `setCreativeGenerationStatus(Experiment, String)` and `getCreativeGenerationStatusName(Experiment)` which resolve the backend enum via reflection and invoke `Experiment` accessors at runtime. 
- Updated all calls in `ExperimentCreativeService` to use the new helpers and adjusted service comments to Portuguese for clarity. 
- Recorded the change in `docs/registros/experimentos.md` to document the fix and rationale.

### Testing
- Built and installed the backend canonical library with `mvn -q install -DskipTests` in `backend/ads-service`, which completed successfully. 
- Packaged the AI worker with `mvn -q package -DskipTests` in `ai-worker`, which completed successfully (compilation/packaging validated). 
- Ran the AI worker test suite with `mvn -q test` in `ai-worker`, which failed: `ExperimentCreativeServiceTest` reported 3 failures (Mockito `TooManyActualInvocations`) and the test suite contains additional preexisting failures; packaging succeeded but unit tests did not all pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3452dc30f48321bef705ea2a670d02)