### PR TITLE
fix(mois): refresh page detail and dossier pipeline after reprocess

### DIFF
--- a/docs/registros/mois1.md
+++ b/docs/registros/mois1.md
@@ -1,3 +1,8 @@
+## 2026-06-27 — MOIS Biblioteca de Páginas: atualização da tela após reprocessar dossiê
+- Causa-raiz identificada na página `/mois/sales-pages-library/286`: o backend aceitou o reprocessamento e o worker concluiu o dossiê, mas a tela de detalhe não invalidava a query da própria página ao clicar em **Reprocessar dossiê** e também não fazia polling do estado do dossiê.
+- Correção aplicada no frontend: o comando agora invalida a query do detalhe da página e as consultas de detalhe/pipeline do dossiê são atualizadas periodicamente, reduzindo a chance de a tela mostrar status antigo enquanto o backend já avançou.
+- Verificação operacional: via MCP, a página 286 ficou com `status_pipeline_dossieproduto=CONCLUIDO` e etapa `dossier-synthesis`; logs do `mois-sales-library-worker` confirmaram execução das etapas após a solicitação.
+
 ## 2026-06-17 — Protocolo padrão backend na Biblioteca de Páginas de Vendas
 - aplicado o protocolo padrão backend no pacote `com.marketinghub.mois.bibliotecapaginavenda.worker.v1` com regras ArchUnit para controller único/canônico, fachada de service canônica, contratos imutáveis e persistência centralizada no pacote `com.marketinghub.repository.jpa.mois.bibliotecapaginavenda.worker.v1`.
 - objetivo: reduzir risco de dispersão arquitetural na Biblioteca de Páginas de Vendas e preservar a capacidade do MOIS de transformar páginas coletadas em inteligência comercial para vendas.

--- a/frontend/src/api/mois/useMoisSalesLibrary.ts
+++ b/frontend/src/api/mois/useMoisSalesLibrary.ts
@@ -293,6 +293,7 @@ export function useMoisSalesLibraryPage(pageId?: number) {
   return useQuery({
     queryKey: ["mois", "sales-library", "page", pageId],
     enabled: Boolean(pageId),
+    refetchInterval: 30000,
     queryFn: async () => {
       const { data } = await axios.get<MoisSalesLibraryPage>(
         `/api/mois/sales-library/pages/${pageId}`,
@@ -333,6 +334,7 @@ export function useMoisDossierProductPipeline(pageId?: number) {
   return useQuery({
     queryKey: ["mois", "sales-library", "dossier-product-pipeline", pageId],
     enabled: Boolean(pageId),
+    refetchInterval: 30000,
     queryFn: async () => {
       const { data } = await axios.get<MoisDossierProductPipelineResponse>(
         `/api/mois/sales-library/pages/${pageId}/dossier-product/pipeline`,
@@ -449,6 +451,9 @@ export function useStartMoisDossierPipeline(workspaceId: string) {
       );
     },
     onSuccess: (_, pageId) => {
+      void queryClient.invalidateQueries({
+        queryKey: ["mois", "sales-library", "page", pageId],
+      });
       void queryClient.invalidateQueries({
         queryKey: ["mois", "sales-library", "dossier-product-pipeline", pageId],
       });


### PR DESCRIPTION
### Motivation
- The page detail did not reflect backend progress after requesting a dossiê reprocess because the detail query was not invalidated and the pipeline view did not poll, causing the UI to show stale status while the worker already finished.

### Description
- Add `refetchInterval: 30000` to the `useMoisSalesLibraryPage` query to poll the page detail every 30s.
- Add `refetchInterval: 30000` to the `useMoisDossierProductPipeline` query to poll the dossiê pipeline every 30s.
- In `useStartMoisDossierPipeline` `onSuccess`, invalidate the page detail query (`["mois","sales-library","page", pageId]`) immediately after starting the dossiê to force an immediate refresh.
- Record the operational investigation and fix in `docs/registros/mois1.md` describing the cause, correction and MCP verification for page `286`.

### Testing
- Ran `npm ci` to install dependencies and it completed successfully.
- Ran `npm run typecheck` and TypeScript type checks passed with no errors.
- Verified via backend queries (MCP) and worker logs that the dossiê for page `286` progressed to `CONCLUIDO` and the frontend now invalidates and polls the relevant queries (manual verification during the investigation).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a40362624fc8321865fc255f7ce2bcb)