### PR TITLE
ArchUnit: enforce independence between NichoCNAE initial and v2 pipelines

### DIFF
--- a/backend/ads-service/src/test/java/com/marketinghub/architecture/ArquiteturaTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/architecture/ArquiteturaTest.java
@@ -166,6 +166,14 @@ class ArquiteturaTest {
                     + OPRM_NICHO_CNAE_V2_EXECUTOR_MODULE);
 
     @ArchTest
+    static final ArchRule oprmNichoCnaeVersionsMustRemainIndependent = classes()
+            .that()
+            .resideInAPackage("com.marketinghub.oprm.nichocnae..")
+            .should(notDependOnOtherOprmNichoCnaeVersion())
+            .because("[ARQUITETURA] [BACKEND][OPRM NichoCNAE] as versões inicial e v2 devem permanecer "
+                    + "independentes; nenhuma classe de uma versão pode depender de classe da outra versão");
+
+    @ArchTest
     static final ArchRule epmMustNotDependOnOtherMarketingHubPackages = noClasses()
             .that()
             .resideInAPackage("com.marketinghub.epm..")
@@ -1709,6 +1717,50 @@ class ArquiteturaTest {
                 || targetPackage.startsWith("org.openqa.selenium")
                 || targetPackage.startsWith("software.amazon.awssdk.services.s3")
                 || targetPackage.startsWith("com.amazonaws.services.s3");
+    }
+
+    /**
+     * Bloqueia dependência direta entre a versão inicial e a versão v2 do backend OPRM NichoCNAE.
+     */
+    private static ArchCondition<JavaClass> notDependOnOtherOprmNichoCnaeVersion() {
+        return new ArchCondition<>(
+                "[ARQUITETURA] [BACKEND][OPRM NichoCNAE] não depender de outra versão NichoCNAE") {
+            @Override
+            public void check(JavaClass item, ConditionEvents events) {
+                String sourceVersion = oprmNichoCnaeVersionOf(item);
+                if (sourceVersion == null) {
+                    return;
+                }
+                item.getDirectDependenciesFromSelf().forEach(dependency -> {
+                    JavaClass targetClass = dependency.getTargetClass();
+                    String targetVersion = oprmNichoCnaeVersionOf(targetClass);
+                    if (targetVersion == null || sourceVersion.equals(targetVersion)) {
+                        return;
+                    }
+                    String message = "[ARQUITETURA] [BACKEND][OPRM NichoCNAE] classe-origem=" + item.getName()
+                            + " pertence à versão " + sourceVersion + " mas depende da versão " + targetVersion
+                            + ": " + dependency.getDescription()
+                            + " | regra: versões NichoCNAE devem se comunicar apenas por contratos persistidos, "
+                            + "endpoints canônicos ou artefatos auditáveis, nunca por dependência direta de classe.";
+                    events.add(SimpleConditionEvent.violated(item, message));
+                });
+            }
+        };
+    }
+
+    /**
+     * Identifica a versão do pacote backend OPRM NichoCNAE.
+     */
+    private static String oprmNichoCnaeVersionOf(JavaClass javaClass) {
+        String packageName = javaClass.getPackageName();
+        if (!packageName.startsWith(OPRM_NICHO_CNAE_STAGE_PACKAGE_PREFIX)) {
+            return null;
+        }
+        if (packageName.equals(OPRM_NICHO_CNAE_V2_PACKAGE)
+                || packageName.startsWith(OPRM_NICHO_CNAE_V2_PACKAGE + ".")) {
+            return "v2";
+        }
+        return "inicial";
     }
 
     /**

--- a/oprm-coletor-mei/src/test/java/com/marketinghub/nichocnae/architecture/NichoCnaePipelineArchitectureTest.java
+++ b/oprm-coletor-mei/src/test/java/com/marketinghub/nichocnae/architecture/NichoCnaePipelineArchitectureTest.java
@@ -20,6 +20,7 @@ import org.junit.jupiter.api.Test;
  */
 class NichoCnaePipelineArchitectureTest {
     private static final String BASE_PACKAGE = "com.marketinghub.nichocnae";
+    private static final String V2_PACKAGE = "com.marketinghub.nichocnaev2";
     private static final String PIPELINE_PACKAGE = BASE_PACKAGE + ".pipeline";
 
     private static final DescribedPredicate<JavaClass> ARE_IN_CONCRETE_STAGE =
@@ -68,11 +69,23 @@ class NichoCnaePipelineArchitectureTest {
                 .check(importedClasses);
     }
 
+    /** Valida que a versão inicial não conhece classes da versão 2 do pipeline NichoCNAE. */
+    @Test
+    void initialVersionShouldNotDependOnVersionTwo() {
+        JavaClasses importedClasses = importNichoCnaeProductionClasses();
+
+        classes()
+                .that().resideInAPackage(BASE_PACKAGE + "..")
+                .should(notDependOnNichoCnaeVersionTwo())
+                .because("[ARQUITETURA] a versão inicial nichocnae deve permanecer independente da versão 2")
+                .check(importedClasses);
+    }
+
     /** Importa somente classes de produção do contexto nichocnae para evitar ruído de testes. */
     private JavaClasses importNichoCnaeProductionClasses() {
         return new ClassFileImporter()
                 .withImportOption(new ImportOption.DoNotIncludeTests())
-                .importPackages(BASE_PACKAGE);
+                .importPackages(BASE_PACKAGE, V2_PACKAGE);
     }
 
     /** Cria a condição explícita de dependência para evitar falso positivo em regras genéricas de pacotes. */
@@ -112,6 +125,26 @@ class NichoCnaePipelineArchitectureTest {
                         String message = "[ARQUITETURA] " + source.getName()
                                 + " pertence à etapa '" + sourceStage + "' mas depende da etapa '"
                                 + targetStage + "' via: " + dependency.getDescription();
+                        events.add(SimpleConditionEvent.violated(source, message));
+                    }
+                }
+            }
+        };
+    }
+
+    /** Cria condição explícita que bloqueia dependência direta da versão inicial para a versão 2. */
+    private ArchCondition<JavaClass> notDependOnNichoCnaeVersionTwo() {
+        return new ArchCondition<>("[ARQUITETURA] não depender de " + V2_PACKAGE) {
+            /** Verifica qualquer dependência direta da versão inicial para classes do pacote v2. */
+            @Override
+            public void check(JavaClass source, ConditionEvents events) {
+                for (Dependency dependency : source.getDirectDependenciesFromSelf()) {
+                    JavaClass target = dependency.getTargetClass();
+                    if (target.getPackageName().equals(V2_PACKAGE)
+                            || target.getPackageName().startsWith(V2_PACKAGE + ".")) {
+                        String message = "[ARQUITETURA] " + source.getName()
+                                + " pertence à versão inicial mas depende da versão 2 "
+                                + target.getName() + " via: " + dependency.getDescription();
                         events.add(SimpleConditionEvent.violated(source, message));
                     }
                 }

--- a/oprm-coletor-mei/src/test/java/com/marketinghub/nichocnaev2/architecture/NichoCnaeV2PipelineArchitectureTest.java
+++ b/oprm-coletor-mei/src/test/java/com/marketinghub/nichocnaev2/architecture/NichoCnaeV2PipelineArchitectureTest.java
@@ -16,6 +16,7 @@ import org.junit.jupiter.api.Test;
 
 /** Garante que o pipeline NichoCNAE versão 2 siga o protocolo padrão módulo no executor OPRM. */
 class NichoCnaeV2PipelineArchitectureTest {
+    private static final String INITIAL_VERSION_PACKAGE = "com.marketinghub.nichocnae";
     private static final String BASE_PACKAGE = "com.marketinghub.nichocnaev2";
     private static final String PIPELINE_PACKAGE = BASE_PACKAGE + ".pipeline";
 
@@ -65,11 +66,23 @@ class NichoCnaeV2PipelineArchitectureTest {
                 .check(importedClasses);
     }
 
+    /** Valida que a versão 2 não conhece classes da versão inicial do pipeline NichoCNAE. */
+    @Test
+    void versionTwoShouldNotDependOnInitialVersion() {
+        JavaClasses importedClasses = importProductionClasses();
+
+        classes()
+                .that().resideInAPackage(BASE_PACKAGE + "..")
+                .should(notDependOnInitialVersion())
+                .because("[ARQUITETURA] a versão 2 nichocnae deve permanecer independente da versão inicial")
+                .check(importedClasses);
+    }
+
     /** Importa classes de produção do pipeline versão 2. */
     private JavaClasses importProductionClasses() {
         return new ClassFileImporter()
                 .withImportOption(new ImportOption.DoNotIncludeTests())
-                .importPackages(BASE_PACKAGE);
+                .importPackages(BASE_PACKAGE, INITIAL_VERSION_PACKAGE);
     }
 
     /** Cria condição explícita que bloqueia dependência do núcleo para etapa concreta. */
@@ -100,6 +113,25 @@ class NichoCnaeV2PipelineArchitectureTest {
                     if (targetStage != null && !targetStage.equals(sourceStage)) {
                         events.add(SimpleConditionEvent.violated(source, "[ARQUITETURA] " + source.getName()
                                 + " pertence à etapa " + sourceStage + " mas depende da etapa " + targetStage));
+                    }
+                }
+            }
+        };
+    }
+
+    /** Cria condição explícita que bloqueia dependência direta da versão 2 para a versão inicial. */
+    private ArchCondition<JavaClass> notDependOnInitialVersion() {
+        return new ArchCondition<>("[ARQUITETURA] não depender de " + INITIAL_VERSION_PACKAGE) {
+            /** Verifica dependências diretas originadas na versão 2 para classes da versão inicial. */
+            @Override
+            public void check(JavaClass source, ConditionEvents events) {
+                for (Dependency dependency : source.getDirectDependenciesFromSelf()) {
+                    JavaClass target = dependency.getTargetClass();
+                    if (target.getPackageName().equals(INITIAL_VERSION_PACKAGE)
+                            || target.getPackageName().startsWith(INITIAL_VERSION_PACKAGE + ".")) {
+                        events.add(SimpleConditionEvent.violated(source, "[ARQUITETURA] " + source.getName()
+                                + " pertence à versão 2 mas depende da versão inicial "
+                                + target.getName() + " via: " + dependency.getDescription()));
                     }
                 }
             }


### PR DESCRIPTION
### Motivation
- Prevent accidental compile-time coupling between the original NichoCNAE implementation and the v2 implementation so both versions remain independently deployable and maintain clear boundaries.

### Description
- Added a new ArchUnit `ArchRule` in `ArquiteturaTest` to forbid direct class dependencies between OPRM NichoCNAE versions and implemented the `notDependOnOtherOprmNichoCnaeVersion` condition with helper `oprmNichoCnaeVersionOf`.
- Added package-level isolation tests in `NichoCnaePipelineArchitectureTest` to ensure the initial pipeline does not depend on `com.marketinghub.nichocnaev2`, including import of both packages and a `notDependOnNichoCnaeVersionTwo` condition.
- Added package-level isolation tests in `NichoCnaeV2PipelineArchitectureTest` to ensure the v2 pipeline does not depend on the initial `com.marketinghub.nichocnae`, including import of both packages and a `notDependOnInitialVersion` condition.
- Updated class importers in both pipeline tests to include both packages so cross-version dependencies are detected during test execution.

### Testing
- Ran the project test suite including the new ArchUnit tests with `./gradlew test` and all tests completed successfully.
- Executed module-level tests for `backend/ads-service` and `oprm-coletor-mei` which included the modified ArchUnit checks and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a34c060c8848321990d7a15c95400e6)