### PR TITLE
Bloqueia materialização v3 sem evidências funcionais

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/progress/service/BackendNichoCnaeV3ProgressService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/progress/service/BackendNichoCnaeV3ProgressService.java
@@ -7,6 +7,7 @@ import com.marketinghub.oprm.nichocnae.v3.OprmNichoCnaeV3StageExecutionStatus;
 import com.marketinghub.oprm.nichocnae.v3.personaroutinematerializer.gateway.PersonaRoutineMaterializerNicheGateway;
 import com.marketinghub.oprm.nichocnae.v3.personaroutinematerializer.service.BackendPersonaRoutineMaterializerService;
 import com.marketinghub.repository.jpa.oprm.nichocnae.v3.OprmNichoCnaeV3StageExecutionRepository;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
 import org.springframework.stereotype.Service;
@@ -59,6 +60,11 @@ public class BackendNichoCnaeV3ProgressService {
         if (qualityGate.getStatus() != OprmNichoCnaeV3StageExecutionStatus.COMPLETED) {
             throw new ResponseStatusException(HttpStatus.CONFLICT, "Quality gate ainda não foi concluído.");
         }
+        JsonNode output = parseOutput(qualityGate.getOutputPayload());
+        List<String> missingFields = missingFunctionalEvidence(output);
+        if (!missingFields.isEmpty()) {
+            throw new ResponseStatusException(HttpStatus.CONFLICT, "A etapa 9 não trouxe informações funcionais suficientes para liberar a materialização: " + String.join(", ", missingFields) + ".");
+        }
         if (!repository.existsByJobIdAndStageCode(latest.getJobId(), FINAL_STAGE)) {
             materializerService.create(latest.getJobId(), latest.getCnaeCode(), qualityGate.getOutputPayload(), qualityGate.getAttemptNumber(), qualityGate.getKnowledgeVersion());
         }
@@ -76,6 +82,8 @@ public class BackendNichoCnaeV3ProgressService {
         String targetName = "CNAE " + qualityGate.getCnaeCode() + " — " + cnaeDescription;
         Long existingId = nicheGateway.findPersonaRoutineMaterializedNiche(qualityGate.getCnaeCode(), targetName.trim().toLowerCase(Locale.ROOT))
                 .map(PersonaRoutineMaterializerNicheGateway.MarketNicheSnapshot::marketNicheId).orElse(null);
+        List<String> missingFields = missingFunctionalEvidence(output);
+        boolean canConfirm = missingFields.isEmpty();
         return new NichoCnaeV3FinalizationReviewResponse(
                 true,
                 qualityGate.getId(),
@@ -83,7 +91,9 @@ public class BackendNichoCnaeV3ProgressService {
                 existingId,
                 targetName,
                 buildNicheInformation(output, cnaeDescription),
-                buildEnrichedInformation(output, qualityGate.getOutputPayload()));
+                buildEnrichedInformation(output),
+                canConfirm,
+                canConfirm ? null : "A etapa 9 não trouxe informações funcionais suficientes: " + String.join(", ", missingFields) + ". Reexecute o job v3 antes de materializar.");
     }
 
     /** Converte a entidade persistida em contrato de progresso para a UI. */
@@ -117,8 +127,26 @@ public class BackendNichoCnaeV3ProgressService {
         return "Descrição CNAE: " + cnaeDescription + "\n\nRotina observada: " + textOrDefault(firstText(output, "routineSummary", "routine", "rotina"), "Não informada.") + "\n\nTarefas diárias: " + textOrDefault(firstText(output, "personaDailyTasks", "dailyTasks", "tarefasDiarias", "tasks"), "Não informadas.");
     }
 
-    /** Monta resumo do perfil enriquecido encontrado antes da materialização. */
-    private String buildEnrichedInformation(JsonNode output, String fallback) {
-        return "Persona: " + textOrDefault(firstText(output, "personaSummary", "persona"), "Não informada.") + "\n\nEvidências: " + textOrDefault(firstText(output, "evidenceSummary", "evidences"), fallback) + "\n\nGatilhos comerciais: " + textOrDefault(firstText(output, "commercialTriggers", "triggers"), "Não informados.") + "\n\nObjeções: " + textOrDefault(firstText(output, "objections"), "Não informadas.");
+    /** Monta resumo do perfil enriquecido encontrado antes da materialização sem expor payload técnico. */
+    private String buildEnrichedInformation(JsonNode output) {
+        return "Persona: " + textOrDefault(firstText(output, "personaSummary", "persona"), "Não informada.") + "\n\nEvidências: " + textOrDefault(firstText(output, "evidenceSummary", "evidences"), "Não informadas.") + "\n\nGatilhos comerciais: " + textOrDefault(firstText(output, "commercialTriggers", "triggers"), "Não informados.") + "\n\nObjeções: " + textOrDefault(firstText(output, "objections"), "Não informadas.");
+    }
+
+    /** Lista campos funcionais ausentes que impedem materialização segura. */
+    private List<String> missingFunctionalEvidence(JsonNode output) {
+        List<String> missing = new ArrayList<>();
+        if (!StringUtils.hasText(firstText(output, "routineSummary", "routine", "rotina"))) {
+            missing.add("rotina observada");
+        }
+        if (!StringUtils.hasText(firstText(output, "personaDailyTasks", "dailyTasks", "tarefasDiarias", "tasks"))) {
+            missing.add("tarefas diárias");
+        }
+        if (!StringUtils.hasText(firstText(output, "personaSummary", "persona"))) {
+            missing.add("persona");
+        }
+        if (!StringUtils.hasText(firstText(output, "evidenceSummary", "evidences"))) {
+            missing.add("evidências");
+        }
+        return missing;
     }
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/progress/service/NichoCnaeV3FinalizationReviewResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/v3/progress/service/NichoCnaeV3FinalizationReviewResponse.java
@@ -8,4 +8,6 @@ public record NichoCnaeV3FinalizationReviewResponse(
         Long targetMarketNicheId,
         String targetNicheName,
         String nicheInformation,
-        String enrichedNicheInformation) {}
+        String enrichedNicheInformation,
+        boolean canConfirmFinalization,
+        String blockingReason) {}

--- a/backend/ads-service/src/test/java/com/marketinghub/oprm/nichocnae/v3/progress/service/BackendNichoCnaeV3ProgressServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/oprm/nichocnae/v3/progress/service/BackendNichoCnaeV3ProgressServiceTest.java
@@ -1,0 +1,92 @@
+package com.marketinghub.oprm.nichocnae.v3.progress.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.marketinghub.oprm.nichocnae.v3.OprmNichoCnaeV3StageExecution;
+import com.marketinghub.oprm.nichocnae.v3.OprmNichoCnaeV3StageExecutionStatus;
+import com.marketinghub.oprm.nichocnae.v3.personaroutinematerializer.gateway.PersonaRoutineMaterializerNicheGateway;
+import com.marketinghub.oprm.nichocnae.v3.personaroutinematerializer.service.BackendPersonaRoutineMaterializerService;
+import com.marketinghub.repository.jpa.oprm.nichocnae.v3.OprmNichoCnaeV3StageExecutionRepository;
+import java.time.Instant;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.web.server.ResponseStatusException;
+
+/** Testa a prévia e a confirmação manual do progresso NichoCNAE v3. */
+@ExtendWith(MockitoExtension.class)
+class BackendNichoCnaeV3ProgressServiceTest {
+    @Mock
+    private OprmNichoCnaeV3StageExecutionRepository repository;
+
+    @Mock
+    private PersonaRoutineMaterializerNicheGateway nicheGateway;
+
+    @Mock
+    private BackendPersonaRoutineMaterializerService materializerService;
+
+    private BackendNichoCnaeV3ProgressService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new BackendNichoCnaeV3ProgressService(repository, nicheGateway, materializerService, new ObjectMapper());
+    }
+
+    /** Deve bloquear a confirmação quando o quality-gate traz apenas payload técnico sem informações de mercado. */
+    @Test
+    void latestByCnaeBlocksFinalizationWhenFunctionalEvidenceIsMissing() {
+        OprmNichoCnaeV3StageExecution intake = execution(1L, "cnae-intake", OprmNichoCnaeV3StageExecutionStatus.COMPLETED, "{}");
+        OprmNichoCnaeV3StageExecution qualityGate = execution(9L, "quality-gate", OprmNichoCnaeV3StageExecutionStatus.COMPLETED, "{\"stage\":\"quality-gate\",\"status\":\"QUALIDADE_APROVADA\",\"jobId\":\"nichocnae-v3-4781400\"}");
+        when(repository.findTop1ByCnaeCodeAndStageCodeOrderByCreatedAtDesc("4781400", "cnae-intake")).thenReturn(Optional.of(intake));
+        when(repository.findByJobIdOrderByCreatedAtAsc("nichocnae-v3-4781400")).thenReturn(List.of(intake, qualityGate));
+        when(nicheGateway.findPersonaRoutineMaterializedNiche(anyString(), anyString())).thenReturn(Optional.empty());
+
+        NichoCnaeV3JobProgressResponse response = service.latestByCnae("4781400");
+
+        assertThat(response.finalizationReview()).isNotNull();
+        assertThat(response.finalizationReview().canConfirmFinalization()).isFalse();
+        assertThat(response.finalizationReview().blockingReason()).contains("rotina observada", "tarefas diárias", "persona", "evidências");
+        assertThat(response.finalizationReview().enrichedNicheInformation()).contains("Evidências: Não informadas.");
+        assertThat(response.finalizationReview().enrichedNicheInformation()).doesNotContain("jobId");
+    }
+
+    /** Deve rejeitar a confirmação para impedir materialização de nicho vazio ou técnico. */
+    @Test
+    void confirmFinalizationRejectsMissingFunctionalEvidence() {
+        OprmNichoCnaeV3StageExecution intake = execution(1L, "cnae-intake", OprmNichoCnaeV3StageExecutionStatus.COMPLETED, "{}");
+        OprmNichoCnaeV3StageExecution qualityGate = execution(9L, "quality-gate", OprmNichoCnaeV3StageExecutionStatus.COMPLETED, "{\"stage\":\"quality-gate\",\"status\":\"QUALIDADE_APROVADA\"}");
+        when(repository.findTop1ByCnaeCodeAndStageCodeOrderByCreatedAtDesc("4781400", "cnae-intake")).thenReturn(Optional.of(intake));
+        when(repository.findByJobIdAndStageCode("nichocnae-v3-4781400", "quality-gate")).thenReturn(Optional.of(qualityGate));
+
+        assertThatThrownBy(() -> service.confirmFinalization("4781400"))
+                .isInstanceOf(ResponseStatusException.class)
+                .hasMessageContaining("não trouxe informações funcionais suficientes");
+        verify(materializerService, never()).create(anyString(), anyString(), anyString(), org.mockito.ArgumentMatchers.any(), org.mockito.ArgumentMatchers.any());
+    }
+
+    /** Monta uma execução de etapa v3 para cenários de progresso. */
+    private OprmNichoCnaeV3StageExecution execution(Long id, String stageCode, OprmNichoCnaeV3StageExecutionStatus status, String outputPayload) {
+        OprmNichoCnaeV3StageExecution execution = new OprmNichoCnaeV3StageExecution();
+        execution.setId(id);
+        execution.setJobId("nichocnae-v3-4781400");
+        execution.setCnaeCode("4781400");
+        execution.setStageCode(stageCode);
+        execution.setStatus(status);
+        execution.setOutputPayload(outputPayload);
+        execution.setAttemptNumber(1);
+        execution.setKnowledgeVersion(1);
+        execution.setCreatedAt(Instant.parse("2026-06-25T21:08:56Z"));
+        execution.setUpdatedAt(Instant.parse("2026-06-25T21:08:56Z"));
+        return execution;
+    }
+}

--- a/frontend/src/api/oprm/useOprmNichoCnaeV3Progress.ts
+++ b/frontend/src/api/oprm/useOprmNichoCnaeV3Progress.ts
@@ -18,6 +18,8 @@ export interface OprmNichoCnaeV3FinalizationReview {
   targetNicheName: string;
   nicheInformation: string;
   enrichedNicheInformation: string;
+  canConfirmFinalization: boolean;
+  blockingReason: string | null;
 }
 
 export interface OprmNichoCnaeV3JobProgress {

--- a/frontend/src/pages/oprm/OprmNichoCnaeV3PipelinePage.tsx
+++ b/frontend/src/pages/oprm/OprmNichoCnaeV3PipelinePage.tsx
@@ -62,7 +62,8 @@ export default function OprmNichoCnaeV3PipelinePage() {
   const decodedCnaeCode = decodeURIComponent(cnaeCode ?? "");
   const startJob = useStartOprmNichoCnaeV3Job(decodedCnaeCode);
   const progress = useOprmNichoCnaeV3Progress(decodedCnaeCode);
-  const confirmFinalization = useConfirmOprmNichoCnaeV3Finalization(decodedCnaeCode);
+  const confirmFinalization =
+    useConfirmOprmNichoCnaeV3Finalization(decodedCnaeCode);
   const stagesByCode = new Map(
     (progress.data?.stages ?? []).map((stage) => [stage.stageCode, stage]),
   );
@@ -75,7 +76,11 @@ export default function OprmNichoCnaeV3PipelinePage() {
   };
 
   const handleConfirmFinalization = () => {
-    if (!decodedCnaeCode || confirmFinalization.isPending) {
+    if (
+      !decodedCnaeCode ||
+      confirmFinalization.isPending ||
+      progress.data?.finalizationReview?.canConfirmFinalization === false
+    ) {
       return;
     }
     confirmFinalization.mutate();
@@ -138,10 +143,13 @@ export default function OprmNichoCnaeV3PipelinePage() {
               <div>
                 <h2 className="h5 mb-1">Conferência antes da finalização</h2>
                 <p className="text-muted mb-0">
-                  A etapa final (#10) só será liberada depois da sua confirmação.
+                  A etapa final (#10) só será liberada depois da sua
+                  confirmação.
                 </p>
               </div>
-              <span className="badge text-bg-warning">Aguardando confirmação</span>
+              <span className="badge text-bg-warning">
+                Aguardando confirmação
+              </span>
             </div>
             <div className="alert alert-light border" role="status">
               <strong>Decisão de materialização:</strong>{" "}
@@ -150,11 +158,20 @@ export default function OprmNichoCnaeV3PipelinePage() {
                 ? "aproveitar nicho existente"
                 : "criar nicho novo"}
               {" — "}
-              <strong>{progress.data.finalizationReview.targetNicheName}</strong>
+              <strong>
+                {progress.data.finalizationReview.targetNicheName}
+              </strong>
               {progress.data.finalizationReview.targetMarketNicheId ? (
                 <> #{progress.data.finalizationReview.targetMarketNicheId}</>
               ) : null}
             </div>
+            {progress.data.finalizationReview.canConfirmFinalization ? null : (
+              <div className="alert alert-danger" role="alert">
+                <strong>Materialização bloqueada.</strong>{" "}
+                {progress.data.finalizationReview.blockingReason ??
+                  "A etapa 9 não trouxe dados funcionais suficientes para criar ou atualizar o nicho."}
+              </div>
+            )}
             <div className="row g-3">
               <div className="col-12 col-lg-6">
                 <h3 className="h6">Informações de nicho encontradas</h3>
@@ -163,7 +180,9 @@ export default function OprmNichoCnaeV3PipelinePage() {
                 </pre>
               </div>
               <div className="col-12 col-lg-6">
-                <h3 className="h6">Informações de nicho enriquecido encontradas</h3>
+                <h3 className="h6">
+                  Informações de nicho enriquecido encontradas
+                </h3>
                 <pre className="small bg-light border rounded-3 p-3 text-wrap mb-0">
                   {progress.data.finalizationReview.enrichedNicheInformation}
                 </pre>
@@ -174,7 +193,10 @@ export default function OprmNichoCnaeV3PipelinePage() {
                 type="button"
                 className="btn btn-success"
                 onClick={handleConfirmFinalization}
-                disabled={confirmFinalization.isPending}
+                disabled={
+                  confirmFinalization.isPending ||
+                  !progress.data.finalizationReview.canConfirmFinalization
+                }
               >
                 {confirmFinalization.isPending ? (
                   <>


### PR DESCRIPTION
### Motivation
- A UI estava exibindo payload técnico/bruto como se fosse evidência validada e permitia confirmar a materialização mesmo quando a etapa `quality-gate` não trouxe informações funcionais mínimas (rotina, tarefas diárias, persona, evidências).
- É necessário bloquear a criação/atualização de nicho quando os dados não são funcionais para evitar materializar nichos vazios ou contaminados por metadados técnicos.

### Description
- Adiciona verificação no backend para recusar `confirmFinalization` quando faltam campos funcionais, implementada em `BackendNichoCnaeV3ProgressService` com `missingFunctionalEvidence(...)` e validação antes de chamar o materializer.
- Amplia o contrato de prévia `NichoCnaeV3FinalizationReviewResponse` para expor `canConfirmFinalization` e `blockingReason` e altera a montagem da prévia para não expor payload bruto como evidência. (arquivo modificado: `NichoCnaeV3FinalizationReviewResponse.java`).
- Atualiza a UI para ler `canConfirmFinalization`/`blockingReason`, exibir um alerta "Materialização bloqueada" quando aplicável e desabilitar o botão de confirmação; também remove o fallback que mostrava payload técnico na pré-visualização. (arquivos modificados: `useOprmNichoCnaeV3Progress.ts` e `OprmNichoCnaeV3PipelinePage.tsx`).
- Adiciona testes unitários em `BackendNichoCnaeV3ProgressServiceTest` cobrindo a prévia bloqueada e a rejeição de confirmação quando faltam evidências funcionais, garantindo que metadados como `jobId` não sejam apresentados como evidência.

### Testing
- Executei `mvn -Dtest=BackendNichoCnaeV3ProgressServiceTest test` e os testes unitários relevantes passaram (`Tests run: 2, Failures: 0, Errors: 0`).
- Executei `npm ci` para instalar dependências do frontend e a instalação completou com sucesso. 
- Formatei os arquivos frontend com `npx prettier --write src/api/oprm/useOprmNichoCnaeV3Progress.ts src/pages/oprm/OprmNichoCnaeV3PipelinePage.tsx` sem erros.
- Rodei `npm run typecheck` e a checagem TypeScript completou com sucesso após instalação das dependências.
- Tentativa de rodar `mvn spotless:apply ...` não foi executada porque o plugin Spotless não está disponível via prefixo `spotless` no projeto; isso é uma observação de ferramenta e não afeta os testes automatizados acima.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3de8517bc8832181e5bbcf74cfc8ea)