### PR TITLE
Alinha testes de hipóteses ao código automático

### DIFF
--- a/ai-worker/src/test/java/com/marketinghub/worker/niche/NicheHypothesisServiceTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/niche/NicheHypothesisServiceTest.java
@@ -189,11 +189,11 @@ class NicheHypothesisServiceTest {
         List<Hypothesis> hyps = result.get(niche.getId());
         assertThat(hyps).hasSize(2);
         Hypothesis first = hyps.get(0);
-        assertThat(first.getTitle()).isEqualTo("H1");
+        assertThat(first.getTitle()).isEqualTo("SXX-H001");
         assertThat(first.getMarketNiche().getId()).isEqualTo(niche.getId());
         assertThat(first.getModel()).isEqualTo(model);
         assertThat(first.getPrompt()).isNotBlank();
-        // Access the field via reflection since older ads-service builds may lack the getter
+        // Acessa o campo por reflexão porque builds antigos do ads-service podem não ter o getter
         assertThat(org.springframework.test.util.ReflectionTestUtils.getField(first, "generatedAt"))
                 .isNotNull();
         assertThat(first.getPromptAttributeDescriptions()).extracting(PromptAttributeDescription::getId).contains(desc.getId());

--- a/ai-worker/src/test/java/com/marketinghub/worker/successproduct/SuccessProductNicheHypothesisServiceTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/successproduct/SuccessProductNicheHypothesisServiceTest.java
@@ -85,7 +85,7 @@ class SuccessProductNicheHypothesisServiceTest {
         var hypothesis = hypothesisRepository.findAll().get(0);
         assertThat(niche.getName()).isEqualTo("Saude");
         assertThat(niche.getDescription()).isEqualTo("Nicho de saude");
-        assertThat(hypothesis.getTitle()).isEqualTo("Hipotese A");
+        assertThat(hypothesis.getTitle()).isEqualTo("SXX-H001");
         assertThat(hypothesis.getMarketNiche().getId()).isEqualTo(niche.getId());
         assertThat(hypothesis.getPersona()).isEqualTo("Persona A");
         assertThat(hypothesis.getProblem()).isEqualTo("Problema A");

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -5143,3 +5143,9 @@
 - Causa-raiz: o fluxo de targeting ainda usava `gpt-4.1` como padrão e montava instruções diretamente na classe Java, sem reforçar a separação entre geração de seeds pela IA e validação oficial posterior na API da Meta.
 - Alteração: o AI Worker passa a usar `gpt-5.5`, inclui `service_tier: flex` no payload da Responses API e carrega prompt versionado que instrui o modelo a gerar seeds compatíveis com Targeting Search/Meta Ads; a validação de existência oficial continua sendo feita pelo Facebook Ads Worker na API da Meta.
 - Impacto esperado: os candidatos iniciais devem chegar mais próximos da taxonomia real da Meta, reduzindo retrabalho e acelerando a liberação de público para campanhas de experimento.
+
+## 2026-06-23 — Alinhamento dos testes de hipótese ao código automático
+- Problema: dois testes do AI Worker ainda esperavam o título textual retornado pela IA, mas o contrato canônico atual determina identificação automática da hipótese pelo backend.
+- Causa-raiz: a regra de nomeação automática (`<SIGLA>-H001`) evoluiu no backend e os testes de integração do worker ficaram com expectativa legada.
+- Correção aplicada: os testes passaram a validar o identificador automático gerado para o nicho, preservando a checagem dos demais campos funcionais da hipótese.
+- Prevenção de recorrência: a cobertura agora confirma o contrato canônico de criação de hipótese e reduz risco de reintroduzir nomes manuais vindos da IA.


### PR DESCRIPTION
### Motivation
- Os testes do AI Worker esperavam títulos gerados pela IA enquanto o backend passou a gerar títulos automáticos no formato `<SIGLA>-H001`, causando falhas de expectativa em integração de domínio.
- É necessário manter os testes alinhados ao contrato canônico de identificação automática de hipótese para evitar regressões e reforçar o contrato entre backend e worker.

### Description
- Atualiza a asserção do teste `NicheHypothesisServiceTest` para esperar o título automático `SXX-H001` em vez do literal `H1` e adapta comentário explicativo para português; file `ai-worker/src/test/java/com/marketinghub/worker/niche/NicheHypothesisServiceTest.java`.
- Atualiza a asserção do teste `SuccessProductNicheHypothesisServiceTest` para esperar `SXX-H001` em vez de `Hipotese A`; file `ai-worker/src/test/java/com/marketinghub/worker/successproduct/SuccessProductNicheHypothesisServiceTest.java`.
- Registra a correção e a causa-raiz em `docs/registros/experimentos.md` para rastreabilidade e prevenção de recorrência.

### Testing
- Executed `mvn -DskipTests install` in `backend/ads-service` to build and install the backend artifact used by the worker, which completed successfully.
- Executed `mvn -Dtest=NicheHypothesisServiceTest,SuccessProductNicheHypothesisServiceTest test` in `ai-worker` and observed `Tests run: 6, Failures: 0, Errors: 0, Skipped: 0`, indicating the updated tests pass.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3ace974ce083218a7c64e50f6af554)