### PR TITLE
Expose backend progress API and wire frontend polling/UI for NichoCNAE v3 pipeline

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/progress/controller/BackendNichoCnaeV3ProgressController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/progress/controller/BackendNichoCnaeV3ProgressController.java
@@ -1,0 +1,26 @@
+package com.marketinghub.oprm.nichocnae.v3.progress.controller;
+
+import com.marketinghub.oprm.nichocnae.v3.progress.service.BackendNichoCnaeV3ProgressService;
+import com.marketinghub.oprm.nichocnae.v3.progress.service.NichoCnaeV3JobProgressResponse;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/** Controller de leitura do progresso do pipeline NichoCNAE v3 para a tela administrativa. */
+@RestController
+@RequestMapping("/api/oprm/nichocnae/v3/cnaes/{cnaeCode}/progress")
+public class BackendNichoCnaeV3ProgressController {
+    private final BackendNichoCnaeV3ProgressService service;
+
+    /** Inicializa o controller com service de leitura do progresso v3. */
+    public BackendNichoCnaeV3ProgressController(BackendNichoCnaeV3ProgressService service) {
+        this.service = service;
+    }
+
+    /** Expõe o progresso do job mais recente do CNAE informado. */
+    @GetMapping
+    public NichoCnaeV3JobProgressResponse latestByCnae(@PathVariable String cnaeCode) {
+        return service.latestByCnae(cnaeCode);
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/progress/service/BackendNichoCnaeV3ProgressService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/progress/service/BackendNichoCnaeV3ProgressService.java
@@ -1,0 +1,40 @@
+package com.marketinghub.oprm.nichocnae.v3.progress.service;
+
+import com.marketinghub.oprm.nichocnae.v3.OprmNichoCnaeV3StageExecution;
+import com.marketinghub.repository.jpa.oprm.nichocnae.v3.OprmNichoCnaeV3StageExecutionRepository;
+import java.util.List;
+import org.springframework.stereotype.Service;
+
+/** Consulta o progresso persistido do pipeline NichoCNAE v3 sem inferir execução no frontend. */
+@Service
+public class BackendNichoCnaeV3ProgressService {
+    private final OprmNichoCnaeV3StageExecutionRepository repository;
+
+    /** Inicializa o service com o repository canônico de execuções v3. */
+    public BackendNichoCnaeV3ProgressService(OprmNichoCnaeV3StageExecutionRepository repository) {
+        this.repository = repository;
+    }
+
+    /** Retorna o job mais recente do CNAE com suas etapas persistidas em ordem de criação. */
+    public NichoCnaeV3JobProgressResponse latestByCnae(String cnaeCode) {
+        return repository.findTop1ByCnaeCodeAndStageCodeOrderByCreatedAtDesc(cnaeCode, "cnae-intake")
+                .map(latest -> new NichoCnaeV3JobProgressResponse(
+                        latest.getJobId(),
+                        latest.getCnaeCode(),
+                        repository.findByJobIdOrderByCreatedAtAsc(latest.getJobId()).stream()
+                                .map(this::toStage)
+                                .toList()))
+                .orElseGet(() -> new NichoCnaeV3JobProgressResponse(null, cnaeCode, List.of()));
+    }
+
+    /** Converte a entidade persistida em contrato de progresso para a UI. */
+    private NichoCnaeV3StageProgressResponse toStage(OprmNichoCnaeV3StageExecution execution) {
+        return new NichoCnaeV3StageProgressResponse(
+                execution.getId(),
+                execution.getStageCode(),
+                execution.getStatus().name(),
+                execution.getCreatedAt(),
+                execution.getUpdatedAt(),
+                execution.getErrorMessage());
+    }
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/progress/service/NichoCnaeV3JobProgressResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/progress/service/NichoCnaeV3JobProgressResponse.java
@@ -1,0 +1,6 @@
+package com.marketinghub.oprm.nichocnae.v3.progress.service;
+
+import java.util.List;
+
+/** Representa o progresso do job mais recente de um CNAE no pipeline NichoCNAE v3. */
+public record NichoCnaeV3JobProgressResponse(String jobId, String cnaeCode, List<NichoCnaeV3StageProgressResponse> stages) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/progress/service/NichoCnaeV3StageProgressResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/progress/service/NichoCnaeV3StageProgressResponse.java
@@ -1,0 +1,12 @@
+package com.marketinghub.oprm.nichocnae.v3.progress.service;
+
+import java.time.Instant;
+
+/** Representa o progresso de uma etapa do pipeline NichoCNAE v3 para a tela administrativa. */
+public record NichoCnaeV3StageProgressResponse(
+        Long stageExecutionId,
+        String stageCode,
+        String status,
+        Instant createdAt,
+        Instant updatedAt,
+        String errorMessage) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/oprm/nichocnae/v3/OprmNichoCnaeV3StageExecutionRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/oprm/nichocnae/v3/OprmNichoCnaeV3StageExecutionRepository.java
@@ -3,6 +3,7 @@ package com.marketinghub.repository.jpa.oprm.nichocnae.v3;
 import com.marketinghub.oprm.nichocnae.v3.OprmNichoCnaeV3StageExecution;
 import com.marketinghub.oprm.nichocnae.v3.OprmNichoCnaeV3StageExecutionStatus;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 /** Repository JPA canônico das execuções de etapa do NichoCNAE v3. */
@@ -13,4 +14,11 @@ public interface OprmNichoCnaeV3StageExecutionRepository extends JpaRepository<O
 
     /** Verifica se o job já possui pendência ou conclusão para uma etapa específica. */
     boolean existsByJobIdAndStageCode(String jobId, String stageCode);
+
+    /** Busca a entrada mais recente de um CNAE para recuperar o último job iniciado na tela. */
+    Optional<OprmNichoCnaeV3StageExecution> findTop1ByCnaeCodeAndStageCodeOrderByCreatedAtDesc(
+            String cnaeCode, String stageCode);
+
+    /** Lista todas as etapas persistidas de um job em ordem de criação. */
+    List<OprmNichoCnaeV3StageExecution> findByJobIdOrderByCreatedAtAsc(String jobId);
 }

--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -1403,3 +1403,10 @@
 
 - Alterado o botão da tabela de CNAEs do OPRM para abrir o pipeline NichoCNAE v3 em vez da v2.
 - Criada tela inicial do pipeline v3 no frontend, com acionamento do endpoint canônico `cnae-intake` para iniciar novo job v3 por CNAE.
+
+## 2026-06-25 — Indicadores visuais no pipeline NichoCNAE v3
+
+- Adicionado endpoint de leitura do progresso do job v3 mais recente por CNAE, baseado nas execuções persistidas pelo backend.
+- A tela do pipeline v3 passa a consultar esse progresso periodicamente e mostrar nos cards o status real de cada etapa, com destaque visual para etapas na fila/em execução.
+- Ajustado para recuperar sempre o último job iniciado pelo CNAE no backend ao sair e voltar para a tela, sem depender do estado local do navegador.
+- Objetivo de negócio: dar clareza operacional ao usuário sobre o que está acontecendo agora, reduzindo incerteza durante a geração de personas, rotina e tarefas diárias.

--- a/frontend/src/api/oprm/useOprmNichoCnaeV3Progress.ts
+++ b/frontend/src/api/oprm/useOprmNichoCnaeV3Progress.ts
@@ -1,0 +1,46 @@
+import { useQuery } from "@tanstack/react-query";
+import { buildApiUrl } from "../../utils/buildApiUrl";
+
+export interface OprmNichoCnaeV3StageProgress {
+  stageExecutionId: number;
+  stageCode: string;
+  status: string;
+  createdAt: string;
+  updatedAt: string;
+  errorMessage: string | null;
+}
+
+export interface OprmNichoCnaeV3JobProgress {
+  jobId: string | null;
+  cnaeCode: string;
+  stages: OprmNichoCnaeV3StageProgress[];
+}
+
+async function fetchOprmNichoCnaeV3Progress(
+  cnaeCode: string,
+): Promise<OprmNichoCnaeV3JobProgress> {
+  const response = await fetch(
+    buildApiUrl(
+      `/api/oprm/nichocnae/v3/cnaes/${encodeURIComponent(cnaeCode)}/progress`,
+    ),
+  );
+
+  if (!response.ok) {
+    const message = await response.text();
+    throw new Error(
+      message ||
+        `Não foi possível carregar o progresso v3 do NichoCNAE (status ${response.status}).`,
+    );
+  }
+
+  return (await response.json()) as OprmNichoCnaeV3JobProgress;
+}
+
+export function useOprmNichoCnaeV3Progress(cnaeCode: string) {
+  return useQuery({
+    queryKey: ["oprm-nichocnae-v3-progress", cnaeCode],
+    queryFn: () => fetchOprmNichoCnaeV3Progress(cnaeCode),
+    enabled: Boolean(cnaeCode),
+    refetchInterval: 5000,
+  });
+}

--- a/frontend/src/api/oprm/useStartOprmNichoCnaeV3Job.ts
+++ b/frontend/src/api/oprm/useStartOprmNichoCnaeV3Job.ts
@@ -1,4 +1,4 @@
-import { useMutation } from "@tanstack/react-query";
+import { useMutation, useQueryClient } from "@tanstack/react-query";
 import { buildApiUrl } from "../../utils/buildApiUrl";
 
 export interface OprmNichoCnaeV3JobStartResult {
@@ -29,7 +29,14 @@ async function startOprmNichoCnaeV3Job(
 }
 
 export function useStartOprmNichoCnaeV3Job(cnaeCode: string) {
+  const queryClient = useQueryClient();
+
   return useMutation({
     mutationFn: () => startOprmNichoCnaeV3Job(cnaeCode),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({
+        queryKey: ["oprm-nichocnae-v3-progress", cnaeCode],
+      });
+    },
   });
 }

--- a/frontend/src/pages/oprm/OprmNichoCnaeV3PipelinePage.tsx
+++ b/frontend/src/pages/oprm/OprmNichoCnaeV3PipelinePage.tsx
@@ -1,24 +1,69 @@
 import { Link, useParams } from "react-router-dom";
 import PageTitle from "../../components/PageTitle";
 import { useStartOprmNichoCnaeV3Job } from "../../api/oprm/useStartOprmNichoCnaeV3Job";
+import { useOprmNichoCnaeV3Progress } from "../../api/oprm/useOprmNichoCnaeV3Progress";
 
 const v3Stages = [
-  "Entrada do CNAE",
-  "Geração de personas candidatas",
-  "Torneio de personas",
-  "Planejamento de buscas da rotina",
-  "Busca de fontes",
-  "Coleta de fontes",
-  "Extração de sinais da rotina",
-  "Síntese de tarefas diárias",
-  "Quality gate",
-  "Materialização de persona e rotina",
+  {
+    code: "cnae-intake",
+    title: "Entrada do CNAE",
+    activity: "Lendo o CNAE e abrindo a execução.",
+  },
+  {
+    code: "persona-candidate-generator",
+    title: "Geração de personas candidatas",
+    activity: "Gerando hipóteses de personas vendáveis.",
+  },
+  {
+    code: "persona-tournament",
+    title: "Torneio de personas",
+    activity: "Comparando e priorizando as melhores personas.",
+  },
+  {
+    code: "routine-query-planner",
+    title: "Planejamento de buscas da rotina",
+    activity: "Planejando buscas sobre rotina e tarefas reais.",
+  },
+  {
+    code: "source-searcher",
+    title: "Busca de fontes",
+    activity: "Procurando fontes úteis para entender a rotina.",
+  },
+  {
+    code: "source-fetcher",
+    title: "Coleta de fontes",
+    activity: "Coletando conteúdos das fontes selecionadas.",
+  },
+  {
+    code: "routine-signal-extractor",
+    title: "Extração de sinais da rotina",
+    activity: "Extraindo dores, esforço e tarefas recorrentes.",
+  },
+  {
+    code: "daily-tasks-synthesizer",
+    title: "Síntese de tarefas diárias",
+    activity: "Organizando tarefas diárias em padrões claros.",
+  },
+  {
+    code: "quality-gate",
+    title: "Quality gate",
+    activity: "Validando qualidade antes de materializar.",
+  },
+  {
+    code: "persona-routine-materializer",
+    title: "Materialização de persona e rotina",
+    activity: "Montando a persona e a rotina final para uso comercial.",
+  },
 ];
 
 export default function OprmNichoCnaeV3PipelinePage() {
   const { cnaeCode } = useParams();
   const decodedCnaeCode = decodeURIComponent(cnaeCode ?? "");
   const startJob = useStartOprmNichoCnaeV3Job(decodedCnaeCode);
+  const progress = useOprmNichoCnaeV3Progress(decodedCnaeCode);
+  const stagesByCode = new Map(
+    (progress.data?.stages ?? []).map((stage) => [stage.stageCode, stage]),
+  );
 
   const handleStart = () => {
     if (!decodedCnaeCode || startJob.isPending) {
@@ -79,18 +124,78 @@ export default function OprmNichoCnaeV3PipelinePage() {
 
       <section className="card border-0 shadow-sm">
         <div className="card-body">
-          <h2 className="h5 mb-3">Etapas do pipeline v3</h2>
+          <div className="d-flex flex-wrap justify-content-between gap-2 align-items-center mb-3">
+            <div>
+              <h2 className="h5 mb-1">Etapas do pipeline v3</h2>
+              <p className="text-muted small mb-0">
+                {progress.data?.jobId
+                  ? `Acompanhando agora: ${progress.data.jobId}`
+                  : "O status fica salvo no backend e será recuperado ao voltar para esta tela."}
+              </p>
+            </div>
+            {progress.isFetching ? (
+              <span className="badge rounded-pill text-bg-light border">
+                <span
+                  className="spinner-border spinner-border-sm me-2"
+                  aria-hidden="true"
+                />
+                Atualizando
+              </span>
+            ) : null}
+          </div>
           <div className="row g-3">
-            {v3Stages.map((stage, index) => (
-              <div className="col-12 col-md-6 col-xl-4" key={stage}>
-                <div className="border rounded-3 p-3 h-100 bg-light">
-                  <span className="badge text-bg-primary mb-2">
-                    {index + 1}
-                  </span>
-                  <h3 className="h6 mb-0">{stage}</h3>
+            {v3Stages.map((stage, index) => {
+              const stageProgress = stagesByCode.get(stage.code);
+              const status = stageProgress?.status ?? "WAITING";
+              const isActive = status === "PENDING" || status === "RUNNING";
+              const statusLabel =
+                {
+                  WAITING: "Aguardando",
+                  PENDING: "Na fila",
+                  RUNNING: "Em execução",
+                  COMPLETED: "Concluído",
+                  FAILED: "Falhou",
+                  CANCELED: "Cancelado",
+                }[status] ?? status;
+              const statusClass =
+                {
+                  WAITING: "text-bg-secondary",
+                  PENDING: "text-bg-warning",
+                  RUNNING: "text-bg-primary",
+                  COMPLETED: "text-bg-success",
+                  FAILED: "text-bg-danger",
+                  CANCELED: "text-bg-secondary",
+                }[status] ?? "text-bg-secondary";
+
+              return (
+                <div className="col-12 col-md-6 col-xl-4" key={stage.code}>
+                  <div
+                    className={`border rounded-3 p-3 h-100 ${
+                      isActive ? "bg-primary-subtle border-primary" : "bg-light"
+                    }`}
+                  >
+                    <div className="d-flex justify-content-between gap-2 align-items-start mb-2">
+                      <span className="badge text-bg-primary">{index + 1}</span>
+                      <span className={`badge rounded-pill ${statusClass}`}>
+                        {isActive ? (
+                          <span
+                            className="spinner-border spinner-border-sm me-1"
+                            aria-hidden="true"
+                          />
+                        ) : null}
+                        {statusLabel}
+                      </span>
+                    </div>
+                    <h3 className="h6 mb-2">{stage.title}</h3>
+                    <p className="small text-muted mb-0">
+                      {stageProgress
+                        ? stage.activity
+                        : "Ainda não chegou nesta etapa."}
+                    </p>
+                  </div>
                 </div>
-              </div>
-            ))}
+              );
+            })}
           </div>
         </div>
       </section>


### PR DESCRIPTION
### Motivation

- Provide a backend endpoint that returns the most recent job progress for a given CNAE so the administrative UI can show the real-time state of the NichoCNAE v3 pipeline. 
- Persisted stage executions need query methods to find the last job and the ordered stages for that job to avoid relying on client-side inferred state. 
- The frontend must poll the backend and visually surface active/queued/running stages to improve operational clarity for users.

### Description

- Added `BackendNichoCnaeV3ProgressController` exposing `GET /api/oprm/nichocnae/v3/cnaes/{cnaeCode}/progress` which returns the latest job progress for a CNAE. 
- Implemented `BackendNichoCnaeV3ProgressService` and two response records `NichoCnaeV3JobProgressResponse` and `NichoCnaeV3StageProgressResponse`, and extended `OprmNichoCnaeV3StageExecutionRepository` with `findTop1ByCnaeCodeAndStageCodeOrderByCreatedAtDesc` and `findByJobIdOrderByCreatedAtAsc`. 
- Frontend: added `useOprmNichoCnaeV3Progress` hook (5s polling) and updated `useStartOprmNichoCnaeV3Job` to invalidate the progress query on job start; updated `OprmNichoCnaeV3PipelinePage` to map stages by code, show status labels, active highlighting, and a small fetching indicator. 
- Updated documentation `docs/registros/oprm1.md` to record the new progress endpoint and UI behavior for NichoCNAE v3.

### Testing

- No new automated tests were added for the new endpoint or UI components. 
- Executed backend build artifact creation via `mvn -DskipTests=true package`, which completed successfully. 
- Executed frontend build via `yarn build`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d705c1888832185eb8e29de82a631)