### PR TITLE
Implementa start GeracaoAnuncios por CNAE

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/cnae/OprmNicheCandidate.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/cnae/OprmNicheCandidate.java
@@ -72,6 +72,12 @@ public class OprmNicheCandidate {
     @Column(name = "routine_research_status", nullable = false, length = 32)
     private String routineResearchStatus;
 
+    @Column(name = "geracao_anuncios_pipeline_status", length = 32)
+    private String geracaoAnunciosPipelineStatus;
+
+    @Column(name = "geracao_anuncios_current_stage_code", length = 64)
+    private String geracaoAnunciosCurrentStageCode;
+
     @Column(name = "last_routine_research_cycle_id")
     private Long lastRoutineResearchCycleId;
 

--- a/backend/ads-service/src/main/java/com/marketinghub/pipelines/aiworker/geracaoanuncios/v1/imagem/service/GeraAnuncioImagemService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/pipelines/aiworker/geracaoanuncios/v1/imagem/service/GeraAnuncioImagemService.java
@@ -8,6 +8,8 @@ import com.marketinghub.pipelines.aiworker.geracaoanuncios.v1.imagem.service.rec
 import com.marketinghub.experiment.CreativeGenerationMode;
 import com.marketinghub.experiment.Experiment;
 import com.marketinghub.experiment.service.ExperimentService;
+import com.marketinghub.oprm.cnae.OprmNicheCandidate;
+import com.marketinghub.repository.jpa.oprm.cnae.OprmNicheCandidateRepository;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
@@ -27,10 +29,12 @@ public class GeraAnuncioImagemService {
     private static final String STATUS_COMPLETED = "CONCLUIDO";
     private static final String STATUS_FAILED = "FALHA";
     private final ExperimentService experimentService;
+    private final OprmNicheCandidateRepository cnaeRepository;
 
-    /** Inicializa o service com o serviço canônico de experimentos. */
-    public GeraAnuncioImagemService(ExperimentService experimentService) {
+    /** Inicializa o service com o repositório canônico de candidatos CNAE. */
+    public GeraAnuncioImagemService(ExperimentService experimentService, OprmNicheCandidateRepository cnaeRepository) {
         this.experimentService = experimentService;
+        this.cnaeRepository = cnaeRepository;
     }
 
     /** Inicia uma solicitação da etapa Imagem usando o código/chave operacional do experimento. */
@@ -38,15 +42,17 @@ public class GeraAnuncioImagemService {
         return start(resolveExperimentId(experimentKey));
     }
 
-    /** Inicia uma solicitação da etapa Imagem para um experimento. */
+    /** Inicia uma solicitação da etapa Imagem para o candidato CNAE informado. */
     public GeraAnuncioImagemExecutionSummaryResponse start(Long experimentId) {
-        Experiment experiment = experimentService.requestPipelineCreatives(experimentId);
+        OprmNicheCandidate cnae = cnaeRepository
+                .findById(experimentId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "CNAE experiment not found"));
+        cnae.setGeracaoAnunciosPipelineStatus(STATUS_STARTED);
+        cnae.setGeracaoAnunciosCurrentStageCode(STAGE_CODE);
+        cnae.setUpdatedAt(Instant.now());
+        OprmNicheCandidate saved = cnaeRepository.save(cnae);
         return new GeraAnuncioImagemExecutionSummaryResponse(
-                null,
-                experiment.getId(),
-                null,
-                experiment.getCreativeGenerationStatus().name(),
-                experiment.getCreativeGenerationRequestedAt());
+                stageExecutionId(saved), saved.getId(), stageJobId(saved), STATUS_STARTED, saved.getUpdatedAt());
     }
 
     /** Lista execuções da etapa Imagem para relatório operacional. */
@@ -131,6 +137,16 @@ public class GeraAnuncioImagemService {
     /** Gera identificador de job estável para correlação operacional. */
     private String stageJobId(Experiment experiment) {
         return "exp:" + experiment.getId() + "|pipeline:geracaoanuncios|v:1|stage:" + STAGE_CODE;
+    }
+
+    /** Gera identificador determinístico da execução da etapa a partir do candidato CNAE. */
+    private String stageExecutionId(OprmNicheCandidate cnae) {
+        return "geracaoanuncios-v1-" + STAGE_CODE + "-cnae-" + cnae.getId();
+    }
+
+    /** Gera identificador de job estável para correlação operacional do candidato CNAE. */
+    private String stageJobId(OprmNicheCandidate cnae) {
+        return "cnae:" + cnae.getId() + "|pipeline:geracaoanuncios|v:1|stage:" + STAGE_CODE;
     }
 
     /** Extrai o experimento de um identificador determinístico da etapa. */

--- a/backend/ads-service/src/main/java/com/marketinghub/pipelines/aiworker/geracaoanuncios/v1/texto/service/GeraAnuncioTextoService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/pipelines/aiworker/geracaoanuncios/v1/texto/service/GeraAnuncioTextoService.java
@@ -8,6 +8,8 @@ import com.marketinghub.pipelines.aiworker.geracaoanuncios.v1.texto.service.rece
 import com.marketinghub.experiment.CreativeGenerationMode;
 import com.marketinghub.experiment.Experiment;
 import com.marketinghub.experiment.service.ExperimentService;
+import com.marketinghub.oprm.cnae.OprmNicheCandidate;
+import com.marketinghub.repository.jpa.oprm.cnae.OprmNicheCandidateRepository;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
@@ -27,10 +29,12 @@ public class GeraAnuncioTextoService {
     private static final String STATUS_COMPLETED = "CONCLUIDO";
     private static final String STATUS_FAILED = "FALHA";
     private final ExperimentService experimentService;
+    private final OprmNicheCandidateRepository cnaeRepository;
 
-    /** Inicializa o service com o serviço canônico de experimentos. */
-    public GeraAnuncioTextoService(ExperimentService experimentService) {
+    /** Inicializa o service com o repositório canônico de candidatos CNAE. */
+    public GeraAnuncioTextoService(ExperimentService experimentService, OprmNicheCandidateRepository cnaeRepository) {
         this.experimentService = experimentService;
+        this.cnaeRepository = cnaeRepository;
     }
 
     /** Inicia uma solicitação da etapa Texto usando o código/chave operacional do experimento. */
@@ -38,15 +42,17 @@ public class GeraAnuncioTextoService {
         return start(resolveExperimentId(experimentKey));
     }
 
-    /** Inicia uma solicitação da etapa Texto para um experimento. */
+    /** Inicia uma solicitação da etapa Texto para o candidato CNAE informado. */
     public GeraAnuncioTextoExecutionSummaryResponse start(Long experimentId) {
-        Experiment experiment = experimentService.requestPipelineCreatives(experimentId);
+        OprmNicheCandidate cnae = cnaeRepository
+                .findById(experimentId)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "CNAE experiment not found"));
+        cnae.setGeracaoAnunciosPipelineStatus(STATUS_STARTED);
+        cnae.setGeracaoAnunciosCurrentStageCode(STAGE_CODE);
+        cnae.setUpdatedAt(Instant.now());
+        OprmNicheCandidate saved = cnaeRepository.save(cnae);
         return new GeraAnuncioTextoExecutionSummaryResponse(
-                null,
-                experiment.getId(),
-                null,
-                experiment.getCreativeGenerationStatus().name(),
-                experiment.getCreativeGenerationRequestedAt());
+                stageExecutionId(saved), saved.getId(), stageJobId(saved), STATUS_STARTED, saved.getUpdatedAt());
     }
 
     /** Lista execuções da etapa Texto para relatório operacional. */
@@ -131,6 +137,16 @@ public class GeraAnuncioTextoService {
     /** Gera identificador de job estável para correlação operacional. */
     private String stageJobId(Experiment experiment) {
         return "exp:" + experiment.getId() + "|pipeline:geracaoanuncios|v:1|stage:" + STAGE_CODE;
+    }
+
+    /** Gera identificador determinístico da execução da etapa a partir do candidato CNAE. */
+    private String stageExecutionId(OprmNicheCandidate cnae) {
+        return "geracaoanuncios-v1-" + STAGE_CODE + "-cnae-" + cnae.getId();
+    }
+
+    /** Gera identificador de job estável para correlação operacional do candidato CNAE. */
+    private String stageJobId(OprmNicheCandidate cnae) {
+        return "cnae:" + cnae.getId() + "|pipeline:geracaoanuncios|v:1|stage:" + STAGE_CODE;
     }
 
     /** Extrai o experimento de um identificador determinístico da etapa. */

--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-26-oprm-niche-candidate-geracao-anuncios-status.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-26-oprm-niche-candidate-geracao-anuncios-status.yaml
@@ -1,0 +1,24 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-06-26-01-oprm-niche-candidate-geracao-anuncios-status
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - dbms:
+            type: mysql
+        - tableExists:
+            tableName: oprm_niche_candidate
+        - not:
+            - columnExists:
+                tableName: oprm_niche_candidate
+                columnName: geracao_anuncios_pipeline_status
+      changes:
+        - addColumn:
+            tableName: oprm_niche_candidate
+            columns:
+              - column:
+                  name: geracao_anuncios_pipeline_status
+                  type: VARCHAR(32)
+              - column:
+                  name: geracao_anuncios_current_stage_code
+                  type: VARCHAR(64)

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -1,5 +1,8 @@
 databaseChangeLog:
   - include:
+      file: changesets/2026-06-26-oprm-niche-candidate-geracao-anuncios-status.yaml
+      relativeToChangelogFile: true
+  - include:
       file: changesets/2026-06-26-market-niche-cnae-link.yaml
       relativeToChangelogFile: true
   - include:


### PR DESCRIPTION
### Motivation
- Permitir que as etapas `texto` e `imagem` do pipeline `geracaoanuncios.v1` sejam iniciadas a partir do registro de candidato CNAE no backend, marcando o pipeline como `INICIADO` e registrando a etapa atual para rastreabilidade operacional.

### Description
- Atualiza `GeraAnuncioTextoService.start` e `GeraAnuncioImagemService.start` para carregar o candidato via `OprmNicheCandidateRepository.findById`, setar `geracaoAnunciosPipelineStatus = STATUS_STARTED`, setar `geracaoAnunciosCurrentStageCode = STAGE_CODE`, atualizar `updatedAt` e salvar o registro; a resposta retorna identificadores gerados a partir do candidato CNAE.
- Adiciona os campos persistidos `geracao_anuncios_pipeline_status` e `geracao_anuncios_current_stage_code` na entidade `OprmNicheCandidate` para armazenar status e etapa atuais.
- Inclui changelog Liquibase `backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-26-oprm-niche-candidate-geracao-anuncios-status.yaml` e adiciona `relativeToChangelogFile: true` no `db.changelog-master.yaml` para criar as colunas no schema MySQL.
- Ajusta construtores dos services para receber `OprmNicheCandidateRepository` e adiciona helpers `stageExecutionId`/`stageJobId` específicos para `OprmNicheCandidate` sem alterar o restante das APIs existentes.

### Testing
- Rodei `mvn -DskipTests compile` no módulo `backend/ads-service` e o build compilou com sucesso.
- Executei `mvn test` no backend; a execução iniciou e muitos testes unitários/integrados passaram, porém a suíte completa encontrou uma falha de integridade referencial em `FacebookInstantFormControllerTest` ao limpar `market_niche` (erro de FK em `lead_portal_flow`), que é fora do escopo desta alteração e interrompeu a finalização total dos testes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3ee6a50e248321b4472c4bf06cd9cd)