### PR TITLE
Implementa etapa 8 (Knowledge Accumulator) do pipeline NichoCNAE v2

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/knowledgeaccumulator/controller/BackendKnowledgeAccumulatorController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/knowledgeaccumulator/controller/BackendKnowledgeAccumulatorController.java
@@ -1,0 +1,55 @@
+package com.marketinghub.oprm.nichocnae.v2.knowledgeaccumulator.controller;
+
+import com.marketinghub.oprm.nichocnae.v2.knowledgeaccumulator.service.BackendKnowledgeAccumulatorService;
+import com.marketinghub.oprm.nichocnae.v2.knowledgeaccumulator.service.completeStageExecution.KnowledgeAccumulatorCompletionRequest;
+import com.marketinghub.oprm.nichocnae.v2.knowledgeaccumulator.service.completeStageExecution.KnowledgeAccumulatorCompletionResponse;
+import com.marketinghub.oprm.nichocnae.v2.knowledgeaccumulator.service.createStageExecution.KnowledgeAccumulatorCreateRequest;
+import com.marketinghub.oprm.nichocnae.v2.knowledgeaccumulator.service.createStageExecution.KnowledgeAccumulatorCreateResponse;
+import com.marketinghub.oprm.nichocnae.v2.knowledgeaccumulator.service.failStageExecution.KnowledgeAccumulatorFailureRequest;
+import com.marketinghub.oprm.nichocnae.v2.knowledgeaccumulator.service.failStageExecution.KnowledgeAccumulatorFailureResponse;
+import com.marketinghub.oprm.nichocnae.v2.knowledgeaccumulator.service.pending.KnowledgeAccumulatorPendingResponse;
+import java.util.List;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/** Borda HTTP interna da etapa knowledge-accumulator do pipeline NichoCNAE versão 2. */
+@RestController
+@RequestMapping("/api/internal/oprm/nichocnae/v2/knowledge-accumulator/stage-executions")
+public class BackendKnowledgeAccumulatorController {
+    private final BackendKnowledgeAccumulatorService service;
+
+    /** Recebe o service canônico da etapa para delegar operações HTTP internas. */
+    public BackendKnowledgeAccumulatorController(BackendKnowledgeAccumulatorService service) {
+        this.service = service;
+    }
+
+    /** Entrega execuções pendentes da etapa knowledge-accumulator ao módulo executor OPRM. */
+    @GetMapping("/pending")
+    public List<KnowledgeAccumulatorPendingResponse> pending() {
+        return service.pending();
+    }
+
+    /** Grava uma pendência da etapa knowledge-accumulator solicitada pelo módulo executor OPRM. */
+    @PostMapping
+    public KnowledgeAccumulatorCreateResponse create(@RequestBody KnowledgeAccumulatorCreateRequest request) {
+        return service.create(request);
+    }
+
+    /** Registra a conclusão da execução de acumulação de conhecimento informada pelo módulo executor OPRM. */
+    @PostMapping("/{stageExecutionId}/complete")
+    public KnowledgeAccumulatorCompletionResponse complete(
+            @PathVariable Long stageExecutionId, @RequestBody KnowledgeAccumulatorCompletionRequest request) {
+        return service.complete(stageExecutionId, request);
+    }
+
+    /** Registra a falha da execução de acumulação de conhecimento informada pelo módulo executor OPRM. */
+    @PostMapping("/{stageExecutionId}/fail")
+    public KnowledgeAccumulatorFailureResponse fail(
+            @PathVariable Long stageExecutionId, @RequestBody KnowledgeAccumulatorFailureRequest request) {
+        return service.fail(stageExecutionId, request);
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/knowledgeaccumulator/service/BackendKnowledgeAccumulatorService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/knowledgeaccumulator/service/BackendKnowledgeAccumulatorService.java
@@ -1,0 +1,169 @@
+package com.marketinghub.oprm.nichocnae.v2.knowledgeaccumulator.service;
+
+import com.marketinghub.oprm.nichocnae.v2.OprmNichoCnaeV2FailureType;
+import com.marketinghub.oprm.nichocnae.v2.OprmNichoCnaeV2StageExecution;
+import com.marketinghub.oprm.nichocnae.v2.OprmNichoCnaeV2StageExecutionStatus;
+import com.marketinghub.oprm.nichocnae.v2.knowledgeaccumulator.service.completeStageExecution.KnowledgeAccumulatorCompletionRequest;
+import com.marketinghub.oprm.nichocnae.v2.knowledgeaccumulator.service.completeStageExecution.KnowledgeAccumulatorCompletionResponse;
+import com.marketinghub.oprm.nichocnae.v2.knowledgeaccumulator.service.createStageExecution.KnowledgeAccumulatorCreateRequest;
+import com.marketinghub.oprm.nichocnae.v2.knowledgeaccumulator.service.createStageExecution.KnowledgeAccumulatorCreateResponse;
+import com.marketinghub.oprm.nichocnae.v2.knowledgeaccumulator.service.failStageExecution.KnowledgeAccumulatorFailureRequest;
+import com.marketinghub.oprm.nichocnae.v2.knowledgeaccumulator.service.failStageExecution.KnowledgeAccumulatorFailureResponse;
+import com.marketinghub.oprm.nichocnae.v2.knowledgeaccumulator.service.pending.KnowledgeAccumulatorPendingResponse;
+import com.marketinghub.repository.jpa.oprm.nichocnae.v2.OprmNichoCnaeV2StageExecutionRepository;
+import java.time.Instant;
+import java.util.List;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+/** Expõe contratos de leitura/escrita do backend para a etapa knowledge-accumulator do pipeline NichoCNAE v2. */
+@Service
+public class BackendKnowledgeAccumulatorService {
+    public static final String STAGE_CODE = "knowledge-accumulator";
+    private final OprmNichoCnaeV2StageExecutionRepository stageExecutionRepository;
+    private final boolean v2Enabled;
+
+    /** Inicializa o service com repositório canônico e feature flag de calibração da v2. */
+    public BackendKnowledgeAccumulatorService(
+            OprmNichoCnaeV2StageExecutionRepository stageExecutionRepository,
+            @Value("${oprm.nichocnae.v2.enabled:false}") boolean v2Enabled) {
+        this.stageExecutionRepository = stageExecutionRepository;
+        this.v2Enabled = v2Enabled;
+    }
+
+    /** Lista pendências disponíveis para consumo canônico pelo executor OPRM NichoCNAE v2. */
+    @Transactional(readOnly = true)
+    public List<KnowledgeAccumulatorPendingResponse> pending() {
+        if (!v2Enabled) {
+            return List.of();
+        }
+        return stageExecutionRepository
+                .findByStageCodeAndStatusOrderByCreatedAtAsc(
+                        STAGE_CODE, OprmNichoCnaeV2StageExecutionStatus.PENDING, PageRequest.of(0, 5))
+                .stream()
+                .map(this::toPendingResponse)
+                .toList();
+    }
+
+    /** Registra conclusão da acumulação de conhecimento usando a próxima etapa informada pelo executor externo. */
+    @Transactional
+    public KnowledgeAccumulatorCompletionResponse complete(
+            Long stageExecutionId, KnowledgeAccumulatorCompletionRequest request) {
+        OprmNichoCnaeV2StageExecution execution = findExecution(stageExecutionId);
+        execution.setStatus(OprmNichoCnaeV2StageExecutionStatus.COMPLETED);
+        execution.setOutputPayload(request == null ? null : request.outputPayload());
+        execution.setNextStageCode(request == null ? null : request.nextStageCode());
+        execution.setUpdatedAt(Instant.now());
+        OprmNichoCnaeV2StageExecution saved = stageExecutionRepository.save(execution);
+        return new KnowledgeAccumulatorCompletionResponse(
+                String.valueOf(saved.getId()),
+                saved.getStatus().name(),
+                saved.getNextStageCode(),
+                request == null ? null : request.knowledgeVersion(),
+                request == null ? null : request.validatedFactCount(),
+                request == null ? null : request.acceptedSourceCount(),
+                request == null ? null : request.rejectedSourceCount());
+    }
+
+    /** Registra falha e cria nova execução somente quando a falha for retry técnico de infraestrutura. */
+    @Transactional
+    public KnowledgeAccumulatorFailureResponse fail(Long stageExecutionId, KnowledgeAccumulatorFailureRequest request) {
+        OprmNichoCnaeV2StageExecution execution = findExecution(stageExecutionId);
+        OprmNichoCnaeV2FailureType failureType = request == null || request.failureType() == null
+                ? OprmNichoCnaeV2FailureType.VALIDATION
+                : request.failureType();
+        execution.setFailureType(failureType);
+        execution.setErrorMessage(request == null ? null : request.errorMessage());
+        execution.setInputPayload(request == null ? execution.getInputPayload() : request.inputPayload());
+        execution.setUpdatedAt(Instant.now());
+        if (failureType == OprmNichoCnaeV2FailureType.INFRASTRUCTURE) {
+            execution.setStatus(OprmNichoCnaeV2StageExecutionStatus.TECHNICAL_RETRY_SCHEDULED);
+            OprmNichoCnaeV2StageExecution retry = createTechnicalRetry(execution);
+            stageExecutionRepository.save(execution);
+            OprmNichoCnaeV2StageExecution savedRetry = stageExecutionRepository.save(retry);
+            return new KnowledgeAccumulatorFailureResponse(
+                    String.valueOf(execution.getId()),
+                    execution.getStatus().name(),
+                    String.valueOf(savedRetry.getId()),
+                    savedRetry.getAttemptNumber(),
+                    savedRetry.getTechnicalRetryNumber());
+        }
+        execution.setStatus(OprmNichoCnaeV2StageExecutionStatus.FAILED);
+        OprmNichoCnaeV2StageExecution saved = stageExecutionRepository.save(execution);
+        return new KnowledgeAccumulatorFailureResponse(
+                String.valueOf(saved.getId()),
+                saved.getStatus().name(),
+                null,
+                saved.getAttemptNumber(),
+                saved.getTechnicalRetryNumber());
+    }
+
+    /** Grava uma pendência da etapa de acumulação de conhecimento solicitada pelo executor externo. */
+    @Transactional
+    public KnowledgeAccumulatorCreateResponse create(KnowledgeAccumulatorCreateRequest request) {
+        OprmNichoCnaeV2StageExecution saved = stageExecutionRepository.save(toPendingExecution(request));
+        return new KnowledgeAccumulatorCreateResponse(
+                String.valueOf(saved.getId()), saved.getStatus().name(), saved.getStageCode());
+    }
+
+    /** Converte o contrato recebido do executor em entidade persistível, sem decidir regra operacional. */
+    private OprmNichoCnaeV2StageExecution toPendingExecution(KnowledgeAccumulatorCreateRequest request) {
+        Instant now = Instant.now();
+        OprmNichoCnaeV2StageExecution execution = new OprmNichoCnaeV2StageExecution();
+        execution.setJobId(request.jobId());
+        execution.setResearchCycleId(request.researchCycleId());
+        execution.setSourceNicheId(request.sourceNicheId());
+        execution.setCnaeCode(request.cnaeCode());
+        execution.setStageCode(STAGE_CODE);
+        execution.setAttemptNumber(request.attemptNumber());
+        execution.setTechnicalRetryNumber(0);
+        execution.setKnowledgeVersion(request.knowledgeVersion());
+        execution.setStatus(OprmNichoCnaeV2StageExecutionStatus.PENDING);
+        execution.setInputPayload(request.inputPayload());
+        execution.setMaterializationEnabled(Boolean.TRUE.equals(request.materializationEnabled()));
+        execution.setCreatedAt(now);
+        execution.setUpdatedAt(now);
+        return execution;
+    }
+
+    /** Cria uma nova linha para retry técnico preservando a tentativa cognitiva e a versão de conhecimento. */
+    private OprmNichoCnaeV2StageExecution createTechnicalRetry(OprmNichoCnaeV2StageExecution previousExecution) {
+        OprmNichoCnaeV2StageExecution retry = toPendingExecution(new KnowledgeAccumulatorCreateRequest(
+                previousExecution.getJobId(),
+                previousExecution.getResearchCycleId(),
+                previousExecution.getSourceNicheId(),
+                previousExecution.getCnaeCode(),
+                previousExecution.getAttemptNumber(),
+                previousExecution.getKnowledgeVersion(),
+                previousExecution.getMaterializationEnabled(),
+                previousExecution.getInputPayload()));
+        retry.setTechnicalRetryNumber(previousExecution.getTechnicalRetryNumber() + 1);
+        return retry;
+    }
+
+    /** Carrega a execução da etapa atual ou devolve erro HTTP claro ao executor. */
+    private OprmNichoCnaeV2StageExecution findExecution(Long stageExecutionId) {
+        return stageExecutionRepository
+                .findByIdAndStageCode(stageExecutionId, STAGE_CODE)
+                .orElseThrow(() -> new ResponseStatusException(
+                        HttpStatus.NOT_FOUND,
+                        "NichoCNAE v2 knowledge-accumulator stage execution not found: " + stageExecutionId));
+    }
+
+    /** Converte a entidade persistida no contrato canônico de pending do executor. */
+    private KnowledgeAccumulatorPendingResponse toPendingResponse(OprmNichoCnaeV2StageExecution execution) {
+        return new KnowledgeAccumulatorPendingResponse(
+                String.valueOf(execution.getId()),
+                execution.getJobId(),
+                execution.getCnaeCode(),
+                execution.getSourceNicheId(),
+                execution.getAttemptNumber(),
+                execution.getTechnicalRetryNumber(),
+                execution.getKnowledgeVersion(),
+                execution.getInputPayload());
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/knowledgeaccumulator/service/completeStageExecution/KnowledgeAccumulatorCompletionRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/knowledgeaccumulator/service/completeStageExecution/KnowledgeAccumulatorCompletionRequest.java
@@ -1,0 +1,10 @@
+package com.marketinghub.oprm.nichocnae.v2.knowledgeaccumulator.service.completeStageExecution;
+
+/** Contrato recebido do executor ao concluir a etapa knowledge-accumulator do NichoCNAE v2. */
+public record KnowledgeAccumulatorCompletionRequest(
+        Integer knowledgeVersion,
+        Integer validatedFactCount,
+        Integer acceptedSourceCount,
+        Integer rejectedSourceCount,
+        String outputPayload,
+        String nextStageCode) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/knowledgeaccumulator/service/completeStageExecution/KnowledgeAccumulatorCompletionResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/knowledgeaccumulator/service/completeStageExecution/KnowledgeAccumulatorCompletionResponse.java
@@ -1,0 +1,11 @@
+package com.marketinghub.oprm.nichocnae.v2.knowledgeaccumulator.service.completeStageExecution;
+
+/** Contrato devolvido após o backend registrar a conclusão knowledge-accumulator do NichoCNAE v2. */
+public record KnowledgeAccumulatorCompletionResponse(
+        String stageExecutionId,
+        String status,
+        String nextStageCode,
+        Integer knowledgeVersion,
+        Integer validatedFactCount,
+        Integer acceptedSourceCount,
+        Integer rejectedSourceCount) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/knowledgeaccumulator/service/createStageExecution/KnowledgeAccumulatorCreateRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/knowledgeaccumulator/service/createStageExecution/KnowledgeAccumulatorCreateRequest.java
@@ -1,0 +1,12 @@
+package com.marketinghub.oprm.nichocnae.v2.knowledgeaccumulator.service.createStageExecution;
+
+/** Contrato enviado pelo executor para registrar uma pendência da etapa knowledge-accumulator do NichoCNAE v2. */
+public record KnowledgeAccumulatorCreateRequest(
+        String jobId,
+        Long researchCycleId,
+        Long sourceNicheId,
+        String cnaeCode,
+        Integer attemptNumber,
+        Integer knowledgeVersion,
+        Boolean materializationEnabled,
+        String inputPayload) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/knowledgeaccumulator/service/createStageExecution/KnowledgeAccumulatorCreateResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/knowledgeaccumulator/service/createStageExecution/KnowledgeAccumulatorCreateResponse.java
@@ -1,0 +1,4 @@
+package com.marketinghub.oprm.nichocnae.v2.knowledgeaccumulator.service.createStageExecution;
+
+/** Contrato devolvido após o backend gravar a pendência knowledge-accumulator do NichoCNAE v2. */
+public record KnowledgeAccumulatorCreateResponse(String stageExecutionId, String status, String stageCode) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/knowledgeaccumulator/service/failStageExecution/KnowledgeAccumulatorFailureRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/knowledgeaccumulator/service/failStageExecution/KnowledgeAccumulatorFailureRequest.java
@@ -1,0 +1,7 @@
+package com.marketinghub.oprm.nichocnae.v2.knowledgeaccumulator.service.failStageExecution;
+
+import com.marketinghub.oprm.nichocnae.v2.OprmNichoCnaeV2FailureType;
+
+/** Contrato recebido do executor para registrar falha da etapa knowledge-accumulator do NichoCNAE v2. */
+public record KnowledgeAccumulatorFailureRequest(
+        OprmNichoCnaeV2FailureType failureType, String errorMessage, String inputPayload) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/knowledgeaccumulator/service/failStageExecution/KnowledgeAccumulatorFailureResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/knowledgeaccumulator/service/failStageExecution/KnowledgeAccumulatorFailureResponse.java
@@ -1,0 +1,9 @@
+package com.marketinghub.oprm.nichocnae.v2.knowledgeaccumulator.service.failStageExecution;
+
+/** Contrato devolvido após o backend registrar falha knowledge-accumulator do NichoCNAE v2. */
+public record KnowledgeAccumulatorFailureResponse(
+        String stageExecutionId,
+        String status,
+        String retryStageExecutionId,
+        Integer attemptNumber,
+        Integer technicalRetryNumber) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/knowledgeaccumulator/service/pending/KnowledgeAccumulatorPendingResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/knowledgeaccumulator/service/pending/KnowledgeAccumulatorPendingResponse.java
@@ -1,0 +1,12 @@
+package com.marketinghub.oprm.nichocnae.v2.knowledgeaccumulator.service.pending;
+
+/** Contrato entregue ao executor com a pendência da etapa knowledge-accumulator do NichoCNAE v2. */
+public record KnowledgeAccumulatorPendingResponse(
+        String stageExecutionId,
+        String jobId,
+        String cnaeCode,
+        Long sourceNicheId,
+        Integer attemptNumber,
+        Integer technicalRetryNumber,
+        Integer knowledgeVersion,
+        String inputPayload) {}

--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -1061,3 +1061,9 @@
 - Reforçada a etapa `commercial-evidence-gate` no executor `oprm-coletor-mei` para impedir materialização automática quando houver menos de três domínios independentes ou evidência contraditória pendente.
 - A decisão E0-E5, confiança, gaps, contradições e próximo movimento continuam calculados exclusivamente no executor externo; o backend foi coberto por teste para atuar apenas como leitura/escrita da decisão recebida.
 - Adicionados testes de regressão para independência mínima de fontes, revisão humana por contradição e contratos backend sem regra comercial.
+
+## 2026-06-19 — NichoCNAE v2 etapa 8 Knowledge Accumulator
+
+- Implementada a etapa 8 no executor externo `oprm-coletor-mei`, consolidando snapshot versionado com fatos validados, fontes aceitas/rejeitadas, claims rejeitados, queries executadas, assinaturas de falha, lacunas de evidência e linhagem mínima.
+- Criados contratos internos no backend apenas para leitura/escrita de pendências, conclusão e falha da etapa `knowledge-accumulator`, mantendo lógica, controle, inteligência e regras de negócio no executor externo.
+- Documentado o contrato em `docs/swagger/oprm-nichocnae-v2-knowledge-accumulator-swagger.yaml` e atualizada a tela do pipeline v2 para indicar implementação inicial da etapa.

--- a/docs/swagger/oprm-nichocnae-v2-knowledge-accumulator-swagger.yaml
+++ b/docs/swagger/oprm-nichocnae-v2-knowledge-accumulator-swagger.yaml
@@ -1,0 +1,42 @@
+openapi: 3.0.3
+info:
+  title: OPRM NichoCNAE v2 Knowledge Accumulator API
+  version: 1.0.0
+  description: Contratos internos de leitura e escrita da etapa 8 do pipeline NichoCNAE v2. A lógica de acumulação de conhecimento, versionamento, gaps e regras de negócio fica no executor externo oprm-coletor-mei; o backend apenas persiste e expõe pendências/resultados.
+paths:
+  /api/internal/oprm/nichocnae/v2/knowledge-accumulator/stage-executions/pending:
+    get:
+      summary: Lista pendências da etapa 8 para o executor OPRM.
+      responses:
+        '200':
+          description: Pendências disponíveis.
+  /api/internal/oprm/nichocnae/v2/knowledge-accumulator/stage-executions:
+    post:
+      summary: Registra uma pendência da etapa 8 solicitada pelo executor.
+      responses:
+        '200':
+          description: Pendência gravada.
+  /api/internal/oprm/nichocnae/v2/knowledge-accumulator/stage-executions/{stageExecutionId}/complete:
+    post:
+      summary: Registra conclusão da acumulação de conhecimento executada fora do backend.
+      parameters:
+        - name: stageExecutionId
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Conclusão persistida.
+  /api/internal/oprm/nichocnae/v2/knowledge-accumulator/stage-executions/{stageExecutionId}/fail:
+    post:
+      summary: Registra falha da etapa 8, separando retry técnico de reprovação funcional.
+      parameters:
+        - name: stageExecutionId
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Falha persistida.

--- a/frontend/src/pages/oprm/OprmNichoCnaeV2PipelinePage.tsx
+++ b/frontend/src/pages/oprm/OprmNichoCnaeV2PipelinePage.tsx
@@ -78,7 +78,7 @@ const v2Stages = [
   {
     number: 8,
     title: "Knowledge Accumulator",
-    status: "Design aprovado · implementação parcial",
+    status: "Design aprovado · implementação inicial",
     purpose:
       "Consolidar conhecimento versionado do ciclo, preservando fontes aceitas, rejeições, gaps e aprendizados.",
     output:

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnaev2/pipeline/knowledgeaccumulator/KnowledgeAccumulatorProcessor.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnaev2/pipeline/knowledgeaccumulator/KnowledgeAccumulatorProcessor.java
@@ -1,0 +1,262 @@
+package com.marketinghub.nichocnaev2.pipeline.knowledgeaccumulator;
+
+import com.marketinghub.nichocnaev2.pipeline.StageArtifact;
+import com.marketinghub.nichocnaev2.pipeline.StageContext;
+import com.marketinghub.nichocnaev2.pipeline.StageProcessor;
+import com.marketinghub.nichocnaev2.pipeline.StageResult;
+import java.net.URI;
+import java.net.URISyntaxException;
+import java.text.Normalizer;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+
+/** Consolida o conhecimento versionado do ciclo NichoCNAE v2 sem criar fatos novos. */
+public final class KnowledgeAccumulatorProcessor implements StageProcessor {
+    private static final Set<String> VALIDATED_STATES = Set.of("ACCEPT", "ACCEPTED", "VALIDATED");
+    private static final Set<String> REJECTED_STATES = Set.of("REJECT", "REJECTED", "STALE", "SUPERSEDED");
+
+    /** Gera um snapshot auditável com fatos aceitos, rejeições, gaps e memória para reprocessamento. */
+    @Override
+    public StageResult process(StageContext context) {
+        Map<String, Object> input = context.input();
+        int previousKnowledgeVersion = integer(input.get("knowledgeVersion"), 0);
+        List<Map<String, Object>> candidates = mapList(input.get("candidates"));
+        List<Map<String, Object>> claims = firstNonEmpty(input, "claims", "validatedClaims", "evidenceClaims");
+        List<Map<String, Object>> sources = firstNonEmpty(input, "sources", "selectedSources", "rankedSources");
+        List<Map<String, Object>> queries = firstNonEmpty(input, "queries", "executedQueries", "queryMemory");
+        List<Map<String, Object>> failures = firstNonEmpty(input, "failures", "previousFailures", "failureSignatures");
+        List<Map<String, Object>> decisions = firstNonEmpty(input, "gateDecisions", "decisions");
+
+        List<Map<String, Object>> validatedFacts = validatedFacts(claims);
+        List<Map<String, Object>> rejectedClaims = rejectedClaims(claims);
+        List<Map<String, Object>> acceptedSources = acceptedSources(sources);
+        List<Map<String, Object>> rejectedSources = rejectedSources(sources);
+        List<String> evidenceGaps = evidenceGaps(input, validatedFacts, acceptedSources);
+        int knowledgeVersion = previousKnowledgeVersion + 1;
+
+        Map<String, Object> snapshot = new LinkedHashMap<>();
+        snapshot.put("researchCycleId", input.get("researchCycleId"));
+        snapshot.put("candidateId", input.get("candidateId"));
+        snapshot.put("candidateVersion", integer(input.get("candidateVersion"), 1));
+        snapshot.put("knowledgeVersion", knowledgeVersion);
+        snapshot.put("validatedFacts", validatedFacts);
+        snapshot.put("acceptedSources", acceptedSources);
+        snapshot.put("rejectedSources", rejectedSources);
+        snapshot.put("rejectedClaims", rejectedClaims);
+        snapshot.put("queriesAlreadyExecuted", queryMemory(queries));
+        snapshot.put("failureSignatures", failureSignatures(failures));
+        snapshot.put("gateDecisions", decisions);
+        snapshot.put("evidenceGaps", evidenceGaps);
+        snapshot.put("artifactLineage", artifactLineage(input));
+        snapshot.put("budgetConsumed", input.getOrDefault("budgetConsumed", 0));
+        snapshot.put("epistemicSummary", epistemicSummary(validatedFacts, rejectedClaims, acceptedSources, evidenceGaps));
+
+        Map<String, Object> output = new LinkedHashMap<>();
+        output.put("stage", "knowledge-accumulator");
+        output.put("knowledgeVersion", knowledgeVersion);
+        output.put("snapshot", snapshot);
+        output.put("validatedFactCount", validatedFacts.size());
+        output.put("acceptedSourceCount", acceptedSources.size());
+        output.put("rejectedSourceCount", rejectedSources.size());
+        output.put("evidenceGaps", evidenceGaps);
+        output.put("nextStageCode", "reprocess-controller");
+        return new StageResult("KNOWLEDGE_SNAPSHOT_READY", output, List.of(new StageArtifact(
+                "KNOWLEDGE_SNAPSHOT",
+                "inline://knowledge-accumulator/snapshot/v" + knowledgeVersion,
+                "Snapshot versionado com conhecimento validado, rejeições, memória de queries/fontes e gaps acionáveis.")));
+    }
+
+    /** Seleciona claims aceitos com trecho exato para virar fato validado. */
+    private List<Map<String, Object>> validatedFacts(List<Map<String, Object>> claims) {
+        return claims.stream()
+                .filter(claim -> VALIDATED_STATES.contains(stateOf(claim)))
+                .filter(claim -> !text(claim.get("exactEvidenceSpan")).isBlank())
+                .map(this::validatedFact)
+                .toList();
+    }
+
+    /** Converte claim validado em fato canônico sem inventar conteúdo novo. */
+    private Map<String, Object> validatedFact(Map<String, Object> claim) {
+        Map<String, Object> fact = new LinkedHashMap<>();
+        fact.put("canonicalClaimId", claim.getOrDefault("canonicalClaimId", claim.get("claimId")));
+        fact.put("claimType", claim.get("claimType"));
+        fact.put("claimText", claim.getOrDefault("claimText", claim.get("canonicalClaim")));
+        fact.put("exactEvidenceSpan", claim.get("exactEvidenceSpan"));
+        fact.put("sourceUrl", claim.get("sourceUrl"));
+        fact.put("canonicalDomain", domainOf(text(claim.get("sourceUrl")), text(claim.get("canonicalDomain"))));
+        fact.put("epistemicState", "VALIDATED");
+        return fact;
+    }
+
+    /** Preserva claims rejeitados ou contraditórios como diagnóstico, não como sinal positivo. */
+    private List<Map<String, Object>> rejectedClaims(List<Map<String, Object>> claims) {
+        return claims.stream()
+                .filter(claim -> REJECTED_STATES.contains(stateOf(claim)) || isContradictory(claim))
+                .map(claim -> Map.<String, Object>of(
+                        "claimId", claim.getOrDefault("claimId", ""),
+                        "claimType", claim.getOrDefault("claimType", ""),
+                        "reason", claim.getOrDefault("rejectionReason", claim.getOrDefault("rejectionReasons", "REJECTED_OR_CONTRADICTED")),
+                        "epistemicState", isContradictory(claim) ? "CONTRADICTED" : stateOf(claim)))
+                .toList();
+    }
+
+    /** Lista fontes aceitas com domínio canônico para reuso seguro. */
+    private List<Map<String, Object>> acceptedSources(List<Map<String, Object>> sources) {
+        return sources.stream().filter(source -> !Boolean.TRUE.equals(source.get("unsafe")) && text(source.get("rejectionReason")).isBlank())
+                .map(source -> sourceMemory(source, "ACCEPTED"))
+                .toList();
+    }
+
+    /** Lista fontes rejeitadas para evitar repetição de coleta e custo. */
+    private List<Map<String, Object>> rejectedSources(List<Map<String, Object>> sources) {
+        return sources.stream().filter(source -> Boolean.TRUE.equals(source.get("unsafe")) || !text(source.get("rejectionReason")).isBlank())
+                .map(source -> sourceMemory(source, "REJECTED"))
+                .toList();
+    }
+
+    /** Converte uma fonte em memória auditável mínima. */
+    private Map<String, Object> sourceMemory(Map<String, Object> source, String status) {
+        Map<String, Object> memory = new LinkedHashMap<>();
+        memory.put("url", source.get("url"));
+        memory.put("canonicalDomain", domainOf(text(source.get("url")), text(source.get("canonicalDomain"))));
+        memory.put("contentHash", source.get("contentHash"));
+        memory.put("status", status);
+        memory.put("reason", source.getOrDefault("rejectionReason", source.get("rerankRationale")));
+        return memory;
+    }
+
+    /** Consolida memória de queries já executadas por hash textual simples. */
+    private List<Map<String, Object>> queryMemory(List<Map<String, Object>> queries) {
+        Set<String> seen = new LinkedHashSet<>();
+        List<Map<String, Object>> memory = new ArrayList<>();
+        for (Map<String, Object> query : queries) {
+            String text = text(query.getOrDefault("query", query.get("queryText")));
+            String hash = normalize(text);
+            if (!hash.isBlank() && seen.add(hash)) {
+                memory.add(Map.of("queryText", text, "queryHash", hash, "resultCount", integer(query.get("resultCount"), 0)));
+            }
+        }
+        return memory;
+    }
+
+    /** Consolida assinaturas de falhas anteriores para impedir loops cognitivos. */
+    private List<Map<String, Object>> failureSignatures(List<Map<String, Object>> failures) {
+        return failures.stream()
+                .map(failure -> Map.<String, Object>of(
+                        "stage", failure.getOrDefault("stage", failure.getOrDefault("stageCode", "")),
+                        "reasonCode", failure.getOrDefault("reasonCode", failure.getOrDefault("failureType", "")),
+                        "signature", normalize(text(failure.getOrDefault("signature", failure.get("errorMessage"))))))
+                .toList();
+    }
+
+    /** Calcula gaps acionáveis a partir do snapshot recebido e dos fatos realmente validados. */
+    private List<String> evidenceGaps(Map<String, Object> input, List<Map<String, Object>> facts, List<Map<String, Object>> sources) {
+        Set<String> gaps = new LinkedHashSet<>(textList(input.get("evidenceGaps")));
+        if (facts.stream().noneMatch(fact -> typeOf(fact).contains("TASK") || typeOf(fact).contains("ROUTINE"))) {
+            gaps.add("CONCRETE_EXECUTOR_TASKS");
+        }
+        if (facts.stream().noneMatch(fact -> typeOf(fact).contains("PAIN") || typeOf(fact).contains("FAILURE"))) {
+            gaps.add("DISTINCT_RECURRING_PAINS");
+        }
+        if (facts.stream().noneMatch(fact -> typeOf(fact).contains("ECONOMIC") || typeOf(fact).contains("COST") || typeOf(fact).contains("WORKAROUND"))) {
+            gaps.add("ECONOMIC_IMPACT_OR_WORKAROUND");
+        }
+        long independentDomains = sources.stream().map(source -> text(source.get("canonicalDomain"))).filter(domain -> !domain.isBlank()).distinct().count();
+        if (independentDomains < 3) {
+            gaps.add("THREE_INDEPENDENT_DOMAINS");
+        }
+        return List.copyOf(gaps);
+    }
+
+    /** Registra linhagem mínima dos artefatos recebidos sem inspecionar infraestrutura externa. */
+    private List<Map<String, Object>> artifactLineage(Map<String, Object> input) {
+        return mapList(input.get("artifactLineage")).isEmpty() ? List.of() : mapList(input.get("artifactLineage"));
+    }
+
+    /** Resume o estado epistêmico do snapshot para a tela e para o controlador de reprocessamento. */
+    private Map<String, Object> epistemicSummary(List<Map<String, Object>> facts, List<Map<String, Object>> rejected, List<Map<String, Object>> sources, List<String> gaps) {
+        return Map.of(
+                "validatedFactCount", facts.size(),
+                "rejectedClaimCount", rejected.size(),
+                "acceptedSourceCount", sources.size(),
+                "openGapCount", gaps.size(),
+                "readyForReprocessController", true);
+    }
+
+    /** Extrai a primeira lista de mapas disponível entre chaves alternativas. */
+    private List<Map<String, Object>> firstNonEmpty(Map<String, Object> input, String... keys) {
+        for (String key : keys) {
+            List<Map<String, Object>> values = mapList(input.get(key));
+            if (!values.isEmpty()) return values;
+        }
+        return List.of();
+    }
+
+    /** Extrai lista de mapas de contratos flexíveis. */
+    private List<Map<String, Object>> mapList(Object value) {
+        if (!(value instanceof List<?> items)) return List.of();
+        List<Map<String, Object>> mapped = new ArrayList<>();
+        for (Object item : items) {
+            if (item instanceof Map<?, ?> map) {
+                Map<String, Object> copy = new LinkedHashMap<>();
+                map.forEach((key, val) -> copy.put(String.valueOf(key), val));
+                mapped.add(copy);
+            }
+        }
+        return mapped;
+    }
+
+    /** Extrai strings normalizadas de lista flexível. */
+    private List<String> textList(Object value) {
+        if (!(value instanceof List<?> items)) return List.of();
+        return items.stream().map(this::text).filter(item -> !item.isBlank()).toList();
+    }
+
+    /** Identifica o estado epistêmico/status do claim. */
+    private String stateOf(Map<String, Object> claim) {
+        String state = text(claim.get("epistemicState")).toUpperCase(Locale.ROOT);
+        return state.isBlank() ? text(claim.get("status")).toUpperCase(Locale.ROOT) : state;
+    }
+
+    /** Identifica contradição explícita. */
+    private boolean isContradictory(Map<String, Object> claim) {
+        return "CONTRADICTED".equals(stateOf(claim)) || Boolean.TRUE.equals(claim.get("contradictsTarget"));
+    }
+
+    /** Retorna tipo textual do fato. */
+    private String typeOf(Map<String, Object> fact) {
+        return text(fact.get("claimType")).toUpperCase(Locale.ROOT);
+    }
+
+    /** Converte número flexível para inteiro seguro. */
+    private int integer(Object value, int fallback) {
+        if (value instanceof Number number) return number.intValue();
+        try { return value == null ? fallback : Integer.parseInt(String.valueOf(value)); } catch (NumberFormatException ex) { return fallback; }
+    }
+
+    /** Retorna texto seguro. */
+    private String text(Object value) {
+        return value == null ? "" : String.valueOf(value).trim();
+    }
+
+    /** Normaliza texto para assinatura determinística simples. */
+    private String normalize(String value) {
+        return Normalizer.normalize(value.toLowerCase(Locale.ROOT), Normalizer.Form.NFD).replaceAll("\\p{M}", "").trim();
+    }
+
+    /** Descobre domínio canônico preservando valor já informado pelo contrato. */
+    private String domainOf(String url, String fallback) {
+        if (!fallback.isBlank()) return fallback;
+        try {
+            String host = new URI(url).getHost();
+            return host == null ? "" : host.toLowerCase(Locale.ROOT).replaceFirst("^www\\.", "");
+        } catch (URISyntaxException ex) {
+            return "";
+        }
+    }
+}

--- a/oprm-coletor-mei/src/test/java/com/marketinghub/nichocnaev2/pipeline/knowledgeaccumulator/KnowledgeAccumulatorProcessorTest.java
+++ b/oprm-coletor-mei/src/test/java/com/marketinghub/nichocnaev2/pipeline/knowledgeaccumulator/KnowledgeAccumulatorProcessorTest.java
@@ -1,0 +1,66 @@
+package com.marketinghub.nichocnaev2.pipeline.knowledgeaccumulator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.marketinghub.nichocnaev2.pipeline.StageContext;
+import com.marketinghub.nichocnaev2.pipeline.StageResult;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/** Valida a etapa 8 de acumulação de conhecimento do pipeline NichoCNAE v2. */
+class KnowledgeAccumulatorProcessorTest {
+    /** Garante que apenas claims validados com trecho exato viram fatos positivos no snapshot. */
+    @Test
+    void shouldBuildVersionedSnapshotOnlyFromValidatedClaimsWithExactSpan() {
+        KnowledgeAccumulatorProcessor processor = new KnowledgeAccumulatorProcessor();
+        StageResult result = processor.process(new StageContext("job-1", "stage-8", Map.of(
+                "researchCycleId", 72,
+                "candidateId", 31,
+                "candidateVersion", 2,
+                "knowledgeVersion", 4,
+                "claims", List.of(
+                        Map.of(
+                                "claimId", 101,
+                                "claimType", "ROUTINE_TASK",
+                                "claimText", "agenda clientes por WhatsApp",
+                                "exactEvidenceSpan", "agenda clientes por WhatsApp",
+                                "sourceUrl", "https://exemplo.com/rotina",
+                                "status", "ACCEPTED"),
+                        Map.of(
+                                "claimId", 102,
+                                "claimType", "ECONOMIC_IMPACT",
+                                "claimText", "perde dinheiro",
+                                "status", "ACCEPTED")),
+                "sources", List.of(Map.of("url", "https://exemplo.com/rotina", "contentHash", "abc")),
+                "queries", List.of(Map.of("queryText", "rotina manicure agenda", "resultCount", 3)))));
+
+        assertThat(result.status()).isEqualTo("KNOWLEDGE_SNAPSHOT_READY");
+        assertThat(result.output()).containsEntry("knowledgeVersion", 5);
+        Map<String, Object> snapshot = (Map<String, Object>) result.output().get("snapshot");
+        assertThat((List<?>) snapshot.get("validatedFacts")).hasSize(1);
+        assertThat((List<String>) snapshot.get("evidenceGaps")).contains("ECONOMIC_IMPACT_OR_WORKAROUND", "THREE_INDEPENDENT_DOMAINS");
+        assertThat(result.output()).containsEntry("nextStageCode", "reprocess-controller");
+    }
+
+    /** Garante que fontes e claims rejeitados permanecem auditáveis para evitar repetição de erro. */
+    @Test
+    void shouldPreserveRejectedSourcesAndContradictedClaimsAsDiagnostics() {
+        KnowledgeAccumulatorProcessor processor = new KnowledgeAccumulatorProcessor();
+        StageResult result = processor.process(new StageContext("job-1", "stage-8", Map.of(
+                "knowledgeVersion", 1,
+                "claims", List.of(Map.of(
+                        "claimId", 201,
+                        "claimType", "PAIN",
+                        "epistemicState", "CONTRADICTED",
+                        "rejectionReason", "ATOR_ADJACENTE")),
+                "sources", List.of(Map.of(
+                        "url", "https://adult.example/conteudo",
+                        "unsafe", true,
+                        "rejectionReason", "UNSAFE_SOURCE")))));
+
+        Map<String, Object> snapshot = (Map<String, Object>) result.output().get("snapshot");
+        assertThat((List<?>) snapshot.get("rejectedClaims")).hasSize(1);
+        assertThat((List<?>) snapshot.get("rejectedSources")).hasSize(1);
+    }
+}


### PR DESCRIPTION
### Motivation
- Consolidar conhecimento versionado do ciclo NichoCNAE (fatos validados, fontes aceitas/rejeitadas, claims rejeitados, queries, falhas e gaps) para habilitar reprocessamento seletivo sem repetir custos ou contaminações.
- Manter toda lógica, regras de negócio e decisões no executor externo e usar o backend apenas como camada de leitura/escrita de pendências, conclusão e falhas.
- Entregar contrato claro e auditável entre executor e backend para a nova etapa 8 (`knowledge-accumulator`) e atualizar documentação e UI para refletir o avanço da v2.

### Description
- Adiciona o processor executor `KnowledgeAccumulatorProcessor` em `oprm-coletor-mei` que gera snapshot versionado com `validatedFacts`, `acceptedSources`, `rejectedSources`, `rejectedClaims`, `queriesAlreadyExecuted`, `failureSignatures`, `evidenceGaps`, `artifactLineage` e próximo estágio `reprocess-controller` (file: `oprm-coletor-mei/src/main/java/.../knowledgeaccumulator/KnowledgeAccumulatorProcessor.java`).
- Cria contratos backend e endpoints internos apenas para persistir/consultar pendências, registrar conclusão e registrar falhas da etapa `knowledge-accumulator` sem conter regras de negócio (`backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/knowledgeaccumulator/*`).
- Declaraion of DTOs as `record` for `pending`, `create`, `complete` and `fail` contracts and controller `BackendKnowledgeAccumulatorController` which exposes the canonical `/api/internal/oprm/nichocnae/v2/knowledge-accumulator/stage-executions` routes.
- Documenta o contrato em `docs/swagger/oprm-nichocnae-v2-knowledge-accumulator-swagger.yaml`, atualiza a tela do pipeline v2 (`frontend/src/pages/oprm/OprmNichoCnaeV2PipelinePage.tsx`) e registra a entrega em `docs/registros/oprm1.md`.
- Inclui testes unitários para a etapa no executor (`oprm-coletor-mei/src/test/java/.../KnowledgeAccumulatorProcessorTest.java`) cobrindo fatos validados com `exactEvidenceSpan` e preservação de rejeições/contradições como diagnóstico.

### Testing
- Executed the new unit test: `mvn -Dtest=KnowledgeAccumulatorProcessorTest test` in `oprm-coletor-mei`, and the `KnowledgeAccumulatorProcessorTest` passed.
- Compiled backend successfully with `mvn -DskipTests compile` in `backend/ads-service` to ensure new controller/service and DTOs build.
- Ran `mvn test` in `oprm-coletor-mei`; the test run completed and the new processor tests remained green while unrelated tests that depend on external services produced transient warnings/errors (OpenAI rate limits / missing operational keys) unrelated to the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a35661d844c832194729f2cff49ba3c)