### PR TITLE
Implementa etapa 3 do pipeline NichoCNAE v2 (Adaptive Query Planner)

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/adaptivequeryplanner/controller/BackendAdaptiveQueryPlannerController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/adaptivequeryplanner/controller/BackendAdaptiveQueryPlannerController.java
@@ -1,0 +1,55 @@
+package com.marketinghub.oprm.nichocnae.v2.adaptivequeryplanner.controller;
+
+import com.marketinghub.oprm.nichocnae.v2.adaptivequeryplanner.service.BackendAdaptiveQueryPlannerService;
+import com.marketinghub.oprm.nichocnae.v2.adaptivequeryplanner.service.completeStageExecution.AdaptiveQueryPlannerCompletionRequest;
+import com.marketinghub.oprm.nichocnae.v2.adaptivequeryplanner.service.completeStageExecution.AdaptiveQueryPlannerCompletionResponse;
+import com.marketinghub.oprm.nichocnae.v2.adaptivequeryplanner.service.createStageExecution.AdaptiveQueryPlannerCreateRequest;
+import com.marketinghub.oprm.nichocnae.v2.adaptivequeryplanner.service.createStageExecution.AdaptiveQueryPlannerCreateResponse;
+import com.marketinghub.oprm.nichocnae.v2.adaptivequeryplanner.service.failStageExecution.AdaptiveQueryPlannerFailureRequest;
+import com.marketinghub.oprm.nichocnae.v2.adaptivequeryplanner.service.failStageExecution.AdaptiveQueryPlannerFailureResponse;
+import com.marketinghub.oprm.nichocnae.v2.adaptivequeryplanner.service.pending.AdaptiveQueryPlannerPendingResponse;
+import java.util.List;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/** Borda HTTP interna da etapa adaptive-query-planner do pipeline NichoCNAE versão 2. */
+@RestController
+@RequestMapping("/api/internal/oprm/nichocnae/v2/adaptive-query-planner/stage-executions")
+public class BackendAdaptiveQueryPlannerController {
+    private final BackendAdaptiveQueryPlannerService service;
+
+    /** Recebe o service canônico da etapa para delegar operações HTTP internas. */
+    public BackendAdaptiveQueryPlannerController(BackendAdaptiveQueryPlannerService service) {
+        this.service = service;
+    }
+
+    /** Entrega execuções pendentes da etapa adaptive-query-planner ao módulo executor OPRM. */
+    @GetMapping("/pending")
+    public List<AdaptiveQueryPlannerPendingResponse> pending() {
+        return service.pending();
+    }
+
+    /** Grava uma pendência da etapa adaptive-query-planner solicitada pelo módulo executor OPRM. */
+    @PostMapping
+    public AdaptiveQueryPlannerCreateResponse create(@RequestBody AdaptiveQueryPlannerCreateRequest request) {
+        return service.create(request);
+    }
+
+    /** Registra a conclusão da execução de planejamento informada pelo módulo executor OPRM. */
+    @PostMapping("/{stageExecutionId}/complete")
+    public AdaptiveQueryPlannerCompletionResponse complete(
+            @PathVariable Long stageExecutionId, @RequestBody AdaptiveQueryPlannerCompletionRequest request) {
+        return service.complete(stageExecutionId, request);
+    }
+
+    /** Registra a falha da execução de planejamento informada pelo módulo executor OPRM. */
+    @PostMapping("/{stageExecutionId}/fail")
+    public AdaptiveQueryPlannerFailureResponse fail(
+            @PathVariable Long stageExecutionId, @RequestBody AdaptiveQueryPlannerFailureRequest request) {
+        return service.fail(stageExecutionId, request);
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/adaptivequeryplanner/service/BackendAdaptiveQueryPlannerService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/adaptivequeryplanner/service/BackendAdaptiveQueryPlannerService.java
@@ -1,0 +1,168 @@
+package com.marketinghub.oprm.nichocnae.v2.adaptivequeryplanner.service;
+
+import com.marketinghub.oprm.nichocnae.v2.OprmNichoCnaeV2FailureType;
+import com.marketinghub.oprm.nichocnae.v2.OprmNichoCnaeV2StageExecution;
+import com.marketinghub.oprm.nichocnae.v2.OprmNichoCnaeV2StageExecutionStatus;
+import com.marketinghub.oprm.nichocnae.v2.adaptivequeryplanner.service.completeStageExecution.AdaptiveQueryPlannerCompletionRequest;
+import com.marketinghub.oprm.nichocnae.v2.adaptivequeryplanner.service.completeStageExecution.AdaptiveQueryPlannerCompletionResponse;
+import com.marketinghub.oprm.nichocnae.v2.adaptivequeryplanner.service.createStageExecution.AdaptiveQueryPlannerCreateRequest;
+import com.marketinghub.oprm.nichocnae.v2.adaptivequeryplanner.service.createStageExecution.AdaptiveQueryPlannerCreateResponse;
+import com.marketinghub.oprm.nichocnae.v2.adaptivequeryplanner.service.failStageExecution.AdaptiveQueryPlannerFailureRequest;
+import com.marketinghub.oprm.nichocnae.v2.adaptivequeryplanner.service.failStageExecution.AdaptiveQueryPlannerFailureResponse;
+import com.marketinghub.oprm.nichocnae.v2.adaptivequeryplanner.service.pending.AdaptiveQueryPlannerPendingResponse;
+import com.marketinghub.repository.jpa.oprm.nichocnae.v2.OprmNichoCnaeV2StageExecutionRepository;
+import java.time.Instant;
+import java.util.List;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+/** Expõe contratos de leitura/escrita do backend para a etapa adaptive-query-planner do pipeline NichoCNAE v2. */
+@Service
+public class BackendAdaptiveQueryPlannerService {
+    public static final String STAGE_CODE = "adaptive-query-planner";
+    private final OprmNichoCnaeV2StageExecutionRepository stageExecutionRepository;
+    private final boolean v2Enabled;
+
+    /** Inicializa o service com repositório canônico e feature flag de calibração da v2. */
+    public BackendAdaptiveQueryPlannerService(
+            OprmNichoCnaeV2StageExecutionRepository stageExecutionRepository,
+            @Value("${oprm.nichocnae.v2.enabled:false}") boolean v2Enabled) {
+        this.stageExecutionRepository = stageExecutionRepository;
+        this.v2Enabled = v2Enabled;
+    }
+
+    /** Lista pendências disponíveis para consumo canônico pelo executor OPRM NichoCNAE v2. */
+    @Transactional(readOnly = true)
+    public List<AdaptiveQueryPlannerPendingResponse> pending() {
+        if (!v2Enabled) {
+            return List.of();
+        }
+        return stageExecutionRepository
+                .findByStageCodeAndStatusOrderByCreatedAtAsc(
+                        STAGE_CODE, OprmNichoCnaeV2StageExecutionStatus.PENDING, PageRequest.of(0, 5))
+                .stream()
+                .map(this::toPendingResponse)
+                .toList();
+    }
+
+    /** Registra conclusão do planejamento usando a próxima etapa informada pelo executor externo. */
+    @Transactional
+    public AdaptiveQueryPlannerCompletionResponse complete(
+            Long stageExecutionId, AdaptiveQueryPlannerCompletionRequest request) {
+        OprmNichoCnaeV2StageExecution execution = findExecution(stageExecutionId);
+        execution.setStatus(OprmNichoCnaeV2StageExecutionStatus.COMPLETED);
+        execution.setOutputPayload(request == null ? null : request.outputPayload());
+        execution.setNextStageCode(request == null ? null : request.nextStageCode());
+        execution.setUpdatedAt(Instant.now());
+        OprmNichoCnaeV2StageExecution saved = stageExecutionRepository.save(execution);
+        return new AdaptiveQueryPlannerCompletionResponse(
+                String.valueOf(saved.getId()),
+                saved.getStatus().name(),
+                saved.getNextStageCode(),
+                request == null ? null : request.plannedQueryCount(),
+                request == null ? null : request.reusedQueryCount(),
+                request == null ? null : request.skippedQueryCount());
+    }
+
+    /** Registra falha e cria nova execução somente quando a falha for retry técnico de infraestrutura. */
+    @Transactional
+    public AdaptiveQueryPlannerFailureResponse fail(Long stageExecutionId, AdaptiveQueryPlannerFailureRequest request) {
+        OprmNichoCnaeV2StageExecution execution = findExecution(stageExecutionId);
+        OprmNichoCnaeV2FailureType failureType = request == null || request.failureType() == null
+                ? OprmNichoCnaeV2FailureType.VALIDATION
+                : request.failureType();
+        execution.setFailureType(failureType);
+        execution.setErrorMessage(request == null ? null : request.errorMessage());
+        execution.setInputPayload(request == null ? execution.getInputPayload() : request.inputPayload());
+        execution.setUpdatedAt(Instant.now());
+        if (failureType == OprmNichoCnaeV2FailureType.INFRASTRUCTURE) {
+            execution.setStatus(OprmNichoCnaeV2StageExecutionStatus.TECHNICAL_RETRY_SCHEDULED);
+            OprmNichoCnaeV2StageExecution retry = createTechnicalRetry(execution);
+            stageExecutionRepository.save(execution);
+            OprmNichoCnaeV2StageExecution savedRetry = stageExecutionRepository.save(retry);
+            return new AdaptiveQueryPlannerFailureResponse(
+                    String.valueOf(execution.getId()),
+                    execution.getStatus().name(),
+                    String.valueOf(savedRetry.getId()),
+                    savedRetry.getAttemptNumber(),
+                    savedRetry.getTechnicalRetryNumber());
+        }
+        execution.setStatus(OprmNichoCnaeV2StageExecutionStatus.FAILED);
+        OprmNichoCnaeV2StageExecution saved = stageExecutionRepository.save(execution);
+        return new AdaptiveQueryPlannerFailureResponse(
+                String.valueOf(saved.getId()),
+                saved.getStatus().name(),
+                null,
+                saved.getAttemptNumber(),
+                saved.getTechnicalRetryNumber());
+    }
+
+    /** Grava uma pendência da etapa de planejamento solicitada pelo executor externo. */
+    @Transactional
+    public AdaptiveQueryPlannerCreateResponse create(AdaptiveQueryPlannerCreateRequest request) {
+        OprmNichoCnaeV2StageExecution saved = stageExecutionRepository.save(toPendingExecution(request));
+        return new AdaptiveQueryPlannerCreateResponse(
+                String.valueOf(saved.getId()), saved.getStatus().name(), saved.getStageCode());
+    }
+
+    /** Converte o contrato recebido do executor em entidade persistível, sem decidir regra operacional. */
+    private OprmNichoCnaeV2StageExecution toPendingExecution(AdaptiveQueryPlannerCreateRequest request) {
+        Instant now = Instant.now();
+        OprmNichoCnaeV2StageExecution execution = new OprmNichoCnaeV2StageExecution();
+        execution.setJobId(request.jobId());
+        execution.setResearchCycleId(request.researchCycleId());
+        execution.setSourceNicheId(request.sourceNicheId());
+        execution.setCnaeCode(request.cnaeCode());
+        execution.setStageCode(STAGE_CODE);
+        execution.setAttemptNumber(request.attemptNumber());
+        execution.setTechnicalRetryNumber(0);
+        execution.setKnowledgeVersion(request.knowledgeVersion());
+        execution.setStatus(OprmNichoCnaeV2StageExecutionStatus.PENDING);
+        execution.setInputPayload(request.inputPayload());
+        execution.setMaterializationEnabled(Boolean.TRUE.equals(request.materializationEnabled()));
+        execution.setCreatedAt(now);
+        execution.setUpdatedAt(now);
+        return execution;
+    }
+
+    /** Cria uma nova linha para retry técnico preservando a tentativa cognitiva e a versão de conhecimento. */
+    private OprmNichoCnaeV2StageExecution createTechnicalRetry(OprmNichoCnaeV2StageExecution previousExecution) {
+        OprmNichoCnaeV2StageExecution retry = toPendingExecution(new AdaptiveQueryPlannerCreateRequest(
+                previousExecution.getJobId(),
+                previousExecution.getResearchCycleId(),
+                previousExecution.getSourceNicheId(),
+                previousExecution.getCnaeCode(),
+                previousExecution.getAttemptNumber(),
+                previousExecution.getKnowledgeVersion(),
+                previousExecution.getMaterializationEnabled(),
+                previousExecution.getInputPayload()));
+        retry.setTechnicalRetryNumber(previousExecution.getTechnicalRetryNumber() + 1);
+        return retry;
+    }
+
+    /** Carrega a execução da etapa atual ou devolve erro HTTP claro ao executor. */
+    private OprmNichoCnaeV2StageExecution findExecution(Long stageExecutionId) {
+        return stageExecutionRepository
+                .findByIdAndStageCode(stageExecutionId, STAGE_CODE)
+                .orElseThrow(() -> new ResponseStatusException(
+                        HttpStatus.NOT_FOUND,
+                        "NichoCNAE v2 adaptive-query-planner stage execution not found: " + stageExecutionId));
+    }
+
+    /** Converte a entidade persistida no contrato canônico de pending do executor. */
+    private AdaptiveQueryPlannerPendingResponse toPendingResponse(OprmNichoCnaeV2StageExecution execution) {
+        return new AdaptiveQueryPlannerPendingResponse(
+                String.valueOf(execution.getId()),
+                execution.getJobId(),
+                execution.getCnaeCode(),
+                execution.getSourceNicheId(),
+                execution.getAttemptNumber(),
+                execution.getTechnicalRetryNumber(),
+                execution.getKnowledgeVersion(),
+                execution.getInputPayload());
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/adaptivequeryplanner/service/completeStageExecution/AdaptiveQueryPlannerCompletionRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/adaptivequeryplanner/service/completeStageExecution/AdaptiveQueryPlannerCompletionRequest.java
@@ -1,0 +1,10 @@
+package com.marketinghub.oprm.nichocnae.v2.adaptivequeryplanner.service.completeStageExecution;
+
+/** Contrato recebido do executor ao concluir a etapa adaptive-query-planner do NichoCNAE v2. */
+public record AdaptiveQueryPlannerCompletionRequest(
+        String planDecision,
+        Integer plannedQueryCount,
+        Integer reusedQueryCount,
+        Integer skippedQueryCount,
+        String outputPayload,
+        String nextStageCode) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/adaptivequeryplanner/service/completeStageExecution/AdaptiveQueryPlannerCompletionResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/adaptivequeryplanner/service/completeStageExecution/AdaptiveQueryPlannerCompletionResponse.java
@@ -1,0 +1,10 @@
+package com.marketinghub.oprm.nichocnae.v2.adaptivequeryplanner.service.completeStageExecution;
+
+/** Contrato devolvido após o backend registrar a conclusão adaptive-query-planner do NichoCNAE v2. */
+public record AdaptiveQueryPlannerCompletionResponse(
+        String stageExecutionId,
+        String status,
+        String nextStageCode,
+        Integer plannedQueryCount,
+        Integer reusedQueryCount,
+        Integer skippedQueryCount) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/adaptivequeryplanner/service/createStageExecution/AdaptiveQueryPlannerCreateRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/adaptivequeryplanner/service/createStageExecution/AdaptiveQueryPlannerCreateRequest.java
@@ -1,0 +1,12 @@
+package com.marketinghub.oprm.nichocnae.v2.adaptivequeryplanner.service.createStageExecution;
+
+/** Contrato enviado pelo executor para registrar uma pendência da etapa adaptive-query-planner do NichoCNAE v2. */
+public record AdaptiveQueryPlannerCreateRequest(
+        String jobId,
+        Long researchCycleId,
+        Long sourceNicheId,
+        String cnaeCode,
+        Integer attemptNumber,
+        Integer knowledgeVersion,
+        Boolean materializationEnabled,
+        String inputPayload) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/adaptivequeryplanner/service/createStageExecution/AdaptiveQueryPlannerCreateResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/adaptivequeryplanner/service/createStageExecution/AdaptiveQueryPlannerCreateResponse.java
@@ -1,0 +1,4 @@
+package com.marketinghub.oprm.nichocnae.v2.adaptivequeryplanner.service.createStageExecution;
+
+/** Contrato devolvido após o backend gravar a pendência adaptive-query-planner do NichoCNAE v2. */
+public record AdaptiveQueryPlannerCreateResponse(String stageExecutionId, String status, String stageCode) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/adaptivequeryplanner/service/failStageExecution/AdaptiveQueryPlannerFailureRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/adaptivequeryplanner/service/failStageExecution/AdaptiveQueryPlannerFailureRequest.java
@@ -1,0 +1,7 @@
+package com.marketinghub.oprm.nichocnae.v2.adaptivequeryplanner.service.failStageExecution;
+
+import com.marketinghub.oprm.nichocnae.v2.OprmNichoCnaeV2FailureType;
+
+/** Contrato recebido do executor para registrar falha da etapa adaptive-query-planner do NichoCNAE v2. */
+public record AdaptiveQueryPlannerFailureRequest(
+        OprmNichoCnaeV2FailureType failureType, String errorMessage, String inputPayload) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/adaptivequeryplanner/service/failStageExecution/AdaptiveQueryPlannerFailureResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/adaptivequeryplanner/service/failStageExecution/AdaptiveQueryPlannerFailureResponse.java
@@ -1,0 +1,9 @@
+package com.marketinghub.oprm.nichocnae.v2.adaptivequeryplanner.service.failStageExecution;
+
+/** Contrato devolvido após o backend registrar falha adaptive-query-planner do NichoCNAE v2. */
+public record AdaptiveQueryPlannerFailureResponse(
+        String stageExecutionId,
+        String status,
+        String retryStageExecutionId,
+        Integer attemptNumber,
+        Integer technicalRetryNumber) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/adaptivequeryplanner/service/pending/AdaptiveQueryPlannerPendingResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/adaptivequeryplanner/service/pending/AdaptiveQueryPlannerPendingResponse.java
@@ -1,0 +1,12 @@
+package com.marketinghub.oprm.nichocnae.v2.adaptivequeryplanner.service.pending;
+
+/** Contrato entregue ao executor com a pendência da etapa adaptive-query-planner do NichoCNAE v2. */
+public record AdaptiveQueryPlannerPendingResponse(
+        String stageExecutionId,
+        String jobId,
+        String cnaeCode,
+        Long sourceNicheId,
+        Integer attemptNumber,
+        Integer technicalRetryNumber,
+        Integer knowledgeVersion,
+        String inputPayload) {}

--- a/backend/ads-service/src/test/java/com/marketinghub/oprm/nichocnae/v2/adaptivequeryplanner/service/BackendAdaptiveQueryPlannerServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/oprm/nichocnae/v2/adaptivequeryplanner/service/BackendAdaptiveQueryPlannerServiceTest.java
@@ -1,0 +1,149 @@
+package com.marketinghub.oprm.nichocnae.v2.adaptivequeryplanner.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.marketinghub.oprm.nichocnae.v2.OprmNichoCnaeV2FailureType;
+import com.marketinghub.oprm.nichocnae.v2.OprmNichoCnaeV2StageExecution;
+import com.marketinghub.oprm.nichocnae.v2.OprmNichoCnaeV2StageExecutionStatus;
+import com.marketinghub.oprm.nichocnae.v2.adaptivequeryplanner.service.completeStageExecution.AdaptiveQueryPlannerCompletionRequest;
+import com.marketinghub.oprm.nichocnae.v2.adaptivequeryplanner.service.createStageExecution.AdaptiveQueryPlannerCreateRequest;
+import com.marketinghub.oprm.nichocnae.v2.adaptivequeryplanner.service.failStageExecution.AdaptiveQueryPlannerFailureRequest;
+import com.marketinghub.oprm.nichocnae.v2.adaptivequeryplanner.service.pending.AdaptiveQueryPlannerPendingResponse;
+import com.marketinghub.repository.jpa.oprm.nichocnae.v2.OprmNichoCnaeV2StageExecutionRepository;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Pageable;
+
+/** Valida os contratos backend da etapa adaptive-query-planner do pipeline OPRM NichoCNAE v2. */
+@ExtendWith(MockitoExtension.class)
+class BackendAdaptiveQueryPlannerServiceTest {
+    @Mock private OprmNichoCnaeV2StageExecutionRepository stageExecutionRepository;
+
+    /** Deve manter a etapa 3 sem pendências quando a feature flag da v2 estiver desligada. */
+    @Test
+    void pendingReturnsEmptyWhenFeatureFlagIsDisabled() {
+        BackendAdaptiveQueryPlannerService service = service(false);
+
+        List<AdaptiveQueryPlannerPendingResponse> result = service.pending();
+
+        assertThat(result).isEmpty();
+        verify(stageExecutionRepository, never()).findByStageCodeAndStatusOrderByCreatedAtAsc(any(), any(), any());
+    }
+
+    /** Deve expor pendência da etapa 3 com o snapshot de conhecimento recebido do executor. */
+    @Test
+    void pendingReturnsAdaptiveQueryPlannerExecutions() {
+        BackendAdaptiveQueryPlannerService service = service(true);
+        when(stageExecutionRepository.findByStageCodeAndStatusOrderByCreatedAtAsc(
+                        eq("adaptive-query-planner"),
+                        eq(OprmNichoCnaeV2StageExecutionStatus.PENDING),
+                        any(Pageable.class)))
+                .thenReturn(List.of(execution(400L)));
+
+        List<AdaptiveQueryPlannerPendingResponse> result = service.pending();
+
+        assertThat(result).hasSize(1);
+        assertThat(result.getFirst().stageExecutionId()).isEqualTo("400");
+        assertThat(result.getFirst().inputPayload()).contains("evidenceGaps");
+    }
+
+    /** Deve persistir a próxima etapa recebida do executor sem calcular plano ou regra de negócio no backend. */
+    @Test
+    void completePersistsExecutorDecisionOnly() {
+        BackendAdaptiveQueryPlannerService service = service(true);
+        OprmNichoCnaeV2StageExecution execution = execution(401L);
+        when(stageExecutionRepository.findByIdAndStageCode(401L, "adaptive-query-planner"))
+                .thenReturn(Optional.of(execution));
+        when(stageExecutionRepository.save(any(OprmNichoCnaeV2StageExecution.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        var response = service.complete(
+                401L,
+                new AdaptiveQueryPlannerCompletionRequest(
+                        "PLAN_READY", 4, 3, 2, "{\"plannedQueries\":[]}", "source-searcher"));
+
+        assertThat(response.status()).isEqualTo("COMPLETED");
+        assertThat(response.nextStageCode()).isEqualTo("source-searcher");
+        assertThat(response.plannedQueryCount()).isEqualTo(4);
+        assertThat(response.reusedQueryCount()).isEqualTo(3);
+        assertThat(response.skippedQueryCount()).isEqualTo(2);
+    }
+
+    /** Deve gravar pendência da etapa 3 quando o executor solicitar reprocessamento cognitivo para query planner. */
+    @Test
+    void createPersistsPendingExecutionRequestedByExecutor() {
+        BackendAdaptiveQueryPlannerService service = service(true);
+        when(stageExecutionRepository.save(any(OprmNichoCnaeV2StageExecution.class))).thenAnswer(invocation -> {
+            OprmNichoCnaeV2StageExecution saved = invocation.getArgument(0);
+            saved.setId(402L);
+            return saved;
+        });
+
+        var response = service.create(new AdaptiveQueryPlannerCreateRequest(
+                "job-72", 72L, 69L, "4781400", 2, 4, false, "{\"evidenceGaps\":[]}"));
+
+        assertThat(response.stageExecutionId()).isEqualTo("402");
+        assertThat(response.status()).isEqualTo("PENDING");
+        assertThat(response.stageCode()).isEqualTo("adaptive-query-planner");
+    }
+
+    /** Deve preservar retry técnico sem mudar tentativa cognitiva quando a falha da etapa 3 for infraestrutura. */
+    @Test
+    void failCreatesTechnicalRetryForInfrastructureFailure() {
+        BackendAdaptiveQueryPlannerService service = service(true);
+        OprmNichoCnaeV2StageExecution execution = execution(403L);
+        when(stageExecutionRepository.findByIdAndStageCode(403L, "adaptive-query-planner"))
+                .thenReturn(Optional.of(execution));
+        when(stageExecutionRepository.save(any(OprmNichoCnaeV2StageExecution.class))).thenAnswer(invocation -> {
+            OprmNichoCnaeV2StageExecution saved = invocation.getArgument(0);
+            if (saved.getId() == null) {
+                saved.setId(404L);
+            }
+            return saved;
+        });
+
+        var response = service.fail(
+                403L,
+                new AdaptiveQueryPlannerFailureRequest(
+                        OprmNichoCnaeV2FailureType.INFRASTRUCTURE, "TIMEOUT gerando plano", "{}"));
+
+        assertThat(response.status()).isEqualTo("TECHNICAL_RETRY_SCHEDULED");
+        assertThat(response.retryStageExecutionId()).isEqualTo("404");
+        assertThat(response.attemptNumber()).isEqualTo(2);
+        assertThat(response.technicalRetryNumber()).isEqualTo(1);
+    }
+
+    /** Cria o service testável com flag explícita para a v2. */
+    private BackendAdaptiveQueryPlannerService service(boolean v2Enabled) {
+        return new BackendAdaptiveQueryPlannerService(stageExecutionRepository, v2Enabled);
+    }
+
+    /** Monta execução persistida mínima da etapa adaptive-query-planner. */
+    private OprmNichoCnaeV2StageExecution execution(Long id) {
+        OprmNichoCnaeV2StageExecution execution = new OprmNichoCnaeV2StageExecution();
+        execution.setId(id);
+        execution.setJobId("job-72");
+        execution.setResearchCycleId(72L);
+        execution.setSourceNicheId(69L);
+        execution.setCnaeCode("4781400");
+        execution.setStageCode("adaptive-query-planner");
+        execution.setAttemptNumber(2);
+        execution.setTechnicalRetryNumber(0);
+        execution.setKnowledgeVersion(4);
+        execution.setStatus(OprmNichoCnaeV2StageExecutionStatus.PENDING);
+        execution.setInputPayload("{\"evidenceGaps\":[\"MISSING_EXECUTOR_ROUTINE_EVIDENCE\"]}");
+        execution.setMaterializationEnabled(false);
+        execution.setCreatedAt(Instant.parse("2026-06-19T10:00:00Z"));
+        execution.setUpdatedAt(Instant.parse("2026-06-19T10:00:00Z"));
+        return execution;
+    }
+}

--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -1031,3 +1031,9 @@
 ## 2026-06-19 — Correção leitura/escrita da etapa 2 Source Safety Filter
 - Revisada a implementação da etapa `source-safety-filter` para manter o backend como camada de leitura/escrita: a decisão de próxima etapa passou a vir no callback do executor, e o backend deixou de calcular transição por `safetyDecision`.
 - Removida a criação automática de pendência da etapa 2 dentro da conclusão do `candidate-generator`; o executor externo passa a solicitar explicitamente a gravação da pendência pelo contrato de escrita da etapa 2.
+
+## 2026-06-19 — OPRM NichoCNAE v2 etapa 3 Adaptive Query Planner
+
+- Implementada a etapa 3 `adaptive-query-planner` da v2 do pipeline NichoCNAE com backend restrito a leitura/escrita: endpoints internos de `pending`, criação de pendência, conclusão e falha técnica/cognitiva sobre a tabela genérica de execuções de etapa, sem cálculo de plano, decisão comercial ou inteligência no backend.
+- Implementado no executor externo `oprm-coletor-mei` o processor plugável da etapa 3, responsável por transformar gaps de conhecimento em plano curto de queries naturais, reutilizando memória de queries anteriores, aplicando fallback de termos, deduplicação por hash e early stopping quando não há ganho informacional.
+- Atualizada a tela de mapa do pipeline v2 para marcar a etapa 3 como `Design aprovado · implementação inicial`.

--- a/frontend/src/pages/oprm/OprmNichoCnaeV2PipelinePage.tsx
+++ b/frontend/src/pages/oprm/OprmNichoCnaeV2PipelinePage.tsx
@@ -26,7 +26,7 @@ const v2Stages = [
   {
     number: 3,
     title: "Adaptive Query Planner",
-    status: "Design",
+    status: "Design aprovado · implementação inicial",
     purpose:
       "Planejar buscas pelos gaps reais de conhecimento, reaproveitando queries, fontes e falhas anteriores.",
     output:

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnaev2/pipeline/adaptivequeryplanner/AdaptiveQueryPlannerProcessor.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnaev2/pipeline/adaptivequeryplanner/AdaptiveQueryPlannerProcessor.java
@@ -1,0 +1,130 @@
+package com.marketinghub.nichocnaev2.pipeline.adaptivequeryplanner;
+
+import com.marketinghub.nichocnaev2.pipeline.StageArtifact;
+import com.marketinghub.nichocnaev2.pipeline.StageContext;
+import com.marketinghub.nichocnaev2.pipeline.StageProcessor;
+import com.marketinghub.nichocnaev2.pipeline.StageResult;
+import java.text.Normalizer;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+
+/** Planeja buscas adaptativas por gaps reais de conhecimento do pipeline NichoCNAE versão 2. */
+public final class AdaptiveQueryPlannerProcessor implements StageProcessor {
+    private static final int MAX_QUERIES = 8;
+
+    /** Cria um plano curto de pesquisa, reutilizando memória e evitando repetir queries ou fontes anteriores. */
+    @Override
+    public StageResult process(StageContext context) {
+        Map<String, Object> input = context.input();
+        List<String> gaps = textList(input.get("evidenceGaps"));
+        if (gaps.isEmpty()) {
+            gaps = textList(input.get("gaps"));
+        }
+        String audience = firstText(input, "audience", "targetAudience", "neutralCandidateName");
+        String jobContext = firstText(input, "jobContext", "operationalJob", "context");
+        Set<String> previousQueryHashes = new LinkedHashSet<>(textList(input.get("previousQueryHashes")));
+        List<Map<String, Object>> plannedQueries = new ArrayList<>();
+        int skipped = 0;
+        for (String gap : gaps) {
+            for (String query : candidateQueries(audience, jobContext, gap)) {
+                String hash = queryHash(query);
+                if (previousQueryHashes.contains(hash) || containsQuery(plannedQueries, hash)) {
+                    skipped++;
+                    continue;
+                }
+                plannedQueries.add(plannedQuery(query, gap, hash));
+                if (plannedQueries.size() >= MAX_QUERIES) {
+                    break;
+                }
+            }
+            if (plannedQueries.size() >= MAX_QUERIES) {
+                break;
+            }
+        }
+        String decision = plannedQueries.isEmpty() ? "NO_RESEARCH_GAIN" : "PLAN_READY";
+        Map<String, Object> output = new LinkedHashMap<>();
+        output.put("stage", "adaptive-query-planner");
+        output.put("planDecision", decision);
+        output.put("plannedQueryCount", plannedQueries.size());
+        output.put("reusedQueryCount", previousQueryHashes.size());
+        output.put("skippedQueryCount", skipped);
+        output.put("plannedQueries", plannedQueries);
+        output.put("earlyStopping", plannedQueries.isEmpty());
+        output.put("nextStageCode", plannedQueries.isEmpty() ? "candidate-tournament" : "source-searcher");
+        return new StageResult(decision, output, List.of(new StageArtifact(
+                "QUERY_PLAN", "inline://adaptive-query-planner/plan", "Plano curto orientado aos gaps ainda não provados.")));
+    }
+
+    /** Gera variações naturais de busca a partir do público, contexto e lacuna de evidência. */
+    private List<String> candidateQueries(String audience, String jobContext, String gap) {
+        String compactAudience = audience.isBlank() ? "profissional autonomo" : audience;
+        String compactContext = jobContext.isBlank() ? compactAudience : jobContext;
+        String compactGap = normalizeGap(gap);
+        return List.of(
+                compactAudience + " " + compactGap,
+                compactContext + " " + compactGap,
+                compactAudience + " relatos " + compactGap,
+                compactAudience + " rotina " + compactGap);
+    }
+
+    /** Normaliza o gap para produzir termos curtos, pesquisáveis e sem linguagem de oferta. */
+    private String normalizeGap(String gap) {
+        String normalized = String.valueOf(gap == null ? "" : gap).trim().toLowerCase(Locale.ROOT);
+        normalized = normalized.replace('_', ' ').replace('-', ' ');
+        normalized = normalized.replaceAll("(?i)\\b(produto|oferta|curso|landing|campanha|promessa)\\b", "");
+        normalized = normalized.replaceAll("\\s+", " ").trim();
+        return normalized.isBlank() ? "dificuldade rotina" : normalized;
+    }
+
+    /** Monta o item estruturado da query planejada para auditoria e próxima etapa. */
+    private Map<String, Object> plannedQuery(String query, String gap, String hash) {
+        Map<String, Object> item = new LinkedHashMap<>();
+        item.put("query", query);
+        item.put("queryHash", hash);
+        item.put("gap", gap);
+        item.put("objective", "EVIDENCE_GAP");
+        item.put("maxResults", 5);
+        return item;
+    }
+
+    /** Verifica duplicidade dentro do próprio plano em construção. */
+    private boolean containsQuery(List<Map<String, Object>> plannedQueries, String hash) {
+        return plannedQueries.stream().anyMatch(query -> hash.equals(query.get("queryHash")));
+    }
+
+    /** Extrai uma lista textual de contratos flexíveis do snapshot recebido do backend. */
+    private List<String> textList(Object value) {
+        if (!(value instanceof List<?> items)) {
+            return List.of();
+        }
+        return items.stream()
+                .filter(item -> item != null && !String.valueOf(item).isBlank())
+                .map(String::valueOf)
+                .toList();
+    }
+
+    /** Retorna o primeiro campo textual não vazio entre aliases de contrato. */
+    private String firstText(Map<String, Object> input, String... keys) {
+        for (String key : keys) {
+            Object value = input.get(key);
+            if (value != null && !String.valueOf(value).isBlank()) {
+                return String.valueOf(value).trim();
+            }
+        }
+        return "";
+    }
+
+    /** Gera hash estável simples para impedir repetição de queries já tentadas. */
+    private String queryHash(String query) {
+        String normalized = Normalizer.normalize(query.toLowerCase(Locale.ROOT), Normalizer.Form.NFD)
+                .replaceAll("\\p{M}", "")
+                .replaceAll("\\s+", " ")
+                .trim();
+        return Integer.toHexString(normalized.hashCode());
+    }
+}

--- a/oprm-coletor-mei/src/test/java/com/marketinghub/nichocnaev2/pipeline/adaptivequeryplanner/AdaptiveQueryPlannerProcessorTest.java
+++ b/oprm-coletor-mei/src/test/java/com/marketinghub/nichocnaev2/pipeline/adaptivequeryplanner/AdaptiveQueryPlannerProcessorTest.java
@@ -1,0 +1,58 @@
+package com.marketinghub.nichocnaev2.pipeline.adaptivequeryplanner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.marketinghub.nichocnaev2.pipeline.StageContext;
+import com.marketinghub.nichocnaev2.pipeline.StageResult;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class AdaptiveQueryPlannerProcessorTest {
+    @Test
+    void shouldPlanOnlyEvidenceGapQueriesWithoutOfferLanguage() {
+        AdaptiveQueryPlannerProcessor processor = new AdaptiveQueryPlannerProcessor();
+        StageResult result = processor.process(new StageContext(
+                "job-72",
+                "stage-72",
+                Map.of(
+                        "audience", "Motoristas autônomos de transfer aeroportuário",
+                        "jobContext", "corridas agendadas para passageiros e empresas",
+                        "evidenceGaps", List.of("MISSING_EXECUTOR_ROUTINE_EVIDENCE", "impacto econômico sem oferta de produto"),
+                        "previousQueryHashes", List.of())));
+
+        assertThat(result.status()).isEqualTo("PLAN_READY");
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> plannedQueries = (List<Map<String, Object>>) result.output().get("plannedQueries");
+        assertThat(plannedQueries).isNotEmpty().hasSizeLessThanOrEqualTo(8);
+        assertThat(plannedQueries)
+                .extracting(query -> String.valueOf(query.get("query")))
+                .allSatisfy(query -> assertThat(query).doesNotContain("oferta", "produto"));
+    }
+
+    @Test
+    void shouldStopWhenMemoryShowsNoNewQueryGain() {
+        AdaptiveQueryPlannerProcessor processor = new AdaptiveQueryPlannerProcessor();
+        StageResult first = processor.process(new StageContext(
+                "job-72",
+                "stage-72",
+                Map.of(
+                        "audience", "Motoristas autônomos de transfer aeroportuário",
+                        "evidenceGaps", List.of("cancelamento tardio"),
+                        "previousQueryHashes", List.of())));
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> planned = (List<Map<String, Object>>) first.output().get("plannedQueries");
+        List<String> hashes = planned.stream().map(query -> String.valueOf(query.get("queryHash"))).toList();
+
+        StageResult second = processor.process(new StageContext(
+                "job-72",
+                "stage-72",
+                Map.of(
+                        "audience", "Motoristas autônomos de transfer aeroportuário",
+                        "evidenceGaps", List.of("cancelamento tardio"),
+                        "previousQueryHashes", hashes)));
+
+        assertThat(second.status()).isEqualTo("NO_RESEARCH_GAIN");
+        assertThat(second.output()).containsEntry("earlyStopping", true);
+    }
+}


### PR DESCRIPTION
### Motivation
- Implementar a Etapa 3 (Adaptive Query Planner) conforme os planos em `docs/implementacao/oprm/*` para planejar buscas por gaps de conhecimento e reduzir custo/contaminação das queries. 
- Garantir que o backend permaneça apenas como camada de leitura/escrita de execuções de estágio, mantendo toda lógica, controle e regras de negócio no executor externo. 
- Fornecer contratos canônicos e visibilidade operacional para que o executor possa solicitar pendências, persistir decisões e reportar falhas técnicas/cognitivas sem delegar inteligência ao backend. 

### Description
- Adiciona contratos e API internas de leitura/escrita para a etapa `adaptive-query-planner` em `backend/ads-service` (`pending`, `create`, `complete`, `fail`) e o `BackendAdaptiveQueryPlannerService`/`BackendAdaptiveQueryPlannerController`. 
- Cria objetos de contrato HTTP/DTOs: `AdaptiveQueryPlannerCreateRequest/Response`, `AdaptiveQueryPlannerCompletionRequest/Response`, `AdaptiveQueryPlannerFailureRequest/Response`, e `AdaptiveQueryPlannerPendingResponse`. 
- Implementa o processor executor `AdaptiveQueryPlannerProcessor` em `oprm-coletor-mei`, que gera um plano curto de queries orientado por `evidenceGaps`, reaproveita memória (`previousQueryHashes`), deduplica por hash, remove linguagem de oferta e aplica `early stopping`. 
- Adiciona testes unitários e de arquitetura: backend `BackendAdaptiveQueryPlannerServiceTest`, executor `AdaptiveQueryPlannerProcessorTest`, e validação ArchUnit `NichoCnaeV2PipelineArchitectureTest`, além de atualizar a tela de mapa da pipeline (`frontend/src/pages/oprm/OprmNichoCnaeV2PipelinePage.tsx`) e o registro em `docs/registros/oprm1.md`. 

### Testing
- Executed backend tests: `BackendAdaptiveQueryPlannerServiceTest` ran via Maven and passed (tests green). 
- Executed executor/module tests: `AdaptiveQueryPlannerProcessorTest` and `NichoCnaeV2PipelineArchitectureTest` ran via Maven and passed (tests green). 
- Ran `git diff --check` with no blocking findings and updated `docs/registros/oprm1.md` and frontend stage status. 
- `npm run typecheck` failed in this environment due to missing frontend `node_modules` and absent type packages (`@testing-library/jest-dom`, `vite/client`, `vitest/globals`) and reported `tsconfig` deprecation warnings. 
- `spotless` invocation could not be executed in this environment because the Spotless plugin was not resolved for the invoked Maven run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a353a2b4e5483218f77625d2f459239)