### PR TITLE
Ajusta endpoints internos do aiworker.geracaoanuncios.v1 para usar `idExterno` no path

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/pipelines/aiworker/geracaoanuncios/v1/imagem/controller/GeraAnuncioImagemController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/pipelines/aiworker/geracaoanuncios/v1/imagem/controller/GeraAnuncioImagemController.java
@@ -16,7 +16,6 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 /** Responsabilidade: disponibilizar a borda HTTP canônica da etapa Imagem do pipeline GeraAnuncio v2. */
@@ -31,10 +30,10 @@ public class GeraAnuncioImagemController {
         this.service = service;
     }
 
-    /** Inicia uma execução da etapa Imagem para o código/chave do experimento informado. */
-    @PostMapping("/start")
-    public GeraAnuncioImagemExecutionSummaryResponse startPorChave(@RequestParam("experimentKey") String experimentKey) {
-        return service.start(experimentKey);
+    /** Inicia uma execução da etapa Imagem para o identificador externo informado no caminho. */
+    @PostMapping("/{idExterno}/start")
+    public GeraAnuncioImagemExecutionSummaryResponse startPorIdExterno(@PathVariable String idExterno) {
+        return service.start(idExterno);
     }
 
     /** Inicia uma execução da etapa Imagem para o experimento informado. */
@@ -56,23 +55,23 @@ public class GeraAnuncioImagemController {
     }
 
     /** Recebe o request operacional gerado pelo AI Worker para a etapa usando o jobId da execução. */
-    @PostMapping("/{experimentKey}/jobs/{jobId}/recebeRequest")
+    @PostMapping("/{idExterno}/{jobId}/recebeRequest")
     public ResponseEntity<Void> recebeRequest(
-            @PathVariable String experimentKey, @PathVariable String jobId, @RequestBody GeraAnuncioImagemRecebeRequestRequest request) {
-        service.recebeRequest(experimentKey, jobId, request);
+            @PathVariable String idExterno, @PathVariable String jobId, @RequestBody GeraAnuncioImagemRecebeRequestRequest request) {
+        service.recebeRequest(idExterno, jobId, request);
         return ResponseEntity.accepted().build();
     }
 
     /** Recebe o callback final do AI Worker com a resposta da etapa e retorna a próxima etapa, quando existir. */
-    @PostMapping("/{experimentKey}/jobs/{jobId}/recebeResponse")
+    @PostMapping("/{idExterno}/{jobId}/recebeResponse")
     public ResponseEntity<String> recebeResponse(
-            @PathVariable String experimentKey, @PathVariable String jobId, @RequestBody GeraAnuncioImagemRespostaRequest request) {
+            @PathVariable String idExterno, @PathVariable String jobId, @RequestBody GeraAnuncioImagemRespostaRequest request) {
         log.info(
-                "Recebendo response do pipeline geracaoanuncios; etapa=imagem; experimentKey={}; jobId={}; payload={}",
-                experimentKey,
+                "Recebendo response do pipeline geracaoanuncios; etapa=imagem; idExterno={}; jobId={}; payload={}",
+                idExterno,
                 jobId,
                 request);
-        String nextStageCode = service.recebeResponse(experimentKey, jobId, request);
+        String nextStageCode = service.recebeResponse(idExterno, jobId, request);
         return ResponseEntity.accepted().body(nextStageCode);
     }
 

--- a/backend/ads-service/src/main/java/com/marketinghub/pipelines/aiworker/geracaoanuncios/v1/texto/controller/GeraAnuncioTextoController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/pipelines/aiworker/geracaoanuncios/v1/texto/controller/GeraAnuncioTextoController.java
@@ -16,7 +16,6 @@ import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 /** Responsabilidade: disponibilizar a borda HTTP canônica da etapa Texto do pipeline GeraAnuncio v2. */
@@ -31,10 +30,10 @@ public class GeraAnuncioTextoController {
         this.service = service;
     }
 
-    /** Inicia uma execução da etapa Texto para o código/chave do experimento informado. */
-    @PostMapping("/start")
-    public GeraAnuncioTextoExecutionSummaryResponse startPorChave(@RequestParam("experimentKey") String experimentKey) {
-        return service.start(experimentKey);
+    /** Inicia uma execução da etapa Texto para o identificador externo informado no caminho. */
+    @PostMapping("/{idExterno}/start")
+    public GeraAnuncioTextoExecutionSummaryResponse startPorIdExterno(@PathVariable String idExterno) {
+        return service.start(idExterno);
     }
 
     /** Inicia uma execução da etapa Texto para o experimento informado. */
@@ -56,23 +55,23 @@ public class GeraAnuncioTextoController {
     }
 
     /** Recebe o request operacional gerado pelo AI Worker para a etapa usando o jobId da execução. */
-    @PostMapping("/{experimentKey}/jobs/{jobId}/recebeRequest")
+    @PostMapping("/{idExterno}/{jobId}/recebeRequest")
     public ResponseEntity<Void> recebeRequest(
-            @PathVariable String experimentKey, @PathVariable String jobId, @RequestBody GeraAnuncioTextoRecebeRequestRequest request) {
-        service.recebeRequest(experimentKey, jobId, request);
+            @PathVariable String idExterno, @PathVariable String jobId, @RequestBody GeraAnuncioTextoRecebeRequestRequest request) {
+        service.recebeRequest(idExterno, jobId, request);
         return ResponseEntity.accepted().build();
     }
 
     /** Recebe o callback final do AI Worker com a resposta da etapa e retorna a próxima etapa, quando existir. */
-    @PostMapping("/{experimentKey}/jobs/{jobId}/recebeResponse")
+    @PostMapping("/{idExterno}/{jobId}/recebeResponse")
     public ResponseEntity<String> recebeResponse(
-            @PathVariable String experimentKey, @PathVariable String jobId, @RequestBody GeraAnuncioTextoRespostaRequest request) {
+            @PathVariable String idExterno, @PathVariable String jobId, @RequestBody GeraAnuncioTextoRespostaRequest request) {
         log.info(
-                "Recebendo response do pipeline geracaoanuncios; etapa=texto; experimentKey={}; jobId={}; payload={}",
-                experimentKey,
+                "Recebendo response do pipeline geracaoanuncios; etapa=texto; idExterno={}; jobId={}; payload={}",
+                idExterno,
                 jobId,
                 request);
-        String nextStageCode = service.recebeResponse(experimentKey, jobId, request);
+        String nextStageCode = service.recebeResponse(idExterno, jobId, request);
         return ResponseEntity.accepted().body(nextStageCode);
     }
 

--- a/docs/swagger/aiworker-geracaoanuncios-v1-swagger.yaml
+++ b/docs/swagger/aiworker-geracaoanuncios-v1-swagger.yaml
@@ -16,13 +16,13 @@ tags:
   - name: Imagem
     description: Etapa de geração de imagens dos anúncios.
 paths:
-  /api/internal/aiworker/geracaoanuncios/v1/texto/stage-executions/start:
+  /api/internal/aiworker/geracaoanuncios/v1/texto/stage-executions/{idExterno}/start:
     post:
       tags: [Texto]
-      operationId: startAiWorkerGeracaoAnunciosV1TextoByExperimentKey
-      summary: Inicia a etapa Texto pela chave do experimento
+      operationId: startAiWorkerGeracaoAnunciosV1TextoByIdExterno
+      summary: Inicia a etapa Texto pelo identificador externo
       parameters:
-        - $ref: '#/components/parameters/ExperimentKeyQuery'
+        - $ref: '#/components/parameters/IdExternoPath'
       responses:
         '200':
           description: Execução da etapa Texto registrada.
@@ -75,13 +75,13 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/PendingStageExecution'
-  /api/internal/aiworker/geracaoanuncios/v1/texto/stage-executions/{experimentKey}/jobs/{jobId}/recebeRequest:
+  /api/internal/aiworker/geracaoanuncios/v1/texto/stage-executions/{idExterno}/{jobId}/recebeRequest:
     post:
       tags: [Texto]
       operationId: receiveAiWorkerGeracaoAnunciosV1TextoRequestByJob
       summary: Registra o request operacional da etapa Texto
       parameters:
-        - $ref: '#/components/parameters/ExperimentKeyPath'
+        - $ref: '#/components/parameters/IdExternoPath'
         - $ref: '#/components/parameters/JobIdPath'
       requestBody:
         required: true
@@ -92,14 +92,14 @@ paths:
       responses:
         '202':
           description: Request aceito para auditoria.
-  /api/internal/aiworker/geracaoanuncios/v1/texto/stage-executions/{experimentKey}/jobs/{jobId}/recebeResponse:
+  /api/internal/aiworker/geracaoanuncios/v1/texto/stage-executions/{idExterno}/{jobId}/recebeResponse:
     post:
       tags: [Texto]
       operationId: receiveAiWorkerGeracaoAnunciosV1TextoResponseByJob
       summary: Registra o callback final da etapa Texto
       description: Retorna o código da próxima etapa quando houver avanço funcional.
       parameters:
-        - $ref: '#/components/parameters/ExperimentKeyPath'
+        - $ref: '#/components/parameters/IdExternoPath'
         - $ref: '#/components/parameters/JobIdPath'
       requestBody:
         required: true
@@ -162,13 +162,13 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/StageExecutionDetail'
-  /api/internal/aiworker/geracaoanuncios/v1/imagem/stage-executions/start:
+  /api/internal/aiworker/geracaoanuncios/v1/imagem/stage-executions/{idExterno}/start:
     post:
       tags: [Imagem]
-      operationId: startAiWorkerGeracaoAnunciosV1ImagemByExperimentKey
-      summary: Inicia a etapa Imagem pela chave do experimento
+      operationId: startAiWorkerGeracaoAnunciosV1ImagemByIdExterno
+      summary: Inicia a etapa Imagem pelo identificador externo
       parameters:
-        - $ref: '#/components/parameters/ExperimentKeyQuery'
+        - $ref: '#/components/parameters/IdExternoPath'
       responses:
         '200':
           description: Execução da etapa Imagem registrada.
@@ -221,13 +221,13 @@ paths:
                 type: array
                 items:
                   $ref: '#/components/schemas/PendingStageExecution'
-  /api/internal/aiworker/geracaoanuncios/v1/imagem/stage-executions/{experimentKey}/jobs/{jobId}/recebeRequest:
+  /api/internal/aiworker/geracaoanuncios/v1/imagem/stage-executions/{idExterno}/{jobId}/recebeRequest:
     post:
       tags: [Imagem]
       operationId: receiveAiWorkerGeracaoAnunciosV1ImagemRequestByJob
       summary: Registra o request operacional da etapa Imagem
       parameters:
-        - $ref: '#/components/parameters/ExperimentKeyPath'
+        - $ref: '#/components/parameters/IdExternoPath'
         - $ref: '#/components/parameters/JobIdPath'
       requestBody:
         required: true
@@ -238,13 +238,13 @@ paths:
       responses:
         '202':
           description: Request aceito para auditoria.
-  /api/internal/aiworker/geracaoanuncios/v1/imagem/stage-executions/{experimentKey}/jobs/{jobId}/recebeResponse:
+  /api/internal/aiworker/geracaoanuncios/v1/imagem/stage-executions/{idExterno}/{jobId}/recebeResponse:
     post:
       tags: [Imagem]
       operationId: receiveAiWorkerGeracaoAnunciosV1ImagemResponseByJob
       summary: Registra o callback final da etapa Imagem
       parameters:
-        - $ref: '#/components/parameters/ExperimentKeyPath'
+        - $ref: '#/components/parameters/IdExternoPath'
         - $ref: '#/components/parameters/JobIdPath'
       requestBody:
         required: true
@@ -308,20 +308,13 @@ paths:
                 $ref: '#/components/schemas/StageExecutionDetail'
 components:
   parameters:
-    ExperimentKeyQuery:
-      name: experimentKey
-      in: query
-      required: true
-      schema:
-        type: string
-      description: Chave operacional do experimento; atualmente aceita o id numérico em formato textual.
-    ExperimentKeyPath:
-      name: experimentKey
+    IdExternoPath:
+      name: idExterno
       in: path
       required: true
       schema:
         type: string
-      description: Chave operacional do experimento vinculada ao job.
+      description: Identificador externo da execução.
     ExperimentIdPath:
       name: experimentId
       in: path
@@ -361,7 +354,7 @@ components:
           example: 123
         jobId:
           type: string
-          example: exp:123|pipeline:geracaoanuncios|v:1|stage:texto
+          example: geracaoanuncios-v1-texto-exp-123
         status:
           type: string
           example: PENDING

--- a/docs/swagger/geraanuncio-v2-swagger.yaml
+++ b/docs/swagger/geraanuncio-v2-swagger.yaml
@@ -4,13 +4,13 @@ info:
   version: v2
   description: Contratos internos do pipeline GeraAnuncio v2 para geração separada de texto e imagem de anúncios pelo AI Worker.
 paths:
-  /api/internal/aiworker/geracaoanuncios/v1/texto/stage-executions/start:
+  /api/internal/aiworker/geracaoanuncios/v1/texto/stage-executions/{idExterno}/start:
     post:
       summary: Inicia execução da etapa Texto pela chave do experimento
       description: Endpoint usado pela tela administrativa para iniciar a etapa de texto do GeraAnuncio v2 usando o código/chave operacional do experimento.
       parameters:
-        - name: experimentKey
-          in: query
+        - name: idExterno
+          in: path
           required: true
           schema:
             type: string
@@ -39,12 +39,12 @@ paths:
       responses:
         '200':
           description: Execuções pendentes retornadas com contexto e artefatos anteriores.
-  /api/internal/aiworker/geracaoanuncios/v1/texto/stage-executions/{experimentKey}/jobs/{jobId}/recebeRequest:
+  /api/internal/aiworker/geracaoanuncios/v1/texto/stage-executions/{idExterno}/{jobId}/recebeRequest:
     post:
       summary: Registra request operacional da etapa Texto
       description: Recebe o request gerado pelo AI Worker vinculado ao id do objeto e ao jobId UUID criado no start.
       parameters:
-        - name: experimentKey
+        - name: idExterno
           in: path
           required: true
           schema:
@@ -58,12 +58,12 @@ paths:
       responses:
         '202':
           description: Request aceito para auditoria.
-  /api/internal/aiworker/geracaoanuncios/v1/texto/stage-executions/{experimentKey}/jobs/{jobId}/recebeResponse:
+  /api/internal/aiworker/geracaoanuncios/v1/texto/stage-executions/{idExterno}/{jobId}/recebeResponse:
     post:
       summary: Registra response final da etapa Texto
       description: Recebe o callback final do AI Worker, atualiza status/data do experimento e grava auditoria em pipeline_geracaoanuncios. Retorna o código da próxima etapa quando a etapa termina sem erro.
       parameters:
-        - name: experimentKey
+        - name: idExterno
           in: path
           required: true
           schema:
@@ -101,13 +101,13 @@ paths:
       responses:
         '202':
           description: Resposta aceita para auditoria e relatório.
-  /api/internal/aiworker/geracaoanuncios/v1/imagem/stage-executions/start:
+  /api/internal/aiworker/geracaoanuncios/v1/imagem/stage-executions/{idExterno}/start:
     post:
       summary: Inicia execução da etapa Imagem pela chave do experimento
       description: Endpoint usado pela tela administrativa para iniciar a etapa de imagem do GeraAnuncio v2 usando o código/chave operacional do experimento.
       parameters:
-        - name: experimentKey
-          in: query
+        - name: idExterno
+          in: path
           required: true
           schema:
             type: string
@@ -136,12 +136,12 @@ paths:
       responses:
         '200':
           description: Execuções pendentes retornadas com contexto e artefatos anteriores.
-  /api/internal/aiworker/geracaoanuncios/v1/imagem/stage-executions/{experimentKey}/jobs/{jobId}/recebeRequest:
+  /api/internal/aiworker/geracaoanuncios/v1/imagem/stage-executions/{idExterno}/{jobId}/recebeRequest:
     post:
       summary: Registra request operacional da etapa Imagem
       description: Recebe o request gerado pelo AI Worker vinculado ao id do objeto e ao jobId UUID criado no start.
       parameters:
-        - name: experimentKey
+        - name: idExterno
           in: path
           required: true
           schema:
@@ -155,12 +155,12 @@ paths:
       responses:
         '202':
           description: Request aceito para auditoria.
-  /api/internal/aiworker/geracaoanuncios/v1/imagem/stage-executions/{experimentKey}/jobs/{jobId}/recebeResponse:
+  /api/internal/aiworker/geracaoanuncios/v1/imagem/stage-executions/{idExterno}/{jobId}/recebeResponse:
     post:
       summary: Registra response final da etapa Imagem
       description: Recebe o callback final do AI Worker, atualiza status/data do experimento e grava auditoria em pipeline_geracaoanuncios. Retorna nulo/corpo vazio quando a etapa final termina sem erro.
       parameters:
-        - name: experimentKey
+        - name: idExterno
           in: path
           required: true
           schema:


### PR DESCRIPTION
### Motivation
- Alinhar os endpoints da API do pipeline `aiworker.geracaoanuncios.v1` ao contrato canônico de consumo pelo executor, usando `idExterno` no caminho e simplificando o formato de callbacks, para tornar o consumo pelo AI Worker mais direto e auditável. 

### Description
- Atualiza os controllers das etapas Texto e Imagem para trocar o `POST /.../start` com query por `POST /.../{idExterno}/start` e para expor callbacks em `POST /.../{idExterno}/{jobId}/recebeRequest` e `POST /.../{idExterno}/{jobId}/recebeResponse`, bem como ajustar logs e chamadas ao service para usar `idExterno` (arquivos modificados: `GeraAnuncioTextoController.java`, `GeraAnuncioImagemController.java`).
- Remove import de `RequestParam` onde não é mais usado e preserva endpoints auxiliares já existentes (`/experiments/{experimentId}/start`, `/pending`, `/.../{stageExecutionId}/prompt`, `/.../{stageExecutionId}/response`, `/.../{stageExecutionId}`).
- Atualiza a documentação OpenAPI/Swagger para refletir os novos paths e parâmetros em `docs/swagger/aiworker-geracaoanuncios-v1-swagger.yaml` e `docs/swagger/geraanuncio-v2-swagger.yaml`, adicionando o componente `IdExternoPath` e ajustando exemplos de `jobId`.

### Testing
- Executei `cd backend/ads-service && mvn -DskipTests compile`, que concluiu com sucesso. 
- Executei `cd backend/ads-service && mvn -Dtest=ArquiteturaTest test`, que passou com sucesso (ArquiteturaTest OK). 
- Rodei o conjunto de testes `cd backend/ads-service && mvn test -DskipITs`, que apresentou falha em `FacebookInstantFormControllerTest.setup` por violação de integridade referencial (FK) em fixtures de teste não relacionadas às alterações de endpoint; a falha é externa às mudanças de rota e documentação.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3fb7e5bc6c8321a6275cb4bc01dc83)