### PR TITLE
Padroniza constantes de etapa nos services do dossiê MOIS v1

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/dossiersynthesis/service/DossierDossierSynthesisService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/dossiersynthesis/service/DossierDossierSynthesisService.java
@@ -8,6 +8,12 @@ import org.springframework.stereotype.Service;
 /** Publica pendências e contratos da etapa síntese final do dossiê do pipeline de dossiê MOIS v1. */
 @Service
 public class DossierDossierSynthesisService {
+    private static final String STAGE_CODE = "dossier-synthesis";
+    private static final String NEXT_STAGE = "";
+    private static final String STATUS_STARTED = "INICIADO";
+    private static final String STATUS_WAITING = "AGUARDANDO_RETORNO_MODULO";
+    private static final String STATUS_COMPLETED = "CONCLUIDO";
+    private static final String STATUS_FAILED = "FALHA";
 
     /** Registra a intenção de iniciar a etapa para o produto informado sem executar a rotina no backend. */
     public void start(String productKey) {

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/intake/service/DossierIntakeService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/intake/service/DossierIntakeService.java
@@ -8,6 +8,12 @@ import org.springframework.stereotype.Service;
 /** Publica pendências e contratos da etapa entrada inicial do pipeline de dossiê MOIS v1. */
 @Service
 public class DossierIntakeService {
+    private static final String STAGE_CODE = "intake";
+    private static final String NEXT_STAGE = "product-understanding";
+    private static final String STATUS_STARTED = "INICIADO";
+    private static final String STATUS_WAITING = "AGUARDANDO_RETORNO_MODULO";
+    private static final String STATUS_COMPLETED = "CONCLUIDO";
+    private static final String STATUS_FAILED = "FALHA";
 
     /** Registra a intenção de iniciar a etapa para o produto informado sem executar a rotina no backend. */
     public void start(String productKey) {

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/investigationanchorbuilder/service/DossierInvestigationAnchorBuilderService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/investigationanchorbuilder/service/DossierInvestigationAnchorBuilderService.java
@@ -8,6 +8,12 @@ import org.springframework.stereotype.Service;
 /** Publica pendências e contratos da etapa geração de âncoras de investigação do pipeline de dossiê MOIS v1. */
 @Service
 public class DossierInvestigationAnchorBuilderService {
+    private static final String STAGE_CODE = "investigation-anchor-builder";
+    private static final String NEXT_STAGE = "warmup-resource-discovery";
+    private static final String STATUS_STARTED = "INICIADO";
+    private static final String STATUS_WAITING = "AGUARDANDO_RETORNO_MODULO";
+    private static final String STATUS_COMPLETED = "CONCLUIDO";
+    private static final String STATUS_FAILED = "FALHA";
 
     /** Registra a intenção de iniciar a etapa para o produto informado sem executar a rotina no backend. */
     public void start(String productKey) {

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/productunderstanding/service/DossierProductUnderstandingService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/productunderstanding/service/DossierProductUnderstandingService.java
@@ -8,6 +8,12 @@ import org.springframework.stereotype.Service;
 /** Publica pendências e contratos da etapa entendimento do produto do pipeline de dossiê MOIS v1. */
 @Service
 public class DossierProductUnderstandingService {
+    private static final String STAGE_CODE = "product-understanding";
+    private static final String NEXT_STAGE = "investigation-anchor-builder";
+    private static final String STATUS_STARTED = "INICIADO";
+    private static final String STATUS_WAITING = "AGUARDANDO_RETORNO_MODULO";
+    private static final String STATUS_COMPLETED = "CONCLUIDO";
+    private static final String STATUS_FAILED = "FALHA";
 
     /** Registra a intenção de iniciar a etapa para o produto informado sem executar a rotina no backend. */
     public void start(String productKey) {

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/sourceproductmatch/service/DossierSourceProductMatchService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/sourceproductmatch/service/DossierSourceProductMatchService.java
@@ -8,6 +8,12 @@ import org.springframework.stereotype.Service;
 /** Publica pendências e contratos da etapa validação de relação fonte-produto do pipeline de dossiê MOIS v1. */
 @Service
 public class DossierSourceProductMatchService {
+    private static final String STAGE_CODE = "source-product-match";
+    private static final String NEXT_STAGE = "warmup-signal-extraction";
+    private static final String STATUS_STARTED = "INICIADO";
+    private static final String STATUS_WAITING = "AGUARDANDO_RETORNO_MODULO";
+    private static final String STATUS_COMPLETED = "CONCLUIDO";
+    private static final String STATUS_FAILED = "FALHA";
 
     /** Registra a intenção de iniciar a etapa para o produto informado sem executar a rotina no backend. */
     public void start(String productKey) {

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/warmupmapbuilder/service/DossierWarmupMapBuilderService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/warmupmapbuilder/service/DossierWarmupMapBuilderService.java
@@ -8,6 +8,12 @@ import org.springframework.stereotype.Service;
 /** Publica pendências e contratos da etapa montagem do mapa de aquecimento do pipeline de dossiê MOIS v1. */
 @Service
 public class DossierWarmupMapBuilderService {
+    private static final String STAGE_CODE = "warmup-map-builder";
+    private static final String NEXT_STAGE = "dossier-synthesis";
+    private static final String STATUS_STARTED = "INICIADO";
+    private static final String STATUS_WAITING = "AGUARDANDO_RETORNO_MODULO";
+    private static final String STATUS_COMPLETED = "CONCLUIDO";
+    private static final String STATUS_FAILED = "FALHA";
 
     /** Registra a intenção de iniciar a etapa para o produto informado sem executar a rotina no backend. */
     public void start(String productKey) {

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/warmupresourcediscovery/service/DossierWarmupResourceDiscoveryService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/warmupresourcediscovery/service/DossierWarmupResourceDiscoveryService.java
@@ -8,6 +8,12 @@ import org.springframework.stereotype.Service;
 /** Publica pendências e contratos da etapa descoberta de recursos de aquecimento do pipeline de dossiê MOIS v1. */
 @Service
 public class DossierWarmupResourceDiscoveryService {
+    private static final String STAGE_CODE = "warmup-resource-discovery";
+    private static final String NEXT_STAGE = "source-product-match";
+    private static final String STATUS_STARTED = "INICIADO";
+    private static final String STATUS_WAITING = "AGUARDANDO_RETORNO_MODULO";
+    private static final String STATUS_COMPLETED = "CONCLUIDO";
+    private static final String STATUS_FAILED = "FALHA";
 
     /** Registra a intenção de iniciar a etapa para o produto informado sem executar a rotina no backend. */
     public void start(String productKey) {

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/warmupsignalextraction/service/DossierWarmupSignalExtractionService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/warmupsignalextraction/service/DossierWarmupSignalExtractionService.java
@@ -8,6 +8,12 @@ import org.springframework.stereotype.Service;
 /** Publica pendências e contratos da etapa extração de sinais de aquecimento do pipeline de dossiê MOIS v1. */
 @Service
 public class DossierWarmupSignalExtractionService {
+    private static final String STAGE_CODE = "warmup-signal-extraction";
+    private static final String NEXT_STAGE = "warmup-map-builder";
+    private static final String STATUS_STARTED = "INICIADO";
+    private static final String STATUS_WAITING = "AGUARDANDO_RETORNO_MODULO";
+    private static final String STATUS_COMPLETED = "CONCLUIDO";
+    private static final String STATUS_FAILED = "FALHA";
 
     /** Registra a intenção de iniciar a etapa para o produto informado sem executar a rotina no backend. */
     public void start(String productKey) {


### PR DESCRIPTION
### Motivation
- Padronizar metadados de etapa nas classes de service do pipeline dossiê MOIS v1 para facilitar orquestração, identificação e interoperabilidade entre executor e backend. 
- Garantir que cada service exponha os mesmos identificadores estáticos (`STAGE_CODE` e `NEXT_STAGE`) e status canônicos para reduzir erros causados por strings espalhadas no código. 

### Description
- Adiciona as constantes `STAGE_CODE`, `NEXT_STAGE`, `STATUS_STARTED`, `STATUS_WAITING`, `STATUS_COMPLETED` e `STATUS_FAILED` em todos os services do pipeline dossiê MOIS v1. 
- Arquivos alterados: `DossierIntakeService`, `DossierProductUnderstandingService`, `DossierInvestigationAnchorBuilderService`, `DossierWarmupResourceDiscoveryService`, `DossierSourceProductMatchService`, `DossierWarmupSignalExtractionService`, `DossierWarmupMapBuilderService` e `DossierDossierSynthesisService` sob `backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/.../service`. 
- `NEXT_STAGE` foi deixado vazio na etapa final (`dossier-synthesis`) e os valores de `STAGE_CODE`/`NEXT_STAGE` seguem a sequência canônica das etapas v1 do dossiê. 

### Testing
- Executei `../mvnw -DskipTests compile` no módulo `backend/ads-service` e a compilação passou com sucesso. 
- Executei `../mvnw test` no módulo `backend/ads-service` e a suíte de testes falhou devido a testes preexistentes fora do escopo desta mudança; as falhas apontam para verificações de estrutura/arquitetura e pacotes ausentes que não foram introduzidos por este diff. 
- Não foram adicionados novos testes unitários neste PR porque a alteração é exclusivamente a inclusão de constantes estáticas nos services.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3ed681bdf083219a0c06df68f9d368)