### PR TITLE
Rename reserved pipeline column `schema` to `schema_json` and add migration

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/PipelineNichoCnae.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprm/nichocnae/PipelineNichoCnae.java
@@ -56,7 +56,7 @@ public class PipelineNichoCnae {
     @Column(name = "prompt", columnDefinition = "LONGTEXT")
     private String prompt;
 
-    @Column(name = "schema", columnDefinition = "LONGTEXT")
+    @Column(name = "schema_json", columnDefinition = "LONGTEXT")
     private String schema;
 
     @Column(name = "versao_pipeline", length = 32)

--- a/backend/ads-service/src/main/java/com/marketinghub/pipeline/geracaoanuncios/PipelineGeracaoAnuncios.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/pipeline/geracaoanuncios/PipelineGeracaoAnuncios.java
@@ -61,7 +61,7 @@ public class PipelineGeracaoAnuncios {
     @Column(name = "prompt", columnDefinition = "LONGTEXT")
     private String prompt;
 
-    @Column(name = "schema", columnDefinition = "LONGTEXT")
+    @Column(name = "schema_json", columnDefinition = "LONGTEXT")
     private String schema;
 
     @Column(name = "versao_pipeline", length = 64)

--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-26-pipeline-geracaoanuncios.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-26-pipeline-geracaoanuncios.yaml
@@ -64,7 +64,7 @@ databaseChangeLog:
                   name: prompt
                   type: LONGTEXT
               - column:
-                  name: schema
+                  name: schema_json
                   type: LONGTEXT
               - column:
                   name: versao_pipeline

--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-26-pipeline-nichocnae.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-26-pipeline-nichocnae.yaml
@@ -60,7 +60,7 @@ databaseChangeLog:
                   name: prompt
                   type: LONGTEXT
               - column:
-                  name: schema
+                  name: schema_json
                   type: LONGTEXT
               - column:
                   name: versao_pipeline

--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-27-pipeline-schema-json-column-names.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-27-pipeline-schema-json-column-names.yaml
@@ -1,0 +1,64 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-06-27-01-rename-pipeline-geracaoanuncios-schema-json
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - onError: HALT
+        - dbms:
+            type: mysql
+        - tableExists:
+            tableName: pipeline_geracaoanuncios
+        - columnExists:
+            tableName: pipeline_geracaoanuncios
+            columnName: schema
+        - not:
+            columnExists:
+              tableName: pipeline_geracaoanuncios
+              columnName: schema_json
+      changes:
+        - sql:
+            splitStatements: true
+            stripComments: true
+            sql: |
+              ALTER TABLE pipeline_geracaoanuncios
+                CHANGE COLUMN `schema` schema_json LONGTEXT NULL;
+      rollback:
+        - sql:
+            splitStatements: true
+            stripComments: true
+            sql: |
+              ALTER TABLE pipeline_geracaoanuncios
+                CHANGE COLUMN schema_json `schema` LONGTEXT NULL;
+
+  - changeSet:
+      id: 2026-06-27-02-rename-pipeline-nichocnae-schema-json
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - onError: HALT
+        - dbms:
+            type: mysql
+        - tableExists:
+            tableName: pipeline_nichocnae
+        - columnExists:
+            tableName: pipeline_nichocnae
+            columnName: schema
+        - not:
+            columnExists:
+              tableName: pipeline_nichocnae
+              columnName: schema_json
+      changes:
+        - sql:
+            splitStatements: true
+            stripComments: true
+            sql: |
+              ALTER TABLE pipeline_nichocnae
+                CHANGE COLUMN `schema` schema_json LONGTEXT NULL;
+      rollback:
+        - sql:
+            splitStatements: true
+            stripComments: true
+            sql: |
+              ALTER TABLE pipeline_nichocnae
+                CHANGE COLUMN schema_json `schema` LONGTEXT NULL;

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -1164,6 +1164,10 @@ databaseChangeLog:
       file: changesets/2026-06-26-pipeline-geracaoanuncios.yaml
       relativeToChangelogFile: true
 
+  - include:
+      file: changesets/2026-06-27-pipeline-schema-json-column-names.yaml
+      relativeToChangelogFile: true
+
 
   - include:
       file: changesets/2026-06-26-mois-sales-page-geracaoanuncios-pipeline.yaml

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -5456,3 +5456,5 @@
 - Solicitação: o botão “Gerar anúncios do pipeline” deve chamar o `/start` da primeira etapa do pipeline GeraAnuncio v2 usando o código/chave do experimento.
 - Ajuste aplicado: o frontend deixou de chamar o endpoint legado por `experimentId` no caminho e passou a chamar `/api/internal/aiworker/geracaoanuncios/v1/texto/stage-executions/start` com `experimentKey` como parâmetro de query, alinhando a tela ao contrato documentado da primeira etapa.
 - Prevenção de recorrência: adicionado teste de frontend validando que o clique no botão envia a chave do experimento para o endpoint de início da etapa Texto.
+
+- 2026-06-27: identificado erro 500 no start de `/api/internal/aiworker/geracaoanuncios/v1/texto/stage-executions/start` causado por persistência JPA em coluna MySQL reservada `schema`; a correção final renomeou o mapeamento para a coluna canônica `schema_json` e adicionou migração para ambientes que já tinham a coluna antiga em `PipelineGeracaoAnuncios` e `PipelineNichoCnae`.


### PR DESCRIPTION
### Motivation

- MySQL column named `schema` caused runtime errors (500) due to it being a reserved identifier, so the persistent mapping must be changed to a non-reserved name.
- The entities and changelogs must be aligned so new deployments create `schema_json` while existing databases are migrated safely. 

### Description

- Renamed the JPA column mapping from `schema` to `schema_json` in `PipelineGeracaoAnuncios` and `PipelineNichoCnae` entity classes. 
- Updated the table creation changelog files to define the column as `schema_json` for both `pipeline_geracaoanuncios` and `pipeline_nichocnae`. 
- Added a new Liquibase changeset `2026-06-27-pipeline-schema-json-column-names.yaml` that conditionally renames existing `schema` columns to `schema_json` for both tables with safe preconditions and rollbacks. 
- Included the new changeset in `db.changelog-master.yaml` and recorded the fix in `docs/registros/experimentos.md`.

### Testing

- Ran backend unit tests with `./gradlew test`, and the test suite completed successfully. 
- Performed Liquibase changelog validation/dry-run for the new changeset against MySQL, and validation succeeded.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3f3df96bd4832195dd4b9ce77ef617)