### PR TITLE
Fix Spring bootstrap: annotate OPRM NichoCNAE v2 service constructors with @Autowired

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/adaptivequeryplanner/service/BackendAdaptiveQueryPlannerService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/adaptivequeryplanner/service/BackendAdaptiveQueryPlannerService.java
@@ -17,6 +17,7 @@ import com.marketinghub.repository.jpa.oprm.nichocnae.v2.OprmNichoCnaeV2OpenAiIn
 import com.marketinghub.repository.jpa.oprm.nichocnae.v2.OprmNichoCnaeV2StageExecutionRepository;
 import java.time.Instant;
 import java.util.List;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
@@ -34,6 +35,7 @@ public class BackendAdaptiveQueryPlannerService {
     private final boolean v2Enabled;
 
     /** Inicializa o service com repositório canônico e feature flag de calibração da v2. */
+    @Autowired
     public BackendAdaptiveQueryPlannerService(
             OprmNichoCnaeV2StageExecutionRepository stageExecutionRepository,
             OprmNichoCnaeV2OpenAiInteractionRepository openAiInteractionRepository,

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/candidategenerator/service/BackendCandidateGeneratorService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/candidategenerator/service/BackendCandidateGeneratorService.java
@@ -29,6 +29,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
@@ -70,6 +71,7 @@ public class BackendCandidateGeneratorService {
     private final boolean materializationEnabled;
 
     /** Inicializa o service com repositórios canônicos e feature flags de calibração da v2. */
+    @Autowired
     public BackendCandidateGeneratorService(
             OprmNicheCandidateRepository nicheCandidateRepository,
             OprmNichoCnaeV2StageExecutionRepository stageExecutionRepository,

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/candidatetournament/service/BackendCandidateTournamentService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/candidatetournament/service/BackendCandidateTournamentService.java
@@ -17,6 +17,7 @@ import com.marketinghub.repository.jpa.oprm.nichocnae.v2.OprmNichoCnaeV2OpenAiIn
 import com.marketinghub.repository.jpa.oprm.nichocnae.v2.OprmNichoCnaeV2StageExecutionRepository;
 import java.time.Instant;
 import java.util.List;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
@@ -34,6 +35,7 @@ public class BackendCandidateTournamentService {
     private final boolean v2Enabled;
 
     /** Inicializa o service com repositório canônico e feature flag de calibração da v2. */
+    @Autowired
     public BackendCandidateTournamentService(
             OprmNichoCnaeV2StageExecutionRepository stageExecutionRepository,
             OprmNichoCnaeV2OpenAiInteractionRepository openAiInteractionRepository,

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/commercialevidencegate/service/BackendCommercialEvidenceGateService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/commercialevidencegate/service/BackendCommercialEvidenceGateService.java
@@ -17,6 +17,7 @@ import com.marketinghub.repository.jpa.oprm.nichocnae.v2.OprmNichoCnaeV2OpenAiIn
 import com.marketinghub.repository.jpa.oprm.nichocnae.v2.OprmNichoCnaeV2StageExecutionRepository;
 import java.time.Instant;
 import java.util.List;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
@@ -34,6 +35,7 @@ public class BackendCommercialEvidenceGateService {
     private final boolean v2Enabled;
 
     /** Inicializa o service com repositório canônico e feature flag de calibração da v2. */
+    @Autowired
     public BackendCommercialEvidenceGateService(
             OprmNichoCnaeV2StageExecutionRepository stageExecutionRepository,
             OprmNichoCnaeV2OpenAiInteractionRepository openAiInteractionRepository,

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/enrichednichematerializer/service/BackendEnrichedNicheMaterializerService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/enrichednichematerializer/service/BackendEnrichedNicheMaterializerService.java
@@ -17,6 +17,7 @@ import com.marketinghub.repository.jpa.oprm.nichocnae.v2.OprmNichoCnaeV2OpenAiIn
 import com.marketinghub.repository.jpa.oprm.nichocnae.v2.OprmNichoCnaeV2StageExecutionRepository;
 import java.time.Instant;
 import java.util.List;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
@@ -34,6 +35,7 @@ public class BackendEnrichedNicheMaterializerService {
     private final boolean v2Enabled;
 
     /** Inicializa o service com repositório canônico e feature flag de calibração da v2. */
+    @Autowired
     public BackendEnrichedNicheMaterializerService(
             OprmNichoCnaeV2StageExecutionRepository stageExecutionRepository,
             OprmNichoCnaeV2OpenAiInteractionRepository openAiInteractionRepository,

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/knowledgeaccumulator/service/BackendKnowledgeAccumulatorService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/knowledgeaccumulator/service/BackendKnowledgeAccumulatorService.java
@@ -17,6 +17,7 @@ import com.marketinghub.repository.jpa.oprm.nichocnae.v2.OprmNichoCnaeV2OpenAiIn
 import com.marketinghub.repository.jpa.oprm.nichocnae.v2.OprmNichoCnaeV2StageExecutionRepository;
 import java.time.Instant;
 import java.util.List;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
@@ -34,6 +35,7 @@ public class BackendKnowledgeAccumulatorService {
     private final boolean v2Enabled;
 
     /** Inicializa o service com repositório canônico e feature flag de calibração da v2. */
+    @Autowired
     public BackendKnowledgeAccumulatorService(
             OprmNichoCnaeV2StageExecutionRepository stageExecutionRepository,
             OprmNichoCnaeV2OpenAiInteractionRepository openAiInteractionRepository,

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/reprocesscontroller/service/BackendReprocessControllerService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/reprocesscontroller/service/BackendReprocessControllerService.java
@@ -17,6 +17,7 @@ import com.marketinghub.repository.jpa.oprm.nichocnae.v2.OprmNichoCnaeV2OpenAiIn
 import com.marketinghub.repository.jpa.oprm.nichocnae.v2.OprmNichoCnaeV2StageExecutionRepository;
 import java.time.Instant;
 import java.util.List;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
@@ -34,6 +35,7 @@ public class BackendReprocessControllerService {
     private final boolean v2Enabled;
 
     /** Inicializa o service com repositório canônico e feature flag de calibração da v2. */
+    @Autowired
     public BackendReprocessControllerService(
             OprmNichoCnaeV2StageExecutionRepository stageExecutionRepository,
             OprmNichoCnaeV2OpenAiInteractionRepository openAiInteractionRepository,

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/sourcefetcherreranker/service/BackendSourceFetcherRerankerService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/sourcefetcherreranker/service/BackendSourceFetcherRerankerService.java
@@ -17,6 +17,7 @@ import com.marketinghub.repository.jpa.oprm.nichocnae.v2.OprmNichoCnaeV2OpenAiIn
 import com.marketinghub.repository.jpa.oprm.nichocnae.v2.OprmNichoCnaeV2StageExecutionRepository;
 import java.time.Instant;
 import java.util.List;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
@@ -34,6 +35,7 @@ public class BackendSourceFetcherRerankerService {
     private final boolean v2Enabled;
 
     /** Inicializa o service com repositório canônico e feature flag de calibração da v2. */
+    @Autowired
     public BackendSourceFetcherRerankerService(
             OprmNichoCnaeV2StageExecutionRepository stageExecutionRepository,
             OprmNichoCnaeV2OpenAiInteractionRepository openAiInteractionRepository,

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/sourcesafetyfilter/service/BackendSourceSafetyFilterService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/sourcesafetyfilter/service/BackendSourceSafetyFilterService.java
@@ -17,6 +17,7 @@ import com.marketinghub.repository.jpa.oprm.nichocnae.v2.OprmNichoCnaeV2OpenAiIn
 import com.marketinghub.repository.jpa.oprm.nichocnae.v2.OprmNichoCnaeV2StageExecutionRepository;
 import java.time.Instant;
 import java.util.List;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
@@ -34,6 +35,7 @@ public class BackendSourceSafetyFilterService {
     private final boolean v2Enabled;
 
     /** Inicializa o service com repositório canônico e feature flag de calibração da v2. */
+    @Autowired
     public BackendSourceSafetyFilterService(
             OprmNichoCnaeV2StageExecutionRepository stageExecutionRepository,
             OprmNichoCnaeV2OpenAiInteractionRepository openAiInteractionRepository,

--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -1,4 +1,10 @@
 
+## 2026-06-21 — OPRM NichoCNAE v2: bootstrap do backend corrigido
+
+- Causa-raiz tratada: services de etapas OPRM NichoCNAE v2 tinham múltiplos construtores e o Spring podia tentar instanciá-los pelo construtor vazio inexistente durante testes `@SpringBootTest`, derrubando o contexto completo do backend.
+- Correção aplicada: marcado explicitamente o construtor canônico de injeção do Spring, preservando o construtor auxiliar usado por teste unitário e evitando falha em testes de outros módulos.
+- Prevenção de recorrência: a regra do backend sobre múltiplos construtores em beans Spring foi aplicada às etapas OPRM v2 afetadas.
+
 ## 2026-06-21 — OPRM OpenAI em modo Flex com GPT-5.2
 
 - Decisão operacional aplicada: acessos OpenAI das etapas OPRM NichoCNAE com IA devem usar modo Flex (`service_tier=flex`) e modelo `gpt-5.2`.


### PR DESCRIPTION
### Motivation

- Services for multiple OPRM NichoCNAE v2 stages exposed more than one constructor which allowed Spring to pick the wrong constructor during `@SpringBootTest` bootstrap and break the backend context.

### Description

- Added `org.springframework.beans.factory.annotation.Autowired` import and annotated the canonical injection constructors with `@Autowired` across the OPRM NichoCNAE v2 backend services to force Spring to use the intended constructor.
- Applied the change to the following services: `BackendAdaptiveQueryPlannerService`, `BackendCandidateGeneratorService`, `BackendCandidateTournamentService`, `BackendCommercialEvidenceGateService`, `BackendEnrichedNicheMaterializerService`, `BackendKnowledgeAccumulatorService`, `BackendReprocessControllerService`, `BackendSourceFetcherRerankerService`, and `BackendSourceSafetyFilterService`.
- Preserved the existing auxiliary constructors used by unit tests to keep backward compatibility with tests that do not exercise OpenAI auditing.
- Added an entry to `docs/registros/oprm1.md` describing the bootstrap fix and rationale.

### Testing

- Executed the repository unit and Spring context tests that previously failed due to constructor ambiguity and they now complete successfully.
- No production behavior changes were introduced beyond constructor wiring, so no additional integration test changes were required.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3743cd67e08321a3fe14e35ded1051)