### PR TITLE
Fix experiment promise status schema (allow DISMISSED)

### DIFF
--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-23-experiment-promise-status-varchar.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-23-experiment-promise-status-varchar.yaml
@@ -1,0 +1,30 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-06-23-experiment-promise-status-varchar
+      author: marketinghub
+      preConditions:
+        - onFail: MARK_RAN
+        - onError: HALT
+        - dbms:
+            type: mysql
+        - tableExists:
+            tableName: experiment_promise_generation_request
+        - columnExists:
+            tableName: experiment_promise_generation_request
+            columnName: status
+      changes:
+        - sql:
+            dbms: mysql
+            splitStatements: true
+            stripComments: true
+            sql: |
+              ALTER TABLE experiment_promise_generation_request
+                MODIFY status VARCHAR(32) NOT NULL DEFAULT 'PENDING';
+      rollback:
+        - sql:
+            dbms: mysql
+            splitStatements: true
+            stripComments: true
+            sql: |
+              ALTER TABLE experiment_promise_generation_request
+                MODIFY status VARCHAR(32) NOT NULL DEFAULT 'PENDING';

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -1,5 +1,8 @@
 databaseChangeLog:
   - include:
+      file: changesets/2026-06-23-experiment-promise-status-varchar.yaml
+      relativeToChangelogFile: true
+  - include:
       file: changesets/2026-06-22-oprm-nichocnae-v2-status-varchar.yaml
       relativeToChangelogFile: true
   - include:

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -5088,3 +5088,9 @@
 - Causa-raiz: a implementação do analytics da landing evoluiu, mas o contrato textual do teste não foi atualizado junto.
 - Correção aplicada: o teste de regressão passou a validar o contrato atual de persistência first-party em `localStorage` e `sessionStorage`, mantendo as proteções contra metadados técnicos no HTML final.
 - Prevenção de recorrência: a validação agora acompanha os trechos efetivamente emitidos pelo controller, evitando falha por expectativa legada sem reduzir a cobertura do analytics público.
+
+## 2026-06-23 — Correção do salvamento de experimento com promessa única
+- Problema: ao salvar um experimento criado a partir da promessa única gerada por IA, o backend falhava ao descartar a solicitação usada com status `DISMISSED`.
+- Causa-raiz: o schema real da coluna `experiment_promise_generation_request.status` ainda podia estar restrito a um tipo/enum antigo que não aceitava `DISMISSED`, apesar do contrato Java já prever esse status.
+- Correção aplicada: criado changelog incremental para normalizar a coluna `status` como `VARCHAR(32) NOT NULL DEFAULT 'PENDING'`, permitindo todos os estados operacionais atuais sem truncamento.
+- Prevenção de recorrência: o descarte do rascunho passa a depender de uma coluna textual compatível com evolução de estados da fila, evitando novo bloqueio ao adicionar status legítimos.


### PR DESCRIPTION
### Motivation
- Salvar um experimento falhava com erro SQL `Data truncated for column 'status'` porque a coluna `experiment_promise_generation_request.status` não aceitava o valor operacional `DISMISSED` atualmente usado pelo backend Java.
- É necessário garantir que o esquema do banco seja compatível com a evolução dos estados da fila para evitar truncamento ao descartar rascunhos gerados pelo AI Worker.

### Description
- Adiciona um changelog Liquibase `changesets/2026-06-23-experiment-promise-status-varchar.yaml` que altera a coluna para `VARCHAR(32) NOT NULL DEFAULT 'PENDING'` permitindo todos os estados atuais (incluindo `DISMISSED`).
- Inclui o novo changeset no `db.changelog-master.yaml` com `relativeToChangelogFile: true` para evitar problemas de resolução de caminho no Liquibase.
- Atualiza `docs/registros/experimentos.md` registrando o diagnóstico, causa-raiz e a correção aplicada.
- Commit realizado com a mensagem `Fix experiment promise status schema` e arquivos adicionados ao repositório.

### Testing
- Executado o teste unitário `ExperimentPromiseGenerationServiceTest` com `cd backend/ads-service && ../mvnw -Dtest=ExperimentPromiseGenerationServiceTest test` e a suíte específica completou com sucesso.
- Verificado `git diff --check` para assegurar ausência de problemas no diff e validado o commit criado com sucesso.
- Executado script de verificação das entradas do `db.changelog-master.yaml` (valida `relativeToChangelogFile`) e a checagem automática passou.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3a6abd16d883218bfd9af66fde146d)