### PR TITLE
Use `/start?cnaeCode=` endpoint when starting NichoCNAE v3 job

### DIFF
--- a/frontend/src/api/oprm/useStartOprmNichoCnaeV3Job.ts
+++ b/frontend/src/api/oprm/useStartOprmNichoCnaeV3Job.ts
@@ -14,7 +14,7 @@ async function startOprmNichoCnaeV3Job(
 ): Promise<OprmNichoCnaeV3JobStartResult> {
   const response = await fetch(
     buildApiUrl(
-      `/api/internal/oprm/nichocnae/v3/cnae-intake/stage-executions/cnaes/${encodeURIComponent(cnaeCode)}`,
+      `/api/internal/oprm/nichocnae/v3/cnae-intake/stage-executions/start?cnaeCode=${encodeURIComponent(cnaeCode)}`,
     ),
     { method: "POST" },
   );


### PR DESCRIPTION
### Motivation
- Align the frontend with the updated backend endpoint for starting NichoCNAE v3 jobs by sending the CNAE as a query parameter to the `/start` route instead of embedding it in the path.

### Description
- Updated `startOprmNichoCnaeV3Job` to call `
/api/internal/oprm/nichocnae/v3/cnae-intake/stage-executions/start?cnaeCode={...}` instead of the previous `/stage-executions/cnaes/{cnae}` path while keeping the `POST` method and response handling unchanged.

### Testing
- Ran the TypeScript build and existing automated test suite and they completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3ecc5f4e4c83219d159d9bd5d45429)