### PR TITLE
Align finalize-hypothesis test and Swagger to automatic naming

### DIFF
--- a/backend/ads-service/src/test/java/com/marketinghub/hypothesis/service/finalizeHypothesis/HypothesisPipelineFinalizationServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/hypothesis/service/finalizeHypothesis/HypothesisPipelineFinalizationServiceTest.java
@@ -61,11 +61,12 @@ class HypothesisPipelineFinalizationServiceTest {
         mockCompletedStage("hypothesis-mechanism", "mecanismo plausível", "gpt-5.2", new BigDecimal("0.03000000"));
         mockCompletedStage("hypothesis-proof", "prova segura", "gpt-5.2", new BigDecimal("0.04000000"));
         mockCompletedStage("hypothesis-offer", "oferta low-ticket", "gpt-5.2", new BigDecimal("0.05000000"));
+        when(hypothesisRepository.countByMarketNicheId(18L)).thenReturn(0L);
         when(hypothesisRepository.save(any(Hypothesis.class))).thenAnswer(invocation -> invocation.getArgument(0));
 
         Hypothesis hypothesis = service.finalizeHypothesis(18L, new FinalizeHypothesisRequest(" Hipótese final "));
 
-        assertEquals("Hipótese final", hypothesis.getTitle());
+        assertEquals("SDB-H001", hypothesis.getTitle());
         assertEquals("Salões de beleza", hypothesis.getPersona());
         assertEquals("dor validada", hypothesis.getProblem());
         assertEquals("resultado claro", hypothesis.getPromise());

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -1,3 +1,8 @@
+## 2026-06-23 — Correção do teste de fechamento automático de hipótese
+
+- foi feito: o teste de finalização do pipeline de hipótese foi alinhado à regra vigente de nome automático por sigla do nicho e sequência (`<SIGLA>-H001`).
+- causa-raiz: a mudança para nome automático já estava aplicada no serviço, mas a asserção do teste ainda esperava o nome manual legado enviado no request.
+- prevenção de recorrência: o contrato Swagger passou a marcar `name` como campo legado opcional, deixando explícito que o backend decide o nome final.
 
 ## 2026-06-23 — Nome automático para hipóteses e experimentos
 

--- a/docs/swagger/hypothesis-pain-stage-swagger.yaml
+++ b/docs/swagger/hypothesis-pain-stage-swagger.yaml
@@ -605,11 +605,11 @@ components:
         sourceField: { type: string }
     FinalizeHypothesisRequest:
       type: object
-      required: [name]
       properties:
         name:
           type: string
-          description: Nome final da hipótese que aparecerá na criação de experimento.
+          nullable: true
+          description: Campo legado mantido por compatibilidade; o backend gera automaticamente o nome final da hipótese.
     HypothesisDto:
       type: object
       properties:


### PR DESCRIPTION
### Motivation
- The hypothesis finalization code generates automatic names (`<SIGLA>-H001`) for hypotheses, but a unit test still expected a manual name provided in the request, causing a test mismatch.\
- The OpenAPI contract still marked the `name` input as required, which contradicts the backend behavior where the backend decides the final name.\
- Update the project records to explain the fix and prevent recurrence.\

### Description
- Update unit test to reflect automatic naming: `backend/ads-service/src/test/java/com/marketinghub/hypothesis/service/finalizeHypothesis/HypothesisPipelineFinalizationServiceTest.java` now stubs `hypothesisRepository.countByMarketNicheId(18L)` and asserts the generated title `SDB-H001`.\
- Make the finalize request field optional in the Swagger contract: `docs/swagger/hypothesis-pain-stage-swagger.yaml` changes `FinalizeHypothesisRequest` so `name` is nullable and no longer required, with description noting it is a legacy field.\
- Add an entry documenting the fix and root cause to the experiments registry: `docs/registros/experimentos.md`.\

### Testing
- Ran the focused unit test with `mvn -Dtest=HypothesisPipelineFinalizationServiceTest test`, which passed.\
- Ran the module test suite with `mvn test` in `backend/ads-service`, which completed successfully (all tests in the module passed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3ab00129bc8321b9b2821177cfeae0)