### PR TITLE
fix: enable OPRM NichoCNAE v2 jobs by default

### DIFF
--- a/backend/ads-service/src/main/resources/application.properties
+++ b/backend/ads-service/src/main/resources/application.properties
@@ -184,3 +184,7 @@ integrations.mois.hotmart-collection.min-success-score=${MOIS_HOTMART_COLLECTION
 
 # MOIS sales page two-table migration
 mois.sales-page.backfill.enabled=${MOIS_SALES_PAGE_BACKFILL_ENABLED:false}
+
+# OPRM NichoCNAE v2
+oprm.nichocnae.v2.enabled=${OPRM_NICHOCNAE_V2_ENABLED:true}
+oprm.nichocnae.v2.materialization-enabled=${OPRM_NICHOCNAE_V2_MATERIALIZATION_ENABLED:false}

--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -1102,3 +1102,8 @@
 - Ajustada a tela do pipeline v2 para permitir iniciar um novo job do CNAE selecionado diretamente no mapa de etapas.
 - O backend apenas grava uma execução pendente da etapa `candidate-generator`; a execução e o controle do fluxo permanecem no módulo externo `oprm-coletor-mei`, que consome o endpoint `pending` canônico.
 - Prevenção de recorrência: o botão mostra carregamento durante a requisição e a mensagem da tela explicita que o job foi apenas gravado para o executor externo.
+
+## 2026-06-19 — Liberação operacional da v2 NichoCNAE
+
+- Corrigida a causa-raiz do erro ao clicar em **Iniciar novo job v2**: o backend não tinha valor padrão explícito para a feature flag `oprm.nichocnae.v2.enabled`, fazendo a tela oferecer o comando enquanto o contrato de gravação bloqueava a criação com `409 Conflict`.
+- A v2 passa a ficar habilitada por padrão para criação de jobs operacionais, mantendo a materialização automática desligada por padrão até validação de qualidade.


### PR DESCRIPTION
### Motivation
- The frontend could create a v2 job but the backend rejected creation with `409 Conflict` because there was no explicit default for the `oprm.nichocnae.v2.enabled` feature flag.

### Description
- Add explicit runtime properties to `backend/ads-service/src/main/resources/application.properties`: `oprm.nichocnae.v2.enabled=${OPRM_NICHOCNAE_V2_ENABLED:true}` and `oprm.nichocnae.v2.materialization-enabled=${OPRM_NICHOCNAE_V2_MATERIALIZATION_ENABLED:false}`, and register the operational fix in `docs/registros/oprm1.md`.

### Testing
- Ran the module unit tests with `../mvnw -Dtest=BackendCandidateGeneratorServiceTest test` and the test class passed (7 tests, 0 failures, BUILD SUCCESS).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a358e0c514c8321a15f96eb78bf89e7)