### PR TITLE
Atualiza card de hipóteses no detalhe do nicho

### DIFF
--- a/frontend/src/pages/niche/NicheDetailPage.css
+++ b/frontend/src/pages/niche/NicheDetailPage.css
@@ -266,6 +266,69 @@
   text-decoration: underline;
 }
 
+.niche-detail__hypotheses-card {
+  gap: 1rem;
+}
+
+.niche-detail__hypotheses-card-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 0.85rem;
+}
+
+.niche-detail__hypotheses-create,
+.niche-detail__hypothesis-row .btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.niche-detail__hypotheses-list {
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+}
+
+.niche-detail__hypothesis-row {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 0.85rem 1rem;
+  border: 1px solid var(--bs-border-color, rgba(33, 37, 41, 0.1));
+  border-radius: 0.85rem;
+  background: rgba(var(--bs-primary-rgb, 13, 110, 253), 0.035);
+}
+
+.niche-detail__hypothesis-main {
+  display: flex;
+  min-width: 0;
+  flex-direction: column;
+  gap: 0.2rem;
+}
+
+.niche-detail__hypothesis-name {
+  overflow: hidden;
+  color: var(--bs-emphasis-color, #212529);
+  font-weight: 700;
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.niche-detail__hypothesis-name:hover,
+.niche-detail__hypothesis-name:focus-visible {
+  color: var(--bs-primary, #0d6efd);
+  text-decoration: underline;
+}
+
+.niche-detail__hypothesis-meta {
+  color: var(--bs-secondary-color, #6c757d);
+  font-size: 0.875rem;
+}
+
 .niche-section {
   display: flex;
   flex-direction: column;

--- a/frontend/src/pages/niche/NicheDetailPage.tsx
+++ b/frontend/src/pages/niche/NicheDetailPage.tsx
@@ -599,9 +599,6 @@ export default function NicheDetailPage() {
     ? new Date(data.updatedAt).toLocaleString("pt-BR")
     : undefined;
   const infoCards = [
-    { label: "Descrição", value: data.description },
-    { label: "Categoria de interesse", value: data.interestCategory },
-    { label: "Categoria de cargo", value: data.roleCategory },
     { label: "Volume de demanda", value: data.demandVolume },
     { label: "Promessas", value: data.promises },
     { label: "Ofertas", value: data.offers },
@@ -1007,13 +1004,6 @@ export default function NicheDetailPage() {
           </p>
         </div>
         <div className="niche-detail__actions">
-          <Link
-            className="btn btn-primary niche-detail__action-btn"
-            to={`/niches/${normalizedNicheId}/hypotheses/new`}
-          >
-            <Plus size={18} />
-            <span>Criar hipótese</span>
-          </Link>
           <button
             type="button"
             className="btn btn-outline-secondary niche-detail__action-btn"
@@ -1071,6 +1061,62 @@ export default function NicheDetailPage() {
       </ul>
       <section aria-label="Informações do nicho">
         <div className="niche-detail__grid">
+          <article className="niche-detail__card niche-detail__hypotheses-card">
+            <div className="niche-detail__hypotheses-card-header">
+              <h3 className="niche-detail__card-title">Hipóteses do nicho</h3>
+              <Link
+                className="btn btn-primary niche-detail__hypotheses-create"
+                to={`/niches/${normalizedNicheId}/hypotheses/new`}
+              >
+                <Plus size={18} />
+                <span>Criar nova hipótese</span>
+              </Link>
+            </div>
+            <div className="niche-detail__card-content">
+              {list.length === 0 ? (
+                <span className="niche-detail__card-empty">
+                  Nenhuma hipótese criada para este nicho ainda.
+                </span>
+              ) : (
+                <div className="niche-detail__hypotheses-list">
+                  {list.map((hypothesis) => {
+                    const experimentCount =
+                      experimentsCountByHypothesis[hypothesis.id] ?? 0;
+                    const experimentLabel =
+                      experimentCount === 1
+                        ? "1 experimento"
+                        : `${experimentCount} experimentos`;
+                    const costLabel = formatUsd(hypothesis.costUsd) ?? "-";
+                    return (
+                      <div
+                        key={hypothesis.id}
+                        className="niche-detail__hypothesis-row"
+                      >
+                        <div className="niche-detail__hypothesis-main">
+                          <Link
+                            className="niche-detail__hypothesis-name"
+                            to={`hypotheses/${hypothesis.id}`}
+                          >
+                            {hypothesis.title || "Hipótese sem nome"}
+                          </Link>
+                          <span className="niche-detail__hypothesis-meta">
+                            Custo: {costLabel} • {experimentLabel}
+                          </span>
+                        </div>
+                        <Link
+                          className="btn btn-sm btn-outline-primary"
+                          to={`hypotheses/${hypothesis.id}`}
+                        >
+                          Entrar
+                          <ArrowUpRight size={16} />
+                        </Link>
+                      </div>
+                    );
+                  })}
+                </div>
+              )}
+            </div>
+          </article>
           {visibleInfoCards.map((card) => (
             <article key={card.label} className="niche-detail__card">
               <h3 className="niche-detail__card-title">{card.label}</h3>


### PR DESCRIPTION
### Motivation
- Substituir os cards de `Descrição`, `Categoria de interesse` e `Categoria de cargo` na tela de detalhe do nicho por um card único que mostre as hipóteses do nicho com informações úteis e ações de entrada/criação.
- Facilitar a navegação e a criação de hipóteses trazendo o CTA para dentro do novo card e apresentando métricas relevantes por hipótese (nome, custo, quantidade de experimentos). 

### Description
- Removeu os itens `{ label: "Descrição" }`, `{ label: "Categoria de interesse" }` e `{ label: "Categoria de cargo" }` do array `infoCards` em `frontend/src/pages/niche/NicheDetailPage.tsx`.
- Adicionou um novo card JSX `Hipóteses do nicho` em `NicheDetailPage.tsx` que lista as hipóteses retornadas por `useHypothesesByNiche`, mostrando `title`, `costUsd` (formatado) e a contagem de experimentos (calculada por `experimentsCountByHypothesis`), mais um botão `Entrar` com link para a rota da hipótese.
- Moveu o CTA de criação de hipótese do topo da página para dentro do novo card e reutiliza a rota existente `/niches/:id/hypotheses/new` (sem criar novos endpoints backend).
- Incluiu estilos CSS em `frontend/src/pages/niche/NicheDetailPage.css` para o layout do card, linhas de hipótese e botões (`.niche-detail__hypotheses-card`, `.niche-detail__hypothesis-row`, etc.).

### Testing
- Executado `npm --prefix frontend install` — concluído com dependências instaladas (vulnerabilidades reportadas pelo npm audit não bloqueiam o build aqui).
- Formatado com `npx prettier` nos arquivos modificados — concluído com sucesso.
- Build de produção com `npm --prefix frontend run build` (Vite) — concluído com sucesso, gerou warning de chunk grande mas artefato foi construído (`✓ built`).
- Typecheck com `npm --prefix frontend run typecheck` (`tsc --noEmit`) — concluído sem erros.
- Observação: tentativa automática de screenshot falhou por ausência do Playwright/Chromium no ambiente, portanto não há imagem anexada.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cbf8a14948321a3df418532c05b9f)