### PR TITLE
Reset funnel when campaign impressions start

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentCampaignMetricService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentCampaignMetricService.java
@@ -3,6 +3,9 @@ package com.marketinghub.experiment.service;
 import com.marketinghub.experiment.Experiment;
 import com.marketinghub.experiment.ExperimentCampaignMetric;
 import com.marketinghub.repository.jpa.experiment.ExperimentCampaignMetricRepository;
+import com.marketinghub.repository.jpa.experiment.ExperimentRepository;
+import com.marketinghub.repository.jpa.experiment.funnel.ExperimentFunnelEventRepository;
+import com.marketinghub.repository.jpa.experiment.funnel.ExperimentLandingAnalyticsEventRepository;
 import com.marketinghub.facebookads.FacebookAdsCampaign;
 import com.marketinghub.cost.CostAttributionService;
 import com.marketinghub.repository.jpa.facebookads.FacebookAdsCampaignRepository;
@@ -11,6 +14,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.math.BigDecimal;
 import java.math.RoundingMode;
+import java.time.Instant;
 import java.time.LocalDate;
 
 /**
@@ -21,16 +25,25 @@ public class ExperimentCampaignMetricService {
     private final ExperimentCampaignMetricRepository repository;
     private final FacebookAdsCampaignRepository campaignRepository;
     private final CostAttributionService costAttributionService;
+    private final ExperimentRepository experimentRepository;
+    private final ExperimentFunnelEventRepository funnelEventRepository;
+    private final ExperimentLandingAnalyticsEventRepository landingAnalyticsEventRepository;
 
     /**
      * Inicializa o serviço com repositórios de campanha, métricas e atribuição de custo.
      */
     public ExperimentCampaignMetricService(ExperimentCampaignMetricRepository repository,
                                            FacebookAdsCampaignRepository campaignRepository,
-                                           CostAttributionService costAttributionService) {
+                                           CostAttributionService costAttributionService,
+                                           ExperimentRepository experimentRepository,
+                                           ExperimentFunnelEventRepository funnelEventRepository,
+                                           ExperimentLandingAnalyticsEventRepository landingAnalyticsEventRepository) {
         this.repository = repository;
         this.campaignRepository = campaignRepository;
         this.costAttributionService = costAttributionService;
+        this.experimentRepository = experimentRepository;
+        this.funnelEventRepository = funnelEventRepository;
+        this.landingAnalyticsEventRepository = landingAnalyticsEventRepository;
     }
 
     /**
@@ -53,7 +66,9 @@ public class ExperimentCampaignMetricService {
                 .orElseGet(() -> ExperimentCampaignMetric.builder()
                         .experiment(experiment)
                         .build());
+        Long previousImpressions = metric.getImpressions();
         BigDecimal previousSpend = metric.getSpend();
+        resetTestFunnelWhenImpressionsStart(experiment, previousImpressions, impressions);
         metric.setCampaign(campaign);
         metric.setDateStart(dateStart);
         metric.setDateStop(dateStop);
@@ -67,6 +82,28 @@ public class ExperimentCampaignMetricService {
         ExperimentCampaignMetric saved = repository.save(metric);
         applySpendDelta(experiment, normalizedSpend, previousSpend);
         return saved;
+    }
+
+    /**
+     * Remove automaticamente eventos de teste quando a campanha começa a receber impressões reais.
+     */
+    private void resetTestFunnelWhenImpressionsStart(
+            Experiment experiment, Long previousImpressions, Long newImpressions) {
+        if (experiment == null || experiment.getId() == null) {
+            return;
+        }
+        long previous = previousImpressions == null ? 0L : previousImpressions;
+        long current = newImpressions == null ? 0L : newImpressions;
+        if (previous > 0 || current <= 0) {
+            return;
+        }
+        landingAnalyticsEventRepository.deleteByExperimentId(experiment.getId());
+        funnelEventRepository.deleteByExperimentIdAndSource(
+                experiment.getId(),
+                ExperimentFunnelEventRepository.LANDING_PAGE_ANALYTICS_SOURCE);
+        funnelEventRepository.deleteByExperimentId(experiment.getId());
+        experiment.setFunnelResetAt(Instant.now());
+        experimentRepository.save(experiment);
     }
 
     /**

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/service/ExperimentCampaignMetricServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/service/ExperimentCampaignMetricServiceTest.java
@@ -1,0 +1,144 @@
+package com.marketinghub.experiment.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.marketinghub.cost.CostAttributionService;
+import com.marketinghub.experiment.Experiment;
+import com.marketinghub.experiment.ExperimentCampaignMetric;
+import com.marketinghub.facebookads.FacebookAdsCampaign;
+import com.marketinghub.repository.jpa.experiment.ExperimentCampaignMetricRepository;
+import com.marketinghub.repository.jpa.experiment.ExperimentRepository;
+import com.marketinghub.repository.jpa.experiment.funnel.ExperimentFunnelEventRepository;
+import com.marketinghub.repository.jpa.experiment.funnel.ExperimentLandingAnalyticsEventRepository;
+import com.marketinghub.repository.jpa.facebookads.FacebookAdsCampaignRepository;
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.time.LocalDate;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InOrder;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/**
+ * Testa a sincronização de métricas de campanha com o marco comercial real do funil.
+ */
+@ExtendWith(MockitoExtension.class)
+class ExperimentCampaignMetricServiceTest {
+
+    @Mock
+    private ExperimentCampaignMetricRepository repository;
+
+    @Mock
+    private FacebookAdsCampaignRepository campaignRepository;
+
+    @Mock
+    private CostAttributionService costAttributionService;
+
+    @Mock
+    private ExperimentRepository experimentRepository;
+
+    @Mock
+    private ExperimentFunnelEventRepository funnelEventRepository;
+
+    @Mock
+    private ExperimentLandingAnalyticsEventRepository landingAnalyticsEventRepository;
+
+    private ExperimentCampaignMetricService service;
+
+    /** Monta o serviço real com repositórios controlados por mock. */
+    @BeforeEach
+    void setUp() {
+        service = new ExperimentCampaignMetricService(
+                repository,
+                campaignRepository,
+                costAttributionService,
+                experimentRepository,
+                funnelEventRepository,
+                landingAnalyticsEventRepository);
+    }
+
+    /**
+     * Garante que o primeiro recebimento de impressões remove eventos de teste antes de salvar a métrica real.
+     */
+    @Test
+    void upsertResetsFunnelWhenImpressionsStart() {
+        Experiment experiment = Experiment.builder().id(41L).build();
+        FacebookAdsCampaign campaign = new FacebookAdsCampaign();
+        campaign.setId("campaign-1");
+        campaign.setExperiment(experiment);
+        ExperimentCampaignMetric savedMetric = ExperimentCampaignMetric.builder().experiment(experiment).build();
+
+        when(campaignRepository.findById("campaign-1")).thenReturn(Optional.of(campaign));
+        when(repository.findByExperiment(experiment)).thenReturn(Optional.empty());
+        when(repository.save(any(ExperimentCampaignMetric.class))).thenReturn(savedMetric);
+
+        service.upsert(
+                "campaign-1",
+                LocalDate.parse("2026-06-24"),
+                LocalDate.parse("2026-06-24"),
+                10L,
+                194L,
+                3L,
+                0L,
+                new BigDecimal("1.10"));
+
+        InOrder inOrder = inOrder(
+                landingAnalyticsEventRepository,
+                funnelEventRepository,
+                experimentRepository,
+                repository);
+        inOrder.verify(landingAnalyticsEventRepository).deleteByExperimentId(41L);
+        inOrder.verify(funnelEventRepository).deleteByExperimentIdAndSource(
+                41L,
+                ExperimentFunnelEventRepository.LANDING_PAGE_ANALYTICS_SOURCE);
+        inOrder.verify(funnelEventRepository).deleteByExperimentId(41L);
+        inOrder.verify(experimentRepository).save(experiment);
+        inOrder.verify(repository).save(any(ExperimentCampaignMetric.class));
+        assertThat(experiment.getFunnelResetAt()).isNotNull();
+    }
+
+    /**
+     * Garante que uma métrica que já tinha impressões não limpa novamente o funil em sincronizações posteriores.
+     */
+    @Test
+    void upsertDoesNotResetFunnelWhenMetricAlreadyHadImpressions() {
+        Experiment experiment = Experiment.builder()
+                .id(41L)
+                .funnelResetAt(Instant.parse("2026-06-24T00:00:00Z"))
+                .build();
+        FacebookAdsCampaign campaign = new FacebookAdsCampaign();
+        campaign.setId("campaign-1");
+        campaign.setExperiment(experiment);
+        ExperimentCampaignMetric existingMetric = ExperimentCampaignMetric.builder()
+                .experiment(experiment)
+                .impressions(100L)
+                .spend(BigDecimal.ZERO)
+                .build();
+
+        when(campaignRepository.findById("campaign-1")).thenReturn(Optional.of(campaign));
+        when(repository.findByExperiment(experiment)).thenReturn(Optional.of(existingMetric));
+        when(repository.save(existingMetric)).thenReturn(existingMetric);
+
+        service.upsert(
+                "campaign-1",
+                LocalDate.parse("2026-06-24"),
+                LocalDate.parse("2026-06-24"),
+                10L,
+                194L,
+                3L,
+                0L,
+                BigDecimal.ZERO);
+
+        verify(landingAnalyticsEventRepository, never()).deleteByExperimentId(41L);
+        verify(funnelEventRepository, never()).deleteByExperimentId(any());
+        verify(experimentRepository, never()).save(experiment);
+    }
+}

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -5220,3 +5220,9 @@
 - causa-raiz: todos os eventos de analytics da landing eram gravados em `experiment_funnel_event` na etapa `VISUALIZACAO_FORM`, e a consolidação somava qualquer evento dessa origem, inflando o funil.
 - evidência operacional: no experimento 41, o banco tinha 45 eventos nessa etapa, mas apenas 13 eram `page_view`; os demais eram eventos técnicos de analytics e não deveriam virar novas visualizações do formulário.
 - prevenção de recorrência: teste unitário garante que a consulta do resumo filtra `landing-page-analytics` por `eventType=page_view`.
+
+## 2026-06-24 — Reset automático do funil ao iniciar impressões reais
+
+- solicitação: evitar que eventos de teste continuem misturados quando a campanha começa a receber valores reais de impressão.
+- causa-raiz: o reset manual/publicação limpava dados em alguns momentos, mas não existia proteção automática no primeiro recebimento efetivo de impressões do Facebook; assim eventos prévios podiam permanecer visíveis no funil depois que a mídia começava a rodar.
+- foi feito: a sincronização de métricas de campanha agora detecta a transição de zero para impressões reais, apaga eventos de funil/analytics de teste e grava novo marco temporal antes de salvar a métrica real.


### PR DESCRIPTION
### Motivation
- Evitar que eventos de teste permaneçam misturados no funil quando uma campanha começa a receber impressões reais, garantindo que as métricas comerciais reflitam apenas dados de produção.

### Description
- Implementa em `ExperimentCampaignMetricService` a detecção da transição de zero → impressões reais e adiciona `resetTestFunnelWhenImpressionsStart(...)` que apaga `landing` analytics e eventos do funil e grava `experiment.funnelResetAt` antes de salvar a métrica real.
- Chama a rotina de reset no início de `upsert(...)` usando a impressão anterior persistida para decidir se deve limpar os dados de teste.
- Adiciona `ExperimentCampaignMetricServiceTest` com dois cenários: (1) primeiro recebimento de impressões limpa o funil; (2) subsequentes sincronizações não disparam novo reset.
- Atualiza `docs/registros/experimentos.md` registrando a mudança e a causa-raiz identificada.

### Testing
- Executado `./../mvnw -Dtest=ExperimentCampaignMetricServiceTest test` no módulo `backend/ads-service`, com a classe de teste `ExperimentCampaignMetricServiceTest` (2 testes) passando com `BUILD SUCCESS`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3b540af5b48321b6e462bf2b11796f)