### PR TITLE
Corrige prontidão de público: exigir seleção salva para marcar público como pronto

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentReadinessService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentReadinessService.java
@@ -11,7 +11,6 @@ import com.marketinghub.targeting.TargetingElementType;
 import com.marketinghub.targeting.TargetingCandidateType;
 import com.marketinghub.repository.jpa.experiment.ExperimentTargetingSelectionRepository;
 import com.marketinghub.repository.jpa.geralanding.GeraLandingStageExecutionRepository;
-import com.marketinghub.repository.jpa.targeting.TargetingElementRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -37,19 +36,16 @@ public class ExperimentReadinessService {
     );
 
     private final ExperimentTargetingSelectionRepository targetingSelectionRepository;
-    private final TargetingElementRepository targetingElementRepository;
     private final GeraLandingStageExecutionRepository geraLandingStageExecutionRepository;
 
     /** Cria o serviço com as fontes canônicas de prontidão do experimento. */
     public ExperimentReadinessService(ExperimentService experimentService,
                                       CreativeRepository creativeRepository,
                                       ExperimentTargetingSelectionRepository targetingSelectionRepository,
-                                      TargetingElementRepository targetingElementRepository,
                                       GeraLandingStageExecutionRepository geraLandingStageExecutionRepository) {
         this.experimentService = experimentService;
         this.creativeRepository = creativeRepository;
         this.targetingSelectionRepository = targetingSelectionRepository;
-        this.targetingElementRepository = targetingElementRepository;
         this.geraLandingStageExecutionRepository = geraLandingStageExecutionRepository;
     }
 
@@ -63,9 +59,10 @@ public class ExperimentReadinessService {
         long leadPortalFlowCount = hasReadyLeadPortalFlow(experiment) ? 1L : 0L;
         boolean hasLeadPortalFlow = leadPortalFlowCount > 0;
 
-        List<String> missingConfiguration = computeMissingConfiguration(experiment);
-        List<TargetingElementType> missingTypes = mapMissingTargetingTypes(missingConfiguration);
-        boolean hasCompleteTargeting = missingTypes.isEmpty();
+        boolean hasCompleteTargeting = hasConfiguredTargeting(experiment);
+        List<TargetingElementType> missingTypes = hasCompleteTargeting
+                ? List.of()
+                : List.of(TargetingElementType.JOB_TITLE);
         long geraLandingCompletedStageCount = countCompletedGeraLandingStages(experimentId);
         boolean hasGeraLandingPipeline = geraLandingCompletedStageCount == GERA_LANDING_REQUIRED_STAGES.size();
 
@@ -136,6 +133,9 @@ public class ExperimentReadinessService {
         if (!hasApprovedLandingDestination(experiment)) {
             missing.add("landingDestination");
         }
+        if (!hasConfiguredTargeting(experiment)) {
+            missing.add("approvedTargetingPackage");
+        }
         return List.copyOf(missing);
     }
 
@@ -150,37 +150,12 @@ public class ExperimentReadinessService {
                 .count();
     }
 
-    /** Converte pendências de configuração em tipos de segmentação faltantes. */
-    private List<TargetingElementType> mapMissingTargetingTypes(List<String> missingConfiguration) {
-        if (!missingConfiguration.contains("approvedTargetingPackage")) {
-            return List.of();
-        }
-        return List.of(
-                TargetingElementType.JOB_TITLE
-        );
-    }
-
-
-    /** Verifica se o experimento possui alguma segmentação configurada. */
+    /** Verifica se o experimento possui segmentação escolhida e salva pelo usuário. */
     private boolean hasConfiguredTargeting(Experiment experiment) {
         if (experiment == null) {
             return false;
         }
-        if (hasApprovedTargetingPackage(experiment)) {
-            return true;
-        }
         return hasSelectedTargeting(experiment.getId());
-    }
-
-    /** Verifica se existe pacote de cargo aprovado para o nicho e hipótese do experimento. */
-    private boolean hasApprovedTargetingPackage(Experiment experiment) {
-        if (experiment.getNiche() == null || experiment.getNiche().getId() == null) {
-            return false;
-        }
-        return !targetingElementRepository.findApprovedForExperiment(
-                experiment.getNiche().getId(),
-                TargetingElementType.JOB_TITLE,
-                experiment.getHypothesisRef() != null ? experiment.getHypothesisRef().getId() : null).isEmpty();
     }
 
     /** Verifica a aprovação real dos criativos pela fonte canônica: registros READY. */

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/service/ExperimentReadinessServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/service/ExperimentReadinessServiceTest.java
@@ -11,11 +11,9 @@ import com.marketinghub.hypothesis.Hypothesis;
 import com.marketinghub.leadportal.LeadPortalFlow;
 import com.marketinghub.niche.MarketNiche;
 import com.marketinghub.targeting.TargetingCandidateType;
-import com.marketinghub.targeting.TargetingElement;
 import com.marketinghub.targeting.TargetingElementType;
 import com.marketinghub.repository.jpa.experiment.ExperimentTargetingSelectionRepository;
 import com.marketinghub.repository.jpa.geralanding.GeraLandingStageExecutionRepository;
-import com.marketinghub.repository.jpa.targeting.TargetingElementRepository;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
@@ -39,8 +37,6 @@ class ExperimentReadinessServiceTest {
     @Mock
     private ExperimentTargetingSelectionRepository targetingSelectionRepository;
     @Mock
-    private TargetingElementRepository targetingElementRepository;
-    @Mock
     private GeraLandingStageExecutionRepository geraLandingStageExecutionRepository;
 
     @InjectMocks
@@ -57,15 +53,16 @@ class ExperimentReadinessServiceTest {
 
         assertThat(summary.hasCreatives()).isFalse();
         assertThat(summary.hasLeadPortalFlow()).isFalse();
-        assertThat(summary.hasCompleteTargeting()).isTrue();
+        assertThat(summary.hasCompleteTargeting()).isFalse();
         assertThat(summary.hasGeraLandingPipeline()).isFalse();
         assertThat(summary.geraLandingCompletedStageCount()).isZero();
-        assertThat(summary.missingTargetingTypes()).isEmpty();
-        assertThat(summary.issues()).hasSize(3);
+        assertThat(summary.missingTargetingTypes()).containsExactly(TargetingElementType.JOB_TITLE);
+        assertThat(summary.issues()).hasSize(4);
         assertThat(summary.issues()).extracting(ExperimentReadinessIssueDto::type)
                 .containsExactlyInAnyOrder(
                         ExperimentReadinessIssueType.CREATIVE,
                         ExperimentReadinessIssueType.LEAD_PORTAL_FLOW,
+                        ExperimentReadinessIssueType.TARGETING,
                         ExperimentReadinessIssueType.GERA_LANDING
                 );
     }
@@ -81,6 +78,8 @@ class ExperimentReadinessServiceTest {
 
         when(experimentService.get(experimentId)).thenReturn(experiment);
         when(creativeRepository.countByExperimentIdAndStatus(experimentId, CreativeStatus.READY)).thenReturn(2L);
+        when(targetingSelectionRepository.countByExperimentIdAndCandidateType(
+                experimentId, TargetingCandidateType.WORK_POSITION)).thenReturn(1L);
         mockCompletedGeraLandingStages(experimentId);
         ExperimentReadinessSummaryDto summary = service.summarize(experimentId);
 
@@ -101,13 +100,15 @@ class ExperimentReadinessServiceTest {
         experiment.setFollowUpActionUrl("https://example.com/landing/22");
 
         when(creativeRepository.existsByExperimentIdAndStatus(experimentId, CreativeStatus.READY)).thenReturn(true);
+        when(targetingSelectionRepository.countByExperimentIdAndCandidateType(
+                experimentId, TargetingCandidateType.WORK_POSITION)).thenReturn(1L);
 
         assertThat(service.computeMissingConfiguration(experiment)).isEmpty();
         assertThat(service.isReadyForCampaign(experiment)).isTrue();
     }
 
     @Test
-    void shouldNotReportTargetingIssueWhenThereIsNoApprovedJobTitleSelection() {
+    void shouldReportTargetingIssueWhenThereIsNoSavedJobTitleSelection() {
         Long experimentId = 11L;
         Experiment experiment = buildExperiment(experimentId, 19L);
         LeadPortalFlow flow = new LeadPortalFlow();
@@ -118,14 +119,14 @@ class ExperimentReadinessServiceTest {
         when(creativeRepository.countByExperimentIdAndStatus(experimentId, CreativeStatus.READY)).thenReturn(1L);
         ExperimentReadinessSummaryDto summary = service.summarize(experimentId);
 
-        assertThat(summary.hasCompleteTargeting()).isTrue();
-        assertThat(summary.missingTargetingTypes()).isEmpty();
+        assertThat(summary.hasCompleteTargeting()).isFalse();
+        assertThat(summary.missingTargetingTypes()).containsExactly(TargetingElementType.JOB_TITLE);
         assertThat(summary.issues()).extracting(ExperimentReadinessIssueDto::type)
-                .doesNotContain(ExperimentReadinessIssueType.TARGETING);
+                .contains(ExperimentReadinessIssueType.TARGETING);
     }
 
     @Test
-    void shouldTreatApprovedTargetingPackageAsReadyEvenWithoutSelection() {
+    void shouldTreatSavedJobTitleSelectionAsReady() {
         Long experimentId = 15L;
         Experiment experiment = buildExperiment(experimentId, 21L);
         LeadPortalFlow flow = new LeadPortalFlow();
@@ -134,6 +135,8 @@ class ExperimentReadinessServiceTest {
 
         when(experimentService.get(experimentId)).thenReturn(experiment);
         when(creativeRepository.countByExperimentIdAndStatus(experimentId, CreativeStatus.READY)).thenReturn(1L);
+        when(targetingSelectionRepository.countByExperimentIdAndCandidateType(
+                experimentId, TargetingCandidateType.WORK_POSITION)).thenReturn(1L);
         ExperimentReadinessSummaryDto summary = service.summarize(experimentId);
 
         assertThat(summary.hasCompleteTargeting()).isTrue();
@@ -173,6 +176,8 @@ class ExperimentReadinessServiceTest {
         experiment.setFollowUpActionUrl(null);
 
         when(creativeRepository.existsByExperimentIdAndStatus(20L, CreativeStatus.READY)).thenReturn(true);
+        when(targetingSelectionRepository.countByExperimentIdAndCandidateType(
+                20L, TargetingCandidateType.WORK_POSITION)).thenReturn(1L);
 
         assertThat(service.computeMissingConfiguration(experiment))
                 .containsExactly("landingDestination");
@@ -184,6 +189,8 @@ class ExperimentReadinessServiceTest {
         experiment.setFollowUpActionUrl("https://example.com/landing/21");
 
         when(creativeRepository.existsByExperimentIdAndStatus(21L, CreativeStatus.READY)).thenReturn(true);
+        when(targetingSelectionRepository.countByExperimentIdAndCandidateType(
+                21L, TargetingCandidateType.WORK_POSITION)).thenReturn(1L);
 
         assertThat(service.computeMissingConfiguration(experiment)).isEmpty();
         assertThat(service.isReadyForCampaign(experiment)).isTrue();

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -5187,3 +5187,9 @@
 - correção aplicada: a atualização de criativo passou a ter timeout de 30 segundos, o botão de aprovação passou a exibir estado explícito “Aprovando...” com spinner pequeno e a tela limpa o processamento ao receber erro, mantendo mensagem objetiva para nova tentativa.
 - ajuste operacional: o proxy local do Vite foi alinhado para usar o backend na porta 80, evitando dependência da porta 8000 quando ela estiver indisponível atrás do proxy.
 - validação: adicionada cobertura de frontend garantindo que falha na aprovação remove o loading e reabilita o botão.
+
+## 2026-06-24 — Prontidão de público exige seleção salva
+- Problema: o checklist do experimento podia marcar “Escolha de público” como pronto mesmo sem nenhum público selecionado na aba Público.
+- Causa-raiz: o resumo de prontidão calculava público a partir de pendências genéricas de campanha, que não verificavam a seleção salva de targeting do experimento.
+- Correção aplicada: a prontidão de público passou a depender de uma seleção salva de cargo/posição de trabalho para o experimento, e a falta dessa seleção volta a gerar pendência de targeting.
+- Prevenção de recorrência: os testes de prontidão foram ajustados para falhar quando um experimento sem seleção salva aparecer como pronto para público.


### PR DESCRIPTION
### Motivation
- Corrigir bug em que o card “Escolha de público” aparecia como concluído/verde mesmo quando não havia nenhum público salvo para o experimento.
- Garantir que a checagem de prontidão do experimento reflita estritamente dados persistidos (seleção salva) e não inferências indiretas. 

### Description
- Altera `ExperimentReadinessService.summarize` para calcular `hasCompleteTargeting` usando `hasConfiguredTargeting(experiment)`, que agora depende exclusivamente de seleção salva (`hasSelectedTargeting`) em vez de bases aprovadas externas. (`backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentReadinessService.java`)
- Atualiza `computeMissingConfiguration` para incluir a pendência `approvedTargetingPackage` quando não houver seleção salva, fazendo a checagem de liberação de campanha bloquear corretamente experimentos sem público. (`ExperimentReadinessService.java`)
- Remove a dependência e o uso de `TargetingElementRepository` e simplifica a lógica de mapeamento de tipos faltantes para reportar `TargetingElementType.JOB_TITLE` quando aplicável. (`ExperimentReadinessService.java`)
- Ajusta testes em `ExperimentReadinessServiceTest` para refletir a nova regra: atualiza expectativas, remove mocks não usados e adiciona interações simuladas com `ExperimentTargetingSelectionRepository` para representar seleção salva. (`backend/ads-service/src/test/java/com/marketinghub/experiment/service/ExperimentReadinessServiceTest.java`)
- Registra a correção em `docs/registros/experimentos.md` com breve nota operacional sobre a mudança. (`docs/registros/experimentos.md`)

### Testing
- Executado `mvn test -Dtest=ExperimentReadinessServiceTest` no módulo `backend/ads-service`, os testes do caso `ExperimentReadinessServiceTest` passaram: `Tests run: 8, Failures: 0, Errors: 0`.
- Não foram introduzidos novos testes de integração; alteração coberta pelos testes unitários ajustados mencionados acima.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3b2a38674483218ccc75dc062a15f0)