### PR TITLE
Corrige host do AI Worker no Ops Monitor

### DIFF
--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-25-ops-monitor-ai-worker-host.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-25-ops-monitor-ai-worker-host.yaml
@@ -1,0 +1,20 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-06-25-ops-monitor-009-ai-worker-host
+      author: marketing-hub
+      preConditions:
+        - onFail: MARK_RAN
+        - dbms:
+            type: mysql
+        - tableExists:
+            tableName: ops_monitored_module
+      changes:
+        - sql:
+            splitStatements: true
+            stripComments: true
+            sql: |
+              UPDATE ops_monitored_module
+              SET base_url = 'http://191.252.120.96:4567',
+                  health_path = '/worker-observability/health',
+                  log_path = '/worker-observability/logfile'
+              WHERE code = 'ai-worker';

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -1100,6 +1100,9 @@ databaseChangeLog:
   - include:
       file: changesets/2026-06-25-ops-monitor-public-routes.yaml
       relativeToChangelogFile: true
+  - include:
+      file: changesets/2026-06-25-ops-monitor-ai-worker-host.yaml
+      relativeToChangelogFile: true
 
   - include:
       file: changesets/2026-06-24-mois-sales-library-geralanding-insights.yaml

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -5405,3 +5405,8 @@
 - Criado changelog incremental para o Ops Monitor verificar o Lead Portal pelo domínio público canônico, evitando falso offline na tela de operação.
 
 - 2026-06-25 — Remoção de cards redundantes na tela de detalhe do experimento: retiradas as seções “Configurações do experimento” e “Fluxo operacional do Meta” do checklist de publicação, mantendo apenas os bloqueios essenciais para liberar campanha.
+
+## 2026-06-25 — Diagnóstico do alerta falso de AI Worker em experimento 49
+- problema observado: na tela do experimento 49, o menu lateral exibia `AI Worker` como fora do ar enquanto a etapa Quality Review tinha execução recente.
+- causa-raiz confirmada no banco/logs: o experimento 49 tinha jobs recentes no GeraLanding e o log do AI Worker mostrava ciclos ativos, mas o Ops Monitor registrava health checks `OFFLINE` por `Connection refused` no host `191.252.181.168:4567`.
+- correção aplicada: o cadastro monitorado do `ai-worker` foi corrigido para o host operacional `191.252.120.96:4567`, usado pelo endpoint de observabilidade real do worker.

--- a/docs/registros/ops-monitor.md
+++ b/docs/registros/ops-monitor.md
@@ -44,3 +44,9 @@
 ## 2026-06-25 — Protocolo Monitor incluído no AGENTS.md
 - O `AGENTS.md` passou a listar o `Protocolo Monitor` junto dos demais protocolos operacionais acionáveis por gatilho literal.
 - A regra deixa explícito que versões de pipeline monitoradas precisam declarar sinal operacional, degradação/incidente, teste de contrato e registros obrigatórios.
+
+## 2026-06-25 — Correção do host monitorado do AI Worker
+- problema observado: a tela indicava `AI Worker` como módulo fora do ar, embora o worker tivesse acabado de executar jobs do GeraLanding.
+- causa-raiz confirmada: o monitor operacional consultava `http://191.252.181.168:4567/worker-observability/health`, mas os logs reais do AI Worker disponíveis pelo MCP apontam o serviço operacional em `http://191.252.120.96:4567/worker-observability/logfile`; por isso o health check registrava `Connection refused` mesmo com o worker ativo.
+- correção aplicada: novo changeset ajusta o cadastro canônico do `ai-worker` no Ops Monitor para `http://191.252.120.96:4567`, preservando `/worker-observability/health` e `/worker-observability/logfile`.
+- prevenção de recorrência: a disponibilidade do menu lateral passa a depender do endpoint de observabilidade do host real do módulo, reduzindo falso alarme de módulo fora do ar quando há execução recente.


### PR DESCRIPTION
### Motivation
- Corrigir alerta falso de "AI Worker fora do ar" exibido na UI quando o worker havia executado jobs do GeraLanding; o monitor estava consultando o host errado e registrando `Connection refused` apesar do worker ativo. 
- A intenção é apontar o cadastro canônico do `ai-worker` para o host operacional real de observabilidade para evitar falsos alarmes e alinhar saúde exibida com a atividade real. 

### Description
- Adicionado changeset Liquibase `backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-25-ops-monitor-ai-worker-host.yaml` que atualiza `ops_monitored_module` para `ai-worker` com `base_url = 'http://191.252.120.96:4567'` e preserva `health_path` e `log_path`. 
- Incluído o novo changeset no `backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml` com `relativeToChangelogFile: true`. 
- Atualizados os registros operacionais em `docs/registros/ops-monitor.md` e `docs/registros/experimentos.md` com diagnóstico e justificativa da correção. 

### Testing
- Validado que todos os `include` em `db.changelog-master.yaml` usam `relativeToChangelogFile: true` com um script Python (`python - <<'PY' ...`). 
- Compilação do módulo backend foi executada com `mvn -q -f backend/ads-service/pom.xml -DskipTests compile` e retornou sucesso. 
- Verificação estática com `git diff --check` foi executada e não apresentou problemas.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3dabd60f688321b00d4ccb48064afe)