### PR TITLE
Persist search terms/results and final dossier for MOIS market-warmup; expose canonical pending endpoint

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryDtos.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryDtos.java
@@ -815,8 +815,16 @@ public final class MoisSalesLibraryDtos {
             String offerSummary,
             String mechanismSummary,
             String promiseSummary,
-            String proofSummary
+            String proofSummary,
+            String salesPageText
     ) {
+        /**
+         * Mantém compatibilidade para consumidores que ainda não enviam texto completo.
+         */
+        public MarketWarmupClaimedJob(long jobId, long pageId, String workspaceId, String urlCanonical, String title,
+                                      String producerName, String offerSummary, String mechanismSummary, String promiseSummary, String proofSummary) {
+            this(jobId, pageId, workspaceId, urlCanonical, title, producerName, offerSummary, mechanismSummary, promiseSummary, proofSummary, null);
+        }
     }
 
     /**
@@ -908,7 +916,54 @@ public final class MoisSalesLibraryDtos {
             @NotEmpty List<@Valid MarketWarmupSourceCompleteItem> sources,
             @NotEmpty List<@Valid MarketWarmupSignalCompleteItem> signals,
             @NotNull @Valid MarketWarmupSummaryCompleteItem summary,
+            List<@Valid MarketWarmupSearchTermCompleteItem> searchTerms,
+            List<@Valid MarketWarmupSearchResultCompleteItem> searchResults,
+            @Valid MarketWarmupFinalDossierCompleteItem finalDossier,
             Instant finishedAt
+    ) {
+        /**
+         * Mantém compatibilidade com o contrato anterior enquanto os novos campos são opcionais.
+         */
+        public MarketWarmupCompleteRequest(List<MarketWarmupSearchAttemptCompleteItem> searchAttempts,
+                                           List<MarketWarmupSourceCompleteItem> sources,
+                                           List<MarketWarmupSignalCompleteItem> signals,
+                                           MarketWarmupSummaryCompleteItem summary,
+                                           Instant finishedAt) {
+            this(searchAttempts, sources, signals, summary, List.of(), List.of(), null, finishedAt);
+        }
+    }
+
+    /**
+     * Representa termo planejado pela OpenAI para investigar prestígio público.
+     */
+    public record MarketWarmupSearchTermCompleteItem(
+            @NotBlank String termText,
+            String reason,
+            String source
+    ) {
+    }
+
+    /**
+     * Representa resultado bruto pesquisado pelo worker para auditoria do dossiê.
+     */
+    public record MarketWarmupSearchResultCompleteItem(
+            @NotBlank String termText,
+            @NotBlank String resultUrl,
+            String resultTitle,
+            String resultSnippet,
+            String rawPayload,
+            Boolean relatedToProduct
+    ) {
+    }
+
+    /**
+     * Representa as conclusões finais do dossiê de prestígio e aquecimento.
+     */
+    public record MarketWarmupFinalDossierCompleteItem(
+            String prestigeSummary,
+            String externalWarmupResources,
+            String finalConclusion,
+            String rawModelResponse
     ) {
     }
 

--- a/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesPageMarketWarmupService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesPageMarketWarmupService.java
@@ -5,6 +5,9 @@ import com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1.Mois
 import com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1.MoisSalesPageMarketWarmupGateway.MarketWarmupClaimData;
 import com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1.MoisSalesPageMarketWarmupGateway.MarketWarmupJobData;
 import com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1.MoisSalesPageMarketWarmupGateway.MarketWarmupSearchAttemptData;
+import com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1.MoisSalesPageMarketWarmupGateway.MarketWarmupSearchResultData;
+import com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1.MoisSalesPageMarketWarmupGateway.MarketWarmupSearchTermData;
+import com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1.MoisSalesPageMarketWarmupGateway.MarketWarmupFinalDossierData;
 import com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1.MoisSalesPageMarketWarmupGateway.MarketWarmupSignalData;
 import com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1.MoisSalesPageMarketWarmupGateway.MarketWarmupSignalReadData;
 import com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1.MoisSalesPageMarketWarmupGateway.MarketWarmupSourceData;
@@ -140,7 +143,7 @@ public class MoisSalesPageMarketWarmupService {
                     request.workspaceId(), request.workerId(), page.pageId(), pending.job().jobId());
             return new MoisSalesLibraryDtos.MarketWarmupClaimResponse(true, new MoisSalesLibraryDtos.MarketWarmupClaimedJob(
                     pending.job().jobId(), page.pageId(), page.workspaceId(), page.urlCanonical(), page.title(), page.producerName(), page.offerSummary(),
-                    page.mechanismSummary(), page.promiseSummary(), page.proofSummary()));
+                    page.mechanismSummary(), page.promiseSummary(), page.proofSummary(), page.salesPageText()));
         } catch (RuntimeException ex) {
             log.error("Falha ao reservar job de aquecimento MOIS. modulo=MOIS, operacao=claimMarketWarmupJob, workspaceId={}, workerId={}, erroClasse={}, erro={}",
                     request.workspaceId(), request.workerId(), ex.getClass().getName(), ex.getMessage(), ex);
@@ -163,6 +166,9 @@ public class MoisSalesPageMarketWarmupService {
                     job.workspaceId(), job.pageId(), jobId, request.sources().size(), request.signals().size());
             gateway.deleteJobDetails(jobId);
             persistSearchAttempts(job, request.searchAttempts());
+            persistSearchTerms(job, request.searchTerms());
+            persistSearchResults(job, request.searchResults());
+            persistFinalDossier(job, request.finalDossier());
             List<Long> sourceIds = persistSources(job, request.sources());
             persistSignals(job, sourceIds, request.signals());
             MarketWarmupSummaryWriteData summary = mapSummaryWrite(scoreEngine.calculate(request));
@@ -230,6 +236,43 @@ public class MoisSalesPageMarketWarmupService {
         for (MoisSalesLibraryDtos.MarketWarmupSearchAttemptCompleteItem attempt : attempts) {
             gateway.insertSearchAttempt(job.jobId(), job.pageId(), job.workspaceId(), mapSearchAttemptWrite(attempt));
         }
+    }
+
+
+    /**
+     * Persiste os termos de pesquisa extraídos por OpenAI para auditoria do planejamento.
+     */
+    private void persistSearchTerms(MarketWarmupJobData job, List<MoisSalesLibraryDtos.MarketWarmupSearchTermCompleteItem> terms) {
+        if (terms == null || terms.isEmpty()) {
+            return;
+        }
+        for (MoisSalesLibraryDtos.MarketWarmupSearchTermCompleteItem term : terms) {
+            gateway.insertSearchTerm(job.jobId(), job.pageId(), job.workspaceId(), new MarketWarmupSearchTermData(term.termText(), term.reason(), term.source()));
+        }
+    }
+
+    /**
+     * Persiste os resultados brutos de pesquisa enviados pelo worker para rastrear evidências.
+     */
+    private void persistSearchResults(MarketWarmupJobData job, List<MoisSalesLibraryDtos.MarketWarmupSearchResultCompleteItem> results) {
+        if (results == null || results.isEmpty()) {
+            return;
+        }
+        for (MoisSalesLibraryDtos.MarketWarmupSearchResultCompleteItem result : results) {
+            gateway.insertSearchResult(job.jobId(), job.pageId(), job.workspaceId(), new MarketWarmupSearchResultData(
+                    result.termText(), result.resultUrl(), result.resultTitle(), result.resultSnippet(), result.rawPayload(), result.relatedToProduct()));
+        }
+    }
+
+    /**
+     * Persiste as conclusões finais do dossiê para exibição direta pela tela.
+     */
+    private void persistFinalDossier(MarketWarmupJobData job, MoisSalesLibraryDtos.MarketWarmupFinalDossierCompleteItem dossier) {
+        if (dossier == null) {
+            return;
+        }
+        gateway.insertFinalDossier(job.jobId(), job.pageId(), job.workspaceId(), new MarketWarmupFinalDossierData(
+                dossier.prestigeSummary(), dossier.externalWarmupResources(), dossier.finalConclusion(), dossier.rawModelResponse()));
     }
 
     /**

--- a/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/web/MoisSalesLibraryController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/web/MoisSalesLibraryController.java
@@ -255,6 +255,16 @@ public class MoisSalesLibraryController {
     }
 
     /**
+     * Expõe o ponto inicial canônico pending da etapa de dossiê para o worker MOIS.
+     */
+    @PostMapping("/market-warmup/stage-executions/pending")
+    public MoisSalesLibraryDtos.MarketWarmupClaimResponse pending(
+            @Valid @RequestBody MoisSalesLibraryDtos.MarketWarmupClaimRequest request
+    ) {
+        return marketWarmupService.claimJob(request);
+    }
+
+    /**
      * Reserva internamente o próximo job pendente de aquecimento para o worker MOIS.
      */
     @PostMapping("/market-warmup/jobs:claim")

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/mois/bibliotecapaginavenda/worker/v1/MoisSalesPageMarketWarmupGateway.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/mois/bibliotecapaginavenda/worker/v1/MoisSalesPageMarketWarmupGateway.java
@@ -56,6 +56,21 @@ public interface MoisSalesPageMarketWarmupGateway {
     void insertSearchAttempt(long jobId, long pageId, String workspaceId, MarketWarmupSearchAttemptData attempt);
 
     /**
+     * Insere termo planejado pela OpenAI para pesquisa pública do dossiê.
+     */
+    void insertSearchTerm(long jobId, long pageId, String workspaceId, MarketWarmupSearchTermData term);
+
+    /**
+     * Insere resultado pesquisado pelo worker para auditoria do dossiê.
+     */
+    void insertSearchResult(long jobId, long pageId, String workspaceId, MarketWarmupSearchResultData result);
+
+    /**
+     * Insere o dossiê final textual exibido na tela do item da biblioteca.
+     */
+    void insertFinalDossier(long jobId, long pageId, String workspaceId, MarketWarmupFinalDossierData dossier);
+
+    /**
      * Insere uma fonte pública rastreável coletada pelo worker.
      */
     long insertSource(long jobId, long pageId, String workspaceId, MarketWarmupSourceData source);
@@ -119,8 +134,35 @@ public interface MoisSalesPageMarketWarmupGateway {
             String offerSummary,
             String mechanismSummary,
             String promiseSummary,
-            String proofSummary
+            String proofSummary,
+            String salesPageText
     ) {
+        /**
+         * Mantém compatibilidade de testes e chamadas existentes sem texto completo da página.
+         */
+        public SalesPageWarmupData(long pageId, String workspaceId, String urlCanonical, String title, String producerName,
+                                   String currentStatus, String analysisStatus, String offerSummary, String mechanismSummary,
+                                   String promiseSummary, String proofSummary) {
+            this(pageId, workspaceId, urlCanonical, title, producerName, currentStatus, analysisStatus, offerSummary, mechanismSummary, promiseSummary, proofSummary, null);
+        }
+    }
+
+    /**
+     * Representa termo de pesquisa planejado e persistido para auditoria.
+     */
+    record MarketWarmupSearchTermData(String termText, String reason, String source) {
+    }
+
+    /**
+     * Representa resultado bruto de pesquisa vinculado ao termo originador.
+     */
+    record MarketWarmupSearchResultData(String termText, String resultUrl, String resultTitle, String resultSnippet, String rawPayload, Boolean relatedToProduct) {
+    }
+
+    /**
+     * Representa o dossiê final gerado pelo worker para exposição na tela.
+     */
+    record MarketWarmupFinalDossierData(String prestigeSummary, String externalWarmupResources, String finalConclusion, String rawModelResponse) {
     }
 
     /**

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/mois/bibliotecapaginavenda/worker/v1/jdbc/MoisSalesPageMarketWarmupRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/mois/bibliotecapaginavenda/worker/v1/jdbc/MoisSalesPageMarketWarmupRepository.java
@@ -4,6 +4,9 @@ import com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1.Mois
 import com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1.MoisSalesPageMarketWarmupGateway.MarketWarmupClaimData;
 import com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1.MoisSalesPageMarketWarmupGateway.MarketWarmupJobData;
 import com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1.MoisSalesPageMarketWarmupGateway.MarketWarmupSearchAttemptData;
+import com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1.MoisSalesPageMarketWarmupGateway.MarketWarmupSearchResultData;
+import com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1.MoisSalesPageMarketWarmupGateway.MarketWarmupSearchTermData;
+import com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1.MoisSalesPageMarketWarmupGateway.MarketWarmupFinalDossierData;
 import com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1.MoisSalesPageMarketWarmupGateway.MarketWarmupSignalData;
 import com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1.MoisSalesPageMarketWarmupGateway.MarketWarmupSignalReadData;
 import com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1.MoisSalesPageMarketWarmupGateway.MarketWarmupSourceData;
@@ -44,7 +47,10 @@ public class MoisSalesPageMarketWarmupRepository implements MoisSalesPageMarketW
                        COALESCE(NULLIF(cr_link.hotmart_producer, ''), NULLIF(cr_link.producer_name, ''),
                                 NULLIF(cr_url.hotmart_producer, ''), NULLIF(cr_url.producer_name, '')) AS producer_name,
                        sp.current_status, sp.analysis_status,
-                       sp.offer_summary, sp.mechanism_summary, sp.promise_summary, sp.proof_summary
+                       sp.offer_summary, sp.mechanism_summary, sp.promise_summary, sp.proof_summary,
+                       (SELECT je.raw_html FROM mois_sales_page_job_execution je
+                        WHERE je.sales_page_id = sp.id AND je.raw_html IS NOT NULL AND je.raw_html_bytes > 0
+                        ORDER BY je.created_at DESC, je.id DESC LIMIT 1) AS sales_page_text
                 FROM mois_sales_page sp
                 LEFT JOIN mois_collected_reference cr_link ON cr_link.id = sp.collected_reference_id
                 LEFT JOIN mois_collected_reference cr_url ON cr_url.id = (
@@ -128,7 +134,10 @@ public class MoisSalesPageMarketWarmupRepository implements MoisSalesPageMarketW
                        COALESCE(NULLIF(cr_link.hotmart_producer, ''), NULLIF(cr_link.producer_name, ''),
                                 NULLIF(cr_url.hotmart_producer, ''), NULLIF(cr_url.producer_name, '')) AS producer_name,
                        sp.current_status, sp.analysis_status,
-                       sp.offer_summary, sp.mechanism_summary, sp.promise_summary, sp.proof_summary
+                       sp.offer_summary, sp.mechanism_summary, sp.promise_summary, sp.proof_summary,
+                       (SELECT je.raw_html FROM mois_sales_page_job_execution je
+                        WHERE je.sales_page_id = sp.id AND je.raw_html IS NOT NULL AND je.raw_html_bytes > 0
+                        ORDER BY je.created_at DESC, je.id DESC LIMIT 1) AS sales_page_text
                 FROM mois_sales_page_market_warmup_job j
                 JOIN mois_sales_page sp ON sp.id = j.sales_page_id
                 LEFT JOIN mois_collected_reference cr_link ON cr_link.id = sp.collected_reference_id
@@ -183,6 +192,9 @@ public class MoisSalesPageMarketWarmupRepository implements MoisSalesPageMarketW
      */
     @Override
     public void deleteJobDetails(long jobId) {
+        jdbcTemplate.update("DELETE FROM mois_sales_page_market_warmup_final_dossier WHERE job_id = ?", jobId);
+        jdbcTemplate.update("DELETE FROM mois_sales_page_market_warmup_search_result WHERE job_id = ?", jobId);
+        jdbcTemplate.update("DELETE FROM mois_sales_page_market_warmup_search_term WHERE job_id = ?", jobId);
         jdbcTemplate.update("DELETE FROM mois_sales_page_market_warmup_signal WHERE job_id = ?", jobId);
         jdbcTemplate.update("DELETE FROM mois_sales_page_market_warmup_source WHERE job_id = ?", jobId);
         jdbcTemplate.update("DELETE FROM mois_sales_page_market_warmup_summary WHERE job_id = ?", jobId);
@@ -201,6 +213,45 @@ public class MoisSalesPageMarketWarmupRepository implements MoisSalesPageMarketW
                 VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, UTC_TIMESTAMP())
                 """, jobId, pageId, workspaceId, attempt.queryText(), attempt.resultCount(), attempt.qualifiedCount(),
                 attempt.rejectedCount(), attempt.status(), attempt.rejectionReason(), attempt.sampleResultTitle(), attempt.sampleResultUrl());
+    }
+
+
+    /**
+     * Insere termo de pesquisa planejado pela OpenAI para o dossiê.
+     */
+    @Override
+    public void insertSearchTerm(long jobId, long pageId, String workspaceId, MarketWarmupSearchTermData term) {
+        jdbcTemplate.update("""
+                INSERT INTO mois_sales_page_market_warmup_search_term
+                (job_id, sales_page_id, workspace_id, term_text, reason, source, created_at)
+                VALUES (?, ?, ?, ?, ?, ?, UTC_TIMESTAMP())
+                """, jobId, pageId, workspaceId, term.termText(), term.reason(), term.source());
+    }
+
+    /**
+     * Insere resultado bruto de pesquisa usado para gerar o dossiê.
+     */
+    @Override
+    public void insertSearchResult(long jobId, long pageId, String workspaceId, MarketWarmupSearchResultData result) {
+        jdbcTemplate.update("""
+                INSERT INTO mois_sales_page_market_warmup_search_result
+                (job_id, sales_page_id, workspace_id, term_text, result_url, result_title, result_snippet, raw_payload, related_to_product, created_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, UTC_TIMESTAMP())
+                """, jobId, pageId, workspaceId, result.termText(), result.resultUrl(), result.resultTitle(),
+                result.resultSnippet(), result.rawPayload(), result.relatedToProduct());
+    }
+
+    /**
+     * Insere as conclusões finais exibidas como dossiê do produto.
+     */
+    @Override
+    public void insertFinalDossier(long jobId, long pageId, String workspaceId, MarketWarmupFinalDossierData dossier) {
+        jdbcTemplate.update("""
+                INSERT INTO mois_sales_page_market_warmup_final_dossier
+                (job_id, sales_page_id, workspace_id, prestige_summary, external_warmup_resources, final_conclusion, raw_model_response, created_at, updated_at)
+                VALUES (?, ?, ?, ?, ?, ?, ?, UTC_TIMESTAMP(), UTC_TIMESTAMP())
+                """, jobId, pageId, workspaceId, dossier.prestigeSummary(), dossier.externalWarmupResources(),
+                dossier.finalConclusion(), dossier.rawModelResponse());
     }
 
     /**
@@ -383,7 +434,8 @@ public class MoisSalesPageMarketWarmupRepository implements MoisSalesPageMarketW
     private SalesPageWarmupData mapSalesPage(ResultSet rs, int rowNum) throws SQLException {
         return new SalesPageWarmupData(rs.getLong("id"), rs.getString("workspace_id"), rs.getString("url_canonical"), rs.getString("title"),
                 rs.getString("producer_name"), rs.getString("current_status"), rs.getString("analysis_status"),
-                rs.getString("offer_summary"), rs.getString("mechanism_summary"), rs.getString("promise_summary"), rs.getString("proof_summary"));
+                rs.getString("offer_summary"), rs.getString("mechanism_summary"), rs.getString("promise_summary"), rs.getString("proof_summary"),
+                rs.getString("sales_page_text"));
     }
 
     /**
@@ -404,7 +456,8 @@ public class MoisSalesPageMarketWarmupRepository implements MoisSalesPageMarketW
                 rs.getString("error_category"), rs.getString("error_message"));
         SalesPageWarmupData page = new SalesPageWarmupData(rs.getLong("sales_page_id"), rs.getString("workspace_id"), rs.getString("url_canonical"),
                 rs.getString("title"), rs.getString("producer_name"), rs.getString("current_status"), rs.getString("analysis_status"),
-                rs.getString("offer_summary"), rs.getString("mechanism_summary"), rs.getString("promise_summary"), rs.getString("proof_summary"));
+                rs.getString("offer_summary"), rs.getString("mechanism_summary"), rs.getString("promise_summary"), rs.getString("proof_summary"),
+                rs.getString("sales_page_text"));
         return new MarketWarmupClaimData(job, page);
     }
 

--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-25-mois-market-warmup-dossier-evidence.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-25-mois-market-warmup-dossier-evidence.yaml
@@ -1,0 +1,125 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-06-25-mois-market-warmup-search-term-01
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - onError: HALT
+        - dbms:
+            type: mysql
+        - tableExists:
+            tableName: mois_sales_page_market_warmup_job
+        - tableExists:
+            tableName: mois_sales_page
+        - not:
+            tableExists:
+              tableName: mois_sales_page_market_warmup_search_term
+      changes:
+        - sql:
+            splitStatements: true
+            stripComments: true
+            sql: |
+              CREATE TABLE mois_sales_page_market_warmup_search_term (
+                id BIGINT NOT NULL AUTO_INCREMENT,
+                job_id BIGINT NOT NULL,
+                sales_page_id BIGINT NOT NULL,
+                workspace_id VARCHAR(120) NOT NULL,
+                term_text VARCHAR(512) NOT NULL,
+                reason VARCHAR(1000) NULL,
+                source VARCHAR(80) NULL,
+                created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                PRIMARY KEY (id),
+                KEY idx_mois_market_warmup_term_job (job_id, id),
+                KEY idx_mois_market_warmup_term_page (sales_page_id, created_at),
+                KEY idx_mois_market_warmup_term_workspace (workspace_id, created_at),
+                CONSTRAINT fk_mois_market_warmup_term_job
+                  FOREIGN KEY (job_id) REFERENCES mois_sales_page_market_warmup_job(id)
+                  ON DELETE CASCADE,
+                CONSTRAINT fk_mois_market_warmup_term_page
+                  FOREIGN KEY (sales_page_id) REFERENCES mois_sales_page(id)
+                  ON DELETE CASCADE
+              ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+  - changeSet:
+      id: 2026-06-25-mois-market-warmup-search-result-01
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - onError: HALT
+        - dbms:
+            type: mysql
+        - tableExists:
+            tableName: mois_sales_page_market_warmup_job
+        - tableExists:
+            tableName: mois_sales_page
+        - not:
+            tableExists:
+              tableName: mois_sales_page_market_warmup_search_result
+      changes:
+        - sql:
+            splitStatements: true
+            stripComments: true
+            sql: |
+              CREATE TABLE mois_sales_page_market_warmup_search_result (
+                id BIGINT NOT NULL AUTO_INCREMENT,
+                job_id BIGINT NOT NULL,
+                sales_page_id BIGINT NOT NULL,
+                workspace_id VARCHAR(120) NOT NULL,
+                term_text VARCHAR(512) NOT NULL,
+                result_url VARCHAR(1024) NOT NULL,
+                result_title VARCHAR(512) NULL,
+                result_snippet VARCHAR(2000) NULL,
+                raw_payload LONGTEXT NULL,
+                related_to_product TINYINT(1) NULL,
+                created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                PRIMARY KEY (id),
+                KEY idx_mois_market_warmup_result_job (job_id, id),
+                KEY idx_mois_market_warmup_result_page (sales_page_id, created_at),
+                KEY idx_mois_market_warmup_result_url (result_url(191)),
+                CONSTRAINT fk_mois_market_warmup_result_job
+                  FOREIGN KEY (job_id) REFERENCES mois_sales_page_market_warmup_job(id)
+                  ON DELETE CASCADE,
+                CONSTRAINT fk_mois_market_warmup_result_page
+                  FOREIGN KEY (sales_page_id) REFERENCES mois_sales_page(id)
+                  ON DELETE CASCADE
+              ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;
+
+  - changeSet:
+      id: 2026-06-25-mois-market-warmup-final-dossier-01
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - onError: HALT
+        - dbms:
+            type: mysql
+        - tableExists:
+            tableName: mois_sales_page_market_warmup_job
+        - tableExists:
+            tableName: mois_sales_page
+        - not:
+            tableExists:
+              tableName: mois_sales_page_market_warmup_final_dossier
+      changes:
+        - sql:
+            splitStatements: true
+            stripComments: true
+            sql: |
+              CREATE TABLE mois_sales_page_market_warmup_final_dossier (
+                job_id BIGINT NOT NULL,
+                sales_page_id BIGINT NOT NULL,
+                workspace_id VARCHAR(120) NOT NULL,
+                prestige_summary LONGTEXT NULL,
+                external_warmup_resources LONGTEXT NULL,
+                final_conclusion LONGTEXT NULL,
+                raw_model_response LONGTEXT NULL,
+                created_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+                updated_at DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+                PRIMARY KEY (job_id),
+                KEY idx_mois_market_warmup_dossier_page (sales_page_id, updated_at),
+                CONSTRAINT fk_mois_market_warmup_dossier_job
+                  FOREIGN KEY (job_id) REFERENCES mois_sales_page_market_warmup_job(id)
+                  ON DELETE CASCADE,
+                CONSTRAINT fk_mois_market_warmup_dossier_page
+                  FOREIGN KEY (sales_page_id) REFERENCES mois_sales_page(id)
+                  ON DELETE CASCADE
+              ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -1,5 +1,8 @@
 databaseChangeLog:
   - include:
+      file: changesets/2026-06-25-mois-market-warmup-dossier-evidence.yaml
+      relativeToChangelogFile: true
+  - include:
       file: changesets/2026-06-24-meta-audience-sync.yaml
       relativeToChangelogFile: true
   - include:

--- a/backend/ads-service/src/test/java/com/marketinghub/architecture/ArquiteturaTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/architecture/ArquiteturaTest.java
@@ -1113,6 +1113,25 @@ class ArquiteturaTest {
     }
 
     /**
+     * Garante que o protocolo padrão backend da etapa de dossiê exponha pending canônico.
+     */
+    @ArchTest
+    static void moisSalesLibraryDossierMustExposeCanonicalPendingEndpoint(JavaClasses importedClasses) {
+        List<String> violations = new ArrayList<>();
+        directPackageClasses(importedClasses, MOIS_SALES_LIBRARY_WEB_PACKAGE).stream()
+                .filter(javaClass -> javaClass.getSimpleName().equals("MoisSalesLibraryController"))
+                .findFirst()
+                .ifPresentOrElse(controller -> {
+                    boolean hasPending = controller.getMethods().stream().anyMatch(method -> method.getName().equals("pending"));
+                    if (!hasPending) {
+                        violations.add("[ARQUITETURA] [BACKEND][MOIS][BibliotecaPaginaVenda] classe=" + controller.getName()
+                                + " deve expor método pending como ponto inicial canônico em /api/mois/sales-library/market-warmup/stage-executions/pending");
+                    }
+                }, () -> violations.add("[ARQUITETURA] [BACKEND][MOIS][BibliotecaPaginaVenda] MoisSalesLibraryController não encontrado para validar pending canônico"));
+        failWithArchitectureViolations(violations);
+    }
+
+    /**
      * Garante que a Biblioteca de Páginas de Vendas do MOIS possua a fachada de service canônica.
      */
     @ArchTest

--- a/backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesPageMarketWarmupServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesPageMarketWarmupServiceTest.java
@@ -133,7 +133,7 @@ class MoisSalesPageMarketWarmupServiceTest {
 
         service.completeJob(99L, new MoisSalesLibraryDtos.MarketWarmupCompleteRequest(
                 List.of(),
-                List.of(source), List.of(signal), summary, Instant.parse("2026-06-10T10:00:00Z")));
+                List.of(source), List.of(signal), summary, List.of(), List.of(), null, Instant.parse("2026-06-10T10:00:00Z")));
 
         verify(gateway).deleteJobDetails(99L);
         verify(gateway).insertSignal(99L, 10L, "workspace-001", 501L, signalData(signal));
@@ -169,7 +169,7 @@ class MoisSalesPageMarketWarmupServiceTest {
 
         assertThatThrownBy(() -> service.completeJob(99L, new MoisSalesLibraryDtos.MarketWarmupCompleteRequest(
                 List.of(),
-                List.of(source), List.of(signal), sampleSummary(), Instant.parse("2026-06-10T10:00:00Z"))))
+                List.of(source), List.of(signal), sampleSummary(), List.of(), List.of(), null, Instant.parse("2026-06-10T10:00:00Z"))))
                 .isInstanceOf(IllegalArgumentException.class)
                 .hasMessageContaining("Índice de fonte inválido");
 

--- a/docs/canonical/mois-worker-canon.v1.md
+++ b/docs/canonical/mois-worker-canon.v1.md
@@ -599,18 +599,29 @@ Contratos operacionais do backend:
 - `POST /api/mois/sales-library/collected-reference-html/{captureId}:complete` persiste HTML bruto, URL final, status HTTP, content type, hash e tamanho em `mois_sales_page_job_execution` e consolida `mois_sales_page`.
 - `POST /api/mois/sales-library/collected-reference-html/{captureId}:fail` registra falha de captura em `mois_sales_page_job_execution` e atualiza o último erro consolidado da página.
 
-### 13.9 Dossiê de produto da Biblioteca de Páginas de Vendas — reconstrução passo a passo
+### 13.9 Dossiê de produto da Biblioteca de Páginas de Vendas — processo de prestígio e aquecimento
 
-A Etapa 3 da Biblioteca de Páginas de Vendas fica temporariamente reduzida a um dossiê factual e incremental. A tela não deve apresentar score, narrativa, hipótese, fontes públicas, sinais, perguntas de pesquisa ou conclusões comerciais enquanto esses blocos não forem reconstruídos e validados passo a passo.
+A geração do dossiê da Biblioteca de Páginas de Vendas passa a seguir um fluxo simples em cinco etapas, documentado também em `docs/novos-modulos/mois-biblioteca-pagina-venda/processo-geracao-dossie.md`.
 
-Regra de reconstrução:
+Regra operacional:
 
-1. O primeiro bloco obrigatório do dossiê é a identificação básica observada na página de venda: **preço exibido** e **produtor exibido**.
-2. Para produtos Hotmart, esses dados devem ser lidos preferencialmente de `mois_collected_reference.hotmart_price` e `mois_collected_reference.hotmart_producer`.
-3. Se o banco não possuir preço ou produtor, a UI deve mostrar lacuna operacional em vez de inferir, completar por texto genérico ou usar conclusão do modelo.
-4. O dossiê só pode avançar para novos blocos depois que o bloco factual anterior estiver persistido e auditável.
-5. A pesquisa pública do dossiê deve construir queries qualificadas antes da coleta, priorizando produtor, domínio da página, título/subtítulo do produto, canais sociais, reviews, afiliados, prova social e sinais de distribuição; quando houver OpenAI configurada no worker, ela pode ser usada como camada de planejamento de queries, mantendo fallback heurístico auditável.
-6. Para o produto `mois_sales_page.id = 1057`, a verificação manual da página Hotmart em 2026-06-11 identificou:
-   - preço exibido: `R$ 5.997,00`;
-   - produtor exibido: `Abrantes Lima Empreendimentos LTDA`.
-7. Esses dois fatos são apenas o ponto inicial do dossiê; nenhuma conclusão de venda, autoridade, canal, mecanismo ou prova deve ser derivada deles sem etapa posterior específica.
+1. O worker acessa no backend o texto completo da página de venda e envia esse conteúdo para a OpenAI extrair termos de pesquisa que ajudem a entender o prestígio público da página, do produto, do produtor, da promessa e da marca.
+2. Ao receber a resposta da OpenAI, o worker envia os termos de pesquisa para o backend, que deve armazená-los no banco vinculados ao item da Biblioteca de Páginas de Vendas.
+3. O worker obtém do backend os termos persistidos, executa as pesquisas sugeridas e envia os resultados encontrados novamente para o backend, mantendo vínculo com o item da biblioteca e com os termos pesquisados.
+4. O worker obtém do backend os resultados de pesquisa e envia esse material para a OpenAI analisar o que tem relação real com a página do produto e quais recursos externos estão aquecendo o público, como vídeos, redes sociais, anúncios, reviews, afiliados, comunidades, matérias, páginas auxiliares ou canais do produtor.
+5. O worker envia as conclusões finais para o backend; o backend grava o dossiê final no banco e disponibiliza esse dossiê na tela do item da biblioteca.
+
+Separação obrigatória de responsabilidades:
+
+- O backend controla estado, persistência, contratos e exposição do dossiê para a tela.
+- O worker executa OpenAI, pesquisas externas e callbacks para o backend.
+- O worker não acessa o banco diretamente.
+- Cada etapa deve persistir evidência suficiente para auditoria e relatório ao usuário.
+- O frontend deve exibir o dossiê retornado pelo backend, sem recomputar conclusões.
+
+Persistência mínima obrigatória:
+
+- termos planejados para pesquisa pública vinculados ao job e à página;
+- resultados pesquisados vinculados ao termo originador;
+- conclusão final do dossiê com resumo de prestígio, recursos externos de aquecimento e recomendação final;
+- endpoint pending canônico do fluxo no backend: `/api/mois/sales-library/market-warmup/stage-executions/pending`.

--- a/docs/novos-modulos/mois-biblioteca-pagina-venda/processo-geracao-dossie.md
+++ b/docs/novos-modulos/mois-biblioteca-pagina-venda/processo-geracao-dossie.md
@@ -1,0 +1,61 @@
+# Processo simples — geração do dossiê da Biblioteca de Páginas de Vendas
+
+Data: 2026-06-25
+
+## Objetivo
+
+Gerar um dossiê simples para entender o prestígio e o aquecimento público de um produto a partir da página de venda já capturada na biblioteca.
+
+O dossiê deve responder:
+
+- quais termos devem ser pesquisados para entender a presença pública do produto;
+- quais resultados externos parecem relevantes;
+- quais recursos, além da própria página de venda, estão aquecendo o público;
+- qual conclusão final deve ficar disponível na tela do item da biblioteca.
+
+## Etapas do processo
+
+### Etapa 1 — Extrair termos de pesquisa
+
+O worker acessa no backend o texto completo da página de venda.
+
+Depois, envia esse texto para a OpenAI com a orientação de extrair termos de pesquisa capazes de investigar o prestígio daquela página, produto, produtor, promessa, marca e sinais públicos relacionados.
+
+### Etapa 2 — Armazenar termos no backend
+
+Ao receber a resposta da OpenAI, o worker envia os termos de pesquisa para o backend.
+
+O backend armazena esses termos no banco de dados vinculados ao item da Biblioteca de Páginas de Vendas.
+
+### Etapa 3 — Executar pesquisas sugeridas
+
+O worker obtém do backend os termos de pesquisa armazenados.
+
+Com esses termos, executa as pesquisas sugeridas e envia os resultados encontrados novamente para o backend.
+
+O backend persiste os resultados vinculados ao item da biblioteca e aos termos que originaram cada pesquisa.
+
+### Etapa 4 — Analisar relação com o produto
+
+O worker obtém do backend os resultados de pesquisa persistidos.
+
+Depois, envia esses resultados para a OpenAI analisar:
+
+- o que tem relação real com a página e o produto;
+- quais evidências reforçam prestígio, prova social, autoridade ou distribuição;
+- quais outros recursos além da página de venda aquecem o público desse produto, como vídeos, redes sociais, anúncios, reviews, afiliados, comunidades, matérias, páginas auxiliares ou canais do produtor.
+
+### Etapa 5 — Disponibilizar dossiê final
+
+O worker envia as conclusões finais para o backend.
+
+O backend grava o dossiê final no banco de dados, vinculado ao item da Biblioteca de Páginas de Vendas.
+
+Esse dossiê passa a ficar disponível na tela do item da biblioteca para apoiar decisões comerciais e reutilização de padrões vencedores.
+
+## Regras simples
+
+- O worker executa OpenAI e pesquisas externas; o backend controla estado, persistência e exposição para a tela.
+- O worker não acessa o banco diretamente.
+- Cada etapa deve deixar evidência persistida suficiente para auditoria e exibição ao usuário.
+- A tela deve mostrar o dossiê final vindo do backend, sem recomputar conclusões no frontend.

--- a/docs/registro-protocolo/padrao-backend.md
+++ b/docs/registro-protocolo/padrao-backend.md
@@ -12,3 +12,9 @@
 - Pacote backend protegido: `com.marketinghub.opsmonitor`.
 - Executor operacional externo: `ops-monitor-worker`.
 - Endpoint pending canônico: `/api/internal/ops-monitor/v1/module-checks/stage-executions/pending`.
+
+## 2026-06-25 — MOIS Biblioteca de Páginas de Vendas / dossiê
+- Pacote protegido: `com.marketinghub.mois.bibliotecapaginavenda.worker.v1`.
+- Etapa: dossiê de prestígio e aquecimento da Biblioteca de Páginas de Vendas.
+- Endpoint pending canônico exposto no controller único: `/api/mois/sales-library/market-warmup/stage-executions/pending`.
+- Executor externo responsável pela execução operacional: `mois-sales-library-worker`.

--- a/docs/registro-protocolo/padrao-modulo.md
+++ b/docs/registro-protocolo/padrao-modulo.md
@@ -14,3 +14,9 @@
 - Etapas iniciais: `healthcheck`, `availability` e `logscan`.
 - Ponto inicial canônico previsto para consumo no backend: `GET /api/internal/ops-monitor/v1/module-checks/stage-executions/pending`.
 - O worker não acessa banco de dados diretamente; a persistência permanece no backend principal.
+
+## 2026-06-25 — MOIS Sales Library Worker / dossiê
+- Módulo executor: `mois-sales-library-worker`.
+- Pacote executor: `com.marketinghub.mois.bibliotecapaginavenda.worker.v1`.
+- Fluxo protegido: dossiê de prestígio e aquecimento da Biblioteca de Páginas de Vendas.
+- O worker mantém a execução operacional de OpenAI e pesquisas externas; o backend mantém estado, persistência, pending e callbacks.

--- a/docs/registros/mois1.md
+++ b/docs/registros/mois1.md
@@ -1816,3 +1816,14 @@ Arquivos principais:
 ## 2026-06-25 — Custo total na Biblioteca de Páginas de Vendas
 - adicionada exposição do custo total em USD das análises comerciais consolidadas no resumo da Biblioteca de Páginas de Vendas MOIS.
 - ajustada a tela `/mois/sales-pages-library` para exibir o card **Custo total da biblioteca**, ajudando o operador a acompanhar investimento acumulado de IA na biblioteca.
+
+## 2026-06-25 — Novo processo simples do dossiê da Biblioteca de Páginas de Vendas
+- definido o novo fluxo em 5 etapas para gerar dossiê: extrair termos via OpenAI, persistir termos, pesquisar resultados, analisar relação com o produto e gravar conclusões finais no backend.
+- registrado que o objetivo do dossiê é entender prestígio e aquecimento público do produto, identificando recursos externos que ajudam a aquecer o público além da página de venda.
+- atualizado o cânone MOIS e criado documento simples do processo para orientar implementação futura do worker, backend e tela.
+
+## 2026-06-25 — Implementação do dossiê com protocolos padrão
+- implementado no backend o suporte persistente ao novo dossiê da Biblioteca de Páginas de Vendas: termos de pesquisa, resultados pesquisados e conclusão final vinculados ao job e ao item da biblioteca.
+- exposto endpoint pending canônico para o worker iniciar a etapa de dossiê pelo backend, mantendo o backend como controlador de estado e persistência.
+- ajustado o `mois-sales-library-worker` para enviar termos, resultados e dossiê final estruturados ao backend, sem acessar banco diretamente.
+- aplicados e registrados o protocolo padrão backend e o protocolo padrão módulo para este fluxo.

--- a/docs/swagger/mois-sales-library-swagger.yaml
+++ b/docs/swagger/mois-sales-library-swagger.yaml
@@ -504,6 +504,28 @@ paths:
                 $ref: '#/components/schemas/MarketWarmupSignalListResponse'
         '404':
           $ref: '#/components/responses/MarketWarmupNotFound'
+  /market-warmup/stage-executions/pending:
+    post:
+      summary: Reserva pelo endpoint pending canônico a etapa de dossiê
+      description: Ponto inicial canônico do worker para o protocolo padrão backend/módulo. Entrega o texto completo disponível da página e os dados comerciais necessários.
+      tags: [MOIS Sales Library]
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/MarketWarmupClaimRequest'
+      responses:
+        '200':
+          description: Resultado da reserva interna
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/MarketWarmupClaimResponse'
+        '400':
+          $ref: '#/components/responses/MarketWarmupBadRequest'
+        '403':
+          $ref: '#/components/responses/MarketWarmupForbidden'
   /market-warmup/jobs:claim:
     post:
       summary: Reserva internamente uma pesquisa pendente de aquecimento
@@ -995,6 +1017,10 @@ components:
         proofSummary:
           type: string
           nullable: true
+        salesPageText:
+          type: string
+          nullable: true
+          description: Texto/HTML completo da página de venda usado pelo worker para planejar termos de pesquisa.
     MarketWarmupClaimResponse:
       type: object
       properties:
@@ -1145,9 +1171,66 @@ components:
             $ref: '#/components/schemas/MarketWarmupSignalCompleteItem'
         summary:
           $ref: '#/components/schemas/MarketWarmupSummaryCompleteItem'
+        searchTerms:
+          type: array
+          items:
+            $ref: '#/components/schemas/MarketWarmupSearchTermCompleteItem'
+        searchResults:
+          type: array
+          items:
+            $ref: '#/components/schemas/MarketWarmupSearchResultCompleteItem'
+        finalDossier:
+          $ref: '#/components/schemas/MarketWarmupFinalDossierCompleteItem'
         finishedAt:
           type: string
           format: date-time
+          nullable: true
+    MarketWarmupSearchTermCompleteItem:
+      type: object
+      required: [termText]
+      properties:
+        termText:
+          type: string
+        reason:
+          type: string
+          nullable: true
+        source:
+          type: string
+          nullable: true
+    MarketWarmupSearchResultCompleteItem:
+      type: object
+      required: [termText, resultUrl]
+      properties:
+        termText:
+          type: string
+        resultUrl:
+          type: string
+        resultTitle:
+          type: string
+          nullable: true
+        resultSnippet:
+          type: string
+          nullable: true
+        rawPayload:
+          type: string
+          nullable: true
+        relatedToProduct:
+          type: boolean
+          nullable: true
+    MarketWarmupFinalDossierCompleteItem:
+      type: object
+      properties:
+        prestigeSummary:
+          type: string
+          nullable: true
+        externalWarmupResources:
+          type: string
+          nullable: true
+        finalConclusion:
+          type: string
+          nullable: true
+        rawModelResponse:
+          type: string
           nullable: true
     MarketWarmupFailRequest:
       type: object
@@ -1553,6 +1636,10 @@ components:
         proofSummary:
           type: string
           nullable: true
+        salesPageText:
+          type: string
+          nullable: true
+          description: Texto/HTML completo da página de venda usado pelo worker para planejar termos de pesquisa.
         modelName:
           type: string
           nullable: true

--- a/mois-sales-library-worker/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/client/BackendClient.java
+++ b/mois-sales-library-worker/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/client/BackendClient.java
@@ -166,7 +166,7 @@ public class BackendClient {
     public MarketWarmupClaimResponse claimMarketWarmup(MarketWarmupClaimRequest request) {
         log.info("MOIS market-warmup worker calling backend claim endpoint. workspaceId={}, workerId={}", request.workspaceId(), request.workerId());
         MarketWarmupClaimResponse response = restClient.post()
-                .uri("/api/mois/sales-library/market-warmup/jobs:claim")
+                .uri("/api/mois/sales-library/market-warmup/stage-executions/pending")
                 .contentType(MediaType.APPLICATION_JSON)
                 .body(request)
                 .retrieve()

--- a/mois-sales-library-worker/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/marketwarmup/MarketWarmupProcessor.java
+++ b/mois-sales-library-worker/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/marketwarmup/MarketWarmupProcessor.java
@@ -6,6 +6,9 @@ import com.marketinghub.mois.bibliotecapaginavenda.worker.v1.model.WorkerDtos.Ma
 import com.marketinghub.mois.bibliotecapaginavenda.worker.v1.model.WorkerDtos.MarketWarmupPlatform;
 import com.marketinghub.mois.bibliotecapaginavenda.worker.v1.model.WorkerDtos.MarketWarmupRecommendation;
 import com.marketinghub.mois.bibliotecapaginavenda.worker.v1.model.WorkerDtos.MarketWarmupSearchAttemptCompleteItem;
+import com.marketinghub.mois.bibliotecapaginavenda.worker.v1.model.WorkerDtos.MarketWarmupSearchResultCompleteItem;
+import com.marketinghub.mois.bibliotecapaginavenda.worker.v1.model.WorkerDtos.MarketWarmupSearchTermCompleteItem;
+import com.marketinghub.mois.bibliotecapaginavenda.worker.v1.model.WorkerDtos.MarketWarmupFinalDossierCompleteItem;
 import com.marketinghub.mois.bibliotecapaginavenda.worker.v1.model.WorkerDtos.MarketWarmupSignalCompleteItem;
 import com.marketinghub.mois.bibliotecapaginavenda.worker.v1.model.WorkerDtos.MarketWarmupSignalType;
 import com.marketinghub.mois.bibliotecapaginavenda.worker.v1.model.WorkerDtos.MarketWarmupSourceCompleteItem;
@@ -64,9 +67,11 @@ public class MarketWarmupProcessor {
         List<String> queries = queryPlanner.planQueries(job, baseQueries);
         List<PublicSearchResult> rawResults = new ArrayList<>();
         List<MarketWarmupSearchAttemptCompleteItem> searchAttempts = new ArrayList<>();
+        List<MarketWarmupSearchResultCompleteItem> searchResults = new ArrayList<>();
         for (String query : queries) {
             List<PublicSearchResult> queryResults = searchClient.search(query, searchLimit);
             rawResults.addAll(queryResults);
+            searchResults.addAll(buildSearchResults(job, query, queryResults));
             searchAttempts.add(buildSearchAttempt(job, query, queryResults));
         }
         List<PublicSearchResult> deduplicatedResults = deduplicate(rawResults).stream().limit(searchLimit * 2L).toList();
@@ -77,9 +82,47 @@ public class MarketWarmupProcessor {
         List<MarketWarmupSourceCompleteItem> sources = buildSources(qualifiedResults);
         List<MarketWarmupSignalCompleteItem> signals = buildSignals(qualifiedResults);
         MarketWarmupSummaryCompleteItem summary = buildSummary(job, sources, signals);
+        List<MarketWarmupSearchTermCompleteItem> searchTerms = queries.stream()
+                .map(query -> new MarketWarmupSearchTermCompleteItem(query, "Termo usado para medir prestígio público e aquecimento externo do produto.", "OPENAI_OR_FALLBACK"))
+                .toList();
+        MarketWarmupFinalDossierCompleteItem finalDossier = buildFinalDossier(job, sources, signals, summary);
         log.info("MOIS market-warmup dossier built. jobId={}, pageId={}, queries={}, sources={}, signals={}, score={}",
                 job.jobId(), job.pageId(), queries.size(), sources.size(), signals.size(), summary.scoreTotal());
-        return new MarketWarmupCompleteRequest(searchAttempts, sources, signals, summary, Instant.now());
+        return new MarketWarmupCompleteRequest(searchAttempts, sources, signals, summary, searchTerms, searchResults, finalDossier, Instant.now());
+    }
+
+
+    /**
+     * Converte resultados de busca em evidências persistíveis relacionadas ao termo pesquisado.
+     */
+    private List<MarketWarmupSearchResultCompleteItem> buildSearchResults(MarketWarmupClaimedJob job, String query, List<PublicSearchResult> results) {
+        List<PublicSearchResult> qualified = keepOnlyQualifiedProducerSocialResults(job, results);
+        Set<String> qualifiedUrls = qualified.stream().map(PublicSearchResult::url).collect(java.util.stream.Collectors.toSet());
+        return results.stream()
+                .map(result -> new MarketWarmupSearchResultCompleteItem(query, result.url(), result.title(), result.snippet(), result.rawPayload(), qualifiedUrls.contains(result.url())))
+                .toList();
+    }
+
+    /**
+     * Monta o texto final simples do dossiê para a tela sem depender de recomputação no frontend.
+     */
+    private MarketWarmupFinalDossierCompleteItem buildFinalDossier(
+            MarketWarmupClaimedJob job,
+            List<MarketWarmupSourceCompleteItem> sources,
+            List<MarketWarmupSignalCompleteItem> signals,
+            MarketWarmupSummaryCompleteItem summary
+    ) {
+        String resources = sources.stream()
+                .map(source -> source.platform() + ": " + source.sourceTitle() + " (" + source.sourceUrl() + ")")
+                .limit(8)
+                .reduce((left, right) -> left + "\n" + right)
+                .orElse("Nenhum recurso externo qualificado foi identificado.");
+        String prestige = "Foram encontradas " + sources.size() + " fontes externas qualificadas e " + signals.size()
+                + " sinais de aquecimento relacionados ao produto " + nullSafe(job.title()) + ".";
+        String conclusion = summary.opportunityRecommendation() == null || summary.opportunityRecommendation().isBlank()
+                ? "Dossiê concluído para apoiar decisão comercial da biblioteca."
+                : summary.opportunityRecommendation();
+        return new MarketWarmupFinalDossierCompleteItem(prestige, resources, conclusion, null);
     }
 
     /**
@@ -181,6 +224,13 @@ public class MarketWarmupProcessor {
         }
         String withoutAccents = Normalizer.normalize(value, Normalizer.Form.NFD).replaceAll("\\p{M}+", "");
         return NON_ALPHANUMERIC.matcher(withoutAccents.toLowerCase(Locale.ROOT)).replaceAll(" ").replaceAll("\\s+", " ").trim();
+    }
+
+    /**
+     * Normaliza textos nulos para montar conclusão final segura.
+     */
+    private String nullSafe(String value) {
+        return value == null || value.isBlank() ? "produto sem título" : value;
     }
 
     /**

--- a/mois-sales-library-worker/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/model/WorkerDtos.java
+++ b/mois-sales-library-worker/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/model/WorkerDtos.java
@@ -39,12 +39,25 @@ public final class WorkerDtos {
     public enum MarketWarmupRecommendation { PRIORITIZE, OBSERVE, RESEARCH_MORE, DISCARD, SATURATED_REQUIRES_ANGLE }
 
     public record MarketWarmupClaimRequest(String workspaceId, String workerId) {}
-    public record MarketWarmupClaimedJob(Long jobId, Long pageId, String workspaceId, String urlCanonical, String title, String producerName, String offerSummary, String mechanismSummary, String promiseSummary, String proofSummary) {}
+    public record MarketWarmupClaimedJob(Long jobId, Long pageId, String workspaceId, String urlCanonical, String title, String producerName, String offerSummary, String mechanismSummary, String promiseSummary, String proofSummary, String salesPageText) {
+        /** Mantém compatibilidade com testes e payloads sem texto completo. */
+        public MarketWarmupClaimedJob(Long jobId, Long pageId, String workspaceId, String urlCanonical, String title, String producerName, String offerSummary, String mechanismSummary, String promiseSummary, String proofSummary) {
+            this(jobId, pageId, workspaceId, urlCanonical, title, producerName, offerSummary, mechanismSummary, promiseSummary, proofSummary, null);
+        }
+    }
     public record MarketWarmupClaimResponse(boolean claimed, MarketWarmupClaimedJob job) {}
     public record MarketWarmupSourceCompleteItem(MarketWarmupPlatform platform, MarketWarmupSourceType sourceType, String sourceUrl, String sourceTitle, String authorName, Instant publishedAt, Instant lastActivityAt, Long followersOrSubscribers, Long viewsCount, Long likesCount, Long commentsCount, BigDecimal recencyScore, BigDecimal engagementScore, String evidenceSummary) {}
     public record MarketWarmupSignalCompleteItem(int sourceIndex, MarketWarmupSignalType signalType, BigDecimal signalStrength, String signalText, String businessInterpretation) {}
     public record MarketWarmupSummaryCompleteItem(BigDecimal scoreTotal, MarketWarmupTemperature marketTemperature, MarketWarmupEcosystemType ecosystemType, MarketWarmupRecommendation recommendation, java.util.List<String> mainPains, java.util.List<String> mainObjections, java.util.List<String> mainPromises, java.util.List<String> mainChannels, java.util.List<String> mainCompetitors, String saturationRisk, String opportunityRecommendation, String nextExperimentSuggestion) {}
     public record MarketWarmupSearchAttemptCompleteItem(String queryText, int resultCount, int qualifiedCount, int rejectedCount, String status, String rejectionReason, String sampleResultTitle, String sampleResultUrl) {}
-    public record MarketWarmupCompleteRequest(java.util.List<MarketWarmupSearchAttemptCompleteItem> searchAttempts, java.util.List<MarketWarmupSourceCompleteItem> sources, java.util.List<MarketWarmupSignalCompleteItem> signals, MarketWarmupSummaryCompleteItem summary, Instant finishedAt) {}
+    public record MarketWarmupSearchTermCompleteItem(String termText, String reason, String source) {}
+    public record MarketWarmupSearchResultCompleteItem(String termText, String resultUrl, String resultTitle, String resultSnippet, String rawPayload, Boolean relatedToProduct) {}
+    public record MarketWarmupFinalDossierCompleteItem(String prestigeSummary, String externalWarmupResources, String finalConclusion, String rawModelResponse) {}
+    public record MarketWarmupCompleteRequest(java.util.List<MarketWarmupSearchAttemptCompleteItem> searchAttempts, java.util.List<MarketWarmupSourceCompleteItem> sources, java.util.List<MarketWarmupSignalCompleteItem> signals, MarketWarmupSummaryCompleteItem summary, java.util.List<MarketWarmupSearchTermCompleteItem> searchTerms, java.util.List<MarketWarmupSearchResultCompleteItem> searchResults, MarketWarmupFinalDossierCompleteItem finalDossier, Instant finishedAt) {
+        /** Mantém compatibilidade com chamadas sem evidências detalhadas do dossiê. */
+        public MarketWarmupCompleteRequest(java.util.List<MarketWarmupSearchAttemptCompleteItem> searchAttempts, java.util.List<MarketWarmupSourceCompleteItem> sources, java.util.List<MarketWarmupSignalCompleteItem> signals, MarketWarmupSummaryCompleteItem summary, Instant finishedAt) {
+            this(searchAttempts, sources, signals, summary, java.util.List.of(), java.util.List.of(), null, finishedAt);
+        }
+    }
     public record MarketWarmupFailRequest(String errorCategory, String errorMessage, java.util.List<MarketWarmupSearchAttemptCompleteItem> searchAttempts) {}
 }

--- a/mois-sales-library-worker/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/marketwarmup/MarketWarmupProcessorTest.java
+++ b/mois-sales-library-worker/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/marketwarmup/MarketWarmupProcessorTest.java
@@ -30,11 +30,15 @@ class MarketWarmupProcessorTest {
                 "Oferta contra insônia",
                 "método respiratório",
                 "dormir melhor em 7 dias",
-                "depoimentos");
+                "depoimentos",
+                "texto completo da pagina");
 
         var result = processor.process(job, 3);
 
         assertThat(result.sources()).isNotEmpty();
+        assertThat(result.searchTerms()).isNotEmpty();
+        assertThat(result.searchResults()).isNotEmpty();
+        assertThat(result.finalDossier().finalConclusion()).isNotBlank();
         assertThat(result.signals()).extracting(signal -> signal.signalType()).contains(MarketWarmupSignalType.PAIN_EXPLICIT, MarketWarmupSignalType.BUYING_INTENT, MarketWarmupSignalType.CREATOR_AUTHORITY, MarketWarmupSignalType.SOCIAL_PROOF);
         assertThat(result.sources()).extracting(source -> source.platform()).contains(MarketWarmupPlatform.YOUTUBE);
         assertThat(result.summary().recommendation()).isNotNull();
@@ -60,7 +64,8 @@ class MarketWarmupProcessorTest {
                 "certificação para prescrição segura de peptídeos",
                 "protocolo avançado de peptídeos",
                 "dominar peptídeos com segurança clínica",
-                "depoimentos de profissionais");
+                "depoimentos de profissionais",
+                "texto completo da pagina");
 
         var result = processor.process(job, 4);
 
@@ -86,7 +91,8 @@ class MarketWarmupProcessorTest {
                 null,
                 null,
                 null,
-                null);
+                null,
+                "texto completo da pagina");
 
         assertThatThrownBy(() -> processor.process(job, 4))
                 .isInstanceOf(IllegalStateException.class)

--- a/mois-sales-library-worker/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/marketwarmup/MarketWarmupQueryBuilderTest.java
+++ b/mois-sales-library-worker/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/marketwarmup/MarketWarmupQueryBuilderTest.java
@@ -50,7 +50,8 @@ class MarketWarmupQueryBuilderTest {
                 null,
                 null,
                 null,
-                null);
+                null,
+                "texto completo da pagina");
 
         assertThat(builder.buildQueries(job))
                 .anySatisfy(query -> assertThat(query).contains("\"andreavermont.online\""))


### PR DESCRIPTION
### Motivation
- Enable auditable evidence for the MOIS market-warmup flow by persisting planned search terms, raw search results and a final dossier so the backend can display and review the worker's findings. 
- Provide the worker the full captured page text (`salesPageText`) to allow OpenAI-based term planning and ensure the worker/backend protocol is explicit and reproducible. 
- Expose a canonical `pending` endpoint for the stage execution protocol so workers follow the standard backend/module pattern. 
- Keep backwards compatibility for existing callers and tests while evolving contracts and schema.

### Description
- Added new DTO fields and compatibility constructors: `salesPageText` to claim/job DTOs and `searchTerms`, `searchResults`, `finalDossier` to `MarketWarmupCompleteRequest` in backend and worker contracts. 
- Implemented persistence and mapping for new artifacts: new gateway methods and repository JDBC implementations for `insertSearchTerm`, `insertSearchResult`, and `insertFinalDossier`, plus deleting these rows on job reset; `SalesPageWarmupData` and claim mapping now include `salesPageText`. 
- Added Liquibase changeset to create three new tables: `mois_sales_page_market_warmup_search_term`, `mois_sales_page_market_warmup_search_result` and `mois_sales_page_market_warmup_final_dossier`, and included it in the master changelog. 
- Exposed canonical controller endpoint `POST /api/mois/sales-library/market-warmup/stage-executions/pending`, updated service to persist the new fields, updated worker client to use the pending endpoint, and updated worker processor to build and send `searchTerms`, `searchResults` and `finalDossier`. 
- Updated OpenAPI/Swagger, internal docs and protocol records, and added an ArchUnit rule to require the canonical pending endpoint in the controller. 

### Testing
- Ran backend unit tests including `MoisSalesPageMarketWarmupServiceTest` and `ArquiteturaTest` which were updated to reflect the new API contract and passed. 
- Ran worker unit tests including `MarketWarmupProcessorTest` and `MarketWarmupQueryBuilderTest` which were updated to include `salesPageText`, `searchTerms`, `searchResults`, and `finalDossier` and passed. 
- Database changelog was added and linted as part of the change; migration creation tests succeeded locally.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3cff9902908321af5a96c0e4f688da)