### PR TITLE
Use READY creatives as canonical approval for experiment readiness and sync legacy flags

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentReadinessService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentReadinessService.java
@@ -134,12 +134,12 @@ public class ExperimentReadinessService {
                 experiment.getHypothesisRef() != null ? experiment.getHypothesisRef().getId() : null).isEmpty();
     }
 
+    /** Verifica a aprovação real dos criativos pela fonte canônica: registros READY. */
     private boolean hasApprovedCreative(Experiment experiment) {
         if (experiment == null || experiment.getId() == null) {
             return false;
         }
-        return experiment.isCreativeApproved()
-                && creativeRepository.existsByExperimentIdAndStatus(experiment.getId(), CreativeStatus.READY);
+        return creativeRepository.existsByExperimentIdAndStatus(experiment.getId(), CreativeStatus.READY);
     }
 
     private boolean hasReadyLeadPortalFlow(Experiment experiment) {

--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-21-sync-experiment-creative-approved.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-21-sync-experiment-creative-approved.yaml
@@ -1,0 +1,35 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-06-21-sync-experiment-creative-approved
+      author: marketinghub
+      preConditions:
+        - onFail: MARK_RAN
+        - onError: HALT
+        - dbms:
+            type: mysql
+        - tableExists:
+            tableName: experiment
+        - tableExists:
+            tableName: creative
+      changes:
+        - sql:
+            splitStatements: true
+            stripComments: true
+            sql: |
+              UPDATE experiment e
+              LEFT JOIN (
+                SELECT experiment_id, COUNT(*) AS ready_count
+                FROM creative
+                WHERE status = 'READY'
+                GROUP BY experiment_id
+              ) ready_creatives ON ready_creatives.experiment_id = e.id
+              SET e.creative_approved = CASE
+                WHEN COALESCE(ready_creatives.ready_count, 0) > 0 THEN TRUE
+                ELSE FALSE
+              END;
+      rollback:
+        - sql:
+            splitStatements: true
+            stripComments: true
+            sql: |
+              SELECT 1;

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -1057,3 +1057,6 @@ databaseChangeLog:
   - include:
       file: changesets/2026-06-21-oprm-nichocnae-v2-clear-stale-open-jobs.yaml
       relativeToChangelogFile: true
+  - include:
+      file: changesets/2026-06-21-sync-experiment-creative-approved.yaml
+      relativeToChangelogFile: true

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/service/ExperimentReadinessServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/service/ExperimentReadinessServiceTest.java
@@ -67,6 +67,7 @@ class ExperimentReadinessServiceTest {
     void shouldReturnNoIssuesWhenEverythingIsReady() {
         Long experimentId = 8L;
         Experiment experiment = buildExperiment(experimentId, 18L);
+        experiment.setCreativeApproved(false);
         LeadPortalFlow flow = new LeadPortalFlow();
         flow.setApproved(true);
         experiment.setLeadPortalFlow(flow);
@@ -81,6 +82,19 @@ class ExperimentReadinessServiceTest {
         assertThat(summary.hasCompleteTargeting()).isTrue();
         assertThat(summary.missingTargetingTypes()).isEmpty();
         assertThat(summary.issues()).isEmpty();
+    }
+
+    @Test
+    void shouldUseReadyCreativeAsApprovalSourceEvenWhenExperimentFlagIsStale() {
+        Long experimentId = 22L;
+        Experiment experiment = buildExperiment(experimentId, 32L);
+        experiment.setCreativeApproved(false);
+        experiment.setFollowUpActionUrl("https://example.com/landing/22");
+
+        when(creativeRepository.existsByExperimentIdAndStatus(experimentId, CreativeStatus.READY)).thenReturn(true);
+
+        assertThat(service.computeMissingConfiguration(experiment)).isEmpty();
+        assertThat(service.isReadyForCampaign(experiment)).isTrue();
     }
 
     @Test

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -4958,6 +4958,13 @@
 - Contexto comercial: o backend passou a incluir descrição rica ativa do nicho e o snapshot completo do pipeline de hipótese no prompt persistido para o worker.
 - Prevenção: a saída da OpenAI agora é validada por schema JSON estrito, reduzindo retorno fora do contrato esperado pela tela.
 
+## 2026-06-21 — Unificação da aprovação de criativos para prontidão de campanha
+
+- Problema: o experimento 42 possuía criativos `READY`, mas continuava bloqueado porque o campo consolidado `experiment.creative_approved` estava falso.
+- Causa-raiz: a prontidão de publicação exigia duas fontes para a mesma decisão, o flag do experimento e a existência de criativo `READY`, permitindo divergência entre caminhos de aprovação.
+- Correção aplicada: a prontidão de campanha passa a usar como fonte canônica a existência de criativo `READY`; um changelog incremental sincroniza `experiment.creative_approved` com os criativos existentes para corrigir dados legados.
+- Prevenção de recorrência: teste unitário cobre o caso de flag legado desatualizado com criativo `READY`, garantindo que a campanha não fique bloqueada por estado duplicado.
+
 ## 2026-06-21 — Contrato de promessa única sem campos manuais
 
 - Solicitação: retirar da tela de novo experimento os campos editáveis de dor, recompensa, promessa e CTA, porque o contrato deve vir da opção gerada pela IA.


### PR DESCRIPTION
### Motivation
- Prevent experiments from being blocked when there are `READY` creatives but the consolidated `experiment.creative_approved` flag is stale.
- Simplify readiness logic to rely on the canonical source of truth (creative records) instead of duplicated flags.
- Provide a data migration to reconcile legacy `experiment.creative_approved` values with existing `READY` creatives.

### Description
- Change readiness logic in `ExperimentReadinessService` to consider creative approval by checking `creativeRepository.existsByExperimentIdAndStatus(..., CreativeStatus.READY)` and remove dependence on `experiment.isCreativeApproved()`.
- Add a Liquibase changeset `changesets/2026-06-21-sync-experiment-creative-approved.yaml` and include it in `db.changelog-master.yaml` to synchronize `experiment.creative_approved` from existing `creative` rows (setting it true when READY creatives exist).
- Update `ExperimentReadinessServiceTest` to cover the case where the experiment flag is stale and a `READY` creative should be treated as approval, and adjust an existing test to reflect the new canonical check.
- Add a documentation entry in `docs/registros/experimentos.md` describing the rationale, migration and prevention measures.

### Testing
- Ran unit tests for `ExperimentReadinessServiceTest` which include the new test `shouldUseReadyCreativeAsApprovalSourceEvenWhenExperimentFlagIsStale`, and they passed.
- Executed project unit test suite targeting the ads-service module via the standard test task, and all tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a38585e14bc8321b4f20d4b5bc2367d)