### PR TITLE
Simplify OPRM v2 job status UI

### DIFF
--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -1,3 +1,8 @@
+## 2026-06-20 11:45:00 (UTC-3) — OPRM NichoCNAE v2: leitura operacional dos jobs simplificada
+
+- Ajustada a tela do pipeline NichoCNAE v2 para trocar a tabela técnica de jobs por cards de acompanhamento com etapa, situação em linguagem humana, resumo do motivo e próximo passo operacional.
+- Causa-raiz tratada: a tela exibia identificadores longos e stack trace bruto como decisão principal, impedindo o usuário de entender rapidamente onde o job parou e o que precisa acontecer para avançar.
+
 ## 2026-06-19 00:00:00 (UTC) — OPRM NichoCNAE v2: separação visual entre jobs abertos e concluídos
 
 - Ajustada a tela do pipeline NichoCNAE v2 para separar visualmente os blocos de jobs abertos e concluídos com cards dedicados, trilha lateral de status e divisor elegante entre os painéis.

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -247,3 +247,79 @@
   box-shadow: 0 0 0 0.35rem rgba(15, 23, 42, 0.06);
 }
 
+.oprm-v2-job-list {
+  display: grid;
+  gap: 0.85rem;
+}
+
+.oprm-v2-job-card {
+  display: grid;
+  gap: 0.9rem;
+  padding: 1rem;
+  border: 1px solid rgba(15, 23, 42, 0.08);
+  border-radius: 0.85rem;
+  background: #f8fafc;
+}
+
+.oprm-v2-job-card__header,
+.oprm-v2-job-card__body,
+.oprm-v2-job-card__footer {
+  display: flex;
+  gap: 0.85rem;
+}
+
+.oprm-v2-job-card__header {
+  align-items: flex-start;
+  justify-content: space-between;
+}
+
+.oprm-v2-job-card__body {
+  flex-wrap: wrap;
+}
+
+.oprm-v2-job-card__main {
+  flex: 2 1 22rem;
+}
+
+.oprm-v2-job-card__action {
+  flex: 1 1 16rem;
+  padding: 0.75rem;
+  border-radius: 0.75rem;
+  background: #ffffff;
+  color: #334155;
+}
+
+.oprm-v2-job-card__label {
+  color: #64748b;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.oprm-v2-job-card__title {
+  font-size: 1.05rem;
+  font-weight: 700;
+}
+
+.oprm-v2-job-card__meta,
+.oprm-v2-job-card__footer {
+  color: #64748b;
+  font-size: 0.82rem;
+}
+
+.oprm-v2-job-card__stage {
+  font-size: 1rem;
+  font-weight: 700;
+}
+
+.oprm-v2-job-card__reason {
+  margin-top: 0.35rem;
+  color: #475569;
+}
+
+.oprm-v2-job-card__footer {
+  flex-wrap: wrap;
+  padding-top: 0.75rem;
+  border-top: 1px solid rgba(15, 23, 42, 0.08);
+}

--- a/frontend/src/pages/oprm/OprmNichoCnaeV2PipelinePage.tsx
+++ b/frontend/src/pages/oprm/OprmNichoCnaeV2PipelinePage.tsx
@@ -39,9 +39,7 @@ export function formatStage(stageCode: string | null | undefined) {
   if (!normalizedStageCode) return "Sem etapa aberta";
   const slugStageCode = normalizedStageCode.replace(/[_\s]+/g, "-");
   return (
-    stageLabels[normalizedStageCode] ??
-    stageLabels[slugStageCode] ??
-    stageCode
+    stageLabels[normalizedStageCode] ?? stageLabels[slugStageCode] ?? stageCode
   );
 }
 
@@ -61,6 +59,49 @@ function formatAiCost(value: number | string | null | undefined) {
     minimumFractionDigits: 4,
     maximumFractionDigits: 6,
   }).format(Number.isFinite(numericValue) ? numericValue : 0);
+}
+
+function formatJobId(jobId: string) {
+  const parts = jobId.split("-");
+  const lastPart = parts[parts.length - 1];
+  if (lastPart?.startsWith("job")) {
+    return lastPart.toUpperCase();
+  }
+  return jobId;
+}
+
+function explainStatus(job: OprmNichoCnaeV2JobSummary, open: boolean) {
+  if (open) return "Aguardando processamento";
+  if (job.lastStageStatus === "FAILED") return "Falhou e parou";
+  if (job.finalDecision === "NO_VIABLE_SUBNICHE") return "Sem subnicho viável";
+  return job.finalDecisionLabel ?? job.finalDecision ?? "Concluído";
+}
+
+function simplifyDecisionReason(reason: string | null | undefined) {
+  if (!reason) return null;
+  const reasonCode = reason.match(/reasonCode=([^;]+)/)?.[1];
+  const exception =
+    reason.match(/exception=([^;]+)/)?.[1] ??
+    reason.match(/^([A-Za-z]+Exception)/)?.[1];
+  if (reasonCode === "TECHNICAL_RETRY_LIMIT_EXCEEDED") {
+    return "O sistema tentou novamente, mas atingiu o limite técnico desta etapa.";
+  }
+  if (exception === "NullPointerException") {
+    return "Erro técnico interno ao preparar os dados da etapa.";
+  }
+  const firstSentence = reason.split(/[.;]/)[0]?.trim();
+  return firstSentence || reason;
+}
+
+function getOperatorNextAction(job: OprmNichoCnaeV2JobSummary, open: boolean) {
+  if (open) return "Aguardar o executor continuar este job.";
+  if (job.lastStageStatus === "FAILED") {
+    return "Corrigir a falha técnica antes de iniciar novo job.";
+  }
+  if (job.finalDecision === "NO_VIABLE_SUBNICHE") {
+    return "Usar o histórico como aprendizado e pesquisar outro recorte.";
+  }
+  return "Verificar se o nicho gerado já pode avançar para produto.";
 }
 
 function decisionBadgeClass(job: OprmNichoCnaeV2JobSummary, open: boolean) {
@@ -86,62 +127,62 @@ function JobsTable({
   }
 
   return (
-    <div className="table-responsive">
-      <table className="table table-sm align-middle mb-0">
-        <thead>
-          <tr>
-            <th>Job</th>
-            {open ? <th>Etapa atual</th> : <th>Última etapa</th>}
-            <th>Status</th>
-            <th>Decisão</th>
-            <th>Custo IA</th>
-            <th>Tentativa</th>
-            <th>Atualizado</th>
-          </tr>
-        </thead>
-        <tbody>
-          {jobs.map((job) => (
-            <tr key={job.jobId}>
-              <td className="font-monospace small">{job.jobId}</td>
-              <td>
-                {formatStage(open ? job.currentStageCode : job.lastStageCode)}
-              </td>
-              <td>
-                <span
-                  className={decisionBadgeClass(job, open)}
-                >
-                  {open ? "Aberto" : (job.lastStageStatus ?? "Concluído")}
-                </span>
-              </td>
-              <td>
-                <div className="fw-semibold">
-                  {job.finalDecisionLabel ?? job.finalDecision ?? "—"}
+    <div className="oprm-v2-job-list">
+      {jobs.map((job) => {
+        const stageName = formatStage(
+          open ? job.currentStageCode : job.lastStageCode,
+        );
+        const simplifiedReason = simplifyDecisionReason(
+          job.finalDecisionReason,
+        );
+        return (
+          <article className="oprm-v2-job-card" key={job.jobId}>
+            <div className="oprm-v2-job-card__header">
+              <div>
+                <div className="oprm-v2-job-card__label">Job</div>
+                <div className="oprm-v2-job-card__title">
+                  {formatJobId(job.jobId)}
                 </div>
-                {job.finalDecisionReason ? (
-                  <div className="text-secondary small">
-                    {job.finalDecisionReason}
-                  </div>
+                <div className="oprm-v2-job-card__meta" title={job.jobId}>
+                  Código completo: {job.jobId}
+                </div>
+              </div>
+              <span className={decisionBadgeClass(job, open)}>
+                {explainStatus(job, open)}
+              </span>
+            </div>
+
+            <div className="oprm-v2-job-card__body">
+              <div className="oprm-v2-job-card__main">
+                <div className="oprm-v2-job-card__label">
+                  {open ? "Onde está parado" : "Última etapa"}
+                </div>
+                <div className="oprm-v2-job-card__stage">{stageName}</div>
+                {simplifiedReason ? (
+                  <p className="oprm-v2-job-card__reason mb-0">
+                    {simplifiedReason}
+                  </p>
                 ) : null}
-              </td>
-              <td>
-                <span className="fw-semibold">
-                  {formatAiCost(job.aiCostUsd)}
-                </span>
-                <div className="text-secondary small">
-                  {job.usedAi ? "IA usada no job" : "Sem IA contabilizada"}
-                </div>
-              </td>
-              <td>
-                {job.attemptNumber ?? "—"}
+              </div>
+              <div className="oprm-v2-job-card__action">
+                <div className="oprm-v2-job-card__label">Próximo passo</div>
+                <div>{getOperatorNextAction(job, open)}</div>
+              </div>
+            </div>
+
+            <div className="oprm-v2-job-card__footer">
+              <span>IA: {formatAiCost(job.aiCostUsd)}</span>
+              <span>
+                Tentativa: {job.attemptNumber ?? "—"}
                 {job.technicalRetryNumber
                   ? ` · retry ${job.technicalRetryNumber}`
                   : ""}
-              </td>
-              <td>{formatDateTime(job.updatedAt)}</td>
-            </tr>
-          ))}
-        </tbody>
-      </table>
+              </span>
+              <span>Atualizado: {formatDateTime(job.updatedAt)}</span>
+            </div>
+          </article>
+        );
+      })}
     </div>
   );
 }


### PR DESCRIPTION
### Motivation

- Users had difficulty quickly understanding job status because the page showed long identifiers and raw decision traces in a technical table. 

### Description

- Replace the technical jobs table on `frontend/src/pages/oprm/OprmNichoCnaeV2PipelinePage.tsx` with operational cards that surface human-friendly status, current/last stage, a concise reason and the recommended next action. 
- Add helper functions `formatJobId`, `explainStatus`, `simplifyDecisionReason` and `getOperatorNextAction` to transform raw job data into readable text. 
- Add card styles in `frontend/src/App.css` to present jobs as compact cards and improve layout and readability. 
- Register the UI change and root cause in `docs/registros/oprm1.md` so the operational record is preserved.

### Testing

- Ran `npm run typecheck` which completed successfully with no type errors. 
- Built the frontend with `npm run build`, which succeeded (Vite emitted a chunk-size warning only).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a36d0940a648321bdba802a0d2d78b5)