### PR TITLE
Add OpenAI interaction audit table and plumbing for NichoCNAE v2

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/OprmNichoCnaeV2OpenAiInteraction.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/OprmNichoCnaeV2OpenAiInteraction.java
@@ -1,0 +1,72 @@
+package com.marketinghub.oprm.nichocnae.v2;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.math.BigDecimal;
+import java.time.Instant;
+import lombok.Data;
+
+/** Entidade responsável por auditar cada interação OpenAI executada por etapas do pipeline NichoCNAE v2. */
+@Entity
+@Data
+@Table(name = "oprm_nichocnae_v2_openai_interaction")
+public class OprmNichoCnaeV2OpenAiInteraction {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "stage_execution_id", nullable = false)
+    private Long stageExecutionId;
+
+    @Column(name = "job_id", nullable = false, length = 96)
+    private String jobId;
+
+    @Column(name = "stage_code", nullable = false, length = 64)
+    private String stageCode;
+
+    @Column(name = "attempt_number", nullable = false)
+    private Integer attemptNumber;
+
+    @Column(name = "technical_retry_number", nullable = false)
+    private Integer technicalRetryNumber;
+
+    @Column(name = "model", length = 128)
+    private String model;
+
+    @Column(name = "service_tier", length = 32)
+    private String serviceTier;
+
+    @Column(name = "input_tokens")
+    private Integer inputTokens;
+
+    @Column(name = "output_tokens")
+    private Integer outputTokens;
+
+    @Column(name = "total_tokens")
+    private Integer totalTokens;
+
+    @Column(name = "cost_usd", precision = 12, scale = 6)
+    private BigDecimal costUsd;
+
+    @Column(name = "openai_response_id", length = 128)
+    private String openAiResponseId;
+
+    @Column(name = "raw_request", columnDefinition = "LONGTEXT")
+    private String rawRequest;
+
+    @Column(name = "raw_response", columnDefinition = "LONGTEXT")
+    private String rawResponse;
+
+    @Column(name = "status", length = 40)
+    private String status;
+
+    @Column(name = "error_message", columnDefinition = "LONGTEXT")
+    private String errorMessage;
+
+    @Column(name = "created_at", nullable = false)
+    private Instant createdAt;
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/adaptivequeryplanner/service/BackendAdaptiveQueryPlannerService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/adaptivequeryplanner/service/BackendAdaptiveQueryPlannerService.java
@@ -10,6 +10,7 @@ import com.marketinghub.oprm.nichocnae.v2.adaptivequeryplanner.service.createSta
 import com.marketinghub.oprm.nichocnae.v2.adaptivequeryplanner.service.failStageExecution.AdaptiveQueryPlannerFailureRequest;
 import com.marketinghub.oprm.nichocnae.v2.adaptivequeryplanner.service.failStageExecution.AdaptiveQueryPlannerFailureResponse;
 import com.marketinghub.oprm.nichocnae.v2.adaptivequeryplanner.service.pending.AdaptiveQueryPlannerPendingResponse;
+import com.marketinghub.oprm.nichocnae.v2.service.openaiinteraction.OpenAiInteractionAuditService;
 import com.marketinghub.repository.jpa.oprm.cnae.OprmNicheCandidateRepository;
 import com.marketinghub.repository.jpa.oprm.nichocnae.v2.OprmNichoCnaeV2StageExecutionRepository;
 import java.time.Instant;
@@ -26,19 +27,30 @@ import org.springframework.web.server.ResponseStatusException;
 public class BackendAdaptiveQueryPlannerService {
     public static final String STAGE_CODE = "adaptive-query-planner";
     private final OprmNichoCnaeV2StageExecutionRepository stageExecutionRepository;
+    private final OpenAiInteractionAuditService openAiInteractionAuditService;
     private final OprmNicheCandidateRepository nicheCandidateRepository;
     private final boolean v2Enabled;
 
     /** Inicializa o service com repositório canônico e feature flag de calibração da v2. */
     public BackendAdaptiveQueryPlannerService(
             OprmNichoCnaeV2StageExecutionRepository stageExecutionRepository,
+            OpenAiInteractionAuditService openAiInteractionAuditService,
             OprmNicheCandidateRepository nicheCandidateRepository,
             @Value("${oprm.nichocnae.v2.enabled:false}") boolean v2Enabled) {
         this.stageExecutionRepository = stageExecutionRepository;
+        this.openAiInteractionAuditService = openAiInteractionAuditService;
         this.nicheCandidateRepository = nicheCandidateRepository;
         this.v2Enabled = v2Enabled;
     }
 
+
+    /** Mantém compatibilidade com testes unitários que não exercem auditoria OpenAI. */
+    public BackendAdaptiveQueryPlannerService(
+            OprmNichoCnaeV2StageExecutionRepository stageExecutionRepository,
+            OprmNicheCandidateRepository nicheCandidateRepository,
+            boolean v2Enabled) {
+        this(stageExecutionRepository, null, nicheCandidateRepository, v2Enabled);
+    }
     /** Lista pendências disponíveis para consumo canônico pelo executor OPRM NichoCNAE v2. */
     @Transactional(readOnly = true)
     public List<AdaptiveQueryPlannerPendingResponse> pending() {
@@ -63,6 +75,9 @@ public class BackendAdaptiveQueryPlannerService {
         execution.setNextStageCode(request == null ? null : request.nextStageCode());
         execution.setUpdatedAt(Instant.now());
         OprmNichoCnaeV2StageExecution saved = stageExecutionRepository.save(execution);
+        if (openAiInteractionAuditService != null) {
+            openAiInteractionAuditService.record(saved, request == null ? null : request.openAiInteractions());
+        }
         return new AdaptiveQueryPlannerCompletionResponse(
                 String.valueOf(saved.getId()),
                 saved.getStatus().name(),

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/adaptivequeryplanner/service/completeStageExecution/AdaptiveQueryPlannerCompletionRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/adaptivequeryplanner/service/completeStageExecution/AdaptiveQueryPlannerCompletionRequest.java
@@ -1,5 +1,8 @@
 package com.marketinghub.oprm.nichocnae.v2.adaptivequeryplanner.service.completeStageExecution;
 
+import com.marketinghub.oprm.nichocnae.v2.service.openaiinteraction.OpenAiInteractionAuditRequest;
+import java.util.List;
+
 /** Contrato recebido do executor ao concluir a etapa adaptive-query-planner do NichoCNAE v2. */
 public record AdaptiveQueryPlannerCompletionRequest(
         String planDecision,
@@ -7,4 +10,16 @@ public record AdaptiveQueryPlannerCompletionRequest(
         Integer reusedQueryCount,
         Integer skippedQueryCount,
         String outputPayload,
-        String nextStageCode) {}
+        String nextStageCode,
+        List<OpenAiInteractionAuditRequest> openAiInteractions) {
+    /** Mantém compatibilidade com chamadas que ainda não enviam auditoria OpenAI estruturada. */
+    public AdaptiveQueryPlannerCompletionRequest(
+            String planDecision,
+            Integer plannedQueryCount,
+            Integer reusedQueryCount,
+            Integer skippedQueryCount,
+            String outputPayload,
+            String nextStageCode) {
+        this(planDecision, plannedQueryCount, reusedQueryCount, skippedQueryCount, outputPayload, nextStageCode, List.of());
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/candidategenerator/service/BackendCandidateGeneratorService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/candidategenerator/service/BackendCandidateGeneratorService.java
@@ -15,7 +15,9 @@ import com.marketinghub.oprm.nichocnae.v2.candidategenerator.service.failStageEx
 import com.marketinghub.oprm.nichocnae.v2.candidategenerator.service.listCnaeJobs.CandidateGeneratorCnaeJobSummary;
 import com.marketinghub.oprm.nichocnae.v2.candidategenerator.service.listCnaeJobs.CandidateGeneratorCnaeJobsResponse;
 import com.marketinghub.oprm.nichocnae.v2.candidategenerator.service.pending.CandidateGeneratorPendingResponse;
+import com.marketinghub.oprm.nichocnae.v2.service.openaiinteraction.OpenAiInteractionAuditService;
 import com.marketinghub.repository.jpa.oprm.cnae.OprmNicheCandidateRepository;
+import com.marketinghub.repository.jpa.oprm.nichocnae.v2.OprmNichoCnaeV2OpenAiInteractionRepository;
 import com.marketinghub.repository.jpa.oprm.nichocnae.v2.OprmNichoCnaeV2StageExecutionRepository;
 import java.math.BigDecimal;
 import java.time.Instant;
@@ -62,6 +64,8 @@ public class BackendCandidateGeneratorService {
 
     private final OprmNicheCandidateRepository nicheCandidateRepository;
     private final OprmNichoCnaeV2StageExecutionRepository stageExecutionRepository;
+    private final OpenAiInteractionAuditService openAiInteractionAuditService;
+    private final OprmNichoCnaeV2OpenAiInteractionRepository openAiInteractionRepository;
     private final boolean v2Enabled;
     private final boolean materializationEnabled;
 
@@ -69,14 +73,27 @@ public class BackendCandidateGeneratorService {
     public BackendCandidateGeneratorService(
             OprmNicheCandidateRepository nicheCandidateRepository,
             OprmNichoCnaeV2StageExecutionRepository stageExecutionRepository,
+            OpenAiInteractionAuditService openAiInteractionAuditService,
+            OprmNichoCnaeV2OpenAiInteractionRepository openAiInteractionRepository,
             @Value("${oprm.nichocnae.v2.enabled:false}") boolean v2Enabled,
             @Value("${oprm.nichocnae.v2.materialization-enabled:false}") boolean materializationEnabled) {
         this.nicheCandidateRepository = nicheCandidateRepository;
         this.stageExecutionRepository = stageExecutionRepository;
+        this.openAiInteractionAuditService = openAiInteractionAuditService;
+        this.openAiInteractionRepository = openAiInteractionRepository;
         this.v2Enabled = v2Enabled;
         this.materializationEnabled = materializationEnabled;
     }
 
+
+    /** Mantém compatibilidade com testes unitários que não exercem auditoria OpenAI. */
+    public BackendCandidateGeneratorService(
+            OprmNicheCandidateRepository nicheCandidateRepository,
+            OprmNichoCnaeV2StageExecutionRepository stageExecutionRepository,
+            boolean v2Enabled,
+            boolean materializationEnabled) {
+        this(nicheCandidateRepository, stageExecutionRepository, null, null, v2Enabled, materializationEnabled);
+    }
     /** Lista pendências disponíveis para consumo canônico pelo executor OPRM NichoCNAE v2. */
     @Transactional
     public List<CandidateGeneratorPendingResponse> pending() {
@@ -140,9 +157,10 @@ public class BackendCandidateGeneratorService {
         openJobs.sort(newestFirst);
         completedJobs.sort(newestFirst);
         BigDecimal cnaeAiCostUsd = executionsByJob.values().stream()
-                .map(this::sumAiCostUsd)
+                .map(executions -> sumAiCostUsd(executions.getFirst().getJobId(), executions))
                 .reduce(BigDecimal.ZERO, BigDecimal::add);
         boolean cnaeUsedAi = cnaeAiCostUsd.compareTo(BigDecimal.ZERO) > 0
+                || executionsByJob.keySet().stream().anyMatch(this::hasAuditedOpenAiInteraction)
                 || executionsByJob.values().stream().flatMap(List::stream).anyMatch(this::hasAiUsageSignal);
         return new CandidateGeneratorCnaeJobsResponse(cnaeCode, cnaeAiCostUsd, cnaeUsedAi, openJobs, completedJobs);
     }
@@ -157,6 +175,9 @@ public class BackendCandidateGeneratorService {
         execution.setNextStageCode(request == null ? null : request.nextStageCode());
         execution.setUpdatedAt(Instant.now());
         OprmNichoCnaeV2StageExecution saved = stageExecutionRepository.save(execution);
+        if (openAiInteractionAuditService != null) {
+            openAiInteractionAuditService.record(saved, request == null ? null : request.openAiInteractions());
+        }
         return new CandidateGeneratorCompletionResponse(
                 String.valueOf(saved.getId()),
                 saved.getStatus().name(),
@@ -211,8 +232,10 @@ public class BackendCandidateGeneratorService {
         String finalDecision = decisionFrom(lastOutput, lastExecution, executions);
         String finalDecisionReason = reasonForDecision(finalDecision, lastOutput, lastExecution, executions);
         String marketNicheId = marketNicheIdFrom(executions);
-        BigDecimal aiCostUsd = sumAiCostUsd(executions);
-        boolean usedAi = aiCostUsd.compareTo(BigDecimal.ZERO) > 0 || executions.stream().anyMatch(this::hasAiUsageSignal);
+        BigDecimal aiCostUsd = sumAiCostUsd(lastExecution.getJobId(), executions);
+        boolean usedAi = aiCostUsd.compareTo(BigDecimal.ZERO) > 0
+                || hasAuditedOpenAiInteraction(lastExecution.getJobId())
+                || executions.stream().anyMatch(this::hasAiUsageSignal);
         return new CandidateGeneratorCnaeJobSummary(
                 lastExecution.getJobId(),
                 lastExecution.getCnaeCode(),
@@ -385,7 +408,11 @@ public class BackendCandidateGeneratorService {
     }
 
     /** Soma custo de IA em dólares registrado na saída própria de cada etapa do job. */
-    private BigDecimal sumAiCostUsd(List<OprmNichoCnaeV2StageExecution> executions) {
+    private BigDecimal sumAiCostUsd(String jobId, List<OprmNichoCnaeV2StageExecution> executions) {
+        BigDecimal auditedCost = openAiInteractionRepository == null ? BigDecimal.ZERO : openAiInteractionRepository.sumCostUsdByJobId(jobId);
+        if (auditedCost != null && auditedCost.compareTo(BigDecimal.ZERO) > 0) {
+            return auditedCost;
+        }
         return executions.stream()
                 .map(execution -> costFromPayload(execution.getOutputPayload()))
                 .reduce(BigDecimal.ZERO, BigDecimal::add);
@@ -394,6 +421,11 @@ public class BackendCandidateGeneratorService {
     /** Verifica se há sinal de uso de IA mesmo quando o custo registrado for zero ou ausente. */
     private boolean hasAiUsageSignal(OprmNichoCnaeV2StageExecution execution) {
         return hasAiUsageSignal(parsePayload(execution.getOutputPayload()));
+    }
+
+    /** Verifica se o job possui interação OpenAI auditada em tabela própria. */
+    private boolean hasAuditedOpenAiInteraction(String jobId) {
+        return openAiInteractionRepository != null && openAiInteractionRepository.existsByJobId(jobId);
     }
 
     /** Detecta chaves explícitas de IA em payload estruturado para classificar o job corretamente. */

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/candidategenerator/service/completeStageExecution/CandidateGeneratorCompletionRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/candidategenerator/service/completeStageExecution/CandidateGeneratorCompletionRequest.java
@@ -1,13 +1,23 @@
 package com.marketinghub.oprm.nichocnae.v2.candidategenerator.service.completeStageExecution;
 
+import com.marketinghub.oprm.nichocnae.v2.service.openaiinteraction.OpenAiInteractionAuditRequest;
+import java.util.List;
+
 /** Contrato recebido do executor ao concluir a etapa candidate-generator do NichoCNAE v2. */
 public record CandidateGeneratorCompletionRequest(
         String qualityStatus,
         String requestedAction,
         String outputPayload,
-        String nextStageCode) {
+        String nextStageCode,
+        List<OpenAiInteractionAuditRequest> openAiInteractions) {
+    /** Mantém compatibilidade com chamadas que ainda não enviam auditoria OpenAI estruturada. */
+    public CandidateGeneratorCompletionRequest(
+            String qualityStatus, String requestedAction, String outputPayload, String nextStageCode) {
+        this(qualityStatus, requestedAction, outputPayload, nextStageCode, List.of());
+    }
+
     /** Mantém compatibilidade com chamadas que ainda não enviam a próxima etapa decidida pelo executor. */
     public CandidateGeneratorCompletionRequest(String qualityStatus, String requestedAction, String outputPayload) {
-        this(qualityStatus, requestedAction, outputPayload, null);
+        this(qualityStatus, requestedAction, outputPayload, null, List.of());
     }
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/candidatetournament/service/BackendCandidateTournamentService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/candidatetournament/service/BackendCandidateTournamentService.java
@@ -10,6 +10,7 @@ import com.marketinghub.oprm.nichocnae.v2.candidatetournament.service.createStag
 import com.marketinghub.oprm.nichocnae.v2.candidatetournament.service.failStageExecution.CandidateTournamentFailureRequest;
 import com.marketinghub.oprm.nichocnae.v2.candidatetournament.service.failStageExecution.CandidateTournamentFailureResponse;
 import com.marketinghub.oprm.nichocnae.v2.candidatetournament.service.pending.CandidateTournamentPendingResponse;
+import com.marketinghub.oprm.nichocnae.v2.service.openaiinteraction.OpenAiInteractionAuditService;
 import com.marketinghub.repository.jpa.oprm.cnae.OprmNicheCandidateRepository;
 import com.marketinghub.repository.jpa.oprm.nichocnae.v2.OprmNichoCnaeV2StageExecutionRepository;
 import java.time.Instant;
@@ -26,19 +27,30 @@ import org.springframework.web.server.ResponseStatusException;
 public class BackendCandidateTournamentService {
     public static final String STAGE_CODE = "candidate-tournament";
     private final OprmNichoCnaeV2StageExecutionRepository stageExecutionRepository;
+    private final OpenAiInteractionAuditService openAiInteractionAuditService;
     private final OprmNicheCandidateRepository nicheCandidateRepository;
     private final boolean v2Enabled;
 
     /** Inicializa o service com repositório canônico e feature flag de calibração da v2. */
     public BackendCandidateTournamentService(
             OprmNichoCnaeV2StageExecutionRepository stageExecutionRepository,
+            OpenAiInteractionAuditService openAiInteractionAuditService,
             OprmNicheCandidateRepository nicheCandidateRepository,
             @Value("${oprm.nichocnae.v2.enabled:false}") boolean v2Enabled) {
         this.stageExecutionRepository = stageExecutionRepository;
+        this.openAiInteractionAuditService = openAiInteractionAuditService;
         this.nicheCandidateRepository = nicheCandidateRepository;
         this.v2Enabled = v2Enabled;
     }
 
+
+    /** Mantém compatibilidade com testes unitários que não exercem auditoria OpenAI. */
+    public BackendCandidateTournamentService(
+            OprmNichoCnaeV2StageExecutionRepository stageExecutionRepository,
+            OprmNicheCandidateRepository nicheCandidateRepository,
+            boolean v2Enabled) {
+        this(stageExecutionRepository, null, nicheCandidateRepository, v2Enabled);
+    }
     /** Lista pendências disponíveis para consumo canônico pelo executor OPRM NichoCNAE v2. */
     @Transactional(readOnly = true)
     public List<CandidateTournamentPendingResponse> pending() {
@@ -63,6 +75,9 @@ public class BackendCandidateTournamentService {
         execution.setNextStageCode(request == null ? null : request.nextStageCode());
         execution.setUpdatedAt(Instant.now());
         OprmNichoCnaeV2StageExecution saved = stageExecutionRepository.save(execution);
+        if (openAiInteractionAuditService != null) {
+            openAiInteractionAuditService.record(saved, request == null ? null : request.openAiInteractions());
+        }
         return new CandidateTournamentCompletionResponse(
                 String.valueOf(saved.getId()),
                 saved.getStatus().name(),

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/candidatetournament/service/completeStageExecution/CandidateTournamentCompletionRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/candidatetournament/service/completeStageExecution/CandidateTournamentCompletionRequest.java
@@ -1,9 +1,19 @@
 package com.marketinghub.oprm.nichocnae.v2.candidatetournament.service.completeStageExecution;
 
+import com.marketinghub.oprm.nichocnae.v2.service.openaiinteraction.OpenAiInteractionAuditRequest;
+import java.util.List;
+
 /** Contrato recebido do executor ao concluir a etapa candidate-tournament do NichoCNAE v2. */
 public record CandidateTournamentCompletionRequest(
         String tournamentDecision,
         Integer candidateCount,
         Integer finalistCount,
         String outputPayload,
-        String nextStageCode) {}
+        String nextStageCode,
+        List<OpenAiInteractionAuditRequest> openAiInteractions) {
+    /** Mantém compatibilidade com chamadas que ainda não enviam auditoria OpenAI estruturada. */
+    public CandidateTournamentCompletionRequest(
+            String tournamentDecision, Integer candidateCount, Integer finalistCount, String outputPayload, String nextStageCode) {
+        this(tournamentDecision, candidateCount, finalistCount, outputPayload, nextStageCode, List.of());
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/commercialevidencegate/service/BackendCommercialEvidenceGateService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/commercialevidencegate/service/BackendCommercialEvidenceGateService.java
@@ -10,6 +10,7 @@ import com.marketinghub.oprm.nichocnae.v2.commercialevidencegate.service.createS
 import com.marketinghub.oprm.nichocnae.v2.commercialevidencegate.service.failStageExecution.CommercialEvidenceGateFailureRequest;
 import com.marketinghub.oprm.nichocnae.v2.commercialevidencegate.service.failStageExecution.CommercialEvidenceGateFailureResponse;
 import com.marketinghub.oprm.nichocnae.v2.commercialevidencegate.service.pending.CommercialEvidenceGatePendingResponse;
+import com.marketinghub.oprm.nichocnae.v2.service.openaiinteraction.OpenAiInteractionAuditService;
 import com.marketinghub.repository.jpa.oprm.cnae.OprmNicheCandidateRepository;
 import com.marketinghub.repository.jpa.oprm.nichocnae.v2.OprmNichoCnaeV2StageExecutionRepository;
 import java.time.Instant;
@@ -26,19 +27,30 @@ import org.springframework.web.server.ResponseStatusException;
 public class BackendCommercialEvidenceGateService {
     public static final String STAGE_CODE = "commercial-evidence-gate";
     private final OprmNichoCnaeV2StageExecutionRepository stageExecutionRepository;
+    private final OpenAiInteractionAuditService openAiInteractionAuditService;
     private final OprmNicheCandidateRepository nicheCandidateRepository;
     private final boolean v2Enabled;
 
     /** Inicializa o service com repositório canônico e feature flag de calibração da v2. */
     public BackendCommercialEvidenceGateService(
             OprmNichoCnaeV2StageExecutionRepository stageExecutionRepository,
+            OpenAiInteractionAuditService openAiInteractionAuditService,
             OprmNicheCandidateRepository nicheCandidateRepository,
             @Value("${oprm.nichocnae.v2.enabled:false}") boolean v2Enabled) {
         this.stageExecutionRepository = stageExecutionRepository;
+        this.openAiInteractionAuditService = openAiInteractionAuditService;
         this.nicheCandidateRepository = nicheCandidateRepository;
         this.v2Enabled = v2Enabled;
     }
 
+
+    /** Mantém compatibilidade com testes unitários que não exercem auditoria OpenAI. */
+    public BackendCommercialEvidenceGateService(
+            OprmNichoCnaeV2StageExecutionRepository stageExecutionRepository,
+            OprmNicheCandidateRepository nicheCandidateRepository,
+            boolean v2Enabled) {
+        this(stageExecutionRepository, null, nicheCandidateRepository, v2Enabled);
+    }
     /** Lista pendências disponíveis para consumo canônico pelo executor OPRM NichoCNAE v2. */
     @Transactional(readOnly = true)
     public List<CommercialEvidenceGatePendingResponse> pending() {
@@ -63,6 +75,9 @@ public class BackendCommercialEvidenceGateService {
         execution.setNextStageCode(request == null ? null : request.nextStageCode());
         execution.setUpdatedAt(Instant.now());
         OprmNichoCnaeV2StageExecution saved = stageExecutionRepository.save(execution);
+        if (openAiInteractionAuditService != null) {
+            openAiInteractionAuditService.record(saved, request == null ? null : request.openAiInteractions());
+        }
         return new CommercialEvidenceGateCompletionResponse(
                 String.valueOf(saved.getId()),
                 saved.getStatus().name(),

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/commercialevidencegate/service/completeStageExecution/CommercialEvidenceGateCompletionRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/commercialevidencegate/service/completeStageExecution/CommercialEvidenceGateCompletionRequest.java
@@ -1,5 +1,8 @@
 package com.marketinghub.oprm.nichocnae.v2.commercialevidencegate.service.completeStageExecution;
 
+import com.marketinghub.oprm.nichocnae.v2.service.openaiinteraction.OpenAiInteractionAuditRequest;
+import java.util.List;
+
 /** Contrato de escrita para registrar o resultado do gate comercial decidido pelo executor externo. */
 public record CommercialEvidenceGateCompletionRequest(
         String evidenceLevel,
@@ -9,4 +12,18 @@ public record CommercialEvidenceGateCompletionRequest(
         Double informationGain,
         String gateDecision,
         String nextStageCode,
-        String outputPayload) {}
+        String outputPayload,
+        List<OpenAiInteractionAuditRequest> openAiInteractions) {
+    /** Mantém compatibilidade com chamadas que ainda não enviam auditoria OpenAI estruturada. */
+    public CommercialEvidenceGateCompletionRequest(
+            String evidenceLevel,
+            Double confidence,
+            Boolean automaticMaterializationAllowed,
+            Boolean humanReviewRequired,
+            Double informationGain,
+            String gateDecision,
+            String nextStageCode,
+            String outputPayload) {
+        this(evidenceLevel, confidence, automaticMaterializationAllowed, humanReviewRequired, informationGain, gateDecision, nextStageCode, outputPayload, List.of());
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/enrichednichematerializer/service/BackendEnrichedNicheMaterializerService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/enrichednichematerializer/service/BackendEnrichedNicheMaterializerService.java
@@ -10,6 +10,7 @@ import com.marketinghub.oprm.nichocnae.v2.enrichednichematerializer.service.crea
 import com.marketinghub.oprm.nichocnae.v2.enrichednichematerializer.service.failStageExecution.EnrichedNicheMaterializerFailureRequest;
 import com.marketinghub.oprm.nichocnae.v2.enrichednichematerializer.service.failStageExecution.EnrichedNicheMaterializerFailureResponse;
 import com.marketinghub.oprm.nichocnae.v2.enrichednichematerializer.service.pending.EnrichedNicheMaterializerPendingResponse;
+import com.marketinghub.oprm.nichocnae.v2.service.openaiinteraction.OpenAiInteractionAuditService;
 import com.marketinghub.repository.jpa.oprm.cnae.OprmNicheCandidateRepository;
 import com.marketinghub.repository.jpa.oprm.nichocnae.v2.OprmNichoCnaeV2StageExecutionRepository;
 import java.time.Instant;
@@ -26,19 +27,30 @@ import org.springframework.web.server.ResponseStatusException;
 public class BackendEnrichedNicheMaterializerService {
     public static final String STAGE_CODE = "enriched-niche-materializer";
     private final OprmNichoCnaeV2StageExecutionRepository stageExecutionRepository;
+    private final OpenAiInteractionAuditService openAiInteractionAuditService;
     private final OprmNicheCandidateRepository nicheCandidateRepository;
     private final boolean v2Enabled;
 
     /** Inicializa o service com repositório canônico e feature flag de calibração da v2. */
     public BackendEnrichedNicheMaterializerService(
             OprmNichoCnaeV2StageExecutionRepository stageExecutionRepository,
+            OpenAiInteractionAuditService openAiInteractionAuditService,
             OprmNicheCandidateRepository nicheCandidateRepository,
             @Value("${oprm.nichocnae.v2.enabled:false}") boolean v2Enabled) {
         this.stageExecutionRepository = stageExecutionRepository;
+        this.openAiInteractionAuditService = openAiInteractionAuditService;
         this.nicheCandidateRepository = nicheCandidateRepository;
         this.v2Enabled = v2Enabled;
     }
 
+
+    /** Mantém compatibilidade com testes unitários que não exercem auditoria OpenAI. */
+    public BackendEnrichedNicheMaterializerService(
+            OprmNichoCnaeV2StageExecutionRepository stageExecutionRepository,
+            OprmNicheCandidateRepository nicheCandidateRepository,
+            boolean v2Enabled) {
+        this(stageExecutionRepository, null, nicheCandidateRepository, v2Enabled);
+    }
     /** Lista pendências disponíveis para consumo canônico pelo executor OPRM NichoCNAE v2. */
     @Transactional(readOnly = true)
     public List<EnrichedNicheMaterializerPendingResponse> pending() {
@@ -63,6 +75,9 @@ public class BackendEnrichedNicheMaterializerService {
         execution.setNextStageCode(request == null ? null : request.nextStageCode());
         execution.setUpdatedAt(Instant.now());
         OprmNichoCnaeV2StageExecution saved = stageExecutionRepository.save(execution);
+        if (openAiInteractionAuditService != null) {
+            openAiInteractionAuditService.record(saved, request == null ? null : request.openAiInteractions());
+        }
         return new EnrichedNicheMaterializerCompletionResponse(
                 String.valueOf(saved.getId()),
                 saved.getStatus().name(),

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/enrichednichematerializer/service/completeStageExecution/EnrichedNicheMaterializerCompletionRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/enrichednichematerializer/service/completeStageExecution/EnrichedNicheMaterializerCompletionRequest.java
@@ -1,5 +1,8 @@
 package com.marketinghub.oprm.nichocnae.v2.enrichednichematerializer.service.completeStageExecution;
 
+import com.marketinghub.oprm.nichocnae.v2.service.openaiinteraction.OpenAiInteractionAuditRequest;
+import java.util.List;
+
 /** Contrato de escrita para registrar a materialização decidida e executada pelo executor externo. */
 public record EnrichedNicheMaterializerCompletionRequest(
         String materializationDecision,
@@ -7,4 +10,16 @@ public record EnrichedNicheMaterializerCompletionRequest(
         Double confidence,
         Long materializedNicheId,
         String nextStageCode,
-        String outputPayload) {}
+        String outputPayload,
+        List<OpenAiInteractionAuditRequest> openAiInteractions) {
+    /** Mantém compatibilidade com chamadas que ainda não enviam auditoria OpenAI estruturada. */
+    public EnrichedNicheMaterializerCompletionRequest(
+            String materializationDecision,
+            String validationLevel,
+            Double confidence,
+            Long materializedNicheId,
+            String nextStageCode,
+            String outputPayload) {
+        this(materializationDecision, validationLevel, confidence, materializedNicheId, nextStageCode, outputPayload, List.of());
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/knowledgeaccumulator/service/BackendKnowledgeAccumulatorService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/knowledgeaccumulator/service/BackendKnowledgeAccumulatorService.java
@@ -10,6 +10,7 @@ import com.marketinghub.oprm.nichocnae.v2.knowledgeaccumulator.service.createSta
 import com.marketinghub.oprm.nichocnae.v2.knowledgeaccumulator.service.failStageExecution.KnowledgeAccumulatorFailureRequest;
 import com.marketinghub.oprm.nichocnae.v2.knowledgeaccumulator.service.failStageExecution.KnowledgeAccumulatorFailureResponse;
 import com.marketinghub.oprm.nichocnae.v2.knowledgeaccumulator.service.pending.KnowledgeAccumulatorPendingResponse;
+import com.marketinghub.oprm.nichocnae.v2.service.openaiinteraction.OpenAiInteractionAuditService;
 import com.marketinghub.repository.jpa.oprm.cnae.OprmNicheCandidateRepository;
 import com.marketinghub.repository.jpa.oprm.nichocnae.v2.OprmNichoCnaeV2StageExecutionRepository;
 import java.time.Instant;
@@ -26,19 +27,30 @@ import org.springframework.web.server.ResponseStatusException;
 public class BackendKnowledgeAccumulatorService {
     public static final String STAGE_CODE = "knowledge-accumulator";
     private final OprmNichoCnaeV2StageExecutionRepository stageExecutionRepository;
+    private final OpenAiInteractionAuditService openAiInteractionAuditService;
     private final OprmNicheCandidateRepository nicheCandidateRepository;
     private final boolean v2Enabled;
 
     /** Inicializa o service com repositório canônico e feature flag de calibração da v2. */
     public BackendKnowledgeAccumulatorService(
             OprmNichoCnaeV2StageExecutionRepository stageExecutionRepository,
+            OpenAiInteractionAuditService openAiInteractionAuditService,
             OprmNicheCandidateRepository nicheCandidateRepository,
             @Value("${oprm.nichocnae.v2.enabled:false}") boolean v2Enabled) {
         this.stageExecutionRepository = stageExecutionRepository;
+        this.openAiInteractionAuditService = openAiInteractionAuditService;
         this.nicheCandidateRepository = nicheCandidateRepository;
         this.v2Enabled = v2Enabled;
     }
 
+
+    /** Mantém compatibilidade com testes unitários que não exercem auditoria OpenAI. */
+    public BackendKnowledgeAccumulatorService(
+            OprmNichoCnaeV2StageExecutionRepository stageExecutionRepository,
+            OprmNicheCandidateRepository nicheCandidateRepository,
+            boolean v2Enabled) {
+        this(stageExecutionRepository, null, nicheCandidateRepository, v2Enabled);
+    }
     /** Lista pendências disponíveis para consumo canônico pelo executor OPRM NichoCNAE v2. */
     @Transactional(readOnly = true)
     public List<KnowledgeAccumulatorPendingResponse> pending() {
@@ -63,6 +75,9 @@ public class BackendKnowledgeAccumulatorService {
         execution.setNextStageCode(request == null ? null : request.nextStageCode());
         execution.setUpdatedAt(Instant.now());
         OprmNichoCnaeV2StageExecution saved = stageExecutionRepository.save(execution);
+        if (openAiInteractionAuditService != null) {
+            openAiInteractionAuditService.record(saved, request == null ? null : request.openAiInteractions());
+        }
         return new KnowledgeAccumulatorCompletionResponse(
                 String.valueOf(saved.getId()),
                 saved.getStatus().name(),

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/knowledgeaccumulator/service/completeStageExecution/KnowledgeAccumulatorCompletionRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/knowledgeaccumulator/service/completeStageExecution/KnowledgeAccumulatorCompletionRequest.java
@@ -1,5 +1,8 @@
 package com.marketinghub.oprm.nichocnae.v2.knowledgeaccumulator.service.completeStageExecution;
 
+import com.marketinghub.oprm.nichocnae.v2.service.openaiinteraction.OpenAiInteractionAuditRequest;
+import java.util.List;
+
 /** Contrato recebido do executor ao concluir a etapa knowledge-accumulator do NichoCNAE v2. */
 public record KnowledgeAccumulatorCompletionRequest(
         Integer knowledgeVersion,
@@ -7,4 +10,16 @@ public record KnowledgeAccumulatorCompletionRequest(
         Integer acceptedSourceCount,
         Integer rejectedSourceCount,
         String outputPayload,
-        String nextStageCode) {}
+        String nextStageCode,
+        List<OpenAiInteractionAuditRequest> openAiInteractions) {
+    /** Mantém compatibilidade com chamadas que ainda não enviam auditoria OpenAI estruturada. */
+    public KnowledgeAccumulatorCompletionRequest(
+            Integer knowledgeVersion,
+            Integer validatedFactCount,
+            Integer acceptedSourceCount,
+            Integer rejectedSourceCount,
+            String outputPayload,
+            String nextStageCode) {
+        this(knowledgeVersion, validatedFactCount, acceptedSourceCount, rejectedSourceCount, outputPayload, nextStageCode, List.of());
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/reprocesscontroller/service/BackendReprocessControllerService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/reprocesscontroller/service/BackendReprocessControllerService.java
@@ -10,6 +10,7 @@ import com.marketinghub.oprm.nichocnae.v2.reprocesscontroller.service.createStag
 import com.marketinghub.oprm.nichocnae.v2.reprocesscontroller.service.failStageExecution.ReprocessControllerFailureRequest;
 import com.marketinghub.oprm.nichocnae.v2.reprocesscontroller.service.failStageExecution.ReprocessControllerFailureResponse;
 import com.marketinghub.oprm.nichocnae.v2.reprocesscontroller.service.pending.ReprocessControllerPendingResponse;
+import com.marketinghub.oprm.nichocnae.v2.service.openaiinteraction.OpenAiInteractionAuditService;
 import com.marketinghub.repository.jpa.oprm.cnae.OprmNicheCandidateRepository;
 import com.marketinghub.repository.jpa.oprm.nichocnae.v2.OprmNichoCnaeV2StageExecutionRepository;
 import java.time.Instant;
@@ -26,19 +27,30 @@ import org.springframework.web.server.ResponseStatusException;
 public class BackendReprocessControllerService {
     public static final String STAGE_CODE = "reprocess-controller";
     private final OprmNichoCnaeV2StageExecutionRepository stageExecutionRepository;
+    private final OpenAiInteractionAuditService openAiInteractionAuditService;
     private final OprmNicheCandidateRepository nicheCandidateRepository;
     private final boolean v2Enabled;
 
     /** Inicializa o service com repositório canônico e feature flag de calibração da v2. */
     public BackendReprocessControllerService(
             OprmNichoCnaeV2StageExecutionRepository stageExecutionRepository,
+            OpenAiInteractionAuditService openAiInteractionAuditService,
             OprmNicheCandidateRepository nicheCandidateRepository,
             @Value("${oprm.nichocnae.v2.enabled:false}") boolean v2Enabled) {
         this.stageExecutionRepository = stageExecutionRepository;
+        this.openAiInteractionAuditService = openAiInteractionAuditService;
         this.nicheCandidateRepository = nicheCandidateRepository;
         this.v2Enabled = v2Enabled;
     }
 
+
+    /** Mantém compatibilidade com testes unitários que não exercem auditoria OpenAI. */
+    public BackendReprocessControllerService(
+            OprmNichoCnaeV2StageExecutionRepository stageExecutionRepository,
+            OprmNicheCandidateRepository nicheCandidateRepository,
+            boolean v2Enabled) {
+        this(stageExecutionRepository, null, nicheCandidateRepository, v2Enabled);
+    }
     /** Lista pendências disponíveis para consumo canônico pelo executor OPRM NichoCNAE v2. */
     @Transactional(readOnly = true)
     public List<ReprocessControllerPendingResponse> pending() {
@@ -62,6 +74,9 @@ public class BackendReprocessControllerService {
         execution.setNextStageCode(request == null ? null : request.nextStageCode());
         execution.setUpdatedAt(Instant.now());
         OprmNichoCnaeV2StageExecution saved = stageExecutionRepository.save(execution);
+        if (openAiInteractionAuditService != null) {
+            openAiInteractionAuditService.record(saved, request == null ? null : request.openAiInteractions());
+        }
         return new ReprocessControllerCompletionResponse(String.valueOf(saved.getId()), saved.getStatus().name(), request == null ? null : request.executionMode(), request == null ? null : request.rewindToStage(), request == null ? null : request.knowledgeVersionTo(), saved.getNextStageCode());
     }
 

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/reprocesscontroller/service/completeStageExecution/ReprocessControllerCompletionRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/reprocesscontroller/service/completeStageExecution/ReprocessControllerCompletionRequest.java
@@ -1,4 +1,14 @@
 package com.marketinghub.oprm.nichocnae.v2.reprocesscontroller.service.completeStageExecution;
 
+import com.marketinghub.oprm.nichocnae.v2.service.openaiinteraction.OpenAiInteractionAuditRequest;
+import java.util.List;
+
 /** Contrato de escrita para registrar plano de retry ou reprocessamento decidido pelo executor externo. */
-public record ReprocessControllerCompletionRequest(String executionMode, String rewindToStage, Integer knowledgeVersionTo, String nextStageCode, String outputPayload) {}
+public record ReprocessControllerCompletionRequest(String executionMode, String rewindToStage, Integer knowledgeVersionTo, String nextStageCode, String outputPayload,
+        List<OpenAiInteractionAuditRequest> openAiInteractions) {
+    /** Mantém compatibilidade com chamadas que ainda não enviam auditoria OpenAI estruturada. */
+    public ReprocessControllerCompletionRequest(
+            String executionMode, String rewindToStage, Integer knowledgeVersionTo, String nextStageCode, String outputPayload) {
+        this(executionMode, rewindToStage, knowledgeVersionTo, nextStageCode, outputPayload, List.of());
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/service/openaiinteraction/OpenAiInteractionAuditRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/service/openaiinteraction/OpenAiInteractionAuditRequest.java
@@ -1,0 +1,17 @@
+package com.marketinghub.oprm.nichocnae.v2.service.openaiinteraction;
+
+import java.math.BigDecimal;
+
+/** Contrato de auditoria recebido do executor para registrar uma chamada OpenAI feita por uma etapa v2. */
+public record OpenAiInteractionAuditRequest(
+        String model,
+        String serviceTier,
+        Integer inputTokens,
+        Integer outputTokens,
+        Integer totalTokens,
+        BigDecimal costUsd,
+        String openAiResponseId,
+        String rawRequest,
+        String rawResponse,
+        String status,
+        String errorMessage) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/service/openaiinteraction/OpenAiInteractionAuditService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/service/openaiinteraction/OpenAiInteractionAuditService.java
@@ -1,0 +1,52 @@
+package com.marketinghub.oprm.nichocnae.v2.service.openaiinteraction;
+
+import com.marketinghub.oprm.nichocnae.v2.OprmNichoCnaeV2OpenAiInteraction;
+import com.marketinghub.oprm.nichocnae.v2.OprmNichoCnaeV2StageExecution;
+import com.marketinghub.repository.jpa.oprm.nichocnae.v2.OprmNichoCnaeV2OpenAiInteractionRepository;
+import java.time.Instant;
+import java.util.List;
+import org.springframework.stereotype.Service;
+
+/** Service responsável por persistir auditoria financeira e operacional de chamadas OpenAI do NichoCNAE v2. */
+@Service
+public class OpenAiInteractionAuditService {
+    private final OprmNichoCnaeV2OpenAiInteractionRepository repository;
+
+    /** Inicializa o service com o repositório canônico de interações OpenAI do pipeline v2. */
+    public OpenAiInteractionAuditService(OprmNichoCnaeV2OpenAiInteractionRepository repository) {
+        this.repository = repository;
+    }
+
+    /** Registra as interações OpenAI informadas pelo executor para a execução de etapa concluída. */
+    public void record(OprmNichoCnaeV2StageExecution execution, List<OpenAiInteractionAuditRequest> requests) {
+        if (execution == null || requests == null || requests.isEmpty()) {
+            return;
+        }
+        Instant now = Instant.now();
+        repository.saveAll(requests.stream().map(request -> toEntity(execution, request, now)).toList());
+    }
+
+    /** Converte o contrato de auditoria em entidade persistível ligada ao job e à etapa. */
+    private OprmNichoCnaeV2OpenAiInteraction toEntity(
+            OprmNichoCnaeV2StageExecution execution, OpenAiInteractionAuditRequest request, Instant now) {
+        OprmNichoCnaeV2OpenAiInteraction entity = new OprmNichoCnaeV2OpenAiInteraction();
+        entity.setStageExecutionId(execution.getId());
+        entity.setJobId(execution.getJobId());
+        entity.setStageCode(execution.getStageCode());
+        entity.setAttemptNumber(execution.getAttemptNumber());
+        entity.setTechnicalRetryNumber(execution.getTechnicalRetryNumber());
+        entity.setModel(request.model());
+        entity.setServiceTier(request.serviceTier());
+        entity.setInputTokens(request.inputTokens());
+        entity.setOutputTokens(request.outputTokens());
+        entity.setTotalTokens(request.totalTokens());
+        entity.setCostUsd(request.costUsd());
+        entity.setOpenAiResponseId(request.openAiResponseId());
+        entity.setRawRequest(request.rawRequest());
+        entity.setRawResponse(request.rawResponse());
+        entity.setStatus(request.status());
+        entity.setErrorMessage(request.errorMessage());
+        entity.setCreatedAt(now);
+        return entity;
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/sourcefetcherreranker/service/BackendSourceFetcherRerankerService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/sourcefetcherreranker/service/BackendSourceFetcherRerankerService.java
@@ -10,6 +10,7 @@ import com.marketinghub.oprm.nichocnae.v2.sourcefetcherreranker.service.createSt
 import com.marketinghub.oprm.nichocnae.v2.sourcefetcherreranker.service.failStageExecution.SourceFetcherRerankerFailureRequest;
 import com.marketinghub.oprm.nichocnae.v2.sourcefetcherreranker.service.failStageExecution.SourceFetcherRerankerFailureResponse;
 import com.marketinghub.oprm.nichocnae.v2.sourcefetcherreranker.service.pending.SourceFetcherRerankerPendingResponse;
+import com.marketinghub.oprm.nichocnae.v2.service.openaiinteraction.OpenAiInteractionAuditService;
 import com.marketinghub.repository.jpa.oprm.cnae.OprmNicheCandidateRepository;
 import com.marketinghub.repository.jpa.oprm.nichocnae.v2.OprmNichoCnaeV2StageExecutionRepository;
 import java.time.Instant;
@@ -26,19 +27,30 @@ import org.springframework.web.server.ResponseStatusException;
 public class BackendSourceFetcherRerankerService {
     public static final String STAGE_CODE = "source-fetcher-reranker";
     private final OprmNichoCnaeV2StageExecutionRepository stageExecutionRepository;
+    private final OpenAiInteractionAuditService openAiInteractionAuditService;
     private final OprmNicheCandidateRepository nicheCandidateRepository;
     private final boolean v2Enabled;
 
     /** Inicializa o service com repositório canônico e feature flag de calibração da v2. */
     public BackendSourceFetcherRerankerService(
             OprmNichoCnaeV2StageExecutionRepository stageExecutionRepository,
+            OpenAiInteractionAuditService openAiInteractionAuditService,
             OprmNicheCandidateRepository nicheCandidateRepository,
             @Value("${oprm.nichocnae.v2.enabled:false}") boolean v2Enabled) {
         this.stageExecutionRepository = stageExecutionRepository;
+        this.openAiInteractionAuditService = openAiInteractionAuditService;
         this.nicheCandidateRepository = nicheCandidateRepository;
         this.v2Enabled = v2Enabled;
     }
 
+
+    /** Mantém compatibilidade com testes unitários que não exercem auditoria OpenAI. */
+    public BackendSourceFetcherRerankerService(
+            OprmNichoCnaeV2StageExecutionRepository stageExecutionRepository,
+            OprmNicheCandidateRepository nicheCandidateRepository,
+            boolean v2Enabled) {
+        this(stageExecutionRepository, null, nicheCandidateRepository, v2Enabled);
+    }
     /** Lista pendências disponíveis para consumo canônico pelo executor OPRM NichoCNAE v2. */
     @Transactional(readOnly = true)
     public List<SourceFetcherRerankerPendingResponse> pending() {
@@ -63,6 +75,9 @@ public class BackendSourceFetcherRerankerService {
         execution.setNextStageCode(request == null ? null : request.nextStageCode());
         execution.setUpdatedAt(Instant.now());
         OprmNichoCnaeV2StageExecution saved = stageExecutionRepository.save(execution);
+        if (openAiInteractionAuditService != null) {
+            openAiInteractionAuditService.record(saved, request == null ? null : request.openAiInteractions());
+        }
         return new SourceFetcherRerankerCompletionResponse(
                 String.valueOf(saved.getId()),
                 saved.getStatus().name(),

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/sourcefetcherreranker/service/completeStageExecution/SourceFetcherRerankerCompletionRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/sourcefetcherreranker/service/completeStageExecution/SourceFetcherRerankerCompletionRequest.java
@@ -1,5 +1,8 @@
 package com.marketinghub.oprm.nichocnae.v2.sourcefetcherreranker.service.completeStageExecution;
 
+import com.marketinghub.oprm.nichocnae.v2.service.openaiinteraction.OpenAiInteractionAuditRequest;
+import java.util.List;
+
 /** Contrato recebido do executor ao concluir a etapa source-fetcher-reranker do NichoCNAE v2. */
 public record SourceFetcherRerankerCompletionRequest(
         String sourceFetchDecision,
@@ -7,4 +10,16 @@ public record SourceFetcherRerankerCompletionRequest(
         Integer selectedSourceCount,
         Integer rejectedSourceCount,
         String outputPayload,
-        String nextStageCode) {}
+        String nextStageCode,
+        List<OpenAiInteractionAuditRequest> openAiInteractions) {
+    /** Mantém compatibilidade com chamadas que ainda não enviam auditoria OpenAI estruturada. */
+    public SourceFetcherRerankerCompletionRequest(
+            String sourceFetchDecision,
+            Integer fetchedSnapshotCount,
+            Integer selectedSourceCount,
+            Integer rejectedSourceCount,
+            String outputPayload,
+            String nextStageCode) {
+        this(sourceFetchDecision, fetchedSnapshotCount, selectedSourceCount, rejectedSourceCount, outputPayload, nextStageCode, List.of());
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/sourcesafetyfilter/service/BackendSourceSafetyFilterService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/sourcesafetyfilter/service/BackendSourceSafetyFilterService.java
@@ -10,6 +10,7 @@ import com.marketinghub.oprm.nichocnae.v2.sourcesafetyfilter.service.createStage
 import com.marketinghub.oprm.nichocnae.v2.sourcesafetyfilter.service.failStageExecution.SourceSafetyFilterFailureRequest;
 import com.marketinghub.oprm.nichocnae.v2.sourcesafetyfilter.service.failStageExecution.SourceSafetyFilterFailureResponse;
 import com.marketinghub.oprm.nichocnae.v2.sourcesafetyfilter.service.pending.SourceSafetyFilterPendingResponse;
+import com.marketinghub.oprm.nichocnae.v2.service.openaiinteraction.OpenAiInteractionAuditService;
 import com.marketinghub.repository.jpa.oprm.cnae.OprmNicheCandidateRepository;
 import com.marketinghub.repository.jpa.oprm.nichocnae.v2.OprmNichoCnaeV2StageExecutionRepository;
 import java.time.Instant;
@@ -26,19 +27,30 @@ import org.springframework.web.server.ResponseStatusException;
 public class BackendSourceSafetyFilterService {
     public static final String STAGE_CODE = "source-safety-filter";
     private final OprmNichoCnaeV2StageExecutionRepository stageExecutionRepository;
+    private final OpenAiInteractionAuditService openAiInteractionAuditService;
     private final OprmNicheCandidateRepository nicheCandidateRepository;
     private final boolean v2Enabled;
 
     /** Inicializa o service com repositório canônico e feature flag de calibração da v2. */
     public BackendSourceSafetyFilterService(
             OprmNichoCnaeV2StageExecutionRepository stageExecutionRepository,
+            OpenAiInteractionAuditService openAiInteractionAuditService,
             OprmNicheCandidateRepository nicheCandidateRepository,
             @Value("${oprm.nichocnae.v2.enabled:false}") boolean v2Enabled) {
         this.stageExecutionRepository = stageExecutionRepository;
+        this.openAiInteractionAuditService = openAiInteractionAuditService;
         this.nicheCandidateRepository = nicheCandidateRepository;
         this.v2Enabled = v2Enabled;
     }
 
+
+    /** Mantém compatibilidade com testes unitários que não exercem auditoria OpenAI. */
+    public BackendSourceSafetyFilterService(
+            OprmNichoCnaeV2StageExecutionRepository stageExecutionRepository,
+            OprmNicheCandidateRepository nicheCandidateRepository,
+            boolean v2Enabled) {
+        this(stageExecutionRepository, null, nicheCandidateRepository, v2Enabled);
+    }
     /** Lista pendências disponíveis para consumo canônico pelo executor OPRM NichoCNAE v2. */
     @Transactional(readOnly = true)
     public List<SourceSafetyFilterPendingResponse> pending() {
@@ -63,6 +75,9 @@ public class BackendSourceSafetyFilterService {
         execution.setNextStageCode(request == null ? null : request.nextStageCode());
         execution.setUpdatedAt(Instant.now());
         OprmNichoCnaeV2StageExecution saved = stageExecutionRepository.save(execution);
+        if (openAiInteractionAuditService != null) {
+            openAiInteractionAuditService.record(saved, request == null ? null : request.openAiInteractions());
+        }
         return new SourceSafetyFilterCompletionResponse(
                 String.valueOf(saved.getId()),
                 saved.getStatus().name(),

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/sourcesafetyfilter/service/completeStageExecution/SourceSafetyFilterCompletionRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/sourcesafetyfilter/service/completeStageExecution/SourceSafetyFilterCompletionRequest.java
@@ -1,15 +1,25 @@
 package com.marketinghub.oprm.nichocnae.v2.sourcesafetyfilter.service.completeStageExecution;
 
+import com.marketinghub.oprm.nichocnae.v2.service.openaiinteraction.OpenAiInteractionAuditRequest;
+import java.util.List;
+
 /** Contrato recebido do executor ao concluir a etapa source-safety-filter do NichoCNAE v2. */
 public record SourceSafetyFilterCompletionRequest(
         String safetyDecision,
         Integer allowedUrlCount,
         Integer rejectedUrlCount,
         String outputPayload,
-        String nextStageCode) {
+        String nextStageCode,
+        List<OpenAiInteractionAuditRequest> openAiInteractions) {
+    /** Mantém compatibilidade com chamadas que ainda não enviam auditoria OpenAI estruturada. */
+    public SourceSafetyFilterCompletionRequest(
+            String safetyDecision, Integer allowedUrlCount, Integer rejectedUrlCount, String outputPayload, String nextStageCode) {
+        this(safetyDecision, allowedUrlCount, rejectedUrlCount, outputPayload, nextStageCode, List.of());
+    }
+
     /** Mantém compatibilidade com chamadas que ainda não enviam a próxima etapa decidida pelo executor. */
     public SourceSafetyFilterCompletionRequest(
             String safetyDecision, Integer allowedUrlCount, Integer rejectedUrlCount, String outputPayload) {
-        this(safetyDecision, allowedUrlCount, rejectedUrlCount, outputPayload, null);
+        this(safetyDecision, allowedUrlCount, rejectedUrlCount, outputPayload, null, List.of());
     }
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/oprm/nichocnae/v2/OprmNichoCnaeV2OpenAiInteractionRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/oprm/nichocnae/v2/OprmNichoCnaeV2OpenAiInteractionRepository.java
@@ -1,0 +1,18 @@
+package com.marketinghub.repository.jpa.oprm.nichocnae.v2;
+
+import com.marketinghub.oprm.nichocnae.v2.OprmNichoCnaeV2OpenAiInteraction;
+import java.math.BigDecimal;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+/** Repositório responsável por consultar auditoria OpenAI do pipeline NichoCNAE v2. */
+public interface OprmNichoCnaeV2OpenAiInteractionRepository
+        extends JpaRepository<OprmNichoCnaeV2OpenAiInteraction, Long> {
+    /** Soma o custo auditado das chamadas OpenAI vinculadas a um job. */
+    @Query("select coalesce(sum(i.costUsd), 0) from OprmNichoCnaeV2OpenAiInteraction i where i.jobId = :jobId")
+    BigDecimal sumCostUsdByJobId(@Param("jobId") String jobId);
+
+    /** Verifica se existe qualquer interação OpenAI auditada para um job. */
+    boolean existsByJobId(String jobId);
+}

--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-21-oprm-nichocnae-v2-openai-interaction.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-21-oprm-nichocnae-v2-openai-interaction.yaml
@@ -1,0 +1,104 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-06-21-01-oprm-nichocnae-v2-openai-interaction
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - dbms:
+            type: mysql
+        - not:
+            - tableExists:
+                tableName: oprm_nichocnae_v2_openai_interaction
+      changes:
+        - createTable:
+            tableName: oprm_nichocnae_v2_openai_interaction
+            columns:
+              - column:
+                  name: id
+                  type: BIGINT
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    primaryKeyName: pk_oprm_nichocnae_v2_openai_interaction
+                    nullable: false
+              - column:
+                  name: stage_execution_id
+                  type: BIGINT
+                  constraints:
+                    nullable: false
+              - column:
+                  name: job_id
+                  type: VARCHAR(96)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: stage_code
+                  type: VARCHAR(64)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: attempt_number
+                  type: INT
+                  constraints:
+                    nullable: false
+              - column:
+                  name: technical_retry_number
+                  type: INT
+                  constraints:
+                    nullable: false
+              - column:
+                  name: model
+                  type: VARCHAR(128)
+              - column:
+                  name: service_tier
+                  type: VARCHAR(32)
+              - column:
+                  name: input_tokens
+                  type: INT
+              - column:
+                  name: output_tokens
+                  type: INT
+              - column:
+                  name: total_tokens
+                  type: INT
+              - column:
+                  name: cost_usd
+                  type: DECIMAL(12,6)
+              - column:
+                  name: openai_response_id
+                  type: VARCHAR(128)
+              - column:
+                  name: raw_request
+                  type: LONGTEXT
+              - column:
+                  name: raw_response
+                  type: LONGTEXT
+              - column:
+                  name: status
+                  type: VARCHAR(40)
+              - column:
+                  name: error_message
+                  type: LONGTEXT
+              - column:
+                  name: created_at
+                  type: DATETIME(6)
+                  constraints:
+                    nullable: false
+        - addForeignKeyConstraint:
+            baseTableName: oprm_nichocnae_v2_openai_interaction
+            baseColumnNames: stage_execution_id
+            constraintName: fk_oprm_nichocnae_v2_openai_interaction_stage
+            referencedTableName: oprm_nichocnae_v2_stage_execution
+            referencedColumnNames: id
+        - createIndex:
+            tableName: oprm_nichocnae_v2_openai_interaction
+            indexName: idx_oprm_nichocnae_v2_openai_job
+            columns:
+              - column:
+                  name: job_id
+        - createIndex:
+            tableName: oprm_nichocnae_v2_openai_interaction
+            indexName: idx_oprm_nichocnae_v2_openai_stage_execution
+            columns:
+              - column:
+                  name: stage_execution_id

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -1,5 +1,8 @@
 databaseChangeLog:
   - include:
+      file: changesets/2026-06-21-oprm-nichocnae-v2-openai-interaction.yaml
+      relativeToChangelogFile: true
+  - include:
       file: changesets/2026-06-20-experiment-promise-generation-request.yaml
       relativeToChangelogFile: true
   - include:

--- a/backend/ads-service/src/test/java/com/marketinghub/oprm/nichocnae/v2/OpenAiInteractionAuditServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/oprm/nichocnae/v2/OpenAiInteractionAuditServiceTest.java
@@ -1,0 +1,61 @@
+package com.marketinghub.oprm.nichocnae.v2;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyIterable;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.marketinghub.oprm.nichocnae.v2.service.openaiinteraction.OpenAiInteractionAuditRequest;
+import com.marketinghub.oprm.nichocnae.v2.service.openaiinteraction.OpenAiInteractionAuditService;
+import com.marketinghub.repository.jpa.oprm.nichocnae.v2.OprmNichoCnaeV2OpenAiInteractionRepository;
+import java.math.BigDecimal;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mockito;
+
+/** Testa a auditoria de interações OpenAI do pipeline NichoCNAE v2. */
+class OpenAiInteractionAuditServiceTest {
+    /** Deve persistir request, response, tokens, custo e vínculo operacional com job/etapa. */
+    @Test
+    void shouldPersistOpenAiInteractionAudit() {
+        OprmNichoCnaeV2OpenAiInteractionRepository repository = Mockito.mock(OprmNichoCnaeV2OpenAiInteractionRepository.class);
+        when(repository.saveAll(anyIterable())).thenAnswer(invocation -> invocation.getArgument(0));
+        OpenAiInteractionAuditService service = new OpenAiInteractionAuditService(repository);
+        OprmNichoCnaeV2StageExecution execution = new OprmNichoCnaeV2StageExecution();
+        execution.setId(42L);
+        execution.setJobId("job-1");
+        execution.setStageCode("candidate-generator");
+        execution.setAttemptNumber(1);
+        execution.setTechnicalRetryNumber(0);
+
+        service.record(
+                execution,
+                List.of(new OpenAiInteractionAuditRequest(
+                        "gpt-4.1-mini",
+                        "flex",
+                        100,
+                        40,
+                        140,
+                        new BigDecimal("0.001234"),
+                        "resp_123",
+                        "{\"request\":true}",
+                        "{\"response\":true}",
+                        "completed",
+                        null)));
+
+        ArgumentCaptor<Iterable<OprmNichoCnaeV2OpenAiInteraction>> captor = ArgumentCaptor.forClass(Iterable.class);
+        verify(repository).saveAll(captor.capture());
+        OprmNichoCnaeV2OpenAiInteraction saved = captor.getValue().iterator().next();
+        assertThat(saved.getStageExecutionId()).isEqualTo(42L);
+        assertThat(saved.getJobId()).isEqualTo("job-1");
+        assertThat(saved.getStageCode()).isEqualTo("candidate-generator");
+        assertThat(saved.getServiceTier()).isEqualTo("flex");
+        assertThat(saved.getInputTokens()).isEqualTo(100);
+        assertThat(saved.getOutputTokens()).isEqualTo(40);
+        assertThat(saved.getTotalTokens()).isEqualTo(140);
+        assertThat(saved.getCostUsd()).isEqualByComparingTo("0.001234");
+        assertThat(saved.getRawRequest()).contains("request");
+        assertThat(saved.getRawResponse()).contains("response");
+    }
+}

--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -1186,3 +1186,10 @@
 - Prevenção de recorrência: testes cobrem o encaminhamento do torneio para reprocessamento, a leitura de `NO_VIABLE_SUBNICHE` pelo controlador e a propagação de tentativa/versão para a próxima pendência.
 
 - 2026-06-20 00:00:00 (UTC): ajustada a tela e o contrato de jobs OPRM NichoCNAE v2 para exibir mensagem clara de sucesso ou fracasso no job concluído e CTA do backend para visualizar nicho materializado, abrir o CNAE para materialização ou pesquisar outro recorte, evitando que o usuário fique sem próximo passo.
+
+## 2026-06-21 — Auditoria OpenAI do pipeline NichoCNAE v2
+
+- Implementada tabela própria `oprm_nichocnae_v2_openai_interaction` para registrar, por execução de etapa v2, modelo, service tier, tokens, custo, request bruto, response bruto, status, erro e vínculo com `jobId`/`stageCode`.
+- Os callbacks de conclusão das etapas backend da v2 passam a aceitar `openAiInteractions`, permitindo que o executor informe todas as chamadas OpenAI realizadas pela etapa sem depender de JSON solto no `outputPayload`.
+- A tela/listagem de jobs passa a priorizar o custo auditado na tabela própria e mantém fallback para custos legados dentro do `outputPayload`, evitando perda de histórico durante transição.
+- Causa-raiz tratada: custo e auditoria de IA estavam inferidos por payload funcional, o que podia esconder gasto real quando uma etapa esquecesse de incluir chaves de custo no JSON de saída.

--- a/docs/swagger/oprm-nichocnae-v2-adaptive-query-planner-swagger.yaml
+++ b/docs/swagger/oprm-nichocnae-v2-adaptive-query-planner-swagger.yaml
@@ -27,7 +27,7 @@ paths:
             format: int64
       responses:
         "200":
-          description: Conclusão registrada com decisão de planejamento e próxima etapa.
+          description: Conclusão registrada; callbacks de etapas que usam OpenAI podem enviar openAiInteractions com modelo, service tier, tokens, custo, request e response brutos para auditoria. com decisão de planejamento e próxima etapa.
   /api/internal/oprm/nichocnae/v2/adaptive-query-planner/stage-executions/{stageExecutionId}/fail:
     post:
       summary: Registra falha e retry técnico da etapa adaptive-query-planner v2

--- a/docs/swagger/oprm-nichocnae-v2-candidate-generator-swagger.yaml
+++ b/docs/swagger/oprm-nichocnae-v2-candidate-generator-swagger.yaml
@@ -77,7 +77,7 @@ paths:
             format: int64
       responses:
         "200":
-          description: Conclusão registrada
+          description: Conclusão registrada; callbacks de etapas que usam OpenAI podem enviar openAiInteractions com modelo, service tier, tokens, custo, request e response brutos para auditoria.
   /api/internal/oprm/nichocnae/v2/candidate-generator/stage-executions/{stageExecutionId}/fail:
     post:
       summary: Registra falha e retry técnico da etapa candidate-generator v2

--- a/docs/swagger/oprm-nichocnae-v2-source-safety-filter-swagger.yaml
+++ b/docs/swagger/oprm-nichocnae-v2-source-safety-filter-swagger.yaml
@@ -27,7 +27,7 @@ paths:
             format: int64
       responses:
         "200":
-          description: Conclusão registrada com decisão de segurança e próxima etapa
+          description: Conclusão registrada; callbacks de etapas que usam OpenAI podem enviar openAiInteractions com modelo, service tier, tokens, custo, request e response brutos para auditoria. com decisão de segurança e próxima etapa
   /api/internal/oprm/nichocnae/v2/source-safety-filter/stage-executions/{stageExecutionId}/fail:
     post:
       summary: Registra falha e retry técnico da etapa source-safety-filter v2


### PR DESCRIPTION
### Motivation

- Introduzir auditoria estruturada de chamadas OpenAI do pipeline NichoCNAE v2 para registrar modelo, tokens, custo, request/response brutos e vínculo com `jobId`/`stageExecutionId` em tabela própria. 
- Permitir que as etapas da v2 enviem auditoria explícita em vez de depender apenas de campos livres no `outputPayload`, e priorizar custo auditado para exibição por job/CNAE.

### Description

- Added new JPA entity `OprmNichoCnaeV2OpenAiInteraction`, repository `OprmNichoCnaeV2OpenAiInteractionRepository`, Liquibase changeset `2026-06-21-oprm-nichocnae-v2-openai-interaction.yaml` and included it in `db.changelog-master.yaml` to create the `oprm_nichocnae_v2_openai_interaction` table. 
- Implemented `OpenAiInteractionAuditRequest` DTO and `OpenAiInteractionAuditService` which converts requests into entities and persists them via the new repository. 
- Extended multiple stage completion request contracts to accept `openAiInteractions` (records added/overloaded in `*CompletionRequest` types) and updated backend stage services to call `OpenAiInteractionAuditService.record(...)` on completion while preserving compatibility constructors for tests. 
- Updated `BackendCandidateGeneratorService` to prefer audited cost from `OprmNichoCnaeV2OpenAiInteractionRepository.sumCostUsdByJobId(...)`, added `hasAuditedOpenAiInteraction(...)` and wired the new repository where appropriate; updated Swagger and documentation to reflect the new audit field. 

### Testing

- Added `OpenAiInteractionAuditServiceTest` which mocks the repository, records a sample `OpenAiInteractionAuditRequest`, and asserts the persisted entity fields, and the test passed. 
- Project compiles with added entities, repository and database changelog (no other automated test failures reported).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3731d67a888321b0a7348845c1c75a)