### PR TITLE
Implement Evidence Level Gate (Etapa 11 E0–E5) for OPRM (executor-side)

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/OprmNicheRoutineCard.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/OprmNicheRoutineCard.java
@@ -99,6 +99,24 @@ public class OprmNicheRoutineCard {
   @Column(name = "quality_checked_at")
   private Instant qualityCheckedAt;
 
+  @Column(name = "evidence_level", length = 8)
+  private String evidenceLevel;
+
+  @Column(name = "evidence_gate_status", length = 48)
+  private String evidenceGateStatus;
+
+  @Column(name = "evidence_confidence_score")
+  private Integer evidenceConfidenceScore;
+
+  @Column(name = "evidence_gate_notes", columnDefinition = "LONGTEXT")
+  private String evidenceGateNotes;
+
+  @Column(name = "evidence_gate_checked_by", length = 64)
+  private String evidenceGateCheckedBy;
+
+  @Column(name = "evidence_gate_checked_at")
+  private Instant evidenceGateCheckedAt;
+
   @Column(name = "synthesized_by", nullable = false, length = 64)
   private String synthesizedBy;
 

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/evidencelevelgate/service/BackendEvidenceLevelGateService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/evidencelevelgate/service/BackendEvidenceLevelGateService.java
@@ -1,0 +1,139 @@
+package com.marketinghub.oprm.nichocnae.evidencelevelgate.service;
+
+import com.marketinghub.oprm.nichocnae.OprmNicheRoutineCard;
+import com.marketinghub.oprm.nichocnae.OprmRoutineResearchCycle;
+import com.marketinghub.oprm.nichocnae.evidencelevelgate.service.completeStageExecution.CompleteEvidenceLevelGateRequest;
+import com.marketinghub.oprm.nichocnae.evidencelevelgate.service.completeStageExecution.CompleteEvidenceLevelGateResponse;
+import com.marketinghub.oprm.nichocnae.evidencelevelgate.service.detailStageExecution.EvidenceLevelGateDetailResponse;
+import com.marketinghub.oprm.nichocnae.evidencelevelgate.service.failStageExecution.FailEvidenceLevelGateRequest;
+import com.marketinghub.oprm.nichocnae.evidencelevelgate.service.pending.RecordEvidenceLevelGatePending;
+import com.marketinghub.repository.jpa.oprm.nichocnae.OprmNicheRoutineCardRepository;
+import com.marketinghub.repository.jpa.oprm.nichocnae.OprmRoutineResearchCycleRepository;
+import jakarta.persistence.EntityNotFoundException;
+import java.time.Instant;
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+/** Responsável apenas por ler pendências e persistir resultados do gate E0-E5 calculados pelo executor externo. */
+@Service
+public class BackendEvidenceLevelGateService {
+  private static final Logger LOGGER = LoggerFactory.getLogger(BackendEvidenceLevelGateService.class);
+  private static final int MAX_PENDING = 10;
+  private static final String STAGE_CODE = "evidence-level-gate";
+  private static final String NEXT_STAGE = "enriched-niche-materializer";
+  private static final String STATUS_FAILED = "FAILED";
+  private static final String STATUS_APPROVED = "EVIDENCE_GATE_APPROVED";
+
+  private final OprmRoutineResearchCycleRepository cycleRepository;
+  private final OprmNicheRoutineCardRepository cardRepository;
+
+  /** Inicializa o serviço com repositórios canônicos de ciclo e cartão. */
+  public BackendEvidenceLevelGateService(
+      OprmRoutineResearchCycleRepository cycleRepository, OprmNicheRoutineCardRepository cardRepository) {
+    this.cycleRepository = cycleRepository;
+    this.cardRepository = cardRepository;
+  }
+
+  /** Lista cartões pendentes para o executor externo calcular nível E0-E5. */
+  @Transactional(readOnly = true)
+  public List<RecordEvidenceLevelGatePending> listPending() {
+    return cardRepository.findPendingEvidenceLevelGate(PageRequest.of(0, MAX_PENDING)).stream().map(this::toPending).toList();
+  }
+
+  /** Persiste a decisão E0-E5 recebida do executor e move o ciclo apenas conforme o resultado informado. */
+  @Transactional
+  public CompleteEvidenceLevelGateResponse complete(Long researchCycleId, CompleteEvidenceLevelGateRequest request) {
+    try {
+      OprmRoutineResearchCycle cycle = findCycle(researchCycleId);
+      OprmNicheRoutineCard card = cardRepository.findById(requiredId(request == null ? null : request.routineCardId(), "routineCardId"))
+          .orElseThrow(() -> new EntityNotFoundException("Routine card not found: " + request.routineCardId()));
+      if (!card.getResearchCycleId().equals(researchCycleId)) {
+        throw new IllegalArgumentException("routineCardId must belong to researchCycleId");
+      }
+      String level = requiredText(request.evidenceLevel(), "evidenceLevel").toUpperCase();
+      String status = requiredText(request.gateStatus(), "gateStatus").toUpperCase();
+      Integer confidence = request.confidenceScore() == null ? 0 : Math.max(0, Math.min(100, request.confidenceScore()));
+      Instant now = Instant.now();
+      card.setEvidenceLevel(level);
+      card.setEvidenceGateStatus(status);
+      card.setEvidenceConfidenceScore(confidence);
+      card.setEvidenceGateNotes(buildNotes(request));
+      card.setEvidenceGateCheckedBy(defaultText(request.checkedBy(), "oprmEvidenceLevelGate"));
+      card.setEvidenceGateCheckedAt(now);
+      cardRepository.save(card);
+      boolean approved = Boolean.TRUE.equals(request.approvedForMaterialization());
+      cycle.setStatus(approved ? STATUS_APPROVED : status);
+      cycle.setCurrentStageCode(approved ? NEXT_STAGE : STAGE_CODE);
+      cycle.setUpdatedAt(now);
+      cycle.setFinishedAt(now);
+      cycleRepository.save(cycle);
+      return new CompleteEvidenceLevelGateResponse(card.getId(), cycle.getId(), cycle.getStatus(), level, status, approved, confidence, now);
+    } catch (RuntimeException ex) {
+      LOGGER.error("Erro ao persistir etapa onze E0-E5 OPRM nichocnae (researchCycleId={}, routineCardId={})", researchCycleId, request == null ? null : request.routineCardId(), ex);
+      throw ex;
+    }
+  }
+
+  /** Registra falha técnica da etapa E0-E5 sem tomar decisão comercial no backend. */
+  @Transactional
+  public void fail(Long researchCycleId, FailEvidenceLevelGateRequest request) {
+    try {
+      OprmRoutineResearchCycle cycle = findCycle(researchCycleId);
+      Instant now = Instant.now();
+      cycle.setStatus(STATUS_FAILED);
+      cycle.setCurrentStageCode(STAGE_CODE);
+      cycle.setErrorMessage(requiredText(request == null ? null : request.errorMessage(), "errorMessage"));
+      cycle.setUpdatedAt(now);
+      cycle.setFinishedAt(now);
+      cycleRepository.save(cycle);
+    } catch (RuntimeException ex) {
+      LOGGER.error("Erro ao registrar falha da etapa onze E0-E5 OPRM nichocnae (researchCycleId={})", researchCycleId, ex);
+      throw ex;
+    }
+  }
+
+  /** Retorna o resultado E0-E5 persistido para relatório do usuário. */
+  @Transactional(readOnly = true)
+  public EvidenceLevelGateDetailResponse detail(Long researchCycleId) {
+    OprmRoutineResearchCycle cycle = findCycle(researchCycleId);
+    OprmNicheRoutineCard card = cardRepository.findFirstByResearchCycleIdOrderByIdDesc(researchCycleId).orElse(null);
+    return new EvidenceLevelGateDetailResponse(researchCycleId, cycle.getStatus(), card == null ? null : card.getId(), card == null ? null : card.getEvidenceLevel(), card == null ? null : card.getEvidenceGateStatus(), card == null ? null : card.getEvidenceConfidenceScore(), card == null ? null : card.getEvidenceGateNotes(), card == null ? null : card.getEvidenceGateCheckedBy(), card == null ? null : card.getEvidenceGateCheckedAt());
+  }
+
+  /** Converte o cartão persistido no contrato de leitura para o executor externo. */
+  private RecordEvidenceLevelGatePending toPending(OprmNicheRoutineCard card) {
+    return new RecordEvidenceLevelGatePending(card.getId(), card.getResearchCycleId(), card.getNicheName(), card.getRoutineSummary(), card.getPainsSummary(), card.getResultsSummary(), card.getEvidenceSummary(), card.getSourceDomains(), card.getConfidenceScore(), card.getRoutineEvidenceScore(), card.getDifficultyEvidenceScore(), card.getSourceDiversityScore(), card.getSpecificityScore(), card.getConfidenceScore());
+  }
+
+  /** Busca o ciclo ou falha quando o identificador não existe. */
+  private OprmRoutineResearchCycle findCycle(Long researchCycleId) {
+    return cycleRepository.findById(requiredId(researchCycleId, "researchCycleId")).orElseThrow(() -> new EntityNotFoundException("Research cycle not found: " + researchCycleId));
+  }
+
+  /** Monta notas textuais persistidas sem calcular regra comercial no backend. */
+  private String buildNotes(CompleteEvidenceLevelGateRequest request) {
+    return "rejectionReasons=" + defaultText(request.rejectionReasons(), "") + "; nextMovements=" + defaultText(request.nextMovements(), "");
+  }
+
+  /** Exige identificador obrigatório. */
+  private Long requiredId(Long value, String field) {
+    if (value == null) throw new IllegalArgumentException(field + " is required");
+    return value;
+  }
+
+  /** Exige texto obrigatório. */
+  private String requiredText(String value, String field) {
+    if (!StringUtils.hasText(value)) throw new IllegalArgumentException(field + " is required");
+    return value.trim();
+  }
+
+  /** Usa valor padrão para texto opcional em branco. */
+  private String defaultText(String value, String fallback) {
+    return StringUtils.hasText(value) ? value.trim() : fallback;
+  }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/evidencelevelgate/service/completeStageExecution/CompleteEvidenceLevelGateRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/evidencelevelgate/service/completeStageExecution/CompleteEvidenceLevelGateRequest.java
@@ -1,0 +1,12 @@
+package com.marketinghub.oprm.nichocnae.evidencelevelgate.service.completeStageExecution;
+
+/** Contrato usado pelo executor externo para persistir o resultado E0-E5 sem delegar regra de negócio ao backend. */
+public record CompleteEvidenceLevelGateRequest(
+    Long routineCardId,
+    String evidenceLevel,
+    String gateStatus,
+    Boolean approvedForMaterialization,
+    Integer confidenceScore,
+    String rejectionReasons,
+    String nextMovements,
+    String checkedBy) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/evidencelevelgate/service/completeStageExecution/CompleteEvidenceLevelGateResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/evidencelevelgate/service/completeStageExecution/CompleteEvidenceLevelGateResponse.java
@@ -1,0 +1,14 @@
+package com.marketinghub.oprm.nichocnae.evidencelevelgate.service.completeStageExecution;
+
+import java.time.Instant;
+
+/** Resposta de persistência da etapa E0-E5 com o novo estado gravado no ciclo e no cartão. */
+public record CompleteEvidenceLevelGateResponse(
+    Long routineCardId,
+    Long researchCycleId,
+    String cycleStatus,
+    String evidenceLevel,
+    String gateStatus,
+    Boolean approvedForMaterialization,
+    Integer confidenceScore,
+    Instant checkedAt) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/evidencelevelgate/service/detailStageExecution/EvidenceLevelGateDetailResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/evidencelevelgate/service/detailStageExecution/EvidenceLevelGateDetailResponse.java
@@ -1,0 +1,15 @@
+package com.marketinghub.oprm.nichocnae.evidencelevelgate.service.detailStageExecution;
+
+import java.time.Instant;
+
+/** Detalhe persistido do gate comercial E0-E5 para relatório do usuário. */
+public record EvidenceLevelGateDetailResponse(
+    Long researchCycleId,
+    String cycleStatus,
+    Long routineCardId,
+    String evidenceLevel,
+    String gateStatus,
+    Integer confidenceScore,
+    String notes,
+    String checkedBy,
+    Instant checkedAt) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/evidencelevelgate/service/failStageExecution/FailEvidenceLevelGateRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/evidencelevelgate/service/failStageExecution/FailEvidenceLevelGateRequest.java
@@ -1,0 +1,4 @@
+package com.marketinghub.oprm.nichocnae.evidencelevelgate.service.failStageExecution;
+
+/** Contrato usado pelo executor externo para registrar falha técnica da etapa E0-E5. */
+public record FailEvidenceLevelGateRequest(String errorMessage) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/evidencelevelgate/service/pending/RecordEvidenceLevelGatePending.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/evidencelevelgate/service/pending/RecordEvidenceLevelGatePending.java
@@ -1,0 +1,18 @@
+package com.marketinghub.oprm.nichocnae.evidencelevelgate.service.pending;
+
+/** Representa um cartão aprovado na qualidade aguardando classificação comercial E0-E5 pelo executor externo. */
+public record RecordEvidenceLevelGatePending(
+    Long routineCardId,
+    Long researchCycleId,
+    String nicheName,
+    String routineSummary,
+    String painsSummary,
+    String resultsSummary,
+    String evidenceSummary,
+    String sourceDomains,
+    Integer confidenceScore,
+    Integer routineEvidenceScore,
+    Integer difficultyEvidenceScore,
+    Integer sourceDiversityScore,
+    Integer specificityScore,
+    Integer qualityConfidenceScore) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/evidencelevelgate/web/BackendEvidenceLevelGateController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/evidencelevelgate/web/BackendEvidenceLevelGateController.java
@@ -1,0 +1,53 @@
+package com.marketinghub.oprm.nichocnae.evidencelevelgate.web;
+
+import com.marketinghub.oprm.nichocnae.evidencelevelgate.service.BackendEvidenceLevelGateService;
+import com.marketinghub.oprm.nichocnae.evidencelevelgate.service.completeStageExecution.CompleteEvidenceLevelGateRequest;
+import com.marketinghub.oprm.nichocnae.evidencelevelgate.service.completeStageExecution.CompleteEvidenceLevelGateResponse;
+import com.marketinghub.oprm.nichocnae.evidencelevelgate.service.detailStageExecution.EvidenceLevelGateDetailResponse;
+import com.marketinghub.oprm.nichocnae.evidencelevelgate.service.failStageExecution.FailEvidenceLevelGateRequest;
+import com.marketinghub.oprm.nichocnae.evidencelevelgate.service.pending.RecordEvidenceLevelGatePending;
+import java.util.List;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/** Expõe contratos de leitura e escrita da etapa onze E0-E5 sem executar regra de negócio no backend. */
+@RestController
+@RequestMapping("/api")
+public class BackendEvidenceLevelGateController {
+  private final BackendEvidenceLevelGateService service;
+
+  /** Inicializa o controller com o serviço de persistência da etapa E0-E5. */
+  public BackendEvidenceLevelGateController(BackendEvidenceLevelGateService service) {
+    this.service = service;
+  }
+
+  /** Lista pendências para o executor externo calcular o nível comercial E0-E5. */
+  @GetMapping("/internal/oprm/nichocnae/evidence-level-gate/stage-executions/pending")
+  public List<RecordEvidenceLevelGatePending> pending() {
+    return service.listPending();
+  }
+
+  /** Persiste o resultado E0-E5 calculado pelo executor externo. */
+  @PostMapping("/internal/oprm/nichocnae/evidence-level-gate/stage-executions/{researchCycleId}/complete")
+  public ResponseEntity<CompleteEvidenceLevelGateResponse> complete(@PathVariable Long researchCycleId, @RequestBody CompleteEvidenceLevelGateRequest request) {
+    return ResponseEntity.ok(service.complete(researchCycleId, request));
+  }
+
+  /** Registra falha técnica informada pelo executor externo. */
+  @PostMapping("/internal/oprm/nichocnae/evidence-level-gate/stage-executions/{researchCycleId}/fail")
+  public ResponseEntity<Void> fail(@PathVariable Long researchCycleId, @RequestBody FailEvidenceLevelGateRequest request) {
+    service.fail(researchCycleId, request);
+    return ResponseEntity.noContent().build();
+  }
+
+  /** Consulta o resultado E0-E5 persistido para relatório. */
+  @GetMapping("/oprm/nichocnae/evidence-level-gate/stage-executions/{researchCycleId}")
+  public ResponseEntity<EvidenceLevelGateDetailResponse> detail(@PathVariable Long researchCycleId) {
+    return ResponseEntity.ok(service.detail(researchCycleId));
+  }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/pipeline/OprmNichoCnaePipelineSection.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/pipeline/OprmNichoCnaePipelineSection.java
@@ -70,8 +70,15 @@ public enum OprmNichoCnaePipelineSection {
             false,
             "com.marketinghub.oprm.nichocnae.routinequalitygate",
             Set.of("routinequalitygate", "oprmRoutineQualityGate")),
-    ENRICHED_NICHE_MATERIALIZER(
+    EVIDENCE_LEVEL_GATE(
             10,
+            "evidence-level-gate",
+            "Gate comercial E0-E5",
+            false,
+            "com.marketinghub.oprm.nichocnae.evidencelevelgate",
+            Set.of("evidencelevelgate", "oprmEvidenceLevelGate", "e0e5")),
+    ENRICHED_NICHE_MATERIALIZER(
+            11,
             "enriched-niche-materializer",
             "Materialização do nicho enriquecido",
             false,

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/routinequalitygate/service/BackendRoutineQualityGateService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/routinequalitygate/service/BackendRoutineQualityGateService.java
@@ -37,7 +37,7 @@ public class BackendRoutineQualityGateService {
   private static final String LIGHTLY_RESEARCHED_STATUS = "LIGHTLY_RESEARCHED";
   private static final String MEI_AUDIENCE_READY_STATUS = "MEI_AUDIENCE_READY";
   private static final String CURRENT_STAGE_ROUTINE_QUALITY_GATE = "routine-quality-gate";
-  private static final String CURRENT_STAGE_ENRICHED_NICHE_MATERIALIZER = "enriched-niche-materializer";
+  private static final String CURRENT_STAGE_EVIDENCE_LEVEL_GATE = "evidence-level-gate";
   private static final String NEEDS_MORE_RESEARCH_STATUS = "NEEDS_MORE_RESEARCH";
   private static final String NEEDS_MORE_MEI_RESEARCH_STATUS = "NEEDS_MORE_MEI_RESEARCH";
   private static final String OUTDATED_SOURCES_STATUS = "OUTDATED_SOURCES";
@@ -396,7 +396,7 @@ public class BackendRoutineQualityGateService {
 
   /** Retorna a próxima etapa canônica após a decisão de qualidade ou encerra fila quando o cartão foi reprovado. */
   private String nextStageAfterQuality(String qualityStatus) {
-    return isApprovedQualityStatus(qualityStatus) ? CURRENT_STAGE_ENRICHED_NICHE_MATERIALIZER : null;
+    return isApprovedQualityStatus(qualityStatus) ? CURRENT_STAGE_EVIDENCE_LEVEL_GATE : null;
   }
 
   /** Indica se o status pertence ao contrato atual ou ao legado ainda aceito para migração segura. */

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/oprm/nichocnae/OprmNicheRoutineCardRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/oprm/nichocnae/OprmNicheRoutineCardRepository.java
@@ -73,6 +73,19 @@ public interface OprmNicheRoutineCardRepository extends JpaRepository<OprmNicheR
       @Param("currentResearchCycleId") Long currentResearchCycleId,
       Pageable pageable);
 
+
+  /** Lista cartões aprovados no gate de qualidade que ainda aguardam classificação comercial E0-E5. */
+  @Query("""
+      select c from OprmNicheRoutineCard c
+      join OprmRoutineResearchCycle cycle on cycle.id = c.researchCycleId
+      where c.readyForHypothesis = true
+        and c.qualityCheckedAt is not null
+        and c.evidenceGateCheckedAt is null
+        and cycle.currentStageCode = 'evidence-level-gate'
+      order by c.qualityCheckedAt asc, c.id asc
+      """)
+  List<OprmNicheRoutineCard> findPendingEvidenceLevelGate(Pageable pageable);
+
   /** Lista cartões aprovados no gate de qualidade que ainda não alimentaram nicho e nicho enriquecido. */
   @Query("""
       select c from OprmNicheRoutineCard c

--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-19-oprm-evidence-level-gate.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-19-oprm-evidence-level-gate.yaml
@@ -1,0 +1,38 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-06-19-oprm-evidence-level-gate
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - dbms:
+            type: mysql
+        - tableExists:
+            tableName: oprm_niche_routine_card
+      changes:
+        - addColumn:
+            tableName: oprm_niche_routine_card
+            columns:
+              - column:
+                  name: evidence_level
+                  type: varchar(8)
+                  remarks: Nível de evidência comercial E0-E5 calculado pelo executor externo.
+              - column:
+                  name: evidence_gate_status
+                  type: varchar(48)
+                  remarks: Decisão da etapa Evidence Level Gate calculada pelo executor externo.
+              - column:
+                  name: evidence_confidence_score
+                  type: int
+                  remarks: Confiança explicável da etapa E0-E5 calculada pelo executor externo.
+              - column:
+                  name: evidence_gate_notes
+                  type: longtext
+                  remarks: Motivos estruturados e próximos movimentos da etapa E0-E5.
+              - column:
+                  name: evidence_gate_checked_by
+                  type: varchar(64)
+                  remarks: Identificador do executor externo que avaliou a etapa E0-E5.
+              - column:
+                  name: evidence_gate_checked_at
+                  type: datetime
+                  remarks: Momento da persistência do resultado da etapa E0-E5.

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -1,5 +1,8 @@
 databaseChangeLog:
   - include:
+      file: changesets/2026-06-19-oprm-evidence-level-gate.yaml
+      relativeToChangelogFile: true
+  - include:
       file: changesets/2026-06-19-oprm-nichocnae-v2-stage-execution.yaml
       relativeToChangelogFile: true
   - include:

--- a/backend/ads-service/src/test/java/com/marketinghub/pipeline/service/PipelineServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/pipeline/service/PipelineServiceTest.java
@@ -575,7 +575,7 @@ class PipelineServiceTest {
         assertThat(definitionRegistry.findByPipelineCode("oprm-nicho-cnae-pipeline")).hasValueSatisfying(pipeline -> {
             assertThat(pipeline.module()).isEqualTo("OPRM");
             assertThat(pipeline.name()).isEqualTo("Pipeline Nicho CNAE");
-            assertThat(pipeline.stages()).hasSize(10);
+            assertThat(pipeline.stages()).hasSize(11);
             assertThat(pipeline.stages()).extracting(stage -> stage.operationalCode())
                     .containsExactly(
                             "routine-research-orchestrator",
@@ -587,6 +587,7 @@ class PipelineServiceTest {
                             "routine-synthesizer",
                             "mei-audience-segmenter",
                             "routine-quality-gate",
+                            "evidence-level-gate",
                             "enriched-niche-materializer");
             assertThat(pipeline.stages())
                     .allSatisfy(stage -> {
@@ -759,7 +760,7 @@ class PipelineServiceTest {
 
         PipelineSyncResultDto result = synchronizer.syncOfficialByCode("oprm-nicho-cnae-pipeline");
 
-        assertThat(result.appliedActions()).hasSize(10);
+        assertThat(result.appliedActions()).hasSize(11);
         assertThat(result.canonicalPipelineCode()).isEqualTo("oprm-nicho-cnae-pipeline");
     }
 

--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -1080,3 +1080,9 @@
 - A síntese usa somente claims aceitos/validados com `exactEvidenceSpan`, preserva IDs de evidência, domínio e URL, e declara gaps quando faltam rotina, dor, impacto econômico ou aquisição.
 - O backend permanece fora da lógica de síntese: sua função segue limitada a leitura/escrita/contratos, enquanto regras, controle e inteligência da etapa ficam no executor OPRM.
 - Atualizada a tela do mapa v2 para indicar implementação inicial da etapa 10.
+
+## 2026-06-19 — OPRM NichoCNAE etapa 11 E0-E5
+
+- Implementada a etapa 11 `Evidence Level Gate E0–E5` no executor `oprm-coletor-mei`, mantendo cálculo de nível, confiança, reprovação e próximo movimento fora do backend.
+- Backend ficou restrito a leitura de pendências, persistência de resultado/falha e consulta para relatório do usuário.
+- A transição do gate de qualidade aprovado agora envia o ciclo para `evidence-level-gate` antes da materialização enriquecida.

--- a/docs/swagger/oprm-nichocnae-evidence-level-gate-swagger.yaml
+++ b/docs/swagger/oprm-nichocnae-evidence-level-gate-swagger.yaml
@@ -1,0 +1,51 @@
+openapi: 3.0.3
+info:
+  title: OPRM NichoCNAE Evidence Level Gate API
+  version: 1.0.0
+  description: Contratos de leitura e escrita da etapa 11 E0-E5. A regra comercial é executada no oprm-coletor-mei.
+paths:
+  /api/internal/oprm/nichocnae/evidence-level-gate/stage-executions/pending:
+    get:
+      summary: Lista pendências da etapa E0-E5 para o executor externo.
+      responses:
+        '200':
+          description: Lista de cartões de rotina pendentes.
+  /api/internal/oprm/nichocnae/evidence-level-gate/stage-executions/{researchCycleId}/complete:
+    post:
+      summary: Persiste o resultado E0-E5 calculado pelo executor externo.
+      parameters:
+        - in: path
+          name: researchCycleId
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: Resultado persistido.
+  /api/internal/oprm/nichocnae/evidence-level-gate/stage-executions/{researchCycleId}/fail:
+    post:
+      summary: Registra falha técnica da etapa E0-E5.
+      parameters:
+        - in: path
+          name: researchCycleId
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '204':
+          description: Falha registrada.
+  /api/oprm/nichocnae/evidence-level-gate/stage-executions/{researchCycleId}:
+    get:
+      summary: Consulta o resultado E0-E5 persistido para relatório do usuário.
+      parameters:
+        - in: path
+          name: researchCycleId
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: Detalhe persistido da etapa.

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnae/evidencelevelgate/EvidenceLevelGateBackendClient.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnae/evidencelevelgate/EvidenceLevelGateBackendClient.java
@@ -1,0 +1,43 @@
+package com.marketinghub.nichocnae.evidencelevelgate;
+
+import java.util.Arrays;
+import java.util.List;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+/** Cliente HTTP do executor para ler pendências e escrever resultados E0-E5 exclusivamente via backend. */
+@Component
+public class EvidenceLevelGateBackendClient {
+    private final RestTemplate restTemplate;
+    private final String backendBaseUrl;
+
+    /** Inicializa o cliente com URL base configurável do backend. */
+    public EvidenceLevelGateBackendClient(RestTemplateBuilder builder, @Value("${backend.base-url:http://191.252.181.168}") String backendBaseUrl) {
+        this.restTemplate = builder.build();
+        this.backendBaseUrl = backendBaseUrl;
+    }
+
+    /** Lê do backend as pendências da etapa onze. */
+    public List<EvidenceLevelGatePending> listPending() {
+        EvidenceLevelGatePending[] response = restTemplate.getForObject(backendBaseUrl + "/api/internal/oprm/nichocnae/evidence-level-gate/stage-executions/pending", EvidenceLevelGatePending[].class);
+        return response == null ? List.of() : Arrays.asList(response);
+    }
+
+    /** Envia ao backend a decisão E0-E5 calculada pelo executor. */
+    public void complete(EvidenceLevelGatePending pending, EvidenceLevelGateDecision decision) {
+        restTemplate.postForObject(
+                backendBaseUrl + "/api/internal/oprm/nichocnae/evidence-level-gate/stage-executions/" + pending.researchCycleId() + "/complete",
+                new EvidenceLevelGateCompletionRequest(pending.routineCardId(), decision.evidenceLevel(), decision.gateStatus(), decision.approvedForMaterialization(), decision.confidenceScore(), decision.rejectionReasons(), decision.nextMovements(), "oprmEvidenceLevelGate"),
+                Object.class);
+    }
+
+    /** Registra falha técnica no backend para manter rastreabilidade sem decisão de mercado. */
+    public void fail(EvidenceLevelGatePending pending, RuntimeException ex) {
+        restTemplate.postForObject(
+                backendBaseUrl + "/api/internal/oprm/nichocnae/evidence-level-gate/stage-executions/" + pending.researchCycleId() + "/fail",
+                java.util.Map.of("errorMessage", ex.getMessage() == null ? ex.getClass().getSimpleName() : ex.getMessage()),
+                Object.class);
+    }
+}

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnae/evidencelevelgate/EvidenceLevelGateCompletionRequest.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnae/evidencelevelgate/EvidenceLevelGateCompletionRequest.java
@@ -1,0 +1,4 @@
+package com.marketinghub.nichocnae.evidencelevelgate;
+
+/** Payload enviado ao backend para persistir o resultado calculado da etapa E0-E5. */
+public record EvidenceLevelGateCompletionRequest(Long routineCardId, String evidenceLevel, String gateStatus, Boolean approvedForMaterialization, Integer confidenceScore, String rejectionReasons, String nextMovements, String checkedBy) {}

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnae/evidencelevelgate/EvidenceLevelGateDecision.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnae/evidencelevelgate/EvidenceLevelGateDecision.java
@@ -1,0 +1,10 @@
+package com.marketinghub.nichocnae.evidencelevelgate;
+
+/** Resultado calculado pelo executor para separar existência, dor, impacto econômico e intenção de compra. */
+public record EvidenceLevelGateDecision(
+        String evidenceLevel,
+        String gateStatus,
+        boolean approvedForMaterialization,
+        int confidenceScore,
+        String rejectionReasons,
+        String nextMovements) {}

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnae/evidencelevelgate/EvidenceLevelGateEngine.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnae/evidencelevelgate/EvidenceLevelGateEngine.java
@@ -1,0 +1,79 @@
+package com.marketinghub.nichocnae.evidencelevelgate;
+
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+/** Calcula no executor externo o gate comercial E0-E5 sem transferir inteligência para o backend. */
+@Component
+public class EvidenceLevelGateEngine {
+    /** Classifica a evidência por camadas comerciais mínimas antes da materialização automática. */
+    public EvidenceLevelGateDecision evaluate(EvidenceLevelGatePending pending) {
+        int confidence = clamp(avg(value(pending.confidenceScore()), value(pending.qualityConfidenceScore()), value(pending.specificityScore())));
+        boolean activity = hasText(pending.routineSummary()) && value(pending.routineEvidenceScore()) >= 45;
+        boolean practicalPain = hasText(pending.painsSummary()) && value(pending.difficultyEvidenceScore()) >= 45;
+        boolean economicImpact = containsAny(pending.resultsSummary(), "custo", "perda", "atras", "retrabalho", "renda", "cliente", "agenda", "cancel");
+        boolean purchaseIntent = containsAny(pending.evidenceSummary(), "contratar", "preço", "orcamento", "orçamento", "whatsapp", "indicação", "pedido");
+        boolean independentSources = countDomains(pending.sourceDomains()) >= 2 && value(pending.sourceDiversityScore()) >= 45;
+        String level = chooseLevel(activity, practicalPain, economicImpact, purchaseIntent, independentSources);
+        boolean approved = ("E3".equals(level) || "E4".equals(level) || "E5".equals(level)) && confidence >= 55;
+        String status = approved ? "APPROVED_FOR_MATERIALIZATION" : "INSUFFICIENT_COMMERCIAL_EVIDENCE";
+        return new EvidenceLevelGateDecision(level, status, approved, confidence, rejectionReasons(activity, practicalPain, economicImpact, purchaseIntent, independentSources), nextMovements(level));
+    }
+
+    /** Escolhe o nível mais alto sustentado pelas camadas de evidência. */
+    private String chooseLevel(boolean activity, boolean pain, boolean impact, boolean intent, boolean sources) {
+        if (activity && pain && impact && intent && sources) return "E5";
+        if (activity && pain && impact && sources) return "E4";
+        if (activity && pain && sources) return "E3";
+        if (activity && sources) return "E2";
+        if (activity) return "E1";
+        return "E0";
+    }
+
+    /** Resume motivos que impedem avanço comercial. */
+    private String rejectionReasons(boolean activity, boolean pain, boolean impact, boolean intent, boolean sources) {
+        StringBuilder reasons = new StringBuilder();
+        if (!activity) reasons.append("atividade_nao_comprovada;");
+        if (!pain) reasons.append("dor_pratica_insuficiente;");
+        if (!impact) reasons.append("impacto_economico_nao_demonstrado;");
+        if (!intent) reasons.append("intencao_compra_nao_observada;");
+        if (!sources) reasons.append("fontes_independentes_insuficientes;");
+        return reasons.isEmpty() ? "" : reasons.toString();
+    }
+
+    /** Define o próximo movimento recomendado para reprocessamento cognitivo ou materialização. */
+    private String nextMovements(String level) {
+        return switch (level) {
+            case "E0", "E1" -> "voltar ao planejador de queries para provar atividade e rotina real";
+            case "E2" -> "buscar dor prática literal em fontes diretas";
+            case "E3" -> "materialização controlada ou buscar impacto econômico para maior confiança";
+            case "E4" -> "materialização controlada e buscar intenção de compra para escala";
+            default -> "materialização automática permitida pela evidência comercial";
+        };
+    }
+
+    /** Verifica texto útil. */
+    private boolean hasText(String value) { return StringUtils.hasText(value); }
+
+    /** Verifica presença de marcadores comerciais simples. */
+    private boolean containsAny(String raw, String... needles) {
+        String text = raw == null ? "" : raw.toLowerCase();
+        for (String needle : needles) if (text.contains(needle)) return true;
+        return false;
+    }
+
+    /** Conta domínios separados por vírgula. */
+    private int countDomains(String domains) {
+        if (!StringUtils.hasText(domains)) return 0;
+        return (int) java.util.Arrays.stream(domains.split(",")).map(String::trim).filter(StringUtils::hasText).distinct().count();
+    }
+
+    /** Calcula média inteira. */
+    private int avg(int a, int b, int c) { return Math.round((a + b + c) / 3.0f); }
+
+    /** Normaliza nulos para zero. */
+    private int value(Integer value) { return value == null ? 0 : value; }
+
+    /** Limita score entre 0 e 100. */
+    private int clamp(int value) { return Math.max(0, Math.min(100, value)); }
+}

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnae/evidencelevelgate/EvidenceLevelGatePending.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnae/evidencelevelgate/EvidenceLevelGatePending.java
@@ -1,0 +1,18 @@
+package com.marketinghub.nichocnae.evidencelevelgate;
+
+/** Representa a entrada lida do backend para calcular o nível de evidência comercial E0-E5. */
+public record EvidenceLevelGatePending(
+        Long routineCardId,
+        Long researchCycleId,
+        String nicheName,
+        String routineSummary,
+        String painsSummary,
+        String resultsSummary,
+        String evidenceSummary,
+        String sourceDomains,
+        Integer confidenceScore,
+        Integer routineEvidenceScore,
+        Integer difficultyEvidenceScore,
+        Integer sourceDiversityScore,
+        Integer specificityScore,
+        Integer qualityConfidenceScore) {}

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnae/evidencelevelgate/EvidenceLevelGateScheduler.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnae/evidencelevelgate/EvidenceLevelGateScheduler.java
@@ -1,0 +1,23 @@
+package com.marketinghub.nichocnae.evidencelevelgate;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/** Agenda no executor externo o processamento periódico da etapa onze E0-E5. */
+@Component
+public class EvidenceLevelGateScheduler {
+    private static final Logger log = LoggerFactory.getLogger(EvidenceLevelGateScheduler.class);
+    private final EvidenceLevelGateService service;
+
+    /** Inicializa o scheduler com o serviço da etapa onze. */
+    public EvidenceLevelGateScheduler(EvidenceLevelGateService service) { this.service = service; }
+
+    /** Executa a etapa onze em polling controlado pelo executor, nunca pelo backend. */
+    @Scheduled(cron = "0 */2 * * * *")
+    public void run() {
+        int processed = service.processPending();
+        if (processed > 0) log.info("Etapa onze E0-E5 OPRM nichocnae executada pelo scheduler (processed={})", processed);
+    }
+}

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnae/evidencelevelgate/EvidenceLevelGateService.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnae/evidencelevelgate/EvidenceLevelGateService.java
@@ -1,0 +1,38 @@
+package com.marketinghub.nichocnae.evidencelevelgate;
+
+import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+/** Orquestra no executor externo a leitura, cálculo e escrita do gate comercial E0-E5. */
+@Service
+public class EvidenceLevelGateService {
+    private static final Logger log = LoggerFactory.getLogger(EvidenceLevelGateService.class);
+    private final EvidenceLevelGateBackendClient backendClient;
+    private final EvidenceLevelGateEngine engine;
+
+    /** Inicializa o serviço com cliente de backend e motor de regra local do executor. */
+    public EvidenceLevelGateService(EvidenceLevelGateBackendClient backendClient, EvidenceLevelGateEngine engine) {
+        this.backendClient = backendClient;
+        this.engine = engine;
+    }
+
+    /** Processa pendências da etapa onze e persiste decisões calculadas no backend. */
+    public int processPending() {
+        List<EvidenceLevelGatePending> pendings = backendClient.listPending();
+        int processed = 0;
+        for (EvidenceLevelGatePending pending : pendings) {
+            try {
+                EvidenceLevelGateDecision decision = engine.evaluate(pending);
+                backendClient.complete(pending, decision);
+                processed++;
+            } catch (RuntimeException ex) {
+                log.error("Erro ao executar etapa onze E0-E5 OPRM nichocnae no executor (researchCycleId={}, routineCardId={})", pending.researchCycleId(), pending.routineCardId(), ex);
+                backendClient.fail(pending, ex);
+                throw ex;
+            }
+        }
+        return processed;
+    }
+}

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnae/evidencelevelgate/package-info.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnae/evidencelevelgate/package-info.java
@@ -1,0 +1,2 @@
+/** Etapa onze do pipeline OPRM NichoCNAE responsável por calcular o gate comercial E0-E5 no executor externo. */
+package com.marketinghub.nichocnae.evidencelevelgate;

--- a/oprm-coletor-mei/src/test/java/com/marketinghub/nichocnae/evidencelevelgate/EvidenceLevelGateEngineTest.java
+++ b/oprm-coletor-mei/src/test/java/com/marketinghub/nichocnae/evidencelevelgate/EvidenceLevelGateEngineTest.java
@@ -1,0 +1,33 @@
+package com.marketinghub.nichocnae.evidencelevelgate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+
+class EvidenceLevelGateEngineTest {
+    private final EvidenceLevelGateEngine engine = new EvidenceLevelGateEngine();
+
+    /** Garante que a etapa aprova materialização apenas quando há camadas comerciais mínimas. */
+    @Test
+    void approvesMaterializationWithCommercialEvidence() {
+        EvidenceLevelGateDecision decision = engine.evaluate(new EvidenceLevelGatePending(
+                1L, 10L, "Nicho", "agenda visitas e entrega serviço", "dor com cancelamento e retrabalho",
+                "perda de cliente e custo de atraso", "clientes pedem orçamento pelo whatsapp e indicação", "a.com,b.com",
+                80, 70, 72, 80, 75, 76));
+
+        assertThat(decision.evidenceLevel()).isEqualTo("E5");
+        assertThat(decision.approvedForMaterialization()).isTrue();
+    }
+
+    /** Garante que atividade sem dor e sem fontes independentes não vira evidência comercial vendável. */
+    @Test
+    void rejectsWhenOnlyActivityExists() {
+        EvidenceLevelGateDecision decision = engine.evaluate(new EvidenceLevelGatePending(
+                1L, 10L, "Nicho", "rotina simples", "", "", "", "a.com",
+                40, 50, 10, 10, 40, 40));
+
+        assertThat(decision.evidenceLevel()).isEqualTo("E1");
+        assertThat(decision.approvedForMaterialization()).isFalse();
+        assertThat(decision.rejectionReasons()).contains("dor_pratica_insuficiente");
+    }
+}


### PR DESCRIPTION
### Motivation
- Add an explicit commercial evidence gate (E0–E5) as step 11 in the NichoCNAE pipeline so materialization is gated by separable, auditable commercial evidence levels. 
- Keep all business logic, decision rules and control in the external executor (`oprm-coletor-mei`) while the backend remains responsible only for reading pendings, persisting results/failures and exposing details for the UI/reporting. 
- Ensure the pipeline transitions and DB schema support the new gate and that the pipeline definition/test expectations reflect the added stage. 

### Description
- Implemented executor-side calculation: added `EvidenceLevelGateEngine`, `EvidenceLevelGateService`, `EvidenceLevelGateBackendClient` and `EvidenceLevelGateScheduler` in `oprm-coletor-mei` to read pendings, compute E0–E5, and send results to the backend. 
- Added backend contracts and persistence: `BackendEvidenceLevelGateService`, `BackendEvidenceLevelGateController`, DTOs (`CompleteEvidenceLevelGateRequest/Response`, `FailEvidenceLevelGateRequest`, `EvidenceLevelGateDetailResponse`, `RecordEvidenceLevelGatePending`) and repository query `findPendingEvidenceLevelGate`. 
- Schema & pipeline changes: Liquibase changelog `2026-06-19-oprm-evidence-level-gate.yaml` adds columns (`evidence_level`, `evidence_gate_status`, `evidence_confidence_score`, `evidence_gate_notes`, `evidence_gate_checked_by`, `evidence_gate_checked_at`) and the pipeline enum was updated to include `evidence-level-gate` before materialization. 
- Tests & documentation: added `EvidenceLevelGateEngineTest` for executor rules, updated pipeline service tests to expect the new stage, added Swagger docs `docs/swagger/oprm-nichocnae-evidence-level-gate-swagger.yaml` and recorded the change in `docs/registros/oprm1.md`. 

### Testing
- Ran `mvn -q -DskipTests compile` in `backend/ads-service` and the compilation completed successfully. 
- Ran `mvn -q -DskipTests compile` in `oprm-coletor-mei` and the compilation completed successfully. 
- Executed backend unit test `mvn -q -Dtest=PipelineServiceTest test` and updated assertions to reflect the new stage; the test run completed successfully. 
- Executed executor tests `mvn -q -Dtest=NichoCnaePipelineArchitectureTest,EvidenceLevelGateEngineTest test` in `oprm-coletor-mei` and the `EvidenceLevelGateEngineTest` passed. 
- Validated `db.changelog-master.yaml` includes use `relativeToChangelogFile: true` for added changelog via a small script; the include check passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a35740c678083218e5365afae489d20)