### PR TITLE
Corrige exibição de horários no histórico da Biblioteca Sales Pages

### DIFF
--- a/docs/registros/mois1.md
+++ b/docs/registros/mois1.md
@@ -1772,3 +1772,8 @@ Arquivos principais:
 - Alterada a integração OpenAI da etapa de análise comercial do `mois-sales-library-worker` para usar Responses API com `service_tier: "flex"`, removendo o fluxo operacional de criação/polling da Batch API.
 - Atualizado o cânone MOIS para refletir que a análise comercial usa Responses Flex, timeout canônico de 15 minutos e payload auditado com `service_tier: "flex"`.
 - Ajustado o teste de contrato do analisador para impedir regressão para payload sem modo Flex.
+
+## 2026-06-23 — Horários sem conversão de fuso na Biblioteca Sales Pages
+
+- Corrigida a exibição dos horários no detalhe `/mois/sales-pages-library/:pageId` para apresentar o horário literal retornado pelo backend, sem conversão automática pelo fuso do navegador.
+- A mudança evita que o histórico da página apareça com 3 horas a menos e mantém a tela mostrando a verdade persistida pelo backend.

--- a/frontend/src/pages/mois/MoisSalesPageLibraryDetailPage.tsx
+++ b/frontend/src/pages/mois/MoisSalesPageLibraryDetailPage.tsx
@@ -36,10 +36,14 @@ function formatHotmartTemperature(value?: number | null) {
 
 function formatDate(value?: string) {
   if (!value) return "—";
-  const date = new Date(value);
-  return Number.isNaN(date.getTime())
-    ? "—"
-    : date.toLocaleString("pt-BR", { dateStyle: "short", timeStyle: "short" });
+  const match = value.match(
+    /^(\d{4})-(\d{2})-(\d{2})(?:[T\s](\d{2}):(\d{2}))?/,
+  );
+  if (!match) return "—";
+
+  const [, year, month, day, hour, minute] = match;
+  const formattedDate = `${day}/${month}/${year}`;
+  return hour && minute ? `${formattedDate}, ${hour}:${minute}` : formattedDate;
 }
 
 function labelStatus(value?: string) {


### PR DESCRIPTION
### Motivation
- O histórico da página estava sendo exibido com diferença de 3 horas devido à conversão automática de fuso horáreo pelo navegador; é preciso mostrar o horário literal persistido pelo backend para manter a "regra de verdade da tela".

### Description
- Substituída a função `formatDate` em `frontend/src/pages/mois/MoisSalesPageLibraryDetailPage.tsx` para formatar o valor literal retornado pelo backend (parsing por regex e saída `DD/MM/YYYY` ou `DD/MM/YYYY, HH:MM`) sem criar um `Date` que aplique conversão de fuso.
- Atualizado `docs/registros/mois1.md` com registro da correção para manter o histórico de mudanças do módulo MOIS.
- Alteração focada no frontend para preservar o valor persistido pelo backend ao apresentar histórico de execuções.

### Testing
- Executado `npm ci` para instalar dependências e a execução concluiu com sucesso.
- Executado `npm run typecheck` e o `tsc --noEmit` completou sem erros.
- Executado `npx prettier --check src/pages/mois/MoisSalesPageLibraryDetailPage.tsx` e a verificação de formatação passou sem problemas.
- Executado `git diff --check` para validar o diff e não foram encontrados erros de checagem automática.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3a6b46203883218020adc9d9374496)