### PR TITLE
fix(mois): considerar densidade visual na análise de sales pages

### DIFF
--- a/docs/registros/mois1.md
+++ b/docs/registros/mois1.md
@@ -1743,3 +1743,8 @@ Arquivos principais:
 - Diagnosticado que o produto 401 possuía análise comercial persistida (`scoreTotal=78`, status `DONE` e JSONs de seções/copy/visual/imagens), mas a tela de detalhe não renderizava essa informação.
 - Corrigida a causa-raiz no frontend MOIS: a rota `/mois/sales-pages-library/:pageId` agora consulta o endpoint de análise da página e exibe score, status, modelo, data, notas e blocos colapsáveis dos JSONs comerciais retornados pelo backend.
 - Mantida a regra de verdade da tela: a interface apenas apresenta os dados do contrato existente do backend, sem inferir conteúdo localmente.
+
+## 2026-06-20 — Correção do diagnóstico visual da Biblioteca Sales Pages
+
+- Corrigida a causa-raiz da análise comercial tratar páginas carregadas de imagens como se não tivessem evidência visual: o worker agora envia ao modelo um resumo objetivo de densidade de imagens e sinais de prova/depoimento extraídos do HTML.
+- Ajustado o prompt da análise para avaliar excesso, repetição e poluição visual, evitando recomendar mais imagens quando o problema comercial é organizar melhor o fluxo Dor → Resultado → Mecanismo → Prova → Oferta.

--- a/mois-sales-library-worker/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/pipeline/pageanalysis/OpenAiSalesPageAnalyzer.java
+++ b/mois-sales-library-worker/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/pipeline/pageanalysis/OpenAiSalesPageAnalyzer.java
@@ -68,8 +68,11 @@ public class OpenAiSalesPageAnalyzer {
      * Monta a linha JSONL enviada ao endpoint Batch da OpenAI.
      */
     private String buildBatchLine(long pageId, String canonicalUrl, String htmlBodyText) {
-        String prompt = "Analise a página de vendas e devolva JSON válido com os campos: score_total (0-100), sections_json (objeto), copy_json (objeto), visual_json (objeto), image_json (objeto), analysis_notes (texto curto). URL: "
-                + canonicalUrl + "\nConteúdo: " + htmlBodyText;
+        String prompt = "Analise a página de vendas e devolva JSON válido com os campos: score_total (0-100), sections_json (objeto), copy_json (objeto), visual_json (objeto), image_json (objeto), analysis_notes (texto curto). "
+                + "No campo image_json, avalie o fluxo visual real: densidade de imagens, repetição de depoimentos/antes-e-depois, excesso de provas visuais, risco de poluição visual e impacto na clareza da oferta. "
+                + "Se total_img ou imagens_com_sinais_de_prova indicar página carregada de imagens, não recomende adicionar mais imagens; recomende reduzir, agrupar, hierarquizar ou substituir por prova mais limpa. "
+                + "O campo recommended_images deve ser usado apenas para lacunas reais e deve priorizar no máximo 3 imagens essenciais ao fluxo Dor → Resultado → Mecanismo → Prova → Oferta. URL: "
+                + canonicalUrl + "\nConteúdo e resumo visual: " + htmlBodyText;
         try {
             return objectMapper.writeValueAsString(Map.of(
                     "custom_id", "page-" + pageId,

--- a/mois-sales-library-worker/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/pipeline/pageanalysis/PageAnalysisProcessor.java
+++ b/mois-sales-library-worker/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/pipeline/pageanalysis/PageAnalysisProcessor.java
@@ -49,12 +49,50 @@ public class PageAnalysisProcessor implements StageProcessor<PageAnalysisInput, 
         PageAnalysisInput input = context.input();
         if (input.rawHtml() != null && !input.rawHtml().isBlank()) {
             var doc = Jsoup.parse(input.rawHtml(), input.urlCanonical());
-            return doc.body() != null ? doc.body().text() : doc.text();
+            String bodyText = doc.body() != null ? doc.body().text() : doc.text();
+            return bodyText + "\n\n" + summarizeImagesForAnalysis(input.rawHtml(), input.urlCanonical());
         }
         log.warn("MOIS pageanalysis recebeu job sem rawHtml capturado; usando fallback ao vivo. jobId={}, pageId={}, urlCanonical={}",
                 context.execution().idJob(), input.pageId(), input.urlCanonical());
         var doc = Jsoup.connect(input.urlCanonical()).timeout(properties.requestTimeoutMs()).get();
-        return doc.body() != null ? doc.body().text() : "";
+        String bodyText = doc.body() != null ? doc.body().text() : "";
+        return bodyText + "\n\n" + summarizeImagesForAnalysis(doc.html(), input.urlCanonical());
+    }
+
+    /** Resume evidências visuais do HTML para evitar que a análise trate página carregada de imagens como página sem imagem. */
+    String summarizeImagesForAnalysis(String rawHtml, String baseUrl) {
+        var doc = Jsoup.parse(rawHtml == null ? "" : rawHtml, baseUrl);
+        var images = doc.select("img");
+        long proofLikeImages = images.stream()
+                .filter(img -> {
+                    String evidence = (img.attr("alt") + " " + img.attr("src") + " " + img.attr("class") + " " + (img.parent() == null ? "" : img.parent().text())).toLowerCase();
+                    return evidence.contains("depo") || evidence.contains("antes") || evidence.contains("after")
+                            || evidence.contains("before") || evidence.contains("resultado") || evidence.contains("print")
+                            || evidence.contains("prova") || evidence.contains("whatsapp") || evidence.contains("instagram");
+                })
+                .count();
+        String samples = images.stream()
+                .limit(12)
+                .map(img -> {
+                    String alt = img.attr("alt").isBlank() ? "sem alt" : img.attr("alt");
+                    String src = img.attr("src").isBlank() ? img.attr("data-src") : img.attr("src");
+                    String parentText = img.parent() == null ? "" : img.parent().text();
+                    return "- alt='" + truncateForSummary(alt, 80) + "', src='" + truncateForSummary(src, 100)
+                            + "', contexto='" + truncateForSummary(parentText, 140) + "'";
+                })
+                .reduce("", (left, right) -> left + "\n" + right);
+        return "Resumo visual extraído do HTML: total_img=" + images.size()
+                + "; imagens_com_sinais_de_prova=" + proofLikeImages
+                + "; amostras=" + samples;
+    }
+
+    /** Limita textos usados no resumo visual para manter o prompt objetivo e barato. */
+    private String truncateForSummary(String value, int maxLength) {
+        String normalized = value == null ? "" : value.replaceAll("\\s+", " ").trim();
+        if (normalized.length() <= maxLength) {
+            return normalized;
+        }
+        return normalized.substring(0, maxLength) + "...";
     }
 
     /** Registra artefato lógico para o texto extraído do HTML capturado. */

--- a/mois-sales-library-worker/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/pipeline/pageanalysis/PageAnalysisProcessorTest.java
+++ b/mois-sales-library-worker/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/pipeline/pageanalysis/PageAnalysisProcessorTest.java
@@ -1,0 +1,50 @@
+package com.marketinghub.mois.bibliotecapaginavenda.worker.v1.pipeline.pageanalysis;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.marketinghub.mois.bibliotecapaginavenda.worker.v1.config.WorkerProperties;
+import org.junit.jupiter.api.Test;
+
+class PageAnalysisProcessorTest {
+
+    /** Garante que o resumo visual contabiliza imagens para evitar análise falsa de página sem imagem. */
+    @Test
+    void shouldSummarizeImageDensityAndProofSignals() {
+        PageAnalysisProcessor processor = new PageAnalysisProcessor(properties(), null);
+        String summary = processor.summarizeImagesForAnalysis("""
+                <html><body>
+                  <img src="depoimento-1.jpg" alt="print de depoimento">
+                  <img src="antes-depois.jpg" alt="antes e depois">
+                  <img src="hero.jpg" alt="capa do produto">
+                </body></html>
+                """, "https://example.com");
+
+        assertTrue(summary.contains("total_img=3"));
+        assertTrue(summary.contains("imagens_com_sinais_de_prova=2"));
+        assertTrue(summary.contains("print de depoimento"));
+    }
+
+    /** Cria propriedades mínimas para instanciar o processador sem executar integrações externas. */
+    private WorkerProperties properties() {
+        return new WorkerProperties(
+                "http://localhost",
+                "workspace",
+                "HOTMART",
+                "HOTMART",
+                "HOTMART",
+                "HOTMART",
+                1000,
+                1000,
+                1000,
+                10,
+                false,
+                false,
+                1000,
+                "worker",
+                "https://duckduckgo.com/html/",
+                10,
+                "Mozilla/5.0",
+                1000
+        );
+    }
+}


### PR DESCRIPTION
### Motivation

- Páginas muito carregadas de imagens estavam sendo tratadas como se não tivessem evidência visual, levando o modelo a recomendar mais imagens e gerando confusão na tela de detalhe; a intenção é que a análise reconheça densidade/provas visuais e oriente reduzir/organizar quando apropriado.

### Description

- Adiciona `summarizeImagesForAnalysis` em `PageAnalysisProcessor` para extrair `total_img`, contagem de imagens com sinais de prova/depoimento e amostras (`alt/src/contexto`) do HTML e anexar esse resumo ao texto enviado ao modelo (`mois-sales-library-worker/src/main/java/.../PageAnalysisProcessor.java`).
- Refina o prompt em `OpenAiSalesPageAnalyzer.buildBatchLine` para instruir o modelo a avaliar densidade de imagens, repetição/antes-e-depois, risco de poluição visual e a limitar `recommended_images` a no máximo 3, recomendando redução/agrupamento quando a página já estiver carregada (`mois-sales-library-worker/src/main/java/.../OpenAiSalesPageAnalyzer.java`).
- Garante que tanto o caminho com `rawHtml` quanto o fallback ao vivo incluam o resumo visual antes do envio ao OpenAI.
- Adiciona teste de regressão `PageAnalysisProcessorTest` que valida contagem de imagens e sinalização de provas; e registra a correção em `docs/registros/mois1.md`.

### Testing

- Executado `mvn -q -f mois-sales-library-worker/pom.xml test -Dtest=PageAnalysisProcessorTest` e o teste unitário passou com sucesso.
- Executado `mvn -q -f mois-sales-library-worker/pom.xml test` (testes do módulo MOIS) e a suíte do módulo passou sem falhas.
- O PR inclui o novo teste em `mois-sales-library-worker/src/test/java/.../PageAnalysisProcessorTest.java` e as alterações nos arquivos de worker e documentação listados acima.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a37255d1ea8832184e56dd2fff4d3aa)