### PR TITLE
Introduce MOIS dossiê v1 pipeline: backend pending endpoints, worker pipeline skeleton and ArchUnit rules

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/mois/dossie/v1/dossiersynthesis/controller/DossierDossierSynthesisController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/dossie/v1/dossiersynthesis/controller/DossierDossierSynthesisController.java
@@ -1,0 +1,26 @@
+package com.marketinghub.mois.dossie.v1.dossiersynthesis.controller;
+
+import com.marketinghub.mois.dossie.v1.dossiersynthesis.service.DossierDossierSynthesisService;
+import com.marketinghub.mois.dossie.v1.dossiersynthesis.service.pending.DossierDossierSynthesisPendingRequest;
+import com.marketinghub.mois.dossie.v1.dossiersynthesis.service.pending.DossierDossierSynthesisPendingResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/** Expõe a borda HTTP interna da etapa síntese final do dossiê do pipeline de dossiê MOIS v1. */
+@RestController
+@RequestMapping("/api/internal/mois/dossie/v1/dossier-synthesis/stage-executions")
+@RequiredArgsConstructor
+public class DossierDossierSynthesisController {
+
+    private final DossierDossierSynthesisService service;
+
+    /** Expõe o ponto inicial canônico de consumo da fila pelo módulo executor. */
+    @PostMapping("/pending")
+    public DossierDossierSynthesisPendingResponse pending(@Valid @RequestBody DossierDossierSynthesisPendingRequest request) {
+        return service.pending(request);
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/mois/dossie/v1/dossiersynthesis/service/DossierDossierSynthesisService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/dossie/v1/dossiersynthesis/service/DossierDossierSynthesisService.java
@@ -1,0 +1,16 @@
+package com.marketinghub.mois.dossie.v1.dossiersynthesis.service;
+
+import com.marketinghub.mois.dossie.v1.dossiersynthesis.service.pending.DossierDossierSynthesisPendingRequest;
+import com.marketinghub.mois.dossie.v1.dossiersynthesis.service.pending.DossierDossierSynthesisPendingResponse;
+import java.util.List;
+import org.springframework.stereotype.Service;
+
+/** Publica pendências e contratos da etapa síntese final do dossiê do pipeline de dossiê MOIS v1. */
+@Service
+public class DossierDossierSynthesisService {
+
+    /** Entrega trabalhos pendentes ao executor sem assumir controle operacional de execução no backend. */
+    public DossierDossierSynthesisPendingResponse pending(DossierDossierSynthesisPendingRequest request) {
+        return new DossierDossierSynthesisPendingResponse(false, List.of());
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/mois/dossie/v1/dossiersynthesis/service/pending/DossierDossierSynthesisPendingJob.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/dossie/v1/dossiersynthesis/service/pending/DossierDossierSynthesisPendingJob.java
@@ -1,0 +1,7 @@
+package com.marketinghub.mois.dossie.v1.dossiersynthesis.service.pending;
+
+import java.util.Map;
+
+/** Contrato de trabalho pendente entregue ao executor da etapa síntese final do dossiê do dossiê MOIS v1. */
+public record DossierDossierSynthesisPendingJob(long stageExecutionId, long dossierId, String workspaceId, String stageName, Map<String, Object> input) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/mois/dossie/v1/dossiersynthesis/service/pending/DossierDossierSynthesisPendingRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/dossie/v1/dossiersynthesis/service/pending/DossierDossierSynthesisPendingRequest.java
@@ -1,0 +1,7 @@
+package com.marketinghub.mois.dossie.v1.dossiersynthesis.service.pending;
+
+import jakarta.validation.constraints.NotBlank;
+
+/** Contrato de solicitação do endpoint pending da etapa síntese final do dossiê do dossiê MOIS v1. */
+public record DossierDossierSynthesisPendingRequest(@NotBlank String workspaceId, @NotBlank String workerId, Integer limit) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/mois/dossie/v1/dossiersynthesis/service/pending/DossierDossierSynthesisPendingResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/dossie/v1/dossiersynthesis/service/pending/DossierDossierSynthesisPendingResponse.java
@@ -1,0 +1,7 @@
+package com.marketinghub.mois.dossie.v1.dossiersynthesis.service.pending;
+
+import java.util.List;
+
+/** Contrato de resposta do endpoint pending da etapa síntese final do dossiê do dossiê MOIS v1. */
+public record DossierDossierSynthesisPendingResponse(boolean claimed, List<DossierDossierSynthesisPendingJob> jobs) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/mois/dossie/v1/intake/controller/DossierIntakeController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/dossie/v1/intake/controller/DossierIntakeController.java
@@ -1,0 +1,26 @@
+package com.marketinghub.mois.dossie.v1.intake.controller;
+
+import com.marketinghub.mois.dossie.v1.intake.service.DossierIntakeService;
+import com.marketinghub.mois.dossie.v1.intake.service.pending.DossierIntakePendingRequest;
+import com.marketinghub.mois.dossie.v1.intake.service.pending.DossierIntakePendingResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/** Expõe a borda HTTP interna da etapa entrada inicial do pipeline de dossiê MOIS v1. */
+@RestController
+@RequestMapping("/api/internal/mois/dossie/v1/intake/stage-executions")
+@RequiredArgsConstructor
+public class DossierIntakeController {
+
+    private final DossierIntakeService service;
+
+    /** Expõe o ponto inicial canônico de consumo da fila pelo módulo executor. */
+    @PostMapping("/pending")
+    public DossierIntakePendingResponse pending(@Valid @RequestBody DossierIntakePendingRequest request) {
+        return service.pending(request);
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/mois/dossie/v1/intake/service/DossierIntakeService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/dossie/v1/intake/service/DossierIntakeService.java
@@ -1,0 +1,16 @@
+package com.marketinghub.mois.dossie.v1.intake.service;
+
+import com.marketinghub.mois.dossie.v1.intake.service.pending.DossierIntakePendingRequest;
+import com.marketinghub.mois.dossie.v1.intake.service.pending.DossierIntakePendingResponse;
+import java.util.List;
+import org.springframework.stereotype.Service;
+
+/** Publica pendências e contratos da etapa entrada inicial do pipeline de dossiê MOIS v1. */
+@Service
+public class DossierIntakeService {
+
+    /** Entrega trabalhos pendentes ao executor sem assumir controle operacional de execução no backend. */
+    public DossierIntakePendingResponse pending(DossierIntakePendingRequest request) {
+        return new DossierIntakePendingResponse(false, List.of());
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/mois/dossie/v1/intake/service/pending/DossierIntakePendingJob.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/dossie/v1/intake/service/pending/DossierIntakePendingJob.java
@@ -1,0 +1,7 @@
+package com.marketinghub.mois.dossie.v1.intake.service.pending;
+
+import java.util.Map;
+
+/** Contrato de trabalho pendente entregue ao executor da etapa entrada inicial do dossiê MOIS v1. */
+public record DossierIntakePendingJob(long stageExecutionId, long dossierId, String workspaceId, String stageName, Map<String, Object> input) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/mois/dossie/v1/intake/service/pending/DossierIntakePendingRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/dossie/v1/intake/service/pending/DossierIntakePendingRequest.java
@@ -1,0 +1,7 @@
+package com.marketinghub.mois.dossie.v1.intake.service.pending;
+
+import jakarta.validation.constraints.NotBlank;
+
+/** Contrato de solicitação do endpoint pending da etapa entrada inicial do dossiê MOIS v1. */
+public record DossierIntakePendingRequest(@NotBlank String workspaceId, @NotBlank String workerId, Integer limit) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/mois/dossie/v1/intake/service/pending/DossierIntakePendingResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/dossie/v1/intake/service/pending/DossierIntakePendingResponse.java
@@ -1,0 +1,7 @@
+package com.marketinghub.mois.dossie.v1.intake.service.pending;
+
+import java.util.List;
+
+/** Contrato de resposta do endpoint pending da etapa entrada inicial do dossiê MOIS v1. */
+public record DossierIntakePendingResponse(boolean claimed, List<DossierIntakePendingJob> jobs) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/mois/dossie/v1/investigationanchorbuilder/controller/DossierInvestigationAnchorBuilderController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/dossie/v1/investigationanchorbuilder/controller/DossierInvestigationAnchorBuilderController.java
@@ -1,0 +1,26 @@
+package com.marketinghub.mois.dossie.v1.investigationanchorbuilder.controller;
+
+import com.marketinghub.mois.dossie.v1.investigationanchorbuilder.service.DossierInvestigationAnchorBuilderService;
+import com.marketinghub.mois.dossie.v1.investigationanchorbuilder.service.pending.DossierInvestigationAnchorBuilderPendingRequest;
+import com.marketinghub.mois.dossie.v1.investigationanchorbuilder.service.pending.DossierInvestigationAnchorBuilderPendingResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/** Expõe a borda HTTP interna da etapa geração de âncoras de investigação do pipeline de dossiê MOIS v1. */
+@RestController
+@RequestMapping("/api/internal/mois/dossie/v1/investigation-anchor-builder/stage-executions")
+@RequiredArgsConstructor
+public class DossierInvestigationAnchorBuilderController {
+
+    private final DossierInvestigationAnchorBuilderService service;
+
+    /** Expõe o ponto inicial canônico de consumo da fila pelo módulo executor. */
+    @PostMapping("/pending")
+    public DossierInvestigationAnchorBuilderPendingResponse pending(@Valid @RequestBody DossierInvestigationAnchorBuilderPendingRequest request) {
+        return service.pending(request);
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/mois/dossie/v1/investigationanchorbuilder/service/DossierInvestigationAnchorBuilderService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/dossie/v1/investigationanchorbuilder/service/DossierInvestigationAnchorBuilderService.java
@@ -1,0 +1,16 @@
+package com.marketinghub.mois.dossie.v1.investigationanchorbuilder.service;
+
+import com.marketinghub.mois.dossie.v1.investigationanchorbuilder.service.pending.DossierInvestigationAnchorBuilderPendingRequest;
+import com.marketinghub.mois.dossie.v1.investigationanchorbuilder.service.pending.DossierInvestigationAnchorBuilderPendingResponse;
+import java.util.List;
+import org.springframework.stereotype.Service;
+
+/** Publica pendências e contratos da etapa geração de âncoras de investigação do pipeline de dossiê MOIS v1. */
+@Service
+public class DossierInvestigationAnchorBuilderService {
+
+    /** Entrega trabalhos pendentes ao executor sem assumir controle operacional de execução no backend. */
+    public DossierInvestigationAnchorBuilderPendingResponse pending(DossierInvestigationAnchorBuilderPendingRequest request) {
+        return new DossierInvestigationAnchorBuilderPendingResponse(false, List.of());
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/mois/dossie/v1/investigationanchorbuilder/service/pending/DossierInvestigationAnchorBuilderPendingJob.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/dossie/v1/investigationanchorbuilder/service/pending/DossierInvestigationAnchorBuilderPendingJob.java
@@ -1,0 +1,7 @@
+package com.marketinghub.mois.dossie.v1.investigationanchorbuilder.service.pending;
+
+import java.util.Map;
+
+/** Contrato de trabalho pendente entregue ao executor da etapa geração de âncoras de investigação do dossiê MOIS v1. */
+public record DossierInvestigationAnchorBuilderPendingJob(long stageExecutionId, long dossierId, String workspaceId, String stageName, Map<String, Object> input) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/mois/dossie/v1/investigationanchorbuilder/service/pending/DossierInvestigationAnchorBuilderPendingRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/dossie/v1/investigationanchorbuilder/service/pending/DossierInvestigationAnchorBuilderPendingRequest.java
@@ -1,0 +1,7 @@
+package com.marketinghub.mois.dossie.v1.investigationanchorbuilder.service.pending;
+
+import jakarta.validation.constraints.NotBlank;
+
+/** Contrato de solicitação do endpoint pending da etapa geração de âncoras de investigação do dossiê MOIS v1. */
+public record DossierInvestigationAnchorBuilderPendingRequest(@NotBlank String workspaceId, @NotBlank String workerId, Integer limit) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/mois/dossie/v1/investigationanchorbuilder/service/pending/DossierInvestigationAnchorBuilderPendingResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/dossie/v1/investigationanchorbuilder/service/pending/DossierInvestigationAnchorBuilderPendingResponse.java
@@ -1,0 +1,7 @@
+package com.marketinghub.mois.dossie.v1.investigationanchorbuilder.service.pending;
+
+import java.util.List;
+
+/** Contrato de resposta do endpoint pending da etapa geração de âncoras de investigação do dossiê MOIS v1. */
+public record DossierInvestigationAnchorBuilderPendingResponse(boolean claimed, List<DossierInvestigationAnchorBuilderPendingJob> jobs) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/mois/dossie/v1/productunderstanding/controller/DossierProductUnderstandingController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/dossie/v1/productunderstanding/controller/DossierProductUnderstandingController.java
@@ -1,0 +1,26 @@
+package com.marketinghub.mois.dossie.v1.productunderstanding.controller;
+
+import com.marketinghub.mois.dossie.v1.productunderstanding.service.DossierProductUnderstandingService;
+import com.marketinghub.mois.dossie.v1.productunderstanding.service.pending.DossierProductUnderstandingPendingRequest;
+import com.marketinghub.mois.dossie.v1.productunderstanding.service.pending.DossierProductUnderstandingPendingResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/** Expõe a borda HTTP interna da etapa entendimento do produto do pipeline de dossiê MOIS v1. */
+@RestController
+@RequestMapping("/api/internal/mois/dossie/v1/product-understanding/stage-executions")
+@RequiredArgsConstructor
+public class DossierProductUnderstandingController {
+
+    private final DossierProductUnderstandingService service;
+
+    /** Expõe o ponto inicial canônico de consumo da fila pelo módulo executor. */
+    @PostMapping("/pending")
+    public DossierProductUnderstandingPendingResponse pending(@Valid @RequestBody DossierProductUnderstandingPendingRequest request) {
+        return service.pending(request);
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/mois/dossie/v1/productunderstanding/service/DossierProductUnderstandingService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/dossie/v1/productunderstanding/service/DossierProductUnderstandingService.java
@@ -1,0 +1,16 @@
+package com.marketinghub.mois.dossie.v1.productunderstanding.service;
+
+import com.marketinghub.mois.dossie.v1.productunderstanding.service.pending.DossierProductUnderstandingPendingRequest;
+import com.marketinghub.mois.dossie.v1.productunderstanding.service.pending.DossierProductUnderstandingPendingResponse;
+import java.util.List;
+import org.springframework.stereotype.Service;
+
+/** Publica pendências e contratos da etapa entendimento do produto do pipeline de dossiê MOIS v1. */
+@Service
+public class DossierProductUnderstandingService {
+
+    /** Entrega trabalhos pendentes ao executor sem assumir controle operacional de execução no backend. */
+    public DossierProductUnderstandingPendingResponse pending(DossierProductUnderstandingPendingRequest request) {
+        return new DossierProductUnderstandingPendingResponse(false, List.of());
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/mois/dossie/v1/productunderstanding/service/pending/DossierProductUnderstandingPendingJob.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/dossie/v1/productunderstanding/service/pending/DossierProductUnderstandingPendingJob.java
@@ -1,0 +1,7 @@
+package com.marketinghub.mois.dossie.v1.productunderstanding.service.pending;
+
+import java.util.Map;
+
+/** Contrato de trabalho pendente entregue ao executor da etapa entendimento do produto do dossiê MOIS v1. */
+public record DossierProductUnderstandingPendingJob(long stageExecutionId, long dossierId, String workspaceId, String stageName, Map<String, Object> input) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/mois/dossie/v1/productunderstanding/service/pending/DossierProductUnderstandingPendingRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/dossie/v1/productunderstanding/service/pending/DossierProductUnderstandingPendingRequest.java
@@ -1,0 +1,7 @@
+package com.marketinghub.mois.dossie.v1.productunderstanding.service.pending;
+
+import jakarta.validation.constraints.NotBlank;
+
+/** Contrato de solicitação do endpoint pending da etapa entendimento do produto do dossiê MOIS v1. */
+public record DossierProductUnderstandingPendingRequest(@NotBlank String workspaceId, @NotBlank String workerId, Integer limit) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/mois/dossie/v1/productunderstanding/service/pending/DossierProductUnderstandingPendingResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/dossie/v1/productunderstanding/service/pending/DossierProductUnderstandingPendingResponse.java
@@ -1,0 +1,7 @@
+package com.marketinghub.mois.dossie.v1.productunderstanding.service.pending;
+
+import java.util.List;
+
+/** Contrato de resposta do endpoint pending da etapa entendimento do produto do dossiê MOIS v1. */
+public record DossierProductUnderstandingPendingResponse(boolean claimed, List<DossierProductUnderstandingPendingJob> jobs) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/mois/dossie/v1/sourceproductmatch/controller/DossierSourceProductMatchController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/dossie/v1/sourceproductmatch/controller/DossierSourceProductMatchController.java
@@ -1,0 +1,26 @@
+package com.marketinghub.mois.dossie.v1.sourceproductmatch.controller;
+
+import com.marketinghub.mois.dossie.v1.sourceproductmatch.service.DossierSourceProductMatchService;
+import com.marketinghub.mois.dossie.v1.sourceproductmatch.service.pending.DossierSourceProductMatchPendingRequest;
+import com.marketinghub.mois.dossie.v1.sourceproductmatch.service.pending.DossierSourceProductMatchPendingResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/** Expõe a borda HTTP interna da etapa validação de relação fonte-produto do pipeline de dossiê MOIS v1. */
+@RestController
+@RequestMapping("/api/internal/mois/dossie/v1/source-product-match/stage-executions")
+@RequiredArgsConstructor
+public class DossierSourceProductMatchController {
+
+    private final DossierSourceProductMatchService service;
+
+    /** Expõe o ponto inicial canônico de consumo da fila pelo módulo executor. */
+    @PostMapping("/pending")
+    public DossierSourceProductMatchPendingResponse pending(@Valid @RequestBody DossierSourceProductMatchPendingRequest request) {
+        return service.pending(request);
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/mois/dossie/v1/sourceproductmatch/service/DossierSourceProductMatchService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/dossie/v1/sourceproductmatch/service/DossierSourceProductMatchService.java
@@ -1,0 +1,16 @@
+package com.marketinghub.mois.dossie.v1.sourceproductmatch.service;
+
+import com.marketinghub.mois.dossie.v1.sourceproductmatch.service.pending.DossierSourceProductMatchPendingRequest;
+import com.marketinghub.mois.dossie.v1.sourceproductmatch.service.pending.DossierSourceProductMatchPendingResponse;
+import java.util.List;
+import org.springframework.stereotype.Service;
+
+/** Publica pendências e contratos da etapa validação de relação fonte-produto do pipeline de dossiê MOIS v1. */
+@Service
+public class DossierSourceProductMatchService {
+
+    /** Entrega trabalhos pendentes ao executor sem assumir controle operacional de execução no backend. */
+    public DossierSourceProductMatchPendingResponse pending(DossierSourceProductMatchPendingRequest request) {
+        return new DossierSourceProductMatchPendingResponse(false, List.of());
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/mois/dossie/v1/sourceproductmatch/service/pending/DossierSourceProductMatchPendingJob.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/dossie/v1/sourceproductmatch/service/pending/DossierSourceProductMatchPendingJob.java
@@ -1,0 +1,7 @@
+package com.marketinghub.mois.dossie.v1.sourceproductmatch.service.pending;
+
+import java.util.Map;
+
+/** Contrato de trabalho pendente entregue ao executor da etapa validação de relação fonte-produto do dossiê MOIS v1. */
+public record DossierSourceProductMatchPendingJob(long stageExecutionId, long dossierId, String workspaceId, String stageName, Map<String, Object> input) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/mois/dossie/v1/sourceproductmatch/service/pending/DossierSourceProductMatchPendingRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/dossie/v1/sourceproductmatch/service/pending/DossierSourceProductMatchPendingRequest.java
@@ -1,0 +1,7 @@
+package com.marketinghub.mois.dossie.v1.sourceproductmatch.service.pending;
+
+import jakarta.validation.constraints.NotBlank;
+
+/** Contrato de solicitação do endpoint pending da etapa validação de relação fonte-produto do dossiê MOIS v1. */
+public record DossierSourceProductMatchPendingRequest(@NotBlank String workspaceId, @NotBlank String workerId, Integer limit) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/mois/dossie/v1/sourceproductmatch/service/pending/DossierSourceProductMatchPendingResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/dossie/v1/sourceproductmatch/service/pending/DossierSourceProductMatchPendingResponse.java
@@ -1,0 +1,7 @@
+package com.marketinghub.mois.dossie.v1.sourceproductmatch.service.pending;
+
+import java.util.List;
+
+/** Contrato de resposta do endpoint pending da etapa validação de relação fonte-produto do dossiê MOIS v1. */
+public record DossierSourceProductMatchPendingResponse(boolean claimed, List<DossierSourceProductMatchPendingJob> jobs) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/mois/dossie/v1/warmupmapbuilder/controller/DossierWarmupMapBuilderController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/dossie/v1/warmupmapbuilder/controller/DossierWarmupMapBuilderController.java
@@ -1,0 +1,26 @@
+package com.marketinghub.mois.dossie.v1.warmupmapbuilder.controller;
+
+import com.marketinghub.mois.dossie.v1.warmupmapbuilder.service.DossierWarmupMapBuilderService;
+import com.marketinghub.mois.dossie.v1.warmupmapbuilder.service.pending.DossierWarmupMapBuilderPendingRequest;
+import com.marketinghub.mois.dossie.v1.warmupmapbuilder.service.pending.DossierWarmupMapBuilderPendingResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/** Expõe a borda HTTP interna da etapa montagem do mapa de aquecimento do pipeline de dossiê MOIS v1. */
+@RestController
+@RequestMapping("/api/internal/mois/dossie/v1/warmup-map-builder/stage-executions")
+@RequiredArgsConstructor
+public class DossierWarmupMapBuilderController {
+
+    private final DossierWarmupMapBuilderService service;
+
+    /** Expõe o ponto inicial canônico de consumo da fila pelo módulo executor. */
+    @PostMapping("/pending")
+    public DossierWarmupMapBuilderPendingResponse pending(@Valid @RequestBody DossierWarmupMapBuilderPendingRequest request) {
+        return service.pending(request);
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/mois/dossie/v1/warmupmapbuilder/service/DossierWarmupMapBuilderService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/dossie/v1/warmupmapbuilder/service/DossierWarmupMapBuilderService.java
@@ -1,0 +1,16 @@
+package com.marketinghub.mois.dossie.v1.warmupmapbuilder.service;
+
+import com.marketinghub.mois.dossie.v1.warmupmapbuilder.service.pending.DossierWarmupMapBuilderPendingRequest;
+import com.marketinghub.mois.dossie.v1.warmupmapbuilder.service.pending.DossierWarmupMapBuilderPendingResponse;
+import java.util.List;
+import org.springframework.stereotype.Service;
+
+/** Publica pendências e contratos da etapa montagem do mapa de aquecimento do pipeline de dossiê MOIS v1. */
+@Service
+public class DossierWarmupMapBuilderService {
+
+    /** Entrega trabalhos pendentes ao executor sem assumir controle operacional de execução no backend. */
+    public DossierWarmupMapBuilderPendingResponse pending(DossierWarmupMapBuilderPendingRequest request) {
+        return new DossierWarmupMapBuilderPendingResponse(false, List.of());
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/mois/dossie/v1/warmupmapbuilder/service/pending/DossierWarmupMapBuilderPendingJob.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/dossie/v1/warmupmapbuilder/service/pending/DossierWarmupMapBuilderPendingJob.java
@@ -1,0 +1,7 @@
+package com.marketinghub.mois.dossie.v1.warmupmapbuilder.service.pending;
+
+import java.util.Map;
+
+/** Contrato de trabalho pendente entregue ao executor da etapa montagem do mapa de aquecimento do dossiê MOIS v1. */
+public record DossierWarmupMapBuilderPendingJob(long stageExecutionId, long dossierId, String workspaceId, String stageName, Map<String, Object> input) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/mois/dossie/v1/warmupmapbuilder/service/pending/DossierWarmupMapBuilderPendingRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/dossie/v1/warmupmapbuilder/service/pending/DossierWarmupMapBuilderPendingRequest.java
@@ -1,0 +1,7 @@
+package com.marketinghub.mois.dossie.v1.warmupmapbuilder.service.pending;
+
+import jakarta.validation.constraints.NotBlank;
+
+/** Contrato de solicitação do endpoint pending da etapa montagem do mapa de aquecimento do dossiê MOIS v1. */
+public record DossierWarmupMapBuilderPendingRequest(@NotBlank String workspaceId, @NotBlank String workerId, Integer limit) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/mois/dossie/v1/warmupmapbuilder/service/pending/DossierWarmupMapBuilderPendingResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/dossie/v1/warmupmapbuilder/service/pending/DossierWarmupMapBuilderPendingResponse.java
@@ -1,0 +1,7 @@
+package com.marketinghub.mois.dossie.v1.warmupmapbuilder.service.pending;
+
+import java.util.List;
+
+/** Contrato de resposta do endpoint pending da etapa montagem do mapa de aquecimento do dossiê MOIS v1. */
+public record DossierWarmupMapBuilderPendingResponse(boolean claimed, List<DossierWarmupMapBuilderPendingJob> jobs) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/mois/dossie/v1/warmupresourcediscovery/controller/DossierWarmupResourceDiscoveryController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/dossie/v1/warmupresourcediscovery/controller/DossierWarmupResourceDiscoveryController.java
@@ -1,0 +1,26 @@
+package com.marketinghub.mois.dossie.v1.warmupresourcediscovery.controller;
+
+import com.marketinghub.mois.dossie.v1.warmupresourcediscovery.service.DossierWarmupResourceDiscoveryService;
+import com.marketinghub.mois.dossie.v1.warmupresourcediscovery.service.pending.DossierWarmupResourceDiscoveryPendingRequest;
+import com.marketinghub.mois.dossie.v1.warmupresourcediscovery.service.pending.DossierWarmupResourceDiscoveryPendingResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/** Expõe a borda HTTP interna da etapa descoberta de recursos de aquecimento do pipeline de dossiê MOIS v1. */
+@RestController
+@RequestMapping("/api/internal/mois/dossie/v1/warmup-resource-discovery/stage-executions")
+@RequiredArgsConstructor
+public class DossierWarmupResourceDiscoveryController {
+
+    private final DossierWarmupResourceDiscoveryService service;
+
+    /** Expõe o ponto inicial canônico de consumo da fila pelo módulo executor. */
+    @PostMapping("/pending")
+    public DossierWarmupResourceDiscoveryPendingResponse pending(@Valid @RequestBody DossierWarmupResourceDiscoveryPendingRequest request) {
+        return service.pending(request);
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/mois/dossie/v1/warmupresourcediscovery/service/DossierWarmupResourceDiscoveryService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/dossie/v1/warmupresourcediscovery/service/DossierWarmupResourceDiscoveryService.java
@@ -1,0 +1,16 @@
+package com.marketinghub.mois.dossie.v1.warmupresourcediscovery.service;
+
+import com.marketinghub.mois.dossie.v1.warmupresourcediscovery.service.pending.DossierWarmupResourceDiscoveryPendingRequest;
+import com.marketinghub.mois.dossie.v1.warmupresourcediscovery.service.pending.DossierWarmupResourceDiscoveryPendingResponse;
+import java.util.List;
+import org.springframework.stereotype.Service;
+
+/** Publica pendências e contratos da etapa descoberta de recursos de aquecimento do pipeline de dossiê MOIS v1. */
+@Service
+public class DossierWarmupResourceDiscoveryService {
+
+    /** Entrega trabalhos pendentes ao executor sem assumir controle operacional de execução no backend. */
+    public DossierWarmupResourceDiscoveryPendingResponse pending(DossierWarmupResourceDiscoveryPendingRequest request) {
+        return new DossierWarmupResourceDiscoveryPendingResponse(false, List.of());
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/mois/dossie/v1/warmupresourcediscovery/service/pending/DossierWarmupResourceDiscoveryPendingJob.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/dossie/v1/warmupresourcediscovery/service/pending/DossierWarmupResourceDiscoveryPendingJob.java
@@ -1,0 +1,7 @@
+package com.marketinghub.mois.dossie.v1.warmupresourcediscovery.service.pending;
+
+import java.util.Map;
+
+/** Contrato de trabalho pendente entregue ao executor da etapa descoberta de recursos de aquecimento do dossiê MOIS v1. */
+public record DossierWarmupResourceDiscoveryPendingJob(long stageExecutionId, long dossierId, String workspaceId, String stageName, Map<String, Object> input) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/mois/dossie/v1/warmupresourcediscovery/service/pending/DossierWarmupResourceDiscoveryPendingRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/dossie/v1/warmupresourcediscovery/service/pending/DossierWarmupResourceDiscoveryPendingRequest.java
@@ -1,0 +1,7 @@
+package com.marketinghub.mois.dossie.v1.warmupresourcediscovery.service.pending;
+
+import jakarta.validation.constraints.NotBlank;
+
+/** Contrato de solicitação do endpoint pending da etapa descoberta de recursos de aquecimento do dossiê MOIS v1. */
+public record DossierWarmupResourceDiscoveryPendingRequest(@NotBlank String workspaceId, @NotBlank String workerId, Integer limit) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/mois/dossie/v1/warmupresourcediscovery/service/pending/DossierWarmupResourceDiscoveryPendingResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/dossie/v1/warmupresourcediscovery/service/pending/DossierWarmupResourceDiscoveryPendingResponse.java
@@ -1,0 +1,7 @@
+package com.marketinghub.mois.dossie.v1.warmupresourcediscovery.service.pending;
+
+import java.util.List;
+
+/** Contrato de resposta do endpoint pending da etapa descoberta de recursos de aquecimento do dossiê MOIS v1. */
+public record DossierWarmupResourceDiscoveryPendingResponse(boolean claimed, List<DossierWarmupResourceDiscoveryPendingJob> jobs) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/mois/dossie/v1/warmupsignalextraction/controller/DossierWarmupSignalExtractionController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/dossie/v1/warmupsignalextraction/controller/DossierWarmupSignalExtractionController.java
@@ -1,0 +1,26 @@
+package com.marketinghub.mois.dossie.v1.warmupsignalextraction.controller;
+
+import com.marketinghub.mois.dossie.v1.warmupsignalextraction.service.DossierWarmupSignalExtractionService;
+import com.marketinghub.mois.dossie.v1.warmupsignalextraction.service.pending.DossierWarmupSignalExtractionPendingRequest;
+import com.marketinghub.mois.dossie.v1.warmupsignalextraction.service.pending.DossierWarmupSignalExtractionPendingResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/** Expõe a borda HTTP interna da etapa extração de sinais de aquecimento do pipeline de dossiê MOIS v1. */
+@RestController
+@RequestMapping("/api/internal/mois/dossie/v1/warmup-signal-extraction/stage-executions")
+@RequiredArgsConstructor
+public class DossierWarmupSignalExtractionController {
+
+    private final DossierWarmupSignalExtractionService service;
+
+    /** Expõe o ponto inicial canônico de consumo da fila pelo módulo executor. */
+    @PostMapping("/pending")
+    public DossierWarmupSignalExtractionPendingResponse pending(@Valid @RequestBody DossierWarmupSignalExtractionPendingRequest request) {
+        return service.pending(request);
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/mois/dossie/v1/warmupsignalextraction/service/DossierWarmupSignalExtractionService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/dossie/v1/warmupsignalextraction/service/DossierWarmupSignalExtractionService.java
@@ -1,0 +1,16 @@
+package com.marketinghub.mois.dossie.v1.warmupsignalextraction.service;
+
+import com.marketinghub.mois.dossie.v1.warmupsignalextraction.service.pending.DossierWarmupSignalExtractionPendingRequest;
+import com.marketinghub.mois.dossie.v1.warmupsignalextraction.service.pending.DossierWarmupSignalExtractionPendingResponse;
+import java.util.List;
+import org.springframework.stereotype.Service;
+
+/** Publica pendências e contratos da etapa extração de sinais de aquecimento do pipeline de dossiê MOIS v1. */
+@Service
+public class DossierWarmupSignalExtractionService {
+
+    /** Entrega trabalhos pendentes ao executor sem assumir controle operacional de execução no backend. */
+    public DossierWarmupSignalExtractionPendingResponse pending(DossierWarmupSignalExtractionPendingRequest request) {
+        return new DossierWarmupSignalExtractionPendingResponse(false, List.of());
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/mois/dossie/v1/warmupsignalextraction/service/pending/DossierWarmupSignalExtractionPendingJob.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/dossie/v1/warmupsignalextraction/service/pending/DossierWarmupSignalExtractionPendingJob.java
@@ -1,0 +1,7 @@
+package com.marketinghub.mois.dossie.v1.warmupsignalextraction.service.pending;
+
+import java.util.Map;
+
+/** Contrato de trabalho pendente entregue ao executor da etapa extração de sinais de aquecimento do dossiê MOIS v1. */
+public record DossierWarmupSignalExtractionPendingJob(long stageExecutionId, long dossierId, String workspaceId, String stageName, Map<String, Object> input) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/mois/dossie/v1/warmupsignalextraction/service/pending/DossierWarmupSignalExtractionPendingRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/dossie/v1/warmupsignalextraction/service/pending/DossierWarmupSignalExtractionPendingRequest.java
@@ -1,0 +1,7 @@
+package com.marketinghub.mois.dossie.v1.warmupsignalextraction.service.pending;
+
+import jakarta.validation.constraints.NotBlank;
+
+/** Contrato de solicitação do endpoint pending da etapa extração de sinais de aquecimento do dossiê MOIS v1. */
+public record DossierWarmupSignalExtractionPendingRequest(@NotBlank String workspaceId, @NotBlank String workerId, Integer limit) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/mois/dossie/v1/warmupsignalextraction/service/pending/DossierWarmupSignalExtractionPendingResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/dossie/v1/warmupsignalextraction/service/pending/DossierWarmupSignalExtractionPendingResponse.java
@@ -1,0 +1,7 @@
+package com.marketinghub.mois.dossie.v1.warmupsignalextraction.service.pending;
+
+import java.util.List;
+
+/** Contrato de resposta do endpoint pending da etapa extração de sinais de aquecimento do dossiê MOIS v1. */
+public record DossierWarmupSignalExtractionPendingResponse(boolean claimed, List<DossierWarmupSignalExtractionPendingJob> jobs) {
+}

--- a/backend/ads-service/src/test/java/com/marketinghub/architecture/ArquiteturaTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/architecture/ArquiteturaTest.java
@@ -33,6 +33,7 @@ import java.util.regex.Pattern;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Service;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -164,6 +165,17 @@ class ArquiteturaTest {
             HYPOTHESIS_REPOSITORY_CLASS,
             FRAMEWORK_IMAGE_GENERATION_JOB_REPOSITORY_CLASS,
             GERALANDING_STAGE_EXECUTION_REPOSITORY_CLASS);
+    private static final String MOIS_DOSSIE_V1_EXECUTOR_MODULE = "mois-sales-library-worker";
+    private static final String MOIS_DOSSIE_V1_PACKAGE = "com.marketinghub.mois.dossie.v1";
+    private static final Map<String, String> MOIS_DOSSIE_V1_STAGE_ENDPOINT_SLUGS = Map.ofEntries(
+            Map.entry("intake", "intake"),
+            Map.entry("productunderstanding", "product-understanding"),
+            Map.entry("investigationanchorbuilder", "investigation-anchor-builder"),
+            Map.entry("warmupresourcediscovery", "warmup-resource-discovery"),
+            Map.entry("sourceproductmatch", "source-product-match"),
+            Map.entry("warmupsignalextraction", "warmup-signal-extraction"),
+            Map.entry("warmupmapbuilder", "warmup-map-builder"),
+            Map.entry("dossiersynthesis", "dossier-synthesis"));
 
 
     @ArchTest
@@ -337,6 +349,56 @@ class ArquiteturaTest {
             .dependOnClassesThat()
             .resideInAPackage(MOIS_SALES_LIBRARY_PACKAGE + "..")
             .because("[ARQUITETURA][MOIS] nenhum outro pacote interno deve depender da biblioteca de páginas de vendas do MOIS");
+
+    @ArchTest
+    static final ArchRule moisDossieV1BackendMustRemainReadWriteOnly = classes()
+            .that()
+            .resideInAPackage("com.marketinghub.mois.dossie.v1..")
+            .should(notAssumeOperationalExecutionResponsibilityForMoisDossieV1())
+            .because("[ARQUITETURA] [BACKEND][MOIS Dossiê v1] o backend deve publicar pendências e receber callbacks; "
+                    + "o controle operacional pertence ao módulo executor " + MOIS_DOSSIE_V1_EXECUTOR_MODULE);
+
+    /**
+     * Garante a estrutura canônica da etapa intake do pipeline de dossiê MOIS v1 no backend.
+     */
+    @ArchTest
+    static void moisDossieV1StagesMustExposeCanonicalStructure(JavaClasses importedClasses) {
+        List<String> violations = new ArrayList<>();
+        MOIS_DOSSIE_V1_STAGE_ENDPOINT_SLUGS.forEach((stagePackage, endpointSlug) -> {
+            String controllerPackage = MOIS_DOSSIE_V1_PACKAGE + "." + stagePackage + ".controller";
+            String servicePackage = MOIS_DOSSIE_V1_PACKAGE + "." + stagePackage + ".service";
+            List<JavaClass> controllerClasses = directPackageClasses(importedClasses, controllerPackage);
+            List<JavaClass> serviceClasses = directPackageClasses(importedClasses, servicePackage);
+            long controllers = controllerClasses.stream().filter(javaClass -> javaClass.isAnnotatedWith(RestController.class)).count();
+            long services = serviceClasses.stream().filter(javaClass -> javaClass.isAnnotatedWith(Service.class)).count();
+            if (controllers != 1) {
+                violations.add("[ARQUITETURA] [BACKEND][MOIS Dossiê v1] etapa " + stagePackage
+                        + " deve possuir exatamente um controller canônico em " + controllerPackage
+                        + "; encontrados=" + controllers);
+            }
+            if (services != 1) {
+                violations.add("[ARQUITETURA] [BACKEND][MOIS Dossiê v1] etapa " + stagePackage
+                        + " deve possuir exatamente um service canônico em " + servicePackage
+                        + "; encontrados=" + services);
+            }
+            boolean hasPending = controllerClasses.stream()
+                    .flatMap(javaClass -> javaClass.getMethods().stream())
+                    .anyMatch(method -> method.getName().equals("pending") && method.isAnnotatedWith(PostMapping.class));
+            if (!hasPending) {
+                violations.add("[ARQUITETURA] [BACKEND][MOIS Dossiê v1] etapa " + stagePackage
+                        + " deve expor endpoint pending canônico /api/internal/mois/dossie/v1/"
+                        + endpointSlug + "/stage-executions/pending");
+            }
+        });
+        failWithArchitectureViolations(violations);
+    }
+
+    @ArchTest
+    static final ArchRule moisDossieV1ServiceContractsMustBeRecords = classes()
+            .that()
+            .resideInAPackage("com.marketinghub.mois.dossie.v1.*.service..")
+            .should(beRecordWhenInsideMoisDossieV1ServiceSubpackage())
+            .because("[ARQUITETURA] [BACKEND][MOIS Dossiê v1] DTOs/contratos de service devem ser records em subpacotes da operação");
 
     @ArchTest
     static final ArchRule springDataJpaRepositoriesMustResideInRepositoryJpaSubpackages = classes()
@@ -1732,6 +1794,26 @@ class ArquiteturaTest {
     }
 
     /**
+     * Exige records nos subpacotes de service que representam contratos do dossiê MOIS v1.
+     */
+    private static ArchCondition<JavaClass> beRecordWhenInsideMoisDossieV1ServiceSubpackage() {
+        return new ArchCondition<>("[ARQUITETURA] ser record quando estiver em subpacote de service do dossiê MOIS v1") {
+            @Override
+            public void check(JavaClass item, ConditionEvents events) {
+                boolean contractSubpackage = MOIS_DOSSIE_V1_STAGE_ENDPOINT_SLUGS.keySet().stream()
+                        .anyMatch(stagePackage -> item.getPackageName()
+                                .startsWith(MOIS_DOSSIE_V1_PACKAGE + "." + stagePackage + ".service."));
+                if (!contractSubpackage || item.reflect().isRecord()) {
+                    return;
+                }
+                events.add(SimpleConditionEvent.violated(item,
+                        "[ARQUITETURA] [BACKEND][MOIS Dossiê v1] classe=" + item.getName()
+                                + " está em subpacote de service e deve ser declarada como record"));
+            }
+        };
+    }
+
+    /**
      * Garante que controllers Facebook Ads não consumam controllers de outros módulos.
      */
     private static ArchCondition<JavaClass> notDependOnOtherModuleControllers() {
@@ -1988,6 +2070,75 @@ class ArquiteturaTest {
                 || targetPackage.startsWith("org.openqa.selenium")
                 || targetPackage.startsWith("software.amazon.awssdk.services.s3")
                 || targetPackage.startsWith("com.amazonaws.services.s3");
+    }
+
+    /**
+     * Bloqueia responsabilidades operacionais de execução no backend do dossiê MOIS v1.
+     */
+    private static ArchCondition<JavaClass> notAssumeOperationalExecutionResponsibilityForMoisDossieV1() {
+        return new ArchCondition<>("[ARQUITETURA] [BACKEND][MOIS Dossiê v1] não assume execução operacional externa") {
+            @Override
+            public void check(JavaClass item, ConditionEvents events) {
+                if (hasForbiddenMoisDossieV1ExecutionName(item)) {
+                    events.add(SimpleConditionEvent.violated(item,
+                            "[ARQUITETURA] [BACKEND][MOIS Dossiê v1] classe=" + item.getName()
+                                    + " tem nome de worker/runner/processor/núcleo operacional. "
+                                    + "O backend deve publicar pendências e receber resultados; a execução operacional fica no módulo "
+                                    + MOIS_DOSSIE_V1_EXECUTOR_MODULE + "."));
+                }
+                item.getDirectDependenciesFromSelf().forEach(dependency -> {
+                    JavaClass targetClass = dependency.getTargetClass();
+                    if (!isForbiddenMoisDossieV1ExecutionDependency(targetClass)) {
+                        return;
+                    }
+                    events.add(SimpleConditionEvent.violated(item,
+                            "[ARQUITETURA] [BACKEND][MOIS Dossiê v1] classe=" + item.getName()
+                                    + " depende de tecnologia/contrato operacional proibido no backend: "
+                                    + dependency.getDescription() + ". A execução pertence ao módulo "
+                                    + MOIS_DOSSIE_V1_EXECUTOR_MODULE + "."));
+                });
+            }
+        };
+    }
+
+    /**
+     * Identifica nomes que indicam execução operacional indevida no backend do dossiê MOIS v1.
+     */
+    private static boolean hasForbiddenMoisDossieV1ExecutionName(JavaClass javaClass) {
+        String simpleName = javaClass.getSimpleName();
+        return simpleName.equals("PipelineWorker")
+                || simpleName.equals("StageProcessor")
+                || simpleName.equals("StageContext")
+                || simpleName.equals("StageResult")
+                || simpleName.equals("StageArtifact")
+                || simpleName.endsWith("Worker")
+                || simpleName.endsWith("Runner")
+                || simpleName.endsWith("Poller")
+                || simpleName.endsWith("Scheduler")
+                || simpleName.endsWith("Processor");
+    }
+
+    /**
+     * Identifica dependências de execução externa que não podem entrar no backend do dossiê MOIS v1.
+     */
+    private static boolean isForbiddenMoisDossieV1ExecutionDependency(JavaClass targetClass) {
+        String targetName = targetClass.getName();
+        String targetPackage = targetClass.getPackageName();
+        return targetName.equals("org.springframework.scheduling.annotation.Scheduled")
+                || targetName.equals("org.springframework.web.reactive.function.client.WebClient")
+                || targetPackage.startsWith("org.springframework.web.client")
+                || targetPackage.startsWith("com.openai")
+                || targetPackage.startsWith("com.theokanning.openai")
+                || targetPackage.startsWith("org.jsoup")
+                || targetPackage.startsWith("com.microsoft.playwright")
+                || targetPackage.startsWith("org.openqa.selenium")
+                || targetPackage.startsWith("software.amazon.awssdk.services.s3")
+                || targetPackage.startsWith("com.amazonaws.services.s3")
+                || targetName.contains("PipelineWorker")
+                || targetName.contains("StageProcessor")
+                || targetName.contains("StageContext")
+                || targetName.contains("StageResult")
+                || targetName.contains("StageArtifact");
     }
 
     /**

--- a/docs/registro-protocolo/padrao-backend.md
+++ b/docs/registro-protocolo/padrao-backend.md
@@ -33,3 +33,10 @@
 - Pacote backend protegido: `com.marketinghub.oprm.nichocnae.v3`.
 - Módulo executor externo: `oprm-coletor-mei`.
 - Protocolo aplicado com etapas versionadas, controller/service canônicos por etapa, contratos `record` em subpacotes de service e endpoint `pending` em `/api/internal/oprm/nichocnae/v3/<etapa>/stage-executions/pending`.
+
+## 2026-06-25 — MOIS dossiê v1
+
+- Backend protegido/criado: `com.marketinghub.mois.dossie.v1` com pacotes por etapa.
+- Módulo executor responsável pela execução operacional: `mois-sales-library-worker`.
+- Endpoints internos pending canônicos aplicados no padrão `/api/internal/mois/dossie/v1/<etapa>/stage-executions/pending`.
+- Contratos da operação mantidos como `record` em subpacotes de `service`.

--- a/docs/registro-protocolo/padrao-modulo.md
+++ b/docs/registro-protocolo/padrao-modulo.md
@@ -26,3 +26,10 @@
 - Módulo executor: `oprm-coletor-mei`.
 - Pacote executor: `com.marketinghub.nichocnaev3`.
 - Protocolo aplicado com núcleo genérico `pipeline`, etapas concretas plugáveis em subpacotes por etapa, scheduler no executor, consumo via endpoint `pending` do backend e teste ArchUnit próprio.
+
+## 2026-06-25 — MOIS dossiê v1
+
+- Módulo executor: `mois-sales-library-worker`.
+- Pacote protegido/criado: `com.marketinghub.mois.dossiev1.pipeline`.
+- Pipeline criado como `v1`, com núcleo genérico (`PipelineWorker`, `StageProcessor`, `StageContext`, `StageResult`, `StageArtifact`, `ArtifactStore`) e etapas plugáveis `intake`, `product-understanding`, `investigation-anchor-builder`, `warmup-resource-discovery`, `source-product-match`, `warmup-signal-extraction`, `warmup-map-builder` e `dossier-synthesis`.
+- Pontos iniciais canônicos previstos para consumo pelo executor: `/api/internal/mois/dossie/v1/<etapa>/stage-executions/pending`, começando por `intake` e cobrindo todas as etapas v1 do dossiê.

--- a/docs/registros/mois1.md
+++ b/docs/registros/mois1.md
@@ -1832,3 +1832,15 @@ Arquivos principais:
 
 - Identificada a causa dos alertas “Fora do ar” nos coletores MOIS ClickBank/Hotmart: o cadastro operacional do Ops Monitor apontava para `host.docker.internal`, mas esses coletores estão expostos em rota externa monitorável.
 - Criado changelog incremental para restaurar as URLs externas dos coletores e corrigir o endpoint de log do Hotmart, evitando recorrência do falso offline na tela de operação.
+
+## 2026-06-25 — Pipeline de criação de dossiê MOIS v1
+
+- Criado esqueleto do pipeline de dossiê MOIS v1 no módulo executor `mois-sales-library-worker`.
+- Criado contrato backend inicial para etapa `intake`, expondo pending canônico para o executor.
+- Aplicados protocolo padrão módulo e protocolo padrão backend para garantir versionamento, separação de responsabilidades e ponto inicial canônico antes do estudo detalhado das etapas.
+
+## 2026-06-25 15:06:34 UTC-3
+
+- Expandido o desenho do dossiê v1 para refletir o objetivo de entender o produto e mapear recursos usados para aquecer o público.
+- Criadas etapas canônicas: intake, product-understanding, investigation-anchor-builder, warmup-resource-discovery, source-product-match, warmup-signal-extraction, warmup-map-builder e dossier-synthesis.
+- Mantida a separação operacional: backend publica pendências por etapa e o módulo executor mantém processamento, integrações externas e evolução dos processors.

--- a/docs/swagger/mois-dossie-v1-swagger.yaml
+++ b/docs/swagger/mois-dossie-v1-swagger.yaml
@@ -1,0 +1,520 @@
+openapi: 3.0.3
+info:
+  title: MOIS Dossiê v1 API
+  version: v1
+  description: Contratos internos do pipeline de criação de dossiê MOIS v1.
+paths:
+  /api/internal/mois/dossie/v1/intake/stage-executions/pending:
+    post:
+      summary: Lista pendências canônicas da etapa Entrada inicial do dossiê MOIS v1
+      operationId: pendingMoisDossieV1IntakeStageExecutions
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DossierIntakePendingRequest'
+      responses:
+        '200':
+          description: Pendências disponíveis para o executor
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DossierIntakePendingResponse'
+  /api/internal/mois/dossie/v1/product-understanding/stage-executions/pending:
+    post:
+      summary: Lista pendências canônicas da etapa Entendimento do produto do dossiê MOIS v1
+      operationId: pendingMoisDossieV1ProductUnderstandingStageExecutions
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DossierProductUnderstandingPendingRequest'
+      responses:
+        '200':
+          description: Pendências disponíveis para o executor
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DossierProductUnderstandingPendingResponse'
+  /api/internal/mois/dossie/v1/investigation-anchor-builder/stage-executions/pending:
+    post:
+      summary: Lista pendências canônicas da etapa Geração de âncoras de investigação do dossiê MOIS v1
+      operationId: pendingMoisDossieV1InvestigationAnchorBuilderStageExecutions
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DossierInvestigationAnchorBuilderPendingRequest'
+      responses:
+        '200':
+          description: Pendências disponíveis para o executor
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DossierInvestigationAnchorBuilderPendingResponse'
+  /api/internal/mois/dossie/v1/warmup-resource-discovery/stage-executions/pending:
+    post:
+      summary: Lista pendências canônicas da etapa Descoberta de recursos de aquecimento do dossiê MOIS v1
+      operationId: pendingMoisDossieV1WarmupResourceDiscoveryStageExecutions
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DossierWarmupResourceDiscoveryPendingRequest'
+      responses:
+        '200':
+          description: Pendências disponíveis para o executor
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DossierWarmupResourceDiscoveryPendingResponse'
+  /api/internal/mois/dossie/v1/source-product-match/stage-executions/pending:
+    post:
+      summary: Lista pendências canônicas da etapa Validação de relação fonte-produto do dossiê MOIS v1
+      operationId: pendingMoisDossieV1SourceProductMatchStageExecutions
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DossierSourceProductMatchPendingRequest'
+      responses:
+        '200':
+          description: Pendências disponíveis para o executor
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DossierSourceProductMatchPendingResponse'
+  /api/internal/mois/dossie/v1/warmup-signal-extraction/stage-executions/pending:
+    post:
+      summary: Lista pendências canônicas da etapa Extração de sinais de aquecimento do dossiê MOIS v1
+      operationId: pendingMoisDossieV1WarmupSignalExtractionStageExecutions
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DossierWarmupSignalExtractionPendingRequest'
+      responses:
+        '200':
+          description: Pendências disponíveis para o executor
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DossierWarmupSignalExtractionPendingResponse'
+  /api/internal/mois/dossie/v1/warmup-map-builder/stage-executions/pending:
+    post:
+      summary: Lista pendências canônicas da etapa Montagem do mapa de aquecimento do dossiê MOIS v1
+      operationId: pendingMoisDossieV1WarmupMapBuilderStageExecutions
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DossierWarmupMapBuilderPendingRequest'
+      responses:
+        '200':
+          description: Pendências disponíveis para o executor
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DossierWarmupMapBuilderPendingResponse'
+  /api/internal/mois/dossie/v1/dossier-synthesis/stage-executions/pending:
+    post:
+      summary: Lista pendências canônicas da etapa Síntese final do dossiê do dossiê MOIS v1
+      operationId: pendingMoisDossieV1DossierSynthesisStageExecutions
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DossierDossierSynthesisPendingRequest'
+      responses:
+        '200':
+          description: Pendências disponíveis para o executor
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DossierDossierSynthesisPendingResponse'
+components:
+  schemas:
+    DossierIntakePendingRequest:
+      type: object
+      required:
+        - workspaceId
+        - workerId
+      properties:
+        workspaceId:
+          type: string
+        workerId:
+          type: string
+        limit:
+          type: integer
+          format: int32
+    DossierIntakePendingResponse:
+      type: object
+      required:
+        - claimed
+        - jobs
+      properties:
+        claimed:
+          type: boolean
+        jobs:
+          type: array
+          items:
+            $ref: '#/components/schemas/DossierIntakePendingJob'
+    DossierIntakePendingJob:
+      type: object
+      required:
+        - stageExecutionId
+        - dossierId
+        - workspaceId
+        - stageName
+        - input
+      properties:
+        stageExecutionId:
+          type: integer
+          format: int64
+        dossierId:
+          type: integer
+          format: int64
+        workspaceId:
+          type: string
+        stageName:
+          type: string
+        input:
+          type: object
+          additionalProperties: true
+    DossierProductUnderstandingPendingRequest:
+      type: object
+      required:
+        - workspaceId
+        - workerId
+      properties:
+        workspaceId:
+          type: string
+        workerId:
+          type: string
+        limit:
+          type: integer
+          format: int32
+    DossierProductUnderstandingPendingResponse:
+      type: object
+      required:
+        - claimed
+        - jobs
+      properties:
+        claimed:
+          type: boolean
+        jobs:
+          type: array
+          items:
+            $ref: '#/components/schemas/DossierProductUnderstandingPendingJob'
+    DossierProductUnderstandingPendingJob:
+      type: object
+      required:
+        - stageExecutionId
+        - dossierId
+        - workspaceId
+        - stageName
+        - input
+      properties:
+        stageExecutionId:
+          type: integer
+          format: int64
+        dossierId:
+          type: integer
+          format: int64
+        workspaceId:
+          type: string
+        stageName:
+          type: string
+        input:
+          type: object
+          additionalProperties: true
+    DossierInvestigationAnchorBuilderPendingRequest:
+      type: object
+      required:
+        - workspaceId
+        - workerId
+      properties:
+        workspaceId:
+          type: string
+        workerId:
+          type: string
+        limit:
+          type: integer
+          format: int32
+    DossierInvestigationAnchorBuilderPendingResponse:
+      type: object
+      required:
+        - claimed
+        - jobs
+      properties:
+        claimed:
+          type: boolean
+        jobs:
+          type: array
+          items:
+            $ref: '#/components/schemas/DossierInvestigationAnchorBuilderPendingJob'
+    DossierInvestigationAnchorBuilderPendingJob:
+      type: object
+      required:
+        - stageExecutionId
+        - dossierId
+        - workspaceId
+        - stageName
+        - input
+      properties:
+        stageExecutionId:
+          type: integer
+          format: int64
+        dossierId:
+          type: integer
+          format: int64
+        workspaceId:
+          type: string
+        stageName:
+          type: string
+        input:
+          type: object
+          additionalProperties: true
+    DossierWarmupResourceDiscoveryPendingRequest:
+      type: object
+      required:
+        - workspaceId
+        - workerId
+      properties:
+        workspaceId:
+          type: string
+        workerId:
+          type: string
+        limit:
+          type: integer
+          format: int32
+    DossierWarmupResourceDiscoveryPendingResponse:
+      type: object
+      required:
+        - claimed
+        - jobs
+      properties:
+        claimed:
+          type: boolean
+        jobs:
+          type: array
+          items:
+            $ref: '#/components/schemas/DossierWarmupResourceDiscoveryPendingJob'
+    DossierWarmupResourceDiscoveryPendingJob:
+      type: object
+      required:
+        - stageExecutionId
+        - dossierId
+        - workspaceId
+        - stageName
+        - input
+      properties:
+        stageExecutionId:
+          type: integer
+          format: int64
+        dossierId:
+          type: integer
+          format: int64
+        workspaceId:
+          type: string
+        stageName:
+          type: string
+        input:
+          type: object
+          additionalProperties: true
+    DossierSourceProductMatchPendingRequest:
+      type: object
+      required:
+        - workspaceId
+        - workerId
+      properties:
+        workspaceId:
+          type: string
+        workerId:
+          type: string
+        limit:
+          type: integer
+          format: int32
+    DossierSourceProductMatchPendingResponse:
+      type: object
+      required:
+        - claimed
+        - jobs
+      properties:
+        claimed:
+          type: boolean
+        jobs:
+          type: array
+          items:
+            $ref: '#/components/schemas/DossierSourceProductMatchPendingJob'
+    DossierSourceProductMatchPendingJob:
+      type: object
+      required:
+        - stageExecutionId
+        - dossierId
+        - workspaceId
+        - stageName
+        - input
+      properties:
+        stageExecutionId:
+          type: integer
+          format: int64
+        dossierId:
+          type: integer
+          format: int64
+        workspaceId:
+          type: string
+        stageName:
+          type: string
+        input:
+          type: object
+          additionalProperties: true
+    DossierWarmupSignalExtractionPendingRequest:
+      type: object
+      required:
+        - workspaceId
+        - workerId
+      properties:
+        workspaceId:
+          type: string
+        workerId:
+          type: string
+        limit:
+          type: integer
+          format: int32
+    DossierWarmupSignalExtractionPendingResponse:
+      type: object
+      required:
+        - claimed
+        - jobs
+      properties:
+        claimed:
+          type: boolean
+        jobs:
+          type: array
+          items:
+            $ref: '#/components/schemas/DossierWarmupSignalExtractionPendingJob'
+    DossierWarmupSignalExtractionPendingJob:
+      type: object
+      required:
+        - stageExecutionId
+        - dossierId
+        - workspaceId
+        - stageName
+        - input
+      properties:
+        stageExecutionId:
+          type: integer
+          format: int64
+        dossierId:
+          type: integer
+          format: int64
+        workspaceId:
+          type: string
+        stageName:
+          type: string
+        input:
+          type: object
+          additionalProperties: true
+    DossierWarmupMapBuilderPendingRequest:
+      type: object
+      required:
+        - workspaceId
+        - workerId
+      properties:
+        workspaceId:
+          type: string
+        workerId:
+          type: string
+        limit:
+          type: integer
+          format: int32
+    DossierWarmupMapBuilderPendingResponse:
+      type: object
+      required:
+        - claimed
+        - jobs
+      properties:
+        claimed:
+          type: boolean
+        jobs:
+          type: array
+          items:
+            $ref: '#/components/schemas/DossierWarmupMapBuilderPendingJob'
+    DossierWarmupMapBuilderPendingJob:
+      type: object
+      required:
+        - stageExecutionId
+        - dossierId
+        - workspaceId
+        - stageName
+        - input
+      properties:
+        stageExecutionId:
+          type: integer
+          format: int64
+        dossierId:
+          type: integer
+          format: int64
+        workspaceId:
+          type: string
+        stageName:
+          type: string
+        input:
+          type: object
+          additionalProperties: true
+    DossierDossierSynthesisPendingRequest:
+      type: object
+      required:
+        - workspaceId
+        - workerId
+      properties:
+        workspaceId:
+          type: string
+        workerId:
+          type: string
+        limit:
+          type: integer
+          format: int32
+    DossierDossierSynthesisPendingResponse:
+      type: object
+      required:
+        - claimed
+        - jobs
+      properties:
+        claimed:
+          type: boolean
+        jobs:
+          type: array
+          items:
+            $ref: '#/components/schemas/DossierDossierSynthesisPendingJob'
+    DossierDossierSynthesisPendingJob:
+      type: object
+      required:
+        - stageExecutionId
+        - dossierId
+        - workspaceId
+        - stageName
+        - input
+      properties:
+        stageExecutionId:
+          type: integer
+          format: int64
+        dossierId:
+          type: integer
+          format: int64
+        workspaceId:
+          type: string
+        stageName:
+          type: string
+        input:
+          type: object
+          additionalProperties: true

--- a/mois-sales-library-worker/src/main/java/com/marketinghub/mois/dossiev1/pipeline/ArtifactStore.java
+++ b/mois-sales-library-worker/src/main/java/com/marketinghub/mois/dossiev1/pipeline/ArtifactStore.java
@@ -1,0 +1,7 @@
+package com.marketinghub.mois.dossiev1.pipeline;
+
+/** Define a porta de armazenamento de artefatos auditáveis do pipeline de dossiê MOIS v1. */
+public interface ArtifactStore {
+    /** Persiste ou encaminha um artefato produzido por uma etapa concreta. */
+    StageArtifact save(StageContext context, StageArtifact artifact);
+}

--- a/mois-sales-library-worker/src/main/java/com/marketinghub/mois/dossiev1/pipeline/PipelineWorker.java
+++ b/mois-sales-library-worker/src/main/java/com/marketinghub/mois/dossiev1/pipeline/PipelineWorker.java
@@ -1,0 +1,27 @@
+package com.marketinghub.mois.dossiev1.pipeline;
+
+import java.util.List;
+import java.util.Optional;
+
+/** Orquestra processors plugáveis sem conhecer detalhes das etapas concretas do dossiê MOIS v1. */
+public class PipelineWorker {
+
+    private final List<StageProcessor> processors;
+
+    /** Recebe a lista de processors disponíveis para o pipeline v1. */
+    public PipelineWorker(List<StageProcessor> processors) {
+        this.processors = List.copyOf(processors);
+    }
+
+    /** Executa a etapa indicada no contexto usando o processor compatível. */
+    public StageResult execute(StageContext context) {
+        StageProcessor processor = findProcessor(context.stageName())
+                .orElseThrow(() -> new IllegalArgumentException("Etapa de dossiê não suportada: " + context.stageName()));
+        return processor.process(context);
+    }
+
+    /** Localiza o processor de uma etapa pelo nome canônico. */
+    private Optional<StageProcessor> findProcessor(String stageName) {
+        return processors.stream().filter(processor -> processor.stageName().equals(stageName)).findFirst();
+    }
+}

--- a/mois-sales-library-worker/src/main/java/com/marketinghub/mois/dossiev1/pipeline/StageArtifact.java
+++ b/mois-sales-library-worker/src/main/java/com/marketinghub/mois/dossiev1/pipeline/StageArtifact.java
@@ -1,0 +1,7 @@
+package com.marketinghub.mois.dossiev1.pipeline;
+
+import java.time.Instant;
+
+/** Representa um artefato auditável produzido por uma etapa do pipeline de dossiê MOIS v1. */
+public record StageArtifact(String type, String storageKey, String payload, Instant createdAt) {
+}

--- a/mois-sales-library-worker/src/main/java/com/marketinghub/mois/dossiev1/pipeline/StageContext.java
+++ b/mois-sales-library-worker/src/main/java/com/marketinghub/mois/dossiev1/pipeline/StageContext.java
@@ -1,0 +1,7 @@
+package com.marketinghub.mois.dossiev1.pipeline;
+
+import java.util.Map;
+
+/** Carrega o contexto funcional persistido pelo backend para execução de uma etapa do dossiê MOIS v1. */
+public record StageContext(long stageExecutionId, long dossierId, String workspaceId, String stageName, Map<String, Object> input) {
+}

--- a/mois-sales-library-worker/src/main/java/com/marketinghub/mois/dossiev1/pipeline/StageProcessor.java
+++ b/mois-sales-library-worker/src/main/java/com/marketinghub/mois/dossiev1/pipeline/StageProcessor.java
@@ -1,0 +1,10 @@
+package com.marketinghub.mois.dossiev1.pipeline;
+
+/** Define o contrato plugável que toda etapa concreta do pipeline de dossiê MOIS v1 deve implementar. */
+public interface StageProcessor {
+    /** Informa o nome canônico da etapa executada pelo processor. */
+    String stageName();
+
+    /** Processa uma etapa a partir do contexto recebido do backend e devolve saída estruturada. */
+    StageResult process(StageContext context);
+}

--- a/mois-sales-library-worker/src/main/java/com/marketinghub/mois/dossiev1/pipeline/StageResult.java
+++ b/mois-sales-library-worker/src/main/java/com/marketinghub/mois/dossiev1/pipeline/StageResult.java
@@ -1,0 +1,12 @@
+package com.marketinghub.mois.dossiev1.pipeline;
+
+import java.util.List;
+import java.util.Map;
+
+/** Descreve a saída estruturada de uma etapa executada pelo pipeline de dossiê MOIS v1. */
+public record StageResult(String status, Map<String, Object> output, List<StageArtifact> artifacts, String errorMessage) {
+    /** Cria um resultado concluído com saída funcional e artefatos auditáveis. */
+    public static StageResult done(Map<String, Object> output, List<StageArtifact> artifacts) {
+        return new StageResult("DONE", output, artifacts, null);
+    }
+}

--- a/mois-sales-library-worker/src/main/java/com/marketinghub/mois/dossiev1/pipeline/dossiersynthesis/DossierDossierSynthesisInput.java
+++ b/mois-sales-library-worker/src/main/java/com/marketinghub/mois/dossiev1/pipeline/dossiersynthesis/DossierDossierSynthesisInput.java
@@ -1,0 +1,7 @@
+package com.marketinghub.mois.dossiev1.pipeline.dossiersynthesis;
+
+import java.util.Map;
+
+/** Representa a entrada funcional da etapa síntese final do dossiê do dossiê MOIS v1. */
+public record DossierDossierSynthesisInput(long dossierId, String workspaceId, Map<String, Object> context) {
+}

--- a/mois-sales-library-worker/src/main/java/com/marketinghub/mois/dossiev1/pipeline/dossiersynthesis/DossierDossierSynthesisOutput.java
+++ b/mois-sales-library-worker/src/main/java/com/marketinghub/mois/dossiev1/pipeline/dossiersynthesis/DossierDossierSynthesisOutput.java
@@ -1,0 +1,5 @@
+package com.marketinghub.mois.dossiev1.pipeline.dossiersynthesis;
+
+/** Representa a saída funcional da etapa síntese final do dossiê do dossiê MOIS v1. */
+public record DossierDossierSynthesisOutput(long dossierId, String status, String businessDecision) {
+}

--- a/mois-sales-library-worker/src/main/java/com/marketinghub/mois/dossiev1/pipeline/dossiersynthesis/DossierDossierSynthesisProcessor.java
+++ b/mois-sales-library-worker/src/main/java/com/marketinghub/mois/dossiev1/pipeline/dossiersynthesis/DossierDossierSynthesisProcessor.java
@@ -1,0 +1,28 @@
+package com.marketinghub.mois.dossiev1.pipeline.dossiersynthesis;
+
+import com.marketinghub.mois.dossiev1.pipeline.StageContext;
+import com.marketinghub.mois.dossiev1.pipeline.StageProcessor;
+import com.marketinghub.mois.dossiev1.pipeline.StageResult;
+import java.util.List;
+import java.util.Map;
+
+/** Executa a etapa síntese final do dossiê sem acoplar o núcleo do pipeline às demais etapas do dossiê. */
+public class DossierDossierSynthesisProcessor implements StageProcessor {
+
+    /** Informa o nome canônico da etapa síntese final do dossiê. */
+    @Override
+    public String stageName() {
+        return "dossier-synthesis";
+    }
+
+    /** Produz saída estruturada mínima para auditoria e evolução incremental da etapa. */
+    @Override
+    public StageResult process(StageContext context) {
+        DossierDossierSynthesisOutput output = new DossierDossierSynthesisOutput(
+                context.dossierId(),
+                "READY_FOR_IMPLEMENTATION",
+                "Gerar conclusão de negócio, evidências, estrutura reutilizável e próximos passos comerciais."
+        );
+        return StageResult.done(Map.of("dossier-synthesis", output), List.of());
+    }
+}

--- a/mois-sales-library-worker/src/main/java/com/marketinghub/mois/dossiev1/pipeline/intake/DossierIntakeInput.java
+++ b/mois-sales-library-worker/src/main/java/com/marketinghub/mois/dossiev1/pipeline/intake/DossierIntakeInput.java
@@ -1,0 +1,7 @@
+package com.marketinghub.mois.dossiev1.pipeline.intake;
+
+import java.util.Map;
+
+/** Representa a entrada funcional da etapa entrada inicial do dossiê MOIS v1. */
+public record DossierIntakeInput(long dossierId, String workspaceId, Map<String, Object> context) {
+}

--- a/mois-sales-library-worker/src/main/java/com/marketinghub/mois/dossiev1/pipeline/intake/DossierIntakeOutput.java
+++ b/mois-sales-library-worker/src/main/java/com/marketinghub/mois/dossiev1/pipeline/intake/DossierIntakeOutput.java
@@ -1,0 +1,5 @@
+package com.marketinghub.mois.dossiev1.pipeline.intake;
+
+/** Representa a saída funcional da etapa entrada inicial do dossiê MOIS v1. */
+public record DossierIntakeOutput(long dossierId, String status, String businessDecision) {
+}

--- a/mois-sales-library-worker/src/main/java/com/marketinghub/mois/dossiev1/pipeline/intake/DossierIntakeProcessor.java
+++ b/mois-sales-library-worker/src/main/java/com/marketinghub/mois/dossiev1/pipeline/intake/DossierIntakeProcessor.java
@@ -1,0 +1,28 @@
+package com.marketinghub.mois.dossiev1.pipeline.intake;
+
+import com.marketinghub.mois.dossiev1.pipeline.StageContext;
+import com.marketinghub.mois.dossiev1.pipeline.StageProcessor;
+import com.marketinghub.mois.dossiev1.pipeline.StageResult;
+import java.util.List;
+import java.util.Map;
+
+/** Executa a etapa entrada inicial sem acoplar o núcleo do pipeline às demais etapas do dossiê. */
+public class DossierIntakeProcessor implements StageProcessor {
+
+    /** Informa o nome canônico da etapa entrada inicial. */
+    @Override
+    public String stageName() {
+        return "intake";
+    }
+
+    /** Produz saída estruturada mínima para auditoria e evolução incremental da etapa. */
+    @Override
+    public StageResult process(StageContext context) {
+        DossierIntakeOutput output = new DossierIntakeOutput(
+                context.dossierId(),
+                "READY_FOR_IMPLEMENTATION",
+                "Confirmar elegibilidade e preparar contexto mínimo para o dossiê v1."
+        );
+        return StageResult.done(Map.of("intake", output), List.of());
+    }
+}

--- a/mois-sales-library-worker/src/main/java/com/marketinghub/mois/dossiev1/pipeline/investigationanchorbuilder/DossierInvestigationAnchorBuilderInput.java
+++ b/mois-sales-library-worker/src/main/java/com/marketinghub/mois/dossiev1/pipeline/investigationanchorbuilder/DossierInvestigationAnchorBuilderInput.java
@@ -1,0 +1,7 @@
+package com.marketinghub.mois.dossiev1.pipeline.investigationanchorbuilder;
+
+import java.util.Map;
+
+/** Representa a entrada funcional da etapa geração de âncoras de investigação do dossiê MOIS v1. */
+public record DossierInvestigationAnchorBuilderInput(long dossierId, String workspaceId, Map<String, Object> context) {
+}

--- a/mois-sales-library-worker/src/main/java/com/marketinghub/mois/dossiev1/pipeline/investigationanchorbuilder/DossierInvestigationAnchorBuilderOutput.java
+++ b/mois-sales-library-worker/src/main/java/com/marketinghub/mois/dossiev1/pipeline/investigationanchorbuilder/DossierInvestigationAnchorBuilderOutput.java
@@ -1,0 +1,5 @@
+package com.marketinghub.mois.dossiev1.pipeline.investigationanchorbuilder;
+
+/** Representa a saída funcional da etapa geração de âncoras de investigação do dossiê MOIS v1. */
+public record DossierInvestigationAnchorBuilderOutput(long dossierId, String status, String businessDecision) {
+}

--- a/mois-sales-library-worker/src/main/java/com/marketinghub/mois/dossiev1/pipeline/investigationanchorbuilder/DossierInvestigationAnchorBuilderProcessor.java
+++ b/mois-sales-library-worker/src/main/java/com/marketinghub/mois/dossiev1/pipeline/investigationanchorbuilder/DossierInvestigationAnchorBuilderProcessor.java
@@ -1,0 +1,28 @@
+package com.marketinghub.mois.dossiev1.pipeline.investigationanchorbuilder;
+
+import com.marketinghub.mois.dossiev1.pipeline.StageContext;
+import com.marketinghub.mois.dossiev1.pipeline.StageProcessor;
+import com.marketinghub.mois.dossiev1.pipeline.StageResult;
+import java.util.List;
+import java.util.Map;
+
+/** Executa a etapa geração de âncoras de investigação sem acoplar o núcleo do pipeline às demais etapas do dossiê. */
+public class DossierInvestigationAnchorBuilderProcessor implements StageProcessor {
+
+    /** Informa o nome canônico da etapa geração de âncoras de investigação. */
+    @Override
+    public String stageName() {
+        return "investigation-anchor-builder";
+    }
+
+    /** Produz saída estruturada mínima para auditoria e evolução incremental da etapa. */
+    @Override
+    public StageResult process(StageContext context) {
+        DossierInvestigationAnchorBuilderOutput output = new DossierInvestigationAnchorBuilderOutput(
+                context.dossierId(),
+                "READY_FOR_IMPLEMENTATION",
+                "Gerar âncoras confiáveis como produto, produtor, domínio, marca, promessa e termos proprietários."
+        );
+        return StageResult.done(Map.of("investigation-anchor-builder", output), List.of());
+    }
+}

--- a/mois-sales-library-worker/src/main/java/com/marketinghub/mois/dossiev1/pipeline/productunderstanding/DossierProductUnderstandingInput.java
+++ b/mois-sales-library-worker/src/main/java/com/marketinghub/mois/dossiev1/pipeline/productunderstanding/DossierProductUnderstandingInput.java
@@ -1,0 +1,7 @@
+package com.marketinghub.mois.dossiev1.pipeline.productunderstanding;
+
+import java.util.Map;
+
+/** Representa a entrada funcional da etapa entendimento do produto do dossiê MOIS v1. */
+public record DossierProductUnderstandingInput(long dossierId, String workspaceId, Map<String, Object> context) {
+}

--- a/mois-sales-library-worker/src/main/java/com/marketinghub/mois/dossiev1/pipeline/productunderstanding/DossierProductUnderstandingOutput.java
+++ b/mois-sales-library-worker/src/main/java/com/marketinghub/mois/dossiev1/pipeline/productunderstanding/DossierProductUnderstandingOutput.java
@@ -1,0 +1,5 @@
+package com.marketinghub.mois.dossiev1.pipeline.productunderstanding;
+
+/** Representa a saída funcional da etapa entendimento do produto do dossiê MOIS v1. */
+public record DossierProductUnderstandingOutput(long dossierId, String status, String businessDecision) {
+}

--- a/mois-sales-library-worker/src/main/java/com/marketinghub/mois/dossiev1/pipeline/productunderstanding/DossierProductUnderstandingProcessor.java
+++ b/mois-sales-library-worker/src/main/java/com/marketinghub/mois/dossiev1/pipeline/productunderstanding/DossierProductUnderstandingProcessor.java
@@ -1,0 +1,28 @@
+package com.marketinghub.mois.dossiev1.pipeline.productunderstanding;
+
+import com.marketinghub.mois.dossiev1.pipeline.StageContext;
+import com.marketinghub.mois.dossiev1.pipeline.StageProcessor;
+import com.marketinghub.mois.dossiev1.pipeline.StageResult;
+import java.util.List;
+import java.util.Map;
+
+/** Executa a etapa entendimento do produto sem acoplar o núcleo do pipeline às demais etapas do dossiê. */
+public class DossierProductUnderstandingProcessor implements StageProcessor {
+
+    /** Informa o nome canônico da etapa entendimento do produto. */
+    @Override
+    public String stageName() {
+        return "product-understanding";
+    }
+
+    /** Produz saída estruturada mínima para auditoria e evolução incremental da etapa. */
+    @Override
+    public StageResult process(StageContext context) {
+        DossierProductUnderstandingOutput output = new DossierProductUnderstandingOutput(
+                context.dossierId(),
+                "READY_FOR_IMPLEMENTATION",
+                "Identificar produto, público, dor, promessa, mecanismo, formato, oferta e prova antes da pesquisa externa."
+        );
+        return StageResult.done(Map.of("product-understanding", output), List.of());
+    }
+}

--- a/mois-sales-library-worker/src/main/java/com/marketinghub/mois/dossiev1/pipeline/sourceproductmatch/DossierSourceProductMatchInput.java
+++ b/mois-sales-library-worker/src/main/java/com/marketinghub/mois/dossiev1/pipeline/sourceproductmatch/DossierSourceProductMatchInput.java
@@ -1,0 +1,7 @@
+package com.marketinghub.mois.dossiev1.pipeline.sourceproductmatch;
+
+import java.util.Map;
+
+/** Representa a entrada funcional da etapa validação de relação fonte-produto do dossiê MOIS v1. */
+public record DossierSourceProductMatchInput(long dossierId, String workspaceId, Map<String, Object> context) {
+}

--- a/mois-sales-library-worker/src/main/java/com/marketinghub/mois/dossiev1/pipeline/sourceproductmatch/DossierSourceProductMatchOutput.java
+++ b/mois-sales-library-worker/src/main/java/com/marketinghub/mois/dossiev1/pipeline/sourceproductmatch/DossierSourceProductMatchOutput.java
@@ -1,0 +1,5 @@
+package com.marketinghub.mois.dossiev1.pipeline.sourceproductmatch;
+
+/** Representa a saída funcional da etapa validação de relação fonte-produto do dossiê MOIS v1. */
+public record DossierSourceProductMatchOutput(long dossierId, String status, String businessDecision) {
+}

--- a/mois-sales-library-worker/src/main/java/com/marketinghub/mois/dossiev1/pipeline/sourceproductmatch/DossierSourceProductMatchProcessor.java
+++ b/mois-sales-library-worker/src/main/java/com/marketinghub/mois/dossiev1/pipeline/sourceproductmatch/DossierSourceProductMatchProcessor.java
@@ -1,0 +1,28 @@
+package com.marketinghub.mois.dossiev1.pipeline.sourceproductmatch;
+
+import com.marketinghub.mois.dossiev1.pipeline.StageContext;
+import com.marketinghub.mois.dossiev1.pipeline.StageProcessor;
+import com.marketinghub.mois.dossiev1.pipeline.StageResult;
+import java.util.List;
+import java.util.Map;
+
+/** Executa a etapa validação de relação fonte-produto sem acoplar o núcleo do pipeline às demais etapas do dossiê. */
+public class DossierSourceProductMatchProcessor implements StageProcessor {
+
+    /** Informa o nome canônico da etapa validação de relação fonte-produto. */
+    @Override
+    public String stageName() {
+        return "source-product-match";
+    }
+
+    /** Produz saída estruturada mínima para auditoria e evolução incremental da etapa. */
+    @Override
+    public StageResult process(StageContext context) {
+        DossierSourceProductMatchOutput output = new DossierSourceProductMatchOutput(
+                context.dossierId(),
+                "READY_FOR_IMPLEMENTATION",
+                "Validar se cada fonte pertence ao produto, produtor ou recurso de aquecimento antes de virar evidência."
+        );
+        return StageResult.done(Map.of("source-product-match", output), List.of());
+    }
+}

--- a/mois-sales-library-worker/src/main/java/com/marketinghub/mois/dossiev1/pipeline/warmupmapbuilder/DossierWarmupMapBuilderInput.java
+++ b/mois-sales-library-worker/src/main/java/com/marketinghub/mois/dossiev1/pipeline/warmupmapbuilder/DossierWarmupMapBuilderInput.java
@@ -1,0 +1,7 @@
+package com.marketinghub.mois.dossiev1.pipeline.warmupmapbuilder;
+
+import java.util.Map;
+
+/** Representa a entrada funcional da etapa montagem do mapa de aquecimento do dossiê MOIS v1. */
+public record DossierWarmupMapBuilderInput(long dossierId, String workspaceId, Map<String, Object> context) {
+}

--- a/mois-sales-library-worker/src/main/java/com/marketinghub/mois/dossiev1/pipeline/warmupmapbuilder/DossierWarmupMapBuilderOutput.java
+++ b/mois-sales-library-worker/src/main/java/com/marketinghub/mois/dossiev1/pipeline/warmupmapbuilder/DossierWarmupMapBuilderOutput.java
@@ -1,0 +1,5 @@
+package com.marketinghub.mois.dossiev1.pipeline.warmupmapbuilder;
+
+/** Representa a saída funcional da etapa montagem do mapa de aquecimento do dossiê MOIS v1. */
+public record DossierWarmupMapBuilderOutput(long dossierId, String status, String businessDecision) {
+}

--- a/mois-sales-library-worker/src/main/java/com/marketinghub/mois/dossiev1/pipeline/warmupmapbuilder/DossierWarmupMapBuilderProcessor.java
+++ b/mois-sales-library-worker/src/main/java/com/marketinghub/mois/dossiev1/pipeline/warmupmapbuilder/DossierWarmupMapBuilderProcessor.java
@@ -1,0 +1,28 @@
+package com.marketinghub.mois.dossiev1.pipeline.warmupmapbuilder;
+
+import com.marketinghub.mois.dossiev1.pipeline.StageContext;
+import com.marketinghub.mois.dossiev1.pipeline.StageProcessor;
+import com.marketinghub.mois.dossiev1.pipeline.StageResult;
+import java.util.List;
+import java.util.Map;
+
+/** Executa a etapa montagem do mapa de aquecimento sem acoplar o núcleo do pipeline às demais etapas do dossiê. */
+public class DossierWarmupMapBuilderProcessor implements StageProcessor {
+
+    /** Informa o nome canônico da etapa montagem do mapa de aquecimento. */
+    @Override
+    public String stageName() {
+        return "warmup-map-builder";
+    }
+
+    /** Produz saída estruturada mínima para auditoria e evolução incremental da etapa. */
+    @Override
+    public StageResult process(StageContext context) {
+        DossierWarmupMapBuilderOutput output = new DossierWarmupMapBuilderOutput(
+                context.dossierId(),
+                "READY_FOR_IMPLEMENTATION",
+                "Organizar os recursos externos que aquecem o público antes da compra."
+        );
+        return StageResult.done(Map.of("warmup-map-builder", output), List.of());
+    }
+}

--- a/mois-sales-library-worker/src/main/java/com/marketinghub/mois/dossiev1/pipeline/warmupresourcediscovery/DossierWarmupResourceDiscoveryInput.java
+++ b/mois-sales-library-worker/src/main/java/com/marketinghub/mois/dossiev1/pipeline/warmupresourcediscovery/DossierWarmupResourceDiscoveryInput.java
@@ -1,0 +1,7 @@
+package com.marketinghub.mois.dossiev1.pipeline.warmupresourcediscovery;
+
+import java.util.Map;
+
+/** Representa a entrada funcional da etapa descoberta de recursos de aquecimento do dossiê MOIS v1. */
+public record DossierWarmupResourceDiscoveryInput(long dossierId, String workspaceId, Map<String, Object> context) {
+}

--- a/mois-sales-library-worker/src/main/java/com/marketinghub/mois/dossiev1/pipeline/warmupresourcediscovery/DossierWarmupResourceDiscoveryOutput.java
+++ b/mois-sales-library-worker/src/main/java/com/marketinghub/mois/dossiev1/pipeline/warmupresourcediscovery/DossierWarmupResourceDiscoveryOutput.java
@@ -1,0 +1,5 @@
+package com.marketinghub.mois.dossiev1.pipeline.warmupresourcediscovery;
+
+/** Representa a saída funcional da etapa descoberta de recursos de aquecimento do dossiê MOIS v1. */
+public record DossierWarmupResourceDiscoveryOutput(long dossierId, String status, String businessDecision) {
+}

--- a/mois-sales-library-worker/src/main/java/com/marketinghub/mois/dossiev1/pipeline/warmupresourcediscovery/DossierWarmupResourceDiscoveryProcessor.java
+++ b/mois-sales-library-worker/src/main/java/com/marketinghub/mois/dossiev1/pipeline/warmupresourcediscovery/DossierWarmupResourceDiscoveryProcessor.java
@@ -1,0 +1,28 @@
+package com.marketinghub.mois.dossiev1.pipeline.warmupresourcediscovery;
+
+import com.marketinghub.mois.dossiev1.pipeline.StageContext;
+import com.marketinghub.mois.dossiev1.pipeline.StageProcessor;
+import com.marketinghub.mois.dossiev1.pipeline.StageResult;
+import java.util.List;
+import java.util.Map;
+
+/** Executa a etapa descoberta de recursos de aquecimento sem acoplar o núcleo do pipeline às demais etapas do dossiê. */
+public class DossierWarmupResourceDiscoveryProcessor implements StageProcessor {
+
+    /** Informa o nome canônico da etapa descoberta de recursos de aquecimento. */
+    @Override
+    public String stageName() {
+        return "warmup-resource-discovery";
+    }
+
+    /** Produz saída estruturada mínima para auditoria e evolução incremental da etapa. */
+    @Override
+    public StageResult process(StageContext context) {
+        DossierWarmupResourceDiscoveryOutput output = new DossierWarmupResourceDiscoveryOutput(
+                context.dossierId(),
+                "READY_FOR_IMPLEMENTATION",
+                "Descobrir canais, comunidades, aulas, lives, reviews, afiliados e provas sociais que aquecem o público."
+        );
+        return StageResult.done(Map.of("warmup-resource-discovery", output), List.of());
+    }
+}

--- a/mois-sales-library-worker/src/main/java/com/marketinghub/mois/dossiev1/pipeline/warmupsignalextraction/DossierWarmupSignalExtractionInput.java
+++ b/mois-sales-library-worker/src/main/java/com/marketinghub/mois/dossiev1/pipeline/warmupsignalextraction/DossierWarmupSignalExtractionInput.java
@@ -1,0 +1,7 @@
+package com.marketinghub.mois.dossiev1.pipeline.warmupsignalextraction;
+
+import java.util.Map;
+
+/** Representa a entrada funcional da etapa extração de sinais de aquecimento do dossiê MOIS v1. */
+public record DossierWarmupSignalExtractionInput(long dossierId, String workspaceId, Map<String, Object> context) {
+}

--- a/mois-sales-library-worker/src/main/java/com/marketinghub/mois/dossiev1/pipeline/warmupsignalextraction/DossierWarmupSignalExtractionOutput.java
+++ b/mois-sales-library-worker/src/main/java/com/marketinghub/mois/dossiev1/pipeline/warmupsignalextraction/DossierWarmupSignalExtractionOutput.java
@@ -1,0 +1,5 @@
+package com.marketinghub.mois.dossiev1.pipeline.warmupsignalextraction;
+
+/** Representa a saída funcional da etapa extração de sinais de aquecimento do dossiê MOIS v1. */
+public record DossierWarmupSignalExtractionOutput(long dossierId, String status, String businessDecision) {
+}

--- a/mois-sales-library-worker/src/main/java/com/marketinghub/mois/dossiev1/pipeline/warmupsignalextraction/DossierWarmupSignalExtractionProcessor.java
+++ b/mois-sales-library-worker/src/main/java/com/marketinghub/mois/dossiev1/pipeline/warmupsignalextraction/DossierWarmupSignalExtractionProcessor.java
@@ -1,0 +1,28 @@
+package com.marketinghub.mois.dossiev1.pipeline.warmupsignalextraction;
+
+import com.marketinghub.mois.dossiev1.pipeline.StageContext;
+import com.marketinghub.mois.dossiev1.pipeline.StageProcessor;
+import com.marketinghub.mois.dossiev1.pipeline.StageResult;
+import java.util.List;
+import java.util.Map;
+
+/** Executa a etapa extração de sinais de aquecimento sem acoplar o núcleo do pipeline às demais etapas do dossiê. */
+public class DossierWarmupSignalExtractionProcessor implements StageProcessor {
+
+    /** Informa o nome canônico da etapa extração de sinais de aquecimento. */
+    @Override
+    public String stageName() {
+        return "warmup-signal-extraction";
+    }
+
+    /** Produz saída estruturada mínima para auditoria e evolução incremental da etapa. */
+    @Override
+    public StageResult process(StageContext context) {
+        DossierWarmupSignalExtractionOutput output = new DossierWarmupSignalExtractionOutput(
+                context.dossierId(),
+                "READY_FOR_IMPLEMENTATION",
+                "Extrair sinais de autoridade, prova social, educação pré-venda, comunidade, distribuição e objeções."
+        );
+        return StageResult.done(Map.of("warmup-signal-extraction", output), List.of());
+    }
+}

--- a/mois-sales-library-worker/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/archunit/ArquiteturaTest.java
+++ b/mois-sales-library-worker/src/test/java/com/marketinghub/mois/bibliotecapaginavenda/worker/archunit/ArquiteturaTest.java
@@ -17,10 +17,11 @@ import com.tngtech.archunit.lang.ConditionEvents;
 import com.tngtech.archunit.lang.SimpleConditionEvent;
 
 /** Garante contratos estruturais de rastreabilidade OpenAI consumidos pelo PromptBuilder. */
-@AnalyzeClasses(packages = "com.marketinghub.mois.bibliotecapaginavenda.worker", importOptions = ImportOption.DoNotIncludeTests.class)
+@AnalyzeClasses(packages = "com.marketinghub.mois", importOptions = ImportOption.DoNotIncludeTests.class)
 class ArquiteturaTest {
 
     private static final String PIPELINE_ROOT = "com.marketinghub.mois.bibliotecapaginavenda.worker.v1.pipeline";
+    private static final String DOSSIER_V1_PIPELINE_ROOT = "com.marketinghub.mois.dossiev1.pipeline";
 
     private static final DescribedPredicate<JavaClass> CLASSES_DE_ETAPA =
             new DescribedPredicate<>("[ARQUITETURA] classes dentro de pipeline.<etapa>") {
@@ -74,6 +75,50 @@ class ArquiteturaTest {
             .resideInAPackage(PIPELINE_ROOT)
             .should(notDependOnConcreteTechnologies())
             .because("[ARQUITETURA] o núcleo do pipeline deve depender de abstrações, não de tecnologias concretas");
+
+    /** Garante que o núcleo genérico do dossiê MOIS v1 não importe etapas concretas. */
+    @ArchTest
+    static final ArchRule dossie_v1_pipeline_raiz_nao_deve_depender_de_etapas = classes()
+            .that()
+            .resideInAPackage(DOSSIER_V1_PIPELINE_ROOT)
+            .should(notDependOnConcreteDossierV1Stages())
+            .because("[ARQUITETURA] o núcleo do dossiê MOIS v1 não pode conhecer etapas concretas");
+
+    /** Garante independência plugável entre etapas concretas do dossiê MOIS v1. */
+    @ArchTest
+    static final ArchRule dossie_v1_etapas_nao_devem_depender_umas_das_outras = classes()
+            .that(resideInDossierV1ConcreteStage())
+            .should(notDependOnAnotherDossierV1ConcreteStage())
+            .because("[ARQUITETURA] cada etapa concreta de com.marketinghub.mois.dossiev1.pipeline.<etapa> deve ser independente");
+
+    /** Garante que as etapas concretas do dossiê MOIS v1 não formem ciclos. */
+    @ArchTest
+    static final ArchRule dossie_v1_etapas_nao_devem_ter_ciclos = slices()
+            .matching("com.marketinghub.mois.dossiev1.pipeline.(*)..")
+            .should()
+            .beFreeOfCycles()
+            .because("[ARQUITETURA] etapas concretas do dossiê MOIS v1 não podem formar ciclos");
+
+    /** Garante que processors concretos do dossiê MOIS v1 implementem o contrato de etapa. */
+    @ArchTest
+    static final ArchRule dossie_v1_processors_devem_implementar_stage_processor = classes()
+            .that()
+            .resideInAPackage("com.marketinghub.mois.dossiev1.pipeline..")
+            .and()
+            .resideOutsideOfPackage(DOSSIER_V1_PIPELINE_ROOT)
+            .and()
+            .haveSimpleNameEndingWith("Processor")
+            .should()
+            .implement(com.marketinghub.mois.dossiev1.pipeline.StageProcessor.class)
+            .because("[ARQUITETURA] toda etapa concreta do dossiê MOIS v1 deve implementar StageProcessor");
+
+    /** Garante que o núcleo do dossiê MOIS v1 não dependa de tecnologias concretas. */
+    @ArchTest
+    static final ArchRule dossie_v1_pipeline_raiz_nao_deve_depender_de_tecnologias_concretas = classes()
+            .that()
+            .resideInAPackage(DOSSIER_V1_PIPELINE_ROOT)
+            .should(notDependOnConcreteTechnologies())
+            .because("[ARQUITETURA] o núcleo do dossiê MOIS v1 deve depender de abstrações, não de tecnologias concretas");
 
     /** Valida assinatura obrigatória com 4 parâmetros para uso direto do PromptBuilder. */
     @ArchTest
@@ -139,6 +184,58 @@ class ArquiteturaTest {
                 }
             }
         };
+    }
+
+    private static DescribedPredicate<JavaClass> resideInDossierV1ConcreteStage() {
+        return new DescribedPredicate<>("[ARQUITETURA] classes dentro de dossiev1.pipeline.<etapa>") {
+            @Override
+            public boolean test(JavaClass javaClass) {
+                return concreteDossierV1StageName(javaClass) != null;
+            }
+        };
+    }
+
+    private static ArchCondition<JavaClass> notDependOnConcreteDossierV1Stages() {
+        return new ArchCondition<>("[ARQUITETURA] não depender de dossiev1.pipeline.<etapa>") {
+            @Override
+            public void check(JavaClass javaClass, ConditionEvents events) {
+                for (Dependency dependency : javaClass.getDirectDependenciesFromSelf()) {
+                    JavaClass target = dependency.getTargetClass();
+                    boolean valid = concreteDossierV1StageName(target) == null;
+                    events.add(new SimpleConditionEvent(dependency, valid,
+                            "[ARQUITETURA] " + javaClass.getName() + " não pode depender da etapa concreta de dossiê "
+                                    + target.getName()));
+                }
+            }
+        };
+    }
+
+    private static ArchCondition<JavaClass> notDependOnAnotherDossierV1ConcreteStage() {
+        return new ArchCondition<>("[ARQUITETURA] não depender de outra etapa concreta do dossiê MOIS v1") {
+            @Override
+            public void check(JavaClass javaClass, ConditionEvents events) {
+                String sourceStage = concreteDossierV1StageName(javaClass);
+                for (Dependency dependency : javaClass.getDirectDependenciesFromSelf()) {
+                    JavaClass target = dependency.getTargetClass();
+                    String targetStage = concreteDossierV1StageName(target);
+                    boolean valid = targetStage == null || targetStage.equals(sourceStage);
+                    events.add(new SimpleConditionEvent(dependency, valid,
+                            "[ARQUITETURA] " + javaClass.getName() + " da etapa " + sourceStage
+                                    + " não pode depender de " + target.getName() + " da etapa " + targetStage));
+                }
+            }
+        };
+    }
+
+    private static String concreteDossierV1StageName(JavaClass javaClass) {
+        String prefix = DOSSIER_V1_PIPELINE_ROOT + ".";
+        String packageName = javaClass.getPackageName();
+        if (!packageName.startsWith(prefix)) {
+            return null;
+        }
+        String suffix = packageName.substring(prefix.length());
+        int dot = suffix.indexOf('.');
+        return dot < 0 ? suffix : suffix.substring(0, dot);
     }
 
     private static String concreteStageName(JavaClass javaClass) {


### PR DESCRIPTION
### Motivation

- Provide canonical backend contracts and internal pending endpoints for the new MOIS dossiê v1 pipeline while keeping operational execution in an external worker; enforce the separation via architecture tests and documentation.
- Provide a worker-side pipeline skeleton so an external executor (`mois-sales-library-worker`) can implement stage processors and take operational responsibility for integrations and OpenAI calls.

### Description

- Add backend package `com.marketinghub.mois.dossie.v1` with canonical controllers and services for each stage (`intake`, `product-understanding`, `investigation-anchor-builder`, `warmup-resource-discovery`, `source-product-match`, `warmup-signal-extraction`, `warmup-map-builder`, `dossier-synthesis`) exposing `POST /api/internal/mois/dossie/v1/<stage>/stage-executions/pending` and DTO contracts implemented as Java `record`s (`PendingRequest`, `PendingResponse`, `PendingJob`).
- Provide a simple service implementation that returns an unclaimed empty job list for each stage and add OpenAPI specification `docs/swagger/mois-dossie-v1-swagger.yaml` plus documentation updates under `docs/registro-protocolo` and `docs/registros/mois1.md` describing the protocol and executor module.
- Add the worker module `mois-sales-library-worker` with a generic pipeline core (`PipelineWorker`, `StageProcessor`, `StageContext`, `StageResult`, `StageArtifact`, `ArtifactStore`) and minimal stage processors/DTOs for each stage that produce placeholder `READY_FOR_IMPLEMENTATION` outputs to serve as a starting point for executor implementation.
- Extend ArchUnit tests in both backend and worker test suites to enforce the new MOIS dossiê v1 rules: one canonical controller/service per stage, presence of canonical `pending` endpoint annotated with `@PostMapping`, service DTOs as records, and a backend rule that forbids assuming operational execution responsibilities (forbidden technology/dependency names and worker-like class names).

### Testing

- Ran the project's automated unit and architecture tests including ArchUnit checks for `backend/ads-service` and `mois-sales-library-worker` (e.g. via the standard test task) and the test suite passed with no architecture violations.
- Verified the new OpenAPI/Swagger file and schema additions are present in the repository and included in the commit for API documentation coverage.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d4327ff148321b344c4c323df85b4)