### PR TITLE
Padroniza constantes dos services NichoCNAE v3

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/cnaeintake/service/BackendCnaeIntakeService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/cnaeintake/service/BackendCnaeIntakeService.java
@@ -12,6 +12,11 @@ import org.springframework.stereotype.Service;
 @Service
 public class BackendCnaeIntakeService extends OprmNichoCnaeV3StageServiceSupport {
     private static final String STAGE_CODE = "cnae-intake";
+    private static final String NEXT_STAGE = "persona-candidate-generator";
+    private static final String STATUS_STARTED = "INICIADO";
+    private static final String STATUS_WAITING = "AGUARDANDO_RETORNO_MODULO";
+    private static final String STATUS_COMPLETED = "CONCLUIDO";
+    private static final String STATUS_FAILED = "FALHA";
 
     /** Inicializa o service com repository canônico de execuções v3. */
     public BackendCnaeIntakeService(OprmNichoCnaeV3StageExecutionRepository repository) {

--- a/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/dailytaskssynthesizer/service/BackendDailyTasksSynthesizerService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/dailytaskssynthesizer/service/BackendDailyTasksSynthesizerService.java
@@ -12,6 +12,11 @@ import org.springframework.stereotype.Service;
 @Service
 public class BackendDailyTasksSynthesizerService extends OprmNichoCnaeV3StageServiceSupport {
     private static final String STAGE_CODE = "daily-tasks-synthesizer";
+    private static final String NEXT_STAGE = "quality-gate";
+    private static final String STATUS_STARTED = "INICIADO";
+    private static final String STATUS_WAITING = "AGUARDANDO_RETORNO_MODULO";
+    private static final String STATUS_COMPLETED = "CONCLUIDO";
+    private static final String STATUS_FAILED = "FALHA";
 
     /** Inicializa o service com repository canônico de execuções v3. */
     public BackendDailyTasksSynthesizerService(OprmNichoCnaeV3StageExecutionRepository repository) {

--- a/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/personacandidategenerator/service/BackendPersonaCandidateGeneratorService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/personacandidategenerator/service/BackendPersonaCandidateGeneratorService.java
@@ -12,6 +12,11 @@ import org.springframework.stereotype.Service;
 @Service
 public class BackendPersonaCandidateGeneratorService extends OprmNichoCnaeV3StageServiceSupport {
     private static final String STAGE_CODE = "persona-candidate-generator";
+    private static final String NEXT_STAGE = "persona-tournament";
+    private static final String STATUS_STARTED = "INICIADO";
+    private static final String STATUS_WAITING = "AGUARDANDO_RETORNO_MODULO";
+    private static final String STATUS_COMPLETED = "CONCLUIDO";
+    private static final String STATUS_FAILED = "FALHA";
 
     /** Inicializa o service com repository canônico de execuções v3. */
     public BackendPersonaCandidateGeneratorService(OprmNichoCnaeV3StageExecutionRepository repository) {

--- a/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/personaroutinematerializer/service/BackendPersonaRoutineMaterializerService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/personaroutinematerializer/service/BackendPersonaRoutineMaterializerService.java
@@ -20,6 +20,11 @@ import org.springframework.util.StringUtils;
 @Service
 public class BackendPersonaRoutineMaterializerService extends OprmNichoCnaeV3StageServiceSupport {
     private static final String STAGE_CODE = "persona-routine-materializer";
+    private static final String NEXT_STAGE = "";
+    private static final String STATUS_STARTED = "INICIADO";
+    private static final String STATUS_WAITING = "AGUARDANDO_RETORNO_MODULO";
+    private static final String STATUS_COMPLETED = "CONCLUIDO";
+    private static final String STATUS_FAILED = "FALHA";
     private static final String CREATED_BY = "OPRM_NICHO_CNAE_V3";
     private static final String DEFAULT_QUALITY_STATUS = "V3_PERSONA_ROUTINE_MATERIALIZED";
     private static final BigDecimal DEFAULT_SOURCE_SCORE = BigDecimal.ZERO;

--- a/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/personatournament/service/BackendPersonaTournamentService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/personatournament/service/BackendPersonaTournamentService.java
@@ -12,6 +12,11 @@ import org.springframework.stereotype.Service;
 @Service
 public class BackendPersonaTournamentService extends OprmNichoCnaeV3StageServiceSupport {
     private static final String STAGE_CODE = "persona-tournament";
+    private static final String NEXT_STAGE = "routine-query-planner";
+    private static final String STATUS_STARTED = "INICIADO";
+    private static final String STATUS_WAITING = "AGUARDANDO_RETORNO_MODULO";
+    private static final String STATUS_COMPLETED = "CONCLUIDO";
+    private static final String STATUS_FAILED = "FALHA";
 
     /** Inicializa o service com repository canônico de execuções v3. */
     public BackendPersonaTournamentService(OprmNichoCnaeV3StageExecutionRepository repository) {

--- a/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/qualitygate/service/BackendQualityGateService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/qualitygate/service/BackendQualityGateService.java
@@ -12,6 +12,11 @@ import org.springframework.stereotype.Service;
 @Service
 public class BackendQualityGateService extends OprmNichoCnaeV3StageServiceSupport {
     private static final String STAGE_CODE = "quality-gate";
+    private static final String NEXT_STAGE = "persona-routine-materializer";
+    private static final String STATUS_STARTED = "INICIADO";
+    private static final String STATUS_WAITING = "AGUARDANDO_RETORNO_MODULO";
+    private static final String STATUS_COMPLETED = "CONCLUIDO";
+    private static final String STATUS_FAILED = "FALHA";
 
     /** Inicializa o service com repository canônico de execuções v3. */
     public BackendQualityGateService(OprmNichoCnaeV3StageExecutionRepository repository) {

--- a/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/routinequeryplanner/service/BackendRoutineQueryPlannerService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/routinequeryplanner/service/BackendRoutineQueryPlannerService.java
@@ -12,6 +12,11 @@ import org.springframework.stereotype.Service;
 @Service
 public class BackendRoutineQueryPlannerService extends OprmNichoCnaeV3StageServiceSupport {
     private static final String STAGE_CODE = "routine-query-planner";
+    private static final String NEXT_STAGE = "source-searcher";
+    private static final String STATUS_STARTED = "INICIADO";
+    private static final String STATUS_WAITING = "AGUARDANDO_RETORNO_MODULO";
+    private static final String STATUS_COMPLETED = "CONCLUIDO";
+    private static final String STATUS_FAILED = "FALHA";
 
     /** Inicializa o service com repository canônico de execuções v3. */
     public BackendRoutineQueryPlannerService(OprmNichoCnaeV3StageExecutionRepository repository) {

--- a/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/routinesignalextractor/service/BackendRoutineSignalExtractorService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/routinesignalextractor/service/BackendRoutineSignalExtractorService.java
@@ -12,6 +12,11 @@ import org.springframework.stereotype.Service;
 @Service
 public class BackendRoutineSignalExtractorService extends OprmNichoCnaeV3StageServiceSupport {
     private static final String STAGE_CODE = "routine-signal-extractor";
+    private static final String NEXT_STAGE = "daily-tasks-synthesizer";
+    private static final String STATUS_STARTED = "INICIADO";
+    private static final String STATUS_WAITING = "AGUARDANDO_RETORNO_MODULO";
+    private static final String STATUS_COMPLETED = "CONCLUIDO";
+    private static final String STATUS_FAILED = "FALHA";
 
     /** Inicializa o service com repository canônico de execuções v3. */
     public BackendRoutineSignalExtractorService(OprmNichoCnaeV3StageExecutionRepository repository) {

--- a/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/sourcefetcher/service/BackendSourceFetcherV3Service.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/sourcefetcher/service/BackendSourceFetcherV3Service.java
@@ -12,6 +12,11 @@ import org.springframework.stereotype.Service;
 @Service
 public class BackendSourceFetcherV3Service extends OprmNichoCnaeV3StageServiceSupport {
     private static final String STAGE_CODE = "source-fetcher";
+    private static final String NEXT_STAGE = "routine-signal-extractor";
+    private static final String STATUS_STARTED = "INICIADO";
+    private static final String STATUS_WAITING = "AGUARDANDO_RETORNO_MODULO";
+    private static final String STATUS_COMPLETED = "CONCLUIDO";
+    private static final String STATUS_FAILED = "FALHA";
 
     /** Inicializa o service com repository canônico de execuções v3. */
     public BackendSourceFetcherV3Service(OprmNichoCnaeV3StageExecutionRepository repository) {

--- a/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/sourcesearcher/service/BackendSourceSearcherV3Service.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/sourcesearcher/service/BackendSourceSearcherV3Service.java
@@ -12,6 +12,11 @@ import org.springframework.stereotype.Service;
 @Service
 public class BackendSourceSearcherV3Service extends OprmNichoCnaeV3StageServiceSupport {
     private static final String STAGE_CODE = "source-searcher";
+    private static final String NEXT_STAGE = "source-fetcher";
+    private static final String STATUS_STARTED = "INICIADO";
+    private static final String STATUS_WAITING = "AGUARDANDO_RETORNO_MODULO";
+    private static final String STATUS_COMPLETED = "CONCLUIDO";
+    private static final String STATUS_FAILED = "FALHA";
 
     /** Inicializa o service com repository canônico de execuções v3. */
     public BackendSourceSearcherV3Service(OprmNichoCnaeV3StageExecutionRepository repository) {

--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -1551,3 +1551,8 @@
 - Correção: cada etapa interna do backend NichoCNAE v3 passou a expor `POST /start` recebendo `cnaeCode` como parâmetro para criar uma execução pendente da própria etapa.
 - Service: cada service canônico da etapa recebeu método `start(String cnaeCode)`, mantendo o backend como fonte de verdade para abertura de pendências e preservando o executor externo apenas como consumidor do endpoint `pending`.
 - Contrato: a documentação Swagger v3 foi atualizada com o novo endpoint genérico por etapa.
+
+## 2026-06-26 — NichoCNAE v3: constantes operacionais nos services de etapa
+
+- Correção: os services canônicos de etapa do backend NichoCNAE v3 receberam constantes explícitas para `STAGE_CODE`, `NEXT_STAGE` e statuses operacionais (`INICIADO`, `AGUARDANDO_RETORNO_MODULO`, `CONCLUIDO`, `FALHA`).
+- Objetivo: reduzir divergência de códigos de etapa/status entre backend, executor OPRM MEI e relatórios operacionais do pipeline.


### PR DESCRIPTION
### Motivation
- Garantir que os services canônicos do pipeline `oprmcoletormei.nichocnae.v3` declarem explicitamente `STAGE_CODE`, `NEXT_STAGE` e os status operacionais para evitar divergências entre backend, executor OPRM MEI e relatórios operacionais. 
- Facilitar padronização e leitura operacional do fluxo por etapa, reduzindo risco de códigos de etapa/status espalhados ou inconsistentes entre módulos. 

### Description
- Adicionei as constantes `STAGE_CODE`, `NEXT_STAGE`, `STATUS_STARTED`, `STATUS_WAITING`, `STATUS_COMPLETED` e `STATUS_FAILED` nos services de etapa do NichoCNAE v3: `cnae-intake`, `persona-candidate-generator`, `persona-tournament`, `routine-query-planner`, `source-searcher`, `source-fetcher`, `routine-signal-extractor`, `daily-tasks-synthesizer`, `quality-gate` e `persona-routine-materializer`. 
- Atualizei o registro operacional em `docs/registros/oprm1.md` documentando a alteração e objetivo da padronização. 
- Não foram alteradas as implementações de lógica das operações; a mudança é declarativa (constantes) e preserva o comportamento existente das rotinas de criação/complete/fail/start/pending. 

### Testing
- Rodei `mvn -DskipTests compile` no módulo `backend/ads-service` e a compilação passou com sucesso. 
- Rodei `mvn test` no mesmo módulo e os testes falharam por problemas preexistentes não relacionados a esta alteração, especificamente regras ArchUnit esperando estrutura do MOIS Dossiê v1 e um teste (`PipelineServiceTest`) esperando pacote legado do coletor OPRM. 
- As alterações foram limitadas a constantes e documentação, e não introduzem mudanças funcionais que impactariam os testes existentes; recomendo reexecutar a suíte de testes após sincronizar/ajustar as regressões de arquitetura já identificadas.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3ed6c3caf48321a6e661de744b902c)