### PR TITLE
fix: enqueue pipeline ad creatives

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentService.java
@@ -738,13 +738,20 @@ public class ExperimentService {
     }
 
     /**
-     * Bloqueia a solicitação antiga de anúncios do pipeline para forçar uso do GeraAnuncio v2.
+     * Enfileira a geração de criativos usando os textos e briefings já aprovados no pipeline do experimento.
      */
     @Transactional
     public Experiment requestPipelineCreatives(Long id) {
-        throw new ResponseStatusException(
-                HttpStatus.GONE,
-                "A geração antiga de anúncios foi desligada. Use o pipeline GeraAnuncio v2.");
+        Experiment exp = repository.findById(id).orElseThrow();
+        ensurePipelinePrerequisites(exp);
+        exp.setCreativesToGenerate(3);
+        exp.setCreativeGenerationMode(CreativeGenerationMode.PIPELINE_ADS);
+        exp.setCreativeGenerationStatus(CreativeGenerationStatus.REQUESTED);
+        exp.setCreativeGenerationRequestedAt(Instant.now());
+        exp.setCreativeGenerationStartedAt(null);
+        exp.setCreativeGenerationFinishedAt(null);
+        exp.setCreativeGenerationError(null);
+        return exp;
     }
 
     /**
@@ -987,7 +994,6 @@ public class ExperimentService {
     public List<Experiment> listPendingCreativeGeneration(int limit) {
         int effectiveLimit = Math.max(1, limit);
         return repository.findAllToGenerateCreatives().stream()
-                .filter(experiment -> experiment.getCreativeGenerationMode() != CreativeGenerationMode.PIPELINE_ADS)
                 .filter(experiment -> experiment.getCreativeGenerationStatus() == CreativeGenerationStatus.REQUESTED
                         || experiment.getCreativeGenerationStatus() == CreativeGenerationStatus.PROCESSING)
                 .limit(effectiveLimit)

--- a/backend/ads-service/src/main/java/com/marketinghub/geraanuncio/v2/criativo/service/GeraAnuncioCriativoService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/geraanuncio/v2/criativo/service/GeraAnuncioCriativoService.java
@@ -5,6 +5,8 @@ import com.marketinghub.geraanuncio.v2.criativo.service.listStageExecutions.Gera
 import com.marketinghub.geraanuncio.v2.criativo.service.pending.GeraAnuncioCriativoPendingResponse;
 import com.marketinghub.geraanuncio.v2.criativo.service.recebePrompt.GeraAnuncioCriativoPromptRequest;
 import com.marketinghub.geraanuncio.v2.criativo.service.recebeResposta.GeraAnuncioCriativoRespostaRequest;
+import com.marketinghub.experiment.Experiment;
+import com.marketinghub.experiment.service.ExperimentService;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
@@ -13,9 +15,22 @@ import org.springframework.stereotype.Service;
 /** Responsabilidade: expor contratos de leitura, escrita e auditoria da etapa Criativo do pipeline GeraAnuncio v2. */
 @Service
 public class GeraAnuncioCriativoService {
+    private final ExperimentService experimentService;
+
+    /** Inicializa o service com o serviço canônico de experimentos. */
+    public GeraAnuncioCriativoService(ExperimentService experimentService) {
+        this.experimentService = experimentService;
+    }
+
     /** Inicia uma solicitação de geração de criativos para um experimento. */
     public GeraAnuncioCriativoExecutionSummaryResponse start(Long experimentId) {
-        return new GeraAnuncioCriativoExecutionSummaryResponse(null, experimentId, null, "REQUESTED", Instant.now());
+        Experiment experiment = experimentService.requestPipelineCreatives(experimentId);
+        return new GeraAnuncioCriativoExecutionSummaryResponse(
+                null,
+                experiment.getId(),
+                null,
+                experiment.getCreativeGenerationStatus().name(),
+                experiment.getCreativeGenerationRequestedAt());
     }
 
     /** Lista execuções da etapa Criativo para relatório operacional. */

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/ExperimentServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/ExperimentServiceTest.java
@@ -105,7 +105,7 @@ class ExperimentServiceTest {
     }
 
     @Test
-    void requestPipelineCreativesRejectsLegacyPipelineAssets() {
+    void requestPipelineCreativesQueuesPipelineAdsForWorker() {
         MarketNiche niche = nicheRepository.save(MarketNiche.builder().name("Teste").build());
         var angle = angleRepository.save(com.marketinghub.creative.label.Angle.builder().name("A").build());
         var hyp = hypothesisRepository.save(com.marketinghub.hypothesis.Hypothesis.builder()
@@ -142,14 +142,18 @@ class ExperimentServiceTest {
         exp.setAdImageBriefing("{\"adImageBriefing\":{\"briefings\":[{\"mustMatchAdVariant\":\"dor\",\"visualBriefing\":\"Use contraste simples\",\"assetType\":\"estatico\"}]}}");
         experimentRepository.save(exp);
 
-        assertThatThrownBy(() -> service.requestPipelineCreatives(exp.getId()))
-                .isInstanceOf(org.springframework.web.server.ResponseStatusException.class)
-                .hasMessageContaining("410 GONE")
-                .hasMessageContaining("GeraAnuncio v2");
+        Experiment requested = service.requestPipelineCreatives(exp.getId());
+
+        assertThat(requested.getCreativeGenerationMode()).isEqualTo(CreativeGenerationMode.PIPELINE_ADS);
+        assertThat(requested.getCreativeGenerationStatus()).isEqualTo(CreativeGenerationStatus.REQUESTED);
+        assertThat(requested.getCreativesToGenerate()).isEqualTo(3);
+        assertThat(service.listPendingCreativeGeneration(10))
+                .extracting(Experiment::getId)
+                .contains(requested.getId());
     }
 
     @Test
-    void requestPipelineCreativesRejectsLegacyDraftWithoutDestination() {
+    void requestPipelineCreativesRejectsMissingPipelineAssets() {
         MarketNiche niche = nicheRepository.save(MarketNiche.builder().name("Teste sem destino").build());
         var angle = angleRepository.save(com.marketinghub.creative.label.Angle.builder().name("A").build());
         var hyp = hypothesisRepository.save(com.marketinghub.hypothesis.Hypothesis.builder()
@@ -181,14 +185,9 @@ class ExperimentServiceTest {
         req.setInstagramAccountId(createInstagramAccount().getId());
         req.setLeadPortalFlowId(createLeadPortalFlow(niche));
         Experiment exp = service.create(req);
-        exp.setAdCopy("{\"adCopy\":{\"primaryTextVariants\":[{\"label\":\"dor\",\"primaryText\":\"Texto\",\"headline\":\"Headline\",\"description\":\"Descrição\",\"ctaText\":\"Saiba mais\"}]}}");
-        exp.setAdImageBriefing("{\"adImageBriefing\":{\"briefings\":[{\"mustMatchAdVariant\":\"dor\",\"visualBriefing\":\"Use contraste simples\",\"assetType\":\"estatico\"}]}}");
-        experimentRepository.save(exp);
-
         assertThatThrownBy(() -> service.requestPipelineCreatives(exp.getId()))
                 .isInstanceOf(org.springframework.web.server.ResponseStatusException.class)
-                .hasMessageContaining("410 GONE")
-                .hasMessageContaining("GeraAnuncio v2");
+                .hasMessageContaining("Conclua as etapas de Texto do Anúncio e Prompt da Imagem");
     }
 
 

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -5436,3 +5436,10 @@
 - Causa-raiz: os clientes `CreativeChatGptClient` e `CreativeImageClient` existiam no AI Worker, mas não havia scheduler/service ativo consumindo a fila `creatives_to_generate` do backend e registrando os criativos.
 - Correção aplicada: o backend passou a expor contrato pending/start/complete/fail para geração de criativos; o AI Worker recebeu `CreativeGenerationScheduler`, `CreativeGenerationService` e `CreativeGenerationBackendClient` para consumir a fila via backend, gerar imagens e criar criativos `DRAFT`.
 - Prevenção de recorrência: adicionado teste unitário garantindo que a fila pendente é consumida, o criativo é criado e a pendência é concluída no backend.
+
+## 2026-06-26 — Botão de gerar anúncios do pipeline volta a enfileirar trabalho
+
+- Problema: o botão “Gerar anúncios do pipeline” chamava o endpoint canônico do GeraAnuncio v2, mas o backend apenas devolvia um resumo em memória e não gravava pendência para o AI Worker.
+- Causa-raiz: a reativação anterior do AI Worker consumia apenas a fila padrão e excluía solicitações `PIPELINE_ADS`; ao mesmo tempo, o endpoint v2 de start não atualizava o experimento.
+- Correção aplicada: o start do GeraAnuncio v2 passou a enfileirar o experimento em modo `PIPELINE_ADS`, validar textos/briefings do pipeline e permitir que a fila de criativos pendentes entregue também esse modo ao AI Worker.
+- Prevenção de recorrência: teste unitário confirma que uma solicitação do pipeline fica com status `REQUESTED`, quantidade 3 e aparece na fila consumida pelo worker.


### PR DESCRIPTION
### Motivation

- The experiment "Gerar anúncios do pipeline" button called the GeraAnuncio v2 start endpoint but the backend returned only an in-memory summary and did not persist a pending job for the AI Worker, so pipeline ad generation never ran. 
- The AI Worker/queue flow excluded `PIPELINE_ADS` requests from the pending list, causing requests to be ignored even when the UI called the v2 endpoint.

### Description

- Implemented `requestPipelineCreatives(Long id)` in `backend/ads-service/src/main/java/com/marketinghub/experiment/service/ExperimentService.java` to validate pipeline assets and persist the experiment with `creativesToGenerate=3`, `creativeGenerationMode=PIPELINE_ADS`, and `creativeGenerationStatus=REQUESTED`.
- Removed the filter that excluded `PIPELINE_ADS` from `listPendingCreativeGeneration(...)` so the worker queue can return pipeline ad requests for processing.
- Wired the GeraAnuncio v2 start flow by changing `GeraAnuncioCriativoService.start` to call `ExperimentService.requestPipelineCreatives(...)` and return the persisted summary instead of a transient in-memory response.
- Updated `ExperimentServiceTest` to verify the pipeline request enqueues work (checks mode, status, quantity and that the experiment appears in the pending list) and adjusted the negative case to assert missing assets produce the expected `BAD_REQUEST` message, and recorded the change in `docs/registros/experimentos.md`.

### Testing

- Ran the experiment unit tests with `./mvnw -Dtest=ExperimentServiceTest test` in the backend module; the test suite executed `21` tests with `0` failures and the build completed successfully. 
- The modified test `ExperimentServiceTest` verifying pipeline enqueueing passed, confirming `PIPELINE_ADS` requests are persisted and visible to the worker queue.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3de6897d2c83218b8fd82dab164461)