### PR TITLE
Implementa endpoints `recebeRequest` e auditoria do pipeline `geracaoanuncios` v1

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/pipelines/aiworker/geracaoanuncios/v1/imagem/controller/GeraAnuncioImagemController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/pipelines/aiworker/geracaoanuncios/v1/imagem/controller/GeraAnuncioImagemController.java
@@ -5,6 +5,7 @@ import com.marketinghub.pipelines.aiworker.geracaoanuncios.v1.imagem.service.det
 import com.marketinghub.pipelines.aiworker.geracaoanuncios.v1.imagem.service.listStageExecutions.GeraAnuncioImagemExecutionSummaryResponse;
 import com.marketinghub.pipelines.aiworker.geracaoanuncios.v1.imagem.service.pending.GeraAnuncioImagemPendingResponse;
 import com.marketinghub.pipelines.aiworker.geracaoanuncios.v1.imagem.service.recebePrompt.GeraAnuncioImagemPromptRequest;
+import com.marketinghub.pipelines.aiworker.geracaoanuncios.v1.imagem.service.recebeRequest.GeraAnuncioImagemRecebeRequestRequest;
 import com.marketinghub.pipelines.aiworker.geracaoanuncios.v1.imagem.service.recebeResposta.GeraAnuncioImagemRespostaRequest;
 import java.util.List;
 import org.springframework.http.ResponseEntity;
@@ -49,6 +50,14 @@ public class GeraAnuncioImagemController {
     @PostMapping("/pending")
     public List<GeraAnuncioImagemPendingResponse> pending() {
         return service.pending();
+    }
+
+    /** Recebe o request operacional gerado pelo AI Worker para a etapa. */
+    @PostMapping("/{experimentKey}/recebeRequest")
+    public ResponseEntity<Void> recebeRequest(
+            @PathVariable String experimentKey, @RequestBody GeraAnuncioImagemRecebeRequestRequest request) {
+        service.recebeRequest(experimentKey, request);
+        return ResponseEntity.accepted().build();
     }
 
     /** Recebe o prompt operacional enviado ao modelo pelo AI Worker. */

--- a/backend/ads-service/src/main/java/com/marketinghub/pipelines/aiworker/geracaoanuncios/v1/imagem/service/GeraAnuncioImagemService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/pipelines/aiworker/geracaoanuncios/v1/imagem/service/GeraAnuncioImagemService.java
@@ -1,41 +1,70 @@
 package com.marketinghub.pipelines.aiworker.geracaoanuncios.v1.imagem.service;
 
-import com.marketinghub.pipelines.aiworker.geracaoanuncios.v1.imagem.service.detailStageExecution.GeraAnuncioImagemDetailResponse;
-import com.marketinghub.pipelines.aiworker.geracaoanuncios.v1.imagem.service.listStageExecutions.GeraAnuncioImagemExecutionSummaryResponse;
-import com.marketinghub.pipelines.aiworker.geracaoanuncios.v1.imagem.service.pending.GeraAnuncioImagemPendingResponse;
-import com.marketinghub.pipelines.aiworker.geracaoanuncios.v1.imagem.service.recebePrompt.GeraAnuncioImagemPromptRequest;
-import com.marketinghub.pipelines.aiworker.geracaoanuncios.v1.imagem.service.recebeResposta.GeraAnuncioImagemRespostaRequest;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marketinghub.experiment.CreativeGenerationMode;
 import com.marketinghub.experiment.Experiment;
 import com.marketinghub.experiment.service.ExperimentService;
 import com.marketinghub.oprm.cnae.OprmNicheCandidate;
+import com.marketinghub.pipeline.geracaoanuncios.PipelineGeracaoAnuncios;
+import com.marketinghub.pipelines.aiworker.geracaoanuncios.v1.imagem.service.detailStageExecution.GeraAnuncioImagemDetailResponse;
+import com.marketinghub.pipelines.aiworker.geracaoanuncios.v1.imagem.service.listStageExecutions.GeraAnuncioImagemExecutionSummaryResponse;
+import com.marketinghub.pipelines.aiworker.geracaoanuncios.v1.imagem.service.pending.GeraAnuncioImagemPendingResponse;
+import com.marketinghub.pipelines.aiworker.geracaoanuncios.v1.imagem.service.recebePrompt.GeraAnuncioImagemPromptRequest;
+import com.marketinghub.pipelines.aiworker.geracaoanuncios.v1.imagem.service.recebeRequest.GeraAnuncioImagemRecebeRequestRequest;
+import com.marketinghub.pipelines.aiworker.geracaoanuncios.v1.imagem.service.recebeResposta.GeraAnuncioImagemRespostaRequest;
+import com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1.MoisSalesPageRepository;
+import com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1.entity.MoisSalesPage;
 import com.marketinghub.repository.jpa.oprm.cnae.OprmNicheCandidateRepository;
+import com.marketinghub.repository.jpa.pipeline.geracaoanuncios.PipelineGeracaoAnunciosRepository;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.time.Instant;
+import java.util.HexFormat;
 import java.util.List;
 import java.util.Map;
-import org.springframework.data.domain.PageRequest;
 import java.util.Objects;
+import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 import org.springframework.web.server.ResponseStatusException;
 
 /** Responsabilidade: expor contratos de leitura, escrita e auditoria da etapa Imagem do pipeline GeraAnuncio v2. */
 @Service
 public class GeraAnuncioImagemService {
+    private static final Logger log = LoggerFactory.getLogger(GeraAnuncioImagemService.class);
     private static final String STAGE_CODE = "imagem";
     private static final String NEXT_STAGE = "fim";
     private static final String STATUS_STARTED = "INICIADO";
     private static final String STATUS_WAITING = "AGUARDANDO_RETORNO_MODULO";
+    private static final String STATUS_AGUARDANDO_MODULO = "AGUARDANDO_MODULO";
+    private static final String PIPELINE_VERSION = "v1";
     private static final String STATUS_COMPLETED = "CONCLUIDO";
     private static final String STATUS_FAILED = "FALHA";
     private final ExperimentService experimentService;
     private final OprmNicheCandidateRepository cnaeRepository;
+    private final MoisSalesPageRepository salesPageRepository;
+    private final PipelineGeracaoAnunciosRepository pipelineRepository;
+    private final ObjectMapper objectMapper;
 
-    /** Inicializa o service com o repositório canônico de candidatos CNAE. */
-    public GeraAnuncioImagemService(ExperimentService experimentService, OprmNicheCandidateRepository cnaeRepository) {
+    /** Inicializa o service com os repositórios canônicos de controle e auditoria. */
+    public GeraAnuncioImagemService(
+            ExperimentService experimentService,
+            OprmNicheCandidateRepository cnaeRepository,
+            MoisSalesPageRepository salesPageRepository,
+            PipelineGeracaoAnunciosRepository pipelineRepository,
+            ObjectMapper objectMapper) {
         this.experimentService = experimentService;
         this.cnaeRepository = cnaeRepository;
+        this.salesPageRepository = salesPageRepository;
+        this.pipelineRepository = pipelineRepository;
+        this.objectMapper = objectMapper;
     }
 
     /** Inicia uma solicitação da etapa Imagem usando o código/chave operacional do experimento. */
@@ -72,6 +101,33 @@ public class GeraAnuncioImagemService {
                 .stream()
                 .map(this::toPending)
                 .toList();
+    }
+
+    /** Recebe e audita o request operacional enviado para a etapa Imagem. */
+    @Transactional
+    public void recebeRequest(String experimentKey, GeraAnuncioImagemRecebeRequestRequest request) {
+        if (request == null) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "payload required");
+        }
+        Instant now = Instant.now();
+        MoisSalesPage salesPage = salesPageRepository
+                .findById(resolveExperimentId(experimentKey))
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Sales page not found"));
+        salesPage.setStatusPipelineGeracaoAnuncios(STATUS_AGUARDANDO_MODULO);
+        salesPage.setDataPipelineGeracaoAnuncios(now);
+        salesPageRepository.save(salesPage);
+
+        PipelineGeracaoAnuncios pipeline = new PipelineGeracaoAnuncios();
+        pipeline.setIdExterno(experimentKey);
+        pipeline.setRequest(serializeRequest(request.request()));
+        pipeline.setCodigoEtapa(STAGE_CODE);
+        pipeline.setDataHora(now);
+        pipeline.setJobId(createJobHash(experimentKey, now));
+        pipeline.setPlataforma(request.plataforma());
+        pipeline.setPrompt(request.prompt());
+        pipeline.setSchema(request.schema());
+        pipeline.setVersaoPipeline(PIPELINE_VERSION);
+        pipelineRepository.save(pipeline);
     }
 
     /** Registra o prompt enviado ao modelo para auditoria da etapa. */
@@ -158,6 +214,35 @@ public class GeraAnuncioImagemService {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "experimentKey must be the numeric experiment id");
         }
         return Long.valueOf(normalizedExperimentKey);
+    }
+
+    /** Serializa o request recebido preservando payload estruturado quando existir. */
+    private String serializeRequest(Object request) {
+        if (request == null) {
+            return null;
+        }
+        if (request instanceof String requestText) {
+            return requestText;
+        }
+        try {
+            return objectMapper.writeValueAsString(request);
+        } catch (JsonProcessingException ex) {
+            log.warn("Falha ao serializar request do pipeline geracaoanuncios; etapa={}", STAGE_CODE, ex);
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "request payload invalid", ex);
+        }
+    }
+
+    /** Cria um hash único para rastrear o job recebido nesta chamada. */
+    private String createJobHash(String experimentKey, Instant now) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hash = digest.digest((experimentKey + "|" + STAGE_CODE + "|" + now + "|" + UUID.randomUUID())
+                    .getBytes(StandardCharsets.UTF_8));
+            return HexFormat.of().formatHex(hash);
+        } catch (NoSuchAlgorithmException ex) {
+            log.error("Falha ao gerar hash jobId do pipeline geracaoanuncios; etapa={}, experimentKey={}", STAGE_CODE, experimentKey, ex);
+            throw new IllegalStateException("SHA-256 indisponível para gerar jobId", ex);
+        }
     }
 
     /** Gera identificador determinístico da execução da etapa a partir do experimento. */

--- a/backend/ads-service/src/main/java/com/marketinghub/pipelines/aiworker/geracaoanuncios/v1/imagem/service/recebeRequest/GeraAnuncioImagemRecebeRequestRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/pipelines/aiworker/geracaoanuncios/v1/imagem/service/recebeRequest/GeraAnuncioImagemRecebeRequestRequest.java
@@ -1,0 +1,4 @@
+package com.marketinghub.pipelines.aiworker.geracaoanuncios.v1.imagem.service.recebeRequest;
+
+/** Contrato que recebe o request operacional montado pelo AI Worker para a etapa Imagem. */
+public record GeraAnuncioImagemRecebeRequestRequest(Object request, String plataforma, String prompt, String schema) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/pipelines/aiworker/geracaoanuncios/v1/texto/controller/GeraAnuncioTextoController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/pipelines/aiworker/geracaoanuncios/v1/texto/controller/GeraAnuncioTextoController.java
@@ -5,6 +5,7 @@ import com.marketinghub.pipelines.aiworker.geracaoanuncios.v1.texto.service.deta
 import com.marketinghub.pipelines.aiworker.geracaoanuncios.v1.texto.service.listStageExecutions.GeraAnuncioTextoExecutionSummaryResponse;
 import com.marketinghub.pipelines.aiworker.geracaoanuncios.v1.texto.service.pending.GeraAnuncioTextoPendingResponse;
 import com.marketinghub.pipelines.aiworker.geracaoanuncios.v1.texto.service.recebePrompt.GeraAnuncioTextoPromptRequest;
+import com.marketinghub.pipelines.aiworker.geracaoanuncios.v1.texto.service.recebeRequest.GeraAnuncioTextoRecebeRequestRequest;
 import com.marketinghub.pipelines.aiworker.geracaoanuncios.v1.texto.service.recebeResposta.GeraAnuncioTextoRespostaRequest;
 import java.util.List;
 import org.springframework.http.ResponseEntity;
@@ -49,6 +50,14 @@ public class GeraAnuncioTextoController {
     @PostMapping("/pending")
     public List<GeraAnuncioTextoPendingResponse> pending() {
         return service.pending();
+    }
+
+    /** Recebe o request operacional gerado pelo AI Worker para a etapa. */
+    @PostMapping("/{experimentKey}/recebeRequest")
+    public ResponseEntity<Void> recebeRequest(
+            @PathVariable String experimentKey, @RequestBody GeraAnuncioTextoRecebeRequestRequest request) {
+        service.recebeRequest(experimentKey, request);
+        return ResponseEntity.accepted().build();
     }
 
     /** Recebe o prompt operacional enviado ao modelo pelo AI Worker. */

--- a/backend/ads-service/src/main/java/com/marketinghub/pipelines/aiworker/geracaoanuncios/v1/texto/service/GeraAnuncioTextoService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/pipelines/aiworker/geracaoanuncios/v1/texto/service/GeraAnuncioTextoService.java
@@ -1,41 +1,70 @@
 package com.marketinghub.pipelines.aiworker.geracaoanuncios.v1.texto.service;
 
-import com.marketinghub.pipelines.aiworker.geracaoanuncios.v1.texto.service.detailStageExecution.GeraAnuncioTextoDetailResponse;
-import com.marketinghub.pipelines.aiworker.geracaoanuncios.v1.texto.service.listStageExecutions.GeraAnuncioTextoExecutionSummaryResponse;
-import com.marketinghub.pipelines.aiworker.geracaoanuncios.v1.texto.service.pending.GeraAnuncioTextoPendingResponse;
-import com.marketinghub.pipelines.aiworker.geracaoanuncios.v1.texto.service.recebePrompt.GeraAnuncioTextoPromptRequest;
-import com.marketinghub.pipelines.aiworker.geracaoanuncios.v1.texto.service.recebeResposta.GeraAnuncioTextoRespostaRequest;
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
 import com.marketinghub.experiment.CreativeGenerationMode;
 import com.marketinghub.experiment.Experiment;
 import com.marketinghub.experiment.service.ExperimentService;
 import com.marketinghub.oprm.cnae.OprmNicheCandidate;
+import com.marketinghub.pipeline.geracaoanuncios.PipelineGeracaoAnuncios;
+import com.marketinghub.pipelines.aiworker.geracaoanuncios.v1.texto.service.detailStageExecution.GeraAnuncioTextoDetailResponse;
+import com.marketinghub.pipelines.aiworker.geracaoanuncios.v1.texto.service.listStageExecutions.GeraAnuncioTextoExecutionSummaryResponse;
+import com.marketinghub.pipelines.aiworker.geracaoanuncios.v1.texto.service.pending.GeraAnuncioTextoPendingResponse;
+import com.marketinghub.pipelines.aiworker.geracaoanuncios.v1.texto.service.recebePrompt.GeraAnuncioTextoPromptRequest;
+import com.marketinghub.pipelines.aiworker.geracaoanuncios.v1.texto.service.recebeRequest.GeraAnuncioTextoRecebeRequestRequest;
+import com.marketinghub.pipelines.aiworker.geracaoanuncios.v1.texto.service.recebeResposta.GeraAnuncioTextoRespostaRequest;
+import com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1.MoisSalesPageRepository;
+import com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1.entity.MoisSalesPage;
 import com.marketinghub.repository.jpa.oprm.cnae.OprmNicheCandidateRepository;
+import com.marketinghub.repository.jpa.pipeline.geracaoanuncios.PipelineGeracaoAnunciosRepository;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.time.Instant;
+import java.util.HexFormat;
 import java.util.List;
 import java.util.Map;
-import org.springframework.data.domain.PageRequest;
 import java.util.Objects;
+import java.util.UUID;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 import org.springframework.web.server.ResponseStatusException;
 
 /** Responsabilidade: expor contratos de leitura, escrita e auditoria da etapa Texto do pipeline GeraAnuncio v2. */
 @Service
 public class GeraAnuncioTextoService {
+    private static final Logger log = LoggerFactory.getLogger(GeraAnuncioTextoService.class);
     private static final String STAGE_CODE = "texto";
     private static final String NEXT_STAGE = "imagem";
     private static final String STATUS_STARTED = "INICIADO";
     private static final String STATUS_WAITING = "AGUARDANDO_RETORNO_MODULO";
+    private static final String STATUS_AGUARDANDO_MODULO = "AGUARDANDO_MODULO";
+    private static final String PIPELINE_VERSION = "v1";
     private static final String STATUS_COMPLETED = "CONCLUIDO";
     private static final String STATUS_FAILED = "FALHA";
     private final ExperimentService experimentService;
     private final OprmNicheCandidateRepository cnaeRepository;
+    private final MoisSalesPageRepository salesPageRepository;
+    private final PipelineGeracaoAnunciosRepository pipelineRepository;
+    private final ObjectMapper objectMapper;
 
-    /** Inicializa o service com o repositório canônico de candidatos CNAE. */
-    public GeraAnuncioTextoService(ExperimentService experimentService, OprmNicheCandidateRepository cnaeRepository) {
+    /** Inicializa o service com os repositórios canônicos de controle e auditoria. */
+    public GeraAnuncioTextoService(
+            ExperimentService experimentService,
+            OprmNicheCandidateRepository cnaeRepository,
+            MoisSalesPageRepository salesPageRepository,
+            PipelineGeracaoAnunciosRepository pipelineRepository,
+            ObjectMapper objectMapper) {
         this.experimentService = experimentService;
         this.cnaeRepository = cnaeRepository;
+        this.salesPageRepository = salesPageRepository;
+        this.pipelineRepository = pipelineRepository;
+        this.objectMapper = objectMapper;
     }
 
     /** Inicia uma solicitação da etapa Texto usando o código/chave operacional do experimento. */
@@ -72,6 +101,33 @@ public class GeraAnuncioTextoService {
                 .stream()
                 .map(this::toPending)
                 .toList();
+    }
+
+    /** Recebe e audita o request operacional enviado para a etapa Texto. */
+    @Transactional
+    public void recebeRequest(String experimentKey, GeraAnuncioTextoRecebeRequestRequest request) {
+        if (request == null) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "payload required");
+        }
+        Instant now = Instant.now();
+        MoisSalesPage salesPage = salesPageRepository
+                .findById(resolveExperimentId(experimentKey))
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Sales page not found"));
+        salesPage.setStatusPipelineGeracaoAnuncios(STATUS_AGUARDANDO_MODULO);
+        salesPage.setDataPipelineGeracaoAnuncios(now);
+        salesPageRepository.save(salesPage);
+
+        PipelineGeracaoAnuncios pipeline = new PipelineGeracaoAnuncios();
+        pipeline.setIdExterno(experimentKey);
+        pipeline.setRequest(serializeRequest(request.request()));
+        pipeline.setCodigoEtapa(STAGE_CODE);
+        pipeline.setDataHora(now);
+        pipeline.setJobId(createJobHash(experimentKey, now));
+        pipeline.setPlataforma(request.plataforma());
+        pipeline.setPrompt(request.prompt());
+        pipeline.setSchema(request.schema());
+        pipeline.setVersaoPipeline(PIPELINE_VERSION);
+        pipelineRepository.save(pipeline);
     }
 
     /** Registra o prompt enviado ao modelo para auditoria da etapa. */
@@ -158,6 +214,35 @@ public class GeraAnuncioTextoService {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "experimentKey must be the numeric experiment id");
         }
         return Long.valueOf(normalizedExperimentKey);
+    }
+
+    /** Serializa o request recebido preservando payload estruturado quando existir. */
+    private String serializeRequest(Object request) {
+        if (request == null) {
+            return null;
+        }
+        if (request instanceof String requestText) {
+            return requestText;
+        }
+        try {
+            return objectMapper.writeValueAsString(request);
+        } catch (JsonProcessingException ex) {
+            log.warn("Falha ao serializar request do pipeline geracaoanuncios; etapa={}", STAGE_CODE, ex);
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "request payload invalid", ex);
+        }
+    }
+
+    /** Cria um hash único para rastrear o job recebido nesta chamada. */
+    private String createJobHash(String experimentKey, Instant now) {
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hash = digest.digest((experimentKey + "|" + STAGE_CODE + "|" + now + "|" + UUID.randomUUID())
+                    .getBytes(StandardCharsets.UTF_8));
+            return HexFormat.of().formatHex(hash);
+        } catch (NoSuchAlgorithmException ex) {
+            log.error("Falha ao gerar hash jobId do pipeline geracaoanuncios; etapa={}, experimentKey={}", STAGE_CODE, experimentKey, ex);
+            throw new IllegalStateException("SHA-256 indisponível para gerar jobId", ex);
+        }
     }
 
     /** Gera identificador determinístico da execução da etapa a partir do experimento. */

--- a/backend/ads-service/src/main/java/com/marketinghub/pipelines/aiworker/geracaoanuncios/v1/texto/service/recebeRequest/GeraAnuncioTextoRecebeRequestRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/pipelines/aiworker/geracaoanuncios/v1/texto/service/recebeRequest/GeraAnuncioTextoRecebeRequestRequest.java
@@ -1,0 +1,4 @@
+package com.marketinghub.pipelines.aiworker.geracaoanuncios.v1.texto.service.recebeRequest;
+
+/** Contrato que recebe o request operacional montado pelo AI Worker para a etapa Texto. */
+public record GeraAnuncioTextoRecebeRequestRequest(Object request, String plataforma, String prompt, String schema) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/mois/bibliotecapaginavenda/worker/v1/entity/MoisSalesPage.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/mois/bibliotecapaginavenda/worker/v1/entity/MoisSalesPage.java
@@ -28,4 +28,10 @@ public class MoisSalesPage {
 
     @Column(name = "dossie_produto_updated_at")
     private Instant dossieProdutoUpdatedAt;
+
+    @Column(name = "status_pipeline_geracaoanuncios", length = 40)
+    private String statusPipelineGeracaoAnuncios;
+
+    @Column(name = "data_pipeline_geracaoanuncios")
+    private Instant dataPipelineGeracaoAnuncios;
 }

--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-26-mois-sales-page-geracaoanuncios-pipeline.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-26-mois-sales-page-geracaoanuncios-pipeline.yaml
@@ -1,0 +1,34 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-06-26-mois-sales-page-geracaoanuncios-pipeline-01
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - onError: HALT
+        - dbms:
+            type: mysql
+        - tableExists:
+            tableName: mois_sales_page
+        - not:
+            columnExists:
+              tableName: mois_sales_page
+              columnName: status_pipeline_geracaoanuncios
+      changes:
+        - sql:
+            splitStatements: true
+            stripComments: true
+            sql: |
+              ALTER TABLE mois_sales_page
+                ADD COLUMN status_pipeline_geracaoanuncios VARCHAR(40) NULL AFTER dossie_produto_updated_at,
+                ADD COLUMN data_pipeline_geracaoanuncios DATETIME(6) NULL AFTER status_pipeline_geracaoanuncios;
+              CREATE INDEX idx_mois_sales_page_geracaoanuncios_pipeline
+                ON mois_sales_page (status_pipeline_geracaoanuncios, data_pipeline_geracaoanuncios);
+      rollback:
+        - sql:
+            splitStatements: true
+            stripComments: true
+            sql: |
+              DROP INDEX idx_mois_sales_page_geracaoanuncios_pipeline ON mois_sales_page;
+              ALTER TABLE mois_sales_page
+                DROP COLUMN data_pipeline_geracaoanuncios,
+                DROP COLUMN status_pipeline_geracaoanuncios;

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -1151,3 +1151,8 @@ databaseChangeLog:
   - include:
       file: changesets/2026-06-26-pipeline-geracaoanuncios.yaml
       relativeToChangelogFile: true
+
+
+  - include:
+      file: changesets/2026-06-26-mois-sales-page-geracaoanuncios-pipeline.yaml
+      relativeToChangelogFile: true


### PR DESCRIPTION
### Motivation
- Atender à necessidade operacional do AI Worker de enviar um `request` fechado para as etapas `texto` e `imagem` do pipeline `aiworker.geracaoanuncios.v1` usando o identificador único do experimento/página na URL. 
- Persistir auditoria do request e colocar a página/produto MOIS em estado de espera para que o backend tenha rastreabilidade e controle do avanço do pipeline.

### Description
- Adiciona endpoints `POST /api/internal/aiworker/geracaoanuncios/v1/texto/stage-executions/{experimentKey}/recebeRequest` e `POST /api/internal/aiworker/geracaoanuncios/v1/imagem/stage-executions/{experimentKey}/recebeRequest` que retornam `202 Accepted` e delegam para `recebeRequest` no service. 
- Implementa `recebeRequest` em `GeraAnuncioTextoService` e `GeraAnuncioImagemService` que atualizam `mois_sales_page` definindo `status_pipeline_geracaoanuncios = 'AGUARDANDO_MODULO'` e `data_pipeline_geracaoanuncios = Instant.now()`, e salvam um registro em `pipeline_geracaoanuncios` com `id_externo`, `request`, `codigo_etapa`, `data_hora`, `job_id` (hash gerado na chamada), `plataforma`, `prompt`, `schema` e `versao_pipeline = 'v1'`. 
- Adiciona DTOs/`record` para o payload recebido em `recebeRequest` nas duas etapas (`GeraAnuncioTextoRecebeRequestRequest` e `GeraAnuncioImagemRecebeRequestRequest`), helpers `serializeRequest` e `createJobHash`, injeção de `ObjectMapper`, e marcadores de transação/logs apropriados. 
- Cria changelog Liquibase `2026-06-26-mois-sales-page-geracaoanuncios-pipeline.yaml` e mapeamento JPA para as colunas `status_pipeline_geracaoanuncios` e `data_pipeline_geracaoanuncios` na entidade `MoisSalesPage` para suportar o controle de estado.

### Testing
- Executado `../mvnw -DskipTests compile` no módulo `backend/ads-service` e a compilação foi bem-sucedida. 
- Executado `git diff --check` e não foram encontradas quebras de sintaxe no diff. 
- Executado `../mvnw test` (suite completa); a execução compilou e muitos testes passaram, porém a execução apresentou uma falha existente e não relacionada em `PipelineServiceTest.shouldMatchOprmNichoCnaeOpenAiFlagsWithCollectorCode` causada pela ausência do pacote esperado no módulo `oprm-coletor-mei`, portanto a suíte completa não foi considerada verde nesta execução.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3ef30ed3c883219abca6d62cb05e2f)