### PR TITLE
Exibe URL tentada no Ops Monitor

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/opsmonitor/service/OpsMonitorService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/opsmonitor/service/OpsMonitorService.java
@@ -203,7 +203,8 @@ public class OpsMonitorService {
             if (queueIncident.isPresent()) {
                 SyntheticIncident incident = queueIncident.get();
                 return new ModuleAvailabilityResponse(module.getCode(), module.getName(), module.getType(),
-                        module.getCriticality(), "DEGRADED", incident.startedAt(), null, incident.lastError());
+                        module.getCriticality(), "DEGRADED", incident.startedAt(), null, incident.lastError(),
+                        buildAttemptedUrl(module));
             }
         }
         if (OPRM_COLETOR_MEI_MODULE_CODE.equals(module.getCode())) {
@@ -211,15 +212,28 @@ public class OpsMonitorService {
             if (queueIncident.isPresent()) {
                 SyntheticIncident incident = queueIncident.get();
                 return new ModuleAvailabilityResponse(module.getCode(), module.getName(), module.getType(),
-                        module.getCriticality(), "DEGRADED", incident.startedAt(), null, incident.lastError());
+                        module.getCriticality(), "DEGRADED", incident.startedAt(), null, incident.lastError(),
+                        buildAttemptedUrl(module));
             }
         }
         return healthCheckRepository.findTop1ByModuleCodeOrderByCheckedAtDesc(module.getCode())
                 .map(check -> new ModuleAvailabilityResponse(module.getCode(), module.getName(), module.getType(),
                         module.getCriticality(), check.getStatus(), check.getCheckedAt(), check.getResponseTimeMs(),
-                        check.getErrorMessage()))
+                        check.getErrorMessage(), buildAttemptedUrl(module)))
                 .orElseGet(() -> new ModuleAvailabilityResponse(module.getCode(), module.getName(), module.getType(),
-                        module.getCriticality(), "UNKNOWN", null, null, null));
+                        module.getCriticality(), "UNKNOWN", null, null, null, buildAttemptedUrl(module)));
+    }
+
+    /** Monta a URL de healthcheck que o worker deve tentar para o módulo monitorado. */
+    private String buildAttemptedUrl(OpsMonitoredModule module) {
+        String baseUrl = module.getBaseUrl();
+        String healthPath = module.getHealthPath();
+        if (baseUrl == null || baseUrl.isBlank() || healthPath == null || healthPath.isBlank()) {
+            return null;
+        }
+        String normalizedBaseUrl = baseUrl.endsWith("/") ? baseUrl.substring(0, baseUrl.length() - 1) : baseUrl;
+        String normalizedHealthPath = healthPath.startsWith("/") ? healthPath : "/" + healthPath;
+        return normalizedBaseUrl + normalizedHealthPath;
     }
 
     /** Cria incidente sintético quando há fila de GeraLanding parada antes do worker iniciar processamento. */

--- a/backend/ads-service/src/main/java/com/marketinghub/opsmonitor/service/listAvailability/ModuleAvailabilityResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/opsmonitor/service/listAvailability/ModuleAvailabilityResponse.java
@@ -4,4 +4,4 @@ import java.time.Instant;
 
 /** Status atual de disponibilidade de um módulo monitorado. */
 public record ModuleAvailabilityResponse(String moduleCode, String name, String type, String criticality,
-        String status, Instant lastCheckedAt, Long lastResponseTimeMs, String lastError) {}
+        String status, Instant lastCheckedAt, Long lastResponseTimeMs, String lastError, String attemptedUrl) {}

--- a/backend/ads-service/src/test/java/com/marketinghub/opsmonitor/service/OpsMonitorServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/opsmonitor/service/OpsMonitorServiceTest.java
@@ -77,6 +77,8 @@ class OpsMonitorServiceTest {
         criticalWorker.setCode("ai-worker");
         criticalWorker.setName("AI Worker");
         criticalWorker.setType("WORKER");
+        criticalWorker.setBaseUrl("http://191.252.120.96:4567/");
+        criticalWorker.setHealthPath("worker-observability/health");
         criticalWorker.setCriticality("CRITICAL");
 
         OpsMonitoredModule highCollector = new OpsMonitoredModule();
@@ -96,6 +98,7 @@ class OpsMonitorServiceTest {
 
         assertThat(filtered).hasSize(1);
         assertThat(filtered.getFirst().moduleCode()).isEqualTo("ai-worker");
+        assertThat(filtered.getFirst().attemptedUrl()).isEqualTo("http://191.252.120.96:4567/worker-observability/health");
     }
 
     /** Garante que fila antiga de GeraLanding aparece como incidente do AI Worker. */
@@ -168,6 +171,8 @@ class OpsMonitorServiceTest {
         collector.setCode("oprm-coletor-mei");
         collector.setName("OPRM Coletor MEI");
         collector.setType("COLLECTOR");
+        collector.setBaseUrl("http://191.252.181.168");
+        collector.setHealthPath("/actuator/health");
         collector.setCriticality("HIGH");
 
         OprmNichoCnaeV3StageExecution execution = new OprmNichoCnaeV3StageExecution();
@@ -192,6 +197,7 @@ class OpsMonitorServiceTest {
         assertThat(availability.getFirst().moduleCode()).isEqualTo("oprm-coletor-mei");
         assertThat(availability.getFirst().status()).isEqualTo("DEGRADED");
         assertThat(availability.getFirst().lastError()).contains("NichoCNAE v3");
+        assertThat(availability.getFirst().attemptedUrl()).isEqualTo("http://191.252.181.168/actuator/health");
     }
 
     /** Garante que o payload bruto de healthcheck suporta respostas Actuator maiores que 255 caracteres. */

--- a/docs/registros/ops-monitor.md
+++ b/docs/registros/ops-monitor.md
@@ -50,3 +50,8 @@
 - causa-raiz confirmada: o monitor operacional consultava `http://191.252.181.168:4567/worker-observability/health`, mas os logs reais do AI Worker disponíveis pelo MCP apontam o serviço operacional em `http://191.252.120.96:4567/worker-observability/logfile`; por isso o health check registrava `Connection refused` mesmo com o worker ativo.
 - correção aplicada: novo changeset ajusta o cadastro canônico do `ai-worker` no Ops Monitor para `http://191.252.120.96:4567`, preservando `/worker-observability/health` e `/worker-observability/logfile`.
 - prevenção de recorrência: a disponibilidade do menu lateral passa a depender do endpoint de observabilidade do host real do módulo, reduzindo falso alarme de módulo fora do ar quando há execução recente.
+
+## 2026-06-26 — URL tentada visível na tela do Ops Monitor
+- Ajuste: a disponibilidade dos módulos passa a expor a URL completa de healthcheck tentada pelo monitor e a tela `/ops-monitor` mostra essa URL na tabela de status atual.
+- Motivo: reduzir tempo de diagnóstico quando um módulo aparece fora do ar, deixando claro se o problema está no serviço ou no endereço configurado para verificação.
+- Prevenção: testes de backend e frontend cobrem a presença da URL no contrato e na tela.

--- a/docs/swagger/ops-monitor-swagger.yaml
+++ b/docs/swagger/ops-monitor-swagger.yaml
@@ -47,7 +47,14 @@ paths:
           required: false
           schema: { type: string, enum: [BACKEND, WORKER, COLLECTOR, PORTAL, SERVICE] }
       responses:
-        '200': { description: OK }
+        '200':
+          description: OK
+          content:
+            application/json:
+              schema:
+                type: array
+                items:
+                  $ref: '#/components/schemas/ModuleAvailabilityResponse'
   /api/ops-monitor/v1/modules/{moduleCode}/availability-history:
     get:
       summary: Lista histórico de disponibilidade do módulo
@@ -88,3 +95,21 @@ paths:
           schema: { type: string, enum: [BACKEND, WORKER, COLLECTOR, PORTAL, SERVICE] }
       responses:
         '200': { description: OK }
+
+components:
+  schemas:
+    ModuleAvailabilityResponse:
+      type: object
+      properties:
+        moduleCode: { type: string }
+        name: { type: string }
+        type: { type: string }
+        criticality: { type: string }
+        status: { type: string }
+        lastCheckedAt: { type: string, format: date-time, nullable: true }
+        lastResponseTimeMs: { type: integer, format: int64, nullable: true }
+        lastError: { type: string, nullable: true }
+        attemptedUrl:
+          type: string
+          nullable: true
+          description: URL completa de healthcheck que o monitor tenta acessar para o módulo.

--- a/frontend/src/api/useOpsMonitor.ts
+++ b/frontend/src/api/useOpsMonitor.ts
@@ -20,6 +20,7 @@ export interface ModuleAvailability {
   lastCheckedAt?: string | null;
   lastResponseTimeMs?: number | null;
   lastError?: string | null;
+  attemptedUrl?: string | null;
 }
 
 export interface ModuleAvailabilityHistory {

--- a/frontend/src/pages/OpsMonitorPage.test.tsx
+++ b/frontend/src/pages/OpsMonitorPage.test.tsx
@@ -46,6 +46,7 @@ describe("OpsMonitorPage", () => {
               lastCheckedAt: "2026-06-23T10:00:00Z",
               lastResponseTimeMs: null,
               lastError: "timeout",
+              attemptedUrl: "http://191.252.181.168/actuator/health",
             },
           ],
         });
@@ -94,5 +95,8 @@ describe("OpsMonitorPage", () => {
     expect(await screen.findByText("Backend indisponível")).toBeInTheDocument();
     expect(await screen.findByTestId("availability-chart")).toBeInTheDocument();
     expect(await screen.findByText("timeout")).toBeInTheDocument();
+    expect(
+      await screen.findByText("http://191.252.181.168/actuator/health"),
+    ).toBeInTheDocument();
   });
 });

--- a/frontend/src/pages/OpsMonitorPage.tsx
+++ b/frontend/src/pages/OpsMonitorPage.tsx
@@ -358,6 +358,7 @@ export default function OpsMonitorPage() {
                 <th>Última verificação</th>
                 <th>Tempo de resposta</th>
                 <th>Último erro</th>
+                <th>URL tentada</th>
                 <th>Impacto de negócio</th>
               </tr>
             </thead>
@@ -384,6 +385,9 @@ export default function OpsMonitorPage() {
                   <td className="ops-monitor-page__table-error">
                     {module.lastError ?? "Sem erro"}
                   </td>
+                  <td>
+                    <code>{module.attemptedUrl ?? "Sem URL"}</code>
+                  </td>
                   <td className="ops-monitor-page__impact">
                     <AlertTriangle size={14} aria-hidden="true" />{" "}
                     {getImpact(module)}
@@ -392,7 +396,7 @@ export default function OpsMonitorPage() {
               ))}
               {modules.length === 0 ? (
                 <tr>
-                  <td colSpan={7} className="text-center text-muted py-4">
+                  <td colSpan={8} className="text-center text-muted py-4">
                     Nenhum módulo monitorado retornado pelo backend.
                   </td>
                 </tr>


### PR DESCRIPTION
### Motivation
- Reduzir o tempo de diagnóstico quando um módulo aparece como fora do ar, deixando explícito qual URL de healthcheck o monitor tentou acessar. 
- Tornar a informação de verificação (endereço consultado) parte do contrato/API para evitar ambiguidade entre serviço e configuração de observabilidade. 

### Description
- Adiciona o campo `attemptedUrl` ao DTO `ModuleAvailabilityResponse` no backend e popula-o com `baseUrl + healthPath` via o novo método `buildAttemptedUrl(OpsMonitoredModule)`. 
- Faz o backend retornar `attemptedUrl` tanto para checks reais (último heartbeat) quanto para incidentes sintéticos (AI Worker / OPRM stale-queue). 
- Atualiza o frontend: adiciona `attemptedUrl` ao `ModuleAvailability` TypeScript, inclui a coluna "URL tentada" na tabela `/ops-monitor` e ajusta os testes de UI. 
- Atualiza a documentação Swagger (`docs/swagger/ops-monitor-swagger.yaml`) e registra a mudança em `docs/registros/ops-monitor.md`. 

### Testing
- Executado o teste unitário do backend `OpsMonitorServiceTest` com `./mvnw -f ads-service -Dtest=OpsMonitorServiceTest test`, que completou sem falhas observadas. 
- Executado o teste de frontend `src/pages/OpsMonitorPage.test.tsx` com `npm test`, que passou (`vitest` reported 1 test passed). 
- Rodado o typecheck TypeScript com `npm run typecheck` no frontend, sem erros. 
- Observação: tentativa de executar `spotless:apply` no módulo `ads-service` não aplicou porque o plugin Spotless não está configurado naquele módulo (informação operacional).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3dc13d9e388321a636ebf7bc686898)