### PR TITLE
Add `POST /start` endpoints and `start` service methods for NichoCNAE v3 stages

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/cnaeintake/controller/BackendCnaeIntakeController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/cnaeintake/controller/BackendCnaeIntakeController.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 /** Controller canônico da etapa cnae-intake do pipeline NichoCNAE v3. */
@@ -22,6 +23,12 @@ public class BackendCnaeIntakeController {
     /** Inicializa o controller com service canônico da etapa. */
     public BackendCnaeIntakeController(BackendCnaeIntakeService service) {
         this.service = service;
+    }
+
+    /** Inicia uma execução pendente da etapa a partir do CNAE informado pela tela. */
+    @PostMapping("/start")
+    public CnaeIntakeCreateResponse start(@RequestParam String cnaeCode) {
+        return service.start(cnaeCode);
     }
 
     /** Cria uma execução pendente da etapa cnae-intake. */

--- a/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/cnaeintake/service/BackendCnaeIntakeService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/cnaeintake/service/BackendCnaeIntakeService.java
@@ -23,6 +23,11 @@ public class BackendCnaeIntakeService extends OprmNichoCnaeV3StageServiceSupport
         return toCreateResponse(doCreate(jobId, cnaeCode, inputPayload, attemptNumber, knowledgeVersion));
     }
 
+    /** Inicia pendência da etapa para o CNAE informado pela tela administrativa. */
+    public CnaeIntakeCreateResponse start(String cnaeCode) {
+        return create(null, cnaeCode, "{\"cnaeCode\":\"" + cnaeCode + "\"}", 1, 1);
+    }
+
     /** Lista pendências da etapa cnae-intake para o executor OPRM. */
     public List<CnaeIntakePendingResponse> pending() {
         return pendingExecutions().stream().map(this::toPendingResponse).toList();

--- a/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/dailytaskssynthesizer/controller/BackendDailyTasksSynthesizerController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/dailytaskssynthesizer/controller/BackendDailyTasksSynthesizerController.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 /** Controller canônico da etapa daily-tasks-synthesizer do pipeline NichoCNAE v3. */
@@ -22,6 +23,12 @@ public class BackendDailyTasksSynthesizerController {
     /** Inicializa o controller com service canônico da etapa. */
     public BackendDailyTasksSynthesizerController(BackendDailyTasksSynthesizerService service) {
         this.service = service;
+    }
+
+    /** Inicia uma execução pendente da etapa a partir do CNAE informado pela tela. */
+    @PostMapping("/start")
+    public DailyTasksSynthesizerCreateResponse start(@RequestParam String cnaeCode) {
+        return service.start(cnaeCode);
     }
 
     /** Cria uma execução pendente da etapa daily-tasks-synthesizer. */

--- a/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/dailytaskssynthesizer/service/BackendDailyTasksSynthesizerService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/dailytaskssynthesizer/service/BackendDailyTasksSynthesizerService.java
@@ -23,6 +23,11 @@ public class BackendDailyTasksSynthesizerService extends OprmNichoCnaeV3StageSer
         return toCreateResponse(doCreate(jobId, cnaeCode, inputPayload, attemptNumber, knowledgeVersion));
     }
 
+    /** Inicia pendência da etapa para o CNAE informado pela tela administrativa. */
+    public DailyTasksSynthesizerCreateResponse start(String cnaeCode) {
+        return create(null, cnaeCode, "{\"cnaeCode\":\"" + cnaeCode + "\"}", 1, 1);
+    }
+
     /** Lista pendências da etapa daily-tasks-synthesizer para o executor OPRM. */
     public List<DailyTasksSynthesizerPendingResponse> pending() {
         return pendingExecutions().stream().map(this::toPendingResponse).toList();

--- a/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/personacandidategenerator/controller/BackendPersonaCandidateGeneratorController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/personacandidategenerator/controller/BackendPersonaCandidateGeneratorController.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 /** Controller canônico da etapa persona-candidate-generator do pipeline NichoCNAE v3. */
@@ -22,6 +23,12 @@ public class BackendPersonaCandidateGeneratorController {
     /** Inicializa o controller com service canônico da etapa. */
     public BackendPersonaCandidateGeneratorController(BackendPersonaCandidateGeneratorService service) {
         this.service = service;
+    }
+
+    /** Inicia uma execução pendente da etapa a partir do CNAE informado pela tela. */
+    @PostMapping("/start")
+    public PersonaCandidateGeneratorCreateResponse start(@RequestParam String cnaeCode) {
+        return service.start(cnaeCode);
     }
 
     /** Cria uma execução pendente da etapa persona-candidate-generator. */

--- a/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/personacandidategenerator/service/BackendPersonaCandidateGeneratorService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/personacandidategenerator/service/BackendPersonaCandidateGeneratorService.java
@@ -23,6 +23,11 @@ public class BackendPersonaCandidateGeneratorService extends OprmNichoCnaeV3Stag
         return toCreateResponse(doCreate(jobId, cnaeCode, inputPayload, attemptNumber, knowledgeVersion));
     }
 
+    /** Inicia pendência da etapa para o CNAE informado pela tela administrativa. */
+    public PersonaCandidateGeneratorCreateResponse start(String cnaeCode) {
+        return create(null, cnaeCode, "{\"cnaeCode\":\"" + cnaeCode + "\"}", 1, 1);
+    }
+
     /** Lista pendências da etapa persona-candidate-generator para o executor OPRM. */
     public List<PersonaCandidateGeneratorPendingResponse> pending() {
         return pendingExecutions().stream().map(this::toPendingResponse).toList();

--- a/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/personaroutinematerializer/controller/BackendPersonaRoutineMaterializerController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/personaroutinematerializer/controller/BackendPersonaRoutineMaterializerController.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 /** Controller canônico da etapa persona-routine-materializer do pipeline NichoCNAE v3. */
@@ -22,6 +23,12 @@ public class BackendPersonaRoutineMaterializerController {
     /** Inicializa o controller com service canônico da etapa. */
     public BackendPersonaRoutineMaterializerController(BackendPersonaRoutineMaterializerService service) {
         this.service = service;
+    }
+
+    /** Inicia uma execução pendente da etapa a partir do CNAE informado pela tela. */
+    @PostMapping("/start")
+    public PersonaRoutineMaterializerCreateResponse start(@RequestParam String cnaeCode) {
+        return service.start(cnaeCode);
     }
 
     /** Cria uma execução pendente da etapa persona-routine-materializer. */

--- a/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/personaroutinematerializer/service/BackendPersonaRoutineMaterializerService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/personaroutinematerializer/service/BackendPersonaRoutineMaterializerService.java
@@ -41,6 +41,11 @@ public class BackendPersonaRoutineMaterializerService extends OprmNichoCnaeV3Sta
         return toCreateResponse(doCreate(jobId, cnaeCode, inputPayload, attemptNumber, knowledgeVersion));
     }
 
+    /** Inicia pendência da etapa para o CNAE informado pela tela administrativa. */
+    public PersonaRoutineMaterializerCreateResponse start(String cnaeCode) {
+        return create(null, cnaeCode, "{\"cnaeCode\":\"" + cnaeCode + "\"}", 1, 1);
+    }
+
     /** Lista pendências da etapa persona-routine-materializer para o executor OPRM. */
     public List<PersonaRoutineMaterializerPendingResponse> pending() {
         return pendingExecutions().stream().map(this::toPendingResponse).toList();

--- a/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/personatournament/controller/BackendPersonaTournamentController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/personatournament/controller/BackendPersonaTournamentController.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 /** Controller canônico da etapa persona-tournament do pipeline NichoCNAE v3. */
@@ -22,6 +23,12 @@ public class BackendPersonaTournamentController {
     /** Inicializa o controller com service canônico da etapa. */
     public BackendPersonaTournamentController(BackendPersonaTournamentService service) {
         this.service = service;
+    }
+
+    /** Inicia uma execução pendente da etapa a partir do CNAE informado pela tela. */
+    @PostMapping("/start")
+    public PersonaTournamentCreateResponse start(@RequestParam String cnaeCode) {
+        return service.start(cnaeCode);
     }
 
     /** Cria uma execução pendente da etapa persona-tournament. */

--- a/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/personatournament/service/BackendPersonaTournamentService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/personatournament/service/BackendPersonaTournamentService.java
@@ -23,6 +23,11 @@ public class BackendPersonaTournamentService extends OprmNichoCnaeV3StageService
         return toCreateResponse(doCreate(jobId, cnaeCode, inputPayload, attemptNumber, knowledgeVersion));
     }
 
+    /** Inicia pendência da etapa para o CNAE informado pela tela administrativa. */
+    public PersonaTournamentCreateResponse start(String cnaeCode) {
+        return create(null, cnaeCode, "{\"cnaeCode\":\"" + cnaeCode + "\"}", 1, 1);
+    }
+
     /** Lista pendências da etapa persona-tournament para o executor OPRM. */
     public List<PersonaTournamentPendingResponse> pending() {
         return pendingExecutions().stream().map(this::toPendingResponse).toList();

--- a/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/qualitygate/controller/BackendQualityGateController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/qualitygate/controller/BackendQualityGateController.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 /** Controller canônico da etapa quality-gate do pipeline NichoCNAE v3. */
@@ -22,6 +23,12 @@ public class BackendQualityGateController {
     /** Inicializa o controller com service canônico da etapa. */
     public BackendQualityGateController(BackendQualityGateService service) {
         this.service = service;
+    }
+
+    /** Inicia uma execução pendente da etapa a partir do CNAE informado pela tela. */
+    @PostMapping("/start")
+    public QualityGateCreateResponse start(@RequestParam String cnaeCode) {
+        return service.start(cnaeCode);
     }
 
     /** Cria uma execução pendente da etapa quality-gate. */

--- a/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/qualitygate/service/BackendQualityGateService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/qualitygate/service/BackendQualityGateService.java
@@ -23,6 +23,11 @@ public class BackendQualityGateService extends OprmNichoCnaeV3StageServiceSuppor
         return toCreateResponse(doCreate(jobId, cnaeCode, inputPayload, attemptNumber, knowledgeVersion));
     }
 
+    /** Inicia pendência da etapa para o CNAE informado pela tela administrativa. */
+    public QualityGateCreateResponse start(String cnaeCode) {
+        return create(null, cnaeCode, "{\"cnaeCode\":\"" + cnaeCode + "\"}", 1, 1);
+    }
+
     /** Lista pendências da etapa quality-gate para o executor OPRM. */
     public List<QualityGatePendingResponse> pending() {
         return pendingExecutions().stream().map(this::toPendingResponse).toList();

--- a/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/routinequeryplanner/controller/BackendRoutineQueryPlannerController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/routinequeryplanner/controller/BackendRoutineQueryPlannerController.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 /** Controller canônico da etapa routine-query-planner do pipeline NichoCNAE v3. */
@@ -22,6 +23,12 @@ public class BackendRoutineQueryPlannerController {
     /** Inicializa o controller com service canônico da etapa. */
     public BackendRoutineQueryPlannerController(BackendRoutineQueryPlannerService service) {
         this.service = service;
+    }
+
+    /** Inicia uma execução pendente da etapa a partir do CNAE informado pela tela. */
+    @PostMapping("/start")
+    public RoutineQueryPlannerCreateResponse start(@RequestParam String cnaeCode) {
+        return service.start(cnaeCode);
     }
 
     /** Cria uma execução pendente da etapa routine-query-planner. */

--- a/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/routinequeryplanner/service/BackendRoutineQueryPlannerService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/routinequeryplanner/service/BackendRoutineQueryPlannerService.java
@@ -23,6 +23,11 @@ public class BackendRoutineQueryPlannerService extends OprmNichoCnaeV3StageServi
         return toCreateResponse(doCreate(jobId, cnaeCode, inputPayload, attemptNumber, knowledgeVersion));
     }
 
+    /** Inicia pendência da etapa para o CNAE informado pela tela administrativa. */
+    public RoutineQueryPlannerCreateResponse start(String cnaeCode) {
+        return create(null, cnaeCode, "{\"cnaeCode\":\"" + cnaeCode + "\"}", 1, 1);
+    }
+
     /** Lista pendências da etapa routine-query-planner para o executor OPRM. */
     public List<RoutineQueryPlannerPendingResponse> pending() {
         return pendingExecutions().stream().map(this::toPendingResponse).toList();

--- a/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/routinesignalextractor/controller/BackendRoutineSignalExtractorController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/routinesignalextractor/controller/BackendRoutineSignalExtractorController.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 /** Controller canônico da etapa routine-signal-extractor do pipeline NichoCNAE v3. */
@@ -22,6 +23,12 @@ public class BackendRoutineSignalExtractorController {
     /** Inicializa o controller com service canônico da etapa. */
     public BackendRoutineSignalExtractorController(BackendRoutineSignalExtractorService service) {
         this.service = service;
+    }
+
+    /** Inicia uma execução pendente da etapa a partir do CNAE informado pela tela. */
+    @PostMapping("/start")
+    public RoutineSignalExtractorCreateResponse start(@RequestParam String cnaeCode) {
+        return service.start(cnaeCode);
     }
 
     /** Cria uma execução pendente da etapa routine-signal-extractor. */

--- a/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/routinesignalextractor/service/BackendRoutineSignalExtractorService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/routinesignalextractor/service/BackendRoutineSignalExtractorService.java
@@ -23,6 +23,11 @@ public class BackendRoutineSignalExtractorService extends OprmNichoCnaeV3StageSe
         return toCreateResponse(doCreate(jobId, cnaeCode, inputPayload, attemptNumber, knowledgeVersion));
     }
 
+    /** Inicia pendência da etapa para o CNAE informado pela tela administrativa. */
+    public RoutineSignalExtractorCreateResponse start(String cnaeCode) {
+        return create(null, cnaeCode, "{\"cnaeCode\":\"" + cnaeCode + "\"}", 1, 1);
+    }
+
     /** Lista pendências da etapa routine-signal-extractor para o executor OPRM. */
     public List<RoutineSignalExtractorPendingResponse> pending() {
         return pendingExecutions().stream().map(this::toPendingResponse).toList();

--- a/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/sourcefetcher/controller/BackendSourceFetcherV3Controller.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/sourcefetcher/controller/BackendSourceFetcherV3Controller.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 /** Controller canônico da etapa source-fetcher do pipeline NichoCNAE v3. */
@@ -22,6 +23,12 @@ public class BackendSourceFetcherV3Controller {
     /** Inicializa o controller com service canônico da etapa. */
     public BackendSourceFetcherV3Controller(BackendSourceFetcherV3Service service) {
         this.service = service;
+    }
+
+    /** Inicia uma execução pendente da etapa a partir do CNAE informado pela tela. */
+    @PostMapping("/start")
+    public SourceFetcherCreateResponse start(@RequestParam String cnaeCode) {
+        return service.start(cnaeCode);
     }
 
     /** Cria uma execução pendente da etapa source-fetcher. */

--- a/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/sourcefetcher/service/BackendSourceFetcherV3Service.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/sourcefetcher/service/BackendSourceFetcherV3Service.java
@@ -23,6 +23,11 @@ public class BackendSourceFetcherV3Service extends OprmNichoCnaeV3StageServiceSu
         return toCreateResponse(doCreate(jobId, cnaeCode, inputPayload, attemptNumber, knowledgeVersion));
     }
 
+    /** Inicia pendência da etapa para o CNAE informado pela tela administrativa. */
+    public SourceFetcherCreateResponse start(String cnaeCode) {
+        return create(null, cnaeCode, "{\"cnaeCode\":\"" + cnaeCode + "\"}", 1, 1);
+    }
+
     /** Lista pendências da etapa source-fetcher para o executor OPRM. */
     public List<SourceFetcherPendingResponse> pending() {
         return pendingExecutions().stream().map(this::toPendingResponse).toList();

--- a/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/sourcesearcher/controller/BackendSourceSearcherV3Controller.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/sourcesearcher/controller/BackendSourceSearcherV3Controller.java
@@ -11,6 +11,7 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 /** Controller canônico da etapa source-searcher do pipeline NichoCNAE v3. */
@@ -22,6 +23,12 @@ public class BackendSourceSearcherV3Controller {
     /** Inicializa o controller com service canônico da etapa. */
     public BackendSourceSearcherV3Controller(BackendSourceSearcherV3Service service) {
         this.service = service;
+    }
+
+    /** Inicia uma execução pendente da etapa a partir do CNAE informado pela tela. */
+    @PostMapping("/start")
+    public SourceSearcherCreateResponse start(@RequestParam String cnaeCode) {
+        return service.start(cnaeCode);
     }
 
     /** Cria uma execução pendente da etapa source-searcher. */

--- a/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/sourcesearcher/service/BackendSourceSearcherV3Service.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/sourcesearcher/service/BackendSourceSearcherV3Service.java
@@ -23,6 +23,11 @@ public class BackendSourceSearcherV3Service extends OprmNichoCnaeV3StageServiceS
         return toCreateResponse(doCreate(jobId, cnaeCode, inputPayload, attemptNumber, knowledgeVersion));
     }
 
+    /** Inicia pendência da etapa para o CNAE informado pela tela administrativa. */
+    public SourceSearcherCreateResponse start(String cnaeCode) {
+        return create(null, cnaeCode, "{\"cnaeCode\":\"" + cnaeCode + "\"}", 1, 1);
+    }
+
     /** Lista pendências da etapa source-searcher para o executor OPRM. */
     public List<SourceSearcherPendingResponse> pending() {
         return pendingExecutions().stream().map(this::toPendingResponse).toList();

--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -1545,3 +1545,9 @@
 - Objetivo: evitar nova divergência entre a refatoração de pacotes, os protocolos de arquitetura por etapa e a documentação usada como fonte de verdade.
 
 - 2026-06-26 00:00:00 (UTC): padronizado o NichoCNAE v3 para manter no executor apenas a raiz `com.marketinghub.pipelines.nichocnae.v3`; removidos do módulo os pacotes legados `com.marketinghub.nichocnae` e `com.marketinghub.nichocnaev2`. No backend, o pacote v3 foi movido de `com.marketinghub.pipelines.oprm.nichocnae.v3` para `com.marketinghub.oprmcoletormei.nichocnae.v3`, preservando o backend como fonte de verdade das execuções e o executor como consumidor dos endpoints `pending`.
+
+## 2026-06-26 — NichoCNAE v3: endpoint start por etapa no backend
+
+- Correção: cada etapa interna do backend NichoCNAE v3 passou a expor `POST /start` recebendo `cnaeCode` como parâmetro para criar uma execução pendente da própria etapa.
+- Service: cada service canônico da etapa recebeu método `start(String cnaeCode)`, mantendo o backend como fonte de verdade para abertura de pendências e preservando o executor externo apenas como consumidor do endpoint `pending`.
+- Contrato: a documentação Swagger v3 foi atualizada com o novo endpoint genérico por etapa.

--- a/docs/swagger/oprm-nichocnae-v3-swagger.yaml
+++ b/docs/swagger/oprm-nichocnae-v3-swagger.yaml
@@ -26,6 +26,27 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/StageExecutionResponse'
+  /api/internal/oprm/nichocnae/v3/{stage}/stage-executions/start:
+    post:
+      summary: Inicia uma execução pendente da etapa NichoCNAE v3 para o CNAE informado.
+      parameters:
+        - name: stage
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: cnaeCode
+          in: query
+          required: true
+          schema:
+            type: string
+      responses:
+        '200':
+          description: Execução iniciada.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StageExecutionResponse'
   /api/internal/oprm/nichocnae/v3/{stage}/stage-executions/cnaes/{cnaeCode}:
     post:
       summary: Inicia a primeira execução v3 para um CNAE.


### PR DESCRIPTION
### Motivation
- Enable the administrative UI to open a pipeline execution for a given CNAE directly against the backend while keeping the backend as the source of truth for stage executions. 
- Provide a simple, consistent contract across all NichoCNAE v3 stages so the frontend can trigger work without requiring the executor to create the initial pending item.

### Description
- Added `POST /start` endpoints to each NichoCNAE v3 stage controller that accept `cnaeCode` as a query parameter and delegate to the stage service via `service.start(cnaeCode)`.
- Implemented `start(String cnaeCode)` methods in each corresponding `Backend*Service` that call the existing `create` flow using `null` jobId and a minimal input payload to create a pending execution.
- Updated the API contract in `docs/swagger/oprm-nichocnae-v3-swagger.yaml` with the new `/stage-executions/start` path and documented `cnaeCode` as a query parameter.
- Recorded the change in the OPRM register `docs/registros/oprm1.md` and applied the edits across the set of stage controllers/services under `com.marketinghub.oprmcoletormei.nichocnae.v3` (approx. 20 files modified: controllers, services, Swagger and docs).

### Testing
- Verified the backend compiles successfully with `mvn -q -DskipTests compile` and no compilation errors were reported.
- Executed the focused unit test `mvn -q -Dtest='com.marketinghub.oprmcoletormei.nichocnae.v3.personaroutinematerializer.service.BackendPersonaRoutineMaterializerServiceTest' test` and it completed successfully.
- Performed repository checks to ensure code formatting and diffs are clean and no outstanding compile-time issues were found.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3ec92eb1648321befd84c42f96a26d)