### PR TITLE
Corrige hosts do Ops Monitor para Facebook Ads e OPRM MEI

### DIFF
--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-26-ops-monitor-facebook-oprm-hosts.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-26-ops-monitor-facebook-oprm-hosts.yaml
@@ -1,0 +1,26 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-06-26-ops-monitor-010-facebook-oprm-hosts
+      author: marketing-hub
+      preConditions:
+        - onFail: MARK_RAN
+        - dbms:
+            type: mysql
+        - tableExists:
+            tableName: ops_monitored_module
+      changes:
+        - sql:
+            splitStatements: true
+            stripComments: true
+            sql: |
+              UPDATE ops_monitored_module
+              SET base_url = 'http://191.252.120.96:8082',
+                  health_path = '/worker-observability/health',
+                  log_path = '/worker-observability/logfile'
+              WHERE code = 'facebook-ads-worker';
+
+              UPDATE ops_monitored_module
+              SET base_url = 'http://191.252.120.96:8094',
+                  health_path = '/actuator/health',
+                  log_path = '/actuator/logfile'
+              WHERE code = 'oprm-coletor-mei';

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -1106,6 +1106,9 @@ databaseChangeLog:
   - include:
       file: changesets/2026-06-25-ops-monitor-ai-worker-host.yaml
       relativeToChangelogFile: true
+  - include:
+      file: changesets/2026-06-26-ops-monitor-facebook-oprm-hosts.yaml
+      relativeToChangelogFile: true
 
   - include:
       file: changesets/2026-06-24-mois-sales-library-geralanding-insights.yaml

--- a/docs/ops-monitor/arquitetura.md
+++ b/docs/ops-monitor/arquitetura.md
@@ -38,7 +38,7 @@ A fase 4 expande a lista operacional para incluir OPRM, coletores MOIS, Lead Por
 
 O `ops-monitor-worker` roda em container Docker, mas deve acessar os módulos monitorados sempre pela URL pública oficial cadastrada no backend, nunca por atalhos internos como `host.docker.internal`. O objetivo do monitor é refletir a disponibilidade real percebida pelos demais módulos e operadores fora do container local; se a URL pública estiver indisponível, o módulo deve aparecer como indisponível mesmo que responda por rota interna do host.
 
-A configuração de módulos monitorados mantém o backend principal em `http://191.252.181.168`, pois ele responde pela porta 80; os demais módulos com portas dedicadas também devem usar a URL pública oficial com a porta publicada correspondente no contrato entregue ao worker.
+A configuração de módulos monitorados mantém o backend principal em `http://191.252.181.168`, pois ele responde pela porta 80; os demais módulos com portas dedicadas devem usar a URL pública oficial do host onde o módulo está realmente publicado com a porta correspondente no contrato entregue ao worker. Em 26/06/2026, `ai-worker`, `facebook-ads-worker` e `oprm-coletor-mei` usam o host operacional `191.252.120.96`.
 
 ## Correção de persistência do heartbeat do backend — 2026-06-25
 

--- a/docs/registros/ops-monitor.md
+++ b/docs/registros/ops-monitor.md
@@ -55,3 +55,9 @@
 - Ajuste: a disponibilidade dos módulos passa a expor a URL completa de healthcheck tentada pelo monitor e a tela `/ops-monitor` mostra essa URL na tabela de status atual.
 - Motivo: reduzir tempo de diagnóstico quando um módulo aparece fora do ar, deixando claro se o problema está no serviço ou no endereço configurado para verificação.
 - Prevenção: testes de backend e frontend cobrem a presença da URL no contrato e na tela.
+
+## 2026-06-26 — Correção dos hosts monitorados de Facebook Ads e OPRM MEI
+- Problema observado: a tela `/ops-monitor` marcava `facebook-ads-worker` e `oprm-coletor-mei` como fora do ar porque os health checks estavam sendo feitos no host `191.252.181.168`.
+- Causa-raiz confirmada pela URL tentada exibida na própria tela: esses dois módulos estão publicados no host operacional `191.252.120.96`, mantendo as portas `8082` para Facebook Ads e `8094` para OPRM MEI.
+- Correção aplicada: novo changeset ajusta o cadastro canônico do Ops Monitor para `http://191.252.120.96:8082/worker-observability/health` e `http://191.252.120.96:8094/actuator/health`.
+- Prevenção de recorrência: o endereço real fica versionado no Liquibase e registrado no histórico operacional do monitor.


### PR DESCRIPTION
### Motivation
- The Ops Monitor was checking health for `facebook-ads-worker` and `oprm-coletor-mei` against the wrong host (`191.252.181.168`), causing false `OFFLINE` status in the UI. 
- Update must persist the correct public host (`191.252.120.96`) and ports in the canonical DB seeding so the monitor and operators see the real availability.

### Description
- Added a Liquibase changeset `backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-26-ops-monitor-facebook-oprm-hosts.yaml` that updates `ops_monitored_module` for `facebook-ads-worker` and `oprm-coletor-mei` to use `http://191.252.120.96:8082` and `http://191.252.120.96:8094` respectively with the correct health and log paths. 
- Included the new changeset in the master changelog `backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml` with `relativeToChangelogFile: true`. 
- Updated documentation to record the cause and remediation in `docs/registros/ops-monitor.md` and clarified the architecture note in `docs/ops-monitor/arquitetura.md` to reference the actual host used by these modules. 

### Testing
- Ran the unit test `OpsMonitorServiceTest` with `cd backend/ads-service && mvn -Dtest=OpsMonitorServiceTest test` and it passed. 
- Performed textual validation of the new changeset with `python3` checks to confirm required keys and URLs are present and it passed. 
- Verified changelog includes are `relativeToChangelogFile: true` using `rg`/`awk` checks and ran `git diff --check` for basic whitespace/errors, all succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3dd1cb7ec48321a6da6df2e21a708a)