### PR TITLE
Mostrar entrada e saída por etapa no progresso do pipeline NichoCNAE v3

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/progress/service/BackendNichoCnaeV3ProgressService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/progress/service/BackendNichoCnaeV3ProgressService.java
@@ -88,7 +88,15 @@ public class BackendNichoCnaeV3ProgressService {
 
     /** Converte a entidade persistida em contrato de progresso para a UI. */
     private NichoCnaeV3StageProgressResponse toStage(OprmNichoCnaeV3StageExecution execution) {
-        return new NichoCnaeV3StageProgressResponse(execution.getId(), execution.getStageCode(), execution.getStatus().name(), execution.getCreatedAt(), execution.getUpdatedAt(), execution.getErrorMessage());
+        return new NichoCnaeV3StageProgressResponse(
+                execution.getId(),
+                execution.getStageCode(),
+                execution.getStatus().name(),
+                execution.getCreatedAt(),
+                execution.getUpdatedAt(),
+                execution.getErrorMessage(),
+                execution.getInputPayload(),
+                execution.getOutputPayload());
     }
 
     /** Converte JSON funcional ou payload livre para leitura da prévia. */

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/progress/service/NichoCnaeV3StageProgressResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/progress/service/NichoCnaeV3StageProgressResponse.java
@@ -9,4 +9,6 @@ public record NichoCnaeV3StageProgressResponse(
         String status,
         Instant createdAt,
         Instant updatedAt,
-        String errorMessage) {}
+        String errorMessage,
+        String inputPayload,
+        String outputPayload) {}

--- a/docs/swagger/oprm-nichocnae-v3-swagger.yaml
+++ b/docs/swagger/oprm-nichocnae-v3-swagger.yaml
@@ -121,6 +121,22 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/StageExecutionResponse'
+  /api/oprm/nichocnae/v3/cnaes/{cnaeCode}/progress:
+    get:
+      summary: Consulta o progresso do job v3 mais recente de um CNAE para a tela administrativa.
+      parameters:
+        - name: cnaeCode
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Progresso persistido do pipeline com entrada e saída de cada etapa.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/JobProgressResponse'
 components:
   schemas:
     StagePendingRequest:
@@ -151,6 +167,44 @@ components:
       properties:
         errorMessage:
           type: string
+    JobProgressResponse:
+      type: object
+      properties:
+        jobId:
+          type: string
+        cnaeCode:
+          type: string
+        stages:
+          type: array
+          items:
+            $ref: '#/components/schemas/StageProgressResponse'
+        finalizationReview:
+          type: object
+          nullable: true
+    StageProgressResponse:
+      type: object
+      properties:
+        stageExecutionId:
+          type: integer
+          format: int64
+        stageCode:
+          type: string
+        status:
+          type: string
+        createdAt:
+          type: string
+          format: date-time
+        updatedAt:
+          type: string
+          format: date-time
+        errorMessage:
+          type: string
+        inputPayload:
+          type: string
+          nullable: true
+        outputPayload:
+          type: string
+          nullable: true
     StageExecutionResponse:
       type: object
       properties:

--- a/frontend/src/api/oprm/useOprmNichoCnaeV3Progress.ts
+++ b/frontend/src/api/oprm/useOprmNichoCnaeV3Progress.ts
@@ -8,6 +8,8 @@ export interface OprmNichoCnaeV3StageProgress {
   createdAt: string;
   updatedAt: string;
   errorMessage: string | null;
+  inputPayload: string | null;
+  outputPayload: string | null;
 }
 
 export interface OprmNichoCnaeV3FinalizationReview {

--- a/frontend/src/pages/oprm/OprmNichoCnaeV3PipelinePage.tsx
+++ b/frontend/src/pages/oprm/OprmNichoCnaeV3PipelinePage.tsx
@@ -4,6 +4,55 @@ import { useStartOprmNichoCnaeV3Job } from "../../api/oprm/useStartOprmNichoCnae
 import { useOprmNichoCnaeV3Progress } from "../../api/oprm/useOprmNichoCnaeV3Progress";
 import { useConfirmOprmNichoCnaeV3Finalization } from "../../api/oprm/useConfirmOprmNichoCnaeV3Finalization";
 
+function parsePayload(payload: string | null | undefined) {
+  if (!payload) return null;
+  try {
+    return JSON.parse(payload) as unknown;
+  } catch {
+    return null;
+  }
+}
+
+function summarizePayload(payload: string | null | undefined) {
+  if (!payload) return "Sem registro.";
+  const parsed = parsePayload(payload);
+  if (parsed && typeof parsed === "object" && !Array.isArray(parsed)) {
+    const keys = Object.keys(parsed);
+    if (keys.length === 0) return "JSON vazio.";
+    const visibleKeys = keys.slice(0, 5).join(", ");
+    return `JSON com campos: ${visibleKeys}${keys.length > 5 ? "..." : ""}.`;
+  }
+  if (Array.isArray(parsed)) return `JSON com ${parsed.length} item(ns).`;
+  return "Texto registrado.";
+}
+
+function PayloadSummary({
+  label,
+  payload,
+}: {
+  label: string;
+  payload: string | null | undefined;
+}) {
+  if (!payload) {
+    return <span className="text-muted">Sem {label} registrada.</span>;
+  }
+
+  const parsed = parsePayload(payload);
+  const display = parsed === null ? payload : JSON.stringify(parsed, null, 2);
+
+  return (
+    <details className="small">
+      <summary className="fw-semibold">{summarizePayload(payload)}</summary>
+      <pre
+        className="mt-2 mb-0 bg-white border rounded p-2 text-wrap overflow-auto"
+        style={{ maxHeight: "16rem", whiteSpace: "pre-wrap" }}
+      >
+        {display}
+      </pre>
+    </details>
+  );
+}
+
 const v3Stages = [
   {
     code: "cnae-intake",
@@ -62,7 +111,8 @@ export default function OprmNichoCnaeV3PipelinePage() {
   const decodedCnaeCode = decodeURIComponent(cnaeCode ?? "");
   const startJob = useStartOprmNichoCnaeV3Job(decodedCnaeCode);
   const progress = useOprmNichoCnaeV3Progress(decodedCnaeCode);
-  const confirmFinalization = useConfirmOprmNichoCnaeV3Finalization(decodedCnaeCode);
+  const confirmFinalization =
+    useConfirmOprmNichoCnaeV3Finalization(decodedCnaeCode);
   const stagesByCode = new Map(
     (progress.data?.stages ?? []).map((stage) => [stage.stageCode, stage]),
   );
@@ -138,10 +188,13 @@ export default function OprmNichoCnaeV3PipelinePage() {
               <div>
                 <h2 className="h5 mb-1">Conferência antes da finalização</h2>
                 <p className="text-muted mb-0">
-                  A etapa final (#10) só será liberada depois da sua confirmação.
+                  A etapa final (#10) só será liberada depois da sua
+                  confirmação.
                 </p>
               </div>
-              <span className="badge text-bg-warning">Aguardando confirmação</span>
+              <span className="badge text-bg-warning">
+                Aguardando confirmação
+              </span>
             </div>
             <div className="alert alert-light border" role="status">
               <strong>Decisão de materialização:</strong>{" "}
@@ -150,7 +203,9 @@ export default function OprmNichoCnaeV3PipelinePage() {
                 ? "aproveitar nicho existente"
                 : "criar nicho novo"}
               {" — "}
-              <strong>{progress.data.finalizationReview.targetNicheName}</strong>
+              <strong>
+                {progress.data.finalizationReview.targetNicheName}
+              </strong>
               {progress.data.finalizationReview.targetMarketNicheId ? (
                 <> #{progress.data.finalizationReview.targetMarketNicheId}</>
               ) : null}
@@ -163,7 +218,9 @@ export default function OprmNichoCnaeV3PipelinePage() {
                 </pre>
               </div>
               <div className="col-12 col-lg-6">
-                <h3 className="h6">Informações de nicho enriquecido encontradas</h3>
+                <h3 className="h6">
+                  Informações de nicho enriquecido encontradas
+                </h3>
                 <pre className="small bg-light border rounded-3 p-3 text-wrap mb-0">
                   {progress.data.finalizationReview.enrichedNicheInformation}
                 </pre>
@@ -268,11 +325,33 @@ export default function OprmNichoCnaeV3PipelinePage() {
                       </span>
                     </div>
                     <h3 className="h6 mb-2">{stage.title}</h3>
-                    <p className="small text-muted mb-0">
+                    <p className="small text-muted mb-3">
                       {stageProgress
                         ? stage.activity
                         : "Ainda não chegou nesta etapa."}
                     </p>
+                    {stageProgress ? (
+                      <div className="d-flex flex-column gap-2">
+                        <div>
+                          <div className="small fw-semibold mb-1">
+                            O que recebeu de entrada
+                          </div>
+                          <PayloadSummary
+                            label="entrada"
+                            payload={stageProgress.inputPayload}
+                          />
+                        </div>
+                        <div>
+                          <div className="small fw-semibold mb-1">
+                            O que gerou de saída
+                          </div>
+                          <PayloadSummary
+                            label="saída"
+                            payload={stageProgress.outputPayload}
+                          />
+                        </div>
+                      </div>
+                    ) : null}
                   </div>
                 </div>
               );


### PR DESCRIPTION
### Motivation
- Melhorar a observabilidade e auditoria do pipeline NichoCNAE v3 exibindo, para cada etapa persistida, exatamente o payload de entrada e o payload gerado de saída.  
- Garantir que a interface administrativa mostre a verdade do backend sobre o que ocorreu em cada etapa, facilitando debugging, revisões de qualidade e materialização manual.

### Description
- Backend: adiciona `inputPayload` e `outputPayload` ao contrato de progresso `NichoCnaeV3StageProgressResponse` e popula esses campos em `BackendNichoCnaeV3ProgressService#toStage` a partir da entidade `OprmNichoCnaeV3StageExecution`.  
- Frontend API: estende `OprmNichoCnaeV3StageProgress` com `inputPayload` e `outputPayload` em `useOprmNichoCnaeV3Progress.ts`.  
- Frontend UI: atualiza `OprmNichoCnaeV3PipelinePage.tsx` para mostrar, por etapa executada, um resumo e uma visualização expansível do payload de entrada e do payload de saída usando o novo componente `PayloadSummary`.  
- Docs/Swagger: documenta o endpoint de progresso (`/api/oprm/nichocnae/v3/cnaes/{cnaeCode}/progress`) e adiciona `StageProgressResponse`/`JobProgressResponse` com os novos campos `inputPayload` e `outputPayload` no `oprm-nichocnae-v3-swagger.yaml`.

### Testing
- Backend compile: `mvn -DskipTests compile` (module `ads-service`) completed successfully.  
- Formatting: `prettier --write` executed on modified frontend files successfully.  
- Frontend typecheck: `npm run typecheck` failed in this environment due to missing dev dependencies/type definitions (`@testing-library/jest-dom`, `vite/client`, `vitest/globals`) and deprecated tsconfig options, which are unrelated to the code changes and are environment-specific.  
- All changed Java classes were compiled as part of the Maven build reported above and no runtime tests were executed in this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3de8c82b788321a0d7f98e4fd09401)