### PR TITLE
Exibe módulos fora do ar no menu lateral

### DIFF
--- a/frontend/src/components/MainNavigation.css
+++ b/frontend/src/components/MainNavigation.css
@@ -11,7 +11,9 @@
   gap: 1.5rem;
   background: var(--bs-body-bg);
   border-right: 1px solid var(--bs-border-color);
-  box-shadow: 0 0 0 1px rgba(15, 23, 42, 0.02), 0 18px 36px -24px rgba(15, 23, 42, 0.32);
+  box-shadow:
+    0 0 0 1px rgba(15, 23, 42, 0.02),
+    0 18px 36px -24px rgba(15, 23, 42, 0.32);
   transition: width 0.24s ease;
   z-index: 1030;
   overflow-x: hidden;
@@ -187,7 +189,9 @@
 .main-navigation__label {
   opacity: 0;
   transform: translateX(-4px);
-  transition: opacity 0.2s ease, transform 0.2s ease;
+  transition:
+    opacity 0.2s ease,
+    transform 0.2s ease;
   white-space: nowrap;
   pointer-events: none;
 }
@@ -200,28 +204,52 @@
   pointer-events: auto;
 }
 
-.main-navigation__market-test {
+.main-navigation__offline-modules {
   display: none;
   margin-top: auto;
   padding: 1rem 0.75rem 0;
   border-top: 1px solid var(--bs-border-color);
 }
 
-.main-navigation.is-expanded .main-navigation__market-test {
+.main-navigation.is-expanded .main-navigation__offline-modules {
   display: block;
 }
 
-.main-navigation__market-list {
+.main-navigation__offline-status {
   margin: 0;
-  padding-left: 1.25rem;
-  display: grid;
-  gap: 0.25rem;
   color: var(--bs-secondary-color);
   font-size: 0.8rem;
+  line-height: 1.35;
 }
 
-.main-navigation__market-step {
+.main-navigation__offline-status--error {
+  color: var(--bs-danger);
+}
+
+.main-navigation__offline-list {
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 0.45rem;
+  list-style: none;
+}
+
+.main-navigation__offline-item {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.4rem;
+  color: var(--bs-danger);
+  font-size: 0.8rem;
   line-height: 1.3;
+}
+
+.main-navigation__offline-icon {
+  flex: 0 0 auto;
+  margin-top: 0.05rem;
+}
+
+.main-navigation__offline-name {
+  min-width: 0;
 }
 
 @media (max-width: 991.98px) {
@@ -266,7 +294,7 @@
   }
 
   .main-navigation__section-title,
-  .main-navigation__market-test {
+  .main-navigation__offline-modules {
     display: none !important;
   }
 

--- a/frontend/src/components/MainNavigation.tsx
+++ b/frontend/src/components/MainNavigation.tsx
@@ -264,6 +264,10 @@ export default function MainNavigation() {
       .filter((module) => module.status === "OFFLINE")
       .slice(0, OFFLINE_MODULE_LIMIT);
   }, [availabilityQuery.data]);
+  const shouldShowOfflinePanel =
+    availabilityQuery.isLoading ||
+    availabilityQuery.isError ||
+    offlineModules.length > 0;
 
   return (
     <aside
@@ -414,49 +418,44 @@ export default function MainNavigation() {
           </div>
         ))}
       </nav>
-      <div
-        className="main-navigation__offline-modules"
-        aria-label="Módulos fora do ar apontados pelo monitor"
-      >
-        <p className="main-navigation__section-title">Módulos fora do ar</p>
-        {availabilityQuery.isLoading ? (
-          <p className="main-navigation__offline-status">
-            Consultando monitor...
-          </p>
-        ) : null}
-        {availabilityQuery.isError ? (
-          <p className="main-navigation__offline-status main-navigation__offline-status--error">
-            Monitor indisponível
-          </p>
-        ) : null}
-        {!availabilityQuery.isLoading &&
-        !availabilityQuery.isError &&
-        offlineModules.length === 0 ? (
-          <p className="main-navigation__offline-status">
-            Nenhum módulo fora do ar
-          </p>
-        ) : null}
-        {offlineModules.length > 0 ? (
-          <ul className="main-navigation__offline-list">
-            {offlineModules.map((module) => (
-              <li
-                key={module.moduleCode}
-                className="main-navigation__offline-item"
-                title={module.lastError ?? module.name}
-              >
-                <AlertTriangle
-                  className="main-navigation__offline-icon"
-                  size={14}
-                  aria-hidden="true"
-                />
-                <span className="main-navigation__offline-name">
-                  {module.name}
-                </span>
-              </li>
-            ))}
-          </ul>
-        ) : null}
-      </div>
+      {shouldShowOfflinePanel ? (
+        <div
+          className="main-navigation__offline-modules"
+          aria-label="Módulos fora do ar apontados pelo monitor"
+        >
+          <p className="main-navigation__section-title">Módulos fora do ar</p>
+          {availabilityQuery.isLoading ? (
+            <p className="main-navigation__offline-status">
+              Consultando monitor...
+            </p>
+          ) : null}
+          {availabilityQuery.isError ? (
+            <p className="main-navigation__offline-status main-navigation__offline-status--error">
+              Monitor indisponível
+            </p>
+          ) : null}
+          {offlineModules.length > 0 ? (
+            <ul className="main-navigation__offline-list">
+              {offlineModules.map((module) => (
+                <li
+                  key={module.moduleCode}
+                  className="main-navigation__offline-item"
+                  title={module.lastError ?? module.name}
+                >
+                  <AlertTriangle
+                    className="main-navigation__offline-icon"
+                    size={14}
+                    aria-hidden="true"
+                  />
+                  <span className="main-navigation__offline-name">
+                    {module.name}
+                  </span>
+                </li>
+              ))}
+            </ul>
+          ) : null}
+        </div>
+      ) : null}
     </aside>
   );
 }

--- a/frontend/src/components/MainNavigation.tsx
+++ b/frontend/src/components/MainNavigation.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { NavLink } from "react-router-dom";
 import type { LucideIcon } from "lucide-react";
 import {
@@ -41,6 +41,7 @@ import {
 import experimentIcon from "../assets/icons/experiment-icon.svg";
 import hypothesisIcon from "../assets/icons/hypothesis-icon.svg";
 import nicheIcon from "../assets/icons/niche-icon.svg";
+import { useOpsMonitorAvailability } from "../api/useOpsMonitor";
 import "./MainNavigation.css";
 
 type NavIcon = LucideIcon | string;
@@ -251,18 +252,18 @@ const NAV_SECTIONS: NavSection[] = [
   },
 ];
 
-const MARKET_TEST_STEPS = [
-  "1- Hipótese e Oferta Isca",
-  "2- Funil Mínimo",
-  "3- Tráfego e Segmentação",
-  "4- KPIs e limiares de decisão",
-  "5- Automação analítica",
-];
+const OFFLINE_MODULE_LIMIT = 4;
 
 export default function MainNavigation() {
   const [isPinned, setIsPinned] = useState(false);
   const [isHovered, setIsHovered] = useState(false);
   const isExpanded = isPinned || isHovered;
+  const availabilityQuery = useOpsMonitorAvailability();
+  const offlineModules = useMemo(() => {
+    return (availabilityQuery.data ?? [])
+      .filter((module) => module.status === "OFFLINE")
+      .slice(0, OFFLINE_MODULE_LIMIT);
+  }, [availabilityQuery.data]);
 
   return (
     <aside
@@ -414,17 +415,47 @@ export default function MainNavigation() {
         ))}
       </nav>
       <div
-        className="main-navigation__market-test"
-        aria-label="Etapas do teste de mercado"
+        className="main-navigation__offline-modules"
+        aria-label="Módulos fora do ar apontados pelo monitor"
       >
-        <p className="main-navigation__section-title">Teste de Mercado</p>
-        <ol className="main-navigation__market-list">
-          {MARKET_TEST_STEPS.map((step) => (
-            <li key={step} className="main-navigation__market-step">
-              {step}
-            </li>
-          ))}
-        </ol>
+        <p className="main-navigation__section-title">Módulos fora do ar</p>
+        {availabilityQuery.isLoading ? (
+          <p className="main-navigation__offline-status">
+            Consultando monitor...
+          </p>
+        ) : null}
+        {availabilityQuery.isError ? (
+          <p className="main-navigation__offline-status main-navigation__offline-status--error">
+            Monitor indisponível
+          </p>
+        ) : null}
+        {!availabilityQuery.isLoading &&
+        !availabilityQuery.isError &&
+        offlineModules.length === 0 ? (
+          <p className="main-navigation__offline-status">
+            Nenhum módulo fora do ar
+          </p>
+        ) : null}
+        {offlineModules.length > 0 ? (
+          <ul className="main-navigation__offline-list">
+            {offlineModules.map((module) => (
+              <li
+                key={module.moduleCode}
+                className="main-navigation__offline-item"
+                title={module.lastError ?? module.name}
+              >
+                <AlertTriangle
+                  className="main-navigation__offline-icon"
+                  size={14}
+                  aria-hidden="true"
+                />
+                <span className="main-navigation__offline-name">
+                  {module.name}
+                </span>
+              </li>
+            ))}
+          </ul>
+        ) : null}
       </div>
     </aside>
   );


### PR DESCRIPTION
### Motivation
- Substituir a área inferior do menu lateral (lista estática de "Teste de Mercado") por um painel que mostre módulos reportados como fora do ar pelo monitor operacional. 
- Garantir que a informação exibida seja a verdade vinda do backend/monitor, evitando inferência local na UI.

### Description
- Alterado `frontend/src/components/MainNavigation.tsx` para importar e usar `useOpsMonitorAvailability()`, calcular `offlineModules` com `useMemo` e limitar a exibição a `OFFLINE_MODULE_LIMIT = 4` itens.  
- A nova área renderiza estados de carregamento, erro do monitor, mensagem quando não há módulos offline e a lista de módulos com `status === "OFFLINE"`.  
- Atualizado `frontend/src/components/MainNavigation.css` para adicionar estilos das classes `.main-navigation__offline-*` e preservar o comportamento de ocultar essa área em layout mobile.  
- Removida a constante `MARKET_TEST_STEPS` e o bloco JSX correspondente ao conteúdo antigo do menu lateral.

### Testing
- Executado `npm run typecheck` (TypeScript `tsc --noEmit`) e o check passou com sucesso.  
- Executado `npm run build` (Vite) e a build completou com sucesso; houve avisos de chunk size, sem falha no build.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d6af60a588321a0c1108c65c4cecb)