### PR TITLE
NichoCNAE v2: fix candidate-generator ↔ source-safety-filter loop, classify failures and add tests

### DIFF
--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -1123,3 +1123,10 @@
 - Implementado scheduler no `oprm-coletor-mei` para consultar a cada 3 minutos os endpoints `pending` das etapas NichoCNAE v2 com contrato backend existente.
 - O executor agora carrega o pacote `com.marketinghub.nichocnaev2`, processa pendências com os processors plugáveis, registra conclusão/falha no backend e cria a próxima pendência quando a próxima etapa v2 existe no catálogo local.
 - Causa-raiz corrigida: a v2 possuía contratos `pending` no backend e processors no executor, mas não havia rotina operacional registrada no Spring para buscar e executar os jobs pendentes.
+
+## 2026-06-19 — Correção de loop técnico entre Candidate Generator e Source Safety Filter v2
+
+- Corrigida a causa-raiz do job `nichocnae-v2-candidate-2-job-1` entrar em retries técnicos repetidos na etapa `source-safety-filter`: a etapa `candidate-generator` emitia apenas `{"stage":"candidate-generator"}`, sem candidatos neutros nem `candidateUrls` para o filtro de segurança.
+- O executor externo `oprm-coletor-mei` agora mantém a lógica de negócio no módulo executor: o `CandidateGeneratorProcessor` entrega candidatos neutros, URLs-semente seguras e `nextStageCode`, enquanto o `SourceSafetyFilterProcessor` rejeita contrato sem URLs como erro de validação, não como infraestrutura retryável.
+- Adicionado limite operacional no executor para retry técnico por tentativa, classificando limite excedido como `VALIDATION/TECHNICAL_RETRY_LIMIT_EXCEEDED`; o backend permanece limitado a persistir o status informado pelo executor.
+- Prevenção de recorrência: testes cobrem geração de payload útil para a etapa seguinte, rejeição de entrada inválida no filtro de segurança e classificação de contrato inválido sem novo retry técnico.

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnaev2/execution/NichoCnaeV2BackendClient.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnaev2/execution/NichoCnaeV2BackendClient.java
@@ -60,12 +60,17 @@ public class NichoCnaeV2BackendClient {
         restTemplate.postForObject(backendBaseUrl + nextStage.backendPath(), request, Object.class);
     }
 
-    /** Registra falha técnica com contexto suficiente para retry ou diagnóstico no backend. */
-    public void fail(NichoCnaeV2StageDefinition stage, NichoCnaeV2PendingExecution pending, RuntimeException ex) {
+    /** Registra falha classificada pelo executor externo com contexto suficiente para diagnóstico no backend. */
+    public void fail(
+            NichoCnaeV2StageDefinition stage,
+            NichoCnaeV2PendingExecution pending,
+            RuntimeException ex,
+            String failureType,
+            String reasonCode) {
         Map<String, Object> request = new LinkedHashMap<>();
-        request.put("failureType", "INFRASTRUCTURE");
-        request.put("reasonCode", "SCHEDULER_PROCESSING_ERROR");
-        request.put("errorCode", "SCHEDULER_PROCESSING_ERROR");
+        request.put("failureType", failureType);
+        request.put("reasonCode", reasonCode);
+        request.put("errorCode", reasonCode);
         request.put("errorMessage", ex.getMessage() == null ? ex.getClass().getSimpleName() : ex.getMessage());
         request.put("inputPayload", pending.inputPayload());
         restTemplate.postForObject(

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnaev2/execution/NichoCnaeV2PendingExecutionService.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnaev2/execution/NichoCnaeV2PendingExecutionService.java
@@ -15,6 +15,7 @@ import org.springframework.stereotype.Service;
 @Service
 public class NichoCnaeV2PendingExecutionService {
     private static final Logger log = LoggerFactory.getLogger(NichoCnaeV2PendingExecutionService.class);
+    private static final int MAX_TECHNICAL_RETRIES_PER_ATTEMPT = 3;
 
     private final NichoCnaeV2BackendClient backendClient;
     private final NichoCnaeV2StageDefinitions stageDefinitions;
@@ -83,8 +84,27 @@ public class NichoCnaeV2PendingExecutionService {
                     pending.cnaeCode(),
                     pending.sourceNicheId(),
                     ex);
-            backendClient.fail(stage, pending, ex);
+            registerFailure(stage, pending, ex);
         }
+    }
+
+    /** Classifica falhas no executor para evitar retry técnico infinito em erro de contrato ou limite excedido. */
+    private void registerFailure(NichoCnaeV2StageDefinition stage, NichoCnaeV2PendingExecution pending, RuntimeException ex) {
+        String failureType = "INFRASTRUCTURE";
+        String reasonCode = "SCHEDULER_PROCESSING_ERROR";
+        if (ex instanceof IllegalArgumentException) {
+            failureType = "VALIDATION";
+            reasonCode = "INVALID_STAGE_INPUT_CONTRACT";
+        } else if (technicalRetryNumber(pending) >= MAX_TECHNICAL_RETRIES_PER_ATTEMPT) {
+            failureType = "VALIDATION";
+            reasonCode = "TECHNICAL_RETRY_LIMIT_EXCEEDED";
+        }
+        backendClient.fail(stage, pending, ex, failureType, reasonCode);
+    }
+
+    /** Normaliza o contador de retry técnico ausente para zero antes de comparar com o limite operacional. */
+    private int technicalRetryNumber(NichoCnaeV2PendingExecution pending) {
+        return pending.technicalRetryNumber() == null ? 0 : pending.technicalRetryNumber();
     }
 
     /** Monta o input do processor com JSON estruturado e metadados do pending sem JSON dentro de JSON. */

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnaev2/pipeline/candidategenerator/CandidateGeneratorProcessor.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnaev2/pipeline/candidategenerator/CandidateGeneratorProcessor.java
@@ -8,9 +8,52 @@ import java.util.Map;
 
 /** Executa a etapa plugável que cria candidatos neutros para pesquisa NichoCNAE versão 2. */
 public final class CandidateGeneratorProcessor implements StageProcessor {
-    /** Produz uma saída mínima de bootstrap sem escolher vencedor nem declarar dor validada. */
+    /** Produz candidatos neutros e fontes-semente seguras sem escolher vencedor nem declarar dor validada. */
     @Override
     public StageResult process(StageContext context) {
-        return new StageResult("BOOTSTRAPPED", Map.of("stage", "candidate-generator"), List.of());
+        String cnaeCode = String.valueOf(context.input().getOrDefault("cnaeCode", "CNAE_DESCONHECIDO"));
+        List<Map<String, Object>> candidates = candidateSetFor(cnaeCode);
+        List<String> candidateUrls = List.of(
+                "https://sebrae.com.br/sites/PortalSebrae/ideias/como-montar-uma-loja-de-roupas",
+                "https://www.gov.br/empresas-e-negocios/pt-br/empreendedor",
+                "https://www.gov.br/receitafederal/pt-br/assuntos/orientacao-tributaria/cadastros/cnpj/classificacao-nacional-de-atividades-economicas-2013-cnae",
+                "https://sebrae.com.br/sites/PortalSebrae/ufs/sp/artigos/gestao-de-estoque-no-varejo");
+        return new StageResult(
+                "BOOTSTRAPPED",
+                Map.of(
+                        "stage", "candidate-generator",
+                        "candidateCount", candidates.size(),
+                        "candidates", candidates,
+                        "candidateUrls", candidateUrls,
+                        "nextStageCode", "source-safety-filter"),
+                List.of());
+    }
+
+    /** Escolhe recortes neutros específicos quando há conhecimento seguro do CNAE; caso contrário usa recortes genéricos. */
+    private List<Map<String, Object>> candidateSetFor(String cnaeCode) {
+        if ("4781400".equals(cnaeCode)) {
+            return List.of(
+                    neutralCandidate("C1", "RETAIL_OPERATOR", "VESTUARIO_ATENDIMENTO_LOJA", "Atendimento e venda assistida em loja de vestuário"),
+                    neutralCandidate("C2", "RETAIL_OPERATOR", "VESTUARIO_ESTOQUE_GRADE", "Organização de estoque, grade e reposição de peças"),
+                    neutralCandidate("C3", "RETAIL_OPERATOR", "VESTUARIO_TROCAS_AJUSTES", "Trocas, ajustes e atendimento pós-venda de vestuário"),
+                    neutralCandidate("C4", "RETAIL_OPERATOR", "VESTUARIO_VENDA_DIGITAL_LOCAL", "Venda digital local de artigos de vestuário"));
+        }
+        return List.of(
+                neutralCandidate("C1", "CNAE_OPERATOR", "ATENDIMENTO_OPERACIONAL", "Atendimento operacional do CNAE " + cnaeCode),
+                neutralCandidate("C2", "CNAE_OPERATOR", "GESTAO_DE_ROTINA", "Gestão de rotina e execução diária do CNAE " + cnaeCode),
+                neutralCandidate("C3", "CNAE_OPERATOR", "AQUISICAO_DE_CLIENTES", "Aquisição e atendimento de clientes do CNAE " + cnaeCode),
+                neutralCandidate("C4", "CNAE_OPERATOR", "OPERACAO_DIGITAL_LOCAL", "Operação digital local do CNAE " + cnaeCode));
+    }
+
+    /** Monta um candidato neutro sem dor, canal ou promessa ainda não comprovados. */
+    private Map<String, Object> neutralCandidate(String candidateId, String operator, String job, String operationalContext) {
+        return Map.of(
+                "candidateId", candidateId,
+                "operator", operator,
+                "job", job,
+                "buyerTypes", List.of("B2C"),
+                "operationalContext", operationalContext,
+                "painHypotheses", List.of(),
+                "priorConfidence", "LOW");
     }
 }

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnaev2/pipeline/sourcesafetyfilter/SourceSafetyFilterProcessor.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnaev2/pipeline/sourcesafetyfilter/SourceSafetyFilterProcessor.java
@@ -56,10 +56,14 @@ public final class SourceSafetyFilterProcessor implements StageProcessor {
         if (!(candidateUrls instanceof List<?> values)) {
             candidateUrls = input.get("urls");
         }
-        if (!(candidateUrls instanceof List<?> values)) {
-            return List.of();
+        if (!(candidateUrls instanceof List<?> values) || values.isEmpty()) {
+            throw new IllegalArgumentException("Source Safety Filter exige candidateUrls ou urls com pelo menos uma URL candidata.");
         }
-        return values.stream().filter(String.class::isInstance).map(String.class::cast).toList();
+        List<String> urls = values.stream().filter(String.class::isInstance).map(String.class::cast).toList();
+        if (urls.isEmpty()) {
+            throw new IllegalArgumentException("Source Safety Filter recebeu lista de URLs sem itens textuais válidos.");
+        }
+        return urls;
     }
 
     /** Classifica uma URL bruta usando hard blocklist local e regras determinísticas de canonicalização. */

--- a/oprm-coletor-mei/src/test/java/com/marketinghub/nichocnaev2/execution/NichoCnaeV2PendingExecutionServiceTest.java
+++ b/oprm-coletor-mei/src/test/java/com/marketinghub/nichocnaev2/execution/NichoCnaeV2PendingExecutionServiceTest.java
@@ -1,0 +1,38 @@
+package com.marketinghub.nichocnaev2.execution;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/** Valida a classificação operacional de falhas feita no executor NichoCNAE v2. */
+class NichoCnaeV2PendingExecutionServiceTest {
+    /** Deve bloquear loop quando contrato de entrada inválido chega à etapa de segurança. */
+    @Test
+    void classifiesInvalidStageInputAsValidationFailureWithoutTechnicalRetry() {
+        NichoCnaeV2BackendClient backendClient = mock(NichoCnaeV2BackendClient.class);
+        NichoCnaeV2StageDefinitions stageDefinitions = new NichoCnaeV2StageDefinitions();
+        NichoCnaeV2PendingExecutionService service = new NichoCnaeV2PendingExecutionService(backendClient, stageDefinitions);
+        NichoCnaeV2PendingExecution pending = new NichoCnaeV2PendingExecution(
+                "54", "job-1", "4781400", 1L, 2L, 1, 26, 1, false, "{\"stage\":\"candidate-generator\"}", Map.of());
+        when(backendClient.listPending(any())).thenAnswer(invocation -> {
+            NichoCnaeV2StageDefinition stage = invocation.getArgument(0);
+            return "source-safety-filter".equals(stage.stageCode()) ? List.of(pending) : List.of();
+        });
+        when(backendClient.parseInput(pending.inputPayload())).thenReturn(Map.of("stage", "candidate-generator"));
+
+        service.processAllPending();
+
+        verify(backendClient).fail(
+                any(NichoCnaeV2StageDefinition.class),
+                eq(pending),
+                any(IllegalArgumentException.class),
+                eq("VALIDATION"),
+                eq("INVALID_STAGE_INPUT_CONTRACT"));
+    }
+}

--- a/oprm-coletor-mei/src/test/java/com/marketinghub/nichocnaev2/pipeline/candidategenerator/CandidateGeneratorProcessorTest.java
+++ b/oprm-coletor-mei/src/test/java/com/marketinghub/nichocnaev2/pipeline/candidategenerator/CandidateGeneratorProcessorTest.java
@@ -1,0 +1,26 @@
+package com.marketinghub.nichocnaev2.pipeline.candidategenerator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.marketinghub.nichocnaev2.pipeline.StageContext;
+import com.marketinghub.nichocnaev2.pipeline.StageResult;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/** Valida o gerador inicial de candidatos neutros da v2 sem contaminar dor, canal ou promessa. */
+class CandidateGeneratorProcessorTest {
+    /** Deve gerar candidatos neutros e URLs-semente para a etapa de segurança sem escolher vencedor. */
+    @Test
+    void generatesNeutralCandidatesAndCandidateUrlsForSafetyFilter() {
+        CandidateGeneratorProcessor processor = new CandidateGeneratorProcessor();
+
+        StageResult result = processor.process(new StageContext("job-1", "stage-1", Map.of("cnaeCode", "4781400")));
+
+        assertThat(result.status()).isEqualTo("BOOTSTRAPPED");
+        assertThat(result.output().get("nextStageCode")).isEqualTo("source-safety-filter");
+        assertThat((List<?>) result.output().get("candidateUrls")).hasSizeGreaterThanOrEqualTo(3);
+        assertThat((List<?>) result.output().get("candidates")).hasSizeBetween(4, 6);
+        assertThat(String.valueOf(result.output().get("candidates"))).contains("painHypotheses=[]", "priorConfidence=LOW");
+    }
+}

--- a/oprm-coletor-mei/src/test/java/com/marketinghub/nichocnaev2/pipeline/sourcesafetyfilter/SourceSafetyFilterProcessorTest.java
+++ b/oprm-coletor-mei/src/test/java/com/marketinghub/nichocnaev2/pipeline/sourcesafetyfilter/SourceSafetyFilterProcessorTest.java
@@ -1,6 +1,7 @@
 package com.marketinghub.nichocnaev2.pipeline.sourcesafetyfilter;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.marketinghub.nichocnaev2.pipeline.StageContext;
 import com.marketinghub.nichocnaev2.pipeline.StageResult;
@@ -29,6 +30,17 @@ class SourceSafetyFilterProcessorTest {
         assertThat(result.output().get("rejectedUrlCount")).isEqualTo(2);
         assertThat(result.output().toString()).contains("https://www.gov.br/mei/rotina?id=10");
         assertThat(result.output().toString()).contains("HARD_BLOCKED_DOMAIN", "DUPLICATE");
+    }
+
+    /** Deve rejeitar contrato sem URLs para evitar retry técnico da mesma entrada inválida. */
+    @Test
+    void rejectsMissingCandidateUrlsAsInvalidInputContract() {
+        SourceSafetyFilterProcessor processor = new SourceSafetyFilterProcessor();
+        StageContext context = new StageContext("job-1", "stage-2", Map.of("stage", "candidate-generator"));
+
+        assertThatThrownBy(() -> processor.process(context))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("candidateUrls ou urls");
     }
 
     /** Deve registrar hard reject global quando todas as URLs candidatas forem inseguras. */


### PR DESCRIPTION
### Motivation

- Prevent an infinite technical retry loop when `candidate-generator` emitted an empty/insufficient contract and `source-safety-filter` retried the same invalid input; also make executor failures classifiable for diagnostics and limits. 
- Provide a useful candidate payload for the safety filter so the pipeline can advance with seed URLs and neutral candidates. 

### Description

- Updated `NichoCnaeV2BackendClient.fail` to accept explicit `failureType` and `reasonCode` and propagate those to the backend.  
- Implemented operational failure classification and a technical retry cap in `NichoCnaeV2PendingExecutionService` via `registerFailure`, `technicalRetryNumber` and `MAX_TECHNICAL_RETRIES_PER_ATTEMPT`.  
- Enhanced `CandidateGeneratorProcessor` to emit neutral `candidates`, `candidateCount`, `candidateUrls` and `nextStageCode` instead of a minimal bootstrap marker.  
- Tightened `SourceSafetyFilterProcessor.extractCandidateUrls` to validate presence of at least one textual URL and to throw `IllegalArgumentException` for invalid/empty URL lists.  
- Added unit tests covering the new behavior: `NichoCnaeV2PendingExecutionServiceTest`, `CandidateGeneratorProcessorTest` and expanded `SourceSafetyFilterProcessorTest`.  
- Documentation updated (`docs/registros/oprm1.md`) with release notes describing the fix and prevention measures.

### Testing

- Added unit tests `CandidateGeneratorProcessorTest`, `SourceSafetyFilterProcessorTest` and `NichoCnaeV2PendingExecutionServiceTest` to validate candidate generation, safety-filter input validation and failure classification.  
- Ran the unit test suite for the modified module and verified the new tests execute and assert the expected behavior (validation exception classification and generated payload fields) successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a35be42cd5083218150ab7516c38691)