### PR TITLE
Enforce Meta Ads character limits for ad copy schema and prompt

### DIFF
--- a/ai-worker/src/main/resources/prompts/experiment/ad-copy.md
+++ b/ai-worker/src/main/resources/prompts/experiment/ad-copy.md
@@ -28,10 +28,11 @@ Regras fixas da etapa:
 9. `lengthVariants.curta` deve ser direta e rápida para mobile.
 10. `lengthVariants.media` deve explicar a promessa com mecanismo e CTA.
 11. `lengthVariants.longa` deve aprofundar dor, resultado, mecanismo, prova e ação sem virar texto de landing.
-12. `headline` deve ser curta, clara e específica, sem promessa absoluta.
-13. `description` deve apoiar a headline com benefício concreto e baixo atrito.
-14. `ctaText` deve repetir a ação principal do `campaignAngle`, sem inventar ação nova.
-15. `primaryText` deve ser a melhor versão pronta para uso no anúncio, derivada das variações de tamanho.
+12. `primaryText` é o texto final que será salvo e publicado no campo Primary text do Meta Ads; deve ter no máximo 125 caracteres.
+12.1. As variações em `lengthVariants` são apenas apoio criativo; se alguma passar de 125 caracteres, reescreva `primaryText` como síntese curta, sem copiar a versão longa.
+13. `headline` deve ser curta, clara e específica, sem promessa absoluta, com no máximo 40 caracteres.
+14. `description` deve apoiar a headline com benefício concreto e baixo atrito, com no máximo 25 caracteres.
+15. `ctaText` deve repetir a ação principal do `campaignAngle`, sem inventar ação nova.
 16. Não prometa consultoria, call, acompanhamento humano, diagnóstico individualizado ou gestão manual se isso não estiver no envelope real do produto.
 17. Não use promessas absolutas, garantias individuais, linguagem de enriquecimento rápido ou alegações impossíveis de comprovar.
 18. Não crie campos técnicos, comentários internos, instruções de pipeline ou metadados fora do contrato final.
@@ -55,3 +56,4 @@ Checklist antes de responder:
 3. A copy evita promessa absoluta e promessa individual?
 4. A copy evita consultoria/call/acompanhamento se não fizer parte do produto?
 5. O JSON final contém somente `adCopy` e `experimentMetadata` na raiz?
+6. Cada `primaryText` tem até 125 caracteres, cada `headline` até 40 caracteres e cada `description` até 25 caracteres?

--- a/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationService.java
@@ -103,6 +103,9 @@ public class ExperimentPipelineGenerationService {
             ExperimentPipelineGenerationJobStatus.PENDING,
             ExperimentPipelineGenerationJobStatus.PROCESSING);
     private static final int PREVIOUS_REJECTED_EXPERIMENTS_LIMIT = 4;
+    private static final int META_AD_PRIMARY_TEXT_MAX_LENGTH = 125;
+    private static final int META_AD_HEADLINE_MAX_LENGTH = 40;
+    private static final int META_AD_DESCRIPTION_MAX_LENGTH = 25;
     private static final FacebookCampaignStopReason FORM_ZERO_REJECTION_REASON =
             FacebookCampaignStopReason.FORM_ZERO_CONVERSION_RULE_OF_THREE;
     private static final Set<ExperimentStatus> PIPELINE_ELIGIBLE_EXPERIMENT_STATUSES = Set.of(
@@ -2939,9 +2942,15 @@ public class ExperimentPipelineGenerationService {
                                                         ),
                                                         "required", List.of("curta", "media", "longa")
                                                 ),
-                                                "primaryText", Map.of("type", "string"),
-                                                "headline", Map.of("type", "string"),
-                                                "description", Map.of("type", "string"),
+                                                "primaryText", metaAdStringSchema(
+                                                        META_AD_PRIMARY_TEXT_MAX_LENGTH,
+                                                        "Texto principal do anúncio Meta Ads, limitado para evitar truncamento em mobile."),
+                                                "headline", metaAdStringSchema(
+                                                        META_AD_HEADLINE_MAX_LENGTH,
+                                                        "Headline do anúncio Meta Ads."),
+                                                "description", metaAdStringSchema(
+                                                        META_AD_DESCRIPTION_MAX_LENGTH,
+                                                        "Descrição curta de apoio do anúncio Meta Ads."),
                                                 "ctaText", Map.of("type", "string"),
                                                 "compliance", Map.of(
                                                         "type", "object",
@@ -2962,6 +2971,7 @@ public class ExperimentPipelineGenerationService {
                                                 "openingHookType",
                                                 "placementHint",
                                                 "lengthVariants",
+                                                "primaryText",
                                                 "headline",
                                                 "description",
                                                 "ctaText",
@@ -4313,6 +4323,11 @@ public class ExperimentPipelineGenerationService {
     /** Cria um schema de string com descrição comercial para orientar respostas detalhadas em modo estrito. */
     private Map<String, Object> detailedStringSchema(String description) {
         return Map.of("type", "string", "description", description);
+    }
+
+    /** Cria um schema textual com limite máximo aderente aos campos recomendados do Meta Ads. */
+    private Map<String, Object> metaAdStringSchema(int maxLength, String description) {
+        return Map.of("type", "string", "maxLength", maxLength, "description", description);
     }
 
     private Map<String, Object> stringSchema() {

--- a/backend/ads-service/src/test/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationServiceTest.java
+++ b/backend/ads-service/src/test/java/com/marketinghub/experiment/pipeline/service/ExperimentPipelineGenerationServiceTest.java
@@ -544,6 +544,41 @@ class ExperimentPipelineGenerationServiceTest {
     }
 
     @Test
+    void generateAdCopyLimitsMetaAdsTextFieldsInJsonSchema() {
+        Experiment experiment = new Experiment();
+        experiment.setId(133L);
+        experiment.setName("Experimento 133");
+        experiment.setCampaignAngle("{\"campaignAngle\":true}");
+
+        when(experimentRepository.findById(133L)).thenReturn(Optional.of(experiment));
+        when(jobRepository.findByExperimentIdAndStatusInOrderByCreatedAtDesc(
+                133L,
+                Set.of(ExperimentPipelineGenerationJobStatus.PENDING, ExperimentPipelineGenerationJobStatus.PROCESSING)))
+                .thenReturn(List.of());
+        when(jobRepository.findLatestCompletedPerSectionByExperimentId(133L, null))
+                .thenReturn(List.of(completedJob(
+                        experiment,
+                        ExperimentPipelineSection.CAMPAIGN_ANGLE,
+                        experiment.getCampaignAngle())));
+        when(jobRepository.save(any(ExperimentPipelineGenerationJob.class))).thenAnswer(invocation -> invocation.getArgument(0));
+        when(experimentMapper.toDto(experiment)).thenReturn(new ExperimentDto());
+
+        service.generate(133L, ExperimentPipelineSection.AD_COPY, new ExperimentPipelineGenerationRequest());
+
+        verify(jobRepository).save(argThat(job -> {
+            String requestBodyJson = job.getRequestBodyJson();
+            return requestBodyJson != null
+                    && requestBodyJson.contains("\"primaryText\"")
+                    && requestBodyJson.contains("\"maxLength\":125")
+                    && requestBodyJson.contains("\"headline\"")
+                    && requestBodyJson.contains("\"maxLength\":40")
+                    && requestBodyJson.contains("\"description\"")
+                    && requestBodyJson.contains("\"maxLength\":25")
+                    && requestBodyJson.contains("\"required\":[\"label\",\"openingHookType\",\"placementHint\",\"lengthVariants\",\"primaryText\",\"headline\",\"description\",\"ctaText\",\"compliance\"]");
+        }));
+    }
+
+    @Test
     void generateRejectsNewStageWhenAnotherStageIsAlreadyActiveForExperiment() {
         Experiment experiment = new Experiment();
         experiment.setId(14L);

--- a/docs/registros/experimentos.md
+++ b/docs/registros/experimentos.md
@@ -5486,3 +5486,9 @@
 - Causa-raiz: o endpoint genérico `/{idExterno}/start` e o service da etapa Texto resolviam o número recebido pelo repositório de CNAE, enquanto a tela de experimento precisava gravar a fila real `creatives_to_generate` do próprio experimento.
 - Correção aplicada: a tela passou a chamar a rota explícita `/experiments/{experimentId}/start`, e o start da etapa Texto passou a usar `ExperimentService.requestPipelineCreatives`, gravando `PIPELINE_ADS`, `REQUESTED` e `creatives_to_generate=3` para consumo do AI Worker que cria os criativos.
 - Prevenção de recorrência: adicionado teste backend garantindo que o start do GeraAnuncio v2 coloca o experimento na fila `/api/experiments/creatives/stage-executions/pending`, e teste frontend atualizado para bloquear a rota ambígua.
+
+## 2026-06-27 — Correção do limite de copy de anúncios Meta Ads
+
+- Sintoma: a tela de experimento falhava ao salvar criativos quando o pipeline gerava `primaryText` maior que o campo persistido.
+- Causa-raiz confirmada: o schema/prompt de `AD_COPY` não limitava `primaryText`, `headline` e `description` aos tamanhos operacionais recomendados para Meta Ads; ampliar a coluna apenas mascarava o problema e permitiria copy longa/truncada na publicação.
+- Correção: revertida a ampliação de banco e adicionados limites no prompt/schema da etapa: `primaryText` até 125 caracteres, `headline` até 40 e `description` até 25, para bloquear a recorrência na origem da geração.


### PR DESCRIPTION
### Motivation
- Prevent generated ad creatives from exceeding storage and Meta display limits by enforcing operational character caps at source in the AD_COPY prompt and schema.
- Align pipeline generation with Meta Ads constraints to avoid truncated copies and save failures when persisting or publishing creatives.

### Description
- Added three constants (`META_AD_PRIMARY_TEXT_MAX_LENGTH`, `META_AD_HEADLINE_MAX_LENGTH`, `META_AD_DESCRIPTION_MAX_LENGTH`) and a helper `metaAdStringSchema(int,String)` to produce string schemas with `maxLength` and descriptions.
- Updated the AD_COPY JSON schema in `ExperimentPipelineGenerationService` to use the new `metaAdStringSchema` for `primaryText`, `headline` and `description`, and made `primaryText` required in the variant schema.
- Updated the `ad-copy.md` prompt to document and enforce character limits (primary text ≤125, headline ≤40, description ≤25) and added checklist validation for those limits.
- Added/updated documentation (`docs/registros/experimentos.md`) describing the fix and rationale.

### Testing
- Added unit test `generateAdCopyLimitsMetaAdsTextFieldsInJsonSchema` which asserts the generated job request schema contains `maxLength` 125/40/25 and the updated required fields, and this test passed.
- Existing related unit tests were executed as part of the suite and passed (no failures observed).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a402bea99348321a75d64422638db27)