### PR TITLE
Acompanha solicitação de promessa por IA e mostra mensagem de aguardando até conclusão

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentPromiseGenerationService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentPromiseGenerationService.java
@@ -73,6 +73,14 @@ public class ExperimentPromiseGenerationService {
         return new GenerateExperimentPromiseOptionsResponse(saved.getId(), saved.getStatus().name(), List.of());
     }
 
+    /** Consulta uma solicitação específica para a tela acompanhar até a resposta final do AI Worker. */
+    @Transactional(readOnly = true)
+    public GenerateExperimentPromiseOptionsResponse get(Long id) {
+        ExperimentPromiseGenerationRequest entity = requestRepository.findById(id)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Solicitação não encontrada"));
+        return toResponse(entity);
+    }
+
     /** Lista solicitações pendentes para o AI Worker consumir pelo endpoint pending. */
     @Transactional(readOnly = true)
     public List<GenerateExperimentPromiseOptionsResponse> listPending(int limit) {

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/web/ExperimentController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/web/ExperimentController.java
@@ -157,6 +157,12 @@ public class ExperimentController {
         return promiseGenerationService.generate(request);
     }
 
+    /** Consulta o status e o resultado de uma solicitação de promessa feita pela tela. */
+    @GetMapping("/promise-contract-options/stage-executions/{requestId}")
+    public GenerateExperimentPromiseOptionsResponse getPromiseOptions(@PathVariable Long requestId) {
+        return promiseGenerationService.get(requestId);
+    }
+
     /** Lista solicitações pendentes para consumo canônico do AI Worker pelo método pending. */
     @GetMapping("/promise-contract-options/stage-executions/pending")
     public java.util.List<GenerateExperimentPromiseOptionsResponse> pendingPromiseOptions(

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/service/ExperimentPromiseGenerationServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/service/ExperimentPromiseGenerationServiceTest.java
@@ -101,4 +101,19 @@ class ExperimentPromiseGenerationServiceTest {
                 .contains("Nicho selecionado", "Promessa validada", "Hipótese selecionada", "Fluxo de manutenção guiada");
         assertThat(persisted.getStatus()).isEqualTo(ExperimentPromiseGenerationRequestStatus.PENDING);
     }
+    /** Deve retornar o status persistido para a tela acompanhar a solicitação até a conclusão. */
+    @Test
+    void shouldGetPersistedPromiseOptionsRequestStatus() {
+        ExperimentPromiseGenerationRequest request = ExperimentPromiseGenerationRequest.builder()
+                .status(ExperimentPromiseGenerationRequestStatus.PROCESSING)
+                .build();
+        request.setId(456L);
+        when(requestRepository.findById(456L)).thenReturn(Optional.of(request));
+
+        var response = service.get(456L);
+
+        assertThat(response.requestId()).isEqualTo(456L);
+        assertThat(response.status()).isEqualTo(ExperimentPromiseGenerationRequestStatus.PROCESSING.name());
+        assertThat(response.options()).isEmpty();
+    }
 }

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -4934,3 +4934,10 @@
 - Atualizados os documentos canônicos para deixar explícito que o backend principal não executa OpenAI em fluxos de negócio.
 - Registrada a regra de que ações com IA devem ser persistidas pelo backend e consumidas pelo AI Worker ou worker executor via endpoint `pending`, com callback de resultado para consolidação no domínio.
 - Causa-raiz documental tratada: a regra estava aplicada no código/ArquiteturaTest, mas ainda não estava clara nos cânones globais de governança, pipeline operacional e persistência de informações tratadas por IA.
+
+## 2026-06-20 — Tela aguarda resposta final da IA na promessa única
+
+- Solicitação: manter na criação de experimento apenas a ação de solicitar por IA e exibir uma mensagem de aguardando até o fim do processamento e resposta da OpenAI.
+- Causa-raiz: o frontend tratava a solicitação assíncrona como se a resposta pudesse vir imediatamente, deixando a tela sem acompanhamento claro após registrar o pedido ao AI Worker.
+- Correção aplicada: a tela passa a registrar a solicitação, consultar o status pelo backend e manter aviso de aguardando até o retorno final; o backend expõe consulta por `requestId` para a tela mostrar a verdade persistida.
+- Prevenção de recorrência: o fluxo agora depende do status persistido no backend, evitando inferência local sobre conclusão de processamento da IA.

--- a/docs/swagger/openapi.yaml
+++ b/docs/swagger/openapi.yaml
@@ -128,6 +128,24 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/GenerateExperimentPromiseOptionsResponse'
+  /api/experiments/promise-contract-options/stage-executions/{requestId}:
+    get:
+      tags: [Experiments]
+      summary: Consultar status e resultado de uma solicitação de promessa
+      parameters:
+        - in: path
+          name: requestId
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: Status atual da solicitação
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/GenerateExperimentPromiseOptionsResponse'
   /api/experiments/promise-contract-options/stage-executions/pending:
     get:
       tags: [Experiments]

--- a/frontend/src/api/experiment/useGeneratePromiseOptions.ts
+++ b/frontend/src/api/experiment/useGeneratePromiseOptions.ts
@@ -1,4 +1,4 @@
-import { useMutation } from "@tanstack/react-query";
+import { useMutation, useQuery } from "@tanstack/react-query";
 import axios from "axios";
 import { toast } from "react-toastify";
 
@@ -19,7 +19,7 @@ interface GeneratePromiseOptionsPayload {
   currentPrimaryCta?: string;
 }
 
-interface GeneratePromiseOptionsResponse {
+export interface GeneratePromiseOptionsResponse {
   requestId: number;
   status: string;
   options: PromiseOption[];
@@ -39,6 +39,23 @@ export function useGeneratePromiseOptions() {
     },
     onError: () => {
       toast.error("Não foi possível gerar opções com IA");
+    },
+  });
+}
+
+export function usePromiseOptionsRequest(requestId?: number) {
+  return useQuery({
+    queryKey: ["experiment-promise-options-request", requestId],
+    queryFn: async () => {
+      const { data } = await axios.get<GeneratePromiseOptionsResponse>(
+        `/api/experiments/promise-contract-options/stage-executions/${requestId}`,
+      );
+      return data;
+    },
+    enabled: Boolean(requestId),
+    refetchInterval: (query) => {
+      const status = query.state.data?.status;
+      return status && ["COMPLETED", "FAILED"].includes(status) ? false : 3000;
     },
   });
 }

--- a/frontend/src/pages/experiment/NewExperimentPage.tsx
+++ b/frontend/src/pages/experiment/NewExperimentPage.tsx
@@ -1,7 +1,10 @@
 import { useEffect, useState } from "react";
 import { useSearchParams } from "react-router-dom";
 import { useCreateExperiment } from "../../api/experiment/useCreateExperiment";
-import { useGeneratePromiseOptions } from "../../api/experiment/useGeneratePromiseOptions";
+import {
+  useGeneratePromiseOptions,
+  usePromiseOptionsRequest,
+} from "../../api/experiment/useGeneratePromiseOptions";
 import type { PromiseOption } from "../../api/experiment/useGeneratePromiseOptions";
 import { useImageGenerationModels } from "../../api/ai/useImageGenerationModels";
 import { useNiches } from "../../api/niche/useNiches";
@@ -83,6 +86,9 @@ export default function NewExperimentPage() {
   });
   const [autoSampleSize, setAutoSampleSize] = useState(true);
   const [promiseOptions, setPromiseOptions] = useState<PromiseOption[]>([]);
+  const [promiseRequestId, setPromiseRequestId] = useState<
+    number | undefined
+  >();
   const [autoMde, setAutoMde] = useState(true);
   const { data: hypotheses } = useHypothesesByNiche(form.nicheId);
   const { data: selectedHypothesis } = useHypothesis(
@@ -105,12 +111,24 @@ export default function NewExperimentPage() {
   const showHypSelect = hypothesisIdParam === "";
   const workerRequests = { instantForms: 0, emails: 0 };
   const canGeneratePromiseOptions = Boolean(form.nicheId && form.hypothesisId);
+  const promiseOptionsRequest = usePromiseOptionsRequest(promiseRequestId);
+  const promiseRequestStatus = promiseOptionsRequest.data?.status;
+  const isWaitingPromiseOptions = Boolean(
+    promiseRequestId &&
+    !["COMPLETED", "FAILED"].includes(promiseRequestStatus ?? ""),
+  );
 
   useEffect(() => {
     if (selectedHypothesis?.title) {
       setForm((f) => ({ ...f, hypothesis: selectedHypothesis.title }));
     }
   }, [selectedHypothesis]);
+
+  useEffect(() => {
+    if (promiseOptionsRequest.data?.status === "COMPLETED") {
+      setPromiseOptions(promiseOptionsRequest.data.options ?? []);
+    }
+  }, [promiseOptionsRequest.data]);
 
   useEffect(() => {
     if ((!autoSampleSize && !autoMde) || !form.dailyBudget.trim()) {
@@ -147,6 +165,7 @@ export default function NewExperimentPage() {
       alert("Selecione o nicho e a hipótese antes de gerar com IA");
       return;
     }
+    setPromiseOptions([]);
     const response = await generatePromiseOptions.mutateAsync({
       nicheId: Number(form.nicheId),
       hypothesisId: form.hypothesisId,
@@ -155,6 +174,7 @@ export default function NewExperimentPage() {
       currentFunnelPromise: form.funnelPromise || undefined,
       currentPrimaryCta: form.primaryCta || undefined,
     });
+    setPromiseRequestId(response.requestId);
     setPromiseOptions(response.options ?? []);
   };
 
@@ -379,7 +399,9 @@ export default function NewExperimentPage() {
               type="button"
               className="btn btn-outline-primary btn-sm"
               disabled={
-                !canGeneratePromiseOptions || generatePromiseOptions.isPending
+                !canGeneratePromiseOptions ||
+                generatePromiseOptions.isPending ||
+                isWaitingPromiseOptions
               }
               title={
                 canGeneratePromiseOptions
@@ -388,21 +410,34 @@ export default function NewExperimentPage() {
               }
               onClick={handleGeneratePromiseOptions}
             >
-              {generatePromiseOptions.isPending ? (
+              {generatePromiseOptions.isPending || isWaitingPromiseOptions ? (
                 <span className="d-inline-flex align-items-center gap-1">
                   <span
                     className="spinner-border spinner-border-sm"
                     aria-hidden="true"
                   />
-                  Gerando...
+                  Aguardando IA...
                 </span>
               ) : canGeneratePromiseOptions ? (
-                "Gerar 3 opções com IA"
+                "Solicitar por IA"
               ) : (
                 "Selecione nicho e hipótese"
               )}
             </button>
           </div>
+          {isWaitingPromiseOptions && (
+            <div className="alert alert-warning py-2 mb-3" role="status">
+              Aguardando o processamento do AI Worker e a resposta final da
+              OpenAI. As opções aparecerão aqui automaticamente quando a
+              solicitação for concluída.
+            </div>
+          )}
+          {promiseRequestStatus === "FAILED" && (
+            <div className="alert alert-danger py-2 mb-3" role="alert">
+              A IA não conseguiu concluir esta solicitação. Tente solicitar
+              novamente.
+            </div>
+          )}
           {promiseOptions.length > 0 && (
             <div className="row g-2 mb-3">
               {promiseOptions.map((option, index) => (


### PR DESCRIPTION
### Motivation
- Manter na tela de novo experimento apenas a ação de "Solicitar por IA" e exibir ao usuário um estado claro de "aguardando" até que o AI Worker / OpenAI conclua a geração das 3 opções de promessa.

### Description
- Frontend: substituído o botão por "Solicitar por IA", adicionado `promiseRequestId` e a consulta periódica `usePromiseOptionsRequest` para acompanhar a solicitação registrada no backend e bloquear/mostrar indicador enquanto estiver pendente; exibe alerta de "Aguardando o processamento do AI Worker e a resposta final da OpenAI" e erro quando o request falha. (`frontend/src/pages/experiment/NewExperimentPage.tsx`, `frontend/src/api/experiment/useGeneratePromiseOptions.ts`)
- Backend: adicionado endpoint `GET /api/experiments/promise-contract-options/stage-executions/{requestId}` e método `ExperimentPromiseGenerationService.get(Long id)` para retornar o status/resultado persistido da solicitação. (`backend/ads-service/src/main/java/com/marketinghub/experiment/web/ExperimentController.java`, `backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentPromiseGenerationService.java`)
- Contratos & docs: atualização do OpenAPI (`docs/swagger/openapi.yaml`) para expor o novo endpoint e registro em `docs/registros/experimentos.md` descrevendo o comportamento de aguardar a resposta final da IA.
- Testes: adicionado teste unitário que valida a consulta do status persistido no serviço de geração de promessa. (`backend/ads-service/src/test/java/com/marketinghub/experiment/service/ExperimentPromiseGenerationServiceTest.java`)

### Testing
- Backend unit tests: rodei `cd backend/ads-service && mvn -Dtest=ExperimentPromiseGenerationServiceTest test` e os testes do `ExperimentPromiseGenerationServiceTest` (4 testes) passaram com sucesso. ✅
- Frontend build: rodei `npm --prefix frontend run build` e a build de produção do frontend foi gerada com sucesso. ✅

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a36fedd2110832183d8ad4b9feea061)