### PR TITLE
NichoCNAE v2: stage-execution framework, selective reprocess preserving accepted evidence, and stricter signal-extraction validation

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/routineresearchorchestrator/service/BackendRoutineResearchOrchestratorService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/routineresearchorchestrator/service/BackendRoutineResearchOrchestratorService.java
@@ -1,13 +1,17 @@
 package com.marketinghub.oprm.nichocnae.routineresearchorchestrator.service;
 
 import com.marketinghub.oprm.cnae.OprmNicheCandidate;
+import com.marketinghub.oprm.nichocnae.OprmExtractedSignal;
 import com.marketinghub.oprm.nichocnae.OprmNicheRoutineCard;
 import com.marketinghub.oprm.nichocnae.OprmRoutineResearchCycle;
+import com.marketinghub.oprm.nichocnae.OprmSourceSnapshot;
 import com.marketinghub.oprm.nichocnae.meiaudienceprofile.OprmMeiAudienceProfile;
 import com.marketinghub.oprm.nichocnae.RoutineResearchNicheNameNormalizer;
 import com.marketinghub.oprm.nichocnae.RoutineResearchNicheNameNormalizer.NormalizedNicheName;
 import com.marketinghub.oprm.nichocnae.routineresearchorchestrator.service.pending.RecordRoutineResearchOrchestratorPending;
 import com.marketinghub.oprm.nichocnae.routineresearchorchestrator.service.recent.RecordRoutineResearchOrchestratorRecent;
+import com.marketinghub.oprm.nichocnae.routineresearchorchestrator.service.reprocess.RecordRoutineResearchKnowledgeSnapshot;
+import com.marketinghub.oprm.nichocnae.routineresearchorchestrator.service.reprocess.RecordRoutineResearchOrchestratorReprocessPlan;
 import com.marketinghub.oprm.nichocnae.routineresearchorchestrator.service.reprocess.RecordRoutineResearchOrchestratorReprocessRequest;
 import com.marketinghub.oprm.nichocnae.routineresearchorchestrator.service.reprocess.RecordRoutineResearchOrchestratorReprocessResult;
 import com.marketinghub.oprm.nichocnae.routineresearchorchestrator.service.runNext.RecordRoutineResearchOrchestratorResult;
@@ -22,6 +26,7 @@ import com.marketinghub.repository.jpa.oprm.nichocnae.OprmRoutineResearchCycleRe
 import com.marketinghub.repository.jpa.oprm.nichocnae.meiaudienceprofile.OprmMeiAudienceProfileRepository;
 import java.math.BigDecimal;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import org.slf4j.Logger;
@@ -48,6 +53,8 @@ public class BackendRoutineResearchOrchestratorService {
     private static final String CYCLE_STATUS_SOLUTION_CONTAMINATED = "SOLUTION_CONTAMINATED";
     private static final String CYCLE_STATUS_GENERIC = "GENERIC";
     private static final String CYCLE_STATUS_NEEDS_EXECUTOR_ROUTINE_EVIDENCE = "NEEDS_EXECUTOR_ROUTINE_EVIDENCE";
+    private static final String SIGNAL_TYPE_SEMANTIC_CONTEXT_MISMATCH = "SEMANTIC_CONTEXT_MISMATCH";
+    private static final String SIGNAL_TYPE_SOLUTION_LANGUAGE_RISK = "SOLUTION_LANGUAGE_RISK";
     private static final String CYCLE_STATUS_CANCELLED_BY_MANUAL_RESTART = "CANCELLED_BY_MANUAL_RESTART";
     private static final String CYCLE_STATUS_STALLED = "STALLED";
     private static final String TRIGGER_SOURCE_AUTO_SCORE_QUEUE = "AUTO_SCORE_QUEUE";
@@ -164,8 +171,10 @@ public class BackendRoutineResearchOrchestratorService {
         String triggerSource = resolveReprocessTriggerSource(request);
         Instant now = Instant.now();
         preserveCurrentAiCostBeforeRerun(cycle);
-        clearArtifactsForStageRerun(cycle.getId());
-        reopenCycleForStageRerun(cycle, previousCycleStatus, previousQualityCard, triggerSource, now);
+        RecordRoutineResearchKnowledgeSnapshot knowledgeSnapshot = buildKnowledgeSnapshot(cycle.getId(), previousCycleStatus, previousQualityCard);
+        RecordRoutineResearchOrchestratorReprocessPlan reprocessPlan = planReprocess(cycle.getId(), previousCycleStatus, knowledgeSnapshot);
+        clearArtifactsForStageRerun(cycle.getId(), reprocessPlan);
+        reopenCycleForStageRerun(cycle, previousCycleStatus, previousQualityCard, triggerSource, now, reprocessPlan);
         OprmRoutineResearchCycle savedCycle = routineResearchCycleRepository.save(cycle);
         candidate.setRoutineResearchStatus(ROUTINE_STATUS_RUNNING);
         candidate.setLastRoutineResearchCycleId(savedCycle.getId());
@@ -204,11 +213,14 @@ public class BackendRoutineResearchOrchestratorService {
     }
 
     /** Remove artefatos derivados para que as etapas do próprio job sejam executadas novamente com novo input. */
-    private void clearArtifactsForStageRerun(Long researchCycleId) {
+    private void clearArtifactsForStageRerun(
+            Long researchCycleId, RecordRoutineResearchOrchestratorReprocessPlan reprocessPlan) {
         meiAudienceProfileRepository.deleteByResearchCycleId(researchCycleId);
         routineCardRepository.deleteByResearchCycleId(researchCycleId);
-        extractedSignalRepository.deleteByResearchCycleId(researchCycleId);
-        sourceSnapshotRepository.deleteByResearchCycleId(researchCycleId);
+        if (!reprocessPlan.preserveAcceptedEvidence()) {
+            extractedSignalRepository.deleteByResearchCycleId(researchCycleId);
+            sourceSnapshotRepository.deleteByResearchCycleId(researchCycleId);
+        }
         sourceCandidateRepository.deleteByResearchCycleId(researchCycleId);
         researchQueryRepository.deleteByResearchCycleId(researchCycleId);
         seedRepository.deleteByResearchCycleId(researchCycleId);
@@ -220,7 +232,8 @@ public class BackendRoutineResearchOrchestratorService {
             String previousCycleStatus,
             OprmNicheRoutineCard previousQualityCard,
             String triggerSource,
-            Instant now) {
+            Instant now,
+            RecordRoutineResearchOrchestratorReprocessPlan reprocessPlan) {
         cycle.setTriggerSource(triggerSource);
         cycle.setStatus(CYCLE_STATUS_RUNNING);
         cycle.setCurrentStageCode(CURRENT_STAGE_SEED_BUILDER);
@@ -229,19 +242,39 @@ public class BackendRoutineResearchOrchestratorService {
         cycle.setTotalSourceSnapshots(0);
         cycle.setTotalExtractedSignals(0);
         cycle.setFinishedAt(null);
-        cycle.setErrorMessage(buildStageRerunLearningNote(previousCycleStatus, previousQualityCard, triggerSource));
+        cycle.setErrorMessage(buildStageRerunLearningNote(previousCycleStatus, previousQualityCard, triggerSource, reprocessPlan));
         cycle.setUpdatedAt(now);
     }
 
     /** Monta a nota auditável que mantém o aprendizado do gate mesmo após limpar artefatos reexecutáveis. */
     private String buildStageRerunLearningNote(
-            String previousCycleStatus, OprmNicheRoutineCard previousQualityCard, String triggerSource) {
+            String previousCycleStatus,
+            OprmNicheRoutineCard previousQualityCard,
+            String triggerSource,
+            RecordRoutineResearchOrchestratorReprocessPlan reprocessPlan) {
         StringBuilder note = new StringBuilder()
                 .append("Reexecução de etapas do mesmo job solicitada por ")
                 .append(triggerSource)
                 .append(" após status ")
                 .append(previousCycleStatus)
-                .append(". O próximo seed deve usar o aprendizado do gate anterior.");
+                .append(". O próximo seed deve usar o aprendizado do gate anterior.")
+                .append(" knowledgeVersion=")
+                .append(reprocessPlan.knowledgeVersion())
+                .append("; rewindStage=")
+                .append(reprocessPlan.rewindStageCode())
+                .append("; preserveAcceptedEvidence=")
+                .append(reprocessPlan.preserveAcceptedEvidence())
+                .append("; evidenceGaps=")
+                .append(reprocessPlan.evidenceGaps())
+                .append("; preservedSourceSnapshotIds=")
+                .append(reprocessPlan.preservedSourceSnapshotIds())
+                .append("; preservedSignalIds=")
+                .append(reprocessPlan.preservedSignalIds())
+                .append("; rejectedSourceSnapshotIds=")
+                .append(reprocessPlan.rejectedSourceSnapshotIds())
+                .append("; reasonCode=")
+                .append(reprocessPlan.reasonCode())
+                .append(".");
         if (previousQualityCard != null) {
             note.append(" previousQualityStatus=")
                     .append(previousQualityCard.getQualityStatus())
@@ -249,6 +282,126 @@ public class BackendRoutineResearchOrchestratorService {
                     .append(previousQualityCard.getQualityNotes());
         }
         return note.toString();
+    }
+
+
+    /** Monta o snapshot de conhecimento com fontes e claims aceitos antes de reabrir o job. */
+    private RecordRoutineResearchKnowledgeSnapshot buildKnowledgeSnapshot(
+            Long researchCycleId, String previousCycleStatus, OprmNicheRoutineCard previousQualityCard) {
+        List<OprmSourceSnapshot> snapshots = sourceSnapshotRepository.findByResearchCycleIdOrderByIdAsc(researchCycleId);
+        List<OprmExtractedSignal> signals = extractedSignalRepository.findByResearchCycleIdOrderByIdAsc(researchCycleId);
+        List<Long> acceptedSignalIds = signals.stream()
+                .filter(this::isAcceptedSignal)
+                .map(OprmExtractedSignal::getId)
+                .toList();
+        List<Long> acceptedSourceSnapshotIds = signals.stream()
+                .filter(this::isAcceptedSignal)
+                .map(OprmExtractedSignal::getSourceSnapshotId)
+                .distinct()
+                .toList();
+        List<Long> rejectedSourceSnapshotIds = signals.stream()
+                .filter(this::isRejectedEvidenceSignal)
+                .map(OprmExtractedSignal::getSourceSnapshotId)
+                .distinct()
+                .toList();
+        List<String> evidenceGaps = resolveEvidenceGaps(previousCycleStatus, previousQualityCard);
+        return new RecordRoutineResearchKnowledgeSnapshot(
+                researchCycleId,
+                buildKnowledgeVersion(researchCycleId, snapshots, signals),
+                snapshots.size(),
+                signals.size(),
+                acceptedSourceSnapshotIds,
+                acceptedSignalIds,
+                rejectedSourceSnapshotIds,
+                evidenceGaps);
+    }
+
+    /** Decide a menor reexecução segura para buscar evidência faltante sem apagar fontes aceitas. */
+    private RecordRoutineResearchOrchestratorReprocessPlan planReprocess(
+            Long researchCycleId, String previousCycleStatus, RecordRoutineResearchKnowledgeSnapshot knowledgeSnapshot) {
+        boolean preserveAcceptedEvidence = shouldPreserveAcceptedEvidence(previousCycleStatus, knowledgeSnapshot);
+        return new RecordRoutineResearchOrchestratorReprocessPlan(
+                researchCycleId,
+                CURRENT_STAGE_SEED_BUILDER,
+                knowledgeSnapshot.knowledgeVersion(),
+                preserveAcceptedEvidence,
+                knowledgeSnapshot.acceptedSourceSnapshotIds(),
+                knowledgeSnapshot.acceptedSignalIds(),
+                knowledgeSnapshot.rejectedSourceSnapshotIds(),
+                knowledgeSnapshot.evidenceGaps(),
+                preserveAcceptedEvidence ? "QUERY_PLANNER_EVIDENCE_GAP" : "FULL_STAGE_RERUN");
+    }
+
+    /** Identifica sinais que representam claims aproveitáveis e auditáveis para a próxima tentativa. */
+    private boolean isAcceptedSignal(OprmExtractedSignal signal) {
+        return signal.getId() != null
+                && signal.getSourceSnapshotId() != null
+                && hasText(signal.getEvidenceExcerpt())
+                && !isRejectedEvidenceSignal(signal);
+    }
+
+    /** Identifica sinais negativos que apontam fonte/claim contaminado e não devem guiar a próxima síntese. */
+    private boolean isRejectedEvidenceSignal(OprmExtractedSignal signal) {
+        String signalType = signal.getSignalType();
+        return SIGNAL_TYPE_SEMANTIC_CONTEXT_MISMATCH.equals(signalType)
+                || SIGNAL_TYPE_SOLUTION_LANGUAGE_RISK.equals(signalType)
+                || (signalType != null && signalType.endsWith("_RISK"));
+    }
+
+    /** Define se a reprovação deve preservar evidência aceita e voltar apenas ao planejador de queries. */
+    private boolean shouldPreserveAcceptedEvidence(
+            String previousCycleStatus, RecordRoutineResearchKnowledgeSnapshot knowledgeSnapshot) {
+        return !knowledgeSnapshot.acceptedSignalIds().isEmpty()
+                && (CYCLE_STATUS_NEEDS_EXECUTOR_ROUTINE_EVIDENCE.equals(previousCycleStatus)
+                        || CYCLE_STATUS_NEEDS_MORE_RESEARCH.equals(previousCycleStatus)
+                        || CYCLE_STATUS_NEEDS_MORE_MEI_RESEARCH.equals(previousCycleStatus)
+                        || CYCLE_STATUS_GENERIC.equals(previousCycleStatus)
+                        || CYCLE_STATUS_OUTDATED_SOURCES.equals(previousCycleStatus));
+    }
+
+    /** Deriva lacunas de evidência que o query planner deve cobrir na nova tentativa. */
+    private List<String> resolveEvidenceGaps(String previousCycleStatus, OprmNicheRoutineCard previousQualityCard) {
+        List<String> gaps = new ArrayList<>();
+        if (CYCLE_STATUS_NEEDS_EXECUTOR_ROUTINE_EVIDENCE.equals(previousCycleStatus)) {
+            gaps.add("EXECUTOR_ROUTINE");
+        }
+        if (CYCLE_STATUS_NEEDS_MORE_RESEARCH.equals(previousCycleStatus)
+                || CYCLE_STATUS_NEEDS_MORE_MEI_RESEARCH.equals(previousCycleStatus)) {
+            gaps.add("MEI_AUTONOMOUS_REALITY");
+            gaps.add("ECONOMIC_IMPACT");
+        }
+        if (CYCLE_STATUS_GENERIC.equals(previousCycleStatus)) {
+            gaps.add("CONCRETE_TASKS_AND_PAIN");
+        }
+        if (CYCLE_STATUS_OUTDATED_SOURCES.equals(previousCycleStatus)) {
+            gaps.add("RECENT_BRAZILIAN_SOURCES");
+        }
+        if (previousQualityCard != null && hasText(previousQualityCard.getQualityNotes())) {
+            String notes = previousQualityCard.getQualityNotes().toLowerCase(Locale.ROOT);
+            if (notes.contains("rotina") && !gaps.contains("EXECUTOR_ROUTINE")) {
+                gaps.add("EXECUTOR_ROUTINE");
+            }
+            if (notes.contains("evid") && !gaps.contains("PUBLIC_EVIDENCE")) {
+                gaps.add("PUBLIC_EVIDENCE");
+            }
+        }
+        if (gaps.isEmpty()) {
+            gaps.add("PUBLIC_EVIDENCE");
+        }
+        return gaps.stream().distinct().toList();
+    }
+
+    /** Cria uma versão estável do snapshot para auditoria textual do reprocessamento. */
+    private String buildKnowledgeVersion(
+            Long researchCycleId, List<OprmSourceSnapshot> snapshots, List<OprmExtractedSignal> signals) {
+        Long lastSnapshotId = snapshots.isEmpty() ? 0L : snapshots.getLast().getId();
+        Long lastSignalId = signals.isEmpty() ? 0L : signals.getLast().getId();
+        return "cycle-" + researchCycleId + "-snap-" + lastSnapshotId + "-sig-" + lastSignalId;
+    }
+
+    /** Verifica se um texto possui conteúdo útil para decisão de reprocessamento. */
+    private boolean hasText(String value) {
+        return value != null && !value.isBlank();
     }
 
     /** Normaliza a origem solicitada pelo executor externo sem permitir valores arbitrários no histórico. */

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/routineresearchorchestrator/service/reprocess/RecordRoutineResearchKnowledgeSnapshot.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/routineresearchorchestrator/service/reprocess/RecordRoutineResearchKnowledgeSnapshot.java
@@ -1,0 +1,14 @@
+package com.marketinghub.oprm.nichocnae.routineresearchorchestrator.service.reprocess;
+
+import java.util.List;
+
+/** Representa o snapshot mínimo de conhecimento aceito antes de reprocessar o mesmo job. */
+public record RecordRoutineResearchKnowledgeSnapshot(
+        Long researchCycleId,
+        String knowledgeVersion,
+        int sourceSnapshotCount,
+        int extractedSignalCount,
+        List<Long> acceptedSourceSnapshotIds,
+        List<Long> acceptedSignalIds,
+        List<Long> rejectedSourceSnapshotIds,
+        List<String> evidenceGaps) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/routineresearchorchestrator/service/reprocess/RecordRoutineResearchOrchestratorReprocessPlan.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/routineresearchorchestrator/service/reprocess/RecordRoutineResearchOrchestratorReprocessPlan.java
@@ -1,0 +1,15 @@
+package com.marketinghub.oprm.nichocnae.routineresearchorchestrator.service.reprocess;
+
+import java.util.List;
+
+/** Representa o plano mínimo de rewind para reprocessar um job sem perder evidências aceitas. */
+public record RecordRoutineResearchOrchestratorReprocessPlan(
+        Long researchCycleId,
+        String rewindStageCode,
+        String knowledgeVersion,
+        boolean preserveAcceptedEvidence,
+        List<Long> preservedSourceSnapshotIds,
+        List<Long> preservedSignalIds,
+        List<Long> rejectedSourceSnapshotIds,
+        List<String> evidenceGaps,
+        String reasonCode) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/signalextractor/service/BackendSignalExtractorService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/signalextractor/service/BackendSignalExtractorService.java
@@ -77,6 +77,7 @@ public class BackendSignalExtractorService {
         throw new IllegalStateException("sourceSnapshot already has extracted signals: " + sourceSnapshotId);
       }
       Instant now = Instant.now();
+      request.signals().forEach(signal -> validateSignalItem(signal, snapshot));
       List<OprmExtractedSignal> persistedSignals = request.signals().stream()
           .map(signal -> createSignal(snapshot, request, signal, now))
           .map(extractedSignalRepository::save)
@@ -175,7 +176,6 @@ public class BackendSignalExtractorService {
     if (request.signals().size() > MAX_SIGNALS_PER_SNAPSHOT) {
       throw new IllegalArgumentException("signals must contain at most " + MAX_SIGNALS_PER_SNAPSHOT + " items");
     }
-    request.signals().forEach(this::validateSignalItem);
   }
 
   /** Confere se os sinais recebidos pertencem exatamente ao snapshot processado pelo worker. */
@@ -191,8 +191,8 @@ public class BackendSignalExtractorService {
     }
   }
 
-  /** Valida um sinal individual para bloquear textos vazios ou payloads grandes demais. */
-  private void validateSignalItem(SignalExtractionItemRequest signal) {
+  /** Valida um sinal individual para bloquear textos vazios, payloads grandes ou evidência fora do snapshot. */
+  private void validateSignalItem(SignalExtractionItemRequest signal, OprmSourceSnapshot snapshot) {
     if (signal == null) {
       throw new IllegalArgumentException("signal item is required");
     }
@@ -205,10 +205,50 @@ public class BackendSignalExtractorService {
     if (evidence.length() > MAX_EVIDENCE_LENGTH) {
       throw new IllegalArgumentException("evidenceExcerpt must contain at most " + MAX_EVIDENCE_LENGTH + " characters");
     }
+    if (!isExactEvidenceSpan(snapshot, evidence)) {
+      throw new IllegalArgumentException("evidenceExcerpt must be an exact span from sourceTitle, snippet or shortExcerpt");
+    }
+    if (isPositiveSignal(signal.signalType()) && hasActorContextMismatch(evidence)) {
+      throw new IllegalArgumentException("signal actor/context does not match the target executor");
+    }
     Integer confidence = signal.confidenceScore();
     if (confidence == null || confidence < 0 || confidence > 100) {
       throw new IllegalArgumentException("confidenceScore must be between 0 and 100");
     }
+  }
+
+
+  /** Confere se a evidência enviada é trecho literal de um dos campos persistidos do snapshot. */
+  private boolean isExactEvidenceSpan(OprmSourceSnapshot snapshot, String evidence) {
+    return containsExactSpan(snapshot.getSourceTitle(), evidence)
+        || containsExactSpan(snapshot.getSnippet(), evidence)
+        || containsExactSpan(snapshot.getShortExcerpt(), evidence);
+  }
+
+  /** Verifica se o campo persistido contém literalmente o trecho de evidência aprovado. */
+  private boolean containsExactSpan(String sourceText, String evidence) {
+    return StringUtils.hasText(sourceText) && sourceText.contains(evidence);
+  }
+
+  /** Identifica sinais positivos que não podem nascer de ator ou contexto adjacente. */
+  private boolean isPositiveSignal(String signalType) {
+    String normalized = signalType == null ? "" : signalType.trim().toUpperCase(java.util.Locale.ROOT);
+    return !normalized.endsWith("_RISK") && !normalized.equals("SEMANTIC_CONTEXT_MISMATCH");
+  }
+
+  /** Detecta evidências de ator ou ocupação adjacente que não provam a rotina do executor alvo. */
+  private boolean hasActorContextMismatch(String evidence) {
+    String normalized = evidence.toLowerCase(java.util.Locale.ROOT);
+    return normalized.contains("companhia aérea")
+        || normalized.contains("voo cancelado")
+        || normalized.contains("cancelamento de voo")
+        || normalized.contains("motorista de aplicativo")
+        || normalized.contains("entregador de aplicativo")
+        || normalized.contains("ifood")
+        || normalized.contains("uber")
+        || normalized.contains("degustador de grãos")
+        || normalized.contains("personal shopper")
+        || normalized.contains("revendedora plus size");
   }
 
   /** Cria uma entidade de sinal preservando somente campos contratuais e evidência curta. */

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/OprmNichoCnaeV2FailureType.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/OprmNichoCnaeV2FailureType.java
@@ -1,0 +1,9 @@
+package com.marketinghub.oprm.nichocnae.v2;
+
+/** Classifica a causa operacional da falha para separar infraestrutura, validação, qualidade e evidência de mercado. */
+public enum OprmNichoCnaeV2FailureType {
+    INFRASTRUCTURE,
+    VALIDATION,
+    QUALITY,
+    MARKET_EVIDENCE
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/OprmNichoCnaeV2StageExecution.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/OprmNichoCnaeV2StageExecution.java
@@ -1,0 +1,75 @@
+package com.marketinghub.oprm.nichocnae.v2;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import lombok.Data;
+
+/** Entidade responsável por registrar tentativas imutáveis de etapa do pipeline NichoCNAE v2. */
+@Entity
+@Data
+@Table(name = "oprm_nichocnae_v2_stage_execution")
+public class OprmNichoCnaeV2StageExecution {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "job_id", nullable = false, length = 96)
+    private String jobId;
+
+    @Column(name = "research_cycle_id")
+    private Long researchCycleId;
+
+    @Column(name = "source_niche_id", nullable = false)
+    private Long sourceNicheId;
+
+    @Column(name = "cnae_code", nullable = false, length = 7)
+    private String cnaeCode;
+
+    @Column(name = "stage_code", nullable = false, length = 64)
+    private String stageCode;
+
+    @Column(name = "attempt_number", nullable = false)
+    private Integer attemptNumber;
+
+    @Column(name = "technical_retry_number", nullable = false)
+    private Integer technicalRetryNumber;
+
+    @Column(name = "knowledge_version", nullable = false)
+    private Integer knowledgeVersion;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 40)
+    private OprmNichoCnaeV2StageExecutionStatus status;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "failure_type", length = 32)
+    private OprmNichoCnaeV2FailureType failureType;
+
+    @Column(name = "input_payload", columnDefinition = "LONGTEXT")
+    private String inputPayload;
+
+    @Column(name = "output_payload", columnDefinition = "LONGTEXT")
+    private String outputPayload;
+
+    @Column(name = "error_message", columnDefinition = "LONGTEXT")
+    private String errorMessage;
+
+    @Column(name = "next_stage_code", length = 64)
+    private String nextStageCode;
+
+    @Column(name = "materialization_enabled", nullable = false)
+    private Boolean materializationEnabled;
+
+    @Column(name = "created_at", nullable = false)
+    private Instant createdAt;
+
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/OprmNichoCnaeV2StageExecutionStatus.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/OprmNichoCnaeV2StageExecutionStatus.java
@@ -1,0 +1,10 @@
+package com.marketinghub.oprm.nichocnae.v2;
+
+/** Define o estado persistido de uma execução imutável de etapa do pipeline NichoCNAE v2. */
+public enum OprmNichoCnaeV2StageExecutionStatus {
+    PENDING,
+    RUNNING,
+    COMPLETED,
+    TECHNICAL_RETRY_SCHEDULED,
+    FAILED
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/candidategenerator/controller/BackendCandidateGeneratorController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/candidategenerator/controller/BackendCandidateGeneratorController.java
@@ -1,9 +1,16 @@
 package com.marketinghub.oprm.nichocnae.v2.candidategenerator.controller;
 
 import com.marketinghub.oprm.nichocnae.v2.candidategenerator.service.BackendCandidateGeneratorService;
+import com.marketinghub.oprm.nichocnae.v2.candidategenerator.service.completeStageExecution.CandidateGeneratorCompletionRequest;
+import com.marketinghub.oprm.nichocnae.v2.candidategenerator.service.completeStageExecution.CandidateGeneratorCompletionResponse;
+import com.marketinghub.oprm.nichocnae.v2.candidategenerator.service.failStageExecution.CandidateGeneratorFailureRequest;
+import com.marketinghub.oprm.nichocnae.v2.candidategenerator.service.failStageExecution.CandidateGeneratorFailureResponse;
 import com.marketinghub.oprm.nichocnae.v2.candidategenerator.service.pending.CandidateGeneratorPendingResponse;
 import java.util.List;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -22,5 +29,19 @@ public class BackendCandidateGeneratorController {
     @GetMapping("/pending")
     public List<CandidateGeneratorPendingResponse> pending() {
         return service.pending();
+    }
+
+    /** Registra a conclusão da execução de etapa informada pelo módulo executor OPRM. */
+    @PostMapping("/{stageExecutionId}/complete")
+    public CandidateGeneratorCompletionResponse complete(
+            @PathVariable Long stageExecutionId, @RequestBody CandidateGeneratorCompletionRequest request) {
+        return service.complete(stageExecutionId, request);
+    }
+
+    /** Registra a falha da execução de etapa informada pelo módulo executor OPRM. */
+    @PostMapping("/{stageExecutionId}/fail")
+    public CandidateGeneratorFailureResponse fail(
+            @PathVariable Long stageExecutionId, @RequestBody CandidateGeneratorFailureRequest request) {
+        return service.fail(stageExecutionId, request);
     }
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/candidategenerator/service/BackendCandidateGeneratorService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/candidategenerator/service/BackendCandidateGeneratorService.java
@@ -1,14 +1,199 @@
 package com.marketinghub.oprm.nichocnae.v2.candidategenerator.service;
 
+import com.marketinghub.oprm.cnae.OprmNicheCandidate;
+import com.marketinghub.oprm.nichocnae.v2.OprmNichoCnaeV2FailureType;
+import com.marketinghub.oprm.nichocnae.v2.OprmNichoCnaeV2StageExecution;
+import com.marketinghub.oprm.nichocnae.v2.OprmNichoCnaeV2StageExecutionStatus;
+import com.marketinghub.oprm.nichocnae.v2.candidategenerator.service.completeStageExecution.CandidateGeneratorCompletionRequest;
+import com.marketinghub.oprm.nichocnae.v2.candidategenerator.service.completeStageExecution.CandidateGeneratorCompletionResponse;
+import com.marketinghub.oprm.nichocnae.v2.candidategenerator.service.failStageExecution.CandidateGeneratorFailureRequest;
+import com.marketinghub.oprm.nichocnae.v2.candidategenerator.service.failStageExecution.CandidateGeneratorFailureResponse;
 import com.marketinghub.oprm.nichocnae.v2.candidategenerator.service.pending.CandidateGeneratorPendingResponse;
+import com.marketinghub.repository.jpa.oprm.cnae.OprmNicheCandidateRepository;
+import com.marketinghub.repository.jpa.oprm.nichocnae.v2.OprmNichoCnaeV2StageExecutionRepository;
+import java.time.Instant;
 import java.util.List;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
 
 /** Expõe contratos de leitura/escrita do backend para a etapa candidate-generator do pipeline NichoCNAE v2. */
 @Service
 public class BackendCandidateGeneratorService {
+    private static final String STAGE_CODE = "candidate-generator";
+    private static final String MATERIALIZER_STAGE_CODE = "enriched-niche-materializer";
+    private static final String ACTION_MATERIALIZAR_NICHO = "MATERIALIZAR_NICHO";
+    private static final String QUALITY_STATUS_MEI_AUDIENCE_READY = "MEI_AUDIENCE_READY";
+
+    private final OprmNicheCandidateRepository nicheCandidateRepository;
+    private final OprmNichoCnaeV2StageExecutionRepository stageExecutionRepository;
+    private final boolean v2Enabled;
+    private final boolean materializationEnabled;
+
+    /** Inicializa o service com repositórios canônicos e feature flags de calibração da v2. */
+    public BackendCandidateGeneratorService(
+            OprmNicheCandidateRepository nicheCandidateRepository,
+            OprmNichoCnaeV2StageExecutionRepository stageExecutionRepository,
+            @Value("${oprm.nichocnae.v2.enabled:false}") boolean v2Enabled,
+            @Value("${oprm.nichocnae.v2.materialization-enabled:false}") boolean materializationEnabled) {
+        this.nicheCandidateRepository = nicheCandidateRepository;
+        this.stageExecutionRepository = stageExecutionRepository;
+        this.v2Enabled = v2Enabled;
+        this.materializationEnabled = materializationEnabled;
+    }
+
     /** Lista pendências disponíveis para consumo canônico pelo executor OPRM NichoCNAE v2. */
+    @Transactional
     public List<CandidateGeneratorPendingResponse> pending() {
-        return List.of();
+        if (!v2Enabled) {
+            return List.of();
+        }
+        ensureInitialPendingExecution();
+        return stageExecutionRepository
+                .findByStageCodeAndStatusOrderByCreatedAtAsc(
+                        STAGE_CODE, OprmNichoCnaeV2StageExecutionStatus.PENDING, PageRequest.of(0, 1))
+                .stream()
+                .map(this::toPendingResponse)
+                .toList();
+    }
+
+    /** Registra conclusão da etapa e calcula a próxima etapa sem liberar materialização automática durante calibração. */
+    @Transactional
+    public CandidateGeneratorCompletionResponse complete(
+            Long stageExecutionId, CandidateGeneratorCompletionRequest request) {
+        OprmNichoCnaeV2StageExecution execution = findExecution(stageExecutionId);
+        execution.setStatus(OprmNichoCnaeV2StageExecutionStatus.COMPLETED);
+        execution.setOutputPayload(request == null ? null : request.outputPayload());
+        execution.setNextStageCode(resolveNextStage(request));
+        execution.setUpdatedAt(Instant.now());
+        OprmNichoCnaeV2StageExecution saved = stageExecutionRepository.save(execution);
+        return new CandidateGeneratorCompletionResponse(
+                String.valueOf(saved.getId()),
+                saved.getStatus().name(),
+                saved.getNextStageCode(),
+                saved.getMaterializationEnabled());
+    }
+
+    /** Registra falha e cria nova execução somente quando a falha for retry técnico de infraestrutura. */
+    @Transactional
+    public CandidateGeneratorFailureResponse fail(Long stageExecutionId, CandidateGeneratorFailureRequest request) {
+        OprmNichoCnaeV2StageExecution execution = findExecution(stageExecutionId);
+        OprmNichoCnaeV2FailureType failureType = request == null || request.failureType() == null
+                ? OprmNichoCnaeV2FailureType.VALIDATION
+                : request.failureType();
+        execution.setFailureType(failureType);
+        execution.setErrorMessage(request == null ? null : request.errorMessage());
+        execution.setInputPayload(request == null ? execution.getInputPayload() : request.inputPayload());
+        execution.setUpdatedAt(Instant.now());
+        if (failureType == OprmNichoCnaeV2FailureType.INFRASTRUCTURE) {
+            execution.setStatus(OprmNichoCnaeV2StageExecutionStatus.TECHNICAL_RETRY_SCHEDULED);
+            OprmNichoCnaeV2StageExecution retry = createTechnicalRetry(execution);
+            stageExecutionRepository.save(execution);
+            OprmNichoCnaeV2StageExecution savedRetry = stageExecutionRepository.save(retry);
+            return new CandidateGeneratorFailureResponse(
+                    String.valueOf(execution.getId()),
+                    execution.getStatus().name(),
+                    String.valueOf(savedRetry.getId()),
+                    savedRetry.getAttemptNumber(),
+                    savedRetry.getTechnicalRetryNumber());
+        }
+        execution.setStatus(OprmNichoCnaeV2StageExecutionStatus.FAILED);
+        OprmNichoCnaeV2StageExecution saved = stageExecutionRepository.save(execution);
+        return new CandidateGeneratorFailureResponse(
+                String.valueOf(saved.getId()),
+                saved.getStatus().name(),
+                null,
+                saved.getAttemptNumber(),
+                saved.getTechnicalRetryNumber());
+    }
+
+    /** Garante uma pendência inicial real a partir da fila atual de candidatos, sem materialização automática. */
+    private void ensureInitialPendingExecution() {
+        if (!stageExecutionRepository
+                .findByStageCodeAndStatusOrderByCreatedAtAsc(
+                        STAGE_CODE, OprmNichoCnaeV2StageExecutionStatus.PENDING, PageRequest.of(0, 1))
+                .isEmpty()) {
+            return;
+        }
+        nicheCandidateRepository.findNextPendingRoutineResearchCandidatePreview(PageRequest.of(0, 1)).stream()
+                .filter(candidate -> !stageExecutionRepository.existsBySourceNicheIdAndStageCode(
+                        candidate.getId(), STAGE_CODE))
+                .findFirst()
+                .ifPresent(candidate -> stageExecutionRepository.save(createInitialExecution(candidate)));
+    }
+
+    /** Cria a primeira execução imutável da etapa candidate-generator para o candidato priorizado. */
+    private OprmNichoCnaeV2StageExecution createInitialExecution(OprmNicheCandidate candidate) {
+        Instant now = Instant.now();
+        OprmNichoCnaeV2StageExecution execution = new OprmNichoCnaeV2StageExecution();
+        execution.setJobId("nichocnae-v2-candidate-" + candidate.getId());
+        execution.setSourceNicheId(candidate.getId());
+        execution.setCnaeCode(candidate.getCnaeCode());
+        execution.setStageCode(STAGE_CODE);
+        execution.setAttemptNumber(1);
+        execution.setTechnicalRetryNumber(0);
+        execution.setKnowledgeVersion(1);
+        execution.setStatus(OprmNichoCnaeV2StageExecutionStatus.PENDING);
+        execution.setMaterializationEnabled(materializationEnabled);
+        execution.setCreatedAt(now);
+        execution.setUpdatedAt(now);
+        return execution;
+    }
+
+    /** Cria uma nova linha para retry técnico preservando a tentativa cognitiva e a versão de conhecimento. */
+    private OprmNichoCnaeV2StageExecution createTechnicalRetry(OprmNichoCnaeV2StageExecution previousExecution) {
+        Instant now = Instant.now();
+        OprmNichoCnaeV2StageExecution retry = new OprmNichoCnaeV2StageExecution();
+        retry.setJobId(previousExecution.getJobId());
+        retry.setResearchCycleId(previousExecution.getResearchCycleId());
+        retry.setSourceNicheId(previousExecution.getSourceNicheId());
+        retry.setCnaeCode(previousExecution.getCnaeCode());
+        retry.setStageCode(previousExecution.getStageCode());
+        retry.setAttemptNumber(previousExecution.getAttemptNumber());
+        retry.setTechnicalRetryNumber(previousExecution.getTechnicalRetryNumber() + 1);
+        retry.setKnowledgeVersion(previousExecution.getKnowledgeVersion());
+        retry.setStatus(OprmNichoCnaeV2StageExecutionStatus.PENDING);
+        retry.setInputPayload(previousExecution.getInputPayload());
+        retry.setMaterializationEnabled(previousExecution.getMaterializationEnabled());
+        retry.setCreatedAt(now);
+        retry.setUpdatedAt(now);
+        return retry;
+    }
+
+    /** Calcula a próxima etapa protegendo a materialização automática quando a v2 está em calibração. */
+    private String resolveNextStage(CandidateGeneratorCompletionRequest request) {
+        if (request == null) {
+            return null;
+        }
+        if (QUALITY_STATUS_MEI_AUDIENCE_READY.equals(request.qualityStatus())
+                && ACTION_MATERIALIZAR_NICHO.equals(request.requestedAction())) {
+            return materializationEnabled ? MATERIALIZER_STAGE_CODE : null;
+        }
+        return null;
+    }
+
+    /** Carrega a execução da etapa atual ou devolve erro HTTP claro ao executor. */
+    private OprmNichoCnaeV2StageExecution findExecution(Long stageExecutionId) {
+        return stageExecutionRepository
+                .findByIdAndStageCode(stageExecutionId, STAGE_CODE)
+                .orElseThrow(() -> new ResponseStatusException(
+                        HttpStatus.NOT_FOUND,
+                        "NichoCNAE v2 candidate-generator stage execution not found: " + stageExecutionId));
+    }
+
+    /** Converte a entidade persistida no contrato canônico de pending do executor. */
+    private CandidateGeneratorPendingResponse toPendingResponse(OprmNichoCnaeV2StageExecution execution) {
+        return new CandidateGeneratorPendingResponse(
+                String.valueOf(execution.getId()),
+                execution.getJobId(),
+                execution.getCnaeCode(),
+                execution.getSourceNicheId(),
+                execution.getAttemptNumber(),
+                execution.getTechnicalRetryNumber(),
+                execution.getKnowledgeVersion(),
+                execution.getMaterializationEnabled());
     }
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/candidategenerator/service/completeStageExecution/CandidateGeneratorCompletionRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/candidategenerator/service/completeStageExecution/CandidateGeneratorCompletionRequest.java
@@ -1,0 +1,7 @@
+package com.marketinghub.oprm.nichocnae.v2.candidategenerator.service.completeStageExecution;
+
+/** Contrato recebido do executor ao concluir a etapa candidate-generator do NichoCNAE v2. */
+public record CandidateGeneratorCompletionRequest(
+        String qualityStatus,
+        String requestedAction,
+        String outputPayload) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/candidategenerator/service/completeStageExecution/CandidateGeneratorCompletionResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/candidategenerator/service/completeStageExecution/CandidateGeneratorCompletionResponse.java
@@ -1,0 +1,8 @@
+package com.marketinghub.oprm.nichocnae.v2.candidategenerator.service.completeStageExecution;
+
+/** Contrato retornado ao executor após registrar a conclusão da etapa candidate-generator do NichoCNAE v2. */
+public record CandidateGeneratorCompletionResponse(
+        String stageExecutionId,
+        String status,
+        String nextStageCode,
+        Boolean materializationEnabled) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/candidategenerator/service/failStageExecution/CandidateGeneratorFailureRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/candidategenerator/service/failStageExecution/CandidateGeneratorFailureRequest.java
@@ -1,0 +1,10 @@
+package com.marketinghub.oprm.nichocnae.v2.candidategenerator.service.failStageExecution;
+
+import com.marketinghub.oprm.nichocnae.v2.OprmNichoCnaeV2FailureType;
+
+/** Contrato recebido do executor ao reportar falha da etapa candidate-generator do NichoCNAE v2. */
+public record CandidateGeneratorFailureRequest(
+        OprmNichoCnaeV2FailureType failureType,
+        String reasonCode,
+        String errorMessage,
+        String inputPayload) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/candidategenerator/service/failStageExecution/CandidateGeneratorFailureResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/candidategenerator/service/failStageExecution/CandidateGeneratorFailureResponse.java
@@ -1,0 +1,9 @@
+package com.marketinghub.oprm.nichocnae.v2.candidategenerator.service.failStageExecution;
+
+/** Contrato retornado ao executor após registrar falha e possível retry técnico do NichoCNAE v2. */
+public record CandidateGeneratorFailureResponse(
+        String stageExecutionId,
+        String status,
+        String retryStageExecutionId,
+        Integer attemptNumber,
+        Integer technicalRetryNumber) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/candidategenerator/service/pending/CandidateGeneratorPendingResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/candidategenerator/service/pending/CandidateGeneratorPendingResponse.java
@@ -1,4 +1,12 @@
 package com.marketinghub.oprm.nichocnae.v2.candidategenerator.service.pending;
 
 /** Contrato de fila interna entregue ao executor para processar a etapa candidate-generator do NichoCNAE v2. */
-public record CandidateGeneratorPendingResponse(String stageExecutionId, String jobId, String cnaeCode) {}
+public record CandidateGeneratorPendingResponse(
+        String stageExecutionId,
+        String jobId,
+        String cnaeCode,
+        Long sourceNicheId,
+        Integer attemptNumber,
+        Integer technicalRetryNumber,
+        Integer knowledgeVersion,
+        Boolean materializationEnabled) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/oprm/nichocnae/v2/OprmNichoCnaeV2StageExecutionRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/oprm/nichocnae/v2/OprmNichoCnaeV2StageExecutionRepository.java
@@ -1,0 +1,21 @@
+package com.marketinghub.repository.jpa.oprm.nichocnae.v2;
+
+import com.marketinghub.oprm.nichocnae.v2.OprmNichoCnaeV2StageExecution;
+import com.marketinghub.oprm.nichocnae.v2.OprmNichoCnaeV2StageExecutionStatus;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/** Repositório responsável por persistir execuções de etapa versionadas do NichoCNAE v2. */
+public interface OprmNichoCnaeV2StageExecutionRepository extends JpaRepository<OprmNichoCnaeV2StageExecution, Long> {
+    /** Lista execuções pendentes por etapa em ordem operacional estável. */
+    List<OprmNichoCnaeV2StageExecution> findByStageCodeAndStatusOrderByCreatedAtAsc(
+            String stageCode, OprmNichoCnaeV2StageExecutionStatus status, Pageable pageable);
+
+    /** Verifica se o candidato já possui execução registrada para a etapa. */
+    boolean existsBySourceNicheIdAndStageCode(Long sourceNicheId, String stageCode);
+
+    /** Localiza uma execução específica por etapa para callbacks internos do executor. */
+    Optional<OprmNichoCnaeV2StageExecution> findByIdAndStageCode(Long id, String stageCode);
+}

--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-19-oprm-nichocnae-v2-stage-execution.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-19-oprm-nichocnae-v2-stage-execution.yaml
@@ -1,0 +1,121 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-06-19-01-oprm-nichocnae-v2-stage-execution
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - onError: HALT
+        - dbms:
+            type: mysql
+        - not:
+            tableExists:
+              tableName: oprm_nichocnae_v2_stage_execution
+      changes:
+        - createTable:
+            tableName: oprm_nichocnae_v2_stage_execution
+            remarks: Execuções imutáveis de etapa do pipeline OPRM NichoCNAE v2 com separação entre tentativa cognitiva e retry técnico.
+            columns:
+              - column:
+                  name: id
+                  type: BIGINT
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    primaryKeyName: pk_oprm_nichocnae_v2_stage_execution
+                    nullable: false
+              - column:
+                  name: job_id
+                  type: VARCHAR(96)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: research_cycle_id
+                  type: BIGINT
+              - column:
+                  name: source_niche_id
+                  type: BIGINT
+                  constraints:
+                    nullable: false
+              - column:
+                  name: cnae_code
+                  type: VARCHAR(7)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: stage_code
+                  type: VARCHAR(64)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: attempt_number
+                  type: INT
+                  constraints:
+                    nullable: false
+              - column:
+                  name: technical_retry_number
+                  type: INT
+                  constraints:
+                    nullable: false
+              - column:
+                  name: knowledge_version
+                  type: INT
+                  constraints:
+                    nullable: false
+              - column:
+                  name: status
+                  type: VARCHAR(40)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: failure_type
+                  type: VARCHAR(32)
+              - column:
+                  name: input_payload
+                  type: LONGTEXT
+              - column:
+                  name: output_payload
+                  type: LONGTEXT
+              - column:
+                  name: error_message
+                  type: LONGTEXT
+              - column:
+                  name: next_stage_code
+                  type: VARCHAR(64)
+              - column:
+                  name: materialization_enabled
+                  type: TINYINT(1)
+                  defaultValueNumeric: 0
+                  constraints:
+                    nullable: false
+              - column:
+                  name: created_at
+                  type: DATETIME(6)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: updated_at
+                  type: DATETIME(6)
+                  constraints:
+                    nullable: false
+        - createIndex:
+            tableName: oprm_nichocnae_v2_stage_execution
+            indexName: idx_oprm_nichocnae_v2_stage_pending
+            columns:
+              - column:
+                  name: stage_code
+              - column:
+                  name: status
+              - column:
+                  name: created_at
+        - createIndex:
+            tableName: oprm_nichocnae_v2_stage_execution
+            indexName: idx_oprm_nichocnae_v2_stage_source
+            columns:
+              - column:
+                  name: source_niche_id
+              - column:
+                  name: stage_code
+              - column:
+                  name: attempt_number
+              - column:
+                  name: technical_retry_number

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -1,5 +1,8 @@
 databaseChangeLog:
   - include:
+      file: changesets/2026-06-19-oprm-nichocnae-v2-stage-execution.yaml
+      relativeToChangelogFile: true
+  - include:
       file: changesets/2026-06-18-experiment-creative-generation-status.yaml
       relativeToChangelogFile: true
   - include:

--- a/backend/ads-service/src/test/java/com/marketinghub/architecture/ArquiteturaTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/architecture/ArquiteturaTest.java
@@ -102,6 +102,8 @@ class ArquiteturaTest {
     private static final Pattern OPRM_NICHO_CNAE_STAGE_SERVICE_PACKAGE_PATTERN = Pattern.compile(
             "^com\\.marketinghub\\.oprm\\.nichocnae\\.([a-zA-Z0-9_]+)\\.service$");
     private static final String OPRM_NICHO_CNAE_STAGE_PACKAGE_PREFIX = "com.marketinghub.oprm.nichocnae.";
+    private static final String OPRM_NICHO_CNAE_V2_PACKAGE = "com.marketinghub.oprm.nichocnae.v2";
+    private static final String OPRM_NICHO_CNAE_V2_EXECUTOR_MODULE = "oprm-coletor-mei";
     private static final String OPRM_CNAE_PACKAGE = "com.marketinghub.oprm.cnae";
     private static final String OPRM_CNAE_WEB_PACKAGE = OPRM_CNAE_PACKAGE + ".web";
     private static final String OPRM_CNAE_SERVICE_PACKAGE = OPRM_CNAE_PACKAGE + ".service";
@@ -153,6 +155,15 @@ class ArquiteturaTest {
             .resideInAPackage("com.marketinghub.oprm..")
             .should(onlyDependOnAllowedOprmMarketingHubClasses())
             .because("[ARQUITETURA][OPRM] o módulo OPRM não deve depender de outros pacotes internos do sistema");
+
+    @ArchTest
+    static final ArchRule oprmNichoCnaeV2BackendMustRemainReadWriteOnly = classes()
+            .that()
+            .resideInAPackage(OPRM_NICHO_CNAE_V2_PACKAGE + "..")
+            .should(notAssumeOperationalExecutionResponsibilityForOprmNichoCnaeV2())
+            .because("[ARQUITETURA] [BACKEND][OPRM NichoCNAE v2] o backend v2 deve ficar restrito a leitura, escrita, "
+                    + "contratos, persistência, pendências e callbacks; o controle operacional de execução pertence ao módulo "
+                    + OPRM_NICHO_CNAE_V2_EXECUTOR_MODULE);
 
     @ArchTest
     static final ArchRule epmMustNotDependOnOtherMarketingHubPackages = noClasses()
@@ -1634,6 +1645,70 @@ class ArquiteturaTest {
         String targetStage = extractFacebookAdsStage(targetClass.getPackageName());
         String targetLayer = extractFacebookAdsStageLayer(targetClass.getPackageName());
         return sourceStage != null && sourceStage.equals(targetStage) && "service".equals(targetLayer);
+    }
+
+    /**
+     * Bloqueia responsabilidades operacionais de execução no backend OPRM NichoCNAE v2.
+     */
+    private static ArchCondition<JavaClass> notAssumeOperationalExecutionResponsibilityForOprmNichoCnaeV2() {
+        return new ArchCondition<>(
+                "[ARQUITETURA] [BACKEND][OPRM NichoCNAE v2] não assume execução operacional externa") {
+            @Override
+            public void check(JavaClass item, ConditionEvents events) {
+                if (hasForbiddenOprmNichoCnaeV2ExecutionName(item)) {
+                    String message = "[ARQUITETURA] [BACKEND][OPRM NichoCNAE v2] classe=" + item.getName()
+                            + " tem nome de worker/runner/processor/núcleo operacional. "
+                            + "O backend deve apenas ler, gravar, publicar pendências e receber callbacks; "
+                            + "a execução operacional fica no módulo " + OPRM_NICHO_CNAE_V2_EXECUTOR_MODULE + ".";
+                    events.add(SimpleConditionEvent.violated(item, message));
+                }
+                item.getDirectDependenciesFromSelf().forEach(dependency -> {
+                    JavaClass targetClass = dependency.getTargetClass();
+                    if (!isForbiddenOprmNichoCnaeV2ExecutionDependency(targetClass)) {
+                        return;
+                    }
+                    String message = "[ARQUITETURA] [BACKEND][OPRM NichoCNAE v2] classe=" + item.getName()
+                            + " depende de responsabilidade operacional bloqueada: " + dependency.getDescription()
+                            + " (alvo=" + targetClass.getName() + "). "
+                            + "Tecnologias externas, @Scheduled, polling, workers e núcleos Stage* devem ficar no módulo "
+                            + OPRM_NICHO_CNAE_V2_EXECUTOR_MODULE + "; o backend v2 permanece leitura/escrita.";
+                    events.add(SimpleConditionEvent.violated(item, message));
+                });
+            }
+        };
+    }
+
+    /**
+     * Identifica nomes de classes que indicam execução operacional em vez de contrato/persistência backend.
+     */
+    private static boolean hasForbiddenOprmNichoCnaeV2ExecutionName(JavaClass javaClass) {
+        String simpleName = javaClass.getSimpleName();
+        return simpleName.equals("PipelineWorker")
+                || simpleName.equals("StageProcessor")
+                || simpleName.equals("StageContext")
+                || simpleName.equals("StageResult")
+                || simpleName.equals("StageArtifact")
+                || simpleName.endsWith("Worker")
+                || simpleName.endsWith("Runner")
+                || simpleName.endsWith("Poller")
+                || simpleName.endsWith("Scheduler");
+    }
+
+    /**
+     * Identifica dependências que deslocariam execução operacional do executor para o backend.
+     */
+    private static boolean isForbiddenOprmNichoCnaeV2ExecutionDependency(JavaClass targetClass) {
+        String targetName = targetClass.getName();
+        String targetPackage = targetClass.getPackageName();
+        return targetName.equals("org.springframework.scheduling.annotation.Scheduled")
+                || targetName.equals("org.springframework.web.reactive.function.client.WebClient")
+                || targetPackage.startsWith("com.openai")
+                || targetPackage.startsWith("com.theokanning.openai")
+                || targetPackage.startsWith("org.jsoup")
+                || targetPackage.startsWith("com.microsoft.playwright")
+                || targetPackage.startsWith("org.openqa.selenium")
+                || targetPackage.startsWith("software.amazon.awssdk.services.s3")
+                || targetPackage.startsWith("com.amazonaws.services.s3");
     }
 
     /**

--- a/backend/ads-service/src/test/java/com/marketinghub/oprm/nichocnae/routineresearchorchestrator/service/BackendRoutineResearchOrchestratorServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/oprm/nichocnae/routineresearchorchestrator/service/BackendRoutineResearchOrchestratorServiceTest.java
@@ -7,8 +7,10 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.marketinghub.oprm.cnae.OprmNicheCandidate;
+import com.marketinghub.oprm.nichocnae.OprmExtractedSignal;
 import com.marketinghub.oprm.nichocnae.OprmNicheRoutineCard;
 import com.marketinghub.oprm.nichocnae.OprmRoutineResearchCycle;
+import com.marketinghub.oprm.nichocnae.OprmSourceSnapshot;
 import com.marketinghub.oprm.nichocnae.routineresearchorchestrator.service.pending.RecordRoutineResearchOrchestratorPending;
 import com.marketinghub.oprm.nichocnae.routineresearchorchestrator.service.recent.RecordRoutineResearchOrchestratorRecent;
 import com.marketinghub.oprm.nichocnae.routineresearchorchestrator.service.reprocess.RecordRoutineResearchOrchestratorReprocessRequest;
@@ -260,6 +262,53 @@ class BackendRoutineResearchOrchestratorServiceTest {
         assertThat(learningCycle.getErrorMessage()).contains("O próximo seed deve usar o aprendizado do gate anterior");
         assertThat(learningCycle.getErrorMessage()).contains("previousQualityStatus=SOLUTION_CONTAMINATED");
         assertThat(learningCycle.getErrorMessage()).contains("riscoLinguagemSolucao=70");
+    }
+
+    /** Deve preservar fontes e claims aceitos no ciclo 72 e voltar ao query planner quando faltar evidência de rotina. */
+    @Test
+    void reprocessCycle72PreservesAcceptedKnowledgeAndRewindsToQueryPlanner() {
+        OprmRoutineResearchCycle weakCycle = cycle(72L, 55L, "Escovista em domicílio", "2026-06-03T01:00:00Z");
+        weakCycle.setStatus("NEEDS_EXECUTOR_ROUTINE_EVIDENCE");
+        OprmNicheCandidate candidate = candidate();
+        OprmNicheRoutineCard previousCard = new OprmNicheRoutineCard();
+        previousCard.setQualityStatus("NEEDS_EXECUTOR_ROUTINE_EVIDENCE");
+        previousCard.setQualityNotes("faltou evidência literal da rotina do executor MEI");
+        when(routineResearchCycleRepository.findById(72L)).thenReturn(Optional.of(weakCycle));
+        when(nicheCandidateRepository.findById(55L)).thenReturn(Optional.of(candidate));
+        when(routineCardRepository.findFirstByResearchCycleIdOrderByIdDesc(72L)).thenReturn(Optional.of(previousCard));
+        when(sourceSnapshotRepository.findByResearchCycleIdOrderByIdAsc(72L))
+                .thenReturn(List.of(sourceSnapshot(701L), sourceSnapshot(702L)));
+        when(extractedSignalRepository.findByResearchCycleIdOrderByIdAsc(72L))
+                .thenReturn(List.of(
+                        signal(801L, 701L, "ROUTINE_PAIN", "agenda lotada em casa"),
+                        signal(802L, 702L, "SEMANTIC_CONTEXT_MISMATCH", "salão estruturado com equipe")));
+        when(routineResearchCycleRepository.save(any(OprmRoutineResearchCycle.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+        when(nicheCandidateRepository.save(any(OprmNicheCandidate.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+
+        var result = service.reprocessCycle(72L, new RecordRoutineResearchOrchestratorReprocessRequest("AUTO_QUALITY_REPROCESS"));
+
+        assertThat(result.researchCycleId()).isEqualTo(72L);
+        assertThat(result.previousCycleStatus()).isEqualTo("NEEDS_EXECUTOR_ROUTINE_EVIDENCE");
+        ArgumentCaptor<OprmRoutineResearchCycle> cycleCaptor =
+                ArgumentCaptor.forClass(OprmRoutineResearchCycle.class);
+        verify(routineResearchCycleRepository).save(cycleCaptor.capture());
+        OprmRoutineResearchCycle reopenedCycle = cycleCaptor.getValue();
+        assertThat(reopenedCycle.getStatus()).isEqualTo("RUNNING");
+        assertThat(reopenedCycle.getCurrentStageCode()).isEqualTo("niche-research-seed-builder");
+        assertThat(reopenedCycle.getErrorMessage()).contains("knowledgeVersion=cycle-72-snap-702-sig-802");
+        assertThat(reopenedCycle.getErrorMessage()).contains("rewindStage=niche-research-seed-builder");
+        assertThat(reopenedCycle.getErrorMessage()).contains("preserveAcceptedEvidence=true");
+        assertThat(reopenedCycle.getErrorMessage()).contains("evidenceGaps=[EXECUTOR_ROUTINE, PUBLIC_EVIDENCE]");
+        assertThat(reopenedCycle.getErrorMessage()).contains("preservedSourceSnapshotIds=[701]");
+        assertThat(reopenedCycle.getErrorMessage()).contains("preservedSignalIds=[801]");
+        assertThat(reopenedCycle.getErrorMessage()).contains("rejectedSourceSnapshotIds=[702]");
+        verify(sourceSnapshotRepository, never()).deleteByResearchCycleId(72L);
+        verify(extractedSignalRepository, never()).deleteByResearchCycleId(72L);
+        verify(sourceCandidateRepository).deleteByResearchCycleId(72L);
+        verify(researchQueryRepository).deleteByResearchCycleId(72L);
+        verify(seedRepository).deleteByResearchCycleId(72L);
     }
 
     /** Deve reabrir o mesmo job ao reprocessar um ciclo parado sem progresso. */
@@ -548,6 +597,46 @@ class BackendRoutineResearchOrchestratorServiceTest {
         cycle.setCreatedAt(Instant.parse(startedAt));
         cycle.setUpdatedAt(Instant.parse(startedAt));
         return cycle;
+    }
+
+
+    /** Monta um snapshot de fonte usado para simular o snapshot de conhecimento preservável. */
+    private OprmSourceSnapshot sourceSnapshot(Long id) {
+        OprmSourceSnapshot snapshot = new OprmSourceSnapshot();
+        snapshot.setId(id);
+        snapshot.setResearchCycleId(72L);
+        snapshot.setSourceCandidateId(id + 1000);
+        snapshot.setSourceUrl("https://example.com/" + id);
+        snapshot.setSourceDomain("example.com");
+        snapshot.setSourceTitle("Fonte " + id);
+        snapshot.setSourceType("FORUM");
+        snapshot.setCommercialPageRisk(false);
+        snapshot.setSolutionLanguageRisk(false);
+        snapshot.setOutdatedSourceRisk(false);
+        snapshot.setStructuredBusinessDriftRisk(false);
+        snapshot.setFetchedAt(Instant.parse("2026-06-03T01:20:00Z"));
+        snapshot.setFetchStatus("FETCHED");
+        snapshot.setStoragePolicy("SNIPPET_ONLY");
+        snapshot.setSignalExtractionStatus("EXTRACTED");
+        snapshot.setCreatedAt(Instant.parse("2026-06-03T01:20:00Z"));
+        return snapshot;
+    }
+
+    /** Monta um sinal extraído usado para classificar claims aceitos ou rejeitados no reprocessamento. */
+    private OprmExtractedSignal signal(Long id, Long sourceSnapshotId, String signalType, String evidenceExcerpt) {
+        OprmExtractedSignal signal = new OprmExtractedSignal();
+        signal.setId(id);
+        signal.setResearchCycleId(72L);
+        signal.setSourceSnapshotId(sourceSnapshotId);
+        signal.setSourceCandidateId(sourceSnapshotId + 1000);
+        signal.setSignalType(signalType);
+        signal.setSignalText("Sinal " + id);
+        signal.setEvidenceExcerpt(evidenceExcerpt);
+        signal.setSourceDomain("example.com");
+        signal.setConfidenceScore(90);
+        signal.setCreatedBy("unit-test");
+        signal.setCreatedAt(Instant.parse("2026-06-03T01:30:00Z"));
+        return signal;
     }
 
     /** Monta um candidato de nicho CNAE com score para a etapa zero do pipeline. */

--- a/backend/ads-service/src/test/java/com/marketinghub/oprm/nichocnae/signalextractor/service/BackendSignalExtractorServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/oprm/nichocnae/signalextractor/service/BackendSignalExtractorServiceTest.java
@@ -96,6 +96,89 @@ class BackendSignalExtractorServiceTest {
     verify(extractedSignalRepository, never()).save(any(OprmExtractedSignal.class));
   }
 
+
+
+  /** Ciclo 70: deve rejeitar sinal positivo cujo trecho pertence a ator ou contexto adjacente. */
+  @Test
+  void completeRejectsPositiveSignalFromAdjacentActorEvidenceForCycle70() {
+    OprmSourceSnapshot snapshot = snapshot();
+    snapshot.setShortExcerpt("Companhia aérea cancelou o voo e passageiros pediram reembolso.");
+    when(sourceSnapshotRepository.findById(901L)).thenReturn(Optional.of(snapshot));
+    when(routineResearchCycleRepository.findById(1001L)).thenReturn(Optional.of(cycle()));
+    when(extractedSignalRepository.existsBySourceSnapshotId(901L)).thenReturn(false);
+    CompleteSignalExtractorRequest request = new CompleteSignalExtractorRequest(
+        1001L,
+        301L,
+        "exemplo.com",
+        "COMPLETED",
+        "test",
+        List.of(new SignalExtractionItemRequest(
+            "OPERATIONAL_PAIN",
+            "Cancelamento usado como dor operacional do executor",
+            "Companhia aérea cancelou o voo e passageiros pediram reembolso.",
+            80)));
+
+    assertThatThrownBy(() -> service.complete(901L, request))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("signal actor/context does not match the target executor");
+    verify(extractedSignalRepository, never()).save(any(OprmExtractedSignal.class));
+  }
+
+  /** Ciclo 72: deve rejeitar evidência que não existe literalmente no snapshot persistido. */
+  @Test
+  void completeRejectsEvidenceExcerptThatIsNotExactSpanForCycle72() {
+    when(sourceSnapshotRepository.findById(901L)).thenReturn(Optional.of(snapshot()));
+    when(routineResearchCycleRepository.findById(1001L)).thenReturn(Optional.of(cycle()));
+    when(extractedSignalRepository.existsBySourceSnapshotId(901L)).thenReturn(false);
+    CompleteSignalExtractorRequest request = new CompleteSignalExtractorRequest(
+        1001L,
+        301L,
+        "exemplo.com",
+        "COMPLETED",
+        "test",
+        List.of(new SignalExtractionItemRequest(
+            "ROUTINE_TASK",
+            "Confirmar agenda pelo WhatsApp",
+            "Resumo criado pela IA que não está no snapshot literal",
+            88)));
+
+    assertThatThrownBy(() -> service.complete(901L, request))
+        .isInstanceOf(IllegalArgumentException.class)
+        .hasMessageContaining("evidenceExcerpt must be an exact span");
+    verify(extractedSignalRepository, never()).save(any(OprmExtractedSignal.class));
+  }
+
+  /** Ciclo 75: deve permitir diagnóstico de contexto incompatível sem tratá-lo como sinal positivo. */
+  @Test
+  void completeAllowsSemanticContextMismatchDiagnosticForCycle75() {
+    OprmSourceSnapshot snapshot = snapshot();
+    snapshot.setShortExcerpt("Personal shopper ajuda consumidoras a escolher roupas em lojas.");
+    OprmRoutineResearchCycle cycle = cycle();
+    when(sourceSnapshotRepository.findById(901L)).thenReturn(Optional.of(snapshot));
+    when(routineResearchCycleRepository.findById(1001L)).thenReturn(Optional.of(cycle));
+    when(extractedSignalRepository.existsBySourceSnapshotId(901L)).thenReturn(false);
+    when(extractedSignalRepository.save(any(OprmExtractedSignal.class))).thenAnswer(invocation -> invocation.getArgument(0));
+    when(extractedSignalRepository.findByResearchCycleIdOrderByIdAsc(1001L)).thenReturn(List.of());
+    CompleteSignalExtractorRequest request = new CompleteSignalExtractorRequest(
+        1001L,
+        301L,
+        "exemplo.com",
+        "COMPLETED",
+        "test",
+        List.of(new SignalExtractionItemRequest(
+            "SEMANTIC_CONTEXT_MISMATCH",
+            "Fonte pertence a ator ou ocupação adjacente",
+            "Personal shopper ajuda consumidoras a escolher roupas em lojas.",
+            95)));
+
+    CompleteSignalExtractorResponse response = service.complete(901L, request);
+
+    assertThat(response.extractedSignalCount()).isEqualTo(1);
+    ArgumentCaptor<OprmExtractedSignal> signalCaptor = ArgumentCaptor.forClass(OprmExtractedSignal.class);
+    verify(extractedSignalRepository).save(signalCaptor.capture());
+    assertThat(signalCaptor.getValue().getSignalType()).isEqualTo("SEMANTIC_CONTEXT_MISMATCH");
+  }
+
   /** Cria um snapshot curto coletado para os testes da etapa cinco. */
   private OprmSourceSnapshot snapshot() {
     OprmSourceSnapshot snapshot = new OprmSourceSnapshot();

--- a/backend/ads-service/src/test/java/com/marketinghub/oprm/nichocnae/v2/candidategenerator/service/BackendCandidateGeneratorServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/oprm/nichocnae/v2/candidategenerator/service/BackendCandidateGeneratorServiceTest.java
@@ -1,0 +1,219 @@
+package com.marketinghub.oprm.nichocnae.v2.candidategenerator.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.marketinghub.oprm.cnae.OprmNicheCandidate;
+import com.marketinghub.oprm.nichocnae.v2.OprmNichoCnaeV2FailureType;
+import com.marketinghub.oprm.nichocnae.v2.OprmNichoCnaeV2StageExecution;
+import com.marketinghub.oprm.nichocnae.v2.OprmNichoCnaeV2StageExecutionStatus;
+import com.marketinghub.oprm.nichocnae.v2.candidategenerator.service.completeStageExecution.CandidateGeneratorCompletionRequest;
+import com.marketinghub.oprm.nichocnae.v2.candidategenerator.service.completeStageExecution.CandidateGeneratorCompletionResponse;
+import com.marketinghub.oprm.nichocnae.v2.candidategenerator.service.failStageExecution.CandidateGeneratorFailureRequest;
+import com.marketinghub.oprm.nichocnae.v2.candidategenerator.service.failStageExecution.CandidateGeneratorFailureResponse;
+import com.marketinghub.oprm.nichocnae.v2.candidategenerator.service.pending.CandidateGeneratorPendingResponse;
+import com.marketinghub.repository.jpa.oprm.cnae.OprmNicheCandidateRepository;
+import com.marketinghub.repository.jpa.oprm.nichocnae.v2.OprmNichoCnaeV2StageExecutionRepository;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Pageable;
+
+/** Valida o primeiro incremento backend da etapa candidate-generator do pipeline OPRM NichoCNAE v2. */
+@ExtendWith(MockitoExtension.class)
+class BackendCandidateGeneratorServiceTest {
+    @Mock private OprmNicheCandidateRepository nicheCandidateRepository;
+
+    @Mock private OprmNichoCnaeV2StageExecutionRepository stageExecutionRepository;
+
+    /** Deve manter a v2 sem pendências quando a feature flag estiver desligada durante calibração. */
+    @Test
+    void pendingReturnsEmptyWhenFeatureFlagIsDisabled() {
+        BackendCandidateGeneratorService service = service(false, false);
+
+        List<CandidateGeneratorPendingResponse> result = service.pending();
+
+        assertThat(result).isEmpty();
+        verify(nicheCandidateRepository, never()).findNextPendingRoutineResearchCandidatePreview(any(Pageable.class));
+    }
+
+    /** Ciclo 69: deve criar execução inicial sem liberar materialização automática na calibração. */
+    @Test
+    void pendingCreatesInitialImmutableExecutionForCycle69WithoutAutomaticMaterialization() {
+        BackendCandidateGeneratorService service = service(true, false);
+        OprmNicheCandidate candidate = candidate(69L, "9602501");
+        List<OprmNichoCnaeV2StageExecution> stored = new ArrayList<>();
+        when(stageExecutionRepository.findByStageCodeAndStatusOrderByCreatedAtAsc(
+                        eq("candidate-generator"), eq(OprmNichoCnaeV2StageExecutionStatus.PENDING), any(Pageable.class)))
+                .thenAnswer(invocation -> stored.stream()
+                        .filter(execution -> execution.getStatus() == OprmNichoCnaeV2StageExecutionStatus.PENDING)
+                        .toList());
+        when(nicheCandidateRepository.findNextPendingRoutineResearchCandidatePreview(any(Pageable.class)))
+                .thenReturn(List.of(candidate));
+        when(stageExecutionRepository.existsBySourceNicheIdAndStageCode(69L, "candidate-generator"))
+                .thenReturn(false);
+        when(stageExecutionRepository.save(any(OprmNichoCnaeV2StageExecution.class))).thenAnswer(invocation -> {
+            OprmNichoCnaeV2StageExecution execution = invocation.getArgument(0);
+            execution.setId(1001L);
+            stored.add(execution);
+            return execution;
+        });
+
+        List<CandidateGeneratorPendingResponse> result = service.pending();
+
+        assertThat(result).hasSize(1);
+        assertThat(result.getFirst().stageExecutionId()).isEqualTo("1001");
+        assertThat(result.getFirst().jobId()).isEqualTo("nichocnae-v2-candidate-69");
+        assertThat(result.getFirst().cnaeCode()).isEqualTo("9602501");
+        assertThat(result.getFirst().attemptNumber()).isEqualTo(1);
+        assertThat(result.getFirst().technicalRetryNumber()).isZero();
+        assertThat(result.getFirst().knowledgeVersion()).isEqualTo(1);
+        assertThat(result.getFirst().materializationEnabled()).isFalse();
+    }
+
+    /** Ciclo 74: deve transformar falha de infraestrutura em retry técnico sem nova tentativa cognitiva. */
+    @Test
+    void failCreatesTechnicalRetryForInfrastructureFailureInCycle74() {
+        BackendCandidateGeneratorService service = service(true, false);
+        OprmNichoCnaeV2StageExecution execution = execution(74L, 1, 0, 3);
+        when(stageExecutionRepository.findByIdAndStageCode(74L, "candidate-generator"))
+                .thenReturn(Optional.of(execution));
+        when(stageExecutionRepository.save(any(OprmNichoCnaeV2StageExecution.class))).thenAnswer(invocation -> {
+            OprmNichoCnaeV2StageExecution saved = invocation.getArgument(0);
+            if (saved.getId() == null) {
+                saved.setId(75L);
+            }
+            return saved;
+        });
+
+        CandidateGeneratorFailureResponse result = service.fail(
+                74L,
+                new CandidateGeneratorFailureRequest(
+                        OprmNichoCnaeV2FailureType.INFRASTRUCTURE,
+                        "OPENAI_BROKEN_PIPE",
+                        "broken pipe",
+                        "{\"cycle\":74}"));
+
+        assertThat(result.stageExecutionId()).isEqualTo("74");
+        assertThat(result.status()).isEqualTo("TECHNICAL_RETRY_SCHEDULED");
+        assertThat(result.retryStageExecutionId()).isEqualTo("75");
+        assertThat(result.attemptNumber()).isEqualTo(1);
+        assertThat(result.technicalRetryNumber()).isEqualTo(1);
+        assertThat(execution.getFailureType()).isEqualTo(OprmNichoCnaeV2FailureType.INFRASTRUCTURE);
+        ArgumentCaptor<OprmNichoCnaeV2StageExecution> executionCaptor =
+                ArgumentCaptor.forClass(OprmNichoCnaeV2StageExecution.class);
+        verify(stageExecutionRepository, org.mockito.Mockito.times(2)).save(executionCaptor.capture());
+        OprmNichoCnaeV2StageExecution retry = executionCaptor.getAllValues().get(1);
+        assertThat(retry.getAttemptNumber()).isEqualTo(1);
+        assertThat(retry.getTechnicalRetryNumber()).isEqualTo(1);
+        assertThat(retry.getKnowledgeVersion()).isEqualTo(3);
+        assertThat(retry.getStatus()).isEqualTo(OprmNichoCnaeV2StageExecutionStatus.PENDING);
+    }
+
+    /** Deve classificar falha de qualidade sem agendar retry técnico automático. */
+    @Test
+    void failDoesNotRetryQualityFailure() {
+        BackendCandidateGeneratorService service = service(true, false);
+        OprmNichoCnaeV2StageExecution execution = execution(80L, 2, 0, 4);
+        when(stageExecutionRepository.findByIdAndStageCode(80L, "candidate-generator"))
+                .thenReturn(Optional.of(execution));
+        when(stageExecutionRepository.save(any(OprmNichoCnaeV2StageExecution.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        CandidateGeneratorFailureResponse result = service.fail(
+                80L,
+                new CandidateGeneratorFailureRequest(
+                        OprmNichoCnaeV2FailureType.QUALITY,
+                        "ROUTINE_TOO_GENERIC",
+                        "síntese genérica",
+                        null));
+
+        assertThat(result.status()).isEqualTo("FAILED");
+        assertThat(result.retryStageExecutionId()).isNull();
+        assertThat(execution.getFailureType()).isEqualTo(OprmNichoCnaeV2FailureType.QUALITY);
+        assertThat(execution.getStatus()).isEqualTo(OprmNichoCnaeV2StageExecutionStatus.FAILED);
+    }
+
+    /** Deve bloquear a transição de materialização automática enquanto a feature flag da v2 estiver desligada. */
+    @Test
+    void completeBlocksMeiAudienceReadyMaterializationWhenCalibrationFlagIsDisabled() {
+        BackendCandidateGeneratorService service = service(true, false);
+        OprmNichoCnaeV2StageExecution execution = execution(90L, 1, 0, 1);
+        when(stageExecutionRepository.findByIdAndStageCode(90L, "candidate-generator"))
+                .thenReturn(Optional.of(execution));
+        when(stageExecutionRepository.save(any(OprmNichoCnaeV2StageExecution.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        CandidateGeneratorCompletionResponse result = service.complete(
+                90L, new CandidateGeneratorCompletionRequest("MEI_AUDIENCE_READY", "MATERIALIZAR_NICHO", "{}"));
+
+        assertThat(result.status()).isEqualTo("COMPLETED");
+        assertThat(result.nextStageCode()).isNull();
+        assertThat(result.materializationEnabled()).isFalse();
+    }
+
+    /** Deve resolver MEI_AUDIENCE_READY + MATERIALIZAR_NICHO para o materializer quando a calibração liberar. */
+    @Test
+    void completeRoutesMeiAudienceReadyMaterializationWhenFlagIsEnabled() {
+        BackendCandidateGeneratorService service = service(true, true);
+        OprmNichoCnaeV2StageExecution execution = execution(91L, 1, 0, 1);
+        execution.setMaterializationEnabled(true);
+        when(stageExecutionRepository.findByIdAndStageCode(91L, "candidate-generator"))
+                .thenReturn(Optional.of(execution));
+        when(stageExecutionRepository.save(any(OprmNichoCnaeV2StageExecution.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        CandidateGeneratorCompletionResponse result = service.complete(
+                91L, new CandidateGeneratorCompletionRequest("MEI_AUDIENCE_READY", "MATERIALIZAR_NICHO", "{}"));
+
+        assertThat(result.status()).isEqualTo("COMPLETED");
+        assertThat(result.nextStageCode()).isEqualTo("enriched-niche-materializer");
+        assertThat(result.materializationEnabled()).isTrue();
+    }
+
+    /** Cria o service testável com flags explícitas para a v2. */
+    private BackendCandidateGeneratorService service(boolean v2Enabled, boolean materializationEnabled) {
+        return new BackendCandidateGeneratorService(
+                nicheCandidateRepository, stageExecutionRepository, v2Enabled, materializationEnabled);
+    }
+
+    /** Monta candidato de nicho mínimo para geração de pendência da v2. */
+    private OprmNicheCandidate candidate(Long id, String cnaeCode) {
+        OprmNicheCandidate candidate = new OprmNicheCandidate();
+        candidate.setId(id);
+        candidate.setCnaeCode(cnaeCode);
+        candidate.setCnaeDescription("Serviços de beleza");
+        candidate.setCandidateNicheName("Manicure autônoma");
+        candidate.setOpportunityScore(new BigDecimal("92.50"));
+        candidate.setRoutineResearchStatus("PENDING");
+        candidate.setCreatedAt(Instant.parse("2026-06-19T10:00:00Z"));
+        candidate.setUpdatedAt(Instant.parse("2026-06-19T10:00:00Z"));
+        return candidate;
+    }
+
+    /** Monta execução persistida mínima para callbacks de conclusão e falha. */
+    private OprmNichoCnaeV2StageExecution execution(Long id, int attemptNumber, int technicalRetryNumber, int knowledgeVersion) {
+        OprmNichoCnaeV2StageExecution execution = new OprmNichoCnaeV2StageExecution();
+        execution.setId(id);
+        execution.setJobId("nichocnae-v2-candidate-" + id);
+        execution.setSourceNicheId(id);
+        execution.setCnaeCode("9602501");
+        execution.setStageCode("candidate-generator");
+        execution.setAttemptNumber(attemptNumber);
+        execution.setTechnicalRetryNumber(technicalRetryNumber);
+        execution.setKnowledgeVersion(knowledgeVersion);
+        execution.setStatus(OprmNichoCnaeV2StageExecutionStatus.PENDING);
+        execution.setMaterializationEnabled(false);
+        execution.setCreatedAt(Instant.parse("2026-06-19T10:00:00Z"));
+        execution.setUpdatedAt(Instant.parse("2026-06-19T10:00:00Z"));
+        return execution;
+    }
+}

--- a/docs/registro-protocolo/leitura-escrita.md
+++ b/docs/registro-protocolo/leitura-escrita.md
@@ -1,0 +1,6 @@
+# Registro do protocolo leitura escrita
+
+## 2026-06-19 — OPRM NichoCNAE v2
+- Pacote backend protegido: `com.marketinghub.oprm.nichocnae.v2..`.
+- Módulo executor externo responsável pelo controle operacional: `oprm-coletor-mei`.
+- Regra aplicada em `ArquiteturaTest` para manter a v2 do backend restrita a leitura, escrita, contratos, persistência, publicação de pendências e recebimento de callbacks, bloqueando responsabilidades de execução operacional como `@Scheduled`, polling, workers/runners/processors, núcleo `Stage*` e tecnologias externas de execução.

--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -993,3 +993,26 @@
 
 - Adicionada regra operacional e canônica determinando que todo pipeline deve persistir dados suficientes para gerar relatório de execução ao usuário pelo frontend.
 - A regra reforça que logs técnicos não substituem dados funcionais persistidos de etapas, decisões, evidências, artefatos, custos, erros e próximos movimentos.
+
+## 2026-06-19 — Primeiro incremento NichoCNAE v2
+
+- Criada fundação backend da v2 para a etapa `candidate-generator`, com execução de estágio versionada por `attemptNumber`, `technicalRetryNumber` e `knowledgeVersion`.
+- Separada a classificação de falhas em `INFRASTRUCTURE`, `VALIDATION`, `QUALITY` e `MARKET_EVIDENCE`, mantendo retry técnico apenas para infraestrutura.
+- Mantida a materialização automática bloqueada por feature flag durante calibração da v2.
+- Registrados contratos internos de `pending`, `complete` e `fail` para o executor OPRM consumir e reportar a etapa inicial.
+
+## 2026-06-19 — Segundo incremento NichoCNAE v2
+
+- Fortalecida a integridade da evidência da extração de sinais do NichoCNAE: sinais agora usam trecho literal dos campos persistidos do snapshot, sem evidência recomposta artificialmente.
+- Adicionado bloqueio semântico para fontes de ator, ocupação ou contexto adjacente, registrando diagnóstico `SEMANTIC_CONTEXT_MISMATCH` em vez de promover o conteúdo a sinal positivo.
+- Backend da etapa `signal-extractor` passou a rejeitar `evidenceExcerpt` que não exista literalmente em `sourceTitle`, `snippet` ou `shortExcerpt`, e também rejeita sinais positivos vindos de contexto incompatível.
+- Adicionados testes de regressão dos ciclos 70, 72 e 75 para ator/contexto, trecho exato obrigatório e ocupação adjacente.
+
+## 2026-06-19 — Terceiro incremento NichoCNAE v2: snapshot de conhecimento e rewind seletivo
+- Implementado snapshot mínimo de conhecimento no reprocessamento de pesquisa de rotina, registrando versão, fontes aceitas, claims aceitos, fontes rejeitadas e lacunas de evidência antes de reabrir o mesmo job.
+- Ajustado o reprocessamento de ciclos com falta de evidência para voltar ao query planner (`niche-research-seed-builder`) sem apagar fontes e claims já aceitos, preservando material validado para reduzir retrabalho e melhorar rastreabilidade do relatório.
+- Adicionado teste de regressão do ciclo 72 para garantir preservação de evidência aceita, rejeição de contexto semântico contaminado e limpeza apenas dos artefatos reexecutáveis.
+
+## 2026-06-19 — Protocolo leitura escrita aplicado à v2 NichoCNAE
+- Aplicado o protocolo leitura escrita no backend da v2 do pipeline NichoCNAE, protegendo `com.marketinghub.oprm.nichocnae.v2..` para permanecer como camada de contratos, persistência, pendências e callbacks.
+- Registrado que o controle operacional de execução da v2 permanece no módulo externo `oprm-coletor-mei`, bloqueando no backend responsabilidades como agendamento, polling, workers/runners/processors e integrações externas de execução.

--- a/docs/swagger/oprm-nichocnae-v2-candidate-generator-swagger.yaml
+++ b/docs/swagger/oprm-nichocnae-v2-candidate-generator-swagger.yaml
@@ -1,0 +1,37 @@
+openapi: 3.0.3
+info:
+  title: OPRM NichoCNAE v2 Candidate Generator API
+  version: "1.0"
+paths:
+  /api/internal/oprm/nichocnae/v2/candidate-generator/stage-executions/pending:
+    get:
+      summary: Lista execuções pendentes da etapa candidate-generator v2
+      responses:
+        "200":
+          description: Pendências disponíveis para o executor OPRM
+  /api/internal/oprm/nichocnae/v2/candidate-generator/stage-executions/{stageExecutionId}/complete:
+    post:
+      summary: Registra conclusão de execução da etapa candidate-generator v2
+      parameters:
+        - name: stageExecutionId
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        "200":
+          description: Conclusão registrada
+  /api/internal/oprm/nichocnae/v2/candidate-generator/stage-executions/{stageExecutionId}/fail:
+    post:
+      summary: Registra falha e retry técnico da etapa candidate-generator v2
+      parameters:
+        - name: stageExecutionId
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        "200":
+          description: Falha registrada

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnae/signalextractor/SignalExtractorEngine.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnae/signalextractor/SignalExtractorEngine.java
@@ -16,9 +16,14 @@ public class SignalExtractorEngine {
 
     /** Analisa título, snippet e trecho curto para produzir sinais classificados da etapa cinco. */
     public List<ExtractedSignal> extract(SignalExtractorPending pending) {
-        String evidence = normalizeEvidence(pending);
-        String normalized = evidence.toLowerCase(Locale.ROOT);
+        EvidenceText evidence = EvidenceText.from(pending);
+        String normalized = evidence.normalizedText();
         Map<String, ExtractedSignal> signals = new LinkedHashMap<>();
+        if (hasActorContextMismatch(normalized)) {
+            addContextMismatchRisk(signals, evidence);
+            addSolutionRiskIfPresent(signals, normalized, evidence);
+            return signals.values().stream().limit(MAX_SIGNALS).toList();
+        }
         addIfPresent(signals, normalized, evidence, List.of("mei", "autônom", "por conta própria", "dono-operador", "profissional independente"),
                 "AUTONOMOUS_WORK_MODE", "Trabalho executado diretamente pelo MEI ou profissional autônomo", 86);
         addSpecificRoutineTaskSignals(signals, normalized, evidence);
@@ -61,15 +66,15 @@ public class SignalExtractorEngine {
         addIfPresent(signals, normalized, evidence, List.of("organizar", "controle", "processo", "minha rotina", "meus clientes", "linguagem", "apelido"),
                 "CONTEXT_MARKER", "Sinal de organização e controle observado na rotina", 74);
         addSolutionRiskIfPresent(signals, normalized, evidence);
-        if (signals.isEmpty() && StringUtils.hasText(evidence)) {
+        if (signals.isEmpty() && StringUtils.hasText(evidence.normalizedText())) {
             signals.put("LANGUAGE_MARKER|fallback", new ExtractedSignal(
-                    "LANGUAGE_MARKER", "Vocabulário público do nicho identificado para síntese", evidence, 60));
+                    "LANGUAGE_MARKER", "Vocabulário público do nicho identificado para síntese", evidence.firstExactSpan(), 60));
         }
         return signals.values().stream().limit(MAX_SIGNALS).toList();
     }
 
     /** Adiciona sinais de rotina preservando ações concretas encontradas na evidência pública. */
-    private void addSpecificRoutineTaskSignals(Map<String, ExtractedSignal> signals, String normalized, String evidence) {
+    private void addSpecificRoutineTaskSignals(Map<String, ExtractedSignal> signals, String normalized, EvidenceText evidence) {
         addRoutineTaskIfPresent(
                 signals,
                 normalized,
@@ -112,11 +117,11 @@ public class SignalExtractorEngine {
                 86);
     }
 
-    /** Adiciona uma tarefa de rotina quando existe verbo de ação e objeto concreto na evidência. */
+    /** Adiciona uma tarefa de rotina quando existe verbo de ação, objeto concreto e trecho exato na evidência. */
     private void addRoutineTaskIfPresent(
             Map<String, ExtractedSignal> signals,
             String normalized,
-            String evidence,
+            EvidenceText evidence,
             List<String> actionKeywords,
             List<String> objectKeywords,
             String signalText,
@@ -124,7 +129,11 @@ public class SignalExtractorEngine {
         if (!containsAny(normalized, actionKeywords) || !containsAny(normalized, objectKeywords)) {
             return;
         }
-        signals.putIfAbsent("ROUTINE_TASK|" + signalText, new ExtractedSignal("ROUTINE_TASK", signalText, evidence, confidenceScore));
+        String exactSpan = evidence.findExactSpan(actionKeywords, objectKeywords);
+        if (!StringUtils.hasText(exactSpan)) {
+            return;
+        }
+        signals.putIfAbsent("ROUTINE_TASK|" + signalText, new ExtractedSignal("ROUTINE_TASK", signalText, exactSpan, confidenceScore));
     }
 
     /** Verifica se algum sinal do tipo informado já foi extraído. */
@@ -137,14 +146,37 @@ public class SignalExtractorEngine {
         return keywords.stream().anyMatch(normalized::contains);
     }
 
+    /** Bloqueia fontes de ator ou ocupação adjacente antes que virem prova positiva do executor alvo. */
+    private boolean hasActorContextMismatch(String normalized) {
+        return normalized.contains("companhia aérea")
+                || normalized.contains("voo cancelado")
+                || normalized.contains("cancelamento de voo")
+                || normalized.contains("motorista de aplicativo")
+                || normalized.contains("entregador de aplicativo")
+                || normalized.contains("ifood")
+                || normalized.contains("uber")
+                || normalized.contains("degustador de grãos")
+                || normalized.contains("personal shopper")
+                || normalized.contains("revendedora plus size");
+    }
+
+    /** Registra risco auditável quando a fonte pertence a ator ou contexto incompatível. */
+    private void addContextMismatchRisk(Map<String, ExtractedSignal> signals, EvidenceText evidence) {
+        signals.putIfAbsent("SEMANTIC_CONTEXT_MISMATCH|ator-contexto", new ExtractedSignal(
+                "SEMANTIC_CONTEXT_MISMATCH",
+                "Fonte pertence a ator ou ocupação adjacente e não pode provar rotina do executor alvo",
+                evidence.firstExactSpan(),
+                95));
+    }
+
     /** Adiciona risco de solução quando a evidência contém termos explícitos de solução precoce. */
-    private void addSolutionRiskIfPresent(Map<String, ExtractedSignal> signals, String normalized, String evidence) {
+    private void addSolutionRiskIfPresent(Map<String, ExtractedSignal> signals, String normalized, EvidenceText evidence) {
         boolean present = containsSolutionLanguage(normalized);
         if (!present) {
             return;
         }
         signals.putIfAbsent("SOLUTION_LANGUAGE_RISK|Termo de solução detectado antes da aprovação da rotina", new ExtractedSignal(
-                "SOLUTION_LANGUAGE_RISK", "Termo de solução detectado antes da aprovação da rotina", evidence, 70));
+                "SOLUTION_LANGUAGE_RISK", "Termo de solução detectado antes da aprovação da rotina", evidence.findExactSpan(List.of("inteligência artificial", "automação", "sistema", "software", "ferramenta", "curso", "ia", "app")), 70));
     }
 
     /** Detecta termos de solução com cuidado para não confundir sílabas comuns como "ia" em palavras maiores. */
@@ -165,11 +197,11 @@ public class SignalExtractorEngine {
         return tokenized.contains(" " + token + " ");
     }
 
-    /** Adiciona um sinal quando o conteúdo contém algum indicador textual do grupo de palavras-chave. */
+    /** Adiciona um sinal somente quando há trecho exato contendo indicador textual do grupo de palavras-chave. */
     private void addIfPresent(
             Map<String, ExtractedSignal> signals,
             String normalized,
-            String evidence,
+            EvidenceText evidence,
             List<String> keywords,
             String signalType,
             String signalText,
@@ -178,26 +210,71 @@ public class SignalExtractorEngine {
         if (!present) {
             return;
         }
-        signals.putIfAbsent(signalType + "|" + signalText, new ExtractedSignal(signalType, signalText, evidence, confidenceScore));
-    }
-
-    /** Monta evidência curta a partir dos campos públicos permitidos, sem carregar HTML completo. */
-    private String normalizeEvidence(SignalExtractorPending pending) {
-        List<String> parts = new ArrayList<>();
-        addPart(parts, pending.sourceTitle());
-        addPart(parts, pending.snippet());
-        addPart(parts, pending.shortExcerpt());
-        String evidence = String.join(" — ", parts).replaceAll("\\s+", " ").trim();
-        if (evidence.length() > MAX_EVIDENCE_LENGTH) {
-            return evidence.substring(0, MAX_EVIDENCE_LENGTH).trim();
+        String exactSpan = evidence.findExactSpan(keywords);
+        if (!StringUtils.hasText(exactSpan)) {
+            return;
         }
-        return evidence;
+        signals.putIfAbsent(signalType + "|" + signalText, new ExtractedSignal(signalType, signalText, exactSpan, confidenceScore));
     }
 
-    /** Inclui parte textual quando ela contém conteúdo útil para extração. */
-    private void addPart(List<String> parts, String value) {
-        if (StringUtils.hasText(value)) {
-            parts.add(value.trim());
+    /** Guarda partes textuais auditáveis e localiza trechos exatos sem recompor fonte artificial. */
+    private record EvidenceText(List<String> parts) {
+        /** Monta a evidência auditável a partir dos campos públicos do snapshot. */
+        private static EvidenceText from(SignalExtractorPending pending) {
+            List<String> parts = new ArrayList<>();
+            addPart(parts, pending.sourceTitle());
+            addPart(parts, pending.snippet());
+            addPart(parts, pending.shortExcerpt());
+            return new EvidenceText(parts);
+        }
+
+        /** Normaliza as partes apenas para busca semântica interna. */
+        private String normalizedText() {
+            return String.join(" ", parts).toLowerCase(Locale.ROOT);
+        }
+
+        /** Retorna o primeiro trecho exato disponível no snapshot. */
+        private String firstExactSpan() {
+            return parts.stream().findFirst().orElse("");
+        }
+
+        /** Localiza trecho exato que contenha qualquer palavra-chave informada. */
+        private String findExactSpan(List<String> keywords) {
+            return parts.stream()
+                    .filter(part -> keywords.stream().anyMatch(keyword -> containsKeyword(part, keyword)))
+                    .findFirst()
+                    .map(EvidenceText::trimToLimit)
+                    .orElse(firstExactSpan());
+        }
+
+        /** Localiza trecho exato que contenha ação e objeto concreto ao mesmo tempo. */
+        private String findExactSpan(List<String> actionKeywords, List<String> objectKeywords) {
+            return parts.stream()
+                    .filter(part -> actionKeywords.stream().anyMatch(keyword -> containsKeyword(part, keyword)))
+                    .filter(part -> objectKeywords.stream().anyMatch(keyword -> containsKeyword(part, keyword)))
+                    .findFirst()
+                    .map(EvidenceText::trimToLimit)
+                    .orElse("");
+        }
+
+        /** Verifica palavra-chave dentro da parte textual preservada. */
+        private static boolean containsKeyword(String part, String keyword) {
+            return part.toLowerCase(Locale.ROOT).contains(keyword.toLowerCase(Locale.ROOT));
+        }
+
+        /** Inclui parte textual quando ela contém conteúdo útil para extração. */
+        private static void addPart(List<String> parts, String value) {
+            if (StringUtils.hasText(value)) {
+                parts.add(trimToLimit(value.trim().replaceAll("\\s+", " ")));
+            }
+        }
+
+        /** Limita trecho mantendo-o como substring literal do campo persistido. */
+        private static String trimToLimit(String value) {
+            if (value.length() > MAX_EVIDENCE_LENGTH) {
+                return value.substring(0, MAX_EVIDENCE_LENGTH).trim();
+            }
+            return value;
         }
     }
 }

--- a/oprm-coletor-mei/src/test/java/com/marketinghub/nichocnae/signalextractor/SignalExtractorEngineTest.java
+++ b/oprm-coletor-mei/src/test/java/com/marketinghub/nichocnae/signalextractor/SignalExtractorEngineTest.java
@@ -3,6 +3,7 @@ package com.marketinghub.nichocnae.signalextractor;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.Instant;
+import java.util.List;
 import org.junit.jupiter.api.Test;
 
 /** Responsabilidade: validar a extração determinística de sinais da etapa cinco. */
@@ -120,6 +121,50 @@ class SignalExtractorEngineTest {
                         "PRICE_INSECURITY",
                         "CLIENT_NO_SHOW_OR_CANCELLATION");
         assertThat(signals).allSatisfy(signal -> assertThat(signal.evidenceExcerpt()).doesNotContain("<html"));
+    }
+
+
+
+    /** Ciclo 70: deve bloquear prova positiva quando o trecho é de ator adjacente como companhia aérea. */
+    @Test
+    void shouldRejectAdjacentActorEvidenceForCycle70() {
+        var signals = engine.extract(pending(
+                "Cancelamento de voo por companhia aérea",
+                "Companhia aérea cancelou o voo e passageiros pediram reembolso.",
+                "Esse relato não descreve rotina do executor MEI pesquisado."));
+
+        assertThat(signals).extracting(ExtractedSignal::signalType)
+                .contains("SEMANTIC_CONTEXT_MISMATCH")
+                .doesNotContain("CLIENT_NO_SHOW_OR_CANCELLATION", "OPERATIONAL_PAIN", "ROUTINE_TASK");
+    }
+
+    /** Ciclo 72: cada sinal aprovado deve carregar trecho literal de um campo do snapshot, sem síntese recomposta. */
+    @Test
+    void shouldUseExactEvidenceSpanForCycle72() {
+        String title = "Rotina de manicure autônoma";
+        String snippet = "Antes do atendimento, esterilizar alicates e materiais.";
+        String excerpt = "A profissional precisa lixar, retirar cutícula e esmaltar unhas.";
+
+        var signals = engine.extract(pending(title, snippet, excerpt));
+
+        assertThat(signals).isNotEmpty();
+        assertThat(signals).allSatisfy(signal -> assertThat(List.of(title, snippet, excerpt))
+                .anySatisfy(part -> assertThat(part).contains(signal.evidenceExcerpt())));
+        assertThat(signals).extracting(ExtractedSignal::evidenceExcerpt)
+                .doesNotContain(title + " — " + snippet + " — " + excerpt);
+    }
+
+    /** Ciclo 75: deve bloquear ocupação homônima/adjacente antes de virar prova do nicho pesquisado. */
+    @Test
+    void shouldRejectHomonymousOrAdjacentOccupationForCycle75() {
+        var signals = engine.extract(pending(
+                "Personal shopper plus size",
+                "Personal shopper ajuda consumidoras a escolher roupas em lojas.",
+                "Revendedora plus size não descreve rotina de manicure, cabeleireiro ou executor pesquisado."));
+
+        assertThat(signals).extracting(ExtractedSignal::signalType)
+                .contains("SEMANTIC_CONTEXT_MISMATCH")
+                .doesNotContain("ROUTINE_TASK", "CUSTOMER_ACQUISITION_BEHAVIOR", "OPERATIONAL_PAIN");
     }
 
     /** Cria uma pendência mínima para validar o extrator local. */


### PR DESCRIPTION
### Motivation
- Introduzir fundação para o pipeline NichoCNAE v2 com execuções de etapa imutáveis e separação entre tentativa cognitiva e retry técnico. 
- Melhorar o fluxo de reprocessamento para preservar evidências aceitas e reduzir retrabalho ao reabrir ciclos que falharam por falta de evidência. 
- Fortalecer a integridade da extração de sinais garantindo que `evidenceExcerpt` seja trecho literal do snapshot e bloqueando provas provenientes de atores/ocupações adjacentes.

### Description
- Adiciona entidades e persistência para execução de estágio v2: `OprmNichoCnaeV2StageExecution`, `OprmNichoCnaeV2StageExecutionStatus`, `OprmNichoCnaeV2FailureType` e `OprmNichoCnaeV2StageExecutionRepository`, mais migration Liquibase incluída em `db.changelog-master.yaml`.
- Implementa API e service para a etapa `candidate-generator` v2 com endpoints `pending`, `/{id}/complete` e `/{id}/fail`, gerenciamento de retry técnico para `INFRASTRUCTURE` e feature flags para habilitar a materialização via `BackendCandidateGeneratorService`.
- Introduz reprocessamento seletivo em `BackendRoutineResearchOrchestratorService` com `RecordRoutineResearchKnowledgeSnapshot` e `RecordRoutineResearchOrchestratorReprocessPlan`, preservação condicional de `OprmExtractedSignal`/`OprmSourceSnapshot`, geração de `knowledgeVersion`, e dedução de `evidenceGaps` e planificação de rewind mínimo.
- Reforça validação na etapa de extração de sinais em `BackendSignalExtractorService` para exigir que `evidenceExcerpt` seja um span literal do `OprmSourceSnapshot` e para bloquear sinais positivos vindos de contexto/ator adjacente, além de ajustes no fluxo de persistência de sinais.
- Atualiza o executor `oprm-coletor-mei` (`SignalExtractorEngine`) para trabalhar com trechos literais auditáveis (`EvidenceText`), detectar `SEMANTIC_CONTEXT_MISMATCH` e produzir `SOLUTION_LANGUAGE_RISK` e `ROUTINE_TASK` apenas quando houver span exato.
- Aplica regras arquiteturais em `ArquiteturaTest` para restringir responsabilidades operacionais do pacote `com.marketinghub.oprm.nichocnae.v2..` e adiciona documentação e swagger para a v2.

### Testing
- Executados testes unitários adicionados e atualizados: `BackendCandidateGeneratorServiceTest`, `BackendRoutineResearchOrchestratorServiceTest` (incluindo caso de preservação de conhecimento para ciclo 72), `BackendSignalExtractorServiceTest` (valida rejeição de evidência não literal e contexto adjacente) e `SignalExtractorEngineTest` (valida spans literais e diagnósticos `SEMANTIC_CONTEXT_MISMATCH`); todos foram executados localmente e passaram.
- Cobertura de comportamento incluída para: criação de execução inicial v2, agendamento de retry técnico para falha de infraestrutura, bloqueio de materialização por flag, validações de `evidenceExcerpt` exato e regras de preservação de evidência no reprocessamento; asserts automatizados confirmaram os retornos esperados e efeitos colaterais em repositórios mocks.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a34ae897a34832187ff05865989d3ee)