### PR TITLE
AI-powered generation of experiment promise options (backend + frontend)

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentPromiseGenerationService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentPromiseGenerationService.java
@@ -1,0 +1,221 @@
+package com.marketinghub.experiment.service;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marketinghub.ai.generation.dto.AiWorkerGenerationRequest;
+import com.marketinghub.ai.generation.service.AiWorkerGenerationService;
+import com.marketinghub.experiment.service.generatepromise.ExperimentPromiseOptionDto;
+import com.marketinghub.experiment.service.generatepromise.GenerateExperimentPromiseOptionsRequest;
+import com.marketinghub.experiment.service.generatepromise.GenerateExperimentPromiseOptionsResponse;
+import com.marketinghub.hypothesis.Hypothesis;
+import com.marketinghub.niche.MarketNiche;
+import com.marketinghub.openai.OpenAiBatchClient;
+import com.marketinghub.openai.OpenAiResponse;
+import com.marketinghub.openai.service.OpenAiPricingService;
+import com.marketinghub.repository.jpa.hypothesis.HypothesisRepository;
+import com.marketinghub.repository.jpa.niche.MarketNicheRepository;
+import java.math.BigDecimal;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.http.HttpStatus;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+import org.springframework.web.server.ResponseStatusException;
+
+/** Responsabilidade: gerar opções de contrato de promessa única para novos experimentos com apoio da IA. */
+@Service
+public class ExperimentPromiseGenerationService {
+    private static final Logger log = LoggerFactory.getLogger(ExperimentPromiseGenerationService.class);
+    private static final String MODEL = "gpt-5.2";
+
+    private final MarketNicheRepository nicheRepository;
+    private final HypothesisRepository hypothesisRepository;
+    private final OpenAiBatchClient openAiBatchClient;
+    private final ObjectMapper objectMapper;
+    private final AiWorkerGenerationService generationService;
+    private final OpenAiPricingService pricingService;
+
+    /** Inicializa o serviço com repositórios, cliente OpenAI e auditoria de gerações. */
+    public ExperimentPromiseGenerationService(MarketNicheRepository nicheRepository,
+                                              HypothesisRepository hypothesisRepository,
+                                              OpenAiBatchClient openAiBatchClient,
+                                              ObjectMapper objectMapper,
+                                              AiWorkerGenerationService generationService,
+                                              OpenAiPricingService pricingService) {
+        this.nicheRepository = nicheRepository;
+        this.hypothesisRepository = hypothesisRepository;
+        this.openAiBatchClient = openAiBatchClient;
+        this.objectMapper = objectMapper;
+        this.generationService = generationService;
+        this.pricingService = pricingService;
+    }
+
+    /** Gera três opções completas para preencher o contrato de promessa única do experimento. */
+    @Transactional(readOnly = true)
+    public GenerateExperimentPromiseOptionsResponse generate(GenerateExperimentPromiseOptionsRequest request) {
+        if (request == null || request.nicheId() == null) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Selecione um nicho antes de gerar com IA.");
+        }
+        MarketNiche niche = nicheRepository.findById(request.nicheId())
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Nicho não encontrado"));
+        Hypothesis hypothesis = resolveHypothesis(request.hypothesisId());
+        String prompt = buildPrompt(request, niche, hypothesis);
+        Map<String, Object> body = buildOpenAiRequest(prompt);
+        try {
+            OpenAiResponse response = openAiBatchClient.executeSingle(body, "experiment-promise-" + UUID.randomUUID());
+            String content = response.firstText();
+            if (!StringUtils.hasText(content)) {
+                throw new ResponseStatusException(HttpStatus.BAD_GATEWAY, "A IA não retornou opções de promessa.");
+            }
+            GenerateExperimentPromiseOptionsResponse parsed = sanitize(objectMapper.readValue(content, GenerateExperimentPromiseOptionsResponse.class));
+            recordGeneration(request, prompt, content, response.usage());
+            return parsed;
+        } catch (ResponseStatusException ex) {
+            throw ex;
+        } catch (RuntimeException ex) {
+            log.error("Falha ao gerar contrato de promessa do experimento; operation=experiment-promise-generate nicheId={} hypothesisId={}", request.nicheId(), request.hypothesisId(), ex);
+            throw new ResponseStatusException(HttpStatus.BAD_GATEWAY, "Não foi possível gerar opções com IA.", ex);
+        } catch (Exception ex) {
+            log.error("Falha ao interpretar contrato de promessa do experimento; operation=experiment-promise-parse nicheId={} hypothesisId={}", request.nicheId(), request.hypothesisId(), ex);
+            throw new ResponseStatusException(HttpStatus.BAD_GATEWAY, "Não foi possível interpretar as opções da IA.", ex);
+        }
+    }
+
+    /** Localiza a hipótese opcional usada como contexto da geração. */
+    private Hypothesis resolveHypothesis(UUID hypothesisId) {
+        if (hypothesisId == null) {
+            return null;
+        }
+        return hypothesisRepository.findById(hypothesisId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Hipótese não encontrada"));
+    }
+
+    /** Monta o payload da Responses API com schema estruturado para evitar texto livre. */
+    private Map<String, Object> buildOpenAiRequest(String prompt) {
+        Map<String, Object> body = new LinkedHashMap<>();
+        body.put("model", MODEL);
+        body.put("input", List.of(message("system", systemPrompt()), message("user", prompt)));
+        body.put("max_output_tokens", 1400);
+        Map<String, Object> text = new LinkedHashMap<>();
+        text.put("format", jsonSchemaFormat());
+        body.put("text", text);
+        return body;
+    }
+
+    /** Cria uma mensagem no formato aceito pela Responses API. */
+    private Map<String, Object> message(String role, String content) {
+        Map<String, Object> message = new LinkedHashMap<>();
+        message.put("role", role);
+        message.put("content", content);
+        return message;
+    }
+
+    /** Define as regras comerciais que o modelo deve respeitar na geração. */
+    private String systemPrompt() {
+        return "Você é especialista em marketing de resposta direta para produtos digitais. "
+                + "Gere contratos de promessa única claros, simples e focados em venda via geração de leads. "
+                + "Cada opção deve ter uma única dor, uma recompensa gratuita específica, promessa do funil e CTA coerentes. "
+                + "Não prometa resultados impossíveis, não sugira objetivo de tráfego e mantenha tudo pronto para campanha de Leads.";
+    }
+
+    /** Monta o contexto funcional do nicho, hipótese e campos já digitados na tela. */
+    private String buildPrompt(GenerateExperimentPromiseOptionsRequest request, MarketNiche niche, Hypothesis hypothesis) {
+        StringBuilder sb = new StringBuilder();
+        sb.append("Gere exatamente 3 opções diferentes de contrato de promessa única para um novo experimento.\n");
+        sb.append("Nicho: ").append(niche.getName()).append('\n');
+        appendIfPresent(sb, "Descrição do nicho", niche.getDescription());
+        if (hypothesis != null) {
+            appendIfPresent(sb, "Hipótese selecionada", hypothesis.getTitle());
+            appendIfPresent(sb, "Problema da hipótese", hypothesis.getProblem());
+            appendIfPresent(sb, "Promessa da hipótese", hypothesis.getPromise());
+            appendIfPresent(sb, "Mecanismo", hypothesis.getMechanism());
+            appendIfPresent(sb, "Entrega", hypothesis.getEntrega());
+        } else {
+            appendIfPresent(sb, "Hipótese digitada", request.hypothesis());
+        }
+        appendIfPresent(sb, "Dor atual digitada", request.currentSinglePain());
+        appendIfPresent(sb, "Recompensa atual digitada", request.currentFreeReward());
+        appendIfPresent(sb, "Promessa atual digitada", request.currentFunnelPromise());
+        appendIfPresent(sb, "CTA atual digitado", request.currentPrimaryCta());
+        sb.append("\nAs três opções devem ser distintas: uma direta, uma emocional e uma operacional/prática.");
+        return sb.toString();
+    }
+
+    /** Adiciona ao prompt apenas campos com conteúdo útil. */
+    private void appendIfPresent(StringBuilder sb, String label, String value) {
+        if (StringUtils.hasText(value)) {
+            sb.append(label).append(": ").append(value.trim()).append('\n');
+        }
+    }
+
+    /** Declara o schema JSON esperado do modelo para três opções completas. */
+    private Map<String, Object> jsonSchemaFormat() {
+        Map<String, Object> option = new LinkedHashMap<>();
+        option.put("type", "object");
+        option.put("additionalProperties", false);
+        option.put("required", List.of("singlePain", "freeReward", "funnelPromise", "primaryCta", "reason"));
+        option.put("properties", Map.of(
+                "singlePain", Map.of("type", "string"),
+                "freeReward", Map.of("type", "string"),
+                "funnelPromise", Map.of("type", "string"),
+                "primaryCta", Map.of("type", "string"),
+                "reason", Map.of("type", "string")));
+        Map<String, Object> schema = new LinkedHashMap<>();
+        schema.put("type", "object");
+        schema.put("additionalProperties", false);
+        schema.put("required", List.of("options"));
+        schema.put("properties", Map.of("options", Map.of("type", "array", "minItems", 3, "maxItems", 3, "items", option)));
+        Map<String, Object> format = new LinkedHashMap<>();
+        format.put("type", "json_schema");
+        format.put("name", "experiment_promise_options");
+        format.put("schema", schema);
+        format.put("json_schema", Map.of("name", "experiment_promise_options", "schema", schema));
+        return format;
+    }
+
+    /** Normaliza a resposta para garantir exatamente três opções utilizáveis pela tela. */
+    private GenerateExperimentPromiseOptionsResponse sanitize(GenerateExperimentPromiseOptionsResponse response) {
+        List<ExperimentPromiseOptionDto> options = response == null || response.options() == null
+                ? List.of()
+                : response.options().stream()
+                        .filter(option -> StringUtils.hasText(option.singlePain())
+                                && StringUtils.hasText(option.freeReward())
+                                && StringUtils.hasText(option.funnelPromise())
+                                && StringUtils.hasText(option.primaryCta()))
+                        .limit(3)
+                        .toList();
+        if (options.size() != 3) {
+            throw new ResponseStatusException(HttpStatus.BAD_GATEWAY, "A IA não retornou três opções completas.");
+        }
+        return new GenerateExperimentPromiseOptionsResponse(options);
+    }
+
+    /** Registra a geração para auditoria operacional e acompanhamento de custo. */
+    private void recordGeneration(GenerateExperimentPromiseOptionsRequest request, String prompt, String content, OpenAiResponse.OpenAiUsage usage) {
+        BigDecimal cost = estimateCostSafely(usage);
+        generationService.recordGeneration(AiWorkerGenerationRequest.builder()
+                .domain("experiment.promise-options")
+                .referenceId(String.valueOf(request.nicheId()))
+                .prompt(prompt)
+                .rawResponse(content)
+                .model(MODEL)
+                .inputTokens(usage != null ? usage.effectiveInputTokens() : null)
+                .outputTokens(usage != null ? usage.effectiveOutputTokens() : null)
+                .costUsd(cost)
+                .build());
+    }
+
+    /** Calcula o custo sem bloquear a entrega das opções quando o catálogo financeiro estiver incompleto. */
+    private BigDecimal estimateCostSafely(OpenAiResponse.OpenAiUsage usage) {
+        try {
+            return pricingService.estimateStandardCost(MODEL, usage);
+        } catch (RuntimeException ex) {
+            log.error("Falha ao calcular custo da geração de promessa; operation=experiment-promise-cost model={}", MODEL, ex);
+            return BigDecimal.ZERO;
+        }
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/service/generatepromise/ExperimentPromiseOptionDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/service/generatepromise/ExperimentPromiseOptionDto.java
@@ -1,0 +1,9 @@
+package com.marketinghub.experiment.service.generatepromise;
+
+/** Responsabilidade: transportar uma opção de contrato de promessa única gerada por IA. */
+public record ExperimentPromiseOptionDto(
+        String singlePain,
+        String freeReward,
+        String funnelPromise,
+        String primaryCta,
+        String reason) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/service/generatepromise/GenerateExperimentPromiseOptionsRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/service/generatepromise/GenerateExperimentPromiseOptionsRequest.java
@@ -1,0 +1,13 @@
+package com.marketinghub.experiment.service.generatepromise;
+
+import java.util.UUID;
+
+/** Responsabilidade: receber o contexto usado para sugerir contratos de promessa única do experimento. */
+public record GenerateExperimentPromiseOptionsRequest(
+        Long nicheId,
+        UUID hypothesisId,
+        String hypothesis,
+        String currentSinglePain,
+        String currentFreeReward,
+        String currentFunnelPromise,
+        String currentPrimaryCta) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/service/generatepromise/GenerateExperimentPromiseOptionsResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/service/generatepromise/GenerateExperimentPromiseOptionsResponse.java
@@ -1,0 +1,6 @@
+package com.marketinghub.experiment.service.generatepromise;
+
+import java.util.List;
+
+/** Responsabilidade: transportar as opções de contrato de promessa única sugeridas pela IA. */
+public record GenerateExperimentPromiseOptionsResponse(List<ExperimentPromiseOptionDto> options) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/web/ExperimentController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/web/ExperimentController.java
@@ -10,13 +10,16 @@ import com.marketinghub.experiment.mapper.ExperimentMapper;
 import com.marketinghub.experiment.service.ExperimentDiagnosticsService;
 import com.marketinghub.experiment.service.ExperimentService;
 import com.marketinghub.experiment.service.ExperimentReadinessService;
+import com.marketinghub.experiment.service.ExperimentPromiseGenerationService;
+import com.marketinghub.experiment.service.generatepromise.GenerateExperimentPromiseOptionsRequest;
+import com.marketinghub.experiment.service.generatepromise.GenerateExperimentPromiseOptionsResponse;
 import org.springframework.web.bind.annotation.*;
 
 import java.util.List;
 import java.util.stream.StreamSupport;
 
 /**
- * REST controller for experiments.
+ * Responsabilidade: expor endpoints administrativos para criação, leitura e ações dos experimentos.
  */
 @RestController
 @RequestMapping("/api/experiments")
@@ -25,41 +28,51 @@ public class ExperimentController {
     private final ExperimentMapper mapper;
     private final ExperimentDiagnosticsService diagnosticsService;
     private final ExperimentReadinessService readinessService;
+    private final ExperimentPromiseGenerationService promiseGenerationService;
 
+    /** Inicializa o controller com serviços de experimento, diagnóstico, prontidão e geração de promessas. */
     public ExperimentController(ExperimentService service, ExperimentMapper mapper,
                                 ExperimentDiagnosticsService diagnosticsService,
-                                ExperimentReadinessService readinessService) {
+                                ExperimentReadinessService readinessService,
+                                ExperimentPromiseGenerationService promiseGenerationService) {
         this.service = service;
         this.mapper = mapper;
         this.diagnosticsService = diagnosticsService;
         this.readinessService = readinessService;
+        this.promiseGenerationService = promiseGenerationService;
     }
 
+    /** Cria um novo experimento com os dados comerciais informados na tela. */
     @PostMapping
     public ExperimentDto create(@RequestBody CreateExperimentRequest request) {
         return mapper.toDto(service.create(request));
     }
 
+    /** Duplica um experimento existente preservando seu contrato comercial. */
     @PostMapping("/{id}/duplicate")
     public ExperimentDto duplicate(@PathVariable Long id) {
         return mapper.toDto(service.duplicate(id));
     }
 
+    /** Busca os detalhes de um experimento pelo identificador. */
     @GetMapping("/{id}")
     public ExperimentDto get(@PathVariable Long id) {
         return mapper.toDto(service.get(id));
     }
 
+    /** Retorna diagnósticos operacionais e comerciais do experimento. */
     @GetMapping("/{id}/diagnostics")
     public ExperimentDiagnosticsDto diagnostics(@PathVariable Long id) {
         return diagnosticsService.diagnose(id);
     }
 
+    /** Resume a prontidão do experimento para publicação e execução. */
     @GetMapping("/{id}/readiness")
     public ExperimentReadinessSummaryDto readiness(@PathVariable Long id) {
         return readinessService.summarize(id);
     }
 
+    /** Lista os experimentos cadastrados para acompanhamento administrativo. */
     @GetMapping
     public List<ExperimentDto> list() {
         return StreamSupport.stream(service.list().spliterator(), false)
@@ -67,9 +80,7 @@ public class ExperimentController {
                 .toList();
     }
 
-    /**
-     * Atualiza apenas o status do experimento.
-     */
+    /** Atualiza apenas o status do experimento. */
     @PatchMapping("/{id}/status")
     public ExperimentDto updateStatus(
             @PathVariable Long id,
@@ -77,35 +88,43 @@ public class ExperimentController {
         return mapper.toDto(service.updateStatus(id, status));
     }
 
+    /** Atualiza os campos editáveis de um experimento existente. */
     @RequestMapping(value = "/{id}", method = {RequestMethod.PUT, RequestMethod.PATCH})
     public ExperimentDto update(@PathVariable Long id, @RequestBody UpdateExperimentRequest request) {
         return mapper.toDto(service.update(id, request));
     }
 
+    /** Solicita geração de criativos para o experimento. */
     @PatchMapping("/{id}/creatives-to-generate")
     public ExperimentDto requestCreatives(@PathVariable Long id, @RequestParam("quantity") int quantity) {
         return mapper.toDto(service.requestCreatives(id, quantity));
     }
 
+    /** Solicita geração de anúncios pelo pipeline do experimento. */
     @PostMapping("/{id}/pipeline/ads")
     public ExperimentDto requestPipelineAds(@PathVariable Long id) {
         return mapper.toDto(service.requestPipelineCreatives(id));
     }
 
+    /** Solicita geração de formulários instantâneos para captação de leads. */
     @PatchMapping("/{id}/instant-forms-to-generate")
     public ExperimentDto requestInstantForms(@PathVariable Long id, @RequestParam("quantity") int quantity) {
         return mapper.toDto(service.requestInstantForms(id, quantity));
     }
 
+    /** Solicita geração de e-mails do fluxo do experimento. */
     @PatchMapping("/{id}/emails-to-generate")
     public ExperimentDto requestEmails(@PathVariable Long id, @RequestParam("quantity") int quantity) {
         return mapper.toDto(service.requestEmails(id, quantity));
     }
 
+    /** Solicita geração de e-mails de amostra para o experimento. */
     @PatchMapping("/{id}/sample-emails-to-generate")
     public ExperimentDto requestSampleEmails(@PathVariable Long id, @RequestParam("quantity") int quantity) {
         return mapper.toDto(service.requestSampleEmails(id, quantity));
     }
+
+    /** Define o e-mail de amostra selecionado para uso no experimento. */
     @PutMapping("/{id}/selected-sample-email")
     public ExperimentDto updateSelectedSampleEmail(
             @PathVariable Long id,
@@ -113,19 +132,29 @@ public class ExperimentController {
         return mapper.toDto(service.updateSelectedSampleEmail(id, request.sampleEmailId()));
     }
 
+    /** Solicita geração de entregáveis digitais do experimento. */
     @PatchMapping("/{id}/deliverables-to-generate")
     public ExperimentDto requestDeliverables(@PathVariable Long id, @RequestParam("quantity") int quantity) {
         return mapper.toDto(service.requestDeliverables(id, quantity));
     }
 
+    /** Solicita geração de fluxos do portal do lead. */
     @PatchMapping("/{id}/lead-portal-flows-to-generate")
     public ExperimentDto requestLeadPortalFlows(@PathVariable Long id, @RequestParam("quantity") int quantity) {
         return mapper.toDto(service.requestLeadPortalFlows(id, quantity));
     }
 
+    /** Libera o experimento para publicação no Facebook Ads. */
     @PostMapping("/{id}/facebook-release")
     public ExperimentDto releaseForFacebook(@PathVariable Long id) {
         return mapper.toDto(service.releaseForFacebook(id));
+    }
+
+    /** Gera três opções de contrato de promessa única para o formulário de novo experimento. */
+    @PostMapping("/promise-contract-options/generate")
+    public GenerateExperimentPromiseOptionsResponse generatePromiseOptions(
+            @RequestBody GenerateExperimentPromiseOptionsRequest request) {
+        return promiseGenerationService.generate(request);
     }
 
 }

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/service/ExperimentPromiseGenerationServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/service/ExperimentPromiseGenerationServiceTest.java
@@ -1,0 +1,80 @@
+package com.marketinghub.experiment.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marketinghub.ai.generation.service.AiWorkerGenerationService;
+import com.marketinghub.experiment.service.generatepromise.GenerateExperimentPromiseOptionsRequest;
+import com.marketinghub.niche.MarketNiche;
+import com.marketinghub.openai.OpenAiBatchClient;
+import com.marketinghub.openai.OpenAiResponse;
+import com.marketinghub.openai.service.OpenAiPricingService;
+import com.marketinghub.repository.jpa.hypothesis.HypothesisRepository;
+import com.marketinghub.repository.jpa.niche.MarketNicheRepository;
+import java.math.BigDecimal;
+import java.util.Optional;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.server.ResponseStatusException;
+
+/** Responsabilidade: validar a geração de opções de promessa única para experimentos. */
+@ExtendWith(MockitoExtension.class)
+class ExperimentPromiseGenerationServiceTest {
+    @Mock
+    private MarketNicheRepository nicheRepository;
+    @Mock
+    private HypothesisRepository hypothesisRepository;
+    @Mock
+    private OpenAiBatchClient openAiBatchClient;
+    @Spy
+    private ObjectMapper objectMapper = new ObjectMapper();
+    @Mock
+    private AiWorkerGenerationService generationService;
+    @Mock
+    private OpenAiPricingService pricingService;
+    @InjectMocks
+    private ExperimentPromiseGenerationService service;
+
+    /** Deve bloquear geração sem nicho porque a IA precisa de contexto comercial mínimo. */
+    @Test
+    void shouldRejectRequestWithoutNiche() {
+        assertThatThrownBy(() -> service.generate(new GenerateExperimentPromiseOptionsRequest(
+                null, null, null, null, null, null, null)))
+                .isInstanceOf(ResponseStatusException.class)
+                .hasMessageContaining("Selecione um nicho");
+    }
+
+    /** Deve retornar exatamente três opções completas e registrar a geração para auditoria. */
+    @Test
+    void shouldGenerateThreePromiseOptions() {
+        MarketNiche niche = MarketNiche.builder().id(7L).name("Salões de beleza").build();
+        when(nicheRepository.findById(7L)).thenReturn(Optional.of(niche));
+        when(openAiBatchClient.executeSingle(any(), anyString())).thenReturn(new OpenAiResponse(
+                "resp-1",
+                "{\"options\":["
+                        + "{\"singlePain\":\"Agenda vazia\",\"freeReward\":\"Checklist de reagendamento\",\"funnelPromise\":\"Receber o checklist\",\"primaryCta\":\"Receber checklist\",\"reason\":\"Direta\"},"
+                        + "{\"singlePain\":\"Clientes somem\",\"freeReward\":\"3 mensagens prontas\",\"funnelPromise\":\"Receber as mensagens\",\"primaryCta\":\"Quero as mensagens\",\"reason\":\"Emocional\"},"
+                        + "{\"singlePain\":\"Faltas no horário\",\"freeReward\":\"Roteiro de confirmação\",\"funnelPromise\":\"Receber o roteiro\",\"primaryCta\":\"Usar roteiro\",\"reason\":\"Operacional\"}]} ",
+                null,
+                new OpenAiResponse.OpenAiUsage(10, 20, null, null, 30),
+                null,
+                "completed"));
+        when(pricingService.estimateStandardCost(anyString(), any())).thenReturn(BigDecimal.ZERO);
+
+        var response = service.generate(new GenerateExperimentPromiseOptionsRequest(
+                7L, null, "Hipótese", null, null, null, null));
+
+        assertThat(response.options()).hasSize(3);
+        assertThat(response.options().getFirst().singlePain()).isEqualTo("Agenda vazia");
+        verify(generationService).recordGeneration(any());
+    }
+}

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -4908,3 +4908,9 @@
 - Solicitação: confirmar que a prontidão para campanha Facebook precisa exigir `metaId` oficial nos públicos aprovados.
 - Causa-raiz: o teste `listReadyForCampaignRequiresApprovals` criava públicos aprovados sem `metaId`, mas a regra operacional e a query de fila já bloqueiam publicação ampla exigindo identificador oficial da Meta.
 - Correção aplicada: o teste agora cria públicos aprovados com `metaId`, mantendo o contrato de que a campanha só entra na fila quando existe pelo menos um público publicável pela Meta.
+
+## 2026-06-20 — Geração de contrato de promessa única com IA
+
+- Adicionado fluxo para a tela de novo experimento gerar 3 opções de contrato de promessa única com IA.
+- O backend passa a expor endpoint próprio de experimentos para gerar opções com dor única, recompensa gratuita, promessa do funil e CTA principal.
+- O frontend permite escolher uma das opções geradas e preencher automaticamente o formulário antes de salvar o experimento.

--- a/docs/swagger/openapi.yaml
+++ b/docs/swagger/openapi.yaml
@@ -111,6 +111,23 @@ paths:
       responses:
         '201':
           description: Experimento criado
+  /api/experiments/promise-contract-options/generate:
+    post:
+      tags: [Experiments]
+      summary: Gerar 3 opções de contrato de promessa única com IA
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/GenerateExperimentPromiseOptionsRequest'
+      responses:
+        '200':
+          description: Opções de contrato geradas
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenerateExperimentPromiseOptionsResponse'
   /api/experiments/{id}/duplicate:
     post:
       tags: [Experiments]
@@ -1065,6 +1082,57 @@ components:
         createdAt:
           type: string
           format: date-time
+    GenerateExperimentPromiseOptionsRequest:
+      type: object
+      required:
+        - nicheId
+      properties:
+        nicheId:
+          type: integer
+          format: int64
+        hypothesisId:
+          type: string
+          format: uuid
+        hypothesis:
+          type: string
+        currentSinglePain:
+          type: string
+        currentFreeReward:
+          type: string
+        currentFunnelPromise:
+          type: string
+        currentPrimaryCta:
+          type: string
+    GenerateExperimentPromiseOptionsResponse:
+      type: object
+      required:
+        - options
+      properties:
+        options:
+          type: array
+          minItems: 3
+          maxItems: 3
+          items:
+            $ref: '#/components/schemas/ExperimentPromiseOption'
+    ExperimentPromiseOption:
+      type: object
+      required:
+        - singlePain
+        - freeReward
+        - funnelPromise
+        - primaryCta
+        - reason
+      properties:
+        singlePain:
+          type: string
+        freeReward:
+          type: string
+        funnelPromise:
+          type: string
+        primaryCta:
+          type: string
+        reason:
+          type: string
     CreateExperimentRequest:
       type: object
       required:

--- a/frontend/src/api/experiment/useGeneratePromiseOptions.ts
+++ b/frontend/src/api/experiment/useGeneratePromiseOptions.ts
@@ -1,0 +1,43 @@
+import { useMutation } from "@tanstack/react-query";
+import axios from "axios";
+import { toast } from "react-toastify";
+
+export interface PromiseOption {
+  singlePain: string;
+  freeReward: string;
+  funnelPromise: string;
+  primaryCta: string;
+  reason: string;
+}
+
+interface GeneratePromiseOptionsPayload {
+  nicheId: number;
+  hypothesisId?: string;
+  hypothesis?: string;
+  currentSinglePain?: string;
+  currentFreeReward?: string;
+  currentFunnelPromise?: string;
+  currentPrimaryCta?: string;
+}
+
+interface GeneratePromiseOptionsResponse {
+  options: PromiseOption[];
+}
+
+export function useGeneratePromiseOptions() {
+  return useMutation({
+    mutationFn: async (payload: GeneratePromiseOptionsPayload) => {
+      const { data } = await axios.post<GeneratePromiseOptionsResponse>(
+        "/api/experiments/promise-contract-options/generate",
+        payload,
+      );
+      return data.options;
+    },
+    onSuccess: () => {
+      toast.success("IA gerou 3 opções de promessa");
+    },
+    onError: () => {
+      toast.error("Não foi possível gerar opções com IA");
+    },
+  });
+}

--- a/frontend/src/pages/experiment/NewExperimentPage.tsx
+++ b/frontend/src/pages/experiment/NewExperimentPage.tsx
@@ -1,6 +1,8 @@
 import { useEffect, useState } from "react";
 import { useSearchParams } from "react-router-dom";
 import { useCreateExperiment } from "../../api/experiment/useCreateExperiment";
+import { useGeneratePromiseOptions } from "../../api/experiment/useGeneratePromiseOptions";
+import type { PromiseOption } from "../../api/experiment/useGeneratePromiseOptions";
 import { useImageGenerationModels } from "../../api/ai/useImageGenerationModels";
 import { useNiches } from "../../api/niche/useNiches";
 import { useHypothesesByNiche } from "../../api/hypothesis/useHypothesesByNiche";
@@ -47,6 +49,7 @@ export default function NewExperimentPage() {
   const nicheIdParam = params.get("nicheId") ?? "";
   const hypothesisIdParam = params.get("hypothesisId") ?? "";
   const create = useCreateExperiment();
+  const generatePromiseOptions = useGeneratePromiseOptions();
   const { data: niches } = useNiches();
   const [form, setForm] = useState<FormState>({
     nicheId: nicheIdParam,
@@ -79,6 +82,7 @@ export default function NewExperimentPage() {
     primaryCta: "Receber as 3 mensagens",
   });
   const [autoSampleSize, setAutoSampleSize] = useState(true);
+  const [promiseOptions, setPromiseOptions] = useState<PromiseOption[]>([]);
   const [autoMde, setAutoMde] = useState(true);
   const { data: hypotheses } = useHypothesesByNiche(form.nicheId);
   const { data: selectedHypothesis } = useHypothesis(
@@ -136,6 +140,33 @@ export default function NewExperimentPage() {
       return changed ? next : prev;
     });
   }, [autoSampleSize, autoMde, form.dailyBudget]);
+
+  const handleGeneratePromiseOptions = async () => {
+    if (!form.nicheId) {
+      alert("Selecione um nicho antes de gerar com IA");
+      return;
+    }
+    const options = await generatePromiseOptions.mutateAsync({
+      nicheId: Number(form.nicheId),
+      hypothesisId: form.hypothesisId || undefined,
+      hypothesis: form.hypothesis || undefined,
+      currentSinglePain: form.singlePain || undefined,
+      currentFreeReward: form.freeReward || undefined,
+      currentFunnelPromise: form.funnelPromise || undefined,
+      currentPrimaryCta: form.primaryCta || undefined,
+    });
+    setPromiseOptions(options);
+  };
+
+  const applyPromiseOption = (option: PromiseOption) => {
+    setForm((prev) => ({
+      ...prev,
+      singlePain: option.singlePain,
+      freeReward: option.freeReward,
+      funnelPromise: option.funnelPromise,
+      primaryCta: option.primaryCta,
+    }));
+  };
 
   const submit = async () => {
     try {
@@ -336,11 +367,71 @@ export default function NewExperimentPage() {
       />
       <div className="card border-primary mb-3">
         <div className="card-body">
-          <h2 className="h6">Contrato de promessa única</h2>
-          <p className="text-muted small mb-3">
-            Use uma dor, uma recompensa gratuita e um CTA iguais no anúncio,
-            botão, formulário e entrega.
-          </p>
+          <div className="d-flex flex-column flex-md-row align-items-md-start justify-content-between gap-2 mb-3">
+            <div>
+              <h2 className="h6">Contrato de promessa única</h2>
+              <p className="text-muted small mb-0">
+                Use uma dor, uma recompensa gratuita e um CTA iguais no anúncio,
+                botão, formulário e entrega.
+              </p>
+            </div>
+            <button
+              type="button"
+              className="btn btn-outline-primary btn-sm"
+              disabled={generatePromiseOptions.isPending}
+              onClick={handleGeneratePromiseOptions}
+            >
+              {generatePromiseOptions.isPending ? (
+                <span className="d-inline-flex align-items-center gap-1">
+                  <span
+                    className="spinner-border spinner-border-sm"
+                    aria-hidden="true"
+                  />
+                  Gerando...
+                </span>
+              ) : (
+                "Gerar 3 opções com IA"
+              )}
+            </button>
+          </div>
+          {promiseOptions.length > 0 && (
+            <div className="row g-2 mb-3">
+              {promiseOptions.map((option, index) => (
+                <div
+                  className="col-12 col-lg-4"
+                  key={`${option.singlePain}-${index}`}
+                >
+                  <div className="card h-100 border-info">
+                    <div className="card-body p-3">
+                      <h3 className="h6">Opção {index + 1}</h3>
+                      <p className="small mb-1">
+                        <strong>Dor:</strong> {option.singlePain}
+                      </p>
+                      <p className="small mb-1">
+                        <strong>Recompensa:</strong> {option.freeReward}
+                      </p>
+                      <p className="small mb-1">
+                        <strong>Promessa:</strong> {option.funnelPromise}
+                      </p>
+                      <p className="small mb-1">
+                        <strong>CTA:</strong> {option.primaryCta}
+                      </p>
+                      {option.reason && (
+                        <p className="text-muted small mb-2">{option.reason}</p>
+                      )}
+                      <button
+                        type="button"
+                        className="btn btn-primary btn-sm"
+                        onClick={() => applyPromiseOption(option)}
+                      >
+                        Usar esta opção
+                      </button>
+                    </div>
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
           <label className="form-label" htmlFor="singlePain">
             Dor única <span className="text-danger">*</span>
           </label>


### PR DESCRIPTION
### Motivation
- Provide a fast way for users to generate three alternative "single-promise" contracts for new experiments using an LLM to speed form filling and ideation. 
- Keep generated options structured and auditable to be consumable by the UI and track cost/usage. 
- Surface the feature in the new-experiment UI so users can pick a generated option and populate form fields.

### Description
- Added `ExperimentPromiseGenerationService` which calls the Responses API (`gpt-5.2`) with a JSON schema format, sanitizes the output to exactly three complete options, and records generation via `AiWorkerGenerationService` and `OpenAiPricingService`.
- Introduced DTO/record types `GenerateExperimentPromiseOptionsRequest`, `GenerateExperimentPromiseOptionsResponse`, and `ExperimentPromiseOptionDto` for typed request/response handling and added the controller endpoint `POST /api/experiments/promise-contract-options/generate` wired in `ExperimentController`.
- Updated API docs (`openapi.yaml`) and release notes, added unit tests `ExperimentPromiseGenerationServiceTest`, and implemented frontend support: the `useGeneratePromiseOptions` hook and UI controls in `NewExperimentPage.tsx` to request, display, and apply generated options.

### Testing
- Added `ExperimentPromiseGenerationServiceTest` with cases for missing niche rejection and successful three-option generation, and the test suite for the new service passed locally.
- Verified the backend endpoint compiles and the new Swagger definitions were generated for `GenerateExperimentPromiseOptionsRequest` and `GenerateExperimentPromiseOptionsResponse` during build-time checks.
- Exercised the frontend hook `useGeneratePromiseOptions` in the browser manually and verified the UI shows the loading state, displays options, and correctly applies a chosen option to the form (automated UI tests were not added).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a36a9b21d48832192afa482a604358a)