### PR TITLE
Publish pending by started CNAE for NichoCNAE v3

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/cnaeintake/service/BackendCnaeIntakeService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/cnaeintake/service/BackendCnaeIntakeService.java
@@ -1,6 +1,7 @@
 package com.marketinghub.oprmcoletormei.nichocnae.v3.cnaeintake.service;
 
 import com.marketinghub.oprmcoletormei.nichocnae.v3.OprmNichoCnaeV3StageExecution;
+import com.marketinghub.oprm.market.OprmCnpjCnaeDim;
 import com.marketinghub.oprmcoletormei.nichocnae.v3.cnaeintake.service.createStageExecution.CnaeIntakeCreateResponse;
 import com.marketinghub.oprmcoletormei.nichocnae.v3.cnaeintake.service.pending.CnaeIntakePendingResponse;
 import com.marketinghub.oprmcoletormei.nichocnae.v3.shared.OprmNichoCnaeV3StageServiceSupport;
@@ -14,7 +15,6 @@ import org.springframework.stereotype.Service;
 public class BackendCnaeIntakeService extends OprmNichoCnaeV3StageServiceSupport {
     private static final String STAGE_CODE = "cnae-intake";
     private static final String NEXT_STAGE = "persona-candidate-generator";
-    private static final String STATUS_STARTED = "INICIADO";
     private static final String STATUS_WAITING = "AGUARDANDO_RETORNO_MODULO";
     private static final String STATUS_COMPLETED = "CONCLUIDO";
     private static final String STATUS_FAILED = "FALHA";
@@ -37,7 +37,7 @@ public class BackendCnaeIntakeService extends OprmNichoCnaeV3StageServiceSupport
 
     /** Lista pendências da etapa cnae-intake para o executor OPRM. */
     public List<CnaeIntakePendingResponse> pending() {
-        return pendingExecutions().stream().map(this::toPendingResponse).toList();
+        return pendingCnaes().stream().map(this::toPendingResponse).toList();
     }
 
     /** Registra conclusão da etapa cnae-intake. */
@@ -56,7 +56,14 @@ public class BackendCnaeIntakeService extends OprmNichoCnaeV3StageServiceSupport
     }
 
     /** Converte entidade persistida em item pendente para executor externo. */
-    private CnaeIntakePendingResponse toPendingResponse(OprmNichoCnaeV3StageExecution execution) {
-        return new CnaeIntakePendingResponse(execution.getId(), execution.getJobId(), execution.getCnaeCode(), execution.getInputPayload(), execution.getAttemptNumber(), execution.getKnowledgeVersion());
+    private CnaeIntakePendingResponse toPendingResponse(OprmCnpjCnaeDim cnae) {
+        OprmNichoCnaeV3StageExecution execution = pendingExecution(cnae).orElse(null);
+        return new CnaeIntakePendingResponse(
+                execution == null ? null : execution.getId(),
+                execution == null ? pendingJobId(cnae) : execution.getJobId(),
+                cnae.getCnaeCode(),
+                execution == null ? cnaeInputPayload(cnae) : execution.getInputPayload(),
+                execution == null ? 1 : execution.getAttemptNumber(),
+                execution == null ? 1 : execution.getKnowledgeVersion());
     }
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/dailytaskssynthesizer/service/BackendDailyTasksSynthesizerService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/dailytaskssynthesizer/service/BackendDailyTasksSynthesizerService.java
@@ -1,6 +1,7 @@
 package com.marketinghub.oprmcoletormei.nichocnae.v3.dailytaskssynthesizer.service;
 
 import com.marketinghub.oprmcoletormei.nichocnae.v3.OprmNichoCnaeV3StageExecution;
+import com.marketinghub.oprm.market.OprmCnpjCnaeDim;
 import com.marketinghub.oprmcoletormei.nichocnae.v3.dailytaskssynthesizer.service.createStageExecution.DailyTasksSynthesizerCreateResponse;
 import com.marketinghub.oprmcoletormei.nichocnae.v3.dailytaskssynthesizer.service.pending.DailyTasksSynthesizerPendingResponse;
 import com.marketinghub.oprmcoletormei.nichocnae.v3.shared.OprmNichoCnaeV3StageServiceSupport;
@@ -14,7 +15,6 @@ import org.springframework.stereotype.Service;
 public class BackendDailyTasksSynthesizerService extends OprmNichoCnaeV3StageServiceSupport {
     private static final String STAGE_CODE = "daily-tasks-synthesizer";
     private static final String NEXT_STAGE = "quality-gate";
-    private static final String STATUS_STARTED = "INICIADO";
     private static final String STATUS_WAITING = "AGUARDANDO_RETORNO_MODULO";
     private static final String STATUS_COMPLETED = "CONCLUIDO";
     private static final String STATUS_FAILED = "FALHA";
@@ -37,7 +37,7 @@ public class BackendDailyTasksSynthesizerService extends OprmNichoCnaeV3StageSer
 
     /** Lista pendências da etapa daily-tasks-synthesizer para o executor OPRM. */
     public List<DailyTasksSynthesizerPendingResponse> pending() {
-        return pendingExecutions().stream().map(this::toPendingResponse).toList();
+        return pendingCnaes().stream().map(this::toPendingResponse).toList();
     }
 
     /** Registra conclusão da etapa daily-tasks-synthesizer. */
@@ -56,7 +56,14 @@ public class BackendDailyTasksSynthesizerService extends OprmNichoCnaeV3StageSer
     }
 
     /** Converte entidade persistida em item pendente para executor externo. */
-    private DailyTasksSynthesizerPendingResponse toPendingResponse(OprmNichoCnaeV3StageExecution execution) {
-        return new DailyTasksSynthesizerPendingResponse(execution.getId(), execution.getJobId(), execution.getCnaeCode(), execution.getInputPayload(), execution.getAttemptNumber(), execution.getKnowledgeVersion());
+    private DailyTasksSynthesizerPendingResponse toPendingResponse(OprmCnpjCnaeDim cnae) {
+        OprmNichoCnaeV3StageExecution execution = pendingExecution(cnae).orElse(null);
+        return new DailyTasksSynthesizerPendingResponse(
+                execution == null ? null : execution.getId(),
+                execution == null ? pendingJobId(cnae) : execution.getJobId(),
+                cnae.getCnaeCode(),
+                execution == null ? cnaeInputPayload(cnae) : execution.getInputPayload(),
+                execution == null ? 1 : execution.getAttemptNumber(),
+                execution == null ? 1 : execution.getKnowledgeVersion());
     }
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/personacandidategenerator/service/BackendPersonaCandidateGeneratorService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/personacandidategenerator/service/BackendPersonaCandidateGeneratorService.java
@@ -1,6 +1,7 @@
 package com.marketinghub.oprmcoletormei.nichocnae.v3.personacandidategenerator.service;
 
 import com.marketinghub.oprmcoletormei.nichocnae.v3.OprmNichoCnaeV3StageExecution;
+import com.marketinghub.oprm.market.OprmCnpjCnaeDim;
 import com.marketinghub.oprmcoletormei.nichocnae.v3.personacandidategenerator.service.createStageExecution.PersonaCandidateGeneratorCreateResponse;
 import com.marketinghub.oprmcoletormei.nichocnae.v3.personacandidategenerator.service.pending.PersonaCandidateGeneratorPendingResponse;
 import com.marketinghub.oprmcoletormei.nichocnae.v3.shared.OprmNichoCnaeV3StageServiceSupport;
@@ -14,7 +15,6 @@ import org.springframework.stereotype.Service;
 public class BackendPersonaCandidateGeneratorService extends OprmNichoCnaeV3StageServiceSupport {
     private static final String STAGE_CODE = "persona-candidate-generator";
     private static final String NEXT_STAGE = "persona-tournament";
-    private static final String STATUS_STARTED = "INICIADO";
     private static final String STATUS_WAITING = "AGUARDANDO_RETORNO_MODULO";
     private static final String STATUS_COMPLETED = "CONCLUIDO";
     private static final String STATUS_FAILED = "FALHA";
@@ -37,7 +37,7 @@ public class BackendPersonaCandidateGeneratorService extends OprmNichoCnaeV3Stag
 
     /** Lista pendências da etapa persona-candidate-generator para o executor OPRM. */
     public List<PersonaCandidateGeneratorPendingResponse> pending() {
-        return pendingExecutions().stream().map(this::toPendingResponse).toList();
+        return pendingCnaes().stream().map(this::toPendingResponse).toList();
     }
 
     /** Registra conclusão da etapa persona-candidate-generator. */
@@ -56,7 +56,14 @@ public class BackendPersonaCandidateGeneratorService extends OprmNichoCnaeV3Stag
     }
 
     /** Converte entidade persistida em item pendente para executor externo. */
-    private PersonaCandidateGeneratorPendingResponse toPendingResponse(OprmNichoCnaeV3StageExecution execution) {
-        return new PersonaCandidateGeneratorPendingResponse(execution.getId(), execution.getJobId(), execution.getCnaeCode(), execution.getInputPayload(), execution.getAttemptNumber(), execution.getKnowledgeVersion());
+    private PersonaCandidateGeneratorPendingResponse toPendingResponse(OprmCnpjCnaeDim cnae) {
+        OprmNichoCnaeV3StageExecution execution = pendingExecution(cnae).orElse(null);
+        return new PersonaCandidateGeneratorPendingResponse(
+                execution == null ? null : execution.getId(),
+                execution == null ? pendingJobId(cnae) : execution.getJobId(),
+                cnae.getCnaeCode(),
+                execution == null ? cnaeInputPayload(cnae) : execution.getInputPayload(),
+                execution == null ? 1 : execution.getAttemptNumber(),
+                execution == null ? 1 : execution.getKnowledgeVersion());
     }
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/personaroutinematerializer/service/BackendPersonaRoutineMaterializerService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/personaroutinematerializer/service/BackendPersonaRoutineMaterializerService.java
@@ -4,6 +4,7 @@ import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marketinghub.oprmcoletormei.nichocnae.v3.personaroutinematerializer.gateway.PersonaRoutineMaterializerNicheGateway;
 import com.marketinghub.oprmcoletormei.nichocnae.v3.OprmNichoCnaeV3StageExecution;
+import com.marketinghub.oprm.market.OprmCnpjCnaeDim;
 import com.marketinghub.oprmcoletormei.nichocnae.v3.personaroutinematerializer.service.createStageExecution.PersonaRoutineMaterializerCreateResponse;
 import com.marketinghub.oprmcoletormei.nichocnae.v3.personaroutinematerializer.service.pending.PersonaRoutineMaterializerPendingResponse;
 import com.marketinghub.oprmcoletormei.nichocnae.v3.shared.OprmNichoCnaeV3StageServiceSupport;
@@ -22,7 +23,6 @@ import org.springframework.util.StringUtils;
 public class BackendPersonaRoutineMaterializerService extends OprmNichoCnaeV3StageServiceSupport {
     private static final String STAGE_CODE = "persona-routine-materializer";
     private static final String NEXT_STAGE = "";
-    private static final String STATUS_STARTED = "INICIADO";
     private static final String STATUS_WAITING = "AGUARDANDO_RETORNO_MODULO";
     private static final String STATUS_COMPLETED = "CONCLUIDO";
     private static final String STATUS_FAILED = "FALHA";
@@ -56,7 +56,7 @@ public class BackendPersonaRoutineMaterializerService extends OprmNichoCnaeV3Sta
 
     /** Lista pendências da etapa persona-routine-materializer para o executor OPRM. */
     public List<PersonaRoutineMaterializerPendingResponse> pending() {
-        return pendingExecutions().stream().map(this::toPendingResponse).toList();
+        return pendingCnaes().stream().map(this::toPendingResponse).toList();
     }
 
     /** Registra conclusão da etapa persona-routine-materializer. */
@@ -78,8 +78,15 @@ public class BackendPersonaRoutineMaterializerService extends OprmNichoCnaeV3Sta
     }
 
     /** Converte entidade persistida em item pendente para executor externo. */
-    private PersonaRoutineMaterializerPendingResponse toPendingResponse(OprmNichoCnaeV3StageExecution execution) {
-        return new PersonaRoutineMaterializerPendingResponse(execution.getId(), execution.getJobId(), execution.getCnaeCode(), execution.getInputPayload(), execution.getAttemptNumber(), execution.getKnowledgeVersion());
+    private PersonaRoutineMaterializerPendingResponse toPendingResponse(OprmCnpjCnaeDim cnae) {
+        OprmNichoCnaeV3StageExecution execution = pendingExecution(cnae).orElse(null);
+        return new PersonaRoutineMaterializerPendingResponse(
+                execution == null ? null : execution.getId(),
+                execution == null ? pendingJobId(cnae) : execution.getJobId(),
+                cnae.getCnaeCode(),
+                execution == null ? cnaeInputPayload(cnae) : execution.getInputPayload(),
+                execution == null ? 1 : execution.getAttemptNumber(),
+                execution == null ? 1 : execution.getKnowledgeVersion());
     }
 
     /** Materializa o resultado final v3 nas estruturas reutilizáveis do nicho. */

--- a/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/personatournament/service/BackendPersonaTournamentService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/personatournament/service/BackendPersonaTournamentService.java
@@ -1,6 +1,7 @@
 package com.marketinghub.oprmcoletormei.nichocnae.v3.personatournament.service;
 
 import com.marketinghub.oprmcoletormei.nichocnae.v3.OprmNichoCnaeV3StageExecution;
+import com.marketinghub.oprm.market.OprmCnpjCnaeDim;
 import com.marketinghub.oprmcoletormei.nichocnae.v3.personatournament.service.createStageExecution.PersonaTournamentCreateResponse;
 import com.marketinghub.oprmcoletormei.nichocnae.v3.personatournament.service.pending.PersonaTournamentPendingResponse;
 import com.marketinghub.oprmcoletormei.nichocnae.v3.shared.OprmNichoCnaeV3StageServiceSupport;
@@ -14,7 +15,6 @@ import org.springframework.stereotype.Service;
 public class BackendPersonaTournamentService extends OprmNichoCnaeV3StageServiceSupport {
     private static final String STAGE_CODE = "persona-tournament";
     private static final String NEXT_STAGE = "routine-query-planner";
-    private static final String STATUS_STARTED = "INICIADO";
     private static final String STATUS_WAITING = "AGUARDANDO_RETORNO_MODULO";
     private static final String STATUS_COMPLETED = "CONCLUIDO";
     private static final String STATUS_FAILED = "FALHA";
@@ -37,7 +37,7 @@ public class BackendPersonaTournamentService extends OprmNichoCnaeV3StageService
 
     /** Lista pendências da etapa persona-tournament para o executor OPRM. */
     public List<PersonaTournamentPendingResponse> pending() {
-        return pendingExecutions().stream().map(this::toPendingResponse).toList();
+        return pendingCnaes().stream().map(this::toPendingResponse).toList();
     }
 
     /** Registra conclusão da etapa persona-tournament. */
@@ -56,7 +56,14 @@ public class BackendPersonaTournamentService extends OprmNichoCnaeV3StageService
     }
 
     /** Converte entidade persistida em item pendente para executor externo. */
-    private PersonaTournamentPendingResponse toPendingResponse(OprmNichoCnaeV3StageExecution execution) {
-        return new PersonaTournamentPendingResponse(execution.getId(), execution.getJobId(), execution.getCnaeCode(), execution.getInputPayload(), execution.getAttemptNumber(), execution.getKnowledgeVersion());
+    private PersonaTournamentPendingResponse toPendingResponse(OprmCnpjCnaeDim cnae) {
+        OprmNichoCnaeV3StageExecution execution = pendingExecution(cnae).orElse(null);
+        return new PersonaTournamentPendingResponse(
+                execution == null ? null : execution.getId(),
+                execution == null ? pendingJobId(cnae) : execution.getJobId(),
+                cnae.getCnaeCode(),
+                execution == null ? cnaeInputPayload(cnae) : execution.getInputPayload(),
+                execution == null ? 1 : execution.getAttemptNumber(),
+                execution == null ? 1 : execution.getKnowledgeVersion());
     }
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/qualitygate/service/BackendQualityGateService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/qualitygate/service/BackendQualityGateService.java
@@ -1,6 +1,7 @@
 package com.marketinghub.oprmcoletormei.nichocnae.v3.qualitygate.service;
 
 import com.marketinghub.oprmcoletormei.nichocnae.v3.OprmNichoCnaeV3StageExecution;
+import com.marketinghub.oprm.market.OprmCnpjCnaeDim;
 import com.marketinghub.oprmcoletormei.nichocnae.v3.qualitygate.service.createStageExecution.QualityGateCreateResponse;
 import com.marketinghub.oprmcoletormei.nichocnae.v3.qualitygate.service.pending.QualityGatePendingResponse;
 import com.marketinghub.oprmcoletormei.nichocnae.v3.shared.OprmNichoCnaeV3StageServiceSupport;
@@ -14,7 +15,6 @@ import org.springframework.stereotype.Service;
 public class BackendQualityGateService extends OprmNichoCnaeV3StageServiceSupport {
     private static final String STAGE_CODE = "quality-gate";
     private static final String NEXT_STAGE = "persona-routine-materializer";
-    private static final String STATUS_STARTED = "INICIADO";
     private static final String STATUS_WAITING = "AGUARDANDO_RETORNO_MODULO";
     private static final String STATUS_COMPLETED = "CONCLUIDO";
     private static final String STATUS_FAILED = "FALHA";
@@ -37,7 +37,7 @@ public class BackendQualityGateService extends OprmNichoCnaeV3StageServiceSuppor
 
     /** Lista pendências da etapa quality-gate para o executor OPRM. */
     public List<QualityGatePendingResponse> pending() {
-        return pendingExecutions().stream().map(this::toPendingResponse).toList();
+        return pendingCnaes().stream().map(this::toPendingResponse).toList();
     }
 
     /** Registra conclusão da etapa quality-gate. */
@@ -56,7 +56,14 @@ public class BackendQualityGateService extends OprmNichoCnaeV3StageServiceSuppor
     }
 
     /** Converte entidade persistida em item pendente para executor externo. */
-    private QualityGatePendingResponse toPendingResponse(OprmNichoCnaeV3StageExecution execution) {
-        return new QualityGatePendingResponse(execution.getId(), execution.getJobId(), execution.getCnaeCode(), execution.getInputPayload(), execution.getAttemptNumber(), execution.getKnowledgeVersion());
+    private QualityGatePendingResponse toPendingResponse(OprmCnpjCnaeDim cnae) {
+        OprmNichoCnaeV3StageExecution execution = pendingExecution(cnae).orElse(null);
+        return new QualityGatePendingResponse(
+                execution == null ? null : execution.getId(),
+                execution == null ? pendingJobId(cnae) : execution.getJobId(),
+                cnae.getCnaeCode(),
+                execution == null ? cnaeInputPayload(cnae) : execution.getInputPayload(),
+                execution == null ? 1 : execution.getAttemptNumber(),
+                execution == null ? 1 : execution.getKnowledgeVersion());
     }
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/routinequeryplanner/service/BackendRoutineQueryPlannerService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/routinequeryplanner/service/BackendRoutineQueryPlannerService.java
@@ -1,6 +1,7 @@
 package com.marketinghub.oprmcoletormei.nichocnae.v3.routinequeryplanner.service;
 
 import com.marketinghub.oprmcoletormei.nichocnae.v3.OprmNichoCnaeV3StageExecution;
+import com.marketinghub.oprm.market.OprmCnpjCnaeDim;
 import com.marketinghub.oprmcoletormei.nichocnae.v3.routinequeryplanner.service.createStageExecution.RoutineQueryPlannerCreateResponse;
 import com.marketinghub.oprmcoletormei.nichocnae.v3.routinequeryplanner.service.pending.RoutineQueryPlannerPendingResponse;
 import com.marketinghub.oprmcoletormei.nichocnae.v3.shared.OprmNichoCnaeV3StageServiceSupport;
@@ -14,7 +15,6 @@ import org.springframework.stereotype.Service;
 public class BackendRoutineQueryPlannerService extends OprmNichoCnaeV3StageServiceSupport {
     private static final String STAGE_CODE = "routine-query-planner";
     private static final String NEXT_STAGE = "source-searcher";
-    private static final String STATUS_STARTED = "INICIADO";
     private static final String STATUS_WAITING = "AGUARDANDO_RETORNO_MODULO";
     private static final String STATUS_COMPLETED = "CONCLUIDO";
     private static final String STATUS_FAILED = "FALHA";
@@ -37,7 +37,7 @@ public class BackendRoutineQueryPlannerService extends OprmNichoCnaeV3StageServi
 
     /** Lista pendências da etapa routine-query-planner para o executor OPRM. */
     public List<RoutineQueryPlannerPendingResponse> pending() {
-        return pendingExecutions().stream().map(this::toPendingResponse).toList();
+        return pendingCnaes().stream().map(this::toPendingResponse).toList();
     }
 
     /** Registra conclusão da etapa routine-query-planner. */
@@ -56,7 +56,14 @@ public class BackendRoutineQueryPlannerService extends OprmNichoCnaeV3StageServi
     }
 
     /** Converte entidade persistida em item pendente para executor externo. */
-    private RoutineQueryPlannerPendingResponse toPendingResponse(OprmNichoCnaeV3StageExecution execution) {
-        return new RoutineQueryPlannerPendingResponse(execution.getId(), execution.getJobId(), execution.getCnaeCode(), execution.getInputPayload(), execution.getAttemptNumber(), execution.getKnowledgeVersion());
+    private RoutineQueryPlannerPendingResponse toPendingResponse(OprmCnpjCnaeDim cnae) {
+        OprmNichoCnaeV3StageExecution execution = pendingExecution(cnae).orElse(null);
+        return new RoutineQueryPlannerPendingResponse(
+                execution == null ? null : execution.getId(),
+                execution == null ? pendingJobId(cnae) : execution.getJobId(),
+                cnae.getCnaeCode(),
+                execution == null ? cnaeInputPayload(cnae) : execution.getInputPayload(),
+                execution == null ? 1 : execution.getAttemptNumber(),
+                execution == null ? 1 : execution.getKnowledgeVersion());
     }
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/routinesignalextractor/service/BackendRoutineSignalExtractorService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/routinesignalextractor/service/BackendRoutineSignalExtractorService.java
@@ -1,6 +1,7 @@
 package com.marketinghub.oprmcoletormei.nichocnae.v3.routinesignalextractor.service;
 
 import com.marketinghub.oprmcoletormei.nichocnae.v3.OprmNichoCnaeV3StageExecution;
+import com.marketinghub.oprm.market.OprmCnpjCnaeDim;
 import com.marketinghub.oprmcoletormei.nichocnae.v3.routinesignalextractor.service.createStageExecution.RoutineSignalExtractorCreateResponse;
 import com.marketinghub.oprmcoletormei.nichocnae.v3.routinesignalextractor.service.pending.RoutineSignalExtractorPendingResponse;
 import com.marketinghub.oprmcoletormei.nichocnae.v3.shared.OprmNichoCnaeV3StageServiceSupport;
@@ -14,7 +15,6 @@ import org.springframework.stereotype.Service;
 public class BackendRoutineSignalExtractorService extends OprmNichoCnaeV3StageServiceSupport {
     private static final String STAGE_CODE = "routine-signal-extractor";
     private static final String NEXT_STAGE = "daily-tasks-synthesizer";
-    private static final String STATUS_STARTED = "INICIADO";
     private static final String STATUS_WAITING = "AGUARDANDO_RETORNO_MODULO";
     private static final String STATUS_COMPLETED = "CONCLUIDO";
     private static final String STATUS_FAILED = "FALHA";
@@ -37,7 +37,7 @@ public class BackendRoutineSignalExtractorService extends OprmNichoCnaeV3StageSe
 
     /** Lista pendências da etapa routine-signal-extractor para o executor OPRM. */
     public List<RoutineSignalExtractorPendingResponse> pending() {
-        return pendingExecutions().stream().map(this::toPendingResponse).toList();
+        return pendingCnaes().stream().map(this::toPendingResponse).toList();
     }
 
     /** Registra conclusão da etapa routine-signal-extractor. */
@@ -56,7 +56,14 @@ public class BackendRoutineSignalExtractorService extends OprmNichoCnaeV3StageSe
     }
 
     /** Converte entidade persistida em item pendente para executor externo. */
-    private RoutineSignalExtractorPendingResponse toPendingResponse(OprmNichoCnaeV3StageExecution execution) {
-        return new RoutineSignalExtractorPendingResponse(execution.getId(), execution.getJobId(), execution.getCnaeCode(), execution.getInputPayload(), execution.getAttemptNumber(), execution.getKnowledgeVersion());
+    private RoutineSignalExtractorPendingResponse toPendingResponse(OprmCnpjCnaeDim cnae) {
+        OprmNichoCnaeV3StageExecution execution = pendingExecution(cnae).orElse(null);
+        return new RoutineSignalExtractorPendingResponse(
+                execution == null ? null : execution.getId(),
+                execution == null ? pendingJobId(cnae) : execution.getJobId(),
+                cnae.getCnaeCode(),
+                execution == null ? cnaeInputPayload(cnae) : execution.getInputPayload(),
+                execution == null ? 1 : execution.getAttemptNumber(),
+                execution == null ? 1 : execution.getKnowledgeVersion());
     }
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/shared/OprmNichoCnaeV3StageServiceSupport.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/shared/OprmNichoCnaeV3StageServiceSupport.java
@@ -8,11 +8,15 @@ import com.marketinghub.repository.jpa.oprm.nichocnae.v3.OprmNichoCnaeV3StageExe
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.web.server.ResponseStatusException;
 
 /** Base compartilhada para services canônicos de etapas NichoCNAE v3 sem assumir execução operacional. */
 public abstract class OprmNichoCnaeV3StageServiceSupport {
+    protected static final String STATUS_STARTED = "INICIADO";
+    private static final int PENDING_LIMIT = 10;
     private static final Map<String, Integer> STAGE_ORDER = Map.ofEntries(
             Map.entry("cnae-intake", 1),
             Map.entry("persona-candidate-generator", 2),
@@ -62,9 +66,25 @@ public abstract class OprmNichoCnaeV3StageServiceSupport {
         return repository.save(execution);
     }
 
-    /** Lista pendências da etapa para o executor externo consumir pelo endpoint pending. */
-    protected List<OprmNichoCnaeV3StageExecution> pendingExecutions() {
-        return repository.findTop10ByStageCodeAndStatusOrderByCreatedAtAsc(stageCode, OprmNichoCnaeV3StageExecutionStatus.PENDING);
+    /** Lista CNAEs iniciados na etapa corrente para o executor externo consumir pelo endpoint pending. */
+    protected List<OprmCnpjCnaeDim> pendingCnaes() {
+        return cnaeRepository.findByNichocnaeCurrentStageCodeAndNichocnaePipelineStatusOrderByNichocnaePipelineUpdatedAtAsc(
+                stageCode, STATUS_STARTED, PageRequest.of(0, PENDING_LIMIT));
+    }
+
+    /** Recupera a execução mais recente do CNAE na etapa corrente para preservar o contrato de callback. */
+    protected Optional<OprmNichoCnaeV3StageExecution> pendingExecution(OprmCnpjCnaeDim cnae) {
+        return repository.findTop1ByCnaeCodeAndStageCodeOrderByCreatedAtDesc(cnae.getCnaeCode(), stageCode);
+    }
+
+    /** Monta payload mínimo de entrada para um CNAE pendente quando não houver execução persistida. */
+    protected String cnaeInputPayload(OprmCnpjCnaeDim cnae) {
+        return "{\"cnaeCode\":\"" + cnae.getCnaeCode() + "\"}";
+    }
+
+    /** Monta jobId estável para uma pendência publicada diretamente pelo cadastro de CNAE. */
+    protected String pendingJobId(OprmCnpjCnaeDim cnae) {
+        return "nichocnae-v3-" + cnae.getCnaeCode();
     }
 
     /** Registra conclusão reportada pelo executor externo. */

--- a/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/sourcefetcher/service/BackendSourceFetcherV3Service.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/sourcefetcher/service/BackendSourceFetcherV3Service.java
@@ -1,6 +1,7 @@
 package com.marketinghub.oprmcoletormei.nichocnae.v3.sourcefetcher.service;
 
 import com.marketinghub.oprmcoletormei.nichocnae.v3.OprmNichoCnaeV3StageExecution;
+import com.marketinghub.oprm.market.OprmCnpjCnaeDim;
 import com.marketinghub.oprmcoletormei.nichocnae.v3.sourcefetcher.service.createStageExecution.SourceFetcherCreateResponse;
 import com.marketinghub.oprmcoletormei.nichocnae.v3.sourcefetcher.service.pending.SourceFetcherPendingResponse;
 import com.marketinghub.oprmcoletormei.nichocnae.v3.shared.OprmNichoCnaeV3StageServiceSupport;
@@ -14,7 +15,6 @@ import org.springframework.stereotype.Service;
 public class BackendSourceFetcherV3Service extends OprmNichoCnaeV3StageServiceSupport {
     private static final String STAGE_CODE = "source-fetcher";
     private static final String NEXT_STAGE = "routine-signal-extractor";
-    private static final String STATUS_STARTED = "INICIADO";
     private static final String STATUS_WAITING = "AGUARDANDO_RETORNO_MODULO";
     private static final String STATUS_COMPLETED = "CONCLUIDO";
     private static final String STATUS_FAILED = "FALHA";
@@ -37,7 +37,7 @@ public class BackendSourceFetcherV3Service extends OprmNichoCnaeV3StageServiceSu
 
     /** Lista pendências da etapa source-fetcher para o executor OPRM. */
     public List<SourceFetcherPendingResponse> pending() {
-        return pendingExecutions().stream().map(this::toPendingResponse).toList();
+        return pendingCnaes().stream().map(this::toPendingResponse).toList();
     }
 
     /** Registra conclusão da etapa source-fetcher. */
@@ -56,7 +56,14 @@ public class BackendSourceFetcherV3Service extends OprmNichoCnaeV3StageServiceSu
     }
 
     /** Converte entidade persistida em item pendente para executor externo. */
-    private SourceFetcherPendingResponse toPendingResponse(OprmNichoCnaeV3StageExecution execution) {
-        return new SourceFetcherPendingResponse(execution.getId(), execution.getJobId(), execution.getCnaeCode(), execution.getInputPayload(), execution.getAttemptNumber(), execution.getKnowledgeVersion());
+    private SourceFetcherPendingResponse toPendingResponse(OprmCnpjCnaeDim cnae) {
+        OprmNichoCnaeV3StageExecution execution = pendingExecution(cnae).orElse(null);
+        return new SourceFetcherPendingResponse(
+                execution == null ? null : execution.getId(),
+                execution == null ? pendingJobId(cnae) : execution.getJobId(),
+                cnae.getCnaeCode(),
+                execution == null ? cnaeInputPayload(cnae) : execution.getInputPayload(),
+                execution == null ? 1 : execution.getAttemptNumber(),
+                execution == null ? 1 : execution.getKnowledgeVersion());
     }
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/sourcesearcher/service/BackendSourceSearcherV3Service.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/sourcesearcher/service/BackendSourceSearcherV3Service.java
@@ -1,6 +1,7 @@
 package com.marketinghub.oprmcoletormei.nichocnae.v3.sourcesearcher.service;
 
 import com.marketinghub.oprmcoletormei.nichocnae.v3.OprmNichoCnaeV3StageExecution;
+import com.marketinghub.oprm.market.OprmCnpjCnaeDim;
 import com.marketinghub.oprmcoletormei.nichocnae.v3.sourcesearcher.service.createStageExecution.SourceSearcherCreateResponse;
 import com.marketinghub.oprmcoletormei.nichocnae.v3.sourcesearcher.service.pending.SourceSearcherPendingResponse;
 import com.marketinghub.oprmcoletormei.nichocnae.v3.shared.OprmNichoCnaeV3StageServiceSupport;
@@ -14,7 +15,6 @@ import org.springframework.stereotype.Service;
 public class BackendSourceSearcherV3Service extends OprmNichoCnaeV3StageServiceSupport {
     private static final String STAGE_CODE = "source-searcher";
     private static final String NEXT_STAGE = "source-fetcher";
-    private static final String STATUS_STARTED = "INICIADO";
     private static final String STATUS_WAITING = "AGUARDANDO_RETORNO_MODULO";
     private static final String STATUS_COMPLETED = "CONCLUIDO";
     private static final String STATUS_FAILED = "FALHA";
@@ -37,7 +37,7 @@ public class BackendSourceSearcherV3Service extends OprmNichoCnaeV3StageServiceS
 
     /** Lista pendências da etapa source-searcher para o executor OPRM. */
     public List<SourceSearcherPendingResponse> pending() {
-        return pendingExecutions().stream().map(this::toPendingResponse).toList();
+        return pendingCnaes().stream().map(this::toPendingResponse).toList();
     }
 
     /** Registra conclusão da etapa source-searcher. */
@@ -56,7 +56,14 @@ public class BackendSourceSearcherV3Service extends OprmNichoCnaeV3StageServiceS
     }
 
     /** Converte entidade persistida em item pendente para executor externo. */
-    private SourceSearcherPendingResponse toPendingResponse(OprmNichoCnaeV3StageExecution execution) {
-        return new SourceSearcherPendingResponse(execution.getId(), execution.getJobId(), execution.getCnaeCode(), execution.getInputPayload(), execution.getAttemptNumber(), execution.getKnowledgeVersion());
+    private SourceSearcherPendingResponse toPendingResponse(OprmCnpjCnaeDim cnae) {
+        OprmNichoCnaeV3StageExecution execution = pendingExecution(cnae).orElse(null);
+        return new SourceSearcherPendingResponse(
+                execution == null ? null : execution.getId(),
+                execution == null ? pendingJobId(cnae) : execution.getJobId(),
+                cnae.getCnaeCode(),
+                execution == null ? cnaeInputPayload(cnae) : execution.getInputPayload(),
+                execution == null ? 1 : execution.getAttemptNumber(),
+                execution == null ? 1 : execution.getKnowledgeVersion());
     }
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/oprm/market/OprmCnpjCnaeDimRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/oprm/market/OprmCnpjCnaeDimRepository.java
@@ -1,9 +1,15 @@
 package com.marketinghub.repository.jpa.oprm.market;
 
 import com.marketinghub.oprm.market.OprmCnpjCnaeDim;
+import java.util.List;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 /**
  * Repositório JPA responsável pela persistência de OprmCnpjCnaeDim.
  */
-public interface OprmCnpjCnaeDimRepository extends JpaRepository<OprmCnpjCnaeDim, String> {}
+public interface OprmCnpjCnaeDimRepository extends JpaRepository<OprmCnpjCnaeDim, String> {
+    /** Lista CNAEs iniciados em uma etapa corrente para publicação pelo endpoint pending. */
+    List<OprmCnpjCnaeDim> findByNichocnaeCurrentStageCodeAndNichocnaePipelineStatusOrderByNichocnaePipelineUpdatedAtAsc(
+            String currentStageCode, String pipelineStatus, Pageable pageable);
+}

--- a/backend/ads-service/src/test/java/com/marketinghub/oprmcoletormei/nichocnae/v3/personaroutinematerializer/service/BackendPersonaRoutineMaterializerServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/oprmcoletormei/nichocnae/v3/personaroutinematerializer/service/BackendPersonaRoutineMaterializerServiceTest.java
@@ -14,7 +14,9 @@ import com.marketinghub.oprmcoletormei.nichocnae.v3.personaroutinematerializer.g
 import com.marketinghub.repository.jpa.oprm.market.OprmCnpjCnaeDimRepository;
 import com.marketinghub.repository.jpa.oprm.nichocnae.v3.OprmNichoCnaeV3StageExecutionRepository;
 import java.time.Instant;
+import java.util.List;
 import java.util.Optional;
+import org.springframework.data.domain.PageRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -103,6 +105,35 @@ class BackendPersonaRoutineMaterializerServiceTest {
         assertThat(cnae.getNichocnaeCurrentStageCode()).isEqualTo("persona-routine-materializer");
         assertThat(cnae.getNichocnaePipelineUpdatedAt()).isNotNull();
         verify(cnaeRepository).save(cnae);
+    }
+
+
+    /** Garante que o pending lê CNAEs iniciados da etapa corrente pelo cadastro canônico de CNAE. */
+    @Test
+    void pendingListsStartedCnaesFromCurrentStage() {
+        OprmCnpjCnaeDim cnae = new OprmCnpjCnaeDim();
+        cnae.setCnaeCode("4781400");
+        cnae.setNichocnaeCurrentStageCode("persona-routine-materializer");
+        cnae.setNichocnaePipelineStatus("INICIADO");
+        OprmNichoCnaeV3StageExecution execution = execution();
+        execution.setInputPayload("{\"origin\":\"stage-execution\"}");
+        execution.setAttemptNumber(2);
+        execution.setKnowledgeVersion(3);
+        when(cnaeRepository.findByNichocnaeCurrentStageCodeAndNichocnaePipelineStatusOrderByNichocnaePipelineUpdatedAtAsc(
+                eq("persona-routine-materializer"), eq("INICIADO"), eq(PageRequest.of(0, 10))))
+                .thenReturn(List.of(cnae));
+        when(repository.findTop1ByCnaeCodeAndStageCodeOrderByCreatedAtDesc("4781400", "persona-routine-materializer"))
+                .thenReturn(Optional.of(execution));
+
+        var pending = service.pending();
+
+        assertThat(pending).hasSize(1);
+        assertThat(pending.getFirst().stageExecutionId()).isEqualTo(19L);
+        assertThat(pending.getFirst().jobId()).isEqualTo("nichocnae-v3-4781400-1782411268024");
+        assertThat(pending.getFirst().cnaeCode()).isEqualTo("4781400");
+        assertThat(pending.getFirst().inputPayload()).isEqualTo("{\"origin\":\"stage-execution\"}");
+        assertThat(pending.getFirst().attemptNumber()).isEqualTo(2);
+        assertThat(pending.getFirst().knowledgeVersion()).isEqualTo(3);
     }
 
     /** Monta uma execução final pendente para o callback de conclusão. */

--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -1565,3 +1565,5 @@
 ## 2026-06-26 — NichoCNAE v3: data/hora do status no cadastro CNAE
 
 - Ajuste: adicionada a coluna `nichocnae_pipeline_updated_at` em `oprm_cnpj_cnae_dim` para registrar a data/hora corrente sempre que o `start` de uma etapa atualizar o status e a etapa atual do pipeline NichoCNAE v3.
+
+- 2026-06-26: Ajustado pending do backend NichoCNAE v3 para publicar até 10 CNAEs iniciados por etapa corrente a partir de oprm_cnpj_cnae_dim, ordenados por atualização ascendente, usando a constante INICIADO no suporte compartilhado das etapas.


### PR DESCRIPTION
### Motivation
- The OPRM executor needs a canonical `pending` feed that publishes CNAEs that were marked as started in the CNAE registry rather than relying only on stage-execution rows. 
- The goal is to publish up to 10 CNAEs per stage ordered by update time, keep a stable `jobId` for CNAE-originated pendings, and preserve any existing stage-execution data when present to keep callback compatibility.

### Description
- Added a new JPA query `findByNichocnaeCurrentStageCodeAndNichocnaePipelineStatusOrderByNichocnaePipelineUpdatedAtAsc(...)` to `OprmCnpjCnaeDimRepository` to fetch CNAEs by current stage and `INICIADO` status with `Pageable` limiting results. 
- Extended `OprmNichoCnaeV3StageServiceSupport` with `STATUS_STARTED`, `PENDING_LIMIT`, `pendingCnaes()`, `pendingExecution(...)`, `cnaeInputPayload(...)` and `pendingJobId(...)` to centralize the pending-by-CNAE behavior and jobId/payload construction. 
- Updated all v3 stage services (`cnae-intake`, `persona-candidate-generator`, `persona-tournament`, `routine-query-planner`, `source-searcher`, `source-fetcher`, `routine-signal-extractor`, `daily-tasks-synthesizer`, `quality-gate`, `persona-routine-materializer`) to populate their `/pending` responses from the CNAE registry using the shared support methods and to return preserved stage-execution fields when an execution already exists. 
- Preserved callback contract by returning existing `stageExecutionId`, `jobId`, `inputPayload`, `attemptNumber` and `knowledgeVersion` when a stage-execution row exists, otherwise returning CNAE-derived defaults. 
- Added a unit test (`BackendPersonaRoutineMaterializerServiceTest`) that covers the new `pending` behavior for the `persona-routine-materializer` stage and updated `docs/registros/oprm1.md` with the change record. 

### Testing
- Ran the module unit test `mvn -DskipITs test -Dtest='BackendPersonaRoutineMaterializerServiceTest'` inside `backend/ads-service`, and the test suite passed successfully. 
- Verified `git diff --check` reported no whitespace/patch issues and created a commit for the changes. 
- Note: running the same Maven command from the repository root fails because the `pom.xml` for the module is under `backend/ads-service`, so tests were executed in the module directory as required.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3eea190368832195266662d972be1a)