### PR TITLE
Lead Portal: filter Meta crawler accesses and expose technicalAccessesFiltered metric

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/leadportal/dto/LeadPortalExperimentMetricsDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/leadportal/dto/LeadPortalExperimentMetricsDto.java
@@ -10,6 +10,7 @@ public record LeadPortalExperimentMetricsDto(
         Long experimentId,
         String experimentName,
         long leadsAccessed,
+        long technicalAccessesFiltered,
         long leadsWithImage,
         List<LeadPortalExperimentUserDto> uniqueLeads,
         long sampleEmailsGenerated,

--- a/backend/ads-service/src/main/java/com/marketinghub/leadportal/service/LeadPortalMetricsService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/leadportal/service/LeadPortalMetricsService.java
@@ -42,9 +42,26 @@ public class LeadPortalMetricsService {
         String accessSql = """
                 SELECT e.id AS experiment_id,
                        e.name AS experiment_name,
-                       COUNT(DISTINCT COALESCE(fa.visitor_id,
-                                                CONCAT('ip:', fa.client_ip),
-                                                CONCAT('access:', fa.id))) AS unique_accesses
+                       COUNT(DISTINCT CASE
+                           WHEN fa.id IS NOT NULL AND NOT (
+                               LOWER(COALESCE(fa.user_agent, '')) LIKE '%facebookexternalhit%'
+                               OR LOWER(COALESCE(fa.user_agent, '')) LIKE '%meta-externalads%'
+                               OR LOWER(COALESCE(fa.user_agent, '')) LIKE '%facebot%'
+                           ) THEN COALESCE(fa.visitor_id,
+                                           CONCAT('ip:', fa.client_ip),
+                                           CONCAT('access:', fa.id))
+                           ELSE NULL
+                       END) AS unique_accesses,
+                       COUNT(DISTINCT CASE
+                           WHEN fa.id IS NOT NULL AND (
+                               LOWER(COALESCE(fa.user_agent, '')) LIKE '%facebookexternalhit%'
+                               OR LOWER(COALESCE(fa.user_agent, '')) LIKE '%meta-externalads%'
+                               OR LOWER(COALESCE(fa.user_agent, '')) LIKE '%facebot%'
+                           ) THEN COALESCE(fa.visitor_id,
+                                           CONCAT('ip:', fa.client_ip),
+                                           CONCAT('access:', fa.id))
+                           ELSE NULL
+                       END) AS technical_accesses_filtered
                 FROM experiment e
                 JOIN lead_portal_flow lpf ON lpf.id = e.lead_portal_flow_id
                 LEFT JOIN flow_access fa ON fa.flow_slug = lpf.slug
@@ -59,7 +76,9 @@ public class LeadPortalMetricsService {
                     experiments.computeIfAbsent(
                             experimentId, id -> new ExperimentMetricsAccumulator(id, experimentName));
 
-            accumulator.setLeadsAccessed(rs.getLong("unique_accesses"));
+            long uniqueAccesses = rs.getLong("unique_accesses");
+            long technicalAccessesFiltered = rs.getLong("technical_accesses_filtered");
+            accumulator.setAccessCounts(uniqueAccesses, technicalAccessesFiltered);
         });
     }
 
@@ -298,6 +317,7 @@ public class LeadPortalMetricsService {
         private final long experimentId;
         private final String experimentName;
         private long leadsAccessed;
+        private long technicalAccessesFiltered;
         private final Map<String, LeadPortalExperimentUserDto> uniqueUsers = new LinkedHashMap<>();
         private long sampleEmailCount;
         private Long selectedSampleEmailId;
@@ -314,8 +334,12 @@ public class LeadPortalMetricsService {
             this.experimentName = experimentName;
         }
 
-        void setLeadsAccessed(long leadsAccessed) {
+        /**
+         * Atualiza as contagens de acessos humanos e acessos técnicos filtrados.
+         */
+        void setAccessCounts(long leadsAccessed, long technicalAccessesFiltered) {
             this.leadsAccessed = leadsAccessed;
+            this.technicalAccessesFiltered = technicalAccessesFiltered;
         }
 
         void setSampleEmailCount(long sampleEmailCount) {
@@ -360,6 +384,7 @@ public class LeadPortalMetricsService {
                     experimentId,
                     experimentName,
                     leadsAccessed,
+                    technicalAccessesFiltered,
                     leadsWithImage,
                     leads,
                     sampleEmailCount,

--- a/backend/ads-service/src/test/java/com/marketinghub/facebookads/controller/FacebookAdsCampaignControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/facebookads/controller/FacebookAdsCampaignControllerTest.java
@@ -216,6 +216,7 @@ class FacebookAdsCampaignControllerTest {
                         exp.getId(),
                         exp.getName(),
                         25L,
+                        0L,
                         5L,
                         List.of(new LeadPortalExperimentUserDto("Lead 1", "lead@example.com", null, false)),
                         0L,

--- a/backend/ads-service/src/test/java/com/marketinghub/leadportal/service/LeadPortalMetricsServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/leadportal/service/LeadPortalMetricsServiceTest.java
@@ -1,0 +1,45 @@
+package com.marketinghub.leadportal.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.doAnswer;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.jdbc.core.RowCallbackHandler;
+
+/**
+ * Valida as regras comerciais das métricas consolidadas do portal do lead.
+ */
+class LeadPortalMetricsServiceTest {
+
+    /**
+     * Garante que acessos técnicos da Meta não sejam contados como acesso humano no funil.
+     */
+    @Test
+    void listExperimentMetricsFiltersMetaCrawlerAccessesFromCommercialFunnel() {
+        JdbcTemplate jdbcTemplate = org.mockito.Mockito.mock(JdbcTemplate.class);
+        List<String> executedSql = new ArrayList<>();
+        doAnswer(invocation -> {
+                    executedSql.add(invocation.getArgument(0));
+                    return null;
+                })
+                .when(jdbcTemplate)
+                .query(anyString(), any(RowCallbackHandler.class));
+
+        LeadPortalMetricsService service = new LeadPortalMetricsService(jdbcTemplate);
+        service.listExperimentMetrics();
+
+        String accessSql = executedSql.getFirst();
+        assertThat(accessSql)
+                .contains("unique_accesses")
+                .contains("technical_accesses_filtered")
+                .contains("CASE")
+                .contains("facebookexternalhit")
+                .contains("meta-externalads")
+                .contains("facebot");
+    }
+}

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -5036,3 +5036,10 @@
 - Solicitação: incluir a opção GPT Image 2 na lista de modelo de geração de imagem da tela de novo experimento.
 - Correção aplicada: criado changelog incremental para cadastrar o modelo `gpt-image-2`, suas qualidades e preços base no catálogo consumido pelo endpoint `/api/image-generation/models`.
 - Prevenção de recorrência: o changelog foi incluído no master com `relativeToChangelogFile: true`, mantendo a lista da tela orientada pela verdade persistida no backend.
+
+## 2026-06-22 — Funil: filtragem de acessos técnicos da Meta
+
+- solicitação: corrigir sistemicamente a distorção de métricas do funil causada por acessos automáticos do Facebook/Meta logo após a criação/publicação da campanha.
+- causa-raiz identificada: a métrica de acessos do Lead Portal contava registros de `flow_access` sem distinguir visitante humano de crawler técnico da Meta, especialmente `facebookexternalhit` e `meta-externalads`, inflando o funil antes de haver tráfego comercial real.
+- correção aplicada: o backend passou a calcular acessos válidos do funil excluindo user agents técnicos da Meta e a expor a quantidade de acessos técnicos filtrados; a tela de métricas do Lead Portal passou a mostrar acessos válidos e acessos técnicos filtrados separadamente.
+- prevenção de recorrência: adicionado teste de contrato no backend garantindo que a consulta de métricas mantém o filtro explícito para crawlers da Meta antes de alimentar o funil comercial.

--- a/frontend/src/api/leadPortal/useLeadPortalExperimentMetrics.ts
+++ b/frontend/src/api/leadPortal/useLeadPortalExperimentMetrics.ts
@@ -12,6 +12,7 @@ export interface LeadPortalExperimentMetrics {
   experimentId: number;
   experimentName: string;
   leadsAccessed: number;
+  technicalAccessesFiltered: number;
   leadsWithImage: number;
   uniqueLeads: LeadPortalExperimentLead[];
   sampleEmailsGenerated: number;

--- a/frontend/src/pages/leadPortal/LeadPortalExperimentMetricsPage.tsx
+++ b/frontend/src/pages/leadPortal/LeadPortalExperimentMetricsPage.tsx
@@ -47,7 +47,8 @@ export default function LeadPortalExperimentMetricsPage() {
                 <thead>
                   <tr>
                     <th>Experimento</th>
-                    <th>Leads que acessaram</th>
+                    <th>Acessos válidos</th>
+                    <th>Acessos técnicos filtrados</th>
                     <th>Leads que enviaram imagem</th>
                     <th>Conversão para imagem</th>
                     <th>E-mails de amostra gerados</th>
@@ -67,6 +68,7 @@ export default function LeadPortalExperimentMetricsPage() {
                       <tr key={row.experimentId}>
                         <td className="fw-semibold">{row.experimentName}</td>
                         <td>{row.leadsAccessed}</td>
+                        <td>{row.technicalAccessesFiltered}</td>
                         <td>{row.leadsWithImage}</td>
                         <td>
                           {conversion.toLocaleString("pt-BR", {


### PR DESCRIPTION
### Motivation

- Prevent inflated funnel metrics caused by automated Meta crawlers by distinguishing human accesses from technical accesses in `flow_access` records.

### Description

- Updated the metrics SQL in `LeadPortalMetricsService` to exclude Meta crawler user agents (`facebookexternalhit`, `meta-externalads`, `facebot`) when counting valid funnel accesses and to separately count `technical_accesses_filtered` using `CASE` expressions. 
- Added `technicalAccessesFiltered` to the backend DTO `LeadPortalExperimentMetricsDto` and to the `ExperimentMetricsAccumulator` with a new `setAccessCounts` method and inclusion in `toDto`. 
- Updated the frontend types in `useLeadPortalExperimentMetrics.ts` and the UI in `LeadPortalExperimentMetricsPage.tsx` to surface both the valid accesses and the newly exposed `technicalAccessesFiltered` column. 
- Added a changelog entry in `docs/registros/experimentos.md` describing the fix and its rationale. 

### Testing

- Added unit test `LeadPortalMetricsServiceTest.listExperimentMetricsFiltersMetaCrawlerAccessesFromCommercialFunnel` which asserts the metrics SQL contains the `CASE` filter and known Meta user agents, and this test passed. 
- Updated `FacebookAdsCampaignControllerTest` to accommodate the expanded DTO shape and existing controller tests passed. 
- Ran the project unit test suite for the `ads-service` module and observed no failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a391b9e8cf48321b0817f1e63c85494)