### PR TITLE
Show stage error messages in NichoCNAE v3 UI and add OpenAI key fallback with config test

### DIFF
--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -1399,6 +1399,7 @@
 
 - Corrigida a diferenciação dos nomes das classes versionadas v3 das etapas `source-fetcher` e `source-searcher`, evitando conflito de bean Spring com as classes legadas de mesmo papel.
 - Verificados os componentes Spring do backend para localizar outros nomes simples duplicados com bean name padrão; não restaram duplicidades sem nome explícito após o ajuste.
+
 ## 2026-06-25 — Tela de CNAEs passa a abrir NichoCNAE v3
 
 - Alterado o botão da tabela de CNAEs do OPRM para abrir o pipeline NichoCNAE v3 em vez da v2.
@@ -1430,11 +1431,13 @@
 - Prevenção: adicionado teste de contrato garantindo que o pacote v2 permaneça fora do component scan e que o pacote v3 continue carregado.
 
 ## 2026-06-25 — Monitoramento operacional do NichoCNAE v3 no Ops Monitor
+
 - O Ops Monitor passou a detectar pendências antigas do pipeline NichoCNAE v3 persistidas no backend como incidente sintético do módulo `oprm-coletor-mei`.
 - A regra degrada o módulo quando existir execução v3 em `PENDING` há mais de 6 minutos, expondo o job, CNAE e etapa parada para facilitar ação operacional.
 - A causa-raiz tratada é a diferença entre container ativo e pipeline sem consumo: saúde HTTP isolada não garante que o executor esteja processando a fila v3.
 
 ## 2026-06-25 — NichoCNAE v3 registrado no Protocolo Monitor
+
 - O NichoCNAE v3 ficou registrado como primeiro caso do `Protocolo Monitor`, usando o `oprm-coletor-mei` como módulo executor monitorado.
 - A regra operacional é detectar fila v3 parada mesmo quando o container está online, evitando falso positivo de saúde operacional.
 
@@ -1475,3 +1478,14 @@
 - Correção: a etapa `persona-candidate-generator` passou a usar cliente da OpenAI Responses API com prompt e schema versionados, `service_tier=flex`, JSON Schema estrito e validação de quantidade mínima de personas antes de concluir.
 - Prevenção de recorrência: adicionados testes de processor e cliente OpenAI garantindo que a etapa chama o gerador, envia `json_schema`/Flex e falha quando a resposta não contém personas suficientes.
 
+## 2026-06-26 — NichoCNAE v3: erro visível na etapa falha
+
+- Diagnóstico: a etapa `persona-candidate-generator` do CNAE `4781400` falhou com `IllegalStateException: OpenAI API key não configurada para persona-candidate-generator NichoCNAE v3.`, e o backend já persistia esse erro em `oprm_nichocnae_v3_stage_execution.error_message`.
+- Causa-raiz da tela: a página do pipeline v3 exibia apenas entrada e saída da etapa, ignorando `errorMessage`; por isso o card aparecia como `Falhou`, mas mostrava `Sem saída registrada` em vez da causa da falha.
+- Correção: a tela passou a mostrar o bloco `Erro registrado` quando o backend retornar `errorMessage` para a etapa.
+
+## 2026-06-26 — NichoCNAE v3: OpenAI API key pelo mesmo fallback das versões anteriores
+
+- Causa-raiz complementar: o `persona-candidate-generator` v3 tinha `@ConfigurationProperties`, mas o `application.yml` não declarava o bloco `oprm.nichocnaev3.persona-candidate-generator.openai`; por isso a etapa não herdava o fallback global `OPENAI_API_KEY`/`OPENAI_API_KEY_FILE` já usado pelas etapas anteriores do OPRM.
+- Correção: o coletor OPRM passou a configurar a etapa v3 com variável específica opcional e fallback para `OPENAI_API_KEY` e `OPENAI_API_KEY_FILE`, mantendo o mesmo padrão operacional das versões anteriores.
+- Prevenção de recorrência: adicionado teste de configuração garantindo que o fallback global da OpenAI continue presente no `application.yml` para a etapa `persona-candidate-generator` v3.

--- a/frontend/src/pages/oprm/OprmNichoCnaeV3PipelinePage.tsx
+++ b/frontend/src/pages/oprm/OprmNichoCnaeV3PipelinePage.tsx
@@ -411,6 +411,19 @@ export default function OprmNichoCnaeV3PipelinePage() {
                             payload={stageProgress.inputPayload}
                           />
                         </div>
+                        {stageProgress.errorMessage ? (
+                          <div
+                            className="alert alert-danger py-2 px-3 mb-0"
+                            role="alert"
+                          >
+                            <div className="small fw-semibold mb-1">
+                              Erro registrado
+                            </div>
+                            <div className="small text-break">
+                              {stageProgress.errorMessage}
+                            </div>
+                          </div>
+                        ) : null}
                         <div>
                           <div className="small fw-semibold mb-1">
                             O que gerou de saída

--- a/oprm-coletor-mei/src/main/resources/application.yml
+++ b/oprm-coletor-mei/src/main/resources/application.yml
@@ -42,6 +42,14 @@ oprm:
         expected-api-key-variable: OPRM_MEI_AUDIENCE_SEGMENTER_OPENAI_API_KEY
         fallback-api-key-variable: OPENAI_API_KEY
         service-tier: ${OPRM_MEI_AUDIENCE_SEGMENTER_OPENAI_SERVICE_TIER:flex}
+  nichocnaev3:
+    persona-candidate-generator:
+      openai:
+        base-url: ${OPRM_NICHO_CNAE_V3_PERSONA_CANDIDATE_GENERATOR_OPENAI_BASE_URL:https://api.openai.com/v1}
+        api-key: ${OPRM_NICHO_CNAE_V3_PERSONA_CANDIDATE_GENERATOR_OPENAI_API_KEY:${OPENAI_API_KEY:}}
+        api-key-file: ${OPRM_NICHO_CNAE_V3_PERSONA_CANDIDATE_GENERATOR_OPENAI_API_KEY_FILE:${OPENAI_API_KEY_FILE:}}
+        model: ${OPRM_NICHO_CNAE_V3_PERSONA_CANDIDATE_GENERATOR_OPENAI_MODEL:gpt-5.2}
+        service-tier: ${OPRM_NICHO_CNAE_V3_PERSONA_CANDIDATE_GENERATOR_OPENAI_SERVICE_TIER:flex}
 
   market-import:
     collector:

--- a/oprm-coletor-mei/src/test/java/com/marketinghub/nichocnaev3/pipeline/personacandidategenerator/PersonaCandidateOpenAiConfigurationTest.java
+++ b/oprm-coletor-mei/src/test/java/com/marketinghub/nichocnaev3/pipeline/personacandidategenerator/PersonaCandidateOpenAiConfigurationTest.java
@@ -1,0 +1,26 @@
+package com.marketinghub.nichocnaev3.pipeline.personacandidategenerator;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.io.IOException;
+import java.nio.charset.StandardCharsets;
+import org.junit.jupiter.api.Test;
+import org.springframework.core.io.ClassPathResource;
+import org.springframework.util.StreamUtils;
+
+/** Valida a configuração operacional da OpenAI para a etapa persona-candidate-generator v3. */
+class PersonaCandidateOpenAiConfigurationTest {
+    /** Confirma que a etapa v3 reutiliza o fallback global de chave OpenAI já usado pelas versões anteriores. */
+    @Test
+    void shouldUseGlobalOpenAiKeyFallbackFromApplicationConfiguration() throws IOException {
+        String applicationYaml = StreamUtils.copyToString(
+                new ClassPathResource("application.yml").getInputStream(), StandardCharsets.UTF_8);
+
+        assertThat(applicationYaml)
+                .contains("oprm:")
+                .contains("nichocnaev3:")
+                .contains("persona-candidate-generator:")
+                .contains("api-key: ${OPRM_NICHO_CNAE_V3_PERSONA_CANDIDATE_GENERATOR_OPENAI_API_KEY:${OPENAI_API_KEY:}}")
+                .contains("api-key-file: ${OPRM_NICHO_CNAE_V3_PERSONA_CANDIDATE_GENERATOR_OPENAI_API_KEY_FILE:${OPENAI_API_KEY_FILE:}}");
+    }
+}


### PR DESCRIPTION
### Motivation

- Make pipeline failures visible to users by surfacing backend `errorMessage` for v3 stages in the UI so cards show the real cause instead of "Sem saída registrada". 
- Ensure the v3 `persona-candidate-generator` reuses the same operational OpenAI API key fallback already used by earlier OPRM stages. 
- Capture the change in project docs so operators can follow the incident and configuration decisions.

### Description

- Frontend: the v3 pipeline page now displays a new `Erro registrado` block when the backend returns `stageProgress.errorMessage`, rendering the actual error text in an alert box. 
- Backend config: added `oprm.nichocnaev3.persona-candidate-generator.openai` entries to `application.yml` with `api-key` and `api-key-file` fallbacks to the global `OPENAI_API_KEY` / `OPENAI_API_KEY_FILE`. 
- Tests: added `PersonaCandidateOpenAiConfigurationTest` to validate that `application.yml` contains the expected v3 OpenAI configuration and fallback variables. 
- Docs: updated `docs/registros/oprm1.md` with changelog entries describing the visible error handling and the OpenAI configuration fallback for NichoCNAE v3.

### Testing

- Ran the Java unit tests including `PersonaCandidateOpenAiConfigurationTest`, which passed and verifies the `application.yml` contains the v3 OpenAI fallback entries. 
- Project build and unit test suite completed successfully locally (no failures reported for affected modules).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3e0e5f60a88321960e2fcaabecfbd0)