### PR TITLE
Add NichoCNAE pipeline audit table

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/PipelineNichoCnae.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/PipelineNichoCnae.java
@@ -1,0 +1,64 @@
+package com.marketinghub.oprm.nichocnae;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.math.BigDecimal;
+import java.time.Instant;
+import lombok.Data;
+
+/** Entidade responsável por auditar interações e custos operacionais do pipeline NichoCNAE. */
+@Entity
+@Data
+@Table(name = "pipeline_nichocnae")
+public class PipelineNichoCnae {
+    @Id
+    @Column(name = "id_externo", nullable = false, length = 96)
+    private String idExterno;
+
+    @Column(name = "request", columnDefinition = "LONGTEXT")
+    private String request;
+
+    @Column(name = "response", columnDefinition = "LONGTEXT")
+    private String response;
+
+    @Column(name = "codigo_etapa", length = 96)
+    private String codigoEtapa;
+
+    @Column(name = "data_hora")
+    private Instant dataHora;
+
+    @Column(name = "job_id", length = 128)
+    private String jobId;
+
+    @Column(name = "quantidade_token_entrada")
+    private Long quantidadeTokenEntrada;
+
+    @Column(name = "quantidade_token_saida")
+    private Long quantidadeTokenSaida;
+
+    @Column(name = "modelo", length = 128)
+    private String modelo;
+
+    @Column(name = "custo", precision = 19, scale = 4)
+    private BigDecimal custo;
+
+    @Column(name = "descricao_erro", columnDefinition = "LONGTEXT")
+    private String descricaoErro;
+
+    @Column(name = "job_id_externo", length = 128)
+    private String jobIdExterno;
+
+    @Column(name = "plataforma", length = 64)
+    private String plataforma;
+
+    @Column(name = "prompt", columnDefinition = "LONGTEXT")
+    private String prompt;
+
+    @Column(name = "schema", columnDefinition = "LONGTEXT")
+    private String schema;
+
+    @Column(name = "versao_pipeline", length = 32)
+    private String versaoPipeline;
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/oprm/nichocnae/PipelineNichoCnaeRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/oprm/nichocnae/PipelineNichoCnaeRepository.java
@@ -1,0 +1,17 @@
+package com.marketinghub.repository.jpa.oprm.nichocnae;
+
+import com.marketinghub.oprm.nichocnae.PipelineNichoCnae;
+import java.math.BigDecimal;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+/** Repositório responsável por consultar auditorias do pipeline NichoCNAE. */
+public interface PipelineNichoCnaeRepository extends JpaRepository<PipelineNichoCnae, String> {
+    /** Verifica se já existe auditoria registrada para um job do pipeline. */
+    boolean existsByJobId(String jobId);
+
+    /** Soma o custo auditado das interações vinculadas a um job do pipeline. */
+    @Query("select coalesce(sum(p.custo), 0) from PipelineNichoCnae p where p.jobId = :jobId")
+    BigDecimal sumCustoByJobId(@Param("jobId") String jobId);
+}

--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-26-pipeline-nichocnae.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-26-pipeline-nichocnae.yaml
@@ -1,0 +1,81 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-06-26-01-pipeline-nichocnae
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - dbms:
+            type: mysql
+        - not:
+            - tableExists:
+                tableName: pipeline_nichocnae
+      changes:
+        - createTable:
+            tableName: pipeline_nichocnae
+            columns:
+              - column:
+                  name: id_externo
+                  type: VARCHAR(96)
+                  constraints:
+                    primaryKey: true
+                    primaryKeyName: pk_pipeline_nichocnae
+                    nullable: false
+              - column:
+                  name: request
+                  type: LONGTEXT
+              - column:
+                  name: response
+                  type: LONGTEXT
+              - column:
+                  name: codigo_etapa
+                  type: VARCHAR(96)
+              - column:
+                  name: data_hora
+                  type: DATETIME(6)
+              - column:
+                  name: job_id
+                  type: VARCHAR(128)
+              - column:
+                  name: quantidade_token_entrada
+                  type: BIGINT
+              - column:
+                  name: quantidade_token_saida
+                  type: BIGINT
+              - column:
+                  name: modelo
+                  type: VARCHAR(128)
+              - column:
+                  name: custo
+                  type: DECIMAL(19,4)
+              - column:
+                  name: descricao_erro
+                  type: LONGTEXT
+              - column:
+                  name: job_id_externo
+                  type: VARCHAR(128)
+              - column:
+                  name: plataforma
+                  type: VARCHAR(64)
+              - column:
+                  name: prompt
+                  type: LONGTEXT
+              - column:
+                  name: schema
+                  type: LONGTEXT
+              - column:
+                  name: versao_pipeline
+                  type: VARCHAR(32)
+        - createIndex:
+            tableName: pipeline_nichocnae
+            indexName: idx_pipeline_nichocnae_job_id
+            columns:
+              - column:
+                  name: job_id
+        - createIndex:
+            tableName: pipeline_nichocnae
+            indexName: idx_pipeline_nichocnae_etapa_versao
+            columns:
+              - column:
+                  name: codigo_etapa
+              - column:
+                  name: versao_pipeline

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -1,5 +1,8 @@
 databaseChangeLog:
   - include:
+      file: changesets/2026-06-26-pipeline-nichocnae.yaml
+      relativeToChangelogFile: true
+  - include:
       file: changesets/2026-06-26-oprm-niche-candidate-geracao-anuncios-status.yaml
       file: changesets/2026-06-26-mois-sales-page-dossie-produto-updated-at.yaml
       relativeToChangelogFile: true

--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -1567,3 +1567,8 @@
 - Ajuste: adicionada a coluna `nichocnae_pipeline_updated_at` em `oprm_cnpj_cnae_dim` para registrar a data/hora corrente sempre que o `start` de uma etapa atualizar o status e a etapa atual do pipeline NichoCNAE v3.
 
 - 2026-06-26: Ajustado pending do backend NichoCNAE v3 para publicar até 10 CNAEs iniciados por etapa corrente a partir de oprm_cnpj_cnae_dim, ordenados por atualização ascendente, usando a constante INICIADO no suporte compartilhado das etapas.
+
+## 2026-06-26 — Backend: tabela de auditoria `pipeline_nichocnae`
+
+- Criada a tabela `pipeline_nichocnae` para centralizar auditoria de request/response, prompt/schema, tokens, modelo, custo, erro, etapa, plataforma e versão do pipeline NichoCNAE.
+- Criadas a entidade JPA e o repository canônico no backend para permitir persistência e consultas de custo por `jobId` sem acesso direto ao banco por módulos externos.


### PR DESCRIPTION
### Motivation
- Centralizar auditoria das interações do pipeline NichoCNAE (request/response, prompt/schema, tokens, modelo, custo, erro, etapa, plataforma, versão) para permitir rastreio e agregação por `jobId` no backend. 

### Description
- Adiciona changelog Liquibase `changesets/2026-06-26-pipeline-nichocnae.yaml` que cria a tabela `pipeline_nichocnae` com `id_externo` PK, colunas LONGTEXT para payloads e índices por `job_id` e `(codigo_etapa, versao_pipeline)`. 
- Registra o include no `db.changelog-master.yaml` com `relativeToChangelogFile: true` para conformidade com o padrão Liquibase do projeto. 
- Cria a entidade JPA `com.marketinghub.oprm.nichocnae.PipelineNichoCnae` com mapeamento explícito de colunas e comentário de responsabilidade em português. 
- Cria o repository canônico `com.marketinghub.repository.jpa.oprm.nichocnae.PipelineNichoCnaeRepository` com `existsByJobId` e consulta `sumCustoByJobId` para agregação de custos. 
- Atualiza `docs/registros/oprm1.md` registrando a mudança operacional. 

### Testing
- Executed `mvn -q -DskipTests compile` inside `backend/ads-service` and compilation passed. 
- Ran full test suite (`mvn -q test`) in `backend/ads-service` and the run failed due to an existing test assertion unrelated to this persistence-only change (`PipelineServiceTest` expecting a collector package path), reproducing the same preexisting failure when running the specific test `PipelineServiceTest#shouldMatchOprmNichoCnaeOpenAiFlagsWithCollectorCode`. 
- Attempt to run `spotless:apply` failed because the Spotless plugin prefix is not available in this project's reactor (tooling check only).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3eeef1e824832188eeda394ac85c56)