### PR TITLE
Fix Spring bean name collision for v2 enriched-niche-materializer (explicit bean names)

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/enrichednichematerializer/controller/BackendEnrichedNicheMaterializerController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/enrichednichematerializer/controller/BackendEnrichedNicheMaterializerController.java
@@ -17,7 +17,7 @@ import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
 /** Borda HTTP interna da etapa enriched-niche-materializer do pipeline NichoCNAE versão 2. */
-@RestController
+@RestController("oprmNichocnaeV2BackendEnrichedNicheMaterializerController")
 @RequestMapping("/api/internal/oprm/nichocnae/v2/enriched-niche-materializer/stage-executions")
 public class BackendEnrichedNicheMaterializerController {
     private final BackendEnrichedNicheMaterializerService service;

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/enrichednichematerializer/service/BackendEnrichedNicheMaterializerService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/enrichednichematerializer/service/BackendEnrichedNicheMaterializerService.java
@@ -21,7 +21,7 @@ import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
 
 /** Expõe contratos de leitura/escrita do backend para a etapa enriched-niche-materializer do pipeline NichoCNAE v2. */
-@Service
+@Service("oprmNichocnaeV2BackendEnrichedNicheMaterializerService")
 public class BackendEnrichedNicheMaterializerService {
     public static final String STAGE_CODE = "enriched-niche-materializer";
     private final OprmNichoCnaeV2StageExecutionRepository stageExecutionRepository;

--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -1090,3 +1090,9 @@
 - Implementada a etapa 12 `enriched-niche-materializer` da v2 com backend limitado a contratos de leitura/escrita (`pending`, criação, conclusão e falha) sobre execuções de estágio.
 - A decisão de materialização, validação E3+, bloqueio por feature flag e montagem do nicho enriquecido ficam no executor externo `oprm-coletor-mei`, preservando o backend sem lógica, inteligência ou regra de negócio do pipeline.
 - Atualizados Swagger e tela de design da v2 para indicar a implementação inicial protegida por feature flag.
+
+## 2026-06-19 — Correção de conflito de bean no controller NichoCNAE v2
+
+- Corrigido o bootstrap dos testes do backend afetado por conflito de nome de bean Spring entre componentes legados e componentes versionados v2 da etapa `enriched-niche-materializer`.
+- Causa-raiz: classes versionadas e legadas com o mesmo nome simples (`BackendEnrichedNicheMaterializerController` e `BackendEnrichedNicheMaterializerService`) eram registradas com bean names padrão duplicados.
+- Prevenção aplicada: o controller e o service v2 passaram a declarar bean names explícitos e versionados, preservando convivência entre versões do pipeline.


### PR DESCRIPTION
### Motivation
- Tests and application bootstrap were failing due to Spring bean name collisions between legacy and v2 classes sharing the same simple names for the enriched-niche-materializer controller and service.
- The change enables coexistence of versioned and legacy components without changing class names or behavior.
- Documentation was updated to record the v2 implementation and the preventive fix for the bean conflict.

### Description
- Set an explicit bean name on the controller with `@RestController("oprmNichocnaeV2BackendEnrichedNicheMaterializerController")` to avoid duplicate bean registration.
- Set an explicit bean name on the service with `@Service("oprmNichocnaeV2BackendEnrichedNicheMaterializerService")` to avoid duplicate bean registration.
- Updated `docs/registros/oprm1.md` to document the enriched-niche-materializer v2 implementation and the conflict correction in the test bootstrap.

### Testing
- Ran backend unit tests via `./gradlew :backend:ads-service:test` and they completed successfully.
- Performed an application startup smoke test for the `backend-ads-service` and verified there are no Spring bean-definition collisions on startup.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a357b877e0c83218f090bfaefb074fa)