### PR TITLE
Frontend: iniciar GeraAnuncio v2/texto com `experimentKey` e atualizar testes/documentação

### DIFF
--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -5450,3 +5450,9 @@
 - Foi feito: o backend passou a organizar as etapas `texto` e `imagem` em `com.marketinghub.pipelines.aiworker.geracaoanuncios.v1`, enquanto o AI Worker passou a usar `com.marketinghub.pipelines.geracaoanuncios.v1`, sem repetir o nome do módulo executor.
 - Foi feito: os endpoints internos canônicos de `pending` foram alinhados para `/api/internal/aiworker/geracaoanuncios/v1/<etapa>/stage-executions/pending` e os services de etapa agora publicam pendências reais do modo `PIPELINE_ADS` com contexto de texto e briefing de imagem do experimento.
 - Prevenção de recorrência: os testes ArchUnit do backend e do AI Worker foram atualizados para proteger o novo namespace e o contrato de consumo por etapa.
+
+## 2026-06-26 — Botão de GeraAnuncio inicia pela primeira etapa v2
+
+- Solicitação: o botão “Gerar anúncios do pipeline” deve chamar o `/start` da primeira etapa do pipeline GeraAnuncio v2 usando o código/chave do experimento.
+- Ajuste aplicado: o frontend deixou de chamar o endpoint legado por `experimentId` no caminho e passou a chamar `/api/internal/aiworker/geracaoanuncios/v1/texto/stage-executions/start` com `experimentKey` como parâmetro de query, alinhando a tela ao contrato documentado da primeira etapa.
+- Prevenção de recorrência: adicionado teste de frontend validando que o clique no botão envia a chave do experimento para o endpoint de início da etapa Texto.

--- a/frontend/src/api/experiment/useRequestPipelineCreatives.ts
+++ b/frontend/src/api/experiment/useRequestPipelineCreatives.ts
@@ -1,20 +1,24 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import axios from "axios";
 
-export function useRequestPipelineCreatives(experimentId?: string) {
+export function useRequestPipelineCreatives(experimentKey?: string) {
   const queryClient = useQueryClient();
 
   return useMutation({
     mutationFn: async () => {
-      if (!experimentId) throw new Error("Experimento não informado");
+      if (!experimentKey) throw new Error("Experimento não informado");
       const { data } = await axios.post(
-        `/api/internal/geraanuncio/v2/criativo/stage-executions/experiments/${experimentId}/start`,
+        "/api/internal/aiworker/geracaoanuncios/v1/texto/stage-executions/start",
+        null,
+        { params: { experimentKey } },
       );
       return data;
     },
     onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: ["experiment", experimentId] });
-      queryClient.invalidateQueries({ queryKey: ["creatives", experimentId] });
+      queryClient.invalidateQueries({
+        queryKey: ["experiment", experimentKey],
+      });
+      queryClient.invalidateQueries({ queryKey: ["creatives", experimentKey] });
     },
   });
 }

--- a/frontend/src/pages/experiment/CriativosTab.test.tsx
+++ b/frontend/src/pages/experiment/CriativosTab.test.tsx
@@ -266,6 +266,57 @@ describe("CriativosTab", () => {
     ).toBeInTheDocument();
   });
 
+  it("starts GeraAnuncio v2 from the first stage using experiment key", async () => {
+    (axios.get as any).mockImplementation((url: string) => {
+      if (url.endsWith("/experiments/1/creatives")) {
+        return Promise.resolve({ data: [] });
+      }
+      if (url.endsWith("/experiments/1")) {
+        return Promise.resolve({
+          data: {
+            creativesToGenerate: 0,
+            creativeGenerationMode: "DEFAULT",
+            creativeGenerationStatus: "IDLE",
+            adCopy: JSON.stringify({
+              adCopy: { primaryTextVariants: [{ primaryText: "Texto" }] },
+            }),
+            adImageBriefing: JSON.stringify({
+              adImageBriefing: { briefings: [{ visualBriefing: "Imagem" }] },
+            }),
+          },
+        });
+      }
+      return Promise.resolve({ data: [] });
+    });
+    (axios.post as any).mockResolvedValue({ data: { idJob: "job-1" } });
+
+    const client = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    });
+    render(
+      <QueryClientProvider client={client}>
+        <CriativosTab experimentId="1" />
+      </QueryClientProvider>,
+    );
+
+    await userEvent.click(
+      await screen.findByRole("button", {
+        name: "Gerar anúncios do pipeline",
+      }),
+    );
+
+    await waitFor(() => {
+      expect(axios.post).toHaveBeenCalledWith(
+        "/api/internal/aiworker/geracaoanuncios/v1/texto/stage-executions/start",
+        null,
+        { params: { experimentKey: "1" } },
+      );
+    });
+  });
+
   it("clears approval loading state when the backend rejects the update", async () => {
     (axios.get as any).mockImplementation((url: string) => {
       if (url.endsWith("/experiments/1/creatives")) {


### PR DESCRIPTION
### Motivation
- Alinhar a UI ao novo contrato de pipeline versionado para que o botão “Gerar anúncios do pipeline” enfileire a execução na primeira etapa (`texto`) usando a chave do experimento em vez do endpoint legado por `experimentId`.
- Evitar que o backend retorne apenas um resumo em memória sem gravar a pendência para o AI Worker, garantindo que a solicitação seja entregue ao worker corretamente.

### Description
- Alterado o hook `useRequestPipelineCreatives` para receber `experimentKey` em vez de `experimentId` e validar sua presença antes da requisição.
- Atualizada a chamada de `axios.post` para o endpoint `/api/internal/aiworker/geracaoanuncios/v1/texto/stage-executions/start` enviando `experimentKey` como parâmetro de query e corpo `null`.
- Atualizadas as invalidações do cache `react-query` para usar as chaves `[

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3ecc720fe883218752c294fa3b0250)