### PR TITLE
Exibe formato vendido no dossiê MOIS

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryDtos.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryDtos.java
@@ -244,6 +244,7 @@ public final class MoisSalesLibraryDtos {
             String hotmartPrice,
             BigDecimal hotmartTemperature,
             String hotmartProducer,
+            String soldProductFormat,
             String currentStage,
             String currentStatus,
             String captureStatus,

--- a/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryService.java
@@ -627,7 +627,7 @@ public class MoisSalesLibraryService {
         List<MoisSalesLibraryDtos.SalesLibraryPageResponse> items = jdbcTemplate.query("""
                 SELECT p.id, p.workspace_id, p.source, p.url_canonical, p.title, p.current_stage, p.current_status, p.capture_status,
                        COALESCE(p.analysis_status, p.current_status) AS analysis_status, p.url_final, p.http_status, p.html_sha256,
-                       p.html_bytes, p.score_total, p.product_name, COALESCE(cr_direct.producer_name, cr_url.producer_name) AS producer_name, COALESCE(cr_direct.hotmart_price, cr_url.hotmart_price) AS hotmart_price, COALESCE(cr_direct.hotmart_temperature, cr_url.hotmart_temperature) AS hotmart_temperature, COALESCE(cr_direct.hotmart_producer, cr_url.hotmart_producer) AS hotmart_producer,
+                       p.html_bytes, p.score_total, p.product_name, COALESCE(cr_direct.producer_name, cr_url.producer_name) AS producer_name, COALESCE(cr_direct.hotmart_price, cr_url.hotmart_price) AS hotmart_price, COALESCE(cr_direct.hotmart_temperature, cr_url.hotmart_temperature) AS hotmart_temperature, COALESCE(cr_direct.hotmart_producer, cr_url.hotmart_producer) AS hotmart_producer, COALESCE(cr_direct.hotmart_description, cr_url.hotmart_description) AS hotmart_description,
                        p.offer_summary, p.mechanism_summary, p.promise_summary, p.proof_summary,
                        p.model_name, p.input_tokens, p.output_tokens, p.model_cost_usd,
                        p.last_error_category, p.last_error_message, p.last_job_execution_id, p.last_captured_at, p.last_analyzed_at, p.updated_at,
@@ -798,7 +798,7 @@ public class MoisSalesLibraryService {
         List<MoisSalesLibraryDtos.SalesLibraryPageResponse> rows = jdbcTemplate.query("""
                 SELECT p.id, p.workspace_id, p.source, p.url_canonical, p.title, p.current_stage, p.current_status, p.capture_status,
                        COALESCE(p.analysis_status, p.current_status) AS analysis_status, p.url_final, p.http_status, p.html_sha256,
-                       p.html_bytes, p.score_total, p.product_name, COALESCE(cr_direct.producer_name, cr_url.producer_name) AS producer_name, COALESCE(cr_direct.hotmart_price, cr_url.hotmart_price) AS hotmart_price, COALESCE(cr_direct.hotmart_temperature, cr_url.hotmart_temperature) AS hotmart_temperature, COALESCE(cr_direct.hotmart_producer, cr_url.hotmart_producer) AS hotmart_producer,
+                       p.html_bytes, p.score_total, p.product_name, COALESCE(cr_direct.producer_name, cr_url.producer_name) AS producer_name, COALESCE(cr_direct.hotmart_price, cr_url.hotmart_price) AS hotmart_price, COALESCE(cr_direct.hotmart_temperature, cr_url.hotmart_temperature) AS hotmart_temperature, COALESCE(cr_direct.hotmart_producer, cr_url.hotmart_producer) AS hotmart_producer, COALESCE(cr_direct.hotmart_description, cr_url.hotmart_description) AS hotmart_description,
                        p.offer_summary, p.mechanism_summary, p.promise_summary, p.proof_summary,
                        p.model_name, p.input_tokens, p.output_tokens, p.model_cost_usd,
                        p.last_error_category, p.last_error_message, p.last_job_execution_id, p.last_captured_at, p.last_analyzed_at, p.updated_at,
@@ -1468,6 +1468,13 @@ public class MoisSalesLibraryService {
                 rs.getString("hotmart_price"),
                 rs.getBigDecimal("hotmart_temperature"),
                 rs.getString("hotmart_producer"),
+                classifySoldProductFormat(
+                        rs.getString("title"),
+                        rs.getString("product_name"),
+                        rs.getString("hotmart_description"),
+                        rs.getString("offer_summary"),
+                        rs.getString("promise_summary")
+                ),
                 rs.getString("current_stage"),
                 rs.getString("current_status"),
                 rs.getString("capture_status"),
@@ -1498,6 +1505,58 @@ public class MoisSalesLibraryService {
                 mapEnum(MoisSalesLibraryDtos.MarketWarmupJobStatus.class, rs.getString("market_warmup_status")),
                 toInstant(rs, "market_warmup_updated_at")
         );
+    }
+
+    /**
+     * Classifica o formato vendido usando apenas textos persistidos da página e da referência Hotmart.
+     */
+    private String classifySoldProductFormat(
+            String title,
+            String productName,
+            String hotmartDescription,
+            String offerSummary,
+            String promiseSummary
+    ) {
+        String text = String.join(
+                " ",
+                title == null ? "" : title,
+                productName == null ? "" : productName,
+                hotmartDescription == null ? "" : hotmartDescription,
+                offerSummary == null ? "" : offerSummary,
+                promiseSummary == null ? "" : promiseSummary
+        ).toLowerCase(Locale.ROOT);
+        if (text.isBlank()) {
+            return null;
+        }
+        if (text.contains("consultoria")
+                || text.contains("mentoria")
+                || text.contains("sessão individual")
+                || text.contains("sessao individual")) {
+            return "Consultoria / mentoria";
+        }
+        if (text.contains("ebook")
+                || text.contains("e-book")
+                || text.contains("livro digital")
+                || text.contains("pdf")) {
+            return "E-book / material em PDF";
+        }
+        if (text.contains("curso")
+                || text.contains("aula")
+                || text.contains("videoaula")
+                || text.contains("vídeo aula")
+                || text.contains("video aula")) {
+            return "Curso em vídeo";
+        }
+        if (text.contains("comunidade") || text.contains("assinatura") || text.contains("membros")) {
+            return "Comunidade / assinatura";
+        }
+        if (text.contains("software")
+                || text.contains("sistema")
+                || text.contains("ferramenta")
+                || text.contains("app")) {
+            return "Software / ferramenta";
+        }
+        return "Formato não identificado";
     }
 
 

--- a/backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryServiceTest.java
@@ -537,7 +537,7 @@ class MoisSalesLibraryServiceTest {
         lenient().when(jdbcTemplate.query(contains("WHERE workspace_id = ? AND url_canonical = ?"), isA(RowMapper.class), any(), any()))
                 .thenReturn(List.of(99L));
         lenient().when(jdbcTemplate.query(contains("SELECT p.id, p.workspace_id, p.source"), isA(RowMapper.class), any()))
-                .thenReturn(List.of(new MoisSalesLibraryDtos.SalesLibraryPageResponse(99L, "10", "HOTMART", "https://example.com/pagina", "Title", "Produto Teste", "Produtor Teste", "R$ 5.997,00", BigDecimal.valueOf(150), "Abrantes Lima Empreendimentos LTDA",
+                .thenReturn(List.of(new MoisSalesLibraryDtos.SalesLibraryPageResponse(99L, "10", "HOTMART", "https://example.com/pagina", "Title", "Produto Teste", "Produtor Teste", "R$ 5.997,00", BigDecimal.valueOf(150), "Abrantes Lima Empreendimentos LTDA", "Curso em vídeo",
                         "ANALYSIS", "PENDING", null, "PENDING", null, null, null, 0L, BigDecimal.ZERO, null, null, null, null, null, null, null, null, null, null, null, Instant.now(), null, null, null, null, null, null, null, null)));
         lenient().when(jdbcTemplate.update(contains("INSERT INTO mois_sales_page_job_execution"), any(), any(), any())).thenReturn(1);
         lenient().when(jdbcTemplate.queryForObject(contains("SELECT LAST_INSERT_ID()"), eq(Long.class))).thenReturn(123L);

--- a/docs/registros/mois1.md
+++ b/docs/registros/mois1.md
@@ -1760,3 +1760,8 @@ Arquivos principais:
 - Corrigida a falta de confirmação visual após o comando **Voltar para pendente** na rota `/mois/sales-pages-library/:pageId`.
 - A tela agora exibe um bloco explícito de **Status atual da solicitação**, com status geral, captura e análise comercial vindos do backend, além da confirmação retornada pelo endpoint de atualização manual.
 - Ajustada a invalidação do cache do detalhe da página para recarregar a verdade atualizada do backend depois da mudança de status.
+
+## 2026-06-22 — Formato vendido no dossiê da Biblioteca Sales Pages
+
+- Incluído no contrato do backend o campo de formato vendido do produto, classificado a partir dos textos persistidos da página/Hotmart para diferenciar curso em vídeo, e-book/PDF, consultoria/mentoria, comunidade/assinatura ou software/ferramenta.
+- Atualizada a tela de detalhe `/mois/sales-pages-library/:pageId` para exibir o card **O que está sendo vendido** no dossiê do produto, mantendo a regra de verdade da tela: o frontend apenas apresenta o dado retornado pelo backend.

--- a/frontend/src/api/mois/types.ts
+++ b/frontend/src/api/mois/types.ts
@@ -265,6 +265,7 @@ export interface MoisSalesLibraryPage {
   hotmartPrice?: string;
   hotmartTemperature?: number | null;
   hotmartProducer?: string;
+  soldProductFormat?: string;
   currentStage?: string;
   currentStatus?: string;
   captureStatus?: string;

--- a/frontend/src/pages/mois/MoisSalesPageLibraryDetailPage.tsx
+++ b/frontend/src/pages/mois/MoisSalesPageLibraryDetailPage.tsx
@@ -169,6 +169,7 @@ export default function MoisSalesPageLibraryDetailPage() {
   const hotmartProducer =
     cleanText(pageQuery.data?.hotmartProducer) ||
     cleanText(pageQuery.data?.producerName);
+  const soldProductFormat = cleanText(pageQuery.data?.soldProductFormat);
 
   const producerSocialSources = (marketWarmupSourcesQuery.data?.items ?? [])
     .filter(
@@ -398,13 +399,13 @@ export default function MoisSalesPageLibraryDetailPage() {
           </div>
 
           <div className="row g-3">
-            <div className="col-md-4">
+            <div className="col-md-3">
               <div className="border rounded p-3 h-100 bg-light-subtle">
                 <div className="text-secondary small">Preço Hotmart</div>
                 <strong className="fs-5">{displayText(hotmartPrice)}</strong>
               </div>
             </div>
-            <div className="col-md-4">
+            <div className="col-md-3">
               <div className="border rounded p-3 h-100 bg-light-subtle">
                 <div className="text-secondary small">Temperatura Hotmart</div>
                 <strong className="fs-5">
@@ -415,19 +416,36 @@ export default function MoisSalesPageLibraryDetailPage() {
                 </div>
               </div>
             </div>
-            <div className="col-md-4">
+            <div className="col-md-3">
               <div className="border rounded p-3 h-100 bg-light-subtle">
                 <div className="text-secondary small">Produtor Hotmart</div>
                 <strong className="fs-5">{displayText(hotmartProducer)}</strong>
               </div>
             </div>
+            <div className="col-md-3">
+              <div className="border rounded p-3 h-100 bg-light-subtle">
+                <div className="text-secondary small">
+                  O que está sendo vendido
+                </div>
+                <strong className="fs-5">
+                  {displayText(soldProductFormat)}
+                </strong>
+                <div className="small text-secondary">
+                  Formato identificado pelo backend
+                </div>
+              </div>
+            </div>
           </div>
 
-          {!hotmartPrice || hotmartTemperature == null || !hotmartProducer ? (
+          {!hotmartPrice ||
+          hotmartTemperature == null ||
+          !hotmartProducer ||
+          !soldProductFormat ? (
             <div className="alert alert-warning mb-0">
               O banco ainda não possui todos os fatos básicos do dossiê. O
               próximo passo é corrigir a coleta para preencher preço,
-              temperatura e produtor diretamente da página de venda.
+              temperatura, produtor e formato vendido diretamente da página de
+              venda.
             </div>
           ) : null}
         </div>


### PR DESCRIPTION
### Motivation
- Tornar explícito no dossiê do produto qual o formato comercial vendido (curso em vídeo, e-book, consultoria, etc.) para que a UI mostre a verdade do backend sem inferência local.

### Description
- Adiciona o campo de contrato `soldProductFormat` em `MoisSalesLibraryDtos.SalesLibraryPageResponse` e passa a selecionar `hotmart_description` na query para compor evidência textual no backend (`backend/ads-service/src/main/java/.../MoisSalesLibraryDtos.java`, `MoisSalesLibraryService.java`).
- Implementa `classifySoldProductFormat(...)` no backend que classifica o formato a partir de títulos, nome do produto, descrição Hotmart e sumários persistidos e inclui essa classificação em `mapSalesPageResponse` (SQL + mapeamento em `MoisSalesLibraryService.java`).
- Atualiza o contrato TypeScript para incluir `soldProductFormat` em `MoisSalesLibraryPage` e ajusta a tela de detalhe `/mois/sales-pages-library/:pageId` para mostrar o card "O que está sendo vendido" (frontend: `frontend/src/api/mois/types.ts`, `frontend/src/pages/mois/MoisSalesPageLibraryDetailPage.tsx`).
- Registra a mudança no histórico MOIS em `docs/registros/mois1.md` e faz pequenos ajustes de layout (colunas reduzidas para acomodar o novo card).

### Testing
- Executado `cd backend/ads-service && mvn -q -Dtest=MoisSalesLibraryServiceTest test` e o teste de serviço associado foi executado com sucesso (unit tests relacionados ao mapeamento atualizados para refletir o novo campo).
- Executado `npm install` e `cd frontend && npm run typecheck` e a checagem de tipos TypeScript passou sem erros após instalação das dependências.
- Executado `git diff --check` sem problemas encontrados; verificação `spotless:check` não pôde ser executada porque o plugin Spotless não está disponível no ambiente (`mvn spotless:check` falha no CI local).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3917176fd08321bae49b000caafcb1)