### PR TITLE
Implement OPRM NichoCNAE v2 stage 5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@ local/
 /vitrines/frontend/node_modules
 /vitrines/frontend/dist
 /vitrines/backend/target
+
+/oprm-coletor-mei/target/

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/sourcefetcherreranker/controller/BackendSourceFetcherRerankerController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/sourcefetcherreranker/controller/BackendSourceFetcherRerankerController.java
@@ -1,0 +1,55 @@
+package com.marketinghub.oprm.nichocnae.v2.sourcefetcherreranker.controller;
+
+import com.marketinghub.oprm.nichocnae.v2.sourcefetcherreranker.service.BackendSourceFetcherRerankerService;
+import com.marketinghub.oprm.nichocnae.v2.sourcefetcherreranker.service.completeStageExecution.SourceFetcherRerankerCompletionRequest;
+import com.marketinghub.oprm.nichocnae.v2.sourcefetcherreranker.service.completeStageExecution.SourceFetcherRerankerCompletionResponse;
+import com.marketinghub.oprm.nichocnae.v2.sourcefetcherreranker.service.createStageExecution.SourceFetcherRerankerCreateRequest;
+import com.marketinghub.oprm.nichocnae.v2.sourcefetcherreranker.service.createStageExecution.SourceFetcherRerankerCreateResponse;
+import com.marketinghub.oprm.nichocnae.v2.sourcefetcherreranker.service.failStageExecution.SourceFetcherRerankerFailureRequest;
+import com.marketinghub.oprm.nichocnae.v2.sourcefetcherreranker.service.failStageExecution.SourceFetcherRerankerFailureResponse;
+import com.marketinghub.oprm.nichocnae.v2.sourcefetcherreranker.service.pending.SourceFetcherRerankerPendingResponse;
+import java.util.List;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/** Borda HTTP interna da etapa source-fetcher-reranker do pipeline NichoCNAE versão 2. */
+@RestController
+@RequestMapping("/api/internal/oprm/nichocnae/v2/source-fetcher-reranker/stage-executions")
+public class BackendSourceFetcherRerankerController {
+    private final BackendSourceFetcherRerankerService service;
+
+    /** Recebe o service canônico da etapa para delegar operações HTTP internas. */
+    public BackendSourceFetcherRerankerController(BackendSourceFetcherRerankerService service) {
+        this.service = service;
+    }
+
+    /** Entrega execuções pendentes da etapa source-fetcher-reranker ao módulo executor OPRM. */
+    @GetMapping("/pending")
+    public List<SourceFetcherRerankerPendingResponse> pending() {
+        return service.pending();
+    }
+
+    /** Grava uma pendência da etapa source-fetcher-reranker solicitada pelo módulo executor OPRM. */
+    @PostMapping
+    public SourceFetcherRerankerCreateResponse create(@RequestBody SourceFetcherRerankerCreateRequest request) {
+        return service.create(request);
+    }
+
+    /** Registra a conclusão da execução de coleta e reranking informada pelo módulo executor OPRM. */
+    @PostMapping("/{stageExecutionId}/complete")
+    public SourceFetcherRerankerCompletionResponse complete(
+            @PathVariable Long stageExecutionId, @RequestBody SourceFetcherRerankerCompletionRequest request) {
+        return service.complete(stageExecutionId, request);
+    }
+
+    /** Registra a falha da execução de coleta e reranking informada pelo módulo executor OPRM. */
+    @PostMapping("/{stageExecutionId}/fail")
+    public SourceFetcherRerankerFailureResponse fail(
+            @PathVariable Long stageExecutionId, @RequestBody SourceFetcherRerankerFailureRequest request) {
+        return service.fail(stageExecutionId, request);
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/sourcefetcherreranker/service/BackendSourceFetcherRerankerService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/sourcefetcherreranker/service/BackendSourceFetcherRerankerService.java
@@ -1,0 +1,169 @@
+package com.marketinghub.oprm.nichocnae.v2.sourcefetcherreranker.service;
+
+import com.marketinghub.oprm.nichocnae.v2.OprmNichoCnaeV2FailureType;
+import com.marketinghub.oprm.nichocnae.v2.OprmNichoCnaeV2StageExecution;
+import com.marketinghub.oprm.nichocnae.v2.OprmNichoCnaeV2StageExecutionStatus;
+import com.marketinghub.oprm.nichocnae.v2.sourcefetcherreranker.service.completeStageExecution.SourceFetcherRerankerCompletionRequest;
+import com.marketinghub.oprm.nichocnae.v2.sourcefetcherreranker.service.completeStageExecution.SourceFetcherRerankerCompletionResponse;
+import com.marketinghub.oprm.nichocnae.v2.sourcefetcherreranker.service.createStageExecution.SourceFetcherRerankerCreateRequest;
+import com.marketinghub.oprm.nichocnae.v2.sourcefetcherreranker.service.createStageExecution.SourceFetcherRerankerCreateResponse;
+import com.marketinghub.oprm.nichocnae.v2.sourcefetcherreranker.service.failStageExecution.SourceFetcherRerankerFailureRequest;
+import com.marketinghub.oprm.nichocnae.v2.sourcefetcherreranker.service.failStageExecution.SourceFetcherRerankerFailureResponse;
+import com.marketinghub.oprm.nichocnae.v2.sourcefetcherreranker.service.pending.SourceFetcherRerankerPendingResponse;
+import com.marketinghub.repository.jpa.oprm.nichocnae.v2.OprmNichoCnaeV2StageExecutionRepository;
+import java.time.Instant;
+import java.util.List;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+/** Expõe contratos de leitura/escrita do backend para a etapa source-fetcher-reranker do pipeline NichoCNAE v2. */
+@Service
+public class BackendSourceFetcherRerankerService {
+    public static final String STAGE_CODE = "source-fetcher-reranker";
+    private final OprmNichoCnaeV2StageExecutionRepository stageExecutionRepository;
+    private final boolean v2Enabled;
+
+    /** Inicializa o service com repositório canônico e feature flag de calibração da v2. */
+    public BackendSourceFetcherRerankerService(
+            OprmNichoCnaeV2StageExecutionRepository stageExecutionRepository,
+            @Value("${oprm.nichocnae.v2.enabled:false}") boolean v2Enabled) {
+        this.stageExecutionRepository = stageExecutionRepository;
+        this.v2Enabled = v2Enabled;
+    }
+
+    /** Lista pendências disponíveis para consumo canônico pelo executor OPRM NichoCNAE v2. */
+    @Transactional(readOnly = true)
+    public List<SourceFetcherRerankerPendingResponse> pending() {
+        if (!v2Enabled) {
+            return List.of();
+        }
+        return stageExecutionRepository
+                .findByStageCodeAndStatusOrderByCreatedAtAsc(
+                        STAGE_CODE, OprmNichoCnaeV2StageExecutionStatus.PENDING, PageRequest.of(0, 5))
+                .stream()
+                .map(this::toPendingResponse)
+                .toList();
+    }
+
+    /** Registra conclusão da coleta e do reranking usando a próxima etapa informada pelo executor externo. */
+    @Transactional
+    public SourceFetcherRerankerCompletionResponse complete(
+            Long stageExecutionId, SourceFetcherRerankerCompletionRequest request) {
+        OprmNichoCnaeV2StageExecution execution = findExecution(stageExecutionId);
+        execution.setStatus(OprmNichoCnaeV2StageExecutionStatus.COMPLETED);
+        execution.setOutputPayload(request == null ? null : request.outputPayload());
+        execution.setNextStageCode(request == null ? null : request.nextStageCode());
+        execution.setUpdatedAt(Instant.now());
+        OprmNichoCnaeV2StageExecution saved = stageExecutionRepository.save(execution);
+        return new SourceFetcherRerankerCompletionResponse(
+                String.valueOf(saved.getId()),
+                saved.getStatus().name(),
+                saved.getNextStageCode(),
+                request == null ? null : request.sourceFetchDecision(),
+                request == null ? null : request.fetchedSnapshotCount(),
+                request == null ? null : request.selectedSourceCount(),
+                request == null ? null : request.rejectedSourceCount());
+    }
+
+    /** Registra falha e cria nova execução somente quando a falha for retry técnico de infraestrutura. */
+    @Transactional
+    public SourceFetcherRerankerFailureResponse fail(Long stageExecutionId, SourceFetcherRerankerFailureRequest request) {
+        OprmNichoCnaeV2StageExecution execution = findExecution(stageExecutionId);
+        OprmNichoCnaeV2FailureType failureType = request == null || request.failureType() == null
+                ? OprmNichoCnaeV2FailureType.VALIDATION
+                : request.failureType();
+        execution.setFailureType(failureType);
+        execution.setErrorMessage(request == null ? null : request.errorMessage());
+        execution.setInputPayload(request == null ? execution.getInputPayload() : request.inputPayload());
+        execution.setUpdatedAt(Instant.now());
+        if (failureType == OprmNichoCnaeV2FailureType.INFRASTRUCTURE) {
+            execution.setStatus(OprmNichoCnaeV2StageExecutionStatus.TECHNICAL_RETRY_SCHEDULED);
+            OprmNichoCnaeV2StageExecution retry = createTechnicalRetry(execution);
+            stageExecutionRepository.save(execution);
+            OprmNichoCnaeV2StageExecution savedRetry = stageExecutionRepository.save(retry);
+            return new SourceFetcherRerankerFailureResponse(
+                    String.valueOf(execution.getId()),
+                    execution.getStatus().name(),
+                    String.valueOf(savedRetry.getId()),
+                    savedRetry.getAttemptNumber(),
+                    savedRetry.getTechnicalRetryNumber());
+        }
+        execution.setStatus(OprmNichoCnaeV2StageExecutionStatus.FAILED);
+        OprmNichoCnaeV2StageExecution saved = stageExecutionRepository.save(execution);
+        return new SourceFetcherRerankerFailureResponse(
+                String.valueOf(saved.getId()),
+                saved.getStatus().name(),
+                null,
+                saved.getAttemptNumber(),
+                saved.getTechnicalRetryNumber());
+    }
+
+    /** Grava uma pendência da etapa de coleta e reranking solicitada pelo executor externo. */
+    @Transactional
+    public SourceFetcherRerankerCreateResponse create(SourceFetcherRerankerCreateRequest request) {
+        OprmNichoCnaeV2StageExecution saved = stageExecutionRepository.save(toPendingExecution(request));
+        return new SourceFetcherRerankerCreateResponse(
+                String.valueOf(saved.getId()), saved.getStatus().name(), saved.getStageCode());
+    }
+
+    /** Converte o contrato recebido do executor em entidade persistível, sem decidir regra operacional. */
+    private OprmNichoCnaeV2StageExecution toPendingExecution(SourceFetcherRerankerCreateRequest request) {
+        Instant now = Instant.now();
+        OprmNichoCnaeV2StageExecution execution = new OprmNichoCnaeV2StageExecution();
+        execution.setJobId(request.jobId());
+        execution.setResearchCycleId(request.researchCycleId());
+        execution.setSourceNicheId(request.sourceNicheId());
+        execution.setCnaeCode(request.cnaeCode());
+        execution.setStageCode(STAGE_CODE);
+        execution.setAttemptNumber(request.attemptNumber());
+        execution.setTechnicalRetryNumber(0);
+        execution.setKnowledgeVersion(request.knowledgeVersion());
+        execution.setStatus(OprmNichoCnaeV2StageExecutionStatus.PENDING);
+        execution.setInputPayload(request.inputPayload());
+        execution.setMaterializationEnabled(Boolean.TRUE.equals(request.materializationEnabled()));
+        execution.setCreatedAt(now);
+        execution.setUpdatedAt(now);
+        return execution;
+    }
+
+    /** Cria uma nova linha para retry técnico preservando a tentativa cognitiva e a versão de conhecimento. */
+    private OprmNichoCnaeV2StageExecution createTechnicalRetry(OprmNichoCnaeV2StageExecution previousExecution) {
+        OprmNichoCnaeV2StageExecution retry = toPendingExecution(new SourceFetcherRerankerCreateRequest(
+                previousExecution.getJobId(),
+                previousExecution.getResearchCycleId(),
+                previousExecution.getSourceNicheId(),
+                previousExecution.getCnaeCode(),
+                previousExecution.getAttemptNumber(),
+                previousExecution.getKnowledgeVersion(),
+                previousExecution.getMaterializationEnabled(),
+                previousExecution.getInputPayload()));
+        retry.setTechnicalRetryNumber(previousExecution.getTechnicalRetryNumber() + 1);
+        return retry;
+    }
+
+    /** Carrega a execução da etapa atual ou devolve erro HTTP claro ao executor. */
+    private OprmNichoCnaeV2StageExecution findExecution(Long stageExecutionId) {
+        return stageExecutionRepository
+                .findByIdAndStageCode(stageExecutionId, STAGE_CODE)
+                .orElseThrow(() -> new ResponseStatusException(
+                        HttpStatus.NOT_FOUND,
+                        "NichoCNAE v2 source-fetcher-reranker stage execution not found: " + stageExecutionId));
+    }
+
+    /** Converte a entidade persistida no contrato canônico de pending do executor. */
+    private SourceFetcherRerankerPendingResponse toPendingResponse(OprmNichoCnaeV2StageExecution execution) {
+        return new SourceFetcherRerankerPendingResponse(
+                String.valueOf(execution.getId()),
+                execution.getJobId(),
+                execution.getCnaeCode(),
+                execution.getSourceNicheId(),
+                execution.getAttemptNumber(),
+                execution.getTechnicalRetryNumber(),
+                execution.getKnowledgeVersion(),
+                execution.getInputPayload());
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/sourcefetcherreranker/service/completeStageExecution/SourceFetcherRerankerCompletionRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/sourcefetcherreranker/service/completeStageExecution/SourceFetcherRerankerCompletionRequest.java
@@ -1,0 +1,10 @@
+package com.marketinghub.oprm.nichocnae.v2.sourcefetcherreranker.service.completeStageExecution;
+
+/** Contrato recebido do executor ao concluir a etapa source-fetcher-reranker do NichoCNAE v2. */
+public record SourceFetcherRerankerCompletionRequest(
+        String sourceFetchDecision,
+        Integer fetchedSnapshotCount,
+        Integer selectedSourceCount,
+        Integer rejectedSourceCount,
+        String outputPayload,
+        String nextStageCode) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/sourcefetcherreranker/service/completeStageExecution/SourceFetcherRerankerCompletionResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/sourcefetcherreranker/service/completeStageExecution/SourceFetcherRerankerCompletionResponse.java
@@ -1,0 +1,11 @@
+package com.marketinghub.oprm.nichocnae.v2.sourcefetcherreranker.service.completeStageExecution;
+
+/** Contrato devolvido após o backend registrar a conclusão source-fetcher-reranker do NichoCNAE v2. */
+public record SourceFetcherRerankerCompletionResponse(
+        String stageExecutionId,
+        String status,
+        String nextStageCode,
+        String sourceFetchDecision,
+        Integer fetchedSnapshotCount,
+        Integer selectedSourceCount,
+        Integer rejectedSourceCount) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/sourcefetcherreranker/service/createStageExecution/SourceFetcherRerankerCreateRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/sourcefetcherreranker/service/createStageExecution/SourceFetcherRerankerCreateRequest.java
@@ -1,0 +1,12 @@
+package com.marketinghub.oprm.nichocnae.v2.sourcefetcherreranker.service.createStageExecution;
+
+/** Contrato enviado pelo executor para registrar uma pendência da etapa source-fetcher-reranker do NichoCNAE v2. */
+public record SourceFetcherRerankerCreateRequest(
+        String jobId,
+        Long researchCycleId,
+        Long sourceNicheId,
+        String cnaeCode,
+        Integer attemptNumber,
+        Integer knowledgeVersion,
+        Boolean materializationEnabled,
+        String inputPayload) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/sourcefetcherreranker/service/createStageExecution/SourceFetcherRerankerCreateResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/sourcefetcherreranker/service/createStageExecution/SourceFetcherRerankerCreateResponse.java
@@ -1,0 +1,4 @@
+package com.marketinghub.oprm.nichocnae.v2.sourcefetcherreranker.service.createStageExecution;
+
+/** Contrato devolvido após o backend gravar a pendência source-fetcher-reranker do NichoCNAE v2. */
+public record SourceFetcherRerankerCreateResponse(String stageExecutionId, String status, String stageCode) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/sourcefetcherreranker/service/failStageExecution/SourceFetcherRerankerFailureRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/sourcefetcherreranker/service/failStageExecution/SourceFetcherRerankerFailureRequest.java
@@ -1,0 +1,7 @@
+package com.marketinghub.oprm.nichocnae.v2.sourcefetcherreranker.service.failStageExecution;
+
+import com.marketinghub.oprm.nichocnae.v2.OprmNichoCnaeV2FailureType;
+
+/** Contrato recebido do executor para registrar falha da etapa source-fetcher-reranker do NichoCNAE v2. */
+public record SourceFetcherRerankerFailureRequest(
+        OprmNichoCnaeV2FailureType failureType, String errorMessage, String inputPayload) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/sourcefetcherreranker/service/failStageExecution/SourceFetcherRerankerFailureResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/sourcefetcherreranker/service/failStageExecution/SourceFetcherRerankerFailureResponse.java
@@ -1,0 +1,9 @@
+package com.marketinghub.oprm.nichocnae.v2.sourcefetcherreranker.service.failStageExecution;
+
+/** Contrato devolvido após o backend registrar falha source-fetcher-reranker do NichoCNAE v2. */
+public record SourceFetcherRerankerFailureResponse(
+        String stageExecutionId,
+        String status,
+        String retryStageExecutionId,
+        Integer attemptNumber,
+        Integer technicalRetryNumber) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/sourcefetcherreranker/service/pending/SourceFetcherRerankerPendingResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/sourcefetcherreranker/service/pending/SourceFetcherRerankerPendingResponse.java
@@ -1,0 +1,12 @@
+package com.marketinghub.oprm.nichocnae.v2.sourcefetcherreranker.service.pending;
+
+/** Contrato entregue ao executor com a pendência da etapa source-fetcher-reranker do NichoCNAE v2. */
+public record SourceFetcherRerankerPendingResponse(
+        String stageExecutionId,
+        String jobId,
+        String cnaeCode,
+        Long sourceNicheId,
+        Integer attemptNumber,
+        Integer technicalRetryNumber,
+        Integer knowledgeVersion,
+        String inputPayload) {}

--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -1043,3 +1043,9 @@
 - Implementada a etapa 4 `candidate-tournament` no executor `oprm-coletor-mei`, comparando candidatos por evidências observadas, fontes independentes e penalidades de risco antes de selecionar até dois finalistas.
 - Criados contratos internos no backend apenas para leitura/escrita da etapa 4: `pending`, criação de pendência, conclusão e falha/retry técnico, mantendo lógica, controle e regra de negócio no executor externo.
 - Documentado o endpoint interno em `docs/swagger/oprm-nichocnae-v2-candidate-tournament-swagger.yaml`.
+
+## 2026-06-19 — OPRM NichoCNAE v2 etapa 5 Source Fetcher + Reranker
+
+- Implementada a etapa 5 `source-fetcher-reranker` no executor `oprm-coletor-mei`, priorizando snapshots/fontes por prova direta, independência de domínio, aderência de ator/contexto e objetivo do gate, com retorno ao `adaptive-query-planner` quando não houver fonte direta útil.
+- Criados contratos backend somente de leitura/escrita em `com.marketinghub.oprm.nichocnae.v2.sourcefetcherreranker`, preservando lógica, controle e regras comerciais no executor externo.
+- Documentado o endpoint interno em `docs/swagger/oprm-nichocnae-v2-source-fetcher-reranker-swagger.yaml` e atualizada a tela de design da v2 para indicar implementação inicial da etapa 5.

--- a/docs/swagger/oprm-nichocnae-v2-source-fetcher-reranker-swagger.yaml
+++ b/docs/swagger/oprm-nichocnae-v2-source-fetcher-reranker-swagger.yaml
@@ -1,0 +1,42 @@
+openapi: 3.0.3
+info:
+  title: OPRM NichoCNAE v2 Source Fetcher Reranker API
+  version: 1.0.0
+  description: Contratos internos de leitura e escrita da etapa 5 do pipeline NichoCNAE v2. A lógica de coleta, priorização e regras de negócio fica no executor externo oprm-coletor-mei.
+paths:
+  /api/internal/oprm/nichocnae/v2/source-fetcher-reranker/stage-executions/pending:
+    get:
+      summary: Lista pendências da etapa 5 para o executor OPRM.
+      responses:
+        '200':
+          description: Pendências disponíveis.
+  /api/internal/oprm/nichocnae/v2/source-fetcher-reranker/stage-executions:
+    post:
+      summary: Registra uma pendência da etapa 5 solicitada pelo executor.
+      responses:
+        '200':
+          description: Pendência gravada.
+  /api/internal/oprm/nichocnae/v2/source-fetcher-reranker/stage-executions/{stageExecutionId}/complete:
+    post:
+      summary: Registra conclusão da coleta e reranking executados fora do backend.
+      parameters:
+        - name: stageExecutionId
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Conclusão persistida.
+  /api/internal/oprm/nichocnae/v2/source-fetcher-reranker/stage-executions/{stageExecutionId}/fail:
+    post:
+      summary: Registra falha da etapa 5, separando retry técnico de reprovação funcional.
+      parameters:
+        - name: stageExecutionId
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Falha persistida.

--- a/frontend/src/pages/oprm/OprmNichoCnaeV2PipelinePage.tsx
+++ b/frontend/src/pages/oprm/OprmNichoCnaeV2PipelinePage.tsx
@@ -47,7 +47,7 @@ const v2Stages = [
   {
     number: 5,
     title: "Source Fetcher + Reranker",
-    status: "Design",
+    status: "Design aprovado · implementação inicial",
     purpose:
       "Coletar páginas úteis e priorizar fontes diretas, independentes e alinhadas ao objetivo do gate.",
     output:

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnaev2/pipeline/candidatetournament/CandidateTournamentProcessor.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnaev2/pipeline/candidatetournament/CandidateTournamentProcessor.java
@@ -38,7 +38,7 @@ public final class CandidateTournamentProcessor implements StageProcessor {
         output.put("finalistCount", finalists.size());
         output.put("rankedCandidates", ranked);
         output.put("finalists", finalists);
-        output.put("nextStageCode", finalists.isEmpty() ? "" : "source-fetcher");
+        output.put("nextStageCode", finalists.isEmpty() ? "" : "source-fetcher-reranker");
         return new StageResult(decision, output, List.of(new StageArtifact(
                 "CANDIDATE_TOURNAMENT",
                 "inline://candidate-tournament/ranking",

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnaev2/pipeline/sourcefetcherreranker/SourceFetcherRerankerProcessor.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnaev2/pipeline/sourcefetcherreranker/SourceFetcherRerankerProcessor.java
@@ -1,0 +1,242 @@
+package com.marketinghub.nichocnaev2.pipeline.sourcefetcherreranker;
+
+import com.marketinghub.nichocnaev2.pipeline.StageArtifact;
+import com.marketinghub.nichocnaev2.pipeline.StageContext;
+import com.marketinghub.nichocnaev2.pipeline.StageProcessor;
+import com.marketinghub.nichocnaev2.pipeline.StageResult;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.text.Normalizer;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+
+/** Coleta snapshots já recebidos e prioriza fontes diretas, independentes e alinhadas ao gate do NichoCNAE v2. */
+public final class SourceFetcherRerankerProcessor implements StageProcessor {
+    private static final int MAX_SELECTED_SOURCES = 8;
+    private static final int MAX_SOURCES_PER_DOMAIN = 2;
+
+    /** Seleciona fontes úteis, deduplicadas e rastreáveis sem acessar banco ou decidir avanço fora do executor. */
+    @Override
+    public StageResult process(StageContext context) {
+        List<Map<String, Object>> sources = mapList(context.input().get("sources"));
+        if (sources.isEmpty()) {
+            sources = mapList(context.input().get("sourceCandidates"));
+        }
+        Set<String> fetchedContentHashes = new LinkedHashSet<>(
+                normalizedTextList(context.input().get("fetchedContentHashes")));
+        Map<String, Integer> selectedByDomain = new LinkedHashMap<>();
+        List<Map<String, Object>> rankedSources = sources.stream()
+                .map(source -> scoreSource(source, fetchedContentHashes))
+                .sorted(Comparator.comparingDouble(this::scoreOf).reversed())
+                .toList();
+        List<Map<String, Object>> selectedSources = new ArrayList<>();
+        List<Map<String, Object>> rejectedSources = new ArrayList<>();
+        for (Map<String, Object> source : rankedSources) {
+            String domain = text(source.get("canonicalDomain"));
+            if (domain.isBlank()) {
+                domain = domainOf(text(source.get("url")));
+            }
+            boolean duplicate = Boolean.TRUE.equals(source.get("duplicateContent"));
+            boolean unsafe = Boolean.TRUE.equals(source.get("unsafe"));
+            boolean domainQuotaExceeded = selectedByDomain.getOrDefault(domain, 0) >= MAX_SOURCES_PER_DOMAIN;
+            if (!duplicate && !unsafe && !domainQuotaExceeded && selectedSources.size() < MAX_SELECTED_SOURCES) {
+                selectedSources.add(source);
+                selectedByDomain.put(domain, selectedByDomain.getOrDefault(domain, 0) + 1);
+            } else {
+                Map<String, Object> rejected = new LinkedHashMap<>(source);
+                rejected.put("rejectionReason", rejectionReason(duplicate, unsafe, domainQuotaExceeded));
+                rejectedSources.add(rejected);
+            }
+        }
+        String decision = selectedSources.isEmpty() ? "NO_FETCHABLE_DIRECT_SOURCE" : "SOURCES_SELECTED";
+        Map<String, Object> output = new LinkedHashMap<>();
+        output.put("stage", "source-fetcher-reranker");
+        output.put("sourceFetchDecision", decision);
+        output.put("fetchedSnapshotCount", rankedSources.size());
+        output.put("selectedSourceCount", selectedSources.size());
+        output.put("rejectedSourceCount", rejectedSources.size());
+        output.put("rankedSources", rankedSources);
+        output.put("selectedSources", selectedSources);
+        output.put("rejectedSources", rejectedSources);
+        output.put("nextStageCode", selectedSources.isEmpty() ? "adaptive-query-planner" : "signal-extractor");
+        return new StageResult(decision, output, List.of(new StageArtifact(
+                "SOURCE_FETCH_RERANKING",
+                "inline://source-fetcher-reranker/selection",
+                "Snapshots priorizados por prova direta, independência de domínio e alinhamento ao objetivo do gate.")));
+    }
+
+    /** Calcula prioridade conservadora privilegiando fonte direta, aderência de ator/contexto e independência. */
+    private Map<String, Object> scoreSource(Map<String, Object> source, Set<String> fetchedContentHashes) {
+        Map<String, Object> scored = new LinkedHashMap<>(source);
+        String contentHash = normalize(text(source.get("contentHash")));
+        boolean duplicateContent = !contentHash.isBlank() && fetchedContentHashes.contains(contentHash);
+        boolean unsafe = Boolean.TRUE.equals(source.get("unsafe")) || containsUnsafeMarker(source);
+        double directness = directnessScore(text(source.get("sourceDirectness")), text(source.get("sourceType")));
+        double actor = decimal(source, "actorMatch", "targetActorMatch");
+        double context = decimal(source, "contextMatch", "jobContextMatch");
+        double objective = objectiveScore(source.get("supportedGoals"));
+        double penalty = (duplicateContent ? 2.0 : 0.0) + (unsafe ? 3.0 : 0.0) + decimal(source, "contaminationRisk");
+        double score = Math.max(0.0, directness + actor + context + objective - penalty);
+        scored.put("canonicalDomain", domainOf(text(source.get("url"))));
+        scored.put("duplicateContent", duplicateContent);
+        scored.put("unsafe", unsafe);
+        scored.put("rerankScore", score);
+        scored.put(
+                "rerankRationale",
+                "direta=" + directness
+                        + "; ator=" + actor
+                        + "; contexto=" + context
+                        + "; objetivo=" + objective
+                        + "; penalidade=" + penalty);
+        return scored;
+    }
+
+    /** Converte classificação textual de fonte em peso de valor marginal para fetch. */
+    private double directnessScore(String sourceDirectness, String sourceType) {
+        String joined = (sourceDirectness + " " + sourceType).toUpperCase(Locale.ROOT);
+        if (joined.contains("FIRST_PERSON") || joined.contains("DIRECT")) {
+            return 2.0;
+        }
+        if (joined.contains("INSTITUTIONAL") || joined.contains("MARKETPLACE")) {
+            return 1.0;
+        }
+        if (joined.contains("ANALOGY")) {
+            return 0.0;
+        }
+        return 0.5;
+    }
+
+    /** Mede se a fonte atende objetivos funcionais do gate, sem criar nova regra de negócio no backend. */
+    private double objectiveScore(Object supportedGoals) {
+        List<String> goals = textList(supportedGoals);
+        double score = 0.0;
+        if (goals.contains("ROUTINE")) {
+            score += 0.8;
+        }
+        if (goals.contains("PAIN")) {
+            score += 0.8;
+        }
+        if (goals.contains("ECONOMIC_IMPACT") || goals.contains("HIRING_BEHAVIOR")) {
+            score += 0.6;
+        }
+        return score;
+    }
+
+    /** Identifica marcadores de risco de segurança já enviados pela etapa anterior. */
+    private boolean containsUnsafeMarker(Map<String, Object> source) {
+        String text = normalize(text(source.get("safetyDecision")) + " " + text(source.get("riskLevel")));
+        return text.contains("unsafe") || text.contains("blocked") || text.contains("adult");
+    }
+
+    /** Explica por que uma fonte ficou fora da seleção final. */
+    private String rejectionReason(boolean duplicate, boolean unsafe, boolean domainQuotaExceeded) {
+        if (unsafe) {
+            return "UNSAFE_SOURCE";
+        }
+        if (duplicate) {
+            return "DUPLICATE_CONTENT";
+        }
+        if (domainQuotaExceeded) {
+            return "DOMAIN_QUOTA_EXCEEDED";
+        }
+        return "LOW_MARGINAL_VALUE";
+    }
+
+    /** Extrai lista de mapas de contratos flexíveis. */
+    private List<Map<String, Object>> mapList(Object value) {
+        if (!(value instanceof List<?> items)) {
+            return List.of();
+        }
+        List<Map<String, Object>> mapped = new ArrayList<>();
+        for (Object item : items) {
+            if (item instanceof Map<?, ?> map) {
+                Map<String, Object> copy = new LinkedHashMap<>();
+                map.forEach((key, val) -> copy.put(String.valueOf(key), val));
+                mapped.add(copy);
+            }
+        }
+        return mapped;
+    }
+
+    /** Extrai lista textual de contratos flexíveis. */
+    private List<String> textList(Object value) {
+        if (!(value instanceof List<?> items)) {
+            return List.of();
+        }
+        return items.stream()
+                .filter(item -> item != null)
+                .map(item -> String.valueOf(item).trim().toUpperCase(Locale.ROOT))
+                .filter(item -> !item.isBlank())
+                .toList();
+    }
+
+    /** Extrai lista textual normalizada sem alterar a semântica de hashes e URLs. */
+    private List<String> normalizedTextList(Object value) {
+        if (!(value instanceof List<?> items)) {
+            return List.of();
+        }
+        return items.stream()
+                .filter(item -> item != null)
+                .map(item -> normalize(String.valueOf(item)))
+                .filter(item -> !item.isBlank())
+                .toList();
+    }
+
+    /** Lê número decimal entre aliases sem exigir DTO específico. */
+    private double decimal(Map<String, Object> source, String... keys) {
+        for (String key : keys) {
+            Object value = source.get(key);
+            if (value instanceof Number number) {
+                return number.doubleValue();
+            }
+            if (value != null) {
+                try {
+                    return Double.parseDouble(String.valueOf(value));
+                } catch (NumberFormatException ignored) {
+                    return 0.0;
+                }
+            }
+        }
+        return 0.0;
+    }
+
+    /** Retorna texto seguro para normalização. */
+    private String text(Object value) {
+        return value == null ? "" : String.valueOf(value).trim();
+    }
+
+    /** Normaliza texto para comparações simples de marcadores. */
+    private String normalize(String value) {
+        return Normalizer.normalize(value.toLowerCase(Locale.ROOT), Normalizer.Form.NFD)
+                .replaceAll("\\p{M}", "")
+                .trim();
+    }
+
+    /** Extrai domínio canônico básico da URL para cotas de independência. */
+    private String domainOf(String url) {
+        if (url.isBlank()) {
+            return "";
+        }
+        try {
+            String host = new URI(url).getHost();
+            if (host == null) {
+                return "";
+            }
+            return host.toLowerCase(Locale.ROOT).replaceFirst("^www\\.", "");
+        } catch (URISyntaxException ex) {
+            return "";
+        }
+    }
+
+    /** Lê o score de reranking calculado. */
+    private double scoreOf(Map<String, Object> source) {
+        Object value = source.get("rerankScore");
+        return value instanceof Number number ? number.doubleValue() : 0.0;
+    }
+}

--- a/oprm-coletor-mei/src/test/java/com/marketinghub/nichocnaev2/pipeline/candidatetournament/CandidateTournamentProcessorTest.java
+++ b/oprm-coletor-mei/src/test/java/com/marketinghub/nichocnaev2/pipeline/candidatetournament/CandidateTournamentProcessorTest.java
@@ -25,7 +25,7 @@ class CandidateTournamentProcessorTest {
         @SuppressWarnings("unchecked")
         List<Map<String, Object>> finalists = (List<Map<String, Object>>) result.output().get("finalists");
         assertThat(finalists).hasSize(2);
-        assertThat(result.output()).containsEntry("nextStageCode", "source-fetcher");
+        assertThat(result.output()).containsEntry("nextStageCode", "source-fetcher-reranker");
     }
 
     @Test

--- a/oprm-coletor-mei/src/test/java/com/marketinghub/nichocnaev2/pipeline/sourcefetcherreranker/SourceFetcherRerankerProcessorTest.java
+++ b/oprm-coletor-mei/src/test/java/com/marketinghub/nichocnaev2/pipeline/sourcefetcherreranker/SourceFetcherRerankerProcessorTest.java
@@ -1,0 +1,58 @@
+package com.marketinghub.nichocnaev2.pipeline.sourcefetcherreranker;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.marketinghub.nichocnaev2.pipeline.StageContext;
+import com.marketinghub.nichocnaev2.pipeline.StageResult;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class SourceFetcherRerankerProcessorTest {
+    @Test
+    void shouldSelectDirectIndependentSourcesForSignalExtraction() {
+        SourceFetcherRerankerProcessor processor = new SourceFetcherRerankerProcessor();
+
+        StageResult result = processor.process(new StageContext(
+                "job-90",
+                "stage-5",
+                Map.of("sources", List.of(
+                        Map.of(
+                                "url", "https://forum-exemplo.com/rotina",
+                                "sourceDirectness", "DIRECT",
+                                "actorMatch", 0.95,
+                                "contextMatch", 0.9,
+                                "supportedGoals", List.of("ROUTINE", "PAIN")),
+                        Map.of(
+                                "url", "https://blog-exemplo.com/analogia",
+                                "sourceDirectness", "ANALOGY_ONLY",
+                                "actorMatch", 0.3,
+                                "contextMatch", 0.2,
+                                "supportedGoals", List.of("ROUTINE"))))));
+
+        assertThat(result.status()).isEqualTo("SOURCES_SELECTED");
+        assertThat(result.output()).containsEntry("nextStageCode", "signal-extractor");
+        @SuppressWarnings("unchecked")
+        List<Map<String, Object>> selected = (List<Map<String, Object>>) result.output().get("selectedSources");
+        assertThat(selected).hasSize(2);
+        assertThat(selected.get(0)).containsEntry("canonicalDomain", "forum-exemplo.com");
+    }
+
+    @Test
+    void shouldReturnToAdaptivePlannerWhenEverySourceIsUnsafeOrDuplicated() {
+        SourceFetcherRerankerProcessor processor = new SourceFetcherRerankerProcessor();
+
+        StageResult result = processor.process(new StageContext(
+                "job-91",
+                "stage-5",
+                Map.of(
+                        "fetchedContentHashes", List.of("hash-a"),
+                        "sources", List.of(
+                                Map.of("url", "https://unsafe.example/a", "unsafe", true),
+                                Map.of("url", "https://duplicate.example/a", "contentHash", "hash-a")))));
+
+        assertThat(result.status()).isEqualTo("NO_FETCHABLE_DIRECT_SOURCE");
+        assertThat(result.output()).containsEntry("selectedSourceCount", 0);
+        assertThat(result.output()).containsEntry("nextStageCode", "adaptive-query-planner");
+    }
+}


### PR DESCRIPTION
### Motivation
- Implement the planned P1.1–P1.5 flow by adding the Stage 5 step that collects and prioritizes source snapshots so the pipeline can prefer direct, independent and on-context evidence before signal extraction. 
- Preserve the architecture rule that the backend is only read/write for pipeline stages while the executor contains all collection intelligence, prioritization, gating and business rules. 

### Description
- Add backend read/write contracts for stage 5 under `com.marketinghub.oprm.nichocnae.v2.sourcefetcherreranker`: controller `BackendSourceFetcherRerankerController`, service `BackendSourceFetcherRerankerService`, and DTO `record`s for `pending/create/complete/fail` (contracts follow the existing stage-execution pattern). 
- Implement executor processor `SourceFetcherRerankerProcessor` in `oprm-coletor-mei` to perform source reranking: deduplication by content hash, domain quotas, safety checks, directness/actor/context scoring, selection of up to `MAX_SELECTED_SOURCES`, and decision to return to the `adaptive-query-planner` when no useful direct sources exist. 
- Update handoff and UI: change the candidate tournament next stage to `source-fetcher-reranker`, mark stage 5 as implemented in the v2 pipeline page, and add Swagger `docs/swagger/oprm-nichocnae-v2-source-fetcher-reranker-swagger.yaml`. 
- Add unit tests for the executor processor `SourceFetcherRerankerProcessorTest` and adjust the candidate-tournament test to expect the new next-stage code, and register the change in `docs/registros/oprm1.md`. 
- Keep the backend deliberately simple: all decision logic, scoring and gating remain in the executor; backend only persists `OprmNichoCnaeV2StageExecution` rows and exposes `pending/create/complete/fail` endpoints per the protocol. 

### Testing
- Ran executor unit tests: `mvn test -Dtest=CandidateTournamentProcessorTest,SourceFetcherRerankerProcessorTest,NichoCnaeV2PipelineArchitectureTest` in `oprm-coletor-mei`, and all tests passed. 
- Built backend module and ran tests (skipped tests for full ads-service run) via `../mvnw test -DskipTests` in `backend/ads-service`, and build succeeded. 
- Ran frontend unit tests `npm test -- --run OprmNavigation.test.tsx` and the `OprmNavigation` test suite passed. 
- Performed `git diff --check` and basic formatting checks; attempted `mvn spotless:apply` but that plugin is not exposed in the module so formatting was validated by `git diff --check` and local compile/test success.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a35453cea848321b1202afb9fc37895)