### PR TITLE
Add manual start button for NichoCNAE v2 jobs

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/candidategenerator/controller/BackendCandidateGeneratorController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/candidategenerator/controller/BackendCandidateGeneratorController.java
@@ -3,6 +3,7 @@ package com.marketinghub.oprm.nichocnae.v2.candidategenerator.controller;
 import com.marketinghub.oprm.nichocnae.v2.candidategenerator.service.BackendCandidateGeneratorService;
 import com.marketinghub.oprm.nichocnae.v2.candidategenerator.service.completeStageExecution.CandidateGeneratorCompletionRequest;
 import com.marketinghub.oprm.nichocnae.v2.candidategenerator.service.completeStageExecution.CandidateGeneratorCompletionResponse;
+import com.marketinghub.oprm.nichocnae.v2.candidategenerator.service.createStageExecution.CandidateGeneratorCreateResponse;
 import com.marketinghub.oprm.nichocnae.v2.candidategenerator.service.failStageExecution.CandidateGeneratorFailureRequest;
 import com.marketinghub.oprm.nichocnae.v2.candidategenerator.service.failStageExecution.CandidateGeneratorFailureResponse;
 import com.marketinghub.oprm.nichocnae.v2.candidategenerator.service.pending.CandidateGeneratorPendingResponse;
@@ -23,6 +24,12 @@ public class BackendCandidateGeneratorController {
     /** Recebe o service canônico da etapa para delegar operações HTTP internas. */
     public BackendCandidateGeneratorController(BackendCandidateGeneratorService service) {
         this.service = service;
+    }
+
+    /** Grava um novo job da etapa candidate-generator para o CNAE selecionado na UI. */
+    @PostMapping("/cnaes/{cnaeCode}")
+    public CandidateGeneratorCreateResponse createForCnae(@PathVariable String cnaeCode) {
+        return service.createForCnae(cnaeCode);
     }
 
     /** Entrega execuções pendentes da etapa candidate-generator ao módulo executor OPRM. */

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/candidategenerator/service/BackendCandidateGeneratorService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/candidategenerator/service/BackendCandidateGeneratorService.java
@@ -6,6 +6,7 @@ import com.marketinghub.oprm.nichocnae.v2.OprmNichoCnaeV2StageExecution;
 import com.marketinghub.oprm.nichocnae.v2.OprmNichoCnaeV2StageExecutionStatus;
 import com.marketinghub.oprm.nichocnae.v2.candidategenerator.service.completeStageExecution.CandidateGeneratorCompletionRequest;
 import com.marketinghub.oprm.nichocnae.v2.candidategenerator.service.completeStageExecution.CandidateGeneratorCompletionResponse;
+import com.marketinghub.oprm.nichocnae.v2.candidategenerator.service.createStageExecution.CandidateGeneratorCreateResponse;
 import com.marketinghub.oprm.nichocnae.v2.candidategenerator.service.failStageExecution.CandidateGeneratorFailureRequest;
 import com.marketinghub.oprm.nichocnae.v2.candidategenerator.service.failStageExecution.CandidateGeneratorFailureResponse;
 import com.marketinghub.oprm.nichocnae.v2.candidategenerator.service.pending.CandidateGeneratorPendingResponse;
@@ -55,6 +56,32 @@ public class BackendCandidateGeneratorService {
                 .stream()
                 .map(this::toPendingResponse)
                 .toList();
+    }
+
+    /** Grava um novo job inicial da v2 para o CNAE escolhido, deixando a execução para o módulo externo. */
+    @Transactional
+    public CandidateGeneratorCreateResponse createForCnae(String cnaeCode) {
+        if (!v2Enabled) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, "NichoCNAE v2 is disabled");
+        }
+        OprmNicheCandidate candidate = nicheCandidateRepository
+                .findManualRoutineResearchCandidateByCnaeCode(cnaeCode, PageRequest.of(0, 1))
+                .stream()
+                .findFirst()
+                .orElseThrow(() -> new ResponseStatusException(
+                        HttpStatus.NOT_FOUND, "No scored NichoCNAE candidate found for CNAE: " + cnaeCode));
+        long existingExecutions = stageExecutionRepository.countBySourceNicheIdAndStageCode(candidate.getId(), STAGE_CODE);
+        OprmNichoCnaeV2StageExecution saved = stageExecutionRepository.save(createInitialExecution(candidate, existingExecutions + 1));
+        return new CandidateGeneratorCreateResponse(
+                String.valueOf(saved.getId()),
+                saved.getJobId(),
+                saved.getCnaeCode(),
+                saved.getSourceNicheId(),
+                saved.getAttemptNumber(),
+                saved.getTechnicalRetryNumber(),
+                saved.getKnowledgeVersion(),
+                saved.getMaterializationEnabled(),
+                saved.getStatus().name());
     }
 
     /** Registra conclusão da etapa persistindo a próxima etapa informada pelo executor externo. */
@@ -119,14 +146,14 @@ public class BackendCandidateGeneratorService {
                 .filter(candidate -> !stageExecutionRepository.existsBySourceNicheIdAndStageCode(
                         candidate.getId(), STAGE_CODE))
                 .findFirst()
-                .ifPresent(candidate -> stageExecutionRepository.save(createInitialExecution(candidate)));
+                .ifPresent(candidate -> stageExecutionRepository.save(createInitialExecution(candidate, 1)));
     }
 
     /** Cria a primeira execução imutável da etapa candidate-generator para o candidato priorizado. */
-    private OprmNichoCnaeV2StageExecution createInitialExecution(OprmNicheCandidate candidate) {
+    private OprmNichoCnaeV2StageExecution createInitialExecution(OprmNicheCandidate candidate, long jobSequence) {
         Instant now = Instant.now();
         OprmNichoCnaeV2StageExecution execution = new OprmNichoCnaeV2StageExecution();
-        execution.setJobId("nichocnae-v2-candidate-" + candidate.getId());
+        execution.setJobId("nichocnae-v2-candidate-" + candidate.getId() + "-job-" + jobSequence);
         execution.setSourceNicheId(candidate.getId());
         execution.setCnaeCode(candidate.getCnaeCode());
         execution.setStageCode(STAGE_CODE);

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/candidategenerator/service/createStageExecution/CandidateGeneratorCreateResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/candidategenerator/service/createStageExecution/CandidateGeneratorCreateResponse.java
@@ -1,0 +1,13 @@
+package com.marketinghub.oprm.nichocnae.v2.candidategenerator.service.createStageExecution;
+
+/** Contrato retornado ao frontend quando um novo job v2 é gravado para consumo do executor externo. */
+public record CandidateGeneratorCreateResponse(
+        String stageExecutionId,
+        String jobId,
+        String cnaeCode,
+        Long sourceNicheId,
+        Integer attemptNumber,
+        Integer technicalRetryNumber,
+        Integer knowledgeVersion,
+        Boolean materializationEnabled,
+        String status) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/oprm/nichocnae/v2/OprmNichoCnaeV2StageExecutionRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/oprm/nichocnae/v2/OprmNichoCnaeV2StageExecutionRepository.java
@@ -16,6 +16,9 @@ public interface OprmNichoCnaeV2StageExecutionRepository extends JpaRepository<O
     /** Verifica se o candidato já possui execução registrada para a etapa. */
     boolean existsBySourceNicheIdAndStageCode(Long sourceNicheId, String stageCode);
 
+    /** Conta execuções já abertas para o candidato na etapa para gerar jobId estável de nova rodada manual. */
+    long countBySourceNicheIdAndStageCode(Long sourceNicheId, String stageCode);
+
     /** Localiza uma execução específica por etapa para callbacks internos do executor. */
     Optional<OprmNichoCnaeV2StageExecution> findByIdAndStageCode(Long id, String stageCode);
 }

--- a/backend/ads-service/src/test/java/com/marketinghub/oprm/nichocnae/v2/candidategenerator/service/BackendCandidateGeneratorServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/oprm/nichocnae/v2/candidategenerator/service/BackendCandidateGeneratorServiceTest.java
@@ -74,12 +74,36 @@ class BackendCandidateGeneratorServiceTest {
 
         assertThat(result).hasSize(1);
         assertThat(result.getFirst().stageExecutionId()).isEqualTo("1001");
-        assertThat(result.getFirst().jobId()).isEqualTo("nichocnae-v2-candidate-69");
+        assertThat(result.getFirst().jobId()).isEqualTo("nichocnae-v2-candidate-69-job-1");
         assertThat(result.getFirst().cnaeCode()).isEqualTo("9602501");
         assertThat(result.getFirst().attemptNumber()).isEqualTo(1);
         assertThat(result.getFirst().technicalRetryNumber()).isZero();
         assertThat(result.getFirst().knowledgeVersion()).isEqualTo(1);
         assertThat(result.getFirst().materializationEnabled()).isFalse();
+    }
+
+
+    /** Deve gravar novo job manual para o CNAE selecionado sem executar o fluxo no backend. */
+    @Test
+    void createForCnaePersistsNewPendingJobForSelectedCnae() {
+        BackendCandidateGeneratorService service = service(true, false);
+        OprmNicheCandidate candidate = candidate(4781400L, "4781400");
+        when(nicheCandidateRepository.findManualRoutineResearchCandidateByCnaeCode(eq("4781400"), any(Pageable.class)))
+                .thenReturn(List.of(candidate));
+        when(stageExecutionRepository.countBySourceNicheIdAndStageCode(4781400L, "candidate-generator"))
+                .thenReturn(2L);
+        when(stageExecutionRepository.save(any(OprmNichoCnaeV2StageExecution.class))).thenAnswer(invocation -> {
+            OprmNichoCnaeV2StageExecution execution = invocation.getArgument(0);
+            execution.setId(1200L);
+            return execution;
+        });
+
+        var result = service.createForCnae("4781400");
+
+        assertThat(result.stageExecutionId()).isEqualTo("1200");
+        assertThat(result.jobId()).isEqualTo("nichocnae-v2-candidate-4781400-job-3");
+        assertThat(result.status()).isEqualTo("PENDING");
+        assertThat(result.cnaeCode()).isEqualTo("4781400");
     }
 
     /** Ciclo 74: deve transformar falha de infraestrutura em retry técnico sem nova tentativa cognitiva. */

--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -1096,3 +1096,9 @@
 - Corrigido o bootstrap dos testes do backend afetado por conflito de nome de bean Spring entre componentes legados e componentes versionados v2 da etapa `enriched-niche-materializer`.
 - Causa-raiz: classes versionadas e legadas com o mesmo nome simples (`BackendEnrichedNicheMaterializerController` e `BackendEnrichedNicheMaterializerService`) eram registradas com bean names padrão duplicados.
 - Prevenção aplicada: o controller e o service v2 passaram a declarar bean names explícitos e versionados, preservando convivência entre versões do pipeline.
+
+## 2026-06-19 12:25:00 (UTC-3) — OPRM NichoCNAE v2: botão para iniciar novo job do CNAE selecionado
+
+- Ajustada a tela do pipeline v2 para permitir iniciar um novo job do CNAE selecionado diretamente no mapa de etapas.
+- O backend apenas grava uma execução pendente da etapa `candidate-generator`; a execução e o controle do fluxo permanecem no módulo externo `oprm-coletor-mei`, que consome o endpoint `pending` canônico.
+- Prevenção de recorrência: o botão mostra carregamento durante a requisição e a mensagem da tela explicita que o job foi apenas gravado para o executor externo.

--- a/docs/swagger/oprm-nichocnae-v2-candidate-generator-swagger.yaml
+++ b/docs/swagger/oprm-nichocnae-v2-candidate-generator-swagger.yaml
@@ -3,6 +3,22 @@ info:
   title: OPRM NichoCNAE v2 Candidate Generator API
   version: "1.0"
 paths:
+  /api/internal/oprm/nichocnae/v2/candidate-generator/stage-executions/cnaes/{cnaeCode}:
+    post:
+      summary: Grava um novo job pendente da v2 para o CNAE selecionado, sem executar o fluxo no backend.
+      parameters:
+        - name: cnaeCode
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Job pendente gravado para consumo do executor externo OPRM.
+        "404":
+          description: Não existe candidato com score para o CNAE informado.
+        "409":
+          description: Pipeline v2 desabilitado por feature flag.
   /api/internal/oprm/nichocnae/v2/candidate-generator/stage-executions/pending:
     get:
       summary: Lista execuções pendentes da etapa candidate-generator v2

--- a/frontend/src/__tests__/OprmNavigation.test.tsx
+++ b/frontend/src/__tests__/OprmNavigation.test.tsx
@@ -56,6 +56,7 @@ describe("OPRM navigation", () => {
     expect(screen.getByText(/^Pipeline NichoCNAE v2$/)).toBeTruthy();
     expect(screen.getByText(/^CNAE 9602501$/)).toBeTruthy();
     expect(screen.getByText(/^Candidate Generator$/)).toBeTruthy();
+    expect(screen.getByRole("button", { name: /iniciar novo job v2/i })).toBeTruthy();
     expect(screen.getByText(/^Knowledge Accumulator$/)).toBeTruthy();
   });
 

--- a/frontend/src/api/oprm/useStartOprmNichoCnaeV2Job.ts
+++ b/frontend/src/api/oprm/useStartOprmNichoCnaeV2Job.ts
@@ -1,0 +1,39 @@
+import { useMutation } from "@tanstack/react-query";
+import { buildApiUrl } from "../../utils/buildApiUrl";
+
+export interface OprmNichoCnaeV2JobStartResult {
+  stageExecutionId: string;
+  jobId: string;
+  cnaeCode: string;
+  sourceNicheId: number;
+  attemptNumber: number;
+  technicalRetryNumber: number;
+  knowledgeVersion: number;
+  materializationEnabled: boolean;
+  status: string;
+}
+
+async function startOprmNichoCnaeV2Job(
+  cnaeCode: string,
+): Promise<OprmNichoCnaeV2JobStartResult> {
+  const response = await fetch(
+    buildApiUrl(
+      `/api/internal/oprm/nichocnae/v2/candidate-generator/stage-executions/cnaes/${encodeURIComponent(cnaeCode)}`,
+    ),
+    { method: "POST" },
+  );
+  if (!response.ok) {
+    const message = await response.text();
+    throw new Error(
+      message ||
+        `Não foi possível iniciar o job v2 do NichoCNAE (status ${response.status}).`,
+    );
+  }
+  return (await response.json()) as OprmNichoCnaeV2JobStartResult;
+}
+
+export function useStartOprmNichoCnaeV2Job(cnaeCode: string) {
+  return useMutation({
+    mutationFn: () => startOprmNichoCnaeV2Job(cnaeCode),
+  });
+}

--- a/frontend/src/pages/oprm/OprmNichoCnaeV2PipelinePage.tsx
+++ b/frontend/src/pages/oprm/OprmNichoCnaeV2PipelinePage.tsx
@@ -1,4 +1,5 @@
 import { Link, useParams } from "react-router-dom";
+import { useStartOprmNichoCnaeV2Job } from "../../api/oprm/useStartOprmNichoCnaeV2Job";
 import PageTitle from "../../components/PageTitle";
 import OprmModuleNavigation from "./OprmModuleNavigation";
 
@@ -133,6 +134,7 @@ const v2Stages = [
 export default function OprmNichoCnaeV2PipelinePage() {
   const { cnaeCode } = useParams();
   const decodedCnaeCode = cnaeCode ? decodeURIComponent(cnaeCode) : undefined;
+  const startJobMutation = useStartOprmNichoCnaeV2Job(decodedCnaeCode ?? "");
 
   return (
     <div className="d-flex flex-column gap-4">
@@ -169,10 +171,43 @@ export default function OprmNichoCnaeV2PipelinePage() {
                 flag.
               </p>
             </div>
-            <span className="badge text-bg-primary align-self-start">
-              v2 · qualidade antes de escala
-            </span>
+            <div className="d-flex flex-column align-items-start align-items-sm-end gap-2">
+              <span className="badge text-bg-primary align-self-start align-self-sm-end">
+                v2 · qualidade antes de escala
+              </span>
+              {decodedCnaeCode ? (
+                <button
+                  className="btn btn-primary"
+                  type="button"
+                  onClick={() => startJobMutation.mutate()}
+                  disabled={startJobMutation.isPending}
+                >
+                  {startJobMutation.isPending ? (
+                    <>
+                      <span
+                        className="spinner-border spinner-border-sm me-2"
+                        aria-hidden="true"
+                      />
+                      Iniciando job...
+                    </>
+                  ) : (
+                    "Iniciar novo job v2"
+                  )}
+                </button>
+              ) : null}
+            </div>
           </div>
+          {startJobMutation.isSuccess ? (
+            <div className="alert alert-success mt-3 mb-0" role="status">
+              Job {startJobMutation.data.jobId} gravado como pendente. O módulo
+              externo OPRM fará a execução pelo endpoint pending.
+            </div>
+          ) : null}
+          {startJobMutation.isError ? (
+            <div className="alert alert-danger mt-3 mb-0" role="alert">
+              {startJobMutation.error.message}
+            </div>
+          ) : null}
         </div>
       </section>
 


### PR DESCRIPTION
### Motivation
- Provide a direct UI control to start a new NichoCNAE v2 pipeline job for the CNAE shown on the v2 design page, so operators can trigger a manual run when a scored candidate exists. 
- Keep the backend strictly as persistence: the backend should only record a pending execution and the external OPRM executor remains responsible for consuming `pending` and controlling the pipeline flow.

### Description
- Frontend: add a new mutation hook `useStartOprmNichoCnaeV2Job` and a button `Iniciar novo job v2` in `OprmNichoCnaeV2PipelinePage.tsx` that shows loading, disables during request and displays success/error alerts on completion. 
- Backend API: add `POST /api/internal/oprm/nichocnae/v2/candidate-generator/stage-executions/cnaes/{cnaeCode}` and `createForCnae` service method that persists an initial `candidate-generator` stage execution but does not execute or advance the pipeline. 
- Persistence/contract: add `CandidateGeneratorCreateResponse` record, a repository method `countBySourceNicheIdAndStageCode(...)` to generate a stable `jobId` sequence for manual rounds, and update `oprm_nichocnae_v2_stage_execution` job id logic to include the job sequence. 
- Documentation & tests: update Swagger in `docs/swagger/oprm-nichocnae-v2-candidate-generator-swagger.yaml`, touch `docs/registros/oprm1.md` for the operational log, and update/add tests to cover the new behavior and UI expectation.

### Testing
- Ran backend unit tests with `../mvnw -Dtest=BackendCandidateGeneratorServiceTest test` and the targeted service tests passed (no failures). 
- Ran frontend tests with `npm test -- OprmNavigation.test.tsx --run` and `vitest` reported the test file passed (all tests green). 
- Ran typecheck with `npm run typecheck` (`tsc --noEmit`) which completed successfully. 
- Verified `git diff --check`; attempted to run `../mvnw spotless:apply ...` but it failed because the Spotless plugin prefix is not available in this module (formatting step skipped).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a358676931883218df973c524b4dd13)