### PR TITLE
Corrige retomada de teste em criação

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentPromiseGenerationService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentPromiseGenerationService.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.databind.JsonNode;
 import com.marketinghub.cost.CostAttributionService;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marketinghub.experiment.ExperimentStatus;
 import com.marketinghub.experiment.promise.ExperimentPromiseGenerationRequest;
 import com.marketinghub.experiment.promise.ExperimentPromiseGenerationRequestStatus;
 import com.marketinghub.experiment.service.generatepromise.ExperimentPromiseOptionDto;
@@ -13,6 +14,7 @@ import com.marketinghub.experiment.service.generatepromise.latestdraft.Experimen
 import com.marketinghub.hypothesis.Hypothesis;
 import com.marketinghub.niche.MarketNiche;
 import com.marketinghub.repository.jpa.experiment.ExperimentPromiseGenerationRequestRepository;
+import com.marketinghub.repository.jpa.experiment.ExperimentRepository;
 import com.marketinghub.repository.jpa.hypothesis.HypothesisRepository;
 import com.marketinghub.repository.jpa.niche.MarketNicheRepository;
 import java.math.BigDecimal;
@@ -37,6 +39,7 @@ public class ExperimentPromiseGenerationService {
     private final MarketNicheRepository nicheRepository;
     private final HypothesisRepository hypothesisRepository;
     private final ExperimentPromiseGenerationRequestRepository requestRepository;
+    private final ExperimentRepository experimentRepository;
     private final ObjectMapper objectMapper;
     private final CostAttributionService costAttributionService;
 
@@ -44,11 +47,13 @@ public class ExperimentPromiseGenerationService {
     public ExperimentPromiseGenerationService(MarketNicheRepository nicheRepository,
                                               HypothesisRepository hypothesisRepository,
                                               ExperimentPromiseGenerationRequestRepository requestRepository,
+                                              ExperimentRepository experimentRepository,
                                               ObjectMapper objectMapper,
                                               CostAttributionService costAttributionService) {
         this.nicheRepository = nicheRepository;
         this.hypothesisRepository = hypothesisRepository;
         this.requestRepository = requestRepository;
+        this.experimentRepository = experimentRepository;
         this.objectMapper = objectMapper;
         this.costAttributionService = costAttributionService;
     }
@@ -84,11 +89,23 @@ public class ExperimentPromiseGenerationService {
     /** Retorna a solicitação mais recente ainda útil para retomada da criação do teste pela tela. */
     @Transactional(readOnly = true)
     public Optional<ExperimentPromiseOptionsDraftResponse> latestDraft() {
-        return requestRepository.findFirstByStatusInOrderByCreatedAtDesc(List.of(
-                        ExperimentPromiseGenerationRequestStatus.PENDING,
-                        ExperimentPromiseGenerationRequestStatus.PROCESSING,
-                        ExperimentPromiseGenerationRequestStatus.COMPLETED))
+        return requestRepository.findTop10ByStatusInOrderByCreatedAtDesc(resumableStatuses()).stream()
+                .filter(this::isStillCreationDraft)
+                .findFirst()
                 .map(this::toDraftResponse);
+    }
+
+    /** Lista os status que ainda podem representar um teste em criação na tela. */
+    private List<ExperimentPromiseGenerationRequestStatus> resumableStatuses() {
+        return List.of(
+                ExperimentPromiseGenerationRequestStatus.PENDING,
+                ExperimentPromiseGenerationRequestStatus.PROCESSING,
+                ExperimentPromiseGenerationRequestStatus.COMPLETED);
+    }
+
+    /** Confirma no backend se o rascunho ainda não virou experimento em execução ou histórico. */
+    private boolean isStillCreationDraft(ExperimentPromiseGenerationRequest entity) {
+        return !experimentRepository.existsByHypothesisRefAndStatusNot(entity.getHypothesis(), ExperimentStatus.PLANNED);
     }
 
     /** Consulta uma solicitação específica para a tela acompanhar até a resposta final do AI Worker. */

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentService.java
@@ -354,8 +354,17 @@ public class ExperimentService {
                 .creativeImagePrompt(normalizePrompt(request.getCreativeImagePrompt()))
                 .build();
         Experiment savedExperiment = repository.save(exp);
+        dismissPromiseGenerationDrafts(request.getPromiseGenerationRequestIds());
         synchronizeLeadPortalFlow(savedExperiment);
         return savedExperiment;
+    }
+
+    /** Descarta rascunhos de promessa usados para criar o experimento e evita retomada de teste já salvo. */
+    private void dismissPromiseGenerationDrafts(List<Long> requestIds) {
+        if (requestIds == null || requestIds.isEmpty()) {
+            return;
+        }
+        promiseGenerationRequestRepository.dismissByIdIn(requestIds);
     }
 
     /** Soma em reais o custo das solicitações de promessa usadas para criar o experimento. */
@@ -413,7 +422,6 @@ public class ExperimentService {
                 .filter(exp -> exp.getFacebookReleaseRequestedAt() != null)
                 .toList();
     }
-
 
     /**
      * Duplica um experimento preservando seu contrato comercial e configurações operacionais.
@@ -474,7 +482,6 @@ public class ExperimentService {
                 .build();
         return repository.save(copy);
     }
-
 
     /**
      * Updates the status of an experiment.
@@ -816,7 +823,6 @@ public class ExperimentService {
         experimentFunnelEventRepository.deleteByExperimentId(id);
         return experiment;
     }
-
 
     /**
      * Remove a publicação anterior do Facebook para permitir que o worker publique um novo ciclo.

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/experiment/ExperimentPromiseGenerationRequestRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/experiment/ExperimentPromiseGenerationRequestRepository.java
@@ -5,9 +5,9 @@ import com.marketinghub.experiment.promise.ExperimentPromiseGenerationRequestSta
 import java.math.BigDecimal;
 import java.util.Collection;
 import java.util.List;
-import java.util.Optional;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Modifying;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 
@@ -18,9 +18,19 @@ public interface ExperimentPromiseGenerationRequestRepository extends JpaReposit
             ExperimentPromiseGenerationRequestStatus status,
             Pageable pageable);
 
-    /** Busca a solicitação mais recente em status retomável para a tela recuperar pelo backend. */
-    Optional<ExperimentPromiseGenerationRequest> findFirstByStatusInOrderByCreatedAtDesc(
+    /** Busca as solicitações recentes em status retomável para a tela recuperar pelo backend. */
+    List<ExperimentPromiseGenerationRequest> findTop10ByStatusInOrderByCreatedAtDesc(
             Collection<ExperimentPromiseGenerationRequestStatus> statuses);
+
+    /** Descarta em lote solicitações já usadas na criação de um experimento. */
+    @Modifying
+    @Query("""
+            update ExperimentPromiseGenerationRequest r
+            set r.status = com.marketinghub.experiment.promise.ExperimentPromiseGenerationRequestStatus.DISMISSED,
+                r.finishedAt = CURRENT_TIMESTAMP
+            where r.id in :ids
+            """)
+    int dismissByIdIn(@Param("ids") Collection<Long> ids);
 
     /** Soma o custo em dólar de solicitações concluídas para compor o custo inicial do experimento criado. */
     @Query("""

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/experiment/ExperimentRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/experiment/ExperimentRepository.java
@@ -25,6 +25,8 @@ public interface ExperimentRepository extends JpaRepository<Experiment, Long> {
     Optional<Experiment> findById(Long id);
     List<Experiment> findByNicheId(Long nicheId);
     boolean existsByNicheAndName(MarketNiche niche, String name);
+    /** Verifica se a hipótese já possui experimento que saiu da criação e entrou em execução/histórico. */
+    boolean existsByHypothesisRefAndStatusNot(Hypothesis hypothesisRef, ExperimentStatus status);
     List<Experiment> findByStatus(ExperimentStatus status);
     List<Experiment> findByStatusAndPlatform(ExperimentStatus status, ExperimentPlatform platform);
 

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/service/ExperimentPromiseGenerationServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/service/ExperimentPromiseGenerationServiceTest.java
@@ -7,12 +7,15 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marketinghub.cost.CostAttributionService;
+import com.marketinghub.experiment.ExperimentStatus;
 import com.marketinghub.experiment.promise.ExperimentPromiseGenerationRequest;
 import com.marketinghub.experiment.promise.ExperimentPromiseGenerationRequestStatus;
 import com.marketinghub.experiment.service.generatepromise.GenerateExperimentPromiseOptionsRequest;
 import com.marketinghub.hypothesis.Hypothesis;
 import com.marketinghub.niche.MarketNiche;
 import com.marketinghub.repository.jpa.experiment.ExperimentPromiseGenerationRequestRepository;
+import com.marketinghub.repository.jpa.experiment.ExperimentRepository;
 import com.marketinghub.repository.jpa.hypothesis.HypothesisRepository;
 import com.marketinghub.repository.jpa.niche.MarketNicheRepository;
 import java.util.List;
@@ -36,6 +39,10 @@ class ExperimentPromiseGenerationServiceTest {
     private HypothesisRepository hypothesisRepository;
     @Mock
     private ExperimentPromiseGenerationRequestRepository requestRepository;
+    @Mock
+    private ExperimentRepository experimentRepository;
+    @Mock
+    private CostAttributionService costAttributionService;
     @Spy
     private ObjectMapper objectMapper = new ObjectMapper();
     @InjectMocks
@@ -144,10 +151,11 @@ class ExperimentPromiseGenerationServiceTest {
                 .currentPrimaryCta("receber mensagens")
                 .build();
         request.setId(789L);
-        when(requestRepository.findFirstByStatusInOrderByCreatedAtDesc(List.of(
+        when(requestRepository.findTop10ByStatusInOrderByCreatedAtDesc(List.of(
                 ExperimentPromiseGenerationRequestStatus.PENDING,
                 ExperimentPromiseGenerationRequestStatus.PROCESSING,
-                ExperimentPromiseGenerationRequestStatus.COMPLETED))).thenReturn(Optional.of(request));
+                ExperimentPromiseGenerationRequestStatus.COMPLETED))).thenReturn(List.of(request));
+        when(experimentRepository.existsByHypothesisRefAndStatusNot(hypothesis, ExperimentStatus.PLANNED)).thenReturn(false);
 
         var response = service.latestDraft();
 
@@ -156,6 +164,32 @@ class ExperimentPromiseGenerationServiceTest {
         assertThat(response.get().nicheId()).isEqualTo(7L);
         assertThat(response.get().hypothesisId()).isEqualTo(hypothesisId);
         assertThat(response.get().currentSinglePain()).isEqualTo("agenda quebra");
+    }
+
+
+    /** Deve ocultar rascunho quando a hipótese já possui teste fora da criação. */
+    @Test
+    void shouldIgnoreDraftWhenHypothesisAlreadyHasRunningExperiment() {
+        UUID hypothesisId = UUID.randomUUID();
+        Hypothesis hypothesis = Hypothesis.builder()
+                .id(hypothesisId)
+                .title("Agenda irregular")
+                .build();
+        ExperimentPromiseGenerationRequest request = ExperimentPromiseGenerationRequest.builder()
+                .niche(MarketNiche.builder().id(7L).name("Manicure").build())
+                .hypothesis(hypothesis)
+                .status(ExperimentPromiseGenerationRequestStatus.COMPLETED)
+                .build();
+        request.setId(790L);
+        when(requestRepository.findTop10ByStatusInOrderByCreatedAtDesc(List.of(
+                ExperimentPromiseGenerationRequestStatus.PENDING,
+                ExperimentPromiseGenerationRequestStatus.PROCESSING,
+                ExperimentPromiseGenerationRequestStatus.COMPLETED))).thenReturn(List.of(request));
+        when(experimentRepository.existsByHypothesisRefAndStatusNot(hypothesis, ExperimentStatus.PLANNED)).thenReturn(true);
+
+        var response = service.latestDraft();
+
+        assertThat(response).isEmpty();
     }
 
     /** Deve descartar o rascunho retomável para não manter atalho antigo após salvar o teste. */

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -5053,3 +5053,10 @@
 
 - Ajustada a tela de funil do experimento para formatar o campo `Último evento` explicitamente no fuso operacional `America/Sao_Paulo`, exibindo o cabeçalho como horário de Brasília e evitando interpretação pelo fuso local do navegador.
 - Adicionado teste de regressão no frontend para garantir que datas do funil sejam apresentadas no fuso operacional do Brasil.
+
+## 2026-06-22 — Retomada de teste em criação não abre experimento em execução
+
+- Problema: o botão `Continuar teste em criação` podia reutilizar uma solicitação antiga de promessa de um experimento que já havia saído da criação e entrado em execução.
+- Causa-raiz: a retomada buscava o último rascunho por status da geração de promessa, sem confirmar se a hipótese daquele rascunho já possuía experimento fora do status `PLANNED`; além disso, a limpeza do rascunho dependia de chamada posterior do frontend.
+- Correção aplicada: o backend agora filtra o rascunho retomável pela verdade dos experimentos persistidos e descarta, no próprio fluxo transacional de criação do experimento, as solicitações de promessa usadas no teste salvo.
+- Prevenção de recorrência: adicionado teste de serviço garantindo que rascunho com experimento já em execução/histórico não é exposto para a tela continuar criação.


### PR DESCRIPTION
### Motivation
- Usuário podia clicar em “Continuar teste em criação” e receber um rascunho de promessa vinculado a uma hipótese cuja criação já havia sido concluída (experimento saiu de `PLANNED`), reabrindo um experimento em execução indevidamente.
- A limpeza dos rascunhos dependia de chamadas posteriores do frontend, deixando atalho reutilizável mesmo após o experimento ter sido salvo.

### Description
- O backend agora filtra rascunhos retornados pelo endpoint de retomada verificando se a hipótese já possui experimento fora do status `PLANNED` via `ExperimentRepository.existsByHypothesisRefAndStatusNot(...)` e expõe apenas rascunhos válidos (`latestDraft()` atualizada e `isStillCreationDraft`).
- Adicionada consulta e operação em lote no repositório `ExperimentPromiseGenerationRequestRepository` para buscar os rascunhos recentes (`findTop10ByStatusInOrderByCreatedAtDesc`) e descartá-los em lote (`dismissByIdIn`) quando usados.
- Ao salvar um novo experimento o backend descarta imediatamente (transacionalmente) os rascunhos de promessa usados, por meio de `dismissPromiseGenerationDrafts(...)` na criação do experimento (`ExperimentService`).
- Incluído teste de regressão em `ExperimentPromiseGenerationServiceTest` que cobre o caso onde um rascunho não deve ser exposto quando a hipótese já tem experimento em execução, e atualizada a documentação operacional em `docs/registros/experimentos.md`.

### Testing
- Executado o teste de unidade `ExperimentPromiseGenerationServiceTest` com `../../backend/mvnw -Dtest=ExperimentPromiseGenerationServiceTest test` e a suíte do teste passou (`BUILD SUCCESS`).
- Observação: `spotless:apply` não foi executado neste módulo por falta do plugin Spotless no ambiente Maven (informação registrada como aviso durante a execução dos comandos).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3998ec3c3c8321b395f93390b233de)