### PR TITLE
Implement Routine Synthesizer (Stage 10) in OPRM NichoCNAE v2 executor

### DIFF
--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -1074,3 +1074,9 @@
 - Adicionados contratos internos no backend apenas para leitura/escrita de pendências, conclusão e falha da etapa `reprocess-controller`; o backend persiste o plano recebido do executor e não decide regra de negócio.
 - Documentado o contrato em `docs/swagger/oprm-nichocnae-v2-reprocess-controller-swagger.yaml` e atualizada a tela do mapa v2 para indicar implementação inicial da etapa 9.
 - Causa-raiz preventiva: a etapa 9 estava apenas descrita no mapa do produto; agora há processor e contratos mínimos testados para impedir que decisões de reprocessamento sejam deslocadas para o backend.
+## 2026-06-19 — NichoCNAE v2 etapa 10 Routine Synthesizer
+
+- Implementada no executor externo `oprm-coletor-mei` a etapa 10 do pipeline NichoCNAE v2 (`RoutineSynthesizerProcessor`).
+- A síntese usa somente claims aceitos/validados com `exactEvidenceSpan`, preserva IDs de evidência, domínio e URL, e declara gaps quando faltam rotina, dor, impacto econômico ou aquisição.
+- O backend permanece fora da lógica de síntese: sua função segue limitada a leitura/escrita/contratos, enquanto regras, controle e inteligência da etapa ficam no executor OPRM.
+- Atualizada a tela do mapa v2 para indicar implementação inicial da etapa 10.

--- a/frontend/src/pages/oprm/OprmNichoCnaeV2PipelinePage.tsx
+++ b/frontend/src/pages/oprm/OprmNichoCnaeV2PipelinePage.tsx
@@ -100,10 +100,11 @@ const v2Stages = [
   {
     number: 10,
     title: "Routine Synthesizer",
-    status: "Design",
+    status: "Design aprovado · implementação inicial",
     purpose:
       "Sintetizar rotina, dores e resultados apenas a partir de claims aprovados e evidências rastreáveis.",
-    output: "Rotina funcional do executor com evidências e limites explícitos.",
+    output:
+      "Rotina funcional do executor com evidências, IDs de claims, domínios e limites explícitos.",
     businessGate: "Síntese não pode inventar dor, canal ou impacto econômico.",
   },
   {

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnaev2/pipeline/routinesynthesizer/RoutineSynthesizerProcessor.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnaev2/pipeline/routinesynthesizer/RoutineSynthesizerProcessor.java
@@ -1,0 +1,179 @@
+package com.marketinghub.nichocnaev2.pipeline.routinesynthesizer;
+
+import com.marketinghub.nichocnaev2.pipeline.StageArtifact;
+import com.marketinghub.nichocnaev2.pipeline.StageContext;
+import com.marketinghub.nichocnaev2.pipeline.StageProcessor;
+import com.marketinghub.nichocnaev2.pipeline.StageResult;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.Set;
+
+/** Sintetiza a rotina do executor somente a partir de claims aprovados e rastreáveis no executor OPRM. */
+public final class RoutineSynthesizerProcessor implements StageProcessor {
+    private static final Set<String> ROUTINE_TYPES = Set.of("ROUTINE_TASK", "TASK", "OPERATIONAL_TASK");
+    private static final Set<String> PAIN_TYPES = Set.of("OPERATIONAL_FAILURE", "PRACTICAL_PAIN", "RECURRING_PAIN", "PAIN", "REWORK", "WAITING_TIME", "EMOTIONAL_PAIN");
+    private static final Set<String> ECONOMIC_TYPES = Set.of("DIRECT_COST", "OPPORTUNITY_COST", "ECONOMIC_IMPACT", "WORKAROUND", "PRICING", "COLLECTION");
+    private static final Set<String> ACQUISITION_TYPES = Set.of("CUSTOMER_ACQUISITION", "RECURRENCE", "PURCHASE_SIGNAL", "HIRING_BEHAVIOR");
+
+    /** Produz síntese funcional com limites explícitos e sem promover hipótese sem evidência a fato. */
+    @Override
+    public StageResult process(StageContext context) {
+        List<Map<String, Object>> acceptedClaims = acceptedClaims(context.input());
+        List<Map<String, Object>> routineTasks = synthesizeItems(acceptedClaims, ROUTINE_TYPES);
+        List<Map<String, Object>> practicalPains = synthesizeItems(acceptedClaims, PAIN_TYPES);
+        List<Map<String, Object>> economicSignals = synthesizeItems(acceptedClaims, ECONOMIC_TYPES);
+        List<Map<String, Object>> acquisitionSignals = synthesizeItems(acceptedClaims, ACQUISITION_TYPES);
+        List<String> evidenceLimits = evidenceLimits(routineTasks, practicalPains, economicSignals, acquisitionSignals);
+
+        Map<String, Object> synthesis = new LinkedHashMap<>();
+        synthesis.put("executor", context.input().get("executor"));
+        synthesis.put("jobContext", context.input().get("jobContext"));
+        synthesis.put("routineTasks", routineTasks);
+        synthesis.put("practicalPains", practicalPains);
+        synthesis.put("economicSignals", economicSignals);
+        synthesis.put("acquisitionSignals", acquisitionSignals);
+        synthesis.put("evidenceLimits", evidenceLimits);
+        synthesis.put("supportingClaimIds", supportingClaimIds(acceptedClaims));
+        synthesis.put("sourceDomains", sourceDomains(acceptedClaims));
+
+        Map<String, Object> output = new LinkedHashMap<>();
+        output.put("stage", "routine-synthesizer");
+        output.put("synthesis", synthesis);
+        output.put("acceptedClaimCount", acceptedClaims.size());
+        output.put("routineTaskCount", routineTasks.size());
+        output.put("practicalPainCount", practicalPains.size());
+        output.put("economicSignalCount", economicSignals.size());
+        output.put("evidenceLimits", evidenceLimits);
+        output.put("nextStageCode", "commercial-evidence-gate");
+
+        String status = evidenceLimits.isEmpty() ? "ROUTINE_SYNTHESIS_READY" : "ROUTINE_SYNTHESIS_WITH_GAPS";
+        return new StageResult(status, output, List.of(new StageArtifact(
+                "ROUTINE_SYNTHESIS",
+                "inline://routine-synthesizer/synthesis",
+                "Síntese de rotina, dores e sinais comerciais baseada exclusivamente em claims aceitos com trecho exato.")));
+    }
+
+    /** Filtra claims validados com trecho exato antes de qualquer síntese funcional. */
+    private List<Map<String, Object>> acceptedClaims(Map<String, Object> input) {
+        return firstNonEmpty(input, "validatedClaims", "claims", "evidenceClaims").stream()
+                .filter(this::isAccepted)
+                .toList();
+    }
+
+    /** Verifica se o claim pode sustentar a síntese como evidência positiva. */
+    private boolean isAccepted(Map<String, Object> claim) {
+        String status = text(claim.get("status")).toUpperCase(Locale.ROOT);
+        String state = text(claim.get("epistemicState")).toUpperCase(Locale.ROOT);
+        String evidenceSpan = text(claim.get("exactEvidenceSpan"));
+        return !evidenceSpan.isBlank()
+                && (status.isBlank() || status.equals("ACCEPT") || status.equals("ACCEPTED") || status.equals("VALIDATED"))
+                && (state.isBlank() || state.equals("VALIDATED") || state.equals("ACCEPTED"));
+    }
+
+    /** Agrupa claims por tipo sem criar afirmações novas além do texto validado. */
+    private List<Map<String, Object>> synthesizeItems(List<Map<String, Object>> claims, Set<String> acceptedTypes) {
+        List<Map<String, Object>> items = new ArrayList<>();
+        Set<String> seen = new LinkedHashSet<>();
+        for (Map<String, Object> claim : claims) {
+            String type = text(claim.get("claimType")).toUpperCase(Locale.ROOT);
+            if (!acceptedTypes.contains(type)) {
+                continue;
+            }
+            String claimText = text(claim.getOrDefault("claimText", claim.get("canonicalClaim")));
+            String key = normalize(type + ":" + claimText);
+            if (claimText.isBlank() || !seen.add(key)) {
+                continue;
+            }
+            Map<String, Object> item = new LinkedHashMap<>();
+            item.put("claimType", type);
+            item.put("text", claimText);
+            item.put("supportingClaimIds", List.of(claim.getOrDefault("canonicalClaimId", claim.getOrDefault("claimId", ""))));
+            item.put("exactEvidenceSpan", claim.get("exactEvidenceSpan"));
+            item.put("sourceUrl", claim.get("sourceUrl"));
+            item.put("canonicalDomain", claim.get("canonicalDomain"));
+            items.add(item);
+        }
+        return items;
+    }
+
+    /** Declara gaps explicitamente quando a evidência ainda não permite afirmações funcionais. */
+    private List<String> evidenceLimits(
+            List<Map<String, Object>> routineTasks,
+            List<Map<String, Object>> practicalPains,
+            List<Map<String, Object>> economicSignals,
+            List<Map<String, Object>> acquisitionSignals) {
+        List<String> limits = new ArrayList<>();
+        if (routineTasks.isEmpty()) {
+            limits.add("Sem tarefas concretas validadas do executor para sintetizar rotina.");
+        }
+        if (practicalPains.isEmpty()) {
+            limits.add("Sem dor prática validada; não sintetizar dor por inferência.");
+        }
+        if (economicSignals.isEmpty()) {
+            limits.add("Sem impacto econômico ou workaround validado; não afirmar valor comercial.");
+        }
+        if (acquisitionSignals.isEmpty()) {
+            limits.add("Sem sinal validado de aquisição, recorrência ou intenção de compra.");
+        }
+        return limits;
+    }
+
+    /** Lista os IDs de claims que sustentam a síntese para auditoria e relatório de usuário. */
+    private List<Object> supportingClaimIds(List<Map<String, Object>> claims) {
+        return claims.stream()
+                .map(claim -> claim.getOrDefault("canonicalClaimId", claim.get("claimId")))
+                .filter(id -> id != null && !text(id).isBlank())
+                .distinct()
+                .toList();
+    }
+
+    /** Lista domínios independentes presentes na síntese para o gate seguinte. */
+    private List<String> sourceDomains(List<Map<String, Object>> claims) {
+        return claims.stream()
+                .map(claim -> text(claim.get("canonicalDomain")))
+                .filter(domain -> !domain.isBlank())
+                .distinct()
+                .toList();
+    }
+
+    /** Extrai a primeira lista de mapas disponível entre chaves alternativas. */
+    private List<Map<String, Object>> firstNonEmpty(Map<String, Object> input, String... keys) {
+        for (String key : keys) {
+            List<Map<String, Object>> values = mapList(input.get(key));
+            if (!values.isEmpty()) {
+                return values;
+            }
+        }
+        return List.of();
+    }
+
+    /** Extrai lista de mapas de contratos flexíveis recebidos do backend. */
+    private List<Map<String, Object>> mapList(Object value) {
+        if (!(value instanceof List<?> items)) {
+            return List.of();
+        }
+        List<Map<String, Object>> mapped = new ArrayList<>();
+        for (Object item : items) {
+            if (item instanceof Map<?, ?> map) {
+                Map<String, Object> copy = new LinkedHashMap<>();
+                map.forEach((key, val) -> copy.put(String.valueOf(key), val));
+                mapped.add(copy);
+            }
+        }
+        return mapped;
+    }
+
+    /** Normaliza texto para deduplicação simples e determinística. */
+    private String normalize(String value) {
+        return text(value).toLowerCase(Locale.ROOT).replaceAll("\\s+", " ");
+    }
+
+    /** Retorna texto seguro para regras determinísticas. */
+    private String text(Object value) {
+        return value == null ? "" : String.valueOf(value).trim();
+    }
+}

--- a/oprm-coletor-mei/src/test/java/com/marketinghub/nichocnaev2/pipeline/routinesynthesizer/RoutineSynthesizerProcessorTest.java
+++ b/oprm-coletor-mei/src/test/java/com/marketinghub/nichocnaev2/pipeline/routinesynthesizer/RoutineSynthesizerProcessorTest.java
@@ -1,0 +1,72 @@
+package com.marketinghub.nichocnaev2.pipeline.routinesynthesizer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.marketinghub.nichocnaev2.pipeline.StageContext;
+import com.marketinghub.nichocnaev2.pipeline.StageResult;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/** Valida a etapa 10 de síntese de rotina do pipeline NichoCNAE v2. */
+class RoutineSynthesizerProcessorTest {
+    /** Garante que a síntese usa somente claims aceitos com trecho exato e mantém IDs de evidência. */
+    @Test
+    void shouldSynthesizeRoutineOnlyFromAcceptedClaimsWithExactEvidenceSpan() {
+        RoutineSynthesizerProcessor processor = new RoutineSynthesizerProcessor();
+
+        StageResult result = processor.process(new StageContext("job-10", "stage-10", Map.of(
+                "executor", "Motoristas autônomos de transfer aeroportuário",
+                "jobContext", "Corridas previamente agendadas",
+                "claims", List.of(
+                        claim(101, "ROUTINE_TASK", "Confirma horários de chegada dos passageiros", "a.com"),
+                        claim(102, "OPERATIONAL_FAILURE", "Cancelamento tardio deixa horário sem reposição", "b.com"),
+                        claim(103, "DIRECT_COST", "Deslocamento até aeroporto pode virar custo perdido", "c.com"),
+                        Map.of(
+                                "claimId", 104,
+                                "claimType", "PURCHASE_SIGNAL",
+                                "claimText", "Texto sem trecho não deve entrar",
+                                "status", "ACCEPTED",
+                                "canonicalDomain", "d.com")))));
+
+        assertThat(result.status()).isEqualTo("ROUTINE_SYNTHESIS_WITH_GAPS");
+        Map<String, Object> synthesis = (Map<String, Object>) result.output().get("synthesis");
+        assertThat((List<?>) synthesis.get("routineTasks")).hasSize(1);
+        assertThat((List<?>) synthesis.get("practicalPains")).hasSize(1);
+        assertThat((List<?>) synthesis.get("economicSignals")).hasSize(1);
+        assertThat((List<?>) synthesis.get("acquisitionSignals")).isEmpty();
+        assertThat((List<Object>) synthesis.get("supportingClaimIds")).containsExactly(101, 102, 103);
+        assertThat(result.output()).containsEntry("nextStageCode", "commercial-evidence-gate");
+    }
+
+    /** Garante que falta de evidência vira limite explícito em vez de texto genérico inventado. */
+    @Test
+    void shouldDeclareEvidenceLimitsInsteadOfInventingSynthesis() {
+        RoutineSynthesizerProcessor processor = new RoutineSynthesizerProcessor();
+
+        StageResult result = processor.process(new StageContext("job-11", "stage-10", Map.of(
+                "claims", List.of(Map.of(
+                        "claimId", 201,
+                        "claimType", "ROUTINE_TASK",
+                        "claimText", "Texto sem trecho exato",
+                        "status", "ACCEPTED")))));
+
+        assertThat(result.status()).isEqualTo("ROUTINE_SYNTHESIS_WITH_GAPS");
+        Map<String, Object> synthesis = (Map<String, Object>) result.output().get("synthesis");
+        assertThat((List<?>) synthesis.get("routineTasks")).isEmpty();
+        assertThat((List<String>) synthesis.get("evidenceLimits"))
+                .contains("Sem tarefas concretas validadas do executor para sintetizar rotina.");
+    }
+
+    private Map<String, Object> claim(int id, String type, String text, String domain) {
+        return Map.of(
+                "claimId", id,
+                "claimType", type,
+                "claimText", text,
+                "status", "ACCEPTED",
+                "epistemicState", "VALIDATED",
+                "exactEvidenceSpan", text,
+                "sourceUrl", "https://" + domain + "/fonte",
+                "canonicalDomain", domain);
+    }
+}


### PR DESCRIPTION
### Motivation
- Implement the pipeline Stage 10 (Routine Synthesizer) so the pipeline can produce a routine summary for an executor only from evidence-approved claims and exact spans, preventing invented hypotheses. 
- Keep all business logic, control and rules in the external executor (`oprm-coletor-mei`) while the backend remains limited to read/write and contract persistence.

### Description
- Added `RoutineSynthesizerProcessor` (`oprm-coletor-mei/src/main/java/com/marketinghub/nichocnaev2/pipeline/routinesynthesizer/RoutineSynthesizerProcessor.java`) which implements `StageProcessor` and synthesizes `routineTasks`, `practicalPains`, `economicSignals`, `acquisitionSignals`, preserves `supportingClaimIds`, `canonicalDomain` and `sourceUrl`, and emits explicit `evidenceLimits` when data is missing. 
- Added unit tests (`RoutineSynthesizerProcessorTest`) validating that synthesis uses only accepted/validated claims with `exactEvidenceSpan` and that missing evidence produces explicit gaps instead of invented text. 
- Updated frontend pipeline map (`frontend/src/pages/oprm/OprmNichoCnaeV2PipelinePage.tsx`) to mark Etapa 10 as "Design aprovado · implementação inicial" and clarify the stage output. 
- Registered the change in `docs/registros/oprm1.md` describing the executor-side implementation and explicitly noting the backend role is limited to persistence/read-write.

### Testing
- Ran `cd oprm-coletor-mei && mvn test -Dtest=RoutineSynthesizerProcessorTest,NichoCnaeV2PipelineArchitectureTest` and both tests completed successfully (build success and tests passed). 
- Ran frontend validation via `cd frontend && npm ci` followed by `cd frontend && npm test -- --run OprmNavigation.test.tsx` and the `OprmNavigation` tests passed. 
- Note that an attempt to run `./mvnw` at the repo root failed because there is no Maven wrapper in the repository, so `mvn` was used to run the Java module tests instead.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a35721a1b548321a764a7727c37a5e6)