### PR TITLE
feat(oprm): list NichoCNAE v2 jobs by CNAE (open vs completed)

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/candidategenerator/controller/BackendCandidateGeneratorController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/candidategenerator/controller/BackendCandidateGeneratorController.java
@@ -6,6 +6,7 @@ import com.marketinghub.oprm.nichocnae.v2.candidategenerator.service.completeSta
 import com.marketinghub.oprm.nichocnae.v2.candidategenerator.service.createStageExecution.CandidateGeneratorCreateResponse;
 import com.marketinghub.oprm.nichocnae.v2.candidategenerator.service.failStageExecution.CandidateGeneratorFailureRequest;
 import com.marketinghub.oprm.nichocnae.v2.candidategenerator.service.failStageExecution.CandidateGeneratorFailureResponse;
+import com.marketinghub.oprm.nichocnae.v2.candidategenerator.service.listCnaeJobs.CandidateGeneratorCnaeJobsResponse;
 import com.marketinghub.oprm.nichocnae.v2.candidategenerator.service.pending.CandidateGeneratorPendingResponse;
 import java.util.List;
 import org.springframework.web.bind.annotation.GetMapping;
@@ -30,6 +31,12 @@ public class BackendCandidateGeneratorController {
     @PostMapping("/cnaes/{cnaeCode}")
     public CandidateGeneratorCreateResponse createForCnae(@PathVariable String cnaeCode) {
         return service.createForCnae(cnaeCode);
+    }
+
+    /** Lista jobs v2 abertos e encerrados do CNAE para acompanhamento na tela administrativa. */
+    @GetMapping("/cnaes/{cnaeCode}/jobs")
+    public CandidateGeneratorCnaeJobsResponse listJobsForCnae(@PathVariable String cnaeCode) {
+        return service.listJobsForCnae(cnaeCode);
     }
 
     /** Entrega execuções pendentes da etapa candidate-generator ao módulo executor OPRM. */

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/candidategenerator/service/BackendCandidateGeneratorService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/candidategenerator/service/BackendCandidateGeneratorService.java
@@ -9,11 +9,17 @@ import com.marketinghub.oprm.nichocnae.v2.candidategenerator.service.completeSta
 import com.marketinghub.oprm.nichocnae.v2.candidategenerator.service.createStageExecution.CandidateGeneratorCreateResponse;
 import com.marketinghub.oprm.nichocnae.v2.candidategenerator.service.failStageExecution.CandidateGeneratorFailureRequest;
 import com.marketinghub.oprm.nichocnae.v2.candidategenerator.service.failStageExecution.CandidateGeneratorFailureResponse;
+import com.marketinghub.oprm.nichocnae.v2.candidategenerator.service.listCnaeJobs.CandidateGeneratorCnaeJobSummary;
+import com.marketinghub.oprm.nichocnae.v2.candidategenerator.service.listCnaeJobs.CandidateGeneratorCnaeJobsResponse;
 import com.marketinghub.oprm.nichocnae.v2.candidategenerator.service.pending.CandidateGeneratorPendingResponse;
 import com.marketinghub.repository.jpa.oprm.cnae.OprmNicheCandidateRepository;
 import com.marketinghub.repository.jpa.oprm.nichocnae.v2.OprmNichoCnaeV2StageExecutionRepository;
 import java.time.Instant;
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
@@ -84,6 +90,31 @@ public class BackendCandidateGeneratorService {
                 saved.getStatus().name());
     }
 
+
+    /** Lista jobs do CNAE agrupados em abertos e encerrados para a tela administrativa. */
+    @Transactional(readOnly = true)
+    public CandidateGeneratorCnaeJobsResponse listJobsForCnae(String cnaeCode) {
+        Map<String, List<OprmNichoCnaeV2StageExecution>> executionsByJob = new LinkedHashMap<>();
+        stageExecutionRepository.findByCnaeCodeOrderByUpdatedAtDesc(cnaeCode).forEach(execution ->
+                executionsByJob.computeIfAbsent(execution.getJobId(), ignored -> new ArrayList<>()).add(execution));
+        List<CandidateGeneratorCnaeJobSummary> openJobs = new ArrayList<>();
+        List<CandidateGeneratorCnaeJobSummary> completedJobs = new ArrayList<>();
+        executionsByJob.values().forEach(executions -> {
+            CandidateGeneratorCnaeJobSummary summary = toJobSummary(executions);
+            if (hasOpenExecution(executions)) {
+                openJobs.add(summary);
+            } else {
+                completedJobs.add(summary);
+            }
+        });
+        Comparator<CandidateGeneratorCnaeJobSummary> newestFirst = Comparator
+                .comparing(CandidateGeneratorCnaeJobSummary::updatedAt, Comparator.nullsLast(Comparator.naturalOrder()))
+                .reversed();
+        openJobs.sort(newestFirst);
+        completedJobs.sort(newestFirst);
+        return new CandidateGeneratorCnaeJobsResponse(cnaeCode, openJobs, completedJobs);
+    }
+
     /** Registra conclusão da etapa persistindo a próxima etapa informada pelo executor externo. */
     @Transactional
     public CandidateGeneratorCompletionResponse complete(
@@ -132,6 +163,44 @@ public class BackendCandidateGeneratorService {
                 null,
                 saved.getAttemptNumber(),
                 saved.getTechnicalRetryNumber());
+    }
+
+
+    /** Monta resumo de job usando a etapa aberta mais recente ou, se não existir, a última etapa atualizada. */
+    private CandidateGeneratorCnaeJobSummary toJobSummary(List<OprmNichoCnaeV2StageExecution> executions) {
+        OprmNichoCnaeV2StageExecution lastExecution = executions.stream()
+                .max(Comparator.comparing(OprmNichoCnaeV2StageExecution::getUpdatedAt, Comparator.nullsLast(Comparator.naturalOrder())))
+                .orElseThrow();
+        OprmNichoCnaeV2StageExecution currentExecution = executions.stream()
+                .filter(this::isOpenExecution)
+                .max(Comparator.comparing(OprmNichoCnaeV2StageExecution::getUpdatedAt, Comparator.nullsLast(Comparator.naturalOrder())))
+                .orElse(lastExecution);
+        String jobStatus = hasOpenExecution(executions) ? "OPEN" : "COMPLETED";
+        return new CandidateGeneratorCnaeJobSummary(
+                lastExecution.getJobId(),
+                lastExecution.getCnaeCode(),
+                jobStatus,
+                isOpenExecution(currentExecution) ? currentExecution.getStageCode() : null,
+                lastExecution.getStageCode(),
+                lastExecution.getStatus().name(),
+                currentExecution.getAttemptNumber(),
+                currentExecution.getTechnicalRetryNumber(),
+                currentExecution.getKnowledgeVersion(),
+                currentExecution.getMaterializationEnabled(),
+                executions.stream().map(OprmNichoCnaeV2StageExecution::getCreatedAt).min(Comparator.naturalOrder()).orElse(null),
+                lastExecution.getUpdatedAt());
+    }
+
+    /** Verifica se o job possui alguma etapa ainda operacionalmente aberta. */
+    private boolean hasOpenExecution(List<OprmNichoCnaeV2StageExecution> executions) {
+        return executions.stream().anyMatch(this::isOpenExecution);
+    }
+
+    /** Identifica estados que ainda exigem execução ou retry pelo módulo OPRM. */
+    private boolean isOpenExecution(OprmNichoCnaeV2StageExecution execution) {
+        return execution.getStatus() == OprmNichoCnaeV2StageExecutionStatus.PENDING
+                || execution.getStatus() == OprmNichoCnaeV2StageExecutionStatus.RUNNING
+                || execution.getStatus() == OprmNichoCnaeV2StageExecutionStatus.TECHNICAL_RETRY_SCHEDULED;
     }
 
     /** Garante uma pendência inicial real a partir da fila atual de candidatos, sem materialização automática. */

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/candidategenerator/service/listCnaeJobs/CandidateGeneratorCnaeJobSummary.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/candidategenerator/service/listCnaeJobs/CandidateGeneratorCnaeJobSummary.java
@@ -1,0 +1,18 @@
+package com.marketinghub.oprm.nichocnae.v2.candidategenerator.service.listCnaeJobs;
+
+import java.time.Instant;
+
+/** Representa o resumo administrativo de um job v2 agrupado por jobId. */
+public record CandidateGeneratorCnaeJobSummary(
+        String jobId,
+        String cnaeCode,
+        String status,
+        String currentStageCode,
+        String lastStageCode,
+        String lastStageStatus,
+        Integer attemptNumber,
+        Integer technicalRetryNumber,
+        Integer knowledgeVersion,
+        Boolean materializationEnabled,
+        Instant createdAt,
+        Instant updatedAt) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/candidategenerator/service/listCnaeJobs/CandidateGeneratorCnaeJobsResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/candidategenerator/service/listCnaeJobs/CandidateGeneratorCnaeJobsResponse.java
@@ -1,0 +1,9 @@
+package com.marketinghub.oprm.nichocnae.v2.candidategenerator.service.listCnaeJobs;
+
+import java.util.List;
+
+/** Representa as listas de jobs v2 abertos e encerrados para um CNAE. */
+public record CandidateGeneratorCnaeJobsResponse(
+        String cnaeCode,
+        List<CandidateGeneratorCnaeJobSummary> openJobs,
+        List<CandidateGeneratorCnaeJobSummary> completedJobs) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/oprm/nichocnae/v2/OprmNichoCnaeV2StageExecutionRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/oprm/nichocnae/v2/OprmNichoCnaeV2StageExecutionRepository.java
@@ -19,6 +19,9 @@ public interface OprmNichoCnaeV2StageExecutionRepository extends JpaRepository<O
     /** Conta execuções já abertas para o candidato na etapa para gerar jobId estável de nova rodada manual. */
     long countBySourceNicheIdAndStageCode(Long sourceNicheId, String stageCode);
 
+    /** Lista execuções de um CNAE para montar o acompanhamento administrativo por job. */
+    List<OprmNichoCnaeV2StageExecution> findByCnaeCodeOrderByUpdatedAtDesc(String cnaeCode);
+
     /** Localiza uma execução específica por etapa para callbacks internos do executor. */
     Optional<OprmNichoCnaeV2StageExecution> findByIdAndStageCode(Long id, String stageCode);
 }

--- a/backend/ads-service/src/test/java/com/marketinghub/oprm/nichocnae/v2/candidategenerator/service/BackendCandidateGeneratorServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/oprm/nichocnae/v2/candidategenerator/service/BackendCandidateGeneratorServiceTest.java
@@ -106,6 +106,36 @@ class BackendCandidateGeneratorServiceTest {
         assertThat(result.cnaeCode()).isEqualTo("4781400");
     }
 
+
+    /** Deve separar jobs do CNAE entre abertos com etapa atual e encerrados pelo histórico persistido. */
+    @Test
+    void listJobsForCnaeSeparatesOpenAndCompletedJobs() {
+        BackendCandidateGeneratorService service = service(true, false);
+        OprmNichoCnaeV2StageExecution open = execution(101L, 1, 0, 1);
+        open.setJobId("job-aberto");
+        open.setCnaeCode("4781400");
+        open.setStageCode("source-safety-filter");
+        open.setStatus(OprmNichoCnaeV2StageExecutionStatus.PENDING);
+        open.setUpdatedAt(Instant.parse("2026-06-19T12:00:00Z"));
+        OprmNichoCnaeV2StageExecution completed = execution(102L, 1, 0, 1);
+        completed.setJobId("job-concluido");
+        completed.setCnaeCode("4781400");
+        completed.setStageCode("candidate-generator");
+        completed.setStatus(OprmNichoCnaeV2StageExecutionStatus.COMPLETED);
+        completed.setUpdatedAt(Instant.parse("2026-06-19T11:00:00Z"));
+        when(stageExecutionRepository.findByCnaeCodeOrderByUpdatedAtDesc("4781400"))
+                .thenReturn(List.of(open, completed));
+
+        var result = service.listJobsForCnae("4781400");
+
+        assertThat(result.openJobs()).hasSize(1);
+        assertThat(result.openJobs().getFirst().jobId()).isEqualTo("job-aberto");
+        assertThat(result.openJobs().getFirst().currentStageCode()).isEqualTo("source-safety-filter");
+        assertThat(result.completedJobs()).hasSize(1);
+        assertThat(result.completedJobs().getFirst().jobId()).isEqualTo("job-concluido");
+        assertThat(result.completedJobs().getFirst().currentStageCode()).isNull();
+    }
+
     /** Ciclo 74: deve transformar falha de infraestrutura em retry técnico sem nova tentativa cognitiva. */
     @Test
     void failCreatesTechnicalRetryForInfrastructureFailureInCycle74() {

--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -1,3 +1,8 @@
+## 2026-06-19 00:00:00 (UTC) — OPRM NichoCNAE v2: lista de jobs por CNAE na tela
+
+- Ajustada a tela do pipeline NichoCNAE v2 para exibir, por CNAE, jobs abertos com etapa atual e jobs encerrados em histórico separado.
+- O backend passou a expor contrato de leitura agrupado por `jobId`, mantendo a UI como apresentação da verdade persistida nas execuções de etapa v2.
+
 ## 2026-06-18 21:15:00 (UTC-3) — OPRM NichoCNAE: download de relatório sem abrir nova aba
 
 - Causa-raiz tratada: a tela de jobs recentes usava link com `target="_blank"` para baixar relatório, abrindo outra aba do navegador e expondo erro visual quando o browser tentava navegar diretamente para o endpoint de arquivo.

--- a/docs/swagger/oprm-nichocnae-v2-candidate-generator-swagger.yaml
+++ b/docs/swagger/oprm-nichocnae-v2-candidate-generator-swagger.yaml
@@ -19,6 +19,19 @@ paths:
           description: Não existe candidato com score para o CNAE informado.
         "409":
           description: Pipeline v2 desabilitado por feature flag.
+  /api/internal/oprm/nichocnae/v2/candidate-generator/stage-executions/cnaes/{cnaeCode}/jobs:
+    get:
+      summary: Lista jobs v2 do CNAE separados entre abertos e encerrados
+      description: Contrato de leitura para a tela administrativa exibir jobs abertos com etapa atual e histórico de jobs concluídos/encerrados.
+      parameters:
+        - name: cnaeCode
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Listas de jobs abertas e encerradas para o CNAE informado.
   /api/internal/oprm/nichocnae/v2/candidate-generator/stage-executions/pending:
     get:
       summary: Lista execuções pendentes da etapa candidate-generator v2

--- a/frontend/src/api/oprm/useOprmNichoCnaeV2Jobs.ts
+++ b/frontend/src/api/oprm/useOprmNichoCnaeV2Jobs.ts
@@ -1,0 +1,48 @@
+import { useQuery } from "@tanstack/react-query";
+import { buildApiUrl } from "../../utils/buildApiUrl";
+
+export interface OprmNichoCnaeV2JobSummary {
+  jobId: string;
+  cnaeCode: string;
+  status: string;
+  currentStageCode: string | null;
+  lastStageCode: string | null;
+  lastStageStatus: string | null;
+  attemptNumber: number | null;
+  technicalRetryNumber: number | null;
+  knowledgeVersion: number | null;
+  materializationEnabled: boolean | null;
+  createdAt: string | null;
+  updatedAt: string | null;
+}
+
+export interface OprmNichoCnaeV2JobsResponse {
+  cnaeCode: string;
+  openJobs: OprmNichoCnaeV2JobSummary[];
+  completedJobs: OprmNichoCnaeV2JobSummary[];
+}
+
+async function fetchOprmNichoCnaeV2Jobs(
+  cnaeCode: string,
+): Promise<OprmNichoCnaeV2JobsResponse> {
+  const response = await fetch(
+    buildApiUrl(
+      `/api/internal/oprm/nichocnae/v2/candidate-generator/stage-executions/cnaes/${encodeURIComponent(cnaeCode)}/jobs`,
+    ),
+  );
+  if (!response.ok) {
+    throw new Error(
+      `Não foi possível carregar os jobs v2 do CNAE (status ${response.status}).`,
+    );
+  }
+  return (await response.json()) as OprmNichoCnaeV2JobsResponse;
+}
+
+export function useOprmNichoCnaeV2Jobs(cnaeCode: string) {
+  return useQuery({
+    queryKey: ["oprm", "nichocnae", "v2", cnaeCode, "jobs"],
+    queryFn: () => fetchOprmNichoCnaeV2Jobs(cnaeCode),
+    enabled: Boolean(cnaeCode),
+    refetchInterval: 15000,
+  });
+}

--- a/frontend/src/api/oprm/useStartOprmNichoCnaeV2Job.ts
+++ b/frontend/src/api/oprm/useStartOprmNichoCnaeV2Job.ts
@@ -1,4 +1,4 @@
-import { useMutation } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { buildApiUrl } from "../../utils/buildApiUrl";
 
 export interface OprmNichoCnaeV2JobStartResult {
@@ -33,7 +33,13 @@ async function startOprmNichoCnaeV2Job(
 }
 
 export function useStartOprmNichoCnaeV2Job(cnaeCode: string) {
+  const queryClient = useQueryClient();
   return useMutation({
     mutationFn: () => startOprmNichoCnaeV2Job(cnaeCode),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({
+        queryKey: ["oprm", "nichocnae", "v2", cnaeCode, "jobs"],
+      });
+    },
   });
 }

--- a/frontend/src/pages/oprm/OprmNichoCnaeV2PipelinePage.tsx
+++ b/frontend/src/pages/oprm/OprmNichoCnaeV2PipelinePage.tsx
@@ -1,7 +1,95 @@
 import { Link, useParams } from "react-router-dom";
+import {
+  useOprmNichoCnaeV2Jobs,
+  type OprmNichoCnaeV2JobSummary,
+} from "../../api/oprm/useOprmNichoCnaeV2Jobs";
 import { useStartOprmNichoCnaeV2Job } from "../../api/oprm/useStartOprmNichoCnaeV2Job";
 import PageTitle from "../../components/PageTitle";
 import OprmModuleNavigation from "./OprmModuleNavigation";
+
+const stageLabels: Record<string, string> = {
+  "candidate-generator": "Candidate Generator",
+  "source-safety-filter": "Source Safety Filter",
+  "adaptive-query-planner": "Adaptive Query Planner",
+  "candidate-tournament": "Candidate Tournament",
+  "source-fetcher-reranker": "Source Fetcher + Reranker",
+  "signal-extractor": "Signal Extractor",
+  "semantic-judge-entailment": "Semantic Judge + Entailment",
+  "knowledge-accumulator": "Knowledge Accumulator",
+  "reprocess-controller": "Reprocess Controller",
+  "routine-synthesizer": "Routine Synthesizer",
+  "commercial-evidence-gate": "Evidence Level Gate E0–E5",
+  "enriched-niche-materializer": "Enriched Niche Materializer",
+};
+
+function formatStage(stageCode: string | null | undefined) {
+  if (!stageCode) return "Sem etapa aberta";
+  return stageLabels[stageCode] ?? stageCode;
+}
+
+function formatDateTime(value: string | null | undefined) {
+  if (!value) return "—";
+  return new Intl.DateTimeFormat("pt-BR", {
+    dateStyle: "short",
+    timeStyle: "short",
+  }).format(new Date(value));
+}
+
+function JobsTable({
+  jobs,
+  emptyMessage,
+  open,
+}: {
+  jobs: OprmNichoCnaeV2JobSummary[];
+  emptyMessage: string;
+  open: boolean;
+}) {
+  if (jobs.length === 0) {
+    return <p className="text-secondary mb-0">{emptyMessage}</p>;
+  }
+
+  return (
+    <div className="table-responsive">
+      <table className="table table-sm align-middle mb-0">
+        <thead>
+          <tr>
+            <th>Job</th>
+            {open ? <th>Etapa atual</th> : <th>Última etapa</th>}
+            <th>Status</th>
+            <th>Tentativa</th>
+            <th>Atualizado</th>
+          </tr>
+        </thead>
+        <tbody>
+          {jobs.map((job) => (
+            <tr key={job.jobId}>
+              <td className="font-monospace small">{job.jobId}</td>
+              <td>
+                {formatStage(open ? job.currentStageCode : job.lastStageCode)}
+              </td>
+              <td>
+                <span
+                  className={
+                    open ? "badge text-bg-warning" : "badge text-bg-success"
+                  }
+                >
+                  {open ? "Aberto" : (job.lastStageStatus ?? "Concluído")}
+                </span>
+              </td>
+              <td>
+                {job.attemptNumber ?? "—"}
+                {job.technicalRetryNumber
+                  ? ` · retry ${job.technicalRetryNumber}`
+                  : ""}
+              </td>
+              <td>{formatDateTime(job.updatedAt)}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  );
+}
 
 const v2Stages = [
   {
@@ -122,7 +210,8 @@ const v2Stages = [
   {
     number: 12,
     title: "Enriched Niche Materializer",
-    status: "Design aprovado · implementação inicial protegida por feature flag",
+    status:
+      "Design aprovado · implementação inicial protegida por feature flag",
     purpose:
       "Materializar no executor externo o nicho enriquecido somente depois dos gates de evidência, qualidade e segurança.",
     output:
@@ -135,6 +224,7 @@ export default function OprmNichoCnaeV2PipelinePage() {
   const { cnaeCode } = useParams();
   const decodedCnaeCode = cnaeCode ? decodeURIComponent(cnaeCode) : undefined;
   const startJobMutation = useStartOprmNichoCnaeV2Job(decodedCnaeCode ?? "");
+  const jobsQuery = useOprmNichoCnaeV2Jobs(decodedCnaeCode ?? "");
 
   return (
     <div className="d-flex flex-column gap-4">
@@ -210,6 +300,61 @@ export default function OprmNichoCnaeV2PipelinePage() {
           ) : null}
         </div>
       </section>
+
+      {decodedCnaeCode ? (
+        <section
+          className="row g-3"
+          aria-label="Jobs do CNAE no pipeline NichoCNAE v2"
+        >
+          <article className="col-12 col-xl-6">
+            <div className="card h-100 border-0 shadow-sm">
+              <div className="card-body">
+                <h2 className="h5 mb-2">Jobs abertos</h2>
+                <p className="text-secondary small">
+                  Mostra onde cada execução ainda aberta está parada agora.
+                </p>
+                {jobsQuery.isLoading ? (
+                  <p className="text-secondary mb-0">Carregando jobs...</p>
+                ) : jobsQuery.isError ? (
+                  <div className="alert alert-danger mb-0" role="alert">
+                    {jobsQuery.error.message}
+                  </div>
+                ) : (
+                  <JobsTable
+                    jobs={jobsQuery.data?.openJobs ?? []}
+                    emptyMessage="Nenhum job aberto para este CNAE."
+                    open
+                  />
+                )}
+              </div>
+            </div>
+          </article>
+          <article className="col-12 col-xl-6">
+            <div className="card h-100 border-0 shadow-sm">
+              <div className="card-body">
+                <h2 className="h5 mb-2">Jobs concluídos</h2>
+                <p className="text-secondary small">
+                  Histórico dos jobs encerrados para evitar repetir pesquisa sem
+                  aprendizado.
+                </p>
+                {jobsQuery.isLoading ? (
+                  <p className="text-secondary mb-0">Carregando histórico...</p>
+                ) : jobsQuery.isError ? (
+                  <div className="alert alert-danger mb-0" role="alert">
+                    {jobsQuery.error.message}
+                  </div>
+                ) : (
+                  <JobsTable
+                    jobs={jobsQuery.data?.completedJobs ?? []}
+                    emptyMessage="Nenhum job concluído para este CNAE."
+                    open={false}
+                  />
+                )}
+              </div>
+            </div>
+          </article>
+        </section>
+      ) : null}
 
       <section className="row g-3" aria-label="Etapas do pipeline NichoCNAE v2">
         {v2Stages.map((stage) => (


### PR DESCRIPTION
### Motivation
- Provide the CNAE pipeline screen with the truth persisted in the backend: show jobs for a CNAE grouped by `jobId`, split into open jobs (showing current stage) and completed jobs (history). 
- Keep UI faithful to backend state so the frontend never infers pipeline truth locally.

### Description
- Backend: added a read endpoint `GET /api/internal/oprm/nichocnae/v2/candidate-generator/stage-executions/cnaes/{cnaeCode}/jobs` and a JPA finder `findByCnaeCodeOrderByUpdatedAtDesc` to load executions for a CNAE. 
- Backend: introduced DTOs `CandidateGeneratorCnaeJobSummary` and `CandidateGeneratorCnaeJobsResponse` and new service method `listJobsForCnae(String cnaeCode)` that groups executions by `jobId`, determines whether a job is open (statuses `PENDING`, `RUNNING`, `TECHNICAL_RETRY_SCHEDULED`), and returns `openJobs` and `completedJobs`; added helpers `toJobSummary`, `hasOpenExecution` and `isOpenExecution`.
- Frontend: added hook `useOprmNichoCnaeV2Jobs` to consume the new endpoint and poll every 15s, and updated `useStartOprmNichoCnaeV2Job` to invalidate the jobs query after starting a job.
- Frontend: updated `OprmNichoCnaeV2PipelinePage` to render two lists side-by-side: "Jobs abertos" (shows current stage) and "Jobs concluídos" (history), with a `JobsTable` component and human-friendly stage labels.
- Documentation: added the new endpoint to the v2 candidate-generator Swagger file and recorded the UI change in `docs/registros/oprm1.md`.
- Tests: added a unit test in `BackendCandidateGeneratorServiceTest` that verifies open vs completed grouping by CNAE.

### Testing
- Ran the backend unit tests for the modified service with `../mvnw -Dtest=BackendCandidateGeneratorServiceTest test`, which executed the test class and completed successfully (all tests passed). 
- Ran the frontend type-check with `npm run typecheck` (TypeScript `tsc --noEmit`), which completed without type errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a35addfb2c48321a3f0d7672a71e197)