### PR TITLE
Adicionar checklist principal na tela do experimento

### DIFF
--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -5155,3 +5155,8 @@
 - Criada regra para invalidar campanhas com pelo menos 1.500 impressões, R$ 20,00 de gasto sincronizado, taxa de acesso ao formulário igual ou inferior a 1,2% e zero envios de formulário.
 - Causa-raiz tratada: campanhas com pouca entrada no formulário e nenhum lead podiam continuar gastando até regras estatísticas mais longas, mesmo já apresentando sinal comercial composto ruim.
 - Prevenção de recorrência: a parada automática passa a registrar o motivo `LOW_FORM_ENTRY_NO_SUBMISSION_AFTER_SPEND` e solicitar pausa ao Facebook Ads Worker.
+
+## 2026-06-23 — Checklist principal na tela do experimento
+- Pedido: incluir na tela principal do experimento um quadro com marcação visual dos marcos já concluídos.
+- Alteração: a tela agora exibe um checklist consolidado com pipeline de experimento, pipeline GeraLanding, aprovação de pelo menos 3 criativos, escolha de público e aprovação da landing.
+- Objetivo de negócio: dar ao usuário uma visão rápida do que falta para transformar o experimento em campanha publicável, reduzindo esforço operacional e acelerando a liberação para vendas.

--- a/frontend/src/pages/experiment/ExperimentDetailPage.tsx
+++ b/frontend/src/pages/experiment/ExperimentDetailPage.tsx
@@ -1770,8 +1770,8 @@ export default function ExperimentDetailPage() {
     readinessSummary?.hasCreatives ?? data.creativeApproved;
   const readinessCreativeCount = readinessSummary?.creativeCount ?? 0;
   const hasDailyBudget = data.dailyBudget != null && data.dailyBudget > 0;
-  const openLandingActions = () => {
-    setTab("landing");
+  const openExperimentTab = (targetTab: string) => {
+    setTab(targetTab);
     window.requestAnimationFrame(() => {
       tabsSectionRef.current?.scrollIntoView({
         behavior: "smooth",
@@ -1779,6 +1779,7 @@ export default function ExperimentDetailPage() {
       });
     });
   };
+  const openLandingActions = () => openExperimentTab("landing");
 
   const blockingChecklist: ChecklistItem[] = [
     {
@@ -1947,6 +1948,90 @@ export default function ExperimentDetailPage() {
       items: operationalChecklist,
     },
   ].filter((group) => group.items.length > 0);
+
+  const hasExperimentPipelineContent = Boolean(
+    data.campaignAngle ||
+    data.adCopy ||
+    data.adImageBriefing ||
+    data.creativeTextPrompt ||
+    data.creativeImagePrompt,
+  );
+  const hasGeraLandingPipelineContent = Boolean(
+    data.landingPageWireframe ||
+    data.landingPageCopy ||
+    data.landingPageImagePlanning ||
+    data.landingPageDesignPreset ||
+    data.landingPageDeliverables ||
+    data.landingPageHtml ||
+    data.htmlGeraLanding,
+  );
+  const hasAtLeastThreeApprovedCreatives = readinessCreativeCount >= 3;
+  const hasAudienceSelection = readinessSummary?.hasCompleteTargeting ?? false;
+  const mainExperimentChecklist = [
+    {
+      id: "experiment-pipeline",
+      title: "Pipeline de experimento",
+      detail: "Aba Estrutura de conteúdo",
+      isMet: hasExperimentPipelineContent,
+      isLoading: false,
+      actionLabel: "Abrir estrutura",
+      action: () => openExperimentTab("content-structure"),
+    },
+    {
+      id: "geralanding-pipeline",
+      title: "Pipeline GeraLanding",
+      detail: "Aba Gera landing",
+      isMet: hasGeraLandingPipelineContent,
+      isLoading:
+        isLoadingPendingGeraLandingExecutions ||
+        isLoadingCompletedGeraLandingExecutions ||
+        isLoadingPendingGeraLandingCopyExecutions ||
+        isLoadingCompletedGeraLandingCopyExecutions ||
+        isLoadingPendingGeraLandingDesignPresetExecutions ||
+        isLoadingCompletedGeraLandingDesignPresetExecutions ||
+        isLoadingPendingGeraLandingImagePromptsExecutions ||
+        isLoadingCompletedGeraLandingImagePromptsExecutions ||
+        isLoadingPendingGeraLandingImageGenerationExecutions ||
+        isLoadingCompletedGeraLandingImageGenerationExecutions ||
+        isLoadingPendingGeraLandingQualityReviewExecutions ||
+        isLoadingCompletedGeraLandingQualityReviewExecutions ||
+        isLoadingPendingGeraLandingDeliverablesExecutions ||
+        isLoadingCompletedGeraLandingDeliverablesExecutions,
+      actionLabel: "Abrir GeraLanding",
+      action: () => openExperimentTab("gera-landing"),
+    },
+    {
+      id: "approved-creatives",
+      title: "Aprovação de criativos",
+      detail: `${readinessCreativeCount}/3 criativos aprovados`,
+      isMet: hasAtLeastThreeApprovedCreatives,
+      isLoading: isLoadingReadiness,
+      actionLabel: "Abrir criativos",
+      action: () => openExperimentTab("creatives"),
+    },
+    {
+      id: "audience-selection",
+      title: "Escolha de público",
+      detail: hasAudienceSelection
+        ? "Público completo selecionado"
+        : "Selecione interesses, comportamentos e dados demográficos",
+      isMet: hasAudienceSelection,
+      isLoading: isLoadingReadiness,
+      actionLabel: "Abrir público",
+      action: () => openExperimentTab("publico"),
+    },
+    {
+      id: "landing-approval",
+      title: "Aprovação da landing",
+      detail: data.followUpActionUrl
+        ? "Landing aprovada com URL ativa"
+        : "Aprove a landing para liberar a URL de destino",
+      isMet: Boolean(data.followUpActionUrl),
+      isLoading: isLoadingReadiness,
+      actionLabel: "Abrir landing",
+      action: openLandingActions,
+    },
+  ];
   const diagnosticsVariant: Record<string, string> = {
     ERROR: "danger",
     WARNING: "warning",
@@ -2273,6 +2358,64 @@ export default function ExperimentDetailPage() {
           ) : null}
         </div>
       ) : null}
+      <div className="card border-0 shadow-sm rounded-3 mt-3">
+        <div className="card-body">
+          <div className="d-flex justify-content-between align-items-start gap-3 flex-wrap">
+            <div>
+              <h5 className="card-title mb-1">
+                Checklist principal do experimento
+              </h5>
+              <p className="text-muted small mb-0">
+                Visão rápida dos marcos necessários para transformar o
+                experimento em campanha publicável.
+              </p>
+            </div>
+            <span className="badge text-bg-light border text-body">
+              {mainExperimentChecklist.filter((item) => item.isMet).length}/
+              {mainExperimentChecklist.length} concluídos
+            </span>
+          </div>
+          <div className="row g-3 mt-1">
+            {mainExperimentChecklist.map((item) => (
+              <div key={item.id} className="col-12 col-md-6 col-xl">
+                <button
+                  type="button"
+                  className={`w-100 h-100 text-start border rounded-3 p-3 bg-body ${
+                    item.isMet
+                      ? "border-success-subtle"
+                      : "border-warning-subtle"
+                  }`}
+                  onClick={item.action}
+                >
+                  <div className="d-flex align-items-start gap-2">
+                    <span
+                      className={`badge rounded-pill ${
+                        item.isLoading
+                          ? "text-bg-secondary"
+                          : item.isMet
+                            ? "text-bg-success"
+                            : "text-bg-warning"
+                      }`}
+                      aria-label={item.isMet ? "Concluído" : "Pendente"}
+                    >
+                      {item.isLoading ? "…" : item.isMet ? "✓" : "!"}
+                    </span>
+                    <span>
+                      <span className="fw-semibold d-block">{item.title}</span>
+                      <span className="small text-muted d-block mt-1">
+                        {item.detail}
+                      </span>
+                      <span className="small text-primary d-block mt-2">
+                        {item.actionLabel}
+                      </span>
+                    </span>
+                  </div>
+                </button>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
       <div className="card border-0 shadow-sm rounded-3 mt-3">
         <div className="card-body">
           <div className="d-flex justify-content-between align-items-start">


### PR DESCRIPTION
### Motivation
- Dar ao usuário uma visão rápida dos marcos essenciais que faltam para transformar um experimento em campanha publicável (reduzir esforço operacional e acelerar liberação para vendas). 
- Exibir visualmente, na tela principal do experimento, os itens solicitados com marcação de concluído/pendente: `pipeline de experimento (aba Estrutura de conteúdo)`, `pipeline GeraLanding`, `aprovação de pelo menos 3 criativos`, `escolha de público` e `aprovação da landing`.

### Description
- Adiciona no frontend a lógica e o cartão de checklist principal em `frontend/src/pages/experiment/ExperimentDetailPage.tsx`, incluindo o novo helper `openExperimentTab(targetTab)` e a lista `mainExperimentChecklist` que calcula `isMet`/`isLoading` para cada item e fornece navegação rápida para as abas relacionadas.
- Insere JSX responsivo que renderiza cada item com badge de status (`✓` para concluído, `!` para pendente, `…` para carregando) e resumo do total concluído sobre o total de itens.
- Reusa dados já expostos pelo backend (ex.: `readinessSummary`, `data.followUpActionUrl`, campos de conteúdo do experimento) sem criar novos endpoints. 
- Registra a alteração no histórico de mudanças em `docs/registros/experimentos.md` com a justificativa e objetivo de negócio.

### Testing
- Executado `npm run typecheck` no `frontend` e o resultado foi bem-sucedido (`tsc --noEmit` concluído sem erros após instalar dependências). 
- Executado `npm run build` no `frontend` e o build do Vite completou com sucesso (apareceram avisos de tamanho de chunk, mas a geração terminou sem erro).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3adce2bb9c8321b8d623c9814cb917)