### PR TITLE
Adicionar tela de detalhe do job NichoCNAE v2 para rastrear fracassos

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/candidategenerator/controller/BackendCandidateGeneratorController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/candidategenerator/controller/BackendCandidateGeneratorController.java
@@ -4,6 +4,7 @@ import com.marketinghub.oprm.nichocnae.v2.candidategenerator.service.BackendCand
 import com.marketinghub.oprm.nichocnae.v2.candidategenerator.service.completeStageExecution.CandidateGeneratorCompletionRequest;
 import com.marketinghub.oprm.nichocnae.v2.candidategenerator.service.completeStageExecution.CandidateGeneratorCompletionResponse;
 import com.marketinghub.oprm.nichocnae.v2.candidategenerator.service.createStageExecution.CandidateGeneratorCreateResponse;
+import com.marketinghub.oprm.nichocnae.v2.candidategenerator.service.detailJob.CandidateGeneratorJobDetailResponse;
 import com.marketinghub.oprm.nichocnae.v2.candidategenerator.service.failStageExecution.CandidateGeneratorFailureRequest;
 import com.marketinghub.oprm.nichocnae.v2.candidategenerator.service.failStageExecution.CandidateGeneratorFailureResponse;
 import com.marketinghub.oprm.nichocnae.v2.candidategenerator.service.listCnaeJobs.CandidateGeneratorCnaeJobsResponse;
@@ -37,6 +38,12 @@ public class BackendCandidateGeneratorController {
     @GetMapping("/cnaes/{cnaeCode}/jobs")
     public CandidateGeneratorCnaeJobsResponse listJobsForCnae(@PathVariable String cnaeCode) {
         return service.listJobsForCnae(cnaeCode);
+    }
+
+    /** Detalha as etapas persistidas de um job para explicar até onde ele avançou. */
+    @GetMapping("/jobs/{jobId}")
+    public CandidateGeneratorJobDetailResponse detailJob(@PathVariable String jobId) {
+        return service.detailJob(jobId);
     }
 
     /** Entrega execuções pendentes da etapa candidate-generator ao módulo executor OPRM. */

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/candidategenerator/service/BackendCandidateGeneratorService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/candidategenerator/service/BackendCandidateGeneratorService.java
@@ -11,6 +11,8 @@ import com.marketinghub.oprm.nichocnae.v2.OprmNichoCnaeV2StageExecutionStatus;
 import com.marketinghub.oprm.nichocnae.v2.candidategenerator.service.completeStageExecution.CandidateGeneratorCompletionRequest;
 import com.marketinghub.oprm.nichocnae.v2.candidategenerator.service.completeStageExecution.CandidateGeneratorCompletionResponse;
 import com.marketinghub.oprm.nichocnae.v2.candidategenerator.service.createStageExecution.CandidateGeneratorCreateResponse;
+import com.marketinghub.oprm.nichocnae.v2.candidategenerator.service.detailJob.CandidateGeneratorJobDetailResponse;
+import com.marketinghub.oprm.nichocnae.v2.candidategenerator.service.detailJob.CandidateGeneratorJobStageStep;
 import com.marketinghub.oprm.nichocnae.v2.candidategenerator.service.failStageExecution.CandidateGeneratorFailureRequest;
 import com.marketinghub.oprm.nichocnae.v2.candidategenerator.service.failStageExecution.CandidateGeneratorFailureResponse;
 import com.marketinghub.oprm.nichocnae.v2.candidategenerator.service.listCnaeJobs.CandidateGeneratorCnaeJobSummary;
@@ -174,6 +176,26 @@ public class BackendCandidateGeneratorService {
         return new CandidateGeneratorCnaeJobsResponse(cnaeCode, cnaeAiCostUsd, cnaeUsedAi, openJobs, completedJobs);
     }
 
+    /** Detalha as etapas persistidas de um job para a tela explicar o caminho até o fracasso ou sucesso. */
+    @Transactional(readOnly = true)
+    public CandidateGeneratorJobDetailResponse detailJob(String jobId) {
+        List<OprmNichoCnaeV2StageExecution> executions = stageExecutionRepository.findByJobIdOrderByCreatedAtAsc(jobId);
+        if (executions.isEmpty()) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "NichoCNAE v2 job not found: " + jobId);
+        }
+        CandidateGeneratorCnaeJobSummary summary = toJobSummary(executions);
+        return new CandidateGeneratorJobDetailResponse(
+                summary.jobId(),
+                summary.cnaeCode(),
+                summary.status(),
+                summary.finalDecision(),
+                summary.finalDecisionLabel(),
+                summary.finalDecisionReason(),
+                summary.outcomeStatus(),
+                summary.outcomeMessage(),
+                executions.stream().map(this::toJobStageStep).toList());
+    }
+
     /** Registra conclusão da etapa persistindo a próxima etapa informada pelo executor externo. */
     @Transactional
     public CandidateGeneratorCompletionResponse complete(
@@ -223,6 +245,25 @@ public class BackendCandidateGeneratorService {
                 null,
                 saved.getAttemptNumber(),
                 saved.getTechnicalRetryNumber());
+    }
+
+    /** Converte uma execução persistida em item de linha cronológico do relatório de job. */
+    private CandidateGeneratorJobStageStep toJobStageStep(OprmNichoCnaeV2StageExecution execution) {
+        return new CandidateGeneratorJobStageStep(
+                String.valueOf(execution.getId()),
+                execution.getStageCode(),
+                execution.getStatus().name(),
+                execution.getFailureType() == null ? null : execution.getFailureType().name(),
+                execution.getAttemptNumber(),
+                execution.getTechnicalRetryNumber(),
+                execution.getKnowledgeVersion(),
+                execution.getMaterializationEnabled(),
+                execution.getInputPayload(),
+                execution.getOutputPayload(),
+                execution.getErrorMessage(),
+                execution.getNextStageCode(),
+                execution.getCreatedAt(),
+                execution.getUpdatedAt());
     }
 
     /** Monta resumo de job usando a etapa aberta mais recente ou, se não existir, a última etapa atualizada. */

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/candidategenerator/service/detailJob/CandidateGeneratorJobDetailResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/candidategenerator/service/detailJob/CandidateGeneratorJobDetailResponse.java
@@ -1,0 +1,15 @@
+package com.marketinghub.oprm.nichocnae.v2.candidategenerator.service.detailJob;
+
+import java.util.List;
+
+/** Detalha o histórico persistido de etapas de um job NichoCNAE v2. */
+public record CandidateGeneratorJobDetailResponse(
+        String jobId,
+        String cnaeCode,
+        String status,
+        String finalDecision,
+        String finalDecisionLabel,
+        String finalDecisionReason,
+        String outcomeStatus,
+        String outcomeMessage,
+        List<CandidateGeneratorJobStageStep> stages) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/candidategenerator/service/detailJob/CandidateGeneratorJobStageStep.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/candidategenerator/service/detailJob/CandidateGeneratorJobStageStep.java
@@ -1,0 +1,20 @@
+package com.marketinghub.oprm.nichocnae.v2.candidategenerator.service.detailJob;
+
+import java.time.Instant;
+
+/** Representa uma etapa executada dentro de um job NichoCNAE v2 para relatório administrativo. */
+public record CandidateGeneratorJobStageStep(
+        String stageExecutionId,
+        String stageCode,
+        String status,
+        String failureType,
+        Integer attemptNumber,
+        Integer technicalRetryNumber,
+        Integer knowledgeVersion,
+        Boolean materializationEnabled,
+        String inputPayload,
+        String outputPayload,
+        String errorMessage,
+        String nextStageCode,
+        Instant createdAt,
+        Instant updatedAt) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/oprm/nichocnae/v2/OprmNichoCnaeV2StageExecutionRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/oprm/nichocnae/v2/OprmNichoCnaeV2StageExecutionRepository.java
@@ -25,6 +25,9 @@ public interface OprmNichoCnaeV2StageExecutionRepository extends JpaRepository<O
     /** Conta execuções por CNAE e estados informados para impedir dois jobs simultâneos no mesmo mercado. */
     long countByCnaeCodeAndStatusIn(String cnaeCode, List<OprmNichoCnaeV2StageExecutionStatus> statuses);
 
+    /** Lista as etapas de um job em ordem cronológica para relatório de falha ou sucesso. */
+    List<OprmNichoCnaeV2StageExecution> findByJobIdOrderByCreatedAtAsc(String jobId);
+
     /** Localiza uma execução específica por etapa para callbacks internos do executor. */
     Optional<OprmNichoCnaeV2StageExecution> findByIdAndStageCode(Long id, String stageCode);
 }

--- a/backend/ads-service/src/test/java/com/marketinghub/oprm/nichocnae/v2/candidategenerator/service/BackendCandidateGeneratorServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/oprm/nichocnae/v2/candidategenerator/service/BackendCandidateGeneratorServiceTest.java
@@ -171,6 +171,39 @@ class BackendCandidateGeneratorServiceTest {
         assertThat(result.completedJobs().getFirst().aiCostUsd()).isEqualByComparingTo(new BigDecimal("0.015"));
     }
 
+    /** Deve detalhar cronologicamente as etapas do job para relatório de fracasso. */
+    @Test
+    void detailJobReturnsStageTimelineForFailureReport() {
+        BackendCandidateGeneratorService service = service(true, false);
+        OprmNichoCnaeV2StageExecution first = execution(201L, 1, 0, 1);
+        first.setJobId("job-fracasso");
+        first.setCnaeCode("4781400");
+        first.setStageCode("candidate-generator");
+        first.setStatus(OprmNichoCnaeV2StageExecutionStatus.COMPLETED);
+        first.setOutputPayload("{\"candidateCount\":4}");
+        first.setNextStageCode("candidate-tournament");
+        first.setUpdatedAt(Instant.parse("2026-06-21T10:00:00Z"));
+        OprmNichoCnaeV2StageExecution last = execution(202L, 1, 0, 1);
+        last.setJobId("job-fracasso");
+        last.setCnaeCode("4781400");
+        last.setStageCode("candidate-tournament");
+        last.setStatus(OprmNichoCnaeV2StageExecutionStatus.COMPLETED);
+        last.setOutputPayload(
+                "{\"tournamentDecision\":\"NO_VIABLE_SUBNICHE\",\"candidateCount\":4,\"finalistCount\":0}");
+        last.setUpdatedAt(Instant.parse("2026-06-21T10:05:00Z"));
+        when(stageExecutionRepository.findByJobIdOrderByCreatedAtAsc("job-fracasso")).thenReturn(List.of(first, last));
+
+        var result = service.detailJob("job-fracasso");
+
+        assertThat(result.jobId()).isEqualTo("job-fracasso");
+        assertThat(result.outcomeStatus()).isEqualTo("FAILURE");
+        assertThat(result.finalDecision()).isEqualTo("NO_VIABLE_SUBNICHE");
+        assertThat(result.stages()).hasSize(2);
+        assertThat(result.stages().getFirst().stageCode()).isEqualTo("candidate-generator");
+        assertThat(result.stages().getFirst().outputPayload()).contains("candidateCount");
+        assertThat(result.stages().get(1).stageCode()).isEqualTo("candidate-tournament");
+    }
+
     /** Deve manter a decisão real do torneio quando o reprocessamento encerra o job sem ganho de informação. */
     @Test
     void listJobsForCnaeExplainsNoViableSubnicheAfterReprocessControllerEnd() {

--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -1236,3 +1236,9 @@
 - Nova regra operacional: o backend passa a bloquear a criação manual de outro job NichoCNAE v2 quando o mesmo CNAE já possui execução aberta (`PENDING`, `RUNNING` ou `TECHNICAL_RETRY_SCHEDULED`).
 - Limpeza: criado changelog para encerrar como falha operacional os jobs presos do CNAE `4781400` anteriores a `2026-06-21 00:00:00`, liberando a tela para uma nova execução controlada.
 - Causa-raiz tratada: a criação manual só contava execuções por candidato/etapa e não verificava jobs abertos por CNAE, permitindo dois jobs simultâneos para o mesmo mercado.
+
+## 2026-06-21 — Relatório de fracasso do job NichoCNAE v2
+
+- Adicionada tela de detalhe do job a partir dos casos de fracasso da tabela do pipeline v2, mostrando cada etapa persistida, entrada resumida, saída resumida, falha registrada e próxima etapa.
+- O backend expõe o histórico cronológico por `jobId`, mantendo a tela fiel ao dado persistido e sem inferir localmente o caminho do pipeline.
+- Causa-raiz tratada: a tabela indicava fracasso, mas não oferecia rastreabilidade operacional suficiente para o usuário entender até onde o job avançou antes de decidir novo recorte ou correção.

--- a/docs/swagger/oprm-nichocnae-v2-candidate-generator-swagger.yaml
+++ b/docs/swagger/oprm-nichocnae-v2-candidate-generator-swagger.yaml
@@ -59,6 +59,25 @@ paths:
                     type: array
                     items:
                       $ref: "#/components/schemas/CandidateGeneratorCnaeJobSummary"
+  /api/internal/oprm/nichocnae/v2/candidate-generator/stage-executions/jobs/{jobId}:
+    get:
+      summary: Detalha as etapas persistidas de um job v2
+      description: Contrato de leitura para a tela administrativa mostrar cada etapa executada até o ponto de fracasso ou sucesso.
+      parameters:
+        - name: jobId
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Histórico cronológico das etapas do job informado.
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/CandidateGeneratorJobDetailResponse"
+        "404":
+          description: Job não encontrado.
   /api/internal/oprm/nichocnae/v2/candidate-generator/stage-executions/pending:
     get:
       summary: Lista execuções pendentes da etapa candidate-generator v2
@@ -178,3 +197,85 @@ components:
           type: string
           format: date-time
           nullable: true
+
+    CandidateGeneratorJobDetailResponse:
+      type: object
+      required:
+        - jobId
+        - cnaeCode
+        - status
+        - stages
+      properties:
+        jobId:
+          type: string
+        cnaeCode:
+          type: string
+        status:
+          type: string
+        finalDecision:
+          type: string
+          nullable: true
+        finalDecisionLabel:
+          type: string
+          nullable: true
+        finalDecisionReason:
+          type: string
+          nullable: true
+        outcomeStatus:
+          type: string
+          nullable: true
+        outcomeMessage:
+          type: string
+          nullable: true
+        stages:
+          type: array
+          items:
+            $ref: "#/components/schemas/CandidateGeneratorJobStageStep"
+    CandidateGeneratorJobStageStep:
+      type: object
+      required:
+        - stageExecutionId
+        - stageCode
+        - status
+        - createdAt
+        - updatedAt
+      properties:
+        stageExecutionId:
+          type: string
+        stageCode:
+          type: string
+        status:
+          type: string
+        failureType:
+          type: string
+          nullable: true
+        attemptNumber:
+          type: integer
+          nullable: true
+        technicalRetryNumber:
+          type: integer
+          nullable: true
+        knowledgeVersion:
+          type: integer
+          nullable: true
+        materializationEnabled:
+          type: boolean
+          nullable: true
+        inputPayload:
+          type: string
+          nullable: true
+        outputPayload:
+          type: string
+          nullable: true
+        errorMessage:
+          type: string
+          nullable: true
+        nextStageCode:
+          type: string
+          nullable: true
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -114,6 +114,7 @@ import OprmCnaeVolumePage from "./pages/oprm/OprmCnaeVolumePage";
 import OprmCnaeDetailPlaceholderPage from "./pages/oprm/OprmCnaeDetailPlaceholderPage";
 import OprmCnaePipelineStageDetailPage from "./pages/oprm/OprmCnaePipelineStageDetailPage";
 import OprmNichoCnaeV2PipelinePage from "./pages/oprm/OprmNichoCnaeV2PipelinePage";
+import OprmNichoCnaeV2JobDetailPage from "./pages/oprm/OprmNichoCnaeV2JobDetailPage";
 import OprmEnrichedNicheDetailPage from "./pages/oprm/OprmEnrichedNicheDetailPage";
 import OprmGeneralAudiencesPage from "./pages/oprm/OprmGeneralAudiencesPage";
 import OprmJobsPage from "./pages/oprm/OprmJobsPage";
@@ -337,6 +338,10 @@ export default function App() {
               <Route
                 path="/oprm/cnaes/:cnaeCode/pipeline-v2"
                 element={<OprmNichoCnaeV2PipelinePage />}
+              />
+              <Route
+                path="/oprm/cnaes/:cnaeCode/pipeline-v2/jobs/:jobId"
+                element={<OprmNichoCnaeV2JobDetailPage />}
               />
               <Route path="/mois" element={<MoisWorkspacePage />} />
               <Route

--- a/frontend/src/api/oprm/useOprmNichoCnaeV2JobDetail.ts
+++ b/frontend/src/api/oprm/useOprmNichoCnaeV2JobDetail.ts
@@ -1,0 +1,55 @@
+import { useQuery } from "@tanstack/react-query";
+import { buildApiUrl } from "../../utils/buildApiUrl";
+
+export interface OprmNichoCnaeV2JobStageStep {
+  stageExecutionId: string;
+  stageCode: string;
+  status: string;
+  failureType: string | null;
+  attemptNumber: number | null;
+  technicalRetryNumber: number | null;
+  knowledgeVersion: number | null;
+  materializationEnabled: boolean | null;
+  inputPayload: string | null;
+  outputPayload: string | null;
+  errorMessage: string | null;
+  nextStageCode: string | null;
+  createdAt: string | null;
+  updatedAt: string | null;
+}
+
+export interface OprmNichoCnaeV2JobDetailResponse {
+  jobId: string;
+  cnaeCode: string;
+  status: string;
+  finalDecision: string | null;
+  finalDecisionLabel: string | null;
+  finalDecisionReason: string | null;
+  outcomeStatus: "SUCCESS" | "FAILURE" | "IN_PROGRESS" | string | null;
+  outcomeMessage: string | null;
+  stages: OprmNichoCnaeV2JobStageStep[];
+}
+
+async function fetchOprmNichoCnaeV2JobDetail(
+  jobId: string,
+): Promise<OprmNichoCnaeV2JobDetailResponse> {
+  const response = await fetch(
+    buildApiUrl(
+      `/api/internal/oprm/nichocnae/v2/candidate-generator/stage-executions/jobs/${encodeURIComponent(jobId)}`,
+    ),
+  );
+  if (!response.ok) {
+    throw new Error(
+      `Não foi possível carregar o detalhe do job v2 (status ${response.status}).`,
+    );
+  }
+  return (await response.json()) as OprmNichoCnaeV2JobDetailResponse;
+}
+
+export function useOprmNichoCnaeV2JobDetail(jobId: string | undefined) {
+  return useQuery({
+    queryKey: ["oprm", "nichocnae", "v2", "job-detail", jobId],
+    queryFn: () => fetchOprmNichoCnaeV2JobDetail(jobId ?? ""),
+    enabled: Boolean(jobId),
+  });
+}

--- a/frontend/src/pages/oprm/OprmNichoCnaeV2JobDetailPage.tsx
+++ b/frontend/src/pages/oprm/OprmNichoCnaeV2JobDetailPage.tsx
@@ -1,0 +1,183 @@
+import { Link, useParams } from "react-router-dom";
+import { useOprmNichoCnaeV2JobDetail } from "../../api/oprm/useOprmNichoCnaeV2JobDetail";
+import PageTitle from "../../components/PageTitle";
+import OprmModuleNavigation from "./OprmModuleNavigation";
+import { formatStage } from "./OprmNichoCnaeV2PipelinePage";
+
+function formatDateTime(value: string | null | undefined) {
+  if (!value) return "—";
+  return new Intl.DateTimeFormat("pt-BR", {
+    dateStyle: "short",
+    timeStyle: "short",
+  }).format(new Date(value));
+}
+
+function statusBadgeClass(status: string) {
+  if (status === "COMPLETED") return "badge text-bg-success";
+  if (status === "FAILED") return "badge text-bg-danger";
+  if (status === "TECHNICAL_RETRY_SCHEDULED") return "badge text-bg-warning";
+  if (status === "RUNNING") return "badge text-bg-primary";
+  return "badge text-bg-secondary";
+}
+
+function summarizePayload(payload: string | null | undefined) {
+  if (!payload) return "Sem payload registrado.";
+  try {
+    const parsed = JSON.parse(payload) as Record<string, unknown>;
+    const keys = Object.keys(parsed).slice(0, 6);
+    if (keys.length === 0) return "Payload vazio.";
+    return `Dados registrados: ${keys.join(", ")}${Object.keys(parsed).length > keys.length ? "..." : ""}.`;
+  } catch {
+    return payload.length > 180 ? `${payload.slice(0, 180)}...` : payload;
+  }
+}
+
+export default function OprmNichoCnaeV2JobDetailPage() {
+  const { cnaeCode, jobId } = useParams();
+  const decodedCnaeCode = cnaeCode ? decodeURIComponent(cnaeCode) : undefined;
+  const decodedJobId = jobId ? decodeURIComponent(jobId) : undefined;
+  const jobQuery = useOprmNichoCnaeV2JobDetail(decodedJobId);
+
+  return (
+    <div className="d-flex flex-column gap-4">
+      <header className="d-flex flex-column gap-2">
+        <div className="d-flex flex-wrap justify-content-between align-items-start gap-3">
+          <div>
+            <PageTitle>Relatório do job NichoCNAE v2</PageTitle>
+            <p className="text-secondary mb-0">
+              Mostra cada etapa persistida pelo backend e o que aconteceu até o
+              ponto de fracasso ou conclusão.
+            </p>
+          </div>
+          <Link
+            className="btn btn-outline-secondary"
+            to={
+              decodedCnaeCode
+                ? `/oprm/cnaes/${encodeURIComponent(decodedCnaeCode)}/pipeline-v2`
+                : "/oprm"
+            }
+          >
+            Voltar para jobs
+          </Link>
+        </div>
+      </header>
+
+      <OprmModuleNavigation />
+
+      {jobQuery.isLoading ? (
+        <div className="card border-0 shadow-sm">
+          <div className="card-body text-secondary">
+            Carregando relatório...
+          </div>
+        </div>
+      ) : jobQuery.isError ? (
+        <div className="alert alert-danger" role="alert">
+          {jobQuery.error.message}
+        </div>
+      ) : jobQuery.data ? (
+        <>
+          <section className="card border-0 shadow-sm">
+            <div className="card-body">
+              <div className="d-flex flex-wrap justify-content-between gap-3">
+                <div>
+                  <span className="text-secondary small text-uppercase fw-semibold">
+                    CNAE {jobQuery.data.cnaeCode}
+                  </span>
+                  <h2 className="h5 mb-1">{jobQuery.data.jobId}</h2>
+                  <p className="mb-0">
+                    {jobQuery.data.outcomeMessage ??
+                      jobQuery.data.finalDecisionReason ??
+                      "Job sem mensagem final registrada."}
+                  </p>
+                </div>
+                <span
+                  className={
+                    jobQuery.data.outcomeStatus === "FAILURE"
+                      ? "badge text-bg-danger align-self-start"
+                      : jobQuery.data.outcomeStatus === "SUCCESS"
+                        ? "badge text-bg-success align-self-start"
+                        : "badge text-bg-warning align-self-start"
+                  }
+                >
+                  {jobQuery.data.finalDecisionLabel ??
+                    jobQuery.data.outcomeStatus ??
+                    jobQuery.data.status}
+                </span>
+              </div>
+            </div>
+          </section>
+
+          <section
+            className="d-flex flex-column gap-3"
+            aria-label="Etapas executadas do job"
+          >
+            {jobQuery.data.stages.map((stage, index) => (
+              <article
+                className="card border-0 shadow-sm"
+                key={stage.stageExecutionId}
+              >
+                <div className="card-body">
+                  <div className="d-flex flex-wrap justify-content-between gap-3 mb-3">
+                    <div>
+                      <span className="badge text-bg-light border mb-2">
+                        Etapa {index + 1}
+                      </span>
+                      <h3 className="h5 mb-1">
+                        {formatStage(stage.stageCode)}
+                      </h3>
+                      <p className="text-secondary small mb-0">
+                        Execução {stage.stageExecutionId} · tentativa{" "}
+                        {stage.attemptNumber ?? "—"}
+                        {stage.technicalRetryNumber
+                          ? ` · retry ${stage.technicalRetryNumber}`
+                          : ""}
+                      </p>
+                    </div>
+                    <span className={statusBadgeClass(stage.status)}>
+                      {stage.status}
+                    </span>
+                  </div>
+
+                  <dl className="row small mb-0 g-2">
+                    <dt className="col-md-3 text-secondary fw-normal">
+                      O que entrou
+                    </dt>
+                    <dd className="col-md-9 mb-0">
+                      {summarizePayload(stage.inputPayload)}
+                    </dd>
+                    <dt className="col-md-3 text-secondary fw-normal">
+                      O que foi feito
+                    </dt>
+                    <dd className="col-md-9 mb-0">
+                      {summarizePayload(stage.outputPayload)}
+                    </dd>
+                    <dt className="col-md-3 text-secondary fw-normal">
+                      Falha registrada
+                    </dt>
+                    <dd className="col-md-9 mb-0">
+                      {stage.errorMessage ??
+                        stage.failureType ??
+                        "Sem falha registrada nesta etapa."}
+                    </dd>
+                    <dt className="col-md-3 text-secondary fw-normal">
+                      Próxima etapa
+                    </dt>
+                    <dd className="col-md-9 mb-0">
+                      {formatStage(stage.nextStageCode)}
+                    </dd>
+                    <dt className="col-md-3 text-secondary fw-normal">
+                      Atualizado
+                    </dt>
+                    <dd className="col-md-9 mb-0">
+                      {formatDateTime(stage.updatedAt)}
+                    </dd>
+                  </dl>
+                </div>
+              </article>
+            ))}
+          </section>
+        </>
+      ) : null}
+    </div>
+  );
+}

--- a/frontend/src/pages/oprm/OprmNichoCnaeV2PipelinePage.tsx
+++ b/frontend/src/pages/oprm/OprmNichoCnaeV2PipelinePage.tsx
@@ -183,9 +183,20 @@ function JobsTable({
                 </td>
                 <td>
                   <div className="d-flex flex-column align-items-start gap-1">
-                    <span className="oprm-v2-job-table__text" title={nextAction}>
+                    <span
+                      className="oprm-v2-job-table__text"
+                      title={nextAction}
+                    >
                       {nextAction}
                     </span>
+                    {!open && job.outcomeStatus === "FAILURE" ? (
+                      <Link
+                        className="btn btn-sm btn-outline-danger py-0 px-2"
+                        to={`/oprm/cnaes/${encodeURIComponent(job.cnaeCode)}/pipeline-v2/jobs/${encodeURIComponent(job.jobId)}`}
+                      >
+                        Ver etapas até o fracasso
+                      </Link>
+                    ) : null}
                     {!open && job.actionLabel && job.actionUrl ? (
                       <Link
                         className="btn btn-sm btn-primary py-0 px-2"


### PR DESCRIPTION
### Motivation
- Facilitar a investigação quando um job v2 fracassa, mostrando até onde o pipeline avançou sem exigir logs externos ou inferência local. 
- Tornar a UI fiel ao dado persistido pelo backend para que o operador possa ver entrada, saída e falha por etapa antes de decidir próximo passo.

### Description
- Backend: adiciona `findByJobIdOrderByCreatedAtAsc` no `OprmNichoCnaeV2StageExecutionRepository`, cria os `record`s `CandidateGeneratorJobDetailResponse` e `CandidateGeneratorJobStageStep`, e implementa `detailJob(jobId)` no `BackendCandidateGeneratorService` com conversor `toJobStageStep` e endpoint HTTP `GET /api/internal/oprm/nichocnae/v2/candidate-generator/stage-executions/jobs/{jobId}` no `BackendCandidateGeneratorController`.
- Frontend: adiciona hook `useOprmNichoCnaeV2JobDetail`, nova página `OprmNichoCnaeV2JobDetailPage`, rota `/oprm/cnaes/:cnaeCode/pipeline-v2/jobs/:jobId` em `App.tsx` e CTA `Ver etapas até o fracasso` na tabela de jobs concluídos do `OprmNichoCnaeV2PipelinePage` que leva à nova tela.
- API / docs: atualiza `docs/swagger/oprm-nichocnae-v2-candidate-generator-swagger.yaml` para incluir o novo contrato de leitura e registra a mudança em `docs/registros/oprm1.md`.
- Tests: adiciona teste unitário `detailJobReturnsStageTimelineForFailureReport` em `BackendCandidateGeneratorServiceTest` que cobre a resposta cronológica do job.

### Testing
- Executado `cd frontend && npm run typecheck` e o typecheck retornou com sucesso.
- Executado `cd backend/ads-service && ../mvnw -Dtest=BackendCandidateGeneratorServiceTest test` e os testes do `BackendCandidateGeneratorServiceTest` passaram (`12 tests, 0 failures`).
- Formatação Spotless não pôde ser executada via `../mvnw spotless:apply` no ambiente por ausência do prefixo/plugin; isso foi sinalizado como aviso manual no rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a385089500c8321b817ec6c4f0ee24b)