### PR TITLE
Preserve OPRM module isolation by introducing OprmConfirmedMarketNiche adapter

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/candidategenerator/service/BackendCandidateGeneratorService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/candidategenerator/service/BackendCandidateGeneratorService.java
@@ -3,7 +3,6 @@ package com.marketinghub.oprm.nichocnae.v2.candidategenerator.service;
 import com.fasterxml.jackson.core.JsonProcessingException;
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.marketinghub.niche.MarketNiche;
 import com.marketinghub.oprm.cnae.OprmNicheCandidate;
 import com.marketinghub.oprm.nichocnae.v2.OprmNichoCnaeV2FailureType;
 import com.marketinghub.oprm.nichocnae.v2.OprmNichoCnaeV2OpenAiInteraction;
@@ -23,7 +22,8 @@ import com.marketinghub.oprm.nichocnae.v2.candidategenerator.service.listCnaeJob
 import com.marketinghub.oprm.nichocnae.v2.candidategenerator.service.listCnaeJobs.CandidateGeneratorCnaeJobsResponse;
 import com.marketinghub.oprm.nichocnae.v2.candidategenerator.service.pending.CandidateGeneratorPendingResponse;
 import com.marketinghub.oprm.nichocnae.v2.service.openaiinteraction.OpenAiInteractionAuditRequest;
-import com.marketinghub.repository.jpa.niche.MarketNicheRepository;
+import com.marketinghub.repository.jpa.oprm.cnae.OprmConfirmedMarketNiche;
+import com.marketinghub.repository.jpa.oprm.cnae.OprmConfirmedMarketNicheRepository;
 import com.marketinghub.repository.jpa.oprm.cnae.OprmNicheCandidateRepository;
 import com.marketinghub.repository.jpa.oprm.nichocnae.v2.OprmNichoCnaeV2OpenAiInteractionRepository;
 import com.marketinghub.repository.jpa.oprm.nichocnae.v2.OprmNichoCnaeV2StageExecutionRepository;
@@ -77,7 +77,7 @@ public class BackendCandidateGeneratorService {
             "createdMarketNicheId");
 
     private final OprmNicheCandidateRepository nicheCandidateRepository;
-    private final MarketNicheRepository marketNicheRepository;
+    private final OprmConfirmedMarketNicheRepository confirmedMarketNicheRepository;
     private final OprmNichoCnaeV2StageExecutionRepository stageExecutionRepository;
     private final OprmNichoCnaeV2OpenAiInteractionRepository openAiInteractionRepository;
     private final boolean v2Enabled;
@@ -87,13 +87,13 @@ public class BackendCandidateGeneratorService {
     @Autowired
     public BackendCandidateGeneratorService(
             OprmNicheCandidateRepository nicheCandidateRepository,
-            MarketNicheRepository marketNicheRepository,
+            OprmConfirmedMarketNicheRepository confirmedMarketNicheRepository,
             OprmNichoCnaeV2StageExecutionRepository stageExecutionRepository,
             OprmNichoCnaeV2OpenAiInteractionRepository openAiInteractionRepository,
             @Value("${oprm.nichocnae.v2.enabled:false}") boolean v2Enabled,
             @Value("${oprm.nichocnae.v2.materialization-enabled:false}") boolean materializationEnabled) {
         this.nicheCandidateRepository = nicheCandidateRepository;
-        this.marketNicheRepository = marketNicheRepository;
+        this.confirmedMarketNicheRepository = confirmedMarketNicheRepository;
         this.stageExecutionRepository = stageExecutionRepository;
         this.openAiInteractionRepository = openAiInteractionRepository;
         this.v2Enabled = v2Enabled;
@@ -103,11 +103,11 @@ public class BackendCandidateGeneratorService {
     /** Mantém compatibilidade com testes unitários que não exercem auditoria OpenAI. */
     public BackendCandidateGeneratorService(
             OprmNicheCandidateRepository nicheCandidateRepository,
-            MarketNicheRepository marketNicheRepository,
+            OprmConfirmedMarketNicheRepository confirmedMarketNicheRepository,
             OprmNichoCnaeV2StageExecutionRepository stageExecutionRepository,
             boolean v2Enabled,
             boolean materializationEnabled) {
-        this(nicheCandidateRepository, marketNicheRepository, stageExecutionRepository, null, v2Enabled, materializationEnabled);
+        this(nicheCandidateRepository, confirmedMarketNicheRepository, stageExecutionRepository, null, v2Enabled, materializationEnabled);
     }
 
     /** Mantém compatibilidade com testes unitários antigos sem repositório de MarketNiche. */
@@ -261,7 +261,7 @@ public class BackendCandidateGeneratorService {
     /** Confirma manualmente um job concluído como nicho de mercado com nome único para uso nas próximas etapas. */
     @Transactional
     public CandidateGeneratorConfirmNicheResponse confirmNiche(String jobId, CandidateGeneratorConfirmNicheRequest request) {
-        if (marketNicheRepository == null) {
+        if (confirmedMarketNicheRepository == null) {
             throw new ResponseStatusException(HttpStatus.CONFLICT, "Repositório de nichos indisponível para confirmação.");
         }
         List<OprmNichoCnaeV2StageExecution> executions = stageExecutionRepository.findByJobIdOrderByCreatedAtAsc(jobId);
@@ -274,26 +274,22 @@ public class BackendCandidateGeneratorService {
         }
         String name = requiredUniqueNicheName(request == null ? null : request.nicheName());
         OprmNichoCnaeV2StageExecution lastExecution = executions.getLast();
-        MarketNiche marketNiche = new MarketNiche();
-        marketNiche.setName(name);
-        marketNiche.setDescription(buildConfirmedNicheDescription(executions));
-        marketNiche.setTotalCost(summary.aiCostUsd());
-        marketNiche.setCost(summary.aiCostUsd());
-        MarketNiche saved = marketNicheRepository.save(marketNiche);
+        OprmConfirmedMarketNiche saved = confirmedMarketNicheRepository.createConfirmedNiche(
+                name, buildConfirmedNicheDescription(executions), summary.aiCostUsd());
         nicheCandidateRepository.findById(lastExecution.getSourceNicheId()).ifPresent(candidate -> {
-            candidate.setMarketNicheId(saved.getId());
+            candidate.setMarketNicheId(saved.id());
             candidate.setStatus("APPROVED");
             candidate.setUpdatedAt(Instant.now());
             nicheCandidateRepository.save(candidate);
         });
-        lastExecution.setOutputPayload(mergeOutputPayload(lastExecution.getOutputPayload(), saved.getId(), name, summary.aiCostUsd()));
+        lastExecution.setOutputPayload(mergeOutputPayload(lastExecution.getOutputPayload(), saved.id(), name, summary.aiCostUsd()));
         lastExecution.setUpdatedAt(Instant.now());
         stageExecutionRepository.save(lastExecution);
         return new CandidateGeneratorConfirmNicheResponse(
                 jobId,
                 lastExecution.getCnaeCode(),
-                saved.getId(),
-                saved.getName(),
+                saved.id(),
+                saved.name(),
                 summary.aiCostUsd(),
                 "CONFIRMED_AS_NICHE",
                 "Nicho confirmado e disponível para a sequência do Marketing Hub.",
@@ -358,7 +354,7 @@ public class BackendCandidateGeneratorService {
         if (normalized.isBlank()) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "Informe um nome para o nicho.");
         }
-        if (marketNicheRepository.existsByNameIgnoreCase(normalized)) {
+        if (confirmedMarketNicheRepository.existsByNameIgnoreCase(normalized)) {
             throw new ResponseStatusException(HttpStatus.CONFLICT, "Já existe um nicho com esse nome. Escolha um nome único.");
         }
         return normalized;

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/oprm/cnae/OprmConfirmedMarketNiche.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/oprm/cnae/OprmConfirmedMarketNiche.java
@@ -1,0 +1,6 @@
+package com.marketinghub.repository.jpa.oprm.cnae;
+
+import java.math.BigDecimal;
+
+/** Representa o nicho de mercado confirmado pelo OPRM sem expor entidades de outros módulos ao service OPRM. */
+public record OprmConfirmedMarketNiche(Long id, String name, BigDecimal cost) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/oprm/cnae/OprmConfirmedMarketNicheRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/oprm/cnae/OprmConfirmedMarketNicheRepository.java
@@ -1,0 +1,33 @@
+package com.marketinghub.repository.jpa.oprm.cnae;
+
+import com.marketinghub.niche.MarketNiche;
+import com.marketinghub.repository.jpa.niche.MarketNicheRepository;
+import java.math.BigDecimal;
+import org.springframework.stereotype.Repository;
+
+/** Centraliza a materialização de nichos confirmados pelo OPRM usando o repositório canônico de nichos. */
+@Repository
+public class OprmConfirmedMarketNicheRepository {
+    private final MarketNicheRepository marketNicheRepository;
+
+    /** Inicializa o adaptador OPRM com o repositório canônico de nichos de mercado. */
+    public OprmConfirmedMarketNicheRepository(MarketNicheRepository marketNicheRepository) {
+        this.marketNicheRepository = marketNicheRepository;
+    }
+
+    /** Verifica se já existe nicho com o mesmo nome para preservar unicidade comercial. */
+    public boolean existsByNameIgnoreCase(String name) {
+        return marketNicheRepository.existsByNameIgnoreCase(name);
+    }
+
+    /** Cria o nicho de mercado confirmado e retorna apenas o contrato permitido ao módulo OPRM. */
+    public OprmConfirmedMarketNiche createConfirmedNiche(String name, String description, BigDecimal cost) {
+        MarketNiche marketNiche = new MarketNiche();
+        marketNiche.setName(name);
+        marketNiche.setDescription(description);
+        marketNiche.setTotalCost(cost);
+        marketNiche.setCost(cost);
+        MarketNiche saved = marketNicheRepository.save(marketNiche);
+        return new OprmConfirmedMarketNiche(saved.getId(), saved.getName(), saved.getCost());
+    }
+}

--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -1320,3 +1320,9 @@
 
 - Adicionado ponto de confirmação no relatório do job NichoCNAE v2 para o usuário definir nome único do nicho, visualizar o custo atual de IA do job e confirmar a criação do `MarketNiche`.
 - Backend passa a impedir repetição de nome de nicho e grava o vínculo do candidato CNAE com o nicho confirmado para uso nas próximas etapas do Marketing Hub.
+
+## 2026-06-23 — Correção da arquitetura OPRM na confirmação de nicho
+
+- Removida a dependência direta do `candidate-generator` OPRM v2 sobre o repositório canônico de nichos fora do pacote permitido pela regra de arquitetura.
+- A criação do `MarketNiche` confirmado passa por um adaptador de persistência em `repository.jpa.oprm`, preservando o contrato do módulo OPRM e mantendo a regra ArchUnit como prevenção de recorrência.
+- Causa-raiz tratada: o service OPRM tinha assumido diretamente a materialização em `MarketNicheRepository`, quebrando o isolamento do módulo OPRM.


### PR DESCRIPTION
### Motivation
- The OPRM candidate-generator service violated the architectural rule by depending directly on the canonical `MarketNicheRepository`, exposing cross-module persistence from `oprm` to `niche` packages. 
- The change restores module isolation required by ArchUnit: OPRM must only depend on approved `repository.jpa.oprm` contracts and not import `repository.jpa.niche` types.

### Description
- Replaced direct usage of the canonical `MarketNicheRepository` in `BackendCandidateGeneratorService` with a new adapter `OprmConfirmedMarketNicheRepository` and lightweight return contract `OprmConfirmedMarketNiche` in `com.marketinghub.repository.jpa.oprm.cnae`.
- Updated `backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v2/candidategenerator/service/BackendCandidateGeneratorService.java` to use the adapter for niche confirmation, adjust constructors and null-checks, and to persist only allowed contract fields (`id`, `name`, `cost`).
- Added adapter implementation in `backend/ads-service/src/main/java/com/marketinghub/repository/jpa/oprm/cnae/OprmConfirmedMarketNicheRepository.java` and contract record in `.../OprmConfirmedMarketNiche.java` that internally delegates to the canonical `MarketNicheRepository` without exposing it to OPRM service code.
- Documented the architectural fix and cause-root in `docs/registros/oprm1.md`.

### Testing
- Ran unit tests for the modified service and architecture checks with `../mvnw -Dtest=BackendCandidateGeneratorServiceTest,ArquiteturaTest test` from `backend/ads-service`. 
- `BackendCandidateGeneratorServiceTest` executed and passed (no failures). 
- `ArquiteturaTest` executed and passed, validating the ArchUnit constraints; overall test run completed with all tests green (`87` tests, `0` failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3a0a03ffe48321a84d3db163d80cc7)