### PR TITLE
Implementa endpoints `pending` para etapas do dossiê MOIS v1

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/dossiersynthesis/service/DossierDossierSynthesisService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/dossiersynthesis/service/DossierDossierSynthesisService.java
@@ -1,10 +1,12 @@
 package com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.dossiersynthesis.service;
 
+import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.dossiersynthesis.service.pending.DossierDossierSynthesisPendingJob;
 import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.dossiersynthesis.service.pending.DossierDossierSynthesisPendingRequest;
 import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.dossiersynthesis.service.pending.DossierDossierSynthesisPendingResponse;
 import com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1.MoisSalesPageRepository;
 import java.time.Instant;
 import java.util.List;
+import java.util.Map;
 import org.springframework.stereotype.Service;
 
 /** Publica pendências e contratos da etapa síntese final do dossiê do pipeline de dossiê MOIS v1. */
@@ -35,8 +37,24 @@ public class DossierDossierSynthesisService {
         salesPageRepository.save(page);
     }
 
-    /** Entrega trabalhos pendentes ao executor sem assumir controle operacional de execução no backend. */
+    /** Entrega até dez trabalhos iniciados da etapa atual ao executor, ordenados pela data operacional mais antiga. */
     public DossierDossierSynthesisPendingResponse pending(DossierDossierSynthesisPendingRequest request) {
-        return new DossierDossierSynthesisPendingResponse(false, List.of());
+        List<DossierDossierSynthesisPendingJob> jobs = salesPageRepository
+                .findTop10ByDossieProdutoStatusAndDossieProdutoCurrentStageOrderByDossieProdutoUpdatedAtAscIdAsc(
+                        STATUS_STARTED, STAGE_CODE)
+                .stream()
+                .map(page -> new DossierDossierSynthesisPendingJob(
+                        page.getId(),
+                        page.getId(),
+                        "mois-sales-page-" + page.getId(),
+                        STAGE_CODE,
+                        Map.of(
+                                "productKey", String.valueOf(page.getId()),
+                                "pageId", page.getId(),
+                                "stageCode", STAGE_CODE,
+                                "status", STATUS_STARTED,
+                                "nextStageCode", NEXT_STAGE)))
+                .toList();
+        return new DossierDossierSynthesisPendingResponse(!jobs.isEmpty(), jobs);
     }
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/intake/service/DossierIntakeService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/intake/service/DossierIntakeService.java
@@ -1,10 +1,12 @@
 package com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.intake.service;
 
+import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.intake.service.pending.DossierIntakePendingJob;
 import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.intake.service.pending.DossierIntakePendingRequest;
 import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.intake.service.pending.DossierIntakePendingResponse;
 import com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1.MoisSalesPageRepository;
 import java.time.Instant;
 import java.util.List;
+import java.util.Map;
 import org.springframework.stereotype.Service;
 
 /** Publica pendências e contratos da etapa entrada inicial do pipeline de dossiê MOIS v1. */
@@ -35,8 +37,24 @@ public class DossierIntakeService {
         salesPageRepository.save(page);
     }
 
-    /** Entrega trabalhos pendentes ao executor sem assumir controle operacional de execução no backend. */
+    /** Entrega até dez trabalhos iniciados da etapa atual ao executor, ordenados pela data operacional mais antiga. */
     public DossierIntakePendingResponse pending(DossierIntakePendingRequest request) {
-        return new DossierIntakePendingResponse(false, List.of());
+        List<DossierIntakePendingJob> jobs = salesPageRepository
+                .findTop10ByDossieProdutoStatusAndDossieProdutoCurrentStageOrderByDossieProdutoUpdatedAtAscIdAsc(
+                        STATUS_STARTED, STAGE_CODE)
+                .stream()
+                .map(page -> new DossierIntakePendingJob(
+                        page.getId(),
+                        page.getId(),
+                        "mois-sales-page-" + page.getId(),
+                        STAGE_CODE,
+                        Map.of(
+                                "productKey", String.valueOf(page.getId()),
+                                "pageId", page.getId(),
+                                "stageCode", STAGE_CODE,
+                                "status", STATUS_STARTED,
+                                "nextStageCode", NEXT_STAGE)))
+                .toList();
+        return new DossierIntakePendingResponse(!jobs.isEmpty(), jobs);
     }
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/investigationanchorbuilder/service/DossierInvestigationAnchorBuilderService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/investigationanchorbuilder/service/DossierInvestigationAnchorBuilderService.java
@@ -1,10 +1,12 @@
 package com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.investigationanchorbuilder.service;
 
+import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.investigationanchorbuilder.service.pending.DossierInvestigationAnchorBuilderPendingJob;
 import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.investigationanchorbuilder.service.pending.DossierInvestigationAnchorBuilderPendingRequest;
 import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.investigationanchorbuilder.service.pending.DossierInvestigationAnchorBuilderPendingResponse;
 import com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1.MoisSalesPageRepository;
 import java.time.Instant;
 import java.util.List;
+import java.util.Map;
 import org.springframework.stereotype.Service;
 
 /** Publica pendências e contratos da etapa geração de âncoras de investigação do pipeline de dossiê MOIS v1. */
@@ -35,8 +37,24 @@ public class DossierInvestigationAnchorBuilderService {
         salesPageRepository.save(page);
     }
 
-    /** Entrega trabalhos pendentes ao executor sem assumir controle operacional de execução no backend. */
+    /** Entrega até dez trabalhos iniciados da etapa atual ao executor, ordenados pela data operacional mais antiga. */
     public DossierInvestigationAnchorBuilderPendingResponse pending(DossierInvestigationAnchorBuilderPendingRequest request) {
-        return new DossierInvestigationAnchorBuilderPendingResponse(false, List.of());
+        List<DossierInvestigationAnchorBuilderPendingJob> jobs = salesPageRepository
+                .findTop10ByDossieProdutoStatusAndDossieProdutoCurrentStageOrderByDossieProdutoUpdatedAtAscIdAsc(
+                        STATUS_STARTED, STAGE_CODE)
+                .stream()
+                .map(page -> new DossierInvestigationAnchorBuilderPendingJob(
+                        page.getId(),
+                        page.getId(),
+                        "mois-sales-page-" + page.getId(),
+                        STAGE_CODE,
+                        Map.of(
+                                "productKey", String.valueOf(page.getId()),
+                                "pageId", page.getId(),
+                                "stageCode", STAGE_CODE,
+                                "status", STATUS_STARTED,
+                                "nextStageCode", NEXT_STAGE)))
+                .toList();
+        return new DossierInvestigationAnchorBuilderPendingResponse(!jobs.isEmpty(), jobs);
     }
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/productunderstanding/service/DossierProductUnderstandingService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/productunderstanding/service/DossierProductUnderstandingService.java
@@ -1,10 +1,12 @@
 package com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.productunderstanding.service;
 
+import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.productunderstanding.service.pending.DossierProductUnderstandingPendingJob;
 import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.productunderstanding.service.pending.DossierProductUnderstandingPendingRequest;
 import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.productunderstanding.service.pending.DossierProductUnderstandingPendingResponse;
 import com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1.MoisSalesPageRepository;
 import java.time.Instant;
 import java.util.List;
+import java.util.Map;
 import org.springframework.stereotype.Service;
 
 /** Publica pendências e contratos da etapa entendimento do produto do pipeline de dossiê MOIS v1. */
@@ -35,8 +37,24 @@ public class DossierProductUnderstandingService {
         salesPageRepository.save(page);
     }
 
-    /** Entrega trabalhos pendentes ao executor sem assumir controle operacional de execução no backend. */
+    /** Entrega até dez trabalhos iniciados da etapa atual ao executor, ordenados pela data operacional mais antiga. */
     public DossierProductUnderstandingPendingResponse pending(DossierProductUnderstandingPendingRequest request) {
-        return new DossierProductUnderstandingPendingResponse(false, List.of());
+        List<DossierProductUnderstandingPendingJob> jobs = salesPageRepository
+                .findTop10ByDossieProdutoStatusAndDossieProdutoCurrentStageOrderByDossieProdutoUpdatedAtAscIdAsc(
+                        STATUS_STARTED, STAGE_CODE)
+                .stream()
+                .map(page -> new DossierProductUnderstandingPendingJob(
+                        page.getId(),
+                        page.getId(),
+                        "mois-sales-page-" + page.getId(),
+                        STAGE_CODE,
+                        Map.of(
+                                "productKey", String.valueOf(page.getId()),
+                                "pageId", page.getId(),
+                                "stageCode", STAGE_CODE,
+                                "status", STATUS_STARTED,
+                                "nextStageCode", NEXT_STAGE)))
+                .toList();
+        return new DossierProductUnderstandingPendingResponse(!jobs.isEmpty(), jobs);
     }
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/sourceproductmatch/service/DossierSourceProductMatchService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/sourceproductmatch/service/DossierSourceProductMatchService.java
@@ -1,10 +1,12 @@
 package com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.sourceproductmatch.service;
 
+import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.sourceproductmatch.service.pending.DossierSourceProductMatchPendingJob;
 import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.sourceproductmatch.service.pending.DossierSourceProductMatchPendingRequest;
 import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.sourceproductmatch.service.pending.DossierSourceProductMatchPendingResponse;
 import com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1.MoisSalesPageRepository;
 import java.time.Instant;
 import java.util.List;
+import java.util.Map;
 import org.springframework.stereotype.Service;
 
 /** Publica pendências e contratos da etapa validação de relação fonte-produto do pipeline de dossiê MOIS v1. */
@@ -35,8 +37,24 @@ public class DossierSourceProductMatchService {
         salesPageRepository.save(page);
     }
 
-    /** Entrega trabalhos pendentes ao executor sem assumir controle operacional de execução no backend. */
+    /** Entrega até dez trabalhos iniciados da etapa atual ao executor, ordenados pela data operacional mais antiga. */
     public DossierSourceProductMatchPendingResponse pending(DossierSourceProductMatchPendingRequest request) {
-        return new DossierSourceProductMatchPendingResponse(false, List.of());
+        List<DossierSourceProductMatchPendingJob> jobs = salesPageRepository
+                .findTop10ByDossieProdutoStatusAndDossieProdutoCurrentStageOrderByDossieProdutoUpdatedAtAscIdAsc(
+                        STATUS_STARTED, STAGE_CODE)
+                .stream()
+                .map(page -> new DossierSourceProductMatchPendingJob(
+                        page.getId(),
+                        page.getId(),
+                        "mois-sales-page-" + page.getId(),
+                        STAGE_CODE,
+                        Map.of(
+                                "productKey", String.valueOf(page.getId()),
+                                "pageId", page.getId(),
+                                "stageCode", STAGE_CODE,
+                                "status", STATUS_STARTED,
+                                "nextStageCode", NEXT_STAGE)))
+                .toList();
+        return new DossierSourceProductMatchPendingResponse(!jobs.isEmpty(), jobs);
     }
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/warmupmapbuilder/service/DossierWarmupMapBuilderService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/warmupmapbuilder/service/DossierWarmupMapBuilderService.java
@@ -1,10 +1,12 @@
 package com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.warmupmapbuilder.service;
 
+import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.warmupmapbuilder.service.pending.DossierWarmupMapBuilderPendingJob;
 import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.warmupmapbuilder.service.pending.DossierWarmupMapBuilderPendingRequest;
 import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.warmupmapbuilder.service.pending.DossierWarmupMapBuilderPendingResponse;
 import com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1.MoisSalesPageRepository;
 import java.time.Instant;
 import java.util.List;
+import java.util.Map;
 import org.springframework.stereotype.Service;
 
 /** Publica pendências e contratos da etapa montagem do mapa de aquecimento do pipeline de dossiê MOIS v1. */
@@ -35,8 +37,24 @@ public class DossierWarmupMapBuilderService {
         salesPageRepository.save(page);
     }
 
-    /** Entrega trabalhos pendentes ao executor sem assumir controle operacional de execução no backend. */
+    /** Entrega até dez trabalhos iniciados da etapa atual ao executor, ordenados pela data operacional mais antiga. */
     public DossierWarmupMapBuilderPendingResponse pending(DossierWarmupMapBuilderPendingRequest request) {
-        return new DossierWarmupMapBuilderPendingResponse(false, List.of());
+        List<DossierWarmupMapBuilderPendingJob> jobs = salesPageRepository
+                .findTop10ByDossieProdutoStatusAndDossieProdutoCurrentStageOrderByDossieProdutoUpdatedAtAscIdAsc(
+                        STATUS_STARTED, STAGE_CODE)
+                .stream()
+                .map(page -> new DossierWarmupMapBuilderPendingJob(
+                        page.getId(),
+                        page.getId(),
+                        "mois-sales-page-" + page.getId(),
+                        STAGE_CODE,
+                        Map.of(
+                                "productKey", String.valueOf(page.getId()),
+                                "pageId", page.getId(),
+                                "stageCode", STAGE_CODE,
+                                "status", STATUS_STARTED,
+                                "nextStageCode", NEXT_STAGE)))
+                .toList();
+        return new DossierWarmupMapBuilderPendingResponse(!jobs.isEmpty(), jobs);
     }
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/warmupresourcediscovery/service/DossierWarmupResourceDiscoveryService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/warmupresourcediscovery/service/DossierWarmupResourceDiscoveryService.java
@@ -1,10 +1,12 @@
 package com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.warmupresourcediscovery.service;
 
+import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.warmupresourcediscovery.service.pending.DossierWarmupResourceDiscoveryPendingJob;
 import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.warmupresourcediscovery.service.pending.DossierWarmupResourceDiscoveryPendingRequest;
 import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.warmupresourcediscovery.service.pending.DossierWarmupResourceDiscoveryPendingResponse;
 import com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1.MoisSalesPageRepository;
 import java.time.Instant;
 import java.util.List;
+import java.util.Map;
 import org.springframework.stereotype.Service;
 
 /** Publica pendências e contratos da etapa descoberta de recursos de aquecimento do pipeline de dossiê MOIS v1. */
@@ -35,8 +37,24 @@ public class DossierWarmupResourceDiscoveryService {
         salesPageRepository.save(page);
     }
 
-    /** Entrega trabalhos pendentes ao executor sem assumir controle operacional de execução no backend. */
+    /** Entrega até dez trabalhos iniciados da etapa atual ao executor, ordenados pela data operacional mais antiga. */
     public DossierWarmupResourceDiscoveryPendingResponse pending(DossierWarmupResourceDiscoveryPendingRequest request) {
-        return new DossierWarmupResourceDiscoveryPendingResponse(false, List.of());
+        List<DossierWarmupResourceDiscoveryPendingJob> jobs = salesPageRepository
+                .findTop10ByDossieProdutoStatusAndDossieProdutoCurrentStageOrderByDossieProdutoUpdatedAtAscIdAsc(
+                        STATUS_STARTED, STAGE_CODE)
+                .stream()
+                .map(page -> new DossierWarmupResourceDiscoveryPendingJob(
+                        page.getId(),
+                        page.getId(),
+                        "mois-sales-page-" + page.getId(),
+                        STAGE_CODE,
+                        Map.of(
+                                "productKey", String.valueOf(page.getId()),
+                                "pageId", page.getId(),
+                                "stageCode", STAGE_CODE,
+                                "status", STATUS_STARTED,
+                                "nextStageCode", NEXT_STAGE)))
+                .toList();
+        return new DossierWarmupResourceDiscoveryPendingResponse(!jobs.isEmpty(), jobs);
     }
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/warmupsignalextraction/service/DossierWarmupSignalExtractionService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/warmupsignalextraction/service/DossierWarmupSignalExtractionService.java
@@ -1,10 +1,12 @@
 package com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.warmupsignalextraction.service;
 
+import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.warmupsignalextraction.service.pending.DossierWarmupSignalExtractionPendingJob;
 import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.warmupsignalextraction.service.pending.DossierWarmupSignalExtractionPendingRequest;
 import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.warmupsignalextraction.service.pending.DossierWarmupSignalExtractionPendingResponse;
 import com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1.MoisSalesPageRepository;
 import java.time.Instant;
 import java.util.List;
+import java.util.Map;
 import org.springframework.stereotype.Service;
 
 /** Publica pendências e contratos da etapa extração de sinais de aquecimento do pipeline de dossiê MOIS v1. */
@@ -35,8 +37,24 @@ public class DossierWarmupSignalExtractionService {
         salesPageRepository.save(page);
     }
 
-    /** Entrega trabalhos pendentes ao executor sem assumir controle operacional de execução no backend. */
+    /** Entrega até dez trabalhos iniciados da etapa atual ao executor, ordenados pela data operacional mais antiga. */
     public DossierWarmupSignalExtractionPendingResponse pending(DossierWarmupSignalExtractionPendingRequest request) {
-        return new DossierWarmupSignalExtractionPendingResponse(false, List.of());
+        List<DossierWarmupSignalExtractionPendingJob> jobs = salesPageRepository
+                .findTop10ByDossieProdutoStatusAndDossieProdutoCurrentStageOrderByDossieProdutoUpdatedAtAscIdAsc(
+                        STATUS_STARTED, STAGE_CODE)
+                .stream()
+                .map(page -> new DossierWarmupSignalExtractionPendingJob(
+                        page.getId(),
+                        page.getId(),
+                        "mois-sales-page-" + page.getId(),
+                        STAGE_CODE,
+                        Map.of(
+                                "productKey", String.valueOf(page.getId()),
+                                "pageId", page.getId(),
+                                "stageCode", STAGE_CODE,
+                                "status", STATUS_STARTED,
+                                "nextStageCode", NEXT_STAGE)))
+                .toList();
+        return new DossierWarmupSignalExtractionPendingResponse(!jobs.isEmpty(), jobs);
     }
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/mois/bibliotecapaginavenda/worker/v1/MoisSalesPageRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/mois/bibliotecapaginavenda/worker/v1/MoisSalesPageRepository.java
@@ -1,8 +1,13 @@
 package com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1;
 
 import com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1.entity.MoisSalesPage;
+import java.util.List;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 /** Repositório JPA responsável por localizar e salvar a página/produto da biblioteca de vendas MOIS. */
 public interface MoisSalesPageRepository extends JpaRepository<MoisSalesPage, Long> {
+
+    /** Lista até dez páginas/produtos iniciados na etapa atual, priorizando os registros mais antigos. */
+    List<MoisSalesPage> findTop10ByDossieProdutoStatusAndDossieProdutoCurrentStageOrderByDossieProdutoUpdatedAtAscIdAsc(
+            String status, String currentStage);
 }


### PR DESCRIPTION
### Motivation
- Entregar ao worker executor um ponto `pending` canônico para as etapas do pipeline de dossiê MOIS v1, permitindo que o executor busque trabalhos prontos para processamento. 
- Respeitar o protocolo do backend: o backend expõe pendências e permanece a fonte de verdade do estado, sem assumir controle operacional do worker. 
- Melhorar a eficiência do consumo priorizando registros mais antigos e limitando o lote para evitar sobrecarga do executor. 

### Description
- Implementa o método `pending` em 8 services do pipeline MOIS v1 (`intake`, `product-understanding`, `investigation-anchor-builder`, `warmup-resource-discovery`, `source-product-match`, `warmup-signal-extraction`, `warmup-map-builder`, `dossier-synthesis`) para retornar até 10 jobs iniciados ordenados por `dossieProdutoUpdatedAt` asc e `id` asc. 
- Adiciona no `MoisSalesPageRepository` a query `findTop10ByDossieProdutoStatusAndDossieProdutoCurrentStageOrderByDossieProdutoUpdatedAtAscIdAsc(String status, String currentStage)` para a busca eficiente dos registros. 
- Cada `pending` monta objetos `*PendingJob` contendo `stageExecutionId`, `dossierId`, `workspaceId`, `stageName` e um `input` `Map` com `productKey`, `pageId`, `stageCode`, `status` e `nextStageCode`. 
- Mantém os contratos de request/response existentes (`*PendingRequest` / `*PendingResponse`) e segue o padrão de pacote `com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.*`. 

### Testing
- Executado `mvn -DskipTests compile` no módulo backend e a compilação completou com sucesso. 
- Executado `mvn test` no backend onde a suíte foi iniciada; a execução encontrou uma falha pré-existente não relacionada à mudança em `PipelineServiceTest.shouldMatchOprmNichoCnaeOpenAiFlagsWithCollectorCode`, interrompendo a bateria completa de testes. 
- Verificações estáticas/format não puderam ser concluídas com `mvn spotless:check -DskipTests` devido à ausência do plugin Spotless no ambiente Maven atual. 
- `git diff --check` foi executado localmente e não apontou problemas de formatação no diff gerado.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3eea0d6270832199464f289594084d)