### PR TITLE
Criar ad sets e anúncios como ACTIVE mantendo campanha PAUSED

### DIFF
--- a/facebook-ads-worker/AGENTS.md
+++ b/facebook-ads-worker/AGENTS.md
@@ -45,6 +45,7 @@
   foi removido da publicação canônica e não deve ser reintroduzido.
 - Na criação de campanhas, não delegue materialização de targeting ao `ai-worker`; o `facebook-ads-worker` monta o targeting
   da Meta localmente a partir do playbook ou do pacote manual aprovado.
+- Na criação de campanhas, manter somente a campanha em `PAUSED`; os ad sets e anúncios devem nascer `ACTIVE` para ficarem prontos para veiculação assim que a campanha for ativada manualmente.
 - Campanhas de experimento devem registrar `budgetMode=ADSET`, enviar o orçamento diário apenas no ad set e criar a campanha sem orçamento próprio com `is_adset_budget_sharing_enabled=false`; orçamento de campanha fica reservado para etapa futura de escala de vencedores.
 - Em caso de erro de permissão do Facebook, o worker bloqueia o experimento em memória até que o serviço seja reiniciado.
 - Ao publicar instant forms aprove os rascunhos com `facebookFormId` nulo e reporte o identificador definitivo recebido da Meta

--- a/facebook-ads-worker/README.md
+++ b/facebook-ads-worker/README.md
@@ -125,8 +125,8 @@ O fluxo automatizado cria toda a hierarquia necessária para veiculação:
    `special_ad_categories = []`, conforme documentado na
    [Marketing API](https://developers.facebook.com/docs/marketing-api/reference/ad-campaign-group#Creating) para contas que
    não se enquadram em categorias especiais.
-2. **Conjunto de anúncios** (`POST /adsets`) atrelado à campanha, também em
-   `PAUSED`; quando o contrato exigir Leads, o worker força
+2. **Conjunto de anúncios** (`POST /adsets`) atrelado à campanha, criado em
+   `ACTIVE`; quando o contrato exigir Leads, o worker força
    `optimization_goal=LEAD_GENERATION` e nunca usa `LINK_CLICKS`. O destino
    continua `ON_AD` para Instant Form e pode permanecer `WEBSITE` para landing
    própria de captura. Antes de
@@ -206,8 +206,8 @@ O fluxo automatizado cria toda a hierarquia necessária para veiculação:
    `image_hash`, mantendo retentativas de criação até 3 tentativas totais antes
    de marcar a publicação como falha definitiva.
 6. **Anúncio** (`POST /ads`) que referencia o conjunto e o criativo recém
-   criados, mantido pausado até que o time operacional revise os detalhes no
-   Gerenciador de Anúncios.
+   criados, já em `ACTIVE`, deixando somente a campanha pausada para ativação
+   manual pelo time operacional no Gerenciador de Anúncios.
 
 As chamadas ao backend utilizam o prefixo `/api`. O worker consome
 `/api/facebook-campaigns/experiments-ready`, tratando respostas `404` como

--- a/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/FacebookAdsService.java
+++ b/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/FacebookAdsService.java
@@ -285,7 +285,7 @@ public class FacebookAdsService {
         body.put("daily_budget", request.dailyBudget());
         body.put("billing_event", request.billingEvent());
         body.put("optimization_goal", request.optimizationGoal());
-        body.put("status", "PAUSED");
+        body.put("status", "ACTIVE");
         body.put("destination_type", request.destinationType());
         body.put("targeting", targeting);
         String bidStrategy = request.bidStrategy();
@@ -2143,7 +2143,7 @@ private FacebookInterest searchInterest(String interestName, String locale) {
         body.put("name", request.name());
         body.put("adset_id", request.adSetId());
         body.put("creative", Map.of("creative_id", request.creativeId()));
-        body.put("status", "PAUSED");
+        body.put("status", "ACTIVE");
         body.put("access_token", requireAccessToken());
 
         String path = buildVersionedPath("/act_" + adAccountId + "/ads");

--- a/facebook-ads-worker/src/test/java/com/marketinghub/facebookadsworker/FacebookAdsServiceTest.java
+++ b/facebook-ads-worker/src/test/java/com/marketinghub/facebookadsworker/FacebookAdsServiceTest.java
@@ -115,7 +115,7 @@ class FacebookAdsServiceTest {
         assertEquals("1500", body.get("daily_budget").asText());
         assertEquals("IMPRESSIONS", body.get("billing_event").asText());
         assertEquals("LINK_CLICKS", body.get("optimization_goal").asText());
-        assertEquals("PAUSED", body.get("status").asText());
+        assertEquals("ACTIVE", body.get("status").asText());
         assertEquals("WEBSITE", body.get("destination_type").asText());
         assertEquals("LOWEST_COST_WITHOUT_CAP", body.get("bid_strategy").asText());
         assertFalse(body.has("bid_amount"));
@@ -725,7 +725,7 @@ class FacebookAdsServiceTest {
         assertEquals("Camp - Ad", body.get("name").asText());
         assertEquals("adset", body.get("adset_id").asText());
         assertEquals("creative", body.get("creative").get("creative_id").asText());
-        assertEquals("PAUSED", body.get("status").asText());
+        assertEquals("ACTIVE", body.get("status").asText());
         assertEquals("444", id);
     }
 


### PR DESCRIPTION
### Motivation
- Tornar a hierarquia publicada pronta para veiculação imediata: a campanha deve permanecer pausada para ativação manual enquanto os conjuntos de anúncios e anúncios já ficam ativos e prontos.

### Description
- Alterado o payload de criação de ad set para enviar `status = "ACTIVE"` em `FacebookAdsService.createAdSet` (substituindo `PAUSED`).
- Alterado o payload de criação de ad para enviar `status = "ACTIVE"` em `FacebookAdsService.createAd` (substituindo `PAUSED`).
- Atualizados testes em `FacebookAdsServiceTest` para validar `ACTIVE` nos `adsets` e `ads` criados.
- Documentação ajustada em `facebook-ads-worker/README.md` e `facebook-ads-worker/AGENTS.md` para explicar o novo comportamento: campanha `PAUSED`; ad sets e anúncios `ACTIVE`.

### Testing
- Executado `mvn test -Dtest=FacebookAdsServiceTest` na module `facebook-ads-worker` e todos os testes passaram: `Tests run: 37, Failures: 0, Errors: 0` (build success).
- Asserções dos testes foram atualizadas para refletir o `status = "ACTIVE"` esperado e o conjunto de testes relevantes foi executado com sucesso.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a391b6a06b483218b5f17a52ff9a3f6)