### PR TITLE
Preserva custo do job OPRM durante reprocessamento

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/OprmRoutineResearchCycle.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/OprmRoutineResearchCycle.java
@@ -69,6 +69,9 @@ public class OprmRoutineResearchCycle {
     @Column(name = "total_extracted_signals", nullable = false)
     private Integer totalExtractedSignals;
 
+    @Column(name = "reprocess_preserved_cost_usd", nullable = false, precision = 12, scale = 8)
+    private BigDecimal reprocessPreservedCostUsd = BigDecimal.ZERO;
+
     @Column(name = "started_at", nullable = false)
     private Instant startedAt;
 

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/enrichednichematerializer/service/BackendEnrichedNicheMaterializerService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/enrichednichematerializer/service/BackendEnrichedNicheMaterializerService.java
@@ -334,10 +334,11 @@ public class BackendEnrichedNicheMaterializerService {
       OprmNicheRoutineCard card,
       OprmRoutineResearchCycle cycle,
       OprmEnrichedNicheMetaSignalService.MetaSignalPackage metaSignalPackage) {
-    BigDecimal identificationCostUsd = seedRepository.sumCostUsdByResearchCycleId(cycle.getId());
-    BigDecimal identificationCostBrl = identificationCostUsd == null || identificationCostUsd.compareTo(BigDecimal.ZERO) <= 0
-        ? null
-        : currencyConversionService.usdToBrl(identificationCostUsd);
+    BigDecimal identificationCostUsd = totalIdentificationCostUsd(cycle);
+    BigDecimal identificationCostBrl =
+        identificationCostUsd == null || identificationCostUsd.compareTo(BigDecimal.ZERO) <= 0
+            ? null
+            : currencyConversionService.usdToBrl(identificationCostUsd);
     return new OprmMarketNicheDraft(
         marketNicheId,
         requiredText(neutralNicheName(cycle), "neutralNicheName"),
@@ -351,6 +352,18 @@ public class BackendEnrichedNicheMaterializerService {
         metaSignalPackage == null ? null : metaSignalService.buildReadableSignalSummary(metaSignalPackage),
         buildExtraTips(card),
         identificationCostBrl);
+  }
+
+  /** Soma o custo atual do seed com o custo preservado de tentativas anteriores do mesmo job. */
+  private BigDecimal totalIdentificationCostUsd(OprmRoutineResearchCycle cycle) {
+    BigDecimal currentSeedCost = seedRepository.sumCostUsdByResearchCycleId(cycle.getId());
+    BigDecimal preservedReprocessCost = cycle.getReprocessPreservedCostUsd();
+    return nullToZero(currentSeedCost).add(nullToZero(preservedReprocessCost));
+  }
+
+  /** Normaliza custo nulo para zero antes de somar valores auditáveis. */
+  private BigDecimal nullToZero(BigDecimal value) {
+    return value == null ? BigDecimal.ZERO : value;
   }
 
   /** Localiza nicho já vinculado ao mesmo CNAE e ao mesmo nome neutro, permitindo vários nichos diferentes no mesmo CNAE. */

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/routineresearchcycle/service/BackendRoutineResearchCycleService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/routineresearchcycle/service/BackendRoutineResearchCycleService.java
@@ -390,7 +390,15 @@ public class BackendRoutineResearchCycleService {
 
   /** Soma o custo registrado pelas etapas com telemetria de IA para uma execução do ciclo. */
   private BigDecimal executionCostUsd(Long researchCycleId) {
-    return nicheResearchSeedRepository.sumCostUsdByResearchCycleId(researchCycleId);
+    OprmRoutineResearchCycle cycle = findCycle(researchCycleId);
+    BigDecimal currentSeedCost = nicheResearchSeedRepository.sumCostUsdByResearchCycleId(researchCycleId);
+    BigDecimal preservedReprocessCost = cycle.getReprocessPreservedCostUsd();
+    return nullToZero(currentSeedCost).add(nullToZero(preservedReprocessCost));
+  }
+
+  /** Normaliza custo nulo para zero antes de somar valores auditáveis. */
+  private BigDecimal nullToZero(BigDecimal value) {
+    return value == null ? BigDecimal.ZERO : value;
   }
 
   /** Converte um ciclo em detalhe operacional completo. */

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/routineresearchorchestrator/service/BackendRoutineResearchOrchestratorService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/routineresearchorchestrator/service/BackendRoutineResearchOrchestratorService.java
@@ -20,6 +20,7 @@ import com.marketinghub.repository.jpa.oprm.nichocnae.OprmResearchQueryRepositor
 import com.marketinghub.repository.jpa.oprm.nichocnae.OprmNicheRoutineCardRepository;
 import com.marketinghub.repository.jpa.oprm.nichocnae.OprmRoutineResearchCycleRepository;
 import com.marketinghub.repository.jpa.oprm.nichocnae.meiaudienceprofile.OprmMeiAudienceProfileRepository;
+import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.List;
 import java.util.Locale;
@@ -162,6 +163,7 @@ public class BackendRoutineResearchOrchestratorService {
                 .orElse(null);
         String triggerSource = resolveReprocessTriggerSource(request);
         Instant now = Instant.now();
+        preserveCurrentAiCostBeforeRerun(cycle);
         clearArtifactsForStageRerun(cycle.getId());
         reopenCycleForStageRerun(cycle, previousCycleStatus, previousQualityCard, triggerSource, now);
         OprmRoutineResearchCycle savedCycle = routineResearchCycleRepository.save(cycle);
@@ -189,6 +191,16 @@ public class BackendRoutineResearchOrchestratorService {
                 savedCandidate.getRoutineResearchStatus(),
                 savedCandidate.getLastRoutineResearchCycleId(),
                 buildReprocessMessage(previousCycleStatus));
+    }
+
+    /** Acumula o custo de IA já registrado antes de limpar os artefatos que serão reprocessados. */
+    private void preserveCurrentAiCostBeforeRerun(OprmRoutineResearchCycle cycle) {
+        BigDecimal currentSeedCost = seedRepository.sumCostUsdByResearchCycleId(cycle.getId());
+        BigDecimal preservedCost = cycle.getReprocessPreservedCostUsd() == null
+                ? BigDecimal.ZERO
+                : cycle.getReprocessPreservedCostUsd();
+        cycle.setReprocessPreservedCostUsd(
+                preservedCost.add(currentSeedCost == null ? BigDecimal.ZERO : currentSeedCost));
     }
 
     /** Remove artefatos derivados para que as etapas do próprio job sejam executadas novamente com novo input. */
@@ -445,6 +457,7 @@ public class BackendRoutineResearchOrchestratorService {
         cycle.setTotalSourceCandidates(0);
         cycle.setTotalSourceSnapshots(0);
         cycle.setTotalExtractedSignals(0);
+        cycle.setReprocessPreservedCostUsd(BigDecimal.ZERO);
         cycle.setStartedAt(now);
         cycle.setCreatedAt(now);
         cycle.setUpdatedAt(now);

--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-18-oprm-routine-cycle-preserved-cost.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-18-oprm-routine-cycle-preserved-cost.yaml
@@ -1,0 +1,23 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-06-18-01-oprm-routine-cycle-preserved-cost
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - onError: HALT
+        - dbms:
+            type: mysql
+        - not:
+            - columnExists:
+                tableName: oprm_routine_research_cycle
+                columnName: reprocess_preserved_cost_usd
+      changes:
+        - addColumn:
+            tableName: oprm_routine_research_cycle
+            columns:
+              - column:
+                  name: reprocess_preserved_cost_usd
+                  type: DECIMAL(12,8)
+                  defaultValueNumeric: 0
+                  constraints:
+                    nullable: false

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -9,6 +9,9 @@ databaseChangeLog:
       file: changesets/2026-06-18-oprm-routine-cycle-current-stage.yaml
       relativeToChangelogFile: true
   - include:
+      file: changesets/2026-06-18-oprm-routine-cycle-preserved-cost.yaml
+      relativeToChangelogFile: true
+  - include:
       file: changesets/2026-06-17-mois-sales-page-job-analysis-versioning.yaml
       relativeToChangelogFile: true
   - include:

--- a/backend/ads-service/src/test/java/com/marketinghub/oprm/nichocnae/routineresearchorchestrator/service/BackendRoutineResearchOrchestratorServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/oprm/nichocnae/routineresearchorchestrator/service/BackendRoutineResearchOrchestratorServiceTest.java
@@ -178,6 +178,7 @@ class BackendRoutineResearchOrchestratorServiceTest {
         candidate.setLastRoutineResearchCycleId(321L);
         when(routineResearchCycleRepository.findById(321L)).thenReturn(Optional.of(failedCycle));
         when(nicheCandidateRepository.findById(55L)).thenReturn(Optional.of(candidate));
+        when(seedRepository.sumCostUsdByResearchCycleId(321L)).thenReturn(new BigDecimal("0.05610000"));
         when(routineResearchCycleRepository.save(any(OprmRoutineResearchCycle.class)))
                 .thenAnswer(invocation -> invocation.getArgument(0));
         when(nicheCandidateRepository.save(any(OprmNicheCandidate.class)))
@@ -199,6 +200,7 @@ class BackendRoutineResearchOrchestratorServiceTest {
         assertThat(cycleCaptor.getValue().getSourceNicheId()).isEqualTo(55L);
         assertThat(cycleCaptor.getValue().getStatus()).isEqualTo("RUNNING");
         assertThat(cycleCaptor.getValue().getTriggerSource()).isEqualTo("MANUAL_REPROCESS");
+        assertThat(cycleCaptor.getValue().getReprocessPreservedCostUsd()).isEqualByComparingTo("0.05610000");
         assertThat(cycleCaptor.getValue().getErrorMessage()).contains("Reexecução de etapas do mesmo job");
         verify(seedRepository).deleteByResearchCycleId(321L);
         verify(researchQueryRepository).deleteByResearchCycleId(321L);
@@ -225,6 +227,7 @@ class BackendRoutineResearchOrchestratorServiceTest {
         failedCycle.setResearchMode("ROUTINE_REALITY_RESEARCH");
         failedCycle.setSolutionLanguageRiskScore(new BigDecimal("35.00"));
         failedCycle.setSourceScore(new BigDecimal("91.00"));
+        failedCycle.setReprocessPreservedCostUsd(new BigDecimal("0.05610000"));
         OprmNicheCandidate candidate = candidate();
         OprmNicheRoutineCard previousCard = new OprmNicheRoutineCard();
         previousCard.setQualityStatus("SOLUTION_CONTAMINATED");
@@ -232,6 +235,7 @@ class BackendRoutineResearchOrchestratorServiceTest {
         when(routineResearchCycleRepository.findById(321L)).thenReturn(Optional.of(failedCycle));
         when(nicheCandidateRepository.findById(55L)).thenReturn(Optional.of(candidate));
         when(routineCardRepository.findFirstByResearchCycleIdOrderByIdDesc(321L)).thenReturn(Optional.of(previousCard));
+        when(seedRepository.sumCostUsdByResearchCycleId(321L)).thenReturn(new BigDecimal("0.01000000"));
         when(routineResearchCycleRepository.save(any(OprmRoutineResearchCycle.class)))
                 .thenAnswer(invocation -> invocation.getArgument(0));
         when(nicheCandidateRepository.save(any(OprmNicheCandidate.class)))
@@ -252,6 +256,7 @@ class BackendRoutineResearchOrchestratorServiceTest {
         assertThat(learningCycle.getResearchMode()).isEqualTo("ROUTINE_REALITY_RESEARCH");
         assertThat(learningCycle.getSolutionLanguageRiskScore()).isEqualByComparingTo("35.00");
         assertThat(learningCycle.getSourceScore()).isEqualByComparingTo("91.00");
+        assertThat(learningCycle.getReprocessPreservedCostUsd()).isEqualByComparingTo("0.06610000");
         assertThat(learningCycle.getErrorMessage()).contains("O próximo seed deve usar o aprendizado do gate anterior");
         assertThat(learningCycle.getErrorMessage()).contains("previousQualityStatus=SOLUTION_CONTAMINATED");
         assertThat(learningCycle.getErrorMessage()).contains("riscoLinguagemSolucao=70");

--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -1,3 +1,9 @@
+## 2026-06-18 — OPRM NichoCNAE: custo preservado em reprocessamento do mesmo job
+
+- Causa-raiz tratada: ao reabrir o mesmo `researchCycleId`, o backend limpava o seed anterior para permitir nova execução, mas junto apagava o custo de IA já consumido e a tela podia voltar o custo para zero durante o reprocessamento.
+- Correção aplicada: antes de limpar artefatos reexecutáveis, o backend acumula o custo já registrado no ciclo e as consultas de acompanhamento/materialização somam esse custo preservado com o novo custo da tentativa atual.
+- Prevenção de recorrência: teste unitário cobre que o reprocessamento preserva e acumula o custo anterior do mesmo job antes de deletar o seed.
+
 ## 2026-06-18 02:23:30 (UTC) — OPRM NichoCNAE: endpoint de jobs por status para reprocessamento pelo executor
 
 - Causa-raiz identificada no ciclo #68: o backend marcava `NEEDS_MORE_RESEARCH` durante a triagem pré-segmentação MEI/autônomo, antes de o job chegar ao gate de qualidade que já aciona o reprocessamento automático no executor.


### PR DESCRIPTION
### Motivation
- Corrige perda de custo observado quando um `researchCycleId` era reprocessado: ao limpar seeds/queries o custo de IA já consumido ficava zerado e a UI mostrava `$0.00` durante a reexecução.

### Description
- Adiciona a coluna canônica `reprocess_preserved_cost_usd` em `oprm_routine_research_cycle` e changelog Liquibase `2026-06-18-oprm-routine-cycle-preserved-cost.yaml` para persistir custo acumulado entre tentativas do mesmo job.
- Antes de apagar artefatos para reexecução, o backend agora acumula o custo atual do seed em `reprocessPreservedCostUsd` via `preserveCurrentAiCostBeforeRerun` em `BackendRoutineResearchOrchestratorService`.
- Ajusta agregações e materialização para somar `reprocessPreservedCostUsd` + custo da tentativa atual em `BackendRoutineResearchCycleService.executionCostUsd` e `BackendEnrichedNicheMaterializerService.totalIdentificationCostUsd`.
- Atualiza testes unitários (`BackendRoutineResearchOrchestratorServiceTest`) e registra a correção em `docs/registros/oprm1.md`.

### Testing
- Executei os testes unitários do caso afetado com `../mvnw -Dtest=BackendRoutineResearchOrchestratorServiceTest test` e a suíte do serviço rodou com sucesso (`Tests run: 15, Failures: 0, Errors: 0`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a34617b62b48321bb6494f8268bf242)