### PR TITLE
Migrate MOIS sales-page analysis from OpenAI Batch to Responses Flex (`service_tier: "flex"`)

### DIFF
--- a/docs/canonical/mois-worker-canon.v1.md
+++ b/docs/canonical/mois-worker-canon.v1.md
@@ -43,7 +43,7 @@ O worker processa de forma assíncrona jobs `PENDING` da biblioteca de páginas 
 - `visual_json`: sinais visuais relevantes;
 - `image_json`: dados de imagem relevantes;
 - `analysis_notes`: observações adicionais;
-- `request_payload_json`: payload literal enviado ao modelo (JSONL da requisição batch) para auditoria;
+- `request_payload_json`: payload literal enviado ao modelo via Responses Flex para auditoria;
 - `parser_version`, `prompt_version`, `model_name`: rastreabilidade técnica.
 
 ## 6. Regras de fonte (source)
@@ -62,12 +62,12 @@ O worker seleciona a fonte por ciclo com a seguinte ordem canônica:
 
 ### 7.2 OpenAI
 - `openai.model` → `${OPENAI_MODEL:gpt-5.2}`
-- `openai.batch-poll-interval-ms` → `${OPENAI_BATCH_POLL_INTERVAL_MS:2000}`
-- `openai.batch-timeout-ms` → `${OPENAI_BATCH_TIMEOUT_MS:1800000}`
+- `openai.request-timeout-ms` → `${OPENAI_REQUEST_TIMEOUT_MS:900000}`
 - Para payload de `/v1/responses`, o formato estruturado deve usar `text.format` (não usar `response_format`).
+- Toda análise comercial OpenAI do MOIS Sales Library deve enviar `service_tier: "flex"` no payload auditado.
 
-## 8. Regra canônica de timeout OpenAI Batch (MOIS Worker)
-Para integrações batch com OpenAI no contexto do MOIS Worker, o timeout canônico é de **30 minutos** (`1800000 ms` / `PT30M`), e não deve ser reduzido sem versionamento explícito deste cânone.
+## 8. Regra canônica de processamento OpenAI Flex (MOIS Worker)
+Para análises comerciais OpenAI no contexto do MOIS Worker, o modo canônico é **Responses API com `service_tier: "flex"`**, sem criação de Batch API. O timeout canônico da chamada síncrona Flex é de **15 minutos** (`900000 ms` / `PT15M`), alinhado ao caráter assíncrono/baixo custo da etapa.
 
 
 ## 8.1 Taxonomia canônica de status (monitoramento de fetching)
@@ -79,7 +79,7 @@ Para acompanhamento operacional na tela de Biblioteca de Páginas de Vendas, o s
 2. `FETCHING`
    - Worker em coleta/parsing da página de origem.
 3. `ANALYZING`
-   - Conteúdo já coletado e enviado para processamento OpenAI (batch em andamento).
+   - Conteúdo já coletado e enviado para processamento OpenAI Flex.
 4. `RETRY_WAIT`
    - Falha transitória detectada; job aguardando nova tentativa automática.
 5. `DONE`
@@ -89,14 +89,14 @@ Para acompanhamento operacional na tela de Biblioteca de Páginas de Vendas, o s
 
 ### 8.1.2 Regras mínimas de exibição na UI
 - Exibir badge por status e tooltip com definição operacional curta.
-- Exibir coluna `Último evento` com motivo objetivo da etapa atual (ex.: `batch.status=running`, `connect timeout`, `output_file_id ausente`).
+- Exibir coluna `Último evento` com motivo objetivo da etapa atual (ex.: `openai.flex=running`, `connect timeout`, `responses output ausente`).
 - Exibir coluna `Tempo em etapa` (`agora - updatedAt`) para detectar stuck jobs em `FETCHING`/`ANALYZING`.
 - Exibir `Tentativas` + `Próxima tentativa em` quando status for `RETRY_WAIT`.
 - Exibir CTA de diagnóstico (link para detalhe do job) quando status for `FAILED`.
 
 ### 8.1.3 Critérios de transição
 - `PENDING -> FETCHING`: claim confirmado pelo backend.
-- `FETCHING -> ANALYZING`: coleta concluída e requisição batch enviada com sucesso.
+- `FETCHING -> ANALYZING`: coleta concluída e requisição Responses Flex enviada com sucesso.
 - `ANALYZING -> DONE`: output válido persistido em `:complete`.
 - `ANALYZING -> RETRY_WAIT`: timeout/intermitência recuperável com orçamento de retry restante.
 - `FETCHING|ANALYZING|RETRY_WAIT -> FAILED`: erro terminal de contrato, parsing irrecuperável ou retries esgotados.
@@ -105,11 +105,10 @@ Para acompanhamento operacional na tela de Biblioteca de Páginas de Vendas, o s
 - O worker **não acessa banco diretamente**; todo tráfego de dados passa pelo backend principal.
 - Transições de estado devem ocorrer exclusivamente pelos endpoints do backend MOIS.
 - Falhas devem ser registradas com contexto e stack trace para diagnóstico de causa-raiz.
-- Erros de contrato/integração OpenAI retornados no output do batch (ex.: `response.status_code >= 400` com `response.body.error`) são falhas terminais e devem:
-  1. obter e processar também o arquivo `error_file_id` (JSONL) do batch para diagnóstico completo da causa-raiz;
-  2. converter os detalhes relevantes do erro em mensagem legível com `status`, `requestId`, `type`, `code` e `message`;
-  3. enviar a falha ao endpoint `jobs/{jobId}:fail` para persistência;
-  4. manter os detalhes disponíveis para exibição ao usuário na tela de jobs (`errorMessage`).
+- Erros de contrato/integração OpenAI retornados pelo Responses Flex são falhas terminais e devem:
+  1. converter os detalhes relevantes do erro em mensagem legível com `type`, `code` e `message`;
+  2. enviar a falha ao endpoint `jobs/{jobId}:fail` para persistência;
+  3. manter os detalhes disponíveis para exibição ao usuário na tela de jobs (`errorMessage`).
 
 ## 10. Substituição documental
 Este documento é o único cânone ativo para o worker do MOIS.
@@ -166,7 +165,7 @@ sequenceDiagram
     participant API as Backend MOIS (/api/mois/sales-library)
     participant WK as MOIS Sales Library Worker
     participant PR as Prompt Builder (Worker)
-    participant OAI as OpenAI Batch (/v1/responses)
+    participant OAI as OpenAI Responses Flex (/v1/responses)
     participant DB as MySQL 5.7
 
     %% Banco destacado com cor própria
@@ -201,7 +200,7 @@ sequenceDiagram
     Note over WK,OAI: 4) Prompt/schema de análise
     WK->>PR: Monta prompt com urlCanonical + body.text()
     PR-->>WK: prompt final + promptVersion + parserVersion
-    WK->>OAI: Batch line -> /v1/responses<br/>model + input + text.format.type=json_object
+    WK->>OAI: POST /v1/responses<br/>model + service_tier=flex + input + text.format.type=json_object
     OAI-->>WK: output JSON (score_total, sections_json, ...)
     WK->>WK: Parse do output e validação dos campos obrigatórios
     end
@@ -549,7 +548,7 @@ Critérios de aceite da Fase 5:
 
 A partir de 2026-06-04, a Biblioteca de Páginas de Vendas considera concluída a troca operacional para o modelo de duas tabelas. O estado atual da operação deve ser lido e escrito somente em `mois_sales_page`, e o histórico/auditoria de execuções deve ser lido e escrito somente em `mois_sales_page_job_execution`.
 
-A partir de 2026-06-11, toda análise OpenAI concluída de página de venda deve registrar no backend o modelo usado, tokens de entrada, tokens de saída e custo USD calculado em modo batch. O estado consolidado da página em `mois_sales_page` deve expor esse custo para decisão comercial, e o histórico em `mois_sales_page_job_execution` deve manter a auditoria da execução que gerou o valor.
+A partir de 2026-06-11, toda análise OpenAI concluída de página de venda deve registrar no backend o modelo usado, tokens de entrada, tokens de saída e custo USD calculado em modo flex. O estado consolidado da página em `mois_sales_page` deve expor esse custo para decisão comercial, e o histórico em `mois_sales_page_job_execution` deve manter a auditoria da execução que gerou o valor.
 
 Tabelas legadas congeladas:
 

--- a/docs/registros/mois1.md
+++ b/docs/registros/mois1.md
@@ -1765,3 +1765,10 @@ Arquivos principais:
 
 - Incluído no contrato do backend o campo de formato vendido do produto, classificado a partir dos textos persistidos da página/Hotmart para diferenciar curso em vídeo, e-book/PDF, consultoria/mentoria, comunidade/assinatura ou software/ferramenta.
 - Atualizada a tela de detalhe `/mois/sales-pages-library/:pageId` para exibir o card **O que está sendo vendido** no dossiê do produto, mantendo a regra de verdade da tela: o frontend apenas apresenta o dado retornado pelo backend.
+
+
+## 2026-06-22 — Análise comercial da Biblioteca Sales Pages em OpenAI Flex
+
+- Alterada a integração OpenAI da etapa de análise comercial do `mois-sales-library-worker` para usar Responses API com `service_tier: "flex"`, removendo o fluxo operacional de criação/polling da Batch API.
+- Atualizado o cânone MOIS para refletir que a análise comercial usa Responses Flex, timeout canônico de 15 minutos e payload auditado com `service_tier: "flex"`.
+- Ajustado o teste de contrato do analisador para impedir regressão para payload sem modo Flex.

--- a/mois-sales-library-worker/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/pipeline/pageanalysis/OpenAiProperties.java
+++ b/mois-sales-library-worker/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/pipeline/pageanalysis/OpenAiProperties.java
@@ -10,8 +10,7 @@ public record OpenAiProperties(
         String apiKey,
         String baseUrl,
         String model,
-        long batchPollIntervalMs,
-        long batchTimeoutMs,
+        long requestTimeoutMs,
         String apiKeyFile
 ) {
     private static final Logger LOGGER = Logger.getLogger(OpenAiProperties.class.getName());
@@ -45,13 +44,8 @@ public record OpenAiProperties(
         return (model == null || model.isBlank()) ? "gpt-5.2" : model.trim();
     }
 
-    /** Normaliza o intervalo de consulta do Batch da OpenAI. */
-    public long normalizedBatchPollIntervalMs() {
-        return batchPollIntervalMs <= 0 ? 2000 : batchPollIntervalMs;
-    }
-
-    /** Normaliza o timeout máximo do Batch da OpenAI. */
-    public long normalizedBatchTimeoutMs() {
-        return batchTimeoutMs <= 0 ? 300000 : batchTimeoutMs;
+    /** Normaliza o timeout máximo da chamada Responses Flex da OpenAI. */
+    public long normalizedRequestTimeoutMs() {
+        return requestTimeoutMs <= 0 ? 900000 : requestTimeoutMs;
     }
 }

--- a/mois-sales-library-worker/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/pipeline/pageanalysis/OpenAiSalesPageAnalyzer.java
+++ b/mois-sales-library-worker/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/pipeline/pageanalysis/OpenAiSalesPageAnalyzer.java
@@ -1,30 +1,25 @@
 package com.marketinghub.mois.bibliotecapaginavenda.worker.v1.pipeline.pageanalysis;
 
-import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import java.nio.charset.StandardCharsets;
-import java.time.Instant;
+import java.math.BigDecimal;
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.MediaType;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.stereotype.Component;
-import org.springframework.util.LinkedMultiValueMap;
-import org.springframework.util.MultiValueMap;
 import org.springframework.util.StringUtils;
 import org.springframework.web.client.RestClient;
 
 /**
- * Executa a análise comercial de páginas de venda via OpenAI Batch e normaliza o JSON retornado.
+ * Executa a análise comercial de páginas de venda via OpenAI Responses em modo Flex e normaliza o JSON retornado.
  */
 @Component
 @Slf4j
 public class OpenAiSalesPageAnalyzer {
-
-    private static final Set<String> TERMINAL_BATCH_STATUSES = Set.of("completed", "failed", "expired", "cancelled");
 
     private final RestClient restClient;
     private final OpenAiProperties properties;
@@ -35,39 +30,33 @@ public class OpenAiSalesPageAnalyzer {
      */
     public OpenAiSalesPageAnalyzer(RestClient.Builder builder, OpenAiProperties properties) {
         this.properties = properties;
-        this.restClient = builder.baseUrl(properties.normalizedBaseUrl())
+        SimpleClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory();
+        requestFactory.setConnectTimeout(Duration.ofSeconds(30));
+        requestFactory.setReadTimeout(Duration.ofMillis(properties.normalizedRequestTimeoutMs()));
+        this.restClient = builder.requestFactory(requestFactory).baseUrl(properties.normalizedBaseUrl())
                 .defaultHeader("Authorization", "Bearer " + properties.resolvedApiKey())
                 .defaultHeader("OpenAI-Beta", "reasoning=1")
                 .build();
     }
 
     /**
-     * Envia o texto capturado da página para análise comercial e retorna o diagnóstico estruturado.
+     * Envia o texto capturado da página para análise comercial em modo Flex e retorna o diagnóstico estruturado.
      */
     public SalesPageAnalysisResult analyze(long jobId, long pageId, String canonicalUrl, String htmlBodyText) {
         if (!StringUtils.hasText(properties.resolvedApiKey())) {
             throw new IllegalStateException("OpenAI api key não configurada para análise de sales page");
         }
-        String payloadLine = buildBatchLine(pageId, canonicalUrl, htmlBodyText);
-        log.info("MOIS sales-library enviando request cru para OpenAI. jobId={}, requestPayload={}", jobId, payloadLine);
-        String inputFileId = uploadInputFile(payloadLine);
-        BatchInfo batch = createBatch(inputFileId);
-        BatchInfo completed = awaitBatch(batch);
-        if (!"completed".equalsIgnoreCase(completed.status())) {
-            throw new IllegalStateException(buildBatchTerminalErrorMessage(completed));
-        }
-        if (!StringUtils.hasText(completed.outputFileId())) {
-            throw new IllegalStateException(buildBatchMissingOutputMessage(completed));
-        }
-        String output = downloadOutput(completed.outputFileId());
-        log.info("MOIS sales-library recebeu resposta crua da OpenAI. jobId={}, rawResponse={}", jobId, output);
-        return parseBatchOutput(output, payloadLine);
+        String requestPayload = buildResponsesRequestPayload(pageId, canonicalUrl, htmlBodyText);
+        log.info("MOIS sales-library enviando request cru para OpenAI. jobId={}, requestPayload={}", jobId, requestPayload);
+        String responsePayload = executeFlexResponsesRequest(requestPayload);
+        log.info("MOIS sales-library recebeu resposta crua da OpenAI. jobId={}, rawResponse={}", jobId, responsePayload);
+        return parseResponsesOutput(responsePayload, requestPayload);
     }
 
     /**
-     * Monta a linha JSONL enviada ao endpoint Batch da OpenAI.
+     * Monta o JSON enviado diretamente ao endpoint Responses da OpenAI em modo Flex.
      */
-    String buildBatchLine(long pageId, String canonicalUrl, String htmlBodyText) {
+    String buildResponsesRequestPayload(long pageId, String canonicalUrl, String htmlBodyText) {
         String prompt = "Analise a página de vendas para identificar por que este produto alcançou sucesso e devolva JSON válido com os campos: score_total (0-100), sections_json (objeto), copy_json (objeto), visual_json (objeto), image_json (objeto), analysis_notes (texto curto). "
                 + "A análise é diagnóstico de sucesso, não consultoria de melhoria: não inclua sugestões, recomendações, próximos passos, itens a adicionar/remover, nem chaves como recommended, suggestions, melhorias ou lacunas em nenhum campo. "
                 + "No campo image_json, explique somente a função persuasiva das imagens existentes no fluxo real: densidade visual, repetição de depoimentos/antes-e-depois, provas visuais, risco assumido de poluição visual e como isso sustenta ou prejudica a clareza da oferta já vencedora. "
@@ -75,152 +64,101 @@ public class OpenAiSalesPageAnalyzer {
                 + canonicalUrl + "\nConteúdo e resumo visual: " + htmlBodyText;
         try {
             return objectMapper.writeValueAsString(Map.of(
-                    "custom_id", "page-" + pageId,
-                    "method", "POST",
-                    "url", "/v1/responses",
-                    "body", Map.of(
-                            "model", properties.normalizedModel(),
-                            "input", List.of(
-                                    Map.of("role", "system", "content", "Você analisa páginas de venda e responde exclusivamente em JSON válido sem markdown."),
-                                    Map.of("role", "user", "content", prompt)
-                            ),
-                            "text", Map.of(
-                                    "format", Map.of("type", "json_object")
-                            )
+                    "model", properties.normalizedModel(),
+                    "service_tier", "flex",
+                    "metadata", Map.of("page_id", Long.toString(pageId)),
+                    "input", List.of(
+                            Map.of("role", "system", "content", "Você analisa páginas de venda e responde exclusivamente em JSON válido sem markdown."),
+                            Map.of("role", "user", "content", prompt)
+                    ),
+                    "text", Map.of(
+                            "format", Map.of("type", "json_object")
                     )
             ));
         } catch (JsonProcessingException e) {
-            throw new IllegalStateException("Falha ao serializar linha batch", e);
+            throw new IllegalStateException("Falha ao serializar request Responses Flex", e);
         }
     }
 
     /**
-     * Faz upload do arquivo JSONL de entrada da análise para a OpenAI.
+     * Executa a chamada síncrona ao endpoint Responses usando service_tier flex.
      */
-    private String uploadInputFile(String line) {
-        MultiValueMap<String, Object> multipart = new LinkedMultiValueMap<>();
-        multipart.add("purpose", "batch");
-        multipart.add("file", new org.springframework.core.io.ByteArrayResource((line + "\n").getBytes(StandardCharsets.UTF_8)) {
-            /**
-             * Retorna o nome do arquivo enviado no multipart.
-             */
-            @Override
-            public String getFilename() {
-                return "sales-page-analysis.jsonl";
-            }
-        });
-        FileUploadResponse response = restClient.post().uri("/files").contentType(MediaType.MULTIPART_FORM_DATA)
-                .body(multipart).retrieve().body(FileUploadResponse.class);
-        if (response == null || !StringUtils.hasText(response.id())) {
-            throw new IllegalStateException("Upload do arquivo batch falhou");
-        }
-        return response.id();
-    }
-
-    /**
-     * Cria o batch OpenAI para processar a linha JSONL enviada.
-     */
-    private BatchInfo createBatch(String inputFileId) {
-        BatchInfo response = restClient.post().uri("/batches")
+    private String executeFlexResponsesRequest(String requestPayload) {
+        String response = restClient.post().uri("/responses")
                 .contentType(MediaType.APPLICATION_JSON)
-                .body(Map.of("input_file_id", inputFileId, "endpoint", "/v1/responses", "completion_window", "24h"))
-                .retrieve().body(BatchInfo.class);
-        if (response == null || !StringUtils.hasText(response.id())) {
-            throw new IllegalStateException("Criação do batch falhou");
+                .body(requestPayload)
+                .retrieve()
+                .body(String.class);
+        if (!StringUtils.hasText(response)) {
+            throw new IllegalStateException("OpenAI Responses Flex retornou corpo vazio");
         }
         return response;
     }
 
     /**
-     * Aguarda o batch alcançar um status terminal dentro do timeout configurado.
+     * Interpreta o JSON de saída da OpenAI e devolve o resultado estruturado da análise.
      */
-    private BatchInfo awaitBatch(BatchInfo batch) {
-        Instant start = Instant.now();
-        BatchInfo current = batch;
-        while (!TERMINAL_BATCH_STATUSES.contains(current.status())) {
-            if (Instant.now().toEpochMilli() - start.toEpochMilli() > properties.normalizedBatchTimeoutMs()) {
-                throw new IllegalStateException("Timeout aguardando batch " + current.id());
-            }
-            try {
-                Thread.sleep(properties.normalizedBatchPollIntervalMs());
-            } catch (InterruptedException e) {
-                Thread.currentThread().interrupt();
-                throw new IllegalStateException(e);
-            }
-            current = restClient.get().uri("/batches/{id}", current.id()).retrieve().body(BatchInfo.class);
-            if (current == null || !StringUtils.hasText(current.status())) {
-                throw new IllegalStateException("Batch status inválido");
-            }
-        }
-        return current;
-    }
-
-    /**
-     * Baixa o arquivo de saída do batch concluído.
-     */
-    private String downloadOutput(String outputFileId) {
-        return restClient.get().uri("/files/{id}/content", outputFileId).retrieve().body(String.class);
-    }
-
-    /**
-     * Baixa o arquivo de erros do batch quando a OpenAI informa um error_file_id.
-     */
-    private String downloadErrorJsonl(BatchInfo batch) {
-        if (batch == null || !StringUtils.hasText(batch.errorFileId())) {
-            return "";
-        }
+    private SalesPageAnalysisResult parseResponsesOutput(String responsePayloadJson, String requestPayloadJson) {
         try {
-            String content = restClient.get().uri("/files/{id}/content", batch.errorFileId()).retrieve().body(String.class);
-            return content == null ? "" : content;
-        } catch (Exception ex) {
-            log.error("Falha ao baixar error_file_id da OpenAI. batchId={}, errorFileId={}", batch.id(), batch.errorFileId(), ex);
-            return "";
-        }
-    }
-
-    /**
-     * Interpreta o JSONL de saída da OpenAI e devolve o resultado estruturado da análise.
-     */
-    private SalesPageAnalysisResult parseBatchOutput(String outputJsonl, String requestPayloadJson) {
-        try {
-            String line = outputJsonl.lines().filter(StringUtils::hasText).findFirst().orElseThrow();
-            JsonNode root = objectMapper.readTree(line);
-            JsonNode statusCodeNode = root.path("response").path("status_code");
-            if (statusCodeNode.isInt() && statusCodeNode.asInt() >= 400) {
-                throw new IllegalStateException(buildBatchErrorMessage(root));
+            JsonNode root = objectMapper.readTree(responsePayloadJson);
+            JsonNode error = root.path("error");
+            if (!error.isMissingNode() && !error.isNull()) {
+                throw new IllegalStateException(buildResponsesErrorMessage(root));
             }
-            JsonNode lineError = root.path("error");
-            if (!lineError.isMissingNode() && !lineError.isNull()) {
-                throw new IllegalStateException("OpenAI batch retornou erro de linha: " + lineError.toString());
-            }
-            JsonNode outputText = root.path("response").path("body").path("output").get(0).path("content").get(0).path("text");
-            if (outputText.isMissingNode() || outputText.isNull()) {
-                outputText = root.path("response").path("body").path("output_text");
+            JsonNode outputText = findOutputText(root);
+            if (outputText.isMissingNode() || outputText.isNull() || !StringUtils.hasText(outputText.asText())) {
+                throw new IllegalStateException("OpenAI Responses Flex não retornou texto de saída");
             }
             JsonNode parsed = objectMapper.readTree(outputText.asText());
-            JsonNode usage = root.path("response").path("body").path("usage");
+            JsonNode usage = root.path("usage");
             Integer inputTokens = nullableInt(usage.path("input_tokens"));
             Integer outputTokens = nullableInt(usage.path("output_tokens"));
             return new SalesPageAnalysisResult(
-                    parsed.path("score_total").decimalValue(),
+                    parsed.path("score_total").isNumber() ? parsed.path("score_total").decimalValue() : BigDecimal.ZERO,
                     objectMapper.writeValueAsString(parsed.path("sections_json")),
                     objectMapper.writeValueAsString(parsed.path("copy_json")),
                     objectMapper.writeValueAsString(parsed.path("visual_json")),
                     objectMapper.writeValueAsString(parsed.path("image_json")),
-                    parsed.path("analysis_notes").asText("Análise gerada via OpenAI batch"),
+                    parsed.path("analysis_notes").asText("Análise gerada via OpenAI Responses Flex"),
                     requestPayloadJson,
-                    outputJsonl,
+                    responsePayloadJson,
                     "html-v1",
-                    "openai-batch-v1",
+                    "openai-flex-v1",
                     properties.normalizedModel(),
                     inputTokens,
                     outputTokens,
                     null
             );
         } catch (Exception e) {
-            log.error("Falha parse output batch OpenAI. output={}", outputJsonl, e);
-            throw new IllegalStateException("Falha ao interpretar output do batch OpenAI", e);
+            log.error("Falha parse output Responses Flex OpenAI. output={}", responsePayloadJson, e);
+            throw new IllegalStateException("Falha ao interpretar output do Responses Flex OpenAI", e);
         }
+    }
+
+    /**
+     * Localiza o texto final tanto no campo consolidado quanto na estrutura detalhada do Responses.
+     */
+    private JsonNode findOutputText(JsonNode root) {
+        JsonNode outputText = root.path("output_text");
+        if (!outputText.isMissingNode() && !outputText.isNull() && StringUtils.hasText(outputText.asText())) {
+            return outputText;
+        }
+        JsonNode output = root.path("output");
+        if (output.isArray()) {
+            for (JsonNode item : output) {
+                JsonNode content = item.path("content");
+                if (!content.isArray()) {
+                    continue;
+                }
+                for (JsonNode contentItem : content) {
+                    JsonNode text = contentItem.path("text");
+                    if (!text.isMissingNode() && !text.isNull() && StringUtils.hasText(text.asText())) {
+                        return text;
+                    }
+                }
+            }
+        }
+        return outputText;
     }
 
     /**
@@ -234,52 +172,15 @@ public class OpenAiSalesPageAnalyzer {
     }
 
     /**
-     * Constrói mensagem legível para erro retornado em uma linha do batch.
+     * Constrói mensagem legível para erro retornado pelo endpoint Responses.
      */
-    private String buildBatchErrorMessage(JsonNode root) {
-        int status = root.path("response").path("status_code").asInt(0);
-        String requestId = root.path("response").path("request_id").asText("");
-        JsonNode error = root.path("response").path("body").path("error");
+    private String buildResponsesErrorMessage(JsonNode root) {
+        JsonNode error = root.path("error");
         String upstreamMessage = error.path("message").asText("");
         String upstreamType = error.path("type").asText("");
         String upstreamCode = error.path("code").asText("");
-        return "OpenAI batch retornou erro HTTP " + status
-                + " (requestId=" + requestId + ", type=" + upstreamType + ", code=" + upstreamCode + "): "
+        return "OpenAI Responses Flex retornou erro"
+                + " (type=" + upstreamType + ", code=" + upstreamCode + "): "
                 + upstreamMessage;
     }
-
-    /**
-     * Constrói mensagem de falha quando o batch termina sem status de sucesso.
-     */
-    private String buildBatchTerminalErrorMessage(BatchInfo completed) {
-        String errorJsonl = downloadErrorJsonl(completed);
-        String trimmedJsonl = errorJsonl.isBlank() ? "" : "\nerror_jsonl=" + errorJsonl.trim();
-        return "Batch da OpenAI finalizou sem sucesso"
-                + " (batchId=" + completed.id()
-                + ", status=" + completed.status()
-                + ", outputFileId=" + completed.outputFileId()
-                + ", errorFileId=" + completed.errorFileId()
-                + ")"
-                + trimmedJsonl;
-    }
-
-    /**
-     * Constrói mensagem de falha quando o batch completa sem arquivo de saída.
-     */
-    private String buildBatchMissingOutputMessage(BatchInfo completed) {
-        String errorJsonl = downloadErrorJsonl(completed);
-        String trimmedJsonl = errorJsonl.isBlank() ? "" : "\nerror_jsonl=" + errorJsonl.trim();
-        return "Batch da OpenAI completou sem output_file_id"
-                + " (batchId=" + completed.id()
-                + ", status=" + completed.status()
-                + ", errorFileId=" + completed.errorFileId()
-                + ")"
-                + trimmedJsonl;
-    }
-
-    private record FileUploadResponse(String id) {}
-    private record BatchInfo(String id,
-                             String status,
-                             @JsonProperty("output_file_id") String outputFileId,
-                             @JsonProperty("error_file_id") String errorFileId) {}
 }

--- a/mois-sales-library-worker/src/main/resources/application.yml
+++ b/mois-sales-library-worker/src/main/resources/application.yml
@@ -45,5 +45,4 @@ openai:
   api-key-file: ${OPENAI_API_KEY_FILE:/run/secrets/openai_api_key}
   base-url: ${OPENAI_BASE_URL:https://api.openai.com/v1}
   model: ${OPENAI_MODEL:gpt-5.2}
-  batch-poll-interval-ms: ${OPENAI_BATCH_POLL_INTERVAL_MS:2000}
-  batch-timeout-ms: ${OPENAI_BATCH_TIMEOUT_MS:1800000}
+  request-timeout-ms: ${OPENAI_REQUEST_TIMEOUT_MS:900000}

--- a/mois-sales-library-worker/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/pipeline/pageanalysis/OpenAiSalesPageAnalyzerTest.java
+++ b/mois-sales-library-worker/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/pipeline/pageanalysis/OpenAiSalesPageAnalyzerTest.java
@@ -13,13 +13,14 @@ class OpenAiSalesPageAnalyzerTest {
     void shouldBuildSuccessDiagnosisPromptWithoutSuggestions() {
         OpenAiSalesPageAnalyzer analyzer = new OpenAiSalesPageAnalyzer(
                 RestClient.builder(),
-                new OpenAiProperties("test-key", "http://localhost", "gpt-test", 1000, 1000, null));
+                new OpenAiProperties("test-key", "http://localhost", "gpt-test", 900000, null));
 
-        String line = analyzer.buildBatchLine(10L, "https://example.com", "Resumo visual extraído do HTML: total_img=12");
+        String payload = analyzer.buildResponsesRequestPayload(10L, "https://example.com", "Resumo visual extraído do HTML: total_img=12");
 
-        assertTrue(line.contains("identificar por que este produto alcançou sucesso"));
-        assertTrue(line.contains("não inclua sugestões"));
-        assertTrue(line.contains("nunca para propor mudanças"));
-        assertFalse(line.contains("recommended_images"));
+        assertTrue(payload.contains("identificar por que este produto alcançou sucesso"));
+        assertTrue(payload.contains("não inclua sugestões"));
+        assertTrue(payload.contains("nunca para propor mudanças"));
+        assertFalse(payload.contains("recommended_images"));
+        assertTrue(payload.contains("\"service_tier\":\"flex\""));
     }
 }


### PR DESCRIPTION
### Motivation
- Replace the legacy OpenAI Batch-based analysis flow with the synchronous Responses API in Flex mode to simplify the pipeline and align auditability and timeout semantics to a canonical 15-minute request timeout.
- Ensure payloads explicitly include `service_tier: "flex"` and update docs/UX traces and error handling to reference Responses/Flex terminology instead of Batch.

### Description
- Update canonical documentation (`docs/canonical/mois-worker-canon.v1.md`) and changelog (`docs/registros/mois1.md`) to replace Batch API references with Responses Flex, require `service_tier: "flex"`, and set the canonical Flex timeout to 15 minutes.
- Replace OpenAI batch configuration with a single `openai.request-timeout-ms` property (default `900000 ms`) in `application.yml` and `OpenAiProperties`, removing batch polling/timeout fields and adding `normalizedRequestTimeoutMs()`.
- Rewrite `OpenAiSalesPageAnalyzer` to build a Responses Flex JSON payload (including `service_tier: "flex"` and `metadata`), perform a synchronous `POST /v1/responses` call with a configured request timeout (`SimpleClientHttpRequestFactory`), and parse the Responses output (`output_text` / `output`) and `usage` into `SalesPageAnalysisResult` while adapting error messages and diagnostics.
- Remove the Batch-related upload/create/poll/download logic and error-file handling, and adjust result fields/versions to reflect `openai-flex-v1` and `Responses Flex` wording.
- Update the unit test `OpenAiSalesPageAnalyzerTest` to use the new properties shape and assert the constructed payload contains the diagnosis text and the `service_tier:flex` marker.

### Testing
- Ran the unit test `OpenAiSalesPageAnalyzerTest`, which passed and verifies the prompt/payload construction and presence of `"service_tier":"flex"` in the request payload.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a396ead05588321be545a196b9cfca6)