### PR TITLE
Fix Ops Monitor hosts for MOIS Sales Library Worker and Email Service

### DIFF
--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-26-ops-monitor-mois-email-hosts.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-26-ops-monitor-mois-email-hosts.yaml
@@ -1,0 +1,26 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-06-26-ops-monitor-011-mois-email-hosts
+      author: marketing-hub
+      preConditions:
+        - onFail: MARK_RAN
+        - dbms:
+            type: mysql
+        - tableExists:
+            tableName: ops_monitored_module
+      changes:
+        - sql:
+            splitStatements: true
+            stripComments: true
+            sql: |
+              UPDATE ops_monitored_module
+              SET base_url = 'http://191.252.120.96:8097',
+                  health_path = '/actuator/health',
+                  log_path = '/actuator/logfile'
+              WHERE code = 'mois-sales-library-worker';
+
+              UPDATE ops_monitored_module
+              SET base_url = 'http://191.252.120.96:8086',
+                  health_path = '/ops-email-gateway-7xk9/health',
+                  log_path = '/ops-email-gateway-7xk9/email-service-audit-log'
+              WHERE code = 'email-service';

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -1109,6 +1109,9 @@ databaseChangeLog:
   - include:
       file: changesets/2026-06-26-ops-monitor-facebook-oprm-hosts.yaml
       relativeToChangelogFile: true
+  - include:
+      file: changesets/2026-06-26-ops-monitor-mois-email-hosts.yaml
+      relativeToChangelogFile: true
 
   - include:
       file: changesets/2026-06-24-mois-sales-library-geralanding-insights.yaml

--- a/docs/ops-monitor/arquitetura.md
+++ b/docs/ops-monitor/arquitetura.md
@@ -38,7 +38,7 @@ A fase 4 expande a lista operacional para incluir OPRM, coletores MOIS, Lead Por
 
 O `ops-monitor-worker` roda em container Docker, mas deve acessar os módulos monitorados sempre pela URL pública oficial cadastrada no backend, nunca por atalhos internos como `host.docker.internal`. O objetivo do monitor é refletir a disponibilidade real percebida pelos demais módulos e operadores fora do container local; se a URL pública estiver indisponível, o módulo deve aparecer como indisponível mesmo que responda por rota interna do host.
 
-A configuração de módulos monitorados mantém o backend principal em `http://191.252.181.168`, pois ele responde pela porta 80; os demais módulos com portas dedicadas devem usar a URL pública oficial do host onde o módulo está realmente publicado com a porta correspondente no contrato entregue ao worker. Em 26/06/2026, `ai-worker`, `facebook-ads-worker` e `oprm-coletor-mei` usam o host operacional `191.252.120.96`.
+A configuração de módulos monitorados mantém o backend principal em `http://191.252.181.168`, pois ele responde pela porta 80; os demais módulos com portas dedicadas devem usar a URL pública oficial do host onde o módulo está realmente publicado com a porta correspondente no contrato entregue ao worker. Em 26/06/2026, `ai-worker`, `facebook-ads-worker`, `oprm-coletor-mei`, `mois-sales-library-worker` e `email-service` usam o host operacional `191.252.120.96`.
 
 ## Correção de persistência do heartbeat do backend — 2026-06-25
 

--- a/docs/registros/ops-monitor.md
+++ b/docs/registros/ops-monitor.md
@@ -61,3 +61,9 @@
 - Causa-raiz confirmada pela URL tentada exibida na própria tela: esses dois módulos estão publicados no host operacional `191.252.120.96`, mantendo as portas `8082` para Facebook Ads e `8094` para OPRM MEI.
 - Correção aplicada: novo changeset ajusta o cadastro canônico do Ops Monitor para `http://191.252.120.96:8082/worker-observability/health` e `http://191.252.120.96:8094/actuator/health`.
 - Prevenção de recorrência: o endereço real fica versionado no Liquibase e registrado no histórico operacional do monitor.
+
+## 2026-06-26 — Correção dos hosts do MOIS Sales Library Worker e Email Service
+
+- Problema observado: a tela `/ops-monitor` marcava `mois-sales-library-worker` e `email-service` como fora do ar porque os health checks estavam cadastrados em `http://191.252.181.168:8097` e `http://191.252.181.168:8086`.
+- Causa-raiz confirmada pelo workflow de deploy e pelo banco via MCP: os dois módulos são publicados pelo GitHub Actions no host operacional `191.252.120.96`, enquanto o cadastro canônico do Ops Monitor ainda apontava para o host antigo/incorreto `191.252.181.168`.
+- Correção aplicada: novo changeset ajusta o cadastro canônico para `http://191.252.120.96:8097/actuator/health` e `http://191.252.120.96:8086/ops-email-gateway-7xk9/health`.


### PR DESCRIPTION
### Motivation

- The Ops Monitor was reporting `mois-sales-library-worker` and `email-service` as offline because their canonical `base_url` entries pointed to the old host `191.252.181.168` while the deployment workflows publish those services to `191.252.120.96`.
- Aligning the Ops Monitor configuration to the actual deploy host prevents false offline alerts and speeds operational diagnosis.

### Description

- Added a Liquibase changeset `backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-26-ops-monitor-mois-email-hosts.yaml` that updates `ops_monitored_module` for `mois-sales-library-worker` to `http://191.252.120.96:8097` and `email-service` to `http://191.252.120.96:8086` including appropriate `health_path` and `log_path` changes.
- Included the new changeset in the master changelog (`backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml`) with `relativeToChangelogFile: true` to follow the Liquibase include convention.
- Updated documentation in `docs/ops-monitor/arquitetura.md` and `docs/registros/ops-monitor.md` to record the cause, the correction and the operational host for these modules.

### Testing

- Ran a Python include-check script to validate that all `include` items in the master changelog have `relativeToChangelogFile: true`, and it passed.
- Executed `mvn -B test -DskipTests` to verify the module builds and resource processing, and the command completed successfully.
- Ran the Ops Monitor unit tests with `mvn -B -Dtest=com.marketinghub.opsmonitor.service.OpsMonitorServiceTest test`, which executed 6 tests with 0 failures.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3ddcafa0488321a8ea90bed94f465c)