### PR TITLE
Corrige chamada de início do dossiê MOIS

### DIFF
--- a/frontend/src/api/mois/useMoisSalesLibrary.ts
+++ b/frontend/src/api/mois/useMoisSalesLibrary.ts
@@ -430,9 +430,7 @@ export function useStartMoisDossierPipeline(workspaceId: string) {
   return useMutation({
     mutationFn: async (pageId: number) => {
       await axios.post(
-        "/api/internal/mois/dossie/v1/intake/stage-executions/start",
-        undefined,
-        { params: { productKey: String(pageId) } },
+        `/api/internal/moissaleslibraryworker/dossieproduto/v1/intake/stage-executions/${pageId}/start`,
       );
     },
     onSuccess: (_, pageId) => {


### PR DESCRIPTION
### Motivation
- Alinhar a chamada do frontend com o contrato Swagger do pipeline de dossiê MOIS v1 para que a ação de iniciar o dossiê use o `idExterno` (id da página) como path parameter conforme o endpoint documentado.

### Description
- Atualiza `frontend/src/api/mois/useMoisSalesLibrary.ts` para usar `/api/internal/moissaleslibraryworker/dossieproduto/v1/intake/stage-executions/{idExterno}/start` e enviar `pageId` como `idExterno` no path em vez de enviar `productKey` como query param.

### Testing
- Executado `npm --prefix frontend ci` and it succeeded, then `npm --prefix frontend run typecheck` which passed after dependencies were installed, and `npx --prefix frontend prettier --write frontend/src/api/mois/useMoisSalesLibrary.ts` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3fc0318d348321a984191338a22dcd)