### PR TITLE
Slim AI prompt for promise generation and remove manual contract fields from UI

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentPromiseGenerationService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentPromiseGenerationService.java
@@ -1,6 +1,7 @@
 package com.marketinghub.experiment.service;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marketinghub.experiment.promise.ExperimentPromiseGenerationRequest;
 import com.marketinghub.experiment.promise.ExperimentPromiseGenerationRequestStatus;
@@ -59,7 +60,7 @@ public class ExperimentPromiseGenerationService {
         MarketNiche niche = nicheRepository.findById(request.nicheId())
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Nicho não encontrado"));
         Hypothesis hypothesis = resolveHypothesis(request.hypothesisId());
-        String prompt = buildPrompt(request, niche, hypothesis);
+        String prompt = buildPrompt(niche, hypothesis);
         ExperimentPromiseGenerationRequest entity = ExperimentPromiseGenerationRequest.builder()
                 .niche(niche)
                 .hypothesis(hypothesis)
@@ -159,75 +160,114 @@ public class ExperimentPromiseGenerationService {
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Hipótese não encontrada"));
     }
 
-    /** Monta o contexto funcional do nicho, hipótese e campos já digitados na tela. */
-    private String buildPrompt(GenerateExperimentPromiseOptionsRequest request, MarketNiche niche, Hypothesis hypothesis) {
+    /** Monta um contexto comercial enxuto para evitar prompts grandes demais na geração de promessa. */
+    private String buildPrompt(MarketNiche niche, Hypothesis hypothesis) {
         StringBuilder sb = new StringBuilder();
-        sb.append("Contexto para gerar exatamente 3 opções diferentes de contrato de promessa única para um novo experimento.\n");
-        appendNicheDetails(sb, niche);
-        appendRichNicheDescription(sb, niche);
-        appendHypothesisPipelineDetails(sb, hypothesis);
-        appendIfPresent(sb, "Dor atual digitada", request.currentSinglePain());
-        appendIfPresent(sb, "Recompensa atual digitada", request.currentFreeReward());
-        appendIfPresent(sb, "Promessa atual digitada", request.currentFunnelPromise());
-        appendIfPresent(sb, "CTA atual digitado", request.currentPrimaryCta());
-        sb.append("\nAs três opções devem ser distintas: uma direta, uma emocional e uma operacional/prática.");
+        sb.append(
+                "Contexto enxuto para gerar exatamente 3 opções diferentes de contrato de promessa única para um novo experimento.\n");
+        appendCompactNicheDetails(sb, niche);
+        appendCompactHypothesisDetails(sb, hypothesis);
+        sb.append("\nRegras da resposta:\n");
+        sb.append("- Gere uma opção direta, uma emocional e uma operacional/prática.\n");
+        sb.append(
+                "- Cada opção deve conter uma dor única, uma recompensa gratuita concreta, uma promessa plausível e um CTA claro.\n");
+        sb.append("- Não use campos digitados pelo usuário; a tela escolhe uma opção gerada pela IA.\n");
         return sb.toString();
     }
 
-    /** Adiciona ao prompt os detalhes disponíveis do nicho selecionado. */
-    private void appendNicheDetails(StringBuilder sb, MarketNiche niche) {
+    /** Adiciona ao prompt apenas os sinais de nicho necessários para gerar promessa comercial. */
+    private void appendCompactNicheDetails(StringBuilder sb, MarketNiche niche) {
         sb.append("Nicho selecionado:\n");
-        appendIfPresent(sb, "- Nome", niche.getName());
-        appendIfPresent(sb, "- Descrição", niche.getDescription());
-        appendIfPresent(sb, "- Categoria de interesse", niche.getInterestCategory());
-        appendIfPresent(sb, "- Categoria de cargo", niche.getRoleCategory());
-        appendIfPresent(sb, "- Segmentação base", niche.getBaseSegmentation());
-        appendIfPresent(sb, "- Interesses", niche.getInterests());
-        appendIfPresent(sb, "- Filtros demográficos", niche.getDemographicFilters());
-        appendIfPresent(sb, "- Dicas extras", niche.getExtraTips());
-        appendIfPresent(sb, "- Promessas validadas", niche.getPromises());
-        appendIfPresent(sb, "- Ofertas validadas", niche.getOffers());
-        appendIfPresent(sb, "- Volume de demanda", niche.getDemandVolume());
-        appendIfPresent(sb, "- Modelo de hipóteses do nicho", niche.getHypothesisModel());
-        appendListIfPresent(sb, "- Lista curada de interesses", niche.getInterestList());
-        appendListIfPresent(sb, "- Lista curada de cargos", niche.getRoleList());
-        appendListIfPresent(sb, "- Lista curada de comportamentos", niche.getBehaviorList());
+        appendIfPresent(sb, "- Nome", compact(niche.getName(), 300));
+        appendIfPresent(sb, "- Descrição", compact(niche.getDescription(), 500));
+        appendIfPresent(sb, "- Segmentação base", compact(niche.getBaseSegmentation(), 500));
+        appendIfPresent(sb, "- Volume de demanda", compact(niche.getDemandVolume(), 300));
+        appendListIfPresent(sb, "- Interesses principais", niche.getInterestList());
+        appendListIfPresent(sb, "- Cargos principais", niche.getRoleList());
+        appendRichNicheSummary(sb, niche);
     }
 
-    /** Adiciona a descrição rica ativa do nicho quando ela já foi gerada pelo pipeline de IA. */
-    private void appendRichNicheDescription(StringBuilder sb, MarketNiche niche) {
+    /** Adiciona ao prompt um resumo da descrição rica sem incluir prompts ou evidências brutas. */
+    private void appendRichNicheSummary(StringBuilder sb, MarketNiche niche) {
         if (niche.getHypothesisDetailedDescription() == null) {
             return;
         }
         var description = niche.getHypothesisDetailedDescription();
-        sb.append("\nDescrição rica ativa do nicho:\n");
-        appendIfPresent(sb, "- Título da descrição rica", description.getTitle());
-        appendIfPresent(sb, "- Descrição rica", description.getDescription());
-        appendIfPresent(sb, "- Dores detalhadas", description.getPains());
-        appendIfPresent(sb, "- Desejos detalhados", description.getDesires());
-        appendIfPresent(sb, "- Necessidades detalhadas", description.getNeeds());
-        appendIfPresent(sb, "- Prompt que gerou a descrição rica", description.getPrompt());
-        appendIfPresent(sb, "- Modelo da descrição rica", description.getModel());
+        sb.append("\nResumo do nicho:\n");
+        appendIfPresent(sb, "- Dores", compact(description.getPains(), 900));
+        appendIfPresent(sb, "- Desejos", compact(description.getDesires(), 700));
+        appendIfPresent(sb, "- Necessidades", compact(description.getNeeds(), 700));
     }
 
-    /** Adiciona ao prompt o pipeline completo conhecido da hipótese selecionada. */
-    private void appendHypothesisPipelineDetails(StringBuilder sb, Hypothesis hypothesis) {
-        sb.append("\nHipótese selecionada e pipeline de hipótese:\n");
-        appendIfPresent(sb, "- Título", hypothesis.getTitle());
-        appendIfPresent(sb, "- Persona", hypothesis.getPersona());
-        appendIfPresent(sb, "- Dor", hypothesis.getProblem());
-        appendIfPresent(sb, "- Promessa", hypothesis.getPromise());
-        appendIfPresent(sb, "- Mecanismo", hypothesis.getMechanism());
-        appendIfPresent(sb, "- Mecanismo único", hypothesis.getUniqueMechanism());
-        appendIfPresent(sb, "- Entrega", hypothesis.getEntrega());
-        appendIfPresent(sb, "- Regra de sucesso", hypothesis.getSuccessRule());
-        appendIfPresent(sb, "- Tipo de oferta", hypothesis.getOfferType() != null ? hypothesis.getOfferType().name() : null);
+    /** Adiciona ao prompt os campos decisivos da hipótese sem carregar JSON completo ou prompt original. */
+    private void appendCompactHypothesisDetails(StringBuilder sb, Hypothesis hypothesis) {
+        sb.append("\nHipótese selecionada:\n");
+        appendIfPresent(sb, "- Título", compact(hypothesis.getTitle(), 300));
+        appendIfPresent(sb, "- Persona", compact(hypothesis.getPersona(), 500));
+        appendStructuredText(sb, "- Dor", hypothesis.getProblem(), 1200);
+        appendStructuredText(sb, "- Promessa", hypothesis.getPromise(), 900);
+        appendStructuredText(
+                sb, "- Mecanismo", firstText(hypothesis.getMechanism(), hypothesis.getUniqueMechanism()), 1000);
+        appendStructuredText(sb, "- Entrega", hypothesis.getEntrega(), 1200);
+        appendStructuredText(sb, "- Prova", hypothesis.getSuccessRule(), 900);
+        appendIfPresent(
+                sb, "- Tipo de oferta", hypothesis.getOfferType() != null ? hypothesis.getOfferType().name() : null);
         appendIfPresent(sb, "- Preço", hypothesis.getPrice() != null ? hypothesis.getPrice().toPlainString() : null);
-        appendIfPresent(sb, "- Meta de CPL", hypothesis.getKpiTargetCpl() != null ? hypothesis.getKpiTargetCpl().toPlainString() : null);
-        appendIfPresent(sb, "- Status", hypothesis.getStatus() != null ? hypothesis.getStatus().name() : null);
-        appendIfPresent(sb, "- Modelo da hipótese", hypothesis.getModel());
-        appendIfPresent(sb, "- Prompt que gerou a hipótese", hypothesis.getPrompt());
-        appendIfPresent(sb, "- Snapshot JSON do framework de hipótese", hypothesis.getFrameworkJson());
+    }
+
+    /** Adiciona texto estruturado priorizando summaries quando o campo estiver em JSON. */
+    private void appendStructuredText(StringBuilder sb, String label, String value, int maxLength) {
+        if (!StringUtils.hasText(value)) {
+            return;
+        }
+        appendIfPresent(sb, label, compact(extractUsefulText(value), maxLength));
+    }
+
+    /** Extrai o resumo funcional de JSONs de pipeline, evitando enviar evidências brutas para a IA. */
+    private String extractUsefulText(String value) {
+        String trimmed = value.trim();
+        if (!trimmed.startsWith("{") && !trimmed.startsWith("[")) {
+            return trimmed;
+        }
+        try {
+            JsonNode root = objectMapper.readTree(trimmed);
+            StringBuilder sb = new StringBuilder();
+            appendJsonField(sb, root, "summary");
+            appendJsonField(sb, root, "surface");
+            appendJsonField(sb, root, "root");
+            appendJsonField(sb, root, "entryPromise");
+            appendJsonField(sb, root, "coreOffer");
+            appendJsonField(sb, root, "proofMessage");
+            appendJsonField(sb, root, "mechanism");
+            return sb.length() > 0 ? sb.toString().trim() : trimmed;
+        } catch (JsonProcessingException ex) {
+            return trimmed;
+        }
+    }
+
+    /** Copia um campo textual de JSON para o resumo enviado ao modelo. */
+    private void appendJsonField(StringBuilder sb, JsonNode root, String fieldName) {
+        JsonNode node = root.path(fieldName);
+        if (node.isTextual() && StringUtils.hasText(node.asText())) {
+            sb.append(fieldName).append(": ").append(node.asText().trim()).append("\n");
+        }
+    }
+
+    /** Retorna o primeiro texto preenchido entre duas opções equivalentes. */
+    private String firstText(String first, String second) {
+        return StringUtils.hasText(first) ? first : second;
+    }
+
+    /** Limita textos longos preservando o começo do contexto de negócio. */
+    private String compact(String value, int maxLength) {
+        if (!StringUtils.hasText(value)) {
+            return null;
+        }
+        String normalized = value.trim().replaceAll("\\s+", " ");
+        if (normalized.length() <= maxLength) {
+            return normalized;
+        }
+        return normalized.substring(0, maxLength).trim() + "...";
     }
 
     /** Adiciona texto ao prompt quando o valor existe. */

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/service/ExperimentPromiseGenerationServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/service/ExperimentPromiseGenerationServiceTest.java
@@ -73,12 +73,13 @@ class ExperimentPromiseGenerationServiceTest {
         Hypothesis hypothesis = Hypothesis.builder()
                 .id(hypothesisId)
                 .title("Hipótese de agenda")
-                .problem("Clientes somem depois do atendimento")
+                .problem("{\"summary\":\"Clientes somem depois do atendimento\",\"evidenceSignals\":[\"evidência extensa que não deve entrar no prompt\"]}")
                 .promise("Agenda mais previsível")
                 .mechanism("Régua de manutenção")
                 .uniqueMechanism("Fluxo de manutenção guiada")
                 .entrega("Mensagens prontas")
                 .frameworkJson("{\"pain\":\"clientes somem\"}")
+                .prompt("Prompt bruto antigo que não deve entrar")
                 .build();
         when(nicheRepository.findById(7L)).thenReturn(Optional.of(niche));
         when(hypothesisRepository.findById(hypothesisId)).thenReturn(Optional.of(hypothesis));
@@ -89,7 +90,7 @@ class ExperimentPromiseGenerationServiceTest {
         });
 
         var response = service.generate(new GenerateExperimentPromiseOptionsRequest(
-                7L, hypothesisId, null, null, null, null, null));
+                7L, hypothesisId, "dor digitada", "recompensa digitada", "promessa digitada", "cta digitado", null));
 
         assertThat(response.requestId()).isEqualTo(123L);
         assertThat(response.status()).isEqualTo(ExperimentPromiseGenerationRequestStatus.PENDING.name());
@@ -99,9 +100,12 @@ class ExperimentPromiseGenerationServiceTest {
         verify(requestRepository).save(requestCaptor.capture());
         ExperimentPromiseGenerationRequest persisted = requestCaptor.getValue();
         assertThat(persisted.getPrompt())
-                .contains("Nicho selecionado", "Promessa validada", "Hipótese selecionada", "Fluxo de manutenção guiada");
+                .contains("Nicho selecionado", "Hipótese selecionada", "Clientes somem depois do atendimento")
+                .doesNotContain("evidência extensa", "Prompt bruto antigo", "dor digitada", "recompensa digitada");
+        assertThat(persisted.getPrompt().length()).isLessThan(8_000);
         assertThat(persisted.getStatus()).isEqualTo(ExperimentPromiseGenerationRequestStatus.PENDING);
     }
+
     /** Deve retornar o status persistido para a tela acompanhar a solicitação até a conclusão. */
     @Test
     void shouldGetPersistedPromiseOptionsRequestStatus() {

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -4957,3 +4957,10 @@
 - Ajuste: a chamada OpenAI da geração de contrato de promessa única passou a usar prompt markdown e schema JSON em arquivos do AI Worker, seguindo o padrão do GeraLanding.
 - Contexto comercial: o backend passou a incluir descrição rica ativa do nicho e o snapshot completo do pipeline de hipótese no prompt persistido para o worker.
 - Prevenção: a saída da OpenAI agora é validada por schema JSON estrito, reduzindo retorno fora do contrato esperado pela tela.
+
+## 2026-06-21 — Contrato de promessa única sem campos manuais
+
+- Solicitação: retirar da tela de novo experimento os campos editáveis de dor, recompensa, promessa e CTA, porque o contrato deve vir da opção gerada pela IA.
+- Causa-raiz: a tela enviava campos manuais mesmo quando nada era digitado e o backend montava um prompt excessivamente grande com JSONs e evidências brutas do nicho/hipótese, aumentando risco de falha no AI Worker/OpenAI.
+- Correção aplicada: o frontend agora só permite escolher uma opção gerada pela IA e exibe o contrato selecionado em modo leitura; o backend monta um contexto comercial enxuto para a fila do AI Worker, sem campos digitados pelo usuário, prompt original, snapshot completo ou evidências brutas.
+- Prevenção de recorrência: teste unitário passou a validar que o prompt persistido é compacto e não inclui campos manuais nem blocos brutos desnecessários.

--- a/frontend/src/pages/experiment/NewExperimentPage.tsx
+++ b/frontend/src/pages/experiment/NewExperimentPage.tsx
@@ -83,10 +83,9 @@ export default function NewExperimentPage() {
     primaryVariable: "",
     primaryMetric: "",
     singlePain: "",
-    freeReward:
-      "3 mensagens prontas para confirmar horário, pedir sinal e reagendar sem climão",
-    funnelPromise: "Receber as 3 mensagens",
-    primaryCta: "Receber as 3 mensagens",
+    freeReward: "",
+    funnelPromise: "",
+    primaryCta: "",
   });
   const [autoSampleSize, setAutoSampleSize] = useState(true);
   const [promiseOptions, setPromiseOptions] = useState<PromiseOption[]>([]);
@@ -139,10 +138,6 @@ export default function NewExperimentPage() {
       ...prev,
       nicheId: String(draft.nicheId),
       hypothesisId: draft.hypothesisId,
-      singlePain: draft.currentSinglePain ?? prev.singlePain,
-      freeReward: draft.currentFreeReward ?? prev.freeReward,
-      funnelPromise: draft.currentFunnelPromise ?? prev.funnelPromise,
-      primaryCta: draft.currentPrimaryCta ?? prev.primaryCta,
     }));
     setPromiseRequestId(draft.requestId);
     setPromiseOptions(draft.options ?? []);
@@ -206,10 +201,6 @@ export default function NewExperimentPage() {
     const response = await generatePromiseOptions.mutateAsync({
       nicheId: Number(form.nicheId),
       hypothesisId: form.hypothesisId,
-      currentSinglePain: form.singlePain || undefined,
-      currentFreeReward: form.freeReward || undefined,
-      currentFunnelPromise: form.funnelPromise || undefined,
-      currentPrimaryCta: form.primaryCta || undefined,
     });
     setPromiseRequestId(response.requestId);
     setPromiseOptions(response.options ?? []);
@@ -344,10 +335,9 @@ export default function NewExperimentPage() {
         primaryVariable: "",
         primaryMetric: "",
         singlePain: "",
-        freeReward:
-          "3 mensagens prontas para confirmar horário, pedir sinal e reagendar sem climão",
-        funnelPromise: "Receber as 3 mensagens",
-        primaryCta: "Receber as 3 mensagens",
+        freeReward: "",
+        funnelPromise: "",
+        primaryCta: "",
       });
       setAutoSampleSize(true);
       setAutoMde(true);
@@ -523,51 +513,33 @@ export default function NewExperimentPage() {
               ))}
             </div>
           )}
-          <label className="form-label" htmlFor="singlePain">
-            Dor única <span className="text-danger">*</span>
-          </label>
-          <input
-            id="singlePain"
-            className="form-control mb-2"
-            placeholder="Ex.: Clientes desmarcam horário em cima da hora"
-            value={form.singlePain}
-            onChange={(e) =>
-              setForm((prev) => ({ ...prev, singlePain: e.target.value }))
-            }
-          />
-          <label className="form-label" htmlFor="freeReward">
-            Recompensa gratuita única <span className="text-danger">*</span>
-          </label>
-          <input
-            id="freeReward"
-            className="form-control mb-2"
-            value={form.freeReward}
-            onChange={(e) =>
-              setForm((prev) => ({ ...prev, freeReward: e.target.value }))
-            }
-          />
-          <label className="form-label" htmlFor="funnelPromise">
-            Promessa do funil <span className="text-danger">*</span>
-          </label>
-          <input
-            id="funnelPromise"
-            className="form-control mb-2"
-            value={form.funnelPromise}
-            onChange={(e) =>
-              setForm((prev) => ({ ...prev, funnelPromise: e.target.value }))
-            }
-          />
-          <label className="form-label" htmlFor="primaryCta">
-            CTA principal <span className="text-danger">*</span>
-          </label>
-          <input
-            id="primaryCta"
-            className="form-control mb-2"
-            value={form.primaryCta}
-            onChange={(e) =>
-              setForm((prev) => ({ ...prev, primaryCta: e.target.value }))
-            }
-          />
+          {form.singlePain &&
+          form.freeReward &&
+          form.funnelPromise &&
+          form.primaryCta ? (
+            <div className="alert alert-success py-2 mb-3" role="status">
+              <div className="fw-semibold mb-1">
+                Contrato selecionado pela IA
+              </div>
+              <div className="small">
+                <strong>Dor:</strong> {form.singlePain}
+              </div>
+              <div className="small">
+                <strong>Recompensa:</strong> {form.freeReward}
+              </div>
+              <div className="small">
+                <strong>Promessa:</strong> {form.funnelPromise}
+              </div>
+              <div className="small">
+                <strong>CTA:</strong> {form.primaryCta}
+              </div>
+            </div>
+          ) : (
+            <div className="alert alert-secondary py-2 mb-3" role="status">
+              Solicite as opções por IA e escolha uma delas para fixar a dor, a
+              recompensa, a promessa e o CTA do experimento.
+            </div>
+          )}
           <div className="alert alert-info py-2 mb-0">
             Objetivo da campanha fixo: <strong>Leads</strong>. Não use Tráfego
             nem otimização para cliques neste fluxo.


### PR DESCRIPTION
### Motivation

- Avoid sending large or sensitive JSON/prompt artifacts and user-typed fields to the AI Worker by producing a compact, focused prompt for promise generation.
- Prevent the frontend from accepting manual promise contract inputs that conflict with the AI-generated contract and simplify the creation flow so the user must choose an AI option.

### Description

- Refactored prompt construction in `ExperimentPromiseGenerationService` to `buildPrompt(MarketNiche, Hypothesis)` and removed inclusion of user-entered fields from the persisted prompt.
- Added compacting and structured-extraction helpers (`compact`, `appendStructuredText`, `extractUsefulText`, `appendJsonField`, `firstText`) that trim long text and safely extract useful summary fields from JSON pipeline snapshots using `ObjectMapper` + `JsonNode`.
- Replaced verbose niche/hypothesis dump with a lean summary (`appendCompactNicheDetails`, `appendRichNicheSummary`, `appendCompactHypothesisDetails`) and explicit response rules to the model.
- Updated unit test `ExperimentPromiseGenerationServiceTest` to assert the prompt is compact, excludes raw evidence/prompt and user-typed fields, and remains below a size threshold; adapted mock hypothesis input to include JSON strings used by the extractor.
- Frontend `NewExperimentPage.tsx` now initializes manual contract fields empty, no longer sends them when requesting AI options, removes free editable inputs for the promise contract, and shows a read-only selected contract or a hint to request AI options.
- Documentation `docs/registros/experimentos.md` updated to record the change in contract handling and backend prompt compaction.

### Testing

- Ran updated backend unit tests including `ExperimentPromiseGenerationServiceTest` which verify prompt composition and persisted request behavior, and the tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3731fd5ce883219f167b44f724eae3)