### PR TITLE
Hide previous pipeline failure while retry request is pending (CriativosTab)

### DIFF
--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -5471,3 +5471,11 @@
 - Solicitação: ao concluir uma etapa com sucesso no backend de `aiworker.geracaoanuncios.v1`, a tabela do experimento deve voltar o pipeline para `INICIADO`, registrar a data-hora atual e apontar a próxima etapa.
 - Ajuste aplicado: os callbacks de sucesso das etapas `texto` e `imagem` agora atualizam `mois_sales_page.status_pipeline_geracaoanuncios`, `data_pipeline_geracaoanuncios` e `etapa_pipeline_geracaoanuncios` conforme a próxima etapa funcional.
 - Prevenção de recorrência: foi adicionada coluna canônica para a etapa do pipeline no controle de experimento, evitando depender apenas do histórico técnico da tabela de auditoria.
+
+## 2026-06-27 — Falha antiga de GeraAnuncio ocultada durante nova tentativa
+
+- Problema: ao clicar novamente em “Gerar anúncios do pipeline”, a aba Criativos mantinha visível a mensagem de falha anterior enquanto a nova solicitação ainda estava em andamento.
+- Causa-raiz: a tela usava corretamente o status persistido no backend, mas não separava o estado transitório da requisição de retry; por isso a falha anterior parecia pertencer à tentativa atual até a atualização do experimento retornar.
+- Correção aplicada: durante o POST de nova solicitação, a UI oculta o badge e o detalhe da falha recuperável anterior, mantendo o botão em carregamento até o backend responder.
+- Prevenção de recorrência: foi adicionado teste de frontend garantindo que a falha anterior desaparece enquanto o retry está pendente.
+- Observação operacional: a consulta aos logs via MCP retornou timeout de conexão no momento da investigação, então não houve evidência nova suficiente para confirmar uma nova falha do worker nesta rodada.

--- a/frontend/src/pages/experiment/CriativosTab.test.tsx
+++ b/frontend/src/pages/experiment/CriativosTab.test.tsx
@@ -315,6 +315,63 @@ describe("CriativosTab", () => {
     });
   });
 
+  it("hides the previous generation failure while a retry request is pending", async () => {
+    (axios.get as any).mockImplementation((url: string) => {
+      if (url.endsWith("/experiments/1/creatives")) {
+        return Promise.resolve({ data: [] });
+      }
+      if (url.endsWith("/experiments/1")) {
+        return Promise.resolve({
+          data: {
+            creativesToGenerate: 0,
+            creativeGenerationStatus: "FAILED",
+            creativeGenerationError: "Falha anterior",
+            adCopy: JSON.stringify({
+              adCopy: { primaryTextVariants: [{ primaryText: "Texto" }] },
+            }),
+            adImageBriefing: JSON.stringify({
+              adImageBriefing: { briefings: [{ visualBriefing: "Imagem" }] },
+            }),
+          },
+        });
+      }
+      return Promise.resolve({ data: [] });
+    });
+    let resolveRetry: (value: unknown) => void = () => {};
+    (axios.post as any).mockImplementation(
+      () => new Promise((resolve) => {
+        resolveRetry = resolve;
+      }),
+    );
+
+    const client = new QueryClient({
+      defaultOptions: {
+        queries: { retry: false },
+        mutations: { retry: false },
+      },
+    });
+    render(
+      <QueryClientProvider client={client}>
+        <CriativosTab experimentId="1" />
+      </QueryClientProvider>,
+    );
+
+    expect(await screen.findByText("Falha anterior")).toBeInTheDocument();
+
+    await userEvent.click(
+      await screen.findByRole("button", {
+        name: "Gerar anúncios do pipeline",
+      }),
+    );
+
+    expect(screen.queryByText("Falha anterior")).not.toBeInTheDocument();
+    expect(
+      screen.queryByText("Geração falhou; revise a causa e tente novamente"),
+    ).not.toBeInTheDocument();
+
+    resolveRetry({ data: { idJob: "job-1" } });
+  });
+
   it("clears approval loading state when the backend rejects the update", async () => {
     (axios.get as any).mockImplementation((url: string) => {
       if (url.endsWith("/experiments/1/creatives")) {

--- a/frontend/src/pages/experiment/CriativosTab.tsx
+++ b/frontend/src/pages/experiment/CriativosTab.tsx
@@ -258,8 +258,9 @@ export default function CriativosTab({
     creativeGenerationStatus === "REQUESTED" ||
     creativeGenerationStatus === "PROCESSING";
   const pipelineHasRecoverableFailure =
-    creativeGenerationStatus === "FAILED" ||
-    creativeGenerationStatus === "TIMEOUT";
+    !pipelineRequest.isPending &&
+    (creativeGenerationStatus === "FAILED" ||
+      creativeGenerationStatus === "TIMEOUT");
   const pipelineStatusLabel =
     creativeGenerationStatus === "REQUESTED"
       ? "Worker AI aguardando a fila de imagens"


### PR DESCRIPTION
### Motivation
- Prevent user confusion by hiding an old pipeline failure message while a new "Gerar anúncios do pipeline" request is in-flight so the user can tell if the current attempt is failing or the previous one.
- Record the investigation and its limitation when log queries to MCP timed out during analysis.

### Description
- Change frontend logic in `CriativosTab.tsx` so `pipelineHasRecoverableFailure` requires `!pipelineRequest.isPending`, hiding recoverable-failure UI while a retry request is pending.
- Add a regression test `hides the previous generation failure while a retry request is pending` in `CriativosTab.test.tsx` that verifies the old failure badge/detail is not shown while the POST is unresolved.
- Update `docs/registros/experimentos.md` with an entry describing the issue, root cause, fix and the MCP timeout observed during log inspection.

### Testing
- Ran the component tests with `npm test -- CriativosTab.test.tsx --run` and the test suite passed (1 file, 10 tests, all green).
- Ran type checking with `npm run typecheck` and it completed without type errors.
- Attempted automated log queries to the MCP (`java_module_logs`) during investigation but observed connection timeouts, so no new worker error evidence was obtained from logs.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a4009c943b883218e7ef66fe778bc40)