### PR TITLE
Ajusta layout dos cards de jobs do pipeline OPRM

### DIFF
--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -1123,3 +1123,8 @@
 - Implementado scheduler no `oprm-coletor-mei` para consultar a cada 3 minutos os endpoints `pending` das etapas NichoCNAE v2 com contrato backend existente.
 - O executor agora carrega o pacote `com.marketinghub.nichocnaev2`, processa pendências com os processors plugáveis, registra conclusão/falha no backend e cria a próxima pendência quando a próxima etapa v2 existe no catálogo local.
 - Causa-raiz corrigida: a v2 possuía contratos `pending` no backend e processors no executor, mas não havia rotina operacional registrada no Spring para buscar e executar os jobs pendentes.
+
+## 2026-06-19 — Ajuste visual dos cards de jobs NichoCNAE v2
+
+- Ajustado o layout da tela do pipeline NichoCNAE v2 para manter os cards de jobs com o mesmo visual, mas exibidos em uma única coluna, ocupando a largura horizontal disponível da tela.
+- Causa-raiz preventiva: o grid anterior dividia os cards em duas colunas em telas largas, reduzindo o espaço útil para leitura de jobs e tabelas operacionais.

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -193,25 +193,8 @@
 
 .oprm-v2-jobs-section {
   display: grid;
-  grid-template-columns: minmax(0, 1fr) minmax(0, 1fr);
+  grid-template-columns: minmax(0, 1fr);
   gap: clamp(1rem, 2vw, 1.5rem);
-  position: relative;
-}
-
-.oprm-v2-jobs-section::before {
-  content: "";
-  position: absolute;
-  top: 0.75rem;
-  bottom: 0.75rem;
-  left: 50%;
-  width: 1px;
-  background: linear-gradient(
-    180deg,
-    transparent,
-    rgba(13, 110, 253, 0.24),
-    rgba(25, 135, 84, 0.24),
-    transparent
-  );
 }
 
 .oprm-v2-job-panel {
@@ -264,12 +247,3 @@
   box-shadow: 0 0 0 0.35rem rgba(15, 23, 42, 0.06);
 }
 
-@media (max-width: 1199.98px) {
-  .oprm-v2-jobs-section {
-    grid-template-columns: 1fr;
-  }
-
-  .oprm-v2-jobs-section::before {
-    display: none;
-  }
-}


### PR DESCRIPTION
### Motivation
- Melhorar leitura e aproveitamento do espaço dos cards de jobs na tela do pipeline NichoCNAE v2 exibindo cada card em largura total horizontal.
- Evitar que a grade em duas colunas reduza o espaço útil para tabelas e informações operacionais dos jobs.
- Manter o visual (bordas, sombra, faixa de status) sem alterar a estrutura interna dos painéis.

### Description
- Altera `frontend/src/App.css` para tornar `.oprm-v2-jobs-section` uma coluna única (`grid-template-columns: minmax(0, 1fr)`) e remove o divisor visual central (`::before`) e a media query associada.
- Mantém as classes de estilo dos painéis (`.oprm-v2-job-panel`, accent, status-dot, etc.) sem modificações funcionais no conteúdo dos cards.
- Registra a mudança no histórico em `docs/registros/oprm1.md` descrevendo o ajuste visual e a justificativa preventiva.

### Testing
- Executado `npm run typecheck` no frontend e o comando concluiu com sucesso.
- Executado `npm run build` no frontend e o build completou com sucesso (com avisos de chunking reportados pelo bundler).
- Verificações de execução local de navegador não foram possíveis no ambiente CI (Chromium não disponível), mas a build produzida foi gerada corretamente.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a35bec071308321bdd3872905c52435)