### PR TITLE
Corrige NullPointer em prompt GeraLanding (presetdesign & imageplanning)

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/openai/core/imageplanning/ImagePlanningBackendClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/openai/core/imageplanning/ImagePlanningBackendClient.java
@@ -169,22 +169,27 @@ public class ImagePlanningBackendClient implements StageBackendPort<ImagePlannin
         Map<String, Object> framework = asMap(hypothesis.get("framework"));
 
         Map<String, Object> payload = new LinkedHashMap<>();
-        payload.put("singlePain", experiment.get("singlePain"));
-        payload.put("freeReward", experiment.get("freeReward"));
-        payload.put("funnelPromise", experiment.get("funnelPromise"));
-        payload.put("primaryCta", experiment.get("primaryCta"));
-        payload.put("campaignObjective", experiment.get("campaignObjective"));
+        payload.put("singlePain", emptyWhenNull(experiment.get("singlePain")));
+        payload.put("freeReward", emptyWhenNull(experiment.get("freeReward")));
+        payload.put("funnelPromise", emptyWhenNull(experiment.get("funnelPromise")));
+        payload.put("primaryCta", emptyWhenNull(experiment.get("primaryCta")));
+        payload.put("campaignObjective", emptyWhenNull(experiment.get("campaignObjective")));
         payload.put("campaignAngle", normalizeJsonArtifact(experiment.get("campaignAngle")));
         payload.put("adCopy", normalizeJsonArtifact(experiment.get("adCopy")));
         payload.put("adImageBriefing", normalizeJsonArtifact(experiment.get("adImageBriefing")));
         payload.put("landingPageCopy", normalizeJsonArtifact(experiment.get("landingPageCopy")));
         payload.put("landingPageWireframe", normalizeJsonArtifact(experiment.get("landingPageWireframe")));
         payload.put("NICHE_NAME", firstText(experiment.get("nicheName"), experiment.get("niche"), experiment.get("name")));
-        payload.put("PAIN_JSON", framework.getOrDefault("pain", Map.of()));
-        payload.put("RESULT_JSON", framework.getOrDefault("result", Map.of()));
+        payload.put("PAIN_JSON", normalizeJsonArtifact(framework.get("pain")));
+        payload.put("RESULT_JSON", normalizeJsonArtifact(framework.get("result")));
         payload.put("CASE_DATA_BLOCK", buildCaseDataBlock(payload));
 
         return payload;
+    }
+
+    /** Substitui valores nulos por texto vazio para impedir nulos em contratos de prompt. */
+    private Object emptyWhenNull(Object value) {
+        return value != null ? value : "";
     }
 
     /** Retorna o primeiro valor não nulo entre as opções informadas. */

--- a/ai-worker/src/main/java/com/marketinghub/worker/openai/core/presetdesign/PresetDesignBackendClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/openai/core/presetdesign/PresetDesignBackendClient.java
@@ -156,11 +156,11 @@ public class PresetDesignBackendClient implements StageBackendPort<PresetDesignI
         Map<String, Object> framework = asMap(hypothesis.get("framework"));
 
         Map<String, Object> payload = new LinkedHashMap<>();
-        payload.put("singlePain", experiment.get("singlePain"));
-        payload.put("freeReward", experiment.get("freeReward"));
-        payload.put("funnelPromise", experiment.get("funnelPromise"));
-        payload.put("primaryCta", experiment.get("primaryCta"));
-        payload.put("campaignObjective", experiment.get("campaignObjective"));
+        payload.put("singlePain", emptyWhenNull(experiment.get("singlePain")));
+        payload.put("freeReward", emptyWhenNull(experiment.get("freeReward")));
+        payload.put("funnelPromise", emptyWhenNull(experiment.get("funnelPromise")));
+        payload.put("primaryCta", emptyWhenNull(experiment.get("primaryCta")));
+        payload.put("campaignObjective", emptyWhenNull(experiment.get("campaignObjective")));
         payload.put("campaignAngle", normalizeJsonArtifact(experiment.get("campaignAngle")));
         payload.put("adCopy", normalizeJsonArtifact(experiment.get("adCopy")));
         payload.put("adImageBriefing", normalizeJsonArtifact(experiment.get("adImageBriefing")));
@@ -169,10 +169,15 @@ public class PresetDesignBackendClient implements StageBackendPort<PresetDesignI
         payload.put("landingPageDesignPreset", normalizeJsonArtifact(experiment.get("landingPageDesignPreset")));
         payload.put("landingPageQualityReview", normalizeJsonArtifact(experiment.get("landingPageQualityReview")));
         payload.put("NICHE_NAME", firstText(experiment.get("nicheName"), experiment.get("niche"), experiment.get("name")));
-        payload.put("PAIN_JSON", framework.getOrDefault("pain", Map.of()));
-        payload.put("RESULT_JSON", framework.getOrDefault("result", Map.of()));
+        payload.put("PAIN_JSON", normalizeJsonArtifact(framework.get("pain")));
+        payload.put("RESULT_JSON", normalizeJsonArtifact(framework.get("result")));
 
         return payload;
+    }
+
+    /** Substitui valores nulos por texto vazio para impedir nulos em contratos de prompt. */
+    private Object emptyWhenNull(Object value) {
+        return value != null ? value : "";
     }
 
     /** Normaliza artefatos que podem chegar como JSON textual, objeto estruturado ou valor simples. */

--- a/ai-worker/src/test/java/com/marketinghub/worker/openai/core/presetdesign/PresetDesignBackendClientTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/openai/core/presetdesign/PresetDesignBackendClientTest.java
@@ -101,6 +101,47 @@ class PresetDesignBackendClientTest {
                 .contains("LANDING_PAGE_DESIGN_PRESET");
     }
 
+
+    /** Deve montar dados do prompt sem NullPointerException quando o backend omite contexto opcional. */
+    @Test
+    void listPendingShouldTolerateMissingOptionalPromptContext() throws Exception {
+        server.enqueue(new MockResponse()
+                .setResponseCode(200)
+                .setHeader("Content-Type", "application/json")
+                .setBody("""
+                        [
+                          {
+                            "experimentId": 12,
+                            "jobid": "job-ia-1",
+                            "stageCode": "landing-page-design-preset",
+                            "executionRequestedAt": "2026-05-29T10:00:00Z",
+                            "experiment": {"id": 12, "name": "Experimento Design"}
+                          }
+                        ]
+                        """));
+        PresetDesignBackendClient client = new PresetDesignBackendClient(
+                WebClient.builder(),
+                new PresetDesignWorkerProperties(
+                        true,
+                        5,
+                        server.url("/").toString(),
+                        "/api",
+                        "prompts/geralanding/landing-page-design-preset.md",
+                        "prompts/geralanding/landing-page-design-preset-schema.json",
+                        "experiment_pipeline_landing_page_design_preset",
+                        "gpt-5.5",
+                        Duration.ofSeconds(5)),
+                objectMapper);
+
+        List<StageExecution<PresetDesignInput>> pending = client.listPending(5);
+
+        assertThat(pending).hasSize(1);
+        assertThat(pending.getFirst().input().promptData())
+                .containsEntry("landingPageQualityReview", Map.of())
+                .containsEntry("PAIN_JSON", Map.of())
+                .containsEntry("RESULT_JSON", Map.of());
+    }
+
     /** Deve enviar prompt, schema e request cru no callback recebe-prompt. */
     @Test
     void markDispatchedShouldSendPromptSchemaAndRawRequestToRecebePrompt() throws Exception {

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -5001,3 +5001,9 @@
 - Causa-raiz: o método auxiliar `firstNonNull` ficou sem a chave de fechamento antes do método `buildCaseDataBlock`, deixando a classe Java com estrutura inválida.
 - Correção aplicada: fechado corretamente o método `firstNonNull`, preservando o contrato de montagem do contexto comercial do prompt.
 - Prevenção de recorrência: a compilação do módulo foi tentada para validar a sintaxe; a validação completa ficou bloqueada por dependência privada do `ads-service` no GitHub Packages sem autenticação no ambiente.
+
+## 2026-06-21 — Correção de NullPointer nos dados de prompt do GeraLanding core
+- Problema: o teste `PresetDesignBackendClientTest.listPendingShouldIncludeQualityReviewDiagnosticInPromptData` falhava com `NullPointerException` ao montar o `promptData` da etapa Design Preset.
+- Causa-raiz: os clients de etapas do Worker AI colocavam valores nulos vindos do backend em `promptData`, mas os records de entrada usam `Map.copyOf`, que rejeita valores nulos.
+- Correção aplicada: Design Preset e Image Planning agora normalizam campos opcionais ausentes para texto vazio ou mapa vazio antes de criar a execução, preservando o diagnóstico do Quality Review e evitando quebra da fila por contexto incompleto.
+- Prevenção de recorrência: adicionado teste cobrindo pending de Design Preset sem contexto opcional, além da execução dos testes do AI Worker.


### PR DESCRIPTION
### Motivation
- O teste `PresetDesignBackendClientTest.listPendingShouldIncludeQualityReviewDiagnosticInPromptData` falhou com `NullPointerException` porque valores nulos vindos do backend entravam em `promptData` e `Map.copyOf` nos records rejeitava nulos.

### Description
- Normaliza campos textuais opcionais usando um helper `emptyWhenNull(...)` e substitui atribuições diretas por `emptyWhenNull(experiment.get(...))` em `PresetDesignBackendClient` e `ImagePlanningBackendClient`.
- Garante que artefatos/framework (pain/result) sejam normalizados via `normalizeJsonArtifact(...)` retornando mapa vazio quando ausente, evitando `null` em `PAIN_JSON`/`RESULT_JSON`.
- Adiciona teste de regressão `listPendingShouldTolerateMissingOptionalPromptContext` em `PresetDesignBackendClientTest` que valida pending sem contexto opcional.
- Atualiza registro operacional em `docs/registros/experimentos.md` e inclui as mudanças em `ai-worker/src/main/java/.../PresetDesignBackendClient.java`, `.../ImagePlanningBackendClient.java` e no teste `PresetDesignBackendClientTest.java`.

### Testing
- Executei `mvn -f backend/ads-service/pom.xml -DskipTests install` e a instalação do artefato `ads-service` foi bem sucedida.
- Rodei os testes alvo com `mvn -f ai-worker/pom.xml -Dtest=PresetDesignBackendClientTest test` e `mvn -f ai-worker/pom.xml -Dtest=ImagePlanningBackendClientTest,PresetDesignBackendClientTest test` e ambos passaram com sucesso.
- Rodei o teste completo do módulo `ai-worker` com `mvn -f ai-worker/pom.xml test` e a suíte terminou com sucesso (`Tests run: 191, Failures: 0, Errors: 0`, `BUILD SUCCESS`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a381fe2a1a88321966d90860d550c23)