### PR TITLE
Add GPT Image 2 to image generation catalog

### DIFF
--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2030-09-18-add-gpt-image-2.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2030-09-18-add-gpt-image-2.yaml
@@ -1,0 +1,149 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2030-09-18-add-gpt-image-2
+      author: ai-hub
+      preConditions:
+        - onFail: MARK_RAN
+        - onError: MARK_RAN
+        - dbms:
+            type: mysql
+      changes:
+        - sql:
+            dbms: mysql
+            splitStatements: true
+            stripComments: true
+            sql: |
+              INSERT INTO image_generation_model (code, display_name, provider, api_model, description)
+              SELECT 'gpt-image-2', 'GPT Image 2', 'OPENAI', 'gpt-image-2',
+                     'Modelo GPT Image 2 para geração de imagens em materiais de marketing.'
+              WHERE NOT EXISTS (
+                  SELECT 1 FROM image_generation_model WHERE code = 'gpt-image-2'
+              );
+        - sql:
+            dbms: mysql
+            splitStatements: true
+            stripComments: true
+            sql: |
+              INSERT INTO image_generation_quality (model_id, code, display_name, api_quality, is_default, position)
+              SELECT m.id, 'low', 'Low', 'standard', 0, 10
+              FROM image_generation_model m
+              WHERE m.code = 'gpt-image-2'
+              ON DUPLICATE KEY UPDATE
+                  display_name = VALUES(display_name),
+                  api_quality = VALUES(api_quality),
+                  is_default = VALUES(is_default),
+                  position = VALUES(position);
+
+              INSERT INTO image_generation_quality (model_id, code, display_name, api_quality, is_default, position)
+              SELECT m.id, 'medium', 'Medium', 'standard', 1, 20
+              FROM image_generation_model m
+              WHERE m.code = 'gpt-image-2'
+              ON DUPLICATE KEY UPDATE
+                  display_name = VALUES(display_name),
+                  api_quality = VALUES(api_quality),
+                  is_default = VALUES(is_default),
+                  position = VALUES(position);
+
+              INSERT INTO image_generation_quality (model_id, code, display_name, api_quality, is_default, position)
+              SELECT m.id, 'high', 'High', 'hd', 0, 30
+              FROM image_generation_model m
+              WHERE m.code = 'gpt-image-2'
+              ON DUPLICATE KEY UPDATE
+                  display_name = VALUES(display_name),
+                  api_quality = VALUES(api_quality),
+                  is_default = VALUES(is_default),
+                  position = VALUES(position);
+        - sql:
+            dbms: mysql
+            splitStatements: true
+            stripComments: true
+            sql: |
+              INSERT INTO image_generation_price (quality_id, orientation, width, height, size_label, unit_price_usd, preferred)
+              SELECT q.id, 'SQUARE', 1024, 1024, '1024x1024', 0.01000, 1
+              FROM image_generation_quality q
+              JOIN image_generation_model m ON m.id = q.model_id
+              WHERE m.code = 'gpt-image-2' AND q.code = 'low'
+              ON DUPLICATE KEY UPDATE
+                  unit_price_usd = VALUES(unit_price_usd),
+                  size_label = VALUES(size_label),
+                  preferred = VALUES(preferred);
+
+              INSERT INTO image_generation_price (quality_id, orientation, width, height, size_label, unit_price_usd, preferred)
+              SELECT q.id, 'PORTRAIT', 1024, 1536, '1024x1536', 0.01500, 0
+              FROM image_generation_quality q
+              JOIN image_generation_model m ON m.id = q.model_id
+              WHERE m.code = 'gpt-image-2' AND q.code = 'low'
+              ON DUPLICATE KEY UPDATE
+                  unit_price_usd = VALUES(unit_price_usd),
+                  size_label = VALUES(size_label),
+                  preferred = VALUES(preferred);
+
+              INSERT INTO image_generation_price (quality_id, orientation, width, height, size_label, unit_price_usd, preferred)
+              SELECT q.id, 'LANDSCAPE', 1536, 1024, '1536x1024', 0.01500, 0
+              FROM image_generation_quality q
+              JOIN image_generation_model m ON m.id = q.model_id
+              WHERE m.code = 'gpt-image-2' AND q.code = 'low'
+              ON DUPLICATE KEY UPDATE
+                  unit_price_usd = VALUES(unit_price_usd),
+                  size_label = VALUES(size_label),
+                  preferred = VALUES(preferred);
+
+              INSERT INTO image_generation_price (quality_id, orientation, width, height, size_label, unit_price_usd, preferred)
+              SELECT q.id, 'SQUARE', 1024, 1024, '1024x1024', 0.04000, 1
+              FROM image_generation_quality q
+              JOIN image_generation_model m ON m.id = q.model_id
+              WHERE m.code = 'gpt-image-2' AND q.code = 'medium'
+              ON DUPLICATE KEY UPDATE
+                  unit_price_usd = VALUES(unit_price_usd),
+                  size_label = VALUES(size_label),
+                  preferred = VALUES(preferred);
+
+              INSERT INTO image_generation_price (quality_id, orientation, width, height, size_label, unit_price_usd, preferred)
+              SELECT q.id, 'PORTRAIT', 1024, 1536, '1024x1536', 0.06000, 0
+              FROM image_generation_quality q
+              JOIN image_generation_model m ON m.id = q.model_id
+              WHERE m.code = 'gpt-image-2' AND q.code = 'medium'
+              ON DUPLICATE KEY UPDATE
+                  unit_price_usd = VALUES(unit_price_usd),
+                  size_label = VALUES(size_label),
+                  preferred = VALUES(preferred);
+
+              INSERT INTO image_generation_price (quality_id, orientation, width, height, size_label, unit_price_usd, preferred)
+              SELECT q.id, 'LANDSCAPE', 1536, 1024, '1536x1024', 0.06000, 0
+              FROM image_generation_quality q
+              JOIN image_generation_model m ON m.id = q.model_id
+              WHERE m.code = 'gpt-image-2' AND q.code = 'medium'
+              ON DUPLICATE KEY UPDATE
+                  unit_price_usd = VALUES(unit_price_usd),
+                  size_label = VALUES(size_label),
+                  preferred = VALUES(preferred);
+
+              INSERT INTO image_generation_price (quality_id, orientation, width, height, size_label, unit_price_usd, preferred)
+              SELECT q.id, 'SQUARE', 1024, 1024, '1024x1024', 0.17000, 1
+              FROM image_generation_quality q
+              JOIN image_generation_model m ON m.id = q.model_id
+              WHERE m.code = 'gpt-image-2' AND q.code = 'high'
+              ON DUPLICATE KEY UPDATE
+                  unit_price_usd = VALUES(unit_price_usd),
+                  size_label = VALUES(size_label),
+                  preferred = VALUES(preferred);
+
+              INSERT INTO image_generation_price (quality_id, orientation, width, height, size_label, unit_price_usd, preferred)
+              SELECT q.id, 'PORTRAIT', 1024, 1536, '1024x1536', 0.25500, 0
+              FROM image_generation_quality q
+              JOIN image_generation_model m ON m.id = q.model_id
+              WHERE m.code = 'gpt-image-2' AND q.code = 'high'
+              ON DUPLICATE KEY UPDATE
+                  unit_price_usd = VALUES(unit_price_usd),
+                  size_label = VALUES(size_label),
+                  preferred = VALUES(preferred);
+
+              INSERT INTO image_generation_price (quality_id, orientation, width, height, size_label, unit_price_usd, preferred)
+              SELECT q.id, 'LANDSCAPE', 1536, 1024, '1536x1024', 0.25500, 0
+              FROM image_generation_quality q
+              JOIN image_generation_model m ON m.id = q.model_id
+              WHERE m.code = 'gpt-image-2' AND q.code = 'high'
+              ON DUPLICATE KEY UPDATE
+                  unit_price_usd = VALUES(unit_price_usd),
+                  size_label = VALUES(size_label),
+                  preferred = VALUES(preferred);

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -916,6 +916,9 @@ databaseChangeLog:
       file: changesets/2030-09-17-add-gpt-image-1-5.yaml
       relativeToChangelogFile: true
   - include:
+      file: changesets/2030-09-18-add-gpt-image-2.yaml
+      relativeToChangelogFile: true
+  - include:
       file: V2036_11_20__experiment_creative_prompts.yaml
       relativeToChangelogFile: true
   - include:

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -5013,3 +5013,8 @@
 - Causa-raiz: o ajuste anterior passou a normalizar campos textuais opcionais para evitar nulos no `promptData`, porém não incluiu o método auxiliar nas duas etapas.
 - Correção aplicada: adicionado o helper local nas etapas Image Planning e Design Preset, preservando o isolamento por etapa do core OpenAI.
 - Prevenção de recorrência: compilação do backend foi instalada localmente e o AI Worker foi compilado antes do PR; testes do AI Worker também foram executados.
+
+## 2026-06-21 — Modelo GPT Image 2 na criação de experimento
+- Solicitação: incluir a opção GPT Image 2 na lista de modelo de geração de imagem da tela de novo experimento.
+- Correção aplicada: criado changelog incremental para cadastrar o modelo `gpt-image-2`, suas qualidades e preços base no catálogo consumido pelo endpoint `/api/image-generation/models`.
+- Prevenção de recorrência: o changelog foi incluído no master com `relativeToChangelogFile: true`, mantendo a lista da tela orientada pela verdade persistida no backend.


### PR DESCRIPTION
### Motivation
- Expose a new image generation option "GPT Image 2" so the experiment/new-experiment UI can offer it as a selectable model backed by the canonical backend catalog. 
- Persist the model, its qualities and base pricing in the database catalog so `/api/image-generation/models` returns the authoritative list.

### Description
- Added a Liquibase changeset `backend/ads-service/src/main/resources/db/changelog/changesets/2030-09-18-add-gpt-image-2.yaml` that inserts the `gpt-image-2` model, `low/medium/high` qualities and pricing rows for supported orientations using idempotent `INSERT ... SELECT ... WHERE NOT EXISTS` and `ON DUPLICATE KEY UPDATE` patterns. 
- Included the new changeset in the master changelog at `backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml` with `relativeToChangelogFile: true`. 
- Recorded the operation in the project log `docs/registros/experimentos.md` documenting the request and the mitigation to keep frontend truth aligned to backend data.

### Testing
- Ran a custom include validation script that scans `db.changelog-master.yaml` to ensure every `changesets/...` `file:` line is followed by `relativeToChangelogFile: true`, and it passed (`All changesets includes are relativeToChangelogFile=true`).
- Compiled the backend module with `cd backend/ads-service && ../mvnw -q -DskipTests compile`, which completed successfully in this environment. 
- Ran `git diff --check` which reported no issues. 
- Attempted to validate YAML parsing via `python3` + `yaml.safe_load(...)` but that step failed because the Python `yaml` module (PyYAML) is not installed in the environment; this is an environment limitation, not a changelog syntax change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3852955f94832186e9a454e663c4e5)