### PR TITLE
Vincula execuções concluídas à hipótese e adiciona filtro `hypothesisId` na listagem

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/hypothesis/pain/controller/HypothesisPainStageController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/hypothesis/pain/controller/HypothesisPainStageController.java
@@ -10,6 +10,7 @@ import com.marketinghub.hypothesis.pain.service.start.HypothesisPainStartRespons
 import com.marketinghub.hypothesis.pain.service.summary.HypothesisStageFinalSummaryResponse;
 import jakarta.validation.Valid;
 import java.util.List;
+import java.util.UUID;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.http.ResponseEntity;
@@ -73,40 +74,45 @@ public class HypothesisPainStageController {
     @GetMapping("/niches/{nicheId}/hypothesis-pipeline/pain/stage-executions")
     public ResponseEntity<List<HypothesisPainExecutionSummaryResponse>> listStageExecutions(
             @PathVariable Long nicheId,
-            @RequestParam(defaultValue = "true") boolean includeCompleted) {
-        return ResponseEntity.ok(service.listStageExecutions(nicheId, includeCompleted));
+            @RequestParam(defaultValue = "true") boolean includeCompleted,
+            @RequestParam(required = false) UUID hypothesisId) {
+        return ResponseEntity.ok(service.listStageExecutions(nicheId, includeCompleted, hypothesisId));
     }
 
     /** Lista execuções da etapa Resultado para acompanhamento na tela de nova hipótese. */
     @GetMapping("/niches/{nicheId}/hypothesis-pipeline/result/stage-executions")
     public ResponseEntity<List<HypothesisPainExecutionSummaryResponse>> listResultStageExecutions(
             @PathVariable Long nicheId,
-            @RequestParam(defaultValue = "true") boolean includeCompleted) {
-        return ResponseEntity.ok(service.listResultStageExecutions(nicheId, includeCompleted));
+            @RequestParam(defaultValue = "true") boolean includeCompleted,
+            @RequestParam(required = false) UUID hypothesisId) {
+        return ResponseEntity.ok(service.listResultStageExecutions(nicheId, includeCompleted, hypothesisId));
     }
 
     /** Lista execuções da etapa Mecanismo para acompanhamento na tela de nova hipótese. */
     @GetMapping("/niches/{nicheId}/hypothesis-pipeline/mechanism/stage-executions")
     public ResponseEntity<List<HypothesisPainExecutionSummaryResponse>> listMechanismStageExecutions(
             @PathVariable Long nicheId,
-            @RequestParam(defaultValue = "true") boolean includeCompleted) {
-        return ResponseEntity.ok(service.listMechanismStageExecutions(nicheId, includeCompleted));
+            @RequestParam(defaultValue = "true") boolean includeCompleted,
+            @RequestParam(required = false) UUID hypothesisId) {
+        return ResponseEntity.ok(service.listMechanismStageExecutions(nicheId, includeCompleted, hypothesisId));
     }
 
     /** Lista execuções da etapa Prova para acompanhamento na tela de nova hipótese. */
     @GetMapping("/niches/{nicheId}/hypothesis-pipeline/proof/stage-executions")
     public ResponseEntity<List<HypothesisPainExecutionSummaryResponse>> listProofStageExecutions(
             @PathVariable Long nicheId,
-            @RequestParam(defaultValue = "true") boolean includeCompleted) {
-        return ResponseEntity.ok(service.listProofStageExecutions(nicheId, includeCompleted));
+            @RequestParam(defaultValue = "true") boolean includeCompleted,
+            @RequestParam(required = false) UUID hypothesisId) {
+        return ResponseEntity.ok(service.listProofStageExecutions(nicheId, includeCompleted, hypothesisId));
     }
 
     /** Lista execuções da etapa Oferta para acompanhamento na tela de nova hipótese. */
     @GetMapping("/niches/{nicheId}/hypothesis-pipeline/offer/stage-executions")
     public ResponseEntity<List<HypothesisPainExecutionSummaryResponse>> listOfferStageExecutions(
             @PathVariable Long nicheId,
-            @RequestParam(defaultValue = "true") boolean includeCompleted) {
-        return ResponseEntity.ok(service.listOfferStageExecutions(nicheId, includeCompleted));
+            @RequestParam(defaultValue = "true") boolean includeCompleted,
+            @RequestParam(required = false) UUID hypothesisId) {
+        return ResponseEntity.ok(service.listOfferStageExecutions(nicheId, includeCompleted, hypothesisId));
     }
 
     /** Lista o conteúdo final de cada etapa concluída do framework para resumo executivo. */

--- a/backend/ads-service/src/main/java/com/marketinghub/hypothesis/pain/service/HypothesisPainStageService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/hypothesis/pain/service/HypothesisPainStageService.java
@@ -187,50 +187,73 @@ public class HypothesisPainStageService {
                 .build();
     }
 
-    /** Lista execuções da etapa Dor para o nicho informado. */
+    /** Lista execuções da etapa Dor para o nicho informado, vazias na criação ou filtradas pela hipótese selecionada. */
     @Transactional(readOnly = true)
-    public List<HypothesisPainExecutionSummaryResponse> listStageExecutions(Long marketNicheId, boolean includeCompleted) {
-        return listStageExecutions(marketNicheId, STAGE_CODE, includeCompleted);
+    public List<HypothesisPainExecutionSummaryResponse> listStageExecutions(
+            Long marketNicheId,
+            boolean includeCompleted,
+            UUID hypothesisId) {
+        return listStageExecutions(marketNicheId, STAGE_CODE, includeCompleted, hypothesisId);
     }
 
     /** Lista execuções da etapa Resultado para o nicho informado. */
     @Transactional(readOnly = true)
-    public List<HypothesisPainExecutionSummaryResponse> listResultStageExecutions(Long marketNicheId, boolean includeCompleted) {
-        return listStageExecutions(marketNicheId, RESULT_STAGE_CODE, includeCompleted);
+    public List<HypothesisPainExecutionSummaryResponse> listResultStageExecutions(
+            Long marketNicheId,
+            boolean includeCompleted,
+            UUID hypothesisId) {
+        return listStageExecutions(marketNicheId, RESULT_STAGE_CODE, includeCompleted, hypothesisId);
     }
 
     /** Lista execuções da etapa Mecanismo para o nicho informado. */
     @Transactional(readOnly = true)
     public List<HypothesisPainExecutionSummaryResponse> listMechanismStageExecutions(
             Long marketNicheId,
-            boolean includeCompleted) {
-        return listStageExecutions(marketNicheId, MECHANISM_STAGE_CODE, includeCompleted);
+            boolean includeCompleted,
+            UUID hypothesisId) {
+        return listStageExecutions(marketNicheId, MECHANISM_STAGE_CODE, includeCompleted, hypothesisId);
     }
 
     /** Lista execuções da etapa Prova para o nicho informado. */
     @Transactional(readOnly = true)
     public List<HypothesisPainExecutionSummaryResponse> listProofStageExecutions(
             Long marketNicheId,
-            boolean includeCompleted) {
-        return listStageExecutions(marketNicheId, PROOF_STAGE_CODE, includeCompleted);
+            boolean includeCompleted,
+            UUID hypothesisId) {
+        return listStageExecutions(marketNicheId, PROOF_STAGE_CODE, includeCompleted, hypothesisId);
     }
 
     /** Lista execuções da etapa Oferta para o nicho informado. */
     @Transactional(readOnly = true)
     public List<HypothesisPainExecutionSummaryResponse> listOfferStageExecutions(
             Long marketNicheId,
-            boolean includeCompleted) {
-        return listStageExecutions(marketNicheId, OFFER_STAGE_CODE, includeCompleted);
+            boolean includeCompleted,
+            UUID hypothesisId) {
+        return listStageExecutions(marketNicheId, OFFER_STAGE_CODE, includeCompleted, hypothesisId);
     }
 
-    /** Lista execuções de uma etapa específica para o nicho informado. */
-    private List<HypothesisPainExecutionSummaryResponse> listStageExecutions(Long marketNicheId, String stageCode, boolean includeCompleted) {
-        List<HypothesisPainStageExecution> executions = includeCompleted
-                ? executionRepository.findByMarketNicheIdAndStageCodeOrderByExecutionRequestedAtDesc(marketNicheId, stageCode)
-                : executionRepository.findTop20ByMarketNicheIdAndStageCodeAndStatusNotOrderByExecutionRequestedAtDesc(
-                        marketNicheId,
-                        stageCode,
-                        STATUS_COMPLETED);
+    /** Lista execuções de uma etapa específica para criação limpa ou auditoria da hipótese selecionada. */
+    private List<HypothesisPainExecutionSummaryResponse> listStageExecutions(
+            Long marketNicheId,
+            String stageCode,
+            boolean includeCompleted,
+            UUID hypothesisId) {
+        List<HypothesisPainStageExecution> executions;
+        if (hypothesisId != null) {
+            executions = executionRepository.findByMarketNicheIdAndStageCodeAndHypothesisIdOrderByExecutionRequestedAtDesc(
+                    marketNicheId,
+                    stageCode,
+                    hypothesisId);
+        } else if (includeCompleted) {
+            executions = executionRepository.findByMarketNicheIdAndStageCodeAndHypothesisIdIsNullOrderByExecutionRequestedAtDesc(
+                    marketNicheId,
+                    stageCode);
+        } else {
+            executions = executionRepository.findTop20ByMarketNicheIdAndStageCodeAndStatusNotAndHypothesisIdIsNullOrderByExecutionRequestedAtDesc(
+                    marketNicheId,
+                    stageCode,
+                    STATUS_COMPLETED);
+        }
         return executions.stream().map(this::toSummaryResponse).toList();
     }
 

--- a/backend/ads-service/src/main/java/com/marketinghub/hypothesis/service/finalizeHypothesis/HypothesisPipelineFinalizationService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/hypothesis/service/finalizeHypothesis/HypothesisPipelineFinalizationService.java
@@ -83,7 +83,9 @@ public class HypothesisPipelineFinalizationService {
                 hypothesis,
                 finalizedFramework(title, pain, result, mechanism, proof, offer),
                 null);
-        return hypothesisRepository.save(hypothesis);
+        Hypothesis savedHypothesis = hypothesisRepository.save(hypothesis);
+        relateCompletedExecutionsToHypothesis(marketNicheId, savedHypothesis);
+        return savedHypothesis;
     }
 
     /** Monta o título automático da hipótese fechada com sigla do nicho e numeração sequencial. */
@@ -162,6 +164,18 @@ public class HypothesisPipelineFinalizationService {
                 .map(HypothesisPainStageExecution::getCostUsd)
                 .filter(cost -> cost != null)
                 .reduce(BigDecimal.ZERO, BigDecimal::add);
+    }
+
+    /** Vincula as execuções concluídas usadas no fechamento à hipótese gerada para auditoria posterior. */
+    private void relateCompletedExecutionsToHypothesis(Long marketNicheId, Hypothesis hypothesis) {
+        STAGE_SEQUENCE.stream()
+                .map(stageCode -> executionRepository
+                        .findTopByMarketNicheIdAndStageCodeAndStatusOrderByExecutionRequestedAtDesc(
+                                marketNicheId,
+                                stageCode,
+                                STATUS_COMPLETED))
+                .flatMap(Optional::stream)
+                .forEach(execution -> execution.setHypothesisId(hypothesis.getId()));
     }
 
     /** Monta o snapshot canônico Dor → Resultado → Mecanismo → Prova → Oferta aprovado para experimento. */

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/hypothesis/HypothesisPainStageExecutionRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/hypothesis/HypothesisPainStageExecutionRepository.java
@@ -4,6 +4,7 @@ import com.marketinghub.hypothesis.pain.HypothesisPainStageExecution;
 import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 import org.springframework.data.jpa.repository.EntityGraph;
 import org.springframework.data.jpa.repository.JpaRepository;
 
@@ -35,8 +36,19 @@ public interface HypothesisPainStageExecutionRepository extends JpaRepository<Hy
     @EntityGraph(attributePaths = {"hypothesis"})
     List<HypothesisPainStageExecution> findByMarketNicheIdAndStageCodeOrderByExecutionRequestedAtDesc(Long marketNicheId, String stageCode);
 
+    /** Lista execuções ainda não vinculadas a uma hipótese fechada para a tela de criação limpa. */
+    List<HypothesisPainStageExecution> findByMarketNicheIdAndStageCodeAndHypothesisIdIsNullOrderByExecutionRequestedAtDesc(
+            Long marketNicheId,
+            String stageCode);
+
+    /** Lista execuções vinculadas a uma hipótese específica para auditoria da hipótese selecionada. */
+    List<HypothesisPainStageExecution> findByMarketNicheIdAndStageCodeAndHypothesisIdOrderByExecutionRequestedAtDesc(
+            Long marketNicheId,
+            String stageCode,
+            UUID hypothesisId);
+
     /** Lista as últimas vinte execuções de uma etapa dentro de um nicho excluindo um status operacional. */
-    List<HypothesisPainStageExecution> findTop20ByMarketNicheIdAndStageCodeAndStatusNotOrderByExecutionRequestedAtDesc(
+    List<HypothesisPainStageExecution> findTop20ByMarketNicheIdAndStageCodeAndStatusNotAndHypothesisIdIsNullOrderByExecutionRequestedAtDesc(
             Long marketNicheId,
             String stageCode,
             String status);

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -5384,3 +5384,4 @@
 - Causa-raiz: a publicação canônica já aceitava `INTEREST`, `JOB_TITLE` ou `BEHAVIOR`, mas a prontidão do experimento ainda verificava apenas `WORK_POSITION`, bloqueando experimentos com interesse aprovado e ID oficial da Meta.
 - Correção aplicada: a prontidão de campanha passou a considerar qualquer seleção salva cujo elemento esteja aprovado, tenha ID oficial da Meta e seja `INTEREST`, `JOB_TITLE` ou `BEHAVIOR`; a UI e o cânone foram alinhados para remover a exigência isolada de cargo.
 - Prevenção de recorrência: testes unitários cobrem interesse e comportamento como suficientes para campanha e bloqueiam seleção sem ID oficial da Meta.
+- 2026-06-25 06:25 (UTC): pipeline de criação de hipótese passou a vincular as execuções concluídas à hipótese fechada; a tela de criar nova hipótese lista apenas execuções ainda sem hipótese, e o clique no nome da hipótese no detalhe do nicho abre a auditoria das execuções daquela hipótese.

--- a/docs/swagger/hypothesis-pain-stage-swagger.yaml
+++ b/docs/swagger/hypothesis-pain-stage-swagger.yaml
@@ -68,6 +68,11 @@ paths:
         - in: query
           name: includeCompleted
           schema: { type: boolean, default: true }
+        - in: query
+          name: hypothesisId
+          required: false
+          schema: { type: string, format: uuid }
+          description: Quando informado, retorna apenas execuções vinculadas à hipótese; quando omitido, retorna apenas execuções ainda não fechadas em hipótese.
       responses:
         '200':
           description: Execuções retornadas.
@@ -176,6 +181,11 @@ paths:
         - in: query
           name: includeCompleted
           schema: { type: boolean, default: true }
+        - in: query
+          name: hypothesisId
+          required: false
+          schema: { type: string, format: uuid }
+          description: Quando informado, retorna apenas execuções vinculadas à hipótese; quando omitido, retorna apenas execuções ainda não fechadas em hipótese.
       responses:
         '200':
           description: Execuções retornadas.
@@ -284,6 +294,11 @@ paths:
         - in: query
           name: includeCompleted
           schema: { type: boolean, default: true }
+        - in: query
+          name: hypothesisId
+          required: false
+          schema: { type: string, format: uuid }
+          description: Quando informado, retorna apenas execuções vinculadas à hipótese; quando omitido, retorna apenas execuções ainda não fechadas em hipótese.
       responses:
         '200':
           description: Execuções retornadas.
@@ -392,6 +407,11 @@ paths:
         - in: query
           name: includeCompleted
           schema: { type: boolean, default: true }
+        - in: query
+          name: hypothesisId
+          required: false
+          schema: { type: string, format: uuid }
+          description: Quando informado, retorna apenas execuções vinculadas à hipótese; quando omitido, retorna apenas execuções ainda não fechadas em hipótese.
       responses:
         '200':
           description: Execuções retornadas.
@@ -500,6 +520,11 @@ paths:
         - in: query
           name: includeCompleted
           schema: { type: boolean, default: true }
+        - in: query
+          name: hypothesisId
+          required: false
+          schema: { type: string, format: uuid }
+          description: Quando informado, retorna apenas execuções vinculadas à hipótese; quando omitido, retorna apenas execuções ainda não fechadas em hipótese.
       responses:
         '200':
           description: Execuções retornadas.

--- a/frontend/src/pages/hypothesis/NewHypothesisPage.tsx
+++ b/frontend/src/pages/hypothesis/NewHypothesisPage.tsx
@@ -1,5 +1,5 @@
-import { FormEvent, useState } from "react";
-import { Link, useParams } from "react-router-dom";
+import { FormEvent } from "react";
+import { Link, useParams, useSearchParams } from "react-router-dom";
 import { useMutation, useQueries, useQueryClient } from "@tanstack/react-query";
 import axios from "axios";
 import { toast } from "react-toastify";
@@ -138,6 +138,7 @@ function StageCard({
   nicheId,
   executionsQuery,
   blockedMessage,
+  readOnly = false,
 }: {
   stage: HypothesisPipelineStageConfig;
   nicheId?: string;
@@ -146,6 +147,7 @@ function StageCard({
     isLoading: boolean;
   };
   blockedMessage?: string;
+  readOnly?: boolean;
 }) {
   const queryClient = useQueryClient();
   const queryKey = ["hypothesis-stage-executions", stage.slug, nicheId];
@@ -176,6 +178,7 @@ function StageCard({
   );
   const isBlockedByPreviousStage = Boolean(blockedMessage);
   const isStartDisabled =
+    readOnly ||
     !nicheId ||
     startMutation.isPending ||
     hasRunningExecution ||
@@ -204,6 +207,8 @@ function StageCard({
               />
               Iniciando...
             </span>
+          ) : readOnly ? (
+            "Execuções da hipótese"
           ) : hasRunningExecution ? (
             "Execução em andamento"
           ) : (
@@ -302,14 +307,22 @@ function stageIsCompleted(executions?: StageExecution[]) {
 
 export default function NewHypothesisPage() {
   const { nicheId } = useParams();
+  const [searchParams] = useSearchParams();
+  const hypothesisId = searchParams.get("hypothesisId")?.trim() || undefined;
   const queryClient = useQueryClient();
   const stageQueries = useQueries({
     queries: STAGES.map((stage) => ({
-      queryKey: ["hypothesis-stage-executions", stage.slug, nicheId],
+      queryKey: [
+        "hypothesis-stage-executions",
+        stage.slug,
+        nicheId,
+        hypothesisId,
+      ],
       enabled: Boolean(nicheId),
       queryFn: async () => {
         const { data } = await axios.get<StageExecution[]>(
           `/api/niches/${nicheId}/hypothesis-pipeline/${stage.slug}/stage-executions`,
+          { params: hypothesisId ? { hypothesisId } : undefined },
         );
         return data;
       },
@@ -341,7 +354,12 @@ export default function NewHypothesisPage() {
       toast.success("Fluxo completo da hipótese iniciado");
       STAGES.forEach((stage) => {
         queryClient.invalidateQueries({
-          queryKey: ["hypothesis-stage-executions", stage.slug, nicheId],
+          queryKey: [
+            "hypothesis-stage-executions",
+            stage.slug,
+            nicheId,
+            hypothesisId,
+          ],
         });
       });
       queryClient.invalidateQueries({
@@ -415,13 +433,20 @@ export default function NewHypothesisPage() {
 
   return (
     <div className="hypothesis-new-page">
-      <PageTitle icon={hypothesisIcon}>Nova hipótese</PageTitle>
+      <PageTitle icon={hypothesisIcon}>
+        {hypothesisId ? "Execuções da hipótese" : "Nova hipótese"}
+      </PageTitle>
 
       {nicheId && (
         <section className="card mb-4">
           <div className="card-body d-flex flex-column flex-md-row gap-2 justify-content-between">
             <p className="mb-0">
               <strong>Nicho recebido:</strong> #{nicheId}
+              {hypothesisId && (
+                <span className="ms-2 text-muted">
+                  Hipótese: {hypothesisId}
+                </span>
+              )}
             </p>
             <div className="d-flex flex-column flex-md-row gap-2 align-items-md-center">
               <p className="mb-0">
@@ -432,6 +457,7 @@ export default function NewHypothesisPage() {
                 type="button"
                 className="btn btn-primary btn-sm"
                 disabled={
+                  Boolean(hypothesisId) ||
                   !nicheId ||
                   fullFlowMutation.isPending ||
                   hasRunningExecution ||
@@ -494,6 +520,7 @@ export default function NewHypothesisPage() {
             nicheId={nicheId}
             executionsQuery={stageQueries[index]}
             blockedMessage={blockedMessage}
+            readOnly={Boolean(hypothesisId)}
           />
         );
       })}
@@ -511,7 +538,8 @@ export default function NewHypothesisPage() {
           >
             <div className="col-12 col-lg-8">
               <div className="alert alert-info mb-0">
-                O backend vai nomear automaticamente com a sigla do nicho e a próxima numeração da hipótese.
+                O backend vai nomear automaticamente com a sigla do nicho e a
+                próxima numeração da hipótese.
               </div>
             </div>
             <div className="col-12 col-lg-4">
@@ -519,6 +547,7 @@ export default function NewHypothesisPage() {
                 type="submit"
                 className="btn btn-success w-100"
                 disabled={
+                  Boolean(hypothesisId) ||
                   !allStagesCompleted ||
                   finalizeMutation.isPending
                 }
@@ -536,7 +565,7 @@ export default function NewHypothesisPage() {
                 )}
               </button>
             </div>
-            {!allStagesCompleted && (
+            {!hypothesisId && !allStagesCompleted && (
               <div className="col-12">
                 <small className="text-muted">
                   Conclua todas as cinco etapas para liberar o fechamento da

--- a/frontend/src/pages/niche/NicheDetailPage.tsx
+++ b/frontend/src/pages/niche/NicheDetailPage.tsx
@@ -1095,7 +1095,7 @@ export default function NicheDetailPage() {
                         <div className="niche-detail__hypothesis-main">
                           <Link
                             className="niche-detail__hypothesis-name"
-                            to={`hypotheses/${hypothesis.id}`}
+                            to={`hypotheses/new?hypothesisId=${hypothesis.id}`}
                           >
                             {hypothesis.title || "Hipótese sem nome"}
                           </Link>


### PR DESCRIPTION
### Motivation
- Garantir rastreabilidade entre a hipótese fechada e as execuções concluídas usadas para compor o framework Dor→Resultado→Mecanismo→Prova→Oferta. 
- Manter a tela de criação de hipótese limpa exibindo apenas execuções sem vínculo para evitar confusão na criação de novas hipóteses. 
- Permitir auditoria direta das execuções já associadas a uma hipótese quando o usuário abrir a hipótese existente.

### Description
- Backend: o endpoint de listagem das execuções das etapas passou a aceitar o parâmetro de query opcional `hypothesisId` e os métodos do service foram estendidos para receber `UUID hypothesisId` e aplicar o filtro apropriado; novos métodos de repository foram adicionados (`findByMarketNicheIdAndStageCodeAndHypothesisId...` e variantes). 
- Finalização: `HypothesisPipelineFinalizationService` agora persiste a relação entre a hipótese criada e as execuções concluídas chamando `relateCompletedExecutionsToHypothesis(...)` após salvar a hipótese. 
- Frontend: `NewHypothesisPage` passa a ler `?hypothesisId=...` (via `useSearchParams`) e, quando presente, muda o título para `Execuções da hipótese`, bloqueia ações de criação (`readOnly`) e busca apenas as execuções vinculadas; `NicheDetailPage` passou a abrir a página de auditoria com `hypothesisId` no link. 
- Documentação: adicionado `hypothesisId` no `docs/swagger/hypothesis-pain-stage-swagger.yaml` e registrado a mudança em `docs/registros/experimentos.md`.

### Testing
- Executado `./mvnw -f ads-service/pom.xml -DskipTests compile` e a compilação do módulo `ads-service` concluiu com sucesso. 
- Executados os testes unitários `HypothesisPipelineFinalizationServiceTest` e `HypothesisPainStageServiceTest` com `./mvnw -f ads-service/pom.xml -Dtest=HypothesisPipelineFinalizationServiceTest,HypothesisPainStageServiceTest test` e todos passaram com sucesso. 
- Frontend: `npm install` seguido de `npm run typecheck` (TS typecheck) foi executado e em seguida os testes com `npm test -- NewHypothesisPage.test.tsx --run` rodaram com sucesso. 
- Mudanças manuais validadas localmente via linter/formatter (`prettier`) e verificação rápida do Swagger atualizada; nenhum teste automatizado falhou.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cf49901d0832190bcdfcc87b7e2db)