### PR TITLE
Expose final decision and AI cost in CNAE job summaries (backend, frontend, docs, tests)

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/candidategenerator/service/BackendCandidateGeneratorService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/candidategenerator/service/BackendCandidateGeneratorService.java
@@ -1,5 +1,8 @@
 package com.marketinghub.oprm.nichocnae.v2.candidategenerator.service;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marketinghub.oprm.cnae.OprmNicheCandidate;
 import com.marketinghub.oprm.nichocnae.v2.OprmNichoCnaeV2FailureType;
 import com.marketinghub.oprm.nichocnae.v2.OprmNichoCnaeV2StageExecution;
@@ -14,12 +17,14 @@ import com.marketinghub.oprm.nichocnae.v2.candidategenerator.service.listCnaeJob
 import com.marketinghub.oprm.nichocnae.v2.candidategenerator.service.pending.CandidateGeneratorPendingResponse;
 import com.marketinghub.repository.jpa.oprm.cnae.OprmNicheCandidateRepository;
 import com.marketinghub.repository.jpa.oprm.nichocnae.v2.OprmNichoCnaeV2StageExecutionRepository;
+import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
@@ -31,6 +36,23 @@ import org.springframework.web.server.ResponseStatusException;
 @Service
 public class BackendCandidateGeneratorService {
     private static final String STAGE_CODE = "candidate-generator";
+    private static final ObjectMapper OBJECT_MAPPER = new ObjectMapper();
+    private static final TypeReference<Map<String, Object>> MAP_TYPE = new TypeReference<>() {};
+    private static final List<String> DECISION_KEYS = List.of(
+            "tournamentDecision",
+            "gateDecision",
+            "materializationDecision",
+            "sourceFetchDecision",
+            "planDecision",
+            "safetyDecision",
+            "qualityStatus",
+            "decision");
+    private static final List<String> COST_KEYS = List.of(
+            "aiCostUsd",
+            "totalAiCostUsd",
+            "estimatedAiCostUsd",
+            "costUsd",
+            "estimatedCostUsd");
 
     private final OprmNicheCandidateRepository nicheCandidateRepository;
     private final OprmNichoCnaeV2StageExecutionRepository stageExecutionRepository;
@@ -112,7 +134,12 @@ public class BackendCandidateGeneratorService {
                 .reversed();
         openJobs.sort(newestFirst);
         completedJobs.sort(newestFirst);
-        return new CandidateGeneratorCnaeJobsResponse(cnaeCode, openJobs, completedJobs);
+        BigDecimal cnaeAiCostUsd = executionsByJob.values().stream()
+                .map(this::sumAiCostUsd)
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+        boolean cnaeUsedAi = cnaeAiCostUsd.compareTo(BigDecimal.ZERO) > 0
+                || executionsByJob.values().stream().flatMap(List::stream).anyMatch(this::hasAiUsageSignal);
+        return new CandidateGeneratorCnaeJobsResponse(cnaeCode, cnaeAiCostUsd, cnaeUsedAi, openJobs, completedJobs);
     }
 
     /** Registra conclusão da etapa persistindo a próxima etapa informada pelo executor externo. */
@@ -176,6 +203,10 @@ public class BackendCandidateGeneratorService {
                 .max(Comparator.comparing(OprmNichoCnaeV2StageExecution::getUpdatedAt, Comparator.nullsLast(Comparator.naturalOrder())))
                 .orElse(lastExecution);
         String jobStatus = hasOpenExecution(executions) ? "OPEN" : "COMPLETED";
+        Map<String, Object> lastOutput = parsePayload(lastExecution.getOutputPayload());
+        String finalDecision = decisionFrom(lastOutput, lastExecution);
+        BigDecimal aiCostUsd = sumAiCostUsd(executions);
+        boolean usedAi = aiCostUsd.compareTo(BigDecimal.ZERO) > 0 || executions.stream().anyMatch(this::hasAiUsageSignal);
         return new CandidateGeneratorCnaeJobSummary(
                 lastExecution.getJobId(),
                 lastExecution.getCnaeCode(),
@@ -187,8 +218,157 @@ public class BackendCandidateGeneratorService {
                 currentExecution.getTechnicalRetryNumber(),
                 currentExecution.getKnowledgeVersion(),
                 currentExecution.getMaterializationEnabled(),
+                finalDecision,
+                labelForDecision(finalDecision, lastExecution),
+                reasonForDecision(finalDecision, lastOutput, lastExecution),
+                usedAi,
+                aiCostUsd,
                 executions.stream().map(OprmNichoCnaeV2StageExecution::getCreatedAt).min(Comparator.naturalOrder()).orElse(null),
                 lastExecution.getUpdatedAt());
+    }
+
+    /** Extrai a decisão funcional persistida no output da última etapa para evitar conclusão sem explicação ao usuário. */
+    private String decisionFrom(Map<String, Object> output, OprmNichoCnaeV2StageExecution lastExecution) {
+        return DECISION_KEYS.stream()
+                .map(output::get)
+                .filter(Objects::nonNull)
+                .map(String::valueOf)
+                .filter(value -> !value.isBlank())
+                .findFirst()
+                .orElseGet(() -> lastExecution.getFailureType() == null
+                        ? lastExecution.getStatus().name()
+                        : lastExecution.getFailureType().name());
+    }
+
+    /** Traduz decisões funcionais críticas em rótulos claros de negócio para a tela administrativa. */
+    private String labelForDecision(String decision, OprmNichoCnaeV2StageExecution lastExecution) {
+        if ("NO_VIABLE_SUBNICHE".equals(decision)) {
+            return "Encerrado sem subnicho viável";
+        }
+        if ("FINALISTS_SELECTED".equals(decision)) {
+            return "Finalistas selecionados";
+        }
+        if (lastExecution.getStatus() == OprmNichoCnaeV2StageExecutionStatus.FAILED) {
+            return "Falha encerrada";
+        }
+        return decision;
+    }
+
+    /** Monta uma explicação curta da decisão final usando contagens estruturadas persistidas pelo executor. */
+    private String reasonForDecision(
+            String decision, Map<String, Object> output, OprmNichoCnaeV2StageExecution lastExecution) {
+        if ("NO_VIABLE_SUBNICHE".equals(decision)) {
+            return "O torneio terminou sem finalistas viáveis; candidatos="
+                    + numberText(output.get("candidateCount"))
+                    + ", finalistas="
+                    + numberText(output.get("finalistCount"))
+                    + ".";
+        }
+        if (lastExecution.getStatus() == OprmNichoCnaeV2StageExecutionStatus.FAILED) {
+            return lastExecution.getErrorMessage();
+        }
+        return null;
+    }
+
+    /** Soma custo de IA em dólares registrado na saída própria de cada etapa do job. */
+    private BigDecimal sumAiCostUsd(List<OprmNichoCnaeV2StageExecution> executions) {
+        return executions.stream()
+                .map(execution -> costFromPayload(execution.getOutputPayload()))
+                .reduce(BigDecimal.ZERO, BigDecimal::add);
+    }
+
+    /** Verifica se há sinal de uso de IA mesmo quando o custo registrado for zero ou ausente. */
+    private boolean hasAiUsageSignal(OprmNichoCnaeV2StageExecution execution) {
+        return hasAiUsageSignal(parsePayload(execution.getOutputPayload()));
+    }
+
+    /** Detecta chaves explícitas de IA em payload estruturado para classificar o job corretamente. */
+    private boolean hasAiUsageSignal(Map<String, Object> payload) {
+        return Boolean.TRUE.equals(payload.get("usedAi"))
+                || Boolean.TRUE.equals(payload.get("aiUsed"))
+                || payload.containsKey("model")
+                || payload.containsKey("openAiModel")
+                || payload.containsKey("aiUsage")
+                || payload.containsKey("tokenUsage");
+    }
+
+    /** Extrai custos conhecidos de um payload JSON sem falhar a tela quando o contrato antigo não tem custo. */
+    private BigDecimal costFromPayload(String payload) {
+        return costFromMap(parsePayload(payload));
+    }
+
+    /** Soma custos por chaves canônicas de custo de IA, incluindo objetos e listas aninhadas. */
+    private BigDecimal costFromMap(Map<String, Object> payload) {
+        BigDecimal total = BigDecimal.ZERO;
+        for (Map.Entry<String, Object> entry : payload.entrySet()) {
+            Object value = entry.getValue();
+            if (COST_KEYS.contains(entry.getKey())) {
+                total = total.add(decimal(value));
+            } else if (value instanceof Map<?, ?> nested) {
+                total = total.add(costFromMap(toStringKeyMap(nested)));
+            } else if (value instanceof List<?> items) {
+                total = total.add(costFromList(items));
+            }
+        }
+        return total;
+    }
+
+    /** Soma custos encontrados dentro de listas estruturadas do payload. */
+    private BigDecimal costFromList(List<?> items) {
+        BigDecimal total = BigDecimal.ZERO;
+        for (Object item : items) {
+            if (item instanceof Map<?, ?> nested) {
+                total = total.add(costFromMap(toStringKeyMap(nested)));
+            } else if (item instanceof List<?> nestedItems) {
+                total = total.add(costFromList(nestedItems));
+            }
+        }
+        return total;
+    }
+
+    /** Converte mapas vindos do Jackson para chaves textuais sem acoplar o contrato a DTO específico. */
+    private Map<String, Object> toStringKeyMap(Map<?, ?> source) {
+        Map<String, Object> converted = new LinkedHashMap<>();
+        source.forEach((key, value) -> converted.put(String.valueOf(key), value));
+        return converted;
+    }
+
+    /** Normaliza números de custo de IA vindos como número ou texto decimal. */
+    private BigDecimal decimal(Object value) {
+        if (value instanceof BigDecimal decimal) {
+            return decimal;
+        }
+        if (value instanceof Number number) {
+            return BigDecimal.valueOf(number.doubleValue());
+        }
+        if (value != null && !String.valueOf(value).isBlank()) {
+            try {
+                return new BigDecimal(String.valueOf(value));
+            } catch (NumberFormatException ignored) {
+                return BigDecimal.ZERO;
+            }
+        }
+        return BigDecimal.ZERO;
+    }
+
+    /** Lê payload JSON estruturado sem impedir o acompanhamento do job quando o payload estiver ausente ou legado. */
+    private Map<String, Object> parsePayload(String payload) {
+        if (payload == null || payload.isBlank()) {
+            return Map.of();
+        }
+        try {
+            return OBJECT_MAPPER.readValue(payload, MAP_TYPE);
+        } catch (JsonProcessingException ignored) {
+            return Map.of();
+        }
+    }
+
+    /** Formata contagens funcionais ausentes como zero para manter a explicação objetiva ao usuário. */
+    private String numberText(Object value) {
+        if (value instanceof Number number) {
+            return String.valueOf(number.intValue());
+        }
+        return value == null || String.valueOf(value).isBlank() ? "0" : String.valueOf(value);
     }
 
     /** Verifica se o job possui alguma etapa ainda operacionalmente aberta. */

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/candidategenerator/service/listCnaeJobs/CandidateGeneratorCnaeJobSummary.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/candidategenerator/service/listCnaeJobs/CandidateGeneratorCnaeJobSummary.java
@@ -1,5 +1,6 @@
 package com.marketinghub.oprm.nichocnae.v2.candidategenerator.service.listCnaeJobs;
 
+import java.math.BigDecimal;
 import java.time.Instant;
 
 /** Representa o resumo administrativo de um job v2 agrupado por jobId. */
@@ -14,5 +15,10 @@ public record CandidateGeneratorCnaeJobSummary(
         Integer technicalRetryNumber,
         Integer knowledgeVersion,
         Boolean materializationEnabled,
+        String finalDecision,
+        String finalDecisionLabel,
+        String finalDecisionReason,
+        Boolean usedAi,
+        BigDecimal aiCostUsd,
         Instant createdAt,
         Instant updatedAt) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/candidategenerator/service/listCnaeJobs/CandidateGeneratorCnaeJobsResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/candidategenerator/service/listCnaeJobs/CandidateGeneratorCnaeJobsResponse.java
@@ -1,9 +1,12 @@
 package com.marketinghub.oprm.nichocnae.v2.candidategenerator.service.listCnaeJobs;
 
+import java.math.BigDecimal;
 import java.util.List;
 
 /** Representa as listas de jobs v2 abertos e encerrados para um CNAE. */
 public record CandidateGeneratorCnaeJobsResponse(
         String cnaeCode,
+        BigDecimal cnaeAiCostUsd,
+        Boolean cnaeUsedAi,
         List<CandidateGeneratorCnaeJobSummary> openJobs,
         List<CandidateGeneratorCnaeJobSummary> completedJobs) {}

--- a/backend/ads-service/src/test/java/com/marketinghub/oprm/nichocnae/v2/candidategenerator/service/BackendCandidateGeneratorServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/oprm/nichocnae/v2/candidategenerator/service/BackendCandidateGeneratorServiceTest.java
@@ -124,18 +124,28 @@ class BackendCandidateGeneratorServiceTest {
         completed.setCnaeCode("4781400");
         completed.setStageCode("candidate-generator");
         completed.setStatus(OprmNichoCnaeV2StageExecutionStatus.COMPLETED);
+        completed.setOutputPayload(
+                "{\"tournamentDecision\":\"NO_VIABLE_SUBNICHE\",\"candidateCount\":0,\"finalistCount\":0,\"aiCostUsd\":0.015}");
         completed.setUpdatedAt(Instant.parse("2026-06-19T11:00:00Z"));
         when(stageExecutionRepository.findByCnaeCodeOrderByUpdatedAtDesc("4781400"))
                 .thenReturn(List.of(open, completed));
 
         var result = service.listJobsForCnae("4781400");
 
+        assertThat(result.cnaeUsedAi()).isTrue();
+        assertThat(result.cnaeAiCostUsd()).isEqualByComparingTo(new BigDecimal("0.015"));
         assertThat(result.openJobs()).hasSize(1);
         assertThat(result.openJobs().getFirst().jobId()).isEqualTo("job-aberto");
         assertThat(result.openJobs().getFirst().currentStageCode()).isEqualTo("source-safety-filter");
         assertThat(result.completedJobs()).hasSize(1);
         assertThat(result.completedJobs().getFirst().jobId()).isEqualTo("job-concluido");
         assertThat(result.completedJobs().getFirst().currentStageCode()).isNull();
+        assertThat(result.completedJobs().getFirst().finalDecision()).isEqualTo("NO_VIABLE_SUBNICHE");
+        assertThat(result.completedJobs().getFirst().finalDecisionLabel()).isEqualTo("Encerrado sem subnicho viável");
+        assertThat(result.completedJobs().getFirst().finalDecisionReason())
+                .isEqualTo("O torneio terminou sem finalistas viáveis; candidatos=0, finalistas=0.");
+        assertThat(result.completedJobs().getFirst().usedAi()).isTrue();
+        assertThat(result.completedJobs().getFirst().aiCostUsd()).isEqualByComparingTo(new BigDecimal("0.015"));
     }
 
     /** Ciclo 74: deve transformar falha de infraestrutura em retry técnico sem nova tentativa cognitiva. */

--- a/docs/canonical/oprm-nichocnae-v2-pending-executor.md
+++ b/docs/canonical/oprm-nichocnae-v2-pending-executor.md
@@ -302,3 +302,11 @@ Existe processor no executor, mas a etapa ainda não está cadastrada na lista c
 6. A próxima etapa receberá todo o contexto necessário sem consultar logs técnicos?
 7. O contrato permite reprocessamento sem perder aprendizado?
 8. O backend continua apenas lendo/escrevendo estado, sem executar regra operacional da etapa?
+
+## Regra de relatório ao usuário e custo de IA por job/CNAE
+
+Todo resumo administrativo de jobs da v2 deve expor a decisão funcional final persistida pela última etapa, e não apenas o status técnico `COMPLETED`/`FAILED`. Quando uma etapa encerrar o fluxo sem próxima etapa, o backend deve retornar um rótulo e motivo de negócio suficientes para a tela explicar o encerramento ao usuário, por exemplo `NO_VIABLE_SUBNICHE` como "Encerrado sem subnicho viável" com contagens de candidatos e finalistas.
+
+Quando houver uso de IA em qualquer etapa do job, o custo deve ser contabilizado no resumo do próprio job e também agregado no resumo do CNAE. A fonte canônica imediata para essa contabilização é o `outputPayload` estruturado persistido pela própria etapa que consumiu IA, com campos explícitos de custo ou uso de IA; contratos novos devem preferir campos numéricos em USD (`aiCostUsd`, `totalAiCostUsd` ou equivalente canônico) e evitar JSON dentro de JSON. O backend não deve somar custo carregado em `inputPayload`, porque esse payload pode conter a saída de etapa anterior e causaria dupla contagem.
+
+A tela administrativa deve mostrar esses valores recebidos do backend, sem inferir estado de negócio localmente: decisão final, motivo, se houve IA e custo acumulado por job/CNAE.

--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -1160,3 +1160,10 @@
 - 2026-06-20 03:10:00 (UTC): corrigida a causa-raiz da etapa 2 `source-safety-filter` do pipeline NichoCNAE v2 falhar no job `nichocnae-v2-candidate-2-job-2`: o executor adicionava metadados opcionais nulos ao `StageContext`, e o `Map.copyOf` interrompia a etapa com `NullPointerException` antes do filtro processar as URLs candidatas. O contexto genérico agora remove valores nulos antes de congelar o mapa e há teste de regressão cobrindo pending com `cnaeDescription`/`researchCycleId` ausentes.
 - 2026-06-20 03:35:00 (UTC): documentado em `docs/canonical/oprm-nichocnae-v2-pending-executor.md` o contrato mínimo de `pending` que cada etapa do executor OPRM NichoCNAE v2 precisa receber, incluindo envelope comum, payload funcional por etapa e lacunas atuais de etapas referenciadas ainda sem contrato completo (`source-searcher`, `signal-extractor` e `routine-synthesizer`).
 - 2026-06-20 03:45:00 (UTC): revisado o backend NichoCNAE v2 contra o contrato do executor e ajustados os endpoints `pending` para devolver envelope comum mais completo ao worker (`researchCycleId`, `cnaeDescription` e `materializationEnabled`, além dos identificadores já existentes). Também foi documentado o Swagger da etapa `adaptive-query-planner` e atualizadas as descrições dos pendings v2.
+
+## 2026-06-20 — NichoCNAE v2 mostra decisão final e custo de IA por job/CNAE
+
+- Ajustado o contrato de jobs do CNAE na v2 para expor decisão funcional final, motivo de encerramento, sinal de uso de IA e soma de custo de IA em USD por job e agregado do CNAE.
+- A tela do pipeline v2 passa a mostrar quando um job foi encerrado sem subnicho viável (`NO_VIABLE_SUBNICHE`) em vez de apresentar apenas `COMPLETED`, reduzindo interpretação falsa de que houve nicho materializado.
+- Causa-raiz corrigida: a tela recebia apenas status técnico de execução aberta/encerrada, mas não recebia a decisão de negócio persistida no `outputPayload` da última etapa nem o custo contabilizado nos payloads.
+- Prevenção de recorrência: teste unitário do backend cobre agregação de decisão `NO_VIABLE_SUBNICHE`, explicação com contagens e custo de IA no job/CNAE.

--- a/docs/swagger/oprm-nichocnae-v2-candidate-generator-swagger.yaml
+++ b/docs/swagger/oprm-nichocnae-v2-candidate-generator-swagger.yaml
@@ -32,6 +32,33 @@ paths:
       responses:
         "200":
           description: Listas de jobs abertas e encerradas para o CNAE informado.
+          content:
+            application/json:
+              schema:
+                type: object
+                required:
+                  - cnaeCode
+                  - cnaeAiCostUsd
+                  - cnaeUsedAi
+                  - openJobs
+                  - completedJobs
+                properties:
+                  cnaeCode:
+                    type: string
+                  cnaeAiCostUsd:
+                    type: number
+                    description: Soma dos custos de IA em USD registrados nos outputPayloads dos jobs listados para o CNAE.
+                  cnaeUsedAi:
+                    type: boolean
+                    description: Indica se algum job listado do CNAE registrou custo ou sinal explícito de uso de IA.
+                  openJobs:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/CandidateGeneratorCnaeJobSummary"
+                  completedJobs:
+                    type: array
+                    items:
+                      $ref: "#/components/schemas/CandidateGeneratorCnaeJobSummary"
   /api/internal/oprm/nichocnae/v2/candidate-generator/stage-executions/pending:
     get:
       summary: Lista execuções pendentes da etapa candidate-generator v2
@@ -64,3 +91,70 @@ paths:
       responses:
         "200":
           description: Falha registrada
+components:
+  schemas:
+    CandidateGeneratorCnaeJobSummary:
+      type: object
+      required:
+        - jobId
+        - cnaeCode
+        - status
+        - lastStageStatus
+        - materializationEnabled
+        - usedAi
+        - aiCostUsd
+      properties:
+        jobId:
+          type: string
+        cnaeCode:
+          type: string
+        status:
+          type: string
+          enum:
+            - OPEN
+            - COMPLETED
+        currentStageCode:
+          type: string
+          nullable: true
+        lastStageCode:
+          type: string
+          nullable: true
+        lastStageStatus:
+          type: string
+        attemptNumber:
+          type: integer
+          nullable: true
+        technicalRetryNumber:
+          type: integer
+          nullable: true
+        knowledgeVersion:
+          type: integer
+          nullable: true
+        materializationEnabled:
+          type: boolean
+        finalDecision:
+          type: string
+          nullable: true
+          description: Decisão funcional persistida na última etapa, como NO_VIABLE_SUBNICHE.
+        finalDecisionLabel:
+          type: string
+          nullable: true
+          description: Rótulo de negócio para explicar a conclusão ou bloqueio ao usuário.
+        finalDecisionReason:
+          type: string
+          nullable: true
+          description: Motivo curto da decisão final, preservando contagens relevantes.
+        usedAi:
+          type: boolean
+          description: Indica se o job registrou custo ou sinal explícito de uso de IA.
+        aiCostUsd:
+          type: number
+          description: Soma dos custos de IA em USD encontrados nos outputPayloads persistidos do job.
+        createdAt:
+          type: string
+          format: date-time
+          nullable: true
+        updatedAt:
+          type: string
+          format: date-time
+          nullable: true

--- a/frontend/src/api/oprm/useOprmNichoCnaeV2Jobs.ts
+++ b/frontend/src/api/oprm/useOprmNichoCnaeV2Jobs.ts
@@ -12,12 +12,19 @@ export interface OprmNichoCnaeV2JobSummary {
   technicalRetryNumber: number | null;
   knowledgeVersion: number | null;
   materializationEnabled: boolean | null;
+  finalDecision: string | null;
+  finalDecisionLabel: string | null;
+  finalDecisionReason: string | null;
+  usedAi: boolean | null;
+  aiCostUsd: number | string | null;
   createdAt: string | null;
   updatedAt: string | null;
 }
 
 export interface OprmNichoCnaeV2JobsResponse {
   cnaeCode: string;
+  cnaeAiCostUsd: number | string | null;
+  cnaeUsedAi: boolean | null;
   openJobs: OprmNichoCnaeV2JobSummary[];
   completedJobs: OprmNichoCnaeV2JobSummary[];
 }

--- a/frontend/src/pages/oprm/OprmNichoCnaeV2PipelinePage.tsx
+++ b/frontend/src/pages/oprm/OprmNichoCnaeV2PipelinePage.tsx
@@ -53,6 +53,25 @@ function formatDateTime(value: string | null | undefined) {
   }).format(new Date(value));
 }
 
+function formatAiCost(value: number | string | null | undefined) {
+  const numericValue = Number(value ?? 0);
+  return new Intl.NumberFormat("pt-BR", {
+    style: "currency",
+    currency: "USD",
+    minimumFractionDigits: 4,
+    maximumFractionDigits: 6,
+  }).format(Number.isFinite(numericValue) ? numericValue : 0);
+}
+
+function decisionBadgeClass(job: OprmNichoCnaeV2JobSummary, open: boolean) {
+  if (open) return "badge text-bg-warning";
+  if (job.finalDecision === "NO_VIABLE_SUBNICHE") {
+    return "badge text-bg-secondary";
+  }
+  if (job.lastStageStatus === "FAILED") return "badge text-bg-danger";
+  return "badge text-bg-success";
+}
+
 function JobsTable({
   jobs,
   emptyMessage,
@@ -74,6 +93,8 @@ function JobsTable({
             <th>Job</th>
             {open ? <th>Etapa atual</th> : <th>Última etapa</th>}
             <th>Status</th>
+            <th>Decisão</th>
+            <th>Custo IA</th>
             <th>Tentativa</th>
             <th>Atualizado</th>
           </tr>
@@ -87,12 +108,28 @@ function JobsTable({
               </td>
               <td>
                 <span
-                  className={
-                    open ? "badge text-bg-warning" : "badge text-bg-success"
-                  }
+                  className={decisionBadgeClass(job, open)}
                 >
                   {open ? "Aberto" : (job.lastStageStatus ?? "Concluído")}
                 </span>
+              </td>
+              <td>
+                <div className="fw-semibold">
+                  {job.finalDecisionLabel ?? job.finalDecision ?? "—"}
+                </div>
+                {job.finalDecisionReason ? (
+                  <div className="text-secondary small">
+                    {job.finalDecisionReason}
+                  </div>
+                ) : null}
+              </td>
+              <td>
+                <span className="fw-semibold">
+                  {formatAiCost(job.aiCostUsd)}
+                </span>
+                <div className="text-secondary small">
+                  {job.usedAi ? "IA usada no job" : "Sem IA contabilizada"}
+                </div>
               </td>
               <td>
                 {job.attemptNumber ?? "—"}
@@ -243,6 +280,7 @@ export default function OprmNichoCnaeV2PipelinePage() {
   const decodedCnaeCode = cnaeCode ? decodeURIComponent(cnaeCode) : undefined;
   const startJobMutation = useStartOprmNichoCnaeV2Job(decodedCnaeCode ?? "");
   const jobsQuery = useOprmNichoCnaeV2Jobs(decodedCnaeCode ?? "");
+  const cnaeAiCostUsd = jobsQuery.data?.cnaeAiCostUsd ?? 0;
 
   return (
     <div className="d-flex flex-column gap-4">
@@ -314,6 +352,15 @@ export default function OprmNichoCnaeV2PipelinePage() {
           {startJobMutation.isError ? (
             <div className="alert alert-danger mt-3 mb-0" role="alert">
               {startJobMutation.error.message}
+            </div>
+          ) : null}
+          {decodedCnaeCode && jobsQuery.data ? (
+            <div className="alert alert-info mt-3 mb-0" role="status">
+              <strong>Custo de IA contabilizado no CNAE:</strong>{" "}
+              {formatAiCost(cnaeAiCostUsd)}.{" "}
+              {jobsQuery.data.cnaeUsedAi
+                ? "Há sinal de uso de IA em pelo menos um job deste CNAE."
+                : "Nenhum uso de IA foi registrado nos jobs listados deste CNAE."}
             </div>
           ) : null}
         </div>


### PR DESCRIPTION
### Motivation
- Provide the administrative UI with business-level information about each job by surfacing the final functional decision persisted in the last stage, a human-friendly label and short reason, and whether the job used AI plus its aggregated USD cost.
- Avoid relying only on technical `COMPLETED`/`FAILED` status for user-facing summaries and make AI cost visible per-job and aggregated per-CNAE while being tolerant of legacy/absent payloads.

### Description
- Backend: enhanced `BackendCandidateGeneratorService` to parse `outputPayload` safely, extract a final decision, compute `finalDecisionLabel` and `finalDecisionReason`, detect AI usage signals, and sum canonical AI cost keys across nested structures; added helpers (`parsePayload`, `costFromMap`, `decimal`, etc.) and kept behaviour safe for legacy payloads.
- API/DTOs: extended `CandidateGeneratorCnaeJobSummary` and `CandidateGeneratorCnaeJobsResponse` to include `finalDecision`, `finalDecisionLabel`, `finalDecisionReason`, `usedAi`, and `aiCostUsd`, and added aggregated `cnaeAiCostUsd` and `cnaeUsedAi` to the CNAE response.
- Frontend: updated types and the pipeline page to display decision badges, decision reason, per-job AI cost/usage and an aggregate CNAE AI cost banner, plus formatting helpers for costs and badge classes.
- Documentation and swagger: updated canonical docs and OpenAPI spec to document the new fields and the rule that the backend must return business decision and AI cost aggregations for the administrative UI.

### Testing
- Unit tests: updated `BackendCandidateGeneratorServiceTest#listJobsForCnaeSeparatesOpenAndCompletedJobs` to assert decision, decision label/reason, `usedAi` and `aiCostUsd`, and the test passed.
- Other existing backend unit tests (including failure/technical-retry scenarios) were run and remained green after the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a36af986d1c83219313cb6e743c5940)