### PR TITLE
Avança dossiê MOIS para próxima etapa após sucesso

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossieproduto/v1/dossiersynthesis/service/DossierDossierSynthesisService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossieproduto/v1/dossiersynthesis/service/DossierDossierSynthesisService.java
@@ -86,15 +86,21 @@ public class DossierDossierSynthesisService {
     }
 
 
-    /** Recebe a resposta operacional da etapa, conclui ou falha a página/produto e audita a saída do pipeline. */
+    /** Recebe a resposta operacional da etapa, avança sucesso para a próxima etapa e audita a saída do pipeline. */
     public DossierDossierSynthesisRecebeResponseResponse recebeResponse(String productKey, String jobId, DossierDossierSynthesisRecebeResponseRequest request) {
         long pageId = Long.parseLong(productKey);
         Instant now = Instant.now();
         String status = isBlank(request.descricaoErro()) ? STATUS_COMPLETED : STATUS_FAILED;
         var page = salesPageRepository.findById(pageId)
                 .orElseThrow(() -> new IllegalArgumentException("Página/produto MOIS não encontrada: " + productKey));
-        page.setDossieProdutoStatus(status);
-        page.setDossieProdutoCurrentStage(STAGE_CODE);
+        String nextStageCode = STATUS_COMPLETED.equals(status) ? normalizeNextStage(NEXT_STAGE) : null;
+        if (nextStageCode == null) {
+            page.setDossieProdutoStatus(status);
+            page.setDossieProdutoCurrentStage(STAGE_CODE);
+        } else {
+            page.setDossieProdutoStatus(STATUS_STARTED);
+            page.setDossieProdutoCurrentStage(nextStageCode);
+        }
         page.setDossieProdutoUpdatedAt(now);
         salesPageRepository.save(page);
 
@@ -112,7 +118,6 @@ public class DossierDossierSynthesisService {
         pipeline.setVersaoPipeline("v1");
         pipelineDossieProdutoRepository.save(pipeline);
 
-        String nextStageCode = STATUS_COMPLETED.equals(status) ? normalizeNextStage(NEXT_STAGE) : null;
         return new DossierDossierSynthesisRecebeResponseResponse(jobId, productKey, STAGE_CODE, status, nextStageCode);
     }
 

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossieproduto/v1/intake/service/DossierIntakeService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossieproduto/v1/intake/service/DossierIntakeService.java
@@ -86,15 +86,21 @@ public class DossierIntakeService {
     }
 
 
-    /** Recebe a resposta operacional da etapa, conclui ou falha a página/produto e audita a saída do pipeline. */
+    /** Recebe a resposta operacional da etapa, avança sucesso para a próxima etapa e audita a saída do pipeline. */
     public DossierIntakeRecebeResponseResponse recebeResponse(String productKey, String jobId, DossierIntakeRecebeResponseRequest request) {
         long pageId = Long.parseLong(productKey);
         Instant now = Instant.now();
         String status = isBlank(request.descricaoErro()) ? STATUS_COMPLETED : STATUS_FAILED;
         var page = salesPageRepository.findById(pageId)
                 .orElseThrow(() -> new IllegalArgumentException("Página/produto MOIS não encontrada: " + productKey));
-        page.setDossieProdutoStatus(status);
-        page.setDossieProdutoCurrentStage(STAGE_CODE);
+        String nextStageCode = STATUS_COMPLETED.equals(status) ? normalizeNextStage(NEXT_STAGE) : null;
+        if (nextStageCode == null) {
+            page.setDossieProdutoStatus(status);
+            page.setDossieProdutoCurrentStage(STAGE_CODE);
+        } else {
+            page.setDossieProdutoStatus(STATUS_STARTED);
+            page.setDossieProdutoCurrentStage(nextStageCode);
+        }
         page.setDossieProdutoUpdatedAt(now);
         salesPageRepository.save(page);
 
@@ -112,7 +118,6 @@ public class DossierIntakeService {
         pipeline.setVersaoPipeline("v1");
         pipelineDossieProdutoRepository.save(pipeline);
 
-        String nextStageCode = STATUS_COMPLETED.equals(status) ? normalizeNextStage(NEXT_STAGE) : null;
         return new DossierIntakeRecebeResponseResponse(jobId, productKey, STAGE_CODE, status, nextStageCode);
     }
 

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossieproduto/v1/investigationanchorbuilder/service/DossierInvestigationAnchorBuilderService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossieproduto/v1/investigationanchorbuilder/service/DossierInvestigationAnchorBuilderService.java
@@ -86,15 +86,21 @@ public class DossierInvestigationAnchorBuilderService {
     }
 
 
-    /** Recebe a resposta operacional da etapa, conclui ou falha a página/produto e audita a saída do pipeline. */
+    /** Recebe a resposta operacional da etapa, avança sucesso para a próxima etapa e audita a saída do pipeline. */
     public DossierInvestigationAnchorBuilderRecebeResponseResponse recebeResponse(String productKey, String jobId, DossierInvestigationAnchorBuilderRecebeResponseRequest request) {
         long pageId = Long.parseLong(productKey);
         Instant now = Instant.now();
         String status = isBlank(request.descricaoErro()) ? STATUS_COMPLETED : STATUS_FAILED;
         var page = salesPageRepository.findById(pageId)
                 .orElseThrow(() -> new IllegalArgumentException("Página/produto MOIS não encontrada: " + productKey));
-        page.setDossieProdutoStatus(status);
-        page.setDossieProdutoCurrentStage(STAGE_CODE);
+        String nextStageCode = STATUS_COMPLETED.equals(status) ? normalizeNextStage(NEXT_STAGE) : null;
+        if (nextStageCode == null) {
+            page.setDossieProdutoStatus(status);
+            page.setDossieProdutoCurrentStage(STAGE_CODE);
+        } else {
+            page.setDossieProdutoStatus(STATUS_STARTED);
+            page.setDossieProdutoCurrentStage(nextStageCode);
+        }
         page.setDossieProdutoUpdatedAt(now);
         salesPageRepository.save(page);
 
@@ -112,7 +118,6 @@ public class DossierInvestigationAnchorBuilderService {
         pipeline.setVersaoPipeline("v1");
         pipelineDossieProdutoRepository.save(pipeline);
 
-        String nextStageCode = STATUS_COMPLETED.equals(status) ? normalizeNextStage(NEXT_STAGE) : null;
         return new DossierInvestigationAnchorBuilderRecebeResponseResponse(jobId, productKey, STAGE_CODE, status, nextStageCode);
     }
 

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossieproduto/v1/productunderstanding/service/DossierProductUnderstandingService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossieproduto/v1/productunderstanding/service/DossierProductUnderstandingService.java
@@ -86,15 +86,21 @@ public class DossierProductUnderstandingService {
     }
 
 
-    /** Recebe a resposta operacional da etapa, conclui ou falha a página/produto e audita a saída do pipeline. */
+    /** Recebe a resposta operacional da etapa, avança sucesso para a próxima etapa e audita a saída do pipeline. */
     public DossierProductUnderstandingRecebeResponseResponse recebeResponse(String productKey, String jobId, DossierProductUnderstandingRecebeResponseRequest request) {
         long pageId = Long.parseLong(productKey);
         Instant now = Instant.now();
         String status = isBlank(request.descricaoErro()) ? STATUS_COMPLETED : STATUS_FAILED;
         var page = salesPageRepository.findById(pageId)
                 .orElseThrow(() -> new IllegalArgumentException("Página/produto MOIS não encontrada: " + productKey));
-        page.setDossieProdutoStatus(status);
-        page.setDossieProdutoCurrentStage(STAGE_CODE);
+        String nextStageCode = STATUS_COMPLETED.equals(status) ? normalizeNextStage(NEXT_STAGE) : null;
+        if (nextStageCode == null) {
+            page.setDossieProdutoStatus(status);
+            page.setDossieProdutoCurrentStage(STAGE_CODE);
+        } else {
+            page.setDossieProdutoStatus(STATUS_STARTED);
+            page.setDossieProdutoCurrentStage(nextStageCode);
+        }
         page.setDossieProdutoUpdatedAt(now);
         salesPageRepository.save(page);
 
@@ -112,7 +118,6 @@ public class DossierProductUnderstandingService {
         pipeline.setVersaoPipeline("v1");
         pipelineDossieProdutoRepository.save(pipeline);
 
-        String nextStageCode = STATUS_COMPLETED.equals(status) ? normalizeNextStage(NEXT_STAGE) : null;
         return new DossierProductUnderstandingRecebeResponseResponse(jobId, productKey, STAGE_CODE, status, nextStageCode);
     }
 

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossieproduto/v1/sourceproductmatch/service/DossierSourceProductMatchService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossieproduto/v1/sourceproductmatch/service/DossierSourceProductMatchService.java
@@ -86,15 +86,21 @@ public class DossierSourceProductMatchService {
     }
 
 
-    /** Recebe a resposta operacional da etapa, conclui ou falha a página/produto e audita a saída do pipeline. */
+    /** Recebe a resposta operacional da etapa, avança sucesso para a próxima etapa e audita a saída do pipeline. */
     public DossierSourceProductMatchRecebeResponseResponse recebeResponse(String productKey, String jobId, DossierSourceProductMatchRecebeResponseRequest request) {
         long pageId = Long.parseLong(productKey);
         Instant now = Instant.now();
         String status = isBlank(request.descricaoErro()) ? STATUS_COMPLETED : STATUS_FAILED;
         var page = salesPageRepository.findById(pageId)
                 .orElseThrow(() -> new IllegalArgumentException("Página/produto MOIS não encontrada: " + productKey));
-        page.setDossieProdutoStatus(status);
-        page.setDossieProdutoCurrentStage(STAGE_CODE);
+        String nextStageCode = STATUS_COMPLETED.equals(status) ? normalizeNextStage(NEXT_STAGE) : null;
+        if (nextStageCode == null) {
+            page.setDossieProdutoStatus(status);
+            page.setDossieProdutoCurrentStage(STAGE_CODE);
+        } else {
+            page.setDossieProdutoStatus(STATUS_STARTED);
+            page.setDossieProdutoCurrentStage(nextStageCode);
+        }
         page.setDossieProdutoUpdatedAt(now);
         salesPageRepository.save(page);
 
@@ -112,7 +118,6 @@ public class DossierSourceProductMatchService {
         pipeline.setVersaoPipeline("v1");
         pipelineDossieProdutoRepository.save(pipeline);
 
-        String nextStageCode = STATUS_COMPLETED.equals(status) ? normalizeNextStage(NEXT_STAGE) : null;
         return new DossierSourceProductMatchRecebeResponseResponse(jobId, productKey, STAGE_CODE, status, nextStageCode);
     }
 

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossieproduto/v1/warmupmapbuilder/service/DossierWarmupMapBuilderService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossieproduto/v1/warmupmapbuilder/service/DossierWarmupMapBuilderService.java
@@ -86,15 +86,21 @@ public class DossierWarmupMapBuilderService {
     }
 
 
-    /** Recebe a resposta operacional da etapa, conclui ou falha a página/produto e audita a saída do pipeline. */
+    /** Recebe a resposta operacional da etapa, avança sucesso para a próxima etapa e audita a saída do pipeline. */
     public DossierWarmupMapBuilderRecebeResponseResponse recebeResponse(String productKey, String jobId, DossierWarmupMapBuilderRecebeResponseRequest request) {
         long pageId = Long.parseLong(productKey);
         Instant now = Instant.now();
         String status = isBlank(request.descricaoErro()) ? STATUS_COMPLETED : STATUS_FAILED;
         var page = salesPageRepository.findById(pageId)
                 .orElseThrow(() -> new IllegalArgumentException("Página/produto MOIS não encontrada: " + productKey));
-        page.setDossieProdutoStatus(status);
-        page.setDossieProdutoCurrentStage(STAGE_CODE);
+        String nextStageCode = STATUS_COMPLETED.equals(status) ? normalizeNextStage(NEXT_STAGE) : null;
+        if (nextStageCode == null) {
+            page.setDossieProdutoStatus(status);
+            page.setDossieProdutoCurrentStage(STAGE_CODE);
+        } else {
+            page.setDossieProdutoStatus(STATUS_STARTED);
+            page.setDossieProdutoCurrentStage(nextStageCode);
+        }
         page.setDossieProdutoUpdatedAt(now);
         salesPageRepository.save(page);
 
@@ -112,7 +118,6 @@ public class DossierWarmupMapBuilderService {
         pipeline.setVersaoPipeline("v1");
         pipelineDossieProdutoRepository.save(pipeline);
 
-        String nextStageCode = STATUS_COMPLETED.equals(status) ? normalizeNextStage(NEXT_STAGE) : null;
         return new DossierWarmupMapBuilderRecebeResponseResponse(jobId, productKey, STAGE_CODE, status, nextStageCode);
     }
 

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossieproduto/v1/warmupresourcediscovery/service/DossierWarmupResourceDiscoveryService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossieproduto/v1/warmupresourcediscovery/service/DossierWarmupResourceDiscoveryService.java
@@ -86,15 +86,21 @@ public class DossierWarmupResourceDiscoveryService {
     }
 
 
-    /** Recebe a resposta operacional da etapa, conclui ou falha a página/produto e audita a saída do pipeline. */
+    /** Recebe a resposta operacional da etapa, avança sucesso para a próxima etapa e audita a saída do pipeline. */
     public DossierWarmupResourceDiscoveryRecebeResponseResponse recebeResponse(String productKey, String jobId, DossierWarmupResourceDiscoveryRecebeResponseRequest request) {
         long pageId = Long.parseLong(productKey);
         Instant now = Instant.now();
         String status = isBlank(request.descricaoErro()) ? STATUS_COMPLETED : STATUS_FAILED;
         var page = salesPageRepository.findById(pageId)
                 .orElseThrow(() -> new IllegalArgumentException("Página/produto MOIS não encontrada: " + productKey));
-        page.setDossieProdutoStatus(status);
-        page.setDossieProdutoCurrentStage(STAGE_CODE);
+        String nextStageCode = STATUS_COMPLETED.equals(status) ? normalizeNextStage(NEXT_STAGE) : null;
+        if (nextStageCode == null) {
+            page.setDossieProdutoStatus(status);
+            page.setDossieProdutoCurrentStage(STAGE_CODE);
+        } else {
+            page.setDossieProdutoStatus(STATUS_STARTED);
+            page.setDossieProdutoCurrentStage(nextStageCode);
+        }
         page.setDossieProdutoUpdatedAt(now);
         salesPageRepository.save(page);
 
@@ -112,7 +118,6 @@ public class DossierWarmupResourceDiscoveryService {
         pipeline.setVersaoPipeline("v1");
         pipelineDossieProdutoRepository.save(pipeline);
 
-        String nextStageCode = STATUS_COMPLETED.equals(status) ? normalizeNextStage(NEXT_STAGE) : null;
         return new DossierWarmupResourceDiscoveryRecebeResponseResponse(jobId, productKey, STAGE_CODE, status, nextStageCode);
     }
 

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossieproduto/v1/warmupsignalextraction/service/DossierWarmupSignalExtractionService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossieproduto/v1/warmupsignalextraction/service/DossierWarmupSignalExtractionService.java
@@ -86,15 +86,21 @@ public class DossierWarmupSignalExtractionService {
     }
 
 
-    /** Recebe a resposta operacional da etapa, conclui ou falha a página/produto e audita a saída do pipeline. */
+    /** Recebe a resposta operacional da etapa, avança sucesso para a próxima etapa e audita a saída do pipeline. */
     public DossierWarmupSignalExtractionRecebeResponseResponse recebeResponse(String productKey, String jobId, DossierWarmupSignalExtractionRecebeResponseRequest request) {
         long pageId = Long.parseLong(productKey);
         Instant now = Instant.now();
         String status = isBlank(request.descricaoErro()) ? STATUS_COMPLETED : STATUS_FAILED;
         var page = salesPageRepository.findById(pageId)
                 .orElseThrow(() -> new IllegalArgumentException("Página/produto MOIS não encontrada: " + productKey));
-        page.setDossieProdutoStatus(status);
-        page.setDossieProdutoCurrentStage(STAGE_CODE);
+        String nextStageCode = STATUS_COMPLETED.equals(status) ? normalizeNextStage(NEXT_STAGE) : null;
+        if (nextStageCode == null) {
+            page.setDossieProdutoStatus(status);
+            page.setDossieProdutoCurrentStage(STAGE_CODE);
+        } else {
+            page.setDossieProdutoStatus(STATUS_STARTED);
+            page.setDossieProdutoCurrentStage(nextStageCode);
+        }
         page.setDossieProdutoUpdatedAt(now);
         salesPageRepository.save(page);
 
@@ -112,7 +118,6 @@ public class DossierWarmupSignalExtractionService {
         pipeline.setVersaoPipeline("v1");
         pipelineDossieProdutoRepository.save(pipeline);
 
-        String nextStageCode = STATUS_COMPLETED.equals(status) ? normalizeNextStage(NEXT_STAGE) : null;
         return new DossierWarmupSignalExtractionRecebeResponseResponse(jobId, productKey, STAGE_CODE, status, nextStageCode);
     }
 


### PR DESCRIPTION
### Motivation

- Automatizar o avanço do dossiê MOIS: quando uma etapa é concluída com sucesso e existe `NEXT_STAGE` definido, a página deve ser reposicionada para a próxima etapa para permitir consumo imediato pelo executor.
- Garantir auditabilidade: continuar registrando a entrada/saída da etapa em `PipelineDossieProduto` enquanto atualiza o status e timestamp da página.

### Description

- Ajusta o comportamento de resposta nas services do pipeline `moissaleslibraryworker.dossieproduto.v1` para as etapas `intake`, `product-understanding`, `investigation-anchor-builder`, `warmup-resource-discovery`, `source-product-match`, `warmup-signal-extraction`, `warmup-map-builder` e `dossier-synthesis` (arquivos em `backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossieproduto/v1/*/service/*Service.java`).
- Ao receber `recebeResponse(...)` agora calcula `nextStageCode = STATUS_COMPLETED.equals(status) ? normalizeNextStage(NEXT_STAGE) : null`; se `nextStageCode != null` a página é colocada com `DossieProdutoStatus = STATUS_STARTED` e `DossieProdutoCurrentStage = nextStageCode`, caso contrário mantém `status` e `STAGE_CODE` atuais.
- Sempre atualiza `dossieProdutoUpdatedAt` com `now` e persiste a página via `salesPageRepository.save(page)`; mantém a criação e salvamento do `PipelineDossieProduto` para auditoria da execução.
- Atualiza a documentação JavaDoc dos métodos `recebeResponse` para refletir o novo comportamento de avanço quando houver próxima etapa.

### Testing

- Executado `git diff --check` para validar o diff do código e formatação; sem erros.
- Tentativa de rodar `mvn test -DskipITs` em `backend/ads-service` foi feita, porém os testes não concluíram por falha externa na resolução de dependências (`org.springframework.boot:spring-boot:pom:3.2.5` retornou HTTP 502 do Maven Central), então a suíte de testes automática não pôde ser executada com sucesso.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3fe2dc59988321b80579d4e8ac6304)