### PR TITLE
Add ad generation pipeline audit persistence

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/pipeline/geracaoanuncios/PipelineGeracaoAnuncios.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/pipeline/geracaoanuncios/PipelineGeracaoAnuncios.java
@@ -1,0 +1,69 @@
+package com.marketinghub.pipeline.geracaoanuncios;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.math.BigDecimal;
+import java.time.Instant;
+import lombok.Data;
+
+/** Entidade responsável por auditar interações e custos do pipeline de geração de anúncios. */
+@Entity
+@Data
+@Table(name = "pipeline_geracaoanuncios")
+public class PipelineGeracaoAnuncios {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "id_externo", length = 191)
+    private String idExterno;
+
+    @Column(name = "request", columnDefinition = "LONGTEXT")
+    private String request;
+
+    @Column(name = "response", columnDefinition = "LONGTEXT")
+    private String response;
+
+    @Column(name = "codigo_etapa", length = 96)
+    private String codigoEtapa;
+
+    @Column(name = "data_hora")
+    private Instant dataHora;
+
+    @Column(name = "job_id", length = 191)
+    private String jobId;
+
+    @Column(name = "quantidade_token_entrada")
+    private Long quantidadeTokenEntrada;
+
+    @Column(name = "quantidade_token_saida")
+    private Long quantidadeTokenSaida;
+
+    @Column(name = "modelo", length = 128)
+    private String modelo;
+
+    @Column(name = "custo", precision = 12, scale = 6)
+    private BigDecimal custo;
+
+    @Column(name = "descricao_erro", columnDefinition = "LONGTEXT")
+    private String descricaoErro;
+
+    @Column(name = "job_id_externo", length = 191)
+    private String jobIdExterno;
+
+    @Column(name = "plataforma", length = 64)
+    private String plataforma;
+
+    @Column(name = "prompt", columnDefinition = "LONGTEXT")
+    private String prompt;
+
+    @Column(name = "schema", columnDefinition = "LONGTEXT")
+    private String schema;
+
+    @Column(name = "versao_pipeline", length = 64)
+    private String versaoPipeline;
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/pipeline/geracaoanuncios/PipelineGeracaoAnunciosRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/pipeline/geracaoanuncios/PipelineGeracaoAnunciosRepository.java
@@ -1,0 +1,17 @@
+package com.marketinghub.repository.jpa.pipeline.geracaoanuncios;
+
+import com.marketinghub.pipeline.geracaoanuncios.PipelineGeracaoAnuncios;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/** Repositório JPA responsável pela auditoria do pipeline de geração de anúncios. */
+public interface PipelineGeracaoAnunciosRepository extends JpaRepository<PipelineGeracaoAnuncios, Long> {
+    /** Lista auditorias vinculadas a um job interno em ordem cronológica. */
+    List<PipelineGeracaoAnuncios> findByJobIdOrderByDataHoraAsc(String jobId);
+
+    /** Lista auditorias vinculadas a uma etapa em ordem cronológica. */
+    List<PipelineGeracaoAnuncios> findByCodigoEtapaOrderByDataHoraAsc(String codigoEtapa);
+
+    /** Verifica se já existe auditoria vinculada a um identificador externo. */
+    boolean existsByIdExterno(String idExterno);
+}

--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-26-pipeline-geracaoanuncios.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-26-pipeline-geracaoanuncios.yaml
@@ -1,0 +1,94 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-06-26-01-create-pipeline-geracaoanuncios
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - onError: HALT
+        - dbms:
+            type: mysql
+        - not:
+            tableExists:
+              tableName: pipeline_geracaoanuncios
+      changes:
+        - createTable:
+            tableName: pipeline_geracaoanuncios
+            columns:
+              - column:
+                  name: id
+                  type: BIGINT
+                  autoIncrement: true
+                  constraints:
+                    primaryKey: true
+                    nullable: false
+              - column:
+                  name: id_externo
+                  type: VARCHAR(191)
+              - column:
+                  name: request
+                  type: LONGTEXT
+              - column:
+                  name: response
+                  type: LONGTEXT
+              - column:
+                  name: codigo_etapa
+                  type: VARCHAR(96)
+              - column:
+                  name: data_hora
+                  type: DATETIME(6)
+              - column:
+                  name: job_id
+                  type: VARCHAR(191)
+              - column:
+                  name: quantidade_token_entrada
+                  type: BIGINT
+              - column:
+                  name: quantidade_token_saida
+                  type: BIGINT
+              - column:
+                  name: modelo
+                  type: VARCHAR(128)
+              - column:
+                  name: custo
+                  type: DECIMAL(12,6)
+              - column:
+                  name: descricao_erro
+                  type: LONGTEXT
+              - column:
+                  name: job_id_externo
+                  type: VARCHAR(191)
+              - column:
+                  name: plataforma
+                  type: VARCHAR(64)
+              - column:
+                  name: prompt
+                  type: LONGTEXT
+              - column:
+                  name: schema
+                  type: LONGTEXT
+              - column:
+                  name: versao_pipeline
+                  type: VARCHAR(64)
+        - createIndex:
+            tableName: pipeline_geracaoanuncios
+            indexName: idx_pipeline_geracaoanuncios_job_id
+            columns:
+              - column:
+                  name: job_id
+        - createIndex:
+            tableName: pipeline_geracaoanuncios
+            indexName: idx_pipeline_geracaoanuncios_etapa_data
+            columns:
+              - column:
+                  name: codigo_etapa
+              - column:
+                  name: data_hora
+        - createIndex:
+            tableName: pipeline_geracaoanuncios
+            indexName: idx_pipeline_geracaoanuncios_id_externo
+            columns:
+              - column:
+                  name: id_externo
+      rollback:
+        - dropTable:
+            tableName: pipeline_geracaoanuncios

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -1143,3 +1143,7 @@ databaseChangeLog:
   - include:
       file: changesets/2026-06-26-remove-commercial-fields-from-niche-profile.yaml
       relativeToChangelogFile: true
+
+  - include:
+      file: changesets/2026-06-26-pipeline-geracaoanuncios.yaml
+      relativeToChangelogFile: true


### PR DESCRIPTION
### Motivation
- Persistir audit trails das interações do pipeline de geração de anúncios (request/response, prompt/schema, tokens, modelo, custo, etapa e identificadores) para diagnóstico, auditoria e relatórios de custo por job/etapa.
- Disponibilizar acesso via JPA/Spring Data para consultas por `jobId`, `codigoEtapa` e `idExterno` seguindo a convenção centralizada de `com.marketinghub.repository.jpa`.
- Garantir migração segura do schema via Liquibase seguindo a regra de `relativeToChangelogFile: true` para includes relativos no changelog mestre.

### Description
- Adicionada entidade JPA `PipelineGeracaoAnuncios` mapeada para a tabela `pipeline_geracaoanuncios` com colunas canônicas e comentários de responsabilidade na classe (`src/main/java/com/marketinghub/pipeline/geracaoanuncios/PipelineGeracaoAnuncios.java`).
- Criado `PipelineGeracaoAnunciosRepository` em `com.marketinghub.repository.jpa.pipeline.geracaoanuncios` com métodos `findByJobIdOrderByDataHoraAsc`, `findByCodigoEtapaOrderByDataHoraAsc` e `existsByIdExterno` para acesso canônico à auditoria.
- Incluído changelog Liquibase `changesets/2026-06-26-pipeline-geracaoanuncios.yaml` que cria a tabela com índices (`idx_pipeline_geracaoanuncios_job_id`, `idx_pipeline_geracaoanuncios_etapa_data`, `idx_pipeline_geracaoanuncios_id_externo`).
- Atualizado o master changelog para incluir o novo changeset com `relativeToChangelogFile: true` (`src/main/resources/db/changelog/db.changelog-master.yaml`).

### Testing
- `git diff --check` passou sem alertas de whitespace ou conflitos na diff de arquivos. 
- Validação de includes relativos com script Python confirmou que todos os `include` em `db.changelog-master.yaml` possuem `relativeToChangelogFile: true` (sucesso).
- Backend compilou sem testes com `../mvnw -q -DskipTests compile` dentro de `backend/ads-service` (sucesso).
- Execução de testes completos com `../mvnw -q test` em `backend/ads-service` executou a suíte, mas terminou com falhas relacionadas a testes existentes e independentes desta alteração: falha em `com.marketinghub.architecture.ArquiteturaTest` (verificação de estrutura canônica do MOIS Dossiê v1) e falha em `PipelineServiceTest.shouldMatchOprmNichoCnaeOpenAiFlagsWithCollectorCode` por ausência do pacote esperado no coletor `oprm-coletor-mei`; essas falhas são pré-existentes e não causadas pela nova entidade/changelog (falha de testes automatizados).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3eef2851f483219d25470e3ef9a537)