### PR TITLE
Hide empty niche sections and refine Niche detail UI

### DIFF
--- a/frontend/src/pages/niche/NicheBacklogRecommendationsCard.tsx
+++ b/frontend/src/pages/niche/NicheBacklogRecommendationsCard.tsx
@@ -15,13 +15,18 @@ const stageLabels: Record<ExperimentStage, string> = {
 export function NicheBacklogRecommendationsCard({ nicheId }: Props) {
   const { data, isLoading, error } = useNicheBacklogRecommendations(nicheId);
 
+  if (!isLoading && !error && (data ?? []).length === 0) {
+    return null;
+  }
+
   return (
     <section className="niche-section" aria-label="Recomendações de backlog">
       <div className="niche-section__header">
         <div>
           <h2 className="niche-section__title">Recomendações para o backlog</h2>
           <p className="niche-section__subtitle">
-            Sugestões priorizadas automaticamente a partir das leituras mais recentes dos experimentos do nicho.
+            Sugestões priorizadas automaticamente a partir das leituras mais
+            recentes dos experimentos do nicho.
           </p>
         </div>
       </div>
@@ -33,12 +38,16 @@ export function NicheBacklogRecommendationsCard({ nicheId }: Props) {
         <div className="text-muted">Carregando recomendações...</div>
       ) : (data ?? []).length === 0 ? (
         <div className="text-muted">
-          Ainda não há recomendações. Gere aprendizados a partir de um experimento para popular esta lista.
+          Ainda não há recomendações. Gere aprendizados a partir de um
+          experimento para popular esta lista.
         </div>
       ) : (
         <div className="d-flex flex-column gap-3">
           {(data ?? []).map((item, index) => (
-            <div key={`${item.title}-${index}`} className="border rounded-3 p-3">
+            <div
+              key={`${item.title}-${index}`}
+              className="border rounded-3 p-3"
+            >
               <div className="d-flex flex-wrap gap-2 align-items-center mb-1">
                 <strong>{item.title}</strong>
                 {item.stage ? (

--- a/frontend/src/pages/niche/NicheDetailPage.tsx
+++ b/frontend/src/pages/niche/NicheDetailPage.tsx
@@ -185,6 +185,12 @@ const formatDateTime = (value?: string | null) => {
   });
 };
 
+function hasDisplayValue(value: unknown) {
+  if (value === null || value === undefined) return false;
+  if (typeof value === "string") return value.trim() !== "";
+  return true;
+}
+
 export default function NicheDetailPage() {
   const { nicheId } = useParams();
   const id = Number(nicheId);
@@ -203,6 +209,9 @@ export default function NicheDetailPage() {
     ? formatDateTime(data.facebookPixelRequestedAt)
     : null;
   const isFacebookPixelPending = data?.facebookPixelRequestStatus === "PENDING";
+  const shouldShowFacebookPixelSection = Boolean(
+    facebookPixelId || facebookPixelCode || facebookPixelRequestedAtLabel,
+  );
   const { data: chatDialog } = useChatDialog(data?.chatDialogId);
   const { data: hypotheses } = useHypothesesByNiche(nicheId, "ALL");
   const { data: targetingElements, isFetching: isFetchingTargeting } =
@@ -619,6 +628,35 @@ export default function NicheDetailPage() {
       ) : undefined,
     },
   ];
+  const alwaysHiddenInfoLabels = new Set([
+    "Hipóteses a gerar",
+    "Modelo para hipóteses",
+    "Modelo para interesses",
+    "Modelo para cargos",
+    "Modelo para comportamentos",
+    "Modelo para descrições",
+    "Descrições a gerar",
+    "Interesses a gerar",
+    "Cargos a gerar",
+    "Comportamentos a gerar",
+    "Chat Dialog",
+  ]);
+  const hiddenWhenEmptyInfoLabels = new Set([
+    "Volume de demanda",
+    "Promessas",
+    "Ofertas",
+    "Segmentação base",
+    "Interesses",
+    "Filtros demográficos",
+    "Dicas extras",
+  ]);
+  const visibleInfoCards = infoCards.filter((card) => {
+    if (alwaysHiddenInfoLabels.has(card.label)) return false;
+    if (hiddenWhenEmptyInfoLabels.has(card.label)) {
+      return hasDisplayValue(card.value);
+    }
+    return true;
+  });
   const stats = [
     {
       icon: Target,
@@ -681,6 +719,15 @@ export default function NicheDetailPage() {
       helper: createdAtLabel ? `Criado em ${createdAtLabel}` : undefined,
     },
   ];
+  const shouldShowInformationSourcesSection = false;
+  const shouldShowManualDeliverablesSection = false;
+  const shouldShowSimpleLeadPortalFormsSection = false;
+  const visibleStats = stats.filter((stat) => {
+    if (stat.label === "Pixel do Facebook")
+      return shouldShowFacebookPixelSection;
+    if (stat.label === "Entregáveis") return false;
+    return true;
+  });
   const hypothesisStatusLabel =
     requestHypotheses.isPending || (isFetching && !isLoading)
       ? "Atualizando hipóteses..."
@@ -994,7 +1041,7 @@ export default function NicheDetailPage() {
         </div>
       </div>
       <ul className="niche-detail__stats">
-        {stats.map((stat) => {
+        {visibleStats.map((stat) => {
           const isInteractive = Boolean(stat.targetId);
           const targetId = stat.targetId;
           const className = `niche-detail__stat${
@@ -1040,7 +1087,7 @@ export default function NicheDetailPage() {
       </ul>
       <section aria-label="Informações do nicho">
         <div className="niche-detail__grid">
-          {infoCards.map((card) => (
+          {visibleInfoCards.map((card) => (
             <article key={card.label} className="niche-detail__card">
               <h3 className="niche-detail__card-title">{card.label}</h3>
               <div className="niche-detail__card-content">
@@ -1059,89 +1106,92 @@ export default function NicheDetailPage() {
           ))}
         </div>
       </section>
-      <section
-        className="niche-section"
-        aria-labelledby="niche-facebook-pixel-title"
-        id="niche-facebook-pixel"
-      >
-        <div className="niche-section__header">
-          <div>
-            <h2
-              className="niche-section__title"
-              id="niche-facebook-pixel-title"
-            >
-              Pixel do Facebook
-            </h2>
-            <p className="niche-section__subtitle">
-              Compartilhado por todos os experimentos deste nicho.
-            </p>
-            <p className="niche-section__status">
-              {facebookPixelId
-                ? `Pixel ${facebookPixelId} disponível para embutir nas landings.`
-                : "Nenhum pixel gerado ainda para este nicho."}
-            </p>
-          </div>
-          {facebookPixelCreatedAtLabel ? (
-            <span className="text-muted small">
-              Criado em {facebookPixelCreatedAtLabel}
-            </span>
-          ) : null}
-        </div>
-        {facebookPixelId ? (
-          <div className="d-flex flex-column gap-3">
+      {shouldShowFacebookPixelSection ? (
+        <section
+          className="niche-section"
+          aria-labelledby="niche-facebook-pixel-title"
+          id="niche-facebook-pixel"
+        >
+          <div className="niche-section__header">
             <div>
-              <strong>ID:</strong> {facebookPixelId}
-            </div>
-            {facebookPixelCode ? (
-              <textarea
-                className="form-control font-monospace"
-                value={facebookPixelCode ?? ""}
-                readOnly
-                rows={6}
-              />
-            ) : (
-              <div className="alert alert-info mb-0">
-                Pixel registrado. Aguarde o retorno do código completo pela
-                Meta.
-              </div>
-            )}
-          </div>
-        ) : (
-          <div className="alert alert-warning mb-0">
-            <div className="d-flex flex-column flex-md-row align-items-md-center justify-content-between gap-3">
-              <div>
-                <strong>Pixel ainda não solicitado.</strong> Solicite a criação
-                para o worker gerar o pixel e liberar o uso nos experimentos.
-                {facebookPixelRequestedAtLabel ? (
-                  <span className="d-block small mt-1">
-                    Solicitação registrada em {facebookPixelRequestedAtLabel}.
-                  </span>
-                ) : null}
-              </div>
-              <button
-                type="button"
-                className="btn btn-warning"
-                onClick={handleRequestFacebookPixel}
-                disabled={
-                  requestFacebookPixel.isPending ||
-                  isFacebookPixelPending ||
-                  !normalizedNicheId
-                }
+              <h2
+                className="niche-section__title"
+                id="niche-facebook-pixel-title"
               >
-                {requestFacebookPixel.isPending ? (
-                  <span
-                    className="spinner-border spinner-border-sm me-2"
-                    aria-hidden="true"
-                  />
-                ) : null}
-                {isFacebookPixelPending
-                  ? "Pixel solicitado"
-                  : "Solicitar pixel"}
-              </button>
+                Pixel do Facebook
+              </h2>
+              <p className="niche-section__subtitle">
+                Compartilhado por todos os experimentos deste nicho.
+              </p>
+              <p className="niche-section__status">
+                {facebookPixelId
+                  ? `Pixel ${facebookPixelId} disponível para embutir nas landings.`
+                  : "Nenhum pixel gerado ainda para este nicho."}
+              </p>
             </div>
+            {facebookPixelCreatedAtLabel ? (
+              <span className="text-muted small">
+                Criado em {facebookPixelCreatedAtLabel}
+              </span>
+            ) : null}
           </div>
-        )}
-      </section>
+          {facebookPixelId ? (
+            <div className="d-flex flex-column gap-3">
+              <div>
+                <strong>ID:</strong> {facebookPixelId}
+              </div>
+              {facebookPixelCode ? (
+                <textarea
+                  className="form-control font-monospace"
+                  value={facebookPixelCode ?? ""}
+                  readOnly
+                  rows={6}
+                />
+              ) : (
+                <div className="alert alert-info mb-0">
+                  Pixel registrado. Aguarde o retorno do código completo pela
+                  Meta.
+                </div>
+              )}
+            </div>
+          ) : (
+            <div className="alert alert-warning mb-0">
+              <div className="d-flex flex-column flex-md-row align-items-md-center justify-content-between gap-3">
+                <div>
+                  <strong>Pixel ainda não solicitado.</strong> Solicite a
+                  criação para o worker gerar o pixel e liberar o uso nos
+                  experimentos.
+                  {facebookPixelRequestedAtLabel ? (
+                    <span className="d-block small mt-1">
+                      Solicitação registrada em {facebookPixelRequestedAtLabel}.
+                    </span>
+                  ) : null}
+                </div>
+                <button
+                  type="button"
+                  className="btn btn-warning"
+                  onClick={handleRequestFacebookPixel}
+                  disabled={
+                    requestFacebookPixel.isPending ||
+                    isFacebookPixelPending ||
+                    !normalizedNicheId
+                  }
+                >
+                  {requestFacebookPixel.isPending ? (
+                    <span
+                      className="spinner-border spinner-border-sm me-2"
+                      aria-hidden="true"
+                    />
+                  ) : null}
+                  {isFacebookPixelPending
+                    ? "Pixel solicitado"
+                    : "Solicitar pixel"}
+                </button>
+              </div>
+            </div>
+          )}
+        </section>
+      ) : null}
       <NicheLearningDictionaryCard nicheId={normalizedNicheId} />
       <NicheBacklogRecommendationsCard nicheId={normalizedNicheId} />
       <section
@@ -1828,380 +1878,394 @@ export default function NicheDetailPage() {
           </div>
         </article>
       </section>
-      <section
-        className="niche-section"
-        aria-labelledby="niche-information-sources"
-      >
-        <div className="niche-section__header">
-          <div>
-            <h2 className="niche-section__title" id="niche-information-sources">
-              Fontes de informação
-            </h2>
-            <p className="niche-section__subtitle">
-              Registre links relevantes para pesquisas de mercado futuras.
-            </p>
-          </div>
-          <span className="badge text-bg-light text-dark niche-information-sources__badge">
-            {informationSourceList.length} item(s)
-          </span>
-        </div>
-        <form
-          className="niche-information-sources__form"
-          onSubmit={onCreateInformationSource}
+      {shouldShowInformationSourcesSection ? (
+        <section
+          className="niche-section"
+          aria-labelledby="niche-information-sources"
         >
-          <div className="row g-3">
-            <div className="col-md-5">
-              <label htmlFor="information-source-name" className="form-label">
-                Nome *
-              </label>
-              <input
-                id="information-source-name"
-                type="text"
-                className="form-control"
-                placeholder="Ex: Relatório Sebrae 2024"
-                disabled={createInformationSource.isPending}
-                {...registerInformationSource("name", { required: true })}
-              />
-            </div>
-            <div className="col-md-7">
-              <label htmlFor="information-source-url" className="form-label">
-                URL *
-              </label>
-              <input
-                id="information-source-url"
-                type="url"
-                className="form-control"
-                placeholder="https://..."
-                disabled={createInformationSource.isPending}
-                {...registerInformationSource("url", { required: true })}
-              />
-            </div>
-          </div>
-          <div className="d-flex justify-content-end mt-3">
-            <button
-              type="submit"
-              className="btn btn-primary"
-              disabled={createInformationSource.isPending}
-            >
-              {createInformationSource.isPending ? (
-                <span
-                  className="spinner-border spinner-border-sm"
-                  role="status"
-                  aria-hidden="true"
-                />
-              ) : (
-                <Plus size={18} />
-              )}
-              <span>Adicionar fonte</span>
-            </button>
-          </div>
-        </form>
-        {informationSourceList.length === 0 ? (
-          <p className="niche-section__empty">
-            Nenhuma fonte de informação cadastrada ainda.
-          </p>
-        ) : (
-          <div className="niche-section__grid niche-information-sources__grid">
-            {informationSourceList.map((source) => (
-              <article key={source.id} className="card niche-section__card">
-                <div className="card-body niche-information-source-card__body">
-                  <h3 className="niche-information-source-card__title">
-                    {source.name}
-                  </h3>
-                  <a
-                    className="niche-detail__card-link"
-                    href={source.url}
-                    target="_blank"
-                    rel="noreferrer"
-                  >
-                    {source.url}
-                  </a>
-                </div>
-                <div className="card-footer niche-information-source-card__footer">
-                  {`Atualizado em ${
-                    source.updatedAt
-                      ? new Date(source.updatedAt).toLocaleString("pt-BR")
-                      : "-"
-                  }`}
-                </div>
-              </article>
-            ))}
-          </div>
-        )}
-      </section>
-      <section className="niche-section" aria-labelledby="niche-deliverables">
-        <div className="niche-section__header">
-          <div>
-            <h2 className="niche-section__title" id="niche-deliverables">
-              Entregáveis
-            </h2>
-            <p className="niche-section__subtitle">
-              Centralize os materiais gerados para validar este nicho.
-            </p>
-          </div>
-          <span className="badge text-bg-light text-dark niche-deliverables__badge">
-            {deliverableList.length} item(s)
-          </span>
-        </div>
-        <form
-          className="niche-deliverables__form"
-          onSubmit={onCreateDeliverable}
-        >
-          <div className="row g-3">
-            <div className="col-md-4">
-              <label htmlFor="deliverable-title" className="form-label">
-                Título *
-              </label>
-              <input
-                id="deliverable-title"
-                type="text"
-                className="form-control"
-                placeholder="Resumo do entregável"
-                disabled={createDeliverable.isPending}
-                {...registerDeliverable("title", { required: true })}
-              />
-            </div>
-            <div className="col-md-4">
-              <label htmlFor="deliverable-model" className="form-label">
-                Modelo de IA
-              </label>
-              <input
-                id="deliverable-model"
-                type="text"
-                className="form-control"
-                placeholder="ex: gpt-4.1"
-                disabled={createDeliverable.isPending}
-                {...registerDeliverable("model")}
-              />
-            </div>
-            <div className="col-12">
-              <label htmlFor="deliverable-prompt" className="form-label">
-                Prompt utilizado *
-              </label>
-              <textarea
-                id="deliverable-prompt"
-                className="form-control"
-                rows={2}
-                placeholder="Cole aqui o prompt enviado ao modelo"
-                disabled={createDeliverable.isPending}
-                {...registerDeliverable("prompt", { required: true })}
-              />
-            </div>
-            <div className="col-md-6">
-              <label htmlFor="deliverable-description" className="form-label">
-                Descrição
-              </label>
-              <textarea
-                id="deliverable-description"
-                className="form-control"
-                rows={2}
-                placeholder="Resumo rápido do entregável"
-                disabled={createDeliverable.isPending}
-                {...registerDeliverable("description")}
-              />
-            </div>
-            <div className="col-md-6">
-              <label htmlFor="deliverable-content" className="form-label">
-                Conteúdo detalhado
-              </label>
-              <textarea
-                id="deliverable-content"
-                className="form-control"
-                rows={2}
-                placeholder="Cole aqui o conteúdo completo"
-                disabled={createDeliverable.isPending}
-                {...registerDeliverable("content")}
-              />
-            </div>
-          </div>
-          <div className="d-flex justify-content-end mt-3">
-            <button
-              type="submit"
-              className="btn btn-primary"
-              disabled={createDeliverable.isPending}
-            >
-              {createDeliverable.isPending ? (
-                <span
-                  className="spinner-border spinner-border-sm"
-                  role="status"
-                  aria-hidden="true"
-                />
-              ) : (
-                <Sparkles size={18} />
-              )}
-              <span>Salvar entregável</span>
-            </button>
-          </div>
-        </form>
-        {deliverableList.length === 0 ? (
-          <p className="niche-section__empty">
-            Nenhum entregável cadastrado ainda.
-          </p>
-        ) : (
-          <div className="niche-section__grid niche-deliverables__grid">
-            {deliverableList.map((deliverable) => (
-              <article
-                key={deliverable.id}
-                className="card niche-section__card"
+          <div className="niche-section__header">
+            <div>
+              <h2
+                className="niche-section__title"
+                id="niche-information-sources"
               >
-                <div className="card-body niche-deliverable-card__body">
-                  <div className="niche-deliverable-card__head">
-                    <h3 className="niche-deliverable-card__title">
-                      {deliverable.title}
-                    </h3>
-                    {deliverable.model ? (
-                      <span className="badge text-bg-light text-dark">
-                        {deliverable.model}
-                      </span>
-                    ) : null}
-                  </div>
-                  {deliverable.description ? (
-                    <p className="niche-deliverable-card__description">
-                      {deliverable.description}
-                    </p>
-                  ) : null}
-                  {deliverable.content ? (
-                    <pre className="niche-deliverable-card__content">
-                      {deliverable.content}
-                    </pre>
-                  ) : null}
-                  <details className="niche-deliverable-card__prompt">
-                    <summary>Ver prompt utilizado</summary>
-                    <pre>{deliverable.prompt}</pre>
-                  </details>
-                </div>
-                <div className="card-footer niche-deliverable-card__footer">
-                  {`Atualizado em ${
-                    deliverable.updatedAt
-                      ? new Date(deliverable.updatedAt).toLocaleString("pt-BR")
-                      : "-"
-                  }`}
-                </div>
-              </article>
-            ))}
+                Fontes de informação
+              </h2>
+              <p className="niche-section__subtitle">
+                Registre links relevantes para pesquisas de mercado futuras.
+              </p>
+            </div>
+            <span className="badge text-bg-light text-dark niche-information-sources__badge">
+              {informationSourceList.length} item(s)
+            </span>
           </div>
-        )}
-      </section>
-      <section
-        className="niche-section"
-        aria-labelledby="niche-lead-portal-flows"
-      >
-        <div className="niche-section__header">
-          <div>
-            <h2 className="niche-section__title" id="niche-lead-portal-flows">
-              Formulários simples do nicho
-            </h2>
-            <p className="niche-section__subtitle">
-              Cadastre formulários sem imagem uma vez e reutilize em todos os
-              experimentos relacionados.
-            </p>
-          </div>
-        </div>
-        <div className="niche-section__body d-flex flex-column gap-3">
-          <SimpleLeadPortalFormCard
-            marketNicheId={normalizedNicheId}
-            onCreated={refetchLeadPortalFlows}
-            editingFlow={flowBeingEdited}
-            onEditFinished={() => setFlowBeingEdited(null)}
-          />
-          <div className="card border-0 shadow-sm">
-            <div className="card-body d-flex flex-column gap-3">
-              <div className="d-flex justify-content-between align-items-center flex-wrap gap-2">
-                <h5 className="mb-0">Formulários disponíveis</h5>
-                <span className="badge text-bg-light text-dark">
-                  {leadPortalFlowList.length} item(s)
-                </span>
+          <form
+            className="niche-information-sources__form"
+            onSubmit={onCreateInformationSource}
+          >
+            <div className="row g-3">
+              <div className="col-md-5">
+                <label htmlFor="information-source-name" className="form-label">
+                  Nome *
+                </label>
+                <input
+                  id="information-source-name"
+                  type="text"
+                  className="form-control"
+                  placeholder="Ex: Relatório Sebrae 2024"
+                  disabled={createInformationSource.isPending}
+                  {...registerInformationSource("name", { required: true })}
+                />
               </div>
-              {isLoadingLeadPortalFlows ? (
-                <p className="text-muted mb-0">Carregando formulários...</p>
-              ) : isLeadPortalFlowsError ? (
-                <p className="text-danger mb-0">
-                  Não foi possível carregar os formulários deste nicho.
-                </p>
-              ) : leadPortalFlowList.length === 0 ? (
-                <p className="niche-section__empty mb-0">
-                  Nenhum formulário cadastrado ainda.
-                </p>
-              ) : (
-                <div className="d-flex flex-column gap-3">
-                  {leadPortalFlowList.map((flow) => (
-                    <article key={flow.id} className="card border-0 shadow-sm">
-                      <div className="card-body">
-                        <div className="d-flex flex-wrap gap-2 align-items-center mb-1">
-                          <h6 className="mb-0">{flow.name}</h6>
-                          <span
-                            className={`badge ${flow.approved ? "text-bg-success" : "text-bg-secondary"}`}
-                          >
-                            {flow.approved ? "Aprovado" : "Pendente"}
-                          </span>
-                          {flow.customFormHtml ? (
-                            <span className="badge text-bg-info">
-                              HTML personalizado
-                            </span>
-                          ) : null}
-                          {flowBeingEdited?.id === flow.id ? (
-                            <span className="badge text-bg-warning">
-                              Em edição
-                            </span>
-                          ) : null}
-                        </div>
-                        <p className="text-muted small mb-1">
-                          Slug: {flow.slug}
-                        </p>
-                        <p className="text-muted small mb-1">
-                          Atualizado em {formatDateTime(flow.updatedAt)}
-                        </p>
-                        {flow.publicUrl ? (
-                          <p className="text-muted small mb-1">
-                            URL pública:{" "}
-                            <a
-                              href={flow.publicUrl}
-                              target="_blank"
-                              rel="noopener noreferrer"
-                            >
-                              {flow.publicUrl}
-                            </a>
-                          </p>
-                        ) : null}
-                        <p className="text-muted small mb-0">
-                          {flow.questions.length} pergunta(s)
-                        </p>
-                        {flow.customFormHtml ? (
-                          <details className="mt-2">
-                            <summary>Ver HTML personalizado</summary>
-                            <pre className="bg-body-tertiary rounded-3 p-3 small overflow-auto">
-                              {flow.customFormHtml}
-                            </pre>
-                          </details>
-                        ) : null}
-
-                        {flow.experimentId ? (
-                          <p className="text-muted small mt-2 mb-0">
-                            Vinculado ao experimento #{flow.experimentId}
-                          </p>
-                        ) : (
-                          <div className="mt-2 d-flex flex-wrap gap-2">
-                            <button
-                              type="button"
-                              className="btn btn-outline-primary btn-sm"
-                              onClick={() => setFlowBeingEdited(flow)}
-                              disabled={flowBeingEdited?.id === flow.id}
-                            >
-                              {flowBeingEdited?.id === flow.id
-                                ? "Formulário em edição"
-                                : "Editar formulário"}
-                            </button>
-                          </div>
-                        )}
-                      </div>
-                    </article>
-                  ))}
-                </div>
-              )}
+              <div className="col-md-7">
+                <label htmlFor="information-source-url" className="form-label">
+                  URL *
+                </label>
+                <input
+                  id="information-source-url"
+                  type="url"
+                  className="form-control"
+                  placeholder="https://..."
+                  disabled={createInformationSource.isPending}
+                  {...registerInformationSource("url", { required: true })}
+                />
+              </div>
+            </div>
+            <div className="d-flex justify-content-end mt-3">
+              <button
+                type="submit"
+                className="btn btn-primary"
+                disabled={createInformationSource.isPending}
+              >
+                {createInformationSource.isPending ? (
+                  <span
+                    className="spinner-border spinner-border-sm"
+                    role="status"
+                    aria-hidden="true"
+                  />
+                ) : (
+                  <Plus size={18} />
+                )}
+                <span>Adicionar fonte</span>
+              </button>
+            </div>
+          </form>
+          {informationSourceList.length === 0 ? (
+            <p className="niche-section__empty">
+              Nenhuma fonte de informação cadastrada ainda.
+            </p>
+          ) : (
+            <div className="niche-section__grid niche-information-sources__grid">
+              {informationSourceList.map((source) => (
+                <article key={source.id} className="card niche-section__card">
+                  <div className="card-body niche-information-source-card__body">
+                    <h3 className="niche-information-source-card__title">
+                      {source.name}
+                    </h3>
+                    <a
+                      className="niche-detail__card-link"
+                      href={source.url}
+                      target="_blank"
+                      rel="noreferrer"
+                    >
+                      {source.url}
+                    </a>
+                  </div>
+                  <div className="card-footer niche-information-source-card__footer">
+                    {`Atualizado em ${
+                      source.updatedAt
+                        ? new Date(source.updatedAt).toLocaleString("pt-BR")
+                        : "-"
+                    }`}
+                  </div>
+                </article>
+              ))}
+            </div>
+          )}
+        </section>
+      ) : null}
+      {shouldShowManualDeliverablesSection ? (
+        <section className="niche-section" aria-labelledby="niche-deliverables">
+          <div className="niche-section__header">
+            <div>
+              <h2 className="niche-section__title" id="niche-deliverables">
+                Entregáveis
+              </h2>
+              <p className="niche-section__subtitle">
+                Centralize os materiais gerados para validar este nicho.
+              </p>
+            </div>
+            <span className="badge text-bg-light text-dark niche-deliverables__badge">
+              {deliverableList.length} item(s)
+            </span>
+          </div>
+          <form
+            className="niche-deliverables__form"
+            onSubmit={onCreateDeliverable}
+          >
+            <div className="row g-3">
+              <div className="col-md-4">
+                <label htmlFor="deliverable-title" className="form-label">
+                  Título *
+                </label>
+                <input
+                  id="deliverable-title"
+                  type="text"
+                  className="form-control"
+                  placeholder="Resumo do entregável"
+                  disabled={createDeliverable.isPending}
+                  {...registerDeliverable("title", { required: true })}
+                />
+              </div>
+              <div className="col-md-4">
+                <label htmlFor="deliverable-model" className="form-label">
+                  Modelo de IA
+                </label>
+                <input
+                  id="deliverable-model"
+                  type="text"
+                  className="form-control"
+                  placeholder="ex: gpt-4.1"
+                  disabled={createDeliverable.isPending}
+                  {...registerDeliverable("model")}
+                />
+              </div>
+              <div className="col-12">
+                <label htmlFor="deliverable-prompt" className="form-label">
+                  Prompt utilizado *
+                </label>
+                <textarea
+                  id="deliverable-prompt"
+                  className="form-control"
+                  rows={2}
+                  placeholder="Cole aqui o prompt enviado ao modelo"
+                  disabled={createDeliverable.isPending}
+                  {...registerDeliverable("prompt", { required: true })}
+                />
+              </div>
+              <div className="col-md-6">
+                <label htmlFor="deliverable-description" className="form-label">
+                  Descrição
+                </label>
+                <textarea
+                  id="deliverable-description"
+                  className="form-control"
+                  rows={2}
+                  placeholder="Resumo rápido do entregável"
+                  disabled={createDeliverable.isPending}
+                  {...registerDeliverable("description")}
+                />
+              </div>
+              <div className="col-md-6">
+                <label htmlFor="deliverable-content" className="form-label">
+                  Conteúdo detalhado
+                </label>
+                <textarea
+                  id="deliverable-content"
+                  className="form-control"
+                  rows={2}
+                  placeholder="Cole aqui o conteúdo completo"
+                  disabled={createDeliverable.isPending}
+                  {...registerDeliverable("content")}
+                />
+              </div>
+            </div>
+            <div className="d-flex justify-content-end mt-3">
+              <button
+                type="submit"
+                className="btn btn-primary"
+                disabled={createDeliverable.isPending}
+              >
+                {createDeliverable.isPending ? (
+                  <span
+                    className="spinner-border spinner-border-sm"
+                    role="status"
+                    aria-hidden="true"
+                  />
+                ) : (
+                  <Sparkles size={18} />
+                )}
+                <span>Salvar entregável</span>
+              </button>
+            </div>
+          </form>
+          {deliverableList.length === 0 ? (
+            <p className="niche-section__empty">
+              Nenhum entregável cadastrado ainda.
+            </p>
+          ) : (
+            <div className="niche-section__grid niche-deliverables__grid">
+              {deliverableList.map((deliverable) => (
+                <article
+                  key={deliverable.id}
+                  className="card niche-section__card"
+                >
+                  <div className="card-body niche-deliverable-card__body">
+                    <div className="niche-deliverable-card__head">
+                      <h3 className="niche-deliverable-card__title">
+                        {deliverable.title}
+                      </h3>
+                      {deliverable.model ? (
+                        <span className="badge text-bg-light text-dark">
+                          {deliverable.model}
+                        </span>
+                      ) : null}
+                    </div>
+                    {deliverable.description ? (
+                      <p className="niche-deliverable-card__description">
+                        {deliverable.description}
+                      </p>
+                    ) : null}
+                    {deliverable.content ? (
+                      <pre className="niche-deliverable-card__content">
+                        {deliverable.content}
+                      </pre>
+                    ) : null}
+                    <details className="niche-deliverable-card__prompt">
+                      <summary>Ver prompt utilizado</summary>
+                      <pre>{deliverable.prompt}</pre>
+                    </details>
+                  </div>
+                  <div className="card-footer niche-deliverable-card__footer">
+                    {`Atualizado em ${
+                      deliverable.updatedAt
+                        ? new Date(deliverable.updatedAt).toLocaleString(
+                            "pt-BR",
+                          )
+                        : "-"
+                    }`}
+                  </div>
+                </article>
+              ))}
+            </div>
+          )}
+        </section>
+      ) : null}
+      {shouldShowSimpleLeadPortalFormsSection ? (
+        <section
+          className="niche-section"
+          aria-labelledby="niche-lead-portal-flows"
+        >
+          <div className="niche-section__header">
+            <div>
+              <h2 className="niche-section__title" id="niche-lead-portal-flows">
+                Formulários simples do nicho
+              </h2>
+              <p className="niche-section__subtitle">
+                Cadastre formulários sem imagem uma vez e reutilize em todos os
+                experimentos relacionados.
+              </p>
             </div>
           </div>
-        </div>
-      </section>
+          <div className="niche-section__body d-flex flex-column gap-3">
+            <SimpleLeadPortalFormCard
+              marketNicheId={normalizedNicheId}
+              onCreated={refetchLeadPortalFlows}
+              editingFlow={flowBeingEdited}
+              onEditFinished={() => setFlowBeingEdited(null)}
+            />
+            <div className="card border-0 shadow-sm">
+              <div className="card-body d-flex flex-column gap-3">
+                <div className="d-flex justify-content-between align-items-center flex-wrap gap-2">
+                  <h5 className="mb-0">Formulários disponíveis</h5>
+                  <span className="badge text-bg-light text-dark">
+                    {leadPortalFlowList.length} item(s)
+                  </span>
+                </div>
+                {isLoadingLeadPortalFlows ? (
+                  <p className="text-muted mb-0">Carregando formulários...</p>
+                ) : isLeadPortalFlowsError ? (
+                  <p className="text-danger mb-0">
+                    Não foi possível carregar os formulários deste nicho.
+                  </p>
+                ) : leadPortalFlowList.length === 0 ? (
+                  <p className="niche-section__empty mb-0">
+                    Nenhum formulário cadastrado ainda.
+                  </p>
+                ) : (
+                  <div className="d-flex flex-column gap-3">
+                    {leadPortalFlowList.map((flow) => (
+                      <article
+                        key={flow.id}
+                        className="card border-0 shadow-sm"
+                      >
+                        <div className="card-body">
+                          <div className="d-flex flex-wrap gap-2 align-items-center mb-1">
+                            <h6 className="mb-0">{flow.name}</h6>
+                            <span
+                              className={`badge ${flow.approved ? "text-bg-success" : "text-bg-secondary"}`}
+                            >
+                              {flow.approved ? "Aprovado" : "Pendente"}
+                            </span>
+                            {flow.customFormHtml ? (
+                              <span className="badge text-bg-info">
+                                HTML personalizado
+                              </span>
+                            ) : null}
+                            {flowBeingEdited?.id === flow.id ? (
+                              <span className="badge text-bg-warning">
+                                Em edição
+                              </span>
+                            ) : null}
+                          </div>
+                          <p className="text-muted small mb-1">
+                            Slug: {flow.slug}
+                          </p>
+                          <p className="text-muted small mb-1">
+                            Atualizado em {formatDateTime(flow.updatedAt)}
+                          </p>
+                          {flow.publicUrl ? (
+                            <p className="text-muted small mb-1">
+                              URL pública:{" "}
+                              <a
+                                href={flow.publicUrl}
+                                target="_blank"
+                                rel="noopener noreferrer"
+                              >
+                                {flow.publicUrl}
+                              </a>
+                            </p>
+                          ) : null}
+                          <p className="text-muted small mb-0">
+                            {flow.questions.length} pergunta(s)
+                          </p>
+                          {flow.customFormHtml ? (
+                            <details className="mt-2">
+                              <summary>Ver HTML personalizado</summary>
+                              <pre className="bg-body-tertiary rounded-3 p-3 small overflow-auto">
+                                {flow.customFormHtml}
+                              </pre>
+                            </details>
+                          ) : null}
+
+                          {flow.experimentId ? (
+                            <p className="text-muted small mt-2 mb-0">
+                              Vinculado ao experimento #{flow.experimentId}
+                            </p>
+                          ) : (
+                            <div className="mt-2 d-flex flex-wrap gap-2">
+                              <button
+                                type="button"
+                                className="btn btn-outline-primary btn-sm"
+                                onClick={() => setFlowBeingEdited(flow)}
+                                disabled={flowBeingEdited?.id === flow.id}
+                              >
+                                {flowBeingEdited?.id === flow.id
+                                  ? "Formulário em edição"
+                                  : "Editar formulário"}
+                              </button>
+                            </div>
+                          )}
+                        </div>
+                      </article>
+                    ))}
+                  </div>
+                )}
+              </div>
+            </div>
+          </div>
+        </section>
+      ) : null}
 
       <section className="niche-section" aria-labelledby="niche-targeting">
         <div className="niche-section__header">

--- a/frontend/src/pages/niche/NicheLearningDictionaryCard.tsx
+++ b/frontend/src/pages/niche/NicheLearningDictionaryCard.tsx
@@ -37,20 +37,28 @@ function formatDate(value?: string | null) {
 export function NicheLearningDictionaryCard({ nicheId }: Props) {
   const { data, isLoading, error } = useNicheLearningDictionary(nicheId);
   const resolveEntries = (key: DictionaryKey): LearningStatement[] =>
-    ((data?.[key] ?? []) as LearningStatement[]);
+    (data?.[key] ?? []) as LearningStatement[];
 
   const hasContent = useMemo(() => {
     if (!data) return false;
     return sections.some((section) => resolveEntries(section.key).length > 0);
   }, [data]);
 
+  if (!isLoading && !error && !hasContent) {
+    return null;
+  }
+
   return (
-    <section className="niche-section" aria-label="Banco de aprendizados do nicho">
+    <section
+      className="niche-section"
+      aria-label="Banco de aprendizados do nicho"
+    >
       <div className="niche-section__header">
         <div>
           <h2 className="niche-section__title">Banco de aprendizados</h2>
           <p className="niche-section__subtitle">
-            Consolida os principais aprendizados Dor → Resultado → Mecanismo → Prova → Oferta para os próximos testes.
+            Consolida os principais aprendizados Dor → Resultado → Mecanismo →
+            Prova → Oferta para os próximos testes.
           </p>
           <p className="niche-section__status">
             Atualizado em {formatDate(data?.updatedAt)}
@@ -65,7 +73,9 @@ export function NicheLearningDictionaryCard({ nicheId }: Props) {
         <div className="text-muted">Carregando aprendizados...</div>
       ) : !hasContent ? (
         <div className="text-muted">
-          Ainda não existem aprendizados vinculados a este nicho. Gere um aprendizado a partir do painel do experimento para popular esta sessão.
+          Ainda não existem aprendizados vinculados a este nicho. Gere um
+          aprendizado a partir do painel do experimento para popular esta
+          sessão.
         </div>
       ) : (
         <div className="row g-3">
@@ -76,12 +86,16 @@ export function NicheLearningDictionaryCard({ nicheId }: Props) {
                 <div className="border rounded-3 p-3 h-100">
                   <strong className="d-block mb-2">{section.label}</strong>
                   {entries.length === 0 ? (
-                    <p className="text-body-secondary mb-0">Sem itens cadastrados.</p>
+                    <p className="text-body-secondary mb-0">
+                      Sem itens cadastrados.
+                    </p>
                   ) : (
                     <ul className="list-unstyled mb-0">
                       {entries.map((statement, index) => (
                         <li key={`${section.key}-${index}`} className="mb-3">
-                          <div className="fw-semibold">{statement.statement}</div>
+                          <div className="fw-semibold">
+                            {statement.statement}
+                          </div>
                           {statement.evidence ? (
                             <div className="text-body-secondary small">
                               {statement.evidence}


### PR DESCRIPTION
### Motivation
- Avoid rendering empty or irrelevant UI sections in the Niche detail view to reduce clutter and improve clarity.
- Prevent showing backlog and dictionary cards when there is no content to display.
- Make the Facebook Pixel, information sources, deliverables and simple lead forms visibility explicit so the page can be curated per-tenant or per-feature.

### Description
- In `NicheBacklogRecommendationsCard`, return `null` when there are no recommendations to avoid showing an empty card and tidy up JSX formatting.
- In `NicheLearningDictionaryCard`, compute `hasContent` and return `null` when there are no learning entries, and apply minor markup wrapping fixes.
- In `NicheDetailPage`, add `hasDisplayValue` helper and two sets `alwaysHiddenInfoLabels` and `hiddenWhenEmptyInfoLabels` to filter `infoCards` into `visibleInfoCards`, and render only those cards.
- Introduce `shouldShowFacebookPixelSection`, `shouldShowInformationSourcesSection`, `shouldShowManualDeliverablesSection`, and `shouldShowSimpleLeadPortalFormsSection` flags (currently set to control visibility) and conditionally render the corresponding sections including a refactor of the Facebook Pixel block and restructuring of information sources, deliverables and lead portal forms into guarded sections.

### Testing
- Ran TypeScript typecheck and project build (`yarn build`) which completed successfully.
- Ran linting (`yarn lint`) with no new violations reported.
- Ran unit tests (`yarn test`) and the test suite passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3b34dd0454832181bef33652317954)