### PR TITLE
Add OpenAI query planner for market warmup and enhance query generation/logging

### DIFF
--- a/docs/canonical/mois-worker-canon.v1.md
+++ b/docs/canonical/mois-worker-canon.v1.md
@@ -607,7 +607,8 @@ Regra de reconstrução:
 2. Para produtos Hotmart, esses dados devem ser lidos preferencialmente de `mois_collected_reference.hotmart_price` e `mois_collected_reference.hotmart_producer`.
 3. Se o banco não possuir preço ou produtor, a UI deve mostrar lacuna operacional em vez de inferir, completar por texto genérico ou usar conclusão do modelo.
 4. O dossiê só pode avançar para novos blocos depois que o bloco factual anterior estiver persistido e auditável.
-5. Para o produto `mois_sales_page.id = 1057`, a verificação manual da página Hotmart em 2026-06-11 identificou:
+5. A pesquisa pública do dossiê deve construir queries qualificadas antes da coleta, priorizando produtor, domínio da página, título/subtítulo do produto, canais sociais, reviews, afiliados, prova social e sinais de distribuição; quando houver OpenAI configurada no worker, ela pode ser usada como camada de planejamento de queries, mantendo fallback heurístico auditável.
+6. Para o produto `mois_sales_page.id = 1057`, a verificação manual da página Hotmart em 2026-06-11 identificou:
    - preço exibido: `R$ 5.997,00`;
    - produtor exibido: `Abrantes Lima Empreendimentos LTDA`.
-6. Esses dois fatos são apenas o ponto inicial do dossiê; nenhuma conclusão de venda, autoridade, canal, mecanismo ou prova deve ser derivada deles sem etapa posterior específica.
+7. Esses dois fatos são apenas o ponto inicial do dossiê; nenhuma conclusão de venda, autoridade, canal, mecanismo ou prova deve ser derivada deles sem etapa posterior específica.

--- a/docs/registros/mois1.md
+++ b/docs/registros/mois1.md
@@ -1710,3 +1710,9 @@ Arquivos principais:
 - Corrigido o mock do teste `shouldListEntriesFromOperationalSalesPageTable` para usar a mesma assinatura UTC do backend ao ler `DATETIME` de `mois_sales_page`.
 - Causa-raiz: o service passou a chamar `ResultSet#getTimestamp(String, Calendar)` para evitar dependência do fuso do servidor, mas o teste ainda simulava `ResultSet#getTimestamp(String)`.
 - A correção mantém a proteção contra regressão de fuso horário sem alterar o contrato funcional da listagem operacional.
+
+## 2026-06-19 — Melhoria da pesquisa do dossiê MOIS
+
+- Corrigida a causa-raiz de dossiês fracos quando o produto possui nome ambíguo: a etapa de aquecimento agora usa uma camada de planejamento de queries com OpenAI quando houver chave configurada, preservando fallback heurístico quando a integração não estiver disponível.
+- As buscas passam a priorizar produtor, domínio da página, título/subtítulo, redes sociais, reviews, afiliados, prova social e canais de aquisição antes de concluir o dossiê.
+- Adicionados testes para impedir que produtos ambíguos voltem a gerar pesquisas genéricas por termos soltos sem domínio ou contexto comercial.

--- a/mois-sales-library-worker/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/marketwarmup/MarketWarmupProcessor.java
+++ b/mois-sales-library-worker/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/marketwarmup/MarketWarmupProcessor.java
@@ -52,13 +52,15 @@ public class MarketWarmupProcessor {
             "avancada");
 
     private final MarketWarmupQueryBuilder queryBuilder;
+    private final MarketWarmupQueryPlanner queryPlanner;
     private final PublicWebSearchClient searchClient;
 
     /**
      * Processa o job reservado sem acessar banco e devolve o payload estruturado aceito pelo backend.
      */
     public MarketWarmupCompleteRequest process(MarketWarmupClaimedJob job, int searchLimit) throws IOException {
-        List<String> queries = queryBuilder.buildQueries(job);
+        List<String> baseQueries = queryBuilder.buildQueries(job);
+        List<String> queries = queryPlanner.planQueries(job, baseQueries);
         List<PublicSearchResult> rawResults = new ArrayList<>();
         for (String query : queries) {
             rawResults.addAll(searchClient.search(query, searchLimit));

--- a/mois-sales-library-worker/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/marketwarmup/MarketWarmupQueryBuilder.java
+++ b/mois-sales-library-worker/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/marketwarmup/MarketWarmupQueryBuilder.java
@@ -1,6 +1,7 @@
 package com.marketinghub.mois.bibliotecapaginavenda.worker.v1.marketwarmup;
 
 import com.marketinghub.mois.bibliotecapaginavenda.worker.v1.model.WorkerDtos.MarketWarmupClaimedJob;
+import java.net.URI;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
@@ -21,6 +22,9 @@ public class MarketWarmupQueryBuilder {
         String mechanism = clean(job.mechanismSummary());
         String offer = clean(job.offerSummary());
         String proof = clean(job.proofSummary());
+        String domain = extractDomain(job.urlCanonical());
+        String titleWithoutSuffix = clean(title.replaceAll("(?i)\\s+-\\s+.*$", ""));
+        String titleSuffix = clean(title.replaceAll("(?i)^.*?\\s+-\\s+", ""));
         String productAndProducer = clean(title + " " + producer);
         Set<String> queries = new LinkedHashSet<>();
         if (!producer.isBlank() && !clean(title + " " + promise + " " + mechanism).isBlank()) {
@@ -33,6 +37,14 @@ public class MarketWarmupQueryBuilder {
             addIfUseful(queries, productAndProducer + " aula gratuita live whatsapp comunidade lançamento");
             addIfUseful(queries, productAndProducer + " afiliado hotmart produtor oferta bônus");
         }
+        if (!domain.isBlank()) {
+            addIfUseful(queries, exact(domain) + " Instagram YouTube TikTok depoimentos");
+            addIfUseful(queries, exact(domain) + " " + producer + " review funciona");
+        }
+        if (!titleWithoutSuffix.isBlank() && !titleSuffix.equals(titleWithoutSuffix)) {
+            addIfUseful(queries, exact(titleWithoutSuffix) + " " + exact(titleSuffix) + " Instagram YouTube TikTok");
+            addIfUseful(queries, exact(titleWithoutSuffix) + " " + titleSuffix + " depoimentos review funciona");
+        }
         if (!producer.isBlank()) {
             addIfUseful(queries, exact(producer) + " autoridade seguidores alunas método " + firstUseful(title, promise));
         }
@@ -42,7 +54,22 @@ public class MarketWarmupQueryBuilder {
         if (!clean(offer + " " + proof).isBlank()) {
             addIfUseful(queries, offer + " " + proof + " prova social depoimentos resultados");
         }
-        return queries.stream().limit(8).toList();
+        return queries.stream().limit(10).toList();
+    }
+
+    /**
+     * Extrai o domínio da página final para achar presença pública quando título e produtor são fracos.
+     */
+    private String extractDomain(String url) {
+        try {
+            String host = URI.create(clean(url)).getHost();
+            if (host == null || host.isBlank()) {
+                return "";
+            }
+            return host.replaceFirst("^www\\.", "");
+        } catch (RuntimeException ex) {
+            return "";
+        }
     }
 
     /**

--- a/mois-sales-library-worker/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/marketwarmup/MarketWarmupQueryPlanner.java
+++ b/mois-sales-library-worker/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/marketwarmup/MarketWarmupQueryPlanner.java
@@ -1,0 +1,14 @@
+package com.marketinghub.mois.bibliotecapaginavenda.worker.v1.marketwarmup;
+
+import com.marketinghub.mois.bibliotecapaginavenda.worker.v1.model.WorkerDtos.MarketWarmupClaimedJob;
+import java.util.List;
+
+/**
+ * Planeja buscas públicas qualificadas para descobrir autoridade, canais e prova social do dossiê.
+ */
+public interface MarketWarmupQueryPlanner {
+    /**
+     * Recebe as buscas heurísticas e devolve buscas enriquecidas, mantendo as originais como fallback seguro.
+     */
+    List<String> planQueries(MarketWarmupClaimedJob job, List<String> baseQueries);
+}

--- a/mois-sales-library-worker/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/marketwarmup/MarketWarmupRunner.java
+++ b/mois-sales-library-worker/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/marketwarmup/MarketWarmupRunner.java
@@ -1,5 +1,6 @@
 package com.marketinghub.mois.bibliotecapaginavenda.worker.v1.marketwarmup;
 
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marketinghub.mois.bibliotecapaginavenda.worker.v1.client.BackendClient;
 import com.marketinghub.mois.bibliotecapaginavenda.worker.v1.config.WorkerProperties;
 import com.marketinghub.mois.bibliotecapaginavenda.worker.v1.model.WorkerDtos.MarketWarmupClaimRequest;
@@ -21,6 +22,7 @@ public class MarketWarmupRunner {
     private final BackendClient backendClient;
     private final WorkerProperties properties;
     private final MarketWarmupProcessor processor;
+    private final ObjectMapper objectMapper = new ObjectMapper();
 
     /**
      * Reserva um job pendente, coleta fontes públicas, completa o dossiê ou persiste falha operacional.
@@ -43,6 +45,7 @@ public class MarketWarmupRunner {
             log.info("MOIS market-warmup worker claimed job. jobId={}, pageId={}, urlCanonical={}",
                     jobId, claim.job().pageId(), claim.job().urlCanonical());
             MarketWarmupCompleteRequest request = processor.process(claim.job(), resolveSearchLimit());
+            log.info("MOIS market-warmup enviando payload ao backend. jobId={}, payload={}", jobId, serializePayload(request));
             backendClient.completeMarketWarmup(jobId, request);
             log.info("MOIS market-warmup worker completed job. jobId={}, pageId={}, sources={}, signals={}",
                     jobId, claim.job().pageId(), request.sources().size(), request.signals().size());
@@ -69,5 +72,18 @@ public class MarketWarmupRunner {
      */
     private String safeMessage(Exception ex) {
         return ex.getMessage() == null || ex.getMessage().isBlank() ? ex.getClass().getSimpleName() : ex.getMessage();
+    }
+
+    /**
+     * Serializa o payload final para log operacional antes do envio ao backend.
+     */
+    private String serializePayload(MarketWarmupCompleteRequest request) {
+        try {
+            return objectMapper.writeValueAsString(request);
+        } catch (Exception ex) {
+            log.warn("MOIS market-warmup falhou ao serializar payload para log. errorClass={}, errorMessage={}",
+                    ex.getClass().getName(), ex.getMessage(), ex);
+            return String.valueOf(request);
+        }
     }
 }

--- a/mois-sales-library-worker/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/marketwarmup/OpenAiMarketWarmupQueryPlanner.java
+++ b/mois-sales-library-worker/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/marketwarmup/OpenAiMarketWarmupQueryPlanner.java
@@ -1,0 +1,190 @@
+package com.marketinghub.mois.bibliotecapaginavenda.worker.v1.marketwarmup;
+
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marketinghub.mois.bibliotecapaginavenda.worker.v1.model.WorkerDtos.MarketWarmupClaimedJob;
+import com.marketinghub.mois.bibliotecapaginavenda.worker.v1.pipeline.pageanalysis.OpenAiProperties;
+import java.util.ArrayList;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+/**
+ * Usa OpenAI como camada de planejamento para melhorar as queries de pesquisa do dossiê.
+ */
+@Component
+@RequiredArgsConstructor
+@Slf4j
+public class OpenAiMarketWarmupQueryPlanner implements MarketWarmupQueryPlanner {
+    private final OpenAiProperties properties;
+    private final ObjectMapper objectMapper = new ObjectMapper();
+
+    /**
+     * Gera consultas mais específicas para encontrar produtor, canais, prova social e distribuição.
+     */
+    @Override
+    public List<String> planQueries(MarketWarmupClaimedJob job, List<String> baseQueries) {
+        List<String> fallback = safeBaseQueries(baseQueries);
+        String apiKey = properties.resolvedApiKey();
+        if (apiKey.isBlank()) {
+            log.info("MOIS market-warmup query planner usando fallback sem OpenAI. jobId={}, pageId={}, baseQueries={}",
+                    job.jobId(), job.pageId(), fallback.size());
+            return fallback;
+        }
+        try {
+            Map<String, Object> request = buildRequest(job, fallback);
+            String requestPayload = objectMapper.writeValueAsString(request);
+            log.info("MOIS market-warmup enviando request cru para OpenAI. jobId={}, requestPayload={}",
+                    job.jobId(), requestPayload);
+            String rawResponse = RestClient.builder()
+                    .baseUrl(properties.normalizedBaseUrl())
+                    .defaultHeader("Authorization", "Bearer " + apiKey)
+                    .defaultHeader("Content-Type", "application/json")
+                    .build()
+                    .post()
+                    .uri("/chat/completions")
+                    .body(request)
+                    .retrieve()
+                    .body(String.class);
+            log.info("MOIS market-warmup recebeu resposta crua da OpenAI. jobId={}, rawResponse={}",
+                    job.jobId(), rawResponse);
+            return mergeQueries(fallback, parseQueries(rawResponse));
+        } catch (RuntimeException ex) {
+            log.warn("MOIS market-warmup query planner falhou e usará fallback. jobId={}, pageId={}, errorClass={}, errorMessage={}",
+                    job.jobId(), job.pageId(), ex.getClass().getName(), ex.getMessage(), ex);
+            return fallback;
+        } catch (Exception ex) {
+            log.warn("MOIS market-warmup query planner falhou ao serializar resposta e usará fallback. jobId={}, pageId={}, errorClass={}, errorMessage={}",
+                    job.jobId(), job.pageId(), ex.getClass().getName(), ex.getMessage(), ex);
+            return fallback;
+        }
+    }
+
+    /**
+     * Monta o payload objetivo enviado ao modelo para produzir somente JSON com queries.
+     */
+    private Map<String, Object> buildRequest(MarketWarmupClaimedJob job, List<String> baseQueries) {
+        String userPrompt = """
+                Gere melhores consultas de busca web para descobrir por que este produto vende.
+                Foque em produtor, pessoa pública, fundador, autoridade, Instagram, YouTube, TikTok, WhatsApp, lives, afiliados, reviews e prova social.
+                Evite consultas genéricas por palavras soltas do nome do produto.
+                Use aspas em nomes próprios e no título do produto quando útil.
+                Responda somente JSON válido no formato {"queries":["..."]}.
+
+                Produto: %s
+                Produtor: %s
+                URL: %s
+                Oferta: %s
+                Mecanismo: %s
+                Promessa: %s
+                Prova: %s
+                Queries base: %s
+                """.formatted(
+                safe(job.title()),
+                safe(job.producerName()),
+                safe(job.urlCanonical()),
+                safe(job.offerSummary()),
+                safe(job.mechanismSummary()),
+                safe(job.promiseSummary()),
+                safe(job.proofSummary()),
+                baseQueries);
+        return Map.of(
+                "model", properties.normalizedModel(),
+                "temperature", 0.2,
+                "messages", List.of(
+                        Map.of("role", "system", "content", "Você é um planejador de pesquisa comercial para dossiês de produtos digitais."),
+                        Map.of("role", "user", "content", userPrompt)));
+    }
+
+    /**
+     * Extrai as queries do JSON retornado pelo modelo.
+     */
+    private List<String> parseQueries(String rawResponse) throws Exception {
+        JsonNode root = objectMapper.readTree(rawResponse);
+        String content = root.path("choices").path(0).path("message").path("content").asText("");
+        if (content.isBlank()) {
+            return List.of();
+        }
+        JsonNode planned = objectMapper.readTree(stripCodeFence(content));
+        JsonNode queriesNode = planned.path("queries");
+        if (!queriesNode.isArray()) {
+            return List.of();
+        }
+        List<String> queries = new ArrayList<>();
+        for (JsonNode queryNode : queriesNode) {
+            String query = clean(queryNode.asText(""));
+            if (isUseful(query)) {
+                queries.add(query);
+            }
+        }
+        return queries;
+    }
+
+    /**
+     * Junta fallback e OpenAI preservando ordem, limite e foco comercial.
+     */
+    private List<String> mergeQueries(List<String> fallback, List<String> planned) {
+        Set<String> queries = new LinkedHashSet<>();
+        planned.stream().map(this::clean).filter(this::isUseful).forEach(queries::add);
+        fallback.stream().map(this::clean).filter(this::isUseful).forEach(queries::add);
+        return queries.stream().limit(10).toList();
+    }
+
+    /**
+     * Garante que as queries base sejam sempre utilizáveis quando a camada OpenAI não responder.
+     */
+    private List<String> safeBaseQueries(List<String> baseQueries) {
+        if (baseQueries == null) {
+            return List.of();
+        }
+        return baseQueries.stream().map(this::clean).filter(this::isUseful).limit(10).toList();
+    }
+
+    /**
+     * Remove cercas Markdown quando o modelo envolve o JSON em bloco de código.
+     */
+    private String stripCodeFence(String value) {
+        String normalized = value.trim();
+        if (normalized.startsWith("```")) {
+            normalized = normalized.replaceFirst("^```(?:json)?", "").replaceFirst("```$", "").trim();
+        }
+        return normalized;
+    }
+
+    /**
+     * Valida que a query carrega sinal específico de busca comercial.
+     */
+    private boolean isUseful(String query) {
+        String normalized = query.toLowerCase();
+        return query.length() >= 18
+                && (normalized.contains("\"")
+                || normalized.contains("instagram")
+                || normalized.contains("youtube")
+                || normalized.contains("tiktok")
+                || normalized.contains("whatsapp")
+                || normalized.contains("hotmart")
+                || normalized.contains("depoimento")
+                || normalized.contains("review")
+                || normalized.contains("afiliado"));
+    }
+
+    /**
+     * Normaliza espaços e limita tamanho para busca pública.
+     */
+    private String clean(String value) {
+        String normalized = safe(value).replaceAll("\\s+", " ").trim();
+        return normalized.length() > 180 ? normalized.substring(0, 180).trim() : normalized;
+    }
+
+    /**
+     * Normaliza nulos em texto vazio para montar prompt seguro.
+     */
+    private String safe(String value) {
+        return value == null ? "" : value;
+    }
+}

--- a/mois-sales-library-worker/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/marketwarmup/MarketWarmupProcessorTest.java
+++ b/mois-sales-library-worker/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/marketwarmup/MarketWarmupProcessorTest.java
@@ -18,7 +18,7 @@ class MarketWarmupProcessorTest {
      */
     @Test
     void shouldBuildStructuredDossierFromPublicSearchResults() throws Exception {
-        MarketWarmupProcessor processor = new MarketWarmupProcessor(new MarketWarmupQueryBuilder(), new FakeSearchClient());
+        MarketWarmupProcessor processor = new MarketWarmupProcessor(new MarketWarmupQueryBuilder(), new FallbackQueryPlanner(), new FakeSearchClient());
         MarketWarmupClaimedJob job = new MarketWarmupClaimedJob(
                 7L,
                 70L,
@@ -48,7 +48,7 @@ class MarketWarmupProcessorTest {
      */
     @Test
     void shouldKeepOnlyProducerSocialProfileWithSimilarProductContent() throws Exception {
-        MarketWarmupProcessor processor = new MarketWarmupProcessor(new MarketWarmupQueryBuilder(), new ProducerSocialSearchClient());
+        MarketWarmupProcessor processor = new MarketWarmupProcessor(new MarketWarmupQueryBuilder(), new FallbackQueryPlanner(), new ProducerSocialSearchClient());
         MarketWarmupClaimedJob job = new MarketWarmupClaimedJob(
                 8L,
                 80L,
@@ -81,6 +81,19 @@ class MarketWarmupProcessorTest {
             return List.of(
                     new PublicSearchResult("Especialista do Sono ensina Sono Profundo", "https://www.youtube.com/watch?v=abc", "Especialista do Sono é professora especialista e faz live sobre método respiratório para dormir melhor; comentários perguntam se funciona e preço.", "<div>raw</div>"),
                     new PublicSearchResult("Review Sono Profundo vale a pena", "https://blog.example.com/review", "Depoimento de alunos mostra resultado e objeção sobre confiança no produto.", "<div>raw</div>"));
+        }
+    }
+
+    /**
+     * Mantém as queries base no teste sem depender de OpenAI.
+     */
+    private static class FallbackQueryPlanner implements MarketWarmupQueryPlanner {
+        /**
+         * Devolve as queries heurísticas sem enriquecimento externo.
+         */
+        @Override
+        public List<String> planQueries(MarketWarmupClaimedJob job, List<String> baseQueries) {
+            return baseQueries;
         }
     }
 

--- a/mois-sales-library-worker/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/marketwarmup/MarketWarmupQueryBuilderTest.java
+++ b/mois-sales-library-worker/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/marketwarmup/MarketWarmupQueryBuilderTest.java
@@ -28,9 +28,32 @@ class MarketWarmupQueryBuilderTest {
                 "depoimentos de alunos");
 
         assertThat(builder.buildQueries(job))
-                .hasSize(8)
+                .hasSizeGreaterThanOrEqualTo(8)
                 .anySatisfy(query -> assertThat(query).contains("\"Especialista do Sono\"").contains("Instagram YouTube TikTok"))
                 .anySatisfy(query -> assertThat(query).contains("Produto Sono Profundo"))
                 .anySatisfy(query -> assertThat(query).contains("aula gratuita"));
+    }
+
+    /**
+     * Garante que nomes ambíguos usem domínio e subtítulo para evitar resultados genéricos.
+     */
+    @Test
+    void shouldBuildSpecificQueriesForAmbiguousProductName() {
+        MarketWarmupQueryBuilder builder = new MarketWarmupQueryBuilder();
+        MarketWarmupClaimedJob job = new MarketWarmupClaimedJob(
+                5L,
+                142L,
+                "workspace-001",
+                "https://www.andreavermont.online/andreia?src=htm_page",
+                "AndreIA - Terapeuta de Bolso",
+                "Force Academy Cursos",
+                null,
+                null,
+                null,
+                null);
+
+        assertThat(builder.buildQueries(job))
+                .anySatisfy(query -> assertThat(query).contains("\"andreavermont.online\""))
+                .anySatisfy(query -> assertThat(query).contains("\"AndreIA\"").contains("\"Terapeuta de Bolso\""));
     }
 }


### PR DESCRIPTION
### Motivation

- Improve the quality of public-search queries for the market-warmup dossier to reduce generic results for ambiguous product names. 
- Allow optional enrichment using OpenAI while keeping a deterministic heuristic fallback and preserving auditability. 
- Provide safer operational logging of the final payload sent to the backend to help debugging.

### Description

- Introduced a new `MarketWarmupQueryPlanner` interface and an `OpenAiMarketWarmupQueryPlanner` implementation that optionally calls an OpenAI-compatible API to enrich queries and merges planned queries with heuristic fallback. 
- Updated `MarketWarmupProcessor` to accept a `MarketWarmupQueryPlanner` and to apply planned queries returned by the planner before performing public searches. 
- Enhanced `MarketWarmupQueryBuilder` to extract the domain from `urlCanonical`, split title suffixes, add domain- and suffix-aware queries, and increase the returned query limit from `8` to `10`. 
- Added safe logging of the serialized `MarketWarmupCompleteRequest` payload in `MarketWarmupRunner` using an `ObjectMapper` and a `serializePayload` helper with guarded fallback. 
- Added/updated unit tests and small test helpers: `FallbackQueryPlanner` in tests, adjusted `MarketWarmupProcessorTest`, and added `shouldBuildSpecificQueriesForAmbiguousProductName` in `MarketWarmupQueryBuilderTest`. 
- Documentation updates reflecting the new planning behavior and search prioritization in canonical and changelog files under `docs/`.

### Testing

- Ran unit tests in the market-warmup package including `MarketWarmupProcessorTest` and `MarketWarmupQueryBuilderTest`, and they passed locally. 
- Verified new tests for ambiguous product names exercise domain and title-suffix logic and succeeded. 
- Built the worker module to ensure compilation of new classes and interface, which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3495cc79ec8321857d5d7b4c7c1819)