### PR TITLE
Implementa endpoints /recebeResponse e auditoria para pipeline dossiê MOIS v1

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/dossiersynthesis/controller/DossierDossierSynthesisController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/dossiersynthesis/controller/DossierDossierSynthesisController.java
@@ -5,8 +5,11 @@ import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.dossiersynthe
 import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.dossiersynthesis.service.receberequest.DossierDossierSynthesisRecebeRequestResponse;
 import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.dossiersynthesis.service.pending.DossierDossierSynthesisPendingRequest;
 import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.dossiersynthesis.service.pending.DossierDossierSynthesisPendingResponse;
+import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.dossiersynthesis.service.receberesponse.DossierDossierSynthesisRecebeResponseRequest;
+import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.dossiersynthesis.service.receberesponse.DossierDossierSynthesisRecebeResponseResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -16,6 +19,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 /** Expõe a borda HTTP interna da etapa síntese final do dossiê do pipeline de dossiê MOIS v1. */
 @RestController
+@Slf4j
 @RequestMapping("/api/internal/mois/dossie/v1/dossier-synthesis/stage-executions")
 @RequiredArgsConstructor
 public class DossierDossierSynthesisController {
@@ -36,6 +40,22 @@ public class DossierDossierSynthesisController {
             @PathVariable("jobId") String jobId,
             @Valid @RequestBody DossierDossierSynthesisRecebeRequestRequest request) {
         return service.recebeRequest(productKey, jobId, request);
+    }
+
+
+    /** Recebe a resposta do módulo executor para a página/produto informada pela chave operacional. */
+    @PostMapping("/{productKey}/{jobId}/recebeResponse")
+    public DossierDossierSynthesisRecebeResponseResponse recebeResponse(
+            @PathVariable("productKey") String productKey,
+            @PathVariable("jobId") String jobId,
+            @Valid @RequestBody DossierDossierSynthesisRecebeResponseRequest request) {
+        log.info(
+                "Recebendo response do dossiê MOIS v1: etapa={}, productKey={}, jobId={}, payload={}",
+                "dossier-synthesis",
+                productKey,
+                jobId,
+                request);
+        return service.recebeResponse(productKey, jobId, request);
     }
 
     /** Expõe o ponto inicial canônico de consumo da fila pelo módulo executor. */

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/dossiersynthesis/service/DossierDossierSynthesisService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/dossiersynthesis/service/DossierDossierSynthesisService.java
@@ -5,6 +5,8 @@ import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.dossiersynthe
 import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.dossiersynthesis.service.pending.DossierDossierSynthesisPendingResponse;
 import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.dossiersynthesis.service.receberequest.DossierDossierSynthesisRecebeRequestRequest;
 import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.dossiersynthesis.service.receberequest.DossierDossierSynthesisRecebeRequestResponse;
+import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.dossiersynthesis.service.receberesponse.DossierDossierSynthesisRecebeResponseRequest;
+import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.dossiersynthesis.service.receberesponse.DossierDossierSynthesisRecebeResponseResponse;
 import com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1.MoisSalesPageRepository;
 import com.marketinghub.repository.jpa.mois.dossieproduto.PipelineDossieProdutoRepository;
 import com.marketinghub.repository.jpa.mois.dossieproduto.entity.PipelineDossieProduto;
@@ -81,6 +83,47 @@ public class DossierDossierSynthesisService {
         pipelineDossieProdutoRepository.save(pipeline);
 
         return new DossierDossierSynthesisRecebeRequestResponse(jobId, productKey, STAGE_CODE, STATUS_WAITING);
+    }
+
+
+    /** Recebe a resposta operacional da etapa, conclui ou falha a página/produto e audita a saída do pipeline. */
+    public DossierDossierSynthesisRecebeResponseResponse recebeResponse(String productKey, String jobId, DossierDossierSynthesisRecebeResponseRequest request) {
+        long pageId = Long.parseLong(productKey);
+        Instant now = Instant.now();
+        String status = isBlank(request.descricaoErro()) ? STATUS_COMPLETED : STATUS_FAILED;
+        var page = salesPageRepository.findById(pageId)
+                .orElseThrow(() -> new IllegalArgumentException("Página/produto MOIS não encontrada: " + productKey));
+        page.setDossieProdutoStatus(status);
+        page.setDossieProdutoCurrentStage(STAGE_CODE);
+        page.setDossieProdutoUpdatedAt(now);
+        salesPageRepository.save(page);
+
+        PipelineDossieProduto pipeline = new PipelineDossieProduto();
+        pipeline.setIdExterno(productKey);
+        pipeline.setResponse(request.response());
+        pipeline.setCodigoEtapa(STAGE_CODE);
+        pipeline.setDataHora(now);
+        pipeline.setJobId(jobId);
+        pipeline.setQuantidadeTokenEntrada(request.quantidadeTokenEntrada());
+        pipeline.setQuantidadeTokenSaida(request.quantidadeTokenSaida());
+        pipeline.setCusto(request.custo());
+        pipeline.setModelo(request.modelo());
+        pipeline.setDescricaoErro(request.descricaoErro());
+        pipeline.setVersaoPipeline("v1");
+        pipelineDossieProdutoRepository.save(pipeline);
+
+        String nextStageCode = STATUS_COMPLETED.equals(status) ? normalizeNextStage(NEXT_STAGE) : null;
+        return new DossierDossierSynthesisRecebeResponseResponse(jobId, productKey, STAGE_CODE, status, nextStageCode);
+    }
+
+    /** Normaliza a próxima etapa para nulo quando a etapa atual encerra o pipeline. */
+    private String normalizeNextStage(String nextStage) {
+        return isBlank(nextStage) ? null : nextStage;
+    }
+
+    /** Verifica se o texto informado está vazio para decidir sucesso ou falha da etapa. */
+    private boolean isBlank(String value) {
+        return value == null || value.isBlank();
     }
 
     /** Entrega até dez trabalhos iniciados da etapa atual ao executor, ordenados pela data operacional mais antiga. */

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/dossiersynthesis/service/receberesponse/DossierDossierSynthesisRecebeResponseRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/dossiersynthesis/service/receberesponse/DossierDossierSynthesisRecebeResponseRequest.java
@@ -1,0 +1,13 @@
+package com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.dossiersynthesis.service.receberesponse;
+
+import java.math.BigDecimal;
+
+/** Contrato de entrada do endpoint recebeResponse da etapa dossiersynthesis do dossiê MOIS v1. */
+public record DossierDossierSynthesisRecebeResponseRequest(
+        String response,
+        String descricaoErro,
+        Long quantidadeTokenEntrada,
+        Long quantidadeTokenSaida,
+        BigDecimal custo,
+        String modelo) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/dossiersynthesis/service/receberesponse/DossierDossierSynthesisRecebeResponseResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/dossiersynthesis/service/receberesponse/DossierDossierSynthesisRecebeResponseResponse.java
@@ -1,0 +1,6 @@
+package com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.dossiersynthesis.service.receberesponse;
+
+/** Contrato de saída do endpoint recebeResponse da etapa dossiersynthesis do dossiê MOIS v1. */
+public record DossierDossierSynthesisRecebeResponseResponse(
+        String jobId, String productKey, String stageCode, String status, String nextStageCode) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/intake/controller/DossierIntakeController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/intake/controller/DossierIntakeController.java
@@ -5,8 +5,11 @@ import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.intake.servic
 import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.intake.service.receberequest.DossierIntakeRecebeRequestResponse;
 import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.intake.service.pending.DossierIntakePendingRequest;
 import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.intake.service.pending.DossierIntakePendingResponse;
+import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.intake.service.receberesponse.DossierIntakeRecebeResponseRequest;
+import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.intake.service.receberesponse.DossierIntakeRecebeResponseResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -16,6 +19,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 /** Expõe a borda HTTP interna da etapa entrada inicial do pipeline de dossiê MOIS v1. */
 @RestController
+@Slf4j
 @RequestMapping("/api/internal/mois/dossie/v1/intake/stage-executions")
 @RequiredArgsConstructor
 public class DossierIntakeController {
@@ -36,6 +40,22 @@ public class DossierIntakeController {
             @PathVariable("jobId") String jobId,
             @Valid @RequestBody DossierIntakeRecebeRequestRequest request) {
         return service.recebeRequest(productKey, jobId, request);
+    }
+
+
+    /** Recebe a resposta do módulo executor para a página/produto informada pela chave operacional. */
+    @PostMapping("/{productKey}/{jobId}/recebeResponse")
+    public DossierIntakeRecebeResponseResponse recebeResponse(
+            @PathVariable("productKey") String productKey,
+            @PathVariable("jobId") String jobId,
+            @Valid @RequestBody DossierIntakeRecebeResponseRequest request) {
+        log.info(
+                "Recebendo response do dossiê MOIS v1: etapa={}, productKey={}, jobId={}, payload={}",
+                "intake",
+                productKey,
+                jobId,
+                request);
+        return service.recebeResponse(productKey, jobId, request);
     }
 
     /** Expõe o ponto inicial canônico de consumo da fila pelo módulo executor. */

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/intake/service/DossierIntakeService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/intake/service/DossierIntakeService.java
@@ -5,6 +5,8 @@ import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.intake.servic
 import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.intake.service.pending.DossierIntakePendingResponse;
 import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.intake.service.receberequest.DossierIntakeRecebeRequestRequest;
 import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.intake.service.receberequest.DossierIntakeRecebeRequestResponse;
+import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.intake.service.receberesponse.DossierIntakeRecebeResponseRequest;
+import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.intake.service.receberesponse.DossierIntakeRecebeResponseResponse;
 import com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1.MoisSalesPageRepository;
 import com.marketinghub.repository.jpa.mois.dossieproduto.PipelineDossieProdutoRepository;
 import com.marketinghub.repository.jpa.mois.dossieproduto.entity.PipelineDossieProduto;
@@ -81,6 +83,47 @@ public class DossierIntakeService {
         pipelineDossieProdutoRepository.save(pipeline);
 
         return new DossierIntakeRecebeRequestResponse(jobId, productKey, STAGE_CODE, STATUS_WAITING);
+    }
+
+
+    /** Recebe a resposta operacional da etapa, conclui ou falha a página/produto e audita a saída do pipeline. */
+    public DossierIntakeRecebeResponseResponse recebeResponse(String productKey, String jobId, DossierIntakeRecebeResponseRequest request) {
+        long pageId = Long.parseLong(productKey);
+        Instant now = Instant.now();
+        String status = isBlank(request.descricaoErro()) ? STATUS_COMPLETED : STATUS_FAILED;
+        var page = salesPageRepository.findById(pageId)
+                .orElseThrow(() -> new IllegalArgumentException("Página/produto MOIS não encontrada: " + productKey));
+        page.setDossieProdutoStatus(status);
+        page.setDossieProdutoCurrentStage(STAGE_CODE);
+        page.setDossieProdutoUpdatedAt(now);
+        salesPageRepository.save(page);
+
+        PipelineDossieProduto pipeline = new PipelineDossieProduto();
+        pipeline.setIdExterno(productKey);
+        pipeline.setResponse(request.response());
+        pipeline.setCodigoEtapa(STAGE_CODE);
+        pipeline.setDataHora(now);
+        pipeline.setJobId(jobId);
+        pipeline.setQuantidadeTokenEntrada(request.quantidadeTokenEntrada());
+        pipeline.setQuantidadeTokenSaida(request.quantidadeTokenSaida());
+        pipeline.setCusto(request.custo());
+        pipeline.setModelo(request.modelo());
+        pipeline.setDescricaoErro(request.descricaoErro());
+        pipeline.setVersaoPipeline("v1");
+        pipelineDossieProdutoRepository.save(pipeline);
+
+        String nextStageCode = STATUS_COMPLETED.equals(status) ? normalizeNextStage(NEXT_STAGE) : null;
+        return new DossierIntakeRecebeResponseResponse(jobId, productKey, STAGE_CODE, status, nextStageCode);
+    }
+
+    /** Normaliza a próxima etapa para nulo quando a etapa atual encerra o pipeline. */
+    private String normalizeNextStage(String nextStage) {
+        return isBlank(nextStage) ? null : nextStage;
+    }
+
+    /** Verifica se o texto informado está vazio para decidir sucesso ou falha da etapa. */
+    private boolean isBlank(String value) {
+        return value == null || value.isBlank();
     }
 
     /** Entrega até dez trabalhos iniciados da etapa atual ao executor, ordenados pela data operacional mais antiga. */

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/intake/service/receberesponse/DossierIntakeRecebeResponseRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/intake/service/receberesponse/DossierIntakeRecebeResponseRequest.java
@@ -1,0 +1,13 @@
+package com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.intake.service.receberesponse;
+
+import java.math.BigDecimal;
+
+/** Contrato de entrada do endpoint recebeResponse da etapa intake do dossiê MOIS v1. */
+public record DossierIntakeRecebeResponseRequest(
+        String response,
+        String descricaoErro,
+        Long quantidadeTokenEntrada,
+        Long quantidadeTokenSaida,
+        BigDecimal custo,
+        String modelo) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/intake/service/receberesponse/DossierIntakeRecebeResponseResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/intake/service/receberesponse/DossierIntakeRecebeResponseResponse.java
@@ -1,0 +1,6 @@
+package com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.intake.service.receberesponse;
+
+/** Contrato de saída do endpoint recebeResponse da etapa intake do dossiê MOIS v1. */
+public record DossierIntakeRecebeResponseResponse(
+        String jobId, String productKey, String stageCode, String status, String nextStageCode) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/investigationanchorbuilder/controller/DossierInvestigationAnchorBuilderController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/investigationanchorbuilder/controller/DossierInvestigationAnchorBuilderController.java
@@ -5,8 +5,11 @@ import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.investigation
 import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.investigationanchorbuilder.service.receberequest.DossierInvestigationAnchorBuilderRecebeRequestResponse;
 import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.investigationanchorbuilder.service.pending.DossierInvestigationAnchorBuilderPendingRequest;
 import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.investigationanchorbuilder.service.pending.DossierInvestigationAnchorBuilderPendingResponse;
+import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.investigationanchorbuilder.service.receberesponse.DossierInvestigationAnchorBuilderRecebeResponseRequest;
+import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.investigationanchorbuilder.service.receberesponse.DossierInvestigationAnchorBuilderRecebeResponseResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -16,6 +19,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 /** Expõe a borda HTTP interna da etapa geração de âncoras de investigação do pipeline de dossiê MOIS v1. */
 @RestController
+@Slf4j
 @RequestMapping("/api/internal/mois/dossie/v1/investigation-anchor-builder/stage-executions")
 @RequiredArgsConstructor
 public class DossierInvestigationAnchorBuilderController {
@@ -36,6 +40,22 @@ public class DossierInvestigationAnchorBuilderController {
             @PathVariable("jobId") String jobId,
             @Valid @RequestBody DossierInvestigationAnchorBuilderRecebeRequestRequest request) {
         return service.recebeRequest(productKey, jobId, request);
+    }
+
+
+    /** Recebe a resposta do módulo executor para a página/produto informada pela chave operacional. */
+    @PostMapping("/{productKey}/{jobId}/recebeResponse")
+    public DossierInvestigationAnchorBuilderRecebeResponseResponse recebeResponse(
+            @PathVariable("productKey") String productKey,
+            @PathVariable("jobId") String jobId,
+            @Valid @RequestBody DossierInvestigationAnchorBuilderRecebeResponseRequest request) {
+        log.info(
+                "Recebendo response do dossiê MOIS v1: etapa={}, productKey={}, jobId={}, payload={}",
+                "investigation-anchor-builder",
+                productKey,
+                jobId,
+                request);
+        return service.recebeResponse(productKey, jobId, request);
     }
 
     /** Expõe o ponto inicial canônico de consumo da fila pelo módulo executor. */

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/investigationanchorbuilder/service/DossierInvestigationAnchorBuilderService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/investigationanchorbuilder/service/DossierInvestigationAnchorBuilderService.java
@@ -5,6 +5,8 @@ import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.investigation
 import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.investigationanchorbuilder.service.pending.DossierInvestigationAnchorBuilderPendingResponse;
 import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.investigationanchorbuilder.service.receberequest.DossierInvestigationAnchorBuilderRecebeRequestRequest;
 import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.investigationanchorbuilder.service.receberequest.DossierInvestigationAnchorBuilderRecebeRequestResponse;
+import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.investigationanchorbuilder.service.receberesponse.DossierInvestigationAnchorBuilderRecebeResponseRequest;
+import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.investigationanchorbuilder.service.receberesponse.DossierInvestigationAnchorBuilderRecebeResponseResponse;
 import com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1.MoisSalesPageRepository;
 import com.marketinghub.repository.jpa.mois.dossieproduto.PipelineDossieProdutoRepository;
 import com.marketinghub.repository.jpa.mois.dossieproduto.entity.PipelineDossieProduto;
@@ -81,6 +83,47 @@ public class DossierInvestigationAnchorBuilderService {
         pipelineDossieProdutoRepository.save(pipeline);
 
         return new DossierInvestigationAnchorBuilderRecebeRequestResponse(jobId, productKey, STAGE_CODE, STATUS_WAITING);
+    }
+
+
+    /** Recebe a resposta operacional da etapa, conclui ou falha a página/produto e audita a saída do pipeline. */
+    public DossierInvestigationAnchorBuilderRecebeResponseResponse recebeResponse(String productKey, String jobId, DossierInvestigationAnchorBuilderRecebeResponseRequest request) {
+        long pageId = Long.parseLong(productKey);
+        Instant now = Instant.now();
+        String status = isBlank(request.descricaoErro()) ? STATUS_COMPLETED : STATUS_FAILED;
+        var page = salesPageRepository.findById(pageId)
+                .orElseThrow(() -> new IllegalArgumentException("Página/produto MOIS não encontrada: " + productKey));
+        page.setDossieProdutoStatus(status);
+        page.setDossieProdutoCurrentStage(STAGE_CODE);
+        page.setDossieProdutoUpdatedAt(now);
+        salesPageRepository.save(page);
+
+        PipelineDossieProduto pipeline = new PipelineDossieProduto();
+        pipeline.setIdExterno(productKey);
+        pipeline.setResponse(request.response());
+        pipeline.setCodigoEtapa(STAGE_CODE);
+        pipeline.setDataHora(now);
+        pipeline.setJobId(jobId);
+        pipeline.setQuantidadeTokenEntrada(request.quantidadeTokenEntrada());
+        pipeline.setQuantidadeTokenSaida(request.quantidadeTokenSaida());
+        pipeline.setCusto(request.custo());
+        pipeline.setModelo(request.modelo());
+        pipeline.setDescricaoErro(request.descricaoErro());
+        pipeline.setVersaoPipeline("v1");
+        pipelineDossieProdutoRepository.save(pipeline);
+
+        String nextStageCode = STATUS_COMPLETED.equals(status) ? normalizeNextStage(NEXT_STAGE) : null;
+        return new DossierInvestigationAnchorBuilderRecebeResponseResponse(jobId, productKey, STAGE_CODE, status, nextStageCode);
+    }
+
+    /** Normaliza a próxima etapa para nulo quando a etapa atual encerra o pipeline. */
+    private String normalizeNextStage(String nextStage) {
+        return isBlank(nextStage) ? null : nextStage;
+    }
+
+    /** Verifica se o texto informado está vazio para decidir sucesso ou falha da etapa. */
+    private boolean isBlank(String value) {
+        return value == null || value.isBlank();
     }
 
     /** Entrega até dez trabalhos iniciados da etapa atual ao executor, ordenados pela data operacional mais antiga. */

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/investigationanchorbuilder/service/receberesponse/DossierInvestigationAnchorBuilderRecebeResponseRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/investigationanchorbuilder/service/receberesponse/DossierInvestigationAnchorBuilderRecebeResponseRequest.java
@@ -1,0 +1,13 @@
+package com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.investigationanchorbuilder.service.receberesponse;
+
+import java.math.BigDecimal;
+
+/** Contrato de entrada do endpoint recebeResponse da etapa investigationanchorbuilder do dossiê MOIS v1. */
+public record DossierInvestigationAnchorBuilderRecebeResponseRequest(
+        String response,
+        String descricaoErro,
+        Long quantidadeTokenEntrada,
+        Long quantidadeTokenSaida,
+        BigDecimal custo,
+        String modelo) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/investigationanchorbuilder/service/receberesponse/DossierInvestigationAnchorBuilderRecebeResponseResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/investigationanchorbuilder/service/receberesponse/DossierInvestigationAnchorBuilderRecebeResponseResponse.java
@@ -1,0 +1,6 @@
+package com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.investigationanchorbuilder.service.receberesponse;
+
+/** Contrato de saída do endpoint recebeResponse da etapa investigationanchorbuilder do dossiê MOIS v1. */
+public record DossierInvestigationAnchorBuilderRecebeResponseResponse(
+        String jobId, String productKey, String stageCode, String status, String nextStageCode) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/productunderstanding/controller/DossierProductUnderstandingController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/productunderstanding/controller/DossierProductUnderstandingController.java
@@ -5,8 +5,11 @@ import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.productunders
 import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.productunderstanding.service.receberequest.DossierProductUnderstandingRecebeRequestResponse;
 import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.productunderstanding.service.pending.DossierProductUnderstandingPendingRequest;
 import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.productunderstanding.service.pending.DossierProductUnderstandingPendingResponse;
+import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.productunderstanding.service.receberesponse.DossierProductUnderstandingRecebeResponseRequest;
+import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.productunderstanding.service.receberesponse.DossierProductUnderstandingRecebeResponseResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -16,6 +19,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 /** Expõe a borda HTTP interna da etapa entendimento do produto do pipeline de dossiê MOIS v1. */
 @RestController
+@Slf4j
 @RequestMapping("/api/internal/mois/dossie/v1/product-understanding/stage-executions")
 @RequiredArgsConstructor
 public class DossierProductUnderstandingController {
@@ -36,6 +40,22 @@ public class DossierProductUnderstandingController {
             @PathVariable("jobId") String jobId,
             @Valid @RequestBody DossierProductUnderstandingRecebeRequestRequest request) {
         return service.recebeRequest(productKey, jobId, request);
+    }
+
+
+    /** Recebe a resposta do módulo executor para a página/produto informada pela chave operacional. */
+    @PostMapping("/{productKey}/{jobId}/recebeResponse")
+    public DossierProductUnderstandingRecebeResponseResponse recebeResponse(
+            @PathVariable("productKey") String productKey,
+            @PathVariable("jobId") String jobId,
+            @Valid @RequestBody DossierProductUnderstandingRecebeResponseRequest request) {
+        log.info(
+                "Recebendo response do dossiê MOIS v1: etapa={}, productKey={}, jobId={}, payload={}",
+                "product-understanding",
+                productKey,
+                jobId,
+                request);
+        return service.recebeResponse(productKey, jobId, request);
     }
 
     /** Expõe o ponto inicial canônico de consumo da fila pelo módulo executor. */

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/productunderstanding/service/DossierProductUnderstandingService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/productunderstanding/service/DossierProductUnderstandingService.java
@@ -5,6 +5,8 @@ import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.productunders
 import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.productunderstanding.service.pending.DossierProductUnderstandingPendingResponse;
 import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.productunderstanding.service.receberequest.DossierProductUnderstandingRecebeRequestRequest;
 import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.productunderstanding.service.receberequest.DossierProductUnderstandingRecebeRequestResponse;
+import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.productunderstanding.service.receberesponse.DossierProductUnderstandingRecebeResponseRequest;
+import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.productunderstanding.service.receberesponse.DossierProductUnderstandingRecebeResponseResponse;
 import com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1.MoisSalesPageRepository;
 import com.marketinghub.repository.jpa.mois.dossieproduto.PipelineDossieProdutoRepository;
 import com.marketinghub.repository.jpa.mois.dossieproduto.entity.PipelineDossieProduto;
@@ -81,6 +83,47 @@ public class DossierProductUnderstandingService {
         pipelineDossieProdutoRepository.save(pipeline);
 
         return new DossierProductUnderstandingRecebeRequestResponse(jobId, productKey, STAGE_CODE, STATUS_WAITING);
+    }
+
+
+    /** Recebe a resposta operacional da etapa, conclui ou falha a página/produto e audita a saída do pipeline. */
+    public DossierProductUnderstandingRecebeResponseResponse recebeResponse(String productKey, String jobId, DossierProductUnderstandingRecebeResponseRequest request) {
+        long pageId = Long.parseLong(productKey);
+        Instant now = Instant.now();
+        String status = isBlank(request.descricaoErro()) ? STATUS_COMPLETED : STATUS_FAILED;
+        var page = salesPageRepository.findById(pageId)
+                .orElseThrow(() -> new IllegalArgumentException("Página/produto MOIS não encontrada: " + productKey));
+        page.setDossieProdutoStatus(status);
+        page.setDossieProdutoCurrentStage(STAGE_CODE);
+        page.setDossieProdutoUpdatedAt(now);
+        salesPageRepository.save(page);
+
+        PipelineDossieProduto pipeline = new PipelineDossieProduto();
+        pipeline.setIdExterno(productKey);
+        pipeline.setResponse(request.response());
+        pipeline.setCodigoEtapa(STAGE_CODE);
+        pipeline.setDataHora(now);
+        pipeline.setJobId(jobId);
+        pipeline.setQuantidadeTokenEntrada(request.quantidadeTokenEntrada());
+        pipeline.setQuantidadeTokenSaida(request.quantidadeTokenSaida());
+        pipeline.setCusto(request.custo());
+        pipeline.setModelo(request.modelo());
+        pipeline.setDescricaoErro(request.descricaoErro());
+        pipeline.setVersaoPipeline("v1");
+        pipelineDossieProdutoRepository.save(pipeline);
+
+        String nextStageCode = STATUS_COMPLETED.equals(status) ? normalizeNextStage(NEXT_STAGE) : null;
+        return new DossierProductUnderstandingRecebeResponseResponse(jobId, productKey, STAGE_CODE, status, nextStageCode);
+    }
+
+    /** Normaliza a próxima etapa para nulo quando a etapa atual encerra o pipeline. */
+    private String normalizeNextStage(String nextStage) {
+        return isBlank(nextStage) ? null : nextStage;
+    }
+
+    /** Verifica se o texto informado está vazio para decidir sucesso ou falha da etapa. */
+    private boolean isBlank(String value) {
+        return value == null || value.isBlank();
     }
 
     /** Entrega até dez trabalhos iniciados da etapa atual ao executor, ordenados pela data operacional mais antiga. */

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/productunderstanding/service/receberesponse/DossierProductUnderstandingRecebeResponseRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/productunderstanding/service/receberesponse/DossierProductUnderstandingRecebeResponseRequest.java
@@ -1,0 +1,13 @@
+package com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.productunderstanding.service.receberesponse;
+
+import java.math.BigDecimal;
+
+/** Contrato de entrada do endpoint recebeResponse da etapa productunderstanding do dossiê MOIS v1. */
+public record DossierProductUnderstandingRecebeResponseRequest(
+        String response,
+        String descricaoErro,
+        Long quantidadeTokenEntrada,
+        Long quantidadeTokenSaida,
+        BigDecimal custo,
+        String modelo) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/productunderstanding/service/receberesponse/DossierProductUnderstandingRecebeResponseResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/productunderstanding/service/receberesponse/DossierProductUnderstandingRecebeResponseResponse.java
@@ -1,0 +1,6 @@
+package com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.productunderstanding.service.receberesponse;
+
+/** Contrato de saída do endpoint recebeResponse da etapa productunderstanding do dossiê MOIS v1. */
+public record DossierProductUnderstandingRecebeResponseResponse(
+        String jobId, String productKey, String stageCode, String status, String nextStageCode) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/sourceproductmatch/controller/DossierSourceProductMatchController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/sourceproductmatch/controller/DossierSourceProductMatchController.java
@@ -5,8 +5,11 @@ import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.sourceproduct
 import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.sourceproductmatch.service.receberequest.DossierSourceProductMatchRecebeRequestResponse;
 import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.sourceproductmatch.service.pending.DossierSourceProductMatchPendingRequest;
 import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.sourceproductmatch.service.pending.DossierSourceProductMatchPendingResponse;
+import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.sourceproductmatch.service.receberesponse.DossierSourceProductMatchRecebeResponseRequest;
+import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.sourceproductmatch.service.receberesponse.DossierSourceProductMatchRecebeResponseResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -16,6 +19,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 /** Expõe a borda HTTP interna da etapa validação de relação fonte-produto do pipeline de dossiê MOIS v1. */
 @RestController
+@Slf4j
 @RequestMapping("/api/internal/mois/dossie/v1/source-product-match/stage-executions")
 @RequiredArgsConstructor
 public class DossierSourceProductMatchController {
@@ -36,6 +40,22 @@ public class DossierSourceProductMatchController {
             @PathVariable("jobId") String jobId,
             @Valid @RequestBody DossierSourceProductMatchRecebeRequestRequest request) {
         return service.recebeRequest(productKey, jobId, request);
+    }
+
+
+    /** Recebe a resposta do módulo executor para a página/produto informada pela chave operacional. */
+    @PostMapping("/{productKey}/{jobId}/recebeResponse")
+    public DossierSourceProductMatchRecebeResponseResponse recebeResponse(
+            @PathVariable("productKey") String productKey,
+            @PathVariable("jobId") String jobId,
+            @Valid @RequestBody DossierSourceProductMatchRecebeResponseRequest request) {
+        log.info(
+                "Recebendo response do dossiê MOIS v1: etapa={}, productKey={}, jobId={}, payload={}",
+                "source-product-match",
+                productKey,
+                jobId,
+                request);
+        return service.recebeResponse(productKey, jobId, request);
     }
 
     /** Expõe o ponto inicial canônico de consumo da fila pelo módulo executor. */

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/sourceproductmatch/service/DossierSourceProductMatchService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/sourceproductmatch/service/DossierSourceProductMatchService.java
@@ -5,6 +5,8 @@ import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.sourceproduct
 import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.sourceproductmatch.service.pending.DossierSourceProductMatchPendingResponse;
 import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.sourceproductmatch.service.receberequest.DossierSourceProductMatchRecebeRequestRequest;
 import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.sourceproductmatch.service.receberequest.DossierSourceProductMatchRecebeRequestResponse;
+import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.sourceproductmatch.service.receberesponse.DossierSourceProductMatchRecebeResponseRequest;
+import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.sourceproductmatch.service.receberesponse.DossierSourceProductMatchRecebeResponseResponse;
 import com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1.MoisSalesPageRepository;
 import com.marketinghub.repository.jpa.mois.dossieproduto.PipelineDossieProdutoRepository;
 import com.marketinghub.repository.jpa.mois.dossieproduto.entity.PipelineDossieProduto;
@@ -81,6 +83,47 @@ public class DossierSourceProductMatchService {
         pipelineDossieProdutoRepository.save(pipeline);
 
         return new DossierSourceProductMatchRecebeRequestResponse(jobId, productKey, STAGE_CODE, STATUS_WAITING);
+    }
+
+
+    /** Recebe a resposta operacional da etapa, conclui ou falha a página/produto e audita a saída do pipeline. */
+    public DossierSourceProductMatchRecebeResponseResponse recebeResponse(String productKey, String jobId, DossierSourceProductMatchRecebeResponseRequest request) {
+        long pageId = Long.parseLong(productKey);
+        Instant now = Instant.now();
+        String status = isBlank(request.descricaoErro()) ? STATUS_COMPLETED : STATUS_FAILED;
+        var page = salesPageRepository.findById(pageId)
+                .orElseThrow(() -> new IllegalArgumentException("Página/produto MOIS não encontrada: " + productKey));
+        page.setDossieProdutoStatus(status);
+        page.setDossieProdutoCurrentStage(STAGE_CODE);
+        page.setDossieProdutoUpdatedAt(now);
+        salesPageRepository.save(page);
+
+        PipelineDossieProduto pipeline = new PipelineDossieProduto();
+        pipeline.setIdExterno(productKey);
+        pipeline.setResponse(request.response());
+        pipeline.setCodigoEtapa(STAGE_CODE);
+        pipeline.setDataHora(now);
+        pipeline.setJobId(jobId);
+        pipeline.setQuantidadeTokenEntrada(request.quantidadeTokenEntrada());
+        pipeline.setQuantidadeTokenSaida(request.quantidadeTokenSaida());
+        pipeline.setCusto(request.custo());
+        pipeline.setModelo(request.modelo());
+        pipeline.setDescricaoErro(request.descricaoErro());
+        pipeline.setVersaoPipeline("v1");
+        pipelineDossieProdutoRepository.save(pipeline);
+
+        String nextStageCode = STATUS_COMPLETED.equals(status) ? normalizeNextStage(NEXT_STAGE) : null;
+        return new DossierSourceProductMatchRecebeResponseResponse(jobId, productKey, STAGE_CODE, status, nextStageCode);
+    }
+
+    /** Normaliza a próxima etapa para nulo quando a etapa atual encerra o pipeline. */
+    private String normalizeNextStage(String nextStage) {
+        return isBlank(nextStage) ? null : nextStage;
+    }
+
+    /** Verifica se o texto informado está vazio para decidir sucesso ou falha da etapa. */
+    private boolean isBlank(String value) {
+        return value == null || value.isBlank();
     }
 
     /** Entrega até dez trabalhos iniciados da etapa atual ao executor, ordenados pela data operacional mais antiga. */

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/sourceproductmatch/service/receberesponse/DossierSourceProductMatchRecebeResponseRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/sourceproductmatch/service/receberesponse/DossierSourceProductMatchRecebeResponseRequest.java
@@ -1,0 +1,13 @@
+package com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.sourceproductmatch.service.receberesponse;
+
+import java.math.BigDecimal;
+
+/** Contrato de entrada do endpoint recebeResponse da etapa sourceproductmatch do dossiê MOIS v1. */
+public record DossierSourceProductMatchRecebeResponseRequest(
+        String response,
+        String descricaoErro,
+        Long quantidadeTokenEntrada,
+        Long quantidadeTokenSaida,
+        BigDecimal custo,
+        String modelo) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/sourceproductmatch/service/receberesponse/DossierSourceProductMatchRecebeResponseResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/sourceproductmatch/service/receberesponse/DossierSourceProductMatchRecebeResponseResponse.java
@@ -1,0 +1,6 @@
+package com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.sourceproductmatch.service.receberesponse;
+
+/** Contrato de saída do endpoint recebeResponse da etapa sourceproductmatch do dossiê MOIS v1. */
+public record DossierSourceProductMatchRecebeResponseResponse(
+        String jobId, String productKey, String stageCode, String status, String nextStageCode) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/warmupmapbuilder/controller/DossierWarmupMapBuilderController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/warmupmapbuilder/controller/DossierWarmupMapBuilderController.java
@@ -5,8 +5,11 @@ import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.warmupmapbuil
 import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.warmupmapbuilder.service.receberequest.DossierWarmupMapBuilderRecebeRequestResponse;
 import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.warmupmapbuilder.service.pending.DossierWarmupMapBuilderPendingRequest;
 import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.warmupmapbuilder.service.pending.DossierWarmupMapBuilderPendingResponse;
+import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.warmupmapbuilder.service.receberesponse.DossierWarmupMapBuilderRecebeResponseRequest;
+import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.warmupmapbuilder.service.receberesponse.DossierWarmupMapBuilderRecebeResponseResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -16,6 +19,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 /** Expõe a borda HTTP interna da etapa montagem do mapa de aquecimento do pipeline de dossiê MOIS v1. */
 @RestController
+@Slf4j
 @RequestMapping("/api/internal/mois/dossie/v1/warmup-map-builder/stage-executions")
 @RequiredArgsConstructor
 public class DossierWarmupMapBuilderController {
@@ -36,6 +40,22 @@ public class DossierWarmupMapBuilderController {
             @PathVariable("jobId") String jobId,
             @Valid @RequestBody DossierWarmupMapBuilderRecebeRequestRequest request) {
         return service.recebeRequest(productKey, jobId, request);
+    }
+
+
+    /** Recebe a resposta do módulo executor para a página/produto informada pela chave operacional. */
+    @PostMapping("/{productKey}/{jobId}/recebeResponse")
+    public DossierWarmupMapBuilderRecebeResponseResponse recebeResponse(
+            @PathVariable("productKey") String productKey,
+            @PathVariable("jobId") String jobId,
+            @Valid @RequestBody DossierWarmupMapBuilderRecebeResponseRequest request) {
+        log.info(
+                "Recebendo response do dossiê MOIS v1: etapa={}, productKey={}, jobId={}, payload={}",
+                "warmup-map-builder",
+                productKey,
+                jobId,
+                request);
+        return service.recebeResponse(productKey, jobId, request);
     }
 
     /** Expõe o ponto inicial canônico de consumo da fila pelo módulo executor. */

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/warmupmapbuilder/service/DossierWarmupMapBuilderService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/warmupmapbuilder/service/DossierWarmupMapBuilderService.java
@@ -5,6 +5,8 @@ import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.warmupmapbuil
 import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.warmupmapbuilder.service.pending.DossierWarmupMapBuilderPendingResponse;
 import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.warmupmapbuilder.service.receberequest.DossierWarmupMapBuilderRecebeRequestRequest;
 import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.warmupmapbuilder.service.receberequest.DossierWarmupMapBuilderRecebeRequestResponse;
+import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.warmupmapbuilder.service.receberesponse.DossierWarmupMapBuilderRecebeResponseRequest;
+import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.warmupmapbuilder.service.receberesponse.DossierWarmupMapBuilderRecebeResponseResponse;
 import com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1.MoisSalesPageRepository;
 import com.marketinghub.repository.jpa.mois.dossieproduto.PipelineDossieProdutoRepository;
 import com.marketinghub.repository.jpa.mois.dossieproduto.entity.PipelineDossieProduto;
@@ -81,6 +83,47 @@ public class DossierWarmupMapBuilderService {
         pipelineDossieProdutoRepository.save(pipeline);
 
         return new DossierWarmupMapBuilderRecebeRequestResponse(jobId, productKey, STAGE_CODE, STATUS_WAITING);
+    }
+
+
+    /** Recebe a resposta operacional da etapa, conclui ou falha a página/produto e audita a saída do pipeline. */
+    public DossierWarmupMapBuilderRecebeResponseResponse recebeResponse(String productKey, String jobId, DossierWarmupMapBuilderRecebeResponseRequest request) {
+        long pageId = Long.parseLong(productKey);
+        Instant now = Instant.now();
+        String status = isBlank(request.descricaoErro()) ? STATUS_COMPLETED : STATUS_FAILED;
+        var page = salesPageRepository.findById(pageId)
+                .orElseThrow(() -> new IllegalArgumentException("Página/produto MOIS não encontrada: " + productKey));
+        page.setDossieProdutoStatus(status);
+        page.setDossieProdutoCurrentStage(STAGE_CODE);
+        page.setDossieProdutoUpdatedAt(now);
+        salesPageRepository.save(page);
+
+        PipelineDossieProduto pipeline = new PipelineDossieProduto();
+        pipeline.setIdExterno(productKey);
+        pipeline.setResponse(request.response());
+        pipeline.setCodigoEtapa(STAGE_CODE);
+        pipeline.setDataHora(now);
+        pipeline.setJobId(jobId);
+        pipeline.setQuantidadeTokenEntrada(request.quantidadeTokenEntrada());
+        pipeline.setQuantidadeTokenSaida(request.quantidadeTokenSaida());
+        pipeline.setCusto(request.custo());
+        pipeline.setModelo(request.modelo());
+        pipeline.setDescricaoErro(request.descricaoErro());
+        pipeline.setVersaoPipeline("v1");
+        pipelineDossieProdutoRepository.save(pipeline);
+
+        String nextStageCode = STATUS_COMPLETED.equals(status) ? normalizeNextStage(NEXT_STAGE) : null;
+        return new DossierWarmupMapBuilderRecebeResponseResponse(jobId, productKey, STAGE_CODE, status, nextStageCode);
+    }
+
+    /** Normaliza a próxima etapa para nulo quando a etapa atual encerra o pipeline. */
+    private String normalizeNextStage(String nextStage) {
+        return isBlank(nextStage) ? null : nextStage;
+    }
+
+    /** Verifica se o texto informado está vazio para decidir sucesso ou falha da etapa. */
+    private boolean isBlank(String value) {
+        return value == null || value.isBlank();
     }
 
     /** Entrega até dez trabalhos iniciados da etapa atual ao executor, ordenados pela data operacional mais antiga. */

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/warmupmapbuilder/service/receberesponse/DossierWarmupMapBuilderRecebeResponseRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/warmupmapbuilder/service/receberesponse/DossierWarmupMapBuilderRecebeResponseRequest.java
@@ -1,0 +1,13 @@
+package com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.warmupmapbuilder.service.receberesponse;
+
+import java.math.BigDecimal;
+
+/** Contrato de entrada do endpoint recebeResponse da etapa warmupmapbuilder do dossiê MOIS v1. */
+public record DossierWarmupMapBuilderRecebeResponseRequest(
+        String response,
+        String descricaoErro,
+        Long quantidadeTokenEntrada,
+        Long quantidadeTokenSaida,
+        BigDecimal custo,
+        String modelo) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/warmupmapbuilder/service/receberesponse/DossierWarmupMapBuilderRecebeResponseResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/warmupmapbuilder/service/receberesponse/DossierWarmupMapBuilderRecebeResponseResponse.java
@@ -1,0 +1,6 @@
+package com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.warmupmapbuilder.service.receberesponse;
+
+/** Contrato de saída do endpoint recebeResponse da etapa warmupmapbuilder do dossiê MOIS v1. */
+public record DossierWarmupMapBuilderRecebeResponseResponse(
+        String jobId, String productKey, String stageCode, String status, String nextStageCode) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/warmupresourcediscovery/controller/DossierWarmupResourceDiscoveryController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/warmupresourcediscovery/controller/DossierWarmupResourceDiscoveryController.java
@@ -5,8 +5,11 @@ import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.warmupresourc
 import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.warmupresourcediscovery.service.receberequest.DossierWarmupResourceDiscoveryRecebeRequestResponse;
 import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.warmupresourcediscovery.service.pending.DossierWarmupResourceDiscoveryPendingRequest;
 import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.warmupresourcediscovery.service.pending.DossierWarmupResourceDiscoveryPendingResponse;
+import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.warmupresourcediscovery.service.receberesponse.DossierWarmupResourceDiscoveryRecebeResponseRequest;
+import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.warmupresourcediscovery.service.receberesponse.DossierWarmupResourceDiscoveryRecebeResponseResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -16,6 +19,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 /** Expõe a borda HTTP interna da etapa descoberta de recursos de aquecimento do pipeline de dossiê MOIS v1. */
 @RestController
+@Slf4j
 @RequestMapping("/api/internal/mois/dossie/v1/warmup-resource-discovery/stage-executions")
 @RequiredArgsConstructor
 public class DossierWarmupResourceDiscoveryController {
@@ -36,6 +40,22 @@ public class DossierWarmupResourceDiscoveryController {
             @PathVariable("jobId") String jobId,
             @Valid @RequestBody DossierWarmupResourceDiscoveryRecebeRequestRequest request) {
         return service.recebeRequest(productKey, jobId, request);
+    }
+
+
+    /** Recebe a resposta do módulo executor para a página/produto informada pela chave operacional. */
+    @PostMapping("/{productKey}/{jobId}/recebeResponse")
+    public DossierWarmupResourceDiscoveryRecebeResponseResponse recebeResponse(
+            @PathVariable("productKey") String productKey,
+            @PathVariable("jobId") String jobId,
+            @Valid @RequestBody DossierWarmupResourceDiscoveryRecebeResponseRequest request) {
+        log.info(
+                "Recebendo response do dossiê MOIS v1: etapa={}, productKey={}, jobId={}, payload={}",
+                "warmup-resource-discovery",
+                productKey,
+                jobId,
+                request);
+        return service.recebeResponse(productKey, jobId, request);
     }
 
     /** Expõe o ponto inicial canônico de consumo da fila pelo módulo executor. */

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/warmupresourcediscovery/service/DossierWarmupResourceDiscoveryService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/warmupresourcediscovery/service/DossierWarmupResourceDiscoveryService.java
@@ -5,6 +5,8 @@ import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.warmupresourc
 import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.warmupresourcediscovery.service.pending.DossierWarmupResourceDiscoveryPendingResponse;
 import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.warmupresourcediscovery.service.receberequest.DossierWarmupResourceDiscoveryRecebeRequestRequest;
 import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.warmupresourcediscovery.service.receberequest.DossierWarmupResourceDiscoveryRecebeRequestResponse;
+import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.warmupresourcediscovery.service.receberesponse.DossierWarmupResourceDiscoveryRecebeResponseRequest;
+import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.warmupresourcediscovery.service.receberesponse.DossierWarmupResourceDiscoveryRecebeResponseResponse;
 import com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1.MoisSalesPageRepository;
 import com.marketinghub.repository.jpa.mois.dossieproduto.PipelineDossieProdutoRepository;
 import com.marketinghub.repository.jpa.mois.dossieproduto.entity.PipelineDossieProduto;
@@ -81,6 +83,47 @@ public class DossierWarmupResourceDiscoveryService {
         pipelineDossieProdutoRepository.save(pipeline);
 
         return new DossierWarmupResourceDiscoveryRecebeRequestResponse(jobId, productKey, STAGE_CODE, STATUS_WAITING);
+    }
+
+
+    /** Recebe a resposta operacional da etapa, conclui ou falha a página/produto e audita a saída do pipeline. */
+    public DossierWarmupResourceDiscoveryRecebeResponseResponse recebeResponse(String productKey, String jobId, DossierWarmupResourceDiscoveryRecebeResponseRequest request) {
+        long pageId = Long.parseLong(productKey);
+        Instant now = Instant.now();
+        String status = isBlank(request.descricaoErro()) ? STATUS_COMPLETED : STATUS_FAILED;
+        var page = salesPageRepository.findById(pageId)
+                .orElseThrow(() -> new IllegalArgumentException("Página/produto MOIS não encontrada: " + productKey));
+        page.setDossieProdutoStatus(status);
+        page.setDossieProdutoCurrentStage(STAGE_CODE);
+        page.setDossieProdutoUpdatedAt(now);
+        salesPageRepository.save(page);
+
+        PipelineDossieProduto pipeline = new PipelineDossieProduto();
+        pipeline.setIdExterno(productKey);
+        pipeline.setResponse(request.response());
+        pipeline.setCodigoEtapa(STAGE_CODE);
+        pipeline.setDataHora(now);
+        pipeline.setJobId(jobId);
+        pipeline.setQuantidadeTokenEntrada(request.quantidadeTokenEntrada());
+        pipeline.setQuantidadeTokenSaida(request.quantidadeTokenSaida());
+        pipeline.setCusto(request.custo());
+        pipeline.setModelo(request.modelo());
+        pipeline.setDescricaoErro(request.descricaoErro());
+        pipeline.setVersaoPipeline("v1");
+        pipelineDossieProdutoRepository.save(pipeline);
+
+        String nextStageCode = STATUS_COMPLETED.equals(status) ? normalizeNextStage(NEXT_STAGE) : null;
+        return new DossierWarmupResourceDiscoveryRecebeResponseResponse(jobId, productKey, STAGE_CODE, status, nextStageCode);
+    }
+
+    /** Normaliza a próxima etapa para nulo quando a etapa atual encerra o pipeline. */
+    private String normalizeNextStage(String nextStage) {
+        return isBlank(nextStage) ? null : nextStage;
+    }
+
+    /** Verifica se o texto informado está vazio para decidir sucesso ou falha da etapa. */
+    private boolean isBlank(String value) {
+        return value == null || value.isBlank();
     }
 
     /** Entrega até dez trabalhos iniciados da etapa atual ao executor, ordenados pela data operacional mais antiga. */

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/warmupresourcediscovery/service/receberesponse/DossierWarmupResourceDiscoveryRecebeResponseRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/warmupresourcediscovery/service/receberesponse/DossierWarmupResourceDiscoveryRecebeResponseRequest.java
@@ -1,0 +1,13 @@
+package com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.warmupresourcediscovery.service.receberesponse;
+
+import java.math.BigDecimal;
+
+/** Contrato de entrada do endpoint recebeResponse da etapa warmupresourcediscovery do dossiê MOIS v1. */
+public record DossierWarmupResourceDiscoveryRecebeResponseRequest(
+        String response,
+        String descricaoErro,
+        Long quantidadeTokenEntrada,
+        Long quantidadeTokenSaida,
+        BigDecimal custo,
+        String modelo) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/warmupresourcediscovery/service/receberesponse/DossierWarmupResourceDiscoveryRecebeResponseResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/warmupresourcediscovery/service/receberesponse/DossierWarmupResourceDiscoveryRecebeResponseResponse.java
@@ -1,0 +1,6 @@
+package com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.warmupresourcediscovery.service.receberesponse;
+
+/** Contrato de saída do endpoint recebeResponse da etapa warmupresourcediscovery do dossiê MOIS v1. */
+public record DossierWarmupResourceDiscoveryRecebeResponseResponse(
+        String jobId, String productKey, String stageCode, String status, String nextStageCode) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/warmupsignalextraction/controller/DossierWarmupSignalExtractionController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/warmupsignalextraction/controller/DossierWarmupSignalExtractionController.java
@@ -5,8 +5,11 @@ import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.warmupsignale
 import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.warmupsignalextraction.service.receberequest.DossierWarmupSignalExtractionRecebeRequestResponse;
 import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.warmupsignalextraction.service.pending.DossierWarmupSignalExtractionPendingRequest;
 import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.warmupsignalextraction.service.pending.DossierWarmupSignalExtractionPendingResponse;
+import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.warmupsignalextraction.service.receberesponse.DossierWarmupSignalExtractionRecebeResponseRequest;
+import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.warmupsignalextraction.service.receberesponse.DossierWarmupSignalExtractionRecebeResponseResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
@@ -16,6 +19,7 @@ import org.springframework.web.bind.annotation.RestController;
 
 /** Expõe a borda HTTP interna da etapa extração de sinais de aquecimento do pipeline de dossiê MOIS v1. */
 @RestController
+@Slf4j
 @RequestMapping("/api/internal/mois/dossie/v1/warmup-signal-extraction/stage-executions")
 @RequiredArgsConstructor
 public class DossierWarmupSignalExtractionController {
@@ -36,6 +40,22 @@ public class DossierWarmupSignalExtractionController {
             @PathVariable("jobId") String jobId,
             @Valid @RequestBody DossierWarmupSignalExtractionRecebeRequestRequest request) {
         return service.recebeRequest(productKey, jobId, request);
+    }
+
+
+    /** Recebe a resposta do módulo executor para a página/produto informada pela chave operacional. */
+    @PostMapping("/{productKey}/{jobId}/recebeResponse")
+    public DossierWarmupSignalExtractionRecebeResponseResponse recebeResponse(
+            @PathVariable("productKey") String productKey,
+            @PathVariable("jobId") String jobId,
+            @Valid @RequestBody DossierWarmupSignalExtractionRecebeResponseRequest request) {
+        log.info(
+                "Recebendo response do dossiê MOIS v1: etapa={}, productKey={}, jobId={}, payload={}",
+                "warmup-signal-extraction",
+                productKey,
+                jobId,
+                request);
+        return service.recebeResponse(productKey, jobId, request);
     }
 
     /** Expõe o ponto inicial canônico de consumo da fila pelo módulo executor. */

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/warmupsignalextraction/service/DossierWarmupSignalExtractionService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/warmupsignalextraction/service/DossierWarmupSignalExtractionService.java
@@ -5,6 +5,8 @@ import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.warmupsignale
 import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.warmupsignalextraction.service.pending.DossierWarmupSignalExtractionPendingResponse;
 import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.warmupsignalextraction.service.receberequest.DossierWarmupSignalExtractionRecebeRequestRequest;
 import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.warmupsignalextraction.service.receberequest.DossierWarmupSignalExtractionRecebeRequestResponse;
+import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.warmupsignalextraction.service.receberesponse.DossierWarmupSignalExtractionRecebeResponseRequest;
+import com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.warmupsignalextraction.service.receberesponse.DossierWarmupSignalExtractionRecebeResponseResponse;
 import com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1.MoisSalesPageRepository;
 import com.marketinghub.repository.jpa.mois.dossieproduto.PipelineDossieProdutoRepository;
 import com.marketinghub.repository.jpa.mois.dossieproduto.entity.PipelineDossieProduto;
@@ -81,6 +83,47 @@ public class DossierWarmupSignalExtractionService {
         pipelineDossieProdutoRepository.save(pipeline);
 
         return new DossierWarmupSignalExtractionRecebeRequestResponse(jobId, productKey, STAGE_CODE, STATUS_WAITING);
+    }
+
+
+    /** Recebe a resposta operacional da etapa, conclui ou falha a página/produto e audita a saída do pipeline. */
+    public DossierWarmupSignalExtractionRecebeResponseResponse recebeResponse(String productKey, String jobId, DossierWarmupSignalExtractionRecebeResponseRequest request) {
+        long pageId = Long.parseLong(productKey);
+        Instant now = Instant.now();
+        String status = isBlank(request.descricaoErro()) ? STATUS_COMPLETED : STATUS_FAILED;
+        var page = salesPageRepository.findById(pageId)
+                .orElseThrow(() -> new IllegalArgumentException("Página/produto MOIS não encontrada: " + productKey));
+        page.setDossieProdutoStatus(status);
+        page.setDossieProdutoCurrentStage(STAGE_CODE);
+        page.setDossieProdutoUpdatedAt(now);
+        salesPageRepository.save(page);
+
+        PipelineDossieProduto pipeline = new PipelineDossieProduto();
+        pipeline.setIdExterno(productKey);
+        pipeline.setResponse(request.response());
+        pipeline.setCodigoEtapa(STAGE_CODE);
+        pipeline.setDataHora(now);
+        pipeline.setJobId(jobId);
+        pipeline.setQuantidadeTokenEntrada(request.quantidadeTokenEntrada());
+        pipeline.setQuantidadeTokenSaida(request.quantidadeTokenSaida());
+        pipeline.setCusto(request.custo());
+        pipeline.setModelo(request.modelo());
+        pipeline.setDescricaoErro(request.descricaoErro());
+        pipeline.setVersaoPipeline("v1");
+        pipelineDossieProdutoRepository.save(pipeline);
+
+        String nextStageCode = STATUS_COMPLETED.equals(status) ? normalizeNextStage(NEXT_STAGE) : null;
+        return new DossierWarmupSignalExtractionRecebeResponseResponse(jobId, productKey, STAGE_CODE, status, nextStageCode);
+    }
+
+    /** Normaliza a próxima etapa para nulo quando a etapa atual encerra o pipeline. */
+    private String normalizeNextStage(String nextStage) {
+        return isBlank(nextStage) ? null : nextStage;
+    }
+
+    /** Verifica se o texto informado está vazio para decidir sucesso ou falha da etapa. */
+    private boolean isBlank(String value) {
+        return value == null || value.isBlank();
     }
 
     /** Entrega até dez trabalhos iniciados da etapa atual ao executor, ordenados pela data operacional mais antiga. */

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/warmupsignalextraction/service/receberesponse/DossierWarmupSignalExtractionRecebeResponseRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/warmupsignalextraction/service/receberesponse/DossierWarmupSignalExtractionRecebeResponseRequest.java
@@ -1,0 +1,13 @@
+package com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.warmupsignalextraction.service.receberesponse;
+
+import java.math.BigDecimal;
+
+/** Contrato de entrada do endpoint recebeResponse da etapa warmupsignalextraction do dossiê MOIS v1. */
+public record DossierWarmupSignalExtractionRecebeResponseRequest(
+        String response,
+        String descricaoErro,
+        Long quantidadeTokenEntrada,
+        Long quantidadeTokenSaida,
+        BigDecimal custo,
+        String modelo) {
+}

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/warmupsignalextraction/service/receberesponse/DossierWarmupSignalExtractionRecebeResponseResponse.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossie/v1/warmupsignalextraction/service/receberesponse/DossierWarmupSignalExtractionRecebeResponseResponse.java
@@ -1,0 +1,6 @@
+package com.marketinghub.moissaleslibraryworker.pipelines.dossie.v1.warmupsignalextraction.service.receberesponse;
+
+/** Contrato de saída do endpoint recebeResponse da etapa warmupsignalextraction do dossiê MOIS v1. */
+public record DossierWarmupSignalExtractionRecebeResponseResponse(
+        String jobId, String productKey, String stageCode, String status, String nextStageCode) {
+}

--- a/docs/swagger/mois-dossie-v1-swagger.yaml
+++ b/docs/swagger/mois-dossie-v1-swagger.yaml
@@ -364,8 +364,472 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/DossierDossierSynthesisRecebeRequestResponse'
+  /api/internal/mois/dossie/v1/intake/stage-executions/{productKey}/{jobId}/recebeResponse:
+    post:
+      summary: Recebe response operacional da etapa intake do dossiê MOIS v1
+      operationId: recebeResponseMoisDossieV1IntakeStageExecutions
+      parameters:
+        - name: productKey
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: jobId
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DossierIntakeRecebeResponseRequest'
+      responses:
+        '200':
+          description: Response recebido, página atualizada e auditoria registrada
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DossierIntakeRecebeResponseResponse'
+  /api/internal/mois/dossie/v1/product-understanding/stage-executions/{productKey}/{jobId}/recebeResponse:
+    post:
+      summary: Recebe response operacional da etapa product-understanding do dossiê MOIS v1
+      operationId: recebeResponseMoisDossieV1ProductUnderstandingStageExecutions
+      parameters:
+        - name: productKey
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: jobId
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DossierProductUnderstandingRecebeResponseRequest'
+      responses:
+        '200':
+          description: Response recebido, página atualizada e auditoria registrada
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DossierProductUnderstandingRecebeResponseResponse'
+  /api/internal/mois/dossie/v1/investigation-anchor-builder/stage-executions/{productKey}/{jobId}/recebeResponse:
+    post:
+      summary: Recebe response operacional da etapa investigation-anchor-builder do dossiê MOIS v1
+      operationId: recebeResponseMoisDossieV1InvestigationAnchorBuilderStageExecutions
+      parameters:
+        - name: productKey
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: jobId
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DossierInvestigationAnchorBuilderRecebeResponseRequest'
+      responses:
+        '200':
+          description: Response recebido, página atualizada e auditoria registrada
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DossierInvestigationAnchorBuilderRecebeResponseResponse'
+  /api/internal/mois/dossie/v1/warmup-resource-discovery/stage-executions/{productKey}/{jobId}/recebeResponse:
+    post:
+      summary: Recebe response operacional da etapa warmup-resource-discovery do dossiê MOIS v1
+      operationId: recebeResponseMoisDossieV1WarmupResourceDiscoveryStageExecutions
+      parameters:
+        - name: productKey
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: jobId
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DossierWarmupResourceDiscoveryRecebeResponseRequest'
+      responses:
+        '200':
+          description: Response recebido, página atualizada e auditoria registrada
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DossierWarmupResourceDiscoveryRecebeResponseResponse'
+  /api/internal/mois/dossie/v1/source-product-match/stage-executions/{productKey}/{jobId}/recebeResponse:
+    post:
+      summary: Recebe response operacional da etapa source-product-match do dossiê MOIS v1
+      operationId: recebeResponseMoisDossieV1SourceProductMatchStageExecutions
+      parameters:
+        - name: productKey
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: jobId
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DossierSourceProductMatchRecebeResponseRequest'
+      responses:
+        '200':
+          description: Response recebido, página atualizada e auditoria registrada
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DossierSourceProductMatchRecebeResponseResponse'
+  /api/internal/mois/dossie/v1/warmup-signal-extraction/stage-executions/{productKey}/{jobId}/recebeResponse:
+    post:
+      summary: Recebe response operacional da etapa warmup-signal-extraction do dossiê MOIS v1
+      operationId: recebeResponseMoisDossieV1WarmupSignalExtractionStageExecutions
+      parameters:
+        - name: productKey
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: jobId
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DossierWarmupSignalExtractionRecebeResponseRequest'
+      responses:
+        '200':
+          description: Response recebido, página atualizada e auditoria registrada
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DossierWarmupSignalExtractionRecebeResponseResponse'
+  /api/internal/mois/dossie/v1/warmup-map-builder/stage-executions/{productKey}/{jobId}/recebeResponse:
+    post:
+      summary: Recebe response operacional da etapa warmup-map-builder do dossiê MOIS v1
+      operationId: recebeResponseMoisDossieV1WarmupMapBuilderStageExecutions
+      parameters:
+        - name: productKey
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: jobId
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DossierWarmupMapBuilderRecebeResponseRequest'
+      responses:
+        '200':
+          description: Response recebido, página atualizada e auditoria registrada
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DossierWarmupMapBuilderRecebeResponseResponse'
+  /api/internal/mois/dossie/v1/dossier-synthesis/stage-executions/{productKey}/{jobId}/recebeResponse:
+    post:
+      summary: Recebe response operacional da etapa dossier-synthesis do dossiê MOIS v1
+      operationId: recebeResponseMoisDossieV1DossierSynthesisStageExecutions
+      parameters:
+        - name: productKey
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: jobId
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/DossierDossierSynthesisRecebeResponseRequest'
+      responses:
+        '200':
+          description: Response recebido, página atualizada e auditoria registrada
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DossierDossierSynthesisRecebeResponseResponse'
 components:
   schemas:
+    DossierIntakeRecebeResponseRequest:
+      type: object
+      properties:
+        response:
+          type: string
+        descricaoErro:
+          type: string
+        quantidadeTokenEntrada:
+          type: integer
+          format: int64
+        quantidadeTokenSaida:
+          type: integer
+          format: int64
+        custo:
+          type: number
+        modelo:
+          type: string
+    DossierIntakeRecebeResponseResponse:
+      type: object
+      properties:
+        jobId:
+          type: string
+        productKey:
+          type: string
+        stageCode:
+          type: string
+        status:
+          type: string
+        nextStageCode:
+          type: string
+    DossierProductUnderstandingRecebeResponseRequest:
+      type: object
+      properties:
+        response:
+          type: string
+        descricaoErro:
+          type: string
+        quantidadeTokenEntrada:
+          type: integer
+          format: int64
+        quantidadeTokenSaida:
+          type: integer
+          format: int64
+        custo:
+          type: number
+        modelo:
+          type: string
+    DossierProductUnderstandingRecebeResponseResponse:
+      type: object
+      properties:
+        jobId:
+          type: string
+        productKey:
+          type: string
+        stageCode:
+          type: string
+        status:
+          type: string
+        nextStageCode:
+          type: string
+    DossierInvestigationAnchorBuilderRecebeResponseRequest:
+      type: object
+      properties:
+        response:
+          type: string
+        descricaoErro:
+          type: string
+        quantidadeTokenEntrada:
+          type: integer
+          format: int64
+        quantidadeTokenSaida:
+          type: integer
+          format: int64
+        custo:
+          type: number
+        modelo:
+          type: string
+    DossierInvestigationAnchorBuilderRecebeResponseResponse:
+      type: object
+      properties:
+        jobId:
+          type: string
+        productKey:
+          type: string
+        stageCode:
+          type: string
+        status:
+          type: string
+        nextStageCode:
+          type: string
+    DossierWarmupResourceDiscoveryRecebeResponseRequest:
+      type: object
+      properties:
+        response:
+          type: string
+        descricaoErro:
+          type: string
+        quantidadeTokenEntrada:
+          type: integer
+          format: int64
+        quantidadeTokenSaida:
+          type: integer
+          format: int64
+        custo:
+          type: number
+        modelo:
+          type: string
+    DossierWarmupResourceDiscoveryRecebeResponseResponse:
+      type: object
+      properties:
+        jobId:
+          type: string
+        productKey:
+          type: string
+        stageCode:
+          type: string
+        status:
+          type: string
+        nextStageCode:
+          type: string
+    DossierSourceProductMatchRecebeResponseRequest:
+      type: object
+      properties:
+        response:
+          type: string
+        descricaoErro:
+          type: string
+        quantidadeTokenEntrada:
+          type: integer
+          format: int64
+        quantidadeTokenSaida:
+          type: integer
+          format: int64
+        custo:
+          type: number
+        modelo:
+          type: string
+    DossierSourceProductMatchRecebeResponseResponse:
+      type: object
+      properties:
+        jobId:
+          type: string
+        productKey:
+          type: string
+        stageCode:
+          type: string
+        status:
+          type: string
+        nextStageCode:
+          type: string
+    DossierWarmupSignalExtractionRecebeResponseRequest:
+      type: object
+      properties:
+        response:
+          type: string
+        descricaoErro:
+          type: string
+        quantidadeTokenEntrada:
+          type: integer
+          format: int64
+        quantidadeTokenSaida:
+          type: integer
+          format: int64
+        custo:
+          type: number
+        modelo:
+          type: string
+    DossierWarmupSignalExtractionRecebeResponseResponse:
+      type: object
+      properties:
+        jobId:
+          type: string
+        productKey:
+          type: string
+        stageCode:
+          type: string
+        status:
+          type: string
+        nextStageCode:
+          type: string
+    DossierWarmupMapBuilderRecebeResponseRequest:
+      type: object
+      properties:
+        response:
+          type: string
+        descricaoErro:
+          type: string
+        quantidadeTokenEntrada:
+          type: integer
+          format: int64
+        quantidadeTokenSaida:
+          type: integer
+          format: int64
+        custo:
+          type: number
+        modelo:
+          type: string
+    DossierWarmupMapBuilderRecebeResponseResponse:
+      type: object
+      properties:
+        jobId:
+          type: string
+        productKey:
+          type: string
+        stageCode:
+          type: string
+        status:
+          type: string
+        nextStageCode:
+          type: string
+    DossierDossierSynthesisRecebeResponseRequest:
+      type: object
+      properties:
+        response:
+          type: string
+        descricaoErro:
+          type: string
+        quantidadeTokenEntrada:
+          type: integer
+          format: int64
+        quantidadeTokenSaida:
+          type: integer
+          format: int64
+        custo:
+          type: number
+        modelo:
+          type: string
+    DossierDossierSynthesisRecebeResponseResponse:
+      type: object
+      properties:
+        jobId:
+          type: string
+        productKey:
+          type: string
+        stageCode:
+          type: string
+        status:
+          type: string
+        nextStageCode:
+          type: string
 
     DossierIntakeRecebeRequestRequest:
       type: object


### PR DESCRIPTION
### Motivation
- Permitir que o módulo executor reporte a resposta de cada etapa do pipeline `moissaleslibraryworker.dossie.v1`, atualizar o status operacional da página/produto e auditar o response para rastreabilidade e análise de custo.
- Garantir que cada resposta seja gravada em `pipeline_dossieproduto` com metadados úteis para relatório e investigação (tokens, custo, modelo, erro, jobId, versão `v1`).

### Description
- Adicionados endpoints `POST /{productKey}/{jobId}/recebeResponse` em todos os controllers das etapas do dossiê MOIS v1 (intake, product-understanding, investigation-anchor-builder, warmup-resource-discovery, source-product-match, warmup-signal-extraction, warmup-map-builder, dossier-synthesis) com `@Slf4j` e log inicial contendo etapa, `productKey`, `jobId` e payload recebido.
- Implementados métodos `recebeResponse(...)` nos respectivos services que: atualizam `status_pipeline_dossieproduto` para `CONCLUIDO` quando `descricaoErro` está vazia ou `FALHA` caso contrário; atualizam `data_pipeline_dossieproduto` (UTC); e inserem um registro em `pipeline_dossieproduto` com `id_externo`, `response`, `codigo_etapa`, `dataHora` (Instant.now()), `jobId`, `quantidade_token_entrada`, `quantidade_token_saida`, `custo`, `modelo`, `descricao_erro` e `versao_pipeline = 'v1'`.
- Criados DTOs de entrada/saída (`receberesponse` package) para cada etapa com campos opcionais `quantidadeTokenEntrada`, `quantidadeTokenSaida`, `custo`, `modelo` e `descricaoErro`, e resposta contendo `jobId`, `productKey`, `stageCode`, `status`, `nextStageCode`.
- Atualizado o Swagger `docs/swagger/mois-dossie-v1-swagger.yaml` para documentar os novos endpoints e os schemas de request/response; adicionadas funções utilitárias locais nos services (`normalizeNextStage`, `isBlank`) para decidir próximo estágio e status.

### Testing
- Rodado `git diff --check` para validar o diff estável (sem problemas).
- Executado `mvn -q -f backend/ads-service/pom.xml test -DskipTests` com sucesso para validar build invocação sem executar testes.
- Iniciada execução completa de testes com `mvn -q -f backend/ads-service/pom.xml test`; a suíte foi iniciada mas apresentou uma falha existente não relacionada (`PipelineServiceTest.shouldMatchOprmNichoCnaeOpenAiFlagsWithCollectorCode`), portanto a execução foi interrompida e não se deve considerar essa falha como regressão das mudanças de callback.
- Tentativas de `spotless:apply` locais tiveram problemas de plugin no ambiente de CI (sem impacto no código funcional criado).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3f1eb6487c8321b57a9a0b903dcb4a)