### PR TITLE
Allow INTEREST/BEHAVIOR targeting and require approved Meta IDs for campaign publication

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentReadinessService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentReadinessService.java
@@ -7,8 +7,9 @@ import com.marketinghub.experiment.Experiment;
 import com.marketinghub.experiment.dto.ExperimentReadinessIssueDto;
 import com.marketinghub.experiment.dto.ExperimentReadinessIssueType;
 import com.marketinghub.experiment.dto.ExperimentReadinessSummaryDto;
+import com.marketinghub.targeting.TargetingElement;
+import com.marketinghub.targeting.TargetingElementStatus;
 import com.marketinghub.targeting.TargetingElementType;
-import com.marketinghub.targeting.TargetingCandidateType;
 import com.marketinghub.repository.jpa.experiment.ExperimentTargetingSelectionRepository;
 import com.marketinghub.repository.jpa.geralanding.GeraLandingStageExecutionRepository;
 import org.springframework.stereotype.Service;
@@ -16,6 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Set;
 
 /**
  * Consolida pendências básicas de preparação do experimento.
@@ -36,6 +38,13 @@ public class ExperimentReadinessService {
     );
 
     private final ExperimentTargetingSelectionRepository targetingSelectionRepository;
+    private static final List<TargetingElementType> PUBLISHABLE_TARGETING_TYPES = List.of(
+            TargetingElementType.INTEREST,
+            TargetingElementType.JOB_TITLE,
+            TargetingElementType.BEHAVIOR
+    );
+    private static final Set<TargetingElementType> PUBLISHABLE_TARGETING_TYPE_SET = Set.copyOf(PUBLISHABLE_TARGETING_TYPES);
+
     private final GeraLandingStageExecutionRepository geraLandingStageExecutionRepository;
 
     /** Cria o serviço com as fontes canônicas de prontidão do experimento. */
@@ -62,7 +71,7 @@ public class ExperimentReadinessService {
         boolean hasCompleteTargeting = hasConfiguredTargeting(experiment);
         List<TargetingElementType> missingTypes = hasCompleteTargeting
                 ? List.of()
-                : List.of(TargetingElementType.JOB_TITLE);
+                : PUBLISHABLE_TARGETING_TYPES;
         long geraLandingCompletedStageCount = countCompletedGeraLandingStages(experimentId);
         boolean hasGeraLandingPipeline = geraLandingCompletedStageCount == GERA_LANDING_REQUIRED_STAGES.size();
 
@@ -89,8 +98,8 @@ public class ExperimentReadinessService {
             issues.add(new ExperimentReadinessIssueDto(
                     ExperimentReadinessIssueType.TARGETING,
                     "Público não selecionado",
-                    "Ainda não há nenhuma segmentação salva para este experimento.",
-                    "Acesse a aba Segmentação, marque ao menos um cargo com ID oficial da Meta e salve o público.",
+                    "Ainda não há nenhum interesse, cargo ou comportamento publicável salvo para este experimento.",
+                    "Acesse a aba Segmentação, marque ao menos um interesse, cargo ou comportamento com ID oficial da Meta e salve o público.",
                     List.copyOf(missingTypes)
             ));
         }
@@ -173,13 +182,24 @@ public class ExperimentReadinessService {
                 && experiment.getLeadPortalFlow().isApproved();
     }
 
-    /** Verifica se o usuário selecionou cargo para segmentação do experimento. */
+    /** Verifica se o usuário selecionou qualquer público publicável para segmentação do experimento. */
     private boolean hasSelectedTargeting(Long experimentId) {
         if (experimentId == null) {
             return false;
         }
-        return targetingSelectionRepository.countByExperimentIdAndCandidateType(
-                experimentId, TargetingCandidateType.WORK_POSITION) > 0;
+        return targetingSelectionRepository.findByExperimentIdWithTargetingElement(experimentId).stream()
+                .map(com.marketinghub.experiment.ExperimentTargetingSelection::getTargetingElement)
+                .anyMatch(this::isPublishableTargetingElement);
+    }
+
+    /** Confirma que o item de público escolhido está aprovado e possui identificador oficial da Meta. */
+    private boolean isPublishableTargetingElement(TargetingElement element) {
+        return element != null
+                && element.getStatus() == TargetingElementStatus.APPROVED
+                && element.getType() != null
+                && PUBLISHABLE_TARGETING_TYPE_SET.contains(element.getType())
+                && element.getMetaId() != null
+                && !element.getMetaId().isBlank();
     }
 
     /** Verifica se o experimento possui URL de destino aprovada para campanha. */

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/service/ExperimentReadinessServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/service/ExperimentReadinessServiceTest.java
@@ -3,6 +3,7 @@ package com.marketinghub.experiment.service;
 import com.marketinghub.repository.jpa.creative.CreativeRepository;
 import com.marketinghub.creative.CreativeStatus;
 import com.marketinghub.experiment.Experiment;
+import com.marketinghub.experiment.ExperimentTargetingSelection;
 import com.marketinghub.experiment.dto.ExperimentReadinessIssueDto;
 import com.marketinghub.experiment.dto.ExperimentReadinessIssueType;
 import com.marketinghub.experiment.dto.ExperimentReadinessSummaryDto;
@@ -11,6 +12,8 @@ import com.marketinghub.hypothesis.Hypothesis;
 import com.marketinghub.leadportal.LeadPortalFlow;
 import com.marketinghub.niche.MarketNiche;
 import com.marketinghub.targeting.TargetingCandidateType;
+import com.marketinghub.targeting.TargetingElement;
+import com.marketinghub.targeting.TargetingElementStatus;
 import com.marketinghub.targeting.TargetingElementType;
 import com.marketinghub.repository.jpa.experiment.ExperimentTargetingSelectionRepository;
 import com.marketinghub.repository.jpa.geralanding.GeraLandingStageExecutionRepository;
@@ -56,7 +59,10 @@ class ExperimentReadinessServiceTest {
         assertThat(summary.hasCompleteTargeting()).isFalse();
         assertThat(summary.hasGeraLandingPipeline()).isFalse();
         assertThat(summary.geraLandingCompletedStageCount()).isZero();
-        assertThat(summary.missingTargetingTypes()).containsExactly(TargetingElementType.JOB_TITLE);
+        assertThat(summary.missingTargetingTypes()).containsExactly(
+                TargetingElementType.INTEREST,
+                TargetingElementType.JOB_TITLE,
+                TargetingElementType.BEHAVIOR);
         assertThat(summary.issues()).hasSize(4);
         assertThat(summary.issues()).extracting(ExperimentReadinessIssueDto::type)
                 .containsExactlyInAnyOrder(
@@ -78,8 +84,7 @@ class ExperimentReadinessServiceTest {
 
         when(experimentService.get(experimentId)).thenReturn(experiment);
         when(creativeRepository.countByExperimentIdAndStatus(experimentId, CreativeStatus.READY)).thenReturn(2L);
-        when(targetingSelectionRepository.countByExperimentIdAndCandidateType(
-                experimentId, TargetingCandidateType.WORK_POSITION)).thenReturn(1L);
+        mockPublishableSelection(experimentId, TargetingCandidateType.INTEREST, TargetingElementType.INTEREST);
         mockCompletedGeraLandingStages(experimentId);
         ExperimentReadinessSummaryDto summary = service.summarize(experimentId);
 
@@ -100,15 +105,14 @@ class ExperimentReadinessServiceTest {
         experiment.setFollowUpActionUrl("https://example.com/landing/22");
 
         when(creativeRepository.existsByExperimentIdAndStatus(experimentId, CreativeStatus.READY)).thenReturn(true);
-        when(targetingSelectionRepository.countByExperimentIdAndCandidateType(
-                experimentId, TargetingCandidateType.WORK_POSITION)).thenReturn(1L);
+        mockPublishableSelection(experimentId, TargetingCandidateType.BEHAVIOR, TargetingElementType.BEHAVIOR);
 
         assertThat(service.computeMissingConfiguration(experiment)).isEmpty();
         assertThat(service.isReadyForCampaign(experiment)).isTrue();
     }
 
     @Test
-    void shouldReportTargetingIssueWhenThereIsNoSavedJobTitleSelection() {
+    void shouldReportTargetingIssueWhenThereIsNoPublishableSelection() {
         Long experimentId = 11L;
         Experiment experiment = buildExperiment(experimentId, 19L);
         LeadPortalFlow flow = new LeadPortalFlow();
@@ -120,13 +124,16 @@ class ExperimentReadinessServiceTest {
         ExperimentReadinessSummaryDto summary = service.summarize(experimentId);
 
         assertThat(summary.hasCompleteTargeting()).isFalse();
-        assertThat(summary.missingTargetingTypes()).containsExactly(TargetingElementType.JOB_TITLE);
+        assertThat(summary.missingTargetingTypes()).containsExactly(
+                TargetingElementType.INTEREST,
+                TargetingElementType.JOB_TITLE,
+                TargetingElementType.BEHAVIOR);
         assertThat(summary.issues()).extracting(ExperimentReadinessIssueDto::type)
                 .contains(ExperimentReadinessIssueType.TARGETING);
     }
 
     @Test
-    void shouldTreatSavedJobTitleSelectionAsReady() {
+    void shouldTreatSavedInterestSelectionAsReady() {
         Long experimentId = 15L;
         Experiment experiment = buildExperiment(experimentId, 21L);
         LeadPortalFlow flow = new LeadPortalFlow();
@@ -135,8 +142,7 @@ class ExperimentReadinessServiceTest {
 
         when(experimentService.get(experimentId)).thenReturn(experiment);
         when(creativeRepository.countByExperimentIdAndStatus(experimentId, CreativeStatus.READY)).thenReturn(1L);
-        when(targetingSelectionRepository.countByExperimentIdAndCandidateType(
-                experimentId, TargetingCandidateType.WORK_POSITION)).thenReturn(1L);
+        mockPublishableSelection(experimentId, TargetingCandidateType.INTEREST, TargetingElementType.INTEREST);
         ExperimentReadinessSummaryDto summary = service.summarize(experimentId);
 
         assertThat(summary.hasCompleteTargeting()).isTrue();
@@ -176,8 +182,7 @@ class ExperimentReadinessServiceTest {
         experiment.setFollowUpActionUrl(null);
 
         when(creativeRepository.existsByExperimentIdAndStatus(20L, CreativeStatus.READY)).thenReturn(true);
-        when(targetingSelectionRepository.countByExperimentIdAndCandidateType(
-                20L, TargetingCandidateType.WORK_POSITION)).thenReturn(1L);
+        mockPublishableSelection(20L, TargetingCandidateType.WORK_POSITION, TargetingElementType.JOB_TITLE);
 
         assertThat(service.computeMissingConfiguration(experiment))
                 .containsExactly("landingDestination");
@@ -189,13 +194,52 @@ class ExperimentReadinessServiceTest {
         experiment.setFollowUpActionUrl("https://example.com/landing/21");
 
         when(creativeRepository.existsByExperimentIdAndStatus(21L, CreativeStatus.READY)).thenReturn(true);
-        when(targetingSelectionRepository.countByExperimentIdAndCandidateType(
-                21L, TargetingCandidateType.WORK_POSITION)).thenReturn(1L);
+        mockPublishableSelection(21L, TargetingCandidateType.BEHAVIOR, TargetingElementType.BEHAVIOR);
 
         assertThat(service.computeMissingConfiguration(experiment)).isEmpty();
         assertThat(service.isReadyForCampaign(experiment)).isTrue();
     }
 
+    @Test
+    void shouldBlockCampaignWhenSelectionDoesNotHaveOfficialMetaId() {
+        Experiment experiment = buildExperiment(23L, 33L);
+        experiment.setFollowUpActionUrl("https://example.com/landing/23");
+
+        when(creativeRepository.existsByExperimentIdAndStatus(23L, CreativeStatus.READY)).thenReturn(true);
+        when(targetingSelectionRepository.findByExperimentIdWithTargetingElement(23L))
+                .thenReturn(List.of(selection(
+                        TargetingCandidateType.INTEREST,
+                        targetingElement(TargetingElementType.INTEREST, ""))));
+
+        assertThat(service.computeMissingConfiguration(experiment)).containsExactly("approvedTargetingPackage");
+        assertThat(service.isReadyForCampaign(experiment)).isFalse();
+    }
+
+
+    /** Simula uma seleção de público aprovada e identificável pela Meta. */
+    private void mockPublishableSelection(Long experimentId, TargetingCandidateType candidateType, TargetingElementType elementType) {
+        when(targetingSelectionRepository.findByExperimentIdWithTargetingElement(experimentId))
+                .thenReturn(List.of(selection(candidateType, targetingElement(elementType, "meta-" + experimentId))));
+    }
+
+    /** Cria uma seleção de público para os testes de prontidão. */
+    private ExperimentTargetingSelection selection(TargetingCandidateType candidateType, TargetingElement element) {
+        return ExperimentTargetingSelection.builder()
+                .candidateType(candidateType)
+                .term(element.getTerm())
+                .targetingElement(element)
+                .build();
+    }
+
+    /** Cria um elemento de público aprovado para os testes de prontidão. */
+    private TargetingElement targetingElement(TargetingElementType type, String metaId) {
+        return TargetingElement.builder()
+                .type(type)
+                .term(type.name())
+                .status(TargetingElementStatus.APPROVED)
+                .metaId(metaId)
+                .build();
+    }
 
     /** Simula todas as etapas obrigatórias do GeraLanding como concluídas. */
     private void mockCompletedGeraLandingStages(Long experimentId) {

--- a/backend/ads-service/src/test/java/com/marketinghub/facebookads/controller/FacebookAdsCampaignControllerTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/facebookads/controller/FacebookAdsCampaignControllerTest.java
@@ -11,6 +11,7 @@ import com.marketinghub.ads.InstagramAccount;
 import com.marketinghub.repository.jpa.experiment.ExperimentTargetingSelectionRepository;
 import com.marketinghub.experiment.AdSet;
 import com.marketinghub.experiment.Experiment;
+import com.marketinghub.experiment.ExperimentTargetingSelection;
 import com.marketinghub.experiment.ExperimentPlatform;
 import com.marketinghub.experiment.ExperimentStatus;
 import com.marketinghub.experiment.funnel.ExperimentFunnelAutoStopService;
@@ -35,6 +36,9 @@ import com.marketinghub.leadportal.dto.LeadPortalExperimentUserDto;
 import com.marketinghub.leadportal.service.LeadPortalMetricsService;
 import com.marketinghub.repository.jpa.experiment.AdSetRepository;
 import com.marketinghub.targeting.TargetingCandidateType;
+import com.marketinghub.targeting.TargetingElement;
+import com.marketinghub.targeting.TargetingElementStatus;
+import com.marketinghub.targeting.TargetingElementType;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
@@ -206,7 +210,17 @@ class FacebookAdsCampaignControllerTest {
                 .leadPortalFlow(leadPortalFlow)
                 .build();
         when(creativeRepository.existsByExperimentIdAndStatus(1L, CreativeStatus.READY)).thenReturn(true);
-        when(targetingSelectionRepository.countByExperimentIdAndCandidateType(1L, TargetingCandidateType.WORK_POSITION)).thenReturn(1L);
+        when(targetingSelectionRepository.findByExperimentIdWithTargetingElement(1L)).thenReturn(List.of(
+                ExperimentTargetingSelection.builder()
+                        .candidateType(TargetingCandidateType.INTEREST)
+                        .term("Loja de roupas")
+                        .targetingElement(TargetingElement.builder()
+                                .type(TargetingElementType.INTEREST)
+                                .term("Loja de roupas")
+                                .status(TargetingElementStatus.APPROVED)
+                                .metaId("meta-interest-1")
+                                .build())
+                        .build()));
         when(experimentService.listByStatusAndPlatform(
                 com.marketinghub.experiment.ExperimentStatus.PLANNED,
                 com.marketinghub.experiment.ExperimentPlatform.FACEBOOK))

--- a/docs/canonical/facebook-campaign-publication-canon.v1.md
+++ b/docs/canonical/facebook-campaign-publication-canon.v1.md
@@ -109,7 +109,7 @@ Implementação: `ExperimentReadinessService` (backend) expõe os mesmos critér
    - O critério operacional de publicação é `experiment.follow_up_action_url` preenchido com a URL aprovada para destino da campanha.
    - O vínculo é do experimento com a própria landing aprovada; não há dependência bloqueante de `lead_portal_flow` para liberar campanha no Facebook Ads Worker.
 3. **Público completo**
-   - Para seleção manual de público, o mínimo de liberação deve seguir exatamente a mesma regra do publicador/backend exposta em `ExperimentReadinessService`: o experimento precisa ter seleção de público salva para publicação, atualmente pelo menos **1 cargo/WORK_POSITION** vinculado ao experimento.
+   - Para seleção manual de público, o mínimo de liberação deve seguir exatamente a mesma regra do publicador/backend exposta em `ExperimentReadinessService`: o experimento precisa ter **ao menos 1 item escolhido, aprovado e identificável pela Meta** em qualquer categoria suportada: **interesse/INTEREST**, **cargo/JOB_TITLE (WORK_POSITION na UI/API de seleção)** ou **comportamento/BEHAVIOR**. Nenhuma categoria é obrigatória isoladamente.
    - A tela não pode considerar o card **Escolha de público** concluído por inferência local, por existência de criativo, por existência de landing ou apenas por playbook visual; ela deve usar a resposta do contrato `/api/experiments/{experimentId}/readiness`, especialmente `hasCompleteTargeting`, para refletir a mesma regra que coloca o experimento na fila `/api/facebook-campaigns/experiments-ready`.
    - O `facebook-ads-worker` deve consumir o pacote manual por `GET /api/facebook-adsets/experiments/{experimentId}/targeting-package`, contrato enxuto contendo somente `experimentId` e `targeting`, sem `ExperimentDto`, HTML, copy, landing ou artefatos de geração.
 
@@ -126,7 +126,7 @@ Em termos práticos, o experimento só pode ser liberado para campanha quando 3 
 2. **Tem página de destino publicada?**
    - A landing precisa estar aprovada e com URL final preenchida para receber o tráfego.
 3. **Tem público definido?**
-   - Precisa haver público salvo pela mesma regra do publicador; hoje isso significa pelo menos 1 cargo/WORK_POSITION salvo para o experimento.
+   - Precisa haver público salvo pela mesma regra do publicador: pelo menos 1 interesse, cargo ou comportamento escolhido, aprovado e com ID oficial da Meta. Se qualquer um desses itens existir, o público está definido para publicação.
 
 Se qualquer resposta for **não**, a liberação deve ser interrompida até a pendência ser resolvida.
 

--- a/docs/canonical/procedimento-experimento-canon.v1.md
+++ b/docs/canonical/procedimento-experimento-canon.v1.md
@@ -466,7 +466,8 @@ A interface de Experimentos deve manter abas/visões que permitam acompanhar, de
 4. Gerar anúncios com IA.
 5. Aprovar anúncios.
 6. Ir para aba Landing, revisar/aprovar/publicar landing e confirmar URL final para campanha.
-7. Validar custos/telemetria da geração no experimento.
+7. Na aba Público, salvar ao menos 1 item escolhido, aprovado e identificável pela Meta em qualquer categoria suportada: interesse, cargo ou comportamento. Qualquer uma dessas categorias basta para liberar campanha; cargo não é requisito isolado.
+8. Validar custos/telemetria da geração no experimento.
 
 ## 13. Fonte de verdade técnica (código)
 

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -5377,3 +5377,10 @@
     - frontend/src/api/experiment/useExperimentRuns.ts
     - frontend/src/pages/experiment/ExperimentRunPanel.tsx
     - frontend/src/pages/experiment/ExperimentDetailPage.tsx
+
+## 2026-06-25 — Público de campanha aceita interesse, cargo ou comportamento
+
+- Solicitação: revisar a liberação de campanha para que qualquer item de público escolhido possa liberar o experimento, sem exigir cargo isoladamente.
+- Causa-raiz: a publicação canônica já aceitava `INTEREST`, `JOB_TITLE` ou `BEHAVIOR`, mas a prontidão do experimento ainda verificava apenas `WORK_POSITION`, bloqueando experimentos com interesse aprovado e ID oficial da Meta.
+- Correção aplicada: a prontidão de campanha passou a considerar qualquer seleção salva cujo elemento esteja aprovado, tenha ID oficial da Meta e seja `INTEREST`, `JOB_TITLE` ou `BEHAVIOR`; a UI e o cânone foram alinhados para remover a exigência isolada de cargo.
+- Prevenção de recorrência: testes unitários cobrem interesse e comportamento como suficientes para campanha e bloqueiam seleção sem ID oficial da Meta.

--- a/frontend/src/pages/experiment/ExperimentDetailPage.tsx
+++ b/frontend/src/pages/experiment/ExperimentDetailPage.tsx
@@ -1819,7 +1819,7 @@ export default function ExperimentDetailPage() {
         ? "Verificando público salvo para o publicador..."
         : hasPublisherTargeting
           ? "Público salvo atende a regra do Facebook Ads Worker."
-          : "Salve na aba Público pelo menos um cargo/WORK_POSITION válido para este experimento.",
+          : "Salve na aba Público pelo menos um interesse, cargo ou comportamento válido para este experimento.",
       action: hasPublisherTargeting
         ? undefined
         : () => openExperimentTab("publico"),


### PR DESCRIPTION
### Motivation

- Align the experiment readiness checks with the canonical publication rules so that any approved and Meta-identifiable targeting item (interest, job title or behavior) can unlock campaign publication instead of only job title/work position.
- Prevent experiments from being released when the selected targeting element lacks an official Meta identifier or approval status.

### Description

- Extended `ExperimentReadinessService` to consider `INTEREST`, `JOB_TITLE` and `BEHAVIOR` as publishable targeting types and to verify that selected `TargetingElement` is `APPROVED` and has a non-empty `metaId` before treating targeting as complete.  
- Replaced the previous count-based check for `WORK_POSITION` with `findByExperimentIdWithTargetingElement(...).anyMatch(...)` and added helper `isPublishableTargetingElement`.  
- Updated unit tests in `ExperimentReadinessServiceTest` to cover interest and behavior as valid selections and added a test `shouldBlockCampaignWhenSelectionDoesNotHaveOfficialMetaId` to assert blocking when `metaId` is missing.  
- Adjusted `FacebookAdsCampaignControllerTest` to mock the new targeting selection payload shape and updated frontend copy in `ExperimentDetailPage.tsx` along with canonical docs to reflect the new rule.  

### Testing

- Ran backend unit tests including `ExperimentReadinessServiceTest` and `FacebookAdsCampaignControllerTest`, and all tests passed.  
- Added and executed the new test `shouldBlockCampaignWhenSelectionDoesNotHaveOfficialMetaId`, which passed.  
- Verified existing GeraLanding and creative readiness tests continue to pass after the changes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3c826a2f04832188b9db308dd7a39b)