### PR TITLE
Start dossier pipeline via intake endpoint and update UI messaging

### DIFF
--- a/frontend/src/api/mois/useMoisSalesLibrary.ts
+++ b/frontend/src/api/mois/useMoisSalesLibrary.ts
@@ -4,7 +4,6 @@ import type {
   MoisCollectedReferenceUrlSummary,
   MoisMarketWarmupOpportunityRankingResponse,
   MoisMarketWarmupReprocessStaleResponse,
-  MoisMarketWarmupRequestResponse,
   MoisMarketWarmupSearchAttemptListResponse,
   MoisMarketWarmupSignalListResponse,
   MoisMarketWarmupSourceListResponse,
@@ -426,14 +425,15 @@ export function useReprocessStaleMoisSalesLibraryMarketWarmup(
   });
 }
 
-export function useRequestMoisSalesLibraryMarketWarmup(workspaceId: string) {
+export function useStartMoisDossierPipeline(workspaceId: string) {
   const queryClient = useQueryClient();
   return useMutation({
     mutationFn: async (pageId: number) => {
-      const { data } = await axios.post<MoisMarketWarmupRequestResponse>(
-        `/api/mois/sales-library/pages/${pageId}/market-warmup:request`,
+      await axios.post(
+        "/api/internal/mois/dossie/v1/intake/stage-executions/start",
+        undefined,
+        { params: { productKey: String(pageId) } },
       );
-      return data;
     },
     onSuccess: (_, pageId) => {
       void queryClient.invalidateQueries({

--- a/frontend/src/pages/mois/MoisSalesPageLibraryDetailPage.tsx
+++ b/frontend/src/pages/mois/MoisSalesPageLibraryDetailPage.tsx
@@ -7,7 +7,7 @@ import {
   useMoisSalesLibraryMarketWarmupSearchAttempts,
   useMoisSalesLibraryMarketWarmupSources,
   useMoisSalesLibraryPage,
-  useRequestMoisSalesLibraryMarketWarmup,
+  useStartMoisDossierPipeline,
   useMoisSalesLibraryPageExecutions,
   useMoisSalesLibraryPages,
   useUpdateMoisSalesLibraryPageStatus,
@@ -151,8 +151,7 @@ export default function MoisSalesPageLibraryDetailPage() {
   const pagesQuery = useMoisSalesLibraryPages(WORKSPACE_ID, 1, PAGE_SIZE);
   const updateStatusMutation =
     useUpdateMoisSalesLibraryPageStatus(WORKSPACE_ID);
-  const requestWarmupMutation =
-    useRequestMoisSalesLibraryMarketWarmup(WORKSPACE_ID);
+  const requestWarmupMutation = useStartMoisDossierPipeline(WORKSPACE_ID);
 
   const currentIndex =
     pagesQuery.data?.items.findIndex((item) => item.pageId === validPageId) ??
@@ -437,20 +436,20 @@ export default function MoisSalesPageLibraryDetailPage() {
 
       {requestWarmupMutation.isSuccess ? (
         <div className="alert alert-success mb-0">
-          Dossiê enviado para fila. A tela sempre mostrará o dossiê mais
-          recente retornado pelo backend.
+          Pipeline v1 do dossiê iniciado pela etapa intake. A tela sempre
+          mostrará o dossiê mais recente retornado pelo backend.
         </div>
       ) : null}
       {requestWarmupMutation.isError ? (
         <div className="alert alert-danger mb-0">
-          Falha ao solicitar dossiê.
+          Falha ao iniciar pipeline v1 do dossiê.
         </div>
       ) : null}
       {hasWarmupDossier && !hasActiveWarmupDossier ? (
         <div className="alert alert-info mb-0">
           Já existe um dossiê para esta página
-          {warmupStatus ? ` com status ${labelStatus(warmupStatus)}` : ""}.
-          Você pode usar o resultado exibido abaixo ou clicar em
+          {warmupStatus ? ` com status ${labelStatus(warmupStatus)}` : ""}. Você
+          pode usar o resultado exibido abaixo ou clicar em
           <strong> Reprocessar dossiê</strong> para criar uma nova fila. A tela
           passará a mostrar o dossiê mais recente retornado pelo backend.
         </div>
@@ -461,8 +460,8 @@ export default function MoisSalesPageLibraryDetailPage() {
           {hasActiveWarmupDossier ? (
             <>
               Esta página já possui dossiê em fila ou em processamento
-              {warmupStatus ? ` com status ${labelStatus(warmupStatus)}` : ""}
-              . Aguarde a conclusão para reprocessar.
+              {warmupStatus ? ` com status ${labelStatus(warmupStatus)}` : ""}.
+              Aguarde a conclusão para reprocessar.
             </>
           ) : (
             <>
@@ -708,8 +707,8 @@ export default function MoisSalesPageLibraryDetailPage() {
                   <h3 className="h6 mb-1">Insumos para GeraLanding</h3>
                   <p className="text-secondary small mb-0">
                     Padrões observados na página vencedora para orientar as
-                    etapas de wireframe, copy, prompt de imagens e preset
-                    design do pipeline.
+                    etapas de wireframe, copy, prompt de imagens e preset design
+                    do pipeline.
                   </p>
                 </div>
                 <div className="row g-3">


### PR DESCRIPTION
### Motivation
- Replace the previous market-warmup request flow with the internal dossier pipeline intake v1 start endpoint and make UI copy clearer about the new pipeline behavior.
- Align hook naming and types with the changed backend integration and remove an unused response type.

### Description
- Rename `useRequestMoisSalesLibraryMarketWarmup` to `useStartMoisDossierPipeline` and change the mutation to POST to `/api/internal/mois/dossie/v1/intake/stage-executions/start` with `params: { productKey: String(pageId) }` instead of the old `/api/mois/sales-library/pages/${pageId}/market-warmup:request` endpoint.
- Remove the `MoisMarketWarmupRequestResponse` typed response usage and stop returning response data from the mutation implementation.
- Update `MoisSalesPageLibraryDetailPage.tsx` to use `useStartMoisDossierPipeline` and adjust success, error and informational alert copy to reference "Pipeline v1 do dossiê" and the intake step, plus small copy formatting fixes.
- Preserve existing query invalidation logic so related cache entries are refreshed after the mutation succeeds.

### Testing
- Ran TypeScript typecheck and `yarn build`, which completed successfully.
- Ran the unit test suite with `yarn test`, and all tests passed.
- Ran the linter with `yarn lint` and no new issues were reported.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3ecc8115e88321b6add33c27877e0e)