### PR TITLE
feat: ajustar jobId no fluxo NichoCNAE v3

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/cnaeintake/controller/BackendCnaeIntakeController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/cnaeintake/controller/BackendCnaeIntakeController.java
@@ -44,10 +44,10 @@ public class BackendCnaeIntakeController {
         return service.create(null, cnaeCode, "{\"cnaeCode\":\"" + cnaeCode + "\"}", 1, 1);
     }
 
-    /** Recebe o request bruto da etapa identificado pelo CNAE. */
-    @PostMapping("/cnaes/{cnaeCode}/recebeRequest")
-    public CnaeIntakeCreateResponse recebeRequest(@PathVariable String cnaeCode, @RequestBody OprmNichoCnaeV3RecebeRequestRequest request) {
-        return service.recebeRequest(cnaeCode, request);
+    /** Recebe o request bruto da etapa identificado pelo CNAE e jobId. */
+    @PostMapping("/cnaes/{cnaeCode}/jobs/{jobId}/recebeRequest")
+    public CnaeIntakeCreateResponse recebeRequest(@PathVariable String cnaeCode, @PathVariable String jobId, @RequestBody OprmNichoCnaeV3RecebeRequestRequest request) {
+        return service.recebeRequest(cnaeCode, jobId, request);
     }
 
     /** Entrega pendências da etapa cnae-intake ao executor OPRM. */

--- a/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/cnaeintake/service/BackendCnaeIntakeService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/cnaeintake/service/BackendCnaeIntakeService.java
@@ -38,8 +38,8 @@ public class BackendCnaeIntakeService extends OprmNichoCnaeV3StageServiceSupport
     }
 
     /** Recebe o request bruto da etapa e registra auditoria para o pipeline NichoCNAE v3. */
-    public CnaeIntakeCreateResponse recebeRequest(String cnaeCode, OprmNichoCnaeV3RecebeRequestRequest request) {
-        return new CnaeIntakeCreateResponse(null, doRecebeRequest(cnaeCode, request).getJobId(), cnaeCode, STAGE_CODE, "AGUARDANDO_MODULO");
+    public CnaeIntakeCreateResponse recebeRequest(String cnaeCode, String jobId, OprmNichoCnaeV3RecebeRequestRequest request) {
+        return new CnaeIntakeCreateResponse(null, doRecebeRequest(cnaeCode, jobId, request).getJobId(), cnaeCode, STAGE_CODE, "AGUARDANDO_MODULO");
     }
 
     /** Lista pendências da etapa cnae-intake para o executor OPRM. */

--- a/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/dailytaskssynthesizer/controller/BackendDailyTasksSynthesizerController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/dailytaskssynthesizer/controller/BackendDailyTasksSynthesizerController.java
@@ -44,10 +44,10 @@ public class BackendDailyTasksSynthesizerController {
         return service.create(null, cnaeCode, "{\"cnaeCode\":\"" + cnaeCode + "\"}", 1, 1);
     }
 
-    /** Recebe o request bruto da etapa identificado pelo CNAE. */
-    @PostMapping("/cnaes/{cnaeCode}/recebeRequest")
-    public DailyTasksSynthesizerCreateResponse recebeRequest(@PathVariable String cnaeCode, @RequestBody OprmNichoCnaeV3RecebeRequestRequest request) {
-        return service.recebeRequest(cnaeCode, request);
+    /** Recebe o request bruto da etapa identificado pelo CNAE e jobId. */
+    @PostMapping("/cnaes/{cnaeCode}/jobs/{jobId}/recebeRequest")
+    public DailyTasksSynthesizerCreateResponse recebeRequest(@PathVariable String cnaeCode, @PathVariable String jobId, @RequestBody OprmNichoCnaeV3RecebeRequestRequest request) {
+        return service.recebeRequest(cnaeCode, jobId, request);
     }
 
     /** Entrega pendências da etapa daily-tasks-synthesizer ao executor OPRM. */

--- a/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/dailytaskssynthesizer/service/BackendDailyTasksSynthesizerService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/dailytaskssynthesizer/service/BackendDailyTasksSynthesizerService.java
@@ -38,8 +38,8 @@ public class BackendDailyTasksSynthesizerService extends OprmNichoCnaeV3StageSer
     }
 
     /** Recebe o request bruto da etapa e registra auditoria para o pipeline NichoCNAE v3. */
-    public DailyTasksSynthesizerCreateResponse recebeRequest(String cnaeCode, OprmNichoCnaeV3RecebeRequestRequest request) {
-        return new DailyTasksSynthesizerCreateResponse(null, doRecebeRequest(cnaeCode, request).getJobId(), cnaeCode, STAGE_CODE, "AGUARDANDO_MODULO");
+    public DailyTasksSynthesizerCreateResponse recebeRequest(String cnaeCode, String jobId, OprmNichoCnaeV3RecebeRequestRequest request) {
+        return new DailyTasksSynthesizerCreateResponse(null, doRecebeRequest(cnaeCode, jobId, request).getJobId(), cnaeCode, STAGE_CODE, "AGUARDANDO_MODULO");
     }
 
     /** Lista pendências da etapa daily-tasks-synthesizer para o executor OPRM. */

--- a/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/personacandidategenerator/controller/BackendPersonaCandidateGeneratorController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/personacandidategenerator/controller/BackendPersonaCandidateGeneratorController.java
@@ -44,10 +44,10 @@ public class BackendPersonaCandidateGeneratorController {
         return service.create(null, cnaeCode, "{\"cnaeCode\":\"" + cnaeCode + "\"}", 1, 1);
     }
 
-    /** Recebe o request bruto da etapa identificado pelo CNAE. */
-    @PostMapping("/cnaes/{cnaeCode}/recebeRequest")
-    public PersonaCandidateGeneratorCreateResponse recebeRequest(@PathVariable String cnaeCode, @RequestBody OprmNichoCnaeV3RecebeRequestRequest request) {
-        return service.recebeRequest(cnaeCode, request);
+    /** Recebe o request bruto da etapa identificado pelo CNAE e jobId. */
+    @PostMapping("/cnaes/{cnaeCode}/jobs/{jobId}/recebeRequest")
+    public PersonaCandidateGeneratorCreateResponse recebeRequest(@PathVariable String cnaeCode, @PathVariable String jobId, @RequestBody OprmNichoCnaeV3RecebeRequestRequest request) {
+        return service.recebeRequest(cnaeCode, jobId, request);
     }
 
     /** Entrega pendências da etapa persona-candidate-generator ao executor OPRM. */

--- a/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/personacandidategenerator/service/BackendPersonaCandidateGeneratorService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/personacandidategenerator/service/BackendPersonaCandidateGeneratorService.java
@@ -38,8 +38,8 @@ public class BackendPersonaCandidateGeneratorService extends OprmNichoCnaeV3Stag
     }
 
     /** Recebe o request bruto da etapa e registra auditoria para o pipeline NichoCNAE v3. */
-    public PersonaCandidateGeneratorCreateResponse recebeRequest(String cnaeCode, OprmNichoCnaeV3RecebeRequestRequest request) {
-        return new PersonaCandidateGeneratorCreateResponse(null, doRecebeRequest(cnaeCode, request).getJobId(), cnaeCode, STAGE_CODE, "AGUARDANDO_MODULO");
+    public PersonaCandidateGeneratorCreateResponse recebeRequest(String cnaeCode, String jobId, OprmNichoCnaeV3RecebeRequestRequest request) {
+        return new PersonaCandidateGeneratorCreateResponse(null, doRecebeRequest(cnaeCode, jobId, request).getJobId(), cnaeCode, STAGE_CODE, "AGUARDANDO_MODULO");
     }
 
     /** Lista pendências da etapa persona-candidate-generator para o executor OPRM. */

--- a/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/personaroutinematerializer/controller/BackendPersonaRoutineMaterializerController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/personaroutinematerializer/controller/BackendPersonaRoutineMaterializerController.java
@@ -44,10 +44,10 @@ public class BackendPersonaRoutineMaterializerController {
         return service.create(null, cnaeCode, "{\"cnaeCode\":\"" + cnaeCode + "\"}", 1, 1);
     }
 
-    /** Recebe o request bruto da etapa identificado pelo CNAE. */
-    @PostMapping("/cnaes/{cnaeCode}/recebeRequest")
-    public PersonaRoutineMaterializerCreateResponse recebeRequest(@PathVariable String cnaeCode, @RequestBody OprmNichoCnaeV3RecebeRequestRequest request) {
-        return service.recebeRequest(cnaeCode, request);
+    /** Recebe o request bruto da etapa identificado pelo CNAE e jobId. */
+    @PostMapping("/cnaes/{cnaeCode}/jobs/{jobId}/recebeRequest")
+    public PersonaRoutineMaterializerCreateResponse recebeRequest(@PathVariable String cnaeCode, @PathVariable String jobId, @RequestBody OprmNichoCnaeV3RecebeRequestRequest request) {
+        return service.recebeRequest(cnaeCode, jobId, request);
     }
 
     /** Entrega pendências da etapa persona-routine-materializer ao executor OPRM. */

--- a/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/personaroutinematerializer/service/BackendPersonaRoutineMaterializerService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/personaroutinematerializer/service/BackendPersonaRoutineMaterializerService.java
@@ -58,8 +58,8 @@ public class BackendPersonaRoutineMaterializerService extends OprmNichoCnaeV3Sta
     }
 
     /** Recebe o request bruto da etapa e registra auditoria para o pipeline NichoCNAE v3. */
-    public PersonaRoutineMaterializerCreateResponse recebeRequest(String cnaeCode, OprmNichoCnaeV3RecebeRequestRequest request) {
-        return new PersonaRoutineMaterializerCreateResponse(null, doRecebeRequest(cnaeCode, request).getJobId(), cnaeCode, STAGE_CODE, "AGUARDANDO_MODULO");
+    public PersonaRoutineMaterializerCreateResponse recebeRequest(String cnaeCode, String jobId, OprmNichoCnaeV3RecebeRequestRequest request) {
+        return new PersonaRoutineMaterializerCreateResponse(null, doRecebeRequest(cnaeCode, jobId, request).getJobId(), cnaeCode, STAGE_CODE, "AGUARDANDO_MODULO");
     }
 
     /** Lista pendências da etapa persona-routine-materializer para o executor OPRM. */

--- a/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/personatournament/controller/BackendPersonaTournamentController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/personatournament/controller/BackendPersonaTournamentController.java
@@ -44,10 +44,10 @@ public class BackendPersonaTournamentController {
         return service.create(null, cnaeCode, "{\"cnaeCode\":\"" + cnaeCode + "\"}", 1, 1);
     }
 
-    /** Recebe o request bruto da etapa identificado pelo CNAE. */
-    @PostMapping("/cnaes/{cnaeCode}/recebeRequest")
-    public PersonaTournamentCreateResponse recebeRequest(@PathVariable String cnaeCode, @RequestBody OprmNichoCnaeV3RecebeRequestRequest request) {
-        return service.recebeRequest(cnaeCode, request);
+    /** Recebe o request bruto da etapa identificado pelo CNAE e jobId. */
+    @PostMapping("/cnaes/{cnaeCode}/jobs/{jobId}/recebeRequest")
+    public PersonaTournamentCreateResponse recebeRequest(@PathVariable String cnaeCode, @PathVariable String jobId, @RequestBody OprmNichoCnaeV3RecebeRequestRequest request) {
+        return service.recebeRequest(cnaeCode, jobId, request);
     }
 
     /** Entrega pendências da etapa persona-tournament ao executor OPRM. */

--- a/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/personatournament/service/BackendPersonaTournamentService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/personatournament/service/BackendPersonaTournamentService.java
@@ -38,8 +38,8 @@ public class BackendPersonaTournamentService extends OprmNichoCnaeV3StageService
     }
 
     /** Recebe o request bruto da etapa e registra auditoria para o pipeline NichoCNAE v3. */
-    public PersonaTournamentCreateResponse recebeRequest(String cnaeCode, OprmNichoCnaeV3RecebeRequestRequest request) {
-        return new PersonaTournamentCreateResponse(null, doRecebeRequest(cnaeCode, request).getJobId(), cnaeCode, STAGE_CODE, "AGUARDANDO_MODULO");
+    public PersonaTournamentCreateResponse recebeRequest(String cnaeCode, String jobId, OprmNichoCnaeV3RecebeRequestRequest request) {
+        return new PersonaTournamentCreateResponse(null, doRecebeRequest(cnaeCode, jobId, request).getJobId(), cnaeCode, STAGE_CODE, "AGUARDANDO_MODULO");
     }
 
     /** Lista pendências da etapa persona-tournament para o executor OPRM. */

--- a/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/qualitygate/controller/BackendQualityGateController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/qualitygate/controller/BackendQualityGateController.java
@@ -44,10 +44,10 @@ public class BackendQualityGateController {
         return service.create(null, cnaeCode, "{\"cnaeCode\":\"" + cnaeCode + "\"}", 1, 1);
     }
 
-    /** Recebe o request bruto da etapa identificado pelo CNAE. */
-    @PostMapping("/cnaes/{cnaeCode}/recebeRequest")
-    public QualityGateCreateResponse recebeRequest(@PathVariable String cnaeCode, @RequestBody OprmNichoCnaeV3RecebeRequestRequest request) {
-        return service.recebeRequest(cnaeCode, request);
+    /** Recebe o request bruto da etapa identificado pelo CNAE e jobId. */
+    @PostMapping("/cnaes/{cnaeCode}/jobs/{jobId}/recebeRequest")
+    public QualityGateCreateResponse recebeRequest(@PathVariable String cnaeCode, @PathVariable String jobId, @RequestBody OprmNichoCnaeV3RecebeRequestRequest request) {
+        return service.recebeRequest(cnaeCode, jobId, request);
     }
 
     /** Entrega pendências da etapa quality-gate ao executor OPRM. */

--- a/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/qualitygate/service/BackendQualityGateService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/qualitygate/service/BackendQualityGateService.java
@@ -38,8 +38,8 @@ public class BackendQualityGateService extends OprmNichoCnaeV3StageServiceSuppor
     }
 
     /** Recebe o request bruto da etapa e registra auditoria para o pipeline NichoCNAE v3. */
-    public QualityGateCreateResponse recebeRequest(String cnaeCode, OprmNichoCnaeV3RecebeRequestRequest request) {
-        return new QualityGateCreateResponse(null, doRecebeRequest(cnaeCode, request).getJobId(), cnaeCode, STAGE_CODE, "AGUARDANDO_MODULO");
+    public QualityGateCreateResponse recebeRequest(String cnaeCode, String jobId, OprmNichoCnaeV3RecebeRequestRequest request) {
+        return new QualityGateCreateResponse(null, doRecebeRequest(cnaeCode, jobId, request).getJobId(), cnaeCode, STAGE_CODE, "AGUARDANDO_MODULO");
     }
 
     /** Lista pendências da etapa quality-gate para o executor OPRM. */

--- a/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/routinequeryplanner/controller/BackendRoutineQueryPlannerController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/routinequeryplanner/controller/BackendRoutineQueryPlannerController.java
@@ -44,10 +44,10 @@ public class BackendRoutineQueryPlannerController {
         return service.create(null, cnaeCode, "{\"cnaeCode\":\"" + cnaeCode + "\"}", 1, 1);
     }
 
-    /** Recebe o request bruto da etapa identificado pelo CNAE. */
-    @PostMapping("/cnaes/{cnaeCode}/recebeRequest")
-    public RoutineQueryPlannerCreateResponse recebeRequest(@PathVariable String cnaeCode, @RequestBody OprmNichoCnaeV3RecebeRequestRequest request) {
-        return service.recebeRequest(cnaeCode, request);
+    /** Recebe o request bruto da etapa identificado pelo CNAE e jobId. */
+    @PostMapping("/cnaes/{cnaeCode}/jobs/{jobId}/recebeRequest")
+    public RoutineQueryPlannerCreateResponse recebeRequest(@PathVariable String cnaeCode, @PathVariable String jobId, @RequestBody OprmNichoCnaeV3RecebeRequestRequest request) {
+        return service.recebeRequest(cnaeCode, jobId, request);
     }
 
     /** Entrega pendências da etapa routine-query-planner ao executor OPRM. */

--- a/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/routinequeryplanner/service/BackendRoutineQueryPlannerService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/routinequeryplanner/service/BackendRoutineQueryPlannerService.java
@@ -38,8 +38,8 @@ public class BackendRoutineQueryPlannerService extends OprmNichoCnaeV3StageServi
     }
 
     /** Recebe o request bruto da etapa e registra auditoria para o pipeline NichoCNAE v3. */
-    public RoutineQueryPlannerCreateResponse recebeRequest(String cnaeCode, OprmNichoCnaeV3RecebeRequestRequest request) {
-        return new RoutineQueryPlannerCreateResponse(null, doRecebeRequest(cnaeCode, request).getJobId(), cnaeCode, STAGE_CODE, "AGUARDANDO_MODULO");
+    public RoutineQueryPlannerCreateResponse recebeRequest(String cnaeCode, String jobId, OprmNichoCnaeV3RecebeRequestRequest request) {
+        return new RoutineQueryPlannerCreateResponse(null, doRecebeRequest(cnaeCode, jobId, request).getJobId(), cnaeCode, STAGE_CODE, "AGUARDANDO_MODULO");
     }
 
     /** Lista pendências da etapa routine-query-planner para o executor OPRM. */

--- a/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/routinesignalextractor/controller/BackendRoutineSignalExtractorController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/routinesignalextractor/controller/BackendRoutineSignalExtractorController.java
@@ -44,10 +44,10 @@ public class BackendRoutineSignalExtractorController {
         return service.create(null, cnaeCode, "{\"cnaeCode\":\"" + cnaeCode + "\"}", 1, 1);
     }
 
-    /** Recebe o request bruto da etapa identificado pelo CNAE. */
-    @PostMapping("/cnaes/{cnaeCode}/recebeRequest")
-    public RoutineSignalExtractorCreateResponse recebeRequest(@PathVariable String cnaeCode, @RequestBody OprmNichoCnaeV3RecebeRequestRequest request) {
-        return service.recebeRequest(cnaeCode, request);
+    /** Recebe o request bruto da etapa identificado pelo CNAE e jobId. */
+    @PostMapping("/cnaes/{cnaeCode}/jobs/{jobId}/recebeRequest")
+    public RoutineSignalExtractorCreateResponse recebeRequest(@PathVariable String cnaeCode, @PathVariable String jobId, @RequestBody OprmNichoCnaeV3RecebeRequestRequest request) {
+        return service.recebeRequest(cnaeCode, jobId, request);
     }
 
     /** Entrega pendências da etapa routine-signal-extractor ao executor OPRM. */

--- a/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/routinesignalextractor/service/BackendRoutineSignalExtractorService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/routinesignalextractor/service/BackendRoutineSignalExtractorService.java
@@ -38,8 +38,8 @@ public class BackendRoutineSignalExtractorService extends OprmNichoCnaeV3StageSe
     }
 
     /** Recebe o request bruto da etapa e registra auditoria para o pipeline NichoCNAE v3. */
-    public RoutineSignalExtractorCreateResponse recebeRequest(String cnaeCode, OprmNichoCnaeV3RecebeRequestRequest request) {
-        return new RoutineSignalExtractorCreateResponse(null, doRecebeRequest(cnaeCode, request).getJobId(), cnaeCode, STAGE_CODE, "AGUARDANDO_MODULO");
+    public RoutineSignalExtractorCreateResponse recebeRequest(String cnaeCode, String jobId, OprmNichoCnaeV3RecebeRequestRequest request) {
+        return new RoutineSignalExtractorCreateResponse(null, doRecebeRequest(cnaeCode, jobId, request).getJobId(), cnaeCode, STAGE_CODE, "AGUARDANDO_MODULO");
     }
 
     /** Lista pendências da etapa routine-signal-extractor para o executor OPRM. */

--- a/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/shared/OprmNichoCnaeV3StageServiceSupport.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/shared/OprmNichoCnaeV3StageServiceSupport.java
@@ -7,15 +7,14 @@ import com.marketinghub.oprm.nichocnae.PipelineNichoCnae;
 import com.marketinghub.repository.jpa.oprm.market.OprmCnpjCnaeDimRepository;
 import com.marketinghub.repository.jpa.oprm.nichocnae.v3.OprmNichoCnaeV3StageExecutionRepository;
 import com.marketinghub.repository.jpa.oprm.nichocnae.PipelineNichoCnaeRepository;
-import java.nio.charset.StandardCharsets;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
 import java.time.Instant;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.UUID;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.http.HttpStatus;
+import org.springframework.util.StringUtils;
 import org.springframework.web.server.ResponseStatusException;
 
 /** Base compartilhada para services canônicos de etapas NichoCNAE v3 sem assumir execução operacional. */
@@ -66,7 +65,10 @@ public abstract class OprmNichoCnaeV3StageServiceSupport {
 
 
     /** Recebe o request bruto da etapa, atualiza o CNAE para aguardar o módulo e audita o payload no pipeline NichoCNAE. */
-    protected PipelineNichoCnae doRecebeRequest(String cnaeCode, OprmNichoCnaeV3RecebeRequestRequest request) {
+    protected PipelineNichoCnae doRecebeRequest(String cnaeCode, String jobId, OprmNichoCnaeV3RecebeRequestRequest request) {
+        if (!StringUtils.hasText(jobId)) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "jobId é obrigatório no recebimento do request.");
+        }
         OprmCnpjCnaeDim cnae = cnaeRepository.findById(cnaeCode)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "CNAE não encontrado."));
         Instant now = Instant.now();
@@ -81,28 +83,12 @@ public abstract class OprmNichoCnaeV3StageServiceSupport {
         pipeline.setRequest(request == null ? null : request.request());
         pipeline.setCodigoEtapa(stageCode);
         pipeline.setDataHora(now);
-        pipeline.setJobId(generateJobId(cnaeCode, now));
+        pipeline.setJobId(jobId);
         pipeline.setPlataforma(request == null ? null : request.plataforma());
         pipeline.setPrompt(request == null ? null : request.prompt());
         pipeline.setSchema(request == null ? null : request.schema());
         pipeline.setVersaoPipeline(PIPELINE_VERSION);
         return pipelineNichoCnaeRepository.save(pipeline);
-    }
-
-    /** Gera hash único para rastrear o request recebido na etapa. */
-    private String generateJobId(String cnaeCode, Instant now) {
-        String source = PIPELINE_VERSION + ":" + stageCode + ":" + cnaeCode + ":" + now.toString();
-        try {
-            MessageDigest digest = MessageDigest.getInstance("SHA-256");
-            byte[] hash = digest.digest(source.getBytes(StandardCharsets.UTF_8));
-            StringBuilder builder = new StringBuilder();
-            for (byte b : hash) {
-                builder.append(String.format("%02x", b));
-            }
-            return builder.toString();
-        } catch (NoSuchAlgorithmException ex) {
-            throw new IllegalStateException("Não foi possível gerar jobId do request NichoCNAE v3.", ex);
-        }
     }
 
     /** Cria uma execução pendente para a etapa canônica. */
@@ -201,6 +187,6 @@ public abstract class OprmNichoCnaeV3StageServiceSupport {
 
     /** Monta jobId simples quando a UI iniciar o fluxo por CNAE sem identificador prévio. */
     private String defaultJobId(String cnaeCode) {
-        return "nichocnae-v3-" + cnaeCode + "-" + Instant.now().toEpochMilli();
+        return UUID.randomUUID().toString();
     }
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/sourcefetcher/controller/BackendSourceFetcherV3Controller.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/sourcefetcher/controller/BackendSourceFetcherV3Controller.java
@@ -44,10 +44,10 @@ public class BackendSourceFetcherV3Controller {
         return service.create(null, cnaeCode, "{\"cnaeCode\":\"" + cnaeCode + "\"}", 1, 1);
     }
 
-    /** Recebe o request bruto da etapa identificado pelo CNAE. */
-    @PostMapping("/cnaes/{cnaeCode}/recebeRequest")
-    public SourceFetcherCreateResponse recebeRequest(@PathVariable String cnaeCode, @RequestBody OprmNichoCnaeV3RecebeRequestRequest request) {
-        return service.recebeRequest(cnaeCode, request);
+    /** Recebe o request bruto da etapa identificado pelo CNAE e jobId. */
+    @PostMapping("/cnaes/{cnaeCode}/jobs/{jobId}/recebeRequest")
+    public SourceFetcherCreateResponse recebeRequest(@PathVariable String cnaeCode, @PathVariable String jobId, @RequestBody OprmNichoCnaeV3RecebeRequestRequest request) {
+        return service.recebeRequest(cnaeCode, jobId, request);
     }
 
     /** Entrega pendências da etapa source-fetcher ao executor OPRM. */

--- a/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/sourcefetcher/service/BackendSourceFetcherV3Service.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/sourcefetcher/service/BackendSourceFetcherV3Service.java
@@ -38,8 +38,8 @@ public class BackendSourceFetcherV3Service extends OprmNichoCnaeV3StageServiceSu
     }
 
     /** Recebe o request bruto da etapa e registra auditoria para o pipeline NichoCNAE v3. */
-    public SourceFetcherCreateResponse recebeRequest(String cnaeCode, OprmNichoCnaeV3RecebeRequestRequest request) {
-        return new SourceFetcherCreateResponse(null, doRecebeRequest(cnaeCode, request).getJobId(), cnaeCode, STAGE_CODE, "AGUARDANDO_MODULO");
+    public SourceFetcherCreateResponse recebeRequest(String cnaeCode, String jobId, OprmNichoCnaeV3RecebeRequestRequest request) {
+        return new SourceFetcherCreateResponse(null, doRecebeRequest(cnaeCode, jobId, request).getJobId(), cnaeCode, STAGE_CODE, "AGUARDANDO_MODULO");
     }
 
     /** Lista pendências da etapa source-fetcher para o executor OPRM. */

--- a/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/sourcesearcher/controller/BackendSourceSearcherV3Controller.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/sourcesearcher/controller/BackendSourceSearcherV3Controller.java
@@ -44,10 +44,10 @@ public class BackendSourceSearcherV3Controller {
         return service.create(null, cnaeCode, "{\"cnaeCode\":\"" + cnaeCode + "\"}", 1, 1);
     }
 
-    /** Recebe o request bruto da etapa identificado pelo CNAE. */
-    @PostMapping("/cnaes/{cnaeCode}/recebeRequest")
-    public SourceSearcherCreateResponse recebeRequest(@PathVariable String cnaeCode, @RequestBody OprmNichoCnaeV3RecebeRequestRequest request) {
-        return service.recebeRequest(cnaeCode, request);
+    /** Recebe o request bruto da etapa identificado pelo CNAE e jobId. */
+    @PostMapping("/cnaes/{cnaeCode}/jobs/{jobId}/recebeRequest")
+    public SourceSearcherCreateResponse recebeRequest(@PathVariable String cnaeCode, @PathVariable String jobId, @RequestBody OprmNichoCnaeV3RecebeRequestRequest request) {
+        return service.recebeRequest(cnaeCode, jobId, request);
     }
 
     /** Entrega pendências da etapa source-searcher ao executor OPRM. */

--- a/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/sourcesearcher/service/BackendSourceSearcherV3Service.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/sourcesearcher/service/BackendSourceSearcherV3Service.java
@@ -38,8 +38,8 @@ public class BackendSourceSearcherV3Service extends OprmNichoCnaeV3StageServiceS
     }
 
     /** Recebe o request bruto da etapa e registra auditoria para o pipeline NichoCNAE v3. */
-    public SourceSearcherCreateResponse recebeRequest(String cnaeCode, OprmNichoCnaeV3RecebeRequestRequest request) {
-        return new SourceSearcherCreateResponse(null, doRecebeRequest(cnaeCode, request).getJobId(), cnaeCode, STAGE_CODE, "AGUARDANDO_MODULO");
+    public SourceSearcherCreateResponse recebeRequest(String cnaeCode, String jobId, OprmNichoCnaeV3RecebeRequestRequest request) {
+        return new SourceSearcherCreateResponse(null, doRecebeRequest(cnaeCode, jobId, request).getJobId(), cnaeCode, STAGE_CODE, "AGUARDANDO_MODULO");
     }
 
     /** Lista pendências da etapa source-searcher para o executor OPRM. */

--- a/backend/ads-service/src/test/java/com/marketinghub/oprmcoletormei/nichocnae/v3/personaroutinematerializer/service/BackendPersonaRoutineMaterializerServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/oprmcoletormei/nichocnae/v3/personaroutinematerializer/service/BackendPersonaRoutineMaterializerServiceTest.java
@@ -17,6 +17,7 @@ import com.marketinghub.repository.jpa.oprm.nichocnae.v3.OprmNichoCnaeV3StageExe
 import java.time.Instant;
 import java.util.List;
 import java.util.Optional;
+import java.util.UUID;
 import org.springframework.data.domain.PageRequest;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -103,8 +104,9 @@ class BackendPersonaRoutineMaterializerServiceTest {
             return saved;
         });
 
-        service.start("4781400");
+        var response = service.start("4781400");
 
+        assertThat(UUID.fromString(response.jobId()).toString()).isEqualTo(response.jobId());
         assertThat(cnae.getNichocnaePipelineStatus()).isEqualTo("INICIADO");
         assertThat(cnae.getNichocnaeCurrentStageCode()).isEqualTo("persona-routine-materializer");
         assertThat(cnae.getNichocnaePipelineUpdatedAt()).isNotNull();

--- a/docs/swagger/oprm-nichocnae-v3-swagger.yaml
+++ b/docs/swagger/oprm-nichocnae-v3-swagger.yaml
@@ -28,7 +28,7 @@ paths:
                 $ref: '#/components/schemas/StageExecutionResponse'
   /api/internal/oprm/nichocnae/v3/{stage}/stage-executions/start:
     post:
-      summary: Inicia uma execução pendente da etapa NichoCNAE v3 para o CNAE informado.
+      summary: Inicia uma execução pendente da etapa NichoCNAE v3 para o CNAE informado com jobId em UUID.
       parameters:
         - name: stage
           in: path
@@ -68,9 +68,41 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/StageExecutionResponse'
+  /api/internal/oprm/nichocnae/v3/{stage}/stage-executions/cnaes/{cnaeCode}/jobs/{jobId}/recebeRequest:
+    post:
+      summary: Registra o request bruto enviado ao executor para um objeto CNAE e jobId específicos.
+      parameters:
+        - name: stage
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: cnaeCode
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: jobId
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RecebeRequestRequest'
+      responses:
+        '200':
+          description: Request auditado com o jobId informado na URL.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/StageExecutionResponse'
   /api/internal/oprm/nichocnae/v3/{stage}/stage-executions/pending:
     get:
-      summary: Lista pendências da etapa para consumo do executor OPRM.
+      summary: Lista pendências da etapa para consumo do executor OPRM com jobId junto do objeto CNAE.
       parameters:
         - name: stage
           in: path
@@ -176,6 +208,17 @@ components:
           type: integer
         knowledgeVersion:
           type: integer
+    RecebeRequestRequest:
+      type: object
+      properties:
+        request:
+          type: string
+        plataforma:
+          type: string
+        prompt:
+          type: string
+        schema:
+          type: string
     CompletionRequest:
       type: object
       properties:


### PR DESCRIPTION
### Motivation
- Unificar e tornar previsível o identificador funcional (`jobId`) do pipeline NichoCNAE v3 usando UUIDs e garantir que o executor e callbacks compartilhem o mesmo `jobId` para rastreabilidade auditável.
- Fornecer contrato claro para o recebimento de requests pelo backend, exigindo `jobId` na URL para evitar ambiguidades na auditoria e no fluxo de pendências.

### Description
- Alterado `OprmNichoCnaeV3StageServiceSupport`: `defaultJobId` agora gera `UUID.randomUUID().toString()` e `doRecebeRequest` passou a aceitar `jobId` (validação de presença) e gravar esse `jobId` no registro de auditoria do pipeline. 
- Atualizados controllers das etapas v3 para a nova rota de callback `POST /cnaes/{cnaeCode}/jobs/{jobId}/recebeRequest` e respectivos services para receber `jobId` como parâmetro e repassar para `doRecebeRequest`.
- Mantida a estrutura do `/pending` que continua retornando o `jobId` junto do objeto pendente; a documentação OpenAPI/Swagger `docs/swagger/oprm-nichocnae-v3-swagger.yaml` foi atualizada para refletir o novo contrato (`/start` retorna `jobId` em UUID e novo `recebeRequest` com `jobId` na URL) e adicionada a definição de payload `RecebeRequestRequest`.
- Ajustado teste unitário `BackendPersonaRoutineMaterializerServiceTest` para validar que o `start` retorna um `jobId` no formato UUID.

### Testing
- Executed `mvn -Dtest=BackendPersonaRoutineMaterializerServiceTest test` in the `backend/ads-service` module and the test class passed (3 tests, 0 failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3f198c61508321946118096d644564)