### PR TITLE
Aumenta timeouts HTTP do coletor OPRM para chamadas OpenAI e adiciona teste

### DIFF
--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -1524,3 +1524,9 @@
 - Diagnóstico: a falha recente da etapa `persona-candidate-generator` chegava ao banco e à tela como erro genérico, porque o log não registrava explicitamente `statusCode`, `statusText`, headers e corpo retornado pela OpenAI em respostas HTTP de erro.
 - Correção: o cliente OpenAI da etapa passou a registrar caminhos de diagnóstico para chave ausente, origem da chave por arquivo seguro, request enviado, response recebido, corpo vazio, erro HTTP com status/corpo, falha genérica com tipo/mensagem da exceção e ausência de texto JSON extraível.
 - Prevenção de recorrência: adicionado teste unitário cobrindo erro HTTP 400 da OpenAI e validando que o log contém status e corpo do provedor sem expor a chave direta.
+
+## 2026-06-26 — NichoCNAE v3: timeout ampliado para OpenAI
+
+- Diagnóstico: a etapa `persona-candidate-generator` do job `nichocnae-v3-4781400-1782477451721` falhou durante POST para `https://api.openai.com/v1/responses` com `Broken pipe`, após a chave e o payload terem sido resolvidos corretamente.
+- Correção: o `RestClient` compartilhado do executor OPRM passou a usar timeout de conexão de 30 segundos e timeout de leitura de 5 minutos, reduzindo falhas prematuras em chamadas OpenAI longas em modo Flex.
+- Prevenção de recorrência: adicionado teste unitário garantindo que os timeouts ampliados permaneçam configurados no cliente HTTP do coletor.

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/oprmcoletormei/marketimport/config/OprmMarketImportConfig.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/oprmcoletormei/marketimport/config/OprmMarketImportConfig.java
@@ -4,9 +4,12 @@ import com.marketinghub.nichocnae.meiaudiencesegmenter.MeiAudienceSegmenterOpenA
 import com.marketinghub.nichocnae.nicheresearchseedbuilder.NicheResearchSeedBuilderOpenAiProperties;
 import com.marketinghub.nichocnae.sourcesearcher.GoogleCustomSearchProperties;
 import com.marketinghub.nichocnaev3.pipeline.personacandidategenerator.PersonaCandidateOpenAiProperties;
+import java.time.Duration;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.http.client.ClientHttpRequestFactory;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
 import org.springframework.web.client.RestClient;
 
 /** Centraliza beans e propriedades operacionais usados pelo coletor OPRM. */
@@ -20,10 +23,21 @@ import org.springframework.web.client.RestClient;
         GoogleCustomSearchProperties.class
 })
 public class OprmMarketImportConfig {
+    private static final Duration HTTP_CONNECT_TIMEOUT = Duration.ofSeconds(30);
+    private static final Duration HTTP_READ_TIMEOUT = Duration.ofMinutes(5);
 
-    /** Cria o cliente HTTP compartilhado para integrações externas do coletor. */
+    /** Cria o cliente HTTP compartilhado para integrações externas do coletor com timeout ampliado. */
     @Bean
-    RestClient restClient() {
-        return RestClient.builder().build();
+    RestClient restClient(ClientHttpRequestFactory requestFactory) {
+        return RestClient.builder().requestFactory(requestFactory).build();
+    }
+
+    /** Define timeouts HTTP para chamadas externas longas, especialmente OpenAI em modo Flex. */
+    @Bean
+    ClientHttpRequestFactory requestFactory() {
+        SimpleClientHttpRequestFactory requestFactory = new SimpleClientHttpRequestFactory();
+        requestFactory.setConnectTimeout(HTTP_CONNECT_TIMEOUT);
+        requestFactory.setReadTimeout(HTTP_READ_TIMEOUT);
+        return requestFactory;
     }
 }

--- a/oprm-coletor-mei/src/test/java/com/marketinghub/oprmcoletormei/marketimport/config/OprmMarketImportConfigTest.java
+++ b/oprm-coletor-mei/src/test/java/com/marketinghub/oprmcoletormei/marketimport/config/OprmMarketImportConfigTest.java
@@ -1,0 +1,22 @@
+package com.marketinghub.oprmcoletormei.marketimport.config;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.DirectFieldAccessor;
+import org.springframework.http.client.SimpleClientHttpRequestFactory;
+
+/** Valida a configuração HTTP operacional compartilhada pelo coletor OPRM. */
+class OprmMarketImportConfigTest {
+
+    /** Garante timeout suficiente para chamadas OpenAI em modo Flex sem quedas prematuras. */
+    @Test
+    void requestFactoryUsesExtendedTimeoutsForLongOpenAiCalls() {
+        SimpleClientHttpRequestFactory requestFactory =
+                (SimpleClientHttpRequestFactory) new OprmMarketImportConfig().requestFactory();
+        DirectFieldAccessor accessor = new DirectFieldAccessor(requestFactory);
+
+        assertThat(accessor.getPropertyValue("connectTimeout")).isEqualTo(30_000);
+        assertThat(accessor.getPropertyValue("readTimeout")).isEqualTo(300_000);
+    }
+}


### PR DESCRIPTION
### Motivation

- Evitar falhas prematuras em chamadas longas ao endpoint da OpenAI que resultavam em `Broken pipe` durante execução em modo Flex.

### Description

- Atualiza `OprmMarketImportConfig` para expor um `ClientHttpRequestFactory` que configura `SimpleClientHttpRequestFactory` com `connectTimeout` de `30s` e `readTimeout` de `5m` e passa esse `requestFactory` para o bean `RestClient` compartilhado.
- Adiciona a constante de tempo e os imports necessários (`Duration`) e documenta que os timeouts foram ampliados para integrações externas, especialmente OpenAI.
- Atualiza a documentação `docs/registros/oprm1.md` registrando a mudança de timeout e a justificativa operacional.

### Testing

- Executado o novo teste unitário `OprmMarketImportConfigTest` que valida os valores de `connectTimeout` e `readTimeout` no `SimpleClientHttpRequestFactory`, e o teste passou com sucesso.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3e74e7506083219d147dec18bcab38)