### PR TITLE
Implement source-safety-filter stage (v2) and make candidate-generator persist executor-provided nextStageCode

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/candidategenerator/service/completeStageExecution/CandidateGeneratorCompletionRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/candidategenerator/service/completeStageExecution/CandidateGeneratorCompletionRequest.java
@@ -4,4 +4,10 @@ package com.marketinghub.oprm.nichocnae.v2.candidategenerator.service.completeSt
 public record CandidateGeneratorCompletionRequest(
         String qualityStatus,
         String requestedAction,
-        String outputPayload) {}
+        String outputPayload,
+        String nextStageCode) {
+    /** Mantém compatibilidade com chamadas que ainda não enviam a próxima etapa decidida pelo executor. */
+    public CandidateGeneratorCompletionRequest(String qualityStatus, String requestedAction, String outputPayload) {
+        this(qualityStatus, requestedAction, outputPayload, null);
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/sourcesafetyfilter/controller/BackendSourceSafetyFilterController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/sourcesafetyfilter/controller/BackendSourceSafetyFilterController.java
@@ -1,0 +1,55 @@
+package com.marketinghub.oprm.nichocnae.v2.sourcesafetyfilter.controller;
+
+import com.marketinghub.oprm.nichocnae.v2.sourcesafetyfilter.service.BackendSourceSafetyFilterService;
+import com.marketinghub.oprm.nichocnae.v2.sourcesafetyfilter.service.completeStageExecution.SourceSafetyFilterCompletionRequest;
+import com.marketinghub.oprm.nichocnae.v2.sourcesafetyfilter.service.completeStageExecution.SourceSafetyFilterCompletionResponse;
+import com.marketinghub.oprm.nichocnae.v2.sourcesafetyfilter.service.createStageExecution.SourceSafetyFilterCreateRequest;
+import com.marketinghub.oprm.nichocnae.v2.sourcesafetyfilter.service.createStageExecution.SourceSafetyFilterCreateResponse;
+import com.marketinghub.oprm.nichocnae.v2.sourcesafetyfilter.service.failStageExecution.SourceSafetyFilterFailureRequest;
+import com.marketinghub.oprm.nichocnae.v2.sourcesafetyfilter.service.failStageExecution.SourceSafetyFilterFailureResponse;
+import com.marketinghub.oprm.nichocnae.v2.sourcesafetyfilter.service.pending.SourceSafetyFilterPendingResponse;
+import java.util.List;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/** Borda HTTP interna da etapa source-safety-filter do pipeline NichoCNAE versão 2. */
+@RestController
+@RequestMapping("/api/internal/oprm/nichocnae/v2/source-safety-filter/stage-executions")
+public class BackendSourceSafetyFilterController {
+    private final BackendSourceSafetyFilterService service;
+
+    /** Recebe o service canônico da etapa para delegar operações HTTP internas. */
+    public BackendSourceSafetyFilterController(BackendSourceSafetyFilterService service) {
+        this.service = service;
+    }
+
+    /** Entrega execuções pendentes da etapa source-safety-filter ao módulo executor OPRM. */
+    @GetMapping("/pending")
+    public List<SourceSafetyFilterPendingResponse> pending() {
+        return service.pending();
+    }
+
+    /** Grava uma pendência da etapa source-safety-filter solicitada pelo módulo executor OPRM. */
+    @PostMapping
+    public SourceSafetyFilterCreateResponse create(@RequestBody SourceSafetyFilterCreateRequest request) {
+        return service.create(request);
+    }
+
+    /** Registra a conclusão da execução de segurança informada pelo módulo executor OPRM. */
+    @PostMapping("/{stageExecutionId}/complete")
+    public SourceSafetyFilterCompletionResponse complete(
+            @PathVariable Long stageExecutionId, @RequestBody SourceSafetyFilterCompletionRequest request) {
+        return service.complete(stageExecutionId, request);
+    }
+
+    /** Registra a falha da execução de segurança informada pelo módulo executor OPRM. */
+    @PostMapping("/{stageExecutionId}/fail")
+    public SourceSafetyFilterFailureResponse fail(
+            @PathVariable Long stageExecutionId, @RequestBody SourceSafetyFilterFailureRequest request) {
+        return service.fail(stageExecutionId, request);
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/sourcesafetyfilter/service/BackendSourceSafetyFilterService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/sourcesafetyfilter/service/BackendSourceSafetyFilterService.java
@@ -1,15 +1,15 @@
-package com.marketinghub.oprm.nichocnae.v2.candidategenerator.service;
+package com.marketinghub.oprm.nichocnae.v2.sourcesafetyfilter.service;
 
-import com.marketinghub.oprm.cnae.OprmNicheCandidate;
 import com.marketinghub.oprm.nichocnae.v2.OprmNichoCnaeV2FailureType;
 import com.marketinghub.oprm.nichocnae.v2.OprmNichoCnaeV2StageExecution;
 import com.marketinghub.oprm.nichocnae.v2.OprmNichoCnaeV2StageExecutionStatus;
-import com.marketinghub.oprm.nichocnae.v2.candidategenerator.service.completeStageExecution.CandidateGeneratorCompletionRequest;
-import com.marketinghub.oprm.nichocnae.v2.candidategenerator.service.completeStageExecution.CandidateGeneratorCompletionResponse;
-import com.marketinghub.oprm.nichocnae.v2.candidategenerator.service.failStageExecution.CandidateGeneratorFailureRequest;
-import com.marketinghub.oprm.nichocnae.v2.candidategenerator.service.failStageExecution.CandidateGeneratorFailureResponse;
-import com.marketinghub.oprm.nichocnae.v2.candidategenerator.service.pending.CandidateGeneratorPendingResponse;
-import com.marketinghub.repository.jpa.oprm.cnae.OprmNicheCandidateRepository;
+import com.marketinghub.oprm.nichocnae.v2.sourcesafetyfilter.service.completeStageExecution.SourceSafetyFilterCompletionRequest;
+import com.marketinghub.oprm.nichocnae.v2.sourcesafetyfilter.service.completeStageExecution.SourceSafetyFilterCompletionResponse;
+import com.marketinghub.oprm.nichocnae.v2.sourcesafetyfilter.service.createStageExecution.SourceSafetyFilterCreateRequest;
+import com.marketinghub.oprm.nichocnae.v2.sourcesafetyfilter.service.createStageExecution.SourceSafetyFilterCreateResponse;
+import com.marketinghub.oprm.nichocnae.v2.sourcesafetyfilter.service.failStageExecution.SourceSafetyFilterFailureRequest;
+import com.marketinghub.oprm.nichocnae.v2.sourcesafetyfilter.service.failStageExecution.SourceSafetyFilterFailureResponse;
+import com.marketinghub.oprm.nichocnae.v2.sourcesafetyfilter.service.pending.SourceSafetyFilterPendingResponse;
 import com.marketinghub.repository.jpa.oprm.nichocnae.v2.OprmNichoCnaeV2StageExecutionRepository;
 import java.time.Instant;
 import java.util.List;
@@ -20,63 +20,56 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
 
-/** Expõe contratos de leitura/escrita do backend para a etapa candidate-generator do pipeline NichoCNAE v2. */
+/** Expõe contratos de leitura/escrita do backend para a etapa source-safety-filter do pipeline NichoCNAE v2. */
 @Service
-public class BackendCandidateGeneratorService {
-    private static final String STAGE_CODE = "candidate-generator";
-
-    private final OprmNicheCandidateRepository nicheCandidateRepository;
+public class BackendSourceSafetyFilterService {
+    public static final String STAGE_CODE = "source-safety-filter";
     private final OprmNichoCnaeV2StageExecutionRepository stageExecutionRepository;
     private final boolean v2Enabled;
-    private final boolean materializationEnabled;
 
-    /** Inicializa o service com repositórios canônicos e feature flags de calibração da v2. */
-    public BackendCandidateGeneratorService(
-            OprmNicheCandidateRepository nicheCandidateRepository,
+    /** Inicializa o service com repositório canônico e feature flag de calibração da v2. */
+    public BackendSourceSafetyFilterService(
             OprmNichoCnaeV2StageExecutionRepository stageExecutionRepository,
-            @Value("${oprm.nichocnae.v2.enabled:false}") boolean v2Enabled,
-            @Value("${oprm.nichocnae.v2.materialization-enabled:false}") boolean materializationEnabled) {
-        this.nicheCandidateRepository = nicheCandidateRepository;
+            @Value("${oprm.nichocnae.v2.enabled:false}") boolean v2Enabled) {
         this.stageExecutionRepository = stageExecutionRepository;
         this.v2Enabled = v2Enabled;
-        this.materializationEnabled = materializationEnabled;
     }
 
     /** Lista pendências disponíveis para consumo canônico pelo executor OPRM NichoCNAE v2. */
-    @Transactional
-    public List<CandidateGeneratorPendingResponse> pending() {
+    @Transactional(readOnly = true)
+    public List<SourceSafetyFilterPendingResponse> pending() {
         if (!v2Enabled) {
             return List.of();
         }
-        ensureInitialPendingExecution();
         return stageExecutionRepository
                 .findByStageCodeAndStatusOrderByCreatedAtAsc(
-                        STAGE_CODE, OprmNichoCnaeV2StageExecutionStatus.PENDING, PageRequest.of(0, 1))
+                        STAGE_CODE, OprmNichoCnaeV2StageExecutionStatus.PENDING, PageRequest.of(0, 5))
                 .stream()
                 .map(this::toPendingResponse)
                 .toList();
     }
 
-    /** Registra conclusão da etapa persistindo a próxima etapa informada pelo executor externo. */
+    /** Registra conclusão do filtro usando a próxima etapa informada pelo executor externo. */
     @Transactional
-    public CandidateGeneratorCompletionResponse complete(
-            Long stageExecutionId, CandidateGeneratorCompletionRequest request) {
+    public SourceSafetyFilterCompletionResponse complete(
+            Long stageExecutionId, SourceSafetyFilterCompletionRequest request) {
         OprmNichoCnaeV2StageExecution execution = findExecution(stageExecutionId);
         execution.setStatus(OprmNichoCnaeV2StageExecutionStatus.COMPLETED);
         execution.setOutputPayload(request == null ? null : request.outputPayload());
         execution.setNextStageCode(request == null ? null : request.nextStageCode());
         execution.setUpdatedAt(Instant.now());
         OprmNichoCnaeV2StageExecution saved = stageExecutionRepository.save(execution);
-        return new CandidateGeneratorCompletionResponse(
+        return new SourceSafetyFilterCompletionResponse(
                 String.valueOf(saved.getId()),
                 saved.getStatus().name(),
                 saved.getNextStageCode(),
-                saved.getMaterializationEnabled());
+                request == null ? null : request.allowedUrlCount(),
+                request == null ? null : request.rejectedUrlCount());
     }
 
     /** Registra falha e cria nova execução somente quando a falha for retry técnico de infraestrutura. */
     @Transactional
-    public CandidateGeneratorFailureResponse fail(Long stageExecutionId, CandidateGeneratorFailureRequest request) {
+    public SourceSafetyFilterFailureResponse fail(Long stageExecutionId, SourceSafetyFilterFailureRequest request) {
         OprmNichoCnaeV2StageExecution execution = findExecution(stageExecutionId);
         OprmNichoCnaeV2FailureType failureType = request == null || request.failureType() == null
                 ? OprmNichoCnaeV2FailureType.VALIDATION
@@ -90,7 +83,7 @@ public class BackendCandidateGeneratorService {
             OprmNichoCnaeV2StageExecution retry = createTechnicalRetry(execution);
             stageExecutionRepository.save(execution);
             OprmNichoCnaeV2StageExecution savedRetry = stageExecutionRepository.save(retry);
-            return new CandidateGeneratorFailureResponse(
+            return new SourceSafetyFilterFailureResponse(
                     String.valueOf(execution.getId()),
                     execution.getStatus().name(),
                     String.valueOf(savedRetry.getId()),
@@ -99,7 +92,7 @@ public class BackendCandidateGeneratorService {
         }
         execution.setStatus(OprmNichoCnaeV2StageExecutionStatus.FAILED);
         OprmNichoCnaeV2StageExecution saved = stageExecutionRepository.save(execution);
-        return new CandidateGeneratorFailureResponse(
+        return new SourceSafetyFilterFailureResponse(
                 String.valueOf(saved.getId()),
                 saved.getStatus().name(),
                 null,
@@ -107,34 +100,29 @@ public class BackendCandidateGeneratorService {
                 saved.getTechnicalRetryNumber());
     }
 
-    /** Garante uma pendência inicial real a partir da fila atual de candidatos, sem materialização automática. */
-    private void ensureInitialPendingExecution() {
-        if (!stageExecutionRepository
-                .findByStageCodeAndStatusOrderByCreatedAtAsc(
-                        STAGE_CODE, OprmNichoCnaeV2StageExecutionStatus.PENDING, PageRequest.of(0, 1))
-                .isEmpty()) {
-            return;
-        }
-        nicheCandidateRepository.findNextPendingRoutineResearchCandidatePreview(PageRequest.of(0, 1)).stream()
-                .filter(candidate -> !stageExecutionRepository.existsBySourceNicheIdAndStageCode(
-                        candidate.getId(), STAGE_CODE))
-                .findFirst()
-                .ifPresent(candidate -> stageExecutionRepository.save(createInitialExecution(candidate)));
+    /** Grava uma pendência da etapa de segurança solicitada pelo executor externo. */
+    @Transactional
+    public SourceSafetyFilterCreateResponse create(SourceSafetyFilterCreateRequest request) {
+        OprmNichoCnaeV2StageExecution saved = stageExecutionRepository.save(toPendingExecution(request));
+        return new SourceSafetyFilterCreateResponse(
+                String.valueOf(saved.getId()), saved.getStatus().name(), saved.getStageCode());
     }
 
-    /** Cria a primeira execução imutável da etapa candidate-generator para o candidato priorizado. */
-    private OprmNichoCnaeV2StageExecution createInitialExecution(OprmNicheCandidate candidate) {
+    /** Converte o contrato recebido do executor em entidade persistível, sem decidir regra operacional. */
+    private OprmNichoCnaeV2StageExecution toPendingExecution(SourceSafetyFilterCreateRequest request) {
         Instant now = Instant.now();
         OprmNichoCnaeV2StageExecution execution = new OprmNichoCnaeV2StageExecution();
-        execution.setJobId("nichocnae-v2-candidate-" + candidate.getId());
-        execution.setSourceNicheId(candidate.getId());
-        execution.setCnaeCode(candidate.getCnaeCode());
+        execution.setJobId(request.jobId());
+        execution.setResearchCycleId(request.researchCycleId());
+        execution.setSourceNicheId(request.sourceNicheId());
+        execution.setCnaeCode(request.cnaeCode());
         execution.setStageCode(STAGE_CODE);
-        execution.setAttemptNumber(1);
+        execution.setAttemptNumber(request.attemptNumber());
         execution.setTechnicalRetryNumber(0);
-        execution.setKnowledgeVersion(1);
+        execution.setKnowledgeVersion(request.knowledgeVersion());
         execution.setStatus(OprmNichoCnaeV2StageExecutionStatus.PENDING);
-        execution.setMaterializationEnabled(materializationEnabled);
+        execution.setInputPayload(request.inputPayload());
+        execution.setMaterializationEnabled(Boolean.TRUE.equals(request.materializationEnabled()));
         execution.setCreatedAt(now);
         execution.setUpdatedAt(now);
         return execution;
@@ -142,21 +130,17 @@ public class BackendCandidateGeneratorService {
 
     /** Cria uma nova linha para retry técnico preservando a tentativa cognitiva e a versão de conhecimento. */
     private OprmNichoCnaeV2StageExecution createTechnicalRetry(OprmNichoCnaeV2StageExecution previousExecution) {
-        Instant now = Instant.now();
-        OprmNichoCnaeV2StageExecution retry = new OprmNichoCnaeV2StageExecution();
-        retry.setJobId(previousExecution.getJobId());
-        retry.setResearchCycleId(previousExecution.getResearchCycleId());
-        retry.setSourceNicheId(previousExecution.getSourceNicheId());
-        retry.setCnaeCode(previousExecution.getCnaeCode());
-        retry.setStageCode(previousExecution.getStageCode());
-        retry.setAttemptNumber(previousExecution.getAttemptNumber());
-        retry.setTechnicalRetryNumber(previousExecution.getTechnicalRetryNumber() + 1);
-        retry.setKnowledgeVersion(previousExecution.getKnowledgeVersion());
-        retry.setStatus(OprmNichoCnaeV2StageExecutionStatus.PENDING);
+        OprmNichoCnaeV2StageExecution retry = toPendingExecution(new SourceSafetyFilterCreateRequest(
+                previousExecution.getJobId(),
+                previousExecution.getResearchCycleId(),
+                previousExecution.getSourceNicheId(),
+                previousExecution.getCnaeCode(),
+                previousExecution.getAttemptNumber(),
+                previousExecution.getKnowledgeVersion(),
+                previousExecution.getMaterializationEnabled(),
+                previousExecution.getInputPayload()));
         retry.setInputPayload(previousExecution.getInputPayload());
-        retry.setMaterializationEnabled(previousExecution.getMaterializationEnabled());
-        retry.setCreatedAt(now);
-        retry.setUpdatedAt(now);
+        retry.setTechnicalRetryNumber(previousExecution.getTechnicalRetryNumber() + 1);
         return retry;
     }
 
@@ -166,12 +150,12 @@ public class BackendCandidateGeneratorService {
                 .findByIdAndStageCode(stageExecutionId, STAGE_CODE)
                 .orElseThrow(() -> new ResponseStatusException(
                         HttpStatus.NOT_FOUND,
-                        "NichoCNAE v2 candidate-generator stage execution not found: " + stageExecutionId));
+                        "NichoCNAE v2 source-safety-filter stage execution not found: " + stageExecutionId));
     }
 
     /** Converte a entidade persistida no contrato canônico de pending do executor. */
-    private CandidateGeneratorPendingResponse toPendingResponse(OprmNichoCnaeV2StageExecution execution) {
-        return new CandidateGeneratorPendingResponse(
+    private SourceSafetyFilterPendingResponse toPendingResponse(OprmNichoCnaeV2StageExecution execution) {
+        return new SourceSafetyFilterPendingResponse(
                 String.valueOf(execution.getId()),
                 execution.getJobId(),
                 execution.getCnaeCode(),
@@ -179,6 +163,6 @@ public class BackendCandidateGeneratorService {
                 execution.getAttemptNumber(),
                 execution.getTechnicalRetryNumber(),
                 execution.getKnowledgeVersion(),
-                execution.getMaterializationEnabled());
+                execution.getInputPayload());
     }
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/sourcesafetyfilter/service/completeStageExecution/SourceSafetyFilterCompletionRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/sourcesafetyfilter/service/completeStageExecution/SourceSafetyFilterCompletionRequest.java
@@ -1,0 +1,15 @@
+package com.marketinghub.oprm.nichocnae.v2.sourcesafetyfilter.service.completeStageExecution;
+
+/** Contrato recebido do executor ao concluir a etapa source-safety-filter do NichoCNAE v2. */
+public record SourceSafetyFilterCompletionRequest(
+        String safetyDecision,
+        Integer allowedUrlCount,
+        Integer rejectedUrlCount,
+        String outputPayload,
+        String nextStageCode) {
+    /** Mantém compatibilidade com chamadas que ainda não enviam a próxima etapa decidida pelo executor. */
+    public SourceSafetyFilterCompletionRequest(
+            String safetyDecision, Integer allowedUrlCount, Integer rejectedUrlCount, String outputPayload) {
+        this(safetyDecision, allowedUrlCount, rejectedUrlCount, outputPayload, null);
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/sourcesafetyfilter/service/completeStageExecution/SourceSafetyFilterCompletionResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/sourcesafetyfilter/service/completeStageExecution/SourceSafetyFilterCompletionResponse.java
@@ -1,0 +1,9 @@
+package com.marketinghub.oprm.nichocnae.v2.sourcesafetyfilter.service.completeStageExecution;
+
+/** Contrato retornado ao executor após registrar a conclusão do filtro de segurança de fontes. */
+public record SourceSafetyFilterCompletionResponse(
+        String stageExecutionId,
+        String status,
+        String nextStageCode,
+        Integer allowedUrlCount,
+        Integer rejectedUrlCount) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/sourcesafetyfilter/service/createStageExecution/SourceSafetyFilterCreateRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/sourcesafetyfilter/service/createStageExecution/SourceSafetyFilterCreateRequest.java
@@ -1,0 +1,12 @@
+package com.marketinghub.oprm.nichocnae.v2.sourcesafetyfilter.service.createStageExecution;
+
+/** Contrato enviado pelo executor para registrar uma pendência da etapa source-safety-filter do NichoCNAE v2. */
+public record SourceSafetyFilterCreateRequest(
+        String jobId,
+        Long researchCycleId,
+        Long sourceNicheId,
+        String cnaeCode,
+        Integer attemptNumber,
+        Integer knowledgeVersion,
+        Boolean materializationEnabled,
+        String inputPayload) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/sourcesafetyfilter/service/createStageExecution/SourceSafetyFilterCreateResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/sourcesafetyfilter/service/createStageExecution/SourceSafetyFilterCreateResponse.java
@@ -1,0 +1,7 @@
+package com.marketinghub.oprm.nichocnae.v2.sourcesafetyfilter.service.createStageExecution;
+
+/** Contrato retornado ao executor após o backend gravar a pendência source-safety-filter solicitada. */
+public record SourceSafetyFilterCreateResponse(
+        String stageExecutionId,
+        String status,
+        String stageCode) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/sourcesafetyfilter/service/failStageExecution/SourceSafetyFilterFailureRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/sourcesafetyfilter/service/failStageExecution/SourceSafetyFilterFailureRequest.java
@@ -1,0 +1,10 @@
+package com.marketinghub.oprm.nichocnae.v2.sourcesafetyfilter.service.failStageExecution;
+
+import com.marketinghub.oprm.nichocnae.v2.OprmNichoCnaeV2FailureType;
+
+/** Contrato recebido do executor ao reportar falha da etapa source-safety-filter do NichoCNAE v2. */
+public record SourceSafetyFilterFailureRequest(
+        OprmNichoCnaeV2FailureType failureType,
+        String errorCode,
+        String errorMessage,
+        String inputPayload) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/sourcesafetyfilter/service/failStageExecution/SourceSafetyFilterFailureResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/sourcesafetyfilter/service/failStageExecution/SourceSafetyFilterFailureResponse.java
@@ -1,0 +1,9 @@
+package com.marketinghub.oprm.nichocnae.v2.sourcesafetyfilter.service.failStageExecution;
+
+/** Contrato retornado ao executor após registrar falha ou retry técnico do filtro de segurança. */
+public record SourceSafetyFilterFailureResponse(
+        String stageExecutionId,
+        String status,
+        String retryStageExecutionId,
+        Integer attemptNumber,
+        Integer technicalRetryNumber) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/sourcesafetyfilter/service/pending/SourceSafetyFilterPendingResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/sourcesafetyfilter/service/pending/SourceSafetyFilterPendingResponse.java
@@ -1,0 +1,12 @@
+package com.marketinghub.oprm.nichocnae.v2.sourcesafetyfilter.service.pending;
+
+/** Contrato de fila interna entregue ao executor para filtrar fontes inseguras do NichoCNAE v2. */
+public record SourceSafetyFilterPendingResponse(
+        String stageExecutionId,
+        String jobId,
+        String cnaeCode,
+        Long sourceNicheId,
+        Integer attemptNumber,
+        Integer technicalRetryNumber,
+        Integer knowledgeVersion,
+        String inputPayload) {}

--- a/backend/ads-service/src/test/java/com/marketinghub/oprm/nichocnae/v2/candidategenerator/service/BackendCandidateGeneratorServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/oprm/nichocnae/v2/candidategenerator/service/BackendCandidateGeneratorServiceTest.java
@@ -161,7 +161,7 @@ class BackendCandidateGeneratorServiceTest {
         assertThat(result.materializationEnabled()).isFalse();
     }
 
-    /** Deve resolver MEI_AUDIENCE_READY + MATERIALIZAR_NICHO para o materializer quando a calibração liberar. */
+    /** Deve apenas persistir a próxima etapa recebida do executor quando a calibração liberar. */
     @Test
     void completeRoutesMeiAudienceReadyMaterializationWhenFlagIsEnabled() {
         BackendCandidateGeneratorService service = service(true, true);
@@ -172,7 +172,7 @@ class BackendCandidateGeneratorServiceTest {
         when(stageExecutionRepository.save(any(OprmNichoCnaeV2StageExecution.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
         CandidateGeneratorCompletionResponse result = service.complete(
-                91L, new CandidateGeneratorCompletionRequest("MEI_AUDIENCE_READY", "MATERIALIZAR_NICHO", "{}"));
+                91L, new CandidateGeneratorCompletionRequest("MEI_AUDIENCE_READY", "MATERIALIZAR_NICHO", "{}", "enriched-niche-materializer"));
 
         assertThat(result.status()).isEqualTo("COMPLETED");
         assertThat(result.nextStageCode()).isEqualTo("enriched-niche-materializer");

--- a/backend/ads-service/src/test/java/com/marketinghub/oprm/nichocnae/v2/sourcesafetyfilter/service/BackendSourceSafetyFilterServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/oprm/nichocnae/v2/sourcesafetyfilter/service/BackendSourceSafetyFilterServiceTest.java
@@ -1,0 +1,148 @@
+package com.marketinghub.oprm.nichocnae.v2.sourcesafetyfilter.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.marketinghub.oprm.nichocnae.v2.OprmNichoCnaeV2FailureType;
+import com.marketinghub.oprm.nichocnae.v2.OprmNichoCnaeV2StageExecution;
+import com.marketinghub.oprm.nichocnae.v2.OprmNichoCnaeV2StageExecutionStatus;
+import com.marketinghub.oprm.nichocnae.v2.sourcesafetyfilter.service.completeStageExecution.SourceSafetyFilterCompletionRequest;
+import com.marketinghub.oprm.nichocnae.v2.sourcesafetyfilter.service.createStageExecution.SourceSafetyFilterCreateRequest;
+import com.marketinghub.oprm.nichocnae.v2.sourcesafetyfilter.service.failStageExecution.SourceSafetyFilterFailureRequest;
+import com.marketinghub.oprm.nichocnae.v2.sourcesafetyfilter.service.pending.SourceSafetyFilterPendingResponse;
+import com.marketinghub.repository.jpa.oprm.nichocnae.v2.OprmNichoCnaeV2StageExecutionRepository;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Pageable;
+
+/** Valida os contratos backend da etapa source-safety-filter do pipeline OPRM NichoCNAE v2. */
+@ExtendWith(MockitoExtension.class)
+class BackendSourceSafetyFilterServiceTest {
+    @Mock private OprmNichoCnaeV2StageExecutionRepository stageExecutionRepository;
+
+    /** Deve manter a etapa 2 sem pendências quando a feature flag da v2 estiver desligada. */
+    @Test
+    void pendingReturnsEmptyWhenFeatureFlagIsDisabled() {
+        BackendSourceSafetyFilterService service = service(false);
+
+        List<SourceSafetyFilterPendingResponse> result = service.pending();
+
+        assertThat(result).isEmpty();
+        verify(stageExecutionRepository, never()).findByStageCodeAndStatusOrderByCreatedAtAsc(any(), any(), any());
+    }
+
+    /** Deve expor pendência da etapa 2 com payload recebido da etapa anterior para filtragem segura. */
+    @Test
+    void pendingReturnsSourceSafetyExecutions() {
+        BackendSourceSafetyFilterService service = service(true);
+        when(stageExecutionRepository.findByStageCodeAndStatusOrderByCreatedAtAsc(
+                        eq("source-safety-filter"), eq(OprmNichoCnaeV2StageExecutionStatus.PENDING), any(Pageable.class)))
+                .thenReturn(List.of(execution(200L)));
+
+        List<SourceSafetyFilterPendingResponse> result = service.pending();
+
+        assertThat(result).hasSize(1);
+        assertThat(result.getFirst().stageExecutionId()).isEqualTo("200");
+        assertThat(result.getFirst().inputPayload()).contains("candidateUrls");
+    }
+
+    /** Deve persistir a próxima etapa recebida do executor sem calcular decisão de negócio no backend. */
+    @Test
+    void completeRoutesToAdaptiveQueryPlannerWhenSafetyAllows() {
+        BackendSourceSafetyFilterService service = service(true);
+        OprmNichoCnaeV2StageExecution execution = execution(201L);
+        when(stageExecutionRepository.findByIdAndStageCode(201L, "source-safety-filter"))
+                .thenReturn(Optional.of(execution));
+        when(stageExecutionRepository.save(any(OprmNichoCnaeV2StageExecution.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        var response = service.complete(
+                201L,
+                new SourceSafetyFilterCompletionRequest(
+                        "ALLOW", 2, 1, "{\"allowedUrls\":[\"https://gov.br/exemplo\"]}", "adaptive-query-planner"));
+
+        assertThat(response.status()).isEqualTo("COMPLETED");
+        assertThat(response.nextStageCode()).isEqualTo("adaptive-query-planner");
+        assertThat(response.allowedUrlCount()).isEqualTo(2);
+        assertThat(response.rejectedUrlCount()).isEqualTo(1);
+    }
+
+    /** Deve gravar pendência da etapa 2 a partir de um comando explícito do executor externo. */
+    @Test
+    void createPersistsPendingExecutionRequestedByExecutor() {
+        BackendSourceSafetyFilterService service = service(true);
+        when(stageExecutionRepository.save(any(OprmNichoCnaeV2StageExecution.class))).thenAnswer(invocation -> {
+            OprmNichoCnaeV2StageExecution saved = invocation.getArgument(0);
+            saved.setId(300L);
+            return saved;
+        });
+
+        var response = service.create(new SourceSafetyFilterCreateRequest(
+                "job-300", 70L, 69L, "9602501", 2, 4, false, "{\"candidateUrls\":[]}"));
+
+        assertThat(response.stageExecutionId()).isEqualTo("300");
+        assertThat(response.status()).isEqualTo("PENDING");
+        assertThat(response.stageCode()).isEqualTo("source-safety-filter");
+    }
+
+    /** Deve preservar retry técnico sem mudar tentativa cognitiva quando a falha da etapa 2 for infraestrutura. */
+    @Test
+    void failCreatesTechnicalRetryForInfrastructureFailure() {
+        BackendSourceSafetyFilterService service = service(true);
+        OprmNichoCnaeV2StageExecution execution = execution(202L);
+        when(stageExecutionRepository.findByIdAndStageCode(202L, "source-safety-filter"))
+                .thenReturn(Optional.of(execution));
+        when(stageExecutionRepository.save(any(OprmNichoCnaeV2StageExecution.class))).thenAnswer(invocation -> {
+            OprmNichoCnaeV2StageExecution saved = invocation.getArgument(0);
+            if (saved.getId() == null) {
+                saved.setId(203L);
+            }
+            return saved;
+        });
+
+        var response = service.fail(
+                202L,
+                new SourceSafetyFilterFailureRequest(
+                        OprmNichoCnaeV2FailureType.INFRASTRUCTURE,
+                        "TIMEOUT",
+                        "timeout lendo fila",
+                        "{}"));
+
+        assertThat(response.status()).isEqualTo("TECHNICAL_RETRY_SCHEDULED");
+        assertThat(response.retryStageExecutionId()).isEqualTo("203");
+        assertThat(response.attemptNumber()).isEqualTo(1);
+        assertThat(response.technicalRetryNumber()).isEqualTo(1);
+    }
+
+    /** Cria o service testável com flag explícita para a v2. */
+    private BackendSourceSafetyFilterService service(boolean v2Enabled) {
+        return new BackendSourceSafetyFilterService(stageExecutionRepository, v2Enabled);
+    }
+
+    /** Monta execução persistida mínima da etapa source-safety-filter. */
+    private OprmNichoCnaeV2StageExecution execution(Long id) {
+        OprmNichoCnaeV2StageExecution execution = new OprmNichoCnaeV2StageExecution();
+        execution.setId(id);
+        execution.setJobId("nichocnae-v2-candidate-69");
+        execution.setSourceNicheId(69L);
+        execution.setCnaeCode("9602501");
+        execution.setStageCode("source-safety-filter");
+        execution.setAttemptNumber(1);
+        execution.setTechnicalRetryNumber(0);
+        execution.setKnowledgeVersion(1);
+        execution.setStatus(OprmNichoCnaeV2StageExecutionStatus.PENDING);
+        execution.setInputPayload("{\"candidateUrls\":[\"https://gov.br/exemplo\",\"https://adult.example/x\"]}");
+        execution.setMaterializationEnabled(false);
+        execution.setCreatedAt(Instant.parse("2026-06-19T10:00:00Z"));
+        execution.setUpdatedAt(Instant.parse("2026-06-19T10:00:00Z"));
+        return execution;
+    }
+}

--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -1022,3 +1022,12 @@
 - Adicionado botão por linha na tela de CNAEs por Score OPRM para abrir a visão da v2 do pipeline no contexto do CNAE selecionado.
 - Criada a tela de design `/oprm/cnaes/:cnaeCode/pipeline-v2` com cards das etapas planejadas da v2, baseada nos planos de melhoria de qualidade, reprocessamento por conhecimento e ordem de implementação OPRM.
 - A tela é informativa e não cria orquestração no frontend; as decisões de execução continuam pertencendo ao backend/executor conforme arquitetura do OPRM.
+
+## 2026-06-19 — Implementação da etapa 2 Source Safety Filter da v2 NichoCNAE
+- Implementada a etapa `source-safety-filter` da v2 NichoCNAE com contratos internos de `pending`, `complete` e `fail` no backend, reaproveitando a tabela versionada de execuções de estágio.
+- Criados contratos de leitura/escrita para permitir que o executor externo solicite e consuma pendências da etapa 2 antes do planejamento adaptativo.
+- Implementado no executor `oprm-coletor-mei` o processor determinístico de segurança, canonicalização, remoção de tracking, deduplicação e hard blocklist de domínios/categorias proibidas.
+
+## 2026-06-19 — Correção leitura/escrita da etapa 2 Source Safety Filter
+- Revisada a implementação da etapa `source-safety-filter` para manter o backend como camada de leitura/escrita: a decisão de próxima etapa passou a vir no callback do executor, e o backend deixou de calcular transição por `safetyDecision`.
+- Removida a criação automática de pendência da etapa 2 dentro da conclusão do `candidate-generator`; o executor externo passa a solicitar explicitamente a gravação da pendência pelo contrato de escrita da etapa 2.

--- a/docs/swagger/oprm-nichocnae-v2-source-safety-filter-swagger.yaml
+++ b/docs/swagger/oprm-nichocnae-v2-source-safety-filter-swagger.yaml
@@ -1,0 +1,43 @@
+openapi: 3.0.3
+info:
+  title: OPRM NichoCNAE v2 Source Safety Filter API
+  version: "1.0"
+paths:
+  /api/internal/oprm/nichocnae/v2/source-safety-filter/stage-executions/pending:
+    get:
+      summary: Lista execuções pendentes da etapa source-safety-filter v2
+      responses:
+        "200":
+          description: Pendências disponíveis para o executor OPRM filtrar URLs candidatas
+  /api/internal/oprm/nichocnae/v2/source-safety-filter/stage-executions:
+    post:
+      summary: Grava pendência da etapa source-safety-filter v2 solicitada pelo executor
+      responses:
+        "200":
+          description: Pendência gravada para consumo pelo endpoint pending
+  /api/internal/oprm/nichocnae/v2/source-safety-filter/stage-executions/{stageExecutionId}/complete:
+    post:
+      summary: Registra conclusão de execução da etapa source-safety-filter v2
+      parameters:
+        - name: stageExecutionId
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        "200":
+          description: Conclusão registrada com decisão de segurança e próxima etapa
+  /api/internal/oprm/nichocnae/v2/source-safety-filter/stage-executions/{stageExecutionId}/fail:
+    post:
+      summary: Registra falha e retry técnico da etapa source-safety-filter v2
+      parameters:
+        - name: stageExecutionId
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        "200":
+          description: Falha registrada

--- a/frontend/src/pages/oprm/OprmNichoCnaeV2PipelinePage.tsx
+++ b/frontend/src/pages/oprm/OprmNichoCnaeV2PipelinePage.tsx
@@ -11,12 +11,13 @@ const v2Stages = [
       "Gerar candidatos neutros de subnicho sem contaminar nome, dor, canal ou promessa antes da evidência.",
     output:
       "4 a 6 candidatos comparáveis, com identidade do executor, job operacional e hipóteses separadas.",
-    businessGate: "Nenhum vencedor obrigatório quando não houver candidato viável.",
+    businessGate:
+      "Nenhum vencedor obrigatório quando não houver candidato viável.",
   },
   {
     number: 2,
     title: "Source Safety Filter",
-    status: "Design",
+    status: "Design aprovado · implementação inicial",
     purpose:
       "Bloquear domínios inseguros, conteúdo inadequado e resultados fora do contexto antes de gastar IA.",
     output: "Lista segura e deduplicada de URLs candidatas para pesquisa.",
@@ -28,8 +29,10 @@ const v2Stages = [
     status: "Design",
     purpose:
       "Planejar buscas pelos gaps reais de conhecimento, reaproveitando queries, fontes e falhas anteriores.",
-    output: "Plano de pesquisa curto, natural e orientado a lacunas de evidência.",
-    businessGate: "A pesquisa aprofunda apenas o que pode mudar a decisão comercial.",
+    output:
+      "Plano de pesquisa curto, natural e orientado a lacunas de evidência.",
+    businessGate:
+      "A pesquisa aprofunda apenas o que pode mudar a decisão comercial.",
   },
   {
     number: 4,
@@ -38,7 +41,8 @@ const v2Stages = [
     purpose:
       "Comparar candidatos por densidade e qualidade de evidências antes de escolher finalistas.",
     output: "Até dois finalistas ou decisão NO_VIABLE_SUBNICHE.",
-    businessGate: "O vencedor nasce de evidência observada, não de opinião prévia do modelo.",
+    businessGate:
+      "O vencedor nasce de evidência observada, não de opinião prévia do modelo.",
   },
   {
     number: 5,
@@ -46,8 +50,10 @@ const v2Stages = [
     status: "Design",
     purpose:
       "Coletar páginas úteis e priorizar fontes diretas, independentes e alinhadas ao objetivo do gate.",
-    output: "Snapshots rastreáveis com origem, trecho curto, metadados e custo.",
-    businessGate: "Fonte adjacente não substitui prova direta do executor específico.",
+    output:
+      "Snapshots rastreáveis com origem, trecho curto, metadados e custo.",
+    businessGate:
+      "Fonte adjacente não substitui prova direta do executor específico.",
   },
   {
     number: 6,
@@ -55,7 +61,8 @@ const v2Stages = [
     status: "Design aprovado · implementação parcial",
     purpose:
       "Extrair claims somente quando houver trecho exato, ator correto, contexto compatível e relação sustentada.",
-    output: "Claims auditáveis com trecho literal, fonte e diagnóstico semântico.",
+    output:
+      "Claims auditáveis com trecho literal, fonte e diagnóstico semântico.",
     businessGate: "Nenhum claim sem trecho exato pode avançar para síntese.",
   },
   {
@@ -64,7 +71,8 @@ const v2Stages = [
     status: "Design",
     purpose:
       "Validar se o trecho realmente sustenta a afirmação sobre o executor e o contexto pesquisado.",
-    output: "Claims aprovados, rejeitados, contraditórios ou pendentes por nível de evidência.",
+    output:
+      "Claims aprovados, rejeitados, contraditórios ou pendentes por nível de evidência.",
     businessGate: "Proximidade lexical não é prova de mercado.",
   },
   {
@@ -73,8 +81,10 @@ const v2Stages = [
     status: "Design aprovado · implementação parcial",
     purpose:
       "Consolidar conhecimento versionado do ciclo, preservando fontes aceitas, rejeições, gaps e aprendizados.",
-    output: "Snapshot de conhecimento com versão, linhagem e lacunas acionáveis.",
-    businessGate: "Reprocessar sem repetir erro, fonte rejeitada ou custo desnecessário.",
+    output:
+      "Snapshot de conhecimento com versão, linhagem e lacunas acionáveis.",
+    businessGate:
+      "Reprocessar sem repetir erro, fonte rejeitada ou custo desnecessário.",
   },
   {
     number: 9,
@@ -82,8 +92,10 @@ const v2Stages = [
     status: "Design aprovado · implementação parcial",
     purpose:
       "Decidir o menor rewind necessário quando um gate falhar por qualidade, mantendo o mesmo job quando aplicável.",
-    output: "Retry técnico ou reprocessamento cognitivo com motivo, estágio de retorno e versão de conhecimento.",
-    businessGate: "Falha técnica não vira reprovação de mercado; falta de evidência não reinicia tudo.",
+    output:
+      "Retry técnico ou reprocessamento cognitivo com motivo, estágio de retorno e versão de conhecimento.",
+    businessGate:
+      "Falha técnica não vira reprovação de mercado; falta de evidência não reinicia tudo.",
   },
   {
     number: 10,
@@ -100,8 +112,10 @@ const v2Stages = [
     status: "Design",
     purpose:
       "Separar existência da atividade, dor prática, impacto econômico e intenção de compra por nível de evidência.",
-    output: "Nível E0 a E5, confiança explicável, motivos de reprovação e próximos movimentos.",
-    businessGate: "Materialização automática só avança com evidência comercial mínima.",
+    output:
+      "Nível E0 a E5, confiança explicável, motivos de reprovação e próximos movimentos.",
+    businessGate:
+      "Materialização automática só avança com evidência comercial mínima.",
   },
   {
     number: 12,
@@ -109,7 +123,8 @@ const v2Stages = [
     status: "Bloqueado por feature flag",
     purpose:
       "Materializar o nicho enriquecido somente depois dos gates de evidência, qualidade e segurança.",
-    output: "Nicho pronto para decisão de produto: executor, dor, resultado, mecanismo plausível e fontes.",
+    output:
+      "Nicho pronto para decisão de produto: executor, dor, resultado, mecanismo plausível e fontes.",
     businessGate: "A v2 calibra antes de publicar automaticamente para vendas.",
   },
 ];
@@ -143,11 +158,14 @@ export default function OprmNichoCnaeV2PipelinePage() {
           <div className="d-flex flex-wrap justify-content-between gap-3">
             <div>
               <h2 className="h5 mb-1">
-                {decodedCnaeCode ? `CNAE ${decodedCnaeCode}` : "Visão geral da v2"}
+                {decodedCnaeCode
+                  ? `CNAE ${decodedCnaeCode}`
+                  : "Visão geral da v2"}
               </h2>
               <p className="text-secondary mb-0">
                 A tela é um mapa de produto: mostra a sequência planejada mesmo
-                quando uma etapa ainda está em design ou protegida por feature flag.
+                quando uma etapa ainda está em design ou protegida por feature
+                flag.
               </p>
             </div>
             <span className="badge text-bg-primary align-self-start">

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnaev2/pipeline/sourcesafetyfilter/SourceSafetyFilterProcessor.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnaev2/pipeline/sourcesafetyfilter/SourceSafetyFilterProcessor.java
@@ -1,0 +1,147 @@
+package com.marketinghub.nichocnaev2.pipeline.sourcesafetyfilter;
+
+import com.marketinghub.nichocnaev2.pipeline.StageArtifact;
+import com.marketinghub.nichocnaev2.pipeline.StageContext;
+import com.marketinghub.nichocnaev2.pipeline.StageProcessor;
+import com.marketinghub.nichocnaev2.pipeline.StageResult;
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+
+/** Executa o filtro plugável de segurança e canonicalização de URLs candidatas do NichoCNAE versão 2. */
+public final class SourceSafetyFilterProcessor implements StageProcessor {
+    private static final Set<String> HARD_BLOCKED_HOST_FRAGMENTS = Set.of(
+            "adult", "porn", "casino", "bet", "torrent", "warez", "malware", "phishing", "xxx");
+    private static final Set<String> TRACKING_QUERY_PREFIXES = Set.of("utm_", "fbclid", "gclid", "msclkid");
+
+    /** Filtra URLs inseguras, deduplica canônicos e devolve somente metadados das rejeições. */
+    @Override
+    public StageResult process(StageContext context) {
+        List<String> rawUrls = extractCandidateUrls(context.input());
+        List<Map<String, Object>> allowedUrls = new ArrayList<>();
+        List<Map<String, Object>> rejectedUrls = new ArrayList<>();
+        Set<String> seenCanonicalUrls = new LinkedHashSet<>();
+        for (String rawUrl : rawUrls) {
+            SafetyDecision decision = classify(rawUrl);
+            if (!decision.allowed()) {
+                rejectedUrls.add(rejection(rawUrl, decision.category(), decision.reason()));
+                continue;
+            }
+            if (!seenCanonicalUrls.add(decision.canonicalUrl())) {
+                rejectedUrls.add(rejection(rawUrl, "DUPLICATE", "URL canônica já havia sido aceita nesta execução."));
+                continue;
+            }
+            allowedUrls.add(allowed(decision.canonicalUrl(), decision.host()));
+        }
+        String safetyDecision = rejectedUrls.size() == rawUrls.size() && !rawUrls.isEmpty() ? "HARD_REJECT" : "ALLOW";
+        Map<String, Object> output = new LinkedHashMap<>();
+        output.put("stage", "source-safety-filter");
+        output.put("safetyDecision", safetyDecision);
+        output.put("allowedUrlCount", allowedUrls.size());
+        output.put("rejectedUrlCount", rejectedUrls.size());
+        output.put("allowedUrls", allowedUrls);
+        output.put("rejectedSources", rejectedUrls);
+        return new StageResult(safetyDecision, output, List.of(new StageArtifact(
+                "SAFETY_SUMMARY", "inline://source-safety-filter/summary", "Resumo auditável sem persistir conteúdo bloqueado.")));
+    }
+
+    /** Extrai URLs candidatas aceitando contratos simples de entrada sem acoplar a etapa anterior. */
+    private List<String> extractCandidateUrls(Map<String, Object> input) {
+        Object candidateUrls = input.get("candidateUrls");
+        if (!(candidateUrls instanceof List<?> values)) {
+            candidateUrls = input.get("urls");
+        }
+        if (!(candidateUrls instanceof List<?> values)) {
+            return List.of();
+        }
+        return values.stream().filter(String.class::isInstance).map(String.class::cast).toList();
+    }
+
+    /** Classifica uma URL bruta usando hard blocklist local e regras determinísticas de canonicalização. */
+    private SafetyDecision classify(String rawUrl) {
+        if (rawUrl == null || rawUrl.isBlank()) {
+            return SafetyDecision.rejected("INVALID_URL", "URL vazia não pode entrar no pipeline.");
+        }
+        URI uri;
+        try {
+            uri = URI.create(rawUrl.trim());
+        } catch (IllegalArgumentException ex) {
+            return SafetyDecision.rejected("INVALID_URL", "URL inválida não pode entrar no pipeline.");
+        }
+        String scheme = uri.getScheme() == null ? "" : uri.getScheme().toLowerCase(Locale.ROOT);
+        String host = uri.getHost() == null ? "" : uri.getHost().toLowerCase(Locale.ROOT);
+        if (!"http".equals(scheme) && !"https".equals(scheme)) {
+            return SafetyDecision.rejected("UNSUPPORTED_SCHEME", "Somente HTTP e HTTPS são permitidos para coleta pública.");
+        }
+        if (host.isBlank()) {
+            return SafetyDecision.rejected("INVALID_DOMAIN", "Domínio ausente não pode ser auditado.");
+        }
+        if (HARD_BLOCKED_HOST_FRAGMENTS.stream().anyMatch(host::contains)) {
+            return SafetyDecision.rejected("HARD_BLOCKED_DOMAIN", "Domínio bloqueado por categoria proibida.");
+        }
+        return SafetyDecision.allowed(canonicalize(uri, scheme, host), host);
+    }
+
+    /** Remove fragmentos e parâmetros de rastreamento para deduplicar a página real. */
+    private String canonicalize(URI uri, String scheme, String host) {
+        String path = uri.getRawPath() == null || uri.getRawPath().isBlank() ? "/" : uri.getRawPath();
+        String query = canonicalQuery(uri.getRawQuery());
+        return scheme + "://" + host + path + (query.isBlank() ? "" : "?" + query);
+    }
+
+    /** Mantém apenas parâmetros funcionais, removendo tracking conhecido. */
+    private String canonicalQuery(String rawQuery) {
+        if (rawQuery == null || rawQuery.isBlank()) {
+            return "";
+        }
+        List<String> kept = new ArrayList<>();
+        for (String parameter : rawQuery.split("&")) {
+            String key = parameter.contains("=") ? parameter.substring(0, parameter.indexOf('=')) : parameter;
+            String normalizedKey = key.toLowerCase(Locale.ROOT);
+            boolean tracking = TRACKING_QUERY_PREFIXES.stream().anyMatch(normalizedKey::startsWith);
+            if (!tracking) {
+                kept.add(parameter);
+            }
+        }
+        return String.join("&", kept);
+    }
+
+    /** Monta o item aceito sem conteúdo textual da página. */
+    private Map<String, Object> allowed(String canonicalUrl, String host) {
+        Map<String, Object> item = new LinkedHashMap<>();
+        item.put("canonicalUrl", canonicalUrl);
+        item.put("domain", host);
+        item.put("safetyDecision", "ALLOW");
+        item.put("persistContent", true);
+        return item;
+    }
+
+    /** Monta rejeição persistindo só categoria e motivo, sem snippet de conteúdo bloqueado. */
+    private Map<String, Object> rejection(String rawUrl, String category, String reason) {
+        Map<String, Object> item = new LinkedHashMap<>();
+        item.put("urlFingerprint", Integer.toHexString(String.valueOf(rawUrl).hashCode()));
+        item.put("safetyCategory", category);
+        item.put("decision", "HARD_REJECT");
+        item.put("persistContent", false);
+        item.put("reason", reason);
+        return item;
+    }
+
+    /** Representa a classificação determinística de segurança de uma URL candidata. */
+    private record SafetyDecision(boolean allowed, String canonicalUrl, String host, String category, String reason) {
+        /** Cria decisão de aceitação com URL canônica. */
+        private static SafetyDecision allowed(String canonicalUrl, String host) {
+            return new SafetyDecision(true, canonicalUrl, host, "ALLOW", "Fonte permitida.");
+        }
+
+        /** Cria decisão de rejeição sem preservar conteúdo sensível. */
+        private static SafetyDecision rejected(String category, String reason) {
+            return new SafetyDecision(false, null, null, category, reason);
+        }
+    }
+}

--- a/oprm-coletor-mei/src/test/java/com/marketinghub/nichocnaev2/pipeline/sourcesafetyfilter/SourceSafetyFilterProcessorTest.java
+++ b/oprm-coletor-mei/src/test/java/com/marketinghub/nichocnaev2/pipeline/sourcesafetyfilter/SourceSafetyFilterProcessorTest.java
@@ -1,0 +1,49 @@
+package com.marketinghub.nichocnaev2.pipeline.sourcesafetyfilter;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.marketinghub.nichocnaev2.pipeline.StageContext;
+import com.marketinghub.nichocnaev2.pipeline.StageResult;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/** Valida o filtro determinístico de segurança da etapa 2 do pipeline NichoCNAE v2. */
+class SourceSafetyFilterProcessorTest {
+    /** Deve bloquear domínio proibido, remover tracking e deduplicar URL canônica antes de qualquer fetch. */
+    @Test
+    void filtersBlockedDomainsTrackingParametersAndDuplicateCanonicalUrls() {
+        SourceSafetyFilterProcessor processor = new SourceSafetyFilterProcessor();
+        StageContext context = new StageContext(
+                "job-1",
+                "stage-2",
+                Map.of("candidateUrls", List.of(
+                        "https://www.gov.br/mei/rotina?utm_source=ads&id=10#x",
+                        "https://www.gov.br/mei/rotina?id=10",
+                        "https://adult.example/oferta")));
+
+        StageResult result = processor.process(context);
+
+        assertThat(result.status()).isEqualTo("ALLOW");
+        assertThat(result.output().get("allowedUrlCount")).isEqualTo(1);
+        assertThat(result.output().get("rejectedUrlCount")).isEqualTo(2);
+        assertThat(result.output().toString()).contains("https://www.gov.br/mei/rotina?id=10");
+        assertThat(result.output().toString()).contains("HARD_BLOCKED_DOMAIN", "DUPLICATE");
+    }
+
+    /** Deve registrar hard reject global quando todas as URLs candidatas forem inseguras. */
+    @Test
+    void returnsHardRejectWhenEveryCandidateUrlIsUnsafe() {
+        SourceSafetyFilterProcessor processor = new SourceSafetyFilterProcessor();
+        StageContext context = new StageContext(
+                "job-1",
+                "stage-2",
+                Map.of("candidateUrls", List.of("ftp://example.com/file", "https://casino.example/aposta")));
+
+        StageResult result = processor.process(context);
+
+        assertThat(result.status()).isEqualTo("HARD_REJECT");
+        assertThat(result.output().get("allowedUrlCount")).isEqualTo(0);
+        assertThat(result.output().get("rejectedUrlCount")).isEqualTo(2);
+    }
+}


### PR DESCRIPTION
### Motivation
- Introduzir a etapa 2 `source-safety-filter` na v2 do pipeline NichoCNAE com contratos de leitura/escrita para que o executor externo controle gravação e decisão operacional. 
- Remover lógica operacional de transição automática do backend no `candidate-generator` para manter o backend como camada canônica de leitura/escrita e delegar decisões de fluxo ao executor.
- Fornecer um processor determinístico no executor para segurança, canonicalização e deduplicação de URLs antes de fetchs custosos.

### Description
- Adiciona backend HTTP e service canônicos para a etapa `source-safety-filter`: `BackendSourceSafetyFilterController`, `BackendSourceSafetyFilterService` e os contratos `pending`, `create`, `complete` e `fail` (DTOs e responses). 
- Atualiza `BackendCandidateGeneratorService` para parar de calcular a próxima etapa internamente e passar a persistir `nextStageCode` recebido no `CandidateGeneratorCompletionRequest`, removendo constantes e função `resolveNextStage`. 
- Extende `CandidateGeneratorCompletionRequest` e introduz compatível construtor para manter compatibilidade com executores antigos; incluiu `nextStageCode` no contrato. 
- Implementa `SourceSafetyFilterProcessor` no executor `oprm-coletor-mei` com regras determinísticas de hard blocklist por domínio, remoção de parâmetros de tracking, canonicalização e deduplicação, além de produzir um resumo auditável (`SAFETY_SUMMARY`). 
- Atualiza frontend (`OprmNichoCnaeV2PipelinePage.tsx`), documentação (`docs/registros/oprm1.md`) e adiciona OpenAPI spec (`docs/swagger/oprm-nichocnae-v2-source-safety-filter-swagger.yaml`) para refletir a nova etapa e as mudanças operacionais.

### Testing
- Unit tests updated and added: `BackendCandidateGeneratorServiceTest` (updated to assert `nextStageCode` is persisted), `BackendSourceSafetyFilterServiceTest` (new), and `SourceSafetyFilterProcessorTest` (new) were executed and passed. 
- New service and processor tests validate pending listing, create/complete/fail flows and deterministic URL filtering including blocking, tracking removal and deduplication, and all assertions succeeded. 
- Full module unit test suites were run locally as part of the change verification and completed without failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3533cb628083218509010a6cbcc143)