### PR TITLE
Exibe status atual no detalhe da Biblioteca Sales Pages

### DIFF
--- a/docs/registros/mois1.md
+++ b/docs/registros/mois1.md
@@ -1754,3 +1754,9 @@ Arquivos principais:
 - Registrada no cânone MOIS a regra de que a análise da Biblioteca Sales Pages é diagnóstico de sucesso de produtos vencedores, não geração de sugestões.
 - Ajustado o worker para proibir sugestões, recomendações, próximos passos e chaves do tipo `recommended*` em todos os campos da resposta do modelo.
 - Ajustado o prompt da análise para avaliar excesso, repetição e poluição visual, evitando recomendar mais imagens quando o problema comercial é organizar melhor o fluxo Dor → Resultado → Mecanismo → Prova → Oferta.
+
+## 2026-06-21 — Status atual no detalhe da Biblioteca Sales Pages
+
+- Corrigida a falta de confirmação visual após o comando **Voltar para pendente** na rota `/mois/sales-pages-library/:pageId`.
+- A tela agora exibe um bloco explícito de **Status atual da solicitação**, com status geral, captura e análise comercial vindos do backend, além da confirmação retornada pelo endpoint de atualização manual.
+- Ajustada a invalidação do cache do detalhe da página para recarregar a verdade atualizada do backend depois da mudança de status.

--- a/frontend/src/api/mois/useMoisSalesLibrary.ts
+++ b/frontend/src/api/mois/useMoisSalesLibrary.ts
@@ -225,6 +225,9 @@ export function useUpdateMoisSalesLibraryPageStatus(workspaceId: string) {
         queryKey: ["mois", "sales-library", "pages", workspaceId],
       });
       void queryClient.invalidateQueries({
+        queryKey: ["mois", "sales-library", "page", variables.pageId],
+      });
+      void queryClient.invalidateQueries({
         queryKey: ["mois", "sales-library", "analysis", variables.pageId],
       });
       void queryClient.invalidateQueries({
@@ -359,9 +362,10 @@ export function useMoisSalesLibraryMarketWarmupSearchAttempts(
     ],
     enabled: Boolean(pageId) && enabled,
     queryFn: async () => {
-      const { data } = await axios.get<MoisMarketWarmupSearchAttemptListResponse>(
-        `/api/mois/sales-library/pages/${pageId}/market-warmup/search-attempts`,
-      );
+      const { data } =
+        await axios.get<MoisMarketWarmupSearchAttemptListResponse>(
+          `/api/mois/sales-library/pages/${pageId}/market-warmup/search-attempts`,
+        );
       return data;
     },
   });

--- a/frontend/src/pages/mois/MoisSalesPageLibraryDetailPage.tsx
+++ b/frontend/src/pages/mois/MoisSalesPageLibraryDetailPage.tsx
@@ -42,6 +42,43 @@ function formatDate(value?: string) {
     : date.toLocaleString("pt-BR", { dateStyle: "short", timeStyle: "short" });
 }
 
+function labelStatus(value?: string) {
+  const labels: Record<string, string> = {
+    PENDING: "Pendente",
+    FETCHING: "Em captura",
+    CAPTURING: "Em captura",
+    CAPTURED: "Capturada",
+    ANALYZING: "Em análise",
+    ANALYZED: "Analisada",
+    DONE: "Concluída",
+    FAILED: "Falhou",
+    ANULADO: "Anulada",
+    BLOCKED_COOLDOWN: "Aguardando nova tentativa",
+  };
+  return value ? labels[value] || value : "—";
+}
+
+function getStatusBadgeClass(value?: string) {
+  switch (value) {
+    case "DONE":
+    case "ANALYZED":
+    case "CAPTURED":
+      return "text-bg-success";
+    case "FAILED":
+    case "ANULADO":
+      return "text-bg-danger";
+    case "FETCHING":
+    case "CAPTURING":
+    case "ANALYZING":
+      return "text-bg-primary";
+    case "PENDING":
+    case "BLOCKED_COOLDOWN":
+      return "text-bg-warning";
+    default:
+      return "text-bg-secondary";
+  }
+}
+
 type HistoryItem = {
   key: string;
   stage: string;
@@ -124,6 +161,9 @@ export default function MoisSalesPageLibraryDetailPage() {
     requestWarmupMutation.isPending ||
     hasActiveWarmupDossier ||
     !isCommercialAnalysisDone;
+  const currentStatus = pageQuery.data?.currentStatus;
+  const analysisStatus = pageQuery.data?.analysisStatus;
+  const captureStatus = pageQuery.data?.captureStatus;
   const hotmartPrice = cleanText(pageQuery.data?.hotmartPrice);
   const hotmartTemperature = pageQuery.data?.hotmartTemperature;
   const hotmartProducer =
@@ -261,6 +301,54 @@ export default function MoisSalesPageLibraryDetailPage() {
         </button>
       </div>
 
+      <section className="card border-0 shadow-sm">
+        <div className="card-body d-flex flex-column gap-3">
+          <div className="d-flex flex-wrap align-items-center justify-content-between gap-2">
+            <div>
+              <h2 className="h5 mb-1">Status atual da solicitação</h2>
+              <p className="text-secondary mb-0">
+                A tela mostra o status confirmado pelo backend para esta página.
+              </p>
+            </div>
+            <span
+              className={`badge fs-6 ${getStatusBadgeClass(currentStatus)}`}
+            >
+              {labelStatus(currentStatus)}
+            </span>
+          </div>
+          <div className="row g-3">
+            <div className="col-md-4">
+              <div className="border rounded p-3 h-100 bg-light-subtle">
+                <div className="text-secondary small">Status geral</div>
+                <strong>{labelStatus(currentStatus)}</strong>
+              </div>
+            </div>
+            <div className="col-md-4">
+              <div className="border rounded p-3 h-100 bg-light-subtle">
+                <div className="text-secondary small">Captura</div>
+                <strong>{labelStatus(captureStatus)}</strong>
+              </div>
+            </div>
+            <div className="col-md-4">
+              <div className="border rounded p-3 h-100 bg-light-subtle">
+                <div className="text-secondary small">Análise comercial</div>
+                <strong>{labelStatus(analysisStatus)}</strong>
+              </div>
+            </div>
+          </div>
+          {updateStatusMutation.isSuccess ? (
+            <div className="alert alert-success mb-0">
+              Solicitação registrada pelo backend: status{" "}
+              <strong>{labelStatus(updateStatusMutation.data.status)}</strong>
+              {updateStatusMutation.data.jobId
+                ? ` • job ${updateStatusMutation.data.jobId}`
+                : ""}
+              .
+            </div>
+          ) : null}
+        </div>
+      </section>
+
       {updateStatusMutation.isError ? (
         <div className="alert alert-danger mb-0">
           Falha ao atualizar status da página.
@@ -380,7 +468,9 @@ export default function MoisSalesPageLibraryDetailPage() {
                 <div className="col-md-3">
                   <div className="border rounded p-3 h-100 bg-light-subtle">
                     <div className="text-secondary small">Status</div>
-                    <strong className="fs-5">{analysisQuery.data.status}</strong>
+                    <strong className="fs-5">
+                      {analysisQuery.data.status}
+                    </strong>
                   </div>
                 </div>
                 <div className="col-md-3">
@@ -483,12 +573,15 @@ export default function MoisSalesPageLibraryDetailPage() {
             <div className="border rounded p-3 bg-light-subtle">
               <h3 className="h6 mb-2">Tentativas de pesquisa realizadas</h3>
               <p className="small text-secondary mb-3">
-                Estas são as buscas que o worker fez e o motivo de elas terem
-                ou não virado fonte do dossiê.
+                Estas são as buscas que o worker fez e o motivo de elas terem ou
+                não virado fonte do dossiê.
               </p>
               <div className="d-flex flex-column gap-2">
                 {marketWarmupSearchAttemptsQuery.data.items.map((attempt) => (
-                  <div key={attempt.attemptId} className="border rounded p-2 bg-white">
+                  <div
+                    key={attempt.attemptId}
+                    className="border rounded p-2 bg-white"
+                  >
                     <div className="d-flex flex-wrap justify-content-between gap-2">
                       <strong>{attempt.queryText}</strong>
                       <span
@@ -504,7 +597,9 @@ export default function MoisSalesPageLibraryDetailPage() {
                       </span>
                     </div>
                     <div className="small text-secondary mt-1">
-                      Resultados lidos: {attempt.resultCount} • aproveitados: {attempt.qualifiedCount} • descartados: {attempt.rejectedCount}
+                      Resultados lidos: {attempt.resultCount} • aproveitados:{" "}
+                      {attempt.qualifiedCount} • descartados:{" "}
+                      {attempt.rejectedCount}
                     </div>
                     {attempt.rejectionReason ? (
                       <div className="small text-secondary mt-1">
@@ -518,7 +613,8 @@ export default function MoisSalesPageLibraryDetailPage() {
                         target="_blank"
                         rel="noreferrer"
                       >
-                        Exemplo retornado: {attempt.sampleResultTitle || attempt.sampleResultUrl}
+                        Exemplo retornado:{" "}
+                        {attempt.sampleResultTitle || attempt.sampleResultUrl}
                       </a>
                     ) : null}
                   </div>


### PR DESCRIPTION
### Motivation
- Usuários não recebiam confirmação visual do backend ao marcar uma página como `PENDING`, gerando dúvida sobre o resultado da ação.
- A tela de detalhe precisava refletir a verdade do backend mostrando status geral, captura e análise de forma explícita.

### Description
- Adiciona funções `labelStatus` e `getStatusBadgeClass` e um bloco visual `Status atual da solicitação` em `frontend/src/pages/mois/MoisSalesPageLibraryDetailPage.tsx` para mostrar `currentStatus`, `captureStatus` e `analysisStatus` vindos do backend.
- Após atualização manual de status, o `useUpdateMoisSalesLibraryPageStatus` mutation invalida também a query `['mois','sales-library','page', pageId]` em `frontend/src/api/mois/useMoisSalesLibrary.ts` para forçar o recarregamento da verdade do backend.
- Registra a alteração operacional no `docs/registros/mois1.md` com um item de log descrevendo a correção de UX/feedback.
- Pequenas correções de render/format no detalhe (ajuste de espaçamento e quebra de linha) e formatação com `prettier` no arquivo alterado.

### Testing
- Ran type checking with `npm --prefix frontend run typecheck` which completed successfully.
- Built the frontend with `npm --prefix frontend run build` which completed successfully and produced the production bundle.
- Attempted `npm --prefix frontend run lint -- --max-warnings=0` but the project has no `lint` script, so lint was not executed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a37319c1cac8321bdf746ee9041a7a9)