### PR TITLE
Add OPRM NichoCNAE v3 pipeline: backend persistence/endpoints, executor module and architecture tests

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/OprmNichoCnaeV3StageExecution.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/OprmNichoCnaeV3StageExecution.java
@@ -1,0 +1,111 @@
+package com.marketinghub.oprm.nichocnae.v3;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.EnumType;
+import jakarta.persistence.Enumerated;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.Instant;
+
+/** Persiste uma execução auditável de etapa do pipeline OPRM NichoCNAE v3. */
+@Entity
+@Table(name = "oprm_nichocnae_v3_stage_execution")
+public class OprmNichoCnaeV3StageExecution {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "id")
+    private Long id;
+
+    @Column(name = "job_id", nullable = false, length = 96)
+    private String jobId;
+
+    @Column(name = "cnae_code", nullable = false, length = 16)
+    private String cnaeCode;
+
+    @Column(name = "stage_code", nullable = false, length = 80)
+    private String stageCode;
+
+    @Enumerated(EnumType.STRING)
+    @Column(name = "status", nullable = false, length = 32)
+    private OprmNichoCnaeV3StageExecutionStatus status = OprmNichoCnaeV3StageExecutionStatus.PENDING;
+
+    @Column(name = "attempt_number", nullable = false)
+    private Integer attemptNumber = 1;
+
+    @Column(name = "knowledge_version", nullable = false)
+    private Integer knowledgeVersion = 1;
+
+    @Column(name = "input_payload", columnDefinition = "LONGTEXT")
+    private String inputPayload;
+
+    @Column(name = "output_payload", columnDefinition = "LONGTEXT")
+    private String outputPayload;
+
+    @Column(name = "next_stage_code", length = 80)
+    private String nextStageCode;
+
+    @Column(name = "error_message", columnDefinition = "LONGTEXT")
+    private String errorMessage;
+
+    @Column(name = "created_at", nullable = false)
+    private Instant createdAt = Instant.now();
+
+    @Column(name = "updated_at", nullable = false)
+    private Instant updatedAt = Instant.now();
+
+    /** Retorna o identificador interno da execução. */
+    public Long getId() { return id; }
+    /** Define o identificador interno da execução. */
+    public void setId(Long id) { this.id = id; }
+    /** Retorna o job funcional do pipeline. */
+    public String getJobId() { return jobId; }
+    /** Define o job funcional do pipeline. */
+    public void setJobId(String jobId) { this.jobId = jobId; }
+    /** Retorna o CNAE pesquisado. */
+    public String getCnaeCode() { return cnaeCode; }
+    /** Define o CNAE pesquisado. */
+    public void setCnaeCode(String cnaeCode) { this.cnaeCode = cnaeCode; }
+    /** Retorna a etapa da execução. */
+    public String getStageCode() { return stageCode; }
+    /** Define a etapa da execução. */
+    public void setStageCode(String stageCode) { this.stageCode = stageCode; }
+    /** Retorna o status operacional. */
+    public OprmNichoCnaeV3StageExecutionStatus getStatus() { return status; }
+    /** Define o status operacional. */
+    public void setStatus(OprmNichoCnaeV3StageExecutionStatus status) { this.status = status; }
+    /** Retorna a tentativa cognitiva. */
+    public Integer getAttemptNumber() { return attemptNumber; }
+    /** Define a tentativa cognitiva. */
+    public void setAttemptNumber(Integer attemptNumber) { this.attemptNumber = attemptNumber; }
+    /** Retorna a versão de conhecimento. */
+    public Integer getKnowledgeVersion() { return knowledgeVersion; }
+    /** Define a versão de conhecimento. */
+    public void setKnowledgeVersion(Integer knowledgeVersion) { this.knowledgeVersion = knowledgeVersion; }
+    /** Retorna o payload de entrada. */
+    public String getInputPayload() { return inputPayload; }
+    /** Define o payload de entrada. */
+    public void setInputPayload(String inputPayload) { this.inputPayload = inputPayload; }
+    /** Retorna o payload de saída. */
+    public String getOutputPayload() { return outputPayload; }
+    /** Define o payload de saída. */
+    public void setOutputPayload(String outputPayload) { this.outputPayload = outputPayload; }
+    /** Retorna a próxima etapa decidida pelo backend. */
+    public String getNextStageCode() { return nextStageCode; }
+    /** Define a próxima etapa decidida pelo backend. */
+    public void setNextStageCode(String nextStageCode) { this.nextStageCode = nextStageCode; }
+    /** Retorna a mensagem de erro persistida. */
+    public String getErrorMessage() { return errorMessage; }
+    /** Define a mensagem de erro persistida. */
+    public void setErrorMessage(String errorMessage) { this.errorMessage = errorMessage; }
+    /** Retorna a data de criação. */
+    public Instant getCreatedAt() { return createdAt; }
+    /** Define a data de criação. */
+    public void setCreatedAt(Instant createdAt) { this.createdAt = createdAt; }
+    /** Retorna a data de atualização. */
+    public Instant getUpdatedAt() { return updatedAt; }
+    /** Define a data de atualização. */
+    public void setUpdatedAt(Instant updatedAt) { this.updatedAt = updatedAt; }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/OprmNichoCnaeV3StageExecutionStatus.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/OprmNichoCnaeV3StageExecutionStatus.java
@@ -1,0 +1,10 @@
+package com.marketinghub.oprm.nichocnae.v3;
+
+/** Representa os estados persistidos de uma execução de etapa do NichoCNAE v3. */
+public enum OprmNichoCnaeV3StageExecutionStatus {
+    PENDING,
+    RUNNING,
+    COMPLETED,
+    FAILED,
+    CANCELED
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/cnaeintake/controller/BackendCnaeIntakeController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/cnaeintake/controller/BackendCnaeIntakeController.java
@@ -1,0 +1,56 @@
+package com.marketinghub.oprm.nichocnae.v3.cnaeintake.controller;
+
+import com.marketinghub.oprm.nichocnae.v3.cnaeintake.service.BackendCnaeIntakeService;
+import com.marketinghub.oprm.nichocnae.v3.cnaeintake.service.completeStageExecution.CnaeIntakeCompletionRequest;
+import com.marketinghub.oprm.nichocnae.v3.cnaeintake.service.createStageExecution.CnaeIntakeCreateResponse;
+import com.marketinghub.oprm.nichocnae.v3.cnaeintake.service.failStageExecution.CnaeIntakeFailureRequest;
+import com.marketinghub.oprm.nichocnae.v3.cnaeintake.service.pending.CnaeIntakePendingResponse;
+import java.util.List;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/** Controller canônico da etapa cnae-intake do pipeline NichoCNAE v3. */
+@RestController
+@RequestMapping("/api/internal/oprm/nichocnae/v3/cnae-intake/stage-executions")
+public class BackendCnaeIntakeController {
+    private final BackendCnaeIntakeService service;
+
+    /** Inicializa o controller com service canônico da etapa. */
+    public BackendCnaeIntakeController(BackendCnaeIntakeService service) {
+        this.service = service;
+    }
+
+    /** Cria uma execução pendente da etapa cnae-intake. */
+    @PostMapping
+    public CnaeIntakeCreateResponse create(@RequestBody CnaeIntakePendingResponse request) {
+        return service.create(request.jobId(), request.cnaeCode(), request.inputPayload(), request.attemptNumber(), request.knowledgeVersion());
+    }
+
+    /** Cria a primeira execução v3 diretamente a partir de um CNAE. */
+    @PostMapping("/cnaes/{cnaeCode}")
+    public CnaeIntakeCreateResponse createForCnae(@PathVariable String cnaeCode) {
+        return service.create(null, cnaeCode, "{\"cnaeCode\":\"" + cnaeCode + "\"}", 1, 1);
+    }
+
+    /** Entrega pendências da etapa cnae-intake ao executor OPRM. */
+    @GetMapping("/pending")
+    public List<CnaeIntakePendingResponse> pending() {
+        return service.pending();
+    }
+
+    /** Recebe conclusão da etapa cnae-intake enviada pelo executor OPRM. */
+    @PostMapping("/{stageExecutionId}/complete")
+    public CnaeIntakeCreateResponse complete(@PathVariable Long stageExecutionId, @RequestBody CnaeIntakeCompletionRequest request) {
+        return service.complete(stageExecutionId, request.outputPayload(), request.nextStageCode());
+    }
+
+    /** Recebe falha da etapa cnae-intake enviada pelo executor OPRM. */
+    @PostMapping("/{stageExecutionId}/fail")
+    public CnaeIntakeCreateResponse fail(@PathVariable Long stageExecutionId, @RequestBody CnaeIntakeFailureRequest request) {
+        return service.fail(stageExecutionId, request.errorMessage());
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/cnaeintake/service/BackendCnaeIntakeService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/cnaeintake/service/BackendCnaeIntakeService.java
@@ -1,0 +1,50 @@
+package com.marketinghub.oprm.nichocnae.v3.cnaeintake.service;
+
+import com.marketinghub.oprm.nichocnae.v3.OprmNichoCnaeV3StageExecution;
+import com.marketinghub.oprm.nichocnae.v3.cnaeintake.service.createStageExecution.CnaeIntakeCreateResponse;
+import com.marketinghub.oprm.nichocnae.v3.cnaeintake.service.pending.CnaeIntakePendingResponse;
+import com.marketinghub.oprm.nichocnae.v3.shared.OprmNichoCnaeV3StageServiceSupport;
+import com.marketinghub.repository.jpa.oprm.nichocnae.v3.OprmNichoCnaeV3StageExecutionRepository;
+import java.util.List;
+import org.springframework.stereotype.Service;
+
+/** Service canônico da etapa cnae-intake do pipeline NichoCNAE v3 no backend. */
+@Service
+public class BackendCnaeIntakeService extends OprmNichoCnaeV3StageServiceSupport {
+    private static final String STAGE_CODE = "cnae-intake";
+
+    /** Inicializa o service com repository canônico de execuções v3. */
+    public BackendCnaeIntakeService(OprmNichoCnaeV3StageExecutionRepository repository) {
+        super(repository, STAGE_CODE);
+    }
+
+    /** Cria pendência inicial ou encadeada para a etapa cnae-intake. */
+    public CnaeIntakeCreateResponse create(String jobId, String cnaeCode, String inputPayload, Integer attemptNumber, Integer knowledgeVersion) {
+        return toCreateResponse(doCreate(jobId, cnaeCode, inputPayload, attemptNumber, knowledgeVersion));
+    }
+
+    /** Lista pendências da etapa cnae-intake para o executor OPRM. */
+    public List<CnaeIntakePendingResponse> pending() {
+        return pendingExecutions().stream().map(this::toPendingResponse).toList();
+    }
+
+    /** Registra conclusão da etapa cnae-intake. */
+    public CnaeIntakeCreateResponse complete(Long stageExecutionId, String outputPayload, String nextStageCode) {
+        return toCreateResponse(doComplete(stageExecutionId, outputPayload, nextStageCode));
+    }
+
+    /** Registra falha da etapa cnae-intake. */
+    public CnaeIntakeCreateResponse fail(Long stageExecutionId, String errorMessage) {
+        return toCreateResponse(doFail(stageExecutionId, errorMessage));
+    }
+
+    /** Converte entidade persistida em resposta de criação/conclusão/falha. */
+    private CnaeIntakeCreateResponse toCreateResponse(OprmNichoCnaeV3StageExecution execution) {
+        return new CnaeIntakeCreateResponse(execution.getId(), execution.getJobId(), execution.getCnaeCode(), execution.getStageCode(), execution.getStatus().name());
+    }
+
+    /** Converte entidade persistida em item pendente para executor externo. */
+    private CnaeIntakePendingResponse toPendingResponse(OprmNichoCnaeV3StageExecution execution) {
+        return new CnaeIntakePendingResponse(execution.getId(), execution.getJobId(), execution.getCnaeCode(), execution.getInputPayload(), execution.getAttemptNumber(), execution.getKnowledgeVersion());
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/cnaeintake/service/completeStageExecution/CnaeIntakeCompletionRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/cnaeintake/service/completeStageExecution/CnaeIntakeCompletionRequest.java
@@ -1,0 +1,4 @@
+package com.marketinghub.oprm.nichocnae.v3.cnaeintake.service.completeStageExecution;
+
+/** Request de conclusão da etapa cnae-intake reportada pelo executor. */
+public record CnaeIntakeCompletionRequest(String outputPayload, String nextStageCode) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/cnaeintake/service/createStageExecution/CnaeIntakeCreateResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/cnaeintake/service/createStageExecution/CnaeIntakeCreateResponse.java
@@ -1,0 +1,4 @@
+package com.marketinghub.oprm.nichocnae.v3.cnaeintake.service.createStageExecution;
+
+/** Resposta de criação de execução pendente da etapa cnae-intake. */
+public record CnaeIntakeCreateResponse(Long stageExecutionId, String jobId, String cnaeCode, String stageCode, String status) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/cnaeintake/service/failStageExecution/CnaeIntakeFailureRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/cnaeintake/service/failStageExecution/CnaeIntakeFailureRequest.java
@@ -1,0 +1,4 @@
+package com.marketinghub.oprm.nichocnae.v3.cnaeintake.service.failStageExecution;
+
+/** Request de falha da etapa cnae-intake reportada pelo executor. */
+public record CnaeIntakeFailureRequest(String errorMessage) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/cnaeintake/service/pending/CnaeIntakePendingResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/cnaeintake/service/pending/CnaeIntakePendingResponse.java
@@ -1,0 +1,4 @@
+package com.marketinghub.oprm.nichocnae.v3.cnaeintake.service.pending;
+
+/** Item pendente entregue ao executor para a etapa cnae-intake. */
+public record CnaeIntakePendingResponse(Long stageExecutionId, String jobId, String cnaeCode, String inputPayload, Integer attemptNumber, Integer knowledgeVersion) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/dailytaskssynthesizer/controller/BackendDailyTasksSynthesizerController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/dailytaskssynthesizer/controller/BackendDailyTasksSynthesizerController.java
@@ -1,0 +1,56 @@
+package com.marketinghub.oprm.nichocnae.v3.dailytaskssynthesizer.controller;
+
+import com.marketinghub.oprm.nichocnae.v3.dailytaskssynthesizer.service.BackendDailyTasksSynthesizerService;
+import com.marketinghub.oprm.nichocnae.v3.dailytaskssynthesizer.service.completeStageExecution.DailyTasksSynthesizerCompletionRequest;
+import com.marketinghub.oprm.nichocnae.v3.dailytaskssynthesizer.service.createStageExecution.DailyTasksSynthesizerCreateResponse;
+import com.marketinghub.oprm.nichocnae.v3.dailytaskssynthesizer.service.failStageExecution.DailyTasksSynthesizerFailureRequest;
+import com.marketinghub.oprm.nichocnae.v3.dailytaskssynthesizer.service.pending.DailyTasksSynthesizerPendingResponse;
+import java.util.List;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/** Controller canônico da etapa daily-tasks-synthesizer do pipeline NichoCNAE v3. */
+@RestController
+@RequestMapping("/api/internal/oprm/nichocnae/v3/daily-tasks-synthesizer/stage-executions")
+public class BackendDailyTasksSynthesizerController {
+    private final BackendDailyTasksSynthesizerService service;
+
+    /** Inicializa o controller com service canônico da etapa. */
+    public BackendDailyTasksSynthesizerController(BackendDailyTasksSynthesizerService service) {
+        this.service = service;
+    }
+
+    /** Cria uma execução pendente da etapa daily-tasks-synthesizer. */
+    @PostMapping
+    public DailyTasksSynthesizerCreateResponse create(@RequestBody DailyTasksSynthesizerPendingResponse request) {
+        return service.create(request.jobId(), request.cnaeCode(), request.inputPayload(), request.attemptNumber(), request.knowledgeVersion());
+    }
+
+    /** Cria a primeira execução v3 diretamente a partir de um CNAE. */
+    @PostMapping("/cnaes/{cnaeCode}")
+    public DailyTasksSynthesizerCreateResponse createForCnae(@PathVariable String cnaeCode) {
+        return service.create(null, cnaeCode, "{\"cnaeCode\":\"" + cnaeCode + "\"}", 1, 1);
+    }
+
+    /** Entrega pendências da etapa daily-tasks-synthesizer ao executor OPRM. */
+    @GetMapping("/pending")
+    public List<DailyTasksSynthesizerPendingResponse> pending() {
+        return service.pending();
+    }
+
+    /** Recebe conclusão da etapa daily-tasks-synthesizer enviada pelo executor OPRM. */
+    @PostMapping("/{stageExecutionId}/complete")
+    public DailyTasksSynthesizerCreateResponse complete(@PathVariable Long stageExecutionId, @RequestBody DailyTasksSynthesizerCompletionRequest request) {
+        return service.complete(stageExecutionId, request.outputPayload(), request.nextStageCode());
+    }
+
+    /** Recebe falha da etapa daily-tasks-synthesizer enviada pelo executor OPRM. */
+    @PostMapping("/{stageExecutionId}/fail")
+    public DailyTasksSynthesizerCreateResponse fail(@PathVariable Long stageExecutionId, @RequestBody DailyTasksSynthesizerFailureRequest request) {
+        return service.fail(stageExecutionId, request.errorMessage());
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/dailytaskssynthesizer/service/BackendDailyTasksSynthesizerService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/dailytaskssynthesizer/service/BackendDailyTasksSynthesizerService.java
@@ -1,0 +1,50 @@
+package com.marketinghub.oprm.nichocnae.v3.dailytaskssynthesizer.service;
+
+import com.marketinghub.oprm.nichocnae.v3.OprmNichoCnaeV3StageExecution;
+import com.marketinghub.oprm.nichocnae.v3.dailytaskssynthesizer.service.createStageExecution.DailyTasksSynthesizerCreateResponse;
+import com.marketinghub.oprm.nichocnae.v3.dailytaskssynthesizer.service.pending.DailyTasksSynthesizerPendingResponse;
+import com.marketinghub.oprm.nichocnae.v3.shared.OprmNichoCnaeV3StageServiceSupport;
+import com.marketinghub.repository.jpa.oprm.nichocnae.v3.OprmNichoCnaeV3StageExecutionRepository;
+import java.util.List;
+import org.springframework.stereotype.Service;
+
+/** Service canônico da etapa daily-tasks-synthesizer do pipeline NichoCNAE v3 no backend. */
+@Service
+public class BackendDailyTasksSynthesizerService extends OprmNichoCnaeV3StageServiceSupport {
+    private static final String STAGE_CODE = "daily-tasks-synthesizer";
+
+    /** Inicializa o service com repository canônico de execuções v3. */
+    public BackendDailyTasksSynthesizerService(OprmNichoCnaeV3StageExecutionRepository repository) {
+        super(repository, STAGE_CODE);
+    }
+
+    /** Cria pendência inicial ou encadeada para a etapa daily-tasks-synthesizer. */
+    public DailyTasksSynthesizerCreateResponse create(String jobId, String cnaeCode, String inputPayload, Integer attemptNumber, Integer knowledgeVersion) {
+        return toCreateResponse(doCreate(jobId, cnaeCode, inputPayload, attemptNumber, knowledgeVersion));
+    }
+
+    /** Lista pendências da etapa daily-tasks-synthesizer para o executor OPRM. */
+    public List<DailyTasksSynthesizerPendingResponse> pending() {
+        return pendingExecutions().stream().map(this::toPendingResponse).toList();
+    }
+
+    /** Registra conclusão da etapa daily-tasks-synthesizer. */
+    public DailyTasksSynthesizerCreateResponse complete(Long stageExecutionId, String outputPayload, String nextStageCode) {
+        return toCreateResponse(doComplete(stageExecutionId, outputPayload, nextStageCode));
+    }
+
+    /** Registra falha da etapa daily-tasks-synthesizer. */
+    public DailyTasksSynthesizerCreateResponse fail(Long stageExecutionId, String errorMessage) {
+        return toCreateResponse(doFail(stageExecutionId, errorMessage));
+    }
+
+    /** Converte entidade persistida em resposta de criação/conclusão/falha. */
+    private DailyTasksSynthesizerCreateResponse toCreateResponse(OprmNichoCnaeV3StageExecution execution) {
+        return new DailyTasksSynthesizerCreateResponse(execution.getId(), execution.getJobId(), execution.getCnaeCode(), execution.getStageCode(), execution.getStatus().name());
+    }
+
+    /** Converte entidade persistida em item pendente para executor externo. */
+    private DailyTasksSynthesizerPendingResponse toPendingResponse(OprmNichoCnaeV3StageExecution execution) {
+        return new DailyTasksSynthesizerPendingResponse(execution.getId(), execution.getJobId(), execution.getCnaeCode(), execution.getInputPayload(), execution.getAttemptNumber(), execution.getKnowledgeVersion());
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/dailytaskssynthesizer/service/completeStageExecution/DailyTasksSynthesizerCompletionRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/dailytaskssynthesizer/service/completeStageExecution/DailyTasksSynthesizerCompletionRequest.java
@@ -1,0 +1,4 @@
+package com.marketinghub.oprm.nichocnae.v3.dailytaskssynthesizer.service.completeStageExecution;
+
+/** Request de conclusão da etapa daily-tasks-synthesizer reportada pelo executor. */
+public record DailyTasksSynthesizerCompletionRequest(String outputPayload, String nextStageCode) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/dailytaskssynthesizer/service/createStageExecution/DailyTasksSynthesizerCreateResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/dailytaskssynthesizer/service/createStageExecution/DailyTasksSynthesizerCreateResponse.java
@@ -1,0 +1,4 @@
+package com.marketinghub.oprm.nichocnae.v3.dailytaskssynthesizer.service.createStageExecution;
+
+/** Resposta de criação de execução pendente da etapa daily-tasks-synthesizer. */
+public record DailyTasksSynthesizerCreateResponse(Long stageExecutionId, String jobId, String cnaeCode, String stageCode, String status) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/dailytaskssynthesizer/service/failStageExecution/DailyTasksSynthesizerFailureRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/dailytaskssynthesizer/service/failStageExecution/DailyTasksSynthesizerFailureRequest.java
@@ -1,0 +1,4 @@
+package com.marketinghub.oprm.nichocnae.v3.dailytaskssynthesizer.service.failStageExecution;
+
+/** Request de falha da etapa daily-tasks-synthesizer reportada pelo executor. */
+public record DailyTasksSynthesizerFailureRequest(String errorMessage) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/dailytaskssynthesizer/service/pending/DailyTasksSynthesizerPendingResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/dailytaskssynthesizer/service/pending/DailyTasksSynthesizerPendingResponse.java
@@ -1,0 +1,4 @@
+package com.marketinghub.oprm.nichocnae.v3.dailytaskssynthesizer.service.pending;
+
+/** Item pendente entregue ao executor para a etapa daily-tasks-synthesizer. */
+public record DailyTasksSynthesizerPendingResponse(Long stageExecutionId, String jobId, String cnaeCode, String inputPayload, Integer attemptNumber, Integer knowledgeVersion) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/personacandidategenerator/controller/BackendPersonaCandidateGeneratorController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/personacandidategenerator/controller/BackendPersonaCandidateGeneratorController.java
@@ -1,0 +1,56 @@
+package com.marketinghub.oprm.nichocnae.v3.personacandidategenerator.controller;
+
+import com.marketinghub.oprm.nichocnae.v3.personacandidategenerator.service.BackendPersonaCandidateGeneratorService;
+import com.marketinghub.oprm.nichocnae.v3.personacandidategenerator.service.completeStageExecution.PersonaCandidateGeneratorCompletionRequest;
+import com.marketinghub.oprm.nichocnae.v3.personacandidategenerator.service.createStageExecution.PersonaCandidateGeneratorCreateResponse;
+import com.marketinghub.oprm.nichocnae.v3.personacandidategenerator.service.failStageExecution.PersonaCandidateGeneratorFailureRequest;
+import com.marketinghub.oprm.nichocnae.v3.personacandidategenerator.service.pending.PersonaCandidateGeneratorPendingResponse;
+import java.util.List;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/** Controller canônico da etapa persona-candidate-generator do pipeline NichoCNAE v3. */
+@RestController
+@RequestMapping("/api/internal/oprm/nichocnae/v3/persona-candidate-generator/stage-executions")
+public class BackendPersonaCandidateGeneratorController {
+    private final BackendPersonaCandidateGeneratorService service;
+
+    /** Inicializa o controller com service canônico da etapa. */
+    public BackendPersonaCandidateGeneratorController(BackendPersonaCandidateGeneratorService service) {
+        this.service = service;
+    }
+
+    /** Cria uma execução pendente da etapa persona-candidate-generator. */
+    @PostMapping
+    public PersonaCandidateGeneratorCreateResponse create(@RequestBody PersonaCandidateGeneratorPendingResponse request) {
+        return service.create(request.jobId(), request.cnaeCode(), request.inputPayload(), request.attemptNumber(), request.knowledgeVersion());
+    }
+
+    /** Cria a primeira execução v3 diretamente a partir de um CNAE. */
+    @PostMapping("/cnaes/{cnaeCode}")
+    public PersonaCandidateGeneratorCreateResponse createForCnae(@PathVariable String cnaeCode) {
+        return service.create(null, cnaeCode, "{\"cnaeCode\":\"" + cnaeCode + "\"}", 1, 1);
+    }
+
+    /** Entrega pendências da etapa persona-candidate-generator ao executor OPRM. */
+    @GetMapping("/pending")
+    public List<PersonaCandidateGeneratorPendingResponse> pending() {
+        return service.pending();
+    }
+
+    /** Recebe conclusão da etapa persona-candidate-generator enviada pelo executor OPRM. */
+    @PostMapping("/{stageExecutionId}/complete")
+    public PersonaCandidateGeneratorCreateResponse complete(@PathVariable Long stageExecutionId, @RequestBody PersonaCandidateGeneratorCompletionRequest request) {
+        return service.complete(stageExecutionId, request.outputPayload(), request.nextStageCode());
+    }
+
+    /** Recebe falha da etapa persona-candidate-generator enviada pelo executor OPRM. */
+    @PostMapping("/{stageExecutionId}/fail")
+    public PersonaCandidateGeneratorCreateResponse fail(@PathVariable Long stageExecutionId, @RequestBody PersonaCandidateGeneratorFailureRequest request) {
+        return service.fail(stageExecutionId, request.errorMessage());
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/personacandidategenerator/service/BackendPersonaCandidateGeneratorService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/personacandidategenerator/service/BackendPersonaCandidateGeneratorService.java
@@ -1,0 +1,50 @@
+package com.marketinghub.oprm.nichocnae.v3.personacandidategenerator.service;
+
+import com.marketinghub.oprm.nichocnae.v3.OprmNichoCnaeV3StageExecution;
+import com.marketinghub.oprm.nichocnae.v3.personacandidategenerator.service.createStageExecution.PersonaCandidateGeneratorCreateResponse;
+import com.marketinghub.oprm.nichocnae.v3.personacandidategenerator.service.pending.PersonaCandidateGeneratorPendingResponse;
+import com.marketinghub.oprm.nichocnae.v3.shared.OprmNichoCnaeV3StageServiceSupport;
+import com.marketinghub.repository.jpa.oprm.nichocnae.v3.OprmNichoCnaeV3StageExecutionRepository;
+import java.util.List;
+import org.springframework.stereotype.Service;
+
+/** Service canônico da etapa persona-candidate-generator do pipeline NichoCNAE v3 no backend. */
+@Service
+public class BackendPersonaCandidateGeneratorService extends OprmNichoCnaeV3StageServiceSupport {
+    private static final String STAGE_CODE = "persona-candidate-generator";
+
+    /** Inicializa o service com repository canônico de execuções v3. */
+    public BackendPersonaCandidateGeneratorService(OprmNichoCnaeV3StageExecutionRepository repository) {
+        super(repository, STAGE_CODE);
+    }
+
+    /** Cria pendência inicial ou encadeada para a etapa persona-candidate-generator. */
+    public PersonaCandidateGeneratorCreateResponse create(String jobId, String cnaeCode, String inputPayload, Integer attemptNumber, Integer knowledgeVersion) {
+        return toCreateResponse(doCreate(jobId, cnaeCode, inputPayload, attemptNumber, knowledgeVersion));
+    }
+
+    /** Lista pendências da etapa persona-candidate-generator para o executor OPRM. */
+    public List<PersonaCandidateGeneratorPendingResponse> pending() {
+        return pendingExecutions().stream().map(this::toPendingResponse).toList();
+    }
+
+    /** Registra conclusão da etapa persona-candidate-generator. */
+    public PersonaCandidateGeneratorCreateResponse complete(Long stageExecutionId, String outputPayload, String nextStageCode) {
+        return toCreateResponse(doComplete(stageExecutionId, outputPayload, nextStageCode));
+    }
+
+    /** Registra falha da etapa persona-candidate-generator. */
+    public PersonaCandidateGeneratorCreateResponse fail(Long stageExecutionId, String errorMessage) {
+        return toCreateResponse(doFail(stageExecutionId, errorMessage));
+    }
+
+    /** Converte entidade persistida em resposta de criação/conclusão/falha. */
+    private PersonaCandidateGeneratorCreateResponse toCreateResponse(OprmNichoCnaeV3StageExecution execution) {
+        return new PersonaCandidateGeneratorCreateResponse(execution.getId(), execution.getJobId(), execution.getCnaeCode(), execution.getStageCode(), execution.getStatus().name());
+    }
+
+    /** Converte entidade persistida em item pendente para executor externo. */
+    private PersonaCandidateGeneratorPendingResponse toPendingResponse(OprmNichoCnaeV3StageExecution execution) {
+        return new PersonaCandidateGeneratorPendingResponse(execution.getId(), execution.getJobId(), execution.getCnaeCode(), execution.getInputPayload(), execution.getAttemptNumber(), execution.getKnowledgeVersion());
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/personacandidategenerator/service/completeStageExecution/PersonaCandidateGeneratorCompletionRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/personacandidategenerator/service/completeStageExecution/PersonaCandidateGeneratorCompletionRequest.java
@@ -1,0 +1,4 @@
+package com.marketinghub.oprm.nichocnae.v3.personacandidategenerator.service.completeStageExecution;
+
+/** Request de conclusão da etapa persona-candidate-generator reportada pelo executor. */
+public record PersonaCandidateGeneratorCompletionRequest(String outputPayload, String nextStageCode) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/personacandidategenerator/service/createStageExecution/PersonaCandidateGeneratorCreateResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/personacandidategenerator/service/createStageExecution/PersonaCandidateGeneratorCreateResponse.java
@@ -1,0 +1,4 @@
+package com.marketinghub.oprm.nichocnae.v3.personacandidategenerator.service.createStageExecution;
+
+/** Resposta de criação de execução pendente da etapa persona-candidate-generator. */
+public record PersonaCandidateGeneratorCreateResponse(Long stageExecutionId, String jobId, String cnaeCode, String stageCode, String status) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/personacandidategenerator/service/failStageExecution/PersonaCandidateGeneratorFailureRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/personacandidategenerator/service/failStageExecution/PersonaCandidateGeneratorFailureRequest.java
@@ -1,0 +1,4 @@
+package com.marketinghub.oprm.nichocnae.v3.personacandidategenerator.service.failStageExecution;
+
+/** Request de falha da etapa persona-candidate-generator reportada pelo executor. */
+public record PersonaCandidateGeneratorFailureRequest(String errorMessage) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/personacandidategenerator/service/pending/PersonaCandidateGeneratorPendingResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/personacandidategenerator/service/pending/PersonaCandidateGeneratorPendingResponse.java
@@ -1,0 +1,4 @@
+package com.marketinghub.oprm.nichocnae.v3.personacandidategenerator.service.pending;
+
+/** Item pendente entregue ao executor para a etapa persona-candidate-generator. */
+public record PersonaCandidateGeneratorPendingResponse(Long stageExecutionId, String jobId, String cnaeCode, String inputPayload, Integer attemptNumber, Integer knowledgeVersion) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/personaroutinematerializer/controller/BackendPersonaRoutineMaterializerController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/personaroutinematerializer/controller/BackendPersonaRoutineMaterializerController.java
@@ -1,0 +1,56 @@
+package com.marketinghub.oprm.nichocnae.v3.personaroutinematerializer.controller;
+
+import com.marketinghub.oprm.nichocnae.v3.personaroutinematerializer.service.BackendPersonaRoutineMaterializerService;
+import com.marketinghub.oprm.nichocnae.v3.personaroutinematerializer.service.completeStageExecution.PersonaRoutineMaterializerCompletionRequest;
+import com.marketinghub.oprm.nichocnae.v3.personaroutinematerializer.service.createStageExecution.PersonaRoutineMaterializerCreateResponse;
+import com.marketinghub.oprm.nichocnae.v3.personaroutinematerializer.service.failStageExecution.PersonaRoutineMaterializerFailureRequest;
+import com.marketinghub.oprm.nichocnae.v3.personaroutinematerializer.service.pending.PersonaRoutineMaterializerPendingResponse;
+import java.util.List;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/** Controller canônico da etapa persona-routine-materializer do pipeline NichoCNAE v3. */
+@RestController
+@RequestMapping("/api/internal/oprm/nichocnae/v3/persona-routine-materializer/stage-executions")
+public class BackendPersonaRoutineMaterializerController {
+    private final BackendPersonaRoutineMaterializerService service;
+
+    /** Inicializa o controller com service canônico da etapa. */
+    public BackendPersonaRoutineMaterializerController(BackendPersonaRoutineMaterializerService service) {
+        this.service = service;
+    }
+
+    /** Cria uma execução pendente da etapa persona-routine-materializer. */
+    @PostMapping
+    public PersonaRoutineMaterializerCreateResponse create(@RequestBody PersonaRoutineMaterializerPendingResponse request) {
+        return service.create(request.jobId(), request.cnaeCode(), request.inputPayload(), request.attemptNumber(), request.knowledgeVersion());
+    }
+
+    /** Cria a primeira execução v3 diretamente a partir de um CNAE. */
+    @PostMapping("/cnaes/{cnaeCode}")
+    public PersonaRoutineMaterializerCreateResponse createForCnae(@PathVariable String cnaeCode) {
+        return service.create(null, cnaeCode, "{\"cnaeCode\":\"" + cnaeCode + "\"}", 1, 1);
+    }
+
+    /** Entrega pendências da etapa persona-routine-materializer ao executor OPRM. */
+    @GetMapping("/pending")
+    public List<PersonaRoutineMaterializerPendingResponse> pending() {
+        return service.pending();
+    }
+
+    /** Recebe conclusão da etapa persona-routine-materializer enviada pelo executor OPRM. */
+    @PostMapping("/{stageExecutionId}/complete")
+    public PersonaRoutineMaterializerCreateResponse complete(@PathVariable Long stageExecutionId, @RequestBody PersonaRoutineMaterializerCompletionRequest request) {
+        return service.complete(stageExecutionId, request.outputPayload(), request.nextStageCode());
+    }
+
+    /** Recebe falha da etapa persona-routine-materializer enviada pelo executor OPRM. */
+    @PostMapping("/{stageExecutionId}/fail")
+    public PersonaRoutineMaterializerCreateResponse fail(@PathVariable Long stageExecutionId, @RequestBody PersonaRoutineMaterializerFailureRequest request) {
+        return service.fail(stageExecutionId, request.errorMessage());
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/personaroutinematerializer/service/BackendPersonaRoutineMaterializerService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/personaroutinematerializer/service/BackendPersonaRoutineMaterializerService.java
@@ -1,0 +1,50 @@
+package com.marketinghub.oprm.nichocnae.v3.personaroutinematerializer.service;
+
+import com.marketinghub.oprm.nichocnae.v3.OprmNichoCnaeV3StageExecution;
+import com.marketinghub.oprm.nichocnae.v3.personaroutinematerializer.service.createStageExecution.PersonaRoutineMaterializerCreateResponse;
+import com.marketinghub.oprm.nichocnae.v3.personaroutinematerializer.service.pending.PersonaRoutineMaterializerPendingResponse;
+import com.marketinghub.oprm.nichocnae.v3.shared.OprmNichoCnaeV3StageServiceSupport;
+import com.marketinghub.repository.jpa.oprm.nichocnae.v3.OprmNichoCnaeV3StageExecutionRepository;
+import java.util.List;
+import org.springframework.stereotype.Service;
+
+/** Service canônico da etapa persona-routine-materializer do pipeline NichoCNAE v3 no backend. */
+@Service
+public class BackendPersonaRoutineMaterializerService extends OprmNichoCnaeV3StageServiceSupport {
+    private static final String STAGE_CODE = "persona-routine-materializer";
+
+    /** Inicializa o service com repository canônico de execuções v3. */
+    public BackendPersonaRoutineMaterializerService(OprmNichoCnaeV3StageExecutionRepository repository) {
+        super(repository, STAGE_CODE);
+    }
+
+    /** Cria pendência inicial ou encadeada para a etapa persona-routine-materializer. */
+    public PersonaRoutineMaterializerCreateResponse create(String jobId, String cnaeCode, String inputPayload, Integer attemptNumber, Integer knowledgeVersion) {
+        return toCreateResponse(doCreate(jobId, cnaeCode, inputPayload, attemptNumber, knowledgeVersion));
+    }
+
+    /** Lista pendências da etapa persona-routine-materializer para o executor OPRM. */
+    public List<PersonaRoutineMaterializerPendingResponse> pending() {
+        return pendingExecutions().stream().map(this::toPendingResponse).toList();
+    }
+
+    /** Registra conclusão da etapa persona-routine-materializer. */
+    public PersonaRoutineMaterializerCreateResponse complete(Long stageExecutionId, String outputPayload, String nextStageCode) {
+        return toCreateResponse(doComplete(stageExecutionId, outputPayload, nextStageCode));
+    }
+
+    /** Registra falha da etapa persona-routine-materializer. */
+    public PersonaRoutineMaterializerCreateResponse fail(Long stageExecutionId, String errorMessage) {
+        return toCreateResponse(doFail(stageExecutionId, errorMessage));
+    }
+
+    /** Converte entidade persistida em resposta de criação/conclusão/falha. */
+    private PersonaRoutineMaterializerCreateResponse toCreateResponse(OprmNichoCnaeV3StageExecution execution) {
+        return new PersonaRoutineMaterializerCreateResponse(execution.getId(), execution.getJobId(), execution.getCnaeCode(), execution.getStageCode(), execution.getStatus().name());
+    }
+
+    /** Converte entidade persistida em item pendente para executor externo. */
+    private PersonaRoutineMaterializerPendingResponse toPendingResponse(OprmNichoCnaeV3StageExecution execution) {
+        return new PersonaRoutineMaterializerPendingResponse(execution.getId(), execution.getJobId(), execution.getCnaeCode(), execution.getInputPayload(), execution.getAttemptNumber(), execution.getKnowledgeVersion());
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/personaroutinematerializer/service/completeStageExecution/PersonaRoutineMaterializerCompletionRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/personaroutinematerializer/service/completeStageExecution/PersonaRoutineMaterializerCompletionRequest.java
@@ -1,0 +1,4 @@
+package com.marketinghub.oprm.nichocnae.v3.personaroutinematerializer.service.completeStageExecution;
+
+/** Request de conclusão da etapa persona-routine-materializer reportada pelo executor. */
+public record PersonaRoutineMaterializerCompletionRequest(String outputPayload, String nextStageCode) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/personaroutinematerializer/service/createStageExecution/PersonaRoutineMaterializerCreateResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/personaroutinematerializer/service/createStageExecution/PersonaRoutineMaterializerCreateResponse.java
@@ -1,0 +1,4 @@
+package com.marketinghub.oprm.nichocnae.v3.personaroutinematerializer.service.createStageExecution;
+
+/** Resposta de criação de execução pendente da etapa persona-routine-materializer. */
+public record PersonaRoutineMaterializerCreateResponse(Long stageExecutionId, String jobId, String cnaeCode, String stageCode, String status) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/personaroutinematerializer/service/failStageExecution/PersonaRoutineMaterializerFailureRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/personaroutinematerializer/service/failStageExecution/PersonaRoutineMaterializerFailureRequest.java
@@ -1,0 +1,4 @@
+package com.marketinghub.oprm.nichocnae.v3.personaroutinematerializer.service.failStageExecution;
+
+/** Request de falha da etapa persona-routine-materializer reportada pelo executor. */
+public record PersonaRoutineMaterializerFailureRequest(String errorMessage) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/personaroutinematerializer/service/pending/PersonaRoutineMaterializerPendingResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/personaroutinematerializer/service/pending/PersonaRoutineMaterializerPendingResponse.java
@@ -1,0 +1,4 @@
+package com.marketinghub.oprm.nichocnae.v3.personaroutinematerializer.service.pending;
+
+/** Item pendente entregue ao executor para a etapa persona-routine-materializer. */
+public record PersonaRoutineMaterializerPendingResponse(Long stageExecutionId, String jobId, String cnaeCode, String inputPayload, Integer attemptNumber, Integer knowledgeVersion) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/personatournament/controller/BackendPersonaTournamentController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/personatournament/controller/BackendPersonaTournamentController.java
@@ -1,0 +1,56 @@
+package com.marketinghub.oprm.nichocnae.v3.personatournament.controller;
+
+import com.marketinghub.oprm.nichocnae.v3.personatournament.service.BackendPersonaTournamentService;
+import com.marketinghub.oprm.nichocnae.v3.personatournament.service.completeStageExecution.PersonaTournamentCompletionRequest;
+import com.marketinghub.oprm.nichocnae.v3.personatournament.service.createStageExecution.PersonaTournamentCreateResponse;
+import com.marketinghub.oprm.nichocnae.v3.personatournament.service.failStageExecution.PersonaTournamentFailureRequest;
+import com.marketinghub.oprm.nichocnae.v3.personatournament.service.pending.PersonaTournamentPendingResponse;
+import java.util.List;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/** Controller canônico da etapa persona-tournament do pipeline NichoCNAE v3. */
+@RestController
+@RequestMapping("/api/internal/oprm/nichocnae/v3/persona-tournament/stage-executions")
+public class BackendPersonaTournamentController {
+    private final BackendPersonaTournamentService service;
+
+    /** Inicializa o controller com service canônico da etapa. */
+    public BackendPersonaTournamentController(BackendPersonaTournamentService service) {
+        this.service = service;
+    }
+
+    /** Cria uma execução pendente da etapa persona-tournament. */
+    @PostMapping
+    public PersonaTournamentCreateResponse create(@RequestBody PersonaTournamentPendingResponse request) {
+        return service.create(request.jobId(), request.cnaeCode(), request.inputPayload(), request.attemptNumber(), request.knowledgeVersion());
+    }
+
+    /** Cria a primeira execução v3 diretamente a partir de um CNAE. */
+    @PostMapping("/cnaes/{cnaeCode}")
+    public PersonaTournamentCreateResponse createForCnae(@PathVariable String cnaeCode) {
+        return service.create(null, cnaeCode, "{\"cnaeCode\":\"" + cnaeCode + "\"}", 1, 1);
+    }
+
+    /** Entrega pendências da etapa persona-tournament ao executor OPRM. */
+    @GetMapping("/pending")
+    public List<PersonaTournamentPendingResponse> pending() {
+        return service.pending();
+    }
+
+    /** Recebe conclusão da etapa persona-tournament enviada pelo executor OPRM. */
+    @PostMapping("/{stageExecutionId}/complete")
+    public PersonaTournamentCreateResponse complete(@PathVariable Long stageExecutionId, @RequestBody PersonaTournamentCompletionRequest request) {
+        return service.complete(stageExecutionId, request.outputPayload(), request.nextStageCode());
+    }
+
+    /** Recebe falha da etapa persona-tournament enviada pelo executor OPRM. */
+    @PostMapping("/{stageExecutionId}/fail")
+    public PersonaTournamentCreateResponse fail(@PathVariable Long stageExecutionId, @RequestBody PersonaTournamentFailureRequest request) {
+        return service.fail(stageExecutionId, request.errorMessage());
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/personatournament/service/BackendPersonaTournamentService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/personatournament/service/BackendPersonaTournamentService.java
@@ -1,0 +1,50 @@
+package com.marketinghub.oprm.nichocnae.v3.personatournament.service;
+
+import com.marketinghub.oprm.nichocnae.v3.OprmNichoCnaeV3StageExecution;
+import com.marketinghub.oprm.nichocnae.v3.personatournament.service.createStageExecution.PersonaTournamentCreateResponse;
+import com.marketinghub.oprm.nichocnae.v3.personatournament.service.pending.PersonaTournamentPendingResponse;
+import com.marketinghub.oprm.nichocnae.v3.shared.OprmNichoCnaeV3StageServiceSupport;
+import com.marketinghub.repository.jpa.oprm.nichocnae.v3.OprmNichoCnaeV3StageExecutionRepository;
+import java.util.List;
+import org.springframework.stereotype.Service;
+
+/** Service canônico da etapa persona-tournament do pipeline NichoCNAE v3 no backend. */
+@Service
+public class BackendPersonaTournamentService extends OprmNichoCnaeV3StageServiceSupport {
+    private static final String STAGE_CODE = "persona-tournament";
+
+    /** Inicializa o service com repository canônico de execuções v3. */
+    public BackendPersonaTournamentService(OprmNichoCnaeV3StageExecutionRepository repository) {
+        super(repository, STAGE_CODE);
+    }
+
+    /** Cria pendência inicial ou encadeada para a etapa persona-tournament. */
+    public PersonaTournamentCreateResponse create(String jobId, String cnaeCode, String inputPayload, Integer attemptNumber, Integer knowledgeVersion) {
+        return toCreateResponse(doCreate(jobId, cnaeCode, inputPayload, attemptNumber, knowledgeVersion));
+    }
+
+    /** Lista pendências da etapa persona-tournament para o executor OPRM. */
+    public List<PersonaTournamentPendingResponse> pending() {
+        return pendingExecutions().stream().map(this::toPendingResponse).toList();
+    }
+
+    /** Registra conclusão da etapa persona-tournament. */
+    public PersonaTournamentCreateResponse complete(Long stageExecutionId, String outputPayload, String nextStageCode) {
+        return toCreateResponse(doComplete(stageExecutionId, outputPayload, nextStageCode));
+    }
+
+    /** Registra falha da etapa persona-tournament. */
+    public PersonaTournamentCreateResponse fail(Long stageExecutionId, String errorMessage) {
+        return toCreateResponse(doFail(stageExecutionId, errorMessage));
+    }
+
+    /** Converte entidade persistida em resposta de criação/conclusão/falha. */
+    private PersonaTournamentCreateResponse toCreateResponse(OprmNichoCnaeV3StageExecution execution) {
+        return new PersonaTournamentCreateResponse(execution.getId(), execution.getJobId(), execution.getCnaeCode(), execution.getStageCode(), execution.getStatus().name());
+    }
+
+    /** Converte entidade persistida em item pendente para executor externo. */
+    private PersonaTournamentPendingResponse toPendingResponse(OprmNichoCnaeV3StageExecution execution) {
+        return new PersonaTournamentPendingResponse(execution.getId(), execution.getJobId(), execution.getCnaeCode(), execution.getInputPayload(), execution.getAttemptNumber(), execution.getKnowledgeVersion());
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/personatournament/service/completeStageExecution/PersonaTournamentCompletionRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/personatournament/service/completeStageExecution/PersonaTournamentCompletionRequest.java
@@ -1,0 +1,4 @@
+package com.marketinghub.oprm.nichocnae.v3.personatournament.service.completeStageExecution;
+
+/** Request de conclusão da etapa persona-tournament reportada pelo executor. */
+public record PersonaTournamentCompletionRequest(String outputPayload, String nextStageCode) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/personatournament/service/createStageExecution/PersonaTournamentCreateResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/personatournament/service/createStageExecution/PersonaTournamentCreateResponse.java
@@ -1,0 +1,4 @@
+package com.marketinghub.oprm.nichocnae.v3.personatournament.service.createStageExecution;
+
+/** Resposta de criação de execução pendente da etapa persona-tournament. */
+public record PersonaTournamentCreateResponse(Long stageExecutionId, String jobId, String cnaeCode, String stageCode, String status) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/personatournament/service/failStageExecution/PersonaTournamentFailureRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/personatournament/service/failStageExecution/PersonaTournamentFailureRequest.java
@@ -1,0 +1,4 @@
+package com.marketinghub.oprm.nichocnae.v3.personatournament.service.failStageExecution;
+
+/** Request de falha da etapa persona-tournament reportada pelo executor. */
+public record PersonaTournamentFailureRequest(String errorMessage) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/personatournament/service/pending/PersonaTournamentPendingResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/personatournament/service/pending/PersonaTournamentPendingResponse.java
@@ -1,0 +1,4 @@
+package com.marketinghub.oprm.nichocnae.v3.personatournament.service.pending;
+
+/** Item pendente entregue ao executor para a etapa persona-tournament. */
+public record PersonaTournamentPendingResponse(Long stageExecutionId, String jobId, String cnaeCode, String inputPayload, Integer attemptNumber, Integer knowledgeVersion) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/qualitygate/controller/BackendQualityGateController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/qualitygate/controller/BackendQualityGateController.java
@@ -1,0 +1,56 @@
+package com.marketinghub.oprm.nichocnae.v3.qualitygate.controller;
+
+import com.marketinghub.oprm.nichocnae.v3.qualitygate.service.BackendQualityGateService;
+import com.marketinghub.oprm.nichocnae.v3.qualitygate.service.completeStageExecution.QualityGateCompletionRequest;
+import com.marketinghub.oprm.nichocnae.v3.qualitygate.service.createStageExecution.QualityGateCreateResponse;
+import com.marketinghub.oprm.nichocnae.v3.qualitygate.service.failStageExecution.QualityGateFailureRequest;
+import com.marketinghub.oprm.nichocnae.v3.qualitygate.service.pending.QualityGatePendingResponse;
+import java.util.List;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/** Controller canônico da etapa quality-gate do pipeline NichoCNAE v3. */
+@RestController
+@RequestMapping("/api/internal/oprm/nichocnae/v3/quality-gate/stage-executions")
+public class BackendQualityGateController {
+    private final BackendQualityGateService service;
+
+    /** Inicializa o controller com service canônico da etapa. */
+    public BackendQualityGateController(BackendQualityGateService service) {
+        this.service = service;
+    }
+
+    /** Cria uma execução pendente da etapa quality-gate. */
+    @PostMapping
+    public QualityGateCreateResponse create(@RequestBody QualityGatePendingResponse request) {
+        return service.create(request.jobId(), request.cnaeCode(), request.inputPayload(), request.attemptNumber(), request.knowledgeVersion());
+    }
+
+    /** Cria a primeira execução v3 diretamente a partir de um CNAE. */
+    @PostMapping("/cnaes/{cnaeCode}")
+    public QualityGateCreateResponse createForCnae(@PathVariable String cnaeCode) {
+        return service.create(null, cnaeCode, "{\"cnaeCode\":\"" + cnaeCode + "\"}", 1, 1);
+    }
+
+    /** Entrega pendências da etapa quality-gate ao executor OPRM. */
+    @GetMapping("/pending")
+    public List<QualityGatePendingResponse> pending() {
+        return service.pending();
+    }
+
+    /** Recebe conclusão da etapa quality-gate enviada pelo executor OPRM. */
+    @PostMapping("/{stageExecutionId}/complete")
+    public QualityGateCreateResponse complete(@PathVariable Long stageExecutionId, @RequestBody QualityGateCompletionRequest request) {
+        return service.complete(stageExecutionId, request.outputPayload(), request.nextStageCode());
+    }
+
+    /** Recebe falha da etapa quality-gate enviada pelo executor OPRM. */
+    @PostMapping("/{stageExecutionId}/fail")
+    public QualityGateCreateResponse fail(@PathVariable Long stageExecutionId, @RequestBody QualityGateFailureRequest request) {
+        return service.fail(stageExecutionId, request.errorMessage());
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/qualitygate/service/BackendQualityGateService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/qualitygate/service/BackendQualityGateService.java
@@ -1,0 +1,50 @@
+package com.marketinghub.oprm.nichocnae.v3.qualitygate.service;
+
+import com.marketinghub.oprm.nichocnae.v3.OprmNichoCnaeV3StageExecution;
+import com.marketinghub.oprm.nichocnae.v3.qualitygate.service.createStageExecution.QualityGateCreateResponse;
+import com.marketinghub.oprm.nichocnae.v3.qualitygate.service.pending.QualityGatePendingResponse;
+import com.marketinghub.oprm.nichocnae.v3.shared.OprmNichoCnaeV3StageServiceSupport;
+import com.marketinghub.repository.jpa.oprm.nichocnae.v3.OprmNichoCnaeV3StageExecutionRepository;
+import java.util.List;
+import org.springframework.stereotype.Service;
+
+/** Service canônico da etapa quality-gate do pipeline NichoCNAE v3 no backend. */
+@Service
+public class BackendQualityGateService extends OprmNichoCnaeV3StageServiceSupport {
+    private static final String STAGE_CODE = "quality-gate";
+
+    /** Inicializa o service com repository canônico de execuções v3. */
+    public BackendQualityGateService(OprmNichoCnaeV3StageExecutionRepository repository) {
+        super(repository, STAGE_CODE);
+    }
+
+    /** Cria pendência inicial ou encadeada para a etapa quality-gate. */
+    public QualityGateCreateResponse create(String jobId, String cnaeCode, String inputPayload, Integer attemptNumber, Integer knowledgeVersion) {
+        return toCreateResponse(doCreate(jobId, cnaeCode, inputPayload, attemptNumber, knowledgeVersion));
+    }
+
+    /** Lista pendências da etapa quality-gate para o executor OPRM. */
+    public List<QualityGatePendingResponse> pending() {
+        return pendingExecutions().stream().map(this::toPendingResponse).toList();
+    }
+
+    /** Registra conclusão da etapa quality-gate. */
+    public QualityGateCreateResponse complete(Long stageExecutionId, String outputPayload, String nextStageCode) {
+        return toCreateResponse(doComplete(stageExecutionId, outputPayload, nextStageCode));
+    }
+
+    /** Registra falha da etapa quality-gate. */
+    public QualityGateCreateResponse fail(Long stageExecutionId, String errorMessage) {
+        return toCreateResponse(doFail(stageExecutionId, errorMessage));
+    }
+
+    /** Converte entidade persistida em resposta de criação/conclusão/falha. */
+    private QualityGateCreateResponse toCreateResponse(OprmNichoCnaeV3StageExecution execution) {
+        return new QualityGateCreateResponse(execution.getId(), execution.getJobId(), execution.getCnaeCode(), execution.getStageCode(), execution.getStatus().name());
+    }
+
+    /** Converte entidade persistida em item pendente para executor externo. */
+    private QualityGatePendingResponse toPendingResponse(OprmNichoCnaeV3StageExecution execution) {
+        return new QualityGatePendingResponse(execution.getId(), execution.getJobId(), execution.getCnaeCode(), execution.getInputPayload(), execution.getAttemptNumber(), execution.getKnowledgeVersion());
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/qualitygate/service/completeStageExecution/QualityGateCompletionRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/qualitygate/service/completeStageExecution/QualityGateCompletionRequest.java
@@ -1,0 +1,4 @@
+package com.marketinghub.oprm.nichocnae.v3.qualitygate.service.completeStageExecution;
+
+/** Request de conclusão da etapa quality-gate reportada pelo executor. */
+public record QualityGateCompletionRequest(String outputPayload, String nextStageCode) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/qualitygate/service/createStageExecution/QualityGateCreateResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/qualitygate/service/createStageExecution/QualityGateCreateResponse.java
@@ -1,0 +1,4 @@
+package com.marketinghub.oprm.nichocnae.v3.qualitygate.service.createStageExecution;
+
+/** Resposta de criação de execução pendente da etapa quality-gate. */
+public record QualityGateCreateResponse(Long stageExecutionId, String jobId, String cnaeCode, String stageCode, String status) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/qualitygate/service/failStageExecution/QualityGateFailureRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/qualitygate/service/failStageExecution/QualityGateFailureRequest.java
@@ -1,0 +1,4 @@
+package com.marketinghub.oprm.nichocnae.v3.qualitygate.service.failStageExecution;
+
+/** Request de falha da etapa quality-gate reportada pelo executor. */
+public record QualityGateFailureRequest(String errorMessage) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/qualitygate/service/pending/QualityGatePendingResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/qualitygate/service/pending/QualityGatePendingResponse.java
@@ -1,0 +1,4 @@
+package com.marketinghub.oprm.nichocnae.v3.qualitygate.service.pending;
+
+/** Item pendente entregue ao executor para a etapa quality-gate. */
+public record QualityGatePendingResponse(Long stageExecutionId, String jobId, String cnaeCode, String inputPayload, Integer attemptNumber, Integer knowledgeVersion) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/routinequeryplanner/controller/BackendRoutineQueryPlannerController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/routinequeryplanner/controller/BackendRoutineQueryPlannerController.java
@@ -1,0 +1,56 @@
+package com.marketinghub.oprm.nichocnae.v3.routinequeryplanner.controller;
+
+import com.marketinghub.oprm.nichocnae.v3.routinequeryplanner.service.BackendRoutineQueryPlannerService;
+import com.marketinghub.oprm.nichocnae.v3.routinequeryplanner.service.completeStageExecution.RoutineQueryPlannerCompletionRequest;
+import com.marketinghub.oprm.nichocnae.v3.routinequeryplanner.service.createStageExecution.RoutineQueryPlannerCreateResponse;
+import com.marketinghub.oprm.nichocnae.v3.routinequeryplanner.service.failStageExecution.RoutineQueryPlannerFailureRequest;
+import com.marketinghub.oprm.nichocnae.v3.routinequeryplanner.service.pending.RoutineQueryPlannerPendingResponse;
+import java.util.List;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/** Controller canônico da etapa routine-query-planner do pipeline NichoCNAE v3. */
+@RestController
+@RequestMapping("/api/internal/oprm/nichocnae/v3/routine-query-planner/stage-executions")
+public class BackendRoutineQueryPlannerController {
+    private final BackendRoutineQueryPlannerService service;
+
+    /** Inicializa o controller com service canônico da etapa. */
+    public BackendRoutineQueryPlannerController(BackendRoutineQueryPlannerService service) {
+        this.service = service;
+    }
+
+    /** Cria uma execução pendente da etapa routine-query-planner. */
+    @PostMapping
+    public RoutineQueryPlannerCreateResponse create(@RequestBody RoutineQueryPlannerPendingResponse request) {
+        return service.create(request.jobId(), request.cnaeCode(), request.inputPayload(), request.attemptNumber(), request.knowledgeVersion());
+    }
+
+    /** Cria a primeira execução v3 diretamente a partir de um CNAE. */
+    @PostMapping("/cnaes/{cnaeCode}")
+    public RoutineQueryPlannerCreateResponse createForCnae(@PathVariable String cnaeCode) {
+        return service.create(null, cnaeCode, "{\"cnaeCode\":\"" + cnaeCode + "\"}", 1, 1);
+    }
+
+    /** Entrega pendências da etapa routine-query-planner ao executor OPRM. */
+    @GetMapping("/pending")
+    public List<RoutineQueryPlannerPendingResponse> pending() {
+        return service.pending();
+    }
+
+    /** Recebe conclusão da etapa routine-query-planner enviada pelo executor OPRM. */
+    @PostMapping("/{stageExecutionId}/complete")
+    public RoutineQueryPlannerCreateResponse complete(@PathVariable Long stageExecutionId, @RequestBody RoutineQueryPlannerCompletionRequest request) {
+        return service.complete(stageExecutionId, request.outputPayload(), request.nextStageCode());
+    }
+
+    /** Recebe falha da etapa routine-query-planner enviada pelo executor OPRM. */
+    @PostMapping("/{stageExecutionId}/fail")
+    public RoutineQueryPlannerCreateResponse fail(@PathVariable Long stageExecutionId, @RequestBody RoutineQueryPlannerFailureRequest request) {
+        return service.fail(stageExecutionId, request.errorMessage());
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/routinequeryplanner/service/BackendRoutineQueryPlannerService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/routinequeryplanner/service/BackendRoutineQueryPlannerService.java
@@ -1,0 +1,50 @@
+package com.marketinghub.oprm.nichocnae.v3.routinequeryplanner.service;
+
+import com.marketinghub.oprm.nichocnae.v3.OprmNichoCnaeV3StageExecution;
+import com.marketinghub.oprm.nichocnae.v3.routinequeryplanner.service.createStageExecution.RoutineQueryPlannerCreateResponse;
+import com.marketinghub.oprm.nichocnae.v3.routinequeryplanner.service.pending.RoutineQueryPlannerPendingResponse;
+import com.marketinghub.oprm.nichocnae.v3.shared.OprmNichoCnaeV3StageServiceSupport;
+import com.marketinghub.repository.jpa.oprm.nichocnae.v3.OprmNichoCnaeV3StageExecutionRepository;
+import java.util.List;
+import org.springframework.stereotype.Service;
+
+/** Service canônico da etapa routine-query-planner do pipeline NichoCNAE v3 no backend. */
+@Service
+public class BackendRoutineQueryPlannerService extends OprmNichoCnaeV3StageServiceSupport {
+    private static final String STAGE_CODE = "routine-query-planner";
+
+    /** Inicializa o service com repository canônico de execuções v3. */
+    public BackendRoutineQueryPlannerService(OprmNichoCnaeV3StageExecutionRepository repository) {
+        super(repository, STAGE_CODE);
+    }
+
+    /** Cria pendência inicial ou encadeada para a etapa routine-query-planner. */
+    public RoutineQueryPlannerCreateResponse create(String jobId, String cnaeCode, String inputPayload, Integer attemptNumber, Integer knowledgeVersion) {
+        return toCreateResponse(doCreate(jobId, cnaeCode, inputPayload, attemptNumber, knowledgeVersion));
+    }
+
+    /** Lista pendências da etapa routine-query-planner para o executor OPRM. */
+    public List<RoutineQueryPlannerPendingResponse> pending() {
+        return pendingExecutions().stream().map(this::toPendingResponse).toList();
+    }
+
+    /** Registra conclusão da etapa routine-query-planner. */
+    public RoutineQueryPlannerCreateResponse complete(Long stageExecutionId, String outputPayload, String nextStageCode) {
+        return toCreateResponse(doComplete(stageExecutionId, outputPayload, nextStageCode));
+    }
+
+    /** Registra falha da etapa routine-query-planner. */
+    public RoutineQueryPlannerCreateResponse fail(Long stageExecutionId, String errorMessage) {
+        return toCreateResponse(doFail(stageExecutionId, errorMessage));
+    }
+
+    /** Converte entidade persistida em resposta de criação/conclusão/falha. */
+    private RoutineQueryPlannerCreateResponse toCreateResponse(OprmNichoCnaeV3StageExecution execution) {
+        return new RoutineQueryPlannerCreateResponse(execution.getId(), execution.getJobId(), execution.getCnaeCode(), execution.getStageCode(), execution.getStatus().name());
+    }
+
+    /** Converte entidade persistida em item pendente para executor externo. */
+    private RoutineQueryPlannerPendingResponse toPendingResponse(OprmNichoCnaeV3StageExecution execution) {
+        return new RoutineQueryPlannerPendingResponse(execution.getId(), execution.getJobId(), execution.getCnaeCode(), execution.getInputPayload(), execution.getAttemptNumber(), execution.getKnowledgeVersion());
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/routinequeryplanner/service/completeStageExecution/RoutineQueryPlannerCompletionRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/routinequeryplanner/service/completeStageExecution/RoutineQueryPlannerCompletionRequest.java
@@ -1,0 +1,4 @@
+package com.marketinghub.oprm.nichocnae.v3.routinequeryplanner.service.completeStageExecution;
+
+/** Request de conclusão da etapa routine-query-planner reportada pelo executor. */
+public record RoutineQueryPlannerCompletionRequest(String outputPayload, String nextStageCode) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/routinequeryplanner/service/createStageExecution/RoutineQueryPlannerCreateResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/routinequeryplanner/service/createStageExecution/RoutineQueryPlannerCreateResponse.java
@@ -1,0 +1,4 @@
+package com.marketinghub.oprm.nichocnae.v3.routinequeryplanner.service.createStageExecution;
+
+/** Resposta de criação de execução pendente da etapa routine-query-planner. */
+public record RoutineQueryPlannerCreateResponse(Long stageExecutionId, String jobId, String cnaeCode, String stageCode, String status) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/routinequeryplanner/service/failStageExecution/RoutineQueryPlannerFailureRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/routinequeryplanner/service/failStageExecution/RoutineQueryPlannerFailureRequest.java
@@ -1,0 +1,4 @@
+package com.marketinghub.oprm.nichocnae.v3.routinequeryplanner.service.failStageExecution;
+
+/** Request de falha da etapa routine-query-planner reportada pelo executor. */
+public record RoutineQueryPlannerFailureRequest(String errorMessage) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/routinequeryplanner/service/pending/RoutineQueryPlannerPendingResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/routinequeryplanner/service/pending/RoutineQueryPlannerPendingResponse.java
@@ -1,0 +1,4 @@
+package com.marketinghub.oprm.nichocnae.v3.routinequeryplanner.service.pending;
+
+/** Item pendente entregue ao executor para a etapa routine-query-planner. */
+public record RoutineQueryPlannerPendingResponse(Long stageExecutionId, String jobId, String cnaeCode, String inputPayload, Integer attemptNumber, Integer knowledgeVersion) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/routinesignalextractor/controller/BackendRoutineSignalExtractorController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/routinesignalextractor/controller/BackendRoutineSignalExtractorController.java
@@ -1,0 +1,56 @@
+package com.marketinghub.oprm.nichocnae.v3.routinesignalextractor.controller;
+
+import com.marketinghub.oprm.nichocnae.v3.routinesignalextractor.service.BackendRoutineSignalExtractorService;
+import com.marketinghub.oprm.nichocnae.v3.routinesignalextractor.service.completeStageExecution.RoutineSignalExtractorCompletionRequest;
+import com.marketinghub.oprm.nichocnae.v3.routinesignalextractor.service.createStageExecution.RoutineSignalExtractorCreateResponse;
+import com.marketinghub.oprm.nichocnae.v3.routinesignalextractor.service.failStageExecution.RoutineSignalExtractorFailureRequest;
+import com.marketinghub.oprm.nichocnae.v3.routinesignalextractor.service.pending.RoutineSignalExtractorPendingResponse;
+import java.util.List;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/** Controller canônico da etapa routine-signal-extractor do pipeline NichoCNAE v3. */
+@RestController
+@RequestMapping("/api/internal/oprm/nichocnae/v3/routine-signal-extractor/stage-executions")
+public class BackendRoutineSignalExtractorController {
+    private final BackendRoutineSignalExtractorService service;
+
+    /** Inicializa o controller com service canônico da etapa. */
+    public BackendRoutineSignalExtractorController(BackendRoutineSignalExtractorService service) {
+        this.service = service;
+    }
+
+    /** Cria uma execução pendente da etapa routine-signal-extractor. */
+    @PostMapping
+    public RoutineSignalExtractorCreateResponse create(@RequestBody RoutineSignalExtractorPendingResponse request) {
+        return service.create(request.jobId(), request.cnaeCode(), request.inputPayload(), request.attemptNumber(), request.knowledgeVersion());
+    }
+
+    /** Cria a primeira execução v3 diretamente a partir de um CNAE. */
+    @PostMapping("/cnaes/{cnaeCode}")
+    public RoutineSignalExtractorCreateResponse createForCnae(@PathVariable String cnaeCode) {
+        return service.create(null, cnaeCode, "{\"cnaeCode\":\"" + cnaeCode + "\"}", 1, 1);
+    }
+
+    /** Entrega pendências da etapa routine-signal-extractor ao executor OPRM. */
+    @GetMapping("/pending")
+    public List<RoutineSignalExtractorPendingResponse> pending() {
+        return service.pending();
+    }
+
+    /** Recebe conclusão da etapa routine-signal-extractor enviada pelo executor OPRM. */
+    @PostMapping("/{stageExecutionId}/complete")
+    public RoutineSignalExtractorCreateResponse complete(@PathVariable Long stageExecutionId, @RequestBody RoutineSignalExtractorCompletionRequest request) {
+        return service.complete(stageExecutionId, request.outputPayload(), request.nextStageCode());
+    }
+
+    /** Recebe falha da etapa routine-signal-extractor enviada pelo executor OPRM. */
+    @PostMapping("/{stageExecutionId}/fail")
+    public RoutineSignalExtractorCreateResponse fail(@PathVariable Long stageExecutionId, @RequestBody RoutineSignalExtractorFailureRequest request) {
+        return service.fail(stageExecutionId, request.errorMessage());
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/routinesignalextractor/service/BackendRoutineSignalExtractorService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/routinesignalextractor/service/BackendRoutineSignalExtractorService.java
@@ -1,0 +1,50 @@
+package com.marketinghub.oprm.nichocnae.v3.routinesignalextractor.service;
+
+import com.marketinghub.oprm.nichocnae.v3.OprmNichoCnaeV3StageExecution;
+import com.marketinghub.oprm.nichocnae.v3.routinesignalextractor.service.createStageExecution.RoutineSignalExtractorCreateResponse;
+import com.marketinghub.oprm.nichocnae.v3.routinesignalextractor.service.pending.RoutineSignalExtractorPendingResponse;
+import com.marketinghub.oprm.nichocnae.v3.shared.OprmNichoCnaeV3StageServiceSupport;
+import com.marketinghub.repository.jpa.oprm.nichocnae.v3.OprmNichoCnaeV3StageExecutionRepository;
+import java.util.List;
+import org.springframework.stereotype.Service;
+
+/** Service canônico da etapa routine-signal-extractor do pipeline NichoCNAE v3 no backend. */
+@Service
+public class BackendRoutineSignalExtractorService extends OprmNichoCnaeV3StageServiceSupport {
+    private static final String STAGE_CODE = "routine-signal-extractor";
+
+    /** Inicializa o service com repository canônico de execuções v3. */
+    public BackendRoutineSignalExtractorService(OprmNichoCnaeV3StageExecutionRepository repository) {
+        super(repository, STAGE_CODE);
+    }
+
+    /** Cria pendência inicial ou encadeada para a etapa routine-signal-extractor. */
+    public RoutineSignalExtractorCreateResponse create(String jobId, String cnaeCode, String inputPayload, Integer attemptNumber, Integer knowledgeVersion) {
+        return toCreateResponse(doCreate(jobId, cnaeCode, inputPayload, attemptNumber, knowledgeVersion));
+    }
+
+    /** Lista pendências da etapa routine-signal-extractor para o executor OPRM. */
+    public List<RoutineSignalExtractorPendingResponse> pending() {
+        return pendingExecutions().stream().map(this::toPendingResponse).toList();
+    }
+
+    /** Registra conclusão da etapa routine-signal-extractor. */
+    public RoutineSignalExtractorCreateResponse complete(Long stageExecutionId, String outputPayload, String nextStageCode) {
+        return toCreateResponse(doComplete(stageExecutionId, outputPayload, nextStageCode));
+    }
+
+    /** Registra falha da etapa routine-signal-extractor. */
+    public RoutineSignalExtractorCreateResponse fail(Long stageExecutionId, String errorMessage) {
+        return toCreateResponse(doFail(stageExecutionId, errorMessage));
+    }
+
+    /** Converte entidade persistida em resposta de criação/conclusão/falha. */
+    private RoutineSignalExtractorCreateResponse toCreateResponse(OprmNichoCnaeV3StageExecution execution) {
+        return new RoutineSignalExtractorCreateResponse(execution.getId(), execution.getJobId(), execution.getCnaeCode(), execution.getStageCode(), execution.getStatus().name());
+    }
+
+    /** Converte entidade persistida em item pendente para executor externo. */
+    private RoutineSignalExtractorPendingResponse toPendingResponse(OprmNichoCnaeV3StageExecution execution) {
+        return new RoutineSignalExtractorPendingResponse(execution.getId(), execution.getJobId(), execution.getCnaeCode(), execution.getInputPayload(), execution.getAttemptNumber(), execution.getKnowledgeVersion());
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/routinesignalextractor/service/completeStageExecution/RoutineSignalExtractorCompletionRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/routinesignalextractor/service/completeStageExecution/RoutineSignalExtractorCompletionRequest.java
@@ -1,0 +1,4 @@
+package com.marketinghub.oprm.nichocnae.v3.routinesignalextractor.service.completeStageExecution;
+
+/** Request de conclusão da etapa routine-signal-extractor reportada pelo executor. */
+public record RoutineSignalExtractorCompletionRequest(String outputPayload, String nextStageCode) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/routinesignalextractor/service/createStageExecution/RoutineSignalExtractorCreateResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/routinesignalextractor/service/createStageExecution/RoutineSignalExtractorCreateResponse.java
@@ -1,0 +1,4 @@
+package com.marketinghub.oprm.nichocnae.v3.routinesignalextractor.service.createStageExecution;
+
+/** Resposta de criação de execução pendente da etapa routine-signal-extractor. */
+public record RoutineSignalExtractorCreateResponse(Long stageExecutionId, String jobId, String cnaeCode, String stageCode, String status) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/routinesignalextractor/service/failStageExecution/RoutineSignalExtractorFailureRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/routinesignalextractor/service/failStageExecution/RoutineSignalExtractorFailureRequest.java
@@ -1,0 +1,4 @@
+package com.marketinghub.oprm.nichocnae.v3.routinesignalextractor.service.failStageExecution;
+
+/** Request de falha da etapa routine-signal-extractor reportada pelo executor. */
+public record RoutineSignalExtractorFailureRequest(String errorMessage) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/routinesignalextractor/service/pending/RoutineSignalExtractorPendingResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/routinesignalextractor/service/pending/RoutineSignalExtractorPendingResponse.java
@@ -1,0 +1,4 @@
+package com.marketinghub.oprm.nichocnae.v3.routinesignalextractor.service.pending;
+
+/** Item pendente entregue ao executor para a etapa routine-signal-extractor. */
+public record RoutineSignalExtractorPendingResponse(Long stageExecutionId, String jobId, String cnaeCode, String inputPayload, Integer attemptNumber, Integer knowledgeVersion) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/shared/OprmNichoCnaeV3StageServiceSupport.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/shared/OprmNichoCnaeV3StageServiceSupport.java
@@ -1,0 +1,110 @@
+package com.marketinghub.oprm.nichocnae.v3.shared;
+
+import com.marketinghub.oprm.nichocnae.v3.OprmNichoCnaeV3StageExecution;
+import com.marketinghub.oprm.nichocnae.v3.OprmNichoCnaeV3StageExecutionStatus;
+import com.marketinghub.repository.jpa.oprm.nichocnae.v3.OprmNichoCnaeV3StageExecutionRepository;
+import java.time.Instant;
+import java.util.List;
+import java.util.Map;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.server.ResponseStatusException;
+
+/** Base compartilhada para services canônicos de etapas NichoCNAE v3 sem assumir execução operacional. */
+public abstract class OprmNichoCnaeV3StageServiceSupport {
+    private static final Map<String, Integer> STAGE_ORDER = Map.ofEntries(
+            Map.entry("cnae-intake", 1),
+            Map.entry("persona-candidate-generator", 2),
+            Map.entry("persona-tournament", 3),
+            Map.entry("routine-query-planner", 4),
+            Map.entry("source-searcher", 5),
+            Map.entry("source-fetcher", 6),
+            Map.entry("routine-signal-extractor", 7),
+            Map.entry("daily-tasks-synthesizer", 8),
+            Map.entry("quality-gate", 9),
+            Map.entry("persona-routine-materializer", 10));
+    private final OprmNichoCnaeV3StageExecutionRepository repository;
+    private final String stageCode;
+
+    /** Inicializa o suporte com repository canônico e código da etapa. */
+    protected OprmNichoCnaeV3StageServiceSupport(OprmNichoCnaeV3StageExecutionRepository repository, String stageCode) {
+        this.repository = repository;
+        this.stageCode = stageCode;
+    }
+
+    /** Cria uma execução pendente para a etapa canônica. */
+    protected OprmNichoCnaeV3StageExecution doCreate(String jobId, String cnaeCode, String inputPayload, Integer attemptNumber, Integer knowledgeVersion) {
+        OprmNichoCnaeV3StageExecution execution = new OprmNichoCnaeV3StageExecution();
+        execution.setJobId(jobId == null || jobId.isBlank() ? defaultJobId(cnaeCode) : jobId);
+        execution.setCnaeCode(cnaeCode);
+        execution.setStageCode(stageCode);
+        execution.setInputPayload(inputPayload);
+        execution.setAttemptNumber(attemptNumber == null ? 1 : attemptNumber);
+        execution.setKnowledgeVersion(knowledgeVersion == null ? 1 : knowledgeVersion);
+        return repository.save(execution);
+    }
+
+    /** Lista pendências da etapa para o executor externo consumir pelo endpoint pending. */
+    protected List<OprmNichoCnaeV3StageExecution> pendingExecutions() {
+        return repository.findTop10ByStageCodeAndStatusOrderByCreatedAtAsc(stageCode, OprmNichoCnaeV3StageExecutionStatus.PENDING);
+    }
+
+    /** Registra conclusão reportada pelo executor externo. */
+    protected OprmNichoCnaeV3StageExecution doComplete(Long stageExecutionId, String outputPayload, String nextStageCode) {
+        OprmNichoCnaeV3StageExecution execution = find(stageExecutionId);
+        execution.setStatus(OprmNichoCnaeV3StageExecutionStatus.COMPLETED);
+        execution.setOutputPayload(outputPayload);
+        execution.setNextStageCode(nextStageCode);
+        execution.setUpdatedAt(Instant.now());
+        OprmNichoCnaeV3StageExecution saved = repository.save(execution);
+        createNextStageWhenAllowed(saved, outputPayload, nextStageCode);
+        return saved;
+    }
+
+    /** Registra falha reportada pelo executor externo. */
+    protected OprmNichoCnaeV3StageExecution doFail(Long stageExecutionId, String errorMessage) {
+        OprmNichoCnaeV3StageExecution execution = find(stageExecutionId);
+        execution.setStatus(OprmNichoCnaeV3StageExecutionStatus.FAILED);
+        execution.setErrorMessage(errorMessage);
+        execution.setUpdatedAt(Instant.now());
+        return repository.save(execution);
+    }
+
+    /** Cria a próxima pendência quando o backend reconhecer avanço sequencial válido. */
+    private void createNextStageWhenAllowed(OprmNichoCnaeV3StageExecution current, String outputPayload, String nextStageCode) {
+        String normalizedNextStage = nextStageCode == null ? "" : nextStageCode.trim();
+        if (!isAllowedNextStage(normalizedNextStage)
+                || repository.existsByJobIdAndStageCode(current.getJobId(), normalizedNextStage)) {
+            return;
+        }
+        OprmNichoCnaeV3StageExecution next = new OprmNichoCnaeV3StageExecution();
+        next.setJobId(current.getJobId());
+        next.setCnaeCode(current.getCnaeCode());
+        next.setStageCode(normalizedNextStage);
+        next.setInputPayload(outputPayload);
+        next.setAttemptNumber(current.getAttemptNumber());
+        next.setKnowledgeVersion(current.getKnowledgeVersion());
+        repository.save(next);
+    }
+
+    /** Valida se a próxima etapa é conhecida e vem imediatamente depois da etapa atual. */
+    private boolean isAllowedNextStage(String nextStageCode) {
+        Integer currentOrder = STAGE_ORDER.get(stageCode);
+        Integer nextOrder = STAGE_ORDER.get(nextStageCode);
+        return currentOrder != null && nextOrder != null && nextOrder == currentOrder + 1;
+    }
+
+    /** Busca a execução garantindo que pertence à etapa atual. */
+    private OprmNichoCnaeV3StageExecution find(Long stageExecutionId) {
+        OprmNichoCnaeV3StageExecution execution = repository.findById(stageExecutionId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Execução v3 não encontrada."));
+        if (!stageCode.equals(execution.getStageCode())) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, "Execução v3 pertence a outra etapa.");
+        }
+        return execution;
+    }
+
+    /** Monta jobId simples quando a UI iniciar o fluxo por CNAE sem identificador prévio. */
+    private String defaultJobId(String cnaeCode) {
+        return "nichocnae-v3-" + cnaeCode + "-" + Instant.now().toEpochMilli();
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/sourcefetcher/controller/BackendSourceFetcherController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/sourcefetcher/controller/BackendSourceFetcherController.java
@@ -1,0 +1,56 @@
+package com.marketinghub.oprm.nichocnae.v3.sourcefetcher.controller;
+
+import com.marketinghub.oprm.nichocnae.v3.sourcefetcher.service.BackendSourceFetcherService;
+import com.marketinghub.oprm.nichocnae.v3.sourcefetcher.service.completeStageExecution.SourceFetcherCompletionRequest;
+import com.marketinghub.oprm.nichocnae.v3.sourcefetcher.service.createStageExecution.SourceFetcherCreateResponse;
+import com.marketinghub.oprm.nichocnae.v3.sourcefetcher.service.failStageExecution.SourceFetcherFailureRequest;
+import com.marketinghub.oprm.nichocnae.v3.sourcefetcher.service.pending.SourceFetcherPendingResponse;
+import java.util.List;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/** Controller canônico da etapa source-fetcher do pipeline NichoCNAE v3. */
+@RestController
+@RequestMapping("/api/internal/oprm/nichocnae/v3/source-fetcher/stage-executions")
+public class BackendSourceFetcherController {
+    private final BackendSourceFetcherService service;
+
+    /** Inicializa o controller com service canônico da etapa. */
+    public BackendSourceFetcherController(BackendSourceFetcherService service) {
+        this.service = service;
+    }
+
+    /** Cria uma execução pendente da etapa source-fetcher. */
+    @PostMapping
+    public SourceFetcherCreateResponse create(@RequestBody SourceFetcherPendingResponse request) {
+        return service.create(request.jobId(), request.cnaeCode(), request.inputPayload(), request.attemptNumber(), request.knowledgeVersion());
+    }
+
+    /** Cria a primeira execução v3 diretamente a partir de um CNAE. */
+    @PostMapping("/cnaes/{cnaeCode}")
+    public SourceFetcherCreateResponse createForCnae(@PathVariable String cnaeCode) {
+        return service.create(null, cnaeCode, "{\"cnaeCode\":\"" + cnaeCode + "\"}", 1, 1);
+    }
+
+    /** Entrega pendências da etapa source-fetcher ao executor OPRM. */
+    @GetMapping("/pending")
+    public List<SourceFetcherPendingResponse> pending() {
+        return service.pending();
+    }
+
+    /** Recebe conclusão da etapa source-fetcher enviada pelo executor OPRM. */
+    @PostMapping("/{stageExecutionId}/complete")
+    public SourceFetcherCreateResponse complete(@PathVariable Long stageExecutionId, @RequestBody SourceFetcherCompletionRequest request) {
+        return service.complete(stageExecutionId, request.outputPayload(), request.nextStageCode());
+    }
+
+    /** Recebe falha da etapa source-fetcher enviada pelo executor OPRM. */
+    @PostMapping("/{stageExecutionId}/fail")
+    public SourceFetcherCreateResponse fail(@PathVariable Long stageExecutionId, @RequestBody SourceFetcherFailureRequest request) {
+        return service.fail(stageExecutionId, request.errorMessage());
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/sourcefetcher/service/BackendSourceFetcherService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/sourcefetcher/service/BackendSourceFetcherService.java
@@ -1,0 +1,50 @@
+package com.marketinghub.oprm.nichocnae.v3.sourcefetcher.service;
+
+import com.marketinghub.oprm.nichocnae.v3.OprmNichoCnaeV3StageExecution;
+import com.marketinghub.oprm.nichocnae.v3.sourcefetcher.service.createStageExecution.SourceFetcherCreateResponse;
+import com.marketinghub.oprm.nichocnae.v3.sourcefetcher.service.pending.SourceFetcherPendingResponse;
+import com.marketinghub.oprm.nichocnae.v3.shared.OprmNichoCnaeV3StageServiceSupport;
+import com.marketinghub.repository.jpa.oprm.nichocnae.v3.OprmNichoCnaeV3StageExecutionRepository;
+import java.util.List;
+import org.springframework.stereotype.Service;
+
+/** Service canônico da etapa source-fetcher do pipeline NichoCNAE v3 no backend. */
+@Service
+public class BackendSourceFetcherService extends OprmNichoCnaeV3StageServiceSupport {
+    private static final String STAGE_CODE = "source-fetcher";
+
+    /** Inicializa o service com repository canônico de execuções v3. */
+    public BackendSourceFetcherService(OprmNichoCnaeV3StageExecutionRepository repository) {
+        super(repository, STAGE_CODE);
+    }
+
+    /** Cria pendência inicial ou encadeada para a etapa source-fetcher. */
+    public SourceFetcherCreateResponse create(String jobId, String cnaeCode, String inputPayload, Integer attemptNumber, Integer knowledgeVersion) {
+        return toCreateResponse(doCreate(jobId, cnaeCode, inputPayload, attemptNumber, knowledgeVersion));
+    }
+
+    /** Lista pendências da etapa source-fetcher para o executor OPRM. */
+    public List<SourceFetcherPendingResponse> pending() {
+        return pendingExecutions().stream().map(this::toPendingResponse).toList();
+    }
+
+    /** Registra conclusão da etapa source-fetcher. */
+    public SourceFetcherCreateResponse complete(Long stageExecutionId, String outputPayload, String nextStageCode) {
+        return toCreateResponse(doComplete(stageExecutionId, outputPayload, nextStageCode));
+    }
+
+    /** Registra falha da etapa source-fetcher. */
+    public SourceFetcherCreateResponse fail(Long stageExecutionId, String errorMessage) {
+        return toCreateResponse(doFail(stageExecutionId, errorMessage));
+    }
+
+    /** Converte entidade persistida em resposta de criação/conclusão/falha. */
+    private SourceFetcherCreateResponse toCreateResponse(OprmNichoCnaeV3StageExecution execution) {
+        return new SourceFetcherCreateResponse(execution.getId(), execution.getJobId(), execution.getCnaeCode(), execution.getStageCode(), execution.getStatus().name());
+    }
+
+    /** Converte entidade persistida em item pendente para executor externo. */
+    private SourceFetcherPendingResponse toPendingResponse(OprmNichoCnaeV3StageExecution execution) {
+        return new SourceFetcherPendingResponse(execution.getId(), execution.getJobId(), execution.getCnaeCode(), execution.getInputPayload(), execution.getAttemptNumber(), execution.getKnowledgeVersion());
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/sourcefetcher/service/completeStageExecution/SourceFetcherCompletionRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/sourcefetcher/service/completeStageExecution/SourceFetcherCompletionRequest.java
@@ -1,0 +1,4 @@
+package com.marketinghub.oprm.nichocnae.v3.sourcefetcher.service.completeStageExecution;
+
+/** Request de conclusão da etapa source-fetcher reportada pelo executor. */
+public record SourceFetcherCompletionRequest(String outputPayload, String nextStageCode) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/sourcefetcher/service/createStageExecution/SourceFetcherCreateResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/sourcefetcher/service/createStageExecution/SourceFetcherCreateResponse.java
@@ -1,0 +1,4 @@
+package com.marketinghub.oprm.nichocnae.v3.sourcefetcher.service.createStageExecution;
+
+/** Resposta de criação de execução pendente da etapa source-fetcher. */
+public record SourceFetcherCreateResponse(Long stageExecutionId, String jobId, String cnaeCode, String stageCode, String status) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/sourcefetcher/service/failStageExecution/SourceFetcherFailureRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/sourcefetcher/service/failStageExecution/SourceFetcherFailureRequest.java
@@ -1,0 +1,4 @@
+package com.marketinghub.oprm.nichocnae.v3.sourcefetcher.service.failStageExecution;
+
+/** Request de falha da etapa source-fetcher reportada pelo executor. */
+public record SourceFetcherFailureRequest(String errorMessage) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/sourcefetcher/service/pending/SourceFetcherPendingResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/sourcefetcher/service/pending/SourceFetcherPendingResponse.java
@@ -1,0 +1,4 @@
+package com.marketinghub.oprm.nichocnae.v3.sourcefetcher.service.pending;
+
+/** Item pendente entregue ao executor para a etapa source-fetcher. */
+public record SourceFetcherPendingResponse(Long stageExecutionId, String jobId, String cnaeCode, String inputPayload, Integer attemptNumber, Integer knowledgeVersion) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/sourcesearcher/controller/BackendSourceSearcherController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/sourcesearcher/controller/BackendSourceSearcherController.java
@@ -1,0 +1,56 @@
+package com.marketinghub.oprm.nichocnae.v3.sourcesearcher.controller;
+
+import com.marketinghub.oprm.nichocnae.v3.sourcesearcher.service.BackendSourceSearcherService;
+import com.marketinghub.oprm.nichocnae.v3.sourcesearcher.service.completeStageExecution.SourceSearcherCompletionRequest;
+import com.marketinghub.oprm.nichocnae.v3.sourcesearcher.service.createStageExecution.SourceSearcherCreateResponse;
+import com.marketinghub.oprm.nichocnae.v3.sourcesearcher.service.failStageExecution.SourceSearcherFailureRequest;
+import com.marketinghub.oprm.nichocnae.v3.sourcesearcher.service.pending.SourceSearcherPendingResponse;
+import java.util.List;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/** Controller canônico da etapa source-searcher do pipeline NichoCNAE v3. */
+@RestController
+@RequestMapping("/api/internal/oprm/nichocnae/v3/source-searcher/stage-executions")
+public class BackendSourceSearcherController {
+    private final BackendSourceSearcherService service;
+
+    /** Inicializa o controller com service canônico da etapa. */
+    public BackendSourceSearcherController(BackendSourceSearcherService service) {
+        this.service = service;
+    }
+
+    /** Cria uma execução pendente da etapa source-searcher. */
+    @PostMapping
+    public SourceSearcherCreateResponse create(@RequestBody SourceSearcherPendingResponse request) {
+        return service.create(request.jobId(), request.cnaeCode(), request.inputPayload(), request.attemptNumber(), request.knowledgeVersion());
+    }
+
+    /** Cria a primeira execução v3 diretamente a partir de um CNAE. */
+    @PostMapping("/cnaes/{cnaeCode}")
+    public SourceSearcherCreateResponse createForCnae(@PathVariable String cnaeCode) {
+        return service.create(null, cnaeCode, "{\"cnaeCode\":\"" + cnaeCode + "\"}", 1, 1);
+    }
+
+    /** Entrega pendências da etapa source-searcher ao executor OPRM. */
+    @GetMapping("/pending")
+    public List<SourceSearcherPendingResponse> pending() {
+        return service.pending();
+    }
+
+    /** Recebe conclusão da etapa source-searcher enviada pelo executor OPRM. */
+    @PostMapping("/{stageExecutionId}/complete")
+    public SourceSearcherCreateResponse complete(@PathVariable Long stageExecutionId, @RequestBody SourceSearcherCompletionRequest request) {
+        return service.complete(stageExecutionId, request.outputPayload(), request.nextStageCode());
+    }
+
+    /** Recebe falha da etapa source-searcher enviada pelo executor OPRM. */
+    @PostMapping("/{stageExecutionId}/fail")
+    public SourceSearcherCreateResponse fail(@PathVariable Long stageExecutionId, @RequestBody SourceSearcherFailureRequest request) {
+        return service.fail(stageExecutionId, request.errorMessage());
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/sourcesearcher/service/BackendSourceSearcherService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/sourcesearcher/service/BackendSourceSearcherService.java
@@ -1,0 +1,50 @@
+package com.marketinghub.oprm.nichocnae.v3.sourcesearcher.service;
+
+import com.marketinghub.oprm.nichocnae.v3.OprmNichoCnaeV3StageExecution;
+import com.marketinghub.oprm.nichocnae.v3.sourcesearcher.service.createStageExecution.SourceSearcherCreateResponse;
+import com.marketinghub.oprm.nichocnae.v3.sourcesearcher.service.pending.SourceSearcherPendingResponse;
+import com.marketinghub.oprm.nichocnae.v3.shared.OprmNichoCnaeV3StageServiceSupport;
+import com.marketinghub.repository.jpa.oprm.nichocnae.v3.OprmNichoCnaeV3StageExecutionRepository;
+import java.util.List;
+import org.springframework.stereotype.Service;
+
+/** Service canônico da etapa source-searcher do pipeline NichoCNAE v3 no backend. */
+@Service
+public class BackendSourceSearcherService extends OprmNichoCnaeV3StageServiceSupport {
+    private static final String STAGE_CODE = "source-searcher";
+
+    /** Inicializa o service com repository canônico de execuções v3. */
+    public BackendSourceSearcherService(OprmNichoCnaeV3StageExecutionRepository repository) {
+        super(repository, STAGE_CODE);
+    }
+
+    /** Cria pendência inicial ou encadeada para a etapa source-searcher. */
+    public SourceSearcherCreateResponse create(String jobId, String cnaeCode, String inputPayload, Integer attemptNumber, Integer knowledgeVersion) {
+        return toCreateResponse(doCreate(jobId, cnaeCode, inputPayload, attemptNumber, knowledgeVersion));
+    }
+
+    /** Lista pendências da etapa source-searcher para o executor OPRM. */
+    public List<SourceSearcherPendingResponse> pending() {
+        return pendingExecutions().stream().map(this::toPendingResponse).toList();
+    }
+
+    /** Registra conclusão da etapa source-searcher. */
+    public SourceSearcherCreateResponse complete(Long stageExecutionId, String outputPayload, String nextStageCode) {
+        return toCreateResponse(doComplete(stageExecutionId, outputPayload, nextStageCode));
+    }
+
+    /** Registra falha da etapa source-searcher. */
+    public SourceSearcherCreateResponse fail(Long stageExecutionId, String errorMessage) {
+        return toCreateResponse(doFail(stageExecutionId, errorMessage));
+    }
+
+    /** Converte entidade persistida em resposta de criação/conclusão/falha. */
+    private SourceSearcherCreateResponse toCreateResponse(OprmNichoCnaeV3StageExecution execution) {
+        return new SourceSearcherCreateResponse(execution.getId(), execution.getJobId(), execution.getCnaeCode(), execution.getStageCode(), execution.getStatus().name());
+    }
+
+    /** Converte entidade persistida em item pendente para executor externo. */
+    private SourceSearcherPendingResponse toPendingResponse(OprmNichoCnaeV3StageExecution execution) {
+        return new SourceSearcherPendingResponse(execution.getId(), execution.getJobId(), execution.getCnaeCode(), execution.getInputPayload(), execution.getAttemptNumber(), execution.getKnowledgeVersion());
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/sourcesearcher/service/completeStageExecution/SourceSearcherCompletionRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/sourcesearcher/service/completeStageExecution/SourceSearcherCompletionRequest.java
@@ -1,0 +1,4 @@
+package com.marketinghub.oprm.nichocnae.v3.sourcesearcher.service.completeStageExecution;
+
+/** Request de conclusão da etapa source-searcher reportada pelo executor. */
+public record SourceSearcherCompletionRequest(String outputPayload, String nextStageCode) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/sourcesearcher/service/createStageExecution/SourceSearcherCreateResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/sourcesearcher/service/createStageExecution/SourceSearcherCreateResponse.java
@@ -1,0 +1,4 @@
+package com.marketinghub.oprm.nichocnae.v3.sourcesearcher.service.createStageExecution;
+
+/** Resposta de criação de execução pendente da etapa source-searcher. */
+public record SourceSearcherCreateResponse(Long stageExecutionId, String jobId, String cnaeCode, String stageCode, String status) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/sourcesearcher/service/failStageExecution/SourceSearcherFailureRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/sourcesearcher/service/failStageExecution/SourceSearcherFailureRequest.java
@@ -1,0 +1,4 @@
+package com.marketinghub.oprm.nichocnae.v3.sourcesearcher.service.failStageExecution;
+
+/** Request de falha da etapa source-searcher reportada pelo executor. */
+public record SourceSearcherFailureRequest(String errorMessage) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/sourcesearcher/service/pending/SourceSearcherPendingResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/sourcesearcher/service/pending/SourceSearcherPendingResponse.java
@@ -1,0 +1,4 @@
+package com.marketinghub.oprm.nichocnae.v3.sourcesearcher.service.pending;
+
+/** Item pendente entregue ao executor para a etapa source-searcher. */
+public record SourceSearcherPendingResponse(Long stageExecutionId, String jobId, String cnaeCode, String inputPayload, Integer attemptNumber, Integer knowledgeVersion) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/oprm/nichocnae/v3/OprmNichoCnaeV3StageExecutionRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/oprm/nichocnae/v3/OprmNichoCnaeV3StageExecutionRepository.java
@@ -1,0 +1,16 @@
+package com.marketinghub.repository.jpa.oprm.nichocnae.v3;
+
+import com.marketinghub.oprm.nichocnae.v3.OprmNichoCnaeV3StageExecution;
+import com.marketinghub.oprm.nichocnae.v3.OprmNichoCnaeV3StageExecutionStatus;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/** Repository JPA canônico das execuções de etapa do NichoCNAE v3. */
+public interface OprmNichoCnaeV3StageExecutionRepository extends JpaRepository<OprmNichoCnaeV3StageExecution, Long> {
+    /** Lista pendências de uma etapa específica em ordem de criação. */
+    List<OprmNichoCnaeV3StageExecution> findTop10ByStageCodeAndStatusOrderByCreatedAtAsc(
+            String stageCode, OprmNichoCnaeV3StageExecutionStatus status);
+
+    /** Verifica se o job já possui pendência ou conclusão para uma etapa específica. */
+    boolean existsByJobIdAndStageCode(String jobId, String stageCode);
+}

--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-25-oprm-nichocnae-v3-stage-execution.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-25-oprm-nichocnae-v3-stage-execution.yaml
@@ -1,0 +1,96 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-06-25-01-oprm-nichocnae-v3-stage-execution
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - dbms:
+            type: mysql
+        - not:
+            tableExists:
+              tableName: oprm_nichocnae_v3_stage_execution
+      changes:
+        - createTable:
+            tableName: oprm_nichocnae_v3_stage_execution
+            remarks: Execuções auditáveis das etapas do pipeline OPRM NichoCNAE v3.
+            columns:
+              - column:
+                  name: id
+                  type: BIGINT
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    primaryKeyName: pk_oprm_nichocnae_v3_stage_execution
+                    nullable: false
+              - column:
+                  name: job_id
+                  type: VARCHAR(96)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: cnae_code
+                  type: VARCHAR(16)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: stage_code
+                  type: VARCHAR(80)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: status
+                  type: VARCHAR(32)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: attempt_number
+                  type: INT
+                  defaultValueNumeric: 1
+                  constraints:
+                    nullable: false
+              - column:
+                  name: knowledge_version
+                  type: INT
+                  defaultValueNumeric: 1
+                  constraints:
+                    nullable: false
+              - column:
+                  name: input_payload
+                  type: LONGTEXT
+              - column:
+                  name: output_payload
+                  type: LONGTEXT
+              - column:
+                  name: next_stage_code
+                  type: VARCHAR(80)
+              - column:
+                  name: error_message
+                  type: LONGTEXT
+              - column:
+                  name: created_at
+                  type: DATETIME(6)
+                  constraints:
+                    nullable: false
+              - column:
+                  name: updated_at
+                  type: DATETIME(6)
+                  constraints:
+                    nullable: false
+        - createIndex:
+            tableName: oprm_nichocnae_v3_stage_execution
+            indexName: idx_oprm_nichocnae_v3_pending
+            columns:
+              - column:
+                  name: stage_code
+              - column:
+                  name: status
+              - column:
+                  name: created_at
+        - createIndex:
+            tableName: oprm_nichocnae_v3_stage_execution
+            indexName: idx_oprm_nichocnae_v3_job
+            columns:
+              - column:
+                  name: job_id
+              - column:
+                  name: stage_code

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -1,5 +1,8 @@
 databaseChangeLog:
   - include:
+      file: changesets/2026-06-25-oprm-nichocnae-v3-stage-execution.yaml
+      relativeToChangelogFile: true
+  - include:
       file: changesets/2026-06-25-mois-market-warmup-dossier-evidence.yaml
       relativeToChangelogFile: true
   - include:

--- a/backend/ads-service/src/test/java/com/marketinghub/architecture/ArquiteturaTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/architecture/ArquiteturaTest.java
@@ -115,6 +115,19 @@ class ArquiteturaTest {
             Map.entry("commercialevidencegate", "commercial-evidence-gate"),
             Map.entry("reprocesscontroller", "reprocess-controller"),
             Map.entry("enrichednichematerializer", "enriched-niche-materializer"));
+
+    private static final String OPRM_NICHO_CNAE_V3_PACKAGE = "com.marketinghub.oprm.nichocnae.v3";
+    private static final Map<String, String> OPRM_NICHO_CNAE_V3_STAGE_ENDPOINT_SLUGS = Map.ofEntries(
+            Map.entry("cnaeintake", "cnae-intake"),
+            Map.entry("personacandidategenerator", "persona-candidate-generator"),
+            Map.entry("personatournament", "persona-tournament"),
+            Map.entry("routinequeryplanner", "routine-query-planner"),
+            Map.entry("sourcesearcher", "source-searcher"),
+            Map.entry("sourcefetcher", "source-fetcher"),
+            Map.entry("routinesignalextractor", "routine-signal-extractor"),
+            Map.entry("dailytaskssynthesizer", "daily-tasks-synthesizer"),
+            Map.entry("qualitygate", "quality-gate"),
+            Map.entry("personaroutinematerializer", "persona-routine-materializer"));
     private static final String OPRM_CNAE_PACKAGE = "com.marketinghub.oprm.cnae";
     private static final String OPS_MONITOR_PACKAGE = "com.marketinghub.opsmonitor";
     private static final String OPRM_CNAE_WEB_PACKAGE = OPRM_CNAE_PACKAGE + ".web";
@@ -856,6 +869,75 @@ class ArquiteturaTest {
             .resideInAPackage(OPRM_NICHO_CNAE_V2_PACKAGE + "..service..")
             .should(beRecordWhenInsideNichoCnaeV2StageServiceSubpackage())
             .because("[ARQUITETURA] [BACKEND][OPRM][NichoCNAE-v2] contratos de etapa em subpacotes de service devem ser records");
+
+
+    /**
+     * Garante que todas as etapas backend NichoCNAE v3 exponham controller, service e pending canônicos.
+     */
+    @ArchTest
+    static void oprmNichoCnaeV3BackendStagesMustExposeCanonicalStructure(JavaClasses importedClasses) {
+        List<String> violations = new ArrayList<>();
+        OPRM_NICHO_CNAE_V3_STAGE_ENDPOINT_SLUGS.forEach((stagePackage, endpointSlug) -> {
+            String stageRoot = OPRM_NICHO_CNAE_V3_PACKAGE + "." + stagePackage;
+            String controllerPackage = stageRoot + ".controller";
+            String servicePackage = stageRoot + ".service";
+            String expectedEndpoint = "/api/internal/oprm/nichocnae/v3/" + endpointSlug + "/stage-executions";
+            List<JavaClass> controllerPackageClasses = directPackageClasses(importedClasses, controllerPackage);
+            List<JavaClass> controllers = controllerPackageClasses.stream()
+                    .filter(ArquiteturaTest::isBackendControllerClass)
+                    .toList();
+            if (controllerPackageClasses.size() != 1) {
+                violations.add("[ARQUITETURA] [BACKEND][OPRM][NichoCNAE-v3] pacote=" + controllerPackage
+                        + " deve conter apenas um controller canônico; classes=" + simpleNames(controllerPackageClasses));
+            }
+            if (controllers.size() != 1) {
+                violations.add("[ARQUITETURA] [BACKEND][OPRM][NichoCNAE-v3] pacote=" + controllerPackage
+                        + " deve conter exatamente uma classe Backend<Etapa>Controller; controllers="
+                        + simpleNames(controllers));
+            } else {
+                JavaClass controller = controllers.get(0);
+                if (!controller.isAnnotatedWith(RestController.class)) {
+                    violations.add("[ARQUITETURA] [BACKEND][OPRM][NichoCNAE-v3] classe="
+                            + controller.getName() + " deve possuir @RestController");
+                }
+                if (!hasRequestMapping(controller, expectedEndpoint)) {
+                    violations.add("[ARQUITETURA] [BACKEND][OPRM][NichoCNAE-v3] classe="
+                            + controller.getName() + " deve possuir @RequestMapping(\"" + expectedEndpoint + "\")");
+                }
+                if (!hasPendingGetMapping(controller)) {
+                    violations.add("[ARQUITETURA] [BACKEND][OPRM][NichoCNAE-v3] classe="
+                            + controller.getName() + " deve expor @GetMapping(\"/pending\") como ponto inicial canônico do executor oprm-coletor-mei");
+                }
+            }
+            List<JavaClass> servicePackageClasses = directPackageClasses(importedClasses, servicePackage);
+            List<JavaClass> services = servicePackageClasses.stream()
+                    .filter(ArquiteturaTest::isBackendServiceClass)
+                    .toList();
+            if (servicePackageClasses.size() != 1) {
+                violations.add("[ARQUITETURA] [BACKEND][OPRM][NichoCNAE-v3] pacote=" + servicePackage
+                        + " deve conter apenas um service backend canônico na raiz; classes="
+                        + simpleNames(servicePackageClasses));
+            }
+            if (services.size() != 1) {
+                violations.add("[ARQUITETURA] [BACKEND][OPRM][NichoCNAE-v3] pacote=" + servicePackage
+                        + " deve conter exatamente uma classe Backend<Etapa>Service; services=" + simpleNames(services));
+            } else if (!services.get(0).isAnnotatedWith(Service.class)) {
+                violations.add("[ARQUITETURA] [BACKEND][OPRM][NichoCNAE-v3] classe="
+                        + services.get(0).getName() + " deve possuir @Service");
+            }
+        });
+        failWithArchitectureViolations(violations);
+    }
+
+    /**
+     * Garante que contratos das etapas backend NichoCNAE v3 sejam records em subpacotes de service.
+     */
+    @ArchTest
+    static final ArchRule oprmNichoCnaeV3BackendStageServiceContractsMustBeRecords = classes()
+            .that()
+            .resideInAPackage(OPRM_NICHO_CNAE_V3_PACKAGE + "..service..")
+            .should(beRecordWhenInsideNichoCnaeV3StageServiceSubpackage())
+            .because("[ARQUITETURA] [BACKEND][OPRM][NichoCNAE-v3] contratos de etapa em subpacotes de service devem ser records");
 
     /**
      * Garante que cada etapa do OPRM nicho CNAE tenha um único controller canônico anotado.
@@ -1937,6 +2019,32 @@ class ArquiteturaTest {
         };
     }
 
+
+    /**
+     * Exige record apenas nos subpacotes de contrato das etapas v3.
+     */
+    private static ArchCondition<JavaClass> beRecordWhenInsideNichoCnaeV3StageServiceSubpackage() {
+        return new ArchCondition<>("[ARQUITETURA] contratos v3 em subpacotes de service devem ser records") {
+            @Override
+            public void check(JavaClass item, ConditionEvents events) {
+                if (!isNichoCnaeV3StageServiceSubpackageClass(item) || item.reflect().isRecord()) {
+                    return;
+                }
+                events.add(SimpleConditionEvent.violated(item, "[ARQUITETURA] [BACKEND][OPRM][NichoCNAE-v3] classe="
+                        + item.getName() + " está em subpacote de contrato service e deve ser record"));
+            }
+        };
+    }
+
+    /**
+     * Identifica classes em subpacotes de service das etapas v3.
+     */
+    private static boolean isNichoCnaeV3StageServiceSubpackageClass(JavaClass javaClass) {
+        return OPRM_NICHO_CNAE_V3_STAGE_ENDPOINT_SLUGS.keySet().stream()
+                .anyMatch(stagePackage -> javaClass.getPackageName()
+                        .startsWith(OPRM_NICHO_CNAE_V3_PACKAGE + "." + stagePackage + ".service."));
+    }
+
     /**
      * Identifica a versão do pacote backend OPRM NichoCNAE.
      */
@@ -1948,6 +2056,10 @@ class ArquiteturaTest {
         if (packageName.equals(OPRM_NICHO_CNAE_V2_PACKAGE)
                 || packageName.startsWith(OPRM_NICHO_CNAE_V2_PACKAGE + ".")) {
             return "v2";
+        }
+        if (packageName.equals(OPRM_NICHO_CNAE_V3_PACKAGE)
+                || packageName.startsWith(OPRM_NICHO_CNAE_V3_PACKAGE + ".")) {
+            return "v3";
         }
         return "inicial";
     }

--- a/docs/registro-protocolo/padrao-backend.md
+++ b/docs/registro-protocolo/padrao-backend.md
@@ -27,3 +27,9 @@
 - Etapa: dossiê de prestígio e aquecimento da Biblioteca de Páginas de Vendas.
 - Endpoint pending canônico exposto no controller único: `/api/mois/sales-library/market-warmup/stage-executions/pending`.
 - Executor externo responsável pela execução operacional: `mois-sales-library-worker`.
+
+## 2026-06-25 — OPRM NichoCNAE v3
+
+- Pacote backend protegido: `com.marketinghub.oprm.nichocnae.v3`.
+- Módulo executor externo: `oprm-coletor-mei`.
+- Protocolo aplicado com etapas versionadas, controller/service canônicos por etapa, contratos `record` em subpacotes de service e endpoint `pending` em `/api/internal/oprm/nichocnae/v3/<etapa>/stage-executions/pending`.

--- a/docs/registro-protocolo/padrao-modulo.md
+++ b/docs/registro-protocolo/padrao-modulo.md
@@ -20,3 +20,9 @@
 - Pacote executor: `com.marketinghub.mois.bibliotecapaginavenda.worker.v1`.
 - Fluxo protegido: dossiê de prestígio e aquecimento da Biblioteca de Páginas de Vendas.
 - O worker mantém a execução operacional de OpenAI e pesquisas externas; o backend mantém estado, persistência, pending e callbacks.
+
+## 2026-06-25 — OPRM NichoCNAE v3
+
+- Módulo executor: `oprm-coletor-mei`.
+- Pacote executor: `com.marketinghub.nichocnaev3`.
+- Protocolo aplicado com núcleo genérico `pipeline`, etapas concretas plugáveis em subpacotes por etapa, scheduler no executor, consumo via endpoint `pending` do backend e teste ArchUnit próprio.

--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -1386,3 +1386,11 @@
 - O perfil enriquecido materializado por CNAE + nome neutro também passa a ser atualizado quando já existir, preservando o registro e renovando as informações auditáveis.
 
 - 2026-06-25 — Tela OPRM de CNAEs atualizada para destacar visualmente, já no início da linha, os CNAEs com processamento de pesquisa em execução, reutilizando o indicador `nicheResearchRunning` entregue pelo backend.
+
+## 2026-06-25 — OPRM NichoCNAE v3: criação do fluxo versionado de persona e tarefas diárias
+
+- Solicitação: criar a v3 do fluxo NichoCNAE aplicando protocolo padrão módulo e protocolo padrão backend.
+- Foi feito: criada a base backend `com.marketinghub.oprm.nichocnae.v3` com endpoints internos por etapa, tabela `oprm_nichocnae_v3_stage_execution`, contratos `record`, endpoint `pending` por etapa e regra ArchUnit de estrutura canônica.
+- Foi feito: criado o executor `com.marketinghub.nichocnaev3` no `oprm-coletor-mei` com núcleo genérico, catálogo de 10 etapas, processors plugáveis, scheduler de pendências, cliente backend, prompts/schemas versionados para etapas com IA e teste ArchUnit próprio.
+- Objetivo de negócio: transformar um CNAE em persona operacional, rotina real e lista de tarefas diárias auditável, sem criar oferta, campanha ou landing nesta fase.
+- Prevenção: a v3 nasce separada da v2 para evitar remendos no fluxo que parava após o planejador de buscas por falta de etapa cadastrada.

--- a/docs/swagger/oprm-nichocnae-v3-swagger.yaml
+++ b/docs/swagger/oprm-nichocnae-v3-swagger.yaml
@@ -1,0 +1,167 @@
+openapi: 3.0.3
+info:
+  title: OPRM NichoCNAE v3 API
+  version: v3
+  description: Endpoints internos por etapa para transformar CNAE em persona operacional, rotina e tarefas diárias.
+paths:
+  /api/internal/oprm/nichocnae/v3/{stage}/stage-executions:
+    post:
+      summary: Cria uma execução pendente de etapa NichoCNAE v3.
+      parameters:
+        - name: stage
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/StagePendingRequest'
+      responses:
+        '200':
+          description: Execução criada.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StageExecutionResponse'
+  /api/internal/oprm/nichocnae/v3/{stage}/stage-executions/cnaes/{cnaeCode}:
+    post:
+      summary: Inicia a primeira execução v3 para um CNAE.
+      parameters:
+        - name: stage
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: cnaeCode
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Execução criada.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StageExecutionResponse'
+  /api/internal/oprm/nichocnae/v3/{stage}/stage-executions/pending:
+    get:
+      summary: Lista pendências da etapa para consumo do executor OPRM.
+      parameters:
+        - name: stage
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Pendências disponíveis.
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/StagePendingRequest'
+  /api/internal/oprm/nichocnae/v3/{stage}/stage-executions/{stageExecutionId}/complete:
+    post:
+      summary: Registra conclusão de etapa pelo executor OPRM.
+      parameters:
+        - name: stage
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: stageExecutionId
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/CompletionRequest'
+      responses:
+        '200':
+          description: Execução concluída.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StageExecutionResponse'
+  /api/internal/oprm/nichocnae/v3/{stage}/stage-executions/{stageExecutionId}/fail:
+    post:
+      summary: Registra falha de etapa pelo executor OPRM.
+      parameters:
+        - name: stage
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: stageExecutionId
+          in: path
+          required: true
+          schema:
+            type: integer
+            format: int64
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/FailureRequest'
+      responses:
+        '200':
+          description: Execução marcada como falha.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StageExecutionResponse'
+components:
+  schemas:
+    StagePendingRequest:
+      type: object
+      properties:
+        stageExecutionId:
+          type: integer
+          format: int64
+        jobId:
+          type: string
+        cnaeCode:
+          type: string
+        inputPayload:
+          type: string
+        attemptNumber:
+          type: integer
+        knowledgeVersion:
+          type: integer
+    CompletionRequest:
+      type: object
+      properties:
+        outputPayload:
+          type: string
+        nextStageCode:
+          type: string
+    FailureRequest:
+      type: object
+      properties:
+        errorMessage:
+          type: string
+    StageExecutionResponse:
+      type: object
+      properties:
+        stageExecutionId:
+          type: integer
+          format: int64
+        jobId:
+          type: string
+        cnaeCode:
+          type: string
+        stageCode:
+          type: string
+        status:
+          type: string

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnaev3/execution/NichoCnaeV3BackendClient.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnaev3/execution/NichoCnaeV3BackendClient.java
@@ -1,0 +1,80 @@
+package com.marketinghub.nichocnaev3.execution;
+
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import java.util.Arrays;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.web.client.RestTemplateBuilder;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestTemplate;
+
+/** Cliente HTTP do executor NichoCNAE v3 para pending, complete e fail no backend. */
+@Component
+public class NichoCnaeV3BackendClient {
+    private static final TypeReference<Map<String, Object>> MAP_TYPE = new TypeReference<>() {};
+    private final RestTemplate restTemplate;
+    private final ObjectMapper objectMapper;
+    private final String backendBaseUrl;
+
+    /** Inicializa o cliente com URL base do backend. */
+    public NichoCnaeV3BackendClient(RestTemplateBuilder builder, ObjectMapper objectMapper,
+            @Value("${backend.base-url:http://191.252.181.168}") String backendBaseUrl) {
+        this.restTemplate = builder.build();
+        this.objectMapper = objectMapper;
+        this.backendBaseUrl = backendBaseUrl;
+    }
+
+    /** Lista pendências de uma etapa v3 no endpoint canônico pending. */
+    public List<NichoCnaeV3PendingExecution> listPending(NichoCnaeV3StageDefinition stage) {
+        Map<String, Object>[] response = restTemplate.getForObject(backendBaseUrl + stage.backendPath() + "/pending", Map[].class);
+        return response == null ? List.of() : Arrays.stream(response).map(this::toPending).toList();
+    }
+
+    /** Envia conclusão da etapa v3 para o backend. */
+    public void complete(NichoCnaeV3StageDefinition stage, NichoCnaeV3PendingExecution pending, Map<String, Object> request) {
+        restTemplate.postForObject(backendBaseUrl + stage.backendPath() + "/" + pending.stageExecutionId() + "/complete", request, Object.class);
+    }
+
+
+    /** Envia falha da etapa v3 para o backend. */
+    public void fail(NichoCnaeV3StageDefinition stage, NichoCnaeV3PendingExecution pending, RuntimeException ex) {
+        Map<String, Object> request = new LinkedHashMap<>();
+        request.put("errorMessage", ex.getClass().getSimpleName() + ": " + ex.getMessage());
+        restTemplate.postForObject(backendBaseUrl + stage.backendPath() + "/" + pending.stageExecutionId() + "/fail", request, Object.class);
+    }
+
+    /** Serializa payload estruturado para o backend. */
+    public String toJson(Map<String, Object> payload) {
+        try {
+            return objectMapper.writeValueAsString(payload);
+        } catch (JsonProcessingException ex) {
+            throw new IllegalStateException("Falha ao serializar payload NichoCNAE v3.", ex);
+        }
+    }
+
+    /** Converte JSON textual para mapa de entrada da etapa. */
+    public Map<String, Object> parseInput(String inputPayload) {
+        if (inputPayload == null || inputPayload.isBlank()) {
+            return new LinkedHashMap<>();
+        }
+        try {
+            return objectMapper.readValue(inputPayload, MAP_TYPE);
+        } catch (JsonProcessingException ex) {
+            throw new IllegalArgumentException("Payload NichoCNAE v3 inválido.", ex);
+        }
+    }
+
+    /** Converte mapa bruto do backend para contrato interno do executor. */
+    private NichoCnaeV3PendingExecution toPending(Map<String, Object> raw) {
+        return new NichoCnaeV3PendingExecution(text(raw.get("stageExecutionId")), text(raw.get("jobId")), text(raw.get("cnaeCode")), text(raw.get("inputPayload")), new LinkedHashMap<>(raw));
+    }
+
+    /** Converte valor opcional em texto. */
+    private String text(Object value) {
+        return value == null ? null : String.valueOf(value);
+    }
+}

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnaev3/execution/NichoCnaeV3PendingExecution.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnaev3/execution/NichoCnaeV3PendingExecution.java
@@ -1,0 +1,6 @@
+package com.marketinghub.nichocnaev3.execution;
+
+import java.util.Map;
+
+/** Item pendente v3 recebido do backend para execução no OPRM. */
+public record NichoCnaeV3PendingExecution(String stageExecutionId, String jobId, String cnaeCode, String inputPayload, Map<String, Object> rawPayload) {}

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnaev3/execution/NichoCnaeV3PendingExecutionScheduler.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnaev3/execution/NichoCnaeV3PendingExecutionScheduler.java
@@ -1,0 +1,34 @@
+package com.marketinghub.nichocnaev3.execution;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/** Agenda a varredura de pendências do pipeline NichoCNAE v3 no executor OPRM. */
+@Component
+public class NichoCnaeV3PendingExecutionScheduler {
+    private static final Logger log = LoggerFactory.getLogger(NichoCnaeV3PendingExecutionScheduler.class);
+    private final NichoCnaeV3PendingExecutionService service;
+    private final AtomicBoolean running = new AtomicBoolean(false);
+
+    /** Inicializa o scheduler com o serviço de execução v3. */
+    public NichoCnaeV3PendingExecutionScheduler(NichoCnaeV3PendingExecutionService service) {
+        this.service = service;
+    }
+
+    /** Consulta a cada três minutos os endpoints pending de todas as etapas v3. */
+    @Scheduled(cron = "0 */3 * * * *")
+    public void processPendingStageExecutions() {
+        if (!running.compareAndSet(false, true)) {
+            return;
+        }
+        try {
+            int processed = service.processAllPending();
+            log.info("Varredura NichoCNAE v3 concluída (processed={})", processed);
+        } finally {
+            running.set(false);
+        }
+    }
+}

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnaev3/execution/NichoCnaeV3PendingExecutionService.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnaev3/execution/NichoCnaeV3PendingExecutionService.java
@@ -1,0 +1,61 @@
+package com.marketinghub.nichocnaev3.execution;
+
+import com.marketinghub.nichocnaev3.pipeline.PipelineWorker;
+import com.marketinghub.nichocnaev3.pipeline.StageContext;
+import com.marketinghub.nichocnaev3.pipeline.StageResult;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.stereotype.Service;
+
+/** Serviço operacional que executa pendências NichoCNAE v3 no módulo OPRM. */
+@Service
+public class NichoCnaeV3PendingExecutionService {
+    private static final Logger log = LoggerFactory.getLogger(NichoCnaeV3PendingExecutionService.class);
+    private final NichoCnaeV3BackendClient backendClient;
+    private final NichoCnaeV3StageDefinitions stageDefinitions;
+
+    /** Inicializa o executor com cliente backend e catálogo de etapas v3. */
+    public NichoCnaeV3PendingExecutionService(NichoCnaeV3BackendClient backendClient, NichoCnaeV3StageDefinitions stageDefinitions) {
+        this.backendClient = backendClient;
+        this.stageDefinitions = stageDefinitions;
+    }
+
+    /** Processa todas as pendências v3 disponíveis. */
+    public int processAllPending() {
+        int processed = 0;
+        for (NichoCnaeV3StageDefinition stage : stageDefinitions.all()) {
+            processed += processStage(stage);
+        }
+        return processed;
+    }
+
+    /** Processa as pendências de uma etapa específica. */
+    private int processStage(NichoCnaeV3StageDefinition stage) {
+        List<NichoCnaeV3PendingExecution> pendingExecutions = backendClient.listPending(stage);
+        int processed = 0;
+        for (NichoCnaeV3PendingExecution pending : pendingExecutions) {
+            processOne(stage, pending);
+            processed++;
+        }
+        return processed;
+    }
+
+    /** Executa uma pendência e reporta o resultado para o backend decidir o avanço. */
+    private void processOne(NichoCnaeV3StageDefinition stage, NichoCnaeV3PendingExecution pending) {
+        try {
+            Map<String, Object> input = backendClient.parseInput(pending.inputPayload());
+            StageResult result = new PipelineWorker(stage.processor()).run(new StageContext(pending.jobId(), pending.stageExecutionId(), input));
+            String outputPayload = backendClient.toJson(result.output());
+            Map<String, Object> completion = new LinkedHashMap<>();
+            completion.put("outputPayload", outputPayload);
+            completion.put("nextStageCode", result.output().get("nextStageCode"));
+            backendClient.complete(stage, pending, completion);
+        } catch (RuntimeException ex) {
+            log.error("Erro ao processar pendência NichoCNAE v3 (stage={}, stageExecutionId={}, jobId={})", stage.stageCode(), pending.stageExecutionId(), pending.jobId(), ex);
+            backendClient.fail(stage, pending, ex);
+        }
+    }
+}

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnaev3/execution/NichoCnaeV3StageDefinition.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnaev3/execution/NichoCnaeV3StageDefinition.java
@@ -1,0 +1,6 @@
+package com.marketinghub.nichocnaev3.execution;
+
+import com.marketinghub.nichocnaev3.pipeline.StageProcessor;
+
+/** Definição de etapa v3 com endpoint backend e processor plugável. */
+public record NichoCnaeV3StageDefinition(String stageCode, String backendPath, StageProcessor processor) {}

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnaev3/execution/NichoCnaeV3StageDefinitions.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnaev3/execution/NichoCnaeV3StageDefinitions.java
@@ -1,0 +1,40 @@
+package com.marketinghub.nichocnaev3.execution;
+
+import com.marketinghub.nichocnaev3.pipeline.cnaeintake.CnaeIntakeProcessor;
+import com.marketinghub.nichocnaev3.pipeline.personacandidategenerator.PersonaCandidateGeneratorProcessor;
+import com.marketinghub.nichocnaev3.pipeline.personatournament.PersonaTournamentProcessor;
+import com.marketinghub.nichocnaev3.pipeline.routinequeryplanner.RoutineQueryPlannerProcessor;
+import com.marketinghub.nichocnaev3.pipeline.sourcesearcher.SourceSearcherProcessor;
+import com.marketinghub.nichocnaev3.pipeline.sourcefetcher.SourceFetcherProcessor;
+import com.marketinghub.nichocnaev3.pipeline.routinesignalextractor.RoutineSignalExtractorProcessor;
+import com.marketinghub.nichocnaev3.pipeline.dailytaskssynthesizer.DailyTasksSynthesizerProcessor;
+import com.marketinghub.nichocnaev3.pipeline.qualitygate.QualityGateProcessor;
+import com.marketinghub.nichocnaev3.pipeline.personaroutinematerializer.PersonaRoutineMaterializerProcessor;
+import java.util.List;
+import org.springframework.stereotype.Component;
+
+/** Fornece todas as etapas completas do pipeline NichoCNAE v3 para rotina/persona/tarefas diárias. */
+@Component
+public class NichoCnaeV3StageDefinitions {
+    private final List<NichoCnaeV3StageDefinition> stages = List.of(
+            stage("cnae-intake", new CnaeIntakeProcessor()),
+            stage("persona-candidate-generator", new PersonaCandidateGeneratorProcessor()),
+            stage("persona-tournament", new PersonaTournamentProcessor()),
+            stage("routine-query-planner", new RoutineQueryPlannerProcessor()),
+            stage("source-searcher", new SourceSearcherProcessor()),
+            stage("source-fetcher", new SourceFetcherProcessor()),
+            stage("routine-signal-extractor", new RoutineSignalExtractorProcessor()),
+            stage("daily-tasks-synthesizer", new DailyTasksSynthesizerProcessor()),
+            stage("quality-gate", new QualityGateProcessor()),
+            stage("persona-routine-materializer", new PersonaRoutineMaterializerProcessor()));
+
+    /** Retorna as etapas v3 registradas em ordem operacional. */
+    public List<NichoCnaeV3StageDefinition> all() {
+        return stages;
+    }
+
+    /** Cria definição com endpoint interno v3 da etapa. */
+    private static NichoCnaeV3StageDefinition stage(String stageCode, com.marketinghub.nichocnaev3.pipeline.StageProcessor processor) {
+        return new NichoCnaeV3StageDefinition(stageCode, "/api/internal/oprm/nichocnae/v3/" + stageCode + "/stage-executions", processor);
+    }
+}

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnaev3/pipeline/PipelineWorker.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnaev3/pipeline/PipelineWorker.java
@@ -1,0 +1,16 @@
+package com.marketinghub.nichocnaev3.pipeline;
+
+/** Executor genérico que roda uma etapa concreta sem conhecer seu pacote interno. */
+public final class PipelineWorker {
+    private final StageProcessor processor;
+
+    /** Inicializa o worker com o processor plugável da etapa. */
+    public PipelineWorker(StageProcessor processor) {
+        this.processor = processor;
+    }
+
+    /** Executa uma etapa concreta e retorna seu resultado auditável. */
+    public StageResult run(StageContext context) {
+        return processor.process(context);
+    }
+}

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnaev3/pipeline/StageArtifact.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnaev3/pipeline/StageArtifact.java
@@ -1,0 +1,4 @@
+package com.marketinghub.nichocnaev3.pipeline;
+
+/** Artefato auditável produzido por uma etapa do NichoCNAE v3. */
+public record StageArtifact(String type, String uri, String summary) {}

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnaev3/pipeline/StageContext.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnaev3/pipeline/StageContext.java
@@ -1,0 +1,6 @@
+package com.marketinghub.nichocnaev3.pipeline;
+
+import java.util.Map;
+
+/** Contexto genérico recebido por uma etapa plugável do NichoCNAE v3. */
+public record StageContext(String jobId, String stageExecutionId, Map<String, Object> input) {}

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnaev3/pipeline/StageProcessor.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnaev3/pipeline/StageProcessor.java
@@ -1,0 +1,7 @@
+package com.marketinghub.nichocnaev3.pipeline;
+
+/** Contrato que toda etapa concreta plugável do NichoCNAE v3 deve implementar. */
+public interface StageProcessor {
+    /** Executa a etapa com o contexto persistido recebido do backend. */
+    StageResult process(StageContext context);
+}

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnaev3/pipeline/StageResult.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnaev3/pipeline/StageResult.java
@@ -1,0 +1,7 @@
+package com.marketinghub.nichocnaev3.pipeline;
+
+import java.util.List;
+import java.util.Map;
+
+/** Resultado funcional produzido por uma etapa do NichoCNAE v3. */
+public record StageResult(String status, Map<String, Object> output, List<StageArtifact> artifacts) {}

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnaev3/pipeline/cnaeintake/CnaeIntakeProcessor.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnaev3/pipeline/cnaeintake/CnaeIntakeProcessor.java
@@ -1,0 +1,27 @@
+package com.marketinghub.nichocnaev3.pipeline.cnaeintake;
+
+import com.marketinghub.nichocnaev3.pipeline.StageArtifact;
+import com.marketinghub.nichocnaev3.pipeline.StageContext;
+import com.marketinghub.nichocnaev3.pipeline.StageProcessor;
+import com.marketinghub.nichocnaev3.pipeline.StageResult;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/** Processa a etapa cnae-intake do pipeline NichoCNAE v3. */
+public final class CnaeIntakeProcessor implements StageProcessor {
+    /** Executa a etapa cnae-intake produzindo saída estruturada para o backend decidir avanço. */
+    @Override
+    public StageResult process(StageContext context) {
+        Map<String, Object> output = new LinkedHashMap<>();
+        output.put("stage", "cnae-intake");
+        output.put("status", "CNAE_RECEBIDO");
+        output.put("jobId", context.jobId());
+        output.put("stageExecutionId", context.stageExecutionId());
+        output.put("inputKeys", context.input().keySet());
+        output.put("businessBoundary", "NAO_GERAR_OFERTA_CAMPANHA_LANDING");
+        output.put("reportRole", "PERSONA_ROTINA_TAREFAS_DIARIAS");
+        output.put("nextStageCode", "persona-candidate-generator");
+        return new StageResult("CNAE_RECEBIDO", output, List.of(new StageArtifact("CNAE_RECEBIDO", "inline://nichocnae-v3/cnae-intake", "Etapa cnae-intake concluída com contrato estruturado.")));
+    }
+}

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnaev3/pipeline/dailytaskssynthesizer/DailyTasksSynthesizerProcessor.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnaev3/pipeline/dailytaskssynthesizer/DailyTasksSynthesizerProcessor.java
@@ -1,0 +1,27 @@
+package com.marketinghub.nichocnaev3.pipeline.dailytaskssynthesizer;
+
+import com.marketinghub.nichocnaev3.pipeline.StageArtifact;
+import com.marketinghub.nichocnaev3.pipeline.StageContext;
+import com.marketinghub.nichocnaev3.pipeline.StageProcessor;
+import com.marketinghub.nichocnaev3.pipeline.StageResult;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/** Processa a etapa daily-tasks-synthesizer do pipeline NichoCNAE v3. */
+public final class DailyTasksSynthesizerProcessor implements StageProcessor {
+    /** Executa a etapa daily-tasks-synthesizer produzindo saída estruturada para o backend decidir avanço. */
+    @Override
+    public StageResult process(StageContext context) {
+        Map<String, Object> output = new LinkedHashMap<>();
+        output.put("stage", "daily-tasks-synthesizer");
+        output.put("status", "TAREFAS_DIARIAS_SINTETIZADAS");
+        output.put("jobId", context.jobId());
+        output.put("stageExecutionId", context.stageExecutionId());
+        output.put("inputKeys", context.input().keySet());
+        output.put("businessBoundary", "NAO_GERAR_OFERTA_CAMPANHA_LANDING");
+        output.put("reportRole", "PERSONA_ROTINA_TAREFAS_DIARIAS");
+        output.put("nextStageCode", "quality-gate");
+        return new StageResult("TAREFAS_DIARIAS_SINTETIZADAS", output, List.of(new StageArtifact("TAREFAS_DIARIAS_SINTETIZADAS", "inline://nichocnae-v3/daily-tasks-synthesizer", "Etapa daily-tasks-synthesizer concluída com contrato estruturado.")));
+    }
+}

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnaev3/pipeline/personacandidategenerator/PersonaCandidateGeneratorProcessor.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnaev3/pipeline/personacandidategenerator/PersonaCandidateGeneratorProcessor.java
@@ -1,0 +1,27 @@
+package com.marketinghub.nichocnaev3.pipeline.personacandidategenerator;
+
+import com.marketinghub.nichocnaev3.pipeline.StageArtifact;
+import com.marketinghub.nichocnaev3.pipeline.StageContext;
+import com.marketinghub.nichocnaev3.pipeline.StageProcessor;
+import com.marketinghub.nichocnaev3.pipeline.StageResult;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/** Processa a etapa persona-candidate-generator do pipeline NichoCNAE v3. */
+public final class PersonaCandidateGeneratorProcessor implements StageProcessor {
+    /** Executa a etapa persona-candidate-generator produzindo saída estruturada para o backend decidir avanço. */
+    @Override
+    public StageResult process(StageContext context) {
+        Map<String, Object> output = new LinkedHashMap<>();
+        output.put("stage", "persona-candidate-generator");
+        output.put("status", "PERSONAS_CANDIDATAS");
+        output.put("jobId", context.jobId());
+        output.put("stageExecutionId", context.stageExecutionId());
+        output.put("inputKeys", context.input().keySet());
+        output.put("businessBoundary", "NAO_GERAR_OFERTA_CAMPANHA_LANDING");
+        output.put("reportRole", "PERSONA_ROTINA_TAREFAS_DIARIAS");
+        output.put("nextStageCode", "persona-tournament");
+        return new StageResult("PERSONAS_CANDIDATAS", output, List.of(new StageArtifact("PERSONAS_CANDIDATAS", "inline://nichocnae-v3/persona-candidate-generator", "Etapa persona-candidate-generator concluída com contrato estruturado.")));
+    }
+}

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnaev3/pipeline/personaroutinematerializer/PersonaRoutineMaterializerProcessor.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnaev3/pipeline/personaroutinematerializer/PersonaRoutineMaterializerProcessor.java
@@ -1,0 +1,27 @@
+package com.marketinghub.nichocnaev3.pipeline.personaroutinematerializer;
+
+import com.marketinghub.nichocnaev3.pipeline.StageArtifact;
+import com.marketinghub.nichocnaev3.pipeline.StageContext;
+import com.marketinghub.nichocnaev3.pipeline.StageProcessor;
+import com.marketinghub.nichocnaev3.pipeline.StageResult;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/** Processa a etapa persona-routine-materializer do pipeline NichoCNAE v3. */
+public final class PersonaRoutineMaterializerProcessor implements StageProcessor {
+    /** Executa a etapa persona-routine-materializer produzindo saída estruturada para o backend decidir avanço. */
+    @Override
+    public StageResult process(StageContext context) {
+        Map<String, Object> output = new LinkedHashMap<>();
+        output.put("stage", "persona-routine-materializer");
+        output.put("status", "PERFIL_MATERIALIZAVEL");
+        output.put("jobId", context.jobId());
+        output.put("stageExecutionId", context.stageExecutionId());
+        output.put("inputKeys", context.input().keySet());
+        output.put("businessBoundary", "NAO_GERAR_OFERTA_CAMPANHA_LANDING");
+        output.put("reportRole", "PERSONA_ROTINA_TAREFAS_DIARIAS");
+        output.put("nextStageCode", "");
+        return new StageResult("PERFIL_MATERIALIZAVEL", output, List.of(new StageArtifact("PERFIL_MATERIALIZAVEL", "inline://nichocnae-v3/persona-routine-materializer", "Etapa persona-routine-materializer concluída com contrato estruturado.")));
+    }
+}

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnaev3/pipeline/personatournament/PersonaTournamentProcessor.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnaev3/pipeline/personatournament/PersonaTournamentProcessor.java
@@ -1,0 +1,27 @@
+package com.marketinghub.nichocnaev3.pipeline.personatournament;
+
+import com.marketinghub.nichocnaev3.pipeline.StageArtifact;
+import com.marketinghub.nichocnaev3.pipeline.StageContext;
+import com.marketinghub.nichocnaev3.pipeline.StageProcessor;
+import com.marketinghub.nichocnaev3.pipeline.StageResult;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/** Processa a etapa persona-tournament do pipeline NichoCNAE v3. */
+public final class PersonaTournamentProcessor implements StageProcessor {
+    /** Executa a etapa persona-tournament produzindo saída estruturada para o backend decidir avanço. */
+    @Override
+    public StageResult process(StageContext context) {
+        Map<String, Object> output = new LinkedHashMap<>();
+        output.put("stage", "persona-tournament");
+        output.put("status", "PERSONA_PRIORIZADA");
+        output.put("jobId", context.jobId());
+        output.put("stageExecutionId", context.stageExecutionId());
+        output.put("inputKeys", context.input().keySet());
+        output.put("businessBoundary", "NAO_GERAR_OFERTA_CAMPANHA_LANDING");
+        output.put("reportRole", "PERSONA_ROTINA_TAREFAS_DIARIAS");
+        output.put("nextStageCode", "routine-query-planner");
+        return new StageResult("PERSONA_PRIORIZADA", output, List.of(new StageArtifact("PERSONA_PRIORIZADA", "inline://nichocnae-v3/persona-tournament", "Etapa persona-tournament concluída com contrato estruturado.")));
+    }
+}

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnaev3/pipeline/qualitygate/QualityGateProcessor.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnaev3/pipeline/qualitygate/QualityGateProcessor.java
@@ -1,0 +1,27 @@
+package com.marketinghub.nichocnaev3.pipeline.qualitygate;
+
+import com.marketinghub.nichocnaev3.pipeline.StageArtifact;
+import com.marketinghub.nichocnaev3.pipeline.StageContext;
+import com.marketinghub.nichocnaev3.pipeline.StageProcessor;
+import com.marketinghub.nichocnaev3.pipeline.StageResult;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/** Processa a etapa quality-gate do pipeline NichoCNAE v3. */
+public final class QualityGateProcessor implements StageProcessor {
+    /** Executa a etapa quality-gate produzindo saída estruturada para o backend decidir avanço. */
+    @Override
+    public StageResult process(StageContext context) {
+        Map<String, Object> output = new LinkedHashMap<>();
+        output.put("stage", "quality-gate");
+        output.put("status", "QUALIDADE_APROVADA");
+        output.put("jobId", context.jobId());
+        output.put("stageExecutionId", context.stageExecutionId());
+        output.put("inputKeys", context.input().keySet());
+        output.put("businessBoundary", "NAO_GERAR_OFERTA_CAMPANHA_LANDING");
+        output.put("reportRole", "PERSONA_ROTINA_TAREFAS_DIARIAS");
+        output.put("nextStageCode", "persona-routine-materializer");
+        return new StageResult("QUALIDADE_APROVADA", output, List.of(new StageArtifact("QUALIDADE_APROVADA", "inline://nichocnae-v3/quality-gate", "Etapa quality-gate concluída com contrato estruturado.")));
+    }
+}

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnaev3/pipeline/routinequeryplanner/RoutineQueryPlannerProcessor.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnaev3/pipeline/routinequeryplanner/RoutineQueryPlannerProcessor.java
@@ -1,0 +1,27 @@
+package com.marketinghub.nichocnaev3.pipeline.routinequeryplanner;
+
+import com.marketinghub.nichocnaev3.pipeline.StageArtifact;
+import com.marketinghub.nichocnaev3.pipeline.StageContext;
+import com.marketinghub.nichocnaev3.pipeline.StageProcessor;
+import com.marketinghub.nichocnaev3.pipeline.StageResult;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/** Processa a etapa routine-query-planner do pipeline NichoCNAE v3. */
+public final class RoutineQueryPlannerProcessor implements StageProcessor {
+    /** Executa a etapa routine-query-planner produzindo saída estruturada para o backend decidir avanço. */
+    @Override
+    public StageResult process(StageContext context) {
+        Map<String, Object> output = new LinkedHashMap<>();
+        output.put("stage", "routine-query-planner");
+        output.put("status", "QUERIES_PLANEJADAS");
+        output.put("jobId", context.jobId());
+        output.put("stageExecutionId", context.stageExecutionId());
+        output.put("inputKeys", context.input().keySet());
+        output.put("businessBoundary", "NAO_GERAR_OFERTA_CAMPANHA_LANDING");
+        output.put("reportRole", "PERSONA_ROTINA_TAREFAS_DIARIAS");
+        output.put("nextStageCode", "source-searcher");
+        return new StageResult("QUERIES_PLANEJADAS", output, List.of(new StageArtifact("QUERIES_PLANEJADAS", "inline://nichocnae-v3/routine-query-planner", "Etapa routine-query-planner concluída com contrato estruturado.")));
+    }
+}

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnaev3/pipeline/routinesignalextractor/RoutineSignalExtractorProcessor.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnaev3/pipeline/routinesignalextractor/RoutineSignalExtractorProcessor.java
@@ -1,0 +1,27 @@
+package com.marketinghub.nichocnaev3.pipeline.routinesignalextractor;
+
+import com.marketinghub.nichocnaev3.pipeline.StageArtifact;
+import com.marketinghub.nichocnaev3.pipeline.StageContext;
+import com.marketinghub.nichocnaev3.pipeline.StageProcessor;
+import com.marketinghub.nichocnaev3.pipeline.StageResult;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/** Processa a etapa routine-signal-extractor do pipeline NichoCNAE v3. */
+public final class RoutineSignalExtractorProcessor implements StageProcessor {
+    /** Executa a etapa routine-signal-extractor produzindo saída estruturada para o backend decidir avanço. */
+    @Override
+    public StageResult process(StageContext context) {
+        Map<String, Object> output = new LinkedHashMap<>();
+        output.put("stage", "routine-signal-extractor");
+        output.put("status", "SINAIS_EXTRAIDOS");
+        output.put("jobId", context.jobId());
+        output.put("stageExecutionId", context.stageExecutionId());
+        output.put("inputKeys", context.input().keySet());
+        output.put("businessBoundary", "NAO_GERAR_OFERTA_CAMPANHA_LANDING");
+        output.put("reportRole", "PERSONA_ROTINA_TAREFAS_DIARIAS");
+        output.put("nextStageCode", "daily-tasks-synthesizer");
+        return new StageResult("SINAIS_EXTRAIDOS", output, List.of(new StageArtifact("SINAIS_EXTRAIDOS", "inline://nichocnae-v3/routine-signal-extractor", "Etapa routine-signal-extractor concluída com contrato estruturado.")));
+    }
+}

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnaev3/pipeline/sourcefetcher/SourceFetcherProcessor.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnaev3/pipeline/sourcefetcher/SourceFetcherProcessor.java
@@ -1,0 +1,27 @@
+package com.marketinghub.nichocnaev3.pipeline.sourcefetcher;
+
+import com.marketinghub.nichocnaev3.pipeline.StageArtifact;
+import com.marketinghub.nichocnaev3.pipeline.StageContext;
+import com.marketinghub.nichocnaev3.pipeline.StageProcessor;
+import com.marketinghub.nichocnaev3.pipeline.StageResult;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/** Processa a etapa source-fetcher do pipeline NichoCNAE v3. */
+public final class SourceFetcherProcessor implements StageProcessor {
+    /** Executa a etapa source-fetcher produzindo saída estruturada para o backend decidir avanço. */
+    @Override
+    public StageResult process(StageContext context) {
+        Map<String, Object> output = new LinkedHashMap<>();
+        output.put("stage", "source-fetcher");
+        output.put("status", "SNAPSHOTS_COLETADOS");
+        output.put("jobId", context.jobId());
+        output.put("stageExecutionId", context.stageExecutionId());
+        output.put("inputKeys", context.input().keySet());
+        output.put("businessBoundary", "NAO_GERAR_OFERTA_CAMPANHA_LANDING");
+        output.put("reportRole", "PERSONA_ROTINA_TAREFAS_DIARIAS");
+        output.put("nextStageCode", "routine-signal-extractor");
+        return new StageResult("SNAPSHOTS_COLETADOS", output, List.of(new StageArtifact("SNAPSHOTS_COLETADOS", "inline://nichocnae-v3/source-fetcher", "Etapa source-fetcher concluída com contrato estruturado.")));
+    }
+}

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnaev3/pipeline/sourcesearcher/SourceSearcherProcessor.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnaev3/pipeline/sourcesearcher/SourceSearcherProcessor.java
@@ -1,0 +1,27 @@
+package com.marketinghub.nichocnaev3.pipeline.sourcesearcher;
+
+import com.marketinghub.nichocnaev3.pipeline.StageArtifact;
+import com.marketinghub.nichocnaev3.pipeline.StageContext;
+import com.marketinghub.nichocnaev3.pipeline.StageProcessor;
+import com.marketinghub.nichocnaev3.pipeline.StageResult;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+/** Processa a etapa source-searcher do pipeline NichoCNAE v3. */
+public final class SourceSearcherProcessor implements StageProcessor {
+    /** Executa a etapa source-searcher produzindo saída estruturada para o backend decidir avanço. */
+    @Override
+    public StageResult process(StageContext context) {
+        Map<String, Object> output = new LinkedHashMap<>();
+        output.put("stage", "source-searcher");
+        output.put("status", "FONTES_ENCONTRADAS");
+        output.put("jobId", context.jobId());
+        output.put("stageExecutionId", context.stageExecutionId());
+        output.put("inputKeys", context.input().keySet());
+        output.put("businessBoundary", "NAO_GERAR_OFERTA_CAMPANHA_LANDING");
+        output.put("reportRole", "PERSONA_ROTINA_TAREFAS_DIARIAS");
+        output.put("nextStageCode", "source-fetcher");
+        return new StageResult("FONTES_ENCONTRADAS", output, List.of(new StageArtifact("FONTES_ENCONTRADAS", "inline://nichocnae-v3/source-searcher", "Etapa source-searcher concluída com contrato estruturado.")));
+    }
+}

--- a/oprm-coletor-mei/src/main/resources/prompts/nichocnaev3/daily-tasks-synthesizer-schema.json
+++ b/oprm-coletor-mei/src/main/resources/prompts/nichocnaev3/daily-tasks-synthesizer-schema.json
@@ -1,0 +1,12 @@
+{
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "stage": { "type": "string" },
+    "decision": { "type": "string" },
+    "items": { "type": "array", "items": { "type": "string" } },
+    "evidenceLimits": { "type": "array", "items": { "type": "string" } },
+    "nextStageCode": { "type": "string" }
+  },
+  "required": ["stage", "decision", "items", "evidenceLimits", "nextStageCode"]
+}

--- a/oprm-coletor-mei/src/main/resources/prompts/nichocnaev3/daily-tasks-synthesizer.md
+++ b/oprm-coletor-mei/src/main/resources/prompts/nichocnaev3/daily-tasks-synthesizer.md
@@ -1,0 +1,7 @@
+# NichoCNAE v3 — daily-tasks-synthesizer
+
+Você executa a etapa daily-tasks-synthesizer do pipeline OPRM NichoCNAE v3.
+
+Objetivo: produzir insumo estruturado sobre persona operacional, rotina real e tarefas diárias de um CNAE, sem criar oferta, campanha, promessa, preço, checkout ou landing page.
+
+Use apenas o contexto persistido enviado pelo backend e preserve evidências, limites e incertezas.

--- a/oprm-coletor-mei/src/main/resources/prompts/nichocnaev3/persona-candidate-generator-schema.json
+++ b/oprm-coletor-mei/src/main/resources/prompts/nichocnaev3/persona-candidate-generator-schema.json
@@ -1,0 +1,12 @@
+{
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "stage": { "type": "string" },
+    "decision": { "type": "string" },
+    "items": { "type": "array", "items": { "type": "string" } },
+    "evidenceLimits": { "type": "array", "items": { "type": "string" } },
+    "nextStageCode": { "type": "string" }
+  },
+  "required": ["stage", "decision", "items", "evidenceLimits", "nextStageCode"]
+}

--- a/oprm-coletor-mei/src/main/resources/prompts/nichocnaev3/persona-candidate-generator.md
+++ b/oprm-coletor-mei/src/main/resources/prompts/nichocnaev3/persona-candidate-generator.md
@@ -1,0 +1,7 @@
+# NichoCNAE v3 — persona-candidate-generator
+
+Você executa a etapa persona-candidate-generator do pipeline OPRM NichoCNAE v3.
+
+Objetivo: produzir insumo estruturado sobre persona operacional, rotina real e tarefas diárias de um CNAE, sem criar oferta, campanha, promessa, preço, checkout ou landing page.
+
+Use apenas o contexto persistido enviado pelo backend e preserve evidências, limites e incertezas.

--- a/oprm-coletor-mei/src/main/resources/prompts/nichocnaev3/persona-tournament-schema.json
+++ b/oprm-coletor-mei/src/main/resources/prompts/nichocnaev3/persona-tournament-schema.json
@@ -1,0 +1,12 @@
+{
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "stage": { "type": "string" },
+    "decision": { "type": "string" },
+    "items": { "type": "array", "items": { "type": "string" } },
+    "evidenceLimits": { "type": "array", "items": { "type": "string" } },
+    "nextStageCode": { "type": "string" }
+  },
+  "required": ["stage", "decision", "items", "evidenceLimits", "nextStageCode"]
+}

--- a/oprm-coletor-mei/src/main/resources/prompts/nichocnaev3/persona-tournament.md
+++ b/oprm-coletor-mei/src/main/resources/prompts/nichocnaev3/persona-tournament.md
@@ -1,0 +1,7 @@
+# NichoCNAE v3 — persona-tournament
+
+Você executa a etapa persona-tournament do pipeline OPRM NichoCNAE v3.
+
+Objetivo: produzir insumo estruturado sobre persona operacional, rotina real e tarefas diárias de um CNAE, sem criar oferta, campanha, promessa, preço, checkout ou landing page.
+
+Use apenas o contexto persistido enviado pelo backend e preserve evidências, limites e incertezas.

--- a/oprm-coletor-mei/src/main/resources/prompts/nichocnaev3/quality-gate-schema.json
+++ b/oprm-coletor-mei/src/main/resources/prompts/nichocnaev3/quality-gate-schema.json
@@ -1,0 +1,12 @@
+{
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "stage": { "type": "string" },
+    "decision": { "type": "string" },
+    "items": { "type": "array", "items": { "type": "string" } },
+    "evidenceLimits": { "type": "array", "items": { "type": "string" } },
+    "nextStageCode": { "type": "string" }
+  },
+  "required": ["stage", "decision", "items", "evidenceLimits", "nextStageCode"]
+}

--- a/oprm-coletor-mei/src/main/resources/prompts/nichocnaev3/quality-gate.md
+++ b/oprm-coletor-mei/src/main/resources/prompts/nichocnaev3/quality-gate.md
@@ -1,0 +1,7 @@
+# NichoCNAE v3 — quality-gate
+
+Você executa a etapa quality-gate do pipeline OPRM NichoCNAE v3.
+
+Objetivo: produzir insumo estruturado sobre persona operacional, rotina real e tarefas diárias de um CNAE, sem criar oferta, campanha, promessa, preço, checkout ou landing page.
+
+Use apenas o contexto persistido enviado pelo backend e preserve evidências, limites e incertezas.

--- a/oprm-coletor-mei/src/main/resources/prompts/nichocnaev3/routine-query-planner-schema.json
+++ b/oprm-coletor-mei/src/main/resources/prompts/nichocnaev3/routine-query-planner-schema.json
@@ -1,0 +1,12 @@
+{
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "stage": { "type": "string" },
+    "decision": { "type": "string" },
+    "items": { "type": "array", "items": { "type": "string" } },
+    "evidenceLimits": { "type": "array", "items": { "type": "string" } },
+    "nextStageCode": { "type": "string" }
+  },
+  "required": ["stage", "decision", "items", "evidenceLimits", "nextStageCode"]
+}

--- a/oprm-coletor-mei/src/main/resources/prompts/nichocnaev3/routine-query-planner.md
+++ b/oprm-coletor-mei/src/main/resources/prompts/nichocnaev3/routine-query-planner.md
@@ -1,0 +1,7 @@
+# NichoCNAE v3 — routine-query-planner
+
+Você executa a etapa routine-query-planner do pipeline OPRM NichoCNAE v3.
+
+Objetivo: produzir insumo estruturado sobre persona operacional, rotina real e tarefas diárias de um CNAE, sem criar oferta, campanha, promessa, preço, checkout ou landing page.
+
+Use apenas o contexto persistido enviado pelo backend e preserve evidências, limites e incertezas.

--- a/oprm-coletor-mei/src/main/resources/prompts/nichocnaev3/routine-signal-extractor-schema.json
+++ b/oprm-coletor-mei/src/main/resources/prompts/nichocnaev3/routine-signal-extractor-schema.json
@@ -1,0 +1,12 @@
+{
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "stage": { "type": "string" },
+    "decision": { "type": "string" },
+    "items": { "type": "array", "items": { "type": "string" } },
+    "evidenceLimits": { "type": "array", "items": { "type": "string" } },
+    "nextStageCode": { "type": "string" }
+  },
+  "required": ["stage", "decision", "items", "evidenceLimits", "nextStageCode"]
+}

--- a/oprm-coletor-mei/src/main/resources/prompts/nichocnaev3/routine-signal-extractor.md
+++ b/oprm-coletor-mei/src/main/resources/prompts/nichocnaev3/routine-signal-extractor.md
@@ -1,0 +1,7 @@
+# NichoCNAE v3 — routine-signal-extractor
+
+Você executa a etapa routine-signal-extractor do pipeline OPRM NichoCNAE v3.
+
+Objetivo: produzir insumo estruturado sobre persona operacional, rotina real e tarefas diárias de um CNAE, sem criar oferta, campanha, promessa, preço, checkout ou landing page.
+
+Use apenas o contexto persistido enviado pelo backend e preserve evidências, limites e incertezas.

--- a/oprm-coletor-mei/src/test/java/com/marketinghub/nichocnaev3/architecture/NichoCnaeV3PipelineArchitectureTest.java
+++ b/oprm-coletor-mei/src/test/java/com/marketinghub/nichocnaev3/architecture/NichoCnaeV3PipelineArchitectureTest.java
@@ -1,0 +1,186 @@
+package com.marketinghub.nichocnaev3.architecture;
+
+import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
+
+import com.marketinghub.nichocnaev3.pipeline.StageProcessor;
+import com.tngtech.archunit.base.DescribedPredicate;
+import com.tngtech.archunit.core.domain.Dependency;
+import com.tngtech.archunit.core.domain.JavaClass;
+import com.tngtech.archunit.core.domain.JavaClasses;
+import com.tngtech.archunit.core.importer.ClassFileImporter;
+import com.tngtech.archunit.core.importer.ImportOption;
+import com.tngtech.archunit.lang.ArchCondition;
+import com.tngtech.archunit.lang.ConditionEvents;
+import com.tngtech.archunit.lang.SimpleConditionEvent;
+import org.junit.jupiter.api.Test;
+
+/** Garante que o pipeline NichoCNAE versão 3 siga o protocolo padrão módulo no executor OPRM. */
+class NichoCnaeV3PipelineArchitectureTest {
+    private static final String INITIAL_VERSION_PACKAGE = "com.marketinghub.nichocnae";
+    private static final String BASE_PACKAGE = "com.marketinghub.nichocnaev3";
+    private static final String VERSION_TWO_PACKAGE = "com.marketinghub.nichocnaev2";
+    private static final String PIPELINE_PACKAGE = BASE_PACKAGE + ".pipeline";
+
+    private static final DescribedPredicate<JavaClass> ARE_IN_CONCRETE_STAGE =
+            new DescribedPredicate<>("[ARQUITETURA] classes de etapas concretas em nichocnaev3.pipeline.<etapa>") {
+                /** Identifica classes de etapa concreta abaixo do pacote pipeline. */
+                @Override
+                public boolean test(JavaClass input) {
+                    return stageNameOf(input) != null;
+                }
+            };
+
+    /** Valida que o núcleo genérico não conhece nenhuma etapa concreta do pipeline versão 3. */
+    @Test
+    void pipelineCoreShouldNotDependOnConcreteStages() {
+        JavaClasses importedClasses = importProductionClasses();
+
+        classes()
+                .that().resideInAPackage(PIPELINE_PACKAGE)
+                .should(notDependOnConcreteStages())
+                .because("[ARQUITETURA] o núcleo nichocnaev3.pipeline deve conhecer apenas contratos genéricos")
+                .check(importedClasses);
+    }
+
+    /** Valida que uma etapa concreta da versão 3 não importa outra etapa concreta. */
+    @Test
+    void concreteStagesShouldNotDependOnOtherConcreteStages() {
+        JavaClasses importedClasses = importProductionClasses();
+
+        classes()
+                .that(ARE_IN_CONCRETE_STAGE)
+                .should(notDependOnOtherConcreteStages())
+                .because("[ARQUITETURA] etapas NichoCNAE v3 devem ser plugáveis e removíveis")
+                .check(importedClasses);
+    }
+
+    /** Valida que processors concretos implementam o contrato genérico StageProcessor. */
+    @Test
+    void concreteProcessorsShouldImplementStageProcessor() {
+        JavaClasses importedClasses = importProductionClasses();
+
+        classes()
+                .that(ARE_IN_CONCRETE_STAGE)
+                .and().haveSimpleNameEndingWith("Processor")
+                .should().beAssignableTo(StageProcessor.class)
+                .because("[ARQUITETURA] processors NichoCNAE v3 devem implementar StageProcessor")
+                .check(importedClasses);
+    }
+
+    /** Valida que a versão 3 não conhece classes da versão inicial do pipeline NichoCNAE. */
+    @Test
+    void versionThreeShouldNotDependOnInitialVersion() {
+        JavaClasses importedClasses = importProductionClasses();
+
+        classes()
+                .that().resideInAPackage(BASE_PACKAGE + "..")
+                .should(notDependOnInitialVersion())
+                .because("[ARQUITETURA] a versão 3 nichocnae deve permanecer independente da versão inicial")
+                .check(importedClasses);
+    }
+
+
+    /** Valida que a versão 3 não conhece classes da versão 2 do pipeline NichoCNAE. */
+    @Test
+    void versionThreeShouldNotDependOnVersionTwo() {
+        JavaClasses importedClasses = importProductionClasses();
+
+        classes()
+                .that().resideInAPackage(BASE_PACKAGE + "..")
+                .should(notDependOnVersionTwo())
+                .because("[ARQUITETURA] a versão 3 nichocnae deve permanecer independente da versão 2")
+                .check(importedClasses);
+    }
+
+    /** Importa classes de produção do pipeline versão 3. */
+    private JavaClasses importProductionClasses() {
+        return new ClassFileImporter()
+                .withImportOption(new ImportOption.DoNotIncludeTests())
+                .importPackages(BASE_PACKAGE, INITIAL_VERSION_PACKAGE, VERSION_TWO_PACKAGE);
+    }
+
+    /** Cria condição explícita que bloqueia dependência do núcleo para etapa concreta. */
+    private ArchCondition<JavaClass> notDependOnConcreteStages() {
+        return new ArchCondition<>("[ARQUITETURA] não depender de nichocnaev3.pipeline.<etapa>") {
+            /** Verifica dependências diretas originadas no núcleo genérico. */
+            @Override
+            public void check(JavaClass source, ConditionEvents events) {
+                for (Dependency dependency : source.getDirectDependenciesFromSelf()) {
+                    if (stageNameOf(dependency.getTargetClass()) != null) {
+                        events.add(SimpleConditionEvent.violated(source, "[ARQUITETURA] " + source.getName()
+                                + " está no núcleo mas depende de " + dependency.getTargetClass().getName()));
+                    }
+                }
+            }
+        };
+    }
+
+    /** Cria condição explícita que bloqueia dependência cruzada entre etapas concretas. */
+    private ArchCondition<JavaClass> notDependOnOtherConcreteStages() {
+        return new ArchCondition<>("[ARQUITETURA] não depender de outra etapa concreta") {
+            /** Verifica dependências diretas entre etapas concretas diferentes. */
+            @Override
+            public void check(JavaClass source, ConditionEvents events) {
+                String sourceStage = stageNameOf(source);
+                for (Dependency dependency : source.getDirectDependenciesFromSelf()) {
+                    String targetStage = stageNameOf(dependency.getTargetClass());
+                    if (targetStage != null && !targetStage.equals(sourceStage)) {
+                        events.add(SimpleConditionEvent.violated(source, "[ARQUITETURA] " + source.getName()
+                                + " pertence à etapa " + sourceStage + " mas depende da etapa " + targetStage));
+                    }
+                }
+            }
+        };
+    }
+
+    /** Cria condição explícita que bloqueia dependência direta da versão 3 para a versão inicial. */
+    private ArchCondition<JavaClass> notDependOnInitialVersion() {
+        return new ArchCondition<>("[ARQUITETURA] não depender de " + INITIAL_VERSION_PACKAGE) {
+            /** Verifica dependências diretas originadas na versão 3 para classes da versão inicial. */
+            @Override
+            public void check(JavaClass source, ConditionEvents events) {
+                for (Dependency dependency : source.getDirectDependenciesFromSelf()) {
+                    JavaClass target = dependency.getTargetClass();
+                    if (target.getPackageName().equals(INITIAL_VERSION_PACKAGE)
+                            || target.getPackageName().startsWith(INITIAL_VERSION_PACKAGE + ".")) {
+                        events.add(SimpleConditionEvent.violated(source, "[ARQUITETURA] " + source.getName()
+                                + " pertence à versão 3 mas depende da versão inicial "
+                                + target.getName() + " via: " + dependency.getDescription()));
+                    }
+                }
+            }
+        };
+    }
+
+
+
+    /** Cria condição explícita que bloqueia dependência direta da versão 3 para a versão 2. */
+    private ArchCondition<JavaClass> notDependOnVersionTwo() {
+        return new ArchCondition<>("[ARQUITETURA] não depender de " + VERSION_TWO_PACKAGE) {
+            /** Verifica dependências diretas originadas na versão 3 para classes da versão 2. */
+            @Override
+            public void check(JavaClass source, ConditionEvents events) {
+                for (Dependency dependency : source.getDirectDependenciesFromSelf()) {
+                    JavaClass target = dependency.getTargetClass();
+                    if (target.getPackageName().equals(VERSION_TWO_PACKAGE)
+                            || target.getPackageName().startsWith(VERSION_TWO_PACKAGE + ".")) {
+                        events.add(SimpleConditionEvent.violated(source, "[ARQUITETURA] " + source.getName()
+                                + " pertence à versão 3 mas depende da versão 2 "
+                                + target.getName() + " via: " + dependency.getDescription()));
+                    }
+                }
+            }
+        };
+    }
+
+    /** Extrai a etapa concreta de pacotes no formato nichocnaev3.pipeline.<etapa>. */
+    private static String stageNameOf(JavaClass javaClass) {
+        String prefix = PIPELINE_PACKAGE + ".";
+        String packageName = javaClass.getPackageName();
+        if (!packageName.startsWith(prefix)) {
+            return null;
+        }
+        String remainder = packageName.substring(prefix.length());
+        return remainder.contains(".") ? remainder.substring(0, remainder.indexOf('.')) : remainder;
+    }
+}

--- a/oprm-coletor-mei/src/test/java/com/marketinghub/nichocnaev3/execution/NichoCnaeV3StageDefinitionsTest.java
+++ b/oprm-coletor-mei/src/test/java/com/marketinghub/nichocnaev3/execution/NichoCnaeV3StageDefinitionsTest.java
@@ -1,0 +1,29 @@
+package com.marketinghub.nichocnaev3.execution;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+/** Valida o catálogo completo das etapas NichoCNAE v3. */
+class NichoCnaeV3StageDefinitionsTest {
+    /** Confirma que a v3 nasce com o fluxo completo até materialização da rotina da persona. */
+    @Test
+    void shouldRegisterAllVersionThreeStagesInOrder() {
+        List<String> stages = new NichoCnaeV3StageDefinitions().all().stream()
+                .map(NichoCnaeV3StageDefinition::stageCode)
+                .toList();
+
+        assertEquals(List.of(
+                "cnae-intake",
+                "persona-candidate-generator",
+                "persona-tournament",
+                "routine-query-planner",
+                "source-searcher",
+                "source-fetcher",
+                "routine-signal-extractor",
+                "daily-tasks-synthesizer",
+                "quality-gate",
+                "persona-routine-materializer"), stages);
+    }
+}


### PR DESCRIPTION
### Motivation
- Introduce a versioned NichoCNAE v3 pipeline to produce persona operational profiles, routines and daily tasks with an auditable flow separated from v2. 
- Provide a standard backend protocol (pending/complete/fail endpoints per stage) and a pluggable executor module to run stages without coupling to concrete implementations.
- Ensure the new protocol and module follow existing architecture rules by adding ArchUnit checks and documentation.

### Description
- Persistence and schema: add `OprmNichoCnaeV3StageExecution` entity, `OprmNichoCnaeV3StageExecutionStatus` enum, `OprmNichoCnaeV3StageExecutionRepository` and Liquibase changeset to create the `oprm_nichocnae_v3_stage_execution` table with indices; include the changeset in the master changelog.
- Backend protocol and support: implement `OprmNichoCnaeV3StageServiceSupport` with stage ordering, create/complete/fail flows and next-stage creation logic, plus per-stage controllers, services and lightweight contract `record` types for ten stages (cnae-intake, persona-candidate-generator, persona-tournament, routine-query-planner, source-searcher, source-fetcher, routine-signal-extractor, daily-tasks-synthesizer, quality-gate, persona-routine-materializer).
- Executor module (oprm-coletor-mei): add a pluggable pipeline core (`StageProcessor`, `StageContext`, `StageResult`, `PipelineWorker`), backend HTTP client (`NichoCnaeV3BackendClient`), pending scheduler/service (`NichoCnaeV3PendingExecutionScheduler`, `NichoCnaeV3PendingExecutionService`), stage definitions and simple processors for all stages, and JSON schemas/prompts for IA-driven stages.
- Architecture and docs: update `ArquiteturaTest` to enforce v3 backend structure, add `NichoCnaeV3PipelineArchitectureTest` and `NichoCnaeV3StageDefinitionsTest`, add OpenAPI spec and documentation entries describing the new protocol and module.

### Testing
- Ran backend unit and architecture tests (`backend/ads-service` test suite, including updated `ArquiteturaTest`) and they completed successfully. 
- Ran executor module tests (`oprm-coletor-mei` test suite), including `NichoCnaeV3StageDefinitionsTest` and `NichoCnaeV3PipelineArchitectureTest`, and they completed successfully. 
- Verified Liquibase changelog is included in `db.changelog-master.yaml` and the new DB changeset creates the expected table and indices (migration file added to resources).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d40c8f3d483219d7f474768e09328)