### PR TITLE
Automatiza nomes de hipóteses e experimentos (sigla do nicho + sequência)

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentService.java
@@ -37,8 +37,10 @@ import com.marketinghub.repository.jpa.imagegeneration.ImageGenerationQualityRep
 import com.marketinghub.sampleemail.SampleEmail;
 import jakarta.persistence.EntityManager;
 import java.math.BigDecimal;
+import java.text.Normalizer;
 import java.time.Instant;
 import java.util.List;
+import java.util.Locale;
 import java.util.Objects;
 import jakarta.persistence.EntityNotFoundException;
 import org.springframework.http.HttpStatus;
@@ -246,6 +248,38 @@ public class ExperimentService {
 
     private record ImageGenerationSelection(ImageGenerationModel model, ImageGenerationQuality quality) { }
 
+    /** Monta o nome automático do experimento com sigla do nicho e numeração sequencial. */
+    private String buildAutomaticExperimentName(MarketNiche niche) {
+        long nextNumber = repository.countByNicheId(niche.getId()) + 1;
+        return "%s-E%03d".formatted(nicheAcronym(niche), nextNumber);
+    }
+
+    /** Gera uma sigla estável a partir do nome do nicho para identificar experimentos. */
+    private String nicheAcronym(MarketNiche niche) {
+        if (niche == null || niche.getName() == null || niche.getName().isBlank()) {
+            return "GER";
+        }
+        String normalized = Normalizer.normalize(niche.getName(), Normalizer.Form.NFD)
+                .replaceAll("\\p{M}", "")
+                .toUpperCase(Locale.ROOT);
+        StringBuilder acronym = new StringBuilder();
+        for (String word : normalized.split("[^A-Z0-9]+")) {
+            if (!word.isBlank()) {
+                acronym.append(word.charAt(0));
+            }
+            if (acronym.length() == 4) {
+                break;
+            }
+        }
+        if (acronym.isEmpty()) {
+            return "GER";
+        }
+        while (acronym.length() < 3) {
+            acronym.append('X');
+        }
+        return acronym.toString();
+    }
+
     /**
      * Cria e persiste um novo experimento com o contrato comercial inicial.
      */
@@ -263,8 +297,9 @@ public class ExperimentService {
                 request.getStartDate().isAfter(request.getEndDate())) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "startDate must be before endDate");
         }
-        if (repository.existsByNicheAndName(niche, request.getName())) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "name already exists for niche");
+        String automaticName = buildAutomaticExperimentName(niche);
+        if (repository.existsByNicheAndName(niche, automaticName)) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "automatic name already exists for niche");
         }
         String normalizedPrimaryVariable = normalizeOptionalPrimaryDescriptor(request.getPrimaryVariable());
         String normalizedPrimaryMetric = normalizeOptionalPrimaryDescriptor(request.getPrimaryMetric());
@@ -303,7 +338,7 @@ public class ExperimentService {
         BigDecimal initialTotalCost = addNullable(request.getCost(), promiseGenerationCost);
         Experiment exp = Experiment.builder()
                 .niche(niche)
-                .name(request.getName())
+                .name(automaticName)
                 .hypothesis(request.getHypothesis())
                 .singlePain(normalizeExperimentPromiseField(request.getSinglePain()))
                 .freeReward(normalizeExperimentPromiseField(request.getFreeReward()))

--- a/backend/ads-service/src/main/java/com/marketinghub/hypothesis/service/HypothesisService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/hypothesis/service/HypothesisService.java
@@ -16,6 +16,8 @@ import com.marketinghub.repository.jpa.prompt.PromptAttributeDescriptionReposito
 import com.marketinghub.cost.CostAttributionService;
 import com.marketinghub.finance.CurrencyConversionService;
 import java.math.BigDecimal;
+import java.text.Normalizer;
+import java.util.Locale;
 import java.util.UUID;
 import java.time.Instant;
 import java.util.HashSet;
@@ -28,6 +30,7 @@ import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.web.server.ResponseStatusException;
 
+/** Responsabilidade: aplicar as regras de criação, edição e status das hipóteses comerciais. */
 @Service
 public class HypothesisService {
     private final HypothesisRepository repository;
@@ -76,16 +79,47 @@ public class HypothesisService {
         return em.getReference(Angle.class, id);
     }
 
+    /** Valida os campos comerciais obrigatórios para criar uma hipótese. */
     private void validate(CreateHypothesisRequest req) {
-        if (req.getTitle() == null || req.getTitle().isBlank()) {
-            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "title required");
-        }
         if (req.getProblem() == null || req.getProblem().isBlank()) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "problem required");
         }
         if (req.getPersona() == null || req.getPersona().isBlank()) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "persona required");
         }
+    }
+
+    /** Monta o título automático da hipótese com sigla do nicho e numeração sequencial. */
+    private String buildAutomaticHypothesisTitle(MarketNiche niche) {
+        String acronym = nicheAcronym(niche);
+        long nextNumber = repository.countByMarketNicheId(niche != null ? niche.getId() : null) + 1;
+        return "%s-H%03d".formatted(acronym, nextNumber);
+    }
+
+    /** Gera uma sigla estável a partir do nome do nicho ou usa GER quando o nicho ainda não foi informado. */
+    private String nicheAcronym(MarketNiche niche) {
+        if (niche == null || niche.getName() == null || niche.getName().isBlank()) {
+            return "GER";
+        }
+        String normalized = Normalizer.normalize(niche.getName(), Normalizer.Form.NFD)
+                .replaceAll("\\p{M}", "")
+                .toUpperCase(Locale.ROOT);
+        StringBuilder acronym = new StringBuilder();
+        for (String word : normalized.split("[^A-Z0-9]+")) {
+            if (!word.isBlank()) {
+                acronym.append(word.charAt(0));
+            }
+            if (acronym.length() == 4) {
+                break;
+            }
+        }
+        if (acronym.isEmpty()) {
+            return "GER";
+        }
+        while (acronym.length() < 3) {
+            acronym.append('X');
+        }
+        return acronym.toString();
     }
 
     private BigDecimal resolveTotalCostDelta(CreateHypothesisRequest req) {
@@ -130,12 +164,15 @@ public class HypothesisService {
         return pack;
     }
 
+    /** Cria uma hipótese usando identificação automática por sigla do nicho e sequência numérica. */
     @Transactional
     public Hypothesis create(CreateHypothesisRequest req) {
         validate(req);
+        MarketNiche niche = attachNiche(req.getMarketNicheId());
+        String automaticTitle = buildAutomaticHypothesisTitle(niche);
         Hypothesis h = Hypothesis.builder()
-                .marketNiche(attachNiche(req.getMarketNicheId()))
-                .title(req.getTitle())
+                .marketNiche(niche)
+                .title(automaticTitle)
                 .premiseAngle(attachAngle(req.getPremiseAngleId()))
                 .promise(req.getPromise())
                 .problem(req.getProblem())

--- a/backend/ads-service/src/main/java/com/marketinghub/hypothesis/service/finalizeHypothesis/FinalizeHypothesisRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/hypothesis/service/finalizeHypothesis/FinalizeHypothesisRequest.java
@@ -1,9 +1,5 @@
 package com.marketinghub.hypothesis.service.finalizeHypothesis;
 
-import jakarta.validation.constraints.NotBlank;
-
 /** Contrato de entrada da etapa de fechamento que materializa o framework validado como hipótese. */
-public record FinalizeHypothesisRequest(
-        @NotBlank(message = "O nome da hipótese é obrigatório")
-        String name) {
+public record FinalizeHypothesisRequest(String name) {
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/hypothesis/service/finalizeHypothesis/HypothesisPipelineFinalizationService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/hypothesis/service/finalizeHypothesis/HypothesisPipelineFinalizationService.java
@@ -11,8 +11,10 @@ import com.marketinghub.repository.jpa.hypothesis.HypothesisRepository;
 import com.marketinghub.repository.jpa.niche.MarketNicheRepository;
 import jakarta.persistence.EntityNotFoundException;
 import java.math.BigDecimal;
+import java.text.Normalizer;
 import java.time.Instant;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -54,9 +56,9 @@ public class HypothesisPipelineFinalizationService {
     /** Fecha o framework concluído em uma hipótese BACKLOG pronta para gerar experimento. */
     @Transactional
     public Hypothesis finalizeHypothesis(Long marketNicheId, FinalizeHypothesisRequest request) {
-        String title = normalizeHypothesisName(request.name());
         MarketNiche niche = marketNicheRepository.findById(marketNicheId)
                 .orElseThrow(() -> new EntityNotFoundException("Market niche not found: " + marketNicheId));
+        String title = buildAutomaticHypothesisTitle(niche);
         String pain = requireCompletedStageResponse(marketNicheId, STAGE_CODE, "Dor");
         String result = requireCompletedStageResponse(marketNicheId, RESULT_STAGE_CODE, "Resultado");
         String mechanism = requireCompletedStageResponse(marketNicheId, MECHANISM_STAGE_CODE, "Mecanismo");
@@ -84,12 +86,36 @@ public class HypothesisPipelineFinalizationService {
         return hypothesisRepository.save(hypothesis);
     }
 
-    /** Normaliza e valida o nome informado pelo usuário para a hipótese final. */
-    private String normalizeHypothesisName(String rawName) {
-        if (!StringUtils.hasText(rawName)) {
-            throw new IllegalStateException("Informe um nome para fechar a hipótese.");
+    /** Monta o título automático da hipótese fechada com sigla do nicho e numeração sequencial. */
+    private String buildAutomaticHypothesisTitle(MarketNiche niche) {
+        long nextNumber = hypothesisRepository.countByMarketNicheId(niche.getId()) + 1;
+        return "%s-H%03d".formatted(nicheAcronym(niche), nextNumber);
+    }
+
+    /** Gera uma sigla estável a partir do nome do nicho para identificar hipóteses. */
+    private String nicheAcronym(MarketNiche niche) {
+        if (niche == null || !StringUtils.hasText(niche.getName())) {
+            return "GER";
         }
-        return rawName.trim();
+        String normalized = Normalizer.normalize(niche.getName(), Normalizer.Form.NFD)
+                .replaceAll("\\p{M}", "")
+                .toUpperCase(Locale.ROOT);
+        StringBuilder acronym = new StringBuilder();
+        for (String word : normalized.split("[^A-Z0-9]+")) {
+            if (!word.isBlank()) {
+                acronym.append(word.charAt(0));
+            }
+            if (acronym.length() == 4) {
+                break;
+            }
+        }
+        if (acronym.isEmpty()) {
+            return "GER";
+        }
+        while (acronym.length() < 3) {
+            acronym.append('X');
+        }
+        return acronym.toString();
     }
 
     /** Exige uma resposta concluída de etapa antes de permitir fechar a hipótese. */

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/experiment/ExperimentRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/experiment/ExperimentRepository.java
@@ -25,6 +25,7 @@ public interface ExperimentRepository extends JpaRepository<Experiment, Long> {
     Optional<Experiment> findById(Long id);
     List<Experiment> findByNicheId(Long nicheId);
     boolean existsByNicheAndName(MarketNiche niche, String name);
+    long countByNicheId(Long nicheId);
     /** Verifica se a hipótese já possui experimento que saiu da criação e entrou em execução/histórico. */
     boolean existsByHypothesisRefAndStatusNot(Hypothesis hypothesisRef, ExperimentStatus status);
     List<Experiment> findByStatus(ExperimentStatus status);

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/hypothesis/HypothesisRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/hypothesis/HypothesisRepository.java
@@ -19,6 +19,7 @@ public interface HypothesisRepository extends JpaRepository<Hypothesis, UUID> {
     List<Hypothesis> findByMarketNicheId(Long marketNicheId);
     List<Hypothesis> findByMarketNicheIdAndStatus(Long marketNicheId, HypothesisStatus status);
     List<Hypothesis> findByStatus(HypothesisStatus status);
+    long countByMarketNicheId(Long marketNicheId);
 
     @Modifying
     @Query("""

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/ExperimentServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/ExperimentServiceTest.java
@@ -249,6 +249,7 @@ class ExperimentServiceTest {
         var exp = service.create(req);
         assertThat(exp.getId()).isNotNull();
         assertThat(exp.getPlatform()).isEqualTo(ExperimentPlatform.FACEBOOK);
+        assertThat(exp.getName()).isEqualTo("TXX-E001");
     }
 
 

--- a/backend/ads-service/src/test/java/com/marketinghub/hypothesis/HypothesisServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/hypothesis/HypothesisServiceTest.java
@@ -43,7 +43,7 @@ class HypothesisServiceTest {
     @Test
     void createValidHypothesis() {
         CreateHypothesisRequest req = new CreateHypothesisRequest();
-        req.setTitle("Teste");
+        req.setTitle("Teste ignorado");
         req.setProblem("Problema");
         req.setPersona("Persona");
         Hypothesis h = service.create(req);
@@ -51,6 +51,7 @@ class HypothesisServiceTest {
         assertThat(h.getStatus()).isEqualTo(HypothesisStatus.BACKLOG);
         assertThat(h.getGeneratedAt()).isNotNull();
         assertThat(h.getImageFilterTitle()).isNull();
+        assertThat(h.getTitle()).isEqualTo("GER-H001");
     }
 
     @Test
@@ -61,15 +62,6 @@ class HypothesisServiceTest {
         req.setPersona("Persona");
         Hypothesis h = service.create(req);
         assertThat(h.getPremiseAngle()).isNull();
-    }
-
-    @Test
-    void validateTitle() {
-        CreateHypothesisRequest req = new CreateHypothesisRequest();
-        req.setTitle("   ");
-        req.setProblem("Problema");
-        assertThatThrownBy(() -> service.create(req))
-                .isInstanceOf(org.springframework.web.server.ResponseStatusException.class);
     }
 
     @Test
@@ -112,6 +104,7 @@ class HypothesisServiceTest {
                 .toList();
 
         assertThat(list).hasSize(2);
+        assertThat(list).extracting(Hypothesis::getTitle).contains("NXX-H001", "NXX-H002");
     }
 
     @Test
@@ -146,7 +139,7 @@ class HypothesisServiceTest {
         PromptAttribute attr = attributeRepository.save(PromptAttribute.builder().entity(entity).name("title").build());
         PromptAttributeDescription desc = descriptionRepository.save(PromptAttributeDescription.builder().attribute(attr).description("d").build());
         CreateHypothesisRequest req = new CreateHypothesisRequest();
-        req.setTitle("Teste");
+        req.setTitle("Teste ignorado");
         req.setProblem("Problema");
         req.setPersona("Persona");
         req.setPromptAttributeDescriptionIds(java.util.List.of(desc.getId()));

--- a/docs/canonical/procedimento-experimento-canon.v1.md
+++ b/docs/canonical/procedimento-experimento-canon.v1.md
@@ -25,6 +25,18 @@ Aplica-se ao fluxo de experimentos no Marketing Hub, especialmente:
 1. O usuário cria o experimento pela tela, preenchendo os campos obrigatórios do formulário.
 2. Após salvar, o experimento passa a ter contexto para geração de ativos do pipeline.
 
+
+### 3.1.1 Regra mandatória — identificação automática de hipótese e experimento
+
+O usuário não deve escolher manualmente nome de hipótese nem nome de experimento. Para reduzir esforço operacional e evitar nomes inconsistentes, o backend deve gerar a identificação no momento da criação usando:
+
+- sigla derivada do nome do nicho, com 3 a 4 caracteres em caixa alta;
+- sequência numérica por nicho para hipótese no formato `<SIGLA>-H001`, `<SIGLA>-H002`, ...;
+- sequência numérica por nicho para experimento no formato `<SIGLA>-E001`, `<SIGLA>-E002`, ...;
+- quando não houver nicho associado, usar a sigla operacional `GER` como fallback.
+
+A interface deve informar que o identificador será automático e não deve exigir campo de nome para fechar hipótese ou criar experimento.
+
 ### 3.2 Execução no detalhe do experimento
 1. O usuário entra no detalhe do experimento.
 2. A execução acontece por etapas guiadas, com geração e validação progressiva dos artefatos.

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -1,3 +1,17 @@
+
+## 2026-06-23 — Nome automático para hipóteses e experimentos
+
+- solicitação: parar de exigir que o usuário escolha nome de hipótese e nome de experimento.
+- decisão aplicada: o backend passa a gerar identificadores por sigla do nicho e sequência numérica (`<SIGLA>-H001` para hipótese e `<SIGLA>-E001` para experimento).
+- impacto esperado: menos esforço operacional para o usuário, nomes consistentes por nicho e tela de criação mais simples.
+- arquivos principais alterados:
+  - `backend/ads-service/src/main/java/com/marketinghub/hypothesis/service/HypothesisService.java`
+  - `backend/ads-service/src/main/java/com/marketinghub/hypothesis/service/finalizeHypothesis/HypothesisPipelineFinalizationService.java`
+  - `backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentService.java`
+  - `frontend/src/pages/hypothesis/NewHypothesisModal.tsx`
+  - `frontend/src/pages/hypothesis/NewHypothesisPage.tsx`
+  - `frontend/src/pages/experiment/NewExperimentPage.tsx`
+
 ## 2026-06-22 — Experimentos: implementação do standby no primeiro envio
 
 - foi feito: o backend passou a aplicar `STANDBY` no primeiro envio válido do formulário público de um experimento em execução.

--- a/frontend/src/api/experiment/useCreateExperiment.ts
+++ b/frontend/src/api/experiment/useCreateExperiment.ts
@@ -9,7 +9,7 @@ import type {
 export interface CreateExperiment {
   nicheId: number;
   hypothesisId?: string;
-  name: string;
+  name?: string;
   hypothesis: string;
   singlePain?: string;
   freeReward?: string;

--- a/frontend/src/pages/experiment/NewExperimentPage.tsx
+++ b/frontend/src/pages/experiment/NewExperimentPage.tsx
@@ -21,7 +21,6 @@ import { getStatisticsDefaultsForBudget } from "./statisticsDefaults";
 
 type FormState = {
   nicheId: string;
-  name: string;
   hypothesisId: string;
   hypothesis: string;
   kpiTarget: string;
@@ -60,7 +59,6 @@ export default function NewExperimentPage() {
   const { data: niches } = useNiches();
   const [form, setForm] = useState<FormState>({
     nicheId: nicheIdParam,
-    name: "",
     hypothesisId: hypothesisIdParam,
     hypothesis: "",
     kpiTarget: "",
@@ -285,7 +283,7 @@ export default function NewExperimentPage() {
       await create.mutateAsync({
         nicheId: Number(form.nicheId),
         hypothesisId: form.hypothesisId || undefined,
-        name: form.name,
+        name: "",
         hypothesis: form.hypothesis,
         stage: "AD",
         singlePain: form.singlePain.trim(),
@@ -327,7 +325,6 @@ export default function NewExperimentPage() {
       setForm({
         nicheId: nicheIdParam,
         hypothesisId: hypothesisIdParam,
-        name: "",
         hypothesis: "",
         kpiTarget: "",
         metricPresetId: "",
@@ -431,12 +428,9 @@ export default function NewExperimentPage() {
         </>
       )}
       {form.hypothesis && <h2 className="h5 mb-2">{form.hypothesis}</h2>}
-      <input
-        className="form-control mb-2"
-        placeholder="Nome"
-        value={form.name}
-        onChange={(e) => setForm((prev) => ({ ...prev, name: e.target.value }))}
-      />
+      <div className="alert alert-info py-2 mb-3">
+        O nome do experimento será gerado automaticamente pelo backend com a sigla do nicho e a próxima numeração.
+      </div>
       <div className="card border-primary mb-3">
         <div className="card-body">
           <div className="d-flex flex-column flex-md-row align-items-md-start justify-content-between gap-2 mb-3">

--- a/frontend/src/pages/hypothesis/NewHypothesisModal.tsx
+++ b/frontend/src/pages/hypothesis/NewHypothesisModal.tsx
@@ -7,10 +7,6 @@ import { zodResolver } from "@hookform/resolvers/zod";
 
 const schema = z
   .object({
-    title: z
-      .string()
-      .min(8, "mínimo 8 caracteres")
-      .max(120, "máx. 120 caracteres"),
     promise: z.string().min(1, "obrigatório").max(140, "máx. 140"),
     problem: z.string().min(1, "obrigatório"),
     persona: z.string().min(1, "obrigatório"),
@@ -53,7 +49,6 @@ export default function NewHypothesisModal({
 
   const onSubmit = handleSubmit(async (values) => {
     const body: any = {
-      title: values.title,
       promise: values.promise,
       problem: values.problem,
       persona: values.persona,
@@ -89,20 +84,9 @@ export default function NewHypothesisModal({
                 />
               </div>
               <div className="modal-body">
-                <label className="form-label" htmlFor="title">
-                  Título
-                </label>
-               <input
-                  id="title"
-                  {...register("title")}
-                  className={`form-control mb-2 ${errors.title ? "is-invalid" : ""}`}
-                  aria-describedby="title-error"
-                />
-                {errors.title && (
-                  <div id="title-error" className="invalid-feedback d-block">
-                    {errors.title.message}
-                  </div>
-                )}
+                <div className="alert alert-info py-2 mb-3">
+                  O nome será gerado automaticamente pelo backend com a sigla do nicho e a próxima numeração.
+                </div>
 
                 <label className="form-label" htmlFor="promise">
                   Promessa

--- a/frontend/src/pages/hypothesis/NewHypothesisPage.test.tsx
+++ b/frontend/src/pages/hypothesis/NewHypothesisPage.test.tsx
@@ -150,7 +150,7 @@ describe("NewHypothesisPage", () => {
     expect(screen.getByText("Etapa 4 — Prova")).toBeInTheDocument();
     expect(screen.getByText("Etapa 5 — Oferta")).toBeInTheDocument();
     expect(screen.getByText(/US\$\s*0,026345/)).toBeInTheDocument();
-    expect(screen.getByLabelText(/Nome da hipótese/)).toBeInTheDocument();
+    expect(screen.getByText(/backend vai nomear automaticamente/i)).toBeInTheDocument();
     expect(
       screen.getByRole("button", { name: "Fechar hipótese" }),
     ).toBeDisabled();
@@ -237,14 +237,15 @@ describe("NewHypothesisPage", () => {
 
     renderPage();
 
-    const input = await screen.findByLabelText(/Nome da hipótese/);
-    fireEvent.change(input, { target: { value: "Agenda recorrente" } });
-    fireEvent.click(screen.getByRole("button", { name: "Fechar hipótese" }));
+    await screen.findByText(/backend vai nomear automaticamente/i);
+    const closeButton = screen.getByRole("button", { name: "Fechar hipótese" });
+    await waitFor(() => expect(closeButton).not.toBeDisabled());
+    fireEvent.click(closeButton);
 
     await waitFor(() => {
       expect(axios.post).toHaveBeenCalledWith(
         "/api/niches/18/hypothesis-pipeline/finalize",
-        { name: "Agenda recorrente" },
+        { name: "" },
       );
     });
   });

--- a/frontend/src/pages/hypothesis/NewHypothesisPage.tsx
+++ b/frontend/src/pages/hypothesis/NewHypothesisPage.tsx
@@ -326,7 +326,6 @@ export default function NewHypothesisPage() {
   const hasRunningExecution = stageQueries.some((query) =>
     (query.data ?? []).some((item) => RUNNING_STATUSES.has(item.status)),
   );
-  const [hypothesisName, setHypothesisName] = useState("");
   const allStagesCompleted = STAGES.every((_, index) =>
     stageIsCompleted(stageQueries[index]?.data),
   );
@@ -358,7 +357,7 @@ export default function NewHypothesisPage() {
     mutationFn: async () => {
       const { data } = await axios.post(
         `/api/niches/${nicheId}/hypothesis-pipeline/finalize`,
-        { name: hypothesisName.trim() },
+        { name: "" },
       );
       return data;
     },
@@ -375,10 +374,6 @@ export default function NewHypothesisPage() {
 
   function handleFinalizeSubmit(event: FormEvent<HTMLFormElement>) {
     event.preventDefault();
-    if (!hypothesisName.trim()) {
-      toast.error("Informe um nome para a hipótese.");
-      return;
-    }
     finalizeMutation.mutate();
   }
 
@@ -515,18 +510,9 @@ export default function NewHypothesisPage() {
             onSubmit={handleFinalizeSubmit}
           >
             <div className="col-12 col-lg-8">
-              <label className="form-label" htmlFor="final-hypothesis-name">
-                Nome da hipótese <span className="text-danger">*</span>
-              </label>
-              <input
-                id="final-hypothesis-name"
-                className="form-control"
-                type="text"
-                value={hypothesisName}
-                onChange={(event) => setHypothesisName(event.target.value)}
-                placeholder="Ex.: Agenda recorrente sem retrabalho para manicure autônoma"
-                disabled={!allStagesCompleted || finalizeMutation.isPending}
-              />
+              <div className="alert alert-info mb-0">
+                O backend vai nomear automaticamente com a sigla do nicho e a próxima numeração da hipótese.
+              </div>
             </div>
             <div className="col-12 col-lg-4">
               <button
@@ -534,8 +520,7 @@ export default function NewHypothesisPage() {
                 className="btn btn-success w-100"
                 disabled={
                   !allStagesCompleted ||
-                  finalizeMutation.isPending ||
-                  !hypothesisName.trim()
+                  finalizeMutation.isPending
                 }
               >
                 {finalizeMutation.isPending ? (


### PR DESCRIPTION
### Motivation
- Reduzir esforço manual e evitar nomes inconsistentes ao criar hipóteses e experimentos, padronizando a identificação por sigla do nicho mais sequência numérica. 
- Garantir rastreabilidade e nomes previsíveis por nicho (`<SIGLA>-H001` para hipótese e `<SIGLA>-E001` para experimento) usados em telas, relatórios e contratos.

### Description
- Backend: adiciona geração de sigla estável do nicho (`nicheAcronym`) e montagem automática de títulos (`buildAutomaticHypothesisTitle`, `buildAutomaticExperimentName`) e passa a salvar esses valores em `HypothesisService`, `HypothesisPipelineFinalizationService` e `ExperimentService`. 
- Repositórios: adiciona contadores por nicho em `HypothesisRepository` e `ExperimentRepository` para suportar a numeração sequencial por nicho. 
- Frontend: remove/oculta campos de nome manual em `NewHypothesisModal`, `NewHypothesisPage` e `NewExperimentPage`, exibe mensagem informando que o backend gerará o identificador automaticamente e adapta payloads para enviar nome vazio/opcional. 
- Documentação: inclui a nova regra canônica em `docs/canonical/procedimento-experimento-canon.v1.md` e registra a decisão em `docs/registros/experimentos.md`.

### Testing
- Executed backend unit tests with `mvn -Dtest=HypothesisServiceTest,ExperimentServiceTest test` and all relevant tests passed (28 tests, 0 failures). 
- Ran frontend tests with `npm test -- --run NewHypothesisPage.test.tsx` and the modified UI test suite passed (4 tests, 0 failures). 
- Ran the frontend TypeScript check with `npm run typecheck` and it completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3aac1b42988321abf5caa83da044cc)