### PR TITLE
Evita repetição de hipóteses por nicho

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/pipeline/hypothesispain/HypothesisPainBackendClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/pipeline/hypothesispain/HypothesisPainBackendClient.java
@@ -144,9 +144,40 @@ public class HypothesisPainBackendClient implements StageBackendPort<HypothesisP
         payload.put("interests", optionalText(niche.get("interests")));
         payload.put("demographicFilters", optionalText(niche.get("demographicFilters")));
         payload.put("extraTips", optionalText(niche.get("extraTips")));
+        payload.put("existingHypothesesSummary", summarizeExistingHypotheses(asList(pending.get("existingHypotheses"))));
         putEnrichedNicheContext(payload, enrichmentProfile);
         payload.put("CASE_DATA_BLOCK", buildCaseDataBlock(payload));
         return payload;
+    }
+
+    /** Resume hipóteses já existentes para orientar o modelo a criar uma dor diferente no mesmo nicho. */
+    private String summarizeExistingHypotheses(List<Object> existingHypotheses) {
+        if (existingHypotheses.isEmpty()) {
+            return "Nenhuma hipótese anterior registrada para este nicho.";
+        }
+        StringBuilder builder = new StringBuilder();
+        int index = 1;
+        for (Object item : existingHypotheses) {
+            Map<String, Object> hypothesis = asMap(item);
+            builder.append(index++).append(") ");
+            appendSummaryField(builder, "código", hypothesis.get("title"));
+            appendSummaryField(builder, "dor", hypothesis.get("problem"));
+            appendSummaryField(builder, "promessa", hypothesis.get("promise"));
+            appendSummaryField(builder, "persona", hypothesis.get("persona"));
+            appendSummaryField(builder, "mecanismo", hypothesis.get("mechanism"));
+            appendSummaryField(builder, "entrega", hypothesis.get("entrega"));
+            appendSummaryField(builder, "status", hypothesis.get("status"));
+            builder.append('\n');
+        }
+        return builder.toString().trim();
+    }
+
+    /** Acrescenta um campo textual ao resumo quando houver conteúdo útil. */
+    private void appendSummaryField(StringBuilder builder, String label, Object value) {
+        String text = optionalText(value).trim();
+        if (!text.isEmpty()) {
+            builder.append(label).append(": ").append(text).append("; ");
+        }
     }
 
     /** Copia o perfil enriquecido do OPRM para o contexto estratégico consumido pela etapa. */
@@ -185,6 +216,7 @@ public class HypothesisPainBackendClient implements StageBackendPort<HypothesisP
         appendCaseData(builder, "interests", payload.get("interests"));
         appendCaseData(builder, "demographicFilters", payload.get("demographicFilters"));
         appendCaseData(builder, "extraTips", payload.get("extraTips"));
+        appendCaseData(builder, "existingHypothesesSummary", payload.get("existingHypothesesSummary"));
         appendEnrichedNicheContext(builder, payload);
         builder.append("[CASE_DATA_END]");
         return builder.toString();
@@ -249,6 +281,14 @@ public class HypothesisPainBackendClient implements StageBackendPort<HypothesisP
             return converted;
         }
         return Map.of();
+    }
+
+    /** Normaliza listas vindas do payload pendente para leitura segura do contrato. */
+    private List<Object> asList(Object value) {
+        if (value instanceof List<?> list) {
+            return list.stream().map(item -> (Object) item).toList();
+        }
+        return List.of();
     }
 
     /** Converte um valor genérico para Long quando possível. */

--- a/ai-worker/src/main/resources/prompts/hypothesis-pipeline/hypothesis-pain.md
+++ b/ai-worker/src/main/resources/prompts/hypothesis-pipeline/hypothesis-pain.md
@@ -15,6 +15,7 @@ Regras obrigatórias:
 - O custo deve expressar perda de dinheiro, tempo, previsibilidade ou oportunidade.
 - A dor deve poder ser atacada por produto digital, diagnóstico, roteiro, template, plano, biblioteca ou ferramenta baseada em IA.
 - Não crie promessa final, preço ou oferta nesta etapa.
+- Não repita hipótese já gerada para o mesmo nicho. Quando `existingHypothesesSummary` trouxer histórico, escolha uma dor de entrada, persona, promessa implícita e mecanismo potencial claramente diferentes das hipóteses anteriores.
 - Não use markdown dentro dos campos.
 - Quando o contexto trouxer campos `enriched*`, trate-os como ponte oficial do pipeline nicho-cnae: use rotina, linguagem, evidências, gatilhos e objeções observadas sem transformá-los em promessa ou oferta prematura.
 

--- a/ai-worker/src/test/java/com/marketinghub/worker/pipeline/hypothesispain/HypothesisPainBackendClientTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/pipeline/hypothesispain/HypothesisPainBackendClientTest.java
@@ -26,10 +26,16 @@ class HypothesisPainBackendClientTest {
         enrichmentProfile.put("languagePatterns", "agenda quebrada; cliente some");
         enrichmentProfile.put("commercialTriggers", "busca previsibilidade");
         enrichmentProfile.put("objections", "medo de parecer complicado");
+        Map<String, Object> existingHypothesis = new LinkedHashMap<>();
+        existingHypothesis.put("title", "CPM-H001");
+        existingHypothesis.put("problem", "Agenda quebrada por remarcações.");
+        existingHypothesis.put("promise", "Agenda previsível em 7 dias.");
+        existingHypothesis.put("persona", "Manicure autônoma em domicílio");
         Map<String, Object> pending = new LinkedHashMap<>();
         pending.put("marketNicheId", 18L);
         pending.put("niche", niche);
         pending.put("enrichmentProfile", enrichmentProfile);
+        pending.put("existingHypotheses", java.util.List.of(existingHypothesis));
 
         Map<String, Object> promptData = client.buildPromptDataFromPending(pending);
         HypothesisPainInput input = new HypothesisPainInput(18L, "hypothesis-pain", "job-1", promptData);
@@ -42,6 +48,7 @@ class HypothesisPainBackendClientTest {
                 .contains("promises: ")
                 .contains("offers: ")
                 .contains("extraTips: Usar rotina real")
+                .contains("existingHypothesesSummary: 1) código: CPM-H001; dor: Agenda quebrada por remarcações.; promessa: Agenda previsível em 7 dias.; persona: Manicure autônoma em domicílio;")
                 .contains("enrichedPersonaSummary: Manicure autônoma em domicílio.")
                 .contains("enrichedLanguagePatterns: agenda quebrada; cliente some")
                 .contains("enrichedCommercialTriggers: busca previsibilidade")

--- a/backend/ads-service/src/main/java/com/marketinghub/hypothesis/pain/service/HypothesisPainStageService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/hypothesis/pain/service/HypothesisPainStageService.java
@@ -7,12 +7,14 @@ import com.marketinghub.hypothesis.pain.provisorio.HypothesisPainEnrichmentProfi
 import com.marketinghub.hypothesis.pain.service.detailStageExecution.HypothesisPainExecutionDetailResponse;
 import com.marketinghub.hypothesis.pain.service.listStageExecutions.HypothesisPainExecutionSummaryResponse;
 import com.marketinghub.hypothesis.pain.service.pending.HypothesisPainPendingEnrichmentProfile;
+import com.marketinghub.hypothesis.pain.service.pending.HypothesisPainPendingExistingHypothesis;
 import com.marketinghub.hypothesis.pain.service.pending.HypothesisPainPendingExecution;
 import com.marketinghub.hypothesis.pain.service.pending.HypothesisPainPendingNiche;
 import com.marketinghub.hypothesis.pain.service.recebeResposta.RecebeRespostaRequest;
 import com.marketinghub.hypothesis.pain.service.start.HypothesisPainStartResponse;
 import com.marketinghub.hypothesis.pain.service.summary.HypothesisStageFinalSummaryResponse;
 import com.marketinghub.niche.MarketNiche;
+import com.marketinghub.repository.jpa.hypothesis.HypothesisRepository;
 import com.marketinghub.repository.jpa.hypothesis.HypothesisPainStageExecutionRepository;
 import com.marketinghub.repository.jpa.niche.MarketNicheRepository;
 import jakarta.persistence.EntityNotFoundException;
@@ -63,6 +65,7 @@ public class HypothesisPainStageService {
     private final MarketNicheRepository marketNicheRepository;
     private final HypothesisPainEnrichmentProfileReader enrichmentProfileReader;
     private final HypothesisPainStageExecutionRepository executionRepository;
+    private final HypothesisRepository hypothesisRepository;
     private final HypothesisPainCostCalculator costCalculator;
 
     /** Inicializa o serviço com os repositórios canônicos e o calculador interno de custo da etapa. */
@@ -70,10 +73,12 @@ public class HypothesisPainStageService {
             MarketNicheRepository marketNicheRepository,
             HypothesisPainEnrichmentProfileReader enrichmentProfileReader,
             HypothesisPainStageExecutionRepository executionRepository,
+            HypothesisRepository hypothesisRepository,
             HypothesisPainCostCalculator costCalculator) {
         this.marketNicheRepository = marketNicheRepository;
         this.enrichmentProfileReader = enrichmentProfileReader;
         this.executionRepository = executionRepository;
+        this.hypothesisRepository = hypothesisRepository;
         this.costCalculator = costCalculator;
     }
 
@@ -374,10 +379,30 @@ public class HypothesisPainStageService {
                         execution.getProcessingStartedAt(),
                         toPendingNiche(execution.getMarketNiche()),
                         toPendingEnrichmentProfile(execution.getMarketNicheId()),
+                        toExistingHypotheses(execution.getMarketNicheId()),
                         pendingPainResponse(execution),
                         pendingResultResponse(execution),
                         pendingMechanismResponse(execution),
                         pendingProofResponse(execution)))
+                .toList();
+    }
+
+    /** Resume as hipóteses já geradas para o mesmo nicho antes de criar uma nova variação. */
+    private List<HypothesisPainPendingExistingHypothesis> toExistingHypotheses(Long marketNicheId) {
+        if (marketNicheId == null) {
+            return List.of();
+        }
+        return hypothesisRepository.findByMarketNicheId(marketNicheId).stream()
+                .map(hypothesis -> new HypothesisPainPendingExistingHypothesis(
+                        hypothesis.getId() == null ? null : hypothesis.getId().toString(),
+                        hypothesis.getTitle(),
+                        hypothesis.getProblem(),
+                        hypothesis.getPromise(),
+                        hypothesis.getPersona(),
+                        hypothesis.getMechanism(),
+                        hypothesis.getUniqueMechanism(),
+                        hypothesis.getEntrega(),
+                        hypothesis.getStatus() == null ? null : hypothesis.getStatus().name()))
                 .toList();
     }
 

--- a/backend/ads-service/src/main/java/com/marketinghub/hypothesis/pain/service/pending/HypothesisPainPendingExecution.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/hypothesis/pain/service/pending/HypothesisPainPendingExecution.java
@@ -1,6 +1,7 @@
 package com.marketinghub.hypothesis.pain.service.pending;
 
 import java.time.Instant;
+import java.util.List;
 
 /** Execução pendente de etapa do pipeline de hipótese entregue ao Worker AI. */
 public record HypothesisPainPendingExecution(
@@ -12,6 +13,7 @@ public record HypothesisPainPendingExecution(
         Instant processingStartedAt,
         HypothesisPainPendingNiche niche,
         HypothesisPainPendingEnrichmentProfile enrichmentProfile,
+        List<HypothesisPainPendingExistingHypothesis> existingHypotheses,
         String painModelResponse,
         String resultModelResponse,
         String mechanismModelResponse,

--- a/backend/ads-service/src/main/java/com/marketinghub/hypothesis/pain/service/pending/HypothesisPainPendingExistingHypothesis.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/hypothesis/pain/service/pending/HypothesisPainPendingExistingHypothesis.java
@@ -1,0 +1,15 @@
+package com.marketinghub.hypothesis.pain.service.pending;
+
+/** Resumo de uma hipótese já gerada para o mesmo nicho usado para evitar repetição no prompt. */
+public record HypothesisPainPendingExistingHypothesis(
+        String id,
+        String title,
+        String problem,
+        String promise,
+        String persona,
+        String mechanism,
+        String uniqueMechanism,
+        String entrega,
+        String status
+) {
+}

--- a/backend/ads-service/src/test/java/com/marketinghub/hypothesis/pain/service/HypothesisPainStageServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/hypothesis/pain/service/HypothesisPainStageServiceTest.java
@@ -7,12 +7,15 @@ import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
+import com.marketinghub.hypothesis.Hypothesis;
+import com.marketinghub.hypothesis.HypothesisStatus;
 import com.marketinghub.hypothesis.pain.HypothesisPainCostCalculator;
 import com.marketinghub.hypothesis.pain.HypothesisPainStageExecution;
 import com.marketinghub.hypothesis.pain.provisorio.HypothesisPainEnrichmentProfileReader;
 import com.marketinghub.hypothesis.pain.provisorio.HypothesisPainEnrichmentProfileSnapshot;
 import com.marketinghub.hypothesis.pain.service.recebeResposta.RecebeRespostaRequest;
 import com.marketinghub.niche.MarketNiche;
+import com.marketinghub.repository.jpa.hypothesis.HypothesisRepository;
 import com.marketinghub.repository.jpa.hypothesis.HypothesisPainStageExecutionRepository;
 import com.marketinghub.repository.jpa.niche.MarketNicheRepository;
 import java.math.BigDecimal;
@@ -41,6 +44,9 @@ class HypothesisPainStageServiceTest {
     private HypothesisPainStageExecutionRepository executionRepository;
 
     @Mock
+    private HypothesisRepository hypothesisRepository;
+
+    @Mock
     private HypothesisPainCostCalculator costCalculator;
 
     private HypothesisPainStageService service;
@@ -52,6 +58,7 @@ class HypothesisPainStageServiceTest {
                 marketNicheRepository,
                 enrichmentProfileReader,
                 executionRepository,
+                hypothesisRepository,
                 costCalculator);
     }
 
@@ -196,6 +203,52 @@ class HypothesisPainStageServiceTest {
         assertEquals("agenda quebrada; cliente some", pending.getFirst().enrichmentProfile().languagePatterns());
         assertEquals("busca previsibilidade e redução de retrabalho", pending.getFirst().enrichmentProfile().commercialTriggers());
         assertEquals("medo de parecer complicado", pending.getFirst().enrichmentProfile().objections());
+    }
+
+    /** Deve entregar as hipóteses já criadas do nicho para impedir repetição na próxima geração. */
+    @Test
+    void listPendingIncludesExistingHypothesesForSameNiche() {
+        MarketNiche niche = new MarketNiche();
+        niche.setId(18L);
+        String idJob = "5bb83a22-3894-43bd-9752-374f84eb6a2c";
+        HypothesisPainStageExecution execution = HypothesisPainStageExecution.builder()
+                .idJob(idJob.getBytes(StandardCharsets.UTF_8))
+                .marketNicheId(18L)
+                .marketNiche(niche)
+                .stageCode("hypothesis-pain")
+                .status("INICIADO")
+                .executionRequestedAt(Instant.parse("2026-06-11T09:59:00Z"))
+                .build();
+        Hypothesis existing = Hypothesis.builder()
+                .id(java.util.UUID.fromString("11111111-1111-1111-1111-111111111111"))
+                .title("CPM-H001")
+                .problem("Agenda quebrada por remarcações.")
+                .promise("Agenda previsível em 7 dias.")
+                .persona("Manicure autônoma em domicílio")
+                .mechanism("Roteiro de confirmação por WhatsApp")
+                .uniqueMechanism("Checklist de pré-atendimento")
+                .entrega("Template operacional")
+                .status(HypothesisStatus.BACKLOG)
+                .build();
+
+        when(executionRepository.findTop50ByStageCodeAndStatusInAndCompletedAtIsNullAndProcessingStartedAtBeforeOrderByProcessingStartedAtAsc(
+                        any(),
+                        any(),
+                        any()))
+                .thenReturn(List.of());
+        when(executionRepository.findTop20ByStageCodeAndStatusOrderByExecutionRequestedAtAsc(
+                        "hypothesis-pain",
+                        "INICIADO"))
+                .thenReturn(List.of(execution));
+        when(hypothesisRepository.findByMarketNicheId(18L)).thenReturn(List.of(existing));
+
+        var pending = service.listPending();
+
+        assertEquals(1, pending.size());
+        assertEquals(1, pending.getFirst().existingHypotheses().size());
+        assertEquals("CPM-H001", pending.getFirst().existingHypotheses().getFirst().title());
+        assertEquals("Agenda quebrada por remarcações.", pending.getFirst().existingHypotheses().getFirst().problem());
+        assertEquals("BACKLOG", pending.getFirst().existingHypotheses().getFirst().status());
     }
 
     /** Deve falhar job antigo com openai_job_id para impedir recaptura duplicada de execução ativa na OpenAI. */

--- a/docs/canonical/procedimento-experimento-canon.v1.md
+++ b/docs/canonical/procedimento-experimento-canon.v1.md
@@ -146,6 +146,16 @@ Regras obrigatórias:
 - o pipeline de hipótese deve usar esses sinais para aumentar especificidade, linguagem real, plausibilidade do mecanismo, redução de objeções e percepção de valor da oferta low-ticket;
 - a passagem enriquecida não autoriza o `nicho-cnae` a criar promessa, oferta, preço, checkout, landing ou campanha. O `nicho-cnae` permanece responsável por realidade operacional e evidências; a hipótese permanece responsável por transformar essa realidade em Dor → Resultado → Mecanismo → Prova → Oferta.
 
+### 4.2.4 Regra mandatória — não repetir hipóteses no mesmo nicho
+
+Quando uma nova hipótese for solicitada para um nicho, o backend deve obter as demais hipóteses já geradas para esse mesmo `market_niche_id` e incluí-las no contrato pendente entregue ao Worker AI.
+
+Regras obrigatórias:
+- o contrato pendente deve enviar um resumo das hipóteses anteriores do nicho, incluindo no mínimo código/título, dor, promessa, persona, mecanismo, entrega e status quando existirem;
+- o Worker AI deve inserir esse resumo no prompt da etapa Dor como histórico de diferenciação;
+- a nova hipótese não deve repetir a mesma dor de entrada, persona, promessa implícita ou mecanismo potencial já usado no mesmo nicho;
+- se o histórico estiver vazio, o prompt deve declarar explicitamente que não há hipótese anterior registrada para o nicho.
+
 ### 4.3 Regra de diferenciação de ângulo após experimento reprovado
 
 Ao gerar a etapa `CAMPAIGN_ANGLE`, o prompt deve receber o histórico dos experimentos reprovados por 100 acessos sem envio da mesma hipótese, quando existir. A reprovação de um experimento reprova aquela materialização de mercado (público, criativo, landing, isca e formulário), mas não reprova automaticamente a hipótese estratégica.

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -1,3 +1,9 @@
+## 2026-06-23 — Hipóteses: histórico do nicho no prompt
+
+- decisão aplicada: toda nova solicitação de hipótese passa a carregar o resumo das hipóteses já existentes do mesmo nicho no contrato pendente para o Worker AI.
+- objetivo de negócio: evitar repetição de dor, promessa, persona ou mecanismo no mesmo nicho, aumentando variedade de apostas comerciais testáveis.
+- prevenção de recorrência: o cânone de experimentos passou a exigir esse histórico e foram adicionados testes no backend e no AI Worker para garantir que o resumo chega ao prompt.
+
 ## 2026-06-23 — Correção do teste de fechamento automático de hipótese
 
 - foi feito: o teste de finalização do pipeline de hipótese foi alinhado à regra vigente de nome automático por sigla do nicho e sequência (`<SIGLA>-H001`).


### PR DESCRIPTION
### Motivation
- Evitar que o Worker AI gere hipóteses repetidas para o mesmo nicho ao criar nova hipótese automática, preservando variedade e eficácia das apostas comerciais.
- Fornecer ao modelo histórico resumido das hipóteses já existentes do nicho para servir como contexto discriminador no prompt da etapa "Dor".

### Description
- Backend: adiciona campo `existingHypotheses` ao contrato pendente `HypothesisPainPendingExecution` e cria o record `HypothesisPainPendingExistingHypothesis` com os campos essenciais (id, título/código, dor, promessa, persona, mecanismo, entrega, status). (files: `.../HypothesisPainPendingExecution.java`, `.../HypothesisPainPendingExistingHypothesis.java`)
- Backend: injeta `HypothesisRepository` em `HypothesisPainStageService` e inclui `toExistingHypotheses(Long marketNicheId)` que consulta e mapeia as hipóteses do mesmo nicho para o `pending`. (file: `HypothesisPainStageService.java`)
- AI Worker: no `HypothesisPainBackendClient` o histórico `existingHypotheses` é transformado em `existingHypothesesSummary` e inserido no `CASE_DATA_BLOCK` do prompt da etapa Dor, além de utilitários para montar esse resumo. (file: `HypothesisPainBackendClient.java`)
- Prompts & docs: atualiza o prompt `hypothesis-pain.md` para exigir que o modelo não repita hipóteses já geradas no nicho e documenta a regra no cânone (`procedimento-experimento-canon.v1.md`) e em registros operacionais (`docs/registros/experimentos.md`).
- Tests: adiciona/atualiza testes unitários que verificam que o histórico chega no contrato e no prompt (`HypothesisPainStageServiceTest`, `HypothesisPainBackendClientTest`).

### Testing
- Executed backend unit tests: `HypothesisPainStageServiceTest` run via `../mvnw -Dtest=HypothesisPainStageServiceTest test` and all tests passed (16 tests, 0 failures). 
- Built & installed backend artifact locally: `../mvnw -DskipTests install` to satisfy ai-worker dependency, which succeeded. 
- Executed ai-worker unit test: `mvn -Dtest=HypothesisPainBackendClientTest test` after installing backend artifact and the test passed (1 test, 0 failures).
- Note: initial attempt to run ai-worker tests failed due to missing local `ads-service` artifact (GitHub Packages auth); this was resolved by installing the backend artifact locally and re-running the tests successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3ab5f1488083218427eab4767f7415)