### PR TITLE
Corrige métrica de visualização do formulário no funil

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/funnel/ExperimentFunnelService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/funnel/ExperimentFunnelService.java
@@ -678,7 +678,13 @@ public class ExperimentFunnelService {
                         FROM experiment_funnel_event
                         WHERE experiment_id = ?
                           AND stage = 'VISUALIZACAO_FORM'
-                          AND source IN (?, ?)
+                          AND (
+                              source = ?
+                              OR (
+                                  source = ?
+                                  AND payload LIKE '%eventType=page_view%'
+                              )
+                          )
                           AND (? IS NULL OR occurred_at > ?)
                         """, experimentId,
                         ExperimentFunnelEventRepository.RENDER_COMPLETE_SOURCE,

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/funnel/ExperimentFunnelServiceRenderCompleteTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/funnel/ExperimentFunnelServiceRenderCompleteTest.java
@@ -492,11 +492,53 @@ class ExperimentFunnelServiceRenderCompleteTest {
                         FROM experiment_funnel_event
                         WHERE experiment_id = ?
                           AND stage = 'VISUALIZACAO_FORM'
-                          AND source IN (?, ?)
+                          AND (
+                              source = ?
+                              OR (
+                                  source = ?
+                                  AND payload LIKE '%eventType=page_view%'
+                              )
+                          )
                           AND (? IS NULL OR occurred_at > ?)
                         """),
                 any(ResultSetExtractor.class),
                 eq(37L),
+                eq(ExperimentFunnelEventRepository.RENDER_COMPLETE_SOURCE),
+                eq(ExperimentFunnelEventRepository.LANDING_PAGE_ANALYTICS_SOURCE),
+                eq(null),
+                eq(null));
+    }
+
+    /**
+     * Valida que o resumo não transforma eventos técnicos de analytics em novas visualizações do formulário.
+     */
+    @Test
+    void summarizeFiltersLandingAnalyticsFormVisualizationToPageViewOnly() {
+        Experiment experiment = Experiment.builder().id(41L).build();
+        when(experimentRepository.findById(41L)).thenReturn(Optional.of(experiment));
+        when(eventRepository.aggregateManualByExperiment(41L, null)).thenReturn(List.of());
+
+        service.summarize(41L);
+
+        verify(jdbcTemplate).query(
+                eq("""
+                        SELECT COUNT(*) AS total,
+                               NULL AS unique_count,
+                               MAX(occurred_at) AS last_event
+                        FROM experiment_funnel_event
+                        WHERE experiment_id = ?
+                          AND stage = 'VISUALIZACAO_FORM'
+                          AND (
+                              source = ?
+                              OR (
+                                  source = ?
+                                  AND payload LIKE '%eventType=page_view%'
+                              )
+                          )
+                          AND (? IS NULL OR occurred_at > ?)
+                        """),
+                any(ResultSetExtractor.class),
+                eq(41L),
                 eq(ExperimentFunnelEventRepository.RENDER_COMPLETE_SOURCE),
                 eq(ExperimentFunnelEventRepository.LANDING_PAGE_ANALYTICS_SOURCE),
                 eq(null),

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -5199,3 +5199,10 @@
 - Problema: o experimento 48 não exibia opções na aba Público porque o nicho 24 possuía candidatos de targeting gerados, mas sem registros correspondentes em `targeting_resolution_job`; assim o Facebook Ads Worker não consumia os candidatos para validar IDs oficiais da Meta e materializar `targeting_element` aprovado.
 - Causa-raiz: a fila operacional de resolução dependia exclusivamente do enfileiramento pós-gravação dos candidatos. Se esse enfileiramento não acontecesse em produção, não havia reconciliação automática no worker.
 - Correção aplicada: o `facebook-ads-worker` passou a recriar automaticamente jobs ausentes para candidatos em `PENDING_FACEBOOK_MATCH` antes de reivindicar a fila, permitindo que o processamento automático continue e evitando que novos experimentos fiquem sem público por lacuna na fila.
+
+## 2026-06-24 — Experimentos: correção da métrica de visualização do formulário
+
+- foi feito: o resumo do funil passou a contar como `Visualização do formulário` apenas `page_view` da landing e renderização explícita do formulário, sem somar eventos técnicos de analytics como tempo de seção e métricas de carregamento.
+- causa-raiz: todos os eventos de analytics da landing eram gravados em `experiment_funnel_event` na etapa `VISUALIZACAO_FORM`, e a consolidação somava qualquer evento dessa origem, inflando o funil.
+- evidência operacional: no experimento 41, o banco tinha 45 eventos nessa etapa, mas apenas 13 eram `page_view`; os demais eram eventos técnicos de analytics e não deveriam virar novas visualizações do formulário.
+- prevenção de recorrência: teste unitário garante que a consulta do resumo filtra `landing-page-analytics` por `eventType=page_view`.


### PR DESCRIPTION
### Motivation
- The funnel stage `VISUALIZACAO_FORM` was being inflated because all landing analytics events (including technical events like `section_view_time` and `page_load_metric`) were counted as form views. 

### Description
- Limit the automatic metric SQL for `VISUALIZACAO_FORM` to include `lead-portal-render-complete` events or `landing-page-analytics` events only when `payload` contains `eventType=page_view`. 
- Add a unit test `summarizeFiltersLandingAnalyticsFormVisualizationToPageViewOnly` in `ExperimentFunnelServiceRenderCompleteTest` that asserts the revised query is used. 
- Update `docs/registros/experimentos.md` with an operational note describing the bug, root cause and prevention. 
- Files changed: `backend/ads-service/src/main/java/com/marketinghub/experiment/funnel/ExperimentFunnelService.java`, `backend/ads-service/src/test/java/com/marketinghub/experiment/funnel/ExperimentFunnelServiceRenderCompleteTest.java`, and `docs/registros/experimentos.md`.

### Testing
- Ran the focused unit tests with `mvn -f backend/ads-service/pom.xml -Dtest=ExperimentFunnelServiceRenderCompleteTest test` and the suite passed (all tests green). 
- Verified with the MCP DB query that for `experiment_id=41` the corrected logic reduces the counted `VISUALIZACAO_FORM` events from 45 raw analytics events to 13 `page_view`-qualified form views. 
- Tests and DB validation succeeded and confirm the metric no longer counts technical analytics events as form visualizations.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3b4b27cf348321abd920fa2b211ce1)