### PR TITLE
Add scheduled healthcheck runner and backend heartbeat reporting to ops-monitor-worker

### DIFF
--- a/docs/registros/ops-monitor.md
+++ b/docs/registros/ops-monitor.md
@@ -1,0 +1,7 @@
+# Registros do monitor operacional
+
+## 2026-06-23 — Ativação do heartbeat periódico do monitor operacional
+
+- Causa-raiz: a tela de operação mostrava todos os módulos como `Sem verificação recente` porque não havia registros em `ops_module_health_check`.
+- Ajuste: o `ops-monitor-worker` passou a consumir o endpoint canônico de pendências, executar health check periódico e registrar heartbeat no backend.
+- Prevenção: teste unitário garante que o runner consome pendências e chama o contrato de heartbeat.

--- a/ops-monitor-worker/src/main/java/com/marketinghub/opsmonitor/OpsMonitorWorkerApplication.java
+++ b/ops-monitor-worker/src/main/java/com/marketinghub/opsmonitor/OpsMonitorWorkerApplication.java
@@ -2,9 +2,11 @@ package com.marketinghub.opsmonitor;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 /** Inicializa o worker responsável pelo monitoramento operacional dos módulos. */
 @SpringBootApplication
+@EnableScheduling
 public class OpsMonitorWorkerApplication {
 
     /** Executa a aplicação Spring Boot do monitor operacional. */

--- a/ops-monitor-worker/src/main/java/com/marketinghub/opsmonitor/pipeline/healthcheck/HealthCheckBackendClient.java
+++ b/ops-monitor-worker/src/main/java/com/marketinghub/opsmonitor/pipeline/healthcheck/HealthCheckBackendClient.java
@@ -1,5 +1,7 @@
 package com.marketinghub.opsmonitor.pipeline.healthcheck;
 
+import java.util.List;
+import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.web.reactive.function.client.WebClient;
 import reactor.core.publisher.Mono;
 
@@ -9,6 +11,13 @@ public class HealthCheckBackendClient {
 
     /** Recebe o cliente HTTP apontado para o backend principal. */
     public HealthCheckBackendClient(WebClient webClient) { this.webClient = webClient; }
+
+    /** Busca no backend a lista canônica de módulos pendentes de verificação. */
+    public List<PendingModuleCheck> fetchPendingChecks() {
+        return webClient.get().uri("/api/internal/ops-monitor/v1/module-checks/stage-executions/pending")
+                .retrieve().bodyToMono(new ParameterizedTypeReference<List<PendingModuleCheck>>() {})
+                .blockOptional().orElse(List.of());
+    }
 
     /** Registra o heartbeat do módulo monitorado no contrato oficial do backend. */
     public Mono<Void> sendHeartbeat(HealthCheckOutput output) {

--- a/ops-monitor-worker/src/main/java/com/marketinghub/opsmonitor/pipeline/healthcheck/HealthCheckConfiguration.java
+++ b/ops-monitor-worker/src/main/java/com/marketinghub/opsmonitor/pipeline/healthcheck/HealthCheckConfiguration.java
@@ -1,9 +1,34 @@
 package com.marketinghub.opsmonitor.pipeline.healthcheck;
 
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.web.reactive.function.client.WebClient;
 
-/** Habilita as propriedades da etapa de health check. */
+/** Habilita as propriedades e componentes da etapa de health check. */
 @Configuration
 @EnableConfigurationProperties(HealthCheckProperties.class)
-public class HealthCheckConfiguration {}
+public class HealthCheckConfiguration {
+
+    /** Cria o cliente HTTP usado para chamadas aos módulos monitorados. */
+    @Bean
+    public HealthCheckProcessor healthCheckProcessor(WebClient.Builder builder) {
+        return new HealthCheckProcessor(builder.build());
+    }
+
+    /** Cria o cliente HTTP apontado para o backend principal. */
+    @Bean
+    public HealthCheckBackendClient healthCheckBackendClient(WebClient.Builder builder,
+            @Value("${ops-monitor.backend.base-url:http://191.252.181.168}") String backendBaseUrl) {
+        return new HealthCheckBackendClient(builder.baseUrl(backendBaseUrl).build());
+    }
+
+    /** Cria o executor periódico que consome pendências e registra heartbeats. */
+    @Bean
+    public HealthCheckRunner healthCheckRunner(HealthCheckBackendClient backendClient,
+            @Qualifier("healthCheckProcessor") HealthCheckProcessor processor, HealthCheckProperties properties) {
+        return new HealthCheckRunner(backendClient, processor, properties);
+    }
+}

--- a/ops-monitor-worker/src/main/java/com/marketinghub/opsmonitor/pipeline/healthcheck/HealthCheckOutput.java
+++ b/ops-monitor-worker/src/main/java/com/marketinghub/opsmonitor/pipeline/healthcheck/HealthCheckOutput.java
@@ -1,4 +1,6 @@
 package com.marketinghub.opsmonitor.pipeline.healthcheck;
 
+import java.time.Instant;
+
 /** Representa o resultado da chamada de saúde feita para um módulo. */
-public record HealthCheckOutput(String moduleCode, String status, Integer httpStatus, long responseTimeMs, String rawPayload, String errorMessage) {}
+public record HealthCheckOutput(String moduleCode, Instant checkedAt, String status, Integer httpStatus, long responseTimeMs, String rawPayload, String errorMessage) {}

--- a/ops-monitor-worker/src/main/java/com/marketinghub/opsmonitor/pipeline/healthcheck/HealthCheckProcessor.java
+++ b/ops-monitor-worker/src/main/java/com/marketinghub/opsmonitor/pipeline/healthcheck/HealthCheckProcessor.java
@@ -3,6 +3,7 @@ package com.marketinghub.opsmonitor.pipeline.healthcheck;
 import com.marketinghub.opsmonitor.pipeline.StageContext;
 import com.marketinghub.opsmonitor.pipeline.StageProcessor;
 import java.time.Duration;
+import java.time.Instant;
 import org.springframework.web.reactive.function.client.WebClient;
 
 /** Executa a verificação ativa de disponibilidade técnica de um módulo. */
@@ -18,15 +19,16 @@ public class HealthCheckProcessor implements StageProcessor<HealthCheckInput, He
     @Override
     public HealthCheckOutput process(StageContext context, HealthCheckInput input) {
         long started = System.nanoTime();
+        Instant checkedAt = Instant.now();
         try {
             var entity = webClient.get().uri(input.url()).retrieve().toEntity(String.class)
                     .timeout(timeout(input)).block();
             long elapsed = elapsedMs(started);
             int statusCode = entity.getStatusCode().value();
             String status = statusCode >= 200 && statusCode < 300 ? "ONLINE" : "DEGRADED";
-            return new HealthCheckOutput(input.moduleCode(), status, statusCode, elapsed, entity.getBody(), null);
+            return new HealthCheckOutput(input.moduleCode(), checkedAt, status, statusCode, elapsed, entity.getBody(), null);
         } catch (RuntimeException ex) {
-            return new HealthCheckOutput(input.moduleCode(), "OFFLINE", null, elapsedMs(started), null, ex.getClass().getSimpleName() + ": " + ex.getMessage());
+            return new HealthCheckOutput(input.moduleCode(), checkedAt, "OFFLINE", null, elapsedMs(started), null, ex.getClass().getSimpleName() + ": " + ex.getMessage());
         }
     }
 

--- a/ops-monitor-worker/src/main/java/com/marketinghub/opsmonitor/pipeline/healthcheck/HealthCheckRunner.java
+++ b/ops-monitor-worker/src/main/java/com/marketinghub/opsmonitor/pipeline/healthcheck/HealthCheckRunner.java
@@ -1,0 +1,67 @@
+package com.marketinghub.opsmonitor.pipeline.healthcheck;
+
+import com.marketinghub.opsmonitor.pipeline.StageContext;
+import java.time.Duration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Scheduled;
+
+/** Executa periodicamente as verificações de saúde entregues pelo backend. */
+public class HealthCheckRunner {
+    private static final Logger log = LoggerFactory.getLogger(HealthCheckRunner.class);
+    private final HealthCheckBackendClient backendClient;
+    private final HealthCheckProcessor processor;
+    private final HealthCheckProperties properties;
+
+    /** Recebe as dependências usadas para buscar pendências, verificar saúde e reportar heartbeat. */
+    public HealthCheckRunner(HealthCheckBackendClient backendClient, HealthCheckProcessor processor,
+            HealthCheckProperties properties) {
+        this.backendClient = backendClient;
+        this.processor = processor;
+        this.properties = properties;
+    }
+
+    /** Executa um ciclo periódico completo de verificação dos módulos pendentes. */
+    @Scheduled(cron = "0 */1 * * * *")
+    public void runScheduledChecks() {
+        runOnce();
+    }
+
+    /** Executa um ciclo imediato de verificação para reuso em testes e inicializações manuais. */
+    public void runOnce() {
+        var pendingChecks = backendClient.fetchPendingChecks();
+        log.info("ops-monitor-worker healthcheck ciclo iniciado: modules={}", pendingChecks.size());
+        pendingChecks.forEach(this::processModule);
+    }
+
+    /** Processa um único módulo e registra o heartbeat mesmo quando a chamada de saúde falha. */
+    private void processModule(PendingModuleCheck check) {
+        String targetUrl = targetUrl(check);
+        try {
+            var output = processor.process(StageContext.simple("healthcheck-" + check.moduleCode(), check.moduleCode()),
+                    new HealthCheckInput(check.moduleCode(), targetUrl, defaultTimeout()));
+            backendClient.sendHeartbeat(output).block(defaultTimeout());
+            log.info("ops-monitor-worker heartbeat registrado: module={} status={} url={}", check.moduleCode(), output.status(), targetUrl);
+        } catch (RuntimeException ex) {
+            log.error("ops-monitor-worker falhou ao processar heartbeat: module={} url={}", check.moduleCode(), targetUrl, ex);
+        }
+    }
+
+    /** Monta a URL final de saúde a partir do contrato recebido do backend. */
+    private String targetUrl(PendingModuleCheck check) {
+        String baseUrl = stripTrailingSlash(check.baseUrl());
+        String healthPath = check.healthPath() == null || check.healthPath().isBlank() ? "/actuator/health" : check.healthPath();
+        return baseUrl + (healthPath.startsWith("/") ? healthPath : "/" + healthPath);
+    }
+
+    /** Remove barras finais para evitar URL com separador duplicado. */
+    private String stripTrailingSlash(String value) {
+        if (value == null || value.isBlank()) return "";
+        return value.endsWith("/") ? value.substring(0, value.length() - 1) : value;
+    }
+
+    /** Resolve o timeout padrão configurado para as chamadas de saúde e reporte. */
+    private Duration defaultTimeout() {
+        return properties.defaultTimeout() == null ? Duration.ofSeconds(5) : properties.defaultTimeout();
+    }
+}

--- a/ops-monitor-worker/src/main/java/com/marketinghub/opsmonitor/pipeline/healthcheck/PendingModuleCheck.java
+++ b/ops-monitor-worker/src/main/java/com/marketinghub/opsmonitor/pipeline/healthcheck/PendingModuleCheck.java
@@ -1,0 +1,5 @@
+package com.marketinghub.opsmonitor.pipeline.healthcheck;
+
+/** Representa uma pendência de verificação entregue pelo backend ao worker. */
+public record PendingModuleCheck(String moduleCode, String name, String type, String baseUrl, String healthPath,
+        String logPath, String criticality, Integer offlineThresholdSeconds) {}

--- a/ops-monitor-worker/src/main/resources/application.properties
+++ b/ops-monitor-worker/src/main/resources/application.properties
@@ -3,3 +3,5 @@ management.endpoints.web.exposure.include=health,info
 ops-monitor.health-check.default-timeout=5s
 ops-monitor.availability.degraded-response-time-ms=5000
 ops-monitor.availability.offline-failure-threshold=3
+
+ops-monitor.backend.base-url=${OPS_MONITOR_BACKEND_BASE_URL:http://191.252.181.168}

--- a/ops-monitor-worker/src/test/java/com/marketinghub/opsmonitor/pipeline/healthcheck/HealthCheckBackendClientTest.java
+++ b/ops-monitor-worker/src/test/java/com/marketinghub/opsmonitor/pipeline/healthcheck/HealthCheckBackendClientTest.java
@@ -16,7 +16,7 @@ class HealthCheckBackendClientTest {
             server.start();
             var client = new HealthCheckBackendClient(WebClient.builder().baseUrl(server.url("/").toString()).build());
 
-            client.sendHeartbeat(new HealthCheckOutput("backend", "ONLINE", 200, 15, "{}", null)).block();
+            client.sendHeartbeat(new HealthCheckOutput("backend", java.time.Instant.parse("2026-06-23T12:00:00Z"), "ONLINE", 200, 15, "{}", null)).block();
 
             var request = server.takeRequest();
             assertThat(request.getMethod()).isEqualTo("POST");

--- a/ops-monitor-worker/src/test/java/com/marketinghub/opsmonitor/pipeline/healthcheck/HealthCheckRunnerTest.java
+++ b/ops-monitor-worker/src/test/java/com/marketinghub/opsmonitor/pipeline/healthcheck/HealthCheckRunnerTest.java
@@ -1,0 +1,35 @@
+package com.marketinghub.opsmonitor.pipeline.healthcheck;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.time.Duration;
+import java.time.Instant;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+import reactor.core.publisher.Mono;
+
+class HealthCheckRunnerTest {
+
+    @Test
+    void deveConsumirPendenciasERegistrarHeartbeat() {
+        var backendClient = mock(HealthCheckBackendClient.class);
+        var processor = mock(HealthCheckProcessor.class);
+        var properties = new HealthCheckProperties(Duration.ofSeconds(2));
+        var pending = new PendingModuleCheck("backend", "Backend principal", "BACKEND", "http://localhost:8080",
+                "/actuator/health", "/actuator/logfile", "CRITICAL", 300);
+        var output = new HealthCheckOutput("backend", Instant.parse("2026-06-23T12:00:00Z"), "ONLINE", 200, 10,
+                "{\"status\":\"UP\"}", null);
+        when(backendClient.fetchPendingChecks()).thenReturn(List.of(pending));
+        when(processor.process(any(), any())).thenReturn(output);
+        when(backendClient.sendHeartbeat(output)).thenReturn(Mono.empty());
+
+        new HealthCheckRunner(backendClient, processor, properties).runOnce();
+
+        verify(backendClient).fetchPendingChecks();
+        verify(processor).process(any(), any(HealthCheckInput.class));
+        verify(backendClient).sendHeartbeat(output);
+    }
+}


### PR DESCRIPTION
### Motivation

- The operational UI showed modules as `Sem verificação recente` because no heartbeats were being recorded in `ops_module_health_check`, so the worker must periodically fetch pending checks, run healthchecks and record heartbeats. 

### Description

- Enable scheduling in the application by adding `@EnableScheduling` to `OpsMonitorWorkerApplication` and register a periodic `HealthCheckRunner` that executes scheduled checks.
- Add `HealthCheckRunner` to fetch pending checks from the backend, execute healthchecks via `HealthCheckProcessor`, build target URLs and send heartbeats with `HealthCheckBackendClient`.
- Extend `HealthCheckBackendClient` with `fetchPendingChecks()` and keep `sendHeartbeat()`; add `PendingModuleCheck` model and expose backend base URL via `ops-monitor.backend.base-url` property wired in `HealthCheckConfiguration` with beans for `HealthCheckProcessor`, `HealthCheckBackendClient`, and `HealthCheckRunner`.
- Add `checkedAt` timestamp to `HealthCheckOutput` and propagate it from `HealthCheckProcessor`; adjust timeouts and URL normalization logic in the runner; add documentation file `docs/registros/ops-monitor.md` describing the activation.
- Update `application.properties` to include `ops-monitor.backend.base-url` and update tests to cover the new behaviour.

### Testing

- Ran unit test `HealthCheckBackendClientTest` which exercises `sendHeartbeat` with the updated `HealthCheckOutput` and it passed.
- Ran new unit test `HealthCheckRunnerTest` which mocks backend and processor to verify `fetchPendingChecks`, `process` and `sendHeartbeat` are invoked and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3ad8f8c7e48321b3b35867fe7c8659)