### PR TITLE
Formatar datas do funil em horário de Brasília e adicionar teste de regressão

### DIFF
--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -5048,3 +5048,8 @@
 - Causa-raiz: a mesma classe de parada automática concentrava diagnóstico estatístico e standby por submissão, fazendo o serviço de funil depender de volta da cadeia que já dependia dele para sumarizar métricas.
 - Correção aplicada: extraído `ExperimentFunnelStandbyService` para concentrar standby e solicitação de pausa de campanhas, removendo a dependência direta de `ExperimentFunnelService` para `ExperimentFunnelAutoStopService`.
 - Prevenção de recorrência: testes de controller, funil e parada automática foram executados juntos para validar que o contexto Spring volta a subir sem referência circular.
+
+## 2026-06-22 — Horário de Brasília no funil do experimento
+
+- Ajustada a tela de funil do experimento para formatar o campo `Último evento` explicitamente no fuso operacional `America/Sao_Paulo`, exibindo o cabeçalho como horário de Brasília e evitando interpretação pelo fuso local do navegador.
+- Adicionado teste de regressão no frontend para garantir que datas do funil sejam apresentadas no fuso operacional do Brasil.

--- a/frontend/src/pages/experiment/ExperimentFunnelTab.test.tsx
+++ b/frontend/src/pages/experiment/ExperimentFunnelTab.test.tsx
@@ -176,6 +176,17 @@ describe("ExperimentFunnelTab", () => {
     ).not.toBeInTheDocument();
   });
 
+  it("formats funnel dates using Brazil operational timezone", () => {
+    renderWithClient(
+      <ExperimentFunnelTab experimentId="42" totalSpend={100} />,
+    );
+
+    expect(
+      screen.getByText("Último evento (horário de Brasília)"),
+    ).toBeInTheDocument();
+    expect(screen.getByText(/10\/03\/2024, 09:00/)).toBeInTheDocument();
+  });
+
   it("shows the cost per conversion for each stage", () => {
     renderWithClient(
       <ExperimentFunnelTab experimentId="42" totalSpend={100} />,

--- a/frontend/src/pages/experiment/ExperimentFunnelTab.tsx
+++ b/frontend/src/pages/experiment/ExperimentFunnelTab.tsx
@@ -31,13 +31,20 @@ interface ExperimentFunnelTabProps {
   alterationLocked?: boolean;
 }
 
+const BRAZIL_OPERATIONAL_TIME_ZONE = "America/Sao_Paulo";
+
 function formatDate(value?: string | null) {
   if (!value) return "—";
   const date = new Date(value);
   if (Number.isNaN(date.getTime())) return "—";
   return date.toLocaleString("pt-BR", {
-    dateStyle: "short",
-    timeStyle: "short",
+    day: "2-digit",
+    month: "2-digit",
+    year: "numeric",
+    hour: "2-digit",
+    minute: "2-digit",
+    timeZone: BRAZIL_OPERATIONAL_TIME_ZONE,
+    timeZoneName: "short",
   });
 }
 
@@ -338,7 +345,7 @@ export default function ExperimentFunnelTab({
                   <th>% vs. etapa anterior</th>
                   <th>Custo por conv.</th>
                   <th>Únicos</th>
-                  <th>Último evento</th>
+                  <th>Último evento (horário de Brasília)</th>
                 </tr>
               </thead>
               <tbody>


### PR DESCRIPTION
### Motivation
- Garantir que a coluna `Último evento` na tela do funil do experimento seja exibida no fuso operacional do produto (`America/Sao_Paulo`) para evitar diferenças causadas pelo fuso do navegador do usuário.
- Tornar explícita a informação de fuso no cabeçalho da tabela para melhorar a clareza para operadores no Brasil.
- Prevenir regressões na apresentação de datas adicionando um teste que verifica o comportamento esperado.

### Description
- Adicionado o constante `BRAZIL_OPERATIONAL_TIME_ZONE = "America/Sao_Paulo"` e atualizado `formatDate` para usar `toLocaleString` com `timeZone: BRAZIL_OPERATIONAL_TIME_ZONE` e formato de data/hora explícito.
- Atualizado o cabeçalho da tabela para exibir `Último evento (horário de Brasília)` em `ExperimentFunnelTab.tsx`.
- Incluído teste de frontend `formats funnel dates using Brazil operational timezone` em `ExperimentFunnelTab.test.tsx` que verifica o cabeçalho e a renderização da data no formato esperado.
- Documentação de changelog atualizada em `docs/registros/experimentos.md` registrando a mudança e o teste de regressão.

### Testing
- Executado suíte de testes de frontend incluindo `ExperimentFunnelTab.test.tsx` via o comando de testes da aplicação e o novo teste passou.
- Os testes de componente relacionados ao funil foram executados e não apresentaram regressões após a alteração.
- Nenhum teste automatizado adicional no backend foi necessário para esta alteração de UI/formatacao de data.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a39218daaf4832195c0489519acca97)