### PR TITLE
Corrige download de relatórios OPRM sem abrir nova aba

### DIFF
--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -1,3 +1,9 @@
+## 2026-06-18 21:15:00 (UTC-3) — OPRM NichoCNAE: download de relatório sem abrir nova aba
+
+- Causa-raiz tratada: a tela de jobs recentes usava link com `target="_blank"` para baixar relatório, abrindo outra aba do navegador e expondo erro visual quando o browser tentava navegar diretamente para o endpoint de arquivo.
+- Correção aplicada: o botão de relatório agora executa o download via `fetch` no próprio frontend, cria um blob local e dispara o arquivo Markdown sem sair da tela de acompanhamento.
+- Prevenção de recorrência: adicionado teste de tela cobrindo que o botão baixa o relatório do job por blob e mantém o fluxo dentro da mesma aba.
+
 ## 2026-06-18 20:20:00 (UTC-3) — OPRM NichoCNAE: logs operacionais na etapa de busca pública
 
 - Diagnóstico do ciclo #74: o banco respondeu normalmente via MCP e o ciclo continuava avançando na etapa `source-searcher`, sem evidência de lentidão do MySQL; a lacuna real era baixa observabilidade para saber se o coletor estava parado antes de buscar, durante a chamada ao provedor ou ao concluir no backend.

--- a/frontend/src/api/oprm/useOprmNichoCnaeJobs.ts
+++ b/frontend/src/api/oprm/useOprmNichoCnaeJobs.ts
@@ -39,6 +39,28 @@ async function fetchOprmNichoCnaeJobs(
   return (await response.json()) as OprmNichoCnaeJobsPage;
 }
 
+export async function downloadOprmNichoCnaeJobReport(jobId: number) {
+  const response = await fetch(
+    buildApiUrl(
+      `/api/oprm/nichocnae/routine-research-cycle/stage-executions/${jobId}/report`,
+    ),
+  );
+  if (!response.ok) {
+    throw new Error(
+      `Não foi possível baixar o relatório do job #${jobId} (status ${response.status}).`,
+    );
+  }
+  const blob = await response.blob();
+  const url = URL.createObjectURL(blob);
+  const link = document.createElement("a");
+  link.href = url;
+  link.download = `nicho-cnae${jobId}.md`;
+  document.body.appendChild(link);
+  link.click();
+  link.remove();
+  URL.revokeObjectURL(url);
+}
+
 export function useOprmNichoCnaeJobs(page: number, size = 20) {
   return useQuery({
     queryKey: ["oprm", "nichocnae", "jobs", page, size],

--- a/frontend/src/pages/oprm/OprmJobsPage.test.tsx
+++ b/frontend/src/pages/oprm/OprmJobsPage.test.tsx
@@ -1,0 +1,105 @@
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter } from "react-router-dom";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import OprmJobsPage from "./OprmJobsPage";
+
+function renderPage() {
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  });
+
+  return render(
+    <QueryClientProvider client={client}>
+      <MemoryRouter initialEntries={["/oprm/jobs"]}>
+        <OprmJobsPage />
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe("OprmJobsPage", () => {
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it("baixa relatório pela mesma aba usando fetch e blob", async () => {
+    const createObjectURL = vi.fn(() => "blob:oprm-report");
+    const revokeObjectURL = vi.fn();
+    vi.stubGlobal("URL", {
+      ...URL,
+      createObjectURL,
+      revokeObjectURL,
+    });
+
+    const clickedAnchor: { href: string; download: string } = { href: "", download: "" };
+    const click = vi
+      .spyOn(HTMLAnchorElement.prototype, "click")
+      .mockImplementation(function captureClick(this: HTMLAnchorElement) {
+        clickedAnchor.href = this.href;
+        clickedAnchor.download = this.download;
+      });
+
+    const fetchMock = vi.fn(async (input: RequestInfo | URL) => {
+      const url = input.toString();
+      if (url.includes("/api/oprm/nichocnae/jobs")) {
+        return new Response(
+          JSON.stringify({
+            content: [
+              {
+                id: 74,
+                cnaeCode: "4781400",
+                cnaeDescription: "Comércio varejista de artigos do vestuário",
+                subniche: "revendedora autônoma de moda feminina plus size",
+                status: "FAILED",
+                costUsd: 0.2821,
+                lastStageCode: "mei-audience-segmenter",
+                lastStageAt: "2026-06-18T23:50:36Z",
+                reportUrl:
+                  "/api/oprm/nichocnae/routine-research-cycle/stage-executions/74/report",
+                trackingUrl: "/oprm/cnaes/4781400/subnichos/74",
+              },
+            ],
+            page: 0,
+            size: 20,
+            totalElements: 1,
+            totalPages: 1,
+            first: true,
+            last: true,
+          }),
+          { status: 200, headers: { "Content-Type": "application/json" } },
+        );
+      }
+      if (url.includes("stage-executions/74/report")) {
+        return new Response("# Relatório da execução NichoCNAE #74", {
+          status: 200,
+          headers: { "Content-Type": "text/markdown" },
+        });
+      }
+      return new Response("{}", { status: 404 });
+    });
+    vi.stubGlobal("fetch", fetchMock);
+
+    renderPage();
+
+    const downloadButton = await screen.findByRole("button", {
+      name: "Baixar",
+    });
+    await userEvent.click(downloadButton);
+
+    await waitFor(() => expect(click).toHaveBeenCalledTimes(1));
+    expect(fetchMock).toHaveBeenCalledWith(
+      "http://localhost/api/oprm/nichocnae/routine-research-cycle/stage-executions/74/report",
+    );
+    expect(clickedAnchor.href).toBe("blob:oprm-report");
+    expect(clickedAnchor.download).toBe("nicho-cnae74.md");
+    expect(createObjectURL).toHaveBeenCalledTimes(1);
+    expect(revokeObjectURL).toHaveBeenCalledWith("blob:oprm-report");
+  });
+});

--- a/frontend/src/pages/oprm/OprmJobsPage.tsx
+++ b/frontend/src/pages/oprm/OprmJobsPage.tsx
@@ -2,8 +2,10 @@ import { useState } from "react";
 import { AlertCircle } from "lucide-react";
 import { Link } from "react-router-dom";
 import PageTitle from "../../components/PageTitle";
-import { buildApiUrl } from "../../utils/buildApiUrl";
-import { useOprmNichoCnaeJobs } from "../../api/oprm/useOprmNichoCnaeJobs";
+import {
+  downloadOprmNichoCnaeJobReport,
+  useOprmNichoCnaeJobs,
+} from "../../api/oprm/useOprmNichoCnaeJobs";
 import OprmModuleNavigation from "./OprmModuleNavigation";
 
 const PAGE_SIZE = 20;
@@ -23,8 +25,26 @@ function formatCost(value: number | string | null): string {
 
 export default function OprmJobsPage() {
   const [page, setPage] = useState(0);
+  const [downloadingJobId, setDownloadingJobId] = useState<number | null>(null);
+  const [downloadError, setDownloadError] = useState<string | null>(null);
   const jobsQuery = useOprmNichoCnaeJobs(page, PAGE_SIZE);
   const jobsPage = jobsQuery.data;
+
+  async function handleDownloadReport(jobId: number) {
+    setDownloadError(null);
+    setDownloadingJobId(jobId);
+    try {
+      await downloadOprmNichoCnaeJobReport(jobId);
+    } catch (error) {
+      setDownloadError(
+        error instanceof Error
+          ? error.message
+          : "Não foi possível baixar o relatório do job.",
+      );
+    } finally {
+      setDownloadingJobId(null);
+    }
+  }
 
   return (
     <div className="d-flex flex-column gap-4">
@@ -54,6 +74,12 @@ export default function OprmJobsPage() {
               onClick={() => jobsQuery.refetch()}
               disabled={jobsQuery.isFetching}
             >
+              {jobsQuery.isFetching ? (
+                <span
+                  className="spinner-border spinner-border-sm me-2"
+                  aria-hidden="true"
+                />
+              ) : null}
               Atualizar
             </button>
           </div>
@@ -70,6 +96,13 @@ export default function OprmJobsPage() {
             <div className="alert alert-danger d-flex gap-2 mb-0" role="alert">
               <AlertCircle size={18} className="mt-1" aria-hidden="true" />
               <div>Não foi possível carregar os jobs recentes.</div>
+            </div>
+          ) : null}
+
+          {downloadError ? (
+            <div className="alert alert-danger d-flex gap-2 mb-0" role="alert">
+              <AlertCircle size={18} className="mt-1" aria-hidden="true" />
+              <div>{downloadError}</div>
             </div>
           ) : null}
 
@@ -92,40 +125,49 @@ export default function OprmJobsPage() {
                       </tr>
                     </thead>
                     <tbody>
-                      {jobsPage.content.map((job) => (
-                        <tr key={job.id}>
-                          <td className="font-monospace">#{job.id}</td>
-                          <td>
-                            <div className="fw-semibold">{job.cnaeCode}</div>
-                            <div className="small text-secondary">
-                              {job.cnaeDescription}
-                            </div>
-                          </td>
-                          <td>{job.subniche ?? "-"}</td>
-                          <td>{job.status}</td>
-                          <td>{formatCost(job.costUsd)}</td>
-                          <td>{job.lastStageCode ?? "-"}</td>
-                          <td>{formatDate(job.lastStageAt)}</td>
-                          <td>
-                            <a
-                              className="btn btn-outline-secondary btn-sm"
-                              href={buildApiUrl(job.reportUrl)}
-                              target="_blank"
-                              rel="noreferrer"
-                            >
-                              Baixar
-                            </a>
-                          </td>
-                          <td>
-                            <Link
-                              className="btn btn-outline-primary btn-sm"
-                              to={job.trackingUrl}
-                            >
-                              Abrir
-                            </Link>
-                          </td>
-                        </tr>
-                      ))}
+                      {jobsPage.content.map((job) => {
+                        const isDownloading = downloadingJobId === job.id;
+                        return (
+                          <tr key={job.id}>
+                            <td className="font-monospace">#{job.id}</td>
+                            <td>
+                              <div className="fw-semibold">{job.cnaeCode}</div>
+                              <div className="small text-secondary">
+                                {job.cnaeDescription}
+                              </div>
+                            </td>
+                            <td>{job.subniche ?? "-"}</td>
+                            <td>{job.status}</td>
+                            <td>{formatCost(job.costUsd)}</td>
+                            <td>{job.lastStageCode ?? "-"}</td>
+                            <td>{formatDate(job.lastStageAt)}</td>
+                            <td>
+                              <button
+                                type="button"
+                                className="btn btn-outline-secondary btn-sm"
+                                onClick={() => handleDownloadReport(job.id)}
+                                disabled={isDownloading}
+                              >
+                                {isDownloading ? (
+                                  <span
+                                    className="spinner-border spinner-border-sm me-1"
+                                    aria-hidden="true"
+                                  />
+                                ) : null}
+                                {isDownloading ? "Baixando" : "Baixar"}
+                              </button>
+                            </td>
+                            <td>
+                              <Link
+                                className="btn btn-outline-primary btn-sm"
+                                to={job.trackingUrl}
+                              >
+                                Abrir
+                              </Link>
+                            </td>
+                          </tr>
+                        );
+                      })}
                     </tbody>
                   </table>
                 </div>


### PR DESCRIPTION
### Motivation

- Corrigir comportamento em que o botão "Baixar" na tela de Jobs OPRM abria outra aba do navegador e expunha erro ao navegar diretamente para o endpoint de arquivo.
- Melhorar a experiência mantendo o usuário na mesma aba e prevenindo falhas visuais e navegações indesejadas ao baixar relatórios grandes.

### Description

- Substitui o link `a[target="_blank"]` por um botão que chama `downloadOprmNichoCnaeJobReport` para baixar o Markdown via `fetch` + `Blob` sem sair da aba em `frontend/src/pages/oprm/OprmJobsPage.tsx`.
- Adiciona a função `downloadOprmNichoCnaeJobReport(jobId)` em `frontend/src/api/oprm/useOprmNichoCnaeJobs.ts` que faz a requisição, cria o blob, gera `URL.createObjectURL` e aciona o download programaticamente.
- Implementa estado de loading (`downloadingJobId`), tratamento de erro (`downloadError`) e indicador de carregamento no botão `Atualizar` para seguir a convenção de botões assíncronos do frontend.
- Inclui teste de regressão `frontend/src/pages/oprm/OprmJobsPage.test.tsx` que simula `fetch`/`blob` e verifica que o arquivo é baixado via blob na mesma aba, e registra a correção em `docs/registros/oprm1.md`.

### Testing

- Executei `npm run typecheck` no frontend e a checagem de tipos terminou com sucesso após ajustes no teste (sucesso).
- Rodei o teste unitário específico com `npm test -- --run src/pages/oprm/OprmJobsPage.test.tsx` e ele passou validando o fluxo de `fetch` + `blob` sem abrir nova aba (sucesso).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a348832dd0483219ba75236b0c67036)