### PR TITLE
Aplica protocolo padrão módulo ao GeracaoAnuncios v1 no ai-worker

### DIFF
--- a/ai-worker/src/main/java/com/marketinghub/pipelines/geracaoanuncios/v1/GeracaoAnunciosV1Pipeline.java
+++ b/ai-worker/src/main/java/com/marketinghub/pipelines/geracaoanuncios/v1/GeracaoAnunciosV1Pipeline.java
@@ -2,14 +2,14 @@ package com.marketinghub.pipelines.geracaoanuncios.v1;
 
 import java.util.Set;
 
-/** Representa o núcleo declarativo do pipeline GeraAnuncio v2 no AI Worker. */
-public final class GeraAnuncioV2Pipeline {
+/** Representa o núcleo declarativo do pipeline GeracaoAnuncios v1 no AI Worker. */
+public final class GeracaoAnunciosV1Pipeline {
     public static final String TEXTO = "texto";
     public static final String IMAGEM = "imagem";
     private static final Set<String> ETAPAS = Set.of(TEXTO, IMAGEM);
 
     /** Impede instanciação de classe utilitária do núcleo do pipeline. */
-    private GeraAnuncioV2Pipeline() {}
+    private GeracaoAnunciosV1Pipeline() {}
 
     /** Informa se o código recebido representa uma etapa conhecida do pipeline. */
     public static boolean contemEtapa(String etapa) {

--- a/ai-worker/src/main/java/com/marketinghub/pipelines/geracaoanuncios/v1/imagem/GeraAnuncioImagemBackendClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/pipelines/geracaoanuncios/v1/imagem/GeraAnuncioImagemBackendClient.java
@@ -9,7 +9,7 @@ import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
 
-/** Responsabilidade: consumir os contratos backend da etapa Imagem do GeraAnuncio v2. */
+/** Responsabilidade: consumir os contratos backend da etapa Imagem do GeracaoAnuncios v1. */
 @Component
 public class GeraAnuncioImagemBackendClient {
     public static final String PENDING_ENDPOINT = "/internal/aiworker/geracaoanuncios/v1/imagem/stage-executions/pending";
@@ -33,13 +33,13 @@ public class GeraAnuncioImagemBackendClient {
     /** Busca execuções pendentes pelo endpoint pending canônico da etapa Imagem no backend. */
     public List<GeraAnuncioImagemInput> fetchPending() {
         String uri = UrlUtils.joinPath(backendBaseUrl, apiPrefix, PENDING_ENDPOINT);
-        log.info("Buscando pending GeraAnuncio v2 Imagem. endpoint={}", uri);
+        log.info("Buscando pending GeracaoAnuncios v1 Imagem. endpoint={}", uri);
         List<GeraAnuncioImagemInput> response = webClient.post()
                 .uri(uri)
                 .retrieve()
                 .bodyToMono(new ParameterizedTypeReference<List<GeraAnuncioImagemInput>>() {})
                 .doOnNext(payload -> log.info(
-                        "Resposta pending GeraAnuncio v2 Imagem recebida. endpoint={} quantidade={}",
+                        "Resposta pending GeracaoAnuncios v1 Imagem recebida. endpoint={} quantidade={}",
                         uri,
                         payload.size()))
                 .block();

--- a/ai-worker/src/main/java/com/marketinghub/pipelines/geracaoanuncios/v1/imagem/GeraAnuncioImagemProcessor.java
+++ b/ai-worker/src/main/java/com/marketinghub/pipelines/geracaoanuncios/v1/imagem/GeraAnuncioImagemProcessor.java
@@ -7,7 +7,7 @@ import java.util.List;
 import java.util.Map;
 import org.springframework.stereotype.Component;
 
-/** Responsabilidade: executar a etapa Imagem do pipeline GeraAnuncio v2 a partir do contrato canônico do backend. */
+/** Responsabilidade: executar a etapa Imagem do pipeline GeracaoAnuncios v1 a partir do contrato canônico do backend. */
 @Component
 public class GeraAnuncioImagemProcessor implements StageProcessor<GeraAnuncioImagemInput, GeraAnuncioImagemOutput> {
     /** Processa o contexto pendente e devolve saída estruturada pronta para callback ao backend. */

--- a/ai-worker/src/main/java/com/marketinghub/pipelines/geracaoanuncios/v1/texto/GeraAnuncioTextoBackendClient.java
+++ b/ai-worker/src/main/java/com/marketinghub/pipelines/geracaoanuncios/v1/texto/GeraAnuncioTextoBackendClient.java
@@ -9,7 +9,7 @@ import org.springframework.core.ParameterizedTypeReference;
 import org.springframework.stereotype.Component;
 import org.springframework.web.reactive.function.client.WebClient;
 
-/** Responsabilidade: consumir os contratos backend da etapa Texto do GeraAnuncio v2. */
+/** Responsabilidade: consumir os contratos backend da etapa Texto do GeracaoAnuncios v1. */
 @Component
 public class GeraAnuncioTextoBackendClient {
     public static final String PENDING_ENDPOINT = "/internal/aiworker/geracaoanuncios/v1/texto/stage-executions/pending";
@@ -33,13 +33,13 @@ public class GeraAnuncioTextoBackendClient {
     /** Busca execuções pendentes pelo endpoint pending canônico da etapa Texto no backend. */
     public List<GeraAnuncioTextoInput> fetchPending() {
         String uri = UrlUtils.joinPath(backendBaseUrl, apiPrefix, PENDING_ENDPOINT);
-        log.info("Buscando pending GeraAnuncio v2 Texto. endpoint={}", uri);
+        log.info("Buscando pending GeracaoAnuncios v1 Texto. endpoint={}", uri);
         List<GeraAnuncioTextoInput> response = webClient.post()
                 .uri(uri)
                 .retrieve()
                 .bodyToMono(new ParameterizedTypeReference<List<GeraAnuncioTextoInput>>() {})
                 .doOnNext(payload -> log.info(
-                        "Resposta pending GeraAnuncio v2 Texto recebida. endpoint={} quantidade={}",
+                        "Resposta pending GeracaoAnuncios v1 Texto recebida. endpoint={} quantidade={}",
                         uri,
                         payload.size()))
                 .block();

--- a/ai-worker/src/main/java/com/marketinghub/pipelines/geracaoanuncios/v1/texto/GeraAnuncioTextoProcessor.java
+++ b/ai-worker/src/main/java/com/marketinghub/pipelines/geracaoanuncios/v1/texto/GeraAnuncioTextoProcessor.java
@@ -7,7 +7,7 @@ import java.util.List;
 import java.util.Map;
 import org.springframework.stereotype.Component;
 
-/** Responsabilidade: executar a etapa Texto do pipeline GeraAnuncio v2 a partir do contrato canônico do backend. */
+/** Responsabilidade: executar a etapa Texto do pipeline GeracaoAnuncios v1 a partir do contrato canônico do backend. */
 @Component
 public class GeraAnuncioTextoProcessor implements StageProcessor<GeraAnuncioTextoInput, GeraAnuncioTextoOutput> {
     /** Processa o contexto pendente e devolve saída estruturada pronta para callback ao backend. */

--- a/ai-worker/src/test/java/com/marketinghub/worker/architecture/GeracaoAnunciosV1ArchitectureTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/architecture/GeracaoAnunciosV1ArchitectureTest.java
@@ -1,75 +1,120 @@
 package com.marketinghub.worker.architecture;
 
 import com.marketinghub.worker.pipeline.StageProcessor;
+import com.tngtech.archunit.core.domain.Dependency;
+import com.tngtech.archunit.core.domain.JavaClass;
 import com.tngtech.archunit.core.domain.JavaClasses;
 import com.tngtech.archunit.core.importer.ImportOption;
 import com.tngtech.archunit.junit.AnalyzeClasses;
 import com.tngtech.archunit.junit.ArchTest;
+import com.tngtech.archunit.lang.ArchCondition;
 import com.tngtech.archunit.lang.ArchRule;
+import com.tngtech.archunit.lang.ConditionEvents;
+import com.tngtech.archunit.lang.SimpleConditionEvent;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import java.util.TreeSet;
 import java.util.stream.Stream;
 
 import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.classes;
-import static com.tngtech.archunit.lang.syntax.ArchRuleDefinition.noClasses;
 import static com.tngtech.archunit.library.dependencies.SlicesRuleDefinition.slices;
 
-/** Guarda arquitetural do pipeline executor GeraAnuncio v2 no AI Worker. */
+/** Guarda arquitetural do pipeline executor GeracaoAnuncios v1 no AI Worker. */
 @AnalyzeClasses(packages = "com.marketinghub", importOptions = ImportOption.DoNotIncludeTests.class)
-class GeraAnuncioV2ArchitectureTest {
+class GeracaoAnunciosV1ArchitectureTest {
     private static final String PIPELINE_ROOT = "com.marketinghub.pipelines.geracaoanuncios.v1";
 
     @ArchTest
-    static final ArchRule nucleo_geraanuncio_v2_nao_deve_depender_de_etapas = noClasses()
+    static final ArchRule nucleo_geracaoanuncios_v1_nao_deve_depender_de_etapas = classes()
             .that()
             .resideInAPackage(PIPELINE_ROOT)
-            .should()
-            .dependOnClassesThat()
-            .resideInAPackage(PIPELINE_ROOT + ".*..")
-            .because("[ARQUITETURA] [AI Worker][GeraAnuncio v2] o núcleo genérico não pode conhecer etapas concretas");
+            .should(naoDependerDeEtapasConcretas())
+            .because("[ARQUITETURA] [AI Worker][GeracaoAnuncios v1] o núcleo genérico não pode conhecer etapas concretas");
 
     @ArchTest
-    static final ArchRule etapas_geraanuncio_v2_nao_devem_depender_umas_das_outras = slices()
+    static final ArchRule etapas_geracaoanuncios_v1_nao_devem_depender_umas_das_outras = slices()
             .matching("com.marketinghub.pipelines.geracaoanuncios.v1.(*)..")
             .should()
             .notDependOnEachOther()
-            .because("[ARQUITETURA] [AI Worker][GeraAnuncio v2] etapas concretas não podem depender umas das outras");
+            .because("[ARQUITETURA] [AI Worker][GeracaoAnuncios v1] etapas concretas não podem depender umas das outras");
 
     @ArchTest
-    static final ArchRule etapas_geraanuncio_v2_nao_devem_ter_ciclos = slices()
+    static final ArchRule etapas_geracaoanuncios_v1_nao_devem_ter_ciclos = slices()
             .matching("com.marketinghub.pipelines.geracaoanuncios.v1.(*)..")
             .should()
             .beFreeOfCycles()
-            .because("[ARQUITETURA] [AI Worker][GeraAnuncio v2] etapas do pipeline não podem formar ciclos");
+            .because("[ARQUITETURA] [AI Worker][GeracaoAnuncios v1] etapas do pipeline não podem formar ciclos");
 
     @ArchTest
-    static final ArchRule processors_geraanuncio_v2_devem_implementar_stage_processor = classes()
+    static final ArchRule processors_geracaoanuncios_v1_devem_implementar_stage_processor = classes()
             .that()
             .resideInAPackage(PIPELINE_ROOT + "..")
             .and()
             .haveSimpleNameEndingWith("Processor")
             .should()
             .implement(StageProcessor.class)
-            .because("[ARQUITETURA] [AI Worker][GeraAnuncio v2] processors concretos devem implementar StageProcessor");
+            .because("[ARQUITETURA] [AI Worker][GeracaoAnuncios v1] processors concretos devem implementar StageProcessor");
 
     @ArchTest
-    static final ArchRule nucleo_geraanuncio_v2_nao_deve_depender_de_tecnologias_concretas = noClasses()
+    static final ArchRule nucleo_geracaoanuncios_v1_nao_deve_depender_de_tecnologias_concretas = classes()
             .that()
             .resideInAPackage(PIPELINE_ROOT)
-            .should()
-            .dependOnClassesThat()
-            .resideInAnyPackage("org.springframework.web.reactive.function.client..", "org.jsoup..", "com.microsoft.playwright..", "software.amazon.awssdk..", "okhttp3..")
-            .because("[ARQUITETURA] [AI Worker][GeraAnuncio v2] o núcleo deve depender de contratos, não de tecnologias concretas");
+            .should(naoDependerDeTecnologiasConcretas())
+            .because("[ARQUITETURA] [AI Worker][GeracaoAnuncios v1] o núcleo deve depender de contratos, não de tecnologias concretas");
+
+    /** Bloqueia dependência do núcleo em qualquer subpacote de etapa concreta. */
+    private static ArchCondition<JavaClass> naoDependerDeEtapasConcretas() {
+        return new ArchCondition<>("[ARQUITETURA] não depender de etapas concretas do GeracaoAnuncios v1") {
+            /** Avalia dependências diretas da classe do núcleo contra subpacotes de etapa. */
+            @Override
+            public void check(JavaClass item, ConditionEvents events) {
+                for (Dependency dependency : item.getDirectDependenciesFromSelf()) {
+                    String targetPackage = dependency.getTargetClass().getPackageName();
+                    if (targetPackage.startsWith(PIPELINE_ROOT + ".")) {
+                        events.add(SimpleConditionEvent.violated(item, "[ARQUITETURA] [AI Worker][GeracaoAnuncios v1] "
+                                + item.getName() + " depende da etapa concreta " + dependency.getTargetClass().getName()));
+                    }
+                }
+            }
+        };
+    }
+
+    /** Bloqueia tecnologias concretas no núcleo declarativo do pipeline. */
+    private static ArchCondition<JavaClass> naoDependerDeTecnologiasConcretas() {
+        List<String> pacotesTecnicos = Arrays.asList(
+                "org.springframework.web.reactive.function.client",
+                "org.jsoup",
+                "com.microsoft.playwright",
+                "software.amazon.awssdk",
+                "okhttp3");
+        return new ArchCondition<>("[ARQUITETURA] não depender de tecnologias concretas no núcleo") {
+            /** Avalia se alguma dependência direta aponta para tecnologia permitida apenas em etapas/infra. */
+            @Override
+            public void check(JavaClass item, ConditionEvents events) {
+                for (Dependency dependency : item.getDirectDependenciesFromSelf()) {
+                    String targetPackage = dependency.getTargetClass().getPackageName();
+                    Optional<String> pacoteBloqueado = pacotesTecnicos.stream()
+                            .filter(targetPackage::startsWith)
+                            .findFirst();
+                    pacoteBloqueado.ifPresent(pacote -> events.add(SimpleConditionEvent.violated(item,
+                            "[ARQUITETURA] [AI Worker][GeracaoAnuncios v1] " + item.getName()
+                                    + " depende de tecnologia concreta " + dependency.getTargetClass().getName()
+                                    + " do pacote " + pacote)));
+                }
+            }
+        };
+    }
 
     /** Garante que o módulo externo espelhe as etapas backend e consuma o pending canônico de cada etapa. */
     @ArchTest
-    static void modulo_externo_geraanuncio_v2_deve_espelhar_subpacotes_backend_e_consumir_pending(JavaClasses importedClasses) {
+    static void modulo_externo_geracaoanuncios_v1_deve_espelhar_subpacotes_backend_e_consumir_pending(JavaClasses importedClasses) {
         importedClasses.stream().filter(javaClass -> javaClass.getPackageName().startsWith(PIPELINE_ROOT)).findAny();
         Path repositoryRoot = repositoryRoot();
         Path backendRoot = repositoryRoot.resolve(Path.of(
@@ -80,7 +125,7 @@ class GeraAnuncioV2ArchitectureTest {
         Set<String> workerStages = directSubpackages(workerRoot);
         List<String> violations = new ArrayList<>();
         if (!workerStages.equals(backendStages)) {
-            violations.add("[ARQUITETURA] [AI Worker][GeraAnuncio v2] subpacotes do módulo externo devem espelhar o backend; backend="
+            violations.add("[ARQUITETURA] [AI Worker][GeracaoAnuncios v1] subpacotes do módulo externo devem espelhar o backend; backend="
                     + backendStages + "; ai-worker=" + workerStages);
         }
         backendStages.forEach(stage -> validatePendingEndpoint(workerRoot, stage, violations));
@@ -92,13 +137,13 @@ class GeraAnuncioV2ArchitectureTest {
         Path stageDirectory = workerRoot.resolve(stage);
         String expectedEndpoint = "/internal/aiworker/geracaoanuncios/v1/" + stage + "/stage-executions/pending";
         if (!Files.isDirectory(stageDirectory)) {
-            violations.add("[ARQUITETURA] [AI Worker][GeraAnuncio v2] etapa " + stage
+            violations.add("[ARQUITETURA] [AI Worker][GeracaoAnuncios v1] etapa " + stage
                     + " deve existir no módulo externo antes de validar pending");
             return;
         }
         boolean containsPendingEndpoint = javaFiles(stageDirectory).stream().anyMatch(path -> fileContains(path, expectedEndpoint));
         if (!containsPendingEndpoint) {
-            violations.add("[ARQUITETURA] [AI Worker][GeraAnuncio v2] etapa " + stage
+            violations.add("[ARQUITETURA] [AI Worker][GeracaoAnuncios v1] etapa " + stage
                     + " deve chamar o endpoint pending canônico " + expectedEndpoint);
         }
     }
@@ -144,7 +189,7 @@ class GeraAnuncioV2ArchitectureTest {
             }
             current = current.getParent();
         }
-        throw new AssertionError("[ARQUITETURA] raiz do repositório não foi localizada para validar GeraAnuncio v2");
+        throw new AssertionError("[ARQUITETURA] raiz do repositório não foi localizada para validar GeracaoAnuncios v1");
     }
 
     /** Falha com mensagem de arquitetura consolidada quando houver violações. */

--- a/docs/registro-protocolo/padrao-modulo.md
+++ b/docs/registro-protocolo/padrao-modulo.md
@@ -50,3 +50,11 @@
 - Módulo executor: `ai-worker`.
 - Pacote protegido: `com.marketinghub.pipelines.geracaoanuncios.v1`.
 - Alteração: o pipeline GeracaoAnuncios v1 passou a ter duas etapas internas espelhadas com o backend, `texto` e `imagem`, cada uma com client próprio para o endpoint `pending` canônico da etapa par no backend.
+
+## 2026-06-27 — AI Worker — GeracaoAnuncios v1
+
+- Módulo executor: `ai-worker`.
+- Pacote protegido: `com.marketinghub.pipelines.geracaoanuncios.v1`.
+- Etapas protegidas: `texto` e `imagem`.
+- Ponto inicial canônico de consumo pelo executor: `/api/internal/aiworker/geracaoanuncios/v1/<etapa>/stage-executions/pending`.
+- Aplicação: protocolo padrão módulo reforçado no executor, sem alterar o backend principal, com núcleo declarativo versionado, etapas plugáveis e regras ArchUnit específicas para impedir dependência do núcleo em etapas concretas, dependência entre etapas, ciclos, processor fora do contrato `StageProcessor` e tecnologia concreta no núcleo.


### PR DESCRIPTION
### Motivation
- Padronizar e aplicar o protocolo padrão módulo no executor `ai-worker` para o pipeline `geracaoanuncios.v1`, garantindo núcleo versionado e proteção arquitetural entre núcleo e etapas.
- Evitar acoplamento entre etapas concretas e garantir que o núcleo dependa apenas de contratos, não de tecnologias concretas, conforme cânone do Marketing Hub.

### Description
- Renomeei o núcleo do pipeline para `GeracaoAnunciosV1Pipeline` em `ai-worker/src/main/java/com/marketinghub/pipelines/geracaoanuncios/v1/GeracaoAnunciosV1Pipeline.java` e atualizei referências e comentários correspondentes.
- Ajustei mensagens/logs e comentários nos clients/processors das etapas `texto` e `imagem` para refletir `GeracaoAnuncios v1` (arquivos em `.../texto/*` e `.../imagem/*`).
- Substituí e reforcei o teste de arquitetura: `GeraAnuncioV2ArchitectureTest` → `GeracaoAnunciosV1ArchitectureTest` e adicionei `ArchCondition` customizadas (`naoDependerDeEtapasConcretas` e `naoDependerDeTecnologiasConcretas`) para bloquear dependência do núcleo em subpacotes de etapa e em tecnologias concretas.
- Registrei a aplicação do protocolo em `docs/registro-protocolo/padrao-modulo.md` com um novo bloco de data e descrição da aplicação.

### Testing
- Tentei executar o teste de arquitetura com `mvn -q -Dtest=GeracaoAnunciosV1ArchitectureTest test` no diretório do projeto, mas a execução falhou por resolução de dependência externa; o Maven não conseguiu baixar `com.marketinghub:ads-service:0.0.1-SNAPSHOT` do GitHub Packages (HTTP 401 Unauthorized).
- Tentei também invocar Maven apontando o módulo (`-pl ai-worker`) e validar localmente, porém o ambiente não tem acesso às credenciais necessárias, portanto os testes automatizados não concluíram com sucesso.
- Código alterado foi commitado (`Aplica protocolo modulo ao GeracaoAnuncios v1`) e um PR foi aberto com este conjunto de mudanças.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3f250b10c48321a680c7e707cc02b1)