### PR TITLE
Expose dossier v1 pipeline audit endpoint and integrate into Sales Library UI

### DIFF
--- a/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryDtos.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryDtos.java
@@ -912,6 +912,42 @@ public final class MoisSalesLibraryDtos {
     }
 
     /**
+     * Representa a auditoria completa do pipeline novo de dossiê v1 para a tela.
+     */
+    public record DossierProductPipelineResponse(
+            long pageId,
+            String status,
+            String currentStage,
+            Instant updatedAt,
+            List<DossierProductPipelineStageItem> stages,
+            DossierProductPipelineStageItem finalResult
+    ) {
+    }
+
+    /**
+     * Representa uma etapa auditada do pipeline novo de dossiê v1.
+     */
+    public record DossierProductPipelineStageItem(
+            Long auditId,
+            String jobId,
+            String stageCode,
+            String pipelineVersion,
+            Instant occurredAt,
+            String platform,
+            String model,
+            Long inputTokens,
+            Long outputTokens,
+            BigDecimal cost,
+            String request,
+            String response,
+            String prompt,
+            String schema,
+            String errorDescription
+    ) {
+    }
+
+
+    /**
      * Representa o payload final do worker sem JSON serializado em campos textuais funcionais.
      */
     public record MarketWarmupCompleteRequest(

--- a/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryService.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/service/MoisSalesLibraryService.java
@@ -1587,6 +1587,66 @@ public class MoisSalesLibraryService {
         return Enum.valueOf(enumType, value);
     }
 
+
+    /**
+     * Consulta a auditoria do pipeline novo de dossiê v1 para a tela exibir entrada, saída e resultado final.
+     */
+    public MoisSalesLibraryDtos.DossierProductPipelineResponse getDossierProductPipeline(long pageId) {
+        var page = getPage(pageId);
+        List<MoisSalesLibraryDtos.DossierProductPipelineStageItem> stages = jdbcTemplate.query("""
+                SELECT id,
+                       job_id,
+                       codigo_etapa,
+                       versao_pipeline,
+                       data_hora,
+                       plataforma,
+                       modelo,
+                       quantidade_token_entrada,
+                       quantidade_token_saida,
+                       custo,
+                       request,
+                       response,
+                       prompt,
+                       `schema`,
+                       descricao_erro
+                FROM pipeline_dossieproduto
+                WHERE id_externo = ?
+                  AND versao_pipeline = 'v1'
+                ORDER BY data_hora ASC, id ASC
+                """, (rs, rowNum) -> new MoisSalesLibraryDtos.DossierProductPipelineStageItem(
+                rs.getLong("id"),
+                rs.getString("job_id"),
+                rs.getString("codigo_etapa"),
+                rs.getString("versao_pipeline"),
+                toInstant(rs, "data_hora"),
+                rs.getString("plataforma"),
+                rs.getString("modelo"),
+                nullableLong(rs, "quantidade_token_entrada"),
+                nullableLong(rs, "quantidade_token_saida"),
+                rs.getBigDecimal("custo"),
+                rs.getString("request"),
+                rs.getString("response"),
+                rs.getString("prompt"),
+                rs.getString("schema"),
+                rs.getString("descricao_erro")
+        ), String.valueOf(pageId));
+        MoisSalesLibraryDtos.DossierProductPipelineStageItem finalResult = stages.stream()
+                .filter(stage -> "dossier-synthesis".equals(stage.stageCode()) && stage.response() != null && !stage.response().isBlank())
+                .reduce((previous, current) -> current)
+                .orElseGet(() -> stages.stream()
+                        .filter(stage -> stage.response() != null && !stage.response().isBlank())
+                        .reduce((previous, current) -> current)
+                        .orElse(null));
+        return new MoisSalesLibraryDtos.DossierProductPipelineResponse(
+                pageId,
+                page.dossieProdutoStatus(),
+                page.dossieProdutoCurrentStage(),
+                page.dossieProdutoUpdatedAt(),
+                stages,
+                finalResult
+        );
+    }
+
     /**
      * Normaliza uma URL para deduplicação por esquema, host e caminho.
      */

--- a/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/web/MoisSalesLibraryController.java
+++ b/backend/ads-service/src/main/java/com/marketinghub/mois/bibliotecapaginavenda/worker/v1/web/MoisSalesLibraryController.java
@@ -172,6 +172,20 @@ public class MoisSalesLibraryController {
         }
     }
 
+
+    /**
+     * Consulta a auditoria do pipeline novo de dossiê v1 para exibição na tela.
+     */
+    @GetMapping("/pages/{pageId}/dossier-product/pipeline")
+    public MoisSalesLibraryDtos.DossierProductPipelineResponse getDossierProductPipeline(@PathVariable long pageId) {
+        try {
+            return service.getDossierProductPipeline(pageId);
+        } catch (IllegalArgumentException ex) {
+            log.warn("Biblioteca de páginas de vendas não encontrou dossiê v1 solicitado. operacao=getDossierProductPipeline, pageId={}, erro={}", pageId, ex.getMessage(), ex);
+            throw new ResponseStatusException(HttpStatus.NOT_FOUND, ex.getMessage(), ex);
+        }
+    }
+
     /**
      * Lista oportunidades priorizadas pela combinação de análise comercial e aquecimento de mercado.
      */

--- a/docs/registros/mois1.md
+++ b/docs/registros/mois1.md
@@ -1887,3 +1887,9 @@ Arquivos principais:
 ## 2026-06-27 — Destravamento da fila do dossiê MOIS v1
 - Diagnosticado que o dossiê do produto 286 (`Vértuz App`) estava iniciado em `product-understanding`, mas a fila canônica da etapa retornava erro 500 antes de entregar trabalhos ao executor por causa de uma pendência legada do produto 329 sem `jobId` auditável.
 - Corrigida a causa-raiz no backend: os endpoints `pending` do pipeline `dossieproduto.v1` agora recompõem um `jobId` UUID com auditoria mínima quando encontram pendências antigas sem registro rastreável, evitando que um item legado bloqueie os demais produtos da fila.
+
+## 2026-06-27 — Tela de dossiê MOIS v1 sem endpoint legado
+
+- Removida da tela de detalhe da Biblioteca Sales Pages a dependência do endpoint legado de `market-warmup` para exibir o dossiê do produto.
+- Criado endpoint público de leitura do pipeline novo `dossieproduto.v1`, expondo auditoria de cada etapa com entrada, saída, prompt, schema, modelo, tokens, custo, erro e resultado final.
+- Atualizada a tela para apresentar o resultado final consolidado e os registros de cada etapa diretamente a partir do backend novo.

--- a/docs/swagger/mois-sales-library-swagger.yaml
+++ b/docs/swagger/mois-sales-library-swagger.yaml
@@ -420,6 +420,22 @@ paths:
             application/json:
               schema:
                 $ref: '#/components/schemas/SalesLibrarySnapshotCaptureResponse'
+  /pages/{pageId}/dossier-product/pipeline:
+    get:
+      summary: Consulta auditoria do pipeline novo de dossiê v1
+      description: Retorna somente dados do pipeline `dossieproduto.v1`, incluindo entradas, saídas, prompts, schemas, custos e resultado final por etapa para a tela de detalhe da página.
+      tags: [MOIS Sales Library]
+      parameters:
+        - $ref: '#/components/parameters/PageId'
+      responses:
+        '200':
+          description: Auditoria do dossiê v1 da página
+          content:
+            application/json:
+              schema:
+                $ref: '#/components/schemas/DossierProductPipelineResponse'
+        '404':
+          description: Página não encontrada
   /pages/{pageId}/market-warmup:request:
     post:
       summary: Solicita investigação de sucesso do produto para uma página
@@ -2114,3 +2130,80 @@ components:
         capturedAt:
           type: string
           format: date-time
+
+    DossierProductPipelineResponse:
+      type: object
+      properties:
+        pageId:
+          type: integer
+          format: int64
+        status:
+          type: string
+          nullable: true
+        currentStage:
+          type: string
+          nullable: true
+        updatedAt:
+          type: string
+          format: date-time
+          nullable: true
+        stages:
+          type: array
+          items:
+            $ref: '#/components/schemas/DossierProductPipelineStageItem'
+        finalResult:
+          nullable: true
+          allOf:
+            - $ref: '#/components/schemas/DossierProductPipelineStageItem'
+    DossierProductPipelineStageItem:
+      type: object
+      properties:
+        auditId:
+          type: integer
+          format: int64
+          nullable: true
+        jobId:
+          type: string
+          nullable: true
+        stageCode:
+          type: string
+          nullable: true
+        pipelineVersion:
+          type: string
+          nullable: true
+        occurredAt:
+          type: string
+          format: date-time
+          nullable: true
+        platform:
+          type: string
+          nullable: true
+        model:
+          type: string
+          nullable: true
+        inputTokens:
+          type: integer
+          format: int64
+          nullable: true
+        outputTokens:
+          type: integer
+          format: int64
+          nullable: true
+        cost:
+          type: number
+          nullable: true
+        request:
+          type: string
+          nullable: true
+        response:
+          type: string
+          nullable: true
+        prompt:
+          type: string
+          nullable: true
+        schema:
+          type: string
+          nullable: true
+        errorDescription:
+          type: string
+          nullable: true

--- a/frontend/src/api/mois/types.ts
+++ b/frontend/src/api/mois/types.ts
@@ -300,6 +300,34 @@ export interface MoisSalesLibraryPage {
   dossieProdutoUpdatedAt?: string;
 }
 
+
+export interface MoisDossierProductPipelineStageItem {
+  auditId?: number;
+  jobId?: string;
+  stageCode?: string;
+  pipelineVersion?: string;
+  occurredAt?: string;
+  platform?: string;
+  model?: string;
+  inputTokens?: number;
+  outputTokens?: number;
+  cost?: number;
+  request?: string;
+  response?: string;
+  prompt?: string;
+  schema?: string;
+  errorDescription?: string;
+}
+
+export interface MoisDossierProductPipelineResponse {
+  pageId: number;
+  status?: string;
+  currentStage?: string;
+  updatedAt?: string;
+  stages: MoisDossierProductPipelineStageItem[];
+  finalResult?: MoisDossierProductPipelineStageItem;
+}
+
 export interface MoisSalesLibraryPageSummary {
   workspaceId: string;
   total: number;

--- a/frontend/src/api/mois/useMoisSalesLibrary.ts
+++ b/frontend/src/api/mois/useMoisSalesLibrary.ts
@@ -8,6 +8,7 @@ import type {
   MoisMarketWarmupSignalListResponse,
   MoisMarketWarmupSourceListResponse,
   MoisMarketWarmupSummary,
+  MoisDossierProductPipelineResponse,
   MoisSalesLibraryEntryPageResponse,
   MoisSalesLibraryJobPageResponse,
   MoisSalesLibraryPage,
@@ -327,6 +328,20 @@ export function useMoisSalesLibraryPageExecutions(pageId?: number) {
   });
 }
 
+
+export function useMoisDossierProductPipeline(pageId?: number) {
+  return useQuery({
+    queryKey: ["mois", "sales-library", "dossier-product-pipeline", pageId],
+    enabled: Boolean(pageId),
+    queryFn: async () => {
+      const { data } = await axios.get<MoisDossierProductPipelineResponse>(
+        `/api/mois/sales-library/pages/${pageId}/dossier-product/pipeline`,
+      );
+      return data;
+    },
+  });
+}
+
 export function useMoisSalesLibraryMarketWarmup(pageId?: number) {
   return useQuery({
     queryKey: ["mois", "sales-library", "market-warmup", pageId],
@@ -435,22 +450,7 @@ export function useStartMoisDossierPipeline(workspaceId: string) {
     },
     onSuccess: (_, pageId) => {
       void queryClient.invalidateQueries({
-        queryKey: ["mois", "sales-library", "market-warmup", pageId],
-      });
-      void queryClient.invalidateQueries({
-        queryKey: ["mois", "sales-library", "market-warmup", pageId, "sources"],
-      });
-      void queryClient.invalidateQueries({
-        queryKey: [
-          "mois",
-          "sales-library",
-          "market-warmup",
-          pageId,
-          "search-attempts",
-        ],
-      });
-      void queryClient.invalidateQueries({
-        queryKey: ["mois", "sales-library", "market-warmup", pageId, "signals"],
+        queryKey: ["mois", "sales-library", "dossier-product-pipeline", pageId],
       });
       void queryClient.invalidateQueries({
         queryKey: ["mois", "sales-library", "pages", workspaceId],

--- a/frontend/src/pages/mois/MoisSalesPageLibraryDetailPage.tsx
+++ b/frontend/src/pages/mois/MoisSalesPageLibraryDetailPage.tsx
@@ -3,9 +3,7 @@ import CollapsibleJsonViewer from "../../components/CollapsibleJsonViewer";
 import PageTitle from "../../components/PageTitle";
 import {
   useMoisSalesLibraryPageAnalysis,
-  useMoisSalesLibraryMarketWarmup,
-  useMoisSalesLibraryMarketWarmupSearchAttempts,
-  useMoisSalesLibraryMarketWarmupSources,
+  useMoisDossierProductPipeline,
   useMoisSalesLibraryPage,
   useStartMoisDossierPipeline,
   useMoisSalesLibraryPageExecutions,
@@ -106,36 +104,6 @@ type DossierPipelineStage = {
   model: string;
 };
 
-const SOCIAL_PLATFORMS = new Set(["YOUTUBE", "INSTAGRAM", "TIKTOK"]);
-const PRODUCER_SOCIAL_SOURCE_TYPES = new Set([
-  "CREATOR_CONTENT",
-  "SPECIALIST_CONTENT",
-  "SOCIAL_POST",
-]);
-
-function labelPlatform(value: string) {
-  const labels: Record<string, string> = {
-    YOUTUBE: "YouTube",
-    INSTAGRAM: "Instagram",
-    TIKTOK: "TikTok",
-    WEB: "Web",
-    MARKETPLACE: "Marketplace",
-    REVIEW_SITE: "Reviews",
-  };
-  return labels[value] || value;
-}
-
-function labelRecommendation(value?: string) {
-  const labels: Record<string, string> = {
-    PRIORITIZE: "priorizar",
-    OBSERVE: "observar",
-    RESEARCH_MORE: "pesquisar mais",
-    DISCARD: "descartar",
-    SATURATED_REQUIRES_ANGLE: "exige novo ângulo",
-  };
-  return value ? labels[value] || value : "—";
-}
-
 export default function MoisSalesPageLibraryDetailPage() {
   const { pageId } = useParams();
   const numericPageId = Number(pageId);
@@ -145,20 +113,11 @@ export default function MoisSalesPageLibraryDetailPage() {
   const pageQuery = useMoisSalesLibraryPage(validPageId);
   const analysisQuery = useMoisSalesLibraryPageAnalysis(validPageId);
   const executionsQuery = useMoisSalesLibraryPageExecutions(validPageId);
-  const marketWarmupQuery = useMoisSalesLibraryMarketWarmup(validPageId);
-  const marketWarmupSearchAttemptsQuery =
-    useMoisSalesLibraryMarketWarmupSearchAttempts(
-      validPageId,
-      Boolean(pageQuery.data?.marketWarmupStatus),
-    );
-  const marketWarmupSourcesQuery = useMoisSalesLibraryMarketWarmupSources(
-    validPageId,
-    Boolean(marketWarmupQuery.data),
-  );
+  const dossierPipelineQuery = useMoisDossierProductPipeline(validPageId);
   const pagesQuery = useMoisSalesLibraryPages(WORKSPACE_ID, 1, PAGE_SIZE);
   const updateStatusMutation =
     useUpdateMoisSalesLibraryPageStatus(WORKSPACE_ID);
-  const requestWarmupMutation = useStartMoisDossierPipeline(WORKSPACE_ID);
+  const requestDossierMutation = useStartMoisDossierPipeline(WORKSPACE_ID);
 
   const currentIndex =
     pagesQuery.data?.items.findIndex((item) => item.pageId === validPageId) ??
@@ -168,25 +127,27 @@ export default function MoisSalesPageLibraryDetailPage() {
   const isMutating = updateStatusMutation.isPending;
   const dossierStatus = pageQuery.data?.dossieProdutoStatus || "";
   const dossierStage = pageQuery.data?.dossieProdutoCurrentStage || "";
-  const hasWarmupDossier = Boolean(dossierStatus);
-  const hasActiveWarmupDossier = ["INICIADO", "AGUARDANDO"].includes(
-    dossierStatus,
-  );
+  const hasDossierRequest = Boolean(dossierStatus);
+  const hasActiveDossierRequest = [
+    "INICIADO",
+    "AGUARDANDO",
+    "AGUARDANDO_RETORNO_MODULO",
+  ].includes(dossierStatus);
   const isCommercialAnalysisDone = ["DONE", "ANALYZED"].includes(
     pageQuery.data?.analysisStatus || pageQuery.data?.currentStatus || "",
   );
-  const warmupRequestBlockReason = hasActiveWarmupDossier
+  const dossierRequestBlockReason = hasActiveDossierRequest
     ? "Esta página já possui dossiê em fila ou em processamento; aguarde o backend concluir antes de reprocessar."
     : !isCommercialAnalysisDone
       ? "O dossiê só pode iniciar depois que a análise comercial da página estiver concluída."
       : undefined;
-  const warmupRequestButtonLabel = hasWarmupDossier
+  const dossierRequestButtonLabel = hasDossierRequest
     ? "Reprocessar dossiê"
     : "Iniciar dossiê";
-  const isWarmupRequestDisabled =
+  const isDossierRequestDisabled =
     !validPageId ||
-    requestWarmupMutation.isPending ||
-    Boolean(warmupRequestBlockReason);
+    requestDossierMutation.isPending ||
+    Boolean(dossierRequestBlockReason);
   const currentStatus = pageQuery.data?.currentStatus;
   const analysisStatus = pageQuery.data?.analysisStatus;
   const captureStatus = pageQuery.data?.captureStatus;
@@ -261,14 +222,6 @@ export default function MoisSalesPageLibraryDetailPage() {
       model: "Não usa OpenAI",
     },
   ];
-
-  const producerSocialSources = (marketWarmupSourcesQuery.data?.items ?? [])
-    .filter(
-      (source) =>
-        SOCIAL_PLATFORMS.has(source.platform) &&
-        PRODUCER_SOCIAL_SOURCE_TYPES.has(source.sourceType),
-    )
-    .slice(0, 6);
 
   const history: HistoryItem[] = (executionsQuery.data ?? []).map((item) => ({
     key: String(item.executionId),
@@ -354,22 +307,22 @@ export default function MoisSalesPageLibraryDetailPage() {
         <button
           type="button"
           className="btn btn-outline-primary"
-          disabled={isWarmupRequestDisabled}
-          title={warmupRequestBlockReason}
+          disabled={isDossierRequestDisabled}
+          title={dossierRequestBlockReason}
           onClick={() =>
-            validPageId && requestWarmupMutation.mutate(validPageId)
+            validPageId && requestDossierMutation.mutate(validPageId)
           }
         >
-          {requestWarmupMutation.isPending ? (
+          {requestDossierMutation.isPending ? (
             <span
               className="spinner-border spinner-border-sm me-2"
               role="status"
               aria-hidden="true"
             />
           ) : null}
-          {requestWarmupMutation.isPending
+          {requestDossierMutation.isPending
             ? "Solicitando dossiê..."
-            : warmupRequestButtonLabel}
+            : dossierRequestButtonLabel}
         </button>
         <button
           type="button"
@@ -459,18 +412,18 @@ export default function MoisSalesPageLibraryDetailPage() {
         </div>
       ) : null}
 
-      {requestWarmupMutation.isSuccess ? (
+      {requestDossierMutation.isSuccess ? (
         <div className="alert alert-success mb-0">
           Pipeline v1 do dossiê iniciado pela etapa intake. A tela sempre
           mostrará o dossiê mais recente retornado pelo backend.
         </div>
       ) : null}
-      {requestWarmupMutation.isError ? (
+      {requestDossierMutation.isError ? (
         <div className="alert alert-danger mb-0">
           Falha ao iniciar pipeline v1 do dossiê.
         </div>
       ) : null}
-      {hasWarmupDossier && !hasActiveWarmupDossier ? (
+      {hasDossierRequest && !hasActiveDossierRequest ? (
         <div className="alert alert-info mb-0">
           Já existe uma solicitação de dossiê v1 para esta página
           {dossierStatus ? ` com status ${labelStatus(dossierStatus)}` : ""}
@@ -480,9 +433,9 @@ export default function MoisSalesPageLibraryDetailPage() {
         </div>
       ) : null}
 
-      {warmupRequestBlockReason ? (
+      {dossierRequestBlockReason ? (
         <div className="alert alert-warning mb-0">
-          {hasActiveWarmupDossier ? (
+          {hasActiveDossierRequest ? (
             <>
               Esta página já possui dossiê em fila ou em processamento
               {dossierStatus ? ` com status ${labelStatus(dossierStatus)}` : ""}
@@ -799,165 +752,165 @@ export default function MoisSalesPageLibraryDetailPage() {
       <section className="card border-0 shadow-sm">
         <div className="card-body d-flex flex-column gap-3">
           <div>
-            <h2 className="h5 mb-1">Dossiê do produto — redes do produtor</h2>
+            <h2 className="h5 mb-1">Resultado do dossiê v1</h2>
             <p className="text-secondary mb-0">
-              Quando o produtor Hotmart está disponível, a pesquisa pública
-              busca perfis sociais do mesmo nome e só aproveita fontes que
-              também falam de conteúdo semelhante ao produto.
+              Esta seção usa somente o pipeline novo de dossiê v1 e mostra a
+              auditoria real gravada pelo backend: entrada, saída, modelo, custo
+              e resultado final de cada etapa.
             </p>
           </div>
 
-          {marketWarmupQuery.isLoading ? (
+          {dossierPipelineQuery.isLoading ? (
             <p className="text-secondary mb-0">
-              Carregando pesquisa pública do dossiê...
+              Carregando auditoria do dossiê v1...
             </p>
           ) : null}
-          {marketWarmupQuery.isError || marketWarmupSourcesQuery.isError ? (
+          {dossierPipelineQuery.isError ? (
             <div className="alert alert-danger mb-0">
-              Falha ao carregar a pesquisa pública do produtor.
+              Falha ao carregar o pipeline novo de dossiê v1.
             </div>
           ) : null}
-          {!marketWarmupQuery.isLoading && !marketWarmupQuery.data ? (
+          {dossierPipelineQuery.data &&
+          dossierPipelineQuery.data.stages.length === 0 ? (
             <div className="alert alert-warning mb-0">
-              Ainda não há dossiê de aquecimento concluído para este produto. O
-              comando será liberado quando a análise comercial da página estiver
-              concluída.
+              Ainda não há auditoria do dossiê v1 para esta página. Inicie o
+              dossiê para o backend registrar as etapas.
             </div>
           ) : null}
 
-          {marketWarmupSearchAttemptsQuery.data?.items.length ? (
-            <div className="border rounded p-3 bg-light-subtle">
-              <h3 className="h6 mb-2">Tentativas de pesquisa realizadas</h3>
-              <p className="small text-secondary mb-3">
-                Estas são as buscas que o worker fez e o motivo de elas terem ou
-                não virado fonte do dossiê.
-              </p>
-              <div className="d-flex flex-column gap-2">
-                {marketWarmupSearchAttemptsQuery.data.items.map((attempt) => (
-                  <div
-                    key={attempt.attemptId}
-                    className="border rounded p-2 bg-white"
-                  >
-                    <div className="d-flex flex-wrap justify-content-between gap-2">
-                      <strong>{attempt.queryText}</strong>
-                      <span
-                        className={
-                          attempt.qualifiedCount > 0
+          {dossierPipelineQuery.data?.finalResult ? (
+            <div className="border rounded p-3 bg-success-subtle">
+              <div className="d-flex flex-wrap justify-content-between gap-2 mb-2">
+                <div>
+                  <h3 className="h6 mb-1">Resultado final consolidado</h3>
+                  <p className="small text-secondary mb-0">
+                    Última resposta da etapa final do pipeline novo.
+                  </p>
+                </div>
+                <span className="badge text-bg-success">
+                  {labelStatus(dossierPipelineQuery.data.status)}
+                </span>
+              </div>
+              <CollapsibleJsonViewer
+                content={dossierPipelineQuery.data.finalResult.response}
+                initiallyCollapsed={false}
+              />
+            </div>
+          ) : null}
+
+          {dossierPipelineQuery.data?.stages.length ? (
+            <div className="d-flex flex-column gap-3">
+              {dossierPipelineQuery.data.stages.map((stage, index) => (
+                <div
+                  key={`${stage.auditId ?? index}-${stage.stageCode ?? "stage"}`}
+                  className="border rounded p-3 bg-light-subtle"
+                >
+                  <div className="d-flex flex-wrap align-items-start justify-content-between gap-2 mb-3">
+                    <div>
+                      <h3 className="h6 mb-1">
+                        {index + 1}. {stage.stageCode || "Etapa sem código"}
+                      </h3>
+                      <p className="small text-secondary mb-0">
+                        jobId: {stage.jobId || "—"} • versão: {stage.pipelineVersion || "—"} • data: {formatDate(stage.occurredAt)}
+                      </p>
+                    </div>
+                    <span
+                      className={
+                        stage.errorDescription
+                          ? "badge text-bg-danger"
+                          : stage.response
                             ? "badge text-bg-success"
-                            : "badge text-bg-warning"
-                        }
-                      >
-                        {attempt.qualifiedCount > 0
-                          ? "gerou fonte"
-                          : "sem fonte útil"}
-                      </span>
-                    </div>
-                    <div className="small text-secondary mt-1">
-                      Resultados lidos: {attempt.resultCount} • aproveitados:{" "}
-                      {attempt.qualifiedCount} • descartados:{" "}
-                      {attempt.rejectedCount}
-                    </div>
-                    {attempt.rejectionReason ? (
-                      <div className="small text-secondary mt-1">
-                        {attempt.rejectionReason}
+                            : "badge text-bg-secondary"
+                      }
+                    >
+                      {stage.errorDescription
+                        ? "falha"
+                        : stage.response
+                          ? "com saída"
+                          : "registro"}
+                    </span>
+                  </div>
+
+                  <div className="row g-3 mb-3">
+                    <div className="col-md-3">
+                      <div className="border rounded p-2 bg-white h-100">
+                        <div className="small text-secondary">Plataforma</div>
+                        <strong>{displayText(stage.platform)}</strong>
                       </div>
-                    ) : null}
-                    {attempt.sampleResultUrl ? (
-                      <a
-                        className="small"
-                        href={attempt.sampleResultUrl}
-                        target="_blank"
-                        rel="noreferrer"
-                      >
-                        Exemplo retornado:{" "}
-                        {attempt.sampleResultTitle || attempt.sampleResultUrl}
-                      </a>
-                    ) : null}
+                    </div>
+                    <div className="col-md-3">
+                      <div className="border rounded p-2 bg-white h-100">
+                        <div className="small text-secondary">Modelo</div>
+                        <strong>{displayText(stage.model)}</strong>
+                      </div>
+                    </div>
+                    <div className="col-md-3">
+                      <div className="border rounded p-2 bg-white h-100">
+                        <div className="small text-secondary">Tokens</div>
+                        <strong>
+                          {stage.inputTokens ?? "—"} / {stage.outputTokens ?? "—"}
+                        </strong>
+                      </div>
+                    </div>
+                    <div className="col-md-3">
+                      <div className="border rounded p-2 bg-white h-100">
+                        <div className="small text-secondary">Custo</div>
+                        <strong>{stage.cost ?? "—"}</strong>
+                      </div>
+                    </div>
                   </div>
-                ))}
-              </div>
-            </div>
-          ) : null}
 
-          {marketWarmupQuery.data ? (
-            <>
-              <div className="row g-3">
-                <div className="col-md-4">
-                  <div className="border rounded p-3 h-100 bg-light-subtle">
-                    <div className="text-secondary small">Temperatura</div>
-                    <strong>{marketWarmupQuery.data.marketTemperature}</strong>
-                  </div>
-                </div>
-                <div className="col-md-4">
-                  <div className="border rounded p-3 h-100 bg-light-subtle">
-                    <div className="text-secondary small">Recomendação</div>
-                    <strong>
-                      {labelRecommendation(
-                        marketWarmupQuery.data.recommendation,
-                      )}
-                    </strong>
-                  </div>
-                </div>
-                <div className="col-md-4">
-                  <div className="border rounded p-3 h-100 bg-light-subtle">
-                    <div className="text-secondary small">Score do dossiê</div>
-                    <strong>{marketWarmupQuery.data.scoreTotal ?? "—"}</strong>
-                  </div>
-                </div>
-              </div>
+                  {stage.errorDescription ? (
+                    <div className="alert alert-danger mb-3">
+                      {stage.errorDescription}
+                    </div>
+                  ) : null}
 
-              {marketWarmupQuery.data.opportunityRecommendation ? (
-                <div className="alert alert-info mb-0">
-                  {marketWarmupQuery.data.opportunityRecommendation}
-                </div>
-              ) : null}
-
-              <div>
-                <h3 className="h6 mb-2">Fontes sociais qualificadas</h3>
-                {marketWarmupSourcesQuery.isLoading ? (
-                  <p className="text-secondary mb-0">
-                    Carregando fontes sociais qualificadas...
-                  </p>
-                ) : null}
-                {!marketWarmupSourcesQuery.isLoading &&
-                producerSocialSources.length === 0 ? (
-                  <p className="text-secondary mb-0">
-                    Nenhuma rede social do produtor foi qualificada ainda. Isso
-                    evita usar homônimos ou perfis com assunto diferente do
-                    produto.
-                  </p>
-                ) : (
-                  <div className="d-flex flex-column gap-2">
-                    {producerSocialSources.map((source) => (
-                      <div
-                        key={source.sourceId}
-                        className="border rounded p-3 bg-light-subtle"
-                      >
-                        <div className="d-flex flex-wrap justify-content-between gap-2">
-                          <strong>
-                            {source.sourceTitle || source.sourceUrl}
-                          </strong>
-                          <span className="badge text-bg-primary">
-                            {labelPlatform(source.platform)}
-                          </span>
+                  <div className="row g-3">
+                    <div className="col-lg-6">
+                      <div className="border rounded p-3 h-100 bg-white">
+                        <h4 className="h6 mb-2">Entrada recebida pela etapa</h4>
+                        <CollapsibleJsonViewer
+                          content={stage.request}
+                          initiallyCollapsed
+                        />
+                      </div>
+                    </div>
+                    <div className="col-lg-6">
+                      <div className="border rounded p-3 h-100 bg-white">
+                        <h4 className="h6 mb-2">Saída retornada pela etapa</h4>
+                        <CollapsibleJsonViewer
+                          content={stage.response}
+                          initiallyCollapsed
+                        />
+                      </div>
+                    </div>
+                    {stage.prompt ? (
+                      <div className="col-lg-6">
+                        <div className="border rounded p-3 h-100 bg-white">
+                          <h4 className="h6 mb-2">Prompt</h4>
+                          <CollapsibleJsonViewer
+                            content={stage.prompt}
+                            initiallyCollapsed
+                          />
                         </div>
-                        <p className="small text-secondary mb-2 mt-2">
-                          {source.evidenceSummary ||
-                            "Fonte social qualificada pela pesquisa pública."}
-                        </p>
-                        <a
-                          href={source.sourceUrl}
-                          target="_blank"
-                          rel="noreferrer"
-                        >
-                          Abrir fonte
-                        </a>
                       </div>
-                    ))}
+                    ) : null}
+                    {stage.schema ? (
+                      <div className="col-lg-6">
+                        <div className="border rounded p-3 h-100 bg-white">
+                          <h4 className="h6 mb-2">Schema</h4>
+                          <CollapsibleJsonViewer
+                            content={stage.schema}
+                            initiallyCollapsed
+                          />
+                        </div>
+                      </div>
+                    ) : null}
                   </div>
-                )}
-              </div>
-            </>
+                </div>
+              ))}
+            </div>
           ) : null}
         </div>
       </section>


### PR DESCRIPTION
### Motivation
- Provide the frontend with a first-class read endpoint for the new `dossieproduto.v1` pipeline audit so the UI no longer depends on the legacy `market-warmup` endpoint to show dossier details. 
- Surface full per-stage audit data (request, response, prompt, schema, model, tokens, cost, errors) and the consolidated final result for inspection in the page detail view. 
- Allow UI actions (start/reprocess) to invalidate and refresh the new pipeline data stream.

### Description
- Added DTO records `DossierProductPipelineResponse` and `DossierProductPipelineStageItem` to `MoisSalesLibraryDtos` to represent pipeline audit responses. 
- Implemented `getDossierProductPipeline` in `MoisSalesLibraryService` to query `pipeline_dossieproduto` rows for `versao_pipeline = 'v1'`, assemble stage list and pick `finalResult` (prefer last `dossier-synthesis` with response, otherwise last stage with response). 
- Exposed a new controller endpoint `GET /api/mois/sales-library/pages/{pageId}/dossier-product/pipeline` in `MoisSalesLibraryController` with `404` handling. 
- Updated Swagger (`docs/swagger/mois-sales-library-swagger.yaml`) to document the new path and components schema. 
- Frontend: added TypeScript types `MoisDossierProductPipelineResponse` and `MoisDossierProductPipelineStageItem`, hook `useMoisDossierProductPipeline`, and integrated the new pipeline data into `MoisSalesPageLibraryDetailPage.tsx` to replace the legacy warmup UI with the pipeline audit viewer and final consolidated result. 
- Adjusted start/reprocess mutation invalidation to refresh `dossier-product-pipeline` queries and renamed related variables/messages to reflect dossier pipeline usage. 
- Updated release notes in `docs/registros/mois1.md` describing the UI/backend change.

### Testing
- Ran the backend test suite and application build in CI which completed successfully. 
- Executed TypeScript build and lint for the frontend which succeeded and validated the new types and hooks. 
- Performed integration smoke checks by exercising the new `GET /pages/{pageId}/dossier-product/pipeline` endpoint and the page UI rendering in a local environment, and observed the expected stage list and final result display.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a402d8e2be883219de8887e3e2f2088)