### PR TITLE
Padroniza constantes dos services GeraAnuncio v1

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/pipelines/aiworker/geracaoanuncios/v1/imagem/service/GeraAnuncioImagemService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/pipelines/aiworker/geracaoanuncios/v1/imagem/service/GeraAnuncioImagemService.java
@@ -20,6 +20,12 @@ import org.springframework.web.server.ResponseStatusException;
 /** Responsabilidade: expor contratos de leitura, escrita e auditoria da etapa Imagem do pipeline GeraAnuncio v2. */
 @Service
 public class GeraAnuncioImagemService {
+    private static final String STAGE_CODE = "imagem";
+    private static final String NEXT_STAGE = "fim";
+    private static final String STATUS_STARTED = "INICIADO";
+    private static final String STATUS_WAITING = "AGUARDANDO_RETORNO_MODULO";
+    private static final String STATUS_COMPLETED = "CONCLUIDO";
+    private static final String STATUS_FAILED = "FALHA";
     private final ExperimentService experimentService;
 
     /** Inicializa o service com o serviço canônico de experimentos. */
@@ -119,17 +125,17 @@ public class GeraAnuncioImagemService {
 
     /** Gera identificador determinístico da execução da etapa a partir do experimento. */
     private String stageExecutionId(Experiment experiment) {
-        return "geracaoanuncios-v1-imagem-exp-" + experiment.getId();
+        return "geracaoanuncios-v1-" + STAGE_CODE + "-exp-" + experiment.getId();
     }
 
     /** Gera identificador de job estável para correlação operacional. */
     private String stageJobId(Experiment experiment) {
-        return "exp:" + experiment.getId() + "|pipeline:geracaoanuncios|v:1|stage:imagem";
+        return "exp:" + experiment.getId() + "|pipeline:geracaoanuncios|v:1|stage:" + STAGE_CODE;
     }
 
     /** Extrai o experimento de um identificador determinístico da etapa. */
     private Long extractExperimentId(String stageExecutionId) {
-        String prefix = "geracaoanuncios-v1-imagem-exp-";
+        String prefix = "geracaoanuncios-v1-" + STAGE_CODE + "-exp-";
         if (stageExecutionId == null || !stageExecutionId.startsWith(prefix)) {
             return null;
         }

--- a/backend/ads-service/src/main/java/com/marketinghub/pipelines/aiworker/geracaoanuncios/v1/texto/service/GeraAnuncioTextoService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/pipelines/aiworker/geracaoanuncios/v1/texto/service/GeraAnuncioTextoService.java
@@ -20,6 +20,12 @@ import org.springframework.web.server.ResponseStatusException;
 /** Responsabilidade: expor contratos de leitura, escrita e auditoria da etapa Texto do pipeline GeraAnuncio v2. */
 @Service
 public class GeraAnuncioTextoService {
+    private static final String STAGE_CODE = "texto";
+    private static final String NEXT_STAGE = "imagem";
+    private static final String STATUS_STARTED = "INICIADO";
+    private static final String STATUS_WAITING = "AGUARDANDO_RETORNO_MODULO";
+    private static final String STATUS_COMPLETED = "CONCLUIDO";
+    private static final String STATUS_FAILED = "FALHA";
     private final ExperimentService experimentService;
 
     /** Inicializa o service com o serviço canônico de experimentos. */
@@ -119,17 +125,17 @@ public class GeraAnuncioTextoService {
 
     /** Gera identificador determinístico da execução da etapa a partir do experimento. */
     private String stageExecutionId(Experiment experiment) {
-        return "geracaoanuncios-v1-texto-exp-" + experiment.getId();
+        return "geracaoanuncios-v1-" + STAGE_CODE + "-exp-" + experiment.getId();
     }
 
     /** Gera identificador de job estável para correlação operacional. */
     private String stageJobId(Experiment experiment) {
-        return "exp:" + experiment.getId() + "|pipeline:geracaoanuncios|v:1|stage:texto";
+        return "exp:" + experiment.getId() + "|pipeline:geracaoanuncios|v:1|stage:" + STAGE_CODE;
     }
 
     /** Extrai o experimento de um identificador determinístico da etapa. */
     private Long extractExperimentId(String stageExecutionId) {
-        String prefix = "geracaoanuncios-v1-texto-exp-";
+        String prefix = "geracaoanuncios-v1-" + STAGE_CODE + "-exp-";
         if (stageExecutionId == null || !stageExecutionId.startsWith(prefix)) {
             return null;
         }


### PR DESCRIPTION
### Motivation
- Garantir que os services do pipeline `geracaoanuncios.v1` usem constantes padronizadas para `STAGE_CODE`, `NEXT_STAGE` e status operacionais conforme o contrato de pipeline, reduzindo risco de divergência entre código de etapa e identificadores gerados.

### Description
- Adiciona `STAGE_CODE`, `NEXT_STAGE`, `STATUS_STARTED`, `STATUS_WAITING`, `STATUS_COMPLETED` e `STATUS_FAILED` em `backend/ads-service/src/main/java/com/marketinghub/pipelines/aiworker/geracaoanuncios/v1/texto/service/GeraAnuncioTextoService.java` e em `.../imagem/service/GeraAnuncioImagemService.java` em conformidade com o padrão pedido.
- Centraliza o uso de `STAGE_CODE` na formação de `stageExecutionId`, `stageJobId` e no prefixo usado por `extractExperimentId`, substituindo literais anteriores por concatenação com `STAGE_CODE`.

### Testing
- Rodado `../mvnw -DskipTests compile` no módulo `backend/ads-service` e a compilação foi bem-sucedida.
- Executado o teste de arquitetura alvo com `../mvnw -Dtest=ArquiteturaTest#geraanuncioV2BackendSegueProtocoloPadrao test` e a suíte passou (51 tests, 0 falhas).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3ed702aca4832194d5f67b4ad90418)