### PR TITLE
ops-monitor: restore public URLs for monitored modules and add DB changeset

### DIFF
--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-25-ops-monitor-public-routes.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-25-ops-monitor-public-routes.yaml
@@ -1,0 +1,44 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-06-25-ops-monitor-008-public-routes
+      author: marketing-hub
+      preConditions:
+        - onFail: MARK_RAN
+        - dbms:
+            type: mysql
+        - tableExists:
+            tableName: ops_monitored_module
+      changes:
+        - sql:
+            splitStatements: true
+            stripComments: true
+            sql: |
+              UPDATE ops_monitored_module
+              SET base_url = 'http://191.252.181.168:4567',
+                  health_path = '/worker-observability/health',
+                  log_path = '/worker-observability/logfile'
+              WHERE code = 'ai-worker';
+
+              UPDATE ops_monitored_module
+              SET base_url = 'http://191.252.181.168:8082',
+                  health_path = '/worker-observability/health',
+                  log_path = '/worker-observability/logfile'
+              WHERE code = 'facebook-ads-worker';
+
+              UPDATE ops_monitored_module
+              SET base_url = 'http://191.252.181.168:8094',
+                  health_path = '/actuator/health',
+                  log_path = '/actuator/logfile'
+              WHERE code = 'oprm-coletor-mei';
+
+              UPDATE ops_monitored_module
+              SET base_url = 'http://191.252.181.168:8097',
+                  health_path = '/actuator/health',
+                  log_path = '/actuator/logfile'
+              WHERE code = 'mois-sales-library-worker';
+
+              UPDATE ops_monitored_module
+              SET base_url = 'http://191.252.181.168:8086',
+                  health_path = '/ops-email-gateway-7xk9/health',
+                  log_path = '/ops-email-gateway-7xk9/email-service-audit-log'
+              WHERE code = 'email-service';

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -1097,6 +1097,9 @@ databaseChangeLog:
   - include:
       file: changesets/2026-06-25-ops-monitor-external-module-routes.yaml
       relativeToChangelogFile: true
+  - include:
+      file: changesets/2026-06-25-ops-monitor-public-routes.yaml
+      relativeToChangelogFile: true
 
   - include:
       file: changesets/2026-06-24-mois-sales-library-geralanding-insights.yaml

--- a/docs/ops-monitor/arquitetura.md
+++ b/docs/ops-monitor/arquitetura.md
@@ -36,9 +36,9 @@ A fase 4 expande a lista operacional para incluir OPRM, coletores MOIS, Lead Por
 
 ## Ajuste de rota interna — 2026-06-25
 
-O `ops-monitor-worker` roda em container Docker e deve acessar os módulos publicados no host pelo gateway interno `host.docker.internal`, não pelo IP público do servidor. O IP público pode passar por proxy/firewall e retornar conexão recusada mesmo quando o módulo está ativo no próprio host.
+O `ops-monitor-worker` roda em container Docker, mas deve acessar os módulos monitorados sempre pela URL pública oficial cadastrada no backend, nunca por atalhos internos como `host.docker.internal`. O objetivo do monitor é refletir a disponibilidade real percebida pelos demais módulos e operadores fora do container local; se a URL pública estiver indisponível, o módulo deve aparecer como indisponível mesmo que responda por rota interna do host.
 
-A configuração de módulos monitorados mantém o backend principal em `http://191.252.181.168`, pois ele responde pela porta 80; os demais módulos com portas dedicadas devem usar `http://host.docker.internal:<porta>` no contrato entregue ao worker.
+A configuração de módulos monitorados mantém o backend principal em `http://191.252.181.168`, pois ele responde pela porta 80; os demais módulos com portas dedicadas também devem usar a URL pública oficial com a porta publicada correspondente no contrato entregue ao worker.
 
 ## Correção de persistência do heartbeat do backend — 2026-06-25
 

--- a/docs/registros/ops-monitor.md
+++ b/docs/registros/ops-monitor.md
@@ -25,3 +25,10 @@
 - Causa-raiz tratada: cadastro inicial do monitor usou endpoints genéricos em vez dos contratos reais de observabilidade dos módulos.
 - Ajuste: criado changelog para corrigir `base_url`, `health_path` e `log_path` de backend, AI Worker, Facebook Ads Worker, OPRM Coletor MEI, MOIS Sales Library Worker e Email Service.
 - Prevenção: a correção fica versionada em Liquibase para manter o banco alinhado após deploy e evitar reincidência em novos ambientes.
+
+## 2026-06-25 — Monitor operacional passa a usar URLs públicas
+
+- Decisão operacional: o Ops Monitor deve acessar os módulos sempre pela URL pública oficial, sem usar `host.docker.internal` como atalho interno.
+- Causa-raiz: o monitor podia marcar um módulo como `ONLINE` pela rede interna do Docker mesmo quando a rota pública estava recusando conexão, criando divergência entre saúde operacional exibida e disponibilidade real percebida fora do host.
+- Ajuste: criado changelog incremental para restaurar URLs públicas de AI Worker, Facebook Ads Worker, OPRM Coletor MEI, MOIS Sales Library Worker e Email Service no cadastro `ops_monitored_module`.
+- Prevenção: a regra foi registrada na arquitetura do Ops Monitor para impedir novos ajustes que voltem a usar rotas internas como fonte de verdade de disponibilidade.


### PR DESCRIPTION
### Motivation

- Ensure the Ops Monitor reflects external availability by making it probe modules via their official public URLs rather than internal Docker shortcuts like `host.docker.internal`. 
- Persist corrected observability endpoints for several modules in the canonical database so the frontend and reports show the real public-facing status. 

### Description

- Add a new Liquibase changeset `changesets/2026-06-25-ops-monitor-public-routes.yaml` that updates `base_url`, `health_path` and `log_path` for `ai-worker`, `facebook-ads-worker`, `oprm-coletor-mei`, `mois-sales-library-worker` and `email-service` in the `ops_monitored_module` table. 
- Include the new changeset in `db.changelog-master.yaml` by adding an `- include:` entry for `2026-06-25-ops-monitor-public-routes.yaml`. 
- Update architecture documentation `docs/ops-monitor/arquitetura.md` to require public URLs as the source of truth for monitoring and remove guidance to use internal host routes. 
- Record the decision and changelog entry in `docs/registros/ops-monitor.md` documenting the operational change to public URLs and the purpose of the database migration. 

### Testing

- No new automated tests were added for this PR, and the Liquibase changeset is guarded by `preConditions` (`dbms: mysql` and `tableExists`) to avoid unintended application. 
- The repository CI pipeline was executed for the branch and the build and docs lint stages completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d7a0a280483219aa718650ee8a921)