### PR TITLE
Implementa /recebeRequest e auditoria em pipeline_nichocnae para NichoCNAE v3

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/cnaeintake/controller/BackendCnaeIntakeController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/cnaeintake/controller/BackendCnaeIntakeController.java
@@ -5,6 +5,7 @@ import com.marketinghub.oprmcoletormei.nichocnae.v3.cnaeintake.service.completeS
 import com.marketinghub.oprmcoletormei.nichocnae.v3.cnaeintake.service.createStageExecution.CnaeIntakeCreateResponse;
 import com.marketinghub.oprmcoletormei.nichocnae.v3.cnaeintake.service.failStageExecution.CnaeIntakeFailureRequest;
 import com.marketinghub.oprmcoletormei.nichocnae.v3.cnaeintake.service.pending.CnaeIntakePendingResponse;
+import com.marketinghub.oprmcoletormei.nichocnae.v3.shared.OprmNichoCnaeV3RecebeRequestRequest;
 import java.util.List;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -41,6 +42,12 @@ public class BackendCnaeIntakeController {
     @PostMapping("/cnaes/{cnaeCode}")
     public CnaeIntakeCreateResponse createForCnae(@PathVariable String cnaeCode) {
         return service.create(null, cnaeCode, "{\"cnaeCode\":\"" + cnaeCode + "\"}", 1, 1);
+    }
+
+    /** Recebe o request bruto da etapa identificado pelo CNAE. */
+    @PostMapping("/cnaes/{cnaeCode}/recebeRequest")
+    public CnaeIntakeCreateResponse recebeRequest(@PathVariable String cnaeCode, @RequestBody OprmNichoCnaeV3RecebeRequestRequest request) {
+        return service.recebeRequest(cnaeCode, request);
     }
 
     /** Entrega pendências da etapa cnae-intake ao executor OPRM. */

--- a/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/cnaeintake/service/BackendCnaeIntakeService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/cnaeintake/service/BackendCnaeIntakeService.java
@@ -5,7 +5,9 @@ import com.marketinghub.oprm.market.OprmCnpjCnaeDim;
 import com.marketinghub.oprmcoletormei.nichocnae.v3.cnaeintake.service.createStageExecution.CnaeIntakeCreateResponse;
 import com.marketinghub.oprmcoletormei.nichocnae.v3.cnaeintake.service.pending.CnaeIntakePendingResponse;
 import com.marketinghub.oprmcoletormei.nichocnae.v3.shared.OprmNichoCnaeV3StageServiceSupport;
+import com.marketinghub.oprmcoletormei.nichocnae.v3.shared.OprmNichoCnaeV3RecebeRequestRequest;
 import com.marketinghub.repository.jpa.oprm.market.OprmCnpjCnaeDimRepository;
+import com.marketinghub.repository.jpa.oprm.nichocnae.PipelineNichoCnaeRepository;
 import com.marketinghub.repository.jpa.oprm.nichocnae.v3.OprmNichoCnaeV3StageExecutionRepository;
 import java.util.List;
 import org.springframework.stereotype.Service;
@@ -20,8 +22,8 @@ public class BackendCnaeIntakeService extends OprmNichoCnaeV3StageServiceSupport
     private static final String STATUS_FAILED = "FALHA";
 
     /** Inicializa o service com repository canônico de execuções v3. */
-    public BackendCnaeIntakeService(OprmNichoCnaeV3StageExecutionRepository repository, OprmCnpjCnaeDimRepository cnaeRepository) {
-        super(repository, cnaeRepository, STAGE_CODE);
+    public BackendCnaeIntakeService(OprmNichoCnaeV3StageExecutionRepository repository, OprmCnpjCnaeDimRepository cnaeRepository, PipelineNichoCnaeRepository pipelineNichoCnaeRepository) {
+        super(repository, cnaeRepository, pipelineNichoCnaeRepository, STAGE_CODE);
     }
 
     /** Cria pendência inicial ou encadeada para a etapa cnae-intake. */
@@ -33,6 +35,11 @@ public class BackendCnaeIntakeService extends OprmNichoCnaeV3StageServiceSupport
     public CnaeIntakeCreateResponse start(String cnaeCode) {
         markCnaePipelineStarted(cnaeCode, STATUS_STARTED);
         return create(null, cnaeCode, "{\"cnaeCode\":\"" + cnaeCode + "\"}", 1, 1);
+    }
+
+    /** Recebe o request bruto da etapa e registra auditoria para o pipeline NichoCNAE v3. */
+    public CnaeIntakeCreateResponse recebeRequest(String cnaeCode, OprmNichoCnaeV3RecebeRequestRequest request) {
+        return new CnaeIntakeCreateResponse(null, doRecebeRequest(cnaeCode, request).getJobId(), cnaeCode, STAGE_CODE, "AGUARDANDO_MODULO");
     }
 
     /** Lista pendências da etapa cnae-intake para o executor OPRM. */

--- a/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/dailytaskssynthesizer/controller/BackendDailyTasksSynthesizerController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/dailytaskssynthesizer/controller/BackendDailyTasksSynthesizerController.java
@@ -5,6 +5,7 @@ import com.marketinghub.oprmcoletormei.nichocnae.v3.dailytaskssynthesizer.servic
 import com.marketinghub.oprmcoletormei.nichocnae.v3.dailytaskssynthesizer.service.createStageExecution.DailyTasksSynthesizerCreateResponse;
 import com.marketinghub.oprmcoletormei.nichocnae.v3.dailytaskssynthesizer.service.failStageExecution.DailyTasksSynthesizerFailureRequest;
 import com.marketinghub.oprmcoletormei.nichocnae.v3.dailytaskssynthesizer.service.pending.DailyTasksSynthesizerPendingResponse;
+import com.marketinghub.oprmcoletormei.nichocnae.v3.shared.OprmNichoCnaeV3RecebeRequestRequest;
 import java.util.List;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -41,6 +42,12 @@ public class BackendDailyTasksSynthesizerController {
     @PostMapping("/cnaes/{cnaeCode}")
     public DailyTasksSynthesizerCreateResponse createForCnae(@PathVariable String cnaeCode) {
         return service.create(null, cnaeCode, "{\"cnaeCode\":\"" + cnaeCode + "\"}", 1, 1);
+    }
+
+    /** Recebe o request bruto da etapa identificado pelo CNAE. */
+    @PostMapping("/cnaes/{cnaeCode}/recebeRequest")
+    public DailyTasksSynthesizerCreateResponse recebeRequest(@PathVariable String cnaeCode, @RequestBody OprmNichoCnaeV3RecebeRequestRequest request) {
+        return service.recebeRequest(cnaeCode, request);
     }
 
     /** Entrega pendências da etapa daily-tasks-synthesizer ao executor OPRM. */

--- a/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/dailytaskssynthesizer/service/BackendDailyTasksSynthesizerService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/dailytaskssynthesizer/service/BackendDailyTasksSynthesizerService.java
@@ -5,7 +5,9 @@ import com.marketinghub.oprm.market.OprmCnpjCnaeDim;
 import com.marketinghub.oprmcoletormei.nichocnae.v3.dailytaskssynthesizer.service.createStageExecution.DailyTasksSynthesizerCreateResponse;
 import com.marketinghub.oprmcoletormei.nichocnae.v3.dailytaskssynthesizer.service.pending.DailyTasksSynthesizerPendingResponse;
 import com.marketinghub.oprmcoletormei.nichocnae.v3.shared.OprmNichoCnaeV3StageServiceSupport;
+import com.marketinghub.oprmcoletormei.nichocnae.v3.shared.OprmNichoCnaeV3RecebeRequestRequest;
 import com.marketinghub.repository.jpa.oprm.market.OprmCnpjCnaeDimRepository;
+import com.marketinghub.repository.jpa.oprm.nichocnae.PipelineNichoCnaeRepository;
 import com.marketinghub.repository.jpa.oprm.nichocnae.v3.OprmNichoCnaeV3StageExecutionRepository;
 import java.util.List;
 import org.springframework.stereotype.Service;
@@ -20,8 +22,8 @@ public class BackendDailyTasksSynthesizerService extends OprmNichoCnaeV3StageSer
     private static final String STATUS_FAILED = "FALHA";
 
     /** Inicializa o service com repository canônico de execuções v3. */
-    public BackendDailyTasksSynthesizerService(OprmNichoCnaeV3StageExecutionRepository repository, OprmCnpjCnaeDimRepository cnaeRepository) {
-        super(repository, cnaeRepository, STAGE_CODE);
+    public BackendDailyTasksSynthesizerService(OprmNichoCnaeV3StageExecutionRepository repository, OprmCnpjCnaeDimRepository cnaeRepository, PipelineNichoCnaeRepository pipelineNichoCnaeRepository) {
+        super(repository, cnaeRepository, pipelineNichoCnaeRepository, STAGE_CODE);
     }
 
     /** Cria pendência inicial ou encadeada para a etapa daily-tasks-synthesizer. */
@@ -33,6 +35,11 @@ public class BackendDailyTasksSynthesizerService extends OprmNichoCnaeV3StageSer
     public DailyTasksSynthesizerCreateResponse start(String cnaeCode) {
         markCnaePipelineStarted(cnaeCode, STATUS_STARTED);
         return create(null, cnaeCode, "{\"cnaeCode\":\"" + cnaeCode + "\"}", 1, 1);
+    }
+
+    /** Recebe o request bruto da etapa e registra auditoria para o pipeline NichoCNAE v3. */
+    public DailyTasksSynthesizerCreateResponse recebeRequest(String cnaeCode, OprmNichoCnaeV3RecebeRequestRequest request) {
+        return new DailyTasksSynthesizerCreateResponse(null, doRecebeRequest(cnaeCode, request).getJobId(), cnaeCode, STAGE_CODE, "AGUARDANDO_MODULO");
     }
 
     /** Lista pendências da etapa daily-tasks-synthesizer para o executor OPRM. */

--- a/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/personacandidategenerator/controller/BackendPersonaCandidateGeneratorController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/personacandidategenerator/controller/BackendPersonaCandidateGeneratorController.java
@@ -5,6 +5,7 @@ import com.marketinghub.oprmcoletormei.nichocnae.v3.personacandidategenerator.se
 import com.marketinghub.oprmcoletormei.nichocnae.v3.personacandidategenerator.service.createStageExecution.PersonaCandidateGeneratorCreateResponse;
 import com.marketinghub.oprmcoletormei.nichocnae.v3.personacandidategenerator.service.failStageExecution.PersonaCandidateGeneratorFailureRequest;
 import com.marketinghub.oprmcoletormei.nichocnae.v3.personacandidategenerator.service.pending.PersonaCandidateGeneratorPendingResponse;
+import com.marketinghub.oprmcoletormei.nichocnae.v3.shared.OprmNichoCnaeV3RecebeRequestRequest;
 import java.util.List;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -41,6 +42,12 @@ public class BackendPersonaCandidateGeneratorController {
     @PostMapping("/cnaes/{cnaeCode}")
     public PersonaCandidateGeneratorCreateResponse createForCnae(@PathVariable String cnaeCode) {
         return service.create(null, cnaeCode, "{\"cnaeCode\":\"" + cnaeCode + "\"}", 1, 1);
+    }
+
+    /** Recebe o request bruto da etapa identificado pelo CNAE. */
+    @PostMapping("/cnaes/{cnaeCode}/recebeRequest")
+    public PersonaCandidateGeneratorCreateResponse recebeRequest(@PathVariable String cnaeCode, @RequestBody OprmNichoCnaeV3RecebeRequestRequest request) {
+        return service.recebeRequest(cnaeCode, request);
     }
 
     /** Entrega pendências da etapa persona-candidate-generator ao executor OPRM. */

--- a/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/personacandidategenerator/service/BackendPersonaCandidateGeneratorService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/personacandidategenerator/service/BackendPersonaCandidateGeneratorService.java
@@ -5,7 +5,9 @@ import com.marketinghub.oprm.market.OprmCnpjCnaeDim;
 import com.marketinghub.oprmcoletormei.nichocnae.v3.personacandidategenerator.service.createStageExecution.PersonaCandidateGeneratorCreateResponse;
 import com.marketinghub.oprmcoletormei.nichocnae.v3.personacandidategenerator.service.pending.PersonaCandidateGeneratorPendingResponse;
 import com.marketinghub.oprmcoletormei.nichocnae.v3.shared.OprmNichoCnaeV3StageServiceSupport;
+import com.marketinghub.oprmcoletormei.nichocnae.v3.shared.OprmNichoCnaeV3RecebeRequestRequest;
 import com.marketinghub.repository.jpa.oprm.market.OprmCnpjCnaeDimRepository;
+import com.marketinghub.repository.jpa.oprm.nichocnae.PipelineNichoCnaeRepository;
 import com.marketinghub.repository.jpa.oprm.nichocnae.v3.OprmNichoCnaeV3StageExecutionRepository;
 import java.util.List;
 import org.springframework.stereotype.Service;
@@ -20,8 +22,8 @@ public class BackendPersonaCandidateGeneratorService extends OprmNichoCnaeV3Stag
     private static final String STATUS_FAILED = "FALHA";
 
     /** Inicializa o service com repository canônico de execuções v3. */
-    public BackendPersonaCandidateGeneratorService(OprmNichoCnaeV3StageExecutionRepository repository, OprmCnpjCnaeDimRepository cnaeRepository) {
-        super(repository, cnaeRepository, STAGE_CODE);
+    public BackendPersonaCandidateGeneratorService(OprmNichoCnaeV3StageExecutionRepository repository, OprmCnpjCnaeDimRepository cnaeRepository, PipelineNichoCnaeRepository pipelineNichoCnaeRepository) {
+        super(repository, cnaeRepository, pipelineNichoCnaeRepository, STAGE_CODE);
     }
 
     /** Cria pendência inicial ou encadeada para a etapa persona-candidate-generator. */
@@ -33,6 +35,11 @@ public class BackendPersonaCandidateGeneratorService extends OprmNichoCnaeV3Stag
     public PersonaCandidateGeneratorCreateResponse start(String cnaeCode) {
         markCnaePipelineStarted(cnaeCode, STATUS_STARTED);
         return create(null, cnaeCode, "{\"cnaeCode\":\"" + cnaeCode + "\"}", 1, 1);
+    }
+
+    /** Recebe o request bruto da etapa e registra auditoria para o pipeline NichoCNAE v3. */
+    public PersonaCandidateGeneratorCreateResponse recebeRequest(String cnaeCode, OprmNichoCnaeV3RecebeRequestRequest request) {
+        return new PersonaCandidateGeneratorCreateResponse(null, doRecebeRequest(cnaeCode, request).getJobId(), cnaeCode, STAGE_CODE, "AGUARDANDO_MODULO");
     }
 
     /** Lista pendências da etapa persona-candidate-generator para o executor OPRM. */

--- a/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/personaroutinematerializer/controller/BackendPersonaRoutineMaterializerController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/personaroutinematerializer/controller/BackendPersonaRoutineMaterializerController.java
@@ -5,6 +5,7 @@ import com.marketinghub.oprmcoletormei.nichocnae.v3.personaroutinematerializer.s
 import com.marketinghub.oprmcoletormei.nichocnae.v3.personaroutinematerializer.service.createStageExecution.PersonaRoutineMaterializerCreateResponse;
 import com.marketinghub.oprmcoletormei.nichocnae.v3.personaroutinematerializer.service.failStageExecution.PersonaRoutineMaterializerFailureRequest;
 import com.marketinghub.oprmcoletormei.nichocnae.v3.personaroutinematerializer.service.pending.PersonaRoutineMaterializerPendingResponse;
+import com.marketinghub.oprmcoletormei.nichocnae.v3.shared.OprmNichoCnaeV3RecebeRequestRequest;
 import java.util.List;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -41,6 +42,12 @@ public class BackendPersonaRoutineMaterializerController {
     @PostMapping("/cnaes/{cnaeCode}")
     public PersonaRoutineMaterializerCreateResponse createForCnae(@PathVariable String cnaeCode) {
         return service.create(null, cnaeCode, "{\"cnaeCode\":\"" + cnaeCode + "\"}", 1, 1);
+    }
+
+    /** Recebe o request bruto da etapa identificado pelo CNAE. */
+    @PostMapping("/cnaes/{cnaeCode}/recebeRequest")
+    public PersonaRoutineMaterializerCreateResponse recebeRequest(@PathVariable String cnaeCode, @RequestBody OprmNichoCnaeV3RecebeRequestRequest request) {
+        return service.recebeRequest(cnaeCode, request);
     }
 
     /** Entrega pendências da etapa persona-routine-materializer ao executor OPRM. */

--- a/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/personaroutinematerializer/service/BackendPersonaRoutineMaterializerService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/personaroutinematerializer/service/BackendPersonaRoutineMaterializerService.java
@@ -8,7 +8,9 @@ import com.marketinghub.oprm.market.OprmCnpjCnaeDim;
 import com.marketinghub.oprmcoletormei.nichocnae.v3.personaroutinematerializer.service.createStageExecution.PersonaRoutineMaterializerCreateResponse;
 import com.marketinghub.oprmcoletormei.nichocnae.v3.personaroutinematerializer.service.pending.PersonaRoutineMaterializerPendingResponse;
 import com.marketinghub.oprmcoletormei.nichocnae.v3.shared.OprmNichoCnaeV3StageServiceSupport;
+import com.marketinghub.oprmcoletormei.nichocnae.v3.shared.OprmNichoCnaeV3RecebeRequestRequest;
 import com.marketinghub.repository.jpa.oprm.market.OprmCnpjCnaeDimRepository;
+import com.marketinghub.repository.jpa.oprm.nichocnae.PipelineNichoCnaeRepository;
 import com.marketinghub.repository.jpa.oprm.nichocnae.v3.OprmNichoCnaeV3StageExecutionRepository;
 import java.math.BigDecimal;
 import java.time.Instant;
@@ -36,9 +38,10 @@ public class BackendPersonaRoutineMaterializerService extends OprmNichoCnaeV3Sta
     public BackendPersonaRoutineMaterializerService(
             OprmNichoCnaeV3StageExecutionRepository repository,
             OprmCnpjCnaeDimRepository cnaeRepository,
+            PipelineNichoCnaeRepository pipelineNichoCnaeRepository,
             PersonaRoutineMaterializerNicheGateway nicheGateway,
             ObjectMapper objectMapper) {
-        super(repository, cnaeRepository, STAGE_CODE);
+        super(repository, cnaeRepository, pipelineNichoCnaeRepository, STAGE_CODE);
         this.nicheGateway = nicheGateway;
         this.objectMapper = objectMapper;
     }
@@ -52,6 +55,11 @@ public class BackendPersonaRoutineMaterializerService extends OprmNichoCnaeV3Sta
     public PersonaRoutineMaterializerCreateResponse start(String cnaeCode) {
         markCnaePipelineStarted(cnaeCode, STATUS_STARTED);
         return create(null, cnaeCode, "{\"cnaeCode\":\"" + cnaeCode + "\"}", 1, 1);
+    }
+
+    /** Recebe o request bruto da etapa e registra auditoria para o pipeline NichoCNAE v3. */
+    public PersonaRoutineMaterializerCreateResponse recebeRequest(String cnaeCode, OprmNichoCnaeV3RecebeRequestRequest request) {
+        return new PersonaRoutineMaterializerCreateResponse(null, doRecebeRequest(cnaeCode, request).getJobId(), cnaeCode, STAGE_CODE, "AGUARDANDO_MODULO");
     }
 
     /** Lista pendências da etapa persona-routine-materializer para o executor OPRM. */

--- a/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/personatournament/controller/BackendPersonaTournamentController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/personatournament/controller/BackendPersonaTournamentController.java
@@ -5,6 +5,7 @@ import com.marketinghub.oprmcoletormei.nichocnae.v3.personatournament.service.co
 import com.marketinghub.oprmcoletormei.nichocnae.v3.personatournament.service.createStageExecution.PersonaTournamentCreateResponse;
 import com.marketinghub.oprmcoletormei.nichocnae.v3.personatournament.service.failStageExecution.PersonaTournamentFailureRequest;
 import com.marketinghub.oprmcoletormei.nichocnae.v3.personatournament.service.pending.PersonaTournamentPendingResponse;
+import com.marketinghub.oprmcoletormei.nichocnae.v3.shared.OprmNichoCnaeV3RecebeRequestRequest;
 import java.util.List;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -41,6 +42,12 @@ public class BackendPersonaTournamentController {
     @PostMapping("/cnaes/{cnaeCode}")
     public PersonaTournamentCreateResponse createForCnae(@PathVariable String cnaeCode) {
         return service.create(null, cnaeCode, "{\"cnaeCode\":\"" + cnaeCode + "\"}", 1, 1);
+    }
+
+    /** Recebe o request bruto da etapa identificado pelo CNAE. */
+    @PostMapping("/cnaes/{cnaeCode}/recebeRequest")
+    public PersonaTournamentCreateResponse recebeRequest(@PathVariable String cnaeCode, @RequestBody OprmNichoCnaeV3RecebeRequestRequest request) {
+        return service.recebeRequest(cnaeCode, request);
     }
 
     /** Entrega pendências da etapa persona-tournament ao executor OPRM. */

--- a/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/personatournament/service/BackendPersonaTournamentService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/personatournament/service/BackendPersonaTournamentService.java
@@ -5,7 +5,9 @@ import com.marketinghub.oprm.market.OprmCnpjCnaeDim;
 import com.marketinghub.oprmcoletormei.nichocnae.v3.personatournament.service.createStageExecution.PersonaTournamentCreateResponse;
 import com.marketinghub.oprmcoletormei.nichocnae.v3.personatournament.service.pending.PersonaTournamentPendingResponse;
 import com.marketinghub.oprmcoletormei.nichocnae.v3.shared.OprmNichoCnaeV3StageServiceSupport;
+import com.marketinghub.oprmcoletormei.nichocnae.v3.shared.OprmNichoCnaeV3RecebeRequestRequest;
 import com.marketinghub.repository.jpa.oprm.market.OprmCnpjCnaeDimRepository;
+import com.marketinghub.repository.jpa.oprm.nichocnae.PipelineNichoCnaeRepository;
 import com.marketinghub.repository.jpa.oprm.nichocnae.v3.OprmNichoCnaeV3StageExecutionRepository;
 import java.util.List;
 import org.springframework.stereotype.Service;
@@ -20,8 +22,8 @@ public class BackendPersonaTournamentService extends OprmNichoCnaeV3StageService
     private static final String STATUS_FAILED = "FALHA";
 
     /** Inicializa o service com repository canônico de execuções v3. */
-    public BackendPersonaTournamentService(OprmNichoCnaeV3StageExecutionRepository repository, OprmCnpjCnaeDimRepository cnaeRepository) {
-        super(repository, cnaeRepository, STAGE_CODE);
+    public BackendPersonaTournamentService(OprmNichoCnaeV3StageExecutionRepository repository, OprmCnpjCnaeDimRepository cnaeRepository, PipelineNichoCnaeRepository pipelineNichoCnaeRepository) {
+        super(repository, cnaeRepository, pipelineNichoCnaeRepository, STAGE_CODE);
     }
 
     /** Cria pendência inicial ou encadeada para a etapa persona-tournament. */
@@ -33,6 +35,11 @@ public class BackendPersonaTournamentService extends OprmNichoCnaeV3StageService
     public PersonaTournamentCreateResponse start(String cnaeCode) {
         markCnaePipelineStarted(cnaeCode, STATUS_STARTED);
         return create(null, cnaeCode, "{\"cnaeCode\":\"" + cnaeCode + "\"}", 1, 1);
+    }
+
+    /** Recebe o request bruto da etapa e registra auditoria para o pipeline NichoCNAE v3. */
+    public PersonaTournamentCreateResponse recebeRequest(String cnaeCode, OprmNichoCnaeV3RecebeRequestRequest request) {
+        return new PersonaTournamentCreateResponse(null, doRecebeRequest(cnaeCode, request).getJobId(), cnaeCode, STAGE_CODE, "AGUARDANDO_MODULO");
     }
 
     /** Lista pendências da etapa persona-tournament para o executor OPRM. */

--- a/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/qualitygate/controller/BackendQualityGateController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/qualitygate/controller/BackendQualityGateController.java
@@ -5,6 +5,7 @@ import com.marketinghub.oprmcoletormei.nichocnae.v3.qualitygate.service.complete
 import com.marketinghub.oprmcoletormei.nichocnae.v3.qualitygate.service.createStageExecution.QualityGateCreateResponse;
 import com.marketinghub.oprmcoletormei.nichocnae.v3.qualitygate.service.failStageExecution.QualityGateFailureRequest;
 import com.marketinghub.oprmcoletormei.nichocnae.v3.qualitygate.service.pending.QualityGatePendingResponse;
+import com.marketinghub.oprmcoletormei.nichocnae.v3.shared.OprmNichoCnaeV3RecebeRequestRequest;
 import java.util.List;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -41,6 +42,12 @@ public class BackendQualityGateController {
     @PostMapping("/cnaes/{cnaeCode}")
     public QualityGateCreateResponse createForCnae(@PathVariable String cnaeCode) {
         return service.create(null, cnaeCode, "{\"cnaeCode\":\"" + cnaeCode + "\"}", 1, 1);
+    }
+
+    /** Recebe o request bruto da etapa identificado pelo CNAE. */
+    @PostMapping("/cnaes/{cnaeCode}/recebeRequest")
+    public QualityGateCreateResponse recebeRequest(@PathVariable String cnaeCode, @RequestBody OprmNichoCnaeV3RecebeRequestRequest request) {
+        return service.recebeRequest(cnaeCode, request);
     }
 
     /** Entrega pendências da etapa quality-gate ao executor OPRM. */

--- a/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/qualitygate/service/BackendQualityGateService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/qualitygate/service/BackendQualityGateService.java
@@ -5,7 +5,9 @@ import com.marketinghub.oprm.market.OprmCnpjCnaeDim;
 import com.marketinghub.oprmcoletormei.nichocnae.v3.qualitygate.service.createStageExecution.QualityGateCreateResponse;
 import com.marketinghub.oprmcoletormei.nichocnae.v3.qualitygate.service.pending.QualityGatePendingResponse;
 import com.marketinghub.oprmcoletormei.nichocnae.v3.shared.OprmNichoCnaeV3StageServiceSupport;
+import com.marketinghub.oprmcoletormei.nichocnae.v3.shared.OprmNichoCnaeV3RecebeRequestRequest;
 import com.marketinghub.repository.jpa.oprm.market.OprmCnpjCnaeDimRepository;
+import com.marketinghub.repository.jpa.oprm.nichocnae.PipelineNichoCnaeRepository;
 import com.marketinghub.repository.jpa.oprm.nichocnae.v3.OprmNichoCnaeV3StageExecutionRepository;
 import java.util.List;
 import org.springframework.stereotype.Service;
@@ -20,8 +22,8 @@ public class BackendQualityGateService extends OprmNichoCnaeV3StageServiceSuppor
     private static final String STATUS_FAILED = "FALHA";
 
     /** Inicializa o service com repository canônico de execuções v3. */
-    public BackendQualityGateService(OprmNichoCnaeV3StageExecutionRepository repository, OprmCnpjCnaeDimRepository cnaeRepository) {
-        super(repository, cnaeRepository, STAGE_CODE);
+    public BackendQualityGateService(OprmNichoCnaeV3StageExecutionRepository repository, OprmCnpjCnaeDimRepository cnaeRepository, PipelineNichoCnaeRepository pipelineNichoCnaeRepository) {
+        super(repository, cnaeRepository, pipelineNichoCnaeRepository, STAGE_CODE);
     }
 
     /** Cria pendência inicial ou encadeada para a etapa quality-gate. */
@@ -33,6 +35,11 @@ public class BackendQualityGateService extends OprmNichoCnaeV3StageServiceSuppor
     public QualityGateCreateResponse start(String cnaeCode) {
         markCnaePipelineStarted(cnaeCode, STATUS_STARTED);
         return create(null, cnaeCode, "{\"cnaeCode\":\"" + cnaeCode + "\"}", 1, 1);
+    }
+
+    /** Recebe o request bruto da etapa e registra auditoria para o pipeline NichoCNAE v3. */
+    public QualityGateCreateResponse recebeRequest(String cnaeCode, OprmNichoCnaeV3RecebeRequestRequest request) {
+        return new QualityGateCreateResponse(null, doRecebeRequest(cnaeCode, request).getJobId(), cnaeCode, STAGE_CODE, "AGUARDANDO_MODULO");
     }
 
     /** Lista pendências da etapa quality-gate para o executor OPRM. */

--- a/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/routinequeryplanner/controller/BackendRoutineQueryPlannerController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/routinequeryplanner/controller/BackendRoutineQueryPlannerController.java
@@ -5,6 +5,7 @@ import com.marketinghub.oprmcoletormei.nichocnae.v3.routinequeryplanner.service.
 import com.marketinghub.oprmcoletormei.nichocnae.v3.routinequeryplanner.service.createStageExecution.RoutineQueryPlannerCreateResponse;
 import com.marketinghub.oprmcoletormei.nichocnae.v3.routinequeryplanner.service.failStageExecution.RoutineQueryPlannerFailureRequest;
 import com.marketinghub.oprmcoletormei.nichocnae.v3.routinequeryplanner.service.pending.RoutineQueryPlannerPendingResponse;
+import com.marketinghub.oprmcoletormei.nichocnae.v3.shared.OprmNichoCnaeV3RecebeRequestRequest;
 import java.util.List;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -41,6 +42,12 @@ public class BackendRoutineQueryPlannerController {
     @PostMapping("/cnaes/{cnaeCode}")
     public RoutineQueryPlannerCreateResponse createForCnae(@PathVariable String cnaeCode) {
         return service.create(null, cnaeCode, "{\"cnaeCode\":\"" + cnaeCode + "\"}", 1, 1);
+    }
+
+    /** Recebe o request bruto da etapa identificado pelo CNAE. */
+    @PostMapping("/cnaes/{cnaeCode}/recebeRequest")
+    public RoutineQueryPlannerCreateResponse recebeRequest(@PathVariable String cnaeCode, @RequestBody OprmNichoCnaeV3RecebeRequestRequest request) {
+        return service.recebeRequest(cnaeCode, request);
     }
 
     /** Entrega pendências da etapa routine-query-planner ao executor OPRM. */

--- a/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/routinequeryplanner/service/BackendRoutineQueryPlannerService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/routinequeryplanner/service/BackendRoutineQueryPlannerService.java
@@ -5,7 +5,9 @@ import com.marketinghub.oprm.market.OprmCnpjCnaeDim;
 import com.marketinghub.oprmcoletormei.nichocnae.v3.routinequeryplanner.service.createStageExecution.RoutineQueryPlannerCreateResponse;
 import com.marketinghub.oprmcoletormei.nichocnae.v3.routinequeryplanner.service.pending.RoutineQueryPlannerPendingResponse;
 import com.marketinghub.oprmcoletormei.nichocnae.v3.shared.OprmNichoCnaeV3StageServiceSupport;
+import com.marketinghub.oprmcoletormei.nichocnae.v3.shared.OprmNichoCnaeV3RecebeRequestRequest;
 import com.marketinghub.repository.jpa.oprm.market.OprmCnpjCnaeDimRepository;
+import com.marketinghub.repository.jpa.oprm.nichocnae.PipelineNichoCnaeRepository;
 import com.marketinghub.repository.jpa.oprm.nichocnae.v3.OprmNichoCnaeV3StageExecutionRepository;
 import java.util.List;
 import org.springframework.stereotype.Service;
@@ -20,8 +22,8 @@ public class BackendRoutineQueryPlannerService extends OprmNichoCnaeV3StageServi
     private static final String STATUS_FAILED = "FALHA";
 
     /** Inicializa o service com repository canônico de execuções v3. */
-    public BackendRoutineQueryPlannerService(OprmNichoCnaeV3StageExecutionRepository repository, OprmCnpjCnaeDimRepository cnaeRepository) {
-        super(repository, cnaeRepository, STAGE_CODE);
+    public BackendRoutineQueryPlannerService(OprmNichoCnaeV3StageExecutionRepository repository, OprmCnpjCnaeDimRepository cnaeRepository, PipelineNichoCnaeRepository pipelineNichoCnaeRepository) {
+        super(repository, cnaeRepository, pipelineNichoCnaeRepository, STAGE_CODE);
     }
 
     /** Cria pendência inicial ou encadeada para a etapa routine-query-planner. */
@@ -33,6 +35,11 @@ public class BackendRoutineQueryPlannerService extends OprmNichoCnaeV3StageServi
     public RoutineQueryPlannerCreateResponse start(String cnaeCode) {
         markCnaePipelineStarted(cnaeCode, STATUS_STARTED);
         return create(null, cnaeCode, "{\"cnaeCode\":\"" + cnaeCode + "\"}", 1, 1);
+    }
+
+    /** Recebe o request bruto da etapa e registra auditoria para o pipeline NichoCNAE v3. */
+    public RoutineQueryPlannerCreateResponse recebeRequest(String cnaeCode, OprmNichoCnaeV3RecebeRequestRequest request) {
+        return new RoutineQueryPlannerCreateResponse(null, doRecebeRequest(cnaeCode, request).getJobId(), cnaeCode, STAGE_CODE, "AGUARDANDO_MODULO");
     }
 
     /** Lista pendências da etapa routine-query-planner para o executor OPRM. */

--- a/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/routinesignalextractor/controller/BackendRoutineSignalExtractorController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/routinesignalextractor/controller/BackendRoutineSignalExtractorController.java
@@ -5,6 +5,7 @@ import com.marketinghub.oprmcoletormei.nichocnae.v3.routinesignalextractor.servi
 import com.marketinghub.oprmcoletormei.nichocnae.v3.routinesignalextractor.service.createStageExecution.RoutineSignalExtractorCreateResponse;
 import com.marketinghub.oprmcoletormei.nichocnae.v3.routinesignalextractor.service.failStageExecution.RoutineSignalExtractorFailureRequest;
 import com.marketinghub.oprmcoletormei.nichocnae.v3.routinesignalextractor.service.pending.RoutineSignalExtractorPendingResponse;
+import com.marketinghub.oprmcoletormei.nichocnae.v3.shared.OprmNichoCnaeV3RecebeRequestRequest;
 import java.util.List;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -41,6 +42,12 @@ public class BackendRoutineSignalExtractorController {
     @PostMapping("/cnaes/{cnaeCode}")
     public RoutineSignalExtractorCreateResponse createForCnae(@PathVariable String cnaeCode) {
         return service.create(null, cnaeCode, "{\"cnaeCode\":\"" + cnaeCode + "\"}", 1, 1);
+    }
+
+    /** Recebe o request bruto da etapa identificado pelo CNAE. */
+    @PostMapping("/cnaes/{cnaeCode}/recebeRequest")
+    public RoutineSignalExtractorCreateResponse recebeRequest(@PathVariable String cnaeCode, @RequestBody OprmNichoCnaeV3RecebeRequestRequest request) {
+        return service.recebeRequest(cnaeCode, request);
     }
 
     /** Entrega pendências da etapa routine-signal-extractor ao executor OPRM. */

--- a/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/routinesignalextractor/service/BackendRoutineSignalExtractorService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/routinesignalextractor/service/BackendRoutineSignalExtractorService.java
@@ -5,7 +5,9 @@ import com.marketinghub.oprm.market.OprmCnpjCnaeDim;
 import com.marketinghub.oprmcoletormei.nichocnae.v3.routinesignalextractor.service.createStageExecution.RoutineSignalExtractorCreateResponse;
 import com.marketinghub.oprmcoletormei.nichocnae.v3.routinesignalextractor.service.pending.RoutineSignalExtractorPendingResponse;
 import com.marketinghub.oprmcoletormei.nichocnae.v3.shared.OprmNichoCnaeV3StageServiceSupport;
+import com.marketinghub.oprmcoletormei.nichocnae.v3.shared.OprmNichoCnaeV3RecebeRequestRequest;
 import com.marketinghub.repository.jpa.oprm.market.OprmCnpjCnaeDimRepository;
+import com.marketinghub.repository.jpa.oprm.nichocnae.PipelineNichoCnaeRepository;
 import com.marketinghub.repository.jpa.oprm.nichocnae.v3.OprmNichoCnaeV3StageExecutionRepository;
 import java.util.List;
 import org.springframework.stereotype.Service;
@@ -20,8 +22,8 @@ public class BackendRoutineSignalExtractorService extends OprmNichoCnaeV3StageSe
     private static final String STATUS_FAILED = "FALHA";
 
     /** Inicializa o service com repository canônico de execuções v3. */
-    public BackendRoutineSignalExtractorService(OprmNichoCnaeV3StageExecutionRepository repository, OprmCnpjCnaeDimRepository cnaeRepository) {
-        super(repository, cnaeRepository, STAGE_CODE);
+    public BackendRoutineSignalExtractorService(OprmNichoCnaeV3StageExecutionRepository repository, OprmCnpjCnaeDimRepository cnaeRepository, PipelineNichoCnaeRepository pipelineNichoCnaeRepository) {
+        super(repository, cnaeRepository, pipelineNichoCnaeRepository, STAGE_CODE);
     }
 
     /** Cria pendência inicial ou encadeada para a etapa routine-signal-extractor. */
@@ -33,6 +35,11 @@ public class BackendRoutineSignalExtractorService extends OprmNichoCnaeV3StageSe
     public RoutineSignalExtractorCreateResponse start(String cnaeCode) {
         markCnaePipelineStarted(cnaeCode, STATUS_STARTED);
         return create(null, cnaeCode, "{\"cnaeCode\":\"" + cnaeCode + "\"}", 1, 1);
+    }
+
+    /** Recebe o request bruto da etapa e registra auditoria para o pipeline NichoCNAE v3. */
+    public RoutineSignalExtractorCreateResponse recebeRequest(String cnaeCode, OprmNichoCnaeV3RecebeRequestRequest request) {
+        return new RoutineSignalExtractorCreateResponse(null, doRecebeRequest(cnaeCode, request).getJobId(), cnaeCode, STAGE_CODE, "AGUARDANDO_MODULO");
     }
 
     /** Lista pendências da etapa routine-signal-extractor para o executor OPRM. */

--- a/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/shared/OprmNichoCnaeV3RecebeRequestRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/shared/OprmNichoCnaeV3RecebeRequestRequest.java
@@ -1,0 +1,5 @@
+package com.marketinghub.oprmcoletormei.nichocnae.v3.shared;
+
+/** Payload recebido do módulo executor para registrar auditoria de request da etapa NichoCNAE v3. */
+public record OprmNichoCnaeV3RecebeRequestRequest(String request, String plataforma, String prompt, String schema) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/shared/OprmNichoCnaeV3StageServiceSupport.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/shared/OprmNichoCnaeV3StageServiceSupport.java
@@ -3,8 +3,13 @@ package com.marketinghub.oprmcoletormei.nichocnae.v3.shared;
 import com.marketinghub.oprmcoletormei.nichocnae.v3.OprmNichoCnaeV3StageExecution;
 import com.marketinghub.oprmcoletormei.nichocnae.v3.OprmNichoCnaeV3StageExecutionStatus;
 import com.marketinghub.oprm.market.OprmCnpjCnaeDim;
+import com.marketinghub.oprm.nichocnae.PipelineNichoCnae;
 import com.marketinghub.repository.jpa.oprm.market.OprmCnpjCnaeDimRepository;
 import com.marketinghub.repository.jpa.oprm.nichocnae.v3.OprmNichoCnaeV3StageExecutionRepository;
+import com.marketinghub.repository.jpa.oprm.nichocnae.PipelineNichoCnaeRepository;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
@@ -17,6 +22,8 @@ import org.springframework.web.server.ResponseStatusException;
 public abstract class OprmNichoCnaeV3StageServiceSupport {
     protected static final String STATUS_STARTED = "INICIADO";
     private static final int PENDING_LIMIT = 10;
+    private static final String STATUS_WAITING_MODULE = "AGUARDANDO_MODULO";
+    private static final String PIPELINE_VERSION = "v3";
     private static final Map<String, Integer> STAGE_ORDER = Map.ofEntries(
             Map.entry("cnae-intake", 1),
             Map.entry("persona-candidate-generator", 2),
@@ -30,15 +37,18 @@ public abstract class OprmNichoCnaeV3StageServiceSupport {
             Map.entry("persona-routine-materializer", 10));
     private final OprmNichoCnaeV3StageExecutionRepository repository;
     private final OprmCnpjCnaeDimRepository cnaeRepository;
+    private final PipelineNichoCnaeRepository pipelineNichoCnaeRepository;
     private final String stageCode;
 
     /** Inicializa o suporte com repository canônico e código da etapa. */
     protected OprmNichoCnaeV3StageServiceSupport(
             OprmNichoCnaeV3StageExecutionRepository repository,
             OprmCnpjCnaeDimRepository cnaeRepository,
+            PipelineNichoCnaeRepository pipelineNichoCnaeRepository,
             String stageCode) {
         this.repository = repository;
         this.cnaeRepository = cnaeRepository;
+        this.pipelineNichoCnaeRepository = pipelineNichoCnaeRepository;
         this.stageCode = stageCode;
     }
 
@@ -52,6 +62,47 @@ public abstract class OprmNichoCnaeV3StageServiceSupport {
         cnae.setNichocnaePipelineUpdatedAt(now);
         cnae.setUpdatedAt(now);
         cnaeRepository.save(cnae);
+    }
+
+
+    /** Recebe o request bruto da etapa, atualiza o CNAE para aguardar o módulo e audita o payload no pipeline NichoCNAE. */
+    protected PipelineNichoCnae doRecebeRequest(String cnaeCode, OprmNichoCnaeV3RecebeRequestRequest request) {
+        OprmCnpjCnaeDim cnae = cnaeRepository.findById(cnaeCode)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "CNAE não encontrado."));
+        Instant now = Instant.now();
+        cnae.setNichocnaePipelineStatus(STATUS_WAITING_MODULE);
+        cnae.setNichocnaeCurrentStageCode(stageCode);
+        cnae.setNichocnaePipelineUpdatedAt(now);
+        cnae.setUpdatedAt(now);
+        cnaeRepository.save(cnae);
+
+        PipelineNichoCnae pipeline = new PipelineNichoCnae();
+        pipeline.setIdExterno(cnaeCode);
+        pipeline.setRequest(request == null ? null : request.request());
+        pipeline.setCodigoEtapa(stageCode);
+        pipeline.setDataHora(now);
+        pipeline.setJobId(generateJobId(cnaeCode, now));
+        pipeline.setPlataforma(request == null ? null : request.plataforma());
+        pipeline.setPrompt(request == null ? null : request.prompt());
+        pipeline.setSchema(request == null ? null : request.schema());
+        pipeline.setVersaoPipeline(PIPELINE_VERSION);
+        return pipelineNichoCnaeRepository.save(pipeline);
+    }
+
+    /** Gera hash único para rastrear o request recebido na etapa. */
+    private String generateJobId(String cnaeCode, Instant now) {
+        String source = PIPELINE_VERSION + ":" + stageCode + ":" + cnaeCode + ":" + now.toString();
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-256");
+            byte[] hash = digest.digest(source.getBytes(StandardCharsets.UTF_8));
+            StringBuilder builder = new StringBuilder();
+            for (byte b : hash) {
+                builder.append(String.format("%02x", b));
+            }
+            return builder.toString();
+        } catch (NoSuchAlgorithmException ex) {
+            throw new IllegalStateException("Não foi possível gerar jobId do request NichoCNAE v3.", ex);
+        }
     }
 
     /** Cria uma execução pendente para a etapa canônica. */

--- a/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/sourcefetcher/controller/BackendSourceFetcherV3Controller.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/sourcefetcher/controller/BackendSourceFetcherV3Controller.java
@@ -5,6 +5,7 @@ import com.marketinghub.oprmcoletormei.nichocnae.v3.sourcefetcher.service.comple
 import com.marketinghub.oprmcoletormei.nichocnae.v3.sourcefetcher.service.createStageExecution.SourceFetcherCreateResponse;
 import com.marketinghub.oprmcoletormei.nichocnae.v3.sourcefetcher.service.failStageExecution.SourceFetcherFailureRequest;
 import com.marketinghub.oprmcoletormei.nichocnae.v3.sourcefetcher.service.pending.SourceFetcherPendingResponse;
+import com.marketinghub.oprmcoletormei.nichocnae.v3.shared.OprmNichoCnaeV3RecebeRequestRequest;
 import java.util.List;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -41,6 +42,12 @@ public class BackendSourceFetcherV3Controller {
     @PostMapping("/cnaes/{cnaeCode}")
     public SourceFetcherCreateResponse createForCnae(@PathVariable String cnaeCode) {
         return service.create(null, cnaeCode, "{\"cnaeCode\":\"" + cnaeCode + "\"}", 1, 1);
+    }
+
+    /** Recebe o request bruto da etapa identificado pelo CNAE. */
+    @PostMapping("/cnaes/{cnaeCode}/recebeRequest")
+    public SourceFetcherCreateResponse recebeRequest(@PathVariable String cnaeCode, @RequestBody OprmNichoCnaeV3RecebeRequestRequest request) {
+        return service.recebeRequest(cnaeCode, request);
     }
 
     /** Entrega pendências da etapa source-fetcher ao executor OPRM. */

--- a/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/sourcefetcher/service/BackendSourceFetcherV3Service.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/sourcefetcher/service/BackendSourceFetcherV3Service.java
@@ -5,7 +5,9 @@ import com.marketinghub.oprm.market.OprmCnpjCnaeDim;
 import com.marketinghub.oprmcoletormei.nichocnae.v3.sourcefetcher.service.createStageExecution.SourceFetcherCreateResponse;
 import com.marketinghub.oprmcoletormei.nichocnae.v3.sourcefetcher.service.pending.SourceFetcherPendingResponse;
 import com.marketinghub.oprmcoletormei.nichocnae.v3.shared.OprmNichoCnaeV3StageServiceSupport;
+import com.marketinghub.oprmcoletormei.nichocnae.v3.shared.OprmNichoCnaeV3RecebeRequestRequest;
 import com.marketinghub.repository.jpa.oprm.market.OprmCnpjCnaeDimRepository;
+import com.marketinghub.repository.jpa.oprm.nichocnae.PipelineNichoCnaeRepository;
 import com.marketinghub.repository.jpa.oprm.nichocnae.v3.OprmNichoCnaeV3StageExecutionRepository;
 import java.util.List;
 import org.springframework.stereotype.Service;
@@ -20,8 +22,8 @@ public class BackendSourceFetcherV3Service extends OprmNichoCnaeV3StageServiceSu
     private static final String STATUS_FAILED = "FALHA";
 
     /** Inicializa o service com repository canônico de execuções v3. */
-    public BackendSourceFetcherV3Service(OprmNichoCnaeV3StageExecutionRepository repository, OprmCnpjCnaeDimRepository cnaeRepository) {
-        super(repository, cnaeRepository, STAGE_CODE);
+    public BackendSourceFetcherV3Service(OprmNichoCnaeV3StageExecutionRepository repository, OprmCnpjCnaeDimRepository cnaeRepository, PipelineNichoCnaeRepository pipelineNichoCnaeRepository) {
+        super(repository, cnaeRepository, pipelineNichoCnaeRepository, STAGE_CODE);
     }
 
     /** Cria pendência inicial ou encadeada para a etapa source-fetcher. */
@@ -33,6 +35,11 @@ public class BackendSourceFetcherV3Service extends OprmNichoCnaeV3StageServiceSu
     public SourceFetcherCreateResponse start(String cnaeCode) {
         markCnaePipelineStarted(cnaeCode, STATUS_STARTED);
         return create(null, cnaeCode, "{\"cnaeCode\":\"" + cnaeCode + "\"}", 1, 1);
+    }
+
+    /** Recebe o request bruto da etapa e registra auditoria para o pipeline NichoCNAE v3. */
+    public SourceFetcherCreateResponse recebeRequest(String cnaeCode, OprmNichoCnaeV3RecebeRequestRequest request) {
+        return new SourceFetcherCreateResponse(null, doRecebeRequest(cnaeCode, request).getJobId(), cnaeCode, STAGE_CODE, "AGUARDANDO_MODULO");
     }
 
     /** Lista pendências da etapa source-fetcher para o executor OPRM. */

--- a/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/sourcesearcher/controller/BackendSourceSearcherV3Controller.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/sourcesearcher/controller/BackendSourceSearcherV3Controller.java
@@ -5,6 +5,7 @@ import com.marketinghub.oprmcoletormei.nichocnae.v3.sourcesearcher.service.compl
 import com.marketinghub.oprmcoletormei.nichocnae.v3.sourcesearcher.service.createStageExecution.SourceSearcherCreateResponse;
 import com.marketinghub.oprmcoletormei.nichocnae.v3.sourcesearcher.service.failStageExecution.SourceSearcherFailureRequest;
 import com.marketinghub.oprmcoletormei.nichocnae.v3.sourcesearcher.service.pending.SourceSearcherPendingResponse;
+import com.marketinghub.oprmcoletormei.nichocnae.v3.shared.OprmNichoCnaeV3RecebeRequestRequest;
 import java.util.List;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -41,6 +42,12 @@ public class BackendSourceSearcherV3Controller {
     @PostMapping("/cnaes/{cnaeCode}")
     public SourceSearcherCreateResponse createForCnae(@PathVariable String cnaeCode) {
         return service.create(null, cnaeCode, "{\"cnaeCode\":\"" + cnaeCode + "\"}", 1, 1);
+    }
+
+    /** Recebe o request bruto da etapa identificado pelo CNAE. */
+    @PostMapping("/cnaes/{cnaeCode}/recebeRequest")
+    public SourceSearcherCreateResponse recebeRequest(@PathVariable String cnaeCode, @RequestBody OprmNichoCnaeV3RecebeRequestRequest request) {
+        return service.recebeRequest(cnaeCode, request);
     }
 
     /** Entrega pendências da etapa source-searcher ao executor OPRM. */

--- a/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/sourcesearcher/service/BackendSourceSearcherV3Service.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/sourcesearcher/service/BackendSourceSearcherV3Service.java
@@ -5,7 +5,9 @@ import com.marketinghub.oprm.market.OprmCnpjCnaeDim;
 import com.marketinghub.oprmcoletormei.nichocnae.v3.sourcesearcher.service.createStageExecution.SourceSearcherCreateResponse;
 import com.marketinghub.oprmcoletormei.nichocnae.v3.sourcesearcher.service.pending.SourceSearcherPendingResponse;
 import com.marketinghub.oprmcoletormei.nichocnae.v3.shared.OprmNichoCnaeV3StageServiceSupport;
+import com.marketinghub.oprmcoletormei.nichocnae.v3.shared.OprmNichoCnaeV3RecebeRequestRequest;
 import com.marketinghub.repository.jpa.oprm.market.OprmCnpjCnaeDimRepository;
+import com.marketinghub.repository.jpa.oprm.nichocnae.PipelineNichoCnaeRepository;
 import com.marketinghub.repository.jpa.oprm.nichocnae.v3.OprmNichoCnaeV3StageExecutionRepository;
 import java.util.List;
 import org.springframework.stereotype.Service;
@@ -20,8 +22,8 @@ public class BackendSourceSearcherV3Service extends OprmNichoCnaeV3StageServiceS
     private static final String STATUS_FAILED = "FALHA";
 
     /** Inicializa o service com repository canônico de execuções v3. */
-    public BackendSourceSearcherV3Service(OprmNichoCnaeV3StageExecutionRepository repository, OprmCnpjCnaeDimRepository cnaeRepository) {
-        super(repository, cnaeRepository, STAGE_CODE);
+    public BackendSourceSearcherV3Service(OprmNichoCnaeV3StageExecutionRepository repository, OprmCnpjCnaeDimRepository cnaeRepository, PipelineNichoCnaeRepository pipelineNichoCnaeRepository) {
+        super(repository, cnaeRepository, pipelineNichoCnaeRepository, STAGE_CODE);
     }
 
     /** Cria pendência inicial ou encadeada para a etapa source-searcher. */
@@ -33,6 +35,11 @@ public class BackendSourceSearcherV3Service extends OprmNichoCnaeV3StageServiceS
     public SourceSearcherCreateResponse start(String cnaeCode) {
         markCnaePipelineStarted(cnaeCode, STATUS_STARTED);
         return create(null, cnaeCode, "{\"cnaeCode\":\"" + cnaeCode + "\"}", 1, 1);
+    }
+
+    /** Recebe o request bruto da etapa e registra auditoria para o pipeline NichoCNAE v3. */
+    public SourceSearcherCreateResponse recebeRequest(String cnaeCode, OprmNichoCnaeV3RecebeRequestRequest request) {
+        return new SourceSearcherCreateResponse(null, doRecebeRequest(cnaeCode, request).getJobId(), cnaeCode, STAGE_CODE, "AGUARDANDO_MODULO");
     }
 
     /** Lista pendências da etapa source-searcher para o executor OPRM. */

--- a/backend/ads-service/src/test/java/com/marketinghub/oprmcoletormei/nichocnae/v3/personaroutinematerializer/service/BackendPersonaRoutineMaterializerServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/oprmcoletormei/nichocnae/v3/personaroutinematerializer/service/BackendPersonaRoutineMaterializerServiceTest.java
@@ -12,6 +12,7 @@ import com.marketinghub.oprmcoletormei.nichocnae.v3.OprmNichoCnaeV3StageExecutio
 import com.marketinghub.oprmcoletormei.nichocnae.v3.OprmNichoCnaeV3StageExecutionStatus;
 import com.marketinghub.oprmcoletormei.nichocnae.v3.personaroutinematerializer.gateway.PersonaRoutineMaterializerNicheGateway;
 import com.marketinghub.repository.jpa.oprm.market.OprmCnpjCnaeDimRepository;
+import com.marketinghub.repository.jpa.oprm.nichocnae.PipelineNichoCnaeRepository;
 import com.marketinghub.repository.jpa.oprm.nichocnae.v3.OprmNichoCnaeV3StageExecutionRepository;
 import java.time.Instant;
 import java.util.List;
@@ -36,11 +37,14 @@ class BackendPersonaRoutineMaterializerServiceTest {
     @Mock
     private PersonaRoutineMaterializerNicheGateway nicheGateway;
 
+    @Mock
+    private PipelineNichoCnaeRepository pipelineNichoCnaeRepository;
+
     private BackendPersonaRoutineMaterializerService service;
 
     @BeforeEach
     void setUp() {
-        service = new BackendPersonaRoutineMaterializerService(repository, cnaeRepository, nicheGateway, new ObjectMapper());
+        service = new BackendPersonaRoutineMaterializerService(repository, cnaeRepository, pipelineNichoCnaeRepository, nicheGateway, new ObjectMapper());
     }
 
     /** Garante que a etapa final grava MarketNiche e perfil enriquecido para uso por outros pipelines. */


### PR DESCRIPTION
### Motivation
- Fornecer um endpoint padrão para o módulo executor reportar o `request` bruto por CNAE e permitir que o backend marque o CNAE como aguardando o módulo antes do processamento do worker. 
- Auditar a entrada recebida por etapa no histórico genérico `pipeline_nichocnae` para rastreabilidade e jobId estável. 
- Reusar suporte compartilhado entre todas as etapas v3 para garantir comportamento canônico e evitar duplicação de lógica. 

### Description
- Adiciona o endpoint HTTP `POST /api/internal/oprm/nichocnae/v3/<etapa>/stage-executions/cnaes/{cnaeCode}/recebeRequest` em todos os controllers de etapa v3 e encaminha para o respectivo service `recebeRequest`. 
- Implementa `doRecebeRequest` em `OprmNichoCnaeV3StageServiceSupport` que atualiza `oprm_cnpj_cnae_dim` (`nichocnae_pipeline_status`, `nichocnae_current_stage_code`, `nichocnae_pipeline_updated_at`) para `AGUARDANDO_MODULO` e insere um registro em `pipeline_nichocnae` com `idExterno`, `request`, `codigo_etapa`, `dataHora` (UTC), `jobId` (SHA-256 hash gerado na hora), `plataforma`, `prompt`, `schema` e `versao_pipeline = 'v3'`. 
- Introduz o `record` `OprmNichoCnaeV3RecebeRequestRequest` para o payload do endpoint (`request`, `plataforma`, `prompt`, `schema`) e passa `PipelineNichoCnaeRepository` via construtores dos services v3 para persistência da auditoria. 
- Atualiza serviços e controllers das etapas (`cnae-intake`, `persona-candidate-generator`, `persona-tournament`, `routine-query-planner`, `source-searcher`, `source-fetcher`, `routine-signal-extractor`, `daily-tasks-synthesizer`, `quality-gate`, `persona-routine-materializer`) e ajusta teste afetado para mockar a nova dependência `PipelineNichoCnaeRepository`. 

### Testing
- Rodei `mvn -q -DskipTests compile` e a compilação do módulo `backend/ads-service` concluiu com sucesso. 
- Executei o teste específico `mvn -q -Dtest=com.marketinghub.oprmcoletormei.nichocnae.v3.personaroutinematerializer.service.BackendPersonaRoutineMaterializerServiceTest test` e ele passou após ajustar o mock do `PipelineNichoCnaeRepository`. 
- Executei `mvn -q test` no módulo backend e a suíte completa falhou por testes pré-existentes e não relacionados (ex.: `ArquiteturaTest` do MOIS Dossiê v1, `PipelineServiceTest` do coletor OPRM e uma falha de integridade referencial em `CreativeControllerTest`); essas falhas não são causadas pelas mudanças deste PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3ef2aff3548321a36de926873b1203)