### PR TITLE
Destaca processamento em execução nas linhas OPRM

### DIFF
--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -1384,3 +1384,5 @@
 - Regra ajustada: executar novamente o pipeline para CNAE que já possui nicho não deve bloquear a pesquisa.
 - Na conclusão, quando o candidato/CNAE já estiver ligado a um `market_niche`, o fluxo atualiza o nicho existente e renova `updated_at`, em vez de criar duplicidade silenciosa.
 - O perfil enriquecido materializado por CNAE + nome neutro também passa a ser atualizado quando já existir, preservando o registro e renovando as informações auditáveis.
+
+- 2026-06-25 — Tela OPRM de CNAEs atualizada para destacar visualmente, já no início da linha, os CNAEs com processamento de pesquisa em execução, reutilizando o indicador `nicheResearchRunning` entregue pelo backend.

--- a/frontend/src/pages/oprm/OprmCnaeVolumePage.tsx
+++ b/frontend/src/pages/oprm/OprmCnaeVolumePage.tsx
@@ -33,6 +33,19 @@ function formatDateTime(value: string | null | undefined) {
   return new Date(value).toLocaleString("pt-BR");
 }
 
+function RunningProcessingIcon() {
+  return (
+    <span
+      className="d-inline-flex align-items-center gap-1 text-primary"
+      title="Processamento em execução neste CNAE"
+      aria-label="Processamento em execução neste CNAE"
+    >
+      <span className="spinner-border spinner-border-sm" aria-hidden="true" />
+      <span aria-hidden="true">⚙️</span>
+    </span>
+  );
+}
+
 export default function OprmCnaeVolumePage() {
   const pageSize = 50;
   const [currentPage, setCurrentPage] = useState(1);
@@ -297,7 +310,14 @@ export default function OprmCnaeVolumePage() {
                 {hasVolumeData
                   ? volumeData.map((item, index) => (
                       <tr key={`${item.snapshotDate}-${item.cnaeCode}`}>
-                        <td>{(currentPage - 1) * pageSize + index + 1}</td>
+                        <td>
+                          <span className="d-inline-flex align-items-center gap-2">
+                            <span>{(currentPage - 1) * pageSize + index + 1}</span>
+                            {item.nicheResearchRunning ? (
+                              <RunningProcessingIcon />
+                            ) : null}
+                          </span>
+                        </td>
                         <td>{item.cnaeCode}</td>
                         <td>
                           <Link
@@ -328,13 +348,7 @@ export default function OprmCnaeVolumePage() {
                         <td>{formatCurrencyUsd(item.researchCostUsd)}</td>
                         <td>
                           {item.nicheResearchRunning ? (
-                            <span
-                              className="text-primary"
-                              title="Pesquisa de nicho em execução neste CNAE"
-                              aria-label="Pesquisa de nicho em execução"
-                            >
-                              🔎
-                            </span>
+                            <RunningProcessingIcon />
                           ) : (
                             <span
                               className="text-secondary"


### PR DESCRIPTION
### Motivation
- Melhorar a visibilidade, na tela "CNAEs por Score OPRM", das linhas que têm processamento de pesquisa em execução para facilitar acompanhamento operacional.
- Reutilizar o indicador já exposto pelo backend `nicheResearchRunning` em vez de inferir localmente.

### Description
- Adiciona o componente reutilizável `RunningProcessingIcon` em `frontend/src/pages/oprm/OprmCnaeVolumePage.tsx` que mostra spinner + ícone de engrenagem. 
- Exibe o ícone logo no início da linha ao lado do número da posição quando `nicheResearchRunning` for `true` e substitui o indicador antigo na coluna `Pesquisa` pelo mesmo componente. 
- Registra a alteração no histórico operacional em `docs/registros/oprm1.md`.

### Testing
- Executado `npm run typecheck` e o comando completou com sucesso. 
- Executado `npm run build` e o build de produção completou com sucesso.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d3ce8b9ac8321934420dc1b44736d)