### PR TITLE
Corrige saída do torneio de personas v3

### DIFF
--- a/oprm-coletor-mei/src/main/java/com/marketinghub/pipelines/nichocnae/v3/personatournament/PersonaTournamentProcessor.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/pipelines/nichocnae/v3/personatournament/PersonaTournamentProcessor.java
@@ -4,24 +4,95 @@ import com.marketinghub.pipelines.nichocnae.v3.core.StageArtifact;
 import com.marketinghub.pipelines.nichocnae.v3.core.StageContext;
 import com.marketinghub.pipelines.nichocnae.v3.core.StageProcessor;
 import com.marketinghub.pipelines.nichocnae.v3.core.StageResult;
+import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
-/** Processa a etapa persona-tournament do pipeline NichoCNAE v3. */
+/** Processa a etapa persona-tournament do pipeline NichoCNAE v3 selecionando a persona vencedora. */
 public final class PersonaTournamentProcessor implements StageProcessor {
-    /** Executa a etapa persona-tournament produzindo saída estruturada para o backend decidir avanço. */
+    private static final String STATUS = "PERSONA_PRIORIZADA";
+
+    /** Executa a etapa persona-tournament escolhendo o candidato vencedor para guiar as próximas etapas. */
     @Override
     public StageResult process(StageContext context) {
+        List<Map<String, Object>> candidates = candidatePersonas(context.input());
+        if (candidates.isEmpty()) {
+            throw new IllegalStateException("Entrada de persona-tournament não contém candidatePersonas para escolher candidato vencedor.");
+        }
+
+        List<Map<String, Object>> ranking = rankCandidates(candidates);
+        Map<String, Object> winner = ranking.getFirst();
+
         Map<String, Object> output = new LinkedHashMap<>();
         output.put("stage", "persona-tournament");
-        output.put("status", "PERSONA_PRIORIZADA");
+        output.put("status", STATUS);
         output.put("jobId", context.jobId());
         output.put("stageExecutionId", context.stageExecutionId());
         output.put("inputKeys", context.input().keySet());
+        output.put("winnerPersona", winner);
+        output.put("winningPersonaName", text(winner.get("name")));
+        output.put("selectionRationale", selectionRationale(winner));
+        output.put("personaRanking", ranking);
         output.put("businessBoundary", "NAO_GERAR_OFERTA_CAMPANHA_LANDING");
         output.put("reportRole", "PERSONA_ROTINA_TAREFAS_DIARIAS");
         output.put("nextStageCode", "routine-query-planner");
-        return new StageResult("PERSONA_PRIORIZADA", output, List.of(new StageArtifact("PERSONA_PRIORIZADA", "inline://nichocnae-v3/persona-tournament", "Etapa persona-tournament concluída com contrato estruturado.")));
+        return new StageResult(STATUS, output, List.of(new StageArtifact(STATUS, "inline://nichocnae-v3/persona-tournament", "Persona vencedora selecionada para orientar rotina e tarefas diárias.")));
+    }
+
+    /** Extrai personas candidatas da entrada persistida recebida do backend. */
+    private List<Map<String, Object>> candidatePersonas(Map<String, Object> input) {
+        Object raw = input.get("candidatePersonas");
+        if (!(raw instanceof List<?> list)) {
+            return List.of();
+        }
+        List<Map<String, Object>> candidates = new ArrayList<>();
+        for (Object item : list) {
+            if (item instanceof Map<?, ?> map) {
+                Map<String, Object> normalized = new LinkedHashMap<>();
+                map.forEach((key, value) -> normalized.put(String.valueOf(key), value));
+                candidates.add(normalized);
+            }
+        }
+        return candidates;
+    }
+
+    /** Ordena candidatos por aderência operacional usando sinais já gerados na etapa anterior. */
+    private List<Map<String, Object>> rankCandidates(List<Map<String, Object>> candidates) {
+        return candidates.stream()
+                .map(this::withScore)
+                .sorted(Comparator.comparingInt((Map<String, Object> persona) -> (Integer) persona.get("tournamentScore")).reversed()
+                        .thenComparing(persona -> text(persona.get("name"))))
+                .toList();
+    }
+
+    /** Calcula pontuação simples baseada em dor, tarefas diárias e sinais de compra disponíveis. */
+    private Map<String, Object> withScore(Map<String, Object> persona) {
+        int painCount = listSize(persona.get("operationalPains"));
+        int taskCount = listSize(persona.get("dailyTasks"));
+        int signalCount = listSize(persona.get("buyingSignals"));
+        int score = painCount * 3 + taskCount * 2 + signalCount;
+        Map<String, Object> scored = new LinkedHashMap<>(persona);
+        scored.put("tournamentScore", score);
+        scored.put("scoreBreakdown", Map.of("operationalPains", painCount, "dailyTasks", taskCount, "buyingSignals", signalCount));
+        return scored;
+    }
+
+    /** Monta justificativa objetiva para exibir ao usuário por que a persona venceu. */
+    private String selectionRationale(Map<String, Object> winner) {
+        Object breakdown = winner.get("scoreBreakdown");
+        return "Candidato vencedor por concentrar maior evidência operacional de dores, tarefas diárias e sinais de compra. Pontuação: "
+                + winner.get("tournamentScore") + ". Detalhe: " + breakdown + ".";
+    }
+
+    /** Conta itens de listas recebidas de forma tolerante. */
+    private int listSize(Object value) {
+        return value instanceof List<?> list ? list.size() : 0;
+    }
+
+    /** Converte valores opcionais em texto seguro. */
+    private String text(Object value) {
+        return value == null ? "" : String.valueOf(value).trim();
     }
 }

--- a/oprm-coletor-mei/src/test/java/com/marketinghub/pipelines/nichocnae/v3/personatournament/PersonaTournamentProcessorTest.java
+++ b/oprm-coletor-mei/src/test/java/com/marketinghub/pipelines/nichocnae/v3/personatournament/PersonaTournamentProcessorTest.java
@@ -1,0 +1,40 @@
+package com.marketinghub.pipelines.nichocnae.v3.personatournament;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.marketinghub.pipelines.nichocnae.v3.core.StageContext;
+import com.marketinghub.pipelines.nichocnae.v3.core.StageResult;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/** Valida a seleção da persona vencedora no torneio do pipeline NichoCNAE v3. */
+class PersonaTournamentProcessorTest {
+    /** Garante que a saída contenha explicitamente o candidato vencedor para cumprir o objetivo da etapa. */
+    @Test
+    void shouldSelectWinnerPersonaFromCandidates() {
+        PersonaTournamentProcessor processor = new PersonaTournamentProcessor();
+
+        StageResult result = processor.process(new StageContext("job-4781400", "73", Map.of("candidatePersonas", List.of(
+                Map.of("name", "Persona fraca", "operationalPains", List.of("dor"), "dailyTasks", List.of("tarefa"), "buyingSignals", List.of()),
+                Map.of("name", "Dono operador de loja", "operationalPains", List.of("caixa", "estoque"), "dailyTasks", List.of("atender", "comprar", "conferir"), "buyingSignals", List.of("busca modelo pronto", "paga por facilidade"))))));
+
+        assertThat(result.status()).isEqualTo("PERSONA_PRIORIZADA");
+        assertThat(result.output()).containsEntry("nextStageCode", "routine-query-planner");
+        assertThat(result.output()).containsEntry("winningPersonaName", "Dono operador de loja");
+        assertThat(result.output()).containsKeys("winnerPersona", "selectionRationale", "personaRanking");
+        Map<?, ?> winner = (Map<?, ?>) result.output().get("winnerPersona");
+        assertThat(winner.get("tournamentScore")).isEqualTo(14);
+    }
+
+    /** Bloqueia avanço quando a etapa anterior não forneceu candidatos para o torneio. */
+    @Test
+    void shouldFailWithoutCandidatePersonas() {
+        PersonaTournamentProcessor processor = new PersonaTournamentProcessor();
+
+        assertThatThrownBy(() -> processor.process(new StageContext("job-1", "73", Map.of("cnaeCode", "4781400"))))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("candidatePersonas");
+    }
+}


### PR DESCRIPTION
### Motivation
- A etapa `persona-tournament` estava marcando conclusão sem escolher nem expor um candidato vencedor, deixando o pipeline sem insumo funcional para as próximas etapas.
- É necessário um vencedor rastreável (nome, artefato e justificativa) para guiar `routine-query-planner` e manter a cadeia de decisão persistida.

### Description
- Implementa seleção e ranking de candidatos em `oprm-coletor-mei/src/main/java/.../PersonaTournamentProcessor.java`, adicionando pontuação (`tournamentScore`) e critérios simples por `operationalPains`, `dailyTasks` e `buyingSignals`.
- A saída agora inclui `winnerPersona`, `winningPersonaName`, `selectionRationale` e `personaRanking`, além de manter `nextStageCode` e artefatos de etapa canônicos; a etapa passa a lançar erro quando não há `candidatePersonas` na entrada.
- Adiciona teste unitário `oprm-coletor-mei/src/test/java/.../PersonaTournamentProcessorTest.java` cobrindo seleção do vencedor e falha quando não há candidatos.

### Testing
- Executei `mvn test -Dtest=PersonaTournamentProcessorTest` no módulo `oprm-coletor-mei` e os testes passaram com `BUILD SUCCESS` (2 tests ran, 0 failures).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4002e77638832197c7930671234cba)