### PR TITLE
Corrige endpoints de observabilidade do Ops Monitor

### DIFF
--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-24-ops-monitor-correct-observability-endpoints.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-24-ops-monitor-correct-observability-endpoints.yaml
@@ -1,0 +1,48 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-06-24-ops-monitor-004-correct-observability-endpoints
+      author: marketing-hub
+      preConditions:
+        - onFail: MARK_RAN
+        - dbms:
+            type: mysql
+      changes:
+        - sql:
+            splitStatements: true
+            stripComments: true
+            sql: |
+              UPDATE ops_monitored_module
+              SET base_url = 'http://191.252.181.168',
+                  health_path = '/ops-mh-observability-v2/health',
+                  log_path = '/ops-mh-observability-v2/backend-log-stream-x9k'
+              WHERE code = 'backend';
+
+              UPDATE ops_monitored_module
+              SET base_url = 'http://191.252.181.168:4567',
+                  health_path = '/worker-observability/health',
+                  log_path = '/worker-observability/logfile'
+              WHERE code = 'ai-worker';
+
+              UPDATE ops_monitored_module
+              SET base_url = 'http://191.252.181.168:8082',
+                  health_path = '/worker-observability/health',
+                  log_path = '/worker-observability/logfile'
+              WHERE code = 'facebook-ads-worker';
+
+              UPDATE ops_monitored_module
+              SET base_url = 'http://191.252.181.168:8094',
+                  health_path = '/actuator/health',
+                  log_path = '/actuator/logfile'
+              WHERE code = 'oprm-coletor-mei';
+
+              UPDATE ops_monitored_module
+              SET base_url = 'http://191.252.181.168:8097',
+                  health_path = '/actuator/health',
+                  log_path = '/actuator/logfile'
+              WHERE code = 'mois-sales-library-worker';
+
+              UPDATE ops_monitored_module
+              SET base_url = 'http://191.252.181.168:8086',
+                  health_path = '/ops-email-gateway-7xk9/health',
+                  log_path = '/ops-email-gateway-7xk9/email-service-audit-log'
+              WHERE code = 'email-service';

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -1079,6 +1079,9 @@ databaseChangeLog:
   - include:
       file: changesets/2026-06-23-ops-monitor-phase4-modules.yaml
       relativeToChangelogFile: true
+  - include:
+      file: changesets/2026-06-24-ops-monitor-correct-observability-endpoints.yaml
+      relativeToChangelogFile: true
 
   - include:
       file: changesets/2026-06-24-mois-sales-library-geralanding-insights.yaml

--- a/docs/registros/ops-monitor.md
+++ b/docs/registros/ops-monitor.md
@@ -18,3 +18,10 @@
 - Causa-raiz tratada: o `ops-monitor-worker` não tinha exposição de logfile própria no Actuator, não estava listado na tool `java_module_logs` do MCP Server e não havia workflow dedicado de publicação.
 - Ajuste: o worker passou a expor `/actuator/logfile`, o MCP passou a aceitar o módulo `ops-monitor-worker` e foi criado workflow de teste, build, push e deploy para publicação do executor.
 - Prevenção: teste de contrato do MCP valida leitura dos logs do `ops-monitor-worker`.
+
+## 2026-06-24 — Correção dos endpoints monitorados
+
+- Problema observado: a tela `/ops-monitor` marcava módulos como fora do ar com erro `404 Not Found` porque alguns registros de `ops_monitored_module` apontavam para `/actuator/health` na porta 80, enquanto os módulos expõem Actuator em portas e base paths próprios.
+- Causa-raiz tratada: cadastro inicial do monitor usou endpoints genéricos em vez dos contratos reais de observabilidade dos módulos.
+- Ajuste: criado changelog para corrigir `base_url`, `health_path` e `log_path` de backend, AI Worker, Facebook Ads Worker, OPRM Coletor MEI, MOIS Sales Library Worker e Email Service.
+- Prevenção: a correção fica versionada em Liquibase para manter o banco alinhado após deploy e evitar reincidência em novos ambientes.


### PR DESCRIPTION
### Motivation

- Corrigir registros incorretos em `ops_monitored_module` que apontavam para endpoints genéricos (`/actuator/health` na porta 80) causando falsos estados “Fora do ar” na tela `/ops-monitor` para vários módulos. 
- Alinhar o cadastro no banco com os contratos reais de observabilidade expostos por cada serviço (backend, workers e serviços auxiliares) e cumprir a regra de includes relativos do Liquibase.

### Description

- Adiciona o changelog Liquibase `backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-24-ops-monitor-correct-observability-endpoints.yaml` que atualiza `base_url`, `health_path` e `log_path` para os módulos `backend`, `ai-worker`, `facebook-ads-worker`, `oprm-coletor-mei`, `mois-sales-library-worker` e `email-service` via `UPDATE` SQL. 
- Inclui o novo changelog no `db.changelog-master.yaml` com `relativeToChangelogFile: true` para obedecer à convenção de includes relativos. 
- Registra o incidente e a correção em `docs/registros/ops-monitor.md` descrevendo a causa-raiz e a prevenção aplicada.

### Testing

- Executed a Python check to validate that all `include` entries in `db.changelog-master.yaml` declare `relativeToChangelogFile: true`, which succeeded. 
- Ran `mvn -q -Dtest=OpsMonitorServiceTest test` for the backend module, and the `OpsMonitorServiceTest` passed. 
- Ran a repository consistency check with `git diff --check` to ensure no whitespace/conflict markers, which returned clean results.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3c160e66d083219913dd88cd81d7fb)