### PR TITLE
Expose backend-detected operational loop for open NichoCNAE v2 jobs

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/candidategenerator/service/BackendCandidateGeneratorService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/candidategenerator/service/BackendCandidateGeneratorService.java
@@ -32,6 +32,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.data.domain.PageRequest;
@@ -333,8 +334,42 @@ public class BackendCandidateGeneratorService {
                 actionUrl(finalDecision, lastExecution.getCnaeCode(), marketNicheId),
                 usedAi,
                 aiCostUsd,
+                loopDetected(executions),
+                loopLabel(executions),
+                loopReason(executions),
+                repeatedStageCount(executions),
                 executions.stream().map(OprmNichoCnaeV2StageExecution::getCreatedAt).min(Comparator.naturalOrder()).orElse(null),
                 lastExecution.getUpdatedAt());
+    }
+
+
+    /** Detecta quando um job aberto está repetindo etapas de pesquisa/reclassificação em vez de avançar linearmente. */
+    private boolean loopDetected(List<OprmNichoCnaeV2StageExecution> executions) {
+        return hasOpenExecution(executions) && repeatedStageCount(executions) >= 2;
+    }
+
+    /** Define o rótulo operacional do ciclo para a tela exibir a verdade persistida pelo backend. */
+    private String loopLabel(List<OprmNichoCnaeV2StageExecution> executions) {
+        return loopDetected(executions) ? "Em ciclo de pesquisa" : null;
+    }
+
+    /** Explica por que o job foi classificado como ciclo, sem depender de heurística no front-end. */
+    private String loopReason(List<OprmNichoCnaeV2StageExecution> executions) {
+        int repeatedStages = repeatedStageCount(executions);
+        if (!hasOpenExecution(executions) || repeatedStages < 2) {
+            return null;
+        }
+        return "O job repetiu "
+                + repeatedStages
+                + " etapas no histórico recente e ainda está aberto; o executor está buscando novas evidências antes de decidir.";
+    }
+
+    /** Conta quantas etapas aparecem mais de uma vez no mesmo job para sinalizar loop operacional. */
+    private int repeatedStageCount(List<OprmNichoCnaeV2StageExecution> executions) {
+        Map<String, Long> stageOccurrences = executions.stream()
+                .collect(Collectors.groupingBy(
+                        OprmNichoCnaeV2StageExecution::getStageCode, LinkedHashMap::new, Collectors.counting()));
+        return (int) stageOccurrences.values().stream().filter(count -> count > 1).count();
     }
 
     /** Extrai a decisão funcional persistida no output da última etapa para evitar conclusão sem explicação ao usuário. */

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/candidategenerator/service/listCnaeJobs/CandidateGeneratorCnaeJobSummary.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/candidategenerator/service/listCnaeJobs/CandidateGeneratorCnaeJobSummary.java
@@ -24,5 +24,9 @@ public record CandidateGeneratorCnaeJobSummary(
         String actionUrl,
         Boolean usedAi,
         BigDecimal aiCostUsd,
+        Boolean loopDetected,
+        String loopLabel,
+        String loopReason,
+        Integer repeatedStageCount,
         Instant createdAt,
         Instant updatedAt) {}

--- a/backend/ads-service/src/test/java/com/marketinghub/oprm/nichocnae/v2/candidategenerator/service/BackendCandidateGeneratorServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/oprm/nichocnae/v2/candidategenerator/service/BackendCandidateGeneratorServiceTest.java
@@ -171,6 +171,48 @@ class BackendCandidateGeneratorServiceTest {
         assertThat(result.completedJobs().getFirst().aiCostUsd()).isEqualByComparingTo(new BigDecimal("0.015"));
     }
 
+
+    /** Deve expor na resposta do backend quando job aberto repete etapas e está em ciclo operacional. */
+    @Test
+    void listJobsForCnaeShowsOpenJobLoopDetectedByBackend() {
+        BackendCandidateGeneratorService service = service(true, false);
+        OprmNichoCnaeV2StageExecution firstPlanner = execution(401L, 1, 0, 1);
+        firstPlanner.setJobId("job-em-ciclo");
+        firstPlanner.setCnaeCode("4781400");
+        firstPlanner.setStageCode("adaptive-query-planner");
+        firstPlanner.setStatus(OprmNichoCnaeV2StageExecutionStatus.COMPLETED);
+        firstPlanner.setUpdatedAt(Instant.parse("2026-06-22T12:00:00Z"));
+        OprmNichoCnaeV2StageExecution firstTournament = execution(402L, 1, 0, 1);
+        firstTournament.setJobId("job-em-ciclo");
+        firstTournament.setCnaeCode("4781400");
+        firstTournament.setStageCode("candidate-tournament");
+        firstTournament.setStatus(OprmNichoCnaeV2StageExecutionStatus.COMPLETED);
+        firstTournament.setUpdatedAt(Instant.parse("2026-06-22T12:01:00Z"));
+        OprmNichoCnaeV2StageExecution secondPlanner = execution(403L, 1, 0, 1);
+        secondPlanner.setJobId("job-em-ciclo");
+        secondPlanner.setCnaeCode("4781400");
+        secondPlanner.setStageCode("adaptive-query-planner");
+        secondPlanner.setStatus(OprmNichoCnaeV2StageExecutionStatus.COMPLETED);
+        secondPlanner.setUpdatedAt(Instant.parse("2026-06-22T12:02:00Z"));
+        OprmNichoCnaeV2StageExecution openTournament = execution(404L, 1, 0, 1);
+        openTournament.setJobId("job-em-ciclo");
+        openTournament.setCnaeCode("4781400");
+        openTournament.setStageCode("candidate-tournament");
+        openTournament.setStatus(OprmNichoCnaeV2StageExecutionStatus.PENDING);
+        openTournament.setUpdatedAt(Instant.parse("2026-06-22T12:03:00Z"));
+        when(stageExecutionRepository.findByCnaeCodeOrderByUpdatedAtDesc("4781400"))
+                .thenReturn(List.of(openTournament, secondPlanner, firstTournament, firstPlanner));
+
+        var result = service.listJobsForCnae("4781400");
+
+        assertThat(result.openJobs()).hasSize(1);
+        var job = result.openJobs().getFirst();
+        assertThat(job.loopDetected()).isTrue();
+        assertThat(job.loopLabel()).isEqualTo("Em ciclo de pesquisa");
+        assertThat(job.loopReason()).contains("O job repetiu 2 etapas");
+        assertThat(job.repeatedStageCount()).isEqualTo(2);
+    }
+
     /** Deve detalhar cronologicamente as etapas do job para relatório de fracasso. */
     @Test
     void detailJobReturnsStageTimelineForFailureReport() {

--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -1257,3 +1257,8 @@
 - Causa-raiz tratada: o fluxo estava aplicando critério conservador de viabilidade/dor cedo demais, encerrando jobs com `finalistas=0` mesmo quando ainda havia recortes operacionais que poderiam alimentar nova pesquisa.
 - Prevenção de recorrência: testes da v2 agora cobrem geração de pelo menos 10 candidatos e seleção de até três finalistas por clareza operacional.
 - 2026-06-22 00:00:00 (UTC): adicionada opção administrativa para cancelar jobs abertos/presos do OPRM NichoCNAE v2 na tela `/oprm/cnaes/:cnaeCode/pipeline-v2`. A correção fecha a causa-raiz operacional do bloqueio por `409 Conflict`: o backend agora possui contrato explícito de cancelamento por `jobId`, marca execuções abertas como `CANCELED`, preserva histórico/auditoria e libera o CNAE para iniciar novo job v2 sem apagar dados.
+
+## 2026-06-22 — Observabilidade de ciclo em jobs abertos NichoCNAE v2
+
+- A tela `/oprm/cnaes/:cnaeCode/pipeline-v2` passou a mostrar quando um job aberto está em ciclo operacional, usando campos explícitos do backend (`loopDetected`, `loopLabel`, `loopReason` e `repeatedStageCount`) em vez de inferência local no frontend.
+- O backend do OPRM NichoCNAE v2 agora classifica jobs abertos com repetição de etapas no histórico como “Em ciclo de pesquisa”, deixando claro ao usuário que o executor está repetindo pesquisa/reclassificação antes de decidir.

--- a/docs/swagger/oprm-nichocnae-v2-candidate-generator-swagger.yaml
+++ b/docs/swagger/oprm-nichocnae-v2-candidate-generator-swagger.yaml
@@ -143,6 +143,7 @@ components:
         - materializationEnabled
         - usedAi
         - aiCostUsd
+        - loopDetected
       properties:
         jobId:
           type: string
@@ -210,6 +211,21 @@ components:
         aiCostUsd:
           type: number
           description: Soma dos custos de IA em USD encontrados nos outputPayloads persistidos do job.
+        loopDetected:
+          type: boolean
+          description: Indica que o backend detectou repetição de etapas em job aberto, sinalizando ciclo operacional.
+        loopLabel:
+          type: string
+          nullable: true
+          description: Rótulo operacional para a UI exibir quando o job está em ciclo.
+        loopReason:
+          type: string
+          nullable: true
+          description: Explicação persistida pelo backend sobre a repetição de etapas do job aberto.
+        repeatedStageCount:
+          type: integer
+          nullable: true
+          description: Quantidade de etapas que aparecem mais de uma vez no histórico do job.
         createdAt:
           type: string
           format: date-time

--- a/frontend/src/api/oprm/useOprmNichoCnaeV2Jobs.ts
+++ b/frontend/src/api/oprm/useOprmNichoCnaeV2Jobs.ts
@@ -21,6 +21,10 @@ export interface OprmNichoCnaeV2JobSummary {
   actionUrl: string | null;
   usedAi: boolean | null;
   aiCostUsd: number | string | null;
+  loopDetected: boolean | null;
+  loopLabel: string | null;
+  loopReason: string | null;
+  repeatedStageCount: number | null;
   createdAt: string | null;
   updatedAt: string | null;
 }

--- a/frontend/src/pages/oprm/OprmNichoCnaeV2PipelinePage.tsx
+++ b/frontend/src/pages/oprm/OprmNichoCnaeV2PipelinePage.tsx
@@ -73,6 +73,7 @@ function formatJobId(jobId: string) {
 }
 
 function explainStatus(job: OprmNichoCnaeV2JobSummary, open: boolean) {
+  if (open && job.loopDetected) return job.loopLabel ?? "Em ciclo";
   if (open) return "Aguardando processamento";
   if (job.outcomeStatus === "FAILURE") return "Fracasso";
   if (job.outcomeStatus === "SUCCESS") return "Sucesso";
@@ -98,6 +99,9 @@ function simplifyDecisionReason(reason: string | null | undefined) {
 }
 
 function getOperatorNextAction(job: OprmNichoCnaeV2JobSummary, open: boolean) {
+  if (open && job.loopDetected) {
+    return "Acompanhar o ciclo; cancelar apenas se estiver preso por tempo excessivo.";
+  }
   if (open) return "Aguardar o executor continuar este job.";
   if (job.outcomeMessage) return job.outcomeMessage;
   if (job.lastStageStatus === "FAILED") {
@@ -110,6 +114,7 @@ function getOperatorNextAction(job: OprmNichoCnaeV2JobSummary, open: boolean) {
 }
 
 function decisionBadgeClass(job: OprmNichoCnaeV2JobSummary, open: boolean) {
+  if (open && job.loopDetected) return "badge text-bg-info";
   if (open) return "badge text-bg-warning";
   if (job.outcomeStatus === "FAILURE") return "badge text-bg-danger";
   if (job.outcomeStatus === "SUCCESS") return "badge text-bg-success";
@@ -157,9 +162,9 @@ function JobsTable({
             const stageName = formatStage(
               open ? job.currentStageCode : job.lastStageCode,
             );
-            const simplifiedReason = simplifyDecisionReason(
-              job.finalDecisionReason,
-            );
+            const simplifiedReason = job.loopDetected
+              ? (job.loopReason ?? "Job aberto repetindo etapas de pesquisa.")
+              : simplifyDecisionReason(job.finalDecisionReason);
             const nextAction = getOperatorNextAction(job, open);
             return (
               <tr key={job.jobId}>
@@ -177,6 +182,14 @@ function JobsTable({
                   <span className="oprm-v2-job-table__stage" title={stageName}>
                     {stageName}
                   </span>
+                  {open && job.loopDetected ? (
+                    <div className="small text-info fw-semibold mt-1">
+                      Ciclo detectado
+                      {job.repeatedStageCount
+                        ? ` · ${job.repeatedStageCount} etapas repetidas`
+                        : ""}
+                    </div>
+                  ) : null}
                 </td>
                 <td>
                   <span


### PR DESCRIPTION
### Motivation
- Improve observability when an open NichoCNAE v2 job is repeatedly re-running the same stages instead of progressing, so the UI can show a backend-validated signal rather than inferring it client-side.

### Description
- Add loop detection to the backend by counting repeated stage codes with `repeatedStageCount` and exposing `loopDetected`, `loopLabel` and `loopReason` in `CandidateGeneratorCnaeJobSummary` and job listing responses.
- Implement helper methods `loopDetected`, `loopLabel`, `loopReason` and `repeatedStageCount` in `BackendCandidateGeneratorService` using Java streams and grouping to compute the signal from stage history.
- Update API schema (`swagger.yaml`) and the frontend types (`useOprmNichoCnaeV2Jobs.ts`) and UI (`OprmNichoCnaeV2PipelinePage.tsx`) to surface the loop label, reason, badge styling and a short summary in the jobs table when `loopDetected` is true.
- Add an automated unit test `listJobsForCnaeShowsOpenJobLoopDetectedByBackend` to verify the backend exposes loop fields for an open job that repeats stages, and update changelog/docs to mention the new observability feature.

### Testing
- Ran backend unit tests including `BackendCandidateGeneratorServiceTest`, and the new `listJobsForCnaeShowsOpenJobLoopDetectedByBackend` test passed.
- Built and type-checked the frontend code paths affected by the new fields and UI branches without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a39534edecc83218f9fa78e2f4d92ce)