### PR TITLE
OPRM: switch CNAE table button to NichoCNAE v3 and add v3 pipeline page

### DIFF
--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -1394,3 +1394,8 @@
 - Foi feito: criado o executor `com.marketinghub.nichocnaev3` no `oprm-coletor-mei` com núcleo genérico, catálogo de 10 etapas, processors plugáveis, scheduler de pendências, cliente backend, prompts/schemas versionados para etapas com IA e teste ArchUnit próprio.
 - Objetivo de negócio: transformar um CNAE em persona operacional, rotina real e lista de tarefas diárias auditável, sem criar oferta, campanha ou landing nesta fase.
 - Prevenção: a v3 nasce separada da v2 para evitar remendos no fluxo que parava após o planejador de buscas por falta de etapa cadastrada.
+
+## 2026-06-25 — Tela de CNAEs passa a abrir NichoCNAE v3
+
+- Alterado o botão da tabela de CNAEs do OPRM para abrir o pipeline NichoCNAE v3 em vez da v2.
+- Criada tela inicial do pipeline v3 no frontend, com acionamento do endpoint canônico `cnae-intake` para iniciar novo job v3 por CNAE.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -115,6 +115,7 @@ import OprmCnaeDetailPlaceholderPage from "./pages/oprm/OprmCnaeDetailPlaceholde
 import OprmCnaePipelineStageDetailPage from "./pages/oprm/OprmCnaePipelineStageDetailPage";
 import OprmNichoCnaeV2PipelinePage from "./pages/oprm/OprmNichoCnaeV2PipelinePage";
 import OprmNichoCnaeV2JobDetailPage from "./pages/oprm/OprmNichoCnaeV2JobDetailPage";
+import OprmNichoCnaeV3PipelinePage from "./pages/oprm/OprmNichoCnaeV3PipelinePage";
 import OprmEnrichedNicheDetailPage from "./pages/oprm/OprmEnrichedNicheDetailPage";
 import OprmGeneralAudiencesPage from "./pages/oprm/OprmGeneralAudiencesPage";
 import OprmJobsPage from "./pages/oprm/OprmJobsPage";
@@ -339,6 +340,10 @@ export default function App() {
               <Route
                 path="/oprm/cnaes/:cnaeCode/pipeline-v2"
                 element={<OprmNichoCnaeV2PipelinePage />}
+              />
+              <Route
+                path="/oprm/cnaes/:cnaeCode/pipeline-v3"
+                element={<OprmNichoCnaeV3PipelinePage />}
               />
               <Route
                 path="/oprm/cnaes/:cnaeCode/pipeline-v2/jobs/:jobId"

--- a/frontend/src/__tests__/OprmNavigation.test.tsx
+++ b/frontend/src/__tests__/OprmNavigation.test.tsx
@@ -53,17 +53,17 @@ describe("OPRM navigation", () => {
     ).toBeTruthy();
   });
 
-  it("renders v2 pipeline design page for a CNAE", () => {
-    setup(<App />, ["/oprm/cnaes/9602501/pipeline-v2"]);
-    expect(screen.getByText(/^Pipeline NichoCNAE v2$/)).toBeTruthy();
+  it("renders v3 pipeline page for a CNAE", () => {
+    setup(<App />, ["/oprm/cnaes/9602501/pipeline-v3"]);
+    expect(screen.getByText(/^Pipeline NichoCNAE v3$/)).toBeTruthy();
     expect(screen.getByText(/^CNAE 9602501$/)).toBeTruthy();
-    expect(screen.getByText(/^Gerador de Candidatos$/)).toBeTruthy();
+    expect(screen.getByText(/^Entrada do CNAE$/)).toBeTruthy();
     expect(
-      screen.getByRole("button", { name: /iniciar novo job v2/i }),
+      screen.getByRole("button", { name: /iniciar novo job v3/i }),
     ).toBeTruthy();
-    expect(screen.getByText(/^Acumulador de Conhecimento$/)).toBeTruthy();
-    expect(screen.getAllByText(/^IA$/).length).toBeGreaterThan(0);
-    expect(screen.getAllByText(/^Web$/).length).toBeGreaterThan(0);
+    expect(
+      screen.getByText(/^Materialização de persona e rotina$/),
+    ).toBeTruthy();
   });
 
   it("translates v2 job stage names returned in English", () => {

--- a/frontend/src/api/oprm/useStartOprmNichoCnaeV3Job.ts
+++ b/frontend/src/api/oprm/useStartOprmNichoCnaeV3Job.ts
@@ -1,0 +1,35 @@
+import { useMutation } from "@tanstack/react-query";
+import { buildApiUrl } from "../../utils/buildApiUrl";
+
+export interface OprmNichoCnaeV3JobStartResult {
+  stageExecutionId: number;
+  jobId: string;
+  cnaeCode: string;
+  stageCode: string;
+  status: string;
+}
+
+async function startOprmNichoCnaeV3Job(
+  cnaeCode: string,
+): Promise<OprmNichoCnaeV3JobStartResult> {
+  const response = await fetch(
+    buildApiUrl(
+      `/api/internal/oprm/nichocnae/v3/cnae-intake/stage-executions/cnaes/${encodeURIComponent(cnaeCode)}`,
+    ),
+    { method: "POST" },
+  );
+  if (!response.ok) {
+    const message = await response.text();
+    throw new Error(
+      message ||
+        `Não foi possível iniciar o job v3 do NichoCNAE (status ${response.status}).`,
+    );
+  }
+  return (await response.json()) as OprmNichoCnaeV3JobStartResult;
+}
+
+export function useStartOprmNichoCnaeV3Job(cnaeCode: string) {
+  return useMutation({
+    mutationFn: () => startOprmNichoCnaeV3Job(cnaeCode),
+  });
+}

--- a/frontend/src/pages/oprm/OprmCnaeVolumePage.tsx
+++ b/frontend/src/pages/oprm/OprmCnaeVolumePage.tsx
@@ -299,7 +299,7 @@ export default function OprmCnaeVolumePage() {
                       <th>Pendente materializar</th>
                       <th>Custo</th>
                       <th>Pesquisa</th>
-                      <th>Pipeline v2</th>
+                      <th>Pipeline v3</th>
                     </>
                   ) : (
                     <th>Status</th>
@@ -312,7 +312,9 @@ export default function OprmCnaeVolumePage() {
                       <tr key={`${item.snapshotDate}-${item.cnaeCode}`}>
                         <td>
                           <span className="d-inline-flex align-items-center gap-2">
-                            <span>{(currentPage - 1) * pageSize + index + 1}</span>
+                            <span>
+                              {(currentPage - 1) * pageSize + index + 1}
+                            </span>
                             {item.nicheResearchRunning ? (
                               <RunningProcessingIcon />
                             ) : null}
@@ -361,10 +363,10 @@ export default function OprmCnaeVolumePage() {
                         <td>
                           <Link
                             className="btn btn-sm btn-outline-primary text-nowrap"
-                            to={`/oprm/cnaes/${encodeURIComponent(item.cnaeCode)}/pipeline-v2`}
-                            title="Abrir design da v2 do pipeline NichoCNAE"
+                            to={`/oprm/cnaes/${encodeURIComponent(item.cnaeCode)}/pipeline-v3`}
+                            title="Abrir design da v3 do pipeline NichoCNAE"
                           >
-                            Ver v2
+                            Ver v3
                           </Link>
                         </td>
                       </tr>

--- a/frontend/src/pages/oprm/OprmNichoCnaeV3PipelinePage.tsx
+++ b/frontend/src/pages/oprm/OprmNichoCnaeV3PipelinePage.tsx
@@ -1,0 +1,99 @@
+import { Link, useParams } from "react-router-dom";
+import PageTitle from "../../components/PageTitle";
+import { useStartOprmNichoCnaeV3Job } from "../../api/oprm/useStartOprmNichoCnaeV3Job";
+
+const v3Stages = [
+  "Entrada do CNAE",
+  "Geração de personas candidatas",
+  "Torneio de personas",
+  "Planejamento de buscas da rotina",
+  "Busca de fontes",
+  "Coleta de fontes",
+  "Extração de sinais da rotina",
+  "Síntese de tarefas diárias",
+  "Quality gate",
+  "Materialização de persona e rotina",
+];
+
+export default function OprmNichoCnaeV3PipelinePage() {
+  const { cnaeCode } = useParams();
+  const decodedCnaeCode = decodeURIComponent(cnaeCode ?? "");
+  const startJob = useStartOprmNichoCnaeV3Job(decodedCnaeCode);
+
+  const handleStart = () => {
+    if (!decodedCnaeCode || startJob.isPending) {
+      return;
+    }
+    startJob.mutate();
+  };
+
+  return (
+    <div className="d-flex flex-column gap-4">
+      <div className="d-flex flex-wrap justify-content-between gap-3 align-items-start">
+        <div>
+          <PageTitle>Pipeline NichoCNAE v3</PageTitle>
+          <p className="text-muted mb-1">CNAE {decodedCnaeCode}</p>
+          <p className="mb-0">
+            Fluxo v3 focado em transformar o CNAE em personas, rotina real e
+            tarefas diárias para encontrar dores vendáveis com mais precisão.
+          </p>
+        </div>
+        <div className="d-flex gap-2">
+          <Link className="btn btn-outline-secondary" to="/oprm">
+            Voltar para CNAEs
+          </Link>
+          <button
+            type="button"
+            className="btn btn-primary"
+            onClick={handleStart}
+            disabled={!decodedCnaeCode || startJob.isPending}
+          >
+            {startJob.isPending ? (
+              <>
+                <span
+                  className="spinner-border spinner-border-sm me-2"
+                  aria-hidden="true"
+                />
+                Iniciando v3...
+              </>
+            ) : (
+              "Iniciar novo job v3"
+            )}
+          </button>
+        </div>
+      </div>
+
+      {startJob.isSuccess ? (
+        <div className="alert alert-success" role="status">
+          Job v3 iniciado: <strong>{startJob.data.jobId}</strong>. A primeira
+          etapa criada foi <strong>{startJob.data.stageCode}</strong> com status{" "}
+          <strong>{startJob.data.status}</strong>.
+        </div>
+      ) : null}
+
+      {startJob.isError ? (
+        <div className="alert alert-danger" role="alert">
+          {(startJob.error as Error).message}
+        </div>
+      ) : null}
+
+      <section className="card border-0 shadow-sm">
+        <div className="card-body">
+          <h2 className="h5 mb-3">Etapas do pipeline v3</h2>
+          <div className="row g-3">
+            {v3Stages.map((stage, index) => (
+              <div className="col-12 col-md-6 col-xl-4" key={stage}>
+                <div className="border rounded-3 p-3 h-100 bg-light">
+                  <span className="badge text-bg-primary mb-2">
+                    {index + 1}
+                  </span>
+                  <h3 className="h6 mb-0">{stage}</h3>
+                </div>
+              </div>
+            ))}
+          </div>
+        </div>
+      </section>
+    </div>
+  );
+}


### PR DESCRIPTION
### Motivation
- Update the OPRM CNAE list so the user opens the new versioned pipeline (NichoCNAE v3) instead of the legacy v2 flow to align UI with backend v3 endpoints and the new execution model.
- Provide an initial frontend entrypoint for v3 that allows starting a v3 job for a given CNAE using the backend `cnae-intake` endpoint.
- Keep tests and documentation in sync with the UX change so navigation and history reflect the new pipeline version.

### Description
- Added a new route and page `OprmNichoCnaeV3PipelinePage` at `frontend/src/pages/oprm/OprmNichoCnaeV3PipelinePage.tsx` that lists v3 stages and exposes an `Iniciar novo job v3` button wired to start the job. 
- Implemented `useStartOprmNichoCnaeV3Job` in `frontend/src/api/oprm/useStartOprmNichoCnaeV3Job.ts` which calls the backend POST `/api/internal/oprm/nichocnae/v3/cnae-intake/stage-executions/cnaes/{cnaeCode}` to create the first v3 stage execution. 
- Replaced the CNAE table column/link from v2 → v3 in `frontend/src/pages/oprm/OprmCnaeVolumePage.tsx` and added the v3 route import and registration in `frontend/src/App.tsx`. 
- Updated the navigation test `frontend/src/__tests__/OprmNavigation.test.tsx` to assert the v3 page and recorded the change in `docs/registros/oprm1.md`.

### Testing
- Ran formatting with `npx prettier --write` on the changed files and applied fixes successfully. 
- Executed `npm run typecheck` in the frontend after installing dependencies and the typecheck completed without blocking the change. 
- Ran `npx vitest run src/__tests__/OprmNavigation.test.tsx` and the test file passed (9 tests). 
- Started the frontend dev server with `npm run dev` and Vite reported the local server ready during manual verification.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d6436f8488321924317c33b690485)