### PR TITLE
Corrige dossiê MOIS com fontes genéricas

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/mois/bibliotecapaginavenda/worker/v1/jdbc/MoisSalesPageMarketWarmupRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/mois/bibliotecapaginavenda/worker/v1/jdbc/MoisSalesPageMarketWarmupRepository.java
@@ -38,7 +38,9 @@ public class MoisSalesPageMarketWarmupRepository implements MoisSalesPageMarketW
     @Override
     public Optional<SalesPageWarmupData> findSalesPage(long pageId) {
         List<SalesPageWarmupData> rows = jdbcTemplate.query("""
-                SELECT sp.id, sp.workspace_id, sp.url_canonical, sp.title, cr.producer_name,
+                SELECT sp.id, sp.workspace_id, sp.url_canonical,
+                       COALESCE(NULLIF(sp.product_name, ''), NULLIF(cr.product_name, ''), sp.title) AS title,
+                       COALESCE(NULLIF(cr.hotmart_producer, ''), NULLIF(cr.producer_name, '')) AS producer_name,
                        sp.current_status, sp.analysis_status,
                        sp.offer_summary, sp.mechanism_summary, sp.promise_summary, sp.proof_summary
                 FROM mois_sales_page sp
@@ -108,7 +110,10 @@ public class MoisSalesPageMarketWarmupRepository implements MoisSalesPageMarketW
     public Optional<MarketWarmupClaimData> findNextPendingJob(String workspaceId) {
         List<MarketWarmupClaimData> rows = jdbcTemplate.query("""
                 SELECT j.id AS job_id, j.sales_page_id, j.workspace_id, j.status, j.created_at, j.error_category, j.error_message,
-                       sp.url_canonical, sp.title, cr.producer_name, sp.current_status, sp.analysis_status,
+                       sp.url_canonical,
+                       COALESCE(NULLIF(sp.product_name, ''), NULLIF(cr.product_name, ''), sp.title) AS title,
+                       COALESCE(NULLIF(cr.hotmart_producer, ''), NULLIF(cr.producer_name, '')) AS producer_name,
+                       sp.current_status, sp.analysis_status,
                        sp.offer_summary, sp.mechanism_summary, sp.promise_summary, sp.proof_summary
                 FROM mois_sales_page_market_warmup_job j
                 JOIN mois_sales_page sp ON sp.id = j.sales_page_id

--- a/docs/registros/mois1.md
+++ b/docs/registros/mois1.md
@@ -1716,3 +1716,13 @@ Arquivos principais:
 - Corrigida a causa-raiz de dossiês fracos quando o produto possui nome ambíguo: a etapa de aquecimento agora usa uma camada de planejamento de queries com OpenAI quando houver chave configurada, preservando fallback heurístico quando a integração não estiver disponível.
 - As buscas passam a priorizar produtor, domínio da página, título/subtítulo, redes sociais, reviews, afiliados, prova social e canais de aquisição antes de concluir o dossiê.
 - Adicionados testes para impedir que produtos ambíguos voltem a gerar pesquisas genéricas por termos soltos sem domínio ou contexto comercial.
+
+## 2026-06-20 — Correção de dossiê MOIS com fontes genéricas
+- diagnosticado o dossiê vazio/sem informação do produto 262: o backend entregava ao worker apenas `producer_name` legado e título fraco quando existiam fatos Hotmart mais específicos, e o worker aceitava resultados web genéricos por palavras soltas do título como "revolução".
+- corrigida a causa-raiz em duas camadas: o claim do dossiê passa a priorizar `product_name` e `hotmart_producer`, e o worker bloqueia fontes públicas que não contenham âncora mínima de produtor ou semelhança suficiente com o produto.
+- adicionado teste de regressão para impedir que resultados genéricos como dicionário/história sejam persistidos como dossiê comercial.
+
+Arquivos principais:
+- `backend/ads-service/src/main/java/com/marketinghub/repository/jpa/mois/bibliotecapaginavenda/worker/v1/jdbc/MoisSalesPageMarketWarmupRepository.java`
+- `mois-sales-library-worker/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/marketwarmup/MarketWarmupProcessor.java`
+- `mois-sales-library-worker/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/marketwarmup/MarketWarmupProcessorTest.java`

--- a/mois-sales-library-worker/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/marketwarmup/MarketWarmupProcessor.java
+++ b/mois-sales-library-worker/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/marketwarmup/MarketWarmupProcessor.java
@@ -88,22 +88,30 @@ public class MarketWarmupProcessor {
         productTokens.addAll(meaningfulTokens(job.promiseSummary()));
         productTokens.addAll(meaningfulTokens(job.mechanismSummary()));
         productTokens.addAll(meaningfulTokens(job.offerSummary()));
+        List<String> requiredProducerTokens = producerTokens.isEmpty() ? List.of() : List.of(producerTokens.getFirst());
         List<PublicSearchResult> qualified = new ArrayList<>();
         for (PublicSearchResult result : results) {
             MarketWarmupPlatform platform = detectPlatform(result.url());
-            if (!isProducerSocialPlatform(platform)) {
+            String text = normalizedComparableText(result.title() + " " + result.snippet() + " " + result.url());
+            if (!isProducerSocialPlatform(platform) && containsQualifiedCommercialContext(text, requiredProducerTokens, productTokens)) {
                 qualified.add(result);
                 continue;
             }
-            String text = normalizedComparableText(result.title() + " " + result.snippet() + " " + result.url());
             if (containsAllTokens(text, producerTokens) && containsEnoughProductSimilarity(text, productTokens)) {
                 qualified.add(result);
             } else {
-                log.info("MOIS market-warmup producer social source ignored. jobId={}, pageId={}, platform={}, url={}",
+                log.info("MOIS market-warmup source ignored because it does not match the product dossier anchors. jobId={}, pageId={}, platform={}, url={}",
                         job.jobId(), job.pageId(), platform, result.url());
             }
         }
         return qualified;
+    }
+
+    /**
+     * Exige contexto comercial mínimo em fontes web para impedir que palavras genéricas do título virem dossiê falso.
+     */
+    private boolean containsQualifiedCommercialContext(String text, List<String> producerTokens, Set<String> productTokens) {
+        return containsAllTokens(text, producerTokens) || containsEnoughProductSimilarity(text, productTokens);
     }
 
     /**

--- a/mois-sales-library-worker/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/marketwarmup/MarketWarmupProcessorTest.java
+++ b/mois-sales-library-worker/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/marketwarmup/MarketWarmupProcessorTest.java
@@ -1,6 +1,7 @@
 package com.marketinghub.mois.bibliotecapaginavenda.worker.v1.marketwarmup;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.marketinghub.mois.bibliotecapaginavenda.worker.v1.model.WorkerDtos.MarketWarmupClaimedJob;
 import com.marketinghub.mois.bibliotecapaginavenda.worker.v1.model.WorkerDtos.MarketWarmupPlatform;
@@ -70,6 +71,29 @@ class MarketWarmupProcessorTest {
     }
 
     /**
+     * Garante que resultados genéricos por palavra solta do título não sejam persistidos como dossiê vazio.
+     */
+    @Test
+    void shouldRejectGenericWebResultsThatDoNotMatchProductAnchors() {
+        MarketWarmupProcessor processor = new MarketWarmupProcessor(new MarketWarmupQueryBuilder(), new FallbackQueryPlanner(), new GenericSearchClient());
+        MarketWarmupClaimedJob job = new MarketWarmupClaimedJob(
+                9L,
+                90L,
+                "workspace-001",
+                "https://hotmart.com/pt-br/marketplace/produtos/protocolo-iodo",
+                "A REVOLUÇÃO DO IODO",
+                "Fernanda Geribello Anders",
+                null,
+                null,
+                null,
+                null);
+
+        assertThatThrownBy(() -> processor.process(job, 4))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("Busca pública não retornou fontes rastreáveis");
+    }
+
+    /**
      * Simula uma fonte pública sem dependência de rede para manter o teste determinístico.
      */
     private static class FakeSearchClient implements PublicWebSearchClient {
@@ -110,6 +134,21 @@ class MarketWarmupProcessorTest {
                     new PublicSearchResult("Thiago Bechara dos Santos | Peptídeos", "https://www.instagram.com/thiagobechara.peptideos", "Conteúdo sobre certificação avançada em peptídeos, protocolo seguro, prescrição clínica e depoimentos de profissionais.", "<div>raw</div>"),
                     new PublicSearchResult("Thiago Bechara dos Santos músico", "https://www.instagram.com/thiagobechara.musica", "Agenda de shows, violão e bastidores de música autoral.", "<div>raw</div>"),
                     new PublicSearchResult("Thiago Peptídeos", "https://www.youtube.com/@outrothiagopeptideos", "Canal sobre peptídeos sem relação com Thiago Bechara dos Santos.", "<div>raw</div>"));
+        }
+    }
+
+    /**
+     * Simula resultados públicos genéricos que mencionam apenas uma palavra ampla do título.
+     */
+    private static class GenericSearchClient implements PublicWebSearchClient {
+        /**
+         * Retorna fontes sem produtor e sem semelhança suficiente com o produto.
+         */
+        @Override
+        public List<PublicSearchResult> search(String query, int limit) throws IOException {
+            return List.of(
+                    new PublicSearchResult("Revolução Francesa: resumo", "https://www.todamateria.com.br/revolucao-francesa/", "Texto escolar sobre a Revolução Francesa.", "<div>raw</div>"),
+                    new PublicSearchResult("O que é revolução", "https://www.dicio.com.br/revolucao/", "Significado de revolução no dicionário.", "<div>raw</div>"));
         }
     }
 }


### PR DESCRIPTION
### Motivation
- Corrigir dossiê vazio/sem informação gerado quando o backend entregava nome/título legado ao worker e o worker aceitava resultados públicos genéricos por palavras soltas do título. 
- Evitar que páginas genéricas (ex.: dicionário, resumos históricos) sejam persistidas como dossiê comercial sem evidência mínima de produtor ou similaridade com o produto.

### Description
- Prioriza campos Hotmart ao montar o claim da página: `COALESCE(NULLIF(sp.product_name, ''), NULLIF(cr.product_name, ''), sp.title)` e `COALESCE(NULLIF(cr.hotmart_producer, ''), NULLIF(cr.producer_name, ''))` no SQL de `findSalesPage` e `findNextPendingJob` em `MoisSalesPageMarketWarmupRepository.java`.
- Bloqueio no worker de fontes públicas sem âncora comercial: adicionada lógica `containsQualifiedCommercialContext` e uso de `requiredProducerTokens` na filtragem de resultados em `MarketWarmupProcessor.java` para exigir âncora mínima do produtor ou similaridade suficiente com o produto.
- Mensagem de log ajustada para clareza e adicionado teste de regressão `shouldRejectGenericWebResultsThatDoNotMatchProductAnchors` que simula buscas genéricas e valida que o processamento lança `IllegalStateException` em `MarketWarmupProcessorTest.java`.
- Atualização do registro operacional em `docs/registros/mois1.md` descrevendo a causa-raiz e as mudanças aplicadas.

### Testing
- Executado `mvn test -Dtest=MarketWarmupProcessorTest` no módulo `mois-sales-library-worker` e todos os testes passaram (3 tests, 0 failures). 
- Executado `../mvnw -DskipTests compile` no módulo `backend/ads-service` e a compilação ocorreu com sucesso. 
- Executado `git diff --check` e não foram encontrados problemas de whitespace ou checks; todas as alterações foram commitadas.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a360322e5448321965e07e5a35c3360)