### PR TITLE
Adiciona indicadores de IA e Web nos cards do pipeline NichoCNAE v2

### DIFF
--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -1172,3 +1172,8 @@
 - A tela do pipeline v2 passa a mostrar quando um job foi encerrado sem subnicho viável (`NO_VIABLE_SUBNICHE`) em vez de apresentar apenas `COMPLETED`, reduzindo interpretação falsa de que houve nicho materializado.
 - Causa-raiz corrigida: a tela recebia apenas status técnico de execução aberta/encerrada, mas não recebia a decisão de negócio persistida no `outputPayload` da última etapa nem o custo contabilizado nos payloads.
 - Prevenção de recorrência: teste unitário do backend cobre agregação de decisão `NO_VIABLE_SUBNICHE`, explicação com contagens e custo de IA no job/CNAE.
+
+## 2026-06-20 — Ícones de IA e Web nos cards do pipeline NichoCNAE v2
+
+- Ajustada a tela do pipeline NichoCNAE v2 para sinalizar, em cada card de etapa, quando a etapa usa IA e/ou acessa a Web.
+- Causa-raiz preventiva: antes, o usuário precisava inferir pelo texto se haveria consumo de IA ou pesquisa externa, aumentando risco de leitura operacional errada sobre custo e dependência de fontes.

--- a/frontend/src/__tests__/OprmNavigation.test.tsx
+++ b/frontend/src/__tests__/OprmNavigation.test.tsx
@@ -62,6 +62,8 @@ describe("OPRM navigation", () => {
       screen.getByRole("button", { name: /iniciar novo job v2/i }),
     ).toBeTruthy();
     expect(screen.getByText(/^Acumulador de Conhecimento$/)).toBeTruthy();
+    expect(screen.getAllByText(/^IA$/).length).toBeGreaterThan(0);
+    expect(screen.getAllByText(/^Web$/).length).toBeGreaterThan(0);
   });
 
   it("translates v2 job stage names returned in English", () => {

--- a/frontend/src/pages/oprm/OprmNichoCnaeV2PipelinePage.tsx
+++ b/frontend/src/pages/oprm/OprmNichoCnaeV2PipelinePage.tsx
@@ -1,3 +1,4 @@
+import { Bot, Globe2 } from "lucide-react";
 import { Link, useParams } from "react-router-dom";
 import {
   useOprmNichoCnaeV2Jobs,
@@ -187,7 +188,16 @@ function JobsTable({
   );
 }
 
-const v2Stages = [
+const v2Stages: Array<{
+  number: number;
+  title: string;
+  status: string;
+  purpose: string;
+  output: string;
+  businessGate: string;
+  usesAi: boolean;
+  usesWeb: boolean;
+}> = [
   {
     number: 1,
     title: "Gerador de Candidatos",
@@ -198,6 +208,8 @@ const v2Stages = [
       "4 a 6 candidatos comparáveis, com identidade do executor, job operacional e hipóteses separadas.",
     businessGate:
       "Nenhum vencedor obrigatório quando não houver candidato viável.",
+    usesAi: true,
+    usesWeb: false,
   },
   {
     number: 2,
@@ -207,6 +219,8 @@ const v2Stages = [
       "Bloquear domínios inseguros, conteúdo inadequado e resultados fora do contexto antes de gastar IA.",
     output: "Lista segura e deduplicada de URLs candidatas para pesquisa.",
     businessGate: "Conteúdo inseguro ou contaminado não entra no pipeline.",
+    usesAi: false,
+    usesWeb: true,
   },
   {
     number: 3,
@@ -218,6 +232,8 @@ const v2Stages = [
       "Plano de pesquisa curto, natural e orientado a lacunas de evidência.",
     businessGate:
       "A pesquisa aprofunda apenas o que pode mudar a decisão comercial.",
+    usesAi: true,
+    usesWeb: true,
   },
   {
     number: 4,
@@ -228,6 +244,8 @@ const v2Stages = [
     output: "Até dois finalistas ou decisão NO_VIABLE_SUBNICHE.",
     businessGate:
       "O vencedor nasce de evidência observada, não de opinião prévia do modelo.",
+    usesAi: true,
+    usesWeb: false,
   },
   {
     number: 5,
@@ -239,6 +257,8 @@ const v2Stages = [
       "Snapshots rastreáveis com origem, trecho curto, metadados e custo.",
     businessGate:
       "Fonte adjacente não substitui prova direta do executor específico.",
+    usesAi: true,
+    usesWeb: true,
   },
   {
     number: 6,
@@ -249,6 +269,8 @@ const v2Stages = [
     output:
       "Claims auditáveis com trecho literal, fonte e diagnóstico semântico.",
     businessGate: "Nenhum claim sem trecho exato pode avançar para síntese.",
+    usesAi: true,
+    usesWeb: false,
   },
   {
     number: 7,
@@ -259,6 +281,8 @@ const v2Stages = [
     output:
       "Claims aprovados, rejeitados, contraditórios ou pendentes por nível de evidência.",
     businessGate: "Proximidade lexical não é prova de mercado.",
+    usesAi: true,
+    usesWeb: false,
   },
   {
     number: 8,
@@ -270,6 +294,8 @@ const v2Stages = [
       "Snapshot de conhecimento com versão, linhagem e lacunas acionáveis.",
     businessGate:
       "Reprocessar sem repetir erro, fonte rejeitada ou custo desnecessário.",
+    usesAi: false,
+    usesWeb: false,
   },
   {
     number: 9,
@@ -281,6 +307,8 @@ const v2Stages = [
       "Retry técnico ou reprocessamento cognitivo com motivo, estágio de retorno e versão de conhecimento.",
     businessGate:
       "Falha técnica não vira reprovação de mercado; falta de evidência não reinicia tudo.",
+    usesAi: false,
+    usesWeb: false,
   },
   {
     number: 10,
@@ -291,6 +319,8 @@ const v2Stages = [
     output:
       "Rotina funcional do executor com evidências, IDs de claims, domínios e limites explícitos.",
     businessGate: "Síntese não pode inventar dor, canal ou impacto econômico.",
+    usesAi: true,
+    usesWeb: false,
   },
   {
     number: 11,
@@ -302,6 +332,8 @@ const v2Stages = [
       "Nível E0 a E5, confiança explicável, motivos de reprovação e próximos movimentos.",
     businessGate:
       "Materialização automática só avança com evidência comercial mínima.",
+    usesAi: true,
+    usesWeb: false,
   },
   {
     number: 12,
@@ -313,6 +345,8 @@ const v2Stages = [
     output:
       "Nicho pronto para decisão de produto: executor, dor, resultado, mecanismo plausível e fontes.",
     businessGate: "A v2 calibra antes de publicar automaticamente para vendas.",
+    usesAi: false,
+    usesWeb: false,
   },
 ];
 
@@ -492,6 +526,23 @@ export default function OprmNichoCnaeV2PipelinePage() {
                     <span className="small text-primary fw-semibold">
                       {stage.status}
                     </span>
+                  </div>
+                  <div
+                    className="d-flex flex-wrap justify-content-end align-content-start gap-2"
+                    aria-label="Recursos usados pela etapa"
+                  >
+                    {stage.usesAi ? (
+                      <span className="badge rounded-pill text-bg-primary d-inline-flex align-items-center gap-1">
+                        <Bot size={14} aria-hidden="true" />
+                        IA
+                      </span>
+                    ) : null}
+                    {stage.usesWeb ? (
+                      <span className="badge rounded-pill text-bg-info d-inline-flex align-items-center gap-1">
+                        <Globe2 size={14} aria-hidden="true" />
+                        Web
+                      </span>
+                    ) : null}
                   </div>
                 </div>
                 <p className="mb-0">{stage.purpose}</p>


### PR DESCRIPTION
### Motivation
- Sinalizar de forma clara, por etapa do pipeline NichoCNAE v2, quando a etapa consome IA e/ou acessa a Web para evitar que operadores tenham que inferir esse comportamento pelo texto.
- Reduzir risco operacional e melhorar visibilidade de custo e dependências externas nas decisões de produto.

### Description
- Adiciona importação dos ícones `Bot` e `Globe2` de `lucide-react` e renderiza badges nos cards das etapas quando `usesAi` ou `usesWeb` estão true (`frontend/src/pages/oprm/OprmNichoCnaeV2PipelinePage.tsx`).
- Declara por etapa os novos campos `usesAi` e `usesWeb` no array `v2Stages` para modelar explicitamente os recursos usados por cada etapa.
- Atualiza o teste de navegação OPRM `frontend/src/__tests__/OprmNavigation.test.tsx` para verificar que os indicadores `IA` e `Web` aparecem na tela do pipeline v2.
- Registra a alteração no histórico operacional em `docs/registros/oprm1.md`.

### Testing
- Executado `npm --prefix frontend run typecheck`, que terminou sem erros.
- Executado `npm --prefix frontend run test -- OprmNavigation.test.tsx --run`, que retornou todas as assertions do arquivo (9 testes) como aprovadas.
- Tentativa de captura com Playwright para gerar screenshot falhou por limitação do ambiente (Chromium headless não encontrou a biblioteca de sistema `libatk-1.0.so.0`), ação que é complementar e não bloqueia o deploy das mudanças de interface.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3706805f288321a3f05dbe5c595b37)