### PR TITLE
Corrige direcionamento de sucesso NichoCNAE v2

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/candidategenerator/service/BackendCandidateGeneratorService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/candidategenerator/service/BackendCandidateGeneratorService.java
@@ -331,7 +331,7 @@ public class BackendCandidateGeneratorService {
                 outcomeStatus(finalDecision, lastExecution),
                 outcomeMessage(finalDecision, finalDecisionReason, marketNicheId, lastExecution),
                 actionLabel(finalDecision, marketNicheId, lastExecution),
-                actionUrl(finalDecision, lastExecution.getCnaeCode(), marketNicheId),
+                actionUrl(finalDecision, lastExecution.getCnaeCode(), lastExecution.getJobId(), marketNicheId),
                 usedAi,
                 aiCostUsd,
                 loopDetected(executions),
@@ -499,20 +499,20 @@ public class BackendCandidateGeneratorService {
             return "Pesquisar outro recorte";
         }
         if (lastExecution.getStatus() == OprmNichoCnaeV2StageExecutionStatus.COMPLETED) {
-            return "Abrir CNAE para materializar";
+            return "Ver resultado do pipeline";
         }
         return null;
     }
 
     /** Define a URL interna do comando principal sem deixar a tela inferir regra de negócio. */
-    private String actionUrl(String decision, String cnaeCode, String marketNicheId) {
+    private String actionUrl(String decision, String cnaeCode, String jobId, String marketNicheId) {
         if (marketNicheId != null) {
             return "/niches/" + marketNicheId;
         }
         if ("NO_VIABLE_SUBNICHE".equals(decision)) {
             return "/oprm/cnaes/" + cnaeCode;
         }
-        return "/oprm/cnaes/" + cnaeCode;
+        return "/oprm/cnaes/" + cnaeCode + "/pipeline-v2/jobs/" + jobId;
     }
 
     /** Extrai o ID de nicho materializado quando alguma etapa persistiu esse identificador no payload. */

--- a/backend/ads-service/src/test/java/com/marketinghub/oprm/nichocnae/v2/candidategenerator/service/BackendCandidateGeneratorServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/oprm/nichocnae/v2/candidategenerator/service/BackendCandidateGeneratorServiceTest.java
@@ -213,6 +213,30 @@ class BackendCandidateGeneratorServiceTest {
         assertThat(job.repeatedStageCount()).isEqualTo(2);
     }
 
+    /** Deve direcionar sucesso parcial da v2 para o relatório do job, sem misturar com a tela legada do CNAE. */
+    @Test
+    void listJobsForCnaePointsPartialSuccessToJobReport() {
+        BackendCandidateGeneratorService service = service(true, false);
+        OprmNichoCnaeV2StageExecution completed = execution(501L, 1, 0, 1);
+        completed.setJobId("nichocnae-v2-candidate-2-job-13");
+        completed.setCnaeCode("4781400");
+        completed.setStageCode("adaptive-query-planner");
+        completed.setStatus(OprmNichoCnaeV2StageExecutionStatus.COMPLETED);
+        completed.setOutputPayload("{\"planDecision\":\"ENOUGH_INFORMATION_FOR_NEXT_PIPELINE\",\"aiCostUsd\":0}");
+        completed.setUpdatedAt(Instant.parse("2026-06-22T23:51:00Z"));
+        when(stageExecutionRepository.findByCnaeCodeOrderByUpdatedAtDesc("4781400"))
+                .thenReturn(List.of(completed));
+
+        var result = service.listJobsForCnae("4781400");
+
+        assertThat(result.completedJobs()).hasSize(1);
+        var job = result.completedJobs().getFirst();
+        assertThat(job.outcomeStatus()).isEqualTo("SUCCESS");
+        assertThat(job.actionLabel()).isEqualTo("Ver resultado do pipeline");
+        assertThat(job.actionUrl())
+                .isEqualTo("/oprm/cnaes/4781400/pipeline-v2/jobs/nichocnae-v2-candidate-2-job-13");
+    }
+
     /** Deve detalhar cronologicamente as etapas do job para relatório de fracasso. */
     @Test
     void detailJobReturnsStageTimelineForFailureReport() {

--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -1308,3 +1308,10 @@
 - O `candidate-generator` e o `routine-synthesizer` agora registram `commercialBoundary=NAO_GERAR_DOR_RESULTADO_OFERTA` e papéis de insumo para o pipeline de hipótese.
 - Causa-raiz tratada: o fluxo ainda carregava etapas e campos que empurravam o NichoCNAE para validação/oferta, apesar de a divulgação por Instagram exigir primeiro um pacote amplo de público, rotina e linguagem.
 - Prevenção de recorrência: adicionado teste garantindo que o catálogo v2 não registra etapas comerciais/materialização.
+
+
+## 2026-06-23 — Direcionamento do resultado NichoCNAE v2
+
+- Ajustado o comando de sucesso parcial do histórico NichoCNAE v2 para abrir o relatório do job, e não a tela legada do CNAE.
+- Causa-raiz tratada: o backend enviava o usuário para a página geral do CNAE quando a materialização automática estava desativada, misturando resultado v2 novo com subnichos/processamentos antigos.
+- Prevenção de recorrência: teste unitário valida que job v2 concluído sem nicho materializado direciona para o relatório do próprio job.


### PR DESCRIPTION
### Motivation

- Corrigir comportamento confuso observado: quando um job v2 terminava com sucesso operacional mas sem nicho materializado, o botão levava o usuário à tela geral do CNAE com dados antigos em vez de mostrar o resultado do job recém-executado.

### Description

- Altera o rótulo de ação para sucesso parcial para `"Ver resultado do pipeline"` em `BackendCandidateGeneratorService` para deixar a intenção explícita.
- Ajusta `actionUrl` para receber `jobId` e, quando não houver `marketNicheId` nem `NO_VIABLE_SUBNICHE`, linkar para `/oprm/cnaes/{cnaeCode}/pipeline-v2/jobs/{jobId}` em vez da página CNAE legada.
- Atualiza o ponto que monta o `CandidateGeneratorCnaeJobSummary` para passar o `jobId` ao `actionUrl` e adiciona um teste de regressão que valida o novo direcionamento.
- Registra a mudança no histórico operacional `docs/registros/oprm1.md` para documentar causa-raiz e prevenção de recorrência.

### Testing

- Executei o teste de unidade específico com `../mvnw -Dtest=BackendCandidateGeneratorServiceTest test` no módulo `backend/ads-service`, que rodou os 15 testes do caso `BackendCandidateGeneratorServiceTest` com sucesso (15 tests, 0 failures) e `BUILD SUCCESS`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a39f5ab354c8321b51053202e4d2e5d)