### PR TITLE
Add NichoCNAE v2 pending scheduler and backend client to oprm-coletor-mei

### DIFF
--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -1107,3 +1107,9 @@
 
 - Corrigida a causa-raiz do erro ao clicar em **Iniciar novo job v2**: o backend não tinha valor padrão explícito para a feature flag `oprm.nichocnae.v2.enabled`, fazendo a tela oferecer o comando enquanto o contrato de gravação bloqueava a criação com `409 Conflict`.
 - A v2 passa a ficar habilitada por padrão para criação de jobs operacionais, mantendo a materialização automática desligada por padrão até validação de qualidade.
+
+## 2026-06-19 — Agendamento de pendências NichoCNAE v2 no executor OPRM
+
+- Implementado scheduler no `oprm-coletor-mei` para consultar a cada 3 minutos os endpoints `pending` das etapas NichoCNAE v2 com contrato backend existente.
+- O executor agora carrega o pacote `com.marketinghub.nichocnaev2`, processa pendências com os processors plugáveis, registra conclusão/falha no backend e cria a próxima pendência quando a próxima etapa v2 existe no catálogo local.
+- Causa-raiz corrigida: a v2 possuía contratos `pending` no backend e processors no executor, mas não havia rotina operacional registrada no Spring para buscar e executar os jobs pendentes.

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnaev2/execution/NichoCnaeV2BackendClient.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnaev2/execution/NichoCnaeV2BackendClient.java
@@ -1,0 +1,142 @@
+package com.marketinghub.nichocnaev2.execution;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+/** Cliente HTTP do executor NichoCNAE v2 para consumir pendências e reportar resultados ao backend. */
+@Component
+public class NichoCnaeV2BackendClient {
+    private static final TypeReference<Map<String, Object>> MAP_TYPE = new TypeReference<>() {};
+
+    private final RestTemplate restTemplate;
+    private final ObjectMapper objectMapper;
+    private final String backendBaseUrl;
+
+    /** Inicializa o cliente com URL base do backend e mapper para contratos estruturados. */
+    public NichoCnaeV2BackendClient(
+            RestTemplateBuilder builder,
+            ObjectMapper objectMapper,
+            @Value("${backend.base-url:http://191.252.181.168}") String backendBaseUrl) {
+        this.restTemplate = builder.build();
+        this.objectMapper = objectMapper;
+        this.backendBaseUrl = backendBaseUrl;
+    }
+
+    /** Consulta o endpoint pending da etapa e converte cada item para a unidade operacional genérica. */
+    public List<NichoCnaeV2PendingExecution> listPending(NichoCnaeV2StageDefinition stage) {
+        String url = backendBaseUrl + stage.backendPath() + "/pending";
+        Map<String, Object>[] response = restTemplate.getForObject(url, Map[].class);
+        return response == null ? List.of() : Arrays.stream(response).map(this::toPendingExecution).toList();
+    }
+
+    /** Registra no backend a conclusão da etapa processada pelo executor. */
+    public void complete(NichoCnaeV2StageDefinition stage, NichoCnaeV2PendingExecution pending, Map<String, Object> request) {
+        restTemplate.postForObject(
+                backendBaseUrl + stage.backendPath() + "/" + pending.stageExecutionId() + "/complete",
+                request,
+                Object.class);
+    }
+
+    /** Registra no backend a próxima etapa pendente quando o contrato da etapa informar avanço operacional. */
+    public void createNextStage(NichoCnaeV2StageDefinition nextStage, NichoCnaeV2PendingExecution pending, String inputPayload) {
+        Map<String, Object> request = new LinkedHashMap<>();
+        request.put("jobId", pending.jobId());
+        request.put("researchCycleId", pending.researchCycleId());
+        request.put("sourceNicheId", pending.sourceNicheId());
+        request.put("cnaeCode", pending.cnaeCode());
+        request.put("attemptNumber", pending.attemptNumber());
+        request.put("knowledgeVersion", pending.knowledgeVersion());
+        request.put("materializationEnabled", pending.materializationEnabled());
+        request.put("inputPayload", inputPayload);
+        restTemplate.postForObject(backendBaseUrl + nextStage.backendPath(), request, Object.class);
+    }
+
+    /** Registra falha técnica com contexto suficiente para retry ou diagnóstico no backend. */
+    public void fail(NichoCnaeV2StageDefinition stage, NichoCnaeV2PendingExecution pending, RuntimeException ex) {
+        Map<String, Object> request = new LinkedHashMap<>();
+        request.put("failureType", "INFRASTRUCTURE");
+        request.put("reasonCode", "SCHEDULER_PROCESSING_ERROR");
+        request.put("errorCode", "SCHEDULER_PROCESSING_ERROR");
+        request.put("errorMessage", ex.getMessage() == null ? ex.getClass().getSimpleName() : ex.getMessage());
+        request.put("inputPayload", pending.inputPayload());
+        restTemplate.postForObject(
+                backendBaseUrl + stage.backendPath() + "/" + pending.stageExecutionId() + "/fail",
+                request,
+                Object.class);
+    }
+
+    /** Serializa payload estruturado para armazenamento funcional no backend. */
+    public String toJson(Map<String, Object> payload) {
+        try {
+            return objectMapper.writeValueAsString(payload);
+        } catch (JsonProcessingException ex) {
+            throw new IllegalStateException("Falha ao serializar payload NichoCNAE v2.", ex);
+        }
+    }
+
+    /** Converte JSON textual recebido no pending para mapa estruturado usado pelo processor. */
+    public Map<String, Object> parseInput(String inputPayload) {
+        if (inputPayload == null || inputPayload.isBlank()) {
+            return new LinkedHashMap<>();
+        }
+        try {
+            return objectMapper.readValue(inputPayload, MAP_TYPE);
+        } catch (JsonProcessingException ex) {
+            throw new IllegalArgumentException("Payload de entrada NichoCNAE v2 não é JSON estruturado válido.", ex);
+        }
+    }
+
+    /** Converte mapa bruto do RestTemplate para contrato interno preservando o payload original auditável. */
+    private NichoCnaeV2PendingExecution toPendingExecution(Map<String, Object> raw) {
+        return new NichoCnaeV2PendingExecution(
+                text(raw.get("stageExecutionId")),
+                text(raw.get("jobId")),
+                text(raw.get("cnaeCode")),
+                longValue(raw.get("researchCycleId")),
+                longValue(raw.get("sourceNicheId")),
+                intValue(raw.get("attemptNumber")),
+                intValue(raw.get("technicalRetryNumber")),
+                intValue(raw.get("knowledgeVersion")),
+                booleanValue(raw.get("materializationEnabled")),
+                text(raw.get("inputPayload")),
+                new LinkedHashMap<>(raw));
+    }
+
+    /** Extrai texto nullable sem quebrar campos ausentes. */
+    private String text(Object value) {
+        return value == null ? null : String.valueOf(value);
+    }
+
+    /** Extrai inteiro nullable aceitando números ou strings numéricas. */
+    private Integer intValue(Object value) {
+        if (value instanceof Number number) {
+            return number.intValue();
+        }
+        return value == null || String.valueOf(value).isBlank() ? null : Integer.valueOf(String.valueOf(value));
+    }
+
+    /** Extrai long nullable aceitando números ou strings numéricas. */
+    private Long longValue(Object value) {
+        if (value instanceof Number number) {
+            return number.longValue();
+        }
+        return value == null || String.valueOf(value).isBlank() ? null : Long.valueOf(String.valueOf(value));
+    }
+
+    /** Extrai boolean nullable aceitando boolean ou string. */
+    private Boolean booleanValue(Object value) {
+        if (value instanceof Boolean bool) {
+            return bool;
+        }
+        return value == null || String.valueOf(value).isBlank() ? null : Boolean.valueOf(String.valueOf(value));
+    }
+}

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnaev2/execution/NichoCnaeV2PendingExecution.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnaev2/execution/NichoCnaeV2PendingExecution.java
@@ -1,0 +1,17 @@
+package com.marketinghub.nichocnaev2.execution;
+
+import java.util.Map;
+
+/** Representa uma unidade pendente do backend NichoCNAE v2 consumida pelo agendador do executor. */
+public record NichoCnaeV2PendingExecution(
+        String stageExecutionId,
+        String jobId,
+        String cnaeCode,
+        Long researchCycleId,
+        Long sourceNicheId,
+        Integer attemptNumber,
+        Integer technicalRetryNumber,
+        Integer knowledgeVersion,
+        Boolean materializationEnabled,
+        String inputPayload,
+        Map<String, Object> rawPayload) {}

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnaev2/execution/NichoCnaeV2PendingExecutionScheduler.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnaev2/execution/NichoCnaeV2PendingExecutionScheduler.java
@@ -1,0 +1,54 @@
+package com.marketinghub.nichocnaev2.execution;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import jakarta.annotation.PostConstruct;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/** Agenda a busca de pendências de todas as etapas do pipeline NichoCNAE v2 no executor OPRM. */
+@Component
+public class NichoCnaeV2PendingExecutionScheduler {
+    private static final Logger log = LoggerFactory.getLogger(NichoCnaeV2PendingExecutionScheduler.class);
+    private static final String REQUESTED_BY = "SCHEDULED_OPRM_NICHO_CNAE_V2_PENDING_EXECUTION";
+
+    private final NichoCnaeV2PendingExecutionService executionService;
+    private final AtomicBoolean running = new AtomicBoolean(false);
+
+    /** Inicializa o scheduler com o serviço que consulta e executa pendências v2. */
+    public NichoCnaeV2PendingExecutionScheduler(NichoCnaeV2PendingExecutionService executionService) {
+        this.executionService = executionService;
+    }
+
+    /** Registra no boot o cron fixo de três minutos usado pela varredura v2. */
+    @PostConstruct
+    public void logScheduleConfiguration() {
+        log.info(
+                "Scheduler NichoCNAE v2 carregado para consultar pendências de todas as etapas (cron={}, requestedBy={})",
+                "0 */3 * * * *",
+                REQUESTED_BY);
+    }
+
+    /** Consulta a cada três minutos os endpoints pending de todas as etapas NichoCNAE v2. */
+    @Scheduled(cron = "0 */3 * * * *")
+    public void processPendingStageExecutions() {
+        if (!running.compareAndSet(false, true)) {
+            log.info("Ignorando varredura concorrente NichoCNAE v2 porque outra execução está ativa (requestedBy={})", REQUESTED_BY);
+            return;
+        }
+        try {
+            log.info("Iniciando varredura agendada NichoCNAE v2 de pendências (requestedBy={})", REQUESTED_BY);
+            int processedCount = executionService.processAllPending();
+            log.info(
+                    "Varredura agendada NichoCNAE v2 concluída (processedCount={}, requestedBy={})",
+                    processedCount,
+                    REQUESTED_BY);
+        } catch (RuntimeException ex) {
+            log.error("Erro na varredura agendada NichoCNAE v2 de pendências (requestedBy={})", REQUESTED_BY, ex);
+            throw ex;
+        } finally {
+            running.set(false);
+        }
+    }
+}

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnaev2/execution/NichoCnaeV2PendingExecutionService.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnaev2/execution/NichoCnaeV2PendingExecutionService.java
@@ -1,0 +1,199 @@
+package com.marketinghub.nichocnaev2.execution;
+
+import com.marketinghub.nichocnaev2.pipeline.PipelineWorker;
+import com.marketinghub.nichocnaev2.pipeline.StageContext;
+import com.marketinghub.nichocnaev2.pipeline.StageResult;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+/** Executa pendências NichoCNAE v2 publicadas pelo backend para todas as etapas cadastradas. */
+@Service
+public class NichoCnaeV2PendingExecutionService {
+    private static final Logger log = LoggerFactory.getLogger(NichoCnaeV2PendingExecutionService.class);
+
+    private final NichoCnaeV2BackendClient backendClient;
+    private final NichoCnaeV2StageDefinitions stageDefinitions;
+
+    /** Inicializa o serviço com o cliente do backend e o catálogo de etapas v2. */
+    public NichoCnaeV2PendingExecutionService(
+            NichoCnaeV2BackendClient backendClient, NichoCnaeV2StageDefinitions stageDefinitions) {
+        this.backendClient = backendClient;
+        this.stageDefinitions = stageDefinitions;
+    }
+
+    /** Consulta e processa pendências de todas as etapas registradas no pipeline NichoCNAE v2. */
+    public int processAllPending() {
+        int processed = 0;
+        for (NichoCnaeV2StageDefinition stage : stageDefinitions.all()) {
+            processed += processStagePending(stage);
+        }
+        return processed;
+    }
+
+    /** Consulta o pending de uma etapa, executa cada item retornado e reporta conclusão ou falha. */
+    private int processStagePending(NichoCnaeV2StageDefinition stage) {
+        List<NichoCnaeV2PendingExecution> pendingExecutions = backendClient.listPending(stage);
+        if (pendingExecutions.isEmpty()) {
+            log.info("Nenhuma pendência NichoCNAE v2 encontrada (stage={})", stage.stageCode());
+            return 0;
+        }
+        int processed = 0;
+        for (NichoCnaeV2PendingExecution pending : pendingExecutions) {
+            processOne(stage, pending);
+            processed++;
+        }
+        return processed;
+    }
+
+    /** Executa um item pendente preservando callback de falha com stack trace completo em log. */
+    private void processOne(NichoCnaeV2StageDefinition stage, NichoCnaeV2PendingExecution pending) {
+        try {
+            log.info(
+                    "Processando pendência NichoCNAE v2 (stage={}, stageExecutionId={}, jobId={}, cnaeCode={}, sourceNicheId={})",
+                    stage.stageCode(),
+                    pending.stageExecutionId(),
+                    pending.jobId(),
+                    pending.cnaeCode(),
+                    pending.sourceNicheId());
+            Map<String, Object> input = inputFor(pending);
+            StageResult result = new PipelineWorker(stage.processor())
+                    .run(new StageContext(pending.jobId(), pending.stageExecutionId(), input));
+            String outputPayload = backendClient.toJson(result.output());
+            Map<String, Object> completion = completionRequest(stage.stageCode(), result, outputPayload);
+            backendClient.complete(stage, pending, completion);
+            createNextStageIfNeeded(stage, pending, result, outputPayload);
+            log.info(
+                    "Pendência NichoCNAE v2 concluída (stage={}, stageExecutionId={}, jobId={}, status={}, nextStageCode={})",
+                    stage.stageCode(),
+                    pending.stageExecutionId(),
+                    pending.jobId(),
+                    result.status(),
+                    result.output().get("nextStageCode"));
+        } catch (RuntimeException ex) {
+            log.error(
+                    "Erro ao processar pendência NichoCNAE v2 (stage={}, stageExecutionId={}, jobId={}, cnaeCode={}, sourceNicheId={})",
+                    stage.stageCode(),
+                    pending.stageExecutionId(),
+                    pending.jobId(),
+                    pending.cnaeCode(),
+                    pending.sourceNicheId(),
+                    ex);
+            backendClient.fail(stage, pending, ex);
+        }
+    }
+
+    /** Monta o input do processor com JSON estruturado e metadados do pending sem JSON dentro de JSON. */
+    private Map<String, Object> inputFor(NichoCnaeV2PendingExecution pending) {
+        Map<String, Object> input = new LinkedHashMap<>(backendClient.parseInput(pending.inputPayload()));
+        input.putIfAbsent("stageExecutionId", pending.stageExecutionId());
+        input.putIfAbsent("jobId", pending.jobId());
+        input.putIfAbsent("cnaeCode", pending.cnaeCode());
+        input.putIfAbsent("sourceNicheId", pending.sourceNicheId());
+        input.putIfAbsent("attemptNumber", pending.attemptNumber());
+        input.putIfAbsent("technicalRetryNumber", pending.technicalRetryNumber());
+        input.putIfAbsent("knowledgeVersion", pending.knowledgeVersion());
+        input.putIfAbsent("materializationEnabled", pending.materializationEnabled());
+        return input;
+    }
+
+    /** Monta o corpo de complete compatível com cada contrato de etapa do backend. */
+    private Map<String, Object> completionRequest(String stageCode, StageResult result, String outputPayload) {
+        Map<String, Object> output = result.output();
+        Map<String, Object> request = new LinkedHashMap<>();
+        request.put("outputPayload", outputPayload);
+        request.put("nextStageCode", output.get("nextStageCode"));
+        switch (stageCode) {
+            case "candidate-generator" -> {
+                request.put("qualityStatus", result.status());
+                request.put("requestedAction", "CONTINUE_PIPELINE");
+                request.putIfAbsent("nextStageCode", "source-safety-filter");
+            }
+            case "source-safety-filter" -> {
+                request.put("safetyDecision", output.getOrDefault("safetyDecision", result.status()));
+                request.put("allowedUrlCount", output.get("allowedUrlCount"));
+                request.put("rejectedUrlCount", output.get("rejectedUrlCount"));
+                request.putIfAbsent("nextStageCode", "adaptive-query-planner");
+            }
+            case "adaptive-query-planner" -> {
+                request.put("planDecision", output.getOrDefault("planDecision", result.status()));
+                request.put("plannedQueryCount", output.get("plannedQueryCount"));
+                request.put("reusedQueryCount", output.get("reusedQueryCount"));
+                request.put("skippedQueryCount", output.get("skippedQueryCount"));
+            }
+            case "candidate-tournament" -> {
+                request.put("tournamentDecision", output.getOrDefault("tournamentDecision", result.status()));
+                request.put("candidateCount", output.get("candidateCount"));
+                request.put("finalistCount", output.get("finalistCount"));
+            }
+            case "source-fetcher-reranker" -> {
+                request.put("sourceFetchDecision", output.getOrDefault("sourceFetchDecision", result.status()));
+                request.put("fetchedSnapshotCount", output.get("fetchedSnapshotCount"));
+                request.put("selectedSourceCount", output.get("selectedSourceCount"));
+                request.put("rejectedSourceCount", output.get("rejectedSourceCount"));
+            }
+            case "knowledge-accumulator" -> {
+                request.put("knowledgeVersion", output.get("knowledgeVersion"));
+                request.put("validatedFactCount", output.get("validatedFactCount"));
+                request.put("acceptedSourceCount", output.get("acceptedSourceCount"));
+                request.put("rejectedSourceCount", output.get("rejectedSourceCount"));
+            }
+            case "commercial-evidence-gate" -> {
+                request.put("evidenceLevel", output.get("evidenceLevel"));
+                request.put("confidence", output.get("confidence"));
+                request.put("automaticMaterializationAllowed", output.get("automaticMaterializationAllowed"));
+                request.put("humanReviewRequired", output.get("humanReviewRequired"));
+                request.put("informationGain", output.get("informationGain"));
+                request.put("gateDecision", output.getOrDefault("gateDecision", result.status()));
+            }
+            case "reprocess-controller" -> {
+                request.put("executionMode", output.get("executionMode"));
+                request.put("rewindToStage", output.get("rewindToStage"));
+                request.put("knowledgeVersionTo", output.get("knowledgeVersionTo"));
+            }
+            case "enriched-niche-materializer" -> {
+                request.put("materializationDecision", output.getOrDefault("materializationDecision", result.status()));
+                request.put("validationLevel", output.get("validationLevel"));
+                request.put("confidence", output.get("confidence"));
+                request.put("materializedNicheId", output.get("materializedNicheId"));
+            }
+            default -> throw new IllegalArgumentException("Etapa NichoCNAE v2 sem contrato de conclusão: " + stageCode);
+        }
+        return request;
+    }
+
+    /** Cria a próxima pendência quando existe uma etapa v2 correspondente no catálogo local. */
+    private void createNextStageIfNeeded(
+            NichoCnaeV2StageDefinition currentStage,
+            NichoCnaeV2PendingExecution pending,
+            StageResult result,
+            String outputPayload) {
+        String nextStageCode = String.valueOf(result.output().getOrDefault("nextStageCode", "")).trim();
+        if (nextStageCode.isBlank() && "candidate-generator".equals(currentStage.stageCode())) {
+            nextStageCode = "source-safety-filter";
+        }
+        if (nextStageCode.isBlank() && "source-safety-filter".equals(currentStage.stageCode())) {
+            nextStageCode = "adaptive-query-planner";
+        }
+        if (nextStageCode.isBlank()) {
+            return;
+        }
+        String resolvedNextStageCode = nextStageCode;
+        Optional<NichoCnaeV2StageDefinition> nextStage = stageDefinitions.all().stream()
+                .filter(stage -> stage.stageCode().equals(resolvedNextStageCode))
+                .findFirst();
+        if (nextStage.isEmpty()) {
+            log.info(
+                    "Próxima etapa NichoCNAE v2 não possui executor local cadastrado; somente conclusão foi registrada (currentStage={}, nextStageCode={}, stageExecutionId={})",
+                    currentStage.stageCode(),
+                    nextStageCode,
+                    pending.stageExecutionId());
+            return;
+        }
+        backendClient.createNextStage(nextStage.get(), pending, outputPayload);
+    }
+}

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnaev2/execution/NichoCnaeV2StageDefinition.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnaev2/execution/NichoCnaeV2StageDefinition.java
@@ -1,0 +1,6 @@
+package com.marketinghub.nichocnaev2.execution;
+
+import com.marketinghub.nichocnaev2.pipeline.StageProcessor;
+
+/** Define os dados operacionais de uma etapa NichoCNAE v2 consumida pelo agendador genérico. */
+public record NichoCnaeV2StageDefinition(String stageCode, String backendPath, StageProcessor processor) {}

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnaev2/execution/NichoCnaeV2StageDefinitions.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnaev2/execution/NichoCnaeV2StageDefinitions.java
@@ -1,0 +1,41 @@
+package com.marketinghub.nichocnaev2.execution;
+
+import com.marketinghub.nichocnaev2.pipeline.adaptivequeryplanner.AdaptiveQueryPlannerProcessor;
+import com.marketinghub.nichocnaev2.pipeline.candidategenerator.CandidateGeneratorProcessor;
+import com.marketinghub.nichocnaev2.pipeline.candidatetournament.CandidateTournamentProcessor;
+import com.marketinghub.nichocnaev2.pipeline.commercialevidencegate.CommercialEvidenceGateProcessor;
+import com.marketinghub.nichocnaev2.pipeline.enrichednichematerializer.EnrichedNicheMaterializerProcessor;
+import com.marketinghub.nichocnaev2.pipeline.knowledgeaccumulator.KnowledgeAccumulatorProcessor;
+import com.marketinghub.nichocnaev2.pipeline.reprocesscontroller.ReprocessControllerProcessor;
+import com.marketinghub.nichocnaev2.pipeline.sourcefetcherreranker.SourceFetcherRerankerProcessor;
+import com.marketinghub.nichocnaev2.pipeline.sourcesafetyfilter.SourceSafetyFilterProcessor;
+import java.util.List;
+import org.springframework.stereotype.Component;
+
+/** Fornece a lista canônica de etapas NichoCNAE v2 que devem consultar pendências no backend. */
+@Component
+public class NichoCnaeV2StageDefinitions {
+    private final List<NichoCnaeV2StageDefinition> stages = List.of(
+            stage("candidate-generator", new CandidateGeneratorProcessor()),
+            stage("source-safety-filter", new SourceSafetyFilterProcessor()),
+            stage("adaptive-query-planner", new AdaptiveQueryPlannerProcessor()),
+            stage("candidate-tournament", new CandidateTournamentProcessor()),
+            stage("source-fetcher-reranker", new SourceFetcherRerankerProcessor()),
+            stage("knowledge-accumulator", new KnowledgeAccumulatorProcessor()),
+            stage("commercial-evidence-gate", new CommercialEvidenceGateProcessor()),
+            stage("reprocess-controller", new ReprocessControllerProcessor()),
+            stage("enriched-niche-materializer", new EnrichedNicheMaterializerProcessor()));
+
+    /** Retorna todas as etapas registradas para varredura periódica de pendências. */
+    public List<NichoCnaeV2StageDefinition> all() {
+        return stages;
+    }
+
+    /** Cria a definição padronizada com o endpoint interno de stage-executions da etapa. */
+    private static NichoCnaeV2StageDefinition stage(String stageCode, com.marketinghub.nichocnaev2.pipeline.StageProcessor processor) {
+        return new NichoCnaeV2StageDefinition(
+                stageCode,
+                "/api/internal/oprm/nichocnae/v2/" + stageCode + "/stage-executions",
+                processor);
+    }
+}

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/oprmcoletormei/OprmColetorMeiApplication.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/oprmcoletormei/OprmColetorMeiApplication.java
@@ -8,7 +8,7 @@ import org.springframework.scheduling.annotation.EnableScheduling;
 /**
  * Inicializa o coletor OPRM MEI e inclui o submódulo nichocnae no contexto Spring.
  */
-@SpringBootApplication(scanBasePackages = {"com.marketinghub.oprmcoletormei", "com.marketinghub.nichocnae"})
+@SpringBootApplication(scanBasePackages = {"com.marketinghub.oprmcoletormei", "com.marketinghub.nichocnae", "com.marketinghub.nichocnaev2"})
 @EnableScheduling
 @ConfigurationPropertiesScan
 public class OprmColetorMeiApplication {


### PR DESCRIPTION
### Motivation

- Provide an operational scheduler in the executor `oprm-coletor-mei` to consume `pending` contracts published by the backend for NichoCNAE v2 and close the operational gap preventing processing of published jobs. 
- Keep backend logic-free by having the executor load v2 processors, run them, and report completion/failure while optionally creating the next stage when the next v2 stage exists locally. 
- Document the operational changes in the pipeline history so release notes reflect the new scheduled polling behavior.

### Description

- Added a polling scheduler `NichoCnaeV2PendingExecutionScheduler` that runs every 3 minutes and delegates processing to `NichoCnaeV2PendingExecutionService`. 
- Implemented `NichoCnaeV2BackendClient` to call backend `pending`, `complete` and `fail` endpoints and to create next-stage executions, plus `NichoCnaeV2PendingExecution` record to model pending items. 
- Added `NichoCnaeV2PendingExecutionService`, `NichoCnaeV2StageDefinition`, and `NichoCnaeV2StageDefinitions` to enumerate v2 stages, convert backend payloads, execute processors, assemble `complete` requests per-stage, and create next-stage pending items when applicable. 
- Updated Spring boot app scan in `OprmColetorMeiApplication` to include the `com.marketinghub.nichocnaev2` package and updated docs `docs/registros/oprm1.md` with the new scheduling release notes.

### Testing

- Executed a full project build and module checks with `./gradlew build` and the command completed successfully. 
- Ran the existing unit test suite via `./gradlew test` and all tests passed. 
- Verified automated application startup build for `oprm-coletor-mei` to ensure scheduler and beans are discovered during boot (CI build succeeded).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a35a5ee18d08321807866847b81bbf7)