### PR TITLE
Prevent repeated clicks on "Aprovar landing" — frontend guard and tests

### DIFF
--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -5160,3 +5160,9 @@
 - Pedido: incluir na tela principal do experimento um quadro com marcação visual dos marcos já concluídos.
 - Alteração: a tela agora exibe um checklist consolidado com pipeline de experimento, pipeline GeraLanding, aprovação de pelo menos 3 criativos, escolha de público e aprovação da landing.
 - Objetivo de negócio: dar ao usuário uma visão rápida do que falta para transformar o experimento em campanha publicável, reduzindo esforço operacional e acelerando a liberação para vendas.
+
+## 2026-06-23 — Prevenção de múltiplos cliques na aprovação da landing
+- Problema investigado: no experimento 41, a aprovação da landing demorava alguns segundos por publicar no Lead Portal e podia induzir o usuário a clicar novamente no botão.
+- Evidência: o banco já registrava `follow_up_action_url` para o experimento 41 e o endpoint canônico respondeu `200 OK`, mas com tempo perceptível de publicação externa.
+- Correção aplicada: a aba Landing passa a bloquear nova aprovação quando já existe URL oficial de campanha ou quando a publicação acabou de retornar sucesso na própria tela.
+- Prevenção de recorrência: o botão passa a funcionar como comando único de publicação, evitando repetição desnecessária de chamadas ao backend/Lead Portal.

--- a/frontend/src/pages/experiment/LandingTab.test.ts
+++ b/frontend/src/pages/experiment/LandingTab.test.ts
@@ -26,11 +26,31 @@ describe("LandingTab", () => {
     ).toBeNull();
   });
 
-  it("permite tentar aprovação pelo backend mesmo sem prévia local", () => {
-    expect(canAttemptLandingApproval({ id: "35" })).toBe(true);
+  it("permite tentar aprovação pelo backend quando ainda não há URL aprovada", () => {
+    expect(
+      canAttemptLandingApproval({ id: "35", followUpActionUrl: null }),
+    ).toBe(true);
   });
 
-  it("bloqueia aprovação apenas quando o experimento não tem id", () => {
-    expect(canAttemptLandingApproval({ id: "" })).toBe(false);
+  it("bloqueia aprovação quando o experimento não tem id", () => {
+    expect(canAttemptLandingApproval({ id: "", followUpActionUrl: null })).toBe(
+      false,
+    );
+  });
+
+  it("bloqueia nova aprovação quando já existe URL oficial de campanha", () => {
+    expect(
+      canAttemptLandingApproval({
+        id: "41",
+        followUpActionUrl:
+          "https://oportunidadebrasil.shop/api/flows/exp-41-landing-geralanding/page",
+      }),
+    ).toBe(false);
+  });
+
+  it("bloqueia cliques repetidos depois da publicação local", () => {
+    expect(
+      canAttemptLandingApproval({ id: "41", followUpActionUrl: null }, true),
+    ).toBe(false);
   });
 });

--- a/frontend/src/pages/experiment/LandingTab.tsx
+++ b/frontend/src/pages/experiment/LandingTab.tsx
@@ -35,8 +35,15 @@ export function resolveLandingHtml(
   return typeof raw === "string" && raw.trim().length > 0 ? raw : null;
 }
 
-export function canAttemptLandingApproval(experiment: Pick<Experiment, "id">) {
-  return String(experiment.id ?? "").trim().length > 0;
+export function canAttemptLandingApproval(
+  experiment: Pick<Experiment, "id" | "followUpActionUrl">,
+  hasLocalPublication = false,
+) {
+  const hasExperimentId = String(experiment.id ?? "").trim().length > 0;
+  const alreadyPublished =
+    normalizeUrl(experiment.followUpActionUrl).length > 0 ||
+    hasLocalPublication;
+  return hasExperimentId && !alreadyPublished;
 }
 
 export default function LandingTab({
@@ -56,8 +63,12 @@ export default function LandingTab({
     iframeUrl: string | null;
     standaloneUrl: string | null;
   } | null>(null);
+  const hasLocalPublication =
+    normalizeUrl(publishedUrls?.standaloneUrl).length > 0;
   const canApproveLanding =
-    !alterationLocked && canAttemptLandingApproval(experiment);
+    !alterationLocked &&
+    canAttemptLandingApproval(experiment, hasLocalPublication) &&
+    !approveAndPublishLanding.isPending;
   const selectedDestinationUrl = normalizeUrl(
     publishedUrls?.standaloneUrl ?? experiment.followUpActionUrl,
   );
@@ -66,6 +77,10 @@ export default function LandingTab({
   );
 
   const handleApproveLanding = async () => {
+    if (!canApproveLanding) {
+      return;
+    }
+
     setFeedback(null);
 
     try {
@@ -197,7 +212,7 @@ export default function LandingTab({
           type="button"
           className="btn btn-success"
           onClick={() => handleApproveLanding()}
-          disabled={approveAndPublishLanding.isPending || !canApproveLanding}
+          disabled={!canApproveLanding}
         >
           {approveAndPublishLanding.isPending ? (
             <span className="d-inline-flex align-items-center gap-2">
@@ -208,6 +223,8 @@ export default function LandingTab({
               />
               Aprovando...
             </span>
+          ) : selectedDestinationUrl ? (
+            "Landing aprovada"
           ) : (
             "Aprovar landing para campanha"
           )}


### PR DESCRIPTION
### Motivation
- Users experienced needing to click the "Aprovar landing para campanha" button multiple times because publication to the Lead Portal can take a few seconds, allowing duplicate requests.
- Repeated calls risk duplicate external publishes and confusing UI state, so the frontend must enforce a single-command behavior while publication is pending or already published.
- Add a small UI guard and tests to prevent recurrence and record the investigation in experiment logs.

### Description
- Changed `frontend/src/pages/experiment/LandingTab.tsx` to extend `canAttemptLandingApproval` to accept `followUpActionUrl` and `hasLocalPublication`, compute `hasLocalPublication` from local `publishedUrls`, and block approval when an official `followUpActionUrl` exists or a local publication was just completed; the button is also disabled while the mutation is pending and the handler returns early if `canApproveLanding` is false.
- Updated the button label/disabled behavior so the user sees the published state and cannot trigger repeated requests while publication is in progress or already done.
- Added unit tests in `frontend/src/pages/experiment/LandingTab.test.ts` covering: attempt-when-no-URL, block-when-experiment-has-no-id, block-when-followUpActionUrl-present, and block-after-local-publication.
- Appended a short entry to `docs/registros/experimentos.md` documenting the investigation and the preventative change.

### Testing
- Called the backend endpoint `POST /api/experiments/41/geralanding/landing/approve-end-publish` and received `200 OK` with `iframeUrl` and `standaloneUrl` in the response, confirming the backend publication flow remained functional.
- Ran frontend unit tests with `vitest` (`npm run test -- LandingTab.test.ts --run`) and all tests passed (7/7).
- Ran TypeScript check with `tsc --noEmit` and it completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3b168dc9808321a864d76483126bcb)