### PR TITLE
Corrige endpoint de início do NichoCNAE v3

### DIFF
--- a/frontend/src/api/oprm/useStartOprmNichoCnaeV3Job.ts
+++ b/frontend/src/api/oprm/useStartOprmNichoCnaeV3Job.ts
@@ -14,7 +14,7 @@ async function startOprmNichoCnaeV3Job(
 ): Promise<OprmNichoCnaeV3JobStartResult> {
   const response = await fetch(
     buildApiUrl(
-      `/api/internal/oprm/nichocnae/v3/cnae-intake/stage-executions/start?cnaeCode=${encodeURIComponent(cnaeCode)}`,
+      `/api/internal/oprmcoletormei/nichocnae/v3/cnae-intake/stage-executions/${encodeURIComponent(cnaeCode)}/start`,
     ),
     { method: "POST" },
   );


### PR DESCRIPTION
### Motivation
- A chamada da tela para iniciar o pipeline NichoCNAE v3 estava usando o endpoint errado (query `cnaeCode` e base `oprm`), causando `404` porque o backend expõe o contrato canônico com `idExterno` no path e base `oprmcoletormei`.

### Description
- Altera a chamada no frontend em `frontend/src/api/oprm/useStartOprmNichoCnaeV3Job.ts` para usar o endpoint canônico `/api/internal/oprmcoletormei/nichocnae/v3/cnae-intake/stage-executions/{idExterno}/start` (CNAE enviado como path parameter em vez de query string).

### Testing
- `curl -X POST http://191.252.181.168/api/internal/oprm/nichocnae/v3/cnae-intake/stage-executions/start?cnaeCode=4781400` retornou `404` (chamada antiga inválida). 
- `curl -X POST http://191.252.181.168/api/internal/oprmcoletormei/nichocnae/v3/cnae-intake/stage-executions/4781400/start` retornou `200` (contrato correto).
- `npm test -- --run OprmNavigation.test.tsx` passou (`9 tests` OK).
- `npm run typecheck` ( `tsc --noEmit` ) executou sem erros.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3fc06a250083219980eb2f76684b16)