### PR TITLE
Fix AI Worker targeting generation contracts

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/targeting/dto/generation/TargetingElementGenerationFailureRequest.java
+++ b/ai-worker/src/main/java/com/marketinghub/targeting/dto/generation/TargetingElementGenerationFailureRequest.java
@@ -1,0 +1,7 @@
+package com.marketinghub.targeting.dto.generation;
+
+/**
+ * Responsabilidade: representar o payload enviado pelo AI Worker ao backend quando a geração falha.
+ */
+public record TargetingElementGenerationFailureRequest(String error) {
+}

--- a/ai-worker/src/main/java/com/marketinghub/targeting/dto/generation/TargetingElementGenerationPendingDto.java
+++ b/ai-worker/src/main/java/com/marketinghub/targeting/dto/generation/TargetingElementGenerationPendingDto.java
@@ -1,0 +1,21 @@
+package com.marketinghub.targeting.dto.generation;
+
+import com.marketinghub.targeting.TargetingElementType;
+
+/**
+ * Responsabilidade: representar a pendência de geração de público recebida do backend pelo AI Worker.
+ */
+public record TargetingElementGenerationPendingDto(
+        Long nicheId,
+        String name,
+        String description,
+        String baseSegmentation,
+        String interests,
+        String demographicFilters,
+        String extraTips,
+        String interestCategory,
+        String roleCategory,
+        TargetingElementType type,
+        int quantity,
+        String model) {
+}

--- a/ai-worker/src/main/java/com/marketinghub/targeting/dto/generation/TargetingElementGenerationResultRequest.java
+++ b/ai-worker/src/main/java/com/marketinghub/targeting/dto/generation/TargetingElementGenerationResultRequest.java
@@ -1,0 +1,10 @@
+package com.marketinghub.targeting.dto.generation;
+
+import com.marketinghub.targeting.dto.CreateTargetingElementRequest;
+import java.util.List;
+
+/**
+ * Responsabilidade: representar o payload enviado pelo AI Worker ao backend com públicos gerados.
+ */
+public record TargetingElementGenerationResultRequest(List<CreateTargetingElementRequest> items) {
+}

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -5295,3 +5295,10 @@
 - Problema: após remover o bootstrap de banco, ainda existiam classes produtivas legadas no AI Worker com repositories, JPA, EntityManager e services internos do backend.
 - Correção aplicada: removidos os fluxos legados desativados que ainda dependiam de acesso direto ao banco; o worker mantém somente fluxos que consomem contratos do backend ou integrações externas.
 - Prevenção de recorrência: a guarda ArchUnit passou a bloquear dependência de todo o AI Worker produtivo contra `repository`, JPA e services internos do backend.
+
+## 2026-06-24 — Correção de compilação dos contratos de targeting no AI Worker
+
+- Problema: o CI do AI Worker falhava porque o worker importava contratos de geração de targeting que ainda não estavam disponíveis no artefato `ads-service` publicado usado pela build isolada.
+- Causa-raiz: o endpoint interno de targeting foi criado no backend, mas a build do worker depende de um pacote publicado que pode ficar defasado em relação ao código do monorepo.
+- Correção aplicada: o AI Worker passou a declarar localmente os contratos HTTP mínimos de pendência, resultado e falha usados nessa integração, preservando o consumo exclusivo via backend e evitando acesso direto ao banco.
+- Prevenção de recorrência: os contratos necessários à compilação isolada do worker ficam no próprio módulo executor, sem depender da publicação imediata do artefato do backend.


### PR DESCRIPTION
### Motivation
- The AI Worker CI was failing because it imported generation DTOs that only existed in the backend `ads-service` artifact, which may be unavailable in isolated CI builds. 
- To make the worker compile independently (while still consuming the backend at runtime), minimal HTTP contract records needed to exist in the `ai-worker` module.

### Description
- Added local contract records in `ai-worker` under `com.marketinghub.targeting.dto.generation`: `TargetingElementGenerationPendingDto`, `TargetingElementGenerationResultRequest`, and `TargetingElementGenerationFailureRequest`.
- These records mirror the minimal payload shapes used by the targeting generation endpoints and allow the worker to compile without requiring the published `ads-service` package.
- Updated the experiment log `docs/registros/experimentos.md` with the incident, root cause and the prevention decision.

### Testing
- Attempted to run `mvn -f ai-worker/pom.xml -s ai-worker/settings.xml test`, but Maven could not fetch remote artifacts / GitHub Packages due to network/auth restrictions in this environment, so automated tests could not complete.
- Prior to this change the build produced `package com.marketinghub.targeting.dto.generation does not exist` errors; adding the local DTOs removes the missing-package source of those compile errors when building the worker module in isolation.
- No unit test failures were observed here because tests could not be executed in this environment; recommend running `mvn -f ai-worker/pom.xml -s ai-worker/settings.xml test` in CI (with repository access) to validate fully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3c25ec7f5483219c5daa8e76b59808)