### PR TITLE
Add ExperimentRun persistence, preflight gates, API, UI and DB migrations

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/run/ExperimentEvidenceValidity.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/run/ExperimentEvidenceValidity.java
@@ -1,0 +1,13 @@
+package com.marketinghub.experiment.run;
+
+/**
+ * Classifica se a evidência de um run pode apoiar aprendizado comercial.
+ */
+public enum ExperimentEvidenceValidity {
+    NOT_EVALUATED,
+    TECHNICALLY_INVALID,
+    MEASUREMENT_INVALID,
+    STRATEGICALLY_INVALID,
+    INSUFFICIENT_DATA,
+    COMMERCIALLY_VALID
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/run/ExperimentRun.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/run/ExperimentRun.java
@@ -1,0 +1,119 @@
+package com.marketinghub.experiment.run;
+
+import com.marketinghub.experiment.Experiment;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+import org.hibernate.annotations.UpdateTimestamp;
+
+import java.time.Instant;
+
+/**
+ * Representa uma tentativa operacional auditável de executar um experimento comercial.
+ */
+@Entity
+@Table(name = "experiment_run", uniqueConstraints = @UniqueConstraint(columnNames = {"experiment_id", "run_number"}))
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ExperimentRun {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(optional = false, fetch = FetchType.LAZY)
+    @JoinColumn(name = "experiment_id", nullable = false)
+    private Experiment experiment;
+
+    @Column(name = "run_number", nullable = false)
+    private Integer runNumber;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "mode", length = 24, nullable = false)
+    private ExperimentRunMode mode;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", length = 32, nullable = false)
+    private ExperimentRunStatus status;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "evidence_validity", length = 32, nullable = false)
+    private ExperimentEvidenceValidity evidenceValidity;
+
+    @Column(name = "strategy_version")
+    private Integer strategyVersion;
+
+    @Column(name = "asset_bundle_version")
+    private Integer assetBundleVersion;
+
+    @Column(name = "audience_version")
+    private Integer audienceVersion;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "stop_policy", length = 48, nullable = false)
+    private ExperimentRunStopPolicy stopPolicy;
+
+    @Column(name = "stop_reason", length = 96)
+    private String stopReason;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "failure_classification", length = 64)
+    private ExperimentRunFailureClassification failureClassification;
+
+    @Column(name = "failure_detail", columnDefinition = "LONGTEXT")
+    private String failureDetail;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "data_quality_status", length = 32, nullable = false)
+    private ExperimentRunDataQualityStatus dataQualityStatus;
+
+    @Column(name = "requested_at", nullable = false)
+    private Instant requestedAt;
+
+    @Column(name = "preflight_started_at")
+    private Instant preflightStartedAt;
+
+    @Column(name = "preflight_completed_at")
+    private Instant preflightCompletedAt;
+
+    @Column(name = "publication_requested_at")
+    private Instant publicationRequestedAt;
+
+    @Column(name = "published_at")
+    private Instant publishedAt;
+
+    @Column(name = "first_verified_impression_at")
+    private Instant firstVerifiedImpressionAt;
+
+    @Column(name = "commercial_window_started_at")
+    private Instant commercialWindowStartedAt;
+
+    @Column(name = "ended_at")
+    private Instant endedAt;
+
+    @Column(name = "created_by", length = 191)
+    private String createdBy;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+
+    @UpdateTimestamp
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt;
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/run/ExperimentRunDataQualityStatus.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/run/ExperimentRunDataQualityStatus.java
@@ -1,0 +1,12 @@
+package com.marketinghub.experiment.run;
+
+/**
+ * Resume a qualidade dos dados disponíveis para uma execução de experimento.
+ */
+public enum ExperimentRunDataQualityStatus {
+    UNKNOWN,
+    VALID,
+    WARNING,
+    BLOCKED,
+    STALE
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/run/ExperimentRunFailureClassification.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/run/ExperimentRunFailureClassification.java
@@ -1,0 +1,22 @@
+package com.marketinghub.experiment.run;
+
+/**
+ * Taxonomia inicial de causa-raiz para falhas de execução ou evidência comercial.
+ */
+public enum ExperimentRunFailureClassification {
+    INTEGRATION_FAILURE,
+    PUBLICATION_FAILURE,
+    MEASUREMENT_FAILURE,
+    FORM_FUNCTIONAL_FAILURE,
+    LANDING_QUALITY_FAILURE,
+    UPSTREAM_DATA_QUALITY_FAILURE,
+    STRATEGY_CONFIGURATION_FAILURE,
+    AUDIENCE_FAILURE,
+    CREATIVE_FAILURE,
+    PROMISE_OR_LEAD_MAGNET_FAILURE,
+    OFFER_FAILURE,
+    PRICE_OR_CHECKOUT_FAILURE,
+    INSUFFICIENT_DATA,
+    COMMERCIAL_HYPOTHESIS_FAILURE,
+    USER_STOPPED
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/run/ExperimentRunGateEvaluatorType.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/run/ExperimentRunGateEvaluatorType.java
@@ -1,0 +1,10 @@
+package com.marketinghub.experiment.run;
+
+/**
+ * Indica qual tipo de avaliador produziu o resultado do gate.
+ */
+public enum ExperimentRunGateEvaluatorType {
+    DETERMINISTIC,
+    HUMAN,
+    EXTERNAL_PROVIDER
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/run/ExperimentRunGateGroup.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/run/ExperimentRunGateGroup.java
@@ -1,0 +1,13 @@
+package com.marketinghub.experiment.run;
+
+/**
+ * Agrupa gates de preflight conforme a preparação comercial e operacional do run.
+ */
+public enum ExperimentRunGateGroup {
+    UPSTREAM_QUALITY,
+    EXPERIMENT_DESIGN,
+    ASSET_QUALITY,
+    FUNCTIONAL_E2E,
+    META_PUBLICATION,
+    MEASUREMENT
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/run/ExperimentRunGateResult.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/run/ExperimentRunGateResult.java
@@ -1,0 +1,78 @@
+package com.marketinghub.experiment.run;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.ManyToOne;
+import jakarta.persistence.Table;
+import jakarta.persistence.UniqueConstraint;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.Instant;
+
+/**
+ * Registra o resultado atual de um gate de preparação vinculado a um run de experimento.
+ */
+@Entity
+@Table(name = "experiment_run_gate_result", uniqueConstraints = @UniqueConstraint(columnNames = {"experiment_run_id", "gate_code"}))
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+public class ExperimentRunGateResult {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(optional = false, fetch = FetchType.LAZY)
+    @JoinColumn(name = "experiment_run_id", nullable = false)
+    private ExperimentRun experimentRun;
+
+    @Column(name = "gate_code", length = 96, nullable = false)
+    private String gateCode;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "gate_group", length = 48, nullable = false)
+    private ExperimentRunGateGroup gateGroup;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", length = 24, nullable = false)
+    private ExperimentRunGateStatus status;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "severity", length = 24, nullable = false)
+    private ExperimentRunGateSeverity severity;
+
+    @Column(name = "summary", length = 512, nullable = false)
+    private String summary;
+
+    @Column(name = "evidence_reference", length = 512)
+    private String evidenceReference;
+
+    @Column(name = "remediation_code", length = 96)
+    private String remediationCode;
+
+    @Column(name = "evaluated_at", nullable = false)
+    private Instant evaluatedAt;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "evaluator_type", length = 24, nullable = false)
+    private ExperimentRunGateEvaluatorType evaluatorType;
+
+    @Column(name = "evaluator_version", length = 64)
+    private String evaluatorVersion;
+
+    @CreationTimestamp
+    @Column(name = "created_at", nullable = false, updatable = false)
+    private Instant createdAt;
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/run/ExperimentRunGateSeverity.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/run/ExperimentRunGateSeverity.java
@@ -1,0 +1,10 @@
+package com.marketinghub.experiment.run;
+
+/**
+ * Define a severidade operacional de um gate de preparação do run.
+ */
+public enum ExperimentRunGateSeverity {
+    INFO,
+    WARNING,
+    BLOCKER
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/run/ExperimentRunGateStatus.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/run/ExperimentRunGateStatus.java
@@ -1,0 +1,12 @@
+package com.marketinghub.experiment.run;
+
+/**
+ * Representa o resultado objetivo de um gate de preparação do run.
+ */
+public enum ExperimentRunGateStatus {
+    PASS,
+    WARNING,
+    FAIL,
+    NOT_APPLICABLE,
+    PENDING
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/run/ExperimentRunMode.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/run/ExperimentRunMode.java
@@ -1,0 +1,9 @@
+package com.marketinghub.experiment.run;
+
+/**
+ * Define se a execução do experimento é teste técnico ou produção comercial.
+ */
+public enum ExperimentRunMode {
+    TEST,
+    PRODUCTION
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/run/ExperimentRunStatus.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/run/ExperimentRunStatus.java
@@ -1,0 +1,22 @@
+package com.marketinghub.experiment.run;
+
+/**
+ * Representa o estado operacional de uma tentativa de execução do experimento.
+ */
+public enum ExperimentRunStatus {
+    DRAFT,
+    PREFLIGHT_PENDING,
+    PREFLIGHT_RUNNING,
+    PREFLIGHT_FAILED,
+    READY_TO_PUBLISH,
+    PUBLICATION_PENDING,
+    PUBLISHING,
+    PUBLISHED_AWAITING_EXPOSURE,
+    RUNNING,
+    PAUSE_REQUESTED,
+    PAUSED,
+    STOP_REQUESTED,
+    COMPLETED,
+    FAILED,
+    CANCELLED
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/run/ExperimentRunStopPolicy.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/run/ExperimentRunStopPolicy.java
@@ -1,0 +1,12 @@
+package com.marketinghub.experiment.run;
+
+/**
+ * Define a política operacional usada para encerrar ou pausar uma execução.
+ */
+public enum ExperimentRunStopPolicy {
+    FIRST_VALID_LEAD_STANDBY,
+    FIXED_WINDOW,
+    MIN_SAMPLE_AND_WINDOW,
+    STOP_LOSS,
+    MANUAL_ONLY
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/run/controller/BackendExperimentRunController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/run/controller/BackendExperimentRunController.java
@@ -1,0 +1,59 @@
+package com.marketinghub.experiment.run.controller;
+
+import com.marketinghub.experiment.run.service.BackendExperimentRunService;
+import com.marketinghub.experiment.run.service.create.CreateExperimentRunRequest;
+import com.marketinghub.experiment.run.service.get.ExperimentRunResponse;
+import com.marketinghub.experiment.run.service.preflight.ExperimentRunPreflightResponse;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.util.List;
+
+/**
+ * Expõe endpoints administrativos para criação e consulta de execuções de experimento.
+ */
+@RestController
+@RequestMapping("/api")
+public class BackendExperimentRunController {
+    private final BackendExperimentRunService service;
+
+    /** Inicializa o controller com o serviço canônico de runs de experimento. */
+    public BackendExperimentRunController(BackendExperimentRunService service) {
+        this.service = service;
+    }
+
+    /** Cria uma nova tentativa operacional sequencial para o experimento informado. */
+    @PostMapping("/experiments/{experimentId}/runs")
+    public ExperimentRunResponse create(@PathVariable Long experimentId,
+                                        @RequestBody(required = false) CreateExperimentRunRequest request) {
+        return service.create(experimentId, request);
+    }
+
+    /** Lista as tentativas operacionais já criadas para um experimento. */
+    @GetMapping("/experiments/{experimentId}/runs")
+    public List<ExperimentRunResponse> listByExperiment(@PathVariable Long experimentId) {
+        return service.listByExperiment(experimentId);
+    }
+
+    /** Consulta o resultado atual de preflight do run. */
+    @GetMapping("/experiment-runs/{runId}/preflight")
+    public ExperimentRunPreflightResponse getPreflight(@PathVariable Long runId) {
+        return service.getPreflight(runId);
+    }
+
+    /** Executa a avaliação determinística inicial de preflight do run. */
+    @PostMapping("/experiment-runs/{runId}/preflight")
+    public ExperimentRunPreflightResponse runPreflight(@PathVariable Long runId) {
+        return service.runPreflight(runId);
+    }
+
+    /** Retorna os detalhes de uma tentativa operacional pelo identificador do run. */
+    @GetMapping("/experiment-runs/{runId}")
+    public ExperimentRunResponse get(@PathVariable Long runId) {
+        return service.get(runId);
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/run/service/BackendExperimentRunService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/run/service/BackendExperimentRunService.java
@@ -1,0 +1,254 @@
+package com.marketinghub.experiment.run.service;
+
+import com.marketinghub.experiment.Experiment;
+import com.marketinghub.experiment.run.ExperimentEvidenceValidity;
+import com.marketinghub.experiment.run.ExperimentRunGateEvaluatorType;
+import com.marketinghub.experiment.run.ExperimentRunGateGroup;
+import com.marketinghub.experiment.run.ExperimentRunGateResult;
+import com.marketinghub.experiment.run.ExperimentRunGateSeverity;
+import com.marketinghub.experiment.run.ExperimentRunGateStatus;
+import com.marketinghub.experiment.run.ExperimentRun;
+import com.marketinghub.experiment.run.ExperimentRunDataQualityStatus;
+import com.marketinghub.experiment.run.ExperimentRunMode;
+import com.marketinghub.experiment.run.ExperimentRunStatus;
+import com.marketinghub.experiment.run.ExperimentRunStopPolicy;
+import com.marketinghub.experiment.run.service.create.CreateExperimentRunRequest;
+import com.marketinghub.experiment.run.service.get.ExperimentRunResponse;
+import com.marketinghub.experiment.run.service.preflight.ExperimentRunGateResultResponse;
+import com.marketinghub.experiment.run.service.preflight.ExperimentRunPreflightResponse;
+import com.marketinghub.hypothesis.Hypothesis;
+import com.marketinghub.repository.jpa.experiment.ExperimentRepository;
+import com.marketinghub.repository.jpa.experiment.ExperimentRunGateResultRepository;
+import com.marketinghub.repository.jpa.experiment.ExperimentRunRepository;
+import jakarta.persistence.EntityNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Instant;
+import java.util.List;
+
+/**
+ * Orquestra criação e leitura dos runs operacionais vinculados a experimentos.
+ */
+@Service
+public class BackendExperimentRunService {
+    private final ExperimentRepository experimentRepository;
+    private static final String EVALUATOR_VERSION = "experiment-run-preflight.v1";
+
+    private final ExperimentRunRepository experimentRunRepository;
+    private final ExperimentRunGateResultRepository gateResultRepository;
+
+    /** Inicializa o serviço com os repositórios canônicos de experimento e run. */
+    public BackendExperimentRunService(ExperimentRepository experimentRepository,
+                                       ExperimentRunRepository experimentRunRepository,
+                                       ExperimentRunGateResultRepository gateResultRepository) {
+        this.experimentRepository = experimentRepository;
+        this.experimentRunRepository = experimentRunRepository;
+        this.gateResultRepository = gateResultRepository;
+    }
+
+    /** Cria um novo run sequencial para o experimento sem alterar o status legado do experimento. */
+    @Transactional
+    public ExperimentRunResponse create(Long experimentId, CreateExperimentRunRequest request) {
+        Experiment experiment = experimentRepository.findById(experimentId)
+                .orElseThrow(() -> new EntityNotFoundException("Experimento %d não encontrado".formatted(experimentId)));
+        int nextRunNumber = experimentRunRepository.findMaxRunNumberByExperimentId(experimentId) + 1;
+        Instant now = Instant.now();
+        ExperimentRun run = ExperimentRun.builder()
+                .experiment(experiment)
+                .runNumber(nextRunNumber)
+                .mode(request != null && request.mode() != null ? request.mode() : ExperimentRunMode.PRODUCTION)
+                .status(ExperimentRunStatus.DRAFT)
+                .evidenceValidity(ExperimentEvidenceValidity.NOT_EVALUATED)
+                .stopPolicy(request != null && request.stopPolicy() != null ? request.stopPolicy() : ExperimentRunStopPolicy.MANUAL_ONLY)
+                .dataQualityStatus(ExperimentRunDataQualityStatus.UNKNOWN)
+                .requestedAt(now)
+                .createdBy(request != null ? request.createdBy() : null)
+                .build();
+        return toResponse(experimentRunRepository.save(run));
+    }
+
+    /** Lista todos os runs de um experimento na ordem em que foram criados. */
+    @Transactional(readOnly = true)
+    public List<ExperimentRunResponse> listByExperiment(Long experimentId) {
+        if (!experimentRepository.existsById(experimentId)) {
+            throw new EntityNotFoundException("Experimento %d não encontrado".formatted(experimentId));
+        }
+        return experimentRunRepository.findByExperimentIdOrderByRunNumberAsc(experimentId).stream()
+                .map(this::toResponse)
+                .toList();
+    }
+
+
+    /** Avalia novamente os gates determinísticos iniciais e atualiza o status operacional do run. */
+    @Transactional
+    public ExperimentRunPreflightResponse runPreflight(Long runId) {
+        ExperimentRun run = experimentRunRepository.findById(runId)
+                .orElseThrow(() -> new EntityNotFoundException("Run de experimento %d não encontrado".formatted(runId)));
+        gateResultRepository.deleteByExperimentRunId(runId);
+        List<ExperimentRunGateResult> gates = buildInitialGateResults(run);
+        List<ExperimentRunGateResult> savedGates = gateResultRepository.saveAll(gates);
+        boolean hasBlockers = savedGates.stream().anyMatch(gate -> gate.getStatus() == ExperimentRunGateStatus.FAIL);
+        run.setStatus(hasBlockers ? ExperimentRunStatus.PREFLIGHT_FAILED : ExperimentRunStatus.READY_TO_PUBLISH);
+        run.setDataQualityStatus(hasBlockers ? ExperimentRunDataQualityStatus.BLOCKED : ExperimentRunDataQualityStatus.VALID);
+        run.setEvidenceValidity(hasBlockers ? ExperimentEvidenceValidity.STRATEGICALLY_INVALID : ExperimentEvidenceValidity.NOT_EVALUATED);
+        run.setPreflightStartedAt(run.getPreflightStartedAt() != null ? run.getPreflightStartedAt() : Instant.now());
+        run.setPreflightCompletedAt(Instant.now());
+        ExperimentRun savedRun = experimentRunRepository.save(run);
+        return toPreflightResponse(savedRun, savedGates);
+    }
+
+    /** Consulta o último resultado de preflight persistido para o run. */
+    @Transactional(readOnly = true)
+    public ExperimentRunPreflightResponse getPreflight(Long runId) {
+        ExperimentRun run = experimentRunRepository.findById(runId)
+                .orElseThrow(() -> new EntityNotFoundException("Run de experimento %d não encontrado".formatted(runId)));
+        List<ExperimentRunGateResult> gates = gateResultRepository.findByExperimentRunIdOrderByGateGroupAscGateCodeAsc(runId);
+        return toPreflightResponse(run, gates);
+    }
+
+    /** Busca um run específico pelo identificador técnico. */
+    @Transactional(readOnly = true)
+    public ExperimentRunResponse get(Long runId) {
+        return experimentRunRepository.findById(runId)
+                .map(this::toResponse)
+                .orElseThrow(() -> new EntityNotFoundException("Run de experimento %d não encontrado".formatted(runId)));
+    }
+
+
+    /** Monta a lista inicial de gates determinísticos com base no experimento vinculado ao run. */
+    private List<ExperimentRunGateResult> buildInitialGateResults(ExperimentRun run) {
+        Experiment experiment = run.getExperiment();
+        Hypothesis hypothesis = experiment.getHypothesisRef();
+        Instant evaluatedAt = Instant.now();
+        return List.of(
+                gate(run, "HYPOTHESIS_ARTIFACT_APPROVED", ExperimentRunGateGroup.UPSTREAM_QUALITY,
+                        hypothesis != null, "Hipótese vinculada ao experimento.",
+                        "Experimento sem hipótese vinculada.", "LINK_HYPOTHESIS", evaluatedAt),
+                gate(run, "PERSONA_MINIMUM_COMPLETE", ExperimentRunGateGroup.UPSTREAM_QUALITY,
+                        hypothesis != null && hasUsefulText(hypothesis.getPersona()), "Persona mínima preenchida.",
+                        "Persona ausente ou preenchida como teste.", "REVIEW_PERSONA", evaluatedAt),
+                gate(run, "DRPO_FRAMEWORK_COMPLETE", ExperimentRunGateGroup.UPSTREAM_QUALITY,
+                        hypothesis != null && hasUsefulText(hypothesis.getProblem()) && hasUsefulText(hypothesis.getPromise())
+                                && hasUsefulText(hypothesis.getMechanism()) && hasUsefulText(hypothesis.getEntrega()),
+                        "Dor, promessa, mecanismo e entrega estão preenchidos.",
+                        "Framework Dor → Resultado → Mecanismo → Prova → Oferta incompleto.",
+                        "COMPLETE_DRPO_FRAMEWORK", evaluatedAt),
+                gate(run, "PRIMARY_VARIABLE_DEFINED", ExperimentRunGateGroup.EXPERIMENT_DESIGN,
+                        hasUsefulText(experiment.getPrimaryVariable()), "Variável primária definida.",
+                        "Variável primária ausente.", "DEFINE_PRIMARY_VARIABLE", evaluatedAt),
+                gate(run, "PRIMARY_METRIC_DEFINED", ExperimentRunGateGroup.EXPERIMENT_DESIGN,
+                        hasUsefulText(experiment.getPrimaryMetric()), "Métrica primária definida.",
+                        "Métrica primária ausente.", "DEFINE_PRIMARY_METRIC", evaluatedAt),
+                gate(run, "KPI_TARGET_CPL_VALID", ExperimentRunGateGroup.EXPERIMENT_DESIGN,
+                        experiment.getKpiTargetCpl() != null && experiment.getKpiTargetCpl().signum() > 0,
+                        "KPI alvo de CPL definido com valor positivo.",
+                        "KPI alvo de CPL ausente ou igual a zero.", "DEFINE_KPI_TARGET_CPL", evaluatedAt),
+                pendingGate(run, "LANDING_QUALITY_REVIEW_APPROVED", ExperimentRunGateGroup.ASSET_QUALITY,
+                        "Revisão da landing ainda não avaliada neste incremento.", evaluatedAt),
+                pendingGate(run, "FORM_CAN_BE_SUBMITTED", ExperimentRunGateGroup.FUNCTIONAL_E2E,
+                        "Teste E2E do formulário será executado em incremento posterior.", evaluatedAt),
+                pendingGate(run, "META_EFFECTIVE_STATUS_CONFIRMED", ExperimentRunGateGroup.META_PUBLICATION,
+                        "Publicação Meta será vinculada ao run em incremento posterior.", evaluatedAt),
+                pendingGate(run, "DATA_FRESHNESS_VALID", ExperimentRunGateGroup.MEASUREMENT,
+                        "Freshness de dados comerciais será calculado em incremento posterior.", evaluatedAt)
+        );
+    }
+
+    /** Cria um gate determinístico com PASS ou FAIL conforme a condição objetiva. */
+    private ExperimentRunGateResult gate(ExperimentRun run, String gateCode, ExperimentRunGateGroup group, boolean passed,
+                                         String passSummary, String failSummary, String remediationCode, Instant evaluatedAt) {
+        return ExperimentRunGateResult.builder()
+                .experimentRun(run)
+                .gateCode(gateCode)
+                .gateGroup(group)
+                .status(passed ? ExperimentRunGateStatus.PASS : ExperimentRunGateStatus.FAIL)
+                .severity(passed ? ExperimentRunGateSeverity.INFO : ExperimentRunGateSeverity.BLOCKER)
+                .summary(passed ? passSummary : failSummary)
+                .remediationCode(passed ? null : remediationCode)
+                .evaluatedAt(evaluatedAt)
+                .evaluatorType(ExperimentRunGateEvaluatorType.DETERMINISTIC)
+                .evaluatorVersion(EVALUATOR_VERSION)
+                .build();
+    }
+
+    /** Cria um gate pendente para etapas que ainda serão implementadas nos próximos incrementos. */
+    private ExperimentRunGateResult pendingGate(ExperimentRun run, String gateCode, ExperimentRunGateGroup group,
+                                                String summary, Instant evaluatedAt) {
+        return ExperimentRunGateResult.builder()
+                .experimentRun(run)
+                .gateCode(gateCode)
+                .gateGroup(group)
+                .status(ExperimentRunGateStatus.PENDING)
+                .severity(ExperimentRunGateSeverity.WARNING)
+                .summary(summary)
+                .evaluatedAt(evaluatedAt)
+                .evaluatorType(ExperimentRunGateEvaluatorType.DETERMINISTIC)
+                .evaluatorVersion(EVALUATOR_VERSION)
+                .build();
+    }
+
+    /** Verifica se um texto possui conteúdo útil para decisão comercial. */
+    private boolean hasUsefulText(String value) {
+        if (value == null || value.isBlank()) {
+            return false;
+        }
+        String normalized = value.trim().toLowerCase(java.util.Locale.ROOT);
+        return !normalized.equals("teste") && !normalized.equals("test") && !normalized.equals("n/a");
+    }
+
+    /** Converte os gates persistidos em contrato de preflight para o frontend. */
+    private ExperimentRunPreflightResponse toPreflightResponse(ExperimentRun run, List<ExperimentRunGateResult> gates) {
+        boolean hasBlockers = gates.stream().anyMatch(gate -> gate.getStatus() == ExperimentRunGateStatus.FAIL);
+        return new ExperimentRunPreflightResponse(
+                run.getId(),
+                run.getStatus(),
+                hasBlockers,
+                gates.stream().map(this::toGateResponse).toList());
+    }
+
+    /** Converte um gate persistido para o contrato de leitura do preflight. */
+    private ExperimentRunGateResultResponse toGateResponse(ExperimentRunGateResult gate) {
+        return new ExperimentRunGateResultResponse(
+                gate.getGateCode(),
+                gate.getGateGroup(),
+                gate.getStatus(),
+                gate.getSeverity(),
+                gate.getSummary(),
+                gate.getEvidenceReference(),
+                gate.getRemediationCode(),
+                gate.getEvaluatedAt(),
+                gate.getEvaluatorType(),
+                gate.getEvaluatorVersion());
+    }
+
+    /** Converte a entidade persistida no contrato de leitura usado pelo frontend. */
+    private ExperimentRunResponse toResponse(ExperimentRun run) {
+        return new ExperimentRunResponse(
+                run.getId(),
+                run.getExperiment().getId(),
+                run.getRunNumber(),
+                run.getMode(),
+                run.getStatus(),
+                run.getEvidenceValidity(),
+                run.getStrategyVersion(),
+                run.getAssetBundleVersion(),
+                run.getAudienceVersion(),
+                run.getStopPolicy(),
+                run.getStopReason(),
+                run.getFailureClassification(),
+                run.getFailureDetail(),
+                run.getDataQualityStatus(),
+                run.getRequestedAt(),
+                run.getPreflightStartedAt(),
+                run.getPreflightCompletedAt(),
+                run.getPublicationRequestedAt(),
+                run.getPublishedAt(),
+                run.getFirstVerifiedImpressionAt(),
+                run.getCommercialWindowStartedAt(),
+                run.getEndedAt(),
+                run.getCreatedBy(),
+                run.getCreatedAt(),
+                run.getUpdatedAt());
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/run/service/create/CreateExperimentRunRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/run/service/create/CreateExperimentRunRequest.java
@@ -1,0 +1,14 @@
+package com.marketinghub.experiment.run.service.create;
+
+import com.marketinghub.experiment.run.ExperimentRunMode;
+import com.marketinghub.experiment.run.ExperimentRunStopPolicy;
+
+/**
+ * Contrato recebido para criar uma nova execução operacional de experimento.
+ */
+public record CreateExperimentRunRequest(
+        ExperimentRunMode mode,
+        ExperimentRunStopPolicy stopPolicy,
+        String createdBy
+) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/run/service/get/ExperimentRunResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/run/service/get/ExperimentRunResponse.java
@@ -1,0 +1,42 @@
+package com.marketinghub.experiment.run.service.get;
+
+import com.marketinghub.experiment.run.ExperimentEvidenceValidity;
+import com.marketinghub.experiment.run.ExperimentRunDataQualityStatus;
+import com.marketinghub.experiment.run.ExperimentRunFailureClassification;
+import com.marketinghub.experiment.run.ExperimentRunMode;
+import com.marketinghub.experiment.run.ExperimentRunStatus;
+import com.marketinghub.experiment.run.ExperimentRunStopPolicy;
+
+import java.time.Instant;
+
+/**
+ * Contrato de leitura de uma execução operacional de experimento.
+ */
+public record ExperimentRunResponse(
+        Long id,
+        Long experimentId,
+        Integer runNumber,
+        ExperimentRunMode mode,
+        ExperimentRunStatus status,
+        ExperimentEvidenceValidity evidenceValidity,
+        Integer strategyVersion,
+        Integer assetBundleVersion,
+        Integer audienceVersion,
+        ExperimentRunStopPolicy stopPolicy,
+        String stopReason,
+        ExperimentRunFailureClassification failureClassification,
+        String failureDetail,
+        ExperimentRunDataQualityStatus dataQualityStatus,
+        Instant requestedAt,
+        Instant preflightStartedAt,
+        Instant preflightCompletedAt,
+        Instant publicationRequestedAt,
+        Instant publishedAt,
+        Instant firstVerifiedImpressionAt,
+        Instant commercialWindowStartedAt,
+        Instant endedAt,
+        String createdBy,
+        Instant createdAt,
+        Instant updatedAt
+) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/run/service/preflight/ExperimentRunGateResultResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/run/service/preflight/ExperimentRunGateResultResponse.java
@@ -1,0 +1,25 @@
+package com.marketinghub.experiment.run.service.preflight;
+
+import com.marketinghub.experiment.run.ExperimentRunGateEvaluatorType;
+import com.marketinghub.experiment.run.ExperimentRunGateGroup;
+import com.marketinghub.experiment.run.ExperimentRunGateSeverity;
+import com.marketinghub.experiment.run.ExperimentRunGateStatus;
+
+import java.time.Instant;
+
+/**
+ * Contrato de leitura de um gate avaliado para um run de experimento.
+ */
+public record ExperimentRunGateResultResponse(
+        String gateCode,
+        ExperimentRunGateGroup gateGroup,
+        ExperimentRunGateStatus status,
+        ExperimentRunGateSeverity severity,
+        String summary,
+        String evidenceReference,
+        String remediationCode,
+        Instant evaluatedAt,
+        ExperimentRunGateEvaluatorType evaluatorType,
+        String evaluatorVersion
+) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/run/service/preflight/ExperimentRunPreflightResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/run/service/preflight/ExperimentRunPreflightResponse.java
@@ -1,0 +1,16 @@
+package com.marketinghub.experiment.run.service.preflight;
+
+import com.marketinghub.experiment.run.ExperimentRunStatus;
+
+import java.util.List;
+
+/**
+ * Contrato de leitura do preflight atual de um run de experimento.
+ */
+public record ExperimentRunPreflightResponse(
+        Long runId,
+        ExperimentRunStatus runStatus,
+        boolean hasBlockers,
+        List<ExperimentRunGateResultResponse> gates
+) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/experiment/ExperimentRunGateResultRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/experiment/ExperimentRunGateResultRepository.java
@@ -1,0 +1,17 @@
+package com.marketinghub.repository.jpa.experiment;
+
+import com.marketinghub.experiment.run.ExperimentRunGateResult;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.List;
+
+/**
+ * Repositório JPA responsável pelos resultados atuais de gates de runs de experimento.
+ */
+public interface ExperimentRunGateResultRepository extends JpaRepository<ExperimentRunGateResult, Long> {
+    /** Lista os gates de um run agrupáveis para leitura do frontend. */
+    List<ExperimentRunGateResult> findByExperimentRunIdOrderByGateGroupAscGateCodeAsc(Long experimentRunId);
+
+    /** Remove resultados anteriores para reavaliar o preflight de forma idempotente. */
+    void deleteByExperimentRunId(Long experimentRunId);
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/experiment/ExperimentRunRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/experiment/ExperimentRunRepository.java
@@ -1,0 +1,20 @@
+package com.marketinghub.repository.jpa.experiment;
+
+import com.marketinghub.experiment.run.ExperimentRun;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+/**
+ * Repositório JPA responsável por persistir execuções operacionais de experimentos.
+ */
+public interface ExperimentRunRepository extends JpaRepository<ExperimentRun, Long> {
+    /** Lista os runs de um experimento na ordem operacional. */
+    List<ExperimentRun> findByExperimentIdOrderByRunNumberAsc(Long experimentId);
+
+    /** Retorna o maior número de run já criado para um experimento. */
+    @Query("select coalesce(max(run.runNumber), 0) from ExperimentRun run where run.experiment.id = :experimentId")
+    int findMaxRunNumberByExperimentId(@Param("experimentId") Long experimentId);
+}

--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-25-experiment-run-gate-result.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-25-experiment-run-gate-result.yaml
@@ -1,0 +1,98 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-06-25-experiment-run-gate-result-001
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - dbms:
+            type: mysql
+        - not:
+            tableExists:
+              tableName: experiment_run_gate_result
+      changes:
+        - createTable:
+            tableName: experiment_run_gate_result
+            columns:
+              - column:
+                  name: id
+                  type: BIGINT
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: experiment_run_id
+                  type: BIGINT
+                  constraints:
+                    nullable: false
+              - column:
+                  name: gate_code
+                  type: VARCHAR(96)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: gate_group
+                  type: VARCHAR(48)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: status
+                  type: VARCHAR(24)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: severity
+                  type: VARCHAR(24)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: summary
+                  type: VARCHAR(512)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: evidence_reference
+                  type: VARCHAR(512)
+              - column:
+                  name: remediation_code
+                  type: VARCHAR(96)
+              - column:
+                  name: evaluated_at
+                  type: DATETIME(6)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: evaluator_type
+                  type: VARCHAR(24)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: evaluator_version
+                  type: VARCHAR(64)
+              - column:
+                  name: created_at
+                  type: DATETIME(6)
+                  constraints:
+                    nullable: false
+        - addUniqueConstraint:
+            tableName: experiment_run_gate_result
+            columnNames: experiment_run_id, gate_code
+            constraintName: uk_experiment_run_gate_code
+        - createIndex:
+            tableName: experiment_run_gate_result
+            indexName: idx_experiment_run_gate_group_status
+            columns:
+              - column:
+                  name: gate_group
+              - column:
+                  name: status
+        - addForeignKeyConstraint:
+            baseTableName: experiment_run_gate_result
+            baseColumnNames: experiment_run_id
+            referencedTableName: experiment_run
+            referencedColumnNames: id
+            constraintName: fk_experiment_run_gate_result_run
+            onDelete: CASCADE
+      rollback:
+        - dropTable:
+            tableName: experiment_run_gate_result

--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-25-experiment-run.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-25-experiment-run.yaml
@@ -1,0 +1,150 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-06-25-experiment-run-001
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - dbms:
+            type: mysql
+        - not:
+            tableExists:
+              tableName: experiment_run
+      changes:
+        - createTable:
+            tableName: experiment_run
+            columns:
+              - column:
+                  name: id
+                  type: BIGINT
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: experiment_id
+                  type: BIGINT
+                  constraints:
+                    nullable: false
+              - column:
+                  name: run_number
+                  type: INT
+                  constraints:
+                    nullable: false
+              - column:
+                  name: mode
+                  type: VARCHAR(24)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: status
+                  type: VARCHAR(32)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: evidence_validity
+                  type: VARCHAR(32)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: strategy_version
+                  type: INT
+              - column:
+                  name: asset_bundle_version
+                  type: INT
+              - column:
+                  name: audience_version
+                  type: INT
+              - column:
+                  name: stop_policy
+                  type: VARCHAR(48)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: stop_reason
+                  type: VARCHAR(96)
+              - column:
+                  name: failure_classification
+                  type: VARCHAR(64)
+              - column:
+                  name: failure_detail
+                  type: LONGTEXT
+              - column:
+                  name: data_quality_status
+                  type: VARCHAR(32)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: requested_at
+                  type: DATETIME(6)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: preflight_started_at
+                  type: DATETIME(6)
+              - column:
+                  name: preflight_completed_at
+                  type: DATETIME(6)
+              - column:
+                  name: publication_requested_at
+                  type: DATETIME(6)
+              - column:
+                  name: published_at
+                  type: DATETIME(6)
+              - column:
+                  name: first_verified_impression_at
+                  type: DATETIME(6)
+              - column:
+                  name: commercial_window_started_at
+                  type: DATETIME(6)
+              - column:
+                  name: ended_at
+                  type: DATETIME(6)
+              - column:
+                  name: created_by
+                  type: VARCHAR(191)
+              - column:
+                  name: created_at
+                  type: DATETIME(6)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: updated_at
+                  type: DATETIME(6)
+                  constraints:
+                    nullable: false
+        - addUniqueConstraint:
+            tableName: experiment_run
+            columnNames: experiment_id, run_number
+            constraintName: uk_experiment_run_experiment_number
+        - createIndex:
+            tableName: experiment_run
+            indexName: idx_experiment_run_experiment_status
+            columns:
+              - column:
+                  name: experiment_id
+              - column:
+                  name: status
+        - createIndex:
+            tableName: experiment_run
+            indexName: idx_experiment_run_status_requested
+            columns:
+              - column:
+                  name: status
+              - column:
+                  name: requested_at
+        - createIndex:
+            tableName: experiment_run
+            indexName: idx_experiment_run_evidence_validity
+            columns:
+              - column:
+                  name: evidence_validity
+        - addForeignKeyConstraint:
+            baseTableName: experiment_run
+            baseColumnNames: experiment_id
+            referencedTableName: experiment
+            referencedColumnNames: id
+            constraintName: fk_experiment_run_experiment
+            onDelete: RESTRICT
+      rollback:
+        - dropTable:
+            tableName: experiment_run

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -1086,3 +1086,11 @@ databaseChangeLog:
   - include:
       file: changesets/2026-06-24-mois-sales-library-geralanding-insights.yaml
       relativeToChangelogFile: true
+
+  - include:
+      file: changesets/2026-06-25-experiment-run.yaml
+      relativeToChangelogFile: true
+
+  - include:
+      file: changesets/2026-06-25-experiment-run-gate-result.yaml
+      relativeToChangelogFile: true

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/run/BackendExperimentRunControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/run/BackendExperimentRunControllerTest.java
@@ -1,0 +1,238 @@
+package com.marketinghub.experiment.run;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marketinghub.ads.AdsServiceApplication;
+import com.marketinghub.creative.label.Angle;
+import com.marketinghub.experiment.Experiment;
+import com.marketinghub.experiment.ExperimentPlatform;
+import com.marketinghub.experiment.ExperimentStatus;
+import com.marketinghub.experiment.run.service.create.CreateExperimentRunRequest;
+import com.marketinghub.hypothesis.Hypothesis;
+import com.marketinghub.hypothesis.OfferType;
+import com.marketinghub.niche.MarketNiche;
+import com.marketinghub.repository.jpa.creative.label.AngleRepository;
+import com.marketinghub.repository.jpa.experiment.ExperimentRepository;
+import com.marketinghub.repository.jpa.experiment.ExperimentRunGateResultRepository;
+import com.marketinghub.repository.jpa.experiment.ExperimentRunRepository;
+import com.marketinghub.repository.jpa.hypothesis.HypothesisRepository;
+import com.marketinghub.repository.jpa.niche.MarketNicheRepository;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.math.BigDecimal;
+
+import static org.hamcrest.Matchers.hasItem;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * Valida a API administrativa inicial de execuções operacionais de experimentos.
+ */
+@SpringBootTest(classes = AdsServiceApplication.class)
+@AutoConfigureMockMvc
+@TestPropertySource(properties = {
+        "spring.datasource.url=jdbc:h2:mem:experiment_run_test;MODE=MySQL;DB_CLOSE_DELAY=-1;DB_CLOSE_ON_EXIT=FALSE",
+        "spring.datasource.driverClassName=org.h2.Driver",
+        "spring.datasource.username=sa",
+        "spring.datasource.password=",
+        "spring.jpa.hibernate.ddl-auto=create",
+        "spring.liquibase.enabled=false"
+})
+class BackendExperimentRunControllerTest {
+    @Autowired
+    private MockMvc mockMvc;
+    @Autowired
+    private ObjectMapper objectMapper;
+    @Autowired
+    private ExperimentRepository experimentRepository;
+    @Autowired
+    private ExperimentRunRepository experimentRunRepository;
+    @Autowired
+    private ExperimentRunGateResultRepository gateResultRepository;
+    @Autowired
+    private MarketNicheRepository marketNicheRepository;
+    @Autowired
+    private HypothesisRepository hypothesisRepository;
+    @Autowired
+    private AngleRepository angleRepository;
+
+    /** Limpa dados persistidos para manter a ordem sequencial dos runs previsível. */
+    @BeforeEach
+    void cleanDb() {
+        gateResultRepository.deleteAll();
+        experimentRunRepository.deleteAll();
+        experimentRepository.deleteAll();
+        hypothesisRepository.deleteAll();
+        angleRepository.deleteAll();
+        marketNicheRepository.deleteAll();
+    }
+
+    /** Deve criar runs sequenciais com validade inicial neutra e sem alterar o experimento legado. */
+    @Test
+    void createSequentialRuns() throws Exception {
+        Long experimentId = createExperiment();
+        CreateExperimentRunRequest request = new CreateExperimentRunRequest(
+                ExperimentRunMode.TEST,
+                ExperimentRunStopPolicy.MANUAL_ONLY,
+                "codex");
+
+        mockMvc.perform(post("/api/experiments/{experimentId}/runs", experimentId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.experimentId").value(experimentId))
+                .andExpect(jsonPath("$.runNumber").value(1))
+                .andExpect(jsonPath("$.mode").value("TEST"))
+                .andExpect(jsonPath("$.status").value("DRAFT"))
+                .andExpect(jsonPath("$.evidenceValidity").value("NOT_EVALUATED"))
+                .andExpect(jsonPath("$.dataQualityStatus").value("UNKNOWN"));
+
+        mockMvc.perform(post("/api/experiments/{experimentId}/runs", experimentId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(request)))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.runNumber").value(2));
+    }
+
+    /** Deve listar e consultar runs já persistidos para alimentar o frontend. */
+    @Test
+    void listAndGetRuns() throws Exception {
+        Long experimentId = createExperiment();
+        String response = mockMvc.perform(post("/api/experiments/{experimentId}/runs", experimentId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new CreateExperimentRunRequest(
+                                ExperimentRunMode.PRODUCTION,
+                                ExperimentRunStopPolicy.FIRST_VALID_LEAD_STANDBY,
+                                "operador"))))
+                .andExpect(status().isOk())
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+        Long runId = objectMapper.readTree(response).get("id").asLong();
+
+        mockMvc.perform(get("/api/experiments/{experimentId}/runs", experimentId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$[0].id").value(runId))
+                .andExpect(jsonPath("$[0].stopPolicy").value("FIRST_VALID_LEAD_STANDBY"));
+
+        mockMvc.perform(get("/api/experiment-runs/{runId}", runId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.id").value(runId))
+                .andExpect(jsonPath("$.experimentId").value(experimentId));
+    }
+
+
+
+    /** Deve executar preflight determinístico e liberar run sem bloqueadores estratégicos iniciais. */
+    @Test
+    void runPreflightWithoutBlockers() throws Exception {
+        Long experimentId = createExperiment();
+        Long runId = createRun(experimentId);
+
+        mockMvc.perform(post("/api/experiment-runs/{runId}/preflight", runId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.runStatus").value("READY_TO_PUBLISH"))
+                .andExpect(jsonPath("$.hasBlockers").value(false))
+                .andExpect(jsonPath("$.gates[?(@.gateCode == 'PRIMARY_VARIABLE_DEFINED')].status").value(hasItem("PASS")))
+                .andExpect(jsonPath("$.gates[?(@.gateCode == 'FORM_CAN_BE_SUBMITTED')].status").value(hasItem("PENDING")));
+
+        mockMvc.perform(get("/api/experiment-runs/{runId}/preflight", runId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.runStatus").value("READY_TO_PUBLISH"));
+    }
+
+    /** Deve bloquear preflight quando desenho experimental ou persona estiverem incompletos. */
+    @Test
+    void runPreflightWithStrategicBlockers() throws Exception {
+        Long experimentId = createExperimentWithMissingDesign();
+        Long runId = createRun(experimentId);
+
+        mockMvc.perform(post("/api/experiment-runs/{runId}/preflight", runId))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.runStatus").value("PREFLIGHT_FAILED"))
+                .andExpect(jsonPath("$.hasBlockers").value(true))
+                .andExpect(jsonPath("$.gates[?(@.gateCode == 'PERSONA_MINIMUM_COMPLETE')].status").value(hasItem("FAIL")))
+                .andExpect(jsonPath("$.gates[?(@.gateCode == 'PRIMARY_METRIC_DEFINED')].status").value(hasItem("FAIL")))
+                .andExpect(jsonPath("$.gates[?(@.gateCode == 'KPI_TARGET_CPL_VALID')].remediationCode").value(hasItem("DEFINE_KPI_TARGET_CPL")));
+    }
+
+    /** Cria o experimento mínimo necessário para vincular runs nos testes. */
+    private Long createExperiment() {
+        MarketNiche niche = marketNicheRepository.save(MarketNiche.builder().name("Nicho Run").build());
+        Angle angle = angleRepository.save(Angle.builder().name("Ângulo Run").build());
+        Hypothesis hypothesis = hypothesisRepository.save(Hypothesis.builder()
+                .marketNiche(niche)
+                .title("Hipótese Run")
+                .premiseAngle(angle)
+                .promise("Promessa")
+                .problem("Problema")
+                .persona("Persona")
+                .offerType(OfferType.LEAD)
+                .kpiTargetCpl(new BigDecimal("1"))
+                .mechanism("Mecanismo")
+                .entrega("Entrega")
+                .build());
+        Experiment experiment = Experiment.builder()
+                .niche(niche)
+                .name("Experimento Run")
+                .hypothesisRef(hypothesis)
+                .hypothesis("Resumo")
+                .status(ExperimentStatus.PLANNED)
+                .platform(ExperimentPlatform.FACEBOOK)
+                .primaryVariable("Ângulo de dor")
+                .primaryMetric("Envio de formulário")
+                .kpiTargetCpl(new BigDecimal("45"))
+                .build();
+        return experimentRepository.save(experiment).getId();
+    }
+
+    /** Cria um run e retorna seu identificador para os testes de preflight. */
+    private Long createRun(Long experimentId) throws Exception {
+        String response = mockMvc.perform(post("/api/experiments/{experimentId}/runs", experimentId)
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content(objectMapper.writeValueAsString(new CreateExperimentRunRequest(
+                                ExperimentRunMode.PRODUCTION,
+                                ExperimentRunStopPolicy.MANUAL_ONLY,
+                                "teste"))))
+                .andExpect(status().isOk())
+                .andReturn()
+                .getResponse()
+                .getContentAsString();
+        return objectMapper.readTree(response).get("id").asLong();
+    }
+
+    /** Cria experimento com lacunas estratégicas para validar bloqueios de preflight. */
+    private Long createExperimentWithMissingDesign() {
+        MarketNiche niche = marketNicheRepository.save(MarketNiche.builder().name("Nicho Bloqueado").build());
+        Angle angle = angleRepository.save(Angle.builder().name("Ângulo Bloqueado").build());
+        Hypothesis hypothesis = hypothesisRepository.save(Hypothesis.builder()
+                .marketNiche(niche)
+                .title("Hipótese Bloqueada")
+                .premiseAngle(angle)
+                .promise("Promessa")
+                .problem("Problema")
+                .persona("teste")
+                .offerType(OfferType.LEAD)
+                .kpiTargetCpl(BigDecimal.ZERO)
+                .build());
+        Experiment experiment = Experiment.builder()
+                .niche(niche)
+                .name("Experimento Bloqueado")
+                .hypothesisRef(hypothesis)
+                .hypothesis("Resumo")
+                .status(ExperimentStatus.PLANNED)
+                .platform(ExperimentPlatform.FACEBOOK)
+                .kpiTargetCpl(BigDecimal.ZERO)
+                .build();
+        return experimentRepository.save(experiment).getId();
+    }
+
+}

--- a/docs/canonical/procedimento-experimento-canon.v1.md
+++ b/docs/canonical/procedimento-experimento-canon.v1.md
@@ -106,6 +106,69 @@ Regras obrigatórias:
 - o status `STANDBY` por primeiro envio não substitui a validação estatística de 30+ envios qualificados, nem a regra de reprovação por 100 acessos sem envio;
 - a tela administrativa deve deixar claro que o experimento parou por sinal inicial, não por validação completa.
 
+### 4.1.4 Regra mandatória — execução auditável por `ExperimentRun`
+
+O `Experiment` continua representando uma pergunta comercial atômica: uma dor principal, uma promessa principal, uma oferta principal, uma rota comercial, uma variável primária e uma métrica primária. A tentativa operacional de colocar essa pergunta no mercado deve ser representada por `ExperimentRun`, sem alterar o significado comercial do experimento.
+
+Regras obrigatórias:
+- correção técnica que não muda a pergunta comercial principal cria novo `ExperimentRun` do mesmo experimento;
+- mudança de dor, promessa, isca, rota de captura, produto, oferta, preço, CTA principal, público estratégico, métrica primária ou pergunta de negócio cria novo `Experiment`;
+- `ExperimentRun` deve possuir modo explícito `TEST` ou `PRODUCTION`;
+- eventos, passos, gates e evidências de `TEST` não podem alimentar métricas comerciais de `PRODUCTION`;
+- status operacional do run e validade comercial da evidência são dimensões independentes;
+- run tecnicamente inválido continua visível para aprendizado operacional, mas não pode reprovar hipótese, materialização comercial ou mercado;
+- somente run com validade `COMMERCIALLY_VALID` pode alimentar comparação, declaração de vencedor, decisão de escala, reprovação comercial ou recomendação de próximo teste baseada em resultado.
+
+Validades canônicas iniciais:
+- `NOT_EVALUATED`: evidência ainda não avaliada ou legado migrado sem reclassificação segura;
+- `TECHNICALLY_INVALID`: publicação, destino, formulário, integração, targeting técnico ou exposição falharam;
+- `MEASUREMENT_INVALID`: eventos, custos, conversões, deduplicação ou janela comercial não são confiáveis;
+- `STRATEGICALLY_INVALID`: desenho experimental, variável primária, estratégia, público ou insumo upstream impedem conclusão de mercado;
+- `INSUFFICIENT_DATA`: execução e mensuração são válidas, mas a amostra ou janela ainda não sustentam decisão;
+- `COMMERCIALLY_VALID`: execução, exposição, estratégia e mensuração permitem aprendizado confiável, mesmo quando o resultado for negativo ou inconclusivo.
+
+Compatibilidade obrigatória com legado:
+- status existentes de `Experiment` permanecem legíveis durante a migração;
+- `INVALIDATED` legado não deve ser convertido automaticamente em falha de hipótese comercial;
+- experimentos legados ativos/concluídos devem receber run legado com validade inicial `NOT_EVALUATED` quando a persistência de runs for implementada;
+- a regra transitória de primeiro envio válido em `STANDBY` permanece como política de parada do modo inicial, mas deve ser registrada no run e não substitui validação comercial completa.
+
+### 4.1.5 Feature flags canônicas da evolução de experimentos
+
+A evolução de Experimentos deve ser liberada por feature flags, mantendo o comportamento legado como padrão até validação explícita. Nenhuma flag abaixo autoriza, sozinha, publicação, aumento de orçamento, decisão automática de vencedor ou remoção de fluxo legado.
+
+Flags iniciais:
+
+| Flag | Padrão | Responsabilidade | Rollback |
+|---|---:|---|---|
+| `experiments.runs.enabled` | `false` | habilita leitura/escrita operacional de `ExperimentRun` após a fase de persistência | voltar a UI e comandos para status legado de `Experiment` |
+| `experiments.runs.preflight-enabled` | `false` | habilita gates de readiness/preflight antes da mídia | desativar bloqueios novos e manter diagnósticos apenas informativos |
+| `experiments.runs.frontend-enabled` | `false` | exibe card/aba de execução atual e histórico mínimo de runs | ocultar UI nova sem apagar dados persistidos |
+| `experiments.comparison.enabled` | `false` | habilita criação e leitura de `ExperimentComparison` | pausar comparações sem pausar experimentos individuais |
+| `experiments.decision-ai.enabled` | `false` | habilita pipeline de apoio por IA somente após dados confiáveis | manter Centro de Decisão determinístico |
+
+Rollback obrigatório:
+- dados novos devem ser append-only ou compatíveis com leitura legada;
+- desativar a flag não deve apagar runs, gates, passos, fixtures nem histórico de decisão;
+- enquanto `experiments.runs.enabled=false`, comandos produtivos continuam usando o contrato legado;
+- enquanto `experiments.comparison.enabled=false`, a política de primeiro envio válido em `STANDBY` continua aplicável ao modo inicial.
+
+### 4.1.6 Fixtures históricas obrigatórias de regressão
+
+Os experimentos 37, 38, 39 e 40 formam baseline de regressão do processo decisório. O objetivo dessas fixtures não é reproduzir todos os relatórios históricos, mas impedir que o sistema volte a tratar falha técnica, dado contaminado, desenho incompleto ou medição inválida como rejeição simples de mercado.
+
+Fonte versionada das fixtures da Fase 0:
+
+- `docs/implementacao/experimentos/fixtures/experimentos-37-40-regressao.json`
+
+Regras obrigatórias para testes futuros:
+- experimento 37 deve bloquear conclusão comercial quando formulário/landing/captura não comprovam evidência válida;
+- experimento 38 deve bloquear aprendizado de mercado quando variável, métrica, KPI ou publicação estiverem incompletos;
+- experimento 39 deve diferenciar falha de qualidade upstream, reset/liberação, alcance e targeting antes de interpretar mercado;
+- experimento 40 deve bloquear materialização automática quando houver baixa correspondência semântica, fonte frágil ou contaminação por solução;
+- nenhum desses casos pode declarar `COMMERCIAL_HYPOTHESIS_FAILURE` sem run comercialmente válido e evidências persistidas.
+
+
 ### 4.2 Prompts dessas etapas
 Os prompts do pipeline ficam versionados no repositório, em `resources` do Worker AI.
 

--- a/docs/implementacao/experimentos/fixtures/experimentos-37-40-regressao.json
+++ b/docs/implementacao/experimentos/fixtures/experimentos-37-40-regressao.json
@@ -1,0 +1,106 @@
+{
+  "schemaVersion": "experiment-history-regression.v1",
+  "sourceDocument": "docs/implementacao/experimentos/analise-historico-experimentos-sem-sucesso.md",
+  "purpose": "Baseline de regressão para impedir que falhas técnicas, estratégicas, de medição ou de qualidade upstream sejam interpretadas como rejeição comercial sem evidência válida.",
+  "experiments": [
+    {
+      "experimentId": 37,
+      "expectedEvidenceValidity": "TECHNICALLY_INVALID",
+      "primaryFailureClassifications": [
+        "FORM_FUNCTIONAL_FAILURE",
+        "LANDING_QUALITY_FAILURE",
+        "STRATEGY_CONFIGURATION_FAILURE"
+      ],
+      "observedSignals": {
+        "impressions": 2524,
+        "clicks": 114,
+        "spendBrl": 25.11,
+        "formViews": 100,
+        "formSubmissions": 0,
+        "legacyConclusion": "FORM_ZERO_CONVERSION_RULE_OF_THREE"
+      },
+      "regressionAssertions": [
+        "Não declarar rejeição de mercado sem formulário E2E comprovado.",
+        "Não usar landing com revisão insuficiente como evidência comercial confiável.",
+        "Correção técnica deve criar novo run do mesmo experimento quando a pergunta comercial não mudar."
+      ]
+    },
+    {
+      "experimentId": 38,
+      "expectedEvidenceValidity": "STRATEGICALLY_INVALID",
+      "primaryFailureClassifications": [
+        "STRATEGY_CONFIGURATION_FAILURE",
+        "PUBLICATION_FAILURE",
+        "INTEGRATION_FAILURE"
+      ],
+      "observedSignals": {
+        "legacyStatus": "INVALIDATED",
+        "persona": "teste",
+        "primaryVariablePresent": false,
+        "primaryMetricPresent": false,
+        "kpiTargetCpl": 0
+      },
+      "regressionAssertions": [
+        "Não iniciar produção sem variável e métrica primárias.",
+        "KPI zero ou ausente deve bloquear ou alertar explicitamente.",
+        "Falha de publicação não pode virar invalidação comercial automática."
+      ]
+    },
+    {
+      "experimentId": 39,
+      "expectedEvidenceValidity": "STRATEGICALLY_INVALID",
+      "primaryFailureClassifications": [
+        "UPSTREAM_DATA_QUALITY_FAILURE",
+        "AUDIENCE_FAILURE",
+        "PUBLICATION_FAILURE"
+      ],
+      "observedSignals": {
+        "niche": "manicure",
+        "upstreamIssues": [
+          "evidências duplicadas",
+          "rótulos genéricos repetidos",
+          "conteúdo adjacente ao trabalho da profissional",
+          "fontes de baixa utilidade comercial"
+        ],
+        "publicationIssues": [
+          "reset com dependência de eventos",
+          "estimativa de alcance sem localização",
+          "audiência estreita por composição inadequada"
+        ]
+      },
+      "regressionAssertions": [
+        "Validar qualidade de nicho/hipótese antes de interpretar mercado.",
+        "Diferenciar audiência inexistente, audiência estreita e erro técnico de payload.",
+        "Publicação deve registrar passos por jobId para explicar por que não chegou ao mercado."
+      ]
+    },
+    {
+      "experimentId": 40,
+      "expectedEvidenceValidity": "STRATEGICALLY_INVALID",
+      "primaryFailureClassifications": [
+        "UPSTREAM_DATA_QUALITY_FAILURE",
+        "PROMISE_OR_LEAD_MAGNET_FAILURE"
+      ],
+      "observedSignals": {
+        "niche": "alongamento de unhas",
+        "upstreamIssues": [
+          "claims genéricos promovidos como dores específicas",
+          "fontes de consumidor/procedimento usadas como rotina comercial da profissional",
+          "fontes duplicadas",
+          "contaminação por solução",
+          "ausência de eixo comercial único"
+        ]
+      },
+      "regressionAssertions": [
+        "Artefato upstream reprovado ou incompleto bloqueia materialização automática.",
+        "Contaminação por solução impede usar solução como prova da dor.",
+        "Dados insuficientes devem gerar revisão ou novo ciclo de pesquisa, não preenchimento especulativo."
+      ]
+    }
+  ],
+  "globalRegressionAssertions": [
+    "INVALIDATED legado não reprova hipótese sem run comercialmente válido.",
+    "Run tecnicamente inválido alimenta aprendizado operacional, não decisão de mercado.",
+    "Somente COMMERCIALLY_VALID entra em comparação, vencedor, escala ou recomendação de próximo teste baseada em resultado."
+  ]
+}

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -5345,3 +5345,35 @@
 - Causa-raiz: a query da fila Meta Ads entregava apenas elementos `APPROVED`, enquanto a aprovação de interesse, cargo e comportamento exige `metaId` oficial; isso criava um bloqueio circular entre validação Meta e aprovação humana.
 - Correção aplicada: a fila Meta Ads passou a incluir elementos `NEEDS_REVIEW` e `APPROVED` dos três tipos suportados (`INTEREST`, `JOB_TITLE` e `BEHAVIOR`), mantendo o bloqueio contra itens `DRAFT`, `REJECTED`, hipótese específica e itens já marcados como Meta indisponível.
 - Prevenção de recorrência: adicionado teste de repository cobrindo interesse, cargo e comportamento em revisão na fila Meta Ads e excluindo rascunho.
+
+
+- 2026-06-25 — Fase 0 da evolução comercial de Experimentos: formalizado no cânone o modelo de `ExperimentRun`, validade da evidência, modos `TEST`/`PRODUCTION`, compatibilidade com status legados, feature flags iniciais e fixtures históricas de regressão dos experimentos 37–40.
+  - causa-raiz tratada: experimentos anteriores podiam misturar falha técnica, estratégia incompleta, medição inválida e rejeição comercial em um único status final.
+  - prevenção de recorrência: os casos 37–40 agora possuem fixture versionada para futuros testes de regressão do processo decisório.
+  - arquivos principais:
+    - docs/canonical/procedimento-experimento-canon.v1.md
+    - docs/implementacao/experimentos/fixtures/experimentos-37-40-regressao.json
+
+- 2026-06-25 — Persistência e API inicial de `ExperimentRun`: criada a entidade de run operacional, enums canônicos, changelog MySQL 5.7, repository centralizado, service/controller administrativo e Swagger para criação/listagem/consulta de runs.
+  - causa-raiz tratada: o sistema não possuía unidade persistida para separar tentativa operacional de hipótese comercial.
+  - prevenção de recorrência: adicionados testes de controller para criação sequencial e consulta de runs com validade inicial `NOT_EVALUATED`.
+  - arquivos principais:
+    - backend/ads-service/src/main/java/com/marketinghub/experiment/run/ExperimentRun.java
+    - backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-25-experiment-run.yaml
+    - docs/swagger/experiment-runs-swagger.yaml
+
+- 2026-06-25 — Gates determinísticos iniciais de `ExperimentRun`: criada a persistência de `experiment_run_gate_result` e os endpoints de preflight para avaliar qualidade upstream e desenho experimental antes da mídia.
+  - causa-raiz tratada: runs podiam existir sem checklist persistido explicando por que uma execução está pronta ou bloqueada.
+  - prevenção de recorrência: testes cobrem preflight sem bloqueadores e preflight bloqueado por persona, métrica primária e KPI ausentes/inválidos.
+  - arquivos principais:
+    - backend/ads-service/src/main/java/com/marketinghub/experiment/run/ExperimentRunGateResult.java
+    - backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-25-experiment-run-gate-result.yaml
+    - docs/swagger/experiment-runs-swagger.yaml
+
+- 2026-06-25 — Frontend mínimo de `ExperimentRun`: adicionada API frontend para runs/preflight e painel de execução atual no detalhe do experimento, com comandos para criar run e rodar preflight consumindo a verdade do backend.
+  - causa-raiz tratada: a tela de experimento ainda não mostrava a unidade operacional que separa falha técnica de evidência comercial.
+  - prevenção de recorrência: a tela passou a exibir status, validade, dados e checklist retornados pelo backend, sem inferir causa-raiz no navegador.
+  - arquivos principais:
+    - frontend/src/api/experiment/useExperimentRuns.ts
+    - frontend/src/pages/experiment/ExperimentRunPanel.tsx
+    - frontend/src/pages/experiment/ExperimentDetailPage.tsx

--- a/docs/swagger/experiment-runs-swagger.yaml
+++ b/docs/swagger/experiment-runs-swagger.yaml
@@ -1,0 +1,278 @@
+openapi: 3.0.3
+info:
+  title: Marketing Hub Experiment Runs API
+  version: 1.0.0
+  description: Contratos administrativos iniciais para criar e consultar execuções operacionais de experimentos.
+paths:
+  /api/experiments/{experimentId}/runs:
+    post:
+      summary: Cria um novo run sequencial para o experimento
+      description: Cria uma tentativa operacional sem alterar o status legado do experimento.
+      parameters:
+        - name: experimentId
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+      requestBody:
+        required: false
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CreateExperimentRunRequest'
+      responses:
+        '200':
+          description: Run criado
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ExperimentRunResponse'
+    get:
+      summary: Lista runs de um experimento
+      parameters:
+        - name: experimentId
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: Runs do experimento em ordem operacional
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ExperimentRunResponse'
+  /api/experiment-runs/{runId}:
+    get:
+      summary: Consulta um run pelo identificador
+      parameters:
+        - name: runId
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: Detalhe do run
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ExperimentRunResponse'
+
+  /api/experiment-runs/{runId}/preflight:
+    get:
+      summary: Consulta o preflight atual de um run
+      parameters:
+        - name: runId
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: Resultado atual do preflight
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ExperimentRunPreflightResponse'
+    post:
+      summary: Executa a avaliação determinística inicial de preflight
+      description: Reavalia gates determinísticos iniciais e atualiza o status operacional do run.
+      parameters:
+        - name: runId
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+      responses:
+        '200':
+          description: Resultado atualizado do preflight
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/ExperimentRunPreflightResponse'
+components:
+  schemas:
+
+    ExperimentRunPreflightResponse:
+      type: object
+      required: [runId, runStatus, hasBlockers, gates]
+      properties:
+        runId:
+          type: integer
+          format: int64
+        runStatus:
+          $ref: '#/components/schemas/ExperimentRunStatus'
+        hasBlockers:
+          type: boolean
+        gates:
+          type: array
+          items:
+            $ref: '#/components/schemas/ExperimentRunGateResultResponse'
+    ExperimentRunGateResultResponse:
+      type: object
+      required: [gateCode, gateGroup, status, severity, summary, evaluatedAt, evaluatorType]
+      properties:
+        gateCode:
+          type: string
+        gateGroup:
+          $ref: '#/components/schemas/ExperimentRunGateGroup'
+        status:
+          $ref: '#/components/schemas/ExperimentRunGateStatus'
+        severity:
+          $ref: '#/components/schemas/ExperimentRunGateSeverity'
+        summary:
+          type: string
+        evidenceReference:
+          type: string
+          nullable: true
+        remediationCode:
+          type: string
+          nullable: true
+        evaluatedAt:
+          type: string
+          format: date-time
+        evaluatorType:
+          $ref: '#/components/schemas/ExperimentRunGateEvaluatorType'
+        evaluatorVersion:
+          type: string
+          nullable: true
+    CreateExperimentRunRequest:
+      type: object
+      properties:
+        mode:
+          $ref: '#/components/schemas/ExperimentRunMode'
+        stopPolicy:
+          $ref: '#/components/schemas/ExperimentRunStopPolicy'
+        createdBy:
+          type: string
+          maxLength: 191
+    ExperimentRunResponse:
+      type: object
+      required:
+        - id
+        - experimentId
+        - runNumber
+        - mode
+        - status
+        - evidenceValidity
+        - stopPolicy
+        - dataQualityStatus
+        - requestedAt
+      properties:
+        id:
+          type: integer
+          format: int64
+        experimentId:
+          type: integer
+          format: int64
+        runNumber:
+          type: integer
+        mode:
+          $ref: '#/components/schemas/ExperimentRunMode'
+        status:
+          $ref: '#/components/schemas/ExperimentRunStatus'
+        evidenceValidity:
+          $ref: '#/components/schemas/ExperimentEvidenceValidity'
+        strategyVersion:
+          type: integer
+          nullable: true
+        assetBundleVersion:
+          type: integer
+          nullable: true
+        audienceVersion:
+          type: integer
+          nullable: true
+        stopPolicy:
+          $ref: '#/components/schemas/ExperimentRunStopPolicy'
+        stopReason:
+          type: string
+          nullable: true
+        failureClassification:
+          $ref: '#/components/schemas/ExperimentRunFailureClassification'
+        failureDetail:
+          type: string
+          nullable: true
+        dataQualityStatus:
+          $ref: '#/components/schemas/ExperimentRunDataQualityStatus'
+        requestedAt:
+          type: string
+          format: date-time
+        preflightStartedAt:
+          type: string
+          format: date-time
+          nullable: true
+        preflightCompletedAt:
+          type: string
+          format: date-time
+          nullable: true
+        publicationRequestedAt:
+          type: string
+          format: date-time
+          nullable: true
+        publishedAt:
+          type: string
+          format: date-time
+          nullable: true
+        firstVerifiedImpressionAt:
+          type: string
+          format: date-time
+          nullable: true
+        commercialWindowStartedAt:
+          type: string
+          format: date-time
+          nullable: true
+        endedAt:
+          type: string
+          format: date-time
+          nullable: true
+        createdBy:
+          type: string
+          nullable: true
+        createdAt:
+          type: string
+          format: date-time
+          nullable: true
+        updatedAt:
+          type: string
+          format: date-time
+          nullable: true
+    ExperimentRunMode:
+      type: string
+      enum: [TEST, PRODUCTION]
+    ExperimentRunStatus:
+      type: string
+      enum: [DRAFT, PREFLIGHT_PENDING, PREFLIGHT_RUNNING, PREFLIGHT_FAILED, READY_TO_PUBLISH, PUBLICATION_PENDING, PUBLISHING, PUBLISHED_AWAITING_EXPOSURE, RUNNING, PAUSE_REQUESTED, PAUSED, STOP_REQUESTED, COMPLETED, FAILED, CANCELLED]
+    ExperimentEvidenceValidity:
+      type: string
+      enum: [NOT_EVALUATED, TECHNICALLY_INVALID, MEASUREMENT_INVALID, STRATEGICALLY_INVALID, INSUFFICIENT_DATA, COMMERCIALLY_VALID]
+    ExperimentRunDataQualityStatus:
+      type: string
+      enum: [UNKNOWN, VALID, WARNING, BLOCKED, STALE]
+    ExperimentRunFailureClassification:
+      type: string
+      nullable: true
+      enum: [INTEGRATION_FAILURE, PUBLICATION_FAILURE, MEASUREMENT_FAILURE, FORM_FUNCTIONAL_FAILURE, LANDING_QUALITY_FAILURE, UPSTREAM_DATA_QUALITY_FAILURE, STRATEGY_CONFIGURATION_FAILURE, AUDIENCE_FAILURE, CREATIVE_FAILURE, PROMISE_OR_LEAD_MAGNET_FAILURE, OFFER_FAILURE, PRICE_OR_CHECKOUT_FAILURE, INSUFFICIENT_DATA, COMMERCIAL_HYPOTHESIS_FAILURE, USER_STOPPED]
+    ExperimentRunStopPolicy:
+      type: string
+      enum: [FIRST_VALID_LEAD_STANDBY, FIXED_WINDOW, MIN_SAMPLE_AND_WINDOW, STOP_LOSS, MANUAL_ONLY]
+
+    ExperimentRunGateGroup:
+      type: string
+      enum: [UPSTREAM_QUALITY, EXPERIMENT_DESIGN, ASSET_QUALITY, FUNCTIONAL_E2E, META_PUBLICATION, MEASUREMENT]
+    ExperimentRunGateStatus:
+      type: string
+      enum: [PASS, WARNING, FAIL, NOT_APPLICABLE, PENDING]
+    ExperimentRunGateSeverity:
+      type: string
+      enum: [INFO, WARNING, BLOCKER]
+    ExperimentRunGateEvaluatorType:
+      type: string
+      enum: [DETERMINISTIC, HUMAN, EXTERNAL_PROVIDER]

--- a/frontend/src/api/experiment/useExperimentRuns.ts
+++ b/frontend/src/api/experiment/useExperimentRuns.ts
@@ -1,0 +1,166 @@
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import axios from "axios";
+
+export type ExperimentRunMode = "TEST" | "PRODUCTION";
+export type ExperimentRunStatus =
+  | "DRAFT"
+  | "PREFLIGHT_PENDING"
+  | "PREFLIGHT_RUNNING"
+  | "PREFLIGHT_FAILED"
+  | "READY_TO_PUBLISH"
+  | "PUBLICATION_PENDING"
+  | "PUBLISHING"
+  | "PUBLISHED_AWAITING_EXPOSURE"
+  | "RUNNING"
+  | "PAUSE_REQUESTED"
+  | "PAUSED"
+  | "STOP_REQUESTED"
+  | "COMPLETED"
+  | "FAILED"
+  | "CANCELLED";
+export type ExperimentEvidenceValidity =
+  | "NOT_EVALUATED"
+  | "TECHNICALLY_INVALID"
+  | "MEASUREMENT_INVALID"
+  | "STRATEGICALLY_INVALID"
+  | "INSUFFICIENT_DATA"
+  | "COMMERCIALLY_VALID";
+export type ExperimentRunDataQualityStatus =
+  | "UNKNOWN"
+  | "VALID"
+  | "WARNING"
+  | "BLOCKED"
+  | "STALE";
+export type ExperimentRunStopPolicy =
+  | "FIRST_VALID_LEAD_STANDBY"
+  | "FIXED_WINDOW"
+  | "MIN_SAMPLE_AND_WINDOW"
+  | "STOP_LOSS"
+  | "MANUAL_ONLY";
+export type ExperimentRunGateStatus =
+  | "PASS"
+  | "WARNING"
+  | "FAIL"
+  | "NOT_APPLICABLE"
+  | "PENDING";
+export type ExperimentRunGateSeverity = "INFO" | "WARNING" | "BLOCKER";
+export type ExperimentRunGateGroup =
+  | "UPSTREAM_QUALITY"
+  | "EXPERIMENT_DESIGN"
+  | "ASSET_QUALITY"
+  | "FUNCTIONAL_E2E"
+  | "META_PUBLICATION"
+  | "MEASUREMENT";
+
+export type ExperimentRun = {
+  id: number;
+  experimentId: number;
+  runNumber: number;
+  mode: ExperimentRunMode;
+  status: ExperimentRunStatus;
+  evidenceValidity: ExperimentEvidenceValidity;
+  dataQualityStatus: ExperimentRunDataQualityStatus;
+  stopPolicy: ExperimentRunStopPolicy;
+  requestedAt: string;
+  preflightStartedAt?: string | null;
+  preflightCompletedAt?: string | null;
+  firstVerifiedImpressionAt?: string | null;
+  commercialWindowStartedAt?: string | null;
+  createdBy?: string | null;
+};
+
+export type ExperimentRunGateResult = {
+  gateCode: string;
+  gateGroup: ExperimentRunGateGroup;
+  status: ExperimentRunGateStatus;
+  severity: ExperimentRunGateSeverity;
+  summary: string;
+  evidenceReference?: string | null;
+  remediationCode?: string | null;
+  evaluatedAt: string;
+  evaluatorType: string;
+  evaluatorVersion?: string | null;
+};
+
+export type ExperimentRunPreflight = {
+  runId: number;
+  runStatus: ExperimentRunStatus;
+  hasBlockers: boolean;
+  gates: ExperimentRunGateResult[];
+};
+
+const experimentRunsQueryKey = (experimentId?: string | number) => [
+  "experiment-runs",
+  experimentId,
+];
+
+const experimentRunPreflightQueryKey = (runId?: number) => [
+  "experiment-run-preflight",
+  runId,
+];
+
+export function useExperimentRuns(experimentId?: string | number) {
+  return useQuery({
+    queryKey: experimentRunsQueryKey(experimentId),
+    enabled: Boolean(experimentId),
+    queryFn: async () => {
+      const { data } = await axios.get<ExperimentRun[]>(
+        `/api/experiments/${experimentId}/runs`,
+      );
+      return data;
+    },
+  });
+}
+
+export function useExperimentRunPreflight(runId?: number) {
+  return useQuery({
+    queryKey: experimentRunPreflightQueryKey(runId),
+    enabled: Boolean(runId),
+    queryFn: async () => {
+      const { data } = await axios.get<ExperimentRunPreflight>(
+        `/api/experiment-runs/${runId}/preflight`,
+      );
+      return data;
+    },
+  });
+}
+
+export function useCreateExperimentRun(experimentId?: string | number) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (mode: ExperimentRunMode) => {
+      const { data } = await axios.post<ExperimentRun>(
+        `/api/experiments/${experimentId}/runs`,
+        { mode, stopPolicy: "MANUAL_ONLY" },
+      );
+      return data;
+    },
+    onSuccess: async () => {
+      await queryClient.invalidateQueries({
+        queryKey: experimentRunsQueryKey(experimentId),
+      });
+    },
+  });
+}
+
+export function useRunExperimentPreflight(experimentId?: string | number) {
+  const queryClient = useQueryClient();
+  return useMutation({
+    mutationFn: async (runId: number) => {
+      const { data } = await axios.post<ExperimentRunPreflight>(
+        `/api/experiment-runs/${runId}/preflight`,
+      );
+      return data;
+    },
+    onSuccess: async (preflight) => {
+      await Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: experimentRunsQueryKey(experimentId),
+        }),
+        queryClient.invalidateQueries({
+          queryKey: experimentRunPreflightQueryKey(preflight.runId),
+        }),
+      ]);
+    },
+  });
+}

--- a/frontend/src/pages/experiment/ExperimentDetailPage.tsx
+++ b/frontend/src/pages/experiment/ExperimentDetailPage.tsx
@@ -28,6 +28,7 @@ import ExperimentFunnelTab from "./ExperimentFunnelTab";
 import ExperimentLandingAnalyticsTab from "./ExperimentLandingAnalyticsTab";
 import ExperimentContentGenerationTab from "./ExperimentContentGenerationTab";
 import { ExperimentAudienceTab } from "./ExperimentAudienceTab";
+import ExperimentRunPanel from "./ExperimentRunPanel";
 import LandingTab from "./LandingTab";
 import CollapsibleJsonViewer from "../../components/CollapsibleJsonViewer";
 import { useExperimentFacebookRelease } from "../../api/experiment/useExperimentFacebookRelease";
@@ -2689,6 +2690,9 @@ export default function ExperimentDetailPage() {
             <Tabs.Trigger value="funnel" className="nav-link">
               Funil de vendas
             </Tabs.Trigger>
+            <Tabs.Trigger value="execucao" className="nav-link">
+              Execução
+            </Tabs.Trigger>
             <Tabs.Trigger value="analytics" className="nav-link">
               Analytics
             </Tabs.Trigger>
@@ -2713,6 +2717,7 @@ export default function ExperimentDetailPage() {
           </Tabs.List>
           <Tabs.Content value="overview" asChild>
             <div className="d-flex flex-column gap-3">
+              <ExperimentRunPanel experimentId={expId} compact />
               <div className="card">
                 <div className="card-body p-0">
                   <dl className="row mb-0">
@@ -2733,6 +2738,11 @@ export default function ExperimentDetailPage() {
                   </dl>
                 </div>
               </div>
+            </div>
+          </Tabs.Content>
+          <Tabs.Content value="execucao" asChild>
+            <div className="d-flex flex-column gap-3">
+              <ExperimentRunPanel experimentId={expId} />
             </div>
           </Tabs.Content>
           <Tabs.Content value="funnel" asChild>

--- a/frontend/src/pages/experiment/ExperimentRunPanel.tsx
+++ b/frontend/src/pages/experiment/ExperimentRunPanel.tsx
@@ -1,0 +1,238 @@
+import type {
+  ExperimentRun,
+  ExperimentRunGateGroup,
+  ExperimentRunGateResult,
+  ExperimentRunPreflight,
+} from "../../api/experiment/useExperimentRuns";
+import {
+  useCreateExperimentRun,
+  useExperimentRunPreflight,
+  useExperimentRuns,
+  useRunExperimentPreflight,
+} from "../../api/experiment/useExperimentRuns";
+
+const gateGroupLabels: Record<ExperimentRunGateGroup, string> = {
+  UPSTREAM_QUALITY: "Qualidade upstream",
+  EXPERIMENT_DESIGN: "Desenho experimental",
+  ASSET_QUALITY: "Qualidade dos ativos",
+  FUNCTIONAL_E2E: "Teste ponta a ponta",
+  META_PUBLICATION: "Publicação Meta",
+  MEASUREMENT: "Mensuração",
+};
+
+const statusLabels: Record<string, string> = {
+  DRAFT: "Rascunho",
+  PREFLIGHT_PENDING: "Preflight pendente",
+  PREFLIGHT_RUNNING: "Preflight em execução",
+  PREFLIGHT_FAILED: "Preflight bloqueado",
+  READY_TO_PUBLISH: "Pronto para publicar",
+  PUBLICATION_PENDING: "Publicação pendente",
+  PUBLISHING: "Publicando",
+  PUBLISHED_AWAITING_EXPOSURE: "Publicado sem exposição confirmada",
+  RUNNING: "Execução comercial",
+  PAUSE_REQUESTED: "Pausa solicitada",
+  PAUSED: "Pausado",
+  STOP_REQUESTED: "Parada solicitada",
+  COMPLETED: "Concluído",
+  FAILED: "Falhou",
+  CANCELLED: "Cancelado",
+  NOT_EVALUATED: "Não avaliada",
+  TECHNICALLY_INVALID: "Inválida tecnicamente",
+  MEASUREMENT_INVALID: "Medição inválida",
+  STRATEGICALLY_INVALID: "Inválida estrategicamente",
+  INSUFFICIENT_DATA: "Dados insuficientes",
+  COMMERCIALLY_VALID: "Comercialmente válida",
+  UNKNOWN: "Desconhecida",
+  VALID: "Válida",
+  WARNING: "Atenção",
+  BLOCKED: "Bloqueada",
+  STALE: "Desatualizada",
+};
+
+function label(value?: string | null) {
+  if (!value) return "—";
+  return statusLabels[value] ?? value;
+}
+
+function badgeClass(value?: string | null) {
+  if (!value) return "text-bg-secondary";
+  if (["READY_TO_PUBLISH", "COMMERCIALLY_VALID", "VALID", "PASS"].includes(value)) {
+    return "text-bg-success";
+  }
+  if (["PREFLIGHT_FAILED", "TECHNICALLY_INVALID", "MEASUREMENT_INVALID", "STRATEGICALLY_INVALID", "BLOCKED", "FAIL"].includes(value)) {
+    return "text-bg-danger";
+  }
+  if (["WARNING", "INSUFFICIENT_DATA", "PENDING"].includes(value)) {
+    return "text-bg-warning text-dark";
+  }
+  return "text-bg-secondary";
+}
+
+function latestRun(runs?: ExperimentRun[]) {
+  return [...(runs ?? [])].sort((left, right) => right.runNumber - left.runNumber)[0];
+}
+
+function groupGates(gates: ExperimentRunGateResult[]) {
+  return gates.reduce<Record<string, ExperimentRunGateResult[]>>((acc, gate) => {
+    acc[gate.gateGroup] = [...(acc[gate.gateGroup] ?? []), gate];
+    return acc;
+  }, {});
+}
+
+type ExperimentRunPanelProps = {
+  experimentId: string;
+  compact?: boolean;
+};
+
+export default function ExperimentRunPanel({ experimentId, compact = false }: ExperimentRunPanelProps) {
+  const runsQuery = useExperimentRuns(experimentId);
+  const currentRun = latestRun(runsQuery.data);
+  const preflightQuery = useExperimentRunPreflight(currentRun?.id);
+  const createRun = useCreateExperimentRun(experimentId);
+  const runPreflight = useRunExperimentPreflight(experimentId);
+  const preflight = preflightQuery.data;
+  const gateGroups = groupGates(preflight?.gates ?? []);
+
+  const handleCreateRun = () => {
+    if (!createRun.isPending) {
+      createRun.mutate("PRODUCTION");
+    }
+  };
+
+  const handleRunPreflight = () => {
+    if (currentRun && !runPreflight.isPending) {
+      runPreflight.mutate(currentRun.id);
+    }
+  };
+
+  return (
+    <div className="card">
+      <div className="card-body">
+        <div className="d-flex flex-wrap justify-content-between align-items-start gap-3">
+          <div>
+            <h5 className="card-title mb-1">Execução atual</h5>
+            <p className="text-muted small mb-0">
+              Verdade operacional do backend sobre a tentativa de colocar este experimento no mercado.
+            </p>
+          </div>
+          <div className="d-flex flex-wrap gap-2">
+            <button
+              type="button"
+              className="btn btn-outline-primary btn-sm"
+              onClick={handleCreateRun}
+              disabled={createRun.isPending || runsQuery.isLoading}
+            >
+              {createRun.isPending ? (
+                <span className="spinner-border spinner-border-sm me-2" aria-hidden="true" />
+              ) : null}
+              Criar run
+            </button>
+            <button
+              type="button"
+              className="btn btn-primary btn-sm"
+              onClick={handleRunPreflight}
+              disabled={!currentRun || runPreflight.isPending}
+            >
+              {runPreflight.isPending ? (
+                <span className="spinner-border spinner-border-sm me-2" aria-hidden="true" />
+              ) : null}
+              Rodar preflight
+            </button>
+          </div>
+        </div>
+
+        {runsQuery.isLoading ? (
+          <div className="text-muted small mt-3">Carregando execução atual...</div>
+        ) : !currentRun ? (
+          <div className="alert alert-info mt-3 mb-0">
+            Nenhum run foi criado para este experimento. Crie um run antes de interpretar falha técnica como resultado de mercado.
+          </div>
+        ) : (
+          <>
+            <div className="row g-3 mt-1">
+              <StatusItem label="Run" value={`#${currentRun.runNumber}`} />
+              <StatusItem label="Modo" value={currentRun.mode} />
+              <StatusItem label="Status" value={label(currentRun.status)} badge={currentRun.status} />
+              <StatusItem label="Validade" value={label(currentRun.evidenceValidity)} badge={currentRun.evidenceValidity} />
+              <StatusItem label="Dados" value={label(currentRun.dataQualityStatus)} badge={currentRun.dataQualityStatus} />
+              <StatusItem label="Exposição confirmada" value={currentRun.firstVerifiedImpressionAt ?? "—"} />
+            </div>
+
+            {!compact ? (
+              <div className="mt-4">
+                <div className="d-flex justify-content-between align-items-center mb-2">
+                  <h6 className="mb-0">Checklist de preparação</h6>
+                  {preflight ? (
+                    <span className={`badge ${preflight.hasBlockers ? "text-bg-danger" : "text-bg-success"}`}>
+                      {preflight.hasBlockers ? "Com bloqueadores" : "Sem bloqueadores"}
+                    </span>
+                  ) : null}
+                </div>
+                {preflightQuery.isLoading ? (
+                  <div className="text-muted small">Carregando preflight...</div>
+                ) : !preflight || preflight.gates.length === 0 ? (
+                  <div className="text-muted small">Preflight ainda não executado.</div>
+                ) : (
+                  <div className="accordion" id={`experiment-run-preflight-${currentRun.id}`}>
+                    {Object.entries(gateGroups).map(([group, gates], index) => (
+                      <div className="accordion-item" key={group}>
+                        <h2 className="accordion-header">
+                          <button
+                            className={`accordion-button ${index === 0 ? "" : "collapsed"}`}
+                            type="button"
+                            data-bs-toggle="collapse"
+                            data-bs-target={`#experiment-run-preflight-${currentRun.id}-${group}`}
+                          >
+                            {gateGroupLabels[group as ExperimentRunGateGroup] ?? group}
+                          </button>
+                        </h2>
+                        <div
+                          id={`experiment-run-preflight-${currentRun.id}-${group}`}
+                          className={`accordion-collapse collapse ${index === 0 ? "show" : ""}`}
+                        >
+                          <div className="accordion-body p-0">
+                            <ul className="list-group list-group-flush">
+                              {gates.map((gate) => (
+                                <li className="list-group-item" key={gate.gateCode}>
+                                  <div className="d-flex flex-wrap justify-content-between gap-2">
+                                    <div>
+                                      <div className="fw-semibold">{gate.gateCode}</div>
+                                      <div className="text-muted small">{gate.summary}</div>
+                                      {gate.remediationCode ? (
+                                        <div className="small text-danger">Remediação: {gate.remediationCode}</div>
+                                      ) : null}
+                                    </div>
+                                    <span className={`badge align-self-start ${badgeClass(gate.status)}`}>
+                                      {gate.status}
+                                    </span>
+                                  </div>
+                                </li>
+                              ))}
+                            </ul>
+                          </div>
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                )}
+              </div>
+            ) : null}
+          </>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function StatusItem({ label, value, badge }: { label: string; value: string; badge?: string }) {
+  return (
+    <div className="col-12 col-md-4 col-xl-2">
+      <div className="text-muted small">{label}</div>
+      {badge ? (
+        <span className={`badge ${badgeClass(badge)}`}>{value}</span>
+      ) : (
+        <div className="fw-semibold text-break">{value}</div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
### Motivation
- Introduce a persisted `ExperimentRun` to represent an auditable operational attempt separate from the commercial `Experiment` concept.
- Provide deterministic preflight gates to surface upstream quality, experimental design and measurement blockers before media publication.
- Expose administrative APIs and a minimal frontend panel so runs can be created, listed and preflighted without changing legacy experiment status.
- Record migration, feature flags and regression fixtures in docs to govern compatibility and prevent regressions when enabling runs.

### Description
- Added JPA entities `ExperimentRun` and `ExperimentRunGateResult`, multiple enums for run/gate states, repositories `ExperimentRunRepository` and `ExperimentRunGateResultRepository`, and Liquibase changelogs `2026-06-25-experiment-run.yaml` and `2026-06-25-experiment-run-gate-result.yaml` to create the DB schema.
- Implemented `BackendExperimentRunService` with deterministic preflight gate builders and `BackendExperimentRunController` exposing endpoints `POST /api/experiments/{experimentId}/runs`, `GET /api/experiments/{experimentId}/runs`, `GET/POST /api/experiment-runs/{runId}/preflight` and `GET /api/experiment-runs/{runId}`.
- Added frontend client hooks (`useExperimentRuns`), `ExperimentRunPanel` UI, experiment detail integration, Swagger contract `docs/swagger/experiment-runs-swagger.yaml`, canonical procedure docs updates and regression fixture `experimentos-37-40-regressao.json`.
- Included request/response record types and an integration test `BackendExperimentRunControllerTest` covering sequential run creation, listing/get and deterministic preflight scenarios (with and without blockers).

### Testing
- Executed the module integration test `BackendExperimentRunControllerTest` as a `@SpringBootTest` using H2 in MySQL compatibility mode, and all assertions in the test class passed.
- The modified ads-service module was built and the added tests completed successfully in the local CI-like run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3c728008988321915b896d9abeb699)