### PR TITLE
GeraAnuncio v1: create UUID jobId at start and propagate to pending/recebeRequest

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/pipelines/aiworker/geracaoanuncios/v1/imagem/controller/GeraAnuncioImagemController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/pipelines/aiworker/geracaoanuncios/v1/imagem/controller/GeraAnuncioImagemController.java
@@ -52,11 +52,11 @@ public class GeraAnuncioImagemController {
         return service.pending();
     }
 
-    /** Recebe o request operacional gerado pelo AI Worker para a etapa. */
-    @PostMapping("/{experimentKey}/recebeRequest")
+    /** Recebe o request operacional gerado pelo AI Worker para a etapa usando o jobId da execução. */
+    @PostMapping("/{experimentKey}/jobs/{jobId}/recebeRequest")
     public ResponseEntity<Void> recebeRequest(
-            @PathVariable String experimentKey, @RequestBody GeraAnuncioImagemRecebeRequestRequest request) {
-        service.recebeRequest(experimentKey, request);
+            @PathVariable String experimentKey, @PathVariable String jobId, @RequestBody GeraAnuncioImagemRecebeRequestRequest request) {
+        service.recebeRequest(experimentKey, jobId, request);
         return ResponseEntity.accepted().build();
     }
 

--- a/backend/ads-service/src/main/java/com/marketinghub/pipelines/aiworker/geracaoanuncios/v1/imagem/service/GeraAnuncioImagemService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/pipelines/aiworker/geracaoanuncios/v1/imagem/service/GeraAnuncioImagemService.java
@@ -17,11 +17,7 @@ import com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1.Mois
 import com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1.entity.MoisSalesPage;
 import com.marketinghub.repository.jpa.oprm.cnae.OprmNicheCandidateRepository;
 import com.marketinghub.repository.jpa.pipeline.geracaoanuncios.PipelineGeracaoAnunciosRepository;
-import java.nio.charset.StandardCharsets;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
 import java.time.Instant;
-import java.util.HexFormat;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -72,17 +68,21 @@ public class GeraAnuncioImagemService {
         return start(resolveExperimentId(experimentKey));
     }
 
-    /** Inicia uma solicitação da etapa Imagem para o candidato CNAE informado. */
+    /** Inicia uma solicitação da etapa Imagem para o candidato CNAE informado e cria o jobId UUID da execução. */
+    @Transactional
     public GeraAnuncioImagemExecutionSummaryResponse start(Long experimentId) {
         OprmNicheCandidate cnae = cnaeRepository
                 .findById(experimentId)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "CNAE experiment not found"));
         cnae.setGeracaoAnunciosPipelineStatus(STATUS_STARTED);
         cnae.setGeracaoAnunciosCurrentStageCode(STAGE_CODE);
-        cnae.setUpdatedAt(Instant.now());
+        Instant now = Instant.now();
+        cnae.setUpdatedAt(now);
         OprmNicheCandidate saved = cnaeRepository.save(cnae);
+        String jobId = UUID.randomUUID().toString();
+        registrarInicioPipeline(saved, jobId, now);
         return new GeraAnuncioImagemExecutionSummaryResponse(
-                stageExecutionId(saved), saved.getId(), stageJobId(saved), STATUS_STARTED, saved.getUpdatedAt());
+                stageExecutionId(saved), saved.getId(), jobId, STATUS_STARTED, saved.getUpdatedAt());
     }
 
     /** Lista execuções da etapa Imagem para relatório operacional. */
@@ -105,9 +105,12 @@ public class GeraAnuncioImagemService {
 
     /** Recebe e audita o request operacional enviado para a etapa Imagem. */
     @Transactional
-    public void recebeRequest(String experimentKey, GeraAnuncioImagemRecebeRequestRequest request) {
+    public void recebeRequest(String experimentKey, String jobId, GeraAnuncioImagemRecebeRequestRequest request) {
         if (request == null) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "payload required");
+        }
+        if (!StringUtils.hasText(jobId)) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "jobId required");
         }
         Instant now = Instant.now();
         MoisSalesPage salesPage = salesPageRepository
@@ -122,7 +125,7 @@ public class GeraAnuncioImagemService {
         pipeline.setRequest(serializeRequest(request.request()));
         pipeline.setCodigoEtapa(STAGE_CODE);
         pipeline.setDataHora(now);
-        pipeline.setJobId(createJobHash(experimentKey, now));
+        pipeline.setJobId(jobId.trim());
         pipeline.setPlataforma(request.plataforma());
         pipeline.setPrompt(request.prompt());
         pipeline.setSchema(request.schema());
@@ -161,8 +164,26 @@ public class GeraAnuncioImagemService {
 
     /** Converte um candidato CNAE iniciado em unidade de trabalho fechada para o AI Worker. */
     private GeraAnuncioImagemPendingResponse toPending(OprmNicheCandidate cnae) {
-        return new GeraAnuncioImagemPendingResponse(stageExecutionId(cnae), cnae.getId(), stageJobId(cnae), cnae.getUpdatedAt(), context(cnae),
+        return new GeraAnuncioImagemPendingResponse(stageExecutionId(cnae), cnae.getId(), resolveJobId(cnae), cnae.getUpdatedAt(), context(cnae),
                 previousArtifacts(cnae));
+    }
+
+    /** Registra a criação da execução com o jobId UUID gerado pelo endpoint start. */
+    private void registrarInicioPipeline(OprmNicheCandidate cnae, String jobId, Instant now) {
+        PipelineGeracaoAnuncios pipeline = new PipelineGeracaoAnuncios();
+        pipeline.setIdExterno(String.valueOf(cnae.getId()));
+        pipeline.setCodigoEtapa(STAGE_CODE);
+        pipeline.setDataHora(now);
+        pipeline.setJobId(jobId);
+        pipeline.setVersaoPipeline(PIPELINE_VERSION);
+        pipelineRepository.save(pipeline);
+    }
+
+    /** Resolve o jobId UUID criado no start para envio junto com a pendência ao AI Worker. */
+    private String resolveJobId(OprmNicheCandidate cnae) {
+        return pipelineRepository.findTopByIdExternoAndCodigoEtapaOrderByDataHoraDesc(String.valueOf(cnae.getId()), STAGE_CODE)
+                .map(PipelineGeracaoAnuncios::getJobId)
+                .orElseGet(() -> stageJobId(cnae));
     }
 
     /** Monta o contexto funcional necessário para geração de anúncio sem consulta adicional. */
@@ -229,19 +250,6 @@ public class GeraAnuncioImagemService {
         } catch (JsonProcessingException ex) {
             log.warn("Falha ao serializar request do pipeline geracaoanuncios; etapa={}", STAGE_CODE, ex);
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "request payload invalid", ex);
-        }
-    }
-
-    /** Cria um hash único para rastrear o job recebido nesta chamada. */
-    private String createJobHash(String experimentKey, Instant now) {
-        try {
-            MessageDigest digest = MessageDigest.getInstance("SHA-256");
-            byte[] hash = digest.digest((experimentKey + "|" + STAGE_CODE + "|" + now + "|" + UUID.randomUUID())
-                    .getBytes(StandardCharsets.UTF_8));
-            return HexFormat.of().formatHex(hash);
-        } catch (NoSuchAlgorithmException ex) {
-            log.error("Falha ao gerar hash jobId do pipeline geracaoanuncios; etapa={}, experimentKey={}", STAGE_CODE, experimentKey, ex);
-            throw new IllegalStateException("SHA-256 indisponível para gerar jobId", ex);
         }
     }
 

--- a/backend/ads-service/src/main/java/com/marketinghub/pipelines/aiworker/geracaoanuncios/v1/texto/controller/GeraAnuncioTextoController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/pipelines/aiworker/geracaoanuncios/v1/texto/controller/GeraAnuncioTextoController.java
@@ -52,11 +52,11 @@ public class GeraAnuncioTextoController {
         return service.pending();
     }
 
-    /** Recebe o request operacional gerado pelo AI Worker para a etapa. */
-    @PostMapping("/{experimentKey}/recebeRequest")
+    /** Recebe o request operacional gerado pelo AI Worker para a etapa usando o jobId da execução. */
+    @PostMapping("/{experimentKey}/jobs/{jobId}/recebeRequest")
     public ResponseEntity<Void> recebeRequest(
-            @PathVariable String experimentKey, @RequestBody GeraAnuncioTextoRecebeRequestRequest request) {
-        service.recebeRequest(experimentKey, request);
+            @PathVariable String experimentKey, @PathVariable String jobId, @RequestBody GeraAnuncioTextoRecebeRequestRequest request) {
+        service.recebeRequest(experimentKey, jobId, request);
         return ResponseEntity.accepted().build();
     }
 

--- a/backend/ads-service/src/main/java/com/marketinghub/pipelines/aiworker/geracaoanuncios/v1/texto/service/GeraAnuncioTextoService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/pipelines/aiworker/geracaoanuncios/v1/texto/service/GeraAnuncioTextoService.java
@@ -17,11 +17,7 @@ import com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1.Mois
 import com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1.entity.MoisSalesPage;
 import com.marketinghub.repository.jpa.oprm.cnae.OprmNicheCandidateRepository;
 import com.marketinghub.repository.jpa.pipeline.geracaoanuncios.PipelineGeracaoAnunciosRepository;
-import java.nio.charset.StandardCharsets;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
 import java.time.Instant;
-import java.util.HexFormat;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
@@ -72,17 +68,21 @@ public class GeraAnuncioTextoService {
         return start(resolveExperimentId(experimentKey));
     }
 
-    /** Inicia uma solicitação da etapa Texto para o candidato CNAE informado. */
+    /** Inicia uma solicitação da etapa Texto para o candidato CNAE informado e cria o jobId UUID da execução. */
+    @Transactional
     public GeraAnuncioTextoExecutionSummaryResponse start(Long experimentId) {
         OprmNicheCandidate cnae = cnaeRepository
                 .findById(experimentId)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "CNAE experiment not found"));
         cnae.setGeracaoAnunciosPipelineStatus(STATUS_STARTED);
         cnae.setGeracaoAnunciosCurrentStageCode(STAGE_CODE);
-        cnae.setUpdatedAt(Instant.now());
+        Instant now = Instant.now();
+        cnae.setUpdatedAt(now);
         OprmNicheCandidate saved = cnaeRepository.save(cnae);
+        String jobId = UUID.randomUUID().toString();
+        registrarInicioPipeline(saved, jobId, now);
         return new GeraAnuncioTextoExecutionSummaryResponse(
-                stageExecutionId(saved), saved.getId(), stageJobId(saved), STATUS_STARTED, saved.getUpdatedAt());
+                stageExecutionId(saved), saved.getId(), jobId, STATUS_STARTED, saved.getUpdatedAt());
     }
 
     /** Lista execuções da etapa Texto para relatório operacional. */
@@ -105,9 +105,12 @@ public class GeraAnuncioTextoService {
 
     /** Recebe e audita o request operacional enviado para a etapa Texto. */
     @Transactional
-    public void recebeRequest(String experimentKey, GeraAnuncioTextoRecebeRequestRequest request) {
+    public void recebeRequest(String experimentKey, String jobId, GeraAnuncioTextoRecebeRequestRequest request) {
         if (request == null) {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "payload required");
+        }
+        if (!StringUtils.hasText(jobId)) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "jobId required");
         }
         Instant now = Instant.now();
         MoisSalesPage salesPage = salesPageRepository
@@ -122,7 +125,7 @@ public class GeraAnuncioTextoService {
         pipeline.setRequest(serializeRequest(request.request()));
         pipeline.setCodigoEtapa(STAGE_CODE);
         pipeline.setDataHora(now);
-        pipeline.setJobId(createJobHash(experimentKey, now));
+        pipeline.setJobId(jobId.trim());
         pipeline.setPlataforma(request.plataforma());
         pipeline.setPrompt(request.prompt());
         pipeline.setSchema(request.schema());
@@ -161,8 +164,26 @@ public class GeraAnuncioTextoService {
 
     /** Converte um candidato CNAE iniciado em unidade de trabalho fechada para o AI Worker. */
     private GeraAnuncioTextoPendingResponse toPending(OprmNicheCandidate cnae) {
-        return new GeraAnuncioTextoPendingResponse(stageExecutionId(cnae), cnae.getId(), stageJobId(cnae), cnae.getUpdatedAt(), context(cnae),
+        return new GeraAnuncioTextoPendingResponse(stageExecutionId(cnae), cnae.getId(), resolveJobId(cnae), cnae.getUpdatedAt(), context(cnae),
                 previousArtifacts(cnae));
+    }
+
+    /** Registra a criação da execução com o jobId UUID gerado pelo endpoint start. */
+    private void registrarInicioPipeline(OprmNicheCandidate cnae, String jobId, Instant now) {
+        PipelineGeracaoAnuncios pipeline = new PipelineGeracaoAnuncios();
+        pipeline.setIdExterno(String.valueOf(cnae.getId()));
+        pipeline.setCodigoEtapa(STAGE_CODE);
+        pipeline.setDataHora(now);
+        pipeline.setJobId(jobId);
+        pipeline.setVersaoPipeline(PIPELINE_VERSION);
+        pipelineRepository.save(pipeline);
+    }
+
+    /** Resolve o jobId UUID criado no start para envio junto com a pendência ao AI Worker. */
+    private String resolveJobId(OprmNicheCandidate cnae) {
+        return pipelineRepository.findTopByIdExternoAndCodigoEtapaOrderByDataHoraDesc(String.valueOf(cnae.getId()), STAGE_CODE)
+                .map(PipelineGeracaoAnuncios::getJobId)
+                .orElseGet(() -> stageJobId(cnae));
     }
 
     /** Monta o contexto funcional necessário para geração de anúncio sem consulta adicional. */
@@ -229,19 +250,6 @@ public class GeraAnuncioTextoService {
         } catch (JsonProcessingException ex) {
             log.warn("Falha ao serializar request do pipeline geracaoanuncios; etapa={}", STAGE_CODE, ex);
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "request payload invalid", ex);
-        }
-    }
-
-    /** Cria um hash único para rastrear o job recebido nesta chamada. */
-    private String createJobHash(String experimentKey, Instant now) {
-        try {
-            MessageDigest digest = MessageDigest.getInstance("SHA-256");
-            byte[] hash = digest.digest((experimentKey + "|" + STAGE_CODE + "|" + now + "|" + UUID.randomUUID())
-                    .getBytes(StandardCharsets.UTF_8));
-            return HexFormat.of().formatHex(hash);
-        } catch (NoSuchAlgorithmException ex) {
-            log.error("Falha ao gerar hash jobId do pipeline geracaoanuncios; etapa={}, experimentKey={}", STAGE_CODE, experimentKey, ex);
-            throw new IllegalStateException("SHA-256 indisponível para gerar jobId", ex);
         }
     }
 

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/pipeline/geracaoanuncios/PipelineGeracaoAnunciosRepository.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/pipeline/geracaoanuncios/PipelineGeracaoAnunciosRepository.java
@@ -2,6 +2,7 @@ package com.marketinghub.repository.jpa.pipeline.geracaoanuncios;
 
 import com.marketinghub.pipeline.geracaoanuncios.PipelineGeracaoAnuncios;
 import java.util.List;
+import java.util.Optional;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 /** Repositório JPA responsável pela auditoria do pipeline de geração de anúncios. */
@@ -14,4 +15,7 @@ public interface PipelineGeracaoAnunciosRepository extends JpaRepository<Pipelin
 
     /** Verifica se já existe auditoria vinculada a um identificador externo. */
     boolean existsByIdExterno(String idExterno);
+
+    /** Busca a auditoria mais recente de uma etapa vinculada a um identificador externo. */
+    Optional<PipelineGeracaoAnuncios> findTopByIdExternoAndCodigoEtapaOrderByDataHoraDesc(String idExterno, String codigoEtapa);
 }

--- a/docs/swagger/geraanuncio-v2-swagger.yaml
+++ b/docs/swagger/geraanuncio-v2-swagger.yaml
@@ -35,10 +35,29 @@ paths:
   /api/internal/aiworker/geracaoanuncios/v1/texto/stage-executions/pending:
     post:
       summary: Lista execuções pendentes da etapa Texto
-      description: Endpoint canônico usado pelo AI Worker para consumir a fila da etapa Texto.
+      description: Endpoint canônico usado pelo AI Worker para consumir a fila da etapa Texto, retornando cada objeto pendente com o jobId UUID da execução.
       responses:
         '200':
           description: Execuções pendentes retornadas com contexto e artefatos anteriores.
+  /api/internal/aiworker/geracaoanuncios/v1/texto/stage-executions/{experimentKey}/jobs/{jobId}/recebeRequest:
+    post:
+      summary: Registra request operacional da etapa Texto
+      description: Recebe o request gerado pelo AI Worker vinculado ao id do objeto e ao jobId UUID criado no start.
+      parameters:
+        - name: experimentKey
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: jobId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '202':
+          description: Request aceito para auditoria.
   /api/internal/aiworker/geracaoanuncios/v1/texto/stage-executions/{stageExecutionId}/prompt:
     post:
       summary: Registra prompt enviado ao modelo na etapa Texto
@@ -94,10 +113,29 @@ paths:
   /api/internal/aiworker/geracaoanuncios/v1/imagem/stage-executions/pending:
     post:
       summary: Lista execuções pendentes da etapa Imagem
-      description: Endpoint canônico usado pelo AI Worker para consumir a fila da etapa Imagem.
+      description: Endpoint canônico usado pelo AI Worker para consumir a fila da etapa Imagem, retornando cada objeto pendente com o jobId UUID da execução.
       responses:
         '200':
           description: Execuções pendentes retornadas com contexto e artefatos anteriores.
+  /api/internal/aiworker/geracaoanuncios/v1/imagem/stage-executions/{experimentKey}/jobs/{jobId}/recebeRequest:
+    post:
+      summary: Registra request operacional da etapa Imagem
+      description: Recebe o request gerado pelo AI Worker vinculado ao id do objeto e ao jobId UUID criado no start.
+      parameters:
+        - name: experimentKey
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: jobId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '202':
+          description: Request aceito para auditoria.
   /api/internal/aiworker/geracaoanuncios/v1/imagem/stage-executions/{stageExecutionId}/prompt:
     post:
       summary: Registra prompt enviado ao modelo na etapa Imagem


### PR DESCRIPTION
### Motivation
- Align pipeline execution tracing so each `start` creates a stable UUID `jobId` that is returned to the caller and used to correlate subsequent worker interactions. 

### Description
- `start` in `GeraAnuncioTextoService` and `GeraAnuncioImagemService` now generates `jobId = UUID.randomUUID().toString()`, persists an initial `PipelineGeracaoAnuncios` audit row and returns the UUID in the start response. 
- `pending()` for CNAE candidates now returns the `jobId` resolved from the latest `PipelineGeracaoAnuncios` audit entry via a new `resolveJobId(...)` helper instead of the previous deterministic `stageJobId(...)`. 
- `recebeRequest` signature and controller routes were changed to accept `jobId` in the URL (`/{experimentKey}/jobs/{jobId}/recebeRequest`) and the service persists the incoming request using the provided `jobId`. 
- `PipelineGeracaoAnunciosRepository` gained `findTopByIdExternoAndCodigoEtapaOrderByDataHoraDesc(...)` to locate the most recent audit entry; Swagger (`docs/swagger/geraanuncio-v2-swagger.yaml`) was updated to document the new `recebeRequest` path and that `pending` returns `jobId`.

### Testing
- Ran `mvn -q -DskipTests compile` in `backend/ads-service`, which completed successfully. 
- Ran `mvn -q test`, which exercised the test suite but failed due to unrelated preexisting failures in `PipelineServiceTest.shouldMatchOprmNichoCnaeOpenAiFlagsWithCollectorCode` and `ArquiteturaTest.moisDossieV1StagesMustExposeCanonicalStructure`, not caused by these changes. 
- Attempted `mvn -q spotless:check`, which did not run because the Spotless plugin is not configured in the current Maven project environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3f1996473483219c3582d888ed1cb9)