### PR TITLE
Extract ExperimentFunnelStandbyService to break circular dependency and centralize campaign stop logic

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/funnel/ExperimentFunnelAutoStopService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/funnel/ExperimentFunnelAutoStopService.java
@@ -7,10 +7,8 @@ import com.marketinghub.experiment.funnel.dto.ExperimentFunnelDiagnosticsRespons
 import com.marketinghub.experiment.funnel.dto.ExperimentFunnelStageDiagnosticDto;
 import com.marketinghub.experiment.funnel.dto.FunnelDiagnosticStatus;
 import com.marketinghub.experiment.funnel.dto.FunnelThresholdCheckDto;
-import com.marketinghub.facebookads.FacebookAdsCampaign;
 import com.marketinghub.facebookads.FacebookCampaignStopReason;
 import com.marketinghub.repository.jpa.experiment.ExperimentCampaignMetricRepository;
-import com.marketinghub.repository.jpa.facebookads.FacebookAdsCampaignRepository;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.stereotype.Service;
@@ -18,7 +16,6 @@ import org.springframework.stereotype.Service;
 import java.math.BigDecimal;
 import java.time.Duration;
 import java.time.Instant;
-import java.util.List;
 import java.util.Objects;
 
 /**
@@ -34,17 +31,17 @@ public class ExperimentFunnelAutoStopService {
     private static final long LOW_IMPRESSIONS_MINIMUM = 100L;
 
     private final ExperimentFunnelDiagnosticService diagnosticService;
-    private final FacebookAdsCampaignRepository campaignRepository;
+    private final ExperimentFunnelStandbyService standbyService;
     private final ExperimentCampaignMetricRepository campaignMetricRepository;
 
     /**
      * Cria o serviço com diagnóstico de funil, campanhas e métricas para registrar pausas automáticas.
      */
     public ExperimentFunnelAutoStopService(ExperimentFunnelDiagnosticService diagnosticService,
-                                           FacebookAdsCampaignRepository campaignRepository,
+                                           ExperimentFunnelStandbyService standbyService,
                                            ExperimentCampaignMetricRepository campaignMetricRepository) {
         this.diagnosticService = diagnosticService;
-        this.campaignRepository = campaignRepository;
+        this.standbyService = standbyService;
         this.campaignMetricRepository = campaignMetricRepository;
     }
 
@@ -178,25 +175,12 @@ public class ExperimentFunnelAutoStopService {
     }
 
     /**
-     * Coloca o experimento em standby no primeiro envio válido e solicita pausa das campanhas Meta vinculadas.
+     * Coloca o experimento em standby no primeiro envio válido usando o serviço sem dependência circular.
      *
      * @return {@code true} quando o standby foi aplicado, {@code false} caso o experimento não esteja elegível.
      */
     public boolean standbyOnFirstValidFormSubmission(Experiment experiment) {
-        if (experiment == null || experiment.getStatus() != ExperimentStatus.RUNNING) {
-            return false;
-        }
-        LOGGER.info(
-                "Standby triggered for experiment {} after first valid form submission.",
-                experiment.getId()
-        );
-        experiment.setStatus(ExperimentStatus.STANDBY);
-        requestFacebookCampaignStops(
-                experiment.getId(),
-                FacebookCampaignStopReason.FIRST_FORM_SUBMISSION_STANDBY,
-                "primeiro envio válido de formulário no regime inicial de validação"
-        );
-        return true;
+        return standbyService.standbyOnFirstValidFormSubmission(experiment);
     }
 
     /**
@@ -216,39 +200,7 @@ public class ExperimentFunnelAutoStopService {
                                                      FacebookCampaignStopReason stopReason,
                                                      String businessReason) {
         experiment.setStatus(ExperimentStatus.INVALIDATED);
-        requestFacebookCampaignStops(experiment.getId(), stopReason, businessReason);
+        standbyService.requestFacebookCampaignStops(experiment.getId(), stopReason, businessReason);
     }
 
-    /**
-     * Registra a solicitação de pausa para as campanhas Facebook ainda não finalizadas.
-     */
-    private void requestFacebookCampaignStops(Long experimentId,
-                                              FacebookCampaignStopReason stopReason,
-                                              String businessReason) {
-        List<FacebookAdsCampaign> campaigns = campaignRepository.findByExperimentId(experimentId);
-        if (campaigns == null || campaigns.isEmpty()) {
-            LOGGER.info(
-                    "Experiment {} has no Facebook campaigns registered; status updated but no stop request was necessary.",
-                    experimentId
-            );
-            return;
-        }
-        Instant now = Instant.now();
-        campaigns.stream()
-                .filter(campaign -> campaign.getStopCompletedAt() == null)
-                .forEach(campaign -> {
-                    if (campaign.getStopRequestedAt() == null) {
-                        campaign.setStopRequestedAt(now);
-                    }
-                    campaign.setStopReason(stopReason);
-                    campaign.setStopLastError(null);
-                    LOGGER.info(
-                            "Stop request registered for campaign {} from experiment {}: reason={}, businessReason={}",
-                            campaign.getId(),
-                            experimentId,
-                            stopReason,
-                            businessReason
-                    );
-                });
-    }
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/funnel/ExperimentFunnelService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/funnel/ExperimentFunnelService.java
@@ -54,7 +54,7 @@ public class ExperimentFunnelService {
     private final ExperimentLandingAnalyticsEventRepository landingAnalyticsEventRepository;
     private final LeadRepository leadRepository;
     private final JdbcTemplate jdbcTemplate;
-    private final ExperimentFunnelAutoStopService autoStopService;
+    private final ExperimentFunnelStandbyService standbyService;
 
     static final String FLOW_SCOPE_CONDITION = """
             (
@@ -339,7 +339,7 @@ public class ExperimentFunnelService {
                 .occurredAt(occurredAt)
                 .build();
         eventRepository.save(event);
-        autoStopService.standbyOnFirstValidFormSubmission(experiment);
+        standbyService.standbyOnFirstValidFormSubmission(experiment);
         return true;
     }
 

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/funnel/ExperimentFunnelStandbyService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/funnel/ExperimentFunnelStandbyService.java
@@ -1,0 +1,86 @@
+package com.marketinghub.experiment.funnel;
+
+import com.marketinghub.experiment.Experiment;
+import com.marketinghub.experiment.ExperimentStatus;
+import com.marketinghub.facebookads.FacebookAdsCampaign;
+import com.marketinghub.facebookads.FacebookCampaignStopReason;
+import com.marketinghub.repository.jpa.facebookads.FacebookAdsCampaignRepository;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+import java.time.Instant;
+import java.util.List;
+
+/**
+ * Serviço responsável por colocar experimentos em standby e solicitar pausa de campanhas vinculadas.
+ */
+@Service
+public class ExperimentFunnelStandbyService {
+    private static final Logger LOGGER = LoggerFactory.getLogger(ExperimentFunnelStandbyService.class);
+
+    private final FacebookAdsCampaignRepository campaignRepository;
+
+    /**
+     * Cria o serviço com acesso às campanhas Meta vinculadas ao experimento.
+     */
+    public ExperimentFunnelStandbyService(FacebookAdsCampaignRepository campaignRepository) {
+        this.campaignRepository = campaignRepository;
+    }
+
+    /**
+     * Coloca o experimento em standby no primeiro envio válido e solicita pausa das campanhas Meta vinculadas.
+     *
+     * @return {@code true} quando o standby foi aplicado, {@code false} caso o experimento não esteja elegível.
+     */
+    public boolean standbyOnFirstValidFormSubmission(Experiment experiment) {
+        if (experiment == null || experiment.getStatus() != ExperimentStatus.RUNNING) {
+            return false;
+        }
+        LOGGER.info(
+                "Standby triggered for experiment {} after first valid form submission.",
+                experiment.getId()
+        );
+        experiment.setStatus(ExperimentStatus.STANDBY);
+        requestFacebookCampaignStops(
+                experiment.getId(),
+                FacebookCampaignStopReason.FIRST_FORM_SUBMISSION_STANDBY,
+                "primeiro envio válido de formulário no regime inicial de validação"
+        );
+        return true;
+    }
+
+    /**
+     * Registra a solicitação de pausa para as campanhas Facebook ainda não finalizadas.
+     */
+    public void requestFacebookCampaignStops(Long experimentId,
+                                             FacebookCampaignStopReason stopReason,
+                                             String businessReason) {
+        List<FacebookAdsCampaign> campaigns = campaignRepository.findByExperimentId(experimentId);
+        if (campaigns == null || campaigns.isEmpty()) {
+            LOGGER.info(
+                    "Experiment {} has no Facebook campaigns registered; status updated but no stop request was necessary.",
+                    experimentId
+            );
+            return;
+        }
+        Instant now = Instant.now();
+        campaigns.stream()
+                .filter(campaign -> campaign.getStopCompletedAt() == null)
+                .forEach(campaign -> {
+                    if (campaign.getStopRequestedAt() == null) {
+                        campaign.setStopRequestedAt(now);
+                    }
+                    campaign.setStopReason(stopReason);
+                    campaign.setStopLastError(null);
+                    LOGGER.info(
+                            "Stop request registered for campaign {} from experiment {}: reason={}, businessReason={}",
+                            campaign.getId(),
+                            experimentId,
+                            stopReason,
+                            businessReason
+                    );
+                });
+        campaignRepository.saveAll(campaigns);
+    }
+}

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/funnel/ExperimentFunnelAutoStopServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/funnel/ExperimentFunnelAutoStopServiceTest.java
@@ -15,7 +15,6 @@ import com.marketinghub.repository.jpa.facebookads.FacebookAdsCampaignRepository
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
-import org.mockito.InjectMocks;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
@@ -39,13 +38,17 @@ class ExperimentFunnelAutoStopServiceTest {
     @Mock
     private ExperimentCampaignMetricRepository campaignMetricRepository;
 
-    @InjectMocks
     private ExperimentFunnelAutoStopService service;
 
     private Experiment experiment;
 
     @BeforeEach
     void setUp() {
+        service = new ExperimentFunnelAutoStopService(
+                diagnosticService,
+                new ExperimentFunnelStandbyService(campaignRepository),
+                campaignMetricRepository
+        );
         experiment = new Experiment();
         experiment.setId(99L);
         experiment.setStatus(ExperimentStatus.RUNNING);

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/funnel/ExperimentFunnelServiceSubmissionTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/funnel/ExperimentFunnelServiceSubmissionTest.java
@@ -47,7 +47,7 @@ class ExperimentFunnelServiceSubmissionTest {
     private JdbcTemplate jdbcTemplate;
 
     @Mock
-    private ExperimentFunnelAutoStopService autoStopService;
+    private ExperimentFunnelStandbyService standbyService;
 
     @InjectMocks
     private ExperimentFunnelService service;
@@ -77,7 +77,7 @@ class ExperimentFunnelServiceSubmissionTest {
         assertEquals("submissionId=submission-123", saved.getPayload());
         assertEquals(submittedAt, saved.getOccurredAt());
         assertEquals("ad-xyz", saved.getCampaignCode());
-        verify(autoStopService).standbyOnFirstValidFormSubmission(experiment);
+        verify(standbyService).standbyOnFirstValidFormSubmission(experiment);
     }
 
     /**

--- a/backend/ads-service/src/test/java/com/marketinghub/facebookads/controller/FacebookAdsCampaignMetricsAutoStopControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/facebookads/controller/FacebookAdsCampaignMetricsAutoStopControllerTest.java
@@ -9,6 +9,7 @@ import com.marketinghub.experiment.ExperimentStatus;
 import com.marketinghub.experiment.funnel.ExperimentFunnelAutoStopService;
 import com.marketinghub.experiment.funnel.ExperimentFunnelDiagnosticService;
 import com.marketinghub.experiment.funnel.ExperimentFunnelStage;
+import com.marketinghub.experiment.funnel.ExperimentFunnelStandbyService;
 import com.marketinghub.experiment.funnel.dto.ExperimentFunnelDiagnosticsResponseDto;
 import com.marketinghub.experiment.funnel.dto.ExperimentFunnelStageDiagnosticDto;
 import com.marketinghub.experiment.funnel.dto.FunnelDiagnosticReasonCode;
@@ -105,7 +106,7 @@ class FacebookAdsCampaignMetricsAutoStopControllerTest {
         objectMapper = new ObjectMapper().registerModule(new JavaTimeModule());
         ExperimentFunnelAutoStopService autoStopService = new ExperimentFunnelAutoStopService(
                 diagnosticService,
-                campaignRepository,
+                new ExperimentFunnelStandbyService(campaignRepository),
                 campaignMetricRepository
         );
         FacebookAdsCampaignController controller = new FacebookAdsCampaignController(

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -5036,3 +5036,9 @@
 - Solicitação: incluir a opção GPT Image 2 na lista de modelo de geração de imagem da tela de novo experimento.
 - Correção aplicada: criado changelog incremental para cadastrar o modelo `gpt-image-2`, suas qualidades e preços base no catálogo consumido pelo endpoint `/api/image-generation/models`.
 - Prevenção de recorrência: o changelog foi incluído no master com `relativeToChangelogFile: true`, mantendo a lista da tela orientada pela verdade persistida no backend.
+
+## 2026-06-22 — Correção de ciclo no funil de experimento
+- Problema: testes com `@SpringBootTest` falhavam ao subir o contexto por dependência circular entre `ExperimentFunnelAutoStopService`, `ExperimentFunnelDiagnosticService` e `ExperimentFunnelService`.
+- Causa-raiz: a mesma classe de parada automática concentrava diagnóstico estatístico e standby por submissão, fazendo o serviço de funil depender de volta da cadeia que já dependia dele para sumarizar métricas.
+- Correção aplicada: extraído `ExperimentFunnelStandbyService` para concentrar standby e solicitação de pausa de campanhas, removendo a dependência direta de `ExperimentFunnelService` para `ExperimentFunnelAutoStopService`.
+- Prevenção de recorrência: testes de controller, funil e parada automática foram executados juntos para validar que o contexto Spring volta a subir sem referência circular.


### PR DESCRIPTION
### Motivation
- Resolve a circular Spring dependency between `ExperimentFunnelAutoStopService`, `ExperimentFunnelDiagnosticService` and `ExperimentFunnelService` that prevented `@SpringBootTest` context startup.
- Separate concerns by moving standby and campaign-stop request logic out of the auto-stop service to avoid mixing diagnostic and control responsibilities.

### Description
- Added a new `ExperimentFunnelStandbyService` that encapsulates `standbyOnFirstValidFormSubmission` and `requestFacebookCampaignStops` and persists campaign stop requests with `campaignRepository.saveAll(...)`.
- Updated `ExperimentFunnelAutoStopService` to depend on `ExperimentFunnelStandbyService` and to call `standbyService.requestFacebookCampaignStops(...)` instead of its former internal method, removing the `requestFacebookCampaignStops` helper and `FacebookAdsCampaign` import.
- Updated `ExperimentFunnelService` to call `standbyService.standbyOnFirstValidFormSubmission(...)` where it previously referenced the auto-stop service.
- Adjusted controller wiring and unit tests to instantiate or mock `ExperimentFunnelStandbyService` and updated changelog `docs/registros/experimentos.md` to document the fix.

### Testing
- Ran modified unit tests including `ExperimentFunnelAutoStopServiceTest`, `ExperimentFunnelServiceSubmissionTest`, and `FacebookAdsCampaignMetricsAutoStopControllerTest`, and they passed after updating to use `ExperimentFunnelStandbyService`.
- Verified the Spring application context startup tests (previously failing due to circular dependency) now initialize successfully with the extracted service.
- No automated test failures were observed in the modified test suite.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a391bf338348321aeec2e990ac7865b)