### PR TITLE
Add OPRM NichoCNAE v2 pipeline design view

### DIFF
--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -1016,3 +1016,9 @@
 ## 2026-06-19 — Protocolo leitura escrita aplicado à v2 NichoCNAE
 - Aplicado o protocolo leitura escrita no backend da v2 do pipeline NichoCNAE, protegendo `com.marketinghub.oprm.nichocnae.v2..` para permanecer como camada de contratos, persistência, pendências e callbacks.
 - Registrado que o controle operacional de execução da v2 permanece no módulo externo `oprm-coletor-mei`, bloqueando no backend responsabilidades como agendamento, polling, workers/runners/processors e integrações externas de execução.
+
+
+## 2026-06-19 — Design visual da pipeline NichoCNAE v2 no frontend
+- Adicionado botão por linha na tela de CNAEs por Score OPRM para abrir a visão da v2 do pipeline no contexto do CNAE selecionado.
+- Criada a tela de design `/oprm/cnaes/:cnaeCode/pipeline-v2` com cards das etapas planejadas da v2, baseada nos planos de melhoria de qualidade, reprocessamento por conhecimento e ordem de implementação OPRM.
+- A tela é informativa e não cria orquestração no frontend; as decisões de execução continuam pertencendo ao backend/executor conforme arquitetura do OPRM.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -113,6 +113,7 @@ import OprmOccupationCatalogPage from "./pages/oprm/OprmOccupationCatalogPage";
 import OprmCnaeVolumePage from "./pages/oprm/OprmCnaeVolumePage";
 import OprmCnaeDetailPlaceholderPage from "./pages/oprm/OprmCnaeDetailPlaceholderPage";
 import OprmCnaePipelineStageDetailPage from "./pages/oprm/OprmCnaePipelineStageDetailPage";
+import OprmNichoCnaeV2PipelinePage from "./pages/oprm/OprmNichoCnaeV2PipelinePage";
 import OprmEnrichedNicheDetailPage from "./pages/oprm/OprmEnrichedNicheDetailPage";
 import OprmGeneralAudiencesPage from "./pages/oprm/OprmGeneralAudiencesPage";
 import OprmJobsPage from "./pages/oprm/OprmJobsPage";
@@ -332,6 +333,10 @@ export default function App() {
               <Route
                 path="/oprm/cnaes/:cnaeCode/pipeline/:researchCycleId/stages/:stageCode"
                 element={<OprmCnaePipelineStageDetailPage />}
+              />
+              <Route
+                path="/oprm/cnaes/:cnaeCode/pipeline-v2"
+                element={<OprmNichoCnaeV2PipelinePage />}
               />
               <Route path="/mois" element={<MoisWorkspacePage />} />
               <Route

--- a/frontend/src/__tests__/OprmNavigation.test.tsx
+++ b/frontend/src/__tests__/OprmNavigation.test.tsx
@@ -44,11 +44,19 @@ describe("OPRM navigation", () => {
 
   it("renders placeholder niche detail page on /oprm/cnaes/:cnaeCode route", () => {
     setup(<App />, ["/oprm/cnaes/9602501"]);
-    expect(screen.getByText(/^Detalhe do nicho CNAE$/)).toBeTruthy();
+    expect(screen.getByText(/^Subnichos do CNAE$/)).toBeTruthy();
     expect(screen.getByText(/^CNAE 9602501$/)).toBeTruthy();
     expect(
       screen.getByRole("link", { name: /voltar para cnaes/i }),
     ).toBeTruthy();
+  });
+
+  it("renders v2 pipeline design page for a CNAE", () => {
+    setup(<App />, ["/oprm/cnaes/9602501/pipeline-v2"]);
+    expect(screen.getByText(/^Pipeline NichoCNAE v2$/)).toBeTruthy();
+    expect(screen.getByText(/^CNAE 9602501$/)).toBeTruthy();
+    expect(screen.getByText(/^Candidate Generator$/)).toBeTruthy();
+    expect(screen.getByText(/^Knowledge Accumulator$/)).toBeTruthy();
   });
 
   it("redirects obsolete /oprm/pipeline route to CNAE niche creation flow", () => {

--- a/frontend/src/pages/oprm/OprmCnaeVolumePage.tsx
+++ b/frontend/src/pages/oprm/OprmCnaeVolumePage.tsx
@@ -285,6 +285,7 @@ export default function OprmCnaeVolumePage() {
                       <th>Subnichos</th>
                       <th>Custo</th>
                       <th>Pesquisa</th>
+                      <th>Pipeline v2</th>
                     </>
                   ) : (
                     <th>Status</th>
@@ -331,6 +332,15 @@ export default function OprmCnaeVolumePage() {
                               -
                             </span>
                           )}
+                        </td>
+                        <td>
+                          <Link
+                            className="btn btn-sm btn-outline-primary text-nowrap"
+                            to={`/oprm/cnaes/${encodeURIComponent(item.cnaeCode)}/pipeline-v2`}
+                            title="Abrir design da v2 do pipeline NichoCNAE"
+                          >
+                            Ver v2
+                          </Link>
                         </td>
                       </tr>
                     ))

--- a/frontend/src/pages/oprm/OprmNichoCnaeV2PipelinePage.tsx
+++ b/frontend/src/pages/oprm/OprmNichoCnaeV2PipelinePage.tsx
@@ -1,0 +1,190 @@
+import { Link, useParams } from "react-router-dom";
+import PageTitle from "../../components/PageTitle";
+import OprmModuleNavigation from "./OprmModuleNavigation";
+
+const v2Stages = [
+  {
+    number: 1,
+    title: "Candidate Generator",
+    status: "Design aprovado · implementação inicial",
+    purpose:
+      "Gerar candidatos neutros de subnicho sem contaminar nome, dor, canal ou promessa antes da evidência.",
+    output:
+      "4 a 6 candidatos comparáveis, com identidade do executor, job operacional e hipóteses separadas.",
+    businessGate: "Nenhum vencedor obrigatório quando não houver candidato viável.",
+  },
+  {
+    number: 2,
+    title: "Source Safety Filter",
+    status: "Design",
+    purpose:
+      "Bloquear domínios inseguros, conteúdo inadequado e resultados fora do contexto antes de gastar IA.",
+    output: "Lista segura e deduplicada de URLs candidatas para pesquisa.",
+    businessGate: "Conteúdo inseguro ou contaminado não entra no pipeline.",
+  },
+  {
+    number: 3,
+    title: "Adaptive Query Planner",
+    status: "Design",
+    purpose:
+      "Planejar buscas pelos gaps reais de conhecimento, reaproveitando queries, fontes e falhas anteriores.",
+    output: "Plano de pesquisa curto, natural e orientado a lacunas de evidência.",
+    businessGate: "A pesquisa aprofunda apenas o que pode mudar a decisão comercial.",
+  },
+  {
+    number: 4,
+    title: "Candidate Tournament",
+    status: "Design",
+    purpose:
+      "Comparar candidatos por densidade e qualidade de evidências antes de escolher finalistas.",
+    output: "Até dois finalistas ou decisão NO_VIABLE_SUBNICHE.",
+    businessGate: "O vencedor nasce de evidência observada, não de opinião prévia do modelo.",
+  },
+  {
+    number: 5,
+    title: "Source Fetcher + Reranker",
+    status: "Design",
+    purpose:
+      "Coletar páginas úteis e priorizar fontes diretas, independentes e alinhadas ao objetivo do gate.",
+    output: "Snapshots rastreáveis com origem, trecho curto, metadados e custo.",
+    businessGate: "Fonte adjacente não substitui prova direta do executor específico.",
+  },
+  {
+    number: 6,
+    title: "Signal Extractor",
+    status: "Design aprovado · implementação parcial",
+    purpose:
+      "Extrair claims somente quando houver trecho exato, ator correto, contexto compatível e relação sustentada.",
+    output: "Claims auditáveis com trecho literal, fonte e diagnóstico semântico.",
+    businessGate: "Nenhum claim sem trecho exato pode avançar para síntese.",
+  },
+  {
+    number: 7,
+    title: "Semantic Judge + Entailment",
+    status: "Design",
+    purpose:
+      "Validar se o trecho realmente sustenta a afirmação sobre o executor e o contexto pesquisado.",
+    output: "Claims aprovados, rejeitados, contraditórios ou pendentes por nível de evidência.",
+    businessGate: "Proximidade lexical não é prova de mercado.",
+  },
+  {
+    number: 8,
+    title: "Knowledge Accumulator",
+    status: "Design aprovado · implementação parcial",
+    purpose:
+      "Consolidar conhecimento versionado do ciclo, preservando fontes aceitas, rejeições, gaps e aprendizados.",
+    output: "Snapshot de conhecimento com versão, linhagem e lacunas acionáveis.",
+    businessGate: "Reprocessar sem repetir erro, fonte rejeitada ou custo desnecessário.",
+  },
+  {
+    number: 9,
+    title: "Reprocess Controller",
+    status: "Design aprovado · implementação parcial",
+    purpose:
+      "Decidir o menor rewind necessário quando um gate falhar por qualidade, mantendo o mesmo job quando aplicável.",
+    output: "Retry técnico ou reprocessamento cognitivo com motivo, estágio de retorno e versão de conhecimento.",
+    businessGate: "Falha técnica não vira reprovação de mercado; falta de evidência não reinicia tudo.",
+  },
+  {
+    number: 10,
+    title: "Routine Synthesizer",
+    status: "Design",
+    purpose:
+      "Sintetizar rotina, dores e resultados apenas a partir de claims aprovados e evidências rastreáveis.",
+    output: "Rotina funcional do executor com evidências e limites explícitos.",
+    businessGate: "Síntese não pode inventar dor, canal ou impacto econômico.",
+  },
+  {
+    number: 11,
+    title: "Evidence Level Gate E0–E5",
+    status: "Design",
+    purpose:
+      "Separar existência da atividade, dor prática, impacto econômico e intenção de compra por nível de evidência.",
+    output: "Nível E0 a E5, confiança explicável, motivos de reprovação e próximos movimentos.",
+    businessGate: "Materialização automática só avança com evidência comercial mínima.",
+  },
+  {
+    number: 12,
+    title: "Enriched Niche Materializer",
+    status: "Bloqueado por feature flag",
+    purpose:
+      "Materializar o nicho enriquecido somente depois dos gates de evidência, qualidade e segurança.",
+    output: "Nicho pronto para decisão de produto: executor, dor, resultado, mecanismo plausível e fontes.",
+    businessGate: "A v2 calibra antes de publicar automaticamente para vendas.",
+  },
+];
+
+export default function OprmNichoCnaeV2PipelinePage() {
+  const { cnaeCode } = useParams();
+  const decodedCnaeCode = cnaeCode ? decodeURIComponent(cnaeCode) : undefined;
+
+  return (
+    <div className="d-flex flex-column gap-4">
+      <header className="d-flex flex-column gap-2">
+        <div className="d-flex flex-wrap justify-content-between align-items-start gap-3">
+          <div>
+            <PageTitle>Pipeline NichoCNAE v2</PageTitle>
+            <p className="text-secondary mb-0">
+              Design das etapas da v2 para transformar CNAEs em nichos vendáveis
+              com evidência auditável, reprocessamento inteligente e gates de
+              qualidade antes da materialização.
+            </p>
+          </div>
+          <Link className="btn btn-outline-secondary" to="/oprm">
+            Voltar para CNAEs
+          </Link>
+        </div>
+      </header>
+
+      <OprmModuleNavigation />
+
+      <section className="card border-0 shadow-sm">
+        <div className="card-body">
+          <div className="d-flex flex-wrap justify-content-between gap-3">
+            <div>
+              <h2 className="h5 mb-1">
+                {decodedCnaeCode ? `CNAE ${decodedCnaeCode}` : "Visão geral da v2"}
+              </h2>
+              <p className="text-secondary mb-0">
+                A tela é um mapa de produto: mostra a sequência planejada mesmo
+                quando uma etapa ainda está em design ou protegida por feature flag.
+              </p>
+            </div>
+            <span className="badge text-bg-primary align-self-start">
+              v2 · qualidade antes de escala
+            </span>
+          </div>
+        </div>
+      </section>
+
+      <section className="row g-3" aria-label="Etapas do pipeline NichoCNAE v2">
+        {v2Stages.map((stage) => (
+          <article className="col-12 col-xl-6" key={stage.number}>
+            <div className="card h-100 border-0 shadow-sm">
+              <div className="card-body d-flex flex-column gap-3">
+                <div className="d-flex justify-content-between gap-3">
+                  <div>
+                    <span className="badge text-bg-light border mb-2">
+                      Etapa {stage.number}
+                    </span>
+                    <h3 className="h5 mb-1">{stage.title}</h3>
+                    <span className="small text-primary fw-semibold">
+                      {stage.status}
+                    </span>
+                  </div>
+                </div>
+                <p className="mb-0">{stage.purpose}</p>
+                <dl className="row small mb-0 g-2">
+                  <dt className="col-sm-4 text-secondary fw-normal">Saída</dt>
+                  <dd className="col-sm-8 mb-0">{stage.output}</dd>
+                  <dt className="col-sm-4 text-secondary fw-normal">Gate</dt>
+                  <dd className="col-sm-8 mb-0">{stage.businessGate}</dd>
+                </dl>
+              </div>
+            </div>
+          </article>
+        ))}
+      </section>
+    </div>
+  );
+}


### PR DESCRIPTION
### Motivation
- Provide a design-level view of the planned NichoCNAE v2 pipeline so product and engineering can align on stages and gates before implementation. 
- Make the v2 design discoverable from the CNAE list so stakeholders can open the pipeline design in the context of a specific CNAE. 
- Keep the frontend informational only, deferring execution/orchestration to the backend/executor per OPRM architecture rules. 

### Description
- Added a new informational page and route `
/oprm/cnaes/:cnaeCode/pipeline-v2` implemented in `frontend/src/pages/oprm/OprmNichoCnaeV2PipelinePage.tsx` that renders card-based stage descriptions for the v2 pipeline (Candidate Generator, Source Safety Filter, Adaptive Query Planner, Signal Extractor, Knowledge Accumulator, Reprocess Controller, Evidence Level Gate E0–E5, Materializer blocked by feature flag, etc.).
- Added a per-row `Ver v2` button and new `Pipeline v2` column to the CNAE score table so each CNAE row links to the v2 design page (`frontend/src/pages/oprm/OprmCnaeVolumePage.tsx`).
- Registered the new route in the app router (`frontend/src/App.tsx`) and added navigation test coverage (`frontend/src/__tests__/OprmNavigation.test.tsx`).
- Recorded the UI change in the OPRM task log (`docs/registros/oprm1.md`).

### Testing
- Ran `npm --prefix frontend run build` and the frontend build completed successfully.
- Ran the focused tests with `npm --prefix frontend run test -- --run OprmNavigation` and the updated navigation tests passed (8 tests total, all passed).
- Attempted a Playwright screenshot to validate the rendered page but the environment does not have Playwright installed, so the screenshot step failed (setup limitation only).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a34c12f0a488321a5446d8c9be14ca2)