### PR TITLE
NichoCNAE v3: add MEI/autônomo recorte in intake and produce actionable search plan in routine-query-planner (with tests)

### DIFF
--- a/docs/registros/oprm1.md
+++ b/docs/registros/oprm1.md
@@ -1598,3 +1598,15 @@
 - Atualizados os controllers backend de `com.marketinghub.oprmcoletormei.nichocnae.v3` para expor o prefixo canônico `/api/internal/oprmcoletormei/nichocnae/v3/<etapa>/stage-executions`.
 - Padronizados os callbacks operacionais para `/{idExterno}/start`, `/{idExterno}/{jobId}/recebeRequest`, `/{idExterno}/{jobId}/recebeResponse` e `POST /pending`.
 - Sincronizados o Swagger e o cliente do executor `oprm-coletor-mei` para consumir o novo contrato.
+
+## 2026-06-27 — NichoCNAE v3: saída útil da etapa 4
+
+- Causa-raiz confirmada no executor: `RoutineQueryPlannerProcessor` encerrava a etapa `routine-query-planner` com metadados técnicos (`stage`, `status`, `inputKeys`) e não transformava a persona vencedora em um plano de busca acionável.
+- Correção: a etapa 4 agora exige `winnerPersona` e gera `personaFocus`, objetivo de busca, consultas priorizadas, perguntas de validação, critérios de aceite de fonte e critérios de descarte antes de avançar para `source-searcher`.
+- Prevenção: adicionado teste unitário garantindo que a saída contenha plano útil e bloqueie execução sem persona vencedora.
+
+## 2026-06-27 — NichoCNAE v3: recorte MEI/autônomo na etapa 1
+
+- Ajuste: a saída da etapa `cnae-intake` agora explicita que o pipeline está analisando MEI e profissionais autônomos que atuam por conta própria, sem contratação direta como CLT.
+- Motivo: esse recorte precisa nascer na primeira etapa para orientar a geração de personas e evitar que as próximas etapas pesquisem funcionários CLT de empresas do CNAE.
+- Prevenção: teste unitário da etapa 1 passou a validar `targetAudienceType`, `targetAudienceDefinition` e `employmentBoundary`.

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/pipelines/nichocnae/v3/cnaeintake/CnaeIntakeProcessor.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/pipelines/nichocnae/v3/cnaeintake/CnaeIntakeProcessor.java
@@ -10,7 +10,7 @@ import java.util.Map;
 
 /** Processa a etapa cnae-intake do pipeline NichoCNAE v3. */
 public final class CnaeIntakeProcessor implements StageProcessor {
-    /** Executa a etapa cnae-intake produzindo saída estruturada para o backend decidir avanço. */
+    /** Executa a etapa cnae-intake qualificando o CNAE e o público MEI/autônomo antes de gerar personas. */
     @Override
     public StageResult process(StageContext context) {
         String cnaeCode = requiredText(context.input().get("cnaeCode"), "cnaeCode");
@@ -22,6 +22,9 @@ public final class CnaeIntakeProcessor implements StageProcessor {
         output.put("stageExecutionId", context.stageExecutionId());
         output.put("cnaeCode", cnaeCode);
         output.put("cnaeDescription", cnaeDescription);
+        output.put("targetAudienceType", "MEI_PROFISSIONAIS_AUTONOMOS_NAO_CLT");
+        output.put("targetAudienceDefinition", "Estamos falando de MEI e profissionais autônomos que atuam por conta própria, sem contratação direta como CLT.");
+        output.put("employmentBoundary", "NAO_ANALISAR_FUNCIONARIOS_CLT_CONTRATADOS_DIRETAMENTE");
         output.put("inputKeys", context.input().keySet());
         output.put("businessBoundary", "NAO_GERAR_OFERTA_CAMPANHA_LANDING");
         output.put("reportRole", "PERSONA_ROTINA_TAREFAS_DIARIAS");

--- a/oprm-coletor-mei/src/main/java/com/marketinghub/pipelines/nichocnae/v3/routinequeryplanner/RoutineQueryPlannerProcessor.java
+++ b/oprm-coletor-mei/src/main/java/com/marketinghub/pipelines/nichocnae/v3/routinequeryplanner/RoutineQueryPlannerProcessor.java
@@ -4,24 +4,130 @@ import com.marketinghub.pipelines.nichocnae.v3.core.StageArtifact;
 import com.marketinghub.pipelines.nichocnae.v3.core.StageContext;
 import com.marketinghub.pipelines.nichocnae.v3.core.StageProcessor;
 import com.marketinghub.pipelines.nichocnae.v3.core.StageResult;
+import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
 
 /** Processa a etapa routine-query-planner do pipeline NichoCNAE v3. */
 public final class RoutineQueryPlannerProcessor implements StageProcessor {
-    /** Executa a etapa routine-query-planner produzindo saída estruturada para o backend decidir avanço. */
+    private static final String STATUS = "QUERIES_PLANEJADAS";
+    private static final int MAX_QUERY_ITEMS = 8;
+
+    /** Executa a etapa routine-query-planner produzindo consultas úteis para validar rotina, dor e esforço reais. */
     @Override
     public StageResult process(StageContext context) {
+        Map<String, Object> winnerPersona = winnerPersona(context.input());
+        String personaName = firstNonBlank(text(context.input().get("winningPersonaName")), text(winnerPersona.get("name")), "persona operacional priorizada");
+        List<String> dailyTasks = texts(winnerPersona.get("dailyTasks"));
+        List<String> operationalPains = texts(winnerPersona.get("operationalPains"));
+        List<String> buyingSignals = texts(winnerPersona.get("buyingSignals"));
+        List<Map<String, Object>> plannedQueries = plannedQueries(personaName, dailyTasks, operationalPains, buyingSignals);
+
         Map<String, Object> output = new LinkedHashMap<>();
         output.put("stage", "routine-query-planner");
-        output.put("status", "QUERIES_PLANEJADAS");
+        output.put("status", STATUS);
         output.put("jobId", context.jobId());
         output.put("stageExecutionId", context.stageExecutionId());
         output.put("inputKeys", context.input().keySet());
+        output.put("personaFocus", personaName);
+        output.put("searchObjective", "Encontrar evidências públicas da rotina real, tarefas recorrentes, dores operacionais e sinais de compra da persona vencedora antes de qualquer oferta.");
+        output.put("plannedQueries", plannedQueries);
+        output.put("validationQuestions", validationQuestions(personaName));
+        output.put("sourceAcceptanceCriteria", sourceAcceptanceCriteria());
+        output.put("discardCriteria", discardCriteria());
         output.put("businessBoundary", "NAO_GERAR_OFERTA_CAMPANHA_LANDING");
         output.put("reportRole", "PERSONA_ROTINA_TAREFAS_DIARIAS");
         output.put("nextStageCode", "source-searcher");
-        return new StageResult("QUERIES_PLANEJADAS", output, List.of(new StageArtifact("QUERIES_PLANEJADAS", "inline://nichocnae-v3/routine-query-planner", "Etapa routine-query-planner concluída com contrato estruturado.")));
+        return new StageResult(STATUS, output, List.of(new StageArtifact(STATUS, "inline://nichocnae-v3/routine-query-planner", "Plano de buscas priorizado para validar rotina, dores e esforço real da persona vencedora.")));
+    }
+
+    /** Recupera a persona vencedora gerada na etapa anterior. */
+    private Map<String, Object> winnerPersona(Map<String, Object> input) {
+        Object raw = input.get("winnerPersona");
+        if (!(raw instanceof Map<?, ?> map)) {
+            throw new IllegalStateException("Entrada de routine-query-planner não contém winnerPersona para planejar buscas úteis.");
+        }
+        Map<String, Object> normalized = new LinkedHashMap<>();
+        map.forEach((key, value) -> normalized.put(String.valueOf(key), value));
+        return normalized;
+    }
+
+    /** Monta consultas de busca acionáveis a partir das tarefas, dores e sinais da persona. */
+    private List<Map<String, Object>> plannedQueries(String personaName, List<String> dailyTasks, List<String> operationalPains, List<String> buyingSignals) {
+        List<Map<String, Object>> queries = new ArrayList<>();
+        addQueries(queries, personaName, dailyTasks, "TAREFA_DIARIA", "Validar tarefa recorrente e frequência operacional");
+        addQueries(queries, personaName, operationalPains, "DOR_OPERACIONAL", "Confirmar dor, esforço manual e consequência prática");
+        addQueries(queries, personaName, buyingSignals, "SINAL_DE_COMPRA", "Encontrar evidência de busca por solução, planilha, sistema, consultoria ou modelo pronto");
+        if (queries.isEmpty()) {
+            queries.add(queryItem(personaName + " rotina diária tarefas problemas", "ROTINA_BASE", "Validar rotina e problemas recorrentes quando a persona não trouxe sinais detalhados", 1));
+        }
+        return queries.stream().limit(MAX_QUERY_ITEMS).toList();
+    }
+
+    /** Adiciona consultas mantendo prioridade de acordo com a ordem da evidência recebida. */
+    private void addQueries(List<Map<String, Object>> queries, String personaName, List<String> evidences, String intent, String objective) {
+        for (String evidence : evidences) {
+            queries.add(queryItem(personaName + " " + evidence + " rotina problema frequência", intent, objective, queries.size() + 1));
+        }
+    }
+
+    /** Cria um item estruturado de consulta para a próxima etapa buscar fontes. */
+    private Map<String, Object> queryItem(String query, String intent, String objective, int priority) {
+        Map<String, Object> item = new LinkedHashMap<>();
+        item.put("priority", priority);
+        item.put("query", query);
+        item.put("intent", intent);
+        item.put("objective", objective);
+        item.put("expectedEvidence", List.of("relato de rotina", "tarefa concreta", "dor ou esforço", "frequência ou impacto"));
+        return item;
+    }
+
+    /** Define perguntas que a busca precisa responder para gerar valor comercial depois. */
+    private List<String> validationQuestions(String personaName) {
+        return List.of(
+                "Quais tarefas o " + personaName + " executa toda semana ou todo dia?",
+                "Onde há perda de tempo, retrabalho, erro, estoque parado, atendimento ruim ou controle manual?",
+                "Quais ferramentas, planilhas, sistemas ou serviços já são usados para reduzir esse esforço?",
+                "Que evidência mostra disposição de pagar por facilidade, organização ou economia de tempo?");
+    }
+
+    /** Define critérios mínimos para aceitar uma fonte na busca. */
+    private List<String> sourceAcceptanceCriteria() {
+        return List.of(
+                "fonte descreve rotina operacional real da persona",
+                "fonte cita tarefa, dor, frequência, consequência ou ferramenta usada",
+                "fonte permite extrair evidência sem criar oferta prematura");
+    }
+
+    /** Define o que deve ser descartado para evitar conteúdo inútil ou contaminado. */
+    private List<String> discardCriteria() {
+        return List.of(
+                "conteúdo genérico de marketing sem rotina concreta",
+                "oferta, campanha, landing page, promessa ou preço antes da etapa correta",
+                "fonte sem relação clara com a persona vencedora");
+    }
+
+    /** Converte uma lista opcional em textos limpos. */
+    private List<String> texts(Object value) {
+        if (!(value instanceof List<?> list)) {
+            return List.of();
+        }
+        return list.stream().map(this::text).filter(item -> !item.isBlank()).toList();
+    }
+
+    /** Escolhe o primeiro texto preenchido de uma lista de candidatos. */
+    private String firstNonBlank(String... values) {
+        for (String value : values) {
+            if (!value.isBlank()) {
+                return value;
+            }
+        }
+        return "persona operacional priorizada";
+    }
+
+    /** Converte valores opcionais em texto seguro. */
+    private String text(Object value) {
+        return value == null ? "" : String.valueOf(value).trim();
     }
 }

--- a/oprm-coletor-mei/src/test/java/com/marketinghub/pipelines/nichocnae/v3/cnaeintake/CnaeIntakeProcessorTest.java
+++ b/oprm-coletor-mei/src/test/java/com/marketinghub/pipelines/nichocnae/v3/cnaeintake/CnaeIntakeProcessorTest.java
@@ -10,7 +10,7 @@ import org.junit.jupiter.api.Test;
 
 /** Valida a qualificação inicial do CNAE no pipeline NichoCNAE v3. */
 class CnaeIntakeProcessorTest {
-    /** Garante que a etapa 1 entrega código e nome completo do CNAE para a geração de personas. */
+    /** Garante que a etapa 1 entrega código, nome do CNAE e recorte MEI/autônomo para a geração de personas. */
     @Test
     void shouldQualifyCnaeBeforePersonaGeneration() {
         CnaeIntakeProcessor processor = new CnaeIntakeProcessor();
@@ -23,6 +23,9 @@ class CnaeIntakeProcessorTest {
         assertThat(result.status()).isEqualTo("CNAE_RECEBIDO");
         assertThat(result.output()).containsEntry("cnaeCode", "4781400");
         assertThat(result.output()).containsEntry("cnaeDescription", "Comércio varejista de artigos do vestuário");
+        assertThat(result.output()).containsEntry("targetAudienceType", "MEI_PROFISSIONAIS_AUTONOMOS_NAO_CLT");
+        assertThat(result.output()).containsEntry("targetAudienceDefinition", "Estamos falando de MEI e profissionais autônomos que atuam por conta própria, sem contratação direta como CLT.");
+        assertThat(result.output()).containsEntry("employmentBoundary", "NAO_ANALISAR_FUNCIONARIOS_CLT_CONTRATADOS_DIRETAMENTE");
         assertThat(result.output()).containsEntry("businessBoundary", "NAO_GERAR_OFERTA_CAMPANHA_LANDING");
         assertThat(result.output()).containsEntry("reportRole", "PERSONA_ROTINA_TAREFAS_DIARIAS");
         assertThat(result.output()).containsEntry("nextStageCode", "persona-candidate-generator");

--- a/oprm-coletor-mei/src/test/java/com/marketinghub/pipelines/nichocnae/v3/routinequeryplanner/RoutineQueryPlannerProcessorTest.java
+++ b/oprm-coletor-mei/src/test/java/com/marketinghub/pipelines/nichocnae/v3/routinequeryplanner/RoutineQueryPlannerProcessorTest.java
@@ -1,0 +1,49 @@
+package com.marketinghub.pipelines.nichocnae.v3.routinequeryplanner;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import com.marketinghub.pipelines.nichocnae.v3.core.StageContext;
+import com.marketinghub.pipelines.nichocnae.v3.core.StageResult;
+import java.util.List;
+import java.util.Map;
+import org.junit.jupiter.api.Test;
+
+/** Valida o planejamento útil de buscas da rotina no pipeline NichoCNAE v3. */
+class RoutineQueryPlannerProcessorTest {
+    /** Garante que a saída da etapa quatro contenha buscas acionáveis para validar rotina, dor e esforço real. */
+    @Test
+    void shouldCreateUsefulSearchPlanFromWinnerPersona() {
+        RoutineQueryPlannerProcessor processor = new RoutineQueryPlannerProcessor();
+
+        StageResult result = processor.process(new StageContext("job-4781400", "137", Map.of(
+                "winningPersonaName", "Gerente de loja em rede pequena",
+                "winnerPersona", Map.of(
+                        "name", "Gerente de loja em rede pequena",
+                        "dailyTasks", List.of("conferir estoque", "acompanhar metas"),
+                        "operationalPains", List.of("ruptura de estoque", "retrabalho em planilhas"),
+                        "buyingSignals", List.of("procura sistema simples")))));
+
+        assertThat(result.status()).isEqualTo("QUERIES_PLANEJADAS");
+        assertThat(result.output()).containsEntry("nextStageCode", "source-searcher");
+        assertThat(result.output()).containsEntry("personaFocus", "Gerente de loja em rede pequena");
+        assertThat(result.output()).containsKeys("searchObjective", "plannedQueries", "validationQuestions", "sourceAcceptanceCriteria", "discardCriteria");
+        List<?> plannedQueries = (List<?>) result.output().get("plannedQueries");
+        assertThat(plannedQueries).hasSize(5);
+        assertThat(plannedQueries.getFirst()).asString().contains("conferir estoque");
+        @SuppressWarnings("unchecked")
+        Map<String, Object> firstQuery = (Map<String, Object>) plannedQueries.getFirst();
+        assertThat(firstQuery).containsEntry("intent", "TAREFA_DIARIA");
+        assertThat(firstQuery).containsKeys("query", "objective", "expectedEvidence", "priority");
+    }
+
+    /** Bloqueia uma saída genérica quando a etapa anterior não trouxe a persona vencedora. */
+    @Test
+    void shouldFailWithoutWinnerPersona() {
+        RoutineQueryPlannerProcessor processor = new RoutineQueryPlannerProcessor();
+
+        assertThatThrownBy(() -> processor.process(new StageContext("job-1", "137", Map.of("winningPersonaName", "persona"))))
+                .isInstanceOf(IllegalStateException.class)
+                .hasMessageContaining("winnerPersona");
+    }
+}


### PR DESCRIPTION
### Motivation

- Ensure the pipeline explicitly scopes CNAE processing to MEI and autonomous (non-CLT) workers early to guide persona generation and later searches. 
- Fix a root cause where `routine-query-planner` closed the stage with only technical metadata and did not produce an actionable search plan from the winning persona.
- Keep executor outputs structured so downstream `source-searcher` can run prioritized, validated searches and avoid producing offers prematurely.

### Description

- Updated `CnaeIntakeProcessor` to add `targetAudienceType`, `targetAudienceDefinition` and `employmentBoundary` to the stage output and adjusted the stage javadoc to reflect the MEI/autônomo recorte. 
- Implemented `RoutineQueryPlannerProcessor` enhancements to require `winnerPersona`, derive `personaFocus`, assemble `plannedQueries` (prioritized and limited), produce `searchObjective`, `validationQuestions`, `sourceAcceptanceCriteria`, and `discardCriteria`, and fail if `winnerPersona` is missing. 
- Added unit test `RoutineQueryPlannerProcessorTest` validating actionable query items, persona focus, and failure without `winnerPersona`, and extended `CnaeIntakeProcessorTest` to assert the new MEI-related output fields. 
- Updated documentation `docs/registros/oprm1.md` changelog to describe the fixes: stage 4 producing useful output and stage 1 MEI/autônomo recorte.

### Testing

- Ran unit tests for `CnaeIntakeProcessorTest` which assert CNAE fields and the new `targetAudience*`/`employmentBoundary` outputs and they passed. 
- Added and ran `RoutineQueryPlannerProcessorTest` which verifies `QUERIES_PLANEJADAS` output, `plannedQueries` contents and behavior when `winnerPersona` is missing, and it passed. 
- No integration or backend changes were made and existing pipeline contracts remain compatible with the executor's `pending`/callback flows.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a402c71bbe88321afdbaa99f022baff)