### PR TITLE
Add NichoCNAE v3 recebeResponse callbacks

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/cnaeintake/controller/BackendCnaeIntakeController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/cnaeintake/controller/BackendCnaeIntakeController.java
@@ -6,7 +6,11 @@ import com.marketinghub.oprmcoletormei.nichocnae.v3.cnaeintake.service.createSta
 import com.marketinghub.oprmcoletormei.nichocnae.v3.cnaeintake.service.failStageExecution.CnaeIntakeFailureRequest;
 import com.marketinghub.oprmcoletormei.nichocnae.v3.cnaeintake.service.pending.CnaeIntakePendingResponse;
 import com.marketinghub.oprmcoletormei.nichocnae.v3.shared.OprmNichoCnaeV3RecebeRequestRequest;
+import com.marketinghub.oprmcoletormei.nichocnae.v3.shared.OprmNichoCnaeV3RecebeResponseRequest;
+import com.marketinghub.oprmcoletormei.nichocnae.v3.shared.OprmNichoCnaeV3RecebeResponseResponse;
 import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -19,6 +23,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/internal/oprm/nichocnae/v3/cnae-intake/stage-executions")
 public class BackendCnaeIntakeController {
+    private static final Logger log = LoggerFactory.getLogger(BackendCnaeIntakeController.class);
     private final BackendCnaeIntakeService service;
 
     /** Inicializa o controller com service canônico da etapa. */
@@ -48,6 +53,13 @@ public class BackendCnaeIntakeController {
     @PostMapping("/cnaes/{cnaeCode}/jobs/{jobId}/recebeRequest")
     public CnaeIntakeCreateResponse recebeRequest(@PathVariable String cnaeCode, @PathVariable String jobId, @RequestBody OprmNichoCnaeV3RecebeRequestRequest request) {
         return service.recebeRequest(cnaeCode, jobId, request);
+    }
+
+    /** Recebe o response bruto da etapa identificado pelo CNAE e jobId. */
+    @PostMapping("/cnaes/{cnaeCode}/jobs/{jobId}/recebeResponse")
+    public OprmNichoCnaeV3RecebeResponseResponse recebeResponse(@PathVariable String cnaeCode, @PathVariable String jobId, @RequestBody OprmNichoCnaeV3RecebeResponseRequest request) {
+        log.info("Recebendo response NichoCNAE v3. etapa={}, cnaeCode={}, jobId={}, payload={}", service.stageCode(), cnaeCode, jobId, request);
+        return service.recebeResponse(cnaeCode, jobId, request);
     }
 
     /** Entrega pendências da etapa cnae-intake ao executor OPRM. */

--- a/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/cnaeintake/service/BackendCnaeIntakeService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/cnaeintake/service/BackendCnaeIntakeService.java
@@ -6,6 +6,8 @@ import com.marketinghub.oprmcoletormei.nichocnae.v3.cnaeintake.service.createSta
 import com.marketinghub.oprmcoletormei.nichocnae.v3.cnaeintake.service.pending.CnaeIntakePendingResponse;
 import com.marketinghub.oprmcoletormei.nichocnae.v3.shared.OprmNichoCnaeV3StageServiceSupport;
 import com.marketinghub.oprmcoletormei.nichocnae.v3.shared.OprmNichoCnaeV3RecebeRequestRequest;
+import com.marketinghub.oprmcoletormei.nichocnae.v3.shared.OprmNichoCnaeV3RecebeResponseRequest;
+import com.marketinghub.oprmcoletormei.nichocnae.v3.shared.OprmNichoCnaeV3RecebeResponseResponse;
 import com.marketinghub.repository.jpa.oprm.market.OprmCnpjCnaeDimRepository;
 import com.marketinghub.repository.jpa.oprm.nichocnae.PipelineNichoCnaeRepository;
 import com.marketinghub.repository.jpa.oprm.nichocnae.v3.OprmNichoCnaeV3StageExecutionRepository;
@@ -40,6 +42,11 @@ public class BackendCnaeIntakeService extends OprmNichoCnaeV3StageServiceSupport
     /** Recebe o request bruto da etapa e registra auditoria para o pipeline NichoCNAE v3. */
     public CnaeIntakeCreateResponse recebeRequest(String cnaeCode, String jobId, OprmNichoCnaeV3RecebeRequestRequest request) {
         return new CnaeIntakeCreateResponse(null, doRecebeRequest(cnaeCode, jobId, request).getJobId(), cnaeCode, STAGE_CODE, "AGUARDANDO_MODULO");
+    }
+
+    /** Recebe o response bruto da etapa e registra conclusão ou falha do pipeline NichoCNAE v3. */
+    public OprmNichoCnaeV3RecebeResponseResponse recebeResponse(String cnaeCode, String jobId, OprmNichoCnaeV3RecebeResponseRequest request) {
+        return doRecebeResponse(cnaeCode, jobId, request, NEXT_STAGE);
     }
 
     /** Lista pendências da etapa cnae-intake para o executor OPRM. */

--- a/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/dailytaskssynthesizer/controller/BackendDailyTasksSynthesizerController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/dailytaskssynthesizer/controller/BackendDailyTasksSynthesizerController.java
@@ -6,7 +6,11 @@ import com.marketinghub.oprmcoletormei.nichocnae.v3.dailytaskssynthesizer.servic
 import com.marketinghub.oprmcoletormei.nichocnae.v3.dailytaskssynthesizer.service.failStageExecution.DailyTasksSynthesizerFailureRequest;
 import com.marketinghub.oprmcoletormei.nichocnae.v3.dailytaskssynthesizer.service.pending.DailyTasksSynthesizerPendingResponse;
 import com.marketinghub.oprmcoletormei.nichocnae.v3.shared.OprmNichoCnaeV3RecebeRequestRequest;
+import com.marketinghub.oprmcoletormei.nichocnae.v3.shared.OprmNichoCnaeV3RecebeResponseRequest;
+import com.marketinghub.oprmcoletormei.nichocnae.v3.shared.OprmNichoCnaeV3RecebeResponseResponse;
 import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -19,6 +23,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/internal/oprm/nichocnae/v3/daily-tasks-synthesizer/stage-executions")
 public class BackendDailyTasksSynthesizerController {
+    private static final Logger log = LoggerFactory.getLogger(BackendDailyTasksSynthesizerController.class);
     private final BackendDailyTasksSynthesizerService service;
 
     /** Inicializa o controller com service canônico da etapa. */
@@ -48,6 +53,13 @@ public class BackendDailyTasksSynthesizerController {
     @PostMapping("/cnaes/{cnaeCode}/jobs/{jobId}/recebeRequest")
     public DailyTasksSynthesizerCreateResponse recebeRequest(@PathVariable String cnaeCode, @PathVariable String jobId, @RequestBody OprmNichoCnaeV3RecebeRequestRequest request) {
         return service.recebeRequest(cnaeCode, jobId, request);
+    }
+
+    /** Recebe o response bruto da etapa identificado pelo CNAE e jobId. */
+    @PostMapping("/cnaes/{cnaeCode}/jobs/{jobId}/recebeResponse")
+    public OprmNichoCnaeV3RecebeResponseResponse recebeResponse(@PathVariable String cnaeCode, @PathVariable String jobId, @RequestBody OprmNichoCnaeV3RecebeResponseRequest request) {
+        log.info("Recebendo response NichoCNAE v3. etapa={}, cnaeCode={}, jobId={}, payload={}", service.stageCode(), cnaeCode, jobId, request);
+        return service.recebeResponse(cnaeCode, jobId, request);
     }
 
     /** Entrega pendências da etapa daily-tasks-synthesizer ao executor OPRM. */

--- a/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/dailytaskssynthesizer/service/BackendDailyTasksSynthesizerService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/dailytaskssynthesizer/service/BackendDailyTasksSynthesizerService.java
@@ -6,6 +6,8 @@ import com.marketinghub.oprmcoletormei.nichocnae.v3.dailytaskssynthesizer.servic
 import com.marketinghub.oprmcoletormei.nichocnae.v3.dailytaskssynthesizer.service.pending.DailyTasksSynthesizerPendingResponse;
 import com.marketinghub.oprmcoletormei.nichocnae.v3.shared.OprmNichoCnaeV3StageServiceSupport;
 import com.marketinghub.oprmcoletormei.nichocnae.v3.shared.OprmNichoCnaeV3RecebeRequestRequest;
+import com.marketinghub.oprmcoletormei.nichocnae.v3.shared.OprmNichoCnaeV3RecebeResponseRequest;
+import com.marketinghub.oprmcoletormei.nichocnae.v3.shared.OprmNichoCnaeV3RecebeResponseResponse;
 import com.marketinghub.repository.jpa.oprm.market.OprmCnpjCnaeDimRepository;
 import com.marketinghub.repository.jpa.oprm.nichocnae.PipelineNichoCnaeRepository;
 import com.marketinghub.repository.jpa.oprm.nichocnae.v3.OprmNichoCnaeV3StageExecutionRepository;
@@ -40,6 +42,11 @@ public class BackendDailyTasksSynthesizerService extends OprmNichoCnaeV3StageSer
     /** Recebe o request bruto da etapa e registra auditoria para o pipeline NichoCNAE v3. */
     public DailyTasksSynthesizerCreateResponse recebeRequest(String cnaeCode, String jobId, OprmNichoCnaeV3RecebeRequestRequest request) {
         return new DailyTasksSynthesizerCreateResponse(null, doRecebeRequest(cnaeCode, jobId, request).getJobId(), cnaeCode, STAGE_CODE, "AGUARDANDO_MODULO");
+    }
+
+    /** Recebe o response bruto da etapa e registra conclusão ou falha do pipeline NichoCNAE v3. */
+    public OprmNichoCnaeV3RecebeResponseResponse recebeResponse(String cnaeCode, String jobId, OprmNichoCnaeV3RecebeResponseRequest request) {
+        return doRecebeResponse(cnaeCode, jobId, request, NEXT_STAGE);
     }
 
     /** Lista pendências da etapa daily-tasks-synthesizer para o executor OPRM. */

--- a/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/personacandidategenerator/controller/BackendPersonaCandidateGeneratorController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/personacandidategenerator/controller/BackendPersonaCandidateGeneratorController.java
@@ -6,7 +6,11 @@ import com.marketinghub.oprmcoletormei.nichocnae.v3.personacandidategenerator.se
 import com.marketinghub.oprmcoletormei.nichocnae.v3.personacandidategenerator.service.failStageExecution.PersonaCandidateGeneratorFailureRequest;
 import com.marketinghub.oprmcoletormei.nichocnae.v3.personacandidategenerator.service.pending.PersonaCandidateGeneratorPendingResponse;
 import com.marketinghub.oprmcoletormei.nichocnae.v3.shared.OprmNichoCnaeV3RecebeRequestRequest;
+import com.marketinghub.oprmcoletormei.nichocnae.v3.shared.OprmNichoCnaeV3RecebeResponseRequest;
+import com.marketinghub.oprmcoletormei.nichocnae.v3.shared.OprmNichoCnaeV3RecebeResponseResponse;
 import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -19,6 +23,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/internal/oprm/nichocnae/v3/persona-candidate-generator/stage-executions")
 public class BackendPersonaCandidateGeneratorController {
+    private static final Logger log = LoggerFactory.getLogger(BackendPersonaCandidateGeneratorController.class);
     private final BackendPersonaCandidateGeneratorService service;
 
     /** Inicializa o controller com service canônico da etapa. */
@@ -48,6 +53,13 @@ public class BackendPersonaCandidateGeneratorController {
     @PostMapping("/cnaes/{cnaeCode}/jobs/{jobId}/recebeRequest")
     public PersonaCandidateGeneratorCreateResponse recebeRequest(@PathVariable String cnaeCode, @PathVariable String jobId, @RequestBody OprmNichoCnaeV3RecebeRequestRequest request) {
         return service.recebeRequest(cnaeCode, jobId, request);
+    }
+
+    /** Recebe o response bruto da etapa identificado pelo CNAE e jobId. */
+    @PostMapping("/cnaes/{cnaeCode}/jobs/{jobId}/recebeResponse")
+    public OprmNichoCnaeV3RecebeResponseResponse recebeResponse(@PathVariable String cnaeCode, @PathVariable String jobId, @RequestBody OprmNichoCnaeV3RecebeResponseRequest request) {
+        log.info("Recebendo response NichoCNAE v3. etapa={}, cnaeCode={}, jobId={}, payload={}", service.stageCode(), cnaeCode, jobId, request);
+        return service.recebeResponse(cnaeCode, jobId, request);
     }
 
     /** Entrega pendências da etapa persona-candidate-generator ao executor OPRM. */

--- a/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/personacandidategenerator/service/BackendPersonaCandidateGeneratorService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/personacandidategenerator/service/BackendPersonaCandidateGeneratorService.java
@@ -6,6 +6,8 @@ import com.marketinghub.oprmcoletormei.nichocnae.v3.personacandidategenerator.se
 import com.marketinghub.oprmcoletormei.nichocnae.v3.personacandidategenerator.service.pending.PersonaCandidateGeneratorPendingResponse;
 import com.marketinghub.oprmcoletormei.nichocnae.v3.shared.OprmNichoCnaeV3StageServiceSupport;
 import com.marketinghub.oprmcoletormei.nichocnae.v3.shared.OprmNichoCnaeV3RecebeRequestRequest;
+import com.marketinghub.oprmcoletormei.nichocnae.v3.shared.OprmNichoCnaeV3RecebeResponseRequest;
+import com.marketinghub.oprmcoletormei.nichocnae.v3.shared.OprmNichoCnaeV3RecebeResponseResponse;
 import com.marketinghub.repository.jpa.oprm.market.OprmCnpjCnaeDimRepository;
 import com.marketinghub.repository.jpa.oprm.nichocnae.PipelineNichoCnaeRepository;
 import com.marketinghub.repository.jpa.oprm.nichocnae.v3.OprmNichoCnaeV3StageExecutionRepository;
@@ -40,6 +42,11 @@ public class BackendPersonaCandidateGeneratorService extends OprmNichoCnaeV3Stag
     /** Recebe o request bruto da etapa e registra auditoria para o pipeline NichoCNAE v3. */
     public PersonaCandidateGeneratorCreateResponse recebeRequest(String cnaeCode, String jobId, OprmNichoCnaeV3RecebeRequestRequest request) {
         return new PersonaCandidateGeneratorCreateResponse(null, doRecebeRequest(cnaeCode, jobId, request).getJobId(), cnaeCode, STAGE_CODE, "AGUARDANDO_MODULO");
+    }
+
+    /** Recebe o response bruto da etapa e registra conclusão ou falha do pipeline NichoCNAE v3. */
+    public OprmNichoCnaeV3RecebeResponseResponse recebeResponse(String cnaeCode, String jobId, OprmNichoCnaeV3RecebeResponseRequest request) {
+        return doRecebeResponse(cnaeCode, jobId, request, NEXT_STAGE);
     }
 
     /** Lista pendências da etapa persona-candidate-generator para o executor OPRM. */

--- a/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/personaroutinematerializer/controller/BackendPersonaRoutineMaterializerController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/personaroutinematerializer/controller/BackendPersonaRoutineMaterializerController.java
@@ -6,7 +6,11 @@ import com.marketinghub.oprmcoletormei.nichocnae.v3.personaroutinematerializer.s
 import com.marketinghub.oprmcoletormei.nichocnae.v3.personaroutinematerializer.service.failStageExecution.PersonaRoutineMaterializerFailureRequest;
 import com.marketinghub.oprmcoletormei.nichocnae.v3.personaroutinematerializer.service.pending.PersonaRoutineMaterializerPendingResponse;
 import com.marketinghub.oprmcoletormei.nichocnae.v3.shared.OprmNichoCnaeV3RecebeRequestRequest;
+import com.marketinghub.oprmcoletormei.nichocnae.v3.shared.OprmNichoCnaeV3RecebeResponseRequest;
+import com.marketinghub.oprmcoletormei.nichocnae.v3.shared.OprmNichoCnaeV3RecebeResponseResponse;
 import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -19,6 +23,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/internal/oprm/nichocnae/v3/persona-routine-materializer/stage-executions")
 public class BackendPersonaRoutineMaterializerController {
+    private static final Logger log = LoggerFactory.getLogger(BackendPersonaRoutineMaterializerController.class);
     private final BackendPersonaRoutineMaterializerService service;
 
     /** Inicializa o controller com service canônico da etapa. */
@@ -48,6 +53,13 @@ public class BackendPersonaRoutineMaterializerController {
     @PostMapping("/cnaes/{cnaeCode}/jobs/{jobId}/recebeRequest")
     public PersonaRoutineMaterializerCreateResponse recebeRequest(@PathVariable String cnaeCode, @PathVariable String jobId, @RequestBody OprmNichoCnaeV3RecebeRequestRequest request) {
         return service.recebeRequest(cnaeCode, jobId, request);
+    }
+
+    /** Recebe o response bruto da etapa identificado pelo CNAE e jobId. */
+    @PostMapping("/cnaes/{cnaeCode}/jobs/{jobId}/recebeResponse")
+    public OprmNichoCnaeV3RecebeResponseResponse recebeResponse(@PathVariable String cnaeCode, @PathVariable String jobId, @RequestBody OprmNichoCnaeV3RecebeResponseRequest request) {
+        log.info("Recebendo response NichoCNAE v3. etapa={}, cnaeCode={}, jobId={}, payload={}", service.stageCode(), cnaeCode, jobId, request);
+        return service.recebeResponse(cnaeCode, jobId, request);
     }
 
     /** Entrega pendências da etapa persona-routine-materializer ao executor OPRM. */

--- a/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/personaroutinematerializer/service/BackendPersonaRoutineMaterializerService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/personaroutinematerializer/service/BackendPersonaRoutineMaterializerService.java
@@ -9,6 +9,8 @@ import com.marketinghub.oprmcoletormei.nichocnae.v3.personaroutinematerializer.s
 import com.marketinghub.oprmcoletormei.nichocnae.v3.personaroutinematerializer.service.pending.PersonaRoutineMaterializerPendingResponse;
 import com.marketinghub.oprmcoletormei.nichocnae.v3.shared.OprmNichoCnaeV3StageServiceSupport;
 import com.marketinghub.oprmcoletormei.nichocnae.v3.shared.OprmNichoCnaeV3RecebeRequestRequest;
+import com.marketinghub.oprmcoletormei.nichocnae.v3.shared.OprmNichoCnaeV3RecebeResponseRequest;
+import com.marketinghub.oprmcoletormei.nichocnae.v3.shared.OprmNichoCnaeV3RecebeResponseResponse;
 import com.marketinghub.repository.jpa.oprm.market.OprmCnpjCnaeDimRepository;
 import com.marketinghub.repository.jpa.oprm.nichocnae.PipelineNichoCnaeRepository;
 import com.marketinghub.repository.jpa.oprm.nichocnae.v3.OprmNichoCnaeV3StageExecutionRepository;
@@ -60,6 +62,11 @@ public class BackendPersonaRoutineMaterializerService extends OprmNichoCnaeV3Sta
     /** Recebe o request bruto da etapa e registra auditoria para o pipeline NichoCNAE v3. */
     public PersonaRoutineMaterializerCreateResponse recebeRequest(String cnaeCode, String jobId, OprmNichoCnaeV3RecebeRequestRequest request) {
         return new PersonaRoutineMaterializerCreateResponse(null, doRecebeRequest(cnaeCode, jobId, request).getJobId(), cnaeCode, STAGE_CODE, "AGUARDANDO_MODULO");
+    }
+
+    /** Recebe o response bruto da etapa e registra conclusão ou falha do pipeline NichoCNAE v3. */
+    public OprmNichoCnaeV3RecebeResponseResponse recebeResponse(String cnaeCode, String jobId, OprmNichoCnaeV3RecebeResponseRequest request) {
+        return doRecebeResponse(cnaeCode, jobId, request, NEXT_STAGE);
     }
 
     /** Lista pendências da etapa persona-routine-materializer para o executor OPRM. */

--- a/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/personatournament/controller/BackendPersonaTournamentController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/personatournament/controller/BackendPersonaTournamentController.java
@@ -6,7 +6,11 @@ import com.marketinghub.oprmcoletormei.nichocnae.v3.personatournament.service.cr
 import com.marketinghub.oprmcoletormei.nichocnae.v3.personatournament.service.failStageExecution.PersonaTournamentFailureRequest;
 import com.marketinghub.oprmcoletormei.nichocnae.v3.personatournament.service.pending.PersonaTournamentPendingResponse;
 import com.marketinghub.oprmcoletormei.nichocnae.v3.shared.OprmNichoCnaeV3RecebeRequestRequest;
+import com.marketinghub.oprmcoletormei.nichocnae.v3.shared.OprmNichoCnaeV3RecebeResponseRequest;
+import com.marketinghub.oprmcoletormei.nichocnae.v3.shared.OprmNichoCnaeV3RecebeResponseResponse;
 import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -19,6 +23,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/internal/oprm/nichocnae/v3/persona-tournament/stage-executions")
 public class BackendPersonaTournamentController {
+    private static final Logger log = LoggerFactory.getLogger(BackendPersonaTournamentController.class);
     private final BackendPersonaTournamentService service;
 
     /** Inicializa o controller com service canônico da etapa. */
@@ -48,6 +53,13 @@ public class BackendPersonaTournamentController {
     @PostMapping("/cnaes/{cnaeCode}/jobs/{jobId}/recebeRequest")
     public PersonaTournamentCreateResponse recebeRequest(@PathVariable String cnaeCode, @PathVariable String jobId, @RequestBody OprmNichoCnaeV3RecebeRequestRequest request) {
         return service.recebeRequest(cnaeCode, jobId, request);
+    }
+
+    /** Recebe o response bruto da etapa identificado pelo CNAE e jobId. */
+    @PostMapping("/cnaes/{cnaeCode}/jobs/{jobId}/recebeResponse")
+    public OprmNichoCnaeV3RecebeResponseResponse recebeResponse(@PathVariable String cnaeCode, @PathVariable String jobId, @RequestBody OprmNichoCnaeV3RecebeResponseRequest request) {
+        log.info("Recebendo response NichoCNAE v3. etapa={}, cnaeCode={}, jobId={}, payload={}", service.stageCode(), cnaeCode, jobId, request);
+        return service.recebeResponse(cnaeCode, jobId, request);
     }
 
     /** Entrega pendências da etapa persona-tournament ao executor OPRM. */

--- a/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/personatournament/service/BackendPersonaTournamentService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/personatournament/service/BackendPersonaTournamentService.java
@@ -6,6 +6,8 @@ import com.marketinghub.oprmcoletormei.nichocnae.v3.personatournament.service.cr
 import com.marketinghub.oprmcoletormei.nichocnae.v3.personatournament.service.pending.PersonaTournamentPendingResponse;
 import com.marketinghub.oprmcoletormei.nichocnae.v3.shared.OprmNichoCnaeV3StageServiceSupport;
 import com.marketinghub.oprmcoletormei.nichocnae.v3.shared.OprmNichoCnaeV3RecebeRequestRequest;
+import com.marketinghub.oprmcoletormei.nichocnae.v3.shared.OprmNichoCnaeV3RecebeResponseRequest;
+import com.marketinghub.oprmcoletormei.nichocnae.v3.shared.OprmNichoCnaeV3RecebeResponseResponse;
 import com.marketinghub.repository.jpa.oprm.market.OprmCnpjCnaeDimRepository;
 import com.marketinghub.repository.jpa.oprm.nichocnae.PipelineNichoCnaeRepository;
 import com.marketinghub.repository.jpa.oprm.nichocnae.v3.OprmNichoCnaeV3StageExecutionRepository;
@@ -40,6 +42,11 @@ public class BackendPersonaTournamentService extends OprmNichoCnaeV3StageService
     /** Recebe o request bruto da etapa e registra auditoria para o pipeline NichoCNAE v3. */
     public PersonaTournamentCreateResponse recebeRequest(String cnaeCode, String jobId, OprmNichoCnaeV3RecebeRequestRequest request) {
         return new PersonaTournamentCreateResponse(null, doRecebeRequest(cnaeCode, jobId, request).getJobId(), cnaeCode, STAGE_CODE, "AGUARDANDO_MODULO");
+    }
+
+    /** Recebe o response bruto da etapa e registra conclusão ou falha do pipeline NichoCNAE v3. */
+    public OprmNichoCnaeV3RecebeResponseResponse recebeResponse(String cnaeCode, String jobId, OprmNichoCnaeV3RecebeResponseRequest request) {
+        return doRecebeResponse(cnaeCode, jobId, request, NEXT_STAGE);
     }
 
     /** Lista pendências da etapa persona-tournament para o executor OPRM. */

--- a/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/qualitygate/controller/BackendQualityGateController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/qualitygate/controller/BackendQualityGateController.java
@@ -6,7 +6,11 @@ import com.marketinghub.oprmcoletormei.nichocnae.v3.qualitygate.service.createSt
 import com.marketinghub.oprmcoletormei.nichocnae.v3.qualitygate.service.failStageExecution.QualityGateFailureRequest;
 import com.marketinghub.oprmcoletormei.nichocnae.v3.qualitygate.service.pending.QualityGatePendingResponse;
 import com.marketinghub.oprmcoletormei.nichocnae.v3.shared.OprmNichoCnaeV3RecebeRequestRequest;
+import com.marketinghub.oprmcoletormei.nichocnae.v3.shared.OprmNichoCnaeV3RecebeResponseRequest;
+import com.marketinghub.oprmcoletormei.nichocnae.v3.shared.OprmNichoCnaeV3RecebeResponseResponse;
 import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -19,6 +23,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/internal/oprm/nichocnae/v3/quality-gate/stage-executions")
 public class BackendQualityGateController {
+    private static final Logger log = LoggerFactory.getLogger(BackendQualityGateController.class);
     private final BackendQualityGateService service;
 
     /** Inicializa o controller com service canônico da etapa. */
@@ -48,6 +53,13 @@ public class BackendQualityGateController {
     @PostMapping("/cnaes/{cnaeCode}/jobs/{jobId}/recebeRequest")
     public QualityGateCreateResponse recebeRequest(@PathVariable String cnaeCode, @PathVariable String jobId, @RequestBody OprmNichoCnaeV3RecebeRequestRequest request) {
         return service.recebeRequest(cnaeCode, jobId, request);
+    }
+
+    /** Recebe o response bruto da etapa identificado pelo CNAE e jobId. */
+    @PostMapping("/cnaes/{cnaeCode}/jobs/{jobId}/recebeResponse")
+    public OprmNichoCnaeV3RecebeResponseResponse recebeResponse(@PathVariable String cnaeCode, @PathVariable String jobId, @RequestBody OprmNichoCnaeV3RecebeResponseRequest request) {
+        log.info("Recebendo response NichoCNAE v3. etapa={}, cnaeCode={}, jobId={}, payload={}", service.stageCode(), cnaeCode, jobId, request);
+        return service.recebeResponse(cnaeCode, jobId, request);
     }
 
     /** Entrega pendências da etapa quality-gate ao executor OPRM. */

--- a/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/qualitygate/service/BackendQualityGateService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/qualitygate/service/BackendQualityGateService.java
@@ -6,6 +6,8 @@ import com.marketinghub.oprmcoletormei.nichocnae.v3.qualitygate.service.createSt
 import com.marketinghub.oprmcoletormei.nichocnae.v3.qualitygate.service.pending.QualityGatePendingResponse;
 import com.marketinghub.oprmcoletormei.nichocnae.v3.shared.OprmNichoCnaeV3StageServiceSupport;
 import com.marketinghub.oprmcoletormei.nichocnae.v3.shared.OprmNichoCnaeV3RecebeRequestRequest;
+import com.marketinghub.oprmcoletormei.nichocnae.v3.shared.OprmNichoCnaeV3RecebeResponseRequest;
+import com.marketinghub.oprmcoletormei.nichocnae.v3.shared.OprmNichoCnaeV3RecebeResponseResponse;
 import com.marketinghub.repository.jpa.oprm.market.OprmCnpjCnaeDimRepository;
 import com.marketinghub.repository.jpa.oprm.nichocnae.PipelineNichoCnaeRepository;
 import com.marketinghub.repository.jpa.oprm.nichocnae.v3.OprmNichoCnaeV3StageExecutionRepository;
@@ -40,6 +42,11 @@ public class BackendQualityGateService extends OprmNichoCnaeV3StageServiceSuppor
     /** Recebe o request bruto da etapa e registra auditoria para o pipeline NichoCNAE v3. */
     public QualityGateCreateResponse recebeRequest(String cnaeCode, String jobId, OprmNichoCnaeV3RecebeRequestRequest request) {
         return new QualityGateCreateResponse(null, doRecebeRequest(cnaeCode, jobId, request).getJobId(), cnaeCode, STAGE_CODE, "AGUARDANDO_MODULO");
+    }
+
+    /** Recebe o response bruto da etapa e registra conclusão ou falha do pipeline NichoCNAE v3. */
+    public OprmNichoCnaeV3RecebeResponseResponse recebeResponse(String cnaeCode, String jobId, OprmNichoCnaeV3RecebeResponseRequest request) {
+        return doRecebeResponse(cnaeCode, jobId, request, NEXT_STAGE);
     }
 
     /** Lista pendências da etapa quality-gate para o executor OPRM. */

--- a/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/routinequeryplanner/controller/BackendRoutineQueryPlannerController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/routinequeryplanner/controller/BackendRoutineQueryPlannerController.java
@@ -6,7 +6,11 @@ import com.marketinghub.oprmcoletormei.nichocnae.v3.routinequeryplanner.service.
 import com.marketinghub.oprmcoletormei.nichocnae.v3.routinequeryplanner.service.failStageExecution.RoutineQueryPlannerFailureRequest;
 import com.marketinghub.oprmcoletormei.nichocnae.v3.routinequeryplanner.service.pending.RoutineQueryPlannerPendingResponse;
 import com.marketinghub.oprmcoletormei.nichocnae.v3.shared.OprmNichoCnaeV3RecebeRequestRequest;
+import com.marketinghub.oprmcoletormei.nichocnae.v3.shared.OprmNichoCnaeV3RecebeResponseRequest;
+import com.marketinghub.oprmcoletormei.nichocnae.v3.shared.OprmNichoCnaeV3RecebeResponseResponse;
 import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -19,6 +23,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/internal/oprm/nichocnae/v3/routine-query-planner/stage-executions")
 public class BackendRoutineQueryPlannerController {
+    private static final Logger log = LoggerFactory.getLogger(BackendRoutineQueryPlannerController.class);
     private final BackendRoutineQueryPlannerService service;
 
     /** Inicializa o controller com service canônico da etapa. */
@@ -48,6 +53,13 @@ public class BackendRoutineQueryPlannerController {
     @PostMapping("/cnaes/{cnaeCode}/jobs/{jobId}/recebeRequest")
     public RoutineQueryPlannerCreateResponse recebeRequest(@PathVariable String cnaeCode, @PathVariable String jobId, @RequestBody OprmNichoCnaeV3RecebeRequestRequest request) {
         return service.recebeRequest(cnaeCode, jobId, request);
+    }
+
+    /** Recebe o response bruto da etapa identificado pelo CNAE e jobId. */
+    @PostMapping("/cnaes/{cnaeCode}/jobs/{jobId}/recebeResponse")
+    public OprmNichoCnaeV3RecebeResponseResponse recebeResponse(@PathVariable String cnaeCode, @PathVariable String jobId, @RequestBody OprmNichoCnaeV3RecebeResponseRequest request) {
+        log.info("Recebendo response NichoCNAE v3. etapa={}, cnaeCode={}, jobId={}, payload={}", service.stageCode(), cnaeCode, jobId, request);
+        return service.recebeResponse(cnaeCode, jobId, request);
     }
 
     /** Entrega pendências da etapa routine-query-planner ao executor OPRM. */

--- a/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/routinequeryplanner/service/BackendRoutineQueryPlannerService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/routinequeryplanner/service/BackendRoutineQueryPlannerService.java
@@ -6,6 +6,8 @@ import com.marketinghub.oprmcoletormei.nichocnae.v3.routinequeryplanner.service.
 import com.marketinghub.oprmcoletormei.nichocnae.v3.routinequeryplanner.service.pending.RoutineQueryPlannerPendingResponse;
 import com.marketinghub.oprmcoletormei.nichocnae.v3.shared.OprmNichoCnaeV3StageServiceSupport;
 import com.marketinghub.oprmcoletormei.nichocnae.v3.shared.OprmNichoCnaeV3RecebeRequestRequest;
+import com.marketinghub.oprmcoletormei.nichocnae.v3.shared.OprmNichoCnaeV3RecebeResponseRequest;
+import com.marketinghub.oprmcoletormei.nichocnae.v3.shared.OprmNichoCnaeV3RecebeResponseResponse;
 import com.marketinghub.repository.jpa.oprm.market.OprmCnpjCnaeDimRepository;
 import com.marketinghub.repository.jpa.oprm.nichocnae.PipelineNichoCnaeRepository;
 import com.marketinghub.repository.jpa.oprm.nichocnae.v3.OprmNichoCnaeV3StageExecutionRepository;
@@ -40,6 +42,11 @@ public class BackendRoutineQueryPlannerService extends OprmNichoCnaeV3StageServi
     /** Recebe o request bruto da etapa e registra auditoria para o pipeline NichoCNAE v3. */
     public RoutineQueryPlannerCreateResponse recebeRequest(String cnaeCode, String jobId, OprmNichoCnaeV3RecebeRequestRequest request) {
         return new RoutineQueryPlannerCreateResponse(null, doRecebeRequest(cnaeCode, jobId, request).getJobId(), cnaeCode, STAGE_CODE, "AGUARDANDO_MODULO");
+    }
+
+    /** Recebe o response bruto da etapa e registra conclusão ou falha do pipeline NichoCNAE v3. */
+    public OprmNichoCnaeV3RecebeResponseResponse recebeResponse(String cnaeCode, String jobId, OprmNichoCnaeV3RecebeResponseRequest request) {
+        return doRecebeResponse(cnaeCode, jobId, request, NEXT_STAGE);
     }
 
     /** Lista pendências da etapa routine-query-planner para o executor OPRM. */

--- a/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/routinesignalextractor/controller/BackendRoutineSignalExtractorController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/routinesignalextractor/controller/BackendRoutineSignalExtractorController.java
@@ -6,7 +6,11 @@ import com.marketinghub.oprmcoletormei.nichocnae.v3.routinesignalextractor.servi
 import com.marketinghub.oprmcoletormei.nichocnae.v3.routinesignalextractor.service.failStageExecution.RoutineSignalExtractorFailureRequest;
 import com.marketinghub.oprmcoletormei.nichocnae.v3.routinesignalextractor.service.pending.RoutineSignalExtractorPendingResponse;
 import com.marketinghub.oprmcoletormei.nichocnae.v3.shared.OprmNichoCnaeV3RecebeRequestRequest;
+import com.marketinghub.oprmcoletormei.nichocnae.v3.shared.OprmNichoCnaeV3RecebeResponseRequest;
+import com.marketinghub.oprmcoletormei.nichocnae.v3.shared.OprmNichoCnaeV3RecebeResponseResponse;
 import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -19,6 +23,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/internal/oprm/nichocnae/v3/routine-signal-extractor/stage-executions")
 public class BackendRoutineSignalExtractorController {
+    private static final Logger log = LoggerFactory.getLogger(BackendRoutineSignalExtractorController.class);
     private final BackendRoutineSignalExtractorService service;
 
     /** Inicializa o controller com service canônico da etapa. */
@@ -48,6 +53,13 @@ public class BackendRoutineSignalExtractorController {
     @PostMapping("/cnaes/{cnaeCode}/jobs/{jobId}/recebeRequest")
     public RoutineSignalExtractorCreateResponse recebeRequest(@PathVariable String cnaeCode, @PathVariable String jobId, @RequestBody OprmNichoCnaeV3RecebeRequestRequest request) {
         return service.recebeRequest(cnaeCode, jobId, request);
+    }
+
+    /** Recebe o response bruto da etapa identificado pelo CNAE e jobId. */
+    @PostMapping("/cnaes/{cnaeCode}/jobs/{jobId}/recebeResponse")
+    public OprmNichoCnaeV3RecebeResponseResponse recebeResponse(@PathVariable String cnaeCode, @PathVariable String jobId, @RequestBody OprmNichoCnaeV3RecebeResponseRequest request) {
+        log.info("Recebendo response NichoCNAE v3. etapa={}, cnaeCode={}, jobId={}, payload={}", service.stageCode(), cnaeCode, jobId, request);
+        return service.recebeResponse(cnaeCode, jobId, request);
     }
 
     /** Entrega pendências da etapa routine-signal-extractor ao executor OPRM. */

--- a/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/routinesignalextractor/service/BackendRoutineSignalExtractorService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/routinesignalextractor/service/BackendRoutineSignalExtractorService.java
@@ -6,6 +6,8 @@ import com.marketinghub.oprmcoletormei.nichocnae.v3.routinesignalextractor.servi
 import com.marketinghub.oprmcoletormei.nichocnae.v3.routinesignalextractor.service.pending.RoutineSignalExtractorPendingResponse;
 import com.marketinghub.oprmcoletormei.nichocnae.v3.shared.OprmNichoCnaeV3StageServiceSupport;
 import com.marketinghub.oprmcoletormei.nichocnae.v3.shared.OprmNichoCnaeV3RecebeRequestRequest;
+import com.marketinghub.oprmcoletormei.nichocnae.v3.shared.OprmNichoCnaeV3RecebeResponseRequest;
+import com.marketinghub.oprmcoletormei.nichocnae.v3.shared.OprmNichoCnaeV3RecebeResponseResponse;
 import com.marketinghub.repository.jpa.oprm.market.OprmCnpjCnaeDimRepository;
 import com.marketinghub.repository.jpa.oprm.nichocnae.PipelineNichoCnaeRepository;
 import com.marketinghub.repository.jpa.oprm.nichocnae.v3.OprmNichoCnaeV3StageExecutionRepository;
@@ -40,6 +42,11 @@ public class BackendRoutineSignalExtractorService extends OprmNichoCnaeV3StageSe
     /** Recebe o request bruto da etapa e registra auditoria para o pipeline NichoCNAE v3. */
     public RoutineSignalExtractorCreateResponse recebeRequest(String cnaeCode, String jobId, OprmNichoCnaeV3RecebeRequestRequest request) {
         return new RoutineSignalExtractorCreateResponse(null, doRecebeRequest(cnaeCode, jobId, request).getJobId(), cnaeCode, STAGE_CODE, "AGUARDANDO_MODULO");
+    }
+
+    /** Recebe o response bruto da etapa e registra conclusão ou falha do pipeline NichoCNAE v3. */
+    public OprmNichoCnaeV3RecebeResponseResponse recebeResponse(String cnaeCode, String jobId, OprmNichoCnaeV3RecebeResponseRequest request) {
+        return doRecebeResponse(cnaeCode, jobId, request, NEXT_STAGE);
     }
 
     /** Lista pendências da etapa routine-signal-extractor para o executor OPRM. */

--- a/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/shared/OprmNichoCnaeV3RecebeResponseRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/shared/OprmNichoCnaeV3RecebeResponseRequest.java
@@ -1,0 +1,13 @@
+package com.marketinghub.oprmcoletormei.nichocnae.v3.shared;
+
+import java.math.BigDecimal;
+
+/** Payload recebido do módulo executor para registrar auditoria de response da etapa NichoCNAE v3. */
+public record OprmNichoCnaeV3RecebeResponseRequest(
+        String response,
+        String descricaoErro,
+        Long quantidadeTokenEntrada,
+        Long quantidadeTokenSaida,
+        BigDecimal custo,
+        String modelo) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/shared/OprmNichoCnaeV3RecebeResponseResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/shared/OprmNichoCnaeV3RecebeResponseResponse.java
@@ -1,0 +1,5 @@
+package com.marketinghub.oprmcoletormei.nichocnae.v3.shared;
+
+/** Resposta canônica do backend após receber response de etapa NichoCNAE v3. */
+public record OprmNichoCnaeV3RecebeResponseResponse(String codigoProximaEtapa) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/shared/OprmNichoCnaeV3StageServiceSupport.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/shared/OprmNichoCnaeV3StageServiceSupport.java
@@ -23,6 +23,9 @@ public abstract class OprmNichoCnaeV3StageServiceSupport {
     private static final int PENDING_LIMIT = 10;
     private static final String STATUS_WAITING_MODULE = "AGUARDANDO_MODULO";
     private static final String PIPELINE_VERSION = "v3";
+    private static final String RESPONSE_PIPELINE_VERSION = "v1";
+    private static final String STATUS_COMPLETED = "CONCLUIDO";
+    private static final String STATUS_FAILED = "FALHA";
     private static final Map<String, Integer> STAGE_ORDER = Map.ofEntries(
             Map.entry("cnae-intake", 1),
             Map.entry("persona-candidate-generator", 2),
@@ -49,6 +52,12 @@ public abstract class OprmNichoCnaeV3StageServiceSupport {
         this.cnaeRepository = cnaeRepository;
         this.pipelineNichoCnaeRepository = pipelineNichoCnaeRepository;
         this.stageCode = stageCode;
+    }
+
+
+    /** Retorna o código canônico da etapa atendida pelo service. */
+    public String stageCode() {
+        return stageCode;
     }
 
     /** Marca no cadastro de CNAE que o pipeline NichoCNAE v3 foi iniciado na etapa atual. */
@@ -89,6 +98,41 @@ public abstract class OprmNichoCnaeV3StageServiceSupport {
         pipeline.setSchema(request == null ? null : request.schema());
         pipeline.setVersaoPipeline(PIPELINE_VERSION);
         return pipelineNichoCnaeRepository.save(pipeline);
+    }
+
+
+    /** Recebe o response bruto da etapa, conclui ou falha o CNAE e audita o retorno no pipeline NichoCNAE. */
+    protected OprmNichoCnaeV3RecebeResponseResponse doRecebeResponse(
+            String cnaeCode, String jobId, OprmNichoCnaeV3RecebeResponseRequest request, String nextStageCode) {
+        if (!StringUtils.hasText(jobId)) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "jobId é obrigatório no recebimento do response.");
+        }
+        OprmCnpjCnaeDim cnae = cnaeRepository.findById(cnaeCode)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "CNAE não encontrado."));
+        Instant now = Instant.now();
+        boolean hasFailure = request != null && StringUtils.hasText(request.descricaoErro());
+        cnae.setNichocnaePipelineStatus(hasFailure ? STATUS_FAILED : STATUS_COMPLETED);
+        cnae.setNichocnaeCurrentStageCode(stageCode);
+        cnae.setNichocnaePipelineUpdatedAt(now);
+        cnae.setUpdatedAt(now);
+        cnaeRepository.save(cnae);
+
+        PipelineNichoCnae pipeline = new PipelineNichoCnae();
+        pipeline.setIdExterno(cnaeCode);
+        pipeline.setResponse(request == null ? null : request.response());
+        pipeline.setCodigoEtapa(stageCode);
+        pipeline.setDataHora(now);
+        pipeline.setJobId(jobId);
+        pipeline.setQuantidadeTokenEntrada(request == null ? null : request.quantidadeTokenEntrada());
+        pipeline.setQuantidadeTokenSaida(request == null ? null : request.quantidadeTokenSaida());
+        pipeline.setCusto(request == null ? null : request.custo());
+        pipeline.setModelo(request == null ? null : request.modelo());
+        pipeline.setDescricaoErro(request == null ? null : request.descricaoErro());
+        pipeline.setVersaoPipeline(RESPONSE_PIPELINE_VERSION);
+        pipelineNichoCnaeRepository.save(pipeline);
+
+        String normalizedNextStage = StringUtils.hasText(nextStageCode) ? nextStageCode : null;
+        return new OprmNichoCnaeV3RecebeResponseResponse(hasFailure ? null : normalizedNextStage);
     }
 
     /** Cria uma execução pendente para a etapa canônica. */

--- a/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/sourcefetcher/controller/BackendSourceFetcherV3Controller.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/sourcefetcher/controller/BackendSourceFetcherV3Controller.java
@@ -6,7 +6,11 @@ import com.marketinghub.oprmcoletormei.nichocnae.v3.sourcefetcher.service.create
 import com.marketinghub.oprmcoletormei.nichocnae.v3.sourcefetcher.service.failStageExecution.SourceFetcherFailureRequest;
 import com.marketinghub.oprmcoletormei.nichocnae.v3.sourcefetcher.service.pending.SourceFetcherPendingResponse;
 import com.marketinghub.oprmcoletormei.nichocnae.v3.shared.OprmNichoCnaeV3RecebeRequestRequest;
+import com.marketinghub.oprmcoletormei.nichocnae.v3.shared.OprmNichoCnaeV3RecebeResponseRequest;
+import com.marketinghub.oprmcoletormei.nichocnae.v3.shared.OprmNichoCnaeV3RecebeResponseResponse;
 import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -19,6 +23,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/internal/oprm/nichocnae/v3/source-fetcher/stage-executions")
 public class BackendSourceFetcherV3Controller {
+    private static final Logger log = LoggerFactory.getLogger(BackendSourceFetcherV3Controller.class);
     private final BackendSourceFetcherV3Service service;
 
     /** Inicializa o controller com service canônico da etapa. */
@@ -48,6 +53,13 @@ public class BackendSourceFetcherV3Controller {
     @PostMapping("/cnaes/{cnaeCode}/jobs/{jobId}/recebeRequest")
     public SourceFetcherCreateResponse recebeRequest(@PathVariable String cnaeCode, @PathVariable String jobId, @RequestBody OprmNichoCnaeV3RecebeRequestRequest request) {
         return service.recebeRequest(cnaeCode, jobId, request);
+    }
+
+    /** Recebe o response bruto da etapa identificado pelo CNAE e jobId. */
+    @PostMapping("/cnaes/{cnaeCode}/jobs/{jobId}/recebeResponse")
+    public OprmNichoCnaeV3RecebeResponseResponse recebeResponse(@PathVariable String cnaeCode, @PathVariable String jobId, @RequestBody OprmNichoCnaeV3RecebeResponseRequest request) {
+        log.info("Recebendo response NichoCNAE v3. etapa={}, cnaeCode={}, jobId={}, payload={}", service.stageCode(), cnaeCode, jobId, request);
+        return service.recebeResponse(cnaeCode, jobId, request);
     }
 
     /** Entrega pendências da etapa source-fetcher ao executor OPRM. */

--- a/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/sourcefetcher/service/BackendSourceFetcherV3Service.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/sourcefetcher/service/BackendSourceFetcherV3Service.java
@@ -6,6 +6,8 @@ import com.marketinghub.oprmcoletormei.nichocnae.v3.sourcefetcher.service.create
 import com.marketinghub.oprmcoletormei.nichocnae.v3.sourcefetcher.service.pending.SourceFetcherPendingResponse;
 import com.marketinghub.oprmcoletormei.nichocnae.v3.shared.OprmNichoCnaeV3StageServiceSupport;
 import com.marketinghub.oprmcoletormei.nichocnae.v3.shared.OprmNichoCnaeV3RecebeRequestRequest;
+import com.marketinghub.oprmcoletormei.nichocnae.v3.shared.OprmNichoCnaeV3RecebeResponseRequest;
+import com.marketinghub.oprmcoletormei.nichocnae.v3.shared.OprmNichoCnaeV3RecebeResponseResponse;
 import com.marketinghub.repository.jpa.oprm.market.OprmCnpjCnaeDimRepository;
 import com.marketinghub.repository.jpa.oprm.nichocnae.PipelineNichoCnaeRepository;
 import com.marketinghub.repository.jpa.oprm.nichocnae.v3.OprmNichoCnaeV3StageExecutionRepository;
@@ -40,6 +42,11 @@ public class BackendSourceFetcherV3Service extends OprmNichoCnaeV3StageServiceSu
     /** Recebe o request bruto da etapa e registra auditoria para o pipeline NichoCNAE v3. */
     public SourceFetcherCreateResponse recebeRequest(String cnaeCode, String jobId, OprmNichoCnaeV3RecebeRequestRequest request) {
         return new SourceFetcherCreateResponse(null, doRecebeRequest(cnaeCode, jobId, request).getJobId(), cnaeCode, STAGE_CODE, "AGUARDANDO_MODULO");
+    }
+
+    /** Recebe o response bruto da etapa e registra conclusão ou falha do pipeline NichoCNAE v3. */
+    public OprmNichoCnaeV3RecebeResponseResponse recebeResponse(String cnaeCode, String jobId, OprmNichoCnaeV3RecebeResponseRequest request) {
+        return doRecebeResponse(cnaeCode, jobId, request, NEXT_STAGE);
     }
 
     /** Lista pendências da etapa source-fetcher para o executor OPRM. */

--- a/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/sourcesearcher/controller/BackendSourceSearcherV3Controller.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/sourcesearcher/controller/BackendSourceSearcherV3Controller.java
@@ -6,7 +6,11 @@ import com.marketinghub.oprmcoletormei.nichocnae.v3.sourcesearcher.service.creat
 import com.marketinghub.oprmcoletormei.nichocnae.v3.sourcesearcher.service.failStageExecution.SourceSearcherFailureRequest;
 import com.marketinghub.oprmcoletormei.nichocnae.v3.sourcesearcher.service.pending.SourceSearcherPendingResponse;
 import com.marketinghub.oprmcoletormei.nichocnae.v3.shared.OprmNichoCnaeV3RecebeRequestRequest;
+import com.marketinghub.oprmcoletormei.nichocnae.v3.shared.OprmNichoCnaeV3RecebeResponseRequest;
+import com.marketinghub.oprmcoletormei.nichocnae.v3.shared.OprmNichoCnaeV3RecebeResponseResponse;
 import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -19,6 +23,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/internal/oprm/nichocnae/v3/source-searcher/stage-executions")
 public class BackendSourceSearcherV3Controller {
+    private static final Logger log = LoggerFactory.getLogger(BackendSourceSearcherV3Controller.class);
     private final BackendSourceSearcherV3Service service;
 
     /** Inicializa o controller com service canônico da etapa. */
@@ -48,6 +53,13 @@ public class BackendSourceSearcherV3Controller {
     @PostMapping("/cnaes/{cnaeCode}/jobs/{jobId}/recebeRequest")
     public SourceSearcherCreateResponse recebeRequest(@PathVariable String cnaeCode, @PathVariable String jobId, @RequestBody OprmNichoCnaeV3RecebeRequestRequest request) {
         return service.recebeRequest(cnaeCode, jobId, request);
+    }
+
+    /** Recebe o response bruto da etapa identificado pelo CNAE e jobId. */
+    @PostMapping("/cnaes/{cnaeCode}/jobs/{jobId}/recebeResponse")
+    public OprmNichoCnaeV3RecebeResponseResponse recebeResponse(@PathVariable String cnaeCode, @PathVariable String jobId, @RequestBody OprmNichoCnaeV3RecebeResponseRequest request) {
+        log.info("Recebendo response NichoCNAE v3. etapa={}, cnaeCode={}, jobId={}, payload={}", service.stageCode(), cnaeCode, jobId, request);
+        return service.recebeResponse(cnaeCode, jobId, request);
     }
 
     /** Entrega pendências da etapa source-searcher ao executor OPRM. */

--- a/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/sourcesearcher/service/BackendSourceSearcherV3Service.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/sourcesearcher/service/BackendSourceSearcherV3Service.java
@@ -6,6 +6,8 @@ import com.marketinghub.oprmcoletormei.nichocnae.v3.sourcesearcher.service.creat
 import com.marketinghub.oprmcoletormei.nichocnae.v3.sourcesearcher.service.pending.SourceSearcherPendingResponse;
 import com.marketinghub.oprmcoletormei.nichocnae.v3.shared.OprmNichoCnaeV3StageServiceSupport;
 import com.marketinghub.oprmcoletormei.nichocnae.v3.shared.OprmNichoCnaeV3RecebeRequestRequest;
+import com.marketinghub.oprmcoletormei.nichocnae.v3.shared.OprmNichoCnaeV3RecebeResponseRequest;
+import com.marketinghub.oprmcoletormei.nichocnae.v3.shared.OprmNichoCnaeV3RecebeResponseResponse;
 import com.marketinghub.repository.jpa.oprm.market.OprmCnpjCnaeDimRepository;
 import com.marketinghub.repository.jpa.oprm.nichocnae.PipelineNichoCnaeRepository;
 import com.marketinghub.repository.jpa.oprm.nichocnae.v3.OprmNichoCnaeV3StageExecutionRepository;
@@ -40,6 +42,11 @@ public class BackendSourceSearcherV3Service extends OprmNichoCnaeV3StageServiceS
     /** Recebe o request bruto da etapa e registra auditoria para o pipeline NichoCNAE v3. */
     public SourceSearcherCreateResponse recebeRequest(String cnaeCode, String jobId, OprmNichoCnaeV3RecebeRequestRequest request) {
         return new SourceSearcherCreateResponse(null, doRecebeRequest(cnaeCode, jobId, request).getJobId(), cnaeCode, STAGE_CODE, "AGUARDANDO_MODULO");
+    }
+
+    /** Recebe o response bruto da etapa e registra conclusão ou falha do pipeline NichoCNAE v3. */
+    public OprmNichoCnaeV3RecebeResponseResponse recebeResponse(String cnaeCode, String jobId, OprmNichoCnaeV3RecebeResponseRequest request) {
+        return doRecebeResponse(cnaeCode, jobId, request, NEXT_STAGE);
     }
 
     /** Lista pendências da etapa source-searcher para o executor OPRM. */


### PR DESCRIPTION
### Motivation
- Allow external executors to report back the step `response` for OPRM NichoCNAE v3 so the backend can audit the payload, update CNAE pipeline status/timestamps and decide the next stage. 
- Persist a canonical audit record for responses in `pipeline_nichocnae` including tokens, cost, model and error detail to enable end-to-end traceability and cost accounting.

### Description
- Added request/response DTOs `OprmNichoCnaeV3RecebeResponseRequest` and `OprmNichoCnaeV3RecebeResponseResponse` to represent the response payload and canonical backend reply. 
- Added `recebeResponse` endpoints to all NichoCNAE v3 stage controllers under the pattern `/cnaes/{cnaeCode}/jobs/{jobId}/recebeResponse` with an initial `log.info(...)` that includes `stage`, `cnaeCode`, `jobId` and `payload`. 
- Implemented shared handling in `OprmNichoCnaeV3StageServiceSupport.doRecebeResponse(...)` which validates `jobId`, sets `nichocnae_pipeline_status` to `CONCLUIDO` or `FALHA` depending on `descricaoErro`, updates pipeline timestamp fields, persists a `PipelineNichoCnae` audit row (`response`, `descricao_erro`, `quantidade_token_*`, `custo`, `modelo`, `versao_pipeline='v1'`, etc.), and returns the next stage code or `null` on failure/final stage. 
- Exposed a `stageCode()` accessor on the shared support and wired each stage service to expose `recebeResponse(...)` delegating to the shared `doRecebeResponse(...)` with the stage-specific `NEXT_STAGE` constant.

### Testing
- Ran `mvn -DskipTests compile` and the module compiled successfully. 
- Ran the focused test `mvn -Dtest=BackendPersonaRoutineMaterializerServiceTest test` and it passed. 
- Ran full `mvn test -DskipITs` which reported pre-existing/unrelated test failures (`PipelineServiceTest.shouldMatchOprmNichoCnaeOpenAiFlagsWithCollectorCode` and `ArquiteturaTest.moisDossieV1StagesMustExposeCanonicalStructure`) not introduced by this change. 
- Attempted `mvn -DskipTests spotless:check` which failed because the `spotless` plugin prefix is not resolvable in CI here (project plugin config environment issue).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3f1ec390d08321a21f5edb39f0ad6e)