### PR TITLE
test(oprm-coletor-mei): impor 9 classes canônicas por etapa do NichoCNAE v3

### DIFF
--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -1578,3 +1578,8 @@
 - Aplicado reforço do protocolo padrão módulo no `oprm-coletor-mei` para o pacote executor `com.marketinghub.pipelines.nichocnae.v3`.
 - O teste ArchUnit da v3 agora também bloqueia tecnologia concreta no núcleo `v3.core` e ciclos entre pacotes, prevenindo acoplamento que dificultaria troca, remoção ou evolução das etapas.
 - Backend não foi alterado: o executor continua consumindo o trabalho pelos endpoints `pending` canônicos e reportando resultado ao backend.
+
+## 2026-06-27 — OPRM NichoCNAE v3: regra de classes canônicas por etapa
+
+- Adicionada regra no teste de arquitetura do `oprm-coletor-mei` para validar que subpacotes de etapa concreta em `com.marketinghub.pipelines.nichocnae.v3`, quando adotarem o padrão canônico do worker, fiquem restritos às 9 classes esperadas: `BackendClient`, `ExecutionScheduler`, `Input`, `Output`, `PromptBuilder`, `ResponseHandler`, `ResponseValidator`, `WorkerConfiguration` e `WorkerProperties`.
+- Objetivo: impedir crescimento desordenado dos subpacotes de etapa e manter o executor simples, auditável e plugável.

--- a/oprm-coletor-mei/src/test/java/com/marketinghub/pipelines/nichocnae/v3/architecture/NichoCnaeV3PipelineArchitectureTest.java
+++ b/oprm-coletor-mei/src/test/java/com/marketinghub/pipelines/nichocnae/v3/architecture/NichoCnaeV3PipelineArchitectureTest.java
@@ -13,13 +13,27 @@ import com.tngtech.archunit.core.importer.ImportOption;
 import com.tngtech.archunit.lang.ArchCondition;
 import com.tngtech.archunit.lang.ConditionEvents;
 import com.tngtech.archunit.lang.SimpleConditionEvent;
+import java.util.HashMap;
+import java.util.Map;
 import java.util.Set;
+import java.util.TreeSet;
 import org.junit.jupiter.api.Test;
 
 /** Garante que o pipeline NichoCNAE versão 3 siga o protocolo padrão módulo no executor OPRM. */
 class NichoCnaeV3PipelineArchitectureTest {
     private static final String BASE_PACKAGE = "com.marketinghub.pipelines.nichocnae.v3";
     private static final String CORE_PACKAGE = BASE_PACKAGE + ".core";
+    private static final Set<String> SUPPORT_PACKAGES = Set.of("core", "execution", "architecture");
+    private static final Set<String> REQUIRED_STAGE_CLASS_SUFFIXES = Set.of(
+            "BackendClient",
+            "ExecutionScheduler",
+            "Input",
+            "Output",
+            "PromptBuilder",
+            "ResponseHandler",
+            "ResponseValidator",
+            "WorkerConfiguration",
+            "WorkerProperties");
     private static final Set<String> FORBIDDEN_CORE_TECH_PACKAGES = Set.of(
             "org.springframework",
             "org.jsoup",
@@ -59,6 +73,19 @@ class NichoCnaeV3PipelineArchitectureTest {
                 .that(ARE_IN_CONCRETE_STAGE)
                 .should(notDependOnOtherConcreteStages())
                 .because("[ARQUITETURA] etapas NichoCNAE v3 devem ser plugáveis e removíveis")
+                .check(importedClasses);
+    }
+
+
+    /** Valida que cada etapa concreta da v3 possui somente as 9 classes canônicas do worker. */
+    @Test
+    void concreteStagePackagesShouldHaveOnlyCanonicalWorkerClasses() {
+        JavaClasses importedClasses = importProductionClasses();
+
+        classes()
+                .that(ARE_IN_CONCRETE_STAGE)
+                .should(haveOnlyCanonicalWorkerClassesByStagePackage(importedClasses))
+                .because("[ARQUITETURA] cada subpacote de etapa NichoCNAE v3 deve ter apenas as 9 classes canônicas do worker")
                 .check(importedClasses);
     }
 
@@ -104,6 +131,77 @@ class NichoCnaeV3PipelineArchitectureTest {
         return new ClassFileImporter()
                 .withImportOption(new ImportOption.DoNotIncludeTests())
                 .importPackages(BASE_PACKAGE);
+    }
+
+
+    /** Cria condição explícita que valida o conjunto exato de classes por subpacote de etapa. */
+    private ArchCondition<JavaClass> haveOnlyCanonicalWorkerClassesByStagePackage(JavaClasses importedClasses) {
+        Map<String, Set<String>> classesByStage = classesByStage(importedClasses);
+        return new ArchCondition<>("[ARQUITETURA] ter somente as 9 classes canônicas por etapa NichoCNAE v3") {
+            /** Valida se o pacote da etapa possui exatamente os nomes esperados pelo padrão canônico. */
+            @Override
+            public void check(JavaClass source, ConditionEvents events) {
+                String stage = stageNameOf(source);
+                if (stage == null) {
+                    return;
+                }
+                Set<String> actualClasses = classesByStage.getOrDefault(stage, Set.of());
+                String expectedPrefix = stageClassPrefix(stage);
+                Set<String> expectedClasses = new TreeSet<>();
+                for (String suffix : REQUIRED_STAGE_CLASS_SUFFIXES) {
+                    expectedClasses.add(expectedPrefix + suffix);
+                }
+                if (!usesCanonicalWorkerClassPattern(actualClasses, expectedPrefix)) {
+                    return;
+                }
+                if (!actualClasses.equals(expectedClasses)) {
+                    Set<String> missingClasses = new TreeSet<>(expectedClasses);
+                    missingClasses.removeAll(actualClasses);
+                    Set<String> extraClasses = new TreeSet<>(actualClasses);
+                    extraClasses.removeAll(expectedClasses);
+                    events.add(SimpleConditionEvent.violated(source, "[ARQUITETURA] etapa NichoCNAE v3 '" + stage
+                            + "' deve conter exatamente 9 classes canônicas " + expectedClasses
+                            + ", mas encontrou " + actualClasses
+                            + ". Faltando: " + missingClasses + ". Extras: " + extraClasses));
+                }
+            }
+        };
+    }
+
+    /** Identifica subpacotes que já adotaram pelo menos uma classe do padrão canônico do worker com o prefixo da etapa. */
+    private static boolean usesCanonicalWorkerClassPattern(Set<String> actualClasses, String expectedPrefix) {
+        return actualClasses.stream().anyMatch(className -> REQUIRED_STAGE_CLASS_SUFFIXES.stream()
+                .map(expectedPrefix::concat)
+                .anyMatch(className::equals));
+    }
+
+    /** Agrupa classes de produção por subpacote de etapa concreta. */
+    private static Map<String, Set<String>> classesByStage(JavaClasses importedClasses) {
+        Map<String, Set<String>> classesByStage = new HashMap<>();
+        for (JavaClass javaClass : importedClasses) {
+            String stage = stageNameOf(javaClass);
+            if (stage != null) {
+                classesByStage.computeIfAbsent(stage, ignored -> new TreeSet<>()).add(javaClass.getSimpleName());
+            }
+        }
+        return classesByStage;
+    }
+
+    /** Converte o nome do pacote da etapa em prefixo PascalCase esperado para as classes. */
+    private static String stageClassPrefix(String stage) {
+        StringBuilder prefix = new StringBuilder();
+        boolean capitalizeNext = true;
+        for (char character : stage.toCharArray()) {
+            if (character == '-' || character == '_') {
+                capitalizeNext = true;
+            } else if (capitalizeNext) {
+                prefix.append(Character.toUpperCase(character));
+                capitalizeNext = false;
+            } else {
+                prefix.append(character);
+            }
+        }
+        return prefix.toString();
     }
 
     /** Cria condição explícita que bloqueia dependência do núcleo para etapa concreta. */
@@ -168,7 +266,7 @@ class NichoCnaeV3PipelineArchitectureTest {
         }
         String remainder = packageName.substring(prefix.length());
         String firstSegment = remainder.contains(".") ? remainder.substring(0, remainder.indexOf('.')) : remainder;
-        if (firstSegment.equals("core") || firstSegment.equals("execution") || firstSegment.equals("architecture")) {
+        if (SUPPORT_PACKAGES.contains(firstSegment)) {
             return null;
         }
         return firstSegment;


### PR DESCRIPTION
### Motivation
- Garantir que os subpacotes de etapas do executor NichoCNAE v3 mantenham um tamanho e forma previsíveis para preservar a simplicidade, auditabilidade e plugabilidade do motor de etapas. 
- Evitar crescimento desordenado dos pacotes de etapa e impor o padrão canônico do worker adotado pelo protocolo padrão módulo.

### Description
- Adiciona validação ArchUnit em `oprm-coletor-mei/src/test/java/com/marketinghub/pipelines/nichocnae/v3/architecture/NichoCnaeV3PipelineArchitectureTest.java` que declara os 9 sufixos canônicos (`BackendClient`, `ExecutionScheduler`, `Input`, `Output`, `PromptBuilder`, `ResponseHandler`, `ResponseValidator`, `WorkerConfiguration`, `WorkerProperties`) e a regra `concreteStagePackagesShouldHaveOnlyCanonicalWorkerClasses`. 
- Implementa a condição `haveOnlyCanonicalWorkerClassesByStagePackage` com utilitários auxiliares (`classesByStage`, `stageClassPrefix`, `usesCanonicalWorkerClassPattern`) e ajusta a identificação de pacotes de suporte (`SUPPORT_PACKAGES`) usada por `stageNameOf`. 
- Atualiza o registro operacional em `docs/registros/oprm1.md` documentando a nova regra de classes canônicas por etapa.

### Testing
- Executado o teste específico com `mvn -Dtest=NichoCnaeV3PipelineArchitectureTest test` no módulo `oprm-coletor-mei` como validação automatizada do novo comportamento. 
- Resultado: `BUILD SUCCESS` e `Tests run: 6, Failures: 0, Errors: 0`, ou seja, a suíte ArchUnit da v3 passou sem falhas.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3f283a7da083219edfc66005cb3fe1)