### PR TITLE
Implement NichoCNAE v2 commercial evidence gate (stage 6)

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/commercialevidencegate/controller/BackendCommercialEvidenceGateController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/commercialevidencegate/controller/BackendCommercialEvidenceGateController.java
@@ -1,0 +1,55 @@
+package com.marketinghub.oprm.nichocnae.v2.commercialevidencegate.controller;
+
+import com.marketinghub.oprm.nichocnae.v2.commercialevidencegate.service.BackendCommercialEvidenceGateService;
+import com.marketinghub.oprm.nichocnae.v2.commercialevidencegate.service.completeStageExecution.CommercialEvidenceGateCompletionRequest;
+import com.marketinghub.oprm.nichocnae.v2.commercialevidencegate.service.completeStageExecution.CommercialEvidenceGateCompletionResponse;
+import com.marketinghub.oprm.nichocnae.v2.commercialevidencegate.service.createStageExecution.CommercialEvidenceGateCreateRequest;
+import com.marketinghub.oprm.nichocnae.v2.commercialevidencegate.service.createStageExecution.CommercialEvidenceGateCreateResponse;
+import com.marketinghub.oprm.nichocnae.v2.commercialevidencegate.service.failStageExecution.CommercialEvidenceGateFailureRequest;
+import com.marketinghub.oprm.nichocnae.v2.commercialevidencegate.service.failStageExecution.CommercialEvidenceGateFailureResponse;
+import com.marketinghub.oprm.nichocnae.v2.commercialevidencegate.service.pending.CommercialEvidenceGatePendingResponse;
+import java.util.List;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/** Borda HTTP interna da etapa commercial-evidence-gate do pipeline NichoCNAE versão 2. */
+@RestController
+@RequestMapping("/api/internal/oprm/nichocnae/v2/commercial-evidence-gate/stage-executions")
+public class BackendCommercialEvidenceGateController {
+    private final BackendCommercialEvidenceGateService service;
+
+    /** Recebe o service canônico da etapa para delegar operações HTTP internas. */
+    public BackendCommercialEvidenceGateController(BackendCommercialEvidenceGateService service) {
+        this.service = service;
+    }
+
+    /** Entrega execuções pendentes da etapa commercial-evidence-gate ao módulo executor OPRM. */
+    @GetMapping("/pending")
+    public List<CommercialEvidenceGatePendingResponse> pending() {
+        return service.pending();
+    }
+
+    /** Grava uma pendência da etapa commercial-evidence-gate solicitada pelo módulo executor OPRM. */
+    @PostMapping
+    public CommercialEvidenceGateCreateResponse create(@RequestBody CommercialEvidenceGateCreateRequest request) {
+        return service.create(request);
+    }
+
+    /** Registra a conclusão do gate comercial informada pelo módulo executor OPRM. */
+    @PostMapping("/{stageExecutionId}/complete")
+    public CommercialEvidenceGateCompletionResponse complete(
+            @PathVariable Long stageExecutionId, @RequestBody CommercialEvidenceGateCompletionRequest request) {
+        return service.complete(stageExecutionId, request);
+    }
+
+    /** Registra a falha do gate comercial informada pelo módulo executor OPRM. */
+    @PostMapping("/{stageExecutionId}/fail")
+    public CommercialEvidenceGateFailureResponse fail(
+            @PathVariable Long stageExecutionId, @RequestBody CommercialEvidenceGateFailureRequest request) {
+        return service.fail(stageExecutionId, request);
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/commercialevidencegate/service/BackendCommercialEvidenceGateService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/commercialevidencegate/service/BackendCommercialEvidenceGateService.java
@@ -1,0 +1,150 @@
+package com.marketinghub.oprm.nichocnae.v2.commercialevidencegate.service;
+
+import com.marketinghub.oprm.nichocnae.v2.OprmNichoCnaeV2FailureType;
+import com.marketinghub.oprm.nichocnae.v2.OprmNichoCnaeV2StageExecution;
+import com.marketinghub.oprm.nichocnae.v2.OprmNichoCnaeV2StageExecutionStatus;
+import com.marketinghub.oprm.nichocnae.v2.commercialevidencegate.service.completeStageExecution.CommercialEvidenceGateCompletionRequest;
+import com.marketinghub.oprm.nichocnae.v2.commercialevidencegate.service.completeStageExecution.CommercialEvidenceGateCompletionResponse;
+import com.marketinghub.oprm.nichocnae.v2.commercialevidencegate.service.createStageExecution.CommercialEvidenceGateCreateRequest;
+import com.marketinghub.oprm.nichocnae.v2.commercialevidencegate.service.createStageExecution.CommercialEvidenceGateCreateResponse;
+import com.marketinghub.oprm.nichocnae.v2.commercialevidencegate.service.failStageExecution.CommercialEvidenceGateFailureRequest;
+import com.marketinghub.oprm.nichocnae.v2.commercialevidencegate.service.failStageExecution.CommercialEvidenceGateFailureResponse;
+import com.marketinghub.oprm.nichocnae.v2.commercialevidencegate.service.pending.CommercialEvidenceGatePendingResponse;
+import com.marketinghub.repository.jpa.oprm.nichocnae.v2.OprmNichoCnaeV2StageExecutionRepository;
+import java.time.Instant;
+import java.util.List;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+/** Expõe contratos de leitura/escrita do backend para a etapa commercial-evidence-gate do pipeline NichoCNAE v2. */
+@Service
+public class BackendCommercialEvidenceGateService {
+    public static final String STAGE_CODE = "commercial-evidence-gate";
+    private final OprmNichoCnaeV2StageExecutionRepository stageExecutionRepository;
+    private final boolean v2Enabled;
+
+    /** Inicializa o service com repositório canônico e feature flag de calibração da v2. */
+    public BackendCommercialEvidenceGateService(
+            OprmNichoCnaeV2StageExecutionRepository stageExecutionRepository,
+            @Value("${oprm.nichocnae.v2.enabled:false}") boolean v2Enabled) {
+        this.stageExecutionRepository = stageExecutionRepository;
+        this.v2Enabled = v2Enabled;
+    }
+
+    /** Lista pendências disponíveis para consumo canônico pelo executor OPRM NichoCNAE v2. */
+    @Transactional(readOnly = true)
+    public List<CommercialEvidenceGatePendingResponse> pending() {
+        if (!v2Enabled) {
+            return List.of();
+        }
+        return stageExecutionRepository
+                .findByStageCodeAndStatusOrderByCreatedAtAsc(
+                        STAGE_CODE, OprmNichoCnaeV2StageExecutionStatus.PENDING, PageRequest.of(0, 5))
+                .stream()
+                .map(this::toPendingResponse)
+                .toList();
+    }
+
+    /** Registra conclusão do gate comercial usando a decisão informada pelo executor externo. */
+    @Transactional
+    public CommercialEvidenceGateCompletionResponse complete(
+            Long stageExecutionId, CommercialEvidenceGateCompletionRequest request) {
+        OprmNichoCnaeV2StageExecution execution = findExecution(stageExecutionId);
+        execution.setStatus(OprmNichoCnaeV2StageExecutionStatus.COMPLETED);
+        execution.setOutputPayload(request == null ? null : request.outputPayload());
+        execution.setNextStageCode(request == null ? null : request.nextStageCode());
+        execution.setUpdatedAt(Instant.now());
+        OprmNichoCnaeV2StageExecution saved = stageExecutionRepository.save(execution);
+        return new CommercialEvidenceGateCompletionResponse(
+                String.valueOf(saved.getId()),
+                saved.getStatus().name(),
+                saved.getNextStageCode(),
+                request == null ? null : request.evidenceLevel(),
+                request == null ? null : request.confidence(),
+                request == null ? null : request.automaticMaterializationAllowed(),
+                request == null ? null : request.humanReviewRequired(),
+                request == null ? null : request.informationGain(),
+                request == null ? null : request.gateDecision());
+    }
+
+    /** Registra falha e cria nova execução somente quando a falha for retry técnico de infraestrutura. */
+    @Transactional
+    public CommercialEvidenceGateFailureResponse fail(Long stageExecutionId, CommercialEvidenceGateFailureRequest request) {
+        OprmNichoCnaeV2StageExecution execution = findExecution(stageExecutionId);
+        OprmNichoCnaeV2FailureType failureType = request == null || request.failureType() == null
+                ? OprmNichoCnaeV2FailureType.VALIDATION
+                : request.failureType();
+        execution.setFailureType(failureType);
+        execution.setErrorMessage(request == null ? null : request.errorMessage());
+        execution.setInputPayload(request == null ? execution.getInputPayload() : request.inputPayload());
+        execution.setUpdatedAt(Instant.now());
+        if (failureType == OprmNichoCnaeV2FailureType.INFRASTRUCTURE) {
+            execution.setStatus(OprmNichoCnaeV2StageExecutionStatus.TECHNICAL_RETRY_SCHEDULED);
+            OprmNichoCnaeV2StageExecution retry = createTechnicalRetry(execution);
+            stageExecutionRepository.save(execution);
+            OprmNichoCnaeV2StageExecution savedRetry = stageExecutionRepository.save(retry);
+            return new CommercialEvidenceGateFailureResponse(
+                    String.valueOf(execution.getId()), execution.getStatus().name(), String.valueOf(savedRetry.getId()),
+                    savedRetry.getAttemptNumber(), savedRetry.getTechnicalRetryNumber());
+        }
+        execution.setStatus(OprmNichoCnaeV2StageExecutionStatus.FAILED);
+        OprmNichoCnaeV2StageExecution saved = stageExecutionRepository.save(execution);
+        return new CommercialEvidenceGateFailureResponse(
+                String.valueOf(saved.getId()), saved.getStatus().name(), null, saved.getAttemptNumber(), saved.getTechnicalRetryNumber());
+    }
+
+    /** Grava uma pendência da etapa de gate comercial solicitada pelo executor externo. */
+    @Transactional
+    public CommercialEvidenceGateCreateResponse create(CommercialEvidenceGateCreateRequest request) {
+        OprmNichoCnaeV2StageExecution saved = stageExecutionRepository.save(toPendingExecution(request));
+        return new CommercialEvidenceGateCreateResponse(String.valueOf(saved.getId()), saved.getStatus().name(), saved.getStageCode());
+    }
+
+    /** Converte o contrato recebido do executor em entidade persistível, sem decidir regra operacional. */
+    private OprmNichoCnaeV2StageExecution toPendingExecution(CommercialEvidenceGateCreateRequest request) {
+        Instant now = Instant.now();
+        OprmNichoCnaeV2StageExecution execution = new OprmNichoCnaeV2StageExecution();
+        execution.setJobId(request.jobId());
+        execution.setResearchCycleId(request.researchCycleId());
+        execution.setSourceNicheId(request.sourceNicheId());
+        execution.setCnaeCode(request.cnaeCode());
+        execution.setStageCode(STAGE_CODE);
+        execution.setAttemptNumber(request.attemptNumber());
+        execution.setTechnicalRetryNumber(0);
+        execution.setKnowledgeVersion(request.knowledgeVersion());
+        execution.setStatus(OprmNichoCnaeV2StageExecutionStatus.PENDING);
+        execution.setInputPayload(request.inputPayload());
+        execution.setMaterializationEnabled(Boolean.TRUE.equals(request.materializationEnabled()));
+        execution.setCreatedAt(now);
+        execution.setUpdatedAt(now);
+        return execution;
+    }
+
+    /** Cria uma nova linha para retry técnico preservando a tentativa cognitiva e a versão de conhecimento. */
+    private OprmNichoCnaeV2StageExecution createTechnicalRetry(OprmNichoCnaeV2StageExecution previousExecution) {
+        OprmNichoCnaeV2StageExecution retry = toPendingExecution(new CommercialEvidenceGateCreateRequest(
+                previousExecution.getJobId(), previousExecution.getResearchCycleId(), previousExecution.getSourceNicheId(),
+                previousExecution.getCnaeCode(), previousExecution.getAttemptNumber(), previousExecution.getKnowledgeVersion(),
+                previousExecution.getMaterializationEnabled(), previousExecution.getInputPayload()));
+        retry.setTechnicalRetryNumber(previousExecution.getTechnicalRetryNumber() + 1);
+        return retry;
+    }
+
+    /** Carrega a execução da etapa atual ou devolve erro HTTP claro ao executor. */
+    private OprmNichoCnaeV2StageExecution findExecution(Long stageExecutionId) {
+        return stageExecutionRepository.findByIdAndStageCode(stageExecutionId, STAGE_CODE).orElseThrow(() ->
+                new ResponseStatusException(HttpStatus.NOT_FOUND,
+                        "NichoCNAE v2 commercial-evidence-gate stage execution not found: " + stageExecutionId));
+    }
+
+    /** Converte a entidade persistida no contrato canônico de pending do executor. */
+    private CommercialEvidenceGatePendingResponse toPendingResponse(OprmNichoCnaeV2StageExecution execution) {
+        return new CommercialEvidenceGatePendingResponse(String.valueOf(execution.getId()), execution.getJobId(),
+                execution.getCnaeCode(), execution.getSourceNicheId(), execution.getAttemptNumber(),
+                execution.getTechnicalRetryNumber(), execution.getKnowledgeVersion(), execution.getInputPayload());
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/commercialevidencegate/service/completeStageExecution/CommercialEvidenceGateCompletionRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/commercialevidencegate/service/completeStageExecution/CommercialEvidenceGateCompletionRequest.java
@@ -1,0 +1,12 @@
+package com.marketinghub.oprm.nichocnae.v2.commercialevidencegate.service.completeStageExecution;
+
+/** Contrato de escrita para registrar o resultado do gate comercial decidido pelo executor externo. */
+public record CommercialEvidenceGateCompletionRequest(
+        String evidenceLevel,
+        Double confidence,
+        Boolean automaticMaterializationAllowed,
+        Boolean humanReviewRequired,
+        Double informationGain,
+        String gateDecision,
+        String nextStageCode,
+        String outputPayload) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/commercialevidencegate/service/completeStageExecution/CommercialEvidenceGateCompletionResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/commercialevidencegate/service/completeStageExecution/CommercialEvidenceGateCompletionResponse.java
@@ -1,0 +1,13 @@
+package com.marketinghub.oprm.nichocnae.v2.commercialevidencegate.service.completeStageExecution;
+
+/** Resposta de conclusão persistida da etapa commercial-evidence-gate. */
+public record CommercialEvidenceGateCompletionResponse(
+        String stageExecutionId,
+        String status,
+        String nextStageCode,
+        String evidenceLevel,
+        Double confidence,
+        Boolean automaticMaterializationAllowed,
+        Boolean humanReviewRequired,
+        Double informationGain,
+        String gateDecision) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/commercialevidencegate/service/createStageExecution/CommercialEvidenceGateCreateRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/commercialevidencegate/service/createStageExecution/CommercialEvidenceGateCreateRequest.java
@@ -1,0 +1,12 @@
+package com.marketinghub.oprm.nichocnae.v2.commercialevidencegate.service.createStageExecution;
+
+/** Contrato de escrita para criar pendência do gate comercial calculado pelo executor externo. */
+public record CommercialEvidenceGateCreateRequest(
+        String jobId,
+        Long researchCycleId,
+        Long sourceNicheId,
+        String cnaeCode,
+        Integer attemptNumber,
+        Integer knowledgeVersion,
+        Boolean materializationEnabled,
+        String inputPayload) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/commercialevidencegate/service/createStageExecution/CommercialEvidenceGateCreateResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/commercialevidencegate/service/createStageExecution/CommercialEvidenceGateCreateResponse.java
@@ -1,0 +1,4 @@
+package com.marketinghub.oprm.nichocnae.v2.commercialevidencegate.service.createStageExecution;
+
+/** Resposta de criação de pendência da etapa commercial-evidence-gate. */
+public record CommercialEvidenceGateCreateResponse(String stageExecutionId, String status, String stageCode) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/commercialevidencegate/service/failStageExecution/CommercialEvidenceGateFailureRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/commercialevidencegate/service/failStageExecution/CommercialEvidenceGateFailureRequest.java
@@ -1,0 +1,9 @@
+package com.marketinghub.oprm.nichocnae.v2.commercialevidencegate.service.failStageExecution;
+
+import com.marketinghub.oprm.nichocnae.v2.OprmNichoCnaeV2FailureType;
+
+/** Contrato de escrita para registrar falha técnica ou cognitiva da etapa commercial-evidence-gate. */
+public record CommercialEvidenceGateFailureRequest(
+        OprmNichoCnaeV2FailureType failureType,
+        String errorMessage,
+        String inputPayload) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/commercialevidencegate/service/failStageExecution/CommercialEvidenceGateFailureResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/commercialevidencegate/service/failStageExecution/CommercialEvidenceGateFailureResponse.java
@@ -1,0 +1,9 @@
+package com.marketinghub.oprm.nichocnae.v2.commercialevidencegate.service.failStageExecution;
+
+/** Resposta de falha da etapa commercial-evidence-gate, incluindo retry técnico quando aplicável. */
+public record CommercialEvidenceGateFailureResponse(
+        String stageExecutionId,
+        String status,
+        String retryStageExecutionId,
+        Integer attemptNumber,
+        Integer technicalRetryNumber) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/commercialevidencegate/service/pending/CommercialEvidenceGatePendingResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/commercialevidencegate/service/pending/CommercialEvidenceGatePendingResponse.java
@@ -1,0 +1,12 @@
+package com.marketinghub.oprm.nichocnae.v2.commercialevidencegate.service.pending;
+
+/** Contrato de leitura de pendência da etapa commercial-evidence-gate para o executor OPRM. */
+public record CommercialEvidenceGatePendingResponse(
+        String stageExecutionId,
+        String jobId,
+        String cnaeCode,
+        Long sourceNicheId,
+        Integer attemptNumber,
+        Integer technicalRetryNumber,
+        Integer knowledgeVersion,
+        String inputPayload) {}

--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -1049,3 +1049,9 @@
 - Implementada a etapa 5 `source-fetcher-reranker` no executor `oprm-coletor-mei`, priorizando snapshots/fontes por prova direta, independência de domínio, aderência de ator/contexto e objetivo do gate, com retorno ao `adaptive-query-planner` quando não houver fonte direta útil.
 - Criados contratos backend somente de leitura/escrita em `com.marketinghub.oprm.nichocnae.v2.sourcefetcherreranker`, preservando lógica, controle e regras comerciais no executor externo.
 - Documentado o endpoint interno em `docs/swagger/oprm-nichocnae-v2-source-fetcher-reranker-swagger.yaml` e atualizada a tela de design da v2 para indicar implementação inicial da etapa 5.
+
+## 2026-06-19 — NichoCNAE v2 etapa de gate comercial E0-E5
+
+- Implementada a etapa `commercial-evidence-gate` no executor OPRM para calcular níveis E0-E5, confiança explicável, ganho informacional, revisão humana seletiva e liberação gradual de materialização automática.
+- Criado contrato interno no backend apenas para leitura/escrita de pendências, conclusão e falhas da etapa; a lógica comercial permaneceu no executor externo.
+- Atualizada a tela do pipeline v2 para sinalizar a implementação inicial do Evidence Level Gate E0-E5.

--- a/docs/swagger/oprm-nichocnae-v2-commercial-evidence-gate-swagger.yaml
+++ b/docs/swagger/oprm-nichocnae-v2-commercial-evidence-gate-swagger.yaml
@@ -1,0 +1,117 @@
+openapi: 3.0.3
+info:
+  title: OPRM NichoCNAE v2 Commercial Evidence Gate API
+  version: "1.0.0"
+paths:
+  /api/internal/oprm/nichocnae/v2/commercial-evidence-gate/stage-executions/pending:
+    get:
+      summary: Lista pendências do gate comercial E0-E5 para o executor OPRM
+      responses:
+        "200":
+          description: Pendências disponíveis
+  /api/internal/oprm/nichocnae/v2/commercial-evidence-gate/stage-executions:
+    post:
+      summary: Cria pendência do gate comercial E0-E5 calculado pelo executor externo
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CommercialEvidenceGateCreateRequest"
+      responses:
+        "200":
+          description: Pendência criada
+  /api/internal/oprm/nichocnae/v2/commercial-evidence-gate/stage-executions/{stageExecutionId}/complete:
+    post:
+      summary: Registra resultado do gate comercial decidido pelo executor externo
+      parameters:
+        - name: stageExecutionId
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CommercialEvidenceGateCompletionRequest"
+      responses:
+        "200":
+          description: Resultado persistido
+  /api/internal/oprm/nichocnae/v2/commercial-evidence-gate/stage-executions/{stageExecutionId}/fail:
+    post:
+      summary: Registra falha técnica ou cognitiva do gate comercial
+      parameters:
+        - name: stageExecutionId
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: "#/components/schemas/CommercialEvidenceGateFailureRequest"
+      responses:
+        "200":
+          description: Falha persistida
+components:
+  schemas:
+    CommercialEvidenceGateCreateRequest:
+      type: object
+      properties:
+        jobId:
+          type: string
+        researchCycleId:
+          type: integer
+          format: int64
+        sourceNicheId:
+          type: integer
+          format: int64
+        cnaeCode:
+          type: string
+        attemptNumber:
+          type: integer
+        knowledgeVersion:
+          type: integer
+        materializationEnabled:
+          type: boolean
+        inputPayload:
+          type: string
+    CommercialEvidenceGateCompletionRequest:
+      type: object
+      properties:
+        evidenceLevel:
+          type: string
+          enum: [E0_MODEL_HYPOTHESIS, E1_ACTIVITY_EXISTS, E2_ROUTINE_AND_PAIN, E3_ECONOMIC_PAIN, E4_PURCHASE_INTENT, E5_REAL_PURCHASE]
+        confidence:
+          type: number
+          format: double
+        automaticMaterializationAllowed:
+          type: boolean
+        humanReviewRequired:
+          type: boolean
+        informationGain:
+          type: number
+          format: double
+        gateDecision:
+          type: string
+          enum: [MATERIALIZE, HUMAN_REVIEW, NEEDS_MORE_RESEARCH, NO_PUBLIC_EVIDENCE]
+        nextStageCode:
+          type: string
+        outputPayload:
+          type: string
+    CommercialEvidenceGateFailureRequest:
+      type: object
+      properties:
+        failureType:
+          type: string
+          enum: [INFRASTRUCTURE, VALIDATION, QUALITY, MARKET_EVIDENCE]
+        errorMessage:
+          type: string
+        inputPayload:
+          type: string

--- a/frontend/src/pages/oprm/OprmNichoCnaeV2PipelinePage.tsx
+++ b/frontend/src/pages/oprm/OprmNichoCnaeV2PipelinePage.tsx
@@ -109,7 +109,7 @@ const v2Stages = [
   {
     number: 11,
     title: "Evidence Level Gate E0–E5",
-    status: "Design",
+    status: "Design aprovado · implementação inicial",
     purpose:
       "Separar existência da atividade, dor prática, impacto econômico e intenção de compra por nível de evidência.",
     output:

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnaev2/pipeline/commercialevidencegate/CommercialEvidenceGateProcessor.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnaev2/pipeline/commercialevidencegate/CommercialEvidenceGateProcessor.java
@@ -1,0 +1,262 @@
+package com.marketinghub.nichocnaev2.pipeline.commercialevidencegate;
+
+import com.marketinghub.nichocnaev2.pipeline.StageArtifact;
+import com.marketinghub.nichocnaev2.pipeline.StageContext;
+import com.marketinghub.nichocnaev2.pipeline.StageProcessor;
+import com.marketinghub.nichocnaev2.pipeline.StageResult;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+
+/** Calcula o gate comercial E0-E5 do NichoCNAE v2 com regras de negócio mantidas no executor externo. */
+public final class CommercialEvidenceGateProcessor implements StageProcessor {
+    private static final Set<String> TASK_TYPES = Set.of("TASK", "ROUTINE", "OPERATIONAL_TASK");
+    private static final Set<String> PAIN_TYPES = Set.of("PAIN", "PRACTICAL_PAIN", "RECURRING_PAIN");
+    private static final Set<String> ECONOMIC_TYPES = Set.of("ECONOMIC_IMPACT", "WORKAROUND", "COST", "LOST_REVENUE");
+    private static final Set<String> PURCHASE_TYPES = Set.of("PURCHASE_INTENT", "HIRING_BEHAVIOR", "SOLUTION_SEARCH", "SPEND");
+    private static final Set<String> OFFER_TYPES = Set.of("REAL_PURCHASE", "PAID_OFFER", "MVP_PURCHASE");
+
+    /** Avalia claims aceitos e snapshot acumulado para decidir materialização, revisão humana ou nova pesquisa. */
+    @Override
+    public StageResult process(StageContext context) {
+        List<Map<String, Object>> claims = acceptedClaims(context.input());
+        EvidenceCounts counts = countEvidence(claims);
+        String evidenceLevel = evidenceLevel(counts);
+        double confidence = confidence(counts);
+        double informationGain = informationGain(context.input(), evidenceLevel, counts.totalSignals());
+        boolean materializationEnabled = booleanValue(context.input().get("materializationEnabled"));
+        boolean automaticMaterializationAllowed = materializationEnabled && levelRank(evidenceLevel) >= 3 && confidence >= 0.70;
+        boolean humanReviewRequired = levelRank(evidenceLevel) >= 3 && confidence < 0.70;
+        List<String> missingEvidence = missingEvidence(counts);
+        String gateDecision = gateDecision(automaticMaterializationAllowed, humanReviewRequired, evidenceLevel, informationGain);
+        String nextStageCode = nextStageCode(gateDecision);
+
+        Map<String, Object> output = new LinkedHashMap<>();
+        output.put("stage", "commercial-evidence-gate");
+        output.put("evidenceLevel", evidenceLevel);
+        output.put("confidence", confidence);
+        output.put("automaticMaterializationAllowed", automaticMaterializationAllowed);
+        output.put("humanReviewRequired", humanReviewRequired);
+        output.put("informationGain", informationGain);
+        output.put("gateDecision", gateDecision);
+        output.put("nextStageCode", nextStageCode);
+        output.put("missingEvidence", missingEvidence);
+        output.put("evidenceCounts", counts.asMap());
+        output.put("commercialSeparation", Map.of(
+                "activityExists", counts.activitySignals(),
+                "recurringPain", counts.painSignals(),
+                "economicImpact", counts.economicSignals(),
+                "purchaseIntent", counts.purchaseSignals()));
+        return new StageResult(gateDecision, output, List.of(new StageArtifact(
+                "COMMERCIAL_EVIDENCE_GATE",
+                "inline://commercial-evidence-gate/decision",
+                "Nível E0-E5, confiança calculada, gaps e decisão de materialização calculados no executor.")));
+    }
+
+    /** Filtra claims aceitos e validados sem transformar rejeição em sinal positivo. */
+    private List<Map<String, Object>> acceptedClaims(Map<String, Object> input) {
+        List<Map<String, Object>> claims = mapList(input.get("claims"));
+        if (claims.isEmpty()) {
+            claims = mapList(input.get("validatedClaims"));
+        }
+        return claims.stream().filter(this::isAccepted).toList();
+    }
+
+    /** Verifica se o claim pode contar como evidência comercial positiva. */
+    private boolean isAccepted(Map<String, Object> claim) {
+        String status = text(claim.get("status")).toUpperCase(Locale.ROOT);
+        String epistemicState = text(claim.get("epistemicState")).toUpperCase(Locale.ROOT);
+        String evidenceSpan = text(claim.get("exactEvidenceSpan"));
+        return !evidenceSpan.isBlank()
+                && (status.isBlank() || status.equals("ACCEPT") || status.equals("ACCEPTED"))
+                && (epistemicState.isBlank() || epistemicState.equals("VALIDATED"));
+    }
+
+    /** Conta sinais separados de atividade, dor, impacto econômico, intenção e compra real. */
+    private EvidenceCounts countEvidence(List<Map<String, Object>> claims) {
+        int activities = 0;
+        int tasks = 0;
+        int pains = 0;
+        int economic = 0;
+        int purchase = 0;
+        int offers = 0;
+        List<String> domains = new ArrayList<>();
+        for (Map<String, Object> claim : claims) {
+            String type = text(claim.get("claimType")).toUpperCase(Locale.ROOT);
+            if (type.equals("ACTIVITY_EXISTS") || type.equals("AUDIENCE_EXISTS")) {
+                activities++;
+            }
+            if (TASK_TYPES.contains(type)) {
+                tasks++;
+            }
+            if (PAIN_TYPES.contains(type)) {
+                pains++;
+            }
+            if (ECONOMIC_TYPES.contains(type)) {
+                economic++;
+            }
+            if (PURCHASE_TYPES.contains(type)) {
+                purchase++;
+            }
+            if (OFFER_TYPES.contains(type)) {
+                offers++;
+            }
+            String domain = text(claim.get("canonicalDomain"));
+            if (!domain.isBlank() && !domains.contains(domain)) {
+                domains.add(domain);
+            }
+        }
+        return new EvidenceCounts(activities, tasks, pains, economic, purchase, offers, domains.size());
+    }
+
+    /** Define o nível E0-E5 sem misturar dor, impacto econômico e intenção de compra. */
+    private String evidenceLevel(EvidenceCounts counts) {
+        if (counts.offerSignals() > 0) {
+            return "E5_REAL_PURCHASE";
+        }
+        if (counts.purchaseSignals() > 0) {
+            return "E4_PURCHASE_INTENT";
+        }
+        if (counts.economicSignals() > 0 && counts.painSignals() >= 2 && counts.taskSignals() >= 3) {
+            return "E3_ECONOMIC_PAIN";
+        }
+        if (counts.painSignals() > 0 && counts.taskSignals() > 0) {
+            return "E2_ROUTINE_AND_PAIN";
+        }
+        if (counts.activitySignals() > 0 || counts.taskSignals() > 0) {
+            return "E1_ACTIVITY_EXISTS";
+        }
+        return "E0_MODEL_HYPOTHESIS";
+    }
+
+    /** Calcula confiança explicável por quantidade, diversidade e nível atingido, sem score especulativo do modelo. */
+    private double confidence(EvidenceCounts counts) {
+        double raw = (counts.taskSignals() * 0.08)
+                + (counts.painSignals() * 0.10)
+                + (counts.economicSignals() * 0.18)
+                + (counts.purchaseSignals() * 0.20)
+                + (counts.offerSignals() * 0.24)
+                + (Math.min(counts.independentDomainCount(), 5) * 0.06);
+        return Math.round(Math.min(0.95, raw) * 100.0) / 100.0;
+    }
+
+    /** Calcula ganho informacional da tentativa atual em relação ao nível anterior informado no snapshot. */
+    private double informationGain(Map<String, Object> input, String evidenceLevel, int signalCount) {
+        int previousRank = levelRank(text(input.get("previousEvidenceLevel")));
+        int currentRank = levelRank(evidenceLevel);
+        double gain = Math.max(0, currentRank - previousRank) * 0.20 + Math.min(signalCount, 10) * 0.01;
+        return Math.round(gain * 100.0) / 100.0;
+    }
+
+    /** Lista lacunas comerciais que impedem avanço ou priorização. */
+    private List<String> missingEvidence(EvidenceCounts counts) {
+        List<String> missing = new ArrayList<>();
+        if (counts.taskSignals() < 3) {
+            missing.add("CONCRETE_EXECUTOR_TASKS");
+        }
+        if (counts.painSignals() < 2) {
+            missing.add("DISTINCT_RECURRING_PAINS");
+        }
+        if (counts.economicSignals() < 1) {
+            missing.add("ECONOMIC_IMPACT_OR_WORKAROUND");
+        }
+        if (counts.purchaseSignals() < 1) {
+            missing.add("DIRECT_PURCHASE_INTENT_OR_HIRING_BEHAVIOR");
+        }
+        if (counts.independentDomainCount() < 3) {
+            missing.add("THREE_INDEPENDENT_DOMAINS");
+        }
+        return missing;
+    }
+
+    /** Decide o próximo movimento operacional a partir do gate calculado. */
+    private String gateDecision(boolean automaticMaterializationAllowed, boolean humanReviewRequired, String evidenceLevel, double informationGain) {
+        if (automaticMaterializationAllowed) {
+            return "MATERIALIZE";
+        }
+        if (humanReviewRequired) {
+            return "HUMAN_REVIEW";
+        }
+        if (levelRank(evidenceLevel) < 2 || informationGain < 0.10) {
+            return "NO_PUBLIC_EVIDENCE";
+        }
+        return "NEEDS_MORE_RESEARCH";
+    }
+
+    /** Traduz decisão comercial para o estágio canônico seguinte. */
+    private String nextStageCode(String gateDecision) {
+        return switch (gateDecision) {
+            case "MATERIALIZE" -> "enriched-niche-materializer";
+            case "HUMAN_REVIEW" -> "human-review";
+            case "NEEDS_MORE_RESEARCH" -> "adaptive-query-planner";
+            default -> "end";
+        };
+    }
+
+    /** Converte nível E0-E5 em ordem numérica. */
+    private int levelRank(String evidenceLevel) {
+        String normalized = evidenceLevel.toUpperCase(Locale.ROOT);
+        if (normalized.startsWith("E5")) return 5;
+        if (normalized.startsWith("E4")) return 4;
+        if (normalized.startsWith("E3")) return 3;
+        if (normalized.startsWith("E2")) return 2;
+        if (normalized.startsWith("E1")) return 1;
+        return 0;
+    }
+
+    /** Extrai lista de mapas de contratos flexíveis. */
+    private List<Map<String, Object>> mapList(Object value) {
+        if (!(value instanceof List<?> items)) {
+            return List.of();
+        }
+        List<Map<String, Object>> mapped = new ArrayList<>();
+        for (Object item : items) {
+            if (item instanceof Map<?, ?> map) {
+                Map<String, Object> copy = new LinkedHashMap<>();
+                map.forEach((key, val) -> copy.put(String.valueOf(key), val));
+                mapped.add(copy);
+            }
+        }
+        return mapped;
+    }
+
+    /** Converte valor flexível para booleano seguro. */
+    private boolean booleanValue(Object value) {
+        return value instanceof Boolean bool ? bool : Boolean.parseBoolean(text(value));
+    }
+
+    /** Retorna texto seguro para decisões determinísticas. */
+    private String text(Object value) {
+        return value == null ? "" : String.valueOf(value).trim();
+    }
+
+    /** Agrega contagens comerciais separadas para manter a regra auditável. */
+    private record EvidenceCounts(
+            int activitySignals,
+            int taskSignals,
+            int painSignals,
+            int economicSignals,
+            int purchaseSignals,
+            int offerSignals,
+            int independentDomainCount) {
+        /** Soma todos os sinais aceitos para cálculo de ganho informacional. */
+        int totalSignals() {
+            return activitySignals + taskSignals + painSignals + economicSignals + purchaseSignals + offerSignals;
+        }
+
+        /** Expõe as contagens no payload persistível de auditoria. */
+        Map<String, Object> asMap() {
+            return Map.of(
+                    "activitySignals", activitySignals,
+                    "taskSignals", taskSignals,
+                    "painSignals", painSignals,
+                    "economicSignals", economicSignals,
+                    "purchaseSignals", purchaseSignals,
+                    "offerSignals", offerSignals,
+                    "independentDomainCount", independentDomainCount);
+        }
+    }
+}

--- a/oprm-coletor-mei/src/test/java/com/marketinghub/nichocnaev2/pipeline/commercialevidencegate/CommercialEvidenceGateProcessorTest.java
+++ b/oprm-coletor-mei/src/test/java/com/marketinghub/nichocnaev2/pipeline/commercialevidencegate/CommercialEvidenceGateProcessorTest.java
@@ -1,0 +1,81 @@
+package com.marketinghub.nichocnaev2.pipeline.commercialevidencegate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.marketinghub.nichocnaev2.pipeline.StageContext;
+import com.marketinghub.nichocnaev2.pipeline.StageResult;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class CommercialEvidenceGateProcessorTest {
+    @Test
+    void shouldAllowAutomaticMaterializationOnlyFromEconomicEvidenceLevel() {
+        CommercialEvidenceGateProcessor processor = new CommercialEvidenceGateProcessor();
+
+        StageResult result = processor.process(new StageContext(
+                "job-120",
+                "stage-6",
+                Map.of(
+                        "materializationEnabled", true,
+                        "claims", List.of(
+                                claim("TASK", "a.com"),
+                                claim("TASK", "b.com"),
+                                claim("TASK", "c.com"),
+                                claim("PAIN", "a.com"),
+                                claim("PRACTICAL_PAIN", "b.com"),
+                                claim("ECONOMIC_IMPACT", "c.com")))));
+
+        assertThat(result.status()).isEqualTo("MATERIALIZE");
+        assertThat(result.output()).containsEntry("evidenceLevel", "E3_ECONOMIC_PAIN");
+        assertThat(result.output()).containsEntry("automaticMaterializationAllowed", true);
+        assertThat(result.output()).containsEntry("nextStageCode", "enriched-niche-materializer");
+    }
+
+    @Test
+    void shouldKeepPainSeparatedFromPurchaseIntentAndAskMoreResearch() {
+        CommercialEvidenceGateProcessor processor = new CommercialEvidenceGateProcessor();
+
+        StageResult result = processor.process(new StageContext(
+                "job-121",
+                "stage-6",
+                Map.of(
+                        "previousEvidenceLevel", "E1_ACTIVITY_EXISTS",
+                        "claims", List.of(
+                                claim("TASK", "a.com"),
+                                claim("PAIN", "a.com"),
+                                claim("PAIN", "b.com")))));
+
+        assertThat(result.status()).isEqualTo("NEEDS_MORE_RESEARCH");
+        assertThat(result.output()).containsEntry("evidenceLevel", "E2_ROUTINE_AND_PAIN");
+        @SuppressWarnings("unchecked")
+        List<String> missing = (List<String>) result.output().get("missingEvidence");
+        assertThat(missing).contains("ECONOMIC_IMPACT_OR_WORKAROUND", "DIRECT_PURCHASE_INTENT_OR_HIRING_BEHAVIOR");
+    }
+
+    @Test
+    void shouldNotCountClaimWithoutExactEvidenceSpan() {
+        CommercialEvidenceGateProcessor processor = new CommercialEvidenceGateProcessor();
+
+        StageResult result = processor.process(new StageContext(
+                "job-122",
+                "stage-6",
+                Map.of("claims", List.of(Map.of(
+                        "claimType", "ECONOMIC_IMPACT",
+                        "status", "ACCEPTED",
+                        "epistemicState", "VALIDATED",
+                        "canonicalDomain", "a.com")))));
+
+        assertThat(result.status()).isEqualTo("NO_PUBLIC_EVIDENCE");
+        assertThat(result.output()).containsEntry("evidenceLevel", "E0_MODEL_HYPOTHESIS");
+    }
+
+    private Map<String, Object> claim(String type, String domain) {
+        return Map.of(
+                "claimType", type,
+                "status", "ACCEPTED",
+                "epistemicState", "VALIDATED",
+                "exactEvidenceSpan", "trecho literal da fonte com evidência operacional suficiente",
+                "canonicalDomain", domain);
+    }
+}


### PR DESCRIPTION
### Motivation
- Entregar a Etapa 6 (Evidence Level Gate E0–E5) do pipeline NichoCNAE v2 para decidir materialização comercial com evidência auditável, mantendo regras de negócio e lógica no executor externo. 
- Garantir que o backend permaneça apenas como camada de leitura/escrita de pendências/resultado/falhas, evitando cálculo de decisão comercial no servidor.
- Separar claramente sinais de atividade, rotina/dor, impacto econômico e intenção de compra para evitar materializações equivocadas.

### Description
- Adiciona no executor `oprm-coletor-mei` o processor `CommercialEvidenceGateProcessor` que calcula nível E0–E5, confiança explicável, ganho informacional, gaps e decisão (`MATERIALIZE`, `HUMAN_REVIEW`, `NEEDS_MORE_RESEARCH`, `NO_PUBLIC_EVIDENCE`).
- Cria no backend contratos e borda HTTP apenas para leitura/escrita da etapa em `backend/ads-service` (`pending`, criação, `complete`, `fail`) incluindo DTOs `record` para os contratos e serviço `BackendCommercialEvidenceGateService` que persiste execuções de estágio sem lógica de decisão.
- Documenta o endpoint interno em `docs/swagger/oprm-nichocnae-v2-commercial-evidence-gate-swagger.yaml` e atualiza a tela do pipeline v2 para marcar o gate como "Design aprovado · implementação inicial".
- Inclui testes unitários no executor que cobrem materialização a partir de E3, separação de dor vs. compra e bloqueio de claim sem trecho exato, e registra mudança em `docs/registros/oprm1.md`.

### Testing
- Executados testes unitários do executor com `mvn test -Dtest=CommercialEvidenceGateProcessorTest,NichoCnaeV2PipelineArchitectureTest` dentro de `oprm-coletor-mei`; todos os testes passaram.
- Compilação do backend com `../mvnw -q -DskipTests compile` em `backend/ads-service` concluída com sucesso.
- Execução parcial de testes do backend com `../mvnw -q -Dtest='*CandidateGeneratorServiceTest,*SourceFetcherReranker*' test` foi executada conforme rotina de verificação e concluiu sem falhas relevantes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a354aecb3b48321ae8123e9864eb07d)