### PR TITLE
Implement NichoCNAE v2 Reprocess Controller (stage 9)

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/reprocesscontroller/controller/BackendReprocessControllerController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/reprocesscontroller/controller/BackendReprocessControllerController.java
@@ -1,0 +1,43 @@
+package com.marketinghub.oprm.nichocnae.v2.reprocesscontroller.controller;
+
+import com.marketinghub.oprm.nichocnae.v2.reprocesscontroller.service.BackendReprocessControllerService;
+import com.marketinghub.oprm.nichocnae.v2.reprocesscontroller.service.completeStageExecution.ReprocessControllerCompletionRequest;
+import com.marketinghub.oprm.nichocnae.v2.reprocesscontroller.service.completeStageExecution.ReprocessControllerCompletionResponse;
+import com.marketinghub.oprm.nichocnae.v2.reprocesscontroller.service.createStageExecution.ReprocessControllerCreateRequest;
+import com.marketinghub.oprm.nichocnae.v2.reprocesscontroller.service.createStageExecution.ReprocessControllerCreateResponse;
+import com.marketinghub.oprm.nichocnae.v2.reprocesscontroller.service.failStageExecution.ReprocessControllerFailureRequest;
+import com.marketinghub.oprm.nichocnae.v2.reprocesscontroller.service.failStageExecution.ReprocessControllerFailureResponse;
+import com.marketinghub.oprm.nichocnae.v2.reprocesscontroller.service.pending.ReprocessControllerPendingResponse;
+import java.util.List;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/** Borda HTTP interna da etapa reprocess-controller do pipeline NichoCNAE versão 2. */
+@RestController
+@RequestMapping("/api/internal/oprm/nichocnae/v2/reprocess-controller/stage-executions")
+public class BackendReprocessControllerController {
+    private final BackendReprocessControllerService service;
+
+    /** Recebe o service canônico da etapa para delegar operações HTTP internas. */
+    public BackendReprocessControllerController(BackendReprocessControllerService service) { this.service = service; }
+
+    /** Entrega execuções pendentes da etapa reprocess-controller ao módulo executor OPRM. */
+    @GetMapping("/pending")
+    public List<ReprocessControllerPendingResponse> pending() { return service.pending(); }
+
+    /** Grava uma pendência da etapa reprocess-controller solicitada pelo módulo executor OPRM. */
+    @PostMapping
+    public ReprocessControllerCreateResponse create(@RequestBody ReprocessControllerCreateRequest request) { return service.create(request); }
+
+    /** Registra a conclusão do controlador de reprocessamento informada pelo módulo executor OPRM. */
+    @PostMapping("/{stageExecutionId}/complete")
+    public ReprocessControllerCompletionResponse complete(@PathVariable Long stageExecutionId, @RequestBody ReprocessControllerCompletionRequest request) { return service.complete(stageExecutionId, request); }
+
+    /** Registra a falha do controlador de reprocessamento informada pelo módulo executor OPRM. */
+    @PostMapping("/{stageExecutionId}/fail")
+    public ReprocessControllerFailureResponse fail(@PathVariable Long stageExecutionId, @RequestBody ReprocessControllerFailureRequest request) { return service.fail(stageExecutionId, request); }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/reprocesscontroller/service/BackendReprocessControllerService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/reprocesscontroller/service/BackendReprocessControllerService.java
@@ -1,0 +1,119 @@
+package com.marketinghub.oprm.nichocnae.v2.reprocesscontroller.service;
+
+import com.marketinghub.oprm.nichocnae.v2.OprmNichoCnaeV2FailureType;
+import com.marketinghub.oprm.nichocnae.v2.OprmNichoCnaeV2StageExecution;
+import com.marketinghub.oprm.nichocnae.v2.OprmNichoCnaeV2StageExecutionStatus;
+import com.marketinghub.oprm.nichocnae.v2.reprocesscontroller.service.completeStageExecution.ReprocessControllerCompletionRequest;
+import com.marketinghub.oprm.nichocnae.v2.reprocesscontroller.service.completeStageExecution.ReprocessControllerCompletionResponse;
+import com.marketinghub.oprm.nichocnae.v2.reprocesscontroller.service.createStageExecution.ReprocessControllerCreateRequest;
+import com.marketinghub.oprm.nichocnae.v2.reprocesscontroller.service.createStageExecution.ReprocessControllerCreateResponse;
+import com.marketinghub.oprm.nichocnae.v2.reprocesscontroller.service.failStageExecution.ReprocessControllerFailureRequest;
+import com.marketinghub.oprm.nichocnae.v2.reprocesscontroller.service.failStageExecution.ReprocessControllerFailureResponse;
+import com.marketinghub.oprm.nichocnae.v2.reprocesscontroller.service.pending.ReprocessControllerPendingResponse;
+import com.marketinghub.repository.jpa.oprm.nichocnae.v2.OprmNichoCnaeV2StageExecutionRepository;
+import java.time.Instant;
+import java.util.List;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+/** Expõe contratos de leitura/escrita do backend para a etapa reprocess-controller do pipeline NichoCNAE v2. */
+@Service
+public class BackendReprocessControllerService {
+    public static final String STAGE_CODE = "reprocess-controller";
+    private final OprmNichoCnaeV2StageExecutionRepository stageExecutionRepository;
+    private final boolean v2Enabled;
+
+    /** Inicializa o service com repositório canônico e feature flag de calibração da v2. */
+    public BackendReprocessControllerService(OprmNichoCnaeV2StageExecutionRepository stageExecutionRepository, @Value("${oprm.nichocnae.v2.enabled:false}") boolean v2Enabled) {
+        this.stageExecutionRepository = stageExecutionRepository;
+        this.v2Enabled = v2Enabled;
+    }
+
+    /** Lista pendências disponíveis para consumo canônico pelo executor OPRM NichoCNAE v2. */
+    @Transactional(readOnly = true)
+    public List<ReprocessControllerPendingResponse> pending() {
+        if (!v2Enabled) return List.of();
+        return stageExecutionRepository.findByStageCodeAndStatusOrderByCreatedAtAsc(STAGE_CODE, OprmNichoCnaeV2StageExecutionStatus.PENDING, PageRequest.of(0, 5)).stream().map(this::toPendingResponse).toList();
+    }
+
+    /** Grava uma pendência da etapa de controle de reprocessamento solicitada pelo executor externo. */
+    @Transactional
+    public ReprocessControllerCreateResponse create(ReprocessControllerCreateRequest request) {
+        OprmNichoCnaeV2StageExecution saved = stageExecutionRepository.save(toPendingExecution(request));
+        return new ReprocessControllerCreateResponse(String.valueOf(saved.getId()), saved.getStatus().name(), saved.getStageCode());
+    }
+
+    /** Registra conclusão do controlador usando o plano informado pelo executor externo. */
+    @Transactional
+    public ReprocessControllerCompletionResponse complete(Long stageExecutionId, ReprocessControllerCompletionRequest request) {
+        OprmNichoCnaeV2StageExecution execution = findExecution(stageExecutionId);
+        execution.setStatus(OprmNichoCnaeV2StageExecutionStatus.COMPLETED);
+        execution.setOutputPayload(request == null ? null : request.outputPayload());
+        execution.setNextStageCode(request == null ? null : request.nextStageCode());
+        execution.setUpdatedAt(Instant.now());
+        OprmNichoCnaeV2StageExecution saved = stageExecutionRepository.save(execution);
+        return new ReprocessControllerCompletionResponse(String.valueOf(saved.getId()), saved.getStatus().name(), request == null ? null : request.executionMode(), request == null ? null : request.rewindToStage(), request == null ? null : request.knowledgeVersionTo(), saved.getNextStageCode());
+    }
+
+    /** Registra falha e cria nova execução somente quando a falha for retry técnico de infraestrutura. */
+    @Transactional
+    public ReprocessControllerFailureResponse fail(Long stageExecutionId, ReprocessControllerFailureRequest request) {
+        OprmNichoCnaeV2StageExecution execution = findExecution(stageExecutionId);
+        OprmNichoCnaeV2FailureType failureType = request == null || request.failureType() == null ? OprmNichoCnaeV2FailureType.VALIDATION : request.failureType();
+        execution.setFailureType(failureType);
+        execution.setErrorMessage(request == null ? null : request.errorMessage());
+        execution.setInputPayload(request == null ? execution.getInputPayload() : request.inputPayload());
+        execution.setUpdatedAt(Instant.now());
+        if (failureType == OprmNichoCnaeV2FailureType.INFRASTRUCTURE) {
+            execution.setStatus(OprmNichoCnaeV2StageExecutionStatus.TECHNICAL_RETRY_SCHEDULED);
+            OprmNichoCnaeV2StageExecution retry = createTechnicalRetry(execution);
+            stageExecutionRepository.save(execution);
+            OprmNichoCnaeV2StageExecution savedRetry = stageExecutionRepository.save(retry);
+            return new ReprocessControllerFailureResponse(String.valueOf(execution.getId()), execution.getStatus().name(), String.valueOf(savedRetry.getId()), savedRetry.getAttemptNumber(), savedRetry.getTechnicalRetryNumber());
+        }
+        execution.setStatus(OprmNichoCnaeV2StageExecutionStatus.FAILED);
+        OprmNichoCnaeV2StageExecution saved = stageExecutionRepository.save(execution);
+        return new ReprocessControllerFailureResponse(String.valueOf(saved.getId()), saved.getStatus().name(), null, saved.getAttemptNumber(), saved.getTechnicalRetryNumber());
+    }
+
+    /** Converte o contrato recebido do executor em entidade persistível, sem decidir regra operacional. */
+    private OprmNichoCnaeV2StageExecution toPendingExecution(ReprocessControllerCreateRequest request) {
+        Instant now = Instant.now();
+        OprmNichoCnaeV2StageExecution execution = new OprmNichoCnaeV2StageExecution();
+        execution.setJobId(request.jobId());
+        execution.setResearchCycleId(request.researchCycleId());
+        execution.setSourceNicheId(request.sourceNicheId());
+        execution.setCnaeCode(request.cnaeCode());
+        execution.setStageCode(STAGE_CODE);
+        execution.setAttemptNumber(request.attemptNumber());
+        execution.setTechnicalRetryNumber(0);
+        execution.setKnowledgeVersion(request.knowledgeVersion());
+        execution.setStatus(OprmNichoCnaeV2StageExecutionStatus.PENDING);
+        execution.setInputPayload(request.inputPayload());
+        execution.setMaterializationEnabled(Boolean.TRUE.equals(request.materializationEnabled()));
+        execution.setCreatedAt(now);
+        execution.setUpdatedAt(now);
+        return execution;
+    }
+
+    /** Cria uma nova linha para retry técnico preservando a tentativa cognitiva e a versão de conhecimento. */
+    private OprmNichoCnaeV2StageExecution createTechnicalRetry(OprmNichoCnaeV2StageExecution previousExecution) {
+        OprmNichoCnaeV2StageExecution retry = toPendingExecution(new ReprocessControllerCreateRequest(previousExecution.getJobId(), previousExecution.getResearchCycleId(), previousExecution.getSourceNicheId(), previousExecution.getCnaeCode(), previousExecution.getAttemptNumber(), previousExecution.getKnowledgeVersion(), previousExecution.getMaterializationEnabled(), previousExecution.getInputPayload()));
+        retry.setTechnicalRetryNumber(previousExecution.getTechnicalRetryNumber() + 1);
+        return retry;
+    }
+
+    /** Carrega a execução da etapa atual ou devolve erro HTTP claro ao executor. */
+    private OprmNichoCnaeV2StageExecution findExecution(Long stageExecutionId) {
+        return stageExecutionRepository.findByIdAndStageCode(stageExecutionId, STAGE_CODE).orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "NichoCNAE v2 reprocess-controller stage execution not found: " + stageExecutionId));
+    }
+
+    /** Converte a entidade persistida no contrato canônico de pending do executor. */
+    private ReprocessControllerPendingResponse toPendingResponse(OprmNichoCnaeV2StageExecution execution) {
+        return new ReprocessControllerPendingResponse(String.valueOf(execution.getId()), execution.getJobId(), execution.getCnaeCode(), execution.getSourceNicheId(), execution.getAttemptNumber(), execution.getTechnicalRetryNumber(), execution.getKnowledgeVersion(), execution.getInputPayload());
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/reprocesscontroller/service/completeStageExecution/ReprocessControllerCompletionRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/reprocesscontroller/service/completeStageExecution/ReprocessControllerCompletionRequest.java
@@ -1,0 +1,4 @@
+package com.marketinghub.oprm.nichocnae.v2.reprocesscontroller.service.completeStageExecution;
+
+/** Contrato de escrita para registrar plano de retry ou reprocessamento decidido pelo executor externo. */
+public record ReprocessControllerCompletionRequest(String executionMode, String rewindToStage, Integer knowledgeVersionTo, String nextStageCode, String outputPayload) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/reprocesscontroller/service/completeStageExecution/ReprocessControllerCompletionResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/reprocesscontroller/service/completeStageExecution/ReprocessControllerCompletionResponse.java
@@ -1,0 +1,4 @@
+package com.marketinghub.oprm.nichocnae.v2.reprocesscontroller.service.completeStageExecution;
+
+/** Resposta de conclusão persistida da etapa reprocess-controller. */
+public record ReprocessControllerCompletionResponse(String stageExecutionId, String status, String executionMode, String rewindToStage, Integer knowledgeVersionTo, String nextStageCode) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/reprocesscontroller/service/createStageExecution/ReprocessControllerCreateRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/reprocesscontroller/service/createStageExecution/ReprocessControllerCreateRequest.java
@@ -1,0 +1,4 @@
+package com.marketinghub.oprm.nichocnae.v2.reprocesscontroller.service.createStageExecution;
+
+/** Contrato de escrita para criar pendência do controlador de reprocessamento calculado pelo executor externo. */
+public record ReprocessControllerCreateRequest(String jobId, Long researchCycleId, Long sourceNicheId, String cnaeCode, Integer attemptNumber, Integer knowledgeVersion, Boolean materializationEnabled, String inputPayload) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/reprocesscontroller/service/createStageExecution/ReprocessControllerCreateResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/reprocesscontroller/service/createStageExecution/ReprocessControllerCreateResponse.java
@@ -1,0 +1,4 @@
+package com.marketinghub.oprm.nichocnae.v2.reprocesscontroller.service.createStageExecution;
+
+/** Resposta de criação de pendência da etapa reprocess-controller. */
+public record ReprocessControllerCreateResponse(String stageExecutionId, String status, String stageCode) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/reprocesscontroller/service/failStageExecution/ReprocessControllerFailureRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/reprocesscontroller/service/failStageExecution/ReprocessControllerFailureRequest.java
@@ -1,0 +1,6 @@
+package com.marketinghub.oprm.nichocnae.v2.reprocesscontroller.service.failStageExecution;
+
+import com.marketinghub.oprm.nichocnae.v2.OprmNichoCnaeV2FailureType;
+
+/** Contrato de escrita para registrar falha técnica ou cognitiva da etapa reprocess-controller. */
+public record ReprocessControllerFailureRequest(OprmNichoCnaeV2FailureType failureType, String errorMessage, String inputPayload) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/reprocesscontroller/service/failStageExecution/ReprocessControllerFailureResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/reprocesscontroller/service/failStageExecution/ReprocessControllerFailureResponse.java
@@ -1,0 +1,4 @@
+package com.marketinghub.oprm.nichocnae.v2.reprocesscontroller.service.failStageExecution;
+
+/** Resposta de falha da etapa reprocess-controller, incluindo retry técnico quando aplicável. */
+public record ReprocessControllerFailureResponse(String stageExecutionId, String status, String retryStageExecutionId, Integer attemptNumber, Integer technicalRetryNumber) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/reprocesscontroller/service/pending/ReprocessControllerPendingResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/reprocesscontroller/service/pending/ReprocessControllerPendingResponse.java
@@ -1,0 +1,4 @@
+package com.marketinghub.oprm.nichocnae.v2.reprocesscontroller.service.pending;
+
+/** Contrato de leitura de pendência da etapa reprocess-controller para o executor OPRM. */
+public record ReprocessControllerPendingResponse(String stageExecutionId, String jobId, String cnaeCode, Long sourceNicheId, Integer attemptNumber, Integer technicalRetryNumber, Integer knowledgeVersion, String inputPayload) {}

--- a/backend/ads-service/src/test/java/com/marketinghub/oprm/nichocnae/v2/reprocesscontroller/service/BackendReprocessControllerServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/oprm/nichocnae/v2/reprocesscontroller/service/BackendReprocessControllerServiceTest.java
@@ -1,0 +1,143 @@
+package com.marketinghub.oprm.nichocnae.v2.reprocesscontroller.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.marketinghub.oprm.nichocnae.v2.OprmNichoCnaeV2FailureType;
+import com.marketinghub.oprm.nichocnae.v2.OprmNichoCnaeV2StageExecution;
+import com.marketinghub.oprm.nichocnae.v2.OprmNichoCnaeV2StageExecutionStatus;
+import com.marketinghub.oprm.nichocnae.v2.reprocesscontroller.service.completeStageExecution.ReprocessControllerCompletionRequest;
+import com.marketinghub.oprm.nichocnae.v2.reprocesscontroller.service.createStageExecution.ReprocessControllerCreateRequest;
+import com.marketinghub.oprm.nichocnae.v2.reprocesscontroller.service.failStageExecution.ReprocessControllerFailureRequest;
+import com.marketinghub.oprm.nichocnae.v2.reprocesscontroller.service.pending.ReprocessControllerPendingResponse;
+import com.marketinghub.repository.jpa.oprm.nichocnae.v2.OprmNichoCnaeV2StageExecutionRepository;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.data.domain.Pageable;
+
+/** Valida que o backend da etapa reprocess-controller atua somente como leitura e escrita para o executor. */
+@ExtendWith(MockitoExtension.class)
+class BackendReprocessControllerServiceTest {
+    @Mock private OprmNichoCnaeV2StageExecutionRepository stageExecutionRepository;
+
+    /** Deve manter a etapa 9 sem pendências quando a feature flag da v2 estiver desligada. */
+    @Test
+    void pendingReturnsEmptyWhenFeatureFlagIsDisabled() {
+        BackendReprocessControllerService service = service(false);
+        List<ReprocessControllerPendingResponse> result = service.pending();
+        assertThat(result).isEmpty();
+        verify(stageExecutionRepository, never()).findByStageCodeAndStatusOrderByCreatedAtAsc(any(), any(), any());
+    }
+
+    /** Deve entregar ao executor o payload persistido sem recalcular regra comercial no backend. */
+    @Test
+    void pendingReturnsReprocessControllerExecutions() {
+        BackendReprocessControllerService service = service(true);
+        when(stageExecutionRepository.findByStageCodeAndStatusOrderByCreatedAtAsc(
+                        eq("reprocess-controller"),
+                        eq(OprmNichoCnaeV2StageExecutionStatus.PENDING),
+                        any(Pageable.class)))
+                .thenReturn(List.of(execution(700L)));
+        List<ReprocessControllerPendingResponse> result = service.pending();
+        assertThat(result).hasSize(1);
+        assertThat(result.getFirst().stageExecutionId()).isEqualTo("700");
+        assertThat(result.getFirst().inputPayload()).contains("gateDecision");
+    }
+
+    /** Deve persistir exatamente a decisão enviada pelo executor, sem aplicar regra de reprocessamento no backend. */
+    @Test
+    void completePersistsExecutorDecisionOnly() {
+        BackendReprocessControllerService service = service(true);
+        OprmNichoCnaeV2StageExecution execution = execution(701L);
+        when(stageExecutionRepository.findByIdAndStageCode(701L, "reprocess-controller"))
+                .thenReturn(Optional.of(execution));
+        when(stageExecutionRepository.save(any(OprmNichoCnaeV2StageExecution.class)))
+                .thenAnswer(invocation -> invocation.getArgument(0));
+        var response = service.complete(
+                701L,
+                new ReprocessControllerCompletionRequest(
+                        "COGNITIVE_REPROCESS",
+                        "adaptive-query-planner",
+                        6,
+                        "adaptive-query-planner",
+                        "{\"executionMode\":\"COGNITIVE_REPROCESS\"}"));
+        assertThat(response.status()).isEqualTo("COMPLETED");
+        assertThat(response.executionMode()).isEqualTo("COGNITIVE_REPROCESS");
+        assertThat(response.rewindToStage()).isEqualTo("adaptive-query-planner");
+        assertThat(response.nextStageCode()).isEqualTo("adaptive-query-planner");
+    }
+
+    /** Deve gravar pendência da etapa 9 quando o executor solicitar reprocessamento cognitivo. */
+    @Test
+    void createPersistsPendingExecutionRequestedByExecutor() {
+        BackendReprocessControllerService service = service(true);
+        when(stageExecutionRepository.save(any(OprmNichoCnaeV2StageExecution.class))).thenAnswer(invocation -> {
+            OprmNichoCnaeV2StageExecution saved = invocation.getArgument(0);
+            saved.setId(702L);
+            return saved;
+        });
+        var response = service.create(new ReprocessControllerCreateRequest(
+                "job-72", 72L, 69L, "4781400", 3, 5, false, "{\"gateDecision\":\"NEEDS_MORE_RESEARCH\"}"));
+        assertThat(response.stageExecutionId()).isEqualTo("702");
+        assertThat(response.status()).isEqualTo("PENDING");
+        assertThat(response.stageCode()).isEqualTo("reprocess-controller");
+    }
+
+    /** Deve preservar retry técnico sem mudar tentativa cognitiva quando a falha da etapa 9 for infraestrutura. */
+    @Test
+    void failCreatesTechnicalRetryForInfrastructureFailure() {
+        BackendReprocessControllerService service = service(true);
+        OprmNichoCnaeV2StageExecution execution = execution(703L);
+        when(stageExecutionRepository.findByIdAndStageCode(703L, "reprocess-controller"))
+                .thenReturn(Optional.of(execution));
+        when(stageExecutionRepository.save(any(OprmNichoCnaeV2StageExecution.class))).thenAnswer(invocation -> {
+            OprmNichoCnaeV2StageExecution saved = invocation.getArgument(0);
+            if (saved.getId() == null) {
+                saved.setId(704L);
+            }
+            return saved;
+        });
+        var response = service.fail(
+                703L,
+                new ReprocessControllerFailureRequest(
+                        OprmNichoCnaeV2FailureType.INFRASTRUCTURE, "TIMEOUT no callback do executor", "{}"));
+        assertThat(response.status()).isEqualTo("TECHNICAL_RETRY_SCHEDULED");
+        assertThat(response.retryStageExecutionId()).isEqualTo("704");
+        assertThat(response.attemptNumber()).isEqualTo(3);
+        assertThat(response.technicalRetryNumber()).isEqualTo(1);
+    }
+
+    /** Cria o service testável com flag explícita para a v2. */
+    private BackendReprocessControllerService service(boolean v2Enabled) {
+        return new BackendReprocessControllerService(stageExecutionRepository, v2Enabled);
+    }
+
+    /** Monta execução persistida mínima da etapa reprocess-controller. */
+    private OprmNichoCnaeV2StageExecution execution(Long id) {
+        OprmNichoCnaeV2StageExecution execution = new OprmNichoCnaeV2StageExecution();
+        execution.setId(id);
+        execution.setJobId("job-72");
+        execution.setResearchCycleId(72L);
+        execution.setSourceNicheId(69L);
+        execution.setCnaeCode("4781400");
+        execution.setStageCode("reprocess-controller");
+        execution.setAttemptNumber(3);
+        execution.setTechnicalRetryNumber(0);
+        execution.setKnowledgeVersion(5);
+        execution.setStatus(OprmNichoCnaeV2StageExecutionStatus.PENDING);
+        execution.setInputPayload("{\"gateDecision\":\"NEEDS_MORE_RESEARCH\"}");
+        execution.setMaterializationEnabled(false);
+        execution.setCreatedAt(Instant.parse("2026-06-19T10:00:00Z"));
+        execution.setUpdatedAt(Instant.parse("2026-06-19T10:00:00Z"));
+        return execution;
+    }
+}

--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -1067,3 +1067,10 @@
 - Implementada a etapa 8 no executor externo `oprm-coletor-mei`, consolidando snapshot versionado com fatos validados, fontes aceitas/rejeitadas, claims rejeitados, queries executadas, assinaturas de falha, lacunas de evidência e linhagem mínima.
 - Criados contratos internos no backend apenas para leitura/escrita de pendências, conclusão e falha da etapa `knowledge-accumulator`, mantendo lógica, controle, inteligência e regras de negócio no executor externo.
 - Documentado o contrato em `docs/swagger/oprm-nichocnae-v2-knowledge-accumulator-swagger.yaml` e atualizada a tela do pipeline v2 para indicar implementação inicial da etapa.
+
+## 2026-06-19 — NichoCNAE v2 etapa 9 Reprocess Controller
+
+- Implementada a etapa 9 do pipeline NichoCNAE v2 no executor externo `oprm-coletor-mei`, mantendo a lógica de retry técnico, reprocessamento cognitivo, menor rewind, preservação de artefatos e limite por ganho informacional fora do backend.
+- Adicionados contratos internos no backend apenas para leitura/escrita de pendências, conclusão e falha da etapa `reprocess-controller`; o backend persiste o plano recebido do executor e não decide regra de negócio.
+- Documentado o contrato em `docs/swagger/oprm-nichocnae-v2-reprocess-controller-swagger.yaml` e atualizada a tela do mapa v2 para indicar implementação inicial da etapa 9.
+- Causa-raiz preventiva: a etapa 9 estava apenas descrita no mapa do produto; agora há processor e contratos mínimos testados para impedir que decisões de reprocessamento sejam deslocadas para o backend.

--- a/docs/swagger/oprm-nichocnae-v2-reprocess-controller-swagger.yaml
+++ b/docs/swagger/oprm-nichocnae-v2-reprocess-controller-swagger.yaml
@@ -1,0 +1,42 @@
+openapi: 3.0.3
+info:
+  title: OPRM NichoCNAE v2 Reprocess Controller API
+  version: 1.0.0
+  description: Contratos internos de leitura e escrita da etapa 9 do pipeline NichoCNAE v2. A lógica de retry técnico, reprocessamento cognitivo, menor rewind, preservação de artefatos e controle de ganho informacional fica no executor externo oprm-coletor-mei; o backend apenas persiste e expõe pendências/resultados.
+paths:
+  /api/internal/oprm/nichocnae/v2/reprocess-controller/stage-executions/pending:
+    get:
+      summary: Lista pendências da etapa 9 para o executor OPRM.
+      responses:
+        '200':
+          description: Pendências disponíveis.
+  /api/internal/oprm/nichocnae/v2/reprocess-controller/stage-executions:
+    post:
+      summary: Registra uma pendência da etapa 9 solicitada pelo executor.
+      responses:
+        '200':
+          description: Pendência gravada.
+  /api/internal/oprm/nichocnae/v2/reprocess-controller/stage-executions/{stageExecutionId}/complete:
+    post:
+      summary: Registra conclusão do plano de reprocessamento executado fora do backend.
+      parameters:
+        - name: stageExecutionId
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Conclusão persistida.
+  /api/internal/oprm/nichocnae/v2/reprocess-controller/stage-executions/{stageExecutionId}/fail:
+    post:
+      summary: Registra falha da etapa 9, separando retry técnico de falha cognitiva.
+      parameters:
+        - name: stageExecutionId
+          in: path
+          required: true
+          schema:
+            type: integer
+      responses:
+        '200':
+          description: Falha persistida.

--- a/frontend/src/pages/oprm/OprmNichoCnaeV2PipelinePage.tsx
+++ b/frontend/src/pages/oprm/OprmNichoCnaeV2PipelinePage.tsx
@@ -89,7 +89,7 @@ const v2Stages = [
   {
     number: 9,
     title: "Reprocess Controller",
-    status: "Design aprovado · implementação parcial",
+    status: "Design aprovado · implementação inicial",
     purpose:
       "Decidir o menor rewind necessário quando um gate falhar por qualidade, mantendo o mesmo job quando aplicável.",
     output:

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnaev2/pipeline/reprocesscontroller/ReprocessControllerProcessor.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnaev2/pipeline/reprocesscontroller/ReprocessControllerProcessor.java
@@ -1,0 +1,107 @@
+package com.marketinghub.nichocnaev2.pipeline.reprocesscontroller;
+
+import com.marketinghub.nichocnaev2.pipeline.StageArtifact;
+import com.marketinghub.nichocnaev2.pipeline.StageContext;
+import com.marketinghub.nichocnaev2.pipeline.StageProcessor;
+import com.marketinghub.nichocnaev2.pipeline.StageResult;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+/** Decide retry técnico ou reprocessamento cognitivo do NichoCNAE v2 no executor externo. */
+public final class ReprocessControllerProcessor implements StageProcessor {
+    private static final List<String> INFRASTRUCTURE_REASONS = List.of("TIMEOUT", "SSL", "BROKEN_PIPE", "HTTP_429", "HTTP_502", "HTTP_503", "HTTP_504", "CONNECTION");
+
+    /** Calcula o menor retorno necessário preservando conhecimento válido e sem reiniciar o ciclo inteiro. */
+    @Override
+    public StageResult process(StageContext context) {
+        Map<String, Object> input = context.input();
+        String failureType = text(input.get("failureType")).toUpperCase(Locale.ROOT);
+        String reasonCode = text(input.get("reasonCode")).toUpperCase(Locale.ROOT);
+        String gateDecision = text(input.get("gateDecision")).toUpperCase(Locale.ROOT);
+        int attemptNumber = integer(input.get("attemptNumber"), 1);
+        int technicalRetryNumber = integer(input.get("technicalRetryNumber"), 0);
+        int knowledgeVersion = integer(input.get("knowledgeVersion"), 1);
+        int maxCognitiveAttempts = integer(input.get("maxCognitiveAttempts"), 3);
+        double informationGain = decimal(input.get("informationGain"), 0.0);
+        boolean technical = "INFRASTRUCTURE".equals(failureType) || INFRASTRUCTURE_REASONS.stream().anyMatch(reasonCode::contains);
+
+        Map<String, Object> plan = new LinkedHashMap<>();
+        plan.put("researchCycleId", input.get("researchCycleId"));
+        plan.put("candidateId", input.get("candidateId"));
+        plan.put("candidateVersion", integer(input.get("candidateVersion"), 1));
+        plan.put("reasonCode", reasonCode.isBlank() ? gateDecision : reasonCode);
+        plan.put("preservedArtifacts", input.getOrDefault("preservedArtifacts", List.of("VALIDATED_FACTS", "ACCEPTED_SOURCES", "QUERY_MEMORY")));
+        plan.put("invalidatedArtifacts", invalidatedArtifacts(reasonCode, gateDecision));
+
+        if (technical) {
+            plan.put("executionMode", "TECHNICAL_RETRY");
+            plan.put("rewindToStage", text(input.getOrDefault("failedStageCode", input.get("stageCode"))));
+            plan.put("attemptNumber", attemptNumber);
+            plan.put("technicalRetryNumber", technicalRetryNumber + 1);
+            plan.put("knowledgeVersion", knowledgeVersion);
+            plan.put("nextStageCode", text(plan.get("rewindToStage")));
+            return result("TECHNICAL_RETRY_PLANNED", plan, "Retry técnico preservando a mesma versão de conhecimento.");
+        }
+
+        if (attemptNumber >= maxCognitiveAttempts && informationGain < 0.10) {
+            plan.put("executionMode", "STOP_NO_INFORMATION_GAIN");
+            plan.put("rewindToStage", "end");
+            plan.put("attemptNumber", attemptNumber);
+            plan.put("technicalRetryNumber", technicalRetryNumber);
+            plan.put("knowledgeVersion", knowledgeVersion);
+            plan.put("nextStageCode", "end");
+            return result("NO_INFORMATION_GAIN", plan, "Encerramento seguro por falta de ganho informacional.");
+        }
+
+        plan.put("executionMode", "COGNITIVE_REPROCESS");
+        plan.put("rewindToStage", rewindToStage(reasonCode, gateDecision));
+        plan.put("newEvidenceGaps", input.getOrDefault("evidenceGaps", input.getOrDefault("missingEvidence", List.of())));
+        plan.put("attemptNumber", attemptNumber + 1);
+        plan.put("technicalRetryNumber", 0);
+        plan.put("knowledgeVersionFrom", knowledgeVersion);
+        plan.put("knowledgeVersionTo", knowledgeVersion + 1);
+        plan.put("nextStageCode", plan.get("rewindToStage"));
+        return result("COGNITIVE_REPROCESS_PLANNED", plan, "Reprocessamento cognitivo com menor rewind necessário e conhecimento preservado.");
+    }
+
+    /** Monta o StageResult persistível do plano de reprocessamento. */
+    private StageResult result(String status, Map<String, Object> plan, String description) {
+        Map<String, Object> output = new LinkedHashMap<>();
+        output.put("stage", "reprocess-controller");
+        output.put("reprocessPlan", plan);
+        output.put("executionMode", plan.get("executionMode"));
+        output.put("nextStageCode", plan.get("nextStageCode"));
+        return new StageResult(status, output, List.of(new StageArtifact("REPROCESS_PLAN", "inline://reprocess-controller/plan", description)));
+    }
+
+    /** Escolhe a menor etapa de retorno conforme o diagnóstico do gate. */
+    private String rewindToStage(String reasonCode, String gateDecision) {
+        if (reasonCode.contains("SOURCE") || reasonCode.contains("DOMAIN")) return "source-fetcher-reranker";
+        if (reasonCode.contains("CLAIM") || reasonCode.contains("CONTRADICT")) return "signal-extractor";
+        if (reasonCode.contains("CANDIDATE") || "NO_VIABLE_SUBNICHE".equals(gateDecision)) return "candidate-tournament";
+        return "adaptive-query-planner";
+    }
+
+    /** Declara quais descendentes devem ser recalculados sem apagar evidência auditável. */
+    private List<String> invalidatedArtifacts(String reasonCode, String gateDecision) {
+        if (reasonCode.contains("SOURCE") || reasonCode.contains("DOMAIN")) return List.of("SOURCE_RANKING", "CLAIMS", "SYNTHESIS", "GATE_DECISION");
+        if (reasonCode.contains("CLAIM") || reasonCode.contains("CONTRADICT")) return List.of("CLAIMS", "SYNTHESIS", "GATE_DECISION");
+        if ("NO_VIABLE_SUBNICHE".equals(gateDecision)) return List.of("CANDIDATE_FINALIST", "QUERY_PLAN", "GATE_DECISION");
+        return List.of("QUERY_PLAN", "SOURCE_RANKING", "CLAIMS", "GATE_DECISION");
+    }
+
+    /** Converte valor flexível para inteiro com padrão seguro. */
+    private int integer(Object value, int fallback) {
+        try { return value == null ? fallback : Integer.parseInt(String.valueOf(value)); } catch (NumberFormatException ex) { return fallback; }
+    }
+
+    /** Converte valor flexível para decimal com padrão seguro. */
+    private double decimal(Object value, double fallback) {
+        try { return value == null ? fallback : Double.parseDouble(String.valueOf(value)); } catch (NumberFormatException ex) { return fallback; }
+    }
+
+    /** Retorna texto seguro para decisões determinísticas. */
+    private String text(Object value) { return value == null ? "" : String.valueOf(value).trim(); }
+}

--- a/oprm-coletor-mei/src/test/java/com/marketinghub/nichocnaev2/pipeline/reprocesscontroller/ReprocessControllerProcessorTest.java
+++ b/oprm-coletor-mei/src/test/java/com/marketinghub/nichocnaev2/pipeline/reprocesscontroller/ReprocessControllerProcessorTest.java
@@ -1,0 +1,70 @@
+package com.marketinghub.nichocnaev2.pipeline.reprocesscontroller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.marketinghub.nichocnaev2.pipeline.StageContext;
+import com.marketinghub.nichocnaev2.pipeline.StageResult;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/** Valida a etapa 9 de controle de reprocessamento do pipeline NichoCNAE v2. */
+class ReprocessControllerProcessorTest {
+    /** Garante que falha de infraestrutura vira retry técnico sem mudar versão de conhecimento. */
+    @Test
+    void shouldPlanTechnicalRetryWithoutChangingKnowledgeVersion() {
+        ReprocessControllerProcessor processor = new ReprocessControllerProcessor();
+        StageResult result = processor.process(new StageContext("job-72", "stage-9", Map.of(
+                "researchCycleId", 72,
+                "stageCode", "commercial-evidence-gate",
+                "failureType", "INFRASTRUCTURE",
+                "reasonCode", "HTTP_503",
+                "attemptNumber", 2,
+                "technicalRetryNumber", 1,
+                "knowledgeVersion", 4)));
+
+        assertThat(result.status()).isEqualTo("TECHNICAL_RETRY_PLANNED");
+        Map<String, Object> plan = (Map<String, Object>) result.output().get("reprocessPlan");
+        assertThat(plan).containsEntry("executionMode", "TECHNICAL_RETRY");
+        assertThat(plan).containsEntry("rewindToStage", "commercial-evidence-gate");
+        assertThat(plan).containsEntry("knowledgeVersion", 4);
+        assertThat(plan).containsEntry("technicalRetryNumber", 2);
+    }
+
+    /** Garante que falta cognitiva volta ao planejador adaptativo com gaps e nova versão de conhecimento. */
+    @Test
+    void shouldPlanCognitiveReprocessToAdaptivePlannerWithNewKnowledgeVersion() {
+        ReprocessControllerProcessor processor = new ReprocessControllerProcessor();
+        StageResult result = processor.process(new StageContext("job-72", "stage-9", Map.of(
+                "researchCycleId", 72,
+                "candidateId", 31,
+                "gateDecision", "NEEDS_MORE_RESEARCH",
+                "reasonCode", "MISSING_EXECUTOR_ROUTINE_EVIDENCE",
+                "evidenceGaps", List.of("CONCRETE_EXECUTOR_TASKS"),
+                "attemptNumber", 1,
+                "knowledgeVersion", 4,
+                "informationGain", 0.25)));
+
+        assertThat(result.status()).isEqualTo("COGNITIVE_REPROCESS_PLANNED");
+        Map<String, Object> plan = (Map<String, Object>) result.output().get("reprocessPlan");
+        assertThat(plan).containsEntry("executionMode", "COGNITIVE_REPROCESS");
+        assertThat(plan).containsEntry("rewindToStage", "adaptive-query-planner");
+        assertThat(plan).containsEntry("knowledgeVersionTo", 5);
+        assertThat((List<String>) plan.get("newEvidenceGaps")).contains("CONCRETE_EXECUTOR_TASKS");
+    }
+
+    /** Garante encerramento seguro quando não há ganho informacional após o limite de tentativas. */
+    @Test
+    void shouldStopWhenCognitiveAttemptsHaveNoInformationGain() {
+        ReprocessControllerProcessor processor = new ReprocessControllerProcessor();
+        StageResult result = processor.process(new StageContext("job-72", "stage-9", Map.of(
+                "gateDecision", "NO_PUBLIC_EVIDENCE",
+                "attemptNumber", 3,
+                "maxCognitiveAttempts", 3,
+                "knowledgeVersion", 6,
+                "informationGain", 0.02)));
+
+        assertThat(result.status()).isEqualTo("NO_INFORMATION_GAIN");
+        assertThat(result.output()).containsEntry("nextStageCode", "end");
+    }
+}


### PR DESCRIPTION
### Motivation
- Provide stage 9 `reprocess-controller` for the NichoCNAE v2 pipeline so the executor can decide the smallest rewind, preserve validated artifacts and separate technical retries from cognitive reprocessing. 
- Ensure business logic, decision rules and reprocess planning remain in the external executor (`oprm-coletor-mei`) while the backend is used only to persist and expose pending work, completions and failures. 

### Description
- Added executor-side processor `ReprocessControllerProcessor` that builds a reprocess plan (technical retry vs cognitive reprocess), selects the minimal rewind stage, preserves artifact lineage and computes knowledge-version transitions. 
- Added backend HTTP contracts and service/controller for `reprocess-controller` (pending/create/complete/fail) under `com.marketinghub.oprm.nichocnae.v2.reprocesscontroller` that only persist the executor-provided plan and status. 
- Added typed records for create/complete/fail/pending payloads, a Swagger file `docs/swagger/oprm-nichocnae-v2-reprocess-controller-swagger.yaml`, frontend UI update to mark stage 9 as implemented, and an entry in `docs/registros/oprm1.md`. 
- Included unit tests for the executor processor and backend service plus ArchUnit coverage to keep the executor/core separation and module protocol intact. 

### Testing
- Ran executor unit tests with `mvn -Dtest=ReprocessControllerProcessorTest,NichoCnaeV2PipelineArchitectureTest test` in `oprm-coletor-mei`, which succeeded (`BUILD SUCCESS`). 
- Ran backend unit tests with `mvn -Dtest=BackendReprocessControllerServiceTest test` in `backend/ads-service`, which succeeded (`BUILD SUCCESS`). 
- Ran frontend test `npm test -- --run OprmNavigation.test.tsx` in `frontend` and the relevant UI tests passed (`1 test file passed, 8 tests passed`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a356f22da708321973c87ca56d11b4c)