### PR TITLE
Sales Pages Library: show only latest analysis; stop auto-preserving previous results

### DIFF
--- a/docs/registros/mois1.md
+++ b/docs/registros/mois1.md
@@ -1772,3 +1772,9 @@ Arquivos principais:
 - Alterada a integração OpenAI da etapa de análise comercial do `mois-sales-library-worker` para usar Responses API com `service_tier: "flex"`, removendo o fluxo operacional de criação/polling da Batch API.
 - Atualizado o cânone MOIS para refletir que a análise comercial usa Responses Flex, timeout canônico de 15 minutos e payload auditado com `service_tier: "flex"`.
 - Ajustado o teste de contrato do analisador para impedir regressão para payload sem modo Flex.
+
+## 2026-06-23 — Regra de exibição da análise mais recente na Biblioteca Sales Pages
+
+- Revisada a decisão sobre retentativas de análise comercial: a tela deve refletir somente a execução mais recente da página, mesmo quando a tentativa mais recente falhar.
+- Removida a preservação automática de análise anterior concluída no status consolidado, porque ela misturava execução antiga com tentativa nova e poderia esconder erro operacional atual.
+- Mantida a leitura da causa operacional no histórico de execuções, preservando transparência para reprocessar quando a chamada OpenAI falhar.


### PR DESCRIPTION
### Motivation
- Prevent the frontend from displaying a stale successful analysis when a new analysis attempt fails, so the UI reflects the current operational state of the Sales Pages Library.

### Description
- Added a `2026-06-23` entry to `docs/registros/mois1.md` documenting that the detail screen must present only the most recent analysis execution for a page, removed the rule to automatically preserve a prior completed analysis in the consolidated status, and kept the recording of operational failure causes in the execution history.

### Testing
- No automated tests were required or modified for this documentation-only change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3a6723e1188321917fe9825f694e0b)