### PR TITLE
Show per-experiment cost in Experiments list (fix duplicate niche total)

### DIFF
--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -4969,3 +4969,9 @@
 - Solicitação: ao pedir nova IA na tela de novo experimento, remover as 3 opções atuais e gerar 3 novas, contabilizando o custo de IA no nicho, na hipótese e no experimento criado.
 - Foi feito: a tela limpa a opção selecionada e as sugestões antigas antes de registrar nova solicitação; o AI Worker envia tokens/custo da OpenAI; o backend persiste o custo da solicitação, soma no nicho e na hipótese ao concluir e inclui as solicitações usadas no custo inicial do experimento.
 - Prevenção: a telemetria de custo fica no contrato persistido da fila `experiment_promise_generation_request`, evitando opções geradas sem custo auditável.
+
+## 2026-06-21 — Custo individual na lista de Testes de Nicho
+- Problema: a coluna **Custo** da lista de experimentos repetia o total do nicho para todos os experimentos do mesmo nicho, dando a impressão de custo duplicado por hipótese/nicho.
+- Causa-raiz: o frontend calculava um mapa de custo agregado por nicho e usava esse total dentro de cada linha da tabela.
+- Correção aplicada: cada linha da tabela passou a exibir o custo recebido do próprio experimento pelo backend, mantendo o total do nicho apenas no filtro de nichos.
+- Prevenção de recorrência: teste de tela passou a validar que dois experimentos do mesmo nicho exibem custos individuais diferentes e não o total agregado do nicho.

--- a/frontend/src/pages/experiment/ExperimentListPage.test.tsx
+++ b/frontend/src/pages/experiment/ExperimentListPage.test.tsx
@@ -125,7 +125,84 @@ describe("ExperimentListPage", () => {
       within(row as HTMLTableRowElement).getByText("Nicho Principal"),
     ).toBeTruthy();
     expect(
-      within(row as HTMLTableRowElement).getByText("R$ 351,00"),
+      within(row as HTMLTableRowElement).getByText("R$ 1,00"),
     ).toBeTruthy();
   });
+
+  it("shows the individual backend cost for each experiment instead of the niche total", async () => {
+    const experiments = [
+      {
+        id: "2",
+        nicheId: 10,
+        hypothesisId: "hypothesis-2",
+        name: "Experimento 2",
+        hypothesis: "Hipótese 2",
+        cost: 33.18,
+        startDate: "2026-06-02",
+        endDate: null,
+        creativeApproved: false,
+        status: "PLANNED",
+        platform: "FACEBOOK",
+        stage: "AD",
+        createdAt: "2026-06-02T00:00:00Z",
+        updatedAt: "2026-06-02T00:00:00Z",
+      },
+      {
+        id: "1",
+        nicheId: 10,
+        hypothesisId: "hypothesis-1",
+        name: "Experimento 1",
+        hypothesis: "Hipótese 1",
+        cost: 66.63,
+        startDate: "2026-06-01",
+        endDate: null,
+        creativeApproved: false,
+        status: "PLANNED",
+        platform: "FACEBOOK",
+        stage: "AD",
+        createdAt: "2026-06-01T00:00:00Z",
+        updatedAt: "2026-06-01T00:00:00Z",
+      },
+    ];
+
+    (axios.get as any).mockImplementation((url: string) => {
+      if (url === "/api/experiments")
+        return Promise.resolve({ data: experiments });
+      if (url === "/api/niches") {
+        return Promise.resolve({
+          data: [
+            {
+              id: 10,
+              name: "Nicho Principal",
+              description: "",
+              demandVolume: "",
+              promises: "",
+              offers: "",
+              baseSegmentation: "",
+              interests: "",
+              demographicFilters: "",
+              extraTips: "",
+            },
+          ],
+        });
+      }
+      return Promise.resolve({ data: [] });
+    });
+
+    renderPage();
+
+    const row2 = (await screen.findByText("Experimento 2")).closest("tr");
+    const row1 = screen.getByText("Experimento 1").closest("tr");
+
+    expect(row2).not.toBeNull();
+    expect(row1).not.toBeNull();
+    expect(
+      within(row2 as HTMLTableRowElement).getByText("R$ 33,18"),
+    ).toBeTruthy();
+    expect(
+      within(row1 as HTMLTableRowElement).getByText("R$ 66,63"),
+    ).toBeTruthy();
+    expect(screen.queryByText("R$ 99,81")).toBeNull();
+  });
+
 });

--- a/frontend/src/pages/experiment/ExperimentListPage.tsx
+++ b/frontend/src/pages/experiment/ExperimentListPage.tsx
@@ -289,7 +289,7 @@ export default function ExperimentListPage() {
                     {nicheNameById.get(e.nicheId) || `Nicho #${e.nicheId}`}
                   </td>
                   <td>{e.hypothesis || "—"}</td>
-                  <td>{formatCurrency(nicheTotalCostMap[e.nicheId] ?? 0)}</td>
+                  <td>{formatCurrency(resolveExperimentCost(e))}</td>
                   <td>{e.status}</td>
                   <td>
                     <Link


### PR DESCRIPTION
### Motivation
- The experiments list was showing the aggregated niche total for every row, making experiment costs appear duplicated instead of showing each experiment's own cost. 
- The change fixes the root cause by making each row display the cost provided by the backend for that experiment while keeping the niche total only in the niche selector.

### Description
- The experiments table now displays the experiment-specific cost using `resolveExperimentCost(e)` instead of `nicheTotalCostMap[e.nicheId]` in `frontend/src/pages/experiment/ExperimentListPage.tsx`.
- Added a unit test to assert individual experiment costs for experiments that share the same niche and adjusted an existing expectation in `frontend/src/pages/experiment/ExperimentListPage.test.tsx` to the new behavior.
- Documented the bug, root cause and fix in `docs/registros/experimentos.md` under an entry `2026-06-21 — Custo individual na lista de Testes de Nicho`.

### Testing
- Installed frontend dependencies with `npm --prefix frontend install` which completed successfully.
- Ran the focused UI tests with `npm --prefix frontend test -- ExperimentListPage.test.tsx --run` and `vitest` reported all tests passed (`3 tests` passed).
- Ran type checking with `npm --prefix frontend run typecheck` (`tsc --noEmit`) which completed without type errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a380027d5148321921ed7e2a8d442de)