### PR TITLE
Add manual niche confirmation to NichoCNAE v2 (backend + frontend)

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/candidategenerator/controller/BackendCandidateGeneratorController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/candidategenerator/controller/BackendCandidateGeneratorController.java
@@ -4,6 +4,8 @@ import com.marketinghub.oprm.nichocnae.v2.candidategenerator.service.BackendCand
 import com.marketinghub.oprm.nichocnae.v2.candidategenerator.service.cancelJob.CandidateGeneratorCancelJobResponse;
 import com.marketinghub.oprm.nichocnae.v2.candidategenerator.service.completeStageExecution.CandidateGeneratorCompletionRequest;
 import com.marketinghub.oprm.nichocnae.v2.candidategenerator.service.completeStageExecution.CandidateGeneratorCompletionResponse;
+import com.marketinghub.oprm.nichocnae.v2.candidategenerator.service.confirmNiche.CandidateGeneratorConfirmNicheRequest;
+import com.marketinghub.oprm.nichocnae.v2.candidategenerator.service.confirmNiche.CandidateGeneratorConfirmNicheResponse;
 import com.marketinghub.oprm.nichocnae.v2.candidategenerator.service.createStageExecution.CandidateGeneratorCreateResponse;
 import com.marketinghub.oprm.nichocnae.v2.candidategenerator.service.detailJob.CandidateGeneratorJobDetailResponse;
 import com.marketinghub.oprm.nichocnae.v2.candidategenerator.service.failStageExecution.CandidateGeneratorFailureRequest;
@@ -45,6 +47,13 @@ public class BackendCandidateGeneratorController {
     @GetMapping("/jobs/{jobId}")
     public CandidateGeneratorJobDetailResponse detailJob(@PathVariable String jobId) {
         return service.detailJob(jobId);
+    }
+
+    /** Confirma o nome único e transforma o job concluído em nicho de mercado para a sequência do Marketing Hub. */
+    @PostMapping("/jobs/{jobId}/confirm-niche")
+    public CandidateGeneratorConfirmNicheResponse confirmNiche(
+            @PathVariable String jobId, @RequestBody(required = false) CandidateGeneratorConfirmNicheRequest request) {
+        return service.confirmNiche(jobId, request);
     }
 
     /** Cancela manualmente um job preso para liberar o CNAE para nova tentativa. */

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/candidategenerator/service/BackendCandidateGeneratorService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/candidategenerator/service/BackendCandidateGeneratorService.java
@@ -3,6 +3,7 @@ package com.marketinghub.oprm.nichocnae.v2.candidategenerator.service;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marketinghub.niche.MarketNiche;
 import com.marketinghub.oprm.cnae.OprmNicheCandidate;
 import com.marketinghub.oprm.nichocnae.v2.OprmNichoCnaeV2FailureType;
 import com.marketinghub.oprm.nichocnae.v2.OprmNichoCnaeV2OpenAiInteraction;
@@ -11,6 +12,8 @@ import com.marketinghub.oprm.nichocnae.v2.OprmNichoCnaeV2StageExecutionStatus;
 import com.marketinghub.oprm.nichocnae.v2.candidategenerator.service.cancelJob.CandidateGeneratorCancelJobResponse;
 import com.marketinghub.oprm.nichocnae.v2.candidategenerator.service.completeStageExecution.CandidateGeneratorCompletionRequest;
 import com.marketinghub.oprm.nichocnae.v2.candidategenerator.service.completeStageExecution.CandidateGeneratorCompletionResponse;
+import com.marketinghub.oprm.nichocnae.v2.candidategenerator.service.confirmNiche.CandidateGeneratorConfirmNicheRequest;
+import com.marketinghub.oprm.nichocnae.v2.candidategenerator.service.confirmNiche.CandidateGeneratorConfirmNicheResponse;
 import com.marketinghub.oprm.nichocnae.v2.candidategenerator.service.createStageExecution.CandidateGeneratorCreateResponse;
 import com.marketinghub.oprm.nichocnae.v2.candidategenerator.service.detailJob.CandidateGeneratorJobDetailResponse;
 import com.marketinghub.oprm.nichocnae.v2.candidategenerator.service.detailJob.CandidateGeneratorJobStageStep;
@@ -20,6 +23,7 @@ import com.marketinghub.oprm.nichocnae.v2.candidategenerator.service.listCnaeJob
 import com.marketinghub.oprm.nichocnae.v2.candidategenerator.service.listCnaeJobs.CandidateGeneratorCnaeJobsResponse;
 import com.marketinghub.oprm.nichocnae.v2.candidategenerator.service.pending.CandidateGeneratorPendingResponse;
 import com.marketinghub.oprm.nichocnae.v2.service.openaiinteraction.OpenAiInteractionAuditRequest;
+import com.marketinghub.repository.jpa.niche.MarketNicheRepository;
 import com.marketinghub.repository.jpa.oprm.cnae.OprmNicheCandidateRepository;
 import com.marketinghub.repository.jpa.oprm.nichocnae.v2.OprmNichoCnaeV2OpenAiInteractionRepository;
 import com.marketinghub.repository.jpa.oprm.nichocnae.v2.OprmNichoCnaeV2StageExecutionRepository;
@@ -73,6 +77,7 @@ public class BackendCandidateGeneratorService {
             "createdMarketNicheId");
 
     private final OprmNicheCandidateRepository nicheCandidateRepository;
+    private final MarketNicheRepository marketNicheRepository;
     private final OprmNichoCnaeV2StageExecutionRepository stageExecutionRepository;
     private final OprmNichoCnaeV2OpenAiInteractionRepository openAiInteractionRepository;
     private final boolean v2Enabled;
@@ -82,11 +87,13 @@ public class BackendCandidateGeneratorService {
     @Autowired
     public BackendCandidateGeneratorService(
             OprmNicheCandidateRepository nicheCandidateRepository,
+            MarketNicheRepository marketNicheRepository,
             OprmNichoCnaeV2StageExecutionRepository stageExecutionRepository,
             OprmNichoCnaeV2OpenAiInteractionRepository openAiInteractionRepository,
             @Value("${oprm.nichocnae.v2.enabled:false}") boolean v2Enabled,
             @Value("${oprm.nichocnae.v2.materialization-enabled:false}") boolean materializationEnabled) {
         this.nicheCandidateRepository = nicheCandidateRepository;
+        this.marketNicheRepository = marketNicheRepository;
         this.stageExecutionRepository = stageExecutionRepository;
         this.openAiInteractionRepository = openAiInteractionRepository;
         this.v2Enabled = v2Enabled;
@@ -96,10 +103,30 @@ public class BackendCandidateGeneratorService {
     /** Mantém compatibilidade com testes unitários que não exercem auditoria OpenAI. */
     public BackendCandidateGeneratorService(
             OprmNicheCandidateRepository nicheCandidateRepository,
+            MarketNicheRepository marketNicheRepository,
             OprmNichoCnaeV2StageExecutionRepository stageExecutionRepository,
             boolean v2Enabled,
             boolean materializationEnabled) {
-        this(nicheCandidateRepository, stageExecutionRepository, null, v2Enabled, materializationEnabled);
+        this(nicheCandidateRepository, marketNicheRepository, stageExecutionRepository, null, v2Enabled, materializationEnabled);
+    }
+
+    /** Mantém compatibilidade com testes unitários antigos sem repositório de MarketNiche. */
+    public BackendCandidateGeneratorService(
+            OprmNicheCandidateRepository nicheCandidateRepository,
+            OprmNichoCnaeV2StageExecutionRepository stageExecutionRepository,
+            boolean v2Enabled,
+            boolean materializationEnabled) {
+        this(nicheCandidateRepository, null, stageExecutionRepository, null, v2Enabled, materializationEnabled);
+    }
+
+    /** Mantém compatibilidade com testes unitários antigos que injetam auditoria OpenAI sem MarketNiche. */
+    public BackendCandidateGeneratorService(
+            OprmNicheCandidateRepository nicheCandidateRepository,
+            OprmNichoCnaeV2StageExecutionRepository stageExecutionRepository,
+            OprmNichoCnaeV2OpenAiInteractionRepository openAiInteractionRepository,
+            boolean v2Enabled,
+            boolean materializationEnabled) {
+        this(nicheCandidateRepository, null, stageExecutionRepository, openAiInteractionRepository, v2Enabled, materializationEnabled);
     }
 
     /** Lista pendências disponíveis para consumo canônico pelo executor OPRM NichoCNAE v2. */
@@ -223,7 +250,54 @@ public class BackendCandidateGeneratorService {
                 summary.finalDecisionReason(),
                 summary.outcomeStatus(),
                 summary.outcomeMessage(),
+                proposedNicheName(executions),
+                marketNicheIdFrom(executions).map(Long::valueOf).orElse(null),
+                summary.aiCostUsd(),
+                canConfirmNiche(summary, executions),
                 executions.stream().map(this::toJobStageStep).toList());
+    }
+
+
+    /** Confirma manualmente um job concluído como nicho de mercado com nome único para uso nas próximas etapas. */
+    @Transactional
+    public CandidateGeneratorConfirmNicheResponse confirmNiche(String jobId, CandidateGeneratorConfirmNicheRequest request) {
+        if (marketNicheRepository == null) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, "Repositório de nichos indisponível para confirmação.");
+        }
+        List<OprmNichoCnaeV2StageExecution> executions = stageExecutionRepository.findByJobIdOrderByCreatedAtAsc(jobId);
+        if (executions.isEmpty()) {
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, "NichoCNAE v2 job not found: " + jobId);
+        }
+        CandidateGeneratorCnaeJobSummary summary = toJobSummary(executions);
+        if (!canConfirmNiche(summary, executions)) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, "Este job ainda não está pronto para virar nicho.");
+        }
+        String name = requiredUniqueNicheName(request == null ? null : request.nicheName());
+        OprmNichoCnaeV2StageExecution lastExecution = executions.getLast();
+        MarketNiche marketNiche = new MarketNiche();
+        marketNiche.setName(name);
+        marketNiche.setDescription(buildConfirmedNicheDescription(executions));
+        marketNiche.setTotalCost(summary.aiCostUsd());
+        marketNiche.setCost(summary.aiCostUsd());
+        MarketNiche saved = marketNicheRepository.save(marketNiche);
+        nicheCandidateRepository.findById(lastExecution.getSourceNicheId()).ifPresent(candidate -> {
+            candidate.setMarketNicheId(saved.getId());
+            candidate.setStatus("APPROVED");
+            candidate.setUpdatedAt(Instant.now());
+            nicheCandidateRepository.save(candidate);
+        });
+        lastExecution.setOutputPayload(mergeOutputPayload(lastExecution.getOutputPayload(), saved.getId(), name, summary.aiCostUsd()));
+        lastExecution.setUpdatedAt(Instant.now());
+        stageExecutionRepository.save(lastExecution);
+        return new CandidateGeneratorConfirmNicheResponse(
+                jobId,
+                lastExecution.getCnaeCode(),
+                saved.getId(),
+                saved.getName(),
+                summary.aiCostUsd(),
+                "CONFIRMED_AS_NICHE",
+                "Nicho confirmado e disponível para a sequência do Marketing Hub.",
+                lastExecution.getUpdatedAt());
     }
 
     /** Registra conclusão da etapa persistindo a próxima etapa informada pelo executor externo. */
@@ -277,6 +351,62 @@ public class BackendCandidateGeneratorService {
                 saved.getTechnicalRetryNumber());
     }
 
+
+    /** Valida nome obrigatório e impede repetir nome de nicho já existente. */
+    private String requiredUniqueNicheName(String nicheName) {
+        String normalized = nicheName == null ? "" : nicheName.trim();
+        if (normalized.isBlank()) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Informe um nome para o nicho.");
+        }
+        if (marketNicheRepository.existsByNameIgnoreCase(normalized)) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, "Já existe um nicho com esse nome. Escolha um nome único.");
+        }
+        return normalized;
+    }
+
+    /** Indica se o job concluído ainda pode ser confirmado manualmente como nicho. */
+    private boolean canConfirmNiche(CandidateGeneratorCnaeJobSummary summary, List<OprmNichoCnaeV2StageExecution> executions) {
+        return "SUCCESS".equals(summary.outcomeStatus())
+                && marketNicheIdFrom(executions).isEmpty()
+                && !hasOpenExecution(executions);
+    }
+
+    /** Sugere o nome inicial do nicho a partir do candidato CNAE original. */
+    private String proposedNicheName(List<OprmNichoCnaeV2StageExecution> executions) {
+        Long sourceNicheId = executions.isEmpty() ? null : executions.getFirst().getSourceNicheId();
+        if (sourceNicheId == null) {
+            return null;
+        }
+        return nicheCandidateRepository.findById(sourceNicheId)
+                .map(OprmNicheCandidate::getCandidateNicheName)
+                .filter(name -> !name.isBlank())
+                .orElse(null);
+    }
+
+    /** Monta descrição funcional mínima do nicho confirmado com dados persistidos no job. */
+    private String buildConfirmedNicheDescription(List<OprmNichoCnaeV2StageExecution> executions) {
+        OprmNichoCnaeV2StageExecution first = executions.getFirst();
+        return "Nicho confirmado a partir do pipeline NichoCNAE v2. CNAE "
+                + first.getCnaeCode()
+                + ", job "
+                + first.getJobId()
+                + ".";
+    }
+
+    /** Acrescenta ao payload final os identificadores do nicho confirmado sem descartar o resultado do executor. */
+    private String mergeOutputPayload(String payload, Long marketNicheId, String nicheName, BigDecimal aiCostUsd) {
+        Map<String, Object> output = new LinkedHashMap<>(parsePayload(payload));
+        output.put("marketNicheId", marketNicheId);
+        output.put("confirmedNicheName", nicheName);
+        output.put("totalAiCostUsd", aiCostUsd);
+        output.put("materializationDecision", "CONFIRMED_AS_NICHE");
+        try {
+            return OBJECT_MAPPER.writeValueAsString(output);
+        } catch (JsonProcessingException ex) {
+            throw new ResponseStatusException(HttpStatus.INTERNAL_SERVER_ERROR, "Falha ao registrar confirmação do nicho.", ex);
+        }
+    }
+
     /** Converte uma execução persistida em item de linha cronológico do relatório de job. */
     private CandidateGeneratorJobStageStep toJobStageStep(OprmNichoCnaeV2StageExecution execution) {
         return new CandidateGeneratorJobStageStep(
@@ -309,7 +439,7 @@ public class BackendCandidateGeneratorService {
         Map<String, Object> lastOutput = parsePayload(lastExecution.getOutputPayload());
         String finalDecision = decisionFrom(lastOutput, lastExecution, executions);
         String finalDecisionReason = reasonForDecision(finalDecision, lastOutput, lastExecution, executions);
-        String marketNicheId = marketNicheIdFrom(executions);
+        String marketNicheId = marketNicheIdFrom(executions).orElse(null);
         BigDecimal aiCostUsd = sumAiCostUsd(lastExecution.getJobId(), executions);
         boolean usedAi = aiCostUsd.compareTo(BigDecimal.ZERO) > 0
                 || hasAuditedOpenAiInteraction(lastExecution.getJobId())
@@ -516,7 +646,7 @@ public class BackendCandidateGeneratorService {
     }
 
     /** Extrai o ID de nicho materializado quando alguma etapa persistiu esse identificador no payload. */
-    private String marketNicheIdFrom(List<OprmNichoCnaeV2StageExecution> executions) {
+    private Optional<String> marketNicheIdFrom(List<OprmNichoCnaeV2StageExecution> executions) {
         return executions.stream()
                 .sorted(Comparator.comparing(OprmNichoCnaeV2StageExecution::getUpdatedAt, Comparator.nullsLast(Comparator.naturalOrder()))
                         .reversed())
@@ -525,8 +655,7 @@ public class BackendCandidateGeneratorService {
                 .filter(Objects::nonNull)
                 .map(String::valueOf)
                 .filter(value -> !value.isBlank())
-                .findFirst()
-                .orElse(null);
+                .findFirst();
     }
 
     /** Soma custo de IA em dólares registrado na saída própria de cada etapa do job. */

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/candidategenerator/service/confirmNiche/CandidateGeneratorConfirmNicheRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/candidategenerator/service/confirmNiche/CandidateGeneratorConfirmNicheRequest.java
@@ -1,0 +1,4 @@
+package com.marketinghub.oprm.nichocnae.v2.candidategenerator.service.confirmNiche;
+
+/** Contrato recebido da tela para confirmar o nome único do nicho gerado pelo job NichoCNAE v2. */
+public record CandidateGeneratorConfirmNicheRequest(String nicheName) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/candidategenerator/service/confirmNiche/CandidateGeneratorConfirmNicheResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/candidategenerator/service/confirmNiche/CandidateGeneratorConfirmNicheResponse.java
@@ -1,0 +1,15 @@
+package com.marketinghub.oprm.nichocnae.v2.candidategenerator.service.confirmNiche;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+
+/** Contrato devolvido após transformar o job NichoCNAE v2 aprovado em MarketNiche. */
+public record CandidateGeneratorConfirmNicheResponse(
+        String jobId,
+        String cnaeCode,
+        Long marketNicheId,
+        String nicheName,
+        BigDecimal aiCostUsd,
+        String status,
+        String message,
+        Instant updatedAt) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/candidategenerator/service/detailJob/CandidateGeneratorJobDetailResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/candidategenerator/service/detailJob/CandidateGeneratorJobDetailResponse.java
@@ -1,5 +1,6 @@
 package com.marketinghub.oprm.nichocnae.v2.candidategenerator.service.detailJob;
 
+import java.math.BigDecimal;
 import java.util.List;
 
 /** Detalha o histórico persistido de etapas de um job NichoCNAE v2. */
@@ -12,4 +13,8 @@ public record CandidateGeneratorJobDetailResponse(
         String finalDecisionReason,
         String outcomeStatus,
         String outcomeMessage,
+        String proposedNicheName,
+        Long marketNicheId,
+        BigDecimal aiCostUsd,
+        Boolean canConfirmNiche,
         List<CandidateGeneratorJobStageStep> stages) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/niche/MarketNicheRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/niche/MarketNicheRepository.java
@@ -127,4 +127,9 @@ public interface MarketNicheRepository extends JpaRepository<MarketNiche, Long> 
             """)
     void incrementTotalCost(@Param("id") Long id, @Param("delta") BigDecimal delta);
 
+    /**
+     * Verifica se já existe nicho com o mesmo nome, ignorando caixa, para impedir duplicidade comercial.
+     */
+    boolean existsByNameIgnoreCase(String name);
+
 }

--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -1315,3 +1315,8 @@
 - Ajustado o comando de sucesso parcial do histórico NichoCNAE v2 para abrir o relatório do job, e não a tela legada do CNAE.
 - Causa-raiz tratada: o backend enviava o usuário para a página geral do CNAE quando a materialização automática estava desativada, misturando resultado v2 novo com subnichos/processamentos antigos.
 - Prevenção de recorrência: teste unitário valida que job v2 concluído sem nicho materializado direciona para o relatório do próprio job.
+
+## 2026-06-23 — Confirmação manual de nicho no relatório NichoCNAE v2
+
+- Adicionado ponto de confirmação no relatório do job NichoCNAE v2 para o usuário definir nome único do nicho, visualizar o custo atual de IA do job e confirmar a criação do `MarketNiche`.
+- Backend passa a impedir repetição de nome de nicho e grava o vínculo do candidato CNAE com o nicho confirmado para uso nas próximas etapas do Marketing Hub.

--- a/frontend/src/api/oprm/useOprmNichoCnaeV2ConfirmNiche.ts
+++ b/frontend/src/api/oprm/useOprmNichoCnaeV2ConfirmNiche.ts
@@ -1,0 +1,51 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { buildApiUrl } from "../../utils/buildApiUrl";
+
+export interface OprmNichoCnaeV2ConfirmNicheResponse {
+  jobId: string;
+  cnaeCode: string;
+  marketNicheId: number;
+  nicheName: string;
+  aiCostUsd: number;
+  status: string;
+  message: string;
+  updatedAt: string;
+}
+
+async function confirmOprmNichoCnaeV2Niche({
+  jobId,
+  nicheName,
+}: {
+  jobId: string;
+  nicheName: string;
+}): Promise<OprmNichoCnaeV2ConfirmNicheResponse> {
+  const response = await fetch(
+    buildApiUrl(
+      `/api/internal/oprm/nichocnae/v2/candidate-generator/stage-executions/jobs/${encodeURIComponent(jobId)}/confirm-niche`,
+    ),
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ nicheName }),
+    },
+  );
+  if (!response.ok) {
+    throw new Error(
+      `Não foi possível confirmar o nicho (status ${response.status}).`,
+    );
+  }
+  return (await response.json()) as OprmNichoCnaeV2ConfirmNicheResponse;
+}
+
+export function useOprmNichoCnaeV2ConfirmNiche(jobId: string | undefined) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: (nicheName: string) =>
+      confirmOprmNichoCnaeV2Niche({ jobId: jobId ?? "", nicheName }),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({
+        queryKey: ["oprm", "nichocnae", "v2", "job-detail", jobId],
+      });
+    },
+  });
+}

--- a/frontend/src/api/oprm/useOprmNichoCnaeV2JobDetail.ts
+++ b/frontend/src/api/oprm/useOprmNichoCnaeV2JobDetail.ts
@@ -27,6 +27,10 @@ export interface OprmNichoCnaeV2JobDetailResponse {
   finalDecisionReason: string | null;
   outcomeStatus: "SUCCESS" | "FAILURE" | "IN_PROGRESS" | string | null;
   outcomeMessage: string | null;
+  proposedNicheName: string | null;
+  marketNicheId: number | null;
+  aiCostUsd: number | null;
+  canConfirmNiche: boolean | null;
   stages: OprmNichoCnaeV2JobStageStep[];
 }
 

--- a/frontend/src/pages/oprm/OprmNichoCnaeV2JobDetailPage.tsx
+++ b/frontend/src/pages/oprm/OprmNichoCnaeV2JobDetailPage.tsx
@@ -1,4 +1,6 @@
+import { FormEvent, useEffect, useState } from "react";
 import { Link, useParams } from "react-router-dom";
+import { useOprmNichoCnaeV2ConfirmNiche } from "../../api/oprm/useOprmNichoCnaeV2ConfirmNiche";
 import { useOprmNichoCnaeV2JobDetail } from "../../api/oprm/useOprmNichoCnaeV2JobDetail";
 import PageTitle from "../../components/PageTitle";
 import OprmModuleNavigation from "./OprmModuleNavigation";
@@ -131,6 +133,20 @@ export default function OprmNichoCnaeV2JobDetailPage() {
   const decodedCnaeCode = cnaeCode ? decodeURIComponent(cnaeCode) : undefined;
   const decodedJobId = jobId ? decodeURIComponent(jobId) : undefined;
   const jobQuery = useOprmNichoCnaeV2JobDetail(decodedJobId);
+  const confirmNiche = useOprmNichoCnaeV2ConfirmNiche(decodedJobId);
+  const [nicheName, setNicheName] = useState("");
+
+  useEffect(() => {
+    if (jobQuery.data?.proposedNicheName) {
+      setNicheName(jobQuery.data.proposedNicheName);
+    }
+  }, [jobQuery.data?.proposedNicheName]);
+
+  function handleConfirmNiche(event: FormEvent<HTMLFormElement>) {
+    event.preventDefault();
+    if (!nicheName.trim()) return;
+    confirmNiche.mutate(nicheName.trim());
+  }
 
   return (
     <div className="d-flex flex-column gap-4">
@@ -198,6 +214,94 @@ export default function OprmNichoCnaeV2JobDetailPage() {
                     jobQuery.data.status}
                 </span>
               </div>
+            </div>
+          </section>
+
+
+
+          <section className="card border-0 shadow-sm">
+            <div className="card-body">
+              <div className="d-flex flex-wrap justify-content-between gap-3 mb-3">
+                <div>
+                  <span className="text-secondary small text-uppercase fw-semibold">
+                    Confirmação comercial
+                  </span>
+                  <h3 className="h5 mb-1">Transformar em nicho do Marketing Hub</h3>
+                  <p className="text-secondary mb-0">
+                    Defina um nome único, confira o custo atual de IA e confirme
+                    para liberar este nicho nas próximas etapas do sistema.
+                  </p>
+                </div>
+                {jobQuery.data.marketNicheId ? (
+                  <span className="badge text-bg-success align-self-start">
+                    Nicho confirmado #{jobQuery.data.marketNicheId}
+                  </span>
+                ) : null}
+              </div>
+
+              <form className="row g-3 align-items-end" onSubmit={handleConfirmNiche}>
+                <div className="col-lg-6">
+                  <label className="form-label fw-semibold" htmlFor="nicheName">
+                    Nome do nicho <span className="text-danger">*</span>
+                  </label>
+                  <input
+                    className="form-control"
+                    id="nicheName"
+                    value={nicheName}
+                    onChange={(event) => setNicheName(event.target.value)}
+                    disabled={!jobQuery.data.canConfirmNiche || confirmNiche.isPending}
+                    placeholder="Ex.: Rotina financeira para MEIs de beleza"
+                  />
+                  <div className="form-text">
+                    Não pode repetir o nome de outro nicho já existente.
+                  </div>
+                </div>
+                <div className="col-lg-3">
+                  <label className="form-label fw-semibold">Custo IA atual</label>
+                  <div className="form-control bg-light">
+                    {new Intl.NumberFormat("pt-BR", {
+                      style: "currency",
+                      currency: "USD",
+                    }).format(Number(jobQuery.data.aiCostUsd ?? 0))}
+                  </div>
+                </div>
+                <div className="col-lg-3 d-grid">
+                  <button
+                    className="btn btn-primary"
+                    type="submit"
+                    disabled={
+                      !jobQuery.data.canConfirmNiche ||
+                      confirmNiche.isPending ||
+                      !nicheName.trim()
+                    }
+                  >
+                    {confirmNiche.isPending ? (
+                      <>
+                        <span className="spinner-border spinner-border-sm me-2" aria-hidden="true" />
+                        Confirmando...
+                      </>
+                    ) : (
+                      "Confirmar nicho"
+                    )}
+                  </button>
+                </div>
+              </form>
+              {!jobQuery.data.canConfirmNiche && !jobQuery.data.marketNicheId ? (
+                <p className="text-secondary small mt-3 mb-0">
+                  A confirmação fica disponível quando o backend concluir o job
+                  com sucesso e ainda não existir nicho materializado.
+                </p>
+              ) : null}
+              {confirmNiche.isError ? (
+                <div className="alert alert-danger mt-3 mb-0" role="alert">
+                  {confirmNiche.error.message}
+                </div>
+              ) : null}
+              {confirmNiche.isSuccess ? (
+                <div className="alert alert-success mt-3 mb-0" role="alert">
+                  {confirmNiche.data.message}
+                </div>
+              ) : null}
             </div>
           </section>
 


### PR DESCRIPTION
### Motivation
- Allow an administrator to confirm a completed NichoCNAE v2 job as a MarketNiche by choosing a unique niche name and capturing the AI cost so the Marketing Hub can continue the pipeline. 
- Prevent duplicate niche names and ensure the frontend shows the authoritative backend truth (proposed name, current AI spend and confirmation availability) before transforming a candidate into a `MarketNiche`.

### Description
- Backend: added `POST /api/internal/oprm/nichocnae/v2/candidate-generator/stage-executions/jobs/{jobId}/confirm-niche` and implemented `confirmNiche` in `BackendCandidateGeneratorService` to validate uniqueness, create a `MarketNiche`, link it to the source candidate, update the stage output payload and return a confirmation contract. 
- Backend: extended job detail contract `CandidateGeneratorJobDetailResponse` to include `proposedNicheName`, `marketNicheId`, `aiCostUsd` and `canConfirmNiche`; changed internal `marketNicheIdFrom(...)` to return `Optional<String>`; added helper methods to build description, merge payload and validate uniqueness. 
- Backend: added `CandidateGeneratorConfirmNicheRequest` / `CandidateGeneratorConfirmNicheResponse` records and `existsByNameIgnoreCase` in `MarketNicheRepository` to enforce name uniqueness. 
- Frontend: added `useOprmNichoCnaeV2ConfirmNiche` hook and updated `useOprmNichoCnaeV2JobDetail` types to surface the new fields; updated `OprmNichoCnaeV2JobDetailPage.tsx` to show a confirmation card where the user sets a unique name, sees current AI cost, and confirms the niche with proper disabled/loading states. 
- Documentation: recorded the change in `docs/registros/oprm1.md` to track the OPRM operational decision.

### Testing
- Ran backend compilation and unit tests with `mvn -q -DskipTests compile` and `mvn -q -Dtest=BackendCandidateGeneratorServiceTest test`, which completed after fixes to constructor overloads and type adjustments. (tests exercised the modified service.)
- Ran frontend typecheck and tests with `npm run typecheck` and `npm test -- --run src/pages/oprm/OprmJobsPage.test.tsx`, and the `OprmJobsPage` test passed; typecheck succeeded after installing dependencies. 
- Notes: attempted `mvn -q spotless:apply` but the `spotless` plugin prefix is not configured in this Maven build, and a page-specific Vitest run for `OprmNichoCnaeV2JobDetailPage.tsx` found no matching test file; these are non-blocking operational notes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3a012f574c83219d0c1b068e276683)