### PR TITLE
Mostrar apenas a rodada mais recente de targeting nas telas e registrar no changelog

### DIFF
--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -5237,3 +5237,9 @@
 - Causa-raiz: o card “Escolha de público” inferia prontidão por criativo e landing, em vez de usar a mesma regra do backend/publicador (`hasCompleteTargeting`) usada por `/api/facebook-campaigns/experiments-ready`.
 - Correção aplicada: o checklist principal e os bloqueios de publicação passaram a exigir público salvo pela regra do publicador antes de mostrar pronto ou liberar o botão do Facebook Ads Worker.
 - Cânone atualizado: a regra de publicação Facebook Ads agora determina que cards e checklists da UI devem usar o contrato `/api/experiments/{experimentId}/readiness`, sem inferência local divergente.
+
+## 2026-06-24 — Tela de targeting mostra apenas a rodada mais recente
+
+- Solicitação: deixar a tela de públicos mais limpa após nova geração, evitando mistura visual entre resultados antigos, possivelmente gerados antes das regras atuais, e a rodada nova.
+- Causa-raiz: a tela de nicho/hipótese listava até seis solicitações recentes de targeting por contexto, mantendo na mesma área públicos antigos com scores baixos e públicos novos.
+- Correção aplicada: as telas de detalhe de nicho e hipótese passaram a solicitar somente a rodada mais recente de targeting no painel principal, preservando o histórico no backend sem poluir a decisão operacional do usuário.

--- a/frontend/src/pages/hypothesis/HypothesisDetailPage.tsx
+++ b/frontend/src/pages/hypothesis/HypothesisDetailPage.tsx
@@ -348,7 +348,7 @@ ${data.entrega ?? ""}
         />
         <TargetingRequestStatusPanel
           className="mb-4"
-          limit={6}
+          limit={1}
           nicheId={normalizedNicheId}
           hypothesisId={hypothesisId}
         />

--- a/frontend/src/pages/niche/NicheDetailPage.tsx
+++ b/frontend/src/pages/niche/NicheDetailPage.tsx
@@ -2298,7 +2298,7 @@ export default function NicheDetailPage() {
 
           <TargetingRequestStatusPanel
             className="mb-4"
-            limit={6}
+            limit={1}
             nicheId={normalizedNicheId}
           />
 


### PR DESCRIPTION
### Motivation
- Tornar as telas de detalhe de nicho e hipótese mais claras ao evitar mistura visual entre públicos antigos e a rodada recém-gerada. 
- Registrar a mudança operacional no histórico de experimentos para rastreabilidade. 

### Description
- Ajustado o `TargetingRequestStatusPanel` para pedir apenas uma rodada recente ao trocar o `limit` de `6` para `1` em `frontend/src/pages/hypothesis/HypothesisDetailPage.tsx` e `frontend/src/pages/niche/NicheDetailPage.tsx`. 
- Atualizado o registro em `docs/registros/experimentos.md` com a entrada "Tela de targeting mostra apenas a rodada mais recente" que descreve a correção e a preservação do histórico no backend. 

### Testing
- Executado o conjunto de testes front-end com `yarn test`, que passou sem falhas. 
- Executado `yarn build`/typecheck e `yarn lint` para validar tipagem e estilo, ambos concluídos com sucesso.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3bb69c97548321a90289f59bec5fbd)