### PR TITLE
Require user confirmation before finalizing NichoCNAE v3 materialization

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/progress/controller/BackendNichoCnaeV3ProgressController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/progress/controller/BackendNichoCnaeV3ProgressController.java
@@ -4,6 +4,7 @@ import com.marketinghub.oprm.nichocnae.v3.progress.service.BackendNichoCnaeV3Pro
 import com.marketinghub.oprm.nichocnae.v3.progress.service.NichoCnaeV3JobProgressResponse;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -22,5 +23,11 @@ public class BackendNichoCnaeV3ProgressController {
     @GetMapping
     public NichoCnaeV3JobProgressResponse latestByCnae(@PathVariable String cnaeCode) {
         return service.latestByCnae(cnaeCode);
+    }
+
+    /** Confirma a revisão exibida na tela e libera a etapa final do pipeline. */
+    @PostMapping("/confirm-finalization")
+    public void confirmFinalization(@PathVariable String cnaeCode) {
+        service.confirmFinalization(cnaeCode);
     }
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/progress/service/BackendNichoCnaeV3ProgressService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/progress/service/BackendNichoCnaeV3ProgressService.java
@@ -1,40 +1,124 @@
 package com.marketinghub.oprm.nichocnae.v3.progress.service;
 
+import com.fasterxml.jackson.databind.JsonNode;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marketinghub.oprm.nichocnae.v3.OprmNichoCnaeV3StageExecution;
+import com.marketinghub.oprm.nichocnae.v3.OprmNichoCnaeV3StageExecutionStatus;
+import com.marketinghub.oprm.nichocnae.v3.personaroutinematerializer.gateway.PersonaRoutineMaterializerNicheGateway;
+import com.marketinghub.oprm.nichocnae.v3.personaroutinematerializer.service.BackendPersonaRoutineMaterializerService;
 import com.marketinghub.repository.jpa.oprm.nichocnae.v3.OprmNichoCnaeV3StageExecutionRepository;
 import java.util.List;
+import java.util.Locale;
 import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+import org.springframework.web.server.ResponseStatusException;
+import org.springframework.http.HttpStatus;
 
 /** Consulta o progresso persistido do pipeline NichoCNAE v3 sem inferir execução no frontend. */
 @Service
 public class BackendNichoCnaeV3ProgressService {
+    private static final String QUALITY_GATE_STAGE = "quality-gate";
+    private static final String FINAL_STAGE = "persona-routine-materializer";
     private final OprmNichoCnaeV3StageExecutionRepository repository;
+    private final PersonaRoutineMaterializerNicheGateway nicheGateway;
+    private final BackendPersonaRoutineMaterializerService materializerService;
+    private final ObjectMapper objectMapper;
 
-    /** Inicializa o service com o repository canônico de execuções v3. */
-    public BackendNichoCnaeV3ProgressService(OprmNichoCnaeV3StageExecutionRepository repository) {
+    /** Inicializa o service com dependências canônicas de progresso, prévia e confirmação v3. */
+    public BackendNichoCnaeV3ProgressService(
+            OprmNichoCnaeV3StageExecutionRepository repository,
+            PersonaRoutineMaterializerNicheGateway nicheGateway,
+            BackendPersonaRoutineMaterializerService materializerService,
+            ObjectMapper objectMapper) {
         this.repository = repository;
+        this.nicheGateway = nicheGateway;
+        this.materializerService = materializerService;
+        this.objectMapper = objectMapper;
     }
 
     /** Retorna o job mais recente do CNAE com suas etapas persistidas em ordem de criação. */
     public NichoCnaeV3JobProgressResponse latestByCnae(String cnaeCode) {
         return repository.findTop1ByCnaeCodeAndStageCodeOrderByCreatedAtDesc(cnaeCode, "cnae-intake")
-                .map(latest -> new NichoCnaeV3JobProgressResponse(
-                        latest.getJobId(),
-                        latest.getCnaeCode(),
-                        repository.findByJobIdOrderByCreatedAtAsc(latest.getJobId()).stream()
-                                .map(this::toStage)
-                                .toList()))
-                .orElseGet(() -> new NichoCnaeV3JobProgressResponse(null, cnaeCode, List.of()));
+                .map(latest -> {
+                    List<OprmNichoCnaeV3StageExecution> executions = repository.findByJobIdOrderByCreatedAtAsc(latest.getJobId());
+                    return new NichoCnaeV3JobProgressResponse(
+                            latest.getJobId(),
+                            latest.getCnaeCode(),
+                            executions.stream().map(this::toStage).toList(),
+                            buildFinalizationReview(latest.getJobId(), executions));
+                })
+                .orElseGet(() -> new NichoCnaeV3JobProgressResponse(null, cnaeCode, List.of(), null));
+    }
+
+    /** Confirma manualmente a materialização e libera a etapa final do job. */
+    public void confirmFinalization(String cnaeCode) {
+        OprmNichoCnaeV3StageExecution latest = repository.findTop1ByCnaeCodeAndStageCodeOrderByCreatedAtDesc(cnaeCode, "cnae-intake")
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Job v3 não encontrado para este CNAE."));
+        OprmNichoCnaeV3StageExecution qualityGate = repository.findByJobIdAndStageCode(latest.getJobId(), QUALITY_GATE_STAGE)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.CONFLICT, "Quality gate ainda não foi concluído."));
+        if (qualityGate.getStatus() != OprmNichoCnaeV3StageExecutionStatus.COMPLETED) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, "Quality gate ainda não foi concluído.");
+        }
+        if (!repository.existsByJobIdAndStageCode(latest.getJobId(), FINAL_STAGE)) {
+            materializerService.create(latest.getJobId(), latest.getCnaeCode(), qualityGate.getOutputPayload(), qualityGate.getAttemptNumber(), qualityGate.getKnowledgeVersion());
+        }
+    }
+
+    /** Monta a revisão final quando a etapa 9 terminou e a etapa 10 ainda aguarda confirmação. */
+    private NichoCnaeV3FinalizationReviewResponse buildFinalizationReview(String jobId, List<OprmNichoCnaeV3StageExecution> executions) {
+        OprmNichoCnaeV3StageExecution qualityGate = executions.stream().filter(e -> QUALITY_GATE_STAGE.equals(e.getStageCode())).findFirst().orElse(null);
+        boolean hasFinalStage = executions.stream().anyMatch(e -> FINAL_STAGE.equals(e.getStageCode()));
+        if (qualityGate == null || qualityGate.getStatus() != OprmNichoCnaeV3StageExecutionStatus.COMPLETED || hasFinalStage) {
+            return null;
+        }
+        JsonNode output = parseOutput(qualityGate.getOutputPayload());
+        String cnaeDescription = textOrDefault(firstText(output, "cnaeDescription", "marketDescription", "description"), "CNAE " + qualityGate.getCnaeCode());
+        String targetName = "CNAE " + qualityGate.getCnaeCode() + " — " + cnaeDescription;
+        Long existingId = nicheGateway.findPersonaRoutineMaterializedNiche(qualityGate.getCnaeCode(), targetName.trim().toLowerCase(Locale.ROOT))
+                .map(PersonaRoutineMaterializerNicheGateway.MarketNicheSnapshot::marketNicheId).orElse(null);
+        return new NichoCnaeV3FinalizationReviewResponse(
+                true,
+                qualityGate.getId(),
+                existingId == null ? "CREATE_NEW" : "REUSE_EXISTING",
+                existingId,
+                targetName,
+                buildNicheInformation(output, cnaeDescription),
+                buildEnrichedInformation(output, qualityGate.getOutputPayload()));
     }
 
     /** Converte a entidade persistida em contrato de progresso para a UI. */
     private NichoCnaeV3StageProgressResponse toStage(OprmNichoCnaeV3StageExecution execution) {
-        return new NichoCnaeV3StageProgressResponse(
-                execution.getId(),
-                execution.getStageCode(),
-                execution.getStatus().name(),
-                execution.getCreatedAt(),
-                execution.getUpdatedAt(),
-                execution.getErrorMessage());
+        return new NichoCnaeV3StageProgressResponse(execution.getId(), execution.getStageCode(), execution.getStatus().name(), execution.getCreatedAt(), execution.getUpdatedAt(), execution.getErrorMessage());
+    }
+
+    /** Converte JSON funcional ou payload livre para leitura da prévia. */
+    private JsonNode parseOutput(String outputPayload) {
+        if (!StringUtils.hasText(outputPayload)) return objectMapper.createObjectNode();
+        try { return objectMapper.readTree(outputPayload); } catch (java.io.IOException ex) { return objectMapper.createObjectNode().put("raw", outputPayload); }
+    }
+
+    /** Retorna o primeiro campo textual disponível no payload. */
+    private String firstText(JsonNode root, String... fieldNames) {
+        for (String fieldName : fieldNames) {
+            JsonNode value = root.path(fieldName);
+            if (!value.isMissingNode() && !value.isNull()) {
+                String text = value.isTextual() ? value.asText() : value.toString();
+                if (StringUtils.hasText(text)) return text.trim();
+            }
+        }
+        return null;
+    }
+
+    /** Retorna texto padrão quando o campo não está disponível. */
+    private String textOrDefault(String value, String defaultValue) { return StringUtils.hasText(value) ? value.trim() : defaultValue; }
+
+    /** Monta resumo do nicho base encontrado antes da materialização. */
+    private String buildNicheInformation(JsonNode output, String cnaeDescription) {
+        return "Descrição CNAE: " + cnaeDescription + "\n\nRotina observada: " + textOrDefault(firstText(output, "routineSummary", "routine", "rotina"), "Não informada.") + "\n\nTarefas diárias: " + textOrDefault(firstText(output, "personaDailyTasks", "dailyTasks", "tarefasDiarias", "tasks"), "Não informadas.");
+    }
+
+    /** Monta resumo do perfil enriquecido encontrado antes da materialização. */
+    private String buildEnrichedInformation(JsonNode output, String fallback) {
+        return "Persona: " + textOrDefault(firstText(output, "personaSummary", "persona"), "Não informada.") + "\n\nEvidências: " + textOrDefault(firstText(output, "evidenceSummary", "evidences"), fallback) + "\n\nGatilhos comerciais: " + textOrDefault(firstText(output, "commercialTriggers", "triggers"), "Não informados.") + "\n\nObjeções: " + textOrDefault(firstText(output, "objections"), "Não informadas.");
     }
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/progress/service/NichoCnaeV3FinalizationReviewResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/progress/service/NichoCnaeV3FinalizationReviewResponse.java
@@ -1,0 +1,11 @@
+package com.marketinghub.oprm.nichocnae.v3.progress.service;
+
+/** Representa a conferência manual exigida antes da etapa final do pipeline NichoCNAE v3. */
+public record NichoCnaeV3FinalizationReviewResponse(
+        boolean requiresConfirmation,
+        Long qualityGateStageExecutionId,
+        String materializationMode,
+        Long targetMarketNicheId,
+        String targetNicheName,
+        String nicheInformation,
+        String enrichedNicheInformation) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/progress/service/NichoCnaeV3JobProgressResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/progress/service/NichoCnaeV3JobProgressResponse.java
@@ -3,4 +3,4 @@ package com.marketinghub.oprm.nichocnae.v3.progress.service;
 import java.util.List;
 
 /** Representa o progresso do job mais recente de um CNAE no pipeline NichoCNAE v3. */
-public record NichoCnaeV3JobProgressResponse(String jobId, String cnaeCode, List<NichoCnaeV3StageProgressResponse> stages) {}
+public record NichoCnaeV3JobProgressResponse(String jobId, String cnaeCode, List<NichoCnaeV3StageProgressResponse> stages, NichoCnaeV3FinalizationReviewResponse finalizationReview) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/shared/OprmNichoCnaeV3StageServiceSupport.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/shared/OprmNichoCnaeV3StageServiceSupport.java
@@ -72,7 +72,8 @@ public abstract class OprmNichoCnaeV3StageServiceSupport {
     /** Cria a próxima pendência quando o backend reconhecer avanço sequencial válido. */
     private void createNextStageWhenAllowed(OprmNichoCnaeV3StageExecution current, String outputPayload, String nextStageCode) {
         String normalizedNextStage = nextStageCode == null ? "" : nextStageCode.trim();
-        if (!isAllowedNextStage(normalizedNextStage)
+        if (requiresUserConfirmation(current, normalizedNextStage)
+                || !isAllowedNextStage(normalizedNextStage)
                 || repository.existsByJobIdAndStageCode(current.getJobId(), normalizedNextStage)) {
             return;
         }
@@ -84,6 +85,11 @@ public abstract class OprmNichoCnaeV3StageServiceSupport {
         next.setAttemptNumber(current.getAttemptNumber());
         next.setKnowledgeVersion(current.getKnowledgeVersion());
         repository.save(next);
+    }
+
+    /** Bloqueia a etapa final até a confirmação explícita do usuário na tela. */
+    private boolean requiresUserConfirmation(OprmNichoCnaeV3StageExecution current, String nextStageCode) {
+        return "quality-gate".equals(current.getStageCode()) && "persona-routine-materializer".equals(nextStageCode);
     }
 
     /** Valida se a próxima etapa é conhecida e vem imediatamente depois da etapa atual. */

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/oprm/nichocnae/v3/OprmNichoCnaeV3StageExecutionRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/oprm/nichocnae/v3/OprmNichoCnaeV3StageExecutionRepository.java
@@ -16,6 +16,9 @@ public interface OprmNichoCnaeV3StageExecutionRepository extends JpaRepository<O
     /** Verifica se o job já possui pendência ou conclusão para uma etapa específica. */
     boolean existsByJobIdAndStageCode(String jobId, String stageCode);
 
+    /** Busca uma etapa específica dentro do job para confirmação manual do avanço. */
+    Optional<OprmNichoCnaeV3StageExecution> findByJobIdAndStageCode(String jobId, String stageCode);
+
     /** Busca a entrada mais recente de um CNAE para recuperar o último job iniciado na tela. */
     Optional<OprmNichoCnaeV3StageExecution> findTop1ByCnaeCodeAndStageCodeOrderByCreatedAtDesc(
             String cnaeCode, String stageCode);

--- a/frontend/src/api/oprm/useConfirmOprmNichoCnaeV3Finalization.ts
+++ b/frontend/src/api/oprm/useConfirmOprmNichoCnaeV3Finalization.ts
@@ -1,0 +1,34 @@
+import { useMutation, useQueryClient } from "@tanstack/react-query";
+import { buildApiUrl } from "../../utils/buildApiUrl";
+
+async function confirmOprmNichoCnaeV3Finalization(
+  cnaeCode: string,
+): Promise<void> {
+  const response = await fetch(
+    buildApiUrl(
+      `/api/oprm/nichocnae/v3/cnaes/${encodeURIComponent(cnaeCode)}/progress/confirm-finalization`,
+    ),
+    { method: "POST" },
+  );
+
+  if (!response.ok) {
+    const message = await response.text();
+    throw new Error(
+      message ||
+        `Não foi possível confirmar a finalização v3 do NichoCNAE (status ${response.status}).`,
+    );
+  }
+}
+
+export function useConfirmOprmNichoCnaeV3Finalization(cnaeCode: string) {
+  const queryClient = useQueryClient();
+
+  return useMutation({
+    mutationFn: () => confirmOprmNichoCnaeV3Finalization(cnaeCode),
+    onSuccess: () => {
+      void queryClient.invalidateQueries({
+        queryKey: ["oprm-nichocnae-v3-progress", cnaeCode],
+      });
+    },
+  });
+}

--- a/frontend/src/api/oprm/useOprmNichoCnaeV3Progress.ts
+++ b/frontend/src/api/oprm/useOprmNichoCnaeV3Progress.ts
@@ -10,10 +10,21 @@ export interface OprmNichoCnaeV3StageProgress {
   errorMessage: string | null;
 }
 
+export interface OprmNichoCnaeV3FinalizationReview {
+  requiresConfirmation: boolean;
+  qualityGateStageExecutionId: number;
+  materializationMode: "CREATE_NEW" | "REUSE_EXISTING" | string;
+  targetMarketNicheId: number | null;
+  targetNicheName: string;
+  nicheInformation: string;
+  enrichedNicheInformation: string;
+}
+
 export interface OprmNichoCnaeV3JobProgress {
   jobId: string | null;
   cnaeCode: string;
   stages: OprmNichoCnaeV3StageProgress[];
+  finalizationReview: OprmNichoCnaeV3FinalizationReview | null;
 }
 
 async function fetchOprmNichoCnaeV3Progress(

--- a/frontend/src/pages/oprm/OprmNichoCnaeV3PipelinePage.tsx
+++ b/frontend/src/pages/oprm/OprmNichoCnaeV3PipelinePage.tsx
@@ -2,6 +2,7 @@ import { Link, useParams } from "react-router-dom";
 import PageTitle from "../../components/PageTitle";
 import { useStartOprmNichoCnaeV3Job } from "../../api/oprm/useStartOprmNichoCnaeV3Job";
 import { useOprmNichoCnaeV3Progress } from "../../api/oprm/useOprmNichoCnaeV3Progress";
+import { useConfirmOprmNichoCnaeV3Finalization } from "../../api/oprm/useConfirmOprmNichoCnaeV3Finalization";
 
 const v3Stages = [
   {
@@ -61,6 +62,7 @@ export default function OprmNichoCnaeV3PipelinePage() {
   const decodedCnaeCode = decodeURIComponent(cnaeCode ?? "");
   const startJob = useStartOprmNichoCnaeV3Job(decodedCnaeCode);
   const progress = useOprmNichoCnaeV3Progress(decodedCnaeCode);
+  const confirmFinalization = useConfirmOprmNichoCnaeV3Finalization(decodedCnaeCode);
   const stagesByCode = new Map(
     (progress.data?.stages ?? []).map((stage) => [stage.stageCode, stage]),
   );
@@ -70,6 +72,13 @@ export default function OprmNichoCnaeV3PipelinePage() {
       return;
     }
     startJob.mutate();
+  };
+
+  const handleConfirmFinalization = () => {
+    if (!decodedCnaeCode || confirmFinalization.isPending) {
+      return;
+    }
+    confirmFinalization.mutate();
   };
 
   return (
@@ -120,6 +129,78 @@ export default function OprmNichoCnaeV3PipelinePage() {
         <div className="alert alert-danger" role="alert">
           {(startJob.error as Error).message}
         </div>
+      ) : null}
+
+      {progress.data?.finalizationReview ? (
+        <section className="card border-warning shadow-sm">
+          <div className="card-body">
+            <div className="d-flex flex-wrap justify-content-between gap-3 align-items-start mb-3">
+              <div>
+                <h2 className="h5 mb-1">Conferência antes da finalização</h2>
+                <p className="text-muted mb-0">
+                  A etapa final (#10) só será liberada depois da sua confirmação.
+                </p>
+              </div>
+              <span className="badge text-bg-warning">Aguardando confirmação</span>
+            </div>
+            <div className="alert alert-light border" role="status">
+              <strong>Decisão de materialização:</strong>{" "}
+              {progress.data.finalizationReview.materializationMode ===
+              "REUSE_EXISTING"
+                ? "aproveitar nicho existente"
+                : "criar nicho novo"}
+              {" — "}
+              <strong>{progress.data.finalizationReview.targetNicheName}</strong>
+              {progress.data.finalizationReview.targetMarketNicheId ? (
+                <> #{progress.data.finalizationReview.targetMarketNicheId}</>
+              ) : null}
+            </div>
+            <div className="row g-3">
+              <div className="col-12 col-lg-6">
+                <h3 className="h6">Informações de nicho encontradas</h3>
+                <pre className="small bg-light border rounded-3 p-3 text-wrap mb-0">
+                  {progress.data.finalizationReview.nicheInformation}
+                </pre>
+              </div>
+              <div className="col-12 col-lg-6">
+                <h3 className="h6">Informações de nicho enriquecido encontradas</h3>
+                <pre className="small bg-light border rounded-3 p-3 text-wrap mb-0">
+                  {progress.data.finalizationReview.enrichedNicheInformation}
+                </pre>
+              </div>
+            </div>
+            <div className="d-flex flex-wrap gap-2 align-items-center mt-3">
+              <button
+                type="button"
+                className="btn btn-success"
+                onClick={handleConfirmFinalization}
+                disabled={confirmFinalization.isPending}
+              >
+                {confirmFinalization.isPending ? (
+                  <>
+                    <span
+                      className="spinner-border spinner-border-sm me-2"
+                      aria-hidden="true"
+                    />
+                    Confirmando...
+                  </>
+                ) : (
+                  "Confirmar e executar etapa #10"
+                )}
+              </button>
+              {confirmFinalization.isError ? (
+                <span className="text-danger small">
+                  {(confirmFinalization.error as Error).message}
+                </span>
+              ) : null}
+              {confirmFinalization.isSuccess ? (
+                <span className="text-success small">
+                  Confirmação registrada. A etapa #10 foi liberada.
+                </span>
+              ) : null}
+            </div>
+          </div>
+        </section>
       ) : null}
 
       <section className="card border-0 shadow-sm">


### PR DESCRIPTION
### Motivation
- Prevent automatic advancement from the `quality-gate` to the final materialization stage so a human can review the found niche data and decide whether to create a new niche or reuse an existing one. 
- Make the finalization decision explicit and auditable in the backend, exposing a compact review summary to the UI before executing stage #10. 

### Description
- Block automatic creation of the next stage when `quality-gate` completes by adding `requiresUserConfirmation` in `OprmNichoCnaeV3StageServiceSupport` and a repository method `findByJobIdAndStageCode` to support manual confirmation. 
- Add `NichoCnaeV3FinalizationReviewResponse` and extend `NichoCnaeV3JobProgressResponse` to include a `finalizationReview` payload built by `BackendNichoCnaeV3ProgressService`, which inspects the `quality-gate` output and detects whether to `CREATE_NEW` or `REUSE_EXISTING` (including target niche id/name and summary texts). 
- Expose a confirmation endpoint `POST /api/oprm/nichocnae/v3/cnaes/{cnaeCode}/progress/confirm-finalization` in `BackendNichoCnaeV3ProgressController` that validates the `quality-gate` is completed and then creates the persona-routine-materializer stage only after user confirmation. 
- Update frontend: extend `useOprmNichoCnaeV3Progress` types to include `finalizationReview`, add `useConfirmOprmNichoCnaeV3Finalization` hook, and show a review card with found niche / enriched niche information and a `Confirmar e executar etapa #10` button in `OprmNichoCnaeV3PipelinePage.tsx`. 

### Testing
- Built backend sources with `mvn -DskipTests compile` and the build completed successfully. 
- Ran frontend typecheck with `npm run typecheck` after installing dependencies and it completed without errors. 
- Produced frontend production build with `npm run build` and the build completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3de0ea519c83219d27415bad958e61)