### PR TITLE
Enforce GeracaoAnuncios v1 stage class pattern

### DIFF
--- a/ai-worker/src/test/java/com/marketinghub/worker/architecture/GeracaoAnunciosV1ArchitectureTest.java
+++ b/ai-worker/src/test/java/com/marketinghub/worker/architecture/GeracaoAnunciosV1ArchitectureTest.java
@@ -30,6 +30,16 @@ import static com.tngtech.archunit.library.dependencies.SlicesRuleDefinition.sli
 @AnalyzeClasses(packages = "com.marketinghub", importOptions = ImportOption.DoNotIncludeTests.class)
 class GeracaoAnunciosV1ArchitectureTest {
     private static final String PIPELINE_ROOT = "com.marketinghub.pipelines.geracaoanuncios.v1";
+    private static final List<String> REQUIRED_STAGE_CLASS_SUFFIXES = List.of(
+            "BackendClient",
+            "ExecutionScheduler",
+            "Input",
+            "Output",
+            "PromptBuilder",
+            "ResponseHandler",
+            "ResponseValidator",
+            "WorkerConfiguration",
+            "WorkerProperties");
 
     @ArchTest
     static final ArchRule nucleo_geracaoanuncios_v1_nao_deve_depender_de_etapas = classes()
@@ -110,6 +120,61 @@ class GeracaoAnunciosV1ArchitectureTest {
                 }
             }
         };
+    }
+
+
+    /** Garante que cada etapa concreta tenha somente as nove classes padronizadas do executor. */
+    @ArchTest
+    static void subpacotes_geracaoanuncios_v1_devem_ter_apenas_nove_classes_padronizadas(JavaClasses importedClasses) {
+        importedClasses.stream().filter(javaClass -> javaClass.getPackageName().startsWith(PIPELINE_ROOT)).findAny();
+        Path workerRoot = repositoryRoot().resolve(Path.of(
+                "ai-worker", "src", "main", "java", "com", "marketinghub", "pipelines", "geracaoanuncios", "v1"));
+        List<String> violations = new ArrayList<>();
+        directSubpackages(workerRoot).forEach(stage -> validateStageClassPattern(workerRoot.resolve(stage), stage, violations));
+        failWithArchitectureViolations(violations);
+    }
+
+    /** Valida quantidade, prefixo e sufixos obrigatórios das classes Java de uma etapa. */
+    private static void validateStageClassPattern(Path stageDirectory, String stage, List<String> violations) {
+        List<String> classNames = javaFiles(stageDirectory).stream()
+                .map(path -> path.getFileName().toString().replaceFirst("\\.java$", ""))
+                .sorted()
+                .toList();
+        if (classNames.size() != REQUIRED_STAGE_CLASS_SUFFIXES.size()) {
+            violations.add("[ARQUITETURA] [AI Worker][GeracaoAnuncios v1] etapa " + stage
+                    + " deve ter exatamente " + REQUIRED_STAGE_CLASS_SUFFIXES.size()
+                    + " classes Java padronizadas; encontradas=" + classNames);
+        }
+        Set<String> detectedPrefixes = detectedStagePrefixes(classNames);
+        if (detectedPrefixes.size() != 1) {
+            violations.add("[ARQUITETURA] [AI Worker][GeracaoAnuncios v1] etapa " + stage
+                    + " deve usar um único <nome-etapa> antes dos sufixos padronizados; prefixos="
+                    + detectedPrefixes + "; classes=" + classNames);
+            return;
+        }
+        String stageClassPrefix = detectedPrefixes.iterator().next();
+        Set<String> expectedClassNames = new TreeSet<>();
+        REQUIRED_STAGE_CLASS_SUFFIXES.forEach(suffix -> expectedClassNames.add(stageClassPrefix + suffix));
+        Set<String> actualClassNames = new TreeSet<>(classNames);
+        if (!actualClassNames.equals(expectedClassNames)) {
+            violations.add("[ARQUITETURA] [AI Worker][GeracaoAnuncios v1] etapa " + stage
+                    + " deve conter somente as classes " + expectedClassNames
+                    + "; encontradas=" + actualClassNames);
+        }
+    }
+
+    /** Identifica o prefixo de etapa removendo os sufixos arquiteturais permitidos. */
+    private static Set<String> detectedStagePrefixes(List<String> classNames) {
+        Set<String> prefixes = new TreeSet<>();
+        for (String className : classNames) {
+            Optional<String> suffix = REQUIRED_STAGE_CLASS_SUFFIXES.stream().filter(className::endsWith).findFirst();
+            if (suffix.isPresent()) {
+                prefixes.add(className.substring(0, className.length() - suffix.get().length()));
+            } else {
+                prefixes.add(className);
+            }
+        }
+        return prefixes;
     }
 
     /** Garante que o módulo externo espelhe as etapas backend e consuma o pending canônico de cada etapa. */


### PR DESCRIPTION
### Motivation
- Garantir consistência arquitetural nas etapas do pipeline `geracaoanuncios.v1` do AI Worker impondo um conjunto canônico de classes por etapa para evitar acoplamento e variação ad-hoc entre pacotes de etapa.

### Description
- Adicionada a lista canônica `REQUIRED_STAGE_CLASS_SUFFIXES` com os 9 sufixos obrigatórios: `BackendClient`, `ExecutionScheduler`, `Input`, `Output`, `PromptBuilder`, `ResponseHandler`, `ResponseValidator`, `WorkerConfiguration` e `WorkerProperties` em `ai-worker/src/test/java/com/marketinghub/worker/architecture/GeracaoAnunciosV1ArchitectureTest.java`.
- Inserida uma nova regra de arquitetura (`@ArchTest`) que percorre os subpacotes diretos de `com.marketinghub.pipelines.geracaoanuncios.v1` no worker e valida que cada etapa contenha exatamente as 9 classes padronizadas.
- Implementada validação que assegura um único `<nome-etapa>` (prefixo) por subpacote e compara o conjunto esperado versus o conjunto real de nomes de classe, produzindo mensagens de violação com o prefixo `[ARQUITETURA]` quando divergente.

### Testing
- Foi executada tentativa de teste local com `cd ai-worker && mvn -Dtest=GeracaoAnunciosV1ArchitectureTest test`, porém o build não concluiu por resolução de dependência externa falhando com `401 Unauthorized` ao buscar `com.marketinghub:ads-service:0.0.1-SNAPSHOT` em GitHub Packages, então os testes não puderam ser finalizados no ambiente atual.
- Nenhum outro teste automatizado foi executado com sucesso neste ambiente por limitação de acesso a artefatos remotos.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3f28432ecc8321929a5bc546725fc2)