### PR TITLE
NichoCNAE v3: log OpenAI request/response in persona-candidate-generator and add tests

### DIFF
--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -1507,3 +1507,8 @@
 - Causa-raiz aprofundada: depender apenas de variável de ambiente para apontar o arquivo da chave ainda deixava a etapa vulnerável a deploy sem `OPENAI_API_KEY_FILE`, mesmo com o segredo existente no servidor em `/root/infra/openai-token/openai_api_key`.
 - Correção: a etapa `persona-candidate-generator` v3 agora tenta ler a chave por variável direta, pelo arquivo configurado, pelo segredo montado no container em `/run/secrets/openai_api_key` e, como fallback operacional, pelo caminho seguro do host `/root/infra/openai-token/openai_api_key`.
 - Prevenção de recorrência: o `application.yml` do executor agora tem default explícito para `/run/secrets/openai_api_key`, e os testes validam a leitura de chave por arquivo seguro.
+
+## 2026-06-26 — NichoCNAE v3: logs do request e response OpenAI
+
+- Correção operacional: a etapa `persona-candidate-generator` do executor OPRM passou a registrar em log o payload enviado à OpenAI e a resposta bruta recebida, com `jobId`, `stageExecutionId`, `cnaeCode` e endpoint, sem expor a chave de autenticação.
+- Motivo: permitir diagnosticar a causa real de falhas da OpenAI no NichoCNAE v3 sem depender apenas da mensagem genérica persistida na tela.

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnaev3/pipeline/personacandidategenerator/OpenAiPersonaCandidateGenerationClient.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/nichocnaev3/pipeline/personacandidategenerator/OpenAiPersonaCandidateGenerationClient.java
@@ -55,8 +55,10 @@ public class OpenAiPersonaCandidateGenerationClient implements PersonaCandidateG
         }
         String url = properties.baseUrl() + RESPONSES_PATH;
         Map<String, Object> requestBody = buildRequestBody(promptBuilder.build(request), properties.model());
+        logOpenAiRequest(url, request, requestBody);
         try {
             Map<String, Object> raw = responseBody(url, requestBody, apiKey);
+            logOpenAiResponse(url, request, raw);
             if (raw == null) {
                 throw new IllegalStateException("OpenAI retornou corpo vazio para persona-candidate-generator NichoCNAE v3.");
             }
@@ -135,6 +137,38 @@ public class OpenAiPersonaCandidateGenerationClient implements PersonaCandidateG
         body.put("text", text);
         body.put("service_tier", properties.serviceTier());
         return body;
+    }
+
+    /** Registra o payload enviado à OpenAI sem expor credenciais de autenticação. */
+    private void logOpenAiRequest(String url, PersonaCandidateGenerationRequest request, Map<String, Object> requestBody) {
+        log.info(
+                "Request OpenAI persona-candidate-generator (endpoint={}, jobId={}, stageExecutionId={}, cnaeCode={}, payload={})",
+                url,
+                request.jobId(),
+                request.stageExecutionId(),
+                request.cnaeCode(),
+                toJsonForLog(requestBody));
+    }
+
+    /** Registra a resposta bruta recebida da OpenAI para auditoria operacional. */
+    private void logOpenAiResponse(String url, PersonaCandidateGenerationRequest request, Map<String, Object> raw) {
+        log.info(
+                "Response OpenAI persona-candidate-generator (endpoint={}, jobId={}, stageExecutionId={}, cnaeCode={}, payload={})",
+                url,
+                request.jobId(),
+                request.stageExecutionId(),
+                request.cnaeCode(),
+                toJsonForLog(raw));
+    }
+
+    /** Serializa payloads para log preservando diagnóstico mesmo quando houver valor não serializável. */
+    private String toJsonForLog(Object payload) {
+        try {
+            return objectMapper.writeValueAsString(payload);
+        } catch (JsonProcessingException ex) {
+            log.warn("Falha ao serializar payload OpenAI para log.", ex);
+            return String.valueOf(payload);
+        }
     }
 
     /** Executa a requisição HTTP para a Responses API. */

--- a/oprm-coletor-mei/src/test/java/com/marketinghub/nichocnaev3/pipeline/personacandidategenerator/OpenAiPersonaCandidateGenerationClientTest.java
+++ b/oprm-coletor-mei/src/test/java/com/marketinghub/nichocnaev3/pipeline/personacandidategenerator/OpenAiPersonaCandidateGenerationClientTest.java
@@ -13,15 +13,19 @@ import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.boot.test.system.CapturedOutput;
+import org.springframework.boot.test.system.OutputCaptureExtension;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.client.MockRestServiceServer;
 import org.springframework.web.client.RestClient;
 
 /** Valida o contrato de chamada da OpenAI para geração de personas candidatas v3. */
+@ExtendWith(OutputCaptureExtension.class)
 class OpenAiPersonaCandidateGenerationClientTest {
     /** Confirma que a requisição usa Responses API com JSON Schema e Flex Processing. */
     @Test
-    void shouldCallOpenAiResponsesApiWithStrictJsonSchemaAndFlex() throws Exception {
+    void shouldCallOpenAiResponsesApiWithStrictJsonSchemaAndFlex(CapturedOutput logs) throws Exception {
         RestClient.Builder builder = RestClient.builder();
         MockRestServiceServer server = MockRestServiceServer.bindTo(builder).build();
         String modelJson = """
@@ -50,6 +54,15 @@ class OpenAiPersonaCandidateGenerationClientTest {
                 Map.of("cnaeCode", "4781400")));
 
         assertThat((List<?>) output.get("candidatePersonas")).hasSize(3);
+        assertThat(logs.getOut())
+                .contains("Request OpenAI persona-candidate-generator")
+                .contains("Response OpenAI persona-candidate-generator")
+                .contains("jobId=job-1")
+                .contains("stageExecutionId=72")
+                .contains("cnaeCode=4781400")
+                .contains("\"service_tier\":\"flex\"")
+                .contains("\"output_text\"")
+                .doesNotContain("direct-key");
         server.verify();
     }
 


### PR DESCRIPTION
### Motivation

- Improve operational diagnostics for the `persona-candidate-generator` OpenAI calls so failures can be investigated with full request/response context without exposing the API key.
- Record the operational change in the release notes so the team knows requests and responses are now logged for NichoCNAE v3.

### Description

- Added structured logging of the OpenAI request and raw response in `OpenAiPersonaCandidateGenerationClient` via `logOpenAiRequest`, `logOpenAiResponse`, and `toJsonForLog`, and invoked these from `generate` while avoiding exposure of the API key.
- Implemented resilient serialization for logged payloads with `toJsonForLog` to avoid failures when payloads are not directly serializable.
- Updated `OpenAiPersonaCandidateGenerationClientTest` to capture console output with `@ExtendWith(OutputCaptureExtension.class)` and assert that both request and response logs are present and that the API key value is not leaked.
- Documented the change in `docs/registros/oprm1.md` with an entry describing the new logging behavior for NichoCNAE v3.

### Testing

- Ran `OpenAiPersonaCandidateGenerationClientTest` and the modified test `shouldCallOpenAiResponsesApiWithStrictJsonSchemaAndFlex` passed while asserting request/response logs and absence of the API key.
- Ran the existing unit that validates key-from-file resolution (`shouldResolveApiKeyFromConfiguredSecureFile`) and it passed unchanged.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3e23029644832198d897c34b443744)