### PR TITLE
Fix AI worker GeraLanding compilation

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/openai/core/imageplanning/ImagePlanningBackendClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/openai/core/imageplanning/ImagePlanningBackendClient.java
@@ -266,6 +266,11 @@ public class ImagePlanningBackendClient implements StageBackendPort<ImagePlannin
         }
     }
 
+    /** Retorna texto vazio quando o backend não entrega um campo textual opcional. */
+    private String emptyWhenNull(Object value) {
+        return value != null ? value.toString() : "";
+    }
+
     /** Normaliza artefatos que podem chegar como JSON textual, objeto estruturado ou valor simples. */
     private Object normalizeJsonArtifact(Object value) {
         if (value instanceof String text) {

--- a/ai-worker/src/main/java/com/marketinghub/worker/openai/core/presetdesign/PresetDesignBackendClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/openai/core/presetdesign/PresetDesignBackendClient.java
@@ -217,6 +217,11 @@ public class PresetDesignBackendClient implements StageBackendPort<PresetDesignI
         return value != null && !value.toString().isBlank();
     }
 
+    /** Retorna texto vazio quando o backend não entrega um campo textual opcional. */
+    private String emptyWhenNull(Object value) {
+        return value != null ? value.toString() : "";
+    }
+
     /** Normaliza artefatos que podem chegar como JSON textual, objeto estruturado ou valor simples. */
     private Object normalizeJsonArtifact(Object value) {
         if (value instanceof String text) {

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -5007,3 +5007,9 @@
 - Causa-raiz: os clients de etapas do Worker AI colocavam valores nulos vindos do backend em `promptData`, mas os records de entrada usam `Map.copyOf`, que rejeita valores nulos; além disso, campos comerciais obrigatórios não devem ser mascarados como vazios.
 - Correção aplicada: Design Preset e Image Planning agora preservam os campos comerciais recebidos e ignoram payload pendente sem `singlePain`, `freeReward`, `funnelPromise`, `primaryCta` ou `campaignObjective`, registrando diagnóstico em log em vez de enviar prompt vazio para IA. Artefatos opcionais continuam normalizados como mapa vazio quando ausentes.
 - Prevenção de recorrência: adicionados testes cobrindo pending válido com contrato comercial preenchido e pending inválido sem contrato comercial obrigatório.
+
+## 2026-06-21 — Correção de compilação dos clients GeraLanding core
+- Problema: o build do AI Worker falhava porque `ImagePlanningBackendClient` e `PresetDesignBackendClient` chamavam `emptyWhenNull`, mas o helper não existia nas classes.
+- Causa-raiz: o ajuste anterior passou a normalizar campos textuais opcionais para evitar nulos no `promptData`, porém não incluiu o método auxiliar nas duas etapas.
+- Correção aplicada: adicionado o helper local nas etapas Image Planning e Design Preset, preservando o isolamento por etapa do core OpenAI.
+- Prevenção de recorrência: compilação do backend foi instalada localmente e o AI Worker foi compilado antes do PR; testes do AI Worker também foram executados.


### PR DESCRIPTION
### Motivation
- Compiler errors in the AI Worker caused by calls to a missing helper `emptyWhenNull` in GeraLanding clients needed a minimal, local fix to restore successful compilation while keeping step isolation.

### Description
- Added a local helper method `emptyWhenNull(Object)` to `ImagePlanningBackendClient` and `PresetDesignBackendClient` and recorded the fix in `docs/registros/experimentos.md` to document cause and prevention.

### Testing
- Ran `mvn -q -DskipTests install` in `backend/ads-service` (succeeded), `mvn -q -DskipTests compile` in `ai-worker` (succeeded) and `mvn -q test` in `ai-worker` (tests executed successfully).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a38286efb8883218e1385376f9bdee5)