### PR TITLE
Add v3 PersonaRoutineMaterializerNicheGateway and adapt JPA gateway/service to isolate v3 materialization

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/niche/oprm/JpaOprmEnrichedNicheGateway.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/niche/oprm/JpaOprmEnrichedNicheGateway.java
@@ -3,6 +3,7 @@ package com.marketinghub.niche.oprm;
 import com.marketinghub.niche.MarketNiche;
 import com.marketinghub.niche.MarketNicheEnrichmentProfile;
 import com.marketinghub.oprm.nichocnae.gateway.OprmEnrichedNicheGateway;
+import com.marketinghub.oprm.nichocnae.v3.personaroutinematerializer.gateway.PersonaRoutineMaterializerNicheGateway;
 import com.marketinghub.repository.jpa.niche.MarketNicheEnrichmentProfileRepository;
 import com.marketinghub.repository.jpa.niche.MarketNicheRepository;
 import jakarta.persistence.EntityNotFoundException;
@@ -15,7 +16,7 @@ import org.springframework.util.StringUtils;
 
 /** Adaptador JPA que isola o domínio Niche atrás da porta permitida ao OPRM. */
 @Component
-public class JpaOprmEnrichedNicheGateway implements OprmEnrichedNicheGateway {
+public class JpaOprmEnrichedNicheGateway implements OprmEnrichedNicheGateway, PersonaRoutineMaterializerNicheGateway {
   private static final String SOURCE_MODULE = "OPRM_NICHO_CNAE";
 
   private final MarketNicheRepository marketNicheRepository;
@@ -65,6 +66,27 @@ public class JpaOprmEnrichedNicheGateway implements OprmEnrichedNicheGateway {
     applyProfileDraft(profile, savedNiche, profileDraft);
     MarketNicheEnrichmentProfile savedProfile = enrichmentProfileRepository.save(profile);
     return new OprmEnrichedNicheMaterializationResult(savedNiche.getId(), savedProfile.getId(), savedProfile.getCreatedAt());
+  }
+
+  /** Busca materialização existente pelo contrato exclusivo da etapa persona-routine-materializer v3. */
+  @Override
+  public Optional<PersonaRoutineMaterializerNicheGateway.MarketNicheSnapshot> findPersonaRoutineMaterializedNiche(
+      String cnaeCode, String normalizedNeutralNicheName) {
+    return enrichmentProfileRepository
+        .findMaterializedByCnaeAndNormalizedNeutralName(cnaeCode, normalizedNeutralNicheName, PageRequest.of(0, 1))
+        .stream()
+        .findFirst()
+        .map(profile -> new PersonaRoutineMaterializerNicheGateway.MarketNicheSnapshot(profile.getMarketNiche().getId()));
+  }
+
+  /** Materializa ou atualiza o nicho usando o contrato exclusivo da etapa persona-routine-materializer v3. */
+  @Override
+  public PersonaRoutineMaterializerNicheGateway.NicheMaterializationResult materialize(
+      PersonaRoutineMaterializerNicheGateway.MarketNicheDraft nicheDraft,
+      PersonaRoutineMaterializerNicheGateway.EnrichedNicheProfileDraft profileDraft) {
+    OprmEnrichedNicheMaterializationResult result = materialize(toOprmNicheDraft(nicheDraft), toOprmProfileDraft(profileDraft));
+    return new PersonaRoutineMaterializerNicheGateway.NicheMaterializationResult(
+        result.marketNicheId(), result.profileId(), result.createdAt());
   }
 
   /** Busca o perfil mais recente do ciclo sem retornar entidade JPA ao OPRM. */
@@ -205,5 +227,60 @@ public class JpaOprmEnrichedNicheGateway implements OprmEnrichedNicheGateway {
         profile.getSourceDomains(),
         profile.getResearchReportMarkdown(),
         profile.getCreatedAt());
+  }
+
+  /** Converte o contrato v3 de nicho para o contrato canônico de persistência OPRM. */
+  private OprmMarketNicheDraft toOprmNicheDraft(PersonaRoutineMaterializerNicheGateway.MarketNicheDraft draft) {
+    return new OprmMarketNicheDraft(
+        draft.marketNicheId(),
+        draft.name(),
+        draft.description(),
+        draft.demandVolume(),
+        draft.baseSegmentation(),
+        draft.demographicFilters(),
+        draft.interestList(),
+        draft.roleList(),
+        draft.behaviorList(),
+        draft.interests(),
+        draft.extraTips(),
+        draft.identificationCostBrl());
+  }
+
+  /** Converte o contrato v3 de perfil enriquecido para o contrato canônico de persistência OPRM. */
+  private OprmEnrichedNicheProfileDraft toOprmProfileDraft(
+      PersonaRoutineMaterializerNicheGateway.EnrichedNicheProfileDraft draft) {
+    return new OprmEnrichedNicheProfileDraft(
+        draft.sourceNicheCandidateId(),
+        draft.researchCycleId(),
+        draft.sourceRoutineCardId(),
+        draft.cnaeCode(),
+        draft.cnaeDescription(),
+        draft.sourceScore(),
+        draft.qualityStatus(),
+        draft.specificityScore(),
+        draft.confidenceScore(),
+        draft.duplicationScore(),
+        draft.routineEvidenceScore(),
+        draft.difficultyEvidenceScore(),
+        draft.sourceDiversityScore(),
+        draft.solutionLanguageRiskScore(),
+        draft.originalNicheName(),
+        draft.neutralNicheName(),
+        draft.researchMode(),
+        draft.routineSummary(),
+        draft.personaDailyTasks(),
+        draft.painsSummary(),
+        draft.resultsSummary(),
+        draft.mechanismOpportunitiesSummary(),
+        draft.evidenceSummary(),
+        draft.sourceDomains(),
+        draft.personaSummary(),
+        draft.languagePatterns(),
+        draft.commercialTriggers(),
+        draft.objections(),
+        draft.researchReportMarkdown(),
+        draft.createdBy(),
+        draft.createdAt(),
+        draft.updatedAt());
   }
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/personaroutinematerializer/gateway/PersonaRoutineMaterializerNicheGateway.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/personaroutinematerializer/gateway/PersonaRoutineMaterializerNicheGateway.java
@@ -1,0 +1,71 @@
+package com.marketinghub.oprm.nichocnae.v3.personaroutinematerializer.gateway;
+
+import java.math.BigDecimal;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+
+/** Porta exclusiva da etapa persona-routine-materializer v3 para materializar dados reutilizáveis de nicho. */
+public interface PersonaRoutineMaterializerNicheGateway {
+    /** Busca materialização existente pelo CNAE e nome neutro normalizado. */
+    Optional<MarketNicheSnapshot> findPersonaRoutineMaterializedNiche(String cnaeCode, String normalizedNeutralNicheName);
+
+    /** Materializa ou atualiza o nicho e grava o perfil enriquecido produzido pela etapa v3. */
+    NicheMaterializationResult materialize(MarketNicheDraft nicheDraft, EnrichedNicheProfileDraft profileDraft);
+
+    /** Representa a referência mínima de nicho já materializado para a etapa v3. */
+    record MarketNicheSnapshot(Long marketNicheId) {}
+
+    /** Representa os campos funcionais do nicho que a etapa v3 pode solicitar por contrato próprio. */
+    record MarketNicheDraft(
+            Long marketNicheId,
+            String name,
+            String description,
+            String demandVolume,
+            String baseSegmentation,
+            String demographicFilters,
+            List<String> interestList,
+            List<String> roleList,
+            List<String> behaviorList,
+            String interests,
+            String extraTips,
+            BigDecimal identificationCostBrl) {}
+
+    /** Representa os campos funcionais do perfil enriquecido produzidos pela etapa v3. */
+    record EnrichedNicheProfileDraft(
+            Long sourceNicheCandidateId,
+            Long researchCycleId,
+            Long sourceRoutineCardId,
+            String cnaeCode,
+            String cnaeDescription,
+            BigDecimal sourceScore,
+            String qualityStatus,
+            Integer specificityScore,
+            Integer confidenceScore,
+            Integer duplicationScore,
+            Integer routineEvidenceScore,
+            Integer difficultyEvidenceScore,
+            Integer sourceDiversityScore,
+            Integer solutionLanguageRiskScore,
+            String originalNicheName,
+            String neutralNicheName,
+            String researchMode,
+            String routineSummary,
+            String personaDailyTasks,
+            String painsSummary,
+            String resultsSummary,
+            String mechanismOpportunitiesSummary,
+            String evidenceSummary,
+            String sourceDomains,
+            String personaSummary,
+            String languagePatterns,
+            String commercialTriggers,
+            String objections,
+            String researchReportMarkdown,
+            String createdBy,
+            Instant createdAt,
+            Instant updatedAt) {}
+
+    /** Representa o resultado da materialização da etapa v3. */
+    record NicheMaterializationResult(Long marketNicheId, Long enrichmentProfileId, Instant createdAt) {}
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/personaroutinematerializer/service/BackendPersonaRoutineMaterializerService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/personaroutinematerializer/service/BackendPersonaRoutineMaterializerService.java
@@ -2,10 +2,8 @@ package com.marketinghub.oprm.nichocnae.v3.personaroutinematerializer.service;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marketinghub.oprm.nichocnae.v3.personaroutinematerializer.gateway.PersonaRoutineMaterializerNicheGateway;
 import com.marketinghub.oprm.nichocnae.v3.OprmNichoCnaeV3StageExecution;
-import com.marketinghub.oprm.nichocnae.gateway.OprmEnrichedNicheGateway;
-import com.marketinghub.oprm.nichocnae.gateway.OprmEnrichedNicheGateway.OprmEnrichedNicheProfileDraft;
-import com.marketinghub.oprm.nichocnae.gateway.OprmEnrichedNicheGateway.OprmMarketNicheDraft;
 import com.marketinghub.oprm.nichocnae.v3.personaroutinematerializer.service.createStageExecution.PersonaRoutineMaterializerCreateResponse;
 import com.marketinghub.oprm.nichocnae.v3.personaroutinematerializer.service.pending.PersonaRoutineMaterializerPendingResponse;
 import com.marketinghub.oprm.nichocnae.v3.shared.OprmNichoCnaeV3StageServiceSupport;
@@ -25,16 +23,16 @@ public class BackendPersonaRoutineMaterializerService extends OprmNichoCnaeV3Sta
     private static final String CREATED_BY = "OPRM_NICHO_CNAE_V3";
     private static final String DEFAULT_QUALITY_STATUS = "V3_PERSONA_ROUTINE_MATERIALIZED";
     private static final BigDecimal DEFAULT_SOURCE_SCORE = BigDecimal.ZERO;
-    private final OprmEnrichedNicheGateway enrichedNicheGateway;
+    private final PersonaRoutineMaterializerNicheGateway nicheGateway;
     private final ObjectMapper objectMapper;
 
     /** Inicializa o service com repository canônico de execuções v3. */
     public BackendPersonaRoutineMaterializerService(
             OprmNichoCnaeV3StageExecutionRepository repository,
-            OprmEnrichedNicheGateway enrichedNicheGateway,
+            PersonaRoutineMaterializerNicheGateway nicheGateway,
             ObjectMapper objectMapper) {
         super(repository, STAGE_CODE);
-        this.enrichedNicheGateway = enrichedNicheGateway;
+        this.nicheGateway = nicheGateway;
         this.objectMapper = objectMapper;
     }
 
@@ -99,13 +97,13 @@ public class BackendPersonaRoutineMaterializerService extends OprmNichoCnaeV3Sta
                 firstText(output, "mechanismOpportunitiesSummary", "mechanismOpportunities", "opportunities"),
                 "Oportunidades de mecanismo identificadas pelo NichoCNAE v3.");
         Instant now = Instant.now();
-        Long existingMarketNicheId = enrichedNicheGateway
-                .findByCnaeAndNormalizedNeutralName(
+        Long existingMarketNicheId = nicheGateway
+                .findPersonaRoutineMaterializedNiche(
                         execution.getCnaeCode(), neutralNicheName.trim().toLowerCase(Locale.ROOT))
-                .map(OprmEnrichedNicheGateway.OprmMarketNicheSnapshot::marketNicheId)
+                .map(PersonaRoutineMaterializerNicheGateway.MarketNicheSnapshot::marketNicheId)
                 .orElse(null);
-        enrichedNicheGateway.materialize(
-                new OprmMarketNicheDraft(
+        nicheGateway.materialize(
+                new PersonaRoutineMaterializerNicheGateway.MarketNicheDraft(
                         existingMarketNicheId,
                         neutralNicheName,
                         buildNicheDescription(cnaeDescription, routineSummary, dailyTasks),
@@ -118,7 +116,7 @@ public class BackendPersonaRoutineMaterializerService extends OprmNichoCnaeV3Sta
                         null,
                         dailyTasks,
                         null),
-                new OprmEnrichedNicheProfileDraft(
+                new PersonaRoutineMaterializerNicheGateway.EnrichedNicheProfileDraft(
                         null,
                         execution.getId(),
                         execution.getId(),

--- a/backend/ads-service/src/test/java/com/marketinghub/oprm/nichocnae/v3/personaroutinematerializer/service/BackendPersonaRoutineMaterializerServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/oprm/nichocnae/v3/personaroutinematerializer/service/BackendPersonaRoutineMaterializerServiceTest.java
@@ -7,12 +7,9 @@ import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 import com.fasterxml.jackson.databind.ObjectMapper;
-import com.marketinghub.oprm.nichocnae.gateway.OprmEnrichedNicheGateway;
-import com.marketinghub.oprm.nichocnae.gateway.OprmEnrichedNicheGateway.OprmEnrichedNicheMaterializationResult;
-import com.marketinghub.oprm.nichocnae.gateway.OprmEnrichedNicheGateway.OprmEnrichedNicheProfileDraft;
-import com.marketinghub.oprm.nichocnae.gateway.OprmEnrichedNicheGateway.OprmMarketNicheDraft;
 import com.marketinghub.oprm.nichocnae.v3.OprmNichoCnaeV3StageExecution;
 import com.marketinghub.oprm.nichocnae.v3.OprmNichoCnaeV3StageExecutionStatus;
+import com.marketinghub.oprm.nichocnae.v3.personaroutinematerializer.gateway.PersonaRoutineMaterializerNicheGateway;
 import com.marketinghub.repository.jpa.oprm.nichocnae.v3.OprmNichoCnaeV3StageExecutionRepository;
 import java.time.Instant;
 import java.util.Optional;
@@ -30,13 +27,13 @@ class BackendPersonaRoutineMaterializerServiceTest {
     private OprmNichoCnaeV3StageExecutionRepository repository;
 
     @Mock
-    private OprmEnrichedNicheGateway enrichedNicheGateway;
+    private PersonaRoutineMaterializerNicheGateway nicheGateway;
 
     private BackendPersonaRoutineMaterializerService service;
 
     @BeforeEach
     void setUp() {
-        service = new BackendPersonaRoutineMaterializerService(repository, enrichedNicheGateway, new ObjectMapper());
+        service = new BackendPersonaRoutineMaterializerService(repository, nicheGateway, new ObjectMapper());
     }
 
     /** Garante que a etapa final grava MarketNiche e perfil enriquecido para uso por outros pipelines. */
@@ -59,17 +56,17 @@ class BackendPersonaRoutineMaterializerServiceTest {
                 """;
         when(repository.findById(19L)).thenReturn(Optional.of(execution));
         when(repository.save(any(OprmNichoCnaeV3StageExecution.class))).thenAnswer(invocation -> invocation.getArgument(0));
-        when(enrichedNicheGateway.findByCnaeAndNormalizedNeutralName(
+        when(nicheGateway.findPersonaRoutineMaterializedNiche(
                 eq("4781400"), eq("lojistas de roupas infantis com rotina de reposição")))
                 .thenReturn(Optional.empty());
-        when(enrichedNicheGateway.materialize(any(OprmMarketNicheDraft.class), any(OprmEnrichedNicheProfileDraft.class)))
-                .thenReturn(new OprmEnrichedNicheMaterializationResult(300L, 400L, Instant.now()));
+        when(nicheGateway.materialize(any(PersonaRoutineMaterializerNicheGateway.MarketNicheDraft.class), any(PersonaRoutineMaterializerNicheGateway.EnrichedNicheProfileDraft.class)))
+                .thenReturn(new PersonaRoutineMaterializerNicheGateway.NicheMaterializationResult(300L, 400L, Instant.now()));
 
         service.complete(19L, outputPayload, "");
 
-        ArgumentCaptor<OprmMarketNicheDraft> nicheCaptor = ArgumentCaptor.forClass(OprmMarketNicheDraft.class);
-        ArgumentCaptor<OprmEnrichedNicheProfileDraft> profileCaptor = ArgumentCaptor.forClass(OprmEnrichedNicheProfileDraft.class);
-        verify(enrichedNicheGateway).materialize(nicheCaptor.capture(), profileCaptor.capture());
+        ArgumentCaptor<PersonaRoutineMaterializerNicheGateway.MarketNicheDraft> nicheCaptor = ArgumentCaptor.forClass(PersonaRoutineMaterializerNicheGateway.MarketNicheDraft.class);
+        ArgumentCaptor<PersonaRoutineMaterializerNicheGateway.EnrichedNicheProfileDraft> profileCaptor = ArgumentCaptor.forClass(PersonaRoutineMaterializerNicheGateway.EnrichedNicheProfileDraft.class);
+        verify(nicheGateway).materialize(nicheCaptor.capture(), profileCaptor.capture());
         assertThat(nicheCaptor.getValue().name()).isEqualTo("Lojistas de roupas infantis com rotina de reposição");
         assertThat(nicheCaptor.getValue().description()).contains("Compram, organizam vitrines");
         assertThat(profileCaptor.getValue().researchCycleId()).isEqualTo(19L);

--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -1437,3 +1437,10 @@
 ## 2026-06-25 — NichoCNAE v3 registrado no Protocolo Monitor
 - O NichoCNAE v3 ficou registrado como primeiro caso do `Protocolo Monitor`, usando o `oprm-coletor-mei` como módulo executor monitorado.
 - A regra operacional é detectar fila v3 parada mesmo quando o container está online, evitando falso positivo de saúde operacional.
+
+## 2026-06-25 — OPRM NichoCNAE v3: isolamento da materialização final
+
+- Corrigido o acoplamento direto da etapa `persona-routine-materializer` v3 com a porta da versão inicial `OprmEnrichedNicheGateway`.
+- Causa-raiz tratada: o service v3 reutilizava contrato sem versão, fazendo o ArchUnit interpretar dependência direta da v3 para a versão inicial.
+- Correção aplicada: a etapa v3 passou a depender de uma porta própria, localizada no pacote da própria etapa, e o adaptador JPA externo faz a tradução para a persistência canônica.
+- Prevenção de recorrência: validado que não restam imports de `com.marketinghub.oprm.nichocnae.gateway` dentro do pacote v3 e executados os testes da etapa afetada.


### PR DESCRIPTION
### Motivation
- Decouple the v3 `persona-routine-materializer` stage from the initial unversioned enriched-niche gateway to avoid accidental cross-version coupling and preserve a clear contract for v3 materialization. 
- Provide a stage-scoped port for the v3 pipeline so the backend can translate v3 payloads into the canonical persistence model without leaking v3 types into shared contracts.

### Description
- Introduced a new interface `PersonaRoutineMaterializerNicheGateway` in `com.marketinghub.oprm.nichocnae.v3.personaroutinematerializer.gateway` that defines `findPersonaRoutineMaterializedNiche` and `materialize` with v3-specific record types. 
- Extended `JpaOprmEnrichedNicheGateway` to implement `PersonaRoutineMaterializerNicheGateway`, adding `findPersonaRoutineMaterializedNiche`, a v3 `materialize` overload and conversion helpers `toOprmNicheDraft` and `toOprmProfileDraft` to translate v3 drafts into the canonical OPRM persistence contracts. 
- Updated `BackendPersonaRoutineMaterializerService` to depend on the new `PersonaRoutineMaterializerNicheGateway` and to call its methods and types instead of the unversioned `OprmEnrichedNicheGateway`. 
- Updated the unit test `BackendPersonaRoutineMaterializerServiceTest` to mock and verify interactions with `PersonaRoutineMaterializerNicheGateway` and adjusted argument captors accordingly. 
- Added an entry to documentation (`docs/registros/oprm1.md`) describing the isolation change and rationale.

### Testing
- Ran the updated unit test `BackendPersonaRoutineMaterializerServiceTest` which verifies materialization behavior and argument mapping, and it passed. 
- The project compiled successfully with the new interface and adapter implementations during the test run.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3db1b249648321bd8da86f42fe4aef)