### PR TITLE
Honor per-stage OpenAI `service_tier`; default Quality Review to `default` and audit the change

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/worker/openai/core/model/OpenAiRequest.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/openai/core/model/OpenAiRequest.java
@@ -11,14 +11,38 @@ public record OpenAiRequest(
         String schemaName,
         String schemaJson,
         String promptMarkdownContent,
-        Map<String, Object> metadata
+        Map<String, Object> metadata,
+        String serviceTier
 ) {
+    /** Mantém compatibilidade com etapas existentes que usam Flex por padrão. */
+    public OpenAiRequest(
+            String model,
+            String prompt,
+            String requestBodyJson,
+            String schemaName,
+            String schemaJson,
+            String promptMarkdownContent,
+            Map<String, Object> metadata
+    ) {
+        this(model, prompt, requestBodyJson, schemaName, schemaJson, promptMarkdownContent, metadata, "flex");
+    }
+
     /** Valida os campos obrigatórios e normaliza metadados opcionais. */
     public OpenAiRequest {
         Objects.requireNonNull(model, "model must not be null");
         Objects.requireNonNull(prompt, "prompt must not be null");
         Objects.requireNonNull(requestBodyJson, "requestBodyJson must not be null");
         Objects.requireNonNull(promptMarkdownContent, "promptMarkdownContent must not be null");
+        serviceTier = normalizeServiceTier(serviceTier);
         metadata = metadata == null ? Map.of() : Map.copyOf(metadata);
+    }
+
+    /** Normaliza o tier OpenAI preservando Flex como padrão seguro das etapas legadas. */
+    private static String normalizeServiceTier(String value) {
+        if (value == null || value.isBlank()) {
+            return "flex";
+        }
+        String normalized = value.trim().toLowerCase();
+        return "standard".equals(normalized) ? "default" : normalized;
     }
 }

--- a/ai-worker/src/main/java/com/marketinghub/worker/openai/core/openai/ResponsesApiOpenAiClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/openai/core/openai/ResponsesApiOpenAiClient.java
@@ -48,19 +48,20 @@ public class ResponsesApiOpenAiClient implements OpenAiClientPort {
                 .build();
     }
 
-    /** Envia o request final em modo flex para a OpenAI e devolve os dados de despacho para auditoria no backend. */
+    /** Envia o request final com o service tier da etapa para a OpenAI e devolve os dados de despacho para auditoria no backend. */
     @Override
     public OpenAiDispatch dispatch(OpenAiRequest request) {
         String originalRequestBodyJson = request.requestBodyJson();
         String marketingHubJobId = marketingHubJobId(request);
         String requestBodyJson = originalRequestBodyJson;
         try {
-            Map<String, Object> requestBody = buildFlexRequestBody(originalRequestBodyJson);
+            Map<String, Object> requestBody = buildServiceTierRequestBody(originalRequestBodyJson, request.serviceTier());
             requestBodyJson = objectMapper.writeValueAsString(requestBody);
             log.info(
-                    "Enviando request final em modo flex para OpenAI Responses API [jobId={}, schemaName={}, requestBodyJson={}]",
+                    "Enviando request final para OpenAI Responses API [jobId={}, schemaName={}, serviceTier={}, requestBodyJson={}]",
                     marketingHubJobId,
                     request.schemaName(),
+                    request.serviceTier(),
                     requestBodyJson);
 
             Map<String, Object> raw = webClient.post()
@@ -125,10 +126,10 @@ public class ResponsesApiOpenAiClient implements OpenAiClientPort {
         }
     }
 
-    /** Monta o payload final da Responses API fixando o processamento OpenAI em service_tier flex. */
-    private Map<String, Object> buildFlexRequestBody(String requestBodyJson) throws JsonProcessingException {
+    /** Monta o payload final da Responses API aplicando o service_tier solicitado pela etapa. */
+    private Map<String, Object> buildServiceTierRequestBody(String requestBodyJson, String serviceTier) throws JsonProcessingException {
         Map<String, Object> requestBody = objectMapper.readValue(requestBodyJson, new TypeReference<>() {});
-        requestBody.put("service_tier", "flex");
+        requestBody.put("service_tier", serviceTier);
         return requestBody;
     }
 

--- a/ai-worker/src/main/java/com/marketinghub/worker/openai/core/qualityreview/QualityReviewPromptBuilder.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/openai/core/qualityreview/QualityReviewPromptBuilder.java
@@ -61,7 +61,8 @@ public class QualityReviewPromptBuilder implements StagePromptBuilder<QualityRev
                 properties.schemaName(),
                 schemaJson,
                 promptMarkdownContent,
-                auditMetadata(execution, screenshots, prompt, requestBodyJson));
+                auditMetadata(execution, screenshots, prompt, requestBodyJson),
+                properties.serviceTier());
     }
 
 
@@ -82,6 +83,8 @@ public class QualityReviewPromptBuilder implements StagePromptBuilder<QualityRev
         audit.put("schemaName", properties.schemaName());
         audit.put("visionModel", properties.visionModel());
         audit.put("imageDetail", properties.imageDetail());
+        audit.put("serviceTier", properties.serviceTier());
+        audit.put("serviceTierJustification", "Quality Review usa processamento default/standard para reduzir indisponibilidade operacional observada no modo Flex em requisições multimodais grandes.");
         audit.put("screenshots", screenshots.stream().map(this::toScreenshotAudit).toList());
 
         Map<String, Object> metadata = new LinkedHashMap<>();

--- a/ai-worker/src/main/java/com/marketinghub/worker/openai/core/qualityreview/QualityReviewWorkerProperties.java
+++ b/ai-worker/src/main/java/com/marketinghub/worker/openai/core/qualityreview/QualityReviewWorkerProperties.java
@@ -21,6 +21,7 @@ public record QualityReviewWorkerProperties(
         @NotBlank String schemaName,
         @NotBlank String visionModel,
         @NotBlank String imageDetail,
+        String serviceTier,
         @NotNull Duration timeout,
         String chromiumExecutablePath,
         @NotNull Duration screenshotTimeout
@@ -40,6 +41,17 @@ public record QualityReviewWorkerProperties(
         }
         if (!List.of("low", "high", "original", "auto").contains(imageDetail)) {
             throw new IllegalArgumentException("qualityreview.worker.image-detail must be one of: low, high, original, auto");
+        }
+        if (serviceTier == null || serviceTier.isBlank()) {
+            serviceTier = "default";
+        } else {
+            serviceTier = serviceTier.trim().toLowerCase();
+        }
+        if ("standard".equals(serviceTier)) {
+            serviceTier = "default";
+        }
+        if (!List.of("default", "flex", "auto", "priority").contains(serviceTier)) {
+            throw new IllegalArgumentException("qualityreview.worker.service-tier must be one of: default, flex, auto, priority");
         }
         if (timeout == null) {
             timeout = Duration.ofMinutes(30);

--- a/ai-worker/src/main/resources/application.properties
+++ b/ai-worker/src/main/resources/application.properties
@@ -116,6 +116,7 @@ qualityreview.worker.schema-resource=${QUALITYREVIEW_WORKER_SCHEMA_RESOURCE:prom
 qualityreview.worker.schema-name=${QUALITYREVIEW_WORKER_SCHEMA_NAME:experiment_pipeline_landing_page_quality_review}
 qualityreview.worker.vision-model=${QUALITYREVIEW_WORKER_VISION_MODEL:gpt-5.5}
 qualityreview.worker.image-detail=${QUALITYREVIEW_WORKER_IMAGE_DETAIL:original}
+qualityreview.worker.service-tier=${QUALITYREVIEW_WORKER_SERVICE_TIER:default}
 qualityreview.worker.timeout=${QUALITYREVIEW_WORKER_TIMEOUT:PT30M}
 qualityreview.worker.chromium-executable-path=${QUALITYREVIEW_WORKER_CHROMIUM_EXECUTABLE_PATH:/usr/bin/chromium}
 qualityreview.worker.screenshot-timeout=${QUALITYREVIEW_WORKER_SCREENSHOT_TIMEOUT:PT2M}

--- a/ai-worker/src/test/java/com/marketinghub/worker/openai/core/openai/ResponsesApiOpenAiClientTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/openai/core/openai/ResponsesApiOpenAiClientTest.java
@@ -97,9 +97,9 @@ class ResponsesApiOpenAiClientTest {
                         .contains("Invalid schema"));
     }
 
-    /** Deve fixar service_tier flex no payload enviado e no despacho auditável do core OpenAI. */
+    /** Deve aplicar o service_tier informado pela etapa no payload enviado e no despacho auditável. */
     @Test
-    void dispatchShouldForceFlexServiceTierInOpenAiPayloadAndDispatch() throws Exception {
+    void dispatchShouldApplyRequestServiceTierInOpenAiPayloadAndDispatch() throws Exception {
         server.enqueue(new MockResponse()
                 .setResponseCode(200)
                 .setHeader("Content-Type", "application/json")
@@ -129,7 +129,8 @@ class ResponsesApiOpenAiClientTest {
                 "schema-wireframe",
                 "{\"type\":\"object\"}",
                 "# Prompt markdown bruto",
-                Map.of("idJob", "job-123"));
+                Map.of("idJob", "job-123"),
+                "default");
 
         var dispatch = client.dispatch(request);
 
@@ -139,11 +140,11 @@ class ResponsesApiOpenAiClientTest {
         assertThat(sentPayload)
                 .containsEntry("model", "gpt-test")
                 .containsEntry("input", "Prompt")
-                .containsEntry("service_tier", "flex");
+                .containsEntry("service_tier", "default");
         Map<String, Object> dispatchPayload = new ObjectMapper().readValue(
                 dispatch.requestBodyJson(),
                 new TypeReference<>() {});
-        assertThat(dispatchPayload).containsEntry("service_tier", "flex");
+        assertThat(dispatchPayload).containsEntry("service_tier", "default");
     }
 
     /** Deve estimar custo em modo flex pelo modelo do request quando a configuração não informa tarifa explícita. */

--- a/ai-worker/src/test/java/com/marketinghub/worker/openai/core/qualityreview/QualityReviewBackendClientTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/openai/core/qualityreview/QualityReviewBackendClientTest.java
@@ -125,6 +125,7 @@ class QualityReviewBackendClientTest {
                 "experiment_pipeline_landing_page_quality_review",
                 "gpt-5.5",
                 "original",
+                "default",
                 Duration.ofSeconds(5),
                 "/usr/bin/chromium",
                 Duration.ofSeconds(5));

--- a/ai-worker/src/test/java/com/marketinghub/worker/openai/core/qualityreview/QualityReviewPromptBuilderTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/openai/core/qualityreview/QualityReviewPromptBuilderTest.java
@@ -78,11 +78,13 @@ class QualityReviewPromptBuilderTest {
                 .doesNotContain("https://cdn.example.com/asset-hero.jpg");
         assertThat(body.get("model")).isEqualTo("gpt-5.5");
         assertThat(request.model()).isEqualTo("gpt-5.5");
+        assertThat(request.serviceTier()).isEqualTo("default");
         assertThat(request.metadata()).containsKeys("qualityReviewAudit", "idJob", "experimentId");
         Map<String, Object> audit = (Map<String, Object>) request.metadata().get("qualityReviewAudit");
         assertThat(audit)
                 .containsEntry("landingHtmlLength", 48)
                 .containsEntry("imageDetail", "original")
+                .containsEntry("serviceTier", "default")
                 .containsEntry("visionModel", "gpt-5.5");
         assertThat((List<Map<String, Object>>) audit.get("screenshots"))
                 .extracting(item -> item.get("sha256"))
@@ -101,6 +103,7 @@ class QualityReviewPromptBuilderTest {
                 "experiment_pipeline_landing_page_quality_review",
                 "gpt-5.5",
                 "original",
+                "default",
                 Duration.ofSeconds(5),
                 "/usr/bin/chromium",
                 Duration.ofSeconds(5));

--- a/ai-worker/src/test/java/com/marketinghub/worker/openai/core/qualityreview/QualityReviewWorkerPropertiesTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/openai/core/qualityreview/QualityReviewWorkerPropertiesTest.java
@@ -21,10 +21,12 @@ class QualityReviewWorkerPropertiesTest {
                 "experiment_pipeline_landing_page_quality_review",
                 "gpt-5.5",
                 "original",
+                null,
                 Duration.ofMinutes(30),
                 "/usr/bin/chromium",
                 null);
 
         assertThat(properties.screenshotTimeout()).isEqualTo(Duration.ofMinutes(2));
+        assertThat(properties.serviceTier()).isEqualTo("default");
     }
 }

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -1,3 +1,10 @@
+## 2026-06-26 — GeraLanding Quality Review em processamento default/standard da OpenAI
+
+- solicitação: testar a etapa `landing-page-quality-review` fora do modo Flex após falhas repetidas `HTTP 429 rate_limit_exceeded` em requisições multimodais grandes.
+- causa-raiz operacional provável: a revisão visual envia HTML final completo, schema estrito e screenshots mobile/desktop; no Flex, a OpenAI pode ficar temporariamente indisponível para esse tipo de carga e o worker marcava a tentativa como falha.
+- foi feito: a etapa Quality Review passou a declarar `service_tier=default` no request OpenAI, com configuração própria `QUALITYREVIEW_WORKER_SERVICE_TIER`, mantendo Flex como padrão das demais etapas do core.
+- prevenção de recorrência: o tier efetivo e a justificativa da exceção ficam auditados nos metadados da etapa, permitindo comparar novas tentativas com o histórico de falhas Flex.
+
 ## 2026-06-25 — Remoção do card final de hipóteses no detalhe do nicho
 
 - Solicitação: retirar o card de hipóteses duplicado no final da tela de detalhe do nicho, mantendo o novo card do início como ponto único de consulta.

--- a/docs/registros/loops.md
+++ b/docs/registros/loops.md
@@ -451,7 +451,7 @@ Quando houver divergência entre tentativa antiga e correção efetiva, a corre�
 - **Sintomas recorrentes**:
   - custo aparece `$0.00` apesar de tokens retornados;
   - modelo da etapa não aparece na tela;
-  - request auditado não mostra `service_tier=flex`;
+  - request auditado não mostra o `service_tier` efetivo da etapa;
   - Worker AI usa preço hardcoded ou propriedade zerada;
   - modelo configurado em `/pipelines` não chega à execução.
 - **Causa-raiz sistêmica provável**:
@@ -469,7 +469,8 @@ Quando houver divergência entre tentativa antiga e correção efetiva, a corre�
   - modelo por etapa vindo do pipeline/catálogo;
   - fallback default explícito por tipo de artefato;
   - custo calculado via backend/catalogo `openai_model`;
-  - request auditável sempre com `service_tier=flex`;
+  - request auditável sempre com o `service_tier` efetivo da etapa;
+  - exceções ao Flex, como Quality Review em processamento default/standard por indisponibilidade operacional do Flex em requisições multimodais grandes, devem registrar justificativa funcional no fluxo;
   - UI mostra modelo, modo, preço e custo acumulado.
 - **Regra preventiva**:
   - nenhuma etapa OpenAI deve persistir execução sem modelo efetivo, tokens e regra de preço identificável.


### PR DESCRIPTION
### Motivation
- Prevent repeated OpenAI `429 rate_limit_exceeded` errors for Quality Review multimodal requests by allowing stages to request a non-Flex `service_tier` while keeping Flex as the worker core default.
- Make the effective OpenAI `service_tier` visible in audit metadata so operational investigations can correlate failures with tier choice.
- Provide a safe default and backward-compatible behavior for existing code that constructs `OpenAiRequest` without the new field.

### Description
- Added `serviceTier` to the `OpenAiRequest` record and a backward-compatible constructor that defaults missing values to `"flex"`, and normalized values via `normalizeServiceTier` (maps `standard` -> `default`).
- Modified `ResponsesApiOpenAiClient` to apply `request.serviceTier()` when building the Responses API payload and to log the `serviceTier` in request/audit messages; refactored `buildFlexRequestBody` into `buildServiceTierRequestBody`.
- Extended `QualityReviewPromptBuilder` to pass the worker `serviceTier` into `OpenAiRequest` and to store `serviceTier` and a human `serviceTierJustification` inside the quality review audit metadata.
- Added `serviceTier` to `QualityReviewWorkerProperties` with normalization, allowed-value validation (`default`, `flex`, `auto`, `priority`), and a default of `"default"` when unset; exposed `QUALITYREVIEW_WORKER_SERVICE_TIER` in `application.properties`.
- Updated docs (`docs/registros/experimentos.md`, `docs/registros/loops.md`) to record the operational rationale and the expectation that audits include the effective `service_tier`.
- Updated unit tests and test fixtures to assert the new `service_tier` behavior across `ResponsesApiOpenAiClientTest`, `QualityReviewPromptBuilderTest`, `QualityReviewWorkerPropertiesTest`, and `QualityReviewBackendClientTest`.

### Testing
- Ran unit tests `ResponsesApiOpenAiClientTest`, `QualityReviewPromptBuilderTest`, `QualityReviewWorkerPropertiesTest`, and `QualityReviewBackendClientTest`, all of which passed locally. 
- Verified the request payload sent to the mocked OpenAI server contains the configured `service_tier` and that the dispatch/audit payload preserves the same value.
- Confirmed validation in `QualityReviewWorkerProperties` enforces allowed `service_tier` values and defaults to `"default"` when unset.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3dc284d54083219e1d785c97e1e63f)