### PR TITLE
ops-monitor: use public URLs for monitored modules, add changelog and v3 scheduler/stage tests

### DIFF
--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-25-ops-monitor-public-routes.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-25-ops-monitor-public-routes.yaml
@@ -1,0 +1,44 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-06-25-ops-monitor-008-public-routes
+      author: marketing-hub
+      preConditions:
+        - onFail: MARK_RAN
+        - dbms:
+            type: mysql
+        - tableExists:
+            tableName: ops_monitored_module
+      changes:
+        - sql:
+            splitStatements: true
+            stripComments: true
+            sql: |
+              UPDATE ops_monitored_module
+              SET base_url = 'http://191.252.181.168:4567',
+                  health_path = '/worker-observability/health',
+                  log_path = '/worker-observability/logfile'
+              WHERE code = 'ai-worker';
+
+              UPDATE ops_monitored_module
+              SET base_url = 'http://191.252.181.168:8082',
+                  health_path = '/worker-observability/health',
+                  log_path = '/worker-observability/logfile'
+              WHERE code = 'facebook-ads-worker';
+
+              UPDATE ops_monitored_module
+              SET base_url = 'http://191.252.181.168:8094',
+                  health_path = '/actuator/health',
+                  log_path = '/actuator/logfile'
+              WHERE code = 'oprm-coletor-mei';
+
+              UPDATE ops_monitored_module
+              SET base_url = 'http://191.252.181.168:8097',
+                  health_path = '/actuator/health',
+                  log_path = '/actuator/logfile'
+              WHERE code = 'mois-sales-library-worker';
+
+              UPDATE ops_monitored_module
+              SET base_url = 'http://191.252.181.168:8086',
+                  health_path = '/ops-email-gateway-7xk9/health',
+                  log_path = '/ops-email-gateway-7xk9/email-service-audit-log'
+              WHERE code = 'email-service';

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -1097,6 +1097,9 @@ databaseChangeLog:
   - include:
       file: changesets/2026-06-25-ops-monitor-external-module-routes.yaml
       relativeToChangelogFile: true
+  - include:
+      file: changesets/2026-06-25-ops-monitor-public-routes.yaml
+      relativeToChangelogFile: true
 
   - include:
       file: changesets/2026-06-24-mois-sales-library-geralanding-insights.yaml

--- a/docs/ops-monitor/arquitetura.md
+++ b/docs/ops-monitor/arquitetura.md
@@ -36,9 +36,9 @@ A fase 4 expande a lista operacional para incluir OPRM, coletores MOIS, Lead Por
 
 ## Ajuste de rota interna — 2026-06-25
 
-O `ops-monitor-worker` roda em container Docker e deve acessar os módulos publicados no host pelo gateway interno `host.docker.internal`, não pelo IP público do servidor. O IP público pode passar por proxy/firewall e retornar conexão recusada mesmo quando o módulo está ativo no próprio host.
+O `ops-monitor-worker` roda em container Docker, mas deve acessar os módulos monitorados sempre pela URL pública oficial cadastrada no backend, nunca por atalhos internos como `host.docker.internal`. O objetivo do monitor é refletir a disponibilidade real percebida pelos demais módulos e operadores fora do container local; se a URL pública estiver indisponível, o módulo deve aparecer como indisponível mesmo que responda por rota interna do host.
 
-A configuração de módulos monitorados mantém o backend principal em `http://191.252.181.168`, pois ele responde pela porta 80; os demais módulos com portas dedicadas devem usar `http://host.docker.internal:<porta>` no contrato entregue ao worker.
+A configuração de módulos monitorados mantém o backend principal em `http://191.252.181.168`, pois ele responde pela porta 80; os demais módulos com portas dedicadas também devem usar a URL pública oficial com a porta publicada correspondente no contrato entregue ao worker.
 
 ## Correção de persistência do heartbeat do backend — 2026-06-25
 

--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -1410,3 +1410,9 @@
 - A tela do pipeline v3 passa a consultar esse progresso periodicamente e mostrar nos cards o status real de cada etapa, com destaque visual para etapas na fila/em execução.
 - Ajustado para recuperar sempre o último job iniciado pelo CNAE no backend ao sair e voltar para a tela, sem depender do estado local do navegador.
 - Objetivo de negócio: dar clareza operacional ao usuário sobre o que está acontecendo agora, reduzindo incerteza durante a geração de personas, rotina e tarefas diárias.
+
+## 2026-06-25 — Verificação do agendamento do NichoCNAE v3
+
+- Verificação: o executor `oprm-coletor-mei` possui um scheduler único em `com.marketinghub.nichocnaev3.execution.NichoCnaeV3PendingExecutionScheduler`, com cron `0 */3 * * * *`, que chama a varredura de todas as etapas cadastradas no catálogo v3.
+- Evidência de cobertura: o catálogo v3 contém as 10 etapas `cnae-intake`, `persona-candidate-generator`, `persona-tournament`, `routine-query-planner`, `source-searcher`, `source-fetcher`, `routine-signal-extractor`, `daily-tasks-synthesizer`, `quality-gate` e `persona-routine-materializer`, todas com processor e endpoint backend v3 derivado do código da etapa.
+- Prevenção: adicionados testes de contrato para impedir alteração acidental do cron de 3 em 3 minutos e para garantir que toda etapa v3 cadastrada tenha `backendPath` e `processor` disponíveis para a varredura agendada.

--- a/docs/registros/ops-monitor.md
+++ b/docs/registros/ops-monitor.md
@@ -25,3 +25,10 @@
 - Causa-raiz tratada: cadastro inicial do monitor usou endpoints genéricos em vez dos contratos reais de observabilidade dos módulos.
 - Ajuste: criado changelog para corrigir `base_url`, `health_path` e `log_path` de backend, AI Worker, Facebook Ads Worker, OPRM Coletor MEI, MOIS Sales Library Worker e Email Service.
 - Prevenção: a correção fica versionada em Liquibase para manter o banco alinhado após deploy e evitar reincidência em novos ambientes.
+
+## 2026-06-25 — Monitor operacional passa a usar URLs públicas
+
+- Decisão operacional: o Ops Monitor deve acessar os módulos sempre pela URL pública oficial, sem usar `host.docker.internal` como atalho interno.
+- Causa-raiz: o monitor podia marcar um módulo como `ONLINE` pela rede interna do Docker mesmo quando a rota pública estava recusando conexão, criando divergência entre saúde operacional exibida e disponibilidade real percebida fora do host.
+- Ajuste: criado changelog incremental para restaurar URLs públicas de AI Worker, Facebook Ads Worker, OPRM Coletor MEI, MOIS Sales Library Worker e Email Service no cadastro `ops_monitored_module`.
+- Prevenção: a regra foi registrada na arquitetura do Ops Monitor para impedir novos ajustes que voltem a usar rotas internas como fonte de verdade de disponibilidade.

--- a/oprm-coletor-mei/src/test/java/com/marketinghub/nichocnaev3/execution/NichoCnaeV3PendingExecutionSchedulerTest.java
+++ b/oprm-coletor-mei/src/test/java/com/marketinghub/nichocnaev3/execution/NichoCnaeV3PendingExecutionSchedulerTest.java
@@ -1,0 +1,21 @@
+package com.marketinghub.nichocnaev3.execution;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import java.lang.reflect.Method;
+import org.junit.jupiter.api.Test;
+import org.springframework.scheduling.annotation.Scheduled;
+
+/** Valida o contrato de agendamento único do executor NichoCNAE v3. */
+class NichoCnaeV3PendingExecutionSchedulerTest {
+    /** Confirma que a varredura v3 roda a cada três minutos. */
+    @Test
+    void shouldRunVersionThreePendingScanEveryThreeMinutes() throws NoSuchMethodException {
+        Method method = NichoCnaeV3PendingExecutionScheduler.class.getDeclaredMethod("processPendingStageExecutions");
+        Scheduled scheduled = method.getAnnotation(Scheduled.class);
+
+        assertNotNull(scheduled);
+        assertEquals("0 */3 * * * *", scheduled.cron());
+    }
+}

--- a/oprm-coletor-mei/src/test/java/com/marketinghub/nichocnaev3/execution/NichoCnaeV3StageDefinitionsTest.java
+++ b/oprm-coletor-mei/src/test/java/com/marketinghub/nichocnaev3/execution/NichoCnaeV3StageDefinitionsTest.java
@@ -1,6 +1,8 @@
 package com.marketinghub.nichocnaev3.execution;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.util.List;
 import org.junit.jupiter.api.Test;
@@ -14,7 +16,27 @@ class NichoCnaeV3StageDefinitionsTest {
                 .map(NichoCnaeV3StageDefinition::stageCode)
                 .toList();
 
-        assertEquals(List.of(
+        assertEquals(expectedStages(), stages);
+    }
+
+    /** Confirma que toda etapa v3 cadastrada tem endpoint pending e processor executável pelo scheduler único. */
+    @Test
+    void shouldRegisterBackendPathAndProcessorForEveryVersionThreeStage() {
+        List<NichoCnaeV3StageDefinition> stages = new NichoCnaeV3StageDefinitions().all();
+
+        assertEquals(expectedStages().size(), stages.size());
+        for (NichoCnaeV3StageDefinition stage : stages) {
+            assertEquals(
+                    "/api/internal/oprm/nichocnae/v3/" + stage.stageCode() + "/stage-executions",
+                    stage.backendPath());
+            assertNotNull(stage.processor());
+            assertFalse(stage.stageCode().isBlank());
+        }
+    }
+
+    /** Lista canônica das etapas v3 executadas pela varredura agendada. */
+    private static List<String> expectedStages() {
+        return List.of(
                 "cnae-intake",
                 "persona-candidate-generator",
                 "persona-tournament",
@@ -24,6 +46,6 @@ class NichoCnaeV3StageDefinitionsTest {
                 "routine-signal-extractor",
                 "daily-tasks-synthesizer",
                 "quality-gate",
-                "persona-routine-materializer"), stages);
+                "persona-routine-materializer");
     }
 }


### PR DESCRIPTION
### Motivation

- Ensure the Ops Monitor checks module availability using the official public URLs rather than Docker internal shortcuts so reported availability matches what external systems and operators observe.
- Persist the corrected observability endpoints for several modules in the database so environments remain consistent after deploy.
- Verify the NichoCNAE v3 scheduler contract and stage catalog to prevent accidental changes to the cron or incomplete stage definitions.

### Description

- Added a new Liquibase changeset `changesets/2026-06-25-ops-monitor-public-routes.yaml` that updates `ops_monitored_module` rows for `ai-worker`, `facebook-ads-worker`, `oprm-coletor-mei`, `mois-sales-library-worker` and `email-service` to use public `base_url`, `health_path`, and `log_path` values.
- Included the new changeset in `db.changelog-master.yaml`. 
- Updated `docs/ops-monitor/arquitetura.md` and `docs/registros/ops-monitor.md` to document the decision that the monitor must use public URLs (no `host.docker.internal`) and to record the changelog action. 
- Added unit tests: `NichoCnaeV3PendingExecutionSchedulerTest` to assert the scheduler cron is `0 */3 * * * *`, and extended `NichoCnaeV3StageDefinitionsTest` to assert the full canonical stage list, that each stage exposes the expected `backendPath`, and that each stage has a non-null `processor`.

### Testing

- Ran unit tests in `oprm-coletor-mei`; `NichoCnaeV3PendingExecutionSchedulerTest` and the updated `NichoCnaeV3StageDefinitionsTest` passed. 
- No database migrations were executed as part of tests here, but the changelog is added and included in `db.changelog-master.yaml` for normal deployment execution. 
- Documentation changes were reviewed and saved; no automated doc checks were run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3d7a0a280483219aa718650ee8a921)