### PR TITLE
Bloqueia jobs NichoCNAE v2 paralelos por CNAE

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/candidategenerator/service/BackendCandidateGeneratorService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/candidategenerator/service/BackendCandidateGeneratorService.java
@@ -52,6 +52,10 @@ public class BackendCandidateGeneratorService {
             "safetyDecision",
             "qualityStatus",
             "decision");
+    private static final List<OprmNichoCnaeV2StageExecutionStatus> OPEN_STATUSES = List.of(
+            OprmNichoCnaeV2StageExecutionStatus.PENDING,
+            OprmNichoCnaeV2StageExecutionStatus.RUNNING,
+            OprmNichoCnaeV2StageExecutionStatus.TECHNICAL_RETRY_SCHEDULED);
     private static final List<String> COST_KEYS = List.of(
             "aiCostUsd",
             "totalAiCostUsd",
@@ -85,7 +89,6 @@ public class BackendCandidateGeneratorService {
         this.materializationEnabled = materializationEnabled;
     }
 
-
     /** Mantém compatibilidade com testes unitários que não exercem auditoria OpenAI. */
     public BackendCandidateGeneratorService(
             OprmNicheCandidateRepository nicheCandidateRepository,
@@ -94,6 +97,7 @@ public class BackendCandidateGeneratorService {
             boolean materializationEnabled) {
         this(nicheCandidateRepository, stageExecutionRepository, null, v2Enabled, materializationEnabled);
     }
+
     /** Lista pendências disponíveis para consumo canônico pelo executor OPRM NichoCNAE v2. */
     @Transactional
     public List<CandidateGeneratorPendingResponse> pending() {
@@ -114,6 +118,11 @@ public class BackendCandidateGeneratorService {
     public CandidateGeneratorCreateResponse createForCnae(String cnaeCode) {
         if (!v2Enabled) {
             throw new ResponseStatusException(HttpStatus.CONFLICT, "NichoCNAE v2 is disabled");
+        }
+        if (stageExecutionRepository.countByCnaeCodeAndStatusIn(cnaeCode, OPEN_STATUSES) > 0) {
+            throw new ResponseStatusException(
+                    HttpStatus.CONFLICT,
+                    "Já existe job NichoCNAE v2 aberto para este CNAE. Encerre ou aguarde o job atual antes de iniciar outro.");
         }
         OprmNicheCandidate candidate = nicheCandidateRepository
                 .findManualRoutineResearchCandidateByCnaeCode(cnaeCode, PageRequest.of(0, 1))

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/oprm/nichocnae/v2/OprmNichoCnaeV2StageExecutionRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/oprm/nichocnae/v2/OprmNichoCnaeV2StageExecutionRepository.java
@@ -22,6 +22,9 @@ public interface OprmNichoCnaeV2StageExecutionRepository extends JpaRepository<O
     /** Lista execuções de um CNAE para montar o acompanhamento administrativo por job. */
     List<OprmNichoCnaeV2StageExecution> findByCnaeCodeOrderByUpdatedAtDesc(String cnaeCode);
 
+    /** Conta execuções por CNAE e estados informados para impedir dois jobs simultâneos no mesmo mercado. */
+    long countByCnaeCodeAndStatusIn(String cnaeCode, List<OprmNichoCnaeV2StageExecutionStatus> statuses);
+
     /** Localiza uma execução específica por etapa para callbacks internos do executor. */
     Optional<OprmNichoCnaeV2StageExecution> findByIdAndStageCode(Long id, String stageCode);
 }

--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-21-oprm-nichocnae-v2-clear-stale-open-jobs.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-21-oprm-nichocnae-v2-clear-stale-open-jobs.yaml
@@ -1,0 +1,27 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-06-21-01-oprm-nichocnae-v2-clear-stale-open-jobs
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - onError: HALT
+        - dbms:
+            type: mysql
+        - tableExists:
+            tableName: oprm_nichocnae_v2_stage_execution
+      changes:
+        - sql:
+            splitStatements: true
+            stripComments: true
+            sql: |
+              UPDATE oprm_nichocnae_v2_stage_execution
+              SET status = 'FAILED',
+                  failure_type = 'INFRASTRUCTURE',
+                  error_message = CONCAT(
+                    'Limpeza operacional em 2026-06-21: job aberto ficou preso e foi encerrado para liberar a regra de um job simultâneo por CNAE. Erro anterior: ',
+                    COALESCE(error_message, 'sem erro registrado')
+                  ),
+                  updated_at = CURRENT_TIMESTAMP(6)
+              WHERE cnae_code = '4781400'
+                AND status IN ('PENDING', 'RUNNING', 'TECHNICAL_RETRY_SCHEDULED')
+                AND updated_at < '2026-06-21 00:00:00';

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -1050,3 +1050,7 @@ databaseChangeLog:
   - include:
       file: changesets/2026-06-20-experiment-single-promise-fields.yaml
       relativeToChangelogFile: true
+
+  - include:
+      file: changesets/2026-06-21-oprm-nichocnae-v2-clear-stale-open-jobs.yaml
+      relativeToChangelogFile: true

--- a/backend/ads-service/src/test/java/com/marketinghub/oprm/nichocnae/v2/candidategenerator/service/BackendCandidateGeneratorServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/oprm/nichocnae/v2/candidategenerator/service/BackendCandidateGeneratorServiceTest.java
@@ -1,6 +1,7 @@
 package com.marketinghub.oprm.nichocnae.v2.candidategenerator.service;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.never;
@@ -89,12 +90,12 @@ class BackendCandidateGeneratorServiceTest {
         assertThat(result.getFirst().materializationEnabled()).isFalse();
     }
 
-
     /** Deve gravar novo job manual para o CNAE selecionado sem executar o fluxo no backend. */
     @Test
     void createForCnaePersistsNewPendingJobForSelectedCnae() {
         BackendCandidateGeneratorService service = service(true, false);
         OprmNicheCandidate candidate = candidate(4781400L, "4781400");
+        when(stageExecutionRepository.countByCnaeCodeAndStatusIn(eq("4781400"), any())).thenReturn(0L);
         when(nicheCandidateRepository.findManualRoutineResearchCandidateByCnaeCode(eq("4781400"), any(Pageable.class)))
                 .thenReturn(List.of(candidate));
         when(stageExecutionRepository.countBySourceNicheIdAndStageCode(4781400L, "candidate-generator"))
@@ -113,6 +114,19 @@ class BackendCandidateGeneratorServiceTest {
         assertThat(result.cnaeCode()).isEqualTo("4781400");
     }
 
+    /** Deve impedir novo job manual quando já existe execução aberta para o mesmo CNAE. */
+    @Test
+    void createForCnaeBlocksParallelOpenJobForSameCnae() {
+        BackendCandidateGeneratorService service = service(true, false);
+        when(stageExecutionRepository.countByCnaeCodeAndStatusIn(eq("4781400"), any())).thenReturn(1L);
+
+        assertThatThrownBy(() -> service.createForCnae("4781400"))
+                .isInstanceOf(org.springframework.web.server.ResponseStatusException.class)
+                .hasMessageContaining("Já existe job NichoCNAE v2 aberto para este CNAE");
+
+        verify(nicheCandidateRepository, never()).findManualRoutineResearchCandidateByCnaeCode(any(), any(Pageable.class));
+        verify(stageExecutionRepository, never()).save(any(OprmNichoCnaeV2StageExecution.class));
+    }
 
     /** Deve separar jobs do CNAE entre abertos com etapa atual e encerrados pelo histórico persistido. */
     @Test

--- a/docs/canonical/oprm-canon.v1.md
+++ b/docs/canonical/oprm-canon.v1.md
@@ -329,3 +329,10 @@ Evitar fechamento prematuro de `import run` que destrói a totalização de mark
 
 - As notas do gate devem conter pelo menos um código estável de próximo movimento e uma descrição legível para operação.
 - Testes unitários devem cobrir que reprovações por solução, fonte antiga, desvio corporativo, definição fraca de público executor, aquisição/canais observáveis insuficientes e rotina genérica recebem movimentos diferentes e coerentes com a causa-raiz.
+
+## Regra de concorrência NichoCNAE v2 por CNAE
+
+- Para cada CNAE, pode existir no máximo um job NichoCNAE v2 operacionalmente aberto ao mesmo tempo.
+- Estados considerados abertos: `PENDING`, `RUNNING` e `TECHNICAL_RETRY_SCHEDULED` em `oprm_nichocnae_v2_stage_execution`.
+- O backend deve bloquear a criação manual de novo job v2 quando já existir job aberto para o mesmo `cnae_code`, evitando concorrência, custo duplicado de IA e confusão na tela administrativa.
+- Jobs antigos presos em estado aberto devem ser encerrados como falha operacional auditável antes de liberar uma nova execução para o CNAE.

--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -1230,3 +1230,9 @@
 
 - Ajustada a tela do pipeline NichoCNAE v2 para apresentar jobs abertos e concluídos em tabela compacta, com textos longos limitados e detalhes completos preservados no tooltip.
 - Causa-raiz tratada: os cards deixavam cada job alto demais e dificultavam comparar rapidamente status, etapa, motivo, custo e atualização.
+
+## 2026-06-21 — NichoCNAE v2: um job aberto por CNAE
+
+- Nova regra operacional: o backend passa a bloquear a criação manual de outro job NichoCNAE v2 quando o mesmo CNAE já possui execução aberta (`PENDING`, `RUNNING` ou `TECHNICAL_RETRY_SCHEDULED`).
+- Limpeza: criado changelog para encerrar como falha operacional os jobs presos do CNAE `4781400` anteriores a `2026-06-21 00:00:00`, liberando a tela para uma nova execução controlada.
+- Causa-raiz tratada: a criação manual só contava execuções por candidato/etapa e não verificava jobs abertos por CNAE, permitindo dois jobs simultâneos para o mesmo mercado.


### PR DESCRIPTION
### Motivation

- Evitar que dois jobs do pipeline NichoCNAE v2 rodem simultaneamente para o mesmo CNAE, o que causa concorrência operacional, custos duplicados de IA e confusão na UI.
- Limpar execuções presas já existentes (ex.: CNAE `4781400`) que estão marcadas como abertas mas não progrediram, permitindo liberar o mercado para nova execução controlada.

### Description

- Adiciona verificação no service `BackendCandidateGeneratorService.createForCnae` para impedir criação de novo job quando já existe execução aberta, lançando `ResponseStatusException` em caso de conflito; a lista de estados abertos é `PENDING`, `RUNNING` e `TECHNICAL_RETRY_SCHEDULED` (`OPEN_STATUSES`).
- Expande o repositório `OprmNichoCnaeV2StageExecutionRepository` com `countByCnaeCodeAndStatusIn(...)` para contar execuções por CNAE em estados fornecidos e suportar a nova regra.
- Cria changelog Liquibase `changesets/2026-06-21-oprm-nichocnae-v2-clear-stale-open-jobs.yaml` que encerra como `FAILED` (com `failure_type = 'INFRASTRUCTURE'` e mensagem auditável) jobs abertos do CNAE `4781400` anteriores a `2026-06-21 00:00:00` e inclui o changelog no `db.changelog-master.yaml` com `relativeToChangelogFile: true`.
- Adiciona teste unitário `createForCnaeBlocksParallelOpenJobForSameCnae` em `BackendCandidateGeneratorServiceTest` e atualiza documentação canônica e registro (`docs/canonical/oprm-canon.v1.md` e `docs/registros/oprm1.md`) explicando a nova regra operacional.

### Testing

- Executei os testes unitários do serviço afetado com `mvn -Dtest=com.marketinghub.oprm.nichocnae.v2.candidategenerator.service.BackendCandidateGeneratorServiceTest test` e todas as 11 asserções passaram (BUILD SUCCESS).
- Rodei validações automáticas de integridade do repositório (`git diff --check`) e uma checagem de `include` relativo em `db.changelog-master.yaml` (script de validação), ambos sem problemas.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a382ee5985883219722026b8dc96c5d)