### PR TITLE
oprm-coletor-mei: add operational logging to SourceSearcher stage and backend client

### DIFF
--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -1,3 +1,9 @@
+## 2026-06-18 20:20:00 (UTC-3) — OPRM NichoCNAE: logs operacionais na etapa de busca pública
+
+- Diagnóstico do ciclo #74: o banco respondeu normalmente via MCP e o ciclo continuava avançando na etapa `source-searcher`, sem evidência de lentidão do MySQL; a lacuna real era baixa observabilidade para saber se o coletor estava parado antes de buscar, durante a chamada ao provedor ou ao concluir no backend.
+- Correção aplicada: adicionados logs no `oprm-coletor-mei` para registrar carregamento de pendências, início/fim do lote, início/fim de cada query, chamada ao provedor público, duração, contadores de risco e confirmação de conclusão no backend.
+- Prevenção de recorrência: a próxima execução da etapa três passa a indicar exatamente em qual ponto operacional o job parou, diferenciando fila vazia, provedor lento, falha de complete no backend ou processamento normal.
+
 ## 2026-06-18 — OPRM NichoCNAE: custo preservado em reprocessamento do mesmo job
 
 - Causa-raiz tratada: ao reabrir o mesmo `researchCycleId`, o backend limpava o seed anterior para permitir nova execução, mas junto apagava o custo de IA já consumido e a tela podia voltar o custo para zero durante o reprocessamento.

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnae/sourcesearcher/SourceSearcherBackendClient.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnae/sourcesearcher/SourceSearcherBackendClient.java
@@ -32,7 +32,14 @@ public class SourceSearcherBackendClient {
         String url = collectorProperties.backendBaseUrl() + PENDING_PATH;
         try {
             SourceSearcherPending[] response = restClient.get().uri(url).retrieve().body(SourceSearcherPending[].class);
-            return response == null ? List.of() : Arrays.asList(response);
+            List<SourceSearcherPending> pendingQueries = response == null ? List.of() : Arrays.asList(response);
+            log.info(
+                    "Pendências da etapa três OPRM nichocnae carregadas (endpoint={}, pendingCount={}, firstResearchCycleId={}, firstResearchQueryId={})",
+                    url,
+                    pendingQueries.size(),
+                    pendingQueries.isEmpty() ? null : pendingQueries.get(0).researchCycleId(),
+                    pendingQueries.isEmpty() ? null : pendingQueries.get(0).researchQueryId());
+            return pendingQueries;
         } catch (RestClientException ex) {
             log.error("Erro ao listar pendências da etapa três OPRM nichocnae (endpoint={})", url, ex);
             throw ex;
@@ -48,6 +55,13 @@ public class SourceSearcherBackendClient {
                 + COMPLETE_PATH_SUFFIX;
         SourceSearcherCompletionRequest request = toCompletionRequest(pending, searchProvider, searchResults);
         try {
+            log.info(
+                    "Enviando conclusão da etapa três OPRM nichocnae ao backend (endpoint={}, researchQueryId={}, researchCycleId={}, searchProvider={}, resultCount={})",
+                    url,
+                    pending.researchQueryId(),
+                    pending.researchCycleId(),
+                    searchProvider,
+                    searchResults == null ? 0 : searchResults.size());
             SourceSearcherCompletionResponse response = restClient.post()
                     .uri(url)
                     .body(request)
@@ -56,7 +70,15 @@ public class SourceSearcherBackendClient {
             if (response == null) {
                 throw new IllegalStateException("Backend OPRM nichocnae retornou corpo vazio ao concluir etapa três.");
             }
-            return toOutput(response);
+            SourceSearcherOutput output = toOutput(response);
+            log.info(
+                    "Conclusão da etapa três OPRM nichocnae confirmada pelo backend (researchQueryId={}, researchCycleId={}, queryStatus={}, resultCount={}, cycleTotalSourceCandidates={})",
+                    output.researchQueryId(),
+                    output.researchCycleId(),
+                    output.queryStatus(),
+                    output.resultCount(),
+                    output.cycleTotalSourceCandidates());
+            return output;
         } catch (RestClientException | IllegalStateException ex) {
             log.error(
                     "Erro ao concluir etapa três OPRM nichocnae no backend (endpoint={}, researchQueryId={}, researchCycleId={}, resultCount={})",
@@ -77,6 +99,12 @@ public class SourceSearcherBackendClient {
                 + FAIL_PATH_SUFFIX;
         String message = error.getMessage() == null ? error.getClass().getSimpleName() : error.getMessage();
         try {
+            log.info(
+                    "Notificando falha da etapa três OPRM nichocnae ao backend (endpoint={}, researchQueryId={}, researchCycleId={}, errorMessage={})",
+                    url,
+                    pending.researchQueryId(),
+                    pending.researchCycleId(),
+                    message);
             restClient.post().uri(url).body(new SourceSearcherFailureRequest(message)).retrieve().toBodilessEntity();
         } catch (RestClientException ex) {
             log.error(

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnae/sourcesearcher/SourceSearcherProcessor.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnae/sourcesearcher/SourceSearcherProcessor.java
@@ -6,11 +6,14 @@ import com.marketinghub.nichocnae.pipeline.StageResult;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Component;
 
 /** Processa a etapa três executando queries em provedor público e persistindo fontes candidatas no backend. */
 @Component
 public class SourceSearcherProcessor implements StageProcessor<SourceSearcherPending, SourceSearcherOutput> {
+    private static final Logger log = LoggerFactory.getLogger(SourceSearcherProcessor.class);
     private static final int MAX_RESULTS_PER_QUERY = 20;
 
     private final PublicSourceSearchProvider searchProvider;
@@ -31,6 +34,14 @@ public class SourceSearcherProcessor implements StageProcessor<SourceSearcherPen
     @Override
     public StageResult<SourceSearcherOutput> process(StageContext<SourceSearcherPending> context) {
         SourceSearcherPending input = context.input();
+        long startedAt = System.nanoTime();
+        log.info(
+                "Chamando provedor de busca da etapa três OPRM nichocnae (researchQueryId={}, researchCycleId={}, provider={}, maxResults={}, queryText={})",
+                input.researchQueryId(),
+                input.researchCycleId(),
+                searchProvider.providerCode(),
+                MAX_RESULTS_PER_QUERY,
+                input.queryText());
         List<SourceSearchResult> searchResults = searchProvider.search(input.queryText(), MAX_RESULTS_PER_QUERY).stream()
                 .map(sourceIntentClassifier::classify)
                 .sorted(Comparator.comparing(SourceSearchResult::commercialPageRisk)
@@ -44,6 +55,17 @@ public class SourceSearcherProcessor implements StageProcessor<SourceSearcherPen
                         .thenComparing(Comparator.comparing(SourceSearchResult::sourceFreshnessScore).reversed())
                         .thenComparing(SourceSearchResult::searchPosition))
                 .toList();
+        long durationMs = (System.nanoTime() - startedAt) / 1_000_000;
+        log.info(
+                "Provedor de busca da etapa três OPRM nichocnae retornou resultados (researchQueryId={}, researchCycleId={}, provider={}, resultCount={}, durationMs={}, commercialRiskCount={}, outdatedRiskCount={}, structuredBusinessDriftRiskCount={})",
+                input.researchQueryId(),
+                input.researchCycleId(),
+                searchProvider.providerCode(),
+                searchResults.size(),
+                durationMs,
+                searchResults.stream().filter(SourceSearchResult::commercialPageRisk).count(),
+                searchResults.stream().filter(SourceSearchResult::outdatedSourceRisk).count(),
+                searchResults.stream().filter(SourceSearchResult::structuredBusinessDriftRisk).count());
         SourceSearcherOutput output =
                 backendClient.completeStageExecution(input, searchProvider.providerCode(), searchResults);
         Map<String, Object> metrics = Map.of(

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnae/sourcesearcher/SourceSearcherService.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnae/sourcesearcher/SourceSearcherService.java
@@ -35,9 +35,18 @@ public class SourceSearcherService {
     /** Processa as queries pendentes pela etapa três e retorna as saídas gravadas no backend. */
     public List<SourceSearcherOutput> processPending(String requestedBy) {
         List<SourceSearcherPending> pendingQueries = backendClient.listPendingQueries();
-        return pendingQueries.stream()
+        log.info(
+                "Lote da etapa três OPRM nichocnae preparado para processamento (pendingCount={}, requestedBy={})",
+                pendingQueries.size(),
+                requestedBy);
+        List<SourceSearcherOutput> outputs = pendingQueries.stream()
                 .map(pending -> processOne(pending, requestedBy))
                 .toList();
+        log.info(
+                "Lote da etapa três OPRM nichocnae processado (processedCount={}, requestedBy={})",
+                outputs.size(),
+                requestedBy);
+        return outputs;
     }
 
     /** Executa o worker genérico para uma query da etapa três e registra falha contextual no backend. */
@@ -47,9 +56,23 @@ public class SourceSearcherService {
                 pending,
                 Map.of("stage", "oprmSourceSearcher", "requestedBy", requestedBy));
         try {
+            log.info(
+                    "Iniciando query da etapa três OPRM nichocnae (researchQueryId={}, researchCycleId={}, queryText={}, requestedBy={})",
+                    pending.researchQueryId(),
+                    pending.researchCycleId(),
+                    pending.queryText(),
+                    requestedBy);
             PipelineWorker<SourceSearcherPending, SourceSearcherOutput> worker = new PipelineWorker<>(processor, artifactStore);
             StageResult<SourceSearcherOutput> result = worker.processResult(execution);
-            return result.output();
+            SourceSearcherOutput output = result.output();
+            log.info(
+                    "Query da etapa três OPRM nichocnae concluída (researchQueryId={}, researchCycleId={}, resultCount={}, cycleTotalSourceCandidates={}, requestedBy={})",
+                    output.researchQueryId(),
+                    output.researchCycleId(),
+                    output.resultCount(),
+                    output.cycleTotalSourceCandidates(),
+                    requestedBy);
+            return output;
         } catch (RuntimeException ex) {
             log.error(
                     "Erro ao executar etapa três OPRM nichocnae (researchQueryId={}, researchCycleId={}, requestedBy={})",


### PR DESCRIPTION
### Motivation

- Increase observability of the Stage 3 (source-searcher) pipeline to diagnose collector stalls and differentiate where a job stopped. 
- Capture timings, counters and identifiers to make it possible to distinguish empty queues, slow providers, backend completion failures or normal processing. 
- Provide operational traces useful for debugging and future automation/metrics without changing functional behaviour.

### Description

- Added informational logs to `SourceSearcherBackendClient` for `listPendingQueries`, `completeStageExecution` and `failStageExecution` including endpoint, `researchQueryId`/`researchCycleId`, provider and result counts. 
- Instrumented `SourceSearcherProcessor` to log provider call start, returned result counts, duration and risk counters, while preserving existing ranking logic. 
- Instrumented `SourceSearcherService` to log batch preparation/processing and per-query start/completion with `requestedBy`, `researchQueryId` and result metrics. 
- Updated `docs/registros/oprm1.md` with an operational entry describing the added logs and the intent to improve observability.

### Testing

- Built the project and executed the existing unit test suite and integration tests against the modified modules, and the test run completed successfully. 
- Verified that normal pipeline execution paths still return the same `SourceSearcherOutput` values and that failure paths still call `failStageExecution` (observed via log output during test runs).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3475086f408321be3fcfcfa30494d8)