### PR TITLE
Persist dossiê status to MoisSalesPage and update pipeline services to mark start

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/dossiersynthesis/service/DossierDossierSynthesisService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/dossiersynthesis/service/DossierDossierSynthesisService.java
@@ -2,12 +2,21 @@ package com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.dossiersynth
 
 import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.dossiersynthesis.service.pending.DossierDossierSynthesisPendingRequest;
 import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.dossiersynthesis.service.pending.DossierDossierSynthesisPendingResponse;
+import com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1.MoisSalesPageRepository;
+import java.time.Instant;
 import java.util.List;
 import org.springframework.stereotype.Service;
 
 /** Publica pendências e contratos da etapa síntese final do dossiê do pipeline de dossiê MOIS v1. */
 @Service
 public class DossierDossierSynthesisService {
+    private final MoisSalesPageRepository salesPageRepository;
+
+    /** Cria o service da etapa com acesso ao repositório canônico da página/produto. */
+    public DossierDossierSynthesisService(MoisSalesPageRepository salesPageRepository) {
+        this.salesPageRepository = salesPageRepository;
+    }
+
     private static final String STAGE_CODE = "dossier-synthesis";
     private static final String NEXT_STAGE = "";
     private static final String STATUS_STARTED = "INICIADO";
@@ -15,9 +24,15 @@ public class DossierDossierSynthesisService {
     private static final String STATUS_COMPLETED = "CONCLUIDO";
     private static final String STATUS_FAILED = "FALHA";
 
-    /** Registra a intenção de iniciar a etapa para o produto informado sem executar a rotina no backend. */
+    /** Marca a página/produto como iniciado no dossiê e posiciona a etapa atual. */
     public void start(String productKey) {
-        // Método reservado para criação futura da pendência canônica da etapa para a chave do produto.
+        long pageId = Long.parseLong(productKey);
+        var page = salesPageRepository.findById(pageId)
+                .orElseThrow(() -> new IllegalArgumentException("Página/produto MOIS não encontrada: " + productKey));
+        page.setDossieProdutoStatus(STATUS_STARTED);
+        page.setDossieProdutoCurrentStage(STAGE_CODE);
+        page.setDossieProdutoUpdatedAt(Instant.now());
+        salesPageRepository.save(page);
     }
 
     /** Entrega trabalhos pendentes ao executor sem assumir controle operacional de execução no backend. */

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/intake/service/DossierIntakeService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/intake/service/DossierIntakeService.java
@@ -2,12 +2,21 @@ package com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.intake.servi
 
 import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.intake.service.pending.DossierIntakePendingRequest;
 import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.intake.service.pending.DossierIntakePendingResponse;
+import com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1.MoisSalesPageRepository;
+import java.time.Instant;
 import java.util.List;
 import org.springframework.stereotype.Service;
 
 /** Publica pendências e contratos da etapa entrada inicial do pipeline de dossiê MOIS v1. */
 @Service
 public class DossierIntakeService {
+    private final MoisSalesPageRepository salesPageRepository;
+
+    /** Cria o service da etapa com acesso ao repositório canônico da página/produto. */
+    public DossierIntakeService(MoisSalesPageRepository salesPageRepository) {
+        this.salesPageRepository = salesPageRepository;
+    }
+
     private static final String STAGE_CODE = "intake";
     private static final String NEXT_STAGE = "product-understanding";
     private static final String STATUS_STARTED = "INICIADO";
@@ -15,9 +24,15 @@ public class DossierIntakeService {
     private static final String STATUS_COMPLETED = "CONCLUIDO";
     private static final String STATUS_FAILED = "FALHA";
 
-    /** Registra a intenção de iniciar a etapa para o produto informado sem executar a rotina no backend. */
+    /** Marca a página/produto como iniciado no dossiê e posiciona a etapa atual. */
     public void start(String productKey) {
-        // Método reservado para criação futura da pendência canônica da etapa para a chave do produto.
+        long pageId = Long.parseLong(productKey);
+        var page = salesPageRepository.findById(pageId)
+                .orElseThrow(() -> new IllegalArgumentException("Página/produto MOIS não encontrada: " + productKey));
+        page.setDossieProdutoStatus(STATUS_STARTED);
+        page.setDossieProdutoCurrentStage(STAGE_CODE);
+        page.setDossieProdutoUpdatedAt(Instant.now());
+        salesPageRepository.save(page);
     }
 
     /** Entrega trabalhos pendentes ao executor sem assumir controle operacional de execução no backend. */

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/investigationanchorbuilder/service/DossierInvestigationAnchorBuilderService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/investigationanchorbuilder/service/DossierInvestigationAnchorBuilderService.java
@@ -2,12 +2,21 @@ package com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.investigatio
 
 import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.investigationanchorbuilder.service.pending.DossierInvestigationAnchorBuilderPendingRequest;
 import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.investigationanchorbuilder.service.pending.DossierInvestigationAnchorBuilderPendingResponse;
+import com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1.MoisSalesPageRepository;
+import java.time.Instant;
 import java.util.List;
 import org.springframework.stereotype.Service;
 
 /** Publica pendências e contratos da etapa geração de âncoras de investigação do pipeline de dossiê MOIS v1. */
 @Service
 public class DossierInvestigationAnchorBuilderService {
+    private final MoisSalesPageRepository salesPageRepository;
+
+    /** Cria o service da etapa com acesso ao repositório canônico da página/produto. */
+    public DossierInvestigationAnchorBuilderService(MoisSalesPageRepository salesPageRepository) {
+        this.salesPageRepository = salesPageRepository;
+    }
+
     private static final String STAGE_CODE = "investigation-anchor-builder";
     private static final String NEXT_STAGE = "warmup-resource-discovery";
     private static final String STATUS_STARTED = "INICIADO";
@@ -15,9 +24,15 @@ public class DossierInvestigationAnchorBuilderService {
     private static final String STATUS_COMPLETED = "CONCLUIDO";
     private static final String STATUS_FAILED = "FALHA";
 
-    /** Registra a intenção de iniciar a etapa para o produto informado sem executar a rotina no backend. */
+    /** Marca a página/produto como iniciado no dossiê e posiciona a etapa atual. */
     public void start(String productKey) {
-        // Método reservado para criação futura da pendência canônica da etapa para a chave do produto.
+        long pageId = Long.parseLong(productKey);
+        var page = salesPageRepository.findById(pageId)
+                .orElseThrow(() -> new IllegalArgumentException("Página/produto MOIS não encontrada: " + productKey));
+        page.setDossieProdutoStatus(STATUS_STARTED);
+        page.setDossieProdutoCurrentStage(STAGE_CODE);
+        page.setDossieProdutoUpdatedAt(Instant.now());
+        salesPageRepository.save(page);
     }
 
     /** Entrega trabalhos pendentes ao executor sem assumir controle operacional de execução no backend. */

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/productunderstanding/service/DossierProductUnderstandingService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/productunderstanding/service/DossierProductUnderstandingService.java
@@ -2,12 +2,21 @@ package com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.productunder
 
 import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.productunderstanding.service.pending.DossierProductUnderstandingPendingRequest;
 import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.productunderstanding.service.pending.DossierProductUnderstandingPendingResponse;
+import com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1.MoisSalesPageRepository;
+import java.time.Instant;
 import java.util.List;
 import org.springframework.stereotype.Service;
 
 /** Publica pendências e contratos da etapa entendimento do produto do pipeline de dossiê MOIS v1. */
 @Service
 public class DossierProductUnderstandingService {
+    private final MoisSalesPageRepository salesPageRepository;
+
+    /** Cria o service da etapa com acesso ao repositório canônico da página/produto. */
+    public DossierProductUnderstandingService(MoisSalesPageRepository salesPageRepository) {
+        this.salesPageRepository = salesPageRepository;
+    }
+
     private static final String STAGE_CODE = "product-understanding";
     private static final String NEXT_STAGE = "investigation-anchor-builder";
     private static final String STATUS_STARTED = "INICIADO";
@@ -15,9 +24,15 @@ public class DossierProductUnderstandingService {
     private static final String STATUS_COMPLETED = "CONCLUIDO";
     private static final String STATUS_FAILED = "FALHA";
 
-    /** Registra a intenção de iniciar a etapa para o produto informado sem executar a rotina no backend. */
+    /** Marca a página/produto como iniciado no dossiê e posiciona a etapa atual. */
     public void start(String productKey) {
-        // Método reservado para criação futura da pendência canônica da etapa para a chave do produto.
+        long pageId = Long.parseLong(productKey);
+        var page = salesPageRepository.findById(pageId)
+                .orElseThrow(() -> new IllegalArgumentException("Página/produto MOIS não encontrada: " + productKey));
+        page.setDossieProdutoStatus(STATUS_STARTED);
+        page.setDossieProdutoCurrentStage(STAGE_CODE);
+        page.setDossieProdutoUpdatedAt(Instant.now());
+        salesPageRepository.save(page);
     }
 
     /** Entrega trabalhos pendentes ao executor sem assumir controle operacional de execução no backend. */

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/sourceproductmatch/service/DossierSourceProductMatchService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/sourceproductmatch/service/DossierSourceProductMatchService.java
@@ -2,12 +2,21 @@ package com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.sourceproduc
 
 import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.sourceproductmatch.service.pending.DossierSourceProductMatchPendingRequest;
 import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.sourceproductmatch.service.pending.DossierSourceProductMatchPendingResponse;
+import com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1.MoisSalesPageRepository;
+import java.time.Instant;
 import java.util.List;
 import org.springframework.stereotype.Service;
 
 /** Publica pendências e contratos da etapa validação de relação fonte-produto do pipeline de dossiê MOIS v1. */
 @Service
 public class DossierSourceProductMatchService {
+    private final MoisSalesPageRepository salesPageRepository;
+
+    /** Cria o service da etapa com acesso ao repositório canônico da página/produto. */
+    public DossierSourceProductMatchService(MoisSalesPageRepository salesPageRepository) {
+        this.salesPageRepository = salesPageRepository;
+    }
+
     private static final String STAGE_CODE = "source-product-match";
     private static final String NEXT_STAGE = "warmup-signal-extraction";
     private static final String STATUS_STARTED = "INICIADO";
@@ -15,9 +24,15 @@ public class DossierSourceProductMatchService {
     private static final String STATUS_COMPLETED = "CONCLUIDO";
     private static final String STATUS_FAILED = "FALHA";
 
-    /** Registra a intenção de iniciar a etapa para o produto informado sem executar a rotina no backend. */
+    /** Marca a página/produto como iniciado no dossiê e posiciona a etapa atual. */
     public void start(String productKey) {
-        // Método reservado para criação futura da pendência canônica da etapa para a chave do produto.
+        long pageId = Long.parseLong(productKey);
+        var page = salesPageRepository.findById(pageId)
+                .orElseThrow(() -> new IllegalArgumentException("Página/produto MOIS não encontrada: " + productKey));
+        page.setDossieProdutoStatus(STATUS_STARTED);
+        page.setDossieProdutoCurrentStage(STAGE_CODE);
+        page.setDossieProdutoUpdatedAt(Instant.now());
+        salesPageRepository.save(page);
     }
 
     /** Entrega trabalhos pendentes ao executor sem assumir controle operacional de execução no backend. */

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/warmupmapbuilder/service/DossierWarmupMapBuilderService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/warmupmapbuilder/service/DossierWarmupMapBuilderService.java
@@ -2,12 +2,21 @@ package com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.warmupmapbui
 
 import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.warmupmapbuilder.service.pending.DossierWarmupMapBuilderPendingRequest;
 import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.warmupmapbuilder.service.pending.DossierWarmupMapBuilderPendingResponse;
+import com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1.MoisSalesPageRepository;
+import java.time.Instant;
 import java.util.List;
 import org.springframework.stereotype.Service;
 
 /** Publica pendências e contratos da etapa montagem do mapa de aquecimento do pipeline de dossiê MOIS v1. */
 @Service
 public class DossierWarmupMapBuilderService {
+    private final MoisSalesPageRepository salesPageRepository;
+
+    /** Cria o service da etapa com acesso ao repositório canônico da página/produto. */
+    public DossierWarmupMapBuilderService(MoisSalesPageRepository salesPageRepository) {
+        this.salesPageRepository = salesPageRepository;
+    }
+
     private static final String STAGE_CODE = "warmup-map-builder";
     private static final String NEXT_STAGE = "dossier-synthesis";
     private static final String STATUS_STARTED = "INICIADO";
@@ -15,9 +24,15 @@ public class DossierWarmupMapBuilderService {
     private static final String STATUS_COMPLETED = "CONCLUIDO";
     private static final String STATUS_FAILED = "FALHA";
 
-    /** Registra a intenção de iniciar a etapa para o produto informado sem executar a rotina no backend. */
+    /** Marca a página/produto como iniciado no dossiê e posiciona a etapa atual. */
     public void start(String productKey) {
-        // Método reservado para criação futura da pendência canônica da etapa para a chave do produto.
+        long pageId = Long.parseLong(productKey);
+        var page = salesPageRepository.findById(pageId)
+                .orElseThrow(() -> new IllegalArgumentException("Página/produto MOIS não encontrada: " + productKey));
+        page.setDossieProdutoStatus(STATUS_STARTED);
+        page.setDossieProdutoCurrentStage(STAGE_CODE);
+        page.setDossieProdutoUpdatedAt(Instant.now());
+        salesPageRepository.save(page);
     }
 
     /** Entrega trabalhos pendentes ao executor sem assumir controle operacional de execução no backend. */

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/warmupresourcediscovery/service/DossierWarmupResourceDiscoveryService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/warmupresourcediscovery/service/DossierWarmupResourceDiscoveryService.java
@@ -2,12 +2,21 @@ package com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.warmupresour
 
 import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.warmupresourcediscovery.service.pending.DossierWarmupResourceDiscoveryPendingRequest;
 import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.warmupresourcediscovery.service.pending.DossierWarmupResourceDiscoveryPendingResponse;
+import com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1.MoisSalesPageRepository;
+import java.time.Instant;
 import java.util.List;
 import org.springframework.stereotype.Service;
 
 /** Publica pendências e contratos da etapa descoberta de recursos de aquecimento do pipeline de dossiê MOIS v1. */
 @Service
 public class DossierWarmupResourceDiscoveryService {
+    private final MoisSalesPageRepository salesPageRepository;
+
+    /** Cria o service da etapa com acesso ao repositório canônico da página/produto. */
+    public DossierWarmupResourceDiscoveryService(MoisSalesPageRepository salesPageRepository) {
+        this.salesPageRepository = salesPageRepository;
+    }
+
     private static final String STAGE_CODE = "warmup-resource-discovery";
     private static final String NEXT_STAGE = "source-product-match";
     private static final String STATUS_STARTED = "INICIADO";
@@ -15,9 +24,15 @@ public class DossierWarmupResourceDiscoveryService {
     private static final String STATUS_COMPLETED = "CONCLUIDO";
     private static final String STATUS_FAILED = "FALHA";
 
-    /** Registra a intenção de iniciar a etapa para o produto informado sem executar a rotina no backend. */
+    /** Marca a página/produto como iniciado no dossiê e posiciona a etapa atual. */
     public void start(String productKey) {
-        // Método reservado para criação futura da pendência canônica da etapa para a chave do produto.
+        long pageId = Long.parseLong(productKey);
+        var page = salesPageRepository.findById(pageId)
+                .orElseThrow(() -> new IllegalArgumentException("Página/produto MOIS não encontrada: " + productKey));
+        page.setDossieProdutoStatus(STATUS_STARTED);
+        page.setDossieProdutoCurrentStage(STAGE_CODE);
+        page.setDossieProdutoUpdatedAt(Instant.now());
+        salesPageRepository.save(page);
     }
 
     /** Entrega trabalhos pendentes ao executor sem assumir controle operacional de execução no backend. */

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/warmupsignalextraction/service/DossierWarmupSignalExtractionService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/warmupsignalextraction/service/DossierWarmupSignalExtractionService.java
@@ -2,12 +2,21 @@ package com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.warmupsignal
 
 import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.warmupsignalextraction.service.pending.DossierWarmupSignalExtractionPendingRequest;
 import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.warmupsignalextraction.service.pending.DossierWarmupSignalExtractionPendingResponse;
+import com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1.MoisSalesPageRepository;
+import java.time.Instant;
 import java.util.List;
 import org.springframework.stereotype.Service;
 
 /** Publica pendências e contratos da etapa extração de sinais de aquecimento do pipeline de dossiê MOIS v1. */
 @Service
 public class DossierWarmupSignalExtractionService {
+    private final MoisSalesPageRepository salesPageRepository;
+
+    /** Cria o service da etapa com acesso ao repositório canônico da página/produto. */
+    public DossierWarmupSignalExtractionService(MoisSalesPageRepository salesPageRepository) {
+        this.salesPageRepository = salesPageRepository;
+    }
+
     private static final String STAGE_CODE = "warmup-signal-extraction";
     private static final String NEXT_STAGE = "warmup-map-builder";
     private static final String STATUS_STARTED = "INICIADO";
@@ -15,9 +24,15 @@ public class DossierWarmupSignalExtractionService {
     private static final String STATUS_COMPLETED = "CONCLUIDO";
     private static final String STATUS_FAILED = "FALHA";
 
-    /** Registra a intenção de iniciar a etapa para o produto informado sem executar a rotina no backend. */
+    /** Marca a página/produto como iniciado no dossiê e posiciona a etapa atual. */
     public void start(String productKey) {
-        // Método reservado para criação futura da pendência canônica da etapa para a chave do produto.
+        long pageId = Long.parseLong(productKey);
+        var page = salesPageRepository.findById(pageId)
+                .orElseThrow(() -> new IllegalArgumentException("Página/produto MOIS não encontrada: " + productKey));
+        page.setDossieProdutoStatus(STATUS_STARTED);
+        page.setDossieProdutoCurrentStage(STAGE_CODE);
+        page.setDossieProdutoUpdatedAt(Instant.now());
+        salesPageRepository.save(page);
     }
 
     /** Entrega trabalhos pendentes ao executor sem assumir controle operacional de execução no backend. */

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/mois/bibliotecapaginavenda/worker/v1/MoisSalesPageRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/mois/bibliotecapaginavenda/worker/v1/MoisSalesPageRepository.java
@@ -1,0 +1,8 @@
+package com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1;
+
+import com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1.entity.MoisSalesPage;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/** Repositório JPA responsável por localizar e salvar a página/produto da biblioteca de vendas MOIS. */
+public interface MoisSalesPageRepository extends JpaRepository<MoisSalesPage, Long> {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/mois/bibliotecapaginavenda/worker/v1/entity/MoisSalesPage.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/mois/bibliotecapaginavenda/worker/v1/entity/MoisSalesPage.java
@@ -1,0 +1,31 @@
+package com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.time.Instant;
+import lombok.Getter;
+import lombok.Setter;
+
+/** Entidade JPA mínima da página/produto da biblioteca de vendas MOIS usada para controlar o dossiê. */
+@Entity
+@Table(name = "mois_sales_page")
+@Getter
+@Setter
+public class MoisSalesPage {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "dossie_produto_status", length = 40)
+    private String dossieProdutoStatus;
+
+    @Column(name = "dossie_produto_current_stage", length = 80)
+    private String dossieProdutoCurrentStage;
+
+    @Column(name = "dossie_produto_updated_at")
+    private Instant dossieProdutoUpdatedAt;
+}

--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-26-mois-sales-page-dossie-produto-status.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-26-mois-sales-page-dossie-produto-status.yaml
@@ -1,0 +1,25 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-06-26-mois-sales-page-dossie-produto-status-01
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - onError: HALT
+        - dbms:
+            type: mysql
+        - tableExists:
+            tableName: mois_sales_page
+        - not:
+            columnExists:
+              tableName: mois_sales_page
+              columnName: dossie_produto_status
+      changes:
+        - sql:
+            splitStatements: true
+            stripComments: true
+            sql: |
+              ALTER TABLE mois_sales_page
+                ADD COLUMN dossie_produto_status VARCHAR(40) NULL AFTER current_status,
+                ADD COLUMN dossie_produto_current_stage VARCHAR(80) NULL AFTER dossie_produto_status;
+              CREATE INDEX idx_mois_sales_page_dossie_produto
+                ON mois_sales_page (dossie_produto_status, dossie_produto_current_stage, updated_at);

--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-26-mois-sales-page-dossie-produto-updated-at.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-26-mois-sales-page-dossie-produto-updated-at.yaml
@@ -1,0 +1,22 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-06-26-mois-sales-page-dossie-produto-updated-at-01
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - onError: HALT
+        - dbms:
+            type: mysql
+        - tableExists:
+            tableName: mois_sales_page
+        - not:
+            columnExists:
+              tableName: mois_sales_page
+              columnName: dossie_produto_updated_at
+      changes:
+        - sql:
+            splitStatements: true
+            stripComments: true
+            sql: |
+              ALTER TABLE mois_sales_page
+                ADD COLUMN dossie_produto_updated_at DATETIME NULL AFTER dossie_produto_current_stage;

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -1,5 +1,11 @@
 databaseChangeLog:
   - include:
+      file: changesets/2026-06-26-mois-sales-page-dossie-produto-updated-at.yaml
+      relativeToChangelogFile: true
+  - include:
+      file: changesets/2026-06-26-mois-sales-page-dossie-produto-status.yaml
+      relativeToChangelogFile: true
+  - include:
       file: changesets/2026-06-26-market-niche-cnae-link.yaml
       relativeToChangelogFile: true
   - include:


### PR DESCRIPTION
### Motivation
- Introduce canonical storage for pipeline dossiê state on the MOIS sales page so each pipeline stage can mark the product as started and record the current stage and timestamp.
- Provide concrete `start` behavior in multiple dossiê pipeline services so they update persistent state instead of leaving a TODO.
- Add DB migrations to persist the new fields and support efficient querying by the new dossiê columns.

### Description
- Added JPA entity `MoisSalesPage` and repository `MoisSalesPageRepository` under `repository.jpa.mois.bibliotecapaginavenda.worker.v1` with fields `dossieProdutoStatus`, `dossieProdutoCurrentStage` and `dossieProdutoUpdatedAt`.
- Implemented `start(String productKey)` in the following services to parse the product key as a page id, load the page via `MoisSalesPageRepository`, set `dossieProdutoStatus`, `dossieProdutoCurrentStage`, and `dossieProdutoUpdatedAt`, and persist the page: `DossierIntakeService`, `DossierProductUnderstandingService`, `DossierInvestigationAnchorBuilderService`, `DossierWarmupResourceDiscoveryService`, `DossierWarmupSignalExtractionService`, `DossierWarmupMapBuilderService`, `DossierSourceProductMatchService`, and `DossierDossierSynthesisService`.
- Added Liquibase changelog files to the changelog master to add `dossie_produto_status`, `dossie_produto_current_stage`, and `dossie_produto_updated_at` columns to `mois_sales_page` and created an index `idx_mois_sales_page_dossie_produto` for efficient lookups.

### Testing
- No automated tests were executed as part of this rollout.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3ee6016a9c83218622cc3628b9c202)