### PR TITLE
Fix compilation in ImagePlanningBackendClient (missing brace)

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/openai/core/imageplanning/ImagePlanningBackendClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/openai/core/imageplanning/ImagePlanningBackendClient.java
@@ -195,6 +195,7 @@ public class ImagePlanningBackendClient implements StageBackendPort<ImagePlannin
             }
         }
         return null;
+    }
 
     /** Monta o bloco textual de contexto comercial usado pelo prompt de imageplanning. */
     private String buildCaseDataBlock(Map<String, Object> payload) {

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -4995,3 +4995,9 @@
 - Solicitação: verificar se todos os prompts da etapa GeraLanding usam o contrato de promessa única.
 - Causa-raiz encontrada: Copy, Deliverables e Image Planning já estavam alinhados, mas Wireframe, Design Preset e Quality Review ainda não declaravam explicitamente o contrato; além disso, os pendings dessas etapas não carregavam os campos do contrato.
 - Correção aplicada: todos os prompts GeraLanding passam a receber e respeitar `singlePain`, `freeReward`, `funnelPromise`, `primaryCta` e `campaignObjective`, com propagação nos pendings do backend e nos builders do AI Worker.
+
+## 2026-06-21 — Correção de compilação no Image Planning
+- Problema: o build do AI Worker falhava com `illegal start of expression` em `ImagePlanningBackendClient`.
+- Causa-raiz: o método auxiliar `firstNonNull` ficou sem a chave de fechamento antes do método `buildCaseDataBlock`, deixando a classe Java com estrutura inválida.
+- Correção aplicada: fechado corretamente o método `firstNonNull`, preservando o contrato de montagem do contexto comercial do prompt.
+- Prevenção de recorrência: a compilação do módulo foi tentada para validar a sintaxe; a validação completa ficou bloqueada por dependência privada do `ads-service` no GitHub Packages sem autenticação no ambiente.


### PR DESCRIPTION
### Motivation
- Fix a compilation break in the AI Worker caused by `illegal start of expression` from a missing closing brace in the helper `firstNonNull` method of the image planning backend client.

### Description
- Add the missing closing brace in `ai-worker/src/main/java/com/marketinghub/worker/openai/core/imageplanning/ImagePlanningBackendClient.java` and log the root cause and prevention notes in `docs/registros/experimentos.md`.

### Testing
- Ran `git diff --check` (no whitespace/syntax diff issues); ran `javac -proc:none ai-worker/src/main/java/com/marketinghub/worker/openai/core/imageplanning/ImagePlanningBackendClient.java` which moved past the original syntax error but showed expected dependency/classpath errors; attempted `mvn -DskipTests compile` in `ai-worker` but the build was blocked by GitHub Packages returning `401 Unauthorized` while resolving `com.marketinghub:ads-service:0.0.1-SNAPSHOT`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a381d1337888321b2585cd9054219fb)