### PR TITLE
Add start endpoints for MOIS dossiê v1 stages

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/dossiersynthesis/controller/DossierDossierSynthesisController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/dossiersynthesis/controller/DossierDossierSynthesisController.java
@@ -8,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 /** Expõe a borda HTTP interna da etapa síntese final do dossiê do pipeline de dossiê MOIS v1. */
@@ -17,6 +18,12 @@ import org.springframework.web.bind.annotation.RestController;
 public class DossierDossierSynthesisController {
 
     private final DossierDossierSynthesisService service;
+
+    /** Inicia manualmente a etapa para o produto informado pela chave operacional. */
+    @PostMapping("/start")
+    public void start(@RequestParam("productKey") String productKey) {
+        service.start(productKey);
+    }
 
     /** Expõe o ponto inicial canônico de consumo da fila pelo módulo executor. */
     @PostMapping("/pending")

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/dossiersynthesis/service/DossierDossierSynthesisService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/dossiersynthesis/service/DossierDossierSynthesisService.java
@@ -9,6 +9,11 @@ import org.springframework.stereotype.Service;
 @Service
 public class DossierDossierSynthesisService {
 
+    /** Registra a intenção de iniciar a etapa para o produto informado sem executar a rotina no backend. */
+    public void start(String productKey) {
+        // Método reservado para criação futura da pendência canônica da etapa para a chave do produto.
+    }
+
     /** Entrega trabalhos pendentes ao executor sem assumir controle operacional de execução no backend. */
     public DossierDossierSynthesisPendingResponse pending(DossierDossierSynthesisPendingRequest request) {
         return new DossierDossierSynthesisPendingResponse(false, List.of());

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/intake/controller/DossierIntakeController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/intake/controller/DossierIntakeController.java
@@ -8,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 /** Expõe a borda HTTP interna da etapa entrada inicial do pipeline de dossiê MOIS v1. */
@@ -17,6 +18,12 @@ import org.springframework.web.bind.annotation.RestController;
 public class DossierIntakeController {
 
     private final DossierIntakeService service;
+
+    /** Inicia manualmente a etapa para o produto informado pela chave operacional. */
+    @PostMapping("/start")
+    public void start(@RequestParam("productKey") String productKey) {
+        service.start(productKey);
+    }
 
     /** Expõe o ponto inicial canônico de consumo da fila pelo módulo executor. */
     @PostMapping("/pending")

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/intake/service/DossierIntakeService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/intake/service/DossierIntakeService.java
@@ -9,6 +9,11 @@ import org.springframework.stereotype.Service;
 @Service
 public class DossierIntakeService {
 
+    /** Registra a intenção de iniciar a etapa para o produto informado sem executar a rotina no backend. */
+    public void start(String productKey) {
+        // Método reservado para criação futura da pendência canônica da etapa para a chave do produto.
+    }
+
     /** Entrega trabalhos pendentes ao executor sem assumir controle operacional de execução no backend. */
     public DossierIntakePendingResponse pending(DossierIntakePendingRequest request) {
         return new DossierIntakePendingResponse(false, List.of());

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/investigationanchorbuilder/controller/DossierInvestigationAnchorBuilderController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/investigationanchorbuilder/controller/DossierInvestigationAnchorBuilderController.java
@@ -8,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 /** Expõe a borda HTTP interna da etapa geração de âncoras de investigação do pipeline de dossiê MOIS v1. */
@@ -17,6 +18,12 @@ import org.springframework.web.bind.annotation.RestController;
 public class DossierInvestigationAnchorBuilderController {
 
     private final DossierInvestigationAnchorBuilderService service;
+
+    /** Inicia manualmente a etapa para o produto informado pela chave operacional. */
+    @PostMapping("/start")
+    public void start(@RequestParam("productKey") String productKey) {
+        service.start(productKey);
+    }
 
     /** Expõe o ponto inicial canônico de consumo da fila pelo módulo executor. */
     @PostMapping("/pending")

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/investigationanchorbuilder/service/DossierInvestigationAnchorBuilderService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/investigationanchorbuilder/service/DossierInvestigationAnchorBuilderService.java
@@ -9,6 +9,11 @@ import org.springframework.stereotype.Service;
 @Service
 public class DossierInvestigationAnchorBuilderService {
 
+    /** Registra a intenção de iniciar a etapa para o produto informado sem executar a rotina no backend. */
+    public void start(String productKey) {
+        // Método reservado para criação futura da pendência canônica da etapa para a chave do produto.
+    }
+
     /** Entrega trabalhos pendentes ao executor sem assumir controle operacional de execução no backend. */
     public DossierInvestigationAnchorBuilderPendingResponse pending(DossierInvestigationAnchorBuilderPendingRequest request) {
         return new DossierInvestigationAnchorBuilderPendingResponse(false, List.of());

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/productunderstanding/controller/DossierProductUnderstandingController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/productunderstanding/controller/DossierProductUnderstandingController.java
@@ -8,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 /** Expõe a borda HTTP interna da etapa entendimento do produto do pipeline de dossiê MOIS v1. */
@@ -17,6 +18,12 @@ import org.springframework.web.bind.annotation.RestController;
 public class DossierProductUnderstandingController {
 
     private final DossierProductUnderstandingService service;
+
+    /** Inicia manualmente a etapa para o produto informado pela chave operacional. */
+    @PostMapping("/start")
+    public void start(@RequestParam("productKey") String productKey) {
+        service.start(productKey);
+    }
 
     /** Expõe o ponto inicial canônico de consumo da fila pelo módulo executor. */
     @PostMapping("/pending")

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/productunderstanding/service/DossierProductUnderstandingService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/productunderstanding/service/DossierProductUnderstandingService.java
@@ -9,6 +9,11 @@ import org.springframework.stereotype.Service;
 @Service
 public class DossierProductUnderstandingService {
 
+    /** Registra a intenção de iniciar a etapa para o produto informado sem executar a rotina no backend. */
+    public void start(String productKey) {
+        // Método reservado para criação futura da pendência canônica da etapa para a chave do produto.
+    }
+
     /** Entrega trabalhos pendentes ao executor sem assumir controle operacional de execução no backend. */
     public DossierProductUnderstandingPendingResponse pending(DossierProductUnderstandingPendingRequest request) {
         return new DossierProductUnderstandingPendingResponse(false, List.of());

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/sourceproductmatch/controller/DossierSourceProductMatchController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/sourceproductmatch/controller/DossierSourceProductMatchController.java
@@ -8,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 /** Expõe a borda HTTP interna da etapa validação de relação fonte-produto do pipeline de dossiê MOIS v1. */
@@ -17,6 +18,12 @@ import org.springframework.web.bind.annotation.RestController;
 public class DossierSourceProductMatchController {
 
     private final DossierSourceProductMatchService service;
+
+    /** Inicia manualmente a etapa para o produto informado pela chave operacional. */
+    @PostMapping("/start")
+    public void start(@RequestParam("productKey") String productKey) {
+        service.start(productKey);
+    }
 
     /** Expõe o ponto inicial canônico de consumo da fila pelo módulo executor. */
     @PostMapping("/pending")

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/sourceproductmatch/service/DossierSourceProductMatchService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/sourceproductmatch/service/DossierSourceProductMatchService.java
@@ -9,6 +9,11 @@ import org.springframework.stereotype.Service;
 @Service
 public class DossierSourceProductMatchService {
 
+    /** Registra a intenção de iniciar a etapa para o produto informado sem executar a rotina no backend. */
+    public void start(String productKey) {
+        // Método reservado para criação futura da pendência canônica da etapa para a chave do produto.
+    }
+
     /** Entrega trabalhos pendentes ao executor sem assumir controle operacional de execução no backend. */
     public DossierSourceProductMatchPendingResponse pending(DossierSourceProductMatchPendingRequest request) {
         return new DossierSourceProductMatchPendingResponse(false, List.of());

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/warmupmapbuilder/controller/DossierWarmupMapBuilderController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/warmupmapbuilder/controller/DossierWarmupMapBuilderController.java
@@ -8,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 /** Expõe a borda HTTP interna da etapa montagem do mapa de aquecimento do pipeline de dossiê MOIS v1. */
@@ -17,6 +18,12 @@ import org.springframework.web.bind.annotation.RestController;
 public class DossierWarmupMapBuilderController {
 
     private final DossierWarmupMapBuilderService service;
+
+    /** Inicia manualmente a etapa para o produto informado pela chave operacional. */
+    @PostMapping("/start")
+    public void start(@RequestParam("productKey") String productKey) {
+        service.start(productKey);
+    }
 
     /** Expõe o ponto inicial canônico de consumo da fila pelo módulo executor. */
     @PostMapping("/pending")

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/warmupmapbuilder/service/DossierWarmupMapBuilderService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/warmupmapbuilder/service/DossierWarmupMapBuilderService.java
@@ -9,6 +9,11 @@ import org.springframework.stereotype.Service;
 @Service
 public class DossierWarmupMapBuilderService {
 
+    /** Registra a intenção de iniciar a etapa para o produto informado sem executar a rotina no backend. */
+    public void start(String productKey) {
+        // Método reservado para criação futura da pendência canônica da etapa para a chave do produto.
+    }
+
     /** Entrega trabalhos pendentes ao executor sem assumir controle operacional de execução no backend. */
     public DossierWarmupMapBuilderPendingResponse pending(DossierWarmupMapBuilderPendingRequest request) {
         return new DossierWarmupMapBuilderPendingResponse(false, List.of());

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/warmupresourcediscovery/controller/DossierWarmupResourceDiscoveryController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/warmupresourcediscovery/controller/DossierWarmupResourceDiscoveryController.java
@@ -8,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 /** Expõe a borda HTTP interna da etapa descoberta de recursos de aquecimento do pipeline de dossiê MOIS v1. */
@@ -17,6 +18,12 @@ import org.springframework.web.bind.annotation.RestController;
 public class DossierWarmupResourceDiscoveryController {
 
     private final DossierWarmupResourceDiscoveryService service;
+
+    /** Inicia manualmente a etapa para o produto informado pela chave operacional. */
+    @PostMapping("/start")
+    public void start(@RequestParam("productKey") String productKey) {
+        service.start(productKey);
+    }
 
     /** Expõe o ponto inicial canônico de consumo da fila pelo módulo executor. */
     @PostMapping("/pending")

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/warmupresourcediscovery/service/DossierWarmupResourceDiscoveryService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/warmupresourcediscovery/service/DossierWarmupResourceDiscoveryService.java
@@ -9,6 +9,11 @@ import org.springframework.stereotype.Service;
 @Service
 public class DossierWarmupResourceDiscoveryService {
 
+    /** Registra a intenção de iniciar a etapa para o produto informado sem executar a rotina no backend. */
+    public void start(String productKey) {
+        // Método reservado para criação futura da pendência canônica da etapa para a chave do produto.
+    }
+
     /** Entrega trabalhos pendentes ao executor sem assumir controle operacional de execução no backend. */
     public DossierWarmupResourceDiscoveryPendingResponse pending(DossierWarmupResourceDiscoveryPendingRequest request) {
         return new DossierWarmupResourceDiscoveryPendingResponse(false, List.of());

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/warmupsignalextraction/controller/DossierWarmupSignalExtractionController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/warmupsignalextraction/controller/DossierWarmupSignalExtractionController.java
@@ -8,6 +8,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 /** Expõe a borda HTTP interna da etapa extração de sinais de aquecimento do pipeline de dossiê MOIS v1. */
@@ -17,6 +18,12 @@ import org.springframework.web.bind.annotation.RestController;
 public class DossierWarmupSignalExtractionController {
 
     private final DossierWarmupSignalExtractionService service;
+
+    /** Inicia manualmente a etapa para o produto informado pela chave operacional. */
+    @PostMapping("/start")
+    public void start(@RequestParam("productKey") String productKey) {
+        service.start(productKey);
+    }
 
     /** Expõe o ponto inicial canônico de consumo da fila pelo módulo executor. */
     @PostMapping("/pending")

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/warmupsignalextraction/service/DossierWarmupSignalExtractionService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/warmupsignalextraction/service/DossierWarmupSignalExtractionService.java
@@ -9,6 +9,11 @@ import org.springframework.stereotype.Service;
 @Service
 public class DossierWarmupSignalExtractionService {
 
+    /** Registra a intenção de iniciar a etapa para o produto informado sem executar a rotina no backend. */
+    public void start(String productKey) {
+        // Método reservado para criação futura da pendência canônica da etapa para a chave do produto.
+    }
+
     /** Entrega trabalhos pendentes ao executor sem assumir controle operacional de execução no backend. */
     public DossierWarmupSignalExtractionPendingResponse pending(DossierWarmupSignalExtractionPendingRequest request) {
         return new DossierWarmupSignalExtractionPendingResponse(false, List.of());


### PR DESCRIPTION
### Motivation
- Provide a simple manual trigger on backend side to start each MOIS dossiê v1 stage for a given product key while keeping the backend as a contract boundary and not moving execution logic to the backend.
- Keep a clear API surface for executors/workers to be able to receive a product-specific start command or for manual/testing needs without changing existing pending endpoints.

### Description
- Added `POST /start` endpoints to the controllers of the MOIS Sales Library Worker dossiê v1 stages that accept `productKey` as a `@RequestParam` and delegate to the stage service via `service.start(productKey)`; this was applied to the stages `intake`, `product-understanding`, `dossier-synthesis`, `investigation-anchor-builder`, `source-product-match`, `warmup-map-builder`, `warmup-resource-discovery` and `warmup-signal-extraction`.
- Added placeholder `start(String productKey)` methods to the corresponding services as no-op contract points reserved for future creation of canonical pendency entries, with a clarifying comment in each service method.
- Added required `import org.springframework.web.bind.annotation.RequestParam;` to the modified controllers and kept existing `pending` endpoints unchanged to preserve canonical pending contract.

### Testing
- Built the module with `./../mvnw -DskipTests package`, which succeeded.
- Ran unit/architecture tests with `./../mvnw test -Dtest='*Moissaleslibraryworker*Test,*Dossier*Test,ArquiteturaTest'`, which reported 1 failure (`ArquiteturaTest.moisDossieV1StagesMustExposeCanonicalStructure`) because the test expects the canonical package `com.marketinghub.pipelines.mois.dossie.v1.*` while the changes were applied under `com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.*` (pre-existing constraint unrelated to these endpoint additions).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3ec8e622188321bb386db9effa9f97)