### PR TITLE
Add Registro de pipelines doc for NichoCNAE v3

### DIFF
--- a/docs/registros/pipeline.md
+++ b/docs/registros/pipeline.md
@@ -1,0 +1,73 @@
+# Registro de pipelines
+
+## 2026-06-26 — Mapa do pipeline NichoCNAE v3
+
+### Visão geral
+
+- **Executor real do pipeline v3:** `oprm-coletor-mei`.
+- **Pacote executor:** `com.marketinghub.pipelines.nichocnae.v3`.
+- **Backend fonte de verdade e controle:** `backend/ads-service`.
+- **Pacote backend:** `com.marketinghub.pipelines.oprm.nichocnae.v3`.
+- **Padrão de comunicação:** o executor consome pendências no endpoint `pending` do backend, executa a etapa e devolve `complete` ou `fail`.
+
+### Pacotes no módulo executor `oprm-coletor-mei`
+
+Raiz do executor:
+
+- `com.marketinghub.pipelines.nichocnae.v3`
+
+Subpacotes identificados:
+
+- `cnaeintake`
+- `core`
+- `execution`
+- `personacandidategenerator`
+- `personatournament`
+- `routinequeryplanner`
+- `sourcesearcher`
+- `sourcefetcher`
+- `routinesignalextractor`
+- `dailytaskssynthesizer`
+- `qualitygate`
+- `personaroutinematerializer`
+
+### Pacotes no backend `backend/ads-service`
+
+Raiz backend:
+
+- `com.marketinghub.pipelines.oprm.nichocnae.v3`
+
+Subpacotes principais identificados:
+
+- `cnaeintake`
+- `personacandidategenerator`
+- `personatournament`
+- `routinequeryplanner`
+- `sourcesearcher`
+- `sourcefetcher`
+- `routinesignalextractor`
+- `dailytaskssynthesizer`
+- `qualitygate`
+- `personaroutinematerializer`
+- `progress`
+- `shared`
+
+### Etapas v3 registradas
+
+- `cnae-intake`
+- `persona-candidate-generator`
+- `persona-tournament`
+- `routine-query-planner`
+- `source-searcher`
+- `source-fetcher`
+- `routine-signal-extractor`
+- `daily-tasks-synthesizer`
+- `quality-gate`
+- `persona-routine-materializer`
+
+### Endpoints e leitura administrativa
+
+- O padrão interno por etapa é `/api/internal/oprm/nichocnae/v3/<stageCode>/stage-executions`.
+- A leitura administrativa de progresso fica no pacote `com.marketinghub.pipelines.oprm.nichocnae.v3.progress`.
+- O endpoint administrativo de progresso é `/api/oprm/nichocnae/v3/cnaes/{cnaeCode}/progress`.
+- A confirmação de finalização usa `/api/oprm/nichocnae/v3/cnaes/{cnaeCode}/progress/confirm-finalization`.


### PR DESCRIPTION
### Motivation

- Registrar e centralizar informações do pipeline NichoCNAE v3 incluindo executor, backend e padrão de comunicação.
- Documentar os pacotes e subpacotes identificados no executor `oprm-coletor-mei` e no backend `backend/ads-service` para facilitar navegação de equipe.
- Explicitar as etapas registradas e os endpoints administrativos usados para progresso e confirmação de finalização.

### Description

- Adiciona o arquivo `docs/registros/pipeline.md` com visão geral do pipeline v3 e do executor real `oprm-coletor-mei`.
- Lista os pacotes raiz e subpacotes do executor (`com.marketinghub.pipelines.nichocnae.v3`) e do backend (`com.marketinghub.pipelines.oprm.nichocnae.v3`).
- Documenta as etapas registradas do pipeline e os padrões de endpoint internos como `/api/internal/oprm/nichocnae/v3/<stageCode>/stage-executions` e os endpoints administrativos `/api/oprm/nichocnae/v3/cnaes/{cnaeCode}/progress` e `/api/oprm/nichocnae/v3/cnaes/{cnaeCode}/progress/confirm-finalization`.

### Testing

- Nenhum teste automatizado foi executado pois a mudança é estritamente de documentação.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3eb4025a8c8321bd21e473bdac5661)