### PR TITLE
Report GeraLanding readiness and count only approved creatives in experiment readiness

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/dto/ExperimentReadinessIssueType.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/dto/ExperimentReadinessIssueType.java
@@ -6,5 +6,6 @@ package com.marketinghub.experiment.dto;
 public enum ExperimentReadinessIssueType {
     CREATIVE,
     LEAD_PORTAL_FLOW,
-    TARGETING
+    TARGETING,
+    GERA_LANDING
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/dto/ExperimentReadinessSummaryDto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/dto/ExperimentReadinessSummaryDto.java
@@ -13,6 +13,9 @@ public record ExperimentReadinessSummaryDto(
         boolean hasLeadPortalFlow,
         long leadPortalFlowCount,
         boolean hasCompleteTargeting,
+        boolean hasGeraLandingPipeline,
+        long geraLandingCompletedStageCount,
+        long geraLandingRequiredStageCount,
         List<TargetingElementType> missingTargetingTypes,
         List<ExperimentReadinessIssueDto> issues
 ) { }

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentReadinessService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentReadinessService.java
@@ -2,6 +2,7 @@ package com.marketinghub.experiment.service;
 
 import com.marketinghub.creative.CreativeStatus;
 import com.marketinghub.repository.jpa.creative.CreativeRepository;
+import com.marketinghub.geralanding.GeraLandingStageExecution;
 import com.marketinghub.experiment.Experiment;
 import com.marketinghub.experiment.dto.ExperimentReadinessIssueDto;
 import com.marketinghub.experiment.dto.ExperimentReadinessIssueType;
@@ -9,6 +10,7 @@ import com.marketinghub.experiment.dto.ExperimentReadinessSummaryDto;
 import com.marketinghub.targeting.TargetingElementType;
 import com.marketinghub.targeting.TargetingCandidateType;
 import com.marketinghub.repository.jpa.experiment.ExperimentTargetingSelectionRepository;
+import com.marketinghub.repository.jpa.geralanding.GeraLandingStageExecutionRepository;
 import com.marketinghub.repository.jpa.targeting.TargetingElementRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -23,24 +25,40 @@ import java.util.List;
 public class ExperimentReadinessService {
     private final ExperimentService experimentService;
     private final CreativeRepository creativeRepository;
+    private static final String STATUS_COMPLETED = "CONCLUIDO";
+    private static final List<String> GERA_LANDING_REQUIRED_STAGES = List.of(
+            "landing-page-wireframe",
+            "landing-page-copy",
+            "landing-page-image-planning",
+            "landing-page-image-generation",
+            "landing-page-design-preset",
+            "landing-page-quality-review",
+            "landing-page-deliverables"
+    );
+
     private final ExperimentTargetingSelectionRepository targetingSelectionRepository;
     private final TargetingElementRepository targetingElementRepository;
+    private final GeraLandingStageExecutionRepository geraLandingStageExecutionRepository;
 
+    /** Cria o serviço com as fontes canônicas de prontidão do experimento. */
     public ExperimentReadinessService(ExperimentService experimentService,
                                       CreativeRepository creativeRepository,
                                       ExperimentTargetingSelectionRepository targetingSelectionRepository,
-                                      TargetingElementRepository targetingElementRepository) {
+                                      TargetingElementRepository targetingElementRepository,
+                                      GeraLandingStageExecutionRepository geraLandingStageExecutionRepository) {
         this.experimentService = experimentService;
         this.creativeRepository = creativeRepository;
         this.targetingSelectionRepository = targetingSelectionRepository;
         this.targetingElementRepository = targetingElementRepository;
+        this.geraLandingStageExecutionRepository = geraLandingStageExecutionRepository;
     }
 
+    /** Resume a prontidão do experimento usando apenas dados canônicos aprovados para publicação. */
     @Transactional(readOnly = true)
     public ExperimentReadinessSummaryDto summarize(Long experimentId) {
         Experiment experiment = experimentService.get(experimentId);
-        long creativeCount = creativeRepository.countByExperimentId(experimentId);
-        boolean hasCreatives = hasApprovedCreative(experiment);
+        long creativeCount = creativeRepository.countByExperimentIdAndStatus(experimentId, CreativeStatus.READY);
+        boolean hasCreatives = creativeCount > 0;
 
         long leadPortalFlowCount = hasReadyLeadPortalFlow(experiment) ? 1L : 0L;
         boolean hasLeadPortalFlow = leadPortalFlowCount > 0;
@@ -48,13 +66,15 @@ public class ExperimentReadinessService {
         List<String> missingConfiguration = computeMissingConfiguration(experiment);
         List<TargetingElementType> missingTypes = mapMissingTargetingTypes(missingConfiguration);
         boolean hasCompleteTargeting = missingTypes.isEmpty();
+        long geraLandingCompletedStageCount = countCompletedGeraLandingStages(experimentId);
+        boolean hasGeraLandingPipeline = geraLandingCompletedStageCount == GERA_LANDING_REQUIRED_STAGES.size();
 
         List<ExperimentReadinessIssueDto> issues = new ArrayList<>();
         if (!hasCreatives) {
             issues.add(new ExperimentReadinessIssueDto(
                     ExperimentReadinessIssueType.CREATIVE,
-                    "Nenhum criativo cadastrado",
-                    "Este experimento ainda não possui criativos aprovados ou em produção.",
+                    "Nenhum criativo aprovado",
+                    "Este experimento ainda não possui criativos aprovados para publicação.",
                     "Use a aba Criativos para gerar novas peças por IA ou cadastre um criativo manualmente.",
                     List.of()
             ));
@@ -78,21 +98,36 @@ public class ExperimentReadinessService {
             ));
         }
 
+        if (!hasGeraLandingPipeline) {
+            issues.add(new ExperimentReadinessIssueDto(
+                    ExperimentReadinessIssueType.GERA_LANDING,
+                    "GeraLanding incompleto",
+                    "O fluxo do GeraLanding ainda não concluiu todas as etapas obrigatórias.",
+                    "Abra a aba Gera landing, corrija etapas com falha e execute as pendentes até a finalização.",
+                    List.of()
+            ));
+        }
+
         return new ExperimentReadinessSummaryDto(
                 hasCreatives,
                 creativeCount,
                 hasLeadPortalFlow,
                 leadPortalFlowCount,
                 hasCompleteTargeting,
+                hasGeraLandingPipeline,
+                geraLandingCompletedStageCount,
+                GERA_LANDING_REQUIRED_STAGES.size(),
                 List.copyOf(missingTypes),
                 List.copyOf(issues)
         );
     }
 
+    /** Verifica se o experimento já pode entrar na fila de campanha paga. */
     public boolean isReadyForCampaign(Experiment experiment) {
         return computeMissingConfiguration(experiment).isEmpty();
     }
 
+    /** Lista as configurações faltantes que bloqueiam publicação de campanha. */
     public List<String> computeMissingConfiguration(Experiment experiment) {
         List<String> missing = new ArrayList<>();
         if (!hasApprovedCreative(experiment)) {
@@ -104,6 +139,18 @@ public class ExperimentReadinessService {
         return List.copyOf(missing);
     }
 
+    /** Conta as etapas obrigatórias do GeraLanding cuja execução mais recente foi concluída. */
+    private long countCompletedGeraLandingStages(Long experimentId) {
+        return GERA_LANDING_REQUIRED_STAGES.stream()
+                .filter(stageCode -> geraLandingStageExecutionRepository
+                        .findTopByExperimentIdAndStageCodeOrderByExecutionRequestedAtDesc(experimentId, stageCode)
+                        .map(GeraLandingStageExecution::getStatus)
+                        .map(STATUS_COMPLETED::equalsIgnoreCase)
+                        .orElse(false))
+                .count();
+    }
+
+    /** Converte pendências de configuração em tipos de segmentação faltantes. */
     private List<TargetingElementType> mapMissingTargetingTypes(List<String> missingConfiguration) {
         if (!missingConfiguration.contains("approvedTargetingPackage")) {
             return List.of();
@@ -114,6 +161,7 @@ public class ExperimentReadinessService {
     }
 
 
+    /** Verifica se o experimento possui alguma segmentação configurada. */
     private boolean hasConfiguredTargeting(Experiment experiment) {
         if (experiment == null) {
             return false;
@@ -124,6 +172,7 @@ public class ExperimentReadinessService {
         return hasSelectedTargeting(experiment.getId());
     }
 
+    /** Verifica se existe pacote de cargo aprovado para o nicho e hipótese do experimento. */
     private boolean hasApprovedTargetingPackage(Experiment experiment) {
         if (experiment.getNiche() == null || experiment.getNiche().getId() == null) {
             return false;
@@ -142,12 +191,14 @@ public class ExperimentReadinessService {
         return creativeRepository.existsByExperimentIdAndStatus(experiment.getId(), CreativeStatus.READY);
     }
 
+    /** Verifica se existe fluxo aprovado do portal do lead vinculado ao experimento. */
     private boolean hasReadyLeadPortalFlow(Experiment experiment) {
         return experiment != null
                 && experiment.getLeadPortalFlow() != null
                 && experiment.getLeadPortalFlow().isApproved();
     }
 
+    /** Verifica se o usuário selecionou cargo para segmentação do experimento. */
     private boolean hasSelectedTargeting(Long experimentId) {
         if (experimentId == null) {
             return false;
@@ -156,6 +207,7 @@ public class ExperimentReadinessService {
                 experimentId, TargetingCandidateType.WORK_POSITION) > 0;
     }
 
+    /** Verifica se o experimento possui URL de destino aprovada para campanha. */
     private boolean hasApprovedLandingDestination(Experiment experiment) {
         return experiment != null
                 && experiment.getFollowUpActionUrl() != null

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/creative/CreativeRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/creative/CreativeRepository.java
@@ -13,12 +13,19 @@ import java.util.Optional;
  * Repository for creatives.
  */
 public interface CreativeRepository extends JpaRepository<Creative, Long> {
+    /** Lista os criativos vinculados ao experimento informado. */
     List<Creative> findByExperimentId(Long experimentId);
 
+    /** Verifica se existe criativo do experimento no status informado. */
     boolean existsByExperimentIdAndStatus(Long experimentId, CreativeStatus status);
 
+    /** Busca um criativo carregando também o experimento vinculado. */
     @Query("select c from Creative c join fetch c.experiment where c.id = :id")
     Optional<Creative> findByIdWithExperiment(@Param("id") Long id);
 
+    /** Conta todos os criativos vinculados ao experimento informado. */
     long countByExperimentId(Long experimentId);
+
+    /** Conta os criativos do experimento que estão no status informado. */
+    long countByExperimentIdAndStatus(Long experimentId, CreativeStatus status);
 }

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/service/ExperimentReadinessServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/service/ExperimentReadinessServiceTest.java
@@ -6,6 +6,7 @@ import com.marketinghub.experiment.Experiment;
 import com.marketinghub.experiment.dto.ExperimentReadinessIssueDto;
 import com.marketinghub.experiment.dto.ExperimentReadinessIssueType;
 import com.marketinghub.experiment.dto.ExperimentReadinessSummaryDto;
+import com.marketinghub.geralanding.GeraLandingStageExecution;
 import com.marketinghub.hypothesis.Hypothesis;
 import com.marketinghub.leadportal.LeadPortalFlow;
 import com.marketinghub.niche.MarketNiche;
@@ -13,6 +14,7 @@ import com.marketinghub.targeting.TargetingCandidateType;
 import com.marketinghub.targeting.TargetingElement;
 import com.marketinghub.targeting.TargetingElementType;
 import com.marketinghub.repository.jpa.experiment.ExperimentTargetingSelectionRepository;
+import com.marketinghub.repository.jpa.geralanding.GeraLandingStageExecutionRepository;
 import com.marketinghub.repository.jpa.targeting.TargetingElementRepository;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -21,6 +23,7 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -37,6 +40,8 @@ class ExperimentReadinessServiceTest {
     private ExperimentTargetingSelectionRepository targetingSelectionRepository;
     @Mock
     private TargetingElementRepository targetingElementRepository;
+    @Mock
+    private GeraLandingStageExecutionRepository geraLandingStageExecutionRepository;
 
     @InjectMocks
     private ExperimentReadinessService service;
@@ -47,19 +52,21 @@ class ExperimentReadinessServiceTest {
         Experiment experiment = buildExperiment(experimentId, 16L);
 
         when(experimentService.get(experimentId)).thenReturn(experiment);
-        when(creativeRepository.countByExperimentId(experimentId)).thenReturn(0L);
-        when(creativeRepository.existsByExperimentIdAndStatus(experimentId, CreativeStatus.READY)).thenReturn(false);
+        when(creativeRepository.countByExperimentIdAndStatus(experimentId, CreativeStatus.READY)).thenReturn(0L);
         ExperimentReadinessSummaryDto summary = service.summarize(experimentId);
 
         assertThat(summary.hasCreatives()).isFalse();
         assertThat(summary.hasLeadPortalFlow()).isFalse();
         assertThat(summary.hasCompleteTargeting()).isTrue();
+        assertThat(summary.hasGeraLandingPipeline()).isFalse();
+        assertThat(summary.geraLandingCompletedStageCount()).isZero();
         assertThat(summary.missingTargetingTypes()).isEmpty();
-        assertThat(summary.issues()).hasSize(2);
+        assertThat(summary.issues()).hasSize(3);
         assertThat(summary.issues()).extracting(ExperimentReadinessIssueDto::type)
                 .containsExactlyInAnyOrder(
                         ExperimentReadinessIssueType.CREATIVE,
-                        ExperimentReadinessIssueType.LEAD_PORTAL_FLOW
+                        ExperimentReadinessIssueType.LEAD_PORTAL_FLOW,
+                        ExperimentReadinessIssueType.GERA_LANDING
                 );
     }
 
@@ -73,13 +80,15 @@ class ExperimentReadinessServiceTest {
         experiment.setLeadPortalFlow(flow);
 
         when(experimentService.get(experimentId)).thenReturn(experiment);
-        when(creativeRepository.countByExperimentId(experimentId)).thenReturn(2L);
-        when(creativeRepository.existsByExperimentIdAndStatus(experimentId, CreativeStatus.READY)).thenReturn(true);
+        when(creativeRepository.countByExperimentIdAndStatus(experimentId, CreativeStatus.READY)).thenReturn(2L);
+        mockCompletedGeraLandingStages(experimentId);
         ExperimentReadinessSummaryDto summary = service.summarize(experimentId);
 
         assertThat(summary.hasCreatives()).isTrue();
         assertThat(summary.hasLeadPortalFlow()).isTrue();
         assertThat(summary.hasCompleteTargeting()).isTrue();
+        assertThat(summary.hasGeraLandingPipeline()).isTrue();
+        assertThat(summary.geraLandingCompletedStageCount()).isEqualTo(summary.geraLandingRequiredStageCount());
         assertThat(summary.missingTargetingTypes()).isEmpty();
         assertThat(summary.issues()).isEmpty();
     }
@@ -106,8 +115,7 @@ class ExperimentReadinessServiceTest {
         experiment.setLeadPortalFlow(flow);
 
         when(experimentService.get(experimentId)).thenReturn(experiment);
-        when(creativeRepository.countByExperimentId(experimentId)).thenReturn(1L);
-        when(creativeRepository.existsByExperimentIdAndStatus(experimentId, CreativeStatus.READY)).thenReturn(true);
+        when(creativeRepository.countByExperimentIdAndStatus(experimentId, CreativeStatus.READY)).thenReturn(1L);
         ExperimentReadinessSummaryDto summary = service.summarize(experimentId);
 
         assertThat(summary.hasCompleteTargeting()).isTrue();
@@ -125,14 +133,38 @@ class ExperimentReadinessServiceTest {
         experiment.setLeadPortalFlow(flow);
 
         when(experimentService.get(experimentId)).thenReturn(experiment);
-        when(creativeRepository.countByExperimentId(experimentId)).thenReturn(1L);
-        when(creativeRepository.existsByExperimentIdAndStatus(experimentId, CreativeStatus.READY)).thenReturn(true);
+        when(creativeRepository.countByExperimentIdAndStatus(experimentId, CreativeStatus.READY)).thenReturn(1L);
         ExperimentReadinessSummaryDto summary = service.summarize(experimentId);
 
         assertThat(summary.hasCompleteTargeting()).isTrue();
         assertThat(summary.missingTargetingTypes()).isEmpty();
         assertThat(summary.issues()).extracting(ExperimentReadinessIssueDto::type)
                 .doesNotContain(ExperimentReadinessIssueType.TARGETING);
+    }
+
+    @Test
+    void shouldKeepGeraLandingPendingWhenLatestRequiredStageFailed() {
+        Long experimentId = 48L;
+        Experiment experiment = buildExperiment(experimentId, 22L);
+        LeadPortalFlow flow = new LeadPortalFlow();
+        flow.setApproved(true);
+        experiment.setLeadPortalFlow(flow);
+
+        when(experimentService.get(experimentId)).thenReturn(experiment);
+        when(creativeRepository.countByExperimentIdAndStatus(experimentId, CreativeStatus.READY)).thenReturn(1L);
+        when(geraLandingStageExecutionRepository.findTopByExperimentIdAndStageCodeOrderByExecutionRequestedAtDesc(
+                experimentId, "landing-page-wireframe"))
+                .thenReturn(Optional.of(geraLandingExecution("landing-page-wireframe", "CONCLUIDO")));
+        when(geraLandingStageExecutionRepository.findTopByExperimentIdAndStageCodeOrderByExecutionRequestedAtDesc(
+                experimentId, "landing-page-copy"))
+                .thenReturn(Optional.of(geraLandingExecution("landing-page-copy", "FALHA")));
+
+        ExperimentReadinessSummaryDto summary = service.summarize(experimentId);
+
+        assertThat(summary.hasGeraLandingPipeline()).isFalse();
+        assertThat(summary.geraLandingCompletedStageCount()).isEqualTo(1);
+        assertThat(summary.issues()).extracting(ExperimentReadinessIssueDto::type)
+                .contains(ExperimentReadinessIssueType.GERA_LANDING);
     }
 
     @Test
@@ -158,7 +190,30 @@ class ExperimentReadinessServiceTest {
     }
 
 
+    /** Simula todas as etapas obrigatórias do GeraLanding como concluídas. */
+    private void mockCompletedGeraLandingStages(Long experimentId) {
+        List.of(
+                "landing-page-wireframe",
+                "landing-page-copy",
+                "landing-page-image-planning",
+                "landing-page-image-generation",
+                "landing-page-design-preset",
+                "landing-page-quality-review",
+                "landing-page-deliverables"
+        ).forEach(stageCode -> when(geraLandingStageExecutionRepository
+                .findTopByExperimentIdAndStageCodeOrderByExecutionRequestedAtDesc(experimentId, stageCode))
+                .thenReturn(Optional.of(geraLandingExecution(stageCode, "CONCLUIDO"))));
+    }
 
+    /** Cria uma execução de etapa do GeraLanding para testes de prontidão. */
+    private GeraLandingStageExecution geraLandingExecution(String stageCode, String status) {
+        return GeraLandingStageExecution.builder()
+                .stageCode(stageCode)
+                .status(status)
+                .build();
+    }
+
+    /** Cria um experimento base para os testes de prontidão. */
     private Experiment buildExperiment(Long experimentId, Long nicheId) {
         MarketNiche niche = new MarketNiche();
         niche.setId(nicheId);

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -1,3 +1,17 @@
+## 2026-06-24 — Experimentos: card do GeraLanding usa finalização real
+
+- foi feito: o checklist principal do experimento passou a usar o resumo de prontidão do backend para o card `Pipeline GeraLanding`, contando somente etapas obrigatórias cuja execução mais recente está `CONCLUIDO`.
+- causa-raiz: a tela marcava o card como concluído por presença de qualquer conteúdo parcial do GeraLanding, como wireframe, mesmo quando uma etapa posterior falhava.
+- validação operacional: no experimento 48, consulta via MCP confirmou `landing-page-wireframe=CONCLUIDO` e `landing-page-copy=FALHA`; com o ajuste, a tela deve mostrar `1/7 etapas concluídas` e manter o card pendente.
+- prevenção de recorrência: teste unitário cobre o caso em que a etapa mais recente obrigatória falha e impede o sinal verde.
+
+## 2026-06-24 — Experimentos: card de criativos usa apenas aprovados
+
+- foi feito: a prontidão do experimento passou a contar somente criativos com status `READY` no endpoint `/api/experiments/{id}/readiness`.
+- causa-raiz: o resumo de prontidão já validava aprovação por `READY`, mas o contador exibido na tela somava todos os criativos do experimento, incluindo rascunhos (`DRAFT`), permitindo marcar o card como feito mesmo sem criativo aprovado.
+- validação operacional: no experimento 47, consulta via MCP confirmou 3 criativos `DRAFT` e 0 `READY`; com o ajuste, a tela deve mostrar `0/3 criativos aprovados` e manter o card pendente.
+- prevenção de recorrência: teste unitário do backend foi mantido/ajustado para usar a contagem canônica de criativos `READY`.
+
 ## 2026-06-23 — Hipóteses: histórico do nicho no prompt
 
 - decisão aplicada: toda nova solicitação de hipótese passa a carregar o resumo das hipóteses já existentes do mesmo nicho no contrato pendente para o Worker AI.

--- a/frontend/src/api/experiment/useExperimentReadiness.ts
+++ b/frontend/src/api/experiment/useExperimentReadiness.ts
@@ -5,7 +5,8 @@ import type { TargetingElementType } from "../targeting/types";
 export type ExperimentReadinessIssueType =
   | "CREATIVE"
   | "LEAD_PORTAL_FLOW"
-  | "TARGETING";
+  | "TARGETING"
+  | "GERA_LANDING";
 
 export interface ExperimentReadinessIssue {
   type: ExperimentReadinessIssueType;
@@ -21,6 +22,9 @@ export interface ExperimentReadinessSummary {
   hasLeadPortalFlow: boolean;
   leadPortalFlowCount: number;
   hasCompleteTargeting: boolean;
+  hasGeraLandingPipeline: boolean;
+  geraLandingCompletedStageCount: number;
+  geraLandingRequiredStageCount: number;
   missingTargetingTypes: TargetingElementType[];
   issues: ExperimentReadinessIssue[];
 }

--- a/frontend/src/pages/experiment/ExperimentDetailPage.tsx
+++ b/frontend/src/pages/experiment/ExperimentDetailPage.tsx
@@ -1956,15 +1956,12 @@ export default function ExperimentDetailPage() {
     data.creativeTextPrompt ||
     data.creativeImagePrompt,
   );
-  const hasGeraLandingPipelineContent = Boolean(
-    data.landingPageWireframe ||
-    data.landingPageCopy ||
-    data.landingPageImagePlanning ||
-    data.landingPageDesignPreset ||
-    data.landingPageDeliverables ||
-    data.landingPageHtml ||
-    data.htmlGeraLanding,
-  );
+  const hasGeraLandingPipelineReady =
+    readinessSummary?.hasGeraLandingPipeline ?? false;
+  const geraLandingCompletedStageCount =
+    readinessSummary?.geraLandingCompletedStageCount ?? 0;
+  const geraLandingRequiredStageCount =
+    readinessSummary?.geraLandingRequiredStageCount ?? 7;
   const hasAtLeastThreeApprovedCreatives = readinessCreativeCount >= 3;
   const hasAudienceSelection = readinessSummary?.hasCompleteTargeting ?? false;
   const mainExperimentChecklist = [
@@ -1980,9 +1977,10 @@ export default function ExperimentDetailPage() {
     {
       id: "geralanding-pipeline",
       title: "Pipeline GeraLanding",
-      detail: "Aba Gera landing",
-      isMet: hasGeraLandingPipelineContent,
+      detail: `${geraLandingCompletedStageCount}/${geraLandingRequiredStageCount} etapas concluídas`,
+      isMet: hasGeraLandingPipelineReady,
       isLoading:
+        isLoadingReadiness ||
         isLoadingPendingGeraLandingExecutions ||
         isLoadingCompletedGeraLandingExecutions ||
         isLoadingPendingGeraLandingCopyExecutions ||


### PR DESCRIPTION
### Motivation

- Add canonical readiness for the GeraLanding pipeline so the experiment card is only marked complete when all required stages have a most-recent execution with status `CONCLUIDO`.
- Ensure the creatives counter used in the readiness summary considers only approved creatives (`READY`) so checklist state can't be satisfied by drafts.

### Description

- Added `GERA_LANDING` to `ExperimentReadinessIssueType` and extended `ExperimentReadinessSummaryDto` with `hasGeraLandingPipeline`, `geraLandingCompletedStageCount`, and `geraLandingRequiredStageCount` fields.
- Updated `ExperimentReadinessService` to: count creatives by status `READY` (`countByExperimentIdAndStatus`), define required GeraLanding stage codes, evaluate the most recent execution of each required stage via `GeraLandingStageExecutionRepository`, and add a readiness issue when the GeraLanding pipeline is incomplete; also clarified several helper methods to use canonical data sources and adjusted messages.
- Extended `CreativeRepository` with `countByExperimentIdAndStatus` and added javadoc to several methods used by readiness logic.
- Updated frontend types and `ExperimentDetailPage` to consume the new readiness fields, show a `completed/required` stage detail string, and mark the GeraLanding checklist item only when the backend signals readiness.
- Added documentation entry describing the change to experiment readiness behavior in `docs/registros/experimentos.md`.
- Tests: updated and added unit tests in `ExperimentReadinessServiceTest` to cover GeraLanding completed and failed stage scenarios and to align mocks with the new creative counting behavior.

### Testing

- Ran the updated backend unit test `ExperimentReadinessServiceTest`, which exercises the new GeraLanding counting and creative-status behavior, and all assertions passed.
- Updated unit tests verify that an incomplete/latest-failed GeraLanding stage keeps the pipeline pending and that counting only `READY` creatives affects readiness as expected.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3b218558988321bd1afcb78a2f1d67)