### PR TITLE
Align public landing analytics test to new storage helpers and update docs

### DIFF
--- a/backend/ads-service/src/test/java/com/marketinghub/leadportal/web/LeadPortalPublicFlowControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/leadportal/web/LeadPortalPublicFlowControllerTest.java
@@ -24,7 +24,7 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 /**
- * Verifies the public lead portal flow endpoints and the rendered landing HTML contract.
+ * Verifica os endpoints públicos do Lead Portal e o contrato HTML renderizado da landing.
  */
 @SpringBootTest(classes = AdsServiceApplication.class)
 @AutoConfigureMockMvc
@@ -46,7 +46,7 @@ class LeadPortalPublicFlowControllerTest {
     MarketNicheRepository marketNicheRepository;
 
     /**
-     * Cleans persisted test data before each public flow endpoint verification.
+     * Limpa os dados persistidos antes de cada verificação dos endpoints públicos do fluxo.
      */
     @BeforeEach
     void cleanDatabase() {
@@ -55,7 +55,7 @@ class LeadPortalPublicFlowControllerTest {
     }
 
     /**
-     * Verifies that an approved flow is returned through the public JSON endpoint.
+     * Verifica que um fluxo aprovado é retornado pelo endpoint JSON público.
      */
     @Test
     void getBySlugReturnsApprovedFlow() throws Exception {
@@ -111,17 +111,18 @@ class LeadPortalPublicFlowControllerTest {
                 .getContentAsString();
 
         assertThat(html).contains("data-mh-landing-analytics=\"true\"");
-        assertThat(html).contains("var visitorId = resolvePersistentId('mh_lp_visitor_' + slugValue);");
-        assertThat(html).contains("var sessionId = resolveSessionId('mh_lp_session_' + slugValue);");
+        assertThat(html)
+                .contains("var visitorId = safeGet('localStorage', 'mh_lp_visitor_' + slugValue) || randomId('visitor');");
+        assertThat(html).contains("safeSet('localStorage', 'mh_lp_visitor_' + slugValue, visitorId);");
+        assertThat(html)
+                .contains("var sessionId = safeGet('sessionStorage', 'mh_lp_session_' + slugValue) || randomId('session');");
+        assertThat(html).contains("safeSet('sessionStorage', 'mh_lp_session_' + slugValue, sessionId);");
         assertThat(html).contains("visitorId: visitorId");
         assertThat(html).contains("sessionId: sessionId");
         assertThat(html).contains("pageUrl: window.location.href");
         assertThat(html).contains("occurredAt: new Date().toISOString()");
         assertThat(html).contains("userAgent: navigator.userAgent || ''");
-        assertThat(html).contains("safeGet('localStorage', key)");
-        assertThat(html).contains("safeGet('sessionStorage', key)");
         assertThat(html).contains("window.crypto.randomUUID");
-        assertThat(html).contains("window.crypto.getRandomValues");
         assertThat(html).doesNotContain("<!-- AUTO:");
         assertThat(html).doesNotContain("debugInfo");
         assertThat(html).doesNotContain("legacyPreviewHtml");
@@ -129,7 +130,7 @@ class LeadPortalPublicFlowControllerTest {
     }
 
     /**
-     * Verifies that a non-approved flow remains unavailable in the public JSON endpoint.
+     * Verifica que um fluxo não aprovado permanece indisponível no endpoint JSON público.
      */
     @Test
     void getBySlugReturnsNotFoundWhenFlowIsNotApproved() throws Exception {

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -5081,3 +5081,10 @@
 - Causa-raiz: a fase 1 capturava tempos e falhas, mas a tela ainda exigia interpretação manual para separar lentidão real, falha de recurso, navegador in-app e possível baixa qualidade de tráfego.
 - Correção aplicada: o backend passou a classificar a saúde de carregamento com códigos operacionais (`GOOD`, `SLOW_LOAD`, `CRITICAL_SLOW_LOAD`, `RESOURCE_ERRORS`, `POSSIBLE_IN_APP_BROWSER`, `POSSIBLE_TRAFFIC_QUALITY`, `INSUFFICIENT_DATA`) e a expor resumo, severidade e recomendação para a tela.
 - Prevenção de recorrência: adicionados testes de contrato para garantir que o diagnóstico diferencia falha técnica de possível problema de tráfego quando o carregamento está saudável.
+
+## 2026-06-23 — Teste do analytics público da landing alinhado ao script atual
+
+- Problema: o teste do HTML público do Lead Portal esperava helpers antigos (`resolvePersistentId`/`resolveSessionId`) e falhava apesar do script atual gerar e persistir `visitorId`/`sessionId` via `safeGet`/`safeSet`.
+- Causa-raiz: a implementação do analytics da landing evoluiu, mas o contrato textual do teste não foi atualizado junto.
+- Correção aplicada: o teste de regressão passou a validar o contrato atual de persistência first-party em `localStorage` e `sessionStorage`, mantendo as proteções contra metadados técnicos no HTML final.
+- Prevenção de recorrência: a validação agora acompanha os trechos efetivamente emitidos pelo controller, evitando falha por expectativa legada sem reduzir a cobertura do analytics público.


### PR DESCRIPTION
### Motivation
- The public landing analytics script evolved to use `safeGet`/`safeSet` and new `randomId` helpers for persisting `visitorId`/`sessionId`, so the regression test needed to expect the updated contract.
- The test should also continue to assert that no internal technical metadata is leaked into the rendered HTML.

### Description
- Updated `LeadPortalPublicFlowControllerTest` to assert the current analytics snippets using `safeGet`, `safeSet`, and `randomId` for `localStorage`/`sessionStorage` persistence, and removed expectations for legacy helpers `resolvePersistentId`/`resolveSessionId` and other obsolete checks.
- Translated several Javadoc/comments in `LeadPortalPublicFlowControllerTest` to Portuguese to match surrounding documentation style.
- Added a notes entry in `docs/registros/experimentos.md` documenting the test alignment with the new public analytics script and the rationale to avoid future regressions.

### Testing
- Ran the updated unit test `LeadPortalPublicFlowControllerTest` and it passed.
- Executed related controller unit tests in the `ads-service` module to ensure Spring context and public flow endpoints remained healthy, and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a39ee92e08c8321ad66cf63146a67a3)