### PR TITLE
Add product dossier pipeline audit persistence

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/mois/dossieproduto/PipelineDossieProdutoRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/mois/dossieproduto/PipelineDossieProdutoRepository.java
@@ -1,0 +1,12 @@
+package com.marketinghub.repository.jpa.mois.dossieproduto;
+
+import com.marketinghub.repository.jpa.mois.dossieproduto.entity.PipelineDossieProduto;
+import java.util.List;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/** Repositório JPA responsável por consultar e salvar auditorias do pipeline de dossiê de produto. */
+public interface PipelineDossieProdutoRepository extends JpaRepository<PipelineDossieProduto, Long> {
+
+    /** Lista auditorias de uma execução do dossiê de produto pela ordem em que foram registradas. */
+    List<PipelineDossieProduto> findByJobIdOrderByDataHoraAscIdAsc(String jobId);
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/mois/dossieproduto/entity/PipelineDossieProduto.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/mois/dossieproduto/entity/PipelineDossieProduto.java
@@ -1,0 +1,71 @@
+package com.marketinghub.repository.jpa.mois.dossieproduto.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import java.math.BigDecimal;
+import java.time.Instant;
+import lombok.Getter;
+import lombok.Setter;
+
+/** Entidade JPA responsável por auditar interações e custos das etapas do pipeline de dossiê de produto. */
+@Entity
+@Table(name = "pipeline_dossieproduto")
+@Getter
+@Setter
+public class PipelineDossieProduto {
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(name = "id_externo")
+    private String idExterno;
+
+    @Column(name = "request", columnDefinition = "LONGTEXT")
+    private String request;
+
+    @Column(name = "response", columnDefinition = "LONGTEXT")
+    private String response;
+
+    @Column(name = "codigo_etapa", length = 120)
+    private String codigoEtapa;
+
+    @Column(name = "data_hora")
+    private Instant dataHora;
+
+    @Column(name = "job_id")
+    private String jobId;
+
+    @Column(name = "quantidade_token_entrada")
+    private Long quantidadeTokenEntrada;
+
+    @Column(name = "quantidade_token_saida")
+    private Long quantidadeTokenSaida;
+
+    @Column(name = "modelo", length = 120)
+    private String modelo;
+
+    @Column(name = "custo", precision = 19, scale = 6)
+    private BigDecimal custo;
+
+    @Column(name = "descricao_erro", columnDefinition = "LONGTEXT")
+    private String descricaoErro;
+
+    @Column(name = "job_id_externo")
+    private String jobIdExterno;
+
+    @Column(name = "plataforma", length = 120)
+    private String plataforma;
+
+    @Column(name = "prompt", columnDefinition = "LONGTEXT")
+    private String prompt;
+
+    @Column(name = "`schema`", columnDefinition = "LONGTEXT")
+    private String schema;
+
+    @Column(name = "versao_pipeline", length = 80)
+    private String versaoPipeline;
+}

--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-26-pipeline-dossieproduto.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-26-pipeline-dossieproduto.yaml
@@ -1,0 +1,40 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-06-26-pipeline-dossieproduto-01
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - onError: HALT
+        - dbms:
+            type: mysql
+        - not:
+            tableExists:
+              tableName: pipeline_dossieproduto
+      changes:
+        - sql:
+            splitStatements: true
+            stripComments: true
+            sql: |
+              CREATE TABLE pipeline_dossieproduto (
+                id BIGINT NOT NULL AUTO_INCREMENT,
+                id_externo VARCHAR(255) NULL,
+                request LONGTEXT NULL,
+                response LONGTEXT NULL,
+                codigo_etapa VARCHAR(120) NULL,
+                data_hora DATETIME(6) NULL,
+                job_id VARCHAR(255) NULL,
+                quantidade_token_entrada BIGINT NULL,
+                quantidade_token_saida BIGINT NULL,
+                modelo VARCHAR(120) NULL,
+                custo DECIMAL(19,6) NULL,
+                descricao_erro LONGTEXT NULL,
+                job_id_externo VARCHAR(255) NULL,
+                plataforma VARCHAR(120) NULL,
+                prompt LONGTEXT NULL,
+                `schema` LONGTEXT NULL,
+                versao_pipeline VARCHAR(80) NULL,
+                PRIMARY KEY (id),
+                INDEX idx_pipeline_dossieproduto_job_id (job_id),
+                INDEX idx_pipeline_dossieproduto_id_externo (id_externo),
+                INDEX idx_pipeline_dossieproduto_etapa_data (codigo_etapa, data_hora)
+              ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci;

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -1,5 +1,8 @@
 databaseChangeLog:
   - include:
+      file: changesets/2026-06-26-pipeline-dossieproduto.yaml
+      relativeToChangelogFile: true
+  - include:
       file: changesets/2026-06-26-oprm-niche-candidate-geracao-anuncios-status.yaml
       file: changesets/2026-06-26-mois-sales-page-dossie-produto-updated-at.yaml
       relativeToChangelogFile: true


### PR DESCRIPTION
### Motivation
- Registrar de forma auditável as interações e custos das etapas do pipeline de dossiê de produto para permitir debugging, relatório e análise por execução/job.

### Description
- Adiciona changelog Liquibase que cria a tabela `pipeline_dossieproduto` com campos solicitados (`id_externo`, `request`, `response`, `codigo_etapa`, `data_hora`, `job_id`, tokens, `modelo`, `custo`, `descricao_erro`, `job_id_externo`, `plataforma`, `prompt`, `schema`, `versao_pipeline`) e índices relevantes.
- Registra o novo changelog no `db.changelog-master.yaml` usando `relativeToChangelogFile: true` para seguir a convenção do projeto.
- Cria a entidade JPA `PipelineDossieProduto` com mapeamento explícito de colunas e tipos e comentário de responsabilidade em português.
- Cria o `PipelineDossieProdutoRepository` em `com.marketinghub.repository.jpa` com método `findByJobIdOrderByDataHoraAscIdAsc` para recuperar auditorias por execução.

### Testing
- Validação automática do master changelog para garantir que nenhum `include` relativo falta `relativeToChangelogFile: true` executada com script interno e passou sem violações.
- `mvn -DskipTests compile` no módulo `backend/ads-service` foi executado com sucesso (compilação ok).
- Execução parcial de `mvn test` no módulo `backend/ads-service` foi iniciada; a execução encontrou uma falha existente não relacionada em `PipelineServiceTest.shouldMatchOprmNichoCnaeOpenAiFlagsWithCollectorCode` (ausência de pacote do coletor) e a suíte foi interrompida após essa falha; não foram detectados erros associados às classes adicionadas neste PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3eeec0c03c8321962186648f04eebb)