### PR TITLE
Melhora visualização de jobs NichoCNAE v2

### DIFF
--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -1225,3 +1225,8 @@
 - O executor `oprm-coletor-mei` agora monta o payload da próxima etapa preservando o contexto funcional de entrada, removendo apenas o `nextStageCode` antigo e sobrepondo a saída nova da etapa concluída.
 - O `candidate-tournament` passa a tratar ausência total de candidatos como erro de contrato de entrada, não como fracasso comercial, e aceita `rankedCandidates` em reprocessamentos para não perder histórico do torneio.
 - Prevenção de recorrência: adicionados testes cobrindo preservação de candidatos ao criar a próxima pendência, bloqueio de torneio sem candidatos e reprocessamento a partir de candidatos ranqueados.
+
+## 2026-06-21 — Tabela de jobs no pipeline NichoCNAE v2
+
+- Ajustada a tela do pipeline NichoCNAE v2 para apresentar jobs abertos e concluídos em tabela compacta, com textos longos limitados e detalhes completos preservados no tooltip.
+- Causa-raiz tratada: os cards deixavam cada job alto demais e dificultavam comparar rapidamente status, etapa, motivo, custo e atualização.

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -247,79 +247,51 @@
   box-shadow: 0 0 0 0.35rem rgba(15, 23, 42, 0.06);
 }
 
-.oprm-v2-job-list {
-  display: grid;
-  gap: 0.85rem;
-}
-
-.oprm-v2-job-card {
-  display: grid;
-  gap: 0.9rem;
-  padding: 1rem;
+.oprm-v2-job-table-wrap {
+  overflow-x: auto;
   border: 1px solid rgba(15, 23, 42, 0.08);
   border-radius: 0.85rem;
-  background: #f8fafc;
-}
-
-.oprm-v2-job-card__header,
-.oprm-v2-job-card__body,
-.oprm-v2-job-card__footer {
-  display: flex;
-  gap: 0.85rem;
-}
-
-.oprm-v2-job-card__header {
-  align-items: flex-start;
-  justify-content: space-between;
-}
-
-.oprm-v2-job-card__body {
-  flex-wrap: wrap;
-}
-
-.oprm-v2-job-card__main {
-  flex: 2 1 22rem;
-}
-
-.oprm-v2-job-card__action {
-  flex: 1 1 16rem;
-  padding: 0.75rem;
-  border-radius: 0.75rem;
   background: #ffffff;
-  color: #334155;
 }
 
-.oprm-v2-job-card__label {
+.oprm-v2-job-table {
+  min-width: 62rem;
+  font-size: 0.86rem;
+}
+
+.oprm-v2-job-table thead th {
   color: #64748b;
   font-size: 0.72rem;
   font-weight: 700;
   letter-spacing: 0.08em;
   text-transform: uppercase;
+  background: #f8fafc;
 }
 
-.oprm-v2-job-card__title {
-  font-size: 1.05rem;
+.oprm-v2-job-table th,
+.oprm-v2-job-table td {
+  max-width: 16rem;
+  padding: 0.65rem 0.75rem;
+  border-color: rgba(15, 23, 42, 0.08);
+}
+
+.oprm-v2-job-table__job,
+.oprm-v2-job-table__stage,
+.oprm-v2-job-table__text {
+  display: block;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.oprm-v2-job-table__job,
+.oprm-v2-job-table__stage {
   font-weight: 700;
+  white-space: nowrap;
 }
 
-.oprm-v2-job-card__meta,
-.oprm-v2-job-card__footer {
-  color: #64748b;
-  font-size: 0.82rem;
-}
-
-.oprm-v2-job-card__stage {
-  font-size: 1rem;
-  font-weight: 700;
-}
-
-.oprm-v2-job-card__reason {
-  margin-top: 0.35rem;
-  color: #475569;
-}
-
-.oprm-v2-job-card__footer {
-  flex-wrap: wrap;
-  padding-top: 0.75rem;
-  border-top: 1px solid rgba(15, 23, 42, 0.08);
+.oprm-v2-job-table__text {
+  display: -webkit-box;
+  -webkit-line-clamp: 2;
+  -webkit-box-orient: vertical;
+  line-height: 1.35;
 }

--- a/frontend/src/pages/oprm/OprmNichoCnaeV2PipelinePage.tsx
+++ b/frontend/src/pages/oprm/OprmNichoCnaeV2PipelinePage.tsx
@@ -133,72 +133,82 @@ function JobsTable({
   }
 
   return (
-    <div className="oprm-v2-job-list">
-      {jobs.map((job) => {
-        const stageName = formatStage(
-          open ? job.currentStageCode : job.lastStageCode,
-        );
-        const simplifiedReason = simplifyDecisionReason(
-          job.finalDecisionReason,
-        );
-        return (
-          <article className="oprm-v2-job-card" key={job.jobId}>
-            <div className="oprm-v2-job-card__header">
-              <div>
-                <div className="oprm-v2-job-card__label">Job</div>
-                <div className="oprm-v2-job-card__title">
-                  {formatJobId(job.jobId)}
-                </div>
-                <div className="oprm-v2-job-card__meta" title={job.jobId}>
-                  Código completo: {job.jobId}
-                </div>
-              </div>
-              <span className={decisionBadgeClass(job, open)}>
-                {explainStatus(job, open)}
-              </span>
-            </div>
-
-            <div className="oprm-v2-job-card__body">
-              <div className="oprm-v2-job-card__main">
-                <div className="oprm-v2-job-card__label">
-                  {open ? "Onde está parado" : "Última etapa"}
-                </div>
-                <div className="oprm-v2-job-card__stage">{stageName}</div>
-                {simplifiedReason ? (
-                  <p className="oprm-v2-job-card__reason mb-0">
-                    {simplifiedReason}
-                  </p>
-                ) : null}
-              </div>
-              <div className="oprm-v2-job-card__action">
-                <div className="oprm-v2-job-card__label">
-                  Resultado e próximo passo
-                </div>
-                <div>{getOperatorNextAction(job, open)}</div>
-                {!open && job.actionLabel && job.actionUrl ? (
-                  <Link
-                    className="btn btn-sm btn-primary mt-3"
-                    to={job.actionUrl}
+    <div className="oprm-v2-job-table-wrap">
+      <table className="table table-sm align-middle mb-0 oprm-v2-job-table">
+        <thead>
+          <tr>
+            <th scope="col">Job</th>
+            <th scope="col">Status</th>
+            <th scope="col">Etapa</th>
+            <th scope="col">Motivo</th>
+            <th scope="col">Próximo passo</th>
+            <th scope="col">IA</th>
+            <th scope="col">Tent.</th>
+            <th scope="col">Atualizado</th>
+          </tr>
+        </thead>
+        <tbody>
+          {jobs.map((job) => {
+            const stageName = formatStage(
+              open ? job.currentStageCode : job.lastStageCode,
+            );
+            const simplifiedReason = simplifyDecisionReason(
+              job.finalDecisionReason,
+            );
+            const nextAction = getOperatorNextAction(job, open);
+            return (
+              <tr key={job.jobId}>
+                <th scope="row">
+                  <div className="oprm-v2-job-table__job" title={job.jobId}>
+                    {formatJobId(job.jobId)}
+                  </div>
+                </th>
+                <td>
+                  <span className={decisionBadgeClass(job, open)}>
+                    {explainStatus(job, open)}
+                  </span>
+                </td>
+                <td>
+                  <span className="oprm-v2-job-table__stage" title={stageName}>
+                    {stageName}
+                  </span>
+                </td>
+                <td>
+                  <span
+                    className="oprm-v2-job-table__text"
+                    title={simplifiedReason ?? "Sem motivo informado"}
                   >
-                    {job.actionLabel}
-                  </Link>
-                ) : null}
-              </div>
-            </div>
-
-            <div className="oprm-v2-job-card__footer">
-              <span>IA: {formatAiCost(job.aiCostUsd)}</span>
-              <span>
-                Tentativa: {job.attemptNumber ?? "—"}
-                {job.technicalRetryNumber
-                  ? ` · retry ${job.technicalRetryNumber}`
-                  : ""}
-              </span>
-              <span>Atualizado: {formatDateTime(job.updatedAt)}</span>
-            </div>
-          </article>
-        );
-      })}
+                    {simplifiedReason ?? "—"}
+                  </span>
+                </td>
+                <td>
+                  <div className="d-flex flex-column align-items-start gap-1">
+                    <span className="oprm-v2-job-table__text" title={nextAction}>
+                      {nextAction}
+                    </span>
+                    {!open && job.actionLabel && job.actionUrl ? (
+                      <Link
+                        className="btn btn-sm btn-primary py-0 px-2"
+                        to={job.actionUrl}
+                      >
+                        {job.actionLabel}
+                      </Link>
+                    ) : null}
+                  </div>
+                </td>
+                <td className="text-nowrap">{formatAiCost(job.aiCostUsd)}</td>
+                <td className="text-nowrap">
+                  {job.attemptNumber ?? "—"}
+                  {job.technicalRetryNumber
+                    ? ` · r${job.technicalRetryNumber}`
+                    : ""}
+                </td>
+                <td className="text-nowrap">{formatDateTime(job.updatedAt)}</td>
+              </tr>
+            );
+          })}
+        </tbody>
+      </table>
     </div>
   );
 }


### PR DESCRIPTION
### Motivation
- Tornar mais fácil e rápida a comparação entre `Jobs abertos` e `Jobs concluídos` reduzindo altura das linhas e largura das colunas para visualização compacta.

### Description
- Substitui os cards de job por uma tabela compacta na tela `frontend/src/pages/oprm/OprmNichoCnaeV2PipelinePage.tsx` com colunas: `Job`, `Status`, `Etapa`, `Motivo`, `Próximo passo`, `IA`, `Tent.` e `Atualizado`.
- Adiciona estilos responsivos em `frontend/src/App.css` para limitar textos longos com elipses, tooltips para conteúdo completo e rolagem horizontal quando necessário (`.oprm-v2-job-table-wrap`, `.oprm-v2-job-table-*`).
- Preserva toda informação contextual nos tooltips e mantém formatação de valores (custos, datas) já existentes; mantém fallback de comportamento anterior (links/CTAs) quando aplicável.
- Atualiza registro operacional em `docs/registros/oprm1.md` documentando a mudança de apresentação.

### Testing
- `npm run typecheck` (initial) failed due to missing dependencies before install; after running `npm ci` the TypeScript check `npm run typecheck` completed successfully. 
- `npm ci` completed successfully to install dependencies. 
- `npm run build` (Vite production build) completed successfully and produced the optimized `dist` artifacts. 
- `npm run dev` was started to validate the page locally (dev server up).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3800c3f4c48321af545d70c6f19887)