### PR TITLE
Atualiza avanço do pipeline NichoCNAE v3 no CNAE

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/shared/OprmNichoCnaeV3StageServiceSupport.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/shared/OprmNichoCnaeV3StageServiceSupport.java
@@ -62,11 +62,16 @@ public abstract class OprmNichoCnaeV3StageServiceSupport {
 
     /** Marca no cadastro de CNAE que o pipeline NichoCNAE v3 foi iniciado na etapa atual. */
     protected void markCnaePipelineStarted(String cnaeCode, String statusStarted) {
+        markCnaePipelineStarted(cnaeCode, stageCode, statusStarted);
+    }
+
+    /** Marca no cadastro de CNAE que o pipeline NichoCNAE v3 foi iniciado na etapa informada. */
+    private void markCnaePipelineStarted(String cnaeCode, String currentStageCode, String statusStarted) {
         OprmCnpjCnaeDim cnae = cnaeRepository.findById(cnaeCode)
                 .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "CNAE não encontrado."));
         Instant now = Instant.now();
         cnae.setNichocnaePipelineStatus(statusStarted);
-        cnae.setNichocnaeCurrentStageCode(stageCode);
+        cnae.setNichocnaeCurrentStageCode(currentStageCode);
         cnae.setNichocnaePipelineUpdatedAt(now);
         cnae.setUpdatedAt(now);
         cnaeRepository.save(cnae);
@@ -168,7 +173,7 @@ public abstract class OprmNichoCnaeV3StageServiceSupport {
         return "nichocnae-v3-" + cnae.getCnaeCode();
     }
 
-    /** Registra conclusão reportada pelo executor externo. */
+    /** Registra conclusão reportada pelo executor externo e publica a próxima etapa no cadastro do CNAE. */
     protected OprmNichoCnaeV3StageExecution doComplete(Long stageExecutionId, String outputPayload, String nextStageCode) {
         OprmNichoCnaeV3StageExecution execution = find(stageExecutionId);
         execution.setStatus(OprmNichoCnaeV3StageExecutionStatus.COMPLETED);
@@ -176,7 +181,9 @@ public abstract class OprmNichoCnaeV3StageServiceSupport {
         execution.setNextStageCode(nextStageCode);
         execution.setUpdatedAt(Instant.now());
         OprmNichoCnaeV3StageExecution saved = repository.save(execution);
-        createNextStageWhenAllowed(saved, outputPayload, nextStageCode);
+        if (createNextStageWhenAllowed(saved, outputPayload, nextStageCode)) {
+            markCnaePipelineStarted(saved.getCnaeCode(), normalizedStage(nextStageCode), STATUS_STARTED);
+        }
         return saved;
     }
 
@@ -190,12 +197,12 @@ public abstract class OprmNichoCnaeV3StageServiceSupport {
     }
 
     /** Cria a próxima pendência quando o backend reconhecer avanço sequencial válido. */
-    private void createNextStageWhenAllowed(OprmNichoCnaeV3StageExecution current, String outputPayload, String nextStageCode) {
-        String normalizedNextStage = nextStageCode == null ? "" : nextStageCode.trim();
+    private boolean createNextStageWhenAllowed(OprmNichoCnaeV3StageExecution current, String outputPayload, String nextStageCode) {
+        String normalizedNextStage = normalizedStage(nextStageCode);
         if (requiresUserConfirmation(current, normalizedNextStage)
                 || !isAllowedNextStage(normalizedNextStage)
                 || repository.existsByJobIdAndStageCode(current.getJobId(), normalizedNextStage)) {
-            return;
+            return false;
         }
         OprmNichoCnaeV3StageExecution next = new OprmNichoCnaeV3StageExecution();
         next.setJobId(current.getJobId());
@@ -205,6 +212,12 @@ public abstract class OprmNichoCnaeV3StageServiceSupport {
         next.setAttemptNumber(current.getAttemptNumber());
         next.setKnowledgeVersion(current.getKnowledgeVersion());
         repository.save(next);
+        return true;
+    }
+
+    /** Normaliza o código de etapa para comparação e persistência canônica. */
+    private String normalizedStage(String nextStageCode) {
+        return nextStageCode == null ? "" : nextStageCode.trim();
     }
 
     /** Bloqueia a etapa final até a confirmação explícita do usuário na tela. */

--- a/backend/ads-service/src/test/java/com/marketinghub/oprmcoletormei/nichocnae/v3/cnaeintake/service/BackendCnaeIntakeServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/oprmcoletormei/nichocnae/v3/cnaeintake/service/BackendCnaeIntakeServiceTest.java
@@ -1,0 +1,87 @@
+package com.marketinghub.oprmcoletormei.nichocnae.v3.cnaeintake.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.marketinghub.oprm.market.OprmCnpjCnaeDim;
+import com.marketinghub.oprmcoletormei.nichocnae.v3.OprmNichoCnaeV3StageExecution;
+import com.marketinghub.oprmcoletormei.nichocnae.v3.OprmNichoCnaeV3StageExecutionStatus;
+import com.marketinghub.repository.jpa.oprm.market.OprmCnpjCnaeDimRepository;
+import com.marketinghub.repository.jpa.oprm.nichocnae.PipelineNichoCnaeRepository;
+import com.marketinghub.repository.jpa.oprm.nichocnae.v3.OprmNichoCnaeV3StageExecutionRepository;
+import java.time.Instant;
+import java.util.Optional;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+/** Testa a etapa inicial do pipeline NichoCNAE v3 no backend. */
+@ExtendWith(MockitoExtension.class)
+class BackendCnaeIntakeServiceTest {
+    @Mock
+    private OprmNichoCnaeV3StageExecutionRepository repository;
+
+    @Mock
+    private OprmCnpjCnaeDimRepository cnaeRepository;
+
+    @Mock
+    private PipelineNichoCnaeRepository pipelineNichoCnaeRepository;
+
+    private BackendCnaeIntakeService service;
+
+    @BeforeEach
+    void setUp() {
+        service = new BackendCnaeIntakeService(repository, cnaeRepository, pipelineNichoCnaeRepository);
+    }
+
+    /** Garante que a conclusão com sucesso publica a próxima etapa no cadastro canônico de CNAE. */
+    @Test
+    void completeUpdatesCnaePipelineToNextStage() {
+        OprmNichoCnaeV3StageExecution execution = execution();
+        OprmCnpjCnaeDim cnae = cnae();
+        when(repository.findById(10L)).thenReturn(Optional.of(execution));
+        when(repository.save(any(OprmNichoCnaeV3StageExecution.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        when(repository.existsByJobIdAndStageCode("job-4781400", "persona-candidate-generator")).thenReturn(false);
+        when(cnaeRepository.findById("4781400")).thenReturn(Optional.of(cnae));
+
+        service.complete(10L, "{\"ok\":true}", "persona-candidate-generator");
+
+        assertThat(cnae.getNichocnaePipelineStatus()).isEqualTo("INICIADO");
+        assertThat(cnae.getNichocnaeCurrentStageCode()).isEqualTo("persona-candidate-generator");
+        assertThat(cnae.getNichocnaePipelineUpdatedAt()).isNotNull();
+        ArgumentCaptor<OprmNichoCnaeV3StageExecution> executionCaptor = ArgumentCaptor.forClass(OprmNichoCnaeV3StageExecution.class);
+        verify(repository, times(2)).save(executionCaptor.capture());
+        assertThat(executionCaptor.getAllValues().get(1).getStageCode()).isEqualTo("persona-candidate-generator");
+        verify(cnaeRepository).save(cnae);
+    }
+
+    /** Monta uma execução pendente da etapa inicial. */
+    private OprmNichoCnaeV3StageExecution execution() {
+        OprmNichoCnaeV3StageExecution execution = new OprmNichoCnaeV3StageExecution();
+        execution.setId(10L);
+        execution.setJobId("job-4781400");
+        execution.setCnaeCode("4781400");
+        execution.setStageCode("cnae-intake");
+        execution.setStatus(OprmNichoCnaeV3StageExecutionStatus.PENDING);
+        execution.setAttemptNumber(1);
+        execution.setKnowledgeVersion(1);
+        execution.setCreatedAt(Instant.parse("2026-06-25T21:08:56Z"));
+        execution.setUpdatedAt(Instant.parse("2026-06-25T21:08:56Z"));
+        return execution;
+    }
+
+    /** Monta o CNAE canônico afetado pelo avanço do pipeline. */
+    private OprmCnpjCnaeDim cnae() {
+        OprmCnpjCnaeDim cnae = new OprmCnpjCnaeDim();
+        cnae.setCnaeCode("4781400");
+        cnae.setDescription("Comércio varejista de artigos do vestuário");
+        cnae.setUpdatedAt(Instant.parse("2026-06-25T21:08:56Z"));
+        return cnae;
+    }
+}


### PR DESCRIPTION
### Motivation
- Garantir que, quando uma etapa do pipeline OPRM NichoCNAE v3 é concluída com sucesso, o cadastro canônico do CNAE seja atualizado para refletir o início da próxima etapa com status `INICIADO`, timestamp atual e código da próxima etapa. 
- Evitar que o executor precise orquestrar avançamentos fora do backend e manter o registro auditável do avanço do pipeline no cadastro canônico.

### Description
- Altera `OprmNichoCnaeV3StageServiceSupport` para retornar um booleano de `createNextStageWhenAllowed(...)` e expor `normalizedStage(...)`, permitindo detectar quando a próxima pendência foi criada e, nesse caso, chamar `markCnaePipelineStarted(...)` para atualizar o CNAE com a próxima etapa e timestamp (arquivo modificado: `backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/shared/OprmNichoCnaeV3StageServiceSupport.java`).
- Adiciona sobrecarga privada de `markCnaePipelineStarted(...)` que aceita explicitamente o `currentStageCode` para permitir publicar uma etapa diferente da etapa do service atual ao atualizar o cadastro do CNAE. 
- Inclui teste unitário `BackendCnaeIntakeServiceTest` que valida o fluxo de conclusão da etapa `cnae-intake` para `persona-candidate-generator` e a atualização dos campos `nichocnaePipelineStatus`, `nichocnaeCurrentStageCode` e `nichocnaePipelineUpdatedAt` no CNAE (arquivo adicionado: `backend/ads-service/src/test/java/com/marketinghub/oprmcoletormei/nichocnae/v3/cnaeintake/service/BackendCnaeIntakeServiceTest.java`).

### Testing
- Executei `mvn -f backend/ads-service/pom.xml -Dtest=BackendCnaeIntakeServiceTest test` e o teste unitário `BackendCnaeIntakeServiceTest` passou com sucesso. 
- O teste valida que a conclusão cria a próxima pendência e que o repositório do CNAE é salvo com `nichocnaePipelineStatus = INICIADO`, `nichocnaeCurrentStageCode = persona-candidate-generator` e `nichocnaePipelineUpdatedAt` atualizado.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a3fe2e884d0832197df37b245e3b53a)