### PR TITLE
Add ops-monitor-worker module with pipeline core and health/availability/logscan stages

### DIFF
--- a/docs/ops-monitor/arquitetura.md
+++ b/docs/ops-monitor/arquitetura.md
@@ -1,22 +1,25 @@
-# Ops Monitor — Arquitetura
+# Ops Monitor Worker — arquitetura
 
-O Ops Monitor separa execução operacional e fonte de verdade.
+O `ops-monitor-worker` é o executor operacional do monitoramento de saúde dos módulos do Marketing Hub.
 
-- `ops-monitor-worker` executará as verificações ativas dos módulos.
-- O backend principal persiste módulos, heartbeats, disponibilidade e incidentes.
-- O frontend deverá apenas apresentar os dados expostos pelo backend, sem inferir disponibilidade localmente.
+## Responsabilidade
 
-## Backend — fase 1
+- Executar verificações periódicas de saúde.
+- Consolidar sinais de disponibilidade.
+- Identificar sinais relevantes em logs.
+- Reportar heartbeats, incidentes e evidências ao backend principal.
 
-Pacote criado: `com.marketinghub.opsmonitor`.
+## Separação obrigatória
 
-Contratos principais:
+- O worker não acessa banco de dados.
+- O backend principal é a fonte de verdade para persistência, histórico e dados exibidos no frontend.
+- O núcleo `com.marketinghub.opsmonitor.pipeline` não conhece etapas concretas.
+- As etapas `healthcheck`, `availability` e `logscan` são independentes entre si.
 
-- `GET /api/internal/ops-monitor/v1/module-checks/stage-executions/pending`
-- `POST /api/internal/ops-monitor/v1/modules/{moduleCode}/heartbeat`
-- `POST /api/internal/ops-monitor/v1/modules/{moduleCode}/incidents`
-- `GET /api/ops-monitor/v1/summary`
-- `GET /api/ops-monitor/v1/modules/availability`
-- `GET /api/ops-monitor/v1/modules/{moduleCode}/availability-history`
-- `GET /api/ops-monitor/v1/incidents/open`
-- `GET /api/ops-monitor/v1/incidents/history`
+## Módulos iniciais
+
+A fase 2 prepara o worker para monitorar inicialmente:
+
+1. backend;
+2. ai-worker;
+3. facebook-ads-worker.

--- a/docs/ops-monitor/contratos.md
+++ b/docs/ops-monitor/contratos.md
@@ -1,15 +1,34 @@
-# Ops Monitor — Contratos
+# Ops Monitor Worker — contratos
 
-## Consumo do worker
+## Entrada canônica do executor
 
-`GET /api/internal/ops-monitor/v1/module-checks/stage-executions/pending` retorna módulos habilitados para verificação.
+```http
+GET /api/internal/ops-monitor/v1/module-checks/stage-executions/pending
+```
 
-## Callback do worker
+## Registro de heartbeat
 
-`POST /api/internal/ops-monitor/v1/modules/{moduleCode}/heartbeat` registra uma verificação de saúde.
+```http
+POST /api/internal/ops-monitor/v1/modules/{moduleCode}/heartbeat
+```
 
-`POST /api/internal/ops-monitor/v1/modules/{moduleCode}/incidents` registra um incidente operacional.
+Payload funcional produzido pela etapa `healthcheck`:
 
-## Tela administrativa
+- `moduleCode`
+- `status`
+- `httpStatus`
+- `responseTimeMs`
+- `rawPayload`
+- `errorMessage`
 
-A tela administrativa deve consumir os endpoints `/api/ops-monitor/v1/*` para resumo, disponibilidade, histórico e incidentes.
+## Registro de incidente
+
+```http
+POST /api/internal/ops-monitor/v1/modules/{moduleCode}/incidents
+```
+
+Payload funcional produzido pela etapa `logscan`:
+
+- `moduleCode`
+- `incidentSignalFound`
+- `signals`

--- a/docs/registro-protocolo/padrao-modulo.md
+++ b/docs/registro-protocolo/padrao-modulo.md
@@ -6,3 +6,11 @@
 - **Pacote protegido:** `com.marketinghub.nichocnaev2.pipeline`.
 - **Etapa inicial criada:** `com.marketinghub.nichocnaev2.pipeline.candidategenerator`.
 - **Aplicação:** protocolo padrão módulo aplicado no executor responsável pelo fluxo, com núcleo genérico `pipeline`, etapa concreta plugável e teste ArchUnit para impedir dependência do núcleo em etapas concretas, dependência entre etapas e processor fora do contrato `StageProcessor`.
+
+## 2026-06-23 — ops-monitor-worker
+
+- Aplicado protocolo padrão módulo ao executor `ops-monitor-worker`.
+- Pacote executor: `com.marketinghub.opsmonitor.pipeline`.
+- Etapas iniciais: `healthcheck`, `availability` e `logscan`.
+- Ponto inicial canônico previsto para consumo no backend: `GET /api/internal/ops-monitor/v1/module-checks/stage-executions/pending`.
+- O worker não acessa banco de dados diretamente; a persistência permanece no backend principal.

--- a/ops-monitor-worker/pom.xml
+++ b/ops-monitor-worker/pom.xml
@@ -1,0 +1,16 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
+    <parent><groupId>org.springframework.boot</groupId><artifactId>spring-boot-starter-parent</artifactId><version>3.2.5</version><relativePath/></parent>
+    <groupId>com.marketinghub</groupId><artifactId>ops-monitor-worker</artifactId><version>0.0.1-SNAPSHOT</version><name>ops-monitor-worker</name>
+    <properties><java.version>21</java.version></properties>
+    <dependencies>
+        <dependency><groupId>org.springframework.boot</groupId><artifactId>spring-boot-starter</artifactId></dependency>
+        <dependency><groupId>org.springframework.boot</groupId><artifactId>spring-boot-starter-webflux</artifactId></dependency>
+        <dependency><groupId>org.springframework.boot</groupId><artifactId>spring-boot-starter-actuator</artifactId></dependency>
+        <dependency><groupId>org.springframework.boot</groupId><artifactId>spring-boot-starter-test</artifactId><scope>test</scope></dependency>
+        <dependency><groupId>com.squareup.okhttp3</groupId><artifactId>mockwebserver</artifactId><version>4.12.0</version><scope>test</scope></dependency>
+        <dependency><groupId>com.tngtech.archunit</groupId><artifactId>archunit-junit5</artifactId><version>1.3.0</version><scope>test</scope></dependency>
+    </dependencies>
+    <build><plugins><plugin><groupId>org.springframework.boot</groupId><artifactId>spring-boot-maven-plugin</artifactId><configuration><finalName>app</finalName></configuration></plugin></plugins></build>
+</project>

--- a/ops-monitor-worker/src/main/java/com/marketinghub/opsmonitor/OpsMonitorWorkerApplication.java
+++ b/ops-monitor-worker/src/main/java/com/marketinghub/opsmonitor/OpsMonitorWorkerApplication.java
@@ -1,0 +1,14 @@
+package com.marketinghub.opsmonitor;
+
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+
+/** Inicializa o worker responsável pelo monitoramento operacional dos módulos. */
+@SpringBootApplication
+public class OpsMonitorWorkerApplication {
+
+    /** Executa a aplicação Spring Boot do monitor operacional. */
+    public static void main(String[] args) {
+        SpringApplication.run(OpsMonitorWorkerApplication.class, args);
+    }
+}

--- a/ops-monitor-worker/src/main/java/com/marketinghub/opsmonitor/pipeline/ArtifactStore.java
+++ b/ops-monitor-worker/src/main/java/com/marketinghub/opsmonitor/pipeline/ArtifactStore.java
@@ -1,0 +1,8 @@
+package com.marketinghub.opsmonitor.pipeline;
+
+/** Define o contrato para armazenamento auditável de artefatos da execução. */
+public interface ArtifactStore {
+
+    /** Armazena um artefato e retorna uma referência estável para auditoria. */
+    String store(StageContext context, StageArtifact artifact);
+}

--- a/ops-monitor-worker/src/main/java/com/marketinghub/opsmonitor/pipeline/BackendPort.java
+++ b/ops-monitor-worker/src/main/java/com/marketinghub/opsmonitor/pipeline/BackendPort.java
@@ -1,0 +1,13 @@
+package com.marketinghub.opsmonitor.pipeline;
+
+import java.util.Optional;
+
+/** Define a porta genérica para comunicação persistente com o backend principal. */
+public interface BackendPort {
+
+    /** Busca a próxima pendência canônica entregue pelo backend. */
+    Optional<String> fetchPendingStageExecution();
+
+    /** Registra um resultado estruturado de etapa no backend. */
+    void reportStageResult(String moduleCode, StageResult result);
+}

--- a/ops-monitor-worker/src/main/java/com/marketinghub/opsmonitor/pipeline/PipelineWorker.java
+++ b/ops-monitor-worker/src/main/java/com/marketinghub/opsmonitor/pipeline/PipelineWorker.java
@@ -1,0 +1,16 @@
+package com.marketinghub.opsmonitor.pipeline;
+
+/** Orquestra a execução genérica de etapas sem conhecer implementações concretas. */
+public class PipelineWorker<I, O> {
+    private final StageProcessor<I, O> processor;
+
+    /** Recebe o processador plugável que executará a etapa concreta. */
+    public PipelineWorker(StageProcessor<I, O> processor) {
+        this.processor = processor;
+    }
+
+    /** Executa a etapa configurada com o contexto e a entrada informados. */
+    public O run(StageContext context, I input) {
+        return processor.process(context, input);
+    }
+}

--- a/ops-monitor-worker/src/main/java/com/marketinghub/opsmonitor/pipeline/StageArtifact.java
+++ b/ops-monitor-worker/src/main/java/com/marketinghub/opsmonitor/pipeline/StageArtifact.java
@@ -1,0 +1,4 @@
+package com.marketinghub.opsmonitor.pipeline;
+
+/** Representa evidência auditável produzida por uma etapa do worker. */
+public record StageArtifact(String name, String type, String payload) {}

--- a/ops-monitor-worker/src/main/java/com/marketinghub/opsmonitor/pipeline/StageContext.java
+++ b/ops-monitor-worker/src/main/java/com/marketinghub/opsmonitor/pipeline/StageContext.java
@@ -1,0 +1,13 @@
+package com.marketinghub.opsmonitor.pipeline;
+
+import java.time.Instant;
+import java.util.Map;
+
+/** Mantém o contexto genérico de uma execução de etapa do monitoramento. */
+public record StageContext(String stageExecutionId, String moduleCode, Instant requestedAt, Map<String, Object> metadata) {
+
+    /** Cria um contexto vazio para testes e execuções simples. */
+    public static StageContext simple(String stageExecutionId, String moduleCode) {
+        return new StageContext(stageExecutionId, moduleCode, Instant.now(), Map.of());
+    }
+}

--- a/ops-monitor-worker/src/main/java/com/marketinghub/opsmonitor/pipeline/StageProcessor.java
+++ b/ops-monitor-worker/src/main/java/com/marketinghub/opsmonitor/pipeline/StageProcessor.java
@@ -1,0 +1,8 @@
+package com.marketinghub.opsmonitor.pipeline;
+
+/** Define o contrato comum de processamento para qualquer etapa plugável. */
+public interface StageProcessor<I, O> {
+
+    /** Processa uma entrada da etapa usando o contexto recebido. */
+    O process(StageContext context, I input);
+}

--- a/ops-monitor-worker/src/main/java/com/marketinghub/opsmonitor/pipeline/StageResponseHandler.java
+++ b/ops-monitor-worker/src/main/java/com/marketinghub/opsmonitor/pipeline/StageResponseHandler.java
@@ -1,0 +1,10 @@
+package com.marketinghub.opsmonitor.pipeline;
+
+/** Centraliza o tratamento genérico de respostas produzidas pelas etapas. */
+public class StageResponseHandler {
+
+    /** Converte uma resposta funcional em resultado padronizado do pipeline. */
+    public StageResult handleSuccess(String status, String message) {
+        return StageResult.of(true, status, message);
+    }
+}

--- a/ops-monitor-worker/src/main/java/com/marketinghub/opsmonitor/pipeline/StageResult.java
+++ b/ops-monitor-worker/src/main/java/com/marketinghub/opsmonitor/pipeline/StageResult.java
@@ -1,0 +1,12 @@
+package com.marketinghub.opsmonitor.pipeline;
+
+import java.util.List;
+
+/** Padroniza o resultado funcional e auditável de uma etapa. */
+public record StageResult(boolean success, String status, String message, List<StageArtifact> artifacts) {
+
+    /** Cria um resultado sem artefatos para cenários simples. */
+    public static StageResult of(boolean success, String status, String message) {
+        return new StageResult(success, status, message, List.of());
+    }
+}

--- a/ops-monitor-worker/src/main/java/com/marketinghub/opsmonitor/pipeline/availability/AvailabilityConfiguration.java
+++ b/ops-monitor-worker/src/main/java/com/marketinghub/opsmonitor/pipeline/availability/AvailabilityConfiguration.java
@@ -1,0 +1,9 @@
+package com.marketinghub.opsmonitor.pipeline.availability;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+/** Habilita propriedades da etapa de disponibilidade. */
+@Configuration
+@EnableConfigurationProperties(AvailabilityProperties.class)
+public class AvailabilityConfiguration {}

--- a/ops-monitor-worker/src/main/java/com/marketinghub/opsmonitor/pipeline/availability/AvailabilityInput.java
+++ b/ops-monitor-worker/src/main/java/com/marketinghub/opsmonitor/pipeline/availability/AvailabilityInput.java
@@ -1,0 +1,4 @@
+package com.marketinghub.opsmonitor.pipeline.availability;
+
+/** Entrada usada para consolidar a disponibilidade de um módulo. */
+public record AvailabilityInput(String moduleCode, boolean lastCheckSuccessful, int consecutiveFailures, long responseTimeMs, int offlineThresholdFailures) {}

--- a/ops-monitor-worker/src/main/java/com/marketinghub/opsmonitor/pipeline/availability/AvailabilityOutput.java
+++ b/ops-monitor-worker/src/main/java/com/marketinghub/opsmonitor/pipeline/availability/AvailabilityOutput.java
@@ -1,0 +1,4 @@
+package com.marketinghub.opsmonitor.pipeline.availability;
+
+/** Resultado consolidado de disponibilidade operacional do módulo. */
+public record AvailabilityOutput(String moduleCode, String availabilityStatus, String reason) {}

--- a/ops-monitor-worker/src/main/java/com/marketinghub/opsmonitor/pipeline/availability/AvailabilityProcessor.java
+++ b/ops-monitor-worker/src/main/java/com/marketinghub/opsmonitor/pipeline/availability/AvailabilityProcessor.java
@@ -1,0 +1,21 @@
+package com.marketinghub.opsmonitor.pipeline.availability;
+
+import com.marketinghub.opsmonitor.pipeline.StageContext;
+import com.marketinghub.opsmonitor.pipeline.StageProcessor;
+
+/** Consolida o estado operacional do módulo a partir das verificações recentes. */
+public class AvailabilityProcessor implements StageProcessor<AvailabilityInput, AvailabilityOutput> {
+
+    /** Classifica disponibilidade como ONLINE, DEGRADED, OFFLINE ou UNKNOWN. */
+    @Override
+    public AvailabilityOutput process(StageContext context, AvailabilityInput input) {
+        int threshold = input.offlineThresholdFailures() <= 0 ? 3 : input.offlineThresholdFailures();
+        if (input.consecutiveFailures() >= threshold) {
+            return new AvailabilityOutput(input.moduleCode(), "OFFLINE", "Falhas consecutivas acima do limite");
+        }
+        if (!input.lastCheckSuccessful() || input.responseTimeMs() > 5000) {
+            return new AvailabilityOutput(input.moduleCode(), "DEGRADED", "Falha isolada ou resposta lenta");
+        }
+        return new AvailabilityOutput(input.moduleCode(), "ONLINE", "Última verificação com sucesso");
+    }
+}

--- a/ops-monitor-worker/src/main/java/com/marketinghub/opsmonitor/pipeline/availability/AvailabilityProperties.java
+++ b/ops-monitor-worker/src/main/java/com/marketinghub/opsmonitor/pipeline/availability/AvailabilityProperties.java
@@ -1,0 +1,7 @@
+package com.marketinghub.opsmonitor.pipeline.availability;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/** Guarda limites de classificação da etapa de disponibilidade. */
+@ConfigurationProperties(prefix = "ops-monitor.availability")
+public record AvailabilityProperties(long degradedResponseTimeMs, int offlineFailureThreshold) {}

--- a/ops-monitor-worker/src/main/java/com/marketinghub/opsmonitor/pipeline/healthcheck/HealthCheckBackendClient.java
+++ b/ops-monitor-worker/src/main/java/com/marketinghub/opsmonitor/pipeline/healthcheck/HealthCheckBackendClient.java
@@ -1,0 +1,18 @@
+package com.marketinghub.opsmonitor.pipeline.healthcheck;
+
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+/** Envia ao backend o heartbeat produzido pela etapa de health check. */
+public class HealthCheckBackendClient {
+    private final WebClient webClient;
+
+    /** Recebe o cliente HTTP apontado para o backend principal. */
+    public HealthCheckBackendClient(WebClient webClient) { this.webClient = webClient; }
+
+    /** Registra o heartbeat do módulo monitorado no contrato oficial do backend. */
+    public Mono<Void> sendHeartbeat(HealthCheckOutput output) {
+        return webClient.post().uri("/api/internal/ops-monitor/v1/modules/{moduleCode}/heartbeat", output.moduleCode())
+                .bodyValue(output).retrieve().bodyToMono(Void.class);
+    }
+}

--- a/ops-monitor-worker/src/main/java/com/marketinghub/opsmonitor/pipeline/healthcheck/HealthCheckConfiguration.java
+++ b/ops-monitor-worker/src/main/java/com/marketinghub/opsmonitor/pipeline/healthcheck/HealthCheckConfiguration.java
@@ -1,0 +1,9 @@
+package com.marketinghub.opsmonitor.pipeline.healthcheck;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+/** Habilita as propriedades da etapa de health check. */
+@Configuration
+@EnableConfigurationProperties(HealthCheckProperties.class)
+public class HealthCheckConfiguration {}

--- a/ops-monitor-worker/src/main/java/com/marketinghub/opsmonitor/pipeline/healthcheck/HealthCheckInput.java
+++ b/ops-monitor-worker/src/main/java/com/marketinghub/opsmonitor/pipeline/healthcheck/HealthCheckInput.java
@@ -1,0 +1,6 @@
+package com.marketinghub.opsmonitor.pipeline.healthcheck;
+
+import java.time.Duration;
+
+/** Representa a entrada necessária para verificar a saúde de um módulo. */
+public record HealthCheckInput(String moduleCode, String url, Duration timeout) {}

--- a/ops-monitor-worker/src/main/java/com/marketinghub/opsmonitor/pipeline/healthcheck/HealthCheckOutput.java
+++ b/ops-monitor-worker/src/main/java/com/marketinghub/opsmonitor/pipeline/healthcheck/HealthCheckOutput.java
@@ -1,0 +1,4 @@
+package com.marketinghub.opsmonitor.pipeline.healthcheck;
+
+/** Representa o resultado da chamada de saúde feita para um módulo. */
+public record HealthCheckOutput(String moduleCode, String status, Integer httpStatus, long responseTimeMs, String rawPayload, String errorMessage) {}

--- a/ops-monitor-worker/src/main/java/com/marketinghub/opsmonitor/pipeline/healthcheck/HealthCheckProcessor.java
+++ b/ops-monitor-worker/src/main/java/com/marketinghub/opsmonitor/pipeline/healthcheck/HealthCheckProcessor.java
@@ -1,0 +1,42 @@
+package com.marketinghub.opsmonitor.pipeline.healthcheck;
+
+import com.marketinghub.opsmonitor.pipeline.StageContext;
+import com.marketinghub.opsmonitor.pipeline.StageProcessor;
+import java.time.Duration;
+import org.springframework.web.reactive.function.client.WebClient;
+
+/** Executa a verificação ativa de disponibilidade técnica de um módulo. */
+public class HealthCheckProcessor implements StageProcessor<HealthCheckInput, HealthCheckOutput> {
+    private final WebClient webClient;
+
+    /** Recebe o cliente HTTP usado exclusivamente por esta etapa concreta. */
+    public HealthCheckProcessor(WebClient webClient) {
+        this.webClient = webClient;
+    }
+
+    /** Chama o endpoint de saúde e classifica sucesso, falha HTTP ou timeout. */
+    @Override
+    public HealthCheckOutput process(StageContext context, HealthCheckInput input) {
+        long started = System.nanoTime();
+        try {
+            var entity = webClient.get().uri(input.url()).retrieve().toEntity(String.class)
+                    .timeout(timeout(input)).block();
+            long elapsed = elapsedMs(started);
+            int statusCode = entity.getStatusCode().value();
+            String status = statusCode >= 200 && statusCode < 300 ? "ONLINE" : "DEGRADED";
+            return new HealthCheckOutput(input.moduleCode(), status, statusCode, elapsed, entity.getBody(), null);
+        } catch (RuntimeException ex) {
+            return new HealthCheckOutput(input.moduleCode(), "OFFLINE", null, elapsedMs(started), null, ex.getClass().getSimpleName() + ": " + ex.getMessage());
+        }
+    }
+
+    /** Resolve o timeout efetivo da chamada. */
+    private Duration timeout(HealthCheckInput input) {
+        return input.timeout() == null ? Duration.ofSeconds(5) : input.timeout();
+    }
+
+    /** Calcula o tempo de resposta em milissegundos. */
+    private long elapsedMs(long started) {
+        return Duration.ofNanos(System.nanoTime() - started).toMillis();
+    }
+}

--- a/ops-monitor-worker/src/main/java/com/marketinghub/opsmonitor/pipeline/healthcheck/HealthCheckProperties.java
+++ b/ops-monitor-worker/src/main/java/com/marketinghub/opsmonitor/pipeline/healthcheck/HealthCheckProperties.java
@@ -1,0 +1,8 @@
+package com.marketinghub.opsmonitor.pipeline.healthcheck;
+
+import java.time.Duration;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/** Guarda configurações da etapa de health check. */
+@ConfigurationProperties(prefix = "ops-monitor.health-check")
+public record HealthCheckProperties(Duration defaultTimeout) {}

--- a/ops-monitor-worker/src/main/java/com/marketinghub/opsmonitor/pipeline/logscan/LogScanBackendClient.java
+++ b/ops-monitor-worker/src/main/java/com/marketinghub/opsmonitor/pipeline/logscan/LogScanBackendClient.java
@@ -1,0 +1,18 @@
+package com.marketinghub.opsmonitor.pipeline.logscan;
+
+import org.springframework.web.reactive.function.client.WebClient;
+import reactor.core.publisher.Mono;
+
+/** Envia incidentes detectados em logs para o backend principal. */
+public class LogScanBackendClient {
+    private final WebClient webClient;
+
+    /** Recebe o cliente HTTP do backend. */
+    public LogScanBackendClient(WebClient webClient) { this.webClient = webClient; }
+
+    /** Registra incidente quando a etapa encontra sinais relevantes. */
+    public Mono<Void> sendIncident(LogScanOutput output) {
+        return webClient.post().uri("/api/internal/ops-monitor/v1/modules/{moduleCode}/incidents", output.moduleCode())
+                .bodyValue(output).retrieve().bodyToMono(Void.class);
+    }
+}

--- a/ops-monitor-worker/src/main/java/com/marketinghub/opsmonitor/pipeline/logscan/LogScanConfiguration.java
+++ b/ops-monitor-worker/src/main/java/com/marketinghub/opsmonitor/pipeline/logscan/LogScanConfiguration.java
@@ -1,0 +1,9 @@
+package com.marketinghub.opsmonitor.pipeline.logscan;
+
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Configuration;
+
+/** Habilita propriedades da etapa de leitura de logs. */
+@Configuration
+@EnableConfigurationProperties(LogScanProperties.class)
+public class LogScanConfiguration {}

--- a/ops-monitor-worker/src/main/java/com/marketinghub/opsmonitor/pipeline/logscan/LogScanInput.java
+++ b/ops-monitor-worker/src/main/java/com/marketinghub/opsmonitor/pipeline/logscan/LogScanInput.java
@@ -1,0 +1,4 @@
+package com.marketinghub.opsmonitor.pipeline.logscan;
+
+/** Entrada textual usada para buscar sinais operacionais em logs. */
+public record LogScanInput(String moduleCode, String logPayload) {}

--- a/ops-monitor-worker/src/main/java/com/marketinghub/opsmonitor/pipeline/logscan/LogScanOutput.java
+++ b/ops-monitor-worker/src/main/java/com/marketinghub/opsmonitor/pipeline/logscan/LogScanOutput.java
@@ -1,0 +1,6 @@
+package com.marketinghub.opsmonitor.pipeline.logscan;
+
+import java.util.List;
+
+/** Resultado da análise de sinais relevantes em logs operacionais. */
+public record LogScanOutput(String moduleCode, boolean incidentSignalFound, List<String> signals) {}

--- a/ops-monitor-worker/src/main/java/com/marketinghub/opsmonitor/pipeline/logscan/LogScanProcessor.java
+++ b/ops-monitor-worker/src/main/java/com/marketinghub/opsmonitor/pipeline/logscan/LogScanProcessor.java
@@ -1,0 +1,18 @@
+package com.marketinghub.opsmonitor.pipeline.logscan;
+
+import com.marketinghub.opsmonitor.pipeline.StageContext;
+import com.marketinghub.opsmonitor.pipeline.StageProcessor;
+import java.util.List;
+
+/** Identifica evidências de incidentes em payloads de logs operacionais. */
+public class LogScanProcessor implements StageProcessor<LogScanInput, LogScanOutput> {
+    private static final List<String> DEFAULT_SIGNALS = List.of("exception", "timeout", "connection refused", "openai", "facebook", "authentication", "callback failed");
+
+    /** Procura sinais relevantes em texto bruto de log sem consultar banco de dados. */
+    @Override
+    public LogScanOutput process(StageContext context, LogScanInput input) {
+        String payload = input.logPayload() == null ? "" : input.logPayload().toLowerCase();
+        List<String> found = DEFAULT_SIGNALS.stream().filter(payload::contains).toList();
+        return new LogScanOutput(input.moduleCode(), !found.isEmpty(), found);
+    }
+}

--- a/ops-monitor-worker/src/main/java/com/marketinghub/opsmonitor/pipeline/logscan/LogScanProperties.java
+++ b/ops-monitor-worker/src/main/java/com/marketinghub/opsmonitor/pipeline/logscan/LogScanProperties.java
@@ -1,0 +1,8 @@
+package com.marketinghub.opsmonitor.pipeline.logscan;
+
+import java.util.List;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/** Guarda termos configuráveis de busca em logs. */
+@ConfigurationProperties(prefix = "ops-monitor.log-scan")
+public record LogScanProperties(List<String> keywords) {}

--- a/ops-monitor-worker/src/main/resources/application.properties
+++ b/ops-monitor-worker/src/main/resources/application.properties
@@ -1,0 +1,5 @@
+spring.application.name=ops-monitor-worker
+management.endpoints.web.exposure.include=health,info
+ops-monitor.health-check.default-timeout=5s
+ops-monitor.availability.degraded-response-time-ms=5000
+ops-monitor.availability.offline-failure-threshold=3

--- a/ops-monitor-worker/src/test/java/com/marketinghub/opsmonitor/architecture/ArquiteturaTest.java
+++ b/ops-monitor-worker/src/test/java/com/marketinghub/opsmonitor/architecture/ArquiteturaTest.java
@@ -1,0 +1,71 @@
+package com.marketinghub.opsmonitor.architecture;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
+
+import com.marketinghub.opsmonitor.pipeline.StageProcessor;
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.domain.JavaClass;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import com.tngtech.archunit.lang.ArchCondition;
+import com.tngtech.archunit.lang.ConditionEvents;
+import com.tngtech.archunit.lang.SimpleConditionEvent;
+import org.junit.jupiter.api.Test;
+
+class ArquiteturaTest {
+    private final JavaClasses classes = new ClassFileImporter().importPackages("com.marketinghub.opsmonitor");
+
+    @Test
+    void nucleoNaoDeveDependerDeEtapasConcretas() {
+        noClasses().that().resideInAPackage("..pipeline")
+                .should().dependOnClassesThat().resideInAnyPackage("..pipeline.healthcheck..", "..pipeline.availability..", "..pipeline.logscan..")
+                .because("[ARQUITETURA] O núcleo genérico não pode conhecer etapas concretas.")
+                .check(classes);
+    }
+
+    @Test
+    void etapasNaoDevemDependerEntreSi() {
+        classes().that().resideInAnyPackage("..pipeline.healthcheck..", "..pipeline.availability..", "..pipeline.logscan..")
+                .should(notDependOnOtherConcreteStages())
+                .because("[ARQUITETURA] Etapas concretas devem ser plugáveis e independentes.")
+                .check(classes);
+    }
+
+    @Test
+    void processorsConcretosDevemImplementarContratoDeEtapa() {
+        classes().that().haveSimpleNameEndingWith("Processor").and().resideInAnyPackage("..pipeline.healthcheck..", "..pipeline.availability..", "..pipeline.logscan..")
+                .should().beAssignableTo(StageProcessor.class)
+                .because("[ARQUITETURA] Processors concretos precisam implementar StageProcessor.")
+                .check(classes);
+    }
+
+    @Test
+    void nucleoNaoDeveDependerDeTecnologiasConcretas() {
+        noClasses().that().resideInAPackage("..pipeline")
+                .should().dependOnClassesThat().resideInAnyPackage("org.springframework.web..", "reactor..", "com.fasterxml..", "software.amazon..", "com.microsoft.playwright..")
+                .because("[ARQUITETURA] O núcleo do pipeline não deve depender de tecnologias concretas de execução.")
+                .check(classes);
+    }
+
+    private ArchCondition<JavaClass> notDependOnOtherConcreteStages() {
+        return new ArchCondition<>("[ARQUITETURA] não depender de outra etapa concreta") {
+            @Override
+            public void check(JavaClass item, ConditionEvents events) {
+                String ownStage = stageOf(item.getPackageName());
+                item.getDirectDependenciesFromSelf().forEach(dependency -> {
+                    String targetStage = stageOf(dependency.getTargetClass().getPackageName());
+                    if (targetStage != null && ownStage != null && !ownStage.equals(targetStage)) {
+                        events.add(SimpleConditionEvent.violated(item, "[ARQUITETURA] " + item.getName() + " depende da etapa " + targetStage));
+                    }
+                });
+            }
+        };
+    }
+
+    private String stageOf(String packageName) {
+        if (packageName.contains(".pipeline.healthcheck")) return "healthcheck";
+        if (packageName.contains(".pipeline.availability")) return "availability";
+        if (packageName.contains(".pipeline.logscan")) return "logscan";
+        return null;
+    }
+}

--- a/ops-monitor-worker/src/test/java/com/marketinghub/opsmonitor/pipeline/availability/AvailabilityProcessorTest.java
+++ b/ops-monitor-worker/src/test/java/com/marketinghub/opsmonitor/pipeline/availability/AvailabilityProcessorTest.java
@@ -1,0 +1,16 @@
+package com.marketinghub.opsmonitor.pipeline.availability;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.marketinghub.opsmonitor.pipeline.StageContext;
+import org.junit.jupiter.api.Test;
+
+class AvailabilityProcessorTest {
+
+    @Test
+    void deveMarcarModuloComoOfflineAposFalhasConsecutivas() {
+        var output = new AvailabilityProcessor().process(StageContext.simple("stage-3", "facebook-ads-worker"), new AvailabilityInput("facebook-ads-worker", false, 3, 100, 3));
+
+        assertThat(output.availabilityStatus()).isEqualTo("OFFLINE");
+    }
+}

--- a/ops-monitor-worker/src/test/java/com/marketinghub/opsmonitor/pipeline/healthcheck/HealthCheckBackendClientTest.java
+++ b/ops-monitor-worker/src/test/java/com/marketinghub/opsmonitor/pipeline/healthcheck/HealthCheckBackendClientTest.java
@@ -1,0 +1,26 @@
+package com.marketinghub.opsmonitor.pipeline.healthcheck;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.reactive.function.client.WebClient;
+
+class HealthCheckBackendClientTest {
+
+    @Test
+    void deveEnviarHeartbeatParaBackend() throws Exception {
+        try (MockWebServer server = new MockWebServer()) {
+            server.enqueue(new MockResponse().setResponseCode(200));
+            server.start();
+            var client = new HealthCheckBackendClient(WebClient.builder().baseUrl(server.url("/").toString()).build());
+
+            client.sendHeartbeat(new HealthCheckOutput("backend", "ONLINE", 200, 15, "{}", null)).block();
+
+            var request = server.takeRequest();
+            assertThat(request.getMethod()).isEqualTo("POST");
+            assertThat(request.getPath()).isEqualTo("/api/internal/ops-monitor/v1/modules/backend/heartbeat");
+        }
+    }
+}

--- a/ops-monitor-worker/src/test/java/com/marketinghub/opsmonitor/pipeline/healthcheck/HealthCheckProcessorTest.java
+++ b/ops-monitor-worker/src/test/java/com/marketinghub/opsmonitor/pipeline/healthcheck/HealthCheckProcessorTest.java
@@ -1,0 +1,41 @@
+package com.marketinghub.opsmonitor.pipeline.healthcheck;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.marketinghub.opsmonitor.pipeline.StageContext;
+import java.time.Duration;
+import okhttp3.mockwebserver.MockResponse;
+import okhttp3.mockwebserver.MockWebServer;
+import org.junit.jupiter.api.Test;
+import org.springframework.web.reactive.function.client.WebClient;
+
+class HealthCheckProcessorTest {
+
+    @Test
+    void deveClassificarSucessoComoOnline() throws Exception {
+        try (MockWebServer server = new MockWebServer()) {
+            server.enqueue(new MockResponse().setResponseCode(200).setBody("{\"status\":\"UP\"}"));
+            server.start();
+            var processor = new HealthCheckProcessor(WebClient.builder().build());
+
+            var output = processor.process(StageContext.simple("stage-1", "backend"), new HealthCheckInput("backend", server.url("/actuator/health").toString(), Duration.ofSeconds(2)));
+
+            assertThat(output.status()).isEqualTo("ONLINE");
+            assertThat(output.httpStatus()).isEqualTo(200);
+        }
+    }
+
+    @Test
+    void deveClassificarTimeoutComoOffline() throws Exception {
+        try (MockWebServer server = new MockWebServer()) {
+            server.enqueue(new MockResponse().setBody("late").setBodyDelay(300, java.util.concurrent.TimeUnit.MILLISECONDS));
+            server.start();
+            var processor = new HealthCheckProcessor(WebClient.builder().build());
+
+            var output = processor.process(StageContext.simple("stage-2", "ai-worker"), new HealthCheckInput("ai-worker", server.url("/health").toString(), Duration.ofMillis(50)));
+
+            assertThat(output.status()).isEqualTo("OFFLINE");
+            assertThat(output.errorMessage()).isNotBlank();
+        }
+    }
+}

--- a/ops-monitor-worker/src/test/java/com/marketinghub/opsmonitor/pipeline/logscan/LogScanProcessorTest.java
+++ b/ops-monitor-worker/src/test/java/com/marketinghub/opsmonitor/pipeline/logscan/LogScanProcessorTest.java
@@ -1,0 +1,17 @@
+package com.marketinghub.opsmonitor.pipeline.logscan;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.marketinghub.opsmonitor.pipeline.StageContext;
+import org.junit.jupiter.api.Test;
+
+class LogScanProcessorTest {
+
+    @Test
+    void deveIdentificarErroRelevanteNoPayloadDeLog() {
+        var output = new LogScanProcessor().process(StageContext.simple("stage-4", "backend"), new LogScanInput("backend", "RuntimeException timeout ao chamar OpenAI"));
+
+        assertThat(output.incidentSignalFound()).isTrue();
+        assertThat(output.signals()).contains("exception", "timeout", "openai");
+    }
+}


### PR DESCRIPTION
### Motivation
- Implement phase 2 of the Ops Monitor plan to provide an executor that actively checks module health, consolidates availability and scans logs while keeping persistence in the backend. 
- Apply the project’s "protocolo padrão módulo" by creating an isolated, pluggable pipeline core so the worker can run independently and report results to backend endpoints.

### Description
- Add a new Maven Spring Boot module `ops-monitor-worker` with pipeline core primitives: `StageContext`, `StageProcessor`, `StageResult`, `StageArtifact`, `PipelineWorker`, `ArtifactStore` and `BackendPort` (non-reactive interface). 
- Implement three concrete stages: `healthcheck` (`HealthCheckProcessor`, input/output, properties and `HealthCheckBackendClient`), `availability` (`AvailabilityProcessor` and properties), and `logscan` (`LogScanProcessor`, properties and `LogScanBackendClient`). 
- Add ArchUnit architecture tests enforcing the module protocol (isolation of core from concrete stages and from runtime technologies) plus unit tests for `HealthCheckProcessor`, `HealthCheckBackendClient`, `AvailabilityProcessor` and `LogScanProcessor`. 
- Update documentation under `docs/ops-monitor/` and register application of the module protocol in `docs/registro-protocolo/padrao-modulo.md`.

### Testing
- Ran the module test suite with `cd ops-monitor-worker && mvn test`, and after a small fix to remove reactive return types from the core `BackendPort` the build completed with all automated tests passing. 
- Executed unit tests and architecture tests including `HealthCheckProcessorTest`, `HealthCheckBackendClientTest`, `AvailabilityProcessorTest`, `LogScanProcessorTest` and `ArquiteturaTest` (ArchUnit), and they passed on the final run. 
- Final result: `mvn test` for `ops-monitor-worker` succeeded (all tests green).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3aae7978308321bc67b554b6af20d2)