### PR TITLE
Implementa pending do GeraAnuncio v1

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/pipelines/aiworker/geracaoanuncios/v1/imagem/service/GeraAnuncioImagemService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/pipelines/aiworker/geracaoanuncios/v1/imagem/service/GeraAnuncioImagemService.java
@@ -13,6 +13,7 @@ import com.marketinghub.repository.jpa.oprm.cnae.OprmNicheCandidateRepository;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
+import org.springframework.data.domain.PageRequest;
 import java.util.Objects;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
@@ -64,10 +65,11 @@ public class GeraAnuncioImagemService {
         return List.of(toSummary(experiment));
     }
 
-    /** Publica pendências canônicas para consumo do AI Worker. */
+    /** Publica até dez pendências iniciadas da etapa Imagem para consumo do AI Worker. */
     public List<GeraAnuncioImagemPendingResponse> pending() {
-        return experimentService.listPendingCreativeGeneration(10).stream()
-                .filter(experiment -> experiment.getCreativeGenerationMode() == CreativeGenerationMode.PIPELINE_ADS)
+        return cnaeRepository.findByGeracaoAnunciosCurrentStageCodeAndGeracaoAnunciosPipelineStatusOrderByUpdatedAtAsc(
+                        STAGE_CODE, STATUS_STARTED, PageRequest.of(0, 10))
+                .stream()
                 .map(this::toPending)
                 .toList();
     }
@@ -101,6 +103,12 @@ public class GeraAnuncioImagemService {
                 experiment.getCreativeGenerationRequestedAt(), context(experiment), previousArtifacts(experiment));
     }
 
+    /** Converte um candidato CNAE iniciado em unidade de trabalho fechada para o AI Worker. */
+    private GeraAnuncioImagemPendingResponse toPending(OprmNicheCandidate cnae) {
+        return new GeraAnuncioImagemPendingResponse(stageExecutionId(cnae), cnae.getId(), stageJobId(cnae), cnae.getUpdatedAt(), context(cnae),
+                previousArtifacts(cnae));
+    }
+
     /** Monta o contexto funcional necessário para geração de anúncio sem consulta adicional. */
     private Map<String, Object> context(Experiment experiment) {
         return Map.of(
@@ -110,11 +118,34 @@ public class GeraAnuncioImagemService {
                 "creativeGenerationMode", experiment.getCreativeGenerationMode().name());
     }
 
+    /** Monta o contexto funcional do candidato CNAE para geração de anúncio sem consulta adicional. */
+    private Map<String, Object> context(OprmNicheCandidate cnae) {
+        return Map.of(
+                "experimentId", cnae.getId(),
+                "cnaeCode", Objects.toString(cnae.getCnaeCode(), ""),
+                "cnaeDescription", Objects.toString(cnae.getCnaeDescription(), ""),
+                "candidateNicheName", Objects.toString(cnae.getCandidateNicheName(), ""),
+                "persona", Objects.toString(cnae.getPersona(), ""),
+                "painHypothesis", Objects.toString(cnae.getPainHypothesis(), ""),
+                "desiredOutcome", Objects.toString(cnae.getDesiredOutcome(), ""),
+                "mechanismHypothesis", Objects.toString(cnae.getMechanismHypothesis(), ""),
+                "offerIdea", Objects.toString(cnae.getOfferIdea(), ""),
+                "stageCode", Objects.toString(cnae.getGeracaoAnunciosCurrentStageCode(), ""));
+    }
+
     /** Monta artefatos anteriores já persistidos no experimento. */
     private Map<String, Object> previousArtifacts(Experiment experiment) {
         return Map.of(
                 "adCopy", Objects.toString(experiment.getAdCopy(), ""),
                 "adImageBriefing", Objects.toString(experiment.getAdImageBriefing(), ""));
+    }
+
+    /** Monta artefatos anteriores já persistidos no candidato CNAE. */
+    private Map<String, Object> previousArtifacts(OprmNicheCandidate cnae) {
+        return Map.of(
+                "proofDirection", Objects.toString(cnae.getProofDirection(), ""),
+                "marketVolumeSignals", Objects.toString(cnae.getMarketVolumeSignals(), ""),
+                "sourceArtifacts", Objects.toString(cnae.getSourceArtifacts(), ""));
     }
 
     /** Resolve o código/chave recebido no contrato administrativo para o identificador interno do experimento. */

--- a/backend/ads-service/src/main/java/com/marketinghub/pipelines/aiworker/geracaoanuncios/v1/texto/service/GeraAnuncioTextoService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/pipelines/aiworker/geracaoanuncios/v1/texto/service/GeraAnuncioTextoService.java
@@ -13,6 +13,7 @@ import com.marketinghub.repository.jpa.oprm.cnae.OprmNicheCandidateRepository;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
+import org.springframework.data.domain.PageRequest;
 import java.util.Objects;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
@@ -64,10 +65,11 @@ public class GeraAnuncioTextoService {
         return List.of(toSummary(experiment));
     }
 
-    /** Publica pendências canônicas para consumo do AI Worker. */
+    /** Publica até dez pendências iniciadas da etapa Texto para consumo do AI Worker. */
     public List<GeraAnuncioTextoPendingResponse> pending() {
-        return experimentService.listPendingCreativeGeneration(10).stream()
-                .filter(experiment -> experiment.getCreativeGenerationMode() == CreativeGenerationMode.PIPELINE_ADS)
+        return cnaeRepository.findByGeracaoAnunciosCurrentStageCodeAndGeracaoAnunciosPipelineStatusOrderByUpdatedAtAsc(
+                        STAGE_CODE, STATUS_STARTED, PageRequest.of(0, 10))
+                .stream()
                 .map(this::toPending)
                 .toList();
     }
@@ -101,6 +103,12 @@ public class GeraAnuncioTextoService {
                 experiment.getCreativeGenerationRequestedAt(), context(experiment), previousArtifacts(experiment));
     }
 
+    /** Converte um candidato CNAE iniciado em unidade de trabalho fechada para o AI Worker. */
+    private GeraAnuncioTextoPendingResponse toPending(OprmNicheCandidate cnae) {
+        return new GeraAnuncioTextoPendingResponse(stageExecutionId(cnae), cnae.getId(), stageJobId(cnae), cnae.getUpdatedAt(), context(cnae),
+                previousArtifacts(cnae));
+    }
+
     /** Monta o contexto funcional necessário para geração de anúncio sem consulta adicional. */
     private Map<String, Object> context(Experiment experiment) {
         return Map.of(
@@ -110,11 +118,34 @@ public class GeraAnuncioTextoService {
                 "creativeGenerationMode", experiment.getCreativeGenerationMode().name());
     }
 
+    /** Monta o contexto funcional do candidato CNAE para geração de anúncio sem consulta adicional. */
+    private Map<String, Object> context(OprmNicheCandidate cnae) {
+        return Map.of(
+                "experimentId", cnae.getId(),
+                "cnaeCode", Objects.toString(cnae.getCnaeCode(), ""),
+                "cnaeDescription", Objects.toString(cnae.getCnaeDescription(), ""),
+                "candidateNicheName", Objects.toString(cnae.getCandidateNicheName(), ""),
+                "persona", Objects.toString(cnae.getPersona(), ""),
+                "painHypothesis", Objects.toString(cnae.getPainHypothesis(), ""),
+                "desiredOutcome", Objects.toString(cnae.getDesiredOutcome(), ""),
+                "mechanismHypothesis", Objects.toString(cnae.getMechanismHypothesis(), ""),
+                "offerIdea", Objects.toString(cnae.getOfferIdea(), ""),
+                "stageCode", Objects.toString(cnae.getGeracaoAnunciosCurrentStageCode(), ""));
+    }
+
     /** Monta artefatos anteriores já persistidos no experimento. */
     private Map<String, Object> previousArtifacts(Experiment experiment) {
         return Map.of(
                 "adCopy", Objects.toString(experiment.getAdCopy(), ""),
                 "adImageBriefing", Objects.toString(experiment.getAdImageBriefing(), ""));
+    }
+
+    /** Monta artefatos anteriores já persistidos no candidato CNAE. */
+    private Map<String, Object> previousArtifacts(OprmNicheCandidate cnae) {
+        return Map.of(
+                "proofDirection", Objects.toString(cnae.getProofDirection(), ""),
+                "marketVolumeSignals", Objects.toString(cnae.getMarketVolumeSignals(), ""),
+                "sourceArtifacts", Objects.toString(cnae.getSourceArtifacts(), ""));
     }
 
     /** Resolve o código/chave recebido no contrato administrativo para o identificador interno do experimento. */

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/oprm/cnae/OprmNicheCandidateRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/oprm/cnae/OprmNicheCandidateRepository.java
@@ -54,5 +54,11 @@ public interface OprmNicheCandidateRepository extends JpaRepository<OprmNicheCan
      * Lista candidatos de nicho enriquecidos priorizando maiores scores para acompanhamento no frontend.
      */
     List<OprmNicheCandidate> findAllByOrderByOpportunityScoreDescCreatedAtDesc(Pageable pageable);
+
+    /**
+     * Lista candidatos iniciados na etapa atual da geração de anúncios, em ordem de solicitação mais antiga.
+     */
+    List<OprmNicheCandidate> findByGeracaoAnunciosCurrentStageCodeAndGeracaoAnunciosPipelineStatusOrderByUpdatedAtAsc(
+            String currentStageCode, String pipelineStatus, Pageable pageable);
 }
 


### PR DESCRIPTION
### Motivation
- Disponibilizar ao AI Worker um endpoint `pending` canônico para as etapas Texto e Imagem do pipeline `geracaoanuncios.v1` que retorne até 10 jobs prontos para processamento, priorizando os mais antigos em ordem ascendente e usando o status `INICIADO`.

### Description
- Altera `GeraAnuncioTextoService.pending()` e `GeraAnuncioImagemService.pending()` para buscar até 10 candidatos via `OprmNicheCandidateRepository.findByGeracaoAnunciosCurrentStageCodeAndGeracaoAnunciosPipelineStatusOrderByUpdatedAtAsc(...)` em vez de usar a lista genérica de `Experiment`.
- Adiciona overloads `toPending(OprmNicheCandidate)` e monta `context(...)` e `previousArtifacts(...)` a partir de `OprmNicheCandidate` para retornar `GeraAnuncio<Texto|Imagem>PendingResponse` completos para o worker; inclui `PageRequest` para paginação.
- Declara novo método de consulta no repositório `OprmNicheCandidateRepository` com assinatura `findByGeracaoAnunciosCurrentStageCodeAndGeracaoAnunciosPipelineStatusOrderByUpdatedAtAsc(String, String, Pageable)`.
- Ajustes menores de imports e formatação nos arquivos alterados em `backend/ads-service/src/main/java/...` para suportar a nova lógica de `pending`.

### Testing
- Rodei `mvn -f backend/ads-service/pom.xml -DskipTests compile` e a compilação do módulo `ads-service` foi bem sucedida. (BUILD SUCCESS)
- Rodei `mvn -f backend/ads-service/pom.xml test`; o suíte de testes foi executado parcialmente e a maioria dos testes passou, porém há uma falha pré-existente não relacionada: `PipelineServiceTest.shouldMatchOprmNichoCnaeOpenAiFlagsWithCollectorCode` — erro devido a pacote ausente no módulo `oprm-coletor-mei`, portanto a falha não é introduzida por estas mudanças.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3eea29f388832180df71faef0a1af7)