### PR TITLE
feat(frontend): expandable JSON payload viewer in OPRM job detail

### DIFF
--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -1243,3 +1243,9 @@
 - O backend expõe o histórico cronológico por `jobId`, mantendo a tela fiel ao dado persistido e sem inferir localmente o caminho do pipeline.
 - Causa-raiz tratada: a tabela indicava fracasso, mas não oferecia rastreabilidade operacional suficiente para o usuário entender até onde o job avançou antes de decidir novo recorte ou correção.
 - 2026-06-21 21:30:33 (UTC): ajustada a tela de detalhe do job OPRM NichoCNAE v2 para revelar o conteúdo completo dos payloads de entrada e saída em JSON/texto por etapa, mantendo resumo inicial e expandindo sob demanda para facilitar diagnóstico de decisões do pipeline.
+
+## 2026-06-22 — JSON expansível no detalhe do job NichoCNAE v2
+
+- Ajustada a tela de detalhe do job OPRM NichoCNAE v2 para apresentar payloads JSON como árvore expansível por clique, permitindo abrir objetos e arrays internos conforme a investigação avança.
+- Causa-raiz tratada: o JSON completo era exibido como texto único rolável, dificultando a análise de payloads grandes e a navegação por candidatos, evidências e campos internos.
+- Prevenção de recorrência: teste de frontend cobre a abertura progressiva do JSON interno até campos aninhados.

--- a/frontend/src/pages/oprm/OprmNichoCnaeV2JobDetailPage.test.tsx
+++ b/frontend/src/pages/oprm/OprmNichoCnaeV2JobDetailPage.test.tsx
@@ -86,10 +86,22 @@ describe("OprmNichoCnaeV2JobDetailPage", () => {
     await userEvent.click(
       screen.getByText(/campos: candidates, candidateCount/),
     );
+    expect(screen.getByText("objeto com 2 campo(s)")).toBeInTheDocument();
 
+    await userEvent.click(screen.getByText("objeto com 2 campo(s)"));
     expect(
-      screen.getByText(/"name": "ajustes de roupa plus size"/),
+      screen.getByText("candidates: array com 1 item(ns)"),
     ).toBeInTheDocument();
-    expect(screen.getByText(/"candidateCount": 1/)).toBeInTheDocument();
+
+    await userEvent.click(screen.getByText("candidates: array com 1 item(ns)"));
+    expect(screen.getByText("0: objeto com 1 campo(s)")).toBeInTheDocument();
+
+    await userEvent.click(screen.getByText("0: objeto com 1 campo(s)"));
+    expect(screen.getByText("name:")).toBeInTheDocument();
+    expect(
+      screen.getByText('"ajustes de roupa plus size"'),
+    ).toBeInTheDocument();
+    expect(screen.getByText("candidateCount:")).toBeInTheDocument();
+    expect(screen.getByText("1")).toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/oprm/OprmNichoCnaeV2JobDetailPage.tsx
+++ b/frontend/src/pages/oprm/OprmNichoCnaeV2JobDetailPage.tsx
@@ -29,12 +29,6 @@ function parsePayload(payload: string | null | undefined) {
   }
 }
 
-function formatPayload(payload: string | null | undefined) {
-  const parsed = parsePayload(payload);
-  if (parsed === null) return payload ?? "";
-  return JSON.stringify(parsed, null, 2);
-}
-
 function summarizePayload(payload: string | null | undefined) {
   if (!payload) return "Sem payload registrado.";
   const parsed = parsePayload(payload);
@@ -46,6 +40,58 @@ function summarizePayload(payload: string | null | undefined) {
   if (Array.isArray(parsed))
     return `JSON registrado com ${parsed.length} item(ns).`;
   return "Conteúdo registrado em texto.";
+}
+
+function JsonValueViewer({
+  name,
+  value,
+  level = 0,
+}: {
+  name?: string;
+  value: unknown;
+  level?: number;
+}) {
+  const isArray = Array.isArray(value);
+  const isObject = value !== null && typeof value === "object" && !isArray;
+
+  if (!isArray && !isObject) {
+    return (
+      <div className="font-monospace small">
+        {name ? <span className="text-primary">{name}: </span> : null}
+        <span>{JSON.stringify(value)}</span>
+      </div>
+    );
+  }
+
+  const entries = isArray
+    ? value.map((item, index) => [String(index), item] as const)
+    : Object.entries(value as Record<string, unknown>);
+  const summary = isArray
+    ? `${name ? `${name}: ` : ""}array com ${entries.length} item(ns)`
+    : `${name ? `${name}: ` : ""}objeto com ${entries.length} campo(s)`;
+
+  return (
+    <details
+      className="font-monospace small"
+      style={{ marginLeft: level ? "1rem" : 0 }}
+    >
+      <summary className="json-tree-summary">{summary}</summary>
+      <div className="border-start ps-2 ms-1 mt-1 d-flex flex-column gap-1">
+        {entries.length === 0 ? (
+          <span className="text-secondary">Sem campos internos.</span>
+        ) : (
+          entries.map(([entryName, entryValue]) => (
+            <JsonValueViewer
+              key={entryName}
+              name={entryName}
+              value={entryValue}
+              level={level + 1}
+            />
+          ))
+        )}
+      </div>
+    </details>
+  );
 }
 
 function PayloadViewer({
@@ -66,12 +112,16 @@ function PayloadViewer({
         {summarizePayload(payload)} Clique para ver o conteúdo {contentType} de{" "}
         {label}.
       </summary>
-      <pre
-        className="mt-2 mb-0 small bg-white border rounded p-3 overflow-auto"
+      <div
+        className="mt-2 mb-0 bg-white border rounded p-3 overflow-auto"
         style={{ maxHeight: "26rem", whiteSpace: "pre-wrap" }}
       >
-        {formatPayload(payload)}
-      </pre>
+        {parsed === null ? (
+          <pre className="mb-0 small">{payload}</pre>
+        ) : (
+          <JsonValueViewer value={parsed} />
+        )}
+      </div>
     </details>
   );
 }


### PR DESCRIPTION
### Motivation

- Facilitar a investigação de payloads grandes no detalhe do job NichoCNAE v2 permitindo explorar progressivamente o JSON interno por clique. 
- Manter o comportamento atual de resumo inicial e fallback para payloads não-JSON para evitar regressões na interface.

### Description

- Adiciona o componente recursivo `JsonValueViewer` em `frontend/src/pages/oprm/OprmNichoCnaeV2JobDetailPage.tsx` para renderizar objetos e arrays como árvore expansível por `details/summary`.
- Substitui a exibição de JSON formatado por um visualizador de árvore enquanto preserva o resumo inicial (`summarizePayload`) e o fallback em texto puro para conteúdo não-JSON, removendo a função `formatPayload` redundante.
- Atualiza o teste em `frontend/src/pages/oprm/OprmNichoCnaeV2JobDetailPage.test.tsx` para cobrir a abertura progressiva da árvore JSON até campos aninhados.
- Registra a alteração em `docs/registros/oprm1.md` com causa-raiz e prevenção de recorrência.

### Testing

- Executado `npm run test -- OprmNichoCnaeV2JobDetailPage.test.tsx --run` e o teste do arquivo passou (1 passed). 
- Executado `npm run typecheck` (`tsc --noEmit`) e a verificação de tipos completou sem erros. 
- Código formatado com `npx prettier --write` e não foram encontrados problemas de formatação/cheks no diff.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a39163c24588321a45a91722db2bcc7)