### PR TITLE
Contabiliza custo ao regenerar promessas de experimento

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/experimentpromise/ExperimentPromiseOpenAiClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/experimentpromise/ExperimentPromiseOpenAiClient.java
@@ -3,11 +3,13 @@ package com.marketinghub.worker.experimentpromise;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marketinghub.worker.openai.OpenAiCostEstimator;
 import com.marketinghub.worker.openai.OpenAiRequestUtils;
 import com.marketinghub.worker.openai.OpenAiResponse;
 import com.marketinghub.worker.openai.core.exception.StageWorkerException;
 import com.marketinghub.worker.openai.core.prompt.PromptTemplateResolver;
 import java.io.IOException;
+import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -57,7 +59,7 @@ public class ExperimentPromiseOpenAiClient {
     }
 
     /** Gera exatamente três opções comerciais para a solicitação assumida. */
-    public List<ExperimentPromiseOptionDto> generate(ExperimentPromiseOptionsResponse request) {
+    public ExperimentPromiseOptionsResponse generate(ExperimentPromiseOptionsResponse request) {
         Map<String, Object> payload = buildPayload(request);
         log.info("Enviando request de promessa para OpenAI; requestId={} payload={}", request.requestId(), toJsonOrText(payload));
         OpenAiResponse response = webClient.post()
@@ -71,7 +73,16 @@ public class ExperimentPromiseOpenAiClient {
         if (content == null || content.isBlank()) {
             throw new IllegalStateException("OpenAI não retornou conteúdo para opções de promessa");
         }
-        return parseOptions(content);
+        List<ExperimentPromiseOptionDto> options = parseOptions(content);
+        BigDecimal costUsd = OpenAiCostEstimator.estimateUsd(model, response.usage());
+        return new ExperimentPromiseOptionsResponse(
+                request.requestId(),
+                "COMPLETED",
+                request.prompt(),
+                options,
+                response.usage() != null ? response.usage().effectiveInputTokens() : null,
+                response.usage() != null ? response.usage().effectiveOutputTokens() : null,
+                costUsd);
     }
 
     /** Monta o payload da Responses API com prompt markdown e schema JSON do classpath. */
@@ -93,6 +104,7 @@ public class ExperimentPromiseOpenAiClient {
         payload.put("model", model);
         payload.put("input", prompt);
         payload.put("text", text);
+        payload.put("service_tier", "flex");
         if (OpenAiRequestUtils.supportsTemperature(model)) {
             payload.put("temperature", 0.4);
         }

--- a/ai-worker/src/main/java/com/marketinghub/worker/experimentpromise/ExperimentPromiseOptionsResponse.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/experimentpromise/ExperimentPromiseOptionsResponse.java
@@ -1,7 +1,15 @@
 package com.marketinghub.worker.experimentpromise;
 
+import java.math.BigDecimal;
 import java.util.List;
 
 /** Representa o contrato de solicitação e resposta de opções de promessa no backend. */
-public record ExperimentPromiseOptionsResponse(Long requestId, String status, String prompt, List<ExperimentPromiseOptionDto> options) {
+public record ExperimentPromiseOptionsResponse(
+        Long requestId,
+        String status,
+        String prompt,
+        List<ExperimentPromiseOptionDto> options,
+        Integer inputTokens,
+        Integer outputTokens,
+        BigDecimal costUsd) {
 }

--- a/ai-worker/src/main/java/com/marketinghub/worker/experimentpromise/ExperimentPromiseWorkerService.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/experimentpromise/ExperimentPromiseWorkerService.java
@@ -27,8 +27,8 @@ public class ExperimentPromiseWorkerService {
             Long requestId = pending.requestId();
             try {
                 ExperimentPromiseOptionsResponse claimed = backendClient.claim(requestId, WORKER_ID);
-                List<ExperimentPromiseOptionDto> options = openAiClient.generate(claimed);
-                backendClient.complete(requestId, new ExperimentPromiseOptionsResponse(requestId, "COMPLETED", claimed.prompt(), options));
+                ExperimentPromiseOptionsResponse response = openAiClient.generate(claimed);
+                backendClient.complete(requestId, response);
                 log.info("Solicitação de promessa concluída; requestId={}", requestId);
             } catch (Exception ex) {
                 log.error("Falha ao processar promessa; operation=experiment-promise requestId={}", requestId, ex);

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/dto/CreateExperimentRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/dto/CreateExperimentRequest.java
@@ -6,6 +6,7 @@ import java.math.BigDecimal;
 import com.marketinghub.experiment.ExperimentStage;
 import com.marketinghub.experiment.ExperimentCampaignObjective;
 import java.time.LocalDate;
+import java.util.List;
 import lombok.Data;
 
 /**
@@ -62,4 +63,5 @@ public class CreateExperimentRequest {
     private Long imageModelQualityId;
     private String creativeTextPrompt;
     private String creativeImagePrompt;
+    private List<Long> promiseGenerationRequestIds;
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/promise/ExperimentPromiseGenerationRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/promise/ExperimentPromiseGenerationRequest.java
@@ -14,6 +14,7 @@ import jakarta.persistence.JoinColumn;
 import jakarta.persistence.Lob;
 import jakarta.persistence.ManyToOne;
 import jakarta.persistence.Table;
+import java.math.BigDecimal;
 import java.time.Instant;
 import lombok.AllArgsConstructor;
 import lombok.Builder;
@@ -77,6 +78,15 @@ public class ExperimentPromiseGenerationRequest {
     @Lob
     @Column(name = "error_message", columnDefinition = "TEXT")
     private String errorMessage;
+
+    @Column(name = "input_tokens")
+    private Integer inputTokens;
+
+    @Column(name = "output_tokens")
+    private Integer outputTokens;
+
+    @Column(name = "cost_usd", precision = 12, scale = 4)
+    private BigDecimal costUsd;
 
     @Column(name = "started_at")
     private Instant startedAt;

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentPromiseGenerationService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentPromiseGenerationService.java
@@ -2,6 +2,7 @@ package com.marketinghub.experiment.service;
 
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
+import com.marketinghub.cost.CostAttributionService;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marketinghub.experiment.promise.ExperimentPromiseGenerationRequest;
 import com.marketinghub.experiment.promise.ExperimentPromiseGenerationRequestStatus;
@@ -14,6 +15,7 @@ import com.marketinghub.niche.MarketNiche;
 import com.marketinghub.repository.jpa.experiment.ExperimentPromiseGenerationRequestRepository;
 import com.marketinghub.repository.jpa.hypothesis.HypothesisRepository;
 import com.marketinghub.repository.jpa.niche.MarketNicheRepository;
+import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
@@ -36,16 +38,19 @@ public class ExperimentPromiseGenerationService {
     private final HypothesisRepository hypothesisRepository;
     private final ExperimentPromiseGenerationRequestRepository requestRepository;
     private final ObjectMapper objectMapper;
+    private final CostAttributionService costAttributionService;
 
     /** Inicializa o serviço com repositórios e serializador usados para registrar a solicitação. */
     public ExperimentPromiseGenerationService(MarketNicheRepository nicheRepository,
                                               HypothesisRepository hypothesisRepository,
                                               ExperimentPromiseGenerationRequestRepository requestRepository,
-                                              ObjectMapper objectMapper) {
+                                              ObjectMapper objectMapper,
+                                              CostAttributionService costAttributionService) {
         this.nicheRepository = nicheRepository;
         this.hypothesisRepository = hypothesisRepository;
         this.requestRepository = requestRepository;
         this.objectMapper = objectMapper;
+        this.costAttributionService = costAttributionService;
     }
 
     /** Registra uma solicitação pendente para o AI Worker gerar três opções de promessa. */
@@ -73,7 +78,7 @@ public class ExperimentPromiseGenerationService {
                 .currentPrimaryCta(trimToNull(request.currentPrimaryCta()))
                 .build();
         ExperimentPromiseGenerationRequest saved = requestRepository.save(entity);
-        return new GenerateExperimentPromiseOptionsResponse(saved.getId(), saved.getStatus().name(), saved.getPrompt(), List.of());
+        return new GenerateExperimentPromiseOptionsResponse(saved.getId(), saved.getStatus().name(), saved.getPrompt(), List.of(), null, null, null);
     }
 
     /** Retorna a solicitação mais recente ainda útil para retomada da criação do teste pela tela. */
@@ -128,10 +133,16 @@ public class ExperimentPromiseGenerationService {
         if (options == null || options.size() != 3) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Informe exatamente três opções geradas.");
         }
+        BigDecimal previousCostUsd = entity.getCostUsd();
         entity.setOptionsJson(writeOptions(options));
+        entity.setInputTokens(response.inputTokens());
+        entity.setOutputTokens(response.outputTokens());
+        entity.setCostUsd(normalizeCostUsd(response.costUsd()));
         entity.setStatus(ExperimentPromiseGenerationRequestStatus.COMPLETED);
         entity.setFinishedAt(Instant.now());
         entity.setErrorMessage(null);
+        costAttributionService.addUsdCostToHypothesisHierarchy(
+                entity.getHypothesis(), subtractCostUsd(entity.getCostUsd(), previousCostUsd));
         return toResponse(entity);
     }
 
@@ -295,12 +306,15 @@ public class ExperimentPromiseGenerationService {
                 entity.getCurrentFreeReward(),
                 entity.getCurrentFunnelPromise(),
                 entity.getCurrentPrimaryCta(),
-                readOptions(entity.getOptionsJson()));
+                readOptions(entity.getOptionsJson()),
+                entity.getInputTokens(),
+                entity.getOutputTokens(),
+                entity.getCostUsd());
     }
 
     /** Converte a entidade persistida para contrato de API. */
     private GenerateExperimentPromiseOptionsResponse toResponse(ExperimentPromiseGenerationRequest entity) {
-        return new GenerateExperimentPromiseOptionsResponse(entity.getId(), entity.getStatus().name(), entity.getPrompt(), readOptions(entity.getOptionsJson()));
+        return new GenerateExperimentPromiseOptionsResponse(entity.getId(), entity.getStatus().name(), entity.getPrompt(), readOptions(entity.getOptionsJson()), entity.getInputTokens(), entity.getOutputTokens(), entity.getCostUsd());
     }
 
     /** Serializa as opções recebidas do AI Worker para auditoria persistida. */
@@ -324,6 +338,19 @@ public class ExperimentPromiseGenerationService {
             log.error("Falha ao ler opções de promessa persistidas; operation=experiment-promise-options-read", ex);
             return List.of();
         }
+    }
+
+    /** Calcula apenas o delta novo para não duplicar custo em uma conclusão repetida. */
+    private BigDecimal subtractCostUsd(BigDecimal current, BigDecimal previous) {
+        if (current == null) {
+            return null;
+        }
+        return previous == null ? current : current.subtract(previous);
+    }
+
+    /** Normaliza custo informado pelo worker antes de acumular nos totais. */
+    private BigDecimal normalizeCostUsd(BigDecimal costUsd) {
+        return costUsd != null && costUsd.compareTo(BigDecimal.ZERO) > 0 ? costUsd : null;
     }
 
     /** Normaliza textos opcionais antes da persistência. */

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentService.java
@@ -10,10 +10,12 @@ import com.marketinghub.repository.jpa.ads.FacebookPageRepository;
 import com.marketinghub.ads.InstagramAccount;
 import com.marketinghub.repository.jpa.ads.InstagramAccountRepository;
 import com.marketinghub.experiment.*;
+import com.marketinghub.finance.CurrencyConversionService;
 import com.marketinghub.experiment.dto.CreateExperimentRequest;
 import com.marketinghub.experiment.dto.UpdateExperimentRequest;
 import com.marketinghub.experiment.pipeline.ads.ExperimentPipelineAdExtractor;
 import com.marketinghub.experiment.pipeline.ads.PipelineAdCreativePlan;
+import com.marketinghub.repository.jpa.experiment.ExperimentPromiseGenerationRequestRepository;
 import com.marketinghub.repository.jpa.experiment.ExperimentRepository;
 import com.marketinghub.repository.jpa.experiment.funnel.ExperimentFunnelEventRepository;
 import com.marketinghub.repository.jpa.experiment.funnel.ExperimentLandingAnalyticsEventRepository;
@@ -34,6 +36,7 @@ import com.marketinghub.repository.jpa.imagegeneration.ImageGenerationModelRepos
 import com.marketinghub.repository.jpa.imagegeneration.ImageGenerationQualityRepository;
 import com.marketinghub.sampleemail.SampleEmail;
 import jakarta.persistence.EntityManager;
+import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.List;
 import java.util.Objects;
@@ -50,6 +53,7 @@ import org.springframework.web.server.ResponseStatusException;
 @Service
 public class ExperimentService {
     private final ExperimentRepository repository;
+    private final ExperimentPromiseGenerationRequestRepository promiseGenerationRequestRepository;
     private final MarketNicheRepository nicheRepository;
     private final com.marketinghub.repository.jpa.hypothesis.HypothesisRepository hypothesisRepository;
     private final MetricPresetService metricPresetService;
@@ -69,8 +73,11 @@ public class ExperimentService {
     private final FacebookAdsAdSetRepository facebookAdsAdSetRepository;
     private final FacebookAdsAdRepository facebookAdsAdRepository;
     private final ObjectMapper objectMapper;
+    private final CurrencyConversionService currencyConversionService;
 
-    public ExperimentService(ExperimentRepository repository, MarketNicheRepository nicheRepository,
+    public ExperimentService(ExperimentRepository repository,
+                             ExperimentPromiseGenerationRequestRepository promiseGenerationRequestRepository,
+                             MarketNicheRepository nicheRepository,
                              com.marketinghub.repository.jpa.hypothesis.HypothesisRepository hypothesisRepository,
                              MetricPresetService metricPresetService,
                              EntityManager entityManager,
@@ -88,8 +95,10 @@ public class ExperimentService {
                              FacebookAdsCampaignRepository facebookAdsCampaignRepository,
                              FacebookAdsAdSetRepository facebookAdsAdSetRepository,
                              FacebookAdsAdRepository facebookAdsAdRepository,
-                             ObjectMapper objectMapper) {
+                             ObjectMapper objectMapper,
+                             CurrencyConversionService currencyConversionService) {
         this.repository = repository;
+        this.promiseGenerationRequestRepository = promiseGenerationRequestRepository;
         this.nicheRepository = nicheRepository;
         this.hypothesisRepository = hypothesisRepository;
         this.metricPresetService = metricPresetService;
@@ -109,6 +118,7 @@ public class ExperimentService {
         this.facebookAdsAdSetRepository = facebookAdsAdSetRepository;
         this.facebookAdsAdRepository = facebookAdsAdRepository;
         this.objectMapper = objectMapper;
+        this.currencyConversionService = currencyConversionService;
     }
 
     /**
@@ -289,6 +299,8 @@ public class ExperimentService {
                 normalizeOptionalImagesPerPackage(request.getOpenImagesPerPackage(), "openImagesPerPackage");
         Integer compressedImagesPerPackage =
                 normalizeOptionalImagesPerPackage(request.getCompressedImagesPerPackage(), "compressedImagesPerPackage");
+        BigDecimal promiseGenerationCost = completedPromiseGenerationCostBrl(request.getPromiseGenerationRequestIds());
+        BigDecimal initialTotalCost = addNullable(request.getCost(), promiseGenerationCost);
         Experiment exp = Experiment.builder()
                 .niche(niche)
                 .name(request.getName())
@@ -310,7 +322,7 @@ public class ExperimentService {
                 .dailyBudget(request.getDailyBudget())
                 .unitPrice(unitPrice)
                 .cost(request.getCost())
-                .totalCost(request.getCost())
+                .totalCost(initialTotalCost)
                 .expense(request.getExpense())
                 .startDate(request.getStartDate())
                 .endDate(request.getEndDate())
@@ -344,6 +356,30 @@ public class ExperimentService {
         Experiment savedExperiment = repository.save(exp);
         synchronizeLeadPortalFlow(savedExperiment);
         return savedExperiment;
+    }
+
+    /** Soma em reais o custo das solicitações de promessa usadas para criar o experimento. */
+    private BigDecimal completedPromiseGenerationCostBrl(List<Long> requestIds) {
+        if (requestIds == null || requestIds.isEmpty()) {
+            return null;
+        }
+        BigDecimal costUsd = promiseGenerationRequestRepository.sumCompletedCostUsdByIdIn(requestIds);
+        return currencyConversionService.usdToBrl(costUsd);
+    }
+
+    /** Soma dois valores opcionais de custo preservando nulo quando não há custo. */
+    private BigDecimal addNullable(BigDecimal first, BigDecimal second) {
+        BigDecimal total = BigDecimal.ZERO;
+        boolean hasValue = false;
+        if (first != null) {
+            total = total.add(first);
+            hasValue = true;
+        }
+        if (second != null) {
+            total = total.add(second);
+            hasValue = true;
+        }
+        return hasValue ? total : null;
     }
 
     @Transactional

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/service/generatepromise/GenerateExperimentPromiseOptionsResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/service/generatepromise/GenerateExperimentPromiseOptionsResponse.java
@@ -1,6 +1,14 @@
 package com.marketinghub.experiment.service.generatepromise;
 
+import java.math.BigDecimal;
 import java.util.List;
 
 /** Responsabilidade: transportar o estado da solicitação, o prompt do worker e as opções de promessa geradas. */
-public record GenerateExperimentPromiseOptionsResponse(Long requestId, String status, String prompt, List<ExperimentPromiseOptionDto> options) {}
+public record GenerateExperimentPromiseOptionsResponse(
+        Long requestId,
+        String status,
+        String prompt,
+        List<ExperimentPromiseOptionDto> options,
+        Integer inputTokens,
+        Integer outputTokens,
+        BigDecimal costUsd) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/service/generatepromise/latestdraft/ExperimentPromiseOptionsDraftResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/service/generatepromise/latestdraft/ExperimentPromiseOptionsDraftResponse.java
@@ -1,6 +1,7 @@
 package com.marketinghub.experiment.service.generatepromise.latestdraft;
 
 import com.marketinghub.experiment.service.generatepromise.ExperimentPromiseOptionDto;
+import java.math.BigDecimal;
 import java.util.List;
 import java.util.UUID;
 
@@ -14,4 +15,7 @@ public record ExperimentPromiseOptionsDraftResponse(
         String currentFreeReward,
         String currentFunnelPromise,
         String currentPrimaryCta,
-        List<ExperimentPromiseOptionDto> options) {}
+        List<ExperimentPromiseOptionDto> options,
+        Integer inputTokens,
+        Integer outputTokens,
+        BigDecimal costUsd) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/experiment/ExperimentPromiseGenerationRequestRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/experiment/ExperimentPromiseGenerationRequestRepository.java
@@ -2,11 +2,14 @@ package com.marketinghub.repository.jpa.experiment;
 
 import com.marketinghub.experiment.promise.ExperimentPromiseGenerationRequest;
 import com.marketinghub.experiment.promise.ExperimentPromiseGenerationRequestStatus;
+import java.math.BigDecimal;
 import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
 
 /** Responsabilidade: persistir e consultar solicitações de geração de promessa de experimento. */
 public interface ExperimentPromiseGenerationRequestRepository extends JpaRepository<ExperimentPromiseGenerationRequest, Long> {
@@ -18,4 +21,13 @@ public interface ExperimentPromiseGenerationRequestRepository extends JpaReposit
     /** Busca a solicitação mais recente em status retomável para a tela recuperar pelo backend. */
     Optional<ExperimentPromiseGenerationRequest> findFirstByStatusInOrderByCreatedAtDesc(
             Collection<ExperimentPromiseGenerationRequestStatus> statuses);
+
+    /** Soma o custo em dólar de solicitações concluídas para compor o custo inicial do experimento criado. */
+    @Query("""
+            select coalesce(sum(r.costUsd), 0)
+            from ExperimentPromiseGenerationRequest r
+            where r.id in :ids
+              and r.status = com.marketinghub.experiment.promise.ExperimentPromiseGenerationRequestStatus.COMPLETED
+            """)
+    BigDecimal sumCompletedCostUsdByIdIn(@Param("ids") Collection<Long> ids);
 }

--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-21-experiment-promise-generation-cost.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-21-experiment-promise-generation-cost.yaml
@@ -1,0 +1,34 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-06-21-experiment-promise-generation-cost
+      author: marketinghub
+      preConditions:
+        - onFail: MARK_RAN
+        - onError: HALT
+        - dbms:
+            type: mysql
+        - tableExists:
+            tableName: experiment_promise_generation_request
+      changes:
+        - addColumn:
+            tableName: experiment_promise_generation_request
+            columns:
+              - column:
+                  name: input_tokens
+                  type: int
+              - column:
+                  name: output_tokens
+                  type: int
+              - column:
+                  name: cost_usd
+                  type: decimal(12,4)
+      rollback:
+        - dropColumn:
+            tableName: experiment_promise_generation_request
+            columnName: input_tokens
+        - dropColumn:
+            tableName: experiment_promise_generation_request
+            columnName: output_tokens
+        - dropColumn:
+            tableName: experiment_promise_generation_request
+            columnName: cost_usd

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -1,6 +1,11 @@
 databaseChangeLog:
   - include:
+      file: changesets/2026-06-21-experiment-promise-generation-cost.yaml
+      relativeToChangelogFile: true
+  - include:
       file: changesets/2026-06-21-oprm-openai-flex-gpt52.yaml
+      relativeToChangelogFile: true
+  - include:
       file: changesets/2026-06-21-oprm-nichocnae-v2-openai-interaction.yaml
       relativeToChangelogFile: true
   - include:

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -4964,3 +4964,8 @@
 - Causa-raiz: a tela enviava campos manuais mesmo quando nada era digitado e o backend montava um prompt excessivamente grande com JSONs e evidências brutas do nicho/hipótese, aumentando risco de falha no AI Worker/OpenAI.
 - Correção aplicada: o frontend agora só permite escolher uma opção gerada pela IA e exibe o contrato selecionado em modo leitura; o backend monta um contexto comercial enxuto para a fila do AI Worker, sem campos digitados pelo usuário, prompt original, snapshot completo ou evidências brutas.
 - Prevenção de recorrência: teste unitário passou a validar que o prompt persistido é compacto e não inclui campos manuais nem blocos brutos desnecessários.
+
+## 2026-06-21 — Regeneração de promessa única substitui opções e contabiliza custo
+- Solicitação: ao pedir nova IA na tela de novo experimento, remover as 3 opções atuais e gerar 3 novas, contabilizando o custo de IA no nicho, na hipótese e no experimento criado.
+- Foi feito: a tela limpa a opção selecionada e as sugestões antigas antes de registrar nova solicitação; o AI Worker envia tokens/custo da OpenAI; o backend persiste o custo da solicitação, soma no nicho e na hipótese ao concluir e inclui as solicitações usadas no custo inicial do experimento.
+- Prevenção: a telemetria de custo fica no contrato persistido da fila `experiment_promise_generation_request`, evitando opções geradas sem custo auditável.

--- a/frontend/src/api/experiment/useCreateExperiment.ts
+++ b/frontend/src/api/experiment/useCreateExperiment.ts
@@ -44,6 +44,7 @@ export interface CreateExperiment {
   schemaFirstLeadPortalEnabled?: boolean;
   creativeTextPrompt?: string;
   creativeImagePrompt?: string;
+  promiseGenerationRequestIds?: number[];
 }
 
 export function useCreateExperiment() {

--- a/frontend/src/api/experiment/useGeneratePromiseOptions.ts
+++ b/frontend/src/api/experiment/useGeneratePromiseOptions.ts
@@ -23,6 +23,9 @@ export interface GeneratePromiseOptionsResponse {
   requestId: number;
   status: string;
   options: PromiseOption[];
+  inputTokens?: number | null;
+  outputTokens?: number | null;
+  costUsd?: number | null;
 }
 
 export interface PromiseOptionsDraftResponse extends GeneratePromiseOptionsResponse {

--- a/frontend/src/pages/experiment/NewExperimentPage.tsx
+++ b/frontend/src/pages/experiment/NewExperimentPage.tsx
@@ -92,6 +92,7 @@ export default function NewExperimentPage() {
   const [promiseRequestId, setPromiseRequestId] = useState<
     number | undefined
   >();
+  const [promiseRequestIds, setPromiseRequestIds] = useState<number[]>([]);
   const [autoMde, setAutoMde] = useState(true);
   const { data: hypotheses } = useHypothesesByNiche(form.nicheId);
   const { data: selectedHypothesis } = useHypothesis(
@@ -140,6 +141,7 @@ export default function NewExperimentPage() {
       hypothesisId: draft.hypothesisId,
     }));
     setPromiseRequestId(draft.requestId);
+    setPromiseRequestIds([draft.requestId]);
     setPromiseOptions(draft.options ?? []);
   }, [
     latestPromiseOptionsDraft.data,
@@ -198,11 +200,19 @@ export default function NewExperimentPage() {
       return;
     }
     setPromiseOptions([]);
+    setForm((prev) => ({
+      ...prev,
+      singlePain: "",
+      freeReward: "",
+      funnelPromise: "",
+      primaryCta: "",
+    }));
     const response = await generatePromiseOptions.mutateAsync({
       nicheId: Number(form.nicheId),
       hypothesisId: form.hypothesisId,
     });
     setPromiseRequestId(response.requestId);
+    setPromiseRequestIds((prev) => [...prev, response.requestId]);
     setPromiseOptions(response.options ?? []);
   };
 
@@ -301,6 +311,7 @@ export default function NewExperimentPage() {
         instagramAccountId: Number(form.instagramAccountId),
         imageModelId: form.imageModelId ? Number(form.imageModelId) : undefined,
         imageModelQualityId: undefined,
+        promiseGenerationRequestIds: promiseRequestIds,
         imagesPerPackage: 20,
         openImagesPerPackage: undefined,
         compressedImagesPerPackage: undefined,
@@ -339,6 +350,7 @@ export default function NewExperimentPage() {
         funnelPromise: "",
         primaryCta: "",
       });
+      setPromiseRequestIds([]);
       setAutoSampleSize(true);
       setAutoMde(true);
       alert("Teste salvo!");


### PR DESCRIPTION
### Motivation
- Quando o usuário pede nova geração por IA na tela de criação de experimento, as 3 opções atuais devem ser removidas e substituídas por 3 novas geradas; o fluxo também precisa auditar e somar o custo de IA para nicho, hipótese e experimento. 
- O backend deve persistir a telemetria de tokens/custo das gerações para permitir atribuição confiável e relatórios sem depender de inferência local. 
- O AI Worker deve retornar informação de uso (tokens + custo) e usar o modo Flex na chamada OpenAI para compatibilidade com a política de provedor.  

### Description
- Frontend: a página de novo experimento limpa as opções atuais e o contrato selecionado ao solicitar nova geração por IA, passa a acumular `promiseGenerationRequestIds` e envia esses IDs ao criar o experimento; os hooks `useGeneratePromiseOptions`, `useCreateExperiment` e a tela `NewExperimentPage.tsx` foram ajustados para suportar o fluxo.  
- Backend (persistência): adicionado changelog `changesets/2026-06-21-experiment-promise-generation-cost.yaml` e novos campos na entidade `experiment_promise_generation_request` (`input_tokens`, `output_tokens`, `cost_usd`) para armazenar telemetria de IA. 
- Backend (serviços/repositório): o `ExperimentPromiseGenerationService` grava tokens e custo quando a solicitação é concluída, calcula apenas o delta novo para evitar duplicação e aciona `CostAttributionService` para somar custo na hipótese e no nicho; `ExperimentPromiseGenerationRequestRepository` ganhou uma query para somar custos concluídos por IDs. 
- Backend (criação de experimento): `ExperimentService` aceita `promiseGenerationRequestIds`, soma o custo USD concluído dessas solicitações, converte para BRL via `CurrencyConversionService` e inclui esse valor no `totalCost` inicial do experimento. 
- AI Worker: `ExperimentPromiseOpenAiClient` passou a calcular `costUsd` com `OpenAiCostEstimator`, retornar `inputTokens`, `outputTokens` e `costUsd` no contrato `ExperimentPromiseOptionsResponse`, e a payload usa `service_tier:

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a37cfd9562c832186e2852cb3f0c2c8)