### PR TITLE
Materialize persona-routine output into `market_niche` and enrichment profile for v3

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/personaroutinematerializer/service/BackendPersonaRoutineMaterializerService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/personaroutinematerializer/service/BackendPersonaRoutineMaterializerService.java
@@ -1,21 +1,41 @@
 package com.marketinghub.oprm.nichocnae.v3.personaroutinematerializer.service;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marketinghub.oprm.nichocnae.v3.OprmNichoCnaeV3StageExecution;
+import com.marketinghub.oprm.nichocnae.gateway.OprmEnrichedNicheGateway;
+import com.marketinghub.oprm.nichocnae.gateway.OprmEnrichedNicheGateway.OprmEnrichedNicheProfileDraft;
+import com.marketinghub.oprm.nichocnae.gateway.OprmEnrichedNicheGateway.OprmMarketNicheDraft;
 import com.marketinghub.oprm.nichocnae.v3.personaroutinematerializer.service.createStageExecution.PersonaRoutineMaterializerCreateResponse;
 import com.marketinghub.oprm.nichocnae.v3.personaroutinematerializer.service.pending.PersonaRoutineMaterializerPendingResponse;
 import com.marketinghub.oprm.nichocnae.v3.shared.OprmNichoCnaeV3StageServiceSupport;
 import com.marketinghub.repository.jpa.oprm.nichocnae.v3.OprmNichoCnaeV3StageExecutionRepository;
+import java.math.BigDecimal;
+import java.time.Instant;
 import java.util.List;
+import java.util.Locale;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
 
 /** Service canônico da etapa persona-routine-materializer do pipeline NichoCNAE v3 no backend. */
 @Service
 public class BackendPersonaRoutineMaterializerService extends OprmNichoCnaeV3StageServiceSupport {
     private static final String STAGE_CODE = "persona-routine-materializer";
+    private static final String CREATED_BY = "OPRM_NICHO_CNAE_V3";
+    private static final String DEFAULT_QUALITY_STATUS = "V3_PERSONA_ROUTINE_MATERIALIZED";
+    private static final BigDecimal DEFAULT_SOURCE_SCORE = BigDecimal.ZERO;
+    private final OprmEnrichedNicheGateway enrichedNicheGateway;
+    private final ObjectMapper objectMapper;
 
     /** Inicializa o service com repository canônico de execuções v3. */
-    public BackendPersonaRoutineMaterializerService(OprmNichoCnaeV3StageExecutionRepository repository) {
+    public BackendPersonaRoutineMaterializerService(
+            OprmNichoCnaeV3StageExecutionRepository repository,
+            OprmEnrichedNicheGateway enrichedNicheGateway,
+            ObjectMapper objectMapper) {
         super(repository, STAGE_CODE);
+        this.enrichedNicheGateway = enrichedNicheGateway;
+        this.objectMapper = objectMapper;
     }
 
     /** Cria pendência inicial ou encadeada para a etapa persona-routine-materializer. */
@@ -29,8 +49,11 @@ public class BackendPersonaRoutineMaterializerService extends OprmNichoCnaeV3Sta
     }
 
     /** Registra conclusão da etapa persona-routine-materializer. */
+    @Transactional
     public PersonaRoutineMaterializerCreateResponse complete(Long stageExecutionId, String outputPayload, String nextStageCode) {
-        return toCreateResponse(doComplete(stageExecutionId, outputPayload, nextStageCode));
+        OprmNichoCnaeV3StageExecution execution = doComplete(stageExecutionId, outputPayload, nextStageCode);
+        materializeNicheData(execution);
+        return toCreateResponse(execution);
     }
 
     /** Registra falha da etapa persona-routine-materializer. */
@@ -46,5 +69,135 @@ public class BackendPersonaRoutineMaterializerService extends OprmNichoCnaeV3Sta
     /** Converte entidade persistida em item pendente para executor externo. */
     private PersonaRoutineMaterializerPendingResponse toPendingResponse(OprmNichoCnaeV3StageExecution execution) {
         return new PersonaRoutineMaterializerPendingResponse(execution.getId(), execution.getJobId(), execution.getCnaeCode(), execution.getInputPayload(), execution.getAttemptNumber(), execution.getKnowledgeVersion());
+    }
+
+    /** Materializa o resultado final v3 nas estruturas reutilizáveis do nicho. */
+    private void materializeNicheData(OprmNichoCnaeV3StageExecution execution) {
+        JsonNode output = parseOutput(execution.getOutputPayload());
+        String neutralNicheName = firstText(output, "neutralNicheName", "nicheName", "personaName", "persona");
+        if (!StringUtils.hasText(neutralNicheName)) {
+            neutralNicheName = "CNAE " + execution.getCnaeCode() + " — persona e rotina v3";
+        }
+        String cnaeDescription = firstText(output, "cnaeDescription", "marketDescription", "description");
+        if (!StringUtils.hasText(cnaeDescription)) {
+            cnaeDescription = "Persona, rotina e tarefas diárias materializadas pelo NichoCNAE v3 para o CNAE "
+                    + execution.getCnaeCode() + ".";
+        }
+        String routineSummary = textOrDefault(
+                firstText(output, "routineSummary", "routine", "rotina"),
+                "Rotina operacional materializada pelo NichoCNAE v3.");
+        String dailyTasks = textOrDefault(
+                firstText(output, "personaDailyTasks", "dailyTasks", "tarefasDiarias", "tasks"),
+                "Tarefas diárias materializadas pelo NichoCNAE v3.");
+        String painsSummary = textOrDefault(
+                firstText(output, "painsSummary", "painSignals", "pains", "dores"),
+                "Dores e esforços extraídos pelo NichoCNAE v3.");
+        String resultsSummary = textOrDefault(
+                firstText(output, "resultsSummary", "desiredResults", "resultadosDesejados"),
+                "Resultados desejados inferidos pelo NichoCNAE v3.");
+        String mechanismSummary = textOrDefault(
+                firstText(output, "mechanismOpportunitiesSummary", "mechanismOpportunities", "opportunities"),
+                "Oportunidades de mecanismo identificadas pelo NichoCNAE v3.");
+        Instant now = Instant.now();
+        Long existingMarketNicheId = enrichedNicheGateway
+                .findByCnaeAndNormalizedNeutralName(
+                        execution.getCnaeCode(), neutralNicheName.trim().toLowerCase(Locale.ROOT))
+                .map(OprmEnrichedNicheGateway.OprmMarketNicheSnapshot::marketNicheId)
+                .orElse(null);
+        enrichedNicheGateway.materialize(
+                new OprmMarketNicheDraft(
+                        existingMarketNicheId,
+                        neutralNicheName,
+                        buildNicheDescription(cnaeDescription, routineSummary, dailyTasks),
+                        null,
+                        routineSummary,
+                        null,
+                        List.of(),
+                        List.of(),
+                        List.of(),
+                        null,
+                        dailyTasks,
+                        null),
+                new OprmEnrichedNicheProfileDraft(
+                        null,
+                        execution.getId(),
+                        execution.getId(),
+                        execution.getCnaeCode(),
+                        cnaeDescription,
+                        DEFAULT_SOURCE_SCORE,
+                        DEFAULT_QUALITY_STATUS,
+                        integerOrDefault(output, "specificityScore", 0),
+                        integerOrDefault(output, "confidenceScore", 0),
+                        integerOrDefault(output, "duplicationScore", 0),
+                        integerOrDefault(output, "routineEvidenceScore", 0),
+                        integerOrDefault(output, "difficultyEvidenceScore", 0),
+                        integerOrDefault(output, "sourceDiversityScore", 0),
+                        integerOrDefault(output, "solutionLanguageRiskScore", 0),
+                        neutralNicheName,
+                        neutralNicheName,
+                        "V3_PERSONA_ROUTINE",
+                        routineSummary,
+                        dailyTasks,
+                        painsSummary,
+                        resultsSummary,
+                        mechanismSummary,
+                        textOrDefault(firstText(output, "evidenceSummary", "evidences"), execution.getOutputPayload()),
+                        firstText(output, "sourceDomains", "sources"),
+                        firstText(output, "personaSummary", "persona"),
+                        firstText(output, "languagePatterns", "language"),
+                        firstText(output, "commercialTriggers", "triggers"),
+                        firstText(output, "objections"),
+                        execution.getOutputPayload(),
+                        CREATED_BY,
+                        now,
+                        now));
+    }
+
+    /** Converte o JSON de saída em árvore tolerante a payloads técnicos ou funcionais. */
+    private JsonNode parseOutput(String outputPayload) {
+        if (!StringUtils.hasText(outputPayload)) {
+            return objectMapper.createObjectNode();
+        }
+        try {
+            return objectMapper.readTree(outputPayload);
+        } catch (java.io.IOException ex) {
+            return objectMapper.createObjectNode().put("raw", outputPayload);
+        }
+    }
+
+    /** Retorna o primeiro campo textual disponível no payload. */
+    private String firstText(JsonNode root, String... fieldNames) {
+        if (root == null || root.isMissingNode() || root.isNull()) {
+            return null;
+        }
+        for (String fieldName : fieldNames) {
+            JsonNode value = root.path(fieldName);
+            if (value.isMissingNode() || value.isNull()) {
+                continue;
+            }
+            String text = value.isTextual() ? value.asText() : value.toString();
+            if (StringUtils.hasText(text)) {
+                return text.trim();
+            }
+        }
+        return null;
+    }
+
+    /** Retorna texto padrão quando o campo final ainda não veio no payload do executor. */
+    private String textOrDefault(String value, String defaultValue) {
+        return StringUtils.hasText(value) ? value.trim() : defaultValue;
+    }
+
+    /** Lê pontuação numérica opcional do payload da etapa final. */
+    private Integer integerOrDefault(JsonNode root, String fieldName, int defaultValue) {
+        JsonNode value = root == null ? null : root.path(fieldName);
+        return value != null && value.isNumber() ? value.asInt() : defaultValue;
+    }
+
+    /** Monta uma descrição compacta do nicho base para outros pipelines consumirem. */
+    private String buildNicheDescription(String cnaeDescription, String routineSummary, String dailyTasks) {
+        return "Descrição CNAE: " + cnaeDescription
+                + "\n\nRotina observada: " + routineSummary
+                + "\n\nTarefas diárias: " + dailyTasks;
     }
 }

--- a/backend/ads-service/src/test/java/com/marketinghub/oprm/nichocnae/v3/personaroutinematerializer/service/BackendPersonaRoutineMaterializerServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/oprm/nichocnae/v3/personaroutinematerializer/service/BackendPersonaRoutineMaterializerServiceTest.java
@@ -1,0 +1,96 @@
+package com.marketinghub.oprm.nichocnae.v3.personaroutinematerializer.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marketinghub.oprm.nichocnae.gateway.OprmEnrichedNicheGateway;
+import com.marketinghub.oprm.nichocnae.gateway.OprmEnrichedNicheGateway.OprmEnrichedNicheMaterializationResult;
+import com.marketinghub.oprm.nichocnae.gateway.OprmEnrichedNicheGateway.OprmEnrichedNicheProfileDraft;
+import com.marketinghub.oprm.nichocnae.gateway.OprmEnrichedNicheGateway.OprmMarketNicheDraft;
+import com.marketinghub.oprm.nichocnae.v3.OprmNichoCnaeV3StageExecution;
+import com.marketinghub.oprm.nichocnae.v3.OprmNichoCnaeV3StageExecutionStatus;
+import com.marketinghub.repository.jpa.oprm.nichocnae.v3.OprmNichoCnaeV3StageExecutionRepository;
+import java.time.Instant;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/** Testa a materialização final do NichoCNAE v3 em dados reutilizáveis do nicho. */
+@ExtendWith(MockitoExtension.class)
+class BackendPersonaRoutineMaterializerServiceTest {
+    @Mock
+    private OprmNichoCnaeV3StageExecutionRepository repository;
+
+    @Mock
+    private OprmEnrichedNicheGateway enrichedNicheGateway;
+
+    private BackendPersonaRoutineMaterializerService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new BackendPersonaRoutineMaterializerService(repository, enrichedNicheGateway, new ObjectMapper());
+    }
+
+    /** Garante que a etapa final grava MarketNiche e perfil enriquecido para uso por outros pipelines. */
+    @Test
+    void completeMaterializesFinalPayloadIntoNicheData() {
+        OprmNichoCnaeV3StageExecution execution = execution();
+        String outputPayload = """
+                {
+                  "neutralNicheName":"Lojistas de roupas infantis com rotina de reposição",
+                  "cnaeDescription":"Comércio varejista de artigos do vestuário",
+                  "routineSummary":"Compram, organizam vitrines e atendem famílias diariamente.",
+                  "personaDailyTasks":["repor peças", "responder clientes"],
+                  "painsSummary":"Perdem tempo conciliando estoque e atendimento.",
+                  "resultsSummary":"Querem previsibilidade de vendas e menos ruptura.",
+                  "mechanismOpportunitiesSummary":"Padronização de rotina e priorização de reposição.",
+                  "routineEvidenceScore":82,
+                  "difficultyEvidenceScore":77,
+                  "sourceDiversityScore":68
+                }
+                """;
+        when(repository.findById(19L)).thenReturn(Optional.of(execution));
+        when(repository.save(any(OprmNichoCnaeV3StageExecution.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        when(enrichedNicheGateway.findByCnaeAndNormalizedNeutralName(
+                eq("4781400"), eq("lojistas de roupas infantis com rotina de reposição")))
+                .thenReturn(Optional.empty());
+        when(enrichedNicheGateway.materialize(any(OprmMarketNicheDraft.class), any(OprmEnrichedNicheProfileDraft.class)))
+                .thenReturn(new OprmEnrichedNicheMaterializationResult(300L, 400L, Instant.now()));
+
+        service.complete(19L, outputPayload, "");
+
+        ArgumentCaptor<OprmMarketNicheDraft> nicheCaptor = ArgumentCaptor.forClass(OprmMarketNicheDraft.class);
+        ArgumentCaptor<OprmEnrichedNicheProfileDraft> profileCaptor = ArgumentCaptor.forClass(OprmEnrichedNicheProfileDraft.class);
+        verify(enrichedNicheGateway).materialize(nicheCaptor.capture(), profileCaptor.capture());
+        assertThat(nicheCaptor.getValue().name()).isEqualTo("Lojistas de roupas infantis com rotina de reposição");
+        assertThat(nicheCaptor.getValue().description()).contains("Compram, organizam vitrines");
+        assertThat(profileCaptor.getValue().researchCycleId()).isEqualTo(19L);
+        assertThat(profileCaptor.getValue().sourceRoutineCardId()).isEqualTo(19L);
+        assertThat(profileCaptor.getValue().routineEvidenceScore()).isEqualTo(82);
+        assertThat(profileCaptor.getValue().difficultyEvidenceScore()).isEqualTo(77);
+        assertThat(profileCaptor.getValue().sourceDiversityScore()).isEqualTo(68);
+        assertThat(profileCaptor.getValue().routineSummary()).contains("Compram");
+        assertThat(profileCaptor.getValue().personaDailyTasks()).contains("repor peças");
+    }
+
+    /** Monta uma execução final pendente para o callback de conclusão. */
+    private OprmNichoCnaeV3StageExecution execution() {
+        OprmNichoCnaeV3StageExecution execution = new OprmNichoCnaeV3StageExecution();
+        execution.setId(19L);
+        execution.setJobId("nichocnae-v3-4781400-1782411268024");
+        execution.setCnaeCode("4781400");
+        execution.setStageCode("persona-routine-materializer");
+        execution.setStatus(OprmNichoCnaeV3StageExecutionStatus.PENDING);
+        execution.setCreatedAt(Instant.parse("2026-06-25T21:08:56Z"));
+        execution.setUpdatedAt(Instant.parse("2026-06-25T21:08:56Z"));
+        return execution;
+    }
+}

--- a/docs/canonical/oprm-canon.v1.md
+++ b/docs/canonical/oprm-canon.v1.md
@@ -157,6 +157,7 @@ Evitar fechamento prematuro de `import run` que destrói a totalização de mark
 - Campos legados de materialização com nomes comerciais devem receber somente conteúdo operacional compatível ou valor funcional de reprocessamento neutro; não podem eternizar hipótese, oferta, produto, curso, ferramenta, automação ou oportunidade de solução como verdade da pesquisa inicial.
 - O vínculo entre OPRM e nicho comercial deve permanecer rastreável por `research_cycle_id`, `routine_card_id`, `source_niche_candidate_id` e `market_niche_id`.
 - A conclusão da etapa deve atualizar o ciclo para `ENRICHED_NICHE_CREATED`; falhas devem registrar status `ENRICHED_NICHE_FAILED` e mensagem operacional no ciclo.
+- No pipeline NichoCNAE v3, a etapa final `persona-routine-materializer` também deve alimentar obrigatoriamente `market_niche` e `market_niche_enrichment_profile`; o `output_payload` da execução é auditoria técnica, não pode ser o único local das informações finais, porque pipelines posteriores consomem dados do nicho.
 
 ## Critério de efetividade — nicho enriquecido materializado
 


### PR DESCRIPTION
### Motivation
- Ensure the final step `persona-routine-materializer` in NichoCNAE v3 persists usable niche data into the canonical `market_niche` and `market_niche_enrichment_profile` structures so downstream pipelines do not rely on raw `output_payload` only.
- Provide deterministic mapping, defaults and normalization for varied executor payload shapes to make materialization idempotent and robust.

### Description
- Introduces `BackendPersonaRoutineMaterializerService` enhancements: injects `OprmEnrichedNicheGateway` and `ObjectMapper`, marks `complete` as `@Transactional`, and invokes `materializeNicheData` after completion.
- Implements `materializeNicheData` to parse flexible JSON outputs, pick the first available fields (with `firstText`), apply sane defaults, normalize neutral niche names, and build `OprmMarketNicheDraft` and `OprmEnrichedNicheProfileDraft` for `enrichedNicheGateway.materialize`.
- Adds JSON helper methods: `parseOutput`, `firstText`, `textOrDefault`, `integerOrDefault`, and `buildNicheDescription`, and constants for default status and meta fields.
- Updates canonical docs to state that the v3 final step must persist `market_niche` and `market_niche_enrichment_profile` and that `output_payload` is audit-only.
- Adds unit test `BackendPersonaRoutineMaterializerServiceTest` which verifies the gateway `materialize` call and key mapped fields.

### Testing
- Ran the new unit test `BackendPersonaRoutineMaterializerServiceTest` (JUnit + Mockito) which exercises `complete` and verifies `enrichedNicheGateway.materialize` was called with expected `OprmMarketNicheDraft` and `OprmEnrichedNicheProfileDraft`; the test passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3daa049da08321aef60dc5dd62637d)