### PR TITLE
Include cnaeDescription in candidate-generator pending contract and improve executor error reporting

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/candidategenerator/service/BackendCandidateGeneratorService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/candidategenerator/service/BackendCandidateGeneratorService.java
@@ -267,10 +267,15 @@ public class BackendCandidateGeneratorService {
 
     /** Converte a entidade persistida no contrato canônico de pending do executor. */
     private CandidateGeneratorPendingResponse toPendingResponse(OprmNichoCnaeV2StageExecution execution) {
+        String cnaeDescription = nicheCandidateRepository
+                .findById(execution.getSourceNicheId())
+                .map(OprmNicheCandidate::getCnaeDescription)
+                .orElse(null);
         return new CandidateGeneratorPendingResponse(
                 String.valueOf(execution.getId()),
                 execution.getJobId(),
                 execution.getCnaeCode(),
+                cnaeDescription,
                 execution.getSourceNicheId(),
                 execution.getAttemptNumber(),
                 execution.getTechnicalRetryNumber(),

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/candidategenerator/service/pending/CandidateGeneratorPendingResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/candidategenerator/service/pending/CandidateGeneratorPendingResponse.java
@@ -5,6 +5,7 @@ public record CandidateGeneratorPendingResponse(
         String stageExecutionId,
         String jobId,
         String cnaeCode,
+        String cnaeDescription,
         Long sourceNicheId,
         Integer attemptNumber,
         Integer technicalRetryNumber,

--- a/backend/ads-service/src/test/java/com/marketinghub/oprm/nichocnae/v2/candidategenerator/service/BackendCandidateGeneratorServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/oprm/nichocnae/v2/candidategenerator/service/BackendCandidateGeneratorServiceTest.java
@@ -61,6 +61,7 @@ class BackendCandidateGeneratorServiceTest {
                         .toList());
         when(nicheCandidateRepository.findNextPendingRoutineResearchCandidatePreview(any(Pageable.class)))
                 .thenReturn(List.of(candidate));
+        when(nicheCandidateRepository.findById(69L)).thenReturn(Optional.of(candidate));
         when(stageExecutionRepository.existsBySourceNicheIdAndStageCode(69L, "candidate-generator"))
                 .thenReturn(false);
         when(stageExecutionRepository.save(any(OprmNichoCnaeV2StageExecution.class))).thenAnswer(invocation -> {
@@ -76,6 +77,7 @@ class BackendCandidateGeneratorServiceTest {
         assertThat(result.getFirst().stageExecutionId()).isEqualTo("1001");
         assertThat(result.getFirst().jobId()).isEqualTo("nichocnae-v2-candidate-69-job-1");
         assertThat(result.getFirst().cnaeCode()).isEqualTo("9602501");
+        assertThat(result.getFirst().cnaeDescription()).isEqualTo("Serviços de beleza");
         assertThat(result.getFirst().attemptNumber()).isEqualTo(1);
         assertThat(result.getFirst().technicalRetryNumber()).isZero();
         assertThat(result.getFirst().knowledgeVersion()).isEqualTo(1);

--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -1134,3 +1134,17 @@
 
 - Ajustado o layout da tela do pipeline NichoCNAE v2 para manter os cards de jobs com o mesmo visual, mas exibidos em uma única coluna, ocupando a largura horizontal disponível da tela.
 - Causa-raiz preventiva: o grid anterior dividia os cards em duas colunas em telas largas, reduzindo o espaço útil para leitura de jobs e tabelas operacionais.
+
+## 2026-06-19 — Candidate Generator v2 usa descrição do CNAE no contexto operacional
+
+- Ajustado o contrato `pending` da etapa `candidate-generator` para entregar `cnaeDescription` ao executor OPRM NichoCNAE v2, preservando o backend como fonte de leitura/escrita e o executor como responsável pela geração operacional.
+- O `CandidateGeneratorProcessor` passou a montar candidatos genéricos com a descrição do CNAE quando disponível; para o CNAE `7319002`, a referência operacional passa a ser `Promoção de vendas` em vez de `CNAE 7319002`.
+- Causa-raiz corrigida: o executor recebia apenas o código do CNAE no pending e, por isso, o fallback genérico contaminava o contexto de negócio com identificador técnico numérico.
+- Prevenção de recorrência: testes cobrem a propagação da descrição no pending e a ausência de `CNAE 7319002` nos candidatos quando a descrição está disponível.
+
+## 2026-06-20 — NichoCNAE v2 preserva ponto de falha em callbacks de erro do executor
+
+- Ajustado o tratamento comum de falha do executor `oprm-coletor-mei` para enviar ao backend `errorMessage` com `reasonCode`, etapa, `stageExecutionId`, `jobId`, `cnaeCode`, classe da exception, primeiro frame de aplicação e stack trace completo.
+- Causa-raiz corrigida: exceptions sem mensagem, como `NullPointerException`, eram persistidas apenas como `NullPointerException`, fazendo o sistema perder o ponto exato que gerou o erro.
+- Como o callback comum `NichoCnaeV2BackendClient.fail(...)` atende todas as etapas v2, a preservação do ponto de falha passa a valer para `candidate-generator`, `source-safety-filter`, `adaptive-query-planner`, `candidate-tournament`, `source-fetcher-reranker`, `knowledge-accumulator`, `commercial-evidence-gate`, `reprocess-controller` e `enriched-niche-materializer`.
+- Prevenção de recorrência: adicionado teste unitário cobrindo uma NPE sem mensagem e verificando a persistência do primeiro frame de aplicação junto com o stack trace.

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnaev2/execution/NichoCnaeV2BackendClient.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnaev2/execution/NichoCnaeV2BackendClient.java
@@ -3,6 +3,8 @@ package com.marketinghub.nichocnaev2.execution;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import java.io.PrintWriter;
+import java.io.StringWriter;
 import java.util.Arrays;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -71,12 +73,49 @@ public class NichoCnaeV2BackendClient {
         request.put("failureType", failureType);
         request.put("reasonCode", reasonCode);
         request.put("errorCode", reasonCode);
-        request.put("errorMessage", ex.getMessage() == null ? ex.getClass().getSimpleName() : ex.getMessage());
+        request.put("errorMessage", detailedErrorMessage(stage, pending, ex, reasonCode));
         request.put("inputPayload", pending.inputPayload());
         restTemplate.postForObject(
                 backendBaseUrl + stage.backendPath() + "/" + pending.stageExecutionId() + "/fail",
                 request,
                 Object.class);
+    }
+
+    /** Monta erro persistível com ponto de falha e stack trace para não perder a origem de NPE ou falhas similares. */
+    static String detailedErrorMessage(
+            NichoCnaeV2StageDefinition stage, NichoCnaeV2PendingExecution pending, RuntimeException ex, String reasonCode) {
+        StringWriter stackTrace = new StringWriter();
+        ex.printStackTrace(new PrintWriter(stackTrace));
+        StackTraceElement failurePoint = firstApplicationFrame(ex);
+        String message = ex.getMessage() == null || ex.getMessage().isBlank()
+                ? ex.getClass().getSimpleName()
+                : ex.getClass().getSimpleName() + ": " + ex.getMessage();
+        return "reasonCode="
+                + reasonCode
+                + "; stage="
+                + stage.stageCode()
+                + "; stageExecutionId="
+                + pending.stageExecutionId()
+                + "; jobId="
+                + pending.jobId()
+                + "; cnaeCode="
+                + pending.cnaeCode()
+                + "; exception="
+                + message
+                + "; failurePoint="
+                + failurePoint
+                + "\n"
+                + stackTrace;
+    }
+
+    /** Localiza o primeiro frame da aplicação para apontar rapidamente onde a falha nasceu. */
+    private static StackTraceElement firstApplicationFrame(RuntimeException ex) {
+        for (StackTraceElement frame : ex.getStackTrace()) {
+            if (frame.getClassName().startsWith("com.marketinghub.")) {
+                return frame;
+            }
+        }
+        return ex.getStackTrace().length == 0 ? null : ex.getStackTrace()[0];
     }
 
     /** Serializa payload estruturado para armazenamento funcional no backend. */
@@ -106,6 +145,7 @@ public class NichoCnaeV2BackendClient {
                 text(raw.get("stageExecutionId")),
                 text(raw.get("jobId")),
                 text(raw.get("cnaeCode")),
+                text(raw.get("cnaeDescription")),
                 longValue(raw.get("researchCycleId")),
                 longValue(raw.get("sourceNicheId")),
                 intValue(raw.get("attemptNumber")),

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnaev2/execution/NichoCnaeV2PendingExecution.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnaev2/execution/NichoCnaeV2PendingExecution.java
@@ -7,6 +7,7 @@ public record NichoCnaeV2PendingExecution(
         String stageExecutionId,
         String jobId,
         String cnaeCode,
+        String cnaeDescription,
         Long researchCycleId,
         Long sourceNicheId,
         Integer attemptNumber,

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnaev2/execution/NichoCnaeV2PendingExecutionService.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnaev2/execution/NichoCnaeV2PendingExecutionService.java
@@ -113,6 +113,7 @@ public class NichoCnaeV2PendingExecutionService {
         input.putIfAbsent("stageExecutionId", pending.stageExecutionId());
         input.putIfAbsent("jobId", pending.jobId());
         input.putIfAbsent("cnaeCode", pending.cnaeCode());
+        input.putIfAbsent("cnaeDescription", pending.cnaeDescription());
         input.putIfAbsent("sourceNicheId", pending.sourceNicheId());
         input.putIfAbsent("attemptNumber", pending.attemptNumber());
         input.putIfAbsent("technicalRetryNumber", pending.technicalRetryNumber());

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnaev2/pipeline/candidategenerator/CandidateGeneratorProcessor.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnaev2/pipeline/candidategenerator/CandidateGeneratorProcessor.java
@@ -12,7 +12,8 @@ public final class CandidateGeneratorProcessor implements StageProcessor {
     @Override
     public StageResult process(StageContext context) {
         String cnaeCode = String.valueOf(context.input().getOrDefault("cnaeCode", "CNAE_DESCONHECIDO"));
-        List<Map<String, Object>> candidates = candidateSetFor(cnaeCode);
+        String cnaeReference = cnaeReference(context.input(), cnaeCode);
+        List<Map<String, Object>> candidates = candidateSetFor(cnaeCode, cnaeReference);
         List<String> candidateUrls = List.of(
                 "https://sebrae.com.br/sites/PortalSebrae/ideias/como-montar-uma-loja-de-roupas",
                 "https://www.gov.br/empresas-e-negocios/pt-br/empreendedor",
@@ -30,7 +31,7 @@ public final class CandidateGeneratorProcessor implements StageProcessor {
     }
 
     /** Escolhe recortes neutros específicos quando há conhecimento seguro do CNAE; caso contrário usa recortes genéricos. */
-    private List<Map<String, Object>> candidateSetFor(String cnaeCode) {
+    private List<Map<String, Object>> candidateSetFor(String cnaeCode, String cnaeReference) {
         if ("4781400".equals(cnaeCode)) {
             return List.of(
                     neutralCandidate("C1", "RETAIL_OPERATOR", "VESTUARIO_ATENDIMENTO_LOJA", "Atendimento e venda assistida em loja de vestuário"),
@@ -39,10 +40,19 @@ public final class CandidateGeneratorProcessor implements StageProcessor {
                     neutralCandidate("C4", "RETAIL_OPERATOR", "VESTUARIO_VENDA_DIGITAL_LOCAL", "Venda digital local de artigos de vestuário"));
         }
         return List.of(
-                neutralCandidate("C1", "CNAE_OPERATOR", "ATENDIMENTO_OPERACIONAL", "Atendimento operacional do CNAE " + cnaeCode),
-                neutralCandidate("C2", "CNAE_OPERATOR", "GESTAO_DE_ROTINA", "Gestão de rotina e execução diária do CNAE " + cnaeCode),
-                neutralCandidate("C3", "CNAE_OPERATOR", "AQUISICAO_DE_CLIENTES", "Aquisição e atendimento de clientes do CNAE " + cnaeCode),
-                neutralCandidate("C4", "CNAE_OPERATOR", "OPERACAO_DIGITAL_LOCAL", "Operação digital local do CNAE " + cnaeCode));
+                neutralCandidate("C1", "CNAE_OPERATOR", "ATENDIMENTO_OPERACIONAL", "Atendimento operacional de " + cnaeReference),
+                neutralCandidate("C2", "CNAE_OPERATOR", "GESTAO_DE_ROTINA", "Gestão de rotina e execução diária de " + cnaeReference),
+                neutralCandidate("C3", "CNAE_OPERATOR", "AQUISICAO_DE_CLIENTES", "Aquisição e atendimento de clientes de " + cnaeReference),
+                neutralCandidate("C4", "CNAE_OPERATOR", "OPERACAO_DIGITAL_LOCAL", "Operação digital local de " + cnaeReference));
+    }
+
+    /** Usa a descrição do CNAE quando disponível para evitar contexto operacional genérico por código numérico. */
+    private String cnaeReference(Map<String, Object> input, String cnaeCode) {
+        Object description = input.get("cnaeDescription");
+        if (description instanceof String text && !text.isBlank()) {
+            return text.trim();
+        }
+        return "CNAE " + cnaeCode;
     }
 
     /** Monta um candidato neutro sem dor, canal ou promessa ainda não comprovados. */

--- a/oprm-coletor-mei/src/test/java/com/marketinghub/nichocnaev2/execution/NichoCnaeV2BackendClientTest.java
+++ b/oprm-coletor-mei/src/test/java/com/marketinghub/nichocnaev2/execution/NichoCnaeV2BackendClientTest.java
@@ -1,0 +1,53 @@
+package com.marketinghub.nichocnaev2.execution;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import com.marketinghub.nichocnaev2.pipeline.StageResult;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/** Valida a preservação de detalhes operacionais nos callbacks do backend NichoCNAE v2. */
+class NichoCnaeV2BackendClientTest {
+    /** Deve registrar ponto de falha e stack trace completo quando a exception não possui mensagem. */
+    @Test
+    void detailedErrorMessageKeepsFailurePointForNullPointerException() {
+        NichoCnaeV2StageDefinition stage = new NichoCnaeV2StageDefinition(
+                "source-safety-filter",
+                "/api/internal/oprm/nichocnae/v2/source-safety-filter/stage-executions",
+                context -> new StageResult("IGNORED", Map.of(), List.of()));
+        NichoCnaeV2PendingExecution pending = new NichoCnaeV2PendingExecution(
+                "96",
+                "nichocnae-v2-candidate-3-job-1",
+                "7319002",
+                "Promoção de vendas",
+                null,
+                3L,
+                1,
+                3,
+                1,
+                false,
+                "{}",
+                Map.of());
+        RuntimeException exception = npeFromApplicationFrame();
+
+        String detail = NichoCnaeV2BackendClient.detailedErrorMessage(
+                stage, pending, exception, "SCHEDULER_PROCESSING_ERROR");
+
+        assertThat(detail)
+                .contains("reasonCode=SCHEDULER_PROCESSING_ERROR")
+                .contains("stage=source-safety-filter")
+                .contains("stageExecutionId=96")
+                .contains("jobId=nichocnae-v2-candidate-3-job-1")
+                .contains("exception=NullPointerException")
+                .contains("failurePoint=com.marketinghub.nichocnaev2.execution.NichoCnaeV2BackendClientTest")
+                .contains("java.lang.NullPointerException");
+    }
+
+    /** Gera uma NPE real dentro do pacote da aplicação para validar localização do primeiro frame útil. */
+    private RuntimeException npeFromApplicationFrame() {
+        String value = null;
+        return assertThrows(NullPointerException.class, () -> value.length());
+    }
+}

--- a/oprm-coletor-mei/src/test/java/com/marketinghub/nichocnaev2/execution/NichoCnaeV2PendingExecutionServiceTest.java
+++ b/oprm-coletor-mei/src/test/java/com/marketinghub/nichocnaev2/execution/NichoCnaeV2PendingExecutionServiceTest.java
@@ -19,7 +19,18 @@ class NichoCnaeV2PendingExecutionServiceTest {
         NichoCnaeV2StageDefinitions stageDefinitions = new NichoCnaeV2StageDefinitions();
         NichoCnaeV2PendingExecutionService service = new NichoCnaeV2PendingExecutionService(backendClient, stageDefinitions);
         NichoCnaeV2PendingExecution pending = new NichoCnaeV2PendingExecution(
-                "54", "job-1", "4781400", 1L, 2L, 1, 26, 1, false, "{\"stage\":\"candidate-generator\"}", Map.of());
+                "54",
+                "job-1",
+                "4781400",
+                "Comércio varejista de artigos do vestuário e acessórios",
+                1L,
+                2L,
+                1,
+                26,
+                1,
+                false,
+                "{\"stage\":\"candidate-generator\"}",
+                Map.of());
         when(backendClient.listPending(any())).thenAnswer(invocation -> {
             NichoCnaeV2StageDefinition stage = invocation.getArgument(0);
             return "source-safety-filter".equals(stage.stageCode()) ? List.of(pending) : List.of();

--- a/oprm-coletor-mei/src/test/java/com/marketinghub/nichocnaev2/pipeline/candidategenerator/CandidateGeneratorProcessorTest.java
+++ b/oprm-coletor-mei/src/test/java/com/marketinghub/nichocnaev2/pipeline/candidategenerator/CandidateGeneratorProcessorTest.java
@@ -15,12 +15,18 @@ class CandidateGeneratorProcessorTest {
     void generatesNeutralCandidatesAndCandidateUrlsForSafetyFilter() {
         CandidateGeneratorProcessor processor = new CandidateGeneratorProcessor();
 
-        StageResult result = processor.process(new StageContext("job-1", "stage-1", Map.of("cnaeCode", "4781400")));
+        StageResult result = processor.process(new StageContext(
+                "job-1",
+                "stage-1",
+                Map.of("cnaeCode", "7319002", "cnaeDescription", "Promoção de vendas")));
 
         assertThat(result.status()).isEqualTo("BOOTSTRAPPED");
         assertThat(result.output().get("nextStageCode")).isEqualTo("source-safety-filter");
         assertThat((List<?>) result.output().get("candidateUrls")).hasSizeGreaterThanOrEqualTo(3);
         assertThat((List<?>) result.output().get("candidates")).hasSizeBetween(4, 6);
         assertThat(String.valueOf(result.output().get("candidates"))).contains("painHypotheses=[]", "priorConfidence=LOW");
+        assertThat(String.valueOf(result.output().get("candidates")))
+                .contains("Promoção de vendas")
+                .doesNotContain("CNAE 7319002");
     }
 }


### PR DESCRIPTION
### Motivation
- Provide the executor with a human-friendly CNAE description in the `candidate-generator` pending contract so processors can build operational context without falling back to `CNAE <code>` strings.
- Preserve detailed failure context (first application frame and full stack trace) when the executor reports errors to the backend to make root-cause diagnosis easier.

### Description
- Extend the backend pending contract by adding `cnaeDescription` to `CandidateGeneratorPendingResponse` and populate it in `BackendCandidateGeneratorService#toPendingResponse` by reading `OprmNicheCandidate.getCnaeDescription`.
- Update the executor HTTP client to accept and propagate `cnaeDescription` by adding the field to `NichoCnaeV2PendingExecution` and to the `toPendingExecution` parsing logic in `NichoCnaeV2BackendClient`.
- Add `detailedErrorMessage` (and helper `firstApplicationFrame`) to `NichoCnaeV2BackendClient` and use it in `fail(...)` so callbacks include `reasonCode`, `stage`, `stageExecutionId`, `jobId`, `cnaeCode`, the exception class/message, the first application frame and the full stack trace.
- Propagate `cnaeDescription` into processor input via `NichoCnaeV2PendingExecutionService#inputFor` and update `CandidateGeneratorProcessor` to use `cnaeDescription` (when present) to build more meaningful `operationalContext` for generated neutral candidates instead of `CNAE <code>`.
- Update and add unit tests to cover the new behavior and error formatting, and update docs to record the change in operational contract.

### Testing
- Ran unit tests including `BackendCandidateGeneratorServiceTest` (updated to assert `cnaeDescription`), `NichoCnaeV2BackendClientTest` (new test validating failure detail contains failure point and stack trace), `NichoCnaeV2PendingExecutionServiceTest` (updated to include `cnaeDescription` in pending), and `CandidateGeneratorProcessorTest` (updated to assert description propagation); all tests passed locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a35d442e574832192ba0b09b0e8d1b4)