### PR TITLE
AGENTS.md: clarify MCP log URL accessibility in Codex environment

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -160,6 +160,7 @@ O Marketing Hub é uma fábrica automatizada de produtos digitais: descobre dore
     6. `offset`: paginação por deslocamento dentro do conjunto filtrado.
     7. `cursor`: paginação por cursor retornado em `nextCursor`.
   - Limitações conhecidas:
+    - as URLs diretas de log dos serviços podem existir na configuração do MCP, mas normalmente não são acessíveis diretamente pelo ambiente do Codex; para investigar logs reais, tente sempre pela tool `java_module_logs` do MCP Server em vez de acessar essas URLs diretas.
     - o filtro `contains` é literal (sem regex/full-text avançado);
     - a retenção/janela disponível depende do `actuator/logfile` do módulo (logs antigos podem não estar mais disponíveis);
     - para logs de GitHub Actions, a tool é `github_actions_get_run_logs` e aceita apenas `run_id` (sem `contains`, `from`, `to`).


### PR DESCRIPTION
### Motivation
- Clarify operational guidance that direct service log URLs configured in MCP may not be reachable from the Codex environment and to prefer the MCP tool for investigations.

### Description
- Added a limitation note to `AGENTS.md` under the MCP Server filters explaining that direct log URLs might exist in the MCP configuration but are typically not accessible from the Codex environment and to use the `java_module_logs` tool instead of those URLs.

### Testing
- No automated tests were run for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a34835d8d0883218577b38dfe3b90bb)