### PR TITLE
Add OpenAI service tier display and improve request body parsing

### DIFF
--- a/frontend/src/pages/experiment/ExperimentGeraLandingExecutionDetailPage.tsx
+++ b/frontend/src/pages/experiment/ExperimentGeraLandingExecutionDetailPage.tsx
@@ -16,16 +16,31 @@ function formatDateTime(value?: string) {
   });
 }
 
-function extractModelFromRequestBody(raw?: string) {
-  if (!raw) return "—";
+function parseOpenAiRequestBody(raw?: string) {
+  if (!raw) return null;
   try {
-    const parsed = JSON.parse(raw);
-    return typeof parsed?.model === "string" && parsed.model.trim()
-      ? parsed.model
-      : "—";
+    return JSON.parse(raw) as Record<string, unknown>;
   } catch {
-    return "—";
+    return null;
   }
+}
+
+function extractModelFromRequestBody(raw?: string) {
+  const parsed = parseOpenAiRequestBody(raw);
+  return typeof parsed?.model === "string" && parsed.model.trim()
+    ? parsed.model
+    : "—";
+}
+
+function formatOpenAiServiceTier(raw?: string) {
+  const parsed = parseOpenAiRequestBody(raw);
+  const serviceTier =
+    typeof parsed?.service_tier === "string" ? parsed.service_tier.trim() : "";
+
+  if (!serviceTier || serviceTier === "default") return "Standard";
+  if (serviceTier === "flex") return "Flex";
+
+  return serviceTier;
 }
 
 export interface QualityReviewSentScreenshot {
@@ -239,6 +254,9 @@ export default function ExperimentGeraLandingExecutionDetailPage() {
   const modelUsed = extractModelFromRequestBody(
     detailQuery.data?.openAiRequestBody,
   );
+  const openAiMode = formatOpenAiServiceTier(
+    detailQuery.data?.openAiRequestBody,
+  );
   const provisionalHtml = detailQuery.data?.provisionalHtml?.trim() ?? "";
   const errorFileContent = extractErrorFileContent(
     detailQuery.data?.errorDetail,
@@ -418,6 +436,9 @@ export default function ExperimentGeraLandingExecutionDetailPage() {
                 </div>
                 <div className="col-md-6">
                   <strong>Modelo usado:</strong> {modelUsed}
+                </div>
+                <div className="col-md-6">
+                  <strong>Modo:</strong> {openAiMode}
                 </div>
                 <div className="col-md-6">
                   <strong>Criado em:</strong>{" "}


### PR DESCRIPTION
### Motivation
- Expose the OpenAI service tier (mode) in the experiment execution detail UI and make request-body handling more robust when inspecting OpenAI payloads.
- Replace brittle JSON-to-model extraction with a reusable parser to support additional fields in the future.

### Description
- Added `parseOpenAiRequestBody` to parse the raw `openAiRequestBody` into a `Record<string, unknown>` or return `null` on failure.
- Reworked `extractModelFromRequestBody` to use `parseOpenAiRequestBody` and return the model string or `"—"` as a fallback.
- Added `formatOpenAiServiceTier` to derive a human-friendly `Modo` value from the `service_tier` field and added an `openAiMode` variable to render a new `Modo` column in the UI.
- Kept existing behavior for non-JSON or missing fields by returning safe fallbacks.

### Testing
- No automated tests were run for this change.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3dcd340ff0832198c0ce35e4a143d7)