### PR TITLE
Implementa etapa 12 — Enriched Niche Materializer (NichoCNAE v2)

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/enrichednichematerializer/controller/BackendEnrichedNicheMaterializerController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/enrichednichematerializer/controller/BackendEnrichedNicheMaterializerController.java
@@ -1,0 +1,55 @@
+package com.marketinghub.oprm.nichocnae.v2.enrichednichematerializer.controller;
+
+import com.marketinghub.oprm.nichocnae.v2.enrichednichematerializer.service.BackendEnrichedNicheMaterializerService;
+import com.marketinghub.oprm.nichocnae.v2.enrichednichematerializer.service.completeStageExecution.EnrichedNicheMaterializerCompletionRequest;
+import com.marketinghub.oprm.nichocnae.v2.enrichednichematerializer.service.completeStageExecution.EnrichedNicheMaterializerCompletionResponse;
+import com.marketinghub.oprm.nichocnae.v2.enrichednichematerializer.service.createStageExecution.EnrichedNicheMaterializerCreateRequest;
+import com.marketinghub.oprm.nichocnae.v2.enrichednichematerializer.service.createStageExecution.EnrichedNicheMaterializerCreateResponse;
+import com.marketinghub.oprm.nichocnae.v2.enrichednichematerializer.service.failStageExecution.EnrichedNicheMaterializerFailureRequest;
+import com.marketinghub.oprm.nichocnae.v2.enrichednichematerializer.service.failStageExecution.EnrichedNicheMaterializerFailureResponse;
+import com.marketinghub.oprm.nichocnae.v2.enrichednichematerializer.service.pending.EnrichedNicheMaterializerPendingResponse;
+import java.util.List;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/** Borda HTTP interna da etapa enriched-niche-materializer do pipeline NichoCNAE versão 2. */
+@RestController
+@RequestMapping("/api/internal/oprm/nichocnae/v2/enriched-niche-materializer/stage-executions")
+public class BackendEnrichedNicheMaterializerController {
+    private final BackendEnrichedNicheMaterializerService service;
+
+    /** Recebe o service canônico da etapa para delegar operações HTTP internas. */
+    public BackendEnrichedNicheMaterializerController(BackendEnrichedNicheMaterializerService service) {
+        this.service = service;
+    }
+
+    /** Entrega execuções pendentes da etapa enriched-niche-materializer ao módulo executor OPRM. */
+    @GetMapping("/pending")
+    public List<EnrichedNicheMaterializerPendingResponse> pending() {
+        return service.pending();
+    }
+
+    /** Grava uma pendência da etapa enriched-niche-materializer solicitada pelo módulo executor OPRM. */
+    @PostMapping
+    public EnrichedNicheMaterializerCreateResponse create(@RequestBody EnrichedNicheMaterializerCreateRequest request) {
+        return service.create(request);
+    }
+
+    /** Registra a conclusão do materializador de nicho enriquecido informada pelo módulo executor OPRM. */
+    @PostMapping("/{stageExecutionId}/complete")
+    public EnrichedNicheMaterializerCompletionResponse complete(
+            @PathVariable Long stageExecutionId, @RequestBody EnrichedNicheMaterializerCompletionRequest request) {
+        return service.complete(stageExecutionId, request);
+    }
+
+    /** Registra a falha do materializador de nicho enriquecido informada pelo módulo executor OPRM. */
+    @PostMapping("/{stageExecutionId}/fail")
+    public EnrichedNicheMaterializerFailureResponse fail(
+            @PathVariable Long stageExecutionId, @RequestBody EnrichedNicheMaterializerFailureRequest request) {
+        return service.fail(stageExecutionId, request);
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/enrichednichematerializer/service/BackendEnrichedNicheMaterializerService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/enrichednichematerializer/service/BackendEnrichedNicheMaterializerService.java
@@ -1,0 +1,148 @@
+package com.marketinghub.oprm.nichocnae.v2.enrichednichematerializer.service;
+
+import com.marketinghub.oprm.nichocnae.v2.OprmNichoCnaeV2FailureType;
+import com.marketinghub.oprm.nichocnae.v2.OprmNichoCnaeV2StageExecution;
+import com.marketinghub.oprm.nichocnae.v2.OprmNichoCnaeV2StageExecutionStatus;
+import com.marketinghub.oprm.nichocnae.v2.enrichednichematerializer.service.completeStageExecution.EnrichedNicheMaterializerCompletionRequest;
+import com.marketinghub.oprm.nichocnae.v2.enrichednichematerializer.service.completeStageExecution.EnrichedNicheMaterializerCompletionResponse;
+import com.marketinghub.oprm.nichocnae.v2.enrichednichematerializer.service.createStageExecution.EnrichedNicheMaterializerCreateRequest;
+import com.marketinghub.oprm.nichocnae.v2.enrichednichematerializer.service.createStageExecution.EnrichedNicheMaterializerCreateResponse;
+import com.marketinghub.oprm.nichocnae.v2.enrichednichematerializer.service.failStageExecution.EnrichedNicheMaterializerFailureRequest;
+import com.marketinghub.oprm.nichocnae.v2.enrichednichematerializer.service.failStageExecution.EnrichedNicheMaterializerFailureResponse;
+import com.marketinghub.oprm.nichocnae.v2.enrichednichematerializer.service.pending.EnrichedNicheMaterializerPendingResponse;
+import com.marketinghub.repository.jpa.oprm.nichocnae.v2.OprmNichoCnaeV2StageExecutionRepository;
+import java.time.Instant;
+import java.util.List;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.server.ResponseStatusException;
+
+/** Expõe contratos de leitura/escrita do backend para a etapa enriched-niche-materializer do pipeline NichoCNAE v2. */
+@Service
+public class BackendEnrichedNicheMaterializerService {
+    public static final String STAGE_CODE = "enriched-niche-materializer";
+    private final OprmNichoCnaeV2StageExecutionRepository stageExecutionRepository;
+    private final boolean v2Enabled;
+
+    /** Inicializa o service com repositório canônico e feature flag de calibração da v2. */
+    public BackendEnrichedNicheMaterializerService(
+            OprmNichoCnaeV2StageExecutionRepository stageExecutionRepository,
+            @Value("${oprm.nichocnae.v2.enabled:false}") boolean v2Enabled) {
+        this.stageExecutionRepository = stageExecutionRepository;
+        this.v2Enabled = v2Enabled;
+    }
+
+    /** Lista pendências disponíveis para consumo canônico pelo executor OPRM NichoCNAE v2. */
+    @Transactional(readOnly = true)
+    public List<EnrichedNicheMaterializerPendingResponse> pending() {
+        if (!v2Enabled) {
+            return List.of();
+        }
+        return stageExecutionRepository
+                .findByStageCodeAndStatusOrderByCreatedAtAsc(
+                        STAGE_CODE, OprmNichoCnaeV2StageExecutionStatus.PENDING, PageRequest.of(0, 5))
+                .stream()
+                .map(this::toPendingResponse)
+                .toList();
+    }
+
+    /** Registra conclusão do materializador de nicho enriquecido usando a decisão informada pelo executor externo. */
+    @Transactional
+    public EnrichedNicheMaterializerCompletionResponse complete(
+            Long stageExecutionId, EnrichedNicheMaterializerCompletionRequest request) {
+        OprmNichoCnaeV2StageExecution execution = findExecution(stageExecutionId);
+        execution.setStatus(OprmNichoCnaeV2StageExecutionStatus.COMPLETED);
+        execution.setOutputPayload(request == null ? null : request.outputPayload());
+        execution.setNextStageCode(request == null ? null : request.nextStageCode());
+        execution.setUpdatedAt(Instant.now());
+        OprmNichoCnaeV2StageExecution saved = stageExecutionRepository.save(execution);
+        return new EnrichedNicheMaterializerCompletionResponse(
+                String.valueOf(saved.getId()),
+                saved.getStatus().name(),
+                saved.getNextStageCode(),
+                request == null ? null : request.materializationDecision(),
+                request == null ? null : request.validationLevel(),
+                request == null ? null : request.confidence(),
+                request == null ? null : request.materializedNicheId());
+    }
+
+    /** Registra falha e cria nova execução somente quando a falha for retry técnico de infraestrutura. */
+    @Transactional
+    public EnrichedNicheMaterializerFailureResponse fail(Long stageExecutionId, EnrichedNicheMaterializerFailureRequest request) {
+        OprmNichoCnaeV2StageExecution execution = findExecution(stageExecutionId);
+        OprmNichoCnaeV2FailureType failureType = request == null || request.failureType() == null
+                ? OprmNichoCnaeV2FailureType.VALIDATION
+                : request.failureType();
+        execution.setFailureType(failureType);
+        execution.setErrorMessage(request == null ? null : request.errorMessage());
+        execution.setInputPayload(request == null ? execution.getInputPayload() : request.inputPayload());
+        execution.setUpdatedAt(Instant.now());
+        if (failureType == OprmNichoCnaeV2FailureType.INFRASTRUCTURE) {
+            execution.setStatus(OprmNichoCnaeV2StageExecutionStatus.TECHNICAL_RETRY_SCHEDULED);
+            OprmNichoCnaeV2StageExecution retry = createTechnicalRetry(execution);
+            stageExecutionRepository.save(execution);
+            OprmNichoCnaeV2StageExecution savedRetry = stageExecutionRepository.save(retry);
+            return new EnrichedNicheMaterializerFailureResponse(
+                    String.valueOf(execution.getId()), execution.getStatus().name(), String.valueOf(savedRetry.getId()),
+                    savedRetry.getAttemptNumber(), savedRetry.getTechnicalRetryNumber());
+        }
+        execution.setStatus(OprmNichoCnaeV2StageExecutionStatus.FAILED);
+        OprmNichoCnaeV2StageExecution saved = stageExecutionRepository.save(execution);
+        return new EnrichedNicheMaterializerFailureResponse(
+                String.valueOf(saved.getId()), saved.getStatus().name(), null, saved.getAttemptNumber(), saved.getTechnicalRetryNumber());
+    }
+
+    /** Grava uma pendência da etapa de materializador de nicho enriquecido solicitada pelo executor externo. */
+    @Transactional
+    public EnrichedNicheMaterializerCreateResponse create(EnrichedNicheMaterializerCreateRequest request) {
+        OprmNichoCnaeV2StageExecution saved = stageExecutionRepository.save(toPendingExecution(request));
+        return new EnrichedNicheMaterializerCreateResponse(String.valueOf(saved.getId()), saved.getStatus().name(), saved.getStageCode());
+    }
+
+    /** Converte o contrato recebido do executor em entidade persistível, sem decidir regra operacional. */
+    private OprmNichoCnaeV2StageExecution toPendingExecution(EnrichedNicheMaterializerCreateRequest request) {
+        Instant now = Instant.now();
+        OprmNichoCnaeV2StageExecution execution = new OprmNichoCnaeV2StageExecution();
+        execution.setJobId(request.jobId());
+        execution.setResearchCycleId(request.researchCycleId());
+        execution.setSourceNicheId(request.sourceNicheId());
+        execution.setCnaeCode(request.cnaeCode());
+        execution.setStageCode(STAGE_CODE);
+        execution.setAttemptNumber(request.attemptNumber());
+        execution.setTechnicalRetryNumber(0);
+        execution.setKnowledgeVersion(request.knowledgeVersion());
+        execution.setStatus(OprmNichoCnaeV2StageExecutionStatus.PENDING);
+        execution.setInputPayload(request.inputPayload());
+        execution.setMaterializationEnabled(Boolean.TRUE.equals(request.materializationEnabled()));
+        execution.setCreatedAt(now);
+        execution.setUpdatedAt(now);
+        return execution;
+    }
+
+    /** Cria uma nova linha para retry técnico preservando a tentativa cognitiva e a versão de conhecimento. */
+    private OprmNichoCnaeV2StageExecution createTechnicalRetry(OprmNichoCnaeV2StageExecution previousExecution) {
+        OprmNichoCnaeV2StageExecution retry = toPendingExecution(new EnrichedNicheMaterializerCreateRequest(
+                previousExecution.getJobId(), previousExecution.getResearchCycleId(), previousExecution.getSourceNicheId(),
+                previousExecution.getCnaeCode(), previousExecution.getAttemptNumber(), previousExecution.getKnowledgeVersion(),
+                previousExecution.getMaterializationEnabled(), previousExecution.getInputPayload()));
+        retry.setTechnicalRetryNumber(previousExecution.getTechnicalRetryNumber() + 1);
+        return retry;
+    }
+
+    /** Carrega a execução da etapa atual ou devolve erro HTTP claro ao executor. */
+    private OprmNichoCnaeV2StageExecution findExecution(Long stageExecutionId) {
+        return stageExecutionRepository.findByIdAndStageCode(stageExecutionId, STAGE_CODE).orElseThrow(() ->
+                new ResponseStatusException(HttpStatus.NOT_FOUND,
+                        "NichoCNAE v2 enriched-niche-materializer stage execution not found: " + stageExecutionId));
+    }
+
+    /** Converte a entidade persistida no contrato canônico de pending do executor. */
+    private EnrichedNicheMaterializerPendingResponse toPendingResponse(OprmNichoCnaeV2StageExecution execution) {
+        return new EnrichedNicheMaterializerPendingResponse(String.valueOf(execution.getId()), execution.getJobId(),
+                execution.getCnaeCode(), execution.getSourceNicheId(), execution.getAttemptNumber(),
+                execution.getTechnicalRetryNumber(), execution.getKnowledgeVersion(), execution.getInputPayload());
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/enrichednichematerializer/service/completeStageExecution/EnrichedNicheMaterializerCompletionRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/enrichednichematerializer/service/completeStageExecution/EnrichedNicheMaterializerCompletionRequest.java
@@ -1,0 +1,10 @@
+package com.marketinghub.oprm.nichocnae.v2.enrichednichematerializer.service.completeStageExecution;
+
+/** Contrato de escrita para registrar a materialização decidida e executada pelo executor externo. */
+public record EnrichedNicheMaterializerCompletionRequest(
+        String materializationDecision,
+        String validationLevel,
+        Double confidence,
+        Long materializedNicheId,
+        String nextStageCode,
+        String outputPayload) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/enrichednichematerializer/service/completeStageExecution/EnrichedNicheMaterializerCompletionResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/enrichednichematerializer/service/completeStageExecution/EnrichedNicheMaterializerCompletionResponse.java
@@ -1,0 +1,11 @@
+package com.marketinghub.oprm.nichocnae.v2.enrichednichematerializer.service.completeStageExecution;
+
+/** Resposta de conclusão persistida da etapa enriched-niche-materializer. */
+public record EnrichedNicheMaterializerCompletionResponse(
+        String stageExecutionId,
+        String status,
+        String nextStageCode,
+        String materializationDecision,
+        String validationLevel,
+        Double confidence,
+        Long materializedNicheId) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/enrichednichematerializer/service/createStageExecution/EnrichedNicheMaterializerCreateRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/enrichednichematerializer/service/createStageExecution/EnrichedNicheMaterializerCreateRequest.java
@@ -1,0 +1,12 @@
+package com.marketinghub.oprm.nichocnae.v2.enrichednichematerializer.service.createStageExecution;
+
+/** Contrato de escrita para criar pendência do materializador de nicho enriquecido calculado pelo executor externo. */
+public record EnrichedNicheMaterializerCreateRequest(
+        String jobId,
+        Long researchCycleId,
+        Long sourceNicheId,
+        String cnaeCode,
+        Integer attemptNumber,
+        Integer knowledgeVersion,
+        Boolean materializationEnabled,
+        String inputPayload) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/enrichednichematerializer/service/createStageExecution/EnrichedNicheMaterializerCreateResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/enrichednichematerializer/service/createStageExecution/EnrichedNicheMaterializerCreateResponse.java
@@ -1,0 +1,4 @@
+package com.marketinghub.oprm.nichocnae.v2.enrichednichematerializer.service.createStageExecution;
+
+/** Resposta de criação de pendência da etapa enriched-niche-materializer. */
+public record EnrichedNicheMaterializerCreateResponse(String stageExecutionId, String status, String stageCode) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/enrichednichematerializer/service/failStageExecution/EnrichedNicheMaterializerFailureRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/enrichednichematerializer/service/failStageExecution/EnrichedNicheMaterializerFailureRequest.java
@@ -1,0 +1,9 @@
+package com.marketinghub.oprm.nichocnae.v2.enrichednichematerializer.service.failStageExecution;
+
+import com.marketinghub.oprm.nichocnae.v2.OprmNichoCnaeV2FailureType;
+
+/** Contrato de escrita para registrar falha técnica ou cognitiva da etapa enriched-niche-materializer. */
+public record EnrichedNicheMaterializerFailureRequest(
+        OprmNichoCnaeV2FailureType failureType,
+        String errorMessage,
+        String inputPayload) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/enrichednichematerializer/service/failStageExecution/EnrichedNicheMaterializerFailureResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/enrichednichematerializer/service/failStageExecution/EnrichedNicheMaterializerFailureResponse.java
@@ -1,0 +1,9 @@
+package com.marketinghub.oprm.nichocnae.v2.enrichednichematerializer.service.failStageExecution;
+
+/** Resposta de falha da etapa enriched-niche-materializer, incluindo retry técnico quando aplicável. */
+public record EnrichedNicheMaterializerFailureResponse(
+        String stageExecutionId,
+        String status,
+        String retryStageExecutionId,
+        Integer attemptNumber,
+        Integer technicalRetryNumber) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/enrichednichematerializer/service/pending/EnrichedNicheMaterializerPendingResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/enrichednichematerializer/service/pending/EnrichedNicheMaterializerPendingResponse.java
@@ -1,0 +1,12 @@
+package com.marketinghub.oprm.nichocnae.v2.enrichednichematerializer.service.pending;
+
+/** Contrato de leitura de pendência da etapa enriched-niche-materializer para o executor OPRM. */
+public record EnrichedNicheMaterializerPendingResponse(
+        String stageExecutionId,
+        String jobId,
+        String cnaeCode,
+        Long sourceNicheId,
+        Integer attemptNumber,
+        Integer technicalRetryNumber,
+        Integer knowledgeVersion,
+        String inputPayload) {}

--- a/backend/ads-service/src/test/java/com/marketinghub/oprm/nichocnae/v2/enrichednichematerializer/service/BackendEnrichedNicheMaterializerV2ServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/oprm/nichocnae/v2/enrichednichematerializer/service/BackendEnrichedNicheMaterializerV2ServiceTest.java
@@ -1,0 +1,54 @@
+package com.marketinghub.oprm.nichocnae.v2.enrichednichematerializer.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.marketinghub.oprm.nichocnae.v2.OprmNichoCnaeV2StageExecution;
+import com.marketinghub.oprm.nichocnae.v2.OprmNichoCnaeV2StageExecutionStatus;
+import com.marketinghub.oprm.nichocnae.v2.enrichednichematerializer.service.completeStageExecution.EnrichedNicheMaterializerCompletionRequest;
+import com.marketinghub.oprm.nichocnae.v2.enrichednichematerializer.service.createStageExecution.EnrichedNicheMaterializerCreateRequest;
+import com.marketinghub.repository.jpa.oprm.nichocnae.v2.OprmNichoCnaeV2StageExecutionRepository;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+
+class BackendEnrichedNicheMaterializerV2ServiceTest {
+    @Test
+    void createsOnlyPendingStageExecutionWithoutBusinessDecision() {
+        OprmNichoCnaeV2StageExecutionRepository repository = mock(OprmNichoCnaeV2StageExecutionRepository.class);
+        when(repository.save(any())).thenAnswer(invocation -> {
+            OprmNichoCnaeV2StageExecution execution = invocation.getArgument(0);
+            execution.setId(12L);
+            return execution;
+        });
+        BackendEnrichedNicheMaterializerService service = new BackendEnrichedNicheMaterializerService(repository, true);
+
+        var response = service.create(new EnrichedNicheMaterializerCreateRequest(
+                "job-1", 80L, 44L, "4781400", 1, 3, false, "{}"));
+
+        assertThat(response.stageExecutionId()).isEqualTo("12");
+        assertThat(response.stageCode()).isEqualTo("enriched-niche-materializer");
+        verify(repository).save(any(OprmNichoCnaeV2StageExecution.class));
+    }
+
+    @Test
+    void completesWithDecisionReceivedFromExternalExecutor() {
+        OprmNichoCnaeV2StageExecution execution = new OprmNichoCnaeV2StageExecution();
+        execution.setId(12L);
+        execution.setStageCode("enriched-niche-materializer");
+        execution.setStatus(OprmNichoCnaeV2StageExecutionStatus.PENDING);
+        OprmNichoCnaeV2StageExecutionRepository repository = mock(OprmNichoCnaeV2StageExecutionRepository.class);
+        when(repository.findByIdAndStageCode(12L, "enriched-niche-materializer")).thenReturn(Optional.of(execution));
+        when(repository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+        BackendEnrichedNicheMaterializerService service = new BackendEnrichedNicheMaterializerService(repository, true);
+
+        var response = service.complete(12L, new EnrichedNicheMaterializerCompletionRequest(
+                "DO_NOT_MATERIALIZE", "E2_ROUTINE_PAIN", 0.61, null, null, "{}"));
+
+        assertThat(response.status()).isEqualTo("COMPLETED");
+        assertThat(response.materializationDecision()).isEqualTo("DO_NOT_MATERIALIZE");
+        assertThat(response.validationLevel()).isEqualTo("E2_ROUTINE_PAIN");
+    }
+}

--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -1086,3 +1086,7 @@
 - Implementada a etapa 11 `Evidence Level Gate E0–E5` no executor `oprm-coletor-mei`, mantendo cálculo de nível, confiança, reprovação e próximo movimento fora do backend.
 - Backend ficou restrito a leitura de pendências, persistência de resultado/falha e consulta para relatório do usuário.
 - A transição do gate de qualidade aprovado agora envia o ciclo para `evidence-level-gate` antes da materialização enriquecida.
+## 2026-06-19 — OPRM NichoCNAE v2 etapa 12 Enriched Niche Materializer
+- Implementada a etapa 12 `enriched-niche-materializer` da v2 com backend limitado a contratos de leitura/escrita (`pending`, criação, conclusão e falha) sobre execuções de estágio.
+- A decisão de materialização, validação E3+, bloqueio por feature flag e montagem do nicho enriquecido ficam no executor externo `oprm-coletor-mei`, preservando o backend sem lógica, inteligência ou regra de negócio do pipeline.
+- Atualizados Swagger e tela de design da v2 para indicar a implementação inicial protegida por feature flag.

--- a/docs/swagger/oprm-nichocnae-v2-enriched-niche-materializer-swagger.yaml
+++ b/docs/swagger/oprm-nichocnae-v2-enriched-niche-materializer-swagger.yaml
@@ -1,0 +1,52 @@
+openapi: 3.0.3
+info:
+  title: OPRM NichoCNAE v2 Enriched Niche Materializer API
+  version: 1.0.0
+  description: Contratos internos de leitura e escrita da etapa 12 do pipeline NichoCNAE v2. A decisão de materializar, validação E3+, montagem do nicho enriquecido e proteção por feature flag ficam no executor externo oprm-coletor-mei; o backend apenas persiste pendências e resultados.
+paths:
+  /api/internal/oprm/nichocnae/v2/enriched-niche-materializer/stage-executions/pending:
+    get:
+      summary: Lista execuções pendentes da etapa enriched-niche-materializer v2
+      responses:
+        '200':
+          description: Pendências disponíveis para o executor externo
+  /api/internal/oprm/nichocnae/v2/enriched-niche-materializer/stage-executions:
+    post:
+      summary: Grava pendência da etapa enriched-niche-materializer v2 solicitada pelo executor
+      responses:
+        '200':
+          description: Pendência persistida
+  /api/internal/oprm/nichocnae/v2/enriched-niche-materializer/stage-executions/{stageExecutionId}/complete:
+    post:
+      summary: Registra conclusão da materialização decidida pelo executor externo
+      parameters:
+        - name: stageExecutionId
+          in: path
+          required: true
+          schema: { type: integer, format: int64 }
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/EnrichedNicheMaterializerCompletionRequest'
+      responses:
+        '200':
+          description: Conclusão persistida sem regra comercial no backend
+  /api/internal/oprm/nichocnae/v2/enriched-niche-materializer/stage-executions/{stageExecutionId}/fail:
+    post:
+      summary: Registra falha da etapa enriched-niche-materializer v2
+      responses:
+        '200':
+          description: Falha persistida e retry técnico criado quando failureType=INFRASTRUCTURE
+components:
+  schemas:
+    EnrichedNicheMaterializerCompletionRequest:
+      type: object
+      properties:
+        materializationDecision: { type: string, example: MATERIALIZE }
+        validationLevel: { type: string, example: E3_ECONOMIC_PAIN }
+        confidence: { type: number, format: double }
+        materializedNicheId: { type: integer, format: int64, nullable: true }
+        nextStageCode: { type: string, nullable: true }
+        outputPayload: { type: string, description: JSON estruturado produzido pelo executor externo }

--- a/frontend/src/pages/oprm/OprmNichoCnaeV2PipelinePage.tsx
+++ b/frontend/src/pages/oprm/OprmNichoCnaeV2PipelinePage.tsx
@@ -121,9 +121,9 @@ const v2Stages = [
   {
     number: 12,
     title: "Enriched Niche Materializer",
-    status: "Bloqueado por feature flag",
+    status: "Design aprovado · implementação inicial protegida por feature flag",
     purpose:
-      "Materializar o nicho enriquecido somente depois dos gates de evidência, qualidade e segurança.",
+      "Materializar no executor externo o nicho enriquecido somente depois dos gates de evidência, qualidade e segurança.",
     output:
       "Nicho pronto para decisão de produto: executor, dor, resultado, mecanismo plausível e fontes.",
     businessGate: "A v2 calibra antes de publicar automaticamente para vendas.",

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnaev2/pipeline/enrichednichematerializer/EnrichedNicheMaterializerProcessor.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnaev2/pipeline/enrichednichematerializer/EnrichedNicheMaterializerProcessor.java
@@ -1,0 +1,91 @@
+package com.marketinghub.nichocnaev2.pipeline.enrichednichematerializer;
+
+import com.marketinghub.nichocnaev2.pipeline.StageArtifact;
+import com.marketinghub.nichocnaev2.pipeline.StageContext;
+import com.marketinghub.nichocnaev2.pipeline.StageProcessor;
+import com.marketinghub.nichocnaev2.pipeline.StageResult;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+
+/** Materializa no executor externo somente nichos enriquecidos aprovados pelos gates comerciais da v2. */
+public final class EnrichedNicheMaterializerProcessor implements StageProcessor {
+    /** Monta a decisão final sem permitir publicação automática quando faltam gate, evidência E3 ou feature flag. */
+    @Override
+    public StageResult process(StageContext context) {
+        Map<String, Object> input = context.input();
+        boolean materializationEnabled = Boolean.TRUE.equals(input.get("materializationEnabled"));
+        String gateDecision = text(input.get("gateDecision")).toUpperCase(Locale.ROOT);
+        String validationLevel = firstText(input.get("validationLevel"), input.get("evidenceLevel"));
+        double confidence = number(input.get("confidence"));
+        boolean approvedGate = "MATERIALIZE".equals(gateDecision) || "APPROVED".equals(gateDecision);
+        boolean hasCommercialEvidence = validationLevel.startsWith("E3") || validationLevel.startsWith("E4") || validationLevel.startsWith("E5");
+        boolean canMaterialize = materializationEnabled && approvedGate && hasCommercialEvidence;
+
+        Map<String, Object> enrichedNiche = new LinkedHashMap<>();
+        enrichedNiche.put("executor", input.get("executor"));
+        enrichedNiche.put("jobContext", input.get("jobContext"));
+        enrichedNiche.put("pain", input.get("pain"));
+        enrichedNiche.put("desiredResult", input.get("desiredResult"));
+        enrichedNiche.put("plausibleMechanism", input.get("plausibleMechanism"));
+        enrichedNiche.put("supportingClaimIds", input.get("supportingClaimIds"));
+        enrichedNiche.put("sourceDomains", input.get("sourceDomains"));
+        enrichedNiche.put("validationLevel", validationLevel);
+        enrichedNiche.put("confidence", confidence);
+
+        Map<String, Object> output = new LinkedHashMap<>();
+        output.put("stage", "enriched-niche-materializer");
+        output.put("materializationDecision", canMaterialize ? "MATERIALIZE" : "DO_NOT_MATERIALIZE");
+        output.put("validationLevel", validationLevel);
+        output.put("confidence", confidence);
+        output.put("materializationEnabled", materializationEnabled);
+        output.put("blockingReasons", blockingReasons(materializationEnabled, approvedGate, hasCommercialEvidence));
+        if (canMaterialize) {
+            output.put("enrichedNiche", enrichedNiche);
+        }
+
+        return new StageResult(canMaterialize ? "ENRICHED_NICHE_READY" : "MATERIALIZATION_BLOCKED", output, List.of(new StageArtifact(
+                "ENRICHED_NICHE_MATERIALIZATION_DECISION",
+                "inline://enriched-niche-materializer/decision",
+                "Decisão final da v2 calculada no executor, preservando backend apenas como leitura e escrita.")));
+    }
+
+    /** Explica objetivamente por que a publicação comercial foi bloqueada. */
+    private List<String> blockingReasons(boolean materializationEnabled, boolean approvedGate, boolean hasCommercialEvidence) {
+        java.util.ArrayList<String> reasons = new java.util.ArrayList<>();
+        if (!materializationEnabled) {
+            reasons.add("Feature flag de materialização automática desativada para calibração da v2.");
+        }
+        if (!approvedGate) {
+            reasons.add("Gate comercial anterior não aprovou materialização.");
+        }
+        if (!hasCommercialEvidence) {
+            reasons.add("Nível mínimo E3 de evidência comercial não foi comprovado.");
+        }
+        return reasons;
+    }
+
+    /** Retorna o primeiro texto não vazio entre campos equivalentes do contrato. */
+    private String firstText(Object first, Object second) {
+        String firstValue = text(first);
+        return firstValue.isBlank() ? text(second) : firstValue;
+    }
+
+    /** Converte valores numéricos flexíveis do contrato para double seguro. */
+    private double number(Object value) {
+        if (value instanceof Number number) {
+            return number.doubleValue();
+        }
+        try {
+            return Double.parseDouble(text(value));
+        } catch (NumberFormatException ex) {
+            return 0.0;
+        }
+    }
+
+    /** Retorna texto seguro para regras determinísticas. */
+    private String text(Object value) {
+        return value == null ? "" : String.valueOf(value).trim();
+    }
+}

--- a/oprm-coletor-mei/src/test/java/com/marketinghub/nichocnaev2/pipeline/enrichednichematerializer/EnrichedNicheMaterializerProcessorTest.java
+++ b/oprm-coletor-mei/src/test/java/com/marketinghub/nichocnaev2/pipeline/enrichednichematerializer/EnrichedNicheMaterializerProcessorTest.java
@@ -1,0 +1,41 @@
+package com.marketinghub.nichocnaev2.pipeline.enrichednichematerializer;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.marketinghub.nichocnaev2.pipeline.StageContext;
+import com.marketinghub.nichocnaev2.pipeline.StageResult;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+class EnrichedNicheMaterializerProcessorTest {
+    @Test
+    void blocksMaterializationWhenFlagIsDisabledEvenWithE3Gate() {
+        EnrichedNicheMaterializerProcessor processor = new EnrichedNicheMaterializerProcessor();
+
+        StageResult result = processor.process(new StageContext("job-1", "12", Map.of(
+                "materializationEnabled", false,
+                "gateDecision", "MATERIALIZE",
+                "validationLevel", "E3_ECONOMIC_PAIN",
+                "confidence", 0.78)));
+
+        assertThat(result.status()).isEqualTo("MATERIALIZATION_BLOCKED");
+        assertThat(result.output()).containsEntry("materializationDecision", "DO_NOT_MATERIALIZE");
+        assertThat(result.output().get("blockingReasons").toString()).contains("Feature flag");
+    }
+
+    @Test
+    void materializesOnlyWhenFlagGateAndCommercialEvidenceArePresent() {
+        EnrichedNicheMaterializerProcessor processor = new EnrichedNicheMaterializerProcessor();
+
+        StageResult result = processor.process(new StageContext("job-1", "12", Map.of(
+                "materializationEnabled", true,
+                "gateDecision", "MATERIALIZE",
+                "validationLevel", "E4_PURCHASE_INTENT",
+                "confidence", 0.82,
+                "executor", "Motoristas autônomos de transfer aeroportuário")));
+
+        assertThat(result.status()).isEqualTo("ENRICHED_NICHE_READY");
+        assertThat(result.output()).containsEntry("materializationDecision", "MATERIALIZE");
+        assertThat(result.output().get("enrichedNiche")).isNotNull();
+    }
+}


### PR DESCRIPTION
### Motivation
- Entregar a etapa 12 do pipeline NichoCNAE v2 (`enriched-niche-materializer`) para materializar nichos apenas quando os gates de evidência/qualidade e a feature flag permitirem, mantendo decisões comerciais e regras no executor externo. 
- Garantir que o backend permaneça apenas como camada de leitura/escrita de pendências/resultado/falha, preservando a separação arquitetural entre orquestração persistente e controle/IA no executor.

### Description
- Adiciona contratos HTTP e service no backend para a etapa `enriched-niche-materializer` com endpoints canônicos `pending`, `create`, `/{id}/complete` e `/{id}/fail` e DTOs (`record`) de criação/conclusão/falha/pending. 
- Implementa `EnrichedNicheMaterializerProcessor` no executor `oprm-coletor-mei` que decide a materialização somente se a `feature flag` estiver ativa, o gate anterior aprovar e o nível de evidência for >= E3, produzindo saída auditável e artefato de decisão. 
- Adiciona especificação Swagger `docs/swagger/oprm-nichocnae-v2-enriched-niche-materializer-swagger.yaml` e atualiza a tela de design v2 para indicar que a etapa 12 está protegida por feature flag e executada pelo coletor externo. 
- Inclui testes unitários: `EnrichedNicheMaterializerProcessorTest` (executor) e `BackendEnrichedNicheMaterializerV2ServiceTest` (backend), e registra a mudança em `docs/registros/oprm1.md`.

### Testing
- Executado `cd oprm-coletor-mei && mvn test -Dtest=EnrichedNicheMaterializerProcessorTest -DskipITs`, e os testes do processor passaram com sucesso. 
- Executado `cd backend/ads-service && ../mvnw test -DskipITs -Dtest=BackendEnrichedNicheMaterializerV2ServiceTest`, e os testes do service backend passaram com sucesso. 
- Executado `cd frontend && npm test -- OprmNavigation` (Vitest); a execução com a opção Jest `--runInBand` falhou por opção não suportada, mas ao rodar sem `--runInBand` o teste de navegação (`OprmNavigation.test.tsx`) passou.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3577e57b408321874196b2078d7d8f)