### PR TITLE
Corrige rotas externas do Ops Monitor

### DIFF
--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-25-ops-monitor-external-module-routes.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-25-ops-monitor-external-module-routes.yaml
@@ -1,0 +1,32 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-06-25-ops-monitor-007-external-module-routes
+      author: marketing-hub
+      preConditions:
+        - onFail: MARK_RAN
+        - dbms:
+            type: mysql
+        - tableExists:
+            tableName: ops_monitored_module
+      changes:
+        - sql:
+            splitStatements: true
+            stripComments: true
+            sql: |
+              UPDATE ops_monitored_module
+              SET base_url = 'http://177.153.62.107:9096',
+                  health_path = '/internal/ops-monitor/health',
+                  log_path = '/internal/ops-monitor/logfile'
+              WHERE code = 'mois-clickbank-collector';
+
+              UPDATE ops_monitored_module
+              SET base_url = 'http://177.153.62.107:8096',
+                  health_path = '/ops-monitor/health',
+                  log_path = '/ops-monitor/mois-hotmart-log'
+              WHERE code = 'mois-hotmart-collector';
+
+              UPDATE ops_monitored_module
+              SET base_url = 'https://oportunidadebrasil.shop',
+                  health_path = '/api/ops-lp-observability-v2/health',
+                  log_path = '/api/ops-lp-observability-v2/logfile'
+              WHERE code = 'lead-portal';

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -1091,6 +1091,9 @@ databaseChangeLog:
   - include:
       file: changesets/2026-06-25-ops-monitor-raw-payload-longtext.yaml
       relativeToChangelogFile: true
+  - include:
+      file: changesets/2026-06-25-ops-monitor-external-module-routes.yaml
+      relativeToChangelogFile: true
 
   - include:
       file: changesets/2026-06-24-mois-sales-library-geralanding-insights.yaml

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -5385,3 +5385,8 @@
 - Correção aplicada: a prontidão de campanha passou a considerar qualquer seleção salva cujo elemento esteja aprovado, tenha ID oficial da Meta e seja `INTEREST`, `JOB_TITLE` ou `BEHAVIOR`; a UI e o cânone foram alinhados para remover a exigência isolada de cargo.
 - Prevenção de recorrência: testes unitários cobrem interesse e comportamento como suficientes para campanha e bloqueiam seleção sem ID oficial da Meta.
 - 2026-06-25 06:25 (UTC): pipeline de criação de hipótese passou a vincular as execuções concluídas à hipótese fechada; a tela de criar nova hipótese lista apenas execuções ainda sem hipótese, e o clique no nome da hipótese no detalhe do nicho abre a auditoria das execuções daquela hipótese.
+
+## 2026-06-25 — Rota externa do Ops Monitor para Lead Portal
+
+- Identificada a causa do alerta “Fora do ar” do Lead Portal: o cadastro operacional do Ops Monitor apontava para `host.docker.internal:8080`, enquanto o portal público saudável responde pelo domínio HTTPS `https://oportunidadebrasil.shop`.
+- Criado changelog incremental para o Ops Monitor verificar o Lead Portal pelo domínio público canônico, evitando falso offline na tela de operação.

--- a/docs/registros/mois1.md
+++ b/docs/registros/mois1.md
@@ -1827,3 +1827,8 @@ Arquivos principais:
 - exposto endpoint pending canônico para o worker iniciar a etapa de dossiê pelo backend, mantendo o backend como controlador de estado e persistência.
 - ajustado o `mois-sales-library-worker` para enviar termos, resultados e dossiê final estruturados ao backend, sem acessar banco diretamente.
 - aplicados e registrados o protocolo padrão backend e o protocolo padrão módulo para este fluxo.
+
+## 2026-06-25 — Rotas externas do Ops Monitor para coletores MOIS
+
+- Identificada a causa dos alertas “Fora do ar” nos coletores MOIS ClickBank/Hotmart: o cadastro operacional do Ops Monitor apontava para `host.docker.internal`, mas esses coletores estão expostos em rota externa monitorável.
+- Criado changelog incremental para restaurar as URLs externas dos coletores e corrigir o endpoint de log do Hotmart, evitando recorrência do falso offline na tela de operação.


### PR DESCRIPTION
### Motivation
- Corrigir falsos alertas “Fora do ar” no Ops Monitor causados por URLs operacionais apontando para `host.docker.internal` em vez das rotas externas/canônicas dos coletores e do Lead Portal. 
- Garantir que o monitoramento consulte endpoints publicamente acessíveis e que o changelog do Liquibase seja incluído corretamente com `relativeToChangelogFile: true` para evitar erros de resolução. 

### Description
- Adiciona novo changelog `backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-25-ops-monitor-external-module-routes.yaml` que atualiza `ops_monitored_module` com as URLs externas e paths de health/log para `mois-clickbank-collector`, `mois-hotmart-collector` e `lead-portal`. 
- Atualiza o master `backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml` para incluir o novo changelog com `relativeToChangelogFile: true`. 
- Registra a investigação e a correção nos arquivos de histórico `docs/registros/mois1.md` e `docs/registros/experimentos.md`. 

### Testing
- Validada a sintaxe YAML dos arquivos alterados com `ruby -e "require 'yaml'; ARGV.each { |f| YAML.load_file(f); puts \"#{f} OK\" }"`, que retornou sucesso para o master e o changelog adicionado. 
- Verificado via script Python/consulta que todos os `include` em `db.changelog-master.yaml` possuem `relativeToChangelogFile: true`, que passou sem falhas. 
- Checado o endpoint público do Lead Portal com `curl -sS -m 10 -w '\nHTTP %{http_code}\n' https://oportunidadebrasil.shop/api/ops-lp-observability-v2/health`, que retornou `HTTP 200` e confirmou que a rota pública está saudável. 
- Observação: uma tentativa inicial de carregar YAML com o módulo Python `yaml` falhou por indisponibilidade do pacote no ambiente, então foi usada validação via Ruby/Psych e outras validações automatizadas, todas concluídas com sucesso.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d3bcc7354832181dc1c76e50202e3)