### PR TITLE
Nicho: unifica fluxo de solicitações de públicos e adiciona cancelamento/pending UI

### DIFF
--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -5243,3 +5243,15 @@
 - Solicitação: deixar a tela de públicos mais limpa após nova geração, evitando mistura visual entre resultados antigos, possivelmente gerados antes das regras atuais, e a rodada nova.
 - Causa-raiz: a tela de nicho/hipótese listava até seis solicitações recentes de targeting por contexto, mantendo na mesma área públicos antigos com scores baixos e públicos novos.
 - Correção aplicada: as telas de detalhe de nicho e hipótese passaram a solicitar somente a rodada mais recente de targeting no painel principal, preservando o histórico no backend sem poluir a decisão operacional do usuário.
+
+## 2026-06-24 — Nicho: solicitação de públicos sem duplicidade visual
+
+- Solicitação: reduzir confusão na tela do nicho, onde havia dois pontos aparentes para solicitar públicos de Meta Ads.
+- Causa-raiz: a seção exibia um formulário genérico de solicitação ao AI Worker e, logo abaixo, cards específicos para gerar interesses, cargos e comportamentos; para o usuário, ambos pareciam executar a mesma ação.
+- Correção aplicada: a tela passou a orientar o usuário a solicitar públicos somente pelos cards por tipo, mantendo o painel de solicitações apenas como acompanhamento da última rodada processada.
+
+## 2026-06-24 — Nicho: pendência automática de público fica explícita
+
+- Problema: a lista de públicos do nicho parecia aumentar sem ação do usuário porque solicitações já gravadas em `interests_to_generate`, `job_titles_to_generate` ou `behaviors_to_generate` são processadas automaticamente pelo AI Worker em rotina agendada.
+- Causa-raiz: a tela mostrava apenas “Solicitados: N”, sem explicar que isso era uma pendência ativa que o Worker processaria automaticamente e sem comando visível para cancelar a pendência antes da execução.
+- Correção aplicada: o card de geração passa a mostrar “Solicitação pendente no Worker”, explica que a lista pode aumentar automaticamente ao terminar o processamento e oferece o comando “Cancelar pendência”.

--- a/frontend/src/components/TargetingGenerationForm.tsx
+++ b/frontend/src/components/TargetingGenerationForm.tsx
@@ -36,12 +36,7 @@ export function TargetingGenerationForm({
 }: TargetingGenerationFormProps) {
   const resolvedDefaultModel = defaultModel ?? openAiModels?.[0]?.code ?? "";
   const request = useRequestTargetingElements(nicheId, type);
-  const {
-    register,
-    handleSubmit,
-    reset,
-    setValue,
-  } = useForm<FormValues>({
+  const { register, handleSubmit, reset, setValue } = useForm<FormValues>({
     defaultValues: {
       quantity: 1,
       model: resolvedDefaultModel,
@@ -64,11 +59,30 @@ export function TargetingGenerationForm({
     }
   });
 
+  const cancelRequest = async () => {
+    try {
+      await request.mutateAsync({ quantity: 0 });
+      reset({ quantity: 1, model: resolvedDefaultModel });
+    } catch (error) {
+      console.error("Erro ao cancelar solicitação de segmentação", error);
+      alert("Não foi possível cancelar esta solicitação. Tente novamente.");
+    }
+  };
+
+  const pendingTotal = requestedTotal ?? 0;
+  const hasPendingRequest = pendingTotal > 0;
   const isSubmitting = request.isPending || Boolean(isLoadingModels);
-  const statusMessage = statusLabel ?? `Solicitados: ${requestedTotal ?? 0}`;
+  const statusMessage =
+    statusLabel ??
+    (hasPendingRequest
+      ? `Solicitação pendente no Worker: ${pendingTotal}. A lista pode aumentar automaticamente quando o processamento terminar.`
+      : "Nenhuma solicitação pendente no Worker.");
 
   return (
-    <form onSubmit={onSubmit} className={`d-flex flex-column gap-2 ${className ?? ""}`}>
+    <form
+      onSubmit={onSubmit}
+      className={`d-flex flex-column gap-2 ${className ?? ""}`}
+    >
       <div className="d-flex flex-wrap gap-2">
         <input
           type="number"
@@ -91,14 +105,34 @@ export function TargetingGenerationForm({
             </option>
           ))}
         </select>
-        <button type="submit" className="btn btn-primary" disabled={isSubmitting}>
+        <button
+          type="submit"
+          className="btn btn-primary"
+          disabled={isSubmitting}
+        >
           {isSubmitting && (
-            <span className="spinner-border spinner-border-sm me-2" role="status" aria-hidden="true" />
+            <span
+              className="spinner-border spinner-border-sm me-2"
+              role="status"
+              aria-hidden="true"
+            />
           )}
           {ctaLabel}
         </button>
+        {hasPendingRequest ? (
+          <button
+            type="button"
+            className="btn btn-outline-secondary"
+            disabled={isSubmitting}
+            onClick={cancelRequest}
+          >
+            Cancelar pendência
+          </button>
+        ) : null}
       </div>
-      <small className="text-body-secondary">
+      <small
+        className={hasPendingRequest ? "text-warning" : "text-body-secondary"}
+      >
         {isFetchingStatus ? "Atualizando solicitações..." : statusMessage}
       </small>
     </form>

--- a/frontend/src/pages/niche/NicheDetailPage.tsx
+++ b/frontend/src/pages/niche/NicheDetailPage.tsx
@@ -18,7 +18,6 @@ import type {
   TargetingElementType,
 } from "../../api/targeting/types";
 import { TargetingGenerationForm } from "../../components/TargetingGenerationForm";
-import { TargetingRequestForm } from "../../components/TargetingRequestForm";
 import { TargetingRequestStatusPanel } from "../../components/TargetingRequestStatusPanel";
 import { useRequestHypotheses } from "../../api/niche/useRequestHypotheses";
 import { HypothesisManualForm } from "../../components/HypothesisManualForm";
@@ -195,10 +194,6 @@ export default function NicheDetailPage() {
   const { nicheId } = useParams();
   const id = Number(nicheId);
   const normalizedNicheId = Number.isFinite(id) ? id : undefined;
-  const targetingRequestFilters = useMemo(
-    () => ({ limit: 6, nicheId: normalizedNicheId }),
-    [normalizedNicheId],
-  );
   const { data, isLoading, isFetching } = useNiche(id);
   const facebookPixelId = data?.facebookPixelId ?? null;
   const facebookPixelCode = data?.facebookPixelCode ?? null;
@@ -2286,21 +2281,17 @@ export default function NicheDetailPage() {
           </div>
         </div>
         <div className="niche-section__body">
-          <TargetingRequestForm
-            className="mb-3"
-            defaultDescricao={`Nicho ${data.name}`}
-            defaultIdioma="pt_BR"
-            defaultPais="BR"
-            defaultPublico="PROSPECT"
-            nicheId={normalizedNicheId}
-            queryFilters={targetingRequestFilters}
-          />
-
-          <TargetingRequestStatusPanel
-            className="mb-4"
-            limit={1}
-            nicheId={normalizedNicheId}
-          />
+          <div className="alert alert-info mb-3" role="status">
+            <div className="fw-semibold">
+              Solicite públicos por tipo nos cards abaixo.
+            </div>
+            <div className="small">
+              Para aparecer no experimento, gere e aprove separadamente
+              interesses, cargos e comportamentos com ID oficial da Meta. O
+              painel de solicitações fica apenas como acompanhamento da última
+              rodada processada.
+            </div>
+          </div>
 
           <div className="row row-cols-1 row-cols-md-3 g-3 mb-4">
             {targetingConfigs.map((config) => (
@@ -2332,6 +2323,12 @@ export default function NicheDetailPage() {
               </div>
             ))}
           </div>
+
+          <TargetingRequestStatusPanel
+            className="mb-4"
+            limit={1}
+            nicheId={normalizedNicheId}
+          />
 
           {targetingConfigs.map((config) => (
             <div


### PR DESCRIPTION
### Motivation
- Evitar duplicidade visual e confusão na tela de nicho onde havia um formulário genérico e cards específicos para gerar públicos de Meta Ads.
- Tornar explícito que solicitações gravadas são pendências processadas automaticamente pelo Worker e permitir o cancelamento dessas pendências pela UI.
- Registrar as mudanças operacionais no histórico de experimentos/documentação para rastreabilidade.

### Description
- Atualiza `TargetingGenerationForm.tsx` para exibir uma mensagem de status detalhada quando houver solicitações pendentes, adicionar um botão `Cancelar pendência` que chama `request.mutateAsync({ quantity: 0 })` e resetar o formulário após sucesso, e ajustar a cor do texto de status quando houver pendência.
- Remove o formulário genérico de solicitação da tela e acrescenta um alerta informativo na `NicheDetailPage.tsx` orientando o usuário a solicitar públicos apenas pelos cards por tipo, além de reposicionar o `TargetingRequestStatusPanel` para acompanhar a última rodada processada.
- Atualiza a documentação em `docs/registros/experimentos.md` com entradas descrevendo as mudanças de UI/fluxo de solicitação de públicos e o comportamento do Worker.

### Testing
- Executado `tsc`/build do frontend para checagem de tipos e compilação, que completou sem erros.
- Executado lint e verificação estática do frontend, sem erros reportados.
- Testes de integração/automatizados existentes foram executados localmente e não apresentaram falhas.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3be74af6ac8321aa9155689ebfc7ce)