### PR TITLE
NichoCNAE v2: add reprocess flow for NO_VIABLE_SUBNICHE, propagate attempt/knowledgeVersion and backend API changes

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,7 @@ O Marketing Hub é uma fábrica automatizada de produtos digitais: descobre dore
 - **Consulta obrigatória de loops conhecidos**: antes de corrigir problema recorrente ou investigar falha em GeraLanding, Facebook Ads, Lead Portal, OpenAI/schema, pipelines administrativos ou pipeline de hipótese, consultar `docs/registros/loops.md`. Se o problema corresponder a um `LOOP-*`, a correção deve fechar a causa-raiz sistêmica, atualizar ou criar teste de contrato que previna recorrência e registrar no documento de tema correspondente.
 - **Regra Número 3** : Seja SIMPLES, OBJETIVO e EFICAZ.
 - **Respostas ao usuário nesta interação**: ao responder o usuário, priorize um nível mais alto, conceitual, objetivo e orientado ao negócio; baseie as respostas principalmente na análise do código, do banco de dados e dos logs, e só depois complemente com a documentação quando necessário; reduza detalhes técnicos, comandos e implementação interna ao mínimo necessário para sustentar a decisão ou o próximo passo.
+- **Tamanho das respostas ao usuário**: manter respostas simples, objetivas e no tamanho aproximado da resposta anterior validada pelo usuário nesta conversa; usar seções curtas, bullets e apenas os detalhes necessários para sustentar a conclusão, decisão ou próximo passo.
 - invesgtigação da causa raiz
 - Se for um erro na tela:
 - 1. Pesquisar o dado da tela de qual endpoint ele vem

--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -1177,3 +1177,10 @@
 
 - Ajustada a tela do pipeline NichoCNAE v2 para sinalizar, em cada card de etapa, quando a etapa usa IA e/ou acessa a Web.
 - Causa-raiz preventiva: antes, o usuário precisava inferir pelo texto se haveria consumo de IA ou pesquisa externa, aumentando risco de leitura operacional errada sobre custo e dependência de fontes.
+
+## 2026-06-20 — NichoCNAE v2 reprocessa torneio sem finalistas viáveis
+
+- Ajustado o fluxo do executor OPRM NichoCNAE v2 para que `NO_VIABLE_SUBNICHE` no `candidate-tournament` não encerre o job imediatamente: a etapa agora encaminha para `reprocess-controller` com decisão e motivo explícitos.
+- O controlador de reprocessamento passa a reconhecer a decisão do torneio e devolver a menor etapa necessária (`candidate-tournament`) com nova tentativa cognitiva e nova versão de conhecimento.
+- Causa-raiz corrigida: o torneio sem finalistas emitia `nextStageCode` vazio, então o executor não criava a etapa de reprocessamento prevista na documentação operacional.
+- Prevenção de recorrência: testes cobrem o encaminhamento do torneio para reprocessamento, a leitura de `NO_VIABLE_SUBNICHE` pelo controlador e a propagação de tentativa/versão para a próxima pendência.

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnaev2/execution/NichoCnaeV2BackendClient.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnaev2/execution/NichoCnaeV2BackendClient.java
@@ -49,14 +49,19 @@ public class NichoCnaeV2BackendClient {
     }
 
     /** Registra no backend a próxima etapa pendente quando o contrato da etapa informar avanço operacional. */
-    public void createNextStage(NichoCnaeV2StageDefinition nextStage, NichoCnaeV2PendingExecution pending, String inputPayload) {
+    public void createNextStage(
+            NichoCnaeV2StageDefinition nextStage,
+            NichoCnaeV2PendingExecution pending,
+            String inputPayload,
+            Integer attemptNumber,
+            Integer knowledgeVersion) {
         Map<String, Object> request = new LinkedHashMap<>();
         request.put("jobId", pending.jobId());
         request.put("researchCycleId", pending.researchCycleId());
         request.put("sourceNicheId", pending.sourceNicheId());
         request.put("cnaeCode", pending.cnaeCode());
-        request.put("attemptNumber", pending.attemptNumber());
-        request.put("knowledgeVersion", pending.knowledgeVersion());
+        request.put("attemptNumber", attemptNumber == null ? pending.attemptNumber() : attemptNumber);
+        request.put("knowledgeVersion", knowledgeVersion == null ? pending.knowledgeVersion() : knowledgeVersion);
         request.put("materializationEnabled", pending.materializationEnabled());
         request.put("inputPayload", inputPayload);
         restTemplate.postForObject(backendBaseUrl + nextStage.backendPath(), request, Object.class);

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnaev2/execution/NichoCnaeV2PendingExecutionService.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnaev2/execution/NichoCnaeV2PendingExecutionService.java
@@ -215,6 +215,19 @@ public class NichoCnaeV2PendingExecutionService {
                     pending.stageExecutionId());
             return;
         }
-        backendClient.createNextStage(nextStage.get(), pending, outputPayload);
+        backendClient.createNextStage(
+                nextStage.get(),
+                pending,
+                outputPayload,
+                integer(result.output().get("attemptNumber")),
+                integer(result.output().get("knowledgeVersionTo")));
+    }
+
+    /** Converte metadado opcional da etapa para inteiro sem quebrar avanço quando ausente. */
+    private Integer integer(Object value) {
+        if (value instanceof Number number) {
+            return number.intValue();
+        }
+        return value == null || String.valueOf(value).isBlank() ? null : Integer.valueOf(String.valueOf(value));
     }
 }

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnaev2/pipeline/candidatetournament/CandidateTournamentProcessor.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnaev2/pipeline/candidatetournament/CandidateTournamentProcessor.java
@@ -38,7 +38,9 @@ public final class CandidateTournamentProcessor implements StageProcessor {
         output.put("finalistCount", finalists.size());
         output.put("rankedCandidates", ranked);
         output.put("finalists", finalists);
-        output.put("nextStageCode", finalists.isEmpty() ? "" : "source-fetcher-reranker");
+        output.put("gateDecision", decision);
+        output.put("reasonCode", finalists.isEmpty() ? "NO_VIABLE_SUBNICHE" : "FINALISTS_SELECTED");
+        output.put("nextStageCode", finalists.isEmpty() ? "reprocess-controller" : "source-fetcher-reranker");
         return new StageResult(decision, output, List.of(new StageArtifact(
                 "CANDIDATE_TOURNAMENT",
                 "inline://candidate-tournament/ranking",

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnaev2/pipeline/reprocesscontroller/ReprocessControllerProcessor.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnaev2/pipeline/reprocesscontroller/ReprocessControllerProcessor.java
@@ -19,7 +19,7 @@ public final class ReprocessControllerProcessor implements StageProcessor {
         Map<String, Object> input = context.input();
         String failureType = text(input.get("failureType")).toUpperCase(Locale.ROOT);
         String reasonCode = text(input.get("reasonCode")).toUpperCase(Locale.ROOT);
-        String gateDecision = text(input.get("gateDecision")).toUpperCase(Locale.ROOT);
+        String gateDecision = text(input.getOrDefault("gateDecision", input.get("tournamentDecision"))).toUpperCase(Locale.ROOT);
         int attemptNumber = integer(input.get("attemptNumber"), 1);
         int technicalRetryNumber = integer(input.get("technicalRetryNumber"), 0);
         int knowledgeVersion = integer(input.get("knowledgeVersion"), 1);
@@ -72,6 +72,10 @@ public final class ReprocessControllerProcessor implements StageProcessor {
         output.put("stage", "reprocess-controller");
         output.put("reprocessPlan", plan);
         output.put("executionMode", plan.get("executionMode"));
+        output.put("rewindToStage", plan.get("rewindToStage"));
+        output.put("attemptNumber", plan.get("attemptNumber"));
+        output.put("technicalRetryNumber", plan.get("technicalRetryNumber"));
+        output.put("knowledgeVersionTo", plan.getOrDefault("knowledgeVersionTo", plan.get("knowledgeVersion")));
         output.put("nextStageCode", plan.get("nextStageCode"));
         return new StageResult(status, output, List.of(new StageArtifact("REPROCESS_PLAN", "inline://reprocess-controller/plan", description)));
     }

--- a/oprm-coletor-mei/src/test/java/com/marketinghub/nichocnaev2/execution/NichoCnaeV2PendingExecutionServiceTest.java
+++ b/oprm-coletor-mei/src/test/java/com/marketinghub/nichocnaev2/execution/NichoCnaeV2PendingExecutionServiceTest.java
@@ -77,6 +77,40 @@ class NichoCnaeV2PendingExecutionServiceTest {
         service.processAllPending();
 
         verify(backendClient).complete(any(NichoCnaeV2StageDefinition.class), eq(pending), any());
-        verify(backendClient).createNextStage(any(NichoCnaeV2StageDefinition.class), eq(pending), any());
+        verify(backendClient).createNextStage(any(NichoCnaeV2StageDefinition.class), eq(pending), any(), eq(null), eq(null));
     }
+    /** Deve propagar tentativa e versão calculadas pelo controlador de reprocessamento para a próxima pendência. */
+    @Test
+    void propagatesReprocessAttemptAndKnowledgeVersionToNextStage() {
+        NichoCnaeV2BackendClient backendClient = mock(NichoCnaeV2BackendClient.class);
+        NichoCnaeV2StageDefinitions stageDefinitions = new NichoCnaeV2StageDefinitions();
+        NichoCnaeV2PendingExecutionService service = new NichoCnaeV2PendingExecutionService(backendClient, stageDefinitions);
+        NichoCnaeV2PendingExecution pending = new NichoCnaeV2PendingExecution(
+                "109",
+                "nichocnae-v2-candidate-2-job-4",
+                "4781400",
+                "Comércio varejista de artigos do vestuário e acessórios",
+                4L,
+                2L,
+                1,
+                0,
+                1,
+                false,
+                "{\"tournamentDecision\":\"NO_VIABLE_SUBNICHE\",\"informationGain\":0.2}",
+                Map.of());
+        when(backendClient.listPending(any())).thenAnswer(invocation -> {
+            NichoCnaeV2StageDefinition stage = invocation.getArgument(0);
+            return "reprocess-controller".equals(stage.stageCode()) ? List.of(pending) : List.of();
+        });
+        when(backendClient.parseInput(pending.inputPayload()))
+                .thenReturn(Map.of("tournamentDecision", "NO_VIABLE_SUBNICHE", "informationGain", 0.2));
+        when(backendClient.toJson(any())).thenReturn("{\"stage\":\"reprocess-controller\"}");
+
+        service.processAllPending();
+
+        verify(backendClient).complete(any(NichoCnaeV2StageDefinition.class), eq(pending), any());
+        verify(backendClient).createNextStage(
+                any(NichoCnaeV2StageDefinition.class), eq(pending), any(), eq(2), eq(2));
+    }
+
 }

--- a/oprm-coletor-mei/src/test/java/com/marketinghub/nichocnaev2/pipeline/candidatetournament/CandidateTournamentProcessorTest.java
+++ b/oprm-coletor-mei/src/test/java/com/marketinghub/nichocnaev2/pipeline/candidatetournament/CandidateTournamentProcessorTest.java
@@ -41,6 +41,8 @@ class CandidateTournamentProcessorTest {
 
         assertThat(result.status()).isEqualTo("NO_VIABLE_SUBNICHE");
         assertThat(result.output()).containsEntry("finalistCount", 0);
-        assertThat(result.output()).containsEntry("nextStageCode", "");
+        assertThat(result.output()).containsEntry("gateDecision", "NO_VIABLE_SUBNICHE");
+        assertThat(result.output()).containsEntry("reasonCode", "NO_VIABLE_SUBNICHE");
+        assertThat(result.output()).containsEntry("nextStageCode", "reprocess-controller");
     }
 }

--- a/oprm-coletor-mei/src/test/java/com/marketinghub/nichocnaev2/pipeline/reprocesscontroller/ReprocessControllerProcessorTest.java
+++ b/oprm-coletor-mei/src/test/java/com/marketinghub/nichocnaev2/pipeline/reprocesscontroller/ReprocessControllerProcessorTest.java
@@ -50,7 +50,25 @@ class ReprocessControllerProcessorTest {
         assertThat(plan).containsEntry("executionMode", "COGNITIVE_REPROCESS");
         assertThat(plan).containsEntry("rewindToStage", "adaptive-query-planner");
         assertThat(plan).containsEntry("knowledgeVersionTo", 5);
+        assertThat(result.output()).containsEntry("attemptNumber", 2);
+        assertThat(result.output()).containsEntry("knowledgeVersionTo", 5);
         assertThat((List<String>) plan.get("newEvidenceGaps")).contains("CONCRETE_EXECUTOR_TASKS");
+    }
+
+    /** Garante que ausência de finalista no torneio volta ao próprio torneio com nova tentativa cognitiva. */
+    @Test
+    void shouldReprocessNoViableTournamentDecisionToCandidateTournament() {
+        ReprocessControllerProcessor processor = new ReprocessControllerProcessor();
+        StageResult result = processor.process(new StageContext("job-81", "stage-9", Map.of(
+                "tournamentDecision", "NO_VIABLE_SUBNICHE",
+                "attemptNumber", 1,
+                "knowledgeVersion", 1,
+                "informationGain", 0.20)));
+
+        assertThat(result.status()).isEqualTo("COGNITIVE_REPROCESS_PLANNED");
+        assertThat(result.output()).containsEntry("nextStageCode", "candidate-tournament");
+        assertThat(result.output()).containsEntry("attemptNumber", 2);
+        assertThat(result.output()).containsEntry("knowledgeVersionTo", 2);
     }
 
     /** Garante encerramento seguro quando não há ganho informacional após o limite de tentativas. */


### PR DESCRIPTION
### Motivation

- Ensure a tournament with no viable finalists (`NO_VIABLE_SUBNICHE`) triggers a controlled reprocess instead of ending the job, preserving diagnosis and enabling a new cognitive attempt. 
- Preserve and propagate `attemptNumber` and `knowledgeVersion` information across stages so reprocesses use correct attempt/version metadata. 
- Make the executor-backend contract explicit by adding fields to the `createNextStage` API and reduce NPE/contract surprises. 
- Update operational docs and agent guidance to reflect the new behavior and response-size convention.

### Description

- Changed `CandidateTournamentProcessor` to emit `gateDecision`, `reasonCode`, and to set `nextStageCode` to `reprocess-controller` when no finalists are selected. 
- Extended `ReprocessControllerProcessor` to accept `tournamentDecision` as a fallback for `gateDecision`, include `attemptNumber`, `technicalRetryNumber`, and `knowledgeVersionTo` in the `StageResult` output, and ensure rewind targets `candidate-tournament` for `NO_VIABLE_SUBNICHE`. 
- Updated `NichoCnaeV2BackendClient.createNextStage` signature to accept `attemptNumber` and `knowledgeVersion` and use provided values or fall back to pending metadata. 
- Updated `NichoCnaeV2PendingExecutionService` to extract and forward optional `attemptNumber` and `knowledgeVersionTo` from stage output and added a safe `integer` helper. 
- Updated unit tests to reflect new outputs and propagation and added tests for reprocess propagation and tournament/no-finalist reprocess behavior. 
- Edited documentation files `AGENTS.md` and `docs/registros/oprm1.md` to document the operational change and a guideline about response size.

### Testing

- Ran unit tests for `CandidateTournamentProcessorTest` and they passed after asserting `gateDecision`, `reasonCode` and `nextStageCode` behavior. 
- Ran `ReprocessControllerProcessorTest` and the new tests validating `attemptNumber` and `knowledgeVersionTo` in outputs and the `NO_VIABLE_SUBNICHE` rewind passed. 
- Ran `NichoCnaeV2PendingExecutionServiceTest` and tests confirming `createNextStage` is invoked with propagated attempt/version values passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a370abcc2388321a2dc2657dba1d8b5)