### PR TITLE
Implementa endpoints recebeResponse e auditoria para GeraAnuncio v1 (texto + imagem)

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/pipelines/aiworker/geracaoanuncios/v1/imagem/controller/GeraAnuncioImagemController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/pipelines/aiworker/geracaoanuncios/v1/imagem/controller/GeraAnuncioImagemController.java
@@ -8,6 +8,8 @@ import com.marketinghub.pipelines.aiworker.geracaoanuncios.v1.imagem.service.rec
 import com.marketinghub.pipelines.aiworker.geracaoanuncios.v1.imagem.service.recebeRequest.GeraAnuncioImagemRecebeRequestRequest;
 import com.marketinghub.pipelines.aiworker.geracaoanuncios.v1.imagem.service.recebeResposta.GeraAnuncioImagemRespostaRequest;
 import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -21,6 +23,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/internal/aiworker/geracaoanuncios/v1/imagem/stage-executions")
 public class GeraAnuncioImagemController {
+    private static final Logger log = LoggerFactory.getLogger(GeraAnuncioImagemController.class);
     private final GeraAnuncioImagemService service;
 
     /** Inicializa o controller com o service canônico da etapa. */
@@ -58,6 +61,19 @@ public class GeraAnuncioImagemController {
             @PathVariable String experimentKey, @PathVariable String jobId, @RequestBody GeraAnuncioImagemRecebeRequestRequest request) {
         service.recebeRequest(experimentKey, jobId, request);
         return ResponseEntity.accepted().build();
+    }
+
+    /** Recebe o callback final do AI Worker com a resposta da etapa e retorna a próxima etapa, quando existir. */
+    @PostMapping("/{experimentKey}/jobs/{jobId}/recebeResponse")
+    public ResponseEntity<String> recebeResponse(
+            @PathVariable String experimentKey, @PathVariable String jobId, @RequestBody GeraAnuncioImagemRespostaRequest request) {
+        log.info(
+                "Recebendo response do pipeline geracaoanuncios; etapa=imagem; experimentKey={}; jobId={}; payload={}",
+                experimentKey,
+                jobId,
+                request);
+        String nextStageCode = service.recebeResponse(experimentKey, jobId, request);
+        return ResponseEntity.accepted().body(nextStageCode);
     }
 
     /** Recebe o prompt operacional enviado ao modelo pelo AI Worker. */

--- a/backend/ads-service/src/main/java/com/marketinghub/pipelines/aiworker/geracaoanuncios/v1/imagem/service/GeraAnuncioImagemService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/pipelines/aiworker/geracaoanuncios/v1/imagem/service/GeraAnuncioImagemService.java
@@ -139,6 +139,41 @@ public class GeraAnuncioImagemService {
     /** Registra a resposta do modelo e a saída estruturada retornada pelo worker. */
     public void recebeResposta(String stageExecutionId, GeraAnuncioImagemRespostaRequest request) {}
 
+    /** Recebe o callback final da etapa, atualiza o experimento e audita a resposta do AI Worker. */
+    @Transactional
+    public String recebeResponse(String experimentKey, String jobId, GeraAnuncioImagemRespostaRequest request) {
+        if (request == null) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "payload required");
+        }
+        if (!StringUtils.hasText(jobId)) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "jobId required");
+        }
+        Instant now = Instant.now();
+        String descricaoErro = resolveDescricaoErro(request);
+        MoisSalesPage salesPage = salesPageRepository
+                .findById(resolveExperimentId(experimentKey))
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Sales page not found"));
+        salesPage.setStatusPipelineGeracaoAnuncios(StringUtils.hasText(descricaoErro) ? STATUS_FAILED : STATUS_COMPLETED);
+        salesPage.setDataPipelineGeracaoAnuncios(now);
+        salesPageRepository.save(salesPage);
+
+        PipelineGeracaoAnuncios pipeline = new PipelineGeracaoAnuncios();
+        pipeline.setIdExterno(experimentKey);
+        pipeline.setResponse(serializeRequest(resolveResponsePayload(request)));
+        pipeline.setCodigoEtapa(STAGE_CODE);
+        pipeline.setDataHora(now);
+        pipeline.setVersaoPipeline(PIPELINE_VERSION);
+        pipeline.setJobId(jobId.trim());
+        pipeline.setQuantidadeTokenEntrada(request.quantidadeTokenEntrada());
+        pipeline.setQuantidadeTokenSaida(request.quantidadeTokenSaida());
+        pipeline.setCusto(request.custo());
+        pipeline.setModelo(request.modelo());
+        pipeline.setDescricaoErro(descricaoErro);
+        pipelineRepository.save(pipeline);
+
+        return StringUtils.hasText(descricaoErro) ? null : resolveNextStageCode();
+    }
+
     /** Busca o detalhe auditável de uma execução da etapa. */
     public GeraAnuncioImagemDetailResponse detailStageExecution(String stageExecutionId) {
         Long experimentId = extractExperimentId(stageExecutionId);
@@ -235,6 +270,33 @@ public class GeraAnuncioImagemService {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "experimentKey must be the numeric experiment id");
         }
         return Long.valueOf(normalizedExperimentKey);
+    }
+
+    /** Resolve a descrição de erro recebida pelo worker para decidir sucesso ou falha da etapa. */
+    private String resolveDescricaoErro(GeraAnuncioImagemRespostaRequest request) {
+        if (StringUtils.hasText(request.descricaoErro())) {
+            return request.descricaoErro().trim();
+        }
+        return StringUtils.hasText(request.error()) ? request.error().trim() : null;
+    }
+
+    /** Resolve o payload de resposta que deve ser auditado no histórico do pipeline. */
+    private Object resolveResponsePayload(GeraAnuncioImagemRespostaRequest request) {
+        if (request.response() != null) {
+            return request.response();
+        }
+        if (request.responsePayload() != null) {
+            return request.responsePayload();
+        }
+        if (request.structuredOutput() != null) {
+            return request.structuredOutput();
+        }
+        return request;
+    }
+
+    /** Retorna a próxima etapa funcional ou nulo quando a etapa atual finaliza o pipeline. */
+    private String resolveNextStageCode() {
+        return "fim".equals(NEXT_STAGE) ? null : NEXT_STAGE;
     }
 
     /** Serializa o request recebido preservando payload estruturado quando existir. */

--- a/backend/ads-service/src/main/java/com/marketinghub/pipelines/aiworker/geracaoanuncios/v1/imagem/service/recebeResposta/GeraAnuncioImagemRespostaRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/pipelines/aiworker/geracaoanuncios/v1/imagem/service/recebeResposta/GeraAnuncioImagemRespostaRequest.java
@@ -1,7 +1,20 @@
 package com.marketinghub.pipelines.aiworker.geracaoanuncios.v1.imagem.service.recebeResposta;
 
+import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.Map;
 
 /** Dados auditáveis da resposta e da saída funcional da etapa Imagem. */
-public record GeraAnuncioImagemRespostaRequest(String jobId, Instant receivedAt, String status, Map<String, Object> responsePayload, Map<String, Object> structuredOutput, String error) {}
+public record GeraAnuncioImagemRespostaRequest(
+        String jobId,
+        Instant receivedAt,
+        String status,
+        Object response,
+        Map<String, Object> responsePayload,
+        Map<String, Object> structuredOutput,
+        String error,
+        String descricaoErro,
+        Long quantidadeTokenEntrada,
+        Long quantidadeTokenSaida,
+        BigDecimal custo,
+        String modelo) {}

--- a/backend/ads-service/src/main/java/com/marketinghub/pipelines/aiworker/geracaoanuncios/v1/texto/controller/GeraAnuncioTextoController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/pipelines/aiworker/geracaoanuncios/v1/texto/controller/GeraAnuncioTextoController.java
@@ -8,6 +8,8 @@ import com.marketinghub.pipelines.aiworker.geracaoanuncios.v1.texto.service.rece
 import com.marketinghub.pipelines.aiworker.geracaoanuncios.v1.texto.service.recebeRequest.GeraAnuncioTextoRecebeRequestRequest;
 import com.marketinghub.pipelines.aiworker.geracaoanuncios.v1.texto.service.recebeResposta.GeraAnuncioTextoRespostaRequest;
 import java.util.List;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
@@ -21,6 +23,7 @@ import org.springframework.web.bind.annotation.RestController;
 @RestController
 @RequestMapping("/api/internal/aiworker/geracaoanuncios/v1/texto/stage-executions")
 public class GeraAnuncioTextoController {
+    private static final Logger log = LoggerFactory.getLogger(GeraAnuncioTextoController.class);
     private final GeraAnuncioTextoService service;
 
     /** Inicializa o controller com o service canônico da etapa. */
@@ -58,6 +61,19 @@ public class GeraAnuncioTextoController {
             @PathVariable String experimentKey, @PathVariable String jobId, @RequestBody GeraAnuncioTextoRecebeRequestRequest request) {
         service.recebeRequest(experimentKey, jobId, request);
         return ResponseEntity.accepted().build();
+    }
+
+    /** Recebe o callback final do AI Worker com a resposta da etapa e retorna a próxima etapa, quando existir. */
+    @PostMapping("/{experimentKey}/jobs/{jobId}/recebeResponse")
+    public ResponseEntity<String> recebeResponse(
+            @PathVariable String experimentKey, @PathVariable String jobId, @RequestBody GeraAnuncioTextoRespostaRequest request) {
+        log.info(
+                "Recebendo response do pipeline geracaoanuncios; etapa=texto; experimentKey={}; jobId={}; payload={}",
+                experimentKey,
+                jobId,
+                request);
+        String nextStageCode = service.recebeResponse(experimentKey, jobId, request);
+        return ResponseEntity.accepted().body(nextStageCode);
     }
 
     /** Recebe o prompt operacional enviado ao modelo pelo AI Worker. */

--- a/backend/ads-service/src/main/java/com/marketinghub/pipelines/aiworker/geracaoanuncios/v1/texto/service/GeraAnuncioTextoService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/pipelines/aiworker/geracaoanuncios/v1/texto/service/GeraAnuncioTextoService.java
@@ -139,6 +139,41 @@ public class GeraAnuncioTextoService {
     /** Registra a resposta do modelo e a saída estruturada retornada pelo worker. */
     public void recebeResposta(String stageExecutionId, GeraAnuncioTextoRespostaRequest request) {}
 
+    /** Recebe o callback final da etapa, atualiza o experimento e audita a resposta do AI Worker. */
+    @Transactional
+    public String recebeResponse(String experimentKey, String jobId, GeraAnuncioTextoRespostaRequest request) {
+        if (request == null) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "payload required");
+        }
+        if (!StringUtils.hasText(jobId)) {
+            throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "jobId required");
+        }
+        Instant now = Instant.now();
+        String descricaoErro = resolveDescricaoErro(request);
+        MoisSalesPage salesPage = salesPageRepository
+                .findById(resolveExperimentId(experimentKey))
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Sales page not found"));
+        salesPage.setStatusPipelineGeracaoAnuncios(StringUtils.hasText(descricaoErro) ? STATUS_FAILED : STATUS_COMPLETED);
+        salesPage.setDataPipelineGeracaoAnuncios(now);
+        salesPageRepository.save(salesPage);
+
+        PipelineGeracaoAnuncios pipeline = new PipelineGeracaoAnuncios();
+        pipeline.setIdExterno(experimentKey);
+        pipeline.setResponse(serializeRequest(resolveResponsePayload(request)));
+        pipeline.setCodigoEtapa(STAGE_CODE);
+        pipeline.setDataHora(now);
+        pipeline.setVersaoPipeline(PIPELINE_VERSION);
+        pipeline.setJobId(jobId.trim());
+        pipeline.setQuantidadeTokenEntrada(request.quantidadeTokenEntrada());
+        pipeline.setQuantidadeTokenSaida(request.quantidadeTokenSaida());
+        pipeline.setCusto(request.custo());
+        pipeline.setModelo(request.modelo());
+        pipeline.setDescricaoErro(descricaoErro);
+        pipelineRepository.save(pipeline);
+
+        return StringUtils.hasText(descricaoErro) ? null : resolveNextStageCode();
+    }
+
     /** Busca o detalhe auditável de uma execução da etapa. */
     public GeraAnuncioTextoDetailResponse detailStageExecution(String stageExecutionId) {
         Long experimentId = extractExperimentId(stageExecutionId);
@@ -235,6 +270,33 @@ public class GeraAnuncioTextoService {
             throw new ResponseStatusException(HttpStatus.BAD_REQUEST, "experimentKey must be the numeric experiment id");
         }
         return Long.valueOf(normalizedExperimentKey);
+    }
+
+    /** Resolve a descrição de erro recebida pelo worker para decidir sucesso ou falha da etapa. */
+    private String resolveDescricaoErro(GeraAnuncioTextoRespostaRequest request) {
+        if (StringUtils.hasText(request.descricaoErro())) {
+            return request.descricaoErro().trim();
+        }
+        return StringUtils.hasText(request.error()) ? request.error().trim() : null;
+    }
+
+    /** Resolve o payload de resposta que deve ser auditado no histórico do pipeline. */
+    private Object resolveResponsePayload(GeraAnuncioTextoRespostaRequest request) {
+        if (request.response() != null) {
+            return request.response();
+        }
+        if (request.responsePayload() != null) {
+            return request.responsePayload();
+        }
+        if (request.structuredOutput() != null) {
+            return request.structuredOutput();
+        }
+        return request;
+    }
+
+    /** Retorna a próxima etapa funcional ou nulo quando a etapa atual finaliza o pipeline. */
+    private String resolveNextStageCode() {
+        return "fim".equals(NEXT_STAGE) ? null : NEXT_STAGE;
     }
 
     /** Serializa o request recebido preservando payload estruturado quando existir. */

--- a/backend/ads-service/src/main/java/com/marketinghub/pipelines/aiworker/geracaoanuncios/v1/texto/service/recebeResposta/GeraAnuncioTextoRespostaRequest.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/pipelines/aiworker/geracaoanuncios/v1/texto/service/recebeResposta/GeraAnuncioTextoRespostaRequest.java
@@ -1,7 +1,20 @@
 package com.marketinghub.pipelines.aiworker.geracaoanuncios.v1.texto.service.recebeResposta;
 
+import java.math.BigDecimal;
 import java.time.Instant;
 import java.util.Map;
 
 /** Dados auditáveis da resposta e da saída funcional da etapa Texto. */
-public record GeraAnuncioTextoRespostaRequest(String jobId, Instant receivedAt, String status, Map<String, Object> responsePayload, Map<String, Object> structuredOutput, String error) {}
+public record GeraAnuncioTextoRespostaRequest(
+        String jobId,
+        Instant receivedAt,
+        String status,
+        Object response,
+        Map<String, Object> responsePayload,
+        Map<String, Object> structuredOutput,
+        String error,
+        String descricaoErro,
+        Long quantidadeTokenEntrada,
+        Long quantidadeTokenSaida,
+        BigDecimal custo,
+        String modelo) {}

--- a/docs/swagger/geraanuncio-v2-swagger.yaml
+++ b/docs/swagger/geraanuncio-v2-swagger.yaml
@@ -58,6 +58,25 @@ paths:
       responses:
         '202':
           description: Request aceito para auditoria.
+  /api/internal/aiworker/geracaoanuncios/v1/texto/stage-executions/{experimentKey}/jobs/{jobId}/recebeResponse:
+    post:
+      summary: Registra response final da etapa Texto
+      description: Recebe o callback final do AI Worker, atualiza status/data do experimento e grava auditoria em pipeline_geracaoanuncios. Retorna o código da próxima etapa quando a etapa termina sem erro.
+      parameters:
+        - name: experimentKey
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: jobId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '202':
+          description: Response aceito para auditoria e avanço do pipeline.
   /api/internal/aiworker/geracaoanuncios/v1/texto/stage-executions/{stageExecutionId}/prompt:
     post:
       summary: Registra prompt enviado ao modelo na etapa Texto
@@ -136,6 +155,25 @@ paths:
       responses:
         '202':
           description: Request aceito para auditoria.
+  /api/internal/aiworker/geracaoanuncios/v1/imagem/stage-executions/{experimentKey}/jobs/{jobId}/recebeResponse:
+    post:
+      summary: Registra response final da etapa Imagem
+      description: Recebe o callback final do AI Worker, atualiza status/data do experimento e grava auditoria em pipeline_geracaoanuncios. Retorna nulo/corpo vazio quando a etapa final termina sem erro.
+      parameters:
+        - name: experimentKey
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: jobId
+          in: path
+          required: true
+          schema:
+            type: string
+            format: uuid
+      responses:
+        '202':
+          description: Response aceito para auditoria e avanço do pipeline.
   /api/internal/aiworker/geracaoanuncios/v1/imagem/stage-executions/{stageExecutionId}/prompt:
     post:
       summary: Registra prompt enviado ao modelo na etapa Imagem


### PR DESCRIPTION
### Motivation
- Permitir que o AI Worker notifique o backend com o callback final (`recebeResponse`) das etapas Texto e Imagem do pipeline `aiworker.geracaoanuncios.v1` para atualizar status, registrar data-hora UTC e auditar a resposta.

### Description
- Adiciona endpoint `POST /api/internal/aiworker/geracaoanuncios/v1/{texto|imagem}/stage-executions/{experimentKey}/jobs/{jobId}/recebeResponse` nos controllers com log inicial do `experimentKey`, `jobId` e payload recebido.
- Implementa `recebeResponse` transactional nos services Texto e Imagem que validam `jobId`/payload, atualizam `status_pipeline_geracaoanuncios` (CONCLUIDO/FALHA) e `data_pipeline_geracaoanuncios` em `mois_sales_page`, e inserem um registro em `pipeline_geracaoanuncios` com `id_externo`, `response`, `codigo_etapa`, `dataHora` (Instant.now()), `versao_pipeline` = `v1`, `jobId`, tokens, `custo`, `modelo` e `descricao_erro` quando presente.
- Expande os DTOs de resposta (`GeraAnuncio*RespostaRequest`) para aceitar `response`, `responsePayload`, `structuredOutput`, `descricaoErro`, `quantidadeTokenEntrada`, `quantidadeTokenSaida`, `custo` e `modelo` e adiciona helpers para resolver descrição de erro, payload de resposta e próxima etapa.
- Atualiza a especificação Swagger `docs/swagger/geraanuncio-v2-swagger.yaml` para documentar os novos callbacks `recebeResponse`.

### Testing
- `mvn -DskipTests compile` passou com sucesso (compilação do módulo `ads-service`).
- `git diff --check` não apontou problemas.
- `mvn spotless:apply -DskipTests` falhou porque o plugin `spotless` não está disponível no ambiente Maven do projeto, portanto formatação automática não pôde ser aplicada.
- `mvn -Dtest=ArquiteturaTest test` identificou falha em regra existente do MOIS Dossiê v1 (controllers/services canônicos ausentes), que é uma regra de arquitetura pré-existente e não relacionada às alterações aqui.
- `mvn test` executou a suíte completa e foi interrompido por falhas de testes de integração/unitários existentes (erros de integridade referencial H2 em testes de Creative/Facebook), que também não são consequência das mudanças implementadas nesta PR.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3f1ed20b88832195894d1714f4e22a)