### PR TITLE
Corrige arquitetura da auditoria OpenAI NichoCNAE v2

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/adaptivequeryplanner/service/BackendAdaptiveQueryPlannerService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/adaptivequeryplanner/service/BackendAdaptiveQueryPlannerService.java
@@ -10,7 +10,7 @@ import com.marketinghub.oprm.nichocnae.v2.adaptivequeryplanner.service.createSta
 import com.marketinghub.oprm.nichocnae.v2.adaptivequeryplanner.service.failStageExecution.AdaptiveQueryPlannerFailureRequest;
 import com.marketinghub.oprm.nichocnae.v2.adaptivequeryplanner.service.failStageExecution.AdaptiveQueryPlannerFailureResponse;
 import com.marketinghub.oprm.nichocnae.v2.adaptivequeryplanner.service.pending.AdaptiveQueryPlannerPendingResponse;
-import com.marketinghub.oprm.nichocnae.v2.service.openaiinteraction.OpenAiInteractionAuditService;
+import com.marketinghub.oprm.nichocnae.v2.service.OpenAiInteractionAuditService;
 import com.marketinghub.repository.jpa.oprm.cnae.OprmNicheCandidateRepository;
 import com.marketinghub.repository.jpa.oprm.nichocnae.v2.OprmNichoCnaeV2StageExecutionRepository;
 import java.time.Instant;

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/candidategenerator/service/BackendCandidateGeneratorService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/candidategenerator/service/BackendCandidateGeneratorService.java
@@ -15,7 +15,7 @@ import com.marketinghub.oprm.nichocnae.v2.candidategenerator.service.failStageEx
 import com.marketinghub.oprm.nichocnae.v2.candidategenerator.service.listCnaeJobs.CandidateGeneratorCnaeJobSummary;
 import com.marketinghub.oprm.nichocnae.v2.candidategenerator.service.listCnaeJobs.CandidateGeneratorCnaeJobsResponse;
 import com.marketinghub.oprm.nichocnae.v2.candidategenerator.service.pending.CandidateGeneratorPendingResponse;
-import com.marketinghub.oprm.nichocnae.v2.service.openaiinteraction.OpenAiInteractionAuditService;
+import com.marketinghub.oprm.nichocnae.v2.service.OpenAiInteractionAuditService;
 import com.marketinghub.repository.jpa.oprm.cnae.OprmNicheCandidateRepository;
 import com.marketinghub.repository.jpa.oprm.nichocnae.v2.OprmNichoCnaeV2OpenAiInteractionRepository;
 import com.marketinghub.repository.jpa.oprm.nichocnae.v2.OprmNichoCnaeV2StageExecutionRepository;

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/candidatetournament/service/BackendCandidateTournamentService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/candidatetournament/service/BackendCandidateTournamentService.java
@@ -10,7 +10,7 @@ import com.marketinghub.oprm.nichocnae.v2.candidatetournament.service.createStag
 import com.marketinghub.oprm.nichocnae.v2.candidatetournament.service.failStageExecution.CandidateTournamentFailureRequest;
 import com.marketinghub.oprm.nichocnae.v2.candidatetournament.service.failStageExecution.CandidateTournamentFailureResponse;
 import com.marketinghub.oprm.nichocnae.v2.candidatetournament.service.pending.CandidateTournamentPendingResponse;
-import com.marketinghub.oprm.nichocnae.v2.service.openaiinteraction.OpenAiInteractionAuditService;
+import com.marketinghub.oprm.nichocnae.v2.service.OpenAiInteractionAuditService;
 import com.marketinghub.repository.jpa.oprm.cnae.OprmNicheCandidateRepository;
 import com.marketinghub.repository.jpa.oprm.nichocnae.v2.OprmNichoCnaeV2StageExecutionRepository;
 import java.time.Instant;

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/commercialevidencegate/service/BackendCommercialEvidenceGateService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/commercialevidencegate/service/BackendCommercialEvidenceGateService.java
@@ -10,7 +10,7 @@ import com.marketinghub.oprm.nichocnae.v2.commercialevidencegate.service.createS
 import com.marketinghub.oprm.nichocnae.v2.commercialevidencegate.service.failStageExecution.CommercialEvidenceGateFailureRequest;
 import com.marketinghub.oprm.nichocnae.v2.commercialevidencegate.service.failStageExecution.CommercialEvidenceGateFailureResponse;
 import com.marketinghub.oprm.nichocnae.v2.commercialevidencegate.service.pending.CommercialEvidenceGatePendingResponse;
-import com.marketinghub.oprm.nichocnae.v2.service.openaiinteraction.OpenAiInteractionAuditService;
+import com.marketinghub.oprm.nichocnae.v2.service.OpenAiInteractionAuditService;
 import com.marketinghub.repository.jpa.oprm.cnae.OprmNicheCandidateRepository;
 import com.marketinghub.repository.jpa.oprm.nichocnae.v2.OprmNichoCnaeV2StageExecutionRepository;
 import java.time.Instant;

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/enrichednichematerializer/service/BackendEnrichedNicheMaterializerService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/enrichednichematerializer/service/BackendEnrichedNicheMaterializerService.java
@@ -10,7 +10,7 @@ import com.marketinghub.oprm.nichocnae.v2.enrichednichematerializer.service.crea
 import com.marketinghub.oprm.nichocnae.v2.enrichednichematerializer.service.failStageExecution.EnrichedNicheMaterializerFailureRequest;
 import com.marketinghub.oprm.nichocnae.v2.enrichednichematerializer.service.failStageExecution.EnrichedNicheMaterializerFailureResponse;
 import com.marketinghub.oprm.nichocnae.v2.enrichednichematerializer.service.pending.EnrichedNicheMaterializerPendingResponse;
-import com.marketinghub.oprm.nichocnae.v2.service.openaiinteraction.OpenAiInteractionAuditService;
+import com.marketinghub.oprm.nichocnae.v2.service.OpenAiInteractionAuditService;
 import com.marketinghub.repository.jpa.oprm.cnae.OprmNicheCandidateRepository;
 import com.marketinghub.repository.jpa.oprm.nichocnae.v2.OprmNichoCnaeV2StageExecutionRepository;
 import java.time.Instant;

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/knowledgeaccumulator/service/BackendKnowledgeAccumulatorService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/knowledgeaccumulator/service/BackendKnowledgeAccumulatorService.java
@@ -10,7 +10,7 @@ import com.marketinghub.oprm.nichocnae.v2.knowledgeaccumulator.service.createSta
 import com.marketinghub.oprm.nichocnae.v2.knowledgeaccumulator.service.failStageExecution.KnowledgeAccumulatorFailureRequest;
 import com.marketinghub.oprm.nichocnae.v2.knowledgeaccumulator.service.failStageExecution.KnowledgeAccumulatorFailureResponse;
 import com.marketinghub.oprm.nichocnae.v2.knowledgeaccumulator.service.pending.KnowledgeAccumulatorPendingResponse;
-import com.marketinghub.oprm.nichocnae.v2.service.openaiinteraction.OpenAiInteractionAuditService;
+import com.marketinghub.oprm.nichocnae.v2.service.OpenAiInteractionAuditService;
 import com.marketinghub.repository.jpa.oprm.cnae.OprmNicheCandidateRepository;
 import com.marketinghub.repository.jpa.oprm.nichocnae.v2.OprmNichoCnaeV2StageExecutionRepository;
 import java.time.Instant;

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/reprocesscontroller/service/BackendReprocessControllerService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/reprocesscontroller/service/BackendReprocessControllerService.java
@@ -10,7 +10,7 @@ import com.marketinghub.oprm.nichocnae.v2.reprocesscontroller.service.createStag
 import com.marketinghub.oprm.nichocnae.v2.reprocesscontroller.service.failStageExecution.ReprocessControllerFailureRequest;
 import com.marketinghub.oprm.nichocnae.v2.reprocesscontroller.service.failStageExecution.ReprocessControllerFailureResponse;
 import com.marketinghub.oprm.nichocnae.v2.reprocesscontroller.service.pending.ReprocessControllerPendingResponse;
-import com.marketinghub.oprm.nichocnae.v2.service.openaiinteraction.OpenAiInteractionAuditService;
+import com.marketinghub.oprm.nichocnae.v2.service.OpenAiInteractionAuditService;
 import com.marketinghub.repository.jpa.oprm.cnae.OprmNicheCandidateRepository;
 import com.marketinghub.repository.jpa.oprm.nichocnae.v2.OprmNichoCnaeV2StageExecutionRepository;
 import java.time.Instant;

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/service/OpenAiInteractionAuditService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/service/OpenAiInteractionAuditService.java
@@ -1,7 +1,8 @@
-package com.marketinghub.oprm.nichocnae.v2.service.openaiinteraction;
+package com.marketinghub.oprm.nichocnae.v2.service;
 
 import com.marketinghub.oprm.nichocnae.v2.OprmNichoCnaeV2OpenAiInteraction;
 import com.marketinghub.oprm.nichocnae.v2.OprmNichoCnaeV2StageExecution;
+import com.marketinghub.oprm.nichocnae.v2.service.openaiinteraction.OpenAiInteractionAuditRequest;
 import com.marketinghub.repository.jpa.oprm.nichocnae.v2.OprmNichoCnaeV2OpenAiInteractionRepository;
 import java.time.Instant;
 import java.util.List;

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/sourcefetcherreranker/service/BackendSourceFetcherRerankerService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/sourcefetcherreranker/service/BackendSourceFetcherRerankerService.java
@@ -10,7 +10,7 @@ import com.marketinghub.oprm.nichocnae.v2.sourcefetcherreranker.service.createSt
 import com.marketinghub.oprm.nichocnae.v2.sourcefetcherreranker.service.failStageExecution.SourceFetcherRerankerFailureRequest;
 import com.marketinghub.oprm.nichocnae.v2.sourcefetcherreranker.service.failStageExecution.SourceFetcherRerankerFailureResponse;
 import com.marketinghub.oprm.nichocnae.v2.sourcefetcherreranker.service.pending.SourceFetcherRerankerPendingResponse;
-import com.marketinghub.oprm.nichocnae.v2.service.openaiinteraction.OpenAiInteractionAuditService;
+import com.marketinghub.oprm.nichocnae.v2.service.OpenAiInteractionAuditService;
 import com.marketinghub.repository.jpa.oprm.cnae.OprmNicheCandidateRepository;
 import com.marketinghub.repository.jpa.oprm.nichocnae.v2.OprmNichoCnaeV2StageExecutionRepository;
 import java.time.Instant;

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/sourcesafetyfilter/service/BackendSourceSafetyFilterService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/sourcesafetyfilter/service/BackendSourceSafetyFilterService.java
@@ -10,7 +10,7 @@ import com.marketinghub.oprm.nichocnae.v2.sourcesafetyfilter.service.createStage
 import com.marketinghub.oprm.nichocnae.v2.sourcesafetyfilter.service.failStageExecution.SourceSafetyFilterFailureRequest;
 import com.marketinghub.oprm.nichocnae.v2.sourcesafetyfilter.service.failStageExecution.SourceSafetyFilterFailureResponse;
 import com.marketinghub.oprm.nichocnae.v2.sourcesafetyfilter.service.pending.SourceSafetyFilterPendingResponse;
-import com.marketinghub.oprm.nichocnae.v2.service.openaiinteraction.OpenAiInteractionAuditService;
+import com.marketinghub.oprm.nichocnae.v2.service.OpenAiInteractionAuditService;
 import com.marketinghub.repository.jpa.oprm.cnae.OprmNicheCandidateRepository;
 import com.marketinghub.repository.jpa.oprm.nichocnae.v2.OprmNichoCnaeV2StageExecutionRepository;
 import java.time.Instant;

--- a/backend/ads-service/src/test/java/com/marketinghub/oprm/nichocnae/v2/OpenAiInteractionAuditServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/oprm/nichocnae/v2/OpenAiInteractionAuditServiceTest.java
@@ -6,7 +6,7 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.marketinghub.oprm.nichocnae.v2.service.openaiinteraction.OpenAiInteractionAuditRequest;
-import com.marketinghub.oprm.nichocnae.v2.service.openaiinteraction.OpenAiInteractionAuditService;
+import com.marketinghub.oprm.nichocnae.v2.service.OpenAiInteractionAuditService;
 import com.marketinghub.repository.jpa.oprm.nichocnae.v2.OprmNichoCnaeV2OpenAiInteractionRepository;
 import java.math.BigDecimal;
 import java.util.List;

--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -1200,3 +1200,9 @@
 - Os callbacks de conclusão das etapas backend da v2 passam a aceitar `openAiInteractions`, permitindo que o executor informe todas as chamadas OpenAI realizadas pela etapa sem depender de JSON solto no `outputPayload`.
 - A tela/listagem de jobs passa a priorizar o custo auditado na tabela própria e mantém fallback para custos legados dentro do `outputPayload`, evitando perda de histórico durante transição.
 - Causa-raiz tratada: custo e auditoria de IA estavam inferidos por payload funcional, o que podia esconder gasto real quando uma etapa esquecesse de incluir chaves de custo no JSON de saída.
+
+## 2026-06-21 — Correção de arquitetura da auditoria OpenAI NichoCNAE v2
+
+- Corrigida a violação ArchUnit que colocava `OpenAiInteractionAuditService` dentro de subpacote de contratos do `service`.
+- A causa-raiz era mistura entre contrato DTO, que deve permanecer como `record` no subpacote de operação, e classe de serviço Spring, que não deve ocupar subpacote reservado a contratos.
+- Prevenção de recorrência: a auditoria continua centralizada no service canônico compartilhado, enquanto o subpacote `openaiinteraction` fica restrito ao record de entrada.


### PR DESCRIPTION
### Motivation
- Corrigir violação de ArchUnit onde uma classe Spring `OpenAiInteractionAuditService` havia sido colocada dentro do subpacote reservado a contratos (`service.openaiinteraction`) que deve conter apenas `record` DTOs.
- Garantir separação clara entre contratos imutáveis (`record`) e serviços Spring para evitar falsos positivos nos testes de arquitetura e preservar a convenção de pacotes do pipeline NichoCNAE v2.

### Description
- Move `OpenAiInteractionAuditService` do pacote `com.marketinghub.oprm.nichocnae.v2.service.openaiinteraction` para `com.marketinghub.oprm.nichocnae.v2.service` e ajusta o `package` no arquivo de classe afetado.
- Atualiza imports em todas as classes das etapas NichoCNAE v2 que referenciavam o serviço no subpacote para apontar ao novo pacote canônico `service`.
- Atualiza o teste unitário `OpenAiInteractionAuditServiceTest` para usar o novo caminho do `OpenAiInteractionAuditService` e mantém o `openaiinteraction` subpacote restrito ao `OpenAiInteractionAuditRequest` record.
- Registra a correção, a causa-raiz e a prevenção de recorrência em `docs/registros/oprm1.md`.

### Testing
- Executado `../mvnw -Dtest=ArquiteturaTest#oprmNichoCnaeStageServiceSubpackagesMustContainOnlyRecords test` e o teste passou com sucesso.
- Executado `../mvnw -Dtest=OpenAiInteractionAuditServiceTest test` e o teste passou com sucesso.
- Executado a combinação `../mvnw -Dtest=ArquiteturaTest#oprmNichoCnaeStageServiceSubpackagesMustContainOnlyRecords,OpenAiInteractionAuditServiceTest test` e ambos passaram, resultando em build sucesso do módulo `ads-service`.
- Tentativa de aplicar formatação com `./mvnw -f ads-service/pom.xml spotless:apply` falhou porque o prefixo `spotless` não está disponível no contexto Maven usado (plugin não encontrado).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a373850198c8321b754d4da8e446df0)