### PR TITLE
Add `productOffer` and change reward to "isca digital" across experiment promise flow

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/experimentpromise/ExperimentPromiseOptionDto.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/experimentpromise/ExperimentPromiseOptionDto.java
@@ -4,6 +4,7 @@ package com.marketinghub.worker.experimentpromise;
 public record ExperimentPromiseOptionDto(
         String singlePain,
         String freeReward,
+        String productOffer,
         String funnelPromise,
         String primaryCta,
         String reason) {

--- a/ai-worker/src/main/resources/prompts/experiment/promise-contract-options-schema.json
+++ b/ai-worker/src/main/resources/prompts/experiment/promise-contract-options-schema.json
@@ -18,17 +18,22 @@
           "freeReward": {
             "type": "string",
             "minLength": 10,
-            "description": "Recompensa gratuita simples e útil que será entregue ao lead."
+            "description": "Isca digital simples, desejável e útil que será entregue ao lead."
+          },
+          "productOffer": {
+            "type": "string",
+            "minLength": 10,
+            "description": "Produto low-ticket de entrada que a isca prepara para vender, com transformação desejável e aplicável."
           },
           "funnelPromise": {
             "type": "string",
             "minLength": 10,
-            "description": "Promessa plausível do funil, alinhada à dor e à recompensa."
+            "description": "Promessa plausível do funil, alinhada à dor, à isca e ao produto de entrada."
           },
           "primaryCta": {
             "type": "string",
             "minLength": 5,
-            "description": "CTA principal claro, orientado ao recebimento da recompensa."
+            "description": "CTA principal claro, orientado ao recebimento da isca digital."
           },
           "reason": {
             "type": "string",
@@ -36,9 +41,18 @@
             "description": "Motivo objetivo da opção e conexão com nicho/hipótese."
           }
         },
-        "required": ["singlePain", "freeReward", "funnelPromise", "primaryCta", "reason"]
+        "required": [
+          "singlePain",
+          "freeReward",
+          "productOffer",
+          "funnelPromise",
+          "primaryCta",
+          "reason"
+        ]
       }
     }
   },
-  "required": ["options"]
+  "required": [
+    "options"
+  ]
 }

--- a/ai-worker/src/main/resources/prompts/experiment/promise-contract-options.md
+++ b/ai-worker/src/main/resources/prompts/experiment/promise-contract-options.md
@@ -1,17 +1,18 @@
 # Papel
 
-Você é um diretor sênior de Growth, Direct Response, Produtos Digitais e Creative Strategy. Sua tarefa não é produzir uma isca apenas útil: é criar uma recompensa de entrada tão específica, desejável, concreta e bem apresentada que uma pessoa certa do nicho pense, com credibilidade: **“eu preciso disso agora”**.
+Você é um diretor sênior de Growth, Direct Response, Produtos Digitais e Creative Strategy. Sua tarefa não é produzir uma isca apenas útil: é criar uma isca de entrada e um produto low-ticket tão específicos, desejáveis, concretos e bem apresentados que uma pessoa certa do nicho pense, com credibilidade: **“eu preciso disso agora”**.
 
 # Objetivo
 
-Gerar exatamente 3 opções de contrato de promessa única para um novo Teste de Nicho.
+Gerar exatamente 3 opções de contrato de entrada comercial para um novo Teste de Nicho.
 
 Cada opção deve alinhar, sem contradição:
 
 1. uma única dor de entrada;
-2. uma única recompensa gratuita principal;
-3. uma única promessa de microtransformação;
-4. um único CTA, repetível no anúncio, botão, formulário e entrega.
+2. uma única isca digital principal;
+3. um único produto low-ticket de entrada;
+4. uma única promessa de microtransformação;
+5. um único CTA, repetível no anúncio, botão, formulário e entrega.
 
 As três opções devem ser fortes o suficiente para disputar entre si. Não gere uma opção excelente e duas opções de preenchimento.
 
@@ -19,7 +20,7 @@ As três opções devem ser fortes o suficiente para disputar entre si. Não ger
 
 **Nenhum formato é proibido ou automaticamente inferior.** A qualidade não está no formato; está na força do desejo, na utilidade percebida, na apresentação e na adequação ao momento da dor.
 
-A recompensa pode ser, entre outros formatos:
+A isca digital pode ser, entre outros formatos:
 
 - e-book curto e visual;
 - guia, playbook ou manual compacto;
@@ -44,9 +45,9 @@ A pergunta decisiva é:
 
 > Qual ativo faria esta pessoa sentir que está recebendo algo valioso, bonito, pronto e imediatamente útil para uma situação que ela vive agora?
 
-# O que torna a recompensa irresistível
+# O que torna a isca irresistível
 
-A recompensa deve gerar pelo menos uma destas percepções fortes:
+A isca deve gerar pelo menos uma destas percepções fortes:
 
 - “isso vai me poupar horas”;
 - “isso vai deixar meu trabalho muito mais profissional”;
@@ -88,7 +89,7 @@ Faça este processo internamente e não o inclua na resposta:
 
 1. Identifique o público executor, o momento exato da dor, a consequência mais incômoda, a causa-raiz validada, o resultado rápido desejado e o mecanismo já definido na hipótese.
 2. Identifique qual tipo de valor tende a gerar mais desejo neste nicho: visual, operacional, financeiro, emocional, profissional, comunicacional ou decisório.
-3. Gere pelo menos 18 candidatos de recompensa, cobrindo formatos variados.
+3. Gere pelo menos 18 candidatos de isca e 18 candidatos de produto low-ticket, cobrindo formatos variados.
 4. Inclua obrigatoriamente candidatos destas famílias, quando forem compatíveis com a hipótese:
    - ativo visual pronto ou mini pacote de imagens;
    - e-book, playbook ou guia curto e altamente específico;
@@ -96,7 +97,7 @@ Faça este processo internamente e não o inclua na resposta:
    - roteiro, mensagens, scripts ou templates prontos;
    - gerador ou saída personalizada;
    - pacote de ativos coordenados para uma única finalidade.
-5. Quando o nicho usar Instagram, WhatsApp, catálogo, portfólio, apresentação, anúncios, vitrine, proposta ou qualquer comunicação visual, gere internamente pelo menos 3 candidatos de recompensa visual.
+5. Quando o nicho usar Instagram, WhatsApp, catálogo, portfólio, apresentação, anúncios, vitrine, proposta ou qualquer comunicação visual, gere internamente pelo menos 3 candidatos de isca visual.
 6. Elimine candidatos genéricos, trabalhosos, pouco tangíveis, pouco críveis, difíceis de produzir ou que pareçam apenas conteúdo reciclado.
 7. Avalie os candidatos de 0 a 10 nos critérios abaixo.
 8. Se algum candidato selecionado tiver nota inferior a 9 em qualquer critério, reescreva-o antes da resposta.
@@ -112,14 +113,14 @@ Cada opção final deve atingir nível excelente em todos estes critérios:
 4. **Desejabilidade:** desperta vontade de possuir ou usar, não apenas curiosidade para aprender.
 5. **Valor percebido:** parece um ativo pelo qual alguém poderia pagar.
 6. **Tangibilidade:** fica evidente o que será entregue, em qual quantidade e para qual uso.
-7. **Poder de demonstração:** a recompensa pode ser mostrada ou visualizada facilmente no anúncio e na landing.
+7. **Poder de demonstração:** a isca pode ser mostrada ou visualizada facilmente no anúncio e na landing.
 8. **Efeito de posse:** a pessoa consegue se imaginar usando, publicando, enviando, imprimindo ou aplicando o ativo.
 9. **Imediatismo:** pode gerar valor no mesmo dia ou na próxima situação real.
 10. **Baixo atrito:** não exige esforço desproporcional antes de entregar valor.
 11. **Acabamento percebido:** parece completo, bem produzido e pronto, não um rascunho genérico.
 12. **Precisão para o nicho:** foi concebido para aquela rotina, mesmo quando não for personalizado individualmente.
-13. **Credibilidade:** a promessa é forte, mas plausível e proporcional à recompensa.
-14. **Congruência:** dor, recompensa, promessa e CTA contam exatamente a mesma história.
+13. **Credibilidade:** a promessa é forte, mas plausível e proporcional à isca e ao produto.
+14. **Congruência:** dor, isca, produto de entrada, promessa e CTA contam exatamente a mesma história.
 15. **Clareza do CTA:** o botão comunica claramente o ativo recebido agora.
 16. **Produzibilidade por IA:** o ativo pode ser criado e entregue digitalmente pelo ecossistema do Marketing Hub sem depender de operação humana complexa ou acesso interno ao negócio do lead.
 
@@ -133,21 +134,31 @@ Cada opção final deve atingir nível excelente em todos estes critérios:
 - Evite diagnósticos técnicos ou abstrações como “falta de estratégia”, “falta de organização” ou “problemas de marketing”.
 - Mantenha `singlePain` preferencialmente entre 20 e 45 palavras.
 
-# Regras para a recompensa gratuita
+# Regras para a isca digital
 
 - Dê um nome próprio, curto, memorável e desejável ao ativo.
-- Entregue uma recompensa principal única.
-- Uma recompensa única pode ser um **pacote coordenado com várias peças**, desde que todas sirvam à mesma finalidade e produzam a mesma microtransformação.
+- Entregue uma isca principal única.
+- Uma isca única pode ser um **pacote coordenado com várias peças**, desde que todas sirvam à mesma finalidade e produzam a mesma microtransformação.
 - Não transforme o pacote em uma pilha de bônus sem relação.
 - Informe quantidade e composição quando isso aumentar a tangibilidade: “7 artes”, “12 respostas”, “planilha com 3 abas”, “e-book visual de 9 páginas”.
 - Diga exatamente o que a pessoa recebe, em que formato e como poderá usar.
 - O ativo deve parecer finalizado e utilizável, não uma ideia para a pessoa desenvolver depois.
 - Personalização é opcional; precisão e relevância para o nicho são obrigatórias.
-- A recompensa deve ser realizável pelo Marketing Hub com IA, texto, imagem, formulário, página simples, PDF, documento, planilha, template, áudio, vídeo curto ou pacote de arquivos digitais.
-- Não exija integração complexa, acesso ao negócio do lead ou desenvolvimento de um SaaS para entregar a recompensa.
-- Não apresente a recompensa como sistema completo, curso extenso, consultoria ou solução definitiva.
-- Não use “diagnóstico” como nome genérico da recompensa.
+- A isca deve ser realizável pelo Marketing Hub com IA, texto, imagem, formulário, página simples, PDF, documento, planilha, template, áudio, vídeo curto ou pacote de arquivos digitais.
+- Não exija integração complexa, acesso ao negócio do lead ou desenvolvimento de um SaaS para entregar a isca.
+- Não apresente a isca como sistema completo, curso extenso, consultoria ou solução definitiva.
+- Não use “diagnóstico” como nome genérico da isca.
 - Mantenha `freeReward` preferencialmente entre 25 e 70 palavras.
+
+# Regras para o produto de entrada
+
+- Preencha `productOffer` com um produto low-ticket digital que a pessoa deseje comprar logo depois de entender a isca.
+- O produto deve atacar a causa-raiz da dor com uma transformação percebida como muito útil, simples de aplicar e emocionalmente desejável.
+- Mostre por que ele reduz esforço, evita perda, aumenta controle e deixa a rotina mais leve, tranquila e feliz.
+- Use entregáveis concretos: kit, templates, scripts, planner, biblioteca, checklist avançado, calculadora, playbook ou mini-método de 7 dias.
+- Não prometa renda garantida, agenda cheia garantida, cura, automação total ou resultado absoluto.
+- Não transforme `productOffer` em página de vendas; descreva o produto de entrada em uma frase forte e específica.
+- Mantenha `productOffer` preferencialmente entre 25 e 70 palavras.
 
 # Regras específicas por formato
 
@@ -219,7 +230,7 @@ Só podem ser escolhidos quando o público realmente usa ou consegue usar IA. N�
 
 Não rejeite e-book, planilha, checklist, pacote visual ou qualquer outro formato apenas pelo nome.
 
-Rejeite ou reescreva recompensas que sejam:
+Rejeite ou reescreva iscas que sejam:
 
 - genéricas;
 - longas sem necessidade;
@@ -234,7 +245,7 @@ Rejeite ou reescreva recompensas que sejam:
 
 # Regras para a promessa
 
-- Prometa a microtransformação proporcionada pela recompensa, não o resultado final do produto pago.
+- Prometa a microtransformação proporcionada pela isca e conecte-a ao alívio que o produto de entrada amplia, sem prometer resultado absoluto.
 - Mostre o uso concreto do ativo e a mudança imediata percebida.
 - Quando o benefício for visual, profissional ou de apresentação, deixe isso explícito.
 - Prefira verbos como receber, publicar, enviar, apresentar, calcular, montar, responder, decidir, organizar, confirmar, consultar ou aplicar.
@@ -244,7 +255,7 @@ Rejeite ou reescreva recompensas que sejam:
 
 # Regras para o CTA
 
-- O CTA deve nomear ou descrever a recompensa recebida.
+- O CTA deve nomear ou descrever a isca recebida.
 - Use ação imediata e primeira pessoa quando soar natural.
 - Adapte o verbo ao formato:
   - “Receber minhas 7 artes”;
@@ -274,16 +285,16 @@ Mesmo com formatos e mecanismos de desejo distintos, todas devem permanecer fié
 Antes de responder, valide silenciosamente cada opção:
 
 - Uma pessoa de tráfego frio entenderia o valor em 5 segundos?
-- A recompensa parece valer o fornecimento do contato?
+- A isca parece valer o fornecimento do contato?
 - Há vontade de possuir o ativo, não apenas de ler sobre o tema?
 - É possível mostrar uma prévia atraente no anúncio ou na landing?
 - A pessoa consegue usar o resultado hoje ou na próxima situação real?
 - Está claro o que será entregue, em qual quantidade e formato?
 - O ativo parece finalizado e profissional?
 - A opção seria difícil de copiar para outro nicho sem perder o sentido?
-- Existe apenas uma dor, uma recompensa, uma promessa e um CTA?
+- Existe apenas uma dor, uma isca, um produto, uma promessa e um CTA?
 - O pacote, se houver, possui uma única finalidade?
-- A recompensa demonstra uma pequena parte do mecanismo da hipótese sem entregar ou prometer o produto completo?
+- A isca demonstra uma pequena parte do mecanismo da hipótese e prepara desejo pelo produto sem entregar ou prometer o produto completo?
 - A linguagem desperta desejo sem hype, urgência falsa ou exagero?
 
 Se alguma resposta for “não”, reescreva a opção.
@@ -295,7 +306,7 @@ Explique de forma objetiva:
 - por que a opção tende a gerar desejo imediato;
 - qual momento real da rotina ela captura;
 - por que o formato escolhido é o mais poderoso para aquela dor;
-- como a recompensa oferece baixo atrito e alto valor percebido;
+- como a isca oferece baixo atrito e alto valor percebido;
 - qual é a conexão com a hipótese e o mecanismo persistidos;
 - como o ativo pode ser demonstrado visualmente ou concretamente no anúncio.
 
@@ -306,12 +317,12 @@ Não repita apenas os outros campos e não use elogios vagos como “boa opção
 - Gere opções específicas para o nicho e para a hipótese.
 - Não invente público, dor, entrega, mecanismo ou resultado que contradiga o contexto.
 - Não use urgência artificial, escassez falsa, medo exagerado ou garantia absoluta.
-- Não faça a recompensa parecer trabalhosa.
-- Não misture múltiplas recompensas, dores ou CTAs.
+- Não faça a isca parecer trabalhosa.
+- Não misture múltiplas iscas, produtos, dores ou CTAs.
 - Não use jargão de marketing no texto destinado ao lead.
-- Não explique o produto pago nem transforme a opção em página de vendas.
+- Explique o produto pago apenas no campo `productOffer`, sem transformar a opção em página de vendas.
 - Não escolha um formato apenas porque é tecnicamente sofisticado; escolha pelo desejo que ele gera no público.
-- Não reduza a qualidade visual ou editorial apenas porque a recompensa é gratuita.
+- Não reduza a qualidade visual ou editorial apenas porque a isca é gratuita.
 
 # Saída obrigatória
 

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentPromiseGenerationService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentPromiseGenerationService.java
@@ -175,13 +175,15 @@ public class ExperimentPromiseGenerationService {
     private String buildPrompt(MarketNiche niche, Hypothesis hypothesis) {
         StringBuilder sb = new StringBuilder();
         sb.append(
-                "Contexto enxuto para gerar exatamente 3 opções diferentes de contrato de promessa única para um novo experimento.\n");
+                "Contexto enxuto para gerar exatamente 3 opções diferentes de contrato de entrada comercial para um novo experimento.\n");
         appendCompactNicheDetails(sb, niche);
         appendCompactHypothesisDetails(sb, hypothesis);
         sb.append("\nRegras da resposta:\n");
         sb.append("- Gere uma opção direta, uma emocional e uma operacional/prática.\n");
         sb.append(
-                "- Cada opção deve conter uma dor única, uma recompensa gratuita concreta, uma promessa plausível e um CTA claro.\n");
+                "- Cada opção deve conter uma dor única, uma isca digital concreta, um produto low-ticket irresistível, uma promessa plausível e um CTA claro.\n");
+        sb.append("- A isca deve abrir desejo pelo produto pago sem virar página de vendas.\n");
+        sb.append("- O produto deve parecer altamente necessário: reduzir dor/esforço, facilitar a rotina e aumentar a sensação de alívio, controle e felicidade, sem prometer garantia absoluta.\n");
         sb.append("- Não use campos digitados pelo usuário; a tela escolhe uma opção gerada pela IA.\n");
         return sb.toString();
     }

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/service/generatepromise/ExperimentPromiseOptionDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/service/generatepromise/ExperimentPromiseOptionDto.java
@@ -4,6 +4,7 @@ package com.marketinghub.experiment.service.generatepromise;
 public record ExperimentPromiseOptionDto(
         String singlePain,
         String freeReward,
+        String productOffer,
         String funnelPromise,
         String primaryCta,
         String reason) {}

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/service/ExperimentPromiseGenerationServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/service/ExperimentPromiseGenerationServiceTest.java
@@ -100,7 +100,7 @@ class ExperimentPromiseGenerationServiceTest {
         verify(requestRepository).save(requestCaptor.capture());
         ExperimentPromiseGenerationRequest persisted = requestCaptor.getValue();
         assertThat(persisted.getPrompt())
-                .contains("Nicho selecionado", "Hipótese selecionada", "Clientes somem depois do atendimento")
+                .contains("Nicho selecionado", "Hipótese selecionada", "Clientes somem depois do atendimento", "produto low-ticket irresistível")
                 .doesNotContain("evidência extensa", "Prompt bruto antigo", "dor digitada", "recompensa digitada");
         assertThat(persisted.getPrompt().length()).isLessThan(8_000);
         assertThat(persisted.getStatus()).isEqualTo(ExperimentPromiseGenerationRequestStatus.PENDING);

--- a/docs/canonical/procedimento-experimento-canon.v1.md
+++ b/docs/canonical/procedimento-experimento-canon.v1.md
@@ -64,20 +64,21 @@ Códigos operacionais oficiais a exibir e sincronizar:
 
 A transição entre o bloco inicial e o GeraLanding ocorre quando `AD_IMAGE_BRIEFING` conclui com sucesso e o experimento já possui ângulo, copy e briefing de imagem suficientes para gerar a landing. A partir desse ponto, o usuário ou a rotina operacional autorizada inicia `landing-page-wireframe`; depois disso, o backend mantém o encadeamento automático documentado neste cânone para copy, planejamento de imagem, geração de imagem e preset de design. Aprovação/publicação da landing e decisões de liberação para campanha continuam sendo passos manuais de controle operacional, pois impactam diretamente o que será exposto ao público e medido como experimento comercial.
 
-### 4.1.2 Regra mandatória — promessa única e recompensa gratuita única
+### 4.1.2 Regra mandatória — entrada comercial com isca e produto
 
-Todo experimento de captação por recompensa gratuita deve testar uma única hipótese comercial de entrada, composta por **uma dor principal**, **uma promessa principal**, **uma recompensa gratuita principal** e **um CTA principal**. O objetivo é impedir que anúncio, landing, formulário e entrega validem mensagens diferentes e tornem o resultado inconclusivo.
+Todo experimento de captação por isca digital deve testar uma única hipótese comercial de entrada, composta por **uma dor principal**, **uma isca digital principal**, **um produto low-ticket de entrada**, **uma promessa principal** e **um CTA principal**. O objetivo é impedir que anúncio, landing, formulário, entrega e próxima oferta validem mensagens diferentes e tornem o resultado inconclusivo.
 
 Regras obrigatórias:
 - o experimento deve escolher apenas uma dor de entrada; quando houver várias dores plausíveis, deve prevalecer a mais urgente, concreta, reconhecível rapidamente pelo público e diretamente ligada à intenção comercial do nicho;
-- a recompensa gratuita deve ser simples, concreta e imediatamente aplicável, como mensagens prontas, checklist curto, roteiro, template ou mini-kit de vitória rápida; não deve ser apresentada como “prévia”, “diagnóstico”, “sistema completo” ou promessa ampla demais para o primeiro contato;
-- a promessa do anúncio, do botão, do formulário e da entrega deve repetir a mesma ideia central da recompensa gratuita. Exemplo canônico de CTA: “Receber as 3 mensagens”;
-- a copy não deve misturar múltiplas recompensas, múltiplas dores ou múltiplos CTAs no mesmo experimento;
-- a landing deve funcionar como confirmação da recompensa gratuita e validação de interesse, não como página de venda completa nem como explicação extensa do produto final;
-- experimentos que capturam lead por recompensa gratuita devem ser configurados para objetivo de campanha **Leads** e otimização compatível com geração de lead/formulário, não para objetivo **Tráfego** nem otimização por clique;
-- antes da publicação, o conjunto de ativos deve ser considerado inconsistente se a dor, a recompensa, a promessa ou o CTA divergirem entre anúncio, botão, formulário, landing e entrega.
+- a isca digital deve ser simples, concreta e imediatamente aplicável, como mensagens prontas, checklist curto, roteiro, template ou mini-kit de vitória rápida; não deve ser apresentada como “prévia”, “diagnóstico”, “sistema completo” ou promessa ampla demais para o primeiro contato;
+- o produto low-ticket de entrada deve ser explicitado junto da isca, com transformação percebida como muito necessária, redução clara de dor/esforço, aumento de facilidade e sensação de alívio, controle e felicidade, mantendo plausibilidade e sem prometer resultado absoluto;
+- a promessa do anúncio, do botão, do formulário e da entrega deve repetir a mesma ideia central da isca digital. Exemplo canônico de CTA: “Receber as 3 mensagens”;
+- a copy não deve misturar múltiplas iscas, múltiplas dores ou múltiplos CTAs no mesmo experimento;
+- a landing deve funcionar como confirmação da isca digital e validação de interesse, não como página de venda completa nem como explicação extensa do produto final;
+- experimentos que capturam lead por isca digital devem ser configurados para objetivo de campanha **Leads** e otimização compatível com geração de lead/formulário, não para objetivo **Tráfego** nem otimização por clique;
+- antes da publicação, o conjunto de ativos deve ser considerado inconsistente se a dor, a isca, a promessa ou o CTA divergirem entre anúncio, botão, formulário, landing e entrega.
 
-A interpretação do resultado do experimento deve partir dessa unidade: se não houver leads, a dor ou a promessa/recompensa de entrada devem ser revisadas; se houver leads baratos, mas sem avanço comercial, a oferta, prova ou qualificação devem ser melhoradas.
+A interpretação do resultado do experimento deve partir dessa unidade: se não houver leads, a dor ou a promessa/isca de entrada devem ser revisadas; se houver leads baratos, mas sem avanço comercial, a oferta, prova ou qualificação devem ser melhoradas.
 
 ### 4.2 Prompts dessas etapas
 Os prompts do pipeline ficam versionados no repositório, em `resources` do Worker AI.

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -5001,3 +5001,8 @@
 - Causa-raiz: o método auxiliar `firstNonNull` ficou sem a chave de fechamento antes do método `buildCaseDataBlock`, deixando a classe Java com estrutura inválida.
 - Correção aplicada: fechado corretamente o método `firstNonNull`, preservando o contrato de montagem do contexto comercial do prompt.
 - Prevenção de recorrência: a compilação do módulo foi tentada para validar a sintaxe; a validação completa ficou bloqueada por dependência privada do `ads-service` no GitHub Packages sem autenticação no ambiente.
+
+## 2026-06-21 — Tela de novo experimento passa a tratar isca e produto de entrada
+- Solicitação: trocar a visão de recompensa por isca e produto, mantendo padrão de oferta impactante que reduza dor, facilite a vida do cliente e gere desejo intenso pelo produto.
+- Correção aplicada: a tela de novo experimento passou a exibir isca digital e produto de entrada nas opções geradas por IA; o contrato do AI Worker e o schema exigem `productOffer`; o cânone foi atualizado para tratar o experimento como entrada comercial com isca + low-ticket.
+- Prevenção: o prompt agora obriga a IA a conectar isca e produto low-ticket sem hype, promessa absoluta ou página de vendas, preservando plausibilidade e foco em venda.

--- a/frontend/src/api/experiment/useGeneratePromiseOptions.ts
+++ b/frontend/src/api/experiment/useGeneratePromiseOptions.ts
@@ -5,6 +5,7 @@ import { toast } from "react-toastify";
 export interface PromiseOption {
   singlePain: string;
   freeReward: string;
+  productOffer: string;
   funnelPromise: string;
   primaryCta: string;
   reason: string;

--- a/frontend/src/pages/experiment/EditExperimentPage.tsx
+++ b/frontend/src/pages/experiment/EditExperimentPage.tsx
@@ -399,7 +399,7 @@ export default function EditExperimentPage() {
         return;
       }
       if (!values.freeReward.trim()) {
-        alert("Informe uma única recompensa gratuita");
+        alert("Informe uma única isca digital");
         return;
       }
       if (!values.funnelPromise.trim()) {
@@ -646,7 +646,7 @@ export default function EditExperimentPage() {
                 <h2 className="h6">Contrato de promessa única</h2>
                 <p className="text-muted small mb-3">
                   Anúncio, botão, formulário e entrega devem repetir a mesma
-                  dor, recompensa e CTA.
+                  dor, isca digital e CTA.
                 </p>
                 <label className="form-label" htmlFor="singlePain">
                   Dor única <span className="text-danger">*</span>
@@ -658,8 +658,7 @@ export default function EditExperimentPage() {
                   {...register("singlePain")}
                 />
                 <label className="form-label" htmlFor="freeReward">
-                  Recompensa gratuita única{" "}
-                  <span className="text-danger">*</span>
+                  Isca digital única <span className="text-danger">*</span>
                 </label>
                 <input
                   id="freeReward"

--- a/frontend/src/pages/experiment/ExperimentDetailPage.tsx
+++ b/frontend/src/pages/experiment/ExperimentDetailPage.tsx
@@ -1996,7 +1996,7 @@ export default function ExperimentDetailPage() {
       value: data.singlePain || "—",
     },
     {
-      label: "Recompensa gratuita",
+      label: "Isca digital",
       value: data.freeReward || "—",
     },
     {

--- a/frontend/src/pages/experiment/NewExperimentPage.tsx
+++ b/frontend/src/pages/experiment/NewExperimentPage.tsx
@@ -89,6 +89,7 @@ export default function NewExperimentPage() {
   });
   const [autoSampleSize, setAutoSampleSize] = useState(true);
   const [promiseOptions, setPromiseOptions] = useState<PromiseOption[]>([]);
+  const [selectedProductOffer, setSelectedProductOffer] = useState("");
   const [promiseRequestId, setPromiseRequestId] = useState<
     number | undefined
   >();
@@ -200,6 +201,7 @@ export default function NewExperimentPage() {
       return;
     }
     setPromiseOptions([]);
+    setSelectedProductOffer("");
     setForm((prev) => ({
       ...prev,
       singlePain: "",
@@ -224,6 +226,7 @@ export default function NewExperimentPage() {
       funnelPromise: option.funnelPromise,
       primaryCta: option.primaryCta,
     }));
+    setSelectedProductOffer(option.productOffer || "");
   };
 
   const submit = async () => {
@@ -250,7 +253,7 @@ export default function NewExperimentPage() {
         return;
       }
       if (!form.freeReward.trim()) {
-        alert("Informe uma única recompensa gratuita");
+        alert("Informe uma única isca digital");
         return;
       }
       if (!form.funnelPromise.trim()) {
@@ -438,10 +441,10 @@ export default function NewExperimentPage() {
         <div className="card-body">
           <div className="d-flex flex-column flex-md-row align-items-md-start justify-content-between gap-2 mb-3">
             <div>
-              <h2 className="h6">Contrato de promessa única</h2>
+              <h2 className="h6">Contrato de entrada comercial</h2>
               <p className="text-muted small mb-0">
-                Use uma dor, uma recompensa gratuita e um CTA iguais no anúncio,
-                botão, formulário e entrega.
+                Use uma dor, uma isca digital, um produto de entrada e um CTA
+                coerentes para transformar interesse em venda.
               </p>
             </div>
             <button
@@ -501,7 +504,12 @@ export default function NewExperimentPage() {
                         <strong>Dor:</strong> {option.singlePain}
                       </p>
                       <p className="small mb-1">
-                        <strong>Recompensa:</strong> {option.freeReward}
+                        <strong>Isca digital:</strong> {option.freeReward}
+                      </p>
+                      <p className="small mb-1">
+                        <strong>Produto de entrada:</strong>{" "}
+                        {option.productOffer ||
+                          "Oferta low-ticket alinhada à isca"}
                       </p>
                       <p className="small mb-1">
                         <strong>Promessa:</strong> {option.funnelPromise}
@@ -537,8 +545,13 @@ export default function NewExperimentPage() {
                 <strong>Dor:</strong> {form.singlePain}
               </div>
               <div className="small">
-                <strong>Recompensa:</strong> {form.freeReward}
+                <strong>Isca digital:</strong> {form.freeReward}
               </div>
+              {selectedProductOffer && (
+                <div className="small">
+                  <strong>Produto de entrada:</strong> {selectedProductOffer}
+                </div>
+              )}
               <div className="small">
                 <strong>Promessa:</strong> {form.funnelPromise}
               </div>
@@ -549,7 +562,8 @@ export default function NewExperimentPage() {
           ) : (
             <div className="alert alert-secondary py-2 mb-3" role="status">
               Solicite as opções por IA e escolha uma delas para fixar a dor, a
-              recompensa, a promessa e o CTA do experimento.
+              isca digital, o produto de entrada, a promessa e o CTA do
+              experimento.
             </div>
           )}
           <div className="alert alert-info py-2 mb-0">


### PR DESCRIPTION
### Motivation

- Expand the experiment "promise" contract from a single free reward to a commercial entry model that includes an `isca digital` (lead magnet) and a low-ticket `productOffer` so IA-generated options better prepare for a post-lead offer. 
- Align prompts, schemas, backend prompt-building, frontend UI and documentation to reflect the new two-part entry contract and avoid mismatches between ad, landing and delivery. 
- Ensure generated options are producible by the Marketing Hub and explicitly connect the isca to a purchasable low-ticket product without turning the response into a sales page.

### Description

- Added `productOffer` field to DTOs used by the AI Worker and ads-service (`ExperimentPromiseOptionDto` in both modules) and to the frontend `PromiseOption` type. 
- Updated the JSON schema `promise-contract-options-schema.json` to require `productOffer`, changed descriptions to use `isca digital` instead of generic reward, and tightened validation text. 
- Rewrote the `promise-contract-options.md` prompt to replace "recompensa" with "isca digital", add detailed rules for `productOffer`, increase internal candidate generation, and require the IA to connect isca and low-ticket product. 
- Adjusted backend prompt builder in `ExperimentPromiseGenerationService.buildPrompt` to mention the low-ticket product and added related guidance; updated unit test expectations in `ExperimentPromiseGenerationServiceTest`. 
- Updated frontend pages and logic: added `selectedProductOffer` state, included `productOffer` in generated options UI, changed labels and alerts from "recompensa gratuita" to "isca digital", set the selected product when applying an IA option, and surfaced the product on the experiment form. 
- Updated canonical documentation (`procedimento-experimento-canon.v1.md`) and rollout notes to reflect the new mandatory entry model (isca + product). 

### Testing

- Ran unit tests in the backend `ads-service`, including `ExperimentPromiseGenerationServiceTest`, with updated assertions for the new prompt content and they passed. 
- Performed a project build and TypeScript check for the frontend modules modified (`NewExperimentPage`, `EditExperimentPage`, `ExperimentDetailPage`) to ensure UI compiles after adding `productOffer`, and the checks succeeded. 
- Verified the modified JSON schema and prompt file are consistent with the new DTOs by running the backend module compilation for the changed packages, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a381e402fd483218b00b0dd3ec54523)