### PR TITLE
Melhora separação visual de jobs OPRM v2

### DIFF
--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -1,3 +1,8 @@
+## 2026-06-19 00:00:00 (UTC) — OPRM NichoCNAE v2: separação visual entre jobs abertos e concluídos
+
+- Ajustada a tela do pipeline NichoCNAE v2 para separar visualmente os blocos de jobs abertos e concluídos com cards dedicados, trilha lateral de status e divisor elegante entre os painéis.
+- Causa-raiz tratada: os dois blocos usavam cards genéricos muito próximos, reduzindo a leitura rápida entre operação em andamento e histórico encerrado.
+
 ## 2026-06-19 00:00:00 (UTC) — OPRM NichoCNAE v2: lista de jobs por CNAE na tela
 
 - Ajustada a tela do pipeline NichoCNAE v2 para exibir, por CNAE, jobs abertos com etapa atual e jobs encerrados em histórico separado.

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -190,3 +190,86 @@
     transform: scale(1.15);
   }
 }
+
+.oprm-v2-jobs-section {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  gap: clamp(1rem, 2vw, 1.5rem);
+  position: relative;
+}
+
+.oprm-v2-jobs-section::before {
+  content: "";
+  position: absolute;
+  top: 0.75rem;
+  bottom: 0.75rem;
+  left: 50%;
+  width: 1px;
+  background: linear-gradient(
+    180deg,
+    transparent,
+    rgba(13, 110, 253, 0.24),
+    rgba(25, 135, 84, 0.24),
+    transparent
+  );
+}
+
+.oprm-v2-job-panel {
+  position: relative;
+  overflow: hidden;
+  min-width: 0;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  border-radius: 1rem;
+  background: #ffffff;
+  box-shadow: 0 1rem 2.5rem -1.75rem rgba(15, 23, 42, 0.35);
+}
+
+.oprm-v2-job-panel__accent {
+  position: absolute;
+  inset: 0 auto 0 0;
+  width: 0.35rem;
+}
+
+.oprm-v2-job-panel--open .oprm-v2-job-panel__accent,
+.oprm-v2-job-panel--open .oprm-v2-job-panel__status-dot {
+  background: linear-gradient(180deg, #ffc107, #fd7e14);
+}
+
+.oprm-v2-job-panel--completed .oprm-v2-job-panel__accent,
+.oprm-v2-job-panel--completed .oprm-v2-job-panel__status-dot {
+  background: linear-gradient(180deg, #20c997, #198754);
+}
+
+.oprm-v2-job-panel__content {
+  padding: clamp(1rem, 2vw, 1.35rem) clamp(1rem, 2vw, 1.5rem)
+    clamp(1rem, 2vw, 1.35rem) clamp(1.25rem, 2vw, 1.75rem);
+}
+
+.oprm-v2-job-panel__eyebrow {
+  display: inline-flex;
+  margin-bottom: 0.35rem;
+  color: #64748b;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.oprm-v2-job-panel__status-dot {
+  width: 0.75rem;
+  height: 0.75rem;
+  flex: 0 0 auto;
+  margin-top: 0.25rem;
+  border-radius: 999px;
+  box-shadow: 0 0 0 0.35rem rgba(15, 23, 42, 0.06);
+}
+
+@media (max-width: 1199.98px) {
+  .oprm-v2-jobs-section {
+    grid-template-columns: 1fr;
+  }
+
+  .oprm-v2-jobs-section::before {
+    display: none;
+  }
+}

--- a/frontend/src/pages/oprm/OprmNichoCnaeV2PipelinePage.tsx
+++ b/frontend/src/pages/oprm/OprmNichoCnaeV2PipelinePage.tsx
@@ -303,54 +303,70 @@ export default function OprmNichoCnaeV2PipelinePage() {
 
       {decodedCnaeCode ? (
         <section
-          className="row g-3"
+          className="oprm-v2-jobs-section"
           aria-label="Jobs do CNAE no pipeline NichoCNAE v2"
         >
-          <article className="col-12 col-xl-6">
-            <div className="card h-100 border-0 shadow-sm">
-              <div className="card-body">
-                <h2 className="h5 mb-2">Jobs abertos</h2>
-                <p className="text-secondary small">
-                  Mostra onde cada execução ainda aberta está parada agora.
-                </p>
-                {jobsQuery.isLoading ? (
-                  <p className="text-secondary mb-0">Carregando jobs...</p>
-                ) : jobsQuery.isError ? (
-                  <div className="alert alert-danger mb-0" role="alert">
-                    {jobsQuery.error.message}
-                  </div>
-                ) : (
-                  <JobsTable
-                    jobs={jobsQuery.data?.openJobs ?? []}
-                    emptyMessage="Nenhum job aberto para este CNAE."
-                    open
-                  />
-                )}
+          <article className="oprm-v2-job-panel oprm-v2-job-panel--open">
+            <div className="oprm-v2-job-panel__accent" aria-hidden="true" />
+            <div className="oprm-v2-job-panel__content">
+              <div className="d-flex align-items-start justify-content-between gap-3 mb-3">
+                <div>
+                  <span className="oprm-v2-job-panel__eyebrow">Agora</span>
+                  <h2 className="h5 mb-1">Jobs abertos</h2>
+                  <p className="text-secondary small mb-0">
+                    Mostra onde cada execução ainda aberta está parada agora.
+                  </p>
+                </div>
+                <span
+                  className="oprm-v2-job-panel__status-dot"
+                  aria-hidden="true"
+                />
               </div>
+              {jobsQuery.isLoading ? (
+                <p className="text-secondary mb-0">Carregando jobs...</p>
+              ) : jobsQuery.isError ? (
+                <div className="alert alert-danger mb-0" role="alert">
+                  {jobsQuery.error.message}
+                </div>
+              ) : (
+                <JobsTable
+                  jobs={jobsQuery.data?.openJobs ?? []}
+                  emptyMessage="Nenhum job aberto para este CNAE."
+                  open
+                />
+              )}
             </div>
           </article>
-          <article className="col-12 col-xl-6">
-            <div className="card h-100 border-0 shadow-sm">
-              <div className="card-body">
-                <h2 className="h5 mb-2">Jobs concluídos</h2>
-                <p className="text-secondary small">
-                  Histórico dos jobs encerrados para evitar repetir pesquisa sem
-                  aprendizado.
-                </p>
-                {jobsQuery.isLoading ? (
-                  <p className="text-secondary mb-0">Carregando histórico...</p>
-                ) : jobsQuery.isError ? (
-                  <div className="alert alert-danger mb-0" role="alert">
-                    {jobsQuery.error.message}
-                  </div>
-                ) : (
-                  <JobsTable
-                    jobs={jobsQuery.data?.completedJobs ?? []}
-                    emptyMessage="Nenhum job concluído para este CNAE."
-                    open={false}
-                  />
-                )}
+          <article className="oprm-v2-job-panel oprm-v2-job-panel--completed">
+            <div className="oprm-v2-job-panel__accent" aria-hidden="true" />
+            <div className="oprm-v2-job-panel__content">
+              <div className="d-flex align-items-start justify-content-between gap-3 mb-3">
+                <div>
+                  <span className="oprm-v2-job-panel__eyebrow">Histórico</span>
+                  <h2 className="h5 mb-1">Jobs concluídos</h2>
+                  <p className="text-secondary small mb-0">
+                    Histórico dos jobs encerrados para evitar repetir pesquisa
+                    sem aprendizado.
+                  </p>
+                </div>
+                <span
+                  className="oprm-v2-job-panel__status-dot"
+                  aria-hidden="true"
+                />
               </div>
+              {jobsQuery.isLoading ? (
+                <p className="text-secondary mb-0">Carregando histórico...</p>
+              ) : jobsQuery.isError ? (
+                <div className="alert alert-danger mb-0" role="alert">
+                  {jobsQuery.error.message}
+                </div>
+              ) : (
+                <JobsTable
+                  jobs={jobsQuery.data?.completedJobs ?? []}
+                  emptyMessage="Nenhum job concluído para este CNAE."
+                  open={false}
+                />
+              )}
             </div>
           </article>
         </section>


### PR DESCRIPTION
### Motivation
- Melhorar a leitura operacional da tela do pipeline NichoCNAE v2 separando claramente execuções abertas e histórico de jobs concluídos para reduzir confusão visual entre estados.

### Description
- Substituídos os dois cards colados por dois painéis dedicados (`oprm-v2-job-panel`) para "Jobs abertos" e "Jobs concluídos" em `frontend/src/pages/oprm/OprmNichoCnaeV2PipelinePage.tsx` com rótulos contextuais (`Agora` / `Histórico`) e marcador de status.
- Adicionados estilos em `frontend/src/App.css` para layout em grid responsivo, divisor central visual, faixa de cor lateral (accent) e ajustes de espaçamento/borda/sombra para destacar os painéis.
- Atualizado registro operacional em `docs/registros/oprm1.md` descrevendo a mudança e a causa-raiz da alteração.

### Testing
- Executado `npm run typecheck` no frontend e a checagem de tipos concluiu com sucesso.
- Rodado `npx prettier --write` sobre os arquivos alterados para formatação automática sem erros de formatação.
- Verificada a integridade do diff com `git diff --check` sem problemas reportados.
- Geração de captura de tela de verificação via Playwright com screenshot salvo em `/tmp/oprm-v2-jobs-separation.png`, confirmando a separação visual (dependências do ambiente instaladas quando necessário).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a35b546415c8321ba89ee534d47ee5f)