### PR TITLE
Reduce experiment polling intensity

### DIFF
--- a/frontend/src/api/experiment/useFrameworkImageSummary.ts
+++ b/frontend/src/api/experiment/useFrameworkImageSummary.ts
@@ -22,6 +22,6 @@ export function useFrameworkImageSummary(experimentId?: string) {
       );
       return data;
     },
-    refetchInterval: 5000,
+    refetchInterval: 15000,
   });
 }

--- a/frontend/src/api/experiment/useGeraLandingStageExecutions.ts
+++ b/frontend/src/api/experiment/useGeraLandingStageExecutions.ts
@@ -61,7 +61,7 @@ export function useGeraLandingStageExecutions(
       includeCompleted,
     ],
     enabled: Boolean(experimentId),
-    refetchInterval: includeCompleted ? 10000 : 3000,
+    refetchInterval: includeCompleted ? 60000 : 5000,
     queryFn: async () => {
       const { data } = await axios.get<GeraLandingStageExecutionItem[]>(
         `/api/experiments/${experimentId}/geralanding/${resolveStageExecutionsEndpointSegment(stageCode)}/stage-executions`,


### PR DESCRIPTION
### Motivation
- The experiment detail page was creating high backend load by polling many GeraLanding stage queries and framework-image summaries very frequently; pending/running checks should remain responsive while completed/history and summary queries can be polled less often.

### Description
- Lowered polling frequency in `frontend/src/api/experiment/useGeraLandingStageExecutions.ts` by changing `refetchInterval` from `includeCompleted ? 10000 : 3000` to `includeCompleted ? 60000 : 5000` so pending runs remain responsive but completed-history refreshes are much less frequent.
- Lowered polling frequency in `frontend/src/api/experiment/useFrameworkImageSummary.ts` by changing `refetchInterval` from `5000` to `15000` to reduce repeated backend reads while the page is open.

### Testing
- Ran `git diff --check` which reported no whitespace or diff issues and passed.
- Ran `npm run typecheck` which failed due to local environment/type configuration issues (missing type definition packages for `@testing-library/jest-dom`, `vite/client`, `vitest/globals` and TypeScript deprecation warnings in `tsconfig.json`), unrelated to the small changes in this PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3de657f7a883219f15c6c20bab6bff)