### PR TITLE
Expose synthetic ai-worker incident for stale GeraLanding executions

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/opsmonitor/service/OpsMonitorService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/opsmonitor/service/OpsMonitorService.java
@@ -1,5 +1,6 @@
 package com.marketinghub.opsmonitor.service;
 
+import com.marketinghub.geralanding.GeraLandingStageExecution;
 import com.marketinghub.opsmonitor.OpsModuleHealthCheck;
 import com.marketinghub.opsmonitor.OpsModuleIncident;
 import com.marketinghub.opsmonitor.OpsMonitoredModule;
@@ -12,13 +13,18 @@ import com.marketinghub.opsmonitor.service.registerHeartbeat.RegisterModuleHeart
 import com.marketinghub.opsmonitor.service.registerIncident.RegisterModuleIncidentRequest;
 import com.marketinghub.opsmonitor.service.registerIncident.RegisterModuleIncidentResponse;
 import com.marketinghub.opsmonitor.service.summary.OpsMonitorSummaryResponse;
+import com.marketinghub.repository.jpa.geralanding.GeraLandingStageExecutionRepository;
 import com.marketinghub.repository.jpa.opsmonitor.OpsModuleAvailabilityDailyRepository;
 import com.marketinghub.repository.jpa.opsmonitor.OpsModuleHealthCheckRepository;
 import com.marketinghub.repository.jpa.opsmonitor.OpsModuleIncidentRepository;
 import com.marketinghub.repository.jpa.opsmonitor.OpsMonitoredModuleRepository;
 import jakarta.persistence.EntityNotFoundException;
+import java.nio.charset.StandardCharsets;
+import java.time.Duration;
 import java.time.Instant;
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -28,16 +34,33 @@ public class OpsMonitorService {
     private final OpsMonitoredModuleRepository moduleRepository;
     private final OpsModuleHealthCheckRepository healthCheckRepository;
     private final OpsModuleIncidentRepository incidentRepository;
-    private final OpsModuleAvailabilityDailyRepository availabilityDailyRepository;
+    private static final String AI_WORKER_MODULE_CODE = "ai-worker";
+    private static final String STATUS_STARTED = "INICIADO";
+    private static final String STATUS_OPEN = "OPEN";
+    private static final Duration AI_WORKER_STALE_QUEUE_THRESHOLD = Duration.ofMinutes(5);
+    private static final List<String> AI_WORKER_GERALANDING_STAGES = List.of(
+            "landing-page-wireframe",
+            "landing-page-copy",
+            "landing-page-image-planning",
+            "landing-page-image-generation",
+            "landing-page-design-preset",
+            "landing-page-quality-review",
+            "landing-page-deliverables");
 
+    private final OpsModuleAvailabilityDailyRepository availabilityDailyRepository;
+    private final GeraLandingStageExecutionRepository geraLandingStageExecutionRepository;
+
+    /** Inicializa o serviço com repositórios de monitoramento e filas auditáveis do GeraLanding. */
     public OpsMonitorService(OpsMonitoredModuleRepository moduleRepository,
             OpsModuleHealthCheckRepository healthCheckRepository,
             OpsModuleIncidentRepository incidentRepository,
-            OpsModuleAvailabilityDailyRepository availabilityDailyRepository) {
+            OpsModuleAvailabilityDailyRepository availabilityDailyRepository,
+            GeraLandingStageExecutionRepository geraLandingStageExecutionRepository) {
         this.moduleRepository = moduleRepository;
         this.healthCheckRepository = healthCheckRepository;
         this.incidentRepository = incidentRepository;
         this.availabilityDailyRepository = availabilityDailyRepository;
+        this.geraLandingStageExecutionRepository = geraLandingStageExecutionRepository;
     }
 
     /** Lista módulos habilitados para o worker executar verificações pendentes. */
@@ -120,13 +143,19 @@ public class OpsMonitorService {
     @Transactional(readOnly = true)
     public List<ModuleIncidentResponse> listIncidents(boolean openOnly, String criticality, String type) {
         List<OpsModuleIncident> incidents = openOnly
-                ? incidentRepository.findByStatusOrderByStartedAtDesc("OPEN")
+                ? incidentRepository.findByStatusOrderByStartedAtDesc(STATUS_OPEN)
                 : incidentRepository.findTop100ByOrderByStartedAtDesc();
-        return incidents.stream()
+        List<ModuleIncidentResponse> responses = new ArrayList<>(incidents.stream()
                 .filter(incident -> matchesFilter(incident.getModule().getCriticality(), criticality))
                 .filter(incident -> matchesFilter(incident.getModule().getType(), type))
                 .map(this::toIncidentResponse)
-                .toList();
+                .toList());
+        syntheticAiWorkerQueueIncident(openOnly)
+                .filter(incident -> matchesFilter(incident.criticality(), criticality))
+                .filter(incident -> matchesFilter(incident.type(), type))
+                .map(this::toIncidentResponse)
+                .ifPresent(responses::add);
+        return responses;
     }
 
     /** Gera resumo executivo para a tela administrativa de operação. */
@@ -137,7 +166,8 @@ public class OpsMonitorService {
         long degraded = availability.stream().filter(item -> "DEGRADED".equals(item.status())).count();
         long offline = availability.stream().filter(item -> "OFFLINE".equals(item.status())).count();
         long unknown = availability.stream().filter(item -> "UNKNOWN".equals(item.status())).count();
-        long openIncidents = incidentRepository.findByStatusOrderByStartedAtDesc("OPEN").size();
+        long openIncidents = incidentRepository.findByStatusOrderByStartedAtDesc(STATUS_OPEN).size()
+                + syntheticAiWorkerQueueIncident(true).map(incident -> 1L).orElse(0L);
         return new OpsMonitorSummaryResponse(online, degraded, offline, unknown, openIncidents);
     }
 
@@ -154,12 +184,60 @@ public class OpsMonitorService {
 
     /** Converte entidade de módulo para o status administrativo atual. */
     private ModuleAvailabilityResponse toAvailabilityResponse(OpsMonitoredModule module) {
+        if (AI_WORKER_MODULE_CODE.equals(module.getCode())) {
+            Optional<SyntheticIncident> queueIncident = syntheticAiWorkerQueueIncident(true);
+            if (queueIncident.isPresent()) {
+                SyntheticIncident incident = queueIncident.get();
+                return new ModuleAvailabilityResponse(module.getCode(), module.getName(), module.getType(),
+                        module.getCriticality(), "DEGRADED", incident.startedAt(), null, incident.lastError());
+            }
+        }
         return healthCheckRepository.findTop1ByModuleCodeOrderByCheckedAtDesc(module.getCode())
                 .map(check -> new ModuleAvailabilityResponse(module.getCode(), module.getName(), module.getType(),
                         module.getCriticality(), check.getStatus(), check.getCheckedAt(), check.getResponseTimeMs(),
                         check.getErrorMessage()))
                 .orElseGet(() -> new ModuleAvailabilityResponse(module.getCode(), module.getName(), module.getType(),
                         module.getCriticality(), "UNKNOWN", null, null, null));
+    }
+
+    /** Cria incidente sintético quando há fila de GeraLanding parada antes do worker iniciar processamento. */
+    private Optional<SyntheticIncident> syntheticAiWorkerQueueIncident(boolean openOnly) {
+        if (!openOnly) {
+            return Optional.empty();
+        }
+        Instant threshold = Instant.now().minus(AI_WORKER_STALE_QUEUE_THRESHOLD);
+        for (String stageCode : AI_WORKER_GERALANDING_STAGES) {
+            List<GeraLandingStageExecution> staleExecutions = geraLandingStageExecutionRepository
+                    .findTop20ByStageCodeAndStatusAndExecutionRequestedAtBeforeOrderByExecutionRequestedAtAsc(
+                            stageCode,
+                            STATUS_STARTED,
+                            threshold);
+            if (!staleExecutions.isEmpty()) {
+                GeraLandingStageExecution execution = staleExecutions.getFirst();
+                String jobId = new String(execution.getIdJob(), StandardCharsets.UTF_8);
+                String lastError = "Job " + jobId + " do experimento " + execution.getExperimentId()
+                        + " está em INICIADO sem processamento iniciado na etapa " + stageCode + ".";
+                return Optional.of(new SyntheticIncident(
+                        AI_WORKER_MODULE_CODE,
+                        "AI Worker",
+                        "WORKER",
+                        "CRITICAL",
+                        STATUS_OPEN,
+                        "HIGH",
+                        execution.getExecutionRequestedAt(),
+                        "AI Worker não consumiu job pendente do GeraLanding",
+                        "GERALANDING_QUEUE_STALE",
+                        lastError));
+            }
+        }
+        return Optional.empty();
+    }
+
+    /** Converte incidente sintético para resposta administrativa sem persistir novo estado operacional. */
+    private ModuleIncidentResponse toIncidentResponse(SyntheticIncident incident) {
+        return new ModuleIncidentResponse(null, incident.moduleCode(), incident.moduleName(), incident.status(),
+                incident.severity(), incident.startedAt(), null, null, incident.summary(), incident.rootSignal(),
+                incident.lastError());
     }
 
     /** Converte entidade de incidente para resposta administrativa. */
@@ -170,3 +248,7 @@ public class OpsMonitorService {
                 incident.getSummary(), incident.getRootSignal(), incident.getLastError());
     }
 }
+
+/** Incidente calculado a partir de filas persistidas para destacar falha visível ao usuário. */
+record SyntheticIncident(String moduleCode, String moduleName, String type, String criticality, String status,
+        String severity, Instant startedAt, String summary, String rootSignal, String lastError) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/geralanding/GeraLandingStageExecutionRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/geralanding/GeraLandingStageExecutionRepository.java
@@ -4,6 +4,7 @@ import com.marketinghub.geralanding.GeraLandingStageExecution;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 
@@ -33,6 +34,12 @@ public interface GeraLandingStageExecutionRepository extends JpaRepository<GeraL
     @EntityGraph(attributePaths = {"experiment", "experiment.hypothesisRef"})
     List<GeraLandingStageExecution> findTop20ByStageCodeAndStatusOrderByExecutionRequestedAtAsc(String stageCode,
                                                                                                 String status);
+
+    /** Lista execuções iniciadas antigas de uma etapa para diagnóstico operacional do worker. */
+    List<GeraLandingStageExecution> findTop20ByStageCodeAndStatusAndExecutionRequestedAtBeforeOrderByExecutionRequestedAtAsc(
+            String stageCode,
+            String status,
+            Instant executionRequestedAtBefore);
 
     /** Lista as últimas vinte execuções de uma etapa dentro de um experimento. */
     List<GeraLandingStageExecution>

--- a/backend/ads-service/src/test/java/com/marketinghub/opsmonitor/service/OpsMonitorServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/opsmonitor/service/OpsMonitorServiceTest.java
@@ -3,11 +3,15 @@ package com.marketinghub.opsmonitor.service;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Mockito.when;
 
+import com.marketinghub.geralanding.GeraLandingStageExecution;
 import com.marketinghub.opsmonitor.OpsMonitoredModule;
+import com.marketinghub.repository.jpa.geralanding.GeraLandingStageExecutionRepository;
 import com.marketinghub.repository.jpa.opsmonitor.OpsModuleAvailabilityDailyRepository;
 import com.marketinghub.repository.jpa.opsmonitor.OpsModuleHealthCheckRepository;
 import com.marketinghub.repository.jpa.opsmonitor.OpsModuleIncidentRepository;
 import com.marketinghub.repository.jpa.opsmonitor.OpsMonitoredModuleRepository;
+import java.nio.charset.StandardCharsets;
+import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.Test;
@@ -30,6 +34,9 @@ class OpsMonitorServiceTest {
     @Mock
     private OpsModuleAvailabilityDailyRepository availabilityDailyRepository;
 
+    @Mock
+    private GeraLandingStageExecutionRepository geraLandingStageExecutionRepository;
+
     /** Garante que o pending retorna somente módulos habilitados pelo cadastro operacional. */
     @Test
     void listPendingChecksReturnsEnabledModules() {
@@ -45,7 +52,8 @@ class OpsMonitorServiceTest {
         when(moduleRepository.findByEnabledTrueOrderByCodeAsc()).thenReturn(List.of(module));
 
         OpsMonitorService service = new OpsMonitorService(
-                moduleRepository, healthCheckRepository, incidentRepository, availabilityDailyRepository);
+                moduleRepository, healthCheckRepository, incidentRepository, availabilityDailyRepository,
+                geraLandingStageExecutionRepository);
 
         var pending = service.listPendingChecks();
 
@@ -72,12 +80,43 @@ class OpsMonitorServiceTest {
         when(healthCheckRepository.findTop1ByModuleCodeOrderByCheckedAtDesc("ai-worker")).thenReturn(Optional.empty());
 
         OpsMonitorService service = new OpsMonitorService(
-                moduleRepository, healthCheckRepository, incidentRepository, availabilityDailyRepository);
+                moduleRepository, healthCheckRepository, incidentRepository, availabilityDailyRepository,
+                geraLandingStageExecutionRepository);
 
         var filtered = service.listAvailability("CRITICAL", "WORKER");
 
         assertThat(filtered).hasSize(1);
         assertThat(filtered.getFirst().moduleCode()).isEqualTo("ai-worker");
+    }
+
+    /** Garante que fila antiga de GeraLanding aparece como incidente do AI Worker. */
+    @Test
+    void listIncidentsAddsSyntheticAiWorkerQueueIncident() {
+        GeraLandingStageExecution execution = GeraLandingStageExecution.builder()
+                .experimentId(48L)
+                .stageCode("landing-page-wireframe")
+                .status("INICIADO")
+                .executionRequestedAt(Instant.now().minusSeconds(600))
+                .idJob("job-stale".getBytes(StandardCharsets.UTF_8))
+                .build();
+        when(incidentRepository.findByStatusOrderByStartedAtDesc("OPEN")).thenReturn(List.of());
+        when(geraLandingStageExecutionRepository
+                .findTop20ByStageCodeAndStatusAndExecutionRequestedAtBeforeOrderByExecutionRequestedAtAsc(
+                        org.mockito.ArgumentMatchers.eq("landing-page-wireframe"),
+                        org.mockito.ArgumentMatchers.eq("INICIADO"),
+                        org.mockito.ArgumentMatchers.any(Instant.class)))
+                .thenReturn(List.of(execution));
+
+        OpsMonitorService service = new OpsMonitorService(
+                moduleRepository, healthCheckRepository, incidentRepository, availabilityDailyRepository,
+                geraLandingStageExecutionRepository);
+
+        var incidents = service.listIncidents(true, "CRITICAL", "WORKER");
+
+        assertThat(incidents).hasSize(1);
+        assertThat(incidents.getFirst().moduleCode()).isEqualTo("ai-worker");
+        assertThat(incidents.getFirst().rootSignal()).isEqualTo("GERALANDING_QUEUE_STALE");
+        assertThat(incidents.getFirst().lastError()).contains("job-stale");
     }
 
 }

--- a/docs/registros/ops-monitor.md
+++ b/docs/registros/ops-monitor.md
@@ -5,3 +5,10 @@
 - Causa-raiz: a tela de operação mostrava todos os módulos como `Sem verificação recente` porque não havia registros em `ops_module_health_check`.
 - Ajuste: o `ops-monitor-worker` passou a consumir o endpoint canônico de pendências, executar health check periódico e registrar heartbeat no backend.
 - Prevenção: teste unitário garante que o runner consome pendências e chama o contrato de heartbeat.
+
+## 2026-06-24 — Incidente sintético para fila GeraLanding parada no AI Worker
+
+- Problema observado: job de GeraLanding em `INICIADO` sem `processing_started_at` não aparecia como problema específico na tela `/ops-monitor`.
+- Causa-raiz tratada: o Ops Monitor dependia apenas de heartbeats/incidentes reportados pelo worker; quando o próprio consumo da fila falhava, a tela não destacava a fila parada.
+- Ajuste: o backend passou a expor incidente sintético do `ai-worker` quando houver execução GeraLanding antiga em `INICIADO`, mantendo o backend apenas como leitura/relatório de estado persistido.
+- Prevenção: teste unitário cobre a criação do incidente sintético `GERALANDING_QUEUE_STALE`.


### PR DESCRIPTION
### Motivation
- Make stalled GeraLanding jobs visible in the operational UI by surfacing a synthetic incident for the `ai-worker` when executions remain in `INICIADO` without processing for a configured threshold.

### Description
- Injected `GeraLandingStageExecutionRepository` into `OpsMonitorService` and added constants and a list of relevant GeraLanding stage codes used to detect stale queue items.
- Implemented `syntheticAiWorkerQueueIncident` to scan for old `GeraLandingStageExecution` records and produce an in-memory `SyntheticIncident` describing a `GERALANDING_QUEUE_STALE` root cause without persisting state.
- Included the synthetic incident in `listIncidents`, in the executive `getSummary` open-incident count, and in `toAvailabilityResponse` so `ai-worker` can be shown as `DEGRADED` when appropriate.
- Added a repository query `findTop20ByStageCodeAndStatusAndExecutionRequestedAtBeforeOrderByExecutionRequestedAtAsc` to support the stale-execution lookup and introduced the `SyntheticIncident` record type.

### Testing
- Updated `OpsMonitorServiceTest` to inject a mocked `GeraLandingStageExecutionRepository` and added `listIncidentsAddsSyntheticAiWorkerQueueIncident` unit test which verifies the synthetic incident is emitted and contains `GERALANDING_QUEUE_STALE` and the job id; this test passed.
- Existing unit tests `listPendingChecksReturnsEnabledModules` and `listAvailabilityFiltersByCriticalityAndType` were updated to construct the service with the new repository and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3b503e172483219856ee63716b593d)