### PR TITLE
Qualify CNAE input with description for cnae-intake and enforce it in processor

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/cnaeintake/controller/BackendCnaeIntakeController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/cnaeintake/controller/BackendCnaeIntakeController.java
@@ -44,7 +44,7 @@ public class BackendCnaeIntakeController {
     /** Cria a primeira execução v3 diretamente a partir de um CNAE. */
     @PostMapping("/cnaes/{cnaeCode}")
     public CnaeIntakeCreateResponse createForCnae(@PathVariable String cnaeCode) {
-        return service.create(null, cnaeCode, "{\"cnaeCode\":\"" + cnaeCode + "\"}", 1, 1);
+        return service.createForCnae(cnaeCode);
     }
 
     /** Recebe o request bruto da etapa identificado pelo CNAE e jobId. */

--- a/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/cnaeintake/service/BackendCnaeIntakeService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/cnaeintake/service/BackendCnaeIntakeService.java
@@ -36,7 +36,12 @@ public class BackendCnaeIntakeService extends OprmNichoCnaeV3StageServiceSupport
     /** Inicia pendência da etapa para o CNAE informado pela tela administrativa. */
     public CnaeIntakeCreateResponse start(String cnaeCode) {
         markCnaePipelineStarted(cnaeCode, STATUS_STARTED);
-        return create(null, cnaeCode, "{\"cnaeCode\":\"" + cnaeCode + "\"}", 1, 1);
+        return createForCnae(cnaeCode);
+    }
+
+    /** Cria a pendência inicial qualificada com código e nome completo do CNAE. */
+    public CnaeIntakeCreateResponse createForCnae(String cnaeCode) {
+        return create(null, cnaeCode, cnaeInputPayload(cnaeCode), 1, 1);
     }
 
     /** Recebe o request bruto da etapa e registra auditoria para o pipeline NichoCNAE v3. */

--- a/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/shared/OprmNichoCnaeV3StageServiceSupport.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/oprmcoletormei/nichocnae/v3/shared/OprmNichoCnaeV3StageServiceSupport.java
@@ -1,5 +1,8 @@
 package com.marketinghub.oprmcoletormei.nichocnae.v3.shared;
 
+import com.fasterxml.jackson.core.JsonProcessingException;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.node.ObjectNode;
 import com.marketinghub.oprmcoletormei.nichocnae.v3.OprmNichoCnaeV3StageExecution;
 import com.marketinghub.oprmcoletormei.nichocnae.v3.OprmNichoCnaeV3StageExecutionStatus;
 import com.marketinghub.oprm.market.OprmCnpjCnaeDim;
@@ -41,6 +44,7 @@ public abstract class OprmNichoCnaeV3StageServiceSupport {
     private final OprmCnpjCnaeDimRepository cnaeRepository;
     private final PipelineNichoCnaeRepository pipelineNichoCnaeRepository;
     private final String stageCode;
+    private final ObjectMapper objectMapper = new ObjectMapper();
 
     /** Inicializa o suporte com repository canônico e código da etapa. */
     protected OprmNichoCnaeV3StageServiceSupport(
@@ -165,7 +169,14 @@ public abstract class OprmNichoCnaeV3StageServiceSupport {
 
     /** Monta payload mínimo de entrada para um CNAE pendente quando não houver execução persistida. */
     protected String cnaeInputPayload(OprmCnpjCnaeDim cnae) {
-        return "{\"cnaeCode\":\"" + cnae.getCnaeCode() + "\"}";
+        return buildCnaeInputPayload(cnae.getCnaeCode(), cnae.getDescription());
+    }
+
+    /** Monta payload de entrada com nome completo a partir do cadastro canônico do CNAE. */
+    protected String cnaeInputPayload(String cnaeCode) {
+        OprmCnpjCnaeDim cnae = cnaeRepository.findById(cnaeCode)
+                .orElseThrow(() -> new ResponseStatusException(HttpStatus.NOT_FOUND, "CNAE não encontrado."));
+        return cnaeInputPayload(cnae);
     }
 
     /** Monta jobId estável para uma pendência publicada diretamente pelo cadastro de CNAE. */
@@ -213,6 +224,24 @@ public abstract class OprmNichoCnaeV3StageServiceSupport {
         next.setKnowledgeVersion(current.getKnowledgeVersion());
         repository.save(next);
         return true;
+    }
+
+    /** Monta o JSON canônico com código e nome completo do CNAE. */
+    private String buildCnaeInputPayload(String cnaeCode, String cnaeDescription) {
+        ObjectNode root = objectMapper.createObjectNode();
+        root.put("cnaeCode", cnaeCode);
+        root.put("cnaeDescription", cnaeDescription);
+        try {
+            return objectMapper.writeValueAsString(root);
+        } catch (JsonProcessingException ex) {
+            return inputPayloadFallback(cnaeCode, cnaeDescription);
+        }
+    }
+
+    /** Monta fallback textual seguro para o JSON de CNAE quando a serialização falhar. */
+    private String inputPayloadFallback(String cnaeCode, String cnaeDescription) {
+        String safeDescription = cnaeDescription == null ? "" : cnaeDescription.replace("\\", "\\\\").replace("\"", "\\\"");
+        return "{\"cnaeCode\":\"" + cnaeCode + "\",\"cnaeDescription\":\"" + safeDescription + "\"}";
     }
 
     /** Normaliza o código de etapa para comparação e persistência canônica. */

--- a/backend/ads-service/src/test/java/com/marketinghub/oprmcoletormei/nichocnae/v3/cnaeintake/service/BackendCnaeIntakeServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/oprmcoletormei/nichocnae/v3/cnaeintake/service/BackendCnaeIntakeServiceTest.java
@@ -57,8 +57,25 @@ class BackendCnaeIntakeServiceTest {
         assertThat(cnae.getNichocnaePipelineUpdatedAt()).isNotNull();
         ArgumentCaptor<OprmNichoCnaeV3StageExecution> executionCaptor = ArgumentCaptor.forClass(OprmNichoCnaeV3StageExecution.class);
         verify(repository, times(2)).save(executionCaptor.capture());
-        assertThat(executionCaptor.getAllValues().get(1).getStageCode()).isEqualTo("persona-candidate-generator");
+        OprmNichoCnaeV3StageExecution nextExecution = executionCaptor.getAllValues().get(1);
+        assertThat(nextExecution.getStageCode()).isEqualTo("persona-candidate-generator");
+        assertThat(nextExecution.getInputPayload()).isEqualTo("{\"ok\":true}");
         verify(cnaeRepository).save(cnae);
+    }
+
+    /** Garante que a etapa inicial nasce com o nome completo do CNAE no input funcional. */
+    @Test
+    void startCreatesQualifiedCnaeInputPayload() {
+        OprmCnpjCnaeDim cnae = cnae();
+        when(cnaeRepository.findById("4781400")).thenReturn(Optional.of(cnae));
+        when(repository.save(any(OprmNichoCnaeV3StageExecution.class))).thenAnswer(invocation -> invocation.getArgument(0));
+
+        service.start("4781400");
+
+        ArgumentCaptor<OprmNichoCnaeV3StageExecution> executionCaptor = ArgumentCaptor.forClass(OprmNichoCnaeV3StageExecution.class);
+        verify(repository).save(executionCaptor.capture());
+        assertThat(executionCaptor.getValue().getStageCode()).isEqualTo("cnae-intake");
+        assertThat(executionCaptor.getValue().getInputPayload()).contains("\"cnaeDescription\":\"Comércio varejista de artigos do vestuário\"");
     }
 
     /** Monta uma execução pendente da etapa inicial. */

--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -1,3 +1,8 @@
+## 2026-06-27 — OPRM NichoCNAE v3: etapa 1 qualifica o CNAE antes da geração de personas
+
+- Corrigida a causa-raiz da entrada da etapa `persona-candidate-generator`: a etapa `cnae-intake` agora nasce com `cnaeCode` e `cnaeDescription` vindos da dimensão canônica de CNAE e devolve esses campos na própria saída funcional.
+- Prevenção de recorrência: testes unitários garantem que a etapa 1 bloqueia avanço sem `cnaeDescription` e que o backend cria a pendência inicial já qualificada com o nome completo do CNAE.
+
 ## 2026-06-23 — OPRM NichoCNAE v2: download de relatório do job concluído
 
 - Ajustada a tela do pipeline por CNAE para permitir baixar, em cada job concluído, um relatório Markdown com etapas executadas, entradas, saídas, processamento, falhas e próximos passos persistidos pelo backend.

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/pipelines/nichocnae/v3/cnaeintake/CnaeIntakeProcessor.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/pipelines/nichocnae/v3/cnaeintake/CnaeIntakeProcessor.java
@@ -13,15 +13,27 @@ public final class CnaeIntakeProcessor implements StageProcessor {
     /** Executa a etapa cnae-intake produzindo saída estruturada para o backend decidir avanço. */
     @Override
     public StageResult process(StageContext context) {
+        String cnaeCode = requiredText(context.input().get("cnaeCode"), "cnaeCode");
+        String cnaeDescription = requiredText(context.input().get("cnaeDescription"), "cnaeDescription");
         Map<String, Object> output = new LinkedHashMap<>();
         output.put("stage", "cnae-intake");
         output.put("status", "CNAE_RECEBIDO");
         output.put("jobId", context.jobId());
         output.put("stageExecutionId", context.stageExecutionId());
+        output.put("cnaeCode", cnaeCode);
+        output.put("cnaeDescription", cnaeDescription);
         output.put("inputKeys", context.input().keySet());
         output.put("businessBoundary", "NAO_GERAR_OFERTA_CAMPANHA_LANDING");
         output.put("reportRole", "PERSONA_ROTINA_TAREFAS_DIARIAS");
         output.put("nextStageCode", "persona-candidate-generator");
-        return new StageResult("CNAE_RECEBIDO", output, List.of(new StageArtifact("CNAE_RECEBIDO", "inline://nichocnae-v3/cnae-intake", "Etapa cnae-intake concluída com contrato estruturado.")));
+        return new StageResult("CNAE_RECEBIDO", output, List.of(new StageArtifact("CNAE_RECEBIDO", "inline://nichocnae-v3/cnae-intake", "Etapa cnae-intake concluída com CNAE qualificado para geração de personas.")));
+    }
+
+    /** Extrai texto obrigatório do payload de entrada para impedir avanço sem contexto mínimo. */
+    private String requiredText(Object value, String fieldName) {
+        if (value == null || value.toString().isBlank()) {
+            throw new IllegalStateException("Etapa cnae-intake exige " + fieldName + " para qualificar a entrada do pipeline.");
+        }
+        return value.toString();
     }
 }

--- a/oprm-coletor-mei/src/test/java/com/marketinghub/pipelines/nichocnae/v3/cnaeintake/CnaeIntakeProcessorTest.java
+++ b/oprm-coletor-mei/src/test/java/com/marketinghub/pipelines/nichocnae/v3/cnaeintake/CnaeIntakeProcessorTest.java
@@ -1,0 +1,40 @@
+package com.marketinghub.pipelines.nichocnae.v3.cnaeintake;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.marketinghub.pipelines.nichocnae.v3.core.StageContext;
+import com.marketinghub.pipelines.nichocnae.v3.core.StageResult;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/** Valida a qualificação inicial do CNAE no pipeline NichoCNAE v3. */
+class CnaeIntakeProcessorTest {
+    /** Garante que a etapa 1 entrega código e nome completo do CNAE para a geração de personas. */
+    @Test
+    void shouldQualifyCnaeBeforePersonaGeneration() {
+        CnaeIntakeProcessor processor = new CnaeIntakeProcessor();
+
+        StageResult result = processor.process(new StageContext(
+                "job-4781400",
+                "107",
+                Map.of("cnaeCode", "4781400", "cnaeDescription", "Comércio varejista de artigos do vestuário")));
+
+        assertThat(result.status()).isEqualTo("CNAE_RECEBIDO");
+        assertThat(result.output()).containsEntry("cnaeCode", "4781400");
+        assertThat(result.output()).containsEntry("cnaeDescription", "Comércio varejista de artigos do vestuário");
+        assertThat(result.output()).containsEntry("businessBoundary", "NAO_GERAR_OFERTA_CAMPANHA_LANDING");
+        assertThat(result.output()).containsEntry("reportRole", "PERSONA_ROTINA_TAREFAS_DIARIAS");
+        assertThat(result.output()).containsEntry("nextStageCode", "persona-candidate-generator");
+    }
+
+    /** Bloqueia avanço quando a entrada inicial ainda não tem o nome completo do CNAE. */
+    @Test
+    void shouldFailWithoutCnaeDescription() {
+        CnaeIntakeProcessor processor = new CnaeIntakeProcessor();
+
+        assertThatThrownBy(() -> processor.process(new StageContext("job-4781400", "107", Map.of("cnaeCode", "4781400"))))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("cnaeDescription");
+    }
+}


### PR DESCRIPTION
### Motivation
- Prevent downstream stages from running without the canonical CNAE name by ensuring the `cnae-intake` stage produces and persists both `cnaeCode` and `cnaeDescription` and by blocking advancement when the description is missing. 
- Simplify controller/service flow so admin-triggered starts and programmatic creates produce a qualified input payload derived from the canonical CNAE dimension.

### Description
- Controller change: `BackendCnaeIntakeController#createForCnae` now delegates to `BackendCnaeIntakeService#createForCnae` instead of inlining a minimal JSON payload. 
- Service changes: added `createForCnae` and updated `start` to use it so initial executions are created with a qualified CNAE payload; `create` remains for chained/encapsulated creation. 
- Shared support: `OprmNichoCnaeV3StageServiceSupport` now uses an `ObjectMapper`, exposes `cnaeInputPayload(String)` which loads the canonical `OprmCnpjCnaeDim`, and builds a JSON payload via `buildCnaeInputPayload` with a safe string `inputPayloadFallback` for serialization failures. 
- Collector/processor: `CnaeIntakeProcessor` now requires both `cnaeCode` and `cnaeDescription`, includes them in the structured output, and will throw when `cnaeDescription` is missing; the success artifact message was updated to reflect CNAE qualification. 
- Docs: changelog entry added describing the behavior change. 
- Tests: updated `BackendCnaeIntakeServiceTest` to assert the qualified `inputPayload` contains the CNAE description and added `CnaeIntakeProcessorTest` to validate happy path and missing-description failure.

### Testing
- Ran unit tests with `mvn test` including `BackendCnaeIntakeServiceTest` which asserts the generated execution input contains `"cnaeDescription"`, and the test passed. 
- Added and ran `CnaeIntakeProcessorTest` which verifies output contains `cnaeCode`/`cnaeDescription` and that missing `cnaeDescription` fails, and the test passed. 
- All module unit tests executed in the change set completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a400ac563b08321b8889a9dd92110dd)