### PR TITLE
Atualiza avanço do pipeline GeraAnuncio v1 na tabela de experimento

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/pipelines/aiworker/geracaoanuncios/v1/imagem/service/GeraAnuncioImagemService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/pipelines/aiworker/geracaoanuncios/v1/imagem/service/GeraAnuncioImagemService.java
@@ -41,7 +41,6 @@ public class GeraAnuncioImagemService {
     private static final String STATUS_WAITING = "AGUARDANDO_RETORNO_MODULO";
     private static final String STATUS_AGUARDANDO_MODULO = "AGUARDANDO_MODULO";
     private static final String PIPELINE_VERSION = "v1";
-    private static final String STATUS_COMPLETED = "CONCLUIDO";
     private static final String STATUS_FAILED = "FALHA";
     private final ExperimentService experimentService;
     private final OprmNicheCandidateRepository cnaeRepository;
@@ -153,7 +152,12 @@ public class GeraAnuncioImagemService {
         MoisSalesPage salesPage = salesPageRepository
                 .findById(resolveExperimentId(experimentKey))
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Sales page not found"));
-        salesPage.setStatusPipelineGeracaoAnuncios(StringUtils.hasText(descricaoErro) ? STATUS_FAILED : STATUS_COMPLETED);
+        if (StringUtils.hasText(descricaoErro)) {
+            salesPage.setStatusPipelineGeracaoAnuncios(STATUS_FAILED);
+        } else {
+            salesPage.setStatusPipelineGeracaoAnuncios(STATUS_STARTED);
+            salesPage.setEtapaPipelineGeracaoAnuncios(NEXT_STAGE);
+        }
         salesPage.setDataPipelineGeracaoAnuncios(now);
         salesPageRepository.save(salesPage);
 

--- a/backend/ads-service/src/main/java/com/marketinghub/pipelines/aiworker/geracaoanuncios/v1/texto/service/GeraAnuncioTextoService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/pipelines/aiworker/geracaoanuncios/v1/texto/service/GeraAnuncioTextoService.java
@@ -41,7 +41,6 @@ public class GeraAnuncioTextoService {
     private static final String STATUS_WAITING = "AGUARDANDO_RETORNO_MODULO";
     private static final String STATUS_AGUARDANDO_MODULO = "AGUARDANDO_MODULO";
     private static final String PIPELINE_VERSION = "v1";
-    private static final String STATUS_COMPLETED = "CONCLUIDO";
     private static final String STATUS_FAILED = "FALHA";
     private final ExperimentService experimentService;
     private final OprmNicheCandidateRepository cnaeRepository;
@@ -153,7 +152,12 @@ public class GeraAnuncioTextoService {
         MoisSalesPage salesPage = salesPageRepository
                 .findById(resolveExperimentId(experimentKey))
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "Sales page not found"));
-        salesPage.setStatusPipelineGeracaoAnuncios(StringUtils.hasText(descricaoErro) ? STATUS_FAILED : STATUS_COMPLETED);
+        if (StringUtils.hasText(descricaoErro)) {
+            salesPage.setStatusPipelineGeracaoAnuncios(STATUS_FAILED);
+        } else {
+            salesPage.setStatusPipelineGeracaoAnuncios(STATUS_STARTED);
+            salesPage.setEtapaPipelineGeracaoAnuncios(NEXT_STAGE);
+        }
         salesPage.setDataPipelineGeracaoAnuncios(now);
         salesPageRepository.save(salesPage);
 

--- a/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/mois/bibliotecapaginavenda/worker/v1/entity/MoisSalesPage.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/repository/jpa/mois/bibliotecapaginavenda/worker/v1/entity/MoisSalesPage.java
@@ -34,4 +34,7 @@ public class MoisSalesPage {
 
     @Column(name = "data_pipeline_geracaoanuncios")
     private Instant dataPipelineGeracaoAnuncios;
+
+    @Column(name = "etapa_pipeline_geracaoanuncios", length = 80)
+    private String etapaPipelineGeracaoAnuncios;
 }

--- a/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-27-mois-sales-page-geracaoanuncios-etapa.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/changesets/2026-06-27-mois-sales-page-geracaoanuncios-etapa.yaml
@@ -1,0 +1,32 @@
+databaseChangeLog:
+  - changeSet:
+      id: 2026-06-27-mois-sales-page-geracaoanuncios-etapa-01
+      author: codex
+      preConditions:
+        - onFail: MARK_RAN
+        - onError: HALT
+        - dbms:
+            type: mysql
+        - tableExists:
+            tableName: mois_sales_page
+        - not:
+            columnExists:
+              tableName: mois_sales_page
+              columnName: etapa_pipeline_geracaoanuncios
+      changes:
+        - sql:
+            splitStatements: true
+            stripComments: true
+            sql: |
+              ALTER TABLE mois_sales_page
+                ADD COLUMN etapa_pipeline_geracaoanuncios VARCHAR(80) NULL AFTER data_pipeline_geracaoanuncios;
+              CREATE INDEX idx_mois_sales_page_geracaoanuncios_etapa
+                ON mois_sales_page (etapa_pipeline_geracaoanuncios);
+      rollback:
+        - sql:
+            splitStatements: true
+            stripComments: true
+            sql: |
+              DROP INDEX idx_mois_sales_page_geracaoanuncios_etapa ON mois_sales_page;
+              ALTER TABLE mois_sales_page
+                DROP COLUMN etapa_pipeline_geracaoanuncios;

--- a/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
+++ b/backend/ads-service/src/main/resources/db/changelog/db.changelog-master.yaml
@@ -1174,5 +1174,9 @@ databaseChangeLog:
       relativeToChangelogFile: true
 
   - include:
+      file: changesets/2026-06-27-mois-sales-page-geracaoanuncios-etapa.yaml
+      relativeToChangelogFile: true
+
+  - include:
       file: changesets/2026-06-27-oprm-nichocnae-v3-only-pipeline.yaml
       relativeToChangelogFile: true

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -5465,3 +5465,9 @@
 - Causa-raiz confirmada no Swagger publicado: a tela chamava `/api/internal/aiworker/geracaoanuncios/v1/texto/stage-executions/start` com `experimentKey` por query, mas o contrato exposto pelo backend aceita o início por caminho em `/{idExterno}/start` ou `/experiments/{experimentId}/start`.
 - Correção aplicada: o frontend passou a chamar `/api/internal/aiworker/geracaoanuncios/v1/texto/stage-executions/{experimentId}/start`, tratando o `idExterno` como o id do experimento.
 - Prevenção de recorrência: o teste da aba Criativos foi atualizado para validar exatamente a rota Swagger usada no clique do botão.
+
+## 2026-06-27 — Avanço de etapa do GeraAnuncio v1 na tabela de experimento
+
+- Solicitação: ao concluir uma etapa com sucesso no backend de `aiworker.geracaoanuncios.v1`, a tabela do experimento deve voltar o pipeline para `INICIADO`, registrar a data-hora atual e apontar a próxima etapa.
+- Ajuste aplicado: os callbacks de sucesso das etapas `texto` e `imagem` agora atualizam `mois_sales_page.status_pipeline_geracaoanuncios`, `data_pipeline_geracaoanuncios` e `etapa_pipeline_geracaoanuncios` conforme a próxima etapa funcional.
+- Prevenção de recorrência: foi adicionada coluna canônica para a etapa do pipeline no controle de experimento, evitando depender apenas do histórico técnico da tabela de auditoria.


### PR DESCRIPTION
### Motivation
- Garantir que, ao concluir com sucesso uma etapa do pipeline `aiworker.geracaoanuncios.v1`, o experimento reflita imediatamente o estado operacional: manter `INICIADO`, registrar data/hora e apontar a próxima etapa.

### Description
- Atualiza `GeraAnuncioTextoService` e `GeraAnuncioImagemService` para, no callback de sucesso, definir `status_pipeline_geracaoanuncios` para `INICIADO`, gravar `data_pipeline_geracaoanuncios = Instant.now()` e atualizar `etapa_pipeline_geracaoanuncios` com a próxima etapa (`NEXT_STAGE`), e em caso de erro manter `FALHA`.
- Adiciona o atributo JPA `etapaPipelineGeracaoAnuncios` mapeado para a coluna `etapa_pipeline_geracaoanuncios` em `MoisSalesPage`.
- Cria changelog Liquibase `changesets/2026-06-27-mois-sales-page-geracaoanuncios-etapa.yaml` e inclui no `db.changelog-master.yaml` para adicionar a coluna e índice em `mois_sales_page`.
- Atualiza `docs/registros/experimentos.md` para registrar a mudança e cria auditoria em `pipeline_geracaoanuncios` já existente; commit/PR contém essas alterações.

### Testing
- Executei `mvn -DskipTests compile` em `backend/ads-service`, que completou com sucesso.
- Executei `mvn test` em `backend/ads-service`; a build falhou por erros em testes preexistentes (`CreativeControllerTest.setup`) relacionados a violação de integridade referencial no banco de teste H2 (`targeting_element` -> `hypothesis`), que é pré-existente e não foi introduzido por estas alterações; portanto as mudanças de código compilam, mas a suíte completa de testes apresentou falha não relacionada.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3fe2f21b20832181c19fad37286f5f)