### PR TITLE
Expand Ops Monitor — phase 4 modules, backend filters and frontend UI

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/opsmonitor/controller/OpsMonitorController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/opsmonitor/controller/OpsMonitorController.java
@@ -16,6 +16,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 /** Expõe contratos internos e administrativos do monitoramento operacional. */
@@ -56,8 +57,9 @@ public class OpsMonitorController {
 
     /** Retorna o status atual dos módulos monitorados. */
     @GetMapping("/api/ops-monitor/v1/modules/availability")
-    public List<ModuleAvailabilityResponse> listAvailability() {
-        return service.listAvailability();
+    public List<ModuleAvailabilityResponse> listAvailability(@RequestParam(required = false) String criticality,
+            @RequestParam(required = false) String type) {
+        return service.listAvailability(criticality, type);
     }
 
     /** Retorna o histórico diário de disponibilidade de um módulo. */
@@ -68,13 +70,15 @@ public class OpsMonitorController {
 
     /** Retorna incidentes operacionais abertos. */
     @GetMapping("/api/ops-monitor/v1/incidents/open")
-    public List<ModuleIncidentResponse> listOpenIncidents() {
-        return service.listIncidents(true);
+    public List<ModuleIncidentResponse> listOpenIncidents(@RequestParam(required = false) String criticality,
+            @RequestParam(required = false) String type) {
+        return service.listIncidents(true, criticality, type);
     }
 
     /** Retorna o histórico recente de incidentes operacionais. */
     @GetMapping("/api/ops-monitor/v1/incidents/history")
-    public List<ModuleIncidentResponse> listIncidentHistory() {
-        return service.listIncidents(false);
+    public List<ModuleIncidentResponse> listIncidentHistory(@RequestParam(required = false) String criticality,
+            @RequestParam(required = false) String type) {
+        return service.listIncidents(false, criticality, type);
     }
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/opsmonitor/service/OpsMonitorService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/opsmonitor/service/OpsMonitorService.java
@@ -87,7 +87,17 @@ public class OpsMonitorService {
     /** Lista a disponibilidade atual calculada a partir do último heartbeat de cada módulo. */
     @Transactional(readOnly = true)
     public List<ModuleAvailabilityResponse> listAvailability() {
-        return moduleRepository.findAll().stream().map(this::toAvailabilityResponse).toList();
+        return listAvailability(null, null);
+    }
+
+    /** Lista a disponibilidade atual filtrada por criticidade e tipo quando informado. */
+    @Transactional(readOnly = true)
+    public List<ModuleAvailabilityResponse> listAvailability(String criticality, String type) {
+        return moduleRepository.findAll().stream()
+                .filter(module -> matchesFilter(module.getCriticality(), criticality))
+                .filter(module -> matchesFilter(module.getType(), type))
+                .map(this::toAvailabilityResponse)
+                .toList();
     }
 
     /** Lista o histórico diário de disponibilidade do módulo informado. */
@@ -103,10 +113,20 @@ public class OpsMonitorService {
     /** Lista incidentes abertos ou o histórico recente de incidentes. */
     @Transactional(readOnly = true)
     public List<ModuleIncidentResponse> listIncidents(boolean openOnly) {
+        return listIncidents(openOnly, null, null);
+    }
+
+    /** Lista incidentes operacionais filtrados por criticidade e tipo quando informado. */
+    @Transactional(readOnly = true)
+    public List<ModuleIncidentResponse> listIncidents(boolean openOnly, String criticality, String type) {
         List<OpsModuleIncident> incidents = openOnly
                 ? incidentRepository.findByStatusOrderByStartedAtDesc("OPEN")
                 : incidentRepository.findTop100ByOrderByStartedAtDesc();
-        return incidents.stream().map(this::toIncidentResponse).toList();
+        return incidents.stream()
+                .filter(incident -> matchesFilter(incident.getModule().getCriticality(), criticality))
+                .filter(incident -> matchesFilter(incident.getModule().getType(), type))
+                .map(this::toIncidentResponse)
+                .toList();
     }
 
     /** Gera resumo executivo para a tela administrativa de operação. */
@@ -119,6 +139,11 @@ public class OpsMonitorService {
         long unknown = availability.stream().filter(item -> "UNKNOWN".equals(item.status())).count();
         long openIncidents = incidentRepository.findByStatusOrderByStartedAtDesc("OPEN").size();
         return new OpsMonitorSummaryResponse(online, degraded, offline, unknown, openIncidents);
+    }
+
+    /** Valida se um valor passa pelo filtro opcional recebido da tela. */
+    private boolean matchesFilter(String value, String filter) {
+        return filter == null || filter.isBlank() || value.equalsIgnoreCase(filter);
     }
 
     /** Busca um módulo monitorado pelo código e falha quando ele não existe. */

--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-23-ops-monitor-phase4-modules.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-23-ops-monitor-phase4-modules.yaml
@@ -1,0 +1,33 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-06-23-ops-monitor-003-seed-expanded-modules
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - dbms:
+            type: mysql
+        - tableExists:
+            tableName: ops_monitored_module
+      changes:
+        - sql:
+            splitStatements: true
+            stripComments: true
+            sql: |
+              INSERT INTO ops_monitored_module (code, name, type, base_url, health_path, log_path, enabled, criticality, offline_threshold_seconds)
+              SELECT 'oprm-coletor-mei', 'OPRM Coletor MEI', 'COLLECTOR', 'http://191.252.181.168', '/actuator/health', '/actuator/logfile', 1, 'HIGH', 300
+              FROM DUAL WHERE NOT EXISTS (SELECT 1 FROM ops_monitored_module WHERE code = 'oprm-coletor-mei');
+              INSERT INTO ops_monitored_module (code, name, type, base_url, health_path, log_path, enabled, criticality, offline_threshold_seconds)
+              SELECT 'mois-clickbank-collector', 'MOIS ClickBank Collector', 'COLLECTOR', 'http://191.252.181.168:9096', '/internal/ops-monitor/health', '/internal/ops-monitor/logfile', 1, 'HIGH', 300
+              FROM DUAL WHERE NOT EXISTS (SELECT 1 FROM ops_monitored_module WHERE code = 'mois-clickbank-collector');
+              INSERT INTO ops_monitored_module (code, name, type, base_url, health_path, log_path, enabled, criticality, offline_threshold_seconds)
+              SELECT 'mois-hotmart-collector', 'MOIS Hotmart Collector', 'COLLECTOR', 'http://191.252.181.168:8096', '/ops-monitor/health', '/ops-monitor/logfile', 1, 'HIGH', 300
+              FROM DUAL WHERE NOT EXISTS (SELECT 1 FROM ops_monitored_module WHERE code = 'mois-hotmart-collector');
+              INSERT INTO ops_monitored_module (code, name, type, base_url, health_path, log_path, enabled, criticality, offline_threshold_seconds)
+              SELECT 'mois-sales-library-worker', 'MOIS Sales Library Worker', 'WORKER', 'http://191.252.181.168', '/actuator/health', '/actuator/logfile', 1, 'HIGH', 300
+              FROM DUAL WHERE NOT EXISTS (SELECT 1 FROM ops_monitored_module WHERE code = 'mois-sales-library-worker');
+              INSERT INTO ops_monitored_module (code, name, type, base_url, health_path, log_path, enabled, criticality, offline_threshold_seconds)
+              SELECT 'lead-portal', 'Lead Portal', 'PORTAL', 'http://191.252.181.168:8080', '/api/ops-lp-observability-v2/health', '/api/ops-lp-observability-v2/logfile', 1, 'CRITICAL', 300
+              FROM DUAL WHERE NOT EXISTS (SELECT 1 FROM ops_monitored_module WHERE code = 'lead-portal');
+              INSERT INTO ops_monitored_module (code, name, type, base_url, health_path, log_path, enabled, criticality, offline_threshold_seconds)
+              SELECT 'email-service', 'Email Service', 'SERVICE', 'http://191.252.181.168', '/actuator/health', '/actuator/logfile', 1, 'HIGH', 300
+              FROM DUAL WHERE NOT EXISTS (SELECT 1 FROM ops_monitored_module WHERE code = 'email-service');

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -1073,3 +1073,6 @@ databaseChangeLog:
   - include:
       file: changesets/2026-06-23-ops-monitor.yaml
       relativeToChangelogFile: true
+  - include:
+      file: changesets/2026-06-23-ops-monitor-phase4-modules.yaml
+      relativeToChangelogFile: true

--- a/backend/ads-service/src/test/java/com/marketinghub/opsmonitor/service/OpsMonitorServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/opsmonitor/service/OpsMonitorServiceTest.java
@@ -9,6 +9,7 @@ import com.marketinghub.repository.jpa.opsmonitor.OpsModuleHealthCheckRepository
 import com.marketinghub.repository.jpa.opsmonitor.OpsModuleIncidentRepository;
 import com.marketinghub.repository.jpa.opsmonitor.OpsMonitoredModuleRepository;
 import java.util.List;
+import java.util.Optional;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
@@ -52,4 +53,31 @@ class OpsMonitorServiceTest {
         assertThat(pending.getFirst().moduleCode()).isEqualTo("backend");
         assertThat(pending.getFirst().healthPath()).isEqualTo("/actuator/health");
     }
+    /** Garante que a disponibilidade respeita filtros administrativos por criticidade e tipo. */
+    @Test
+    void listAvailabilityFiltersByCriticalityAndType() {
+        OpsMonitoredModule criticalWorker = new OpsMonitoredModule();
+        criticalWorker.setCode("ai-worker");
+        criticalWorker.setName("AI Worker");
+        criticalWorker.setType("WORKER");
+        criticalWorker.setCriticality("CRITICAL");
+
+        OpsMonitoredModule highCollector = new OpsMonitoredModule();
+        highCollector.setCode("mois-clickbank-collector");
+        highCollector.setName("MOIS ClickBank Collector");
+        highCollector.setType("COLLECTOR");
+        highCollector.setCriticality("HIGH");
+
+        when(moduleRepository.findAll()).thenReturn(List.of(criticalWorker, highCollector));
+        when(healthCheckRepository.findTop1ByModuleCodeOrderByCheckedAtDesc("ai-worker")).thenReturn(Optional.empty());
+
+        OpsMonitorService service = new OpsMonitorService(
+                moduleRepository, healthCheckRepository, incidentRepository, availabilityDailyRepository);
+
+        var filtered = service.listAvailability("CRITICAL", "WORKER");
+
+        assertThat(filtered).hasSize(1);
+        assertThat(filtered.getFirst().moduleCode()).isEqualTo("ai-worker");
+    }
+
 }

--- a/docs/ops-monitor/arquitetura.md
+++ b/docs/ops-monitor/arquitetura.md
@@ -29,3 +29,7 @@ A fase 2 prepara o worker para monitorar inicialmente:
 A fase 3 adicionou a tela `Operação / Saúde dos Módulos` em `/ops-monitor`. A tela consome exclusivamente os contratos do backend (`summary`, `modules/availability`, `availability-history` e `incidents/open`) e apenas apresenta os status já consolidados pelo backend, sem inferir disponibilidade localmente.
 
 A navegação fica no menu principal em Campanhas, e a página mostra resumo executivo, gráfico de disponibilidade, alertas de módulos críticos fora do ar, tabela de status atual, último erro e impacto operacional por módulo.
+
+## Expansão da fase 4
+
+A fase 4 expande a lista operacional para incluir OPRM, coletores MOIS, Lead Portal e Email Service. A tela administrativa passa a consultar também o histórico recente de incidentes e aplicar filtros vindos do backend por criticidade e tipo de módulo, preservando a regra de que o frontend apenas apresenta a verdade consolidada pelo backend.

--- a/docs/ops-monitor/contratos.md
+++ b/docs/ops-monitor/contratos.md
@@ -32,3 +32,20 @@ Payload funcional produzido pela etapa `logscan`:
 - `moduleCode`
 - `incidentSignalFound`
 - `signals`
+
+## Consultas administrativas com filtros
+
+Os endpoints administrativos aceitam filtros opcionais para reduzir a visão operacional por impacto:
+
+```http
+GET /api/ops-monitor/v1/modules/availability?criticality=CRITICAL&type=WORKER
+GET /api/ops-monitor/v1/incidents/open?criticality=CRITICAL&type=WORKER
+GET /api/ops-monitor/v1/incidents/history?criticality=CRITICAL&type=WORKER
+```
+
+- `criticality`: `CRITICAL`, `HIGH`, `MEDIUM` ou `LOW`.
+- `type`: `BACKEND`, `WORKER`, `COLLECTOR`, `PORTAL` ou `SERVICE`.
+
+## Módulos monitorados na fase 4
+
+Além de `backend`, `ai-worker` e `facebook-ads-worker`, o backend passa a cadastrar: `oprm-coletor-mei`, `mois-clickbank-collector`, `mois-hotmart-collector`, `mois-sales-library-worker`, `lead-portal` e `email-service`.

--- a/docs/registros/mois1.md
+++ b/docs/registros/mois1.md
@@ -1793,3 +1793,5 @@ Arquivos principais:
 
 - Ajustada a tela de detalhe da Biblioteca Sales Pages para permitir novo pedido quando já existe dossiê concluído, exibindo explicitamente o botão **Reprocessar dossiê**.
 - Mantido o bloqueio somente quando o backend indica dossiê em fila ou em processamento, e a tela informa que sempre exibirá o dossiê mais recente retornado pelo backend.
+
+- 2026-06-23 — Ops Monitor fase 4: adicionados os coletores MOIS ClickBank, Hotmart e o MOIS Sales Library Worker ao cadastro monitorado do backend; a tela de operação agora permite filtrar módulos por criticidade/tipo e consultar histórico recente de incidentes sem inferência local de status.

--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -1353,3 +1353,5 @@
 - Removida a dependência direta do `candidate-generator` OPRM v2 sobre o repositório canônico de nichos fora do pacote permitido pela regra de arquitetura.
 - A criação do `MarketNiche` confirmado passa por um adaptador de persistência em `repository.jpa.oprm`, preservando o contrato do módulo OPRM e mantendo a regra ArchUnit como prevenção de recorrência.
 - Causa-raiz tratada: o service OPRM tinha assumido diretamente a materialização em `MarketNicheRepository`, quebrando o isolamento do módulo OPRM.
+
+- 2026-06-23 — Ops Monitor fase 4: adicionado o módulo `oprm-coletor-mei` ao cadastro monitorado do backend para acompanhar impacto operacional na descoberta de rotinas, dores e oportunidades.

--- a/docs/swagger/ops-monitor-swagger.yaml
+++ b/docs/swagger/ops-monitor-swagger.yaml
@@ -36,6 +36,16 @@ paths:
   /api/ops-monitor/v1/modules/availability:
     get:
       summary: Lista status atual dos módulos
+
+      parameters:
+        - in: query
+          name: criticality
+          required: false
+          schema: { type: string, enum: [CRITICAL, HIGH, MEDIUM, LOW] }
+        - in: query
+          name: type
+          required: false
+          schema: { type: string, enum: [BACKEND, WORKER, COLLECTOR, PORTAL, SERVICE] }
       responses:
         '200': { description: OK }
   /api/ops-monitor/v1/modules/{moduleCode}/availability-history:
@@ -51,10 +61,30 @@ paths:
   /api/ops-monitor/v1/incidents/open:
     get:
       summary: Lista incidentes abertos
+
+      parameters:
+        - in: query
+          name: criticality
+          required: false
+          schema: { type: string, enum: [CRITICAL, HIGH, MEDIUM, LOW] }
+        - in: query
+          name: type
+          required: false
+          schema: { type: string, enum: [BACKEND, WORKER, COLLECTOR, PORTAL, SERVICE] }
       responses:
         '200': { description: OK }
   /api/ops-monitor/v1/incidents/history:
     get:
       summary: Lista histórico recente de incidentes
+
+      parameters:
+        - in: query
+          name: criticality
+          required: false
+          schema: { type: string, enum: [CRITICAL, HIGH, MEDIUM, LOW] }
+        - in: query
+          name: type
+          required: false
+          schema: { type: string, enum: [BACKEND, WORKER, COLLECTOR, PORTAL, SERVICE] }
       responses:
         '200': { description: OK }

--- a/frontend/src/api/useOpsMonitor.ts
+++ b/frontend/src/api/useOpsMonitor.ts
@@ -59,12 +59,30 @@ export function useOpsMonitorSummary() {
   });
 }
 
-export function useOpsMonitorAvailability() {
+export interface OpsMonitorFilters {
+  criticality?: string;
+  type?: string;
+}
+
+function activeParams(filters?: OpsMonitorFilters) {
+  return {
+    criticality: filters?.criticality || undefined,
+    type: filters?.type || undefined,
+  };
+}
+
+export function useOpsMonitorAvailability(filters?: OpsMonitorFilters) {
   return useQuery({
-    queryKey: ["ops-monitor", "availability"],
+    queryKey: [
+      "ops-monitor",
+      "availability",
+      filters?.criticality ?? "",
+      filters?.type ?? "",
+    ],
     queryFn: async () => {
       const { data } = await axios.get<ModuleAvailability[]>(
         "/api/ops-monitor/v1/modules/availability",
+        { params: activeParams(filters) },
       );
       return data;
     },
@@ -86,15 +104,42 @@ export function useOpsMonitorAvailabilityHistory(moduleCode?: string) {
   });
 }
 
-export function useOpsMonitorOpenIncidents() {
+export function useOpsMonitorOpenIncidents(filters?: OpsMonitorFilters) {
   return useQuery({
-    queryKey: ["ops-monitor", "incidents", "open"],
+    queryKey: [
+      "ops-monitor",
+      "incidents",
+      "open",
+      filters?.criticality ?? "",
+      filters?.type ?? "",
+    ],
     queryFn: async () => {
       const { data } = await axios.get<ModuleIncident[]>(
         "/api/ops-monitor/v1/incidents/open",
+        { params: activeParams(filters) },
       );
       return data;
     },
     refetchInterval: 30_000,
+  });
+}
+
+export function useOpsMonitorIncidentHistory(filters?: OpsMonitorFilters) {
+  return useQuery({
+    queryKey: [
+      "ops-monitor",
+      "incidents",
+      "history",
+      filters?.criticality ?? "",
+      filters?.type ?? "",
+    ],
+    queryFn: async () => {
+      const { data } = await axios.get<ModuleIncident[]>(
+        "/api/ops-monitor/v1/incidents/history",
+        { params: activeParams(filters) },
+      );
+      return data;
+    },
+    refetchInterval: 60_000,
   });
 }

--- a/frontend/src/pages/OpsMonitorPage.tsx
+++ b/frontend/src/pages/OpsMonitorPage.tsx
@@ -7,6 +7,7 @@ import {
   OpsMonitorStatus,
   useOpsMonitorAvailability,
   useOpsMonitorAvailabilityHistory,
+  useOpsMonitorIncidentHistory,
   useOpsMonitorOpenIncidents,
   useOpsMonitorSummary,
 } from "../api/useOpsMonitor";
@@ -74,9 +75,16 @@ function getImpact(module: ModuleAvailability) {
 
 export default function OpsMonitorPage() {
   const [selectedModuleCode, setSelectedModuleCode] = useState<string>();
+  const [criticalityFilter, setCriticalityFilter] = useState("");
+  const [typeFilter, setTypeFilter] = useState("");
+  const filters = useMemo(
+    () => ({ criticality: criticalityFilter, type: typeFilter }),
+    [criticalityFilter, typeFilter],
+  );
   const summaryQuery = useOpsMonitorSummary();
-  const availabilityQuery = useOpsMonitorAvailability();
-  const incidentsQuery = useOpsMonitorOpenIncidents();
+  const availabilityQuery = useOpsMonitorAvailability(filters);
+  const incidentsQuery = useOpsMonitorOpenIncidents(filters);
+  const incidentHistoryQuery = useOpsMonitorIncidentHistory(filters);
 
   const modules = availabilityQuery.data ?? [];
   const selectedModule = useMemo(() => {
@@ -174,6 +182,49 @@ export default function OpsMonitorPage() {
         </div>
       </div>
 
+      <div className="card mb-4">
+        <div className="card-header">Filtros operacionais</div>
+        <div className="card-body">
+          <div className="row g-3">
+            <div className="col-md-6">
+              <label className="form-label" htmlFor="ops-criticality-filter">
+                Criticidade
+              </label>
+              <select
+                id="ops-criticality-filter"
+                className="form-select"
+                value={criticalityFilter}
+                onChange={(event) => setCriticalityFilter(event.target.value)}
+              >
+                <option value="">Todas as criticidades</option>
+                <option value="CRITICAL">Crítica</option>
+                <option value="HIGH">Alta</option>
+                <option value="MEDIUM">Média</option>
+                <option value="LOW">Baixa</option>
+              </select>
+            </div>
+            <div className="col-md-6">
+              <label className="form-label" htmlFor="ops-type-filter">
+                Tipo de módulo
+              </label>
+              <select
+                id="ops-type-filter"
+                className="form-select"
+                value={typeFilter}
+                onChange={(event) => setTypeFilter(event.target.value)}
+              >
+                <option value="">Todos os tipos</option>
+                <option value="BACKEND">Backend</option>
+                <option value="WORKER">Worker</option>
+                <option value="COLLECTOR">Coletor</option>
+                <option value="PORTAL">Portal</option>
+                <option value="SERVICE">Serviço</option>
+              </select>
+            </div>
+          </div>
+        </div>
+      </div>
+
       {criticalAlerts.length > 0 ? (
         <div className="mb-4">
           {criticalAlerts.map((module) => (
@@ -252,6 +303,44 @@ export default function OpsMonitorPage() {
               )}
             </div>
           </div>
+        </div>
+      </div>
+
+      <div className="card mb-4">
+        <div className="card-header">Histórico recente de incidentes</div>
+        <div className="card-body">
+          {(incidentHistoryQuery.data ?? []).length === 0 ? (
+            <p className="text-muted mb-0">
+              Nenhum incidente no histórico recente para os filtros atuais.
+            </p>
+          ) : (
+            <div className="table-responsive">
+              <table className="table table-sm align-middle mb-0">
+                <thead>
+                  <tr>
+                    <th>Módulo</th>
+                    <th>Status</th>
+                    <th>Severidade</th>
+                    <th>Início</th>
+                    <th>Duração</th>
+                    <th>Sinal</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {(incidentHistoryQuery.data ?? []).map((incident) => (
+                    <tr key={incident.id}>
+                      <td>{incident.moduleName}</td>
+                      <td>{incident.status}</td>
+                      <td>{incident.severity}</td>
+                      <td>{formatDateTime(incident.startedAt)}</td>
+                      <td>{formatDuration(incident.durationSeconds)}</td>
+                      <td>{incident.rootSignal ?? incident.summary}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            </div>
+          )}
         </div>
       </div>
 


### PR DESCRIPTION
### Motivation
- Expandir a fase 4 do módulo de monitoramento operacional para cobrir OPRM, coletores MOIS, Lead Portal e Email Service e permitir visão filtrada no painel de operação.
- Garantir que o backend continue sendo a fonte da verdade e que o worker apenas execute verificações; fornecer contratos e endpoints para o worker e frontend.

### Description
- Adicionado changelog Liquibase incremental `backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-23-ops-monitor-phase4-modules.yaml` para inserir os novos módulos monitorados e incluído no `db.changelog-master.yaml` com `relativeToChangelogFile: true`.
- Backend: estendido `OpsMonitorController` para aceitar filtros opcionais `criticality` e `type` nas rotas `GET /api/ops-monitor/v1/modules/availability`, `GET /api/ops-monitor/v1/incidents/open` e `GET /api/ops-monitor/v1/incidents/history` e implementada filtragem correspondente em `OpsMonitorService` (`listAvailability(String,String)` e `listIncidents(boolean,String,String)`) com a função auxiliar `matchesFilter`.
- Frontend: hooks atualizados em `frontend/src/api/useOpsMonitor.ts` para enviar parâmetros de consulta (`criticality`, `type`) e novos hooks para histórico (`useOpsMonitorIncidentHistory`); página `frontend/src/pages/OpsMonitorPage.tsx` ampliada com controles de filtro por criticidade/tipo e um bloco de histórico recente de incidentes que consome os dados consolidados do backend.
- Documentação/Swagger: atualizado `docs/swagger/ops-monitor-swagger.yaml`, `docs/ops-monitor/contratos.md` e `docs/ops-monitor/arquitetura.md` para registrar os filtros administrativos e os módulos adicionados da fase 4.
- Testes: adicionado teste unitário `OpsMonitorServiceTest.listAvailabilityFiltersByCriticalityAndType` para validar a filtragem do service.

### Testing
- Executado `cd backend/ads-service && mvn -Dtest=OpsMonitorServiceTest test` e o teste específico passou com sucesso.
- Executado a suíte Java com `cd backend/ads-service && mvn test` e o build de testes do backend completou com `BUILD SUCCESS` (nenhuma falha nos testes aplicáveis ao escopo modificado).
- Executado o teste frontend específico com `cd frontend && npm test -- OpsMonitorPage.test.tsx --run` e o teste passou.
- Executado verificação de tipos com `cd frontend && npm run typecheck` e o TypeScript não retornou erros.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3ab6d71bd8832194c517bdc103d905)