### PR TITLE
frontend: display MOIS sales-page commercial analysis in detail view

### DIFF
--- a/docs/registros/mois1.md
+++ b/docs/registros/mois1.md
@@ -1737,3 +1737,9 @@ Arquivos principais:
 - A tela de detalhe do produto passa a mostrar as tentativas de pesquisa pública feitas pelo worker do dossiê, incluindo query executada, quantidade de resultados lidos, resultados aproveitados, descartados e exemplo retornado.
 - O backend passa a persistir tentativas de busca em tabela própria e expor endpoint dedicado, para que o frontend mostre a verdade operacional persistida em vez de depender de logs técnicos.
 - O worker passa a reportar as tentativas ao concluir ou falhar o dossiê, explicando quando os resultados encontrados eram genéricos ou sem ligação comprovável com produto/produtor.
+
+## 2026-06-20 — Exibição da análise comercial no detalhe da Biblioteca Sales Pages
+
+- Diagnosticado que o produto 401 possuía análise comercial persistida (`scoreTotal=78`, status `DONE` e JSONs de seções/copy/visual/imagens), mas a tela de detalhe não renderizava essa informação.
+- Corrigida a causa-raiz no frontend MOIS: a rota `/mois/sales-pages-library/:pageId` agora consulta o endpoint de análise da página e exibe score, status, modelo, data, notas e blocos colapsáveis dos JSONs comerciais retornados pelo backend.
+- Mantida a regra de verdade da tela: a interface apenas apresenta os dados do contrato existente do backend, sem inferir conteúdo localmente.

--- a/frontend/src/pages/mois/MoisSalesPageLibraryDetailPage.tsx
+++ b/frontend/src/pages/mois/MoisSalesPageLibraryDetailPage.tsx
@@ -1,6 +1,8 @@
 import { Link, useParams } from "react-router-dom";
+import CollapsibleJsonViewer from "../../components/CollapsibleJsonViewer";
 import PageTitle from "../../components/PageTitle";
 import {
+  useMoisSalesLibraryPageAnalysis,
   useMoisSalesLibraryMarketWarmup,
   useMoisSalesLibraryMarketWarmupSearchAttempts,
   useMoisSalesLibraryMarketWarmupSources,
@@ -84,6 +86,7 @@ export default function MoisSalesPageLibraryDetailPage() {
     ? numericPageId
     : undefined;
   const pageQuery = useMoisSalesLibraryPage(validPageId);
+  const analysisQuery = useMoisSalesLibraryPageAnalysis(validPageId);
   const executionsQuery = useMoisSalesLibraryPageExecutions(validPageId);
   const marketWarmupQuery = useMoisSalesLibraryMarketWarmup(validPageId);
   const marketWarmupSearchAttemptsQuery =
@@ -338,6 +341,111 @@ export default function MoisSalesPageLibraryDetailPage() {
               próximo passo é corrigir a coleta para preencher preço,
               temperatura e produtor diretamente da página de venda.
             </div>
+          ) : null}
+        </div>
+      </section>
+
+      <section className="card border-0 shadow-sm">
+        <div className="card-body d-flex flex-column gap-3">
+          <div>
+            <h2 className="h5 mb-1">Análise da página de vendas</h2>
+            <p className="text-secondary mb-0">
+              Esta visão mostra a análise comercial feita pelo modelo sobre a
+              página capturada, usando somente dados retornados pelo backend.
+            </p>
+          </div>
+
+          {analysisQuery.isLoading ? (
+            <p className="text-secondary mb-0">
+              Carregando análise da página de vendas...
+            </p>
+          ) : null}
+          {analysisQuery.isError ? (
+            <div className="alert alert-warning mb-0">
+              Ainda não há análise comercial detalhada registrada para esta
+              página.
+            </div>
+          ) : null}
+          {analysisQuery.data ? (
+            <>
+              <div className="row g-3">
+                <div className="col-md-3">
+                  <div className="border rounded p-3 h-100 bg-light-subtle">
+                    <div className="text-secondary small">Score comercial</div>
+                    <strong className="fs-5">
+                      {analysisQuery.data.scoreTotal ?? "—"}
+                    </strong>
+                  </div>
+                </div>
+                <div className="col-md-3">
+                  <div className="border rounded p-3 h-100 bg-light-subtle">
+                    <div className="text-secondary small">Status</div>
+                    <strong className="fs-5">{analysisQuery.data.status}</strong>
+                  </div>
+                </div>
+                <div className="col-md-3">
+                  <div className="border rounded p-3 h-100 bg-light-subtle">
+                    <div className="text-secondary small">Modelo</div>
+                    <strong className="fs-5">
+                      {displayText(analysisQuery.data.modelName)}
+                    </strong>
+                  </div>
+                </div>
+                <div className="col-md-3">
+                  <div className="border rounded p-3 h-100 bg-light-subtle">
+                    <div className="text-secondary small">Analisado em</div>
+                    <strong className="fs-6">
+                      {formatDate(analysisQuery.data.analyzedAt)}
+                    </strong>
+                  </div>
+                </div>
+              </div>
+
+              {analysisQuery.data.analysisNotes ? (
+                <div className="alert alert-info mb-0">
+                  {analysisQuery.data.analysisNotes}
+                </div>
+              ) : null}
+
+              <div className="row g-3">
+                <div className="col-lg-6">
+                  <div className="border rounded p-3 h-100">
+                    <h3 className="h6 mb-2">Seções identificadas</h3>
+                    <CollapsibleJsonViewer
+                      content={analysisQuery.data.sectionsJson}
+                      initiallyCollapsed
+                    />
+                  </div>
+                </div>
+                <div className="col-lg-6">
+                  <div className="border rounded p-3 h-100">
+                    <h3 className="h6 mb-2">Copy e persuasão</h3>
+                    <CollapsibleJsonViewer
+                      content={analysisQuery.data.copyJson}
+                      initiallyCollapsed
+                    />
+                  </div>
+                </div>
+                <div className="col-lg-6">
+                  <div className="border rounded p-3 h-100">
+                    <h3 className="h6 mb-2">Visual e confiança</h3>
+                    <CollapsibleJsonViewer
+                      content={analysisQuery.data.visualJson}
+                      initiallyCollapsed
+                    />
+                  </div>
+                </div>
+                <div className="col-lg-6">
+                  <div className="border rounded p-3 h-100">
+                    <h3 className="h6 mb-2">Imagens e provas</h3>
+                    <CollapsibleJsonViewer
+                      content={analysisQuery.data.imageJson}
+                      initiallyCollapsed
+                    />
+                  </div>
+                </div>
+              </div>
+            </>
           ) : null}
         </div>
       </section>


### PR DESCRIPTION
### Motivation

- The Sales Pages Library detail screen did not show persisted commercial analysis produced for a captured sales page, causing users to miss existing `score`, `status` and JSON sections persisted by the backend.
- The UI must surface the backend analysis without attempting to infer or re-compute results locally, so editors and reviewers can see the canonical model output.

### Description

- Added a new API hook usage `useMoisSalesLibraryPageAnalysis` and imported `CollapsibleJsonViewer` in `MoisSalesPageLibraryDetailPage.tsx` to fetch and render the analysis returned by the backend.
- Implemented a dedicated UI section titled "Análise da página de vendas" that shows `scoreTotal`, `status`, `modelName`, `analyzedAt`, optional `analysisNotes`, and four collapsible JSON viewers for `sectionsJson`, `copyJson`, `visualJson`, and `imageJson`.
- The section implements loading and error states and preserves the rule that the interface only presents backend-provided data without local inference.
- Updated documentation `docs/registros/mois1.md` to record the frontend fix and the expected behavior change.

### Testing

- Ran a frontend build and typecheck with `yarn build` and `yarn lint` to ensure no type or lint regressions, and the build completed successfully.
- Executed the frontend unit test suite with `yarn test` and verified relevant tests passed without failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a370074544083219501a866e17c59b5)