### PR TITLE
Adjust MOIS dossieproduto v1 internal endpoints to use moissaleslibraryworker domain and {idExterno} path

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossieproduto/v1/dossiersynthesis/controller/DossierDossierSynthesisController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossieproduto/v1/dossiersynthesis/controller/DossierDossierSynthesisController.java
@@ -14,48 +14,47 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 /** Expõe a borda HTTP interna da etapa síntese final do dossiê do pipeline de dossiê MOIS v1. */
 @RestController
 @Slf4j
-@RequestMapping("/api/internal/mois/dossieproduto/v1/dossier-synthesis/stage-executions")
+@RequestMapping("/api/internal/moissaleslibraryworker/dossieproduto/v1/dossier-synthesis/stage-executions")
 @RequiredArgsConstructor
 public class DossierDossierSynthesisController {
 
     private final DossierDossierSynthesisService service;
 
-    /** Inicia manualmente a etapa para o produto informado pela chave operacional. */
-    @PostMapping("/start")
-    public void start(@RequestParam("productKey") String productKey) {
-        service.start(productKey);
+    /** Inicia manualmente a etapa para o identificador externo informado na URL. */
+    @PostMapping("/{idExterno}/start")
+    public void start(@PathVariable("idExterno") String idExterno) {
+        service.start(idExterno);
     }
 
 
-    /** Recebe o request do módulo executor para a página/produto informada pela chave operacional. */
-    @PostMapping("/{productKey}/{jobId}/recebeRequest")
+    /** Recebe o request do módulo executor para o identificador externo informado na URL. */
+    @PostMapping("/{idExterno}/{jobId}/recebeRequest")
     public DossierDossierSynthesisRecebeRequestResponse recebeRequest(
-            @PathVariable("productKey") String productKey,
+            @PathVariable("idExterno") String idExterno,
             @PathVariable("jobId") String jobId,
             @Valid @RequestBody DossierDossierSynthesisRecebeRequestRequest request) {
-        return service.recebeRequest(productKey, jobId, request);
+        return service.recebeRequest(idExterno, jobId, request);
     }
 
 
-    /** Recebe a resposta do módulo executor para a página/produto informada pela chave operacional. */
-    @PostMapping("/{productKey}/{jobId}/recebeResponse")
+    /** Recebe a resposta do módulo executor para o identificador externo informado na URL. */
+    @PostMapping("/{idExterno}/{jobId}/recebeResponse")
     public DossierDossierSynthesisRecebeResponseResponse recebeResponse(
-            @PathVariable("productKey") String productKey,
+            @PathVariable("idExterno") String idExterno,
             @PathVariable("jobId") String jobId,
             @Valid @RequestBody DossierDossierSynthesisRecebeResponseRequest request) {
         log.info(
-                "Recebendo response do dossiê MOIS v1: etapa={}, productKey={}, jobId={}, payload={}",
+                "Recebendo response do dossiê MOIS v1: etapa={}, idExterno={}, jobId={}, payload={}",
                 "dossier-synthesis",
-                productKey,
+                idExterno,
                 jobId,
                 request);
-        return service.recebeResponse(productKey, jobId, request);
+        return service.recebeResponse(idExterno, jobId, request);
     }
 
     /** Expõe o ponto inicial canônico de consumo da fila pelo módulo executor. */

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossieproduto/v1/intake/controller/DossierIntakeController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossieproduto/v1/intake/controller/DossierIntakeController.java
@@ -14,48 +14,47 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 /** Expõe a borda HTTP interna da etapa entrada inicial do pipeline de dossiê MOIS v1. */
 @RestController
 @Slf4j
-@RequestMapping("/api/internal/mois/dossieproduto/v1/intake/stage-executions")
+@RequestMapping("/api/internal/moissaleslibraryworker/dossieproduto/v1/intake/stage-executions")
 @RequiredArgsConstructor
 public class DossierIntakeController {
 
     private final DossierIntakeService service;
 
-    /** Inicia manualmente a etapa para o produto informado pela chave operacional. */
-    @PostMapping("/start")
-    public void start(@RequestParam("productKey") String productKey) {
-        service.start(productKey);
+    /** Inicia manualmente a etapa para o identificador externo informado na URL. */
+    @PostMapping("/{idExterno}/start")
+    public void start(@PathVariable("idExterno") String idExterno) {
+        service.start(idExterno);
     }
 
 
-    /** Recebe o request do módulo executor para a página/produto informada pela chave operacional. */
-    @PostMapping("/{productKey}/{jobId}/recebeRequest")
+    /** Recebe o request do módulo executor para o identificador externo informado na URL. */
+    @PostMapping("/{idExterno}/{jobId}/recebeRequest")
     public DossierIntakeRecebeRequestResponse recebeRequest(
-            @PathVariable("productKey") String productKey,
+            @PathVariable("idExterno") String idExterno,
             @PathVariable("jobId") String jobId,
             @Valid @RequestBody DossierIntakeRecebeRequestRequest request) {
-        return service.recebeRequest(productKey, jobId, request);
+        return service.recebeRequest(idExterno, jobId, request);
     }
 
 
-    /** Recebe a resposta do módulo executor para a página/produto informada pela chave operacional. */
-    @PostMapping("/{productKey}/{jobId}/recebeResponse")
+    /** Recebe a resposta do módulo executor para o identificador externo informado na URL. */
+    @PostMapping("/{idExterno}/{jobId}/recebeResponse")
     public DossierIntakeRecebeResponseResponse recebeResponse(
-            @PathVariable("productKey") String productKey,
+            @PathVariable("idExterno") String idExterno,
             @PathVariable("jobId") String jobId,
             @Valid @RequestBody DossierIntakeRecebeResponseRequest request) {
         log.info(
-                "Recebendo response do dossiê MOIS v1: etapa={}, productKey={}, jobId={}, payload={}",
+                "Recebendo response do dossiê MOIS v1: etapa={}, idExterno={}, jobId={}, payload={}",
                 "intake",
-                productKey,
+                idExterno,
                 jobId,
                 request);
-        return service.recebeResponse(productKey, jobId, request);
+        return service.recebeResponse(idExterno, jobId, request);
     }
 
     /** Expõe o ponto inicial canônico de consumo da fila pelo módulo executor. */

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossieproduto/v1/investigationanchorbuilder/controller/DossierInvestigationAnchorBuilderController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossieproduto/v1/investigationanchorbuilder/controller/DossierInvestigationAnchorBuilderController.java
@@ -14,48 +14,47 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 /** Expõe a borda HTTP interna da etapa geração de âncoras de investigação do pipeline de dossiê MOIS v1. */
 @RestController
 @Slf4j
-@RequestMapping("/api/internal/mois/dossieproduto/v1/investigation-anchor-builder/stage-executions")
+@RequestMapping("/api/internal/moissaleslibraryworker/dossieproduto/v1/investigation-anchor-builder/stage-executions")
 @RequiredArgsConstructor
 public class DossierInvestigationAnchorBuilderController {
 
     private final DossierInvestigationAnchorBuilderService service;
 
-    /** Inicia manualmente a etapa para o produto informado pela chave operacional. */
-    @PostMapping("/start")
-    public void start(@RequestParam("productKey") String productKey) {
-        service.start(productKey);
+    /** Inicia manualmente a etapa para o identificador externo informado na URL. */
+    @PostMapping("/{idExterno}/start")
+    public void start(@PathVariable("idExterno") String idExterno) {
+        service.start(idExterno);
     }
 
 
-    /** Recebe o request do módulo executor para a página/produto informada pela chave operacional. */
-    @PostMapping("/{productKey}/{jobId}/recebeRequest")
+    /** Recebe o request do módulo executor para o identificador externo informado na URL. */
+    @PostMapping("/{idExterno}/{jobId}/recebeRequest")
     public DossierInvestigationAnchorBuilderRecebeRequestResponse recebeRequest(
-            @PathVariable("productKey") String productKey,
+            @PathVariable("idExterno") String idExterno,
             @PathVariable("jobId") String jobId,
             @Valid @RequestBody DossierInvestigationAnchorBuilderRecebeRequestRequest request) {
-        return service.recebeRequest(productKey, jobId, request);
+        return service.recebeRequest(idExterno, jobId, request);
     }
 
 
-    /** Recebe a resposta do módulo executor para a página/produto informada pela chave operacional. */
-    @PostMapping("/{productKey}/{jobId}/recebeResponse")
+    /** Recebe a resposta do módulo executor para o identificador externo informado na URL. */
+    @PostMapping("/{idExterno}/{jobId}/recebeResponse")
     public DossierInvestigationAnchorBuilderRecebeResponseResponse recebeResponse(
-            @PathVariable("productKey") String productKey,
+            @PathVariable("idExterno") String idExterno,
             @PathVariable("jobId") String jobId,
             @Valid @RequestBody DossierInvestigationAnchorBuilderRecebeResponseRequest request) {
         log.info(
-                "Recebendo response do dossiê MOIS v1: etapa={}, productKey={}, jobId={}, payload={}",
+                "Recebendo response do dossiê MOIS v1: etapa={}, idExterno={}, jobId={}, payload={}",
                 "investigation-anchor-builder",
-                productKey,
+                idExterno,
                 jobId,
                 request);
-        return service.recebeResponse(productKey, jobId, request);
+        return service.recebeResponse(idExterno, jobId, request);
     }
 
     /** Expõe o ponto inicial canônico de consumo da fila pelo módulo executor. */

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossieproduto/v1/productunderstanding/controller/DossierProductUnderstandingController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossieproduto/v1/productunderstanding/controller/DossierProductUnderstandingController.java
@@ -14,48 +14,47 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 /** Expõe a borda HTTP interna da etapa entendimento do produto do pipeline de dossiê MOIS v1. */
 @RestController
 @Slf4j
-@RequestMapping("/api/internal/mois/dossieproduto/v1/product-understanding/stage-executions")
+@RequestMapping("/api/internal/moissaleslibraryworker/dossieproduto/v1/product-understanding/stage-executions")
 @RequiredArgsConstructor
 public class DossierProductUnderstandingController {
 
     private final DossierProductUnderstandingService service;
 
-    /** Inicia manualmente a etapa para o produto informado pela chave operacional. */
-    @PostMapping("/start")
-    public void start(@RequestParam("productKey") String productKey) {
-        service.start(productKey);
+    /** Inicia manualmente a etapa para o identificador externo informado na URL. */
+    @PostMapping("/{idExterno}/start")
+    public void start(@PathVariable("idExterno") String idExterno) {
+        service.start(idExterno);
     }
 
 
-    /** Recebe o request do módulo executor para a página/produto informada pela chave operacional. */
-    @PostMapping("/{productKey}/{jobId}/recebeRequest")
+    /** Recebe o request do módulo executor para o identificador externo informado na URL. */
+    @PostMapping("/{idExterno}/{jobId}/recebeRequest")
     public DossierProductUnderstandingRecebeRequestResponse recebeRequest(
-            @PathVariable("productKey") String productKey,
+            @PathVariable("idExterno") String idExterno,
             @PathVariable("jobId") String jobId,
             @Valid @RequestBody DossierProductUnderstandingRecebeRequestRequest request) {
-        return service.recebeRequest(productKey, jobId, request);
+        return service.recebeRequest(idExterno, jobId, request);
     }
 
 
-    /** Recebe a resposta do módulo executor para a página/produto informada pela chave operacional. */
-    @PostMapping("/{productKey}/{jobId}/recebeResponse")
+    /** Recebe a resposta do módulo executor para o identificador externo informado na URL. */
+    @PostMapping("/{idExterno}/{jobId}/recebeResponse")
     public DossierProductUnderstandingRecebeResponseResponse recebeResponse(
-            @PathVariable("productKey") String productKey,
+            @PathVariable("idExterno") String idExterno,
             @PathVariable("jobId") String jobId,
             @Valid @RequestBody DossierProductUnderstandingRecebeResponseRequest request) {
         log.info(
-                "Recebendo response do dossiê MOIS v1: etapa={}, productKey={}, jobId={}, payload={}",
+                "Recebendo response do dossiê MOIS v1: etapa={}, idExterno={}, jobId={}, payload={}",
                 "product-understanding",
-                productKey,
+                idExterno,
                 jobId,
                 request);
-        return service.recebeResponse(productKey, jobId, request);
+        return service.recebeResponse(idExterno, jobId, request);
     }
 
     /** Expõe o ponto inicial canônico de consumo da fila pelo módulo executor. */

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossieproduto/v1/sourceproductmatch/controller/DossierSourceProductMatchController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossieproduto/v1/sourceproductmatch/controller/DossierSourceProductMatchController.java
@@ -14,48 +14,47 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 /** Expõe a borda HTTP interna da etapa validação de relação fonte-produto do pipeline de dossiê MOIS v1. */
 @RestController
 @Slf4j
-@RequestMapping("/api/internal/mois/dossieproduto/v1/source-product-match/stage-executions")
+@RequestMapping("/api/internal/moissaleslibraryworker/dossieproduto/v1/source-product-match/stage-executions")
 @RequiredArgsConstructor
 public class DossierSourceProductMatchController {
 
     private final DossierSourceProductMatchService service;
 
-    /** Inicia manualmente a etapa para o produto informado pela chave operacional. */
-    @PostMapping("/start")
-    public void start(@RequestParam("productKey") String productKey) {
-        service.start(productKey);
+    /** Inicia manualmente a etapa para o identificador externo informado na URL. */
+    @PostMapping("/{idExterno}/start")
+    public void start(@PathVariable("idExterno") String idExterno) {
+        service.start(idExterno);
     }
 
 
-    /** Recebe o request do módulo executor para a página/produto informada pela chave operacional. */
-    @PostMapping("/{productKey}/{jobId}/recebeRequest")
+    /** Recebe o request do módulo executor para o identificador externo informado na URL. */
+    @PostMapping("/{idExterno}/{jobId}/recebeRequest")
     public DossierSourceProductMatchRecebeRequestResponse recebeRequest(
-            @PathVariable("productKey") String productKey,
+            @PathVariable("idExterno") String idExterno,
             @PathVariable("jobId") String jobId,
             @Valid @RequestBody DossierSourceProductMatchRecebeRequestRequest request) {
-        return service.recebeRequest(productKey, jobId, request);
+        return service.recebeRequest(idExterno, jobId, request);
     }
 
 
-    /** Recebe a resposta do módulo executor para a página/produto informada pela chave operacional. */
-    @PostMapping("/{productKey}/{jobId}/recebeResponse")
+    /** Recebe a resposta do módulo executor para o identificador externo informado na URL. */
+    @PostMapping("/{idExterno}/{jobId}/recebeResponse")
     public DossierSourceProductMatchRecebeResponseResponse recebeResponse(
-            @PathVariable("productKey") String productKey,
+            @PathVariable("idExterno") String idExterno,
             @PathVariable("jobId") String jobId,
             @Valid @RequestBody DossierSourceProductMatchRecebeResponseRequest request) {
         log.info(
-                "Recebendo response do dossiê MOIS v1: etapa={}, productKey={}, jobId={}, payload={}",
+                "Recebendo response do dossiê MOIS v1: etapa={}, idExterno={}, jobId={}, payload={}",
                 "source-product-match",
-                productKey,
+                idExterno,
                 jobId,
                 request);
-        return service.recebeResponse(productKey, jobId, request);
+        return service.recebeResponse(idExterno, jobId, request);
     }
 
     /** Expõe o ponto inicial canônico de consumo da fila pelo módulo executor. */

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossieproduto/v1/warmupmapbuilder/controller/DossierWarmupMapBuilderController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossieproduto/v1/warmupmapbuilder/controller/DossierWarmupMapBuilderController.java
@@ -14,48 +14,47 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 /** Expõe a borda HTTP interna da etapa montagem do mapa de aquecimento do pipeline de dossiê MOIS v1. */
 @RestController
 @Slf4j
-@RequestMapping("/api/internal/mois/dossieproduto/v1/warmup-map-builder/stage-executions")
+@RequestMapping("/api/internal/moissaleslibraryworker/dossieproduto/v1/warmup-map-builder/stage-executions")
 @RequiredArgsConstructor
 public class DossierWarmupMapBuilderController {
 
     private final DossierWarmupMapBuilderService service;
 
-    /** Inicia manualmente a etapa para o produto informado pela chave operacional. */
-    @PostMapping("/start")
-    public void start(@RequestParam("productKey") String productKey) {
-        service.start(productKey);
+    /** Inicia manualmente a etapa para o identificador externo informado na URL. */
+    @PostMapping("/{idExterno}/start")
+    public void start(@PathVariable("idExterno") String idExterno) {
+        service.start(idExterno);
     }
 
 
-    /** Recebe o request do módulo executor para a página/produto informada pela chave operacional. */
-    @PostMapping("/{productKey}/{jobId}/recebeRequest")
+    /** Recebe o request do módulo executor para o identificador externo informado na URL. */
+    @PostMapping("/{idExterno}/{jobId}/recebeRequest")
     public DossierWarmupMapBuilderRecebeRequestResponse recebeRequest(
-            @PathVariable("productKey") String productKey,
+            @PathVariable("idExterno") String idExterno,
             @PathVariable("jobId") String jobId,
             @Valid @RequestBody DossierWarmupMapBuilderRecebeRequestRequest request) {
-        return service.recebeRequest(productKey, jobId, request);
+        return service.recebeRequest(idExterno, jobId, request);
     }
 
 
-    /** Recebe a resposta do módulo executor para a página/produto informada pela chave operacional. */
-    @PostMapping("/{productKey}/{jobId}/recebeResponse")
+    /** Recebe a resposta do módulo executor para o identificador externo informado na URL. */
+    @PostMapping("/{idExterno}/{jobId}/recebeResponse")
     public DossierWarmupMapBuilderRecebeResponseResponse recebeResponse(
-            @PathVariable("productKey") String productKey,
+            @PathVariable("idExterno") String idExterno,
             @PathVariable("jobId") String jobId,
             @Valid @RequestBody DossierWarmupMapBuilderRecebeResponseRequest request) {
         log.info(
-                "Recebendo response do dossiê MOIS v1: etapa={}, productKey={}, jobId={}, payload={}",
+                "Recebendo response do dossiê MOIS v1: etapa={}, idExterno={}, jobId={}, payload={}",
                 "warmup-map-builder",
-                productKey,
+                idExterno,
                 jobId,
                 request);
-        return service.recebeResponse(productKey, jobId, request);
+        return service.recebeResponse(idExterno, jobId, request);
     }
 
     /** Expõe o ponto inicial canônico de consumo da fila pelo módulo executor. */

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossieproduto/v1/warmupresourcediscovery/controller/DossierWarmupResourceDiscoveryController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossieproduto/v1/warmupresourcediscovery/controller/DossierWarmupResourceDiscoveryController.java
@@ -14,48 +14,47 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 /** Expõe a borda HTTP interna da etapa descoberta de recursos de aquecimento do pipeline de dossiê MOIS v1. */
 @RestController
 @Slf4j
-@RequestMapping("/api/internal/mois/dossieproduto/v1/warmup-resource-discovery/stage-executions")
+@RequestMapping("/api/internal/moissaleslibraryworker/dossieproduto/v1/warmup-resource-discovery/stage-executions")
 @RequiredArgsConstructor
 public class DossierWarmupResourceDiscoveryController {
 
     private final DossierWarmupResourceDiscoveryService service;
 
-    /** Inicia manualmente a etapa para o produto informado pela chave operacional. */
-    @PostMapping("/start")
-    public void start(@RequestParam("productKey") String productKey) {
-        service.start(productKey);
+    /** Inicia manualmente a etapa para o identificador externo informado na URL. */
+    @PostMapping("/{idExterno}/start")
+    public void start(@PathVariable("idExterno") String idExterno) {
+        service.start(idExterno);
     }
 
 
-    /** Recebe o request do módulo executor para a página/produto informada pela chave operacional. */
-    @PostMapping("/{productKey}/{jobId}/recebeRequest")
+    /** Recebe o request do módulo executor para o identificador externo informado na URL. */
+    @PostMapping("/{idExterno}/{jobId}/recebeRequest")
     public DossierWarmupResourceDiscoveryRecebeRequestResponse recebeRequest(
-            @PathVariable("productKey") String productKey,
+            @PathVariable("idExterno") String idExterno,
             @PathVariable("jobId") String jobId,
             @Valid @RequestBody DossierWarmupResourceDiscoveryRecebeRequestRequest request) {
-        return service.recebeRequest(productKey, jobId, request);
+        return service.recebeRequest(idExterno, jobId, request);
     }
 
 
-    /** Recebe a resposta do módulo executor para a página/produto informada pela chave operacional. */
-    @PostMapping("/{productKey}/{jobId}/recebeResponse")
+    /** Recebe a resposta do módulo executor para o identificador externo informado na URL. */
+    @PostMapping("/{idExterno}/{jobId}/recebeResponse")
     public DossierWarmupResourceDiscoveryRecebeResponseResponse recebeResponse(
-            @PathVariable("productKey") String productKey,
+            @PathVariable("idExterno") String idExterno,
             @PathVariable("jobId") String jobId,
             @Valid @RequestBody DossierWarmupResourceDiscoveryRecebeResponseRequest request) {
         log.info(
-                "Recebendo response do dossiê MOIS v1: etapa={}, productKey={}, jobId={}, payload={}",
+                "Recebendo response do dossiê MOIS v1: etapa={}, idExterno={}, jobId={}, payload={}",
                 "warmup-resource-discovery",
-                productKey,
+                idExterno,
                 jobId,
                 request);
-        return service.recebeResponse(productKey, jobId, request);
+        return service.recebeResponse(idExterno, jobId, request);
     }
 
     /** Expõe o ponto inicial canônico de consumo da fila pelo módulo executor. */

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossieproduto/v1/warmupsignalextraction/controller/DossierWarmupSignalExtractionController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossieproduto/v1/warmupsignalextraction/controller/DossierWarmupSignalExtractionController.java
@@ -14,48 +14,47 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 /** Expõe a borda HTTP interna da etapa extração de sinais de aquecimento do pipeline de dossiê MOIS v1. */
 @RestController
 @Slf4j
-@RequestMapping("/api/internal/mois/dossieproduto/v1/warmup-signal-extraction/stage-executions")
+@RequestMapping("/api/internal/moissaleslibraryworker/dossieproduto/v1/warmup-signal-extraction/stage-executions")
 @RequiredArgsConstructor
 public class DossierWarmupSignalExtractionController {
 
     private final DossierWarmupSignalExtractionService service;
 
-    /** Inicia manualmente a etapa para o produto informado pela chave operacional. */
-    @PostMapping("/start")
-    public void start(@RequestParam("productKey") String productKey) {
-        service.start(productKey);
+    /** Inicia manualmente a etapa para o identificador externo informado na URL. */
+    @PostMapping("/{idExterno}/start")
+    public void start(@PathVariable("idExterno") String idExterno) {
+        service.start(idExterno);
     }
 
 
-    /** Recebe o request do módulo executor para a página/produto informada pela chave operacional. */
-    @PostMapping("/{productKey}/{jobId}/recebeRequest")
+    /** Recebe o request do módulo executor para o identificador externo informado na URL. */
+    @PostMapping("/{idExterno}/{jobId}/recebeRequest")
     public DossierWarmupSignalExtractionRecebeRequestResponse recebeRequest(
-            @PathVariable("productKey") String productKey,
+            @PathVariable("idExterno") String idExterno,
             @PathVariable("jobId") String jobId,
             @Valid @RequestBody DossierWarmupSignalExtractionRecebeRequestRequest request) {
-        return service.recebeRequest(productKey, jobId, request);
+        return service.recebeRequest(idExterno, jobId, request);
     }
 
 
-    /** Recebe a resposta do módulo executor para a página/produto informada pela chave operacional. */
-    @PostMapping("/{productKey}/{jobId}/recebeResponse")
+    /** Recebe a resposta do módulo executor para o identificador externo informado na URL. */
+    @PostMapping("/{idExterno}/{jobId}/recebeResponse")
     public DossierWarmupSignalExtractionRecebeResponseResponse recebeResponse(
-            @PathVariable("productKey") String productKey,
+            @PathVariable("idExterno") String idExterno,
             @PathVariable("jobId") String jobId,
             @Valid @RequestBody DossierWarmupSignalExtractionRecebeResponseRequest request) {
         log.info(
-                "Recebendo response do dossiê MOIS v1: etapa={}, productKey={}, jobId={}, payload={}",
+                "Recebendo response do dossiê MOIS v1: etapa={}, idExterno={}, jobId={}, payload={}",
                 "warmup-signal-extraction",
-                productKey,
+                idExterno,
                 jobId,
                 request);
-        return service.recebeResponse(productKey, jobId, request);
+        return service.recebeResponse(idExterno, jobId, request);
     }
 
     /** Expõe o ponto inicial canônico de consumo da fila pelo módulo executor. */

--- a/docs/registro-protocolo/padrao-backend.md
+++ b/docs/registro-protocolo/padrao-backend.md
@@ -38,7 +38,7 @@
 
 - Backend protegido/criado: `com.marketinghub.moissaleslibraryworker.pipelines.dossieproduto.v1` com pacotes por etapa.
 - Módulo executor responsável pela execução operacional: `mois-sales-library-worker`.
-- Endpoints internos pending canônicos aplicados no padrão `/api/internal/mois/dossieproduto/v1/<etapa>/stage-executions/pending`.
+- Endpoints internos pending canônicos aplicados no padrão `/api/internal/moissaleslibraryworker/dossieproduto/v1/<etapa>/stage-executions/pending`.
 - Contratos da operação mantidos como `record` em subpacotes de `service`.
 
 - 2026-06-26 — Aplicado ao pipeline `geracaoanuncios` v1 no backend, pacote `com.marketinghub.pipelines.aiworker.geracaoanuncios.v1`, etapas `texto` e `imagem`, com endpoints pending canônicos `/api/internal/aiworker/geracaoanuncios/v1/texto/stage-executions/pending` e `/api/internal/aiworker/geracaoanuncios/v1/imagem/stage-executions/pending` e contratos DTO como `record` em subpacotes de service.

--- a/docs/registro-protocolo/padrao-modulo.md
+++ b/docs/registro-protocolo/padrao-modulo.md
@@ -32,7 +32,7 @@
 - Módulo executor: `mois-sales-library-worker`.
 - Pacote protegido/criado: `com.marketinghub.pipelines.dossie.v1`.
 - Pipeline criado como `v1`, com núcleo genérico (`PipelineWorker`, `StageProcessor`, `StageContext`, `StageResult`, `StageArtifact`, `ArtifactStore`) e etapas plugáveis `intake`, `product-understanding`, `investigation-anchor-builder`, `warmup-resource-discovery`, `source-product-match`, `warmup-signal-extraction`, `warmup-map-builder` e `dossier-synthesis`.
-- Pontos iniciais canônicos previstos para consumo pelo executor: `/api/internal/mois/dossieproduto/v1/<etapa>/stage-executions/pending`, começando por `intake` e cobrindo todas as etapas v1 do dossiê.
+- Pontos iniciais canônicos previstos para consumo pelo executor: `/api/internal/moissaleslibraryworker/dossieproduto/v1/<etapa>/stage-executions/pending`, começando por `intake` e cobrindo todas as etapas v1 do dossiê.
 
 - 2026-06-26 — Registro do pipeline `geracaoanuncios` v1 no `ai-worker` aplicado no pacote correto `com.marketinghub.pipelines.geracaoanuncios.v1` e pelas etapas `texto` e `imagem`.
 - 2026-06-26 — Aplicado ao módulo executor `ai-worker`, pacote `com.marketinghub.worker.geraanunciov2.pipeline`, pipeline `geraanuncio` v2, etapa inicial `criativo`, consumindo trabalho pelo endpoint pending canônico do backend `/api/internal/geraanuncio/v2/criativo/stage-executions/pending`.

--- a/docs/registros/mois1.md
+++ b/docs/registros/mois1.md
@@ -1879,3 +1879,7 @@ Arquivos principais:
 
 - Removida a dependência de posição física `AFTER dossie_produto_current_stage` na criação de `dossie_produto_updated_at`, que quebrava o bootstrap quando a coluna de etapa ainda não existia.
 - Criado changeset incremental para garantir as colunas canônicas `status_pipeline_dossieproduto` e `data_pipeline_dossieproduto` após a criação das colunas legadas, cobrindo bancos onde o rename anterior foi marcado como executado antes da falha.
+## 2026-06-27 — Endpoints internos do dossiê MOIS v1 ajustados
+
+- Ajustados os controllers do backend `moissaleslibraryworker.dossieproduto.v1` para expor os endpoints internos com domínio `moissaleslibraryworker`, etapa na URL e `idExterno` como identificador operacional no caminho.
+- Atualizada a documentação Swagger do dossiê para refletir `start`, `recebeRequest`, `recebeResponse` e `pending` no novo padrão canônico solicitado.

--- a/docs/swagger/mois-dossie-v1-swagger.yaml
+++ b/docs/swagger/mois-dossie-v1-swagger.yaml
@@ -14,15 +14,15 @@ tags:
   - name: moissaleslibraryworker.dossieproduto.v1
     description: Pipeline v1 de dossiê de produto da biblioteca de páginas de venda MOIS
 paths:
-  /api/internal/mois/dossieproduto/v1/intake/stage-executions/start:
+  /api/internal/moissaleslibraryworker/dossieproduto/v1/intake/stage-executions/{idExterno}/start:
     post:
       tags:
         - moissaleslibraryworker.dossieproduto.v1
       summary: Inicia manualmente a etapa Entrada inicial do dossiê MOIS v1
       operationId: startMoisDossieProdutoV1IntakeStageExecution
       parameters:
-        - name: productKey
-          in: query
+        - name: idExterno
+          in: path
           required: true
           schema:
             type: string
@@ -30,7 +30,7 @@ paths:
       responses:
         '200':
           description: Etapa iniciada sem corpo de resposta
-  /api/internal/mois/dossieproduto/v1/intake/stage-executions/pending:
+  /api/internal/moissaleslibraryworker/dossieproduto/v1/intake/stage-executions/pending:
     post:
       tags:
         - moissaleslibraryworker.dossieproduto.v1
@@ -49,14 +49,14 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/DossierIntakePendingResponse"
-  /api/internal/mois/dossieproduto/v1/intake/stage-executions/{productKey}/{jobId}/recebeRequest:
+  /api/internal/moissaleslibraryworker/dossieproduto/v1/intake/stage-executions/{idExterno}/{jobId}/recebeRequest:
     post:
       tags:
         - moissaleslibraryworker.dossieproduto.v1
       summary: Recebe request operacional da etapa intake do dossiê MOIS v1
       operationId: recebeRequestMoisDossieProdutoV1IntakeStageExecutions
       parameters:
-        - name: productKey
+        - name: idExterno
           in: path
           required: true
           schema:
@@ -79,14 +79,14 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/DossierIntakeRecebeRequestResponse"
-  /api/internal/mois/dossieproduto/v1/intake/stage-executions/{productKey}/{jobId}/recebeResponse:
+  /api/internal/moissaleslibraryworker/dossieproduto/v1/intake/stage-executions/{idExterno}/{jobId}/recebeResponse:
     post:
       tags:
         - moissaleslibraryworker.dossieproduto.v1
       summary: Recebe resposta operacional da etapa intake do dossiê MOIS v1
       operationId: recebeResponseMoisDossieProdutoV1IntakeStageExecutions
       parameters:
-        - name: productKey
+        - name: idExterno
           in: path
           required: true
           schema:
@@ -109,15 +109,15 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/DossierIntakeRecebeResponseResponse"
-  /api/internal/mois/dossieproduto/v1/product-understanding/stage-executions/start:
+  /api/internal/moissaleslibraryworker/dossieproduto/v1/product-understanding/stage-executions/{idExterno}/start:
     post:
       tags:
         - moissaleslibraryworker.dossieproduto.v1
       summary: Inicia manualmente a etapa Entendimento do produto do dossiê MOIS v1
       operationId: startMoisDossieProdutoV1ProductUnderstandingStageExecution
       parameters:
-        - name: productKey
-          in: query
+        - name: idExterno
+          in: path
           required: true
           schema:
             type: string
@@ -125,7 +125,7 @@ paths:
       responses:
         '200':
           description: Etapa iniciada sem corpo de resposta
-  /api/internal/mois/dossieproduto/v1/product-understanding/stage-executions/pending:
+  /api/internal/moissaleslibraryworker/dossieproduto/v1/product-understanding/stage-executions/pending:
     post:
       tags:
         - moissaleslibraryworker.dossieproduto.v1
@@ -144,14 +144,14 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/DossierProductUnderstandingPendingResponse"
-  /api/internal/mois/dossieproduto/v1/product-understanding/stage-executions/{productKey}/{jobId}/recebeRequest:
+  /api/internal/moissaleslibraryworker/dossieproduto/v1/product-understanding/stage-executions/{idExterno}/{jobId}/recebeRequest:
     post:
       tags:
         - moissaleslibraryworker.dossieproduto.v1
       summary: Recebe request operacional da etapa product-understanding do dossiê MOIS v1
       operationId: recebeRequestMoisDossieProdutoV1ProductUnderstandingStageExecutions
       parameters:
-        - name: productKey
+        - name: idExterno
           in: path
           required: true
           schema:
@@ -174,14 +174,14 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/DossierProductUnderstandingRecebeRequestResponse"
-  /api/internal/mois/dossieproduto/v1/product-understanding/stage-executions/{productKey}/{jobId}/recebeResponse:
+  /api/internal/moissaleslibraryworker/dossieproduto/v1/product-understanding/stage-executions/{idExterno}/{jobId}/recebeResponse:
     post:
       tags:
         - moissaleslibraryworker.dossieproduto.v1
       summary: Recebe resposta operacional da etapa product-understanding do dossiê MOIS v1
       operationId: recebeResponseMoisDossieProdutoV1ProductUnderstandingStageExecutions
       parameters:
-        - name: productKey
+        - name: idExterno
           in: path
           required: true
           schema:
@@ -204,15 +204,15 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/DossierProductUnderstandingRecebeResponseResponse"
-  /api/internal/mois/dossieproduto/v1/investigation-anchor-builder/stage-executions/start:
+  /api/internal/moissaleslibraryworker/dossieproduto/v1/investigation-anchor-builder/stage-executions/{idExterno}/start:
     post:
       tags:
         - moissaleslibraryworker.dossieproduto.v1
       summary: Inicia manualmente a etapa Geração de âncoras de investigação do dossiê MOIS v1
       operationId: startMoisDossieProdutoV1InvestigationAnchorBuilderStageExecution
       parameters:
-        - name: productKey
-          in: query
+        - name: idExterno
+          in: path
           required: true
           schema:
             type: string
@@ -220,7 +220,7 @@ paths:
       responses:
         '200':
           description: Etapa iniciada sem corpo de resposta
-  /api/internal/mois/dossieproduto/v1/investigation-anchor-builder/stage-executions/pending:
+  /api/internal/moissaleslibraryworker/dossieproduto/v1/investigation-anchor-builder/stage-executions/pending:
     post:
       tags:
         - moissaleslibraryworker.dossieproduto.v1
@@ -239,14 +239,14 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/DossierInvestigationAnchorBuilderPendingResponse"
-  /api/internal/mois/dossieproduto/v1/investigation-anchor-builder/stage-executions/{productKey}/{jobId}/recebeRequest:
+  /api/internal/moissaleslibraryworker/dossieproduto/v1/investigation-anchor-builder/stage-executions/{idExterno}/{jobId}/recebeRequest:
     post:
       tags:
         - moissaleslibraryworker.dossieproduto.v1
       summary: Recebe request operacional da etapa investigation-anchor-builder do dossiê MOIS v1
       operationId: recebeRequestMoisDossieProdutoV1InvestigationAnchorBuilderStageExecutions
       parameters:
-        - name: productKey
+        - name: idExterno
           in: path
           required: true
           schema:
@@ -269,14 +269,14 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/DossierInvestigationAnchorBuilderRecebeRequestResponse"
-  /api/internal/mois/dossieproduto/v1/investigation-anchor-builder/stage-executions/{productKey}/{jobId}/recebeResponse:
+  /api/internal/moissaleslibraryworker/dossieproduto/v1/investigation-anchor-builder/stage-executions/{idExterno}/{jobId}/recebeResponse:
     post:
       tags:
         - moissaleslibraryworker.dossieproduto.v1
       summary: Recebe resposta operacional da etapa investigation-anchor-builder do dossiê MOIS v1
       operationId: recebeResponseMoisDossieProdutoV1InvestigationAnchorBuilderStageExecutions
       parameters:
-        - name: productKey
+        - name: idExterno
           in: path
           required: true
           schema:
@@ -299,15 +299,15 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/DossierInvestigationAnchorBuilderRecebeResponseResponse"
-  /api/internal/mois/dossieproduto/v1/warmup-resource-discovery/stage-executions/start:
+  /api/internal/moissaleslibraryworker/dossieproduto/v1/warmup-resource-discovery/stage-executions/{idExterno}/start:
     post:
       tags:
         - moissaleslibraryworker.dossieproduto.v1
       summary: Inicia manualmente a etapa Descoberta de recursos de aquecimento do dossiê MOIS v1
       operationId: startMoisDossieProdutoV1WarmupResourceDiscoveryStageExecution
       parameters:
-        - name: productKey
-          in: query
+        - name: idExterno
+          in: path
           required: true
           schema:
             type: string
@@ -315,7 +315,7 @@ paths:
       responses:
         '200':
           description: Etapa iniciada sem corpo de resposta
-  /api/internal/mois/dossieproduto/v1/warmup-resource-discovery/stage-executions/pending:
+  /api/internal/moissaleslibraryworker/dossieproduto/v1/warmup-resource-discovery/stage-executions/pending:
     post:
       tags:
         - moissaleslibraryworker.dossieproduto.v1
@@ -334,14 +334,14 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/DossierWarmupResourceDiscoveryPendingResponse"
-  /api/internal/mois/dossieproduto/v1/warmup-resource-discovery/stage-executions/{productKey}/{jobId}/recebeRequest:
+  /api/internal/moissaleslibraryworker/dossieproduto/v1/warmup-resource-discovery/stage-executions/{idExterno}/{jobId}/recebeRequest:
     post:
       tags:
         - moissaleslibraryworker.dossieproduto.v1
       summary: Recebe request operacional da etapa warmup-resource-discovery do dossiê MOIS v1
       operationId: recebeRequestMoisDossieProdutoV1WarmupResourceDiscoveryStageExecutions
       parameters:
-        - name: productKey
+        - name: idExterno
           in: path
           required: true
           schema:
@@ -364,14 +364,14 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/DossierWarmupResourceDiscoveryRecebeRequestResponse"
-  /api/internal/mois/dossieproduto/v1/warmup-resource-discovery/stage-executions/{productKey}/{jobId}/recebeResponse:
+  /api/internal/moissaleslibraryworker/dossieproduto/v1/warmup-resource-discovery/stage-executions/{idExterno}/{jobId}/recebeResponse:
     post:
       tags:
         - moissaleslibraryworker.dossieproduto.v1
       summary: Recebe resposta operacional da etapa warmup-resource-discovery do dossiê MOIS v1
       operationId: recebeResponseMoisDossieProdutoV1WarmupResourceDiscoveryStageExecutions
       parameters:
-        - name: productKey
+        - name: idExterno
           in: path
           required: true
           schema:
@@ -394,15 +394,15 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/DossierWarmupResourceDiscoveryRecebeResponseResponse"
-  /api/internal/mois/dossieproduto/v1/source-product-match/stage-executions/start:
+  /api/internal/moissaleslibraryworker/dossieproduto/v1/source-product-match/stage-executions/{idExterno}/start:
     post:
       tags:
         - moissaleslibraryworker.dossieproduto.v1
       summary: Inicia manualmente a etapa Validação de relação fonte-produto do dossiê MOIS v1
       operationId: startMoisDossieProdutoV1SourceProductMatchStageExecution
       parameters:
-        - name: productKey
-          in: query
+        - name: idExterno
+          in: path
           required: true
           schema:
             type: string
@@ -410,7 +410,7 @@ paths:
       responses:
         '200':
           description: Etapa iniciada sem corpo de resposta
-  /api/internal/mois/dossieproduto/v1/source-product-match/stage-executions/pending:
+  /api/internal/moissaleslibraryworker/dossieproduto/v1/source-product-match/stage-executions/pending:
     post:
       tags:
         - moissaleslibraryworker.dossieproduto.v1
@@ -429,14 +429,14 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/DossierSourceProductMatchPendingResponse"
-  /api/internal/mois/dossieproduto/v1/source-product-match/stage-executions/{productKey}/{jobId}/recebeRequest:
+  /api/internal/moissaleslibraryworker/dossieproduto/v1/source-product-match/stage-executions/{idExterno}/{jobId}/recebeRequest:
     post:
       tags:
         - moissaleslibraryworker.dossieproduto.v1
       summary: Recebe request operacional da etapa source-product-match do dossiê MOIS v1
       operationId: recebeRequestMoisDossieProdutoV1SourceProductMatchStageExecutions
       parameters:
-        - name: productKey
+        - name: idExterno
           in: path
           required: true
           schema:
@@ -459,14 +459,14 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/DossierSourceProductMatchRecebeRequestResponse"
-  /api/internal/mois/dossieproduto/v1/source-product-match/stage-executions/{productKey}/{jobId}/recebeResponse:
+  /api/internal/moissaleslibraryworker/dossieproduto/v1/source-product-match/stage-executions/{idExterno}/{jobId}/recebeResponse:
     post:
       tags:
         - moissaleslibraryworker.dossieproduto.v1
       summary: Recebe resposta operacional da etapa source-product-match do dossiê MOIS v1
       operationId: recebeResponseMoisDossieProdutoV1SourceProductMatchStageExecutions
       parameters:
-        - name: productKey
+        - name: idExterno
           in: path
           required: true
           schema:
@@ -489,15 +489,15 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/DossierSourceProductMatchRecebeResponseResponse"
-  /api/internal/mois/dossieproduto/v1/warmup-signal-extraction/stage-executions/start:
+  /api/internal/moissaleslibraryworker/dossieproduto/v1/warmup-signal-extraction/stage-executions/{idExterno}/start:
     post:
       tags:
         - moissaleslibraryworker.dossieproduto.v1
       summary: Inicia manualmente a etapa Extração de sinais de aquecimento do dossiê MOIS v1
       operationId: startMoisDossieProdutoV1WarmupSignalExtractionStageExecution
       parameters:
-        - name: productKey
-          in: query
+        - name: idExterno
+          in: path
           required: true
           schema:
             type: string
@@ -505,7 +505,7 @@ paths:
       responses:
         '200':
           description: Etapa iniciada sem corpo de resposta
-  /api/internal/mois/dossieproduto/v1/warmup-signal-extraction/stage-executions/pending:
+  /api/internal/moissaleslibraryworker/dossieproduto/v1/warmup-signal-extraction/stage-executions/pending:
     post:
       tags:
         - moissaleslibraryworker.dossieproduto.v1
@@ -524,14 +524,14 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/DossierWarmupSignalExtractionPendingResponse"
-  /api/internal/mois/dossieproduto/v1/warmup-signal-extraction/stage-executions/{productKey}/{jobId}/recebeRequest:
+  /api/internal/moissaleslibraryworker/dossieproduto/v1/warmup-signal-extraction/stage-executions/{idExterno}/{jobId}/recebeRequest:
     post:
       tags:
         - moissaleslibraryworker.dossieproduto.v1
       summary: Recebe request operacional da etapa warmup-signal-extraction do dossiê MOIS v1
       operationId: recebeRequestMoisDossieProdutoV1WarmupSignalExtractionStageExecutions
       parameters:
-        - name: productKey
+        - name: idExterno
           in: path
           required: true
           schema:
@@ -554,14 +554,14 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/DossierWarmupSignalExtractionRecebeRequestResponse"
-  /api/internal/mois/dossieproduto/v1/warmup-signal-extraction/stage-executions/{productKey}/{jobId}/recebeResponse:
+  /api/internal/moissaleslibraryworker/dossieproduto/v1/warmup-signal-extraction/stage-executions/{idExterno}/{jobId}/recebeResponse:
     post:
       tags:
         - moissaleslibraryworker.dossieproduto.v1
       summary: Recebe resposta operacional da etapa warmup-signal-extraction do dossiê MOIS v1
       operationId: recebeResponseMoisDossieProdutoV1WarmupSignalExtractionStageExecutions
       parameters:
-        - name: productKey
+        - name: idExterno
           in: path
           required: true
           schema:
@@ -584,15 +584,15 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/DossierWarmupSignalExtractionRecebeResponseResponse"
-  /api/internal/mois/dossieproduto/v1/warmup-map-builder/stage-executions/start:
+  /api/internal/moissaleslibraryworker/dossieproduto/v1/warmup-map-builder/stage-executions/{idExterno}/start:
     post:
       tags:
         - moissaleslibraryworker.dossieproduto.v1
       summary: Inicia manualmente a etapa Montagem do mapa de aquecimento do dossiê MOIS v1
       operationId: startMoisDossieProdutoV1WarmupMapBuilderStageExecution
       parameters:
-        - name: productKey
-          in: query
+        - name: idExterno
+          in: path
           required: true
           schema:
             type: string
@@ -600,7 +600,7 @@ paths:
       responses:
         '200':
           description: Etapa iniciada sem corpo de resposta
-  /api/internal/mois/dossieproduto/v1/warmup-map-builder/stage-executions/pending:
+  /api/internal/moissaleslibraryworker/dossieproduto/v1/warmup-map-builder/stage-executions/pending:
     post:
       tags:
         - moissaleslibraryworker.dossieproduto.v1
@@ -619,14 +619,14 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/DossierWarmupMapBuilderPendingResponse"
-  /api/internal/mois/dossieproduto/v1/warmup-map-builder/stage-executions/{productKey}/{jobId}/recebeRequest:
+  /api/internal/moissaleslibraryworker/dossieproduto/v1/warmup-map-builder/stage-executions/{idExterno}/{jobId}/recebeRequest:
     post:
       tags:
         - moissaleslibraryworker.dossieproduto.v1
       summary: Recebe request operacional da etapa warmup-map-builder do dossiê MOIS v1
       operationId: recebeRequestMoisDossieProdutoV1WarmupMapBuilderStageExecutions
       parameters:
-        - name: productKey
+        - name: idExterno
           in: path
           required: true
           schema:
@@ -649,14 +649,14 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/DossierWarmupMapBuilderRecebeRequestResponse"
-  /api/internal/mois/dossieproduto/v1/warmup-map-builder/stage-executions/{productKey}/{jobId}/recebeResponse:
+  /api/internal/moissaleslibraryworker/dossieproduto/v1/warmup-map-builder/stage-executions/{idExterno}/{jobId}/recebeResponse:
     post:
       tags:
         - moissaleslibraryworker.dossieproduto.v1
       summary: Recebe resposta operacional da etapa warmup-map-builder do dossiê MOIS v1
       operationId: recebeResponseMoisDossieProdutoV1WarmupMapBuilderStageExecutions
       parameters:
-        - name: productKey
+        - name: idExterno
           in: path
           required: true
           schema:
@@ -679,15 +679,15 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/DossierWarmupMapBuilderRecebeResponseResponse"
-  /api/internal/mois/dossieproduto/v1/dossier-synthesis/stage-executions/start:
+  /api/internal/moissaleslibraryworker/dossieproduto/v1/dossier-synthesis/stage-executions/{idExterno}/start:
     post:
       tags:
         - moissaleslibraryworker.dossieproduto.v1
       summary: Inicia manualmente a etapa Síntese final do dossiê do dossiê MOIS v1
       operationId: startMoisDossieProdutoV1DossierSynthesisStageExecution
       parameters:
-        - name: productKey
-          in: query
+        - name: idExterno
+          in: path
           required: true
           schema:
             type: string
@@ -695,7 +695,7 @@ paths:
       responses:
         '200':
           description: Etapa iniciada sem corpo de resposta
-  /api/internal/mois/dossieproduto/v1/dossier-synthesis/stage-executions/pending:
+  /api/internal/moissaleslibraryworker/dossieproduto/v1/dossier-synthesis/stage-executions/pending:
     post:
       tags:
         - moissaleslibraryworker.dossieproduto.v1
@@ -714,14 +714,14 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/DossierDossierSynthesisPendingResponse"
-  /api/internal/mois/dossieproduto/v1/dossier-synthesis/stage-executions/{productKey}/{jobId}/recebeRequest:
+  /api/internal/moissaleslibraryworker/dossieproduto/v1/dossier-synthesis/stage-executions/{idExterno}/{jobId}/recebeRequest:
     post:
       tags:
         - moissaleslibraryworker.dossieproduto.v1
       summary: Recebe request operacional da etapa dossier-synthesis do dossiê MOIS v1
       operationId: recebeRequestMoisDossieProdutoV1DossierSynthesisStageExecutions
       parameters:
-        - name: productKey
+        - name: idExterno
           in: path
           required: true
           schema:
@@ -744,14 +744,14 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/DossierDossierSynthesisRecebeRequestResponse"
-  /api/internal/mois/dossieproduto/v1/dossier-synthesis/stage-executions/{productKey}/{jobId}/recebeResponse:
+  /api/internal/moissaleslibraryworker/dossieproduto/v1/dossier-synthesis/stage-executions/{idExterno}/{jobId}/recebeResponse:
     post:
       tags:
         - moissaleslibraryworker.dossieproduto.v1
       summary: Recebe resposta operacional da etapa dossier-synthesis do dossiê MOIS v1
       operationId: recebeResponseMoisDossieProdutoV1DossierSynthesisStageExecutions
       parameters:
-        - name: productKey
+        - name: idExterno
           in: path
           required: true
           schema:
@@ -871,7 +871,7 @@ components:
       type: object
       properties:
         jobId: { type: string }
-        productKey: { type: string }
+        idExterno: { type: string }
         stageCode: { type: string }
         status: { type: string }
         nextStageCode: { type: string, nullable: true }
@@ -970,7 +970,7 @@ components:
       type: object
       properties:
         jobId: { type: string }
-        productKey: { type: string }
+        idExterno: { type: string }
         stageCode: { type: string }
         status: { type: string }
         nextStageCode: { type: string, nullable: true }
@@ -1069,7 +1069,7 @@ components:
       type: object
       properties:
         jobId: { type: string }
-        productKey: { type: string }
+        idExterno: { type: string }
         stageCode: { type: string }
         status: { type: string }
         nextStageCode: { type: string, nullable: true }
@@ -1168,7 +1168,7 @@ components:
       type: object
       properties:
         jobId: { type: string }
-        productKey: { type: string }
+        idExterno: { type: string }
         stageCode: { type: string }
         status: { type: string }
         nextStageCode: { type: string, nullable: true }
@@ -1267,7 +1267,7 @@ components:
       type: object
       properties:
         jobId: { type: string }
-        productKey: { type: string }
+        idExterno: { type: string }
         stageCode: { type: string }
         status: { type: string }
         nextStageCode: { type: string, nullable: true }
@@ -1366,7 +1366,7 @@ components:
       type: object
       properties:
         jobId: { type: string }
-        productKey: { type: string }
+        idExterno: { type: string }
         stageCode: { type: string }
         status: { type: string }
         nextStageCode: { type: string, nullable: true }
@@ -1465,7 +1465,7 @@ components:
       type: object
       properties:
         jobId: { type: string }
-        productKey: { type: string }
+        idExterno: { type: string }
         stageCode: { type: string }
         status: { type: string }
         nextStageCode: { type: string, nullable: true }
@@ -1564,7 +1564,7 @@ components:
       type: object
       properties:
         jobId: { type: string }
-        productKey: { type: string }
+        idExterno: { type: string }
         stageCode: { type: string }
         status: { type: string }
         nextStageCode: { type: string, nullable: true }


### PR DESCRIPTION
### Motivation
- Standardize the internal pipeline contract to the canonical executor domain and URL shape required by the module protocol, moving the operational identifier from query/body to the path to make job routing explicit and consistent with other pipelines.
- Ensure the backend exposes the canonical `pending` + callback endpoints the worker expects: `start`, `{idExterno}/{jobId}/recebeRequest`, `{idExterno}/{jobId}/recebeResponse` and `pending` under the executor domain.

### Description
- Updated controllers under `backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossieproduto/v1/*/controller` to change base `@RequestMapping` from `/api/internal/mois/dossieproduto/v1/...` to `/api/internal/moissaleslibraryworker/dossieproduto/v1/...` and to replace `POST /start` with `POST /{idExterno}/start` using `@PathVariable` instead of `@RequestParam`.
- Replaced endpoints for callbacks to `@PostMapping("/{idExterno}/{jobId}/recebeRequest")` and `@PostMapping("/{idExterno}/{jobId}/recebeResponse")`, updated method signatures and service calls to pass `idExterno` and adjusted log messages accordingly.
- Updated the Swagger file `docs/swagger/mois-dossie-v1-swagger.yaml` to reflect the new paths and parameter locations and replaced `productKey` with `idExterno` in component schemas and operation definitions.
- Updated documentation records `docs/registros/mois1.md`, `docs/registro-protocolo/padrao-backend.md` and `docs/registro-protocolo/padrao-modulo.md` to document the new canonical endpoints and the change to `idExterno` path usage.

### Testing
- Ran `cd backend/ads-service && mvn -q -DskipTests compile`, which completed successfully and the backend compiled with the changes.
- Ran `cd backend/ads-service && mvn -q test`, which executed the test suite but reported unit test failures (for example `LeadPortalFlowServiceTest.updateApprovalKeepsLocalStateWhenPublisherFails` and related stack traces), so the full test suite did not pass.
- Attempted `cd backend/ads-service && mvn -q spotless:check`, which failed because the Spotless plugin is not available/configured in the current Maven environment.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3f496f87d88321bd96ff5992592809)