### PR TITLE
Normalize campos coverage_* da Graph API como audience bounds e aceitar nomes alternativos no Facebook Ads Worker

### DIFF
--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -5332,3 +5332,9 @@
 - Solicitação: aplicar aos comportamentos o mesmo controle já reforçado para cargos.
 - Correção aplicada: a regra de aprovação permanece única para interesses, cargos e comportamentos; a cobertura de testes passou a validar explicitamente comportamento sem ID oficial da Meta e comportamento com ID oficial.
 - Resultado esperado: comportamento gerado pela IA fica para revisão e só pode ser aprovado/publicado quando houver ID oficial da Meta.
+
+## 2026-06-24 — Destravamento da fila de resolução Meta Ads para cargos
+
+- Solicitação: confirmar se os cargos gerados para nicho seriam pesquisados na Meta Ads em português e inglês.
+- Causa-raiz encontrada: o fluxo automático existia, mas podia manter itens antigos na fila quando a Graph API retornava alcance como `coverage_lower_bound`/`coverage_upper_bound` em vez de `audience_size_lower_bound`/`audience_size_upper_bound`, atrasando o avanço para cargos novos.
+- Correção aplicada: o Facebook Ads Worker passou a normalizar também os campos `coverage_*` como alcance oficial antes de reportar ao backend, permitindo que itens já resolvidos saiam da fila e a pesquisa avance para os próximos cargos pendentes.

--- a/facebook-ads-worker/README.md
+++ b/facebook-ads-worker/README.md
@@ -50,6 +50,11 @@ interesses, `adworkposition` para cargos e `adTargetingCategory` com
 - limite mínimo estimado (`audience_size_lower_bound`),
 - limite máximo estimado (`audience_size_upper_bound`).
 
+Quando a Graph API retornar os limites como `coverage_lower_bound` e
+`coverage_upper_bound`, o worker normaliza esses campos para o mesmo contrato de
+alcance reportado ao backend. Isso evita que itens com ID oficial permaneçam na
+fila por falta dos nomes alternativos de alcance retornados pela Meta.
+
 Esses limites são usados pelo Marketing Hub como alcance inicial do sinal antes
 de montar ou escalar campanha. Após encontrar o melhor match, o worker envia os dados para o backend via
 `PATCH /api/internal/targeting/elements/{id}/metaads`, mantendo a base local

--- a/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/FacebookAdsService.java
+++ b/facebook-ads-worker/src/main/java/com/marketinghub/facebookadsworker/FacebookAdsService.java
@@ -1523,8 +1523,8 @@ private FacebookInterest searchInterest(String interestName, String locale) {
                 String name = node.path("name").asText(null);
                 String type = node.path("type").asText(null);
                 String topic = node.path("topic").asText(null);
-                Long audienceSizeLower = node.hasNonNull("audience_size_lower_bound") ? node.path("audience_size_lower_bound").asLong() : null;
-                Long audienceSizeUpper = node.hasNonNull("audience_size_upper_bound") ? node.path("audience_size_upper_bound").asLong() : null;
+                Long audienceSizeLower = readLongField(node, "audience_size_lower_bound", "coverage_lower_bound");
+                Long audienceSizeUpper = readLongField(node, "audience_size_upper_bound", "coverage_upper_bound");
                 List<String> hierarchy = parseTargetingPath(node.path("path"));
                 results.add(new FacebookTargetingSearchResult(
                     id.trim(),
@@ -1543,6 +1543,22 @@ private FacebookInterest searchInterest(String interestName, String locale) {
             LOGGER.warn("Facebook targeting search failed for path {}: {}", pathValue, ex.getMessage(), ex);
             return Collections.emptyList();
         }
+    }
+
+    /**
+     * Lê um campo numérico da resposta da Meta aceitando nomes alternativos usados pela Graph API.
+     */
+    private Long readLongField(JsonNode node, String primaryField, String fallbackField) {
+        if (node == null || node.isNull()) {
+            return null;
+        }
+        if (node.hasNonNull(primaryField)) {
+            return node.path(primaryField).asLong();
+        }
+        if (node.hasNonNull(fallbackField)) {
+            return node.path(fallbackField).asLong();
+        }
+        return null;
     }
 
     public record FacebookTargetingSuggestionResult(String id, String name, Long audienceSize, List<String> path) {}

--- a/facebook-ads-worker/src/test/java/com/marketinghub/facebookadsworker/FacebookAdsServiceTest.java
+++ b/facebook-ads-worker/src/test/java/com/marketinghub/facebookadsworker/FacebookAdsServiceTest.java
@@ -354,7 +354,7 @@ class FacebookAdsServiceTest {
 
     @Test
     void searchGlobalTargetingOptionsDoesNotSendFieldsParameter() throws Exception {
-        server.enqueueResponse(new MockResponse().setBody("{\"data\":[{\"id\":\"1419795191647433\",\"name\":\"Certified Personal Trainer\"}]}" )
+        server.enqueueResponse(new MockResponse().setBody("{\"data\":[{\"id\":\"1419795191647433\",\"name\":\"Certified Personal Trainer\",\"coverage_lower_bound\":1000,\"coverage_upper_bound\":2000}]}" )
             .addHeader("Content-Type", "application/json"));
 
         List<FacebookAdsService.FacebookTargetingSearchResult> results = service.searchGlobalTargetingOptions(
@@ -382,6 +382,8 @@ class FacebookAdsServiceTest {
         assertEquals(1, results.size());
         assertEquals("1419795191647433", results.get(0).id());
         assertEquals("Certified Personal Trainer", results.get(0).name());
+        assertEquals(1000L, results.get(0).audienceSizeLowerBound());
+        assertEquals(2000L, results.get(0).audienceSizeUpperBound());
     }
 
 


### PR DESCRIPTION
### Motivation
- Corrigir bloqueio da fila de resolução de targeting quando a Graph API retorna limites de alcance com os nomes `coverage_lower_bound`/`coverage_upper_bound` em vez de `audience_size_lower_bound`/`audience_size_upper_bound`.
- Garantir que itens com ID oficial da Meta sejam liberados da fila mesmo quando a API usar nomes de campo alternativos.

### Description
- Adicionada a função helper `readLongField(JsonNode, String, String)` em `FacebookAdsService` e seu uso em `fetchTargetingResults` para ler limites de alcance a partir de `audience_size_*` ou, em fallback, `coverage_*`.
- Atualizados testes em `FacebookAdsServiceTest` para responder com `coverage_lower_bound`/`coverage_upper_bound` e validar os valores mapeados para `audienceSizeLowerBound` e `audienceSizeUpperBound`.
- Documentação atualizada em `facebook-ads-worker/README.md` e `docs/registros/experimentos.md` para descrever a normalização dos campos `coverage_*` e a correção da fila de resolução de targeting.

### Testing
- Executed unit tests in `FacebookAdsServiceTest`, including `searchGlobalTargetingOptionsDoesNotSendFieldsParameter`, which now asserts mapping from `coverage_*` to audience bounds, and they passed.
- Ran the worker-related test suite that covers targeting search and queue processing, and all tests succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3c490733c48321b3bc655003946aa5)