### PR TITLE
Rename source-fetcher/source-searcher backend classes to V3 to avoid Spring bean conflicts

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/sourcefetcher/controller/BackendSourceFetcherV3Controller.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/sourcefetcher/controller/BackendSourceFetcherV3Controller.java
@@ -1,6 +1,6 @@
 package com.marketinghub.oprm.nichocnae.v3.sourcefetcher.controller;
 
-import com.marketinghub.oprm.nichocnae.v3.sourcefetcher.service.BackendSourceFetcherService;
+import com.marketinghub.oprm.nichocnae.v3.sourcefetcher.service.BackendSourceFetcherV3Service;
 import com.marketinghub.oprm.nichocnae.v3.sourcefetcher.service.completeStageExecution.SourceFetcherCompletionRequest;
 import com.marketinghub.oprm.nichocnae.v3.sourcefetcher.service.createStageExecution.SourceFetcherCreateResponse;
 import com.marketinghub.oprm.nichocnae.v3.sourcefetcher.service.failStageExecution.SourceFetcherFailureRequest;
@@ -16,11 +16,11 @@ import org.springframework.web.bind.annotation.RestController;
 /** Controller canônico da etapa source-fetcher do pipeline NichoCNAE v3. */
 @RestController
 @RequestMapping("/api/internal/oprm/nichocnae/v3/source-fetcher/stage-executions")
-public class BackendSourceFetcherController {
-    private final BackendSourceFetcherService service;
+public class BackendSourceFetcherV3Controller {
+    private final BackendSourceFetcherV3Service service;
 
     /** Inicializa o controller com service canônico da etapa. */
-    public BackendSourceFetcherController(BackendSourceFetcherService service) {
+    public BackendSourceFetcherV3Controller(BackendSourceFetcherV3Service service) {
         this.service = service;
     }
 

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/sourcefetcher/service/BackendSourceFetcherV3Service.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/sourcefetcher/service/BackendSourceFetcherV3Service.java
@@ -10,11 +10,11 @@ import org.springframework.stereotype.Service;
 
 /** Service canônico da etapa source-fetcher do pipeline NichoCNAE v3 no backend. */
 @Service
-public class BackendSourceFetcherService extends OprmNichoCnaeV3StageServiceSupport {
+public class BackendSourceFetcherV3Service extends OprmNichoCnaeV3StageServiceSupport {
     private static final String STAGE_CODE = "source-fetcher";
 
     /** Inicializa o service com repository canônico de execuções v3. */
-    public BackendSourceFetcherService(OprmNichoCnaeV3StageExecutionRepository repository) {
+    public BackendSourceFetcherV3Service(OprmNichoCnaeV3StageExecutionRepository repository) {
         super(repository, STAGE_CODE);
     }
 

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/sourcesearcher/controller/BackendSourceSearcherV3Controller.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/sourcesearcher/controller/BackendSourceSearcherV3Controller.java
@@ -1,6 +1,6 @@
 package com.marketinghub.oprm.nichocnae.v3.sourcesearcher.controller;
 
-import com.marketinghub.oprm.nichocnae.v3.sourcesearcher.service.BackendSourceSearcherService;
+import com.marketinghub.oprm.nichocnae.v3.sourcesearcher.service.BackendSourceSearcherV3Service;
 import com.marketinghub.oprm.nichocnae.v3.sourcesearcher.service.completeStageExecution.SourceSearcherCompletionRequest;
 import com.marketinghub.oprm.nichocnae.v3.sourcesearcher.service.createStageExecution.SourceSearcherCreateResponse;
 import com.marketinghub.oprm.nichocnae.v3.sourcesearcher.service.failStageExecution.SourceSearcherFailureRequest;
@@ -16,11 +16,11 @@ import org.springframework.web.bind.annotation.RestController;
 /** Controller canônico da etapa source-searcher do pipeline NichoCNAE v3. */
 @RestController
 @RequestMapping("/api/internal/oprm/nichocnae/v3/source-searcher/stage-executions")
-public class BackendSourceSearcherController {
-    private final BackendSourceSearcherService service;
+public class BackendSourceSearcherV3Controller {
+    private final BackendSourceSearcherV3Service service;
 
     /** Inicializa o controller com service canônico da etapa. */
-    public BackendSourceSearcherController(BackendSourceSearcherService service) {
+    public BackendSourceSearcherV3Controller(BackendSourceSearcherV3Service service) {
         this.service = service;
     }
 

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/sourcesearcher/service/BackendSourceSearcherV3Service.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/sourcesearcher/service/BackendSourceSearcherV3Service.java
@@ -10,11 +10,11 @@ import org.springframework.stereotype.Service;
 
 /** Service canônico da etapa source-searcher do pipeline NichoCNAE v3 no backend. */
 @Service
-public class BackendSourceSearcherService extends OprmNichoCnaeV3StageServiceSupport {
+public class BackendSourceSearcherV3Service extends OprmNichoCnaeV3StageServiceSupport {
     private static final String STAGE_CODE = "source-searcher";
 
     /** Inicializa o service com repository canônico de execuções v3. */
-    public BackendSourceSearcherService(OprmNichoCnaeV3StageExecutionRepository repository) {
+    public BackendSourceSearcherV3Service(OprmNichoCnaeV3StageExecutionRepository repository) {
         super(repository, STAGE_CODE);
     }
 

--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -1394,3 +1394,8 @@
 - Foi feito: criado o executor `com.marketinghub.nichocnaev3` no `oprm-coletor-mei` com núcleo genérico, catálogo de 10 etapas, processors plugáveis, scheduler de pendências, cliente backend, prompts/schemas versionados para etapas com IA e teste ArchUnit próprio.
 - Objetivo de negócio: transformar um CNAE em persona operacional, rotina real e lista de tarefas diárias auditável, sem criar oferta, campanha ou landing nesta fase.
 - Prevenção: a v3 nasce separada da v2 para evitar remendos no fluxo que parava após o planejador de buscas por falta de etapa cadastrada.
+
+## 2026-06-25 — Correção preventiva de conflito de beans no NichoCNAE v3
+
+- Corrigida a diferenciação dos nomes das classes versionadas v3 das etapas `source-fetcher` e `source-searcher`, evitando conflito de bean Spring com as classes legadas de mesmo papel.
+- Verificados os componentes Spring do backend para localizar outros nomes simples duplicados com bean name padrão; não restaram duplicidades sem nome explícito após o ajuste.


### PR DESCRIPTION
### Motivation
- Prevent Spring bean name conflicts between v3 pipeline components and legacy classes by giving v3 classes distinct names.
- Document the preventive fix in the project registry to record the reasoning and verification performed.

### Description
- Renamed controller classes `BackendSourceFetcherController` and `BackendSourceSearcherController` to `BackendSourceFetcherV3Controller` and `BackendSourceSearcherV3Controller`, respectively, and updated their imports and constructors to use the new types.
- Renamed service classes `BackendSourceFetcherService` and `BackendSourceSearcherService` to `BackendSourceFetcherV3Service` and `BackendSourceSearcherV3Service`, respectively, and updated usages and constructors accordingly.
- Updated `docs/registros/oprm1.md` to add a note about the preventive fix and the verification of duplicated bean names.

### Testing
- Ran a full build and test suite with `./gradlew build`, and the build and unit tests completed successfully.
- Verified the backend module checks with `./gradlew :backend:ads-service:check`, which also succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d6391173483218795e7d7cf5fd317)