### PR TITLE
Enforce official `metaId` for approved targeting in Facebook readiness test and update docs

### DIFF
--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/ExperimentServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/ExperimentServiceTest.java
@@ -38,6 +38,7 @@ import java.math.BigDecimal;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
+/** Valida os fluxos principais do serviço de experimentos com persistência em memória. */
 @SpringBootTest(classes = com.marketinghub.ads.AdsServiceApplication.class)
 @TestPropertySource(properties = {
         "spring.datasource.url=jdbc:h2:mem:testdb;MODE=MySQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE",
@@ -407,6 +408,7 @@ class ExperimentServiceTest {
                 .isInstanceOf(org.springframework.web.server.ResponseStatusException.class);
     }
 
+    /** Verifica que apenas experimentos liberados, criativos aprovados e públicos com metaId entram na fila. */
     @Test
     void listReadyForCampaignRequiresApprovals() {
         MarketNiche niche = nicheRepository.save(MarketNiche.builder().name("Niche").build());
@@ -450,6 +452,7 @@ class ExperimentServiceTest {
                 .hypothesis(hyp)
                 .type(com.marketinghub.targeting.TargetingElementType.INTEREST)
                 .status(com.marketinghub.targeting.TargetingElementStatus.APPROVED)
+                .metaId("meta-interest-1")
                 .term("Interest")
                 .build());
         targetingElementRepository.save(com.marketinghub.targeting.TargetingElement.builder()
@@ -457,6 +460,7 @@ class ExperimentServiceTest {
                 .hypothesis(hyp)
                 .type(com.marketinghub.targeting.TargetingElementType.JOB_TITLE)
                 .status(com.marketinghub.targeting.TargetingElementStatus.APPROVED)
+                .metaId("meta-job-title-1")
                 .term("CMO")
                 .build());
         targetingElementRepository.save(com.marketinghub.targeting.TargetingElement.builder()
@@ -464,6 +468,7 @@ class ExperimentServiceTest {
                 .hypothesis(hyp)
                 .type(com.marketinghub.targeting.TargetingElementType.BEHAVIOR)
                 .status(com.marketinghub.targeting.TargetingElementStatus.APPROVED)
+                .metaId("meta-behavior-1")
                 .term("Engaged")
                 .build());
 

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -4817,3 +4817,9 @@
 - causa-raiz: `ExperimentRepository.findForAdSetTargetingById`, `findAllReadyForAdSets` e `findReadyForCampaign` ainda exigiam `JOB_TITLE`, apesar do cânone de publicação aceitar qualquer item publicável em `INTEREST`, `JOB_TITLE` ou `BEHAVIOR`.
 - correção aplicada: as queries passam a aceitar qualquer uma das três categorias suportadas, desde que o elemento esteja `APPROVED` e tenha `metaId` oficial preenchido, mantendo bloqueio contra público amplo.
 - prevenção de recorrência: teste de repositório passou a cobrir experimento liberável apenas com `INTEREST` aprovado e com `metaId`, incluindo a chamada direta de pacote por experimento.
+
+## 2026-06-19 — Teste de prontidão Facebook exige metaId oficial
+
+- Solicitação: confirmar que a prontidão para campanha Facebook precisa exigir `metaId` oficial nos públicos aprovados.
+- Causa-raiz: o teste `listReadyForCampaignRequiresApprovals` criava públicos aprovados sem `metaId`, mas a regra operacional e a query de fila já bloqueiam publicação ampla exigindo identificador oficial da Meta.
+- Correção aplicada: o teste agora cria públicos aprovados com `metaId`, mantendo o contrato de que a campanha só entra na fila quando existe pelo menos um público publicável pela Meta.


### PR DESCRIPTION
### Motivation

- The readiness queries and publication canon require published audiences to have an official Meta identifier (`metaId`) even if any approved item in `INTEREST`, `JOB_TITLE`, or `BEHAVIOR` is acceptable. 
- A test was creating approved targeting elements without `metaId`, which mismatched the operational query and caused `404`/not-ready behavior. 
- The documentation needed to record the canonical rule and the test alignment to prevent regressions.

### Description

- Updated the test `ExperimentServiceTest#listReadyForCampaignRequiresApprovals` to set `metaId` for the approved `TargetingElement` saves for `INTEREST`, `JOB_TITLE`, and `BEHAVIOR` so the experiment can be considered publishable. 
- Added brief JavaDoc comments in `ExperimentServiceTest` clarifying the tested flows (in Portuguese). 
- Extended `docs/registros/experimentos.md` with entries describing the canonical change that allows any approved item with a `metaId` to unlock manual publication and noting the test update that enforces `metaId` in fixtures.

### Testing

- Ran the ads-service test module with `./gradlew :backend:ads-service:test` and the updated test `ExperimentServiceTest#listReadyForCampaignRequiresApprovals` passed. 
- The ads-service test suite completed successfully after the change. 
- Repository-level targeting/publication tests covering the `findReadyForCampaign`/`findForAdSetTargetingById` scenarios were validated and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a34b8475b908321b68356cb014a613f)