### PR TITLE
Fix NichoCNAE v2 job cancellation status column

### DIFF
--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-22-oprm-nichocnae-v2-status-varchar.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-22-oprm-nichocnae-v2-status-varchar.yaml
@@ -1,0 +1,19 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-06-22-01-oprm-nichocnae-v2-status-varchar
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - onError: HALT
+        - dbms:
+            type: mysql
+        - tableExists:
+            tableName: oprm_nichocnae_v2_stage_execution
+        - columnExists:
+            tableName: oprm_nichocnae_v2_stage_execution
+            columnName: status
+      changes:
+        - modifyDataType:
+            tableName: oprm_nichocnae_v2_stage_execution
+            columnName: status
+            newDataType: VARCHAR(40)

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -1,5 +1,8 @@
 databaseChangeLog:
   - include:
+      file: changesets/2026-06-22-oprm-nichocnae-v2-status-varchar.yaml
+      relativeToChangelogFile: true
+  - include:
       file: changesets/2026-06-22-experiment-standby-status.yaml
       relativeToChangelogFile: true
   - include:

--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -1,3 +1,8 @@
+## 2026-06-22 — OPRM NichoCNAE v2: cancelamento manual de job
+
+- Corrigida a causa-raiz do erro ao cancelar job v2: em produção a coluna `oprm_nichocnae_v2_stage_execution.status` ainda estava como `ENUM` sem o valor `CANCELED`, enquanto o backend já usa status flexível por enum Java.
+- Criado changelog incremental para converter a coluna `status` para `VARCHAR(40)`, permitindo o cancelamento manual e futuras evoluções de status sem truncamento pelo MySQL.
+
 
 ## 2026-06-21 — OPRM NichoCNAE v2: bootstrap do backend corrigido
 


### PR DESCRIPTION
### Motivation
- O cancelamento manual de jobs v2 falhava porque a coluna `oprm_nichocnae_v2_stage_execution.status` em produção era um `ENUM` sem o valor `CANCELED`, causando truncamento e impedindo o backend de persistir a transição para `CANCELED`.

### Description
- Adiciona um changelog incremental Liquibase `backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-22-oprm-nichocnae-v2-status-varchar.yaml` que converte a coluna `status` para `VARCHAR(40)`, inclui esse changeset no `db.changelog-master.yaml` com `relativeToChangelogFile: true` e registra a correção em `docs/registros/oprm1.md`.

### Testing
- Validação de sintaxe dos YAMLs com `ruby -e "require 'yaml'; [...].each{|f| YAML.load_file(f); puts \"ok #{f}\" }"` executada com sucesso; 
- Build do módulo backend executado com `./backend/mvnw -f backend/ads-service/pom.xml -DskipTests compile` resultando em `BUILD SUCCESS`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a39537468d083219cb6b934469bf7b0)