### PR TITLE
Align audience checklist with Facebook Ads release rule and update UI messaging

### DIFF
--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -5220,3 +5220,8 @@
 - causa-raiz: todos os eventos de analytics da landing eram gravados em `experiment_funnel_event` na etapa `VISUALIZACAO_FORM`, e a consolidação somava qualquer evento dessa origem, inflando o funil.
 - evidência operacional: no experimento 41, o banco tinha 45 eventos nessa etapa, mas apenas 13 eram `page_view`; os demais eram eventos técnicos de analytics e não deveriam virar novas visualizações do formulário.
 - prevenção de recorrência: teste unitário garante que a consulta do resumo filtra `landing-page-analytics` por `eventType=page_view`.
+
+## 2026-06-24 — Checklist de público alinhado à liberação Facebook Ads
+- Problema: no experimento 48, o card “Escolha de público” do checklist principal ficava pendente mesmo quando a seção “Campanha de Facebook Ads” já estava pronta para liberação.
+- Causa-raiz: o card usava o resumo de prontidão de targeting (`hasCompleteTargeting`), enquanto a liberação para o Facebook Ads na tela usa os bloqueios de publicação consolidados de criativo aprovado e landing ativa.
+- Correção aplicada: o card “Escolha de público” passou a refletir a mesma regra operacional de liberação exibida na seção Facebook Ads, evitando sinal visual contraditório para o usuário.

--- a/frontend/src/pages/experiment/ExperimentDetailPage.tsx
+++ b/frontend/src/pages/experiment/ExperimentDetailPage.tsx
@@ -1963,7 +1963,8 @@ export default function ExperimentDetailPage() {
   const geraLandingRequiredStageCount =
     readinessSummary?.geraLandingRequiredStageCount ?? 7;
   const hasAtLeastThreeApprovedCreatives = readinessCreativeCount >= 3;
-  const hasAudienceSelection = readinessSummary?.hasCompleteTargeting ?? false;
+  const hasAudienceSelection =
+    hasCreativesReady && Boolean(data.followUpActionUrl);
   const mainExperimentChecklist = [
     {
       id: "experiment-pipeline",
@@ -2011,8 +2012,8 @@ export default function ExperimentDetailPage() {
       id: "audience-selection",
       title: "Escolha de público",
       detail: hasAudienceSelection
-        ? "Público completo selecionado"
-        : "Selecione interesses, comportamentos e dados demográficos",
+        ? "Atende a mesma regra de liberação para Facebook Ads"
+        : "Conclua os bloqueios usados para liberar o Facebook Ads",
       isMet: hasAudienceSelection,
       isLoading: isLoadingReadiness,
       actionLabel: "Abrir público",


### PR DESCRIPTION
### Motivation
- Prevent the main checklist from showing a contradictory "Escolha de público" status when the Facebook Ads section already meets its release blockers. 
- Make the checklist reflect the same operational rule used to allow Facebook Ads releases instead of relying on a separate targeting summary flag.

### Description
- Replace the audience readiness predicate from `readinessSummary?.hasCompleteTargeting` to `hasCreativesReady && Boolean(data.followUpActionUrl)` in `ExperimentDetailPage.tsx` so the checklist follows the Facebook Ads release rule. 
- Update the checklist detail text for the "Escolha de público" card to match the new rule and provide clearer guidance to the user. 
- Add an entry to `docs/registros/experimentos.md` documenting the change to the audience checklist behavior.

### Testing
- Ran frontend unit tests with `yarn test` and they passed. 
- Performed a TypeScript check and local build with `yarn build`/`tsc` which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3b49fdc0008321a891f1577b248ab6)