### PR TITLE
Require Meta official ID for approving targeting elements; add UI feedback and polling for pending generation

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/targeting/service/TargetingElementService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/targeting/service/TargetingElementService.java
@@ -40,6 +40,7 @@ public class TargetingElementService {
         this.hypothesisRepository = hypothesisRepository;
     }
 
+    /** Cria um elemento de segmentação garantindo dados mínimos para aprovação operacional. */
     @Transactional
     public TargetingElement create(CreateTargetingElementRequest request) {
         if (request.getMarketNicheId() == null) {
@@ -77,9 +78,11 @@ public class TargetingElementService {
         if (request.getStatus() != null) {
             element.setStatus(request.getStatus());
         }
+        validateReadyState(element);
         return repository.save(element);
     }
 
+    /** Atualiza um elemento de segmentação sem permitir aprovação sem ID oficial da Meta. */
     @Transactional
     public TargetingElement update(Long id, UpdateTargetingElementRequest request) {
         TargetingElement element = repository.findById(id).orElseThrow();
@@ -244,10 +247,23 @@ public class TargetingElementService {
         return term.trim();
     }
 
+    /** Valida se o elemento aprovado está pronto para uso em campanhas Meta Ads. */
     private void validateReadyState(TargetingElement element) {
         if (element.getStatus() == TargetingElementStatus.APPROVED && !StringUtils.hasText(element.getTerm())) {
             throw new IllegalArgumentException("Não é possível aprovar um elemento sem termo");
         }
+        if (element.getStatus() == TargetingElementStatus.APPROVED
+                && requiresMetaId(element.getType())
+                && !StringUtils.hasText(element.getMetaId())) {
+            throw new IllegalArgumentException("Não é possível aprovar um público sem ID oficial da Meta");
+        }
+    }
+
+    /** Indica se o tipo de público depende de ID oficial da Meta para uso em campanha. */
+    private boolean requiresMetaId(TargetingElementType type) {
+        return type == TargetingElementType.INTEREST
+                || type == TargetingElementType.JOB_TITLE
+                || type == TargetingElementType.BEHAVIOR;
     }
 
     /** Adiciona uma pendência de geração ao contrato interno respeitando o limite solicitado. */

--- a/backend/ads-service/src/test/java/com/marketinghub/targeting/service/TargetingElementGenerationServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/targeting/service/TargetingElementGenerationServiceTest.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -90,6 +91,42 @@ class TargetingElementGenerationServiceTest {
         assertThat(captor.getValue().getType()).isEqualTo(TargetingElementType.JOB_TITLE);
         assertThat(niche.getJobTitlesToGenerate()).isZero();
         verify(nicheRepository).save(niche);
+    }
+
+
+    /** Garante que cargo só pode ser aprovado quando já possui ID oficial da Meta. */
+    @Test
+    void createShouldRejectApprovedJobTitleWithoutMetaId() {
+        MarketNiche niche = MarketNiche.builder().id(23L).build();
+        when(nicheRepository.findById(23L)).thenReturn(Optional.of(niche));
+        CreateTargetingElementRequest item = new CreateTargetingElementRequest();
+        item.setMarketNicheId(23L);
+        item.setType(TargetingElementType.JOB_TITLE);
+        item.setTerm("Gerente de loja");
+        item.setStatus(TargetingElementStatus.APPROVED);
+
+        assertThatThrownBy(() -> service.create(item))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("ID oficial da Meta");
+    }
+
+    /** Garante que cargo com ID oficial da Meta pode ser aprovado para uso operacional. */
+    @Test
+    void createShouldApproveJobTitleWithMetaId() {
+        MarketNiche niche = MarketNiche.builder().id(23L).build();
+        when(nicheRepository.findById(23L)).thenReturn(Optional.of(niche));
+        when(elementRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+        CreateTargetingElementRequest item = new CreateTargetingElementRequest();
+        item.setMarketNicheId(23L);
+        item.setType(TargetingElementType.JOB_TITLE);
+        item.setTerm("Gerente de loja");
+        item.setMetaId("6000000000001");
+        item.setStatus(TargetingElementStatus.APPROVED);
+
+        var saved = service.create(item);
+
+        assertThat(saved.getStatus()).isEqualTo(TargetingElementStatus.APPROVED);
+        assertThat(saved.getMetaId()).isEqualTo("6000000000001");
     }
 
     /** Garante que uma falha reportada pelo worker libera a pendência para evitar loop infinito. */

--- a/backend/ads-service/src/test/java/com/marketinghub/targeting/service/TargetingElementGenerationServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/targeting/service/TargetingElementGenerationServiceTest.java
@@ -129,6 +129,41 @@ class TargetingElementGenerationServiceTest {
         assertThat(saved.getMetaId()).isEqualTo("6000000000001");
     }
 
+    /** Garante que comportamento também só pode ser aprovado quando possui ID oficial da Meta. */
+    @Test
+    void createShouldRejectApprovedBehaviorWithoutMetaId() {
+        MarketNiche niche = MarketNiche.builder().id(23L).build();
+        when(nicheRepository.findById(23L)).thenReturn(Optional.of(niche));
+        CreateTargetingElementRequest item = new CreateTargetingElementRequest();
+        item.setMarketNicheId(23L);
+        item.setType(TargetingElementType.BEHAVIOR);
+        item.setTerm("Compradores engajados");
+        item.setStatus(TargetingElementStatus.APPROVED);
+
+        assertThatThrownBy(() -> service.create(item))
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessageContaining("ID oficial da Meta");
+    }
+
+    /** Garante que comportamento com ID oficial da Meta pode ser aprovado para campanha. */
+    @Test
+    void createShouldApproveBehaviorWithMetaId() {
+        MarketNiche niche = MarketNiche.builder().id(23L).build();
+        when(nicheRepository.findById(23L)).thenReturn(Optional.of(niche));
+        when(elementRepository.save(any())).thenAnswer(invocation -> invocation.getArgument(0));
+        CreateTargetingElementRequest item = new CreateTargetingElementRequest();
+        item.setMarketNicheId(23L);
+        item.setType(TargetingElementType.BEHAVIOR);
+        item.setTerm("Compradores engajados");
+        item.setMetaId("6000000000002");
+        item.setStatus(TargetingElementStatus.APPROVED);
+
+        var saved = service.create(item);
+
+        assertThat(saved.getStatus()).isEqualTo(TargetingElementStatus.APPROVED);
+        assertThat(saved.getMetaId()).isEqualTo("6000000000002");
+    }
+
     /** Garante que uma falha reportada pelo worker libera a pendência para evitar loop infinito. */
     @Test
     void markGenerationFailureShouldResetCounter() {

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -5312,3 +5312,17 @@
 - causa-raiz: fluxos acionados pela tela, como públicos de nicho e targeting, ainda dependiam da Batch API da OpenAI, aumentando latência operacional e dificultando acompanhamento imediato pelo usuário.
 - foi feito: removido o uso da Batch API nos clientes do AI Worker que enviavam lotes para OpenAI; os fluxos passaram a executar chamadas diretas em modo Flex ou equivalente direto, preservando os contratos agregados internos para não quebrar os services chamadores.
 - prevenção de recorrência: validação por busca no código confirmou ausência de chamadas `/batches`, `purpose=batch` e `completion_window` no AI Worker.
+
+## 2026-06-24 — Acompanhamento visual da solicitação de cargos por nicho
+
+- Problema: na tela do nicho, a solicitação de cargos ficava marcada como pendente, mas o usuário precisava acompanhar manualmente se o Worker já havia concluído e atualizado a lista.
+- Causa-raiz: o card exibia apenas uma frase estática de pendência, sem destaque de fila e sem atualização automática enquanto existia solicitação em aberto.
+- Correção aplicada: o card de geração de targeting passou a mostrar um bloco de acompanhamento com fila livre/aguardando Worker, total pendente e aviso de atualização automática; a página do nicho passou a atualizar nicho e públicos a cada 15 segundos enquanto houver qualquer targeting pendente.
+- Prevenção de recorrência: o acompanhamento fica no próprio card de cada tipo, incluindo cargos, evitando depender apenas do painel geral de solicitações recentes.
+
+## 2026-06-24 — Aprovação de cargos exige ID oficial da Meta
+
+- Problema: o usuário não tinha clareza se cargos gerados pela IA já existiam na Meta e se a aprovação seria automática.
+- Causa-raiz: o fluxo permitia ação de aprovação mesmo quando o cargo ainda não tinha ID oficial da Meta, misturando geração por IA com validação operacional para campanha.
+- Correção aplicada: a tela passou a avisar quando falta ID oficial da Meta e bloqueia aprovação nesse caso; o backend passou a rejeitar aprovação de interesse, cargo ou comportamento sem ID oficial da Meta.
+- Prevenção de recorrência: teste unitário garante que cargo aprovado sem ID da Meta é rejeitado e cargo com ID pode ser aprovado.

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -5326,3 +5326,9 @@
 - Causa-raiz: o fluxo permitia ação de aprovação mesmo quando o cargo ainda não tinha ID oficial da Meta, misturando geração por IA com validação operacional para campanha.
 - Correção aplicada: a tela passou a avisar quando falta ID oficial da Meta e bloqueia aprovação nesse caso; o backend passou a rejeitar aprovação de interesse, cargo ou comportamento sem ID oficial da Meta.
 - Prevenção de recorrência: teste unitário garante que cargo aprovado sem ID da Meta é rejeitado e cargo com ID pode ser aprovado.
+
+## 2026-06-24 — Mesma regra de Meta ID para comportamentos
+
+- Solicitação: aplicar aos comportamentos o mesmo controle já reforçado para cargos.
+- Correção aplicada: a regra de aprovação permanece única para interesses, cargos e comportamentos; a cobertura de testes passou a validar explicitamente comportamento sem ID oficial da Meta e comportamento com ID oficial.
+- Resultado esperado: comportamento gerado pela IA fica para revisão e só pode ser aprovado/publicado quando houver ID oficial da Meta.

--- a/frontend/src/components/TargetingElementCard.tsx
+++ b/frontend/src/components/TargetingElementCard.tsx
@@ -20,9 +20,12 @@ const statusLabels: Record<TargetingElementStatus, string> = {
 };
 
 const statusClasses: Record<TargetingElementStatus, string> = {
-  DRAFT: "bg-secondary-subtle text-secondary-emphasis border border-secondary-subtle",
-  NEEDS_REVIEW: "bg-warning-subtle text-warning-emphasis border border-warning-subtle",
-  APPROVED: "bg-success-subtle text-success-emphasis border border-success-subtle",
+  DRAFT:
+    "bg-secondary-subtle text-secondary-emphasis border border-secondary-subtle",
+  NEEDS_REVIEW:
+    "bg-warning-subtle text-warning-emphasis border border-warning-subtle",
+  APPROVED:
+    "bg-success-subtle text-success-emphasis border border-success-subtle",
   REJECTED: "bg-danger-subtle text-danger-emphasis border border-danger-subtle",
 };
 
@@ -90,10 +93,13 @@ export function TargetingElementCard({
   className,
 }: TargetingElementCardProps) {
   const [showModal, setShowModal] = useState(false);
-  const [formState, setFormState] = useState<FormState>(() => buildFormState(element));
-  const nicheId = useMemo(() => String(element.marketNicheId ?? ""), [
-    element.marketNicheId,
-  ]);
+  const [formState, setFormState] = useState<FormState>(() =>
+    buildFormState(element),
+  );
+  const nicheId = useMemo(
+    () => String(element.marketNicheId ?? ""),
+    [element.marketNicheId],
+  );
   const updateElement = useUpdateTargetingElement(nicheId);
   const audienceRangeLabel = formatAudienceRange(
     element.metaAudienceSizeLowerBound,
@@ -136,6 +142,11 @@ export function TargetingElementCard({
   };
 
   const isMutating = updateElement.isPending;
+  const hasOfficialMetaId = Boolean(element.metaId?.trim());
+  const canApprove = element.status === "APPROVED" || hasOfficialMetaId;
+  const approvalHelpText = hasOfficialMetaId
+    ? "ID oficial da Meta encontrado. Pode aprovar para uso em experimento."
+    : "Ainda sem ID oficial da Meta. Revise ou reprocese antes de aprovar.";
 
   const createdAtLabel = element.createdAt
     ? new Date(element.createdAt).toLocaleString("pt-BR")
@@ -164,9 +175,22 @@ export function TargetingElementCard({
               {statusLabels[element.status]}
             </span>
           </div>
-          <p className="text-body-secondary mb-0" style={{ whiteSpace: "pre-wrap" }}>
+          <p
+            className="text-body-secondary mb-0"
+            style={{ whiteSpace: "pre-wrap" }}
+          >
             {element.description?.trim() || "Sem descrição cadastrada."}
           </p>
+          {element.status !== "APPROVED" ? (
+            <div
+              className={`alert ${
+                hasOfficialMetaId ? "alert-success" : "alert-warning"
+              } py-2 mb-0 small`}
+              role="status"
+            >
+              {approvalHelpText}
+            </div>
+          ) : null}
           <dl className="row small mb-0">
             <dt className="col-sm-5">Modelo</dt>
             <dd className="col-sm-7">{element.model ?? "—"}</dd>
@@ -193,14 +217,16 @@ export function TargetingElementCard({
             <button
               type="button"
               className={`btn btn-sm ${
-                element.status === "APPROVED" ? "btn-outline-secondary" : "btn-outline-success"
+                element.status === "APPROVED"
+                  ? "btn-outline-secondary"
+                  : "btn-outline-success"
               }`}
               onClick={() =>
                 handleStatusUpdate(
                   element.status === "APPROVED" ? "NEEDS_REVIEW" : "APPROVED",
                 )
               }
-              disabled={isMutating}
+              disabled={isMutating || !canApprove}
             >
               {isMutating && (
                 <span
@@ -209,9 +235,7 @@ export function TargetingElementCard({
                   aria-hidden="true"
                 />
               )}
-              {element.status === "APPROVED"
-                ? "Revogar aprovação"
-                : "Aprovar"}
+              {element.status === "APPROVED" ? "Revogar aprovação" : "Aprovar"}
             </button>
             <button
               type="button"
@@ -225,7 +249,12 @@ export function TargetingElementCard({
       </div>
 
       {showModal ? (
-        <div className="modal d-block" tabIndex={-1} role="dialog" aria-modal="true">
+        <div
+          className="modal d-block"
+          tabIndex={-1}
+          role="dialog"
+          aria-modal="true"
+        >
           <div className="modal-dialog modal-lg modal-dialog-scrollable">
             <div className="modal-content">
               <div className="modal-header">
@@ -247,7 +276,10 @@ export function TargetingElementCard({
                       className="form-control"
                       value={formState.term}
                       onChange={(event) =>
-                        setFormState((prev) => ({ ...prev, term: event.target.value }))
+                        setFormState((prev) => ({
+                          ...prev,
+                          term: event.target.value,
+                        }))
                       }
                     />
                   </div>
@@ -278,7 +310,9 @@ export function TargetingElementCard({
                       onChange={(event) =>
                         setFormState((prev) => ({
                           ...prev,
-                          source: event.target.value as TargetingElementSource | "",
+                          source: event.target.value as
+                            | TargetingElementSource
+                            | "",
                         }))
                       }
                     >
@@ -296,7 +330,10 @@ export function TargetingElementCard({
                       className="form-control"
                       value={formState.model}
                       onChange={(event) =>
-                        setFormState((prev) => ({ ...prev, model: event.target.value }))
+                        setFormState((prev) => ({
+                          ...prev,
+                          model: event.target.value,
+                        }))
                       }
                     />
                   </div>
@@ -336,7 +373,10 @@ export function TargetingElementCard({
                       rows={4}
                       value={formState.prompt}
                       onChange={(event) =>
-                        setFormState((prev) => ({ ...prev, prompt: event.target.value }))
+                        setFormState((prev) => ({
+                          ...prev,
+                          prompt: event.target.value,
+                        }))
                       }
                     />
                   </div>
@@ -347,12 +387,17 @@ export function TargetingElementCard({
                       rows={3}
                       value={formState.notes}
                       onChange={(event) =>
-                        setFormState((prev) => ({ ...prev, notes: event.target.value }))
+                        setFormState((prev) => ({
+                          ...prev,
+                          notes: event.target.value,
+                        }))
                       }
                     />
                   </div>
                   <div className="col-12 col-md-6">
-                    <label className="form-label">Responsável pela revisão</label>
+                    <label className="form-label">
+                      Responsável pela revisão
+                    </label>
                     <input
                       className="form-control"
                       value={formState.lastReviewedBy}
@@ -370,7 +415,10 @@ export function TargetingElementCard({
                       className="form-control"
                       value={formState.metaId}
                       onChange={(event) =>
-                        setFormState((prev) => ({ ...prev, metaId: event.target.value }))
+                        setFormState((prev) => ({
+                          ...prev,
+                          metaId: event.target.value,
+                        }))
                       }
                     />
                   </div>
@@ -380,7 +428,10 @@ export function TargetingElementCard({
                       className="form-control"
                       value={formState.metaKey}
                       onChange={(event) =>
-                        setFormState((prev) => ({ ...prev, metaKey: event.target.value }))
+                        setFormState((prev) => ({
+                          ...prev,
+                          metaKey: event.target.value,
+                        }))
                       }
                     />
                   </div>

--- a/frontend/src/components/TargetingGenerationForm.tsx
+++ b/frontend/src/components/TargetingGenerationForm.tsx
@@ -72,10 +72,11 @@ export function TargetingGenerationForm({
   const pendingTotal = requestedTotal ?? 0;
   const hasPendingRequest = pendingTotal > 0;
   const isSubmitting = request.isPending || Boolean(isLoadingModels);
+  const progressStatus = hasPendingRequest ? "Aguardando Worker" : "Fila livre";
   const statusMessage =
     statusLabel ??
     (hasPendingRequest
-      ? `Solicitação pendente no Worker: ${pendingTotal}. A lista pode aumentar automaticamente quando o processamento terminar.`
+      ? `Há ${pendingTotal} item(ns) solicitado(s). Esta tela atualiza automaticamente a cada 15 segundos até o Worker concluir.`
       : "Nenhuma solicitação pendente no Worker.");
 
   return (
@@ -130,11 +131,32 @@ export function TargetingGenerationForm({
           </button>
         ) : null}
       </div>
-      <small
-        className={hasPendingRequest ? "text-warning" : "text-body-secondary"}
+      <div
+        className={`border rounded-3 p-2 small ${
+          hasPendingRequest
+            ? "border-warning-subtle bg-warning-subtle"
+            : "bg-light"
+        }`}
+        aria-live="polite"
       >
-        {isFetchingStatus ? "Atualizando solicitações..." : statusMessage}
-      </small>
+        <div className="d-flex justify-content-between gap-2 flex-wrap">
+          <span className="fw-semibold">{progressStatus}</span>
+          <span>{pendingTotal} pendente(s)</span>
+        </div>
+        <div
+          className={
+            hasPendingRequest ? "text-warning-emphasis" : "text-body-secondary"
+          }
+        >
+          {isFetchingStatus ? "Atualizando solicitações..." : statusMessage}
+        </div>
+        {hasPendingRequest ? (
+          <div className="text-body-secondary mt-1">
+            Nova solicitação antes da conclusão substitui a quantidade pendente
+            atual; não soma automaticamente.
+          </div>
+        ) : null}
+      </div>
     </form>
   );
 }

--- a/frontend/src/pages/niche/NicheDetailPage.tsx
+++ b/frontend/src/pages/niche/NicheDetailPage.tsx
@@ -194,7 +194,7 @@ export default function NicheDetailPage() {
   const { nicheId } = useParams();
   const id = Number(nicheId);
   const normalizedNicheId = Number.isFinite(id) ? id : undefined;
-  const { data, isLoading, isFetching } = useNiche(id);
+  const { data, isLoading, isFetching, refetch: refetchNiche } = useNiche(id);
   const facebookPixelId = data?.facebookPixelId ?? null;
   const facebookPixelCode = data?.facebookPixelCode ?? null;
   const facebookPixelCreatedAtLabel = data?.facebookPixelCreatedAt
@@ -209,8 +209,11 @@ export default function NicheDetailPage() {
   );
   const { data: chatDialog } = useChatDialog(data?.chatDialogId);
   const { data: hypotheses } = useHypothesesByNiche(nicheId, "ALL");
-  const { data: targetingElements, isFetching: isFetchingTargeting } =
-    useTargetingElementsByNiche(nicheId);
+  const {
+    data: targetingElements,
+    isFetching: isFetchingTargeting,
+    refetch: refetchTargetingElements,
+  } = useTargetingElementsByNiche(nicheId);
   const { data: experiments } = useExperimentsByNiche(nicheId);
   const { data: deliverables } = useDeliverablesByNiche(nicheId);
   const { data: informationSources } = useInformationSourcesByNiche(nicheId);
@@ -515,6 +518,24 @@ export default function NicheDetailPage() {
       anchor: "niche-behaviors",
     },
   ];
+
+  const hasPendingTargetingGeneration = targetingConfigs.some(
+    (config) => (config.requested ?? 0) > 0,
+  );
+
+  useEffect(() => {
+    if (!hasPendingTargetingGeneration) {
+      return undefined;
+    }
+
+    const intervalId = window.setInterval(() => {
+      void refetchNiche();
+      void refetchTargetingElements();
+    }, 15_000);
+
+    return () => window.clearInterval(intervalId);
+  }, [hasPendingTargetingGeneration, refetchNiche, refetchTargetingElements]);
+
   const informationSourceList = Array.isArray(informationSources)
     ? [...informationSources].sort((a, b) => {
         const aDate = a.createdAt ? new Date(a.createdAt).getTime() : 0;
@@ -2287,9 +2308,9 @@ export default function NicheDetailPage() {
             </div>
             <div className="small">
               Para aparecer no experimento, gere e aprove separadamente
-              interesses, cargos e comportamentos com ID oficial da Meta. O
-              painel de solicitações fica apenas como acompanhamento da última
-              rodada processada.
+              interesses, cargos e comportamentos com ID oficial da Meta. A
+              geração por IA cria itens para revisão; a aprovação final não é
+              automática quando ainda não existe ID oficial da Meta.
             </div>
           </div>
 


### PR DESCRIPTION
### Motivation
- Prevent approving targeting elements (interest, job title, behavior) for campaign use when they lack an official Meta ID and ensure the UI communicates this constraint and current worker queue state.
- Improve user visibility into pending AI Worker generation requests by adding a small progress/status block and automatic polling while any targeting generation is pending.
- Keep tests and docs aligned with the new operational rule so regressions are prevented.

### Description
- Backend: added `validateReadyState(TargetingElement)` to enforce that approved elements must have a non-empty `term` and, for `INTEREST`, `JOB_TITLE`, or `BEHAVIOR`, a non-empty `metaId`; `validateReadyState` is invoked during `create` and a helper `requiresMetaId(TargetingElementType)` was introduced.
- Tests: extended `TargetingElementGenerationServiceTest` with `createShouldRejectApprovedJobTitleWithoutMetaId` and `createShouldApproveJobTitleWithMetaId` to assert the new approval constraints; updated imports to use `assertThatThrownBy`.
- Frontend: updated `TargetingElementCard` to surface an approval help alert, disable the approve button when lacking an official Meta ID, and keep small JSX/formatting improvements; updated `TargetingGenerationForm` to show a compact progress block with queue status and extra messaging; updated `NicheDetailPage` to poll (`refetch`) niche and targeting elements every 15 seconds while any targeting generation is pending.
- Docs: recorded the change and rationale under `docs/registros/experimentos.md` noting UI and backend prevention and added the visual tracking/approval requirement entries.

### Testing
- Ran unit tests for the targeting generation contracts: `TargetingElementGenerationServiceTest` (including the two new tests `createShouldRejectApprovedJobTitleWithoutMetaId` and `createShouldApproveJobTitleWithMetaId`), and they passed.
- Existing backend tests that exercise generation/mark-failure semantics were re-run and passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3c396484cc832199e317231c148fd6)