### PR TITLE
Traduz nomes das etapas do pipeline NichoCNAE v2 no frontend

### DIFF
--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -1152,3 +1152,8 @@
 
 - Atualizados os rótulos exibidos no frontend para apresentar as etapas do pipeline NichoCNAE v2 em português, mantendo os códigos técnicos internos sem alteração.
 - Ajustado o teste de navegação do OPRM para validar os novos nomes visíveis ao usuário.
+
+## 2026-06-20 — Tradução dos nomes das etapas na tela NichoCNAE v2
+
+- Ajustada a tela `/oprm/cnaes/:cnaeCode/pipeline-v2` para exibir em português os nomes das etapas da v2 também quando o backend retorna nomes operacionais em inglês nos jobs abertos/concluídos.
+- Incluído teste de frontend garantindo que `Source Safety Filter` seja apresentado como `Filtro de Segurança das Fontes`, evitando recorrência de rótulo técnico exposto ao usuário.

--- a/frontend/src/__tests__/OprmNavigation.test.tsx
+++ b/frontend/src/__tests__/OprmNavigation.test.tsx
@@ -1,7 +1,8 @@
 import { render, screen, cleanup } from "@testing-library/react";
 import { MemoryRouter } from "react-router-dom";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { afterEach, describe, expect, it } from "vitest";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { formatStage } from "../pages/oprm/OprmNichoCnaeV2PipelinePage";
 import React from "react";
 import App from "../App";
 
@@ -16,6 +17,7 @@ function setup(ui: React.ReactNode, initialEntries: string[]) {
 
 afterEach(() => {
   cleanup();
+  vi.restoreAllMocks();
 });
 
 describe("OPRM navigation", () => {
@@ -60,6 +62,13 @@ describe("OPRM navigation", () => {
       screen.getByRole("button", { name: /iniciar novo job v2/i }),
     ).toBeTruthy();
     expect(screen.getByText(/^Acumulador de Conhecimento$/)).toBeTruthy();
+  });
+
+  it("translates v2 job stage names returned in English", () => {
+    expect(formatStage("Source Safety Filter")).toBe(
+      "Filtro de Segurança das Fontes",
+    );
+    expect(formatStage("Candidate Generator")).toBe("Gerador de Candidatos");
   });
 
   it("redirects obsolete /oprm/pipeline route to CNAE niche creation flow", () => {

--- a/frontend/src/pages/oprm/OprmNichoCnaeV2PipelinePage.tsx
+++ b/frontend/src/pages/oprm/OprmNichoCnaeV2PipelinePage.tsx
@@ -9,22 +9,40 @@ import OprmModuleNavigation from "./OprmModuleNavigation";
 
 const stageLabels: Record<string, string> = {
   "candidate-generator": "Gerador de Candidatos",
+  "candidate generator": "Gerador de Candidatos",
   "source-safety-filter": "Filtro de Segurança das Fontes",
+  "source safety filter": "Filtro de Segurança das Fontes",
   "adaptive-query-planner": "Planejador Adaptativo de Buscas",
+  "adaptive query planner": "Planejador Adaptativo de Buscas",
   "candidate-tournament": "Torneio de Candidatos",
+  "candidate tournament": "Torneio de Candidatos",
   "source-fetcher-reranker": "Coletor e Reordenador de Fontes",
+  "source fetcher reranker": "Coletor e Reordenador de Fontes",
   "signal-extractor": "Extrator de Sinais",
+  "signal extractor": "Extrator de Sinais",
   "semantic-judge-entailment": "Juiz Semântico e Validação de Evidência",
+  "semantic judge entailment": "Juiz Semântico e Validação de Evidência",
   "knowledge-accumulator": "Acumulador de Conhecimento",
+  "knowledge accumulator": "Acumulador de Conhecimento",
   "reprocess-controller": "Controlador de Reprocessamento",
+  "reprocess controller": "Controlador de Reprocessamento",
   "routine-synthesizer": "Sintetizador de Rotina",
+  "routine synthesizer": "Sintetizador de Rotina",
   "commercial-evidence-gate": "Gate de Nível de Evidência E0–E5",
+  "commercial evidence gate": "Gate de Nível de Evidência E0–E5",
   "enriched-niche-materializer": "Materializador de Nicho Enriquecido",
+  "enriched niche materializer": "Materializador de Nicho Enriquecido",
 };
 
-function formatStage(stageCode: string | null | undefined) {
-  if (!stageCode) return "Sem etapa aberta";
-  return stageLabels[stageCode] ?? stageCode;
+export function formatStage(stageCode: string | null | undefined) {
+  const normalizedStageCode = stageCode?.trim().toLowerCase();
+  if (!normalizedStageCode) return "Sem etapa aberta";
+  const slugStageCode = normalizedStageCode.replace(/[_\s]+/g, "-");
+  return (
+    stageLabels[normalizedStageCode] ??
+    stageLabels[slugStageCode] ??
+    stageCode
+  );
 }
 
 function formatDateTime(value: string | null | undefined) {


### PR DESCRIPTION
### Motivation
- Garantir que os nomes das etapas exibidos ao usuário fiquem em português mesmo quando o backend retorna códigos ou nomes operacionais em inglês. 
- Evitar que variações de formato (maiusculas/minusculas, espaços, underscores, hífens) causem exposição de rótulos técnicos ao usuário. 
- Tornar a mapeamento de rótulos mais robusto para prevenir regressões visuais na tela do pipeline v2.

### Description
- Adicionada tabela de traduções `stageLabels` com entradas extras para variantes em inglês e normalizadas em `frontend/src/pages/oprm/OprmNichoCnaeV2PipelinePage.tsx`. 
- Criada e exportada a função `formatStage(stageCode)` que normaliza o código da etapa (`trim`, `toLowerCase`, transformar espaços/underscores em `-`) e resolve o rótulo em português usando `stageLabels`, caindo para o valor original quando não houver mapeamento. 
- Atualizado teste de frontend `frontend/src/__tests__/OprmNavigation.test.tsx` para incluir verificação direta de `formatStage` e adicionar `vi.restoreAllMocks()` no `afterEach`. 
- Registrado o trabalho em `docs/registros/oprm1.md` para rastreabilidade do ajuste de UI.

### Testing
- Executado o teste de frontend com `npm test -- --run src/__tests__/OprmNavigation.test.tsx`, que passou (9 tests). 
- Executado `npm run typecheck` (`tsc --noEmit`) sem erros. 
- Executado `npm run build` (Vite) com sucesso e artefatos gerados sem erro de build.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a35dd8f51d483219a709a676561709e)