### PR TITLE
NichoCNAE v2: anti-cycle detection and controlled-failure on research loops

### DIFF
--- a/docs/canonical/oprm-canon.v1.md
+++ b/docs/canonical/oprm-canon.v1.md
@@ -55,6 +55,9 @@ Evitar fechamento prematuro de `import run` que destrói a totalização de mark
 ## Regra obrigatória — pesquisa inicial NichoCNAE de realidade operacional
 
 - A pesquisa inicial do pipeline OPRM NichoCNAE deve operar sempre no modo `ROUTINE_REALITY_RESEARCH`.
+- O CNAE deve ser tratado como público amplo demais para oferta e comunicação de alta assertividade; ele é apenas ponto de partida estatístico, fonte de volume e trilha de auditoria.
+- O objetivo primário do fluxo NichoCNAE é transformar o CNAE amplo em um subnicho operacional abordável, com pessoa executora, situação de trabalho, rotina, linguagem e contexto de compra suficientemente claros para alimentar uma oferta futura.
+- A pesquisa na internet existe para entender a realidade concreta desse subnicho antes de qualquer tese de produto: tarefas, canais, aquisição de clientes, preço/cobrança, dúvidas, dificuldades, vocabulário, recorrência, evidências públicas e sinais de vida operacional no Brasil.
 - O objetivo desse modo é definir um nicho/subnicho operacional suficientemente claro a partir do CNAE, com recorte de público executor, contexto de atuação, rotina observável, canais de aquisição/atendimento, recorrência e sinais públicos mínimos que sirvam como insumo para a próxima fase.
 - A pesquisa deve parar na definição qualificada do nicho e na descrição realista da rotina/contexto operacional; ela não deve aprofundar tese de dor, hipótese, mecanismo, produto, campanha, oferta, promessa comercial, landing page ou tese de experimento. Dor, mecanismo e demais aspectos comerciais serão tratados em pipeline posterior próprio.
 - Termos de solução, como IA, automação, sistema, app, software, ferramenta, curso ou marketing digital, não podem direcionar a pesquisa inicial quando vierem apenas de enquadramento comercial do nome do candidato.
@@ -84,6 +87,17 @@ Evitar fechamento prematuro de `import run` que destrói a totalização de mark
 - Quando o mesmo job for reaberto após reprovação do gate de qualidade, a etapa `oprmNicheResearchSeedBuilder` deve receber automaticamente o status anterior, `proximoMovimentoCodigo`, `proximoMovimento` e notas compactas do gate anterior para mudar subnicho, queries e estratégia de fontes, evitando repetir a mesma causa dominante de reprovação.
 - A etapa `oprmNicheResearchSeedBuilder` deve rejeitar objetivos e termos que direcionem busca por produto, oferta, campanha ou solução quando não fizerem parte literal da descrição CNAE.
 - A etapa `oprmSourceFetcher` deve propagar para o snapshot curto a classificação da fonte definida na busca: `sourceIntent`, `routineEvidenceScore`, `commercialPageRisk` e `solutionLanguageRisk`, sem armazenar HTML completo.
+
+## Regra obrigatória — anti-ciclo e uso controlado de IA no NichoCNAE v2
+
+- O pipeline NichoCNAE v2 não deve repetir indefinidamente o mesmo circuito de etapas quando não houver ganho novo de conhecimento sobre o subnicho; repetição sem nova evidência é falha controlada, não pesquisa em andamento.
+- Cada job deve manter um orçamento operacional por subnicho, incluindo limite de voltas por etapa, limite de pesquisas sem fontes novas, limite de replanejamentos de query, limite de chamadas de IA e custo máximo em dólar antes de encerrar com decisão auditável.
+- O avanço entre etapas deve ser orientado por progresso mensurável: novo subnicho candidato, nova fonte pública útil, nova evidência de rotina, novo sinal de aquisição/cobrança/recorrência, ou eliminação objetiva de um caminho ruim. Sem um desses ganhos, a próxima ação deve ser trocar recorte, concluir como sem evidência suficiente ou pedir decisão humana.
+- A IA pode ser usada como ferramenta de decisão e síntese, mas não como motor livre de tentativa infinita. Chamadas de IA devem acontecer somente em pontos de alto impacto: escolher/renomear subnicho, planejar queries quando a busca determinística travar, sintetizar evidências, decidir próximo movimento após reprovação e resumir aprendizado para a tela.
+- Antes de qualquer nova chamada de IA por reprocessamento, o executor deve enviar ao prompt o histórico compacto do job: etapas já repetidas, fontes rejeitadas, queries já testadas, causa dominante da reprovação e orçamento restante. A resposta deve obrigatoriamente escolher entre mudar recorte, mudar estratégia de fonte, encerrar sem evidência ou pedir intervenção humana.
+- Quando o job repetir o mesmo trio ou circuito de etapas sem avanço funcional, o executor deve registrar `CONTROLLED_FAILURE` com motivo de negócio claro, custo acumulado, evidências tentadas e recomendação objetiva para nova tentativa em outro subnicho, em vez de manter o job aberto.
+- A UI deve mostrar a situação em linguagem de negócio: “pesquisa sem ganho novo”, “sem fonte pública suficiente”, “subnicho amplo demais”, “recorte precisa mudar” ou “limite de custo atingido”, evitando que o usuário interprete ciclo técnico como progresso real.
+- O uso de IA deve continuar auditado por job/etapa com modelo, service tier, tokens, custo, request e response bruto; jobs sem registro na tabela de auditoria OpenAI devem ser apresentados como execução sem gasto de IA.
 
 ## Regra obrigatória — público-alvo MEI/autônomo no NichoCNAE
 

--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -1267,3 +1267,17 @@
 
 - A tela `/oprm/cnaes/:cnaeCode/pipeline-v2` passou a mostrar quando um job aberto está em ciclo operacional, usando campos explícitos do backend (`loopDetected`, `loopLabel`, `loopReason` e `repeatedStageCount`) em vez de inferência local no frontend.
 - O backend do OPRM NichoCNAE v2 agora classifica jobs abertos com repetição de etapas no histórico como “Em ciclo de pesquisa”, deixando claro ao usuário que o executor está repetindo pesquisa/reclassificação antes de decidir.
+
+## 2026-06-22 — Redefinição do fluxo anti-ciclo NichoCNAE v2
+
+- Registradas no cânone OPRM as premissas de negócio de que o CNAE é público amplo, o fluxo existe para descobrir subnicho operacional abordável e a pesquisa na internet deve entender a realidade concreta antes de qualquer oferta.
+- Definida regra anti-ciclo para NichoCNAE v2: repetição sem ganho novo de evidência deve virar falha controlada ou troca de recorte, não pesquisa infinita.
+- O uso de IA fica permitido como apoio em pontos de alto impacto, com orçamento por job/subnicho, histórico compacto no prompt e auditoria obrigatória de modelo, tokens, custo, request e response.
+- Causa-raiz tratada: o pipeline podia confundir ausência de evidência nova com necessidade de continuar replanejando, prendendo jobs em circuito entre etapas sem avanço comercial real.
+
+## 2026-06-22 — Execução da trava anti-ciclo NichoCNAE v2
+
+- Implementada no executor `oprm-coletor-mei` a trava anti-ciclo do NichoCNAE v2: antes de criar a próxima pendência, o job soma visitas por etapa e sequência sem ganho de informação.
+- Quando etapas de pesquisa repetem circuito sem nova evidência, fonte, query ou finalista útil, o executor registra falha controlada `MARKET_EVIDENCE` com `RESEARCH_LOOP_WITHOUT_INFORMATION_GAIN` em vez de abrir nova pendência.
+- Causa-raiz tratada: a continuidade era decidida apenas pelo `nextStageCode` da etapa atual, sem orçamento de repetição por job/subnicho.
+- Prevenção de recorrência: teste unitário cobre o caso de `source-fetcher-reranker` tentando voltar para `adaptive-query-planner` após repetição sem ganho.

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnaev2/execution/NichoCnaeV2PendingExecutionService.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnaev2/execution/NichoCnaeV2PendingExecutionService.java
@@ -16,6 +16,8 @@ import org.springframework.stereotype.Service;
 public class NichoCnaeV2PendingExecutionService {
     private static final Logger log = LoggerFactory.getLogger(NichoCnaeV2PendingExecutionService.class);
     private static final int MAX_TECHNICAL_RETRIES_PER_ATTEMPT = 3;
+    private static final int MAX_STAGE_VISITS_PER_JOB = 3;
+    private static final int MAX_NO_INFORMATION_GAIN_STREAK = 3;
 
     private final NichoCnaeV2BackendClient backendClient;
     private final NichoCnaeV2StageDefinitions stageDefinitions;
@@ -64,6 +66,10 @@ public class NichoCnaeV2PendingExecutionService {
             Map<String, Object> input = inputFor(pending);
             StageResult result = new PipelineWorker(stage.processor())
                     .run(new StageContext(pending.jobId(), pending.stageExecutionId(), input));
+            if (shouldStopBecauseOfResearchLoop(stage, pending, input, result)) {
+                registerControlledResearchLoop(stage, pending, input, result);
+                return;
+            }
             String outputPayload = backendClient.toJson(result.output());
             Map<String, Object> completion = completionRequest(stage.stageCode(), result, outputPayload);
             backendClient.complete(stage, pending, completion);
@@ -100,6 +106,33 @@ public class NichoCnaeV2PendingExecutionService {
             reasonCode = "TECHNICAL_RETRY_LIMIT_EXCEEDED";
         }
         backendClient.fail(stage, pending, ex, failureType, reasonCode);
+    }
+
+    /** Registra falha controlada quando o job repete pesquisa sem ganho novo de evidência útil. */
+    private void registerControlledResearchLoop(
+            NichoCnaeV2StageDefinition stage,
+            NichoCnaeV2PendingExecution pending,
+            Map<String, Object> input,
+            StageResult result) {
+        Map<String, Object> diagnosticPayload = nextStageInputPayload(input, result, text(result.output().get("nextStageCode")));
+        String message = "Job NichoCNAE v2 encerrado por ciclo de pesquisa sem ganho novo: stage="
+                + stage.stageCode()
+                + "; jobId="
+                + pending.jobId()
+                + "; cnaeCode="
+                + pending.cnaeCode()
+                + "; stageVisitCounts="
+                + diagnosticPayload.get("stageVisitCounts")
+                + "; noInformationGainStreak="
+                + diagnosticPayload.get("noInformationGainStreak")
+                + "; nextRecommendedAction=trocar recorte de subnicho ou iniciar nova pesquisa manual com hipótese de público mais específica";
+        log.warn(message);
+        backendClient.fail(
+                stage,
+                pending,
+                new ControlledResearchLoopException(message),
+                "MARKET_EVIDENCE",
+                "RESEARCH_LOOP_WITHOUT_INFORMATION_GAIN");
     }
 
     /** Normaliza o contador de retry técnico ausente para zero antes de comparar com o limite operacional. */
@@ -230,7 +263,99 @@ public class NichoCnaeV2PendingExecutionService {
         payload.remove("nextStageCode");
         payload.putAll(result.output());
         payload.put("nextStageCode", nextStageCode);
+        payload.put("stageVisitCounts", updatedStageVisitCounts(input, result));
+        payload.put("noInformationGainStreak", updatedNoInformationGainStreak(input, result));
         return payload;
+    }
+
+    /** Decide se a próxima pendência criaria um ciclo operacional sem aprendizado suficiente para continuar. */
+    private boolean shouldStopBecauseOfResearchLoop(
+            NichoCnaeV2StageDefinition stage,
+            NichoCnaeV2PendingExecution pending,
+            Map<String, Object> input,
+            StageResult result) {
+        String nextStageCode = text(result.output().get("nextStageCode"));
+        if (nextStageCode.isBlank()) {
+            return false;
+        }
+        Map<String, Integer> visitCounts = updatedStageVisitCounts(input, result);
+        int currentStageVisits = visitCounts.getOrDefault(stage.stageCode(), 0);
+        int noInformationGainStreak = updatedNoInformationGainStreak(input, result);
+        boolean stageRepeatedTooMuch = currentStageVisits >= MAX_STAGE_VISITS_PER_JOB && noInformationGain(result);
+        boolean noGainTooLong = noInformationGainStreak >= MAX_NO_INFORMATION_GAIN_STREAK;
+        boolean loopingBetweenResearchStages = isResearchLoopStage(stage.stageCode()) && isResearchLoopStage(nextStageCode);
+        if (loopingBetweenResearchStages && (stageRepeatedTooMuch || noGainTooLong)) {
+            log.warn(
+                    "Ciclo de pesquisa NichoCNAE v2 detectado antes de criar próxima etapa (stage={}, nextStage={}, jobId={}, cnaeCode={}, visits={}, noGainStreak={})",
+                    stage.stageCode(),
+                    nextStageCode,
+                    pending.jobId(),
+                    pending.cnaeCode(),
+                    currentStageVisits,
+                    noInformationGainStreak);
+            return true;
+        }
+        return false;
+    }
+
+    /** Atualiza o contador de visitas por etapa preservado no payload funcional do job. */
+    private Map<String, Integer> updatedStageVisitCounts(Map<String, Object> input, StageResult result) {
+        Map<String, Integer> visitCounts = intMap(input.get("stageVisitCounts"));
+        String currentStage = text(result.output().get("stage"));
+        if (!currentStage.isBlank()) {
+            visitCounts.put(currentStage, visitCounts.getOrDefault(currentStage, 0) + 1);
+        }
+        return visitCounts;
+    }
+
+    /** Atualiza a sequência de etapas que não acrescentaram evidência, fonte ou query nova ao job. */
+    private int updatedNoInformationGainStreak(Map<String, Object> input, StageResult result) {
+        int current = integer(input.get("noInformationGainStreak")) == null ? 0 : integer(input.get("noInformationGainStreak"));
+        return noInformationGain(result) ? current + 1 : 0;
+    }
+
+    /** Identifica decisões que representam ausência objetiva de avanço de pesquisa. */
+    private boolean noInformationGain(StageResult result) {
+        Map<String, Object> output = result.output();
+        String status = text(result.status()).toUpperCase();
+        String decision = text(output.getOrDefault(
+                        "planDecision",
+                        output.getOrDefault("sourceFetchDecision", output.getOrDefault("tournamentDecision", ""))))
+                .toUpperCase();
+        Integer plannedQueryCount = integer(output.get("plannedQueryCount"));
+        Integer selectedSourceCount = integer(output.get("selectedSourceCount"));
+        Integer finalistCount = integer(output.get("finalistCount"));
+        return status.contains("NO_RESEARCH_GAIN")
+                || status.contains("NO_FETCHABLE_DIRECT_SOURCE")
+                || status.contains("NO_VIABLE_SUBNICHE")
+                || decision.contains("NO_RESEARCH_GAIN")
+                || decision.contains("NO_FETCHABLE_DIRECT_SOURCE")
+                || decision.contains("NO_VIABLE_SUBNICHE")
+                || Integer.valueOf(0).equals(plannedQueryCount)
+                || Integer.valueOf(0).equals(selectedSourceCount)
+                || Integer.valueOf(0).equals(finalistCount);
+    }
+
+    /** Limita a trava aos estágios que historicamente podem formar circuito de replanejamento de pesquisa. */
+    private boolean isResearchLoopStage(String stageCode) {
+        return "adaptive-query-planner".equals(stageCode)
+                || "candidate-tournament".equals(stageCode)
+                || "source-fetcher-reranker".equals(stageCode)
+                || "reprocess-controller".equals(stageCode);
+    }
+
+    /** Converte mapa livre do payload em contadores inteiros usados pela trava anti-ciclo. */
+    private Map<String, Integer> intMap(Object value) {
+        Map<String, Integer> converted = new LinkedHashMap<>();
+        if (value instanceof Map<?, ?> map) {
+            map.forEach((key, val) -> {
+                Integer parsed = integer(val);
+                if (parsed != null) {
+                    converted.put(String.valueOf(key), parsed);
+                }
+            });
+        }
+        return converted;
     }
 
     /** Converte metadado opcional da etapa para inteiro sem quebrar avanço quando ausente. */
@@ -239,5 +364,18 @@ public class NichoCnaeV2PendingExecutionService {
             return number.intValue();
         }
         return value == null || String.valueOf(value).isBlank() ? null : Integer.valueOf(String.valueOf(value));
+    }
+
+    /** Extrai texto normalizado de campos livres do payload sem quebrar valores ausentes. */
+    private String text(Object value) {
+        return value == null ? "" : String.valueOf(value).trim();
+    }
+
+    /** Exceção operacional usada para registrar falha controlada por ciclo de pesquisa sem ganho novo. */
+    private static final class ControlledResearchLoopException extends RuntimeException {
+        /** Inicializa a exceção com mensagem de negócio persistível no backend. */
+        private ControlledResearchLoopException(String message) {
+            super(message);
+        }
     }
 }

--- a/oprm-coletor-mei/src/test/java/com/marketinghub/nichocnaev2/execution/NichoCnaeV2PendingExecutionServiceTest.java
+++ b/oprm-coletor-mei/src/test/java/com/marketinghub/nichocnaev2/execution/NichoCnaeV2PendingExecutionServiceTest.java
@@ -4,6 +4,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
@@ -159,4 +160,48 @@ class NichoCnaeV2PendingExecutionServiceTest {
                 any(NichoCnaeV2StageDefinition.class), eq(pending), any(), eq(2), eq(2));
     }
 
+    /** Deve encerrar como falha de evidência quando o job repete pesquisa sem ganho novo. */
+    @Test
+    void failsControlledResearchLoopBeforeCreatingAnotherPendingStage() {
+        NichoCnaeV2BackendClient backendClient = mock(NichoCnaeV2BackendClient.class);
+        NichoCnaeV2StageDefinitions stageDefinitions = new NichoCnaeV2StageDefinitions();
+        NichoCnaeV2PendingExecutionService service = new NichoCnaeV2PendingExecutionService(backendClient, stageDefinitions);
+        NichoCnaeV2PendingExecution pending = new NichoCnaeV2PendingExecution(
+                "211",
+                "nichocnae-v2-candidate-3-job-3",
+                "7319002",
+                "Outras atividades profissionais, científicas e técnicas",
+                9L,
+                3L,
+                1,
+                0,
+                1,
+                false,
+                "{\"sourceCandidates\":[],\"stageVisitCounts\":{\"source-fetcher-reranker\":2},\"noInformationGainStreak\":2}",
+                Map.of());
+        when(backendClient.listPending(any())).thenAnswer(invocation -> {
+            NichoCnaeV2StageDefinition stage = invocation.getArgument(0);
+            return "source-fetcher-reranker".equals(stage.stageCode()) ? List.of(pending) : List.of();
+        });
+        when(backendClient.parseInput(pending.inputPayload()))
+                .thenReturn(Map.of(
+                        "sourceCandidates",
+                        List.of(),
+                        "stageVisitCounts",
+                        Map.of("source-fetcher-reranker", 2),
+                        "noInformationGainStreak",
+                        2));
+
+        service.processAllPending();
+
+        verify(backendClient).fail(
+                any(NichoCnaeV2StageDefinition.class),
+                eq(pending),
+                any(RuntimeException.class),
+                eq("MARKET_EVIDENCE"),
+                eq("RESEARCH_LOOP_WITHOUT_INFORMATION_GAIN"));
+        verify(backendClient, never()).complete(any(NichoCnaeV2StageDefinition.class), eq(pending), any());
+        verify(backendClient, never())
+                .createNextStage(any(NichoCnaeV2StageDefinition.class), eq(pending), any(), any(), any());
+    }
 }


### PR DESCRIPTION
### Motivation

- Prevent jobs in the NichoCNAE v2 pipeline from repeating research-stage circuits indefinitely when no new public evidence is discovered. 
- Provide operational visibility and enforce business rules that the CNAE is a broad starting point and research must converge to actionable subniches or fail fast.

### Description

- Added anti-cycle rules to documentation (`docs/canonical/oprm-canon.v1.md` and `docs/registros/oprm1.md`) describing limits, IA usage audit, and expected behavior when research yields no new information. 
- Implemented loop detection in the executor `NichoCnaeV2PendingExecutionService` by introducing visit and no-information counters (`MAX_STAGE_VISITS_PER_JOB`, `MAX_NO_INFORMATION_GAIN_STREAK`), the decision method `shouldStopBecauseOfResearchLoop(...)`, and supporting helpers (`updatedStageVisitCounts`, `updatedNoInformationGainStreak`, `noInformationGain`, `intMap`, `text`).
- When a research loop without information gain is detected, the service now logs a warning and registers a controlled failure via `registerControlledResearchLoop(...)`, failing the job with `failureType=MARKET_EVIDENCE` and `reasonCode=RESEARCH_LOOP_WITHOUT_INFORMATION_GAIN`, instead of creating another pending stage. 
- Preserved functional payload between stages now includes `stageVisitCounts` and `noInformationGainStreak` via `nextStageInputPayload(...)` so downstream steps can reason about prior visits and streaks. 
- Added an operational exception `ControlledResearchLoopException` and updated unit tests to cover the new behavior in `NichoCnaeV2PendingExecutionServiceTest`. 

### Testing

- Ran the updated unit test suite including `NichoCnaeV2PendingExecutionServiceTest`, which exercises normal completion and the new `failsControlledResearchLoopBeforeCreatingAnotherPendingStage` scenario, and all tests passed. 
- Executed the full JVM unit tests with `./gradlew test` and confirmed the new assertions for backend `fail(...)` invocation and the absence of `complete(...)`/`createNextStage(...)` calls succeed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a396720f8b48321878606a8585fecf7)