### PR TITLE
Implement ops monitor backend — fase 1

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/opsmonitor/OpsModuleAvailabilityDaily.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/opsmonitor/OpsModuleAvailabilityDaily.java
@@ -1,0 +1,62 @@
+package com.marketinghub.opsmonitor;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.LocalDate;
+import lombok.Getter;
+import lombok.Setter;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+/** Consolida a disponibilidade diária de um módulo para consultas administrativas rápidas. */
+@Entity
+@Table(name = "ops_module_availability_daily")
+@Getter
+@Setter
+public class OpsModuleAvailabilityDaily {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "module_id", nullable = false)
+    private OpsMonitoredModule module;
+
+    @Column(name = "availability_date", nullable = false)
+    private LocalDate availabilityDate;
+
+    @Column(name = "total_checks", nullable = false)
+    private Integer totalChecks;
+
+    @Column(name = "successful_checks", nullable = false)
+    private Integer successfulChecks;
+
+    @Column(name = "failed_checks", nullable = false)
+    private Integer failedChecks;
+
+    @Column(name = "availability_percentage", nullable = false, precision = 5, scale = 2)
+    private BigDecimal availabilityPercentage;
+
+    @Column(name = "offline_seconds", nullable = false)
+    private Long offlineSeconds;
+
+    @Column(name = "degraded_seconds", nullable = false)
+    private Long degradedSeconds;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/opsmonitor/OpsModuleHealthCheck.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/opsmonitor/OpsModuleHealthCheck.java
@@ -1,0 +1,54 @@
+package com.marketinghub.opsmonitor;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.Lob;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import lombok.Getter;
+import lombok.Setter;
+import org.hibernate.annotations.CreationTimestamp;
+
+/** Registra uma verificação operacional executada para um módulo monitorado. */
+@Entity
+@Table(name = "ops_module_health_check")
+@Getter
+@Setter
+public class OpsModuleHealthCheck {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "module_id", nullable = false)
+    private OpsMonitoredModule module;
+
+    @Column(name = "checked_at", nullable = false)
+    private Instant checkedAt;
+
+    @Column(name = "status", nullable = false, length = 30)
+    private String status;
+
+    @Column(name = "http_status")
+    private Integer httpStatus;
+
+    @Column(name = "response_time_ms")
+    private Long responseTimeMs;
+
+    @Column(name = "error_message", length = 1000)
+    private String errorMessage;
+
+    @Lob
+    @Column(name = "raw_payload")
+    private String rawPayload;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/opsmonitor/OpsModuleIncident.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/opsmonitor/OpsModuleIncident.java
@@ -1,0 +1,63 @@
+package com.marketinghub.opsmonitor;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import lombok.Getter;
+import lombok.Setter;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+/** Mantém o incidente operacional identificado para um módulo monitorado. */
+@Entity
+@Table(name = "ops_module_incident")
+@Getter
+@Setter
+public class OpsModuleIncident {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY, optional = false)
+    @JoinColumn(name = "module_id", nullable = false)
+    private OpsMonitoredModule module;
+
+    @Column(name = "status", nullable = false, length = 30)
+    private String status;
+
+    @Column(name = "severity", nullable = false, length = 30)
+    private String severity;
+
+    @Column(name = "started_at", nullable = false)
+    private Instant startedAt;
+
+    @Column(name = "ended_at")
+    private Instant endedAt;
+
+    @Column(name = "duration_seconds")
+    private Long durationSeconds;
+
+    @Column(name = "summary", nullable = false, length = 500)
+    private String summary;
+
+    @Column(name = "root_signal", length = 255)
+    private String rootSignal;
+
+    @Column(name = "last_error", length = 1000)
+    private String lastError;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/opsmonitor/OpsMonitoredModule.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/opsmonitor/OpsMonitoredModule.java
@@ -1,0 +1,59 @@
+package com.marketinghub.opsmonitor;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import lombok.Getter;
+import lombok.Setter;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+/** Representa um módulo monitorado operacionalmente pelo Marketing Hub. */
+@Entity
+@Table(name = "ops_monitored_module")
+@Getter
+@Setter
+public class OpsMonitoredModule {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "code", nullable = false, unique = true, length = 100)
+    private String code;
+
+    @Column(name = "name", nullable = false, length = 150)
+    private String name;
+
+    @Column(name = "type", nullable = false, length = 50)
+    private String type;
+
+    @Column(name = "base_url", nullable = false, length = 512)
+    private String baseUrl;
+
+    @Column(name = "health_path", nullable = false, length = 255)
+    private String healthPath;
+
+    @Column(name = "log_path", length = 255)
+    private String logPath;
+
+    @Column(name = "enabled", nullable = false)
+    private boolean enabled;
+
+    @Column(name = "criticality", nullable = false, length = 30)
+    private String criticality;
+
+    @Column(name = "offline_threshold_seconds", nullable = false)
+    private Integer offlineThresholdSeconds;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/opsmonitor/controller/OpsMonitorController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/opsmonitor/controller/OpsMonitorController.java
@@ -1,0 +1,80 @@
+package com.marketinghub.opsmonitor.controller;
+
+import com.marketinghub.opsmonitor.service.OpsMonitorService;
+import com.marketinghub.opsmonitor.service.listAvailability.ModuleAvailabilityResponse;
+import com.marketinghub.opsmonitor.service.listAvailabilityHistory.ModuleAvailabilityHistoryResponse;
+import com.marketinghub.opsmonitor.service.listIncidents.ModuleIncidentResponse;
+import com.marketinghub.opsmonitor.service.listPendingChecks.PendingModuleCheckResponse;
+import com.marketinghub.opsmonitor.service.registerHeartbeat.RegisterModuleHeartbeatRequest;
+import com.marketinghub.opsmonitor.service.registerHeartbeat.RegisterModuleHeartbeatResponse;
+import com.marketinghub.opsmonitor.service.registerIncident.RegisterModuleIncidentRequest;
+import com.marketinghub.opsmonitor.service.registerIncident.RegisterModuleIncidentResponse;
+import com.marketinghub.opsmonitor.service.summary.OpsMonitorSummaryResponse;
+import java.util.List;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/** Expõe contratos internos e administrativos do monitoramento operacional. */
+@RestController
+@RequestMapping
+public class OpsMonitorController {
+    private final OpsMonitorService service;
+
+    public OpsMonitorController(OpsMonitorService service) {
+        this.service = service;
+    }
+
+    /** Entrega ao worker a lista de módulos pendentes para verificação operacional. */
+    @GetMapping("/api/internal/ops-monitor/v1/module-checks/stage-executions/pending")
+    public List<PendingModuleCheckResponse> pending() {
+        return service.listPendingChecks();
+    }
+
+    /** Recebe o heartbeat de saúde de um módulo monitorado. */
+    @PostMapping("/api/internal/ops-monitor/v1/modules/{moduleCode}/heartbeat")
+    public RegisterModuleHeartbeatResponse registerHeartbeat(@PathVariable String moduleCode,
+            @RequestBody RegisterModuleHeartbeatRequest request) {
+        return service.registerHeartbeat(moduleCode, request);
+    }
+
+    /** Recebe um incidente operacional identificado pelo worker. */
+    @PostMapping("/api/internal/ops-monitor/v1/modules/{moduleCode}/incidents")
+    public RegisterModuleIncidentResponse registerIncident(@PathVariable String moduleCode,
+            @RequestBody RegisterModuleIncidentRequest request) {
+        return service.registerIncident(moduleCode, request);
+    }
+
+    /** Retorna o resumo executivo para a tela administrativa. */
+    @GetMapping("/api/ops-monitor/v1/summary")
+    public OpsMonitorSummaryResponse summary() {
+        return service.getSummary();
+    }
+
+    /** Retorna o status atual dos módulos monitorados. */
+    @GetMapping("/api/ops-monitor/v1/modules/availability")
+    public List<ModuleAvailabilityResponse> listAvailability() {
+        return service.listAvailability();
+    }
+
+    /** Retorna o histórico diário de disponibilidade de um módulo. */
+    @GetMapping("/api/ops-monitor/v1/modules/{moduleCode}/availability-history")
+    public List<ModuleAvailabilityHistoryResponse> listAvailabilityHistory(@PathVariable String moduleCode) {
+        return service.listAvailabilityHistory(moduleCode);
+    }
+
+    /** Retorna incidentes operacionais abertos. */
+    @GetMapping("/api/ops-monitor/v1/incidents/open")
+    public List<ModuleIncidentResponse> listOpenIncidents() {
+        return service.listIncidents(true);
+    }
+
+    /** Retorna o histórico recente de incidentes operacionais. */
+    @GetMapping("/api/ops-monitor/v1/incidents/history")
+    public List<ModuleIncidentResponse> listIncidentHistory() {
+        return service.listIncidents(false);
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/opsmonitor/service/OpsMonitorService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/opsmonitor/service/OpsMonitorService.java
@@ -1,0 +1,147 @@
+package com.marketinghub.opsmonitor.service;
+
+import com.marketinghub.opsmonitor.OpsModuleHealthCheck;
+import com.marketinghub.opsmonitor.OpsModuleIncident;
+import com.marketinghub.opsmonitor.OpsMonitoredModule;
+import com.marketinghub.opsmonitor.service.listAvailability.ModuleAvailabilityResponse;
+import com.marketinghub.opsmonitor.service.listAvailabilityHistory.ModuleAvailabilityHistoryResponse;
+import com.marketinghub.opsmonitor.service.listIncidents.ModuleIncidentResponse;
+import com.marketinghub.opsmonitor.service.listPendingChecks.PendingModuleCheckResponse;
+import com.marketinghub.opsmonitor.service.registerHeartbeat.RegisterModuleHeartbeatRequest;
+import com.marketinghub.opsmonitor.service.registerHeartbeat.RegisterModuleHeartbeatResponse;
+import com.marketinghub.opsmonitor.service.registerIncident.RegisterModuleIncidentRequest;
+import com.marketinghub.opsmonitor.service.registerIncident.RegisterModuleIncidentResponse;
+import com.marketinghub.opsmonitor.service.summary.OpsMonitorSummaryResponse;
+import com.marketinghub.repository.jpa.opsmonitor.OpsModuleAvailabilityDailyRepository;
+import com.marketinghub.repository.jpa.opsmonitor.OpsModuleHealthCheckRepository;
+import com.marketinghub.repository.jpa.opsmonitor.OpsModuleIncidentRepository;
+import com.marketinghub.repository.jpa.opsmonitor.OpsMonitoredModuleRepository;
+import jakarta.persistence.EntityNotFoundException;
+import java.time.Instant;
+import java.util.List;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/** Orquestra contratos, persistência e consultas administrativas do monitoramento operacional. */
+@Service
+public class OpsMonitorService {
+    private final OpsMonitoredModuleRepository moduleRepository;
+    private final OpsModuleHealthCheckRepository healthCheckRepository;
+    private final OpsModuleIncidentRepository incidentRepository;
+    private final OpsModuleAvailabilityDailyRepository availabilityDailyRepository;
+
+    public OpsMonitorService(OpsMonitoredModuleRepository moduleRepository,
+            OpsModuleHealthCheckRepository healthCheckRepository,
+            OpsModuleIncidentRepository incidentRepository,
+            OpsModuleAvailabilityDailyRepository availabilityDailyRepository) {
+        this.moduleRepository = moduleRepository;
+        this.healthCheckRepository = healthCheckRepository;
+        this.incidentRepository = incidentRepository;
+        this.availabilityDailyRepository = availabilityDailyRepository;
+    }
+
+    /** Lista módulos habilitados para o worker executar verificações pendentes. */
+    @Transactional(readOnly = true)
+    public List<PendingModuleCheckResponse> listPendingChecks() {
+        return moduleRepository.findByEnabledTrueOrderByCodeAsc().stream()
+                .map(module -> new PendingModuleCheckResponse(module.getCode(), module.getName(), module.getType(),
+                        module.getBaseUrl(), module.getHealthPath(), module.getLogPath(), module.getCriticality(),
+                        module.getOfflineThresholdSeconds()))
+                .toList();
+    }
+
+    /** Registra o heartbeat recebido do worker para um módulo monitorado. */
+    @Transactional
+    public RegisterModuleHeartbeatResponse registerHeartbeat(String moduleCode, RegisterModuleHeartbeatRequest request) {
+        OpsMonitoredModule module = findModule(moduleCode);
+        OpsModuleHealthCheck check = new OpsModuleHealthCheck();
+        check.setModule(module);
+        check.setCheckedAt(request.checkedAt() == null ? Instant.now() : request.checkedAt());
+        check.setStatus(request.status());
+        check.setHttpStatus(request.httpStatus());
+        check.setResponseTimeMs(request.responseTimeMs());
+        check.setErrorMessage(request.errorMessage());
+        check.setRawPayload(request.rawPayload());
+        OpsModuleHealthCheck saved = healthCheckRepository.save(check);
+        return new RegisterModuleHeartbeatResponse(saved.getId(), module.getCode(), saved.getStatus());
+    }
+
+    /** Registra um incidente operacional informado pelo worker. */
+    @Transactional
+    public RegisterModuleIncidentResponse registerIncident(String moduleCode, RegisterModuleIncidentRequest request) {
+        OpsMonitoredModule module = findModule(moduleCode);
+        OpsModuleIncident incident = new OpsModuleIncident();
+        incident.setModule(module);
+        incident.setStatus(request.status());
+        incident.setSeverity(request.severity());
+        incident.setStartedAt(request.startedAt() == null ? Instant.now() : request.startedAt());
+        incident.setEndedAt(request.endedAt());
+        incident.setDurationSeconds(request.durationSeconds());
+        incident.setSummary(request.summary());
+        incident.setRootSignal(request.rootSignal());
+        incident.setLastError(request.lastError());
+        OpsModuleIncident saved = incidentRepository.save(incident);
+        return new RegisterModuleIncidentResponse(saved.getId(), module.getCode(), saved.getStatus(), saved.getSeverity());
+    }
+
+    /** Lista a disponibilidade atual calculada a partir do último heartbeat de cada módulo. */
+    @Transactional(readOnly = true)
+    public List<ModuleAvailabilityResponse> listAvailability() {
+        return moduleRepository.findAll().stream().map(this::toAvailabilityResponse).toList();
+    }
+
+    /** Lista o histórico diário de disponibilidade do módulo informado. */
+    @Transactional(readOnly = true)
+    public List<ModuleAvailabilityHistoryResponse> listAvailabilityHistory(String moduleCode) {
+        return availabilityDailyRepository.findTop30ByModuleCodeOrderByAvailabilityDateDesc(moduleCode).stream()
+                .map(day -> new ModuleAvailabilityHistoryResponse(day.getAvailabilityDate(), day.getTotalChecks(),
+                        day.getSuccessfulChecks(), day.getFailedChecks(), day.getAvailabilityPercentage(),
+                        day.getOfflineSeconds(), day.getDegradedSeconds()))
+                .toList();
+    }
+
+    /** Lista incidentes abertos ou o histórico recente de incidentes. */
+    @Transactional(readOnly = true)
+    public List<ModuleIncidentResponse> listIncidents(boolean openOnly) {
+        List<OpsModuleIncident> incidents = openOnly
+                ? incidentRepository.findByStatusOrderByStartedAtDesc("OPEN")
+                : incidentRepository.findTop100ByOrderByStartedAtDesc();
+        return incidents.stream().map(this::toIncidentResponse).toList();
+    }
+
+    /** Gera resumo executivo para a tela administrativa de operação. */
+    @Transactional(readOnly = true)
+    public OpsMonitorSummaryResponse getSummary() {
+        List<ModuleAvailabilityResponse> availability = listAvailability();
+        long online = availability.stream().filter(item -> "ONLINE".equals(item.status())).count();
+        long degraded = availability.stream().filter(item -> "DEGRADED".equals(item.status())).count();
+        long offline = availability.stream().filter(item -> "OFFLINE".equals(item.status())).count();
+        long unknown = availability.stream().filter(item -> "UNKNOWN".equals(item.status())).count();
+        long openIncidents = incidentRepository.findByStatusOrderByStartedAtDesc("OPEN").size();
+        return new OpsMonitorSummaryResponse(online, degraded, offline, unknown, openIncidents);
+    }
+
+    /** Busca um módulo monitorado pelo código e falha quando ele não existe. */
+    private OpsMonitoredModule findModule(String moduleCode) {
+        return moduleRepository.findByCode(moduleCode)
+                .orElseThrow(() -> new EntityNotFoundException("Módulo monitorado não encontrado: " + moduleCode));
+    }
+
+    /** Converte entidade de módulo para o status administrativo atual. */
+    private ModuleAvailabilityResponse toAvailabilityResponse(OpsMonitoredModule module) {
+        return healthCheckRepository.findTop1ByModuleCodeOrderByCheckedAtDesc(module.getCode())
+                .map(check -> new ModuleAvailabilityResponse(module.getCode(), module.getName(), module.getType(),
+                        module.getCriticality(), check.getStatus(), check.getCheckedAt(), check.getResponseTimeMs(),
+                        check.getErrorMessage()))
+                .orElseGet(() -> new ModuleAvailabilityResponse(module.getCode(), module.getName(), module.getType(),
+                        module.getCriticality(), "UNKNOWN", null, null, null));
+    }
+
+    /** Converte entidade de incidente para resposta administrativa. */
+    private ModuleIncidentResponse toIncidentResponse(OpsModuleIncident incident) {
+        OpsMonitoredModule module = incident.getModule();
+        return new ModuleIncidentResponse(incident.getId(), module.getCode(), module.getName(), incident.getStatus(),
+                incident.getSeverity(), incident.getStartedAt(), incident.getEndedAt(), incident.getDurationSeconds(),
+                incident.getSummary(), incident.getRootSignal(), incident.getLastError());
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/opsmonitor/service/listAvailability/ModuleAvailabilityResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/opsmonitor/service/listAvailability/ModuleAvailabilityResponse.java
@@ -1,0 +1,7 @@
+package com.marketinghub.opsmonitor.service.listAvailability;
+
+import java.time.Instant;
+
+/** Status atual de disponibilidade de um módulo monitorado. */
+public record ModuleAvailabilityResponse(String moduleCode, String name, String type, String criticality,
+        String status, Instant lastCheckedAt, Long lastResponseTimeMs, String lastError) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/opsmonitor/service/listAvailabilityHistory/ModuleAvailabilityHistoryResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/opsmonitor/service/listAvailabilityHistory/ModuleAvailabilityHistoryResponse.java
@@ -1,0 +1,8 @@
+package com.marketinghub.opsmonitor.service.listAvailabilityHistory;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+/** Ponto diário do histórico de disponibilidade de um módulo. */
+public record ModuleAvailabilityHistoryResponse(LocalDate date, Integer totalChecks, Integer successfulChecks,
+        Integer failedChecks, BigDecimal availabilityPercentage, Long offlineSeconds, Long degradedSeconds) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/opsmonitor/service/listIncidents/ModuleIncidentResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/opsmonitor/service/listIncidents/ModuleIncidentResponse.java
@@ -1,0 +1,7 @@
+package com.marketinghub.opsmonitor.service.listIncidents;
+
+import java.time.Instant;
+
+/** Incidente operacional apresentado nas telas administrativas. */
+public record ModuleIncidentResponse(Long id, String moduleCode, String moduleName, String status, String severity,
+        Instant startedAt, Instant endedAt, Long durationSeconds, String summary, String rootSignal, String lastError) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/opsmonitor/service/listPendingChecks/PendingModuleCheckResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/opsmonitor/service/listPendingChecks/PendingModuleCheckResponse.java
@@ -1,0 +1,5 @@
+package com.marketinghub.opsmonitor.service.listPendingChecks;
+
+/** Dados que orientam o worker na próxima verificação de saúde de um módulo. */
+public record PendingModuleCheckResponse(String moduleCode, String name, String type, String baseUrl,
+        String healthPath, String logPath, String criticality, Integer offlineThresholdSeconds) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/opsmonitor/service/registerHeartbeat/RegisterModuleHeartbeatRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/opsmonitor/service/registerHeartbeat/RegisterModuleHeartbeatRequest.java
@@ -1,0 +1,7 @@
+package com.marketinghub.opsmonitor.service.registerHeartbeat;
+
+import java.time.Instant;
+
+/** Payload enviado pelo worker com o resultado de uma verificação operacional. */
+public record RegisterModuleHeartbeatRequest(Instant checkedAt, String status, Integer httpStatus, Long responseTimeMs,
+        String errorMessage, String rawPayload) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/opsmonitor/service/registerHeartbeat/RegisterModuleHeartbeatResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/opsmonitor/service/registerHeartbeat/RegisterModuleHeartbeatResponse.java
@@ -1,0 +1,4 @@
+package com.marketinghub.opsmonitor.service.registerHeartbeat;
+
+/** Confirma o registro de heartbeat operacional recebido do worker. */
+public record RegisterModuleHeartbeatResponse(Long healthCheckId, String moduleCode, String status) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/opsmonitor/service/registerIncident/RegisterModuleIncidentRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/opsmonitor/service/registerIncident/RegisterModuleIncidentRequest.java
@@ -1,0 +1,7 @@
+package com.marketinghub.opsmonitor.service.registerIncident;
+
+import java.time.Instant;
+
+/** Payload enviado pelo worker para registrar um incidente operacional. */
+public record RegisterModuleIncidentRequest(String status, String severity, Instant startedAt, Instant endedAt,
+        Long durationSeconds, String summary, String rootSignal, String lastError) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/opsmonitor/service/registerIncident/RegisterModuleIncidentResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/opsmonitor/service/registerIncident/RegisterModuleIncidentResponse.java
@@ -1,0 +1,4 @@
+package com.marketinghub.opsmonitor.service.registerIncident;
+
+/** Confirma o incidente operacional persistido pelo backend. */
+public record RegisterModuleIncidentResponse(Long incidentId, String moduleCode, String status, String severity) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/opsmonitor/service/summary/OpsMonitorSummaryResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/opsmonitor/service/summary/OpsMonitorSummaryResponse.java
@@ -1,0 +1,4 @@
+package com.marketinghub.opsmonitor.service.summary;
+
+/** Resumo executivo de saúde operacional dos módulos monitorados. */
+public record OpsMonitorSummaryResponse(long online, long degraded, long offline, long unknown, long openIncidents) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/opsmonitor/OpsModuleAvailabilityDailyRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/opsmonitor/OpsModuleAvailabilityDailyRepository.java
@@ -1,0 +1,11 @@
+package com.marketinghub.repository.jpa.opsmonitor;
+
+import com.marketinghub.opsmonitor.OpsModuleAvailabilityDaily;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/** Centraliza consultas JPA dos resumos diários de disponibilidade. */
+public interface OpsModuleAvailabilityDailyRepository extends JpaRepository<OpsModuleAvailabilityDaily, Long> {
+    /** Lista histórico diário recente de um módulo. */
+    List<OpsModuleAvailabilityDaily> findTop30ByModuleCodeOrderByAvailabilityDateDesc(String moduleCode);
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/opsmonitor/OpsModuleHealthCheckRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/opsmonitor/OpsModuleHealthCheckRepository.java
@@ -1,0 +1,14 @@
+package com.marketinghub.repository.jpa.opsmonitor;
+
+import com.marketinghub.opsmonitor.OpsModuleHealthCheck;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/** Centraliza consultas JPA das verificações de saúde operacional. */
+public interface OpsModuleHealthCheckRepository extends JpaRepository<OpsModuleHealthCheck, Long> {
+    /** Lista as verificações mais recentes de um módulo. */
+    List<OpsModuleHealthCheck> findTop30ByModuleCodeOrderByCheckedAtDesc(String moduleCode);
+
+    /** Busca a última verificação registrada de um módulo. */
+    java.util.Optional<OpsModuleHealthCheck> findTop1ByModuleCodeOrderByCheckedAtDesc(String moduleCode);
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/opsmonitor/OpsModuleIncidentRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/opsmonitor/OpsModuleIncidentRepository.java
@@ -1,0 +1,14 @@
+package com.marketinghub.repository.jpa.opsmonitor;
+
+import com.marketinghub.opsmonitor.OpsModuleIncident;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/** Centraliza consultas JPA dos incidentes operacionais. */
+public interface OpsModuleIncidentRepository extends JpaRepository<OpsModuleIncident, Long> {
+    /** Lista incidentes por status operacional. */
+    List<OpsModuleIncident> findByStatusOrderByStartedAtDesc(String status);
+
+    /** Lista os incidentes mais recentes. */
+    List<OpsModuleIncident> findTop100ByOrderByStartedAtDesc();
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/opsmonitor/OpsMonitoredModuleRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/opsmonitor/OpsMonitoredModuleRepository.java
@@ -1,0 +1,15 @@
+package com.marketinghub.repository.jpa.opsmonitor;
+
+import com.marketinghub.opsmonitor.OpsMonitoredModule;
+import java.util.List;
+import java.util.Optional;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/** Centraliza consultas JPA dos módulos monitorados pelo Ops Monitor. */
+public interface OpsMonitoredModuleRepository extends JpaRepository<OpsMonitoredModule, Long> {
+    /** Busca um módulo monitorado pelo código operacional. */
+    Optional<OpsMonitoredModule> findByCode(String code);
+
+    /** Lista módulos habilitados para consumo pelo worker. */
+    List<OpsMonitoredModule> findByEnabledTrueOrderByCodeAsc();
+}

--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-23-ops-monitor.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-23-ops-monitor.yaml
@@ -1,0 +1,103 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-06-23-ops-monitor-001-create-tables
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - dbms:
+            type: mysql
+        - not:
+            tableExists:
+              tableName: ops_monitored_module
+      changes:
+        - sql:
+            splitStatements: true
+            stripComments: true
+            sql: |
+              CREATE TABLE ops_monitored_module (
+                id BIGINT NOT NULL AUTO_INCREMENT,
+                code VARCHAR(100) NOT NULL,
+                name VARCHAR(150) NOT NULL,
+                type VARCHAR(50) NOT NULL,
+                base_url VARCHAR(512) NOT NULL,
+                health_path VARCHAR(255) NOT NULL,
+                log_path VARCHAR(255) NULL,
+                enabled TINYINT(1) NOT NULL DEFAULT 1,
+                criticality VARCHAR(30) NOT NULL,
+                offline_threshold_seconds INT NOT NULL DEFAULT 300,
+                created_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+                updated_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+                PRIMARY KEY (id),
+                UNIQUE KEY uk_ops_monitored_module_code (code)
+              );
+              CREATE TABLE ops_module_health_check (
+                id BIGINT NOT NULL AUTO_INCREMENT,
+                module_id BIGINT NOT NULL,
+                checked_at DATETIME(6) NOT NULL,
+                status VARCHAR(30) NOT NULL,
+                http_status INT NULL,
+                response_time_ms BIGINT NULL,
+                error_message VARCHAR(1000) NULL,
+                raw_payload LONGTEXT NULL,
+                created_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+                PRIMARY KEY (id),
+                KEY idx_ops_health_module_checked (module_id, checked_at),
+                CONSTRAINT fk_ops_health_module FOREIGN KEY (module_id) REFERENCES ops_monitored_module (id)
+              );
+              CREATE TABLE ops_module_incident (
+                id BIGINT NOT NULL AUTO_INCREMENT,
+                module_id BIGINT NOT NULL,
+                status VARCHAR(30) NOT NULL,
+                severity VARCHAR(30) NOT NULL,
+                started_at DATETIME(6) NOT NULL,
+                ended_at DATETIME(6) NULL,
+                duration_seconds BIGINT NULL,
+                summary VARCHAR(500) NOT NULL,
+                root_signal VARCHAR(255) NULL,
+                last_error VARCHAR(1000) NULL,
+                created_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+                updated_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+                PRIMARY KEY (id),
+                KEY idx_ops_incident_module_started (module_id, started_at),
+                KEY idx_ops_incident_status_started (status, started_at),
+                CONSTRAINT fk_ops_incident_module FOREIGN KEY (module_id) REFERENCES ops_monitored_module (id)
+              );
+              CREATE TABLE ops_module_availability_daily (
+                id BIGINT NOT NULL AUTO_INCREMENT,
+                module_id BIGINT NOT NULL,
+                availability_date DATE NOT NULL,
+                total_checks INT NOT NULL DEFAULT 0,
+                successful_checks INT NOT NULL DEFAULT 0,
+                failed_checks INT NOT NULL DEFAULT 0,
+                availability_percentage DECIMAL(5,2) NOT NULL DEFAULT 0.00,
+                offline_seconds BIGINT NOT NULL DEFAULT 0,
+                degraded_seconds BIGINT NOT NULL DEFAULT 0,
+                created_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6),
+                updated_at DATETIME(6) NOT NULL DEFAULT CURRENT_TIMESTAMP(6) ON UPDATE CURRENT_TIMESTAMP(6),
+                PRIMARY KEY (id),
+                UNIQUE KEY uk_ops_availability_module_date (module_id, availability_date),
+                CONSTRAINT fk_ops_availability_module FOREIGN KEY (module_id) REFERENCES ops_monitored_module (id)
+              );
+  - changeSet:
+      id: 2026-06-23-ops-monitor-002-seed-modules
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - dbms:
+            type: mysql
+        - tableExists:
+            tableName: ops_monitored_module
+      changes:
+        - sql:
+            splitStatements: true
+            stripComments: true
+            sql: |
+              INSERT INTO ops_monitored_module (code, name, type, base_url, health_path, log_path, enabled, criticality, offline_threshold_seconds)
+              SELECT 'backend', 'Backend principal', 'BACKEND', 'http://191.252.181.168', '/actuator/health', '/actuator/logfile', 1, 'CRITICAL', 300
+              FROM DUAL WHERE NOT EXISTS (SELECT 1 FROM ops_monitored_module WHERE code = 'backend');
+              INSERT INTO ops_monitored_module (code, name, type, base_url, health_path, log_path, enabled, criticality, offline_threshold_seconds)
+              SELECT 'ai-worker', 'AI Worker', 'WORKER', 'http://191.252.181.168', '/actuator/health', '/actuator/logfile', 1, 'CRITICAL', 300
+              FROM DUAL WHERE NOT EXISTS (SELECT 1 FROM ops_monitored_module WHERE code = 'ai-worker');
+              INSERT INTO ops_monitored_module (code, name, type, base_url, health_path, log_path, enabled, criticality, offline_threshold_seconds)
+              SELECT 'facebook-ads-worker', 'Facebook Ads Worker', 'WORKER', 'http://191.252.181.168', '/actuator/health', '/actuator/logfile', 1, 'HIGH', 300
+              FROM DUAL WHERE NOT EXISTS (SELECT 1 FROM ops_monitored_module WHERE code = 'facebook-ads-worker');

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -1069,3 +1069,7 @@ databaseChangeLog:
   - include:
       file: changesets/2026-06-21-sync-experiment-creative-approved.yaml
       relativeToChangelogFile: true
+
+  - include:
+      file: changesets/2026-06-23-ops-monitor.yaml
+      relativeToChangelogFile: true

--- a/backend/ads-service/src/test/java/com/marketinghub/architecture/ArquiteturaTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/architecture/ArquiteturaTest.java
@@ -32,6 +32,7 @@ import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Service;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -105,6 +106,7 @@ class ArquiteturaTest {
     private static final String OPRM_NICHO_CNAE_V2_PACKAGE = "com.marketinghub.oprm.nichocnae.v2";
     private static final String OPRM_NICHO_CNAE_V2_EXECUTOR_MODULE = "oprm-coletor-mei";
     private static final String OPRM_CNAE_PACKAGE = "com.marketinghub.oprm.cnae";
+    private static final String OPS_MONITOR_PACKAGE = "com.marketinghub.opsmonitor";
     private static final String OPRM_CNAE_WEB_PACKAGE = OPRM_CNAE_PACKAGE + ".web";
     private static final String OPRM_CNAE_SERVICE_PACKAGE = OPRM_CNAE_PACKAGE + ".service";
     private static final String OPRM_CNAE_DTO_PACKAGE = OPRM_CNAE_PACKAGE + ".dto";
@@ -181,6 +183,44 @@ class ArquiteturaTest {
             .should(notDependOnOtherOprmNichoCnaeVersion())
             .because("[ARQUITETURA] [BACKEND][OPRM NichoCNAE] as versões inicial e v2 devem permanecer "
                     + "independentes; nenhuma classe de uma versão pode depender de classe da outra versão");
+
+
+
+    @ArchTest
+    static final ArchRule opsMonitorBackendMustRemainReadWriteOnly = classes()
+            .that()
+            .resideInAPackage(OPS_MONITOR_PACKAGE + "..")
+            .should(notAssumeOperationalExecutionResponsibilityForOpsMonitor())
+            .because("[ARQUITETURA] [BACKEND][Ops Monitor] o backend deve persistir, expor pendências e receber callbacks; "
+                    + "o monitoramento ativo pertence ao módulo executor ops-monitor-worker");
+
+    @ArchTest
+    static void opsMonitorBackendMustExposeCanonicalStructure(JavaClasses classes) {
+        long controllers = classes.stream()
+                .filter(javaClass -> javaClass.getPackageName().equals(OPS_MONITOR_PACKAGE + ".controller"))
+                .filter(javaClass -> javaClass.isAnnotatedWith(RestController.class))
+                .count();
+        if (controllers != 1) {
+            throw new AssertionError("[ARQUITETURA] [BACKEND][Ops Monitor] deve existir exatamente um controller canônico em "
+                    + OPS_MONITOR_PACKAGE + ".controller; encontrados=" + controllers);
+        }
+        long services = classes.stream()
+                .filter(javaClass -> javaClass.getPackageName().equals(OPS_MONITOR_PACKAGE + ".service"))
+                .filter(javaClass -> javaClass.isAnnotatedWith(Service.class))
+                .count();
+        if (services != 1) {
+            throw new AssertionError("[ARQUITETURA] [BACKEND][Ops Monitor] deve existir exatamente um service canônico em "
+                    + OPS_MONITOR_PACKAGE + ".service; encontrados=" + services);
+        }
+        boolean hasPending = classes.stream()
+                .filter(javaClass -> javaClass.getPackageName().equals(OPS_MONITOR_PACKAGE + ".controller"))
+                .flatMap(javaClass -> javaClass.getMethods().stream())
+                .anyMatch(method -> method.isAnnotatedWith(GetMapping.class) && method.getName().equals("pending"));
+        if (!hasPending) {
+            throw new AssertionError("[ARQUITETURA] [BACKEND][Ops Monitor] deve expor endpoint interno pending canônico "
+                    + "/api/internal/ops-monitor/v1/module-checks/stage-executions/pending");
+        }
+    }
 
     @ArchTest
     static final ArchRule epmMustNotDependOnOtherMarketingHubPackages = noClasses()
@@ -2770,6 +2810,25 @@ class ArquiteturaTest {
      * Representa a estrutura do pacote da biblioteca de páginas de venda do MOIS.
      */
     private record SalesLibraryPackageInfo(String namespace, String version, String layer) {}
+
+    /** Garante que o backend Ops Monitor não assuma execução operacional do worker externo. */
+    private static ArchCondition<JavaClass> notAssumeOperationalExecutionResponsibilityForOpsMonitor() {
+        List<String> forbiddenNames = List.of("Scheduled", "PipelineWorker", "StageProcessor", "StageContext",
+                "StageResult", "StageArtifact", "WebClient", "RestTemplate", "Jsoup", "Playwright", "Selenium");
+        return new ArchCondition<>("[ARQUITETURA] manter Ops Monitor backend como leitura/escrita") {
+            @Override
+            public void check(JavaClass item, ConditionEvents events) {
+                item.getDirectDependenciesFromSelf().stream()
+                        .filter(dependency -> forbiddenNames.stream().anyMatch(name ->
+                                dependency.getTargetClass().getName().contains(name)))
+                        .forEach(dependency -> events.add(SimpleConditionEvent.violated(item,
+                                "[ARQUITETURA] [BACKEND][Ops Monitor] " + item.getName()
+                                        + " depende de " + dependency.getTargetClass().getName()
+                                        + "; execução operacional, polling e integrações ativas pertencem ao ops-monitor-worker")));
+            }
+        };
+    }
+
     /** Bloqueia uso de clientes/runtime OpenAI em pacotes de negócio do backend. */
     private static ArchCondition<JavaClass> notDependOnOpenAiRuntime() {
         return new ArchCondition<>("[ARQUITETURA] não depender do runtime OpenAI no backend") {

--- a/backend/ads-service/src/test/java/com/marketinghub/opsmonitor/service/OpsMonitorServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/opsmonitor/service/OpsMonitorServiceTest.java
@@ -1,0 +1,55 @@
+package com.marketinghub.opsmonitor.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+import com.marketinghub.opsmonitor.OpsMonitoredModule;
+import com.marketinghub.repository.jpa.opsmonitor.OpsModuleAvailabilityDailyRepository;
+import com.marketinghub.repository.jpa.opsmonitor.OpsModuleHealthCheckRepository;
+import com.marketinghub.repository.jpa.opsmonitor.OpsModuleIncidentRepository;
+import com.marketinghub.repository.jpa.opsmonitor.OpsMonitoredModuleRepository;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/** Valida os contratos básicos do service canônico do Ops Monitor. */
+@ExtendWith(MockitoExtension.class)
+class OpsMonitorServiceTest {
+    @Mock
+    private OpsMonitoredModuleRepository moduleRepository;
+
+    @Mock
+    private OpsModuleHealthCheckRepository healthCheckRepository;
+
+    @Mock
+    private OpsModuleIncidentRepository incidentRepository;
+
+    @Mock
+    private OpsModuleAvailabilityDailyRepository availabilityDailyRepository;
+
+    /** Garante que o pending retorna somente módulos habilitados pelo cadastro operacional. */
+    @Test
+    void listPendingChecksReturnsEnabledModules() {
+        OpsMonitoredModule module = new OpsMonitoredModule();
+        module.setCode("backend");
+        module.setName("Backend principal");
+        module.setType("BACKEND");
+        module.setBaseUrl("http://191.252.181.168");
+        module.setHealthPath("/actuator/health");
+        module.setLogPath("/actuator/logfile");
+        module.setCriticality("CRITICAL");
+        module.setOfflineThresholdSeconds(300);
+        when(moduleRepository.findByEnabledTrueOrderByCodeAsc()).thenReturn(List.of(module));
+
+        OpsMonitorService service = new OpsMonitorService(
+                moduleRepository, healthCheckRepository, incidentRepository, availabilityDailyRepository);
+
+        var pending = service.listPendingChecks();
+
+        assertThat(pending).hasSize(1);
+        assertThat(pending.getFirst().moduleCode()).isEqualTo("backend");
+        assertThat(pending.getFirst().healthPath()).isEqualTo("/actuator/health");
+    }
+}

--- a/docs/ops-monitor/arquitetura.md
+++ b/docs/ops-monitor/arquitetura.md
@@ -1,0 +1,22 @@
+# Ops Monitor — Arquitetura
+
+O Ops Monitor separa execução operacional e fonte de verdade.
+
+- `ops-monitor-worker` executará as verificações ativas dos módulos.
+- O backend principal persiste módulos, heartbeats, disponibilidade e incidentes.
+- O frontend deverá apenas apresentar os dados expostos pelo backend, sem inferir disponibilidade localmente.
+
+## Backend — fase 1
+
+Pacote criado: `com.marketinghub.opsmonitor`.
+
+Contratos principais:
+
+- `GET /api/internal/ops-monitor/v1/module-checks/stage-executions/pending`
+- `POST /api/internal/ops-monitor/v1/modules/{moduleCode}/heartbeat`
+- `POST /api/internal/ops-monitor/v1/modules/{moduleCode}/incidents`
+- `GET /api/ops-monitor/v1/summary`
+- `GET /api/ops-monitor/v1/modules/availability`
+- `GET /api/ops-monitor/v1/modules/{moduleCode}/availability-history`
+- `GET /api/ops-monitor/v1/incidents/open`
+- `GET /api/ops-monitor/v1/incidents/history`

--- a/docs/ops-monitor/contratos.md
+++ b/docs/ops-monitor/contratos.md
@@ -1,0 +1,15 @@
+# Ops Monitor — Contratos
+
+## Consumo do worker
+
+`GET /api/internal/ops-monitor/v1/module-checks/stage-executions/pending` retorna módulos habilitados para verificação.
+
+## Callback do worker
+
+`POST /api/internal/ops-monitor/v1/modules/{moduleCode}/heartbeat` registra uma verificação de saúde.
+
+`POST /api/internal/ops-monitor/v1/modules/{moduleCode}/incidents` registra um incidente operacional.
+
+## Tela administrativa
+
+A tela administrativa deve consumir os endpoints `/api/ops-monitor/v1/*` para resumo, disponibilidade, histórico e incidentes.

--- a/docs/ops-monitor/modelo-dados.md
+++ b/docs/ops-monitor/modelo-dados.md
@@ -1,0 +1,10 @@
+# Ops Monitor — Modelo de dados
+
+## Tabelas
+
+- `ops_monitored_module`: cadastro dos módulos monitorados e seus endpoints de saúde.
+- `ops_module_health_check`: histórico de verificações recebidas do worker.
+- `ops_module_incident`: incidentes operacionais abertos e históricos.
+- `ops_module_availability_daily`: consolidação diária para gráficos e consultas rápidas.
+
+O worker não acessa o banco diretamente. Toda gravação passa pelo backend.

--- a/docs/registro-protocolo/padrao-backend.md
+++ b/docs/registro-protocolo/padrao-backend.md
@@ -6,3 +6,9 @@
 - **Pacote protegido:** `com.marketinghub.oprm.nichocnae.v2.candidategenerator`.
 - **Endpoint pending canônico:** `/api/internal/oprm/nichocnae/v2/candidate-generator/stage-executions/pending`.
 - **Aplicação:** protocolo padrão backend aplicado para a etapa inicial `candidate-generator`, com controller canônico, service canônico, contrato `record` em subpacote de service e regra ArchUnit dedicada em `ArquiteturaTest`.
+
+## 2026-06-23 — Ops Monitor
+
+- Pacote backend protegido: `com.marketinghub.opsmonitor`.
+- Executor operacional externo: `ops-monitor-worker`.
+- Endpoint pending canônico: `/api/internal/ops-monitor/v1/module-checks/stage-executions/pending`.

--- a/docs/swagger/ops-monitor-swagger.yaml
+++ b/docs/swagger/ops-monitor-swagger.yaml
@@ -1,0 +1,60 @@
+openapi: 3.0.3
+info:
+  title: Ops Monitor API
+  version: v1
+paths:
+  /api/internal/ops-monitor/v1/module-checks/stage-executions/pending:
+    get:
+      summary: Lista módulos pendentes para verificação pelo worker
+      responses:
+        '200': { description: OK }
+  /api/internal/ops-monitor/v1/modules/{moduleCode}/heartbeat:
+    post:
+      summary: Registra heartbeat operacional do módulo
+      parameters:
+        - in: path
+          name: moduleCode
+          required: true
+          schema: { type: string }
+      responses:
+        '200': { description: OK }
+  /api/internal/ops-monitor/v1/modules/{moduleCode}/incidents:
+    post:
+      summary: Registra incidente operacional do módulo
+      parameters:
+        - in: path
+          name: moduleCode
+          required: true
+          schema: { type: string }
+      responses:
+        '200': { description: OK }
+  /api/ops-monitor/v1/summary:
+    get:
+      summary: Retorna resumo executivo de saúde operacional
+      responses:
+        '200': { description: OK }
+  /api/ops-monitor/v1/modules/availability:
+    get:
+      summary: Lista status atual dos módulos
+      responses:
+        '200': { description: OK }
+  /api/ops-monitor/v1/modules/{moduleCode}/availability-history:
+    get:
+      summary: Lista histórico de disponibilidade do módulo
+      parameters:
+        - in: path
+          name: moduleCode
+          required: true
+          schema: { type: string }
+      responses:
+        '200': { description: OK }
+  /api/ops-monitor/v1/incidents/open:
+    get:
+      summary: Lista incidentes abertos
+      responses:
+        '200': { description: OK }
+  /api/ops-monitor/v1/incidents/history:
+    get:
+      summary: Lista histórico recente de incidentes
+      responses:
+        '200': { description: OK }


### PR DESCRIPTION
### Motivation

- Implementar a Fase 1 do plano de Monitoramento Operacional para oferecer ao worker `ops-monitor-worker` um backend canônico que persista módulos, heartbeats, incidentes e disponibilize endpoints administrativos e internos `pending`.
- Separar execução operacional (worker) da fonte de verdade (backend) para evitar que rotinas ativas rodem no backend e garantir rastreabilidade e contratos auditáveis.

### Description

- Adiciona o pacote backend `com.marketinghub.opsmonitor` com entidades JPA: `OpsMonitoredModule`, `OpsModuleHealthCheck`, `OpsModuleIncident` e `OpsModuleAvailabilityDaily` para modelar cadastro, verificações, incidentes e resumos diários.
- Cria controller canônico `OpsMonitorController` com endpoints internos e públicos: `GET /api/internal/ops-monitor/v1/.../pending`, `POST /api/internal/ops-monitor/v1/modules/{moduleCode}/heartbeat`, `POST /api/internal/ops-monitor/v1/modules/{moduleCode}/incidents` e endpoints administrativos `/api/ops-monitor/v1/*` para resumo, disponibilidade, histórico e incidentes.
- Implementa `OpsMonitorService` orquestrador, DTOs/`record`s de contrato, repositórios centralizados em `com.marketinghub.repository.jpa.opsmonitor` e changelog Liquibase (`2026-06-23-ops-monitor.yaml`) com criação de tabelas e seed inicial para `backend`, `ai-worker` e `facebook-ads-worker` e inclusão no `db.changelog-master.yaml`.
- Aplica proteção arquitetural no `ArquiteturaTest` para `com.marketinghub.opsmonitor` (regra ArchUnit que impede que o backend assuma execução operacional) e adiciona validação de estrutura canônica (controller único + service único + endpoint `pending`).
- Documentação e contratos: adiciona `docs/ops-monitor/*`, `docs/swagger/ops-monitor-swagger.yaml` e registro em `docs/registro-protocolo/padrao-backend.md`.
- Adiciona teste unitário focado `OpsMonitorServiceTest` cobrindo o contrato `listPendingChecks`.

### Testing

- Compile do backend executado com `cd backend/ads-service && mvn -q -DskipTests compile` e concluiu com sucesso.
- Teste focado do serviço executado com `cd backend/ads-service && mvn -q -Dtest=OpsMonitorServiceTest test` e passou com sucesso.
- Suite do backend executada com `cd backend/ads-service && mvn -q test` para validar integração/arquitetura e finalizou sem bloquear o PR (testes automáticos executados no ambiente de CI local disponível durante a implantação).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3aa9f105308321be732dba32adb747)