### PR TITLE
Implementa fase 3 do monitoramento operacional — frontend (tela, hooks, menu, docs, teste)

### DIFF
--- a/docs/ops-monitor/arquitetura.md
+++ b/docs/ops-monitor/arquitetura.md
@@ -23,3 +23,9 @@ A fase 2 prepara o worker para monitorar inicialmente:
 1. backend;
 2. ai-worker;
 3. facebook-ads-worker.
+
+## Frontend administrativo
+
+A fase 3 adicionou a tela `Operação / Saúde dos Módulos` em `/ops-monitor`. A tela consome exclusivamente os contratos do backend (`summary`, `modules/availability`, `availability-history` e `incidents/open`) e apenas apresenta os status já consolidados pelo backend, sem inferir disponibilidade localmente.
+
+A navegação fica no menu principal em Campanhas, e a página mostra resumo executivo, gráfico de disponibilidade, alertas de módulos críticos fora do ar, tabela de status atual, último erro e impacto operacional por módulo.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -139,6 +139,7 @@ import MdsArtifactsPage from "./pages/mds/MdsArtifactsPage";
 import MdsReportPage from "./pages/mds/MdsReportPage";
 import HotmartPage from "./pages/hotmart/HotmartPage";
 import ClickbasePage from "./pages/clickbase/ClickbasePage";
+import OpsMonitorPage from "./pages/OpsMonitorPage";
 
 export default function App() {
   return (
@@ -453,6 +454,7 @@ export default function App() {
               />
               <Route path="/landing/:id" element={<LandingPreview />} />
               <Route path="/analytics" element={<AnalyticsDashboard />} />
+              <Route path="/ops-monitor" element={<OpsMonitorPage />} />
               <Route path="/funnels" element={<FunnelListPage />} />
               <Route path="/funnels/new" element={<NewFunnelPage />} />
               <Route path="/funnels/:id/edit" element={<EditFunnelPage />} />

--- a/frontend/src/api/useOpsMonitor.ts
+++ b/frontend/src/api/useOpsMonitor.ts
@@ -1,0 +1,100 @@
+import { useQuery } from "@tanstack/react-query";
+import axios from "axios";
+
+export type OpsMonitorStatus = "ONLINE" | "DEGRADED" | "OFFLINE" | "UNKNOWN";
+
+export interface OpsMonitorSummary {
+  online: number;
+  degraded: number;
+  offline: number;
+  unknown: number;
+  openIncidents: number;
+}
+
+export interface ModuleAvailability {
+  moduleCode: string;
+  name: string;
+  type: string;
+  criticality: string;
+  status: OpsMonitorStatus;
+  lastCheckedAt?: string | null;
+  lastResponseTimeMs?: number | null;
+  lastError?: string | null;
+}
+
+export interface ModuleAvailabilityHistory {
+  date: string;
+  totalChecks: number;
+  successfulChecks: number;
+  failedChecks: number;
+  availabilityPercentage: number;
+  offlineSeconds: number;
+  degradedSeconds: number;
+}
+
+export interface ModuleIncident {
+  id: number;
+  moduleCode: string;
+  moduleName: string;
+  status: string;
+  severity: string;
+  startedAt: string;
+  endedAt?: string | null;
+  durationSeconds?: number | null;
+  summary: string;
+  rootSignal?: string | null;
+  lastError?: string | null;
+}
+
+export function useOpsMonitorSummary() {
+  return useQuery({
+    queryKey: ["ops-monitor", "summary"],
+    queryFn: async () => {
+      const { data } = await axios.get<OpsMonitorSummary>(
+        "/api/ops-monitor/v1/summary",
+      );
+      return data;
+    },
+    refetchInterval: 30_000,
+  });
+}
+
+export function useOpsMonitorAvailability() {
+  return useQuery({
+    queryKey: ["ops-monitor", "availability"],
+    queryFn: async () => {
+      const { data } = await axios.get<ModuleAvailability[]>(
+        "/api/ops-monitor/v1/modules/availability",
+      );
+      return data;
+    },
+    refetchInterval: 30_000,
+  });
+}
+
+export function useOpsMonitorAvailabilityHistory(moduleCode?: string) {
+  return useQuery({
+    queryKey: ["ops-monitor", "availability-history", moduleCode],
+    enabled: Boolean(moduleCode),
+    queryFn: async () => {
+      const { data } = await axios.get<ModuleAvailabilityHistory[]>(
+        `/api/ops-monitor/v1/modules/${moduleCode}/availability-history`,
+      );
+      return data;
+    },
+    refetchInterval: 60_000,
+  });
+}
+
+export function useOpsMonitorOpenIncidents() {
+  return useQuery({
+    queryKey: ["ops-monitor", "incidents", "open"],
+    queryFn: async () => {
+      const { data } = await axios.get<ModuleIncident[]>(
+        "/api/ops-monitor/v1/incidents/open",
+      );
+      return data;
+    },
+    refetchInterval: 30_000,
+  });
+}

--- a/frontend/src/components/MainNavigation.tsx
+++ b/frontend/src/components/MainNavigation.tsx
@@ -36,6 +36,7 @@ import {
   Mail,
   Inbox,
   Microscope,
+  HeartPulse,
 } from "lucide-react";
 import experimentIcon from "../assets/icons/experiment-icon.svg";
 import hypothesisIcon from "../assets/icons/hypothesis-icon.svg";
@@ -91,22 +92,26 @@ const NAV_SECTIONS: NavSection[] = [
     title: "Testes",
     items: [
       { to: "/niches", label: "Nichos", icon: nicheIcon },
+      {
+        to: "/experiments",
+        label: "Experimentos",
+        icon: experimentIcon,
+        children: [
           {
-            to: "/experiments",
-            label: "Experimentos",
-            icon: experimentIcon,
-            children: [
-              {
-                to: "/facebook-campaigns",
-                label: "Experimentos para campanha",
-                icon: Flag,
-                end: true,
-              },
-            ],
+            to: "/facebook-campaigns",
+            label: "Experimentos para campanha",
+            icon: Flag,
+            end: true,
           },
+        ],
+      },
       { to: "/hypotheses", label: "Hipóteses", icon: hypothesisIcon },
       { to: "/mois", label: "MOIS", icon: Workflow },
-      { to: "/mois/sales-pages-library", label: "Biblioteca Sales Pages", icon: Workflow },
+      {
+        to: "/mois/sales-pages-library",
+        label: "Biblioteca Sales Pages",
+        icon: Workflow,
+      },
       {
         to: "/oprm",
         label: "OPRM",
@@ -137,10 +142,18 @@ const NAV_SECTIONS: NavSection[] = [
       { to: "/openai-models", label: "Modelos OpenAI", icon: Cpu },
       { to: "/agents", label: "Agentes", icon: Bot },
       { to: "/agent-themes", label: "Temas de agente", icon: Layers },
-      { to: "/differentiated-technologies", label: "Tecnologias diferenciadas", icon: Cpu },
+      {
+        to: "/differentiated-technologies",
+        label: "Tecnologias diferenciadas",
+        icon: Cpu,
+      },
       { to: "/microservices", label: "Microserviços", icon: Server },
       { to: "/pipelines", label: "Pipelines", icon: Workflow },
-      { to: "/microservices/errors", label: "Erros de microserviço", icon: AlertTriangle },
+      {
+        to: "/microservices/errors",
+        label: "Erros de microserviço",
+        icon: AlertTriangle,
+      },
       { to: "/chat-dialogs", label: "ChatGPT", icon: MessageSquare },
       { to: "/prompt-entities", label: "Objetos de Prompt", icon: Shapes },
       { to: "/prompt-domains", label: "Domínios de Prompt", icon: Map },
@@ -209,13 +222,12 @@ const NAV_SECTIONS: NavSection[] = [
         icon: ClipboardCheck,
       },
       { to: "/analytics", label: "Analytics", icon: BarChart3 },
+      { to: "/ops-monitor", label: "Operação / Saúde", icon: HeartPulse },
     ],
   },
   {
     title: "Financeiro",
-    items: [
-      { to: "/payments", label: "Pagamentos", icon: CreditCard },
-    ],
+    items: [{ to: "/payments", label: "Pagamentos", icon: CreditCard }],
   },
   {
     title: "Configurações",
@@ -311,10 +323,7 @@ export default function MainNavigation() {
                       to={item.to}
                       end={item.end}
                       className={({ isActive }) =>
-                        [
-                          "main-navigation__link",
-                          isActive ? "is-active" : "",
-                        ]
+                        ["main-navigation__link", isActive ? "is-active" : ""]
                           .filter(Boolean)
                           .join(" ")
                       }
@@ -342,7 +351,9 @@ export default function MainNavigation() {
                           aria-hidden="true"
                         />
                       )}
-                      <span className="main-navigation__label">{item.label}</span>
+                      <span className="main-navigation__label">
+                        {item.label}
+                      </span>
                     </NavLink>
                     {hasChildren ? (
                       <div
@@ -402,7 +413,10 @@ export default function MainNavigation() {
           </div>
         ))}
       </nav>
-      <div className="main-navigation__market-test" aria-label="Etapas do teste de mercado">
+      <div
+        className="main-navigation__market-test"
+        aria-label="Etapas do teste de mercado"
+      >
         <p className="main-navigation__section-title">Teste de Mercado</p>
         <ol className="main-navigation__market-list">
           {MARKET_TEST_STEPS.map((step) => (

--- a/frontend/src/pages/OpsMonitorPage.css
+++ b/frontend/src/pages/OpsMonitorPage.css
@@ -1,0 +1,29 @@
+.ops-monitor-page__summary-card {
+  border: 1px solid #e5e7eb;
+  border-radius: 16px;
+  background: #fff;
+  padding: 1rem;
+  min-height: 112px;
+}
+
+.ops-monitor-page__summary-value {
+  font-size: 2rem;
+  font-weight: 700;
+  line-height: 1;
+}
+
+.ops-monitor-page__alert {
+  border-left: 6px solid #dc3545;
+}
+
+.ops-monitor-page__impact {
+  color: #475569;
+  font-size: 0.9rem;
+}
+
+.ops-monitor-page__table-error {
+  max-width: 360px;
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}

--- a/frontend/src/pages/OpsMonitorPage.test.tsx
+++ b/frontend/src/pages/OpsMonitorPage.test.tsx
@@ -1,0 +1,98 @@
+import { render, screen } from "@testing-library/react";
+import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
+import axios from "axios";
+import { describe, expect, it, vi } from "vitest";
+import OpsMonitorPage from "./OpsMonitorPage";
+
+vi.mock("axios");
+vi.mock("echarts-for-react", () => ({
+  default: () => <div data-testid="availability-chart" />,
+}));
+
+function renderPage() {
+  const client = new QueryClient({
+    defaultOptions: { queries: { retry: false } },
+  });
+  return render(
+    <QueryClientProvider client={client}>
+      <OpsMonitorPage />
+    </QueryClientProvider>,
+  );
+}
+
+describe("OpsMonitorPage", () => {
+  it("renderiza resumo, gráfico, alerta e tabela com dados do backend", async () => {
+    (axios.get as any).mockImplementation((url: string) => {
+      if (url === "/api/ops-monitor/v1/summary") {
+        return Promise.resolve({
+          data: {
+            online: 1,
+            degraded: 0,
+            offline: 1,
+            unknown: 0,
+            openIncidents: 1,
+          },
+        });
+      }
+      if (url === "/api/ops-monitor/v1/modules/availability") {
+        return Promise.resolve({
+          data: [
+            {
+              moduleCode: "backend",
+              name: "Backend",
+              type: "CORE",
+              criticality: "CRITICAL",
+              status: "OFFLINE",
+              lastCheckedAt: "2026-06-23T10:00:00Z",
+              lastResponseTimeMs: null,
+              lastError: "timeout",
+            },
+          ],
+        });
+      }
+      if (url === "/api/ops-monitor/v1/modules/backend/availability-history") {
+        return Promise.resolve({
+          data: [
+            {
+              date: "2026-06-23",
+              totalChecks: 10,
+              successfulChecks: 9,
+              failedChecks: 1,
+              availabilityPercentage: 90,
+              offlineSeconds: 60,
+              degradedSeconds: 0,
+            },
+          ],
+        });
+      }
+      if (url === "/api/ops-monitor/v1/incidents/open") {
+        return Promise.resolve({
+          data: [
+            {
+              id: 1,
+              moduleCode: "backend",
+              moduleName: "Backend",
+              status: "OPEN",
+              severity: "CRITICAL",
+              startedAt: "2026-06-23T10:00:00Z",
+              summary: "Backend indisponível",
+            },
+          ],
+        });
+      }
+      return Promise.resolve({ data: [] });
+    });
+
+    renderPage();
+
+    expect(
+      await screen.findByText("Operação / Saúde dos Módulos"),
+    ).toBeInTheDocument();
+    expect(
+      await screen.findByText("Backend está fora do ar."),
+    ).toBeInTheDocument();
+    expect(await screen.findByText("Backend indisponível")).toBeInTheDocument();
+    expect(await screen.findByTestId("availability-chart")).toBeInTheDocument();
+    expect(await screen.findByText("timeout")).toBeInTheDocument();
+  });
+});

--- a/frontend/src/pages/OpsMonitorPage.tsx
+++ b/frontend/src/pages/OpsMonitorPage.tsx
@@ -1,0 +1,336 @@
+import { useMemo, useState } from "react";
+import ReactECharts from "echarts-for-react";
+import { AlertTriangle, Activity, ServerCrash } from "lucide-react";
+import PageTitle from "../components/PageTitle";
+import {
+  ModuleAvailability,
+  OpsMonitorStatus,
+  useOpsMonitorAvailability,
+  useOpsMonitorAvailabilityHistory,
+  useOpsMonitorOpenIncidents,
+  useOpsMonitorSummary,
+} from "../api/useOpsMonitor";
+import "./OpsMonitorPage.css";
+
+const STATUS_LABELS: Record<OpsMonitorStatus, string> = {
+  ONLINE: "Online",
+  DEGRADED: "Instável",
+  OFFLINE: "Fora do ar",
+  UNKNOWN: "Sem verificação recente",
+};
+
+const STATUS_BADGES: Record<OpsMonitorStatus, string> = {
+  ONLINE: "text-bg-success",
+  DEGRADED: "text-bg-warning",
+  OFFLINE: "text-bg-danger",
+  UNKNOWN: "text-bg-secondary",
+};
+
+const MODULE_IMPACT: Record<string, string> = {
+  backend:
+    "Sistema administrativo, persistência e comunicação entre módulos podem ficar comprometidos.",
+  "ai-worker":
+    "Geração de ativos com IA, otimizações, imagens e etapas com OpenAI podem parar.",
+  "facebook-ads-worker":
+    "Campanhas, públicos e sincronizações com Meta Ads podem ficar paradas.",
+  "oprm-coletor-mei":
+    "Descoberta de rotinas, dores e oportunidades pode ficar parada.",
+  "lead-portal":
+    "Leads podem não conseguir acessar ofertas, materiais ou páginas pós-clique.",
+  "email-service":
+    "Comunicações transacionais e recuperação de leads podem falhar.",
+};
+
+function formatDateTime(value?: string | null) {
+  if (!value) {
+    return "Sem registro";
+  }
+  return new Intl.DateTimeFormat("pt-BR", {
+    dateStyle: "short",
+    timeStyle: "short",
+  }).format(new Date(value));
+}
+
+function formatDuration(seconds?: number | null) {
+  if (!seconds) {
+    return "Em aberto";
+  }
+  if (seconds < 60) {
+    return `${seconds}s`;
+  }
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) {
+    return `${minutes}min`;
+  }
+  return `${Math.floor(minutes / 60)}h ${minutes % 60}min`;
+}
+
+function getImpact(module: ModuleAvailability) {
+  return (
+    MODULE_IMPACT[module.moduleCode] ??
+    "Fluxos operacionais ligados a este módulo podem ter atraso ou interrupção."
+  );
+}
+
+export default function OpsMonitorPage() {
+  const [selectedModuleCode, setSelectedModuleCode] = useState<string>();
+  const summaryQuery = useOpsMonitorSummary();
+  const availabilityQuery = useOpsMonitorAvailability();
+  const incidentsQuery = useOpsMonitorOpenIncidents();
+
+  const modules = availabilityQuery.data ?? [];
+  const selectedModule = useMemo(() => {
+    return (
+      modules.find((module) => module.moduleCode === selectedModuleCode) ??
+      modules[0]
+    );
+  }, [modules, selectedModuleCode]);
+  const historyQuery = useOpsMonitorAvailabilityHistory(
+    selectedModule?.moduleCode,
+  );
+
+  const criticalAlerts = modules.filter(
+    (module) =>
+      module.criticality === "CRITICAL" && module.status === "OFFLINE",
+  );
+
+  const chartOption = {
+    tooltip: { trigger: "axis" },
+    grid: { left: 48, right: 24, top: 32, bottom: 48 },
+    xAxis: {
+      type: "category",
+      data: (historyQuery.data ?? []).map((item) => item.date),
+    },
+    yAxis: {
+      type: "value",
+      min: 0,
+      max: 100,
+      axisLabel: { formatter: "{value}%" },
+    },
+    series: [
+      {
+        name: "Disponibilidade",
+        type: "bar",
+        data: (historyQuery.data ?? []).map(
+          (item) => item.availabilityPercentage,
+        ),
+        itemStyle: { color: "#0d6efd" },
+      },
+    ],
+  };
+
+  return (
+    <div className="ops-monitor-page">
+      <PageTitle>Operação / Saúde dos Módulos</PageTitle>
+      <p className="text-muted mb-4">
+        Visão operacional baseada no backend para proteger vendas, geração de
+        ativos e publicação de campanhas.
+      </p>
+
+      {summaryQuery.isError ||
+      availabilityQuery.isError ||
+      incidentsQuery.isError ? (
+        <div className="alert alert-danger" role="alert">
+          Não foi possível carregar a saúde operacional. Verifique o backend de
+          monitoramento.
+        </div>
+      ) : null}
+
+      <div className="row g-3 mb-4">
+        <div className="col-md-2">
+          <SummaryCard
+            label="Online"
+            value={summaryQuery.data?.online ?? 0}
+            variant="text-success"
+          />
+        </div>
+        <div className="col-md-2">
+          <SummaryCard
+            label="Instáveis"
+            value={summaryQuery.data?.degraded ?? 0}
+            variant="text-warning"
+          />
+        </div>
+        <div className="col-md-2">
+          <SummaryCard
+            label="Fora do ar"
+            value={summaryQuery.data?.offline ?? 0}
+            variant="text-danger"
+          />
+        </div>
+        <div className="col-md-2">
+          <SummaryCard
+            label="Desconhecidos"
+            value={summaryQuery.data?.unknown ?? 0}
+            variant="text-secondary"
+          />
+        </div>
+        <div className="col-md-4">
+          <SummaryCard
+            label="Incidentes abertos"
+            value={summaryQuery.data?.openIncidents ?? 0}
+            variant="text-danger"
+          />
+        </div>
+      </div>
+
+      {criticalAlerts.length > 0 ? (
+        <div className="mb-4">
+          {criticalAlerts.map((module) => (
+            <div
+              className="alert alert-danger ops-monitor-page__alert"
+              key={module.moduleCode}
+              role="alert"
+            >
+              <div className="d-flex gap-2 align-items-start">
+                <ServerCrash aria-hidden="true" />
+                <div>
+                  <strong>{module.name} está fora do ar.</strong>
+                  <div className="ops-monitor-page__impact">
+                    Impacto: {getImpact(module)}
+                  </div>
+                </div>
+              </div>
+            </div>
+          ))}
+        </div>
+      ) : null}
+
+      <div className="row g-4 mb-4">
+        <div className="col-lg-7">
+          <div className="card h-100">
+            <div className="card-header d-flex justify-content-between align-items-center">
+              <span>Disponibilidade por módulo</span>
+              <select
+                className="form-select form-select-sm w-auto"
+                value={selectedModule?.moduleCode ?? ""}
+                onChange={(event) => setSelectedModuleCode(event.target.value)}
+                aria-label="Selecionar módulo para o gráfico"
+              >
+                {modules.map((module) => (
+                  <option key={module.moduleCode} value={module.moduleCode}>
+                    {module.name}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div className="card-body">
+              {historyQuery.isLoading ? (
+                <p>Carregando gráfico...</p>
+              ) : (
+                <ReactECharts option={chartOption} style={{ height: 320 }} />
+              )}
+            </div>
+          </div>
+        </div>
+        <div className="col-lg-5">
+          <div className="card h-100">
+            <div className="card-header">Incidentes abertos</div>
+            <div className="card-body">
+              {(incidentsQuery.data ?? []).length === 0 ? (
+                <p className="text-muted mb-0">
+                  Nenhum incidente aberto informado pelo backend.
+                </p>
+              ) : (
+                <div className="list-group list-group-flush">
+                  {(incidentsQuery.data ?? []).map((incident) => (
+                    <div className="list-group-item px-0" key={incident.id}>
+                      <div className="d-flex justify-content-between gap-3">
+                        <strong>{incident.moduleName}</strong>
+                        <span className="badge text-bg-danger">
+                          {incident.severity}
+                        </span>
+                      </div>
+                      <div>{incident.summary}</div>
+                      <small className="text-muted">
+                        Início: {formatDateTime(incident.startedAt)} · Duração:{" "}
+                        {formatDuration(incident.durationSeconds)}
+                      </small>
+                    </div>
+                  ))}
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+
+      <div className="card">
+        <div className="card-header d-flex gap-2 align-items-center">
+          <Activity size={18} aria-hidden="true" /> Status atual dos módulos
+        </div>
+        <div className="table-responsive">
+          <table className="table table-hover align-middle mb-0">
+            <thead>
+              <tr>
+                <th>Módulo</th>
+                <th>Status</th>
+                <th>Criticidade</th>
+                <th>Última verificação</th>
+                <th>Tempo de resposta</th>
+                <th>Último erro</th>
+                <th>Impacto de negócio</th>
+              </tr>
+            </thead>
+            <tbody>
+              {modules.map((module) => (
+                <tr key={module.moduleCode}>
+                  <td>
+                    <strong>{module.name}</strong>
+                    <br />
+                    <small className="text-muted">{module.moduleCode}</small>
+                  </td>
+                  <td>
+                    <span className={`badge ${STATUS_BADGES[module.status]}`}>
+                      {STATUS_LABELS[module.status]}
+                    </span>
+                  </td>
+                  <td>{module.criticality}</td>
+                  <td>{formatDateTime(module.lastCheckedAt)}</td>
+                  <td>
+                    {module.lastResponseTimeMs
+                      ? `${module.lastResponseTimeMs}ms`
+                      : "Sem resposta"}
+                  </td>
+                  <td className="ops-monitor-page__table-error">
+                    {module.lastError ?? "Sem erro"}
+                  </td>
+                  <td className="ops-monitor-page__impact">
+                    <AlertTriangle size={14} aria-hidden="true" />{" "}
+                    {getImpact(module)}
+                  </td>
+                </tr>
+              ))}
+              {modules.length === 0 ? (
+                <tr>
+                  <td colSpan={7} className="text-center text-muted py-4">
+                    Nenhum módulo monitorado retornado pelo backend.
+                  </td>
+                </tr>
+              ) : null}
+            </tbody>
+          </table>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function SummaryCard({
+  label,
+  value,
+  variant,
+}: {
+  label: string;
+  value: number;
+  variant: string;
+}) {
+  return (
+    <div className="ops-monitor-page__summary-card">
+      <div className={`ops-monitor-page__summary-value ${variant}`}>
+        {value}
+      </div>
+      <div className="text-muted">{label}</div>
+    </div>
+  );
+}


### PR DESCRIPTION
### Motivation
- Implementar a fase 3 do plano de Monitoramento Operacional para expor ao time uma visão administrativa da saúde dos módulos, baseada exclusivamente nos contratos do backend.
- Fornecer uma tela que traduza sinais técnicos em impacto de negócio para proteger fluxos de vendas e execução operacionais.
- Integrar a UI com os endpoints canônicos do backend (`summary`, `modules/availability`, `availability-history`, `incidents/open`) sem inferir estados localmente.

### Description
- Adiciona hooks reativos em `frontend/src/api/useOpsMonitor.ts` para consumir `summary`, `modules/availability`, `modules/{code}/availability-history` e `incidents/open` com polling configurável.
- Cria a página administrativa `frontend/src/pages/OpsMonitorPage.tsx` com CSS (`OpsMonitorPage.css`), que mostra resumo executivo, gráfico de disponibilidade, alertas críticos, tabela de módulos, último erro e impacto de negócio por módulo.
- Inclui um teste de página `frontend/src/pages/OpsMonitorPage.test.tsx` com mocks de `axios` e `echarts-for-react`, e registra a rota `/ops-monitor` em `frontend/src/App.tsx` e o item de menu em `frontend/src/components/MainNavigation.tsx`.
- Documenta a conclusão da Fase 3 em `docs/ops-monitor/arquitetura.md` e mantém a tela estritamente dependente dos contratos backend.

### Testing
- Executed type checking with `cd frontend && npm run typecheck` and the command completed successfully (no TypeScript errors reported).
- Ran the new page unit test with `cd frontend && npm test -- --run src/pages/OpsMonitorPage.test.tsx` and it passed (page renders summary, chart mock, alert, incident and error as expected).
- Ran the frontend test suite (`cd frontend && npm test -- --run`) during validation and observed one unrelated existing test failure in `src/__tests__/NicheFlow.test.tsx`, which is an existing mock/contract mismatch and not caused by the Ops Monitor additions.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3ab2ff7c108321b118da620ba6e2fa)