### PR TITLE
Fix GeraAnuncio start route from creatives tab

### DIFF
--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -5458,3 +5458,10 @@
 - Prevenção de recorrência: adicionado teste de frontend validando que o clique no botão envia a chave do experimento para o endpoint de início da etapa Texto.
 
 - 2026-06-27: identificado erro 500 no start de `/api/internal/aiworker/geracaoanuncios/v1/texto/stage-executions/start` causado por persistência JPA em coluna MySQL reservada `schema`; a correção final renomeou o mapeamento para a coluna canônica `schema_json` e adicionou migração para ambientes que já tinham a coluna antiga em `PipelineGeracaoAnuncios` e `PipelineNichoCnae`.
+
+## 2026-06-27 — Chamada Swagger correta para iniciar GeraAnuncio v2
+
+- Problema: a aba Criativos ainda exibia erro ao clicar em “Gerar anúncios do pipeline”.
+- Causa-raiz confirmada no Swagger publicado: a tela chamava `/api/internal/aiworker/geracaoanuncios/v1/texto/stage-executions/start` com `experimentKey` por query, mas o contrato exposto pelo backend aceita o início por caminho em `/{idExterno}/start` ou `/experiments/{experimentId}/start`.
+- Correção aplicada: o frontend passou a chamar `/api/internal/aiworker/geracaoanuncios/v1/texto/stage-executions/{experimentId}/start`, tratando o `idExterno` como o id do experimento.
+- Prevenção de recorrência: o teste da aba Criativos foi atualizado para validar exatamente a rota Swagger usada no clique do botão.

--- a/frontend/src/api/experiment/useRequestPipelineCreatives.ts
+++ b/frontend/src/api/experiment/useRequestPipelineCreatives.ts
@@ -1,24 +1,24 @@
 import { useMutation, useQueryClient } from "@tanstack/react-query";
 import axios from "axios";
 
-export function useRequestPipelineCreatives(experimentKey?: string) {
+export function useRequestPipelineCreatives(experimentId?: string) {
   const queryClient = useQueryClient();
 
   return useMutation({
     mutationFn: async () => {
-      if (!experimentKey) throw new Error("Experimento não informado");
+      if (!experimentId) throw new Error("Experimento não informado");
       const { data } = await axios.post(
-        "/api/internal/aiworker/geracaoanuncios/v1/texto/stage-executions/start",
-        null,
-        { params: { experimentKey } },
+        `/api/internal/aiworker/geracaoanuncios/v1/texto/stage-executions/${encodeURIComponent(
+          experimentId,
+        )}/start`,
       );
       return data;
     },
     onSuccess: () => {
       queryClient.invalidateQueries({
-        queryKey: ["experiment", experimentKey],
+        queryKey: ["experiment", experimentId],
       });
-      queryClient.invalidateQueries({ queryKey: ["creatives", experimentKey] });
+      queryClient.invalidateQueries({ queryKey: ["creatives", experimentId] });
     },
   });
 }

--- a/frontend/src/pages/experiment/CriativosTab.test.tsx
+++ b/frontend/src/pages/experiment/CriativosTab.test.tsx
@@ -266,7 +266,7 @@ describe("CriativosTab", () => {
     ).toBeInTheDocument();
   });
 
-  it("starts GeraAnuncio v2 from the first stage using experiment key", async () => {
+  it("starts GeraAnuncio v2 from the first stage using the experiment id as external id", async () => {
     (axios.get as any).mockImplementation((url: string) => {
       if (url.endsWith("/experiments/1/creatives")) {
         return Promise.resolve({ data: [] });
@@ -310,9 +310,7 @@ describe("CriativosTab", () => {
 
     await waitFor(() => {
       expect(axios.post).toHaveBeenCalledWith(
-        "/api/internal/aiworker/geracaoanuncios/v1/texto/stage-executions/start",
-        null,
-        { params: { experimentKey: "1" } },
+        "/api/internal/aiworker/geracaoanuncios/v1/texto/stage-executions/1/start",
       );
     });
   });


### PR DESCRIPTION
### Motivation
- The Creatives tab called the wrong start endpoint (`/.../stage-executions/start?experimentKey=...`) which did not match the published Swagger contract and caused the pipeline request to fail. 
- The `idExterno` path parameter in the Swagger is the experiment id in this context, so the frontend must pass the experiment id in the path when starting the pipeline.

### Description
- Updated `useRequestPipelineCreatives` to accept `experimentId` and call the Swagger route `/api/internal/aiworker/geracaoanuncios/v1/texto/stage-executions/{experimentId}/start` instead of the previous query-based endpoint. 
- Adjusted cache invalidation keys to use `experimentId` in `useRequestPipelineCreatives`. 
- Updated the Creatives tab unit test `CriativosTab.test.tsx` to assert the new path and renamed the test to reflect using the experiment id as external id. 
- Added an entry to `docs/registros/experimentos.md` documenting the investigation, root cause and prevention note.

### Testing
- Ran the frontend unit test file with `vitest` (`npm test -- CriativosTab.test.tsx --run`) and all tests passed (1 file, 9 tests passed). 
- Executed TypeScript checks with `tsc --noEmit` (`npm run typecheck`) and it succeeded with no errors. 
- Verified the backend Swagger contains the expected start paths by fetching `/v3/api-docs/marketing-hub-backend` and confirming the presence of `/api/internal/aiworker/geracaoanuncios/v1/texto/stage-executions/{idExterno}/start` and related routes.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3fbfac36bc832196b03869c825ca92)