### PR TITLE
Implement OPRM NichoCNAE v2 Stage 4: candidate-tournament (executor + backend contracts)

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/candidatetournament/controller/BackendCandidateTournamentController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/candidatetournament/controller/BackendCandidateTournamentController.java
@@ -1,0 +1,55 @@
+package com.marketinghub.oprm.nichocnae.v2.candidatetournament.controller;
+
+import com.marketinghub.oprm.nichocnae.v2.candidatetournament.service.BackendCandidateTournamentService;
+import com.marketinghub.oprm.nichocnae.v2.candidatetournament.service.completeStageExecution.CandidateTournamentCompletionRequest;
+import com.marketinghub.oprm.nichocnae.v2.candidatetournament.service.completeStageExecution.CandidateTournamentCompletionResponse;
+import com.marketinghub.oprm.nichocnae.v2.candidatetournament.service.createStageExecution.CandidateTournamentCreateRequest;
+import com.marketinghub.oprm.nichocnae.v2.candidatetournament.service.createStageExecution.CandidateTournamentCreateResponse;
+import com.marketinghub.oprm.nichocnae.v2.candidatetournament.service.failStageExecution.CandidateTournamentFailureRequest;
+import com.marketinghub.oprm.nichocnae.v2.candidatetournament.service.failStageExecution.CandidateTournamentFailureResponse;
+import com.marketinghub.oprm.nichocnae.v2.candidatetournament.service.pending.CandidateTournamentPendingResponse;
+import java.util.List;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/** Borda HTTP interna da etapa candidate-tournament do pipeline NichoCNAE versão 2. */
+@RestController
+@RequestMapping("/api/internal/oprm/nichocnae/v2/candidate-tournament/stage-executions")
+public class BackendCandidateTournamentController {
+    private final BackendCandidateTournamentService service;
+
+    /** Recebe o service canônico da etapa para delegar operações HTTP internas. */
+    public BackendCandidateTournamentController(BackendCandidateTournamentService service) {
+        this.service = service;
+    }
+
+    /** Entrega execuções pendentes da etapa candidate-tournament ao módulo executor OPRM. */
+    @GetMapping("/pending")
+    public List<CandidateTournamentPendingResponse> pending() {
+        return service.pending();
+    }
+
+    /** Grava uma pendência da etapa candidate-tournament solicitada pelo módulo executor OPRM. */
+    @PostMapping
+    public CandidateTournamentCreateResponse create(@RequestBody CandidateTournamentCreateRequest request) {
+        return service.create(request);
+    }
+
+    /** Registra a conclusão da execução de torneio informada pelo módulo executor OPRM. */
+    @PostMapping("/{stageExecutionId}/complete")
+    public CandidateTournamentCompletionResponse complete(
+            @PathVariable Long stageExecutionId, @RequestBody CandidateTournamentCompletionRequest request) {
+        return service.complete(stageExecutionId, request);
+    }
+
+    /** Registra a falha da execução de torneio informada pelo módulo executor OPRM. */
+    @PostMapping("/{stageExecutionId}/fail")
+    public CandidateTournamentFailureResponse fail(
+            @PathVariable Long stageExecutionId, @RequestBody CandidateTournamentFailureRequest request) {
+        return service.fail(stageExecutionId, request);
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/candidatetournament/service/BackendCandidateTournamentService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/candidatetournament/service/BackendCandidateTournamentService.java
@@ -1,0 +1,168 @@
+package com.marketinghub.oprm.nichocnae.v2.candidatetournament.service;
+
+import com.marketinghub.oprm.nichocnae.v2.OprmNichoCnaeV2FailureType;
+import com.marketinghub.oprm.nichocnae.v2.OprmNichoCnaeV2StageExecution;
+import com.marketinghub.oprm.nichocnae.v2.OprmNichoCnaeV2StageExecutionStatus;
+import com.marketinghub.oprm.nichocnae.v2.candidatetournament.service.completeStageExecution.CandidateTournamentCompletionRequest;
+import com.marketinghub.oprm.nichocnae.v2.candidatetournament.service.completeStageExecution.CandidateTournamentCompletionResponse;
+import com.marketinghub.oprm.nichocnae.v2.candidatetournament.service.createStageExecution.CandidateTournamentCreateRequest;
+import com.marketinghub.oprm.nichocnae.v2.candidatetournament.service.createStageExecution.CandidateTournamentCreateResponse;
+import com.marketinghub.oprm.nichocnae.v2.candidatetournament.service.failStageExecution.CandidateTournamentFailureRequest;
+import com.marketinghub.oprm.nichocnae.v2.candidatetournament.service.failStageExecution.CandidateTournamentFailureResponse;
+import com.marketinghub.oprm.nichocnae.v2.candidatetournament.service.pending.CandidateTournamentPendingResponse;
+import com.marketinghub.repository.jpa.oprm.nichocnae.v2.OprmNichoCnaeV2StageExecutionRepository;
+import java.time.Instant;
+import java.util.List;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+/** Expõe contratos de leitura/escrita do backend para a etapa candidate-tournament do pipeline NichoCNAE v2. */
+@Service
+public class BackendCandidateTournamentService {
+    public static final String STAGE_CODE = "candidate-tournament";
+    private final OprmNichoCnaeV2StageExecutionRepository stageExecutionRepository;
+    private final boolean v2Enabled;
+
+    /** Inicializa o service com repositório canônico e feature flag de calibração da v2. */
+    public BackendCandidateTournamentService(
+            OprmNichoCnaeV2StageExecutionRepository stageExecutionRepository,
+            @Value("${oprm.nichocnae.v2.enabled:false}") boolean v2Enabled) {
+        this.stageExecutionRepository = stageExecutionRepository;
+        this.v2Enabled = v2Enabled;
+    }
+
+    /** Lista pendências disponíveis para consumo canônico pelo executor OPRM NichoCNAE v2. */
+    @Transactional(readOnly = true)
+    public List<CandidateTournamentPendingResponse> pending() {
+        if (!v2Enabled) {
+            return List.of();
+        }
+        return stageExecutionRepository
+                .findByStageCodeAndStatusOrderByCreatedAtAsc(
+                        STAGE_CODE, OprmNichoCnaeV2StageExecutionStatus.PENDING, PageRequest.of(0, 5))
+                .stream()
+                .map(this::toPendingResponse)
+                .toList();
+    }
+
+    /** Registra conclusão do torneio usando a próxima etapa informada pelo executor externo. */
+    @Transactional
+    public CandidateTournamentCompletionResponse complete(
+            Long stageExecutionId, CandidateTournamentCompletionRequest request) {
+        OprmNichoCnaeV2StageExecution execution = findExecution(stageExecutionId);
+        execution.setStatus(OprmNichoCnaeV2StageExecutionStatus.COMPLETED);
+        execution.setOutputPayload(request == null ? null : request.outputPayload());
+        execution.setNextStageCode(request == null ? null : request.nextStageCode());
+        execution.setUpdatedAt(Instant.now());
+        OprmNichoCnaeV2StageExecution saved = stageExecutionRepository.save(execution);
+        return new CandidateTournamentCompletionResponse(
+                String.valueOf(saved.getId()),
+                saved.getStatus().name(),
+                saved.getNextStageCode(),
+                request == null ? null : request.tournamentDecision(),
+                request == null ? null : request.candidateCount(),
+                request == null ? null : request.finalistCount());
+    }
+
+    /** Registra falha e cria nova execução somente quando a falha for retry técnico de infraestrutura. */
+    @Transactional
+    public CandidateTournamentFailureResponse fail(Long stageExecutionId, CandidateTournamentFailureRequest request) {
+        OprmNichoCnaeV2StageExecution execution = findExecution(stageExecutionId);
+        OprmNichoCnaeV2FailureType failureType = request == null || request.failureType() == null
+                ? OprmNichoCnaeV2FailureType.VALIDATION
+                : request.failureType();
+        execution.setFailureType(failureType);
+        execution.setErrorMessage(request == null ? null : request.errorMessage());
+        execution.setInputPayload(request == null ? execution.getInputPayload() : request.inputPayload());
+        execution.setUpdatedAt(Instant.now());
+        if (failureType == OprmNichoCnaeV2FailureType.INFRASTRUCTURE) {
+            execution.setStatus(OprmNichoCnaeV2StageExecutionStatus.TECHNICAL_RETRY_SCHEDULED);
+            OprmNichoCnaeV2StageExecution retry = createTechnicalRetry(execution);
+            stageExecutionRepository.save(execution);
+            OprmNichoCnaeV2StageExecution savedRetry = stageExecutionRepository.save(retry);
+            return new CandidateTournamentFailureResponse(
+                    String.valueOf(execution.getId()),
+                    execution.getStatus().name(),
+                    String.valueOf(savedRetry.getId()),
+                    savedRetry.getAttemptNumber(),
+                    savedRetry.getTechnicalRetryNumber());
+        }
+        execution.setStatus(OprmNichoCnaeV2StageExecutionStatus.FAILED);
+        OprmNichoCnaeV2StageExecution saved = stageExecutionRepository.save(execution);
+        return new CandidateTournamentFailureResponse(
+                String.valueOf(saved.getId()),
+                saved.getStatus().name(),
+                null,
+                saved.getAttemptNumber(),
+                saved.getTechnicalRetryNumber());
+    }
+
+    /** Grava uma pendência da etapa de torneio solicitada pelo executor externo. */
+    @Transactional
+    public CandidateTournamentCreateResponse create(CandidateTournamentCreateRequest request) {
+        OprmNichoCnaeV2StageExecution saved = stageExecutionRepository.save(toPendingExecution(request));
+        return new CandidateTournamentCreateResponse(
+                String.valueOf(saved.getId()), saved.getStatus().name(), saved.getStageCode());
+    }
+
+    /** Converte o contrato recebido do executor em entidade persistível, sem decidir regra operacional. */
+    private OprmNichoCnaeV2StageExecution toPendingExecution(CandidateTournamentCreateRequest request) {
+        Instant now = Instant.now();
+        OprmNichoCnaeV2StageExecution execution = new OprmNichoCnaeV2StageExecution();
+        execution.setJobId(request.jobId());
+        execution.setResearchCycleId(request.researchCycleId());
+        execution.setSourceNicheId(request.sourceNicheId());
+        execution.setCnaeCode(request.cnaeCode());
+        execution.setStageCode(STAGE_CODE);
+        execution.setAttemptNumber(request.attemptNumber());
+        execution.setTechnicalRetryNumber(0);
+        execution.setKnowledgeVersion(request.knowledgeVersion());
+        execution.setStatus(OprmNichoCnaeV2StageExecutionStatus.PENDING);
+        execution.setInputPayload(request.inputPayload());
+        execution.setMaterializationEnabled(Boolean.TRUE.equals(request.materializationEnabled()));
+        execution.setCreatedAt(now);
+        execution.setUpdatedAt(now);
+        return execution;
+    }
+
+    /** Cria uma nova linha para retry técnico preservando a tentativa cognitiva e a versão de conhecimento. */
+    private OprmNichoCnaeV2StageExecution createTechnicalRetry(OprmNichoCnaeV2StageExecution previousExecution) {
+        OprmNichoCnaeV2StageExecution retry = toPendingExecution(new CandidateTournamentCreateRequest(
+                previousExecution.getJobId(),
+                previousExecution.getResearchCycleId(),
+                previousExecution.getSourceNicheId(),
+                previousExecution.getCnaeCode(),
+                previousExecution.getAttemptNumber(),
+                previousExecution.getKnowledgeVersion(),
+                previousExecution.getMaterializationEnabled(),
+                previousExecution.getInputPayload()));
+        retry.setTechnicalRetryNumber(previousExecution.getTechnicalRetryNumber() + 1);
+        return retry;
+    }
+
+    /** Carrega a execução da etapa atual ou devolve erro HTTP claro ao executor. */
+    private OprmNichoCnaeV2StageExecution findExecution(Long stageExecutionId) {
+        return stageExecutionRepository
+                .findByIdAndStageCode(stageExecutionId, STAGE_CODE)
+                .orElseThrow(() -> new ResponseStatusException(
+                        HttpStatus.NOT_FOUND,
+                        "NichoCNAE v2 candidate-tournament stage execution not found: " + stageExecutionId));
+    }
+
+    /** Converte a entidade persistida no contrato canônico de pending do executor. */
+    private CandidateTournamentPendingResponse toPendingResponse(OprmNichoCnaeV2StageExecution execution) {
+        return new CandidateTournamentPendingResponse(
+                String.valueOf(execution.getId()),
+                execution.getJobId(),
+                execution.getCnaeCode(),
+                execution.getSourceNicheId(),
+                execution.getAttemptNumber(),
+                execution.getTechnicalRetryNumber(),
+                execution.getKnowledgeVersion(),
+                execution.getInputPayload());
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/candidatetournament/service/completeStageExecution/CandidateTournamentCompletionRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/candidatetournament/service/completeStageExecution/CandidateTournamentCompletionRequest.java
@@ -1,0 +1,9 @@
+package com.marketinghub.oprm.nichocnae.v2.candidatetournament.service.completeStageExecution;
+
+/** Contrato recebido do executor ao concluir a etapa candidate-tournament do NichoCNAE v2. */
+public record CandidateTournamentCompletionRequest(
+        String tournamentDecision,
+        Integer candidateCount,
+        Integer finalistCount,
+        String outputPayload,
+        String nextStageCode) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/candidatetournament/service/completeStageExecution/CandidateTournamentCompletionResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/candidatetournament/service/completeStageExecution/CandidateTournamentCompletionResponse.java
@@ -1,0 +1,10 @@
+package com.marketinghub.oprm.nichocnae.v2.candidatetournament.service.completeStageExecution;
+
+/** Contrato devolvido após o backend registrar a conclusão candidate-tournament do NichoCNAE v2. */
+public record CandidateTournamentCompletionResponse(
+        String stageExecutionId,
+        String status,
+        String nextStageCode,
+        String tournamentDecision,
+        Integer candidateCount,
+        Integer finalistCount) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/candidatetournament/service/createStageExecution/CandidateTournamentCreateRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/candidatetournament/service/createStageExecution/CandidateTournamentCreateRequest.java
@@ -1,0 +1,12 @@
+package com.marketinghub.oprm.nichocnae.v2.candidatetournament.service.createStageExecution;
+
+/** Contrato enviado pelo executor para registrar uma pendência da etapa candidate-tournament do NichoCNAE v2. */
+public record CandidateTournamentCreateRequest(
+        String jobId,
+        Long researchCycleId,
+        Long sourceNicheId,
+        String cnaeCode,
+        Integer attemptNumber,
+        Integer knowledgeVersion,
+        Boolean materializationEnabled,
+        String inputPayload) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/candidatetournament/service/createStageExecution/CandidateTournamentCreateResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/candidatetournament/service/createStageExecution/CandidateTournamentCreateResponse.java
@@ -1,0 +1,4 @@
+package com.marketinghub.oprm.nichocnae.v2.candidatetournament.service.createStageExecution;
+
+/** Contrato devolvido após o backend gravar a pendência candidate-tournament do NichoCNAE v2. */
+public record CandidateTournamentCreateResponse(String stageExecutionId, String status, String stageCode) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/candidatetournament/service/failStageExecution/CandidateTournamentFailureRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/candidatetournament/service/failStageExecution/CandidateTournamentFailureRequest.java
@@ -1,0 +1,7 @@
+package com.marketinghub.oprm.nichocnae.v2.candidatetournament.service.failStageExecution;
+
+import com.marketinghub.oprm.nichocnae.v2.OprmNichoCnaeV2FailureType;
+
+/** Contrato recebido do executor para registrar falha da etapa candidate-tournament do NichoCNAE v2. */
+public record CandidateTournamentFailureRequest(
+        OprmNichoCnaeV2FailureType failureType, String errorMessage, String inputPayload) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/candidatetournament/service/failStageExecution/CandidateTournamentFailureResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/candidatetournament/service/failStageExecution/CandidateTournamentFailureResponse.java
@@ -1,0 +1,9 @@
+package com.marketinghub.oprm.nichocnae.v2.candidatetournament.service.failStageExecution;
+
+/** Contrato devolvido após o backend registrar falha candidate-tournament do NichoCNAE v2. */
+public record CandidateTournamentFailureResponse(
+        String stageExecutionId,
+        String status,
+        String retryStageExecutionId,
+        Integer attemptNumber,
+        Integer technicalRetryNumber) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/candidatetournament/service/pending/CandidateTournamentPendingResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/candidatetournament/service/pending/CandidateTournamentPendingResponse.java
@@ -1,0 +1,12 @@
+package com.marketinghub.oprm.nichocnae.v2.candidatetournament.service.pending;
+
+/** Contrato entregue ao executor com a pendência da etapa candidate-tournament do NichoCNAE v2. */
+public record CandidateTournamentPendingResponse(
+        String stageExecutionId,
+        String jobId,
+        String cnaeCode,
+        Long sourceNicheId,
+        Integer attemptNumber,
+        Integer technicalRetryNumber,
+        Integer knowledgeVersion,
+        String inputPayload) {}

--- a/backend/ads-service/src/test/java/com/marketinghub/oprm/nichocnae/v2/candidatetournament/service/BackendCandidateTournamentServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/oprm/nichocnae/v2/candidatetournament/service/BackendCandidateTournamentServiceTest.java
@@ -1,0 +1,149 @@
+package com.marketinghub.oprm.nichocnae.v2.candidatetournament.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.marketinghub.oprm.nichocnae.v2.OprmNichoCnaeV2FailureType;
+import com.marketinghub.oprm.nichocnae.v2.OprmNichoCnaeV2StageExecution;
+import com.marketinghub.oprm.nichocnae.v2.OprmNichoCnaeV2StageExecutionStatus;
+import com.marketinghub.oprm.nichocnae.v2.candidatetournament.service.completeStageExecution.CandidateTournamentCompletionRequest;
+import com.marketinghub.oprm.nichocnae.v2.candidatetournament.service.createStageExecution.CandidateTournamentCreateRequest;
+import com.marketinghub.oprm.nichocnae.v2.candidatetournament.service.failStageExecution.CandidateTournamentFailureRequest;
+import com.marketinghub.oprm.nichocnae.v2.candidatetournament.service.pending.CandidateTournamentPendingResponse;
+import com.marketinghub.repository.jpa.oprm.nichocnae.v2.OprmNichoCnaeV2StageExecutionRepository;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Pageable;
+
+/** Valida os contratos backend da etapa candidate-tournament do pipeline OPRM NichoCNAE v2. */
+@ExtendWith(MockitoExtension.class)
+class BackendCandidateTournamentServiceTest {
+    @Mock private OprmNichoCnaeV2StageExecutionRepository stageExecutionRepository;
+
+    /** Deve manter a etapa 4 sem pendências quando a feature flag da v2 estiver desligada. */
+    @Test
+    void pendingReturnsEmptyWhenFeatureFlagIsDisabled() {
+        BackendCandidateTournamentService service = service(false);
+
+        List<CandidateTournamentPendingResponse> result = service.pending();
+
+        assertThat(result).isEmpty();
+        verify(stageExecutionRepository, never()).findByStageCodeAndStatusOrderByCreatedAtAsc(any(), any(), any());
+    }
+
+    /** Deve expor pendência da etapa 4 com o snapshot de conhecimento recebido do executor. */
+    @Test
+    void pendingReturnsCandidateTournamentExecutions() {
+        BackendCandidateTournamentService service = service(true);
+        when(stageExecutionRepository.findByStageCodeAndStatusOrderByCreatedAtAsc(
+                        eq("candidate-tournament"),
+                        eq(OprmNichoCnaeV2StageExecutionStatus.PENDING),
+                        any(Pageable.class)))
+                .thenReturn(List.of(execution(400L)));
+
+        List<CandidateTournamentPendingResponse> result = service.pending();
+
+        assertThat(result).hasSize(1);
+        assertThat(result.getFirst().stageExecutionId()).isEqualTo("400");
+        assertThat(result.getFirst().inputPayload()).contains("candidates");
+    }
+
+    /** Deve persistir a próxima etapa recebida do executor sem calcular torneio ou regra de negócio no backend. */
+    @Test
+    void completePersistsExecutorDecisionOnly() {
+        BackendCandidateTournamentService service = service(true);
+        OprmNichoCnaeV2StageExecution execution = execution(401L);
+        when(stageExecutionRepository.findByIdAndStageCode(401L, "candidate-tournament"))
+                .thenReturn(Optional.of(execution));
+        when(stageExecutionRepository.save(any(OprmNichoCnaeV2StageExecution.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        var response = service.complete(
+                401L,
+                new CandidateTournamentCompletionRequest(
+                        "FINALISTS_SELECTED", 4, 2, "{\"finalists\":[]}", "source-fetcher"));
+
+        assertThat(response.status()).isEqualTo("COMPLETED");
+        assertThat(response.nextStageCode()).isEqualTo("source-fetcher");
+        assertThat(response.tournamentDecision()).isEqualTo("FINALISTS_SELECTED");
+        assertThat(response.candidateCount()).isEqualTo(4);
+        assertThat(response.finalistCount()).isEqualTo(2);
+    }
+
+    /** Deve gravar pendência da etapa 4 quando o executor solicitar reprocessamento cognitivo para query planner. */
+    @Test
+    void createPersistsPendingExecutionRequestedByExecutor() {
+        BackendCandidateTournamentService service = service(true);
+        when(stageExecutionRepository.save(any(OprmNichoCnaeV2StageExecution.class))).thenAnswer(invocation -> {
+            OprmNichoCnaeV2StageExecution saved = invocation.getArgument(0);
+            saved.setId(402L);
+            return saved;
+        });
+
+        var response = service.create(new CandidateTournamentCreateRequest(
+                "job-72", 72L, 69L, "4781400", 2, 4, false, "{\"candidates\":[]}"));
+
+        assertThat(response.stageExecutionId()).isEqualTo("402");
+        assertThat(response.status()).isEqualTo("PENDING");
+        assertThat(response.stageCode()).isEqualTo("candidate-tournament");
+    }
+
+    /** Deve preservar retry técnico sem mudar tentativa cognitiva quando a falha da etapa 4 for infraestrutura. */
+    @Test
+    void failCreatesTechnicalRetryForInfrastructureFailure() {
+        BackendCandidateTournamentService service = service(true);
+        OprmNichoCnaeV2StageExecution execution = execution(403L);
+        when(stageExecutionRepository.findByIdAndStageCode(403L, "candidate-tournament"))
+                .thenReturn(Optional.of(execution));
+        when(stageExecutionRepository.save(any(OprmNichoCnaeV2StageExecution.class))).thenAnswer(invocation -> {
+            OprmNichoCnaeV2StageExecution saved = invocation.getArgument(0);
+            if (saved.getId() == null) {
+                saved.setId(404L);
+            }
+            return saved;
+        });
+
+        var response = service.fail(
+                403L,
+                new CandidateTournamentFailureRequest(
+                        OprmNichoCnaeV2FailureType.INFRASTRUCTURE, "TIMEOUT comparando candidatos", "{}"));
+
+        assertThat(response.status()).isEqualTo("TECHNICAL_RETRY_SCHEDULED");
+        assertThat(response.retryStageExecutionId()).isEqualTo("404");
+        assertThat(response.attemptNumber()).isEqualTo(2);
+        assertThat(response.technicalRetryNumber()).isEqualTo(1);
+    }
+
+    /** Cria o service testável com flag explícita para a v2. */
+    private BackendCandidateTournamentService service(boolean v2Enabled) {
+        return new BackendCandidateTournamentService(stageExecutionRepository, v2Enabled);
+    }
+
+    /** Monta execução persistida mínima da etapa candidate-tournament. */
+    private OprmNichoCnaeV2StageExecution execution(Long id) {
+        OprmNichoCnaeV2StageExecution execution = new OprmNichoCnaeV2StageExecution();
+        execution.setId(id);
+        execution.setJobId("job-72");
+        execution.setResearchCycleId(72L);
+        execution.setSourceNicheId(69L);
+        execution.setCnaeCode("4781400");
+        execution.setStageCode("candidate-tournament");
+        execution.setAttemptNumber(2);
+        execution.setTechnicalRetryNumber(0);
+        execution.setKnowledgeVersion(4);
+        execution.setStatus(OprmNichoCnaeV2StageExecutionStatus.PENDING);
+        execution.setInputPayload("{\"candidates\":[{\"candidateId\":\"a\"}]}");
+        execution.setMaterializationEnabled(false);
+        execution.setCreatedAt(Instant.parse("2026-06-19T10:00:00Z"));
+        execution.setUpdatedAt(Instant.parse("2026-06-19T10:00:00Z"));
+        return execution;
+    }
+}

--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -1037,3 +1037,9 @@
 - Implementada a etapa 3 `adaptive-query-planner` da v2 do pipeline NichoCNAE com backend restrito a leitura/escrita: endpoints internos de `pending`, criação de pendência, conclusão e falha técnica/cognitiva sobre a tabela genérica de execuções de etapa, sem cálculo de plano, decisão comercial ou inteligência no backend.
 - Implementado no executor externo `oprm-coletor-mei` o processor plugável da etapa 3, responsável por transformar gaps de conhecimento em plano curto de queries naturais, reutilizando memória de queries anteriores, aplicando fallback de termos, deduplicação por hash e early stopping quando não há ganho informacional.
 - Atualizada a tela de mapa do pipeline v2 para marcar a etapa 3 como `Design aprovado · implementação inicial`.
+
+## 2026-06-19 — OPRM NichoCNAE v2 etapa 4 Candidate Tournament
+
+- Implementada a etapa 4 `candidate-tournament` no executor `oprm-coletor-mei`, comparando candidatos por evidências observadas, fontes independentes e penalidades de risco antes de selecionar até dois finalistas.
+- Criados contratos internos no backend apenas para leitura/escrita da etapa 4: `pending`, criação de pendência, conclusão e falha/retry técnico, mantendo lógica, controle e regra de negócio no executor externo.
+- Documentado o endpoint interno em `docs/swagger/oprm-nichocnae-v2-candidate-tournament-swagger.yaml`.

--- a/docs/swagger/oprm-nichocnae-v2-candidate-tournament-swagger.yaml
+++ b/docs/swagger/oprm-nichocnae-v2-candidate-tournament-swagger.yaml
@@ -1,0 +1,43 @@
+openapi: 3.0.3
+info:
+  title: OPRM NichoCNAE v2 Candidate Tournament API
+  version: 1.0.0
+paths:
+  /api/internal/oprm/nichocnae/v2/candidate-tournament/stage-executions/pending:
+    get:
+      summary: Lista execuções pendentes da etapa candidate-tournament v2
+      responses:
+        '200':
+          description: Pendências entregues ao executor OPRM sem regra de negócio no backend
+  /api/internal/oprm/nichocnae/v2/candidate-tournament/stage-executions:
+    post:
+      summary: Grava pendência da etapa candidate-tournament v2 solicitada pelo executor
+      responses:
+        '200':
+          description: Pendência registrada para leitura posterior pelo executor
+  /api/internal/oprm/nichocnae/v2/candidate-tournament/stage-executions/{stageExecutionId}/complete:
+    post:
+      summary: Registra conclusão de execução da etapa candidate-tournament v2
+      parameters:
+        - name: stageExecutionId
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: Resultado persistido com finalistas e próxima etapa definidos pelo executor externo
+  /api/internal/oprm/nichocnae/v2/candidate-tournament/stage-executions/{stageExecutionId}/fail:
+    post:
+      summary: Registra falha e retry técnico da etapa candidate-tournament v2
+      parameters:
+        - name: stageExecutionId
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: Falha registrada; retry técnico só é criado para falha de infraestrutura

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnaev2/pipeline/candidatetournament/CandidateTournamentProcessor.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnaev2/pipeline/candidatetournament/CandidateTournamentProcessor.java
@@ -1,0 +1,110 @@
+package com.marketinghub.nichocnaev2.pipeline.candidatetournament;
+
+import com.marketinghub.nichocnaev2.pipeline.StageArtifact;
+import com.marketinghub.nichocnaev2.pipeline.StageContext;
+import com.marketinghub.nichocnaev2.pipeline.StageProcessor;
+import com.marketinghub.nichocnaev2.pipeline.StageResult;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/** Compara candidatos por densidade e qualidade de evidências antes de escolher finalistas do NichoCNAE v2. */
+public final class CandidateTournamentProcessor implements StageProcessor {
+    private static final int MAX_FINALISTS = 2;
+    private static final double MIN_VIABLE_SCORE = 3.0;
+
+    /** Seleciona até dois finalistas usando somente sinais observados recebidos no snapshot de entrada. */
+    @Override
+    public StageResult process(StageContext context) {
+        List<Map<String, Object>> candidates = mapList(context.input().get("candidates"));
+        if (candidates.isEmpty()) {
+            candidates = mapList(context.input().get("candidateEvidence"));
+        }
+        List<Map<String, Object>> ranked = candidates.stream()
+                .map(this::scoreCandidate)
+                .sorted(Comparator.comparingDouble(this::scoreOf).reversed())
+                .toList();
+        List<Map<String, Object>> finalists = ranked.stream()
+                .filter(candidate -> scoreOf(candidate) >= MIN_VIABLE_SCORE)
+                .limit(MAX_FINALISTS)
+                .toList();
+        String decision = finalists.isEmpty() ? "NO_VIABLE_SUBNICHE" : "FINALISTS_SELECTED";
+        Map<String, Object> output = new LinkedHashMap<>();
+        output.put("stage", "candidate-tournament");
+        output.put("tournamentDecision", decision);
+        output.put("candidateCount", ranked.size());
+        output.put("finalistCount", finalists.size());
+        output.put("rankedCandidates", ranked);
+        output.put("finalists", finalists);
+        output.put("nextStageCode", finalists.isEmpty() ? "" : "source-fetcher");
+        return new StageResult(decision, output, List.of(new StageArtifact(
+                "CANDIDATE_TOURNAMENT",
+                "inline://candidate-tournament/ranking",
+                "Ranking auditável baseado em evidências observadas, sem opinião prévia do modelo.")));
+    }
+
+    /** Calcula score comercial conservador a partir de evidências diretas, independentes e riscos observados. */
+    private Map<String, Object> scoreCandidate(Map<String, Object> candidate) {
+        Map<String, Object> scored = new LinkedHashMap<>(candidate);
+        int directEvidenceCount = number(candidate, "directEvidenceCount", "acceptedClaimCount", "evidenceCount");
+        int independentSourceCount = number(candidate, "independentSourceCount", "sourceCount");
+        int rejectedSourceCount = number(candidate, "rejectedSourceCount", "unsafeSourceCount");
+        int contradictionCount = number(candidate, "contradictionCount");
+        double densityScore = Math.min(2.0, directEvidenceCount * 0.7);
+        double independenceScore = Math.min(2.0, independentSourceCount * 0.8);
+        double riskPenalty = (rejectedSourceCount * 0.4) + (contradictionCount * 0.8);
+        double tournamentScore = Math.max(0.0, densityScore + independenceScore - riskPenalty);
+        scored.put("tournamentScore", tournamentScore);
+        scored.put(
+                "tournamentRationale",
+                rationale(directEvidenceCount, independentSourceCount, rejectedSourceCount, contradictionCount));
+        return scored;
+    }
+
+    /** Monta justificativa curta para auditoria da decisão do torneio. */
+    private String rationale(
+            int directEvidenceCount, int independentSourceCount, int rejectedSourceCount, int contradictionCount) {
+        return "evidenciasDiretas=" + directEvidenceCount
+                + "; fontesIndependentes=" + independentSourceCount
+                + "; fontesRejeitadas=" + rejectedSourceCount
+                + "; contradicoes=" + contradictionCount;
+    }
+
+    /** Extrai o primeiro número inteiro disponível entre aliases de contrato. */
+    private int number(Map<String, Object> candidate, String... keys) {
+        for (String key : keys) {
+            Object value = candidate.get(key);
+            if (value instanceof Number number) {
+                return number.intValue();
+            }
+            if (value != null && String.valueOf(value).matches("-?\\d+")) {
+                return Integer.parseInt(String.valueOf(value));
+            }
+        }
+        return 0;
+    }
+
+    /** Lê listas de mapas sem acoplar o processor a DTO específico do backend. */
+    private List<Map<String, Object>> mapList(Object value) {
+        if (!(value instanceof List<?> items)) {
+            return List.of();
+        }
+        List<Map<String, Object>> mapped = new ArrayList<>();
+        for (Object item : items) {
+            if (item instanceof Map<?, ?> map) {
+                Map<String, Object> copy = new LinkedHashMap<>();
+                map.forEach((key, val) -> copy.put(String.valueOf(key), val));
+                mapped.add(copy);
+            }
+        }
+        return mapped;
+    }
+
+    /** Lê o score calculado sem depender de conversão externa. */
+    private double scoreOf(Map<String, Object> candidate) {
+        Object value = candidate.get("tournamentScore");
+        return value instanceof Number number ? number.doubleValue() : 0.0;
+    }
+}

--- a/oprm-coletor-mei/src/test/java/com/marketinghub/nichocnaev2/pipeline/candidatetournament/CandidateTournamentProcessorTest.java
+++ b/oprm-coletor-mei/src/test/java/com/marketinghub/nichocnaev2/pipeline/candidatetournament/CandidateTournamentProcessorTest.java
@@ -1,0 +1,46 @@
+package com.marketinghub.nichocnaev2.pipeline.candidatetournament;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.marketinghub.nichocnaev2.pipeline.StageContext;
+import com.marketinghub.nichocnaev2.pipeline.StageResult;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class CandidateTournamentProcessorTest {
+    @Test
+    void shouldSelectUpToTwoFinalistsFromObservedEvidence() {
+        CandidateTournamentProcessor processor = new CandidateTournamentProcessor();
+
+        StageResult result = processor.process(new StageContext(
+                "job-80",
+                "stage-4",
+                Map.of("candidates", List.of(
+                        Map.of("candidateId", "a", "directEvidenceCount", 4, "independentSourceCount", 3),
+                        Map.of("candidateId", "b", "directEvidenceCount", 3, "independentSourceCount", 2),
+                        Map.of("candidateId", "c", "directEvidenceCount", 1, "independentSourceCount", 1)))));
+
+        assertThat(result.status()).isEqualTo("FINALISTS_SELECTED");
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> finalists = (List<Map<String, Object>>) result.output().get("finalists");
+        assertThat(finalists).hasSize(2);
+        assertThat(result.output()).containsEntry("nextStageCode", "source-fetcher");
+    }
+
+    @Test
+    void shouldAllowNoViableSubnicheWhenEvidenceIsWeak() {
+        CandidateTournamentProcessor processor = new CandidateTournamentProcessor();
+
+        StageResult result = processor.process(new StageContext(
+                "job-81",
+                "stage-4",
+                Map.of("candidates", List.of(
+                        Map.of("candidateId", "a", "directEvidenceCount", 1, "independentSourceCount", 0),
+                        Map.of("candidateId", "b", "directEvidenceCount", 0, "independentSourceCount", 1)))));
+
+        assertThat(result.status()).isEqualTo("NO_VIABLE_SUBNICHE");
+        assertThat(result.output()).containsEntry("finalistCount", 0);
+        assertThat(result.output()).containsEntry("nextStageCode", "");
+    }
+}


### PR DESCRIPTION
### Motivation
- Implement the Stage 4 (Candidate Tournament) of the NichoCNAE v2 pipeline to select viable sub-niches using observed evidence rather than prior model opinion, following the v2 design and reprocessing rules.
- Keep the backend strictly as a read/write contract layer so all logic, control and business rules remain in the external executor module (executor = `oprm-coletor-mei`).

### Description
- Added the executor-side processor `CandidateTournamentProcessor` in `oprm-coletor-mei` that ranks candidates by direct evidence density, independent sources and risk penalties and emits up to two finalists or `NO_VIABLE_SUBNICHE` as decision.  (processor produces audit artifacts and next-stage hint.)
- Added backend read/write contracts for the new stage under `backend/ads-service`: controller `BackendCandidateTournamentController`, service `BackendCandidateTournamentService`, and request/response records for `pending`, `create`, `complete` and `fail` operations; backend only persists/returns data and preserves technical retry semantics for infrastructure failures. 
- Created unit tests for the executor processor (`CandidateTournamentProcessorTest`) and backend contracts (`BackendCandidateTournamentServiceTest`), added Swagger doc `docs/swagger/oprm-nichocnae-v2-candidate-tournament-swagger.yaml`, and registered the change in `docs/registros/oprm1.md`.
- Ensured the implementation follows the canonical rule: backend = persistence/contracts only; all decisioning and intelligence live in the executor external module.

### Testing
- Executed `mvn -Dtest=CandidateTournamentProcessorTest,NichoCnaeV2PipelineArchitectureTest test` in `oprm-coletor-mei` and tests passed after fixes to the processor and tests.
- Executed `mvn -Dtest=BackendCandidateTournamentServiceTest test` in `backend/ads-service` and the backend contract tests passed.
- Ran `git diff --check` to verify no whitespace/conflict markers; no issues found.
- Attempted `mvn -q spotless:apply` in `oprm-coletor-mei` but it failed because the module does not expose the Spotless plugin prefix in the current Maven configuration (informational only).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a353e634bd08321938aeca4698b51ab)