### PR TITLE
Adicionar tela 'Jobs' OPRM com listagem paginada e endpoint backend

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/routineresearchcycle/service/BackendRoutineResearchCycleService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/routineresearchcycle/service/BackendRoutineResearchCycleService.java
@@ -9,6 +9,8 @@ import com.marketinghub.oprm.nichocnae.OprmSourceCandidate;
 import com.marketinghub.oprm.nichocnae.OprmSourceSnapshot;
 import com.marketinghub.oprm.nichocnae.meiaudienceprofile.OprmMeiAudienceProfile;
 import com.marketinghub.oprm.nichocnae.routineresearchcycle.service.detailStageExecution.RecordBackendRoutineResearchCycleDetalheDto;
+import com.marketinghub.oprm.nichocnae.routineresearchcycle.service.listRecentJobs.OprmNichoCnaeJobSummaryResponse;
+import com.marketinghub.oprm.nichocnae.routineresearchcycle.service.listRecentJobs.OprmNichoCnaeJobsPageResponse;
 import com.marketinghub.oprm.nichocnae.routineresearchcycle.service.listStageExecutions.RoutineResearchCycleExecutionSummaryResponse;
 import com.marketinghub.oprm.nichocnae.routineresearchcycle.service.pending.RecordRoutineResearchCyclePending;
 import com.marketinghub.repository.jpa.oprm.nichocnae.OprmExtractedSignalRepository;
@@ -24,6 +26,7 @@ import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -71,6 +74,23 @@ public class BackendRoutineResearchCycleService {
         .stream()
         .map(this::toPending)
         .toList();
+  }
+
+  /** Lista os jobs mais recentes do pipeline NichoCNAE para a tela administrativa paginada. */
+  @Transactional(readOnly = true)
+  public OprmNichoCnaeJobsPageResponse listRecentJobs(int page, int size) {
+    int safePage = Math.max(page, 0);
+    int safeSize = Math.min(Math.max(size, 1), 100);
+    Page<OprmRoutineResearchCycle> cycles =
+        routineResearchCycleRepository.findRecentJobs(PageRequest.of(safePage, safeSize));
+    return new OprmNichoCnaeJobsPageResponse(
+        cycles.getContent().stream().map(this::toJobSummary).toList(),
+        cycles.getNumber(),
+        cycles.getSize(),
+        cycles.getTotalElements(),
+        cycles.getTotalPages(),
+        cycles.isFirst(),
+        cycles.isLast());
   }
 
   /** Lista execuções do ciclo de pesquisa de rotina associadas ao CNAE informado. */
@@ -198,6 +218,25 @@ public class BackendRoutineResearchCycleService {
         cycle.getStartedAt(),
         cycle.getFinishedAt(),
         cycle.getErrorMessage());
+  }
+
+  /** Converte um ciclo em linha da tela de jobs recentes com links de relatório e acompanhamento. */
+  private OprmNichoCnaeJobSummaryResponse toJobSummary(OprmRoutineResearchCycle cycle) {
+    String reportUrl =
+        "/api/oprm/nichocnae/routine-research-cycle/stage-executions/" + cycle.getId() + "/report";
+    String trackingUrl =
+        "/oprm/cnaes/" + cycle.getCnaeCode() + "/subnichos/" + cycle.getId();
+    return new OprmNichoCnaeJobSummaryResponse(
+        cycle.getId(),
+        cycle.getCnaeCode(),
+        cycle.getCnaeDescription(),
+        cycle.getNeutralNicheName(),
+        cycle.getStatus(),
+        executionCostUsd(cycle.getId()),
+        cycle.getCurrentStageCode(),
+        cycle.getUpdatedAt(),
+        reportUrl,
+        trackingUrl);
   }
 
   /** Adiciona o título principal do relatório Markdown. */

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/routineresearchcycle/service/listRecentJobs/OprmNichoCnaeJobSummaryResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/routineresearchcycle/service/listRecentJobs/OprmNichoCnaeJobSummaryResponse.java
@@ -1,0 +1,17 @@
+package com.marketinghub.oprm.nichocnae.routineresearchcycle.service.listRecentJobs;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+
+/** Representa um job recente do pipeline OPRM NichoCNAE para acompanhamento administrativo. */
+public record OprmNichoCnaeJobSummaryResponse(
+    Long id,
+    String cnaeCode,
+    String cnaeDescription,
+    String subniche,
+    String status,
+    BigDecimal costUsd,
+    String lastStageCode,
+    Instant lastStageAt,
+    String reportUrl,
+    String trackingUrl) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/routineresearchcycle/service/listRecentJobs/OprmNichoCnaeJobsPageResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/routineresearchcycle/service/listRecentJobs/OprmNichoCnaeJobsPageResponse.java
@@ -1,0 +1,13 @@
+package com.marketinghub.oprm.nichocnae.routineresearchcycle.service.listRecentJobs;
+
+import java.util.List;
+
+/** Representa uma página de jobs recentes do pipeline OPRM NichoCNAE. */
+public record OprmNichoCnaeJobsPageResponse(
+    List<OprmNichoCnaeJobSummaryResponse> content,
+    int page,
+    int size,
+    long totalElements,
+    int totalPages,
+    boolean first,
+    boolean last) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/routineresearchcycle/web/BackendRoutineResearchCycleController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/routineresearchcycle/web/BackendRoutineResearchCycleController.java
@@ -2,6 +2,7 @@ package com.marketinghub.oprm.nichocnae.routineresearchcycle.web;
 
 import com.marketinghub.oprm.nichocnae.routineresearchcycle.service.BackendRoutineResearchCycleService;
 import com.marketinghub.oprm.nichocnae.routineresearchcycle.service.detailStageExecution.RecordBackendRoutineResearchCycleDetalheDto;
+import com.marketinghub.oprm.nichocnae.routineresearchcycle.service.listRecentJobs.OprmNichoCnaeJobsPageResponse;
 import com.marketinghub.oprm.nichocnae.routineresearchcycle.service.listStageExecutions.RoutineResearchCycleExecutionSummaryResponse;
 import com.marketinghub.oprm.nichocnae.routineresearchcycle.service.pending.RecordRoutineResearchCyclePending;
 import java.nio.charset.StandardCharsets;
@@ -13,6 +14,7 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 /** Responsável por expor os endpoints backend da etapa de ciclo da pesquisa de rotina de nicho CNAE. */
@@ -30,6 +32,13 @@ public class BackendRoutineResearchCycleController {
   @GetMapping("/internal/oprm/nichocnae/routine-research-cycle/stage-executions/pending")
   public List<RecordRoutineResearchCyclePending> pending() {
     return executionService.listPending();
+  }
+
+  /** Lista jobs recentes do OPRM NichoCNAE para acompanhamento administrativo paginado. */
+  @GetMapping("/oprm/nichocnae/jobs")
+  public ResponseEntity<OprmNichoCnaeJobsPageResponse> listRecentJobs(
+      @RequestParam(defaultValue = "0") int page, @RequestParam(defaultValue = "20") int size) {
+    return ResponseEntity.ok(executionService.listRecentJobs(page, size));
   }
 
   /** Lista execuções do ciclo de pesquisa de rotina vinculadas ao CNAE informado. */

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/oprm/nichocnae/OprmRoutineResearchCycleRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/oprm/nichocnae/OprmRoutineResearchCycleRepository.java
@@ -4,6 +4,7 @@ import com.marketinghub.oprm.nichocnae.OprmRoutineResearchCycle;
 import jakarta.persistence.LockModeType;
 import java.time.Instant;
 import java.util.List;
+import org.springframework.data.domain.Page;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
@@ -42,6 +43,14 @@ public interface OprmRoutineResearchCycleRepository extends JpaRepository<OprmRo
 
     /** Lista os ciclos de pesquisa de rotina mais recentes para acompanhamento operacional. */
     List<OprmRoutineResearchCycle> findAllByOrderByStartedAtDesc(Pageable pageable);
+
+    /** Lista ciclos recentes paginados para a tela de jobs do OPRM NichoCNAE. */
+    @Query("""
+            select cycle
+            from OprmRoutineResearchCycle cycle
+            order by cycle.startedAt desc
+            """)
+    Page<OprmRoutineResearchCycle> findRecentJobs(Pageable pageable);
 
     /** Lista ciclos de pesquisa por status para filas de diagnóstico e reprocessamento do executor. */
     List<OprmRoutineResearchCycle> findByStatusInOrderByStartedAtAsc(List<String> statuses, Pageable pageable);

--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -955,3 +955,8 @@
 - Decisão de regra aplicada: o backend não deve controlar fluxo por validação semântica do seed da etapa `niche-research-seed-builder`; decisões de qualidade, reprovação, reprocessamento e próximo movimento pertencem ao executor/gates próprios do OPRM.
 - Correção aplicada: removido o bloqueio backend que rejeitava `nicheName` igual ao nicho atual/CNAE e o pré-gate comercial determinístico antes da persistência. O backend passa a persistir o nome retornado pelo executor, aplicando fallback rastreável quando o campo vier ausente, e deixa o fluxo avançar para as etapas e gates responsáveis pela avaliação.
 - Prevenção de recorrência: testes da etapa dois agora cobrem que o backend aceita o `nicheName` retornado pelo executor e aceita seed fraco sem transformar avaliação semântica em falha técnica de backend.
+
+## 2026-06-18 — Tela de jobs OPRM NichoCNAE
+
+- Criada tela administrativa `/oprm/jobs` com botão na navegação do OPRM para listar jobs recentes do pipeline NichoCNAE com paginação, custo, última etapa, relatório e acompanhamento.
+- Backend expõe `/api/oprm/nichocnae/jobs` para a UI consultar os ciclos recentes sem acessar banco diretamente.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -115,6 +115,7 @@ import OprmCnaeDetailPlaceholderPage from "./pages/oprm/OprmCnaeDetailPlaceholde
 import OprmCnaePipelineStageDetailPage from "./pages/oprm/OprmCnaePipelineStageDetailPage";
 import OprmEnrichedNicheDetailPage from "./pages/oprm/OprmEnrichedNicheDetailPage";
 import OprmGeneralAudiencesPage from "./pages/oprm/OprmGeneralAudiencesPage";
+import OprmJobsPage from "./pages/oprm/OprmJobsPage";
 import OprmGeneralAudienceSeedDetailPage from "./pages/oprm/OprmGeneralAudienceSeedDetailPage";
 import OprmGeneralAudienceSubnicheDetailPage from "./pages/oprm/OprmGeneralAudienceSubnicheDetailPage";
 import MoisWorkspacePage from "./pages/mois/MoisWorkspacePage";
@@ -401,6 +402,7 @@ export default function App() {
                 element={<OprmFeedbackPage />}
               />
               <Route path="/oprm/operations" element={<OprmOperationsPage />} />
+              <Route path="/oprm/jobs" element={<OprmJobsPage />} />
               <Route
                 path="/oprm/pipeline"
                 element={<Navigate to="/oprm" replace />}

--- a/frontend/src/api/oprm/useOprmNichoCnaeJobs.ts
+++ b/frontend/src/api/oprm/useOprmNichoCnaeJobs.ts
@@ -1,0 +1,48 @@
+import { useQuery } from "@tanstack/react-query";
+import { buildApiUrl } from "../../utils/buildApiUrl";
+
+export interface OprmNichoCnaeJobSummary {
+  id: number;
+  cnaeCode: string;
+  cnaeDescription: string;
+  subniche: string | null;
+  status: string;
+  costUsd: number | string | null;
+  lastStageCode: string | null;
+  lastStageAt: string | null;
+  reportUrl: string;
+  trackingUrl: string;
+}
+
+export interface OprmNichoCnaeJobsPage {
+  content: OprmNichoCnaeJobSummary[];
+  page: number;
+  size: number;
+  totalElements: number;
+  totalPages: number;
+  first: boolean;
+  last: boolean;
+}
+
+async function fetchOprmNichoCnaeJobs(
+  page: number,
+  size: number,
+): Promise<OprmNichoCnaeJobsPage> {
+  const response = await fetch(
+    buildApiUrl(`/api/oprm/nichocnae/jobs?page=${page}&size=${size}`),
+  );
+  if (!response.ok) {
+    throw new Error(
+      `Não foi possível carregar os jobs OPRM NichoCNAE (status ${response.status}).`,
+    );
+  }
+  return (await response.json()) as OprmNichoCnaeJobsPage;
+}
+
+export function useOprmNichoCnaeJobs(page: number, size = 20) {
+  return useQuery({
+    queryKey: ["oprm", "nichocnae", "jobs", page, size],
+    queryFn: () => fetchOprmNichoCnaeJobs(page, size),
+    staleTime: 30_000,
+  });
+}

--- a/frontend/src/pages/oprm/OprmJobsPage.tsx
+++ b/frontend/src/pages/oprm/OprmJobsPage.tsx
@@ -1,0 +1,170 @@
+import { useState } from "react";
+import { AlertCircle } from "lucide-react";
+import { Link } from "react-router-dom";
+import PageTitle from "../../components/PageTitle";
+import { buildApiUrl } from "../../utils/buildApiUrl";
+import { useOprmNichoCnaeJobs } from "../../api/oprm/useOprmNichoCnaeJobs";
+import OprmModuleNavigation from "./OprmModuleNavigation";
+
+const PAGE_SIZE = 20;
+
+function formatDate(value: string | null): string {
+  if (!value) return "-";
+  const date = new Date(value);
+  return Number.isNaN(date.getTime())
+    ? "-"
+    : date.toLocaleString("pt-BR", { dateStyle: "short", timeStyle: "short" });
+}
+
+function formatCost(value: number | string | null): string {
+  const numeric = Number(value ?? 0);
+  return Number.isFinite(numeric) ? `US$ ${numeric.toFixed(4)}` : "-";
+}
+
+export default function OprmJobsPage() {
+  const [page, setPage] = useState(0);
+  const jobsQuery = useOprmNichoCnaeJobs(page, PAGE_SIZE);
+  const jobsPage = jobsQuery.data;
+
+  return (
+    <div className="d-flex flex-column gap-4">
+      <header className="d-flex flex-column gap-2">
+        <PageTitle>OPRM · Jobs</PageTitle>
+        <p className="text-secondary mb-0">
+          Acompanhe os 20 jobs NichoCNAE mais recentes por página, com custo,
+          etapa e links de ação.
+        </p>
+      </header>
+
+      <OprmModuleNavigation />
+
+      <section className="card border-0 shadow-sm">
+        <div className="card-body d-flex flex-column gap-3">
+          <div className="d-flex justify-content-between align-items-start gap-3 flex-wrap">
+            <div>
+              <h2 className="h5 mb-1">Jobs recentes</h2>
+              <p className="text-secondary mb-0">
+                Use esta tela para baixar relatórios e entrar no acompanhamento
+                de cada subnicho.
+              </p>
+            </div>
+            <button
+              type="button"
+              className="btn btn-outline-primary"
+              onClick={() => jobsQuery.refetch()}
+              disabled={jobsQuery.isFetching}
+            >
+              Atualizar
+            </button>
+          </div>
+
+          {jobsQuery.isLoading ? (
+            <div className="d-flex justify-content-center py-4">
+              <div className="spinner-border text-primary" role="status">
+                <span className="visually-hidden">Carregando jobs OPRM...</span>
+              </div>
+            </div>
+          ) : null}
+
+          {jobsQuery.isError ? (
+            <div className="alert alert-danger d-flex gap-2 mb-0" role="alert">
+              <AlertCircle size={18} className="mt-1" aria-hidden="true" />
+              <div>Não foi possível carregar os jobs recentes.</div>
+            </div>
+          ) : null}
+
+          {!jobsQuery.isLoading && !jobsQuery.isError ? (
+            jobsPage?.content.length ? (
+              <>
+                <div className="table-responsive">
+                  <table className="table table-hover align-middle mb-0">
+                    <thead>
+                      <tr>
+                        <th>ID</th>
+                        <th>CNAE (descrição)</th>
+                        <th>Subnicho</th>
+                        <th>Situação</th>
+                        <th>Custo</th>
+                        <th>Última etapa</th>
+                        <th>Hora da última etapa</th>
+                        <th>Relatório</th>
+                        <th>Acompanhamento</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      {jobsPage.content.map((job) => (
+                        <tr key={job.id}>
+                          <td className="font-monospace">#{job.id}</td>
+                          <td>
+                            <div className="fw-semibold">{job.cnaeCode}</div>
+                            <div className="small text-secondary">
+                              {job.cnaeDescription}
+                            </div>
+                          </td>
+                          <td>{job.subniche ?? "-"}</td>
+                          <td>{job.status}</td>
+                          <td>{formatCost(job.costUsd)}</td>
+                          <td>{job.lastStageCode ?? "-"}</td>
+                          <td>{formatDate(job.lastStageAt)}</td>
+                          <td>
+                            <a
+                              className="btn btn-outline-secondary btn-sm"
+                              href={buildApiUrl(job.reportUrl)}
+                              target="_blank"
+                              rel="noreferrer"
+                            >
+                              Baixar
+                            </a>
+                          </td>
+                          <td>
+                            <Link
+                              className="btn btn-outline-primary btn-sm"
+                              to={job.trackingUrl}
+                            >
+                              Abrir
+                            </Link>
+                          </td>
+                        </tr>
+                      ))}
+                    </tbody>
+                  </table>
+                </div>
+                <div className="d-flex justify-content-between align-items-center flex-wrap gap-2">
+                  <span className="text-secondary small">
+                    Página {jobsPage.page + 1} de{" "}
+                    {Math.max(jobsPage.totalPages, 1)} ·{" "}
+                    {jobsPage.totalElements} jobs
+                  </span>
+                  <div className="btn-group">
+                    <button
+                      type="button"
+                      className="btn btn-outline-secondary"
+                      disabled={jobsPage.first || jobsQuery.isFetching}
+                      onClick={() =>
+                        setPage((current) => Math.max(current - 1, 0))
+                      }
+                    >
+                      Anterior
+                    </button>
+                    <button
+                      type="button"
+                      className="btn btn-outline-secondary"
+                      disabled={jobsPage.last || jobsQuery.isFetching}
+                      onClick={() => setPage((current) => current + 1)}
+                    >
+                      Próxima
+                    </button>
+                  </div>
+                </div>
+              </>
+            ) : (
+              <div className="alert alert-secondary mb-0" role="status">
+                Nenhum job NichoCNAE encontrado.
+              </div>
+            )
+          ) : null}
+        </div>
+      </section>
+    </div>
+  );
+}

--- a/frontend/src/pages/oprm/OprmModuleNavigation.tsx
+++ b/frontend/src/pages/oprm/OprmModuleNavigation.tsx
@@ -7,6 +7,7 @@ interface OprmModuleNavigationProps {
 const navigationItems = [
   { label: "CNAEs", to: "/oprm", end: true },
   { label: "Públicos Gerais", to: "/oprm/general-audiences" },
+  { label: "Jobs", to: "/oprm/jobs" },
 ];
 
 export default function OprmModuleNavigation({


### PR DESCRIPTION
### Motivation
- Fornecer uma visão administrativa dos jobs recentes do pipeline OPRM NichoCNAE para facilitar acompanhamento, download de relatório e navegação para a tela de acompanhamento. 
- Entregar dados paginados pelo backend para evitar acesso direto do frontend ao banco e manter contrato estável entre UI e backend.

### Description
- Frontend: adicionada a nova rota `/oprm/jobs`, componente de página `frontend/src/pages/oprm/OprmJobsPage.tsx`, hook `frontend/src/api/oprm/useOprmNichoCnaeJobs.ts` e botão/aba `Jobs` na navegação do OPRM; a página mostra ID, CNAE/descrição, subnicho, situação, custo, última etapa, hora da última etapa, botão para baixar relatório e link para acompanhamento com paginação (20 itens por página).
- Backend: exposto endpoint paginado `GET /api/oprm/nichocnae/jobs` que consulta ciclos recentes via `OprmRoutineResearchCycleRepository.findRecentJobs(Pageable)` e monta respostas contendo custo, última etapa, `reportUrl` e `trackingUrl` com dois novos DTOs/records: `OprmNichoCnaeJobSummaryResponse` e `OprmNichoCnaeJobsPageResponse`.
- Repositório: adicionado método JPA `findRecentJobs(Pageable)` em `OprmRoutineResearchCycleRepository` para listar ciclos ordenados por `startedAt` com paginação segura.
- Documentação operacional: registro da alteração em `docs/registros/oprm1.md` descrevendo a nova tela e o endpoint.

### Testing
- Executado `cd frontend && npm run typecheck` e o TypeScript typecheck passou com sucesso.
- Executado `cd backend/ads-service && mvn -DskipTests compile` e a compilação do módulo backend passou com sucesso.
- Executado `cd backend/ads-service && mvn test -Dtest=BackendRoutineResearchOrchestratorServiceTest` e o teste `BackendRoutineResearchOrchestratorServiceTest` foi executado com sucesso (todos os casos passaram).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a347b9b500c832192566676e7c91959)