### PR TITLE
Include NEEDS_REVIEW items in Meta Ads pending queue and add repository test

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/targeting/TargetingElementRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/targeting/TargetingElementRepository.java
@@ -70,11 +70,14 @@ public interface TargetingElementRepository extends JpaRepository<TargetingEleme
                                         @Param("hypothesisId") UUID hypothesisId);
 
     /**
-     * Lista elementos aprovados que ainda precisam de ID e alcance oficial da Meta Ads.
+     * Lista elementos aprovados ou em revisão que ainda precisam de ID e alcance oficial da Meta Ads.
      */
     @Query("""
             select e from TargetingElement e
-            where e.status = com.marketinghub.targeting.TargetingElementStatus.APPROVED
+            where e.status in (
+                com.marketinghub.targeting.TargetingElementStatus.APPROVED,
+                com.marketinghub.targeting.TargetingElementStatus.NEEDS_REVIEW
+              )
               and e.source in (
                 com.marketinghub.targeting.TargetingElementSource.MANUAL,
                 com.marketinghub.targeting.TargetingElementSource.AI,

--- a/backend/ads-service/src/main/java/com/marketinghub/targeting/service/TargetingMetaAdsSyncService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/targeting/service/TargetingMetaAdsSyncService.java
@@ -26,7 +26,7 @@ public class TargetingMetaAdsSyncService {
     }
 
     /**
-     * Lista elementos aprovados que ainda precisam de ID oficial e alcance da Meta Ads.
+     * Lista elementos aprovados ou em revisão que ainda precisam de ID oficial e alcance da Meta Ads.
      */
     public List<TargetingMetaAdsPendingElementDto> listPending(int limit) {
         int safeLimit = Math.max(1, Math.min(limit, 200));

--- a/backend/ads-service/src/test/java/com/marketinghub/targeting/TargetingElementRepositoryTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/targeting/TargetingElementRepositoryTest.java
@@ -1,0 +1,58 @@
+package com.marketinghub.targeting;
+
+import com.marketinghub.niche.MarketNiche;
+import com.marketinghub.repository.jpa.niche.MarketNicheRepository;
+import com.marketinghub.repository.jpa.targeting.TargetingElementRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.test.context.TestPropertySource;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/** Responsabilidade: validar consultas JPA dos elementos de segmentação. */
+@DataJpaTest
+@TestPropertySource(properties = "spring.liquibase.enabled=false")
+class TargetingElementRepositoryTest {
+
+    @Autowired
+    private TargetingElementRepository repository;
+
+    @Autowired
+    private MarketNicheRepository nicheRepository;
+
+    /** Deve listar interesses, cargos e comportamentos em revisão para validação oficial da Meta Ads. */
+    @Test
+    void findMetaAdsPendingIncludesNeedsReviewInterestJobTitleAndBehavior() {
+        MarketNiche niche = nicheRepository.save(MarketNiche.builder().name("Moda").build());
+        TargetingElement interest = pendingElement(niche, TargetingElementType.INTEREST, "Fashion");
+        TargetingElement jobTitle = pendingElement(niche, TargetingElementType.JOB_TITLE, "Fashion Designer");
+        TargetingElement behavior = pendingElement(niche, TargetingElementType.BEHAVIOR, "Engaged shoppers");
+        TargetingElement draft = pendingElement(niche, TargetingElementType.INTEREST, "Draft interest");
+        draft.setStatus(TargetingElementStatus.DRAFT);
+        repository.save(interest);
+        repository.save(jobTitle);
+        repository.save(behavior);
+        repository.save(draft);
+
+        var pending = repository.findMetaAdsPending(PageRequest.of(0, 10));
+
+        assertThat(pending)
+                .extracting(TargetingElement::getTerm)
+                .contains("Fashion", "Fashion Designer", "Engaged shoppers")
+                .doesNotContain("Draft interest");
+    }
+
+    /** Cria elemento de segmentação em revisão para reduzir duplicação no teste. */
+    private TargetingElement pendingElement(MarketNiche niche, TargetingElementType type, String term) {
+        return TargetingElement.builder()
+                .niche(niche)
+                .type(type)
+                .term(term)
+                .source(TargetingElementSource.AI)
+                .status(TargetingElementStatus.NEEDS_REVIEW)
+                .metaIdUnavailable(false)
+                .build();
+    }
+}

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -5338,3 +5338,10 @@
 - Solicitação: confirmar se os cargos gerados para nicho seriam pesquisados na Meta Ads em português e inglês.
 - Causa-raiz encontrada: o fluxo automático existia, mas podia manter itens antigos na fila quando a Graph API retornava alcance como `coverage_lower_bound`/`coverage_upper_bound` em vez de `audience_size_lower_bound`/`audience_size_upper_bound`, atrasando o avanço para cargos novos.
 - Correção aplicada: o Facebook Ads Worker passou a normalizar também os campos `coverage_*` como alcance oficial antes de reportar ao backend, permitindo que itens já resolvidos saiam da fila e a pesquisa avance para os próximos cargos pendentes.
+
+## 2026-06-24 — Fila Meta Ads valida itens em revisão
+
+- Problema: interesses, cargos e comportamentos gerados pela IA ficavam em `NEEDS_REVIEW` sem ID oficial da Meta, mas o Facebook Ads Worker recebia fila vazia em `/api/internal/targeting/elements/metaads-pending`.
+- Causa-raiz: a query da fila Meta Ads entregava apenas elementos `APPROVED`, enquanto a aprovação de interesse, cargo e comportamento exige `metaId` oficial; isso criava um bloqueio circular entre validação Meta e aprovação humana.
+- Correção aplicada: a fila Meta Ads passou a incluir elementos `NEEDS_REVIEW` e `APPROVED` dos três tipos suportados (`INTEREST`, `JOB_TITLE` e `BEHAVIOR`), mantendo o bloqueio contra itens `DRAFT`, `REJECTED`, hipótese específica e itens já marcados como Meta indisponível.
+- Prevenção de recorrência: adicionado teste de repository cobrindo interesse, cargo e comportamento em revisão na fila Meta Ads e excluindo rascunho.


### PR DESCRIPTION
### Motivation

- The Meta Ads worker was sometimes receiving an empty pending queue because the JPA query returned only `APPROVED` elements while IA-generated items remained in `NEEDS_REVIEW`, creating a circular blockage between validation and approval. 
- The change aims to surface both `NEEDS_REVIEW` and `APPROVED` interests, job titles and behaviors for official Meta Ads lookup so they can obtain `metaId` and audience size before approval.

### Description

- Updated `TargetingElementRepository.findMetaAdsPending` query to include statuses `TargetingElementStatus.NEEDS_REVIEW` and `TargetingElementStatus.APPROVED` instead of only `APPROVED` for the Meta Ads pending queue. 
- Kept existing filters (source, null hypothesis, types INTEREST/JOB_TITLE/BEHAVIOR, not `metaIdUnavailable`, and missing `metaId`/audience bounds) and ordering unchanged. 
- Adjusted service Javadoc in `TargetingMetaAdsSyncService` to reflect that both `NEEDS_REVIEW` and `APPROVED` items are returned. 
- Added `TargetingElementRepositoryTest` (Data JPA test) to assert that `findMetaAdsPending` includes AI-generated items in `NEEDS_REVIEW` for INTEREST, JOB_TITLE and BEHAVIOR and excludes items in `DRAFT`. 
- Documented the change in `docs/registros/experimentos.md` describing the fix and rationale.

### Testing

- Ran the new `TargetingElementRepositoryTest` (a `@DataJpaTest` repository slice) which exercised `findMetaAdsPending` and it passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3c510bb5ec83218c410ec6b581b269)