### PR TITLE
Add ops-monitor-worker service, MCP log integration, Docker artifacts and CI/CD workflow

### DIFF
--- a/.github/workflows/ops-monitor-worker-ci.yml
+++ b/.github/workflows/ops-monitor-worker-ci.yml
@@ -1,0 +1,122 @@
+name: CI - Ops Monitor Worker
+
+on:
+  push:
+    branches: ["main"]
+    paths:
+      - "ops-monitor-worker/**"
+      - ".github/workflows/ops-monitor-worker-ci.yml"
+  pull_request:
+    branches: ["main"]
+    paths:
+      - "ops-monitor-worker/**"
+      - ".github/workflows/ops-monitor-worker-ci.yml"
+  workflow_dispatch:
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}/ops-monitor-worker
+
+jobs:
+  test:
+    name: Test (Ops Monitor Worker)
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Java 21
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: '21'
+          cache: maven
+
+      - name: Maven test
+        working-directory: ops-monitor-worker
+        run: mvn -B test
+
+  build-and-push:
+    name: Build and Push Image (Ops Monitor Worker)
+    runs-on: ubuntu-latest
+    needs: test
+    if: github.event_name != 'pull_request'
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=raw,value=sha-${{ github.sha }}
+            type=raw,value=latest
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: ./ops-monitor-worker
+          file: ./ops-monitor-worker/Dockerfile
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+
+  deploy:
+    name: Deploy (Ops Monitor Worker)
+    runs-on: ubuntu-latest
+    needs: build-and-push
+    if: github.ref == 'refs/heads/main'
+    environment: production
+    env:
+      DEPLOY_HOST: 191.252.120.96
+      DEPLOY_USER: root
+      REMOTE_PATH: /root/ops-monitor-worker
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Prepare SSH
+        env:
+          VPS_SSH_KEY: ${{ secrets.VPS_SSH_CHAVE != '' && secrets.VPS_SSH_CHAVE || secrets.VPS_SSH_KEY != '' && secrets.VPS_SSH_KEY || secrets.SSH_PRIVATE_KEY }}
+        run: |
+          if [ -z "${VPS_SSH_KEY}" ]; then
+            echo "Erro: nenhuma chave SSH foi encontrada nos secrets esperados." >&2
+            exit 1
+          fi
+          install -m 700 -d ~/.ssh
+          printf '%s\n' "${VPS_SSH_KEY}" > ~/.ssh/id_ed25519
+          chmod 600 ~/.ssh/id_ed25519
+          ssh-keyscan -H "$DEPLOY_HOST" >> ~/.ssh/known_hosts
+          printf '%s\n' "SSH_COMMON_ARGS=-i $HOME/.ssh/id_ed25519 -o StrictHostKeyChecking=yes -o ServerAliveInterval=60 -o ServerAliveCountMax=10 -o TCPKeepAlive=yes -o ConnectTimeout=60" >> "$GITHUB_ENV"
+
+      - name: Sync project files
+        run: |
+          ssh ${SSH_COMMON_ARGS} "${DEPLOY_USER}@${DEPLOY_HOST}" "mkdir -p ${REMOTE_PATH}"
+          rsync -az --delete -e "ssh ${SSH_COMMON_ARGS}" --exclude '.git' --exclude 'target' --exclude '.idea' --exclude '.vscode' --exclude '.DS_Store' \
+            ops-monitor-worker/ "${DEPLOY_USER}@${DEPLOY_HOST}:${REMOTE_PATH}"
+
+      - name: Deploy with Docker Compose
+        run: |
+          ssh ${SSH_COMMON_ARGS} "${DEPLOY_USER}@${DEPLOY_HOST}" "set -euo pipefail \
+            && cd ${REMOTE_PATH} \
+            && export OPS_MONITOR_WORKER_IMAGE=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}:sha-${GITHUB_SHA} \
+            && export COMPOSE_PROJECT_NAME=marketinghub-ops-monitor-worker \
+            && docker login ${{ env.REGISTRY }} -u ${{ github.actor }} -p ${{ secrets.GITHUB_TOKEN }} \
+            && docker compose -f docker-compose.yml -f docker-compose.deploy.yml pull \
+            && docker compose -f docker-compose.yml -f docker-compose.deploy.yml up -d --remove-orphans \
+            && docker image prune -af"

--- a/docs/registros/ops-monitor.md
+++ b/docs/registros/ops-monitor.md
@@ -12,3 +12,9 @@
 - Causa-raiz tratada: o Ops Monitor dependia apenas de heartbeats/incidentes reportados pelo worker; quando o próprio consumo da fila falhava, a tela não destacava a fila parada.
 - Ajuste: o backend passou a expor incidente sintético do `ai-worker` quando houver execução GeraLanding antiga em `INICIADO`, mantendo o backend apenas como leitura/relatório de estado persistido.
 - Prevenção: teste unitário cobre a criação do incidente sintético `GERALANDING_QUEUE_STALE`.
+
+## 2026-06-24 — Observabilidade e publicação do ops-monitor-worker
+
+- Causa-raiz tratada: o `ops-monitor-worker` não tinha exposição de logfile própria no Actuator, não estava listado na tool `java_module_logs` do MCP Server e não havia workflow dedicado de publicação.
+- Ajuste: o worker passou a expor `/actuator/logfile`, o MCP passou a aceitar o módulo `ops-monitor-worker` e foi criado workflow de teste, build, push e deploy para publicação do executor.
+- Prevenção: teste de contrato do MCP valida leitura dos logs do `ops-monitor-worker`.

--- a/mcp-server/AGENTS.md
+++ b/mcp-server/AGENTS.md
@@ -15,6 +15,7 @@ Manter os seguintes endpoints como defaults de origem de logs no módulo `mcp-se
 - Mois Coletor Hotmart: `http://177.153.62.107:8096/ops-monitor/mois-hotmart-log`
 - Clickbank Coletor Mois: `http://177.153.62.107:9096/internal/ops-monitor/logfile`
 - OPRM Coletor Receita: `http://177.153.62.107:8094/actuator/logfile`
+- Ops Monitor Worker: `http://191.252.120.96:8098/actuator/logfile`
 
 Sempre que houver alteração desses endpoints, atualizar em conjunto:
 

--- a/mcp-server/README.md
+++ b/mcp-server/README.md
@@ -17,7 +17,7 @@ Servidor MCP (Model Context Protocol) do Marketing Hub para execução de ferram
 - `db_list_tables`: lista todas as tabelas disponíveis no schema atual.
 - `db_read_table`: lê dados de uma tabela com paginação (`table`, `limit`, `offset`).
 - `db_query`: executa SQL de leitura (`SELECT`/`WITH`) com limite de linhas.
-- `java_module_logs`: retorna logs do Spring Boot com filtros opcionais por texto/intervalo e paginação (`lines`, `contains`, `from`, `to`, `offset`, `cursor`) para os módulos Java (`backend`, `ai-worker`, `lead-portal`, `facebook-ads`, `email-service`, `lead-portal-payment`, `mds`, `mois`, `mois-sales-library-worker`, `mois-hotmart`, `clickbank-coletor-mois`, `oprm-coletor-receita`).
+- `java_module_logs`: retorna logs do Spring Boot com filtros opcionais por texto/intervalo e paginação (`lines`, `contains`, `from`, `to`, `offset`, `cursor`) para os módulos Java (`backend`, `ai-worker`, `lead-portal`, `facebook-ads`, `email-service`, `lead-portal-payment`, `mds`, `mois`, `mois-sales-library-worker`, `mois-hotmart`, `clickbank-coletor-mois`, `oprm-coletor-receita`, `ops-monitor-worker`).
 - `meta_docs_get`: busca páginas de documentação da Meta em hosts aprovados.
 - `meta_graph_get`: executa leitura (`GET`) da Graph API com token configurado no MCP.
 - `meta_graph_debug_token`: executa `debug_token` para validar tokens.
@@ -58,7 +58,8 @@ O tool `java_module_logs` lê logs do Spring Boot a partir de arquivo local **ou
 - `MCP_LOG_MOIS_SALES_LIBRARY_WORKER_PATH` (MOIS Sales Library Worker; default `http://191.252.120.96:8097/actuator/logfile`);
 - `MCP_LOG_MOIS_HOTMART_PATH` (default `http://177.153.62.107:8096/ops-monitor/mois-hotmart-log`);
 - `MCP_LOG_CLICKBANK_COLETOR_MOIS_PATH` (default `http://177.153.62.107:9096/internal/ops-monitor/logfile`);
-- `MCP_LOG_OPRM_COLETOR_RECEITA_PATH` (default `http://177.153.62.107:8094/actuator/logfile`).
+- `MCP_LOG_OPRM_COLETOR_RECEITA_PATH` (default `http://177.153.62.107:8094/actuator/logfile`);
+- `MCP_LOG_OPS_MONITOR_WORKER_PATH` (default `http://191.252.120.96:8098/actuator/logfile`).
 - `MCP_LOG_FETCH_TIMEOUT_SECONDS` (default `45`);
 - `MCP_LOG_FETCH_ATTEMPTS` (default `3`), número de tentativas para leitura HTTP de logs;
 - `MCP_LOG_FETCH_RETRY_DELAY_MILLIS` (default `400`), intervalo entre tentativas de leitura HTTP;

--- a/mcp-server/src/main/java/com/marketinghub/mcpserver/config/McpProperties.java
+++ b/mcp-server/src/main/java/com/marketinghub/mcpserver/config/McpProperties.java
@@ -38,6 +38,7 @@ public record McpProperties(
             @NotBlank String moisHotmartPath,
             @NotBlank String clickbankColetorMoisPath,
             @NotBlank String oprmColetorReceitaPath,
+            @NotBlank String opsMonitorWorkerPath,
             @Positive int fetchTimeoutSeconds,
             @Positive int fetchAttempts,
             @Positive int fetchRetryDelayMillis,

--- a/mcp-server/src/main/java/com/marketinghub/mcpserver/controller/McpController.java
+++ b/mcp-server/src/main/java/com/marketinghub/mcpserver/controller/McpController.java
@@ -35,7 +35,7 @@ public class McpController {
     private static final int MAX_QUERY_LIMIT = 500;
     private static final List<String> JAVA_LOG_MODULES = List.of("backend", "ai-worker", "lead-portal", "facebook-ads",
             "email-service", "lead-portal-payment", "mds", "mois", "mois-sales-library-worker",
-            "mois-hotmart", "clickbank-coletor-mois", "oprm-coletor-receita");
+            "mois-hotmart", "clickbank-coletor-mois", "oprm-coletor-receita", "ops-monitor-worker");
 
     private final McpProperties properties;
     private final DatabaseDiagnosticsService databaseDiagnosticsService;
@@ -136,7 +136,7 @@ public class McpController {
                     ),
                     Map.of(
                             "name", "java_module_logs",
-                            "description", "Retorna as últimas linhas de logs do Spring Boot dos módulos Java (backend, ai-worker, lead-portal, facebook-ads, email-service, lead-portal-payment, mds, mois, mois-sales-library-worker, mois-hotmart, clickbank-coletor-mois, oprm-coletor-receita).",
+                            "description", "Retorna as últimas linhas de logs do Spring Boot dos módulos Java (backend, ai-worker, lead-portal, facebook-ads, email-service, lead-portal-payment, mds, mois, mois-sales-library-worker, mois-hotmart, clickbank-coletor-mois, oprm-coletor-receita, ops-monitor-worker).",
                             "inputSchema", Map.of(
                                     "type", "object",
                                     "properties", Map.of(

--- a/mcp-server/src/main/java/com/marketinghub/mcpserver/service/ModuleLogService.java
+++ b/mcp-server/src/main/java/com/marketinghub/mcpserver/service/ModuleLogService.java
@@ -255,6 +255,7 @@ public class ModuleLogService {
             case "mois-hotmart" -> properties.logs().moisHotmartPath();
             case "clickbank-coletor-mois" -> properties.logs().clickbankColetorMoisPath();
             case "oprm-coletor-receita" -> properties.logs().oprmColetorReceitaPath();
+            case "ops-monitor-worker" -> properties.logs().opsMonitorWorkerPath();
             default -> throw new IllegalArgumentException("Unknown module: " + module);
         };
     }
@@ -270,10 +271,10 @@ public class ModuleLogService {
         return switch (normalized) {
             case "backend", "ai-worker", "lead-portal", "facebook-ads", "email-service", "lead-portal-payment",
                     "mds", "mois", "mois-sales-library-worker", "mois-hotmart", "clickbank-coletor-mois",
-                    "oprm-coletor-receita" -> normalized;
+                    "oprm-coletor-receita", "ops-monitor-worker" -> normalized;
             default -> throw new IllegalArgumentException("module must be one of: backend, ai-worker, lead-portal, "
                     + "facebook-ads, email-service, lead-portal-payment, mds, mois, mois-sales-library-worker, "
-                    + "mois-hotmart, clickbank-coletor-mois, oprm-coletor-receita");
+                    + "mois-hotmart, clickbank-coletor-mois, oprm-coletor-receita, ops-monitor-worker");
         };
     }
 

--- a/mcp-server/src/main/resources/application.yml
+++ b/mcp-server/src/main/resources/application.yml
@@ -53,6 +53,7 @@ mcp:
     mois-hotmart-path: ${MCP_LOG_MOIS_HOTMART_PATH:http://177.153.62.107:8096/ops-monitor/mois-hotmart-log}
     clickbank-coletor-mois-path: ${MCP_LOG_CLICKBANK_COLETOR_MOIS_PATH:http://177.153.62.107:9096/internal/ops-monitor/logfile}
     oprm-coletor-receita-path: ${MCP_LOG_OPRM_COLETOR_RECEITA_PATH:http://177.153.62.107:8094/actuator/logfile}
+    ops-monitor-worker-path: ${MCP_LOG_OPS_MONITOR_WORKER_PATH:http://191.252.120.96:8098/actuator/logfile}
     fetch-timeout-seconds: ${MCP_LOG_FETCH_TIMEOUT_SECONDS:45}
     fetch-attempts: ${MCP_LOG_FETCH_ATTEMPTS:3}
     fetch-retry-delay-millis: ${MCP_LOG_FETCH_RETRY_DELAY_MILLIS:400}

--- a/mcp-server/src/test/java/com/marketinghub/mcpserver/controller/McpControllerTest.java
+++ b/mcp-server/src/test/java/com/marketinghub/mcpserver/controller/McpControllerTest.java
@@ -57,6 +57,7 @@ class McpControllerTest {
                 () -> TEST_LOG_DIR.resolve("mois-sales-library-worker.log").toString());
         registry.add("mcp.logs.mois-hotmart-path", () -> TEST_LOG_DIR.resolve("mois-hotmart.log").toString());
         registry.add("mcp.logs.oprm-coletor-receita-path", () -> TEST_LOG_DIR.resolve("oprm-coletor-receita.log").toString());
+        registry.add("mcp.logs.ops-monitor-worker-path", () -> TEST_LOG_DIR.resolve("ops-monitor-worker.log").toString());
         registry.add("mcp.logs.max-lines", () -> "500");
         registry.add("mcp.meta.enabled", () -> "false");
         registry.add("mcp.meta.graph-base-url", () -> "https://graph.facebook.com");
@@ -84,6 +85,9 @@ class McpControllerTest {
                 StandardCharsets.UTF_8);
         Files.writeString(TEST_LOG_DIR.resolve("mois-sales-library-worker.log"),
                 "mois-sales-library-worker-line-1\nmois-sales-library-worker-line-2\n",
+                StandardCharsets.UTF_8);
+        Files.writeString(TEST_LOG_DIR.resolve("ops-monitor-worker.log"),
+                "ops-monitor-worker-line-1\nops-monitor-worker-line-2\n",
                 StandardCharsets.UTF_8);
     }
 
@@ -239,6 +243,24 @@ class McpControllerTest {
     }
 
     /**
+     * Garante que o MCP expõe os logs do executor de monitoria operacional.
+     */
+    @Test
+    void shouldReadOpsMonitorWorkerLogs() throws Exception {
+        mockMvc.perform(post("/mcp")
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {"jsonrpc":"2.0","id":17,"method":"tools/call","params":{"name":"java_module_logs","arguments":{"module":"ops-monitor-worker","lines":1}}}
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.result.structuredContent.module").value("ops-monitor-worker"))
+                .andExpect(jsonPath("$.result.structuredContent.path")
+                        .value(TEST_LOG_DIR.resolve("ops-monitor-worker.log").toString()))
+                .andExpect(jsonPath("$.result.structuredContent.lines[0]")
+                        .value("ops-monitor-worker-line-2"));
+    }
+
+    /**
      * Garante que a tool java_module_logs rejeita módulos fora da lista permitida.
      */
     @Test
@@ -251,7 +273,7 @@ class McpControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.error.code").value(-32602))
                 .andExpect(jsonPath("$.error.message")
-                        .value("module must be one of: backend, ai-worker, lead-portal, facebook-ads, email-service, lead-portal-payment, mds, mois, mois-sales-library-worker, mois-hotmart, clickbank-coletor-mois, oprm-coletor-receita"));
+                        .value("module must be one of: backend, ai-worker, lead-portal, facebook-ads, email-service, lead-portal-payment, mds, mois, mois-sales-library-worker, mois-hotmart, clickbank-coletor-mois, oprm-coletor-receita, ops-monitor-worker"));
     }
 
 

--- a/mcp-server/src/test/java/com/marketinghub/mcpserver/service/MetaDiagnosticsServiceTest.java
+++ b/mcp-server/src/test/java/com/marketinghub/mcpserver/service/MetaDiagnosticsServiceTest.java
@@ -103,7 +103,7 @@ class MetaDiagnosticsServiceTest {
         return new McpProperties(
                 "marketing-hub-mcp",
                 "1.0.0",
-                new McpProperties.Logs("a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", 45, 3, 400, 500, 262144),
+                new McpProperties.Logs("a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", 45, 3, 400, 500, 262144),
                 new McpProperties.Meta(
                         true,
                         "https://graph.facebook.com",

--- a/mcp-server/src/test/java/com/marketinghub/mcpserver/service/MetaToolsServiceTest.java
+++ b/mcp-server/src/test/java/com/marketinghub/mcpserver/service/MetaToolsServiceTest.java
@@ -37,7 +37,7 @@ class MetaToolsServiceTest {
         McpProperties properties = new McpProperties(
                 "marketing-hub-mcp",
                 "1.0.0",
-                new McpProperties.Logs("a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", 45, 3, 400, 500, 262144),
+                new McpProperties.Logs("a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", 45, 3, 400, 500, 262144),
                 new McpProperties.Meta(
                         true,
                         "https://graph.facebook.com",

--- a/mcp-server/src/test/java/com/marketinghub/mcpserver/service/ModuleLogServiceTest.java
+++ b/mcp-server/src/test/java/com/marketinghub/mcpserver/service/ModuleLogServiceTest.java
@@ -80,6 +80,7 @@ class ModuleLogServiceTest {
                 logUrl,
                 logUrl,
                 logUrl,
+                logUrl,
                 2,
                 3,
                 1,

--- a/ops-monitor-worker/Dockerfile
+++ b/ops-monitor-worker/Dockerfile
@@ -1,0 +1,10 @@
+FROM maven:3.9.9-eclipse-temurin-21 AS build
+WORKDIR /app
+COPY pom.xml .
+COPY src ./src
+RUN mvn -q -DskipTests package
+
+FROM eclipse-temurin:21-jre
+WORKDIR /app
+COPY --from=build /app/target/app.jar app.jar
+ENTRYPOINT ["java","-jar","/app/app.jar"]

--- a/ops-monitor-worker/docker-compose.deploy.yml
+++ b/ops-monitor-worker/docker-compose.deploy.yml
@@ -1,0 +1,11 @@
+services:
+  ops-monitor-worker:
+    image: ${OPS_MONITOR_WORKER_IMAGE:-ghcr.io/marketing-hub-org/marketing-hub/ops-monitor-worker:latest}
+    container_name: ops-monitor-worker
+    restart: unless-stopped
+    ports:
+      - "${OPS_MONITOR_WORKER_PORT:-8098}:${SERVER_PORT:-8098}"
+    environment:
+      SERVER_PORT: ${SERVER_PORT:-8098}
+      LOG_FILE_NAME: ${LOG_FILE_NAME:-/tmp/ops-monitor-worker.log}
+      OPS_MONITOR_BACKEND_BASE_URL: ${OPS_MONITOR_BACKEND_BASE_URL:-http://191.252.181.168}

--- a/ops-monitor-worker/docker-compose.yml
+++ b/ops-monitor-worker/docker-compose.yml
@@ -1,0 +1,11 @@
+services:
+  ops-monitor-worker:
+    build: .
+    container_name: ops-monitor-worker
+    restart: unless-stopped
+    ports:
+      - "${OPS_MONITOR_WORKER_PORT:-8098}:${SERVER_PORT:-8098}"
+    environment:
+      SERVER_PORT: ${SERVER_PORT:-8098}
+      LOG_FILE_NAME: ${LOG_FILE_NAME:-/tmp/ops-monitor-worker.log}
+      OPS_MONITOR_BACKEND_BASE_URL: ${OPS_MONITOR_BACKEND_BASE_URL:-http://191.252.181.168}

--- a/ops-monitor-worker/src/main/resources/application.properties
+++ b/ops-monitor-worker/src/main/resources/application.properties
@@ -1,7 +1,10 @@
 spring.application.name=ops-monitor-worker
-management.endpoints.web.exposure.include=health,info
+management.endpoints.web.exposure.include=health,info,logfile
+management.endpoint.logfile.enabled=true
 ops-monitor.health-check.default-timeout=5s
 ops-monitor.availability.degraded-response-time-ms=5000
 ops-monitor.availability.offline-failure-threshold=3
 
 ops-monitor.backend.base-url=${OPS_MONITOR_BACKEND_BASE_URL:http://191.252.181.168}
+
+logging.file.name=${LOG_FILE_NAME:/tmp/ops-monitor-worker.log}


### PR DESCRIPTION
### Motivation

- Expose and collect logs from the new `ops-monitor-worker` so it can be observed via Actuator and the MCP `java_module_logs` tool.  
- Provide a reproducible Docker image and compose files to run the worker in production and locally.  
- Automate testing, build, push and deployment of the `ops-monitor-worker` with a dedicated GitHub Actions workflow.  

### Description

- Add `ops-monitor-worker` Docker assets including `Dockerfile`, `docker-compose.yml`, and `docker-compose.deploy.yml` to build and run the worker.  
- Expose the worker logfile via Actuator by enabling `logfile` endpoint and adding `logging.file.name` in `ops-monitor-worker/src/main/resources/application.properties`.  
- Add a GitHub Actions workflow `.github/workflows/ops-monitor-worker-ci.yml` to run `mvn -B test`, build and push the image to GHCR, and deploy via SSH/rsync + `docker compose` on `main` branch.  
- Extend MCP server to support the new module by adding `opsMonitorWorkerPath` to `McpProperties`, adding `ops-monitor-worker` to `JAVA_LOG_MODULES`, mapping the module in `ModuleLogService.modulePath` and `normalizeModule`, and wiring the new configuration into `application.yml`.  
- Update documentation and registries: add `ops-monitor-worker` entry in `mcp-server/AGENTS.md`, add observability/publishing notes to `docs/registros/ops-monitor.md`, and update `mcp-server/README.md` with the module in the `java_module_logs` list.  
- Update and add unit tests to cover the new module (`McpControllerTest`, `ModuleLogServiceTest`, and related tests) and adjust test fixtures and `McpProperties` construction to include the new log path.  

### Testing

- Ran the project unit test suite with `mvn -B test`, including `McpControllerTest`, `ModuleLogServiceTest`, `MetaDiagnosticsServiceTest`, and `MetaToolsServiceTest`.  
- The modified and added tests exercise reading the `ops-monitor-worker` log file and validation paths and they passed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3bb2bb8a0883219e48d0c11719462d)