### PR TITLE
Ajusta endpoints NichoCNAE v3 do OPRM Coletor MEI

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/cnaeintake/controller/BackendCnaeIntakeController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/cnaeintake/controller/BackendCnaeIntakeController.java
@@ -11,17 +11,15 @@ import com.marketinghub.oprmcoletormei.nichocnae.v3.shared.OprmNichoCnaeV3Recebe
 import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 /** Controller canônico da etapa cnae-intake do pipeline NichoCNAE v3. */
 @RestController
-@RequestMapping("/api/internal/oprm/nichocnae/v3/cnae-intake/stage-executions")
+@RequestMapping("/api/internal/oprmcoletormei/nichocnae/v3/cnae-intake/stage-executions")
 public class BackendCnaeIntakeController {
     private static final Logger log = LoggerFactory.getLogger(BackendCnaeIntakeController.class);
     private final BackendCnaeIntakeService service;
@@ -32,8 +30,8 @@ public class BackendCnaeIntakeController {
     }
 
     /** Inicia uma execução pendente da etapa a partir do CNAE informado pela tela. */
-    @PostMapping("/start")
-    public CnaeIntakeCreateResponse start(@RequestParam String cnaeCode) {
+    @PostMapping("/{idExterno}/start")
+    public CnaeIntakeCreateResponse start(@PathVariable("idExterno") String cnaeCode) {
         return service.start(cnaeCode);
     }
 
@@ -50,20 +48,20 @@ public class BackendCnaeIntakeController {
     }
 
     /** Recebe o request bruto da etapa identificado pelo CNAE e jobId. */
-    @PostMapping("/cnaes/{cnaeCode}/jobs/{jobId}/recebeRequest")
-    public CnaeIntakeCreateResponse recebeRequest(@PathVariable String cnaeCode, @PathVariable String jobId, @RequestBody OprmNichoCnaeV3RecebeRequestRequest request) {
+    @PostMapping("/{idExterno}/{jobId}/recebeRequest")
+    public CnaeIntakeCreateResponse recebeRequest(@PathVariable("idExterno") String cnaeCode, @PathVariable String jobId, @RequestBody OprmNichoCnaeV3RecebeRequestRequest request) {
         return service.recebeRequest(cnaeCode, jobId, request);
     }
 
     /** Recebe o response bruto da etapa identificado pelo CNAE e jobId. */
-    @PostMapping("/cnaes/{cnaeCode}/jobs/{jobId}/recebeResponse")
-    public OprmNichoCnaeV3RecebeResponseResponse recebeResponse(@PathVariable String cnaeCode, @PathVariable String jobId, @RequestBody OprmNichoCnaeV3RecebeResponseRequest request) {
+    @PostMapping("/{idExterno}/{jobId}/recebeResponse")
+    public OprmNichoCnaeV3RecebeResponseResponse recebeResponse(@PathVariable("idExterno") String cnaeCode, @PathVariable String jobId, @RequestBody OprmNichoCnaeV3RecebeResponseRequest request) {
         log.info("Recebendo response NichoCNAE v3. etapa={}, cnaeCode={}, jobId={}, payload={}", service.stageCode(), cnaeCode, jobId, request);
         return service.recebeResponse(cnaeCode, jobId, request);
     }
 
     /** Entrega pendências da etapa cnae-intake ao executor OPRM. */
-    @GetMapping("/pending")
+    @PostMapping("/pending")
     public List<CnaeIntakePendingResponse> pending() {
         return service.pending();
     }

--- a/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/dailytaskssynthesizer/controller/BackendDailyTasksSynthesizerController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/dailytaskssynthesizer/controller/BackendDailyTasksSynthesizerController.java
@@ -11,17 +11,15 @@ import com.marketinghub.oprmcoletormei.nichocnae.v3.shared.OprmNichoCnaeV3Recebe
 import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 /** Controller canônico da etapa daily-tasks-synthesizer do pipeline NichoCNAE v3. */
 @RestController
-@RequestMapping("/api/internal/oprm/nichocnae/v3/daily-tasks-synthesizer/stage-executions")
+@RequestMapping("/api/internal/oprmcoletormei/nichocnae/v3/daily-tasks-synthesizer/stage-executions")
 public class BackendDailyTasksSynthesizerController {
     private static final Logger log = LoggerFactory.getLogger(BackendDailyTasksSynthesizerController.class);
     private final BackendDailyTasksSynthesizerService service;
@@ -32,8 +30,8 @@ public class BackendDailyTasksSynthesizerController {
     }
 
     /** Inicia uma execução pendente da etapa a partir do CNAE informado pela tela. */
-    @PostMapping("/start")
-    public DailyTasksSynthesizerCreateResponse start(@RequestParam String cnaeCode) {
+    @PostMapping("/{idExterno}/start")
+    public DailyTasksSynthesizerCreateResponse start(@PathVariable("idExterno") String cnaeCode) {
         return service.start(cnaeCode);
     }
 
@@ -50,20 +48,20 @@ public class BackendDailyTasksSynthesizerController {
     }
 
     /** Recebe o request bruto da etapa identificado pelo CNAE e jobId. */
-    @PostMapping("/cnaes/{cnaeCode}/jobs/{jobId}/recebeRequest")
-    public DailyTasksSynthesizerCreateResponse recebeRequest(@PathVariable String cnaeCode, @PathVariable String jobId, @RequestBody OprmNichoCnaeV3RecebeRequestRequest request) {
+    @PostMapping("/{idExterno}/{jobId}/recebeRequest")
+    public DailyTasksSynthesizerCreateResponse recebeRequest(@PathVariable("idExterno") String cnaeCode, @PathVariable String jobId, @RequestBody OprmNichoCnaeV3RecebeRequestRequest request) {
         return service.recebeRequest(cnaeCode, jobId, request);
     }
 
     /** Recebe o response bruto da etapa identificado pelo CNAE e jobId. */
-    @PostMapping("/cnaes/{cnaeCode}/jobs/{jobId}/recebeResponse")
-    public OprmNichoCnaeV3RecebeResponseResponse recebeResponse(@PathVariable String cnaeCode, @PathVariable String jobId, @RequestBody OprmNichoCnaeV3RecebeResponseRequest request) {
+    @PostMapping("/{idExterno}/{jobId}/recebeResponse")
+    public OprmNichoCnaeV3RecebeResponseResponse recebeResponse(@PathVariable("idExterno") String cnaeCode, @PathVariable String jobId, @RequestBody OprmNichoCnaeV3RecebeResponseRequest request) {
         log.info("Recebendo response NichoCNAE v3. etapa={}, cnaeCode={}, jobId={}, payload={}", service.stageCode(), cnaeCode, jobId, request);
         return service.recebeResponse(cnaeCode, jobId, request);
     }
 
     /** Entrega pendências da etapa daily-tasks-synthesizer ao executor OPRM. */
-    @GetMapping("/pending")
+    @PostMapping("/pending")
     public List<DailyTasksSynthesizerPendingResponse> pending() {
         return service.pending();
     }

--- a/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/personacandidategenerator/controller/BackendPersonaCandidateGeneratorController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/personacandidategenerator/controller/BackendPersonaCandidateGeneratorController.java
@@ -11,17 +11,15 @@ import com.marketinghub.oprmcoletormei.nichocnae.v3.shared.OprmNichoCnaeV3Recebe
 import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 /** Controller canônico da etapa persona-candidate-generator do pipeline NichoCNAE v3. */
 @RestController
-@RequestMapping("/api/internal/oprm/nichocnae/v3/persona-candidate-generator/stage-executions")
+@RequestMapping("/api/internal/oprmcoletormei/nichocnae/v3/persona-candidate-generator/stage-executions")
 public class BackendPersonaCandidateGeneratorController {
     private static final Logger log = LoggerFactory.getLogger(BackendPersonaCandidateGeneratorController.class);
     private final BackendPersonaCandidateGeneratorService service;
@@ -32,8 +30,8 @@ public class BackendPersonaCandidateGeneratorController {
     }
 
     /** Inicia uma execução pendente da etapa a partir do CNAE informado pela tela. */
-    @PostMapping("/start")
-    public PersonaCandidateGeneratorCreateResponse start(@RequestParam String cnaeCode) {
+    @PostMapping("/{idExterno}/start")
+    public PersonaCandidateGeneratorCreateResponse start(@PathVariable("idExterno") String cnaeCode) {
         return service.start(cnaeCode);
     }
 
@@ -50,20 +48,20 @@ public class BackendPersonaCandidateGeneratorController {
     }
 
     /** Recebe o request bruto da etapa identificado pelo CNAE e jobId. */
-    @PostMapping("/cnaes/{cnaeCode}/jobs/{jobId}/recebeRequest")
-    public PersonaCandidateGeneratorCreateResponse recebeRequest(@PathVariable String cnaeCode, @PathVariable String jobId, @RequestBody OprmNichoCnaeV3RecebeRequestRequest request) {
+    @PostMapping("/{idExterno}/{jobId}/recebeRequest")
+    public PersonaCandidateGeneratorCreateResponse recebeRequest(@PathVariable("idExterno") String cnaeCode, @PathVariable String jobId, @RequestBody OprmNichoCnaeV3RecebeRequestRequest request) {
         return service.recebeRequest(cnaeCode, jobId, request);
     }
 
     /** Recebe o response bruto da etapa identificado pelo CNAE e jobId. */
-    @PostMapping("/cnaes/{cnaeCode}/jobs/{jobId}/recebeResponse")
-    public OprmNichoCnaeV3RecebeResponseResponse recebeResponse(@PathVariable String cnaeCode, @PathVariable String jobId, @RequestBody OprmNichoCnaeV3RecebeResponseRequest request) {
+    @PostMapping("/{idExterno}/{jobId}/recebeResponse")
+    public OprmNichoCnaeV3RecebeResponseResponse recebeResponse(@PathVariable("idExterno") String cnaeCode, @PathVariable String jobId, @RequestBody OprmNichoCnaeV3RecebeResponseRequest request) {
         log.info("Recebendo response NichoCNAE v3. etapa={}, cnaeCode={}, jobId={}, payload={}", service.stageCode(), cnaeCode, jobId, request);
         return service.recebeResponse(cnaeCode, jobId, request);
     }
 
     /** Entrega pendências da etapa persona-candidate-generator ao executor OPRM. */
-    @GetMapping("/pending")
+    @PostMapping("/pending")
     public List<PersonaCandidateGeneratorPendingResponse> pending() {
         return service.pending();
     }

--- a/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/personaroutinematerializer/controller/BackendPersonaRoutineMaterializerController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/personaroutinematerializer/controller/BackendPersonaRoutineMaterializerController.java
@@ -11,17 +11,15 @@ import com.marketinghub.oprmcoletormei.nichocnae.v3.shared.OprmNichoCnaeV3Recebe
 import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 /** Controller canônico da etapa persona-routine-materializer do pipeline NichoCNAE v3. */
 @RestController
-@RequestMapping("/api/internal/oprm/nichocnae/v3/persona-routine-materializer/stage-executions")
+@RequestMapping("/api/internal/oprmcoletormei/nichocnae/v3/persona-routine-materializer/stage-executions")
 public class BackendPersonaRoutineMaterializerController {
     private static final Logger log = LoggerFactory.getLogger(BackendPersonaRoutineMaterializerController.class);
     private final BackendPersonaRoutineMaterializerService service;
@@ -32,8 +30,8 @@ public class BackendPersonaRoutineMaterializerController {
     }
 
     /** Inicia uma execução pendente da etapa a partir do CNAE informado pela tela. */
-    @PostMapping("/start")
-    public PersonaRoutineMaterializerCreateResponse start(@RequestParam String cnaeCode) {
+    @PostMapping("/{idExterno}/start")
+    public PersonaRoutineMaterializerCreateResponse start(@PathVariable("idExterno") String cnaeCode) {
         return service.start(cnaeCode);
     }
 
@@ -50,20 +48,20 @@ public class BackendPersonaRoutineMaterializerController {
     }
 
     /** Recebe o request bruto da etapa identificado pelo CNAE e jobId. */
-    @PostMapping("/cnaes/{cnaeCode}/jobs/{jobId}/recebeRequest")
-    public PersonaRoutineMaterializerCreateResponse recebeRequest(@PathVariable String cnaeCode, @PathVariable String jobId, @RequestBody OprmNichoCnaeV3RecebeRequestRequest request) {
+    @PostMapping("/{idExterno}/{jobId}/recebeRequest")
+    public PersonaRoutineMaterializerCreateResponse recebeRequest(@PathVariable("idExterno") String cnaeCode, @PathVariable String jobId, @RequestBody OprmNichoCnaeV3RecebeRequestRequest request) {
         return service.recebeRequest(cnaeCode, jobId, request);
     }
 
     /** Recebe o response bruto da etapa identificado pelo CNAE e jobId. */
-    @PostMapping("/cnaes/{cnaeCode}/jobs/{jobId}/recebeResponse")
-    public OprmNichoCnaeV3RecebeResponseResponse recebeResponse(@PathVariable String cnaeCode, @PathVariable String jobId, @RequestBody OprmNichoCnaeV3RecebeResponseRequest request) {
+    @PostMapping("/{idExterno}/{jobId}/recebeResponse")
+    public OprmNichoCnaeV3RecebeResponseResponse recebeResponse(@PathVariable("idExterno") String cnaeCode, @PathVariable String jobId, @RequestBody OprmNichoCnaeV3RecebeResponseRequest request) {
         log.info("Recebendo response NichoCNAE v3. etapa={}, cnaeCode={}, jobId={}, payload={}", service.stageCode(), cnaeCode, jobId, request);
         return service.recebeResponse(cnaeCode, jobId, request);
     }
 
     /** Entrega pendências da etapa persona-routine-materializer ao executor OPRM. */
-    @GetMapping("/pending")
+    @PostMapping("/pending")
     public List<PersonaRoutineMaterializerPendingResponse> pending() {
         return service.pending();
     }

--- a/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/personatournament/controller/BackendPersonaTournamentController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/personatournament/controller/BackendPersonaTournamentController.java
@@ -11,17 +11,15 @@ import com.marketinghub.oprmcoletormei.nichocnae.v3.shared.OprmNichoCnaeV3Recebe
 import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 /** Controller canônico da etapa persona-tournament do pipeline NichoCNAE v3. */
 @RestController
-@RequestMapping("/api/internal/oprm/nichocnae/v3/persona-tournament/stage-executions")
+@RequestMapping("/api/internal/oprmcoletormei/nichocnae/v3/persona-tournament/stage-executions")
 public class BackendPersonaTournamentController {
     private static final Logger log = LoggerFactory.getLogger(BackendPersonaTournamentController.class);
     private final BackendPersonaTournamentService service;
@@ -32,8 +30,8 @@ public class BackendPersonaTournamentController {
     }
 
     /** Inicia uma execução pendente da etapa a partir do CNAE informado pela tela. */
-    @PostMapping("/start")
-    public PersonaTournamentCreateResponse start(@RequestParam String cnaeCode) {
+    @PostMapping("/{idExterno}/start")
+    public PersonaTournamentCreateResponse start(@PathVariable("idExterno") String cnaeCode) {
         return service.start(cnaeCode);
     }
 
@@ -50,20 +48,20 @@ public class BackendPersonaTournamentController {
     }
 
     /** Recebe o request bruto da etapa identificado pelo CNAE e jobId. */
-    @PostMapping("/cnaes/{cnaeCode}/jobs/{jobId}/recebeRequest")
-    public PersonaTournamentCreateResponse recebeRequest(@PathVariable String cnaeCode, @PathVariable String jobId, @RequestBody OprmNichoCnaeV3RecebeRequestRequest request) {
+    @PostMapping("/{idExterno}/{jobId}/recebeRequest")
+    public PersonaTournamentCreateResponse recebeRequest(@PathVariable("idExterno") String cnaeCode, @PathVariable String jobId, @RequestBody OprmNichoCnaeV3RecebeRequestRequest request) {
         return service.recebeRequest(cnaeCode, jobId, request);
     }
 
     /** Recebe o response bruto da etapa identificado pelo CNAE e jobId. */
-    @PostMapping("/cnaes/{cnaeCode}/jobs/{jobId}/recebeResponse")
-    public OprmNichoCnaeV3RecebeResponseResponse recebeResponse(@PathVariable String cnaeCode, @PathVariable String jobId, @RequestBody OprmNichoCnaeV3RecebeResponseRequest request) {
+    @PostMapping("/{idExterno}/{jobId}/recebeResponse")
+    public OprmNichoCnaeV3RecebeResponseResponse recebeResponse(@PathVariable("idExterno") String cnaeCode, @PathVariable String jobId, @RequestBody OprmNichoCnaeV3RecebeResponseRequest request) {
         log.info("Recebendo response NichoCNAE v3. etapa={}, cnaeCode={}, jobId={}, payload={}", service.stageCode(), cnaeCode, jobId, request);
         return service.recebeResponse(cnaeCode, jobId, request);
     }
 
     /** Entrega pendências da etapa persona-tournament ao executor OPRM. */
-    @GetMapping("/pending")
+    @PostMapping("/pending")
     public List<PersonaTournamentPendingResponse> pending() {
         return service.pending();
     }

--- a/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/qualitygate/controller/BackendQualityGateController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/qualitygate/controller/BackendQualityGateController.java
@@ -11,17 +11,15 @@ import com.marketinghub.oprmcoletormei.nichocnae.v3.shared.OprmNichoCnaeV3Recebe
 import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 /** Controller canônico da etapa quality-gate do pipeline NichoCNAE v3. */
 @RestController
-@RequestMapping("/api/internal/oprm/nichocnae/v3/quality-gate/stage-executions")
+@RequestMapping("/api/internal/oprmcoletormei/nichocnae/v3/quality-gate/stage-executions")
 public class BackendQualityGateController {
     private static final Logger log = LoggerFactory.getLogger(BackendQualityGateController.class);
     private final BackendQualityGateService service;
@@ -32,8 +30,8 @@ public class BackendQualityGateController {
     }
 
     /** Inicia uma execução pendente da etapa a partir do CNAE informado pela tela. */
-    @PostMapping("/start")
-    public QualityGateCreateResponse start(@RequestParam String cnaeCode) {
+    @PostMapping("/{idExterno}/start")
+    public QualityGateCreateResponse start(@PathVariable("idExterno") String cnaeCode) {
         return service.start(cnaeCode);
     }
 
@@ -50,20 +48,20 @@ public class BackendQualityGateController {
     }
 
     /** Recebe o request bruto da etapa identificado pelo CNAE e jobId. */
-    @PostMapping("/cnaes/{cnaeCode}/jobs/{jobId}/recebeRequest")
-    public QualityGateCreateResponse recebeRequest(@PathVariable String cnaeCode, @PathVariable String jobId, @RequestBody OprmNichoCnaeV3RecebeRequestRequest request) {
+    @PostMapping("/{idExterno}/{jobId}/recebeRequest")
+    public QualityGateCreateResponse recebeRequest(@PathVariable("idExterno") String cnaeCode, @PathVariable String jobId, @RequestBody OprmNichoCnaeV3RecebeRequestRequest request) {
         return service.recebeRequest(cnaeCode, jobId, request);
     }
 
     /** Recebe o response bruto da etapa identificado pelo CNAE e jobId. */
-    @PostMapping("/cnaes/{cnaeCode}/jobs/{jobId}/recebeResponse")
-    public OprmNichoCnaeV3RecebeResponseResponse recebeResponse(@PathVariable String cnaeCode, @PathVariable String jobId, @RequestBody OprmNichoCnaeV3RecebeResponseRequest request) {
+    @PostMapping("/{idExterno}/{jobId}/recebeResponse")
+    public OprmNichoCnaeV3RecebeResponseResponse recebeResponse(@PathVariable("idExterno") String cnaeCode, @PathVariable String jobId, @RequestBody OprmNichoCnaeV3RecebeResponseRequest request) {
         log.info("Recebendo response NichoCNAE v3. etapa={}, cnaeCode={}, jobId={}, payload={}", service.stageCode(), cnaeCode, jobId, request);
         return service.recebeResponse(cnaeCode, jobId, request);
     }
 
     /** Entrega pendências da etapa quality-gate ao executor OPRM. */
-    @GetMapping("/pending")
+    @PostMapping("/pending")
     public List<QualityGatePendingResponse> pending() {
         return service.pending();
     }

--- a/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/routinequeryplanner/controller/BackendRoutineQueryPlannerController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/routinequeryplanner/controller/BackendRoutineQueryPlannerController.java
@@ -11,17 +11,15 @@ import com.marketinghub.oprmcoletormei.nichocnae.v3.shared.OprmNichoCnaeV3Recebe
 import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 /** Controller canônico da etapa routine-query-planner do pipeline NichoCNAE v3. */
 @RestController
-@RequestMapping("/api/internal/oprm/nichocnae/v3/routine-query-planner/stage-executions")
+@RequestMapping("/api/internal/oprmcoletormei/nichocnae/v3/routine-query-planner/stage-executions")
 public class BackendRoutineQueryPlannerController {
     private static final Logger log = LoggerFactory.getLogger(BackendRoutineQueryPlannerController.class);
     private final BackendRoutineQueryPlannerService service;
@@ -32,8 +30,8 @@ public class BackendRoutineQueryPlannerController {
     }
 
     /** Inicia uma execução pendente da etapa a partir do CNAE informado pela tela. */
-    @PostMapping("/start")
-    public RoutineQueryPlannerCreateResponse start(@RequestParam String cnaeCode) {
+    @PostMapping("/{idExterno}/start")
+    public RoutineQueryPlannerCreateResponse start(@PathVariable("idExterno") String cnaeCode) {
         return service.start(cnaeCode);
     }
 
@@ -50,20 +48,20 @@ public class BackendRoutineQueryPlannerController {
     }
 
     /** Recebe o request bruto da etapa identificado pelo CNAE e jobId. */
-    @PostMapping("/cnaes/{cnaeCode}/jobs/{jobId}/recebeRequest")
-    public RoutineQueryPlannerCreateResponse recebeRequest(@PathVariable String cnaeCode, @PathVariable String jobId, @RequestBody OprmNichoCnaeV3RecebeRequestRequest request) {
+    @PostMapping("/{idExterno}/{jobId}/recebeRequest")
+    public RoutineQueryPlannerCreateResponse recebeRequest(@PathVariable("idExterno") String cnaeCode, @PathVariable String jobId, @RequestBody OprmNichoCnaeV3RecebeRequestRequest request) {
         return service.recebeRequest(cnaeCode, jobId, request);
     }
 
     /** Recebe o response bruto da etapa identificado pelo CNAE e jobId. */
-    @PostMapping("/cnaes/{cnaeCode}/jobs/{jobId}/recebeResponse")
-    public OprmNichoCnaeV3RecebeResponseResponse recebeResponse(@PathVariable String cnaeCode, @PathVariable String jobId, @RequestBody OprmNichoCnaeV3RecebeResponseRequest request) {
+    @PostMapping("/{idExterno}/{jobId}/recebeResponse")
+    public OprmNichoCnaeV3RecebeResponseResponse recebeResponse(@PathVariable("idExterno") String cnaeCode, @PathVariable String jobId, @RequestBody OprmNichoCnaeV3RecebeResponseRequest request) {
         log.info("Recebendo response NichoCNAE v3. etapa={}, cnaeCode={}, jobId={}, payload={}", service.stageCode(), cnaeCode, jobId, request);
         return service.recebeResponse(cnaeCode, jobId, request);
     }
 
     /** Entrega pendências da etapa routine-query-planner ao executor OPRM. */
-    @GetMapping("/pending")
+    @PostMapping("/pending")
     public List<RoutineQueryPlannerPendingResponse> pending() {
         return service.pending();
     }

--- a/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/routinesignalextractor/controller/BackendRoutineSignalExtractorController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/routinesignalextractor/controller/BackendRoutineSignalExtractorController.java
@@ -11,17 +11,15 @@ import com.marketinghub.oprmcoletormei.nichocnae.v3.shared.OprmNichoCnaeV3Recebe
 import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 /** Controller canônico da etapa routine-signal-extractor do pipeline NichoCNAE v3. */
 @RestController
-@RequestMapping("/api/internal/oprm/nichocnae/v3/routine-signal-extractor/stage-executions")
+@RequestMapping("/api/internal/oprmcoletormei/nichocnae/v3/routine-signal-extractor/stage-executions")
 public class BackendRoutineSignalExtractorController {
     private static final Logger log = LoggerFactory.getLogger(BackendRoutineSignalExtractorController.class);
     private final BackendRoutineSignalExtractorService service;
@@ -32,8 +30,8 @@ public class BackendRoutineSignalExtractorController {
     }
 
     /** Inicia uma execução pendente da etapa a partir do CNAE informado pela tela. */
-    @PostMapping("/start")
-    public RoutineSignalExtractorCreateResponse start(@RequestParam String cnaeCode) {
+    @PostMapping("/{idExterno}/start")
+    public RoutineSignalExtractorCreateResponse start(@PathVariable("idExterno") String cnaeCode) {
         return service.start(cnaeCode);
     }
 
@@ -50,20 +48,20 @@ public class BackendRoutineSignalExtractorController {
     }
 
     /** Recebe o request bruto da etapa identificado pelo CNAE e jobId. */
-    @PostMapping("/cnaes/{cnaeCode}/jobs/{jobId}/recebeRequest")
-    public RoutineSignalExtractorCreateResponse recebeRequest(@PathVariable String cnaeCode, @PathVariable String jobId, @RequestBody OprmNichoCnaeV3RecebeRequestRequest request) {
+    @PostMapping("/{idExterno}/{jobId}/recebeRequest")
+    public RoutineSignalExtractorCreateResponse recebeRequest(@PathVariable("idExterno") String cnaeCode, @PathVariable String jobId, @RequestBody OprmNichoCnaeV3RecebeRequestRequest request) {
         return service.recebeRequest(cnaeCode, jobId, request);
     }
 
     /** Recebe o response bruto da etapa identificado pelo CNAE e jobId. */
-    @PostMapping("/cnaes/{cnaeCode}/jobs/{jobId}/recebeResponse")
-    public OprmNichoCnaeV3RecebeResponseResponse recebeResponse(@PathVariable String cnaeCode, @PathVariable String jobId, @RequestBody OprmNichoCnaeV3RecebeResponseRequest request) {
+    @PostMapping("/{idExterno}/{jobId}/recebeResponse")
+    public OprmNichoCnaeV3RecebeResponseResponse recebeResponse(@PathVariable("idExterno") String cnaeCode, @PathVariable String jobId, @RequestBody OprmNichoCnaeV3RecebeResponseRequest request) {
         log.info("Recebendo response NichoCNAE v3. etapa={}, cnaeCode={}, jobId={}, payload={}", service.stageCode(), cnaeCode, jobId, request);
         return service.recebeResponse(cnaeCode, jobId, request);
     }
 
     /** Entrega pendências da etapa routine-signal-extractor ao executor OPRM. */
-    @GetMapping("/pending")
+    @PostMapping("/pending")
     public List<RoutineSignalExtractorPendingResponse> pending() {
         return service.pending();
     }

--- a/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/sourcefetcher/controller/BackendSourceFetcherV3Controller.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/sourcefetcher/controller/BackendSourceFetcherV3Controller.java
@@ -11,17 +11,15 @@ import com.marketinghub.oprmcoletormei.nichocnae.v3.shared.OprmNichoCnaeV3Recebe
 import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 /** Controller canônico da etapa source-fetcher do pipeline NichoCNAE v3. */
 @RestController
-@RequestMapping("/api/internal/oprm/nichocnae/v3/source-fetcher/stage-executions")
+@RequestMapping("/api/internal/oprmcoletormei/nichocnae/v3/source-fetcher/stage-executions")
 public class BackendSourceFetcherV3Controller {
     private static final Logger log = LoggerFactory.getLogger(BackendSourceFetcherV3Controller.class);
     private final BackendSourceFetcherV3Service service;
@@ -32,8 +30,8 @@ public class BackendSourceFetcherV3Controller {
     }
 
     /** Inicia uma execução pendente da etapa a partir do CNAE informado pela tela. */
-    @PostMapping("/start")
-    public SourceFetcherCreateResponse start(@RequestParam String cnaeCode) {
+    @PostMapping("/{idExterno}/start")
+    public SourceFetcherCreateResponse start(@PathVariable("idExterno") String cnaeCode) {
         return service.start(cnaeCode);
     }
 
@@ -50,20 +48,20 @@ public class BackendSourceFetcherV3Controller {
     }
 
     /** Recebe o request bruto da etapa identificado pelo CNAE e jobId. */
-    @PostMapping("/cnaes/{cnaeCode}/jobs/{jobId}/recebeRequest")
-    public SourceFetcherCreateResponse recebeRequest(@PathVariable String cnaeCode, @PathVariable String jobId, @RequestBody OprmNichoCnaeV3RecebeRequestRequest request) {
+    @PostMapping("/{idExterno}/{jobId}/recebeRequest")
+    public SourceFetcherCreateResponse recebeRequest(@PathVariable("idExterno") String cnaeCode, @PathVariable String jobId, @RequestBody OprmNichoCnaeV3RecebeRequestRequest request) {
         return service.recebeRequest(cnaeCode, jobId, request);
     }
 
     /** Recebe o response bruto da etapa identificado pelo CNAE e jobId. */
-    @PostMapping("/cnaes/{cnaeCode}/jobs/{jobId}/recebeResponse")
-    public OprmNichoCnaeV3RecebeResponseResponse recebeResponse(@PathVariable String cnaeCode, @PathVariable String jobId, @RequestBody OprmNichoCnaeV3RecebeResponseRequest request) {
+    @PostMapping("/{idExterno}/{jobId}/recebeResponse")
+    public OprmNichoCnaeV3RecebeResponseResponse recebeResponse(@PathVariable("idExterno") String cnaeCode, @PathVariable String jobId, @RequestBody OprmNichoCnaeV3RecebeResponseRequest request) {
         log.info("Recebendo response NichoCNAE v3. etapa={}, cnaeCode={}, jobId={}, payload={}", service.stageCode(), cnaeCode, jobId, request);
         return service.recebeResponse(cnaeCode, jobId, request);
     }
 
     /** Entrega pendências da etapa source-fetcher ao executor OPRM. */
-    @GetMapping("/pending")
+    @PostMapping("/pending")
     public List<SourceFetcherPendingResponse> pending() {
         return service.pending();
     }

--- a/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/sourcesearcher/controller/BackendSourceSearcherV3Controller.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/sourcesearcher/controller/BackendSourceSearcherV3Controller.java
@@ -11,17 +11,15 @@ import com.marketinghub.oprmcoletormei.nichocnae.v3.shared.OprmNichoCnaeV3Recebe
 import java.util.List;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 /** Controller canônico da etapa source-searcher do pipeline NichoCNAE v3. */
 @RestController
-@RequestMapping("/api/internal/oprm/nichocnae/v3/source-searcher/stage-executions")
+@RequestMapping("/api/internal/oprmcoletormei/nichocnae/v3/source-searcher/stage-executions")
 public class BackendSourceSearcherV3Controller {
     private static final Logger log = LoggerFactory.getLogger(BackendSourceSearcherV3Controller.class);
     private final BackendSourceSearcherV3Service service;
@@ -32,8 +30,8 @@ public class BackendSourceSearcherV3Controller {
     }
 
     /** Inicia uma execução pendente da etapa a partir do CNAE informado pela tela. */
-    @PostMapping("/start")
-    public SourceSearcherCreateResponse start(@RequestParam String cnaeCode) {
+    @PostMapping("/{idExterno}/start")
+    public SourceSearcherCreateResponse start(@PathVariable("idExterno") String cnaeCode) {
         return service.start(cnaeCode);
     }
 
@@ -50,20 +48,20 @@ public class BackendSourceSearcherV3Controller {
     }
 
     /** Recebe o request bruto da etapa identificado pelo CNAE e jobId. */
-    @PostMapping("/cnaes/{cnaeCode}/jobs/{jobId}/recebeRequest")
-    public SourceSearcherCreateResponse recebeRequest(@PathVariable String cnaeCode, @PathVariable String jobId, @RequestBody OprmNichoCnaeV3RecebeRequestRequest request) {
+    @PostMapping("/{idExterno}/{jobId}/recebeRequest")
+    public SourceSearcherCreateResponse recebeRequest(@PathVariable("idExterno") String cnaeCode, @PathVariable String jobId, @RequestBody OprmNichoCnaeV3RecebeRequestRequest request) {
         return service.recebeRequest(cnaeCode, jobId, request);
     }
 
     /** Recebe o response bruto da etapa identificado pelo CNAE e jobId. */
-    @PostMapping("/cnaes/{cnaeCode}/jobs/{jobId}/recebeResponse")
-    public OprmNichoCnaeV3RecebeResponseResponse recebeResponse(@PathVariable String cnaeCode, @PathVariable String jobId, @RequestBody OprmNichoCnaeV3RecebeResponseRequest request) {
+    @PostMapping("/{idExterno}/{jobId}/recebeResponse")
+    public OprmNichoCnaeV3RecebeResponseResponse recebeResponse(@PathVariable("idExterno") String cnaeCode, @PathVariable String jobId, @RequestBody OprmNichoCnaeV3RecebeResponseRequest request) {
         log.info("Recebendo response NichoCNAE v3. etapa={}, cnaeCode={}, jobId={}, payload={}", service.stageCode(), cnaeCode, jobId, request);
         return service.recebeResponse(cnaeCode, jobId, request);
     }
 
     /** Entrega pendências da etapa source-searcher ao executor OPRM. */
-    @GetMapping("/pending")
+    @PostMapping("/pending")
     public List<SourceSearcherPendingResponse> pending() {
         return service.pending();
     }

--- a/backend/ads-service/src/test/java/com/marketinghub/architecture/ArquiteturaTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/architecture/ArquiteturaTest.java
@@ -990,7 +990,7 @@ class ArquiteturaTest {
             String stageRoot = OPRM_NICHO_CNAE_V3_PACKAGE + "." + stagePackage;
             String controllerPackage = stageRoot + ".controller";
             String servicePackage = stageRoot + ".service";
-            String expectedEndpoint = "/api/internal/oprm/nichocnae/v3/" + endpointSlug + "/stage-executions";
+            String expectedEndpoint = "/api/internal/oprmcoletormei/nichocnae/v3/" + endpointSlug + "/stage-executions";
             List<JavaClass> controllerPackageClasses = directPackageClasses(importedClasses, controllerPackage);
             List<JavaClass> controllers = controllerPackageClasses.stream()
                     .filter(ArquiteturaTest::isBackendControllerClass)
@@ -1013,9 +1013,9 @@ class ArquiteturaTest {
                     violations.add("[ARQUITETURA] [BACKEND][OPRM][NichoCNAE-v3] classe="
                             + controller.getName() + " deve possuir @RequestMapping(\"" + expectedEndpoint + "\")");
                 }
-                if (!hasPendingGetMapping(controller)) {
+                if (!hasPendingPostMapping(controller)) {
                     violations.add("[ARQUITETURA] [BACKEND][OPRM][NichoCNAE-v3] classe="
-                            + controller.getName() + " deve expor @GetMapping(\"/pending\") como ponto inicial canônico do executor oprm-coletor-mei");
+                            + controller.getName() + " deve expor @PostMapping(\"/pending\") como ponto inicial canônico do executor oprm-coletor-mei");
                 }
             }
             List<JavaClass> servicePackageClasses = directPackageClasses(importedClasses, servicePackage);
@@ -1766,6 +1766,18 @@ class ArquiteturaTest {
         }
         return containsOnlyMapping(requestMapping.value(), expectedMapping)
                 || containsOnlyMapping(requestMapping.path(), expectedMapping);
+    }
+
+    /**
+     * Verifica se o controller expõe método pending com @PostMapping("/pending").
+     */
+    private static boolean hasPendingPostMapping(JavaClass javaClass) {
+        return javaClass.getMethods().stream()
+                .filter(method -> method.getName().equals("pending"))
+                .map(method -> method.reflect().getAnnotation(PostMapping.class))
+                .anyMatch(postMapping -> postMapping != null
+                        && (containsOnlyMapping(postMapping.value(), "/pending")
+                                || containsOnlyMapping(postMapping.path(), "/pending")));
     }
 
     /**

--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -1587,3 +1587,9 @@
 - 2026-06-27 00:00:00 (UTC): removido o contrato oficial obsoleto `oprm-nicho-cnae-pipeline` do registry do backend e substituído pelo contrato único `oprm-nicho-cnae-v3-pipeline`, alinhado aos pacotes reais do executor `oprm-coletor-mei` em `com.marketinghub.pipelines.nichocnae.v3`; changelog incremental desativa o pipeline antigo no banco e cria a definição persistente v3.
 
 - 2026-06-27 00:00:00 (UTC): gerado Swagger específico `docs/swagger/oprmcoletormei-nichocnae-v3-swagger.yaml` para o contrato operacional do executor `oprm-coletor-mei` no pipeline `com.marketinghub.pipelines.nichocnae.v3`, documentando consumo de `pending`, callbacks `complete`/`fail`, health do módulo, etapas registradas e separação de responsabilidade em que o backend mantém a decisão de avanço do pipeline.
+
+## 2026-06-27 — Ajuste de endpoints internos NichoCNAE v3 do OPRM Coletor MEI
+
+- Atualizados os controllers backend de `com.marketinghub.oprmcoletormei.nichocnae.v3` para expor o prefixo canônico `/api/internal/oprmcoletormei/nichocnae/v3/<etapa>/stage-executions`.
+- Padronizados os callbacks operacionais para `/{idExterno}/start`, `/{idExterno}/{jobId}/recebeRequest`, `/{idExterno}/{jobId}/recebeResponse` e `POST /pending`.
+- Sincronizados o Swagger e o cliente do executor `oprm-coletor-mei` para consumir o novo contrato.

--- a/docs/registros/pipeline.md
+++ b/docs/registros/pipeline.md
@@ -67,7 +67,7 @@ Subpacotes principais identificados:
 
 ### Endpoints e leitura administrativa
 
-- O padrão interno por etapa é `/api/internal/oprm/nichocnae/v3/<stageCode>/stage-executions`.
+- O padrão interno por etapa é `/api/internal/oprmcoletormei/nichocnae/v3/<stageCode>/stage-executions`.
 - A leitura administrativa de progresso fica no pacote `com.marketinghub.oprmcoletormei.nichocnae.v3.progress`.
 - O endpoint administrativo de progresso é `/api/oprm/nichocnae/v3/cnaes/{cnaeCode}/progress`.
 - A confirmação de finalização usa `/api/oprm/nichocnae/v3/cnaes/{cnaeCode}/progress/confirm-finalization`.

--- a/docs/swagger/oprm-nichocnae-v3-swagger.yaml
+++ b/docs/swagger/oprm-nichocnae-v3-swagger.yaml
@@ -4,7 +4,7 @@ info:
   version: v3
   description: Endpoints internos por etapa para transformar CNAE em persona operacional, rotina e tarefas diárias.
 paths:
-  /api/internal/oprm/nichocnae/v3/{stage}/stage-executions:
+  /api/internal/oprmcoletormei/nichocnae/v3/{stage}/stage-executions:
     post:
       summary: Cria uma execução pendente de etapa NichoCNAE v3.
       parameters:
@@ -26,7 +26,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/StageExecutionResponse'
-  /api/internal/oprm/nichocnae/v3/{stage}/stage-executions/start:
+  /api/internal/oprmcoletormei/nichocnae/v3/{stage}/stage-executions/{idExterno}/start:
     post:
       summary: Inicia uma execução pendente da etapa NichoCNAE v3 para o CNAE informado com jobId em UUID.
       parameters:
@@ -35,8 +35,8 @@ paths:
           required: true
           schema:
             type: string
-        - name: cnaeCode
-          in: query
+        - name: idExterno
+          in: path
           required: true
           schema:
             type: string
@@ -47,7 +47,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/StageExecutionResponse'
-  /api/internal/oprm/nichocnae/v3/{stage}/stage-executions/cnaes/{cnaeCode}:
+  /api/internal/oprmcoletormei/nichocnae/v3/{stage}/stage-executions/cnaes/{cnaeCode}:
     post:
       summary: Inicia a primeira execução v3 para um CNAE.
       parameters:
@@ -68,7 +68,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/StageExecutionResponse'
-  /api/internal/oprm/nichocnae/v3/{stage}/stage-executions/cnaes/{cnaeCode}/jobs/{jobId}/recebeRequest:
+  /api/internal/oprmcoletormei/nichocnae/v3/{stage}/stage-executions/{idExterno}/{jobId}/recebeRequest:
     post:
       summary: Registra o request bruto enviado ao executor para um objeto CNAE e jobId específicos.
       parameters:
@@ -77,7 +77,7 @@ paths:
           required: true
           schema:
             type: string
-        - name: cnaeCode
+        - name: idExterno
           in: path
           required: true
           schema:
@@ -100,8 +100,40 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/StageExecutionResponse'
-  /api/internal/oprm/nichocnae/v3/{stage}/stage-executions/pending:
-    get:
+  /api/internal/oprmcoletormei/nichocnae/v3/{stage}/stage-executions/{idExterno}/{jobId}/recebeResponse:
+    post:
+      summary: Registra o response bruto recebido pelo executor para um objeto externo e jobId específicos.
+      parameters:
+        - name: stage
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: idExterno
+          in: path
+          required: true
+          schema:
+            type: string
+        - name: jobId
+          in: path
+          required: true
+          schema:
+            type: string
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/RecebeResponseRequest'
+      responses:
+        '200':
+          description: Response auditado com o jobId informado na URL.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/RecebeResponseResponse'
+  /api/internal/oprmcoletormei/nichocnae/v3/{stage}/stage-executions/pending:
+    post:
       summary: Lista pendências da etapa para consumo do executor OPRM com jobId junto do objeto CNAE.
       parameters:
         - name: stage
@@ -118,7 +150,7 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/StagePendingRequest'
-  /api/internal/oprm/nichocnae/v3/{stage}/stage-executions/{stageExecutionId}/complete:
+  /api/internal/oprmcoletormei/nichocnae/v3/{stage}/stage-executions/{stageExecutionId}/complete:
     post:
       summary: Registra conclusão de etapa pelo executor OPRM.
       parameters:
@@ -146,7 +178,7 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/StageExecutionResponse'
-  /api/internal/oprm/nichocnae/v3/{stage}/stage-executions/{stageExecutionId}/fail:
+  /api/internal/oprmcoletormei/nichocnae/v3/{stage}/stage-executions/{stageExecutionId}/fail:
     post:
       summary: Registra falha de etapa pelo executor OPRM.
       parameters:
@@ -178,7 +210,7 @@ paths:
     get:
       summary: Consulta o progresso do job v3 mais recente de um CNAE para a tela administrativa.
       parameters:
-        - name: cnaeCode
+        - name: idExterno
           in: path
           required: true
           schema:
@@ -218,6 +250,27 @@ components:
         prompt:
           type: string
         schema:
+          type: string
+    RecebeResponseRequest:
+      type: object
+      properties:
+        response:
+          type: string
+        status:
+          type: string
+        modelo:
+          type: string
+        erro:
+          type: string
+    RecebeResponseResponse:
+      type: object
+      properties:
+        stageExecutionId:
+          type: integer
+          format: int64
+        status:
+          type: string
+        jobId:
           type: string
     CompletionRequest:
       type: object

--- a/docs/swagger/oprmcoletormei-nichocnae-v3-swagger.yaml
+++ b/docs/swagger/oprmcoletormei-nichocnae-v3-swagger.yaml
@@ -19,8 +19,70 @@ tags:
   - name: Executor health
     description: Endpoint próprio do módulo executor para verificação operacional.
 paths:
-  /api/internal/oprm/nichocnae/v3/{stage}/stage-executions/pending:
-    get:
+  /api/internal/oprmcoletormei/nichocnae/v3/{stage}/stage-executions/{idExterno}/start:
+    post:
+      tags:
+        - Backend queue consumed by oprm-coletor-mei
+      summary: Inicia uma execução pendente da etapa NichoCNAE v3 para o identificador externo informado.
+      operationId: startNichoCnaeV3StageExecutionFromExternalId
+      parameters:
+        - $ref: '#/components/parameters/StagePath'
+        - $ref: '#/components/parameters/IdExternoPath'
+      responses:
+        '200':
+          description: Execução iniciada no backend.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NichoCnaeV3StageExecutionResponse'
+  /api/internal/oprmcoletormei/nichocnae/v3/{stage}/stage-executions/{idExterno}/{jobId}/recebeRequest:
+    post:
+      tags:
+        - Backend queue consumed by oprm-coletor-mei
+      summary: Registra o request bruto enviado para a execução por idExterno e jobId.
+      operationId: recebeRequestNichoCnaeV3StageExecution
+      parameters:
+        - $ref: '#/components/parameters/StagePath'
+        - $ref: '#/components/parameters/IdExternoPath'
+        - $ref: '#/components/parameters/JobIdPath'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NichoCnaeV3RecebeRequestRequest'
+      responses:
+        '200':
+          description: Request auditado no backend.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NichoCnaeV3StageExecutionResponse'
+  /api/internal/oprmcoletormei/nichocnae/v3/{stage}/stage-executions/{idExterno}/{jobId}/recebeResponse:
+    post:
+      tags:
+        - Backend queue consumed by oprm-coletor-mei
+      summary: Registra o response bruto recebido na execução por idExterno e jobId.
+      operationId: recebeResponseNichoCnaeV3StageExecution
+      parameters:
+        - $ref: '#/components/parameters/StagePath'
+        - $ref: '#/components/parameters/IdExternoPath'
+        - $ref: '#/components/parameters/JobIdPath'
+      requestBody:
+        required: true
+        content:
+          application/json:
+            schema:
+              $ref: '#/components/schemas/NichoCnaeV3RecebeResponseRequest'
+      responses:
+        '200':
+          description: Response auditado no backend.
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/NichoCnaeV3RecebeResponseResponse'
+  /api/internal/oprmcoletormei/nichocnae/v3/{stage}/stage-executions/pending:
+    post:
       tags:
         - Backend queue consumed by oprm-coletor-mei
       summary: Lista pendências da etapa NichoCNAE v3 para execução no OPRM Coletor MEI.
@@ -42,7 +104,7 @@ paths:
                   $ref: '#/components/schemas/NichoCnaeV3PendingExecution'
         '500':
           $ref: '#/components/responses/BackendError'
-  /api/internal/oprm/nichocnae/v3/{stage}/stage-executions/{stageExecutionId}/complete:
+  /api/internal/oprmcoletormei/nichocnae/v3/{stage}/stage-executions/{stageExecutionId}/complete:
     post:
       tags:
         - Backend queue consumed by oprm-coletor-mei
@@ -74,7 +136,7 @@ paths:
           $ref: '#/components/responses/NotFound'
         '500':
           $ref: '#/components/responses/BackendError'
-  /api/internal/oprm/nichocnae/v3/{stage}/stage-executions/{stageExecutionId}/fail:
+  /api/internal/oprmcoletormei/nichocnae/v3/{stage}/stage-executions/{stageExecutionId}/fail:
     post:
       tags:
         - Backend queue consumed by oprm-coletor-mei
@@ -137,6 +199,22 @@ components:
         type: integer
         format: int64
         minimum: 1
+    IdExternoPath:
+      name: idExterno
+      in: path
+      required: true
+      description: Identificador externo do objeto processado pela etapa; no NichoCNAE v3 corresponde ao CNAE.
+      schema:
+        type: string
+        example: '9602501'
+    JobIdPath:
+      name: jobId
+      in: path
+      required: true
+      description: Identificador operacional ponta a ponta do job.
+      schema:
+        type: string
+        example: nichocnae-v3-9602501-1782411268024
   responses:
     InvalidRequest:
       description: Requisição inválida para o contrato da etapa.
@@ -202,6 +280,40 @@ components:
           type: integer
           minimum: 1
           example: 3
+    NichoCnaeV3RecebeRequestRequest:
+      type: object
+      properties:
+        request:
+          type: string
+        plataforma:
+          type: string
+        prompt:
+          type: string
+        schema:
+          type: string
+      additionalProperties: false
+    NichoCnaeV3RecebeResponseRequest:
+      type: object
+      properties:
+        response:
+          type: string
+        status:
+          type: string
+        modelo:
+          type: string
+        erro:
+          type: string
+      additionalProperties: false
+    NichoCnaeV3RecebeResponseResponse:
+      type: object
+      properties:
+        stageExecutionId:
+          type: integer
+          format: int64
+        status:
+          type: string
+        jobId:
+          type: string
     NichoCnaeV3CompletionRequest:
       type: object
       required:
@@ -274,7 +386,7 @@ components:
           example: Contrato inválido para a etapa informada.
         path:
           type: string
-          example: /api/internal/oprm/nichocnae/v3/source-fetcher/stage-executions/123/complete
+          example: /api/internal/oprmcoletormei/nichocnae/v3/source-fetcher/stage-executions/123/complete
 x-marketinghub:
   executorModule: oprm-coletor-mei
   executorPackage: com.marketinghub.pipelines.nichocnae.v3

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/pipelines/nichocnae/v3/execution/NichoCnaeV3BackendClient.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/pipelines/nichocnae/v3/execution/NichoCnaeV3BackendClient.java
@@ -30,7 +30,7 @@ public class NichoCnaeV3BackendClient {
 
     /** Lista pendências de uma etapa v3 no endpoint canônico pending. */
     public List<NichoCnaeV3PendingExecution> listPending(NichoCnaeV3StageDefinition stage) {
-        Map<String, Object>[] response = restTemplate.getForObject(backendBaseUrl + stage.backendPath() + "/pending", Map[].class);
+        Map<String, Object>[] response = restTemplate.postForObject(backendBaseUrl + stage.backendPath() + "/pending", null, Map[].class);
         return response == null ? List.of() : Arrays.stream(response).map(this::toPending).toList();
     }
 

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/pipelines/nichocnae/v3/execution/NichoCnaeV3StageDefinitions.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/pipelines/nichocnae/v3/execution/NichoCnaeV3StageDefinitions.java
@@ -41,6 +41,6 @@ public class NichoCnaeV3StageDefinitions {
 
     /** Cria definição com endpoint interno v3 da etapa. */
     private static NichoCnaeV3StageDefinition stage(String stageCode, com.marketinghub.pipelines.nichocnae.v3.core.StageProcessor processor) {
-        return new NichoCnaeV3StageDefinition(stageCode, "/api/internal/oprm/nichocnae/v3/" + stageCode + "/stage-executions", processor);
+        return new NichoCnaeV3StageDefinition(stageCode, "/api/internal/oprmcoletormei/nichocnae/v3/" + stageCode + "/stage-executions", processor);
     }
 }

--- a/oprm-coletor-mei/src/test/java/com/marketinghub/pipelines/nichocnae/v3/execution/NichoCnaeV3StageDefinitionsTest.java
+++ b/oprm-coletor-mei/src/test/java/com/marketinghub/pipelines/nichocnae/v3/execution/NichoCnaeV3StageDefinitionsTest.java
@@ -28,7 +28,7 @@ class NichoCnaeV3StageDefinitionsTest {
         assertEquals(expectedStages().size(), stages.size());
         for (NichoCnaeV3StageDefinition stage : stages) {
             assertEquals(
-                    "/api/internal/oprm/nichocnae/v3/" + stage.stageCode() + "/stage-executions",
+                    "/api/internal/oprmcoletormei/nichocnae/v3/" + stage.stageCode() + "/stage-executions",
                     stage.backendPath());
             assertNotNull(stage.processor());
             assertFalse(stage.stageCode().isBlank());


### PR DESCRIPTION
### Motivation
- Padronizar os endpoints internos do backend para o executor `oprm-coletor-mei` usando o prefixo canônico `/api/internal/oprmcoletormei/nichocnae/v3/<etapa>/stage-executions` e suportar identificador externo e job (`{idExterno}` / `{jobId}`) conforme contrato operacional solicitado.
- Tornar o ponto inicial do executor `pending` um `POST` (não `GET`) para permitir envio de payloads/filtragens e alinhar contrato entre backend e executor.
- Habilitar callbacks operacionais auditáveis para `start`, `recebeRequest` e `recebeResponse` usando `/{idExterno}/start`, `/{idExterno}/{jobId}/recebeRequest` e `/{idExterno}/{jobId}/recebeResponse`.

### Description
- Atualiza todos os controllers de `com.marketinghub.oprmcoletormei.nichocnae.v3.*.controller` para usar o mapeamento `@RequestMapping("/api/internal/oprmcoletormei/nichocnae/v3/<etapa>/stage-executions")`, alterar `start` para `@PostMapping("/{idExterno}/start")`, `recebeRequest`/`recebeResponse` para `@PostMapping("/{idExterno}/{jobId}/...")` e `pending` para `@PostMapping("/pending")`.
- Sincroniza o cliente do executor em `oprm-coletor-mei` para consumir `POST /pending` e altera a definição de backendPath para `"/api/internal/oprmcoletormei/nichocnae/v3/"` em `NichoCnaeV3StageDefinitions` e o uso em `NichoCnaeV3BackendClient` (troca de `getForObject(.../pending)` para `postForObject(.../pending, null, ...)`).
- Atualiza a documentação OpenAPI/Swagger em `docs/swagger/oprmcoletormei-nichocnae-v3-swagger.yaml` e `docs/swagger/oprm-nichocnae-v3-swagger.yaml` com os novos endpoints e adiciona esquemas de `recebeResponse`/params `idExterno` e `jobId`.
- Adapta o teste de arquitetura `ArquiteturaTest` para validar o novo prefixo e exigir `@PostMapping("/pending")` como ponto inicial canônico das etapas v3; registra a alteração em `docs/registros/oprm1.md` e `docs/registros/pipeline.md`.

### Testing
- Rodei `../mvnw -Dtest=com.marketinghub.architecture.ArquiteturaTest test` para o módulo `backend/ads-service` e a suite `ArquiteturaTest` executou `84` testes com `Failures: 0` (BUILD SUCCESS).
- Rodei `mvn -Dtest=com.marketinghub.pipelines.nichocnae.v3.execution.NichoCnaeV3StageDefinitionsTest test` no módulo `oprm-coletor-mei` e a suite executou `2` testes com `Failures: 0` (BUILD SUCCESS).
- Os testes de integração/compilação dos módulos afetados foram executados localmente via Maven e concluíram com sucesso; os arquivos Swagger foram ajustados em sincronização com os controllers e o cliente do executor.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3fb7bda8b0832181fe7b0d3b53f427)