### PR TITLE
Preserve accumulated candidates across stages and support rankedCandidates in candidate-tournament

### DIFF
--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -1218,3 +1218,10 @@
 - Removido o `OpenAiInteractionAuditService` para alinhar o backend ao padrão de leitura/escrita usado em GeraLanding: cada service canônico de etapa apenas persiste a auditoria recebida do executor no callback de conclusão.
 - A causa-raiz era a criação de um service auxiliar compartilhado no backend para uma responsabilidade que não deveria virar controle operacional nem nova camada de orquestração; a execução OpenAI permanece no executor OPRM.
 - Prevenção de recorrência: o teste da etapa `candidate-generator` agora cobre a gravação da auditoria OpenAI no próprio service canônico, sem depender de classe auxiliar fora da etapa.
+
+## 2026-06-21 — NichoCNAE v2 preserva candidatos entre etapas do executor
+
+- Corrigida a causa-raiz dos jobs NichoCNAE v2 encerrarem com `candidatos=0`: o executor criava a próxima pendência usando somente o output da etapa atual, apagando candidatos e contexto acumulado gerados nas etapas anteriores.
+- O executor `oprm-coletor-mei` agora monta o payload da próxima etapa preservando o contexto funcional de entrada, removendo apenas o `nextStageCode` antigo e sobrepondo a saída nova da etapa concluída.
+- O `candidate-tournament` passa a tratar ausência total de candidatos como erro de contrato de entrada, não como fracasso comercial, e aceita `rankedCandidates` em reprocessamentos para não perder histórico do torneio.
+- Prevenção de recorrência: adicionados testes cobrindo preservação de candidatos ao criar a próxima pendência, bloqueio de torneio sem candidatos e reprocessamento a partir de candidatos ranqueados.

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnaev2/execution/NichoCnaeV2PendingExecutionService.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnaev2/execution/NichoCnaeV2PendingExecutionService.java
@@ -67,7 +67,7 @@ public class NichoCnaeV2PendingExecutionService {
             String outputPayload = backendClient.toJson(result.output());
             Map<String, Object> completion = completionRequest(stage.stageCode(), result, outputPayload);
             backendClient.complete(stage, pending, completion);
-            createNextStageIfNeeded(stage, pending, result, outputPayload);
+            createNextStageIfNeeded(stage, pending, input, result);
             log.info(
                     "Pendência NichoCNAE v2 concluída (stage={}, stageExecutionId={}, jobId={}, status={}, nextStageCode={})",
                     stage.stageCode(),
@@ -191,8 +191,8 @@ public class NichoCnaeV2PendingExecutionService {
     private void createNextStageIfNeeded(
             NichoCnaeV2StageDefinition currentStage,
             NichoCnaeV2PendingExecution pending,
-            StageResult result,
-            String outputPayload) {
+            Map<String, Object> input,
+            StageResult result) {
         String nextStageCode = String.valueOf(result.output().getOrDefault("nextStageCode", "")).trim();
         if (nextStageCode.isBlank() && "candidate-generator".equals(currentStage.stageCode())) {
             nextStageCode = "source-safety-filter";
@@ -215,12 +215,22 @@ public class NichoCnaeV2PendingExecutionService {
                     pending.stageExecutionId());
             return;
         }
+        String nextStageInputPayload = backendClient.toJson(nextStageInputPayload(input, result, nextStageCode));
         backendClient.createNextStage(
                 nextStage.get(),
                 pending,
-                outputPayload,
+                nextStageInputPayload,
                 integer(result.output().get("attemptNumber")),
                 integer(result.output().get("knowledgeVersionTo")));
+    }
+
+    /** Preserva o contexto funcional acumulado e sobrepõe apenas a saída nova da etapa concluída. */
+    private Map<String, Object> nextStageInputPayload(Map<String, Object> input, StageResult result, String nextStageCode) {
+        Map<String, Object> payload = new LinkedHashMap<>(input);
+        payload.remove("nextStageCode");
+        payload.putAll(result.output());
+        payload.put("nextStageCode", nextStageCode);
+        return payload;
     }
 
     /** Converte metadado opcional da etapa para inteiro sem quebrar avanço quando ausente. */

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnaev2/pipeline/candidatetournament/CandidateTournamentProcessor.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnaev2/pipeline/candidatetournament/CandidateTournamentProcessor.java
@@ -22,6 +22,13 @@ public final class CandidateTournamentProcessor implements StageProcessor {
         if (candidates.isEmpty()) {
             candidates = mapList(context.input().get("candidateEvidence"));
         }
+        if (candidates.isEmpty()) {
+            candidates = mapList(context.input().get("rankedCandidates"));
+        }
+        if (candidates.isEmpty()) {
+            throw new IllegalArgumentException(
+                    "Candidate Tournament exige candidates, candidateEvidence ou rankedCandidates com pelo menos um candidato.");
+        }
         List<Map<String, Object>> ranked = candidates.stream()
                 .map(this::scoreCandidate)
                 .sorted(Comparator.comparingDouble(this::scoreOf).reversed())

--- a/oprm-coletor-mei/src/test/java/com/marketinghub/nichocnaev2/execution/NichoCnaeV2PendingExecutionServiceTest.java
+++ b/oprm-coletor-mei/src/test/java/com/marketinghub/nichocnaev2/execution/NichoCnaeV2PendingExecutionServiceTest.java
@@ -1,5 +1,6 @@
 package com.marketinghub.nichocnaev2.execution;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
@@ -8,6 +9,7 @@ import static org.mockito.Mockito.when;
 
 import java.util.List;
 import java.util.Map;
+import org.mockito.ArgumentCaptor;
 import org.junit.jupiter.api.Test;
 
 /** Valida a classificação operacional de falhas feita no executor NichoCNAE v2. */
@@ -79,6 +81,50 @@ class NichoCnaeV2PendingExecutionServiceTest {
         verify(backendClient).complete(any(NichoCnaeV2StageDefinition.class), eq(pending), any());
         verify(backendClient).createNextStage(any(NichoCnaeV2StageDefinition.class), eq(pending), any(), eq(null), eq(null));
     }
+
+    /** Deve preservar candidatos e trocar apenas o próximo estágio ao criar a pendência seguinte. */
+    @Test
+    void preservesAccumulatedContextWhenCreatingNextStage() {
+        NichoCnaeV2BackendClient backendClient = mock(NichoCnaeV2BackendClient.class);
+        NichoCnaeV2StageDefinitions stageDefinitions = new NichoCnaeV2StageDefinitions();
+        NichoCnaeV2PendingExecutionService service = new NichoCnaeV2PendingExecutionService(backendClient, stageDefinitions);
+        NichoCnaeV2PendingExecution pending = new NichoCnaeV2PendingExecution(
+                "133",
+                "nichocnae-v2-candidate-2-job-7",
+                "4781400",
+                "Comércio varejista de artigos do vestuário e acessórios",
+                null,
+                2L,
+                1,
+                0,
+                1,
+                false,
+                "{\"nextStageCode\":\"source-safety-filter\"}",
+                Map.of());
+        Map<String, Object> input = Map.of(
+                "nextStageCode", "source-safety-filter",
+                "candidateUrls", List.of("https://www.gov.br/empresas-e-negocios/pt-br/empreendedor"),
+                "candidateCount", 1,
+                "candidates", List.of(Map.of("candidateId", "C1", "job", "VESTUARIO_ATENDIMENTO_LOJA")));
+        when(backendClient.listPending(any())).thenAnswer(invocation -> {
+            NichoCnaeV2StageDefinition stage = invocation.getArgument(0);
+            return "source-safety-filter".equals(stage.stageCode()) ? List.of(pending) : List.of();
+        });
+        when(backendClient.parseInput(pending.inputPayload())).thenReturn(input);
+        when(backendClient.toJson(any())).thenAnswer(invocation -> invocation.getArgument(0).toString());
+
+        service.processAllPending();
+
+        ArgumentCaptor<String> payloadCaptor = ArgumentCaptor.forClass(String.class);
+        verify(backendClient).createNextStage(
+                any(NichoCnaeV2StageDefinition.class), eq(pending), payloadCaptor.capture(), eq(null), eq(null));
+        assertThat(payloadCaptor.getValue())
+                .contains("candidates")
+                .contains("candidateCount=1")
+                .contains("nextStageCode=adaptive-query-planner")
+                .doesNotContain("nextStageCode=source-safety-filter");
+    }
+
     /** Deve propagar tentativa e versão calculadas pelo controlador de reprocessamento para a próxima pendência. */
     @Test
     void propagatesReprocessAttemptAndKnowledgeVersionToNextStage() {

--- a/oprm-coletor-mei/src/test/java/com/marketinghub/nichocnaev2/pipeline/candidatetournament/CandidateTournamentProcessorTest.java
+++ b/oprm-coletor-mei/src/test/java/com/marketinghub/nichocnaev2/pipeline/candidatetournament/CandidateTournamentProcessorTest.java
@@ -1,6 +1,7 @@
 package com.marketinghub.nichocnaev2.pipeline.candidatetournament;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.marketinghub.nichocnaev2.pipeline.StageContext;
 import com.marketinghub.nichocnaev2.pipeline.StageResult;
@@ -44,5 +45,28 @@ class CandidateTournamentProcessorTest {
         assertThat(result.output()).containsEntry("gateDecision", "NO_VIABLE_SUBNICHE");
         assertThat(result.output()).containsEntry("reasonCode", "NO_VIABLE_SUBNICHE");
         assertThat(result.output()).containsEntry("nextStageCode", "reprocess-controller");
+    }
+
+    @Test
+    void shouldRejectMissingCandidatesAsInvalidStageContract() {
+        CandidateTournamentProcessor processor = new CandidateTournamentProcessor();
+
+        assertThatThrownBy(() -> processor.process(new StageContext("job-82", "stage-4", Map.of("plannedQueries", List.of()))))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("Candidate Tournament exige candidates");
+    }
+
+    @Test
+    void shouldAcceptRankedCandidatesWhenReprocessingTournament() {
+        CandidateTournamentProcessor processor = new CandidateTournamentProcessor();
+
+        StageResult result = processor.process(new StageContext(
+                "job-83",
+                "stage-4",
+                Map.of("rankedCandidates", List.of(
+                        Map.of("candidateId", "a", "directEvidenceCount", 4, "independentSourceCount", 3)))));
+
+        assertThat(result.status()).isEqualTo("FINALISTS_SELECTED");
+        assertThat(result.output()).containsEntry("candidateCount", 1);
     }
 }


### PR DESCRIPTION
### Motivation

- Fix jobs that ended with `candidates=0` because the executor created the next-stage payload from only the current stage output, losing accumulated candidates and functional context.
- Ensure the `candidate-tournament` stage treats a complete absence of candidates as an invalid stage contract and allow reprocess flows to supply `rankedCandidates` so tournament history is not lost.

### Description

- Modify `NichoCnaeV2PendingExecutionService#createNextStageIfNeeded` to accept the original `input` and build the next-stage payload via a new `nextStageInputPayload` method that preserves the accumulated context and overlays only the current stage output.
- Update the call site in `processOne` to pass `input` to `createNextStageIfNeeded` and serialize the merged payload for `backendClient.createNextStage` instead of the raw `outputPayload`.
- Enhance `CandidateTournamentProcessor` to fallback to `rankedCandidates` when `candidates` and `candidateEvidence` are empty and to throw `IllegalArgumentException` when no candidate list is provided.
- Add and adjust unit tests in `NichoCnaeV2PendingExecutionServiceTest` and `CandidateTournamentProcessorTest` to cover context preservation when creating the next stage, blocking tournament runs with no candidates, and accepting `rankedCandidates` on reprocess; update docs to reflect the behavior.

### Testing

- Ran unit tests `NichoCnaeV2PendingExecutionServiceTest` and `CandidateTournamentProcessorTest`, and all tests passed.
- Verified project compiles and the updated unit-test suite completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a37d28d0c9c83219f5931eb8c810ceb)