### PR TITLE
Fix ai-worker creative metadata compilation

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/creative/ExperimentCreativeService.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/creative/ExperimentCreativeService.java
@@ -26,6 +26,8 @@ import java.util.Locale;
 import java.util.List;
 import java.util.Map;
 import java.lang.reflect.Method;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * Serviço que processa experimentos com criativos pendentes e gera anúncios via IA.
@@ -42,6 +44,7 @@ public class ExperimentCreativeService {
     private static final int PRIMARY_TEXT_MAX = 125;
     private static final int MAX_HASHTAGS = 30;
     private static final Duration CREATIVE_GENERATION_TIMEOUT = Duration.ofMinutes(30);
+    private static final Set<String> MISSING_OPTIONAL_EXPERIMENT_METHODS = ConcurrentHashMap.newKeySet();
 
     public ExperimentCreativeService(ExperimentRepository experimentRepository,
                                      CreativeChatGptClient chatGptClient,
@@ -81,8 +84,8 @@ public class ExperimentCreativeService {
                         : generateWithChatGpt(exp, qty);
                 exp.setCreativesToGenerate(0);
                 setCreativeGenerationStatus(exp, "COMPLETED");
-                exp.setCreativeGenerationFinishedAt(Instant.now());
-                exp.setCreativeGenerationError(null);
+                setCreativeGenerationFinishedAt(exp, Instant.now());
+                setCreativeGenerationError(exp, null);
                 if (pipelineMode) {
                     setCreativeGenerationMode(exp, "DEFAULT");
                 }
@@ -101,8 +104,8 @@ public class ExperimentCreativeService {
      */
     private void markProcessing(Experiment experiment) {
         setCreativeGenerationStatus(experiment, "PROCESSING");
-        experiment.setCreativeGenerationStartedAt(Instant.now());
-        experiment.setCreativeGenerationError(null);
+        setCreativeGenerationStartedAt(experiment, Instant.now());
+        setCreativeGenerationError(experiment, null);
         experimentRepository.save(experiment);
     }
 
@@ -110,7 +113,7 @@ public class ExperimentCreativeService {
      * Verifica se a solicitação ficou pendente por tempo maior que o limite operacional.
      */
     private boolean hasTimedOut(Experiment experiment) {
-        Instant requestedAt = experiment.getCreativeGenerationRequestedAt();
+        Instant requestedAt = getCreativeGenerationRequestedAt(experiment);
         if (requestedAt == null) {
             requestedAt = experiment.getUpdatedAt();
         }
@@ -123,12 +126,12 @@ public class ExperimentCreativeService {
      */
     private void markTimedOut(Experiment experiment) {
         log.warn("Creative generation timed out for experiment {}. pendingCreatives={} requestedAt={} status={}",
-                experiment.getId(), experiment.getCreativesToGenerate(), experiment.getCreativeGenerationRequestedAt(),
+                experiment.getId(), experiment.getCreativesToGenerate(), getCreativeGenerationRequestedAt(experiment),
                 getCreativeGenerationStatusName(experiment));
         experiment.setCreativesToGenerate(0);
         setCreativeGenerationStatus(experiment, "TIMEOUT");
-        experiment.setCreativeGenerationFinishedAt(Instant.now());
-        experiment.setCreativeGenerationError("Geração excedeu o tempo operacional de 30 minutos; solicite nova tentativa.");
+        setCreativeGenerationFinishedAt(experiment, Instant.now());
+        setCreativeGenerationError(experiment, "Geração excedeu o tempo operacional de 30 minutos; solicite nova tentativa.");
         if (isPipelineAdsMode(experiment)) {
             setCreativeGenerationMode(experiment, "DEFAULT");
         }
@@ -145,8 +148,8 @@ public class ExperimentCreativeService {
                 classifyRootCause(exception), rootCauseMessage(exception), exception);
         experiment.setCreativesToGenerate(0);
         setCreativeGenerationStatus(experiment, "FAILED");
-        experiment.setCreativeGenerationFinishedAt(Instant.now());
-        experiment.setCreativeGenerationError(truncate(rootCauseMessage(exception), 1024));
+        setCreativeGenerationFinishedAt(experiment, Instant.now());
+        setCreativeGenerationError(experiment, truncate(rootCauseMessage(exception), 1024));
         if (pipelineMode) {
             setCreativeGenerationMode(experiment, "DEFAULT");
         }
@@ -180,6 +183,75 @@ public class ExperimentCreativeService {
             return status == null ? null : status.toString();
         } catch (ReflectiveOperationException exception) {
             return null;
+        }
+    }
+
+    /**
+     * Marca o início operacional da geração quando a versão canônica do modelo expõe esse campo.
+     */
+    private void setCreativeGenerationStartedAt(Experiment experiment, Instant startedAt) {
+        invokeOptionalExperimentSetter(experiment, "setCreativeGenerationStartedAt", Instant.class, startedAt);
+    }
+
+    /**
+     * Marca o encerramento operacional da geração quando a versão canônica do modelo expõe esse campo.
+     */
+    private void setCreativeGenerationFinishedAt(Experiment experiment, Instant finishedAt) {
+        invokeOptionalExperimentSetter(experiment, "setCreativeGenerationFinishedAt", Instant.class, finishedAt);
+    }
+
+    /**
+     * Registra a mensagem de erro operacional quando a versão canônica do modelo expõe esse campo.
+     */
+    private void setCreativeGenerationError(Experiment experiment, String error) {
+        invokeOptionalExperimentSetter(experiment, "setCreativeGenerationError", String.class, error);
+    }
+
+    /**
+     * Lê a data de solicitação quando a versão canônica do modelo expõe esse campo.
+     */
+    private Instant getCreativeGenerationRequestedAt(Experiment experiment) {
+        Object requestedAt = invokeOptionalExperimentGetter(experiment, "getCreativeGenerationRequestedAt");
+        return requestedAt instanceof Instant instant ? instant : null;
+    }
+
+    /**
+     * Invoca setters opcionais adicionados no modelo canônico sem quebrar a compilação contra pacote ainda defasado.
+     */
+    private void invokeOptionalExperimentSetter(Experiment experiment, String methodName, Class<?> valueType, Object value) {
+        try {
+            Method setter = Experiment.class.getMethod(methodName, valueType);
+            setter.invoke(experiment, value);
+        } catch (NoSuchMethodException exception) {
+            logMissingOptionalExperimentMethod(methodName);
+        } catch (ReflectiveOperationException exception) {
+            throw new IllegalStateException("Falha ao atualizar campo operacional de geração de criativos no modelo canônico do backend.", exception);
+        }
+    }
+
+    /**
+     * Invoca getters opcionais adicionados no modelo canônico sem quebrar a compilação contra pacote ainda defasado.
+     */
+    private Object invokeOptionalExperimentGetter(Experiment experiment, String methodName) {
+        try {
+            Method getter = Experiment.class.getMethod(methodName);
+            return getter.invoke(experiment);
+        } catch (NoSuchMethodException exception) {
+            logMissingOptionalExperimentMethod(methodName);
+            return null;
+        } catch (ReflectiveOperationException exception) {
+            throw new IllegalStateException("Falha ao ler campo operacional de geração de criativos no modelo canônico do backend.", exception);
+        }
+    }
+
+    /**
+     * Registra uma única vez quando o pacote ads-service usado pelo Worker AI ainda não expõe campos opcionais recentes.
+     */
+    private void logMissingOptionalExperimentMethod(String methodName) {
+        if (MISSING_OPTIONAL_EXPERIMENT_METHODS.add(methodName)) {
+            log.warn("Modelo canônico ads-service usado pelo Worker AI ainda não expõe {}. "
+                    + "A compilação permanece compatível, mas atualize/publique o ads-service para persistir esse metadado operacional.",
+                    methodName);
         }
     }
 

--- a/ai-worker/src/test/java/com/marketinghub/worker/creative/ExperimentCreativeServiceTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/creative/ExperimentCreativeServiceTest.java
@@ -3,6 +3,7 @@ package com.marketinghub.worker.creative;
 import com.marketinghub.creative.Creative;
 import com.marketinghub.creative.dto.CreateCreativeRequest;
 import com.marketinghub.experiment.CreativeGenerationMode;
+import com.marketinghub.experiment.CreativeGenerationStatus;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marketinghub.creative.service.CreativeService;
 import com.marketinghub.experiment.Experiment;
@@ -86,8 +87,10 @@ class ExperimentCreativeServiceTest {
         assertThat(usedPrompt).contains("hipótese \"title\"");
         assertThat(req.getImageUrl()).isEqualTo("img");
         verify(creativeService).create(1L, req);
-        verify(experimentRepository).save(experiment);
+        verify(experimentRepository, times(2)).save(experiment);
         assertThat(experiment.getCreativesToGenerate()).isZero();
+        assertThat(experiment.getCreativeGenerationStatus()).isEqualTo(CreativeGenerationStatus.COMPLETED);
+        assertThat(experiment.getCreativeGenerationError()).isNull();
         assertThat(result.get(1L)).containsExactly(saved);
     }
 
@@ -245,7 +248,9 @@ class ExperimentCreativeServiceTest {
         assertThat(req.getImageUrl()).isNull();
         assertThat(result).doesNotContainKey(1L);
         assertThat(experiment.getCreativesToGenerate()).isZero();
-        verify(experimentRepository).save(experiment);
+        verify(experimentRepository, times(2)).save(experiment);
+        assertThat(experiment.getCreativeGenerationStatus()).isEqualTo(CreativeGenerationStatus.FAILED);
+        assertThat(experiment.getCreativeGenerationError()).contains("Image generation returned no URL");
     }
 
     /**
@@ -270,7 +275,9 @@ class ExperimentCreativeServiceTest {
         assertThat(result).doesNotContainKey(1L);
         assertThat(experiment.getCreativesToGenerate()).isZero();
         assertThat(experiment.getCreativeGenerationMode()).isEqualTo(CreativeGenerationMode.DEFAULT);
-        verify(experimentRepository).save(experiment);
+        verify(experimentRepository, times(2)).save(experiment);
+        assertThat(experiment.getCreativeGenerationStatus()).isEqualTo(CreativeGenerationStatus.FAILED);
+        assertThat(experiment.getCreativeGenerationError()).contains("Image generation returned no URL");
     }
 
 }

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -1,3 +1,14 @@
+## 2026-06-18 — Compatibilidade de compilação do Worker AI com metadados de geração de criativos
+
+- solicitação: corrigir a nova falha de compilação do Worker AI antes de gerar PR.
+- causa-raiz: o Worker AI passou a chamar diretamente getters/setters de metadados operacionais recém-adicionados ao `Experiment`, mas a dependência `ads-service` usada na compilação do módulo pode estar publicada em versão defasada.
+- foi feito: os metadados opcionais de data/erro da geração passaram a ser acessados por reflexão tolerante, mantendo compatibilidade de compilação sem duplicar modelo local; os testes do serviço foram alinhados ao fluxo atual, que salva o experimento ao assumir processamento e ao concluir/falhar.
+- validação: o backend foi instalado localmente, a compilação do Worker AI passou e o teste focado de geração de criativos passou; a suíte completa do Worker AI ainda depende de acesso de rede ao backend em schedulers durante testes de contexto.
+- arquivos alterados:
+  - ai-worker/src/main/java/com/marketinghub/worker/creative/ExperimentCreativeService.java
+  - ai-worker/src/test/java/com/marketinghub/worker/creative/ExperimentCreativeServiceTest.java
+  - docs/registros/experimentos.md
+
 ## 2026-06-18 — Correção de compilação do Worker AI na geração de criativos
 
 - solicitação: corrigir falha de compilação por import direto de `CreativeGenerationStatus` no Worker AI.


### PR DESCRIPTION
### Motivation
- Corrigir erro de compilação em `ai-worker` causado por chamadas diretas a getters/setters recentes do modelo `Experiment` que podem não existir na versão publicada de `ads-service` usada na compilação.
- Preservar o comportamento operacional de geração de criativos (marcar `PROCESSING`, `COMPLETED`, `FAILED`, `TIMEOUT`) para evitar que a UI fique travada em "Gerando anúncios...".
- Manter compatibilidade binária sem duplicar modelos canônicos do backend no Worker AI.

### Description
- Substituídas chamadas diretas a `Experiment.setCreativeGenerationStartedAt/FinishedAt/Error/getCreativeGenerationRequestedAt` por invocação reflexiva tolerante com helpers: `invokeOptionalExperimentSetter` e `invokeOptionalExperimentGetter` em `ai-worker/src/main/java/com/marketinghub/worker/creative/ExperimentCreativeService.java`.
- Adicionado conjunto concorrente `MISSING_OPTIONAL_EXPERIMENT_METHODS` para logar uma única vez métodos opcionais ausentes e evitar ruído repetido em runtime.
- Ajustadas chamadas internas (`generate`, `markProcessing`, `markTimedOut`, `handleGenerationFailure`) para usar os novos helpers, preservando a gravação do `Experiment` ao assumir e ao finalizar/falhar a geração.
- Atualizados testes em `ai-worker/src/test/java/com/marketinghub/worker/creative/ExperimentCreativeServiceTest.java` para refletir o fluxo atual (esperar duas gravações `save`, e verificar `creativeGenerationStatus`/`creativeGenerationError`).
- Registrada entrada operacional em `docs/registros/experimentos.md` documentando causa-raiz, solução e arquivos alterados.

### Testing
- Executado `mvn -q -f backend/ads-service/pom.xml -DskipTests install` — sucesso.
- Executado `mvn -q -f ai-worker/pom.xml -DskipTests compile` — sucesso (correção de compilação validada).
- Executado `mvn -q -f ai-worker/pom.xml -Dtest=ExperimentCreativeServiceTest test` — sucesso (teste focado de `ExperimentCreativeService` passou com as novas expectativas).
- Executado `mvn -q -f ai-worker/pom.xml test` (suíte completa) — tentativa realizada; em ambiente CI local a suíte completa falhou por execuções de schedulers/tests de contexto que fazem chamadas de rede a `http://191.252.181.168` e por expectativas de integração fora do escopo desta correção; a alteração corrige a causa de compilação e o teste focal que bloqueava a PR passou.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a345676fae48321a28b3aa1c826b880)