### PR TITLE
Clarify warmup dossier blocking and add explicit "Reprocessar dossiê" action in Mois Sales Pages

### DIFF
--- a/docs/registros/mois1.md
+++ b/docs/registros/mois1.md
@@ -1782,3 +1782,14 @@ Arquivos principais:
 - Revisada a decisão sobre retentativas de análise comercial: a tela deve refletir somente a execução mais recente da página, mesmo quando a tentativa mais recente falhar.
 - Removida a preservação automática de análise anterior concluída no status consolidado, porque ela misturava execução antiga com tentativa nova e poderia esconder erro operacional atual.
 - Mantida a leitura da causa operacional no histórico de execuções, preservando transparência para reprocessar quando a chamada OpenAI falhar.
+
+## 2026-06-23 — Clareza do bloqueio do botão iniciar dossiê
+
+- Corrigida a causa-raiz visual da tela de detalhe da Biblioteca Sales Pages não explicar por que o botão **Iniciar dossiê** ficava desabilitado quando o backend já retornava um dossiê existente.
+- A tela agora mostra um aviso objetivo quando a página já possui dossiê registrado, evitando nova fila duplicada e direcionando o usuário para usar o dossiê exibido.
+
+
+## 2026-06-23 — Reprocessamento explícito do dossiê MOIS
+
+- Ajustada a tela de detalhe da Biblioteca Sales Pages para permitir novo pedido quando já existe dossiê concluído, exibindo explicitamente o botão **Reprocessar dossiê**.
+- Mantido o bloqueio somente quando o backend indica dossiê em fila ou em processamento, e a tela informa que sempre exibirá o dossiê mais recente retornado pelo backend.

--- a/frontend/src/pages/mois/MoisSalesPageLibraryDetailPage.tsx
+++ b/frontend/src/pages/mois/MoisSalesPageLibraryDetailPage.tsx
@@ -151,20 +151,25 @@ export default function MoisSalesPageLibraryDetailPage() {
   const nextItem =
     currentIndex >= 0 ? pagesQuery.data?.items[currentIndex + 1] : undefined;
   const isMutating = updateStatusMutation.isPending;
-  const hasActiveWarmupDossier = Boolean(
-    marketWarmupQuery.data ||
-    ["PENDING", "FETCHING", "DONE"].includes(
-      pageQuery.data?.marketWarmupStatus || "",
-    ),
-  );
+  const warmupStatus =
+    pageQuery.data?.marketWarmupStatus || marketWarmupQuery.data?.status || "";
+  const hasWarmupDossier = Boolean(marketWarmupQuery.data || warmupStatus);
+  const hasActiveWarmupDossier = ["PENDING", "FETCHING"].includes(warmupStatus);
   const isCommercialAnalysisDone = ["DONE", "ANALYZED"].includes(
     pageQuery.data?.analysisStatus || pageQuery.data?.currentStatus || "",
   );
+  const warmupRequestBlockReason = hasActiveWarmupDossier
+    ? "Esta página já possui dossiê em fila ou em processamento; aguarde o backend concluir antes de reprocessar."
+    : !isCommercialAnalysisDone
+      ? "O dossiê só pode iniciar depois que a análise comercial da página estiver concluída."
+      : undefined;
+  const warmupRequestButtonLabel = hasWarmupDossier
+    ? "Reprocessar dossiê"
+    : "Iniciar dossiê";
   const isWarmupRequestDisabled =
     !validPageId ||
     requestWarmupMutation.isPending ||
-    hasActiveWarmupDossier ||
-    !isCommercialAnalysisDone;
+    Boolean(warmupRequestBlockReason);
   const currentStatus = pageQuery.data?.currentStatus;
   const analysisStatus = pageQuery.data?.analysisStatus;
   const captureStatus = pageQuery.data?.captureStatus;
@@ -268,6 +273,7 @@ export default function MoisSalesPageLibraryDetailPage() {
           type="button"
           className="btn btn-outline-primary"
           disabled={isWarmupRequestDisabled}
+          title={warmupRequestBlockReason}
           onClick={() =>
             validPageId && requestWarmupMutation.mutate(validPageId)
           }
@@ -281,7 +287,7 @@ export default function MoisSalesPageLibraryDetailPage() {
           ) : null}
           {requestWarmupMutation.isPending
             ? "Solicitando dossiê..."
-            : "Iniciar dossiê"}
+            : warmupRequestButtonLabel}
         </button>
         <button
           type="button"
@@ -362,7 +368,8 @@ export default function MoisSalesPageLibraryDetailPage() {
 
       {requestWarmupMutation.isSuccess ? (
         <div className="alert alert-success mb-0">
-          Dossiê enviado para fila.
+          Dossiê enviado para fila. A tela sempre mostrará o dossiê mais
+          recente retornado pelo backend.
         </div>
       ) : null}
       {requestWarmupMutation.isError ? (
@@ -370,16 +377,36 @@ export default function MoisSalesPageLibraryDetailPage() {
           Falha ao solicitar dossiê.
         </div>
       ) : null}
-      {!isCommercialAnalysisDone && !hasActiveWarmupDossier ? (
+      {hasWarmupDossier && !hasActiveWarmupDossier ? (
+        <div className="alert alert-info mb-0">
+          Já existe um dossiê para esta página
+          {warmupStatus ? ` com status ${labelStatus(warmupStatus)}` : ""}.
+          Você pode usar o resultado exibido abaixo ou clicar em
+          <strong> Reprocessar dossiê</strong> para criar uma nova fila. A tela
+          passará a mostrar o dossiê mais recente retornado pelo backend.
+        </div>
+      ) : null}
+
+      {warmupRequestBlockReason ? (
         <div className="alert alert-warning mb-0">
-          O dossiê fica disponível somente depois que a análise comercial da
-          página estiver concluída. Esta página ainda está em{" "}
-          <strong>
-            {pageQuery.data?.analysisStatus ||
-              pageQuery.data?.currentStatus ||
-              "SEM STATUS"}
-          </strong>
-          .
+          {hasActiveWarmupDossier ? (
+            <>
+              Esta página já possui dossiê em fila ou em processamento
+              {warmupStatus ? ` com status ${labelStatus(warmupStatus)}` : ""}
+              . Aguarde a conclusão para reprocessar.
+            </>
+          ) : (
+            <>
+              O dossiê fica disponível somente depois que a análise comercial da
+              página estiver concluída. Esta página ainda está em{" "}
+              <strong>
+                {pageQuery.data?.analysisStatus ||
+                  pageQuery.data?.currentStatus ||
+                  "SEM STATUS"}
+              </strong>
+              .
+            </>
+          )}
         </div>
       ) : null}
 


### PR DESCRIPTION
### Motivation

- Improve UX by explaining why the "Iniciar dossiê" button is disabled when a dossier already exists or is being processed and allow explicit reprocessing when appropriate.

### Description

- Updated `MoisSalesPageLibraryDetailPage.tsx` to compute `warmupStatus`, `hasWarmupDossier`, `hasActiveWarmupDossier`, `warmupRequestBlockReason` and to switch the warmup button label between `Iniciar dossiê` and `Reprocessar dossiê` based on backend state.
- Added a `title` tooltip on the warmup request button and adjusted its `disabled` logic to use `warmupRequestBlockReason` so the UI explains blocking causes.
- Reworked alert messages to explicitly inform when a dossier already exists, when a dossier is queued/processing, and to state that the UI always shows the most recent dossier returned by the backend.
- Updated documentation `docs/registros/mois1.md` with entries describing the UI clarity change and the explicit reprocessing affordance.

### Testing

- Performed a TypeScript type check and local frontend build with the modified files, which completed successfully.
- Ran the existing frontend unit test suite (`yarn test` / project test runner) and all tests passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3a803a11308321925b46605ea6f62b)