### PR TITLE
Mostra nichos pendentes para materializar no ranking OPRM

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/market/dto/OprmTopCnaeMarketVolumeDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/market/dto/OprmTopCnaeMarketVolumeDto.java
@@ -18,5 +18,6 @@ public record OprmTopCnaeMarketVolumeDto(
         BigDecimal opportunityScore,
         String scoreStatus,
         long subnicheCount,
+        long pendingMaterializationCount,
         BigDecimal researchCostUsd,
         boolean nicheResearchRunning) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/oprm/market/OprmMarketSizeByCnaeRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/oprm/market/OprmMarketSizeByCnaeRepository.java
@@ -33,6 +33,17 @@ public interface OprmMarketSizeByCnaeRepository extends JpaRepository<OprmMarket
                 (select count(distinct c2.neutralNicheName)
                     from OprmRoutineResearchCycle c2
                     where c2.cnaeCode = ms.id.cnaeCode),
+                (select count(card.id)
+                    from OprmNicheRoutineCard card
+                    join OprmRoutineResearchCycle cycle on cycle.id = card.researchCycleId
+                    where cycle.cnaeCode = ms.id.cnaeCode
+                      and card.readyForHypothesis = true
+                      and cycle.currentStageCode = 'enriched-niche-materializer'
+                      and card.qualityCheckedAt is not null
+                      and not exists (
+                        select 1 from MarketNicheEnrichmentProfile profile
+                        where profile.sourceRoutineCardId = card.id
+                      )),
                 (select coalesce(sum(seed.costUsd), 0)
                     from OprmNicheResearchSeed seed
                     where seed.cnaeCode = ms.id.cnaeCode),
@@ -67,6 +78,17 @@ public interface OprmMarketSizeByCnaeRepository extends JpaRepository<OprmMarket
                 (select count(distinct c2.neutralNicheName)
                     from OprmRoutineResearchCycle c2
                     where c2.cnaeCode = ms.id.cnaeCode),
+                (select count(card.id)
+                    from OprmNicheRoutineCard card
+                    join OprmRoutineResearchCycle cycle on cycle.id = card.researchCycleId
+                    where cycle.cnaeCode = ms.id.cnaeCode
+                      and card.readyForHypothesis = true
+                      and cycle.currentStageCode = 'enriched-niche-materializer'
+                      and card.qualityCheckedAt is not null
+                      and not exists (
+                        select 1 from MarketNicheEnrichmentProfile profile
+                        where profile.sourceRoutineCardId = card.id
+                      )),
                 (select coalesce(sum(seed.costUsd), 0)
                     from OprmNicheResearchSeed seed
                     where seed.cnaeCode = ms.id.cnaeCode),

--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -1355,3 +1355,4 @@
 - Causa-raiz tratada: o service OPRM tinha assumido diretamente a materialização em `MarketNicheRepository`, quebrando o isolamento do módulo OPRM.
 
 - 2026-06-23 — Ops Monitor fase 4: adicionado o módulo `oprm-coletor-mei` ao cadastro monitorado do backend para acompanhar impacto operacional na descoberta de rotinas, dores e oportunidades.
+- 2026-06-23 19:29:11 (UTC): tela OPRM de CNAEs atualizada para mostrar, na tabela principal, a contagem de nichos pendentes para materializar por CNAE. O endpoint `GET /api/oprm/market/import-runs/cnaes/top-volume` passou a expor `pendingMaterializationCount`, calculado no backend a partir dos cartões aprovados em `enriched-niche-materializer` ainda sem perfil materializado, evitando inferência local no frontend.

--- a/frontend/src/api/oprm/useOprmTopCnaeMarketVolume.ts
+++ b/frontend/src/api/oprm/useOprmTopCnaeMarketVolume.ts
@@ -13,6 +13,7 @@ export interface OprmTopCnaeMarketVolume {
   opportunityScore: number | null;
   scoreStatus: string | null;
   subnicheCount: number;
+  pendingMaterializationCount: number;
   researchCostUsd: number | null;
   nicheResearchRunning: boolean;
 }

--- a/frontend/src/pages/oprm/OprmCnaeVolumePage.tsx
+++ b/frontend/src/pages/oprm/OprmCnaeVolumePage.tsx
@@ -283,6 +283,7 @@ export default function OprmCnaeVolumePage() {
                       <th>Simples</th>
                       <th>MEI</th>
                       <th>Subnichos</th>
+                      <th>Pendente materializar</th>
                       <th>Custo</th>
                       <th>Pesquisa</th>
                       <th>Pipeline v2</th>
@@ -314,6 +315,16 @@ export default function OprmCnaeVolumePage() {
                         <td>{formatNumber(item.totalEmpresasSimples)}</td>
                         <td>{formatNumber(item.totalEmpresasMei)}</td>
                         <td>{formatNumber(item.subnicheCount)}</td>
+                        <td>
+                          {item.pendingMaterializationCount > 0 ? (
+                            <span className="badge text-bg-warning">
+                              {formatNumber(item.pendingMaterializationCount)}{" "}
+                              pendente
+                            </span>
+                          ) : (
+                            <span className="text-secondary">-</span>
+                          )}
+                        </td>
                         <td>{formatCurrencyUsd(item.researchCostUsd)}</td>
                         <td>
                           {item.nicheResearchRunning ? (


### PR DESCRIPTION
### Motivation
- Evitar inferência local no frontend e expor do backend a verdade operacional sobre quantos nichos aprovados ainda aguardam materialização por CNAE.
- Fornecer um indicador direto que permita às operações priorizar materialização sem inspecionar cartões ou construir consultas ad-hoc no cliente.

### Description
- Adiciona o campo `pendingMaterializationCount` ao contrato `OprmTopCnaeMarketVolumeDto` no backend para transportar a contagem por CNAE. 
- Atualiza a consulta em `OprmMarketSizeByCnaeRepository` para computar `pendingMaterializationCount` contando `OprmNicheRoutineCard` aprovados em `enriched-niche-materializer` que ainda não possuem `MarketNicheEnrichmentProfile`. 
- Atualiza o tipo TypeScript `OprmTopCnaeMarketVolume` e a tela `OprmCnaeVolumePage.tsx` para exibir a coluna “Pendente materializar” com badge amarelo quando houver pendência. 
- Registra a mudança em `docs/registros/oprm1.md` para auditoria operacional.

### Testing
- Executado o build backend com `cd backend/ads-service && ../mvnw -q -DskipTests compile` com sucesso. 
- Executada a suíte de testes backend com `cd backend/ads-service && ../mvnw -q test` e as alterações não reportaram falhas relativas às mudanças introduzidas. 
- Executados `cd frontend && npm ci`, `cd frontend && npm run typecheck` e `cd frontend && npm run build`, todos concluídos com sucesso; o `vitest` não encontrou testes filtrados (`--run OprmCnaeVolumePage`).
- Tentativa de rodar `../mvnw -q spotless:apply` no módulo `ads-service` não foi realizada com sucesso porque o plugin `spotless` não está disponível/configurado no contexto atual.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3ade3f00a083219538850c077977c0)