### PR TITLE
Add STANDBY experiment status and standby-on-first-form-submission flow

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/ExperimentStatus.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/ExperimentStatus.java
@@ -1,12 +1,13 @@
 package com.marketinghub.experiment;
 
 /**
- * Current status of an experiment.
+ * Estados operacionais de um experimento comercial.
  */
 public enum ExperimentStatus {
     PLANNED,
     RUNNING,
     PAUSED,
+    STANDBY,
     USER_STOPPED,
     VALIDATED,
     INVALIDATED,

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/funnel/ExperimentFunnelAutoStopService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/funnel/ExperimentFunnelAutoStopService.java
@@ -178,6 +178,28 @@ public class ExperimentFunnelAutoStopService {
     }
 
     /**
+     * Coloca o experimento em standby no primeiro envio válido e solicita pausa das campanhas Meta vinculadas.
+     *
+     * @return {@code true} quando o standby foi aplicado, {@code false} caso o experimento não esteja elegível.
+     */
+    public boolean standbyOnFirstValidFormSubmission(Experiment experiment) {
+        if (experiment == null || experiment.getStatus() != ExperimentStatus.RUNNING) {
+            return false;
+        }
+        LOGGER.info(
+                "Standby triggered for experiment {} after first valid form submission.",
+                experiment.getId()
+        );
+        experiment.setStatus(ExperimentStatus.STANDBY);
+        requestFacebookCampaignStops(
+                experiment.getId(),
+                FacebookCampaignStopReason.FIRST_FORM_SUBMISSION_STANDBY,
+                "primeiro envio válido de formulário no regime inicial de validação"
+        );
+        return true;
+    }
+
+    /**
      * Confirma se a checagem estatística representa falha na regra dos 3%.
      */
     private boolean isThreePercentFailure(FunnelThresholdCheckDto check) {

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/funnel/ExperimentFunnelService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/funnel/ExperimentFunnelService.java
@@ -54,6 +54,7 @@ public class ExperimentFunnelService {
     private final ExperimentLandingAnalyticsEventRepository landingAnalyticsEventRepository;
     private final LeadRepository leadRepository;
     private final JdbcTemplate jdbcTemplate;
+    private final ExperimentFunnelAutoStopService autoStopService;
 
     static final String FLOW_SCOPE_CONDITION = """
             (
@@ -305,7 +306,7 @@ public class ExperimentFunnelService {
     }
 
     /**
-     * Registra de forma idempotente o envio do formulário recebido pelo Lead Portal.
+     * Registra de forma idempotente o envio do formulário recebido pelo Lead Portal e aciona standby no primeiro envio válido.
      */
     @Transactional
     public boolean registerFormSubmission(String flowSlug, RegisterLeadPortalSubmissionRequest request) {
@@ -338,6 +339,7 @@ public class ExperimentFunnelService {
                 .occurredAt(occurredAt)
                 .build();
         eventRepository.save(event);
+        autoStopService.standbyOnFirstValidFormSubmission(experiment);
         return true;
     }
 

--- a/backend/ads-service/src/main/java/com/marketinghub/facebookads/FacebookCampaignStopReason.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/facebookads/FacebookCampaignStopReason.java
@@ -4,6 +4,7 @@ package com.marketinghub.facebookads;
  * Motivos que disparam uma solicitação automática de pausa para uma campanha Facebook.
  */
 public enum FacebookCampaignStopReason {
+    FIRST_FORM_SUBMISSION_STANDBY,
     FORM_ZERO_CONVERSION_RULE_OF_THREE,
     LOW_IMPRESSIONS_AFTER_RUNNING_TIME,
     TARGET_AUDIENCE_LOW_INTEREST_STATISTICAL

--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-22-experiment-standby-status.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-22-experiment-standby-status.yaml
@@ -1,0 +1,41 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-06-22-experiment-standby-status
+      author: assistant
+      preConditions:
+        - onFail: MARK_RAN
+        - dbms:
+            type: mysql
+        - sqlCheck:
+            expectedResult: "1"
+            sql: |
+              SELECT CASE
+                       WHEN EXISTS (
+                         SELECT 1
+                         FROM information_schema.columns
+                         WHERE table_schema = DATABASE()
+                           AND table_name = 'experiment'
+                           AND column_name = 'status'
+                           AND data_type = 'enum'
+                           AND column_type NOT LIKE '%''STANDBY''%'
+                       ) THEN 1
+                       ELSE 0
+                     END;
+      changes:
+        - sql:
+            splitStatements: true
+            stripComments: true
+            sql: |
+              ALTER TABLE experiment
+                MODIFY COLUMN status ENUM(
+                  'PLANNED',
+                  'RUNNING',
+                  'PAUSED',
+                  'STANDBY',
+                  'VALIDATED',
+                  'INVALIDATED',
+                  'INCONCLUSIVE',
+                  'FINISHED',
+                  'FAILED',
+                  'USER_STOPPED'
+                ) NULL;

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -1,5 +1,8 @@
 databaseChangeLog:
   - include:
+      file: changesets/2026-06-22-experiment-standby-status.yaml
+      relativeToChangelogFile: true
+  - include:
       file: changesets/2026-06-21-experiment-promise-generation-cost.yaml
       relativeToChangelogFile: true
   - include:

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/funnel/ExperimentFunnelAutoStopServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/funnel/ExperimentFunnelAutoStopServiceTest.java
@@ -118,6 +118,37 @@ class ExperimentFunnelAutoStopServiceTest {
         assertThat(experiment.getStatus()).isEqualTo(ExperimentStatus.RUNNING);
     }
 
+    /**
+     * Garante standby e pausa da campanha no primeiro envio válido do formulário.
+     */
+    @Test
+    void putsRunningExperimentInStandbyAfterFirstValidFormSubmission() {
+        FacebookAdsCampaign campaign = new FacebookAdsCampaign();
+        campaign.setId("camp-first-submission");
+        when(campaignRepository.findByExperimentId(99L)).thenReturn(List.of(campaign));
+
+        boolean stopped = service.standbyOnFirstValidFormSubmission(experiment);
+
+        assertThat(stopped).isTrue();
+        assertThat(experiment.getStatus()).isEqualTo(ExperimentStatus.STANDBY);
+        assertThat(campaign.getStopReason()).isEqualTo(FacebookCampaignStopReason.FIRST_FORM_SUBMISSION_STANDBY);
+        assertThat(campaign.getStopRequestedAt()).isNotNull();
+        assertThat(campaign.getStopLastError()).isNull();
+    }
+
+    /**
+     * Garante que submissões duplicadas ou tardias não alterem experimento já pausado ou finalizado.
+     */
+    @Test
+    void doesNotStandbyExperimentWhenStatusIsNotRunning() {
+        experiment.setStatus(ExperimentStatus.STANDBY);
+
+        boolean stopped = service.standbyOnFirstValidFormSubmission(experiment);
+
+        assertThat(stopped).isFalse();
+        assertThat(experiment.getStatus()).isEqualTo(ExperimentStatus.STANDBY);
+    }
+
     @Test
     void stopsExperimentWhenThreePercentThresholdFails() {
         ExperimentFunnelStageDiagnosticDto stage = new ExperimentFunnelStageDiagnosticDto(

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/funnel/ExperimentFunnelServiceSubmissionTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/funnel/ExperimentFunnelServiceSubmissionTest.java
@@ -46,6 +46,9 @@ class ExperimentFunnelServiceSubmissionTest {
     @Mock
     private JdbcTemplate jdbcTemplate;
 
+    @Mock
+    private ExperimentFunnelAutoStopService autoStopService;
+
     @InjectMocks
     private ExperimentFunnelService service;
 
@@ -74,6 +77,7 @@ class ExperimentFunnelServiceSubmissionTest {
         assertEquals("submissionId=submission-123", saved.getPayload());
         assertEquals(submittedAt, saved.getOccurredAt());
         assertEquals("ad-xyz", saved.getCampaignCode());
+        verify(autoStopService).standbyOnFirstValidFormSubmission(experiment);
     }
 
     /**

--- a/docs/canonical/procedimento-experimento-canon.v1.md
+++ b/docs/canonical/procedimento-experimento-canon.v1.md
@@ -80,6 +80,18 @@ Regras obrigatórias:
 
 A interpretação do resultado do experimento deve partir dessa unidade: se não houver leads, a dor ou a promessa/isca de entrada devem ser revisadas; se houver leads baratos, mas sem avanço comercial, a oferta, prova ou qualificação devem ser melhoradas.
 
+### 4.1.3 Regra transitória — validação inicial por primeiro envio
+
+Enquanto o sistema ainda estiver na fase inicial sem volume recorrente de formulários enviados, o primeiro envio válido do formulário deve ser tratado como sinal comercial suficiente para colocar o experimento em `STANDBY` operacional e pausar imediatamente a exposição paga no Meta Ads. Essa regra não valida estatisticamente o produto nem autoriza escala; ela apenas evita gasto adicional enquanto o time confirma manualmente a qualidade do lead, a coerência da promessa, a entrega mínima prometida e a necessidade de gerar ou ajustar o produto de entrada.
+
+Regras obrigatórias:
+- o evento considerado deve ser um envio real e válido do formulário, com dados mínimos úteis e sem duplicidade operacional evidente;
+- ao detectar o primeiro envio válido, o backend deve registrar a decisão do experimento como `STANDBY` ou estado equivalente de pausa operacional auditável;
+- a campanha, conjunto de anúncios ou anúncio correspondente no Meta Ads deve ser desativado/pausado pelo fluxo oficial de integração, evitando novos gastos até decisão humana ou regra posterior de retomada;
+- o lead não pode ficar sem resposta: deve receber a entrega mínima prometida, uma comunicação de recebimento ou um encaminhamento claro compatível com a promessa feita na landing;
+- o status `STANDBY` por primeiro envio não substitui a validação estatística de 30+ envios qualificados, nem a regra de reprovação por 100 acessos sem envio;
+- a tela administrativa deve deixar claro que o experimento parou por sinal inicial, não por validação completa.
+
 ### 4.2 Prompts dessas etapas
 Os prompts do pipeline ficam versionados no repositório, em `resources` do Worker AI.
 

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -1,3 +1,14 @@
+## 2026-06-22 — Experimentos: implementação do standby no primeiro envio
+
+- foi feito: o backend passou a aplicar `STANDBY` no primeiro envio válido do formulário público de um experimento em execução.
+- foi feito: ao aplicar o standby, o backend registra solicitação de pausa das campanhas Meta vinculadas com motivo `FIRST_FORM_SUBMISSION_STANDBY`, consumível pelo Facebook Ads Worker pela fila existente de stop requests.
+- prevenção de recorrência: adicionados testes unitários cobrindo o registro de submissão pública, a transição para `STANDBY` e a solicitação de pausa da campanha.
+
+## 2026-06-22 — Experimentos: regra transitória de standby no primeiro envio
+
+- decisão registrada: enquanto o sistema ainda não possui volume recorrente de envios de formulário, o primeiro envio válido passa a colocar o experimento em `STANDBY` operacional e deve pausar/desativar a exposição paga no Meta Ads.
+- objetivo de negócio: evitar gasto adicional em mídia no momento inicial, preservar o lead recebido e permitir análise manual da qualidade do sinal antes de escalar ou construir o produto completo.
+- limite da regra: o primeiro envio é apenas sinal inicial; não substitui validação estatística posterior por volume de leads qualificados nem autoriza escala automática.
 ## 2026-06-20 — Experimentos: etapa 5 campanha Meta Leads sem cliques
 
 - solicitação: executar a etapa 5 da melhoria de experimentos, garantindo que a publicação Meta Ads use campanha de Leads para recompensa gratuita.


### PR DESCRIPTION
### Motivation
- Prevent additional ad spend when the first valid public form submission occurs by pausing exposure and allowing manual quality checks. 
- Make the backend and campaign stop reasons aware of a transient `STANDBY` operational state tied to an initial validation signal.

### Description
- Add `STANDBY` to `ExperimentStatus` and include a Liquibase changeset `2026-06-22-experiment-standby-status.yaml` to migrate the `experiment.status` enum in the database. 
- Introduce `FIRST_FORM_SUBMISSION_STANDBY` in `FacebookCampaignStopReason` to represent the stop reason for this flow. 
- Implement `standbyOnFirstValidFormSubmission(Experiment)` in `ExperimentFunnelAutoStopService` to set the experiment to `STANDBY` and request Facebook campaign stops, and call this from `ExperimentFunnelService.registerFormSubmission(...)`. 
- Wire `ExperimentFunnelAutoStopService` into `ExperimentFunnelService`, update unit tests, and add documentation describing the transient validation rule and operational behavior. 

### Testing
- Added and updated unit tests in `ExperimentFunnelAutoStopServiceTest` covering the standby transition and non-eligible statuses, and they passed. 
- Updated `ExperimentFunnelServiceSubmissionTest` to verify `registerFormSubmission` triggers `autoStopService.standbyOnFirstValidFormSubmission(...)`, and the test passed. 
- No automated DB migration tests were run here, but a Liquibase changeset was included to update the enum column for runtime deployment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3915c7db308321b70284f766ce3a95)