### PR TITLE
Fix ai-worker targeting request test compilation

### DIFF
--- a/ai-worker/src/test/java/com/marketinghub/worker/targetingrequest/TargetingRequestChatGptClientTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/targetingrequest/TargetingRequestChatGptClientTest.java
@@ -40,9 +40,8 @@ class TargetingRequestChatGptClientTest {
         payloadMethod.setAccessible(true);
         Map<?, ?> payload = (Map<?, ?>) payloadMethod.invoke(context);
 
-        assertThat(payload)
-                .containsEntry("model", "gpt-5.5")
-                .containsEntry("service_tier", "flex");
+        assertThat(payload.get("model")).isEqualTo("gpt-5.5");
+        assertThat(payload.get("service_tier")).isEqualTo("flex");
     }
 
     /**


### PR DESCRIPTION
### Motivation
- Fix a compilation error in the ai-worker tests caused by asserting `containsEntry` on a wildcard `Map<?, ?>` so the module compiles and tests can run before merging the PR.

### Description
- Update `ai-worker/src/test/java/com/marketinghub/worker/targetingrequest/TargetingRequestChatGptClientTest.java` to assert payload values by key using `Map.get(...)` and `isEqualTo(...)` instead of `containsEntry`, avoiding the Java generic capture incompatibility.
- Install the local `backend/ads-service` artifact to the Maven local repository to satisfy `ai-worker`'s dependency resolution during the build.

### Testing
- Ran `mvn -DskipTests install` in `backend/ads-service` and the install succeeded.
- Ran `mvn test -Dtest=TargetingRequestChatGptClientTest` in `ai-worker` and the tests passed (2 tests, 0 failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3ab769e45483219c978f3e7eb88111)