### PR TITLE
Implementa reforço da etapa 7 (Commercial Evidence Gate) NichoCNAE v2

### DIFF
--- a/backend/ads-service/src/test/java/com/marketinghub/oprm/nichocnae/v2/commercialevidencegate/service/BackendCommercialEvidenceGateServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/oprm/nichocnae/v2/commercialevidencegate/service/BackendCommercialEvidenceGateServiceTest.java
@@ -1,0 +1,146 @@
+package com.marketinghub.oprm.nichocnae.v2.commercialevidencegate.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.marketinghub.oprm.nichocnae.v2.OprmNichoCnaeV2FailureType;
+import com.marketinghub.oprm.nichocnae.v2.OprmNichoCnaeV2StageExecution;
+import com.marketinghub.oprm.nichocnae.v2.OprmNichoCnaeV2StageExecutionStatus;
+import com.marketinghub.oprm.nichocnae.v2.commercialevidencegate.service.completeStageExecution.CommercialEvidenceGateCompletionRequest;
+import com.marketinghub.oprm.nichocnae.v2.commercialevidencegate.service.createStageExecution.CommercialEvidenceGateCreateRequest;
+import com.marketinghub.oprm.nichocnae.v2.commercialevidencegate.service.failStageExecution.CommercialEvidenceGateFailureRequest;
+import com.marketinghub.oprm.nichocnae.v2.commercialevidencegate.service.pending.CommercialEvidenceGatePendingResponse;
+import com.marketinghub.repository.jpa.oprm.nichocnae.v2.OprmNichoCnaeV2StageExecutionRepository;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Pageable;
+
+/** Valida que o backend da etapa commercial-evidence-gate atua somente como leitura e escrita para o executor. */
+@ExtendWith(MockitoExtension.class)
+class BackendCommercialEvidenceGateServiceTest {
+    @Mock private OprmNichoCnaeV2StageExecutionRepository stageExecutionRepository;
+
+    /** Deve manter a etapa 7 sem pendências quando a feature flag da v2 estiver desligada. */
+    @Test
+    void pendingReturnsEmptyWhenFeatureFlagIsDisabled() {
+        BackendCommercialEvidenceGateService service = service(false);
+        List<CommercialEvidenceGatePendingResponse> result = service.pending();
+        assertThat(result).isEmpty();
+        verify(stageExecutionRepository, never()).findByStageCodeAndStatusOrderByCreatedAtAsc(any(), any(), any());
+    }
+
+    /** Deve entregar ao executor o payload persistido sem recalcular regra comercial no backend. */
+    @Test
+    void pendingReturnsCommercialEvidenceGateExecutions() {
+        BackendCommercialEvidenceGateService service = service(true);
+        when(stageExecutionRepository.findByStageCodeAndStatusOrderByCreatedAtAsc(
+                        eq("commercial-evidence-gate"),
+                        eq(OprmNichoCnaeV2StageExecutionStatus.PENDING),
+                        any(Pageable.class)))
+                .thenReturn(List.of(execution(700L)));
+        List<CommercialEvidenceGatePendingResponse> result = service.pending();
+        assertThat(result).hasSize(1);
+        assertThat(result.getFirst().stageExecutionId()).isEqualTo("700");
+        assertThat(result.getFirst().inputPayload()).contains("validatedClaims");
+    }
+
+    /** Deve persistir exatamente a decisão enviada pelo executor, sem aplicar regra E0-E5 no backend. */
+    @Test
+    void completePersistsExecutorDecisionOnly() {
+        BackendCommercialEvidenceGateService service = service(true);
+        OprmNichoCnaeV2StageExecution execution = execution(701L);
+        when(stageExecutionRepository.findByIdAndStageCode(701L, "commercial-evidence-gate"))
+                .thenReturn(Optional.of(execution));
+        when(stageExecutionRepository.save(any(OprmNichoCnaeV2StageExecution.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+        var response = service.complete(
+                701L,
+                new CommercialEvidenceGateCompletionRequest(
+                        "E0_MODEL_HYPOTHESIS",
+                        0.05,
+                        true,
+                        false,
+                        0.0,
+                        "MATERIALIZE",
+                        "enriched-niche-materializer",
+                        "{\"gateDecision\":\"MATERIALIZE\"}"));
+        assertThat(response.status()).isEqualTo("COMPLETED");
+        assertThat(response.evidenceLevel()).isEqualTo("E0_MODEL_HYPOTHESIS");
+        assertThat(response.automaticMaterializationAllowed()).isTrue();
+        assertThat(response.nextStageCode()).isEqualTo("enriched-niche-materializer");
+    }
+
+    /** Deve gravar pendência da etapa 7 quando o executor solicitar reprocessamento cognitivo. */
+    @Test
+    void createPersistsPendingExecutionRequestedByExecutor() {
+        BackendCommercialEvidenceGateService service = service(true);
+        when(stageExecutionRepository.save(any(OprmNichoCnaeV2StageExecution.class))).thenAnswer(invocation -> {
+            OprmNichoCnaeV2StageExecution saved = invocation.getArgument(0);
+            saved.setId(702L);
+            return saved;
+        });
+        var response = service.create(new CommercialEvidenceGateCreateRequest(
+                "job-72", 72L, 69L, "4781400", 3, 5, false, "{\"validatedClaims\":[]}"));
+        assertThat(response.stageExecutionId()).isEqualTo("702");
+        assertThat(response.status()).isEqualTo("PENDING");
+        assertThat(response.stageCode()).isEqualTo("commercial-evidence-gate");
+    }
+
+    /** Deve preservar retry técnico sem mudar tentativa cognitiva quando a falha da etapa 7 for infraestrutura. */
+    @Test
+    void failCreatesTechnicalRetryForInfrastructureFailure() {
+        BackendCommercialEvidenceGateService service = service(true);
+        OprmNichoCnaeV2StageExecution execution = execution(703L);
+        when(stageExecutionRepository.findByIdAndStageCode(703L, "commercial-evidence-gate"))
+                .thenReturn(Optional.of(execution));
+        when(stageExecutionRepository.save(any(OprmNichoCnaeV2StageExecution.class))).thenAnswer(invocation -> {
+            OprmNichoCnaeV2StageExecution saved = invocation.getArgument(0);
+            if (saved.getId() == null) {
+                saved.setId(704L);
+            }
+            return saved;
+        });
+        var response = service.fail(
+                703L,
+                new CommercialEvidenceGateFailureRequest(
+                        OprmNichoCnaeV2FailureType.INFRASTRUCTURE, "TIMEOUT no callback do executor", "{}"));
+        assertThat(response.status()).isEqualTo("TECHNICAL_RETRY_SCHEDULED");
+        assertThat(response.retryStageExecutionId()).isEqualTo("704");
+        assertThat(response.attemptNumber()).isEqualTo(3);
+        assertThat(response.technicalRetryNumber()).isEqualTo(1);
+    }
+
+    /** Cria o service testável com flag explícita para a v2. */
+    private BackendCommercialEvidenceGateService service(boolean v2Enabled) {
+        return new BackendCommercialEvidenceGateService(stageExecutionRepository, v2Enabled);
+    }
+
+    /** Monta execução persistida mínima da etapa commercial-evidence-gate. */
+    private OprmNichoCnaeV2StageExecution execution(Long id) {
+        OprmNichoCnaeV2StageExecution execution = new OprmNichoCnaeV2StageExecution();
+        execution.setId(id);
+        execution.setJobId("job-72");
+        execution.setResearchCycleId(72L);
+        execution.setSourceNicheId(69L);
+        execution.setCnaeCode("4781400");
+        execution.setStageCode("commercial-evidence-gate");
+        execution.setAttemptNumber(3);
+        execution.setTechnicalRetryNumber(0);
+        execution.setKnowledgeVersion(5);
+        execution.setStatus(OprmNichoCnaeV2StageExecutionStatus.PENDING);
+        execution.setInputPayload("{\"validatedClaims\":[{\"claimType\":\"TASK\"}]}");
+        execution.setMaterializationEnabled(false);
+        execution.setCreatedAt(Instant.parse("2026-06-19T10:00:00Z"));
+        execution.setUpdatedAt(Instant.parse("2026-06-19T10:00:00Z"));
+        return execution;
+    }
+}

--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -1055,3 +1055,9 @@
 - Implementada a etapa `commercial-evidence-gate` no executor OPRM para calcular níveis E0-E5, confiança explicável, ganho informacional, revisão humana seletiva e liberação gradual de materialização automática.
 - Criado contrato interno no backend apenas para leitura/escrita de pendências, conclusão e falhas da etapa; a lógica comercial permaneceu no executor externo.
 - Atualizada a tela do pipeline v2 para sinalizar a implementação inicial do Evidence Level Gate E0-E5.
+
+## 2026-06-19 — Reforço da etapa 7 Commercial Evidence Gate NichoCNAE v2
+
+- Reforçada a etapa `commercial-evidence-gate` no executor `oprm-coletor-mei` para impedir materialização automática quando houver menos de três domínios independentes ou evidência contraditória pendente.
+- A decisão E0-E5, confiança, gaps, contradições e próximo movimento continuam calculados exclusivamente no executor externo; o backend foi coberto por teste para atuar apenas como leitura/escrita da decisão recebida.
+- Adicionados testes de regressão para independência mínima de fontes, revisão humana por contradição e contratos backend sem regra comercial.

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnaev2/pipeline/commercialevidencegate/CommercialEvidenceGateProcessor.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnaev2/pipeline/commercialevidencegate/CommercialEvidenceGateProcessor.java
@@ -22,14 +22,22 @@ public final class CommercialEvidenceGateProcessor implements StageProcessor {
     /** Avalia claims aceitos e snapshot acumulado para decidir materialização, revisão humana ou nova pesquisa. */
     @Override
     public StageResult process(StageContext context) {
-        List<Map<String, Object>> claims = acceptedClaims(context.input());
-        EvidenceCounts counts = countEvidence(claims);
+        List<Map<String, Object>> allClaims = candidateClaims(context.input());
+        List<Map<String, Object>> claims = acceptedClaims(allClaims);
+        EvidenceCounts counts = countEvidence(claims, allClaims);
         String evidenceLevel = evidenceLevel(counts);
         double confidence = confidence(counts);
         double informationGain = informationGain(context.input(), evidenceLevel, counts.totalSignals());
         boolean materializationEnabled = booleanValue(context.input().get("materializationEnabled"));
-        boolean automaticMaterializationAllowed = materializationEnabled && levelRank(evidenceLevel) >= 3 && confidence >= 0.70;
-        boolean humanReviewRequired = levelRank(evidenceLevel) >= 3 && confidence < 0.70;
+        boolean hasMinimumCommercialIndependence = counts.independentDomainCount() >= 3;
+        boolean automaticMaterializationAllowed = materializationEnabled
+                && levelRank(evidenceLevel) >= 3
+                && confidence >= 0.70
+                && hasMinimumCommercialIndependence
+                && counts.contradictionSignals() == 0;
+        boolean humanReviewRequired = levelRank(evidenceLevel) >= 3
+                && !automaticMaterializationAllowed
+                && (confidence >= 0.55 || counts.contradictionSignals() > 0);
         List<String> missingEvidence = missingEvidence(counts);
         String gateDecision = gateDecision(automaticMaterializationAllowed, humanReviewRequired, evidenceLevel, informationGain);
         String nextStageCode = nextStageCode(gateDecision);
@@ -45,11 +53,14 @@ public final class CommercialEvidenceGateProcessor implements StageProcessor {
         output.put("nextStageCode", nextStageCode);
         output.put("missingEvidence", missingEvidence);
         output.put("evidenceCounts", counts.asMap());
-        output.put("commercialSeparation", Map.of(
-                "activityExists", counts.activitySignals(),
-                "recurringPain", counts.painSignals(),
-                "economicImpact", counts.economicSignals(),
-                "purchaseIntent", counts.purchaseSignals()));
+        output.put(
+                "commercialSeparation",
+                Map.of(
+                        "activityExists", counts.activitySignals(),
+                        "recurringPain", counts.painSignals(),
+                        "economicImpact", counts.economicSignals(),
+                        "purchaseIntent", counts.purchaseSignals(),
+                        "contradictions", counts.contradictionSignals()));
         return new StageResult(gateDecision, output, List.of(new StageArtifact(
                 "COMMERCIAL_EVIDENCE_GATE",
                 "inline://commercial-evidence-gate/decision",
@@ -57,11 +68,16 @@ public final class CommercialEvidenceGateProcessor implements StageProcessor {
     }
 
     /** Filtra claims aceitos e validados sem transformar rejeição em sinal positivo. */
-    private List<Map<String, Object>> acceptedClaims(Map<String, Object> input) {
+    private List<Map<String, Object>> candidateClaims(Map<String, Object> input) {
         List<Map<String, Object>> claims = mapList(input.get("claims"));
         if (claims.isEmpty()) {
             claims = mapList(input.get("validatedClaims"));
         }
+        return claims;
+    }
+
+    /** Filtra somente os claims que podem ser usados como sinal comercial positivo. */
+    private List<Map<String, Object>> acceptedClaims(List<Map<String, Object>> claims) {
         return claims.stream().filter(this::isAccepted).toList();
     }
 
@@ -76,13 +92,14 @@ public final class CommercialEvidenceGateProcessor implements StageProcessor {
     }
 
     /** Conta sinais separados de atividade, dor, impacto econômico, intenção e compra real. */
-    private EvidenceCounts countEvidence(List<Map<String, Object>> claims) {
+    private EvidenceCounts countEvidence(List<Map<String, Object>> claims, List<Map<String, Object>> allClaims) {
         int activities = 0;
         int tasks = 0;
         int pains = 0;
         int economic = 0;
         int purchase = 0;
         int offers = 0;
+        int contradictions = 0;
         List<String> domains = new ArrayList<>();
         for (Map<String, Object> claim : claims) {
             String type = text(claim.get("claimType")).toUpperCase(Locale.ROOT);
@@ -109,7 +126,17 @@ public final class CommercialEvidenceGateProcessor implements StageProcessor {
                 domains.add(domain);
             }
         }
-        return new EvidenceCounts(activities, tasks, pains, economic, purchase, offers, domains.size());
+        contradictions = (int) allClaims.stream().filter(this::isContradictory).count();
+        return new EvidenceCounts(activities, tasks, pains, economic, purchase, offers, contradictions, domains.size());
+    }
+
+    /** Identifica contradições explícitas para impedir promoção automática de evidência comercial. */
+    private boolean isContradictory(Map<String, Object> claim) {
+        String state = text(claim.get("epistemicState")).toUpperCase(Locale.ROOT);
+        String relation = text(claim.get("relationToTargetClaim")).toUpperCase(Locale.ROOT);
+        return state.equals("CONTRADICTED")
+                || relation.equals("CONTRADICTS")
+                || Boolean.TRUE.equals(claim.get("contradictsTarget"));
     }
 
     /** Define o nível E0-E5 sem misturar dor, impacto econômico e intenção de compra. */
@@ -120,7 +147,10 @@ public final class CommercialEvidenceGateProcessor implements StageProcessor {
         if (counts.purchaseSignals() > 0) {
             return "E4_PURCHASE_INTENT";
         }
-        if (counts.economicSignals() > 0 && counts.painSignals() >= 2 && counts.taskSignals() >= 3) {
+        if (counts.economicSignals() > 0
+                && counts.painSignals() >= 2
+                && counts.taskSignals() >= 3
+                && counts.independentDomainCount() >= 3) {
             return "E3_ECONOMIC_PAIN";
         }
         if (counts.painSignals() > 0 && counts.taskSignals() > 0) {
@@ -139,8 +169,9 @@ public final class CommercialEvidenceGateProcessor implements StageProcessor {
                 + (counts.economicSignals() * 0.18)
                 + (counts.purchaseSignals() * 0.20)
                 + (counts.offerSignals() * 0.24)
-                + (Math.min(counts.independentDomainCount(), 5) * 0.06);
-        return Math.round(Math.min(0.95, raw) * 100.0) / 100.0;
+                + (Math.min(counts.independentDomainCount(), 5) * 0.06)
+                - (counts.contradictionSignals() * 0.18);
+        return Math.round(Math.max(0.0, Math.min(0.95, raw)) * 100.0) / 100.0;
     }
 
     /** Calcula ganho informacional da tentativa atual em relação ao nível anterior informado no snapshot. */
@@ -168,6 +199,9 @@ public final class CommercialEvidenceGateProcessor implements StageProcessor {
         }
         if (counts.independentDomainCount() < 3) {
             missing.add("THREE_INDEPENDENT_DOMAINS");
+        }
+        if (counts.contradictionSignals() > 0) {
+            missing.add("RESOLVE_CONTRADICTORY_EVIDENCE");
         }
         return missing;
     }
@@ -241,6 +275,7 @@ public final class CommercialEvidenceGateProcessor implements StageProcessor {
             int economicSignals,
             int purchaseSignals,
             int offerSignals,
+            int contradictionSignals,
             int independentDomainCount) {
         /** Soma todos os sinais aceitos para cálculo de ganho informacional. */
         int totalSignals() {
@@ -256,6 +291,7 @@ public final class CommercialEvidenceGateProcessor implements StageProcessor {
                     "economicSignals", economicSignals,
                     "purchaseSignals", purchaseSignals,
                     "offerSignals", offerSignals,
+                    "contradictionSignals", contradictionSignals,
                     "independentDomainCount", independentDomainCount);
         }
     }

--- a/oprm-coletor-mei/src/test/java/com/marketinghub/nichocnaev2/pipeline/commercialevidencegate/CommercialEvidenceGateProcessorTest.java
+++ b/oprm-coletor-mei/src/test/java/com/marketinghub/nichocnaev2/pipeline/commercialevidencegate/CommercialEvidenceGateProcessorTest.java
@@ -70,6 +70,62 @@ class CommercialEvidenceGateProcessorTest {
         assertThat(result.output()).containsEntry("evidenceLevel", "E0_MODEL_HYPOTHESIS");
     }
 
+    @Test
+    void shouldRequireIndependentDomainsBeforeAutomaticMaterialization() {
+        CommercialEvidenceGateProcessor processor = new CommercialEvidenceGateProcessor();
+
+        StageResult result = processor.process(new StageContext(
+                "job-123",
+                "stage-7",
+                Map.of(
+                        "materializationEnabled", true,
+                        "claims", List.of(
+                                claim("TASK", "a.com"),
+                                claim("TASK", "a.com"),
+                                claim("TASK", "b.com"),
+                                claim("PAIN", "a.com"),
+                                claim("PRACTICAL_PAIN", "b.com"),
+                                claim("ECONOMIC_IMPACT", "b.com")))));
+
+        assertThat(result.status()).isEqualTo("NEEDS_MORE_RESEARCH");
+        assertThat(result.output()).containsEntry("evidenceLevel", "E2_ROUTINE_AND_PAIN");
+        assertThat(result.output()).containsEntry("automaticMaterializationAllowed", false);
+        @SuppressWarnings("unchecked")
+        List<String> missing = (List<String>) result.output().get("missingEvidence");
+        assertThat(missing).contains("THREE_INDEPENDENT_DOMAINS");
+    }
+
+    @Test
+    void shouldSendContradictoryEconomicEvidenceToHumanReviewInsteadOfMaterializing() {
+        CommercialEvidenceGateProcessor processor = new CommercialEvidenceGateProcessor();
+
+        StageResult result = processor.process(new StageContext(
+                "job-124",
+                "stage-7",
+                Map.of(
+                        "materializationEnabled", true,
+                        "claims", List.of(
+                                claim("TASK", "a.com"),
+                                claim("TASK", "b.com"),
+                                claim("TASK", "c.com"),
+                                claim("PAIN", "a.com"),
+                                claim("PRACTICAL_PAIN", "b.com"),
+                                claim("ECONOMIC_IMPACT", "c.com"),
+                                Map.of(
+                                        "claimType", "ECONOMIC_IMPACT",
+                                        "status", "REJECTED",
+                                        "epistemicState", "CONTRADICTED",
+                                        "exactEvidenceSpan", "trecho literal que contradiz o impacto econômico",
+                                        "canonicalDomain", "d.com")))));
+
+        assertThat(result.status()).isEqualTo("HUMAN_REVIEW");
+        assertThat(result.output()).containsEntry("automaticMaterializationAllowed", false);
+        assertThat(result.output()).containsEntry("humanReviewRequired", true);
+        @SuppressWarnings("unchecked")
+        List<String> missing = (List<String>) result.output().get("missingEvidence");
+        assertThat(missing).contains("RESOLVE_CONTRADICTORY_EVIDENCE");
+    }
+
     private Map<String, Object> claim(String type, String domain) {
         return Map.of(
                 "claimType", type,


### PR DESCRIPTION
### Motivation
- Evitar materialização automática de nichos com evidência insuficiente ou contraditória, garantindo segurança comercial e auditabilidade antes de avançar para materialização.
- Manter a responsabilidade de decisão, controle e regras de negócio no executor externo, enquanto o backend permanece apenas como camada de leitura/escrita do estado do estágio.

### Description
- No executor `oprm-coletor-mei` atualizei `CommercialEvidenceGateProcessor` para exigir pelo menos três domínios independentes e ausência de contradições explícitas para liberar `automaticMaterializationAllowed`, além de expor `contradictions` no `commercialSeparation` do payload de saída.
- Adicionei detecção de contradições (`isContradictory`) e passei a usar `candidateClaims` + `acceptedClaims` para separar entrada bruta e sinais aceitos, e ajustei a fórmula de `confidence` para penalizar contradições.
- Incluí testes de regressão no executor em `CommercialEvidenceGateProcessorTest` cobrindo independência mínima de domínios e envio para `HUMAN_REVIEW` quando houver evidência contraditória, e adicionei `BackendCommercialEvidenceGateServiceTest` no backend para garantir que o backend apenas persiste/entrega decisões do executor sem recalcular regras comerciais.
- Atualizei o registro operacional em `docs/registros/oprm1.md` para documentar a mudança e o reforço da etapa 7.

### Testing
- Executado `mvn -Dtest=CommercialEvidenceGateProcessorTest test` no módulo `oprm-coletor-mei`, com todos os testes verdes (5 tests, 0 failures). 
- Executado `../mvnw -Dtest=BackendCommercialEvidenceGateServiceTest test` no `backend/ads-service`, com todos os testes verdes (5 tests, 0 failures), confirmando que o backend atua apenas como leitura/escrita do stage execution contract.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a355f82ad908321acefd9c5d7e5baff)