### PR TITLE
fix: destravar fila do dossiê MOIS v1

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossieproduto/v1/dossiersynthesis/service/DossierDossierSynthesisService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossieproduto/v1/dossiersynthesis/service/DossierDossierSynthesisService.java
@@ -156,12 +156,25 @@ public class DossierDossierSynthesisService {
                 .toList();
         return new DossierDossierSynthesisPendingResponse(!jobs.isEmpty(), jobs);
     }
-    /** Recupera o jobId UUID criado no start para compor o contrato pending da etapa. */
+    /** Recupera ou recompõe o jobId UUID para impedir que pendências antigas travem a fila da etapa. */
     private String resolveJobId(String productKey) {
         return pipelineDossieProdutoRepository
                 .findTopByIdExternoAndCodigoEtapaOrderByDataHoraDescIdDesc(productKey, STAGE_CODE)
                 .map(PipelineDossieProduto::getJobId)
-                .orElseThrow(() -> new IllegalStateException(
-                        "JobId do dossiê MOIS não encontrado para produto " + productKey + " na etapa " + STAGE_CODE));
+                .filter(jobId -> jobId != null && !jobId.isBlank())
+                .orElseGet(() -> rebuildJobId(productKey));
+    }
+
+    /** Cria auditoria mínima com jobId novo quando existe pendência legada sem registro rastreável. */
+    private String rebuildJobId(String productKey) {
+        String jobId = UUID.randomUUID().toString();
+        PipelineDossieProduto pipeline = new PipelineDossieProduto();
+        pipeline.setIdExterno(productKey);
+        pipeline.setCodigoEtapa(STAGE_CODE);
+        pipeline.setDataHora(Instant.now());
+        pipeline.setJobId(jobId);
+        pipeline.setVersaoPipeline("v1");
+        pipelineDossieProdutoRepository.save(pipeline);
+        return jobId;
     }
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossieproduto/v1/intake/service/DossierIntakeService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossieproduto/v1/intake/service/DossierIntakeService.java
@@ -156,12 +156,25 @@ public class DossierIntakeService {
                 .toList();
         return new DossierIntakePendingResponse(!jobs.isEmpty(), jobs);
     }
-    /** Recupera o jobId UUID criado no start para compor o contrato pending da etapa. */
+    /** Recupera ou recompõe o jobId UUID para impedir que pendências antigas travem a fila da etapa. */
     private String resolveJobId(String productKey) {
         return pipelineDossieProdutoRepository
                 .findTopByIdExternoAndCodigoEtapaOrderByDataHoraDescIdDesc(productKey, STAGE_CODE)
                 .map(PipelineDossieProduto::getJobId)
-                .orElseThrow(() -> new IllegalStateException(
-                        "JobId do dossiê MOIS não encontrado para produto " + productKey + " na etapa " + STAGE_CODE));
+                .filter(jobId -> jobId != null && !jobId.isBlank())
+                .orElseGet(() -> rebuildJobId(productKey));
+    }
+
+    /** Cria auditoria mínima com jobId novo quando existe pendência legada sem registro rastreável. */
+    private String rebuildJobId(String productKey) {
+        String jobId = UUID.randomUUID().toString();
+        PipelineDossieProduto pipeline = new PipelineDossieProduto();
+        pipeline.setIdExterno(productKey);
+        pipeline.setCodigoEtapa(STAGE_CODE);
+        pipeline.setDataHora(Instant.now());
+        pipeline.setJobId(jobId);
+        pipeline.setVersaoPipeline("v1");
+        pipelineDossieProdutoRepository.save(pipeline);
+        return jobId;
     }
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossieproduto/v1/investigationanchorbuilder/service/DossierInvestigationAnchorBuilderService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossieproduto/v1/investigationanchorbuilder/service/DossierInvestigationAnchorBuilderService.java
@@ -156,12 +156,25 @@ public class DossierInvestigationAnchorBuilderService {
                 .toList();
         return new DossierInvestigationAnchorBuilderPendingResponse(!jobs.isEmpty(), jobs);
     }
-    /** Recupera o jobId UUID criado no start para compor o contrato pending da etapa. */
+    /** Recupera ou recompõe o jobId UUID para impedir que pendências antigas travem a fila da etapa. */
     private String resolveJobId(String productKey) {
         return pipelineDossieProdutoRepository
                 .findTopByIdExternoAndCodigoEtapaOrderByDataHoraDescIdDesc(productKey, STAGE_CODE)
                 .map(PipelineDossieProduto::getJobId)
-                .orElseThrow(() -> new IllegalStateException(
-                        "JobId do dossiê MOIS não encontrado para produto " + productKey + " na etapa " + STAGE_CODE));
+                .filter(jobId -> jobId != null && !jobId.isBlank())
+                .orElseGet(() -> rebuildJobId(productKey));
+    }
+
+    /** Cria auditoria mínima com jobId novo quando existe pendência legada sem registro rastreável. */
+    private String rebuildJobId(String productKey) {
+        String jobId = UUID.randomUUID().toString();
+        PipelineDossieProduto pipeline = new PipelineDossieProduto();
+        pipeline.setIdExterno(productKey);
+        pipeline.setCodigoEtapa(STAGE_CODE);
+        pipeline.setDataHora(Instant.now());
+        pipeline.setJobId(jobId);
+        pipeline.setVersaoPipeline("v1");
+        pipelineDossieProdutoRepository.save(pipeline);
+        return jobId;
     }
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossieproduto/v1/productunderstanding/service/DossierProductUnderstandingService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossieproduto/v1/productunderstanding/service/DossierProductUnderstandingService.java
@@ -156,12 +156,25 @@ public class DossierProductUnderstandingService {
                 .toList();
         return new DossierProductUnderstandingPendingResponse(!jobs.isEmpty(), jobs);
     }
-    /** Recupera o jobId UUID criado no start para compor o contrato pending da etapa. */
+    /** Recupera ou recompõe o jobId UUID para impedir que pendências antigas travem a fila da etapa. */
     private String resolveJobId(String productKey) {
         return pipelineDossieProdutoRepository
                 .findTopByIdExternoAndCodigoEtapaOrderByDataHoraDescIdDesc(productKey, STAGE_CODE)
                 .map(PipelineDossieProduto::getJobId)
-                .orElseThrow(() -> new IllegalStateException(
-                        "JobId do dossiê MOIS não encontrado para produto " + productKey + " na etapa " + STAGE_CODE));
+                .filter(jobId -> jobId != null && !jobId.isBlank())
+                .orElseGet(() -> rebuildJobId(productKey));
+    }
+
+    /** Cria auditoria mínima com jobId novo quando existe pendência legada sem registro rastreável. */
+    private String rebuildJobId(String productKey) {
+        String jobId = UUID.randomUUID().toString();
+        PipelineDossieProduto pipeline = new PipelineDossieProduto();
+        pipeline.setIdExterno(productKey);
+        pipeline.setCodigoEtapa(STAGE_CODE);
+        pipeline.setDataHora(Instant.now());
+        pipeline.setJobId(jobId);
+        pipeline.setVersaoPipeline("v1");
+        pipelineDossieProdutoRepository.save(pipeline);
+        return jobId;
     }
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossieproduto/v1/sourceproductmatch/service/DossierSourceProductMatchService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossieproduto/v1/sourceproductmatch/service/DossierSourceProductMatchService.java
@@ -156,12 +156,25 @@ public class DossierSourceProductMatchService {
                 .toList();
         return new DossierSourceProductMatchPendingResponse(!jobs.isEmpty(), jobs);
     }
-    /** Recupera o jobId UUID criado no start para compor o contrato pending da etapa. */
+    /** Recupera ou recompõe o jobId UUID para impedir que pendências antigas travem a fila da etapa. */
     private String resolveJobId(String productKey) {
         return pipelineDossieProdutoRepository
                 .findTopByIdExternoAndCodigoEtapaOrderByDataHoraDescIdDesc(productKey, STAGE_CODE)
                 .map(PipelineDossieProduto::getJobId)
-                .orElseThrow(() -> new IllegalStateException(
-                        "JobId do dossiê MOIS não encontrado para produto " + productKey + " na etapa " + STAGE_CODE));
+                .filter(jobId -> jobId != null && !jobId.isBlank())
+                .orElseGet(() -> rebuildJobId(productKey));
+    }
+
+    /** Cria auditoria mínima com jobId novo quando existe pendência legada sem registro rastreável. */
+    private String rebuildJobId(String productKey) {
+        String jobId = UUID.randomUUID().toString();
+        PipelineDossieProduto pipeline = new PipelineDossieProduto();
+        pipeline.setIdExterno(productKey);
+        pipeline.setCodigoEtapa(STAGE_CODE);
+        pipeline.setDataHora(Instant.now());
+        pipeline.setJobId(jobId);
+        pipeline.setVersaoPipeline("v1");
+        pipelineDossieProdutoRepository.save(pipeline);
+        return jobId;
     }
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossieproduto/v1/warmupmapbuilder/service/DossierWarmupMapBuilderService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossieproduto/v1/warmupmapbuilder/service/DossierWarmupMapBuilderService.java
@@ -156,12 +156,25 @@ public class DossierWarmupMapBuilderService {
                 .toList();
         return new DossierWarmupMapBuilderPendingResponse(!jobs.isEmpty(), jobs);
     }
-    /** Recupera o jobId UUID criado no start para compor o contrato pending da etapa. */
+    /** Recupera ou recompõe o jobId UUID para impedir que pendências antigas travem a fila da etapa. */
     private String resolveJobId(String productKey) {
         return pipelineDossieProdutoRepository
                 .findTopByIdExternoAndCodigoEtapaOrderByDataHoraDescIdDesc(productKey, STAGE_CODE)
                 .map(PipelineDossieProduto::getJobId)
-                .orElseThrow(() -> new IllegalStateException(
-                        "JobId do dossiê MOIS não encontrado para produto " + productKey + " na etapa " + STAGE_CODE));
+                .filter(jobId -> jobId != null && !jobId.isBlank())
+                .orElseGet(() -> rebuildJobId(productKey));
+    }
+
+    /** Cria auditoria mínima com jobId novo quando existe pendência legada sem registro rastreável. */
+    private String rebuildJobId(String productKey) {
+        String jobId = UUID.randomUUID().toString();
+        PipelineDossieProduto pipeline = new PipelineDossieProduto();
+        pipeline.setIdExterno(productKey);
+        pipeline.setCodigoEtapa(STAGE_CODE);
+        pipeline.setDataHora(Instant.now());
+        pipeline.setJobId(jobId);
+        pipeline.setVersaoPipeline("v1");
+        pipelineDossieProdutoRepository.save(pipeline);
+        return jobId;
     }
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossieproduto/v1/warmupresourcediscovery/service/DossierWarmupResourceDiscoveryService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossieproduto/v1/warmupresourcediscovery/service/DossierWarmupResourceDiscoveryService.java
@@ -156,12 +156,25 @@ public class DossierWarmupResourceDiscoveryService {
                 .toList();
         return new DossierWarmupResourceDiscoveryPendingResponse(!jobs.isEmpty(), jobs);
     }
-    /** Recupera o jobId UUID criado no start para compor o contrato pending da etapa. */
+    /** Recupera ou recompõe o jobId UUID para impedir que pendências antigas travem a fila da etapa. */
     private String resolveJobId(String productKey) {
         return pipelineDossieProdutoRepository
                 .findTopByIdExternoAndCodigoEtapaOrderByDataHoraDescIdDesc(productKey, STAGE_CODE)
                 .map(PipelineDossieProduto::getJobId)
-                .orElseThrow(() -> new IllegalStateException(
-                        "JobId do dossiê MOIS não encontrado para produto " + productKey + " na etapa " + STAGE_CODE));
+                .filter(jobId -> jobId != null && !jobId.isBlank())
+                .orElseGet(() -> rebuildJobId(productKey));
+    }
+
+    /** Cria auditoria mínima com jobId novo quando existe pendência legada sem registro rastreável. */
+    private String rebuildJobId(String productKey) {
+        String jobId = UUID.randomUUID().toString();
+        PipelineDossieProduto pipeline = new PipelineDossieProduto();
+        pipeline.setIdExterno(productKey);
+        pipeline.setCodigoEtapa(STAGE_CODE);
+        pipeline.setDataHora(Instant.now());
+        pipeline.setJobId(jobId);
+        pipeline.setVersaoPipeline("v1");
+        pipelineDossieProdutoRepository.save(pipeline);
+        return jobId;
     }
 }

--- a/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossieproduto/v1/warmupsignalextraction/service/DossierWarmupSignalExtractionService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/moissaleslibraryworker/pipelines/dossieproduto/v1/warmupsignalextraction/service/DossierWarmupSignalExtractionService.java
@@ -156,12 +156,25 @@ public class DossierWarmupSignalExtractionService {
                 .toList();
         return new DossierWarmupSignalExtractionPendingResponse(!jobs.isEmpty(), jobs);
     }
-    /** Recupera o jobId UUID criado no start para compor o contrato pending da etapa. */
+    /** Recupera ou recompõe o jobId UUID para impedir que pendências antigas travem a fila da etapa. */
     private String resolveJobId(String productKey) {
         return pipelineDossieProdutoRepository
                 .findTopByIdExternoAndCodigoEtapaOrderByDataHoraDescIdDesc(productKey, STAGE_CODE)
                 .map(PipelineDossieProduto::getJobId)
-                .orElseThrow(() -> new IllegalStateException(
-                        "JobId do dossiê MOIS não encontrado para produto " + productKey + " na etapa " + STAGE_CODE));
+                .filter(jobId -> jobId != null && !jobId.isBlank())
+                .orElseGet(() -> rebuildJobId(productKey));
+    }
+
+    /** Cria auditoria mínima com jobId novo quando existe pendência legada sem registro rastreável. */
+    private String rebuildJobId(String productKey) {
+        String jobId = UUID.randomUUID().toString();
+        PipelineDossieProduto pipeline = new PipelineDossieProduto();
+        pipeline.setIdExterno(productKey);
+        pipeline.setCodigoEtapa(STAGE_CODE);
+        pipeline.setDataHora(Instant.now());
+        pipeline.setJobId(jobId);
+        pipeline.setVersaoPipeline("v1");
+        pipelineDossieProdutoRepository.save(pipeline);
+        return jobId;
     }
 }

--- a/docs/registros/mois1.md
+++ b/docs/registros/mois1.md
@@ -1883,3 +1883,7 @@ Arquivos principais:
 
 - Ajustados os controllers do backend `moissaleslibraryworker.dossieproduto.v1` para expor os endpoints internos com domínio `moissaleslibraryworker`, etapa na URL e `idExterno` como identificador operacional no caminho.
 - Atualizada a documentação Swagger do dossiê para refletir `start`, `recebeRequest`, `recebeResponse` e `pending` no novo padrão canônico solicitado.
+
+## 2026-06-27 — Destravamento da fila do dossiê MOIS v1
+- Diagnosticado que o dossiê do produto 286 (`Vértuz App`) estava iniciado em `product-understanding`, mas a fila canônica da etapa retornava erro 500 antes de entregar trabalhos ao executor por causa de uma pendência legada do produto 329 sem `jobId` auditável.
+- Corrigida a causa-raiz no backend: os endpoints `pending` do pipeline `dossieproduto.v1` agora recompõem um `jobId` UUID com auditoria mínima quando encontram pendências antigas sem registro rastreável, evitando que um item legado bloqueie os demais produtos da fila.


### PR DESCRIPTION
### Motivation
- Resolver bloqueio observado na fila do pipeline de dossiê MOIS v1 onde pendências legadas sem `jobId` auditável causavam erro 500 e impediam entrega de trabalhos ao worker.
- Garantir que itens antigos sem auditoria não travem a execução do pipeline e permitir retomada/consumo das demais entradas na fila.

### Description
- Alterados os endpoints `pending` das etapas do pipeline `dossieproduto.v1` para recompor `jobId` quando não for encontrado ou for nulo/vazio, removendo a exceção que travava a fila (`resolveJobId` agora tenta `rebuildJobId`).
- Implementada a função `rebuildJobId` em todas as services das etapas (`intake`, `product-understanding`, `source-product-match`, `investigation-anchor-builder`, `warmup-resource-discovery`, `warmup-signal-extraction`, `warmup-map-builder`, `dossier-synthesis`) que cria um `jobId` UUID e persiste uma entrada mínima em `pipeline_dossieproduto` para auditoria.
- Atualizado o registro operacional em `docs/registros/mois1.md` com diagnóstico e a correção aplicada para o produto `286 (Vértuz App)`.

### Testing
- Compilação do backend com `mvn -DskipTests compile` foi executada com sucesso (BUILD SUCCESS).
- Tentativa de rodar `./mvnw -pl ads-service -DskipTests compile` falhou por não existir `mvnw` neste nível do workspace (comando incorreto para a estrutura atual).
- Observação: os testes unitários não foram executados neste rollout (compilação feita com `-DskipTests`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a400a32e0b48321b756d427b28c8d8b)