### PR TITLE
Reveal full JSON/text payloads in OPRM NichoCNAE v2 job detail

### DIFF
--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -1242,3 +1242,4 @@
 - Adicionada tela de detalhe do job a partir dos casos de fracasso da tabela do pipeline v2, mostrando cada etapa persistida, entrada resumida, saída resumida, falha registrada e próxima etapa.
 - O backend expõe o histórico cronológico por `jobId`, mantendo a tela fiel ao dado persistido e sem inferir localmente o caminho do pipeline.
 - Causa-raiz tratada: a tabela indicava fracasso, mas não oferecia rastreabilidade operacional suficiente para o usuário entender até onde o job avançou antes de decidir novo recorte ou correção.
+- 2026-06-21 21:30:33 (UTC): ajustada a tela de detalhe do job OPRM NichoCNAE v2 para revelar o conteúdo completo dos payloads de entrada e saída em JSON/texto por etapa, mantendo resumo inicial e expandindo sob demanda para facilitar diagnóstico de decisões do pipeline.

--- a/frontend/src/pages/oprm/OprmNichoCnaeV2JobDetailPage.test.tsx
+++ b/frontend/src/pages/oprm/OprmNichoCnaeV2JobDetailPage.test.tsx
@@ -1,0 +1,95 @@
+import { cleanup, render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import { MemoryRouter, Route, Routes } from "react-router-dom";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import OprmNichoCnaeV2JobDetailPage from "./OprmNichoCnaeV2JobDetailPage";
+
+function renderPage() {
+  const client = new QueryClient({
+    defaultOptions: {
+      queries: {
+        retry: false,
+      },
+    },
+  });
+
+  return render(
+    <QueryClientProvider client={client}>
+      <MemoryRouter
+        initialEntries={["/oprm/cnaes/4781400/pipeline-v2/jobs/job-9"]}
+      >
+        <Routes>
+          <Route
+            path="/oprm/cnaes/:cnaeCode/pipeline-v2/jobs/:jobId"
+            element={<OprmNichoCnaeV2JobDetailPage />}
+          />
+        </Routes>
+      </MemoryRouter>
+    </QueryClientProvider>,
+  );
+}
+
+describe("OprmNichoCnaeV2JobDetailPage", () => {
+  afterEach(() => {
+    cleanup();
+    vi.restoreAllMocks();
+  });
+
+  it("exibe o conteúdo completo dos payloads JSON sob demanda", async () => {
+    vi.stubGlobal(
+      "fetch",
+      vi.fn(
+        async () =>
+          new Response(
+            JSON.stringify({
+              jobId: "job-9",
+              cnaeCode: "4781400",
+              status: "FAILED",
+              finalDecision: "NO_VIABLE_SUBNICHE",
+              finalDecisionLabel: "Encerrado sem subnicho viável",
+              finalDecisionReason: "Sem finalistas viáveis.",
+              outcomeStatus: "FAILURE",
+              outcomeMessage: "O torneio terminou sem finalistas viáveis.",
+              stages: [
+                {
+                  stageExecutionId: "150",
+                  stageCode: "candidate-generator",
+                  status: "COMPLETED",
+                  failureType: null,
+                  attemptNumber: 1,
+                  technicalRetryNumber: null,
+                  knowledgeVersion: null,
+                  materializationEnabled: null,
+                  inputPayload: JSON.stringify({ cnaeCode: "4781400" }),
+                  outputPayload: JSON.stringify({
+                    candidates: [{ name: "ajustes de roupa plus size" }],
+                    candidateCount: 1,
+                  }),
+                  errorMessage: null,
+                  nextStageCode: "source-safety-filter",
+                  createdAt: "2026-06-21T17:50:00Z",
+                  updatedAt: "2026-06-21T17:50:00Z",
+                },
+              ],
+            }),
+            { status: 200, headers: { "Content-Type": "application/json" } },
+          ),
+      ),
+    );
+
+    renderPage();
+
+    expect(
+      await screen.findByText(/JSON registrado com campos: cnaeCode/),
+    ).toBeInTheDocument();
+    await userEvent.click(
+      screen.getByText(/campos: candidates, candidateCount/),
+    );
+
+    expect(
+      screen.getByText(/"name": "ajustes de roupa plus size"/),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/"candidateCount": 1/)).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/oprm/OprmNichoCnaeV2JobDetailPage.tsx
+++ b/frontend/src/pages/oprm/OprmNichoCnaeV2JobDetailPage.tsx
@@ -20,16 +20,60 @@ function statusBadgeClass(status: string) {
   return "badge text-bg-secondary";
 }
 
+function parsePayload(payload: string | null | undefined) {
+  if (!payload) return null;
+  try {
+    return JSON.parse(payload) as unknown;
+  } catch {
+    return null;
+  }
+}
+
+function formatPayload(payload: string | null | undefined) {
+  const parsed = parsePayload(payload);
+  if (parsed === null) return payload ?? "";
+  return JSON.stringify(parsed, null, 2);
+}
+
 function summarizePayload(payload: string | null | undefined) {
   if (!payload) return "Sem payload registrado.";
-  try {
-    const parsed = JSON.parse(payload) as Record<string, unknown>;
+  const parsed = parsePayload(payload);
+  if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
     const keys = Object.keys(parsed).slice(0, 6);
-    if (keys.length === 0) return "Payload vazio.";
-    return `Dados registrados: ${keys.join(", ")}${Object.keys(parsed).length > keys.length ? "..." : ""}.`;
-  } catch {
-    return payload.length > 180 ? `${payload.slice(0, 180)}...` : payload;
+    if (keys.length === 0) return "Payload JSON vazio.";
+    return `JSON registrado com campos: ${keys.join(", ")}${Object.keys(parsed).length > keys.length ? "..." : ""}.`;
   }
+  if (Array.isArray(parsed))
+    return `JSON registrado com ${parsed.length} item(ns).`;
+  return "Conteúdo registrado em texto.";
+}
+
+function PayloadViewer({
+  label,
+  payload,
+}: {
+  label: string;
+  payload: string | null | undefined;
+}) {
+  if (!payload) return <span>Sem payload registrado.</span>;
+
+  const parsed = parsePayload(payload);
+  const contentType = parsed === null ? "texto" : "JSON";
+
+  return (
+    <details className="border rounded bg-light-subtle p-2">
+      <summary className="fw-semibold">
+        {summarizePayload(payload)} Clique para ver o conteúdo {contentType} de{" "}
+        {label}.
+      </summary>
+      <pre
+        className="mt-2 mb-0 small bg-white border rounded p-3 overflow-auto"
+        style={{ maxHeight: "26rem", whiteSpace: "pre-wrap" }}
+      >
+        {formatPayload(payload)}
+      </pre>
+    </details>
+  );
 }
 
 export default function OprmNichoCnaeV2JobDetailPage() {
@@ -143,13 +187,19 @@ export default function OprmNichoCnaeV2JobDetailPage() {
                       O que entrou
                     </dt>
                     <dd className="col-md-9 mb-0">
-                      {summarizePayload(stage.inputPayload)}
+                      <PayloadViewer
+                        label="entrada"
+                        payload={stage.inputPayload}
+                      />
                     </dd>
                     <dt className="col-md-3 text-secondary fw-normal">
                       O que foi feito
                     </dt>
                     <dd className="col-md-9 mb-0">
-                      {summarizePayload(stage.outputPayload)}
+                      <PayloadViewer
+                        label="saída"
+                        payload={stage.outputPayload}
+                      />
                     </dd>
                     <dt className="col-md-3 text-secondary fw-normal">
                       Falha registrada


### PR DESCRIPTION
### Motivation
- Improve diagnosability of failed NichoCNAE v2 jobs by showing the actual payload content sent/returned per stage instead of only a brief field list.
- Keep the UI compact with a summary view and allow operators to expand the payload when they need full context to investigate pipeline decisions.
- Register the UI change in the OPRM operational history to preserve traceability of the improvement.

### Description
- Added `parsePayload`, `formatPayload` and a `PayloadViewer` UI block to `frontend/src/pages/oprm/OprmNichoCnaeV2JobDetailPage.tsx` to detect JSON vs text and render full content inside an expandable `<details>` with a formatted `pre` view.
- Replaced the previous inline `summarizePayload` usage for `inputPayload` and `outputPayload` with the new `PayloadViewer` and improved `summarizePayload` logic to explicitly handle object, array and plain-text payloads.
- Added a regression test `frontend/src/pages/oprm/OprmNichoCnaeV2JobDetailPage.test.tsx` that stubs the job API and asserts the summary and expanded JSON content are shown on demand.
- Recorded the change in `docs/registros/oprm1.md` describing the UI adjustment for job detail payload visibility.

### Testing
- Ran the focused unit test: `npm test -- --run src/pages/oprm/OprmNichoCnaeV2JobDetailPage.test.tsx`, which passed.
- Ran the TypeScript check: `npm run typecheck` (which runs `tsc --noEmit`), which passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3857ad081c832188e7f54707df45f7)