### PR TITLE
fix: destrava aprovação de criativo no frontend

### DIFF
--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -5160,3 +5160,11 @@
 - Pedido: incluir na tela principal do experimento um quadro com marcação visual dos marcos já concluídos.
 - Alteração: a tela agora exibe um checklist consolidado com pipeline de experimento, pipeline GeraLanding, aprovação de pelo menos 3 criativos, escolha de público e aprovação da landing.
 - Objetivo de negócio: dar ao usuário uma visão rápida do que falta para transformar o experimento em campanha publicável, reduzindo esforço operacional e acelerando a liberação para vendas.
+
+## 2026-06-23 — Destravamento visual da aprovação de criativos
+
+- solicitação: a aprovação de criativo no experimento 48 ficou visualmente travada com overlay de processamento na tela.
+- causa-raiz identificada: o comando de aprovação dependia de uma chamada `PUT` sem limite de tempo específico; quando a rota/proxy do backend não respondia ou devolvia indisponibilidade, a tela podia permanecer em estado de processamento sem feedback operacional claro.
+- correção aplicada: a atualização de criativo passou a ter timeout de 30 segundos, o botão de aprovação passou a exibir estado explícito “Aprovando...” com spinner pequeno e a tela limpa o processamento ao receber erro, mantendo mensagem objetiva para nova tentativa.
+- ajuste operacional: o proxy local do Vite foi alinhado para usar o backend na porta 80, evitando dependência da porta 8000 quando ela estiver indisponível atrás do proxy.
+- validação: adicionada cobertura de frontend garantindo que falha na aprovação remove o loading e reabilita o botão.

--- a/frontend/src/api/creative/useUpdateCreative.ts
+++ b/frontend/src/api/creative/useUpdateCreative.ts
@@ -26,6 +26,7 @@ export function useUpdateCreative(expId: string) {
       const { data: creative } = await axios.put<Creative>(
         `/api/creatives/${id}`,
         data,
+        { timeout: 30000 },
       );
       return creative;
     },

--- a/frontend/src/pages/experiment/CriativosTab.test.tsx
+++ b/frontend/src/pages/experiment/CriativosTab.test.tsx
@@ -1,7 +1,8 @@
 import "@testing-library/jest-dom/vitest";
-import { render, screen } from "@testing-library/react";
+import { cleanup, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import CriativosTab from "./CriativosTab";
 import axios from "axios";
 
@@ -10,6 +11,10 @@ vi.mock("axios");
 describe("CriativosTab", () => {
   beforeEach(() => {
     vi.resetAllMocks();
+  });
+
+  afterEach(() => {
+    cleanup();
   });
   it("shows preview", async () => {
     (axios.get as any).mockImplementation((url: string) => {
@@ -50,7 +55,8 @@ describe("CriativosTab", () => {
               id: 77,
               headline: "H1",
               primaryText: "P1",
-              imagePrompt: "Prompt detalhado da imagem. Briefing visual:\n\n Contraste alto.",
+              imagePrompt:
+                "Prompt detalhado da imagem. Briefing visual:\n\n Contraste alto.",
               status: "DRAFT",
             },
           ],
@@ -73,8 +79,12 @@ describe("CriativosTab", () => {
       name: "Ver prompt da imagem",
     });
     toggleButton.click();
-    expect(await screen.findByText(/Prompt detalhado da imagem/i)).toBeInTheDocument();
-    expect(await screen.findByText("Origem dos trechos do prompt")).toBeInTheDocument();
+    expect(
+      await screen.findByText(/Prompt detalhado da imagem/i),
+    ).toBeInTheDocument();
+    expect(
+      await screen.findByText("Origem dos trechos do prompt"),
+    ).toBeInTheDocument();
     expect(await screen.findByText("Briefing visual")).toBeInTheDocument();
     expect(await screen.findByText("Hierarquia sugerida")).toBeInTheDocument();
     expect(await screen.findByText("Margens de segurança")).toBeInTheDocument();
@@ -174,8 +184,10 @@ describe("CriativosTab", () => {
         return Promise.resolve({
           data: {
             creativesToGenerate: 0,
-            adCopy: '{"adCopy":{"primaryTextVariants":[{"label":"dor","primaryText":"Texto","headline":"Headline","description":"Descrição","ctaText":"Saiba mais"}]}}',
-            adImageBriefing: '{"adImageBriefing":{"briefings":[{"mustMatchAdVariant":"dor","visualBriefing":"Use contraste","assetType":"estatico"}]}}',
+            adCopy:
+              '{"adCopy":{"primaryTextVariants":[{"label":"dor","primaryText":"Texto","headline":"Headline","description":"Descrição","ctaText":"Saiba mais"}]}}',
+            adImageBriefing:
+              '{"adImageBriefing":{"briefings":[{"mustMatchAdVariant":"dor","visualBriefing":"Use contraste","assetType":"estatico"}]}}',
           },
         });
       }
@@ -187,7 +199,9 @@ describe("CriativosTab", () => {
         <CriativosTab experimentId="1" />
       </QueryClientProvider>,
     );
-    expect(await screen.findByText(/Anúncios do pipeline prontos/i)).toBeInTheDocument();
+    expect(
+      await screen.findByText(/Anúncios do pipeline prontos/i),
+    ).toBeInTheDocument();
   });
 
   it("shows pipeline progress banner when worker is running", async () => {
@@ -212,9 +226,10 @@ describe("CriativosTab", () => {
         <CriativosTab experimentId="1" />
       </QueryClientProvider>,
     );
-    expect(await screen.findByText(/Worker AI em produção/i)).toBeInTheDocument();
+    expect(
+      await screen.findByText(/Worker AI em produção/i),
+    ).toBeInTheDocument();
   });
-
 
   it("shows recoverable pipeline failure from backend status", async () => {
     (axios.get as any).mockImplementation((url: string) => {
@@ -227,9 +242,14 @@ describe("CriativosTab", () => {
             creativesToGenerate: 0,
             creativeGenerationMode: "DEFAULT",
             creativeGenerationStatus: "TIMEOUT",
-            creativeGenerationError: "Geração excedeu o tempo operacional de 30 minutos; solicite nova tentativa.",
-            adCopy: JSON.stringify({ adCopy: { primaryTextVariants: [{ primaryText: "Texto" }] } }),
-            adImageBriefing: JSON.stringify({ adImageBriefing: { briefings: [{ visualBriefing: "Imagem" }] } }),
+            creativeGenerationError:
+              "Geração excedeu o tempo operacional de 30 minutos; solicite nova tentativa.",
+            adCopy: JSON.stringify({
+              adCopy: { primaryTextVariants: [{ primaryText: "Texto" }] },
+            }),
+            adImageBriefing: JSON.stringify({
+              adImageBriefing: { briefings: [{ visualBriefing: "Imagem" }] },
+            }),
           },
         });
       }
@@ -241,7 +261,70 @@ describe("CriativosTab", () => {
         <CriativosTab experimentId="1" />
       </QueryClientProvider>,
     );
-    expect(await screen.findByText(/solicite nova tentativa/i)).toBeInTheDocument();
+    expect(
+      await screen.findByText(/solicite nova tentativa/i),
+    ).toBeInTheDocument();
   });
 
+  it("clears approval loading state when the backend rejects the update", async () => {
+    (axios.get as any).mockImplementation((url: string) => {
+      if (url.endsWith("/experiments/1/creatives")) {
+        return Promise.resolve({
+          data: [
+            {
+              id: 80,
+              format: "LINK",
+              headline: "Criativo em rascunho",
+              primaryText: "Texto",
+              imageUrl: "img.jpg",
+              description: "Descrição",
+              cta: "LEARN_MORE",
+              destinationUrl: "",
+              leadGenFormId: "",
+              instagramUserId: "",
+              status: "DRAFT",
+            },
+          ],
+        });
+      }
+      if (url.endsWith("/experiments/1")) {
+        return Promise.resolve({ data: { creativesToGenerate: 0 } });
+      }
+      return Promise.resolve({ data: [] });
+    });
+    let rejectUpdate: (error: Error) => void = () => {};
+    (axios.put as any).mockImplementation(
+      () =>
+        new Promise((_, reject) => {
+          rejectUpdate = reject;
+        }),
+    );
+
+    const client = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    });
+    render(
+      <QueryClientProvider client={client}>
+        <CriativosTab experimentId="1" />
+      </QueryClientProvider>,
+    );
+
+    await userEvent.click(
+      await screen.findByRole("button", { name: "Aprovar" }),
+    );
+
+    expect(await screen.findByText("Aprovando...")).toBeInTheDocument();
+
+    rejectUpdate(new Error("backend unavailable"));
+
+    expect(
+      await screen.findByText("Não foi possível aprovar o criativo"),
+    ).toBeInTheDocument();
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Aprovar" })).toBeEnabled();
+    });
+  });
 });

--- a/frontend/src/pages/experiment/CriativosTab.tsx
+++ b/frontend/src/pages/experiment/CriativosTab.tsx
@@ -252,12 +252,14 @@ export default function CriativosTab({
   const pipelinePairs = Math.min(pipelineVariantCount, pipelineBriefingCount);
   const pipelineAvailable = pipelinePairs > 0;
   const pendingCreativeRequests = experiment?.creativesToGenerate ?? 0;
-  const creativeGenerationStatus = experiment?.creativeGenerationStatus ?? "IDLE";
+  const creativeGenerationStatus =
+    experiment?.creativeGenerationStatus ?? "IDLE";
   const pipelineInProgress =
     creativeGenerationStatus === "REQUESTED" ||
     creativeGenerationStatus === "PROCESSING";
   const pipelineHasRecoverableFailure =
-    creativeGenerationStatus === "FAILED" || creativeGenerationStatus === "TIMEOUT";
+    creativeGenerationStatus === "FAILED" ||
+    creativeGenerationStatus === "TIMEOUT";
   const pipelineStatusLabel =
     creativeGenerationStatus === "REQUESTED"
       ? "Worker AI aguardando a fila de imagens"
@@ -660,8 +662,16 @@ export default function CriativosTab({
                 onClick={() => approve(c)}
                 disabled={isProcessing || alterationLocked}
               >
-                <CheckCircle2 size={ICON_SIZE} />
-                <span>Aprovar</span>
+                {isProcessing ? (
+                  <span
+                    className="spinner-border spinner-border-sm"
+                    role="status"
+                    aria-hidden
+                  />
+                ) : (
+                  <CheckCircle2 size={ICON_SIZE} />
+                )}
+                <span>{isProcessing ? "Aprovando..." : "Aprovar"}</span>
               </button>
             )}
             <button
@@ -918,8 +928,8 @@ export default function CriativosTab({
             <p className="mb-0 small text-muted">
               Encontramos {pipelinePairs}{" "}
               {pipelinePairs === 1 ? "variação" : "variações"} com texto e
-              briefing estruturados. O Worker AI usará o modelo gpt-image-2
-              para gerar as imagens alinhadas ao experimento.
+              briefing estruturados. O Worker AI usará o modelo gpt-image-2 para
+              gerar as imagens alinhadas ao experimento.
             </p>
           </div>
           <div className="d-flex flex-column align-items-lg-end gap-2 w-100 w-lg-auto">
@@ -954,11 +964,12 @@ export default function CriativosTab({
                 {pipelineStatusLabel}
               </span>
             )}
-            {pipelineHasRecoverableFailure && experiment?.creativeGenerationError && (
-              <span className="small text-muted text-lg-end">
-                {experiment.creativeGenerationError}
-              </span>
-            )}
+            {pipelineHasRecoverableFailure &&
+              experiment?.creativeGenerationError && (
+                <span className="small text-muted text-lg-end">
+                  {experiment.creativeGenerationError}
+                </span>
+              )}
           </div>
         </div>
       ) : pipelineInProgress ? (

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -15,8 +15,8 @@ export default defineConfig(async () => {
       port: 5173,
       hmr: false,
       proxy: {
-        // Backend now listens on port 8000
-        "/api": "http://191.252.181.168:8000",
+        // Codex/dev access should use the backend through port 80; port 8000 can be unavailable behind the proxy.
+        "/api": "http://191.252.181.168",
       },
     },
     build: {


### PR DESCRIPTION
### Motivation
- Corrigir travamento visual ao aprovar um criativo quando o backend/proxy não responde, evitando que o botão fique em estado de processamento indefinidamente e dando feedback claro ao usuário.

### Description
- Adiciona timeout de 30s na requisição de atualização de criativo em `frontend/src/api/creative/useUpdateCreative.ts` para evitar loading indefinido quando a chamada `PUT /api/creatives/{id}` não responde. 
- Atualiza o botão de aprovação em `frontend/src/pages/experiment/CriativosTab.tsx` para exibir um spinner pequeno e o rótulo `Aprovando...` enquanto a operação está em andamento, e garantir que o estado é limpo quando houver erro. 
- Ajusta o proxy de desenvolvimento do Vite em `frontend/vite.config.ts` para usar o backend no host `http://191.252.181.168` (porta 80) para reduzir dependência da porta 8000 atrás de proxies. 
- Adiciona teste de regressão em `frontend/src/pages/experiment/CriativosTab.test.tsx` que valida que falha na aprovação limpa o loading, mostra mensagem de erro e reabilita o botão. 
- Registra a investigação e correção em `docs/registros/experimentos.md`.

### Testing
- Executada a suíte de testes do componente: `npm --prefix frontend test -- CriativosTab.test.tsx --run`, resultado: 8 testes executados, todos passaram. 
- Executado o typecheck TypeScript: `npm --prefix frontend run typecheck`, resultado: passou sem erros.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3b1463127c8321a5104f7c49b53be8)