### PR TITLE
fix: sanitize gera landing prompt inputs

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/openai/core/copy/CopyInput.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/openai/core/copy/CopyInput.java
@@ -1,5 +1,6 @@
 package com.marketinghub.worker.openai.core.copy;
 
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 /** Responsabilidade: transportar o payload de entrada da etapa copy no core OpenAI. */
@@ -11,6 +12,20 @@ public record CopyInput(
 ) {
     /** Normaliza os dados do prompt para evitar mapas nulos durante a renderização da etapa copy. */
     public CopyInput {
-        promptData = promptData == null ? Map.of() : Map.copyOf(promptData);
+        promptData = normalizePromptData(promptData);
+    }
+
+    /** Copia os dados do prompt trocando valores nulos por texto vazio para preservar placeholders opcionais. */
+    private static Map<String, Object> normalizePromptData(Map<String, Object> source) {
+        if (source == null || source.isEmpty()) {
+            return Map.of();
+        }
+        Map<String, Object> normalized = new LinkedHashMap<>();
+        source.forEach((key, value) -> {
+            if (key != null) {
+                normalized.put(key, value != null ? value : "");
+            }
+        });
+        return Map.copyOf(normalized);
     }
 }

--- a/ai-worker/src/main/java/com/marketinghub/worker/openai/core/imageplanning/ImagePlanningInput.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/openai/core/imageplanning/ImagePlanningInput.java
@@ -1,5 +1,6 @@
 package com.marketinghub.worker.openai.core.imageplanning;
 
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 /** Responsabilidade: transportar os dados de entrada usados no prompt da etapa image planning. */
@@ -11,6 +12,20 @@ public record ImagePlanningInput(
 ) {
     /** Normaliza o mapa de dados do prompt para evitar valores nulos durante a renderização. */
     public ImagePlanningInput {
-        promptData = promptData == null ? Map.of() : Map.copyOf(promptData);
+        promptData = normalizePromptData(promptData);
+    }
+
+    /** Copia os dados do prompt trocando valores nulos por texto vazio para preservar placeholders opcionais. */
+    private static Map<String, Object> normalizePromptData(Map<String, Object> source) {
+        if (source == null || source.isEmpty()) {
+            return Map.of();
+        }
+        Map<String, Object> normalized = new LinkedHashMap<>();
+        source.forEach((key, value) -> {
+            if (key != null) {
+                normalized.put(key, value != null ? value : "");
+            }
+        });
+        return Map.copyOf(normalized);
     }
 }

--- a/ai-worker/src/main/java/com/marketinghub/worker/openai/core/presetdesign/PresetDesignInput.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/openai/core/presetdesign/PresetDesignInput.java
@@ -1,5 +1,6 @@
 package com.marketinghub.worker.openai.core.presetdesign;
 
+import java.util.LinkedHashMap;
 import java.util.Map;
 
 /** Responsabilidade: representar os dados de entrada e placeholders da etapa presetdesign. */
@@ -11,6 +12,20 @@ public record PresetDesignInput(
 ) {
     /** Normaliza mapas nulos para manter o contrato interno da etapa seguro. */
     public PresetDesignInput {
-        promptData = promptData == null ? Map.of() : Map.copyOf(promptData);
+        promptData = normalizePromptData(promptData);
+    }
+
+    /** Copia os dados do prompt trocando valores nulos por texto vazio para preservar placeholders opcionais. */
+    private static Map<String, Object> normalizePromptData(Map<String, Object> source) {
+        if (source == null || source.isEmpty()) {
+            return Map.of();
+        }
+        Map<String, Object> normalized = new LinkedHashMap<>();
+        source.forEach((key, value) -> {
+            if (key != null) {
+                normalized.put(key, value != null ? value : "");
+            }
+        });
+        return Map.copyOf(normalized);
     }
 }

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -5265,3 +5265,9 @@
 - Problema: a lista de públicos do nicho parecia aumentar sem ação do usuário porque solicitações já gravadas em `interests_to_generate`, `job_titles_to_generate` ou `behaviors_to_generate` são processadas automaticamente pelo AI Worker em rotina agendada.
 - Causa-raiz: a tela mostrava apenas “Solicitados: N”, sem explicar que isso era uma pendência ativa que o Worker processaria automaticamente e sem comando visível para cancelar a pendência antes da execução.
 - Correção aplicada: o card de geração passa a mostrar “Solicitação pendente no Worker”, explica que a lista pode aumentar automaticamente ao terminar o processamento e oferece o comando “Cancelar pendência”.
+
+## 2026-06-24 — Correção de NullPointer nos inputs do GeraLanding core
+- Problema: testes de Copy, Image Planning e Design Preset falhavam com `NullPointerException` ao converter pendências válidas do backend em `promptData` do Worker AI.
+- Causa-raiz: os records de entrada (`CopyInput`, `ImagePlanningInput` e `PresetDesignInput`) usavam `Map.copyOf` diretamente, que rejeita valores nulos; campos opcionais do backend, como insights/revisões/artefatos ausentes, podiam chegar nulos mesmo quando o contrato comercial obrigatório estava correto.
+- Correção aplicada: os inputs agora normalizam `promptData` antes de congelar o mapa, preservando chaves válidas e trocando valores nulos por texto vazio para placeholders opcionais, sem mascarar validações comerciais obrigatórias feitas pelos clients.
+- Prevenção de recorrência: executados os testes específicos dos três clients que reproduziam a falha.


### PR DESCRIPTION
### Motivation
- Prevent `NullPointerException` when freezing `promptData` maps for GeraLanding core stages caused by `Map.copyOf` rejecting null values in optional fields. 
- Protect prompt rendering and avoid sending empty/invalid prompts to downstream IA clients while preserving required commercial fields delivered by the backend.

### Description
- Inputs `CopyInput`, `ImagePlanningInput` and `PresetDesignInput` now call a `normalizePromptData` helper that replaces null values with empty strings and returns a safe, immutable `Map.copyOf` result, instead of calling `Map.copyOf` directly; changes are in `ai-worker/src/main/java/com/marketinghub/worker/openai/core/copy/CopyInput.java`, `.../imageplanning/ImagePlanningInput.java` and `.../presetdesign/PresetDesignInput.java`.
- The normalization preserves existing keys and only substitutes `null` values for safe rendering of optional placeholders while leaving absent maps as empty maps.
- Added a short record in `docs/registros/experimentos.md` describing the bug, root cause and the corrective action for audit/tracking.

### Testing
- Ran the client contract unit tests with `mvn -f ai-worker/pom.xml -Dtest=CopyBackendClientTest,ImagePlanningBackendClientTest,PresetDesignBackendClientTest test` and the three previously failing tests now pass (the NPE regressions were resolved). 
- Executed the module test suite with `mvn -f ai-worker/pom.xml test`; unrelated integration and network-dependent tests still fail in this environment (external backend connectivity and image/reporting mocks), so the broader test run reports failures unrelated to this fix.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3c0d759bd48321bd20a09ae98562ae)