### PR TITLE
Remove hypotheses card and section from Niche detail page

### DIFF
--- a/frontend/src/pages/niche/NicheDetailPage.tsx
+++ b/frontend/src/pages/niche/NicheDetailPage.tsx
@@ -3,7 +3,6 @@ import { Link, useParams } from "react-router-dom";
 import { toast } from "react-toastify";
 import { useNiche } from "../../api/niche/useNiche";
 import { useUpdateNiche } from "../../api/niche/useUpdateNiche";
-import { useHypothesesByNiche } from "../../api/hypothesis/useHypothesesByNiche";
 import { useTargetingElementsByNiche } from "../../api/targeting/useTargetingElementsByNiche";
 import PageTitle from "../../components/PageTitle";
 import nicheIcon from "../../assets/icons/niche-icon.svg";
@@ -13,39 +12,28 @@ import { NicheLearningDictionaryCard } from "./NicheLearningDictionaryCard";
 import { NicheBacklogRecommendationsCard } from "./NicheBacklogRecommendationsCard";
 import { useChatDialog } from "../../api/chatDialog/useChatDialog";
 import { useForm } from "react-hook-form";
-import type {
-  TargetingElementType,
-} from "../../api/targeting/types";
+import type { TargetingElementType } from "../../api/targeting/types";
 import { TargetingGenerationForm } from "../../components/TargetingGenerationForm";
 import { TargetingRequestStatusPanel } from "../../components/TargetingRequestStatusPanel";
-import { useRequestHypotheses } from "../../api/niche/useRequestHypotheses";
-import { HypothesisManualForm } from "../../components/HypothesisManualForm";
-import { useNicheDetailedDescriptions } from "../../api/niche/useNicheDetailedDescriptions";
-import { useExperimentsByNiche } from "../../api/experiment/useExperimentsByNiche";
 import { useDeliverablesByNiche } from "../../api/deliverable/useDeliverablesByNiche";
 import { useLeadPortalFlows } from "../../api/leadPortal/useLeadPortalFlows";
 import type { LeadPortalFlow } from "../../api/leadPortal/useLeadPortalFlows";
 import { useCreateDeliverable } from "../../api/deliverable/useCreateDeliverable";
 import SimpleLeadPortalFormCard from "../../components/leadPortal/SimpleLeadPortalFormCard";
 import { useOpenAiModels } from "../../api/openAiModel/useOpenAiModels";
-import { useDifferentiatedTechnologies } from "../../api/differentiatedTechnology/useDifferentiatedTechnologies";
 import { useInformationSourcesByNiche } from "../../api/informationSource/useInformationSourcesByNiche";
 import { useRequestFacebookPixel } from "../../api/niche/useRequestFacebookPixel";
 import { useCreateInformationSource } from "../../api/informationSource/useCreateInformationSource";
 import {
-  ArrowUpRight,
   Check,
   Clock3,
   FileDown,
-  Lightbulb,
-  Pencil,
   Package,
   Plus,
   Sparkles,
   Target,
   Briefcase,
   Activity,
-  Minus,
 } from "lucide-react";
 import "./NicheDetailPage.css";
 
@@ -93,13 +81,11 @@ export default function NicheDetailPage() {
     facebookPixelId || facebookPixelCode || facebookPixelRequestedAtLabel,
   );
   const { data: chatDialog } = useChatDialog(data?.chatDialogId);
-  const { data: hypotheses } = useHypothesesByNiche(nicheId, "ALL");
   const {
     data: targetingElements,
     isFetching: isFetchingTargeting,
     refetch: refetchTargetingElements,
   } = useTargetingElementsByNiche(nicheId);
-  const { data: experiments } = useExperimentsByNiche(nicheId);
   const { data: deliverables } = useDeliverablesByNiche(nicheId);
   const { data: informationSources } = useInformationSourcesByNiche(nicheId);
   const {
@@ -116,34 +102,7 @@ export default function NicheDetailPage() {
   const [flowBeingEdited, setFlowBeingEdited] = useState<LeadPortalFlow | null>(
     null,
   );
-  const { data: detailedDescriptions } = useNicheDetailedDescriptions(nicheId);
-  const requestHypotheses = useRequestHypotheses(id);
   const { data: openAiModels, isLoading: isLoadingModels } = useOpenAiModels();
-  const {
-    data: differentiatedTechnologies,
-    isLoading: isLoadingDifferentiatedTechnologies,
-  } = useDifferentiatedTechnologies();
-  const [isManualHypothesisFormVisible, setManualHypothesisFormVisible] =
-    useState(false);
-  const {
-    register: registerHypothesisRequest,
-    handleSubmit: handleSubmitHypothesisRequest,
-    reset: resetHypothesisRequest,
-    setValue: setHypothesisRequestValue,
-    formState: { errors: hypothesisRequestErrors },
-  } = useForm<{
-    quantity: number;
-    model?: string;
-    differentiatedTechnologyId?: number;
-    detailedDescriptionId?: number;
-  }>({
-    defaultValues: {
-      quantity: 1,
-      model: "",
-      differentiatedTechnologyId: undefined,
-      detailedDescriptionId: undefined,
-    },
-  });
   const {
     register: registerDeliverable,
     handleSubmit: handleSubmitDeliverable,
@@ -176,18 +135,6 @@ export default function NicheDetailPage() {
   const requestFacebookPixel = useRequestFacebookPixel(normalizedNicheId);
   useBreadcrumbs([{ label: data?.name || "...", icon: nicheIcon }]);
 
-  useEffect(() => {
-    const defaultModel = data?.hypothesisModel ?? openAiModels?.[0]?.code ?? "";
-    setHypothesisRequestValue("model", defaultModel);
-  }, [data?.hypothesisModel, openAiModels, setHypothesisRequestValue]);
-
-  useEffect(() => {
-    setHypothesisRequestValue(
-      "differentiatedTechnologyId",
-      data?.differentiatedTechnologyId ?? undefined,
-    );
-  }, [data?.differentiatedTechnologyId, setHypothesisRequestValue]);
-
   const scrollToSection = useCallback((sectionId: string) => {
     if (typeof document === "undefined") return;
     const element = document.getElementById(sectionId);
@@ -195,20 +142,6 @@ export default function NicheDetailPage() {
       element.scrollIntoView({ behavior: "smooth", block: "start" });
     }
   }, []);
-
-  const handleManualHypothesisSuccess = useCallback(() => {
-    setManualHypothesisFormVisible(false);
-  }, []);
-
-  const handleOpenManualHypothesisForm = useCallback(() => {
-    setManualHypothesisFormVisible(true);
-    const scrollToForm = () => scrollToSection("niche-manual-hypothesis-form");
-    if (typeof window.requestAnimationFrame === "function") {
-      window.requestAnimationFrame(scrollToForm);
-      return;
-    }
-    window.setTimeout(scrollToForm, 0);
-  }, [scrollToSection]);
 
   const handleRequestFacebookPixel = useCallback(async () => {
     try {
@@ -221,18 +154,10 @@ export default function NicheDetailPage() {
     }
   }, [requestFacebookPixel]);
 
-  const list = Array.isArray(hypotheses)
-    ? [...hypotheses].sort((a, b) => {
-        const aDate = a.createdAt ? new Date(a.createdAt).getTime() : 0;
-        const bDate = b.createdAt ? new Date(b.createdAt).getTime() : 0;
-        return bDate - aDate;
-      })
-    : [];
   const targetingList = Array.isArray(targetingElements)
     ? targetingElements
     : [];
 
-  const experimentsList = Array.isArray(experiments) ? experiments : [];
   const deliverableList = Array.isArray(deliverables)
     ? [...deliverables].sort((a, b) => {
         const aDate = a.createdAt ? new Date(a.createdAt).getTime() : 0;
@@ -240,16 +165,7 @@ export default function NicheDetailPage() {
         return bDate - aDate;
       })
     : [];
-  const detailedDescriptionList = Array.isArray(detailedDescriptions)
-    ? [...detailedDescriptions].sort((a, b) => {
-        const aDate = a.createdAt ? new Date(a.createdAt).getTime() : 0;
-        const bDate = b.createdAt ? new Date(b.createdAt).getTime() : 0;
-        return bDate - aDate;
-      })
-    : [];
-  const activeDetailedDescriptions = detailedDescriptionList.filter(
-    (description) => description.active ?? true,
-  );
+
   const targetingByType: Record<TargetingElementType, typeof targetingList> = {
     INTEREST: targetingList.filter((element) => element.type === "INTEREST"),
     JOB_TITLE: targetingList.filter((element) => element.type === "JOB_TITLE"),
@@ -317,22 +233,6 @@ export default function NicheDetailPage() {
       })
     : [];
 
-  useEffect(() => {
-    const selectedId = data?.hypothesisDetailedDescriptionId ?? undefined;
-    if (
-      selectedId &&
-      activeDetailedDescriptions.some((desc) => desc.id === selectedId)
-    ) {
-      setHypothesisRequestValue("detailedDescriptionId", selectedId);
-    } else {
-      setHypothesisRequestValue("detailedDescriptionId", undefined);
-    }
-  }, [
-    activeDetailedDescriptions,
-    data?.hypothesisDetailedDescriptionId,
-    setHypothesisRequestValue,
-  ]);
-
   if (isLoading) return <p>Carregando...</p>;
   if (!data) return <p>Não encontrado</p>;
 
@@ -359,13 +259,6 @@ export default function NicheDetailPage() {
     URL.revokeObjectURL(url);
   };
 
-  const experimentsCountByHypothesis = experimentsList.reduce<
-    Record<string, number>
-  >((acc, experiment) => {
-    const key = experiment.hypothesisId;
-    acc[key] = (acc[key] ?? 0) + 1;
-    return acc;
-  }, {});
   const createdAtLabel = data.createdAt
     ? new Date(data.createdAt).toLocaleString("pt-BR")
     : undefined;
@@ -456,13 +349,6 @@ export default function NicheDetailPage() {
       targetId: "niche-behaviors",
     },
     {
-      icon: Lightbulb,
-      label: "Hipóteses",
-      value: `${list.length}`,
-      helper: `Meta: ${data.hypothesesToGenerate ?? 0}`,
-      targetId: "niche-hypotheses",
-    },
-    {
       icon: Package,
       label: "Entregáveis",
       value: `${deliverableList.length}`,
@@ -497,59 +383,6 @@ export default function NicheDetailPage() {
     if (stat.label === "Entregáveis") return false;
     return true;
   });
-  const hypothesisStatusLabel =
-    requestHypotheses.isPending || (isFetching && !isLoading)
-      ? "Atualizando hipóteses..."
-      : `Solicitadas ao Worker: ${data.hypothesesToGenerate ?? 0}`;
-  const formatUsd = (value?: number | string | null) => {
-    if (value === undefined || value === null) return undefined;
-    const num = typeof value === "string" ? Number(value) : value;
-    if (Number.isNaN(num)) return undefined;
-    return num.toLocaleString("en-US", {
-      style: "currency",
-      currency: "USD",
-      minimumFractionDigits: 4,
-      maximumFractionDigits: 4,
-    });
-  };
-
-  const onRequestHypotheses = handleSubmitHypothesisRequest(
-    async ({
-      quantity,
-      model,
-      differentiatedTechnologyId,
-      detailedDescriptionId,
-    }) => {
-      if (!quantity || quantity <= 0) return;
-      const selectedModel = model?.trim();
-      const normalizedTechnologyId =
-        differentiatedTechnologyId === 0
-          ? undefined
-          : differentiatedTechnologyId;
-      const normalizedDescriptionId =
-        detailedDescriptionId === 0 ? undefined : detailedDescriptionId;
-      try {
-        await requestHypotheses.mutateAsync({
-          quantity,
-          model: selectedModel,
-          differentiatedTechnologyId: normalizedTechnologyId,
-          detailedDescriptionId: normalizedDescriptionId,
-        });
-        alert("Solicitação enviada!");
-        resetHypothesisRequest({
-          quantity: 1,
-          model: selectedModel ?? "",
-          differentiatedTechnologyId: normalizedTechnologyId,
-          detailedDescriptionId: normalizedDescriptionId,
-        });
-      } catch {
-        alert("Erro ao solicitar hipóteses");
-      }
-    },
-    (errors) => {
-      console.log("Validation errors", errors);
-    },
-  );
   const onCreateDeliverable = handleSubmitDeliverable(
     async (values) => {
       try {
@@ -666,62 +499,6 @@ export default function NicheDetailPage() {
       </ul>
       <section aria-label="Informações do nicho">
         <div className="niche-detail__grid">
-          <article className="niche-detail__card niche-detail__hypotheses-card">
-            <div className="niche-detail__hypotheses-card-header">
-              <h3 className="niche-detail__card-title">Hipóteses do nicho</h3>
-              <Link
-                className="btn btn-primary niche-detail__hypotheses-create"
-                to={`/niches/${normalizedNicheId}/hypotheses/new`}
-              >
-                <Plus size={18} />
-                <span>Criar nova hipótese</span>
-              </Link>
-            </div>
-            <div className="niche-detail__card-content">
-              {list.length === 0 ? (
-                <span className="niche-detail__card-empty">
-                  Nenhuma hipótese criada para este nicho ainda.
-                </span>
-              ) : (
-                <div className="niche-detail__hypotheses-list">
-                  {list.map((hypothesis) => {
-                    const experimentCount =
-                      experimentsCountByHypothesis[hypothesis.id] ?? 0;
-                    const experimentLabel =
-                      experimentCount === 1
-                        ? "1 experimento"
-                        : `${experimentCount} experimentos`;
-                    const costLabel = formatUsd(hypothesis.costUsd) ?? "-";
-                    return (
-                      <div
-                        key={hypothesis.id}
-                        className="niche-detail__hypothesis-row"
-                      >
-                        <div className="niche-detail__hypothesis-main">
-                          <Link
-                            className="niche-detail__hypothesis-name"
-                            to={`hypotheses/new?hypothesisId=${hypothesis.id}`}
-                          >
-                            {hypothesis.title || "Hipótese sem nome"}
-                          </Link>
-                          <span className="niche-detail__hypothesis-meta">
-                            Custo: {costLabel} • {experimentLabel}
-                          </span>
-                        </div>
-                        <Link
-                          className="btn btn-sm btn-outline-primary"
-                          to={`hypotheses/${hypothesis.id}`}
-                        >
-                          Entrar
-                          <ArrowUpRight size={16} />
-                        </Link>
-                      </div>
-                    );
-                  })}
-                </div>
-              )}
-            </div>
-          </article>
           {visibleInfoCards.map((card) => (
             <article key={card.label} className="niche-detail__card">
               <h3 className="niche-detail__card-title">{card.label}</h3>
@@ -1325,292 +1102,6 @@ export default function NicheDetailPage() {
             </div>
           ))}
         </div>
-      </section>
-      <section className="niche-section" aria-labelledby="niche-hypotheses">
-        <div className="niche-section__header">
-          <div>
-            <h2 className="niche-section__title" id="niche-hypotheses">
-              Hipóteses
-            </h2>
-            <p className="niche-section__subtitle">
-              {list.length === 0
-                ? "As hipóteses aparecerão aqui quando forem geradas pela IA."
-                : "Principais ângulos sugeridos pela IA para o nicho."}
-            </p>
-            <p className="niche-section__status">{hypothesisStatusLabel}</p>
-          </div>
-          <form
-            className="niche-section__actions niche-section__actions--hypotheses"
-            onSubmit={onRequestHypotheses}
-          >
-            <div className="niche-section__action-group niche-section__action-group--quantity">
-              <label htmlFor="hypothesis-quantity" className="form-label">
-                Quantidade <span aria-hidden="true">*</span>
-              </label>
-              <input
-                id="hypothesis-quantity"
-                type="number"
-                min={1}
-                className={`form-control ${
-                  hypothesisRequestErrors.quantity ? "is-invalid" : ""
-                }`}
-                title="Quantidade de hipóteses que o Worker IA irá gerar"
-                disabled={requestHypotheses.isPending}
-                {...registerHypothesisRequest("quantity", {
-                  valueAsNumber: true,
-                  required: "Informe a quantidade",
-                  min: { value: 1, message: "Informe pelo menos 1" },
-                })}
-              />
-              {hypothesisRequestErrors.quantity && (
-                <div className="invalid-feedback">
-                  {hypothesisRequestErrors.quantity.message}
-                </div>
-              )}
-            </div>
-            <div className="niche-section__action-group">
-              <label htmlFor="hypothesis-model" className="form-label">
-                Modelo IA <span aria-hidden="true">*</span>
-              </label>
-              <select
-                id="hypothesis-model"
-                className={`form-select ${
-                  hypothesisRequestErrors.model ? "is-invalid" : ""
-                }`}
-                title="Modelo do OpenAI que o Worker IA irá usar"
-                disabled={requestHypotheses.isPending || isLoadingModels}
-                {...registerHypothesisRequest("model", {
-                  required: "Selecione um modelo",
-                })}
-              >
-                <option value="">Selecione um modelo</option>
-                {(openAiModels ?? []).map((modelOption) => (
-                  <option key={modelOption.code} value={modelOption.code}>
-                    {modelOption.name} ({modelOption.code})
-                  </option>
-                ))}
-              </select>
-              {hypothesisRequestErrors.model && (
-                <div className="invalid-feedback">
-                  {hypothesisRequestErrors.model.message}
-                </div>
-              )}
-            </div>
-            <div className="niche-section__action-group">
-              <label htmlFor="hypothesis-technology" className="form-label">
-                Tecnologia diferenciada <span aria-hidden="true">*</span>
-              </label>
-              <select
-                id="hypothesis-technology"
-                className={`form-select ${
-                  hypothesisRequestErrors.differentiatedTechnologyId
-                    ? "is-invalid"
-                    : ""
-                }`}
-                title="Tecnologia diferenciada para orientar as hipóteses geradas pelo Worker IA"
-                disabled={
-                  requestHypotheses.isPending ||
-                  isLoadingDifferentiatedTechnologies
-                }
-                {...registerHypothesisRequest("differentiatedTechnologyId", {
-                  setValueAs: (value) => (value ? Number(value) : undefined),
-                  required: "Selecione uma tecnologia",
-                })}
-              >
-                <option value="">Selecione uma tecnologia</option>
-                <option value="0">Sem tecnologia diferenciada</option>
-                {(differentiatedTechnologies ?? []).map((tech) => (
-                  <option key={tech.id} value={tech.id}>
-                    {tech.name}
-                  </option>
-                ))}
-              </select>
-              {hypothesisRequestErrors.differentiatedTechnologyId && (
-                <div className="invalid-feedback">
-                  {hypothesisRequestErrors.differentiatedTechnologyId.message}
-                </div>
-              )}
-            </div>
-            <div className="niche-section__action-group">
-              <label
-                htmlFor="hypothesis-detailed-description"
-                className="form-label"
-              >
-                Descrição detalhada <span aria-hidden="true">*</span>
-              </label>
-              <select
-                id="hypothesis-detailed-description"
-                className={`form-select ${
-                  hypothesisRequestErrors.detailedDescriptionId
-                    ? "is-invalid"
-                    : ""
-                }`}
-                title="Descrição detalhada ativa para orientar as hipóteses geradas pelo Worker IA"
-                disabled={requestHypotheses.isPending}
-                {...registerHypothesisRequest("detailedDescriptionId", {
-                  setValueAs: (value) => (value ? Number(value) : undefined),
-                  required: "Selecione uma descrição",
-                })}
-              >
-                <option value="">Selecione uma descrição</option>
-                <option value="0">Sem descrição detalhada ativa</option>
-                {activeDetailedDescriptions.map((description, index) => (
-                  <option key={description.id} value={description.id}>
-                    {description.title ||
-                      description.promptName ||
-                      `Descrição #${index + 1}`}
-                  </option>
-                ))}
-              </select>
-              {hypothesisRequestErrors.detailedDescriptionId && (
-                <div className="invalid-feedback">
-                  {hypothesisRequestErrors.detailedDescriptionId.message}
-                </div>
-              )}
-            </div>
-            <div className="niche-section__action-group niche-section__action-group--submit">
-              <span className="form-label niche-section__action-helper">
-                Solicitar geração
-              </span>
-              <button
-                type="submit"
-                className="btn btn-secondary"
-                disabled={requestHypotheses.isPending}
-              >
-                {requestHypotheses.isPending ? (
-                  <span
-                    className="spinner-border spinner-border-sm"
-                    role="status"
-                    aria-hidden="true"
-                  />
-                ) : (
-                  <Sparkles size={18} />
-                )}
-                <span>Gerar Hipóteses</span>
-              </button>
-            </div>
-          </form>
-        </div>
-        <div className="niche-hypothesis-manual">
-          <button
-            type="button"
-            className="btn btn-outline-primary niche-hypothesis-manual__toggle"
-            onClick={() => setManualHypothesisFormVisible((prev) => !prev)}
-            aria-expanded={isManualHypothesisFormVisible}
-            aria-controls="niche-manual-hypothesis-form"
-          >
-            {isManualHypothesisFormVisible ? (
-              <Minus size={16} />
-            ) : (
-              <Plus size={16} />
-            )}
-            <span>
-              {isManualHypothesisFormVisible
-                ? "Fechar formulário manual"
-                : "Criar hipótese manual"}
-            </span>
-          </button>
-          {isManualHypothesisFormVisible && (
-            <div
-              id="niche-manual-hypothesis-form"
-              className="niche-hypothesis-manual__content"
-            >
-              <HypothesisManualForm
-                nicheId={normalizedNicheId}
-                onCancel={() => setManualHypothesisFormVisible(false)}
-                onSuccess={handleManualHypothesisSuccess}
-              />
-            </div>
-          )}
-        </div>
-        {list.length === 0 ? (
-          <p className="niche-section__empty">Nenhuma hipótese ainda.</p>
-        ) : (
-          <div className="niche-section__grid">
-            {list.map((h) => {
-              const experimentCount = experimentsCountByHypothesis[h.id] ?? 0;
-              const experimentLabel =
-                experimentCount === 1
-                  ? "1 experimento criado"
-                  : `${experimentCount} experimentos criados`;
-              const costLabel = formatUsd(h.costUsd);
-              const fields = [
-                { label: "Promessa", value: h.promise },
-                { label: "Problema", value: h.problem },
-                { label: "Mecanismo", value: h.mechanism },
-                { label: "Mecanismo único", value: h.uniqueMechanism },
-                { label: "Persona", value: h.persona },
-                { label: "Entrega", value: h.entrega },
-              ];
-              return (
-                <div key={h.id} className="card h-100 niche-section__card">
-                  <div className="card-body niche-hypothesis-card__body">
-                    <div className="niche-hypothesis-card__head">
-                      <h3 className="niche-hypothesis-card__title">
-                        {h.title}
-                      </h3>
-                      <div className="d-flex flex-column align-items-end gap-1">
-                        <span className="niche-hypothesis-card__counter">
-                          {experimentLabel}
-                        </span>
-                        <div className="d-flex gap-2 flex-wrap justify-content-end">
-                          {h.model && (
-                            <span className="badge bg-light text-dark">
-                              Modelo: {h.model}
-                            </span>
-                          )}
-                          {costLabel && (
-                            <span className="badge bg-light text-dark">
-                              Custo: {costLabel}
-                            </span>
-                          )}
-                        </div>
-                      </div>
-                    </div>
-                    <div className="niche-hypothesis-card__fields">
-                      {fields.map((field) => (
-                        <div
-                          key={field.label}
-                          className="niche-hypothesis-card__field"
-                        >
-                          <span className="niche-hypothesis-card__field-label">
-                            {`${field.label}:`}
-                          </span>
-                          <p className="niche-hypothesis-card__field-value">
-                            {field.value || "-"}
-                          </p>
-                        </div>
-                      ))}
-                    </div>
-                    <div className="niche-hypothesis-card__actions">
-                      <Link
-                        className="btn btn-sm btn-outline-secondary"
-                        to={`hypotheses/${h.id}/edit`}
-                      >
-                        <span>Editar</span>
-                        <Pencil size={16} />
-                      </Link>
-                      <Link
-                        className="btn btn-sm btn-outline-primary"
-                        to={`hypotheses/${h.id}`}
-                      >
-                        <span>Ver detalhes</span>
-                        <ArrowUpRight size={16} />
-                      </Link>
-                    </div>
-                  </div>
-                  <div className="card-footer niche-hypothesis-card__footer">
-                    {`Gerado com ${h.model || "-"} em ${
-                      h.createdAt
-                        ? new Date(h.createdAt).toLocaleString("pt-BR")
-                        : "-"
-                    }`}
-                  </div>
-                </div>
-              );
-            })}
-          </div>
-        )}
       </section>
     </div>
   );


### PR DESCRIPTION
### Motivation
- The hypotheses card and full hypotheses section were removed to simplify the Niche detail UI and prevent navigation to a subsection that should no longer be displayed. 
- Removing the feature also eliminates unused hooks, state and imports tied to hypothesis generation to avoid dead code and potential runtime/compile noise.

### Description
- Removed the `Hipóteses` stat and the `Hipóteses do nicho` information card and the entire hypotheses section (generation form, manual-creation form and hypotheses list) from `frontend/src/pages/niche/NicheDetailPage.tsx`.
- Cleaned up related imports and hooks including `useHypothesesByNiche`, `useRequestHypotheses`, `useNicheDetailedDescriptions`, `useExperimentsByNiche`, `useDifferentiatedTechnologies`, `HypothesisManualForm`, and unused icon imports (`Lightbulb`, `Pencil`, `Minus`, `ArrowUpRight`).
- Removed hypothesis-specific state, effects and helpers such as the hypothesis request form state, `hypothesisStatusLabel`, `formatUsd`, `experimentsCountByHypothesis` and the request handler logic that were used only by the removed UI.
- Kept the rest of the page intact and left the general info/stats grid and other sections unchanged.

### Testing
- Ran `npm install --prefix frontend` and the install completed successfully. 
- Ran `npm run typecheck --prefix frontend` and the TypeScript check completed without errors after dependencies were installed. 
- Ran `npm run build --prefix frontend` and the production build finished successfully. 
- Ran `git diff --check` to validate whitespace/diff issues and no problems were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3daa5b3df48321acc459f8c279a657)