### PR TITLE
Require niche + hypothesis before AI promise generation and enrich AI prompt with niche/hypothesis details

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentPromiseGenerationService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentPromiseGenerationService.java
@@ -60,6 +60,9 @@ public class ExperimentPromiseGenerationService {
         if (request == null || request.nicheId() == null) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Selecione um nicho antes de gerar com IA.");
         }
+        if (request.hypothesisId() == null) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Selecione uma hipótese antes de gerar com IA.");
+        }
         MarketNiche niche = nicheRepository.findById(request.nicheId())
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Nicho não encontrado"));
         Hypothesis hypothesis = resolveHypothesis(request.hypothesisId());
@@ -85,11 +88,8 @@ public class ExperimentPromiseGenerationService {
         }
     }
 
-    /** Localiza a hipótese opcional usada como contexto da geração. */
+    /** Localiza a hipótese obrigatória usada como contexto da geração. */
     private Hypothesis resolveHypothesis(UUID hypothesisId) {
-        if (hypothesisId == null) {
-            return null;
-        }
         return hypothesisRepository.findById(hypothesisId)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Hipótese não encontrada"));
     }
@@ -126,23 +126,63 @@ public class ExperimentPromiseGenerationService {
     private String buildPrompt(GenerateExperimentPromiseOptionsRequest request, MarketNiche niche, Hypothesis hypothesis) {
         StringBuilder sb = new StringBuilder();
         sb.append("Gere exatamente 3 opções diferentes de contrato de promessa única para um novo experimento.\n");
-        sb.append("Nicho: ").append(niche.getName()).append('\n');
-        appendIfPresent(sb, "Descrição do nicho", niche.getDescription());
-        if (hypothesis != null) {
-            appendIfPresent(sb, "Hipótese selecionada", hypothesis.getTitle());
-            appendIfPresent(sb, "Problema da hipótese", hypothesis.getProblem());
-            appendIfPresent(sb, "Promessa da hipótese", hypothesis.getPromise());
-            appendIfPresent(sb, "Mecanismo", hypothesis.getMechanism());
-            appendIfPresent(sb, "Entrega", hypothesis.getEntrega());
-        } else {
-            appendIfPresent(sb, "Hipótese digitada", request.hypothesis());
-        }
+        appendNicheDetails(sb, niche);
+        appendHypothesisPipelineDetails(sb, hypothesis);
         appendIfPresent(sb, "Dor atual digitada", request.currentSinglePain());
         appendIfPresent(sb, "Recompensa atual digitada", request.currentFreeReward());
         appendIfPresent(sb, "Promessa atual digitada", request.currentFunnelPromise());
         appendIfPresent(sb, "CTA atual digitado", request.currentPrimaryCta());
         sb.append("\nAs três opções devem ser distintas: uma direta, uma emocional e uma operacional/prática.");
         return sb.toString();
+    }
+
+    /** Adiciona ao prompt os detalhes disponíveis do nicho selecionado. */
+    private void appendNicheDetails(StringBuilder sb, MarketNiche niche) {
+        sb.append("Nicho selecionado:\n");
+        appendIfPresent(sb, "- Nome", niche.getName());
+        appendIfPresent(sb, "- Descrição", niche.getDescription());
+        appendIfPresent(sb, "- Categoria de interesse", niche.getInterestCategory());
+        appendIfPresent(sb, "- Categoria de cargo", niche.getRoleCategory());
+        appendIfPresent(sb, "- Segmentação base", niche.getBaseSegmentation());
+        appendIfPresent(sb, "- Interesses", niche.getInterests());
+        appendIfPresent(sb, "- Filtros demográficos", niche.getDemographicFilters());
+        appendIfPresent(sb, "- Dicas extras", niche.getExtraTips());
+        appendIfPresent(sb, "- Promessas validadas", niche.getPromises());
+        appendIfPresent(sb, "- Ofertas validadas", niche.getOffers());
+        appendIfPresent(sb, "- Volume de demanda", niche.getDemandVolume());
+        appendListIfPresent(sb, "- Lista curada de interesses", niche.getInterestList());
+        appendListIfPresent(sb, "- Lista curada de cargos", niche.getRoleList());
+        appendListIfPresent(sb, "- Lista curada de comportamentos", niche.getBehaviorList());
+    }
+
+    /** Adiciona ao prompt o pipeline completo conhecido da hipótese selecionada. */
+    private void appendHypothesisPipelineDetails(StringBuilder sb, Hypothesis hypothesis) {
+        sb.append("\nHipótese selecionada e pipeline de hipótese:\n");
+        appendIfPresent(sb, "- Título", hypothesis.getTitle());
+        appendIfPresent(sb, "- Persona", hypothesis.getPersona());
+        appendIfPresent(sb, "- Problema/dor", hypothesis.getProblem());
+        appendIfPresent(sb, "- Promessa/resultado", hypothesis.getPromise());
+        appendIfPresent(sb, "- Mecanismo", hypothesis.getMechanism());
+        appendIfPresent(sb, "- Mecanismo único", hypothesis.getUniqueMechanism());
+        appendIfPresent(sb, "- Entrega/oferta", hypothesis.getEntrega());
+        appendIfPresent(sb, "- Regra de sucesso", hypothesis.getSuccessRule());
+        appendIfPresent(sb, "- Framework Dor Resultado Mecanismo Prova Oferta", hypothesis.getFrameworkJson());
+        if (hypothesis.getOfferType() != null) {
+            appendIfPresent(sb, "- Tipo de oferta", hypothesis.getOfferType().name());
+        }
+        if (hypothesis.getPrice() != null) {
+            appendIfPresent(sb, "- Preço", hypothesis.getPrice().toPlainString());
+        }
+        if (hypothesis.getKpiTargetCpl() != null) {
+            appendIfPresent(sb, "- KPI alvo CPL", hypothesis.getKpiTargetCpl().toPlainString());
+        }
+    }
+
+    /** Adiciona listas ao prompt apenas quando houver itens úteis. */
+    private void appendListIfPresent(StringBuilder sb, String label, List<String> values) {
+        if (values != null && !values.isEmpty()) {
+            sb.append(label).append(": ").append(String.join(", ", values)).append('\n');
+        }
     }
 
     /** Adiciona ao prompt apenas campos com conteúdo útil. */

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/service/ExperimentPromiseGenerationServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/service/ExperimentPromiseGenerationServiceTest.java
@@ -10,6 +10,7 @@ import static org.mockito.Mockito.when;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marketinghub.ai.generation.service.AiWorkerGenerationService;
 import com.marketinghub.experiment.service.generatepromise.GenerateExperimentPromiseOptionsRequest;
+import com.marketinghub.hypothesis.Hypothesis;
 import com.marketinghub.niche.MarketNiche;
 import com.marketinghub.openai.OpenAiBatchClient;
 import com.marketinghub.openai.OpenAiResponse;
@@ -17,9 +18,12 @@ import com.marketinghub.openai.service.OpenAiPricingService;
 import com.marketinghub.repository.jpa.hypothesis.HypothesisRepository;
 import com.marketinghub.repository.jpa.niche.MarketNicheRepository;
 import java.math.BigDecimal;
+import java.util.Map;
 import java.util.Optional;
+import java.util.UUID;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.Spy;
@@ -53,11 +57,38 @@ class ExperimentPromiseGenerationServiceTest {
                 .hasMessageContaining("Selecione um nicho");
     }
 
+    /** Deve bloquear geração sem hipótese porque a IA precisa do pipeline completo da hipótese. */
+    @Test
+    void shouldRejectRequestWithoutHypothesis() {
+        assertThatThrownBy(() -> service.generate(new GenerateExperimentPromiseOptionsRequest(
+                7L, null, null, null, null, null, null)))
+                .isInstanceOf(ResponseStatusException.class)
+                .hasMessageContaining("Selecione uma hipótese");
+    }
+
     /** Deve retornar exatamente três opções completas e registrar a geração para auditoria. */
     @Test
     void shouldGenerateThreePromiseOptions() {
-        MarketNiche niche = MarketNiche.builder().id(7L).name("Salões de beleza").build();
+        UUID hypothesisId = UUID.randomUUID();
+        MarketNiche niche = MarketNiche.builder()
+                .id(7L)
+                .name("Salões de beleza")
+                .description("Nicho de profissionais locais")
+                .promises("Promessa validada")
+                .offers("Oferta validada")
+                .build();
+        Hypothesis hypothesis = Hypothesis.builder()
+                .id(hypothesisId)
+                .title("Hipótese de agenda")
+                .problem("Clientes somem depois do atendimento")
+                .promise("Agenda mais previsível")
+                .mechanism("Régua de manutenção")
+                .uniqueMechanism("Fluxo de manutenção guiada")
+                .entrega("Mensagens prontas")
+                .frameworkJson("{\"pain\":\"clientes somem\"}")
+                .build();
         when(nicheRepository.findById(7L)).thenReturn(Optional.of(niche));
+        when(hypothesisRepository.findById(hypothesisId)).thenReturn(Optional.of(hypothesis));
         when(openAiBatchClient.executeSingle(any(), anyString())).thenReturn(new OpenAiResponse(
                 "resp-1",
                 "{\"options\":["
@@ -71,10 +102,14 @@ class ExperimentPromiseGenerationServiceTest {
         when(pricingService.estimateStandardCost(anyString(), any())).thenReturn(BigDecimal.ZERO);
 
         var response = service.generate(new GenerateExperimentPromiseOptionsRequest(
-                7L, null, "Hipótese", null, null, null, null));
+                7L, hypothesisId, null, null, null, null, null));
 
         assertThat(response.options()).hasSize(3);
         assertThat(response.options().getFirst().singlePain()).isEqualTo("Agenda vazia");
         verify(generationService).recordGeneration(any());
+        ArgumentCaptor<Map<String, Object>> requestCaptor = ArgumentCaptor.forClass(Map.class);
+        verify(openAiBatchClient).executeSingle(requestCaptor.capture(), anyString());
+        String prompt = requestCaptor.getValue().get("input").toString();
+        assertThat(prompt).contains("Nicho selecionado", "Promessa validada", "Hipótese selecionada", "Fluxo de manutenção guiada", "Framework");
     }
 }

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -4914,3 +4914,10 @@
 - Adicionado fluxo para a tela de novo experimento gerar 3 opções de contrato de promessa única com IA.
 - O backend passa a expor endpoint próprio de experimentos para gerar opções com dor única, recompensa gratuita, promessa do funil e CTA principal.
 - O frontend permite escolher uma das opções geradas e preencher automaticamente o formulário antes de salvar o experimento.
+
+## 2026-06-20 — IA de promessa exige nicho e hipótese completos
+
+- Solicitação: a opção de gerar com IA na criação de experimento só deve ficar habilitada após escolha de nicho e hipótese, e a geração precisa receber todos os detalhes do nicho e do pipeline de hipótese.
+- Causa-raiz: a tela permitia acionar a IA apenas com nicho e o backend aceitava hipótese ausente, usando pouco contexto estratégico para montar dor, recompensa, promessa e CTA.
+- Correção aplicada: o frontend bloqueia o botão até existir nicho e hipótese selecionados; o backend valida a hipótese como obrigatória e monta o prompt com detalhes do nicho e campos centrais da hipótese, incluindo framework/pipeline quando disponível.
+- Prevenção de recorrência: teste unitário do serviço passou a validar bloqueio sem hipótese e presença do contexto de nicho e hipótese no prompt enviado à IA.

--- a/frontend/src/api/experiment/useGeneratePromiseOptions.ts
+++ b/frontend/src/api/experiment/useGeneratePromiseOptions.ts
@@ -12,8 +12,7 @@ export interface PromiseOption {
 
 interface GeneratePromiseOptionsPayload {
   nicheId: number;
-  hypothesisId?: string;
-  hypothesis?: string;
+  hypothesisId: string;
   currentSinglePain?: string;
   currentFreeReward?: string;
   currentFunnelPromise?: string;

--- a/frontend/src/pages/experiment/NewExperimentPage.tsx
+++ b/frontend/src/pages/experiment/NewExperimentPage.tsx
@@ -104,6 +104,7 @@ export default function NewExperimentPage() {
   const showNicheSelect = nicheIdParam === "";
   const showHypSelect = hypothesisIdParam === "";
   const workerRequests = { instantForms: 0, emails: 0 };
+  const canGeneratePromiseOptions = Boolean(form.nicheId && form.hypothesisId);
 
   useEffect(() => {
     if (selectedHypothesis?.title) {
@@ -142,14 +143,13 @@ export default function NewExperimentPage() {
   }, [autoSampleSize, autoMde, form.dailyBudget]);
 
   const handleGeneratePromiseOptions = async () => {
-    if (!form.nicheId) {
-      alert("Selecione um nicho antes de gerar com IA");
+    if (!canGeneratePromiseOptions) {
+      alert("Selecione o nicho e a hipótese antes de gerar com IA");
       return;
     }
     const options = await generatePromiseOptions.mutateAsync({
       nicheId: Number(form.nicheId),
-      hypothesisId: form.hypothesisId || undefined,
-      hypothesis: form.hypothesis || undefined,
+      hypothesisId: form.hypothesisId,
       currentSinglePain: form.singlePain || undefined,
       currentFreeReward: form.freeReward || undefined,
       currentFunnelPromise: form.funnelPromise || undefined,
@@ -378,7 +378,14 @@ export default function NewExperimentPage() {
             <button
               type="button"
               className="btn btn-outline-primary btn-sm"
-              disabled={generatePromiseOptions.isPending}
+              disabled={
+                !canGeneratePromiseOptions || generatePromiseOptions.isPending
+              }
+              title={
+                canGeneratePromiseOptions
+                  ? "Gerar opções com os detalhes do nicho e da hipótese"
+                  : "Selecione o nicho e a hipótese antes de gerar com IA"
+              }
               onClick={handleGeneratePromiseOptions}
             >
               {generatePromiseOptions.isPending ? (
@@ -389,8 +396,10 @@ export default function NewExperimentPage() {
                   />
                   Gerando...
                 </span>
-              ) : (
+              ) : canGeneratePromiseOptions ? (
                 "Gerar 3 opções com IA"
+              ) : (
+                "Selecione nicho e hipótese"
               )}
             </button>
           </div>


### PR DESCRIPTION
### Motivation
- Avoid generating IA-driven promise options with insufficient commercial context by enforcing selection of both `niche` and `hypothesis` before allowing generation. 
- Improve quality and relevance of the IA output by sending the full niche profile and the hypothesis pipeline/framework as prompt context. 
- Prevent UX confusion and invalid experiments by disabling the generator in the UI until required context is present. 

### Description
- Frontend: disable the "Gerar 3 opções com IA" button until both niche and hypothesis are selected and require `hypothesisId` in the payload by changing `frontend/src/pages/experiment/NewExperimentPage.tsx` and `frontend/src/api/experiment/useGeneratePromiseOptions.ts`. 
- Backend: validate `hypothesisId` as mandatory and enrich the model prompt with niche details and the hypothesis pipeline/framework by adding `appendNicheDetails`, `appendHypothesisPipelineDetails` and `appendListIfPresent` helpers in `backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentPromiseGenerationService.java`. 
- Tests: add/adjust unit tests in `backend/ads-service/src/test/java/com/marketinghub/experiment/service/ExperimentPromiseGenerationServiceTest.java` to assert generation is rejected without a hypothesis and to verify the prompt contains niche/hypothesis context. 
- Documentation: record the change in `docs/registros/experimentos.md` describing cause, fix and prevention. 

### Testing
- Ran the backend unit test `ExperimentPromiseGenerationServiceTest`, which executed 3 tests and passed (`BUILD SUCCESS`). 
- Ran `npx prettier --write` on modified frontend files, which completed successfully. 
- Attempted frontend typecheck with `npm run typecheck`, which failed in this environment due to missing `node_modules` (types like `@testing-library/jest-dom`, `vite/client`, `vitest/globals`) and deprecation warnings in `tsconfig`, so type checking could not be validated here.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a36bcb92ab88321aa4c4299d2774eaa)