### PR TITLE
Introduce UUID jobId for MOIS dossiê pipeline and propagate through start/pending/recebeRequest

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/dossiersynthesis/controller/DossierDossierSynthesisController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/dossiersynthesis/controller/DossierDossierSynthesisController.java
@@ -30,11 +30,12 @@ public class DossierDossierSynthesisController {
 
 
     /** Recebe o request do módulo executor para a página/produto informada pela chave operacional. */
-    @PostMapping("/{productKey}/recebeRequest")
+    @PostMapping("/{productKey}/{jobId}/recebeRequest")
     public DossierDossierSynthesisRecebeRequestResponse recebeRequest(
             @PathVariable("productKey") String productKey,
+            @PathVariable("jobId") String jobId,
             @Valid @RequestBody DossierDossierSynthesisRecebeRequestRequest request) {
-        return service.recebeRequest(productKey, request);
+        return service.recebeRequest(productKey, jobId, request);
     }
 
     /** Expõe o ponto inicial canônico de consumo da fila pelo módulo executor. */

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/dossiersynthesis/service/DossierDossierSynthesisService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/dossiersynthesis/service/DossierDossierSynthesisService.java
@@ -8,12 +8,9 @@ import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.dossiersynthe
 import com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1.MoisSalesPageRepository;
 import com.marketinghub.repository.jpa.mois.dossieproduto.PipelineDossieProdutoRepository;
 import com.marketinghub.repository.jpa.mois.dossieproduto.entity.PipelineDossieProduto;
-import java.nio.charset.StandardCharsets;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
 import java.time.Instant;
-import java.util.HexFormat;
 import java.util.List;
+import java.util.UUID;
 import java.util.Map;
 import org.springframework.stereotype.Service;
 
@@ -38,23 +35,32 @@ public class DossierDossierSynthesisService {
     private static final String STATUS_COMPLETED = "CONCLUIDO";
     private static final String STATUS_FAILED = "FALHA";
 
-    /** Marca a página/produto como iniciado no dossiê e posiciona a etapa atual. */
+    /** Marca a página/produto como iniciado no dossiê, cria o jobId UUID e posiciona a etapa atual. */
     public void start(String productKey) {
         long pageId = Long.parseLong(productKey);
+        Instant now = Instant.now();
+        String jobId = UUID.randomUUID().toString();
         var page = salesPageRepository.findById(pageId)
                 .orElseThrow(() -> new IllegalArgumentException("Página/produto MOIS não encontrada: " + productKey));
         page.setDossieProdutoStatus(STATUS_STARTED);
         page.setDossieProdutoCurrentStage(STAGE_CODE);
-        page.setDossieProdutoUpdatedAt(Instant.now());
+        page.setDossieProdutoUpdatedAt(now);
         salesPageRepository.save(page);
+
+        PipelineDossieProduto pipeline = new PipelineDossieProduto();
+        pipeline.setIdExterno(productKey);
+        pipeline.setCodigoEtapa(STAGE_CODE);
+        pipeline.setDataHora(now);
+        pipeline.setJobId(jobId);
+        pipeline.setVersaoPipeline("v1");
+        pipelineDossieProdutoRepository.save(pipeline);
     }
 
 
     /** Recebe o request operacional da etapa, coloca a página em espera do módulo e audita a entrada do pipeline. */
-    public DossierDossierSynthesisRecebeRequestResponse recebeRequest(String productKey, DossierDossierSynthesisRecebeRequestRequest request) {
+    public DossierDossierSynthesisRecebeRequestResponse recebeRequest(String productKey, String jobId, DossierDossierSynthesisRecebeRequestRequest request) {
         long pageId = Long.parseLong(productKey);
         Instant now = Instant.now();
-        String jobId = createJobId(productKey, now);
         var page = salesPageRepository.findById(pageId)
                 .orElseThrow(() -> new IllegalArgumentException("Página/produto MOIS não encontrada: " + productKey));
         page.setDossieProdutoStatus(STATUS_WAITING);
@@ -77,35 +83,37 @@ public class DossierDossierSynthesisService {
         return new DossierDossierSynthesisRecebeRequestResponse(jobId, productKey, STAGE_CODE, STATUS_WAITING);
     }
 
-    /** Cria um hash operacional para rastrear a entrada recebida nesta etapa. */
-    private String createJobId(String productKey, Instant now) {
-        try {
-            MessageDigest digest = MessageDigest.getInstance("SHA-256");
-            byte[] hash = digest.digest((STAGE_CODE + "|" + productKey + "|" + now).getBytes(StandardCharsets.UTF_8));
-            return HexFormat.of().formatHex(hash);
-        } catch (NoSuchAlgorithmException ex) {
-            throw new IllegalStateException("Não foi possível criar jobId do dossiê MOIS", ex);
-        }
-    }
-
     /** Entrega até dez trabalhos iniciados da etapa atual ao executor, ordenados pela data operacional mais antiga. */
     public DossierDossierSynthesisPendingResponse pending(DossierDossierSynthesisPendingRequest request) {
         List<DossierDossierSynthesisPendingJob> jobs = salesPageRepository
                 .findTop10ByDossieProdutoStatusAndDossieProdutoCurrentStageOrderByDossieProdutoUpdatedAtAscIdAsc(
                         STATUS_STARTED, STAGE_CODE)
                 .stream()
-                .map(page -> new DossierDossierSynthesisPendingJob(
+                .map(page -> {
+                    String jobId = resolveJobId(String.valueOf(page.getId()));
+                    return new DossierDossierSynthesisPendingJob(
+                        jobId,
                         page.getId(),
                         page.getId(),
                         "mois-sales-page-" + page.getId(),
                         STAGE_CODE,
                         Map.of(
+                                "jobId", jobId,
                                 "productKey", String.valueOf(page.getId()),
                                 "pageId", page.getId(),
                                 "stageCode", STAGE_CODE,
                                 "status", STATUS_STARTED,
-                                "nextStageCode", NEXT_STAGE)))
+                                "nextStageCode", NEXT_STAGE));
+                })
                 .toList();
         return new DossierDossierSynthesisPendingResponse(!jobs.isEmpty(), jobs);
+    }
+    /** Recupera o jobId UUID criado no start para compor o contrato pending da etapa. */
+    private String resolveJobId(String productKey) {
+        return pipelineDossieProdutoRepository
+                .findTopByIdExternoAndCodigoEtapaOrderByDataHoraDescIdDesc(productKey, STAGE_CODE)
+                .map(PipelineDossieProduto::getJobId)
+                .orElseThrow(() -> new IllegalStateException(
+                        "JobId do dossiê MOIS não encontrado para produto " + productKey + " na etapa " + STAGE_CODE));
     }
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/dossiersynthesis/service/pending/DossierDossierSynthesisPendingJob.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/dossiersynthesis/service/pending/DossierDossierSynthesisPendingJob.java
@@ -3,5 +3,5 @@ package com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.dossiersynth
 import java.util.Map;
 
 /** Contrato de trabalho pendente entregue ao executor da etapa síntese final do dossiê do dossiê MOIS v1. */
-public record DossierDossierSynthesisPendingJob(long stageExecutionId, long dossierId, String workspaceId, String stageName, Map<String, Object> input) {
+public record DossierDossierSynthesisPendingJob(String jobId, long stageExecutionId, long dossierId, String workspaceId, String stageName, Map<String, Object> input) {
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/intake/controller/DossierIntakeController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/intake/controller/DossierIntakeController.java
@@ -30,11 +30,12 @@ public class DossierIntakeController {
 
 
     /** Recebe o request do módulo executor para a página/produto informada pela chave operacional. */
-    @PostMapping("/{productKey}/recebeRequest")
+    @PostMapping("/{productKey}/{jobId}/recebeRequest")
     public DossierIntakeRecebeRequestResponse recebeRequest(
             @PathVariable("productKey") String productKey,
+            @PathVariable("jobId") String jobId,
             @Valid @RequestBody DossierIntakeRecebeRequestRequest request) {
-        return service.recebeRequest(productKey, request);
+        return service.recebeRequest(productKey, jobId, request);
     }
 
     /** Expõe o ponto inicial canônico de consumo da fila pelo módulo executor. */

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/intake/service/DossierIntakeService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/intake/service/DossierIntakeService.java
@@ -8,12 +8,9 @@ import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.intake.servic
 import com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1.MoisSalesPageRepository;
 import com.marketinghub.repository.jpa.mois.dossieproduto.PipelineDossieProdutoRepository;
 import com.marketinghub.repository.jpa.mois.dossieproduto.entity.PipelineDossieProduto;
-import java.nio.charset.StandardCharsets;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
 import java.time.Instant;
-import java.util.HexFormat;
 import java.util.List;
+import java.util.UUID;
 import java.util.Map;
 import org.springframework.stereotype.Service;
 
@@ -38,23 +35,32 @@ public class DossierIntakeService {
     private static final String STATUS_COMPLETED = "CONCLUIDO";
     private static final String STATUS_FAILED = "FALHA";
 
-    /** Marca a página/produto como iniciado no dossiê e posiciona a etapa atual. */
+    /** Marca a página/produto como iniciado no dossiê, cria o jobId UUID e posiciona a etapa atual. */
     public void start(String productKey) {
         long pageId = Long.parseLong(productKey);
+        Instant now = Instant.now();
+        String jobId = UUID.randomUUID().toString();
         var page = salesPageRepository.findById(pageId)
                 .orElseThrow(() -> new IllegalArgumentException("Página/produto MOIS não encontrada: " + productKey));
         page.setDossieProdutoStatus(STATUS_STARTED);
         page.setDossieProdutoCurrentStage(STAGE_CODE);
-        page.setDossieProdutoUpdatedAt(Instant.now());
+        page.setDossieProdutoUpdatedAt(now);
         salesPageRepository.save(page);
+
+        PipelineDossieProduto pipeline = new PipelineDossieProduto();
+        pipeline.setIdExterno(productKey);
+        pipeline.setCodigoEtapa(STAGE_CODE);
+        pipeline.setDataHora(now);
+        pipeline.setJobId(jobId);
+        pipeline.setVersaoPipeline("v1");
+        pipelineDossieProdutoRepository.save(pipeline);
     }
 
 
     /** Recebe o request operacional da etapa, coloca a página em espera do módulo e audita a entrada do pipeline. */
-    public DossierIntakeRecebeRequestResponse recebeRequest(String productKey, DossierIntakeRecebeRequestRequest request) {
+    public DossierIntakeRecebeRequestResponse recebeRequest(String productKey, String jobId, DossierIntakeRecebeRequestRequest request) {
         long pageId = Long.parseLong(productKey);
         Instant now = Instant.now();
-        String jobId = createJobId(productKey, now);
         var page = salesPageRepository.findById(pageId)
                 .orElseThrow(() -> new IllegalArgumentException("Página/produto MOIS não encontrada: " + productKey));
         page.setDossieProdutoStatus(STATUS_WAITING);
@@ -77,35 +83,37 @@ public class DossierIntakeService {
         return new DossierIntakeRecebeRequestResponse(jobId, productKey, STAGE_CODE, STATUS_WAITING);
     }
 
-    /** Cria um hash operacional para rastrear a entrada recebida nesta etapa. */
-    private String createJobId(String productKey, Instant now) {
-        try {
-            MessageDigest digest = MessageDigest.getInstance("SHA-256");
-            byte[] hash = digest.digest((STAGE_CODE + "|" + productKey + "|" + now).getBytes(StandardCharsets.UTF_8));
-            return HexFormat.of().formatHex(hash);
-        } catch (NoSuchAlgorithmException ex) {
-            throw new IllegalStateException("Não foi possível criar jobId do dossiê MOIS", ex);
-        }
-    }
-
     /** Entrega até dez trabalhos iniciados da etapa atual ao executor, ordenados pela data operacional mais antiga. */
     public DossierIntakePendingResponse pending(DossierIntakePendingRequest request) {
         List<DossierIntakePendingJob> jobs = salesPageRepository
                 .findTop10ByDossieProdutoStatusAndDossieProdutoCurrentStageOrderByDossieProdutoUpdatedAtAscIdAsc(
                         STATUS_STARTED, STAGE_CODE)
                 .stream()
-                .map(page -> new DossierIntakePendingJob(
+                .map(page -> {
+                    String jobId = resolveJobId(String.valueOf(page.getId()));
+                    return new DossierIntakePendingJob(
+                        jobId,
                         page.getId(),
                         page.getId(),
                         "mois-sales-page-" + page.getId(),
                         STAGE_CODE,
                         Map.of(
+                                "jobId", jobId,
                                 "productKey", String.valueOf(page.getId()),
                                 "pageId", page.getId(),
                                 "stageCode", STAGE_CODE,
                                 "status", STATUS_STARTED,
-                                "nextStageCode", NEXT_STAGE)))
+                                "nextStageCode", NEXT_STAGE));
+                })
                 .toList();
         return new DossierIntakePendingResponse(!jobs.isEmpty(), jobs);
+    }
+    /** Recupera o jobId UUID criado no start para compor o contrato pending da etapa. */
+    private String resolveJobId(String productKey) {
+        return pipelineDossieProdutoRepository
+                .findTopByIdExternoAndCodigoEtapaOrderByDataHoraDescIdDesc(productKey, STAGE_CODE)
+                .map(PipelineDossieProduto::getJobId)
+                .orElseThrow(() -> new IllegalStateException(
+                        "JobId do dossiê MOIS não encontrado para produto " + productKey + " na etapa " + STAGE_CODE));
     }
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/intake/service/pending/DossierIntakePendingJob.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/intake/service/pending/DossierIntakePendingJob.java
@@ -3,5 +3,5 @@ package com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.intake.servi
 import java.util.Map;
 
 /** Contrato de trabalho pendente entregue ao executor da etapa entrada inicial do dossiê MOIS v1. */
-public record DossierIntakePendingJob(long stageExecutionId, long dossierId, String workspaceId, String stageName, Map<String, Object> input) {
+public record DossierIntakePendingJob(String jobId, long stageExecutionId, long dossierId, String workspaceId, String stageName, Map<String, Object> input) {
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/investigationanchorbuilder/controller/DossierInvestigationAnchorBuilderController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/investigationanchorbuilder/controller/DossierInvestigationAnchorBuilderController.java
@@ -30,11 +30,12 @@ public class DossierInvestigationAnchorBuilderController {
 
 
     /** Recebe o request do módulo executor para a página/produto informada pela chave operacional. */
-    @PostMapping("/{productKey}/recebeRequest")
+    @PostMapping("/{productKey}/{jobId}/recebeRequest")
     public DossierInvestigationAnchorBuilderRecebeRequestResponse recebeRequest(
             @PathVariable("productKey") String productKey,
+            @PathVariable("jobId") String jobId,
             @Valid @RequestBody DossierInvestigationAnchorBuilderRecebeRequestRequest request) {
-        return service.recebeRequest(productKey, request);
+        return service.recebeRequest(productKey, jobId, request);
     }
 
     /** Expõe o ponto inicial canônico de consumo da fila pelo módulo executor. */

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/investigationanchorbuilder/service/DossierInvestigationAnchorBuilderService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/investigationanchorbuilder/service/DossierInvestigationAnchorBuilderService.java
@@ -8,12 +8,9 @@ import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.investigation
 import com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1.MoisSalesPageRepository;
 import com.marketinghub.repository.jpa.mois.dossieproduto.PipelineDossieProdutoRepository;
 import com.marketinghub.repository.jpa.mois.dossieproduto.entity.PipelineDossieProduto;
-import java.nio.charset.StandardCharsets;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
 import java.time.Instant;
-import java.util.HexFormat;
 import java.util.List;
+import java.util.UUID;
 import java.util.Map;
 import org.springframework.stereotype.Service;
 
@@ -38,23 +35,32 @@ public class DossierInvestigationAnchorBuilderService {
     private static final String STATUS_COMPLETED = "CONCLUIDO";
     private static final String STATUS_FAILED = "FALHA";
 
-    /** Marca a página/produto como iniciado no dossiê e posiciona a etapa atual. */
+    /** Marca a página/produto como iniciado no dossiê, cria o jobId UUID e posiciona a etapa atual. */
     public void start(String productKey) {
         long pageId = Long.parseLong(productKey);
+        Instant now = Instant.now();
+        String jobId = UUID.randomUUID().toString();
         var page = salesPageRepository.findById(pageId)
                 .orElseThrow(() -> new IllegalArgumentException("Página/produto MOIS não encontrada: " + productKey));
         page.setDossieProdutoStatus(STATUS_STARTED);
         page.setDossieProdutoCurrentStage(STAGE_CODE);
-        page.setDossieProdutoUpdatedAt(Instant.now());
+        page.setDossieProdutoUpdatedAt(now);
         salesPageRepository.save(page);
+
+        PipelineDossieProduto pipeline = new PipelineDossieProduto();
+        pipeline.setIdExterno(productKey);
+        pipeline.setCodigoEtapa(STAGE_CODE);
+        pipeline.setDataHora(now);
+        pipeline.setJobId(jobId);
+        pipeline.setVersaoPipeline("v1");
+        pipelineDossieProdutoRepository.save(pipeline);
     }
 
 
     /** Recebe o request operacional da etapa, coloca a página em espera do módulo e audita a entrada do pipeline. */
-    public DossierInvestigationAnchorBuilderRecebeRequestResponse recebeRequest(String productKey, DossierInvestigationAnchorBuilderRecebeRequestRequest request) {
+    public DossierInvestigationAnchorBuilderRecebeRequestResponse recebeRequest(String productKey, String jobId, DossierInvestigationAnchorBuilderRecebeRequestRequest request) {
         long pageId = Long.parseLong(productKey);
         Instant now = Instant.now();
-        String jobId = createJobId(productKey, now);
         var page = salesPageRepository.findById(pageId)
                 .orElseThrow(() -> new IllegalArgumentException("Página/produto MOIS não encontrada: " + productKey));
         page.setDossieProdutoStatus(STATUS_WAITING);
@@ -77,35 +83,37 @@ public class DossierInvestigationAnchorBuilderService {
         return new DossierInvestigationAnchorBuilderRecebeRequestResponse(jobId, productKey, STAGE_CODE, STATUS_WAITING);
     }
 
-    /** Cria um hash operacional para rastrear a entrada recebida nesta etapa. */
-    private String createJobId(String productKey, Instant now) {
-        try {
-            MessageDigest digest = MessageDigest.getInstance("SHA-256");
-            byte[] hash = digest.digest((STAGE_CODE + "|" + productKey + "|" + now).getBytes(StandardCharsets.UTF_8));
-            return HexFormat.of().formatHex(hash);
-        } catch (NoSuchAlgorithmException ex) {
-            throw new IllegalStateException("Não foi possível criar jobId do dossiê MOIS", ex);
-        }
-    }
-
     /** Entrega até dez trabalhos iniciados da etapa atual ao executor, ordenados pela data operacional mais antiga. */
     public DossierInvestigationAnchorBuilderPendingResponse pending(DossierInvestigationAnchorBuilderPendingRequest request) {
         List<DossierInvestigationAnchorBuilderPendingJob> jobs = salesPageRepository
                 .findTop10ByDossieProdutoStatusAndDossieProdutoCurrentStageOrderByDossieProdutoUpdatedAtAscIdAsc(
                         STATUS_STARTED, STAGE_CODE)
                 .stream()
-                .map(page -> new DossierInvestigationAnchorBuilderPendingJob(
+                .map(page -> {
+                    String jobId = resolveJobId(String.valueOf(page.getId()));
+                    return new DossierInvestigationAnchorBuilderPendingJob(
+                        jobId,
                         page.getId(),
                         page.getId(),
                         "mois-sales-page-" + page.getId(),
                         STAGE_CODE,
                         Map.of(
+                                "jobId", jobId,
                                 "productKey", String.valueOf(page.getId()),
                                 "pageId", page.getId(),
                                 "stageCode", STAGE_CODE,
                                 "status", STATUS_STARTED,
-                                "nextStageCode", NEXT_STAGE)))
+                                "nextStageCode", NEXT_STAGE));
+                })
                 .toList();
         return new DossierInvestigationAnchorBuilderPendingResponse(!jobs.isEmpty(), jobs);
+    }
+    /** Recupera o jobId UUID criado no start para compor o contrato pending da etapa. */
+    private String resolveJobId(String productKey) {
+        return pipelineDossieProdutoRepository
+                .findTopByIdExternoAndCodigoEtapaOrderByDataHoraDescIdDesc(productKey, STAGE_CODE)
+                .map(PipelineDossieProduto::getJobId)
+                .orElseThrow(() -> new IllegalStateException(
+                        "JobId do dossiê MOIS não encontrado para produto " + productKey + " na etapa " + STAGE_CODE));
     }
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/investigationanchorbuilder/service/pending/DossierInvestigationAnchorBuilderPendingJob.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/investigationanchorbuilder/service/pending/DossierInvestigationAnchorBuilderPendingJob.java
@@ -3,5 +3,5 @@ package com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.investigatio
 import java.util.Map;
 
 /** Contrato de trabalho pendente entregue ao executor da etapa geração de âncoras de investigação do dossiê MOIS v1. */
-public record DossierInvestigationAnchorBuilderPendingJob(long stageExecutionId, long dossierId, String workspaceId, String stageName, Map<String, Object> input) {
+public record DossierInvestigationAnchorBuilderPendingJob(String jobId, long stageExecutionId, long dossierId, String workspaceId, String stageName, Map<String, Object> input) {
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/productunderstanding/controller/DossierProductUnderstandingController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/productunderstanding/controller/DossierProductUnderstandingController.java
@@ -30,11 +30,12 @@ public class DossierProductUnderstandingController {
 
 
     /** Recebe o request do módulo executor para a página/produto informada pela chave operacional. */
-    @PostMapping("/{productKey}/recebeRequest")
+    @PostMapping("/{productKey}/{jobId}/recebeRequest")
     public DossierProductUnderstandingRecebeRequestResponse recebeRequest(
             @PathVariable("productKey") String productKey,
+            @PathVariable("jobId") String jobId,
             @Valid @RequestBody DossierProductUnderstandingRecebeRequestRequest request) {
-        return service.recebeRequest(productKey, request);
+        return service.recebeRequest(productKey, jobId, request);
     }
 
     /** Expõe o ponto inicial canônico de consumo da fila pelo módulo executor. */

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/productunderstanding/service/DossierProductUnderstandingService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/productunderstanding/service/DossierProductUnderstandingService.java
@@ -8,12 +8,9 @@ import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.productunders
 import com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1.MoisSalesPageRepository;
 import com.marketinghub.repository.jpa.mois.dossieproduto.PipelineDossieProdutoRepository;
 import com.marketinghub.repository.jpa.mois.dossieproduto.entity.PipelineDossieProduto;
-import java.nio.charset.StandardCharsets;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
 import java.time.Instant;
-import java.util.HexFormat;
 import java.util.List;
+import java.util.UUID;
 import java.util.Map;
 import org.springframework.stereotype.Service;
 
@@ -38,23 +35,32 @@ public class DossierProductUnderstandingService {
     private static final String STATUS_COMPLETED = "CONCLUIDO";
     private static final String STATUS_FAILED = "FALHA";
 
-    /** Marca a página/produto como iniciado no dossiê e posiciona a etapa atual. */
+    /** Marca a página/produto como iniciado no dossiê, cria o jobId UUID e posiciona a etapa atual. */
     public void start(String productKey) {
         long pageId = Long.parseLong(productKey);
+        Instant now = Instant.now();
+        String jobId = UUID.randomUUID().toString();
         var page = salesPageRepository.findById(pageId)
                 .orElseThrow(() -> new IllegalArgumentException("Página/produto MOIS não encontrada: " + productKey));
         page.setDossieProdutoStatus(STATUS_STARTED);
         page.setDossieProdutoCurrentStage(STAGE_CODE);
-        page.setDossieProdutoUpdatedAt(Instant.now());
+        page.setDossieProdutoUpdatedAt(now);
         salesPageRepository.save(page);
+
+        PipelineDossieProduto pipeline = new PipelineDossieProduto();
+        pipeline.setIdExterno(productKey);
+        pipeline.setCodigoEtapa(STAGE_CODE);
+        pipeline.setDataHora(now);
+        pipeline.setJobId(jobId);
+        pipeline.setVersaoPipeline("v1");
+        pipelineDossieProdutoRepository.save(pipeline);
     }
 
 
     /** Recebe o request operacional da etapa, coloca a página em espera do módulo e audita a entrada do pipeline. */
-    public DossierProductUnderstandingRecebeRequestResponse recebeRequest(String productKey, DossierProductUnderstandingRecebeRequestRequest request) {
+    public DossierProductUnderstandingRecebeRequestResponse recebeRequest(String productKey, String jobId, DossierProductUnderstandingRecebeRequestRequest request) {
         long pageId = Long.parseLong(productKey);
         Instant now = Instant.now();
-        String jobId = createJobId(productKey, now);
         var page = salesPageRepository.findById(pageId)
                 .orElseThrow(() -> new IllegalArgumentException("Página/produto MOIS não encontrada: " + productKey));
         page.setDossieProdutoStatus(STATUS_WAITING);
@@ -77,35 +83,37 @@ public class DossierProductUnderstandingService {
         return new DossierProductUnderstandingRecebeRequestResponse(jobId, productKey, STAGE_CODE, STATUS_WAITING);
     }
 
-    /** Cria um hash operacional para rastrear a entrada recebida nesta etapa. */
-    private String createJobId(String productKey, Instant now) {
-        try {
-            MessageDigest digest = MessageDigest.getInstance("SHA-256");
-            byte[] hash = digest.digest((STAGE_CODE + "|" + productKey + "|" + now).getBytes(StandardCharsets.UTF_8));
-            return HexFormat.of().formatHex(hash);
-        } catch (NoSuchAlgorithmException ex) {
-            throw new IllegalStateException("Não foi possível criar jobId do dossiê MOIS", ex);
-        }
-    }
-
     /** Entrega até dez trabalhos iniciados da etapa atual ao executor, ordenados pela data operacional mais antiga. */
     public DossierProductUnderstandingPendingResponse pending(DossierProductUnderstandingPendingRequest request) {
         List<DossierProductUnderstandingPendingJob> jobs = salesPageRepository
                 .findTop10ByDossieProdutoStatusAndDossieProdutoCurrentStageOrderByDossieProdutoUpdatedAtAscIdAsc(
                         STATUS_STARTED, STAGE_CODE)
                 .stream()
-                .map(page -> new DossierProductUnderstandingPendingJob(
+                .map(page -> {
+                    String jobId = resolveJobId(String.valueOf(page.getId()));
+                    return new DossierProductUnderstandingPendingJob(
+                        jobId,
                         page.getId(),
                         page.getId(),
                         "mois-sales-page-" + page.getId(),
                         STAGE_CODE,
                         Map.of(
+                                "jobId", jobId,
                                 "productKey", String.valueOf(page.getId()),
                                 "pageId", page.getId(),
                                 "stageCode", STAGE_CODE,
                                 "status", STATUS_STARTED,
-                                "nextStageCode", NEXT_STAGE)))
+                                "nextStageCode", NEXT_STAGE));
+                })
                 .toList();
         return new DossierProductUnderstandingPendingResponse(!jobs.isEmpty(), jobs);
+    }
+    /** Recupera o jobId UUID criado no start para compor o contrato pending da etapa. */
+    private String resolveJobId(String productKey) {
+        return pipelineDossieProdutoRepository
+                .findTopByIdExternoAndCodigoEtapaOrderByDataHoraDescIdDesc(productKey, STAGE_CODE)
+                .map(PipelineDossieProduto::getJobId)
+                .orElseThrow(() -> new IllegalStateException(
+                        "JobId do dossiê MOIS não encontrado para produto " + productKey + " na etapa " + STAGE_CODE));
     }
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/productunderstanding/service/pending/DossierProductUnderstandingPendingJob.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/productunderstanding/service/pending/DossierProductUnderstandingPendingJob.java
@@ -3,5 +3,5 @@ package com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.productunder
 import java.util.Map;
 
 /** Contrato de trabalho pendente entregue ao executor da etapa entendimento do produto do dossiê MOIS v1. */
-public record DossierProductUnderstandingPendingJob(long stageExecutionId, long dossierId, String workspaceId, String stageName, Map<String, Object> input) {
+public record DossierProductUnderstandingPendingJob(String jobId, long stageExecutionId, long dossierId, String workspaceId, String stageName, Map<String, Object> input) {
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/sourceproductmatch/controller/DossierSourceProductMatchController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/sourceproductmatch/controller/DossierSourceProductMatchController.java
@@ -30,11 +30,12 @@ public class DossierSourceProductMatchController {
 
 
     /** Recebe o request do módulo executor para a página/produto informada pela chave operacional. */
-    @PostMapping("/{productKey}/recebeRequest")
+    @PostMapping("/{productKey}/{jobId}/recebeRequest")
     public DossierSourceProductMatchRecebeRequestResponse recebeRequest(
             @PathVariable("productKey") String productKey,
+            @PathVariable("jobId") String jobId,
             @Valid @RequestBody DossierSourceProductMatchRecebeRequestRequest request) {
-        return service.recebeRequest(productKey, request);
+        return service.recebeRequest(productKey, jobId, request);
     }
 
     /** Expõe o ponto inicial canônico de consumo da fila pelo módulo executor. */

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/sourceproductmatch/service/DossierSourceProductMatchService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/sourceproductmatch/service/DossierSourceProductMatchService.java
@@ -8,12 +8,9 @@ import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.sourceproduct
 import com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1.MoisSalesPageRepository;
 import com.marketinghub.repository.jpa.mois.dossieproduto.PipelineDossieProdutoRepository;
 import com.marketinghub.repository.jpa.mois.dossieproduto.entity.PipelineDossieProduto;
-import java.nio.charset.StandardCharsets;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
 import java.time.Instant;
-import java.util.HexFormat;
 import java.util.List;
+import java.util.UUID;
 import java.util.Map;
 import org.springframework.stereotype.Service;
 
@@ -38,23 +35,32 @@ public class DossierSourceProductMatchService {
     private static final String STATUS_COMPLETED = "CONCLUIDO";
     private static final String STATUS_FAILED = "FALHA";
 
-    /** Marca a página/produto como iniciado no dossiê e posiciona a etapa atual. */
+    /** Marca a página/produto como iniciado no dossiê, cria o jobId UUID e posiciona a etapa atual. */
     public void start(String productKey) {
         long pageId = Long.parseLong(productKey);
+        Instant now = Instant.now();
+        String jobId = UUID.randomUUID().toString();
         var page = salesPageRepository.findById(pageId)
                 .orElseThrow(() -> new IllegalArgumentException("Página/produto MOIS não encontrada: " + productKey));
         page.setDossieProdutoStatus(STATUS_STARTED);
         page.setDossieProdutoCurrentStage(STAGE_CODE);
-        page.setDossieProdutoUpdatedAt(Instant.now());
+        page.setDossieProdutoUpdatedAt(now);
         salesPageRepository.save(page);
+
+        PipelineDossieProduto pipeline = new PipelineDossieProduto();
+        pipeline.setIdExterno(productKey);
+        pipeline.setCodigoEtapa(STAGE_CODE);
+        pipeline.setDataHora(now);
+        pipeline.setJobId(jobId);
+        pipeline.setVersaoPipeline("v1");
+        pipelineDossieProdutoRepository.save(pipeline);
     }
 
 
     /** Recebe o request operacional da etapa, coloca a página em espera do módulo e audita a entrada do pipeline. */
-    public DossierSourceProductMatchRecebeRequestResponse recebeRequest(String productKey, DossierSourceProductMatchRecebeRequestRequest request) {
+    public DossierSourceProductMatchRecebeRequestResponse recebeRequest(String productKey, String jobId, DossierSourceProductMatchRecebeRequestRequest request) {
         long pageId = Long.parseLong(productKey);
         Instant now = Instant.now();
-        String jobId = createJobId(productKey, now);
         var page = salesPageRepository.findById(pageId)
                 .orElseThrow(() -> new IllegalArgumentException("Página/produto MOIS não encontrada: " + productKey));
         page.setDossieProdutoStatus(STATUS_WAITING);
@@ -77,35 +83,37 @@ public class DossierSourceProductMatchService {
         return new DossierSourceProductMatchRecebeRequestResponse(jobId, productKey, STAGE_CODE, STATUS_WAITING);
     }
 
-    /** Cria um hash operacional para rastrear a entrada recebida nesta etapa. */
-    private String createJobId(String productKey, Instant now) {
-        try {
-            MessageDigest digest = MessageDigest.getInstance("SHA-256");
-            byte[] hash = digest.digest((STAGE_CODE + "|" + productKey + "|" + now).getBytes(StandardCharsets.UTF_8));
-            return HexFormat.of().formatHex(hash);
-        } catch (NoSuchAlgorithmException ex) {
-            throw new IllegalStateException("Não foi possível criar jobId do dossiê MOIS", ex);
-        }
-    }
-
     /** Entrega até dez trabalhos iniciados da etapa atual ao executor, ordenados pela data operacional mais antiga. */
     public DossierSourceProductMatchPendingResponse pending(DossierSourceProductMatchPendingRequest request) {
         List<DossierSourceProductMatchPendingJob> jobs = salesPageRepository
                 .findTop10ByDossieProdutoStatusAndDossieProdutoCurrentStageOrderByDossieProdutoUpdatedAtAscIdAsc(
                         STATUS_STARTED, STAGE_CODE)
                 .stream()
-                .map(page -> new DossierSourceProductMatchPendingJob(
+                .map(page -> {
+                    String jobId = resolveJobId(String.valueOf(page.getId()));
+                    return new DossierSourceProductMatchPendingJob(
+                        jobId,
                         page.getId(),
                         page.getId(),
                         "mois-sales-page-" + page.getId(),
                         STAGE_CODE,
                         Map.of(
+                                "jobId", jobId,
                                 "productKey", String.valueOf(page.getId()),
                                 "pageId", page.getId(),
                                 "stageCode", STAGE_CODE,
                                 "status", STATUS_STARTED,
-                                "nextStageCode", NEXT_STAGE)))
+                                "nextStageCode", NEXT_STAGE));
+                })
                 .toList();
         return new DossierSourceProductMatchPendingResponse(!jobs.isEmpty(), jobs);
+    }
+    /** Recupera o jobId UUID criado no start para compor o contrato pending da etapa. */
+    private String resolveJobId(String productKey) {
+        return pipelineDossieProdutoRepository
+                .findTopByIdExternoAndCodigoEtapaOrderByDataHoraDescIdDesc(productKey, STAGE_CODE)
+                .map(PipelineDossieProduto::getJobId)
+                .orElseThrow(() -> new IllegalStateException(
+                        "JobId do dossiê MOIS não encontrado para produto " + productKey + " na etapa " + STAGE_CODE));
     }
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/sourceproductmatch/service/pending/DossierSourceProductMatchPendingJob.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/sourceproductmatch/service/pending/DossierSourceProductMatchPendingJob.java
@@ -3,5 +3,5 @@ package com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.sourceproduc
 import java.util.Map;
 
 /** Contrato de trabalho pendente entregue ao executor da etapa validação de relação fonte-produto do dossiê MOIS v1. */
-public record DossierSourceProductMatchPendingJob(long stageExecutionId, long dossierId, String workspaceId, String stageName, Map<String, Object> input) {
+public record DossierSourceProductMatchPendingJob(String jobId, long stageExecutionId, long dossierId, String workspaceId, String stageName, Map<String, Object> input) {
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/warmupmapbuilder/controller/DossierWarmupMapBuilderController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/warmupmapbuilder/controller/DossierWarmupMapBuilderController.java
@@ -30,11 +30,12 @@ public class DossierWarmupMapBuilderController {
 
 
     /** Recebe o request do módulo executor para a página/produto informada pela chave operacional. */
-    @PostMapping("/{productKey}/recebeRequest")
+    @PostMapping("/{productKey}/{jobId}/recebeRequest")
     public DossierWarmupMapBuilderRecebeRequestResponse recebeRequest(
             @PathVariable("productKey") String productKey,
+            @PathVariable("jobId") String jobId,
             @Valid @RequestBody DossierWarmupMapBuilderRecebeRequestRequest request) {
-        return service.recebeRequest(productKey, request);
+        return service.recebeRequest(productKey, jobId, request);
     }
 
     /** Expõe o ponto inicial canônico de consumo da fila pelo módulo executor. */

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/warmupmapbuilder/service/DossierWarmupMapBuilderService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/warmupmapbuilder/service/DossierWarmupMapBuilderService.java
@@ -8,12 +8,9 @@ import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.warmupmapbuil
 import com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1.MoisSalesPageRepository;
 import com.marketinghub.repository.jpa.mois.dossieproduto.PipelineDossieProdutoRepository;
 import com.marketinghub.repository.jpa.mois.dossieproduto.entity.PipelineDossieProduto;
-import java.nio.charset.StandardCharsets;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
 import java.time.Instant;
-import java.util.HexFormat;
 import java.util.List;
+import java.util.UUID;
 import java.util.Map;
 import org.springframework.stereotype.Service;
 
@@ -38,23 +35,32 @@ public class DossierWarmupMapBuilderService {
     private static final String STATUS_COMPLETED = "CONCLUIDO";
     private static final String STATUS_FAILED = "FALHA";
 
-    /** Marca a página/produto como iniciado no dossiê e posiciona a etapa atual. */
+    /** Marca a página/produto como iniciado no dossiê, cria o jobId UUID e posiciona a etapa atual. */
     public void start(String productKey) {
         long pageId = Long.parseLong(productKey);
+        Instant now = Instant.now();
+        String jobId = UUID.randomUUID().toString();
         var page = salesPageRepository.findById(pageId)
                 .orElseThrow(() -> new IllegalArgumentException("Página/produto MOIS não encontrada: " + productKey));
         page.setDossieProdutoStatus(STATUS_STARTED);
         page.setDossieProdutoCurrentStage(STAGE_CODE);
-        page.setDossieProdutoUpdatedAt(Instant.now());
+        page.setDossieProdutoUpdatedAt(now);
         salesPageRepository.save(page);
+
+        PipelineDossieProduto pipeline = new PipelineDossieProduto();
+        pipeline.setIdExterno(productKey);
+        pipeline.setCodigoEtapa(STAGE_CODE);
+        pipeline.setDataHora(now);
+        pipeline.setJobId(jobId);
+        pipeline.setVersaoPipeline("v1");
+        pipelineDossieProdutoRepository.save(pipeline);
     }
 
 
     /** Recebe o request operacional da etapa, coloca a página em espera do módulo e audita a entrada do pipeline. */
-    public DossierWarmupMapBuilderRecebeRequestResponse recebeRequest(String productKey, DossierWarmupMapBuilderRecebeRequestRequest request) {
+    public DossierWarmupMapBuilderRecebeRequestResponse recebeRequest(String productKey, String jobId, DossierWarmupMapBuilderRecebeRequestRequest request) {
         long pageId = Long.parseLong(productKey);
         Instant now = Instant.now();
-        String jobId = createJobId(productKey, now);
         var page = salesPageRepository.findById(pageId)
                 .orElseThrow(() -> new IllegalArgumentException("Página/produto MOIS não encontrada: " + productKey));
         page.setDossieProdutoStatus(STATUS_WAITING);
@@ -77,35 +83,37 @@ public class DossierWarmupMapBuilderService {
         return new DossierWarmupMapBuilderRecebeRequestResponse(jobId, productKey, STAGE_CODE, STATUS_WAITING);
     }
 
-    /** Cria um hash operacional para rastrear a entrada recebida nesta etapa. */
-    private String createJobId(String productKey, Instant now) {
-        try {
-            MessageDigest digest = MessageDigest.getInstance("SHA-256");
-            byte[] hash = digest.digest((STAGE_CODE + "|" + productKey + "|" + now).getBytes(StandardCharsets.UTF_8));
-            return HexFormat.of().formatHex(hash);
-        } catch (NoSuchAlgorithmException ex) {
-            throw new IllegalStateException("Não foi possível criar jobId do dossiê MOIS", ex);
-        }
-    }
-
     /** Entrega até dez trabalhos iniciados da etapa atual ao executor, ordenados pela data operacional mais antiga. */
     public DossierWarmupMapBuilderPendingResponse pending(DossierWarmupMapBuilderPendingRequest request) {
         List<DossierWarmupMapBuilderPendingJob> jobs = salesPageRepository
                 .findTop10ByDossieProdutoStatusAndDossieProdutoCurrentStageOrderByDossieProdutoUpdatedAtAscIdAsc(
                         STATUS_STARTED, STAGE_CODE)
                 .stream()
-                .map(page -> new DossierWarmupMapBuilderPendingJob(
+                .map(page -> {
+                    String jobId = resolveJobId(String.valueOf(page.getId()));
+                    return new DossierWarmupMapBuilderPendingJob(
+                        jobId,
                         page.getId(),
                         page.getId(),
                         "mois-sales-page-" + page.getId(),
                         STAGE_CODE,
                         Map.of(
+                                "jobId", jobId,
                                 "productKey", String.valueOf(page.getId()),
                                 "pageId", page.getId(),
                                 "stageCode", STAGE_CODE,
                                 "status", STATUS_STARTED,
-                                "nextStageCode", NEXT_STAGE)))
+                                "nextStageCode", NEXT_STAGE));
+                })
                 .toList();
         return new DossierWarmupMapBuilderPendingResponse(!jobs.isEmpty(), jobs);
+    }
+    /** Recupera o jobId UUID criado no start para compor o contrato pending da etapa. */
+    private String resolveJobId(String productKey) {
+        return pipelineDossieProdutoRepository
+                .findTopByIdExternoAndCodigoEtapaOrderByDataHoraDescIdDesc(productKey, STAGE_CODE)
+                .map(PipelineDossieProduto::getJobId)
+                .orElseThrow(() -> new IllegalStateException(
+                        "JobId do dossiê MOIS não encontrado para produto " + productKey + " na etapa " + STAGE_CODE));
     }
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/warmupmapbuilder/service/pending/DossierWarmupMapBuilderPendingJob.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/warmupmapbuilder/service/pending/DossierWarmupMapBuilderPendingJob.java
@@ -3,5 +3,5 @@ package com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.warmupmapbui
 import java.util.Map;
 
 /** Contrato de trabalho pendente entregue ao executor da etapa montagem do mapa de aquecimento do dossiê MOIS v1. */
-public record DossierWarmupMapBuilderPendingJob(long stageExecutionId, long dossierId, String workspaceId, String stageName, Map<String, Object> input) {
+public record DossierWarmupMapBuilderPendingJob(String jobId, long stageExecutionId, long dossierId, String workspaceId, String stageName, Map<String, Object> input) {
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/warmupresourcediscovery/controller/DossierWarmupResourceDiscoveryController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/warmupresourcediscovery/controller/DossierWarmupResourceDiscoveryController.java
@@ -30,11 +30,12 @@ public class DossierWarmupResourceDiscoveryController {
 
 
     /** Recebe o request do módulo executor para a página/produto informada pela chave operacional. */
-    @PostMapping("/{productKey}/recebeRequest")
+    @PostMapping("/{productKey}/{jobId}/recebeRequest")
     public DossierWarmupResourceDiscoveryRecebeRequestResponse recebeRequest(
             @PathVariable("productKey") String productKey,
+            @PathVariable("jobId") String jobId,
             @Valid @RequestBody DossierWarmupResourceDiscoveryRecebeRequestRequest request) {
-        return service.recebeRequest(productKey, request);
+        return service.recebeRequest(productKey, jobId, request);
     }
 
     /** Expõe o ponto inicial canônico de consumo da fila pelo módulo executor. */

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/warmupresourcediscovery/service/DossierWarmupResourceDiscoveryService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/warmupresourcediscovery/service/DossierWarmupResourceDiscoveryService.java
@@ -8,12 +8,9 @@ import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.warmupresourc
 import com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1.MoisSalesPageRepository;
 import com.marketinghub.repository.jpa.mois.dossieproduto.PipelineDossieProdutoRepository;
 import com.marketinghub.repository.jpa.mois.dossieproduto.entity.PipelineDossieProduto;
-import java.nio.charset.StandardCharsets;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
 import java.time.Instant;
-import java.util.HexFormat;
 import java.util.List;
+import java.util.UUID;
 import java.util.Map;
 import org.springframework.stereotype.Service;
 
@@ -38,23 +35,32 @@ public class DossierWarmupResourceDiscoveryService {
     private static final String STATUS_COMPLETED = "CONCLUIDO";
     private static final String STATUS_FAILED = "FALHA";
 
-    /** Marca a página/produto como iniciado no dossiê e posiciona a etapa atual. */
+    /** Marca a página/produto como iniciado no dossiê, cria o jobId UUID e posiciona a etapa atual. */
     public void start(String productKey) {
         long pageId = Long.parseLong(productKey);
+        Instant now = Instant.now();
+        String jobId = UUID.randomUUID().toString();
         var page = salesPageRepository.findById(pageId)
                 .orElseThrow(() -> new IllegalArgumentException("Página/produto MOIS não encontrada: " + productKey));
         page.setDossieProdutoStatus(STATUS_STARTED);
         page.setDossieProdutoCurrentStage(STAGE_CODE);
-        page.setDossieProdutoUpdatedAt(Instant.now());
+        page.setDossieProdutoUpdatedAt(now);
         salesPageRepository.save(page);
+
+        PipelineDossieProduto pipeline = new PipelineDossieProduto();
+        pipeline.setIdExterno(productKey);
+        pipeline.setCodigoEtapa(STAGE_CODE);
+        pipeline.setDataHora(now);
+        pipeline.setJobId(jobId);
+        pipeline.setVersaoPipeline("v1");
+        pipelineDossieProdutoRepository.save(pipeline);
     }
 
 
     /** Recebe o request operacional da etapa, coloca a página em espera do módulo e audita a entrada do pipeline. */
-    public DossierWarmupResourceDiscoveryRecebeRequestResponse recebeRequest(String productKey, DossierWarmupResourceDiscoveryRecebeRequestRequest request) {
+    public DossierWarmupResourceDiscoveryRecebeRequestResponse recebeRequest(String productKey, String jobId, DossierWarmupResourceDiscoveryRecebeRequestRequest request) {
         long pageId = Long.parseLong(productKey);
         Instant now = Instant.now();
-        String jobId = createJobId(productKey, now);
         var page = salesPageRepository.findById(pageId)
                 .orElseThrow(() -> new IllegalArgumentException("Página/produto MOIS não encontrada: " + productKey));
         page.setDossieProdutoStatus(STATUS_WAITING);
@@ -77,35 +83,37 @@ public class DossierWarmupResourceDiscoveryService {
         return new DossierWarmupResourceDiscoveryRecebeRequestResponse(jobId, productKey, STAGE_CODE, STATUS_WAITING);
     }
 
-    /** Cria um hash operacional para rastrear a entrada recebida nesta etapa. */
-    private String createJobId(String productKey, Instant now) {
-        try {
-            MessageDigest digest = MessageDigest.getInstance("SHA-256");
-            byte[] hash = digest.digest((STAGE_CODE + "|" + productKey + "|" + now).getBytes(StandardCharsets.UTF_8));
-            return HexFormat.of().formatHex(hash);
-        } catch (NoSuchAlgorithmException ex) {
-            throw new IllegalStateException("Não foi possível criar jobId do dossiê MOIS", ex);
-        }
-    }
-
     /** Entrega até dez trabalhos iniciados da etapa atual ao executor, ordenados pela data operacional mais antiga. */
     public DossierWarmupResourceDiscoveryPendingResponse pending(DossierWarmupResourceDiscoveryPendingRequest request) {
         List<DossierWarmupResourceDiscoveryPendingJob> jobs = salesPageRepository
                 .findTop10ByDossieProdutoStatusAndDossieProdutoCurrentStageOrderByDossieProdutoUpdatedAtAscIdAsc(
                         STATUS_STARTED, STAGE_CODE)
                 .stream()
-                .map(page -> new DossierWarmupResourceDiscoveryPendingJob(
+                .map(page -> {
+                    String jobId = resolveJobId(String.valueOf(page.getId()));
+                    return new DossierWarmupResourceDiscoveryPendingJob(
+                        jobId,
                         page.getId(),
                         page.getId(),
                         "mois-sales-page-" + page.getId(),
                         STAGE_CODE,
                         Map.of(
+                                "jobId", jobId,
                                 "productKey", String.valueOf(page.getId()),
                                 "pageId", page.getId(),
                                 "stageCode", STAGE_CODE,
                                 "status", STATUS_STARTED,
-                                "nextStageCode", NEXT_STAGE)))
+                                "nextStageCode", NEXT_STAGE));
+                })
                 .toList();
         return new DossierWarmupResourceDiscoveryPendingResponse(!jobs.isEmpty(), jobs);
+    }
+    /** Recupera o jobId UUID criado no start para compor o contrato pending da etapa. */
+    private String resolveJobId(String productKey) {
+        return pipelineDossieProdutoRepository
+                .findTopByIdExternoAndCodigoEtapaOrderByDataHoraDescIdDesc(productKey, STAGE_CODE)
+                .map(PipelineDossieProduto::getJobId)
+                .orElseThrow(() -> new IllegalStateException(
+                        "JobId do dossiê MOIS não encontrado para produto " + productKey + " na etapa " + STAGE_CODE));
     }
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/warmupresourcediscovery/service/pending/DossierWarmupResourceDiscoveryPendingJob.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/warmupresourcediscovery/service/pending/DossierWarmupResourceDiscoveryPendingJob.java
@@ -3,5 +3,5 @@ package com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.warmupresour
 import java.util.Map;
 
 /** Contrato de trabalho pendente entregue ao executor da etapa descoberta de recursos de aquecimento do dossiê MOIS v1. */
-public record DossierWarmupResourceDiscoveryPendingJob(long stageExecutionId, long dossierId, String workspaceId, String stageName, Map<String, Object> input) {
+public record DossierWarmupResourceDiscoveryPendingJob(String jobId, long stageExecutionId, long dossierId, String workspaceId, String stageName, Map<String, Object> input) {
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/warmupsignalextraction/controller/DossierWarmupSignalExtractionController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/warmupsignalextraction/controller/DossierWarmupSignalExtractionController.java
@@ -30,11 +30,12 @@ public class DossierWarmupSignalExtractionController {
 
 
     /** Recebe o request do módulo executor para a página/produto informada pela chave operacional. */
-    @PostMapping("/{productKey}/recebeRequest")
+    @PostMapping("/{productKey}/{jobId}/recebeRequest")
     public DossierWarmupSignalExtractionRecebeRequestResponse recebeRequest(
             @PathVariable("productKey") String productKey,
+            @PathVariable("jobId") String jobId,
             @Valid @RequestBody DossierWarmupSignalExtractionRecebeRequestRequest request) {
-        return service.recebeRequest(productKey, request);
+        return service.recebeRequest(productKey, jobId, request);
     }
 
     /** Expõe o ponto inicial canônico de consumo da fila pelo módulo executor. */

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/warmupsignalextraction/service/DossierWarmupSignalExtractionService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/warmupsignalextraction/service/DossierWarmupSignalExtractionService.java
@@ -8,12 +8,9 @@ import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.warmupsignale
 import com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1.MoisSalesPageRepository;
 import com.marketinghub.repository.jpa.mois.dossieproduto.PipelineDossieProdutoRepository;
 import com.marketinghub.repository.jpa.mois.dossieproduto.entity.PipelineDossieProduto;
-import java.nio.charset.StandardCharsets;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
 import java.time.Instant;
-import java.util.HexFormat;
 import java.util.List;
+import java.util.UUID;
 import java.util.Map;
 import org.springframework.stereotype.Service;
 
@@ -38,23 +35,32 @@ public class DossierWarmupSignalExtractionService {
     private static final String STATUS_COMPLETED = "CONCLUIDO";
     private static final String STATUS_FAILED = "FALHA";
 
-    /** Marca a página/produto como iniciado no dossiê e posiciona a etapa atual. */
+    /** Marca a página/produto como iniciado no dossiê, cria o jobId UUID e posiciona a etapa atual. */
     public void start(String productKey) {
         long pageId = Long.parseLong(productKey);
+        Instant now = Instant.now();
+        String jobId = UUID.randomUUID().toString();
         var page = salesPageRepository.findById(pageId)
                 .orElseThrow(() -> new IllegalArgumentException("Página/produto MOIS não encontrada: " + productKey));
         page.setDossieProdutoStatus(STATUS_STARTED);
         page.setDossieProdutoCurrentStage(STAGE_CODE);
-        page.setDossieProdutoUpdatedAt(Instant.now());
+        page.setDossieProdutoUpdatedAt(now);
         salesPageRepository.save(page);
+
+        PipelineDossieProduto pipeline = new PipelineDossieProduto();
+        pipeline.setIdExterno(productKey);
+        pipeline.setCodigoEtapa(STAGE_CODE);
+        pipeline.setDataHora(now);
+        pipeline.setJobId(jobId);
+        pipeline.setVersaoPipeline("v1");
+        pipelineDossieProdutoRepository.save(pipeline);
     }
 
 
     /** Recebe o request operacional da etapa, coloca a página em espera do módulo e audita a entrada do pipeline. */
-    public DossierWarmupSignalExtractionRecebeRequestResponse recebeRequest(String productKey, DossierWarmupSignalExtractionRecebeRequestRequest request) {
+    public DossierWarmupSignalExtractionRecebeRequestResponse recebeRequest(String productKey, String jobId, DossierWarmupSignalExtractionRecebeRequestRequest request) {
         long pageId = Long.parseLong(productKey);
         Instant now = Instant.now();
-        String jobId = createJobId(productKey, now);
         var page = salesPageRepository.findById(pageId)
                 .orElseThrow(() -> new IllegalArgumentException("Página/produto MOIS não encontrada: " + productKey));
         page.setDossieProdutoStatus(STATUS_WAITING);
@@ -77,35 +83,37 @@ public class DossierWarmupSignalExtractionService {
         return new DossierWarmupSignalExtractionRecebeRequestResponse(jobId, productKey, STAGE_CODE, STATUS_WAITING);
     }
 
-    /** Cria um hash operacional para rastrear a entrada recebida nesta etapa. */
-    private String createJobId(String productKey, Instant now) {
-        try {
-            MessageDigest digest = MessageDigest.getInstance("SHA-256");
-            byte[] hash = digest.digest((STAGE_CODE + "|" + productKey + "|" + now).getBytes(StandardCharsets.UTF_8));
-            return HexFormat.of().formatHex(hash);
-        } catch (NoSuchAlgorithmException ex) {
-            throw new IllegalStateException("Não foi possível criar jobId do dossiê MOIS", ex);
-        }
-    }
-
     /** Entrega até dez trabalhos iniciados da etapa atual ao executor, ordenados pela data operacional mais antiga. */
     public DossierWarmupSignalExtractionPendingResponse pending(DossierWarmupSignalExtractionPendingRequest request) {
         List<DossierWarmupSignalExtractionPendingJob> jobs = salesPageRepository
                 .findTop10ByDossieProdutoStatusAndDossieProdutoCurrentStageOrderByDossieProdutoUpdatedAtAscIdAsc(
                         STATUS_STARTED, STAGE_CODE)
                 .stream()
-                .map(page -> new DossierWarmupSignalExtractionPendingJob(
+                .map(page -> {
+                    String jobId = resolveJobId(String.valueOf(page.getId()));
+                    return new DossierWarmupSignalExtractionPendingJob(
+                        jobId,
                         page.getId(),
                         page.getId(),
                         "mois-sales-page-" + page.getId(),
                         STAGE_CODE,
                         Map.of(
+                                "jobId", jobId,
                                 "productKey", String.valueOf(page.getId()),
                                 "pageId", page.getId(),
                                 "stageCode", STAGE_CODE,
                                 "status", STATUS_STARTED,
-                                "nextStageCode", NEXT_STAGE)))
+                                "nextStageCode", NEXT_STAGE));
+                })
                 .toList();
         return new DossierWarmupSignalExtractionPendingResponse(!jobs.isEmpty(), jobs);
+    }
+    /** Recupera o jobId UUID criado no start para compor o contrato pending da etapa. */
+    private String resolveJobId(String productKey) {
+        return pipelineDossieProdutoRepository
+                .findTopByIdExternoAndCodigoEtapaOrderByDataHoraDescIdDesc(productKey, STAGE_CODE)
+                .map(PipelineDossieProduto::getJobId)
+                .orElseThrow(() -> new IllegalStateException(
+                        "JobId do dossiê MOIS não encontrado para produto " + productKey + " na etapa " + STAGE_CODE));
     }
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/warmupsignalextraction/service/pending/DossierWarmupSignalExtractionPendingJob.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/warmupsignalextraction/service/pending/DossierWarmupSignalExtractionPendingJob.java
@@ -3,5 +3,5 @@ package com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.warmupsignal
 import java.util.Map;
 
 /** Contrato de trabalho pendente entregue ao executor da etapa extração de sinais de aquecimento do dossiê MOIS v1. */
-public record DossierWarmupSignalExtractionPendingJob(long stageExecutionId, long dossierId, String workspaceId, String stageName, Map<String, Object> input) {
+public record DossierWarmupSignalExtractionPendingJob(String jobId, long stageExecutionId, long dossierId, String workspaceId, String stageName, Map<String, Object> input) {
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/mois/dossieproduto/PipelineDossieProdutoRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/mois/dossieproduto/PipelineDossieProdutoRepository.java
@@ -2,6 +2,7 @@ package com.marketinghub.repository.jpa.mois.dossieproduto;
 
 import com.marketinghub.repository.jpa.mois.dossieproduto.entity.PipelineDossieProduto;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 /** Repositório JPA responsável por consultar e salvar auditorias do pipeline de dossiê de produto. */
@@ -9,4 +10,8 @@ public interface PipelineDossieProdutoRepository extends JpaRepository<PipelineD
 
     /** Lista auditorias de uma execução do dossiê de produto pela ordem em que foram registradas. */
     List<PipelineDossieProduto> findByJobIdOrderByDataHoraAscIdAsc(String jobId);
+
+    /** Busca o registro operacional mais recente do produto e da etapa para recuperar o jobId ativo. */
+    Optional<PipelineDossieProduto> findTopByIdExternoAndCodigoEtapaOrderByDataHoraDescIdDesc(
+            String idExterno, String codigoEtapa);
 }

--- a/docs/registros/mois1.md
+++ b/docs/registros/mois1.md
@@ -1862,3 +1862,9 @@ Arquivos principais:
 - Implementados endpoints `recebeRequest` no backend para as etapas do pipeline `moissaleslibraryworker.dossieproduto.v1`, com identificador da página/produto na URL.
 - Cada chamada coloca a página/produto em espera do módulo, atualiza a data operacional em UTC e registra a auditoria em `pipeline_dossieproduto` com `id_externo`, `request`, etapa, `jobId`, plataforma, prompt, schema e versão `v1`.
 - Padronizados os nomes físicos das colunas operacionais da página/produto para `status_pipeline_dossieproduto` e `data_pipeline_dossieproduto` via changelog incremental.
+
+## 2026-06-27 — JobId UUID no dossiê de produto MOIS v1
+
+- Alterado o backend do fluxo `moissaleslibraryworker.dossieproduto.v1` para criar `jobId` por UUID no `/start` de cada etapa.
+- Ajustado o `/pending` para devolver cada objeto pendente acompanhado do `jobId` ativo da etapa.
+- Ajustado o `recebeRequest` para receber o `jobId` na URL junto com o identificador do objeto, mantendo a auditoria vinculada ao mesmo job iniciado.

--- a/docs/swagger/mois-dossie-v1-swagger.yaml
+++ b/docs/swagger/mois-dossie-v1-swagger.yaml
@@ -140,12 +140,17 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/DossierDossierSynthesisPendingResponse'
-  /api/internal/mois/dossie/v1/intake/stage-executions/{productKey}/recebeRequest:
+  /api/internal/mois/dossie/v1/intake/stage-executions/{productKey}/{jobId}/recebeRequest:
     post:
       summary: Recebe request operacional da etapa intake do dossiê MOIS v1
       operationId: recebeRequestMoisDossieV1IntakeStageExecutions
       parameters:
         - name: productKey
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: jobId
           in: path
           required: true
           schema:
@@ -163,12 +168,17 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/DossierIntakeRecebeRequestResponse'
-  /api/internal/mois/dossie/v1/product-understanding/stage-executions/{productKey}/recebeRequest:
+  /api/internal/mois/dossie/v1/product-understanding/stage-executions/{productKey}/{jobId}/recebeRequest:
     post:
       summary: Recebe request operacional da etapa product-understanding do dossiê MOIS v1
       operationId: recebeRequestMoisDossieV1ProductUnderstandingStageExecutions
       parameters:
         - name: productKey
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: jobId
           in: path
           required: true
           schema:
@@ -186,12 +196,17 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/DossierProductUnderstandingRecebeRequestResponse'
-  /api/internal/mois/dossie/v1/investigation-anchor-builder/stage-executions/{productKey}/recebeRequest:
+  /api/internal/mois/dossie/v1/investigation-anchor-builder/stage-executions/{productKey}/{jobId}/recebeRequest:
     post:
       summary: Recebe request operacional da etapa investigation-anchor-builder do dossiê MOIS v1
       operationId: recebeRequestMoisDossieV1InvestigationAnchorBuilderStageExecutions
       parameters:
         - name: productKey
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: jobId
           in: path
           required: true
           schema:
@@ -209,12 +224,17 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/DossierInvestigationAnchorBuilderRecebeRequestResponse'
-  /api/internal/mois/dossie/v1/warmup-resource-discovery/stage-executions/{productKey}/recebeRequest:
+  /api/internal/mois/dossie/v1/warmup-resource-discovery/stage-executions/{productKey}/{jobId}/recebeRequest:
     post:
       summary: Recebe request operacional da etapa warmup-resource-discovery do dossiê MOIS v1
       operationId: recebeRequestMoisDossieV1WarmupResourceDiscoveryStageExecutions
       parameters:
         - name: productKey
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: jobId
           in: path
           required: true
           schema:
@@ -232,12 +252,17 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/DossierWarmupResourceDiscoveryRecebeRequestResponse'
-  /api/internal/mois/dossie/v1/source-product-match/stage-executions/{productKey}/recebeRequest:
+  /api/internal/mois/dossie/v1/source-product-match/stage-executions/{productKey}/{jobId}/recebeRequest:
     post:
       summary: Recebe request operacional da etapa source-product-match do dossiê MOIS v1
       operationId: recebeRequestMoisDossieV1SourceProductMatchStageExecutions
       parameters:
         - name: productKey
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: jobId
           in: path
           required: true
           schema:
@@ -255,12 +280,17 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/DossierSourceProductMatchRecebeRequestResponse'
-  /api/internal/mois/dossie/v1/warmup-signal-extraction/stage-executions/{productKey}/recebeRequest:
+  /api/internal/mois/dossie/v1/warmup-signal-extraction/stage-executions/{productKey}/{jobId}/recebeRequest:
     post:
       summary: Recebe request operacional da etapa warmup-signal-extraction do dossiê MOIS v1
       operationId: recebeRequestMoisDossieV1WarmupSignalExtractionStageExecutions
       parameters:
         - name: productKey
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: jobId
           in: path
           required: true
           schema:
@@ -278,12 +308,17 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/DossierWarmupSignalExtractionRecebeRequestResponse'
-  /api/internal/mois/dossie/v1/warmup-map-builder/stage-executions/{productKey}/recebeRequest:
+  /api/internal/mois/dossie/v1/warmup-map-builder/stage-executions/{productKey}/{jobId}/recebeRequest:
     post:
       summary: Recebe request operacional da etapa warmup-map-builder do dossiê MOIS v1
       operationId: recebeRequestMoisDossieV1WarmupMapBuilderStageExecutions
       parameters:
         - name: productKey
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: jobId
           in: path
           required: true
           schema:
@@ -301,12 +336,17 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/DossierWarmupMapBuilderRecebeRequestResponse'
-  /api/internal/mois/dossie/v1/dossier-synthesis/stage-executions/{productKey}/recebeRequest:
+  /api/internal/mois/dossie/v1/dossier-synthesis/stage-executions/{productKey}/{jobId}/recebeRequest:
     post:
       summary: Recebe request operacional da etapa dossier-synthesis do dossiê MOIS v1
       operationId: recebeRequestMoisDossieV1DossierSynthesisStageExecutions
       parameters:
         - name: productKey
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: jobId
           in: path
           required: true
           schema:
@@ -594,12 +634,16 @@ components:
     DossierIntakePendingJob:
       type: object
       required:
+        - jobId
         - stageExecutionId
         - dossierId
         - workspaceId
         - stageName
         - input
       properties:
+        jobId:
+          type: string
+          description: JobId UUID criado pelo /start para rastrear a execução da etapa.
         stageExecutionId:
           type: integer
           format: int64
@@ -641,12 +685,16 @@ components:
     DossierProductUnderstandingPendingJob:
       type: object
       required:
+        - jobId
         - stageExecutionId
         - dossierId
         - workspaceId
         - stageName
         - input
       properties:
+        jobId:
+          type: string
+          description: JobId UUID criado pelo /start para rastrear a execução da etapa.
         stageExecutionId:
           type: integer
           format: int64
@@ -688,12 +736,16 @@ components:
     DossierInvestigationAnchorBuilderPendingJob:
       type: object
       required:
+        - jobId
         - stageExecutionId
         - dossierId
         - workspaceId
         - stageName
         - input
       properties:
+        jobId:
+          type: string
+          description: JobId UUID criado pelo /start para rastrear a execução da etapa.
         stageExecutionId:
           type: integer
           format: int64
@@ -735,12 +787,16 @@ components:
     DossierWarmupResourceDiscoveryPendingJob:
       type: object
       required:
+        - jobId
         - stageExecutionId
         - dossierId
         - workspaceId
         - stageName
         - input
       properties:
+        jobId:
+          type: string
+          description: JobId UUID criado pelo /start para rastrear a execução da etapa.
         stageExecutionId:
           type: integer
           format: int64
@@ -782,12 +838,16 @@ components:
     DossierSourceProductMatchPendingJob:
       type: object
       required:
+        - jobId
         - stageExecutionId
         - dossierId
         - workspaceId
         - stageName
         - input
       properties:
+        jobId:
+          type: string
+          description: JobId UUID criado pelo /start para rastrear a execução da etapa.
         stageExecutionId:
           type: integer
           format: int64
@@ -829,12 +889,16 @@ components:
     DossierWarmupSignalExtractionPendingJob:
       type: object
       required:
+        - jobId
         - stageExecutionId
         - dossierId
         - workspaceId
         - stageName
         - input
       properties:
+        jobId:
+          type: string
+          description: JobId UUID criado pelo /start para rastrear a execução da etapa.
         stageExecutionId:
           type: integer
           format: int64
@@ -876,12 +940,16 @@ components:
     DossierWarmupMapBuilderPendingJob:
       type: object
       required:
+        - jobId
         - stageExecutionId
         - dossierId
         - workspaceId
         - stageName
         - input
       properties:
+        jobId:
+          type: string
+          description: JobId UUID criado pelo /start para rastrear a execução da etapa.
         stageExecutionId:
           type: integer
           format: int64
@@ -923,12 +991,16 @@ components:
     DossierDossierSynthesisPendingJob:
       type: object
       required:
+        - jobId
         - stageExecutionId
         - dossierId
         - workspaceId
         - stageName
         - input
       properties:
+        jobId:
+          type: string
+          description: JobId UUID criado pelo /start para rastrear a execução da etapa.
         stageExecutionId:
           type: integer
           format: int64


### PR DESCRIPTION
### Motivation
- Ensure end-to-end traceability of pipeline executions by creating a stable `jobId` at the moment a stage is started and carrying it through the pending and callback flows. 
- Align executor-backend contract so the executor receives the `jobId` with each pending work item and returns it when calling the `recebeRequest` endpoint. 
- Provide an auditable linkage in `pipeline_dossieproduto` for all events of the same logical job to simplify debugging and reporting. 

### Description
- Changed each dossie MOIS v1 stage `start` to generate `jobId` via `UUID.randomUUID()` and persist an initial `PipelineDossieProduto` record with `jobId`, `dataHora`, `codigoEtapa` and `versaoPipeline`.
- Updated all stage `pending` implementations and pending `record` DTOs to include `jobId` as the first field and to inject `jobId` into the returned `input` object for the executor.
- Modified all stage `recebeRequest` controller routes to accept `/{productKey}/{jobId}/recebeRequest` and updated service signatures to receive the `jobId` path parameter and persist the audit row using that `jobId`.
- Added repository method `findTopByIdExternoAndCodigoEtapaOrderByDataHoraDescIdDesc` to fetch the most recent pipeline record and implemented `resolveJobId(...)` helpers in services; updated Swagger (`docs/swagger/mois-dossie-v1-swagger.yaml`) and operational registry (`docs/registros/mois1.md`).

### Testing
- Ran `./backend/mvnw -f backend/ads-service/pom.xml -DskipTests compile` which completed successfully. 
- Ran `git diff --check` (code style/whitespace checks) with no issues reported. 
- Ran `./backend/mvnw -f backend/ads-service/pom.xml test` but it failed due to a transient external dependency resolution error from Maven Central (`502 Bad Gateway` for `org.sonatype.plexus:plexus-sec-dispatcher:pom:1.3`), so unit tests could not complete end-to-end.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3f1982e0048321b38230ba84d15410)